### PR TITLE
WIP: enable cross category drag and drop

### DIFF
--- a/src/app/chat/event_handling.nim
+++ b/src/app/chat/event_handling.nim
@@ -41,6 +41,10 @@ proc handleChatEvents(self: ChatController) =
   # app to be slower
   self.status.events.on("chatUpdate") do(e: Args):
     var evArgs = ChatUpdateArgs(e)
+
+    echo "CHAT UPDATES: ", $evArgs.chats
+
+
     self.view.hideLoadingIndicator()
     self.view.updateChats(evArgs.chats)
     self.view.pushMessages(evArgs.messages)
@@ -67,6 +71,9 @@ proc handleChatEvents(self: ChatController) =
     self.view.reactions.push(evArgs.emojiReactions)
     if (evArgs.communities.len > 0):
       for community in evArgs.communities.mitems:
+
+        echo "COMMUNITY UPDATE: ", $community
+
         if self.view.communities.isUserMemberOfCommunity(community.id) and not community.admin and not community.isMember:
           discard self.view.communities.leaveCommunity(community.id)
           continue

--- a/ui/app/AppLayouts/Chat/CommunityColumn.qml
+++ b/ui/app/AppLayouts/Chat/CommunityColumn.qml
@@ -95,7 +95,7 @@ Item {
     ScrollView {
         id: chatGroupsContainer
         anchors.top: membershipRequests.bottom
-        anchors.topMargin: Style.current.padding
+        anchors.topMargin: Style.current.padding - 8
         anchors.bottom: parent.bottom
         anchors.horizontalCenter: parent.horizontalCenter
 


### PR DESCRIPTION
This depends on https://github.com/status-im/StatusQ/pull/424 and also has a bug because of https://github.com/status-im/status-go/issues/2376 (still waiting for verification on that one).

Anyways, with this PR, drag and drop across categories works. Few things left to be done:

1. The bug in status-go (if confirmed) causes unexpected order of chat items if an item of one category is moved to a different category at the same position. Not a huge issue but a bug. See the linked issue for more details.
2. There's no visual update in the category lists **after** the drop and **before** the signal to backend. I was fiddling around with that by updating the `position` properties of all related chat items in memory, but couldn't get it to work nicely. I probably need some help with that. **One easy option to "fix" this**: Render a rectangle with loading over the entire community after drop until communities chat update happens. That way users won't see a "flicker" when chat item positions are updated.