### PR TITLE
fix: ensure app tab buuttons match correct app section

### DIFF
--- a/ui/app/AppMain.qml
+++ b/ui/app/AppMain.qml
@@ -317,16 +317,6 @@ Item {
                 },
 
                 StatusNavBarTabButton {
-                    enabled: isExperimental === "1" || localAccountSensitiveSettings.timelineEnabled
-                    visible: enabled
-                    //% "Timeline"
-                    tooltip.text: qsTrId("timeline")
-                    icon.name: "status-update"
-                    checked: appView.currentIndex == Utils.getAppSectionIndex(Constants.timeline)
-                    onClicked: appMain.changeAppSection(Constants.timeline)
-                },
-
-                StatusNavBarTabButton {
                     enabled: isExperimental === "1" || localAccountSensitiveSettings.nodeManagementEnabled
                     visible: enabled
                     tooltip.text: qsTr("Node Management")
@@ -412,7 +402,7 @@ Item {
                 if(obj === walletV2LayoutContainer){
                     walletV2LayoutContainer.showSigningPhrasePopup();
                 }
-                localAccountSensitiveSettings.lastModeActiveTab = (currentIndex === Utils.getAppSectionIndex(Constants.timeline)) ? 0 : currentIndex
+                localAccountSensitiveSettings.lastModeActiveTab = currentIndex
             }
 
             ChatLayout {

--- a/ui/imports/utils/Utils.qml
+++ b/ui/imports/utils/Utils.qml
@@ -131,15 +131,15 @@ QtObject {
         case Constants.chat: sectionId = 0; break;
         case Constants.wallet: sectionId = 1; break;
         case Constants.browser: sectionId = 2; break;
-        case Constants.timeline: sectionId = 3; break;
-        case Constants.profile: sectionId = 4; break;
-        case Constants.node: sectionId = 5; break;
-        case Constants.ui: sectionId = 6; break;
-        case Constants.walletv2: sectionId = 7; break;
+        case Constants.profile: sectionId = 3; break;
+        case Constants.node: sectionId = 4; break;
+        case Constants.ui: sectionId = 5; break;
+        case Constants.walletv2: sectionId = 6; break;
         case Constants.community: sectionId = 99; break;
         }
         if (sectionId === -1) {
-            throw new Exception ("Unknown section name. Check the Constants to know the available ones")
+            console.warn("Unknown section name. Defaulting to chat section")
+            return 0
         }
         return sectionId
     }

--- a/ui/main.qml
+++ b/ui/main.qml
@@ -421,7 +421,6 @@ StatusWindow {
         signal droppedOnValidScreen(var drop)
         property alias droppedUrls: rptDraggedPreviews.model
         readonly property int chatView: Utils.getAppSectionIndex(Constants.chat)
-        readonly property int timelineView: Utils.getAppSectionIndex(Constants.timeline)
         property bool enabled: !drag.source && !!loader.item && !!loader.item.appLayout &&
                                (
                                    // in chat view
@@ -433,8 +432,6 @@ StatusWindow {
                                         chatsModel.channelView.activeChannel.chatType === Constants.chatTypePrivateGroupChat
                                         )
                                     ) ||
-                                   // in timeline view
-                                   loader.item.appLayout.appView.currentIndex === timelineView ||
                                    // In community section
                                    loader.item.appLayout.appView.currentIndex === chatsModel.communities.activeCommunity.active
                                    )


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/4254

Since the timeline was removed, this introduced a little hiccup in
the application section selection.

This commit ensures navigation tab buttons match the correct section.
