### PR TITLE
fix(@desktop/communities): `joinedCommunities` doesn't update underlying community

### DIFF
--- a/src/app/chat/event_handling.nim
+++ b/src/app/chat/event_handling.nim
@@ -28,7 +28,6 @@ proc handleChatEvents(self: ChatController) =
   self.status.events.on("activityCenterNotificationsLoaded") do(e:Args):
     let notifications = ActivityCenterNotificationsArgs(e).activityCenterNotifications
     self.view.pushActivityCenterNotifications(notifications)
-    self.view.communities.updateNotifications(notifications)
 
   self.status.events.on("contactBlocked") do(e: Args):
     var evArgs = ContactBlockedArgs(e)
@@ -86,7 +85,6 @@ proc handleChatEvents(self: ChatController) =
       self.view.refreshPinnedMessages(evArgs.pinnedMessages)
     if (evArgs.activityCenterNotifications.len > 0):
       self.view.addActivityCenterNotification(evArgs.activityCenterNotifications)
-      self.view.communities.updateNotifications(evArgs.activityCenterNotifications)
 
     if (evArgs.deletedMessages.len > 0):
       for messageId in evArgs.deletedMessages:

--- a/src/app/chat/views/channels_list.nim
+++ b/src/app/chat/views/channels_list.nim
@@ -181,6 +181,7 @@ QtObject:
 
     let index = self.createIndex(idx, 0, nil)
     self.chats[idx].unviewedMessagesCount = 0
+    self.chats[idx].unviewedMentionsCount = 0
 
     self.dataChanged(index, index, @[ChannelsRoles.UnreadMessages.int])
 
@@ -191,6 +192,7 @@ QtObject:
 
     let index = self.createIndex(idx, 0, nil)
     self.chats[idx].mentionsCount = 0
+    self.chats[idx].unviewedMentionsCount = 0
 
     self.dataChanged(index, index, @[ChannelsRoles.MentionsCount.int])
 
@@ -205,18 +207,7 @@ QtObject:
 
     let index = self.createIndex(idx, 0, nil)
     self.chats[idx].mentionsCount.dec
-
-    self.dataChanged(index, index, @[ChannelsRoles.MentionsCount.int])
-
-  proc incrementMentions*(self: ChannelsList, channelId: string) : bool =
-    result = false
-    let idx = self.chats.findIndexById(channelId)
-    if idx == -1: 
-      return
-
-    let index = self.createIndex(idx, 0, nil)
-    self.chats[idx].mentionsCount.inc
-    result = true
+    self.chats[idx].unviewedMentionsCount.dec
 
     self.dataChanged(index, index, @[ChannelsRoles.MentionsCount.int])
 

--- a/src/app/chat/views/community_item.nim
+++ b/src/app/chat/views/community_item.nim
@@ -249,3 +249,14 @@ QtObject:
     categoryItemView.setCategoryItem(category)
     self.categoryItemViews[id] = categoryItemView
     return categoryItemView
+
+  proc clearAllMentions*(self: CommunityItemView) =
+    self.chats.clearAllMentionsFromAllChannels()
+    self.communityItem.unviewedMentionsCount = 0
+    self.chatsChanged()
+
+  proc decrementMentions*(self: CommunityItemView, channelId: string) =
+    self.chats.decrementMentions(channelId)
+    self.communityItem.unviewedMentionsCount -= 1
+    self.chatsChanged()
+

--- a/src/status/chat/chat.nim
+++ b/src/status/chat/chat.nim
@@ -80,10 +80,11 @@ type Chat* = ref object
   lastClockValue*: int64 # indicates the last clock value to be used when sending messages
   deletedAtClockValue*: int64 # indicates the clock value at time of deletion, messages with lower clock value of this should be discarded
   unviewedMessagesCount*: int
+  unviewedMentionsCount*: int
   lastMessage*: Message
   members*: seq[ChatMember]
   membershipUpdateEvents*: seq[ChatMembershipEvent]
-  mentionsCount*: int
+  mentionsCount*: int  # Using this is not a good approach, we should instead use unviewedMentionsCount and refer to it always.
   muted*: bool
   canPost*: bool
   ensName*: string
@@ -128,6 +129,7 @@ type Community* = object
   members*: seq[string]
   access*: int
   unviewedMessagesCount*: int
+  unviewedMentionsCount*: int
   admin*: bool
   joined*: bool
   verified*: bool
@@ -235,3 +237,18 @@ proc isAdmin*(self: Chat, pubKey: string): bool =
     if member.id == pubKey:
       return member.joined and member.admin
   return false
+
+proc recalculateUnviewedMessages*(community: var Community) =
+  var total = 0
+  for chat in community.chats:
+    total += chat.unviewedMessagesCount
+  
+  community.unviewedMessagesCount = total
+
+proc recalculateMentions*(community: var Community) =
+  echo "(recalculateMentions) chatId: ", community.id, "  before: ", community.unviewedMentionsCount
+  var total = 0
+  for chat in community.chats:
+    total += chat.unviewedMentionsCount
+    
+  community.unviewedMentionsCount = total

--- a/src/status/signals/messages.nim
+++ b/src/status/signals/messages.nim
@@ -174,6 +174,7 @@ proc toChat*(jsonChat: JsonNode): Chat =
     lastClockValue: jsonChat{"lastClockValue"}.getBiggestInt,
     deletedAtClockValue: jsonChat{"deletedAtClockValue"}.getBiggestInt, 
     unviewedMessagesCount: jsonChat{"unviewedMessagesCount"}.getInt,
+    unviewedMentionsCount: jsonChat{"unviewedMentionsCount"}.getInt,
     mentionsCount: 0,
     muted: false,
     ensName: "",

--- a/ui/app/AppMain.qml
+++ b/ui/app/AppMain.qml
@@ -169,7 +169,8 @@ StatusAppLayout {
             icon.color: model.communityColor
             icon.source: model.thumbnailImage
 
-            badge.visible: !checked && model.unviewedMessagesCount > 0
+            badge.value: model.unviewedMentionsCount + model.requestsCount
+            badge.visible: badge.value > 0 || (!checked && model.unviewedMessagesCount > 0)
             badge.border.color: hovered ? Theme.palette.statusBadge.hoverBorderColor : Theme.palette.statusBadge.borderColor
             badge.border.width: 2
             badge.anchors.rightMargin: 4


### PR DESCRIPTION
Counting mentions for community seems was not developed yet. That's added here in this commit, but
instead of using "mentionsCount" we introduced on the side of nim, I found that we're receiving
"unviewedMentionsCount", but only for new messages. I used it for this fix.

Fixes: #2972