### PR TITLE
Fix channel scroll issues + errorSound

### DIFF
--- a/ui/app/AppLayouts/Chat/ChatColumn/ChatMessages.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/ChatMessages.qml
@@ -40,7 +40,7 @@ ScrollView {
         flickDeceleration: 10000
         Layout.fillWidth: true
         Layout.fillHeight: true
-        verticalLayoutDirection: ListView.TopToBottom
+        verticalLayoutDirection: ListView.BottomToTop
 
         Timer {
             id: timer
@@ -115,9 +115,9 @@ ScrollView {
             // Call this twice and with a timer since the first scroll to bottom might have happened before some stuff loads
             // meaning that the scroll will not actually be at the bottom on switch
             // Add a small delay because images, even though they say they say they are loaed, they aren't shown yet
-            Qt.callLater(chatLogView.positionViewAtEnd)
+            Qt.callLater(chatLogView.positionViewAtBeginning)
             timer.setTimeout(function() {
-                 Qt.callLater(chatLogView.positionViewAtEnd)
+                 Qt.callLater(chatLogView.positionViewAtBeginning)
             }, 100);
             return true
         }
@@ -131,7 +131,6 @@ ScrollView {
         }
 
         Connections {
-
             target: chatsModel
             onMessagesLoaded: {
                 loadingMessages = false;
@@ -241,7 +240,7 @@ ScrollView {
     DelegateModel {
         id: messageListDelegate
         property var lessThan: [
-            function(left, right) { return left.clock < right.clock }
+            function(left, right) { return left.clock > right.clock }
         ]
 
         property int sortOrder: 0

--- a/ui/app/AppMain.qml
+++ b/ui/app/AppMain.qml
@@ -122,11 +122,6 @@ RowLayout {
         property bool pdfViewerEnabled: true
         property bool compatibilityMode: true
     }
-    
-
-    ErrorSound {
-        id: errorSound
-    }
 
     Audio {
         id: sendMessageSound

--- a/ui/main.qml
+++ b/ui/main.qml
@@ -37,6 +37,10 @@ ApplicationWindow {
     }
     visible: true
 
+    ErrorSound {
+        id: errorSound
+    }
+
     Action {
         shortcut: StandardKey.FullScreen
         onTriggered: {


### PR DESCRIPTION
This reverses the chatMessages ListView so that the start is actually the Bottom. This, paired with Richard's StackLayout change should make the channel switching very fast