### PR TITLE
feat: highlite mentions in the chat input as well

### DIFF
--- a/ui/app/AppLayouts/Chat/ChatColumn/SuggestionFilter.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/SuggestionFilter.qml
@@ -74,6 +74,7 @@ Item {
         }
 
         let filterWithoutAt = filter.substring(lastAtPosition + 1, this.cursorPosition)
+        filterWithoutAt = filterWithoutAt.replace(/\*/g, "")
 
         return !properties.every(p => item[p].toLowerCase().match(filterWithoutAt.toLowerCase()) === null)
     }

--- a/ui/imports/Constants.qml
+++ b/ui/imports/Constants.qml
@@ -125,4 +125,7 @@ QtObject {
 
     readonly property var acceptedImageExtensions: [".png", ".jpg", ".jpeg", ".svg", ".gif"]
     readonly property var acceptedDragNDropImageExtensions: [".png", ".jpg", ".jpeg", ".heif", "tif", ".tiff"]
+
+
+    readonly property string mentionSpanTag: `<span style="color:${Style.current.mentionColor}; background-color: ${Style.current.mentionBgColor};">`
 }

--- a/ui/imports/Emoji.qml
+++ b/ui/imports/Emoji.qml
@@ -27,7 +27,7 @@ QtObject {
     function fromCodePoint(value) {
         return Twemoji.twemoji.convert.fromCodePoint(value)
     }
-    function deparse(value){
+    function deparse(value) {
         return value.replace(/<img src=\"qrc:\/imports\/twemoji\/.+?" alt=\"(.+?)\" width=\"[0-9]*\" height=\"[0-9]*\" \/>/g, "$1");
     }
     function deparseFromParse(value) {


### PR DESCRIPTION
Fixes #1957

Makes the mentions in the input highlighted as well as in the chat.

This was harder than the other text formations, because mentions don,t wrap the name, they just have an `@` before them and they sometimes have 1 word, sometimes 3.

So I had to create a new deparse "tag" called `[[mention]]`. that way, when we deparse, we add those around so that when we parse back to "normal" text, we remember to add back the styling to highlight. When we send the message, the `span`s are all removed so we just send the normal message as before.

![image](https://user-images.githubusercontent.com/11926403/111837416-3ba14f80-88ce-11eb-80bc-190cf0ffebdb.png)
