### PR TITLE
fix(communities): Naming validation for communities

### DIFF
--- a/ui/app/AppLayouts/Chat/CommunityComponents/CreateCategoryPopup.qml
+++ b/ui/app/AppLayouts/Chat/CommunityComponents/CreateCategoryPopup.qml
@@ -17,7 +17,6 @@ ModalPopup {
     readonly property int maxCategoryNameLength: 30
     readonly property var categoryNameValidator: Utils.Validate.NoEmpty
                                                  | Utils.Validate.TextLength
-                                                 | Utils.Validate.TextLowercase
 
     id: popup
     height: 453
@@ -68,8 +67,6 @@ ModalPopup {
                 maxLength: maxCategoryNameLength
 
                 onTextEdited: {
-                    text = Utils.convertSpacesToDashesAndUpperToLowerCase(text);
-
                     validationError = Utils.validateAndReturnError(text,
                                                                    categoryNameValidator,
                                                                    qsTr("category name"),

--- a/ui/imports/Utils.qml
+++ b/ui/imports/Utils.qml
@@ -552,6 +552,57 @@ QtObject {
         return Array.from(new Set(array))
     }
 
+    function hasUpperCaseLetter(str) {
+        return (/[A-Z]/.test(str))
+    }
+
+    function convertSpacesToDashesAndUpperToLowerCase(str)
+    {
+        if (str.includes(" "))
+            str = str.replace(/ /g, "-")
+
+        if(hasUpperCaseLetter(str))
+            str = str.toLowerCase()
+
+        return str
+    }
+
+    /* Validation section start */
+
+    enum Validate {
+        NoEmpty = 0x01,
+        TextLength = 0x02,
+        TextHexColor = 0x04,
+        TextLowercaseLettersNumberAndDashes = 0x08
+    }
+
+    function validateAndReturnError(str, validation, fieldName = "field", limit = 0)
+    {
+        let errMsg = ""
+
+        if(validation & Utils.Validate.NoEmpty && str === "") {
+            errMsg = qsTr("You need to enter a %1").arg(fieldName)
+        }
+
+        if(validation & Utils.Validate.TextLength && str.length > limit) {
+            errMsg = qsTr("The %1 cannot exceed %2 characters").arg(fieldName, limit)
+        }
+
+        if(validation & Utils.Validate.TextHexColor && !isHexColor(str)) {
+            errMsg = qsTr("Must be an hexadecimal color (eg: #4360DF)")
+        }
+
+        if(validation & Utils.Validate.TextLowercaseLettersNumberAndDashes && !isValidChannelName(str)) {
+            errMsg = qsTr("Use only lowercase letters (a to z), numbers & dashes (-). Do not use chat keys.")
+        }
+
+        return errMsg
+    }
+
+    /* Validation section end */
+
+
+
     // Leave this function at the bottom of the file as QT Creator messes up the code color after this
     function isPunct(c) {
         return /(!|\@|#|\$|%|\^|&|\*|\(|\)|_|\+|\||-|=|\\|{|}|[|]|"|;|'|<|>|\?|,|\.|\/)/.test(c)

--- a/ui/shared/Input.qml
+++ b/ui/shared/Input.qml
@@ -9,6 +9,7 @@ Item {
     property string placeholderText: "My placeholder"
     property string placeholderTextColor: Style.current.secondaryText
     property alias text: inputValue.text
+    property alias maxLength: inputValue.maximumLength
     property string validationError: ""
     property alias validationErrorAlignment: validationErrorText.horizontalAlignment
     property int validationErrorTopMargin: 1


### PR DESCRIPTION
I sorted out some validation related stuff. There were some unused and some redundant methods. I guess that validation messages for each input will be uniform now, across these three parts (channel, channel category and community). If it's needed we may easily change text of the error messages (Utils.validateAndReturnError) which will have same pattern now.

Fixes: #2297