### PR TITLE
fix(chat): GIF widget UI bugs

### DIFF
--- a/ui/shared/status/StatusGifPopup.qml
+++ b/ui/shared/status/StatusGifPopup.qml
@@ -312,15 +312,22 @@ Popup {
             ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
 
             Row {
+                id: gifs
                 anchors.horizontalCenter: parent.horizontalCenter
                 anchors.verticalCenter: parent.verticalCenter
                 spacing: Style.current.halfPadding
+
+                property string lastHoveredId
 
                 StatusGifColumn {
                     gifList.model: chatsModel.gif.columnA
                     gifWidth: (popup.width / 3) - Style.current.padding
                     gifSelected: popup.gifSelected
                     toggleFavorite: popup.toggleFavorite
+                    lastHoveredId: gifs.lastHoveredId
+                    onGifHovered: {
+                        gifs.lastHoveredId = id
+                    }
                 }
 
                 StatusGifColumn {
@@ -328,6 +335,10 @@ Popup {
                     gifWidth: (popup.width / 3) - Style.current.padding
                     gifSelected: popup.gifSelected
                     toggleFavorite: popup.toggleFavorite
+                    lastHoveredId: gifs.lastHoveredId
+                    onGifHovered: {
+                        gifs.lastHoveredId = id
+                    }
                 }
 
                 StatusGifColumn {
@@ -335,6 +346,10 @@ Popup {
                     gifWidth: (popup.width / 3) - Style.current.padding
                     gifSelected: popup.gifSelected
                     toggleFavorite: popup.toggleFavorite
+                    lastHoveredId: gifs.lastHoveredId
+                    onGifHovered: {
+                        gifs.lastHoveredId = id
+                    }
                 }
             }
 


### PR DESCRIPTION
Fixes: #3564.

Several UI bug fixes have been made for the gif widget:

1. Star now only appears once the gif is hovered
2. Default hover star colour is “grey”
3. Once the star is hovered, the star turns yellow
4. If the gif is favourited, the star fills in yellow
5. Removed square border around the gif
6. Added invisible padding around the star to increase the mouse surface area for hover/click
7. Added tooltip to the star for adding/removing from favourites

### Notes
1. An initial attempt at changing star state based on gif thumb hover and star hover proved unsuccessful. Changing visibility of the star had to depend on both the hover state of the thumb AND the star — relying on only the thumb hover caused a flicker.
2. Relying on the local hover state of the star and the thumb hover state caused inconsistencies where the hover state of the star would become true after not being hovered. I’m still unsure as to why this was happening. A workaround was to create a signal to a HOC as to the last hovered gif id. From there, we could rely on matching `model.id` to the last hovered gif id in the HOC.

### Dependencies
1. https://github.com/status-im/StatusQ/pull/422