### PR TITLE
fix(ContactsColumn): call itemAt on statusChatListItems.model instead of delegate

### DIFF
--- a/ui/app/AppLayouts/Chat/ContactsColumn.qml
+++ b/ui/app/AppLayouts/Chat/ContactsColumn.qml
@@ -229,7 +229,7 @@ Item {
                 target: profileModel.contacts.list
                 onContactChanged: {
                     for (var i = 0; i < channelList.chatListItems.count; i++) {
-                        let chatItem = channelList.chatListItems.itemAt(i);
+                        let chatItem = channelList.statusChatListItems.model.itemAt(i);
                         if (chatItem.chatId === pubkey) {
                             let profileImage = appMain.getProfileImage(pubkey)
                             if (!!profileImage) {


### PR DESCRIPTION
**DEPENDS ON https://github.com/status-im/StatusQ/pull/415**

When StatusQ switched to using `DelegateModel` in `StatusChatList` to enable drag and drop,
we lost the API `itemAt` which was previously exposed via the `Repeater` that was aliased as
`chatListItems`.

StatusQ now exposes `statusChatListItems` additionally so we can still access `model.itemAt`
which is used in this commit.

The only reason this is done here though, is because we need to update the profile picture of
contacts when we get a contact changed signal. Ideally, we handle contact changes including the
profile picture entirely in the backend and have it then just rerender the screen (instead of
using a `Connection`).


Fixes #3328