### PR TITLE
chore: improve the bottles logic in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,16 +101,23 @@ ifneq ($(detected_OS),Windows)
 endif
 
 ifeq ($(detected_OS),Darwin)
-bottles/openssl:
-	./scripts/fetch-brew-bottle.sh openssl
+BOTTLES_DIR := $(shell pwd)/bottles
+BOTTLES := $(addprefix $(BOTTLES_DIR)/,hunspell openssl pcre)
 
-bottles/pcre: bottles/openssl
-	./scripts/fetch-brew-bottle.sh pcre
+$(BOTTLES): | $(BOTTLES_DIR)
+	echo -e "\e[92mFetching:\e[39m $(notdir $@) bottle"
+	./scripts/fetch-brew-bottle.sh $(notdir $@)
 
-bottles/hunspell: bottles/pcre
-	./scripts/fetch-brew-bottle.sh hunspell
+$(BOTTLES_DIR):
+	echo -e "\e[92mUpdating:\e[39m macOS Homebrew"
+	if [[ $$(stat -f %u /usr/local/var/homebrew) -ne "$${UID}" ]]; then \
+		echo "Missing permissions to update Homebrew formulae!" >&2; \
+	else \
+		brew update >/dev/null; \
+		mkdir -p $(BOTTLES_DIR); \
+	fi
 
-bottles: bottles/hunspell
+bottles: $(BOTTLES)
 endif
 
 deps: | deps-common bottles

--- a/scripts/fetch-brew-bottle.sh
+++ b/scripts/fetch-brew-bottle.sh
@@ -43,14 +43,6 @@ else
     BEARER_TOKEN=$(get_gh_pkgs_token)
 fi
 
-# We want the most recent available version of the package.
-if [[ $(stat -f %u /usr/local/var/homebrew) -ne "${UID}" ]]; then
-    echo "Missing permissions to update Homebrew formulae!" >&2
-else
-    echo "${BOTTLE_NAME} - Updating HomeBrew repository"
-    brew update >/dev/null
-fi
-
 echo "${BOTTLE_NAME} - Finding bottle URL"
 BOTTLE_JSON=$(get_bottle_json "${BOTTLE_NAME}")
 BOTTLE_URL=$(echo "${BOTTLE_JSON}" | jq -r .url)


### PR DESCRIPTION
With these changes it will be easier to maintain, i.e. to add/remove bottles just modify the `BOTTLES :=` list.

`brew update` is removed from `scripts/fetch-brew-bottle.sh` and instead done
in an [order-only prerequisite](https://www.gnu.org/software/make/manual/html_node/Prerequisite-Types.html). This allows multiple bottles to be fetched in parallel (e.g. `make -j16`) without overlapping invocations of `brew update` (which can result in the script failing for one/more bottles).