### PR TITLE
fix(@desktop/chat): Messages do have wrong indentation (alignment) when being sent in a row

### DIFF
--- a/ui/imports/shared/views/chat/CompactMessageView.qml
+++ b/ui/imports/shared/views/chat/CompactMessageView.qml
@@ -427,8 +427,9 @@ Item {
             anchors.top: chatName.visible ? chatName.bottom :
                                             chatReply.active ? chatReply.bottom :
                                                 pinnedRectangleLoader.active ? pinnedRectangleLoader.bottom : parent.top
-            anchors.left: chatImage.right
-            anchors.leftMargin: root.chatHorizontalPadding
+            // This entire component needs to be reworked and moved to StatusQ, hence providing a hardcoded fix for #4211.
+            anchors.left: parent.left
+            anchors.leftMargin: chatImage.imageWidth + Style.current.padding + root.chatHorizontalPadding
             anchors.right: parent.right
             anchors.rightMargin: root.chatHorizontalPadding
             visible: !isEdit


### PR DESCRIPTION
fix(@desktop/chat): Messages do have wrong indentation (alignment) when being sent in a row

Providing temp fix as this component  will be redesigned and moved to StatusQ

fixes #4211

### What does the PR do

Fixed the alignment issues when chatting in communities

### Affected areas

Communities and Chat View

### Screenshot of functionality
<img width="1141" alt="image" src="https://user-images.githubusercontent.com/60327365/145570122-49b1a47e-4ea5-4382-b95d-63415a0c5f6e.png">


