### PR TITLE
refactor(@desktop/timeline): use new file and store architecture

### DIFF
--- a/ui/app/AppLayouts/Timeline/panels/EmptyTimelinePanel.qml
+++ b/ui/app/AppLayouts/Timeline/panels/EmptyTimelinePanel.qml
@@ -2,9 +2,11 @@ import QtQuick 2.13
 import QtQuick.Controls 2.13
 import QtQuick.Layouts 1.13
 
+import StatusQ.Core 0.1
+import StatusQ.Core.Theme 0.1
+
 import utils 1.0
-import "../../../shared"
-import "../../../shared/status"
+import "../../../../shared"
 
 Rectangle {
     id: root
@@ -34,7 +36,7 @@ Rectangle {
         width: 255
         height: shareYourMindText.height + Style.current.padding
 
-        StyledText {
+        StatusBaseText {
             id: shareYourMindText
             horizontalAlignment: Text.AlignHCenter
             anchors.left: parent.left
@@ -45,8 +47,9 @@ Rectangle {
             //% "Share what's on your mind and stay updated with your contacts"
             text: qsTrId("share-what-s-on-your-mind-and-stay-updated-with-your-contacts")
             font.pixelSize: 15
-            color: Style.current.secondaryText
+            color: Theme.palette.directColor7
             wrapMode: Text.WordWrap
         }
     }
 }
+

--- a/ui/app/AppLayouts/Timeline/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Timeline/stores/RootStore.qml
@@ -1,0 +1,28 @@
+import QtQuick 2.13
+import QtQuick.Dialogs 1.3
+
+import utils 1.0
+
+QtObject {
+    id: root
+
+    property var chatsModelInst: chatsModel
+    property var profileModelInst: profileModel
+
+    function setActiveChannelToTimeline() {
+        chatsModelInst.setActiveChannelToTimeline()
+    }
+
+    function getPlainTextFromRichText(text) {
+        return chatsModelInst.plainText(text)
+    }
+
+    function sendMessage(message, contentType) {
+        chatsModelInst.messageView.sendMessage(message, "", contentType, true)
+    }
+
+    function sendImage(url) {
+        chatsModelInst.sendImage(url, true)
+    }
+
+}


### PR DESCRIPTION
This refactors the timeline module to follow the stores/views/panel/popups
architecture. It extracts all usages of *Model context variables with
store instance equivalents and replaces API calls on such model instances
with store proxy APIs.

Closes #3713