### PR TITLE
fix(@desktop/communities): remove context menu leftover

### DIFF
--- a/ui/app/AppLayouts/Chat/CommunityColumn.qml
+++ b/ui/app/AppLayouts/Chat/CommunityColumn.qml
@@ -38,9 +38,8 @@ Item {
         chatInfoButton.image.source: chatsModel.communities.activeCommunity.thumbnailImage
         chatInfoButton.icon.color: chatsModel.communities.activeCommunity.communityColor
         chatInfoButton.onClicked: communityProfilePopup.open()
-
+        menuButton.visible: chatsModel.communities.activeCommunity.admin && chatsModel.communities.activeCommunity.canManageUsers
         popupMenu: StatusPopupMenu {
-
             StatusMenuItem {
                 //% "Create channel"
                 text: qsTrId("create-channel")
@@ -57,7 +56,7 @@ Item {
                 onTriggered: openPopup(createCategoryPopup, {communityId: chatsModel.communities.activeCommunity.id})
             }
 
-            StatusMenuSeparator {}
+           StatusMenuSeparator {}
 
             StatusMenuItem {
                 //% "Invite people"
@@ -68,7 +67,6 @@ Item {
             }
         }
     }
-
     Loader {
         id: membershipRequests
 
@@ -125,6 +123,7 @@ Item {
             categoryList.model: chatsModel.communities.activeCommunity.categories
 
             showCategoryActionButtons: chatsModel.communities.activeCommunity.admin
+            showPopupMenu: chatsModel.communities.activeCommunity.admin && chatsModel.communities.activeCommunity.canManageUsers
             selectedChatId: chatsModel.channelView.activeChannel.id
 
             onChatItemSelected: chatsModel.channelView.setActiveChannel(id)
@@ -135,7 +134,6 @@ Item {
             })
 
             popupMenu: StatusPopupMenu {
-
                 StatusMenuItem {
                     //% "Create channel"
                     text: qsTrId("create-channel")


### PR DESCRIPTION
fixes #2839

depends of: https://github.com/status-im/StatusQ/pull/268

![image](https://user-images.githubusercontent.com/491074/125919530-a3dfa226-665e-4e5a-b8a4-97b8d7cbf170.png)


Right click are disabled, as well as + action and category action