### PR TITLE
fix(@desktop/chatInput) Pasting text with emoji was invisible

### DIFF
--- a/ui/shared/status/StatusChatInput.qml
+++ b/ui/shared/status/StatusChatInput.qml
@@ -358,7 +358,7 @@ Rectangle {
         // we can only get it in the `released` event
         if (paste) {
             paste = false;
-            const plainText = messageInputField.getText(0, messageInputField.length);
+            const plainText = messageInputField.getFormattedText(0, messageInputField.length);
             messageInputField.remove(0, messageInputField.length);
             insertInTextInput(0, plainText);
         }


### PR DESCRIPTION
When text from clipboard that contained any emoji was pasted
in the chat input it was becoming invisible

Closes #3291