### PR TITLE
fix(StatusRoundButton): enable and correct hover on component

### DIFF
--- a/ui/app/AppLayouts/Profile/Sections/ContactsContainer.qml
+++ b/ui/app/AppLayouts/Profile/Sections/ContactsContainer.qml
@@ -69,6 +69,7 @@ Item {
             anchors.top: addNewContact.bottom
             anchors.topMargin: Style.current.bigPadding
             width: blockButton.width + blockButtonLabel.width + Style.current.padding
+            visible: profileModel.contacts.blockedContacts.rowCount() > 0
             height: addButton.height
 
             StatusRoundButton {
@@ -233,8 +234,10 @@ Item {
 
         Item {
             id: element
-            visible: profileModel.contacts.list.rowCount() === 0
-            anchors.fill: parent
+            visible: profileModel.contacts.addedContacts.rowCount() === 0
+            anchors.top: addNewContact.bottom
+            width: parent.width
+            anchors.bottom: parent.bottom
 
             StyledText {
                 id: noFriendsText
@@ -257,10 +260,9 @@ Item {
                     inviteFriendsPopup.open()
                 }
             }
-
-            InviteFriendsPopup {
-                id: inviteFriendsPopup
-            }
+        }
+        InviteFriendsPopup {
+            id: inviteFriendsPopup
         }
     }
 }

--- a/ui/imports/Themes/DarkTheme.qml
+++ b/ui/imports/Themes/DarkTheme.qml
@@ -58,6 +58,7 @@ Theme {
     property color buttonDisabledForegroundColor: buttonSecondaryColor
     property color buttonDisabledBackgroundColor: evenDarkerGrey
     property color buttonWarnBackgroundColor: "#FFEAEE"
+    property color buttonHoveredBackgroundColor: blue
 
     property color roundedButtonForegroundColor: white
     property color roundedButtonBackgroundColor: secondaryBackground

--- a/ui/imports/Themes/LightTheme.qml
+++ b/ui/imports/Themes/LightTheme.qml
@@ -57,6 +57,7 @@ Theme {
     property color buttonDisabledForegroundColor: buttonSecondaryColor
     property color buttonDisabledBackgroundColor: grey
     property color buttonWarnBackgroundColor: "#FFEAEE"
+    property color buttonHoveredBackgroundColor: blue
 
     property color roundedButtonForegroundColor: buttonForegroundColor
     property color roundedButtonBackgroundColor: secondaryBackground

--- a/ui/shared/status/StatusRoundButton.qml
+++ b/ui/shared/status/StatusRoundButton.qml
@@ -130,6 +130,7 @@ RoundButton {
 
     background: Rectangle {
         anchors.fill: parent
+        opacity: hovered && size === "large" ? 0.2 : 1
         color: {
             if (size === "medium" || size == "small") {
                 return !enabled ? Style.current.roundedButtonSecondaryDisabledBackgroundColor :
@@ -138,7 +139,7 @@ RoundButton {
             }
             return !enabled ?
               Style.current.roundedButtonDisabledBackgroundColor : 
-              hovered ? Qt.darker(Style.current.buttonBackgroundColor, 1.1) : Style.current.roundedButtonBackgroundColor
+              hovered ? Style.current.buttonHoveredBackgroundColor : Style.current.roundedButtonBackgroundColor
         }
         radius: parent.width / 2
     }
@@ -204,6 +205,7 @@ RoundButton {
     }
 
     MouseArea {
+        hoverEnabled: true
         cursorShape: Qt.PointingHandCursor
         anchors.fill: parent
         onPressed: mouse.accepted = false


### PR DESCRIPTION
The `StatusRoundButton` was missing the `hoverEnabled` flag, causing it
to not turn the cursor into a pointer when the component is hovered.
It's also not rendering the proper hover color.

This commit fixes that to improve usability and look & feel.