### PR TITLE
fix: fix scroll speed on Windows

### DIFF
--- a/src/app/utilsView/view.nim
+++ b/src/app/utilsView/view.nim
@@ -33,6 +33,15 @@ QtObject:
   proc getDataDir*(self: UtilsView): string {.slot.} =
     result = accountConstants.DATADIR
 
+  proc getOs*(self: UtilsView): string {.slot.} =
+    if defined(windows):
+      return "windows"
+    elif (defined(macosx)):
+      return "mac"
+    elif (defined(linux)):
+      return "linux"
+    return "unknown"
+
   proc joinPath*(self: UtilsView, start: string, ending: string): string {.slot.} =
     result = os.joinPath(start, ending)
 

--- a/ui/app/AppLayouts/Chat/ChatColumn/ChatMessages.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/ChatMessages.qml
@@ -37,7 +37,12 @@ ScrollView {
         anchors.bottomMargin: Style.current.bigPadding
         spacing: appSettings.useCompactMode ? 0 : 4
         boundsBehavior: Flickable.StopAtBounds
-        flickDeceleration: 10000
+        flickDeceleration: {
+            if (utilsModel.getOs() === Constants.windows) {
+                return 5000
+            }
+            return 10000
+        }
         Layout.fillWidth: true
         Layout.fillHeight: true
         verticalLayoutDirection: ListView.BottomToTop

--- a/ui/imports/Constants.qml
+++ b/ui/imports/Constants.qml
@@ -67,6 +67,10 @@ QtObject {
     readonly property string seedWalletType: "seed"
     readonly property string generatedWalletType: "generated"
 
+    readonly property string windows: "windows"
+    readonly property string linux: "linux"
+    readonly property string mac: "mac"
+
     // Transaction states
     readonly property int addressRequested: 1
     readonly property int declined: 2


### PR DESCRIPTION
Fixes #2121

Makes the scroll twice as fast as before on Windows. It's also possible to customize the other OSes.

Let me know if it's too fast or still too slow @johnlea-quiup 