### PR TITLE
fix(Communities): ensure members count is updated when owner leaves c…

### DIFF
--- a/src/app/chat/view.nim
+++ b/src/app/chat/view.nim
@@ -136,6 +136,7 @@ QtObject:
   proc setPubKey*(self: ChatsView, pubKey: string) =
     self.pubKey = pubKey
     self.messageView.pubKey = pubKey
+    self.communities.pubKey = pubKey
 
   proc getFormatInput(self: ChatsView): QVariant {.slot.} = newQVariant(self.formatInputView)
   QtProperty[QVariant] formatInputView:

--- a/src/app/chat/views/communities.nim
+++ b/src/app/chat/views/communities.nim
@@ -41,6 +41,7 @@ QtObject:
     myCommunityRequests*: seq[CommunityMembershipRequest]
     importingCommunityState: CommunityImportState
     communityImportingProcessId: string
+    pubKey*: string
 
   proc setup(self: CommunitiesView) =
     self.QObject.setup
@@ -60,6 +61,7 @@ QtObject:
     result.observedCommunity = newCommunityItemView(status)
     result.communityList = newCommunityList(status)
     result.joinedCommunityList = newCommunityList(status)
+    result.pubKey = ""
     result.setup
 
   proc importingCommunityStateChanged*(self: CommunitiesView, state: int, communityImportingProcessId: string) {.signal.}
@@ -390,6 +392,8 @@ QtObject:
       self.joinedCommunitiesChanged()
       var updatedCommunity = self.communityList.getCommunityById(communityId)
       updatedCommunity.joined = false
+      let i = updatedCommunity.members.find(self.pubKey)
+      updatedCommunity.members.delete(i)
       self.communityList.replaceCommunity(updatedCommunity)
       self.communitiesChanged()
       self.communityChanged(communityId)


### PR DESCRIPTION
…ommunity

When an owner of a community leaves its own community, we optimistically update the
members list in Status Desktop. The `LeaveCommunity` API that is called via status-lib
has been updated to correctly remove that member as well.

This depends on https://github.com/status-im/status-go/pull/2429

Fixes #4074

### What does the PR do

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas

<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Screenshot of functionality

<!-- screenshot (or gif/video) that demonstrates the functionality, specially important if it's a bug fix. -->

### Cool Spaceship Picture

<!-- optional but cool ->
