### PR TITLE
fix(@desktop/startUpPage): Fix for footer shown when clicking - share your chat key

### DIFF
--- a/ui/app/AppMain.qml
+++ b/ui/app/AppMain.qml
@@ -131,7 +131,7 @@ Item {
         if(parentPopup){
             popup.parentPopup = parentPopup;
         }
-        popup.openPopup(profileModule.pubKey !== fromAuthorParam, userNameParam, fromAuthorParam, identiconParam, textParam, nicknameParam);
+        popup.openPopup(profileModule.model.pubKey !== fromAuthorParam, userNameParam, fromAuthorParam, identiconParam, textParam, nicknameParam);
         profilePopupOpened = true
     }
 


### PR DESCRIPTION
fix(@desktop/startUpPage): Fix for footer shown when clicking - share your chat key

fixes #3462

### What does the PR do

The fix removes the footer when clicking - share you key when no chats are started on a profile

replaced the older profileModule.pubKey with the new profileModule.model.pubKey

### Affected areas

AppMain.qml

### Screenshot of functionality

![image](https://user-images.githubusercontent.com/60327365/142735940-4343fc02-fb2b-4c9c-b77a-bc687b1862e6.png)

### Cool Spaceship Picture

:)
