### PR TITLE
fix(desktop/chat) fixed position view at index

### DIFF
--- a/ui/app/AppLayouts/Chat/ChatColumn.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn.qml
@@ -111,8 +111,8 @@ Item {
         applicationWindow.requestActivate()
     }
 
-    function positionAtMessage(messageId) {
-        stackLayoutChatMessages.children[stackLayoutChatMessages.currentIndex].message.scrollToMessage(messageId)
+    function positionAtMessage(messageId, isSearch = false) {
+        stackLayoutChatMessages.children[stackLayoutChatMessages.currentIndex].message.scrollToMessage(messageId, isSearch);
     }
 
     Timer {
@@ -573,7 +573,7 @@ Item {
             target: chatsModel.messageView
 
             onSearchedMessageLoaded: {
-                positionAtMessage(messageId)
+                positionAtMessage(messageId, true);
             }
 
             onMessageNotificationPushed: function(messageId, communityId, chatId, msg, contentType, chatType, timestamp, identicon, username, hasMention, isAddedContact, channelName) {

--- a/ui/app/AppLayouts/Chat/ChatColumn/ChatMessages.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn/ChatMessages.qml
@@ -56,17 +56,30 @@ Item {
             }
         }
 
-        property var scrollToMessage: function (messageId) {
-            let item
-            for (let i = 0; i < messageListDelegate.count; i++) {
-                item = messageListDelegate.items.get(i)
-                if (item.model.messageId === messageId) {
-                    chatLogView.positionViewAtIndex(i, ListView.Center);
-                    if (appSettings.useCompactMode) {
-                        chatLogView.itemAtIndex(i).startMessageFoundAnimation();
+        property var scrollToMessage: function (messageId, isSearch = false) {
+            delayPositioningViewTimer.msgId = messageId;
+            delayPositioningViewTimer.isSearch = isSearch;
+            delayPositioningViewTimer.restart();
+        }
+
+        Timer {
+            id: delayPositioningViewTimer
+            interval: 1000
+            property string msgId
+            property bool isSearch
+            onTriggered: {
+                let item
+                for (let i = 0; i < messages.rowCount(); i++) {
+                    item = messageListDelegate.items.get(i);
+                    if (item.model.messageId === msgId) {
+                        chatLogView.positionViewAtIndex(i, ListView.Beginning);
+                        if (appSettings.useCompactMode && isSearch) {
+                            chatLogView.itemAtIndex(i).startMessageFoundAnimation();
+                        }
                     }
-                    return
                 }
+                msgId = "";
+                isSearch = false;
             }
         }
 


### PR DESCRIPTION
Position view at chosen message when coming from either search or notifications was not working properly, especially when coming from another channel (eg from desktop to test). Added timer to delay positioning action until the messages model is almost fully loaded so that the view knows all indexes.

Closes #3592, #3683