### PR TITLE
fix(Communities): fallback to letter identicon if no image available

### DIFF
--- a/src/app/chat/views/communities.nim
+++ b/src/app/chat/views/communities.nim
@@ -278,11 +278,12 @@ QtObject:
       error "Error exporting the community", msg = e.msg
       result = fmt"Error exporting the community: {e.msg}"
 
-  proc importCommunity*(self: CommunitiesView, communityKey: string) {.slot.} =
+  proc importCommunity*(self: CommunitiesView, communityKey: string): string {.slot.} =
     try:
-      self.status.chat.importCommunity(communityKey)
+      discard self.status.chat.importCommunity(communityKey)
     except Exception as e:
       error "Error importing the community", msg = e.msg
+      result = fmt"Error importing the community: {e.msg}"
 
   proc removeUserFromCommunity*(self: CommunitiesView, pubKey: string) {.slot.} =
     try:

--- a/src/app/chat/views/community_item.nim
+++ b/src/app/chat/views/community_item.nim
@@ -125,6 +125,11 @@ QtObject:
     read = nbMembers
     notify = nbMembersChanged
 
+  proc communityColor*(self: CommunityItemView): string {.slot.} = result = ?.self.communityItem.communityColor
+
+  QtProperty[string] communityColor:
+    read = communityColor
+
   proc chatsChanged*(self: CommunityItemView) {.signal.}
 
   proc getChats*(self: CommunityItemView): QVariant {.slot.} =

--- a/src/app/chat/views/community_list.nim
+++ b/src/app/chat/views/community_list.nim
@@ -22,6 +22,7 @@ type
     CanJoin = UserRole + 14
     IsMember = UserRole + 15
     UnviewedMessagesCount = UserRole + 16
+    CommunityColor = UserRole + 17
 
 QtObject:
   type
@@ -77,6 +78,7 @@ QtObject:
           result = newQVariant(communityItem.communityImage.large)
         else:
           result = newQVariant("")
+      of CommunityRoles.CommunityColor: result = newQVariant(communityItem.communityColor)
 
   method roleNames(self: CommunityList): Table[int, string] =
     {
@@ -95,7 +97,8 @@ QtObject:
       CommunityRoles.NumMembers.int: "nbMembers",
       CommunityRoles.UnviewedMessagesCount.int: "unviewedMessagesCount",
       CommunityRoles.ThumbnailImage.int:"thumbnailImage",
-      CommunityRoles.LargeImage.int:"largeImage"
+      CommunityRoles.LargeImage.int:"largeImage",
+      CommunityRoles.CommunityColor.int:"communityColor"
     }.toTable
 
   proc setNewData*(self: CommunityList, communityList: seq[Community]) =

--- a/src/status/chat.nim
+++ b/src/status/chat.nim
@@ -440,8 +440,8 @@ proc removeUserFromCommunity*(self: ChatModel, communityId: string, pubKey: stri
 proc exportCommunity*(self: ChatModel, communityId: string): string =
   result = status_chat.exportCommunity(communityId)
 
-proc importCommunity*(self: ChatModel, communityKey: string) =
-  status_chat.importCommunity(communityKey)
+proc importCommunity*(self: ChatModel, communityKey: string): string =
+  result = status_chat.importCommunity(communityKey)
 
 proc requestToJoinCommunity*(self: ChatModel, communityKey: string, ensName: string): seq[CommunityMembershipRequest] =
   status_chat.requestToJoinCommunity(communityKey, ensName)

--- a/src/status/chat/chat.nim
+++ b/src/status/chat/chat.nim
@@ -111,6 +111,7 @@ type Community* = object
   isMember*: bool
   communityImage*: IdentityImage
   membershipRequests*: seq[CommunityMembershipRequest]
+  communityColor*: string
 
 proc `$`*(self: Chat): string =
   result = fmt"Chat(id:{self.id}, name:{self.name}, active:{self.isActive}, type:{self.chatType})"

--- a/src/status/libstatus/chat.nim
+++ b/src/status/libstatus/chat.nim
@@ -315,8 +315,8 @@ proc inviteUsersToCommunity*(communityId: string, pubKeys: seq[string]) =
 proc exportCommunity*(communityId: string):string  =
   result = callPrivateRPC("exportCommunity".prefix, %*[communityId]).parseJson()["result"].getStr
 
-proc importCommunity*(communityKey: string) =
-  discard callPrivateRPC("importCommunity".prefix, %*[communityKey])
+proc importCommunity*(communityKey: string): string =
+  return callPrivateRPC("importCommunity".prefix, %*[communityKey])
 
 proc removeUserFromCommunity*(communityId: string, pubKey: string) =
   discard callPrivateRPC("removeUserFromCommunity".prefix, %*[communityId, pubKey])

--- a/src/status/signals/messages.nim
+++ b/src/status/signals/messages.nim
@@ -183,6 +183,7 @@ proc toCommunity*(jsonCommunity: JsonNode): Community =
     isMember: jsonCommunity{"isMember"}.getBool,
     chats: newSeq[Chat](),
     members: newSeq[string](),
+    communityColor: jsonCommunity{"color"}.getStr,
     communityImage: IdentityImage()
   )
 

--- a/ui/app/AppLayouts/Chat/CommunityComponents/AccessExistingCommunityPopup.qml
+++ b/ui/app/AppLayouts/Chat/CommunityComponents/AccessExistingCommunityPopup.qml
@@ -11,6 +11,18 @@ ModalPopup {
     width: 400
     height: 400
 
+    property string keyValidationError: ""
+    
+    function validate() {
+        keyValidationError = ""
+
+        if (keyInput.text.trim() === "") {
+            keyValidationError = qsTr("You need to enter a key")
+        }
+
+        return !keyValidationError
+    }
+
     title: qsTr("Access existing community")
 
     onClosed: {
@@ -21,7 +33,7 @@ ModalPopup {
         anchors.fill: parent
 
         StyledTextArea {
-            id: pKeyTextArea
+            id: keyInput
             label: qsTr("Community private key")
             placeholderText: "0x0..."
             customHeight: 110
@@ -30,7 +42,7 @@ ModalPopup {
         StyledText {
             id: infoText1
             text: qsTr("Entering a community key will grant you the ownership of that community. Please be responsible with it and don’t share the key with people you don’t trust.")
-            anchors.top: pKeyTextArea.bottom
+            anchors.top: keyInput.bottom
             wrapMode: Text.WordWrap
             anchors.topMargin: Style.current.bigPadding
             width: parent.width
@@ -48,7 +60,7 @@ ModalPopup {
                 return
             }
 
-            let communityKey = keyInput.text
+            let communityKey = keyInput.text.trim()
             if (!communityKey.startsWith("0x")) {
                 communityKey = "0x" + communityKey
             }

--- a/ui/app/AppLayouts/Chat/CommunityComponents/CommunityList.qml
+++ b/ui/app/AppLayouts/Chat/CommunityComponents/CommunityList.qml
@@ -20,5 +20,7 @@ ListView {
         name: model.name
         image: model.thumbnailImage
         unviewedMessagesCount: model.unviewedMessagesCount
+        iconColor: model.communityColor
+        useLetterIdenticon: model.thumbnailImage === ""
     }
 }

--- a/ui/shared/status/StatusIconTabButton.qml
+++ b/ui/shared/status/StatusIconTabButton.qml
@@ -19,6 +19,8 @@ TabButton {
     property int sectionIndex: Utils.getAppSectionIndex(section)
     property bool doNotHandleClick: false
     property bool borderOnChecked: false
+    property bool useLetterIdenticon: false
+    property string name: ""
 
     onClicked: {
         if (doNotHandleClick) {
@@ -55,7 +57,8 @@ TabButton {
             active: true
             anchors.horizontalCenter: parent.horizontalCenter
             anchors.verticalCenter: parent.verticalCenter
-            sourceComponent: !!iconSource ? imageIcon : defaultIcon
+            sourceComponent: useLetterIdenticon ? letterIdenticon :
+              !!iconSource ? imageIcon : defaultIcon
         }
 
         Component {
@@ -82,6 +85,17 @@ TabButton {
             RoundedImage {
                 source: iconSource
                 noMouseArea: true
+            }
+        }
+
+        Component {
+            id: letterIdenticon
+            StatusLetterIdenticon {
+                width: 26
+                height: 26
+                letterSize: 15
+                chatName: control.name
+                color: control.iconColor
             }
         }
     }

--- a/ui/shared/status/StatusLetterIdenticon.qml
+++ b/ui/shared/status/StatusLetterIdenticon.qml
@@ -7,6 +7,7 @@ Rectangle {
 
     property string chatId
     property string chatName
+    property int letterSize: root.isCompact ? 15 : 21
 
     width: 40
     height: 40
@@ -24,9 +25,11 @@ Rectangle {
         text: (root.chatName.charAt(0) == "#" ? root.chatName.charAt(1) : root.chatName.charAt(0)).toUpperCase()
         opacity: 0.7
         font.weight: Font.Bold
-        font.pixelSize: root.isCompact ? 15 : 21
+        font.pixelSize: root.letterSize
         color: "white"
         anchors.horizontalCenter: parent.horizontalCenter
         anchors.verticalCenter: parent.verticalCenter
+        anchors.leftMargin: -1
+        anchors.bottomMargin: -2
     }
 }


### PR DESCRIPTION
Prior to this commit, communities without an image would render invisible
in the navigation bar of the application. To avoid this, we're now falling
back to our StatusLetterIdenticon component, which renders the first letter
of the community name with the color of the community.