### PR TITLE
build: use same container as Jenkins CI for local packaged builds on Linux

### DIFF
--- a/AppRun
+++ b/AppRun
@@ -1,5 +1,10 @@
 #!/bin/bash
 APPDIR="$(dirname "$(readlink -f "${0}")")"
+export GST_PLUGIN_SCANNER="${APPDIR}/usr/lib/gstreamer1.0/gstreamer-1.0/gst-plugin-scanner"
+export GST_PLUGIN_PATH="${APPDIR}/usr/lib/gstreamer-1.0"
+export GST_PLUGIN_PATH_1_0="${APPDIR}/usr/lib/gstreamer-1.0"
+export GST_PLUGIN_SYSTEM_PATH="${APPDIR}/usr/lib/gstreamer-1.0"
+export GST_PLUGIN_SYSTEM_PATH_1_0="${APPDIR}/usr/lib/gstreamer-1.0"
 export LD_LIBRARY_PATH="${APPDIR}/usr/lib/:${LD_LIBRARY_PATH}"
 export QT_QPA_PLATFORM="xcb"
 

--- a/Makefile
+++ b/Makefile
@@ -247,7 +247,7 @@ $(APPIMAGE_TOOL):
 	mv $(_APPIMAGE_TOOL) tmp/linux/tools/
 	chmod +x $(APPIMAGE_TOOL)
 
-STATUS_CLIENT_APPIMAGE ?= pkg/NimStatusClient-x86_64.AppImage
+STATUS_CLIENT_APPIMAGE ?= pkg/Status.AppImage
 
 $(STATUS_CLIENT_APPIMAGE): override RESOURCES_LAYOUT := -d:production
 $(STATUS_CLIENT_APPIMAGE): nim_status_client $(APPIMAGE_TOOL) nim-status.desktop
@@ -269,6 +269,9 @@ $(STATUS_CLIENT_APPIMAGE): nim_status_client $(APPIMAGE_TOOL) nim-status.desktop
 
 	# Libraries
 	cp -r /usr/lib/x86_64-linux-gnu/nss tmp/linux/dist/usr/lib/
+	cp -P /usr/lib/x86_64-linux-gnu/libgst* tmp/linux/dist/usr/lib/
+	cp -r /usr/lib/x86_64-linux-gnu/gstreamer-1.0 tmp/linux/dist/usr/lib/
+	cp -r /usr/lib/x86_64-linux-gnu/gstreamer1.0 tmp/linux/dist/usr/lib/
 	cp vendor/status-go/build/bin/libstatus.so tmp/linux/dist/usr/lib/
 
 	echo -e $(BUILD_MSG) "AppImage"

--- a/build-linux.sh
+++ b/build-linux.sh
@@ -2,10 +2,16 @@
 
 # This script assumes $PWD is the same dir in which this script is located
 
-docker run -it --rm --device /dev/fuse \
-  -v "${PWD}:/nim-status-client:Z" \
-  -w /nim-status-client \
+# Helps avoid permissions problems with `jenkins` user in docker container when
+# making a local packaged build
+git clean -dfx
+
+docker run -it --rm \
   --cap-add SYS_ADMIN \
-  --privileged \
-  a12e/docker-qt:5.14-gcc_64 \
+  --security-opt apparmor:unconfined \
+  --device /dev/fuse \
+  -u jenkins:$(getent group $(whoami) | cut -d: -f3) \
+  -v "${PWD}:/status-desktop" \
+  -w /status-desktop \
+  statusteam/nim-status-client-build:1.0.2 \
   ./docker-linux-app-image.sh

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -4,8 +4,8 @@ FROM a12e/docker-qt:5.14-gcc_64
 # $QT_PATH/$QT_VERSION/$QT_PLATFORM/bin is already prepended to $PATH
 # However $QT_VERSION is not exposed to environment so set it here
 ENV QT_VERSION="5.14.0"
-ENV QTDIR="${QT_PATH}/${QT_VERSION}"
-ENV LD_LIBRARY_PATH="${QTDIR}/${QT_PLATFORM}/lib:${LD_LIBRARY_PATH}"
+ENV QTDIR="${QT_PATH}/${QT_VERSION}/${QT_PLATFORM}"
+ENV LD_LIBRARY_PATH="${QTDIR}/lib:${LD_LIBRARY_PATH}"
 # $OPENSSL_PREFIX is provided by the docker image
 ENV LIBRARY_PATH="${OPENSSL_PREFIX}/lib:${LIBRARY_PATH}"
 
@@ -15,7 +15,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
  && sudo add-apt-repository -y ppa:git-core/ppa \
  && sudo apt update -yq \
  && sudo apt install -yq --fix-missing \
-      build-essential cmake git s3cmd libpcre3-dev libnss3 libxcomposite1 libxtst6 jq
+      build-essential cmake git s3cmd libpcre3-dev libnss3 libxcomposite1 libxtst6 jq gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly gstreamer1.0-libav gstreamer1.0-tools gstreamer1.0-alsa gstreamer1.0-pulseaudio
 
 # Installing Golang
 RUN GOLANG_SHA256="aed845e4185a0b2a3c3d5e1d0a35491702c55889192bb9c30e67a3de6849c067" \

--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -4,7 +4,7 @@ pipeline {
   agent {
     docker { 
       label 'linux'
-      image 'statusteam/nim-status-client-build:1.0.1'
+      image 'statusteam/nim-status-client-build:1.0.2'
       /* allows jenkins use cat and mounts '/dev/fuse' for linuxdeployqt */
       args '--entrypoint="" --cap-add SYS_ADMIN --security-opt apparmor:unconfined --device /dev/fuse'
     }

--- a/nim-status.desktop
+++ b/nim-status.desktop
@@ -3,6 +3,6 @@ Type=Application
 Name=Status Desktop
 Exec=nim_status_client
 Icon=status
-Comment=Hello World
+Comment=Desktop client for the Status Network
 Terminal=true
 Categories=Network;


### PR DESCRIPTION
Make the docker-related logic for doing a local packaged build on Linux match with the Jenkins CI build for Linux.

Also fix the problems with packaged builds for Linux (local or CI) where gstreamer errors were displayed in the terminal shortly after app start/login and there was no sound output.

---

~~Until the `statusteam/nim-status-client-build` docker image has been updated, Jenkins CI builds for Linux will still not have sound output. See: https://github.com/status-im/infra-ci/issues/30.~~

Tag `1.0.2` has been pushed to the docker hub: https://hub.docker.com/layers/statusteam/nim-status-client-build/1.0.2/images/sha256-9d9e493b5d1d5e414bb503d8be25009c9afab91c178b3582e1f6281902bb1f4d?context=explore.

---

Closes #2441.