### PR TITLE
fix(Profile): ensure profile popup has window

### DIFF
--- a/ui/app/AppLayouts/Profile/Sections/Contacts/ContactList.qml
+++ b/ui/app/AppLayouts/Profile/Sections/Contacts/ContactList.qml
@@ -15,6 +15,11 @@ ListView {
     property string lowerCaseSearchString: searchString.toLowerCase()
     property string contactToRemove: ""
 
+    property Component profilePopupComponent: ProfilePopup {
+        id: profilePopup
+        onClosed: destroy()
+    }
+
     width: parent.width
 
     model: contacts
@@ -26,7 +31,10 @@ ListView {
         identicon: model.thumbnailImage || model.identicon
         isContact: model.isContact
         isBlocked: model.isBlocked
-        profileClick: profilePopup.openPopup.bind(profilePopup)
+        profileClick: function (showFooter, userName, fromAuthor, identicon, textParam, nickName) {
+            var popup = profilePopupComponent.createObject(contactList);
+            popup.openPopup(showFooter, userName, fromAuthor, identicon, textParam, nickName);
+        }
         visible: searchString === "" ||
                  model.name.toLowerCase().includes(lowerCaseSearchString) ||
                  model.address.toLowerCase().includes(lowerCaseSearchString)
@@ -39,10 +47,6 @@ ListView {
             removeContactConfirmationDialog.value = address
             removeContactConfirmationDialog.open()
         }
-    }
-
-    ProfilePopup {
-      id: profilePopup
     }
 
     // TODO: Make BlockContactConfirmationDialog a dynamic component on a future refactor


### PR DESCRIPTION
When the profile popup is opened inside the contacts list, it doesn't have
a surrounding window context (`Popup` types should usually be used within `ApplicationWindow`
or `Window` components as per https://doc.qt.io/qt-5/qml-qtquick-controls2-popup.html).

This is problematic when popup are nested, like it's the case with the
nickname popup that will be instantiated by the profile popup.
With no window context, such nested popup can't be opened by the application.

This commit ensures the profile popup is created with a proper context,
fixing the issue that the nickname popup won't open when visting via
contacts list.

Fixes #2216