### PR TITLE
fix(@desktop/communities): mute/unmute communities

### DIFF
--- a/src/app/chat/views/communities.nim
+++ b/src/app/chat/views/communities.nim
@@ -470,6 +470,15 @@ QtObject:
             chat.muted = true
           return chat
 
+  proc setCommunityMuted*(self: CommunitiesView, communityId: string, muted: bool) {.slot.} =
+    self.status.chat.setCommunityMuted(communityId, muted)
+    if (communityId == self.activeCommunity.communityItem.id):
+      self.activeCommunity.setMuted(muted)
+
+    var community = self.joinedCommunityList.getCommunityById(communityId)
+    community.muted = muted
+    self.joinedCommunityList.replaceCommunity(community)
+
   proc markNotificationsAsRead*(self: CommunitiesView, markAsReadProps: MarkAsReadNotificationProperties) =
     if(markAsReadProps.communityId.len == 0 and markAsReadProps.channelId.len == 0):
       # Remove all notifications from all communities and their channels for set types.

--- a/ui/app/AppLayouts/Chat/CommunityComponents/CommunityProfilePopupOverview.qml
+++ b/ui/app/AppLayouts/Chat/CommunityComponents/CommunityProfilePopupOverview.qml
@@ -98,7 +98,7 @@ Column {
         components: [
             StatusSwitch {
                 checked: !root.community.muted
-                onClicked: root.notificationsButtonClicked(checked)
+                onClicked: root.notificationsButtonClicked(!checked)
             }
         ]
     }


### PR DESCRIPTION
fixes #2880

It was previously deleted from: https://github.com/status-im/status-desktop/commit/7fbccec227492c9c9f5188e1088e80304e1101fd#diff-8a095f0b8791047bc1263bddbedc82992225cc88cb743dc9bd35d05d370c5d82

Also the checked value needs to be the opposite of the current one.