### PR TITLE
fix(@desktop/chat): Add new dedicated event for sending message

### DIFF
--- a/src/app/chat/view.nim
+++ b/src/app/chat/view.nim
@@ -485,8 +485,8 @@ QtObject:
   proc calculateUnreadMessages*(self: ChatsView) =
     self.messageView.calculateUnreadMessages()
 
-  proc sendingMessage*(self: ChatsView) =
-    self.messageView.sendingMessage()
+  proc sendingMessageSuccess*(self: ChatsView) =
+    self.messageView.sendingMessageSuccess()
 
   proc sendingMessageFailed*(self: ChatsView) =
     self.messageView.sendingMessageFailed()

--- a/src/app/chat/views/message_list.nim
+++ b/src/app/chat/views/message_list.nim
@@ -339,10 +339,11 @@ QtObject:
         self.replaceMessage(message)
         return
 
+    self.userList.add(message)
+
     self.beginInsertRows(newQModelIndex(), self.messages.len, self.messages.len)
     self.messageIndex[message.id] = self.messages.len
     self.messages.add(message)
-    self.userList.add(message)
     self.endInsertRows()
     self.countChanged()
 

--- a/src/app/chat/views/user_list.nim
+++ b/src/app/chat/views/user_list.nim
@@ -140,7 +140,6 @@ QtObject:
 
   proc add*(self: UserListView, message: Message) =
     if self.userDetails.hasKey(message.fromAuthor):
-        self.beginResetModel()
         self.userDetails[message.fromAuthor] = User(
             userName: message.userName,
             alias: message.alias,
@@ -148,7 +147,22 @@ QtObject:
             lastSeen: message.timestamp,
             identicon: message.identicon
         )
-        self.endResetModel()
+        var index = 0
+        for publicKey in self.users:
+          if publicKey == message.fromAuthor:
+            break
+          
+          index+=1
+
+        let topLeft = self.createIndex(index, index, nil)
+        let bottomRight = self.createIndex(index, index, nil)
+        self.dataChanged(topLeft, bottomRight, @[
+          UserListRoles.UserName.int,
+          UserListRoles.LastSeen.int,
+          UserListRoles.Alias.int,
+          UserListRoles.LocalName.int,
+          UserListRoles.Identicon.int
+        ])
     else:
         self.beginInsertRows(newQModelIndex(), self.users.len, self.users.len)
         self.userDetails[message.fromAuthor] = User(

--- a/src/status/chat.nim
+++ b/src/status/chat.nim
@@ -60,6 +60,10 @@ type
     id*: string
     channel*: string
 
+  MessageSendingSuccess* = ref object of Args
+    chat*: Chat
+    message*: Message
+
   MarkAsReadNotificationProperties* = ref object of Args
     communityId*: string
     channelId*: string
@@ -119,21 +123,22 @@ QtObject:
         
     self.events.emit("chatUpdate", ChatUpdateArgs(messages: messages,chats: chats, contacts: @[], emojiReactions: emojiReactions, communities: communities, communityMembershipRequests: communityMembershipRequests, pinnedMessages: pinnedMessages, activityCenterNotifications: activityCenterNotifications, statusUpdates: statusUpdates, deletedMessages: deletedMessages))
   
-  proc processChatUpdate(self: ChatModel, response: JsonNode): (seq[Chat], seq[Message]) =
+  proc parseChatResponse(self: ChatModel, response: string): (seq[Chat], seq[Message]) =
+    var parsedResponse = parseJson(response)
     var chats: seq[Chat] = @[]
     var messages: seq[Message] = @[]
-    if response{"result"}{"messages"} != nil:
-      for jsonMsg in response["result"]["messages"]:
+    if parsedResponse{"result"}{"messages"} != nil:
+      for jsonMsg in parsedResponse["result"]["messages"]:
         messages.add(jsonMsg.toMessage())
-    if response{"result"}{"chats"} != nil:
-      for jsonChat in response["result"]["chats"]:
+    if parsedResponse{"result"}{"chats"} != nil:
+      for jsonChat in parsedResponse["result"]["chats"]:
         let chat = jsonChat.toChat
         self.channels[chat.id] = chat
         chats.add(chat) 
     result = (chats, messages)
 
   proc emitUpdate(self: ChatModel, response: string) =
-    var (chats, messages) = self.processChatUpdate(parseJson(response))
+    var (chats, messages) = self.parseChatResponse(response)
     self.events.emit("chatUpdate", ChatUpdateArgs(messages: messages, chats: chats, contacts: @[]))
 
   proc removeFiltersByChatId(self: ChatModel, chatId: string, filters: JsonNode)
@@ -318,26 +323,22 @@ QtObject:
   proc setActiveChannel*(self: ChatModel, chatId: string) =
     self.events.emit("activeChannelChanged", ChatIdArg(chatId: chatId))
 
-  proc processMessageUpdateAfterSend(self: ChatModel, response: string, forceActiveChat: bool = false): (seq[Chat], seq[Message])  =
-    result = self.processChatUpdate(parseJson(response))
+  proc processMessageUpdateAfterSend(self: ChatModel, response: string): (seq[Chat], seq[Message])  =
+    result = self.parseChatResponse(response)
     var (chats, messages) = result
     if chats.len == 0 and messages.len == 0:
-      self.events.emit("sendingMessageFailed", MessageArgs())
-    else:
-      if (forceActiveChat):
-        chats[0].isActive = true
-      self.events.emit("chatUpdate", ChatUpdateArgs(messages: messages, chats: chats, contacts: @[]))
-  
-      for msg in messages:
-        self.events.emit("sendingMessage", MessageArgs(id: msg.id, channel: msg.chatId))
+      self.events.emit("messageSendingFailed", Args())
+      return
+    
+    self.events.emit("messageSendingSuccess", MessageSendingSuccess(message: messages[0], chat: chats[0]))
 
-  proc sendMessage*(self: ChatModel, chatId: string, msg: string, replyTo: string = "", contentType: int = ContentType.Message.int, communityId: string = "", forceActiveChat: bool = false) =
+  proc sendMessage*(self: ChatModel, chatId: string, msg: string, replyTo: string = "", contentType: int = ContentType.Message.int, communityId: string = "") =
     var response = status_chat.sendChatMessage(chatId, msg, replyTo, contentType, communityId)
-    discard self.processMessageUpdateAfterSend(response, forceActiveChat)
+    discard self.processMessageUpdateAfterSend(response)
 
   proc editMessage*(self: ChatModel, messageId: string, msg: string) =
     var response = status_chat.editMessage(messageId, msg)
-    discard self.processMessageUpdateAfterSend(response, false)
+    discard self.processMessageUpdateAfterSend(response)
 
   proc sendImage*(self: ChatModel, chatId: string, image: string) =
     var response = status_chat.sendImageMessage(chatId, image)
@@ -349,12 +350,12 @@ QtObject:
 
   proc deleteMessageAndSend*(self: ChatModel, messageId: string) =
     var response = status_chat.deleteMessageAndSend(messageId)    
-    discard self.processMessageUpdateAfterSend(response, false)
+    discard self.processMessageUpdateAfterSend(response)
 
   proc sendSticker*(self: ChatModel, chatId: string, replyTo: string, sticker: Sticker) =
     var response = status_chat.sendStickerMessage(chatId, replyTo, sticker)
     self.events.emit("stickerSent", StickerArgs(sticker: sticker, save: true))
-    var (chats, messages) = self.processChatUpdate(parseJson(response))
+    var (chats, messages) = self.parseChatResponse(response)
     self.events.emit("chatUpdate", ChatUpdateArgs(messages: messages, chats: chats, contacts: @[]))
     self.events.emit("sendingMessage", MessageArgs(id: messages[0].id, channel: messages[0].chatId))
 
@@ -595,8 +596,7 @@ QtObject:
     try:
       let response = status_chat.acceptActivityCenterNotifications(ids)
 
-      let resultTuple = self.processChatUpdate(parseJson(response))
-      let (chats, messages) = resultTuple
+      let (chats, messages) = self.parseChatResponse(response)
       self.events.emit("chatUpdate", ChatUpdateArgs(messages: messages, chats: chats))
 
     except Exception as e:

--- a/ui/app/AppLayouts/Chat/ChatColumn/ChatMessages.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/ChatMessages.qml
@@ -181,7 +181,7 @@ Item {
         Connections {
             target: chatsModel.messageView
 
-            onSendingMessage: {
+            onSendingMessageSuccess: {
                 chatLogView.scrollToBottom(true)
             }
 

--- a/ui/app/AppLayouts/Timeline/TimelineLayout.qml
+++ b/ui/app/AppLayouts/Timeline/TimelineLayout.qml
@@ -76,7 +76,7 @@ ScrollView {
                 var msg = chatsModel.plainText(Emoji.deparse(statusUpdateInput.textInput.text))
                 if (msg.length > 0){
                     msg = statusUpdateInput.interpretMessage(msg)
-                    chatsModel.messageView.sendMessage(msg, "", Utils.isOnlyEmoji(msg) ? Constants.emojiType : Constants.messageType, true, "");
+                    chatsModel.messageView.sendMessage(msg, "", Utils.isOnlyEmoji(msg) ? Constants.emojiType : Constants.messageType, true);
                     statusUpdateInput.textInput.text = "";
                     if(event) event.accepted = true
                     sendMessageSound.stop()


### PR DESCRIPTION
* Optimize UserList.add
* Remove verifyMessageSent (seem unused)
* Remove forceActiveChat (seem unused)

After this (And the PR about suggestion), sending a message takes less than 0.05s vs nearly 1s on big channel like Status