### PR TITLE
fix(Communities): don't list members in contacts to invite list

### DIFF
--- a/src/app/chat/views/community_item.nim
+++ b/src/app/chat/views/community_item.nim
@@ -152,6 +152,9 @@ QtObject:
   proc getMembers*(self: CommunityItemView): QVariant {.slot.} =
     result = newQVariant(self.members)
 
+  proc hasMember*(self: CommunityItemView, pubKey: string): bool {.slot.} =
+    result = self.members.members.contains(pubKey)
+
   QtProperty[QVariant] members:
     read = getMembers
 

--- a/ui/app/AppLayouts/Chat/CommunityComponents/CommunityProfilePopupInviteFriendsView.qml
+++ b/ui/app/AppLayouts/Chat/CommunityComponents/CommunityProfilePopupInviteFriendsView.qml
@@ -53,5 +53,6 @@ Item {
         anchors.top: sep.bottom
         anchors.topMargin: Style.current.smallPadding
         showCheckbox: true
+        hideCommunityMembers: true
     }
 }

--- a/ui/shared/ContactsListAndSearch.qml
+++ b/ui/shared/ContactsListAndSearch.qml
@@ -18,6 +18,7 @@ Item {
     property bool showContactList: true
     signal userClicked(bool isContact, string pubKey, string ensName, string address)
     property var pubKeys: ([])
+    property bool hideCommunityMembers: false
 
     id: root
     width: parent.width
@@ -141,6 +142,7 @@ Item {
     ExistingContacts {
         id: existingContacts
         visible: showContactList
+        hideCommunityMembers: root.hideCommunityMembers
         anchors.topMargin: this.height > 0 ? Style.current.xlPadding : 0
         anchors.top: chatKey.bottom
         showCheckbox: root.showCheckbox

--- a/ui/shared/ExistingContacts.qml
+++ b/ui/shared/ExistingContacts.qml
@@ -14,6 +14,7 @@ Item {
     property string filterText: ""
     property bool expanded: true
     property bool showCheckbox: false
+    property bool hideCommunityMembers: false
     property var pubKeys: ([])
     signal contactClicked(var contact)
 
@@ -47,7 +48,8 @@ Item {
                 visible: model.isContact && (root.filterText === "" ||
                     root.matchesAlias(model.name.toLowerCase(), root.filterText.toLowerCase()) ||
                     model.name.toLowerCase().includes(root.filterText.toLowerCase()) ||
-                    model.address.toLowerCase().includes(root.filterText.toLowerCase()))
+                    model.address.toLowerCase().includes(root.filterText.toLowerCase())) &&
+                    (!root.hideCommunityMembers || !chatsModel.communities.activeCommunity.hasMember(model.pubKey))
                 onContactClicked: function () {
                     root.contactClicked(model)
                 }


### PR DESCRIPTION
When inviting contacts to a community, Status Desktop suggests a list of
all contacts, even if contacts of that list are already members of the community.

This commit introduces a new flag to `ExistingContacts` component that
allows for configuring whether community members should be hidden or not

Fixes #2502