### PR TITLE
fix(@desktop/contacts): Double validation for incorrect ENS name

### DIFF
--- a/ui/app/AppLayouts/Profile/Sections/ContactsContainer.qml
+++ b/ui/app/AppLayouts/Profile/Sections/ContactsContainer.qml
@@ -130,9 +130,7 @@ Item {
 
             function validate(value) {
                 if (!Utils.isChatKey(value) && !Utils.isValidETHNamePrefix(value)) {
-                    //% "Enter a valid chat key or ENS username"
-                    //% "Enter a valid chat key or ENS username"
-                    addContactModal.validationError = qsTrId("enter-a-valid-chat-key-or-ens-username");
+                    addContactModal.validationError = qsTr("Enter a valid chat key or ENS username");
                 } else if (profileModel.profile.pubKey === value) {
                     //% "You can't add yourself"
                     addContactModal.validationError = qsTrId("you-can-t-add-yourself");

--- a/ui/shared/ContactsListAndSearch.qml
+++ b/ui/shared/ContactsListAndSearch.qml
@@ -34,8 +34,7 @@ Item {
 
     function validate() {
         if (!Utils.isChatKey(chatKey.text) && !Utils.isValidETHNamePrefix(chatKey.text)) {
-            //% "Enter a valid chat key or ENS username"
-            root.validationError = "enter-a-valid-chat-key-or-ens-username";
+            root.validationError = qsTr("Enter a valid chat key or ENS username");
             pubKey = ""
             ensUsername = "";
         } else if (profileModel.profile.pubKey === chatKey.text) {


### PR DESCRIPTION
Fixes: #3422.

The string stored in the translation had been doubled-up, so when a validation error occurred, the doubled-up string appeared.

The fix removes the currently in use translation.