### PR TITLE
Beginning of the protocol url support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -73,3 +73,6 @@
 [submodule "vendor/nimage"]
 	path = vendor/nimage
 	url = https://github.com/Ethosa/nimage/
+[submodule "vendor/nim-confutils"]
+	path = vendor/nim-confutils
+	url = https://github.com/status-im/nim-confutils.git

--- a/src/nim_status_client.nim
+++ b/src/nim_status_client.nim
@@ -1,4 +1,5 @@
 import NimQml, eventemitter, chronicles, os, strformat
+import confutils
 
 import app/chat/core as chat
 import app/wallet/core as wallet
@@ -17,12 +18,21 @@ var signalsQObjPointer: pointer
 logScope:
   topics = "main"
 
+type
+  CLIConfig = object
+    uri* {.
+      defaultValue: "",
+      desc: "Protocol URI with params to open a chat or other"
+      name: "uri" }: string
+
 proc mainProc() =
   let status = statuslib.newStatusInstance()
   status.initNode()
 
   enableHDPI()
   initializeOpenGL()
+
+  var cfg = CliConfig.load()
 
   let app = newQApplication("Status Desktop")
   let resources =
@@ -92,7 +102,7 @@ proc mainProc() =
     status.startMessenger()
     profile.init(args.account)
     wallet.init()
-    chat.init()
+    chat.init(cfg.uri)
     utilsController.init()
 
     wallet.checkPendingTransactions()


### PR DESCRIPTION
This makes it possible to pass a command option to the executable that will be interpreted and join a public chat accordingly.

For example, calling:
```
./bin/nim_status_client.exe --uri="status-im://chat/public/status"
```
will open the `#status` chat on login.

I haven't figured out how to have Status already opened and just pass the new params to it though.

To make the uri work on Windows, I had to add the following in the registry. We'll probably need to add that as a step in the installation:
```
[HKEY_CLASSES_ROOT\status-im]
"URL Protocol"="\"\""
@="\"Status IM messenger\""

[HKEY_CLASSES_ROOT\status-im\DefaultIcon]
@="Status.exe,1"

[HKEY_CLASSES_ROOT\status-im\shell]

[HKEY_CLASSES_ROOT\status-im\shell\open]

[HKEY_CLASSES_ROOT\status-im\shell\open\command]
@="C:\\dev\\nim-status-client\\pkg\\Status\\bin\\Status.exe --uri=\"%1\""
```
