### PR TITLE
build: modify run logic for macOS dev builds so notifications work

### DIFF
--- a/Info.dev.plist
+++ b/Info.dev.plist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+        <key>CFBundleDisplayName</key>
+        <string>Status Desktop DEV</string>
+        <key>CFBundleExecutable</key>
+        <string>nim_status_client</string>
+        <key>CFBundleIconFile</key>
+        <string>status-dev.icns</string>
+        <key>CFBundleIdentifier</key>
+        <string>im.Status.NimStatusClientDev</string>
+        <key>CFBundleInfoDictionaryVersion</key>
+        <string>6.0</string>
+        <key>CFBundleName</key>
+        <string>StatusDev</string>
+        <key>CFBundlePackageType</key>
+        <string>APPL</string>
+        <key>CFBundleShortVersionString</key>
+        <string>1.0.0</string>
+        <key>IFMajorVersion</key>
+        <integer>1</integer>
+        <key>IFMinorVersion</key>
+        <integer>0</integer>
+        <key>NSHighResolutionCapable</key>
+        <string>True</string>
+    </dict>
+</plist>

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,6 @@ BUILD_SYSTEM_DIR := vendor/nimbus-build-system
 	run-linux \
 	run-macos \
 	run-windows \
-	set-status-macos-dev-icon \
 	status-go \
 	update
 
@@ -408,17 +407,20 @@ $(ICON_TOOL):
 # Currently not in use: https://github.com/status-im/status-desktop/pull/1858
 # STATUS_PORT ?= 30306
 
-set-status-macos-dev-icon: $(ICON_TOOL)
-	npx fileicon set bin/nim_status_client status-dev.icns
-
 run-linux:
 	echo -e "\e[92mRunning:\e[39m bin/nim_status_client"
 	LD_LIBRARY_PATH="$(QT5_LIBDIR)":"$(STATUSGO_LIBDIR)" \
 	./bin/nim_status_client
 
-run-macos: set-status-macos-dev-icon
-	echo -e "\e[92mRunning:\e[39m bin/nim_status_client"
-	./bin/nim_status_client
+run-macos: $(ICON_TOOL)
+	mkdir -p bin/StatusDev.app/Contents/{MacOS,Resources}
+	cp Info.dev.plist bin/StatusDev.app/Contents/Info.plist
+	cp status-dev.icns bin/StatusDev.app/Contents/Resources/
+	cd bin/StatusDev.app/Contents/MacOS && \
+		ln -fs ../../../nim_status_client ./
+	npx fileicon set bin/nim_status_client status-dev.icns
+	echo -e "\e[92mRunning:\e[39m bin/StatusDev.app/Contents/MacOS/nim_status_client"
+	./bin/StatusDev.app/Contents/MacOS/nim_status_client
 
 run-windows: $(NIM_WINDOWS_PREBUILT_DLLS)
 	echo -e "\e[92mRunning:\e[39m bin/nim_status_client.exe"


### PR DESCRIPTION
For notifications to work in local dev builds (`make run`) *and* if the orange development icon is to display properly, it's important to invoke `bin/nim_status_client` in an `.app` bundle-directory that has the correct layout and an `Info.plist`. The `make run` logic for macOS handles all that automatically per the changes in this PR.

Note that sometimes the notifications for dev and prod builds will mysteriously stop working. If that happens (or they're already not working), on macOS open System Preferences -> Notifications. Then scroll until you reach Status and/or StatusDev. If there's an entry for Status, click on it and press the delete key. If there's an entry for StatusDev, click on it and press the delete key.

The next time you run the dev/prod app, macOS will prompt you to allow notifications for the app. Hopefully notifications will then start working again, at least for awhile. 🤞 