### PR TITLE
fix: fix community button staying active when clicking on a new section

### DIFF
--- a/ui/shared/status/StatusIconTabButton.qml
+++ b/ui/shared/status/StatusIconTabButton.qml
@@ -27,6 +27,7 @@ TabButton {
             return
         }
 
+        chatsModel.communities.activeCommunity.active = false
         appMain.changeAppSection(section)
     }
 


### PR DESCRIPTION
Fixes #2133