### PR TITLE
fix(@desktop/profile): Users profile image/identicon not shown in application navbar

### DIFF
--- a/ui/app/AppMain.qml
+++ b/ui/app/AppMain.qml
@@ -313,7 +313,7 @@ Item {
                 id: profileButton
                 property bool opened: false
 
-                icon.source: profileModule.thumbnailImage || ""
+                icon.source: userProfile.thumbnailImage
                 badge.visible: true
                 badge.anchors.rightMargin: 4
                 badge.anchors.topMargin: 25


### PR DESCRIPTION
fix(@desktop/profile): Users profile image/identicon not shown in application navbar
fixes #4170

### What does the PR do

Used the userProfile module instead of ProfileModule in order to retrieve the thumbnail image

### Affected areas

AppMain

### Screenshot of functionality

<img width="1252" alt="image" src="https://user-images.githubusercontent.com/60327365/143471824-e5733777-d9e5-443f-8479-adb3e9563183.png">

