### PR TITLE
fix: prevent crash checking pending transactions

### DIFF
--- a/src/app/chat/views/stickers.nim
+++ b/src/app/chat/views/stickers.nim
@@ -147,7 +147,7 @@ QtObject:
     let pendingTransactions = status_wallet.getPendingTransactions()
     var pendingStickerPacks = initHashSet[int]()
     if (pendingTransactions != ""):
-      for trx in pendingTransactions.parseJson["result"].getElems():
+      for trx in pendingTransactions.parseJson{"result"}.getElems():
         if trx["type"].getStr == $PendingTransactionType.BuyStickerPack:
           pendingStickerPacks.incl(trx["data"].getStr.parseInt)
 

--- a/src/app/profile/views/ens_manager.nim
+++ b/src/app/profile/views/ens_manager.nim
@@ -111,7 +111,7 @@ QtObject:
     let pendingTransactions = status_wallet.getPendingTransactions()
     if (pendingTransactions == ""):
       return
-    for trx in pendingTransactions.parseJson["result"].getElems():
+    for trx in pendingTransactions.parseJson{"result"}.getElems():
       if trx["type"].getStr == $PendingTransactionType.RegisterENS:
         self.usernames.add trx["data"].getStr
         self.pendingUsernames.incl trx["data"].getStr

--- a/src/status/libstatus/core.nim
+++ b/src/status/libstatus/core.nim
@@ -21,7 +21,7 @@ proc callPrivateRPC*(methodName: string, payload = %* []): string =
     let response = status_go.callPrivateRPC($inputJSON)
     result = $response
     if parseJSON(result).hasKey("error"):
-      error "rpc response error", result = result
+      error "rpc response error", result, payload, methodName
   except Exception as e:
     error "error doing rpc request", methodName = methodName, exception=e.msg
 

--- a/src/status/wallet.nim
+++ b/src/status/wallet.nim
@@ -104,7 +104,7 @@ proc checkPendingTransactions*(self: WalletModel) =
     let latestBlock = parseInt($fromHex(Stuint[256], response["result"]["number"].getStr))
     let pendingTransactions = status_wallet.getPendingTransactions()
     if (pendingTransactions != ""):
-      self.confirmTransactionStatus(pendingTransactions.parseJson["result"], latestBlock)
+      self.confirmTransactionStatus(pendingTransactions.parseJson{"result"}, latestBlock)
     
 
 proc checkPendingTransactions*(self: WalletModel, address: string, blockNumber: int) =


### PR DESCRIPTION
There is an unknown state that the data dir seems to get in that causes the application to crash when checking pending transactions. This is fixed by checking if the pending transactions RPC result has a `”result”` field first before attempting to read it.

### NOTE:
Clearing the data directory fixed the issue for me, however I do not know what caused it in the first place. While the crash was happening, there was also an error appearing in the logs:
```
ERR 2021-05-18 15:40:47+10:00 rpc response error                         topics="rpc" tid=3893906 file=core.nim:24 methodName=wallet_getPendingTransactions payload=[] result="{\"jsonrpc\":\"2.0\",\"id\":0,\"error\":{\"code\":-32000,\"message\":\"no such column: transaction_hash\"}}"
```
After clearing the data dir, this error also went away.