### PR TITLE
fix(@desktop/browser): Fix for Favorites bar is not shown without disabling and enabling toggle

### DIFF
--- a/ui/app/AppLayouts/Browser/panels/BrowserHeader.qml
+++ b/ui/app/AppLayouts/Browser/panels/BrowserHeader.qml
@@ -31,7 +31,7 @@ Rectangle {
     signal addNewFavoritelClicked(var xPos)
 
     width: parent.width
-    height: barRow.height + favoritesBarLoader.height
+    height: barRow.height + (favoritesBarLoader.active ? favoritesBarLoader.height : 0)
     color: Style.current.background
     border.width: 0
 
@@ -270,7 +270,6 @@ Rectangle {
     Loader {
         id: favoritesBarLoader
         active: localAccountSensitiveSettings.shouldShowFavoritesBar
-        height: active ? item.height : 0
         anchors.top: barRow.bottom
         anchors.left: parent.left
         anchors.leftMargin: Style.current.smallPadding

--- a/ui/app/AppLayouts/Browser/panels/FavoritesBar.qml
+++ b/ui/app/AppLayouts/Browser/panels/FavoritesBar.qml
@@ -11,7 +11,7 @@ RowLayout {
     property alias bookmarkModel: bookmarkList.model
 
     spacing: 0
-    height: bookmarkModel.rowCount() > 0 ? 38: 0
+    height: 38
 
     ListView {
         id: bookmarkList


### PR DESCRIPTION
fix(@desktop/browser): Fix for Favorites bar is not shown without disabling and enabling toggle

Also fixed issue of overlap after a switch between disabled to enabled state

fixes #4105

### What does the PR do

This PR assigns a fixed height of 38 to the FavoritesBar because of which it was seen first time.

It also fixes the issue of overlap after a switch between disabled to enabled state

### Affected areas

Browser

### Screenshot of functionality

https://user-images.githubusercontent.com/60327365/142197548-579bd65f-14e2-4090-a91c-f36a938fdb0e.mov


### Cool Spaceship Picture

:dagger: 
