### PR TITLE
WIP get pins from community chat description

### DIFF
--- a/src/app/chat/event_handling.nim
+++ b/src/app/chat/event_handling.nim
@@ -20,6 +20,10 @@ proc handleChatEvents(self: ChatController) =
   # Display already pinned messages
   self.status.events.on("pinnedMessagesLoaded") do(e:Args):
     self.view.pushPinnedMessages(MsgsLoadedArgs(e).messages)
+  # Display community pinned messages
+  self.status.events.on("pinnedCommunityMessagesLoaded") do(e:Args):
+    debug "GOT THE EVENT PLSESSESS"
+    self.view.addPinMessages(MsgsLoadedArgs(e).messages)
 
   self.status.events.on("activityCenterNotificationsLoaded") do(e:Args):
     let notifications = ActivityCenterNotificationsArgs(e).activityCenterNotifications
@@ -64,6 +68,12 @@ proc handleChatEvents(self: ChatController) =
           continue
         
         self.view.communities.addCommunityToList(community)
+
+        debug "ANY PINNED MESSAGES??", len = community.pinnedMessages.len
+        if (community.pinnedMessages.len > 0):
+          debug "PInned messages"
+          self.view.refreshPinnedMessages(community.pinnedMessages)
+
         if (self.view.communities.activeCommunity.active and self.view.communities.activeCommunity.communityItem.id == community.id):
           if (self.view.channelView.activeChannel.chatItem != nil):
             let communityChannel = self.view.communities.activeCommunity.chats.getChannelById(self.view.channelView.activeChannel.chatItem.id)

--- a/src/app/chat/view.nim
+++ b/src/app/chat/view.nim
@@ -463,6 +463,9 @@ QtObject:
     discard self.deleteMessage(chatId, messageId)
 
 
+  proc addPinMessages*(self: ChatsView, pinnedMessages: seq[Message]) =
+    self.messageView.addPinMessages(pinnedMessages)
+
   proc clearMessages*(self: ChatsView, id: string) =
     self.messageView.clearMessages(id)
 

--- a/src/app/chat/views/communities.nim
+++ b/src/app/chat/views/communities.nim
@@ -159,10 +159,11 @@ QtObject:
 
   proc joinedCommunitiesChanged*(self: CommunitiesView) {.signal.}
     
-  proc getJoinedComunities*(self: CommunitiesView): QVariant {.slot.} =
+  proc getJoinedCommunities*(self: CommunitiesView): QVariant {.slot.} =
     if (not self.joinedCommunityList.fetched):
-      var communities = self.status.chat.getJoinedComunities()
+      var communities = self.status.chat.getJoinedCommunities()
       communities = self.populateChats(communities)
+
       self.joinedCommunityList.setNewData(communities)
       self.joinedCommunityList.fetched = true
 
@@ -172,7 +173,7 @@ QtObject:
     return newQVariant(self.joinedCommunityList)
 
   QtProperty[QVariant] joinedCommunities:
-    read = getJoinedComunities
+    read = getJoinedCommunities
     notify = joinedCommunitiesChanged
   
   proc getCommunityNameById*(self: CommunitiesView, communityId: string): string {.slot.} =

--- a/src/app/chat/views/message_format.nim
+++ b/src/app/chat/views/message_format.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, json, re
+import NimQml, Tables, json, re, chronicles
 import ../../../status/status
 import ../../../status/accounts
 import ../../../status/chat

--- a/src/app/login/core.nim
+++ b/src/app/login/core.nim
@@ -26,10 +26,10 @@ proc reset*(self: LoginController) =
 proc handleNodeLogin(self: LoginController, response: NodeSignal) =
   if not self.view.isCurrentFlow: return
   if self.view.currentAccount.account != nil:
-    self.view.setLastLoginResponse(response.event)
     if ?.response.event.error == "":
       self.status.events.emit("login", AccountArgs(account: self.view.currentAccount.account.toAccount))
-
+    self.view.setLastLoginResponse(response.event)
+    
 proc init*(self: LoginController) =
   let nodeAccounts = self.status.accounts.openAccounts()
   self.status.accounts.nodeAccounts = nodeAccounts

--- a/src/app/onboarding/core.nim
+++ b/src/app/onboarding/core.nim
@@ -27,9 +27,9 @@ proc reset*(self: OnboardingController) =
 proc handleNodeLogin(self: OnboardingController, response: NodeSignal) =
   if not self.view.isCurrentFlow: return
   if self.view.currentAccount.account != nil:
-    self.view.setLastLoginResponse(response.event)
     if ?.response.event.error == "":
       self.status.events.emit("login", AccountArgs(account: self.view.currentAccount.account.toAccount))
+    self.view.setLastLoginResponse(response.event)
 
 proc init*(self: OnboardingController) =
   let accounts = self.status.accounts.generateAddresses()

--- a/src/status/chat.nim
+++ b/src/status/chat.nim
@@ -452,8 +452,16 @@ proc requestTransaction*(self: ChatModel, chatId: string, fromAddress: string, a
 proc getAllComunities*(self: ChatModel): seq[Community] =
   result = status_chat.getAllComunities()
 
-proc getJoinedComunities*(self: ChatModel): seq[Community] =
-  result = status_chat.getJoinedComunities()
+proc getJoinedCommunities*(self: ChatModel): seq[Community] =
+  result = status_chat.getJoinedCommunities()
+  for community in result:
+    debug "Community pinend", len = community.pinnedMessages.len
+    if (community.pinnedMessages.len > 0):
+      debug "Emit"
+      self.events.emit("pinnedCommunityMessagesLoaded", MsgsLoadedArgs(messages: community.pinnedMessages))
+
+      # parent.refreshPinnedMessages(community.pinnedMessages)
+      # self.status.events.emit("pinnedCommunityMessagesLoaded", MsgsLoadedArgs(messages: community.pinnedMessages))
 
 proc createCommunity*(self: ChatModel, name: string, description: string, access: int, ensOnly: bool, color: string, imageUrl: string, aX: int, aY: int, bX: int, bY: int): Community =
   result = status_chat.createCommunity(name, description, access, ensOnly, color, imageUrl, aX, aY, bX, bY)

--- a/src/status/chat/chat.nim
+++ b/src/status/chat/chat.nim
@@ -124,6 +124,7 @@ type Community* = object
   lastChannelSeen*: string
   description*: string
   chats*: seq[Chat]
+  pinnedMessages*: seq[Message]
   categories*: seq[CommunityCategory]
   members*: seq[string]
   access*: int

--- a/src/status/libstatus/chat.nim
+++ b/src/status/libstatus/chat.nim
@@ -309,9 +309,10 @@ proc getAllComunities*(): seq[Community] =
       communities.add(community)
   return communities
 
-proc getJoinedComunities*(): seq[Community] =
+proc getJoinedCommunities*(): seq[Community] =
   var communities: seq[Community] = @[]
   let rpcResult = callPrivateRPC("joinedCommunities".prefix).parseJSON()
+  echo rpcResult
   if rpcResult{"result"}.kind != JNull:
     for jsonCommunity in rpcResult["result"]:
       var community = jsonCommunity.toCommunity()
@@ -551,20 +552,21 @@ proc setCommunityMuted*(communityId: string, muted: bool) =
 
 proc parseChatPinnedMessagesResponse*(rpcResult: JsonNode): (string, seq[Message]) =
   var messages: seq[Message] = @[]
-  let messagesObj = rpcResult{"pinnedMessages"}
-  if(messagesObj != nil and messagesObj.kind != JNull):
-    var msg: Message
-    for jsonMsg in messagesObj:
-      msg = jsonMsg["message"].toMessage()
-      msg.pinnedBy = $jsonMsg{"pinnedBy"}.getStr
-      messages.add(msg)
-  return (rpcResult{"cursor"}.getStr, messages)
+  return ("", messages)
+  # let messagesObj = rpcResult{"pinnedMessages"}
+  # if(messagesObj != nil and messagesObj.kind != JNull):
+  #   var msg: Message
+  #   for jsonMsg in messagesObj:
+  #     msg = jsonMsg["message"].toMessage()
+  #     msg.pinnedBy = $jsonMsg{"pinnedBy"}.getStr
+  #     messages.add(msg)
+  # echo "PATSEDJFJKJFWFPFK"
+  # return (rpcResult{"cursor"}.getStr, messages)
 
 proc rpcPinnedChatMessages*(chatId: string, cursorVal: JsonNode, limit: int, success: var bool): string =
   success = true
   try:
     result = callPrivateRPC("chatPinnedMessages".prefix, %* [chatId, cursorVal, limit])
-    debug "chatPinnedMessages", result
   except RpcException as e:
     success = false
     result = e.msg

--- a/ui/app/AppLayouts/Chat/components/PinnedMessagesPopup.qml
+++ b/ui/app/AppLayouts/Chat/components/PinnedMessagesPopup.qml
@@ -112,7 +112,10 @@ ModalPopup {
                     userName: model.userName
                     alias: model.alias
                     localName: model.localName
-                    message: model.message
+                    message: {
+                        console.log('Message', model.message, 'plaintext', model.plainText)
+                        return model.message
+                    }
                     plainText: model.plainText
                     identicon: model.identicon
                     isCurrentUser: model.isCurrentUser


### PR DESCRIPTION
This is a draft PR for the issue https://github.com/status-im/status-desktop/issues/3024

This issue is almost completely done. The only remaining issue, that I'm aware of, is that when you pin a message, the other clients in the community don't save the pins or don't recuperate the pins correctly. That problem in on the status-go side. The status-go PR is: https://github.com/status-im/status-go/pull/2294

How it works is that now, pins are both saved in the Pins table, but also in the Community Chat, so that when a new user is added to a community chat description as well. We save the whole message as stringified JSON in the chat. That way, if the new user is after the 30 days of the message being published, he will still be able to have the pinned message in the popup.

There is also a lot of cleanup to do. Also, I commented out the code to parse the fetched pinned messages, just so I could test getting the pins from the Community instead.