### PR TITLE
fix(@desktop/communities): disable edit for pined message popup

### DIFF
--- a/ui/app/AppLayouts/Chat/ChatColumn/Message.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/Message.qml
@@ -41,6 +41,7 @@ Item {
     property bool isEdit: false
     property string replaces: ""
     property bool isEdited: false
+    property bool showEdit: true
 
     z: {
         if (typeof chatLogView === "undefined") {
@@ -435,6 +436,7 @@ Item {
             linkUrls: root.linkUrls
             isCurrentUser: root.isCurrentUser
             contentType: root.contentType
+            showEdit: root.showEdit
             container: root
         }
     }

--- a/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/ChatButtons.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/ChatButtons.qml
@@ -6,6 +6,7 @@ import "../../../../../imports"
 
 Rectangle {
     property bool parentIsHovered: false
+    property bool showEdit: true
     signal hoverChanged(bool hovered)
     property int containerMargin: 2
     property int contentType: 2
@@ -103,7 +104,7 @@ Rectangle {
 
         Loader {
             id: editBtn
-            active: isText && !isEdit && isCurrentUser
+            active: isText && !isEdit && isCurrentUser && showEdit
             sourceComponent: StatusIconButton {
                 id: btn
                 icon.name: "edit-message"

--- a/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/CompactMessage.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/CompactMessage.qml
@@ -15,6 +15,7 @@ Item {
     property bool isHovered: typeof hoveredMessage !== "undefined" && hoveredMessage === messageId
     property bool isMessageActive: typeof activeMessage !== "undefined" && activeMessage === messageId
     property bool headerRepeatCondition: (authorCurrentMsg !== authorPrevMsg || shouldRepeatHeader || dateGroupLbl.visible || chatReply.active)
+    property bool showEdit: true
 
     id: root
 
@@ -40,6 +41,7 @@ Item {
         anchors.top: messageContainer.top
         // This is not exactly like the design because the hover becomes messed up with the buttons on top of another Message
         anchors.topMargin: -Style.current.halfPadding
+        showEdit: root.showEdit
     }
 
     Loader {

--- a/ui/app/AppLayouts/Chat/components/PinnedMessagesPopup.qml
+++ b/ui/app/AppLayouts/Chat/components/PinnedMessagesPopup.qml
@@ -93,6 +93,7 @@ ModalPopup {
                 pinnedBy: model.pinnedBy
                 forceHoverHandler: true
                 isEdited: model.isEdited
+                showEdit: false
             }
         }
     }


### PR DESCRIPTION
fixes #2852 
Main chat:
![image](https://user-images.githubusercontent.com/491074/125246944-4ef78100-e2ea-11eb-88f1-f7dbd8eff10d.png)

Pinned popup:

![image](https://user-images.githubusercontent.com/491074/125246899-4141fb80-e2ea-11eb-98d1-8e9b54fb95f4.png)
