### PR TITLE
fix(StatusLetterIdenticon): ensure letterSize is correct

### DIFF
--- a/ui/shared/status/StatusLetterIdenticon.qml
+++ b/ui/shared/status/StatusLetterIdenticon.qml
@@ -7,7 +7,7 @@ Rectangle {
 
     property string chatId
     property string chatName
-    property int letterSize: root.isCompact ? 15 : 21
+    property int letterSize: 15
 
     width: 40
     height: 40


### PR DESCRIPTION
Due to historic reasons, conditionally assign a font size for the letter
identicon, based on whether or not the app's compact mode is active.

Compact mode has become the new default a while back and the component's
`isCompact` property isn't set anywhere in throughout the application,
resulting in `letterSize` to always be `21`, which is too big.

This commit removes the condition, defaulting to always having a letter size
of 15 pixels as designed.