### PR TITLE
fix: make gas selector visible in transaction modals

### DIFF
--- a/ui/app/AppLayouts/Profile/Sections/Ens/Search.qml
+++ b/ui/app/AppLayouts/Profile/Sections/Ens/Search.qml
@@ -57,6 +57,9 @@ Item {
             this.active = false // kill an opened instance
         }
         sourceComponent: SetPubKeyModal {
+            onOpened: {
+                walletModel.gasView.getGasPricePredictions()
+            }
             onClosed: {
                 transactionDialog.closed()
             }

--- a/ui/app/AppLayouts/Profile/Sections/Ens/SetPubKeyModal.qml
+++ b/ui/app/AppLayouts/Profile/Sections/Ens/SetPubKeyModal.qml
@@ -95,7 +95,9 @@ ModalPopup {
             }
             GasSelector {
                 id: gasSelector
-                visible: false
+                visible: true
+                anchors.top: selectFromAccount.bottom
+                anchors.topMargin: Style.current.bigPadding * 2
                 slowestGasPrice: parseFloat(walletModel.gasView.safeLowGasPrice)
                 fastestGasPrice: parseFloat(walletModel.gasView.fastestGasPrice)
                 getGasEthValue: walletModel.gasView.getGasEthValue

--- a/ui/app/AppLayouts/Profile/Sections/Ens/TermsAndConditions.qml
+++ b/ui/app/AppLayouts/Profile/Sections/Ens/TermsAndConditions.qml
@@ -33,12 +33,13 @@ Item {
             this.active = false // kill an opened instance
         }
         sourceComponent: RegisterENSModal {
+            onOpened: {
+                walletModel.gasView.getGasPricePredictions()
+            }
             onClosed: {
                 transactionDialog.closed()
             }
             ensUsername: username
-            width: 425
-            height: 425
         }
     }
 

--- a/ui/i18n/base.ts
+++ b/ui/i18n/base.ts
@@ -4124,12 +4124,12 @@ Assets won’t be sent yet.</source>
     </message>
     <message id="use-suggestions">
         <location filename="../shared/GasSelector.qml" line="100"/>
-        <source>Use suggestionsUse custom</source>
+        <source>Use suggestions</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="use-custom">
         <location filename="../shared/GasSelector.qml" line="100"/>
-        <source></source>
+        <source>Use custom</source>
         <translation type="unfinished"></translation>
     </message>
     <message id="low">

--- a/ui/i18n/qml_ar.ts
+++ b/ui/i18n/qml_ar.ts
@@ -4193,12 +4193,12 @@ Assets won’t be sent yet.</source>
         </message>
         <message id="use-suggestions">
             <location filename="../shared/GasSelector.qml" line="100"/>
-            <source>Use suggestionsUse custom</source>
+            <source>Use suggestions</source>
             <translation type="unfinished"/>
         </message>
         <message id="use-custom">
             <location filename="../shared/GasSelector.qml" line="100"/>
-            <source/>
+            <source>Use custom</source>
             <translation type="unfinished"/>
         </message>
         <message id="low">

--- a/ui/i18n/qml_de.ts
+++ b/ui/i18n/qml_de.ts
@@ -4191,12 +4191,12 @@ Assets won’t be sent yet.</source>
         </message>
         <message id="use-suggestions">
             <location filename="../shared/GasSelector.qml" line="100"/>
-            <source>Use suggestionsUse custom</source>
+            <source>Use suggestions</source>
             <translation type="unfinished"/>
         </message>
         <message id="use-custom">
             <location filename="../shared/GasSelector.qml" line="100"/>
-            <source/>
+            <source>Use custom</source>
             <translation type="unfinished"/>
         </message>
         <message id="low">

--- a/ui/i18n/qml_en.ts
+++ b/ui/i18n/qml_en.ts
@@ -4377,13 +4377,13 @@ Assets won’t be sent yet.</translation>
         </message>
         <message id="use-suggestions">
             <location filename="../shared/GasSelector.qml" line="100"/>
-            <source>Use suggestionsUse custom</source>
-            <translation>Use suggestionsUse custom</translation>
+            <source>Use suggestions</source>
+            <translation>Use suggestions</translation>
         </message>
         <message id="use-custom">
             <location filename="../shared/GasSelector.qml" line="100"/>
-            <source/>
-            <translation>undefined</translation>
+            <source>Use custom</source>
+            <translation>Use custom</translation>
         </message>
         <message id="low">
             <location filename="../shared/GasSelector.qml" line="121"/>

--- a/ui/i18n/qml_es.ts
+++ b/ui/i18n/qml_es.ts
@@ -4191,12 +4191,12 @@ Assets won’t be sent yet.</source>
         </message>
         <message id="use-suggestions">
             <location filename="../shared/GasSelector.qml" line="100"/>
-            <source>Use suggestionsUse custom</source>
+            <source>Use suggestions</source>
             <translation type="unfinished"/>
         </message>
         <message id="use-custom">
             <location filename="../shared/GasSelector.qml" line="100"/>
-            <source/>
+            <source>Use custom</source>
             <translation type="unfinished"/>
         </message>
         <message id="low">

--- a/ui/i18n/qml_fil.ts
+++ b/ui/i18n/qml_fil.ts
@@ -4191,12 +4191,12 @@ Assets won’t be sent yet.</source>
         </message>
         <message id="use-suggestions">
             <location filename="../shared/GasSelector.qml" line="100"/>
-            <source>Use suggestionsUse custom</source>
+            <source>Use suggestions</source>
             <translation type="unfinished"/>
         </message>
         <message id="use-custom">
             <location filename="../shared/GasSelector.qml" line="100"/>
-            <source/>
+            <source>Use custom</source>
             <translation type="unfinished"/>
         </message>
         <message id="low">

--- a/ui/i18n/qml_fr.ts
+++ b/ui/i18n/qml_fr.ts
@@ -4183,12 +4183,12 @@ Assets won’t be sent yet.</source>
         </message>
         <message id="use-suggestions">
             <location filename="../shared/GasSelector.qml" line="100"/>
-            <source>Use suggestionsUse custom</source>
+            <source>Use suggestions</source>
             <translation type="unfinished"/>
         </message>
         <message id="use-custom">
             <location filename="../shared/GasSelector.qml" line="100"/>
-            <source/>
+            <source>Use custom</source>
             <translation type="unfinished"/>
         </message>
         <message id="low">

--- a/ui/i18n/qml_id.ts
+++ b/ui/i18n/qml_id.ts
@@ -4183,12 +4183,12 @@ Assets won’t be sent yet.</source>
         </message>
         <message id="use-suggestions">
             <location filename="../shared/GasSelector.qml" line="100"/>
-            <source>Use suggestionsUse custom</source>
+            <source>Use suggestions</source>
             <translation type="unfinished"/>
         </message>
         <message id="use-custom">
             <location filename="../shared/GasSelector.qml" line="100"/>
-            <source/>
+            <source>Use custom</source>
             <translation type="unfinished"/>
         </message>
         <message id="low">

--- a/ui/i18n/qml_it.ts
+++ b/ui/i18n/qml_it.ts
@@ -4183,12 +4183,12 @@ Assets won’t be sent yet.</source>
         </message>
         <message id="use-suggestions">
             <location filename="../shared/GasSelector.qml" line="100"/>
-            <source>Use suggestionsUse custom</source>
+            <source>Use suggestions</source>
             <translation type="unfinished"/>
         </message>
         <message id="use-custom">
             <location filename="../shared/GasSelector.qml" line="100"/>
-            <source/>
+            <source>Use custom</source>
             <translation type="unfinished"/>
         </message>
         <message id="low">

--- a/ui/i18n/qml_ko.ts
+++ b/ui/i18n/qml_ko.ts
@@ -4191,12 +4191,12 @@ Assets won’t be sent yet.</source>
         </message>
         <message id="use-suggestions">
             <location filename="../shared/GasSelector.qml" line="100"/>
-            <source>Use suggestionsUse custom</source>
+            <source>Use suggestions</source>
             <translation type="unfinished"/>
         </message>
         <message id="use-custom">
             <location filename="../shared/GasSelector.qml" line="100"/>
-            <source/>
+            <source>Use custom</source>
             <translation type="unfinished"/>
         </message>
         <message id="low">

--- a/ui/i18n/qml_pt_BR.ts
+++ b/ui/i18n/qml_pt_BR.ts
@@ -4191,12 +4191,12 @@ Assets won’t be sent yet.</source>
         </message>
         <message id="use-suggestions">
             <location filename="../shared/GasSelector.qml" line="100"/>
-            <source>Use suggestionsUse custom</source>
+            <source>Use suggestions</source>
             <translation type="unfinished"/>
         </message>
         <message id="use-custom">
             <location filename="../shared/GasSelector.qml" line="100"/>
-            <source/>
+            <source>Use custom</source>
             <translation type="unfinished"/>
         </message>
         <message id="low">

--- a/ui/i18n/qml_ru.ts
+++ b/ui/i18n/qml_ru.ts
@@ -4191,12 +4191,12 @@ Assets won’t be sent yet.</source>
         </message>
         <message id="use-suggestions">
             <location filename="../shared/GasSelector.qml" line="100"/>
-            <source>Use suggestionsUse custom</source>
+            <source>Use suggestions</source>
             <translation type="unfinished"/>
         </message>
         <message id="use-custom">
             <location filename="../shared/GasSelector.qml" line="100"/>
-            <source/>
+            <source>Use custom</source>
             <translation type="unfinished"/>
         </message>
         <message id="low">

--- a/ui/i18n/qml_tr.ts
+++ b/ui/i18n/qml_tr.ts
@@ -4191,12 +4191,12 @@ Assets won’t be sent yet.</source>
         </message>
         <message id="use-suggestions">
             <location filename="../shared/GasSelector.qml" line="100"/>
-            <source>Use suggestionsUse custom</source>
+            <source>Use suggestions</source>
             <translation type="unfinished"/>
         </message>
         <message id="use-custom">
             <location filename="../shared/GasSelector.qml" line="100"/>
-            <source/>
+            <source>Use custom</source>
             <translation type="unfinished"/>
         </message>
         <message id="low">

--- a/ui/i18n/qml_ur.ts
+++ b/ui/i18n/qml_ur.ts
@@ -4126,12 +4126,12 @@ Assets won’t be sent yet.</source>
         </message>
         <message id="use-suggestions">
             <location filename="../shared/GasSelector.qml" line="100"/>
-            <source>Use suggestionsUse custom</source>
+            <source>Use suggestions</source>
             <translation type="unfinished"/>
         </message>
         <message id="use-custom">
             <location filename="../shared/GasSelector.qml" line="100"/>
-            <source/>
+            <source>Use custom</source>
             <translation type="unfinished"/>
         </message>
         <message id="low">

--- a/ui/i18n/qml_zh.ts
+++ b/ui/i18n/qml_zh.ts
@@ -4191,12 +4191,12 @@ Assets won’t be sent yet.</source>
         </message>
         <message id="use-suggestions">
             <location filename="../shared/GasSelector.qml" line="100"/>
-            <source>Use suggestionsUse custom</source>
+            <source>Use suggestions</source>
             <translation type="unfinished"/>
         </message>
         <message id="use-custom">
             <location filename="../shared/GasSelector.qml" line="100"/>
-            <source/>
+            <source>Use custom</source>
             <translation type="unfinished"/>
         </message>
         <message id="low">

--- a/ui/i18n/qml_zh_TW.ts
+++ b/ui/i18n/qml_zh_TW.ts
@@ -4191,12 +4191,12 @@ Assets won’t be sent yet.</source>
         </message>
         <message id="use-suggestions">
             <location filename="../shared/GasSelector.qml" line="100"/>
-            <source>Use suggestionsUse custom</source>
+            <source>Use suggestions</source>
             <translation type="unfinished"/>
         </message>
         <message id="use-custom">
             <location filename="../shared/GasSelector.qml" line="100"/>
-            <source/>
+            <source>Use custom</source>
             <translation type="unfinished"/>
         </message>
         <message id="low">

--- a/ui/shared/GasSelector.qml
+++ b/ui/shared/GasSelector.qml
@@ -95,9 +95,11 @@ Item {
         id: buttonAdvanced
         anchors.verticalCenter: prioritytext.verticalCenter
         anchors.right: parent.right
-        //% "Use suggestions"
-        //% "Use custom"
-        text: advancedMode ? qsTrId("use-suggestions") : qsTrId("use-custom")
+        text: advancedMode ? 
+            //% "Use suggestions"
+            qsTrId("use-suggestions") : 
+            //% "Use custom"
+            qsTrId("use-custom")
         flat: true
         font.pixelSize: 13
         onClicked: advancedMode = !advancedMode

--- a/ui/shared/status/StatusStickerPackPurchaseModal.qml
+++ b/ui/shared/status/StatusStickerPackPurchaseModal.qml
@@ -8,7 +8,7 @@ import "../../shared/status"
 
 ModalPopup {
     id: root
-    readonly property var asset: JSON.parse(walletModel.getStatusToken())
+    readonly property var asset: JSON.parse(walletModel.tokensView.getStatusToken())
     property int stickerPackId: -1
     property string packPrice
     property bool showBackBtn: false
@@ -99,7 +99,9 @@ ModalPopup {
             }
             GasSelector {
                 id: gasSelector
-                visible: false
+                visible: true
+                anchors.top: selectFromAccount.bottom
+                anchors.topMargin: Style.current.bigPadding * 2
                 slowestGasPrice: parseFloat(walletModel.gasView.safeLowGasPrice)
                 fastestGasPrice: parseFloat(walletModel.gasView.fastestGasPrice)
                 getGasEthValue: walletModel.gasView.getGasEthValue


### PR DESCRIPTION
Fixes #2434.  
Modals that were affected by this issue were:
- RegisterENSModal (for registeing an ens username)
- SetPubKeyModal (for changing the contact code of an already owned ens)
- StatusStickerPackPurchaseModal (for acquiring a sticker pack)