### PR TITLE
fix(@desktop/chat): Blocking a user with big messages leaves an empty space in the chat

### DIFF
--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -228,6 +228,7 @@ Column {
 
     Loader {
         id: messageLoader
+        active: root.visible
         width: parent.width
         sourceComponent: {
             switch(contentType) {


### PR DESCRIPTION
fix(@desktop/chat): Blocking a user with big messages leaves an empty space in the chat

fixes #4123

### What does the PR do

Made height of column 0 when item is not visible

### Affected areas

Chat view

### Screenshot of functionality

<img width="1252" alt="image" src="https://user-images.githubusercontent.com/60327365/143469643-ee07ea1a-0473-499f-8470-bc88eed792b6.png">
