### PR TITLE
feat(Separator): enabled custom separator height

### DIFF
--- a/ui/shared/Separator.qml
+++ b/ui/shared/Separator.qml
@@ -2,9 +2,16 @@ import QtQuick 2.13
 import "../imports"
 
 Rectangle {
-      id: separator
-      width: parent.width
-      height: visible ? 1 : 0
-      color: Style.current.border
-      anchors.topMargin: Style.current.padding
+    id: root
+    width: parent.width
+    height: root.visible ? 1 : 0
+    anchors.topMargin: Style.current.padding
+    color: "transparent"
+    Rectangle {
+          id: separator
+          width: parent.width
+          height: 1
+          color: Style.current.border
+          anchors.verticalCenter: parent.verticalCenter
+    }
 }


### PR DESCRIPTION
Sometimes, `Separator` is used inside context menus to separate groups
of actions that belong together. The separator in itself doesn't have any
padding or margins in this case because the just gets transcluded as is
in the context menu, between menu items.
There are cases in the design where a padding/margin is desired though.

This change makes that possible by wrapping the separator `Rectangle` with
another `Rectangle` which controls a custom height (if desired). The inner
rectangle is then just always vertically center.

In practice this means, existing usages of `Separator` behave exactly the same,
they don't break. In addtion one can set `Separator { height: x }` while maintaining
a 1px separator line.