### PR TITLE
fix(Communities): make rejoining communities work

### DIFF
--- a/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/InvitationBubble.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/InvitationBubble.qml
@@ -144,7 +144,7 @@ Item {
                         //% "Join"
                         qsTrId("join")
                     onClicked: {
-                        chatsModel.communities.joinCommunity(communityId)
+                        chatsModel.communities.joinCommunity(communityId, true)
                         root.joined = true
                     }
                 }

--- a/ui/app/AppLayouts/Chat/CommunityComponents/CommunityDetailPopup.qml
+++ b/ui/app/AppLayouts/Chat/CommunityComponents/CommunityDetailPopup.qml
@@ -228,7 +228,7 @@ ModalPopup {
                         text = qsTr("Pending")
                     }
                 } else {
-                    error = chatsModel.communities.joinCommunity(popup.communityId)
+                    error = chatsModel.communities.joinCommunity(popup.communityId, true)
                 }
 
                 if (error) {


### PR DESCRIPTION
When the communities code was moved into its own view in https://github.com/status-im/status-desktop/commit/b38d1df59
it broke the functionality to join communities again.

Qt complains that the Nim API in use `chatsModel.communities.joinCommunity`
expects two parameters, when it's call with just one.
This is unexpected because the API in question set a default value
for its second parameter.

To make this work again, we have to make sure the `setActive`
parameter is supplied every time we call the API from
within QML.

Also, worth noting that this is not the first time we're running into
a scenario like this.