### PR TITLE
fix: fix unable to write to invite only community channels

### DIFF
--- a/src/app/chat/views/chat_item.nim
+++ b/src/app/chat/views/chat_item.nim
@@ -133,6 +133,11 @@ QtObject:
   QtProperty[bool] hasMentions:
     read = hasMentions
 
+  proc canPost*(self: ChatItemView): bool {.slot.} = result = ?.self.chatItem.canPost
+
+  QtProperty[bool] canPost:
+    read = canPost
+
   proc isMember*(self: ChatItemView): bool {.slot.} =
     if self.chatItem.isNil: return false
     let pubKey = status_settings.getSetting[string](Setting.PublicKey, "0x0")


### PR DESCRIPTION
This was caused by the fact that the canPost property was not exposed from the ChatItem model.
I'm actually not sure why it didn't show an error trying to call  a function that doesn't exist