### PR TITLE
feat: see stickers details when clicking on a sticker

### DIFF
--- a/src/app/chat/views/message_list.nim
+++ b/src/app/chat/views/message_list.nim
@@ -36,6 +36,7 @@ type
     LocalName = UserRole + 26
     CommunityId = UserRole + 27
     HasMention = UserRole + 28
+    StickerPackId = UserRole + 29
 
 QtObject:
   type
@@ -142,6 +143,7 @@ QtObject:
       of ChatMessageRoles.IsCurrentUser: result = newQVariant(message.isCurrentUser)
       of ChatMessageRoles.ContentType: result = newQVariant(message.contentType.int)
       of ChatMessageRoles.Sticker: result = newQVariant(message.stickerHash.decodeContentHash())
+      of ChatMessageRoles.StickerPackId: result = newQVariant(message.stickerPackId)
       of ChatMessageRoles.FromAuthor: result = newQVariant(message.fromAuthor)
       of ChatMessageRoles.ChatId: result = newQVariant(message.chatId)
       of ChatMessageRoles.SectionIdentifier: result = newQVariant(sectionIdentifier(message))
@@ -199,7 +201,8 @@ QtObject:
       ChatMessageRoles.CommunityId.int: "communityId",
       ChatMessageRoles.Alias.int:"alias",
       ChatMessageRoles.HasMention.int:"hasMention",
-      ChatMessageRoles.LocalName.int:"localName"
+      ChatMessageRoles.LocalName.int:"localName",
+      ChatMessageRoles.StickerPackId.int:"stickerPackId"
     }.toTable
 
   proc getMessageIndex(self: ChatMessageList, messageId: string): int {.slot.} =

--- a/src/status/chat/message.nim
+++ b/src/status/chat/message.nim
@@ -52,6 +52,7 @@ type Message* = object
   rtl*: bool              # ???
   seen*: bool             # ???
   sticker*: string
+  stickerPackId*: int
   text*: string
   timestamp*: string
   whisperTimestamp*: string

--- a/src/status/signals/messages.nim
+++ b/src/status/signals/messages.nim
@@ -266,6 +266,7 @@ proc toMessage*(jsonMsg: JsonNode, pk: string): Message =
       outgoingStatus: $jsonMsg{"outgoingStatus"}.getStr,
       isCurrentUser: $jsonMsg{"outgoingStatus"}.getStr == "sending" or $jsonMsg{"outgoingStatus"}.getStr == "sent",
       stickerHash: "",
+      stickerPackId: -1,
       parsedText: @[],
       linkUrls: "",
       image: $jsonMsg{"image"}.getStr,
@@ -286,6 +287,7 @@ proc toMessage*(jsonMsg: JsonNode, pk: string): Message =
 
   if message.contentType == ContentType.Sticker:
     message.stickerHash = jsonMsg["sticker"]["hash"].getStr
+    message.stickerPackId = jsonMsg["sticker"]["pack"].getInt
 
   if message.contentType == ContentType.Transaction:
     let

--- a/ui/app/AppLayouts/Chat/ChatColumn/ChatMessages.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/ChatMessages.qml
@@ -289,6 +289,7 @@ ScrollView {
             linkUrls: model.linkUrls
             communityId: model.communityId
             hasMention: model.hasMention
+            stickerPackId: model.stickerPackId
             prevMessageIndex: {
                 // This is used in order to have access to the previous message and determine the timestamp
                 // we can't rely on the index because the sequence of messages is not ordered on the nim side

--- a/ui/app/AppLayouts/Chat/ChatColumn/Message.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/Message.qml
@@ -27,6 +27,7 @@ Item {
     property string linkUrls: ""
     property bool placeholderMessage: false
     property string communityId: ""
+    property int stickerPackId: -1
 
     property string authorCurrentMsg: "authorCurrentMsg"
     property string authorPrevMsg: "authorPrevMsg"
@@ -129,6 +130,7 @@ Item {
         if (!isProfileClick) {
             SelectedMessage.set(messageId, fromAuthor);
         }
+
         // Get contact nickname
         let nickname = appMain.getUserNickname(fromAuthor)
         messageContextMenu.linkUrls = root.linkUrls

--- a/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/MessageMouseArea.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/MessageMouseArea.qml
@@ -15,7 +15,8 @@ MouseArea {
             }
             return;
         }
-        if (mouse.button & Qt.LeftButton) {                
+        if (mouse.button & Qt.LeftButton && isSticker && stickersLoaded) {
+            openPopup(statusStickerPackClickPopup, {packId: stickerPackId} )
             return;
         }
     }

--- a/ui/app/AppLayouts/Chat/ChatLayout.qml
+++ b/ui/app/AppLayouts/Chat/ChatLayout.qml
@@ -3,6 +3,7 @@ import QtQuick.Controls 2.13
 import Qt.labs.settings 1.0
 import "../../../imports"
 import "../../../shared"
+import "../../../shared/status"
 import "."
 import "components"
 
@@ -11,6 +12,14 @@ SplitView {
     handle: SplitViewHandle {}
 
     property alias chatColumn: chatColumn
+    property bool stickersLoaded: false
+
+    Connections {
+        target: chatsModel.stickers
+        onStickerPacksLoaded: {
+            stickersLoaded = true;
+        }
+    }
 
     property var onActivated: function () {
         chatsModel.restorePreviousActiveChannel()
@@ -83,6 +92,15 @@ SplitView {
     ChatColumn {
         id: chatColumn
         chatGroupsListViewCount: contactColumnLoader.item.chatGroupsListViewCount
+    }
+
+    Component {
+        id: statusStickerPackClickPopup
+        StatusStickerPackClickPopup{
+            onClosed: {
+                destroy();
+            }
+        }
     }
 
     function openProfilePopup(userNameParam, fromAuthorParam, identiconParam, textParam, nicknameParam, parentPopup){

--- a/ui/shared/status/StatusStickerPackClickPopup.qml
+++ b/ui/shared/status/StatusStickerPackClickPopup.qml
@@ -1,0 +1,94 @@
+import QtQuick 2.13
+import QtQuick.Controls 2.13
+import QtQuick.Layouts 1.3
+import QtGraphicalEffects 1.0
+import "../../imports"
+import "../../shared"
+import "../../shared/status"
+import "../../app/AppLayouts/Chat/ChatColumn/samples"
+
+ModalPopup {
+    id: stickerPackDetailsPopup
+
+    property int packId: -1
+
+    property string thumbnail: ""
+    property string name: ""
+    property string author: ""
+    property string price: ""
+    property bool installed: false;
+    property bool bought: false;
+    property bool pending: false;
+    property var stickers;
+
+    Component.onCompleted: {
+        const idx = chatsModel.stickers.stickerPacks.findIndexById(packId, false);
+        if(idx === -1) close();
+        name = chatsModel.stickers.stickerPacks.rowData(idx, "name")
+        author = chatsModel.stickers.stickerPacks.rowData(idx, "author")
+        thumbnail = chatsModel.stickers.stickerPacks.rowData(idx, "thumbnail")
+        price = chatsModel.stickers.stickerPacks.rowData(idx, "price")
+        stickers = chatsModel.stickers.stickerPacks.getStickers()
+        installed = chatsModel.stickers.stickerPacks.rowData(idx, "installed") === "true"
+        bought = chatsModel.stickers.stickerPacks.rowData(idx, "bought") === "true"
+        pending = chatsModel.stickers.stickerPacks.rowData(idx, "pending") === "true"
+    }
+
+    height: 472
+    header: StatusStickerPackDetails {
+        id: stickerGrid
+        height: 46
+        anchors.top: parent.top
+        anchors.left: parent.left
+        anchors.topMargin: Style.current.padding
+        width: parent.width - (Style.current.padding * 2)
+        packThumb: thumbnail
+        packName: name
+        packAuthor: author
+        packNameFontSize: 17
+        spacing: Style.current.padding / 2
+    }
+    footer: StatusStickerButton {
+        height: 76
+        anchors.right: parent.right
+        style: StatusStickerButton.StyleType.LargeNoIcon
+        packPrice: price
+        isInstalled: installed
+        isBought: bought
+        isPending: pending
+        onInstallClicked: {
+            chatsModel.stickers.install(packId);
+            stickerPackDetailsPopup.close();
+        }
+        onUninstallClicked: {
+            chatsModel.stickers.uninstall(packId);
+            stickerPackDetailsPopup.close();
+        }
+        onCancelClicked: function(){}
+        onUpdateClicked: function(){}
+        onBuyClicked: {
+            openPopup(stickerPackPurchaseModal)
+            root.buyClicked(packId)
+        }
+    }
+    contentWrapper.anchors.topMargin: 0
+    contentWrapper.anchors.bottomMargin: 0
+    StatusStickerList {
+        id: stickerGridInPopup
+        model: stickers
+        height: 350
+        Component {
+        id: stickerPackPurchaseModal
+        StatusStickerPackPurchaseModal {
+            onClosed: {
+                destroy()
+            }
+            stickerPackId: packId
+            packPrice: price
+            width: stickerPackDetailsPopup.width
+            height: stickerPackDetailsPopup.height
+            showBackBtn: stickerPackDetailsPopup.opened
+        }
+    }
+    }
+}

--- a/ui/shared/status/StatusStickerPackClickPopup.qml
+++ b/ui/shared/status/StatusStickerPackClickPopup.qml
@@ -37,7 +37,7 @@ ModalPopup {
     height: 472
     header: StatusStickerPackDetails {
         id: stickerGrid
-        height: 46
+        height: 76
         anchors.top: parent.top
         anchors.left: parent.left
         anchors.topMargin: Style.current.padding


### PR DESCRIPTION
Displays a popup containing all the packs that belong to a sticker pack
This option is only available after all the stickers packs have been loaded. 

 
![image](https://user-images.githubusercontent.com/1106587/110371507-74663c80-8023-11eb-95e9-945bdc68767d.png)


Video:
https://user-images.githubusercontent.com/1106587/110371347-3b2dcc80-8023-11eb-9d50-209dfcf25ee0.mp4

