### PR TITLE
fix(desktop/chat): Fixed finish editing msg when pressing enter

### DIFF
--- a/ui/imports/shared/views/chat/CompactMessageView.qml
+++ b/ui/imports/shared/views/chat/CompactMessageView.qml
@@ -379,7 +379,7 @@ Item {
                     isEdit: true
                     textInput.text: editMessageLoader.sourceText
                     onSendMessage: {
-                        saveBtn.clicked()
+                        saveBtn.clicked(null)
                     }
                     suggestions.onVisibleChanged: {
                         if (suggestions.visible) {


### PR DESCRIPTION
Closes #4213

### What does the PR do
When in message editing mode was not possible to cofirm edit and
close edit mode when pressing enter key as the clicked signal
of the StatusButton is called without an argument, aparently that
signal has a var mouse parameter. Passed null as parameter to
get the signal emitted.

### Affected areas
Chat messages

### Screenshot of functionality
https://user-images.githubusercontent.com/31625338/144319241-0bff8baf-637a-44c9-ab21-b78a9d6acf0f.mov



