### PR TITLE
fix: enforce locale provided by appSettings

### DIFF
--- a/ui/app/AppMain.qml
+++ b/ui/app/AppMain.qml
@@ -150,9 +150,7 @@ RowLayout {
     Connections {
         target: profileModel
         onProfileSettingsFileChanged: {
-            if (appSettings.locale !== "en") {
-                profileModel.changeLocale(appSettings.locale)
-            }
+            profileModel.changeLocale(appSettings.locale)
 
             // Since https://github.com/status-im/status-desktop/commit/93668ff75
             // we're hiding the setting to change appearance for compact normal mode


### PR DESCRIPTION
Prior to this commit, we would only set the translation package for the
application's engine when `appSettings.locale !== "en"`.

This is problematic because it seems that `engine` is already provided with
a system default that may not be `en`. In practice, this means that, initially,
engine is loaded with, say `de`. `appSettings.locale` might be `en` but because
we're only loading the correct translation package when it's **not** `en`,
the application will stay in `de`.

Changing the language to `en` at runtime is fine, however once the application
is restarted, `engine` is again initialized with some other possible system default.

It seems that we should *always* load the translation packge when `appSettings` are
loaded.