### PR TITLE
fix(@desktop/chat): fix sticker/image notification with placeholder

### DIFF
--- a/src/app/chat/views/messages.nim
+++ b/src/app/chat/views/messages.nim
@@ -219,7 +219,7 @@ QtObject:
   proc isAddedContact*(self: MessageView, id: string): bool {.slot.} =
     result = self.status.contacts.isAdded(id)
 
-  proc messageNotificationPushed*(self: MessageView, chatId: string, text: string, messageType: string, chatType: int, timestamp: string, identicon: string, username: string, hasMention: bool, isAddedContact: bool, channelName: string) {.signal.}
+  proc messageNotificationPushed*(self: MessageView, chatId: string, text: string, contentType: int, chatType: int, timestamp: string, identicon: string, username: string, hasMention: bool, isAddedContact: bool, channelName: string) {.signal.}
 
   proc pushMessages*(self:MessageView, messages: var seq[Message]) =
     for msg in messages.mitems:
@@ -255,7 +255,7 @@ QtObject:
         if not channel.muted:
           let isAddedContact = channel.chatType.isOneToOne and self.isAddedContact(channel.id)
           if msg.editedAt == "0": # Do not push notifications for edit messages
-            self.messageNotificationPushed(msg.chatId, escape_html(msg.text), msg.messageType, channel.chatType.int, msg.timestamp, msg.identicon, msg.userName, msg.hasMention, isAddedContact, channel.name)
+            self.messageNotificationPushed(msg.chatId, escape_html(msg.text), msg.contentType.int, channel.chatType.int, msg.timestamp, msg.identicon, msg.userName, msg.hasMention, isAddedContact, channel.name)
 
   proc markMessageAsSent*(self:MessageView, chat: string, messageId: string) =
     if self.messageList.contains(chat):

--- a/ui/app/AppLayouts/Chat/ChatColumn/ChatMessages.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/ChatMessages.qml
@@ -206,8 +206,9 @@ SplitView {
                     }
                 }
 
-                onMessageNotificationPushed: function(chatId, msg, messageType, chatType, timestamp, identicon, username, hasMention, isAddedContact, channelName) {
-                    if (messageType == Constants.editType) return;
+                onMessageNotificationPushed: function(chatId, msg, contentType, chatType, timestamp, identicon, username, hasMention, isAddedContact, channelName) {
+                    if (contentType == Constants.editType) return;
+
                     if (appSettings.notificationSetting == Constants.notifyAllMessages || 
                         (appSettings.notificationSetting == Constants.notifyJustMentions && hasMention)) {
                         if (chatId === chatsModel.channelView.activeChannel.id && applicationWindow.active === true) {
@@ -229,7 +230,7 @@ SplitView {
 
                         let message;
                         if (appSettings.notificationMessagePreviewSetting > Constants.notificationPreviewNameOnly) {
-                            switch(messageType){
+                            switch(contentType){
                             //% "Image"
                             case Constants.imageType: message = qsTrId("image"); break
                             //% "Sticker"


### PR DESCRIPTION
fixes #2450

messageType is always empty, I am not sure to what it corresponds but contentType seems to be the field to look for as this is an enum which correspond to the qml part