### PR TITLE
feat: drag and drop images

### DIFF
--- a/src/app/chat/view.nim
+++ b/src/app/chat/view.nim
@@ -223,6 +223,24 @@ QtObject:
       error "Error sending the image", msg = e.msg
       result = fmt"Error sending the image: {e.msg}"
 
+  proc sendImages*(self: ChatsView, imagePathsArray: string): string {.slot.} =
+    result = ""
+    try:
+      var images = Json.decode(imagePathsArray, seq[string])
+      let channelId = self.activeChannel.id
+
+      for imagePath in images.mitems:
+        var image = image_utils.formatImagePath(imagePath)
+        imagePath = image_resizer(image, 2000, TMPDIR)
+
+      self.status.chat.sendImages(channelId, images)
+
+      for imagePath in images.items:
+        removeFile(imagePath)
+    except Exception as e:
+      error "Error sending images", msg = e.msg
+      result = fmt"Error sending images: {e.msg}"
+
   proc activeChannelChanged*(self: ChatsView) {.signal.}
 
   proc contextChannelChanged*(self: ChatsView) {.signal.}

--- a/src/app/utilsView/view.nim
+++ b/src/app/utilsView/view.nim
@@ -10,6 +10,7 @@ import ../../status/libstatus/settings
 import ../../status/libstatus/wallet as status_wallet
 import ../../status/libstatus/utils as status_utils
 import ../../status/ens as status_ens
+import ../utils/image_utils
 import web3/[ethtypes, conversions]
 import stew/byteutils
 
@@ -99,3 +100,13 @@ QtObject:
 
   proc getNetworkName*(self: UtilsView): string {.slot.} =
     getCurrentNetworkDetails().name
+
+  proc getFileSize*(self: UtilsView, filename: string): string {.slot.} =
+    var f: File = nil
+    if f.open(filename.formatImagePath):
+      try:
+        result = $(f.getFileSize())
+      finally:
+        close(f)
+    else:
+      raise newException(IOError, "cannot open: " & filename)

--- a/src/status/chat.nim
+++ b/src/status/chat.nim
@@ -245,6 +245,10 @@ proc sendImage*(self: ChatModel, chatId: string, image: string) =
   var response = status_chat.sendImageMessage(chatId, image)
   discard self.processMessageUpdateAfterSend(response)
 
+proc sendImages*(self: ChatModel, chatId: string, images: var seq[string]) =
+  var response = status_chat.sendImageMessages(chatId, images)
+  discard self.processMessageUpdateAfterSend(response)
+
 proc sendSticker*(self: ChatModel, chatId: string, sticker: Sticker) =
   var response = status_chat.sendStickerMessage(chatId, sticker)
   self.events.emit("stickerSent", StickerArgs(sticker: sticker, save: true))

--- a/ui/app/AppLayouts/Chat/ChatColumn.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn.qml
@@ -317,7 +317,7 @@ StackLayout {
                 }
                 onSendMessage: {
                     if (chatInput.fileUrls.length > 0){
-                        chatsModel.sendImage(chatInput.fileUrls[0], false);
+                        chatsModel.sendImages(JSON.stringify(fileUrls));
                     }
                     let msg = chatsModel.plainText(Emoji.deparse(chatInput.textInput.text))
                     if (msg.length > 0){

--- a/ui/app/AppLayouts/Timeline/TimelineLayout.qml
+++ b/ui/app/AppLayouts/Timeline/TimelineLayout.qml
@@ -71,9 +71,13 @@ ScrollView {
             anchors.top: parent.top
             anchors.topMargin: 40
             chatType: Constants.chatTypeStatusUpdate
+            imageErrorMessageLocation: StatusChatInput.ImageErrorMessageLocation.Bottom
+            z: 1
             onSendMessage: {
                 if (statusUpdateInput.fileUrls.length > 0){
-                    chatsModel.sendImage(statusUpdateInput.fileUrls[0], true);
+                    statusUpdateInput.fileUrls.forEach(url => {
+                        chatsModel.sendImage(url, true);
+                    })
                 }
                 var msg = chatsModel.plainText(Emoji.deparse(statusUpdateInput.textInput.text))
                 if (msg.length > 0){

--- a/ui/app/AppMain.qml
+++ b/ui/app/AppMain.qml
@@ -15,6 +15,7 @@ import Qt.labs.settings 1.0
 
 RowLayout {
     id: appMain
+    property int currentView: sLayout.currentIndex
     spacing: 0
     Layout.fillHeight: true
     Layout.fillWidth: true

--- a/ui/imports/Constants.qml
+++ b/ui/imports/Constants.qml
@@ -124,4 +124,10 @@ QtObject {
 
     readonly property string deepLinkPrefix: 'statusim://'
     readonly property string joinStatusLink: 'join.status.im'
+
+    readonly property int maxUploadFiles: 5
+    readonly property double maxUploadFilesizeMB: 0.5
+
+    readonly property var acceptedImageExtensions: [".png", ".jpg", ".jpeg", ".svg", ".gif"]
+    readonly property var acceptedDragNDropImageExtensions: [".png", ".jpg", ".jpeg", ".heif", "tif", ".tiff"]
 }

--- a/ui/imports/Utils.qml
+++ b/ui/imports/Utils.qml
@@ -404,6 +404,14 @@ QtObject {
     }
 
     function hasImageExtension(url) {
-        return [".png", ".jpg", ".jpeg", ".svg", ".gif"].some(ext => url.includes(ext))
+        return Constants.acceptedImageExtensions.some(ext => url.includes(ext))
+    }
+
+    function hasDragNDropImageExtension(url) {
+        return Constants.acceptedDragNDropImageExtensions.some(ext => url.includes(ext))
+    }
+
+    function deduplicate(array) {
+        return Array.from(new Set(array))
     }
 }

--- a/ui/shared/status/StatusChatImageExtensionValidator.qml
+++ b/ui/shared/status/StatusChatImageExtensionValidator.qml
@@ -1,0 +1,23 @@
+import QtQuick 2.13
+import QtQuick.Controls 2.13
+import QtQuick.Layouts 1.13
+import QtGraphicalEffects 1.0
+import "../../imports"
+import ".."
+
+StatusChatImageValidator {
+    id: root
+
+    errorMessage: qsTr("Format not supported.")
+    secondaryErrorMessage: qsTr("Upload %1 only").arg(Constants.acceptedDragNDropImageExtensions.map(ext => ext.replace(".", "").toUpperCase() + "s").join(", "))
+
+    onImagesChanged: {
+        let isValid = true
+        root.validImages = images.filter(img => {
+            const isImage = Utils.hasDragNDropImageExtension(img)
+            isValid = isValid && isImage
+            return isImage
+        })
+        root.isValid = isValid
+    }
+}

--- a/ui/shared/status/StatusChatImageQtyValidator.qml
+++ b/ui/shared/status/StatusChatImageQtyValidator.qml
@@ -1,0 +1,20 @@
+import QtQuick 2.13
+import QtQuick.Controls 2.13
+import QtQuick.Layouts 1.13
+import QtGraphicalEffects 1.0
+import "../../imports"
+import ".."
+
+StatusChatImageValidator {
+    id: root
+    errorMessage: qsTr("You can only upload %1 images at a time").arg(Constants.maxUploadFiles)
+
+    onImagesChanged: {
+        let isValid = true
+        if (images.length > Constants.maxUploadFiles) {
+            isValid = false
+        }
+        root.isValid = isValid
+        root.validImages = images.slice(0, Constants.maxUploadFiles)
+    }
+}

--- a/ui/shared/status/StatusChatImageSizeValidator.qml
+++ b/ui/shared/status/StatusChatImageSizeValidator.qml
@@ -1,0 +1,23 @@
+import QtQuick 2.13
+import QtQuick.Controls 2.13
+import QtQuick.Layouts 1.13
+import QtGraphicalEffects 1.0
+import "../../imports"
+import ".."
+
+StatusChatImageValidator {
+    id: root
+    readonly property int maxImgSizeBytes: Constants.maxUploadFilesizeMB * 1048576 /* 1 MB in bytes */
+
+    onImagesChanged: {
+        let isValid = true
+        root.validImages = images.filter(img => {
+            let size = parseInt(utilsModel.getFileSize(img))
+            const isSmallEnough = size <= maxImgSizeBytes
+            isValid = isValid && isSmallEnough
+            return isSmallEnough
+        })
+        root.isValid = isValid
+    }
+    errorMessage: qsTr("Max image size is %1 MB").arg(Constants.maxUploadFilesizeMB)
+}

--- a/ui/shared/status/StatusChatImageValidator.qml
+++ b/ui/shared/status/StatusChatImageValidator.qml
@@ -1,0 +1,73 @@
+import QtQuick 2.13
+import QtQuick.Controls 2.13
+import QtQuick.Layouts 1.13
+import QtGraphicalEffects 1.0
+import "../../imports"
+import ".."
+
+Item {
+    id: root
+    property bool isValid: true
+    property alias errorMessage: txtValidationError.text
+    property alias secondaryErrorMessage: txtValidationExtraInfo.text
+    property var images: []
+    property var validImages: []
+
+    visible: !isValid
+    width: imgExclamation.width + txtValidationError.width + txtValidationExtraInfo.width + 24
+    height: txtValidationError.height + 14
+
+    Rectangle {
+        anchors.fill: parent
+        color: Style.current.background
+        radius: Style.current.halfPadding
+        layer.enabled: true
+        layer.effect: DropShadow {
+            verticalOffset: 3
+            radius: 8
+            samples: 15
+            fast: true
+            cached: true
+            color: "#22000000"
+        }
+
+        SVGImage {
+            id: imgExclamation
+            width: 20
+            height: 20
+            sourceSize.height: height * 2
+            sourceSize.width: width * 2
+            verticalAlignment: Image.AlignVCenter
+            anchors.top: parent.top
+            anchors.left: parent.left
+            anchors.topMargin: 6
+            anchors.leftMargin: 6
+            fillMode: Image.PreserveAspectFit
+            source: "../../app/img/exclamation_outline.svg"
+        }
+        StyledText {
+            id: txtValidationError
+            verticalAlignment: Text.AlignVCenter
+            anchors.top: parent.top
+            anchors.left: imgExclamation.right
+            anchors.topMargin: 7
+            anchors.leftMargin: 6
+            wrapMode: Text.WordWrap
+            font.pixelSize: 13
+            height: 18
+            color: Style.current.danger
+        }
+        StyledText {
+            id: txtValidationExtraInfo
+            verticalAlignment: Text.AlignVCenter
+            anchors.top: parent.top
+            anchors.left: txtValidationError.right
+            anchors.topMargin: 7
+            anchors.leftMargin: 6
+            wrapMode: Text.WordWrap
+            font.pixelSize: 13
+            height: 18
+            color: Style.current.textColor
+        }
+    }
+}

--- a/ui/shared/status/StatusChatInputImageArea.qml
+++ b/ui/shared/status/StatusChatInputImageArea.qml
@@ -4,90 +4,93 @@ import QtQuick.Controls 2.13
 import "../../imports"
 import "../../shared"
 
-Rectangle {
+Row {
     id: imageArea
-    height: chatImage.height
+    spacing: Style.current.halfPadding
 
-    signal imageRemoved()
-    property url imageSource: ""
-    color: "transparent"
-    
-    Image {
-        id: chatImage
-        property bool hovered: false
-        height: 64
-        anchors.left: parent.left
-        anchors.top: parent.top
-        fillMode: Image.PreserveAspectFit
-        mipmap: true
-        smooth: false
-        antialiasing: true
-        source: parent.imageSource
-        MouseArea {
-            cursorShape: Qt.PointingHandCursor
-            anchors.fill: parent
-            hoverEnabled: true
-            onEntered: {
-                chatImage.hovered = true
-            }
-            onExited: {
-                chatImage.hovered = false
-            }
-        }
+    signal imageRemoved(int index)
+    property alias imageSource: rptImages.model
 
-        layer.enabled: true
-        layer.effect: OpacityMask {
-            maskSource: Item {
-                width: chatImage.width
-                height: chatImage.height
-
-                Rectangle {
-                    anchors.top: parent.top
-                    anchors.left: parent.left
-                    width: chatImage.width
-                    height: chatImage.height
-                    radius: 16
+    Repeater {
+        id: rptImages
+        Item {
+            height: chatImage.paintedHeight + closeBtn.height - 5
+            width: chatImage.width
+            Image {
+                id: chatImage
+                property bool hovered: false
+                width: 64
+                height: 64
+                fillMode: Image.PreserveAspectCrop
+                mipmap: true
+                smooth: false
+                antialiasing: true
+                source: modelData
+                MouseArea {
+                    cursorShape: Qt.PointingHandCursor
+                    anchors.fill: parent
+                    hoverEnabled: true
+                    onEntered: {
+                        chatImage.hovered = true
+                    }
+                    onExited: {
+                        chatImage.hovered = false
+                    }
                 }
-                Rectangle {
-                    anchors.bottom: parent.bottom
-                    anchors.right: parent.right
-                    width: 32
-                    height: 32
-                    radius: 4
+
+                layer.enabled: true
+                layer.effect: OpacityMask {
+                    maskSource: Item {
+                        width: chatImage.width
+                        height: chatImage.height
+
+                        Rectangle {
+                            anchors.top: parent.top
+                            anchors.left: parent.left
+                            width: chatImage.width
+                            height: chatImage.height
+                            radius: 16
+                        }
+                        Rectangle {
+                            anchors.bottom: parent.bottom
+                            anchors.right: parent.right
+                            width: 32
+                            height: 32
+                            radius: 4
+                        }
+                    }
+                }
+            }
+            RoundButton {
+                id: closeBtn
+                implicitWidth: 24
+                implicitHeight: 24
+                padding: 0
+                anchors.top: chatImage.top
+                anchors.topMargin: -5
+                anchors.right: chatImage.right
+                anchors.rightMargin: -Style.current.halfPadding
+                visible: chatImage.hovered || hovered
+                contentItem: SVGImage {
+                    source: !closeBtn.hovered ?
+                    "../../app/img/close-filled.svg" : "../../app/img/close-filled-hovered.svg"
+                    width: closeBtn.width
+                    height: closeBtn.height
+                }
+                background: Rectangle {
+                    color: "transparent"
+                }
+                onClicked: {
+                    imageArea.imageRemoved(index)
+                    const tmp = imageArea.imageSource.filter((url, idx) => idx !== index)
+                    rptImages.model = tmp
+                }
+                MouseArea {
+                    cursorShape: Qt.PointingHandCursor
+                    anchors.fill: parent
+                    onPressed: mouse.accepted = false
                 }
             }
         }
     }
-
-    RoundButton {
-        id: closeBtn
-        implicitWidth: 24
-        implicitHeight: 24
-        padding: 0
-        anchors.top: chatImage.top
-        anchors.topMargin: -5
-        anchors.right: chatImage.right
-        anchors.rightMargin: -Style.current.halfPadding
-        visible: chatImage.hovered || hovered
-        contentItem: SVGImage {
-            source: !closeBtn.hovered ? 
-              "../../app/img/close-filled.svg" : "../../app/img/close-filled-hovered.svg"
-            width: closeBtn.width
-            height: closeBtn.height
-        }
-        background: Rectangle {
-            color: "transparent"
-        }
-        onClicked: {
-            imageArea.imageRemoved()                
-            imageArea.imageSource = ""
-        }
-        MouseArea {
-            cursorShape: Qt.PointingHandCursor
-            anchors.fill: parent
-            onPressed: mouse.accepted = false
-        }
-    }
-
-
 }


### PR DESCRIPTION
Closes #1374 

Allow up to 5 images to be dragged and dropped in to one-on-one chats and in the timeline. Can be combined with the existing upload button. The upload file dialog has been changed to allow multiple selections. Drag and dropped images adhere to the following rules, with corresponding validations messages:
- Max 5 image
- Image size must be 0.5 MB or less
- File extension must be one of [".png", ".jpg", ".jpeg", ".heif", "tif", ".tiff"]

Drag and drop and uploaded images are now also deduplicated.

### Note
1. There is a console message that appears sometimes when uploading an image via the `FileDialog` component "Model size of -5 is less than 0", however this does not appear to be an error and might be related to known bugs: https://bugreports.qt.io/browse/QTBUG-79168 and https://bugreports.qt.io/browse/QTBUG-72543.
2. Adding 5 images to the timeline does not post 5 images in one timeline entry, however posts a single text timeline entry followed by 5 separate timeline entries. Maybe this is something needs to be addressed in a future PR.