### PR TITLE
fix: increase identicon source image size

### DIFF
--- a/ui/app/AppLayouts/Chat/components/ProfilePopup.qml
+++ b/ui/app/AppLayouts/Chat/components/ProfilePopup.qml
@@ -223,6 +223,7 @@ ModalPopup {
             anchors.bottom: chatSettings.bottom
             anchors.bottomMargin: 5
             width: 13
+            height: 7
             fillMode: Image.PreserveAspectFit
             ColorOverlay {
                 anchors.fill: parent

--- a/ui/shared/SVGImage.qml
+++ b/ui/shared/SVGImage.qml
@@ -1,13 +1,6 @@
 import QtQuick 2.13
 
-// Source: https://forum.qt.io/topic/52161/properly-scaling-svg-images/6
-
 Image {
-  sourceSize: Qt.size(hiddenImg.sourceSize.width * 2, hiddenImg.sourceSize.height * 2)
-  Image {
-    id: hiddenImg
-    source: parent.source
-    width: 0
-    height: 0
-  }
+  sourceSize.width: width
+  sourceSize.height: height
 }

--- a/ui/shared/TransactionPreview.qml
+++ b/ui/shared/TransactionPreview.qml
@@ -90,6 +90,7 @@ Item {
                     SVGImage {
                         id: fromArrow
                         width: 13
+                        height: 7
                         visible: root.isFromEditable
                         anchors.verticalCenter: parent.verticalCenter
                         fillMode: Image.PreserveAspectFit
@@ -441,6 +442,7 @@ Item {
                     SVGImage {
                         id: gasArrow
                         width: 13
+                        height: 7
                         visible: root.isGasEditable
                         anchors.verticalCenter: parent.verticalCenter
                         fillMode: Image.PreserveAspectFit
@@ -489,6 +491,7 @@ Item {
                     }
                     SVGImage {
                         width: 13
+                        height: 7
                         visible: true
                         anchors.verticalCenter: parent.verticalCenter
                         fillMode: Image.PreserveAspectFit


### PR DESCRIPTION
This increases the size of the generated image, however, it takes a while to generate the accounts. I'd suggest to not merge it until we add code to generate these async, or change the code to generate svg instead of pngs?
![image](https://user-images.githubusercontent.com/1106587/109830456-e4845500-7c14-11eb-9dda-b645573ddc96.png)
