### PR TITLE
feat(ActivityCenter): allow users to mark notifications as unread

### DIFF
--- a/src/app/chat/views/activity_notification_list.nim
+++ b/src/app/chat/views/activity_notification_list.nim
@@ -135,6 +135,28 @@ QtObject:
       self.nbUnreadNotifications = 0
     self.unreadCountChanged()
 
+  proc markActivityCenterNotificationUnread(self: ActivityNotificationList, notificationId: string,
+  communityId: string, channelId: string, nType: int): void {.slot.} =
+    let notificationType = ActivityCenterNotificationType(nType)
+    let markAsUnreadProps = MarkAsUnreadNotificationProperties(communityId: communityId,
+    channelId: channelId, notificationTypes: @[notificationType])
+
+    let error = self.status.chat.markActivityCenterNotificationUnread(notificationId, markAsUnreadProps)
+    if (error != ""):
+      return
+
+    self.nbUnreadNotifications = self.nbUnreadNotifications + 1
+    self.unreadCountChanged()
+
+    var i = 0
+    for acnViewItem in self.activityCenterNotifications:
+      if (acnViewItem.id == notificationId):
+        acnViewItem.read = false
+        let index = self.createIndex(i, 0, nil)
+        self.dataChanged(index, index, @[NotifRoles.Read.int])
+        break
+      i.inc
+
   proc markActivityCenterNotificationRead(self: ActivityNotificationList, notificationId: string,
   communityId: string, channelId: string, nType: int): void {.slot.} =
 

--- a/ui/app/AppLayouts/Chat/views/ActivityCenterMessageComponentView.qml
+++ b/ui/app/AppLayouts/Chat/views/ActivityCenterMessageComponentView.qml
@@ -3,9 +3,8 @@ import QtQuick 2.13
 
 import utils 1.0
 
-import StatusQ.Controls 0.1 as StatusQ
+import StatusQ.Controls 0.1
 
-import shared 1.0
 import shared.popups 1.0
 
 import "../controls"
@@ -38,7 +37,7 @@ Item {
 
     Component {
         id: markReadBtnComponent
-        StatusQ.StatusFlatRoundButton {
+        StatusFlatRoundButton {
             id: markReadBtn
             width: 32
             height: 32
@@ -47,11 +46,18 @@ Item {
             icon.source: Style.svg("double-check")
             color: "transparent"
             //% "Mark as Read"
-            tooltip.text: qsTrId("mark-as-read")
-            tooltip.orientation: StatusQ.StatusToolTip.Orientation.Left
+            tooltip.text: !model.read ?
+                qsTr("Mark as Read") :
+                qsTr("Mark as Unread")
+            tooltip.orientation: StatusToolTip.Orientation.Left
             tooltip.x: -tooltip.width - Style.current.padding
             tooltip.y: markReadBtn.height / 2 - height / 2 + 4
-            onClicked: root.store.chatsModelInst.activityNotificationList.markActivityCenterNotificationRead(model.id, model.message.communityId, model.message.chatId, model.notificationType)
+            onClicked: {
+                if (!model.read) {
+                    return root.store.chatsModelInst.activityNotificationList.markActivityCenterNotificationRead(model.id, model.message.communityId, model.message.chatId, model.notificationType)
+                }
+                return root.store.chatsModelInst.activityNotificationList.markActivityCenterNotificationUnread(model.id, model.message.communityId, model.message.chatId, model.notificationType)
+            }
         }
     }
 


### PR DESCRIPTION
As raised in #3665, users aren't able to mark activity center notifications as unread.
The APIs for that didn't exist yet so they have been added in:

- status-go (https://github.com/status-im/status-go/pull/2383)
- status-lib (https://github.com/status-im/status-lib/pull/53)

respectively.

Closes #3665