### PR TITLE
fix: message history issues

### DIFF
--- a/src/app/chat/event_handling.nim
+++ b/src/app/chat/event_handling.nim
@@ -199,6 +199,7 @@ proc handleMailserverEvents(self: ChatController) =
     )
     mailserverWorker.start(task)
   self.status.events.on("mailserverAvailable") do(e:Args):
+    self.view.messageView.setLoadingMessages(true)
     let task = RequestMessagesTaskArg(
       `method`: "requestMessages",
       vptr: cast[ByteAddress](self.view.vptr),

--- a/src/app_service/tasks/marathon/mailserver/model.nim
+++ b/src/app_service/tasks/marathon/mailserver/model.nim
@@ -122,7 +122,7 @@ proc peerSummaryChange*(self: MailserverModel, peers: seq[string]) =
 
   var mailserverAvailable = false
   for knownPeer in self.nodes.keys:
-    if not peers.contains(knownPeer) and self.nodes[knownPeer] != MailserverStatus.Disconnected: 
+    if not peers.contains(knownPeer) and (self.nodes[knownPeer] == MailserverStatus.Connected or (self.nodes[knownPeer] == MailserverStatus.Connecting and (cpuTime() - self.lastConnectionAttempt) > 8)): 
       info "Peer disconnected", peer=knownPeer
       self.nodes[knownPeer] = MailserverStatus.Disconnected
       self.events.emit("peerDisconnected", MailserverArgs(peer: knownPeer))


### PR DESCRIPTION
- Display loading indicator on login when mailserver messages are requested
- Fix bug where the mailserver that's selected as soon as you login is disconnected while being still in the process of connecting instead of waiting until 10s have passed to try connecting to a different mailserver
- Use status-go version that fixes an issue fetching mailserver messages when more than 999 messages are being verified if they're in the cache