### PR TITLE
fix(Profile): ensure invite friends link is rendered

### DIFF
--- a/ui/app/AppLayouts/Profile/Sections/ContactsContainer.qml
+++ b/ui/app/AppLayouts/Profile/Sections/ContactsContainer.qml
@@ -69,6 +69,7 @@ Item {
             anchors.top: addNewContact.bottom
             anchors.topMargin: Style.current.bigPadding
             width: blockButton.width + blockButtonLabel.width + Style.current.padding
+            visible: profileModel.contacts.blockedContacts.rowCount() > 0
             height: addButton.height
 
             StatusRoundButton {
@@ -233,8 +234,10 @@ Item {
 
         Item {
             id: element
-            visible: profileModel.contacts.list.rowCount() === 0
-            anchors.fill: parent
+            visible: profileModel.contacts.addedContacts.rowCount() === 0
+            anchors.top: addNewContact.bottom
+            width: parent.width
+            anchors.bottom: parent.bottom
 
             StyledText {
                 id: noFriendsText
@@ -257,10 +260,9 @@ Item {
                     inviteFriendsPopup.open()
                 }
             }
-
-            InviteFriendsPopup {
-                id: inviteFriendsPopup
-            }
+        }
+        InviteFriendsPopup {
+            id: inviteFriendsPopup
         }
     }
 }


### PR DESCRIPTION
There's a but in the app's profile section where the link to
invite friends is never rendered, even if the currently logged-in
user has no added contacts.

This is because the UI refers to the count of *all* contacts the
user has (even removed ones - remember that, once added, removing
a contact is only done by removing a tag).

This commit ensures that the invitation link is rendered by
relying on the *added* contacts list. It also prevents the
"blocked contacts" button from rendered when there's no blocked
contacts.