### PR TITLE
fix: edit channel modal header

### DIFF
--- a/ui/app/AppLayouts/Chat/CommunityComponents/CreateChannelPopup.qml
+++ b/ui/app/AppLayouts/Chat/CommunityComponents/CreateChannelPopup.qml
@@ -28,6 +28,7 @@ ModalPopup {
         nameInput.text = "";
         if (isEdit) {
             nameInput.text = channel.name;
+            title = qsTr("Edit #%1").arg(channel.name);
             descriptionTextArea.text = channel.description;
             // TODO: re-enable once private channels are implemented
             // privateSwitch.checked = channel.private


### PR DESCRIPTION
Fixes: #2694.

Display channel name in modal header when editing a channel instead of “New channel”.