### PR TITLE
fix(Communities): move backup community popup logic to onClosed handler

### DIFF
--- a/ui/app/AppLayouts/Chat/CommunityComponents/BackUpCommuntyBanner.qml
+++ b/ui/app/AppLayouts/Chat/CommunityComponents/BackUpCommuntyBanner.qml
@@ -62,9 +62,6 @@ Rectangle {
         anchors.top: backUpText.bottom
         anchors.topMargin: Style.current.padding
         onClicked: {
-            let hiddenBannerIds = appSettings.hiddenCommunityBackUpBanners
-            hiddenBannerIds.push(chatsModel.communities.activeCommunity.id)
-            appSettings.hiddenCommunityBackUpBanners = hiddenBannerIds
             openPopup(transferOwnershipPopup, {privateKey: chatsModel.communities.exportCommunity()})
         }
     }
@@ -74,6 +71,9 @@ Rectangle {
         TransferOwnershipPopup {
             anchors.centerIn: parent
             onClosed: {
+                let hiddenBannerIds = appSettings.hiddenCommunityBackUpBanners
+                hiddenBannerIds.push(chatsModel.communities.activeCommunity.id)
+                appSettings.hiddenCommunityBackUpBanners = hiddenBannerIds
                 destroy()
             }
         }


### PR DESCRIPTION
The transfer ownership popup triggered by the backup community baner button
was behaving weirdly because the banner from where it originates lives inside
a loader that is deactivated once the popup was opened.

Moving the logic that deactivates the loader into the onClosed handler of the
popup solves this issue.

Thanks to @pinebit for getting to the bottom of this!

Fixes #2997