### PR TITLE
fix(libstatus): make saveContact API memory safe(r)

### DIFF
--- a/src/status/contacts.nim
+++ b/src/status/contacts.nim
@@ -81,9 +81,15 @@ proc addContact*(self: ContactModel, id: string, localNickname: string): string 
       ""
     else:
       localNickname
-  result = status_contacts.saveContact(contact.id, contact.ensVerified, contact.ensName, contact.ensVerifiedAt, contact.ensVerificationRetries, contact.alias, contact.identicon, contact.identityImage.thumbnail, contact.systemTags, nickname)
+
+  var thumbnail = ""
+  if contact.identityImage != nil:
+    thumbnail = contact.identityImage.thumbnail
+
+  result = status_contacts.saveContact(contact.id, contact.ensVerified, contact.ensName, contact.ensVerifiedAt, contact.ensVerificationRetries, contact.alias, contact.identicon, thumbnail, contact.systemTags, nickname)
   self.events.emit("contactAdded", Args())
   discard requestContactUpdate(contact.id)
+
   if updating:
     let profile = Profile(
       id: contact.id,
@@ -106,7 +112,12 @@ proc addContact*(self: ContactModel, id: string): string =
 proc removeContact*(self: ContactModel, id: string) =
   let contact = self.getContactByID(id)
   contact.systemTags.delete(contact.systemTags.find(":contact/added"))
-  discard status_contacts.saveContact(contact.id, contact.ensVerified, contact.ensName, contact.ensVerifiedAt, contact.ensVerificationRetries, contact.alias, contact.identicon, contact.identityImage.thumbnail, contact.systemTags, contact.localNickname)
+
+  var thumbnail = ""
+  if contact.identityImage != nil:
+    thumbnail = contact.identityImage.thumbnail
+
+  discard status_contacts.saveContact(contact.id, contact.ensVerified, contact.ensName, contact.ensVerifiedAt, contact.ensVerificationRetries, contact.alias, contact.identicon, thumbnail, contact.systemTags, contact.localNickname)
   self.events.emit("contactRemoved", Args())
 
 proc isAdded*(self: ContactModel, id: string): bool =

--- a/ui/app/AppLayouts/Chat/ChatColumn/ChatMessages.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/ChatMessages.qml
@@ -29,6 +29,28 @@ ScrollView {
     ScrollBar.vertical.policy: chatLogView.contentHeight > chatLogView.height ? ScrollBar.AlwaysOn : ScrollBar.AlwaysOff
     ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
 
+    /**
+     * This ListView is prevents a crash of the application during
+     * login *DO NOT REMOVE IT*.
+     *
+     * For an unknown reason, when the `chatLogView` ListView uses
+     * a `verticalLayoutDirection: BottomToTop`, it prevents the application
+     * from successfully rendering during login and crashes.
+     *
+     * From debugging this, we know that this only happens when the above
+     * condition applies *and* when a `DelegateModel` is used.
+     * The delegate doesn't even need proper data, it application would still
+     * crash.
+     *
+     * We found out that the crash can be avoided when another `ListView` exists
+     * in this component (however it's unclear why).
+     *
+     * TODO(pascal): remove this once we know what's exactly going on here.
+     */
+    ListView {
+        id: dummy
+    }
+
     ListView {
         property string currentNotificationChatId
 


### PR DESCRIPTION
In https://github.com/status-im/status-desktop/commit/31a9d1a6f we've fixed
a bug where a contact's thumbnail hasn't been passed to the `saveContact`
API.

Unfortunately, that fix wasn't memory safe. There are cases when a contact's
`identityImage` is `nil`, resulting in illegal storage access when accessing
a contact's thumbnail.

This commit fixes the issue by safe guarding around `identityImage` possibly
being `nil`.