### PR TITLE
fix(@desktop/profile): fix bug in switch buttons for privacy settings

### DIFF
--- a/ui/app/AppLayouts/Profile/views/PrivacyView.qml
+++ b/ui/app/AppLayouts/Profile/views/PrivacyView.qml
@@ -187,7 +187,7 @@ Item {
                 }
             ]
             sensor.onClicked: {
-                switch2.checked = appSettings.onlyShowContactsProfilePics = !switch2.checked
+                switch2.checked = appSettings.displayChatImages = !switch2.checked
             }
         }
 


### PR DESCRIPTION
This bug was introduced with the profile refactor to use stores. Due to
copy and paste, the wrong expression is used in the settings to display chat
images. This commit corrects that.