### PR TITLE
feat: edit communities

### DIFF
--- a/src/app/chat/views/community_list.nim
+++ b/src/app/chat/views/community_list.nim
@@ -143,7 +143,7 @@ QtObject:
     let topLeft = self.createIndex(index, index, nil)
     let bottomRight = self.createIndex(index, index, nil)
     self.communities[index] = community
-    self.dataChanged(topLeft, bottomRight, @[CommunityRoles.Name.int, CommunityRoles.Description.int, CommunityRoles.UnviewedMessagesCount.int])
+    self.dataChanged(topLeft, bottomRight, @[CommunityRoles.Name.int, CommunityRoles.Description.int, CommunityRoles.UnviewedMessagesCount.int, CommunityRoles.ThumbnailImage.int])
 
   proc removeCategoryFromCommunity*(self: CommunityList, communityId: string, categoryId:string) =
     var community = self.getCommunityById(communityId)

--- a/src/status/chat.nim
+++ b/src/status/chat.nim
@@ -447,6 +447,9 @@ proc getJoinedComunities*(self: ChatModel): seq[Community] =
 proc createCommunity*(self: ChatModel, name: string, description: string, access: int, ensOnly: bool, color: string, imageUrl: string, aX: int, aY: int, bX: int, bY: int): Community =
   result = status_chat.createCommunity(name, description, access, ensOnly, color, imageUrl, aX, aY, bX, bY)
 
+proc editCommunity*(self: ChatModel, id: string, name: string, description: string, access: int, ensOnly: bool, color: string, imageUrl: string, aX: int, aY: int, bX: int, bY: int): Community =
+  result = status_chat.editCommunity(id, name, description, access, ensOnly, color, imageUrl, aX, aY, bX, bY)
+
 proc createCommunityChannel*(self: ChatModel, communityId: string, name: string, description: string): Chat =
   result = status_chat.createCommunityChannel(communityId, name, description)
 

--- a/src/status/libstatus/chat.nim
+++ b/src/status/libstatus/chat.nim
@@ -304,7 +304,34 @@ proc createCommunity*(name: string, description: string, access: int, ensOnly: b
       "imageBy": bY
     }]).parseJSON()
 
-  if rpcResult{"result"}.kind != JNull:
+  if rpcResult{"error"} != nil:
+    let error = Json.decode($rpcResult{"error"}, RpcError)
+    raise newException(RpcException, "Error editing community channel: " & error.message)
+
+  if rpcResult{"result"} != nil and rpcResult{"result"}.kind != JNull:
+    result = rpcResult["result"]["communities"][0].toCommunity()
+
+proc editCommunity*(communityId: string, name: string, description: string, access: int, ensOnly: bool, color: string, imageUrl: string, aX: int, aY: int, bX: int, bY: int): Community =
+  let rpcResult = callPrivateRPC("editCommunity".prefix, %*[{
+      # TODO this will need to be renamed membership (small m)
+      "CommunityID": communityId,
+      "Membership": access,
+      "name": name,
+      "description": description,
+      "ensOnly": ensOnly,
+      "color": color,
+      "image": imageUrl,
+      "imageAx": aX,
+      "imageAy": aY,
+      "imageBx": bX,
+      "imageBy": bY
+    }]).parseJSON()
+
+  if rpcResult{"error"} != nil:
+    let error = Json.decode($rpcResult{"error"}, RpcError)
+    raise newException(RpcException, "Error editing community channel: " & error.message)
+
+  if rpcResult{"result"} != nil and rpcResult{"result"}.kind != JNull:
     result = rpcResult["result"]["communities"][0].toCommunity()
 
 proc createCommunityChannel*(communityId: string, name: string, description: string): Chat =

--- a/ui/app/AppLayouts/Chat/CommunityColumn.qml
+++ b/ui/app/AppLayouts/Chat/CommunityColumn.qml
@@ -213,6 +213,14 @@ Rectangle {
 
         CommunityProfilePopup {
             id: communityProfilePopup
+            communityId: chatsModel.communities.activeCommunity.id
+            name: chatsModel.communities.activeCommunity.name
+            description: chatsModel.communities.activeCommunity.description
+            access: chatsModel.communities.activeCommunity.access
+            nbMembers: chatsModel.communities.activeCommunity.nbMembers
+            isAdmin: chatsModel.communities.activeCommunity.admin
+            source: chatsModel.communities.activeCommunity.thumbnailImage
+            communityColor: chatsModel.communities.activeCommunity.communityColor
         }
     }
 }

--- a/ui/app/AppLayouts/Chat/CommunityComponents/CommunityHeaderButton.qml
+++ b/ui/app/AppLayouts/Chat/CommunityComponents/CommunityHeaderButton.qml
@@ -79,15 +79,6 @@ Button {
         cursorShape: Qt.PointingHandCursor
         anchors.fill: parent
         onPressed: {
-          communityProfilePopup.communityId = chatsModel.communities.activeCommunity.id;
-          communityProfilePopup.name = chatsModel.communities.activeCommunity.name;
-          communityProfilePopup.description = chatsModel.communities.activeCommunity.description;
-          communityProfilePopup.access = chatsModel.communities.activeCommunity.access;
-          communityProfilePopup.nbMembers = chatsModel.communities.activeCommunity.nbMembers;
-          communityProfilePopup.isAdmin = chatsModel.communities.activeCommunity.admin
-          communityProfilePopup.source = chatsModel.communities.activeCommunity.thumbnailImage
-          communityProfilePopup.communityColor = chatsModel.communities.activeCommunity.communityColor
-
           communityProfilePopup.open();
         }
         hoverEnabled: true

--- a/ui/app/AppLayouts/Chat/CommunityComponents/CommunityProfilePopup.qml
+++ b/ui/app/AppLayouts/Chat/CommunityComponents/CommunityProfilePopup.qml
@@ -10,15 +10,14 @@ import "../../../../shared/status"
 import "../ContactsColumn"
 
 ModalPopup {
-    property QtObject community: chatsModel.communities.activeCommunity
-    property string communityId: community.id
-    property string name: community.name
-    property string description: community.description
-    property int access: community.access
-    property string source: ""
-    property string communityColor: ""
-    property int nbMembers: community.nbMembers
-    property bool isAdmin: false
+    property string communityId: chatsModel.communities.activeCommunity.id
+    property string name: chatsModel.communities.activeCommunity.name
+    property string description: chatsModel.communities.activeCommunity.description
+    property int access: chatsModel.communities.activeCommunity.access
+    property string source: chatsModel.communities.activeCommunity.source
+    property string communityColor: chatsModel.communities.activeCommunity.communityColor
+    property int nbMembers: chatsModel.communities.activeCommunity.nbMembers
+    property bool isAdmin: chatsModel.communities.activeCommunity.isAdmin
     height: stack.currentItem.height + modalHeader.height + modalFooter.height + Style.current.padding * 3
     id: popup
 
@@ -126,6 +125,7 @@ ModalPopup {
             CommunityProfilePopupMembersList {
                 headerTitle: qsTr("Members")
                 headerDescription: popup.nbMembers.toString()
+                members: chatsModel.communities.activeCommunity.members
             }
         }
 
@@ -133,7 +133,7 @@ ModalPopup {
             id: profileOverview
             CommunityProfilePopupOverview {
                 property bool useLetterIdenticon: !!!popup.source
-                headerTitle: popup.name
+                headerTitle: chatsModel.communities.activeCommunity.name
                 headerDescription: {
                     switch(access) {
                         //% "Public community"
@@ -146,8 +146,8 @@ ModalPopup {
                         default: return qsTrId("unknown-community");
                     }
                 }
-                headerImageSource: popup.source
-                description: popup.description
+                headerImageSource: chatsModel.communities.activeCommunity.thumbnailImage
+                description: chatsModel.communities.activeCommunity.description
             }
         }
     }

--- a/ui/app/AppLayouts/Chat/CommunityComponents/CommunityProfilePopupMembersList.qml
+++ b/ui/app/AppLayouts/Chat/CommunityComponents/CommunityProfilePopupMembersList.qml
@@ -12,6 +12,7 @@ Item {
     property string headerTitle: ""
     property string headerDescription: ""
     property string headerImageSource: ""
+    property alias members: memberList.model
     height: 450
 
     CommunityPopupButton {
@@ -74,7 +75,6 @@ Item {
         anchors.bottomMargin: Style.current.bigPadding
         spacing: 4
         clip: true
-        model: community.members
         delegate: Rectangle {
             id: contactRow
             width: parent.width

--- a/ui/app/AppLayouts/Chat/CommunityComponents/CommunityProfilePopupOverview.qml
+++ b/ui/app/AppLayouts/Chat/CommunityComponents/CommunityProfilePopupOverview.qml
@@ -202,13 +202,14 @@ Item {
         }
 
         Loader {
-            // TODO once Edit is vailable in the app, put back isAdmin
-            active: false//isAdmin
+            // TODO: once Edit is vailable in the app, put back isAdmin
+            active: isAdmin
             width: parent.width
             sourceComponent: CommunityPopupButton {
                 //% "Edit community"
                 label: qsTrId("edit-community")
                 iconName: "edit"
+                type: globalSettings.theme === Universal.Dark ? "secondary" : "primary"
                 onClicked: openPopup(editCommunityPopup)
             }
         }

--- a/ui/app/AppLayouts/Chat/CommunityComponents/CommunityWelcomeBanner.qml
+++ b/ui/app/AppLayouts/Chat/CommunityComponents/CommunityWelcomeBanner.qml
@@ -78,14 +78,6 @@ Rectangle {
         anchors.bottom: parent.bottom
         anchors.bottomMargin: Style.current.padding
         onClicked: {
-          communityProfilePopup.communityId = chatsModel.communities.activeCommunity.id;
-          communityProfilePopup.name = chatsModel.communities.activeCommunity.name;
-          communityProfilePopup.description = chatsModel.communities.activeCommunity.description;
-          communityProfilePopup.access = chatsModel.communities.activeCommunity.access;
-          communityProfilePopup.nbMembers = chatsModel.communities.activeCommunity.nbMembers;
-          communityProfilePopup.isAdmin = chatsModel.communities.activeCommunity.admin;
-          communityProfilePopup.source = chatsModel.communities.activeCommunity.thumbnailImage
-          communityProfilePopup.communityColor = chatsModel.communities.activeCommunity.communityColor
           communityProfilePopup.open()
         }
     }

--- a/ui/app/AppLayouts/Chat/CommunityComponents/CreateCommunityPopup.qml
+++ b/ui/app/AppLayouts/Chat/CommunityComponents/CreateCommunityPopup.qml
@@ -348,6 +348,9 @@ ModalPopup {
 
             StatusSettingsLineButton {
                 id: membershipRequirementSetting
+                // TODO: remove 'isEnabled: false' when we no longer need to force
+                // "request access" membership
+                isEnabled: false
                 anchors.top: separator1.bottom
                 anchors.topMargin: Style.current.halfPadding
                 text: qsTr("Membership requirement")
@@ -420,6 +423,9 @@ ModalPopup {
 
         MembershipRequirementPopup {
             id: membershipRequirementSettingPopup
+            // TODO: remove the 'checkedMemership' setting when we no longer need
+            // to force "require approval" membership
+            checkedMembership: Constants.communityChatOnRequestAccess
         }
     }
 

--- a/ui/app/AppMain.qml
+++ b/ui/app/AppMain.qml
@@ -274,6 +274,9 @@ RowLayout {
         id: editCommunityPopup
         CreateCommunityPopup {
             isEdit: true
+            onClosed: {
+                destroy()
+            }
         }
     }
 


### PR DESCRIPTION
Fixes: #2566.
Fixes: #2582.

Allow editing of Community name, description, image, colour, and access.

## Note
1. This PR relies on a [PR for status-go](https://github.com/status-im/status-go/pull/2229) that is currently not merged. It should be merged *first*, after which this PR can be updated with the new commit hash and then merged.
2. The PR for status-go is based on top of `develop` which may have some consequences for our use of `status-go`.