### PR TITLE
perf(@desktop/chat): avoid query when switching chat

### DIFF
--- a/src/app/chat/views/channel.nim
+++ b/src/app/chat/views/channel.nim
@@ -93,13 +93,13 @@ QtObject:
     if (self.chats.chats.len == 0): return
     let selectedChannel = self.getChannel(channelIndex)
     if (selectedChannel == nil): return
-    discard self.status.chat.markAllChannelMessagesRead(selectedChannel.id)
+    self.status.chat.asyncMarkAllChannelMessagesRead(selectedChannel.id)
 
   proc markChatItemAsRead*(self: ChannelView, id: string) {.slot.} =
     if (self.chats.chats.len == 0): return
     let selectedChannel = self.getChannelById(id)
     if (selectedChannel == nil): return
-    discard self.status.chat.markAllChannelMessagesRead(selectedChannel.id)
+    self.status.chat.asyncMarkAllChannelMessagesRead(selectedChannel.id)
 
   proc clearUnreadIfNeeded*(self: ChannelView, channel: var Chat) =
     if (not channel.isNil and (channel.unviewedMessagesCount > 0 or channel.mentionsCount > 0)):
@@ -166,7 +166,7 @@ QtObject:
     if not self.communities.activeCommunity.active:
       self.previousActiveChannelIndex = self.chats.chats.findIndexById(self.activeChannel.id)
 
-    discard self.status.chat.markAllChannelMessagesRead(self.activeChannel.id)
+    self.status.chat.asyncMarkAllChannelMessagesRead(self.activeChannel.id)
 
     self.activeChannelChanged()
 

--- a/src/app/profile/views/contacts.nim
+++ b/src/app/profile/views/contacts.nim
@@ -152,13 +152,17 @@ QtObject:
     read = getContactToAddPubKey
     notify = contactToAddChanged
 
-  proc isAdded*(self: ContactsView, id: string): bool {.slot.} =
-    if id == "": return false
-    self.status.contacts.isAdded(id)
+  proc isAdded*(self: ContactsView, pubkey: string): bool {.slot.} =
+    for contact in self.addedContacts.contacts:
+      if contact.id == pubkey:
+        return true
+    return false
 
-  proc contactRequestReceived*(self: ContactsView, id: string): bool {.slot.} =
-    if id == "": return false
-    self.status.contacts.contactRequestReceived(id)
+  proc contactRequestReceived*(self: ContactsView, pubkey: string): bool {.slot.} =
+    for contact in self.contactRequests.contacts:
+      if contact.id == pubkey:
+        return true
+    return false
 
   proc lookupContact*(self: ContactsView, value: string) {.slot.} =
     if value == "":

--- a/src/status/chat/async_tasks.nim
+++ b/src/status/chat/async_tasks.nim
@@ -50,6 +50,20 @@ const asyncSearchMessagesInChatsAndCommunitiesTask: Task = proc(argEncoded: stri
   arg.finish(responseJson)
 
 #################################################
+# Async mark messages read
+#################################################
+type
+  AsyncMarkAllReadTaskArg = ref object of QObjectTaskArg
+    chatId: string
+
+const asyncMarkAllReadTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+  let arg = decode[AsyncMarkAllReadTaskArg](argEncoded)
+  arg.finish(%*{
+    "response": status_chat.markAllRead(arg.chatId),
+    "chatId": arg.chatId,
+  })
+
+#################################################
 # Async load messages
 #################################################
 type

--- a/src/status/libstatus/core.nim
+++ b/src/status/libstatus/core.nim
@@ -42,9 +42,6 @@ proc removePeer*(peer: string) =
 proc markTrustedPeer*(peer: string) =
   discard callPrivateRPC("markTrustedPeer".prefix(false), %* [peer])
 
-proc getContactByID*(id: string): string =
-  result = callPrivateRPC("getContactByID".prefix, %* [id])
-
 proc getBlockByNumber*(blockNumber: string): string =
   result = callPrivateRPC("eth_getBlockByNumber", %* [blockNumber, false])
 


### PR DESCRIPTION
As we keep a local list of contact request and contact added
we should not need to query this data each time we switch chat as
we already have this data in memory.

This data should be maintained each time there is a change

fixes #1642

Also: Remove what seems to be duplicated and dead code about
getContactById