### PR TITLE
fix(@desktop/profile): Application nav bar settings button is incorrect

### DIFF
--- a/src/app/global/app_sections_config.nim
+++ b/src/app/global/app_sections_config.nim
@@ -24,4 +24,4 @@ const NODEMANAGEMENT_SECTION_ICON* = "node"
 
 const SETTINGS_SECTION_ID* = "profileSettings"
 const SETTINGS_SECTION_NAME* = "Settings"
-const SETTINGS_SECTION_ICON* = "status-update"
+const SETTINGS_SECTION_ICON* = "settings"


### PR DESCRIPTION
fix(@desktop/profile): Application nav bar settings button is incorrect

Updated the settings icon in the config file.

fixes #4172

The PR updates the settings icon name in the config file so that the correct icon is loaded

### Affected areas

StatusNavBar in AppMain

### Screenshot of functionality

<img width="1252" alt="image" src="https://user-images.githubusercontent.com/60327365/143852044-816c16de-c96c-4a37-9bd3-9b34a693bfc2.png">
