### PR TITLE
fix(@desktop/profile): Custom picture is not applied everywhere in the app without restart

### DIFF
--- a/src/app/core/user_profile.nim
+++ b/src/app/core/user_profile.nim
@@ -29,6 +29,9 @@ QtObject:
     self.address = address
     self.identicon = identicon
     self.pubKey = pubKey
+
+  proc getIdenticon*(self: UserProfile): string {.slot.} =
+    self.identicon
   
   proc getUsername*(self: UserProfile): string {.slot.} = 
     self.username

--- a/src/app/modules/main/profile_section/profile/controller.nim
+++ b/src/app/modules/main/profile_section/profile/controller.nim
@@ -43,7 +43,7 @@ method getProfile*[T](self: Controller[T]): item.Item =
     id: singletonInstance.userProfile.getPubKey(),
     alias: "",
     username: singletonInstance.userProfile.getUsername(),
-    identicon: singletonInstance.userProfile.getThumbnailImage(), 
+    identicon: singletonInstance.userProfile.getIdenticon(),
     address: singletonInstance.userProfile.getAddress(),
     ensName: singletonInstance.userProfile.getEnsName(),
     ensVerified: false,
@@ -61,7 +61,11 @@ method getProfile*[T](self: Controller[T]): item.Item =
   return item
 
 method storeIdentityImage*[T](self: Controller[T], address: string, image: string, aX: int, aY: int, bX: int, bY: int): identity_image.IdentityImage =
-  self.profileService.storeIdentityImage(address, image, aX, aY, bX, bY)
+  result = self.profileService.storeIdentityImage(address, image, aX, aY, bX, bY)
+  singletonInstance.userProfile.setThumbnailImage(result.thumbnail)
+  singletonInstance.userProfile.setLargeImage(result.large)
 
 method deleteIdentityImage*[T](self: Controller[T], address: string): string =
-  self.profileService.deleteIdentityImage(address)
+  result = self.profileService.deleteIdentityImage(address)
+  singletonInstance.userProfile.setThumbnailImage("")
+  singletonInstance.userProfile.setLargeImage("")


### PR DESCRIPTION
fix(@desktop/profile): Custom picture is not applied everywhere in the app without restart

fixes #4099

### What does the PR do### Affected areas

Profile and NavBar

### Screenshot of functionality


https://user-images.githubusercontent.com/60327365/142012022-13b92bfc-0cae-4c9e-ba9e-ed94a200e82a.mov


### Cool Spaceship Picture

