### PR TITLE
build: pass `-extra-plugins=platforms/` cli flag to linuxdeployqt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -283,7 +283,7 @@ $(STATUS_CLIENT_APPIMAGE): nim_status_client $(APPIMAGE_TOOL) nim-status.desktop
 	cp vendor/status-go/build/bin/libstatus.so tmp/linux/dist/usr/lib/
 
 	echo -e $(BUILD_MSG) "AppImage"
-	linuxdeployqt tmp/linux/dist/nim-status.desktop -no-copy-copyright-files -qmldir=ui -qmlimport=$(QTDIR)/qml -bundle-non-qt-libs
+	linuxdeployqt tmp/linux/dist/nim-status.desktop -no-copy-copyright-files -qmldir=ui -qmlimport=$(QTDIR)/qml -bundle-non-qt-libs -extra-plugins=platforms/
 
 	rm tmp/linux/dist/AppRun
 	cp AppRun tmp/linux/dist/.

--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -57,7 +57,7 @@ pipeline {
           credentialsId: utils.getInfuraTokenCred(),
           variable: 'INFURA_TOKEN'
         )]) {
-          sh 'make pkg-linux'
+          sh 'make V=1 pkg-linux'
         }
       }
     }

--- a/docker-linux-app-image.sh
+++ b/docker-linux-app-image.sh
@@ -6,7 +6,7 @@ sudo apt update
 sudo apt install -y software-properties-common
 sudo add-apt-repository -y ppa:git-core/ppa
 sudo apt update
-sudo apt install -y --fix-missing build-essential cmake git libpcre3-dev jq
+sudo apt install -y --fix-missing build-essential cmake git libpcre3-dev jq libnss3
 
 # Installing GO
 # Probably should be part of a dockerfile


### PR DESCRIPTION
Fixes #1785

---

In draft at present because using the `-extra-plugins=platforms/` will likely require some adjustments to `ci/Dockerfile`.