### PR TITLE
fix: block/unblock contacts not persisting

### DIFF
--- a/src/app/chat/core.nim
+++ b/src/app/chat/core.nim
@@ -71,6 +71,14 @@ proc init*(self: ChatController) =
       self.view.handleProtocolUri(self.uriToOpen)
       self.uriToOpen = ""
 
+  self.status.events.on("contactBlocked") do(e: Args):
+    let contactIdArgs = ContactIdArgs(e)
+    self.view.messageView.blockContact(contactIdArgs.id)
+
+  self.status.events.on("contactUnblocked") do(e: Args):
+    let contactIdArgs = ContactIdArgs(e)
+    self.view.messageView.unblockContact(contactIdArgs.id)
+
 proc loadInitialMessagesForChannel*(self: ChatController, channelId: string) =
   if (channelId.len == 0):
     info "empty channel id set for loading initial messages"

--- a/ui/app/AppLayouts/Chat/ChatColumn/ChatMessages.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/ChatMessages.qml
@@ -303,6 +303,7 @@ Item {
             pinnedBy: model.pinnedBy
             gapFrom: model.gapFrom
             gapTo: model.gapTo
+            visible: !model.hide
             Component.onCompleted: {
                 if ((root.countOnStartUp > 0) && (root.countOnStartUp - 1) < index) {
                     //new message, increment z order

--- a/ui/app/AppLayouts/Chat/ChatColumn/Message.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/Message.qml
@@ -10,7 +10,7 @@ Item {
     id: root
     width: parent.width
     anchors.right: !isCurrentUser ? undefined : parent.right
-    height: childrenRect.height
+    height: visible ? childrenRect.height : 0
     z: (typeof chatLogView === "undefined") ? 1 : (chatLogView.count - index)
     property string fromAuthor: "0x0011223344556677889910"
     property string userName: "Jotaro Kujo"


### PR DESCRIPTION
Fixes: #3473.

Sometimes when blocking users and changes channels, blocked user messages would still appear.

This PR fixes the issue by toggling a `hide` property on  messages from a contact when that contact is blocked or unblocked. Previously, the messages were only removed from the view when the contact was blocked, but when the view was reloaded, that state was not tracked correctly.