### PR TITLE
fix: invalid keyuid being used with a newly generated account on first login

### DIFF
--- a/src/app/login/view.nim
+++ b/src/app/login/view.nim
@@ -46,6 +46,7 @@ QtObject:
       name: currNodeAcct.name,
       identicon: currNodeAcct.identicon,
       address: currNodeAcct.keyUid,
+      keyUid: currNodeAcct.keyUid,
       identityImage: currNodeAcct.identityImage
     ))
 

--- a/src/status/types.nim
+++ b/src/status/types.nim
@@ -96,7 +96,7 @@ type
     error*: RpcError
 
 proc toAccount*(account: GeneratedAccount): Account =
-  result = Account(name: account.name, identityImage: account.identityImage, identicon: account.identicon, keyUid: account.address)
+  result = Account(name: account.name, identityImage: account.identityImage, identicon: account.identicon, keyUid: account.keyUid)
 
 proc toAccount*(account: NodeAccount): Account =
   result = Account(name: account.name, identityImage: account.identityImage, identicon: account.identicon, keyUid: account.keyUid)


### PR DESCRIPTION
Generated accounts were using the address as the keyuid value during first login. This was causing that profile pictures updates to not be broadcasted unless you logged out and in again.