### PR TITLE
fix(@desktop/chat): start chat after contact request accepted

### DIFF
--- a/src/status/chat.nim
+++ b/src/status/chat.nim
@@ -124,7 +124,10 @@ proc join*(self: ChatModel, chatId: string, chatType: ChatType, ensName: string 
 
 
 proc createOneToOneChat*(self: ChatModel, publicKey: string, ensName: string = "") =
-  if self.hasChannel(publicKey): return
+  if self.hasChannel(publicKey): 
+    self.emitTopicAndJoin(self.channels[publicKey])
+    return
+
   var chat = newChat(publicKey, ChatType.OneToOne)
   if ensName != "":
     chat.name = ensName


### PR DESCRIPTION
fixes #2902

If we want to create a one to one chat but one already exists, we still need to trigger the event, otherwise the chat is not added to the channel list