### PR TITLE
fix(@desktop/general): right click the icon on the dock and press quit doesn't quit the app (macos)

### DIFF
--- a/ui/main.qml
+++ b/ui/main.qml
@@ -427,7 +427,7 @@ StatusWindow {
 
         onClose: {
             if (loader.sourceComponent == login) {
-                applicationWindow.visible = false;
+                Qt.quit();
             }
             else if (loader.sourceComponent == app) {
                 if (loader.item.appSettings.quitOnClose) {


### PR DESCRIPTION
This issue is reproducible on the app only if you're not logged in yet.
The issue is fixed mostly on the side of dothersidem, [here](https://github.com/status-im/dotherside/pull/34).

Fixes: #3112