### PR TITLE
ci: specify macos host architecture in labels

### DIFF
--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -2,7 +2,7 @@ library 'status-jenkins-lib@v1.3.3'
 
 pipeline {
   agent {
-    label 'macos'
+    label 'macos && x86_64'
   }
 
   parameters {


### PR DESCRIPTION
Since now we have a 5th Gen Mac Mini with `arm64` M1 CPU.