### PR TITLE
fix(@desktop/timeline): render message age instead of message time

### DIFF
--- a/ui/app/AppLayouts/Chat/ChatColumn/Message.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/Message.qml
@@ -86,6 +86,7 @@ Item {
 
     property bool isExpired: (outgoingStatus === "sending" && (Math.floor(timestamp) + 180000) < Date.now())
     property bool isStatusUpdate: false
+    property int statusAgeEpoch: 0
 
     property int replyMessageIndex: chatsModel.messageView.messageList.getMessageIndex(responseTo);
     property string repliedMessageAuthor: replyMessageIndex > -1 ? chatsModel.messageView.messageList.getMessageData(replyMessageIndex, "userName") : "";
@@ -428,6 +429,7 @@ Item {
     Component {
         id: statusUpdateComponent
         StatusUpdate {
+            statusAgeEpoch: root.statusAgeEpoch
             clickMessage: root.clickMessage
             container: root
         }

--- a/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/ChatTime.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/ChatTime.qml
@@ -4,11 +4,10 @@ import "../../../../../shared/status"
 import "../../../../../imports"
 
 StyledText {
-    property bool formatAge: false
     id: chatTime
     visible: isMessage
     color: Style.current.secondaryText
-    text: formatAge ? Utils.formatAgeFromTime(timestamp) : Utils.formatTime(timestamp)
+    text: Utils.formatTime(timestamp)
     font.pixelSize: Style.current.asideTextFontSize
     
     StatusToolTip {

--- a/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/ChatTime.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/ChatTime.qml
@@ -4,11 +4,11 @@ import "../../../../../shared/status"
 import "../../../../../imports"
 
 StyledText {
-    property bool formatDateTime: false
+    property bool formatAge: false
     id: chatTime
     visible: isMessage
     color: Style.current.secondaryText
-    text: formatDateTime ? Utils.formatDateTime(timestamp, globalSettings.locale) : Utils.formatTime(timestamp, globalSettings.locale)
+    text: formatAge ? Utils.formatAgeFromTime(timestamp) : Utils.formatTime(timestamp)
     font.pixelSize: Style.current.asideTextFontSize
     
     StatusToolTip {

--- a/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/StatusUpdate.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/StatusUpdate.qml
@@ -49,7 +49,7 @@ MouseArea {
 
         ChatTime {
             id: chatTime
-            formatDateTime: true
+            formatAge: true
             visible: chatName.visible
             anchors.verticalCenter: chatName.verticalCenter
             anchors.left: chatName.right

--- a/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/StatusUpdate.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/StatusUpdate.qml
@@ -10,6 +10,7 @@ MouseArea {
     property var clickMessage: function () {}
     property bool hovered: containsMouse
     property var container
+    property int statusAgeEpoch: 0
 
     anchors.top: parent.top
     anchors.topMargin: 0
@@ -49,7 +50,9 @@ MouseArea {
 
         ChatTime {
             id: chatTime
-            formatAge: true
+            // statusAgeEpoch is used to trigger Qt property update
+            // since the returned string will be the same in 99% cases, this should not trigger ChatTime re-rendering
+            text: Utils.formatAgeFromTime(timestamp, statusAgeEpoch)
             visible: chatName.visible
             anchors.verticalCenter: chatName.verticalCenter
             anchors.left: chatName.right

--- a/ui/app/AppLayouts/Timeline/TimelineLayout.qml
+++ b/ui/app/AppLayouts/Timeline/TimelineLayout.qml
@@ -96,7 +96,7 @@ ScrollView {
             anchors.top: statusUpdateInput.bottom
             anchors.topMargin: 40
             anchors.horizontalCenter: parent.horizontalCenter
-            visible: chatsModel.messageView.messageList.rowCount() === 0
+            visible: chatLogView.count === 0
         }
 
         ListView {

--- a/ui/app/AppLayouts/Timeline/TimelineLayout.qml
+++ b/ui/app/AppLayouts/Timeline/TimelineLayout.qml
@@ -122,6 +122,15 @@ ScrollView {
             }
         }
 
+        Timer {
+            id: ageUpdateTimer
+            property int epoch: 0
+            running: true
+            repeat: true
+            interval: 60000 // 1 min
+            onTriggered: epoch = epoch + 1
+        }
+
         DelegateModelGeneralized {
             id: messageListDelegate
             lessThan: [
@@ -151,6 +160,7 @@ ScrollView {
                 messageId: model.messageId
                 emojiReactions: model.emojiReactions
                 isStatusUpdate: true
+                statusAgeEpoch: ageUpdateTimer.epoch
                 // This is used in order to have access to the previous message and determine the timestamp
                 // we can't rely on the index because the sequence of messages is not ordered on the nim side
                 prevMessageIndex: {

--- a/ui/imports/Utils.qml
+++ b/ui/imports/Utils.qml
@@ -244,6 +244,25 @@ QtObject {
         return (hours < 10 ? "0" + hours : hours) + ":" + (minutes < 10 ? "0" + minutes : minutes)
     }
 
+    function formatAgeFromTime(timestamp) {
+        const now = new Date()
+        const messageDate = new Date(Math.floor(timestamp))
+        const diffMs = now - messageDate
+        const diffMin = Math.floor(diffMs / 60000)
+        if (diffMin < 1) {
+            return qsTr("NOW")
+        }
+        const diffHour = Math.floor(diffMin / 60)
+        if (diffHour < 1) {
+            return qsTr("%1M").arg(diffMin)
+        }
+        const diffDay = Math.floor(diffHour / 24)
+        if (diffDay < 1) {
+            return qsTr("%1H").arg(diffHour)
+        }
+        return qsTr("%1D").arg(diffDay)
+    }
+
     function formatShortDateStr(longStr) {
         const dmKeys = {
             // Days

--- a/ui/imports/Utils.qml
+++ b/ui/imports/Utils.qml
@@ -244,7 +244,8 @@ QtObject {
         return (hours < 10 ? "0" + hours : hours) + ":" + (minutes < 10 ? "0" + minutes : minutes)
     }
 
-    function formatAgeFromTime(timestamp) {
+    function formatAgeFromTime(timestamp, epoch) {
+        epoch++ // pretending the parameter is not unused
         const now = new Date()
         const messageDate = new Date(Math.floor(timestamp))
         const diffMs = now - messageDate


### PR DESCRIPTION
In according with Figma, we need to render messages' age instead of time/date.
https://www.figma.com/file/Zz6KMBxwrB0l2NPgsjnPjq/%F0%9F%91%A4-Profile%E2%8E%9CDesktop?node-id=1918%3A13058

Fixes #2918 