### PR TITLE
chores(@desktop/chat): add guard when buying stickers

### DIFF
--- a/src/app/chat/views/stickers.nim
+++ b/src/app/chat/views/stickers.nim
@@ -113,8 +113,15 @@ QtObject:
     self.gasEstimateReturned(estimateResult.estimate, estimateResult.uuid)
 
   proc buy*(self: StickersView, packId: int, address: string, price: string, gas: string, gasPrice: string, password: string): string {.slot.} =
+    try:
+      validateTransactionInput(address, address, "", price, gas, gasPrice, "", "ok")
+    except Exception as e:
+      error "Error buying sticker pack", msg = e.msg
+      return ""
+
     var success: bool
     let response = self.status.stickers.buyPack(packId, address, price, gas, gasPrice, password, success)
+
     # TODO:
     # check if response["error"] is not null and handle the error
     result = $(%* { "result": %response, "success": %success })

--- a/src/status/utils.nim
+++ b/src/status/utils.nim
@@ -145,6 +145,7 @@ proc validateTransactionInput*(from_addr, to_addr, assetAddress, value, gas, gas
   if parseFloat(value) < 0: raise newException(ValueError, "value should be a number >= 0")
   if parseInt(gas) <= 0: raise newException(ValueError, "gas should be a number > 0")
   if parseFloat(gasPrice) <= 0: raise newException(ValueError, "gasPrice should be a number > 0")
+
   if uuid.isEmptyOrWhitespace(): raise newException(ValueError, "uuid is required")
 
   if assetAddress != "": # If a token is being used


### PR DESCRIPTION
Call the same function as to when we do a transaction to validate
the argument. From there we validate that the gas in an int.

sister PR of #3071

@anastasiyaig if you could double check that buying sticker pack still work?