### PR TITLE
fix(communities): hide edit category menu for non-admins

### DIFF
--- a/ui/app/AppLayouts/Chat/CommunityComponents/CategoryList.qml
+++ b/ui/app/AppLayouts/Chat/CommunityComponents/CategoryList.qml
@@ -72,7 +72,7 @@ Column {
                 }
 
                 StatusIconButton {
-                    visible: hhandler.hovered
+                    visible: hhandler.hovered && chatsModel.communities.activeCommunity.admin
                     id: moreBtn
                     icon.name: "more"
                     width: 20


### PR DESCRIPTION
Fixes: #2691.

When not an admin, the menu for adding/removing/editing of channels inside of a category should not be visible.