### PR TITLE
fix(notifications): fix notification setup called too soon

### DIFF
--- a/src/app_service/main.nim
+++ b/src/app_service/main.nim
@@ -50,3 +50,4 @@ proc delete*(self: AppService) =
 
 proc onLoggedIn*(self: AppService) =
   self.marathon.onLoggedIn()
+  self.osNotificationService.onLoggedIn()

--- a/src/app_service/service/os_notification/service.nim
+++ b/src/app_service/service/os_notification/service.nim
@@ -11,16 +11,15 @@ QtObject:
   type OsNotificationService* = ref object of QObject
     status: Status
     notification: StatusOSNotification
+    notificationSetUp: bool
 
   proc setup(self: OsNotificationService, status: Status) = 
     self.QObject.setup
     self.status = status
-    self.notification = newStatusOSNotification()
-    signalConnect(self.notification, "notificationClicked(QString)", self,
-    "onNotificationClicked(QString)", 2)
   
   proc delete*(self: OsNotificationService) =
-    self.notification.delete
+    if self.notificationSetUp:
+      self.notification.delete
     self.QObject.delete
 
   proc newOsNotificationService*(status: Status): OsNotificationService =
@@ -46,3 +45,8 @@ QtObject:
     ## This slot is called once user clicks a notificaiton bubble, "identifier"
     ## contains data which uniquely define that notification.
     self.status.osnotifications.onNotificationClicked(identifier)
+
+  proc onLoggedIn*(self: OsNotificationService) =
+    self.notification = newStatusOSNotification()
+    self.notificationSetUp = true
+    signalConnect(self.notification, "notificationClicked(QString)", self, "onNotificationClicked(QString)", 2)


### PR DESCRIPTION
This fixes part of the problems with notifications and tray icon on Windows, but there is still a bit more to do, but I have to move to the refactor for now.