### PR TITLE
fix(StatusRadioButtonRow): ensure checked state is propagated properly

### DIFF
--- a/ui/app/AppLayouts/Profile/Sections/BrowserModals/EthereumExplorerModal.qml
+++ b/ui/app/AppLayouts/Profile/Sections/BrowserModals/EthereumExplorerModal.qml
@@ -15,52 +15,56 @@ ModalPopup {
     }
 
     Column {
-        spacing: Style.current.bigPadding
-        width: parent.width
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.rightMargin: Style.current.padding
+        anchors.leftMargin: Style.current.padding
+
+        spacing: 0
 
         ButtonGroup {
             id: searchEnginGroup
         }
 
-        StatusRadioButton {
+        StatusRadioButtonRow {
             //% "None"
             text: qsTrId("none")
-            ButtonGroup.group: searchEnginGroup
+            buttonGroup: searchEnginGroup
             checked: appSettings.useBrowserEthereumExplorer === Constants.browserEthereumExplorerNone
-            onCheckedChanged: {
+            onRadioCheckedChanged: {
                 if (checked) {
                     appSettings.useBrowserEthereumExplorer = Constants.browserEthereumExplorerNone
                 }
             }
         }
 
-        StatusRadioButton {
+        StatusRadioButtonRow {
             text: "etherscan.io"
-            ButtonGroup.group: searchEnginGroup
+            buttonGroup: searchEnginGroup
             checked: appSettings.useBrowserEthereumExplorer === Constants.browserEthereumExplorerEtherscan
-            onCheckedChanged: {
+            onRadioCheckedChanged: {
                 if (checked) {
                     appSettings.useBrowserEthereumExplorer = Constants.browserEthereumExplorerEtherscan
                 }
             }
         }
 
-        StatusRadioButton {
+        StatusRadioButtonRow {
             text: "ethplorer.io"
-            ButtonGroup.group: searchEnginGroup
+            buttonGroup: searchEnginGroup
             checked: appSettings.useBrowserEthereumExplorer === Constants.browserEthereumExplorerEthplorer
-            onCheckedChanged: {
+            onRadioCheckedChanged: {
                 if (checked) {
                     appSettings.useBrowserEthereumExplorer = Constants.browserEthereumExplorerEthplorer
                 }
             }
         }
 
-        StatusRadioButton {
+        StatusRadioButtonRow {
             text: "blockchair.com"
-            ButtonGroup.group: searchEnginGroup
+            buttonGroup: searchEnginGroup
             checked: appSettings.useBrowserEthereumExplorer === Constants.browserEthereumExplorerBlockchair
-            onCheckedChanged: {
+            onRadioCheckedChanged: {
                 if (checked) {
                     appSettings.useBrowserEthereumExplorer = Constants.browserEthereumExplorerBlockchair
                 }

--- a/ui/app/AppLayouts/Profile/Sections/BrowserModals/HomepageModal.qml
+++ b/ui/app/AppLayouts/Profile/Sections/BrowserModals/HomepageModal.qml
@@ -15,19 +15,25 @@ ModalPopup {
     }
 
     Column {
-        spacing: Style.current.bigPadding
-        width: parent.width
+        anchors.top: parent.top
+        anchors.bottom: parent.bottom
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.rightMargin: Style.current.padding
+        anchors.leftMargin: Style.current.padding
+
+        spacing: Style.current.padding
 
         ButtonGroup {
             id: homepageGroup
         }
 
-        StatusRadioButton {
+        StatusRadioButtonRow {
             //% "Default"
             text: qsTrId("default")
-            ButtonGroup.group: homepageGroup
+            buttonGroup: homepageGroup
             checked: appSettings.browserHomepage === ""
-            onCheckedChanged: {
+            onRadioCheckedChanged: {
                 if (checked) {
                     appSettings.browserHomepage = ""
                     customUrl.visible = false
@@ -35,13 +41,15 @@ ModalPopup {
             }
         }
 
-        StatusRadioButton {
+        StatusRadioButtonRow {
             //% "Custom..."
             text: qsTrId("custom---")
-            ButtonGroup.group: homepageGroup
+            buttonGroup: homepageGroup
             checked: appSettings.browserHomepage !== "" || customUrl.visible
-            onClicked: {
-                customUrl.visible = true
+            onRadioCheckedChanged: {
+                if (checked) {
+                    customUrl.visible = true
+                }
             }
         }
 
@@ -55,6 +63,8 @@ ModalPopup {
             textField.onTextChanged: {
                 appSettings.browserHomepage = customUrl.text
             }
+            anchors.leftMargin: 0
+            anchors.rightMargin: 0
         }
     }
 }

--- a/ui/app/AppLayouts/Profile/Sections/BrowserModals/SearchEngineModal.qml
+++ b/ui/app/AppLayouts/Profile/Sections/BrowserModals/SearchEngineModal.qml
@@ -15,52 +15,56 @@ ModalPopup {
     }
 
     Column {
-        spacing: Style.current.bigPadding
-        width: parent.width
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.rightMargin: Style.current.padding
+        anchors.leftMargin: Style.current.padding
+
+        spacing: 0
 
         ButtonGroup {
             id: searchEnginGroup
         }
 
-        StatusRadioButton {
+        StatusRadioButtonRow {
             //% "None"
             text: qsTrId("none")
-            ButtonGroup.group: searchEnginGroup
+            buttonGroup: searchEnginGroup
             checked: appSettings.shouldShowBrowserSearchEngine === Constants.browserSearchEngineNone
-            onCheckedChanged: {
+            onRadioCheckedChanged: {
                 if (checked) {
                     appSettings.shouldShowBrowserSearchEngine = Constants.browserSearchEngineNone
                 }
             }
         }
 
-        StatusRadioButton {
+        StatusRadioButtonRow {
             text: "Google"
-            ButtonGroup.group: searchEnginGroup
+            buttonGroup: searchEnginGroup
             checked: appSettings.shouldShowBrowserSearchEngine === Constants.browserSearchEngineGoogle
-            onCheckedChanged: {
+            onRadioCheckedChanged: {
                 if (checked) {
                     appSettings.shouldShowBrowserSearchEngine = Constants.browserSearchEngineGoogle
                 }
             }
         }
 
-        StatusRadioButton {
+        StatusRadioButtonRow {
             text: "Yahoo!"
-            ButtonGroup.group: searchEnginGroup
+            buttonGroup: searchEnginGroup
             checked: appSettings.shouldShowBrowserSearchEngine === Constants.browserSearchEngineYahoo
-            onCheckedChanged: {
+            onRadioCheckedChanged: {
                 if (checked) {
                     appSettings.shouldShowBrowserSearchEngine = Constants.browserSearchEngineYahoo
                 }
             }
         }
 
-        StatusRadioButton {
+        StatusRadioButtonRow {
             text: "DuckDuckGo"
-            ButtonGroup.group: searchEnginGroup
+            buttonGroup: searchEnginGroup
             checked: appSettings.shouldShowBrowserSearchEngine === Constants.browserSearchEngineDuckDuckGo
-            onCheckedChanged: {
+            onRadioCheckedChanged: {
                 if (checked) {
                     appSettings.shouldShowBrowserSearchEngine = Constants.browserSearchEngineDuckDuckGo
                 }

--- a/ui/app/AppLayouts/Profile/Sections/FleetRadioSelector.qml
+++ b/ui/app/AppLayouts/Profile/Sections/FleetRadioSelector.qml
@@ -5,10 +5,19 @@ import "../../../../imports"
 import "../../../../shared"
 import "../../../../shared/status"
 
-RowLayout {
+StatusRadioButtonRow {
     property string fleetName: ""
     property string newFleet: ""
-
+    text: fleetName
+    buttonGroup: fleetSettings
+    checked: profileModel.fleets.fleet === text
+    onRadioCheckedChanged: {
+        if (checked) {
+            if (profileModel.fleets.fleet === fleetName) return;
+            newFleet = fleetName;
+            confirmDialog.open();
+        }
+    }
     ConfirmationDialog {
         id: confirmDialog
         //% "Warning!"
@@ -18,23 +27,5 @@ RowLayout {
         onConfirmButtonClicked: profileModel.fleets.setFleet(newFleet)
         onClosed: profileModel.fleets.triggerFleetChange()
     }
-
-
-    width: parent.width
-    StyledText {
-        text: fleetName
-        font.pixelSize: 15
-    }
-    StatusRadioButton {
-        id: radioProd
-        Layout.alignment: Qt.AlignRight
-        ButtonGroup.group: fleetSettings
-        rightPadding: 0
-        checked: profileModel.fleets.fleet === fleetName
-        onClicked: {
-            if (profileModel.fleets.fleet === fleetName) return;
-            newFleet = fleetName;
-            confirmDialog.open();
-        }
-    }
 }
+

--- a/ui/app/AppLayouts/Profile/Sections/FleetsModal.qml
+++ b/ui/app/AppLayouts/Profile/Sections/FleetsModal.qml
@@ -14,8 +14,14 @@ ModalPopup {
     
     Column {
         id: column
-        spacing: Style.current.padding
-        width: parent.width
+        anchors.top: parent.top
+        anchors.bottom: parent.bottom
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.rightMargin: Style.current.padding
+        anchors.leftMargin: Style.current.padding
+
+        spacing: 0
 
         ButtonGroup { id: fleetSettings }
 

--- a/ui/app/AppLayouts/Profile/Sections/MutedChatsModal.qml
+++ b/ui/app/AppLayouts/Profile/Sections/MutedChatsModal.qml
@@ -24,9 +24,12 @@ ModalPopup {
         anchors.right: parent.right
         model: root.showMutedContacts ? profileModel.mutedContacts : profileModel.mutedChats
         delegate: Rectangle {
+            id: channelItem
+            property bool isHovered: false
             height: contactImage.height + Style.current.smallPadding * 2
             width: parent.width
-            color: Style.current.transparent
+            radius: Style.current.radius
+            color: isHovered ? Style.current.backgroundHover : Style.current.transparent
 
             StatusIdenticon {
                 id: contactImage
@@ -36,6 +39,7 @@ ModalPopup {
                 chatType: model.chatType
                 identicon: model.identicon
                 anchors.left: parent.left
+                anchors.leftMargin: Style.current.smallPadding
                 anchors.verticalCenter: parent.verticalCenter
             }
 
@@ -47,21 +51,38 @@ ModalPopup {
                 anchors.right: unmuteButton.left
                 anchors.rightMargin: Style.current.smallPadding
                 elide: Text.ElideRight
-                font.pixelSize: 17
+                font.pixelSize: 15
                 anchors.left: contactImage.right
                 anchors.leftMargin: Style.current.padding
                 anchors.verticalCenter: parent.verticalCenter
+            }
+
+            MouseArea {
+                anchors.fill: parent
+                cursorShape: Qt.PointingHandCursor
+                hoverEnabled: true
+                onEntered: channelItem.isHovered = true
+                onExited: channelItem.isHovered = false
             }
 
             StatusButton {
                 id: unmuteButton
                 type: "secondary"
                 anchors.right: parent.right
+                anchors.rightMargin: Style.current.smallPadding
                 anchors.verticalCenter: parent.verticalCenter
                 //% "Unmute"
                 text: qsTrId("unmute")
                 onClicked: {
                     profileModel.unmuteChannel(model.id)
+                }
+                MouseArea {
+                    anchors.fill: parent
+                    cursorShape: Qt.PointingHandCursor
+                    hoverEnabled: true
+                    onEntered: {
+                        channelItem.isHovered = true
+                    }
                 }
             }
         }

--- a/ui/app/AppLayouts/Profile/Sections/NetworkRadioSelector.qml
+++ b/ui/app/AppLayouts/Profile/Sections/NetworkRadioSelector.qml
@@ -5,10 +5,21 @@ import "../../../../imports"
 import "../../../../shared"
 import "../../../../shared/status"
 
-RowLayout {
+StatusRadioButtonRow {
     property string network: ""
     property string networkName: ""
     property string newNetwork: ""
+    id: radioProd
+    text: networkName == "" ? Utils.getNetworkName(network) : networkName
+    buttonGroup: networkSettings
+    checked: profileModel.network.current  === network
+    onRadioCheckedChanged: {
+        if (checked) {
+            if (profileModel.network.current === network) return;
+            newNetwork = network;
+            confirmDialog.open();
+        }
+    }
 
     ConfirmationDialog {
         id: confirmDialog
@@ -20,23 +31,5 @@ RowLayout {
             profileModel.network.current = newNetwork;
         }
         onClosed: profileModel.network.triggerNetworkChange()
-    }
-
-    width: parent.width
-    StyledText {
-        text: networkName == "" ? Utils.getNetworkName(network) : networkName
-        font.pixelSize: 15
-    }
-    StatusRadioButton {
-        id: radioProd
-        Layout.alignment: Qt.AlignRight
-        ButtonGroup.group: networkSettings
-        rightPadding: 0
-        checked: profileModel.network.current  === network
-        onClicked: {
-            if (profileModel.network.current === network) return;
-            newNetwork = network;
-            confirmDialog.open();
-        }
     }
 }

--- a/ui/app/AppLayouts/Profile/Sections/NetworksModal.qml
+++ b/ui/app/AppLayouts/Profile/Sections/NetworksModal.qml
@@ -41,10 +41,6 @@ ModalPopup {
                     anchors.verticalCenter: parent.verticalCenter
                 }
 
-                ButtonGroup {
-                    id: networkChainGroup
-                }
-
                 StyledText {
                     id: usernameText
                     //% "Add network"
@@ -176,79 +172,54 @@ ModalPopup {
                         anchors.topMargin: Style.current.smallPadding
                         anchors.left: parent.left
                         anchors.right: parent.right
+                        anchors.rightMargin: Style.current.padding
+                        anchors.leftMargin: Style.current.padding
 
-                        RowLayout {
-                            width: parent.width
-                            StyledText {
-                                //% "Main network"
-                                text: qsTrId("mainnet-network")
-                                font.pixelSize: 15
-                            }
+                        ButtonGroup {
+                            id: networkChainGroup
+                        }
 
-                            StatusRadioButton {
-                                id: mainnetRadioBtn
-                                Layout.alignment: Qt.AlignRight
-                                ButtonGroup.group: networkChainGroup
-                                rightPadding: 0
-                                checked: true
-                                onClicked: {
+                        StatusRadioButtonRow {
+                            id: mainnetRadioBtn
+                            text: qsTr("Main network")
+                            buttonGroup: networkChainGroup
+                            checked: true
+                            onRadioCheckedChanged: {
+                                if (checked) {
                                     addNetworkPopup.networkId = 1;
                                     addNetworkPopup.networkType = Constants.networkMainnet;
                                 }
                             }
                         }
 
-                        RowLayout {
-                            width: parent.width
-                            StyledText {
-                                //% "Ropsten test network"
-                                text: qsTrId("ropsten-network")
-                                font.pixelSize: 15
-                            }
-                            StatusRadioButton {
-                                id: ropstenRadioBtn
-                                Layout.alignment: Qt.AlignRight
-                                ButtonGroup.group: networkChainGroup
-                                rightPadding: 0
-                                onClicked: {
+                        StatusRadioButtonRow {
+                            text: qsTr("Ropsten test network")
+                            buttonGroup: networkChainGroup
+                            onRadioCheckedChanged: {
+                                if (checked) {
                                     addNetworkPopup.networkId = 3;
                                     addNetworkPopup.networkType = Constants.networkRopsten;
                                 }
                             }
                         }
 
-                        RowLayout {
-                            width: parent.width
-                            StyledText {
-                                //% "Rinkeby test network"
-                                text: qsTrId("rinkeby-network")
-                                font.pixelSize: 15
-                            }
-                            StatusRadioButton {
-                                id: rinkebyRadioBtn
-                                Layout.alignment: Qt.AlignRight
-                                ButtonGroup.group: networkChainGroup
-                                rightPadding: 0
-                                onClicked: {
+                        StatusRadioButtonRow {
+                            text: qsTr("Rinkeby test network")
+                            buttonGroup: networkChainGroup
+                            onRadioCheckedChanged: {
+                                if (checked) {
                                     addNetworkPopup.networkId = 4;
                                     addNetworkPopup.networkType = Constants.networkRinkeby;
                                 }
                             }
                         }
 
-                        RowLayout {
-                            width: parent.width
-                            StyledText {
-                                //% "Custom"
-                                text: qsTrId("custom")
-                                font.pixelSize: 15
-                            }
-                            StatusRadioButton {
-                                id: customRadioBtn
-                                Layout.alignment: Qt.AlignRight
-                                ButtonGroup.group: networkChainGroup
-                                rightPadding: 0
-                                onClicked: {
+                        StatusRadioButtonRow {
+                            id: customRadioBtn
+                            text: qsTr("Custom")
+                            buttonGroup: networkChainGroup
+                            onRadioCheckedChanged: {
+                                if (checked) {
                                     addNetworkPopup.networkType = "";
                                 }
                             }
@@ -266,51 +237,64 @@ ModalPopup {
                     }
                 }
             }
+            Column {
+                spacing: Style.current.smallPadding
+                anchors.left: parent.left
+                anchors.right: parent.right
+                anchors.leftMargin: Style.current.padding
+                anchors.rightMargin: Style.current.padding
 
-            StatusSectionHeadline {
-                //% "Main networks"
-                text: qsTrId("main-networks")
-            }
 
-            NetworkRadioSelector {
-                network: Constants.networkMainnet
-            }
+                StatusSectionHeadline {
+                    //% "Main networks"
+                    text: qsTrId("main-networks")
+                }
 
-            NetworkRadioSelector {
-                network: Constants.networkPOA
-            }
 
-            NetworkRadioSelector {
-                network: Constants.networkXDai
-            }
+                NetworkRadioSelector {
+                    network: Constants.networkMainnet
+                }
 
-            StatusSectionHeadline {
-                //% "Test networks"
-                text: qsTrId("test-networks")
-            }
+                NetworkRadioSelector {
+                    network: Constants.networkPOA
+                }
 
-            NetworkRadioSelector {
-                network: Constants.networkGoerli
-            }
+                NetworkRadioSelector {
+                    network: Constants.networkXDai
+                }
 
-            NetworkRadioSelector {
-                network: Constants.networkRinkeby
-            }
+                StatusSectionHeadline {
+                    //% "Test networks"
+                    text: qsTrId("test-networks")
+                    anchors.leftMargin: -Style.current.padding
+                    anchors.rightMargin: -Style.current.padding
+                }
 
-            NetworkRadioSelector {
-                network: Constants.networkRopsten
-            }
+                NetworkRadioSelector {
+                    network: Constants.networkGoerli
+                }
 
-            StatusSectionHeadline {
-                //% "Custom Networks"
-                text: qsTrId("custom-networks")
-            }
+                NetworkRadioSelector {
+                    network: Constants.networkRinkeby
+                }
 
-            Repeater {
-                model: profileModel.network.customNetworkList
-                delegate: NetworkRadioSelector {
-                    networkName: name
-                    network: customNetworkId
+                NetworkRadioSelector {
+                    network: Constants.networkRopsten
+                }
+
+                StatusSectionHeadline {
+                    //% "Custom Networks"
+                    text: qsTrId("custom-networks")
+                    anchors.leftMargin: -Style.current.padding
+                    anchors.rightMargin: -Style.current.padding
+                }
+
+                Repeater {
+                    model: profileModel.network.customNetworkList
+                    delegate: NetworkRadioSelector {
+                        networkName: name
+                        network: customNetworkId
+                    }
                 }
             }
         }

--- a/ui/app/AppLayouts/Profile/Sections/OpenLinksWithModal.qml
+++ b/ui/app/AppLayouts/Profile/Sections/OpenLinksWithModal.qml
@@ -15,29 +15,35 @@ ModalPopup {
     }
 
     Column {
-        anchors.fill: parent
-        spacing: Style.current.bigPadding
+        anchors.top: parent.top
+        anchors.bottom: parent.bottom
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.rightMargin: Style.current.padding
+        anchors.leftMargin: Style.current.padding
+
+        spacing: 0
 
         ButtonGroup {
             id: openLinksWithGroup
         }
 
-        StatusRadioButton {
+        StatusRadioButtonRow {
             text: "Status"
-            ButtonGroup.group: openLinksWithGroup
+            buttonGroup: openLinksWithGroup
             checked: appSettings.openLinksInStatus
-            onCheckedChanged: {
+            onRadioCheckedChanged: {
                 if (checked) {
                     appSettings.openLinksInStatus = true
                 }
             }
         }
-        StatusRadioButton {
+        StatusRadioButtonRow {
             //% "My default browser"
             text: qsTrId("my-default-browser")
-            ButtonGroup.group: openLinksWithGroup
+            buttonGroup: openLinksWithGroup
             checked: !appSettings.openLinksInStatus
-            onCheckedChanged: {
+            onRadioCheckedChanged: {
                 if (checked) {
                     appSettings.openLinksInStatus = false
                 }

--- a/ui/shared/status/StatusRadioButtonRow.qml
+++ b/ui/shared/status/StatusRadioButtonRow.qml
@@ -31,6 +31,17 @@ Rectangle {
         anchors.leftMargin: Style.current.padding
     }
 
+    MouseArea {
+        cursorShape: Qt.PointingHandCursor
+        anchors.fill: parent
+        hoverEnabled: true
+        onEntered: root.isHovered = true
+        onExited: root.isHovered = false
+        onClicked: {
+            radioButton.checked = true
+        }
+    }
+
     StatusRadioButton {
         id: radioButton
         anchors.verticalCenter: parent.verticalCenter
@@ -40,18 +51,13 @@ Rectangle {
         rightPadding: 0
         checked: root.checked
         onCheckedChanged: root.radioCheckedChanged(checked)
-    }
-
-    MouseArea {
-        cursorShape: Qt.PointingHandCursor
-        anchors.fill: parent
-        hoverEnabled: true
-        onEntered: root.isHovered = true
-        onExited: root.isHovered = false
-        onClicked: {
-            if (!radioButton.checked) {
-                root.radioCheckedChanged(true)
-            }
+        MouseArea {
+            hoverEnabled: true
+            cursorShape: Qt.PointingHandCursor
+            anchors.fill: parent
+            onPressed: mouse.accepted = false
+            onEntered: root.isHovered = true
         }
     }
+
 }


### PR DESCRIPTION
There were cases in which this component was used and its `checked` state wasn't
properly emitted to the underlying component.

This commit fixes that by ensuring the `MouseArea` only alters the radio button's
`checked` state and let the radio button handle the event propagation.