### PR TITLE
fix(@desktop/chat): hide notification when leaving/creating a group

### DIFF
--- a/src/app/chat/views/messages.nim
+++ b/src/app/chat/views/messages.nim
@@ -257,10 +257,11 @@ QtObject:
           discard self.status.chat.markMessagesSeen(msg.chatId, @[msg.id])
           self.newMessagePushed()
 
-        if not channel.muted:
+        let isGroupSelf = msg.fromAuthor == self.pubKey and msg.contentType == ContentType.Group
+        let isEdit = msg.editedAt != "0" or msg.contentType == ContentType.Edit
+        if not channel.muted and not isEdit and not isGroupSelf:
           let isAddedContact = channel.chatType.isOneToOne and self.isAddedContact(channel.id)
-          if msg.editedAt == "0": # Do not push notifications for edit messages
-            self.messageNotificationPushed(msg.chatId, escape_html(msg.text), msg.contentType.int, channel.chatType.int, msg.timestamp, msg.identicon, msg.userName, msg.hasMention, isAddedContact, channel.name)
+          self.messageNotificationPushed(msg.chatId, escape_html(msg.text), msg.contentType.int, channel.chatType.int, msg.timestamp, msg.identicon, msg.userName, msg.hasMention, isAddedContact, channel.name)
 
   proc markMessageAsSent*(self:MessageView, chat: string, messageId: string) =
     if self.messageList.contains(chat):

--- a/ui/app/AppLayouts/Chat/ChatColumn.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn.qml
@@ -590,9 +590,6 @@ Item {
             target: chatsModel.messageView
 
             onMessageNotificationPushed: function(chatId, msg, contentType, chatType, timestamp, identicon, username, hasMention, isAddedContact, channelName) {
-                if (contentType == Constants.editType)
-                    return;
-
                 if (appSettings.notificationSetting == Constants.notifyAllMessages ||
                         (appSettings.notificationSetting == Constants.notifyJustMentions && hasMention)) {
                     if (chatId === chatsModel.channelView.activeChannel.id && applicationWindow.active === true) {


### PR DESCRIPTION
fixes #2484

Also refactor to add all the guard in nim rather than being in 2 places.
Let me know if the guard I added makes sense