### PR TITLE
fix(@desktop/chat): make chat group popup work again

### DIFF
--- a/ui/app/AppLayouts/Chat/ChatColumn.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn.qml
@@ -222,7 +222,10 @@ Item {
                 chatInfoButton.onClicked: {
                     switch (chatsModel.channelView.activeChannel.chatType) {
                     case Constants.chatTypePrivateGroupChat:
-                        openPopup(groupInfoPopupComponent, {channelType: GroupInfoPopup.ChannelType.ActiveChannel})
+                        openPopup(groupInfoPopupComponent, {
+                            channelType: GroupInfoPopup.ChannelType.ActiveChannel,
+                            channel: chatsModel.channelView.activeChannel
+                        })
                         break;
                     case Constants.chatTypeOneToOne:
                         openProfilePopup(chatsModel.userNameOrAlias(chatsModel.channelView.activeChannel.id),

--- a/ui/app/AppLayouts/Chat/components/ChatContextMenu.qml
+++ b/ui/app/AppLayouts/Chat/components/ChatContextMenu.qml
@@ -44,7 +44,10 @@ StatusPopupMenu {
                 )
             }
             if (chatItem.chatType === Constants.chatTypePrivateGroupChat) {
-                return openPopup(groupInfoPopupComponent, {channelType: GroupInfoPopup.ChannelType.ContextChannel})
+                return openPopup(groupInfoPopupComponent, {
+                    channel: chatItem,
+                    channelType: GroupInfoPopup.ChannelType.ContextChannel
+                })
             }
         }
     }

--- a/ui/app/AppLayouts/Chat/components/GroupInfoPopup.qml
+++ b/ui/app/AppLayouts/Chat/components/GroupInfoPopup.qml
@@ -18,13 +18,7 @@ ModalPopup {
     readonly property int maxMembers: 10
     property var pubKeys: []
     property int channelType: GroupInfoPopup.ChannelType.ActiveChannel
-    property QtObject channel: {
-        if (channelType === GroupInfoPopup.ChannelType.ActiveChannel) {
-            return chatsModel.channelView.activeChannel
-         } else if (channelType === GroupInfoPopup.ChannelType.ContextChannel) {
-            return chatsModel.channelView.contextChannel
-         }
-    }
+    property QtObject channel
     property bool isAdmin: false
     property Component pinnedMessagesPopupComponent
 


### PR DESCRIPTION
This broke during the modal refactoring because we're no longer relying
on `chatsModel.contextChannel`.

Passing the channel item to the popup ensures it's properly hydrated again.

Closes #3050