### PR TITLE
fix(desktop/chat): stickers pack popup not opened

### DIFF
--- a/ui/app/AppLayouts/Chat/controls/MessageMouseArea.qml
+++ b/ui/app/AppLayouts/Chat/controls/MessageMouseArea.qml
@@ -7,11 +7,12 @@ MouseArea {
     z: 50
     enabled: !placeholderMessage
 
-    property bool isHovered: false
-    property bool isSticker: false
-    property bool placeholderMessage: false
+//TODO remove dynamic scoping
+//    property bool isHovered: false
+//    property bool isSticker: false
+//    property bool placeholderMessage: false
+//    property var isMessageActive
     property bool isActivityCenterMessage: false
-    property var isMessageActive
     property var messageContextMenu
     signal setMessageActive(string messageId, bool active)
     signal clickMessage(bool isProfileClick, bool isSticker, bool isImage)
@@ -27,7 +28,6 @@ MouseArea {
         if (mouse.button === Qt.RightButton) {
             if (!!messageContextMenu) {
                 // Set parent, X & Y positions for the messageContextMenu
-                //TODO remove dynamic scoping
                 messageContextMenu.parent = root
                 messageContextMenu.setXPosition = function() { return (mouse.x)};
                 messageContextMenu.setYPosition = function() { return (mouse.y)};
@@ -38,7 +38,6 @@ MouseArea {
             }
             return;
         }
-        //TODO remove dynamic scoping
         if (mouse.button === Qt.LeftButton && isSticker && stickersLoaded) {
             if (isHovered) {
                 isHovered = false;


### PR DESCRIPTION
Closes #4203

### What does the PR do
Fixed can't open a sticker pack when clicking a sticker in a chat.

### Affected areas
Chat

### Screenshot of functionality
https://user-images.githubusercontent.com/31625338/143903716-49ce5ef3-aa81-48fe-93d3-e03d14683a17.mov



