### PR TITLE
Fetch community info from link

### DIFF
--- a/src/app/chat/views/communities.nim
+++ b/src/app/chat/views/communities.nim
@@ -169,11 +169,14 @@ QtObject:
       result = fmt"Error joining the community: {e.msg}"
 
   proc membershipRequestChanged*(self: CommunitiesView, communityName: string, accepted: bool) {.signal.}
+  
+  proc communityAdded*(self: CommunitiesView, communityId: string) {.signal.}
 
   proc addCommunityToList*(self: CommunitiesView, community: Community) =
     let communityCheck = self.communityList.getCommunityById(community.id)
     if (communityCheck.id == ""):
       self.communityList.addCommunityItemToList(community)
+      self.communityAdded(community.id)
     else:
       self.communityList.replaceCommunity(community)
 
@@ -341,6 +344,12 @@ QtObject:
       error "Error declining request to join the community", msg = e.msg
       return "Error declining request to join the community"
     return ""
+
+  proc requestCommunityInfo*(self: CommunitiesView, communityId: string) {.slot.} =
+    try:
+      self.status.chat.requestCommunityInfo(communityId)
+    except Exception as e:
+      error "Error fetching community info", msg = e.msg
 
   proc getChannel*(self: CommunitiesView, channelId: string): Chat =
     for community in self.joinedCommunityList.communities:

--- a/ui/app/AppLayouts/Chat/ChatColumn/Message.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/Message.qml
@@ -29,6 +29,22 @@ Item {
     property string communityId: ""
     property int stickerPackId: -1
 
+    property string displayUserName: {
+        if (isCurrentUser) {
+            //% "You"
+            return qsTrId("You")
+        }
+
+        if (localName !== "") {
+            return localName
+        }
+
+        if (userName !== "") {
+            return Utils.removeStatusEns(userName)
+        }
+        return Utils.removeStatusEns(alias)
+    }
+
     property string authorCurrentMsg: "authorCurrentMsg"
     property string authorPrevMsg: "authorPrevMsg"
 

--- a/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/InvitationBubble.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/InvitationBubble.qml
@@ -71,7 +71,7 @@ Item {
                 StyledText {
                     id: invitedYou
                     //% "%1 invited you to join a community"
-                    text: qsTrId("-1-invited-you-to-join-a-community").arg(userName)
+                    text: qsTrId("-1-invited-you-to-join-a-community").arg(displayUserName)
                     anchors.top: title.bottom
                     anchors.topMargin: 4
                     anchors.left: parent.left

--- a/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/UsernameLabel.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/UsernameLabel.qml
@@ -12,21 +12,7 @@ Item {
 
     StyledTextEdit {
         id: chatName
-        text: {
-            if (isCurrentUser) {
-                //% "You"
-                return qsTrId("You")
-            }
-
-            if (localName !== "") {
-                return localName
-            }
-
-            if (userName !== "") {
-                return Utils.removeStatusEns(userName)
-            }
-            return Utils.removeStatusEns(alias)
-        }
+        text: displayUserName
         color: text.startsWith("@") || isCurrentUser || localName !== "" ? Style.current.blue : Style.current.secondaryText
         font.weight: Font.Medium
         font.pixelSize: Style.current.secondaryTextFontSize

--- a/ui/imports/Utils.qml
+++ b/ui/imports/Utils.qml
@@ -371,7 +371,6 @@ QtObject {
         }
 
         // Community
-        // TODO this will probably change
         index = link.lastIndexOf("/cc/")
         if (index > -1) {
             const communityId = link.substring(index + 4)
@@ -379,8 +378,10 @@ QtObject {
             const communityName = chatsModel.communities.getCommunityNameById(communityId)
 
             if (!communityName) {
-                // Unknown community
-                // TODO use a function to fetch that community?
+                // Unknown community, fetch the info if possible
+                chatsModel.communities.requestCommunityInfo(communityId)
+                result.communityId = communityId
+                result.fetching = true
                 return result
             }
 
@@ -423,6 +424,7 @@ QtObject {
             site: qsTr("Status app link"),
             title: result.title,
             communityId: result.communityId,
+            fetching: result.fetching,
             thumbnailUrl: "../../../../img/status.png",
             contentType: "",
             height: 0,


### PR DESCRIPTION
Fixes #2290

When we find link in the chat and the community is not part of our list, we fetch it from the mailserver.
Since sometimes the mailserver is not ready at first, we use the event to fetch at the right time.

Then we get the signal from QML and show the unfurled data.

We might want a design for what do show during the loading.

Steps to test:
1. Login in account 1
2. Create a community
3. Click Invite and copy the invite link
4. Paste invite link in a chat where the second account can see it
5. Logout and login with account 2
6. Go in the channel where you can see the link
7. Wait a couple of seconds for the fetch to finish (will need a design)
8. Unfurling appears