### PR TITLE
fix(Separator): ensure custom color works as expected

### DIFF
--- a/ui/shared/Separator.qml
+++ b/ui/shared/Separator.qml
@@ -1,17 +1,17 @@
 import QtQuick 2.13
 import "../imports"
 
-Rectangle {
+Item {
     id: root
+    property color color: Style.current.border
     width: parent.width
     height: root.visible ? 1 : 0
     anchors.topMargin: Style.current.padding
-    color: "transparent"
     Rectangle {
           id: separator
           width: parent.width
           height: 1
-          color: Style.current.border
+          color: root.color
           anchors.verticalCenter: parent.verticalCenter
     }
 }


### PR DESCRIPTION
This was a regression introduced in https://github.com/status-im/status-desktop/pull/2065.
The new wrapping Rectangle would get the color that is possibily passed down
to Separator. Instead it should get properly bound to the actual separator.