### PR TITLE
fix(Communities): ensure importCommunity API returns response

### DIFF
--- a/src/app/chat/views/communities.nim
+++ b/src/app/chat/views/communities.nim
@@ -278,11 +278,12 @@ QtObject:
       error "Error exporting the community", msg = e.msg
       result = fmt"Error exporting the community: {e.msg}"
 
-  proc importCommunity*(self: CommunitiesView, communityKey: string) {.slot.} =
+  proc importCommunity*(self: CommunitiesView, communityKey: string): string {.slot.} =
     try:
-      self.status.chat.importCommunity(communityKey)
+      discard self.status.chat.importCommunity(communityKey)
     except Exception as e:
       error "Error importing the community", msg = e.msg
+      result = fmt"Error importing the community: {e.msg}"
 
   proc removeUserFromCommunity*(self: CommunitiesView, pubKey: string) {.slot.} =
     try:

--- a/src/status/chat.nim
+++ b/src/status/chat.nim
@@ -440,8 +440,8 @@ proc removeUserFromCommunity*(self: ChatModel, communityId: string, pubKey: stri
 proc exportCommunity*(self: ChatModel, communityId: string): string =
   result = status_chat.exportCommunity(communityId)
 
-proc importCommunity*(self: ChatModel, communityKey: string) =
-  status_chat.importCommunity(communityKey)
+proc importCommunity*(self: ChatModel, communityKey: string): string =
+  result = status_chat.importCommunity(communityKey)
 
 proc requestToJoinCommunity*(self: ChatModel, communityKey: string, ensName: string): seq[CommunityMembershipRequest] =
   status_chat.requestToJoinCommunity(communityKey, ensName)

--- a/src/status/libstatus/chat.nim
+++ b/src/status/libstatus/chat.nim
@@ -315,8 +315,8 @@ proc inviteUsersToCommunity*(communityId: string, pubKeys: seq[string]) =
 proc exportCommunity*(communityId: string):string  =
   result = callPrivateRPC("exportCommunity".prefix, %*[communityId]).parseJson()["result"].getStr
 
-proc importCommunity*(communityKey: string) =
-  discard callPrivateRPC("importCommunity".prefix, %*[communityKey])
+proc importCommunity*(communityKey: string): string =
+  return callPrivateRPC("importCommunity".prefix, %*[communityKey])
 
 proc removeUserFromCommunity*(communityId: string, pubKey: string) =
   discard callPrivateRPC("removeUserFromCommunity".prefix, %*[communityId, pubKey])

--- a/ui/app/AppLayouts/Chat/CommunityComponents/AccessExistingCommunityPopup.qml
+++ b/ui/app/AppLayouts/Chat/CommunityComponents/AccessExistingCommunityPopup.qml
@@ -11,6 +11,18 @@ ModalPopup {
     width: 400
     height: 400
 
+    property string keyValidationError: ""
+    
+    function validate() {
+        keyValidationError = ""
+
+        if (keyInput.text.trim() === "") {
+            keyValidationError = qsTr("You need to enter a key")
+        }
+
+        return !keyValidationError
+    }
+
     title: qsTr("Access existing community")
 
     onClosed: {
@@ -21,7 +33,7 @@ ModalPopup {
         anchors.fill: parent
 
         StyledTextArea {
-            id: pKeyTextArea
+            id: keyInput
             label: qsTr("Community private key")
             placeholderText: "0x0..."
             customHeight: 110
@@ -30,7 +42,7 @@ ModalPopup {
         StyledText {
             id: infoText1
             text: qsTr("Entering a community key will grant you the ownership of that community. Please be responsible with it and don’t share the key with people you don’t trust.")
-            anchors.top: pKeyTextArea.bottom
+            anchors.top: keyInput.bottom
             wrapMode: Text.WordWrap
             anchors.topMargin: Style.current.bigPadding
             width: parent.width
@@ -48,7 +60,7 @@ ModalPopup {
                 return
             }
 
-            let communityKey = keyInput.text
+            let communityKey = keyInput.text.trim()
             if (!communityKey.startsWith("0x")) {
                 communityKey = "0x" + communityKey
             }


### PR DESCRIPTION
Prior to this commit we were ignoring the returned response of the
API call, making it impossible to work with it in case it's needed.