### PR TITLE
fix(@desktop/chat): push notification is duplicated when mentioning

### DIFF
--- a/ui/app/AppLayouts/Chat/ChatColumn/ChatMessages.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/ChatMessages.qml
@@ -1,5 +1,4 @@
 import QtQuick 2.13
-import Qt.labs.platform 1.1
 import QtQuick.Controls 2.13
 import QtQuick.Window 2.13
 import QtQuick.Layouts 1.13
@@ -203,54 +202,6 @@ SplitView {
                 onNewMessagePushed: {
                     if (!chatLogView.scrollToBottom()) {
                         newMessages++
-                    }
-                }
-
-                onMessageNotificationPushed: function(chatId, msg, contentType, chatType, timestamp, identicon, username, hasMention, isAddedContact, channelName) {
-                    if (contentType == Constants.editType) return;
-
-                    if (appSettings.notificationSetting == Constants.notifyAllMessages || 
-                        (appSettings.notificationSetting == Constants.notifyJustMentions && hasMention)) {
-                        if (chatId === chatsModel.channelView.activeChannel.id && applicationWindow.active === true) {
-                            // Do not show the notif if we are in the channel already and the window is active and focused
-                            return
-                        }
-
-                        chatColumnLayout.currentNotificationChatId = chatId
-                        chatColumnLayout.currentNotificationCommunityId = null
-
-                        let name;
-                        if (appSettings.notificationMessagePreviewSetting === Constants.notificationPreviewAnonymous) {
-                            name = "Status"
-                        } else if (chatType === Constants.chatTypePublic) {
-                            name = chatId
-                        } else {
-                            name = chatType === Constants.chatTypePrivateGroupChat ? Utils.filterXSS(channelName) : Utils.removeStatusEns(username)
-                        }
-
-                        let message;
-                        if (appSettings.notificationMessagePreviewSetting > Constants.notificationPreviewNameOnly) {
-                            switch(contentType){
-                            //% "Image"
-                            case Constants.imageType: message = qsTrId("image"); break
-                            //% "Sticker"
-                            case Constants.stickerType: message = qsTrId("sticker"); break
-                            default: message = msg // don't parse emojis here as it emits HTML
-                            }
-                        } else {
-                            //% "You have a new message"
-                            message = qsTrId("you-have-a-new-message")
-                        }
-
-                        currentlyHasANotification = true
-                        if (appSettings.useOSNotifications && systemTray.supportsMessages) {
-                            systemTray.showMessage(name,
-                                                message,
-                                                SystemTrayIcon.NoIcon,
-                                                Constants.notificationPopupTTL)
-                        } else {
-                            notificationWindow.notifyUser(chatId, name, message, chatType, identicon, chatColumnLayout.clickOnNotification)
-                        }
                     }
                 }
             }


### PR DESCRIPTION
This bug is happening if you have more than one private chat in the contacts column. How many chats
you have that many same notifications you will get. That's happening cause connection is made
between chatsModel.messageView and ChatsMessages component for each private chat, and for each of
them ChatsMessages component is maintained in StackLayout component what means all of them are
exist but only selected instance is visible. When new messageNotificationPushed signal is emitted
each qml component triggers its slot (regardless component is not currently visible it exists in
the background, it's not deleted) and that's why we see more than one OS' notification bubble for
the same notification.

That is fixed adding kind of a filter in those slots, so OS' notification bubble will be fired only
if ChatsMessages component contains message with id which the messageNotificationPushed signal is
fired for.

Fixes: #2551