### PR TITLE
fix(StatusChatInfo): ensure component width is calculated properly

### DIFF
--- a/ui/shared/status/StatusChatInfo.qml
+++ b/ui/shared/status/StatusChatInfo.qml
@@ -44,7 +44,7 @@ Item {
     Item {
         id: nameAndInfo
         height: chatName.height + chatInfo.height
-        width: (chatName.width > chatInfo.width ? chatName.width : chatInfo.width) 
+        width: childrenRect.width
         anchors.verticalCenter: parent.verticalCenter
         anchors.left: chatIdenticon.right
         anchors.leftMargin: Style.current.smallPadding


### PR DESCRIPTION
With the recent addition of the `muted` property in this component,
the `width` is no longer reliably calculated. Sometimes it can happen
that the muted bell icon jumps out of the component. This is very apparent
inside of a `StatusChatInfoButton`.

This commit ensure that the width of this component always includes all
of its children, fixing the ui bug mentioned above.