### PR TITLE
fix(Communities): preserve category id when editing channels

### DIFF
--- a/src/app/chat/view.nim
+++ b/src/app/chat/view.nim
@@ -396,7 +396,7 @@ QtObject:
 
   proc editCommunityChannel*(self: ChatsView, communityId: string, channelId: string, name: string, description: string, categoryId: string): string {.slot.} =
     try:
-      let chat = self.status.chat.editCommunityChannel(communityId, channelId, name, description)
+      let chat = self.status.chat.editCommunityChannel(communityId, channelId, name, description, categoryId)
 
       chat.categoryId = categoryId
       self.communities.joinedCommunityList.replaceChannelInCommunity(communityId, chat)

--- a/src/app/chat/views/chat_item.nim
+++ b/src/app/chat/views/chat_item.nim
@@ -46,6 +46,11 @@ QtObject:
   QtProperty[string] communityId:
     read = communityId
 
+  proc categoryId*(self: ChatItemView): string {.slot.} = result = ?.self.chatItem.categoryId
+
+  QtProperty[string] categoryId:
+    read = categoryId
+
   proc description*(self: ChatItemView): string {.slot.} = result = ?.self.chatItem.description
   
   QtProperty[string] description:

--- a/src/status/chat.nim
+++ b/src/status/chat.nim
@@ -453,8 +453,8 @@ proc editCommunity*(self: ChatModel, id: string, name: string, description: stri
 proc createCommunityChannel*(self: ChatModel, communityId: string, name: string, description: string): Chat =
   result = status_chat.createCommunityChannel(communityId, name, description)
 
-proc editCommunityChannel*(self: ChatModel, communityId: string, channelId: string, name: string, description: string): Chat =
-  result = status_chat.editCommunityChannel(communityId, channelId, name, description)
+proc editCommunityChannel*(self: ChatModel, communityId: string, channelId: string, name: string, description: string, categoryId: string): Chat =
+  result = status_chat.editCommunityChannel(communityId, channelId, name, description, categoryId)
 
 proc createCommunityCategory*(self: ChatModel, communityId: string, name: string, channels: seq[string]): CommunityCategory =
   result = status_chat.createCommunityCategory(communityId, name, channels)

--- a/src/status/libstatus/chat.nim
+++ b/src/status/libstatus/chat.nim
@@ -384,7 +384,7 @@ proc createCommunityChannel*(communityId: string, name: string, description: str
   if rpcResult{"result"} != nil and rpcResult{"result"}.kind != JNull:
     result = rpcResult["result"]["chats"][0].toChat()
 
-proc editCommunityChannel*(communityId: string, channelId: string, name: string, description: string): Chat =
+proc editCommunityChannel*(communityId: string, channelId: string, name: string, description: string, categoryId: string): Chat =
   let rpcResult = callPrivateRPC("editCommunityChat".prefix, %*[
     communityId,
     channelId.replace(communityId, ""),
@@ -404,7 +404,8 @@ proc editCommunityChannel*(communityId: string, channelId: string, name: string,
         #     "image_type": 1 # 1 is a raw payload
         #   }
         # ]
-      }
+      },
+      "category_id": categoryId
     }]).parseJSON()
 
   if rpcResult{"error"} != nil:

--- a/ui/app/AppLayouts/Chat/CommunityComponents/CreateChannelPopup.qml
+++ b/ui/app/AppLayouts/Chat/CommunityComponents/CreateChannelPopup.qml
@@ -263,7 +263,7 @@ StatusModal {
                                                                 channel.id,
                                                                 Utils.filterXSS(popup.contentComponent.channelName.text),
                                                                 Utils.filterXSS(popup.contentComponent.channelDescription.text),
-                      categoryId)
+                      channel.categoryId)
                                                                 // TODO: pass the private value when private channels
                                                                 // are implemented
                                                                 //privateSwitch.checked)


### PR DESCRIPTION
As described in #3015, when editing channels that belong to a category of a community,
after saving them, they'll get kicked out of the category.

This is because we haven't passed the category id along the API that performs the
save operation.

This commit ensures we have access to a category chats' `categoryId` and send it
over to `editCommunityChat` RPC API provided by status-go

Fixes #3015