### PR TITLE
fix(@desktop/onboarding):  All chat names are not displayed on the popup

### DIFF
--- a/ui/app/AppLayouts/Onboarding/panels/AccountListPanel.qml
+++ b/ui/app/AppLayouts/Onboarding/panels/AccountListPanel.qml
@@ -13,8 +13,7 @@ ListView {
 
     anchors.fill: parent
     focus: true
-    spacing: Style.current.smallPadding
-    clip: true
+    spacing: Style.current.halfPadding
 
     delegate: AccountViewDelegate {
         username: model.username


### PR DESCRIPTION
There is no need to allow user to scroll here as all the 5 chat name options should be visible on the popup already.

fixes #3823