### PR TITLE
fix: on macOS download openssl@1.1 bottle because openssl bottle is now alias for openssl@3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ endif
 
 ifeq ($(detected_OS),Darwin)
 BOTTLES_DIR := $(shell pwd)/bottles
-BOTTLES := $(addprefix $(BOTTLES_DIR)/,hunspell openssl pcre)
+BOTTLES := $(addprefix $(BOTTLES_DIR)/,hunspell openssl@1.1 pcre)
 
 $(BOTTLES): | $(BOTTLES_DIR)
 	echo -e "\e[92mFetching:\e[39m $(notdir $@) bottle"

--- a/config.nims
+++ b/config.nims
@@ -17,8 +17,8 @@ if defined(macosx):
   switch("passL", "-rpath" & " " & getEnv("QT5_LIBDIR"))
   switch("passL", "-rpath" & " " & getEnv("STATUSGO_LIBDIR"))
   # statically link these libs
-  switch("passL", "bottles/openssl/lib/libcrypto.a")
-  switch("passL", "bottles/openssl/lib/libssl.a")
+  switch("passL", "bottles/openssl@1.1/lib/libcrypto.a")
+  switch("passL", "bottles/openssl@1.1/lib/libssl.a")
   switch("passL", "bottles/pcre/lib/libpcre.a")
   # https://code.videolan.org/videolan/VLCKit/-/issues/232
   switch("passL", "-Wl,-no_compact_unwind")
@@ -44,4 +44,3 @@ switch("warning", "ObservableStores:off")
 
 # Too many false positives for "Warning: method has lock level <unknown>, but another method has 0 [LockLevel]"
 switch("warning", "LockLevel:off")
-


### PR DESCRIPTION
Homebrew for macOS recently switched the `openssl` bottle from being an alias for `openssl@1.1` to it being an alias for `openssl@3`.

When attempting to link against version 3, the compiler fails with:

```
Undefined symbols for architecture x86_64:
  "_SSL_get_peer_certificate", referenced from:
      _checkCertName__YJ34V0ITZpxT1cfjKMD8vQ in stdlib_net.nim.c.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
Error: execution of an external program failed: 'clang  @nim_status_client_linkerArgs.txt'
make: *** [bin/nim_status_client] Error 1
```

Until a change is made in Nim's stdlib to facilitate linking against version 3, we'll use version 1.1.