### PR TITLE
fix: SyncContainer “activeMailserver” error

### DIFF
--- a/ui/app/AppLayouts/Profile/Sections/SyncContainer.qml
+++ b/ui/app/AppLayouts/Profile/Sections/SyncContainer.qml
@@ -9,6 +9,7 @@ Item {
     id: syncContainer
     Layout.fillHeight: true
     Layout.fillWidth: true
+    property string activeMailserver: ""
 
     Connections {
         target: profileModel.mailservers
@@ -19,7 +20,6 @@ Item {
 
     Item {
         width: profileContainer.profileContentWidth
-
         anchors.horizontalCenter: parent.horizontalCenter
 
         Component {


### PR DESCRIPTION
There was a bad merge in PR #2225 that caused the QML propery `activeMailserver` in `SyncContainer` to be stripped out. This was causing an error in the console: `qrc:/app/AppLayouts/Profile/Sections/SyncContainer.qml:16: Error: Cannot assign to non-existent property "activeMailserver”`.

This PR adds the property back in and resolves the issue.