### PR TITLE
Fix mentions not showing correctly

### DIFF
--- a/src/app/chat/view.nim
+++ b/src/app/chat/view.nim
@@ -176,12 +176,23 @@ QtObject:
   proc plainText(self: ChatsView, input: string): string {.slot.} =
     result = plain_text(input)
 
-  proc sendMessage*(self: ChatsView, message: string, replyTo: string, contentType: int = ContentType.Message.int, isStatusUpdate: bool = false) {.slot.} =
+  proc sendMessage*(self: ChatsView, message: string, replyTo: string, contentType: int = ContentType.Message.int, isStatusUpdate: bool = false, contactsString: string = "") {.slot.} =
     let aliasPattern = re(r"(@[A-z][a-z]+ [A-z][a-z]* [A-z][a-z]*)", flags = {reStudy, reIgnoreCase})
     let ensPattern = re(r"(@\w+(?=(\.stateofus)?\.eth))", flags = {reStudy, reIgnoreCase})
     let namePattern = re(r"(@\w+)", flags = {reStudy, reIgnoreCase})
 
-    let contacts = self.status.contacts.getContacts()
+    var contacts: seq[Profile]
+    if (contactsString == ""):
+      contacts = self.status.contacts.getContacts()
+    else:
+      let contactsJSON = parseJson(contactsString)
+      contacts = @[]
+      for contact in contactsJSON:
+        contacts.add(Profile(
+          address: contact["address"].str,
+          alias: contact["alias"].str,
+          ensName: contact["ensName"].str
+        ))
 
     let aliasMentions = findAll(message, aliasPattern)
     let ensMentions = findAll(message, ensPattern)

--- a/src/app/chat/views/message_list.nim
+++ b/src/app/chat/views/message_list.nim
@@ -220,7 +220,7 @@ QtObject:
     of "alias": result = (message.alias)
     of "localName": result = (message.localName)
     of "ensName": result = (message.ensName)
-    of "message": result = (message.text)
+    of "message": result = (self.renderBlock(message))
     of "identicon": result = (message.identicon)
     of "timestamp": result = $(message.timestamp)
     of "image": result = $(message.image)

--- a/ui/app/AppLayouts/Chat/ChatColumn.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn.qml
@@ -42,21 +42,23 @@ StackLayout {
 
 
     property var idMap: ({})
+    property var suggestionsObj: ([])
 
     function addSuggestionFromMessageList(i){
         const contactAddr = chatsModel.messageList.getMessageData(i, "publicKey");
         if(idMap[contactAddr]) return;
-        chatInput.suggestionsList.append({
-            alias: chatsModel.messageList.getMessageData(i, "alias"),
-            ensName: chatsModel.messageList.getMessageData(i, "ensName"),
-            address: contactAddr,
-            identicon: chatsModel.messageList.getMessageData(i, "identicon"),
-            localNickname: chatsModel.messageList.getMessageData(i, "localName")
-        });
+        suggestionsObj.push({
+                                alias: chatsModel.messageList.getMessageData(i, "alias"),
+                                ensName: chatsModel.messageList.getMessageData(i, "ensName"),
+                                address: contactAddr,
+                                identicon: chatsModel.messageList.getMessageData(i, "identicon"),
+                                localNickname: chatsModel.messageList.getMessageData(i, "localName")
+                            })
+        chatInput.suggestionsList.append(suggestionsObj[suggestionsObj.length - 1]);
         idMap[contactAddr] = true;
     }
 
-    function populateSuggestions(){
+    function populateSuggestions() {
         chatInput.suggestionsList.clear()
         const len = chatsModel.suggestionList.rowCount()
 
@@ -66,13 +68,16 @@ StackLayout {
             const contactAddr = chatsModel.suggestionList.rowData(i, "address");
             if(idMap[contactAddr]) continue;
             const contactIndex = profileModel.contacts.list.getContactIndexByPubkey(chatsModel.suggestionList.rowData(i, "address"));
-            chatInput.suggestionsList.append({
-                alias: chatsModel.suggestionList.rowData(i, "alias"),
-                ensName: chatsModel.suggestionList.rowData(i, "ensName"),
-                address: contactAddr,
-                identicon: profileModel.contacts.list.rowData(contactIndex, "thumbnailImage"),
-                localNickname: chatsModel.suggestionList.rowData(i, "localNickname")
-            });
+
+            suggestionsObj.push({
+                                    alias: chatsModel.suggestionList.rowData(i, "alias"),
+                                    ensName: chatsModel.suggestionList.rowData(i, "ensName"),
+                                    address: contactAddr,
+                                    identicon: profileModel.contacts.list.rowData(contactIndex, "thumbnailImage"),
+                                    localNickname: chatsModel.suggestionList.rowData(i, "localNickname")
+                                })
+
+            chatInput.suggestionsList.append(suggestionsObj[suggestionsObj.length - 1]);
             idMap[contactAddr] = true;
         }
         const len2 = chatsModel.messageList.rowCount();
@@ -322,7 +327,7 @@ StackLayout {
                     let msg = chatsModel.plainText(Emoji.deparse(chatInput.textInput.text))
                     if (msg.length > 0){
                         msg = chatInput.interpretMessage(msg)
-                        chatsModel.sendMessage(msg, chatInput.isReply ? SelectedMessage.messageId : "", Utils.isOnlyEmoji(msg) ? Constants.emojiType : Constants.messageType, false);
+                        chatsModel.sendMessage(msg, chatInput.isReply ? SelectedMessage.messageId : "", Utils.isOnlyEmoji(msg) ? Constants.emojiType : Constants.messageType, false, JSON.stringify(suggestionsObj));
                         if(event) event.accepted = true
                         sendMessageSound.stop();
                         Qt.callLater(sendMessageSound.play);

--- a/ui/app/AppLayouts/Chat/ChatColumn.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn.qml
@@ -86,7 +86,6 @@ StackLayout {
         }
     }
 
-
     function showReplyArea() {
         isReply = true;
         isImage = false;

--- a/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/ChatText.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/ChatText.qml
@@ -74,41 +74,7 @@ Item {
             if(isEmoji) {
                 return Emoji.parse(msg, Emoji.size.middle);
             } else {
-                return `<style type="text/css">` +
-                            `p, img, a, del, code, blockquote { margin: 0; padding: 0; }` +
-                            `code {` +
-                                `background-color: ${Style.current.codeBackground};` +
-                                `color: ${Style.current.white};` +
-                                `white-space: pre;` +
-                            `}` +
-                            `p {` +
-                                `line-height: 22px;` +
-                            `}` +
-                            `a {` +
-                                `color: ${isCurrentUser && !appSettings.useCompactMode ? Style.current.white : Style.current.textColor};` +
-                            `}` +
-                            `a.mention {` +
-                                `color: ${Style.current.mentionColor};` +
-                                `background-color: ${Style.current.mentionBgColor};` +
-                                `text-decoration: none;` +
-                            `}` +
-                            `del {` +
-                                `text-decoration: line-through;` +
-                            `}` +
-                            `table.blockquote td {` +
-                                `padding-left: 10px;` +
-                                `color: ${isCurrentUser ? Style.current.chatReplyCurrentUser : Style.current.secondaryText};` +
-                            `}` +
-                            `table.blockquote td.quoteline {` +
-                                `background-color: ${isCurrentUser ? Style.current.chatReplyCurrentUser : Style.current.secondaryText};` +
-                                `height: 100%;` +
-                                `padding-left: 0;` +
-                            `}` +
-                            `.emoji {` +
-                                `vertical-align: bottom;` +
-                            `}` +
-                        `</style>` +
-                        `${Emoji.parse(msg)}`
+                return Utils.getMessageWithStyle(Emoji.parse(msg), appSettings.useCompactMode, isCurrentUser)
             }
         }
     }

--- a/ui/app/AppLayouts/Timeline/TimelineLayout.qml
+++ b/ui/app/AppLayouts/Timeline/TimelineLayout.qml
@@ -82,7 +82,7 @@ ScrollView {
                 var msg = chatsModel.plainText(Emoji.deparse(statusUpdateInput.textInput.text))
                 if (msg.length > 0){
                     msg = statusUpdateInput.interpretMessage(msg)
-                    chatsModel.sendMessage(msg, "", Utils.isOnlyEmoji(msg) ? Constants.emojiType : Constants.messageType, true);
+                    chatsModel.sendMessage(msg, "", Utils.isOnlyEmoji(msg) ? Constants.emojiType : Constants.messageType, true, "");
                     statusUpdateInput.textInput.text = "";
                     if(event) event.accepted = true
                     statusUpdateInput.messageSound.stop()

--- a/ui/imports/Utils.qml
+++ b/ui/imports/Utils.qml
@@ -49,6 +49,44 @@ QtObject {
         return Style.current.accountColors[colorIndex]
     }
 
+    function getMessageWithStyle(msg, useCompactMode, isCurrentUser) {
+        return `<style type="text/css">` +
+                    `p, img, a, del, code, blockquote { margin: 0; padding: 0; }` +
+                    `code {` +
+                        `background-color: ${Style.current.codeBackground};` +
+                        `color: ${Style.current.white};` +
+                        `white-space: pre;` +
+                    `}` +
+                    `p {` +
+                        `line-height: 22px;` +
+                    `}` +
+                    `a {` +
+                        `color: ${isCurrentUser && !useCompactMode ? Style.current.white : Style.current.textColor};` +
+                    `}` +
+                    `a.mention {` +
+                        `color: ${Style.current.mentionColor};` +
+                        `background-color: ${Style.current.mentionBgColor};` +
+                        `text-decoration: none;` +
+                    `}` +
+                    `del {` +
+                        `text-decoration: line-through;` +
+                    `}` +
+                    `table.blockquote td {` +
+                        `padding-left: 10px;` +
+                        `color: ${isCurrentUser ? Style.current.chatReplyCurrentUser : Style.current.secondaryText};` +
+                    `}` +
+                    `table.blockquote td.quoteline {` +
+                        `background-color: ${isCurrentUser ? Style.current.chatReplyCurrentUser : Style.current.secondaryText};` +
+                        `height: 100%;` +
+                        `padding-left: 0;` +
+                    `}` +
+                    `.emoji {` +
+                        `vertical-align: bottom;` +
+                    `}` +
+                `</style>` +
+                `${msg}`
+    }
+
     function getAppSectionIndex(section) {
         let sectionId = -1
         switch (section) {

--- a/ui/shared/status/StatusChatInput.qml
+++ b/ui/shared/status/StatusChatInput.qml
@@ -78,7 +78,7 @@ Rectangle {
         messageInputField.insert(start, text.replace(/\n/g, "<br/>"));
     }
 
-    property var interpretMessage: function (msg)  {
+    property var interpretMessage: function (msg) {
         if (msg.startsWith("/shrug")) {
             return  msg.replace("/shrug", "") + " ¯\\\\\\_(ツ)\\_/¯"
         }

--- a/ui/shared/status/StatusChatInputReplyArea.qml
+++ b/ui/shared/status/StatusChatInputReplyArea.qml
@@ -38,21 +38,26 @@ Rectangle {
         font.weight: Font.Medium
     }
 
-    StyledText {
-        id: replyText
-        text: Emoji.parse(message)
+    Rectangle {
         anchors.left: replyToUsername.left
         anchors.top: replyToUsername.bottom
-        anchors.topMargin: 2
+        anchors.topMargin: -3
         anchors.right: parent.right
         anchors.rightMargin: Style.current.padding
         anchors.bottom: parent.bottom
-        elide: Text.ElideRight
-        font.pixelSize: 13
-        font.weight: Font.Normal
-        // Eliding only works for PlainText: https://bugreports.qt.io/browse/QTBUG-16567
-        textFormat: Text.PlainText
-        color: Style.current.textColor
+        clip: true
+        color: Style.current.transparent
+
+        StyledText {
+            id: replyText
+            text: Utils.getMessageWithStyle(Utils.linkifyAndXSS(Emoji.parse(message)), appSettings.useCompactMode, false)
+            anchors.fill: parent
+            elide: Text.ElideRight
+            font.pixelSize: 13
+            font.weight: Font.Normal
+            textFormat: Text.RichText
+            color: Style.current.textColor
+        }
     }
 
     RoundButton {


### PR DESCRIPTION
Fixes #2016
Fixes #2088

Fixes the bug where three word names didn't work for some users. The problem was that we added a new way to get suggestions, since contacts are not reliable. that new way involved parsing the messages to get all the users, but in the Nim side, we didn't have that same list of contacts, so when we matched the name with our list, it didn't find it.
To fix it, I now pass the list we created in QML to Nim so that it can use it, but I made it optional, so that the status update send works too.

The other bug was that mentions showed as the pubkey in the mention  text. I fixed it by rendering the message correctly using the data function, also I now show the style and use RichText. It disables the use of Elide because of a QT bug, but I hide the excess so it doesn't look too bad and having the style is worth it

![image](https://user-images.githubusercontent.com/11926403/112198686-c2626f00-8be3-11eb-95c8-008bb5548774.png)
