### PR TITLE
CI: Add a combined Jenkinsfile for releases

### DIFF
--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -1,0 +1,1 @@
+Jenkinsfile.combined

--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -1,0 +1,63 @@
+library 'status-react-jenkins@v1.2.11'
+
+pipeline {
+  agent { label 'linux' }
+
+  options {
+    timestamps()
+    disableConcurrentBuilds()
+    /* Prevent Jenkins jobs from running forever */
+    timeout(time: 35, unit: 'MINUTES')
+    /* Limit builds retained */
+    buildDiscarder(logRotator(
+      numToKeepStr: '10',
+      daysToKeepStr: '30',
+      artifactNumToKeepStr: '10',
+    ))
+  }
+
+  stages {
+    stage('Build') {
+      parallel {
+        stage('Linux') { steps { script {
+          linux = jenkins.Build('status-desktop/platforms/linux')
+        } } }
+        stage('Windows') { steps { script {
+          windows = jenkins.Build('status-desktop/platforms/windows')
+        } } }
+        stage('MacOS') { steps { script {
+          macos = jenkins.Build('status-desktop/platforms/macos')
+        } } }
+      }
+    }
+    stage('Archive') {
+      steps { script {
+        sh('rm -f pkg/*')
+        jenkins.copyArts(linux)
+        jenkins.copyArts(windows)
+        jenkins.copyArts(macos)
+        sha = "pkg/${utils.pkgFilename('sha256')}"
+        dir('pkg') {
+          /* generate sha256 checksums for upload */
+          sh "sha256sum * | tee ../${sha}"
+          archiveArtifacts('*')
+        }
+      } }
+    }
+    stage('Upload') {
+      steps { script {
+        /* object for easier URLs handling */
+        urls = [
+          /* mobile */
+          Linux: utils.pkgUrl(linux),
+          Windows: utils.pkgUrl(windows),
+          MacOS: utils.pkgUrl(macos),
+          /* upload the sha256 checksums file too */
+          SHA: s3.uploadArtifact(sha),
+        ]
+        /* add URLs to the build description */
+        jenkins.setBuildDesc(urls)
+      } }
+    }
+  }
+}

--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -37,6 +37,8 @@ pipeline {
   stages {
     stage('Deps') {
       steps {
+        /* trigger fetching of git submodules */
+        sh 'make check-pkg-target-linux'
         /* avoid re-compiling Nim by using cache */
         cache(maxCacheSize: 250, caches: [[
           $class: 'ArbitraryFileCache',

--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -1,4 +1,4 @@
-library 'status-react-jenkins@v1.2.4'
+library 'status-react-jenkins@v1.2.11'
 
 pipeline {
   agent {

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -33,6 +33,8 @@ pipeline {
   stages {
     stage('Deps') {
       steps { 
+        /* trigger fetching of git submodules */
+        sh 'make check-pkg-target-macos'
         /* avoid re-compiling Nim by using cache */
         cache(maxCacheSize: 250, caches: [[
           $class: 'ArbitraryFileCache',

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -1,4 +1,4 @@
-library 'status-react-jenkins@v1.2.4'
+library 'status-react-jenkins@v1.2.11'
 
 pipeline {
   agent {

--- a/ci/Jenkinsfile.windows
+++ b/ci/Jenkinsfile.windows
@@ -1,4 +1,4 @@
-library 'status-react-jenkins@v1.2.4'
+library 'status-react-jenkins@v1.2.11'
 
 pipeline {
   agent { label 'windows' }

--- a/ci/Jenkinsfile.windows
+++ b/ci/Jenkinsfile.windows
@@ -43,6 +43,8 @@ pipeline {
   stages {
     stage('Deps') {
       steps {
+        /* trigger fetching of git submodules */
+        sh 'make check-pkg-target-windows'
         /* avoid re-compiling Nim by using cache */
         cache(maxCacheSize: 250, caches: [[
           $class: 'ArbitraryFileCache',


### PR DESCRIPTION
This is part of a general restructuring in layout of Jenkins job folders before we can properly introduce Release signing and notarization.  We need this to distinguish between pr/dev builds and release ones to avoid signing the dev builds with a release certificate.

The meta job managed with `ci/Jenkinsfile.combined` runs a job for all 3 platforms and currently is quite basic, but in the future can be extended to include - like the mobile one - updating the nightlies page, or publishing draft GitHub releases.

The addition of `make check-pkg-target-*` steps to other `Jenkinsfile`s is necessary because the sub-jobs under [`platforms`](https://ci.status.im/job/status-desktop/job/platforms/) have no option for checking out Git submodules at the beginning, so I'm making use of how the `Makefile` works and triggering that with a target that doesn't do much.

Example job:
https://ci.status.im/job/status-desktop/job/release/job/ci-meta-release-job/

![image](https://user-images.githubusercontent.com/2212681/114737397-43c2a280-9d47-11eb-81a2-f26dfbf8d2ab.png)