### PR TITLE
fix(wallet): Crash when enter -1 to Gas Selector

### DIFF
--- a/src/app/wallet/views/gas.nim
+++ b/src/app/wallet/views/gas.nim
@@ -58,6 +58,15 @@ QtObject:
     discard gweiValue.parseInt(gweiValueInt)
     discard gasLimit.parseInt(gasLimitInt)
 
+    # The following two check prevents app crash, cause we're trying to promote 
+    # gweiValueInt and gasLimitInt to unsigned 256 int, and these two numbers
+    # must be positive numbers, because of overflow.
+    if (gweiValueInt < 0):
+      gweiValueInt = 0
+    
+    if (gasLimitInt < 0):
+      gasLimitInt = 0
+    
     let weiValue = gweiValueInt.u256 * 1000000000.u256 * gasLimitInt.u256
     let ethValue = wei2Eth(weiValue)
     result = fmt"{ethValue}"

--- a/ui/shared/GasSelector.qml
+++ b/ui/shared/GasSelector.qml
@@ -69,10 +69,10 @@ Item {
         }
         let inputLimit = parseFloat(inputGasLimit.text || "0.00")
         let inputPrice = parseFloat(inputGasPrice.text || "0.00")
-        if (inputLimit === 0.00) {
+        if (inputLimit <= 0) {
             inputGasLimit.validationError = root.greaterThan0ErrorMessage
         }
-        if (inputPrice === 0.00) {
+        if (inputPrice <= 0) {
             inputGasPrice.validationError = root.greaterThan0ErrorMessage
         }
         const isValid = inputGasLimit.validationError === "" && inputGasPrice.validationError === ""


### PR DESCRIPTION
Validation check is updated, so user cannot enter zero or less than zero value for "gas amount limit" or "per-gas overall limit".
In gas.nim a crash prevention check is added.

Fixes: #2753