### PR TITLE
fix(@desktop/chat): after reaching the top of chat history, unable to scroll down again

### DIFF
--- a/ui/app/AppLayouts/Chat/ChatColumn/ChatMessages.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/ChatMessages.qml
@@ -35,12 +35,6 @@ Item {
         spacing: appSettings.useCompactMode ? 0 : 4
         boundsBehavior: Flickable.StopAtBounds
         clip: true
-        flickDeceleration: {
-            if (utilsModel.getOs() === Constants.windows) {
-                return 5000
-            }
-            return 10000
-        }
         verticalLayoutDirection: ListView.BottomToTop
 
         // This header and Connections is to create an invisible padding so that the chat identifier is at the top

--- a/ui/app/AppLayouts/Chat/ChatColumn/Message.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/Message.qml
@@ -10,13 +10,7 @@ Item {
     id: root
     width: parent.width
     anchors.right: !isCurrentUser ? undefined : parent.right
-    height: {
-        switch (contentType) {
-            case Constants.chatIdentifier:
-                return (childrenRect.height + 50);
-            default: return childrenRect.height;
-        }
-    }
+    height: childrenRect.height
     z: (typeof chatLogView === "undefined") ? 1 : (chatLogView.count - index)
     property string fromAuthor: "0x0011223344556677889910"
     property string userName: "Jotaro Kujo"

--- a/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/ChannelIdentifier.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/ChannelIdentifier.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.3
+import QtQuick 2.14
 import "../../../../../shared"
 import "../../../../../imports"
 
@@ -11,8 +11,8 @@ Column {
     spacing: Style.current.padding
     visible: authorCurrentMsg === ""
     anchors.horizontalCenter: parent.horizontalCenter
-    anchors.top: parent.top
-    anchors.topMargin: this.visible ? Style.current.bigPadding : 0
+    topPadding: visible ? Style.current.bigPadding : 0
+    bottomPadding: visible? 50 : 0
 
     Rectangle {
         id: circleId
@@ -137,9 +137,3 @@ Column {
         }
     }
 }
-
-/*##^##
-Designer {
-    D{i:0;autoSize:true;formeditorZoom:0.5;height:480;width:640}
-}
-##^##*/

--- a/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/InvitationBubble.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/InvitationBubble.qml
@@ -14,7 +14,7 @@ Item {
 
     id: root
     anchors.left: parent.left
-    height: childrenRect.height
+    height: rectangleBubbleLoader.height
     width: rectangleBubbleLoader.width
 
     function getCommunity() {
@@ -79,8 +79,6 @@ Item {
     Loader {
         id: rectangleBubbleLoader
         active: !!invitedCommunity
-        width: item ? item.width : 0
-        height: item ? item.height : 0
 
         sourceComponent: Component {
             Rectangle {
@@ -88,7 +86,14 @@ Item {
                 property alias button: joinBtn
                 property bool isPendingRequest: chatsModel.communities.isCommunityRequestPending(communityId)
                 width: 270
-                height: childrenRect.height + Style.current.halfPadding
+                height: title.height + title.anchors.topMargin +
+                        invitedYou.height + invitedYou.anchors.topMargin +
+                        sep1.height + sep1.anchors.topMargin +
+                        communityName.height + communityName.anchors.topMargin +
+                        communityDesc.height + communityDesc.anchors.topMargin +
+                        communityNbMembers.height + communityNbMembers.anchors.topMargin +
+                        sep2.height + sep2.anchors.topMargin +
+                        btnItemId.height + btnItemId.anchors.topMargin
                 radius: 16
                 color: Style.current.background
                 border.color: Style.current.border
@@ -266,6 +271,7 @@ Item {
                     anchors.topMargin: Style.current.halfPadding
                 }
                 Item {
+                    id: btnItemId
                     width: parent.width
                     height: 44
                     anchors.bottom: parent.bottom
@@ -325,9 +331,3 @@ Item {
         }
     }
 }
-
-/*##^##
-Designer {
-    D{i:0;formeditorColor:"#4c4e50";formeditorZoom:1.25}
-}
-##^##*/


### PR DESCRIPTION
InvitationBubble binding loop on height fixed.
Scroll down if you reach the top of the chat is not blocked any more.

Fixes: #3320