### PR TITLE
fix: show suggestion profile pics for contacts only

### DIFF
--- a/src/app/profile/core.nim
+++ b/src/app/profile/core.nim
@@ -108,6 +108,7 @@ proc init*(self: ProfileController, account: Account) =
   self.status.events.on("contactRemoved") do(e: Args):
     let contacts = self.status.contacts.getContacts()
     self.view.contacts.setContactList(contacts)
+    self.view.contactsChanged()
 
   self.status.events.on("mailserver:changed") do(e: Args):
     let mailserverArg = MailserverArgs(e)

--- a/ui/app/AppLayouts/Chat/ChatColumn.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn.qml
@@ -72,13 +72,11 @@ StackLayout {
         for (let i = 0; i < len; i++) {
             const contactAddr = chatsModel.suggestionList.rowData(i, "address");
             if(idMap[contactAddr]) continue;
-            const contactIndex = profileModel.contacts.list.getContactIndexByPubkey(chatsModel.suggestionList.rowData(i, "address"));
-
             suggestionsObj.push({
                                     alias: chatsModel.suggestionList.rowData(i, "alias"),
                                     ensName: chatsModel.suggestionList.rowData(i, "ensName"),
                                     address: contactAddr,
-                                    identicon: profileModel.contacts.list.rowData(contactIndex, "thumbnailImage"),
+                                    identicon: getProfileImage(contactAddr, false, false) || chatsModel.suggestionList.rowData(i, "identicon"),
                                     localNickname: chatsModel.suggestionList.rowData(i, "localNickname")
                                 })
 
@@ -283,6 +281,13 @@ StackLayout {
             }
             onMessagePushed: {
                 addSuggestionFromMessageList(messageIndex);
+            }
+        }
+
+        Connections {
+            target: profileModel
+            onContactsChanged: {
+                populateSuggestions();
             }
         }
 


### PR DESCRIPTION
Fixes: #2365.

Previously, suggestions for mentions were showing profile pics even for users who were not contacts. Now, profile pics are only shown for those users who are contacts. The user’s identicon is shown otherwise.

fix: user thumbnail not shown when no profile pic
When a user was a contact, but didn’t have a profile pic, an image would not be loaded and a ‘reload’ image would be shown instead. With this PR, if the user is a contact and they do not have a profile pic, their identicon will be shown instead.