### PR TITLE
fix(app): fix minimizing the app on close for Windows and Linux

### DIFF
--- a/ui/main.qml
+++ b/ui/main.qml
@@ -96,8 +96,21 @@ StatusWindow {
     Connections {
         target: applicationWindow
         onClosing: {
-            loader.sourceComponent = undefined
-            close.accepted = true
+            if (Qt.platform.os === "osx") {
+                loader.sourceComponent = undefined
+                close.accepted = true
+            } else {
+                if (loader.sourceComponent == login) {
+                    Qt.quit();
+                }
+                else if (loader.sourceComponent == app) {
+                    if (localAccountSensitiveSettings.quitOnClose) {
+                        Qt.quit();
+                    } else {
+                        applicationWindow.visible = false;
+                    }
+                }
+            }
         }
 
         onActiveChanged: {


### PR DESCRIPTION
Fixes #4128

The app didn't minimize on Windows and Linux, because the handling of minimizing was moved to the Mac component