### PR TITLE
fix: gas estimate error

### DIFF
--- a/src/app/wallet/view.nim
+++ b/src/app/wallet/view.nim
@@ -273,13 +273,18 @@ QtObject:
   
   proc estimateGas*(self: WalletView, from_addr: string, to: string, assetAddress: string, value: string, data: string = ""): string {.slot.} =
     var
-      response: int
+      response: string
       success: bool
     if assetAddress != ZERO_ADDRESS and not assetAddress.isEmptyOrWhitespace:
       response = self.status.wallet.estimateTokenGas(from_addr, to, assetAddress, value, success)
     else:
       response = self.status.wallet.estimateGas(from_addr, to, value, data, success)
-    result = $(%* { "result": %response, "success": %success })
+
+    if success == true:
+      let res = fromHex[int](response)
+      result = $(%* { "result": %res, "success": %success })
+    else:
+      result = $(%* { "result": "-1", "success": %success, "error": { "message": %response } })
 
   proc transactionWasSent*(self: WalletView, txResult: string) {.signal.}
 

--- a/ui/app/AppLayouts/Chat/ChatColumn/ChatComponents/SignTransactionModal.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/ChatComponents/SignTransactionModal.qml
@@ -31,10 +31,6 @@ ModalPopup {
         root.close()
     }
 
-    function estimateGas(){
-        gasSelector.estimateGas()
-    }
-
     id: root
 
     //% "Send"
@@ -139,7 +135,10 @@ ModalPopup {
 
                     if (!gasEstimate.success) {
                         //% "Error estimating gas: %1"
-                        console.warn(qsTrId("error-estimating-gas---1").arg(gasEstimate.error.message))
+                        let message = qsTrId("error-estimating-gas---1").arg(gasEstimate.error.message)
+                        console.warn(message)
+                        gasEstimateErrorPopup.confirmationText = message + qsTr(". The transaction will probably fail.")
+                        gasEstimateErrorPopup.open()
                         return
                     }
                     selectedGasLimit = gasEstimate.result

--- a/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/TransactionComponents/AcceptTransaction.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/TransactionComponents/AcceptTransaction.qml
@@ -77,6 +77,14 @@ Item {
         }
     }
 
+    ConfirmationDialog {
+        id: gasEstimateErrorPopup
+        height: 220
+        onConfirmButtonClicked: {
+            gasEstimateErrorPopup.close();
+        }
+    }
+
     Loader {
         id: signTransactionModal
         function open() {


### PR DESCRIPTION
fixes #935
A bug occurs when someone requests a large amount of funds from you since the gas estimation will fail and there isn't a way of handling errors in the source yet and so the operation results in a crash. Another place where the same gas estimation procedures are used is in the Wallet Send Modal where gas estimation error handling is much more robust.

![lots of funds request](https://user-images.githubusercontent.com/58890963/104919564-20ce5f80-599f-11eb-83ff-859725cc8aee.gif)


This PR handles the error appropriatley for both `estimateGas` and `estimateTokenGas` where the response is only converted from hex to int if the RPC call was successful. Otherwise return the error message as the response and let the UI decide how to display it.

Currently the error for gas estimation in transaction bubbles is displayed in a popup however, ive come to realize that 2 popups open instead of one. This is a new bug of which I can't pinpoint the root cause at the moment and have opted to file a separate issue for it. From my understanding this particular code segment is wrapped in a `Backpressure.debounce` method which throttles observables in a easily consumable manner but i am yet to pinpoint why its executed multiple times.

![lots of funds request fixed](https://user-images.githubusercontent.com/58890963/104919581-288e0400-599f-11eb-99ce-9c8f331ecbf4.gif)
