### PR TITLE
fix(CommunityTransfer): fix private key display to match design

### DIFF
--- a/ui/app/AppLayouts/Chat/CommunityComponents/TransferOwnershipPopup.qml
+++ b/ui/app/AppLayouts/Chat/CommunityComponents/TransferOwnershipPopup.qml
@@ -22,10 +22,21 @@ ModalPopup {
         anchors.fill: parent
 
         Input {
+            property string elidedPkey: popup.privateKey.substring(0, 15) + "..." + popup.privateKey.substring(popup.privateKey.length - 16)
+
             id: pKeyInput
             label: qsTr("Community private key")
-            text: popup.privateKey
-            copyToClipboard: popup.privateKey
+            text: elidedPkey
+            textField.onFocusChanged: {
+                if (textField.focus) {
+                   pKeyInput.text =  popup.privateKey
+                } else {
+                    pKeyInput.text =  elidedPkey
+                }
+            }
+
+            copyToClipboard: true
+            textToCopy: popup.privateKey
         }
 
         StyledText {

--- a/ui/shared/Input.qml
+++ b/ui/shared/Input.qml
@@ -19,6 +19,7 @@ Item {
     property int iconHeight: 24
     property int iconWidth: 24
     property bool copyToClipboard: false
+    property string textToCopy
     property bool pasteFromClipboard: false
     property bool readOnly: false
 
@@ -150,7 +151,7 @@ Item {
                         showBorder: true
                         onClicked: {
                             if (inputBox.copyToClipboard) {
-                                chatsModel.copyToClipboard(inputValue.text)
+                                chatsModel.copyToClipboard(inputBox.textToCopy ? inputBox.textToCopy : inputValue.text)
                             } else {
                                 if (inputValue.canPaste) {
                                     inputValue.paste()


### PR DESCRIPTION
Fixes #2419

Makes it so the private key is elided by default so you can see it all from the get-go. If you focus the field, the key will "unfurl" and you can copy it manually.
Otherwise. the Copy button will always copy the whole key