### PR TITLE
fix: remove actions from community member when self

### DIFF
--- a/ui/app/AppLayouts/Chat/CommunityComponents/CommunityProfilePopupMembersList.qml
+++ b/ui/app/AppLayouts/Chat/CommunityComponents/CommunityProfilePopupMembersList.qml
@@ -94,13 +94,23 @@ Item {
             }
 
             StyledText {
+                id: txtUsername
                 text: !model.userName.endsWith(".eth") && !!contactRow.nickname ?
                             contactRow.nickname : Utils.removeStatusEns(model.userName)
                 anchors.left: identicon.right
                 anchors.leftMargin: Style.current.smallPadding
+                anchors.verticalCenter: parent.verticalCenter
+                font.pixelSize: 15
+            }
+            StyledText {
+                text: " (" + qsTr("You") + ")"
+                visible: !moreActionsBtn.visible
+                anchors.left: txtUsername.right
+                anchors.leftMargin: Style.current.smallPadding
                 anchors.right: parent.right
                 anchors.rightMargin: Style.current.smallPadding
                 anchors.verticalCenter: parent.verticalCenter
+                color: Style.current.secondaryText
                 font.pixelSize: 15
             }
 
@@ -119,6 +129,7 @@ Item {
                 anchors.right: parent.right
                 anchors.rightMargin: Style.current.padding
                 anchors.verticalCenter: parent.verticalCenter
+                visible: model.pubKey.toLowerCase() !== profileModel.profile.pubKey.toLowerCase()
                 MouseArea {
                     anchors.fill: parent
                     onClicked: contextMenu.popup(-contextMenu.width + moreActionsBtn.width, moreActionsBtn.height + 4)


### PR DESCRIPTION
Fixes: #2486.

In the community member managment popup, for the current user, remove the “more actions” menu that allows kicking of the user and viewing of their profile.