### PR TITLE
uiux: inform user early when there's no stickers installed

### DIFF
--- a/ui/imports/shared/status/StatusStickersPopup.qml
+++ b/ui/imports/shared/status/StatusStickersPopup.qml
@@ -72,6 +72,13 @@ Popup {
                 footerContent.visible = true
                 stickersContainer.visible = true
             }
+
+            Loader {
+                id: marketLoader
+                active: !root.stickerPacksLoaded
+                sourceComponent: loadingImageComponent
+                anchors.centerIn: parent
+            }
         }
 
         Item {
@@ -87,7 +94,7 @@ Popup {
             Item {
                 id: noStickerPacks
                 anchors.fill: parent
-                visible: false
+                visible: installedPacksCount == 0
 
                 Image {
                     id: imgNoStickers


### PR DESCRIPTION
This makes sure we don't wait until all sticker packs are loaded
to show the user that now packs were installed (we know this much earlier).

Fixes #4127

