### PR TITLE
fix(SetCurrencyModal): fix callstack size exceeded error

### DIFF
--- a/ui/app/AppLayouts/Wallet/SetCurrencyModal.qml
+++ b/ui/app/AppLayouts/Wallet/SetCurrencyModal.qml
@@ -11,14 +11,10 @@ ModalPopup {
     id: popup
     width: 480
     height: 510
+    property string defaultCurrency
 
-    function open() {
-        popup.open()
-        setCurrencyModalContent.currency = walletModel.defaultCurrency
-    }
-
-    function close() {
-        popup.close()
+    onDefaultCurrencyChanged: {
+        setCurrencyModalContent.currency = defaultCurrency
     }
 
     title: qsTr("Set Currency")

--- a/ui/app/AppLayouts/Wallet/WalletHeader.qml
+++ b/ui/app/AppLayouts/Wallet/WalletHeader.qml
@@ -179,7 +179,11 @@ Item {
                     icon.source: "../../img/currency.svg"
                     icon.width: 16
                     icon.height: 16
-                    onTriggered: openPopup(setCurrencyModalComponent)
+                    onTriggered: {
+                        openPopup(setCurrencyModalComponent, { 
+                            defaultCurrency: walletModel.defaultCurrency
+                        })
+                    }
                 }
             }
         }


### PR DESCRIPTION
There's a bug in the `SetCurrencyModal` where it runs into a callstack size
exceeded error because we're calling it's `open()` API to open itself.
That function happens to call itself again and again.

The reason that API was introduced in the first place, was to ensure that
the configured default currency is reflected currectly.

This commit fixes that issue by getting rid off the `open()` and `close()`
APIs which cause the mentioned error, and rely on `openPopup`'s parameters
configuration instead.