### PR TITLE
fix: ens search hang

### DIFF
--- a/src/app/chat/view.nim
+++ b/src/app/chat/view.nim
@@ -84,12 +84,12 @@ proc asyncMessageLoad[T](self: T, slot: string, chatId: string) =
 const resolveEnsTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
   let
     arg = decode[ResolveEnsTaskArg](argEncoded)
-    result = status_ens.pubkey(arg.ens)
-  arg.finish(result)
+    output = status_ens.pubkey(arg.ens)
+  arg.finish(output)
 
 proc resolveEns[T](self: T, slot: string, ens: string) =
   let arg = ResolveEnsTaskArg(
-    tptr: cast[ByteAddress](asyncMessageLoadTask),
+    tptr: cast[ByteAddress](resolveEnsTask),
     vptr: cast[ByteAddress](self.vptr),
     slot: slot,
     ens: ens


### PR DESCRIPTION
ENS search was executed in a task runner task. The task had a mistake during the copy/paste port from spawnAndSend.