### PR TITLE
Unfurl community links in chat

### DIFF
--- a/src/app/chat/views/communities.nim
+++ b/src/app/chat/views/communities.nim
@@ -123,6 +123,20 @@ QtObject:
   QtProperty[QVariant] joinedCommunities:
     read = getJoinedComunities
     notify = joinedCommunitiesChanged
+  
+  proc getCommunityNameById*(self: CommunitiesView, communityId: string): string {.slot.} =
+    let communities = self.getCommunitiesIfNotFetched()
+    for community in communities.communities:
+      if community.id == communityId:
+        return community.name
+    return ""
+  
+  proc isUserMemberOfCommunity*(self: CommunitiesView, communityId: string): bool {.slot.} =
+    let communities = self.getCommunitiesIfNotFetched()
+    for community in communities.communities:
+      if community.id == communityId:
+        return community.joined and community.isMember
+    return false
 
   proc activeCommunityChanged*(self: CommunitiesView) {.signal.}
 

--- a/src/status/signals/messages.nim
+++ b/src/status/signals/messages.nim
@@ -265,7 +265,7 @@ proc toMessage*(jsonMsg: JsonNode, pk: string): Message =
       timestamp: $jsonMsg{"timestamp"}.getInt,
       whisperTimestamp: $jsonMsg{"whisperTimestamp"}.getInt,
       outgoingStatus: $jsonMsg{"outgoingStatus"}.getStr,
-      isCurrentUser: $jsonMsg{"outgoingStatus"}.getStr == "sending" or $jsonMsg{"outgoingStatus"}.getStr == "sent",
+      isCurrentUser: pk == jsonMsg{"from"}.getStr,
       stickerHash: "",
       stickerPackId: -1,
       parsedText: @[],

--- a/ui/app/AppLayouts/Chat/ChatColumn/Message.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/Message.qml
@@ -297,7 +297,7 @@ Item {
     Component {
         id: invitationBubble
         InvitationBubble {
-            communityId: communityId
+            communityId: root.communityId
             anchors.right: !appSettings.useCompactMode && isCurrentUser ? parent.right : undefined
             anchors.rightMargin: Style.current.padding
         }

--- a/ui/app/AppLayouts/Chat/ChatColumn/Message.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/Message.qml
@@ -296,7 +296,11 @@ Item {
 
     Component {
         id: invitationBubble
-        InvitationBubble {}
+        InvitationBubble {
+            communityId: communityId
+            anchors.right: !appSettings.useCompactMode && isCurrentUser ? parent.right : undefined
+            anchors.rightMargin: Style.current.padding
+        }
     }
 }
 

--- a/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/InvitationBubble.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/InvitationBubble.qml
@@ -6,25 +6,29 @@ import "./TransactionComponents"
 import "../../../Wallet/data"
 
 Item {
+    property string communityId
     property var invitedCommunity
     property int innerMargin: 12
     property bool joined: false
+    property bool isLink: false
 
     id: root
     anchors.left: parent.left
     height: childrenRect.height
+    width: rectangleBubbleLoader.width + chatImage.width
 
     Component.onCompleted: {
-        chatsModel.communities.setObservedCommunity(communityId)
+        chatsModel.communities.setObservedCommunity(root.communityId)
 
         root.invitedCommunity = chatsModel.communities.observedCommunity
     }
 
     UserImage {
         id: chatImage
-        visible: authorCurrentMsg != authorPrevMsg && !isCurrentUser
+        visible: (!isLink && authorCurrentMsg !== authorPrevMsg && !isCurrentUser) ||
+                 (appSettings.useCompactMode && isCurrentUser && authorCurrentMsg !== authorPrevMsg)
         anchors.left: parent.left
-        anchors.leftMargin: Style.current.padding
+        anchors.leftMargin: visible ? Style.current.padding : 0
         anchors.top: parent.top
     }
 
@@ -33,10 +37,9 @@ Item {
         active: !!invitedCommunity
         width: item.width
         height: item.height
-        anchors.right: isCurrentUser ? parent.right : undefined
-        anchors.rightMargin: Style.current.padding
-        anchors.left: !isCurrentUser ? chatImage.right : undefined
-        anchors.leftMargin: Style.current.smallPadding
+        anchors.left: !isLink && (!isCurrentUser || (isCurrentUser === appSettings.useCompactMode)) ? chatImage.right : undefined
+        anchors.leftMargin: isLink ? 0 : Style.current.smallPadding
+        anchors.right: !appSettings.useCompactMode && isCurrentUser ? parent.right : undefined
 
         sourceComponent: Component {
             Rectangle {

--- a/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/LinksMessage.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/LinksMessage.qml
@@ -36,6 +36,7 @@ Column {
             property bool fetched: false
             property var linkData
             property int linkWidth: linksRepeater.width
+
             active: true
             
             Connections {
@@ -116,6 +117,10 @@ Column {
                     const data = Utils.getLinkDataForStatusLinks(link)
                     if (data) {
                         linkData = data
+                        if (data.communityId) {
+                            return invitationBubble
+                        }
+
                         return unfurledLinkComponent
                     }
 
@@ -154,6 +159,15 @@ Column {
                     clickMessage(false, false, true, linkImage.imageAlias)
                 }
             }
+        }
+    }
+
+    Component {
+        id: invitationBubble
+        InvitationBubble {
+            communityId: linkData.communityId
+            isLink: true
+            anchors.left: parent.left
         }
     }
 
@@ -216,8 +230,6 @@ Column {
             }
         }
     }
-        
-    
 
     Component {
         id: enableLinkComponent

--- a/ui/app/AppLayouts/Chat/CommunityComponents/CommunityProfilePopupOverview.qml
+++ b/ui/app/AppLayouts/Chat/CommunityComponents/CommunityProfilePopupOverview.qml
@@ -43,8 +43,8 @@ Item {
         anchors.topMargin: Style.current.bigPadding
         //% "Share community"
         label: qsTrId("share-community")
-        text: "https://join.status.im/u/TODO"
-        textToCopy: text
+        text: `${Constants.communityLinkPrefix}${communityId.substring(0, 4)}...${communityId.substring(communityId.length -2)}`
+        textToCopy: Constants.communityLinkPrefix + communityId
     }
 
     Separator {

--- a/ui/app/AppLayouts/Chat/CommunityComponents/InviteFriendsToCommunityPopup.qml
+++ b/ui/app/AppLayouts/Chat/CommunityComponents/InviteFriendsToCommunityPopup.qml
@@ -11,6 +11,7 @@ import "../components"
 ModalPopup {
     id: popup
 
+    property string communityId: chatsModel.communities.activeCommunity.id
     property var pubKeys: []
     property var goBack
 
@@ -36,8 +37,8 @@ ModalPopup {
             anchors.top: parent.top
             //% "Share community"
             label: qsTrId("share-community")
-            text: "https://join.status.im/u/TODO"
-            textToCopy: text
+            text: `${Constants.communityLinkPrefix}${communityId.substring(0, 4)}...${communityId.substring(communityId.length -2)}`
+            textToCopy: Constants.communityLinkPrefix + communityId
         }
 
         Separator {

--- a/ui/app/AppLayouts/Chat/CommunityComponents/MembershipRequestsButton.qml
+++ b/ui/app/AppLayouts/Chat/CommunityComponents/MembershipRequestsButton.qml
@@ -50,7 +50,7 @@ Rectangle {
         anchors.rightMargin: Style.current.padding
         anchors.verticalCenter: parent.verticalCenter
         width: 13
-
+        height: 7
 
         ColorOverlay {
             anchors.fill: parent

--- a/ui/app/AppLayouts/Chat/components/ProfilePopup.qml
+++ b/ui/app/AppLayouts/Chat/components/ProfilePopup.qml
@@ -187,11 +187,10 @@ ModalPopup {
             id: valueShareURL
             //% "Share Profile URL"
             label: qsTrId("share-profile-url")
-            text: "https://join.status.im/u/" + fromAuthor.substr(
-                      0, 4) + "..." + fromAuthor.substr(fromAuthor.length - 5)
+            text: Constants.userLinkPrefix + fromAuthor.substr(0, 4) + "..." + fromAuthor.substr(fromAuthor.length - 5)
             anchors.top: separator.top
             anchors.topMargin: popup.innerMargin
-            textToCopy: "https://join.status.im/u/" + fromAuthor
+            textToCopy: Constants.userLinkPrefix + fromAuthor
         }
 
         Separator {

--- a/ui/app/AppLayouts/Profile/Sections/MyProfileContainer.qml
+++ b/ui/app/AppLayouts/Profile/Sections/MyProfileContainer.qml
@@ -146,8 +146,8 @@ Item {
         TextWithLabel {
             //% "Share Profile URL"
             label: qsTrId("share-profile-url")
-            text: `https://join.status.im/u/${pubkey.substring(0, 5)}...${pubkey.substring(pubkey.length - 5)}`
-            textToCopy: `https://join.status.im/u/${pubkey}`
+            text: `${Constants.userLinkPrefix}${pubkey.substring(0, 5)}...${pubkey.substring(pubkey.length - 5)}`
+            textToCopy: Constants.userLinkPrefix + pubkey
         }
     }
 }

--- a/ui/app/AppMain.qml
+++ b/ui/app/AppMain.qml
@@ -153,17 +153,30 @@ RowLayout {
             try {
                 const whiteListedSites = JSON.parse(whitelist)
                 let settingsUpdated = false
+
+                // Add Status links to whitelist
+                whiteListedSites.push({title: "Status", address: Constants.deepLinkPrefix, imageSite: false})
+                whiteListedSites.push({title: "Status", address: Constants.joinStatusLink, imageSite: false})
+
                 const settings = appSettings.whitelistedUnfurlingSites
+
+                // Set Status links as true. We intercept thoseURLs so it is privacy-safe
+                if (!settings[Constants.deepLinkPrefix] || !settings[Constants.joinStatusLink]) {
+                    settings[Constants.deepLinkPrefix] = true
+                    settings[Constants.joinStatusLink] = true
+                    settingsUpdated = true
+                }
+
                 const whitelistedHostnames = []
 
                 // Add whitelisted sites in to app settings that are not already there
                 whiteListedSites.forEach(site => {
-                    if (!settings.hasOwnProperty(site.address))  {
-                        settings[site.address] = false
-                        settingsUpdated = true
-                    }
-                    whitelistedHostnames.push(site.address)
-                })
+                                             if (!settings.hasOwnProperty(site.address))  {
+                                                 settings[site.address] = false
+                                                 settingsUpdated = true
+                                             }
+                                             whitelistedHostnames.push(site.address)
+                                         })
                 // Remove any whitelisted sites from app settings that don't exist in the
                 // whitelist from status-go
                 Object.keys(settings).forEach(settingsHostname => {
@@ -409,7 +422,7 @@ RowLayout {
                 browserLayoutContainer.active = true;
             }
 
-            timelineLayoutContainer.active = this.children[currentIndex] == timelineLayoutContainer
+            timelineLayoutContainer.active = this.children[currentIndex] === timelineLayoutContainer
 
             if(this.children[currentIndex] === walletLayoutContainer){
                 walletLayoutContainer.showSigningPhrasePopup();

--- a/ui/imports/Constants.qml
+++ b/ui/imports/Constants.qml
@@ -117,6 +117,8 @@ QtObject {
 
     readonly property string deepLinkPrefix: 'statusim://'
     readonly property string joinStatusLink: 'join.status.im'
+    readonly property string communityLinkPrefix: 'https://join.status.im/cc/'
+    readonly property string userLinkPrefix: 'https://join.status.im/u/'
 
     readonly property int maxUploadFiles: 5
     readonly property double maxUploadFilesizeMB: 0.5

--- a/ui/imports/Utils.qml
+++ b/ui/imports/Utils.qml
@@ -329,6 +329,32 @@ QtObject {
             return result
         }
 
+        // Community
+        // TODO this will probably change
+        index = link.lastIndexOf("/cc/")
+        if (index > -1) {
+            const communityId = link.substring(index + 4)
+
+            const communityName = chatsModel.communities.getCommunityNameById(communityId)
+
+            if (!communityName) {
+                // Unknown community
+                // TODO use a function to fetch that community?
+                return result
+            }
+
+            result.title = qsTr("Join the %1 community").arg(communityName)
+            result.callback = function () {
+                const isUserMemberOfCommunity = chatsModel.communities.isUserMemberOfCommunity(communityId)
+                if (isUserMemberOfCommunity) {
+                    chatsModel.communities.setActiveCommunity(communityId)
+                    return
+                }
+                chatsModel.communities.joinCommunity(communityId, true)
+            }
+            return result
+        }
+
         // Public chat
         // This needs to be the last check because it is as VERY loose check
         index = link.lastIndexOf("/")

--- a/ui/imports/Utils.qml
+++ b/ui/imports/Utils.qml
@@ -308,32 +308,57 @@ QtObject {
         return (/( |\t|\n|\r)/.test(c))
     }
 
+    function getLinkTitleAndCb(link) {
+        const result = {
+            title: "Status",
+            callback: null
+        }
+
+        // Link to send a direct message
+        let index = link.indexOf("/u/")
+        if (index === -1) {
+            // Try /p/ as well
+            index = link.indexOf("/p/")
+        }
+        if (index > -1) {
+            const pk = link.substring(index + 3)
+            result.title = qsTr("Start a 1 on 1 chat with %1").arg(utilsModel.generateAlias(pk))
+            result.callback = function () {
+                chatsModel.joinChat(pk, Constants.chatTypeOneToOne);
+            }
+            return result
+        }
+
+        // Public chat
+        // This needs to be the last check because it is as VERY loose check
+        index = link.lastIndexOf("/")
+        if (index > -1) {
+            const chatId = link.substring(index + 1)
+            result.title = qsTr("Join the %1 public channel").arg(chatId)
+            result.callback = function () {
+                chatsModel.joinChat(chatId, Constants.chatTypePublic);
+            }
+            return result
+        }
+
+        return result
+    }
+
     function getLinkDataForStatusLinks(link) {
         if (!link.includes(Constants.deepLinkPrefix) && !link.includes(Constants.joinStatusLink)) {
             return
         }
 
-        let title = "Status"
-        let callback = function () {}
-
-        // Link to send a direct message
-        let index = link.indexOf("/u/")
-        if (index > -1) {
-            const pk = link.substring(index + 3)
-            title = qsTr("Start a 1 on 1 chat with %1").arg(utilsModel.generateAlias(pk))
-            callback = function () {
-                chatsModel.joinChat(pk, Constants.chatTypeOneToOne);
-            }
-        }
+        const result = getLinkTitleAndCb(link)
 
         return {
             site: qsTr("Status app link"),
-            title: title,
+            title: result.title,
             thumbnailUrl: "../../../../img/status.png",
             contentType: "",
             height: 0,
             width: 0,
-            callback: callback
+            callback: result.callback
         }
     }
 

--- a/ui/imports/Utils.qml
+++ b/ui/imports/Utils.qml
@@ -344,6 +344,7 @@ QtObject {
             }
 
             result.title = qsTr("Join the %1 community").arg(communityName)
+            result.communityId = communityId
             result.callback = function () {
                 const isUserMemberOfCommunity = chatsModel.communities.isUserMemberOfCommunity(communityId)
                 if (isUserMemberOfCommunity) {
@@ -380,6 +381,7 @@ QtObject {
         return {
             site: qsTr("Status app link"),
             title: result.title,
+            communityId: result.communityId,
             thumbnailUrl: "../../../../img/status.png",
             contentType: "",
             height: 0,


### PR DESCRIPTION
Fixes #1878

Unfurls community links in chat. If the community is not known, shows a generic unfurling.

Also adds unfurling for public chats

Community link:
![image](https://user-images.githubusercontent.com/11926403/110377547-8693ab00-8022-11eb-95db-e6903a76a3fe.png)

Public chat link:
![image](https://user-images.githubusercontent.com/11926403/110377603-9c08d500-8022-11eb-9d59-11f2b54b221c.png)
