### PR TITLE
fix(Communities): remove type error in item width

### DIFF
--- a/ui/app/AppLayouts/Chat/CommunityComponents/CommunityProfilePopupMembersList.qml
+++ b/ui/app/AppLayouts/Chat/CommunityComponents/CommunityProfilePopupMembersList.qml
@@ -11,7 +11,6 @@ Item {
     property string headerTitle: ""
     property string headerDescription: ""
     property string headerImageSource: ""
-    width: parent.width
     height: childrenRect.height
 
     CommunityPopupButton {


### PR DESCRIPTION
There's no `parent` in that componen, which results in a QML type error
at runtime.