### PR TITLE
CI - Lower number of artifacts kept

### DIFF
--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -18,6 +18,7 @@ pipeline {
     buildDiscarder(logRotator(
       numToKeepStr: '10',
       daysToKeepStr: '30',
+      artifactNumToKeepStr: '3',
     ))
   }
 

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -13,6 +13,7 @@ pipeline {
     buildDiscarder(logRotator(
       numToKeepStr: '10',
       daysToKeepStr: '30',
+      artifactNumToKeepStr: '3',
     ))
   }
 

--- a/ci/Jenkinsfile.windows
+++ b/ci/Jenkinsfile.windows
@@ -11,6 +11,7 @@ pipeline {
     buildDiscarder(logRotator(
       numToKeepStr: '10',
       daysToKeepStr: '30',
+      artifactNumToKeepStr: '3',
     ))
   }
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-# Nim-status-client
+# Status-desktop
 
 Desktop client for the [Status Network](https://statusnetwork.com/) built with [Nim](https://nim-lang.org/) and [Qt](https://www.qt.io/)
 


### PR DESCRIPTION
Desktop build artifacts are taking up far too much space.

Also, noticead that `README.md` title is outdated.