### PR TITLE
Remove activity center backdrop

### DIFF
--- a/ui/app/AppLayouts/Browser/AddFavoriteModal.qml
+++ b/ui/app/AppLayouts/Browser/AddFavoriteModal.qml
@@ -36,7 +36,7 @@ ModalPopup {
             verticalOffset: 5
             radius: 10
             samples: 15
-            color: "#22000000"
+            color: Style.current.dropShadow
         }
     }
 

--- a/ui/app/AppLayouts/Browser/BrowserWalletMenu.qml
+++ b/ui/app/AppLayouts/Browser/BrowserWalletMenu.qml
@@ -31,7 +31,7 @@ Popup {
             verticalOffset: 5
             radius: 10
             samples: 15
-            color: "#22000000"
+            color: Style.current.dropShadow
         }
     }
     padding: Style.current.padding

--- a/ui/app/AppLayouts/Chat/ChatColumn/ActivityCenter.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/ActivityCenter.qml
@@ -1,6 +1,7 @@
 import QtQuick 2.13
 import QtQuick.Controls 2.13
 import QtQml.Models 2.13
+import QtGraphicalEffects 1.13
 import "../../../../shared"
 import "../../../../shared/status"
 import "../../../../imports"
@@ -23,17 +24,24 @@ Popup {
     property bool hideReadNotifications: false
 
     id: activityCenter
-    modal: true
+    modal: false
 
-    Overlay.modal: Rectangle {
-        color: Qt.rgba(0, 0, 0, 0.4)
-    }
     closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
     parent: Overlay.overlay
+
     width: 560
     background: Rectangle {
         color: Style.current.background
         radius: Style.current.radius
+        layer.enabled: true
+        layer.effect: DropShadow {
+            verticalOffset: 3
+            radius: Style.current.radius
+            samples: 15
+            fast: true
+            cached: true
+            color: Style.current.dropShadow
+        }
     }
     x: applicationWindow.width - activityCenter.width - Style.current.halfPadding
     onOpened: {

--- a/ui/imports/Themes/DarkTheme.qml
+++ b/ui/imports/Themes/DarkTheme.qml
@@ -34,6 +34,7 @@ Theme {
     property color orange: "#FFA500"
 
     property color background: "#2C2C2C"
+    property color dropShadow: "#66000000"
     property color appBarDividerColor: darkGrey
     property color border: darkGrey
     property color borderSecondary: tenPercentWhite

--- a/ui/imports/Themes/LightTheme.qml
+++ b/ui/imports/Themes/LightTheme.qml
@@ -34,6 +34,7 @@ Theme {
     property color orange: "#FFA500"
 
     property color background: white
+    property color dropShadow: "#22000000"
     property color appBarDividerColor: darkGrey
     property color border: grey
     property color borderSecondary: tenPercentBlack

--- a/ui/imports/Themes/Theme.qml
+++ b/ui/imports/Themes/Theme.qml
@@ -33,6 +33,7 @@ QtObject {
     property color orange: "#FE8F59"
 
     property color background
+    property color dropShadow
     property color backgroundHover
     property color backgroundHoverLight
     property color border

--- a/ui/shared/ToastMessage.qml
+++ b/ui/shared/ToastMessage.qml
@@ -76,7 +76,7 @@ Popup {
             verticalOffset: 2
             radius: 10
             samples: 15
-            color: "#22000000"
+            color: Style.current.dropShadow
         }
     }
 

--- a/ui/shared/status/StatusInputListPopup.qml
+++ b/ui/shared/status/StatusInputListPopup.qml
@@ -65,7 +65,7 @@ Popup {
             verticalOffset: 2
             radius: 10
             samples: 15
-            color: "#22000000"
+            color: Style.current.dropShadow
         }
     }
 


### PR DESCRIPTION
Fixes #3100

Adds the `dropShadow` color in the theme and use it where needed
Also removes the activity center backdrop