### PR TITLE
feature(@desktop/chat): implement search on sqlcipher (status-go side)

### DIFF
--- a/src/app/chat/views/message_list_proxy.nim
+++ b/src/app/chat/views/message_list_proxy.nim
@@ -1,0 +1,42 @@
+import NimQml, strutils
+
+import message_list
+import ../../../status/[status]
+import ../../../status/chat/[message]
+
+QtObject:
+  type
+    MessageListProxyModel* = ref object of ChatMessageList
+      sourceMessages: seq[Message]
+
+  proc delete(self: MessageListProxyModel) =
+    self.ChatMessageList.delete
+
+  proc setup(self: MessageListProxyModel, status: Status) =
+    self.ChatMessageList.setup("", status, false)
+
+  proc newMessageListProxyModel*(status: Status): MessageListProxyModel =
+    new(result, delete)
+    result.setup(status)
+
+  proc setSourceMessages*(self: MessageListProxyModel, messages: seq[Message]) =
+    self.sourceMessages = messages
+
+  proc setFilter*(self: MessageListProxyModel, filter: string, caseSensitive: bool) =
+    self.clear(false)
+
+    if (filter.len == 0):
+      return
+
+    let pattern  = if(caseSensitive): filter else: filter.toLowerAscii
+
+    var matchedMessages: seq[Message] = @[]
+    for message in self.sourceMessages:
+      if (caseSensitive and message.text.contains(pattern) or 
+      not caseSensitive and message.text.toLowerAscii.contains(pattern)):
+          matchedMessages.add(message)
+
+    if (matchedMessages.len == 0):
+      return
+
+    self.add(matchedMessages)

--- a/src/app/chat/views/message_list_proxy.nim
+++ b/src/app/chat/views/message_list_proxy.nim
@@ -20,9 +20,14 @@ QtObject:
     result.setup(status)
 
   proc setSourceMessages*(self: MessageListProxyModel, messages: seq[Message]) =
+    ## Sets source messages which will be filtered.
     self.sourceMessages = messages
 
   proc setFilter*(self: MessageListProxyModel, filter: string, caseSensitive: bool) =
+    ## This proc filters messages that contain passed "filter" from the previously 
+    ## set source model, respecting case sensitivity or not, based on the passed 
+    ## "caseSensitive" parameter.
+
     self.clear(false)
 
     if (filter.len == 0):
@@ -40,3 +45,10 @@ QtObject:
       return
 
     self.add(matchedMessages)
+
+  proc setFilteredMessages*(self: MessageListProxyModel, messages: seq[Message]) =
+    ## Sets filtered messages. Messages passed to this proc will be immediately
+    ## added to the view model and displayed to user. Method is convenient for 
+    ## displaying already filtered messages (for example filtered response from DB)
+    self.clear(false)
+    self.add(messages)

--- a/src/status/libstatus/chat.nim
+++ b/src/status/libstatus/chat.nim
@@ -630,3 +630,11 @@ proc unreadActivityCenterNotificationsCount*(): int =
 
   if rpcResult{"result"}.kind != JNull:
     return rpcResult["result"].getInt
+
+proc asyncSearchMessages*(chatId: string, searchTerm: string, caseSensitive: bool, success: var bool): string =
+  success = true
+  try:
+    result = callPrivateRPC("allChatMessagesWhichMatchTerm".prefix, %* [chatId, searchTerm, caseSensitive])
+  except RpcException as e:
+    success = false
+    result = e.msg

--- a/src/status/status.nim
+++ b/src/status/status.nim
@@ -33,7 +33,7 @@ proc newStatusInstance*(fleetConfig: string): Status =
   result.tasks = newTaskRunner()
   result.events = createEventEmitter()
   result.fleet = fleet.newFleetModel(fleetConfig)
-  result.chat = chat.newChatModel(result.events)
+  result.chat = chat.newChatModel(result.events, result.tasks)
   result.accounts = accounts.newAccountModel(result.events)
   result.wallet = wallet.newWalletModel(result.events)
   result.wallet.initEvents()

--- a/src/status/tasks/qt.nim
+++ b/src/status/tasks/qt.nim
@@ -9,6 +9,10 @@ type
     vptr*: ByteAddress
     slot*: string
 
+  SlotArg* = ref object of RootObj
+    vptr*: ByteAddress
+    slot*: string
+
 proc finish*[T](arg: QObjectTaskArg, payload: T) =
   signal_handler(cast[pointer](arg.vptr), Json.encode(payload), arg.slot)
 

--- a/ui/app/AppLayouts/Chat/components/SearchPopup.qml
+++ b/ui/app/AppLayouts/Chat/components/SearchPopup.qml
@@ -218,8 +218,6 @@ Popup {
                     prevMessageIndex: -1
                     prevMsgTimestamp: ""
                 }
-
-
             }
         }
     }


### PR DESCRIPTION
Current code adapted to handle future changes on message search (like searching message in multiple
channels). 

Memory leak which was happening in qml assigning (copying) MessageItem to qml variable messageItem
(where that qml variable messageItem was never deleted) is fixed.

Searching messages by some term for a specific channel is added on the side of status-go and an
appropriate part on the side of nim is developed accordingly.

Fixes: #2912