### PR TITLE
fix(dekstop/wallet) wrong account color displayed

### DIFF
--- a/ui/app/AppLayouts/Wallet/panels/WalletHeader.qml
+++ b/ui/app/AppLayouts/Wallet/panels/WalletHeader.qml
@@ -10,6 +10,7 @@ import shared.popups 1.0
 import shared.status 1.0
 import "../popups"
 import "../controls"
+import "../stores"
 
 Item {
     id: walletHeader
@@ -78,7 +79,7 @@ Item {
             onClosed: {
                 destroy();
             }
-            selectedAccount: RootStore.leggacyCurrentAccount
+            selectedAccount: RootStore.currentAccount
         }
     }
 

--- a/ui/app/AppLayouts/Wallet/popups/ReceiveModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/ReceiveModal.qml
@@ -47,7 +47,7 @@ ModalPopup {
         id: accountSelector
         label: ""
         showAccountDetails: false
-        accounts: RootStore.leggacyAccounts
+        accounts: RootStore.accounts
         currency: RootStore.currentCurrency
         anchors.top: qrCodeBox.bottom
         anchors.topMargin: Style.current.padding

--- a/ui/app/AppLayouts/Wallet/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Wallet/stores/RootStore.qml
@@ -5,10 +5,6 @@ import QtQuick 2.13
 QtObject {
     id: root
 
-    // TODO: Received modal is not yet migrated
-    property var leggacyAccounts: walletModel.accountsView.accounts
-    property var leggacyCurrentAccount: walletModel.accountsView.currentAccount
-
     property var currentAccount: walletSectionCurrent
     property var accounts: walletSectionAccounts.model
 


### PR DESCRIPTION
In receive modal the account color was not corresponding to
the actual account color

* Updated StatusAccountSelector to use accounts from
  new backend
* Updated WalletHeader to use currentAccount from new
  backend

Closes #4071
