### PR TITLE
fix: make reactions in 1-on-1 chats work

### DIFF
--- a/src/app/chat/views/reactions.nim
+++ b/src/app/chat/views/reactions.nim
@@ -58,10 +58,19 @@ QtObject:
   proc push*(self: ReactionView, reactions: var seq[Reaction]) =
     let t = reactions.len
     for reaction in reactions.mitems:
-      let chat = self.status.chat.channels[reaction.chatId]
-      var messageList = self.messageList[][reaction.chatId]
+
+      var chatId: string;
+      if reaction.chatId == self.pubKey:
+        chatId = reaction.fromAccount
+      else:
+        chatId = reaction.chatId
+
+      let chat = self.status.chat.channels[chatId]
+      var messageList = self.messageList[][chatId]
+
       if chat.chatType == ChatType.Profile:
         messageList = self.messageList[][status_utils.getTimelineChatId()]
+
       var emojiReactions = messageList.getReactions(reaction.messageId)
       var oldReactions: JsonNode
       if (emojiReactions == "") :


### PR DESCRIPTION
Turns out message reactions weren't functional in 1 on 1 chats.
Reaction signals come with a `chatId` that they correspond to, which is
then used to determine to channel and message list to apply/remove
the reaction to.

Inside of a 1 on 1 chat, the `chatId` of a reaction coming from the
will always be the pubKey of the the user that receives it.
A user however, usually doesn't store a chat item for her own pubKey
unless it's of type `Profile`.

This results in an illega storage access as reported in #1828

This commit fixes this bug by checking whether the reaction `chatId`
matches the user's `pubKey`. If that's the case, we know that the reaction
corresponds to the reaction's `fromAuthor` chat.

Fixes #1828