### PR TITLE
fix(Timeline): remove "fetch more" fake message

### DIFF
--- a/src/app/chat/views/message_list.nim
+++ b/src/app/chat/views/message_list.nim
@@ -69,13 +69,13 @@ QtObject:
     result.chatId = chatId
 
   proc addFakeMessages*(self: ChatMessageList) =
+    self.messages.add(self.fetchMoreMessagesButton())
     self.messages.add(self.chatIdentifier(self.id))
 
   proc newChatMessageList*(chatId: string, status: Status, addFakeMessages: bool = true): ChatMessageList =
     new(result, delete)
     result.messages = @[]
     result.id = chatId
-    result.messages.add(result.fetchMoreMessagesButton())
 
     if addFakeMessages:
       result.addFakeMessages()
@@ -252,7 +252,6 @@ QtObject:
     self.messages = @[]
     if (addFakeMessages):
       self.addFakeMessages()
-    self.messages.add(self.fetchMoreMessagesButton())
     self.endResetModel()
 
   proc setMessageReactions*(self: ChatMessageList, messageId: string, newReactions: string)=


### PR DESCRIPTION
Two fake messages are usually added to chat message lists inside a channel or
chat:

- One that imitates a chat identifier
- one that creates a button to fetch older messages

These two fake messages are added so it's ensured they show up at the beginning
of the chat.

The status timeline is also just a list of messages (filtered by a certain message
type), however there's no need to render these fake messages in this scenario.
That's why a `addFakeMessages` flag has been introduced which conditionally adds
those fake messages here: https://github.com/status-im/status-desktop/commit/3f012dbf0#diff-6aa545137319516beb03623bc6a9750e1d14a40c68d8868b5a672320fc4d680aR69

At some point, possibly around here (https://github.com/status-im/status-desktop/commit/8ee5abe57), the fake message for
the fetch more button has been reintroduced as default fake message.

This commit puts it back into the function so that it doesn't show up
inside the timeline view.