### PR TITLE
fix(@desktop/chat): fix offline indicator in dark mode

### DIFF
--- a/ui/app/AppMain.qml
+++ b/ui/app/AppMain.qml
@@ -305,7 +305,7 @@ StatusAppLayout {
             badge.implicitWidth: 15
             badge.border.color: hovered ? Theme.palette.statusBadge.hoverBorderColor : Theme.palette.statusAppNavBar.backgroundColor
             badge.color: {
-                return profileModel.profile.sendUserStatus ? Style.current.green : Style.current.darkGrey
+                return profileModel.profile.sendUserStatus ? Style.current.green : Style.current.midGrey
                 /*
                 // Use this code once support for custom user status is added
                 switch(profileModel.profile.currentUserStatus){
@@ -314,7 +314,7 @@ StatusAppLayout {
                     case Constants.statusType_DoNotDisturb:
                         return Style.current.red;
                     default:
-                        return Style.current.darkGrey;
+                        return Style.current.midGrey;
                 }*/
             }
             badge.border.width: 3

--- a/ui/shared/UserStatusContextMenu.qml
+++ b/ui/shared/UserStatusContextMenu.qml
@@ -101,7 +101,7 @@ PopupMenu {
             root.close()
         }
 
-        icon.color: Style.current.darkGrey
+        icon.color: Style.current.midGrey
         icon.source: "img/offline.svg"
         icon.width: 16
         icon.height: 16


### PR DESCRIPTION
fixes #3239

This is not visible because this is darkGrey on a color too close to darkGrey, using midGrey fix the problem

![image](https://user-images.githubusercontent.com/491074/130029488-7f87b0c7-0311-47da-8bea-e3403b761729.png)
![image](https://user-images.githubusercontent.com/491074/130029557-35aa6bc6-c9c1-4629-947f-55467e7b109d.png)
