### PR TITLE
fix(@desktop/profile): make devices view work in darkmode again

### DIFF
--- a/ui/app/AppLayouts/Profile/views/AppearanceView.qml
+++ b/ui/app/AppLayouts/Profile/views/AppearanceView.qml
@@ -11,6 +11,7 @@ import shared.status 1.0
 import "../../Chat/views"
 
 import StatusQ.Core 0.1
+import StatusQ.Core.Theme 0.1
 import StatusQ.Controls 0.1 as StatusQ
 
 import "../popups"
@@ -120,6 +121,7 @@ ScrollView {
             font.pixelSize: 15
             //% "Change font size"
             text: qsTrId("change-font-size")
+            color: Theme.palette.directColor1
         }
 
         StatusQ.StatusSlider {
@@ -150,6 +152,7 @@ ScrollView {
                 //% "XS"
                 text: qsTrId("xs")
                 Layout.preferredWidth: fontSizeSlider.width/6
+                color: Theme.palette.directColor1
             }
 
             StatusBaseText {
@@ -158,6 +161,7 @@ ScrollView {
                 text: qsTrId("s")
                 Layout.preferredWidth: fontSizeSlider.width/6
                 Layout.leftMargin: 2
+                color: Theme.palette.directColor1
             }
 
             StatusBaseText {
@@ -166,6 +170,7 @@ ScrollView {
                 text: qsTrId("m")
                 Layout.preferredWidth: fontSizeSlider.width/6
                 Layout.leftMargin: 2
+                color: Theme.palette.directColor1
             }
 
             StatusBaseText {
@@ -174,6 +179,7 @@ ScrollView {
                 text: qsTrId("l")
                 Layout.preferredWidth: fontSizeSlider.width/6
                 Layout.leftMargin: 2
+                color: Theme.palette.directColor1
             }
 
             StatusBaseText {
@@ -182,6 +188,7 @@ ScrollView {
                 text: qsTrId("xl")
                 Layout.preferredWidth: fontSizeSlider.width/6
                 Layout.leftMargin: 0
+                color: Theme.palette.directColor1
             }
 
             StatusBaseText {
@@ -190,6 +197,7 @@ ScrollView {
                 text: qsTrId("xxl")
                 Layout.alignment: Qt.AlignRight
                 Layout.leftMargin: -Style.current.smallPadding
+                color: Theme.palette.directColor1
             }
         }
 
@@ -200,6 +208,7 @@ ScrollView {
             anchors.left: parent.left
             font.pixelSize: 15
             text: qsTr("Change Zoom (requires restart)")
+            color: Theme.palette.directColor1
         }
 
         StatusQ.StatusSlider {
@@ -252,6 +261,7 @@ ScrollView {
             StatusBaseText {
                 font.pixelSize: 15
                 text: "50%"
+                color: Theme.palette.directColor1
             }
 
             Item {
@@ -262,6 +272,7 @@ ScrollView {
                 font.pixelSize: 15
                 Layout.leftMargin: width / 2
                 text: "100%"
+                color: Theme.palette.directColor1
             }
 
             Item {
@@ -272,6 +283,7 @@ ScrollView {
                 font.pixelSize: 15
                 Layout.leftMargin: width / 2
                 text: "150%"
+                color: Theme.palette.directColor1
             }
 
             Item {
@@ -281,6 +293,7 @@ ScrollView {
             StatusBaseText {
                 font.pixelSize: 15
                 text: "200%"
+                color: Theme.palette.directColor1
             }
         }
 

--- a/ui/app/AppLayouts/Profile/views/DevicesView.qml
+++ b/ui/app/AppLayouts/Profile/views/DevicesView.qml
@@ -39,6 +39,7 @@ Item {
             //% "Please set a name for your device."
             text: qsTrId("pairing-please-set-a-name")
             font.pixelSize: 14
+            color: Theme.palette.directColor1
         }
 
         Input {
@@ -114,6 +115,7 @@ Item {
                 anchors.topMargin: 6
                 anchors.left: advertiseImg.right
                 anchors.leftMargin: Style.current.padding
+                color: Theme.palette.directColor1
             }
 
             MouseArea {
@@ -159,6 +161,7 @@ Item {
             text: qsTrId("paired-devices")
             font.pixelSize: 16
             font.weight: Font.Bold
+            color: Theme.palette.directColor1
         }
 
         ListView {
@@ -197,6 +200,7 @@ Item {
                     font.pixelSize: 14
                     anchors.left: enabledIcon.right
                     anchors.leftMargin: Style.current.padding
+                    color: Theme.palette.directColor1
                 }
                 StatusSwitch { 
                     id: devicePairedSwitch

--- a/ui/app/AppLayouts/Profile/views/EnsAddedView.qml
+++ b/ui/app/AppLayouts/Profile/views/EnsAddedView.qml
@@ -22,6 +22,7 @@ Item {
         anchors.topMargin: 24
         font.weight: Font.Bold
         font.pixelSize: 20
+        color: Theme.palette.directColor1
     }
 
 
@@ -59,6 +60,7 @@ Item {
         anchors.right: parent.right
         horizontalAlignment: Text.AlignHCenter
         wrapMode: Text.WordWrap
+        color: Theme.palette.directColor1
     }
 
     StatusBaseText {
@@ -72,6 +74,7 @@ Item {
         anchors.right: parent.right
         horizontalAlignment: Text.AlignHCenter
         wrapMode: Text.WordWrap
+        color: Theme.palette.directColor1
     }
 
     StatusButton {

--- a/ui/app/AppLayouts/Profile/views/EnsConnectedView.qml
+++ b/ui/app/AppLayouts/Profile/views/EnsConnectedView.qml
@@ -22,6 +22,7 @@ Item {
         anchors.topMargin: 24
         font.weight: Font.Bold
         font.pixelSize: 20
+        color: Theme.palette.directColor1
     }
 
 
@@ -59,6 +60,7 @@ Item {
         anchors.right: parent.right
         horizontalAlignment: Text.AlignHCenter
         wrapMode: Text.WordWrap
+        color: Theme.palette.directColor1
     }
     
     StatusBaseText {
@@ -72,6 +74,7 @@ Item {
         anchors.right: parent.right
         horizontalAlignment: Text.AlignHCenter
         wrapMode: Text.WordWrap
+        color: Theme.palette.directColor1
     }
 
     StatusBaseText {
@@ -85,7 +88,7 @@ Item {
         anchors.right: parent.right
         horizontalAlignment: Text.AlignHCenter
         wrapMode: Text.WordWrap
-        color: Theme.palette.directColor7
+        color: Theme.palette.baseColor1
 
     }
 

--- a/ui/app/AppLayouts/Profile/views/EnsDetailsView.qml
+++ b/ui/app/AppLayouts/Profile/views/EnsDetailsView.qml
@@ -3,6 +3,7 @@ import QtQuick.Layouts 1.3
 import QtQuick.Controls 2.14
 
 import StatusQ.Core 0.1
+import StatusQ.Core.Theme 0.1
 import StatusQ.Controls 0.1 as StatusQControls
 import StatusQ.Components 0.1
 
@@ -29,6 +30,7 @@ Item {
         anchors.topMargin: 24
         font.weight: Font.Bold
         font.pixelSize: 20
+        color: Theme.palette.directColor1
     }
 
     Component {

--- a/ui/app/AppLayouts/Profile/views/EnsListView.qml
+++ b/ui/app/AppLayouts/Profile/views/EnsListView.qml
@@ -65,7 +65,7 @@ Item {
                     anchors.top: usernameTxt.bottom
                     anchors.topMargin: 2
                     text: username.substr(username.indexOf("."))
-                    color: Style.current.darkGrey
+                    color: Theme.palette.baseColor1
                 }
             }
         }
@@ -78,7 +78,7 @@ Item {
                     //% "(pending)"
                     text: username  + " " + (isPending ? qsTrId("-pending-") : "")
                     font.pixelSize: 16
-                    color: Style.current.textColor
+                    color: Theme.palette.directColor1
                     anchors.top: parent.top
                     anchors.topMargin: 5
                 }
@@ -142,6 +142,7 @@ Item {
             anchors.topMargin: 24
             font.weight: Font.Bold
             font.pixelSize: 20
+            color: Theme.palette.directColor1
         }
 
         Item {
@@ -187,6 +188,7 @@ Item {
             anchors.top: addUsername.bottom
             anchors.topMargin: 24
             font.pixelSize: 16
+            color: Theme.palette.directColor1
         }
 
         Item {
@@ -231,6 +233,7 @@ Item {
             anchors.top: ensList.bottom
             anchors.topMargin: 24
             font.pixelSize: 16
+            color: Theme.palette.directColor1
         }
 
         Item {
@@ -249,6 +252,7 @@ Item {
                 text: qsTrId("primary-username")
                 font.pixelSize: 14
                 font.weight: Font.Bold
+                color: Theme.palette.directColor1
             }
 
             StatusBaseText {
@@ -259,6 +263,7 @@ Item {
                 anchors.left: usernameLabel.right
                 anchors.leftMargin: Style.current.padding
                 font.pixelSize: 14
+                color: Theme.palette.directColor1
             }
 
             MouseArea {

--- a/ui/app/AppLayouts/Profile/views/EnsRegisteredView.qml
+++ b/ui/app/AppLayouts/Profile/views/EnsRegisteredView.qml
@@ -22,6 +22,7 @@ Item {
         anchors.topMargin: Style.current.bigPadding
         font.weight: Font.Bold
         font.pixelSize: 20
+        color: Theme.palette.directColor1
     }
 
 
@@ -59,6 +60,7 @@ Item {
         anchors.right: parent.right
         horizontalAlignment: Text.AlignHCenter
         wrapMode: Text.WordWrap
+        color: Theme.palette.directColor1
     }
     
     StatusBaseText {
@@ -72,6 +74,7 @@ Item {
         anchors.right: parent.right
         horizontalAlignment: Text.AlignHCenter
         wrapMode: Text.WordWrap
+        color: Theme.palette.directColor1
     }
 
     StatusBaseText {
@@ -85,7 +88,7 @@ Item {
         anchors.right: parent.right
         horizontalAlignment: Text.AlignHCenter
         wrapMode: Text.WordWrap
-        color: Theme.palette.directColor7
+        color: Theme.palette.baseColor1
 
     }
 

--- a/ui/app/AppLayouts/Profile/views/EnsReleasedView.qml
+++ b/ui/app/AppLayouts/Profile/views/EnsReleasedView.qml
@@ -22,6 +22,7 @@ Item {
         anchors.topMargin: Style.current.bigPadding
         font.weight: Font.Bold
         font.pixelSize: 20
+        color: Theme.palette.directColor1
     }
 
 
@@ -58,6 +59,7 @@ Item {
         anchors.right: parent.right
         horizontalAlignment: Text.AlignHCenter
         wrapMode: Text.WordWrap
+        color: Theme.palette.directColor1
     }
     
     StatusBaseText {
@@ -70,6 +72,7 @@ Item {
         anchors.right: parent.right
         horizontalAlignment: Text.AlignHCenter
         wrapMode: Text.WordWrap
+        color: Theme.palette.directColor1
     }
 
     StatusBaseText {
@@ -83,7 +86,7 @@ Item {
         anchors.right: parent.right
         horizontalAlignment: Text.AlignHCenter
         wrapMode: Text.WordWrap
-        color: Theme.palette.directColor7
+        color: Theme.palette.baseColor1
 
     }
 

--- a/ui/app/AppLayouts/Profile/views/EnsSearchView.qml
+++ b/ui/app/AppLayouts/Profile/views/EnsSearchView.qml
@@ -268,6 +268,7 @@ Item {
             anchors.top: ensTypeRect.bottom
             wrapMode: Text.WordWrap
             anchors.topMargin: Style.current.bigPadding
+            color: Theme.palette.directColor1
         }
     }
 }

--- a/ui/app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml
+++ b/ui/app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml
@@ -30,6 +30,7 @@ Item {
         anchors.topMargin: 24
         font.weight: Font.Bold
         font.pixelSize: 20
+        color: Theme.palette.directColor1
     }
 
     Loader {
@@ -91,6 +92,7 @@ Item {
                     wrapMode: Text.WordWrap
                     anchors.left: parent.left
                     anchors.right: parent.right
+                    color: Theme.palette.directColor1
                 }
 
                 StatusBaseText {
@@ -99,6 +101,7 @@ Item {
                     wrapMode: Text.WordWrap
                     anchors.left: parent.left
                     anchors.right: parent.right
+                    color: Theme.palette.directColor1
                 }
 
                 StatusBaseText {
@@ -107,6 +110,7 @@ Item {
                     wrapMode: Text.WordWrap
                     anchors.left: parent.left
                     anchors.right: parent.right
+                    color: Theme.palette.directColor1
                 }
 
                 StatusBaseText {
@@ -115,6 +119,7 @@ Item {
                     wrapMode: Text.WordWrap
                     anchors.left: parent.left
                     anchors.right: parent.right
+                    color: Theme.palette.directColor1
                 }
 
                 StatusBaseText {
@@ -123,6 +128,7 @@ Item {
                     wrapMode: Text.WordWrap
                     anchors.left: parent.left
                     anchors.right: parent.right
+                    color: Theme.palette.directColor1
                 }
 
                 StatusBaseText {
@@ -131,6 +137,7 @@ Item {
                     wrapMode: Text.WordWrap
                     anchors.left: parent.left
                     anchors.right: parent.right
+                    color: Theme.palette.directColor1
                 }
 
                 StatusBaseText {
@@ -139,6 +146,7 @@ Item {
                     wrapMode: Text.WordWrap
                     anchors.left: parent.left
                     anchors.right: parent.right
+                    color: Theme.palette.directColor1
                 }
 
                 StatusBaseText {
@@ -148,6 +156,7 @@ Item {
                     anchors.left: parent.left
                     anchors.right: parent.right
                     font.weight: Font.Bold
+                    color: Theme.palette.directColor1
                 }
 
                 StatusBaseText {
@@ -157,6 +166,7 @@ Item {
                     anchors.left: parent.left
                     anchors.right: parent.right
                     font.family: Style.current.fontHexRegular.name
+                    color: Theme.palette.directColor1
                 }
 
                 StatusBaseText {
@@ -165,6 +175,7 @@ Item {
                     anchors.left: parent.left
                     anchors.right: parent.right
                     onLinkActivated: appMain.openLink(link)
+                    color: Theme.palette.directColor1
                     MouseArea {
                         anchors.fill: parent
                         acceptedButtons: Qt.NoButton // we don't want to eat clicks on the Text
@@ -179,6 +190,7 @@ Item {
                     anchors.left: parent.left
                     anchors.right: parent.right
                     font.family: Style.current.fontHexRegular.name
+                    color: Theme.palette.directColor1
                 }
 
                 StatusBaseText {
@@ -187,6 +199,7 @@ Item {
                     anchors.left: parent.left
                     anchors.right: parent.right
                     onLinkActivated: appMain.openLink(link)
+                    color: Theme.palette.directColor1
                     MouseArea {
                         anchors.fill: parent
                         acceptedButtons: Qt.NoButton // we don't want to eat clicks on the Text
@@ -246,6 +259,7 @@ Item {
                 anchors.left: parent.left
                 anchors.right: parent.right
                 horizontalAlignment: Text.AlignHCenter
+                color: Theme.palette.directColor1
             }
 
             StatusDescriptionListItem {
@@ -297,6 +311,7 @@ Item {
                 wrapMode: Text.WordWrap
                 anchors.top: termsAndConditionsCheckbox.top
                 onLinkActivated: popup.open()
+                color: Theme.palette.directColor1
                 MouseArea {
                     anchors.fill: parent
                     acceptedButtons: Qt.NoButton // we don't want to eat clicks on the Text
@@ -348,7 +363,7 @@ Item {
             anchors.leftMargin: 5
             anchors.topMargin: 5
             anchors.top: ensPriceLbl.bottom
-            color: Theme.palette.directColor7
+            color: Theme.palette.baseColor1
             font.pixelSize: 14
         }
     }

--- a/ui/app/AppLayouts/Profile/views/EnsWelcomeView.qml
+++ b/ui/app/AppLayouts/Profile/views/EnsWelcomeView.qml
@@ -3,6 +3,7 @@ import QtQuick.Layouts 1.3
 import QtQuick.Controls 2.14
 
 import StatusQ.Core 0.1
+import StatusQ.Core.Theme 0.1
 import StatusQ.Controls 0.1
 
 import utils 1.0
@@ -50,6 +51,7 @@ Item {
                 anchors.right: parent.right
                 horizontalAlignment: Text.AlignHCenter
                 wrapMode: Text.WordWrap
+                color: Theme.palette.directColor1
             }
 
             StatusBaseText {
@@ -63,6 +65,7 @@ Item {
                 anchors.right: parent.right
                 horizontalAlignment: Text.AlignHCenter
                 wrapMode: Text.WordWrap
+                color: Theme.palette.directColor1
             }
 
             StatusBaseText {
@@ -74,6 +77,7 @@ Item {
                 anchors.topMargin: 24
                 font.weight: Font.Bold
                 font.pixelSize: 14
+                color: Theme.palette.directColor1
             }
 
             StatusBaseText {
@@ -88,6 +92,7 @@ Item {
                 wrapMode: Text.WordWrap
                 font.weight: Font.Bold
                 font.pixelSize: 14
+                color: Theme.palette.directColor1
             }
 
             StatusBaseText {
@@ -101,6 +106,7 @@ Item {
                 anchors.right: parent.right
                 wrapMode: Text.WordWrap
                 font.pixelSize: 14
+                color: Theme.palette.directColor1
             }
 
             StatusBaseText {
@@ -112,6 +118,7 @@ Item {
                 anchors.topMargin: 24
                 font.weight: Font.Bold
                 font.pixelSize: 14
+                color: Theme.palette.directColor1
             }
 
             StatusBaseText {
@@ -126,6 +133,7 @@ Item {
                 wrapMode: Text.WordWrap
                 font.weight: Font.Bold
                 font.pixelSize: 14
+                color: Theme.palette.directColor1
             }
 
             StatusBaseText {
@@ -139,6 +147,7 @@ Item {
                 anchors.right: parent.right
                 wrapMode: Text.WordWrap
                 font.pixelSize: 14
+                color: Theme.palette.directColor1
             }
 
             StatusBaseText {
@@ -150,6 +159,7 @@ Item {
                 anchors.topMargin: 24
                 font.weight: Font.Bold
                 font.pixelSize: 14
+                color: Theme.palette.directColor1
             }
 
             StatusBaseText {
@@ -164,6 +174,7 @@ Item {
                 wrapMode: Text.WordWrap
                 font.weight: Font.Bold
                 font.pixelSize: 14
+                color: Theme.palette.directColor1
             }
 
             StatusBaseText {
@@ -177,6 +188,7 @@ Item {
                 wrapMode: Text.WordWrap
                 anchors.topMargin: 24
                 font.pixelSize: 14
+                color: Theme.palette.directColor1
             }
 
             StatusBaseText {
@@ -188,6 +200,7 @@ Item {
                 anchors.topMargin: 24
                 font.weight: Font.Bold
                 font.pixelSize: 14
+                color: Theme.palette.directColor1
             }
 
             StatusBaseText {
@@ -202,6 +215,7 @@ Item {
                 wrapMode: Text.WordWrap
                 font.weight: Font.Bold
                 font.pixelSize: 14
+                color: Theme.palette.directColor1
             }
 
             StatusBaseText {
@@ -215,6 +229,7 @@ Item {
                 anchors.right: parent.right
                 wrapMode: Text.WordWrap
                 font.pixelSize: 14
+                color: Theme.palette.directColor1
             }
 
 
@@ -227,6 +242,7 @@ Item {
                 anchors.topMargin: 24
                 font.weight: Font.Bold
                 font.pixelSize: 14
+                color: Theme.palette.directColor1
             }
 
             StatusBaseText {
@@ -241,6 +257,7 @@ Item {
                 wrapMode: Text.WordWrap
                 font.weight: Font.Bold
                 font.pixelSize: 14
+                color: Theme.palette.directColor1
             }
 
             StatusBaseText {
@@ -254,6 +271,7 @@ Item {
                 anchors.right: parent.right
                 wrapMode: Text.WordWrap
                 font.pixelSize: 14
+                color: Theme.palette.directColor1
             }
 
             StatusBaseText {
@@ -267,6 +285,7 @@ Item {
                 anchors.right: parent.right
                 wrapMode: Text.WordWrap
                 font.pixelSize: 11
+                color: Theme.palette.directColor1
             }
         }
     }

--- a/ui/app/AppLayouts/Profile/views/NotificationsView.qml
+++ b/ui/app/AppLayouts/Profile/views/NotificationsView.qml
@@ -177,6 +177,7 @@ ScrollView {
                 font.pixelSize: 15
                 anchors.left: parent.left
                 anchors.right: parent.right
+                color: Theme.palette.directColor1
             }
 
             Column {
@@ -236,6 +237,7 @@ ScrollView {
                 text: qsTrId("no-preview-or-advanced--go-to-notification-center")
                 font.pixelSize: 15
                 anchors.left: parent.left
+                color: Theme.palette.directColor1
             }
         }
 

--- a/ui/app/AppLayouts/Profile/views/SoundsView.qml
+++ b/ui/app/AppLayouts/Profile/views/SoundsView.qml
@@ -5,6 +5,7 @@ import QtQuick.Layouts 1.13
 import utils 1.0
 
 import StatusQ.Core 0.1
+import StatusQ.Core.Theme 0.1
 import StatusQ.Controls 0.1
 
 Item {
@@ -27,6 +28,7 @@ Item {
             //% "Sound volume"
             text: qsTrId("sound-volume") + " " + volume.value.toPrecision(1)
             font.pixelSize: 15
+            color: Theme.palette.directColor1
         }
 
         StatusSlider {

--- a/ui/app/AppLayouts/Profile/views/SyncView.qml
+++ b/ui/app/AppLayouts/Profile/views/SyncView.qml
@@ -159,6 +159,7 @@ Item {
             anchors.leftMargin: 24
             anchors.top: addMailserver.bottom
             anchors.topMargin: 24
+            color: Theme.palette.directColor1
         }
 
         StatusSwitch {
@@ -179,6 +180,7 @@ Item {
             anchors.top: switchLbl.bottom
             anchors.topMargin: 24
             visible: automaticSelectionSwitch.checked
+            color: Theme.palette.directColor1
         }
 
         ListView {


### PR DESCRIPTION
When we switched to `StatusBaseText` we lost the default theme color.
We probably want to consider giving `StatusBaseText` a default theme color
similar to `StyledText` did.