### PR TITLE
fix(@desktop/settings): Navbar icon shows a profile icon instead of settings icon

### DIFF
--- a/ui/app/AppMain.qml
+++ b/ui/app/AppMain.qml
@@ -411,7 +411,7 @@ Item {
                     id: profileBtn
                     //% "Settings"
                     tooltip.text: qsTrId("settings")
-                    icon.name: "profile"
+                    icon.name: "settings"
                     checked: appView.currentIndex == Utils.getAppSectionIndex(Constants.profile)
                     onClicked: appMain.changeAppSection(Constants.profile)
 


### PR DESCRIPTION
fix(@desktop/settings): Navbar icon shows a profile icon instead of settings icon

fixes #3615