### PR TITLE
[#2584] Fixing 'more' chat menu position

### DIFF
--- a/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/ChatButtons.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/ChatButtons.qml
@@ -138,12 +138,14 @@ Rectangle {
                 if (typeof isMessageActive !== "undefined") {
                     setMessageActive(messageId, true)
                 }
-                clickMessage(false, isSticker, false, null, false, true)
+                clickMessage(false, isSticker, false, null, false, true);
+                messageContextMenu.parent = otherBtn;
+                messageContextMenu.x = 0;
+                messageContextMenu.y = (parent.height/2);
             }
             onHoveredChanged: {
                 buttonsContainer.hoverChanged(this.hovered)
             }
-
             StatusToolTip {
                 visible: otherBtn.hovered
                 //% "More"


### PR DESCRIPTION
Re-parented to 'more' button so that it's
following that when scaling the window

Closes #2584