### PR TITLE
fix(PrivacyView): Fix relations between switches and line sensor and local settins

### DIFF
--- a/src/app/chat/view.nim
+++ b/src/app/chat/view.nim
@@ -220,6 +220,18 @@ QtObject:
       return status_ens.userNameOrAlias(self.status.chat.getContacts()[pubKey])
     generateAlias(pubKey)
 
+  proc getProfileThumbnail*(self: ChatsView, pubKey: string): string {.slot.} =
+    if self.status.chat.getContacts().hasKey(pubKey):
+      return self.status.chat.getContacts()[pubKey].identityImage.thumbnail
+    else:
+      return ""
+  
+  proc getProfileImageLarge*(self: ChatsView, pubKey: string): string {.slot.} =
+    if self.status.chat.getContacts().hasKey(pubKey):
+      return self.status.chat.getContacts()[pubKey].identityImage.large
+    else:
+      return ""
+
   proc activityNotificationsChanged*(self: ChatsView) {.signal.}
 
   proc getActivityNotificationList(self: ChatsView): QVariant {.slot.} =

--- a/ui/app/AppLayouts/Profile/views/PrivacyView.qml
+++ b/ui/app/AppLayouts/Profile/views/PrivacyView.qml
@@ -166,10 +166,15 @@ Item {
                 StatusQControls.StatusSwitch {
                     id: switch1
                     checked: !localAccountSensitiveSettings.onlyShowContactsProfilePics
+                    onCheckedChanged: {
+                        if (localAccountSensitiveSettings.onlyShowContactsProfilePics !== !checked) {
+                            localAccountSensitiveSettings.onlyShowContactsProfilePics = !checked
+                        }
+                    }
                 }
             ]
             sensor.onClicked: {
-                switch1.checked = localAccountSensitiveSettings.onlyShowContactsProfilePics = !switch1.checked
+                switch1.checked = !switch1.checked
             }
         }
 
@@ -185,10 +190,15 @@ Item {
                 StatusQControls.StatusSwitch {
                     id: switch2               
                     checked: localAccountSensitiveSettings.displayChatImages
+                    onCheckedChanged: {
+                        if (localAccountSensitiveSettings.displayChatImages !== checked) {
+                            localAccountSensitiveSettings.displayChatImages !== checked
+                        }
+                    }
                 }
             ]
             sensor.onClicked: {
-                switch2.checked = localAccountSensitiveSettings.displayChatImages = !switch2.checked
+                switch2.checked = !switch2.checked
             }
         }
 
@@ -263,10 +273,15 @@ Item {
                 StatusQControls.StatusSwitch {
                     id: switch3
                     checked: !root.store.messagesFromContactsOnly
+                    onCheckedChanged: {
+                        if (root.store.messagesFromContactsOnly !== !checked) {
+                            root.store.messagesFromContactsOnly = !checked
+                        }
+                    }
                 }
             ]
             sensor.onClicked: {
-                switch3.checked = root.store.setMessagesFromContactsOnly(!switch3.checked)
+                switch3.checked = !switch3.checked
             }
         }
     }

--- a/ui/app/AppMain.qml
+++ b/ui/app/AppMain.qml
@@ -57,12 +57,16 @@ Item {
 
         if (localAccountSensitiveSettings.onlyShowContactsProfilePics) {
             const isContact = appMain.rootStore.contactsModuleInst.model.list.rowData(index, "isContact")
-            if (isContact === "false") {
+            if (isContact === "true") {
+                return appMain.rootStore.contactsModuleInst.model.list.rowData(index, useLargeImage ? "largeImage" : "thumbnailImage")
+            } else {
                 return
             }
         }
 
-        return appMain.rootStore.contactsModuleInst.model.list.rowData(index, useLargeImage ? "largeImage" : "thumbnailImage")
+        return  useLargeImage ? appMain.rootStore.chatsModelInst.getProfileImageLarge(pubkey)
+                              : appMain.rootStore.chatsModelInst.getProfileThumbnail(pubkey)
+
     }
 
     function openPopup(popupComponent, params = {}) {


### PR DESCRIPTION
Fix relations between switches and line sensor and local settins

Closes: #4191

### What does the PR do

This PR change interaction in `StatusListItem` in Privacy settings

### Affected areas

Privacy settings

### Screenshot of functionality

https://user-images.githubusercontent.com/82511785/144581330-964e4b2e-ed3b-40d4-90f5-275c985542bd.mov


