### PR TITLE
feat(@desktop): single application instance

### DIFF
--- a/src/nim_status_client.nim
+++ b/src/nim_status_client.nim
@@ -66,7 +66,7 @@ proc mainProc() =
       "/../resources.rcc"
   QResource.registerResource(app.applicationDirPath & resources)
 
-  let singleInstance = newSingleInstance($toMD5(getAppDir()))
+  let singleInstance = newSingleInstance($toMD5(DATADIR))
   defer: singleInstance.delete()
   if singleInstance.secondInstance():
     info "Terminating the app as the second instance"

--- a/src/nim_status_client.nim
+++ b/src/nim_status_client.nim
@@ -1,4 +1,4 @@
-import NimQml, chronicles, os, strformat, times
+import NimQml, chronicles, os, strformat, times, md5
 
 import app/chat/core as chat
 import app/wallet/v1/core as wallet
@@ -65,6 +65,12 @@ proc mainProc() =
     else:
       "/../resources.rcc"
   QResource.registerResource(app.applicationDirPath & resources)
+
+  let singleInstance = newSingleInstance($toMD5(getAppDir()))
+  defer: singleInstance.delete()
+  if singleInstance.secondInstance():
+    info "Terminating the app as the second instance"
+    quit()
 
   let statusAppIcon =
     if defined(production):
@@ -207,6 +213,7 @@ proc mainProc() =
 
   engine.setRootContextProperty("loginModel", login.variant)
   engine.setRootContextProperty("onboardingModel", onboarding.variant)
+  engine.setRootContextProperty("singleInstance", newQVariant(singleInstance))
 
   let isExperimental = if getEnv("EXPERIMENTAL") == "1": "1" else: "0" # value explicity passed to avoid trusting input
   let experimentalFlag = newQVariant(isExperimental)

--- a/ui/main.qml
+++ b/ui/main.qml
@@ -120,6 +120,18 @@ StatusWindow {
             }
         }
     }
+	
+	Connections {
+        target: singleInstance
+
+        onSecondInstanceDetected: {
+            console.log("User attempted to run the second instance of the application")
+            // activating this instance to give user visual feedback
+            applicationWindow.show()
+            applicationWindow.raise()
+            applicationWindow.requestActivate()
+        }
+    }
 
     // The easiest way to get current system theme (is it light or dark) without using
     // OS native methods is to check lightness (0 - 1.0) of the window color.


### PR DESCRIPTION
As a user, I should not be able to run the second Status application instance, either intentionally or not, **for the same data directory** (the directory having your status account data).
The default data directory can be overridden with -d switch. 

If the user is attempted to start the second Status instance, the new process should be immediately terminated and the other (already running) instance should be activated (the main window should be made visible and brought to the foreground).

TODO: support passing command line arguments such as --url for deep links. 

