### PR TITLE
fix(@desktop/profile): chat confirmation notification

### DIFF
--- a/src/app/profile/core.nim
+++ b/src/app/profile/core.nim
@@ -119,9 +119,8 @@ proc init*(self: ProfileController, account: Account) =
     let msgData = MessageSignal(e);
     if msgData.contacts.len > 0:
       # TODO: view should react to model changes
-      self.status.chat.updateContacts(msgData.contacts)
       self.view.contacts.updateContactList(msgData.contacts)
-      self.view.contacts.notifyOnNewContactRequests(msgData.contacts)
+      self.status.chat.updateContacts(msgData.contacts)
     if msgData.installations.len > 0:
       self.view.devices.addDevices(msgData.installations)
 

--- a/src/app/profile/views/contact_list.nim
+++ b/src/app/profile/views/contact_list.nim
@@ -137,6 +137,7 @@ QtObject:
       c.ensName = contact.ensName
       c.ensVerified = contact.ensVerified
       c.identityImage = contact.identityImage
+      c.systemTags = contact.systemTags
 
     if not found:
       self.addContactToList(contact)


### PR DESCRIPTION
fixes #2637

When changing a contact, the notification about being able to chat was sent again.
Prevent this behaviour by ensuring the contact hasn't already been added