### PR TITLE
fix(@desktop/wallet): correct position of not enough gas error

### DIFF
--- a/ui/app/AppLayouts/Wallet/SendModal.qml
+++ b/ui/app/AppLayouts/Wallet/SendModal.qml
@@ -15,7 +15,7 @@ ModalPopup {
 
     //% "Send"
     title: qsTrId("command-button-send")
-    height: 504
+    height: 540
 
     property MessageDialog sendingError: MessageDialog {
         id: sendingError
@@ -156,8 +156,8 @@ ModalPopup {
             }
             GasValidator {
                 id: gasValidator
-                anchors.bottom: parent.bottom
-                anchors.bottomMargin: 8
+                anchors.top: gasSelector.bottom
+                anchors.topMargin: 8
                 selectedAccount: selectFromAccount.selectedAccount
                 selectedAmount: parseFloat(txtAmount.selectedAmount)
                 selectedAsset: txtAmount.selectedAsset


### PR DESCRIPTION
fixes #2714

Increase height of the modal and position the validator to below the previous
item

![image](https://user-images.githubusercontent.com/491074/127325554-97e92e6a-c5d8-4156-b874-469101856785.png)
