### PR TITLE
feat(@desktop/installer): status-im:// protocol support and improvements

### DIFF
--- a/src/app/chat/core.nim
+++ b/src/app/chat/core.nim
@@ -15,11 +15,13 @@ type ChatController* = ref object
   status*: Status
   variant*: QVariant
   appService: AppService
+  uriToOpen: string
 
-proc newController*(status: Status, appService: AppService): ChatController =
+proc newController*(status: Status, appService: AppService, uriToOpen: string): ChatController =
   result = ChatController()
   result.status = status
   result.appService = appService
+  result.uriToOpen = uriToOpen
   result.view = newChatsView(status, appService)
   result.variant = newQVariant(result.view)
 
@@ -65,6 +67,9 @@ proc init*(self: ChatController) =
   self.status.events.on("network:connected") do(e: Args):
     self.view.stickers.clearStickerPacks()
     self.view.stickers.obtainAvailableStickerPacks()
+    if self.uriToOpen != "":
+      self.view.handleProtocolUri(self.uriToOpen)
+      self.uriToOpen = ""
 
 proc loadInitialMessagesForChannel*(self: ChatController, channelId: string) =
   if (channelId.len == 0):

--- a/src/app/chat/view.nim
+++ b/src/app/chat/view.nim
@@ -566,10 +566,13 @@ QtObject:
 
   proc handleProtocolUri*(self: ChatsView, uri: string) =
     # for now this only supports links to 1-1 chats, e.g.
-    # status-im://0x04ecb3636368be823f9c62e2871f8ea5b52eb3fac0132bdcf9e57907a9cb1024d81927fb3ce12fea6d9b9a8f1acb24370df756108170ab0e3454ae93aa601f3c33
+    # status-im://p/0x04ecb3636368be823f9c62e2871f8ea5b52eb3fac0132bdcf9e57907a9cb1024d81927fb3ce12fea6d9b9a8f1acb24370df756108170ab0e3454ae93aa601f3c33
     # TODO: support other chat types
-    let pubKey = uri.replace("status-im://", "").replace("/", "")
-    if pubKey.startsWith("0x"):
+    let parts = uri.replace("status-im://", "").split("/")
+    if parts.len == 2 and parts[0] == "p" and parts[1].startsWith("0x"):
+      let pubKey = parts[1]
       self.status.chat.createOneToOneChat(pubKey)
       self.setActiveChannel(pubKey)
+      return
+    echo "Unsupported deep link structure: " & uri
   

--- a/src/app/chat/view.nim
+++ b/src/app/chat/view.nim
@@ -563,3 +563,13 @@ QtObject:
     
     self.appService.osNotificationService.showNotification(title, message, 
     details, useOSNotifications)
+
+  proc handleProtocolUri*(self: ChatsView, uri: string) =
+    # for now this only supports links to 1-1 chats, e.g.
+    # status-im://0x04ecb3636368be823f9c62e2871f8ea5b52eb3fac0132bdcf9e57907a9cb1024d81927fb3ce12fea6d9b9a8f1acb24370df756108170ab0e3454ae93aa601f3c33
+    # TODO: support other chat types
+    let pubKey = uri.replace("status-im://", "").replace("/", "")
+    if pubKey.startsWith("0x"):
+      self.status.chat.createOneToOneChat(pubKey)
+      self.setActiveChannel(pubKey)
+  

--- a/src/nim_status_client.nim
+++ b/src/nim_status_client.nim
@@ -135,7 +135,7 @@ proc mainProc() =
   defer: wallet2.delete()
   engine.setRootContextProperty("walletV2Model", wallet2.variant)
 
-  var chat = chat.newController(status, appService)
+  var chat = chat.newController(status, appService, OPENURI)
   defer: chat.delete()
   engine.setRootContextProperty("chatsModel", chat.variant)
 

--- a/src/nim_windows_launcher.nim
+++ b/src/nim_windows_launcher.nim
@@ -1,12 +1,17 @@
-from os import getAppDir, joinPath
+from os import getAppDir, joinPath, commandLineParams
 from winlean import Handle, shellExecuteW
+
+proc restoreParamsString(strings: seq[string]): string =
+  result = ""
+  for str in strings:
+    result = result & " " & str
 
 const NULL: Handle = 0
 let launcherDir = getAppDir()
 let workDir_str = joinPath(launcherDir, "bin")
 let exePath_str = joinPath(workDir_str, "Status.exe")
 let open_str = "open"
-let params_str = ""
+let params_str = restoreParamsString(commandLineParams())
 let workDir = newWideCString(workDir_str)
 let exePath = newWideCString(exePath_str)
 let open = newWideCString(open_str)

--- a/status.iss
+++ b/status.iss
@@ -17,11 +17,12 @@ AppSupportURL={#URL}
 AppUpdatesURL={#URL}
 DefaultDirName={localappdata}\{#Name}App
 UsePreviousAppDir=no
-PrivilegesRequired=lowest
+PrivilegesRequired=admin
 WizardStyle=modern
 UninstallDisplayIcon={app}\{#ExeName}
 DefaultGroupName={#Name}
 CloseApplications=yes
+ArchitecturesInstallIn64BitMode=x64
 
 ; output dir for installer
 OutputBaseFileName={#BaseName}
@@ -64,6 +65,7 @@ Name: "{group}\Uninstall {#Name}"; Filename: "{uninstallexe}"
 Name: "{userdesktop}\{#Name}"; Filename: "{app}\{#ExeName}"; IconFilename: "{app}\resources\{#IcoName}"; Tasks: desktopicon
 
 [Run]
+Filename: "{app}\vendor\vc_redist.x64.exe"; Parameters: "/install /quiet /norestart"; StatusMsg: "Installing VS2017 redistributable package (64 Bit)";
 Filename: "{app}\{#ExeName}"; Description: {cm:LaunchProgram,{#Name}}; Flags: nowait postinstall skipifsilent
 
 [UninstallDelete]
@@ -72,10 +74,10 @@ Type: files; Name: "{userdesktop}\{#Name}"
 Type: files; Name: "{commondesktop}\{#Name}"
 
 [Registry]
-Root: HKCU; Subkey: "Software\Classes\status-im"; ValueType: "string"; ValueData: "URL:status-im protocol"; Flags: uninsdeletekey
-Root: HKCU; Subkey: "Software\Classes\status-im"; ValueType: "string"; ValueName: "URL Protocol"; ValueData: ""
-Root: HKCU; Subkey: "Software\Classes\status-im\DefaultIcon"; ValueType: "string"; ValueData: "{app}\Status.exe,1"
-Root: HKCU; Subkey: "Software\Classes\status-im\shell\open\command"; ValueType: "string"; ValueData: """{app}\Status.exe"" ""--url=""%1"""
+Root: HKCR; Subkey: "status-im"; ValueType: "string"; ValueData: "URL:status-im Protocol"; Flags: uninsdeletekey
+Root: HKCR; Subkey: "status-im"; ValueType: "string"; ValueName: "URL Protocol"; ValueData: ""
+Root: HKCR; Subkey: "status-im\DefaultIcon"; ValueType: "string"; ValueData: "{app}\Status.exe,1"
+Root: HKCR; Subkey: "status-im\shell\open\command"; ValueType: "string"; ValueData: """{app}\bin\Status.exe"" ""--uri=%1"""
 
 [Code]
 function IsAppRunning(const FileName : string): Boolean;


### PR DESCRIPTION
Fixes #837 
Fixes https://github.com/status-im/status-desktop/issues/3371

Requires https://github.com/status-im/nim-status-lib/pull/6

1. Windows only.
2. Installer to execute `vc_redist.x64.exe` silently while installing the app.
3. Installer to register `status-im://` protocol handler.
4. Application to receive `--url=status-im://0x123...` cmd line argument to create/open 1-1 chat.
5. Only 1-1 chat links are supported for now.

Future work (TODOs):
1. Integrate "single instance" feature https://github.com/status-im/status-desktop/issues/3374
2. Support status protocol variations for communities, public chats, etc. Need a full list of possibilities.

How to test:
1. Uninstall Status app.
2. Install Status app using the new installer built from this branch.
3. Open a browser (e.g. Chrome) or File Explorer, paste the link
`status-im://0x04ecb3636368be823f9c62e2871f8ea5b52eb3fac0132bdcf9e57907a9cb1024d81927fb3ce12fea6d9b9a8f1acb24370df756108170ab0e3454ae93aa601f3c33`
4. You should have a 1-1 chat with "Round True Cicada" user
Note: application must not be running until the TODOs mentioned in above are resolved.
