### PR TITLE
fix(@desktop/browser): Clicking on add buttons adds the same button twice

### DIFF
--- a/ui/app/AppLayouts/Browser/BrowserLayout.qml
+++ b/ui/app/AppLayouts/Browser/BrowserLayout.qml
@@ -238,13 +238,13 @@ Rectangle {
         onReload: _internal.currentWebView.reload()
         onStopLoading: _internal.currentWebView.stop()
         onAddNewFavoritelClicked: {
-            addFavoriteModal.modifiyModal = browserHeader.currentFavorite
-            addFavoriteModal.toolbarMode = true
-            addFavoriteModal.x = xPos - 30
-            addFavoriteModal.y = browserHeader.y + browserHeader.height + 4
-            addFavoriteModal.ogUrl = browserHeader.currentFavorite ? browserHeader.currentFavorite.url : _internal.currentWebView.url
-            addFavoriteModal.ogName = browserHeader.currentFavorite ? browserHeader.currentFavorite.name : _internal.currentWebView.title
-            addFavoriteModal.open()
+            Global.openPopup(addFavoriteModal, {
+                                 x = xPos - 30,
+                                 y = browserHeader.y + browserHeader.height + 4,
+                                 modifiyModal: browserHeader.currentFavorite,
+                                 toolbarMode: true,
+                                 ogUrl: browserHeader.currentFavorite ? browserHeader.currentFavorite.url : _internal.currentWebView.url,
+                                 ogName: browserHeader.currentFavorite ? browserHeader.currentFavorite.name : _internal.currentWebView.title})
         }
         onLaunchInBrowser: {
             // TODO: disable browsing local files?  file://
@@ -315,8 +315,9 @@ Rectangle {
         z: 100
     }
 
-    AddFavoriteModal {
+    Component {
         id: addFavoriteModal
+        AddFavoriteModal {}
     }
 
     FavoriteMenu {
@@ -324,11 +325,11 @@ Rectangle {
         openInNewTab: function (url) {
             browserWindow.openUrlInNewTab(url)
         }
-        onEditFavoriteTriggered:         {
-            addFavoriteModal.modifiyModal = true
-            addFavoriteModal.ogUrl = favoriteMenu.currentFavorite ? favoriteMenu.currentFavorite.url : _internal.currentWebView.url
-            addFavoriteModal.ogName = favoriteMenu.currentFavorite ? favoriteMenu.currentFavorite.name : _internal.currentWebView.title
-            addFavoriteModal.open()
+        onEditFavoriteTriggered: {
+            Global.openPopup(addFavoriteModal, {
+                                 modifiyModal: true,
+                                 ogUrl: favoriteMenu.currentFavorite ? favoriteMenu.currentFavorite.url : _internal.currentWebView.url,
+                                 ogName: favoriteMenu.currentFavorite ? favoriteMenu.currentFavorite.name : _internal.currentWebView.title})
         }
     }
 
@@ -525,10 +526,9 @@ Rectangle {
                 _internal.currentWebView.url = _internal.determineRealURL(url)
             }
             addFavModal: function() {
-                addFavoriteModal.toolbarMode = true
-                addFavoriteModal.ogUrl = browserHeader.currentFavorite ? browserHeader.currentFavorite.url : _internal.currentWebView.url
-                addFavoriteModal.ogName = browserHeader.currentFavorite ? browserHeader.currentFavorite.name : _internal.currentWebView.title
-                addFavoriteModal.open()
+                Global.openPopup(addFavoriteModal, {toolbarMode: true,
+                                     ogUrl: browserHeader.currentFavorite ? browserHeader.currentFavorite.url : _internal.currentWebView.url,
+                                     ogName: browserHeader.currentFavorite ? browserHeader.currentFavorite.name : _internal.currentWebView.title})
             }
         }
     }

--- a/ui/app/AppLayouts/Browser/panels/FavoritesList.qml
+++ b/ui/app/AppLayouts/Browser/panels/FavoritesList.qml
@@ -22,7 +22,7 @@ GridView {
         webUrl: determineRealURLFn(url)
         onClicked: {
             if (!webUrl.toString()) {
-                addFavModal.open()
+                Global.openPopup(addFavModal)
             } else {
                 setAsCurrentWebUrl(webUrl)
             }

--- a/ui/app/AppLayouts/Browser/popups/AddFavoriteModal.qml
+++ b/ui/app/AppLayouts/Browser/popups/AddFavoriteModal.qml
@@ -13,8 +13,8 @@ import "../stores"
 
 // TODO: replace with StatusModal
 ModalPopup {
-    property string ogUrl
-    property string ogName
+    property string ogUrl: ""
+    property string ogName: ""
     property bool modifiyModal: false
     property bool toolbarMode: false
 
@@ -152,7 +152,7 @@ ModalPopup {
                       //% "Add"
                       qsTrId("add")
             anchors.bottom: parent.bottom
-            enabled: nameInput.valid && urlInput.valid
+            enabled: nameInput.valid && !!nameInput.text && urlInput.valid && !!urlInput.text
             onClicked: {
                 if (!popup.modifiyModal) {
                     // remove "add favorite" button at the end, add new bookmark, add "add favorite" button back


### PR DESCRIPTION
fix(@desktop/browser): Clicking on add buttons adds the same button twice

fixes #4280

### What does the PR do

This fix ensures that the string are validated so that the "Add" button is not activated when nothing in entered by user

### Affected areas

Browser

### Screenshot of functionality
<img width="953" alt="image" src="https://user-images.githubusercontent.com/60327365/146053954-ddf7ff7f-3409-49b0-9652-c9679ded950a.png">



