### PR TITLE
fix(@desktop/contacts): Keep only one contacts list

### DIFF
--- a/src/app/chat/event_handling.nim
+++ b/src/app/chat/event_handling.nim
@@ -42,7 +42,6 @@ proc handleChatEvents(self: ChatController) =
   self.status.events.on("chatUpdate") do(e: Args):
     var evArgs = ChatUpdateArgs(e)
     self.view.hideLoadingIndicator()
-    self.view.updateUsernames(evArgs.contacts)
     self.view.updateChats(evArgs.chats)
     self.view.pushMessages(evArgs.messages)
     self.view.pushMembers(evArgs.chats)

--- a/src/app/chat/view.nim
+++ b/src/app/chat/view.nim
@@ -217,8 +217,8 @@ QtObject:
     generateAlias(pubKey)
 
   proc userNameOrAlias*(self: ChatsView, pubKey: string): string {.slot.} =
-    if self.status.chat.contacts.hasKey(pubKey):
-      return status_ens.userNameOrAlias(self.status.chat.contacts[pubKey])
+    if self.status.chat.getContacts().hasKey(pubKey):
+      return status_ens.userNameOrAlias(self.status.chat.getContacts()[pubKey])
     generateAlias(pubKey)
 
   proc activityNotificationsChanged*(self: ChatsView) {.signal.}

--- a/src/app/chat/views/channel.nim
+++ b/src/app/chat/views/channel.nim
@@ -110,8 +110,8 @@ QtObject:
         self.chats.clearAllMentionsFromChannelWithId(channel.id)
 
   proc userNameOrAlias(self: ChannelView, pubKey: string): string =
-    if self.status.chat.contacts.hasKey(pubKey):
-      return status_ens.userNameOrAlias(self.status.chat.contacts[pubKey])
+    if self.status.chat.getContacts().hasKey(pubKey):
+      return status_ens.userNameOrAlias(self.status.chat.getContacts()[pubKey])
     generateAlias(pubKey)
 
   proc setActiveChannelByIndexWithForce*(self: ChannelView, index: int, forceUpdate: bool) {.slot.} =

--- a/src/app/chat/views/chat_item.nim
+++ b/src/app/chat/views/chat_item.nim
@@ -64,14 +64,14 @@ QtObject:
   proc contactsUpdated*(self: ChatItemView) {.signal}
 
   proc userNameOrAlias(self: ChatItemView, pubKey: string): string {.slot.} =
-    if self.status.chat.contacts.hasKey(pubKey):
-      return ens.userNameOrAlias(self.status.chat.contacts[pubKey])
+    if self.status.chat.getContacts().hasKey(pubKey):
+      return ens.userNameOrAlias(self.status.chat.getContacts()[pubKey])
     generateAlias(pubKey)
 
   proc name*(self: ChatItemView): string {.slot.} = 
     if self.chatItem != nil and self.chatItem.chatType.isOneToOne:
-      if self.status.chat.contacts.hasKey(self.chatItem.id) and self.status.chat.contacts[self.chatItem.id].hasNickname():
-        return self.status.chat.contacts[self.chatItem.id].localNickname
+      if self.status.chat.getContacts().hasKey(self.chatItem.id) and self.status.chat.getContacts()[self.chatItem.id].hasNickname():
+        return self.status.chat.getContacts()[self.chatItem.id].localNickname
       let username = self.userNameOrAlias(self.chatItem.id)
       if username != "":
         result = username.userName(true)      
@@ -87,8 +87,8 @@ QtObject:
 
   proc nickname*(self: ChatItemView): string {.slot.} = 
     if self.chatItem != nil and self.chatItem.chatType.isOneToOne:
-      if self.status.chat.contacts.hasKey(self.chatItem.id) and self.status.chat.contacts[self.chatItem.id].hasNickname():
-        return self.status.chat.contacts[self.chatItem.id].localNickname
+      if self.status.chat.getContacts().hasKey(self.chatItem.id) and self.status.chat.getContacts()[self.chatItem.id].hasNickname():
+        return self.status.chat.getContacts()[self.chatItem.id].localNickname
     result = ""
 
   QtProperty[string] nickname:
@@ -98,8 +98,8 @@ QtObject:
   proc ensVerified*(self: ChatItemView): bool {.slot.} = 
     if self.chatItem != nil and
       self.chatItem.chatType.isOneToOne and
-      self.status.chat.contacts.hasKey(self.chatItem.id):
-        return self.status.chat.contacts[self.chatItem.id].ensVerified
+      self.status.chat.getContacts().hasKey(self.chatItem.id):
+        return self.status.chat.getContacts()[self.chatItem.id].ensVerified
     result = false
 
   QtProperty[bool] ensVerified:
@@ -109,8 +109,8 @@ QtObject:
   proc alias*(self: ChatItemView): string {.slot.} = 
     if self.chatItem != nil and
       self.chatItem.chatType.isOneToOne and
-      self.status.chat.contacts.hasKey(self.chatItem.id):
-        return self.status.chat.contacts[self.chatItem.id].alias
+      self.status.chat.getContacts().hasKey(self.chatItem.id):
+        return self.status.chat.getContacts()[self.chatItem.id].alias
     result = ""
 
   QtProperty[string] alias:

--- a/src/app/chat/views/chat_members.nim
+++ b/src/app/chat/views/chat_members.nim
@@ -35,8 +35,8 @@ QtObject:
   method rowCount(self: ChatMembersView, index: QModelIndex = nil): int = self.members.len
 
   proc userName(self: ChatMembersView, id: string, alias: string): string =
-    if self.status.chat.contacts.hasKey(id):
-      result = ens.userNameOrAlias(self.status.chat.contacts[id])
+    if self.status.chat.getContacts().hasKey(id):
+      result = ens.userNameOrAlias(self.status.chat.getContacts()[id])
     else:
       result = alias
 

--- a/src/app/chat/views/community_members_list.nim
+++ b/src/app/chat/views/community_members_list.nim
@@ -55,29 +55,34 @@ QtObject:
     self.community.members.len
 
   proc userName(self: CommunityMembersView, pk: string, alias: string): string =
-    if self.status.chat.contacts.hasKey(pk):
-      if self.status.chat.contacts[pk].localNickname != "":
-        result = self.status.chat.contacts[pk].localNickname
+    let contacts = self.status.chat.getContacts()
+    if contacts.hasKey(pk):
+      if contacts[pk].localNickname != "":
+        result = contacts[pk].localNickname
       else:
-        result = ens.userNameOrAlias(self.status.chat.contacts[pk])
+        result = ens.userNameOrAlias(contacts[pk])
     else:
       result = alias
 
   proc identicon(self: CommunityMembersView, pk: string): string =
-    if self.status.chat.contacts.hasKey(pk):
-      result = self.status.chat.contacts[pk].identicon
+    let contacts = self.status.chat.getContacts()
+    if contacts.hasKey(pk):
+      result = contacts[pk].identicon
     else:
       result = self.status.accounts.generateIdenticon(pk)
 
   proc alias(self: CommunityMembersView, pk: string): string =
-    if self.status.chat.contacts.hasKey(pk):
-      result = self.status.chat.contacts[pk].alias
+    let contacts = self.status.chat.getContacts()
+    if contacts.hasKey(pk):
+      result = contacts[pk].alias
     else:
       result = self.status.accounts.generateAlias(pk)
 
   proc localNickname(self: CommunityMembersView, pk: string): string =
-    if self.status.chat.contacts.hasKey(pk):
-      result = self.status.chat.contacts[pk].localNickname
+    let contacts = self.status.chat.getContacts()
+
+    if contacts.hasKey(pk):
+      result = contacts[pk].localNickname
 
   proc memberLastSeen(self: CommunityMembersView, pk: string): string =
     if self.community.memberStatus.hasKey(pk):

--- a/src/app/chat/views/message_item.nim
+++ b/src/app/chat/views/message_item.nim
@@ -37,7 +37,7 @@ QtObject:
   QtProperty[string] userName:
     read = userName
 
-  proc message*(self: MessageItem): string {.slot.} = result = renderBlock(self.messageItem, self.status.chat.contacts)
+  proc message*(self: MessageItem): string {.slot.} = result = renderBlock(self.messageItem, self.status.chat.getContacts())
   QtProperty[string] message:
     read = message
 

--- a/src/app/chat/views/message_list.nim
+++ b/src/app/chat/views/message_list.nim
@@ -219,7 +219,7 @@ QtObject:
     let isEdited = if self.isEdited.hasKey(message.id): self.isEdited[message.id] else: false
     case chatMessageRole:
       of ChatMessageRoles.UserName: result = newQVariant(message.userName)
-      of ChatMessageRoles.Message: result = newQVariant(renderBlock(message, self.status.chat.contacts))
+      of ChatMessageRoles.Message: result = newQVariant(renderBlock(message, self.status.chat.getContacts()))
       of ChatMessageRoles.PlainText: result = newQVariant(message.text)
       of ChatMessageRoles.Timestamp: result = newQVariant(message.timestamp)
       of ChatMessageRoles.Clock: result = newQVariant($message.clock)
@@ -316,7 +316,7 @@ QtObject:
     of "alias": result = message.alias
     of "localName": result = message.localName
     of "ensName": result = message.ensName
-    of "message": result = (renderBlock(message, self.status.chat.contacts))
+    of "message": result = (renderBlock(message, self.status.chat.getContacts()))
     of "identicon": result = message.identicon
     of "timestamp": result = $(message.timestamp)
     of "image": result = $(message.image)

--- a/src/app/chat/views/user_list.nim
+++ b/src/app/chat/views/user_list.nim
@@ -97,11 +97,11 @@ QtObject:
       var identicon: string
       var localName: string
 
-      if self.status.chat.contacts.hasKey(pk):
-        userName = ens.userNameOrAlias(self.status.chat.contacts[pk])
-        alias = self.status.chat.contacts[pk].alias
-        identicon = self.status.chat.contacts[pk].identicon
-        localName = self.status.chat.contacts[pk].localNickname
+      if self.status.chat.getContacts().hasKey(pk):
+        userName = ens.userNameOrAlias(self.status.chat.getContacts()[pk])
+        alias = self.status.chat.getContacts()[pk].alias
+        identicon = self.status.chat.getContacts()[pk].identicon
+        localName = self.status.chat.getContacts()[pk].localNickname
       else:
         userName = m.username
         alias = m.username

--- a/src/app/profile/core.nim
+++ b/src/app/profile/core.nim
@@ -56,7 +56,6 @@ proc init*(self: ProfileController, account: Account) =
   profile.currentUserStatus = currentUserStatus
 
   let identityImage = self.status.profile.getIdentityImage(profile.address)
-
   if (identityImage.thumbnail != ""):
     profile.identityImage = identityImage
 
@@ -76,7 +75,6 @@ proc init*(self: ProfileController, account: Account) =
     self.view.mailservers.add(mailserver)
 
   let contacts = self.status.contacts.getContacts()
-  self.status.chat.updateContacts(contacts)
   self.view.contacts.setContactList(contacts)
 
   self.status.events.on("channelLoaded") do(e: Args):
@@ -129,8 +127,8 @@ proc init*(self: ProfileController, account: Account) =
     let msgData = MessageSignal(e);
     if msgData.contacts.len > 0:
       # TODO: view should react to model changes
-      self.view.contacts.updateContactList(msgData.contacts)
-      self.status.chat.updateContacts(msgData.contacts)
+      let contacts = self.status.contacts.getContacts(false)
+      self.view.contacts.updateContactList(contacts)
     if msgData.installations.len > 0:
       self.view.devices.addDevices(msgData.installations)
 

--- a/src/app/profile/view.nim
+++ b/src/app/profile/view.nim
@@ -81,6 +81,7 @@ QtObject:
 
   proc setNewProfile*(self: ProfileView, profile: Profile) =
     self.profile.setProfile(profile)
+    self.contacts.accountKeyUID = profile.address
     self.profileChanged()
 
   QtProperty[QVariant] profile:

--- a/src/app/profile/views/contacts.nim
+++ b/src/app/profile/views/contacts.nim
@@ -40,6 +40,7 @@ QtObject:
     addedContacts*: ContactList
     blockedContacts*: ContactList
     contactToAdd*: Profile
+    accountKeyUID*: string
 
   proc setup(self: ContactsView) =
     self.QObject.setup
@@ -198,7 +199,7 @@ QtObject:
   proc contactChanged(self: ContactsView, publicKey: string, isAdded: bool) {.signal.}
 
   proc addContact*(self: ContactsView, publicKey: string): string {.slot.} =
-    result = self.status.contacts.addContact(publicKey)
+    result = self.status.contacts.addContact(publicKey, self.accountKeyUID)
     self.status.chat.join(status_utils.getTimelineChatId(publicKey), ChatType.Profile, "", publicKey)
     self.contactChanged(publicKey, true)
 
@@ -219,7 +220,7 @@ QtObject:
     var nicknameToSet = nickname
     if (nicknameToSet == ""):
       nicknameToSet = DELETE_CONTACT
-    discard self.status.contacts.setNickName(publicKey, nicknameToSet)
+    discard self.status.contacts.setNickName(publicKey, nicknameToSet, self.accountKeyUID)
 
   proc unblockContact*(self: ContactsView, publicKey: string) {.slot.} =
     self.contactListChanged()


### PR DESCRIPTION
fixes #3485

see dependent PR: https://github.com/status-im/status-lib/pull/37

* correct handling of contacts events, we fetch them from the store and display them rather than having a third contact store not being sync with chat contacts and contacts