### PR TITLE
fix(Contacts): ensure app doesn't crash when contact can't be resolved

### DIFF
--- a/src/app/profile/views/contacts.nim
+++ b/src/app/profile/views/contacts.nim
@@ -123,6 +123,10 @@ QtObject:
 
   proc ensResolved(self: ContactsView, id: string) {.slot.} =
     self.ensWasResolved(id)
+    if id == "":
+      self.contactToAddChanged()
+      return
+
     let contact = self.status.contacts.getContactByID(id)
     
     if contact != nil:


### PR DESCRIPTION
There was a bug introduced https://github.com/status-im/status-desktop/commit/2ac67f95a where we'd rely on the
possibly resolved public key, which is passed to `generateAlias()`.

The public key is never guaranteed to be an actual key (if resolution fails,
it's a an empty string). Passing an empty string to `generateAlias()` causes
`status-go` to crash and we don't handle that error.

This commit ensures that we only attempt to generate an alias when we
indeed have a successfully resolved public key.