### PR TITLE
fix: fix settings not being refetched when they had been edited before

### DIFF
--- a/src/app/wallet/view.nim
+++ b/src/app/wallet/view.nim
@@ -321,15 +321,15 @@ QtObject:
     write = setDefaultCurrency
     notify = defaultCurrencyChanged
 
-  proc hasAsset*(self: WalletView, account: string, symbol: string): bool {.slot.} =
-    self.status.wallet.hasAsset(account, symbol)
+  proc hasAsset*(self: WalletView, symbol: string): bool {.slot.} =
+    self.status.wallet.hasAsset(symbol)
 
   proc toggleAsset*(self: WalletView, symbol: string) {.slot.} =
     self.status.wallet.toggleAsset(symbol)
     for account in self.status.wallet.accounts:
       if account.address == self.currentAccount.address:
         self.currentAccount.setAccountItem(account)
-      else: 
+      else:
         self.accounts.updateAssetsInList(account.address, account.assetList)
     self.accountListChanged()
     self.currentAccountChanged()

--- a/src/status/libstatus/settings.nim
+++ b/src/status/libstatus/settings.nim
@@ -23,9 +23,9 @@ proc saveSetting*(key: Setting, value: string | JsonNode): StatusGoError =
     if responseResult == "null":
       result.error = ""
     else: result = Json.decode(response, StatusGoError)
+    dirty.store(true)
   except Exception as e:
     error "Error saving setting", key=key, value=value, msg=e.msg
-    dirty.store(true)
 
 proc getWeb3ClientVersion*(): string =
   parseJson(callPrivateRPC("web3_clientVersion"))["result"].getStr
@@ -34,7 +34,7 @@ proc getSettings*(useCached: bool = true, keepSensitiveData: bool = false): Json
   let cacheIsDirty = (not settingsInited) or dirty.load
   if useCached and (not cacheIsDirty) and (not keepSensitiveData):
     result = settings
-  else: 
+  else:
     result = callPrivateRPC("settings_getSettings").parseJSON()["result"]
     if not keepSensitiveData:
       dirty.store(false)

--- a/src/status/wallet.nim
+++ b/src/status/wallet.nim
@@ -290,8 +290,7 @@ proc addWatchOnlyAccount*(self: WalletModel, address: string, accountName: strin
   let account = GeneratedAccount(address: address)
   return self.addNewGeneratedAccount(account, "", accountName, color, constants.WATCH, false)
 
-proc hasAsset*(self: WalletModel, account: string, symbol: string): bool =
-  self.tokens = status_tokens.getVisibleTokens()
+proc hasAsset*(self: WalletModel, symbol: string): bool =
   self.tokens.anyIt(it.symbol == symbol)
 
 proc changeAccountSettings*(self: WalletModel, address: string, accountName: string, color: string): string =
@@ -311,8 +310,7 @@ proc deleteAccount*(self: WalletModel, address: string): string =
   result = status_accounts.deleteAccount(address)
 
 proc toggleAsset*(self: WalletModel, symbol: string) =
-  status_tokens.toggleAsset(symbol)
-  self.tokens = status_tokens.getVisibleTokens()
+  self.tokens = status_tokens.toggleAsset(symbol)
   for account in self.accounts:
     account.assetList = self.generateAccountConfiguredAssets(account.address)
     updateBalance(account, self.getDefaultCurrency())

--- a/ui/app/AppLayouts/Wallet/components/TokenSettingsModalContent.qml
+++ b/ui/app/AppLayouts/Wallet/components/TokenSettingsModalContent.qml
@@ -62,7 +62,7 @@ Item {
             }
             StatusCheckBox  {
                 id: assetCheck
-                checked: walletModel.hasAsset("0x123", symbol)
+                checked: walletModel.hasAsset(symbol)
                 anchors.right: parent.right
                 anchors.rightMargin: Style.current.smallPadding
                 onClicked: walletModel.toggleAsset(symbol)


### PR DESCRIPTION
We used to set the settings as dirty only when the `saveSettings` failed, so that meant that in a best case scenario, the settings would **never** be set as dirty.

Dirty means that out local cache needs to be updated when fetching a new setting.

Apart from that, I also made the asset fetch more performant and also removed the useless parameters