### PR TITLE
fix(@desktop/chat): cannot unpin last message in modal

### DIFF
--- a/src/app/chat/event_handling.nim
+++ b/src/app/chat/event_handling.nim
@@ -61,7 +61,7 @@ proc handleChatEvents(self: ChatController) =
     if (evArgs.communityMembershipRequests.len > 0):
       self.view.communities.addMembershipRequests(evArgs.communityMembershipRequests)
     if (evArgs.pinnedMessages.len > 0):
-      self.view.addPinnedMessages(evArgs.pinnedMessages)
+      self.view.refreshPinnedMessages(evArgs.pinnedMessages)
     if (evArgs.activityCenterNotifications.len > 0):
       self.view.addActivityCenterNotification(evArgs.activityCenterNotifications)
       self.view.communities.updateNotifications(evArgs.activityCenterNotifications)

--- a/src/app/chat/view.nim
+++ b/src/app/chat/view.nim
@@ -436,8 +436,8 @@ QtObject:
   proc deleteMessageWhichReplacedMessageWithId*(self: ChatsView, channelId: string, messageId: string): bool =
     result = self.messageView.deleteMessageWhichReplacedMessageWithId(channelId, messageId)
 
-  proc addPinnedMessages*(self: ChatsView, pinnedMessages: seq[Message]) =
-    self.messageView.addPinnedMessages(pinnedMessages)
+  proc refreshPinnedMessages*(self: ChatsView, pinnedMessages: seq[Message]) =
+    self.messageView.refreshPinnedMessages(pinnedMessages)
 
   proc clearMessages*(self: ChatsView, id: string) =
     self.messageView.clearMessages(id)

--- a/src/app/chat/views/message_list.nim
+++ b/src/app/chat/views/message_list.nim
@@ -313,16 +313,6 @@ QtObject:
     self.countChanged()
     self.endInsertRows()
 
-  proc remove*(self: ChatMessageList, messageId: string) =
-    if not self.messageIndex.hasKey(messageId): return
-
-    let index = self.getMessageIndex(messageId)
-    self.beginRemoveRows(newQModelIndex(), index, index)
-    self.messages.delete(index)
-    self.messageIndex.del(messageId)
-    self.countChanged()
-    self.endRemoveRows()
-
   proc getMessageById*(self: ChatMessageList, messageId: string): Message =
     if (not self.messageIndex.hasKey(messageId)): return
     return self.messages[self.messageIndex[messageId]]
@@ -344,9 +334,11 @@ QtObject:
 
   proc changeMessagePinned*(self: ChatMessageList, messageId: string, pinned: bool, pinnedBy: string): bool {.discardable.} =
     if not self.messageIndex.hasKey(messageId): return false
+
     let msgIdx = self.messageIndex[messageId]
     if msgIdx < 0: return false
     if msgIdx >= self.messages.len: return false
+    
     var message = self.messages[msgIdx]
     message.isPinned = pinned
     message.pinnedBy = pinnedBy

--- a/src/app/chat/views/messages.nim
+++ b/src/app/chat/views/messages.nim
@@ -463,7 +463,7 @@ QtObject:
     self.upsertChannel(chatId)
     if self.messageList[chatId].changeMessagePinned(messageId, false, ""):
       try:
-        self.pinnedMessagesList[chatId].remove(messageId)
+        discard self.pinnedMessagesList[chatId].deleteMessage(messageId)
       except Exception as e:
         error "Error removing ", msg = e.msg
 
@@ -475,7 +475,7 @@ QtObject:
     self.status.chat.setPinMessage(messageId, chatId, false)
     self.removePinMessage(messageId, chatId)
 
-  proc addPinnedMessages*(self: MessageView, pinnedMessages: seq[Message]) =
+  proc refreshPinnedMessages*(self: MessageView, pinnedMessages: seq[Message]) =
     for pinnedMessage in pinnedMessages:
       if (pinnedMessage.isPinned):
         self.addPinMessage(pinnedMessage.id, pinnedMessage.localChatId, pinnedMessage.pinnedBy)


### PR DESCRIPTION
fixes #2659

~~1 - Avoid to double refresh the pin messages by removing call to addPinMessage and removePinMessage.~~
~~This is done by event~~

This is only done by event when pinning from a communities chat, not from a group chat

2 - Change call from remove to deleteMessage
Remove were not updating the index and was causing the issue

3 - Erase the remove proc as the deleteMessage should always be used

3 - Rename addPinnedMessages to refreshPinnedMessages