### PR TITLE
fix: Fix missing setup url for new opened tab

### DIFF
--- a/ui/app/AppLayouts/Browser/BrowserLayout.qml
+++ b/ui/app/AppLayouts/Browser/BrowserLayout.qml
@@ -100,8 +100,8 @@ Rectangle {
     }
 
     function openUrlInNewTab(url) {
-        browserWindow.addNewTab()
-        determineRealURL(url)
+        var tab = browserWindow.addNewTab()
+        tab.item.url = determineRealURL(url)
     }
 
     function addNewDownloadTab() {
@@ -110,10 +110,12 @@ Rectangle {
     }
 
     function addNewTab() {
-        tabs.createEmptyTab(tabs.count !== 0 ? currentWebView.profile : defaultProfile);
+        var tab = tabs.createEmptyTab(tabs.count !== 0 ? currentWebView.profile : defaultProfile);
         tabs.currentIndex = tabs.count - 1;
         browserHeader.addressBar.forceActiveFocus();
         browserHeader.addressBar.selectAll();
+
+        return tab;
     }
 
     function onDownloadRequested(download) {


### PR DESCRIPTION
Closes: #4107

### What does the PR do

This PR add return new created from `addNewTab()` method and use it for requested opening url.

### Affected areas

`BrowserLayout`

### Screenshot of functionality

![ezgif com-gif-maker (1)](https://user-images.githubusercontent.com/82511785/141784319-687bd1f0-e23e-458d-9591-b21a13a72590.gif)

