### PR TITLE
fix(communities): re-joining of left communities

### DIFF
--- a/src/app/chat/views/community_list.nim
+++ b/src/app/chat/views/community_list.nim
@@ -1,8 +1,11 @@
-import NimQml, Tables, chronicles
-import ../../../status/chat/chat
-import ../../../status/status
-import ../../../status/accounts
-import strutils
+import # std libs
+  NimQml, Tables, json, strutils
+
+import # vendor libs
+  chronicles, json_serialization
+
+import # status-desktop libs
+  ../../../status/chat/chat, ../../../status/status, ../../../status/accounts
 
 type
   CommunityRoles {.pure.} = enum
@@ -117,6 +120,11 @@ QtObject:
         else:
           result = newQVariant("")
       of CommunityRoles.CommunityColor: result = newQVariant(communityItem.communityColor)
+  
+  proc getCommunityByIdJson(self: CommunityList, communityId: string): string {.slot.} =
+    for community in self.communities:
+      if (community.id == communityId):
+        result = Json.encode(community)
 
   method roleNames(self: CommunityList): Table[int, string] =
     {

--- a/src/status/libstatus/chat.nim
+++ b/src/status/libstatus/chat.nim
@@ -315,7 +315,7 @@ proc createCommunity*(name: string, description: string, access: int, ensOnly: b
 
   if rpcResult{"error"} != nil:
     let error = Json.decode($rpcResult{"error"}, RpcError)
-    raise newException(RpcException, "Error editing community channel: " & error.message)
+    raise newException(RpcException, "Error creating community: " & error.message)
 
   if rpcResult{"result"} != nil and rpcResult{"result"}.kind != JNull:
     result = rpcResult["result"]["communities"][0].toCommunity()
@@ -338,7 +338,7 @@ proc editCommunity*(communityId: string, name: string, description: string, acce
 
   if rpcResult{"error"} != nil:
     let error = Json.decode($rpcResult{"error"}, RpcError)
-    raise newException(RpcException, "Error editing community channel: " & error.message)
+    raise newException(RpcException, "Error editing community: " & error.message)
 
   if rpcResult{"result"} != nil and rpcResult{"result"}.kind != JNull:
     result = rpcResult["result"]["communities"][0].toCommunity()
@@ -481,8 +481,7 @@ proc requestToJoinCommunity*(communityId: string, ensName: string): seq[Communit
   }]).parseJSON()
 
   var communityRequests: seq[CommunityMembershipRequest] = @[]
-
-  if rpcResult{"result"}{"requestsToJoinCommunity"}.kind != JNull:
+  if rpcResult{"result"}{"requestsToJoinCommunity"} != nil and rpcResult{"result"}{"requestsToJoinCommunity"}.kind != JNull:
     for jsonCommunityReqest in rpcResult["result"]["requestsToJoinCommunity"]:
       communityRequests.add(jsonCommunityReqest.toCommunityMembershipRequest())
 


### PR DESCRIPTION
Fixes: #2649.

Upon receipt of status-go signals which included communities that have been left (`joined: false`), those communities were being rejoined automatically when they should not have been.

fix(communities): Invitation bubble button state updates
The community state inside of the invitation bubble was not reactive to any community actions (such as joining, leaving, updating). In addition, requesting to join a community changed the button’s text to “Pending”, but upon approval, the button’s state was not updating.

The component was setting an observed community in the Component.onCompleted event, which was occurring for all invitation bubbles, but because the community wasn’t bound correctly to the bubble, once a bubble  with a different community was encountered, the community in context of the bubble wasn’t updated and instead used a local copy. Once the community was bound correctly (to be reactive), the states started working correctly.

The invitation bubble has been simplied so that it has states instead of using lots of if/else statements inside of the property bindings. This simplified the component’s logic for things like onClick action and made it a lot easier to read and modify.

### NOTE:
1. Membership request rejection will not show up in the invitation bubble by way of a signal from status-go. As it stands, in this PR, nothing will happen when a request to join a community is rejected. @cammellos mentioned this would likely changed in Communities Phase 3, with no need to polish now.