### PR TITLE
fix: remove “Copy” action from emoji menu

### DIFF
--- a/ui/app/AppLayouts/Chat/components/MessageContextMenu.qml
+++ b/ui/app/AppLayouts/Chat/components/MessageContextMenu.qml
@@ -168,6 +168,7 @@ PopupMenu {
 
     Action {
         id: copyAction
+        enabled: !emojiOnly
         text: qsTr("Copy")
         onTriggered: {
             chatsModel.copyToClipboard(messageContextMenu.text)


### PR DESCRIPTION
Fixes: #2722.

Remove the “Copy” action from the emoji popup menu.

![imgur](https://imgur.com/eQOt4NQ.png)