### PR TITLE
fix(@desktop/chat): app crash when you accept contact request

### DIFF
--- a/src/app/chat/views/channel.nim
+++ b/src/app/chat/views/channel.nim
@@ -57,11 +57,12 @@ QtObject:
       result = self.getCommunityChannelById(channel)
       if not result.isNil:
         return result
+    
     # even if communities are active, if we don't find a chat, it's possibly
     # because we are looking for a normal chat, so continue below
+
     let index = self.chats.chats.findIndexById(channel)
-    if index > -1:
-      return self.chats.getChannel(index)
+    return self.chats.getChannel(index)
 
   proc updateChannelInRightList*(self: ChannelView, channel: Chat) =
     if (self.communities.activeCommunity.active):
@@ -151,16 +152,19 @@ QtObject:
     notify = activeChannelChanged
 
   proc setActiveChannel*(self: ChannelView, channel: string) {.slot.} =
-    if (self.activeChannel.id == "" and channel == backToFirstChat):
-      self.setActiveChannelByIndex(0)
+    if (channel.len == 0):
+      return
+    
+    if (channel == backToFirstChat):
+      if (self.activeChannel.id.len == 0):
+        self.setActiveChannelByIndex(0)
       return
 
-    if(channel == "" or channel == backToFirstChat): return
     let selectedChannel = self.getChannelById(channel)
-
     self.activeChannel.setChatItem(selectedChannel)
     
     discard self.status.chat.markAllChannelMessagesRead(self.activeChannel.id)
+
     self.activeChannelChanged()
 
   proc getActiveChannel*(self: ChannelView): QVariant {.slot.} =

--- a/src/app/chat/views/channels_list.nim
+++ b/src/app/chat/views/channels_list.nim
@@ -117,7 +117,11 @@ QtObject:
 
     result = self.chats.len
 
-  proc getChannel*(self: ChannelsList, index: int): Chat = self.chats[index]
+  proc getChannel*(self: ChannelsList, index: int): Chat = 
+    if index < 0 or index >= self.chats.len:
+      return
+
+    result = self.chats[index]
 
   proc getChannelById*(self: ChannelsList, chatId: string): Chat =
     for chat in self.chats:

--- a/src/app/chat/views/chat_item.nim
+++ b/src/app/chat/views/chat_item.nim
@@ -29,6 +29,9 @@ QtObject:
   proc membershipChanged*(self: ChatItemView) {.signal.}
 
   proc setChatItem*(self: ChatItemView, chatItem: Chat) =
+    if (chatItem.isNil):
+      return
+
     self.chatItem = chatItem
     self.chatMembers.setMembers(chatItem.members)
     self.membershipChanged()

--- a/ui/app/AppLayouts/Chat/components/AcceptRejectOptionsButtons.qml
+++ b/ui/app/AppLayouts/Chat/components/AcceptRejectOptionsButtons.qml
@@ -45,6 +45,7 @@ Row {
         property int iconSize: 14
         id: menuButton
         anchors.verticalCenter: parent.verticalCenter
+
         MouseArea {
             id: mouseArea
             cursorShape: Qt.PointingHandCursor
@@ -53,28 +54,28 @@ Row {
             onClicked: {
                 contactContextMenu.popup()
             }
+        }
 
-            PopupMenu {
-                id: contactContextMenu
-                hasArrow: false
-                Action {
-                    icon.source: "../../../img/profileActive.svg"
-                    icon.width: menuButton.iconSize
-                    icon.height: menuButton.iconSize
-                    //% "View Profile"
-                    text: qsTrId("view-profile")
-                    onTriggered: root.profileClicked()
-                    enabled: true
-                }
-                Separator {}
-                Action {
-                    icon.source: "../../../img/block-icon.svg"
-                    icon.width: menuButton.iconSize
-                    icon.height: menuButton.iconSize
-                    icon.color: Style.current.danger
-                    text: qsTr("Decline and block")
-                    onTriggered: root.blockClicked()
-                }
+        PopupMenu {
+            id: contactContextMenu
+            hasArrow: false
+            Action {
+                icon.source: "../../../img/profileActive.svg"
+                icon.width: menuButton.iconSize
+                icon.height: menuButton.iconSize
+                //% "View Profile"
+                text: qsTrId("view-profile")
+                onTriggered: root.profileClicked()
+                enabled: true
+            }
+            Separator {}
+            Action {
+                icon.source: "../../../img/block-icon.svg"
+                icon.width: menuButton.iconSize
+                icon.height: menuButton.iconSize
+                icon.color: Style.current.danger
+                text: qsTr("Decline and block")
+                onTriggered: root.blockClicked()
             }
         }
     }

--- a/ui/app/AppLayouts/Chat/components/ContactRequest.qml
+++ b/ui/app/AppLayouts/Chat/components/ContactRequest.qml
@@ -43,17 +43,6 @@ Rectangle {
         anchors.rightMargin: Style.current.padding
     }
 
-    MouseArea {
-        anchors.fill: parent
-        acceptedButtons: Qt.RightButton
-        onClicked: {
-            if (mouse.button === Qt.RightButton) {
-                contactContextMenu.popup()
-                return
-            }
-        }
-    }
-
     HoverHandler {
         onHoveredChanged: container.isHovered = hovered
     }


### PR DESCRIPTION
This issue is being happened randomly, no general rule, in my case it happens often when you accept
first contact from the list immediately after the app start, but the ticket says that it happens
when you click accept while context menu is opened.

Two places were threat for this crash and both are fixed here:
- getChannel proc, direct access by index to Chat element of the chats sequence,
- setChatItem proc, where we actually were setting chatItem and accessing its property without
  checking if it is an empty object.

Fixes: #2837