### PR TITLE
fix(@desktop/chat): channel links sends to main public channel instead of a channel in that community

### DIFF
--- a/src/app/chat/view.nim
+++ b/src/app/chat/view.nim
@@ -293,11 +293,12 @@ QtObject:
   proc getLinkPreviewData*(self: ChatsView, link: string, uuid: string) {.slot.} =
     self.getLinkPreviewData("linkPreviewDataReceived", link, uuid)
 
-  proc getChatType*(self: ChatsView, channel: string): int {.slot.} =
+  proc getChannel*(self: ChatsView, channel: string): string {.slot.} =
     let selectedChannel = self.channelView.getChannelById(channel)
     if selectedChannel == nil:
-      return -1
-    selectedChannel.chatType.int
+      return ""
+
+    result = Json.encode(selectedChannel.toJsonNode())
 
   proc asyncActivityNotificationLoad*(self: ChatsView) {.slot.} =
     self.asyncActivityNotificationLoad("asyncActivityNotificationLoaded")

--- a/src/app/chat/views/channel.nim
+++ b/src/app/chat/views/channel.nim
@@ -49,9 +49,8 @@ QtObject:
     let index = self.communities.activeCommunity.chats.chats.findIndexById(channel)
     if (index > -1):
       return self.communities.activeCommunity.chats.getChannel(index)
-    let chan = self.communities.activeCommunity.chats.getChannelByName(channel)
-    if not chan.isNil:
-      return chan
+
+    return self.communities.activeCommunity.chats.getChannelByName(channel)
 
   proc getChannelById*(self: ChannelView, channel: string): Chat =
     if self.communities.activeCommunity.active:

--- a/src/app/chat/views/channels_list.nim
+++ b/src/app/chat/views/channels_list.nim
@@ -125,7 +125,7 @@ QtObject:
 
   proc getChannel*(self: ChannelsList, index: int): Chat = 
     if index < 0 or index >= self.chats.len:
-      return
+      return nil
 
     result = self.chats[index]
 
@@ -145,6 +145,8 @@ QtObject:
     for chat in self.chats:
       if chat.name == name:
         return chat
+
+    return nil
 
   proc upsertChannel(self: ChannelsList, channel: Chat): int =
     let idx = self.chats.findIndexById(channel.id)

--- a/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/ChatText.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/ChatText.qml
@@ -44,21 +44,40 @@ Item {
         onLinkActivated: {
             if(link.startsWith("#")) {
                 const channelName = link.substring(1);
-                const chatType = chatsModel.communities.activeCommunity.active ? Constants.chatTypeCommunity : Constants.chatTypePublic;
-                const foundChatType = chatsModel.getChatType(channelName);
+                const foundChannelObj = chatsModel.getChannel(channelName);
 
-                if(foundChatType === -1 || foundChatType !== Constants.chatTypePublic){
-                    chatsModel.channelView.joinPublicChat(channelName);
-                    if(chatsModel.communities.activeCommunity.active) {
-                        chatsModel.communities.activeCommunity.active = false
+                if (!foundChannelObj)
+                {
+                    chatsModel.channelView.joinPublicChat(channelName)
+                    if(chatsModel.communities.activeCommunity.active)
+                    {
+                        chatsModel.channelView.joinPublicChat(channelName)
                         appMain.changeAppSection(Constants.chat)
-                    } 
-                } else {
-                    appMain.changeAppSection(Constants.chat)
+                    }
+                    return
+                }
+
+                let obj = JSON.parse(foundChannelObj)
+
+                if(obj.chatType === -1 || obj.chatType === Constants.chatTypePublic)
+                {
+                    if(chatsModel.communities.activeCommunity.active)
+                    {
+                        chatsModel.channelView.joinPublicChat(channelName)
+                        appMain.changeAppSection(Constants.chat)
+                    }
+
+                    chatsModel.channelView.setActiveChannel(channelName);
+                }
+                else if(obj.communityId === chatsModel.communities.activeCommunity.id &&
+                        obj.chatType === Constants.chatTypeCommunity &&
+                        chatsModel.channelView.activeChannel.id !== obj.id
+                        )
+                {
                     chatsModel.channelView.setActiveChannel(channelName);
                 }
 
-                return;
+                return
             }
 
             if (link.startsWith('//')) {


### PR DESCRIPTION
PR: `status-lib` [here](https://github.com/status-im/status-lib/pull/42)

In case clicked channel:
- exists in a community -> the app will switch you to it
- doesn't exist in a community, but exists in the public chat list -> the app
  will switch to `Chat` section and also to the appropriate channel there
- doesn't exist in a community and doesn't exist in the public chat list -> the app
  will switch to `Chat` section and join new channel

Fixes: #3489