### PR TITLE
fix: set preferred username

### DIFF
--- a/src/app/profile/views/ens_manager.nim
+++ b/src/app/profile/views/ens_manager.nim
@@ -156,6 +156,9 @@ QtObject:
   
   proc connect(self: EnsManager, ensUsername: string) =
     var usernames = getSetting[seq[string]](self.status.settings, Setting.Usernames, @[])
+    if usernames.len == 0:
+      self.setPreferredUsername(ensUsername)
+      
     usernames.add ensUsername
     discard self.status.settings.saveSetting(Setting.Usernames, %*usernames)
   


### PR DESCRIPTION
Fixes: #3292

Notice that in the case of buying an ENS, it will be set as the preferred username once the transaction is mined.