### PR TITLE
Fix Linux notifications

### DIFF
--- a/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
@@ -611,6 +611,11 @@ Item {
 
                     currentlyHasANotification = true
 
+                    if (Qt.platform.os === "linux") {
+                        // Linux Notifications are not implemented in Nim/C++ yet
+                        return systemTray.showMessage(name, message, systemTray.icon.source, 4000)
+                    }
+
                     // Note:
                     // Show notification should be moved to the nim side.
                     // Left here only cause we don't have a way to deal with translations on the nim side.

--- a/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
@@ -222,11 +222,20 @@ Item {
             onMembershipRequestChanged: function (communityId, communityName, accepted) {
                 chatColumnLayout.currentNotificationChatId = null
                 chatColumnLayout.currentNotificationCommunityId = communityId
-                root.store.chatsModelInst.showOSNotification("Status",
-                                              //% "You have been accepted into the ‘%1’ community"
-                                              accepted ? qsTrId("you-have-been-accepted-into-the---1--community").arg(communityName) :
-                                                         //% "Your request to join the ‘%1’ community was declined"
-                                                         qsTrId("your-request-to-join-the---1--community-was-declined").arg(communityName),
+
+                const title = "Status"
+                const message = //% "You have been accepted into the ‘%1’ community"
+                              accepted ? qsTrId("you-have-been-accepted-into-the---1--community").arg(communityName) :
+                                         //% "Your request to join the ‘%1’ community was declined"
+                                         qsTrId("your-request-to-join-the---1--community-was-declined").arg(communityName)
+
+                if (Qt.platform.os === "linux") {
+                    // Linux Notifications are not implemented in Nim/C++ yet
+                    return systemTray.showMessage(title, message, systemTray.icon.source, 4000)
+                }
+
+                root.store.chatsModelInst.showOSNotification(title,
+                                              message,
                                               accepted? Constants.osNotificationType.acceptedIntoCommunity :
                                                         Constants.osNotificationType.rejectedByCommunity,
                                               communityId,
@@ -238,10 +247,19 @@ Item {
             onMembershipRequestPushed: function (communityId, communityName, pubKey) {
                 chatColumnLayout.currentNotificationChatId = null
                 chatColumnLayout.currentNotificationCommunityId = communityId
+
                 //% "New membership request"
-                root.store.chatsModelInst.showOSNotification(qsTrId("new-membership-request"),
-                                              //% "%1 asks to join ‘%2’"
-                                              qsTrId("-1-asks-to-join---2-").arg(Utils.getDisplayName(pubKey)).arg(communityName),
+                const title = qsTrId("new-membership-request")
+                //% "%1 asks to join ‘%2’"
+                const message = qsTrId("-1-asks-to-join---2-").arg(Utils.getDisplayName(pubKey)).arg(communityName)
+
+                if (Qt.platform.os === "linux") {
+                    // Linux Notifications are not implemented in Nim/C++ yet
+                    return systemTray.showMessage(title, message, systemTray.icon.source, 4000)
+                }
+
+                root.store.chatsModelInst.showOSNotification(title,
+                                              message,
                                               Constants.osNotificationType.joinCommunityRequest,
                                               communityId,
                                               "",

--- a/ui/app/AppMain.qml
+++ b/ui/app/AppMain.qml
@@ -539,14 +539,23 @@ Item {
                 // Whole this Connection object should be moved to the nim side.
                 // Left here only cause we don't have a way to deal with translations on the nim side.
 
+                const title = isContact ? qsTrId("contact-request-accepted") :
+                                          //% "New contact request"
+                                          qsTrId("new-contact-request")
+
+                const message = //% "You can now chat with %1"
+                              isContact ? qsTrId("you-can-now-chat-with--1").arg(Utils.removeStatusEns(name)) :
+                                          //% "%1 requests to become contacts"
+                                          qsTrId("-1-requests-to-become-contacts").arg(Utils.removeStatusEns(name))
+
+                if (Qt.platform.os === "linux") {
+                    // Linux Notifications are not implemented in Nim/C++ yet
+                    return systemTray.showMessage(title, message, systemTray.icon.source, 4000)
+                }
+
                 //% "Contact request accepted"
-                profileModel.showOSNotification(isContact ? qsTrId("contact-request-accepted") :
-                                                            //% "New contact request"
-                                                            qsTrId("new-contact-request"),
-                                                //% "You can now chat with %1"
-                                                isContact ? qsTrId("you-can-now-chat-with--1").arg(Utils.removeStatusEns(name)) :
-                                                            //% "%1 requests to become contacts"
-                                                            qsTrId("-1-requests-to-become-contacts").arg(Utils.removeStatusEns(name)),
+                profileModel.showOSNotification(title,
+                                                message,
                                                 isContact? Constants.osNotificationType.acceptedContactRequest :
                                                            Constants.osNotificationType.newContactRequest,
                                                 localAccountSensitiveSettings.useOSNotifications)

--- a/ui/main.qml
+++ b/ui/main.qml
@@ -203,14 +203,14 @@ StatusWindow {
         icon.source: {
             if (production) {
                 if (Qt.platform.os == "osx")
-                    return "imports/shared/img/status-logo-round-rect.svg"
+                    return "imports/assets/images/status-logo-round-rect.svg"
                 else
-                    return "imports/shared/img/status-logo-circle.svg"
+                    return "imports/assets/images/status-logo-circle.svg"
             } else {
                 if (Qt.platform.os == "osx")
-                    return "imports/shared/img/status-logo-dev-round-rect.svg"
+                    return "imports/assets/images/status-logo-dev-round-rect.svg"
                 else
-                    return "imports/shared/img/status-logo-dev-circle.svg"
+                    return "imports/assets/images/status-logo-dev-circle.svg"
             }
         }
 


### PR DESCRIPTION
Fixes #4183

Linux OS notifications are not implemented in Nim yet, so show them with the TrayIcon QML function.