### PR TITLE
fix: Send Message button not working in profile popup

### DIFF
--- a/src/status/signals/messages.nim
+++ b/src/status/signals/messages.nim
@@ -197,10 +197,12 @@ proc toCommunity*(jsonCommunity: JsonNode): Community =
     for chatId, chat in jsonCommunity{"chats"}:
       result.chats.add(Chat(
         id: result.id & chatId,
+        communityId: result.id,
         name: chat{"name"}.getStr,
         canPost: chat{"canPost"}.getBool,
+        chatType: ChatType.CommunityChat
         # TODO get this from access
-        chatType: ChatType.Public#chat{"permissions"}{"access"}.getInt,
+        #chat{"permissions"}{"access"}.getInt,
       ))
 
   if jsonCommunity.hasKey("members") and jsonCommunity["members"].kind != JNull:

--- a/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/ChatText.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/ChatText.qml
@@ -44,7 +44,12 @@ Item {
         clip: true
         onLinkActivated: function (link) {
             if(link.startsWith("#")) {
-                chatsModel.joinChat(link.substring(1), Constants.chatTypePublic);
+                const chatType = chatsModel.communities.activeCommunity.active ? Constants.chatTypeCommunity : Constants.chatTypePublic;
+                const foundChatType = chatsModel.joinChat(link.substring(1), chatType);
+                if (foundChatType === Constants.chatTypePublic && chatsModel.communities.activeCommunity.active) {
+                    chatsModel.communities.activeCommunity.active = false
+                    appMain.changeAppSection(Constants.chat)
+                }
                 return;
             }
 

--- a/ui/app/AppLayouts/Chat/components/ProfilePopup.qml
+++ b/ui/app/AppLayouts/Chat/components/ProfilePopup.qml
@@ -337,8 +337,7 @@ ModalPopup {
             visible: !isBlocked && chatsModel.activeChannel.id !== popup.fromAuthor
             width: visible ? implicitWidth : 0
             onClicked: {
-                if (tabBar.currentIndex !== 0)
-                    tabBar.currentIndex = 0
+                appMain.changeAppSection(Constants.chat)
                 chatsModel.joinChat(fromAuthor, Constants.chatTypeOneToOne)
                 popup.close()
             }

--- a/ui/app/AppMain.qml
+++ b/ui/app/AppMain.qml
@@ -362,6 +362,7 @@ RowLayout {
     }
 
     function changeAppSection(section) {
+        chatsModel.communities.activeCommunity.active = false
         sLayout.currentIndex = Utils.getAppSectionIndex(section)
     }
 


### PR DESCRIPTION
Fixes: #2364

The Send Message button click event was erroring due to a refactor that had been done to allow for changing app sections.

This has been updated to follow the current way to change app sections.