### PR TITLE
build: on Linux use tar+gzip to preserve +x attribute of .AppImage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -245,6 +245,7 @@ $(APPIMAGE_TOOL):
 	chmod +x $(APPIMAGE_TOOL)
 
 STATUS_CLIENT_APPIMAGE ?= pkg/Status.AppImage
+STATUS_CLIENT_TARBALL ?= pkg/Status.tar.gz
 
 $(STATUS_CLIENT_APPIMAGE): override RESOURCES_LAYOUT := -d:production
 $(STATUS_CLIENT_APPIMAGE): nim_status_client $(APPIMAGE_TOOL) nim-status.desktop
@@ -279,6 +280,11 @@ $(STATUS_CLIENT_APPIMAGE): nim_status_client $(APPIMAGE_TOOL) nim-status.desktop
 
 	mkdir -p pkg
 	$(APPIMAGE_TOOL) tmp/linux/dist $(STATUS_CLIENT_APPIMAGE)
+
+$(STATUS_CLIENT_TARBALL): $(STATUS_CLIENT_APPIMAGE)
+	tar czvf $(STATUS_CLIENT_TARBALL) \
+		-C $(shell dirname $(STATUS_CLIENT_APPIMAGE)) \
+		$(shell basename $(STATUS_CLIENT_APPIMAGE))
 
 DMG_TOOL := node_modules/.bin/create-dmg
 
@@ -392,6 +398,8 @@ endif
 pkg: $(PKG_TARGET)
 
 pkg-linux: check-pkg-target-linux $(STATUS_CLIENT_APPIMAGE)
+
+tgz-linux: $(STATUS_CLIENT_TARBALL)
 
 pkg-macos: check-pkg-target-macos $(STATUS_CLIENT_DMG)
 

--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -40,6 +40,7 @@ pipeline {
     QTDIR = "/opt/qt/5.14.0/gcc_64"
     /* Control output the filename */
     STATUS_CLIENT_APPIMAGE = "pkg/${utils.pkgFilename('AppImage')}"
+    STATUS_CLIENT_TARBALL = "pkg/${utils.pkgFilename('tar.gz')}"
   }
 
   stages {
@@ -68,7 +69,7 @@ pipeline {
           credentialsId: utils.getInfuraTokenCred(),
           variable: 'INFURA_TOKEN'
         )]) {
-          sh 'make pkg-linux'
+          sh 'make tgz-linux'
         }
       }
     }
@@ -77,13 +78,13 @@ pipeline {
       parallel {
         stage('Upload') {
           steps { script {
-            env.PKG_URL = s3.uploadArtifact(env.STATUS_CLIENT_APPIMAGE)
+            env.PKG_URL = s3.uploadArtifact(env.STATUS_CLIENT_TARBALL)
             jenkins.setBuildDesc(AppImage: env.PKG_URL)
           } }
         }
         stage('Archive') {
           steps { script {
-            archiveArtifacts(env.STATUS_CLIENT_APPIMAGE)
+            archiveArtifacts(env.STATUS_CLIENT_TARBALL)
           } }
         }
       }


### PR DESCRIPTION
I made changes to `ci/Jenkinsfile.linux` (will see if they work) but I'm not sure if changes need to be made re: the logic of the release builds for Linux.

Closes #1033.

---

Update now that the CI build for Linux finished:

Works fine, e.g. on Ubuntu download the `.AppImage.tar.gz`, double-click it in the file explorer and drag from the archive listing GUI into the folder you want. Afterward, you can simply double click the `.AppImage` and it works as expected.

Alternatively, you can unpack on the command-line with e.g. `tar xvzf Status*`.

I'm still not sure if changes will need to be made re: the release builds logic (I did look at the Jenkinsfile), but hopefully @jakubgs can give provide insight.