### PR TITLE
fix(act-center): multiple fixes to the activity center

### DIFF
--- a/src/app/chat/views/activity_notification_list.nim
+++ b/src/app/chat/views/activity_notification_list.nim
@@ -243,6 +243,12 @@ QtObject:
       self.setNewData(activityCenterNotifications)
     else:
       for activityCenterNotification in activityCenterNotifications:
+        var found = false
+        for notif in self.activityCenterNotifications:
+          if activityCenterNotification.id == notif.id:
+            found = true
+            break
+        if found: continue
         self.addActivityNotificationItemToList(activityCenterNotification, false)
 
     self.nbUnreadNotifications = self.status.chat.unreadActivityCenterNotificationsCount()

--- a/ui/app/AppLayouts/Chat/ChatColumn.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn.qml
@@ -234,7 +234,7 @@ Item {
 
                 membersButton.visible: appSettings.showOnlineUsers && chatsModel.channelView.activeChannel.chatType !== Constants.chatTypeOneToOne
                 notificationButton.visible: appSettings.isActivityCenterEnabled
-                notificationCount: chatsModel.activityNotificationList.unreadCount
+                notificationCount: chatsModel.activityNotificationList.unreadCount + profileModel.contacts.contactRequests.count
 
                 onSearchButtonClicked: searchPopup.open()
                 SearchPopup {

--- a/ui/app/AppLayouts/Chat/ChatColumn.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn.qml
@@ -234,7 +234,7 @@ Item {
 
                 membersButton.visible: appSettings.showOnlineUsers && chatsModel.channelView.activeChannel.chatType !== Constants.chatTypeOneToOne
                 notificationButton.visible: appSettings.isActivityCenterEnabled
-                notificationCount: chatsModel.activityNotificationList.unreadCount + profileModel.contacts.contactRequests.count
+                notificationCount: chatsModel.activityNotificationList.unreadCount
 
                 onSearchButtonClicked: searchPopup.open()
                 SearchPopup {

--- a/ui/app/AppLayouts/Chat/ChatColumn/ActivityCenter.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/ActivityCenter.qml
@@ -18,7 +18,7 @@ Popup {
     property int currentFilter: ActivityCenter.Filter.All
     property bool hasMentions: false
     property bool hasReplies: false
-    property bool hasContactRequests: contactList.count > 0
+//    property bool hasContactRequests: false
 
     property bool hideReadNotifications: false
 
@@ -70,31 +70,31 @@ Popup {
             }
 
             // TODO remove this once it is handled by the activity center
-            Repeater {
-                id: contactList
-                model: profileModel.contacts.contactRequests
+//            Repeater {
+//                id: contactList
+//                model: profileModel.contacts.contactRequests
 
-                delegate: ContactRequest {
-                    visible: !hideReadNotifications &&
-                             (activityCenter.currentFilter === ActivityCenter.Filter.All || activityCenter.currentFilter === ActivityCenter.Filter.ContactRequests)
-                    name: Utils.removeStatusEns(model.name)
-                    address: model.address
-                    localNickname: model.localNickname
-                    identicon: model.thumbnailImage || model.identicon
-                    // TODO set to transparent bg if the notif is read
-                    color: Utils.setColorAlpha(Style.current.blue, 0.1)
-                    radius: 0
-                    profileClick: function (showFooter, userName, fromAuthor, identicon, textParam, nickName) {
-                        var popup = profilePopupComponent.createObject(contactList);
-                        popup.openPopup(showFooter, userName, fromAuthor, identicon, textParam, nickName);
-                    }
-                    onBlockContactActionTriggered: {
-                        blockContactConfirmationDialog.contactName = name
-                        blockContactConfirmationDialog.contactAddress = address
-                        blockContactConfirmationDialog.open()
-                    }
-                }
-            }
+//                delegate: ContactRequest {
+//                    visible: !hideReadNotifications &&
+//                             (activityCenter.currentFilter === ActivityCenter.Filter.All || activityCenter.currentFilter === ActivityCenter.Filter.ContactRequests)
+//                    name: Utils.removeStatusEns(model.name)
+//                    address: model.address
+//                    localNickname: model.localNickname
+//                    identicon: model.thumbnailImage || model.identicon
+//                    // TODO set to transparent bg if the notif is read
+//                    color: Utils.setColorAlpha(Style.current.blue, 0.1)
+//                    radius: 0
+//                    profileClick: function (showFooter, userName, fromAuthor, identicon, textParam, nickName) {
+//                        var popup = profilePopupComponent.createObject(contactList);
+//                        popup.openPopup(showFooter, userName, fromAuthor, identicon, textParam, nickName);
+//                    }
+//                    onBlockContactActionTriggered: {
+//                        blockContactConfirmationDialog.contactName = name
+//                        blockContactConfirmationDialog.contactAddress = address
+//                        blockContactConfirmationDialog.open()
+//                    }
+//                }
+//            }
 
             Repeater {
                 model: notifDelegateList
@@ -129,7 +129,6 @@ Popup {
                                 hasReplies = true
                             }
                             break
-
                         }
                     }
 

--- a/ui/app/AppLayouts/Chat/ChatColumn/ChatComponents/ActivityCenterMessageComponent.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/ChatComponents/ActivityCenterMessageComponent.qml
@@ -20,7 +20,9 @@ Item {
                 (model.notificationType === Constants.activityCenterNotificationTypeReply && activityCenter.currentFilter === ActivityCenter.Filter.Replies)
     }
     width: parent.width
-    height: visible ? messageNotificationContent.height : 0
+    // Setting a height of 0 breaks the layout for when it comes back visible
+    // The Item never goes back to actually have a height or width
+    height: visible ? messageNotificationContent.height : 0.01
 
     function openProfile() {
         const pk = model.author
@@ -58,8 +60,13 @@ Item {
         AcceptRejectOptionsButtons {
             id: buttons
             onAcceptClicked: {
+                const setActiveChannel = chatsModel.channelView.setActiveChannel
+                const chatId = model.message.chatId
+                const messageId = model.message.messageId
                 profileModel.contacts.addContact(model.author)
                 chatsModel.activityNotificationList.acceptActivityCenterNotification(model.id)
+                setActiveChannel(chatId)
+                positionAtMessage(messageId)
             }
             onDeclineClicked: chatsModel.activityNotificationList.dismissActivityCenterNotification(model.id)
             onProfileClicked: root.openProfile()

--- a/ui/app/AppLayouts/Chat/ChatColumn/ChatComponents/ActivityCenterTopBar.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/ChatComponents/ActivityCenterTopBar.qml
@@ -50,16 +50,16 @@ Item {
            onClicked: activityCenter.currentFilter = ActivityCenter.Filter.Replies
        }
 
-       StatusButton {
-           id: contactRequestsBtn
-           //% "Contact requests"
-           text: qsTrId("contact-requests")
-           enabled: hasContactRequests
-           type: "secondary"
-           size: "small"
-           highlighted: activityCenter.currentFilter === ActivityCenter.Filter.ContactRequests
-           onClicked: activityCenter.currentFilter = ActivityCenter.Filter.ContactRequests
-       }
+//       StatusButton {
+//           id: contactRequestsBtn
+//           //% "Contact requests"
+//           text: qsTrId("contact-requests")
+//           enabled: hasContactRequests
+//           type: "secondary"
+//           size: "small"
+//           highlighted: activityCenter.currentFilter === ActivityCenter.Filter.ContactRequests
+//           onClicked: activityCenter.currentFilter = ActivityCenter.Filter.ContactRequests
+//       }
     }
 
     Row {

--- a/ui/app/AppLayouts/Chat/ChatColumn/ChatComponents/ActivityChannelBadge.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/ChatComponents/ActivityChannelBadge.qml
@@ -50,7 +50,7 @@ Rectangle {
         id: replyComponent
 
         Item {
-            property int replyMessageIndex: chatsModel.getMessageIndex(chatId, responseTo)
+            property int replyMessageIndex: chatsModel.messageView.getMessageIndex(chatId, responseTo)
             property string repliedMessageContent: replyMessageIndex > -1 ? chatsModel.messageView.getMessageData(chatId, replyMessageIndex, "message") : "";
 
 


### PR DESCRIPTION
Fixes the following issues:
- Adds the contact request count to the bell icon count
- Fixes an issue where notifications could become duplicated
- Fixes an issue where if there is no notif in the center, the notifs will have a 0 height and width
- Fix the 1-1 accept to go to the channel
- Fix the reply badge missing the message text