### PR TITLE
refactor(StatusToolTip): make orientation enum and match design

### DIFF
--- a/ui/app/AppLayouts/Chat/CommunityComponents/CommunityButton.qml
+++ b/ui/app/AppLayouts/Chat/CommunityComponents/CommunityButton.qml
@@ -32,7 +32,7 @@ StatusIconTabButton {
         visible: communityButton.hovered
         text: communityButton.name
         delay: 50
-        orientation: "right"
+        orientation: StatusToolTip.Orientation.Right
         x: communityButton.width + Style.current.padding
         y: communityButton.height / 2 - height / 2 + 4
     }

--- a/ui/shared/CopyToClipBoardButton.qml
+++ b/ui/shared/CopyToClipBoardButton.qml
@@ -62,7 +62,7 @@ Rectangle {
         id: toolTip
         //% "Copied!"
         text: qsTrId("copied-")
-        orientation: tooltipUnder ? "bottom" : "top"
+        orientation: tooltipUnder ? StatusToolTip.Orientation.Bottom : StatusToolTip.Orientation.Bottom
     }
 
     Timer {

--- a/ui/shared/status/StatusToolTip.qml
+++ b/ui/shared/status/StatusToolTip.qml
@@ -5,8 +5,16 @@ import "../../shared"
 
 ToolTip {
     id: tooltip
+
+    enum Orientation {
+        Top,
+        Bottom,
+        Left,
+        Right
+    }
+
     property int maxWidth: 800
-    property string orientation: "top"
+    property int orientation: StatusToolTip.Orientation.Top
 
     implicitWidth: Math.min(maxWidth, textContent.implicitWidth + Style.current.bigPadding)
     leftPadding: Style.current.smallPadding
@@ -25,29 +33,29 @@ ToolTip {
         }
         Rectangle {
             color: tooltipContentBg.color
-            height: orientation === "top" || orientation === "bottom" ? 24 : 24
-            width: orientation === "top" || orientation === "bottom" ? 24 : 24
+            height: 26
+            width: 26
             rotation: 45
             radius: 1
             x: {
-                if (orientation === "top" || orientation === "bottom") {
+                if (orientation === StatusToolTip.Orientation.Top || orientation === StatusToolTip.Orientation.Bottom) {
                     return tooltipBg.width / 2 - width / 2
                 }
-                if (orientation === "left") {
-                    return tooltipContentBg.width - (width / 2) - 4
+                if (orientation === StatusToolTip.Orientation.Left) {
+                    return tooltipContentBg.width - (width / 2) - 7
                 }
-                if (orientation === "right") {
-                    return -width/2 + 4
+                if (orientation === StatusToolTip.Orientation.Right) {
+                    return -width/2 + 7
                 }
             }
             y: {
-                if (orientation === "bottom") {
-                    return -height / 2
+                if (orientation === StatusToolTip.Orientation.Bottom) {
+                    return -height / 2 + 5
                 }
-                if (orientation === "top") {
-                    return tooltipBg.height - height
+                if (orientation === StatusToolTip.Orientation.Top) {
+                    return tooltipBg.height - height - 5
                 }
-                if (orientation === "left" || orientation === "right") {
+                if (orientation === StatusToolTip.Orientation.Left || orientation === StatusToolTip.Orientation.Right) {
                     return tooltipContentBg.height / 2 - (height / 2)
                 }
             }


### PR DESCRIPTION
Fixes #2335

The component was already pretty good in terms of the design and the wanted properties, but I changed `orientation` to an enum so that it's easier to use and also cleaned it up a little and also made the "arrow" match better with the design