### PR TITLE
fix(@refactoring/base_01): crash on recovering account

### DIFF
--- a/src/app_service/service/contacts/service.nim
+++ b/src/app_service/service/contacts/service.nim
@@ -40,13 +40,25 @@ QtObject:
     result.threadpool = threadpool
     result.contacts = initTable[string, ContactsDto]()
 
+  proc fetchContacts(self: Service) =
+    try:
+      let response = status_contacts.getContacts()
+
+      let contacts = map(response.result.getElems(), proc(x: JsonNode): ContactsDto = x.toContactsDto())
+
+      for contact in contacts:
+        self.contacts[contact.id] = contact
+
+    except Exception as e:
+      let errDesription = e.msg
+      error "error: ", errDesription
+      return
+
   proc init*(self: Service) =
-    discard
+    self.fetchContacts()
 
   proc getContacts*(self: Service): seq[ContactsDto] =
-    let profiles = status_contacts.getContacts()
-    for profile in profiles.result:
-      result.add(profile.toContactsDto)
+    return toSeq(self.contacts.values)
 
   proc getContact*(self: Service, id: string): ContactsDto =
     return status_contacts.getContactByID(id).result.toContactsDto()


### PR DESCRIPTION
It was very hidden issue here, crash is not reproducible neither on mac nor on win if you're building and running the app, but only if you're testing installed app and finally I managed to catch it on Win using windows installer.

The thing is in `JsonNode` cause returned result from the `status_contacts.getContacts` is actually a `JsonNode` which is not an iterable type, and we need to make it iterable first using [getElems](https://nim-lang.org/docs/json.html#getElems%2CJsonNode%2Cseq%5BJsonNode%5D) and then do a for loop over it. Also an exception may happen extracting properties form `toContactsDto` proc raised by Json module, that's why we must have that in try/catch.

@anastasiyaig hope the crash is behind us now.

Fixes: #3953