### PR TITLE
fix(Communities): properly pass `admin` state to profile popup

### DIFF
--- a/ui/app/AppLayouts/Chat/CommunityComponents/CommunityHeaderButton.qml
+++ b/ui/app/AppLayouts/Chat/CommunityComponents/CommunityHeaderButton.qml
@@ -62,6 +62,7 @@ Button {
           communityProfilePopup.description = chatsModel.communities.activeCommunity.description;
           communityProfilePopup.access = chatsModel.communities.activeCommunity.access;
           communityProfilePopup.nbMembers = chatsModel.communities.activeCommunity.nbMembers;
+          communityProfilePopup.isAdmin = chatsModel.communities.activeCommunity.admin
           communityProfilePopup.open();
         }
         hoverEnabled: true

--- a/ui/app/AppLayouts/Chat/CommunityComponents/CommunityProfilePopup.qml
+++ b/ui/app/AppLayouts/Chat/CommunityComponents/CommunityProfilePopup.qml
@@ -16,7 +16,7 @@ ModalPopup {
     // TODO get the real image once it's available
     property string source: "../../../img/ens-header-dark@2x.png"
     property int nbMembers: community.nbMembers
-    property bool isAdmin: true // TODO: 
+    property bool isAdmin: false
     height: (isAdmin ? 600 : 590) + descriptionText.height
 
     id: popup

--- a/ui/app/AppLayouts/Chat/CommunityComponents/CommunityWelcomeBanner.qml
+++ b/ui/app/AppLayouts/Chat/CommunityComponents/CommunityWelcomeBanner.qml
@@ -92,6 +92,7 @@ Rectangle {
           communityProfilePopup.description = chatsModel.communities.activeCommunity.description;
           communityProfilePopup.access = chatsModel.communities.activeCommunity.access;
           communityProfilePopup.nbMembers = chatsModel.communities.activeCommunity.nbMembers;
+          communityProfilePopup.isAdmin = chatsModel.communities.activeCommunity.admin;
           communityProfilePopup.open()
         }
     }


### PR DESCRIPTION
This was hardcoded into `isAdmin` for some reason. It also seems that the
property isn't actually used anywhere in the profile popup, so we might
as well get rid off it.