### PR TITLE
fix(@desktop/chat): Remember the last tab (in nav bar) opened when status app is reopened

### DIFF
--- a/ui/app/AppMain.qml
+++ b/ui/app/AppMain.qml
@@ -36,6 +36,7 @@ Item {
     signal openContactsPopup()
 
     function changeAppSection(section) {
+        appSettings.lastModeActiveCommunity = ""
         chatsModel.communities.activeCommunity.active = false
         appView.currentIndex = Utils.getAppSectionIndex(section)
     }
@@ -217,6 +218,7 @@ Item {
                 onClicked: {
                     appMain.changeAppSection(Constants.chat)
                     chatsModel.communities.setActiveCommunity(model.id)
+                    appSettings.lastModeActiveCommunity = model.id
                 }
 
                 anchors.horizontalCenter: parent.horizontalCenter
@@ -406,6 +408,7 @@ Item {
                 if(obj === walletV2LayoutContainer){
                     walletV2LayoutContainer.showSigningPhrasePopup();
                 }
+                appSettings.lastModeActiveTab = (currentIndex === Utils.getAppSectionIndex(Constants.timeline)) ? 0 : currentIndex
             }
 
             ChatLayout {
@@ -757,6 +760,12 @@ Item {
                 channelPicker.close()
             }
         }
+    }
+
+    Component.onCompleted: {
+        appView.currentIndex = appSettings.lastModeActiveTab
+        if(!!appSettings.lastModeActiveCommunity)
+            chatsModel.communities.setActiveCommunity(appSettings.lastModeActiveCommunity)
     }
 }
 /*##^##

--- a/ui/main.qml
+++ b/ui/main.qml
@@ -78,6 +78,8 @@ StatusWindow {
         property string skinColor: ""
         property bool showDeleteMessageWarning: true
         property bool downloadChannelMessagesEnabled: false
+        property int lastModeActiveTab: 0
+        property string lastModeActiveCommunity: ""
 
         // Browser settings
         property bool showBrowserSelector: true


### PR DESCRIPTION
fix(@desktop/chat): Remember the last tab (in nav bar) opened when status app is reopened

With this fix after a restart the tab which the user was last one (chat, community, wallet, browser, settings) will be the active one.
If the user was on the timeline tab when the app is closed, the app will be launched with the chat tab.

fixes #3559