### PR TITLE
fix(desktop/chatInput) mentions were misused

### DIFF
--- a/ui/app/AppLayouts/Chat/ChatColumn/SuggestionBox.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/SuggestionBox.qml
@@ -59,6 +59,7 @@ Rectangle {
 
     function hide() {
         shouldHide = true
+        formattedPlainTextFilter = "";
     }
 
     function selectCurrentItem() {


### PR DESCRIPTION
formattedPlainTextFilter was not reset when suggestion
box was closed causing the insertMention function to be
called again even thought there was no mention in the
chat input

Closes #3535