### PR TITLE
uiux(CoptyToClipBoardButton): make hover state work in all themes

### DIFF
--- a/ui/shared/CopyToClipBoardButton.qml
+++ b/ui/shared/CopyToClipBoardButton.qml
@@ -30,10 +30,10 @@ Rectangle {
             parent.color = Style.current.transparent
         }
         onEntered:{
-            parent.color = Style.current.grey
+            parent.color = Style.current.backgroundHover
         }
         onPressed: {
-            parent.color = Style.current.grey
+            parent.color = Style.current.backgroundHover
             if (!toolTip.visible) {
                 toolTip.visible = true
             }


### PR DESCRIPTION
The background color of the component was hard coded to grey.
This commit changes it to `backgroundHover` so it looks consistent
in dark and light themes.