### PR TITLE
fix(wallet): QML error when loading history

### DIFF
--- a/src/app/wallet/core.nim
+++ b/src/app/wallet/core.nim
@@ -70,7 +70,7 @@ proc init*(self: WalletController) =
       of "non-archival-node-detected":
         self.view.setHistoryFetchState(self.status.wallet.accounts.map(account => account.address), false)
         self.view.setNonArchivalNode()
-        error "Non-archival node detected, please check your Infura key or your connected node"
+        warn "Non-archival node detected, please check your Infura key or your connected node"
       else:
         error "Unhandled wallet signal", eventType=data.eventType
 

--- a/ui/app/AppLayouts/Wallet/WalletLayout.qml
+++ b/ui/app/AppLayouts/Wallet/WalletLayout.qml
@@ -110,7 +110,6 @@ Item {
                             anchors.leftMargin: 32
                             //% "History"
                             btnText: qsTrId("history")
-                            onClicked: historyTab.checkIfHistoryIsBeingFetched()
                         }
                     }
 


### PR DESCRIPTION
Fixes: #2725.

When clicking on the History tab for a wallet account, there was a QML error for `qrc:/app/AppLayouts/Wallet/WalletLayout.qml:113: TypeError: Property 'checkIfHistoryIsBeingFetched' of object HistoryTab_QMLTYPE_503(0x7fed35da2710) is not a function`. This must have been reintroduced when StatusQ objects were introduced. It has now been removed.

chore: change log level to warn for non-archival node
Previously, there was an error being logged for non-archival infura nodes being used (typically in dev). This log level has been reduced to a warning as the application still functions with non-archival nodes.