### PR TITLE
fix(Communities): make kicking members work again

### DIFF
--- a/ui/app/AppLayouts/Chat/CommunityComponents/CommunityMembersPopup.qml
+++ b/ui/app/AppLayouts/Chat/CommunityComponents/CommunityMembersPopup.qml
@@ -164,7 +164,7 @@ ModalPopup {
                             icon.color: Style.current.red
                             //% "Kick"
                             text: qsTrId("kick")
-                            onTriggered: chatsModel.removeUserFromCommunity(model.pubKey)
+                            onTriggered: chatsModel.communities.removeUserFromCommunity(model.pubKey)
                         }
                         Action {
                             icon.source: "../../../img/communities/menu/ban.svg"

--- a/ui/app/AppLayouts/Chat/CommunityComponents/CommunityProfilePopupMembersList.qml
+++ b/ui/app/AppLayouts/Chat/CommunityComponents/CommunityProfilePopupMembersList.qml
@@ -155,7 +155,7 @@ Item {
                             icon.color: Style.current.red
                             //% "Kick"
                             text: qsTrId("kick")
-                            onTriggered: chatsModel.removeUserFromCommunity(model.pubKey)
+                            onTriggered: chatsModel.communities.removeUserFromCommunity(model.pubKey)
                         }
                         /* Action { */
                         /*     icon.source: "../../../img/communities/menu/ban.svg" */


### PR DESCRIPTION
There's a regression in the application where kicking members from communities
doesn't work anymore. This was due to UI logic being moved to a different model
without updating the corresponding view action.

Fixes #2274