### PR TITLE
fix: chat view shown after community creation

### DIFF
--- a/src/app/chat/views/channel.nim
+++ b/src/app/chat/views/channel.nim
@@ -124,6 +124,8 @@ QtObject:
     self.status.chat.setActiveChannel(selectedChannel.id)
 
   proc setActiveChannelByIndex*(self: ChannelView, index: int) {.slot.} =
+    if self.previousActiveChannelIndex == -1 and self.chats.rowCount() > -1:
+      self.previousActiveChannelIndex = 0
     self.setActiveChannelByIndexWithForce(index, false)
 
   proc getActiveChannelIdx(self: ChannelView): int {.slot.} =


### PR DESCRIPTION
Fixes: #2686.

Previously, when using a new account, joining a chat then creating a community and then returning back to the chat would not show a chat at all and instead show the default chat view. This was due to the previous index not being set when there were no other channels in the chat.

This has been updated such that the previous channel index is set when switching from chat to community and no previous channel index has been set.