### PR TITLE
fix(@desktop/chat): make scroll to message from search work again

### DIFF
--- a/ui/app/AppLayouts/Chat/ChatColumn.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn.qml
@@ -112,7 +112,7 @@ Item {
     }
 
     function positionAtMessage(messageId) {
-        stackLayoutChatMessages.children[stackLayoutChatMessages.currentIndex].item.scrollToMessage(messageId)
+        stackLayoutChatMessages.children[stackLayoutChatMessages.currentIndex].chatMessagesLoader.item.scrollToMessage(messageId)
     }
 
     Timer {
@@ -303,7 +303,9 @@ Item {
                     model: chatsModel.messageView
                     ColumnLayout {
                         property alias chatInput: chatInput
+                        property alias chatMessagesLoader: chatMessagesLoader
                         Loader {
+                            id: chatMessagesLoader
                             Layout.alignment: Qt.AlignHCenter | Qt.AlignBottom
                             Layout.fillWidth: true
                             Layout.fillHeight: true


### PR DESCRIPTION
We were trying to call `scrollToMessage` of `undefined`. Seems like the `Loader`
used in the chat messages view was recently introduced, causing the property lookup
in the API call to be incomplete.

This commit fixes this by exposing the loader on the chat messages column and then accessing
the `scrollToMessage` API from there.

Closes: #3362