### PR TITLE
fix: create community and channel name validation

### DIFF
--- a/ui/shared/ImageCropper.qml
+++ b/ui/shared/ImageCropper.qml
@@ -3,7 +3,8 @@ import "."
 import "../imports"
 
 Item {
-    property var image
+    id: root
+    property Image image
     property alias selectorRectangle: selectorRectangle
     property string ratio: ""
     property var splitRatio: !!ratio ? ratio.split(":") : null
@@ -11,6 +12,7 @@ Item {
     property int heightRatio: !!ratio ? parseInt(splitRatio[1]) : -1
     property bool settingCorners: false
     property int draggedCorner: 0
+    property bool ready: false
 
     readonly property int topLeft: 0
     readonly property int topRight: 1
@@ -96,6 +98,7 @@ Item {
                 if (image.status === Image.Ready) {
                     selectorRectangle.initialSetup()
                     selectorRectangle.visible = true
+                    root.ready = true
                 }
             }
         }

--- a/ui/shared/ImageCropperModal.qml
+++ b/ui/shared/ImageCropperModal.qml
@@ -6,7 +6,11 @@ import "./status"
 
 ModalPopup {
     property string selectedImage
-    property string ratio
+    property string ratio: "1:1"
+    property int aX: 0
+    property int aY: 0
+    property int bX: 0
+    property int bY: 0
     signal cropFinished(aX: int, aY: int, bX: int, bY: int)
 
     id: cropImageModal
@@ -29,6 +33,28 @@ ModalPopup {
         y: image.y
         image: image
         ratio: cropImageModal.ratio
+        onReadyChanged: {
+            if (ready) {
+                // cropImageModal.calculateCrop()
+                cropImageModal.aX = Qt.binding(function() {
+                    const aXPercent = imageCropper.selectorRectangle.x / image.width
+                    return Math.round(aXPercent * image.sourceSize.width)
+                })
+                cropImageModal.aY = Qt.binding(function() {
+                    const aYPercent = imageCropper.selectorRectangle.y / image.height
+                    return Math.round(aYPercent * image.sourceSize.height)
+                })
+                cropImageModal.bX = Qt.binding(function() {
+                    const bXPercent = (imageCropper.selectorRectangle.x + imageCropper.selectorRectangle.width) / image.width
+                    return Math.round(bXPercent * image.sourceSize.width)
+                })
+                cropImageModal.bY = Qt.binding(function() {
+                    const bYPercent = (imageCropper.selectorRectangle.y + imageCropper.selectorRectangle.height) / image.height
+                    return Math.round(bYPercent * image.sourceSize.height)
+                })
+            }
+        }
+
     }
 
     footer: StatusButton {


### PR DESCRIPTION
Fixes #2050.

This PR contains changes to fix the name validation for new communities and new channels in communities. In the process of updating this, better validation was also added to both popups (create community and create channel), including the prevention of the "Create" button from being enabled until all form fields were valid.

During this process, it was noticed that the community image cropper was not actually cropping the image *in the preview*. Once the community was created, status-go was successfully cropping the image as the user intended. However, the preview thumbnail prior to creation was not accurately showing the cropped image preview and showing the entire image centred instead. *This is still yet to be fixed.* One solution is to upgrade Qt to `5.15` to take advantage of Image QML's `sourceClipRect`.

~~This was quite a mind-bending task because there is a thumbnail image which is 128x128px, the original image, and a scaled version of the original image used in the ImageCropper component. Shrinking and moving the portion that is cropped should result in the thumbnail version being enlarged and moved to match. The enlargement should be an inverse proportion of the image cropper rectangle to image size, and the x/y movements should be the inverse of the x/y movement of the image cropper rectangle, also in the same proportion.~~

~~I got *very very* close to getting this work, but i'm the point where need to get some help (maybe @jrainville? @PascalPrecht?), or we upgrade to Qt 5.15 to take advantage of Image QML's `sourceClipRect` which is exactly we need. An alternative solution is to just leave it as it was because it wasn't working in the first place.~~

~~Please try not to get angry at the very dirty state it's in! It needs a massive cleanup!~~

~~Any help here would be greatly appreciated!~~