### PR TITLE
fix(@desktop/profile): Fix to show a confirmation that the contact was added

### DIFF
--- a/ui/app/AppLayouts/Profile/views/ContactsView.qml
+++ b/ui/app/AppLayouts/Profile/views/ContactsView.qml
@@ -255,6 +255,9 @@ Item {
             hideBlocked: true
             searchString: searchBox.text
 
+            // To show the correct status (added/not added)in the addContactModal.
+            onCountChanged: searchResults.isAddedContact = searchResults.isContactAdded()
+
             onContactClicked: {
                 root.store.changeAppSectionBySectionType(Constants.appSection.chat)
                 root.store.joinPrivateChat(contact.address)

--- a/ui/imports/shared/views/SearchResults.qml
+++ b/ui/imports/shared/views/SearchResults.qml
@@ -28,7 +28,7 @@ Item {
     property bool resultClickable: true
     property bool addContactEnabled: true
 
-    property bool isAddedContact: pubKey != "" ? chatsModel.messageView.isAddedContact(pubKey) : false
+    property bool isAddedContact: isContactAdded()
 
     signal resultClicked(string pubKey)
     signal addToContactsButtonClicked(string pubKey)
@@ -39,6 +39,10 @@ Item {
         username = ""
         userAlias = ""
         pubKey = ""
+    }
+
+    function isContactAdded() {
+        return pubKey != "" ? chatsModel.messageView.isAddedContact(pubKey) : false
     }
 
     width: parent.width


### PR DESCRIPTION
### What does the PR do

Added logic to update status of the contact being search once it is added to contact list. Basically to show the "check-mark" on the Add Contact modal after a contact was successfully added

### Affected areas

Profile/Settings

### Screenshot of functionality

![image](https://user-images.githubusercontent.com/60327365/141331562-bdcdd7e1-31dc-4494-ac32-538f28ef0084.png)

### Cool Spaceship Picture

:dancers: 
