### PR TITLE
fix(@desktop/chat): sign and send appears for both recipient and sender when sharing the address

### DIFF
--- a/src/app/chat/event_handling.nim
+++ b/src/app/chat/event_handling.nim
@@ -36,7 +36,13 @@ proc handleChatEvents(self: ChatController) =
     for message in evArgs.messages:
       if (message.replace != ""):
         # Delete the message that this message replaces
-        self.view.deleteMessage(message.chatId, message.replace)
+        if (not self.view.deleteMessage(message.chatId, message.replace)):
+          # In cases where new message need to replace a message which already replaced initial message 
+          # "replace" property contains id of the initial message, but not the id of the message which 
+          # replaced the initial one. That's why we call this proce here in case message with "message.replace"
+          # was not deleted.
+          discard self.view.deleteMessageWhichReplacedMessageWithId(message.chatId, message.replace)
+
     self.view.reactions.push(evArgs.emojiReactions)
     if (evArgs.communities.len > 0):
       for community in evArgs.communities.mitems:
@@ -66,7 +72,7 @@ proc handleChatEvents(self: ChatController) =
 
   self.status.events.on("messageDeleted") do(e: Args):
     var evArgs = MessageArgs(e)
-    self.view.deleteMessage(evArgs.channel, evArgs.id)
+    discard self.view.deleteMessage(evArgs.channel, evArgs.id)
 
   self.status.events.on("chatHistoryCleared") do(e: Args):
     var args = ChannelArgs(e)

--- a/src/app/chat/view.nim
+++ b/src/app/chat/view.nim
@@ -430,8 +430,11 @@ QtObject:
   proc hideLoadingIndicator*(self: ChatsView) {.slot.} =
     self.messageView.hideLoadingIndicator()
 
-  proc deleteMessage*(self: ChatsView, channelId: string, messageId: string) =
-    self.messageView.deleteMessage(channelId, messageId)
+  proc deleteMessage*(self: ChatsView, channelId: string, messageId: string): bool =
+    result = self.messageView.deleteMessage(channelId, messageId)
+
+  proc deleteMessageWhichReplacedMessageWithId*(self: ChatsView, channelId: string, messageId: string): bool =
+    result = self.messageView.deleteMessageWhichReplacedMessageWithId(channelId, messageId)
 
   proc addPinnedMessages*(self: ChatsView, pinnedMessages: seq[Message]) =
     self.messageView.addPinnedMessages(pinnedMessages)

--- a/src/app/chat/views/message_list.nim
+++ b/src/app/chat/views/message_list.nim
@@ -103,8 +103,10 @@ QtObject:
   proc getMessage*(self: ChatMessageList, messageId: string): Message =
     return self.messages[self.messageIndex[messageId]]
 
-  proc deleteMessage*(self: ChatMessageList, messageId: string) =
-    if not self.messageIndex.hasKey(messageId): return
+  proc deleteMessage*(self: ChatMessageList, messageId: string): bool =
+    if not self.messageIndex.hasKey(messageId): 
+      return false
+
     let messageIndex = self.messageIndex[messageId]
     self.beginRemoveRows(newQModelIndex(), messageIndex, messageIndex)
     self.messages.delete(messageIndex)
@@ -115,10 +117,12 @@ QtObject:
       self.messageIndex[self.messages[i].id] = i
     self.endRemoveRows()
 
+    return true
+
   proc deleteMessagesByChatId*(self: ChatMessageList, chatId: string) =
     let messages = self.messages.filter(m => m.chatId == chatId)
     for message in messages:
-      self.deleteMessage(message.id)
+      discard self.deleteMessage(message.id)
 
   proc replaceMessage*(self: ChatMessageList, message: Message) =
     let msgIdx = self.messageIndex[message.id]
@@ -382,7 +386,7 @@ QtObject:
       if m.fromAuthor == publicKey: # Can't delete on a loop
         msgIdxToDelete.add(m.id)
     for m in msgIdxToDelete:
-      self.deleteMessage(m)
+      discard self.deleteMessage(m)
 
   proc getID*(self: ChatMessageList):string  {.slot.} =
     self.id

--- a/src/app/chat/views/messages.nim
+++ b/src/app/chat/views/messages.nim
@@ -415,9 +415,24 @@ QtObject:
       self.unreadDirectMessagesAndMentionsCount = currentUnreadDirectMessagesAndMentionsCount
       self.unreadDirectMessagesAndMentionsCountChanged()
 
-  proc deleteMessage*(self: MessageView, channelId: string, messageId: string) =
-    self.messageList[channelId].deleteMessage(messageId)
-    self.hideMessage(messageId)
+  proc deleteMessage*(self: MessageView, channelId: string, messageId: string): bool =
+    result = self.messageList[channelId].deleteMessage(messageId)
+    if (result):
+      self.hideMessage(messageId)
+
+  proc deleteMessageWhichReplacedMessageWithId*(self: MessageView, channelId: string, messageId: string): bool =
+    var msgIdToBeDeleted: string
+    for message in self.messageList[channelId].messages:
+      if (message.replace == messageId):
+        msgIdToBeDeleted = message.id
+        break
+    
+    if (msgIdToBeDeleted.len == 0):
+      return false
+
+    result = self.messageList[channelId].deleteMessage(msgIdToBeDeleted)
+    if (result):
+      self.hideMessage(msgIdToBeDeleted)
 
   proc removeMessagesByUserId(self: MessageView, publicKey: string) {.slot.} =
     for k in self.messageList.keys:

--- a/src/app/chat/views/transactions.nim
+++ b/src/app/chat/views/transactions.nim
@@ -34,3 +34,6 @@ QtObject:
 
   proc declineRequest*(self: TransactionsView, messageId: string) {.slot.} =
     self.status.chat.declineRequestTransaction(messageId)
+  
+  proc acceptRequestTransaction*(self: TransactionsView, transactionHash: string, messageId: string, signature: string) {.slot.} =
+    self.status.chat.acceptRequestTransaction(transactionHash, messageId, signature)

--- a/src/status/chat.nim
+++ b/src/status/chat.nim
@@ -416,6 +416,10 @@ proc requestAddressForTransaction*(self: ChatModel, chatId: string, fromAddress:
   let response = status_chat_commands.requestAddressForTransaction(chatId, fromAddress, amount, address)
   discard self.processMessageUpdateAfterSend(response)
 
+proc acceptRequestTransaction*(self: ChatModel, transactionHash: string, messageId: string, signature: string) =
+  let response = status_chat_commands.acceptRequestTransaction(transactionHash, messageId, signature)
+  discard self.processMessageUpdateAfterSend(response)
+
 proc requestTransaction*(self: ChatModel, chatId: string, fromAddress: string, amount: string, tokenAddress: string) =
   let address = if (tokenAddress == ZERO_ADDRESS): "" else: tokenAddress
   let response = status_chat_commands.requestTransaction(chatId, fromAddress, amount, address)

--- a/src/status/chat/message.nim
+++ b/src/status/chat/message.nim
@@ -32,6 +32,9 @@ type CommandParameters* = object
   commandState*: int
   signature*: string
 
+proc `$`*(self: CommandParameters): string =
+  result = fmt"CommandParameters(id:{self.id}, fromAddr:{self.fromAddress}, addr:{self.address}, contract:{self.contract}, value:{self.value}, transactionHash:{self.transactionHash}, commandState:{self.commandState}, signature:{self.signature})"
+
 type Message* = object
   alias*: string
   userName*: string

--- a/src/status/chat/utils.nim
+++ b/src/status/chat/utils.nim
@@ -1,24 +1,20 @@
-import ../libstatus/settings as status_settings
-
 proc formatChatUpdate(response: JsonNode): (seq[Chat], seq[Message]) =
   var chats: seq[Chat] = @[]
   var messages: seq[Message] = @[]
-  let pk = status_settings.getSetting[string](Setting.PublicKey, "0x0")
   if response["result"]{"messages"} != nil:
     for jsonMsg in response["result"]["messages"]:
-      messages.add(jsonMsg.toMessage(pk))
+      messages.add(jsonMsg.toMessage())
   if response["result"]{"chats"} != nil:
     for jsonChat in response["result"]["chats"]:
       chats.add(jsonChat.toChat)
   result = (chats, messages)
 
 proc processChatUpdate(self: ChatModel, response: JsonNode): (seq[Chat], seq[Message]) =
-  let pk = status_settings.getSetting[string](Setting.PublicKey, "0x0")
   var chats: seq[Chat] = @[]
   var messages: seq[Message] = @[]
   if response{"result"}{"messages"} != nil:
     for jsonMsg in response["result"]["messages"]:
-      messages.add(jsonMsg.toMessage(pk))
+      messages.add(jsonMsg.toMessage())
   if response{"result"}{"chats"} != nil:
     for jsonChat in response["result"]["chats"]:
       let chat = jsonChat.toChat

--- a/src/status/libstatus/chat.nim
+++ b/src/status/libstatus/chat.nim
@@ -77,18 +77,16 @@ proc parseChatMessagesResponse*(rpcResult: JsonNode): (string, seq[Message]) =
   var messages: seq[Message] = @[]
   let messagesObj = rpcResult{"messages"}
   if(messagesObj != nil and messagesObj.kind != JNull):
-    let pk = status_settings.getSetting[string](Setting.PublicKey, "0x0")
     for jsonMsg in messagesObj:
-      messages.add(jsonMsg.toMessage(pk))
+      messages.add(jsonMsg.toMessage())
   return (rpcResult{"cursor"}.getStr, messages)
 
 proc parseActivityCenterNotifications*(rpcResult: JsonNode): (string, seq[ActivityCenterNotification]) =
-  let pk = status_settings.getSetting[string](Setting.PublicKey, "0x0")
   var notifs: seq[ActivityCenterNotification] = @[]
   var msg: Message
   if rpcResult{"notifications"}.kind != JNull:
     for jsonMsg in rpcResult["notifications"]:
-      notifs.add(jsonMsg.toActivityCenterNotification(pk))
+      notifs.add(jsonMsg.toActivityCenterNotification())
   return (rpcResult{"cursor"}.getStr, notifs)
 
 proc rpcChatMessages*(chatId: string, cursorVal: JsonNode, limit: int, success: var bool): string =
@@ -542,10 +540,9 @@ proc parseChatPinnedMessagesResponse*(rpcResult: JsonNode): (string, seq[Message
   var messages: seq[Message] = @[]
   let messagesObj = rpcResult{"pinnedMessages"}
   if(messagesObj != nil and messagesObj.kind != JNull):
-    let pk = status_settings.getSetting[string](Setting.PublicKey, "0x0")
     var msg: Message
     for jsonMsg in messagesObj:
-      msg = jsonMsg["message"].toMessage(pk)
+      msg = jsonMsg["message"].toMessage()
       msg.pinnedBy = $jsonMsg{"pinnedBy"}.getStr
       messages.add(msg)
   return (rpcResult{"cursor"}.getStr, messages)

--- a/src/status/libstatus/chatCommands.nim
+++ b/src/status/libstatus/chatCommands.nim
@@ -15,3 +15,6 @@ proc requestAddressForTransaction*(chatId: string, fromAddress: string, amount: 
 
 proc requestTransaction*(chatId: string, fromAddress: string, amount: string, tokenAddress: string): string =
   result = callPrivateRPC("requestTransaction".prefix, %* [chatId, amount, tokenAddress, fromAddress])
+
+proc acceptRequestTransaction*(transactionHash: string, messageId: string, signature: string): string =
+  result = callPrivateRPC("acceptRequestTransaction".prefix, %* [transactionHash, messageId, signature])

--- a/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/TransactionBubble.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/TransactionBubble.qml
@@ -24,6 +24,7 @@ Item {
             }
         }
     }
+
     property var token: JSON.parse(commandParametersObject.contract) // TODO: handle {}
     property string tokenAmount: commandParametersObject.value
     property string tokenSymbol: token.symbol || ""
@@ -35,18 +36,10 @@ Item {
         return walletModel.balanceView.getFiatValue(tokenAmount, token.symbol, defaultFiatSymbol) + " " + defaultFiatSymbol.toUpperCase()
     }
     property int state: commandParametersObject.commandState
-    property bool outgoing: {
-        switch (root.state) {
-            case Constants.pending:
-            case Constants.confirmed:
-            case Constants.transactionRequested:
-            case Constants.addressRequested: return isCurrentUser
-            case Constants.declined:
-            case Constants.transactionDeclined:
-            case Constants.addressReceived: return !isCurrentUser
-            default: return false
-        }
-    }
+
+    // Any transaction where isCurrentUser is true is actually outgoing transaction.
+    property bool outgoing: isCurrentUser
+
     property int innerMargin: 12
     property bool isError: commandParametersObject.contract === "{}"
     onTokenSymbolChanged: {
@@ -74,11 +67,12 @@ Item {
             color: Style.current.secondaryText
             text: {
                 if (root.state === Constants.transactionRequested) {
-                    let prefix = root.outgoing ? "↓ ": "↑ " 
+                    let prefix = outgoing? "↑ " : "↓ "
                     //% "Transaction request"
                     return prefix + qsTrId("transaction-request")
                 }
-                return root.outgoing ? 
+
+                return outgoing ?
                     //% "↑ Outgoing transaction"
                     qsTrId("--outgoing-transaction") :
                     //% "↓ Incoming transaction"
@@ -208,9 +202,3 @@ Item {
         }
     }
 }
-
-/*##^##
-Designer {
-    D{i:0;formeditorColor:"#4c4e50";formeditorZoom:1.25}
-}
-##^##*/


### PR DESCRIPTION
The reason for this issue is a message where recipient accepted to share his address with sender.
In that message recipient's public key is set as a "from" property of a "Message" object and we
cannot determine which of two users has initiated transaction actually.

This is fixed checking if the "from" address from the "commandParameters" object of the "Message"
is contained as an address in the wallet of logged in user. If yes, means that currently logged in
user has initiated a transaction (he is a sender), otherwise currently logged in user is a
recipient.

We were just sending a transaction, without notifying message about that. Now we call
callPrivateRPC("acceptRequestTransaction".prefix, %* [transactionHash, messageId, signature])
and that notifies message about the change, but only on the sender side. Appropriate message
on the recipient side was not notified about the change. That need to be checked.

Fixes: #2719