### PR TITLE
[#2549] Muted contacts and chats modal was missing indicative text

### DIFF
--- a/ui/app/AppLayouts/Profile/Sections/MutedChatsModal.qml
+++ b/ui/app/AppLayouts/Profile/Sections/MutedChatsModal.qml
@@ -11,6 +11,7 @@ ModalPopup {
     //% "Muted chats"
     title: qsTrId("muted-chats")
     property bool showMutedContacts: false
+    property string noContentText: ""
 
     onClosed: {
         root.destroy()
@@ -87,5 +88,11 @@ ModalPopup {
                 }
             }
         }
+    }
+
+    StyledText {
+        anchors.centerIn: parent
+        visible: (mutedChatsList.count === 0)
+        text: root.noContentText
     }
 }

--- a/ui/app/AppLayouts/Profile/Sections/NotificationsContainer.qml
+++ b/ui/app/AppLayouts/Profile/Sections/NotificationsContainer.qml
@@ -116,7 +116,7 @@ ScrollView {
 
             StatusSettingsLineButton {
                 //% "Play a sound when receiving a notification"
-                text: qsTrId("play-a-sound-when-receiving-a-notification")
+                text: qsTr("play-a-sound-when-receiving-a-notification")
                 isSwitch: true
                 switchChecked: appSettings.notificationSoundsEnabled
                 onClicked: {
@@ -126,7 +126,7 @@ ScrollView {
 
             StatusSettingsLineButton {
                 //% "Use your operating system's notifications"
-                text: qsTrId("use-your-operating-system-s-notifications")
+                text: qsTr("use-your-operating-system-s-notifications")
                 isSwitch: true
                 switchChecked: appSettings.useOSNotifications
                 onClicked: {
@@ -273,8 +273,9 @@ ScrollView {
                         showMutedContacts: true
                     })
                     //% "Muted contacts"
-                    mutedChatsModal.title = qsTrId("muted-contacts")
-                    mutedChatsModal.open()
+                    mutedChatsModal.title = qsTrId("muted-contacts");
+                    mutedChatsModal.noContentText = qsTr("Muted contacts will appear here");
+                    mutedChatsModal.open();
                 }
             }
 
@@ -289,8 +290,9 @@ ScrollView {
                         showMutedContacts: false
                     })
                     //% "Muted chats"
-                    mutedChatsModal.title = qsTrId("muted-chats")
-                    mutedChatsModal.open()
+                    mutedChatsModal.title = qsTrId("muted-chats");
+                    mutedChatsModal.noContentText = qsTr("Muted chats will appear here");
+                    mutedChatsModal.open();
                 }
 
                 StyledText {


### PR DESCRIPTION
Muted contacts and Muted chats modals were blank when
nothing added to list, added indicative text label

Closes #2549