### PR TITLE
fix(@desktop/onboarding): display the app, then init the profile

### DIFF
--- a/src/nim_status_client.nim
+++ b/src/nim_status_client.nim
@@ -164,9 +164,9 @@ proc mainProc() =
     login.reset()
     onboarding.reset()
 
-    status.events.emit("loginCompleted", args)
     login.moveToAppState()
     onboarding.moveToAppState()
+    status.events.emit("loginCompleted", args)
 
   status.events.once("loginCompleted") do(a: Args):
     var args = AccountArgs(a)


### PR DESCRIPTION
When recovering an account, ensure the mnemonic is backed up
Also, we need to ensure that this bug is not back:
https://github.com/status-im/status-desktop/commit/5a7aac0baf8c6f6b82c32e98835076f3e1fde060

fixes https://github.com/status-im/status-desktop/issues/3089