### PR TITLE
fix: it should be possible to enter gas prices with decimals

### DIFF
--- a/src/app/wallet/views/gas.nim
+++ b/src/app/wallet/views/gas.nim
@@ -52,22 +52,21 @@ QtObject:
     result.setup
 
   proc getGasEthValue*(self: GasView, gweiValue: string, gasLimit: string): string {.slot.} =
-    var gweiValueInt:int
     var gasLimitInt:int
 
-    discard gweiValue.parseInt(gweiValueInt)
     discard gasLimit.parseInt(gasLimitInt)
 
     # The following two check prevents app crash, cause we're trying to promote 
     # gweiValueInt and gasLimitInt to unsigned 256 int, and these two numbers
     # must be positive numbers, because of overflow.
-    if (gweiValueInt < 0):
-      gweiValueInt = 0
+    var gwei = gweiValue.parseFloat()
+    if (gwei < 0):
+      gwei = 0
     
     if (gasLimitInt < 0):
       gasLimitInt = 0
     
-    let weiValue = gweiValueInt.u256 * 1000000000.u256 * gasLimitInt.u256
+    let weiValue = gwei2Wei(gwei) * gasLimitInt.u256
     let ethValue = wei2Eth(weiValue)
     result = fmt"{ethValue}"
  

--- a/src/app/wallet/views/gas.nim
+++ b/src/app/wallet/views/gas.nim
@@ -56,9 +56,9 @@ QtObject:
 
     discard gasLimit.parseInt(gasLimitInt)
 
-    # The following two check prevents app crash, cause we're trying to promote 
-    # gweiValueInt and gasLimitInt to unsigned 256 int, and these two numbers
-    # must be positive numbers, because of overflow.
+    # The following check prevents app crash, cause we're trying to promote 
+    # gasLimitInt to unsigned 256 int, and this number must be a positive number,
+    # because of overflow.
     var gwei = gweiValue.parseFloat()
     if (gwei < 0):
       gwei = 0


### PR DESCRIPTION
The current implementation converts any gas price the user inputs to an integer. With this fix, the gas price will be parsed as a floating point value, fixing this issue