### PR TITLE
fix(desktop/chat) fetch more messages not working

### DIFF
--- a/ui/imports/shared/controls/chat/FetchMoreMessagesButton.qml
+++ b/ui/imports/shared/controls/chat/FetchMoreMessagesButton.qml
@@ -28,6 +28,7 @@ Item {
     Separator {
         id: sep1
     }
+
     Loader {
         id: fetchLoaderIndicator
         anchors.top: sep1.bottom
@@ -59,6 +60,7 @@ Item {
                 fetchLoaderIndicator.active = true;
                 fetchMoreButton.visible = false;
                 fetchDate.visible = false;
+                timer.start();
             }
         }
     }


### PR DESCRIPTION
Closes #4168

### What does the PR do
Fetch more messages is spinning indefinitely when
fetch more messages button is clicked and messages
are never displayed

### Affected areas
chat messages

### Screenshot of functionality
https://user-images.githubusercontent.com/31625338/143450811-39308024-d1eb-498a-9246-4e4ef99efcbd.mov


