### PR TITLE
fix: make sure context menu receives correct channel index

### DIFF
--- a/ui/app/AppLayouts/Chat/ChatColumn/TopBar.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/TopBar.qml
@@ -107,7 +107,7 @@ Rectangle {
                 if (isPrivateGroupChat) {
                     menu.popup(moreActionsBtn.x, moreActionsBtn.height)
                 } else {
-                    menu.openMenu(chatsModel.activeChannel)
+                    menu.openMenu(chatsModel.activeChannel, chatsModel.getActiveChannelIdx())
                 }
             }
             cursorShape: Qt.PointingHandCursor


### PR DESCRIPTION
This was missing in one of our previous PRs and causes the
channel context menu to not function properly e.g. when deleting
chats, it currently always deletes the first chat in the channel list
instead of the active channel.