### PR TITLE
chore(Communities): remove community context menu for non-admins

### DIFF
--- a/ui/app/AppLayouts/Chat/CommunityColumn.qml
+++ b/ui/app/AppLayouts/Chat/CommunityColumn.qml
@@ -54,6 +54,7 @@ Rectangle {
             anchors.rightMargin: Style.current.bigPadding
             anchors.top: parent.top
             anchors.topMargin: 8
+            visible: chatsModel.communities.activeCommunity.admin
 
             onClicked: {
                 optionsBtn.state = "pressed"
@@ -83,16 +84,6 @@ Rectangle {
                     icon.width: 20
                     icon.height: 20
                     onTriggered: openPopup(inviteFriendsToCommunityPopup, {communityId: chatsModel.communities.activeCommunity.id})
-                }
-
-                Action {
-                    //% "Leave community"
-                    text: qsTrId("leave-community")
-                    icon.source: "../../img/delete.svg"
-                    icon.color: Style.current.red
-                    icon.width: 20
-                    icon.height: 20
-                    onTriggered: chatsModel.communities.leaveCurrentCommunity()
                 }
 
                 onAboutToHide: {


### PR DESCRIPTION
Normal members shouldn't be able to create channels, nor should "leave
channel" be an option of the context menu provided inside of a community.

This commit removes these.