### PR TITLE
fix(@desktop/chat): no identicon/profile picture shown and wrong time stamp format in search results

### DIFF
--- a/src/app/chat/views/message_search/result_item.nim
+++ b/src/app/chat/views/message_search/result_item.nim
@@ -7,17 +7,18 @@ type SearchResultItem* = object
   titleId: string
   title: string  
   sectionName: string
-  isLetterIdenticon: bool
-  badgeImage: string
+  image: string
+  color: string
   badgePrimaryText: string
   badgeSecondaryText: string
-  badgeIdenticonColor: string
+  badgeImage: string
+  badgeIconColor: string
+  badgeIsLetterIdenticon: bool
 
 proc initSearchResultItem*(itemId, content, time, titleId, title,
-  sectionName: string,
-  isLetterIdenticon: bool = false,
-  badgeImage, badgePrimaryText, badgeSecondaryText, 
-  badgeIdenticonColor: string = ""): SearchResultItem =
+  sectionName: string, image, color, badgePrimaryText, badgeSecondaryText, 
+  badgeImage, badgeIconColor: string = "", badgeIsLetterIdenticon: bool = false): 
+  SearchResultItem =
 
   result.itemId = itemId
   result.content = content
@@ -25,11 +26,13 @@ proc initSearchResultItem*(itemId, content, time, titleId, title,
   result.titleId = titleId
   result.title = title
   result.sectionName = sectionName
-  result.isLetterIdenticon = isLetterIdenticon
-  result.badgeImage = badgeImage
+  result.image = image
+  result.color = color
   result.badgePrimaryText = badgePrimaryText
   result.badgeSecondaryText = badgeSecondaryText
-  result.badgeIdenticonColor = badgeIdenticonColor
+  result.badgeImage = badgeImage
+  result.badgeIconColor = badgeIconColor
+  result.badgeIsLetterIdenticon = badgeIsLetterIdenticon
 
 proc `$`*(self: SearchResultItem): string =
   result = "MessageSearchResultItem("
@@ -39,11 +42,13 @@ proc `$`*(self: SearchResultItem): string =
   result &= fmt"titleId:{self.titleId}, "
   result &= fmt"title:{self.title}"
   result &= fmt"sectionName:{self.sectionName}"  
-  result &= fmt"isLetterIdenticon:{self.isLetterIdenticon}"
-  result &= fmt"badgeImage:{self.badgeImage}"
+  result &= fmt"image:{self.image}"
+  result &= fmt"color:{self.color}"
   result &= fmt"badgePrimaryText:{self.badgePrimaryText}"
   result &= fmt"badgeSecondaryText:{self.badgeSecondaryText}"
-  result &= fmt"badgeIdenticonColor:{self.badgeIdenticonColor}"
+  result &= fmt"badgeImage:{self.badgeImage}"
+  result &= fmt"badgeIconColor:{self.badgeIconColor}"
+  result &= fmt"badgeIsLetterIdenticon:{self.badgeIsLetterIdenticon}"
   result &= ")"
 
 method getItemId*(self: SearchResultItem): string {.base.} =
@@ -64,11 +69,11 @@ method getTitle*(self: SearchResultItem): string {.base.} =
 method getSectionName*(self: SearchResultItem): string {.base.} =
   return self.sectionName
 
-method getIsLetterIdentIcon*(self: SearchResultItem): bool {.base.} =
-  return self.isLetterIdenticon
+method getImage*(self: SearchResultItem): string {.base.} =
+  return self.image
 
-method getBadgeImage*(self: SearchResultItem): string {.base.} =
-  return self.badgeImage
+method getColor*(self: SearchResultItem): string {.base.} =
+  return self.color
 
 method getBadgePrimaryText*(self: SearchResultItem): string {.base.} =
   return self.badgePrimaryText
@@ -76,5 +81,11 @@ method getBadgePrimaryText*(self: SearchResultItem): string {.base.} =
 method getBadgeSecondaryText*(self: SearchResultItem): string {.base.} =
   return self.badgeSecondaryText
 
-method getBadgeIdenticonColor*(self: SearchResultItem): string {.base.} =
-  return self.badgeIdenticonColor
+method getBadgeImage*(self: SearchResultItem): string {.base.} =
+  return self.badgeImage
+
+method getBadgeIconColor*(self: SearchResultItem): string {.base.} =
+  return self.badgeIconColor
+
+method getBadgeIsLetterIdenticon*(self: SearchResultItem): bool {.base.} =
+  return self.badgeIsLetterIdenticon

--- a/src/app/chat/views/message_search/result_model.nim
+++ b/src/app/chat/views/message_search/result_model.nim
@@ -10,11 +10,13 @@ type
     TitleId
     Title
     SectionName
-    IsLetterIdenticon
-    BadgeImage
+    Image
+    Color
     BadgePrimaryText
     BadgeSecondaryText
-    BadgeIdenticonColor
+    BadgeImage
+    BadgeIconColor
+    BadgeIsLetterIdenticon
 
 QtObject:
   type
@@ -55,11 +57,13 @@ QtObject:
       MessageSearchResultModelRole.TitleId.int:"titleId",
       MessageSearchResultModelRole.Title.int:"title",
       MessageSearchResultModelRole.SectionName.int:"sectionName",
-      MessageSearchResultModelRole.IsLetterIdenticon.int:"isLetterIdenticon",
-      MessageSearchResultModelRole.BadgeImage.int:"badgeImage",
+      MessageSearchResultModelRole.Image.int:"image",
+      MessageSearchResultModelRole.Color.int:"color",
       MessageSearchResultModelRole.BadgePrimaryText.int:"badgePrimaryText",
       MessageSearchResultModelRole.BadgeSecondaryText.int:"badgeSecondaryText",
-      MessageSearchResultModelRole.BadgeIdenticonColor.int:"badgeIdenticonColor"
+      MessageSearchResultModelRole.BadgeImage.int:"badgeImage",
+      MessageSearchResultModelRole.BadgeIconColor.int:"badgeIconColor",
+      MessageSearchResultModelRole.BadgeIsLetterIdenticon.int:"badgeIsLetterIdenticon"
     }.toTable
 
   method data(self: MessageSearchResultModel, index: QModelIndex, role: int): QVariant =
@@ -85,16 +89,20 @@ QtObject:
       result = newQVariant(item.getTitle)
     of MessageSearchResultModelRole.SectionName: 
       result = newQVariant(item.getSectionName)
-    of MessageSearchResultModelRole.IsLetterIdenticon: 
-      result = newQVariant(item.getIsLetterIdentIcon)
-    of MessageSearchResultModelRole.BadgeImage: 
-      result = newQVariant(item.getBadgeImage)
+    of MessageSearchResultModelRole.Image: 
+      result = newQVariant(item.getImage)
+    of MessageSearchResultModelRole.Color: 
+      result = newQVariant(item.getColor)
     of MessageSearchResultModelRole.BadgePrimaryText: 
       result = newQVariant(item.getBadgePrimaryText)
     of MessageSearchResultModelRole.BadgeSecondaryText: 
       result = newQVariant(item.getBadgeSecondaryText)
-    of MessageSearchResultModelRole.BadgeIdenticonColor: 
-      result = newQVariant(item.getBadgeIdenticonColor)
+    of MessageSearchResultModelRole.BadgeImage: 
+      result = newQVariant(item.getBadgeImage)
+    of MessageSearchResultModelRole.BadgeIconColor: 
+      result = newQVariant(item.getBadgeIconColor)
+    of MessageSearchResultModelRole.BadgeIsLetterIdenticon: 
+      result = newQVariant(item.getBadgeIsLetterIdentIcon)
 
   proc add*(self: MessageSearchResultModel, item: SearchResultItem) =
     self.beginInsertRows(newQModelIndex(), self.resultList.len, self.resultList.len)

--- a/src/app/chat/views/message_search/view_controller.nim
+++ b/src/app/chat/views/message_search/view_controller.nim
@@ -164,8 +164,9 @@ QtObject:
       if(self.meassgeSearchLocation.len == 0 and
         co.name.toLower.startsWith(self.meassgeSearchTerm.toLower)):
         let item = initSearchResultItem(co.id, "", "", co.id, co.name, 
-          sr_constants.SEARCH_RESULT_COMMUNITIES_SECTION_NAME, false, 
-          co.communityImage.thumbnail, "", "", co.communityColor)
+          sr_constants.SEARCH_RESULT_COMMUNITIES_SECTION_NAME, 
+          co.communityImage.thumbnail, co.communityColor, "", "", 
+          co.communityImage.thumbnail, co.communityColor)
 
         self.resultItems.add(co.id, ResultItemInfo(communityId: co.id))
         items.add(item)
@@ -182,8 +183,9 @@ QtObject:
 
           if(chatNameRaw.toLower.startsWith(self.meassgeSearchTerm.toLower)):
             let item = initSearchResultItem(c.id, "", "", c.id, chatName, 
-              sr_constants.SEARCH_RESULT_CHANNELS_SECTION_NAME,
-              c.identicon.len > 0, c.identicon, "", "", c.color)
+            sr_constants.SEARCH_RESULT_CHANNELS_SECTION_NAME, 
+            c.identicon, c.color, "", "", c.identicon, c.color, 
+            c.identicon.len > 0)
 
             self.resultItems.add(c.id, ResultItemInfo(communityId: co.id, 
             channelId: c.id))
@@ -200,9 +202,9 @@ QtObject:
 
         if(chatNameRaw.toLower.startsWith(self.meassgeSearchTerm.toLower)):
           let item = initSearchResultItem(c.id, "", "", c.id, chatName, 
-            sr_constants.SEARCH_RESULT_CHATS_SECTION_NAME,
-            c.identicon.len > 0, c.identicon, "", "", c.color)
-          
+          sr_constants.SEARCH_RESULT_CHATS_SECTION_NAME, c.identicon, c.color,
+          "", "", c.identicon, c.color, c.identicon.len > 0)
+
           self.resultItems.add(c.id, ResultItemInfo(communityId: "", 
             channelId: c.id))
           items.add(item)
@@ -217,6 +219,7 @@ QtObject:
 
       var found = false
       var chat = self.channelView.chats.getChannelById(m.chatId, found)
+      let image = if(m.image.len > 0): m.image else: m.identicon
       if (found):
         var channel = self.status.chat.chatName(chat)
         if (channel.endsWith(".stateofus.eth")):
@@ -227,8 +230,8 @@ QtObject:
           alias = "You"
 
         let item = initSearchResultItem(m.id, m.text, m.timestamp, m.fromAuthor,
-        alias, sr_constants.SEARCH_RESULT_MESSAGES_SECTION_NAME, 
-        chat.identicon.len == 0, chat.identicon, channel, "", chat.color)
+        alias, sr_constants.SEARCH_RESULT_MESSAGES_SECTION_NAME, image, "",
+        channel, "", chat.identicon, chat.color, chat.identicon.len == 0)
 
         self.resultItems.add(m.id, ResultItemInfo(communityId: "", 
             channelId: chat.id, messageId: m.id))
@@ -249,10 +252,9 @@ QtObject:
             alias = "You"
 
           let item = initSearchResultItem(m.id, m.text, m.timestamp, m.fromAuthor,
-          m.alias, sr_constants.SEARCH_RESULT_MESSAGES_SECTION_NAME,
-          community.communityImage.thumbnail.len == 0, 
-          community.communityImage.thumbnail, community.name, channel, 
-          community.communityColor)
+          m.alias, sr_constants.SEARCH_RESULT_MESSAGES_SECTION_NAME, image, "",
+          community.name, channel, community.communityImage.thumbnail,
+          community.communityColor, community.communityImage.thumbnail.len == 0)
 
           self.resultItems.add(m.id, ResultItemInfo(communityId: community.id, 
             channelId: chat.id, messageId: m.id))

--- a/ui/app/AppLayouts/Chat/ChatLayout.qml
+++ b/ui/app/AppLayouts/Chat/ChatLayout.qml
@@ -70,6 +70,11 @@ StatusAppThreePanelLayout {
 
         searchOptionsPopupMenu: searchPopupMenu
         searchResults: chatsModel.messageSearchViewController.resultModel
+
+        formatTimestampFn: function (ts) {
+            return new Date(parseInt(ts, 10)).toLocaleString(Qt.locale(globalSettings.locale))
+        }
+
         onSearchTextChanged: {
             searchMessages(searchPopup.searchText);
         }


### PR DESCRIPTION
PR: `StatusQ` [here](https://github.com/status-im/StatusQ/pull/361)

Icons added for messages senders in the search result, also community and chat
icons are colorized now.

Fixes: #3259