### PR TITLE
chore(@desktop): nim compilation warnings - unused imports

### DIFF
--- a/src/app/chat/views/category_item.nim
+++ b/src/app/chat/views/category_item.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, std/wrapnils
+import NimQml, std/wrapnils
 import ../../../status/chat/chat
 
 QtObject:

--- a/src/app/chat/views/communities.nim
+++ b/src/app/chat/views/communities.nim
@@ -1,4 +1,4 @@
-import NimQml, json, sequtils, chronicles, strutils, strformat, tables
+import NimQml, json, sequtils, chronicles, strutils, strformat
 import ../../../status/status
 import ../../../status/chat/chat
 import ./channels_list

--- a/src/app/profile/views/muted_chats.nim
+++ b/src/app/profile/views/muted_chats.nim
@@ -1,15 +1,10 @@
-import NimQml, sequtils, strutils, sugar, os, json, chronicles
+import NimQml, sequtils, strutils, json, chronicles
 import chronicles
 import ../../chat/views/channels_list
-import ../../../status/profile/profile
 import ../../../status/profile as status_profile
 import ../../../status/contacts as status_contacts
 import ../../../status/status
-import ../../../status/ens as status_ens
 import ../../../status/chat/chat
-import ../../../status/types
-import ../../../status/constants as accountConstants
-import ../../utils/image_utils
 
 logScope:
   topics = "muted-chats-view"

--- a/src/app/profile/views/profile_settings.nim
+++ b/src/app/profile/views/profile_settings.nim
@@ -1,9 +1,7 @@
 import NimQml, os
 import chronicles
 import profile_info
-import ../../../status/profile/profile
 import ../../../status/status
-import ../../../status/types
 import ../../../status/constants as accountConstants
 
 logScope:

--- a/src/status/contacts.nim
+++ b/src/status/contacts.nim
@@ -2,9 +2,6 @@ import json, sequtils, sugar, chronicles
 import libstatus/contacts as status_contacts
 import libstatus/accounts as status_accounts
 import libstatus/chat as status_chat
-import utils as status_utils
-import chat/chat
-#import chat/utils
 import profile/profile
 import ../eventemitter
 

--- a/src/status/libstatus/eth/methods.nim
+++ b/src/status/libstatus/eth/methods.nim
@@ -5,7 +5,7 @@ import
   nimcrypto, web3/[encoding, ethtypes]
 
 import 
-  ../coder, eth, transactions, ../../types # FIXME: 'types' produces a compiler warning, but doesn't compiler without it 🤷‍♂️
+  ../../types, ../coder, eth, transactions
 
 export sendTransaction
 

--- a/src/status/mailservers.nim
+++ b/src/status/mailservers.nim
@@ -3,9 +3,6 @@ import json
 import libstatus/mailservers as status_mailservers
 import ../eventemitter
 
-#TODO: temporary?
-import types as LibStatusTypes
-
 type
     MailserversModel* = ref object
         events*: EventEmitter

--- a/src/status/types.nim
+++ b/src/status/types.nim
@@ -1,3 +1,5 @@
+{.used.}
+
 import json, options, typetraits, tables, sequtils, strutils
 import web3/ethtypes, json_serialization, stint
 import libstatus/accounts/constants


### PR DESCRIPTION
When building the app, nim compiler yields several warnings about unused imports. This PR fixes unused imports and ensures the build log is clean.