### PR TITLE
Implement redesign of empty chat

### DIFF
--- a/ui/app/AppLayouts/Chat/ChatColumn/ChatMessages.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/ChatMessages.qml
@@ -63,9 +63,29 @@ ScrollView {
             }
             return 10000
         }
-        Layout.fillWidth: true
-        Layout.fillHeight: true
         verticalLayoutDirection: ListView.BottomToTop
+
+        // This header and Connections is to create an invisible padding so that the chat identifier is at the top
+        // The Connections is necessary, because doing the check inside teh ehader created a binding loop (the contentHeight includes the header height
+        // If the content height is smaller than the full height, we "show" the padding so that the chat identifier is at the top, otherwise we disable the Connections
+        header: Item {
+            height: 0
+            width: chatLogView.width
+        }
+        Connections {
+            id: contentHeightConnection
+            enabled: true
+            target: chatLogView
+            onContentHeightChanged: {
+                if (chatLogView.contentItem.height - chatLogView.headerItem.height < chatLogView.height) {
+                    chatLogView.headerItem.height = chatLogView.height - (chatLogView.contentItem.height - chatLogView.headerItem.height) - 36
+                } else {
+                    chatLogView.headerItem.height = 0
+                    contentHeightConnection.enabled = false
+                }
+            }
+        }
+
 
         Timer {
             id: timer

--- a/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/ChannelIdentifier.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/ChannelIdentifier.qml
@@ -4,7 +4,6 @@ import "../../../../../imports"
 
 Column {
     property string authorCurrentMsg: "authorCurrentMsg"
-    property int verticalMargin: 50
 
     property string profileImage
 
@@ -13,7 +12,7 @@ Column {
     visible: authorCurrentMsg === ""
     anchors.horizontalCenter: parent.horizontalCenter
     anchors.top: parent.top
-    anchors.topMargin: this.visible ? verticalMargin : 0
+    anchors.topMargin: this.visible ? Style.current.bigPadding : 0
 
     Rectangle {
         id: circleId
@@ -76,39 +75,31 @@ Column {
         anchors.horizontalCenter: parent.horizontalCenter
     }
 
-    Item {
-        id: channelDescription
-        visible: descText.visible
-        width: visible ? 330 : 0
-        height: visible ? childrenRect.height : 0
+    StyledText {
+        id: descText
+        wrapMode: Text.Wrap
         anchors.horizontalCenter: parent.horizontalCenter
-
-        StyledText {
-            id: descText
-            wrapMode: Text.Wrap
-            text: {
-                switch(chatsModel.activeChannel.chatType) {
-                    //% "Welcome to the beginning of the <span style='color: %1'>%2</span> group!"
-                    case Constants.chatTypePrivateGroupChat: return qsTrId("welcome-to-the-beginning-of-the--span-style--color---1---2--span--group-").arg(Style.current.textColor).arg(chatsModel.activeChannel.name);
-                    //% "Any messages you send here are encrypted and can only be read by you and <span style='color: %1'>%2</span>"
-                    case Constants.chatTypeOneToOne: return qsTrId("any-messages-you-send-here-are-encrypted-and-can-only-be-read-by-you-and--span-style--color---1---2--span-").arg(Style.current.textColor).arg(channelName.text)
-                    default: return "";
-                }
+        width: 310
+        text: {
+            switch(chatsModel.activeChannel.chatType) {
+                //% "Welcome to the beginning of the <span style='color: %1'>%2</span> group!"
+                case Constants.chatTypePrivateGroupChat: return qsTrId("welcome-to-the-beginning-of-the--span-style--color---1---2--span--group-").arg(Style.current.textColor).arg(chatsModel.activeChannel.name);
+                //% "Any messages you send here are encrypted and can only be read by you and <span style='color: %1'>%2</span>"
+                case Constants.chatTypeOneToOne: return qsTrId("any-messages-you-send-here-are-encrypted-and-can-only-be-read-by-you-and--span-style--color---1---2--span-").arg(Style.current.textColor).arg(channelName.text)
+                default: return "";
             }
-            font.pixelSize: 14
-            color: Style.current.secondaryText
-            anchors.left: parent.left
-            anchors.right: parent.right
-            horizontalAlignment: Text.AlignHCenter
-            textFormat: Text.RichText
         }
+        font.pixelSize: Style.current.primaryTextFontSize
+        color: Style.current.secondaryText
+        horizontalAlignment: Text.AlignHCenter
+        textFormat: Text.RichText
     }
 
     Item {
         visible: chatsModel.activeChannel.chatType === Constants.chatTypePrivateGroupChat && !chatsModel.activeChannel.isMember
         anchors.horizontalCenter: parent.horizontalCenter
-        width: joinChat.width
-        height: visible ? 100 : 10
+        width: visible ? joinChat.width : 0
+        height: visible ? 100 : 0
         id: joinOrDecline
 
         StyledText {
@@ -145,14 +136,6 @@ Column {
                 }
             }
         }
-    }
-
-    Item {
-        id: spacer
-        visible: chatsModel.activeChannel.chatType === Constants.chatTypePrivateGroupChat && chatsModel.activeChannel.isMember
-        width: parent.width
-        height: Style.current.bigPadding
-
     }
 }
 

--- a/ui/app/AppLayouts/Chat/ChatColumn/TopBar.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/TopBar.qml
@@ -6,12 +6,10 @@ import "../../../../shared/status"
 import "../../../../imports"
 import "../components"
 
-Rectangle {
+Item {
     property int iconSize: 16
     id: chatTopBarContent
-    color: Style.current.background
     height: 56
-    Layout.fillWidth: true
 
     Loader {
       property bool isGroupChatOrOneToOne: (chatsModel.activeChannel.chatType === Constants.chatTypePrivateGroupChat || 
@@ -65,7 +63,6 @@ Rectangle {
             muted: chatsModel.activeChannel.muted
         }
     }
-
 
     StatusContextMenuButton {
         id: moreActionsBtn

--- a/ui/shared/status/StatusChatInfo.qml
+++ b/ui/shared/status/StatusChatInfo.qml
@@ -33,7 +33,7 @@ Item {
         target: profileModel.contacts.list
         onContactChanged: {
             if (pubkey === root.chatId) {
-                root.profileImage = appMain.getProfileImage(root.chatId)
+                root.profileImage = appMain.getProfileImage(root.chatId) || ""
             }
         }
     }


### PR DESCRIPTION
Fixes #2384

Adds the "Add to Contact" banner at the top if it's a 1 to 1 chat and the user is not a contact. You can hide it. The banner will come back if you close the app and reopen. It can be changed to be in the settings if wanted.

Positions the chat identifier at the top of the screen when it's empty (or not enough content). We used to have it like that before too, but when we changed the ListView to BottomToTop, we lost it. 
To fake that behaviour, I added a `header` that is invisible and just adds a spacer. I added a big comment in the ChatMessages file to explain how and why it works.

![image](https://user-images.githubusercontent.com/11926403/116447922-83e55300-a826-11eb-90ad-90f73f30ad74.png)
