### PR TITLE
fix(ui): close popups on second click click of button

### DIFF
--- a/ui/app/AppLayouts/Chat/ContactsColumn.qml
+++ b/ui/app/AppLayouts/Chat/ContactsColumn.qml
@@ -90,7 +90,11 @@ Item {
             icon.name: "add"
             state: "default"
 
-            onClicked: chatContextMenu.popup(actionButton.width-chatContextMenu.width, actionButton.height + 4)
+            onClicked: {
+                chatContextMenu.opened ?
+                    chatContextMenu.close() :
+                    chatContextMenu.popup(actionButton.width-chatContextMenu.width, actionButton.height + 4)
+            }
             states: [
                 State {
                     name: "default"
@@ -134,6 +138,7 @@ Item {
 
             StatusPopupMenu {
                 id: chatContextMenu
+                closePolicy: Popup.Popup.CloseOnReleaseOutsideParent | Popup.CloseOnEscape
 
                 onOpened: {
                     actionButton.state = "pressed"

--- a/ui/app/AppMain.qml
+++ b/ui/app/AppMain.qml
@@ -350,6 +350,7 @@ Item {
 
             navBarProfileButton: StatusNavBarTabButton {
                 id: profileButton
+                property bool opened: false
                 icon.source: profileModel.profile.thumbnailImage || ""
                 badge.visible: true
                 badge.anchors.rightMargin: 4
@@ -371,7 +372,11 @@ Item {
                     }*/
                 }
                 badge.border.width: 3
-                onClicked: userStatusContextMenu.open()
+                onClicked: {
+                    userStatusContextMenu.opened ?
+                        userStatusContextMenu.close() :
+                        userStatusContextMenu.open()
+                }
 
                 UserStatusContextMenu {
                     id: userStatusContextMenu

--- a/ui/shared/UserStatusContextMenu.qml
+++ b/ui/shared/UserStatusContextMenu.qml
@@ -9,7 +9,7 @@ import "./"
 PopupMenu {
     id: root
     width: profileHeader.width
-    closePolicy: Popup.CloseOnPressOutside | Popup.CloseOnEscape
+    closePolicy: Popup.CloseOnReleaseOutsideParent | Popup.CloseOnEscape
 
     Item {
         id: profileHeader

--- a/ui/shared/status/StatusChatCommandsPopup.qml
+++ b/ui/shared/status/StatusChatCommandsPopup.qml
@@ -10,6 +10,7 @@ Popup {
     height: buttonRow.height
     padding: 0
     margins: 0
+    closePolicy: Popup.CloseOnReleaseOutsideParent | Popup.CloseOnEscape
 
     signal sendTransactionCommandButtonClicked()
     signal receiveTransactionCommandButtonClicked()

--- a/ui/shared/status/StatusChatInput.qml
+++ b/ui/shared/status/StatusChatInput.qml
@@ -642,6 +642,9 @@ Rectangle {
         onClosed: {
             chatCommandsBtn.highlighted = false
         }
+        onOpened: {
+            chatCommandsBtn.highlighted = true
+        }
     }
 
     StatusGifPopup {
@@ -704,8 +707,9 @@ Rectangle {
         visible: !isEdit && control.chatType === Constants.chatTypeOneToOne && !control.isStatusUpdateInput
         enabled: !control.isContactBlocked
         onClicked: {
-            highlighted = true
-            chatCommandsPopup.open()
+            chatCommandsPopup.opened ?
+                chatCommandsPopup.close() :
+                chatCommandsPopup.open()
         }
     }
 


### PR DESCRIPTION
Fixes #3558.

Previously, clicking a button a second time would cause an open popup to re-open (effectively staying open). 

This PR fixes the issue by changing the close policy of the popups to only close when clicked outside of the parent (`Popup.CloseOnReleaseOutsideParent`). If the policy remained on `Popup.CloseOnPressOutside`, when the button that opened the popup was clicked again, the popup would close because the button sits outside the surface area of the popup. After that, the `onClicked` signal handler would be fired for the button, checking the `opened` state of the popup (which is now `false`) and attempt to reopen the popup.

By changing the close policy to `Popup.CloseOnReleaseOutsideParent`, clicking the button a second time would not be considered outside the surface area of the popup and wouldn't cause the popup to close in the first place. This allows us to rely on the `opened` property of the popup inside the `onClicked` handler of the button.