### PR TITLE
fix(@desktop/chats): add background to member button

### DIFF
--- a/ui/app/AppLayouts/Chat/ChatColumn.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn.qml
@@ -236,6 +236,7 @@ Item {
                 }
 
                 membersButton.visible: appSettings.showOnlineUsers && chatsModel.channelView.activeChannel.chatType !== Constants.chatTypeOneToOne
+                membersButton.highlighted: showUsers
                 notificationButton.visible: appSettings.isActivityCenterEnabled
                 notificationCount: chatsModel.activityNotificationList.unreadCount
 


### PR DESCRIPTION
This fix adds a background to the member button when the members section is open.

fixes #3101