### PR TITLE
refactor text formation to increase performance and enable undo

### DIFF
--- a/src/app/chat/view.nim
+++ b/src/app/chat/view.nim
@@ -945,3 +945,50 @@ QtObject:
         fromValue: fromValue
       )
     mailserverWorker.start(task)
+
+  proc formatInputStuff(self: ChatsView, regex: Regex, inputText: string): string =
+    var matches: seq[tuple[first, last: int]] = @[(-1, 0)]
+
+    var resultTuple: tuple[first, last: int]
+    var start = 0
+    var results: seq[tuple[first, last: int]] = @[]
+
+    while true:
+      resultTuple = inputText.findBounds(regex, matches, start)
+      if (resultTuple[0] == -1):
+        break
+      start = resultTuple[1] + 1
+      results.add(matches[0])
+
+    if (results.len == 0):
+      return ""
+    
+    var jsonString = "["
+    var first = true
+    
+    for result in results:
+      if (not first):
+        jsonString = jsonString & ","
+      first = false
+      jsonString = jsonString & "[" & $result[0] & "," & $result[1] & "]"
+
+    jsonString = jsonString & "]"
+
+    return jsonString
+
+
+  proc formatInputItalic(self: ChatsView, inputText: string): string {.slot.} =
+    let italicRegex = re"""(?<!\>)(?<!\*)\*(?!<span style=" font-style:italic;">)([^*]+)(?!<\/span>)\*"""
+    self.formatInputStuff(italicRegex, inputText)
+
+  proc formatInputBold(self: ChatsView, inputText: string): string {.slot.} =
+    let boldRegex = re"""(?<!\>)\*\*(?!<span style=" font-weight:600;">)([^*]+)(?!<\/span>)\*\*"""
+    self.formatInputStuff(boldRegex, inputText)
+
+  proc formatInputStrikeThrough(self: ChatsView, inputText: string): string {.slot.} =
+    let strikeThroughRegex = re"""(?<!\>)~~(?!<span style=" text-decoration: line-through;">)([^*]+)(?!<\/span>)~~"""
+    self.formatInputStuff(strikeThroughRegex, inputText)
+
+  proc formatInputCode(self: ChatsView, inputText: string): string {.slot.} =
+    let strikeThroughRegex = re"""(?<!\>)`(?!<span style=" font-family:'monospace';">)([^*]+)(?!<\/span>)`"""
+    self.formatInputStuff(strikeThroughRegex, inputText)

--- a/ui/imports/Emoji.qml
+++ b/ui/imports/Emoji.qml
@@ -34,17 +34,21 @@ QtObject {
         return Twemoji.twemoji.convert.fromCodePoint(value)
     }
     function deparse(value) {
-        return value.replace(/<img src=\"qrc:\/imports\/twemoji\/.+?" alt=\"(.+?)\" width=\"[0-9]*\" height=\"[0-9]*\" style=\"(.+?)\" \/>/g, "$1");
+        return value.replace(/<img src=\"qrc:\/imports\/twemoji\/.+?" alt=\"(.+?)\" width=\"[0-9]*\" height=\"[0-9]*\" style=\"(.+?)\" ?\/>/g, "$1");
     }
     function deparseFromParse(value) {
-        return value.replace(/<img class=\"emoji\" draggable=\"false\" alt=\"(.+?)\" src=\"qrc:\/imports\/twemoji\/.+?" width=\"[0-9]*\" height=\"[0-9]*\" style=\"(.+?)\" \/>/g, "$1");
+        return value.replace(/<img class=\"emoji\" draggable=\"false\" alt=\"(.+?)\" src=\"qrc:\/imports\/twemoji\/.+?" width=\"[0-9]*\" height=\"[0-9]*\" style=\"(.+?)\" ?\/>/g, "$1");
     }
     function hasEmoji(value) {
-        let match = value.match(/<img src=\"qrc:\/imports\/twemoji\/.+?" alt=\"(.+?)\" width=\"[0-9]*\" height=\"[0-9]*\" style=\"(.+?)\" \/>/g)
+        let match = value.match(/<img src=\"qrc:\/imports\/twemoji\/.+?" alt=\"(.+?)\" width=\"[0-9]*\" height=\"[0-9]*\" style=\"(.+?)\" ?\/>/g)
         return match && match.length > 0
     }
+    function nbEmojis(value) {
+        let match = value.match(/<img src=\"qrc:\/imports\/twemoji\/.+?" alt=\"(.+?)\" width=\"[0-9]*\" height=\"[0-9]*\" style=\"(.+?)\" ?\/>/g)
+        return match ? match.length : 0
+    }
     function getEmojis(value) {
-        return value.match(/<img class=\"emoji\" draggable=\"false\" alt=\"(.+?)\" src=\"qrc:\/imports\/twemoji\/.+?" width=\"[0-9]*\" height=\"[0-9]*\" style=\"(.+?)\" \/>/g, "$1");
+        return value.match(/<img class=\"emoji\" draggable=\"false\" alt=\"(.+?)\" src=\"qrc:\/imports\/twemoji\/.+?" width=\"[0-9]*\" height=\"[0-9]*\" style=\"(.+?)\" ?\/>/g, "$1");
     }
     function getEmojiUnicode(shortname) {
         var _emoji;


### PR DESCRIPTION
Fixes #2326 

So, enabling ctrl-z should have been simple, it's actually available by default on TextEdits, but since we used `textEdit.text = ...` so much, it breaks the functionality.

So I had to refactor the text formation and the other text insertions like mentions and emojis, so instead of replacing the whole text (and also reparsing ALL of the text), we just remove and insert the particular part that changed.

It's both way more performant and also makes it possible to undo and redo.

I also moved the txt formation regex checks to Ni, because the QML regex engine is a little old and there is no look-behind. Also, it should be a bit faster in Nim than in JS.

Some known issues:
- If thee is an emoji and you move the cursor next to the emoji then hit a space or another character, the following text formations will be broken, because QML adds a useless `span`
- Text formations **right** after a break line (`br`) do not work. Just adding a space or a character makes it work
- Adding a double text formation to a word sometimes doesn't work depending on the order (strike + bold works, but bold + strike is a bit weird)
- Paste still needs a follow up refactor to use the new formation method so we can finally remove the old formation function for good
- interrogateMessage needs a refactor as well so it uses insert correctly