### PR TITLE
fix: interrupt running sticker task when exiting

### DIFF
--- a/src/status/stickers.nim
+++ b/src/status/stickers.nim
@@ -1,5 +1,5 @@
 import # global deps
-  tables, strutils, sequtils
+  atomics, sequtils, strutils, tables
 
 import # project deps
   chronicles, web3/[ethtypes, conversions], stint
@@ -107,7 +107,7 @@ proc getInstalledStickerPacks*(self: StickersModel): Table[int, StickerPack] =
   self.installedStickerPacks = status_stickers.getInstalledStickerPacks()
   result = self.installedStickerPacks
 
-proc getAvailableStickerPacks*(): Table[int, StickerPack] = status_stickers.getAvailableStickerPacks()
+proc getAvailableStickerPacks*(running: var Atomic[bool]): Table[int, StickerPack] = status_stickers.getAvailableStickerPacks(running)
 
 proc getRecentStickers*(self: StickersModel): seq[Sticker] =
   result = status_stickers.getRecentStickers()

--- a/src/status/wallet/collectibles.nim
+++ b/src/status/wallet/collectibles.nim
@@ -1,11 +1,14 @@
-import strformat, httpclient, json, chronicles, sequtils, strutils, tables, sugar, net
-import ../libstatus/core as status
-import ../libstatus/eth/contracts as contracts
-import ../libstatus/stickers as status_stickers
-import ../libstatus/types
-import web3/[conversions, ethtypes], stint
-import ../libstatus/utils
-import account
+import # std libs
+  atomics, strformat, httpclient, json, chronicles, sequtils, strutils, tables,
+  sugar, net
+
+import # vendor libs
+  stint
+
+import # status-desktop libs
+  ../libstatus/core as status, ../libstatus/eth/contracts as contracts,
+  ../libstatus/stickers as status_stickers, ../libstatus/types,
+  web3/[conversions, ethtypes], ../libstatus/utils, account
 
 const CRYPTOKITTY* = "cryptokitty"
 const KUDO* = "kudo"
@@ -198,7 +201,7 @@ proc getKudos*(address: string): string =
   let eth_address = parseAddress(address)
   result = getKudos(eth_address)
 
-proc getStickers*(address: Address): string =
+proc getStickers*(address: Address, running: var Atomic[bool]): string =
   try:
     var stickers: seq[Collectible]
     stickers = @[]
@@ -215,7 +218,7 @@ proc getStickers*(address: Address): string =
     if (purchasedStickerPacks.len == 0):
       return $(%*stickers)
     # TODO find a way to keep those in memory so as not to reload it each time
-    let availableStickerPacks = getAvailableStickerPacks()
+    let availableStickerPacks = getAvailableStickerPacks(running)
 
     var index = 0
     for stickerId in purchasedStickerPacks:
@@ -234,6 +237,6 @@ proc getStickers*(address: Address): string =
     error "Error getting Stickers", msg = e.msg
     result = e.msg
 
-proc getStickers*(address: string): string =
+proc getStickers*(address: string, running: var Atomic[bool]): string =
   let eth_address = parseAddress(address)
-  result = getStickers(eth_address)
+  result = getStickers(eth_address, running)


### PR DESCRIPTION
Fixes: #2318.

Currently, when exiting the app and the sticker packs task is being run, the app will wait for the sticker packs task to completely finish before exiting the app. This causes a beachball to be displayed and can cause a long delay while waiting for the task to finish.

This PR passes an interrupt signal to the sticker pack loading task in the threadpool thread. The task loads the interrupt on each iteration of its loop (each sticker pack to load) and also during the processing of each sticker pack (getting of sticker pack data). This allows the application to exit neatly.

fix: Handle shutdown of long-running (marathon) task before login
Currently, we wait for the “loggedIn” message to be passed to the marathon task runner before initialising the mailserver model. We were, however, blocking the thread until “loggedIn” was received, meaning that if “shutdown” was received (as it is when cmd+q is pressed), this message would be ignored and the application would have to be forced to quit.

This PR adds logic that not only listens for the “loggedIn” message, but also for the “shudown” message. Once the “shutdown” message is received, the marathon worker thread exits.