### PR TITLE
fix: show formation menu in middle of selection or above double click

### DIFF
--- a/ui/shared/status/StatusChatInput.qml
+++ b/ui/shared/status/StatusChatInput.qml
@@ -781,6 +781,8 @@ Rectangle {
             ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
 
             TextArea {
+                property var lastClick: 0
+
                 id: messageInputField
                 textFormat: Text.RichText
                 font.pixelSize: 15
@@ -803,11 +805,18 @@ Rectangle {
                 selectionColor: Style.current.primarySelectionColor
                 persistentSelection: true
                 onReleased: function (event) {
+                    const now = Date.now()
                     if (messageInputField.selectedText.trim() !== "") {
-                        let x = event.x - (textFormatMenu.width / 2)
+                        // If it's a double click, just check the mouse position
+                        // If it's a mouse select, use the start and end position average)
+                        let x = now < messageInputField.lastClick + 500 ? x = event.x :
+                                                        (messageInputField.cursorRectangle.x + event.x) / 2
+                        x -= textFormatMenu.width / 2
+
                         textFormatMenu.popup(x, -messageInputField.height-2)
                         messageInputField.forceActiveFocus();
                     }
+                    lastClick = now
                 }
 
                 StatusTextFormatMenu {


### PR DESCRIPTION
Fixes #1926

It's not possible to know the exact position of the selected text (as far as I know), so instead I either do the average of mouse start position and the final position OR in the case of  a double click, show the menu on top of the double click