### PR TITLE
fix(@desktop/browser) Websites with transparent background not handle…

### DIFF
--- a/ui/app/AppLayouts/Browser/BrowserLayout.qml
+++ b/ui/app/AppLayouts/Browser/BrowserLayout.qml
@@ -526,7 +526,6 @@ property Component sendTransactionModalComponent: SignTransactionModal {}
                         hideStatusText.stop();
                     }
                 }
-                backgroundColor: Style.current.background
 
                 function changeZoomFactor(newFactor) {
                     // FIXME there seems to be a bug in the WebEngine where the zoomFactor only update 1/2 times


### PR DESCRIPTION
…d properly

Removed background color assignment as by default it is set to white if unassigned. This fixes the issue of strange grey background in dark mode with white components from websites with transparent background

fixes #3209