### PR TITLE
fix(@desktop/profile): Fix loading the correct settings

### DIFF
--- a/src/app/login/view.nim
+++ b/src/app/login/view.nim
@@ -62,7 +62,6 @@ QtObject:
       keyUid: currNodeAcct.keyUid,
       identityImage: currNodeAcct.identityImage
     ))
-    self.status.events.emit("currentAccountUpdated", AccountArgs(account: currNodeAcct))
 
   QtProperty[QVariant] currentAccount:
     read = getCurrentAccount

--- a/src/app/login/view.nim
+++ b/src/app/login/view.nim
@@ -63,6 +63,8 @@ QtObject:
       identityImage: currNodeAcct.identityImage
     ))
 
+    self.status.events.emit("accountChanged", AccountArgs(account: currNodeAcct))
+
   QtProperty[QVariant] currentAccount:
     read = getCurrentAccount
     write = setCurrentAccount
@@ -172,7 +174,7 @@ QtObject:
       self.keychainManager.storeDataAsync(username, password)
 
   proc tryToObtainPassword*(self: LoginView) {.slot.} =
-    let value = self.appService.localSettingsService.getValue(
+    let value = self.appService.localSettingsService.getAccountValue(
       LS_KEY_STORE_TO_KEYCHAIN).stringVal
     if (value == LS_VALUE_STORE):
       self.keychainManager.readDataAsync(self.currentAccount.username)
@@ -189,7 +191,7 @@ QtObject:
       return
 
     # We are notifying user only about keychain errors. 
-    self.appService.localSettingsService.removeValue(LS_KEY_STORE_TO_KEYCHAIN)
+    self.appService.localSettingsService.removeAccountValue(LS_KEY_STORE_TO_KEYCHAIN)
     self.obtainingPasswordError(errorDescription)
 
   proc onKeychainManagerSuccess*(self: LoginView, data: string) {.slot.} =

--- a/src/app/onboarding/view.nim
+++ b/src/app/onboarding/view.nim
@@ -100,10 +100,7 @@ QtObject:
     result = self.status.wallet.validateMnemonic(mnemonic.strip())
 
   proc storeDerivedAndLogin(self: OnboardingView, password: string): string {.slot.} =
-    # In this moment we're sure that new account will be logged in, and emit signal.
     let genAcc = self.currentAccount.account
-    let acc = Account(name: genAcc.name, keyUid: genAcc.keyUid, identicon: genAcc.identicon, identityImage: genAcc.identityImage)
-    self.status.events.emit("currentAccountUpdated", status_account_type.AccountArgs(account: acc))
 
     try:
       result = self.status.accounts.storeDerivedAndLogin(self.status.fleet.config, genAcc, password).toJson

--- a/src/app/onboarding/view.nim
+++ b/src/app/onboarding/view.nim
@@ -4,6 +4,8 @@ import status/[status, wallet]
 import status/types/[rpc_response]
 import status/types/account as status_account_type
 import views/account_info
+import ../../app_service/[main]
+
 
 type
   AccountRoles {.pure.} = enum
@@ -101,6 +103,8 @@ QtObject:
 
   proc storeDerivedAndLogin(self: OnboardingView, password: string): string {.slot.} =
     let genAcc = self.currentAccount.account
+    let acc = Account(name: genAcc.name, keyUid: genAcc.keyUid, identicon: genAcc.identicon, identityImage: genAcc.identityImage)
+    self.status.events.emit("accountChanged", status_account_type.AccountArgs(account: acc))
 
     try:
       result = self.status.accounts.storeDerivedAndLogin(self.status.fleet.config, genAcc, password).toJson

--- a/src/app/profile/core.nim
+++ b/src/app/profile/core.nim
@@ -35,9 +35,6 @@ proc delete*(self: ProfileController) =
   delete self.variant
   delete self.view
 
-proc setSettingsFile*(self: ProfileController, username: string) =
-  self.view.setSettingsFile(username)
-
 proc init*(self: ProfileController, account: Account) =
   let profile = account.toProfileModel()
 
@@ -62,6 +59,7 @@ proc init*(self: ProfileController, account: Account) =
   self.view.devices.addDevices(status_devices.getAllDevices())
   self.view.devices.setDeviceSetup(status_devices.isDeviceSetup())
   self.view.setNewProfile(profile)
+  self.view.setSettingsFile(profile.id)
   self.view.network.setNetwork(network)
   self.view.ens.init()
   self.view.initialized()

--- a/src/app/profile/view.nim
+++ b/src/app/profile/view.nim
@@ -184,23 +184,6 @@ QtObject:
   QtProperty[QVariant] picture:
     read = getProfilePicture
 
-  proc settingsFileChanged*(self: ProfileView) {.signal.}
-  
-  proc getSettingsFile*(self: ProfileView): string {.slot.} =
-    self.appService.localSettingsService.getSettingsFilePath
-  
-  proc setSettingsFile*(self: ProfileView, username: string) =
-    if(username.len == 0 or
-      self.appService.localSettingsService.getSettingsFilePath.endsWith(username)):
-      return
-
-    self.appService.localSettingsService.updateSettingsFilePath(username)
-    self.settingsFileChanged()
-
-  QtProperty[string] settingsFile:
-    read = getSettingsFile
-    notify = settingsFileChanged
-
   proc getGlobalSettingsFile*(self: ProfileView): string {.slot.} =
     self.appService.localSettingsService.getGlobalSettingsFilePath
 
@@ -212,6 +195,19 @@ QtObject:
 
   QtProperty[QVariant] mutedChats:
     read = getMutedChats
+
+  proc settingsFileChanged*(self: ProfileView) {.signal.}
+  
+  proc getSettingsFile*(self: ProfileView): string {.slot.} =
+    self.appService.localSettingsService.getSettingsFilePath
+  
+  proc setSettingsFile*(self: ProfileView, pubKey: string) =
+    self.appService.localSettingsService.updateSettingsFilePath(pubKey)
+    self.settingsFileChanged()
+
+  QtProperty[string] settingsFile:
+    read = getSettingsFile
+    notify = settingsFileChanged
 
   proc setSendUserStatus*(self: ProfileView, sendUserStatus: bool) {.slot.} =
     if (sendUserStatus == self.profile.sendUserStatus):

--- a/src/app/profile/view.nim
+++ b/src/app/profile/view.nim
@@ -209,6 +209,19 @@ QtObject:
     read = getSettingsFile
     notify = settingsFileChanged
 
+  proc accountSettingsFileChanged*(self: ProfileView) {.signal.}
+
+  proc setAccountSettingsFile*(self: ProfileView, alias: string) =
+    self.appService.localSettingsService.updateAccountSettingsFilePath(alias)
+    self.accountSettingsFileChanged()
+
+  proc getAccountSettingsFile*(self: ProfileView): string {.slot.} =
+    self.appService.localSettingsService.getAccountSettingsFilePath
+
+  QtProperty[string] accountSettingsFile:
+    read = getAccountSettingsFile
+    notify = accountSettingsFileChanged
+
   proc setSendUserStatus*(self: ProfileView, sendUserStatus: bool) {.slot.} =
     if (sendUserStatus == self.profile.sendUserStatus):
       return

--- a/src/app_service/service/local_settings/service.nim
+++ b/src/app_service/service/local_settings/service.nim
@@ -1,12 +1,13 @@
 import NimQml, os, chronicles
 import ../../../constants
 
-# Local Settings keys:
+# Local Account Settings keys:
 const LS_KEY_STORE_TO_KEYCHAIN* = "storeToKeychain"
-# Local Settings values:
+# Local Account Settings values:
 const LS_VALUE_STORE* = "store"
 
 const UNKNOWN_ACCOUNT = "unknownAccount"
+const UNKNOWN_PROFILE = "unknownProfile"
 
 logScope:
   topics = "local-settings"
@@ -15,12 +16,16 @@ QtObject:
   type LocalSettingsService* = ref object of QObject
     settingsFilePath: string
     settings: QSettings
+    accountSettingsFilePath: string
+    accountSettings: QSettings
     globalSettingsFilePath: string
     globalSettings: QSettings
     
   proc setup(self: LocalSettingsService) =
-    self.settingsFilePath = os.joinPath(DATADIR, "qt", UNKNOWN_ACCOUNT)
+    self.settingsFilePath = os.joinPath(DATADIR, "qt", UNKNOWN_PROFILE)
     self.settings = newQSettings(self.settingsFilePath, QSettingsFormat.IniFormat)
+    self.accountSettingsFilePath = os.joinPath(DATADIR, "qt", UNKNOWN_ACCOUNT)
+    self.accountSettings = newQSettings(self.accountSettingsFilePath, QSettingsFormat.IniFormat)
     self.globalSettingsFilePath = os.joinPath(DATADIR, "qt", "global")
     self.globalSettings = newQSettings(self.globalSettingsFilePath, QSettingsFormat.IniFormat)
     self.QObject.setup
@@ -37,11 +42,14 @@ QtObject:
   proc getGlobalSettingsFilePath*(self: LocalSettingsService): string =
     return self.globalSettingsFilePath
 
+  proc getAccountSettingsFilePath*(self: LocalSettingsService): string =
+    return self.accountSettingsFilePath
+
   proc getSettingsFilePath*(self: LocalSettingsService): string =
     return self.settingsFilePath
 
   proc updateSettingsFilePath*(self: LocalSettingsService, pubKey: string) =
-    let unknownSettingsPath = os.joinPath(DATADIR, "qt", UNKNOWN_ACCOUNT)
+    let unknownSettingsPath = os.joinPath(DATADIR, "qt", UNKNOWN_PROFILE)
     if (not unknownSettingsPath.tryRemoveFile):
       # Only fails if the file exists and an there was an error removing it
       # More info: https://nim-lang.org/docs/os.html#tryRemoveFile%2Cstring
@@ -50,6 +58,27 @@ QtObject:
     self.settings.delete
     self.settingsFilePath = os.joinPath(DATADIR, "qt", pubKey)
     self.settings = newQSettings(self.settingsFilePath, QSettingsFormat.IniFormat)
+
+  proc updateAccountSettingsFilePath*(self: LocalSettingsService, alias: string) =
+    let unknownAccountSettingsPath = os.joinPath(DATADIR, "qt", UNKNOWN_ACCOUNT)
+    if (not unknownAccountSettingsPath.tryRemoveFile):
+      # Only fails if the file exists and an there was an error removing it
+      # More info: https://nim-lang.org/docs/os.html#tryRemoveFile%2Cstring
+      warn "Failed to remove unused settings file", file=unknownAccountSettingsPath
+
+    self.accountSettings.delete
+    self.accountSettingsFilePath = os.joinPath(DATADIR, "qt", alias)
+    self.accountSettings = newQSettings(self.accountSettingsFilePath, QSettingsFormat.IniFormat)
+
+  proc setAccountValue*(self: LocalSettingsService, key: string, value: QVariant) =
+    self.accountSettings.setValue(key, value)
+
+  proc getAccountValue*(self: LocalSettingsService, key: string, 
+    defaultValue: QVariant = newQVariant()): QVariant =
+    self.accountSettings.value(key, defaultValue)
+
+  proc removeAccountValue*(self: LocalSettingsService, key: string) =
+    self.accountSettings.remove(key)
 
   proc setValue*(self: LocalSettingsService, key: string, value: QVariant) =
     self.settings.setValue(key, value)

--- a/src/app_service/service/local_settings/service.nim
+++ b/src/app_service/service/local_settings/service.nim
@@ -40,17 +40,16 @@ QtObject:
   proc getSettingsFilePath*(self: LocalSettingsService): string =
     return self.settingsFilePath
 
-  proc updateSettingsFilePath*(self: LocalSettingsService, username: string) =
-    if (username.len > 0):
-      let unknownSettingsPath = os.joinPath(DATADIR, "qt", UNKNOWN_ACCOUNT)
-      if (not unknownSettingsPath.tryRemoveFile):
-        # Only fails if the file exists and an there was an error removing it
-        # More info: https://nim-lang.org/docs/os.html#tryRemoveFile%2Cstring
-        warn "Failed to remove unused settings file", file=unknownSettingsPath
+  proc updateSettingsFilePath*(self: LocalSettingsService, pubKey: string) =
+    let unknownSettingsPath = os.joinPath(DATADIR, "qt", UNKNOWN_ACCOUNT)
+    if (not unknownSettingsPath.tryRemoveFile):
+      # Only fails if the file exists and an there was an error removing it
+      # More info: https://nim-lang.org/docs/os.html#tryRemoveFile%2Cstring
+      warn "Failed to remove unused settings file", file=unknownSettingsPath
 
-      self.settings.delete
-      self.settingsFilePath = os.joinPath(DATADIR, "qt", username)
-      self.settings = newQSettings(self.settingsFilePath, QSettingsFormat.IniFormat)
+    self.settings.delete
+    self.settingsFilePath = os.joinPath(DATADIR, "qt", pubKey)
+    self.settings = newQSettings(self.settingsFilePath, QSettingsFormat.IniFormat)
 
   proc setValue*(self: LocalSettingsService, key: string, value: QVariant) =
     self.settings.setValue(key, value)

--- a/src/nim_status_client.nim
+++ b/src/nim_status_client.nim
@@ -193,7 +193,6 @@ proc mainProc() =
 
   status.events.once("login") do(a: Args):
     var args = AccountArgs(a)
-
     appService.onLoggedIn()
 
     # Reset login and onboarding to remove any mnemonic that would have been saved in the accounts list
@@ -204,17 +203,9 @@ proc mainProc() =
     onboarding.moveToAppState()
     status.events.emit("loginCompleted", args)
 
-  proc updateProfileSettings(account: Account) =
-    profile.setSettingsFile(account.name)
-
-  status.events.on("currentAccountUpdated") do(a: Args):
-    var args = AccountArgs(a)
-    updateProfileSettings(args.account)
-
   status.events.once("loginCompleted") do(a: Args):
     var args = AccountArgs(a)
     
-    updateProfileSettings(args.account)
     status.startMessenger()
     profile.init(args.account)
     wallet.init()

--- a/src/nim_status_client.nim
+++ b/src/nim_status_client.nim
@@ -7,6 +7,7 @@ import app/node/core as node
 import app/utilsView/core as utilsView
 import app/browser/core as browserView
 import app/profile/core as profile
+import app/profile/view
 import app/onboarding/core as onboarding
 import app/login/core as login
 import app/provider/core as provider
@@ -191,6 +192,13 @@ proc mainProc() =
   var onboarding = onboarding.newController(status)
   defer: onboarding.delete()
 
+  proc onAccountChanged(account: Account) =
+    profile.view.setAccountSettingsFile(account.name)
+
+  status.events.on("accountChanged") do(a: Args):
+    var args = AccountArgs(a)
+    onAccountChanged(args.account)
+
   status.events.once("login") do(a: Args):
     var args = AccountArgs(a)
     appService.onLoggedIn()
@@ -205,7 +213,8 @@ proc mainProc() =
 
   status.events.once("loginCompleted") do(a: Args):
     var args = AccountArgs(a)
-    
+
+    onAccountChanged(args.account)
     status.startMessenger()
     profile.init(args.account)
     wallet.init()

--- a/ui/app/AppLayouts/Profile/Sections/PrivacyContainer.qml
+++ b/ui/app/AppLayouts/Profile/Sections/PrivacyContainer.qml
@@ -50,7 +50,7 @@ Item {
             text: qsTr("Store pass to Keychain")
             visible: Qt.platform.os == "osx" // For now, this is available only on MacOS
             currentValue: {
-                let value = appSettings.storeToKeychain
+                let value = accountSettings.storeToKeychain
                 if(value == Constants.storeToKeychainValueStore)
                     return qsTr("Store")
 

--- a/ui/app/AppLayouts/Profile/Sections/StoreToKeychainSelectionModal.qml
+++ b/ui/app/AppLayouts/Profile/Sections/StoreToKeychainSelectionModal.qml
@@ -30,18 +30,18 @@ ModalPopup {
         StatusRadioButtonRow {
             text: qsTr("Store")
             buttonGroup: openLinksWithGroup
-            checked: appSettings.storeToKeychain === Constants.storeToKeychainValueStore
+            checked: accountSettings.storeToKeychain === Constants.storeToKeychainValueStore
             onRadioCheckedChanged: {
-                if (checked && appSettings.storeToKeychain !== Constants.storeToKeychainValueStore) {
+                if (checked && accountSettings.storeToKeychain !== Constants.storeToKeychainValueStore) {
                     var storePassPopup = openPopup(storePasswordModal)
                     if(storePassPopup)
                     {
                         storePassPopup.closed.connect(function(){
-                            if (appSettings.storeToKeychain === Constants.storeToKeychainValueStore)
+                            if (accountSettings.storeToKeychain === Constants.storeToKeychainValueStore)
                                 popup.close()
-                            else if (appSettings.storeToKeychain === Constants.storeToKeychainValueNotNow)
+                            else if (accountSettings.storeToKeychain === Constants.storeToKeychainValueNotNow)
                                 notNowBtn.checked = true
-                            else if (appSettings.storeToKeychain === Constants.storeToKeychainValueNever)
+                            else if (accountSettings.storeToKeychain === Constants.storeToKeychainValueNever)
                                 neverBtn.checked = true
                         })
                     }
@@ -53,11 +53,11 @@ ModalPopup {
             id: notNowBtn
             text: qsTr("Not now")
             buttonGroup: openLinksWithGroup
-            checked: appSettings.storeToKeychain === Constants.storeToKeychainValueNotNow ||
-                     appSettings.storeToKeychain === ""
+            checked: accountSettings.storeToKeychain === Constants.storeToKeychainValueNotNow ||
+                     accountSettings.storeToKeychain === ""
             onRadioCheckedChanged: {
                 if (checked) {
-                    appSettings.storeToKeychain = Constants.storeToKeychainValueNotNow
+                    accountSettings.storeToKeychain = Constants.storeToKeychainValueNotNow
                 }
             }
         }
@@ -66,10 +66,10 @@ ModalPopup {
             id: neverBtn
             text: qsTr("Never")
             buttonGroup: openLinksWithGroup
-            checked: appSettings.storeToKeychain === Constants.storeToKeychainValueNever
+            checked: accountSettings.storeToKeychain === Constants.storeToKeychainValueNever
             onRadioCheckedChanged: {
                 if (checked) {
-                    appSettings.storeToKeychain = Constants.storeToKeychainValueNever
+                    accountSettings.storeToKeychain = Constants.storeToKeychainValueNever
                 }
             }
         }

--- a/ui/main.qml
+++ b/ui/main.qml
@@ -39,9 +39,15 @@ StatusWindow {
     }
 
     Settings {
+        id: accountSettings
+        fileName: profileModel.accountSettingsFile
+
+        property string storeToKeychain: ""
+    }
+
+    Settings {
         id: appSettings
         fileName: profileModel.settingsFile
-        property string storeToKeychain: ""
 
         property var chatSplitView
         property var walletSplitView
@@ -284,11 +290,11 @@ StatusWindow {
         {
             if(clearStoredValue)
             {
-                appSettings.storeToKeychain = ""
+                accountSettings.storeToKeychain = ""
             }
 
-            if(appSettings.storeToKeychain === "" ||
-               appSettings.storeToKeychain === Constants.storeToKeychainValueNotNow)
+            if(accountSettings.storeToKeychain === "" ||
+               accountSettings.storeToKeychain === Constants.storeToKeychainValueNotNow)
             {
                 storeToKeychainConfirmationPopup.password = password
                 storeToKeychainConfirmationPopup.username = username
@@ -317,18 +323,18 @@ StatusWindow {
         }
 
         onConfirmButtonClicked: {
-            appSettings.storeToKeychain = Constants.storeToKeychainValueStore
+            accountSettings.storeToKeychain = Constants.storeToKeychainValueStore
             loginModel.storePassword(username, password)
             finish()
         }
 
         onRejectButtonClicked: {
-            appSettings.storeToKeychain = Constants.storeToKeychainValueNotNow
+            accountSettings.storeToKeychain = Constants.storeToKeychainValueNotNow
             finish()
         }
 
         onCancelButtonClicked: {
-            appSettings.storeToKeychain = Constants.storeToKeychainValueNever
+            accountSettings.storeToKeychain = Constants.storeToKeychainValueNever
             finish()
         }
     }

--- a/ui/onboarding/CreatePasswordModal.qml
+++ b/ui/onboarding/CreatePasswordModal.qml
@@ -157,7 +157,7 @@ ModalPopup {
             onClicked: {
                 if (storingPasswordModal)
                 {
-                    appSettings.storeToKeychain = Constants.storeToKeychainValueStore
+                    accountSettings.storeToKeychain = Constants.storeToKeychainValueStore
                     loginModel.storePassword(profileModel.profile.username, repeatPasswordField.text)
                     popup.close()
                 }

--- a/ui/onboarding/Login.qml
+++ b/ui/onboarding/Login.qml
@@ -33,7 +33,7 @@ Item {
     }
 
     function resetLogin() {
-        if(appSettings.storeToKeychain === Constants.storeToKeychainValueStore)
+        if(accountSettings.storeToKeychain === Constants.storeToKeychainValueStore)
         {
             connection.enabled = true
             txtPassword.visible = false


### PR DESCRIPTION
Since https://github.com/status-im/status-desktop/commit/e0c53b7012354023e367c33093598f7523063aa6 settings where loaded
according to the username while they should be loaded after the public
key

As the public key is only available once the login happened, it needs
to be set when the profile is being initialized

fixes #3624 