### PR TITLE
fix: fix profile image order since reversing the list order

### DIFF
--- a/ui/app/AppLayouts/Chat/ChatColumn/ChatMessages.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/ChatMessages.qml
@@ -302,7 +302,8 @@ ScrollView {
             outgoingStatus: model.outgoingStatus
             responseTo: model.responseTo
             authorCurrentMsg: msgDelegate.ListView.section
-            authorPrevMsg: msgDelegate.ListView.previousSection
+            // The previous message is actually the nextSection since we reversed the list order
+            authorPrevMsg: msgDelegate.ListView.nextSection
             imageClick: imagePopup.openPopup.bind(imagePopup)
             messageId: model.messageId
             emojiReactions: model.emojiReactions


### PR DESCRIPTION
Before that fix, the profile image was put on your last message instead of your first, making it look like your previous message was said by the person above you