### PR TITLE
ci: fix JSON parsing in release process

### DIFF
--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.2.19'
+library 'status-jenkins-lib@v1.2.20'
 
 pipeline {
   agent { label 'linux' }

--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.2.19'
+library 'status-jenkins-lib@v1.2.20'
 
 pipeline {
   agent {

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.2.19'
+library 'status-jenkins-lib@v1.2.20'
 
 pipeline {
   agent {

--- a/ci/Jenkinsfile.windows
+++ b/ci/Jenkinsfile.windows
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.2.19'
+library 'status-jenkins-lib@v1.2.20'
 
 pipeline {
   agent { label 'windows' }


### PR DESCRIPTION
Fixes:
```
Caused: java.io.NotSerializableException: groovy.json.internal.LazyMap
```
https://ci.status.im/job/status-desktop/job/release/job/release%252F0.1.0-beta.11/2/