### PR TITLE
fix(@desktop/chat): update color of close suggestion to be lighter

### DIFF
--- a/ui/app/AppLayouts/Chat/ContactsColumn/EmptyView.qml
+++ b/ui/app/AppLayouts/Chat/ContactsColumn/EmptyView.qml
@@ -52,7 +52,7 @@ Rectangle {
             anchors.rightMargin: 10
             icon.height: 20
             icon.width: 20
-            iconColor: Style.current.darkGrey
+            iconColor: Style.current.midGrey
         }
 
         MouseArea {


### PR DESCRIPTION
fixes #2367 

Before:
![Screenshot from 2021-07-09 09-48-56](https://user-images.githubusercontent.com/491074/125051847-45c4a500-e09b-11eb-957d-d2a292c6c10a.png)
![Screenshot from 2021-07-09 09-49-10](https://user-images.githubusercontent.com/491074/125051853-478e6880-e09b-11eb-9af7-14da19fa373a.png)


After:
![Screenshot from 2021-07-09 09-48-14](https://user-images.githubusercontent.com/491074/125051830-42311e00-e09b-11eb-900b-bb8a050b017b.png)
![Screenshot from 2021-07-09 09-48-29](https://user-images.githubusercontent.com/491074/125051838-44937800-e09b-11eb-92c7-e6bdf3e002d0.png)
