### PR TITLE
feat(communities): re-enabled open membership communities

### DIFF
--- a/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/InvitationBubble.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/InvitationBubble.qml
@@ -133,7 +133,9 @@ Item {
                     },
                     State {
                         name: "joined"
-                        when: invitedCommunity.joined && invitedCommunity.isMember
+                        when: (invitedCommunity.joined && invitedCommunity.isMember) ||
+                              (invitedCommunity.access === Constants.communityChatPublicAccess &&
+                                invitedCommunity.joined)
                         PropertyChanges {
                             target: joinBtn
                             //% "View"
@@ -154,8 +156,10 @@ Item {
                     },
                     State {
                         name: "unjoined"
-                        when: invitedCommunity.access === Constants.communityChatOnRequestAccess &&
-                              invitedCommunity.isMember
+                        when: (invitedCommunity.access === Constants.communityChatOnRequestAccess &&
+                                invitedCommunity.isMember) ||
+                              (invitedCommunity.access === Constants.communityChatPublicAccess &&
+                                !invitedCommunity.joined)
                         PropertyChanges {
                             target: joinBtn
                             //% "Join"

--- a/ui/app/AppLayouts/Chat/CommunityComponents/CreateCommunityPopup.qml
+++ b/ui/app/AppLayouts/Chat/CommunityComponents/CreateCommunityPopup.qml
@@ -23,6 +23,7 @@ StatusModal {
                                                    | Utils.Validate.TextHexColor
 
     id: popup
+    height: 509
 
     onOpened: {
         if (isEdit) {
@@ -65,9 +66,8 @@ StatusModal {
 
         contentHeight: content.height
         bottomPadding: 8
-        height: Math.min(content.height, 432)
         width: popup.width
-        
+
         ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
 
         clip: true
@@ -79,14 +79,16 @@ StatusModal {
         Column {
             id: content
             width: popup.width
+            spacing: 8
 
-            Item { 
+            Item {
                 height: 8
                 width: parent.width
             }
 
             StatusInput {
                 id: nameInput
+                label: qsTr("Name your community")
                 charLimit: maxCommunityNameLength
                 input.placeholderText: qsTr("A catchy name")
                 validators: [StatusMinLengthValidator { minLength: 1 }]
@@ -288,8 +290,6 @@ StatusModal {
                 visible: !isEdit
                 //% "Membership requirement"
                 title: qsTrId("membership-title")
-                // TODO: remove 'isEnabled: false' when we no longer need to force "request access" membership
-                enabled: false
                 label: {
                     switch (membershipRequirementSettingPopup.checkedMembership) {
                         //% "Require invite from another member"
@@ -311,8 +311,7 @@ StatusModal {
             }
 
             StatusBaseText {
-                // TODO: remove 'false' when we no longer need to force "request access" membership
-                visible: false && !isEdit
+                visible: !isEdit
                 height: visible ? implicitHeight : 0
                 wrapMode: Text.WordWrap
                 font.pixelSize: 13
@@ -451,9 +450,6 @@ StatusModal {
     MembershipRequirementPopup {
         anchors.centerIn: parent
         id: membershipRequirementSettingPopup
-        // TODO: remove the 'checkedMemership' setting when we no longer need
-        // to force "require approval" membership
-        checkedMembership: Constants.communityChatOnRequestAccess
     }
 }
 

--- a/ui/app/AppLayouts/Chat/CommunityComponents/MembershipRequirementPopup.qml
+++ b/ui/app/AppLayouts/Chat/CommunityComponents/MembershipRequirementPopup.qml
@@ -60,24 +60,26 @@ StatusModal {
             anchors.leftMargin: 32
         }
 
-        StatusListItem {
-            anchors.horizontalCenter: parent.horizontalCenter
-            //% "Require invite from another member"
-            title: qsTrId("membership-invite")
-            sensor.onClicked: inviteOnlyRadio.checked = true
-            components: [
-                StatusRadioButton {
-                    id: inviteOnlyRadio
-                    checked: popup.checkedMembership === Constants.communityChatInvitationOnlyAccess
-                    ButtonGroup.group: membershipRequirementGroup
-                    onCheckedChanged: {
-                        if (checked) {
-                            popup.checkedMembership = Constants.communityChatInvitationOnlyAccess
-                        }
-                    }
-                }
-            ]
-        }
+        // TODO: uncomment this when we want to re-enable requiring invite from another member
+        // for community creation
+        // StatusListItem {
+        //     anchors.horizontalCenter: parent.horizontalCenter
+        //     //% "Require invite from another member"
+        //     title: qsTrId("membership-invite")
+        //     sensor.onClicked: inviteOnlyRadio.checked = true
+        //     components: [
+        //         StatusRadioButton {
+        //             id: inviteOnlyRadio
+        //             checked: popup.checkedMembership === Constants.communityChatInvitationOnlyAccess
+        //             ButtonGroup.group: membershipRequirementGroup
+        //             onCheckedChanged: {
+        //                 if (checked) {
+        //                     popup.checkedMembership = Constants.communityChatInvitationOnlyAccess
+        //                 }
+        //             }
+        //         }
+        //     ]
+        // }
 
         StatusBaseText {
             wrapMode: Text.WordWrap


### PR DESCRIPTION
Closes #3410.

Re-enables open membership communities, with necessary changes in the Inivitation Bubble for one-on-one chats.

fix: add/edit communities components not appearing
On add/edit community popup load, some components below the thumbnail image picker were not appearing until the app window was resized. Removing the height of the ScrollView fixed the issue (on mac).

NOTE: this may require windows and linux users to test (@anastasiyaig)