### PR TITLE
fix(@desktop/communities): processing response from InviteUsers call

### DIFF
--- a/src/app/chat/views/messages.nim
+++ b/src/app/chat/views/messages.nim
@@ -217,8 +217,9 @@ QtObject:
           self.newMessagePushed()
 
         let isGroupSelf = msg.fromAuthor == self.pubKey and msg.contentType == ContentType.Group
+        let isMyInvite = msg.fromAuthor == self.pubKey and msg.contentType == ContentType.Community
         let isEdit = msg.editedAt != "0" or msg.contentType == ContentType.Edit
-        if not channel.muted and not isEdit and not isGroupSelf:
+        if not channel.muted and not isEdit and not isGroupSelf and not isMyInvite:
           let isAddedContact = channel.chatType.isOneToOne and self.isAddedContact(channel.id)
           self.messageNotificationPushed(msg.id, channel.communityId, msg.chatId, escape_html(msg.text), msg.contentType.int, channel.chatType.int, msg.timestamp, msg.identicon, msg.userName, msg.hasMention, isAddedContact, channel.name)
 


### PR DESCRIPTION
Fixes #3329 

REQUIRES: https://github.com/status-im/nim-status-lib/pull/2

Original issue description:
`inviteUsersToCommunity` (status-go) call creates and sends an invitation message to the peer, but it was not appeared in my own chat as "sent invitation". 

How to test: just follow the instructions from #3329