### PR TITLE
fix(@desktop/chat): Activity tooltip arrow position is incorrect when members list is visible

### DIFF
--- a/ui/app/AppLayouts/Chat/ChatColumn.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn.qml
@@ -239,6 +239,7 @@ Item {
                 membersButton.visible: appSettings.showOnlineUsers && chatsModel.channelView.activeChannel.chatType !== Constants.chatTypeOneToOne
                 membersButton.highlighted: showUsers
                 notificationButton.visible: appSettings.isActivityCenterEnabled
+                notificationButton.tooltip.offset: showUsers ? 0 : 14
                 notificationCount: chatsModel.activityNotificationList.unreadCount
 
                 onSearchButtonClicked: searchPopup.open()


### PR DESCRIPTION
Updated offset of the notification tooltip arrow based on if the members list is visible. The arrow should be in center when member list is visible else it should be right aligned as there is no place on the window

fixes #3102 