### PR TITLE
feat(@desktop/windows): produce 7z archive when packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -427,7 +427,7 @@ ifdef WINDOWS_CODESIGN_PFX_PATH
 endif
 	echo -e $(BUILD_MSG) "7z"
 	rm $(OUTPUT)/status.iss
-	7z a $(INSTALLER_OUTPUT)/$(STATUS_CLIENT_7Z) ./$(OUTPUT)
+	7z a $(STATUS_CLIENT_7Z) ./$(OUTPUT)
 
 pkg: $(PKG_TARGET)
 

--- a/Makefile
+++ b/Makefile
@@ -424,6 +424,9 @@ endif
 ifdef WINDOWS_CODESIGN_PFX_PATH
 	scripts/sign-windows-bin.sh $(INSTALLER_OUTPUT)
 endif
+	echo -e $(BUILD_MSG) "7z"
+	rm $(OUTPUT)/status.iss
+	7z a $(INSTALLER_OUTPUT)/Status.7z ./$(OUTPUT)
 
 pkg: $(PKG_TARGET)
 

--- a/Makefile
+++ b/Makefile
@@ -425,8 +425,10 @@ endif
 ifdef WINDOWS_CODESIGN_PFX_PATH
 	scripts/sign-windows-bin.sh $(INSTALLER_OUTPUT)
 endif
+
+$(STATUS_CLIENT_7Z): OUTPUT := tmp/windows/dist/Status
+$(STATUS_CLIENT_7Z): $(STATUS_CLIENT_EXE)
 	echo -e $(BUILD_MSG) "7z"
-	rm $(OUTPUT)/status.iss
 	7z a $(STATUS_CLIENT_7Z) ./$(OUTPUT)
 
 pkg: $(PKG_TARGET)
@@ -438,6 +440,8 @@ tgz-linux: $(STATUS_CLIENT_TARBALL)
 pkg-macos: check-pkg-target-macos $(STATUS_CLIENT_DMG)
 
 pkg-windows: check-pkg-target-windows $(STATUS_CLIENT_EXE)
+
+zip-windows: check-pkg-target-windows $(STATUS_CLIENT_7Z)
 
 clean: | clean-common
 	rm -rf bin/* node_modules bottles/* pkg/* tmp/* $(STATUSGO)

--- a/Makefile
+++ b/Makefile
@@ -387,6 +387,7 @@ nim_windows_launcher: | deps
 	$(ENV_SCRIPT) nim c -d:debug --outdir:./bin --passL:"-static-libgcc -Wl,-Bstatic,--whole-archive -lwinpthread -Wl,--no-whole-archive" src/nim_windows_launcher.nim
 
 STATUS_CLIENT_EXE ?= pkg/Status.exe
+STATUS_CLIENT_7Z ?= pkg/Status.7z
 
 $(STATUS_CLIENT_EXE): override RESOURCES_LAYOUT := -d:production
 $(STATUS_CLIENT_EXE): OUTPUT := tmp/windows/dist/Status
@@ -426,7 +427,7 @@ ifdef WINDOWS_CODESIGN_PFX_PATH
 endif
 	echo -e $(BUILD_MSG) "7z"
 	rm $(OUTPUT)/status.iss
-	7z a $(INSTALLER_OUTPUT)/Status.7z ./$(OUTPUT)
+	7z a $(INSTALLER_OUTPUT)/$(STATUS_CLIENT_7Z) ./$(OUTPUT)
 
 pkg: $(PKG_TARGET)
 

--- a/ci/Jenkinsfile.windows
+++ b/ci/Jenkinsfile.windows
@@ -31,6 +31,8 @@ pipeline {
     NIMFLAGS = '--colors:off'
     /* Control output the filename */
     STATUS_CLIENT_EXE = "pkg/${utils.pkgFilename('exe')}"
+    /* 7zip archive filename */
+    STATUS_CLIENT_7Z = "pkg/${utils.pkgFilename('7z')}"
     /* RFC 3161 timestamping URL for DigiCert */
     WINDOWS_CODESIGN_TIMESTAMP_URL = 'http://timestamp.digicert.com'
   }
@@ -65,6 +67,8 @@ pipeline {
       parallel {
         stage('Upload') {
           steps { script {
+            zip_url = s3.uploadArtifact(env.STATUS_CLIENT_7Z)
+            jenkins.setBuildDesc(Zip: zip_url)
             env.PKG_URL = s3.uploadArtifact(env.STATUS_CLIENT_EXE)
             jenkins.setBuildDesc(Exe: env.PKG_URL)
           } }
@@ -72,6 +76,7 @@ pipeline {
         stage('Archive') {
           steps { script {
             archiveArtifacts(env.STATUS_CLIENT_EXE)
+            archiveArtifacts(env.STATUS_CLIENT_7Z)
           } }
         }
       }

--- a/ci/Jenkinsfile.windows
+++ b/ci/Jenkinsfile.windows
@@ -68,9 +68,14 @@ pipeline {
         stage('Upload') {
           steps { script {
             zip_url = s3.uploadArtifact(env.STATUS_CLIENT_7Z)
-            jenkins.setBuildDesc(Zip: zip_url)
-            env.PKG_URL = s3.uploadArtifact(env.STATUS_CLIENT_EXE)
-            jenkins.setBuildDesc(Exe: env.PKG_URL)
+            exe_url = s3.uploadArtifact(env.STATUS_CLIENT_EXE)            
+            env.PKG_URL = exe_url
+
+            urls = [
+              Zip: zip_url,
+              Exe: exe_url,
+            ]
+            jenkins.setBuildDesc(urls)
           } }
         }
         stage('Archive') {

--- a/ci/Jenkinsfile.windows
+++ b/ci/Jenkinsfile.windows
@@ -60,6 +60,7 @@ pipeline {
     stage('Package') {
       steps { script {
         windows.bundle(env.STATUS_CLIENT_EXE)
+        windows.bundle(env.STATUS_CLIENT_7Z)
       } }
     }
 
@@ -70,12 +71,7 @@ pipeline {
             zip_url = s3.uploadArtifact(env.STATUS_CLIENT_7Z)
             exe_url = s3.uploadArtifact(env.STATUS_CLIENT_EXE)            
             env.PKG_URL = exe_url
-
-            urls = [
-              Zip: zip_url,
-              Exe: exe_url,
-            ]
-            jenkins.setBuildDesc(urls)
+            jenkins.setBuildDesc(Zip: zip_url, Exe: exe_url)
           } }
         }
         stage('Archive') {

--- a/ci/Jenkinsfile.windows
+++ b/ci/Jenkinsfile.windows
@@ -59,8 +59,7 @@ pipeline {
 
     stage('Package') {
       steps { script {
-        windows.bundle(env.STATUS_CLIENT_EXE)
-        windows.bundle(env.STATUS_CLIENT_7Z)
+        windows.bundle("${env.STATUS_CLIENT_EXE} ${env.STATUS_CLIENT_7Z}")
       } }
     }
 


### PR DESCRIPTION
Closes #3324

In addition to the installer, we want to create and publish an archive with the app contents. This is because some users may not want to install the app and prefer running "portable" version of the app.