### PR TITLE
fix(@desktop/communities): reaction are being displayed on pinned mes…

### DIFF
--- a/src/app/chat/view.nim
+++ b/src/app/chat/view.nim
@@ -113,7 +113,12 @@ QtObject:
     result.connected = false
     result.currentSuggestions = newSuggestionsList()
     result.activityNotificationList = newActivityNotificationList(status)
-    result.reactions = newReactionView(status, result.messageView.messageList.addr, result.channelView.activeChannel)
+    result.reactions = newReactionView(
+      status,
+      result.messageView.messageList.addr,
+      result.messageView.pinnedMessagesList.addr,
+      result.channelView.activeChannel
+    )
     result.stickers = newStickersView(status, result.channelView.activeChannel)
     result.groups = newGroupsView(status,result.channelView.activeChannel)
     result.transactions = newTransactionsView(status)

--- a/src/app/chat/views/reactions.nim
+++ b/src/app/chat/views/reactions.nim
@@ -10,6 +10,7 @@ logScope:
 QtObject:
   type ReactionView* = ref object of QObject
     messageList: ptr OrderedTable[string, ChatMessageList]
+    pinnedMessageList: ptr OrderedTable[string, ChatMessageList]
     activeChannel: ChatItemView
     status: Status
     pubKey*: string
@@ -20,10 +21,11 @@ QtObject:
   proc delete*(self: ReactionView) =
     self.QObject.delete
 
-  proc newReactionView*(status: Status, messageList: ptr OrderedTable[string, ChatMessageList], activeChannel: ChatItemView): ReactionView =
+  proc newReactionView*(status: Status, messageList: ptr OrderedTable[string, ChatMessageList], pinnedMessageList: ptr OrderedTable[string, ChatMessageList], activeChannel: ChatItemView): ReactionView =
     new(result, delete)
     result = ReactionView()
     result.messageList = messageList
+    result.pinnedMessageList = pinnedMessageList
     result.status = status
     result.activeChannel = activeChannel
     result.setup
@@ -82,6 +84,7 @@ QtObject:
           # Remove the reaction
           oldReactions.delete(reaction.id)
           messageList.setMessageReactions(reaction.messageId, $oldReactions)
+          self.pinnedMessageList[][chatId].setMessageReactions(reaction.messageId, $oldReactions)
         continue
 
       oldReactions[reaction.id] = %* {
@@ -89,3 +92,4 @@ QtObject:
         "emojiId": reaction.emojiId
       }
       messageList.setMessageReactions(reaction.messageId, $oldReactions)
+      self.pinnedMessageList[][chatId].setMessageReactions(reaction.messageId, $oldReactions)


### PR DESCRIPTION
…sage

fixes #2838

This also fix the ability to add/remove a reaction to a pinned message

![image](https://user-images.githubusercontent.com/491074/126118145-0b804329-dd12-48f3-b567-aec48341514e.png)
