### PR TITLE
fix(@desktop/communities): Close popup when edit is successful

### DIFF
--- a/ui/app/AppLayouts/Chat/popups/community/CommunityProfilePopup.qml
+++ b/ui/app/AppLayouts/Chat/popups/community/CommunityProfilePopup.qml
@@ -65,7 +65,8 @@ StatusModal {
                 }
                 onEditButtonClicked: openPopup(editCommunityPopup, {
                     store: root.store,
-                    community: root.community
+                    community: root.community,
+                    onSave: root.close
                 })
                 onTransferOwnershipButtonClicked: openPopup(transferOwnershiproot, {
                     privateKey: root.store.exportCommunity(),

--- a/ui/app/AppLayouts/Chat/popups/community/CreateCommunityPopup.qml
+++ b/ui/app/AppLayouts/Chat/popups/community/CreateCommunityPopup.qml
@@ -21,6 +21,7 @@ StatusModal {
     property var store
     property bool isEdit: false
     property QtObject community: popup.store.chatsModelInst.communities.activeCommunity
+    property var onSave: () => {}
     readonly property int maxCommunityNameLength: 30
     readonly property int maxCommunityDescLength: 140
     readonly property var communityColorValidator: Utils.Validate.NoEmpty
@@ -438,7 +439,7 @@ StatusModal {
                     creatingError.text = error.error
                     return creatingError.open()
                 }
-
+                popup.onSave()
                 popup.close()
             }
         }


### PR DESCRIPTION
fixes #4126

### What does the PR do

When saving the communities all the popup are closed

### Affected areas

Create/Edit Community popup