### PR TITLE
fix: fix access to root store property for user online status

### DIFF
--- a/ui/app/AppLayouts/Chat/ChatLayout.qml
+++ b/ui/app/AppLayouts/Chat/ChatLayout.qml
@@ -186,7 +186,7 @@ StatusAppThreePanelLayout {
             community: root.rootStore.chatsModelInst.communities.activeCommunity
             currentUserName: Utils.removeStatusEns(root.rootStore.profileModelInst.ens.preferredUsername
                                                   || root.rootStore.profileModelInst.profile.username)
-            currentUserOnline: root.store.userProfileInst.userStatus
+            currentUserOnline: root.rootStore.userProfileInst.userStatus
             contactsList: root.rootStore.allContacts
         }
     }


### PR DESCRIPTION
There seems to have been a confusion in how the store is named.

