### PR TITLE
fix(@desktop/wallet): Add wallet confirmation modal

### DIFF
--- a/ui/app/AppLayouts/Profile/Sections/Ens/TermsAndConditions.qml
+++ b/ui/app/AppLayouts/Profile/Sections/Ens/TermsAndConditions.qml
@@ -347,6 +347,23 @@ Item {
           //% "Register"
           qsTrId("ens-register")
         enabled: parseFloat(utilsModel.getSNTBalance()) >= 10 && termsAndConditionsCheckbox.checked
-        onClicked: transactionDialog.open()
+        onClicked: appSettings.isWalletEnabled ? transactionDialog.open() : confirmationPopup.open()
+    }
+
+    ConfirmationDialog {
+        id: confirmationPopup
+        height: 310
+        showCancelButton: true
+        confirmationText: qsTr("This feature is experimental and is meant for testing purposes by core contributors and the community. It's not meant for real use and makes no claims of security or integrity of funds or data. Use at your own risk.")
+        confirmButtonLabel: qsTr("I understand")
+        onConfirmButtonClicked: {
+            appSettings.isWalletEnabled = true
+            close()
+            transactionDialog.open()
+        }
+
+        onCancelButtonClicked: {
+            close()
+        }
     }
 }

--- a/ui/shared/status/StatusChatCommandsPopup.qml
+++ b/ui/shared/status/StatusChatCommandsPopup.qml
@@ -45,9 +45,7 @@ Popup {
             icon.name: "send"
             icon.width: 16
             icon.height: 18
-            onClicked: function () {
-                root.sendTransactionCommandButtonClicked()
-            }
+            onClicked: appSettings.isWalletEnabled ? root.sendTransactionCommandButtonClicked() : confirmationPopup.open()
         }
 
 
@@ -59,10 +57,24 @@ Popup {
             icon.width: 16
             icon.height: 18
             iconRotation: 180
-            onClicked: function () {
-                root.receiveTransactionCommandButtonClicked()
-            }
+            onClicked: appSettings.isWalletEnabled ? root.receiveTransactionCommandButtonClicked() : confirmationPopup.open()
         }
 
+        ConfirmationDialog {
+            id: confirmationPopup
+            height: 310
+            showCancelButton: true
+            confirmationText: qsTr("This feature is experimental and is meant for testing purposes by core contributors and the community. It's not meant for real use and makes no claims of security or integrity of funds or data. Use at your own risk.")
+            confirmButtonLabel: qsTr("I understand")
+            onConfirmButtonClicked: {
+                appSettings.isWalletEnabled = true
+                close()
+                root.sendTransactionCommandButtonClicked()
+            }
+
+            onCancelButtonClicked: {
+                close()
+            }
+        }
     }
 }

--- a/ui/shared/status/StatusStickerMarket.qml
+++ b/ui/shared/status/StatusStickerMarket.qml
@@ -146,9 +146,31 @@ Item {
                     onCancelClicked: root.cancelClicked(packId)
                     onUpdateClicked: root.updateClicked(packId)
                     onBuyClicked: {
+                        if (!appSettings.isWalletEnabled) {
+                            confirmationPopup.open()
+                            return
+                        }
                         root.stickerPurchasePopup = openPopup(stickerPackPurchaseModal)
                         root.buyClicked(packId)
                     }
+                }
+            }
+
+            ConfirmationDialog {
+                id: confirmationPopup
+                height: 310
+                showCancelButton: true
+                confirmationText: qsTr("This feature is experimental and is meant for testing purposes by core contributors and the community. It's not meant for real use and makes no claims of security or integrity of funds or data. Use at your own risk.")
+                confirmButtonLabel: qsTr("I understand")
+                onConfirmButtonClicked: {
+                    appSettings.isWalletEnabled = true
+                    close()
+                    root.stickerPurchasePopup = openPopup(stickerPackPurchaseModal)
+                    root.buyClicked(packId)
+                }
+
+                onCancelButtonClicked: {
+                    close()
                 }
             }
         }


### PR DESCRIPTION
For all actions related to the wallet, add a confirmation if the wallet
is not enabled

fixes #3258