### PR TITLE
fix(@desktop/chat): ensure replacement of mentions with pubkey works …

### DIFF
--- a/src/app/chat/views/community_members_list.nim
+++ b/src/app/chat/views/community_members_list.nim
@@ -1,6 +1,7 @@
 import NimQml, Tables
 import status/[chat/chat, ens, status, settings]
 import status/types/[setting, status_update]
+import user_list
 
 type
   CommunityMembersRoles {.pure.} = enum
@@ -99,6 +100,11 @@ QtObject:
       return true
     if self.community.memberStatus.hasKey(pk):
       result = self.community.memberStatus[pk].statusType.int == StatusUpdateType.Online.int
+
+  proc getUserFromPubKey*(self: CommunityMembersView, pk: string): User =
+    let alias = self.alias(pk)
+    let userName = self.userName(pk, alias)
+    result = User(alias: alias, userName: userName)
 
   proc sortKey(self: CommunityMembersView, pk: string): string =
     let name = self.userName(pk, self.alias(pk))

--- a/src/app/chat/views/user_list.nim
+++ b/src/app/chat/views/user_list.nim
@@ -17,7 +17,7 @@ type
     LocalName = UserRole + 5
     Identicon = UserRole + 6
 
-  User = object
+  User* = object
     username*: string
     alias*: string
     localName: string


### PR DESCRIPTION
…in communities

There were two issues why mentions didn't work in communities:

1. The function that replaces mentions with pubkey looked in the wrong place
2. The same function always prepented `userName` with `@` which isn't always necessary

This commit fix this by ensuring the replacement function looks in the community memberlist
instead of a messageList and also by checking if a `userName` already starts with a `@`
and only prepends it if not.

Fixes #3492