### PR TITLE
chore: add StatusQ as dependency

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -100,3 +100,9 @@
 [submodule "vendor/nim-confutils"]
 	path = vendor/nim-confutils
 	url = https://github.com/status-im/nim-confutils.git
+[submodule "vendor/status-qml"]
+	path = vendor/status-qml
+	url = https://github.com/PascalPrecht/status-qml
+[submodule "ui/StatusQ"]
+	path = ui/StatusQ
+	url = https://github.com/status-im/StatusQ

--- a/src/nim_status_client.nim
+++ b/src/nim_status_client.nim
@@ -80,6 +80,7 @@ proc mainProc() =
   let networkAccessFactory = newQNetworkAccessManagerFactory(TMPDIR & "netcache")
 
   let engine = newQQmlApplicationEngine()
+  engine.addImportPath("qrc:/./StatusQ/src")
   engine.setNetworkAccessManagerFactory(networkAccessFactory)
 
   let netAccMgr = newQNetworkAccessManager(engine.getNetworkAccessManager())

--- a/ui/generate-rcc.sh
+++ b/ui/generate-rcc.sh
@@ -4,7 +4,7 @@ QRC=./resources.qrc
 echo '<!DOCTYPE RCC>' > $QRC
 echo '<RCC version="1.0">' >> $QRC
 echo '  <qresource>' >> $QRC
-for a in $(find . -not -name "*.pro" -not -name "*.rcc" -not -name "*.sh" -not -name "*.qrc"    )
+for a in $(find -L . -not -name "*.pro" -not -name "*.rcc" -not -name "*.sh" -not -name "*.qrc" -not -name ".git" -not -name ".gitignore"   )
 do
     if [ ! -d "$a" ]; then
         echo '      <file>'$a'</file>' >> $QRC


### PR DESCRIPTION
This commit does a couple of things:

- add StatusQ as a dependency (https://github.com/status-im/StatusQ)
  our emerging component library
- updates the rcc generation script to follow symlinks as well
- add qrc:/./StatusQ/src as import path

At the time of creating this commit `StatusQ` provides only the StatusIcon
component, but more will be added in the future.

## Usage:

```
import Status.Core 0.1
```

More modules will be added soon (e.g. `Status.Controls`, `Status.Components`, `Status.Popups` etc)