### PR TITLE
fix(@desktop/chat): invitation bubble long text support

### DIFF
--- a/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/InvitationBubble.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/InvitationBubble.qml
@@ -207,7 +207,7 @@ Item {
                     anchors.right: parent.right
                     anchors.rightMargin: root.innerMargin
                     font.weight: Font.Bold
-                    wrapMode: Text.WordWrap
+                    wrapMode: Text.WrapAtWordBoundaryOrAnywhere
                     font.pixelSize: 17
                 }
 
@@ -220,7 +220,7 @@ Item {
                     anchors.leftMargin: root.innerMargin
                     anchors.right: parent.right
                     anchors.rightMargin: root.innerMargin
-                    wrapMode: Text.WordWrap
+                    wrapMode: Text.WrapAtWordBoundaryOrAnywhere
                     font.pixelSize: 15
                 }
 


### PR DESCRIPTION
Fixes #2922 