### PR TITLE
fix(@desktop/wallet): emit wallet2 event

### DIFF
--- a/src/app/wallet/v2/core.nim
+++ b/src/app/wallet/v2/core.nim
@@ -40,15 +40,15 @@ proc init*(self: WalletController) =
   for account in accounts:
     self.view.addAccountToList(account)
 
-  self.status.events.on("accountsUpdated") do(e: Args):
+  self.status.events.on("wallet2_accountsUpdated") do(e: Args):
     self.view.updateView()
 
-  self.status.events.on("newAccountAdded") do(e: Args):
+  self.status.events.on("wallet2_newAccountAdded") do(e: Args):
     var account = WalletTypes.AccountArgs(e)
     self.view.addAccountToList(account.account)
     self.view.updateView()
 
-  self.status.events.on("cryptoServicesFetched") do(e: Args):
+  self.status.events.on("wallet2_cryptoServicesFetched") do(e: Args):
     var args = CryptoServicesArg(e)
     self.view.onCryptoServicesFetched(args.services)
 


### PR DESCRIPTION
fixes #3659
fixes #3646

Wallet2 needs its own event otherwise wallet1/2 event mixes
and as not everything is implemented in wallet2, it crashes
In this particular case, the account is added into wallet1 but trigger
an event intercepted by wallet2, wallet2 doesn't have the new account
and crash

status-lib PR: https://github.com/status-im/status-lib/pull/47