### PR TITLE
fix(@desktop/timeline): Fix leaving the timeline chat

### DIFF
--- a/ui/shared/status/StatusChatInput.qml
+++ b/ui/shared/status/StatusChatInput.qml
@@ -834,9 +834,6 @@ Rectangle {
             anchors.right: actions.left
             anchors.rightMargin: Style.current.halfPadding
             ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
-            StatusSyntaxHighlighter {
-                quickTextDocument: messageInputField.textDocument
-            }
 
             TextArea {
                 id: messageInputField
@@ -884,6 +881,10 @@ Rectangle {
                         messageInputField.forceActiveFocus();
                     }
                     lastClick = now
+                }
+
+                StatusSyntaxHighlighter {
+                   quickTextDocument: messageInputField.textDocument
                 }
 
                 StatusTextFormatMenu {


### PR DESCRIPTION
fixes #3249

@alexandraB99 if you could help review this one ;) Moving the StatusSyntaxHighlighter prevent it to crash the app when leaving the timeline chat