### PR TITLE
fix: fetch more messages

### DIFF
--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -265,6 +265,7 @@ Column {
 //            nextMsgTimestamp: root.messageStore.nextMsgTimestamp
             onClicked: {
                 root.chatsModel.messageView.hideLoadingIndicator();
+                root.chatsModel.requestMoreMessages(Constants.fetchRangeLast24Hours);
             }
             onTimerTriggered: {
                 root.chatsModel.requestMoreMessages(Constants.fetchRangeLast24Hours);


### PR DESCRIPTION
fixes #4168 

### What does the PR do

The timer triggers it once only cause repeat is not true
Then when the button is clicked, we also need to fetch more
messages

### Affected areas

chat