### PR TITLE
fix(@desktop/profile): Enter key doesnt activate button

### DIFF
--- a/ui/app/AppLayouts/Profile/Sections/BackupSeedModal.qml
+++ b/ui/app/AppLayouts/Profile/Sections/BackupSeedModal.qml
@@ -13,6 +13,8 @@ ModalPopup {
     property int seedWord2Idx: -1;
     property string validationError: ""
 
+    focus: visible
+
     onOpened: {
         seedWord1Idx = -1;
         seedWord2Idx = -1;
@@ -143,9 +145,19 @@ ModalPopup {
     }
 
     Item {
+        id: textInput
         visible: seedWord1Idx > -1 || seedWord2Idx > -1
         anchors.left: parent.left
         anchors.right: parent.right
+        focus: visible
+        onActiveFocusChanged: {
+            if (activeFocus)
+                txtFieldWord.forceActiveFocus(Qt.MouseFocusReason)
+        }
+        Keys.onReturnPressed: function(event) {
+            confirmButton.clicked()
+        }
+
         StyledText {
             id: txtChk
             //% "Check your seed phrase"
@@ -223,6 +235,7 @@ ModalPopup {
     
 
     footer: StatusButton {
+        id: confirmButton
         text: showWarning ? 
                 //% "Okay, continue"
                 qsTrId("ok-continue") : 
@@ -231,6 +244,10 @@ ModalPopup {
         anchors.right: parent.right
         anchors.rightMargin: Style.current.smallPadding
         anchors.bottom: parent.bottom
+        focus: !textInput.visible
+        Keys.onReturnPressed: function(event) {
+            confirmButton.clicked()
+        }
         onClicked: {
             if(showWarning){
                 showWarning = false;

--- a/ui/shared/ConfirmationDialog.qml
+++ b/ui/shared/ConfirmationDialog.qml
@@ -18,6 +18,7 @@ ModalPopup {
     width: 400
     //% "Confirm your action"
     title: qsTrId("confirm-your-action")
+    focus: visible
 
     //% "Confirm"
     property string confirmButtonLabel: qsTrId("close-app-button")
@@ -71,6 +72,10 @@ ModalPopup {
             anchors.rightMargin: cancelButton.visible ? Style.current.smallPadding : 0
             text: confirmationDialog.confirmButtonLabel
             anchors.bottom: parent.bottom
+            focus: true
+            Keys.onReturnPressed: function(event) {
+                confirmButton.clicked()
+            }
             onClicked: {
                 if (executeConfirm && typeof executeConfirm === "function") {
                     executeConfirm()


### PR DESCRIPTION
Added code so that in the backup seed phrase modal all actions can be performed with the enter key.
Also added logic for default focus on the confirm button in the ConfirmationDialog.

fixes#2359