### PR TITLE
Fix ui/onboardingGenKeyModal.qml: fix height by design

### DIFF
--- a/ui/app/AppLayouts/Onboarding/popups/GenKeyModal.qml
+++ b/ui/app/AppLayouts/Onboarding/popups/GenKeyModal.qml
@@ -17,6 +17,7 @@ ModalPopup {
     id: popup
     //% "Choose a chat name"
     title: qsTrId("intro-wizard-title2")
+    height: 504
 
     AccountListPanel {
         id: accountList


### PR DESCRIPTION
Fixes #3794

Fixing height of GenKeyModal.qml to match designs

