### PR TITLE
fix(desktop/messages) Removed separator from options menu

### DIFF
--- a/ui/app/AppLayouts/Chat/components/MessageContextMenu.qml
+++ b/ui/app/AppLayouts/Chat/components/MessageContextMenu.qml
@@ -275,7 +275,8 @@ StatusPopupMenu {
     }
 
     StatusMenuSeparator {
-        visible: deleteMessageAction.enabled
+        visible: deleteMessageAction.enabled && (viewProfileAction.visible
+                || sendMessageOrReplyTo.visible || editMessageAction.visible || pinAction.visible)
     }
 
     StatusMenuItem {


### PR DESCRIPTION
when only "Delete" is available

Closes #3243 