### PR TITLE
fix(@desktop/profile): make profile image work again

### DIFF
--- a/ui/app/AppLayouts/Profile/views/MyProfileView.qml
+++ b/ui/app/AppLayouts/Profile/views/MyProfileView.qml
@@ -31,7 +31,7 @@ Item {
         id: changeProfileModalComponent
         ChangeProfilePicModal {
             largeImage: store.profileLargeImage
-            hasIdentityImage: store.hasIdentityImage
+            hasIdentityImage: store.profileHasIdentityImage
             onCropFinished: {
                 uploadError = store.uploadImage(selectedImage, aX, aY, bX, bY)
             }

--- a/ui/shared/panels/ImageLoader.qml
+++ b/ui/shared/panels/ImageLoader.qml
@@ -89,7 +89,7 @@ Rectangle {
     Component {
         id: reload
         SVGImage {
-            source: "../app/img/reload.svg"
+            source: Style.svg("reload")
             mipmap: false
             width: 15.5
             height: 19.5


### PR DESCRIPTION
There is a bug in the store property accessed for the profile image.
This commit corrects it. It also ensures that the image source used in the
`ImageLoader` component is correct.