### PR TITLE
fix(Communities): don't crash on rejoin attempt

### DIFF
--- a/ui/app/AppLayouts/Chat/CommunityComponents/CommunityDetailPopup.qml
+++ b/ui/app/AppLayouts/Chat/CommunityComponents/CommunityDetailPopup.qml
@@ -16,6 +16,7 @@ ModalPopup {
     property bool ensOnly: community.ensOnly
     property bool canJoin: community.canJoin
     property bool canRequestAccess: community.canRequestAccess
+    property bool isMember: community.isMember
 
     id: popup
 
@@ -220,7 +221,7 @@ ModalPopup {
             anchors.right: parent.right
             onClicked: {
                 let error
-                if (access === Constants.communityChatOnRequestAccess) {
+                if (access === Constants.communityChatOnRequestAccess && !popup.isMember) {
                     error = chatsModel.communities.requestToJoinCommunity(popup.communityId,
                                                               profileModel.profile.ensVerified ? profileModel.profile.username : "")
                     if (!error) {

--- a/ui/app/AppLayouts/Chat/CommunityComponents/CommunityHeaderButton.qml
+++ b/ui/app/AppLayouts/Chat/CommunityComponents/CommunityHeaderButton.qml
@@ -56,7 +56,14 @@ Button {
         visible: enabled
         cursorShape: Qt.PointingHandCursor
         anchors.fill: parent
-        onPressed: communityProfilePopup.open();
+        onPressed: {
+          communityProfilePopup.communityId = chatsModel.communities.activeCommunity.id;
+          communityProfilePopup.name = chatsModel.communities.activeCommunity.name;
+          communityProfilePopup.description = chatsModel.communities.activeCommunity.description;
+          communityProfilePopup.access = chatsModel.communities.activeCommunity.access;
+          communityProfilePopup.nbMembers = chatsModel.communities.activeCommunity.nbMembers;
+          communityProfilePopup.open();
+        }
         hoverEnabled: true
         onExited: {
             btnBackground.color = Style.current.transparent

--- a/ui/app/AppLayouts/Chat/CommunityComponents/CommunityWelcomeBanner.qml
+++ b/ui/app/AppLayouts/Chat/CommunityComponents/CommunityWelcomeBanner.qml
@@ -86,6 +86,13 @@ Rectangle {
         anchors.horizontalCenter: parent.horizontalCenter
         anchors.bottom: parent.bottom
         anchors.bottomMargin: Style.current.padding
-        onClicked: communityProfilePopup.open()
+        onClicked: {
+          communityProfilePopup.communityId = chatsModel.communities.activeCommunity.id;
+          communityProfilePopup.name = chatsModel.communities.activeCommunity.name;
+          communityProfilePopup.description = chatsModel.communities.activeCommunity.description;
+          communityProfilePopup.access = chatsModel.communities.activeCommunity.access;
+          communityProfilePopup.nbMembers = chatsModel.communities.activeCommunity.nbMembers;
+          communityProfilePopup.open()
+        }
     }
 }


### PR DESCRIPTION
Prior to this commit there was a scenario where the application would
crash due a memory bug when attempting to (re)join a community.

The scenario is as follows:

1. User creates or has been invited to community with `ON_REQUEST` permissions
2. User leaves community
3. User decides to rejoin, so she selects the community she's been part
of and hits the "Join" button

At this point Status Desktop would send a new `RequestToJoin` request, as the
community has a corresponding permissions setting.

This would then result in an `already a member` error in status-go, because
status-go checks whether the requestee is already part of the members list of
the community. The error isn't handled inside Status Desktop which causes
a crash because we're trying to access data in memory that doesn't exist.

Why is this happening?

While this might be unexpected, when leaving a community (as done on step 2 of
the mentioned scenario), users don't actually lose membership but simply
"unsubscribe" from all channels in the community in question and their `joined`
flag is set to `false`.

From that point on, re-joininng a community is done by sending a `JoinCommunity`
request (instead of `RequestToJoin`), which will then set the `joined` flag to
`true` and doesn't actually check the membership in the database.

This commit ensures we're calling the right API by checking whether not only
whether the community is needs `ON _REQUEST` permissions, but also whether the
user isn't already a member of it.

Fixes #2017 