### PR TITLE
fix(Communities): make channel popup validation work again

### DIFF
--- a/ui/app/AppLayouts/Chat/CommunityComponents/CreateChannelPopup.qml
+++ b/ui/app/AppLayouts/Chat/CommunityComponents/CreateChannelPopup.qml
@@ -81,7 +81,7 @@ StatusModal {
                 }
                 validators: [StatusMinLengthValidator {
                     minLength: 1
-                    errorMessage: Utils.getErrorMessage(errors, qsTr("channel name"))
+                    errorMessage: Utils.getErrorMessage(nameInput.errors, qsTr("channel name"))
                 }]
             }
 
@@ -100,7 +100,7 @@ StatusModal {
                 input.implicitHeight: 88
                 validators: [StatusMinLengthValidator {
                     minLength: 1
-                    errorMessage:  Utils.getErrorMessage(errors, qsTr("channel description"))
+                    errorMessage:  Utils.getErrorMessage(descriptionTextArea.errors, qsTr("channel description"))
                 }]
             }
 


### PR DESCRIPTION
This was a reference error as there's no `errors` object on `StatusValidator`.
When accessing errors exposed by `StatusInput` we need to dot into the component
reference.