### PR TITLE
fix(desktop/wallet) wrong pass message was not displayed

### DIFF
--- a/ui/app/AppLayouts/Wallet/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Wallet/stores/RootStore.qml
@@ -99,7 +99,8 @@ QtObject {
     }
 
     function addAccountsFromSeed(seedPhrase, password, accountName, color) {
-        return walletSectionAccounts.addAccountsFromSeed(seedPhrase, password, accountName, color)
+        //return walletSectionAccounts.addAccountsFromSeed(seedPhrase, password, accountName, color)
+        return walletModel.accountsView.addAccountsFromSeed(seedPhrase, password, accountName, color)
     }
 
     function addWatchOnlyAccount(address, accountName, color) {


### PR DESCRIPTION
When adding an accound with seed phrase and inserting a
wrong password, the error message was not displayed.

Switched addAccountsFromSeed functions in store to use
walletModel.accountsView.addAccountsFromSeed instead of
walletSectionAccounts.addAccountsFromSeed

Closes #4068