### PR TITLE
fix: show emoji in reaction tooltip

### DIFF
--- a/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/EmojiReactions.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/EmojiReactions.qml
@@ -46,16 +46,11 @@ Item {
 
         //% " reacted with "
         tooltip += qsTrId("-reacted-with-");
-
-        switch (emojiId) {
-        case 1: return tooltip + ":heart:"
-        case 2: return tooltip + ":thumbsup:"
-        case 3: return tooltip + ":thumbsdown:"
-        case 4: return tooltip + ":laughing:"
-        case 5: return tooltip + ":cry:"
-        case 6: return tooltip + ":angry:"
-        default: return tooltip
+        let emojiHtml = Emoji.getEmojiFromId(emojiId);
+        if (emojiHtml) {
+            tooltip += emojiHtml;
         }
+        return tooltip
     }
 
     Row {

--- a/ui/imports/Emoji.qml
+++ b/ui/imports/Emoji.qml
@@ -67,4 +67,25 @@ QtObject {
         })
         return String.fromCodePoint(...codePointParts);
     }
+
+    function getShortcodeFromId(emojiId) {
+        switch (emojiId) {
+            case 1: return ":heart:"
+            case 2: return ":thumbsup:"
+            case 3: return ":thumbsdown:"
+            case 4: return ":laughing:"
+            case 5: return ":cry:"
+            case 6: return ":angry:"
+            default: return undefined
+        }
+    }
+
+    function getEmojiFromId(emojiId) {
+        let shortcode = Emoji.getShortcodeFromId(emojiId)
+        let emojiUnicode = Emoji.getEmojiUnicode(shortcode)
+        if (emojiUnicode) {
+            return Emoji.fromCodePoint(emojiUnicode)
+        }
+        return undefined
+    }
 }


### PR DESCRIPTION
Fixes: #2387.

Shows the emoji in the emoji reaction tooltip instead of the shorthand (ie 👎 instead of `:thumbsdown:`).