### PR TITLE
fix(Communities): make creating channels work again

### DIFF
--- a/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/InvitationBubble.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/InvitationBubble.qml
@@ -144,7 +144,7 @@ Item {
                         //% "Join"
                         qsTrId("join")
                     onClicked: {
-                        chatsModel.communities.joinCommunity(communityId)
+                        chatsModel.communities.joinCommunity(communityId, true)
                         root.joined = true
                     }
                 }

--- a/ui/app/AppLayouts/Chat/CommunityColumn.qml
+++ b/ui/app/AppLayouts/Chat/CommunityColumn.qml
@@ -71,7 +71,7 @@ Item {
                     icon.source: "../../img/hash.svg"
                     icon.width: 20
                     icon.height: 20
-                    onTriggered: openPopup(createChannelPopup, {communityId: chatsModel.activeCommunity.id})
+                    onTriggered: openPopup(createChannelPopup, {communityId: chatsModel.communities.activeCommunity.id})
                 }
 
                 Action {

--- a/ui/app/AppLayouts/Chat/CommunityComponents/CommunityDetailPopup.qml
+++ b/ui/app/AppLayouts/Chat/CommunityComponents/CommunityDetailPopup.qml
@@ -228,7 +228,7 @@ ModalPopup {
                         text = qsTr("Pending")
                     }
                 } else {
-                    error = chatsModel.communities.joinCommunity(popup.communityId)
+                    error = chatsModel.communities.joinCommunity(popup.communityId, true)
                 }
 
                 if (error) {


### PR DESCRIPTION
Very similar to #1986, we're trying to access the `activeCommunity`
property on the `chatsModel` object, which doesn't have such a property
anymore every since we've moved communities into its own view.
This causes errors when trying to create channels.

This commit fixes this bug by ensuring `activeCommunity` is accessed
from `chatsModel.communities` instead.