### PR TITLE
fix(@desktop/chat): revert the visible logic for fetch more messages

### DIFF
--- a/src/app/chat/views/chat_item.nim
+++ b/src/app/chat/views/chat_item.nim
@@ -182,13 +182,6 @@ QtObject:
   proc muted*(self: ChatItemView): bool {.slot.} =
     return ?.self.chatItem.muted
 
-  proc joined*(self: ChatItemView): string {.slot.} = 
-    if self.chatItem.isNil: return ""
-    return $self.chatItem.joined
-
-  QtProperty[string] joined:
-    read = joined
-
   QtProperty[bool] muted:
     read = muted
     notify = mutedChanged

--- a/ui/app/AppLayouts/Chat/ChatColumn/ChatMessages.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/ChatMessages.qml
@@ -311,8 +311,6 @@ Item {
                 }
                 messageContextMenu: svRoot.messageContextMenuInst
 
-                // This is used in order to have access to the previous message and determine the timestamp
-                // we can't rely on the index because the sequence of messages is not ordered on the nim side
                 prevMessageIndex: {
                     // This is used in order to have access to the previous message and determine the timestamp
                     // we can't rely on the index because the sequence of messages is not ordered on the nim side

--- a/ui/app/AppLayouts/Chat/ChatColumn/Message.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/Message.qml
@@ -297,19 +297,6 @@ Item {
         id: fetchMoreMessagesButtonComponent
         Item {
             id: wrapper
-            readonly property int gapNowAndOldest: nextMessageIndex > -1 ? (Date.now() / 1000 - nextMsgTimestamp / 1000) : 0
-            readonly property int gapNowAndJoined: Date.now() / 1000 - +chatsModel.channelView.activeChannel.joined / 1000
-            readonly property int maxGapInSeconds: Constants.maxNbDaysToFetch * Constants.fetchRangeLast24Hours
-
-            visible: {
-                if (!chatsModel.channelView.activeChannel) {
-                    return false
-                }
-                return gapNowAndOldest < maxGapInSeconds
-                        && gapNowAndJoined > maxGapInSeconds
-                        && (chatsModel.channelView.activeChannel.chatType !== Constants.chatTypePrivateGroupChat
-                            || chatsModel.channelView.activeChannel.isMember)
-            }
             height: childrenRect.height + Style.current.smallPadding * 2
             anchors.left: parent.left
             anchors.right: parent.right


### PR DESCRIPTION
This is causing fetch more message to not be visible in other chat type
such as public chat

Mainly revert:
#2797 

fixes #2856

The original issue #2379 : Load more message should not be present when creating a group chat is still present

