### PR TITLE
refactor: replace custom buttons with StatusRoundButton

### DIFF
--- a/ui/app/AppLayouts/Chat/components/GroupChatPopup.qml
+++ b/ui/app/AppLayouts/Chat/components/GroupChatPopup.qml
@@ -4,6 +4,7 @@ import QtQuick.Layouts 1.3
 import QtQml.Models 2.3
 import "../../../../imports"
 import "../../../../shared"
+import "../../../../shared/status"
 import "./"
 
 ModalPopup {
@@ -21,7 +22,6 @@ ModalPopup {
         selectChatMembers = true;
         memberCount = 1;
         pubKeys = [];
-        btnSelectMembers.state = "inactive";
 
         contactList.membersData.clear();
 
@@ -139,7 +139,7 @@ ModalPopup {
                 }
             }
             memberCount = pubKeys.length + 1;
-            btnSelectMembers.state = pubKeys.length > 0 ? "active" : "inactive"
+            btnSelectMembers.enabled = pubKeys.length > 0
         }
     }
 
@@ -147,71 +147,34 @@ ModalPopup {
         width: parent.width
         height: btnSelectMembers.height
 
-        Button {
+        StatusRoundButton {
             id: btnSelectMembers
             visible: selectChatMembers
-            width: 44
-            height: 44
             anchors.bottom: parent.bottom
             anchors.right: parent.right
-            state: "inactive"
-            states: [
-                State {
-                    name: "inactive"
-                    PropertyChanges {
-                        target: btnSelectMembersImg
-                        source: "../../../img/arrow-right-btn-inactive.svg"
-                    }
-                },
-                State {
-                    name: "active"
-                    PropertyChanges {
-                        target: btnSelectMembersImg
-                        source: "../../../img/arrow-right-btn-active.svg"
-                    }
-                }
-            ]
-            SVGImage {
-                id: btnSelectMembersImg
-                width: 50
-                height: 50
-            }
-            background: Rectangle {
-                color: "transparent"
-            }
-            MouseArea {
-                cursorShape: Qt.PointingHandCursor
-                anchors.fill: parent
-                onClicked : {
-                    if(pubKeys.length > 0)
-                        selectChatMembers = false
-                        searchBox.text = ""
-                        groupName.forceActiveFocus(Qt.MouseFocusReason)
-                }
+            icon.name: "arrow-right"
+            icon.width: 20
+            icon.height: 16
+            enabled: !!pubKeys.length
+            onClicked : {
+                if(pubKeys.length > 0)
+                    selectChatMembers = false
+                    searchBox.text = ""
+                    groupName.forceActiveFocus(Qt.MouseFocusReason)
             }
         }
 
-        Button {
+        StatusRoundButton {
             id: btnBack
             visible: !selectChatMembers
-            width: 44
-            height: 44
             anchors.bottom: parent.bottom
             anchors.left: parent.left
-            SVGImage {
-                source: "../../../img/arrow-left-btn-active.svg"
-                width: 50
-                height: 50
-            }
-            background: Rectangle {
-                color: "transparent"
-            }
-            MouseArea {
-                cursorShape: Qt.PointingHandCursor
-                anchors.fill: parent
-                onClicked : {
-                    selectChatMembers = true
-                }
+            icon.name: "arrow-right"
+            icon.width: 20
+            icon.height: 16
+            rotation: 180
+            onClicked : {
+                selectChatMembers = true
             }
         }
 

--- a/ui/app/AppLayouts/Chat/components/GroupInfoPopup.qml
+++ b/ui/app/AppLayouts/Chat/components/GroupInfoPopup.qml
@@ -304,28 +304,18 @@ ModalPopup {
           }
         }
 
-        Button {
+        StatusRoundButton {
             id: btnBack
             visible: addMembers
-            width: 44
-            height: 44
             anchors.bottom: parent.bottom
             anchors.left: parent.left
-            SVGImage {
-                source: "../../../img/arrow-left-btn-active.svg"
-                width: 50
-                height: 50
-            }
-            background: Rectangle {
-                color: "transparent"
-            }
-            MouseArea {
-                cursorShape: Qt.PointingHandCursor
-                anchors.fill: parent
-                onClicked : {
-                    addMembers = false;
-                    resetSelectedMembers();
-                }
+            icon.name: "arrow-right"
+            icon.width: 20
+            icon.height: 16
+            rotation: 180
+            onClicked : {
+                addMembers = false;
+                resetSelectedMembers();
             }
         }
 

--- a/ui/app/AppLayouts/Profile/Sections/ContactsContainer.qml
+++ b/ui/app/AppLayouts/Profile/Sections/ContactsContainer.qml
@@ -69,6 +69,7 @@ Item {
             anchors.top: addNewContact.bottom
             anchors.topMargin: Style.current.bigPadding
             width: blockButton.width + blockButtonLabel.width + Style.current.padding
+            visible: profileModel.contacts.blockedContacts.rowCount() > 0
             height: addButton.height
 
             StatusRoundButton {
@@ -233,8 +234,10 @@ Item {
 
         Item {
             id: element
-            visible: profileModel.contacts.list.rowCount() === 0
-            anchors.fill: parent
+            visible: profileModel.contacts.addedContacts.rowCount() === 0
+            anchors.top: addNewContact.bottom
+            width: parent.width
+            anchors.bottom: parent.bottom
 
             StyledText {
                 id: noFriendsText
@@ -257,10 +260,9 @@ Item {
                     inviteFriendsPopup.open()
                 }
             }
-
-            InviteFriendsPopup {
-                id: inviteFriendsPopup
-            }
+        }
+        InviteFriendsPopup {
+            id: inviteFriendsPopup
         }
     }
 }

--- a/ui/imports/Themes/DarkTheme.qml
+++ b/ui/imports/Themes/DarkTheme.qml
@@ -58,6 +58,7 @@ Theme {
     property color buttonDisabledForegroundColor: buttonSecondaryColor
     property color buttonDisabledBackgroundColor: evenDarkerGrey
     property color buttonWarnBackgroundColor: "#FFEAEE"
+    property color buttonHoveredBackgroundColor: blue
 
     property color roundedButtonForegroundColor: white
     property color roundedButtonBackgroundColor: secondaryBackground

--- a/ui/imports/Themes/LightTheme.qml
+++ b/ui/imports/Themes/LightTheme.qml
@@ -57,6 +57,7 @@ Theme {
     property color buttonDisabledForegroundColor: buttonSecondaryColor
     property color buttonDisabledBackgroundColor: grey
     property color buttonWarnBackgroundColor: "#FFEAEE"
+    property color buttonHoveredBackgroundColor: blue
 
     property color roundedButtonForegroundColor: buttonForegroundColor
     property color roundedButtonBackgroundColor: secondaryBackground

--- a/ui/shared/status/StatusRoundButton.qml
+++ b/ui/shared/status/StatusRoundButton.qml
@@ -130,6 +130,7 @@ RoundButton {
 
     background: Rectangle {
         anchors.fill: parent
+        opacity: hovered && size === "large" ? 0.2 : 1
         color: {
             if (size === "medium" || size == "small") {
                 return !enabled ? Style.current.roundedButtonSecondaryDisabledBackgroundColor :
@@ -138,7 +139,7 @@ RoundButton {
             }
             return !enabled ?
               Style.current.roundedButtonDisabledBackgroundColor : 
-              hovered ? Qt.darker(Style.current.buttonBackgroundColor, 1.1) : Style.current.roundedButtonBackgroundColor
+              hovered ? Style.current.buttonHoveredBackgroundColor : Style.current.roundedButtonBackgroundColor
         }
         radius: parent.width / 2
     }
@@ -204,6 +205,7 @@ RoundButton {
     }
 
     MouseArea {
+        hoverEnabled: true
         cursorShape: Qt.PointingHandCursor
         anchors.fill: parent
         onPressed: mouse.accepted = false


### PR DESCRIPTION
There are some places in the application where a custom round
button has been implemented, which essentially can be realized
using our `StatusRoundButton`. This commit addresses those cases.