### PR TITLE
build: use GitHub credentials when downloading bottles for macOS

### DIFF
--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -41,7 +41,15 @@ pipeline {
           includes: '**/*',
           path: 'vendor/nimbus-build-system/vendor/Nim/bin'
         ]]) {
-          sh 'make deps'
+          withCredentials([
+            usernamePassword( /* For fetching HomeBrew bottles. */
+              credentialsId: "status-im-auto-pkgs",
+              usernameVariable: 'GITHUB_USER',
+              passwordVariable: 'GITHUB_TOKEN'
+            )
+          ]) {
+            sh 'make deps'
+          }
         }
       }
     }

--- a/scripts/fetch-brew-bottle.sh
+++ b/scripts/fetch-brew-bottle.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -eof pipefail
+
+# This script is used to fetch HomeBrew bottles for PCRE and OpenSSL.
+
+function get_gh_pkgs_token() {
+    curl --fail -Ls -u "${GITHUB_USER}:${GITHUB_TOKEN}" https://ghcr.io/token | jq -r '.token'
+}
+
+function get_bottle_json() {
+    brew info --json=v1 "${1}" | jq '.[0].bottle.stable.files.mojave'
+}
+
+function fetch_bottle() {
+    if [[ -n "${BEARER_TOKEN}" ]]; then
+        AUTH=("-H" "Authorization: Bearer ${BEARER_TOKEN}")
+    else
+        AUTH=("-u" "_:_") # WARNING: Unauthorized requests can be throttled.
+    fi
+    curl --fail -Ls "${AUTH[@]}" -o "${1}" "${2}"
+}
+
+if [[ $(uname) != "Darwin" ]]; then
+    echo "This script is intended for use on MacOS!" >&2
+    exit 1
+fi
+
+if [[ $# -ne 1 ]]; then
+    echo "usage: $0 <bottle_name>" >&2
+    exit 1
+fi
+BOTTLE_NAME="${1}"
+BOTTLE_PATH="/tmp/${BOTTLE_NAME}.tar.gz"
+
+# GitHub Packages requires authentication.
+GITHUB_USER="${GITHUB_USER:-_}"
+GITHUB_TOKEN="${GITHUB_TOKEN:-_}"
+if [[ "${GITHUB_USER}" == "_" ]] || [[ "${GITHUB_TOKEN}" == "_" ]]; then
+    echo "No GITHUB_USER or GITHUB_TOKEN variable set!" >&2
+    echo "GitHub Packages which can throttle unauthorized requests." >&2
+else
+    echo "${BOTTLE_NAME} - Fetching GH Pkgs Token"
+    BEARER_TOKEN=$(get_gh_pkgs_token)
+fi
+
+# We want the most recent available version of the package.
+if [[ $(stat -f %u /usr/local/var/homebrew) -ne "${UID}" ]]; then
+    echo "Missing permissions to update Homebrew formulae!" >&2
+else
+    echo "${BOTTLE_NAME} - Updateing HomeBrew repository"
+    brew update >/dev/null
+fi
+
+echo "${BOTTLE_NAME} - Finding bottle URL"
+BOTTLE_JSON=$(get_bottle_json "${BOTTLE_NAME}")
+BOTTLE_URL=$(echo "${BOTTLE_JSON}" | jq -r .url)
+BOTTLE_SHA=$(echo "${BOTTLE_JSON}" | jq -r .sha256)
+
+echo "${BOTTLE_NAME} - Fetching bottles for macOS"
+fetch_bottle "${BOTTLE_PATH}" "${BOTTLE_URL}"
+trap "rm -fr ${BOTTLE_PATH}" EXIT ERR INT QUIT
+
+echo "${BOTTLE_NAME} - Checking SHA256 checksum"
+BOTTLE_LOCAL_SHA=$(shasum -a 256 "${BOTTLE_PATH}" | awk '{print $1}')
+
+if [[ "${BOTTLE_LOCAL_SHA}" != "${BOTTLE_SHA}" ]]; then
+    echo "The SHA256 of downloaded bottle did not match!" >&2
+    exit 1;
+fi
+
+echo "${BOTTLE_NAME} - Unpacking bottle tarball"
+mkdir -p "bottles/${BOTTLE_NAME}"
+tar xzf "${BOTTLE_PATH}" --strip-components 2 -C "bottles/${BOTTLE_NAME}"


### PR DESCRIPTION
See #2255. With the changes made in this PR, to build the app on macOS it will be required to have `GITHUB_USER` and `GITHUB_TOKEN` set in the shell environment where `make` is run.

To generate a personal access token, on the GitHub website open your profile's *Settings*, then go to *Developer settings*, then *Personal access tokens*, then *Generate new token*,  assign it the `read:packages` scope and then at the bottom click the green *Generate token* button.

![image](https://user-images.githubusercontent.com/194260/114939740-7f707180-9e06-11eb-8940-93109f61887f.png)

@jakubgs if it's okay for it to work in Jenkins the same way it's intended to work locally, then `GITHUB_USER` and `GITHUB_TOKEN` will need to be setup in the Jenkins environment.

If instead we're going to pin the bottles then in the Makefile I'll need to add some more environment variables and change the logic a bit more.

---

**NOTES**

It may be that additional token scopes are needed. I've experienced some strange behavior when e.g. I tried to test what happens (how `make` would ultimately fail) when an invalid token is set and when adding/removing various token scopes. But `make bottles` still worked in all cases, possibly because earlier I was using a valid token with proper scopes and somehow GitHub/curl remembers that... I really don't know, it's a big mystery. Anyway, if it doesn't work locally and/or in CI with a valid token then the token probably needs to be granted additional scopes. By suggesting only `read:packages` above, I was trying to be conservative.

It may be important to add more error checking, e.g. right after trying to obtain `BEARER_TOKEN`. But if that fails the string should be "null", which should cause e.g. `bottles/Downloads/openssl.tar.gz` to be invalid and then the `sha256sum` comparison should fail. So I think the bases are pretty well covered.