### PR TITLE
fix: make `getLinkStyle` work again

### DIFF
--- a/ui/app/AppLayouts/Chat/controls/activityCenter/CommunityBadge.qml
+++ b/ui/app/AppLayouts/Chat/controls/activityCenter/CommunityBadge.qml
@@ -73,7 +73,7 @@ Item {
 
     StyledTextEdit {
         id: communityName
-        text: Utils.getLinkStyle(communityBadge.communityName, hoveredLink)
+        text: Utils.getLinkStyle(communityBadge.communityName, hoveredLink, textColor)
         height: 18
         readOnly: true
         textFormat: Text.RichText
@@ -104,7 +104,7 @@ Item {
 
     StyledTextEdit {
         id: channelName
-        text: Utils.getLinkStyle(communityBadge.channelName || name, hoveredLink)
+        text: Utils.getLinkStyle(communityBadge.channelName || name, hoveredLink, textColor)
         height: 18
         readOnly: true
         textFormat: Text.RichText

--- a/ui/app/AppLayouts/Chat/panels/BadgeContentPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/BadgeContentPanel.qml
@@ -100,20 +100,9 @@ Item {
                 }
             }
 
-            function getLinkStyle(link, hoveredLink) {
-                return `<style type="text/css">` +
-                        `a {` +
-                        `color: ${wrapper.textColor};` +
-                        `text-decoration: none;` +
-                        `}` +
-                        (hoveredLink !== "" ? `a[href="${hoveredLink}"] { text-decoration: underline; }` : "") +
-                        `</style>` +
-                        `<a href="${link}">${link}</a>`
-            }
-
             StyledTextEdit {
                 id: communityName
-                text: communityBadge.getLinkStyle(communityBadge.communityName, hoveredLink)
+                text: Utils.getLinkStyle(communityBadge.communityName, hoveredLink, wrapper.textColor)
                 height: 18
                 readOnly: true
                 textFormat: Text.RichText
@@ -146,7 +135,7 @@ Item {
 
             StyledTextEdit {
                 id: channelName
-                text: communityBadge.getLinkStyle(communityBadge.channelName || wrapper.name, hoveredLink)
+                text: communityBadge.getLinkStyle(communityBadge.channelName || wrapper.name, hoveredLink, wrapper.textColor)
                 height: 18
                 readOnly: true
                 textFormat: Text.RichText

--- a/ui/imports/utils/Utils.qml
+++ b/ui/imports/utils/Utils.qml
@@ -115,10 +115,10 @@ QtObject {
             `</html>`
     }
 
-    function getLinkStyle(link, hoveredLink) {
+    function getLinkStyle(link, hoveredLink, textColor) {
         return `<style type="text/css">` +
                 `a {` +
-                `color: ${wrapper.textColor};` +
+                `color: ${textColor};` +
                 `text-decoration: none;` +
                 `}` +
                 (hoveredLink !== "" ? `a[href="${hoveredLink}"] { text-decoration: underline; }` : "") +


### PR DESCRIPTION
Probably slipped through in the refactor: `getLinkStyle` was defined
in to places, was probably meant to live only in `Utils`.

In addition, it expected a `wrapper` expression which wasn't defined.
This commit fixes it by removing the second declaration of that function
and passing a third parameter to the one defined in `Utils`.