### PR TITLE
fix(TransactionModal): fix values oferflowing

### DIFF
--- a/ui/app/AppLayouts/Profile/Sections/Ens/TermsAndConditions.qml
+++ b/ui/app/AppLayouts/Profile/Sections/Ens/TermsAndConditions.qml
@@ -37,8 +37,8 @@ Item {
                 transactionDialog.closed()
             }
             ensUsername: username
-            width: 400
-            height: 400
+            width: 425
+            height: 425
         }
     }
 

--- a/ui/shared/AccountSelector.qml
+++ b/ui/shared/AccountSelector.qml
@@ -3,6 +3,8 @@ import QtQuick.Controls 2.13
 import QtQuick.Layouts 1.13
 import QtGraphicalEffects 1.13
 import "../imports"
+import "../shared"
+import "../shared/status"
 
 Item {
     id: root
@@ -67,7 +69,8 @@ Item {
         if (!assetFound) {
             return
         }
-        txtAssetBalance.text = "Balance: " + (parseFloat(assetFound.value) === 0.0 ? "0" : Utils.stripTrailingZeros(assetFound.value)) + " " + assetFound.symbol
+        txtAssetBalance.text = qsTr("Balance: ") + (parseFloat(assetFound.value) === 0.0 ? "0" : Utils.stripTrailingZeros(assetFound.value))
+        txtAssetSymbol.text = " " + assetFound.symbol
     }
 
     StyledText {
@@ -75,11 +78,39 @@ Item {
         visible: root.assetFound !== undefined
         anchors.bottom: select.top
         anchors.bottomMargin: -18 
-        anchors.right: parent.right
+        anchors.right: txtAssetSymbol.left
+        anchors.left: select.left
+        anchors.leftMargin: select.width / 2.5
         
         color: !root.isValid ? Style.current.danger : Style.current.secondaryText
+        elide: Text.ElideRight
         font.pixelSize: 13
+        horizontalAlignment: Text.AlignRight
         height: 18
+
+        StatusToolTip {
+            enabled: txtAssetBalance.truncated
+            id: assetTooltip
+            text: txtAssetBalance.text
+        }
+
+        MouseArea {
+            enabled: txtAssetBalance.truncated
+            anchors.fill: parent
+            hoverEnabled: enabled
+            onEntered: assetTooltip.visible = true
+            onExited: assetTooltip.visible = false
+        }
+    }
+    StyledText {
+        id: txtAssetSymbol
+        visible: txtAssetBalance.visible
+        anchors.top: txtAssetBalance.top
+        anchors.right: parent.right
+
+        color: txtAssetBalance.color
+        font.pixelSize: 13
+        height: txtAssetBalance.height
     }
     Select {
         id: select

--- a/ui/shared/TransactionPreview.qml
+++ b/ui/shared/TransactionPreview.qml
@@ -391,13 +391,29 @@ Item {
                     anchors.right: parent.right
                     anchors.verticalCenter: parent.verticalCenter
                     StyledText {
+                        id: networkFeeText
                         font.pixelSize: 15
+                        width: 75
                         height: 22
                         text: (root.gas && root.gas.value) ? Utils.stripTrailingZeros(root.gas.value) : ""
                         anchors.verticalCenter: parent.verticalCenter
                         horizontalAlignment: Text.AlignRight
                         verticalAlignment: Text.AlignVCenter
                         elide: Text.ElideRight
+
+                        StatusToolTip {
+                            enabled: networkFeeText.truncated
+                            id: networkFeeTooltip
+                            text: networkFeeText.text
+                        }
+
+                        MouseArea {
+                            enabled: networkFeeText.truncated
+                            anchors.fill: parent
+                            hoverEnabled: enabled
+                            onEntered: networkFeeTooltip.visible = true
+                            onExited: networkFeeTooltip.visible = false
+                        }
                     }
                     StyledText {
                         id: txtFeeSymbol


### PR DESCRIPTION
Fixes #1872

Elides those values and adds a tooltip to show them completely

(disregard the red text, I had to "cheat" the value to test)
![image](https://user-images.githubusercontent.com/11926403/115429478-6f271080-a1d1-11eb-8d42-2f43e89f7073.png)

Same for the network fee