### PR TITLE
fix(reply): fix reply image displaying the current user

### DIFF
--- a/ui/app/AppLayouts/stores/MessageStore.qml
+++ b/ui/app/AppLayouts/stores/MessageStore.qml
@@ -79,16 +79,16 @@ QtObject {
     property bool isStatusUpdate: false
     property int statusAgeEpoch: 0
 
-    property int replyMessageIndex: chatsModel.messageView.messageList.getMessageIndex(responseTo);
-    property string repliedMessageAuthor: replyMessageIndex > -1 ? chatsModel.messageView.messageList.getMessageData(replyMessageIndex, "userName") : "";
-    property string repliedMessageAuthorPubkey: replyMessageIndex > -1 ? chatsModel.messageView.messageList.getMessageData(replyMessageIndex, "publicKey") : "";
-    property bool repliedMessageAuthorIsCurrentUser: replyMessageIndex > -1 ? repliedMessageAuthorPubkey === userProfile.pubKey : "";
-    property bool repliedMessageIsEdited: replyMessageIndex > -1 ? chatsModel.messageView.messageList.getMessageData(replyMessageIndex, "isEdited") === "true" : false;
-    property string repliedMessageContent: replyMessageIndex > -1 ? chatsModel.messageView.messageList.getMessageData(replyMessageIndex, "message") : "";
-    property int repliedMessageType: replyMessageIndex > -1 ? parseInt(chatsModel.messageView.messageList.getMessageData(replyMessageIndex, "contentType")) : 0;
-    property string repliedMessageImage: replyMessageIndex > -1 ? chatsModel.messageView.messageList.getMessageData(replyMessageIndex, "image") : "";
-    property string repliedMessageUserIdenticon: replyMessageIndex > -1 ? chatsModel.messageView.messageList.getMessageData(replyMessageIndex, "identicon") : "";
-    property string repliedMessageUserImage: replyMessageIndex > -1 ? appMain.getProfileImage(repliedMessageAuthorPubkey, repliedMessageAuthorIsCurrentUser , false) || "" : "";
+//    property int replyMessageIndex: chatsModel.messageView.messageList.getMessageIndex(responseTo);
+//    property string repliedMessageAuthor: replyMessageIndex > -1 ? chatsModel.messageView.messageList.getMessageData(replyMessageIndex, "userName") : "";
+//    property string repliedMessageAuthorPubkey: replyMessageIndex > -1 ? chatsModel.messageView.messageList.getMessageData(replyMessageIndex, "publicKey") : "";
+//    property bool repliedMessageAuthorIsCurrentUser: replyMessageIndex > -1 ? repliedMessageAuthorPubkey === userProfile.pubKey : "";
+//    property bool repliedMessageIsEdited: replyMessageIndex > -1 ? chatsModel.messageView.messageList.getMessageData(replyMessageIndex, "isEdited") === "true" : false;
+//    property string repliedMessageContent: replyMessageIndex > -1 ? chatsModel.messageView.messageList.getMessageData(replyMessageIndex, "message") : "";
+//    property int repliedMessageType: replyMessageIndex > -1 ? parseInt(chatsModel.messageView.messageList.getMessageData(replyMessageIndex, "contentType")) : 0;
+//    property string repliedMessageImage: replyMessageIndex > -1 ? chatsModel.messageView.messageList.getMessageData(replyMessageIndex, "image") : "";
+//    property string repliedMessageUserIdenticon: replyMessageIndex > -1 ? chatsModel.messageView.messageList.getMessageData(replyMessageIndex, "identicon") : "";
+//    property string repliedMessageUserImage: replyMessageIndex > -1 ? appMain.getProfileImage(repliedMessageAuthorPubkey, repliedMessageAuthorIsCurrentUser , false) || "" : "";
 
     property var imageClick: function () {}
     property var scrollToBottom: function () {}

--- a/ui/imports/shared/controls/chat/UserImage.qml
+++ b/ui/imports/shared/controls/chat/UserImage.qml
@@ -10,8 +10,8 @@ Loader {
     height: active ? item.height : 0
     property int imageHeight: 36
     property int imageWidth: 36
-//    property string profileImage: ""
-//    property string identiconImageSource: ""
+    property string profileImage: ""
+    property string identiconImageSource: ""
     property bool isReplyImage: false
 //    property var messageContextMenu
 //    property bool isCurrentUser: false
@@ -31,6 +31,14 @@ Loader {
                 border.width: 1
                 border.color: Style.current.border
                 source: {
+                    if (root.isReplyImage) {
+                        if (root.profileImage) {
+                            return root.profileImage
+                        }
+                        if (root.identiconImageSource) {
+                            return root.identiconImageSource
+                        }
+                    }
                     if (profileImageSource) {
                         return profileImageSource
                     }

--- a/ui/imports/shared/panels/chat/ChatReplyPanel.qml
+++ b/ui/imports/shared/panels/chat/ChatReplyPanel.qml
@@ -27,9 +27,9 @@ Loader {
 //    property bool isCurrentUser: false
 //    property int repliedMessageType
 //    property string repliedMessageImage
-//    property string repliedMessageUserIdenticon
+    property string repliedMessageUserIdenticon: ""
 //    property bool repliedMessageIsEdited
-//    property string repliedMessageUserImage
+    property string repliedMessageUserImage: ""
 //    property string repliedMessageAuthor
 //    property string repliedMessageContent
 //    property string responseTo: ""
@@ -107,9 +107,9 @@ Loader {
                 active: true
                 anchors.left: replyCorner.right
                 anchors.leftMargin: Style.current.halfPadding
-//                identiconImageSource: repliedMessageUserIdenticon
+                identiconImageSource: repliedMessageUserIdenticon
                 isReplyImage: true
-//                profileImage: repliedMessageUserImage
+                profileImage: repliedMessageUserImage
 //                isCurrentUser: isCurrentUser
                 onClickMessage: {
                     root.clickMessage(true, false, false, null, false, false, isReplyImage)

--- a/ui/imports/shared/views/chat/CompactMessageView.qml
+++ b/ui/imports/shared/views/chat/CompactMessageView.qml
@@ -40,6 +40,9 @@ Item {
             return false;
         }
     }
+    property string repliedMessageUserIdenticon
+    property string repliedMessageUserImage
+
     property bool showEdit: true
     property var messageContextMenu
     signal addEmoji(bool isProfileClick, bool isSticker, bool isImage , var image, bool emojiOnly, bool hideEmojiPicker)
@@ -243,9 +246,9 @@ Item {
 //            isCurrentUser: root.messageStore.isCurrentUser
 //            repliedMessageType: root.messageStore.repliedMessageType
 //            repliedMessageImage: root.messageStore.repliedMessageImage
-//            repliedMessageUserIdenticon: root.messageStore.repliedMessageUserIdenticon
+            repliedMessageUserIdenticon: root.repliedMessageUserIdenticon
 //            repliedMessageIsEdited: root.messageStore.repliedMessageIsEdited
-//            repliedMessageUserImage: root.messageStore.repliedMessageUserImage
+            repliedMessageUserImage: root.repliedMessageUserImage
 //            repliedMessageAuthor: root.messageStore.repliedMessageAuthor
 //            repliedMessageContent: root.messageStore.repliedMessageContent
 //            responseTo: root.messageStore.responseTo

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -367,6 +367,8 @@ Column {
             messageContextMenu: root.messageContextMenu
             store: root.rootStore
             messageStore: root.messageStore
+            repliedMessageUserIdenticon: root.repliedMessageUserIdenticon
+            repliedMessageUserImage: root.repliedMessageUserImage
             onAddEmoji: {
                 root.clickMessage(isProfileClick, isSticker, isImage , image, emojiOnly, hideEmojiPicker);
             }


### PR DESCRIPTION
Fixes #4185

The binding to the image/identicon was broken, but also, the MessageStore does **not** behave like it should.
Right now, the MessageStore is a single instance, so whenever a message changes the values of the store, it changes them for **all** messages. So if we ever want to use that store, we need to create a new instance for each message,

Anyway, the problem is solved here