### PR TITLE
fix(desktop/profile) back seed indication missing

### DIFF
--- a/ui/app/AppMain.qml
+++ b/ui/app/AppMain.qml
@@ -409,7 +409,7 @@ Item {
                     checked: appView.currentIndex == Utils.getAppSectionIndex(Constants.profile)
                     onClicked: appMain.changeAppSection(Constants.profile)
 
-                    badge.visible: !profileModel.mnemonic.isBackedUp && !checked
+                    badge.visible: !profileModel.mnemonic.isBackedUp
                     badge.anchors.rightMargin: 4
                     badge.anchors.topMargin: 5
                     badge.border.color: hovered ? Theme.palette.statusBadge.hoverBorderColor : Theme.palette.statusAppNavBar.backgroundColor


### PR DESCRIPTION
When other than the profile menu was selected

Closes #3457