### PR TITLE
fix(@desktop/wallet): app crash when click on sign and send message

### DIFF
--- a/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/TransactionComponents/AcceptTransaction.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/TransactionComponents/AcceptTransaction.qml
@@ -112,7 +112,7 @@ Item {
     SelectAccountModal {
         id: selectAccountModal
         onSelectAndShareAddressButtonClicked: {
-            chatsModel.transactions.acceptAddressRequest(messageId, accountSelector.selectedAccount)
+            chatsModel.transactions.acceptAddressRequest(messageId, accountSelector.selectedAccount.address)
             selectAccountModal.close()
         }
     }


### PR DESCRIPTION
A reason why the crash is happening is actually previous step, when an user who is about to receive
a transaction clicks "confirm and share address" button. In that moment instead of his address an
empty js object is shared. After that clicking on the "sign and send" button, by sender, causes an
app crash because transaction cannot be made using invalid address of the recipient.

Fixes: #2718