### PR TITLE
chore: add dummy ListView to ChatMessages to avoid app crash

### DIFF
--- a/ui/app/AppLayouts/Chat/ChatColumn/ChatMessages.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/ChatMessages.qml
@@ -29,6 +29,28 @@ ScrollView {
     ScrollBar.vertical.policy: chatLogView.contentHeight > chatLogView.height ? ScrollBar.AlwaysOn : ScrollBar.AlwaysOff
     ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
 
+    /**
+     * This ListView is prevents a crash of the application during
+     * login *DO NOT REMOVE IT*.
+     *
+     * For an unknown reason, when the `chatLogView` ListView uses
+     * a `verticalLayoutDirection: BottomToTop`, it prevents the application
+     * from successfully rendering during login and crashes.
+     *
+     * From debugging this, we know that this only happens when the above
+     * condition applies *and* when a `DelegateModel` is used.
+     * The delegate doesn't even need proper data, it application would still
+     * crash.
+     *
+     * We found out that the crash can be avoided when another `ListView` exists
+     * in this component (however it's unclear why).
+     *
+     * TODO(pascal): remove this once we know what's exactly going on here.
+     */
+    ListView {
+        id: dummy
+    }
+
     ListView {
         property string currentNotificationChatId
 


### PR DESCRIPTION
For an unknown reason, when the `chatLogView` ListView uses
a `verticalLayoutDirection: BottomToTop`, it prevents the application
from successfully rendering during login and crashes.

From debugging this, we know that this only happens when the above
condition applies *and* when a `DelegateModel` is used.
The delegate doesn't even need proper data, it application would still
crash.

We found out that the crash can be avoided when another `ListView` exists
in this component (however it's unclear why).

For now this commit adds such a placeholder `ListView` until it
we know more about what's going on.