### PR TITLE
fix(@desktop/chat): prevent double addition of private chat

### DIFF
--- a/src/app/chat/views/channels_list.nim
+++ b/src/app/chat/views/channels_list.nim
@@ -103,9 +103,17 @@ QtObject:
     self.endResetModel()
 
   proc addChatItemToList*(self: ChannelsList, channel: Chat): int =
-    self.beginInsertRows(newQModelIndex(), 0, 0)
-    self.chats.insert(channel, 0)
-    self.endInsertRows()
+    var found = false
+    for chat in self.chats:
+      if chat.id == channel.id:
+        found = true
+        break
+    
+    if not found:
+      self.beginInsertRows(newQModelIndex(), 0, 0)
+      self.chats.insert(channel, 0)
+      self.endInsertRows()
+    
     result = 0
 
   proc removeChatItemFromList*(self: ChannelsList, channel: string): int =


### PR DESCRIPTION
fixes #2999

Before:
![image](https://user-images.githubusercontent.com/491074/126636420-a1fda8b3-4f9a-461f-92b3-0a219a619d3d.png)

After:
We switch to the already existing channel