### PR TITLE
fix: various

### DIFF
--- a/src/status/chat.nim
+++ b/src/status/chat.nim
@@ -538,7 +538,7 @@ proc pinnedMessagesByChatID*(self: ChatModel, chatId: string): seq[Message] =
   result = messageTuple[1]
 
 proc pinnedMessagesByChatID*(self: ChatModel, chatId: string, cursor: string = "", pinnedMessages: seq[Message]) =
-  self.msgCursor[chatId] = cursor
+  self.pinnedMsgCursor[chatId] = cursor
 
   self.events.emit("pinnedMessagesLoaded", MsgsLoadedArgs(messages: pinnedMessages))
 

--- a/ui/app/AppLayouts/Timeline/TimelineLayout.qml
+++ b/ui/app/AppLayouts/Timeline/TimelineLayout.qml
@@ -19,7 +19,7 @@ ScrollView {
     ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
     
     property var onActivated: function () {
-        chatsModel.channelView.setActiveChannelToTimeline()
+        chatsModel.setActiveChannelToTimeline()
         statusUpdateInput.textInput.forceActiveFocus(Qt.MouseFocusReason)
     }
 


### PR DESCRIPTION
- Timeline updates were displaying the current active chat messages
- Cursor for existing chat messages was being overwritten