### PR TITLE
fix: fix sticker click modal to only open on sticker click

### DIFF
--- a/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/CompactMessage.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/CompactMessage.qml
@@ -24,8 +24,8 @@ Item {
     MouseArea {
         enabled: !placeholderMessage
         anchors.fill: messageContainer
-        acceptedButtons: Qt.LeftButton | Qt.RightButton
-        onClicked:  messageMouseArea.clicked(mouse)
+        acceptedButtons: Qt.RightButton
+        onClicked: messageMouseArea.clicked(mouse)
     }
 
     ChatButtons {

--- a/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/MessageMouseArea.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/MessageMouseArea.qml
@@ -15,7 +15,11 @@ MouseArea {
             }
             return;
         }
-        if (mouse.button & Qt.LeftButton && isSticker && stickersLoaded) {
+        if (mouse.button === Qt.LeftButton && isSticker && stickersLoaded) {
+            if (isHovered) {
+                isHovered = false
+            }
+            
             openPopup(statusStickerPackClickPopup, {packId: stickerPackId} )
             return;
         }


### PR DESCRIPTION
Fixes #2126

I was not able to reproduce the wrong sticker shown, but I changed the conditions to be more restrictive, so hopefully, it should not happen again.