### PR TITLE
fix(Wallet): prevent signing phrase from leaking out of modal

### DIFF
--- a/ui/app/AppLayouts/Wallet/SignPhraseModal.qml
+++ b/ui/app/AppLayouts/Wallet/SignPhraseModal.qml
@@ -15,6 +15,8 @@ ModalPopup {
 
     Column {
         anchors.horizontalCenter: parent.horizontalCenter
+        anchors.left: parent.left
+        anchors.right: parent.right
 
         StyledText {
             anchors.horizontalCenter: parent.horizontalCenter
@@ -40,8 +42,7 @@ ModalPopup {
         Rectangle {
             color: Style.current.inputBackground
             height: 44
-            width: signPhrasePopup.width
-            anchors.left: signPhrasePopup.left
+            width: parent.width
             StyledText {
                 id: signingPhrase
                 anchors.horizontalCenter: parent.horizontalCenter
@@ -71,6 +72,7 @@ ModalPopup {
             text: qsTrId("three-words-description-2")
             verticalAlignment: Text.AlignVCenter
             horizontalAlignment: Text.AlignHCenter
+            width: parent.width
             font.pixelSize: 13
             height: 18
             color: Style.current.danger


### PR DESCRIPTION
This is what it looks like right now:
<img width="804" alt="Screenshot 2021-03-25 at 10 23 08" src="https://user-images.githubusercontent.com/445106/112451416-c3b3a900-8d55-11eb-872a-659d7fee6d76.png">
