### PR TITLE
fix: inside packaged macOS builds 'OPEN ME.webloc' should be a file not a symlink

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "files": [],
   "devDependencies": {
-    "create-dmg": "status-im/create-dmg",
+    "create-dmg": "status-im/create-dmg#678fbd4",
     "fileicon": "0.2.4"
   },
   "engines": {


### PR DESCRIPTION
The actual fix was applied to the `master` branch of the status-im/create-dmg repo (a fork of the upstream sindresorhus/create-dmg repo).  However, in this repo's `package.json` the dependency on Status' fork is specified (implicitly) as that repo's `master` branch. Instead, specify a (short) SHA-1 hash (committish) for our fork so that if a change to status-im/create-dmg introduces a build problem/failure it will be easier to track down in this repo's commit history.