### PR TITLE
fix(libstatus): add safety check before accessing API response

### DIFF
--- a/src/status/libstatus/chat.nim
+++ b/src/status/libstatus/chat.nim
@@ -376,7 +376,7 @@ proc myPendingRequestsToJoin*(): seq[CommunityMembershipRequest] =
   let rpcResult = callPrivateRPC("myPendingRequestsToJoin".prefix).parseJSON()
   var communityRequests: seq[CommunityMembershipRequest] = @[]
 
-  if rpcResult{"error"}.kind == JNull and rpcResult{"result"}.kind != JNull:
+  if rpcResult.hasKey("result") and rpcResult{"result"}.kind != JNull:
     for jsonCommunityReqest in rpcResult["result"]:
       communityRequests.add(jsonCommunityReqest.toCommunityMembershipRequest())
 


### PR DESCRIPTION
We've introduced a regression in https://github.com/status-im/status-desktop/commit/f1e83f74b#diff-f35edd413addd14c1f81816d6b5ee2bcbdf85fa0e3295d324cb78c98e26d4327L364 where we check whether an RPC's `error` is `null`
and its `result` is not `null`.

This breaks the application with an illegal storage access,
 as in case of a successful API call, the response will have only a `result` key
 (even when it's `null`).

Since we haven't done anything with a possible `error` in the reponse even before
that change was made, this commit removes the `error` check and safe guards around
whether `result` exists.

Fixes #2062