### PR TITLE
ci: manually fix expired LetsEncrypt X3 root cert

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -22,6 +22,10 @@ RUN export DEBIAN_FRONTEND=noninteractive \
       gstreamer1.0-plugins-ugly gstreamer1.0-libav \
       gstreamer1.0-tools gstreamer1.0-alsa gstreamer1.0-pulseaudio
 
+# Fix LetsEncrypt X3 root certificate expliration
+RUN sudo sed -i 's#\(mozilla/DST_Root_CA_X3.crt\)#!\1#' /etc/ca-certificates.conf \
+ && sudo dpkg-reconfigure -fnoninteractive ca-certificates
+
 # Installing Golang
 RUN GOLANG_SHA256="d2c095c95f63c2a3ef961000e0ecb9d81d5c68b6ece176e2a8a2db82dc02931c" \
  && GOLANG_TARBALL="go1.16.9.linux-amd64.tar.gz" \

--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -4,7 +4,7 @@ pipeline {
   agent {
     docker {
       label 'linux'
-      image 'statusteam/nim-status-client-build:1.1.1'
+      image 'statusteam/nim-status-client-build:1.1.2'
       /* allows jenkins use cat and mounts '/dev/fuse' for linuxdeployqt */
       args '--entrypoint="" --cap-add SYS_ADMIN --security-opt apparmor:unconfined --device /dev/fuse'
     }


### PR DESCRIPTION
Just upgrading `ca-certificates` is not enough. This works though:
```
 > docker run --rm -it -u root statusteam/nim-status-client-build:1.1.2 /bin/bash
root@f7bd54502356:/home/user# git clone https://www.bearssl.org/git/BearSSL
Cloning into 'BearSSL'...
remote: Counting objects: 1948, done.
remote: Compressing objects: 100% (1805/1805), done.
remote: Total 1948 (delta 1508), reused 227 (delta 135)
Receiving objects: 100% (1948/1948), 1.30 MiB | 2.18 MiB/s, done.
Resolving deltas: 100% (1508/1508), done.
root@f7bd54502356:/home/user# 
```

https://www.openssl.org/blog/blog/2021/09/13/LetsEncryptRootCertExpire/
https://blog.dnsimple.com/2021/09/letsencrypt-intermediate-expiration/
https://scotthelme.co.uk/lets-encrypt-old-root-expiration/