### PR TITLE
fix(TransferOwnershipPopup): ensure community key is exported properly

### DIFF
--- a/ui/app/AppLayouts/Chat/panels/communities/BackUpCommuntyBannerPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/BackUpCommuntyBannerPanel.qml
@@ -7,10 +7,10 @@ import StatusQ.Controls 0.1
 import StatusQ.Components 0.1
 
 import utils 1.0
-import "../../popups/community"
 
 Rectangle {
     property var activeCommunity
+    signal backupButtonClicked(var mouse)
 
     id: root
     height: childrenRect.height + Style.current.padding
@@ -20,7 +20,7 @@ Rectangle {
     anchors.rightMargin: Style.current.padding
     border.color: Style.current.border
     radius: 16
-    color: Style.current.transparent
+    color: "transparent"
 
     Rectangle {
         width: 66
@@ -63,24 +63,7 @@ Rectangle {
         anchors.horizontalCenter: parent.horizontalCenter
         anchors.top: backUpText.bottom
         anchors.topMargin: Style.current.padding
-        onClicked: {
-            openPopup(transferOwnershipPopup, {privateKey: chatsModel.communities.exportCommunity()})
-        }
-    }
-
-    Component {
-        id: transferOwnershipPopup
-        TransferOwnershipPopup {
-            anchors.centerIn: parent
-            onClosed: {
-                let hiddenBannerIds = localAccountSensitiveSettings.hiddenCommunityBackUpBanners || []
-                if (hiddenBannerIds.includes(root.activeCommunity.id)) {
-                    return
-                }
-                hiddenBannerIds.push(root.activeCommunity.id)
-                localAccountSensitiveSettings.hiddenCommunityBackUpBanners = hiddenBannerIds
-            }
-        }
+        onClicked: root.backupButtonClicked(mouse)
     }
 }
 

--- a/ui/app/AppLayouts/Chat/popups/community/CommunityProfilePopup.qml
+++ b/ui/app/AppLayouts/Chat/popups/community/CommunityProfilePopup.qml
@@ -67,7 +67,10 @@ StatusModal {
                     store: root.store,
                     community: root.community
                 })
-                onTransferOwnershipButtonClicked: openPopup(transferOwnershiproot, {privateKey: root.store.exportCommunity()})
+                onTransferOwnershipButtonClicked: openPopup(transferOwnershiproot, {
+                    privateKey: root.store.exportCommunity(),
+                    store: root.store
+                })
                 onLeaveButtonClicked: {
                     root.store.leaveCommunity(root.community.id);
                     root.close();

--- a/ui/app/AppLayouts/Chat/popups/community/TransferOwnershipPopup.qml
+++ b/ui/app/AppLayouts/Chat/popups/community/TransferOwnershipPopup.qml
@@ -15,6 +15,7 @@ StatusModal {
     id: popup
 
     property string privateKey
+    property var store
 
     //% "Transfer ownership"
     header.title: qsTrId("transfer-ownership")
@@ -25,7 +26,7 @@ StatusModal {
 
     contentItem: Item {
         width: popup.width
-        height: Math.max(300, content.height + 32)
+        implicitHeight: Math.max(300, content.height + 32)
         Column {
             id: content
             anchors.top: parent.top
@@ -35,26 +36,32 @@ StatusModal {
             width: popup.width - 32
             spacing: 16
 
-            Input {
+            StatusInput {
                 property string elidedPkey: popup.privateKey.substring(0, 15) + "..." + popup.privateKey.substring(popup.privateKey.length - 16)
 
                 id: pKeyInput
-                width: parent.width
-
-                //% "Community private key"
-                label: qsTrId("community-key")
-                text: elidedPkey
-                textField.onFocusChanged: {
-                    if (textField.focus) {
-                      pKeyInput.text =  popup.privateKey
-                    } else {
-                        pKeyInput.text =  elidedPkey
+                anchors.left: parent.left
+                anchors.right: parent.right
+                leftPadding: 0
+                rightPadding: 0
+                label: qsTr("Community private key")
+                input.text: elidedPkey
+                input.edit.onActiveFocusChanged: {
+                    pKeyInput.input.text =  pKeyInput.input.edit.focus ? popup.privateKey : elidedPkey
+                }
+                input.component: StatusButton {
+                    anchors.verticalCenter: parent.verticalCenter
+                    border.width: 1
+                    border.color: Theme.palette.primaryColor1
+                    size: StatusBaseButton.Size.Tiny
+                    text: qsTr("Copy")
+                    onClicked: {
+                        text = qsTr("Copied")
+                        popup.store.copyToClipboard(popup.privateKey)
                     }
                 }
-
-                copyToClipboard: true
-                textToCopy: popup.privateKey
             }
+
 
             StatusBaseText {
                 id: infoText1

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -114,7 +114,7 @@ QtObject {
     }
 
     function exportCommunity() {
-        chatsModelInst.communities.exportCommunity();
+        return chatsModelInst.communities.exportCommunity();
     }
 
     function createCommunityChannel(communityId, channelName, channelDescription, categoryId) {

--- a/ui/app/AppLayouts/Chat/views/CommunityColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/CommunityColumnView.qml
@@ -272,6 +272,12 @@ Item {
                     BackUpCommuntyBannerPanel {
                         id: backupBanner
                         activeCommunity: store.activeCommunity
+                        onBackupButtonClicked: {
+                            openPopup(transferOwnershipPopup, { 
+                                privateKey: root.store.exportCommunity(),
+                                store: root.store
+                            })
+                        }
                     }
                     MouseArea {
                         anchors.fill: backupBanner
@@ -352,6 +358,20 @@ Item {
         }
     }
 
+    Component {
+        id: transferOwnershipPopup
+        TransferOwnershipPopup {
+            anchors.centerIn: parent
+            onClosed: {
+                let hiddenBannerIds = localAccountSensitiveSettings.hiddenCommunityBackUpBanners || []
+                if (hiddenBannerIds.includes(root.store.activeCommunity.id)) {
+                    return
+                }
+                hiddenBannerIds.push(root.store.activeCommunity.id)
+                localAccountSensitiveSettings.hiddenCommunityBackUpBanners = hiddenBannerIds
+            }
+        }
+    }
 }
 
 /*##^##


### PR DESCRIPTION
There was a bug in our store where an API wouldn't return a value.
This commit fixes this and also replaces the legacy `Input` component
with StatusInput

Fixes: #4082

