### PR TITLE
fix(notifications): fix missing task bar icon making notif not work

### DIFF
--- a/ui/main.qml
+++ b/ui/main.qml
@@ -203,14 +203,14 @@ StatusWindow {
         icon.source: {
             if (production) {
                 if (Qt.platform.os == "osx")
-                    return "imports/shared/img/status-logo-round-rect.svg"
+                    return "imports/assets/images/status-logo-round-rect.svg"
                 else
-                    return "imports/shared/img/status-logo-circle.svg"
+                    return "imports/assets/images/status-logo-circle.svg"
             } else {
                 if (Qt.platform.os == "osx")
-                    return "imports/shared/img/status-logo-dev-round-rect.svg"
+                    return "imports/assets/images/status-logo-dev-round-rect.svg"
                 else
-                    return "imports/shared/img/status-logo-dev-circle.svg"
+                    return "imports/assets/images/status-logo-dev-circle.svg"
             }
         }
 


### PR DESCRIPTION
Fixes #4183 and #4205

So turns out the issue for the Windows notifications not working was that the icon was missing/wrong.

I went down the whole DotherSide rabbit hole because the error was emitted from there, but turns out the error happens because the Tray is not found by the C++ code because the Tray fails to load on Windows with a bad icon.

Anyway, Windows notifications work on Windows now and the icon is back on every platform

I think Linux notifs are still broken, I'll try and fix in another PR.