### PR TITLE
fix(@desktop/chat): app crash when you leave a chat

### DIFF
--- a/src/app/chat/views/channel.nim
+++ b/src/app/chat/views/channel.nim
@@ -294,3 +294,7 @@ QtObject:
     chatItemView.setChatItem(chat)
     self.chatItemViews[id] = chatItemView
     return chatItemView
+
+  proc removeChat*(self: ChannelView, chatId: string) =
+    discard self.chats.removeChatItemFromList(chatId)
+    self.setActiveChannel(backToFirstChat)

--- a/src/status/chat.nim
+++ b/src/status/chat.nim
@@ -219,7 +219,6 @@ proc leave*(self: ChatModel, chatId: string) =
   self.channels.del(chatId)
   discard status_chat.clearChatHistory(chatId)
   self.events.emit("channelLeft", ChatIdArg(chatId: chatId))
-  self.events.emit("activeChannelChanged", ChatIdArg(chatId: backToFirstChat))
 
 proc clearHistory*(self: ChatModel, chatId: string) =
   discard status_chat.clearChatHistory(chatId)

--- a/ui/app/AppLayouts/Chat/ChatColumn/ChatMessages.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/ChatMessages.qml
@@ -118,16 +118,16 @@ SplitView {
                     radius: 16
                 }
                 onClicked: {
-                    svRoot.newMessages = 0
+                    newMessages = 0
                     scrollDownButton.visible = false
                     chatLogView.scrollToBottom(true)
                 }
 
                 StyledText {
                     id: nbMessages
-                    visible: svRoot.newMessages > 0
+                    visible: newMessages > 0
                     width: visible ? implicitWidth : 0
-                    text: svRoot.newMessages
+                    text: newMessages
                     anchors.verticalCenter: parent.verticalCenter
                     anchors.left: parent.left
                     color: Style.current.pillButtonTextColor
@@ -202,7 +202,7 @@ SplitView {
 
                 onNewMessagePushed: {
                     if (!chatLogView.scrollToBottom()) {
-                        svRoot.newMessages++
+                        newMessages++
                     }
                 }
 

--- a/ui/app/AppLayouts/Chat/ChatColumn/Message.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/Message.qml
@@ -309,7 +309,8 @@ Item {
                 }
                 return gapNowAndOldest < maxGapInSeconds
                         && gapNowAndJoined > maxGapInSeconds
-                        && (chatsModel.channelView.activeChannel.chatType !== Constants.chatTypePrivateGroupChat || chatsModel.channelView.activeChannel.isMember)
+                        && (chatsModel.channelView.activeChannel.chatType !== Constants.chatTypePrivateGroupChat
+                            || chatsModel.channelView.activeChannel.isMember)
             }
             height: childrenRect.height + Style.current.smallPadding * 2
             anchors.left: parent.left


### PR DESCRIPTION
The issue is happening randomly. I managed to catch it few times and hopefully fix it. Problem was
in leave proc in src/status/chat.nim cause we were sending activeChannelChanged signal from it what
started setting activeChannel to the value of the backToFirstChat variable, and while that process
was in progress setActiveChannelByIndex was called from activeChannel what caused another emit of
activeChannelChanged signal while the previous one was not completed. That caused new setting of
activeChannel with active channel index 0, what caused an app crash.

This is fixed by setting active channel to the first one from the list when we get a signal that
any channel from the list is removed. This way activeChannelChanged is broadcasted to the other
parts correctly.

Fixes: #2825