### PR TITLE
fix(ChatLayout): ensure channel name is vertically centered

### DIFF
--- a/ui/app/AppLayouts/Chat/ChatColumn.qml
+++ b/ui/app/AppLayouts/Chat/ChatColumn.qml
@@ -179,7 +179,7 @@ Item {
                         //% "1 member"
                         return qsTrId("1-member");
                     case Constants.chatTypeCommunity:
-                        return Utils.linkifyAndXSS(chatsModel.channelView.activeChannel.description)
+                        return Utils.linkifyAndXSS(chatsModel.channelView.activeChannel.description).trim()
                     default:
                         return ""
                     }


### PR DESCRIPTION
This was originally reported in https://github.com/status-im/StatusQ/issues/427, however it turns out
that the underlying component already handles this case correctly.

The reason the channel name is not vertically centered inside Status Desktop,
is because the returned value of `XSS.filterXss()` for the `subTitle` is never an empty string.

Trimming the return value fixes this.