### PR TITLE
fix(desktop/chat) fixed position view at index

### DIFF
--- a/ui/app/AppLayouts/Chat/ChatColumn.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn.qml
@@ -111,8 +111,8 @@ Item {
         applicationWindow.requestActivate()
     }
 
-    function positionAtMessage(messageId) {
-        stackLayoutChatMessages.children[stackLayoutChatMessages.currentIndex].message.scrollToMessage(messageId)
+    function positionAtMessage(messageId, isSearch = false) {
+        stackLayoutChatMessages.children[stackLayoutChatMessages.currentIndex].message.scrollToMessage(messageId, isSearch);
     }
 
     Timer {
@@ -573,7 +573,7 @@ Item {
             target: chatsModel.messageView
 
             onSearchedMessageLoaded: {
-                positionAtMessage(messageId)
+                positionAtMessage(messageId, true);
             }
 
             onMessageNotificationPushed: function(messageId, communityId, chatId, msg, contentType, chatType, timestamp, identicon, username, hasMention, isAddedContact, channelName) {

--- a/ui/app/AppLayouts/Chat/ChatColumn.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn.qml
@@ -112,7 +112,7 @@ Item {
     }
 
     function positionAtMessage(messageId) {
-        stackLayoutChatMessages.children[stackLayoutChatMessages.currentIndex].item.scrollToMessage(messageId)
+        stackLayoutChatMessages.children[stackLayoutChatMessages.currentIndex].message.scrollToMessage(messageId)
     }
 
     Timer {
@@ -303,7 +303,9 @@ Item {
                     model: chatsModel.messageView
                     ColumnLayout {
                         property alias chatInput: chatInput
+                        property alias message: messageLoader.item
                         Loader {
+                            id: messageLoader
                             Layout.alignment: Qt.AlignHCenter | Qt.AlignBottom
                             Layout.fillWidth: true
                             Layout.fillHeight: true

--- a/ui/app/AppLayouts/Chat/ChatColumn/ChatMessages.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/ChatMessages.qml
@@ -56,17 +56,30 @@ Item {
             }
         }
 
-        property var scrollToMessage: function (messageId) {
-            let item
-            for (let i = 0; i < messageListDelegate.count; i++) {
-                item = messageListDelegate.items.get(i)
-                if (item.model.messageId === messageId) {
-                    chatLogView.positionViewAtIndex(i, ListView.Center);
-                    if (appSettings.useCompactMode) {
-                        chatLogView.itemAtIndex(i).startMessageFoundAnimation();
+        property var scrollToMessage: function (messageId, isSearch = false) {
+            delayPositioningViewTimer.msgId = messageId;
+            delayPositioningViewTimer.isSearch = isSearch;
+            delayPositioningViewTimer.restart();
+        }
+
+        Timer {
+            id: delayPositioningViewTimer
+            interval: 300
+            property string msgId
+            property bool isSearch
+            onTriggered: {
+                let item
+                for (let i = 0; i < messageListDelegate.count; i++) {
+                    item = messageListDelegate.items.get(i)
+                    if (item.model.messageId === msgId) {
+                        chatLogView.positionViewAtIndex(i, ListView.Center);
+                        if (appSettings.useCompactMode && isSearch) {
+                            chatLogView.itemAtIndex(i).startMessageFoundAnimation();
+                        }
                     }
-                    return
                 }
+                msgId = "";
+                isSearch = false;
             }
         }
 

--- a/ui/app/AppLayouts/Chat/ChatColumn/ChatMessages.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/ChatMessages.qml
@@ -61,7 +61,10 @@ Item {
             for (let i = 0; i < messageListDelegate.count; i++) {
                 item = messageListDelegate.items.get(i)
                 if (item.model.messageId === messageId) {
-                    chatLogView.positionViewAtIndex(i, ListView.Center)
+                    chatLogView.positionViewAtIndex(i, ListView.Center);
+                    if (appSettings.useCompactMode) {
+                        chatLogView.itemAtIndex(i).startMessageFoundAnimation();
+                    }
                     return
                 }
             }

--- a/ui/app/AppLayouts/Chat/ChatColumn/Message.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/Message.qml
@@ -140,6 +140,10 @@ Item {
         }
     }
 
+    function startMessageFoundAnimation() {
+        messageLoader.item.startMessageFoundAnimation();
+    }
+
     Connections {
         enabled: !placeholderMessage
         target: profileModel.contacts.list
@@ -206,6 +210,7 @@ Item {
     }
 
     Loader {
+        id: messageLoader
         width: parent.width
         sourceComponent: {
             switch(contentType) {

--- a/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/CompactMessage.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/MessageComponents/CompactMessage.qml
@@ -82,6 +82,40 @@ Item {
         isActivityCenterMessage: activityCenterMessage
     }
 
+    function startMessageFoundAnimation() {
+        messageFoundAnimation.start();
+    }
+
+    SequentialAnimation {
+        id: messageFoundAnimation
+        PauseAnimation {
+            duration: 600
+        }
+         NumberAnimation {
+            target: highlightRect
+            property: "opacity"
+            to: 1.0
+            duration: 1500
+        }
+        PauseAnimation {
+            duration: 1000
+        }
+        NumberAnimation {
+           target: highlightRect
+           property: "opacity"
+            to: 0.0
+            duration: 1500
+        }
+    }
+
+    Rectangle {
+        id: highlightRect
+        anchors.fill: messageContainer
+        opacity: 0
+        visible: (opacity > 0.001)
+        color: Style.current.backgroundHoverLight
+    }
+
     Rectangle {
         property alias chatText: chatText
 
@@ -97,7 +131,6 @@ Item {
                 + (pinnedRectangleLoader.active ? Style.current.smallPadding : 0)
                 + (isEdit ? 25 : 0)
         width: parent.width
-
         color: {
             if (isEdit) {
                 return Style.current.backgroundHoverLight
@@ -116,7 +149,7 @@ Item {
             }
 
             return root.isHovered || isMessageActive ? (hasMention ? Style.current.mentionMessageHoverColor : Style.current.backgroundHoverLight) :
-                                                   (hasMention ? Style.current.mentionMessageColor : Style.current.transparent)
+                                                       (hasMention ? Style.current.mentionMessageColor : Style.current.transparent)
         }
 
         Loader {


### PR DESCRIPTION
Position view at chosen message when coming from either search or notifications was not working properly, especially when coming from another channel (eg from desktop to test). Added timer to delay positioning action until the messages model is almost fully loaded so that the view knows all indexes.

Depends on #3562
Closes #3592, #3683