### PR TITLE
feat(@desktop/wallet): display confirmation block count

### DIFF
--- a/src/app/wallet/view.nim
+++ b/src/app/wallet/view.nim
@@ -102,6 +102,9 @@ QtObject:
     self.balanceView.getAccountBalanceSuccess(jsonResponse)
     self.updateView()
 
+  proc getLatestBlockNumber*(self: WalletView): int {.slot.} =
+    return self.status.wallet.getLatestBlockNumber()
+
   proc getDefaultAddress*(self: WalletView): string {.slot.} =
     result = $self.status.wallet.getWalletAccounts()[0].address
 

--- a/src/app/wallet/views/transaction_list.nim
+++ b/src/app/wallet/views/transaction_list.nim
@@ -17,6 +17,7 @@ type
     From = UserRole + 12,
     To = UserRole + 13
     Contract = UserRole + 14
+    Id = UserRole + 15
 
 QtObject:
   type TransactionList* = ref object of QAbstractListModel
@@ -79,6 +80,7 @@ QtObject:
     of TransactionRoles.From: result = newQVariant(transaction.fromAddress)
     of TransactionRoles.To: result = newQVariant(transaction.to)
     of TransactionRoles.Contract: result = newQVariant(transaction.contract)
+    of TransactionRoles.Id: result = newQVariant(transaction.id)
 
   method roleNames(self: TransactionList): Table[int, string] =
     { TransactionRoles.Type.int:"typeValue",
@@ -94,7 +96,8 @@ QtObject:
     TransactionRoles.Value.int:"value",
     TransactionRoles.From.int:"fromAddress",
     TransactionRoles.To.int:"to",
-    TransactionRoles.Contract.int:"contract"}.toTable
+    TransactionRoles.Contract.int:"contract",
+    TransactionRoles.Id.int:"id",}.toTable
 
   proc addTransactionToList*(self: TransactionList, transaction: Transaction) =
     self.beginInsertRows(newQModelIndex(), self.transactions.len, self.transactions.len)

--- a/ui/app/AppLayouts/Wallet/components/TransactionModal.qml
+++ b/ui/app/AppLayouts/Wallet/components/TransactionModal.qml
@@ -20,9 +20,9 @@ ModalPopup {
 
     StyledText {
       id: confirmationsCount
-      // TODO get the right value
-      //% "9999 Confirmations"
-      text: qsTrId("9999-confirmations")
+      text: {
+        return walletModel.getLatestBlockNumber() - utilsModel.hex2Dec(blockNumber) + qsTrId(" confirmation(s)")
+      }
       font.pixelSize: 14
     }
 
@@ -97,7 +97,7 @@ ModalPopup {
 
     Address {
       id: valueHash
-      text: blockHash
+      text: id
       width: 160
       maxWidth: parent.width - labelHash.width - Style.current.padding
       color: Style.current.textColor


### PR DESCRIPTION
fixes #2715

Also, I update the hash to be the transaction hash rather than the block, let me know if you want me to revert that part. It seemed more logical to me while looking at the transaction popup ;)

![image](https://user-images.githubusercontent.com/491074/126161749-1265db76-bf5f-44e2-9cea-1277a1966abf.png)
