### PR TITLE
refactor: move editChannelPopup to ChatContextMenuView

### DIFF
--- a/ui/app/AppLayouts/Chat/views/ChatContextMenuView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatContextMenuView.qml
@@ -8,6 +8,7 @@ import StatusQ.Popups 0.1
 
 import shared.popups 1.0
 import "../popups"
+import "../popups/community"
 
 StatusPopupMenu {
     id: root
@@ -127,23 +128,31 @@ StatusPopupMenu {
         icon.name: "edit"
         enabled: root.isCommunityChat && root.isCommunityAdmin
         onTriggered: {
-            let popup = Global.openPopup(editChannelPopup, {
-                                          isEdit: true,
-                                          channelName: root.chatName,
-                                          channelDescription: root.chatDescription
-        })
+            Global.openPopup(editChannelPopup, {
+                isEdit: true,
+                channelName: root.chatName,
+                channelDescription: root.chatDescription
+            });
+        }
+    }
 
-            popup.createCommunityChannel.connect(function(chName, chDescription){
-                root.createCommunityChannel(root.chatId, chName, chDescription)
-            })
-            popup.editCommunityChannel.connect(function(chName, chDescription){
-                root.editCommunityChannel(root.chatId, chName, chDescription)
-            })
-            popup.openPinnedMessagesPopup.connect(function(){
-                root.openPinnedMessagesList(root.chatId)
-            })
-
-            popup.open()
+    Component {
+        id: editChannelPopup
+        CreateChannelPopup {
+            anchors.centerIn: parent
+            isEdit: true
+            onCreateCommunityChannel: {
+                root.createCommunityChannel(root.chatId, chName, chDescription);
+            }
+            onEditCommunityChannel: {
+                root.editCommunityChannel(root.chatId, chName, chDescription);
+            }
+            onOpenPinnedMessagesPopup: {
+                root.openPinnedMessagesList(root.chatId, chName, chDescription);
+            }
+            onClosed: {
+                destroy()
+            }
         }
     }
 

--- a/ui/app/AppMain.qml
+++ b/ui/app/AppMain.qml
@@ -660,17 +660,6 @@ Item {
         }
 
         Component {
-            id: editChannelPopup
-            CreateChannelPopup {
-                anchors.centerIn: parent
-                isEdit: true
-                onClosed: {
-                    destroy()
-                }
-            }
-        }
-
-        Component {
             id: genericConfirmationDialog
             ConfirmationDialog {
                 onClosed: {


### PR DESCRIPTION
### What does the PR do
`editChannelPopup` was only used in `ChatContextMenuView` and via dynamic scoping. Moved into `ChatContextMenuView` and cleaned up dynamic scoping.

### Affected areas
`ChatContextMenuView` and `CreateChannelPopup`

