### PR TITLE
fix(@desktop/chat): Hide add contact button on private chat

### DIFF
--- a/ui/app/AppLayouts/Chat/components/PrivateChatPopup.qml
+++ b/ui/app/AppLayouts/Chat/components/PrivateChatPopup.qml
@@ -29,6 +29,7 @@ ModalPopup {
         id: contactFieldAndList
         anchors.top: parent.top
         anchors.bottom: parent.bottom
+        addContactEnabled: false
         onUserClicked: function (isContact, pubKey, ensName) {
             chatsModel.channelView.joinPrivateChat(pubKey, Utils.isChatKey(pubKey) ? "" : ensName);
             popup.close();

--- a/ui/shared/ContactsListAndSearch.qml
+++ b/ui/shared/ContactsListAndSearch.qml
@@ -19,6 +19,7 @@ Item {
     signal userClicked(bool isContact, string pubKey, string ensName, string address)
     property var pubKeys: ([])
     property bool hideCommunityMembers: false
+    property bool addContactEnabled: true
 
     id: root
     width: parent.width
@@ -175,7 +176,7 @@ Item {
         hasExistingContacts: existingContacts.visible
         loading: false
         width: searchResultsWidth > 0 ? searchResultsWidth : parent.width
-
+        addContactEnabled: root.addContactEnabled
         onResultClicked: {
             if (!validate()) {
                 return

--- a/ui/shared/SearchResults.qml
+++ b/ui/shared/SearchResults.qml
@@ -19,6 +19,7 @@ Item {
     property string pubKey: ""
     property string address: ""
     property bool resultClickable: true
+    property bool addContactEnabled: true
 
     property bool isAddedContact: pubKey != "" ? chatsModel.messageView.isAddedContact(pubKey) : false
 
@@ -120,7 +121,7 @@ Item {
             anchors.right: parent.right
             anchors.rightMargin: Style.current.padding
             anchors.verticalCenter: parent.verticalCenter
-            visible: !isAddedContact && !checkIcon.visible
+            visible: addContactEnabled && !isAddedContact && !checkIcon.visible
             MouseArea {
                 anchors.fill: parent
                 hoverEnabled: true


### PR DESCRIPTION
fixes #2595

From private chat:
![image](https://user-images.githubusercontent.com/491074/125432612-91df78f9-035c-4174-b2bd-a4cf9a10df61.png)


From add contact:
![image](https://user-images.githubusercontent.com/491074/125432699-4f1641cd-4cec-40b4-b568-406ed8342b76.png)
