### PR TITLE
fix(activity_center): Mark as read does not clear @ symbol in chat

### DIFF
--- a/src/app/chat/views/channel.nim
+++ b/src/app/chat/views/channel.nim
@@ -91,10 +91,11 @@ QtObject:
     discard self.status.chat.markAllChannelMessagesRead(selectedChannel.id)
 
   proc clearUnreadIfNeeded*(self: ChannelView, channel: var Chat) =
-    if (not channel.isNil and (channel.unviewedMessagesCount > 0 or channel.hasMentions)):
+    if (not channel.isNil and (channel.unviewedMessagesCount > 0 or channel.mentionsCount > 0)):
       var response = self.status.chat.markAllChannelMessagesRead(channel.id)
       if not response.hasKey("error"):
-        self.chats.clearUnreadMessagesCount(channel)
+        self.chats.clearUnreadMessages(channel.id)
+        self.chats.clearAllMentionsFromChannelWithId(channel.id)
 
   proc userNameOrAlias(self: ChannelView, pubKey: string): string =
     if self.status.chat.contacts.hasKey(pubKey):

--- a/src/app/chat/views/chat_item.nim
+++ b/src/app/chat/views/chat_item.nim
@@ -138,10 +138,10 @@ QtObject:
     read = isTimelineChat
 
 
-  proc hasMentions*(self: ChatItemView): bool {.slot.} = result = ?.self.chatItem.hasMentions
+  proc mentionsCount*(self: ChatItemView): int {.slot.} = result = ?.self.chatItem.mentionsCount
 
-  QtProperty[bool] hasMentions:
-    read = hasMentions
+  QtProperty[int] mentionsCount:
+    read = mentionsCount
 
   proc canPost*(self: ChatItemView): bool {.slot.} = result = ?.self.chatItem.canPost
 

--- a/src/app/chat/views/community_list.nim
+++ b/src/app/chat/views/community_list.nim
@@ -208,3 +208,48 @@ QtObject:
     community.categories.delete(idx)
     let index = self.communities.findIndexById(communityId)
     self.communities[index] = community
+
+  proc clearUnreadMessages*(self: CommunityList, communityId: string, clearFromChannels : bool) =
+    let idx = self.communities.findIndexById(communityId)
+    if (idx == -1): 
+      return
+
+    if (clearFromChannels):
+      # Clear unread messages for each channel in community. 
+      for c in self.communities[idx].chats:
+        c.unviewedMessagesCount = 0
+
+    let index = self.createIndex(idx, 0, nil)
+    self.communities[idx].unviewedMessagesCount = 0
+
+    self.dataChanged(index, index, @[CommunityRoles.UnviewedMessagesCount.int])
+  
+  proc clearAllMentions*(self: CommunityList, communityId: string, clearFromChannels : bool) =
+    let idx = self.communities.findIndexById(communityId)
+    if (idx == -1): 
+      return
+
+    if (clearFromChannels):
+      # Clear mentions for each chat in community. No need to emit dataChanged
+      # as mentins are not exposed to qml using roles from this model.
+      for c in self.communities[idx].chats:
+        c.mentionsCount = 0
+
+    # If we decide in one moment to expose mention role we should do that here.
+
+  proc decrementMentions*(self: CommunityList, communityId: string, channelId : string) =
+    let comIndex = self.communities.findIndexById(communityId)
+    if (comIndex == -1): 
+      return
+
+    let chatIndex = self.communities[comIndex].chats.findIndexById(channelId)
+    if (chatIndex == -1): 
+      return
+
+    self.communities[comIndex].chats[chatIndex].mentionsCount.dec
+
+  proc incrementMentions*(self: CommunityList, channelId : string) =
+    for c in self.communities:
+      let chatIndex = c.chats.findIndexById(channelId)
+      if (chatIndex != -1): 
+        c.chats[chatIndex].mentionsCount.inc

--- a/src/status/chat/chat.nim
+++ b/src/status/chat/chat.nim
@@ -83,7 +83,7 @@ type Chat* = ref object
   lastMessage*: Message
   members*: seq[ChatMember]
   membershipUpdateEvents*: seq[ChatMembershipEvent]
-  hasMentions*: bool
+  mentionsCount*: int
   muted*: bool
   canPost*: bool
   ensName*: string

--- a/src/status/signals/messages.nim
+++ b/src/status/signals/messages.nim
@@ -49,7 +49,7 @@ proc fromEvent*(event: JsonNode): Signal =
     for jsonChat in event["event"]["chats"]:
       var chat = jsonChat.toChat
       if chatsWithMentions.contains(chat.id):
-        chat.hasMentions = true
+        chat.mentionsCount.inc
       signal.chats.add(chat)
 
   if event["event"]{"installations"} != nil:
@@ -135,7 +135,7 @@ proc newChat*(id: string, chatType: ChatType): Chat =
     lastClockValue: 0,
     deletedAtClockValue: 0, 
     unviewedMessagesCount: 0,
-    hasMentions: false,
+    mentionsCount: 0,
     members: @[]
   )
 
@@ -165,7 +165,7 @@ proc toChat*(jsonChat: JsonNode): Chat =
     lastClockValue: jsonChat{"lastClockValue"}.getBiggestInt,
     deletedAtClockValue: jsonChat{"deletedAtClockValue"}.getBiggestInt, 
     unviewedMessagesCount: jsonChat{"unviewedMessagesCount"}.getInt,
-    hasMentions: false,
+    mentionsCount: 0,
     muted: false,
     ensName: "",
     joined: 0,

--- a/ui/app/AppLayouts/Chat/ContactsColumn/Channel.qml
+++ b/ui/app/AppLayouts/Chat/ContactsColumn/Channel.qml
@@ -13,7 +13,7 @@ Item {
     property string timestamp: "1605212622434"
     property string unviewedMessagesCount: "2"
     property string identicon
-    property bool hasMentions: false
+    property int mentionsCount: 0
     property int chatType: Constants.chatTypePublic
     property int realChatType: {
         if (chatType === Constants.chatTypeCommunity) {
@@ -163,10 +163,10 @@ Item {
             anchors.bottomMargin: !isCompact ? Style.current.smallPadding : 0
             anchors.verticalCenter: !isCompact ? undefined : parent.verticalCenter
             color: Style.current.blue
-            visible: (unviewedMessagesCount > 0) || wrapper.hasMentions
+            visible: (unviewedMessagesCount > 0) || wrapper.mentionsCount > 0
             StyledText {
                 id: contactNumberChats
-                text: wrapper.hasMentions ? '@' : (wrapper.unviewedMessagesCount < 100 ? wrapper.unviewedMessagesCount : "99+")
+                text: wrapper.mentionsCount > 0 ? '@' : (wrapper.unviewedMessagesCount < 100 ? wrapper.unviewedMessagesCount : "99+")
                 font.pixelSize: 12
                 anchors.horizontalCenter: parent.horizontalCenter
                 anchors.verticalCenter: parent.verticalCenter

--- a/ui/app/AppLayouts/Chat/ContactsColumn/ChannelList.qml
+++ b/ui/app/AppLayouts/Chat/ContactsColumn/ChannelList.qml
@@ -37,7 +37,7 @@ Item {
             chatType: model.chatType
             identicon: model.identicon
             unviewedMessagesCount: model.unviewedMessagesCount
-            hasMentions: model.hasMentions
+            mentionsCount: model.mentionsCount
             contentType: model.contentType
             searchStr: channelListContent.searchStr
             categoryId: model.categoryId


### PR DESCRIPTION
Mark all mention notifications as read is fixed. Also mark as read one by one notification removes "@" from the appropriate channel along with the marking as read last mention notification for that channel. hasMention field which was bool is switched with mentionsCount field which is int, so we have evidention how many mentions were for each channel.

Fixes: #2788