### PR TITLE
fix:  RPC method invocation as soon as Import Community popup was opened

### DIFF
--- a/ui/app/AppLayouts/Chat/popups/community/AccessExistingCommunityPopup.qml
+++ b/ui/app/AppLayouts/Chat/popups/community/AccessExistingCommunityPopup.qml
@@ -16,6 +16,7 @@ StatusModal {
     width: 400
     height: 400
 
+    property var store
     property string error: ""
     property string keyValidationError: ""
     property string communityKey: ""
@@ -81,6 +82,8 @@ StatusModal {
                     communityKey = "0x" + communityKey;
                 }
 
+
+                root.error = root.store.chatsModelInst.communities.importCommunity(communityKey, Utils.uuid())
                 if (!!root.error) {
                     creatingError.text = error;
                     return creatingError.open();

--- a/ui/app/AppLayouts/Chat/views/ContactsColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ContactsColumnView.qml
@@ -349,7 +349,7 @@ Item {
         id: importCommunitiesPopupComponent
         AccessExistingCommunityPopup {
             anchors.centerIn: parent
-            error: root.store.chatsModelInst.communities.importCommunity(communityKey, Utils.uuid())
+            store: root.store
             onClosed: {
                 destroy()
             }


### PR DESCRIPTION
Fixes this error:
```
ERR 2021-11-30 09:14:34.783-04:00 rpc response error                         topics="rpc" tid=480760 file=core.nim:24 result="{\"jsonrpc\":\"2.0\",\"id\":0,\"error\":{\"code\":-32000,\"message\":\"method handler crashed\"}}" payload="[\"\"]" methodName=wakuext_importCommunity
```
which can be seen as soon as you open this dialog:
![image](https://user-images.githubusercontent.com/1106587/144069665-1c02a181-8798-4cba-b7d6-78eb439b8210.png)
