### PR TITLE
fix(@desktop/chat): uploading image limit is 0.5Mb

### DIFF
--- a/ui/imports/Constants.qml
+++ b/ui/imports/Constants.qml
@@ -145,7 +145,7 @@ QtObject {
     readonly property string userLinkPrefix: 'https://join.status.im/u/'
 
     readonly property int maxUploadFiles: 5
-    readonly property double maxUploadFilesizeMB: 0.5
+    readonly property double maxUploadFilesizeMB: 10
 
     readonly property int maxNumberOfPins: 3
 


### PR DESCRIPTION
Fixes #3068 

While sending an image, we call `dos_image_resizer` utility function that uses `QImage` to shrink any given image to max of 2000px width and height. Then it encodes the image to JPEG @ 75 quality. This usually results in <1MB of size.
However, on the UI I think we should impose certain limit and I suggest 10Mb which should be fine for Desktop platform.
If we were removing this limit at all, then resizing of a truly large image (say 100Mb) may cause abnormal memory and CPU usage. Given that we do not have any visual feedback while processing the image, for the user it will look like a UI freeze.
