### PR TITLE
fix: in profile popup display Username instead of ENS Username if ENS is not verified

### DIFF
--- a/ui/app/AppLayouts/Chat/components/ProfilePopup.qml
+++ b/ui/app/AppLayouts/Chat/components/ProfilePopup.qml
@@ -25,7 +25,7 @@ StatusModal {
     property var alias: ""
 
     readonly property int innerMargin: 20
-    
+
     property bool isEnsVerified: false
     property bool noFooter: false
     property bool isBlocked: false
@@ -90,7 +90,7 @@ StatusModal {
             }
 
             StatusDescriptionListItem {
-                title: qsTr("ENS username")
+                title: ((isCurrentUser && profileModel.ens.preferredUsername) || isEnsVerified) ? qsTr("ENS username") : qsTr("Username")
                 subTitle: isCurrentUser ? profileModel.ens.preferredUsername || userName : userName
                 tooltip.text: qsTr("Copy to clipboard")
                 icon.name: "copy"


### PR DESCRIPTION
Closes #3496.

![image](https://user-images.githubusercontent.com/194260/133281855-55bcb432-52f0-46ca-9f0f-f7b85d8e15c9.png)

This may not be the desired solution, but #3496 was very light on suggestions how the profile popup should be changed.