### PR TITLE
Final touches to the sticker refactor + fixes

### DIFF
--- a/src/app/modules/main/stickers/io_interface.nim
+++ b/src/app/modules/main/stickers/io_interface.nim
@@ -1,4 +1,5 @@
 import Tables, stint
+import ./item
 import ../../../../app_service/service/wallet_account/service as wallet_account_service
 import ../../../../app_service/service/stickers/service as stickers_service
 
@@ -60,7 +61,7 @@ method wei2Eth*(self: AccessInterface, price: Stuint[256]): string {.base.} =
 method removeRecentStickers*(self: AccessInterface, packId: int) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method sendSticker*(self: AccessInterface, channelId: string, replyTo: string, sticker: StickerDto) {.base.} =
+method sendSticker*(self: AccessInterface, channelId: string, replyTo: string, sticker: Item) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method populateInstalledStickerPacks*(self: AccessInterface, stickers: Table[int, StickerPackDto]) {.base.} =

--- a/src/app/modules/main/stickers/item.nim
+++ b/src/app/modules/main/stickers/item.nim
@@ -1,0 +1,90 @@
+import strformat, stint
+
+#####
+# Sticker Item
+#####
+type
+  Item* = object
+    hash: string
+    packId: int
+
+proc initItem*(
+  hash: string,
+  packId: int
+): Item =
+  result.hash = hash
+  result.packId = packId
+
+proc `$`*(self: Item): string =
+  result = fmt"""StickerItem(
+    hash: {self.hash}, 
+    packId: {$self.packId}
+    ]"""
+
+proc getHash*(self: Item): string = 
+  return self.hash
+
+proc getPackId*(self: Item): int = 
+  return self.packId
+
+#####
+# Sticker Pack Item
+#####
+type
+  PackItem* = object
+    id*: int
+    name*: string
+    author*: string
+    price*: Stuint[256]
+    preview*: string
+    stickers*: seq[Item]
+    thumbnail*: string
+
+proc initPackItem*(
+  id: int,
+  name: string,
+  author: string,
+  price: Stuint[256],
+  preview: string,
+  stickers: seq[Item],
+  thumbnail: string
+): PackItem =
+  result.id = id
+  result.name = name
+  result.author = author
+  result.price = price
+  result.preview = preview
+  result.stickers = stickers
+  result.thumbnail = thumbnail
+
+proc `$`*(self: PackItem): string =
+  result = fmt"""StickerItem(
+    id: {self.id}, 
+    name: {$self.name},
+    author: {$self.author},
+    price: {$self.price},
+    preview: {$self.preview},
+    stickers: {$self.stickers},
+    thumbnail: {$self.thumbnail},
+    ]"""
+
+proc getId*(self: PackItem): int = 
+  return self.id
+
+proc getName*(self: PackItem): string = 
+  return self.name
+
+proc getAuthor*(self: PackItem): string = 
+  return self.author
+
+proc getPrice*(self: PackItem): Stuint[256] = 
+  return self.price
+
+proc getPreview*(self: PackItem): string = 
+  return self.preview
+
+proc getThumbnail*(self: PackItem): string = 
+  return self.thumbnail
+
+proc getStickers*(self: PackItem): seq[Item] = 
+  return self.stickers

--- a/src/app/modules/main/stickers/models/sticker_list.nim
+++ b/src/app/modules/main/stickers/models/sticker_list.nim
@@ -1,6 +1,5 @@
 import NimQml, Tables, sequtils
-import ../../../../../app_service/service/stickers/dto/stickers as stickers_dto
-import ../io_interface
+import ../io_interface, ../item
 
 type
   StickerRoles {.pure.} = enum
@@ -12,13 +11,13 @@ QtObject:
   type
     StickerList* = ref object of QAbstractListModel
       delegate: io_interface.AccessInterface
-      stickers*: seq[StickerDto]
+      stickers*: seq[Item]
 
   proc setup(self: StickerList) = self.QAbstractListModel.setup
 
   proc delete(self: StickerList) = self.QAbstractListModel.delete
 
-  proc newStickerList*(delegate: io_interface.AccessInterface, stickers: seq[StickerDto] = @[]): StickerList =
+  proc newStickerList*(delegate: io_interface.AccessInterface, stickers: seq[Item] = @[]): StickerList =
     new(result, delete)
     result.delegate = delegate
     result.stickers = stickers
@@ -35,9 +34,9 @@ QtObject:
     let sticker = self.stickers[index.row]
     let stickerRole = role.StickerRoles
     case stickerRole:
-      of StickerRoles.Url: result = newQVariant(self.delegate.decodeContentHash(sticker.hash))
-      of StickerRoles.Hash: result = newQVariant(sticker.hash)
-      of StickerRoles.PackId: result = newQVariant(sticker.packId)
+      of StickerRoles.Url: result = newQVariant(self.delegate.decodeContentHash(sticker.getHash))
+      of StickerRoles.Hash: result = newQVariant(sticker.getHash)
+      of StickerRoles.PackId: result = newQVariant(sticker.getPackId)
 
   method roleNames(self: StickerList): Table[int, string] =
     {
@@ -46,16 +45,16 @@ QtObject:
       StickerRoles.PackId.int:"packId"
     }.toTable
 
-  proc addStickerToList*(self: StickerList, sticker: StickerDto) =
-    if(self.stickers.any(proc(existingSticker: StickerDto): bool = return existingSticker.hash == sticker.hash)):
+  proc addStickerToList*(self: StickerList, sticker: Item) =
+    if(self.stickers.any(proc(existingSticker: Item): bool = return existingSticker.getHash == sticker.getHash)):
       return
     self.beginInsertRows(newQModelIndex(), 0, 0)
     self.stickers.insert(sticker, 0)
     self.endInsertRows()
 
   proc removeStickersFromList*(self: StickerList, packId: int) =
-    if not self.stickers.anyIt(it.packId == packId):
+    if not self.stickers.anyIt(it.getPackId == packId):
       return
     self.beginRemoveRows(newQModelIndex(), 0, 0)
-    self.stickers.keepItIf(it.packId != packId)
+    self.stickers.keepItIf(it.getPackId != packId)
     self.endRemoveRows()

--- a/src/app/modules/main/stickers/models/sticker_pack_list.nim
+++ b/src/app/modules/main/stickers/models/sticker_pack_list.nim
@@ -1,8 +1,7 @@
 import NimQml, Tables, sequtils, sugar
 import ./sticker_list
-import ../io_interface
+import ../io_interface, ../item
 # TODO remove those uses of services stuff
-import ../../../../../app_service/service/stickers/dto/stickers as stickers_dto
 import ../../../../../app_service/service/eth/utils as eth_utils
 
 type
@@ -19,7 +18,7 @@ type
     Pending = UserRole + 10
 
 type
-  StickerPackView* = tuple[pack: StickerPackDto, stickers: StickerList, installed, bought, pending: bool]
+  StickerPackView* = tuple[pack: PackItem, stickers: StickerList, installed, bought, pending: bool]
 
 QtObject:
   type
@@ -93,12 +92,12 @@ QtObject:
   proc hasKey*(self: StickerPackList, packId: int): bool =
     result = self.packs.anyIt(it.pack.id == packId)
   
-  proc `[]`*(self: StickerPackList, packId: int): StickerPackDto =
+  proc `[]`*(self: StickerPackList, packId: int): PackItem =
     if not self.hasKey(packId):
       raise newException(ValueError, "Sticker pack list does not have a pack with id " & $packId)
     result = eth_utils.find(self.packs, (view: StickerPackView) => view.pack.id == packId).pack
 
-  proc addStickerPackToList*(self: StickerPackList, pack: StickerPackDto, stickers: StickerList, installed, bought, pending: bool) =
+  proc addStickerPackToList*(self: StickerPackList, pack: PackItem, stickers: StickerList, installed, bought, pending: bool) =
     self.beginInsertRows(newQModelIndex(), 0, 0)
     self.packs.insert((pack: pack, stickers: stickers, installed: installed, bought: bought, pending: pending), 0)
     self.endInsertRows()

--- a/src/app/modules/main/stickers/view.nim
+++ b/src/app/modules/main/stickers/view.nim
@@ -1,8 +1,7 @@
-import NimQml, json, strutils, tables, json_serialization
+import NimQml, json, strutils, json_serialization
 
 import ./models/[sticker_list, sticker_pack_list]
-import ./io_interface
-import ../../../../app_service/service/stickers/dto/stickers
+import ./io_interface, ./item
 
 QtObject:
   type
@@ -24,7 +23,7 @@ QtObject:
   proc load*(self: View) =
     self.delegate.viewDidLoad()
 
-  proc addStickerPackToList*(self: View, stickerPack: StickerPackDto, isInstalled, isBought, isPending: bool) =
+  proc addStickerPackToList*(self: View, stickerPack: PackItem, isInstalled, isBought, isPending: bool) =
     self.stickerPacks.addStickerPackToList(
       stickerPack,
       newStickerList(self.delegate, stickerPack.stickers),
@@ -71,10 +70,9 @@ QtObject:
   proc clearStickerPacks*(self: View) =
     self.stickerPacks.clear()
 
-  proc populateInstalledStickerPacks*(self: View, installedStickerPacks: Table[int, StickerPackDto]) =
-    for stickerPack in installedStickerPacks.values:
+  proc populateInstalledStickerPacks*(self: View, installedStickerPacks: seq[PackItem]) =
+    for stickerPack in installedStickerPacks:
       self.addStickerPackToList(stickerPack, isInstalled = true, isBought = true, isPending = false)
-
 
   proc getNumInstalledStickerPacks(self: View): int {.slot.} =
     self.delegate.getNumInstalledStickerPacks()
@@ -99,7 +97,7 @@ QtObject:
     self.installedStickerPacksUpdated()
     self.recentStickersUpdated()
 
-  proc addRecentStickerToList*(self: View, sticker: StickerDto) =
+  proc addRecentStickerToList*(self: View, sticker: Item) =
     self.recentStickers.addStickerToList(sticker)
 
   proc allPacksLoaded*(self: View) =
@@ -107,7 +105,7 @@ QtObject:
     self.installedStickerPacksUpdated()
 
   proc send*(self: View, channelId: string, hash: string, replyTo: string, pack: int) {.slot.} =
-    let sticker = StickerDto(hash: hash, packId: pack)
+    let sticker = initItem(hash, pack)
     self.addRecentStickerToList(sticker)
     self.delegate.sendSticker(channelId, replyTo, sticker)
 

--- a/src/app/modules/main/stickers/view.nim
+++ b/src/app/modules/main/stickers/view.nim
@@ -7,6 +7,7 @@ QtObject:
   type
     View* = ref object of QObject
       delegate: io_interface.AccessInterface
+      packsLoaded*: bool
       stickerPacks*: StickerPackList
       recentStickers*: StickerList
 
@@ -100,7 +101,15 @@ QtObject:
   proc addRecentStickerToList*(self: View, sticker: Item) =
     self.recentStickers.addStickerToList(sticker)
 
+  proc getAllPacksLoaded(self: View): bool {.slot.} =
+    self.packsLoaded
+
+  QtProperty[bool] packsLoaded:
+    read = getAllPacksLoaded
+    notify = stickerPacksLoaded
+
   proc allPacksLoaded*(self: View) =
+    self.packsLoaded = true
     self.stickerPacksLoaded()
     self.installedStickerPacksUpdated()
 

--- a/src/app/modules/main/wallet_section/accounts/item.nim
+++ b/src/app/modules/main/wallet_section/accounts/item.nim
@@ -38,8 +38,7 @@ proc initItem*(
   result.assets = assets
 
 proc `$`*(self: Item): string =
-  result = fmt"""AllTokensItem(
-    name: {self.name}, 
+  result = fmt"""WalletAccountItem(
     name: {self.name},
     address: {self.address},
     path: {self.path},

--- a/src/app_service/service/settings/dto/settings.nim
+++ b/src/app_service/service/settings/dto/settings.nim
@@ -1,4 +1,4 @@
-import json, options, tables, strutils
+import json, options, tables, strutils, sequtils
 import ../../stickers/dto/stickers
 
 include  ../../../common/json_utils
@@ -99,7 +99,7 @@ type
     walletVisibleTokens*: WalletVisibleTokens
     nodeConfig*: JsonNode
     wakuBloomFilterMode*: bool
-    recentStickers*: seq[StickerDto]
+    recentStickerHashes*: seq[string]
     installedStickerPacks*: Table[int, StickerPackDto]
 
 proc toUpstreamConfig*(jsonObj: JsonNode): UpstreamConfig =
@@ -151,12 +151,6 @@ proc toSettingsDto*(jsonObj: JsonNode): SettingsDto =
       for networkObj in networksArr:
         result.availableNetworks.add(toNetwork(networkObj))
 
-  var recentStickersArr: JsonNode
-  if(jsonObj.getProp(KEY_RECENT_STICKERS, recentStickersArr)):
-    if(recentStickersArr.kind == JArray):
-      for recentStickerObj in recentStickersArr:
-        result.recentStickers.add(recentStickerObj.toStickerDto)
-
   var installedStickerPacksArr: JsonNode
   if(jsonObj.getProp(KEY_INSTALLED_STICKER_PACKS, installedStickerPacksArr)):
     if(installedStickerPacksArr.kind == JObject):
@@ -164,6 +158,13 @@ proc toSettingsDto*(jsonObj: JsonNode): SettingsDto =
       for i in installedStickerPacksArr.keys:
         let packId = parseInt(i)
         result.installedStickerPacks[packId] = installedStickerPacksArr[i].toStickerPackDto
+
+    
+  var recentStickersArr: JsonNode
+  if(jsonObj.getProp(KEY_RECENT_STICKERS, recentStickersArr)):
+    if(recentStickersArr.kind == JArray):
+      for stickerHash in recentStickersArr:
+        result.recentStickerHashes.add(stickerHash.getStr)
 
   discard jsonObj.getProp(KEY_DAPPS_ADDRESS, result.dappsAddress)
   discard jsonObj.getProp(KEY_EIP1581_ADDRESS, result.eip1581Address)

--- a/src/app_service/service/settings/service.nim
+++ b/src/app_service/service/settings/service.nim
@@ -1,4 +1,4 @@
-import chronicles, json, sequtils, tables
+import chronicles, json, sequtils, tables, sugar
 
 import service_interface, ./dto/settings
 import status/statusgo_backend_new/settings as status_go
@@ -325,12 +325,12 @@ method isEIP1559Enabled*(self: Service, blockNumber: int): bool =
 method isEIP1559Enabled*(self: Service): bool =
   result = self.eip1559Enabled 
 
-method getRecentStickers*(self: Service): seq[StickerDto] =
-  result = self.settings.recentStickers
+method getRecentStickers*(self: Service): seq[string] =
+  result = self.settings.recentStickerHashes
 
 method saveRecentStickers*(self: Service, recentStickers: seq[StickerDto]): bool =
   if(self.saveSetting(KEY_RECENT_STICKERS, %(recentStickers.mapIt($it.hash)))):
-    self.settings.recentStickers = recentStickers
+    self.settings.recentStickerHashes = recentStickers.map(s => s.hash)
     return true
   return false
 
@@ -342,7 +342,7 @@ method saveRecentStickers*(self: Service, installedStickerPacks: Table[int, Stic
   for packId, pack in installedStickerPacks.pairs:
     json[$packId] = %(pack)
 
-  if(self.saveSetting(KEY_INSTALLED_STICKER_PACKS, $json)):
+  if(self.saveSetting(KEY_INSTALLED_STICKER_PACKS, json)):
     self.settings.installedStickerPacks = installedStickerPacks
     return true
   return false

--- a/src/app_service/service/settings/service_interface.nim
+++ b/src/app_service/service/settings/service_interface.nim
@@ -204,7 +204,7 @@ method isEIP1559Enabled*(self: ServiceInterface, blockNumber: int): bool {.base.
 method isEIP1559Enabled*(self: ServiceInterface): bool {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method getRecentStickers*(self: ServiceInterface): seq[StickerDto] {.base.} =
+method getRecentStickers*(self: ServiceInterface): seq[string] {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method saveRecentStickers*(self: ServiceInterface, recentStickers: seq[StickerDto]): bool {.base.} =

--- a/src/app_service/service/stickers/async_tasks.nim
+++ b/src/app_service/service/stickers/async_tasks.nim
@@ -1,28 +1,10 @@
 include ../../common/json_utils
 include ../../../app/core/tasks/common
 
-# type
-#   EstimateTaskArg = ref object of QObjectTaskArg
-#     packId: int
-#     address: string
-#     price: string
-#     uuid: string
-#   ObtainAvailableStickerPacksTaskArg = ref object of QObjectTaskArg
-#     running*: ByteAddress # pointer to threadpool's `.running` Atomic[bool]
-#     contract*: ContractDto
-
 type
-  # EstimateTaskArg = ref object of QObjectTaskArg
-  #   packId: int
-  #   address: string
-  #   price: string
-  #   uuid: string
   EstimateTaskArg = ref object of QObjectTaskArg
     data:  JsonNode
     uuid: string
-    # tx: TransactionDataDto
-    # approveAndCall: ApproveAndCall[100]
-    # sntContract: Erc20ContractDto
   ObtainAvailableStickerPacksTaskArg = ref object of QObjectTaskArg
     running*: ByteAddress # pointer to threadpool's `.running` Atomic[bool]
     contract*: ContractDto

--- a/src/app_service/service/stickers/service.nim
+++ b/src/app_service/service/stickers/service.nim
@@ -1,13 +1,11 @@
 import NimQml, Tables, json, sequtils, chronicles, strutils, atomics, sets, strutils, tables, stint
-import status/types/[transaction, sticker]
 
 import httpclient
 import eventemitter
 import ../../../app/core/[main]
 import ../../../app/core/tasks/[qt, threadpool]
 
-import
-  web3/ethtypes, web3/conversions, stew/byteutils, nimcrypto, json_serialization, chronicles
+import web3/ethtypes, web3/conversions, stew/byteutils, nimcrypto, json_serialization, chronicles
 import json, tables, json_serialization
 
 import status/statusgo_backend_new/stickers as status_stickers
@@ -28,6 +26,7 @@ import ../eth/dto/edn_dto as edn_helper
 
 # TODO Remove those imports once chat is refactored
 import status/statusgo_backend/chat as status_chat
+import status/types/[sticker]
 
 export StickerDto
 export StickerPackDto
@@ -154,7 +153,7 @@ QtObject:
         result,
         address,
         $sntContract.address,
-        transaction.PendingTransactionType.BuyStickerPack,
+        transactions.PendingTransactionType.BuyStickerPack,
         $packId
       )
 

--- a/src/app_service/service/stickers/service.nim
+++ b/src/app_service/service/stickers/service.nim
@@ -345,11 +345,11 @@ QtObject:
     var stickers = newSeq[StickerDto]()
     for hash in recentStickers:
       # pack id is not returned from status-go settings, populate here
-      let packId = getPackIdForSticker(installedStickers, $hash)
+      let packId = getPackIdForSticker(installedStickers, hash)
       # .insert instead of .add to effectively reverse the order stickers because
       # stickers are re-reversed when added to the view due to the nature of
       # inserting recent stickers at the front of the list
-      stickers.insert(StickerDto(hash: $hash, packId: packId), 0)
+      stickers.insert(StickerDto(hash: hash, packId: packId), 0)
 
     for sticker in stickers:
       self.addStickerToRecent(sticker)

--- a/ui/imports/shared/status/StatusStickersPopup.qml
+++ b/ui/imports/shared/status/StatusStickersPopup.qml
@@ -47,6 +47,21 @@ Popup {
             root.close()
         }
     }
+
+    Component.onCompleted: {
+        if (stickersModule.packsLoaded) {
+            root.setStickersReady()
+        }
+    }
+
+    function setStickersReady() {
+        root.stickerPacksLoaded = true
+        stickerPackListView.visible = true
+        loadingGrid.active = false
+        loadingStickerPackListView.model = []
+        noStickerPacks.visible = installedPacksCount === 0 || stickersModule.recent.rowCount() === 0
+    }
+
     contentItem: ColumnLayout {
         anchors.fill: parent
         spacing: 0
@@ -261,13 +276,11 @@ Popup {
         }
     }
     Connections {
+        id: loadedConnection
         target: stickersModule
         onStickerPacksLoaded: {
-            root.stickerPacksLoaded = true
-            stickerPackListView.visible = true
-            loadingGrid.active = false
-            loadingStickerPackListView.model = []
-            noStickerPacks.visible = installedPacksCount === 0 || stickersModule.recent.rowCount() === 0
+            root.setStickersReady()
+            loadedConnection.enabled = false
         }
     }
 }


### PR DESCRIPTION
- remove dependency on dto in views and use Item instead
- Fix getting installed and recent stickers
- Fix stickers appearing as loading on a new account when joining a channel for the first time
- Remove import to the old status-lib code

Has a dependency on https://github.com/status-im/status-lib/pull/124