### PR TITLE
fix: increase min width to alleviate overlaps

### DIFF
--- a/ui/main.qml
+++ b/ui/main.qml
@@ -23,7 +23,7 @@ ApplicationWindow {
     Universal.theme: Universal.System
 
     id: applicationWindow
-    minimumWidth: 800
+    minimumWidth: 1280
     minimumHeight: 600
     width: 1232
     height: 770


### PR DESCRIPTION
increase min width to 1280px so as to fix #1918
(1024px still has overlap issues)

![2021-03-24-115838_1282x321_scrot](https://user-images.githubusercontent.com/58890963/112291148-889f7000-8c98-11eb-968d-a5ea2e6a6086.png)

