### PR TITLE
feat(desktop/profile): add link in advanced settings so log directory can be opened directly

### DIFF
--- a/src/app/profile/view.nim
+++ b/src/app/profile/view.nim
@@ -15,6 +15,7 @@ import status/notifications/[os_notifications]
 import ../../app_service/[main]
 import qrcode/qrcode
 import ../utils/image_utils
+import ../../constants
 
 logScope:
   topics = "profile-view"
@@ -92,7 +93,7 @@ QtObject:
 
   proc changeLocale*(self: ProfileView, locale: string) {.slot.} =
     self.changeLanguage(locale)
-  
+
   proc nodeVersion*(self: ProfileView): string {.slot.} =
     self.status.getNodeVersion()
 
@@ -170,7 +171,7 @@ QtObject:
   QtProperty[QVariant] mnemonic:
     read = getMnemonic
 
-  proc getNetwork*(self: ProfileView): QVariant {.slot.} = 
+  proc getNetwork*(self: ProfileView): QVariant {.slot.} =
     newQVariant(self.network)
 
   QtProperty[QVariant] network:
@@ -217,12 +218,15 @@ QtObject:
     self.profile.setSendUserStatus(sendUserStatus)
     self.status.saveSetting(Setting.SendUserStatus, sendUserStatus)
 
-  proc showOSNotification*(self: ProfileView, title: string, message: string, 
+  proc showOSNotification*(self: ProfileView, title: string, message: string,
     notificationType: int, useOSNotifications: bool) {.slot.} =
 
     let details = OsNotificationDetails(
       notificationType: notificationType.OsNotificationType
     )
 
-    self.appService.osNotificationService.showNotification(title, message, 
+    self.appService.osNotificationService.showNotification(title, message,
     details, useOSNotifications)
+
+  proc logDir*(self: ProfileView): string {.slot.} =
+    url_fromLocalFile(constants.LOGDIR)

--- a/ui/app/AppLayouts/Profile/Sections/AdvancedContainer.qml
+++ b/ui/app/AppLayouts/Profile/Sections/AdvancedContainer.qml
@@ -49,6 +49,25 @@ ScrollView {
                 }
             }
 
+            StyledText {
+                //% "Application Logs"
+                text: qsTr("Application Logs")
+                font.pixelSize: 15
+                font.underline: mouseArea.containsMouse
+                color: Style.current.blue
+                topPadding: 23
+
+                MouseArea {
+                    id: mouseArea
+                    anchors.fill: parent
+                    cursorShape: Qt.PointingHandCursor
+                    hoverEnabled: true
+                    onClicked: {
+                        Qt.openUrlExternally(profileModel.logDir())
+                    }
+                }
+            }
+
             Item {
                 id: spacer1
                 height: Style.current.bigPadding


### PR DESCRIPTION
Closes #3509.

https://user-images.githubusercontent.com/194260/133298112-6694198a-7df6-4286-8253-ace77bc0c465.mp4

#3509 calls for a button, but a link seems to work nicely. I'll test on Windows and Linux after the CI builds become available for this PR.

For the sake of the screen capture I changed `text: qsTrId("app-logs")` to `text: qsTrId("Application Logs")`, but in the commit it's `text: qsTrId("app-logs")`. For this PR to be merge-worthy, do I need to run the i18n scripts or what exactly?

Also, I wasn't sure the best way to deal with top padding of the `StyledText`, so I divided in half the value for `anchors.topMargin` in `AboutContainer.qml` and it looks about right. However, there may be a better way to deal with the styling, I'm just not familiar with it because I've spent so little time with QML to date.