### PR TITLE
Add chat key, search and ENS field to the community invite

### DIFF
--- a/ui/app/AppLayouts/Chat/components/PrivateChatPopup.qml
+++ b/ui/app/AppLayouts/Chat/components/PrivateChatPopup.qml
@@ -7,68 +7,13 @@ import "../../../../shared/status"
 import "./"
 
 ModalPopup {
-    property string validationError: ""
-
-    property string pubKey : "";
-    property string ensUsername : "";
-
-    function validate() {
-        if (!Utils.isChatKey(chatKey.text) && !Utils.isValidETHNamePrefix(chatKey.text)) {
-            //% "Enter a valid chat key or ENS username"
-            validationError = qsTrId("enter-a-valid-chat-key-or-ens-username");
-            pubKey = ""
-            ensUsername.text = "";
-        } else if (profileModel.profile.pubKey === chatKey.text) {
-            //% "Can't chat with yourself"
-            validationError = qsTrId("can-t-chat-with-yourself");
-        } else {
-            validationError = ""
-        }
-        return validationError === ""
-    }
-
-    property var resolveENS: Backpressure.debounce(popup, 500, function (ensName){
-        noContactsRect.visible = false
-        searchResults.loading = true
-        searchResults.showProfileNotFoundMessage = false
-        chatsModel.resolveENS(ensName)
-    });
-
-    function onKeyReleased(){
-        searchResults.pubKey = ""
-        if (!validate()) {
-            searchResults.showProfileNotFoundMessage = false
-            noContactsRect.visible = false
-            return;
-        }
-
-        chatKey.text = chatKey.text.trim();
-        
-        if (Utils.isChatKey(chatKey.text)){
-            pubKey = chatKey.text;
-            if (!profileModel.contacts.isAdded(pubKey)) {
-                searchResults.username = utilsModel.generateAlias(pubKey)
-                searchResults.userAlias = Utils.compactAddress(pubKey, 4)
-                searchResults.pubKey = pubKey
-            }
-            noContactsRect.visible = false
-            return;
-        }
-        
-        Qt.callLater(resolveENS, chatKey.text)
-    }
-
-    function validateAndJoin(pk, ensName) {
-        if (!validate() || pk.trim() === "" || validationError !== "") return;
-        doJoin(pk, ensName)
-    }
     function doJoin(pk, ensName) {
         if(Utils.isChatKey(pk)){
             chatsModel.joinChat(pk, Constants.chatTypeOneToOne);
         } else {
             chatsModel.joinChatWithENS(pk, ensName);
         }
-            
+
         popup.close();
     }
 
@@ -77,116 +22,28 @@ ModalPopup {
     title: qsTrId("new-chat")
 
     onOpened: {
-        chatKey.text = "";
-        pubKey = "";
-        ensUsername.text = "";
-        chatKey.forceActiveFocus(Qt.MouseFocusReason)
-        existingContacts.visible = profileModel.contacts.list.hasAddedContacts()
-        noContactsRect.visible = !existingContacts.visible
+        contactFieldAndList.chatKey.text = ""
+        contactFieldAndList.pubKey = ""
+        contactFieldAndList.ensUsername = ""
+        contactFieldAndList.chatKey.forceActiveFocus(Qt.MouseFocusReason)
+        contactFieldAndList.existingContacts.visible = profileModel.contacts.list.hasAddedContacts()
+        contactFieldAndList.noContactsRect.visible = !contactFieldAndList.existingContacts.visible
     }
 
-    Input {
-        id: chatKey
-        //% "Enter ENS username or chat key"
-        placeholderText: qsTrId("enter-contact-code")
-        Keys.onEnterPressed: validateAndJoin(popup.pubKey, chatKey.text)
-        Keys.onReturnPressed: validateAndJoin(popup.pubKey, chatKey.text)
-        Keys.onReleased: {
-            onKeyReleased();
-        }
-        textField.anchors.rightMargin: clearBtn.width + Style.current.padding + 2
-
-        Connections {
-            target: chatsModel
-            onEnsWasResolved: {
-                if(chatKey.text == ""){
-                    ensUsername.text = "";
-                    pubKey = "";
-                } else if(resolvedPubKey == ""){
-                    ensUsername.text = "";
-                    searchResults.pubKey = pubKey = "";
-                    searchResults.showProfileNotFoundMessage = true
-                } else {
-                    if (profileModel.profile.pubKey === resolvedPubKey) {
-                        //% "Can't chat with yourself"
-                        popup.validationError = qsTrId("can-t-chat-with-yourself");
-                    } else {
-                        searchResults.username = chatsModel.formatENSUsername(chatKey.text)
-                        let userAlias = utilsModel.generateAlias(resolvedPubKey)
-                        userAlias = userAlias.length > 20 ? userAlias.substring(0, 19) + "..." : userAlias
-                        searchResults.userAlias =  userAlias + " • " + Utils.compactAddress(resolvedPubKey, 4)
-                        searchResults.pubKey = pubKey = resolvedPubKey;
-                    }
-                    searchResults.showProfileNotFoundMessage = false
-                }
-                searchResults.loading = false;
-                noContactsRect.visible = pubKey === ""  && ensUsername.text === "" && !profileModel.contacts.list.hasAddedContacts() && !profileNotFoundMessage.visible
+    ContactsListAndSearch {
+        id: contactFieldAndList
+        anchors.top: parent.top
+        anchors.bottom: parent.bottom
+        onUserClicked: function (isContact, pubKey, ensName) {
+            if(Utils.isChatKey(pubKey)){
+                chatsModel.joinChat(pubKey, Constants.chatTypeOneToOne);
+            } else {
+                chatsModel.joinChatWithENS(pubKey, ensName);
             }
-        }
 
-        StatusIconButton {
-            id: clearBtn
-            icon.name: "close-icon"
-            type: "secondary"
-            visible: chatKey.text !== ""
-            icon.width: 14
-            icon.height: 14
-            width: 14
-            height: 14
-            anchors.right: parent.right
-            anchors.rightMargin: Style.current.padding
-            anchors.verticalCenter: parent.verticalCenter
-            onClicked: {
-                chatKey.text = ""
-                chatKey.forceActiveFocus(Qt.MouseFocusReason)
-                searchResults.showProfileNotFoundMessage = false
-                searchResults.pubKey = popup.pubKey = ""
-                noContactsRect.visible = false
-            }
+            popup.close();
         }
     }
-
-    StyledText {
-        id: validationErrorMessage
-        text: popup.validationError
-        visible: popup.validationError !== ""
-        font.pixelSize: 13
-        color: Style.current.danger
-        anchors.top: chatKey.bottom
-        anchors.topMargin: Style.current.smallPadding
-        anchors.horizontalCenter: parent.horizontalCenter
-    }
-
-    ExistingContacts {
-        id: existingContacts
-        anchors.topMargin: this.height > 0 ? Style.current.xlPadding : 0
-        anchors.top: chatKey.bottom
-        filterText: chatKey.text
-        onContactClicked: function (contact) {
-            doJoin(contact.pubKey, profileModel.contacts.addedContacts.userName(contact.pubKey, contact.name))
-        }
-        expanded: !searchResults.loading && popup.pubKey === "" && !searchResults.showProfileNotFoundMessage
-    }
-
-    SearchResults {
-        id: searchResults
-        anchors.top: existingContacts.visible ? existingContacts.bottom : chatKey.bottom
-        anchors.topMargin: Style.current.padding
-        hasExistingContacts: existingContacts.visible
-        loading: false
-
-        onResultClicked: validateAndJoin(popup.pubKey, chatKey.text)
-        onAddToContactsButtonClicked: profileModel.contacts.addContact(popup.pubKey)
-    }
-
-    NoFriendsRectangle {
-        id: noContactsRect
-        anchors.top: chatKey.bottom
-        anchors.topMargin: Style.current.xlPadding * 3
-        anchors.horizontalCenter: parent.horizontalCenter
-        anchors.verticalCenter: parent.verticalCenter
-    }
-
 }
 
 /*##^##

--- a/ui/app/AppLayouts/Chat/components/qmldir
+++ b/ui/app/AppLayouts/Chat/components/qmldir
@@ -9,6 +9,5 @@ GroupChatPopup 1.0 GroupChatPopup.qml
 StickerButton 1.0 StickerButton.qml
 StickerMarket 1.0 StickerMarket.qml
 StickersPopup 1.0 StickersPopup.qml
-InviteFriendsPopup 1.0 InviteFriendsPopup.qml
 StickerPackIconWithIndicator 1.0 StickerPackIconWithIndicator.qml
 SuggestedChannels 1.0 SuggestedChannels.qml

--- a/ui/app/AppLayouts/Profile/Sections/ContactsContainer.qml
+++ b/ui/app/AppLayouts/Profile/Sections/ContactsContainer.qml
@@ -4,7 +4,6 @@ import QtQuick.Layouts 1.13
 import "../../../../imports"
 import "../../../../shared"
 import "../../../../shared/status"
-import "../../Chat/components"
 import "./Contacts"
 
 Item {
@@ -195,7 +194,7 @@ Item {
                 anchors.horizontalCenter: parent.horizontalCenter
             }
 
-            PrivateChatPopupSearchResults {
+            SearchResults {
                 id: searchResults
                 anchors.top: addContactSearchInput.bottom
                 anchors.topMargin: Style.current.xlPadding

--- a/ui/nim-status-client.pro
+++ b/ui/nim-status-client.pro
@@ -364,6 +364,7 @@ DISTFILES += \
     shared/AccountSelector.qml \
     shared/AddButton.qml \
     shared/Address.qml \
+    shared/ContactsListAndSearch.qml \
     shared/CropCornerRectangle.qml \
     shared/DelegateModelGeneralized.qml \
     shared/FormGroup.qml \

--- a/ui/shared/ExistingContacts.qml
+++ b/ui/shared/ExistingContacts.qml
@@ -1,10 +1,11 @@
 import QtQuick 2.13
 import QtQuick.Controls 2.13
 import QtQuick.Layouts 1.13
-import "../../../../imports"
-import "../../../../shared"
-import "../../../../shared/status"
-import "./"
+import "../imports"
+import "./status"
+// TODO move Contact into shared to get rid of that import
+import "../app/AppLayouts/Chat/components"
+import "."
 
 Item {
     id: root
@@ -12,6 +13,8 @@ Item {
     anchors.right: parent.right
     property string filterText: ""
     property bool expanded: true
+    property bool showCheckbox: false
+    property var pubKeys: ([])
     signal contactClicked(var contact)
 
     function matchesAlias(name, filter) {
@@ -33,7 +36,8 @@ Item {
             id: contactListView
             model: profileModel.contacts.list
             delegate: Contact {
-                showCheckbox: false
+                showCheckbox: root.showCheckbox
+                isChecked: root.pubKeys.indexOf(model.pubKey) > -1
                 pubKey: model.pubKey
                 isContact: model.isContact
                 isUser: false
@@ -50,7 +54,6 @@ Item {
             }
         }
     }
-
 }
 
 

--- a/ui/shared/InviteFriendsPopup.qml
+++ b/ui/shared/InviteFriendsPopup.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.12
 import QtQuick.Controls 2.3
-import "../../../../imports"
-import "../../../../shared"
+import "../imports"
+import "."
 
 ModalPopup {
     id: popup

--- a/ui/shared/NoFriendsRectangle.qml
+++ b/ui/shared/NoFriendsRectangle.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.13
-import "../../../../imports"
-import "../../../../shared"
-import "../../../../shared/status"
+import "../imports"
+import "."
+import "./status"
 
 Item {
     id: noContactsRect

--- a/ui/shared/SearchResults.qml
+++ b/ui/shared/SearchResults.qml
@@ -1,9 +1,10 @@
 import QtQuick 2.13
 import QtQuick.Controls 2.13
 import QtQuick.Layouts 1.13
-import "../../../../imports"
-import "../../../../shared"
-import "../../../../shared/status"
+import "../imports"
+import "./status"
+// TODO move Contact into shared to get rid of that import
+import "../app/AppLayouts/Chat/components"
 import "./"
 
 


### PR DESCRIPTION
Fixes #2138 

I did so by extracting the Start a new chat (one on one) field and components to a shared component.  That way, there is close to no duplication.

![image](https://user-images.githubusercontent.com/11926403/113200045-ddf9f500-9235-11eb-98e8-003ab86fc562.png)
