### PR TITLE
feat(@desktop/internal): Specific logfile per app start

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -225,8 +225,7 @@ DEFAULT_TENOR_API_KEY := DU7DWZ27STB2
 TENOR_API_KEY ?= $(DEFAULT_TENOR_API_KEY)
 NIM_PARAMS += -d:TENOR_API_KEY:"$(TENOR_API_KEY)"
 
-# generate a status-desktop.log file with chronicles output. This file will be truncated each time the app starts
-NIM_PARAMS += -d:chronicles_sinks="textlines[stdout],textlines[nocolors,file(status-desktop.log,truncate)]"
+NIM_PARAMS += -d:chronicles_sinks="textlines[stdout],textlines[nocolors,file]"
 
 RESOURCES_LAYOUT := -d:development
 

--- a/src/nim_status_client.nim
+++ b/src/nim_status_client.nim
@@ -1,4 +1,4 @@
-import NimQml, chronicles, os, strformat
+import NimQml, chronicles, os, strformat, times
 
 import app/chat/core as chat
 import app/wallet/v1/core as wallet
@@ -27,6 +27,9 @@ logScope:
 proc mainProc() =
   if defined(macosx) and defined(production):
     setCurrentDir(getAppDir())
+
+  let logFile = fmt"app_{getTime().toUnix}.log"
+  discard defaultChroniclesStream.output.open(LOGDIR & logFile, fmAppend)
 
   var currentLanguageCode: string
 

--- a/src/status/constants.nim
+++ b/src/status/constants.nim
@@ -4,3 +4,4 @@ export DATADIR
 export STATUSGODIR
 export KEYSTOREDIR
 export TMPDIR
+export LOGDIR

--- a/src/status/libstatus/accounts/constants.nim
+++ b/src/status/libstatus/accounts/constants.nim
@@ -227,6 +227,8 @@ let
   STATUSGODIR* = joinPath(baseDir, "data") & sep
   KEYSTOREDIR* = joinPath(baseDir, "data", "keystore") & sep
   TMPDIR* = joinPath(baseDir, "tmp") & sep
+  LOGDIR* = joinPath(baseDir, "logs") & sep
 
 createDir(DATADIR)
 createDir(TMPDIR)
+createDir(LOGDIR)


### PR DESCRIPTION
fixes #3146

Create a dir: Status/logs
Each time the app start, create a new log file: app_{current_timestamp}.log

In order to avoid nearly 0 logs, set the loglevel to error: `make LOG_LEVEL=error`