### PR TITLE
refactor: remove dynamic scoping from browser module

### DIFF
--- a/ui/app/AppLayouts/Browser/BrowserLayout.qml
+++ b/ui/app/AppLayouts/Browser/BrowserLayout.qml
@@ -22,115 +22,120 @@ import "../Chat/popups"
 
 // Code based on https://code.qt.io/cgit/qt/qtwebengine.git/tree/examples/webengine/quicknanobrowser/BrowserWindow.qml?h=5.15 
 // Licensed under BSD
-
 Rectangle {
     id: browserWindow
 
     property var globalStore
-    property Item currentWebView: tabs.currentIndex < tabs.count ? tabs.getTab(tabs.currentIndex).item : null
-
-    property Component browserDialogComponent: BrowserDialog {
-        onClosing: destroy()
-    }
-
-    property Component jsDialogComponent: JSDialogWindow {}
-
-    property bool currentTabConnected: false
-
-    property Component accessDialogComponent: BrowserConnectionModal {
-        currentTab: tabs.getTab(tabs.currentIndex) && tabs.getTab(tabs.currentIndex).item
-        x: appLayout.width - width - Style.current.halfPadding
-        y: browserWindow.y + browserHeader.height + Style.current.halfPadding
-    }
-
-    // TODO we'll need a new dialog at one point because this one is not using the same call, but it's good for now
-    property Component sendTransactionModalComponent: SignTransactionModal {
-        store: browserWindow.globalStore
-    }
-
-    property Component signMessageModalComponent: SignMessageModal {}
-
-    property MessageDialog sendingError: MessageDialog {
-        id: sendingError
-        //% "Error sending the transaction"
-        title: qsTrId("error-sending-the-transaction")
-        icon: StandardIcon.Critical
-        standardButtons: StandardButton.Ok
-    }
-
-    property MessageDialog signingError: MessageDialog {
-        id: signingError
-        //% "Error signing message"
-        title: qsTrId("error-signing-message")
-        icon: StandardIcon.Critical
-        standardButtons: StandardButton.Ok
-    }
-
-    property QtObject defaultProfile: WebEngineProfile {
-        storageName: "Profile"
-        offTheRecord: false
-        httpUserAgent: {
-            if (localAccountSensitiveSettings.compatibilityMode) {
-                // Google doesn't let you connect if the user agent is Chrome-ish and doesn't satisfy some sort of hidden requirement
-                return "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:81.0) Gecko/20100101 Firefox/81.0"
-            }
-            return ""
-        }
-        useForGlobalCertificateVerification: true
-        userScripts: [
-            WebEngineScript {
-                injectionPoint: WebEngineScript.DocumentCreation
-                sourceUrl:  Qt.resolvedUrl("./helpers/provider.js")
-                worldId: WebEngineScript.MainWorld // TODO: check https://doc.qt.io/qt-5/qml-qtwebengine-webenginescript.html#worldId-prop
-            }
-        ]
-    }
-
-    property QtObject otrProfile: WebEngineProfile {
-        offTheRecord: true
-        persistentCookiesPolicy:  WebEngineProfile.NoPersistentCookies
-        httpUserAgent: defaultProfile.httpUserAgent
-        userScripts: [
-            WebEngineScript {
-                injectionPoint: WebEngineScript.DocumentCreation
-                sourceUrl:  Qt.resolvedUrl("./helpers/provider.js")
-                worldId: WebEngineScript.MainWorld // TODO: check https://doc.qt.io/qt-5/qml-qtwebengine-webenginescript.html#worldId-prop
-            }
-        ]
-    }
+    property var sendTransactionModal
 
     function openUrlInNewTab(url) {
-        var tab = browserWindow.addNewTab()
-        tab.item.url = determineRealURL(url)
+        var tab = _internal.addNewTab()
+        tab.item.url = _internal.determineRealURL(url)
     }
 
-    function addNewDownloadTab() {
-        tabs.createDownloadTab(tabs.count !== 0 ? currentWebView.profile : defaultProfile);
-        tabs.currentIndex = tabs.count - 1;
-    }
+    QtObject {
+        id: _internal
 
-    function addNewTab() {
-        var tab = tabs.createEmptyTab(tabs.count !== 0 ? currentWebView.profile : defaultProfile);
-        tabs.currentIndex = tabs.count - 1;
-        browserHeader.addressBar.forceActiveFocus();
-        browserHeader.addressBar.selectAll();
+        property Item currentWebView: tabs.currentIndex < tabs.count ? tabs.getTab(tabs.currentIndex).item : null
 
-        return tab;
-    }
+        property Component browserDialogComponent: BrowserDialog {
+            onClosing: destroy()
+        }
 
-    function onDownloadRequested(download) {
-        downloadBar.isVisible = true
-        download.accept();
-        DownloadsStore.addDownload(download)
-    }
+        property Component jsDialogComponent: JSDialogWindow {}
 
-    function determineRealURL(url) {
-        return Web3ProviderStore.determineRealURL(url)
-    }
+        property Component accessDialogComponent: BrowserConnectionModal {
+            currentTab: tabs.getTab(tabs.currentIndex) && tabs.getTab(tabs.currentIndex).item
+            parent: browserWindow
+            x: browserWindow.width - width - Style.current.halfPadding
+            y: browserWindow.y + browserHeader.height + Style.current.halfPadding
+            web3Response: function(message) {
+                provider.web3Response(message)
+            }
+        }
 
-    onCurrentWebViewChanged: {
-        findBar.reset();
-        browserHeader.addressBar.text = Web3ProviderStore.obtainAddress(currentWebView.url)
+        // TODO we'll need a new dialog at one point because this one is not using the same call, but it's good for now
+        property Component sendTransactionModalComponent: SignTransactionModal {
+            store: browserWindow.globalStore
+        }
+
+        property Component signMessageModalComponent: SignMessageModal {}
+
+        property MessageDialog sendingError: MessageDialog {
+            //% "Error sending the transaction"
+            title: qsTrId("error-sending-the-transaction")
+            icon: StandardIcon.Critical
+            standardButtons: StandardButton.Ok
+        }
+
+        property MessageDialog signingError: MessageDialog {
+            //% "Error signing message"
+            title: qsTrId("error-signing-message")
+            icon: StandardIcon.Critical
+            standardButtons: StandardButton.Ok
+        }
+
+        property QtObject defaultProfile: WebEngineProfile {
+            storageName: "Profile"
+            offTheRecord: false
+            httpUserAgent: {
+                if (localAccountSensitiveSettings.compatibilityMode) {
+                    // Google doesn't let you connect if the user agent is Chrome-ish and doesn't satisfy some sort of hidden requirement
+                    return "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:81.0) Gecko/20100101 Firefox/81.0"
+                }
+                return ""
+            }
+            useForGlobalCertificateVerification: true
+            userScripts: [
+                WebEngineScript {
+                    injectionPoint: WebEngineScript.DocumentCreation
+                    sourceUrl:  Qt.resolvedUrl("./helpers/provider.js")
+                    worldId: WebEngineScript.MainWorld // TODO: check https://doc.qt.io/qt-5/qml-qtwebengine-webenginescript.html#worldId-prop
+                }
+            ]
+        }
+
+        property QtObject otrProfile: WebEngineProfile {
+            offTheRecord: true
+            persistentCookiesPolicy:  WebEngineProfile.NoPersistentCookies
+            httpUserAgent: _internal.defaultProfile.httpUserAgent
+            userScripts: [
+                WebEngineScript {
+                    injectionPoint: WebEngineScript.DocumentCreation
+                    sourceUrl:  Qt.resolvedUrl("./helpers/provider.js")
+                    worldId: WebEngineScript.MainWorld // TODO: check https://doc.qt.io/qt-5/qml-qtwebengine-webenginescript.html#worldId-prop
+                }
+            ]
+        }
+
+        function addNewDownloadTab() {
+            tabs.createDownloadTab(tabs.count !== 0 ? currentWebView.profile : defaultProfile);
+            tabs.currentIndex = tabs.count - 1;
+        }
+
+        function addNewTab() {
+            var tab = tabs.createEmptyTab(tabs.count !== 0 ? currentWebView.profile : defaultProfile);
+            tabs.currentIndex = tabs.count - 1;
+            browserHeader.addressBar.forceActiveFocus();
+            browserHeader.addressBar.selectAll();
+
+            return tab;
+        }
+
+        function onDownloadRequested(download) {
+            downloadBar.isVisible = true
+            download.accept();
+            DownloadsStore.addDownload(download)
+        }
+
+        function determineRealURL(url) {
+            return Web3ProviderStore.determineRealURL(url)
+        }
+
+        onCurrentWebViewChanged: {
+            findBar.reset();
+            browserHeader.addressBar.text = Web3ProviderStore.obtainAddress(currentWebView.url)
+        }
     }
 
     Layout.fillHeight: true
@@ -139,10 +144,71 @@ Rectangle {
     color: Style.current.inputBackground
     border.width: 0
 
-    WebProviderObj { id: provider }
+    WebProviderObj {
+        id: provider
+        createAccessDialogComponent: function() {
+            return _internal.accessDialogComponent.createObject(browserWindow)
+        }
+        createSendTransactionModalComponent: function(request) {
+            return _internal.sendTransactionModalComponent.createObject(browserWindow, {
+                                                                  trxData: request.payload.params[0].data || "",
+                                                                  selectedAccount: {
+                                                                      name: WalletStore.dappBrowserAccount.name,
+                                                                      address: request.payload.params[0].from,
+                                                                      iconColor: WalletStore.dappBrowserAccount.color,
+                                                                      assets: WalletStore.dappBrowserAccount.assets
+                                                                  },
+                                                                  selectedRecipient: {
+                                                                      address: request.payload.params[0].to,
+                                                                      identicon: RootStore.generateIdenticon(request.payload.params[0].to),
+                                                                      name: RootStore.activeChannelName,
+                                                                      type: RecipientSelector.Type.Address
+                                                                  },
+                                                                  selectedAsset: {
+                                                                      name: "ETH",
+                                                                      symbol: "ETH",
+                                                                      address: Constants.zeroAddress
+                                                                  },
+                                                                  selectedFiatAmount: "42", // TODO calculate that
+                                                                  selectedAmount: RootStore.getWei2Eth(request.payload.params[0].value, 18)
+                                                              })
+        }
+        createSignMessageModalComponent: function(request) {
+            return _internal.signMessageModalComponent.createObject(browserWindow, {
+                                                              request,
+                                                              selectedAccount: {
+                                                                  name: WalletStore.dappBrowserAccount.name,
+                                                                  iconColor: WalletStore.dappBrowserAccount.color
+                                                              }
+                                                          })
+        }
+        showSendingError: function(message) {
+            _internal.sendingError.text = e.message
+            return _internal.sendingError.open()
+        }
+        showSigningError: function(message) {
+            _internal.signingError.text = e.message
+            return _internal.signingError.open()
+        }
+        showToastMessage: function(result) {
+            // TODO: WIP under PR https://github.com/status-im/status-desktop/pull/4274
+            //% "Transaction pending..."
+            toastMessage.title = qsTrId("ens-transaction-pending")
+            toastMessage.source = Style.svg("loading")
+            toastMessage.iconColor = Style.current.primary
+            toastMessage.iconRotates = true
+            toastMessage.link = `${WalletStore.etherscanLink}/${result}`
+            toastMessage.open()
+        }
+    }
 
     BrowserShortcutActions {
         id: keyboardShortcutActions
+        currentWebView: _internal.currentWebView
+        findBarComponent: findBar
+        browserHeaderComponent: browserHeader
+        onAddNewDownloadTab: _internal.addNewDownloadTab()
+        onRemoveView: tabs.removeView(tabs.currentIndex)
     }
 
     WebChannel {
@@ -155,19 +221,44 @@ Rectangle {
         anchors.top: parent.top
         anchors.topMargin: tabs.tabHeight + tabs.anchors.topMargin
         z: 52
-        addNewTab: browserWindow.addNewTab
         favoriteComponent: favoritesBar
-        currentFavorite: currentWebView && BookmarksStore.getCurrentFavorite(currentWebView.url)
+        currentFavorite: _internal.currentWebView && BookmarksStore.getCurrentFavorite(_internal.currentWebView.url)
         dappBrowserAccName: WalletStore.dappBrowserAccount.name
         dappBrowserAccIcon: WalletStore.dappBrowserAccount.color
+        settingMenu: settingsMenu
+        walletMenu: browserWalletMenu
+        currentUrl: _internal.currentWebView.url
+        isLoading: _internal.currentWebView.loading
+        canGoBack: _internal.currentWebView.canGoBack
+        canGoForward: _internal.currentWebView.canGoForward
+        currentTabConnected: RootStore.currentTabConnected
+        onOpenHistoryPopup: historyMenu.popup(xPos, yPos)
+        onGoBack: _internal.currentWebView.goBack()
+        onGoForward: _internal.currentWebView.goForward()
+        onReload: _internal.currentWebView.reload()
+        onStopLoading: _internal.currentWebView.stop()
         onAddNewFavoritelClicked: {
             addFavoriteModal.modifiyModal = browserHeader.currentFavorite
             addFavoriteModal.toolbarMode = true
             addFavoriteModal.x = xPos - 30
             addFavoriteModal.y = browserHeader.y + browserHeader.height + 4
-            addFavoriteModal.ogUrl = browserHeader.currentFavorite ? browserHeader.currentFavorite.url : currentWebView.url
-            addFavoriteModal.ogName = browserHeader.currentFavorite ? browserHeader.currentFavorite.name : currentWebView.title
+            addFavoriteModal.ogUrl = browserHeader.currentFavorite ? browserHeader.currentFavorite.url : _internal.currentWebView.url
+            addFavoriteModal.ogName = browserHeader.currentFavorite ? browserHeader.currentFavorite.name : _internal.currentWebView.title
             addFavoriteModal.open()
+        }
+        onLaunchInBrowser: {
+            // TODO: disable browsing local files?  file://
+            if (localAccountSensitiveSettings.useBrowserEthereumExplorer !== Constants.browserEthereumExplorerNone && url.startsWith("0x")) {
+                _internal.currentWebView.url = RootStore.get0xFormedUrl(localAccountSensitiveSettings.useBrowserEthereumExplorer, url)
+                return
+            }
+            if (localAccountSensitiveSettings.shouldShowBrowserSearchEngine !== Constants.browserSearchEngineNone && !Utils.isURL(url) && !Utils.isURLWithOptionalProtocol(url)) {
+                _internal.currentWebView.url = RootStore.getFormedUrl(localAccountSensitiveSettings.shouldShowBrowserSearchEngine, url)
+                return
+            } else if (Utils.isURLWithOptionalProtocol(url)) {
+                url = "https://" + url
+            }
+            _internal.currentWebView.url = _internal.determineRealURL(url);
         }
     }
 
@@ -181,6 +272,18 @@ Rectangle {
         anchors.right: parent.right
         z: 50
         tabComponent: webEngineView
+        currentWebEngineProfile: _internal.currentWebView.profile
+        determineRealURL: function(url) {
+            return _internal.determineRealURL(url)
+        }
+        onOpenNewTabTriggered: _internal.addNewTab()
+        Component.onCompleted: {
+            _internal.defaultProfile.downloadRequested.connect(_internal.onDownloadRequested);
+            _internal.otrProfile.downloadRequested.connect(_internal.onDownloadRequested);
+            var tab = createEmptyTab(_internal.defaultProfile);
+            // For Devs: Uncomment the next lien if you want to use the simpeldapp on first load
+            // tab.item.url = Web3ProviderStore.determineRealURL("https://simpledapp.eth");
+        }
     }
 
     ProgressBar {
@@ -189,7 +292,7 @@ Rectangle {
         from: 0
         to: 100
         visible: value != 0 && value != 100
-        value: (currentWebView && currentWebView.loadProgress < 100) ? currentWebView.loadProgress : 0
+        value: (_internal.currentWebView && _internal.currentWebView.loadProgress < 100) ? _internal.currentWebView.loadProgress : 0
         anchors.bottom: parent.bottom
         anchors.bottomMargin: Style.current.padding
         anchors.right: parent.right
@@ -205,7 +308,7 @@ Rectangle {
         anchors.right: parent.right
         anchors.bottom: parent.bottom
         onNewViewRequested: function(request) {
-            var tab = tabs.createEmptyTab(currentWebView.profile);
+            var tab = tabs.createEmptyTab(_internal.currentWebView.profile);
             tabs.currentIndex = tabs.count - 1;
             request.openIn(tab.item);
         }
@@ -220,6 +323,12 @@ Rectangle {
         id: favoriteMenu
         openInNewTab: function (url) {
             browserWindow.openUrlInNewTab(url)
+        }
+        onEditFavoriteTriggered:         {
+            addFavoriteModal.modifiyModal = true
+            addFavoriteModal.ogUrl = favoriteMenu.currentFavorite ? favoriteMenu.currentFavorite.url : _internal.currentWebView.url
+            addFavoriteModal.ogName = favoriteMenu.currentFavorite ? favoriteMenu.currentFavorite.name : _internal.currentWebView.title
+            addFavoriteModal.open()
         }
     }
 
@@ -260,12 +369,14 @@ Rectangle {
         anchors.bottom: parent.bottom
         z: 60
         downloadsModel: DownloadsStore.downloadModel
+        downloadsMenu: downloadMenu
         onOpenDownloadClicked: {
             if (downloadComplete) {
                 return DownloadsStore.openFile(index)
             }
             DownloadsStore.openDirectory(index)
         }
+        onAddNewDownloadTab: _internal.addNewDownloadTab()
     }
 
     FindBar {
@@ -277,13 +388,13 @@ Rectangle {
 
         onFindNext: {
             if (text)
-                currentWebView && currentWebView.findText(text);
+                _internal.currentWebView && _internal.currentWebView.findText(text);
             else if (!visible)
                 visible = true;
         }
         onFindPrevious: {
             if (text)
-                currentWebView && currentWebView.findText(text, WebEngineView.FindBackward);
+                _internal.currentWebView && _internal.currentWebView.findText(text, WebEngineView.FindBackward);
             else if (!visible)
                 visible = true;
         }
@@ -320,29 +431,182 @@ Rectangle {
         id: downloadMenu
     }
 
+    BrowserSettingsMenu {
+        id: settingsMenu
+        x: parent.width - width
+        y: browserHeader.y + (localAccountSensitiveSettings.shouldShowFavoritesBar ? browserHeader.height - 38 : browserHeader.height)
+        isIncognito: _internal.currentWebView && _internal.currentWebView.profile === _internal.otrProfile
+        onAddNewTab: _internal.addNewTab()
+        onGoIncognito: {
+            if (_internal.currentWebView) {
+                _internal.currentWebView.profile = checked ? _internal.otrProfile : _internal.defaultProfile;
+            }
+        }
+        onZoomIn: {
+            const newZoom = _internal.currentWebView.zoomFactor + 0.1
+            _internal.currentWebView.changeZoomFactor(newZoom)
+        }
+        onZoomOut: {
+            const newZoom = currentWebView.zoomFactor - 0.1
+            _internal.currentWebView.changeZoomFactor(newZoom)
+        }
+        onChangeZoomFactor: _internal.currentWebView.changeZoomFactor(1.0)
+        onLaunchFindBar: {
+            if (!findBar.visible) {
+                findBar.visible = true;
+                findBar.forceActiveFocus()
+            }
+        }
+        onToggleCompatibilityMode: {
+            for (let i = 0; i < tabs.count; ++i){
+                tabs.getTab(i).item.stop() // Stop all loading tabs
+            }
+
+            localAccountSensitiveSettings.compatibilityMode = checked;
+
+            for (let i = 0; i < tabs.count; ++i){
+                tabs.getTab(i).item.reload() // Reload them with new user agent
+            }
+        }
+        onLaunchBrowserSettings: {
+            Global.changeAppSectionBySectionType(Constants.appSection.profile)
+            // TODO: replace with shared store constant
+            // Profile/RootStore.browser_settings_id
+            profileLayoutContainer.changeProfileSection(10)
+        }
+    }
+
+    BrowserWalletMenu {
+        id: browserWalletMenu
+        y: browserHeader.height + browserHeader.anchors.topMargin
+        x: parent.width - width - Style.current.halfPadding
+        onSendTriggered: {
+            sendTransactionModal.selectedAccount = selectedAccount
+            sendTransactionModal.open()
+        }
+        onReload: {
+            for (let i = 0; i < tabs.count; ++i){
+                tabs.getTab(i).item.reload();
+            }
+        }
+        onDisconnect: {
+            Web3ProviderStore.web3ProviderInst.disconnect()
+            provider.postMessage(`{"type":"web3-disconnect-account"}`)
+            close()
+        }
+    }
+
+    Menu {
+        id: historyMenu
+        Instantiator {
+            model: _internal.currentWebView && _internal.currentWebView.navigationHistory.items
+            MenuItem {
+                text: model.title
+                onTriggered: _internal.currentWebView.goBackOrForward(model.offset)
+                checkable: !enabled
+                checked: !enabled
+                enabled: model.offset
+            }
+            onObjectAdded: function(index, object) {
+                historyMenu.insertItem(index, object)
+            }
+            onObjectRemoved: function(index, object) {
+                historyMenu.removeItem(object)
+            }
+        }
+    }
+
     Component {
         id: favoritesBar
         FavoritesBar {
             bookmarkModel: BookmarksStore.bookmarksModel
+            favoritesMenu: favoriteMenu
+            setAsCurrentWebUrl:  function(url) {
+                _internal.currentWebView.url = _internal.determineRealURL(url)
+            }
+            addFavModal: function() {
+                addFavoriteModal.toolbarMode = true
+                addFavoriteModal.ogUrl = browserHeader.currentFavorite ? browserHeader.currentFavorite.url : _internal.currentWebView.url
+                addFavoriteModal.ogName = browserHeader.currentFavorite ? browserHeader.currentFavorite.name : _internal.currentWebView.title
+                addFavoriteModal.open()
+            }
         }
     }
 
     Component {
         id: webEngineView
-        BrowserWebEngineView {}
+        BrowserWebEngineView {
+            anchors.top: parent.top
+            anchors.topMargin: browserHeader.height
+            currentWebView: _internal.currentWebView
+            webChannel: channel
+            findBarComp: findBar
+            favMenu: favoriteMenu
+            addFavModal: addFavoriteModal
+            downloadsMenu: downloadMenu
+            determineRealURLFn: function(url) {
+                return _internal.determineRealURL(url)
+            }
+            onLinkHovered: function(hoveredUrl) {
+                if (hoveredUrl === "")
+                    hideStatusText.start();
+                else {
+                    statusText.text = hoveredUrl;
+                    statusBubble.visible = true;
+                    hideStatusText.stop();
+                }
+            }
+            onSetCurrentWebUrl: {
+                _internal.currentWebView.url = url
+            }
+            onWindowCloseRequested: tabs.removeView(tabs.indexOfView(webEngineView))
+            onNewViewRequested: function(request) {
+                if (!request.userInitiated) {
+                    print("Warning: Blocked a popup window.");
+                } else if (request.destination === WebEngineView.NewViewInTab) {
+                    var tab = tabs.createEmptyTab(_internal.currentWebView.profile);
+                    tabs.currentIndex = tabs.count - 1;
+                    request.openIn(tab.item);
+                } else if (request.destination === WebEngineView.NewViewInBackgroundTab) {
+                    var backgroundTab = tabs.createEmptyTab(_internal.currentWebView.profile);
+                    request.openIn(backgroundTab.item);
+                    // Disabling popups temporarily since we need to set that webengineview settings / channel and other properties
+                    /*} else if (request.destination === WebEngineView.NewViewInDialog) {
+                    var dialog = browserDialogComponent.createObject();
+                    dialog.currentWebView.profile = currentWebView.profile;
+                    dialog.currentWebView.webChannel = channel;
+                    request.openIn(dialog.currentWebView);*/
+                } else {
+                    // Instead of opening a new window, we open a new tab
+                    // TODO: remove "open in new window" from context menu
+                    var tab = tabs.createEmptyTab(_internal.currentWebView.profile);
+                    tabs.currentIndex = tabs.count - 1;
+                    request.openIn(tab.item);
+                }
+            }
+            onCertificateError: function(error) {
+                error.defer();
+                sslDialog.enqueue(error);
+            }
+            onJavaScriptDialogRequested: function(request) {
+                request.accepted = true;
+                var dialog = _internal.jsDialogComponent.createObject(browserWindow, {"request": request});
+                dialog.open();
+            }
+        }
     }
 
     Connections {
-        target: currentWebView
+        target: _internal.currentWebView
         onUrlChanged: {
-            browserHeader.addressBar.text = Web3ProviderStore.obtainAddress(currentWebView.url)
+            browserHeader.addressBar.text = Web3ProviderStore.obtainAddress(_internal.currentWebView.url)
         }
     }
 
     Connections {
         target: BookmarksStore.bookmarksModel
         onModelChanged: {
-            browserHeader.currentFavorite = Qt.binding(function () {return BookmarksStore.getCurrentFavorite(currentWebView.url)})
+            browserHeader.currentFavorite = Qt.binding(function () {return BookmarksStore.getCurrentFavorite(_internal.currentWebView.url)})
         }
     }
 }

--- a/ui/app/AppLayouts/Browser/panels/BrowserTabView.qml
+++ b/ui/app/AppLayouts/Browser/panels/BrowserTabView.qml
@@ -1,5 +1,4 @@
 import QtQuick 2.13
-import QtQuick.Controls 2.13
 import QtQuick.Controls 1.0 as QQC1
 
 import "../controls/styles"
@@ -7,8 +6,12 @@ import "../controls/styles"
 QQC1.TabView {
     id: tabs
 
-    property int tabHeight: 40
+    property var currentWebEngineProfile
     property var tabComponent
+    property var determineRealURL: function(url) {}
+    readonly property int tabHeight: 40
+
+    signal openNewTabTriggered()
 
     function createEmptyTab(profile, createAsStartPage) {
         var tab = addTab("", tabComponent);
@@ -55,27 +58,19 @@ QQC1.TabView {
         return -1
     }
 
+    function openNewTabClicked() {
+         openNewTabTriggered()
+     }
+
     function removeView(index) {
         if (tabs.count === 1) {
-            tabs.createEmptyTab(currentWebView.profile, true)
+            tabs.createEmptyTab(currentWebEngineProfile, true)
         }
         tabs.removeTab(index)
     }
 
-    function openNewTabClicked() {
-        addNewTab()
-    }
-
     function closeButtonClicked(index) {
         removeView(index)
-    }
-
-    Component.onCompleted: {
-        defaultProfile.downloadRequested.connect(onDownloadRequested);
-        otrProfile.downloadRequested.connect(onDownloadRequested);
-        var tab = createEmptyTab(defaultProfile);
-        // For Devs: Uncomment the next lien if you want to use the simpeldapp on first load
-        // tab.item.url = Web3ProviderStore.determineRealURL("https://simpledapp.eth");
     }
 
     style: BrowserTabStyle {}

--- a/ui/app/AppLayouts/Browser/panels/DownloadBar.qml
+++ b/ui/app/AppLayouts/Browser/panels/DownloadBar.qml
@@ -5,9 +5,6 @@ import utils 1.0
 
 import StatusQ.Controls 0.1
 
-import shared 1.0
-import shared.status 1.0
-
 import "../controls"
 
 Rectangle {
@@ -16,8 +13,10 @@ Rectangle {
 
     property bool isVisible: false
     property var downloadsModel
+    property var downloadsMenu
 
     signal openDownloadClicked(bool downloadComplete, int index)
+    signal addNewDownloadTab()
 
     visible: isVisible && !!listView.count
     color: Style.current.background
@@ -78,15 +77,15 @@ Rectangle {
                     openDownloadClicked(downloadComplete, index)
                 }
                 onOptionsButtonClicked: {
-                    downloadMenu.index = index
-                    downloadMenu.downloadComplete = Qt.binding(function() {return downloadElement.downloadComplete})
-
-                    downloadMenu.x =  listView.width + downloadElement.x  + 50
-                    downloadMenu.y = downloadBar.y - downloadMenu.height
-                    downloadMenu.open()
+                    downloadsMenu.index = index
+                    downloadsMenu.downloadComplete = Qt.binding(function() {return downloadElement.downloadComplete})
+                    downloadsMenu.parent = downloadElement
+                    downloadsMenu.x =  xVal + 20
+                    downloadsMenu.y =  -downloadsMenu.height
+                    downloadsMenu.open()
                 }
                 Connections {
-                    target: downloadMenu
+                    target: downloadsMenu
                     onCancelClicked: {
                         isCanceled = true
                     }

--- a/ui/app/AppLayouts/Browser/panels/DownloadView.qml
+++ b/ui/app/AppLayouts/Browser/panels/DownloadView.qml
@@ -1,19 +1,15 @@
 import QtQuick 2.1
-import QtQuick.Controls 1.0
-import QtQuick.Controls.Styles 1.0
-import QtWebEngine 1.9
-import QtQuick.Layouts 1.0
-
-import shared 1.0
-import shared.status 1.0
-import "../controls"
 
 import utils 1.0
 
-Rectangle {
+import "../controls"
+
+    Rectangle {
     id: downloadView
 
     property alias downloadsModel: listView.model
+
+    property var downloadsMenu
 
     signal openDownloadClicked(bool downloadComplete, int index)
 
@@ -56,15 +52,15 @@ Rectangle {
                 openDownloadClicked(downloadComplete, index)
             }
             onOptionsButtonClicked: {
-                downloadMenu.index = index
-                downloadMenu.downloadComplete = Qt.binding(function() {return downloadElement.downloadComplete})
-
-                downloadMenu.x = xVal + 80
-                downloadMenu.y = listView.y + downloadElement.y + downloadElement.height
-                downloadMenu.open()
+                downloadsMenu.index = index
+                downloadsMenu.downloadComplete = Qt.binding(function() {return downloadElement.downloadComplete})
+                downloadsMenu.parent = downloadElement
+                downloadsMenu.x =  xVal
+                downloadsMenu.y = downloadView.y - downloadsMenu.height
+                downloadsMenu.open()
             }
             Connections {
-                target: downloadMenu
+                target: downloadsMenu
                 onCancelClicked: {
                     isCanceled = true
                 }

--- a/ui/app/AppLayouts/Browser/panels/FavoritesBar.qml
+++ b/ui/app/AppLayouts/Browser/panels/FavoritesBar.qml
@@ -10,6 +10,10 @@ RowLayout {
 
     property alias bookmarkModel: bookmarkList.model
 
+    property var favoritesMenu
+    property var setAsCurrentWebUrl: function(url){}
+    property var addFavModal: function(){}
+
     spacing: 0
     height: 38
 
@@ -41,22 +45,19 @@ RowLayout {
                     }
 
                     if (mouse.button === Qt.RightButton) {
-                        favoriteMenu.url = url
-                        favoriteMenu.x = favoriteBtn.x + mouse.x
-                        favoriteMenu.y = Qt.binding(function () {return mouse.y + favoriteMenu.height})
-                        favoriteMenu.open()
+                        favoritesMenu.url = url
+                        favoritesMenu.x = favoriteBtn.x + mouse.x
+                        favoritesMenu.y = Qt.binding(function () {return mouse.y + favoritesMenu.height})
+                        favoritesMenu.open()
                         return
                     }
 
                     if (isAddBookmarkButton) {
-                        addFavoriteModal.toolbarMode = true
-                        addFavoriteModal.ogUrl = browserHeader.currentFavorite ? browserHeader.currentFavorite.url : currentWebView.url
-                        addFavoriteModal.ogName = browserHeader.currentFavorite ? browserHeader.currentFavorite.name : currentWebView.title
-                        addFavoriteModal.open()
+                        addFavModal()
                         return
                     }
 
-                    currentWebView.url = determineRealURL(url)
+                    setAsCurrentWebUrl(url)
                 }
             }
         }

--- a/ui/app/AppLayouts/Browser/panels/FavoritesList.qml
+++ b/ui/app/AppLayouts/Browser/panels/FavoritesList.qml
@@ -1,31 +1,37 @@
 import QtQuick 2.13
-import shared 1.0
-import shared.status 1.0
-import "../controls"
 
 import utils 1.0
 
+import "../controls"
+
 GridView {
     id: bookmarkGrid
+
+    property var determineRealURLFn: function(url){}
+    property var setAsCurrentWebUrl: function(url){}
+    property var favMenu
+    property var addFavModal
+
     cellWidth: 100
     cellHeight: 100
+
     delegate: BookmarkButton {
         id: bookmarkBtn
         text: name
         source: imageUrl
-        webUrl: determineRealURL(url)
+        webUrl: determineRealURLFn(url)
         onClicked: {
             if (!webUrl.toString()) {
-                addFavoriteModal.open()
+                addFavModal.open()
             } else {
-                currentWebView.url = webUrl
+                setAsCurrentWebUrl(webUrl)
             }
         }
         onRightClicked: {
-            favoriteMenu.url = url
-            favoriteMenu.x = bookmarkGrid.x + bookmarkBtn.x + mouse.x
-            favoriteMenu.y = Qt.binding(function () {return bookmarkGrid.y + mouse.y + favoriteMenu.height})
-            favoriteMenu.open()
+            favMenu.url = url
+            favMenu.x = bookmarkGrid.x + bookmarkBtn.x + mouse.x
+            favMenu.y = Qt.binding(function () {return bookmarkGrid.y + mouse.y + favMenu.height})
+            favMenu.open()
         }
     }
 }

--- a/ui/app/AppLayouts/Browser/panels/FindBar.qml
+++ b/ui/app/AppLayouts/Browser/panels/FindBar.qml
@@ -53,14 +53,11 @@ import QtQuick.Controls 2.13
 import QtGraphicalEffects 1.13
 import QtQuick.Layouts 1.0
 
+import StatusQ.Controls 0.1
+
 import shared.controls 1.0
 
-import shared 1.0
-import shared.panels 1.0
-
 import utils 1.0
-
-import StatusQ.Controls 0.1
 
 Rectangle {
     id: root

--- a/ui/app/AppLayouts/Browser/popups/AddFavoriteModal.qml
+++ b/ui/app/AppLayouts/Browser/popups/AddFavoriteModal.qml
@@ -1,17 +1,14 @@
 import QtQuick 2.13
-import QtQuick.Controls 2.13
-import QtQuick.Layouts 1.13
 import QtGraphicalEffects 1.13
-
-import utils 1.0
-import shared.controls 1.0
 
 import StatusQ.Core.Theme 0.1
 import StatusQ.Controls 0.1
 import StatusQ.Controls.Validators 0.1
 
-import shared 1.0
 import shared.popups 1.0
+
+import utils 1.0
+
 import "../stores"
 
 // TODO: replace with StatusModal

--- a/ui/app/AppLayouts/Browser/popups/BrowserConnectionModal.qml
+++ b/ui/app/AppLayouts/Browser/popups/BrowserConnectionModal.qml
@@ -3,7 +3,6 @@ import QtQuick.Controls 2.13
 import QtQuick.Layouts 1.13
 
 import utils 1.0
-import shared.controls 1.0
 import shared.panels 1.0
 
 import StatusQ.Controls 0.1
@@ -14,13 +13,13 @@ import "../controls"
 import "../stores"
 
 StatusModal {
+    id: browserConnectionModal
 
     property var currentTab
     property var request: ({"hostname": "", "title": "", "permission": ""})
     property string currentAddress: ""
     property bool interactedWith: false
-
-    id: browserConnectionModal
+    property var web3Response: function(){}
 
     width: 360
     height: 480
@@ -32,13 +31,13 @@ StatusModal {
     function postMessage(isAllowed){
         interactedWith = true
         request.isAllowed = isAllowed;
-        currentTabConnected = isAllowed
-        provider.web3Response(Web3ProviderStore.web3ProviderInst.postMessage(JSON.stringify(request)));
+        RootStore.currentTabConnected = isAllowed
+        web3Response(Web3ProviderStore.web3ProviderInst.postMessage(JSON.stringify(request)))
     }
 
     onClosed: {
         if(!interactedWith){
-            currentTabConnected = false
+            RootStore.currentTabConnected = false
             postMessage(false);
         }
     }

--- a/ui/app/AppLayouts/Browser/popups/BrowserSettingsMenu.qml
+++ b/ui/app/AppLayouts/Browser/popups/BrowserSettingsMenu.qml
@@ -1,18 +1,28 @@
 import QtQuick 2.13
 import QtQuick.Controls 2.3
 import QtWebEngine 1.9
-import utils 1.0
 
 import shared 1.0
 import shared.panels 1.0
 import shared.status 1.0
 import shared.popups 1.0
 
-import "../../Chat/popups"
+import utils 1.0
 
 // TODO: replace with StatusPopupMenu
 PopupMenu {
-    property var addNewTab: function () {}
+    id: browserSettingsMenu
+
+    property bool isIncognito: false
+
+    signal addNewTab()
+    signal goIncognito(bool checked)
+    signal zoomIn()
+    signal zoomOut()
+    signal changeZoomFactor()
+    signal launchFindBar()
+    signal toggleCompatibilityMode(bool checked)
+    signal launchBrowserSettings()
 
     closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutsideParent
 
@@ -20,9 +30,7 @@ PopupMenu {
         //% "New Tab"
         text: qsTrId("new-tab")
         shortcut: StandardKey.AddTab
-        onTriggered: {
-            addNewTab()
-        }
+        onTriggered: addNewTab()
     }
 
     Action {
@@ -34,12 +42,8 @@ PopupMenu {
                   //% "Go Incognito"
                   qsTrId("go-incognito")
         checkable: true
-        checked: currentWebView && currentWebView.profile === otrProfile
-        onToggled: function(checked) {
-            if (currentWebView) {
-                currentWebView.profile = checked ? otrProfile : defaultProfile;
-            }
-        }
+        checked: isIncognito
+        onToggled: goIncognito(checked)
     }
 
     Separator {}
@@ -49,23 +53,19 @@ PopupMenu {
         //% "Zoom In"
         text: qsTrId("zoom-in")
         shortcut: StandardKey.ZoomIn
-        onTriggered: {
-            const newZoom = currentWebView.zoomFactor + 0.1
-            currentWebView.changeZoomFactor(newZoom)
-        }
+        onTriggered: zoomIn()
     }
+
     Action {
         //% "Zoom Out"
         text: qsTrId("zoom-out")
         shortcut: StandardKey.ZoomOut
-        onTriggered: {
-            const newZoom = currentWebView.zoomFactor - 0.1
-            currentWebView.changeZoomFactor(newZoom)
-        }
+        onTriggered: zoomOut()
     }
+
     Action {
         shortcut: "Ctrl+0"
-        onTriggered: currentWebView.changeZoomFactor(1.0)
+        onTriggered: changeZoomFactor()
     }
 
     Separator {}
@@ -74,12 +74,7 @@ PopupMenu {
         //% "Find"
         text: qsTrId("find")
         shortcut: StandardKey.Find
-        onTriggered: {
-            if (!findBar.visible) {
-                findBar.visible = true;
-                findBar.forceActiveFocus()
-            }
-        }
+        onTriggered: launchFindBar()
     }
 
     Action {
@@ -87,18 +82,7 @@ PopupMenu {
         text: qsTrId("compatibility-mode")
         checkable: true
         checked: true
-        onToggled: {
-            for (let i = 0; i < tabs.count; ++i){
-                tabs.getTab(i).item.stop(); // Stop all loading tabs
-            }
-
-            localAccountSensitiveSettings.compatibilityMode = checked;
-
-            for (let i = 0; i < tabs.count; ++i){
-                tabs.getTab(i).item.reload(); // Reload them with new user agent
-            }
-                            
-        }
+        onToggled: toggleCompatibilityMode(checked)
     }
 
     Action {
@@ -116,11 +100,6 @@ PopupMenu {
         //% "Settings"
         text: qsTrId("settings")
         shortcut: "Ctrl+,"
-        onTriggered: {
-            Global.changeAppSectionBySectionType(Constants.appSection.profile)
-            // TODO: replace with shared store constant
-            // Profile/RootStore.browser_settings_id
-            profileLayoutContainer.changeProfileSection(10)
-        }
+        onTriggered: launchBrowserSettings()
     }
 }

--- a/ui/app/AppLayouts/Browser/popups/BrowserWalletMenu.qml
+++ b/ui/app/AppLayouts/Browser/popups/BrowserWalletMenu.qml
@@ -3,11 +3,12 @@ import QtQuick.Controls 2.13
 import QtQuick.Layouts 1.13
 import QtGraphicalEffects 1.13
 
-import utils 1.0
-import shared.controls 1.0
-import shared.panels 1.0
-
 import StatusQ.Controls 0.1
+import StatusQ.Core 0.1
+
+import shared.controls 1.0
+
+import utils 1.0
 
 import "../../Wallet/views"
 import "../stores"
@@ -15,6 +16,11 @@ import "../stores"
 // TODO: replace with StatusPopupMenu
 Popup {
     id: popup
+
+    signal sendTriggered(var selectedAccount)
+    signal disconnect()
+    signal reload()
+
     modal: false
 
     closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
@@ -26,7 +32,7 @@ Popup {
         color: Style.current.background
         radius: Style.current.radius
         layer.enabled: true
-        layer.effect: DropShadow{
+        layer.effect: DropShadow {
             width: bgPopup.width
             height: bgPopup.height
             x: bgPopup.x
@@ -62,7 +68,7 @@ Popup {
             anchors.verticalCenter: parent.verticalCenter
         }
 
-        StyledText {
+        StatusBaseText {
             id: networkText
             text: {
                 switch (RootStore.currentNetwork) {
@@ -80,7 +86,7 @@ Popup {
             anchors.leftMargin: Style.current.halfPadding
         }
 
-        StyledText {
+        StatusBaseText {
             id: disconectBtn
             //% "Disconnect"
             text: qsTrId("disconnect")
@@ -92,11 +98,7 @@ Popup {
             MouseArea {
                 cursorShape: Qt.PointingHandCursor
                 anchors.fill: parent
-                onClicked: {
-                    Web3ProviderStore.web3ProviderInst.disconnect();
-                    provider.postMessage(`{"type":"web3-disconnect-account"}`);
-                    popup.close();
-                }
+                onClicked: disconnect()
             }
         }
     }
@@ -131,10 +133,8 @@ Popup {
                 accountSelectorRow.currentAddress = selectedAccount.address
                 Web3ProviderStore.web3ProviderInst.dappsAddress = selectedAccount.address;
                 WalletStore.setDappBrowserAddress()
-                Web3ProviderStore.revokeAllPermissions();
-                for (let i = 0; i < tabs.count; ++i){
-                    tabs.getTab(i).item.reload();
-                }
+                Web3ProviderStore.revokeAllPermissions()
+                reload()
             }
         }
 
@@ -157,10 +157,7 @@ Popup {
             anchors.top: parent.top
             anchors.topMargin: Style.current.halfPadding
             icon.name: "send"
-            onClicked: {
-                sendModal.selectFromAccount.selectedAccount = accountSelector.selectedAccount
-                sendModal.open()
-            }
+            onClicked: sendTriggered(accountSelector.selectedAccount)
         }
     }
 

--- a/ui/app/AppLayouts/Browser/popups/DownloadMenu.qml
+++ b/ui/app/AppLayouts/Browser/popups/DownloadMenu.qml
@@ -1,12 +1,12 @@
 import QtQuick 2.13
 import QtQuick.Controls 2.3
 
-import shared 1.0
 import shared.panels 1.0
 import shared.popups 1.0
-import "../stores"
 
 import utils 1.0
+
+import "../stores"
 
 // TODO: replace with StatusPopupMenu
 PopupMenu {

--- a/ui/app/AppLayouts/Browser/popups/FavoriteMenu.qml
+++ b/ui/app/AppLayouts/Browser/popups/FavoriteMenu.qml
@@ -1,23 +1,23 @@
 import QtQuick 2.13
 import QtQuick.Controls 2.3
-import QtWebEngine 1.9
-import shared 1.0
+
 import shared.panels 1.0
-import shared.status 1.0
 import shared.popups 1.0
-import "../stores"
 
 import utils 1.0
 
-import "../../Chat/popups"
+import "../stores"
 
 // TODO: replace with StatusPopupMenu
 PopupMenu {
+    id: favoritePopupMenu
+
     property var openInNewTab: function () {}
     property string url
     property var currentFavorite: BookmarksStore.getCurrentFavorite(url)
 
-    id: root
+    signal editFavoriteTriggered()
+
     closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
 
     Action {
@@ -27,7 +27,7 @@ PopupMenu {
         icon.width: 16
         icon.height: 16
         onTriggered: {
-            openInNewTab(root.url)
+            openInNewTab(favoritePopupMenu.url)
         }
     }
 
@@ -39,12 +39,7 @@ PopupMenu {
         icon.source: Style.svg("edit")
         icon.width: 16
         icon.height: 16
-        onTriggered: {
-            addFavoriteModal.modifiyModal = true
-            addFavoriteModal.ogUrl = root.currentFavorite ? root.currentFavorite.url : currentWebView.url
-            addFavoriteModal.ogName = root.currentFavorite ? root.currentFavorite.name : currentWebView.title
-            addFavoriteModal.open()
-        }
+        onTriggered: editFavoriteTriggered()
     }
 
     Action {
@@ -55,7 +50,7 @@ PopupMenu {
         icon.width: 16
         icon.height: 16
         onTriggered: {
-            BookmarksStore.deleteBookmark(root.url)
+            BookmarksStore.deleteBookmark(favoritePopupMenu.url)
         }
     }
 }

--- a/ui/app/AppLayouts/Browser/popups/SignMessageModal.qml
+++ b/ui/app/AppLayouts/Browser/popups/SignMessageModal.qml
@@ -239,9 +239,4 @@ StatusModal {
     ]
 }
 
-/*##^##
-Designer {
-    D{i:0;autoSize:true;height:480;width:640}
-}
-##^##*/
 

--- a/ui/app/AppLayouts/Browser/stores/BookmarksStore.qml
+++ b/ui/app/AppLayouts/Browser/stores/BookmarksStore.qml
@@ -5,7 +5,6 @@ import QtQuick 2.13
 QtObject {
     id: root
 
-    // Seems like this vould be a BookMarks Store which has everything related to bookmarks
     property var bookmarksModel: bookmarkModule.model
 
     function addBookmark(url, name)
@@ -43,5 +42,4 @@ QtObject {
             image: bookmarkModule.model.rowData(index, 'imageUrl')
         }
     }
-    // END >> Seems like this vould be a BookMarks Store which has everything related to bookmarks
 }

--- a/ui/app/AppLayouts/Browser/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Browser/stores/RootStore.qml
@@ -2,12 +2,16 @@ pragma Singleton
 
 import QtQuick 2.13
 
+import utils 1.0
+
 QtObject {
     id: root
 
     property string activeChannelName: chatsModel.channelView.activeChannel.name
 
     property var currentNetwork: profileModel.network.current
+
+    property bool currentTabConnected: false
 
     function getUrlFromUserInput(input) {
         return utilsModel.urlFromUserInput(input)
@@ -27,5 +31,40 @@ QtObject {
 
     function generateIdenticon(pk) {
         return utilsModel.generateIdenticon(pk)
+    }
+
+    function get0xFormedUrl(browserExplorer, url) {
+        var tempUrl = ""
+        switch (browserExplorer) {
+        case Constants.browserEthereumExplorerEtherscan:
+            if (url.length > 42) {
+                tempUrl = "https://etherscan.io/tx/" + url; break;
+            } else {
+                tempUrl = "https://etherscan.io/address/" + url; break;
+            }
+        case Constants.browserEthereumExplorerEthplorer:
+            if (url.length > 42) {
+                tempUrl = "https://ethplorer.io/tx/" + url; break;
+            } else {
+                tempUrl = "https://ethplorer.io/address/" + url; break;
+            }
+        case Constants.browserEthereumExplorerBlockchair:
+            if (url.length > 42) {
+                tempUrl = "https://blockchair.com/ethereum/transaction/" + url; break;
+            } else {
+                tempUrl = "https://blockchair.com/ethereum/address/" + url; break;
+            }
+        }
+        return tempUrl
+    }
+
+    function getFormedUrl(shouldShowBrowserSearchEngine, url) {
+        var tempUrl = ""
+        switch (localAccountSensitiveSettings.shouldShowBrowserSearchEngine) {
+        case Constants.browserSearchEngineGoogle: tempUrl = "https://www.google.com/search?q=" + url; break;
+        case Constants.browserSearchEngineYahoo: tempUrl = "https://search.yahoo.com/search?p=" + url; break;
+        case Constants.browserSearchEngineDuckDuckGo: tempUrl = "https://duckduckgo.com/?q=" + url; break;
+        }
+        return tempUrl
     }
 }

--- a/ui/app/AppLayouts/Browser/views/BrowserShortcutActions.qml
+++ b/ui/app/AppLayouts/Browser/views/BrowserShortcutActions.qml
@@ -50,8 +50,18 @@
 
 import QtQuick 2.13
 import QtQuick.Controls 2.14
+import QtWebEngine 1.10
 
 Item {
+    id: shortcutActions
+
+    property var currentWebView
+    property var findBarComponent
+    property var browserHeaderComponent
+
+    signal addNewDownloadTab()
+    signal removeView()
+
     Action {
         shortcut: "Ctrl+D"
         onTriggered: {
@@ -61,8 +71,8 @@ Item {
     Action {
         shortcut: "Ctrl+L"
         onTriggered: {
-            browserHeader.addressBar.forceActiveFocus();
-            browserHeader.addressBar.selectAll();
+            browserHeaderComponent.addressBar.forceActiveFocus();
+            browserHeaderComponent.addressBar.selectAll();
         }
     }
     Action {
@@ -74,9 +84,7 @@ Item {
     }
     Action {
         shortcut: "Ctrl+W"
-        onTriggered: {
-            tabs.removeView(tabs.currentIndex)
-        }
+        onTriggered: removeView()
     }
     Action {
         shortcut: StandardKey.Close
@@ -87,8 +95,8 @@ Item {
     Action {
         shortcut: "Escape"
         onTriggered: {
-            if (findBar.visible)
-                findBar.visible = false;
+            if (findBarComponent.visible)
+                findBarComponent.visible = false;
         }
     }
     Action {
@@ -129,10 +137,10 @@ Item {
     }
     Action {
         shortcut: StandardKey.FindNext
-        onTriggered: findBar.findNext()
+        onTriggered: findBarComponent.findNext()
     }
     Action {
         shortcut: StandardKey.FindPrevious
-        onTriggered: findBar.findPrevious()
+        onTriggered: findBarComponent.findPrevious()
     }
 }

--- a/ui/app/AppMain.qml
+++ b/ui/app/AppMain.qml
@@ -439,6 +439,7 @@ Item {
                 id: browserLayoutComponent
                 BrowserLayout {
                     globalStore: appMain.rootStore
+                    sendTransactionModal: sendModal
                 }
             }
 
@@ -748,6 +749,7 @@ Item {
                 // this.sourceComponent = undefined // kill an opened instance
                 this.active = false
             }
+            property var selectedAccount
             sourceComponent: SendModal {
                 store: appMain.rootStore
                 onOpened: {
@@ -755,6 +757,11 @@ Item {
                 }
                 onClosed: {
                     sendModal.closed()
+                }
+            }
+            onLoaded: {
+                if(!!sendModal.selectedAccount) {
+                    item.selectFromAccount.selectedAccount = sendModal.selectedAccount
                 }
             }
         }

--- a/ui/imports/shared/popups/SendModal.qml
+++ b/ui/imports/shared/popups/SendModal.qml
@@ -107,7 +107,7 @@ ModalPopup {
             RecipientSelector {
                 id: selectRecipient
                 accounts: root.store.accounts
-                contacts: popup.store.addedContacts
+                contacts: root.store.addedContacts
                 //% "Recipient"
                 label: qsTrId("recipient")
                 anchors.top: separator.bottom


### PR DESCRIPTION
refactor: remove dynamic scoping from browser module

closes #4246

### What does the PR do

This PR aims at removing the dynamic scoping within the browser module. Whats done is -
1. Pass component from layout to the child components instead of them accessing it directly via dynamic scoping
2. Add and internal compose tin BrowserLayout so that accessing it from other components is not straightforward to discourage it in the future.
3. Move some logic to the store
4. Removed unnecessary import statements an cleaned up some code

### Affected areas

Browser

### Screenshot of functionality

https://user-images.githubusercontent.com/60327365/145122811-9d228ffe-5c32-4002-a2b1-ee9f9f34bda1.mov



