### PR TITLE
fix(chat): Re-position “resend” link

### DIFF
--- a/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/CompactMessage.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/CompactMessage.qml
@@ -470,9 +470,9 @@ Item {
             id: retry
             anchors.left: chatTime.visible ? chatTime.right : messageContent.left
             anchors.leftMargin: chatTime.visible ? chatHorizontalPadding : 0
-            anchors.top: chatTime.visible ? undefined : messageContent.bottom
+            anchors.top: chatTime.visible ? chatTime.top : messageContent.bottom
             anchors.topMargin: chatTime.visible ? 0 : -4
-            anchors.verticalCenter: chatTime.visible ? chatTime.verticalCenter : undefined
+            anchors.bottom: chatTime.visible ? chatTime.bottom : undefined
         }
     }
 


### PR DESCRIPTION
Fixes #3606.

The “resend” link for failed messages was not aligned correctly in the light theme. This was due to setting the `verticalCenter` as well as `anchors.top` in some situations. `verticalCenter` has been removed in favour of setting the top and bottom anchors.