### PR TITLE
fix(@desktop/profile): changing language does not change it in UI

### DIFF
--- a/src/app/boot/app_controller.nim
+++ b/src/app/boot/app_controller.nim
@@ -270,6 +270,7 @@ proc load(self: AppController) =
   self.dappPermissionsService.init()
   self.walletAccountService.init()
   self.transactionService.init()
+  self.languageService.init()
 
   # other global instances
   self.buildAndRegisterLocalAccountSensitiveSettings()  


### PR DESCRIPTION
A call to the init of the language service was missing.
Calling it during boot process resolves the bug.

fixes #4104

### What does the PR do

A call to the init of the language service was missing.
Calling it during boot process, initialized the path to the .qm files and hence the languages are loaded correctly.

### Affected areas

Language

### Screenshot of functionality

https://user-images.githubusercontent.com/60327365/142438351-17652796-5750-479c-9cf0-223f17d1a5df.mov

### Cool Spaceship Picture

:1st_place_medal: 
