### PR TITLE
fix(StatusChatInput): ensure anchors of textfield are set correctly

### DIFF
--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -846,7 +846,7 @@ Rectangle {
             id: scrollView
             anchors.top: parent.top
             anchors.bottom: parent.bottom
-            anchors.left: profileImage.visible ? profileImage.right : parent.left
+            anchors.left: parent.left
             anchors.leftMargin: Style.current.smallPadding
             anchors.right: actions.left
             anchors.rightMargin: Style.current.halfPadding


### PR DESCRIPTION
This broke when we removed timeline support. Most likely because `profileImage`
is undefined, the entire expression fails, leaving `anchors.left` `undefined`,
causing the text area to be slammed to the right.
