### PR TITLE
fix(wallet): Clicking Request Address when sending -1 STT crashes the app

### DIFF
--- a/src/status/utils.nim
+++ b/src/status/utils.nim
@@ -45,7 +45,10 @@ proc handleRPCErrors*(response: string) =
 proc toStUInt*[bits: static[int]](flt: float, T: typedesc[StUint[bits]]): T =
   var stringValue =  fmt"{flt:<.0f}"
   stringValue.removeSuffix('.')
-  result = parse($stringValue, StUint[bits])
+  if (flt >= 0):
+    result = parse($stringValue, StUint[bits])
+  else:
+    result = parse("0", StUint[bits])
 
 proc toUInt256*(flt: float): UInt256 =
   toStUInt(flt, StUInt[256])

--- a/ui/shared/AssetAndAmountInput.qml
+++ b/ui/shared/AssetAndAmountInput.qml
@@ -43,7 +43,7 @@ Item {
         } else if (isNaN(inputAmount.text)) {
             error = invalidInputErrorMessage
             isValid = false
-        } else if (input === 0.00 && hasTyped) {
+        } else if (input <= 0.00 && hasTyped) {
             error = greaterThan0ErrorMessage
             isValid = false
         } else if (validateBalance && input > balance && !noInput) {


### PR DESCRIPTION
Validation check is updated, so user cannot enter zero or less than zero value in amount input field.
Also in utils.nim a crash prevention check is added so if we try to convert a less than zero float number to an unsigned number, app won't crash any more, but that casting will return a zero as unsigned int number.

Fixes: #2755