### PR TITLE
fix(Settings): fix QT settings not being saved on first start

### DIFF
--- a/src/app/profile/view.nim
+++ b/src/app/profile/view.nim
@@ -74,13 +74,13 @@ QtObject:
   proc profileSettingsFileChanged*(self: ProfileView) {.signal.}
 
   proc getProfileSettingsFile(self: ProfileView): string {.slot.} =
-    let address =
-      if (self.profile.address == ""):
+    let pubkey =
+      if (self.profile.pubKey == ""):
         UNKNOWN_ACCOUNT
       else:
-        self.profile.address
+        self.profile.pubKey
 
-    return os.joinPath(accountConstants.DATADIR, "qt", address)
+    return os.joinPath(accountConstants.DATADIR, "qt", pubkey)
 
   QtProperty[string] profileSettingsFile:
     read = getProfileSettingsFile


### PR DESCRIPTION
Fixes #2312

This will reset the QT settings of all users, since we change from using the address to using the pubkey.
The reason for that is that the account address also called keyId is somehow not set correctly on first login. The pubkey stays constant on the other hand. So using the pubkey is better.