### PR TITLE
fix(Community): ensure community members with write access can post t…

### DIFF
--- a/ui/app/AppLayouts/Chat/ChatColumn.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn.qml
@@ -285,7 +285,7 @@ StackLayout {
                     if (chatsModel.activeChannel.chatType !== Constants.chatTypePrivateGroupChat &&
                             (!community.active ||
                             community.access === Constants.communityChatPublicAccess ||
-                            community.admin)) {
+                            community.admin || chatsModel.activeChannel.canPost)) {
                         return true
                     }
                     return chatsModel.activeChannel.isMember


### PR DESCRIPTION
…o channel

When a user is part of a community, write access to any channel of
that community is granted. When the permission allows for it, a community's
channel `canPost` property is `true`, which should be relied on to
render the necessary component for writing into a channel.

This commit makes sure community members with proper access get the
chat input rendered so they can write to channels.

Fixes #1985