### PR TITLE
fix(Communities): receive community info after community import

### DIFF
--- a/src/app/chat/signal_handling.nim
+++ b/src/app/chat/signal_handling.nim
@@ -28,6 +28,10 @@ proc handleSignals(self: ChatController) =
         let chatId = self.status.messages.messages[messageId].chatId
         self.view.messageList[chatId].checkTimeout(messageId)
 
+  self.status.events.on(SignalType.CommunityFound.event) do(e: Args):
+    var data = CommunitySignal(e)
+    self.view.communities.addCommunityToList(data.community)
+
   self.status.events.on(SignalType.MailserverRequestCompleted.event) do(e:Args):
     # TODO: if the signal contains a cursor, request additional messages
     # else: 

--- a/src/status/chat.nim
+++ b/src/status/chat.nim
@@ -461,6 +461,9 @@ proc createCommunityChannel*(self: ChatModel, communityId: string, name: string,
 proc joinCommunity*(self: ChatModel, communityId: string) =
   status_chat.joinCommunity(communityId)
 
+proc requestCommunityInfo*(self: ChatModel, communityId: string) =
+  status_chat.requestCommunityInfo(communityId)
+
 proc leaveCommunity*(self: ChatModel, communityId: string) =
   status_chat.leaveCommunity(communityId)
 

--- a/src/status/libstatus/chat.nim
+++ b/src/status/libstatus/chat.nim
@@ -314,6 +314,9 @@ proc createCommunityChannel*(communityId: string, name: string, description: str
   if rpcResult{"result"}.kind != JNull:
     result = rpcResult["result"]["chats"][0].toChat()
 
+proc requestCommunityInfo*(communityId: string) =
+  discard callPrivateRPC("requestCommunityInfoFromMailserver".prefix, %*[communityId])
+
 proc joinCommunity*(communityId: string) =
   discard callPrivateRPC("joinCommunity".prefix, %*[communityId])
 

--- a/src/status/libstatus/types.nim
+++ b/src/status/libstatus/types.nim
@@ -21,6 +21,7 @@ type SignalType* {.pure.} = enum
   SubscriptionsData = "subscriptions.data"
   SubscriptionsError = "subscriptions.error"
   WhisperFilterAdded = "whisper.filter.added"
+  CommunityFound = "community.found"
   Unknown
 
 proc event*(self:SignalType):string =

--- a/src/status/libstatus/wallet.nim
+++ b/src/status/libstatus/wallet.nim
@@ -84,7 +84,8 @@ proc validateMnemonic*(mnemonic: string): string =
   result = $status_go.validateMnemonic(mnemonic)
 
 proc startWallet*(watchNewBlocks: bool) =
-  discard status_go.startWallet(watchNewBlocks) # TODO: true  to watch trx
+  # this will be fixed in a later PR
+  discard
 
 proc hex2Token*(input: string, decimals: int): string =
   var value = fromHex(Stuint[256], input)

--- a/src/status/signals/communities.nim
+++ b/src/status/signals/communities.nim
@@ -1,0 +1,10 @@
+import json, strutils, sequtils, sugar, chronicles
+import json_serialization
+import ../libstatus/types as status_types
+import ../chat/[chat]
+import types, messages
+
+proc fromEvent*(event: JsonNode): Signal =
+  var signal: CommunitySignal = CommunitySignal()
+  signal.community = event["event"].toCommunity()
+  result = signal

--- a/src/status/signals/core.nim
+++ b/src/status/signals/core.nim
@@ -1,6 +1,6 @@
 import NimQml, tables, json, chronicles, strutils, json_serialization
 import ../libstatus/types as status_types
-import types, messages, discovery, whisperFilter, envelopes, expired, wallet, mailserver
+import types, messages, discovery, whisperFilter, envelopes, expired, wallet, mailserver, communities
 import ../status
 import ../../eventemitter
 
@@ -56,6 +56,7 @@ QtObject:
       of SignalType.DiscoverySummary: discovery.fromEvent(jsonSignal)
       of SignalType.MailserverRequestCompleted: mailserver.fromCompletedEvent(jsonSignal)
       of SignalType.MailserverRequestExpired: mailserver.fromExpiredEvent(jsonSignal)
+      of SignalType.CommunityFound: communities.fromEvent(jsonSignal)
       else: Signal()
 
     if(signalType == SignalType.NodeLogin):

--- a/src/status/signals/types.nim
+++ b/src/status/signals/types.nim
@@ -36,6 +36,9 @@ type MessageSignal* = ref object of Signal
   communities*: seq[Community]
   membershipRequests*: seq[CommunityMembershipRequest]
 
+type CommunitySignal* = ref object of Signal
+  community*: Community
+
 type MailserverRequestCompletedSignal* = ref object of Signal
   requestID*: string
   lastEnvelopeHash*: string


### PR DESCRIPTION
This commit ensures that, once a community was imported, the application
will listen to the newly introduced `community.found` signal, which will be
emitted by status-go.

The signal exposes a `Community` object that is then used to add a
community item to the community list in the UI.

**This can only land after https://github.com/status-im/status-go/pull/2177 has landed first!**

Fixes #2024