### PR TITLE
fix: close window instead of app

### DIFF
--- a/ui/main.qml
+++ b/ui/main.qml
@@ -89,7 +89,7 @@ StatusWindow {
 
     //! Workaround for custom QQuickWindow
     Connections {
-        target: c
+        target: applicationWindow
         onClosing: {
             if (loader.sourceComponent == login) {
                 applicationWindow.visible = false;
@@ -411,12 +411,34 @@ StatusWindow {
     }
 
     MacTrafficLights {
-        parent: Overlay.overlay
+//        parent: Overlay.overlay
         anchors.left: parent.left
         anchors.top: parent.top
         anchors.margins: 13
 
         visible: Qt.platform.os === "osx" && !applicationWindow.isFullScreen
+
+        onClose: {
+            if (loader.sourceComponent == login ||
+                    loader.sourceComponent == intro) {
+                applicationWindow.visible = false;
+            }
+            else if (loader.sourceComponent == app) {
+                if (loader.item.appSettings.quitOnClose) {
+                    Qt.quit();
+                } else {
+                    applicationWindow.visible = false;
+                }
+            }
+        }
+
+        onMinimised: {
+            applicationWindow.showMinimized()
+        }
+
+        onMaximized: {
+            applicationWindow.toggleFullScreen()
+        }
     }
 }
 

--- a/ui/shared/MacTrafficLights.qml
+++ b/ui/shared/MacTrafficLights.qml
@@ -5,6 +5,10 @@ import "../imports"
 MouseArea {
     id: statusMacWindowButtons
 
+    signal close()
+    signal minimised()
+    signal maximized()
+
     hoverEnabled: true
 
     width: layout.implicitWidth
@@ -14,10 +18,6 @@ MouseArea {
                                                                                       : "#10FFFFFF"
     readonly property color inactiveBorder: Style.current.name === Constants.lightThemeName ? "#10000000"
                                                                                             : "#10FFFFFF"
-
-
-
-
 
     Row {
         id: layout
@@ -48,7 +48,7 @@ MouseArea {
                 id: closeSensor
                 anchors.fill: parent
 
-                onClicked: applicationWindow.close()
+                onClicked: statusMacWindowButtons.close()
             }
         }
 
@@ -77,7 +77,7 @@ MouseArea {
                 id: miniSensor
                 anchors.fill: parent
 
-                onClicked: applicationWindow.showMinimized()
+                onClicked: statusMacWindowButtons.minimised()
             }
         }
 
@@ -105,7 +105,7 @@ MouseArea {
                 id: maxiSensor
                 anchors.fill: parent
 
-                onClicked: applicationWindow.toggleFullScreen()
+                onClicked: statusMacWindowButtons.maximized()
             }
         }
     }


### PR DESCRIPTION
Clicking close button on MacOS should not close the desktop app, instead it should be closed and running until you quit it by CMD+Q or from OS UI:

![image](https://user-images.githubusercontent.com/82375995/120618902-2d41e900-c464-11eb-930b-2d49761e032a.png)

![image](https://user-images.githubusercontent.com/82375995/120618921-32069d00-c464-11eb-96e8-a47266071986.png)
