### PR TITLE
feat: preserve app window size after resize

### DIFF
--- a/src/app/core/local_app_settings.nim
+++ b/src/app/core/local_app_settings.nim
@@ -7,6 +7,12 @@ const LAS_KEY_LOCALE* = "global/locale"
 const DEFAULT_LOCALE = "en"
 const LAS_KEY_THEME* = "global/theme"
 const DEFAULT_THEME = 2 #system theme, from qml
+const LAS_KEY_APP_WIDTH = "global/app_width"
+const DEFAULT_APP_WIDTH = 1232
+const LAS_KEY_APP_HEIGHT = "global/app_height"
+const DEFAULT_APP_HEIGHT = 770
+const LAS_KEY_APP_SIZE_INITIALIZED = "global/app_size_initialized"
+const DEFAULT_APP_SIZE_INITIALIZED = false
 
 QtObject:
   type LocalAppSettings* = ref object of QObject
@@ -52,6 +58,41 @@ QtObject:
     write = setTheme
     notify = themeChanged 
 
+  proc appWidthChanged*(self: LocalAppSettings) {.signal.}
+  proc getAppWidth*(self: LocalAppSettings): int {.slot.} =
+    self.settings.value(LAS_KEY_APP_WIDTH, newQVariant(DEFAULT_APP_WIDTH)).intVal
+  proc setAppWidth*(self: LocalAppSettings, value: int) {.slot.} =
+    self.settings.setValue(LAS_KEY_APP_WIDTH, newQVariant(value))
+    self.appWidthChanged()
+
+  QtProperty[int] appWidth:
+    read = getAppWidth
+    write = setAppWidth
+    notify = appWidthChanged
+
+  proc appHeightChanged*(self: LocalAppSettings) {.signal.}
+  proc getAppHeight*(self: LocalAppSettings): int {.slot.} =
+    self.settings.value(LAS_KEY_APP_HEIGHT, newQVariant(DEFAULT_APP_HEIGHT)).intVal
+  proc setAppHeight*(self: LocalAppSettings, value: int) {.slot.} =
+    self.settings.setValue(LAS_KEY_APP_HEIGHT, newQVariant(value))
+    self.appHeightChanged()
+
+  QtProperty[int] appHeight:
+    read = getAppHeight
+    write = setAppHeight
+    notify = appHeightChanged
+
+  proc appSizeInitializedChanged*(self: LocalAppSettings) {.signal.}
+  proc isAppSizeInitialized*(self: LocalAppSettings): bool {.slot.} =
+    self.settings.value(LAS_KEY_APP_SIZE_INITIALIZED, newQVariant(DEFAULT_APP_SIZE_INITIALIZED)).boolVal
+  proc setAppSizeInitialized*(self: LocalAppSettings, value: bool) {.slot.} =
+    self.settings.setValue(LAS_KEY_APP_SIZE_INITIALIZED, newQVariant(value))
+    self.appSizeInitializedChanged()
+
+  QtProperty[bool] appSizeInitialized:
+    read = isAppSizeInitialized
+    write = setAppSizeInitialized
+    notify = appSizeInitializedChanged
 
   proc removeKey*(self: LocalAppSettings, key: string) =
     if(self.settings.isNil):

--- a/ui/main.qml
+++ b/ui/main.qml
@@ -32,8 +32,8 @@ StatusWindow {
     objectName: "mainWindow"
     minimumWidth: 900
     minimumHeight: 600
-    width: Math.min(1232, Screen.desktopAvailableWidth - 64)
-    height: Math.min(770, Screen.desktopAvailableHeight - 64)
+    width: localAppSettings.appWidth
+    height: localAppSettings.appHeight
     color: Style.current.background
     title: {
         // Set application settings
@@ -44,6 +44,17 @@ StatusWindow {
         return Qt.application.name
     }
     visible: true
+
+    function storeWidth() {
+        localAppSettings.appWidth = width
+    }
+
+    function storeHeight() {
+        localAppSettings.appHeight = height
+    }
+
+    onWidthChanged: Qt.callLater(storeWidth)
+    onHeightChanged: Qt.callLater(storeHeight)
 
     Action {
         shortcut: StandardKey.FullScreen
@@ -184,6 +195,11 @@ StatusWindow {
         setX(Qt.application.screens[0].width / 2 - width / 2);
         setY(Qt.application.screens[0].height / 2 - height / 2);
 
+        if (!localAppSettings.appSizeInitialized) {
+            width = Screen.desktopAvailableWidth - 125
+            height = Screen.desktopAvailableHeight - 125
+            localAppSettings.appSizeInitialized = true
+        }
         applicationWindow.updatePosition();
     }
 


### PR DESCRIPTION
This adds the functionality that the application window size is saved in the
app settings, so that it restores the same size the next time the application
is started.

Closes #4120
