### PR TITLE
fix(Communities): ensure profile popup is hydrated with correct data

### DIFF
--- a/ui/app/AppLayouts/Chat/CommunityComponents/CommunityHeaderButton.qml
+++ b/ui/app/AppLayouts/Chat/CommunityComponents/CommunityHeaderButton.qml
@@ -56,7 +56,14 @@ Button {
         visible: enabled
         cursorShape: Qt.PointingHandCursor
         anchors.fill: parent
-        onPressed: communityProfilePopup.open();
+        onPressed: {
+          communityProfilePopup.communityId = chatsModel.communities.activeCommunity.id;
+          communityProfilePopup.name = chatsModel.communities.activeCommunity.name;
+          communityProfilePopup.description = chatsModel.communities.activeCommunity.description;
+          communityProfilePopup.access = chatsModel.communities.activeCommunity.access;
+          communityProfilePopup.nbMembers = chatsModel.communities.activeCommunity.nbMembers;
+          communityProfilePopup.open();
+        }
         hoverEnabled: true
         onExited: {
             btnBackground.color = Style.current.transparent

--- a/ui/app/AppLayouts/Chat/CommunityComponents/CommunityWelcomeBanner.qml
+++ b/ui/app/AppLayouts/Chat/CommunityComponents/CommunityWelcomeBanner.qml
@@ -86,6 +86,13 @@ Rectangle {
         anchors.horizontalCenter: parent.horizontalCenter
         anchors.bottom: parent.bottom
         anchors.bottomMargin: Style.current.padding
-        onClicked: communityProfilePopup.open()
+        onClicked: {
+          communityProfilePopup.communityId = chatsModel.communities.activeCommunity.id;
+          communityProfilePopup.name = chatsModel.communities.activeCommunity.name;
+          communityProfilePopup.description = chatsModel.communities.activeCommunity.description;
+          communityProfilePopup.access = chatsModel.communities.activeCommunity.access;
+          communityProfilePopup.nbMembers = chatsModel.communities.activeCommunity.nbMembers;
+          communityProfilePopup.open()
+        }
     }
 }


### PR DESCRIPTION
The `communityProfilePopup` relies on the currently `activeCommunity` to
get its data. Unfortunately, once read, even when `chatsModel.setActiveCommunity()`
is called which triggers `activeCommunityChanged`, the data in the popup
won't be updated. The next time one would open a community profile page,
it'd have the data that was previously received from the model.

This commit ensures that the popup is hydrated with the most recent data
by explicitly updating its properties right before it's opened.