### PR TITLE
fix(Communities): make leaving communities work again

### DIFF
--- a/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/InvitationBubble.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/InvitationBubble.qml
@@ -144,7 +144,7 @@ Item {
                         //% "Join"
                         qsTrId("join")
                     onClicked: {
-                        chatsModel.communities.joinCommunity(communityId)
+                        chatsModel.communities.joinCommunity(communityId, true)
                         root.joined = true
                     }
                 }

--- a/ui/app/AppLayouts/Chat/CommunityColumn.qml
+++ b/ui/app/AppLayouts/Chat/CommunityColumn.qml
@@ -71,7 +71,7 @@ Item {
                     icon.source: "../../img/hash.svg"
                     icon.width: 20
                     icon.height: 20
-                    onTriggered: openPopup(createChannelPopup, {communityId: chatsModel.activeCommunity.id})
+                    onTriggered: openPopup(createChannelPopup, {communityId: chatsModel.communities.activeCommunity.id})
                 }
 
                 Action {

--- a/ui/app/AppLayouts/Chat/CommunityColumn.qml
+++ b/ui/app/AppLayouts/Chat/CommunityColumn.qml
@@ -81,7 +81,7 @@ Item {
                     icon.color: Style.current.red
                     icon.width: 20
                     icon.height: 20
-                    onTriggered: chatsModel.leaveCurrentCommunity()
+                    onTriggered: chatsModel.communities.leaveCurrentCommunity()
                 }
 
                 onAboutToHide: {

--- a/ui/app/AppLayouts/Chat/CommunityComponents/CommunityDetailPopup.qml
+++ b/ui/app/AppLayouts/Chat/CommunityComponents/CommunityDetailPopup.qml
@@ -228,7 +228,7 @@ ModalPopup {
                         text = qsTr("Pending")
                     }
                 } else {
-                    error = chatsModel.communities.joinCommunity(popup.communityId)
+                    error = chatsModel.communities.joinCommunity(popup.communityId, true)
                 }
 
                 if (error) {


### PR DESCRIPTION
Turns out in https://github.com/status-im/status-desktop/commit/81bb7fcc6 we've introduced a regression where
leaving a communities isn't possible anymore because we're trying
to call an API that doesn't exist on the `chatsModel`.

This commit fixes it by ensuring the API is called from `chatsModel.communities`.