### PR TITLE
fix: custom token validation for non-token addresses

### DIFF
--- a/ui/app/AppLayouts/Wallet/AddCustomTokenModal.qml
+++ b/ui/app/AppLayouts/Wallet/AddCustomTokenModal.qml
@@ -67,13 +67,17 @@ ModalPopup {
             target: walletModel.customTokenList
             onTokenDetailsWereResolved: {
                 const jsonObj = JSON.parse(tokenDetails)
-                if(jsonObj.name === "" || jsonObj.symbol === "" || jsonObj.decimals === ""){
+                if (jsonObj.error) {
+                    validationError = jsonObj.error
+                    return
+                }
+                if (jsonObj.name === "" && jsonObj.symbol === "" && jsonObj.decimals === "") {
                     //% "Invalid ERC20 address"
                     validationError = qsTrId("invalid-erc20-address")
                     return;
                 }
 
-                if(addressInput.text.toLowerCase() === jsonObj.address.toLowerCase()){
+                if (addressInput.text.toLowerCase() === jsonObj.address.toLowerCase()) {
                     symbolInput.text = jsonObj.symbol;
                     decimalsInput.text = jsonObj.decimals;
                     nameInput.text = jsonObj.name;

--- a/ui/shared/Input.qml
+++ b/ui/shared/Input.qml
@@ -179,7 +179,8 @@ Item {
         font.pixelSize: 12
         height: 16
         color: Style.current.danger
-        width: parent.width
+        width: inputRectangle.width
+        wrapMode: TextEdit.Wrap
     }
 }
 


### PR DESCRIPTION
Fixes: #2036.

When contract addresses that are not ERC-20 or ERC-721 were input, the token would be allowed to be added and would crash the app.

In addition, when an ERC-20 contract was deployed without a name and symbol, “Invalid ERC-20 address” would appear.

This PR adds error checking from the token detail lookup and reports the error back to the user in the modal. This prevents non-ERC-20/721 contracts from being able to be added to the app and prevents a crash.

Here you can see the error message when attempting to add the SimpleStorage contract as a custom token:
![Imgur](https://imgur.com/y7sIoUY.png)