### PR TITLE
feat(PrivateChatPopupSearchResults): introduce reset() and config API

### DIFF
--- a/src/app/profile/views/contacts.nim
+++ b/src/app/profile/views/contacts.nim
@@ -123,6 +123,10 @@ QtObject:
 
   proc ensResolved(self: ContactsView, id: string) {.slot.} =
     self.ensWasResolved(id)
+    if id == "":
+      self.contactToAddChanged()
+      return
+
     let contact = self.status.contacts.getContactByID(id)
     
     if contact != nil:

--- a/ui/app/AppLayouts/Chat/components/PrivateChatPopupSearchResults.qml
+++ b/ui/app/AppLayouts/Chat/components/PrivateChatPopupSearchResults.qml
@@ -16,9 +16,19 @@ Item {
     property string username: ""
     property string userAlias: ""
     property string pubKey: ""
+    property bool resultClickable: true
 
     signal resultClicked(string pubKey)
     signal addToContactsButtonClicked(string pubKey)
+
+    function reset() {
+        hasExistingContacts = false
+        showProfileNotFoundMessage = false
+        username = ""
+        userAlias = ""
+        pubKey = ""
+    }
+
     width: parent.width
 
     StyledText {
@@ -82,12 +92,16 @@ Item {
         }
 
         MouseArea {
-            cursorShape: Qt.PointingHandCursor
+            cursorShape: root.resultClickable ? Qt.PointingHandCursor : Qt.ArrowCursor
             anchors.fill: parent
             hoverEnabled: true
             onEntered: foundContact.hovered = true
             onExited: foundContact.hovered = false
-            onClicked: root.resultClicked(root.pubKey)
+            onClicked: {
+                if (root.resultClickable) {
+                    root.resultClicked(root.pubKey)
+                }
+            }
         }
 
         StatusIconButton {


### PR DESCRIPTION
This commit introduces a `reset()` function so that search results inside
the application can be easily reset. It also introduces a `resultClickable`
flag which allows consumers of this component to decide whether a search result
is clickable and emits a dedicated event.

This is useful when UIs should only allow actions via the result icon button
(as it's the case with the new add-to-contact modal).