### PR TITLE
fix(@desktop/onboarding): do not display keyuid as address

### DIFF
--- a/src/app/login/view.nim
+++ b/src/app/login/view.nim
@@ -10,9 +10,9 @@ type
   AccountRoles {.pure.} = enum
     Username = UserRole + 1
     Identicon = UserRole + 2
-    Address = UserRole + 3
-    ThumbnailImage = UserRole + 4
-    LargeImage = UserRole + 5
+    ThumbnailImage = UserRole + 3
+    LargeImage = UserRole + 4
+    KeyUid = UserRole + 5
 
 QtObject:
   type LoginView* = ref object of QAbstractListModel
@@ -45,7 +45,6 @@ QtObject:
     self.currentAccount.setAccount(GeneratedAccount(
       name: currNodeAcct.name,
       identicon: currNodeAcct.identicon,
-      address: currNodeAcct.keyUid,
       keyUid: currNodeAcct.keyUid,
       identityImage: currNodeAcct.identityImage
     ))
@@ -80,7 +79,7 @@ QtObject:
     case assetRole:
     of AccountRoles.Username: result = newQVariant(asset.name)
     of AccountRoles.Identicon: result = newQVariant(asset.identicon)
-    of AccountRoles.Address: result = newQVariant(asset.keyUid)
+    of AccountRoles.KeyUid: result = newQVariant(asset.keyUid)
     of AccountRoles.ThumbnailImage:
       if (not asset.identityImage.isNil):
         result = newQVariant(asset.identityImage.thumbnail)
@@ -95,15 +94,15 @@ QtObject:
   method roleNames(self: LoginView): Table[int, string] =
     { AccountRoles.Username.int:"username",
     AccountRoles.Identicon.int:"identicon",
-    AccountRoles.Address.int:"address",
     AccountRoles.ThumbnailImage.int:"thumbnailImage",
-    AccountRoles.LargeImage.int:"largeImage" }.toTable
+    AccountRoles.LargeImage.int:"largeImage",
+    AccountRoles.KeyUid.int:"keyUid" }.toTable
 
   proc login(self: LoginView, password: string): string {.slot.} =
     var currentAccountId = 0
     var i = 0
     for account in self.accounts:
-      if (account.keyUid == self.currentAccount.address):
+      if (account.keyUid == self.currentAccount.keyUid):
         currentAccountId = i
         break
       i = i + 1

--- a/src/app/onboarding/view.nim
+++ b/src/app/onboarding/view.nim
@@ -9,7 +9,8 @@ type
   AccountRoles {.pure.} = enum
     Username = UserRole + 1,
     Identicon = UserRole + 2,
-    Address = UserRole + 3
+    KeyUid = UserRole + 3,
+    Address = UserRole + 4
 
 QtObject:
   type OnboardingView* = ref object of QAbstractListModel
@@ -59,11 +60,13 @@ QtObject:
     case assetRole:
     of AccountRoles.Username: result = newQVariant(asset.name)
     of AccountRoles.Identicon: result = newQVariant(asset.identicon)
-    of AccountRoles.Address: result = newQVariant(asset.keyUid)
+    of AccountRoles.KeyUid: result = newQVariant(asset.keyUid)
+    of AccountRoles.Address: result = newQVariant(asset.address)
 
   method roleNames(self: OnboardingView): Table[int, string] =
     { AccountRoles.Username.int:"username",
     AccountRoles.Identicon.int:"identicon",
+    AccountRoles.KeyUid.int:"keyUid",
     AccountRoles.Address.int:"address" }.toTable
 
   proc storeAccountAndLogin(self: OnboardingView, selectedAccountIndex: int, password: string): string {.slot.} =

--- a/src/app/onboarding/views/account_info.nim
+++ b/src/app/onboarding/views/account_info.nim
@@ -52,9 +52,9 @@ QtObject:
     read = largeImage
     notify = identityImageChanged
 
-  proc address*(self: AccountInfoView): string {.slot.} = result = ?.self.account.address
-  QtProperty[string] address:
-    read = address
+  proc keyUid*(self: AccountInfoView): string {.slot.} = result = ?.self.account.keyUid
+  QtProperty[string] keyUid:
+    read = keyUid
     notify = accountChanged
 
   proc id*(self: AccountInfoView): string {.slot.} = result = ?.self.account.id

--- a/ui/nim-status-client.pro
+++ b/ui/nim-status-client.pro
@@ -354,7 +354,7 @@ DISTFILES += \
     onboarding/KeysMain.qml \
     onboarding/Login.qml \
     onboarding/Login/AccountList.qml \
-    onboarding/Login/AddressView.qml \
+    onboarding/Login/AccountView.qml \
     onboarding/Login/ConfirmAddExistingKeyModal.qml \
     onboarding/Login/SelectAnotherAccountModal.qml \
     onboarding/Login/qmldir \

--- a/ui/onboarding/GenKeyModal.qml
+++ b/ui/onboarding/GenKeyModal.qml
@@ -20,7 +20,7 @@ ModalPopup {
         interactive: false
 
         accounts: onboardingModel
-        isSelected: function (index, address) {
+        isSelected: function (index) {
             return index === selectedIndex
         }
         onAccountSelect: function(index) {

--- a/ui/onboarding/Login.qml
+++ b/ui/onboarding/Login.qml
@@ -114,19 +114,9 @@ Item {
             }
         }
 
-        Address {
-            id: addressText
-            width: 90
-            text: loginModel.currentAccount.address
-            font.pixelSize: 15
-            anchors.top: usernameText.bottom
-            anchors.topMargin: 4
-            anchors.horizontalCenter: parent.horizontalCenter
-        }
-
         Input {
             id: txtPassword
-            anchors.top: addressText.bottom
+            anchors.top: changeAccountBtn.bottom
             anchors.topMargin: Style.current.padding * 2
             enabled: !loading
             //% "Enter password"

--- a/ui/onboarding/Login/AccountList.qml
+++ b/ui/onboarding/Login/AccountList.qml
@@ -8,22 +8,23 @@ ListView {
     property var isSelected: function () {}
     property var onAccountSelect: function () {}
 
-    id: addressesView
+    id: accountsView
     anchors.fill: parent
     model: accounts
     focus: true
     spacing: Style.current.smallPadding
     clip: true
 
-    delegate: AddressView {
+    delegate: AccountView {
         username: model.username
-        address: model.address
         identicon: model.thumbnailImage || model.identicon
-        isSelected: function (index, address) {
-            return addressesView.isSelected(index, address)
+        keyUid: model.keyUid
+        address: model.address || ''
+        isSelected: function (index, keyUid) {
+            return accountsView.isSelected(index, keyUid)
         }
         onAccountSelect: function (index) {
-            addressesView.onAccountSelect(index)
+            accountsView.onAccountSelect(index)
         }
     }
 }

--- a/ui/onboarding/Login/AccountView.qml
+++ b/ui/onboarding/Login/AccountView.qml
@@ -6,12 +6,13 @@ import "../../shared/status"
 
 Rectangle {
     property string username: "Jotaro Kujo"
-    property string address: "0x123345677890987654321123456"
+    property string keyUid: "0x123345677890987654321123456"
+    property string address: ""
     property url identicon: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADIAAAAyCAYAAAAeP4ixAAAAg0lEQVR4nOzXwQmAMBAFURV7sQybsgybsgyr0QYUlE1g+Mw7ioQMe9lMQwhDaAyhMYTGEJqYkPnrj/t5XE/ft2UdW1yken7MRAyhMYTGEBpDaAyhKe9JbzvSX9WdLWYihtAYQuMLkcYQGkPUScxEDKExhMYQGkNoDKExhMYQmjsAAP//ZfIUZgXTZXQAAAAASUVORK5CYII="
     property var onAccountSelect: function() {}
     property var isSelected: function() {}
     property bool selected: {
-        return isSelected(index, address)
+        return isSelected(index, keyUid)
     }
     property bool isHovered: false
 

--- a/ui/onboarding/Login/SelectAnotherAccountModal.qml
+++ b/ui/onboarding/Login/SelectAnotherAccountModal.qml
@@ -16,8 +16,8 @@ ModalPopup {
         anchors.fill: parent
 
         accounts: loginModel
-        isSelected: function (index, address) {
-            return loginModel.currentAccount.address === address
+        isSelected: function (index, keyUid) {
+            return loginModel.currentAccount.keyUid === keyUid
         }
 
         onAccountSelect: function(index) {

--- a/ui/onboarding/Login/qmldir
+++ b/ui/onboarding/Login/qmldir
@@ -1,4 +1,4 @@
 AccountList 1.0 AccountList.qml
-AddressView 1.0 AddressView.qml
+AccountView 1.0 AccountView.qml
 SelectAnotherAccountModal 1.0 SelectAnotherAccountModal.qml
 ConfirmAddExistingKeyModal 1.0 ConfirmAddExistingKeyModal.qml


### PR DESCRIPTION
fixes #3035

* Avoid mismatch between keyuid and address
* Remove the keyuid from the login screen

We found out that we cannot get the address from the keyuid, and before login the address is not available.