### PR TITLE
feat(@desktop/chat): Hide chat text when the link is only an image

### DIFF
--- a/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/ChatText.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/ChatText.qml
@@ -11,7 +11,6 @@ Item {
     property alias textField: chatText
 
     id: root
-    visible: isText || isEmoji 
     z: 51
 
     implicitHeight: visible ? (showMoreLoader.active ? childrenRect.height - 10 : chatText.height) : 0

--- a/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/CompactMessage.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/CompactMessage.qml
@@ -286,8 +286,17 @@ Item {
             visible: !isEdit
 
             ChatText {
-                readonly property int leftPadding: chatImage.anchors.leftMargin + chatImage.width + root.chatHorizontalPadding
                 id: chatText
+                readonly property int leftPadding: chatImage.anchors.leftMargin + chatImage.width + root.chatHorizontalPadding
+                visible: {
+                    const urls = root.linkUrls.split(" ")
+                    if (urls.length === 1 && Utils.hasImageExtension(urls[0]) && appSettings.displayChatImages) {
+                        return false
+                    }
+
+                    return isText || isEmoji
+                }
+
                 anchors.top: parent.top
                 anchors.topMargin: isEmoji ? 2 : 0
                 anchors.left: parent.left


### PR DESCRIPTION
fixes #3366
When image display is enabled:
![image](https://user-images.githubusercontent.com/491074/132216754-348f34a5-9b5e-4409-a641-e31d3ddd289e.png)

When image display is disabled:
![image](https://user-images.githubusercontent.com/491074/132216830-badc84c4-9a6d-48ff-9ccf-726f2239ee97.png)
