### PR TITLE
fix(@desktop/chat): Right click message actions dont work

### DIFF
--- a/ui/app/AppLayouts/Chat/ChatColumn.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn.qml
@@ -23,7 +23,6 @@ Item {
     id: chatColumnLayout
     anchors.fill: parent
 
-    property var messageContextMenu
     property alias pinnedMessagesPopupComponent: pinnedMessagesPopupComponent
     property int chatGroupsListViewCount: 0
     property bool isReply: false
@@ -87,7 +86,7 @@ Item {
 
         let isCommunity = chatsModel.communities.activeCommunity.active
         let dataSource = isCommunity ? chatsModel.communities.activeCommunity.members : chatsModel.suggestionList
-        
+
         const len = dataSource.rowCount()
         for (let i = 0; i < len; i++) {
             const contactAddr = dataSource.rowData(i, "address");
@@ -341,7 +340,9 @@ Item {
                         sourceComponent: ChatMessages {
                             id: chatMessages
                             messageList: messages
-                            messageContextMenuInst: messageContextMenu
+                            messageContextMenuInst: MessageContextMenu {
+                                reactionModel: EmojiReactions { }
+                            }
                             Component.onCompleted: {
                                 chatColumnLayout.userList = chatMessages.messageList.userList;
                             }
@@ -684,7 +685,7 @@ Item {
                 toastMessage.open()
             }
             onTransactionCompleted: {
-                toastMessage.title = !success ? 
+                toastMessage.title = !success ?
                                      //% "Could not buy Stickerpack"
                                      qsTrId("could-not-buy-stickerpack")
                                      :

--- a/ui/app/AppLayouts/Chat/ChatColumn/Message.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/Message.qml
@@ -214,6 +214,7 @@ Item {
         messageContextMenu.isCurrentUser = isCurrentUser;
         messageContextMenu.isRightClickOnImage = isRightClickOnImage
         messageContextMenu.imageSource = imageSource
+        messageContextMenu.onClickEdit = function() {root.isEdit = true}
 
         if (isReply) {
             let nickname = appMain.getUserNickname(repliedMessageAuthor)

--- a/ui/app/AppLayouts/Chat/ChatColumn/UserList.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/UserList.qml
@@ -13,13 +13,17 @@ import "../components"
 import "./samples/"
 import "./MessageComponents"
 import "../ContactsColumn"
+import "../data"
 
 Item {
     id: root
     anchors.fill: parent
     property var userList
     property var currentTime
-    property var messageContextMenu
+    property var messageContextMenu: MessageContextMenu {
+        id: quickActionMessageOptionsMenu
+        reactionModel: EmojiReactions { }
+    }
 
     Rectangle {
         anchors.fill: parent

--- a/ui/app/AppLayouts/Chat/ChatLayout.qml
+++ b/ui/app/AppLayouts/Chat/ChatLayout.qml
@@ -41,7 +41,6 @@ StatusAppThreePanelLayout {
     centerPanel: ChatColumn {
         id: chatColumn
         chatGroupsListViewCount: contactColumnLoader.item.chatGroupsListViewCount
-        messageContextMenu: quickActionMessageOptionsMenu
     }
 
     showRightPanel: chatColumn.showUsers && (chatsModel.channelView.activeChannel.chatType !== Constants.chatTypeOneToOne)
@@ -54,7 +53,7 @@ StatusAppThreePanelLayout {
 
     Component {
         id: userListComponent
-        UserList { currentTime: chatColumn.currentTime; userList: chatColumn.userList; messageContextMenu: quickActionMessageOptionsMenu }
+        UserList { currentTime: chatColumn.currentTime; userList: chatColumn.userList;}
     }
 
     Component {
@@ -87,11 +86,6 @@ StatusAppThreePanelLayout {
                 destroy();
             }
         }
-    }
-
-    MessageContextMenu {
-        id: quickActionMessageOptionsMenu
-        reactionModel: EmojiReactions { }
     }
 
     ConfirmationDialog {

--- a/ui/app/AppLayouts/Chat/components/MessageContextMenu.qml
+++ b/ui/app/AppLayouts/Chat/components/MessageContextMenu.qml
@@ -238,7 +238,6 @@ StatusPopupMenu {
             } else {
                 showReplyArea()
             }
-            messageContextMenu.closeParentPopup()
             messageContextMenu.close()
         }
         icon.name: "chat"


### PR DESCRIPTION
Fix the bug introduced by removing MessageContextMenu from Chat column. Added missing logic for edit message via MessageContextMenu

fixes #3223