### PR TITLE
feat: show ENS name in notifications

### DIFF
--- a/src/app/chat/view.nim
+++ b/src/app/chat/view.nim
@@ -515,7 +515,7 @@ QtObject:
             channel.chatType.int,
             msg.timestamp,
             msg.identicon,
-            msg.alias,
+            msg.userName,
             msg.hasMention,
             isAddedContact,
             channel.name)


### PR DESCRIPTION
Fixes: #2418.

Chat notifications for one-on-one chats were showing only a user’s alias and not their ENS name if they have one.

This PR now shows a user’s ENS name if they have one, or their alias if they don’t in one-on-one chat notifications.

![imgur](https://imgur.com/WmFoIww.png)