### PR TITLE
fix(@desktop/chat): fix replying to message at early chat

### DIFF
--- a/ui/app/AppLayouts/Chat/ChatColumn/ChatMessages.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/ChatMessages.qml
@@ -232,7 +232,7 @@ Item {
 
         onContentYChanged: {
             scrollDownButton.visible = (contentHeight - (scrollY + height) > 400)
-            if(scrollY < 500){
+            if(scrollDownButton.visible && scrollY < 500){
                 loadMsgs();
             }
         }


### PR DESCRIPTION
When replying to a chat, we were reloading messages and rerendering
the messages which were causing issue with the reply id

fixes #3219