### PR TITLE
Fix context menu losing data and group info being empty sometimes

### DIFF
--- a/src/app/chat/views/channel.nim
+++ b/src/app/chat/views/channel.nim
@@ -305,12 +305,6 @@ QtObject:
     if (selectedChannel == nil): return false
     result = selectedChannel.muted  
 
-  proc getChatItemById*(self: ChannelView, id: string): QObject {.slot.} =
-    let chat = self.getChannelById(id)
-    let chatItemView = newChatItemView(self.status)
-    chatItemView.setChatItem(chat)
-    return chatItemView
-
   proc removeChat*(self: ChannelView, chatId: string) =
     discard self.chats.removeChatItemFromList(chatId)
     self.setActiveChannel(backToFirstChat)

--- a/ui/app/AppLayouts/Chat/views/CommunityColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/CommunityColumnView.qml
@@ -228,9 +228,12 @@ Item {
             }
 
             chatListPopupMenu: ChatContextMenuView {
+                id: chatContextMenuView
                 store: root.store
                 openHandler: function (id) {
-                    chatItem = root.store.chatsModelInst.channelView.getChatItemById(id)
+                    root.store.chatsModelInst.channelView.setContextChannel(id)
+                    chatContextMenuView.chatItem = root.store.chatsModelInst.channelView.contextChannel
+                
                 }
             }
         }

--- a/ui/app/AppLayouts/Chat/views/ContactsColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ContactsColumnView.qml
@@ -259,9 +259,11 @@ Item {
             onChatItemUnmuted: root.store.chatsModelInst.channelView.unmuteChatItem(id)
 
             popupMenu: ChatContextMenuView {
+                id: chatContextMenuView
                 store: root.store
                 openHandler: function (id) {
-                    chatItem = root.store.chatsModelInst.channelView.getChatItemById(id)
+                    root.store.chatsModelInst.channelView.setContextChannel(id)
+                    chatContextMenuView.chatItem = root.store.chatsModelInst.channelView.contextChannel
                 }
             }
         }


### PR DESCRIPTION
This fixes the issue where the Group Info popup would be empty when opening it from the context menu from the channel column.

This was a very weird issue to track, because sometimes, the channel data would be there, and then a second later, disappear, without ever being changed.
I tried to track down what or where it could change and I didn't exactly find an answer. It just seems that whenever a new API call was received, the memory would be erased.

Basically, what we used to do is call `getChatItemById` to receive the Channel as a fresh view.
While it works when you receive it, I think the garbage collector ends up removing it, because it is not binded to any model.

What I did to fix it is just use the `contextChannel` property we already had. Somehow, it was never used, but that is the exact use case where it would be useful. It gets the right channel with the id like `getChatItemById`, but stores it in the model as long as needed. 
It shouldn't change, since it is only changed when opening the context menu, and since we are in it or in a child of it, it's good.

Let me know if you know why the use of `contextChannel` was stopped. Maybe there is a reason to not use it that I missed.

Also, I removed `getChatItemById` because the data being erased is very annoying to debug and can happen very randomly. While that function is useful for quick data checks on a channel, it could be again used by accident on a "long-living" channel check and create the issue.