### PR TITLE
fix(@desktop/onboard): don't submit password creation form on enter w…

### DIFF
--- a/ui/onboarding/CreatePasswordModal.qml
+++ b/ui/onboarding/CreatePasswordModal.qml
@@ -50,7 +50,9 @@ ModalPopup {
         placeholderText: qsTrId("confirm-password…")
         textField.echoMode: TextInput.Password
         Keys.onReturnPressed: function(event) {
-            submitBtn.clicked(event)
+            if (submitBtn.enabled) {
+                submitBtn.clicked(event)
+            }
         }
         onTextChanged: {
             [repeatPasswordFieldValid, repeatPasswordValidationError] =


### PR DESCRIPTION
…hen invalid

There's a bug where creating a password is possible while having an invalid state
because hitting enter causes the submission without checking the form's validity.

This commit fixes it by only submitting the form when both fields are actually valid.

Closes #3412