### PR TITLE
fix(GroupChatPopup): fix ui elements

### DIFF
--- a/ui/app/AppLayouts/Chat/panels/ContactListPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/ContactListPanel.qml
@@ -2,7 +2,6 @@ import QtQuick 2.13
 import QtQuick.Controls 2.3
 
 import utils 1.0
-import "../../../../shared"
 
 import "../controls"
 

--- a/ui/app/AppLayouts/Chat/popups/GroupChatPopup.qml
+++ b/ui/app/AppLayouts/Chat/popups/GroupChatPopup.qml
@@ -127,6 +127,7 @@ ModalPopup {
 
     NoFriendsRectangle {
         id: noContactsRect
+        visible: false
         anchors.top: groupName.bottom
         anchors.topMargin: Style.current.xlPadding
         anchors.horizontalCenter: parent.horizontalCenter
@@ -158,13 +159,12 @@ ModalPopup {
         width: parent.width
         height: btnSelectMembers.height
 
-        StatusFlatRoundButton {
+        StatusRoundButton {
             id: btnSelectMembers
             visible: selectChatMembers
             anchors.bottom: parent.bottom
             anchors.right: parent.right
             icon.name: "arrow-right"
-            type: StatusFlatRoundButton.Type.Secondary
             icon.width: 20
             icon.height: 16
             enabled: !!pubKeys.length

--- a/ui/shared/views/NoFriendsRectangle.qml
+++ b/ui/shared/views/NoFriendsRectangle.qml
@@ -2,10 +2,11 @@ import QtQuick 2.13
 
 import utils 1.0
 
+import StatusQ.Core 0.1
+import StatusQ.Core.Theme 0.1
 import StatusQ.Controls 0.1
 
 import "../popups"
-import "../panels"
 
 Item {
     id: noContactsRect
@@ -13,10 +14,10 @@ Item {
     //% "You don’t have any contacts yet. Invite your friends to start chatting."
     property string text: qsTrId("you-don-t-have-any-contacts-yet--invite-your-friends-to-start-chatting-")
     property alias textColor: noContacts.color
-    StyledText {
+    StatusBaseText {
         id: noContacts
         text: noContactsRect.text
-        color: Style.current.secondaryText
+        color: Theme.palette.baseColor1
         anchors.top: parent.top
         anchors.topMargin: Style.current.padding
         anchors.left: parent.left


### PR DESCRIPTION
This corrects the call to action button in the modal footer
as well as the "no friends" rectangle, which was wrongly rendered.