### PR TITLE
fix: do not show watch-only accounts as “from address”

### DIFF
--- a/ui/app/AppLayouts/Chat/ChatColumn/ChatComponents/ChatCommandModal.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/ChatComponents/ChatCommandModal.qml
@@ -36,7 +36,13 @@ ModalPopup {
             AccountSelector {
                 id: selectFromAccount
                 accounts: walletModel.accounts
-                selectedAccount: walletModel.currentAccount
+                selectedAccount: {
+                    const currAcc = walletModel.currentAccount
+                    if (currAcc.walletType !== Constants.watchWalletType) {
+                        return currAcc
+                    }
+                    return null
+                }
                 currency: walletModel.defaultCurrency
                 width: stack.width
                 label: {

--- a/ui/app/AppLayouts/Profile/Sections/Ens/RegisterENSModal.qml
+++ b/ui/app/AppLayouts/Profile/Sections/Ens/RegisterENSModal.qml
@@ -64,7 +64,13 @@ ModalPopup {
             AccountSelector {
                 id: selectFromAccount
                 accounts: walletModel.accounts
-                selectedAccount: walletModel.currentAccount
+                selectedAccount: {
+                    const currAcc = walletModel.currentAccount
+                    if (currAcc.walletType !== Constants.watchWalletType) {
+                        return currAcc
+                    }
+                    return null
+                }
                 currency: walletModel.defaultCurrency
                 width: stack.width
                 //% "Choose account"

--- a/ui/app/AppLayouts/Profile/Sections/Ens/SetPubKeyModal.qml
+++ b/ui/app/AppLayouts/Profile/Sections/Ens/SetPubKeyModal.qml
@@ -69,7 +69,13 @@ ModalPopup {
             AccountSelector {
                 id: selectFromAccount
                 accounts: walletModel.accounts
-                selectedAccount: walletModel.currentAccount
+                selectedAccount: {
+                    const currAcc = walletModel.currentAccount
+                    if (currAcc.walletType !== Constants.watchWalletType) {
+                        return currAcc
+                    }
+                    return null
+                }
                 currency: walletModel.defaultCurrency
                 width: stack.width
                 //% "Choose account"

--- a/ui/app/AppLayouts/Wallet/SendModal.qml
+++ b/ui/app/AppLayouts/Wallet/SendModal.qml
@@ -56,7 +56,13 @@ ModalPopup {
             AccountSelector {
                 id: selectFromAccount
                 accounts: walletModel.accounts
-                selectedAccount: walletModel.currentAccount
+                selectedAccount: {
+                    const currAcc = walletModel.currentAccount
+                    if (currAcc.walletType !== Constants.watchWalletType) {
+                        return currAcc
+                    }
+                    return null
+                }
                 currency: walletModel.defaultCurrency
                 width: stack.width
                 //% "From account"

--- a/ui/shared/AccountSelector.qml
+++ b/ui/shared/AccountSelector.qml
@@ -2,6 +2,7 @@ import QtQuick 2.13
 import QtQuick.Controls 2.13
 import QtQuick.Layouts 1.13
 import QtGraphicalEffects 1.13
+import QtQml.Models 2.14
 import "../imports"
 import "../shared"
 import "../shared/status"
@@ -187,7 +188,7 @@ Item {
         id: menuItem
         MenuItem {
             id: itemContainer
-            visible: walletType !== 'watch'
+            visible: walletType !== Constants.watchWalletType
             property bool isFirstItem: index === 0
             property bool isLastItem: index === accounts.rowCount() - 1
 
@@ -197,7 +198,7 @@ Item {
                 }
             }
 
-            height: walletType === 'watch' ? 0 : (accountName.height + 14 + accountAddress.height + 14)
+            height: walletType === Constants.watchWalletType ? 0 : (accountName.height + 14 + accountAddress.height + 14)
             SVGImage {
                 id: iconImg
                 anchors.left: parent.left

--- a/ui/shared/status/StatusStickerPackPurchaseModal.qml
+++ b/ui/shared/status/StatusStickerPackPurchaseModal.qml
@@ -73,7 +73,13 @@ ModalPopup {
             AccountSelector {
                 id: selectFromAccount
                 accounts: walletModel.accounts
-                selectedAccount: walletModel.currentAccount
+                selectedAccount: {
+                    const currAcc = walletModel.currentAccount
+                    if (currAcc.walletType !== Constants.watchWalletType) {
+                        return currAcc
+                    }
+                    return null
+                }
                 currency: walletModel.defaultCurrency
                 width: stack.width
                 //% "Choose account"


### PR DESCRIPTION
Fixes: #2257.

If a user had selected a watch-only address in the wallet, the backend `walletModel.currentAccount` property would also change. When loading a transaction modal, this property was used to set the `selectedAccount` value for the “from” `AccountSelector`, regardless if the account was a watch-only address.

This PR updates the logic for `selectedAccount` such that it will only allow the account to be selected if it is not a watch-only account.