### PR TITLE
fix(Chat): disable HoverHandler when profile popup or context menu ar…

### DIFF
--- a/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/CompactMessage.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/CompactMessage.qml
@@ -238,6 +238,7 @@ Item {
     }
 
     HoverHandler {
+        enabled: !messageContextMenu.opened && !profilePopupOpened
         onHoveredChanged: {
             root.isHovered = hovered;
         }

--- a/ui/app/AppLayouts/Chat/ChatLayout.qml
+++ b/ui/app/AppLayouts/Chat/ChatLayout.qml
@@ -13,6 +13,7 @@ SplitView {
 
     property alias chatColumn: chatColumn
     property bool stickersLoaded: false
+    property bool profilePopupOpened: false
 
     Connections {
         target: chatsModel.stickers
@@ -109,6 +110,7 @@ SplitView {
             popup.parentPopup = parentPopup;
         }
         popup.openPopup(profileModel.profile.pubKey !== fromAuthorParam, userNameParam, fromAuthorParam, identiconParam, textParam, nicknameParam);
+        profilePopupOpened = true
     }
 
     property Component profilePopupComponent: ProfilePopup {
@@ -118,6 +120,7 @@ SplitView {
             if(profilePopup.parentPopup){
                 profilePopup.parentPopup.close();
             }
+            profilePopupOpened = false
             destroy()
         }
     }


### PR DESCRIPTION
…e open

Alright, this is an interesting one:

As described in #1829, when the profile popup is opened within the chat view,
users are still able to click *through* the popup on message, which then puts them in
an active state.

I've done a bunch of debugging as described [here](https://github.com/status-im/status-desktop/issues/1829#issuecomment-804748148) and after doing some
further debugging, I found out that `isMessageActive` isn't really the culprit here.

What causes this effect is the `HoverHandler` that's attached to the `CompactMessage` item.
`HoverHandler` is a standard QML type that emits `hoverChanged` signals so one can do things like
applying hover effects on elements, which is exactly what we do:

```
HoverHandler {
  onHoverChanged: {
    root.isHovered = hovered  // `root` being the message item
  }
}
```

I assume we went with this handler because putting a `MouseArea` in there instead, which fills
the entire message component pretty much eliminates all existing mouse handlers attached to
other child components, such as the profile image or the username of the message, which also
open a message context menu.

It turns out that, having a `HoverHandler` as described above, actually activates it when the
user clicks with the left mouse button as well (not just on hover). That's what causes the "click-through"
effect. This can be verified by setting `acceptedButtons` to `Qt.RightButton`, basically telling
the handler that only right clicks will activate it.

I then tried using `Qt.NoButtons` instead so that no button clicks and only hovers will activate
the handler, but that didn't seem to have any effect at all. It still defaults to `Qt.LeftButton`.

So the last resort was to disable the `HoverHandler` altogether, whenever either the profile popup,
or the message context menu (for emojis etc) is open.

Unfortunately, we don't have access to the profile popup in the compact message component, because it's
detached from the component tree. Therefore, I've introduced a new property `profilePopupOpened` on
the chat layout, which we can read from instead.

Fixes #1829