### PR TITLE
ci: upgrade ca-certificates in Linux Docker image

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -16,12 +16,11 @@ RUN export DEBIAN_FRONTEND=noninteractive \
  && sudo apt update -yq \
  && sudo apt purge -yq gnupg \
  && sudo apt install -yq --fix-missing \
-      build-essential cmake jq git s3cmd gnupg2 \
-      libpcre3-dev libnss3 libxcomposite1 libxtst6 \
+      build-essential cmake jq git s3cmd gnupg2 ca-certificates \
+      libpcre3-dev libnss3 libxcomposite1 libxtst6 libpcsclite-dev \
       gstreamer1.0-plugins-good gstreamer1.0-plugins-bad \
       gstreamer1.0-plugins-ugly gstreamer1.0-libav \
-      gstreamer1.0-tools gstreamer1.0-alsa gstreamer1.0-pulseaudio \
-      libpcsclite-dev
+      gstreamer1.0-tools gstreamer1.0-alsa gstreamer1.0-pulseaudio
 
 # Installing Golang
 RUN GOLANG_SHA256="d2c095c95f63c2a3ef961000e0ecb9d81d5c68b6ece176e2a8a2db82dc02931c" \

--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -21,7 +21,7 @@ pipeline {
   options {
     timestamps()
     /* Prevent Jenkins jobs from running forever */
-    timeout(time: 15, unit: 'MINUTES')
+    timeout(time: 20, unit: 'MINUTES')
     /* manage how many builds we keep */
     buildDiscarder(logRotator(
       numToKeepStr: '10',

--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -4,7 +4,7 @@ pipeline {
   agent {
     docker {
       label 'linux'
-      image 'statusteam/nim-status-client-build:1.1.0'
+      image 'statusteam/nim-status-client-build:1.1.1'
       /* allows jenkins use cat and mounts '/dev/fuse' for linuxdeployqt */
       args '--entrypoint="" --cap-add SYS_ADMIN --security-opt apparmor:unconfined --device /dev/fuse'
     }

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -16,7 +16,7 @@ pipeline {
   options {
     timestamps()
     /* Prevent Jenkins jobs from running forever */
-    timeout(time: 15, unit: 'MINUTES')
+    timeout(time: 20, unit: 'MINUTES')
     /* manage how many builds we keep */
     buildDiscarder(logRotator(
       numToKeepStr: '10',


### PR DESCRIPTION
Otherwise cloning of BearSSL fails with:
```
Cloning into '/home/jenkins/workspace/status-desktop/platforms/linux/vendor/status-lib/vendor/nim-task-runner/vendor/nim-bearssl/bearssl/csources'...
fatal: unable to access 'https://www.bearssl.org/git/BearSSL/': server certificate verification failed. CAfile: /etc/ssl/certs/ca-certificates.crt CRLfile: none
fatal: clone of 'https://www.bearssl.org/git/BearSSL' into submodule path '/home/jenkins/workspace/status-desktop/platforms/linux/vendor/status-lib/vendor/nim-task-runner/vendor/nim-bearssl/bearssl/csources' failed
Failed to clone 'bearssl/csources'. Retry scheduled
```
https://ci.status.im/job/status-desktop/job/platforms/job/linux/125/console
https://blog.dnsimple.com/2021/09/letsencrypt-intermediate-expiration/