### PR TITLE
feat: add toggle for switching status-go DEBUG log level

### DIFF
--- a/src/app/modules/main/profile_section/controller.nim
+++ b/src/app/modules/main/profile_section/controller.nim
@@ -43,3 +43,9 @@ method toggleTelemetry*[T](self: Controller[T]) =
 
 method isTelemetryEnabled*[T](self: Controller[T]): bool = 
   return self.settingsService.isTelemetryEnabled()
+
+method toggleDebug*[T](self: Controller[T]) = 
+  self.settingsService.toggleDebug()
+
+method isDebugEnabled*[T](self: Controller[T]): bool = 
+  return self.settingsService.isDebugEnabled()

--- a/src/app/modules/main/profile_section/controller_interface.nim
+++ b/src/app/modules/main/profile_section/controller_interface.nim
@@ -15,6 +15,12 @@ method toggleTelemetry*(self: AccessInterface) {.base.} =
 method isTelemetryEnabled*(self: AccessInterface): bool {.base.} = 
   raise newException(ValueError, "No implementation available")
 
+method toggleDebug*(self: AccessInterface) {.base.} = 
+  raise newException(ValueError, "No implementation available")
+
+method isDebugEnabled*(self: AccessInterface): bool {.base.} = 
+  raise newException(ValueError, "No implementation available")
+
 type
   ## Abstract class (concept) which must be implemented by object/s used in this 
   ## module.

--- a/src/app/modules/main/profile_section/io_interface.nim
+++ b/src/app/modules/main/profile_section/io_interface.nim
@@ -14,6 +14,9 @@ method isLoaded*(self: AccessInterface): bool {.base.} =
 method toggleTelemetry*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method toggleDebug*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 # View Delegate Interface
 # Delegate for the view must be declared here due to use of QtObject and multi 
 # inheritance, which is not well supported in Nim.

--- a/src/app/modules/main/profile_section/module.nim
+++ b/src/app/modules/main/profile_section/module.nim
@@ -86,6 +86,7 @@ method load*[T](self: Module[T]) =
   self.aboutModule.load()
 
   self.view.setIsTelemetryEnabled(self.controller.isTelemetryEnabled())
+  self.view.setIsDebugEnabled(self.controller.isDebugEnabled())
 
   self.moduleLoaded = true
   self.delegate.profileSectionDidLoad()
@@ -98,3 +99,6 @@ method viewDidLoad*(self: Module) =
 
 method toggleTelemetry*[T](self: Module[T]) = 
   self.controller.toggleTelemetry()
+
+method toggleDebug*[T](self: Module[T]) =
+  self.controller.toggleDebug()

--- a/src/app/modules/main/profile_section/view.nim
+++ b/src/app/modules/main/profile_section/view.nim
@@ -8,6 +8,7 @@ QtObject:
       delegate: io_interface.AccessInterface
       # TODO: move to the correct module once all have been merged
       isTelemetryEnabled: bool
+      isDebugEnabled: bool
 
   proc setup(self: View) = 
     self.QObject.setup
@@ -36,3 +37,20 @@ QtObject:
   proc toggleTelemetry*(self: View) {.slot.} = 
     self.delegate.toggleTelemetry()
     self.setIsTelemetryEnabled(not self.isTelemetryEnabled)
+
+  proc isDebugEnabledChanged*(self: View) {.signal.}
+
+  proc setIsDebugEnabled*(self: View, isDebugEnabled: bool) =
+    self.isDebugEnabled = isDebugEnabled
+    self.isDebugEnabledChanged()
+
+  proc getIsDebugEnabled*(self: View): QVariant {.slot.} =
+    return newQVariant(self.isDebugEnabled)
+
+  QtProperty[QVariant] isDebugEnabled:
+    read = getIsDebugEnabled
+    notify = isDebugEnabledChanged
+
+  proc toggleDebug*(self: View) {.slot.} = 
+    self.delegate.toggleDebug()
+    self.setIsDebugEnabled(not self.isDebugEnabled)

--- a/src/app_service/common/account_constants.nim
+++ b/src/app_service/common/account_constants.nim
@@ -2,6 +2,7 @@ import # std libs
   json, os
 
 import utils
+import chronicles
 
 const GENERATED* = "generated"
 const SEED* = "seed"
@@ -122,7 +123,7 @@ var NODE_CONFIG* = %* {
   #"ListenAddr": ":30304",
   "LogEnabled": true,
   "LogFile": "geth.log",
-  "LogLevel": "INFO",
+  "LogLevel": $LogLevel.INFO,
   "MailserversConfig": {
     "Enabled": true
   },

--- a/src/app_service/service/accounts/service.nim
+++ b/src/app_service/service/accounts/service.nim
@@ -189,7 +189,7 @@ proc prepareAccountSettingsJsonObject(self: Service, account: GeneratedAccountDt
     "wallet-root-address": account.derivedAccounts.walletRoot.address,
     "preview-privacy?": true,
     "signing-phrase": generateSigningPhrase(3),
-    "log-level": "INFO",
+    "log-level": $LogLevel.INFO,
     "latest-derived-path": 0,
     "networks/networks": DEFAULT_NETWORKS,
     "currency": "usd",

--- a/src/app_service/service/settings/service.nim
+++ b/src/app_service/service/settings/service.nim
@@ -88,3 +88,16 @@ method toggleTelemetry*(self: Service) =
 method isTelemetryEnabled*(self: Service): bool =
   let telemetryServerUrl = status_go_settings.getSetting[string](Setting.TelemetryServerUrl)
   return telemetryServerUrl != ""
+
+method toggleDebug*(self: Service) =
+  var nodeConfig = status_go_settings.getNodeConfig()
+  if nodeConfig["LogLevel"].getStr() == $LogLevel.INFO:
+    nodeConfig["LogLevel"] = newJString($LogLevel.DEBUG)
+  else:
+    nodeConfig["LogLevel"] = newJString($LogLevel.INFO)
+  discard status_go_settings.saveSetting(Setting.NodeConfig, nodeConfig)
+  quit(QuitSuccess) # quits the app TODO: change this to logout instead when supported
+
+method isDebugEnabled*(self: Service): bool =
+  let nodeConfig = status_go_settings.getNodeConfig()
+  return nodeConfig["LogLevel"].getStr() != $LogLevel.INFO

--- a/src/app_service/service/settings/service_interface.nim
+++ b/src/app_service/service/settings/service_interface.nim
@@ -53,3 +53,9 @@ method toggleTelemetry*(self: ServiceInterface) {.base.} =
 
 method isTelemetryEnabled*(self: ServiceInterface): bool {.base.} =
   raise newException(ValueError, "No implementation available")
+
+method toggleDebug*(self: ServiceInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method isDebugEnabled*(self: ServiceInterface): bool {.base.} =
+  raise newException(ValueError, "No implementation available")

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -14,6 +14,8 @@ QtObject {
     property var profileModelInst: profileModel
     property var profileModuleInst: profileModule
 
+    property bool isDebugEnabled: profileSectionModule.isDebugEnabled
+
     property var activeCommunity: chatsModelInst.communities.activeCommunity
 
     function copyToClipboard(text) {

--- a/ui/app/AppLayouts/Chat/views/MessageContextMenuView.qml
+++ b/ui/app/AppLayouts/Chat/views/MessageContextMenuView.qml
@@ -274,6 +274,17 @@ StatusPopupMenu {
     }
 
     StatusMenuItem {
+        id: copyMessageIdAction
+        text: qsTr("Copy Message Id")
+        icon.name: "chat"
+        enabled: store.isDebugEnabled
+        onTriggered: {
+            root.store.chatsModelInst.copyToClipboard(SelectedMessage.messageId)
+            close()
+        }
+    }
+
+    StatusMenuItem {
         id: pinAction
         text: {
             if (pinnedMessage) {

--- a/ui/app/AppLayouts/Profile/views/AdvancedView.qml
+++ b/ui/app/AppLayouts/Profile/views/AdvancedView.qml
@@ -416,6 +416,15 @@ ScrollView {
                     openPopup(enableTelemetryConfirmationDialogComponent, {light: false})
                 }
             }
+
+            StatusSettingsLineButton {
+                text: qsTr("Debug")
+                isSwitch: true
+                switchChecked: root.store.profileModuleInst.isDebugEnabled
+                onClicked: {
+                    openPopup(enableDebugComponent)
+                }
+            }
         }
 
         NetworksModal {
@@ -436,6 +445,26 @@ ScrollView {
                 confirmationText: qsTr("Are you sure you want to enable telemetry? This will reduce your privacy level while using Status. You need to restart the app for this change to take effect.")
                 onConfirmButtonClicked: {
                     root.store.profileModuleInst.toggleTelemetry()
+                    close()
+                }
+                onCancelButtonClicked: {
+                    close()
+                }
+            }
+        }
+
+        Component {
+            id: enableDebugComponent
+            ConfirmationDialog {
+                property bool mode: false
+
+                id: confirmDialog
+                showCancelButton: true
+                confirmationText: qsTr("Are you sure you want to %1 debug mode? The app will be restarted for this change to take effect.").arg(root.store.profileModuleInst.isDebugEnabled ? 
+                    qsTr("disable") : 
+                    qsTr("enable"))
+                onConfirmButtonClicked: {
+                    root.store.profileModuleInst.toggleDebug()
                     close()
                 }
                 onCancelButtonClicked: {


### PR DESCRIPTION
Fixes #4083 

In a separate PR, i'll make the toggle also switch chronicles log level, since it probably makes sense for release versions to run in info level by default (right now it runs in debug level)