### PR TITLE
feat(@desktop/chat): allow for entering ENS names manually

### DIFF
--- a/ui/app/AppLayouts/Chat/ChatColumn/SuggestionBox.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/SuggestionBox.qml
@@ -33,6 +33,7 @@ Rectangle {
     property alias suggestionsModel: filterItem.model
     property alias filter: filterItem.filter
     property alias formattedPlainTextFilter: filterItem.formattedFilter
+    property alias suggestionFilter: filterItem
     property alias property: filterItem.property
     property int cursorPosition
     signal itemSelected(var item, int lastAtPosition, int lastCursorPosition)


### PR DESCRIPTION
This commit enables users to enter fully qualified ENS names manually
and marking them as mentions, which are then later being replaced with
pubkeys.

The changes do not prevent users from entering ENS names that don't exist.

There's also a fix that ensure prepended "@" signs are removed from the
items selected in the suggestions box.

Closes #3149