### PR TITLE
fix(@desktop/chat): Push notification body contains only chat key

### DIFF
--- a/src/app/chat/views/messages.nim
+++ b/src/app/chat/views/messages.nim
@@ -120,7 +120,7 @@ QtObject:
 
     for mention in pubKeyMentions:
       let pubKey = mention.replace("@","")
-      let userNameAlias = mention(pubKey, self.status.chat.contacts)
+      let userNameAlias = mention(pubKey, self.status.chat.getContacts())
       if userNameAlias != "":
         updatedMessage = updatedMessage.replace(mention, '@' & userNameAlias)
 


### PR DESCRIPTION
fix(@desktop/chat): Push notification body contains only chat key when user is mentioned

fixes #3347