### PR TITLE
fix(desktop/membersList) hide scrollbar when inactive

### DIFF
--- a/ui/app/AppLayouts/Chat/ChatColumn/UserList.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/UserList.qml
@@ -37,7 +37,9 @@ Item {
     ListView {
         id: userListView
         clip: true
-        ScrollBar.vertical: ScrollBar { }
+        ScrollBar.vertical: ScrollBar {
+            policy: ScrollBar.AsNeeded
+        }
         anchors {
             left: parent.left
             top: titleText.bottom

--- a/ui/app/AppLayouts/Chat/CommunityComponents/CommunityUserList.qml
+++ b/ui/app/AppLayouts/Chat/CommunityComponents/CommunityUserList.qml
@@ -39,7 +39,9 @@ Item {
     ListView {
         id: userListView
         clip: true
-        ScrollBar.vertical: ScrollBar { }
+        ScrollBar.vertical: ScrollBar {
+            policy: ScrollBar.AsNeeded
+        }
         anchors {
             top: titleText.bottom
             topMargin: Style.current.padding


### PR DESCRIPTION
The scrollbar should only be visible when scrolling
through the members list

Closes #3557