### PR TITLE
fix: order joined communities from newest to oldest

### DIFF
--- a/ui/app/AppLayouts/Chat/CommunityComponents/CommunityList.qml
+++ b/ui/app/AppLayouts/Chat/CommunityComponents/CommunityList.qml
@@ -13,6 +13,7 @@ ListView {
     visible: height > 10
     width:parent.width
     interactive: false
+    verticalLayoutDirection: ListView.BottomToTop
 
     model: chatsModel.communities.joinedCommunities
     delegate: CommunityButton {

--- a/ui/app/AppMain.qml
+++ b/ui/app/AppMain.qml
@@ -390,6 +390,23 @@ RowLayout {
                 spacing: 12
                 width: scrollView.width
 
+                Loader {
+                    id: communitiesListLoader
+                    active: appSettings.communitiesEnabled
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    width: parent.width
+                    height: {
+                        if (item && active) {
+                            return item.height
+                        }
+
+                        return 0
+                    }
+                    sourceComponent: Component {
+                        CommunityList {}
+                    }
+                }
+
                 StatusIconTabButton {
                     id: chatBtn
                     icon.name: "message"
@@ -422,23 +439,6 @@ RowLayout {
                             anchors.centerIn: parent
                             text: chatsModel.unreadMessagesCount > 99 ? "99+" : chatsModel.unreadMessagesCount
                         }
-                    }
-                }
-
-                Loader {
-                    id: communitiesListLoader
-                    active: appSettings.communitiesEnabled
-                    anchors.horizontalCenter: parent.horizontalCenter
-                    width: parent.width
-                    height: {
-                        if (item && active) {
-                            return item.height
-                        }
-
-                        return 0
-                    }
-                    sourceComponent: Component {
-                        CommunityList {}
                     }
                 }
 


### PR DESCRIPTION
Fixes #2154

The communities api doesn't return the date of joining or creation, but it always returns them in order of oldest to newest, so it was only a matter of inverting the display order.

Later, we can implement drag and drop and save that order, hopefully in the DB

In this picture, the communities were created from 1 to 3
![image](https://user-images.githubusercontent.com/11926403/113913276-20797f80-97aa-11eb-87dc-7f223422a69f.png)
