### PR TITLE
fix(desktop/chat) view group context menu

### DIFF
--- a/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
@@ -212,9 +212,6 @@ Item {
 
                 popupMenu: ChatContextMenuView {
                     store: root.rootStore
-                    onOpened: {
-                        chatItem = root.rootStore.chatsModelInst.channelView.activeChannel
-                    }
                 }
             }
 

--- a/ui/app/AppLayouts/Chat/views/ChatContextMenuView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatContextMenuView.qml
@@ -11,8 +11,8 @@ import "../popups"
 
 StatusPopupMenu {
     id: root
-    property var chatItem
     property var store
+    property var chatItem: root.store.chatsModelInst.channelView.activeChannel
     property bool communityActive: root.store.chatsModelInst.communities.activeCommunity.active
 
     StatusMenuItem {
@@ -57,7 +57,6 @@ StatusPopupMenu {
     StatusMenuSeparator {
         visible: viewProfileMenuItem.enabled
     }
-
 
     Action {
         enabled: root.store.profileModelInst.fleets.fleet == Constants.waku_prod || root.store.profileModelInst.fleets.fleet === Constants.waku_test

--- a/ui/app/AppLayouts/Chat/views/CommunityColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/CommunityColumnView.qml
@@ -229,9 +229,6 @@ Item {
 
             chatListPopupMenu: ChatContextMenuView {
                 store: root.store
-                openHandler: function (id) {
-                    chatItem = root.store.chatsModelInst.channelView.getChatItemById(id)
-                }
             }
         }
 

--- a/ui/app/AppLayouts/Chat/views/ContactsColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ContactsColumnView.qml
@@ -260,9 +260,6 @@ Item {
 
             popupMenu: ChatContextMenuView {
                 store: root.store
-                openHandler: function (id) {
-                    chatItem = root.store.chatsModelInst.channelView.getChatItemById(id)
-                }
             }
         }
 


### PR DESCRIPTION
View group context menu when opened from the chats list
with right click was not displaying correctly. As per
design, updated StatusChatList to also activate the channel
and then open the menu with the active channel's info

Closes #3975
Depends on: https://github.com/status-im/StatusQ/pull/483