### PR TITLE
perf(@desktop): external calls optimization when switching chats

### DIFF
--- a/src/app/chat/core.nim
+++ b/src/app/chat/core.nim
@@ -37,7 +37,7 @@ proc init*(self: ChatController) =
 
   # self.view.pubKey = pubKey
   self.view.setPubKey(pubKey)
-  self.status.chat.init(pubKey)
+  self.status.chat.init(pubKey, self.status.contacts)
   self.status.stickers.init()
   self.view.reactions.init()
   

--- a/src/app/chat/event_handling.nim
+++ b/src/app/chat/event_handling.nim
@@ -10,6 +10,8 @@ proc handleChatEvents(self: ChatController) =
   # Display already saved messages
   self.status.events.on("messagesLoaded") do(e:Args):
     let evArgs = MsgsLoadedArgs(e)
+    if evArgs.messages.len > 0:
+      self.status.chat.statusUpdates()
     self.view.pushMessages(evArgs.messages)
     for statusUpdate in evArgs.statusUpdates:
       self.view.communities.updateMemberVisibility(statusUpdate)    

--- a/src/app/chat/views/channel.nim
+++ b/src/app/chat/views/channel.nim
@@ -93,13 +93,15 @@ QtObject:
     if (self.chats.chats.len == 0): return
     let selectedChannel = self.getChannel(channelIndex)
     if (selectedChannel == nil): return
-    discard self.status.chat.markAllChannelMessagesRead(selectedChannel.id)
+    if (selectedChannel.unviewedMessagesCount > 0 or selectedChannel.mentionsCount > 0):
+      discard self.status.chat.markAllChannelMessagesRead(selectedChannel.id)
 
   proc markChatItemAsRead*(self: ChannelView, id: string) {.slot.} =
     if (self.chats.chats.len == 0): return
     let selectedChannel = self.getChannelById(id)
     if (selectedChannel == nil): return
-    discard self.status.chat.markAllChannelMessagesRead(selectedChannel.id)
+    if (selectedChannel.unviewedMessagesCount > 0 or selectedChannel.mentionsCount > 0):
+      discard self.status.chat.markAllChannelMessagesRead(selectedChannel.id)
 
   proc clearUnreadIfNeeded*(self: ChannelView, channel: var Chat) =
     if (not channel.isNil and (channel.unviewedMessagesCount > 0 or channel.mentionsCount > 0)):
@@ -163,7 +165,8 @@ QtObject:
     let selectedChannel = self.getChannelById(channel)
     self.activeChannel.setChatItem(selectedChannel)
     
-    discard self.status.chat.markAllChannelMessagesRead(self.activeChannel.id)
+    if (selectedChannel.unviewedMessagesCount > 0 or selectedChannel.mentionsCount > 0):
+      discard self.status.chat.markAllChannelMessagesRead(self.activeChannel.id)
 
     self.activeChannelChanged()
 

--- a/src/app/chat/views/messages.nim
+++ b/src/app/chat/views/messages.nim
@@ -322,7 +322,6 @@ QtObject:
     trace "Loading more messages", chaId = self.channelView.activeChannel.id
     self.status.chat.chatMessages(self.channelView.activeChannel.id, false)
     self.status.chat.chatReactions(self.channelView.activeChannel.id, false)
-    self.status.chat.statusUpdates()
     self.messagesLoaded();
 
   proc loadMoreMessagesWithIndex*(self: MessageView, channelIndex: int) {.slot.} =
@@ -332,7 +331,6 @@ QtObject:
     trace "Loading more messages", chaId = selectedChannel.id
     self.status.chat.chatMessages(selectedChannel.id, false)
     self.status.chat.chatReactions(selectedChannel.id, false)
-    self.status.chat.statusUpdates()
     self.messagesLoaded();
 
   proc loadingMessagesChanged*(self: MessageView, value: bool) {.signal.}

--- a/src/status/chat.nim
+++ b/src/status/chat.nim
@@ -159,10 +159,10 @@ proc requestMissingCommunityInfos*(self: ChatModel) =
   for communityId in self.communitiesToFetch:
     status_chat.requestCommunityInfo(communityId)
 
-proc init*(self: ChatModel, pubKey: string) =
+proc init*(self: ChatModel, pubKey: string, statusContacts: ContactModel) =
   self.publicKey = pubKey
 
-  var contacts = getAddedContacts()
+  var contacts = statusContacts.getAddedContacts()
   var chatList = status_chat.loadChats()
 
   let profileUpdatesChatIds = chatList.filter(c => c.chatType == ChatType.Profile).map(c => c.id)
@@ -290,7 +290,6 @@ proc chatMessages*(self: ChatModel, chatId: string, initialLoad:bool = true) =
     self.lastMessageTimestamps[chatId] = ts
 
   self.events.emit("messagesLoaded", MsgsLoadedArgs(messages: messageTuple[1]))
-
 
 proc statusUpdates*(self: ChatModel) =
   let statusUpdates = status_chat.statusUpdates()

--- a/src/status/contacts.nim
+++ b/src/status/contacts.nim
@@ -26,7 +26,6 @@ proc getContactByID*(self: ContactModel, id: string): Profile =
   if self.contactsMap.hasKey(id):
     return self.contactsMap[id]
 
-  echo "*** getContactByID cache miss: ", id
   let response = status_contacts.getContactByID(id)
   # TODO: change to options
   let responseResult = parseJSON($response)["result"]

--- a/src/status/contacts.nim
+++ b/src/status/contacts.nim
@@ -1,4 +1,4 @@
-import json, sequtils, sugar, chronicles
+import json, sequtils, sugar, chronicles, tables
 import libstatus/contacts as status_contacts
 import libstatus/accounts as status_accounts
 import libstatus/chat as status_chat
@@ -9,6 +9,8 @@ const DELETE_CONTACT* = "__deleteThisContact__"
 
 type
   ContactModel* = ref object
+    # contact.ID => Profile
+    contactsMap: Table[string, Profile]
     events*: EventEmitter
 
 type 
@@ -17,9 +19,14 @@ type
 
 proc newContactModel*(events: EventEmitter): ContactModel =
     result = ContactModel()
+    result.contactsMap = initTable[string, Profile]()
     result.events = events
 
 proc getContactByID*(self: ContactModel, id: string): Profile =
+  if self.contactsMap.hasKey(id):
+    return self.contactsMap[id]
+
+  echo "*** getContactByID cache miss: ", id
   let response = status_contacts.getContactByID(id)
   # TODO: change to options
   let responseResult = parseJSON($response)["result"]
@@ -27,6 +34,7 @@ proc getContactByID*(self: ContactModel, id: string): Profile =
     result = nil
   else:
     result = toProfileModel(parseJSON($response)["result"])
+    self.contactsMap[id] = result
 
 proc blockContact*(self: ContactModel, id: string): string =
   var contact = self.getContactByID(id)
@@ -34,24 +42,32 @@ proc blockContact*(self: ContactModel, id: string): string =
   let index = contact.systemTags.find(contactAdded)
   if (index > -1):
     contact.systemTags.delete(index)
-  discard status_contacts.blockContact(contact)
+  self.contactsMap[id] = contact
+  discard status_contacts.blockContact(contact.id, contact.ensVerified, contact.ensName, contact.alias, contact.identicon, contact.systemTags, contact.localNickname)
   self.events.emit("contactBlocked", Args())
-  
 
 proc unblockContact*(self: ContactModel, id: string): string =
   var contact = self.getContactByID(id)
-  contact.systemTags.delete(contact.systemTags.find(contactBlocked))
-  discard status_contacts.saveContact(contact.id, contact.ensVerified, contact.ensName, contact.alias, contact.identicon, contact.identityImage.thumbnail, contact.systemTags, contact.localNickname)
-  self.events.emit("contactUnblocked", Args())
+  let index = contact.systemTags.find(contactBlocked)
+  if (index > -1):
+    contact.systemTags.delete(index)
+    self.contactsMap[id] = contact
+    discard status_contacts.saveContact(contact.id, contact.ensVerified, contact.ensName, contact.alias, contact.identicon, contact.identityImage.thumbnail, contact.systemTags, contact.localNickname)
+    self.events.emit("contactUnblocked", Args())
 
-proc getAllContacts*(): seq[Profile] =
-  result = map(status_contacts.getContacts().getElems(), proc(x: JsonNode): Profile = x.toProfileModel())
+proc getAllContacts*(self: ContactModel): seq[Profile] =
+  if self.contactsMap.len == 0:
+    result = map(status_contacts.getContacts().getElems(), proc(x: JsonNode): Profile = x.toProfileModel())
+    for profile in result:
+      self.contactsMap[profile.id] = profile
+  else:
+    result = toSeq(self.contactsMap.values)
 
-proc getAddedContacts*(): seq[Profile] =
-  result = getAllContacts().filter(c => c.systemTags.contains(contactAdded))
+proc getAddedContacts*(self: ContactModel): seq[Profile] =
+  result = self.getAllContacts().filter(c => c.systemTags.contains(contactAdded))
 
 proc getContacts*(self: ContactModel): seq[Profile] =
-  result = getAllContacts()
+  result = self.getAllContacts()
   self.events.emit("contactUpdate", ContactUpdateArgs(contacts: result))
 
 proc getOrCreateContact*(self: ContactModel, id: string): Profile =
@@ -83,10 +99,11 @@ proc setNickName*(self: ContactModel, id: string, localNickname: string): string
   var thumbnail = ""
   if contact.identityImage != nil:
     thumbnail = contact.identityImage.thumbnail
+
+  self.contactsMap[id].localNickname = nickname
   result = status_contacts.saveContact(contact.id, contact.ensVerified, contact.ensName, contact.alias, contact.identicon, thumbnail, contact.systemTags, nickname)
   self.events.emit("contactAdded", Args())
   discard requestContactUpdate(contact.id)
-
 
 proc addContact*(self: ContactModel, id: string): string =
   var contact = self.getOrCreateContact(id)
@@ -104,6 +121,7 @@ proc addContact*(self: ContactModel, id: string): string =
   if contact.identityImage != nil:
     thumbnail = contact.identityImage.thumbnail
 
+  self.contactsMap[id] = contact
   result = status_contacts.saveContact(contact.id, contact.ensVerified, contact.ensName, contact.alias, contact.identicon, thumbnail, contact.systemTags, contact.localNickname)
   self.events.emit("contactAdded", Args())
   discard requestContactUpdate(contact.id)
@@ -130,6 +148,7 @@ proc removeContact*(self: ContactModel, id: string) =
   if contact.identityImage != nil:
     thumbnail = contact.identityImage.thumbnail
 
+  self.contactsMap[id] = contact
   discard status_contacts.saveContact(contact.id, contact.ensVerified, contact.ensName, contact.alias, contact.identicon, thumbnail, contact.systemTags, contact.localNickname)
   self.events.emit("contactRemoved", Args())
 
@@ -151,5 +170,6 @@ proc rejectContactRequest*(self: ContactModel, id: string) =
   if contact.identityImage != nil:
     thumbnail = contact.identityImage.thumbnail
 
+  self.contactsMap[id] = contact
   discard status_contacts.saveContact(contact.id, contact.ensVerified, contact.ensName, contact.alias, contact.identicon, thumbnail, contact.systemTags, contact.localNickname)
   self.events.emit("contactRemoved", Args())


### PR DESCRIPTION
Probably fixes #1642 

Here I tried to optimize the RPC calls (assuming they are expensive) being made when the user is switching chats:
- getContactByID
- markAllRead
- statusUpdated
