### PR TITLE
fix(@desktop/chat): ensure emoji selection works

### DIFF
--- a/ui/main.qml
+++ b/ui/main.qml
@@ -89,6 +89,18 @@ StatusWindow {
             mainModule.openStoreToKeychainPopup.connect(function(){
                 storeToKeychainConfirmationPopup.open()
             })
+            if(localAccountSensitiveSettings.recentEmojis === "") {
+                 localAccountSensitiveSettings.recentEmojis = [];
+             }
+            if (localAccountSensitiveSettings.whitelistedUnfurlingSites === "") {
+                localAccountSensitiveSettings.whitelistedUnfurlingSites = {};
+            }
+            if (localAccountSensitiveSettings.hiddenCommunityWelcomeBanners === "") {
+                localAccountSensitiveSettings.hiddenCommunityWelcomeBanners = [];
+            }
+            if (localAccountSensitiveSettings.hiddenCommunityBackUpBanners === "") {
+                localAccountSensitiveSettings.hiddenCommunityBackUpBanners = [];
+            }
         }
     }
 


### PR DESCRIPTION
This broke in https://github.com/status-im/status-desktop/pull/4135 due to incorrect
initialization of `recentEmojis` property in `localAccountSensitiveSettings`.

Closes #4102