### PR TITLE
fix(Status): import missing `utils` module

### DIFF
--- a/src/status/provider.nim
+++ b/src/status/provider.nim
@@ -1,6 +1,7 @@
 import ens, wallet, permissions
 import ../eventemitter
 import types
+import utils
 import libstatus/accounts
 import libstatus/core
 import libstatus/settings as status_settings


### PR DESCRIPTION
There's an API used in `provider.nim`, which is defined in `utils.nim` but utils aren't imported.
The usage of that API was introduced in https://github.com/status-im/status-desktop/commit/065bd26786ac7be28e1fc1644f3ea0cf36c53300#diff-778feda87f0918b600d692bd16cdd1af92ae0611f81ae6557749e5f462636694R127