### PR TITLE
fix(@desktop/chat): app crash when you click macOS' notification

### DIFF
--- a/ui/app/AppLayouts/Chat/ChatColumn.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn.qml
@@ -184,15 +184,14 @@ StackLayout {
     }
 
     function clickOnNotification() {
+        // So far we're just showing this app as the top most window. Once we decide about the way
+        // how to notify the app what channle should be displayed within the app when user clicks
+        // notificaiton bubble this part should be updated accordingly.
+        //
+        // I removed part of this function which caused app crash.
         applicationWindow.show()
         applicationWindow.raise()
         applicationWindow.requestActivate()
-        appMain.changeAppSection(Constants.chat)
-        if (currentNotificationChatId) {
-            chatsModel.channelView.setActiveChannel(currentNotificationChatId)
-        } else if (currentNotificationCommunityId) {
-            chatsModel.communities.setActiveCommunity(currentNotificationCommunityId)
-        }
     }
 
     Connections {


### PR DESCRIPTION
A crash is happening not only when you click on a notification bubble with mentions, but on any
chat notification displayed in macOS' notification center. Discussion and details how we can
overcome this may be seen on zenhub, in issue 2819. So far this commit is just a simple solution
to avoid an app crash.

Fixes: #2819