### PR TITLE
fix(@desktop/onboarding):

### DIFF
--- a/ui/onboarding/CreatePasswordModal.qml
+++ b/ui/onboarding/CreatePasswordModal.qml
@@ -49,8 +49,8 @@ ModalPopup {
         //% "Confirm password…"
         placeholderText: qsTrId("confirm-password…")
         textField.echoMode: TextInput.Password
-        Keys.onReturnPressed: {
-            submitBtn.clicked()
+        Keys.onReturnPressed: function(event) {
+            submitBtn.clicked(event)
         }
         onTextChanged: {
             [repeatPasswordFieldValid, repeatPasswordValidationError] =


### PR DESCRIPTION
Allow to click enter when generating a new account and clicking enter
Error was:
qrc:/onboarding/CreatePasswordModal.qml:53: Error: Insufficient arguments