### PR TITLE
feat: stickers spawnAndSend to threadpool task

### DIFF
--- a/src/app/chat/views/stickers.nim
+++ b/src/app/chat/views/stickers.nim
@@ -65,12 +65,7 @@ QtObject:
       self.transactionWasSent(response)
 
   proc obtainAvailableStickerPacks*(self: StickersView) =
-    spawnAndSend(self, "setAvailableStickerPacks") do:
-      let availableStickerPacks = status_stickers.getAvailableStickerPacks()
-      var packs: seq[StickerPack] = @[]
-      for packId, stickerPack in availableStickerPacks.pairs:
-        packs.add(stickerPack)
-      $(%*(packs))
+    self.status.taskManager.threadPool.stickers.obtainAvailableStickerPacks(cast[pointer](self.vptr), "setAvailableStickerPacks")
 
   proc stickerPacksLoaded*(self: StickersView) {.signal.}
 

--- a/src/status/stickers.nim
+++ b/src/status/stickers.nim
@@ -107,7 +107,7 @@ proc getInstalledStickerPacks*(self: StickersModel): Table[int, StickerPack] =
   self.installedStickerPacks = status_stickers.getInstalledStickerPacks()
   result = self.installedStickerPacks
 
-proc getAvailableStickerPacks*(self: StickersModel): Table[int, StickerPack] = status_stickers.getAvailableStickerPacks()
+proc getAvailableStickerPacks*(): Table[int, StickerPack] = status_stickers.getAvailableStickerPacks()
 
 proc getRecentStickers*(self: StickersModel): seq[Sticker] =
   result = status_stickers.getRecentStickers()

--- a/src/status/tasks/common.nim
+++ b/src/status/tasks/common.nim
@@ -1,0 +1,17 @@
+import
+  json_serialization, NimQml, task_runner
+
+type
+  BaseTasks* = ref object of RootObj
+    chanSendToPool*: AsyncChannel[ThreadSafeString]
+  BaseTask* = ref object of RootObj
+    vptr*: ByteAddress
+    slot*: string
+
+proc start*[T: BaseTask](self: BaseTasks, task: T) =
+  let payload = task.toJson(typeAnnotations = true)
+  self.chanSendToPool.sendSync(payload.safe)
+
+proc finish*[T](task: BaseTask, payload: T) =
+  let resultPayload = Json.encode(payload)
+  signal_handler(cast[pointer](task.vptr), resultPayload, task.slot)

--- a/src/status/tasks/threadpool.nim
+++ b/src/status/tasks/threadpool.nim
@@ -3,7 +3,7 @@ import
   task_runner
 
 import
-  ./stickers
+  ./common, ./stickers
 export
   stickers
 
@@ -89,9 +89,12 @@ proc task(arg: TaskThreadArg) {.async.} =
 
     try:
       case messageType
-        of "StickerPackPurchaseGasEstimate":
+        of "StickerPackPurchaseGasEstimate:ObjectType":
           let decoded = Json.decode(received, StickerPackPurchaseGasEstimate, allowUnknownFields = true)
-          decoded.runTask()
+          decoded.run()
+        of "ObtainAvailableStickerPacks:ObjectType":
+          let decoded = Json.decode(received, ObtainAvailableStickerPacks, allowUnknownFields = true)
+          decoded.run()
         else:
           error "[threadpool task thread] unknown message", message=received
     except Exception as e:

--- a/src/status/wallet/collectibles.nim
+++ b/src/status/wallet/collectibles.nim
@@ -215,7 +215,7 @@ proc getStickers*(address: Address): string =
     if (purchasedStickerPacks.len == 0):
       return $(%*stickers)
     # TODO find a way to keep those in memory so as not to reload it each time
-    let availableStickerPacks = status_stickers.getAvailableStickerPacks()
+    let availableStickerPacks = getAvailableStickerPacks()
 
     var index = 0
     for stickerId in purchasedStickerPacks:


### PR DESCRIPTION
Move the remaining stickers `spawnAndSend` (`obtainAvailableStickerPacks`) into a threadpool task.

refactor: create a base class for tasks models to inherit from

NOTE: this branch is based off of `experiment/tasks-3` and should be rebased on master once that branch is merged.