### PR TITLE
ci: do no delete non-draft releases

### DIFF
--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.2.15'
+library 'status-jenkins-lib@v1.2.18'
 
 pipeline {
   agent { label 'linux' }

--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.2.15'
+library 'status-jenkins-lib@v1.2.18'
 
 pipeline {
   agent {

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@ci-macos-notarization'
+library 'status-jenkins-lib@v1.2.18'
 
 pipeline {
   agent {

--- a/ci/Jenkinsfile.windows
+++ b/ci/Jenkinsfile.windows
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.2.15'
+library 'status-jenkins-lib@v1.2.18'
 
 pipeline {
   agent { label 'windows' }


### PR DESCRIPTION
We identified this issue in status-desktop release from branch `release/0.1.0-beta.10` which had old version in VERSION file.
https://ci.status.im/job/status-desktop/job/release/job/release%252F0.1.0-beta.10/

Depends on: https://github.com/status-im/status-jenkins-lib/pull/28

Signed-off-by: Jakub Sokołowski <jakub@status.im>