### PR TITLE
bug(@desktop/wallet): gas selector modal has text, divider and custom/suggestions toggle overlapped

### DIFF
--- a/ui/shared/status/StatusStickerMarket.qml
+++ b/ui/shared/status/StatusStickerMarket.qml
@@ -51,7 +51,7 @@ Item {
 
             ModalPopup {
                 id: stickerPackDetailsPopup
-                height: 472
+                height: 540
                 header: StatusStickerPackDetails {
                     packThumb: thumbnail
                     packName: name

--- a/ui/shared/status/StatusStickerPackPurchaseModal.qml
+++ b/ui/shared/status/StatusStickerPackPurchaseModal.qml
@@ -126,7 +126,6 @@ ModalPopup {
             GasValidator {
                 id: gasValidator
                 anchors.bottom: parent.bottom
-                anchors.bottomMargin: 8
                 selectedAccount: selectFromAccount.selectedAccount
                 selectedAsset: root.asset
                 selectedAmount: parseFloat(packPrice)


### PR DESCRIPTION
Bug is easily reproducible if you try to buy some stickers, in that case suggestion text
overlaps divider and buttons, and if you don't enough balance warning about that will overlap
all that also.

Fixed by increasing hight of the appropriate modal.

Fixes: #2994