### PR TITLE
feat(ModalPopup): hide footer section if footerContent height is 0

### DIFF
--- a/ui/app/AppLayouts/Chat/CommunityComponents/CommunityHeaderButton.qml
+++ b/ui/app/AppLayouts/Chat/CommunityComponents/CommunityHeaderButton.qml
@@ -62,6 +62,7 @@ Button {
           communityProfilePopup.description = chatsModel.communities.activeCommunity.description;
           communityProfilePopup.access = chatsModel.communities.activeCommunity.access;
           communityProfilePopup.nbMembers = chatsModel.communities.activeCommunity.nbMembers;
+          communityProfilePopup.isAdmin = chatsModel.communities.activeCommunity.admin
           communityProfilePopup.open();
         }
         hoverEnabled: true

--- a/ui/app/AppLayouts/Chat/CommunityComponents/CommunityProfilePopup.qml
+++ b/ui/app/AppLayouts/Chat/CommunityComponents/CommunityProfilePopup.qml
@@ -16,7 +16,7 @@ ModalPopup {
     // TODO get the real image once it's available
     property string source: "../../../img/ens-header-dark@2x.png"
     property int nbMembers: community.nbMembers
-    property bool isAdmin: true // TODO: 
+    property bool isAdmin: false
     height: (isAdmin ? 600 : 590) + descriptionText.height
 
     id: popup

--- a/ui/app/AppLayouts/Chat/CommunityComponents/CommunityWelcomeBanner.qml
+++ b/ui/app/AppLayouts/Chat/CommunityComponents/CommunityWelcomeBanner.qml
@@ -92,6 +92,7 @@ Rectangle {
           communityProfilePopup.description = chatsModel.communities.activeCommunity.description;
           communityProfilePopup.access = chatsModel.communities.activeCommunity.access;
           communityProfilePopup.nbMembers = chatsModel.communities.activeCommunity.nbMembers;
+          communityProfilePopup.isAdmin = chatsModel.communities.activeCommunity.admin;
           communityProfilePopup.open()
         }
     }

--- a/ui/shared/ModalPopup.qml
+++ b/ui/shared/ModalPopup.qml
@@ -126,7 +126,7 @@ Popup {
 
         Separator {
             id: separator2
-            visible: footerContent.visible
+            visible: footerContent.visible && footerContent.height > 0
             anchors.bottom: footerContent.top
             anchors.bottomMargin: visible ? Style.current.padding : 0
         }


### PR DESCRIPTION
In the recent past we've improved our `ModalPopup` to allow for a bit more control
when it comes to rendering a modal footer section with call-to-action items.

The footer section is rendered when there's `footerContent` and when the height
of the footer content is > 0. This means it's possible to also hide the footer content
section from the modal, even when there's footer content children.

However, there's a separator rendered whenver the footer is visible, regardless of its
height. This results in undesired behaviour when rendering footer children of height 0.

To avoid this, this commit adjust the condition so that the separator is only rendered
when the footer visible AND the height of it is > 0.