### PR TITLE
refactor(@desktop/chat-messages): pin/unpin messages and pinned messages list updated

### DIFF
--- a/src/app/modules/main/chat_section/chat_content/messages/controller.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/controller.nim
@@ -95,3 +95,6 @@ method getContactById*(self: Controller, contactId: string): ContactsDto =
 method getContactNameAndImage*(self: Controller, contactId: string): 
   tuple[name: string, image: string, isIdenticon: bool] =
   return self.contactService.getContactNameAndImage(contactId)
+
+method getNumOfPinnedMessages*(self: Controller): int =
+  return self.messageService.getNumOfPinnedMessages(self.chatId)

--- a/src/app/modules/main/chat_section/chat_content/messages/controller_interface.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/controller_interface.nim
@@ -39,3 +39,6 @@ method getContactById*(self: AccessInterface, contactId: string): ContactsDto {.
 method getContactNameAndImage*(self: AccessInterface, contactId: string): 
   tuple[name: string, image: string, isIdenticon: bool] {.base.} =
   raise newException(ValueError, "No implementation available")
+
+method getNumOfPinnedMessages*(self: AccessInterface): int {.base.} =
+  raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/chat_section/chat_content/messages/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/module.nim
@@ -71,8 +71,6 @@ proc createChatIdentifierItem(self: Module): Item =
 
   result = initItem(CHAT_IDENTIFIER_MESSAGE_ID, "", chatDto.id, chatName, "", chatIcon, isIdenticon, false, "", "", "", 
   true, 0, ContentType.ChatIdentifier, -1)
-  result.chatColorThisMessageBelongsTo = chatDto.color
-  result.chatTypeThisMessageBelongsTo = chatDto.chatType.int
 
 method newMessagesLoaded*(self: Module, messages: seq[MessageDto], reactions: seq[ReactionDto], 
   pinnedMessages: seq[PinnedMessageDto]) = 
@@ -137,3 +135,17 @@ method pinUnpinMessage*(self: Module, messageId: string, pin: bool) =
 
 method onPinUnpinMessage*(self: Module, messageId: string, pin: bool) =
   self.view.model().pinUnpinMessage(messageId, pin)
+
+method getChatType*(self: Module): int =
+  let chatDto = self.controller.getChatDetails()
+  return chatDto.chatType.int
+
+method getChatColor*(self: Module): string =
+  let chatDto = self.controller.getChatDetails()
+  return chatDto.color
+
+method amIChatAdmin*(self: Module): bool =
+  return false
+
+method getNumberOfPinnedMessages*(self: Module): int =
+  return self.controller.getNumOfPinnedMessages()

--- a/src/app/modules/main/chat_section/chat_content/messages/private_interfaces/module_view_delegate_interface.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/private_interfaces/module_view_delegate_interface.nim
@@ -10,3 +10,15 @@ method pinUnpinMessage*(self: AccessInterface, messageId: string, pin: bool) {.b
 method getNamesReactedWithEmojiIdForMessageId*(self: AccessInterface, messageId: string, emojiId: int): seq[string] 
   {.base.} =
   raise newException(ValueError, "No implementation available")
+
+method getChatType*(self: AccessInterface): int {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method getChatColor*(self: AccessInterface): string {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method amIChatAdmin*(self: AccessInterface): bool {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method getNumberOfPinnedMessages*(self: AccessInterface): int {.base.} =
+  raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/chat_section/chat_content/messages/view.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/view.nim
@@ -56,3 +56,15 @@ QtObject:
     if(jsonObj.isNil):
       return ""
     return $jsonObj
+
+  proc getChatType*(self: View): int {.slot.} = 
+    return self.delegate.getChatType()
+
+  proc getChatColor*(self: View): string {.slot.} = 
+    return self.delegate.getChatColor()
+
+  proc amIChatAdmin*(self: View): bool {.slot.} = 
+    return self.delegate.amIChatAdmin()
+
+  proc getNumberOfPinnedMessages*(self: View): int {.slot.} = 
+    return self.delegate.getNumberOfPinnedMessages()

--- a/src/app/modules/main/chat_section/chat_content/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/module.nim
@@ -130,7 +130,7 @@ proc buildPinnedMessageItem(self: Module, messageId: string, item: var pinned_ms
 
   let contactDetails = self.controller.getContactDetails(m.`from`)
     
-  var item = initItem(
+  item = pinned_msg_item.initItem(
     m.id,
     m.responseTo,
     m.`from`,
@@ -157,7 +157,7 @@ proc buildPinnedMessageItem(self: Module, messageId: string, item: var pinned_ms
   return true
 
 method newPinnedMessagesLoaded*(self: Module, pinnedMessages: seq[PinnedMessageDto]) = 
-  var viewItems: seq[Item] 
+  var viewItems: seq[pinned_msg_item.Item] 
   for p in pinnedMessages:
     var item: pinned_msg_item.Item
     if(not self.buildPinnedMessageItem(p.message.id, item)):

--- a/src/app/modules/shared_models/message_item.nim
+++ b/src/app/modules/shared_models/message_item.nim
@@ -41,9 +41,6 @@ type
     reactions: OrderedTable[int, seq[tuple[publicKey: string, reactionId: string]]] # [emojiId, list of [user publicKey reacted with the emojiId, reaction id]]
     reactionIds: seq[string]
     pinned: bool
-    # used in case of ContentType.ChatIdentifier only
-    chatTypeThisMessageBelongsTo: int
-    chatColorThisMessageBelongsTo: string
 
 proc initItem*(id, responseToMessageWithId, senderId, senderDisplayName, senderLocalName, senderIcon: string, 
   isSenderIconIdenticon, amISender: bool, outgoingStatus, text, image: string, seen: bool, timestamp: int64, 
@@ -82,8 +79,6 @@ proc `$`*(self: Item): string =
     timestamp:{$self.timestamp},
     contentType:{$self.contentType.int},
     messageType:{$self.messageType},
-    chatTypeThisMessageBelongsTo:{self.chatTypeThisMessageBelongsTo},
-    chatColorThisMessageBelongsTo:{self.chatColorThisMessageBelongsTo},
     pinned:{$self.pinned}
     )"""
 
@@ -143,19 +138,6 @@ proc pinned*(self: Item): bool {.inline.} =
 
 proc `pinned=`*(self: Item, value: bool) {.inline.} = 
   self.pinned = value
-
-proc chatTypeThisMessageBelongsTo*(self: Item): int {.inline.} = 
-  self.chatTypeThisMessageBelongsTo
-
-proc `chatTypeThisMessageBelongsTo=`*(self: Item, value: int) {.inline.} = 
-  self.chatTypeThisMessageBelongsTo = value
-
-proc chatColorThisMessageBelongsTo*(self: Item): string {.inline.} = 
-  self.chatColorThisMessageBelongsTo
-
-proc `chatColorThisMessageBelongsTo=`*(self: Item, value: string) {.inline.} = 
-  self.chatColorThisMessageBelongsTo = value
-
 
 proc shouldAddReaction*(self: Item, emojiId: int, publicKey: string): bool = 
   for k, values in self.reactions:

--- a/src/app/modules/shared_models/message_model.nim
+++ b/src/app/modules/shared_models/message_model.nim
@@ -25,8 +25,6 @@ type
     # GapTo
     Pinned
     CountsForReactions
-    ChatTypeThisMessageBelongsTo
-    ChatColorThisMessageBelongsTo
 
 QtObject:
   type
@@ -83,8 +81,6 @@ QtObject:
       # ModelRole.GapTo.int:"gapTo",
       ModelRole.Pinned.int:"pinned",
       ModelRole.CountsForReactions.int:"countsForReactions",
-      ModelRole.ChatTypeThisMessageBelongsTo.int:"chatTypeThisMessageBelongsTo",
-      ModelRole.ChatColorThisMessageBelongsTo.int:"chatColorThisMessageBelongsTo",
     }.toTable
 
   method data(self: Model, index: QModelIndex, role: int): QVariant =
@@ -140,10 +136,6 @@ QtObject:
       result = newQVariant(item.pinned)
     of ModelRole.CountsForReactions: 
       result = newQVariant($(%* item.getCountsForReactions))
-    of ModelRole.ChatTypeThisMessageBelongsTo: 
-      result = newQVariant(item.chatTypeThisMessageBelongsTo)
-    of ModelRole.ChatColorThisMessageBelongsTo: 
-      result = newQVariant(item.chatColorThisMessageBelongsTo)
 
   proc findIndexForMessageId(self: Model, messageId: string): int = 
     for i in 0 ..< self.items.len:

--- a/src/app/modules/shared_models/message_model.nim
+++ b/src/app/modules/shared_models/message_model.nim
@@ -145,6 +145,9 @@ QtObject:
     return -1
 
   proc prependItems*(self: Model, items: seq[Item]) =
+    if(items.len == 0):
+      return
+      
     let parentModelIndex = newQModelIndex()
     defer: parentModelIndex.delete
 

--- a/ui/app/AppLayouts/Chat/ChatLayout.qml
+++ b/ui/app/AppLayouts/Chat/ChatLayout.qml
@@ -97,12 +97,8 @@ StatusAppThreePanelLayout {
         CommunityUserListPanel {
             messageContextMenu: quickActionMessageOptionsMenu
             usersModule: {
-                if(chatCommunitySectionModule.activeItem.isSubItemActive)
-                    chatCommunitySectionModule.prepareChatContentModuleForChatId(chatCommunitySectionModule.activeItem.activeSubItem.id)
-                else
-                    chatCommunitySectionModule.prepareChatContentModuleForChatId(chatCommunitySectionModule.activeItem.id)
-
-                return chatCommunitySectionModule.getChatContentModule().usersModule
+                let chatContentModule = currentChatContentModule()
+                return chatContentModule.usersModule
             }
         }
     }
@@ -112,8 +108,8 @@ StatusAppThreePanelLayout {
         UserListPanel {
             messageContextMenu: quickActionMessageOptionsMenu
             usersModule: {
-                chatCommunitySectionModule.prepareChatContentModuleForChatId(chatCommunitySectionModule.activeItem.id)
-                return chatCommunitySectionModule.getChatContentModule().usersModule
+                let chatContentModule = currentChatContentModule()
+                return chatContentModule.usersModule
             }
         }
     }
@@ -178,15 +174,13 @@ StatusAppThreePanelLayout {
 
     MessageContextMenuView {
         id: quickActionMessageOptionsMenu
-        chatSectionModule: root.chatCommunitySectionModule
-        // Not Refactored
-       store: root.rootStore
-//        reactionModel: root.rootStore.emojiReactionsModel
+
+        onOpenProfileClicked: {
+            openProfilePopup(displayName, publicKey, icon, "", displayName)
+        }
+        onCreateOneToOneChat: {
+            Global.changeAppSectionBySectionType(Constants.appSection.chat)
+            root.chatCommunitySectionModule.createOneToOneChat(chatId, ensName)
+        }
     }
 }
-
-/*##^##
-Designer {
-    D{i:0;formeditorColor:"#ffffff";formeditorZoom:1.25;height:770;width:1152}
-}
-##^##*/

--- a/ui/app/AppLayouts/Chat/controls/UserDelegate.qml
+++ b/ui/app/AppLayouts/Chat/controls/UserDelegate.qml
@@ -17,11 +17,12 @@ Item {
 
     property string publicKey: ""
     property string name: ""
-    property string identicon: ""
+    property string icon: ""
     property bool isIdenticon: true
     property int userStatus: Constants.userStatus.offline
     property var messageContextMenu
     property bool enableMouseArea: true
+    property bool hovered: false
     property color color: {
         if (wrapper.hovered) {
             return Style.current.menuBackgroundHover
@@ -44,7 +45,7 @@ Item {
             image: StatusImageSettings {
                 width: 28
                 height: 28
-                source: wrapper.identicon
+                source: wrapper.icon
                 isIdenticon: wrapper.isIdenticon
             }
             icon: StatusIconSettings {
@@ -106,15 +107,21 @@ Item {
             onClicked: {
                 if (mouse.button === Qt.LeftButton) {
                     //TODO remove dynamic scoping
-                    openProfilePopup(wrapper.name, wrapper.publicKey, wrapper.identicon, "", wrapper.name);
+                    openProfilePopup(wrapper.name, wrapper.publicKey, wrapper.icon, "", wrapper.name);
                 }
                  else if (mouse.button === Qt.RightButton && !!messageContextMenu) {
                     // Set parent, X & Y positions for the messageContextMenu
                     messageContextMenu.parent = rectangle
                     messageContextMenu.setXPosition = function() { return 0}
                     messageContextMenu.setYPosition = function() { return rectangle.height}
-                    messageContextMenu.isProfile = true;
-                    messageContextMenu.show(wrapper.name, wrapper.publicKey, wrapper.identicon, "", wrapper.name)
+
+                    messageContextMenu.isProfile = true
+                    messageContextMenu.myPublicKey = userProfile.pubKey
+                    messageContextMenu.selectedUserPublicKey = wrapper.publicKey
+                    messageContextMenu.selectedUserDisplayName = wrapper.name
+                    messageContextMenu.selectedUserIcon = wrapper.icon
+                    messageContextMenu.isSelectedUserIconIdenticon = wrapper.isIdenticon
+                    messageContextMenu.popup()
                 }
             }
         }

--- a/ui/app/AppLayouts/Chat/panels/UserListPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/UserListPanel.qml
@@ -50,7 +50,7 @@ Item {
         delegate: UserDelegate {
             publicKey: model.id
             name: model.name
-            identicon: model.icon
+            icon: model.icon
             isIdenticon: model.isIdenticon
             userStatus: model.onlineStatus
             messageContextMenu: root.messageContextMenu

--- a/ui/app/AppLayouts/Chat/panels/communities/CommunityUserListPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/CommunityUserListPanel.qml
@@ -55,7 +55,7 @@ Item {
         delegate: UserDelegate {
             publicKey: model.id
             name: model.name
-            identicon: model.icon
+            icon: model.icon
             isIdenticon: model.isIdenticon
             userStatus: model.onlineStatus
             messageContextMenu: root.messageContextMenu

--- a/ui/app/AppLayouts/Chat/popups/PinnedMessagesPopup.qml
+++ b/ui/app/AppLayouts/Chat/popups/PinnedMessagesPopup.qml
@@ -215,9 +215,9 @@ ModalPopup {
             id: msgContextMenu
             pinnedPopup: true
             pinnedMessage: true
-            chatSectionModule: popup.chatSectionModule
-            store: popup.rootStore
-            reactionModel: popup.rootStore.emojiReactionsModel
+//            chatSectionModule: popup.chatSectionModule
+//            store: popup.rootStore
+//            reactionModel: popup.rootStore.emojiReactionsModel
             onShouldCloseParentPopup: {
                 popup.close()
             }

--- a/ui/app/AppLayouts/Chat/stores/MessageStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/MessageStore.qml
@@ -1,4 +1,5 @@
 import QtQuick 2.13
+import utils 1.0
 
 QtObject {
     id: root
@@ -31,5 +32,47 @@ QtObject {
         }
 
         return obj
+    }
+
+    function getChatType () {
+        if(!messageModule)
+            return Constants.chatType.unknown
+
+        return messageModule.getChatType()
+    }
+
+    function getChatColor () {
+        if(!messageModule)
+            return Style.current.blue
+
+        return messageModule.getChatColor()
+    }
+
+    function amIChatAdmin () {
+        if(!messageModule)
+            return false
+
+        return messageModule.amIChatAdmin()
+    }
+
+    function getNumberOfPinnedMessages () {
+        if(!messageModule)
+            return 0
+
+        return messageModule.getNumberOfPinnedMessages()
+    }
+
+    function pinMessage (messageId) {
+        if(!messageModule)
+            return
+
+        return messageModule.pinMessage(messageId)
+    }
+
+    function unpinMessage (messageId) {
+        if(!messageModule)
+            return
+
+        return messageModule.unpinMessage(messageId)
     }
 }

--- a/ui/app/AppLayouts/Chat/stores/MessageStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/MessageStore.qml
@@ -13,6 +13,7 @@ QtObject {
         let jsonObj = messageModule.getMessageByIdAsJson(id)
         let obj = JSON.parse(jsonObj)
         if (obj.error) {
+            // This log is available only in debug mode, if it's annoying we can remove it
             console.debug("error parsing message for index: ", id, " error: ", obj.error)
             return false
         }
@@ -27,6 +28,7 @@ QtObject {
         let jsonObj = messageModule.getMessageByIndexAsJson(index)
         let obj = JSON.parse(jsonObj)
         if (obj.error) {
+            // This log is available only in debug mode, if it's annoying we can remove it
             console.debug("error parsing message for index: ", index, " error: ", obj.error)
             return false
         }

--- a/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
@@ -122,28 +122,6 @@ Item {
         }
     }
 
-    MessageContextMenuView {
-        id: contextmenu
-        chatSectionModule: root.parentModule
-        store: root.rootStore
-        reactionModel: root.rootStore.emojiReactionsModel
-    }
-
-    StatusImageModal {
-        id: imagePopup
-        onClicked: {
-            if (button === Qt.LeftButton) {
-                imagePopup.close()
-            }
-            else if(button === Qt.RightButton) {
-                contextmenu.imageSource = imagePopup.imageSource
-                contextmenu.hideEmojiPicker = true
-                contextmenu.isRightClickOnImage = true;
-                contextmenu.show()
-            }
-        }
-    }
-
     StackLayout {
         anchors.fill: parent
         currentIndex: {

--- a/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
@@ -333,9 +333,6 @@ Item {
             id: pinnedMessagesPopupComponent
             PinnedMessagesPopup {
                 id: pinnedMessagesPopup
-                chatSectionModule: root.parentModule
-                rootStore: root.rootStore
-                messageStore: root.rootStore.messageStore
                 onClosed: destroy()
             }
         }

--- a/ui/app/AppLayouts/Chat/views/ChatContentView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatContentView.qml
@@ -67,7 +67,13 @@ ColumnLayout {
         chatInfoButton.pinnedMessagesCount: chatContentModule.pinnedMessagesModel.count
         chatInfoButton.muted: chatContentModule.chatDetails.muted
 
-        chatInfoButton.onPinnedMessagesCountClicked: openPopup(pinnedMessagesPopupComponent)
+        chatInfoButton.onPinnedMessagesCountClicked: {
+            Global.openPopup(pinnedMessagesPopupComponent, {
+                          messageStore: messageStore,
+                          pinnedMessagesModel: chatContentModule.pinnedMessagesModel,
+                          messageToPin: ""
+                      })
+        }
         chatInfoButton.onUnmute: chatContentModule.unmuteChat()
 
         chatInfoButton.sensor.enabled: chatContentModule.chatDetails.type !== Constants.chatType.publicChat &&
@@ -192,6 +198,14 @@ ColumnLayout {
 
         onUnpinMessage: {
             messageStore.unpinMessage(messageId)
+        }
+
+        onPinnedMessagesLimitReached: {
+            Global.openPopup(pinnedMessagesPopupComponent, {
+                          messageStore: messageStore,
+                          pinnedMessagesModel: chatContentModule.pinnedMessagesModel,
+                          messageToPin: messageId
+                      })
         }
     }
 

--- a/ui/app/AppLayouts/Chat/views/ChatContentView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatContentView.qml
@@ -178,6 +178,38 @@ ColumnLayout {
         }
     }
 
+    MessageStore{
+        id: messageStore
+        messageModule: chatContentModule.messagesModule
+    }
+
+    MessageContextMenuView {
+        id: contextmenu
+        reactionModel: root.rootStore.emojiReactionsModel
+        onPinMessage: {
+            messageStore.pinMessage(messageId)
+        }
+
+        onUnpinMessage: {
+            messageStore.unpinMessage(messageId)
+        }
+    }
+
+    StatusImageModal {
+        id: imagePopup
+        onClicked: {
+            if (button === Qt.LeftButton) {
+                imagePopup.close()
+            }
+            else if(button === Qt.RightButton) {
+                contextmenu.imageSource = imagePopup.imageSource
+                contextmenu.hideEmojiPicker = true
+                contextmenu.isRightClickOnImage = true;
+                contextmenu.popup()
+            }
+        }
+    }
+
     ColumnLayout {
         Layout.fillWidth: true
         Layout.fillHeight: true
@@ -189,9 +221,7 @@ ColumnLayout {
             Layout.fillHeight: true
             store: root.rootStore
             messageContextMenuInst: contextmenu
-            messageStore: MessageStore{
-                messageModule: chatContentModule.messagesModule
-            }
+            messageStore: messageStore
         }
 
         Item {

--- a/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
@@ -296,6 +296,7 @@ Item {
             id: msgDelegate
 
             messageStore: root.messageStore
+            messageContextMenu: messageContextMenuInst
 
             messageId: model.id
             responseToMessageWithId: model.responseToMessageWithId
@@ -311,10 +312,6 @@ Item {
             messageOutgoingStatus: model.outgoingStatus
             messageContentType: model.contentType
             pinnedMessage: model.pinned
-
-            // Used only in case of ChatIdentifier
-            chatTypeThisMessageBelongsTo: model.chatTypeThisMessageBelongsTo
-            chatColorThisMessageBelongsTo: model.chatColorThisMessageBelongsTo
 
             // This is possible since we have all data loaded before we load qml.
             // When we fetch messages to fulfill a gap we have to set them at once.

--- a/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
@@ -319,9 +319,6 @@ Item {
             prevMessageAsJsonObj: messageStore.getMessageByIndexAsJson(index - 1)
             nextMessageIndex: index + 1
             nextMessageAsJsonObj: messageStore.getMessageByIndexAsJson(index + 1)
-
-            Component.onCompleted: {
-            }
         }
     }
 

--- a/ui/app/AppLayouts/Timeline/TimelineLayout.qml
+++ b/ui/app/AppLayouts/Timeline/TimelineLayout.qml
@@ -220,12 +220,12 @@ ScrollView {
 //                    messageStore.timeout = model.timeout;
 //                    messageStore.messageContextMenu = msgCntxtMenu;
 //                }
-                MessageContextMenuView {
-                    id: msgCntxtMenu
-                    store: root.store
-                    chatSectionModule: root.chatSectionModule
-                    reactionModel: EmojiReactions { }
-                }
+//                MessageContextMenuView {
+//                    id: msgCntxtMenu
+//                    store: root.store
+//                    chatSectionModule: root.chatSectionModule
+//                    reactionModel: EmojiReactions { }
+//                }
             }
         }
 

--- a/ui/imports/shared/controls/chat/MessageMouseArea.qml
+++ b/ui/imports/shared/controls/chat/MessageMouseArea.qml
@@ -4,6 +4,7 @@ import utils 1.0
 import shared 1.0
 
 MouseArea {
+    id: mouseArea
     z: 50
     enabled: !placeholderMessage
 
@@ -23,16 +24,17 @@ MouseArea {
 
     onClicked: {
         if (isActivityCenterMessage) {
-            return clickMessage(false, isSticker, false)
+            mouseArea.clickMessage(false, isSticker, false)
+            return
         }
         if (mouse.button === Qt.RightButton) {
-            if (!!messageContextMenu) {
+            if (!!mouseArea.messageContextMenu) {
                 // Set parent, X & Y positions for the messageContextMenu
                 messageContextMenu.parent = root
                 messageContextMenu.setXPosition = function() { return (mouse.x)};
                 messageContextMenu.setYPosition = function() { return (mouse.y)};
             }
-            clickMessage(false, isSticker, false)
+            mouseArea.clickMessage(false, isSticker, false)
             if (typeof isMessageActive !== "undefined") {
                 setMessageActive(messageId, true)
             }

--- a/ui/imports/shared/panels/chat/ChatButtonsPanel.qml
+++ b/ui/imports/shared/panels/chat/ChatButtonsPanel.qml
@@ -77,7 +77,7 @@ Rectangle {
                 buttonsContainer.messageContextMenu.parent = buttonsContainer
                 buttonsContainer.messageContextMenu.setXPosition = function() { return (-Math.abs(buttonsContainer.width - buttonsContainer.messageContextMenu.emojiContainer.width))}
                 buttonsContainer.messageContextMenu.setYPosition = function() { return (-buttonsContainer.messageContextMenu.height - 4)}
-                clickMessage(false, false, false, null, true, false)
+                buttonsContainer.clickMessage(false, false, false, null, true, false)
             }
             onHoveredChanged: buttonsContainer.hoverChanged(this.hovered)
         }
@@ -120,7 +120,7 @@ Rectangle {
             id: otherBtn
             width: 32
             height: 32
-            visible: showMoreButton
+            visible: buttonsContainer.showMoreButton
             icon.name: "more"
             type: StatusFlatRoundButton.Type.Tertiary
             //% "More"
@@ -133,7 +133,7 @@ Rectangle {
                 buttonsContainer.messageContextMenu.parent = buttonsContainer
                 buttonsContainer.messageContextMenu.setXPosition = function() { return (-Math.abs(buttonsContainer.width - 176))}
                 buttonsContainer.messageContextMenu.setYPosition = function() { return (-buttonsContainer.messageContextMenu.height - 4)}
-                clickMessage(false, isSticker, false, null, false, true);
+                buttonsContainer.clickMessage(false, isSticker, false, null, false, true);
             }
             onHoveredChanged: buttonsContainer.hoverChanged(this.hovered)
         }

--- a/ui/imports/shared/panels/chat/ChatButtonsPanel.qml
+++ b/ui/imports/shared/panels/chat/ChatButtonsPanel.qml
@@ -12,14 +12,15 @@ Rectangle {
     property int contentType: 2
     property var messageContextMenu
     property bool showMoreButton: true
-    property bool activityCenterMessage
+    property bool activityCenterMsg
+    property bool placeholderMsg
     property string fromAuthor
     property alias editBtnActive: editBtn.active
     signal hoverChanged(bool hovered)
     signal setMessageActive(string messageId, bool active)
     signal clickMessage(bool isProfileClick, bool isSticker, bool isImage, var image, bool emojiOnly, bool hideEmojiPicker)
 
-    visible: !placeholderMessage && !activityCenterMessage &&
+    visible: !buttonsContainer.placeholderMsg && !buttonsContainer.activityCenterMsg &&
              (buttonsContainer.parentIsHovered || isMessageActive)
              && contentType !== Constants.messageContentType.transactionType
     width: buttonRow.width + buttonsContainer.containerMargin * 2

--- a/ui/imports/shared/panels/chat/ChatReplyPanel.qml
+++ b/ui/imports/shared/panels/chat/ChatReplyPanel.qml
@@ -104,7 +104,7 @@ Loader {
                 icon: repliedMessageSenderIcon
                 isIdenticon: repliedMessageSenderIconIsIdenticon
                 onClickMessage: {
-                    root.clickMessage(true, false, false, null, false, false, isReplyImage)
+                    root.clickMessage(true, false, false, null, false, false, true)
                 }
             }
 

--- a/ui/imports/shared/views/chat/CompactMessageView.qml
+++ b/ui/imports/shared/views/chat/CompactMessageView.qml
@@ -83,6 +83,8 @@ Item {
         showMoreButton: root.showMoreButton
         fromAuthor: senderId
         editBtnActive: isText && !isEdit && isCurrentUser && showEdit
+        activityCenterMsg: activityCenterMessage
+        placeholderMsg: placeholderMessage
         onClickMessage: {
             root.clickMessage(isProfileClick, isSticker, isImage, image, emojiOnly, hideEmojiPicker, false, false, "");
         }
@@ -479,7 +481,7 @@ Item {
                 z: 51
                 sourceComponent: Component {
                     StatusChatImage {
-                        imageSource: image
+                        imageSource: messageImage
                         imageWidth: 200
                         onClicked: {
                             if (mouse.button === Qt.LeftButton) {

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -185,7 +185,7 @@ Column {
         messageContextMenu.messageSenderId = root.senderId
         messageContextMenu.messageContentType = root.messageContentType
         messageContextMenu.pinnedMessage = root.pinnedMessage
-        messageContextMenu.canPin = messageStore.getNumberOfPinnedMessages() <= Constants.maxNumberOfPins
+        messageContextMenu.canPin = messageStore.getNumberOfPinnedMessages() < Constants.maxNumberOfPins
 
         messageContextMenu.selectedUserPublicKey = root.senderId
         messageContextMenu.selectedUserDisplayName = root.senderDisplayName


### PR DESCRIPTION
- `MessageContextMenuView` is updated a bit in a way that it exposes properties which that component is using, so there is no need to pass entire store or instances of modules to this popup. Also we have appropriate signals for actions which may be performed by this component.
- `PinnedMessagesPopup` is updated in a similar way, only necessary things needed for this popup to work properly are exposed as properties which may be set for this component.
- `MessageStore` moved to `ChatContentView` since it's unique per chat/channel
- `clickMessage` of `MessageView` component updated so it handles all clicks on a certain message and set properties of `MessageContextMenuView` accordingly.