### PR TITLE
fix(Communities): allow everyone to activate community profile popup

### DIFF
--- a/ui/app/AppLayouts/Chat/CommunityColumn.qml
+++ b/ui/app/AppLayouts/Chat/CommunityColumn.qml
@@ -54,6 +54,7 @@ Rectangle {
             anchors.rightMargin: Style.current.bigPadding
             anchors.top: parent.top
             anchors.topMargin: 8
+            visible: chatsModel.communities.activeCommunity.admin
 
             onClicked: {
                 optionsBtn.state = "pressed"
@@ -83,16 +84,6 @@ Rectangle {
                     icon.width: 20
                     icon.height: 20
                     onTriggered: openPopup(inviteFriendsToCommunityPopup, {communityId: chatsModel.communities.activeCommunity.id})
-                }
-
-                Action {
-                    //% "Leave community"
-                    text: qsTrId("leave-community")
-                    icon.source: "../../img/delete.svg"
-                    icon.color: Style.current.red
-                    icon.width: 20
-                    icon.height: 20
-                    onTriggered: chatsModel.communities.leaveCurrentCommunity()
                 }
 
                 onAboutToHide: {

--- a/ui/app/AppLayouts/Chat/CommunityComponents/CommunityHeaderButton.qml
+++ b/ui/app/AppLayouts/Chat/CommunityComponents/CommunityHeaderButton.qml
@@ -76,8 +76,6 @@ Button {
 
     MouseArea {
         id: mouseAreaBtn
-        enabled: chatsModel.communities.activeCommunity.admin
-        visible: enabled
         cursorShape: Qt.PointingHandCursor
         anchors.fill: parent
         onPressed: {


### PR DESCRIPTION
Prior to this commit, only admins of a community could open up the community
profile popup from inside the community. However, normal members should be able
to do so too.