### PR TITLE
refactor: replace StyledButton with StatusButton

### DIFF
--- a/ui/app/AppLayouts/Browser/BrowserConnectionModal.qml
+++ b/ui/app/AppLayouts/Browser/BrowserConnectionModal.qml
@@ -2,6 +2,7 @@ import QtQuick 2.13
 import QtQuick.Controls 2.13
 import QtQuick.Layouts 1.13
 import "../../../shared"
+import "../../../shared/status"
 import "../../../imports"
 
 Popup {
@@ -161,11 +162,10 @@ Popup {
             spacing: Style.current.padding
             Layout.alignment: Qt.AlignHCenter | Qt.AlignTop
 
-            StyledButton {
-                btnColor: Utils.setColorAlpha(Style.current.danger, 0.1)
-                textColor: Style.current.danger
+            StatusButton {
+                type: "warn"
                 width: 155
-                label: qsTr("Deny")
+                text: qsTr("Deny")
                 onClicked: {
                     postMessage(false);
                     root.close();

--- a/ui/app/AppLayouts/Browser/JSDialogWindow.qml
+++ b/ui/app/AppLayouts/Browser/JSDialogWindow.qml
@@ -3,6 +3,7 @@ import QtQuick.Controls 2.13
 import QtQuick.Layouts 1.13
 import QtWebEngine 1.10
 import "../../../shared"
+import "../../../shared/status"
 import "../../../imports"
 
 ModalPopup {
@@ -54,10 +55,10 @@ ModalPopup {
         width: parent.width
         height: okButton.height
 
-        StyledButton {
+        StatusButton {
             id: okButton
             anchors.right: parent.right
-            label: qsTr("Ok")
+            text: qsTr("Ok")
             anchors.bottom: parent.bottom
             onClicked: {
                 request.dialogAccept(prompt.text);
@@ -65,12 +66,12 @@ ModalPopup {
             }
         }
 
-        StyledButton {
+        StatusButton {
             id: cancelButton
+            type: "secondary"
             anchors.right: okButton.left
             anchors.rightMargin: Style.current.smallPadding
-            label: qsTr("Cancel")
-            btnColor: Style.current.transparent
+            text: qsTr("Cancel")
             anchors.bottom: parent.bottom
             onClicked: {
                 request.dialogReject();

--- a/ui/app/AppLayouts/Chat/ContactsColumn/EmptyView.qml
+++ b/ui/app/AppLayouts/Chat/ContactsColumn/EmptyView.qml
@@ -5,6 +5,7 @@ import QtGraphicalEffects 1.13
 import "../components"
 import "../data/channelList.js" as ChannelJSON
 import "../../../../shared"
+import "../../../../shared/status"
 import "../../../../imports"
 
 Rectangle {
@@ -80,9 +81,9 @@ Rectangle {
             anchors.leftMargin: Style.current.xlPadding
         }
 
-        StyledButton {
+        StatusButton {
             //% "Invite friends"
-            label: qsTrId("invite-friends")
+            text: qsTrId("invite-friends")
             anchors.horizontalCenter: parent.horizontalCenter
             anchors.bottom: parent.bottom
             anchors.bottomMargin: Style.current.xlPadding

--- a/ui/app/AppLayouts/Chat/components/GroupChatPopup.qml
+++ b/ui/app/AppLayouts/Chat/components/GroupChatPopup.qml
@@ -178,13 +178,13 @@ ModalPopup {
             }
         }
 
-        StyledButton {
+        StatusButton {
             visible: !selectChatMembers
             anchors.bottom: parent.bottom
             anchors.right: parent.right
             //% "Create Group Chat"
-            label: qsTrId("create-group-chat")
-            disabled: groupName.text === ""
+            text: qsTrId("create-group-chat")
+            enabled: groupName.text !== ""
             onClicked : doJoin()
         }
     }

--- a/ui/app/AppLayouts/Chat/components/GroupInfoPopup.qml
+++ b/ui/app/AppLayouts/Chat/components/GroupInfoPopup.qml
@@ -293,11 +293,11 @@ ModalPopup {
         visible: popup.isAdmin
         width: parent.width
         height: children[0].height
-        StyledButton {
+        StatusButton {
           visible: !addMembers
           anchors.right: parent.right
           //% "Add members"
-          label: qsTrId("add-members")
+          text: qsTrId("add-members")
           anchors.bottom: parent.bottom
           onClicked: {
             addMembers = true;
@@ -319,13 +319,13 @@ ModalPopup {
             }
         }
 
-        StyledButton {
+        StatusButton {
           id: btnSelectMembers
           visible: addMembers
-          disabled: memberCount <= currMemberCount
+          enabled: memberCount >= currMemberCount
           anchors.right: parent.right
           //% "Add selected"
-          label: qsTrId("add-selected")
+          text: qsTrId("add-selected")
           anchors.bottom: parent.bottom
           onClicked: doAddMembers()
         }

--- a/ui/app/AppLayouts/Chat/components/NicknamePopup.qml
+++ b/ui/app/AppLayouts/Chat/components/NicknamePopup.qml
@@ -4,6 +4,7 @@ import QtQuick.Layouts 1.13
 import QtGraphicalEffects 1.13
 import "../../../../imports"
 import "../../../../shared"
+import "../../../../shared/status"
 import "./"
 
 ModalPopup {
@@ -95,14 +96,14 @@ ModalPopup {
         color: popup.nicknameTooLong ? Style.current.danger : Style.current.secondaryText
     }
 
-    footer: StyledButton {
+    footer: StatusButton {
         id: doneBtn
         anchors.right: parent.right
         anchors.rightMargin: Style.current.smallPadding
         //% "Done"
-        label: qsTrId("done")
+        text: qsTrId("done")
         anchors.bottom: parent.bottom
-        disabled: popup.nicknameTooLong
+        enabled: !popup.nicknameTooLong
         onClicked: {
             if (!isEnsVerified) {
                 // Change username title only if it was not an ENS name

--- a/ui/app/AppLayouts/Chat/components/NoFriendsRectangle.qml
+++ b/ui/app/AppLayouts/Chat/components/NoFriendsRectangle.qml
@@ -1,6 +1,7 @@
 import QtQuick 2.13
 import "../../../../imports"
 import "../../../../shared"
+import "../../../../shared/status"
 
 Rectangle {
     id: noContactsRect
@@ -17,9 +18,9 @@ Rectangle {
         wrapMode: Text.WordWrap
         horizontalAlignment: Text.AlignHCenter
     }
-    StyledButton {
+    StatusButton {
         //% "Invite friends"
-        label: qsTrId("invite-friends")
+        text: qsTrId("invite-friends")
         anchors.horizontalCenter: parent.horizontalCenter
         anchors.top: noContacts.bottom
         anchors.topMargin: Style.current.xlPadding

--- a/ui/app/AppLayouts/Chat/components/PrivateChatPopup.qml
+++ b/ui/app/AppLayouts/Chat/components/PrivateChatPopup.qml
@@ -165,9 +165,9 @@ ModalPopup {
                     wrapMode: Text.WordWrap
                     horizontalAlignment: Text.AlignHCenter
                 }
-                StyledButton {
+                StatusButton {
                     //% "Invite friends"
-                    label: qsTrId("invite-friends")
+                    text: qsTrId("invite-friends")
                     anchors.horizontalCenter: parent.horizontalCenter
                     anchors.top: noContacts.bottom
                     anchors.topMargin: Style.current.xlPadding

--- a/ui/app/AppLayouts/Chat/components/ProfilePopup.qml
+++ b/ui/app/AppLayouts/Chat/components/ProfilePopup.qml
@@ -272,10 +272,11 @@ ModalPopup {
             anchors.right: addToContactsButton.left
             anchors.rightMargin: addToContactsButton ? Style.current.padding : 0
             anchors.bottom: parent.bottom
-            type: "secondary"
-            color: Style.current.red
+            type: "warn"
             showBorder: true
+            bgColor: "transparent"
             borderColor: Style.current.border
+            hoveredBorderColor: Style.current.transparent
             text: isBlocked ?
                       qsTr("Unblock User") :
                       qsTr("Block User")
@@ -304,10 +305,11 @@ ModalPopup {
                       //% "Add to contacts"
                       qsTrId("add-to-contacts")
             anchors.bottom: parent.bottom
-            type: isAdded ? "secondary" : "primary"
-            color: isAdded ? Style.current.danger : Style.current.primary
+            type: isAdded ? "warn" : "primary"
             showBorder: isAdded
             borderColor: Style.current.border
+            bgColor: isAdded ? "transparent" : Style.current.buttonBackgroundColor
+            hoveredBorderColor: Style.current.transparent
             visible: !isBlocked
             width: visible ? implicitWidth : 0
             onClicked: {

--- a/ui/app/AppLayouts/Chat/components/RenameGroupPopup.qml
+++ b/ui/app/AppLayouts/Chat/components/RenameGroupPopup.qml
@@ -3,6 +3,7 @@ import QtQuick.Controls 2.13
 import QtQuick.Layouts 1.13
 import "../../../../imports"
 import "../../../../shared"
+import "../../../../shared/status"
 import "./"
 
 ModalPopup {
@@ -34,13 +35,12 @@ ModalPopup {
         Keys.onReturnPressed: doRename()
     }
 
-    footer: StyledButton {
+    footer: StatusButton {
         id: saveBtn
-        height: 44
         anchors.bottom: parent.bottom
         anchors.right: parent.right
         //% "Save"
-        label: qsTrId("save")
+        text: qsTrId("save")
         onClicked : doRename()
     }
 }

--- a/ui/app/AppLayouts/Profile/Sections/BackupSeedModal.qml
+++ b/ui/app/AppLayouts/Profile/Sections/BackupSeedModal.qml
@@ -3,6 +3,7 @@ import QtQuick.Controls 2.3
 import QtQuick.Layouts 1.3
 import "../../../../imports"
 import "../../../../shared"
+import "../../../../shared/status"
 
 ModalPopup {
     id: popup
@@ -211,8 +212,8 @@ ModalPopup {
 
     
 
-    footer: StyledButton {
-        label: showWarning ? 
+    footer: StatusButton {
+        text: showWarning ? 
                 qsTr("Okay, continue") : 
                 qsTrId("Next")
         anchors.right: parent.right

--- a/ui/app/AppLayouts/Profile/Sections/ContactsContainer.qml
+++ b/ui/app/AppLayouts/Profile/Sections/ContactsContainer.qml
@@ -209,12 +209,12 @@ Item {
                 }
 
             }
-            footer: StyledButton {
+            footer: StatusButton {
                 anchors.right: parent.right
                 anchors.leftMargin: Style.current.padding
                 //% "Add contact"
-                label: qsTrId("add-contact")
-                disabled: !contactToAddInfo.visible
+                text: qsTrId("add-contact")
+                enabled: contactToAddInfo.visible
                 anchors.bottom: parent.bottom
                 onClicked: {
                     profileModel.contacts.addContact(profileModel.contacts.contactToAddPubKey);
@@ -250,12 +250,12 @@ Item {
                 color: Style.current.darkGrey
             }
 
-            StyledButton {
+            StatusButton {
                 anchors.horizontalCenter: noFriendsText.horizontalCenter
                 anchors.top: noFriendsText.bottom
                 anchors.topMargin: Style.current.bigPadding
                 //% "Invite friends"
-                label: qsTrId("invite-friends")
+                text: qsTrId("invite-friends")
                 onClicked: function () {
                     inviteFriendsPopup.open()
                 }

--- a/ui/app/AppLayouts/Profile/Sections/DevicesContainer.qml
+++ b/ui/app/AppLayouts/Profile/Sections/DevicesContainer.qml
@@ -52,13 +52,13 @@ Item {
             anchors.topMargin: Style.current.padding
         }
 
-        StyledButton {
+        StatusButton {
             anchors.top: deviceNameTxt.bottom
             anchors.topMargin: 10
             anchors.right: deviceNameTxt.right
             //% "Continue"
-            label: qsTrId("continue")
-            disabled: deviceNameTxt.text === ""
+            text: qsTrId("continue")
+            enabled: deviceNameTxt.text !== ""
             onClicked : profileModel.devices.setName(deviceNameTxt.text.trim())
         }
     }
@@ -202,17 +202,17 @@ Item {
         }
     }
 
-    StyledButton {
+    StatusButton {
         id: syncAllBtn
         anchors.bottom: syncContainer.bottom
         anchors.bottomMargin: Style.current.padding
         anchors.horizontalCenter: parent.horizontalCenter
-        label: isSyncing ?
+        text: isSyncing ?
         //% "Syncing..."
         qsTrId("sync-in-progress") :
         //% "Sync all devices"
         qsTrId("sync-all-devices")
-        disabled: isSyncing
+        enabled: !isSyncing
         onClicked : {
             isSyncing = true;
             profileModel.devices.syncAll()

--- a/ui/app/AppLayouts/Profile/Sections/Ens/Added.qml
+++ b/ui/app/AppLayouts/Profile/Sections/Ens/Added.qml
@@ -3,6 +3,7 @@ import QtQuick.Layouts 1.3
 import QtQuick.Controls 2.14
 import "../../../../../imports"
 import "../../../../../shared"
+import "../../../../../shared/status"
 
 Item {
     property string ensUsername: ""
@@ -69,13 +70,13 @@ Item {
         wrapMode: Text.WordWrap
     }
 
-    StyledButton {
+    StatusButton {
         id: startBtn
         anchors.top: subtitle.bottom
         anchors.topMargin: Style.current.padding
         anchors.horizontalCenter: parent.horizontalCenter
         //% "Ok, got it"
-        label: qsTrId("ens-got-it")
+        text: qsTrId("ens-got-it")
         onClicked: okBtnClicked()
     }
 }

--- a/ui/app/AppLayouts/Profile/Sections/Ens/ENSConnected.qml
+++ b/ui/app/AppLayouts/Profile/Sections/Ens/ENSConnected.qml
@@ -3,6 +3,7 @@ import QtQuick.Layouts 1.3
 import QtQuick.Controls 2.14
 import "../../../../../imports"
 import "../../../../../shared"
+import "../../../../../shared/status"
 
 Item {
     property string ensUsername: ""
@@ -84,13 +85,13 @@ Item {
 
     }
 
-    StyledButton {
+    StatusButton {
         id: startBtn
         anchors.top: progress.bottom
         anchors.topMargin: Style.current.padding
         anchors.horizontalCenter: parent.horizontalCenter
         //% "Ok, got it"
-        label: qsTrId("ens-got-it")
+        text: qsTrId("ens-got-it")
         onClicked: okBtnClicked()
     }
 }

--- a/ui/app/AppLayouts/Profile/Sections/Ens/ENSDetails.qml
+++ b/ui/app/AppLayouts/Profile/Sections/Ens/ENSDetails.qml
@@ -3,6 +3,7 @@ import QtQuick.Layouts 1.3
 import QtQuick.Controls 2.14
 import "../../../../../imports"
 import "../../../../../shared"
+import "../../../../../shared/status"
 
 Item {
     property string username: ""
@@ -82,12 +83,12 @@ Item {
         anchors.topMargin: 24
     }
 
-    StyledButton {
+    StatusButton {
         anchors.bottom: parent.bottom
         anchors.bottomMargin: Style.current.padding
         anchors.horizontalCenter: parent.horizontalCenter
         //% "Back"
-        label: qsTrId("back")
+        text: qsTrId("back")
         onClicked: backBtnClicked()
     }
 }

--- a/ui/app/AppLayouts/Profile/Sections/Ens/ENSRegistered.qml
+++ b/ui/app/AppLayouts/Profile/Sections/Ens/ENSRegistered.qml
@@ -3,6 +3,7 @@ import QtQuick.Layouts 1.3
 import QtQuick.Controls 2.14
 import "../../../../../imports"
 import "../../../../../shared"
+import "../../../../../shared/status"
 
 Item {
     property string ensUsername: ""
@@ -84,13 +85,13 @@ Item {
 
     }
 
-    StyledButton {
+    StatusButton {
         id: startBtn
         anchors.top: progress.bottom
         anchors.topMargin: Style.current.padding
         anchors.horizontalCenter: parent.horizontalCenter
         //% "Ok, got it"
-        label: qsTrId("ens-got-it")
+        text: qsTrId("ens-got-it")
         onClicked: okBtnClicked()
     }
 }

--- a/ui/app/AppLayouts/Profile/Sections/Ens/SetPubKeyModal.qml
+++ b/ui/app/AppLayouts/Profile/Sections/Ens/SetPubKeyModal.qml
@@ -4,6 +4,7 @@ import QtQuick.Layouts 1.13
 import QtQuick.Dialogs 1.3
 import "../../../../../imports"
 import "../../../../../shared"
+import "../../../../../shared/status"
 
 ModalPopup {
     id: root
@@ -56,7 +57,7 @@ ModalPopup {
         anchors.rightMargin: Style.current.padding
         onGroupActivated: {
             root.title = group.headerText
-            btnNext.label = group.footerText
+            btnNext.text = group.footerText
         }
         TransactionFormGroup {
             id: group1
@@ -156,12 +157,12 @@ ModalPopup {
         width: parent.width
         height: btnNext.height
         
-        StyledButton {
+        StatusButton {
             id: btnNext
             anchors.right: parent.right
             //% "Next"
-            label: qsTrId("next")
-            disabled: !stack.currentGroup.isValid
+            text: qsTrId("next")
+            enabled: stack.currentGroup.isValid
             onClicked: {
                 const validity = stack.currentGroup.validate() 
                 if (validity.isValid && !validity.isPending) { 

--- a/ui/app/AppLayouts/Profile/Sections/Ens/Welcome.qml
+++ b/ui/app/AppLayouts/Profile/Sections/Ens/Welcome.qml
@@ -3,6 +3,7 @@ import QtQuick.Layouts 1.3
 import QtQuick.Controls 2.14
 import "../../../../../imports"
 import "../../../../../shared"
+import "../../../../../shared/status"
 
 Item {
     signal startBtnClicked()
@@ -277,14 +278,14 @@ Item {
         }
     }
 
-    StyledButton {
+    StatusButton {
         id: startBtn
         anchors.bottom: parent.bottom
         anchors.bottomMargin: Style.current.padding
         anchors.horizontalCenter: parent.horizontalCenter
-        disabled:  profileModel.network.current !== Constants.networkMainnet // Comment this to use on testnet
+        enabled:  profileModel.network.current === Constants.networkMainnet // Comment this to use on testnet
         //% "Start"
-        label: !disabled ? 
+        text: enabled ? 
           qsTrId("start") :
           //% "Only available on Mainnet"
           qsTrId("ens-network-restriction")

--- a/ui/app/AppLayouts/Profile/Sections/NetworksModal.qml
+++ b/ui/app/AppLayouts/Profile/Sections/NetworksModal.qml
@@ -110,12 +110,12 @@ ModalPopup {
                         networkValidationError = "";
                     }
 
-                    footer: StyledButton {
+                    footer: StatusButton {
                         anchors.right: parent.right
                         anchors.rightMargin: Style.current.smallPadding
-                        label: qsTr("Save")
+                        text: qsTr("Save")
                         anchors.bottom: parent.bottom
-                        disabled: nameInput.text == "" || rpcInput.text == ""
+                        enabled: nameInput.text !== "" && rpcInput.text !== ""
                         onClicked: {
                             if (!addNetworkPopup.validate()) {
                                 return;

--- a/ui/app/AppLayouts/Profile/Sections/Privileges/PermissionList.qml
+++ b/ui/app/AppLayouts/Profile/Sections/Privileges/PermissionList.qml
@@ -3,6 +3,7 @@ import QtQuick.Controls 2.13
 import QtQuick.Layouts 1.13
 import "../../../../../imports"
 import "../../../../../shared"
+import "../../../../../shared/status"
 import "./"
 
 ModalPopup {
@@ -51,13 +52,10 @@ ModalPopup {
         }
     }
     
-    footer: StyledButton {
+    footer: StatusButton {
         anchors.horizontalCenter: parent.horizontalCenter
-        btnColor: Style.current.lightRed
-        btnBorderWidth: 1
-        btnBorderColor: Style.current.border
-        textColor: Style.current.red
-        label: qsTr("Revoke all access")
+        type: "warn"
+        text: qsTr("Revoke all access")
         onClicked: {
             profileModel.dappList.permissionList.revokeAccess();
             accessRevoked(dapp);

--- a/ui/app/AppLayouts/Profile/Sections/SignoutContainer.qml
+++ b/ui/app/AppLayouts/Profile/Sections/SignoutContainer.qml
@@ -3,6 +3,7 @@ import QtQuick.Controls 2.13
 import QtQuick.Layouts 1.13
 import "../../../../imports"
 import "../../../../shared"
+import "../../../../shared/status"
 
 Item {
     id: signoutContainer
@@ -23,14 +24,14 @@ Item {
         font.pixelSize: 20
     }
 
-    StyledButton {
+    StatusButton {
         id: btnLogout
         anchors.top: txtTitle.bottom
         anchors.topMargin: Style.current.padding
         //% "Logout"
-        // label: qsTrId("logout")
+        // text: qsTrId("logout")
         //% "Exit"
-        label: qsTrId("exit")
+        text: qsTrId("exit")
 
         onClicked: {
             // profileModel.logout();

--- a/ui/app/AppLayouts/Profile/Sections/SyncContainer.qml
+++ b/ui/app/AppLayouts/Profile/Sections/SyncContainer.qml
@@ -98,12 +98,12 @@ Item {
                 enodeValidationError = "";
             }
 
-            footer: StyledButton {
+            footer: StatusButton {
                 anchors.right: parent.right
                 anchors.rightMargin: Style.current.smallPadding
-                label: qsTr("Save")
+                text: qsTr("Save")
                 anchors.bottom: parent.bottom
-                disabled: nameInput.text == "" || enodeInput.text == ""
+                enabled: nameInput.text !== "" && enodeInput.text !== ""
                 onClicked: {
                     if (!addMailserverPopup.validate()) {
                         return;

--- a/ui/app/AppLayouts/Wallet/AccountSettingsModal.qml
+++ b/ui/app/AppLayouts/Wallet/AccountSettingsModal.qml
@@ -109,15 +109,18 @@ ModalPopup {
         width: parent.width
         height: saveBtn.height
 
-        StyledButton {
+        StatusButton {
             visible:  currentAccount.walletType === Constants.watchWalletType
             anchors.top: parent.top
             anchors.right: saveBtn.left
             anchors.rightMargin: Style.current.padding
             //% "Delete account"
-            label: qsTrId("delete-account")
-            btnColor: Style.current.white
-            textColor: Style.current.red
+            text: qsTrId("delete-account")
+            bgColor: "transparent"
+            showBorder: true
+            borderColor: Style.current.border
+            hoveredBorderColor: Style.current.transparent
+            type: "warn"
 
             MessageDialog {
                 id: deleteError
@@ -154,15 +157,15 @@ ModalPopup {
                 confirmationDialog.open()
             }
         }
-        StyledButton {
+        StatusButton {
             id: saveBtn
             anchors.top: parent.top
             anchors.right: parent.right
             anchors.rightMargin: Style.current.padding
             //% "Save changes"
-            label: qsTrId("save-changes")
+            text: qsTrId("save-changes")
 
-            disabled: accountNameInput.text === ""
+            enabled: accountNameInput.text !== ""
 
             MessageDialog {
                 id: changeError

--- a/ui/app/AppLayouts/Wallet/AddCustomTokenModal.qml
+++ b/ui/app/AppLayouts/Wallet/AddCustomTokenModal.qml
@@ -3,6 +3,7 @@ import QtQuick.Controls 2.13
 import QtQuick.Layouts 1.13
 import "../../../imports"
 import "../../../shared"
+import "../../../shared/status"
 
 ModalPopup {
     id: popup
@@ -135,15 +136,15 @@ ModalPopup {
         height: addBtn.height
         visible: editable
 
-        StyledButton {
+        StatusButton {
             id: addBtn
             anchors.top: parent.top
             anchors.right: parent.right
             anchors.rightMargin: Style.current.padding
             //% "Add"
-            label: qsTrId("add")
+            text: qsTrId("add")
 
-            disabled: validationError !== "" && addressInput.text === "" || nameInput.text === "" || symbolInput.text === "" || decimalsInput.text === ""
+            enabled: validationError === "" && addressInput.text !== "" && nameInput.text !== "" && symbolInput.text !== "" && decimalsInput.text !== ""
 
             onClicked : {
                 const error = walletModel.addCustomToken(addressInput.text, nameInput.text, symbolInput.text, decimalsInput.text);

--- a/ui/app/AppLayouts/Wallet/SetCurrencyModal.qml
+++ b/ui/app/AppLayouts/Wallet/SetCurrencyModal.qml
@@ -4,6 +4,7 @@ import QtQuick.Controls 2.13
 //import Qt.labs.platform 1.1
 import "../../../imports"
 import "../../../shared"
+import "../../../shared/status"
 import "./components"
 
 Item {
@@ -27,10 +28,10 @@ Item {
             id: setCurrencyModalContent
         }
 
-        footer: StyledButton {
+        footer: StatusButton {
             anchors.right: parent.right
             //% "Save"
-            label: qsTrId("save")
+            text: qsTrId("save")
             onClicked: {
                 console.log("TODO: apply all accounts")
                 popup.close()

--- a/ui/app/AppLayouts/Wallet/components/collectiblesComponents/CollectiblesContent.qml
+++ b/ui/app/AppLayouts/Wallet/components/collectiblesComponents/CollectiblesContent.qml
@@ -4,6 +4,7 @@ import QtGraphicalEffects 1.13
 import QtQml.Models 2.13
 import "../../../../../imports"
 import "../../../../../shared"
+import "../../../../../shared/status"
 
 ScrollView {
     readonly property int imageSize: 164
@@ -49,9 +50,9 @@ ScrollView {
                     font.pixelSize: 13
                 }
 
-                StyledButton {
+                StatusButton {
                     //% "Reload"
-                    label: qsTrId("reload")
+                    text: qsTrId("reload")
                     anchors.horizontalCenter: parent.horizontalCenter
                     anchors.top: somethingWentWrongText.bottom
                     anchors.topMargin: Style.current.halfPadding

--- a/ui/app/AppLayouts/Wallet/components/collectiblesComponents/CollectiblesModal.qml
+++ b/ui/app/AppLayouts/Wallet/components/collectiblesComponents/CollectiblesModal.qml
@@ -2,6 +2,7 @@ import QtQuick 2.13
 import QtGraphicalEffects 1.13
 import "../../../../../imports"
 import "../../../../../shared"
+import "../../../../../shared/status"
 
 ModalPopup {
     property string collectibleName: "Furbeard"
@@ -32,11 +33,11 @@ ModalPopup {
         collectibleDescription: popup.collectibleDescription
     }
 
-    footer: StyledButton {
+    footer: StatusButton {
         visible: !!popup.buttonLink
         anchors.right: parent.right
         anchors.rightMargin: Style.current.padding
-        label: popup.buttonText
+        text: popup.buttonText
         anchors.top: parent.top
         onClicked: {
             appMain.openLink(popup.buttonLink)

--- a/ui/onboarding/Intro.qml
+++ b/ui/onboarding/Intro.qml
@@ -104,11 +104,10 @@ RowLayout {
             text: qsTrId("i-understand")
         }
 
-        StyledButton {
+        StatusButton {
             id: btnGetStarted
             enabled: warningCheckBox.checked
-            btnColor: this.enabled ? Style.current.secondaryBackground : "lightgrey"
-            label: "Get Started"
+            text: "Get Started"
             anchors.top: warningCheckBox.bottom
             anchors.topMargin: 5
             anchors.horizontalCenter: parent.horizontalCenter

--- a/ui/onboarding/InvalidSeedPhraseModal.qml
+++ b/ui/onboarding/InvalidSeedPhraseModal.qml
@@ -2,6 +2,7 @@ import QtQuick 2.13
 import QtQuick.Controls 2.13
 import "../imports"
 import "../shared"
+import "../shared/status"
 
 ModalPopup {
   id: popup
@@ -17,11 +18,11 @@ ModalPopup {
       font.pixelSize: 15
   }
   
-  footer: StyledButton {
+  footer: StatusButton {
       anchors.right: parent.right
       anchors.rightMargin: Style.current.smallPadding
       //% "Cancel"
-      label: qsTrId("browsing-cancel")
+      text: qsTrId("browsing-cancel")
       anchors.bottom: parent.bottom
       onClicked: {
           popup.close()

--- a/ui/onboarding/KeysMain.qml
+++ b/ui/onboarding/KeysMain.qml
@@ -2,6 +2,7 @@ import QtQuick 2.13
 import QtQuick.Controls 2.13
 import QtQuick.Controls.Universal 2.12
 import "../shared"
+import "../shared/status"
 import "../imports"
 
 Page {
@@ -66,25 +67,23 @@ Page {
         }
 
 
-        StyledButton {
+        StatusButton {
             id: btnGenKey
-            height: 44
             anchors.top: txtDesc1.bottom
             anchors.topMargin: 40
             anchors.horizontalCenter: parent.horizontalCenter
             //% "I'm new, generate keys"
-            label: qsTrId("im-new,-generate-keys")
+            text: qsTrId("im-new,-generate-keys")
         }
 
-        StyledButton {
+        StatusButton {
             id: btnExistingKey
             //% "Access existing key"
-            label: qsTrId("access-existing-key")
+            text: qsTrId("access-existing-key")
             anchors.top: btnGenKey.bottom
             anchors.topMargin: Style.current.padding
             anchors.horizontalCenter: parent.horizontalCenter
-            height: 44
-            background: Rectangle {color: "transparent"}
+            type: "secondary"
         }
     }
 }

--- a/ui/onboarding/Login/ConfirmAddExistingKeyModal.qml
+++ b/ui/onboarding/Login/ConfirmAddExistingKeyModal.qml
@@ -2,6 +2,7 @@ import QtQuick 2.13
 import QtQuick.Controls 2.13
 import "../../imports"
 import "../../shared"
+import "../../shared/status"
 
 ModalPopup {
     property var onOpenModalClick: function () {}
@@ -11,17 +12,17 @@ ModalPopup {
     height: 200
 
     StyledText {
-        text: "Do you want to add another existing key?"
+        text: qsTr("Do you want to add another existing key?")
         anchors.left: parent.left
         anchors.top: parent.top
     }
 
-    footer: StyledButton {
+    footer: StatusButton {
         anchors.bottom: parent.bottom
         anchors.topMargin: Style.current.padding
         anchors.right: parent.right
         anchors.rightMargin: Style.current.padding
-        label: "Add another existing key"
+        text: qsTr("Add another existing key")
 
         onClicked : {
             onOpenModalClick()

--- a/ui/onboarding/Login/SelectAnotherAccountModal.qml
+++ b/ui/onboarding/Login/SelectAnotherAccountModal.qml
@@ -2,6 +2,7 @@ import QtQuick 2.13
 import QtQuick.Controls 2.13
 import "../../imports"
 import "../../shared"
+import "../../shared/status"
 
 ModalPopup {
     property var onAccountSelect: function () {}
@@ -24,11 +25,11 @@ ModalPopup {
         }
     }
 
-    footer: StyledButton {
+    footer: StatusButton {
         anchors.bottom: parent.bottom
         anchors.topMargin: Style.current.padding
         anchors.right: parent.right
-        label: qsTr("Add another existing key")
+        text: qsTr("Add another existing key")
 
         onClicked : {
            onOpenModalClick()

--- a/ui/shared/BlockContactConfirmationDialog.qml
+++ b/ui/shared/BlockContactConfirmationDialog.qml
@@ -2,6 +2,7 @@ import QtQuick 2.13
 import QtQuick.Controls 2.13
 import QtQuick.Layouts 1.13
 import "../imports"
+import "../shared/status"
 import "./"
 
 ModalPopup {
@@ -31,15 +32,12 @@ ModalPopup {
         width: parent.width
         height: children[0].height
 
-        StyledButton {
+        StatusButton {
             anchors.right: parent.right
             anchors.rightMargin: Style.current.smallPadding
-            btnColor: Style.current.lightRed
-            btnBorderWidth: 1
-            btnBorderColor: Style.current.grey
-            textColor: Style.current.red
+            type: "warn"
             //% "Block User"
-            label: qsTrId("block-user")
+            text: qsTrId("block-user")
             anchors.bottom: parent.bottom
             onClicked: blockContactConfirmationDialog.blockButtonClicked()
         }

--- a/ui/shared/GasSelector.qml
+++ b/ui/shared/GasSelector.qml
@@ -127,16 +127,15 @@ Item {
         }
     }
 
-    StyledButton {
+    StatusButton {
         id: buttonReset
         anchors.top: sliderWrapper.bottom
         anchors.topMargin: sliderWrapper.visible ? Style.current.smallPadding : 0
         anchors.right: buttonAdvanced.left
-        anchors.rightMargin: -Style.current.padding
-        //% "Reset"
-        label: qsTrId("reset")
-        btnColor: "transparent"
-        textSize: 13
+        anchors.rightMargin: Style.current.padding
+        text: qsTr("Reset")
+        flat: true
+        font.pixelSize: 13
         visible: !sliderWrapper.visible
         onClicked: {
             gasSlider.value = root.defaultGasPrice()
@@ -144,16 +143,15 @@ Item {
         }
     }
 
-    StyledButton {
+    StatusButton {
         id: buttonAdvanced
         anchors.top: sliderWrapper.bottom
         anchors.topMargin: sliderWrapper.visible ? Style.current.smallPadding : 0
         anchors.right: parent.right
         anchors.rightMargin: -Style.current.padding
-        //% "Advanced"
-        label: qsTrId("advanced")
-        btnColor: "transparent"
-        textSize: 13
+        text: qsTr("Advanced")
+        flat: true
+        font.pixelSize: 13
         onClicked: {
             customNetworkFeeDialog.open()
         }
@@ -267,14 +265,14 @@ Item {
             color: Style.current.secondaryText
         }
 
-        footer: StyledButton {
+        footer: StatusButton {
             id: applyButton
             anchors.right: parent.right
             anchors.rightMargin: Style.current.smallPadding
             //% "Apply"
-            label: qsTrId("invalid-key-confirm")
+            text: qsTrId("invalid-key-confirm")
             anchors.bottom: parent.bottom
-            disabled: !customNetworkFeeDialog.isValid
+            enabled: customNetworkFeeDialog.isValid
             onClicked: {
                 if (customNetworkFeeDialog.validate()) {
                     root.updateGasEthValue()

--- a/ui/shared/Input.qml
+++ b/ui/shared/Input.qml
@@ -1,6 +1,7 @@
 import QtQuick 2.13
 import QtQuick.Controls 2.13
 import "../imports"
+import "../shared/status"
 import "."
 
 Item {
@@ -84,7 +85,7 @@ Item {
             anchors.topMargin: 0
             anchors.bottom: parent.bottom
             anchors.bottomMargin: 0
-            anchors.right: parent.right
+            anchors.right: clipboardButtonLoader.active ? clipboardButtonLoader.left : parent.right
             anchors.rightMargin: parent.rightMargin
             anchors.left: parent.left
             anchors.leftMargin: 0
@@ -111,6 +112,7 @@ Item {
         }
 
         Loader {
+            id: clipboardButtonLoader
             active: inputBox.copyToClipboard || inputBox.pasteFromClipboard
             anchors.verticalCenter: parent.verticalCenter
             anchors.right: parent.right
@@ -124,10 +126,10 @@ Item {
                         id: timer
                     }
 
-                    StyledButton {
+                    StatusButton {
                         property bool copied: false
                         id: copyBtn
-                        label: {
+                        text: {
                             if (copied) {
                                 return inputBox.copyToClipboard ?
                                             //% "Copied"
@@ -141,9 +143,9 @@ Item {
 
                         }
                         height: 28
-                        textSize: 12
-                        btnBorderColor: Style.current.blue
-                        btnBorderWidth: 1
+                        font.pixelSize: 12
+                        borderColor: Style.current.blue
+                        showBorder: true
                         onClicked: {
                             if (inputBox.copyToClipboard) {
                                 chatsModel.copyToClipboard(inputValue.text)

--- a/ui/shared/UnblockContactConfirmationDialog.qml
+++ b/ui/shared/UnblockContactConfirmationDialog.qml
@@ -2,6 +2,7 @@ import QtQuick 2.13
 import QtQuick.Controls 2.13
 import QtQuick.Layouts 1.13
 import "../imports"
+import "../shared/status"
 import "./"
 
 ModalPopup {
@@ -31,14 +32,11 @@ ModalPopup {
         width: parent.width
         height: children[0].height
 
-        StyledButton {
+        StatusButton {
             anchors.right: parent.right
             anchors.rightMargin: Style.current.smallPadding
-            btnColor: Style.current.lightRed
-            btnBorderWidth: 1
-            btnBorderColor: Style.current.grey
-            textColor: Style.current.red
-            label: qsTr("Unblock User")
+            type: "warn"
+            text: qsTr("Unblock User")
             anchors.bottom: parent.bottom
             onClicked: unblockContactConfirmationDialog.unblockButtonClicked()
         }

--- a/ui/shared/status/StatusStickersPopup.qml
+++ b/ui/shared/status/StatusStickersPopup.qml
@@ -126,10 +126,10 @@ Popup {
                     }
                 }
 
-                StyledButton {
+                StatusButton {
                     visible: lblNoStickersYet.visible
                     //% "Get Stickers"
-                    label: qsTrId("get-stickers")
+                    text: qsTrId("get-stickers")
                     anchors.top: noStickersContainer.bottom
                     anchors.topMargin: Style.current.padding
                     anchors.horizontalCenter: parent.horizontalCenter


### PR DESCRIPTION
There are some inconcistencies in the application when it comes to
button UI elements because we're using `StatusButton` in some places,
in other we use `StyledButton`. The latter is the original
component we've created when we started out building Status
Desktop, but is planned to be removed entirely in favour of
`StatusButton`.

This commit replaces the usages of `StyledButton` with `StatusButton`