### PR TITLE
fix: ensure contact data is refetched when changes where made

### DIFF
--- a/src/app/modules/main/profile_section/contacts/controller.nim
+++ b/src/app/modules/main/profile_section/contacts/controller.nim
@@ -34,18 +34,22 @@ method delete*[T](self: Controller[T]) =
 
 method init*[T](self: Controller[T]) = 
   self.events.on("contactAdded") do(e: Args):
+    self.contactsService.fetchContacts()
     let contacts = self.getContacts()
     self.delegate.setContactList(contacts)
 
   self.events.on("contactBlocked") do(e: Args):
+    self.contactsService.fetchContacts()
     let contacts = self.getContacts()
     self.delegate.setContactList(contacts)
 
   self.events.on("contactUnblocked") do(e: Args):
+    self.contactsService.fetchContacts()
     let contacts = self.getContacts()
     self.delegate.setContactList(contacts)
 
   self.events.on("contactRemoved") do(e: Args):
+    self.contactsService.fetchContacts()
     let contacts = self.getContacts()
     self.delegate.setContactList(contacts)
 

--- a/src/app_service/service/contacts/service.nim
+++ b/src/app_service/service/contacts/service.nim
@@ -40,7 +40,7 @@ QtObject:
     result.threadpool = threadpool
     result.contacts = initTable[string, ContactsDto]()
 
-  proc fetchContacts(self: Service) =
+  proc fetchContacts*(self: Service) =
     try:
       let response = status_contacts.getContacts()
 


### PR DESCRIPTION
Changes in contact data caused via calls to any contact related APIs wouldn't be
reflected in the UI because it doesn't re-fetch the updated state from status-go.

This commit makes the contactsService `fetchContacts` API public so it can be
used on the profile section control to re-fetch contact data when changes to
contacts have been emitted.
