### PR TITLE
feat: introduce new StatusContextMenuButton component

### DIFF
--- a/ui/imports/Themes/DarkTheme.qml
+++ b/ui/imports/Themes/DarkTheme.qml
@@ -10,6 +10,7 @@ Theme {
     property color almostBlack: "#141414"
     property color grey: "#EEF2F5"
     property color lightGrey: "#7A7A7A"
+    property color midGrey: "#7f8990"
     property color darkGrey: "#373737"
     property color evenDarkerGrey: "#4b4b4b"
     property color lightBlue: "#ECEFFC"
@@ -71,6 +72,8 @@ Theme {
     property color buttonOutlineHoveredWarnBackgroundColor: "#4dff5c7b"
     property color buttonHoveredWarnBackgroundColor: red
     property color buttonHoveredBackgroundColor: blue
+
+    property color contextMenuButtonForegroundColor: midGrey
 
     property color roundedButtonForegroundColor: white
     property color roundedButtonBackgroundColor: secondaryBackground

--- a/ui/imports/Themes/LightTheme.qml
+++ b/ui/imports/Themes/LightTheme.qml
@@ -8,6 +8,7 @@ Theme {
     property color white2: "#FCFCFC"
     property color black: "#000000"
     property color grey: "#EEF2F5"
+    property color midGrey: "#7f8990"
     property color lightGrey: "#ccd0d4"
     property color lightBlue: "#ECEFFC"
     property color cyan: "#00FFFF"
@@ -70,6 +71,8 @@ Theme {
     property color buttonOutlineHoveredWarnBackgroundColor: "#1affeaee"
     property color buttonHoveredWarnBackgroundColor: red
     property color buttonHoveredBackgroundColor: blue
+
+    property color contextMenuButtonForegroundColor: black
 
     property color roundedButtonForegroundColor: buttonForegroundColor
     property color roundedButtonBackgroundColor: secondaryBackground

--- a/ui/shared/Separator.qml
+++ b/ui/shared/Separator.qml
@@ -2,9 +2,16 @@ import QtQuick 2.13
 import "../imports"
 
 Rectangle {
-      id: separator
-      width: parent.width
-      height: visible ? 1 : 0
-      color: Style.current.border
-      anchors.topMargin: Style.current.padding
+    id: root
+    width: parent.width
+    height: root.visible ? 1 : 0
+    anchors.topMargin: Style.current.padding
+    color: "transparent"
+    Rectangle {
+          id: separator
+          width: parent.width
+          height: 1
+          color: Style.current.border
+          anchors.verticalCenter: parent.verticalCenter
+    }
 }

--- a/ui/shared/status/StatusContextMenuButton.qml
+++ b/ui/shared/status/StatusContextMenuButton.qml
@@ -1,0 +1,44 @@
+import QtQuick 2.13
+import QtQuick.Controls 2.13
+import QtQml 2.14
+import QtGraphicalEffects 1.13
+import "../../imports"
+import "../../shared"
+
+RoundButton {
+    id: control
+    implicitWidth: 32
+    implicitHeight: 32
+    contentItem: Item {
+        anchors.fill: parent
+
+        SVGImage {
+            id: iconImg
+            source: "/../../app/img/dots-icon.svg"
+            width: 18
+            height: 4
+            anchors.horizontalCenter: parent.horizontalCenter
+            anchors.verticalCenter: parent.verticalCenter
+            fillMode: Image.PreserveAspectFit
+        }
+
+        ColorOverlay {
+            id: iconColorOverlay
+            anchors.fill: iconImg
+            source: iconImg
+            color: Style.current.contextMenuButtonForegroundColor
+            antialiasing: true
+        }
+    }
+    background: Rectangle {
+        radius: Style.current.radius
+        color: hovered ? Utils.setColorAlpha(Style.current.black, 0.1) : Style.current.transparent
+    }
+
+    MouseArea {
+        hoverEnabled: true
+        cursorShape: Qt.PointingHandCursor
+        anchors.fill: parent
+        onPressed: mouse.accepted = false
+    }
+}


### PR DESCRIPTION
We've been implementing such a button in various ways throughout the
application. Sometimes using SVG icons and rectangles, sometimes highjacking
`StyledText` components (which was clever though).

Obviously this resulted in inconsistencies, so this commit introduces
a new dedicated component to render the three-dots button for context menus.