### PR TITLE
fix(@desktop/chat) members' status circle is not always right

### DIFF
--- a/ui/app/AppLayouts/Chat/CommunityComponents/CommunityUserList.qml
+++ b/ui/app/AppLayouts/Chat/CommunityComponents/CommunityUserList.qml
@@ -60,6 +60,7 @@ Item {
                 StyledText {
                     anchors.fill: parent
                     anchors.leftMargin: Style.current.padding
+                    verticalAlignment: Text.AlignVCenter
                     font.pixelSize: Style.current.additionalTextSize
                     color: Style.current.darkGrey
                     text: section === 'true' ? qsTr("Online") : qsTr("Offline")
@@ -83,7 +84,7 @@ Item {
             lastSeen: model.lastSeen
             statusType: model.statusType
             currentTime: root.currentTime
-            offlineColor: "transparent"
+            isOnline: model.online
         }
     }
 }


### PR DESCRIPTION
fixed to display online status only if is the current user and
if they have been active in the last 7 minutes. Respective color
is shown depending on if they are in "do not disturb" mode or they
have been active more than 5 minutes ago

Closes #3282