### PR TITLE
ci: bump jenkins lib to make release filenames nicer

### DIFF
--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.2.12'
+library 'status-jenkins-lib@v1.2.13'
 
 pipeline {
   agent { label 'linux' }

--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.2.12'
+library 'status-jenkins-lib@v1.2.13'
 
 pipeline {
   agent {

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.2.12'
+library 'status-jenkins-lib@v1.2.13'
 
 pipeline {
   agent {

--- a/ci/Jenkinsfile.windows
+++ b/ci/Jenkinsfile.windows
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.2.12'
+library 'status-jenkins-lib@v1.2.13'
 
 pipeline {
   agent { label 'windows' }


### PR DESCRIPTION
Essentially same thing as: https://github.com/status-im/status-react/pull/12015

Depends on: https://github.com/status-im/status-jenkins-lib/pull/24