### PR TITLE
refactor(@desktop/profile-notifications): notifications settings added

### DIFF
--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -120,7 +120,7 @@ proc newModule*[T](
   dappPermissionsService, providerService)
   result.profileSectionModule = profile_section_module.newModule(result, events, accountsService, settingsService, 
   profileService, contactsService, aboutService, languageService, mnemonicService, privacyService,
-  nodeConfigurationService, devicesService, mailserversService)
+  nodeConfigurationService, devicesService, mailserversService, chatService)
   result.stickersModule = stickers_module.newModule(result, events, stickersService)
   result.activityCenterModule = activity_center_module.newModule(result, events, activityCenterService, contactsService)
   result.communitiesModule = communities_module.newModule(result, events, communityService)

--- a/src/app/modules/main/profile_section/io_interface.nim
+++ b/src/app/modules/main/profile_section/io_interface.nim
@@ -56,6 +56,12 @@ method syncModuleDidLoad*(self: AccessInterface) {.base.} =
 method getSyncModule*(self: AccessInterface): QVariant {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method notificationsModuleDidLoad*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method getNotificationsModule*(self: AccessInterface): QVariant {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 type
   ## Abstract class (concept) which must be implemented by object/s used in this 
   ## module.

--- a/src/app/modules/main/profile_section/notifications/controller.nim
+++ b/src/app/modules/main/profile_section/notifications/controller.nim
@@ -1,0 +1,57 @@
+import Tables, chronicles
+import controller_interface
+import io_interface
+
+import ../../../../../app_service/service/chat/service as chat_service
+
+import eventemitter
+
+export controller_interface
+
+logScope:
+  topics = "profile-section-notifications-module-controller"
+
+type 
+  Controller* = ref object of controller_interface.AccessInterface
+    delegate: io_interface.AccessInterface
+    events: EventEmitter
+    chatService: chat_service.Service
+    
+proc newController*(delegate: io_interface.AccessInterface, 
+  events: EventEmitter,
+  chatService: chat_service.Service): Controller =
+  result = Controller()
+  result.delegate = delegate
+  result.events = events
+  result.chatService = chatService
+  
+method delete*(self: Controller) =
+  discard
+
+method init*(self: Controller) = 
+  self.events.on(chat_service.SIGNAL_CHAT_MUTED) do(e:Args):
+    let args = chat_service.ChatArgs(e)
+    self.delegate.onChatMuted(args.chatId)
+
+  self.events.on(chat_service.SIGNAL_CHAT_UNMUTED) do(e:Args):
+    let args = chat_service.ChatArgs(e)
+    self.delegate.onChatUnmuted(args.chatId)
+
+  self.events.on(chat_service.SIGNAL_CHAT_LEFT) do(e: Args):
+    let args = chat_service.ChatArgs(e)
+    self.delegate.onChatLeft(args.chatId)
+
+  ## We need to add leave community handler here, once we have appropriate signal in place
+
+method getAllChats*(self: Controller): seq[ChatDto] = 
+  return self.chatService.getAllChats()
+
+method getChatDetails*(self: Controller, chatId: string): ChatDto =
+  return self.chatService.getChatById(chatId)
+
+method getOneToOneChatNameAndImage*(self: Controller, chatId: string): 
+  tuple[name: string, image: string, isIdenticon: bool] =
+  return self.chatService.getOneToOneChatNameAndImage(chatId)
+
+method unmuteChat*(self: Controller, chatId: string) =
+  self.chatService.unmuteChat(chatId)

--- a/src/app/modules/main/profile_section/notifications/controller_interface.nim
+++ b/src/app/modules/main/profile_section/notifications/controller_interface.nim
@@ -1,0 +1,24 @@
+import ../../../../../app_service/service/chat/dto/chat as chat_dto
+
+type 
+  AccessInterface* {.pure inheritable.} = ref object of RootObj
+  ## Abstract class for any input/interaction with this module.
+
+method delete*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method init*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method getAllChats*(self: AccessInterface): seq[ChatDto] {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method getChatDetails*(self: AccessInterface, chatId: string): ChatDto {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method getOneToOneChatNameAndImage*(self: AccessInterface, chatId: string): 
+  tuple[name: string, image: string, isIdenticon: bool] {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method unmuteChat*(self: AccessInterface, chatId: string) {.base.} =
+  raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/profile_section/notifications/io_interface.nim
+++ b/src/app/modules/main/profile_section/notifications/io_interface.nim
@@ -1,0 +1,11 @@
+# Defines how parent module accesses this module
+include ./private_interfaces/module_base_interface
+include ./private_interfaces/module_access_interface
+
+# Defines how this module view communicates with this module
+include ./private_interfaces/module_view_delegate_interface
+
+# Defines how this controller communicates with this module
+include ./private_interfaces/module_controller_delegate_interface
+
+# Defines how submodules of this module communicate with this module

--- a/src/app/modules/main/profile_section/notifications/item.nim
+++ b/src/app/modules/main/profile_section/notifications/item.nim
@@ -1,0 +1,30 @@
+type 
+  Item* = object
+    id: string
+    name: string
+    icon: string
+    isIdenticon: bool
+    color: string
+
+proc initItem*(id, name, icon: string, isIdenticon: bool, color: string): Item =
+  result = Item()
+  result.id = id
+  result.name = name
+  result.icon = icon
+  result.isIdenticon = isIdenticon
+  result.color = color
+
+proc id*(self: Item): string = 
+  self.id
+
+proc name*(self: Item): string = 
+  self.name
+
+proc icon*(self: Item): string = 
+  self.icon
+
+proc isIdenticon*(self: Item): bool = 
+  self.isIdenticon
+
+proc color*(self: Item): string = 
+  self.color

--- a/src/app/modules/main/profile_section/notifications/model.nim
+++ b/src/app/modules/main/profile_section/notifications/model.nim
@@ -1,0 +1,102 @@
+import NimQml, Tables
+
+import item
+
+type
+  ModelRole {.pure.} = enum
+    Id = UserRole + 1
+    Name
+    Icon
+    IsIdenticon
+    Color
+
+QtObject:
+  type
+    Model* = ref object of QAbstractListModel
+      items: seq[Item]
+
+  proc delete*(self: Model) =
+    self.items = @[]
+    self.QAbstractListModel.delete
+
+  proc setup(self: Model) =
+    self.QAbstractListModel.setup
+
+  proc newModel*(): Model =
+    new(result, delete)
+    result.setup
+
+  proc countChanged(self: Model) {.signal.}
+
+  proc getCount(self: Model): int {.slot.} =
+    self.items.len
+
+  QtProperty[int] count:
+    read = getCount
+    notify = countChanged
+
+  method rowCount(self: Model, index: QModelIndex = nil): int =
+    return self.items.len
+
+  method roleNames(self: Model): Table[int, string] =
+    {
+      ModelRole.Id.int:"itemId",
+      ModelRole.Name.int:"name",
+      ModelRole.Icon.int:"icon",
+      ModelRole.IsIdenticon.int:"isIdenticon",
+      ModelRole.Color.int:"color"
+    }.toTable
+
+  method data(self: Model, index: QModelIndex, role: int): QVariant =
+    if (not index.isValid):
+      return
+
+    if (index.row < 0 or index.row >= self.items.len):
+      return
+
+    let item = self.items[index.row]
+    let enumRole = role.ModelRole
+
+    case enumRole:
+    of ModelRole.Id: 
+      result = newQVariant(item.id)
+    of ModelRole.Name: 
+      result = newQVariant(item.name)
+    of ModelRole.Icon: 
+      result = newQVariant(item.icon)
+    of ModelRole.IsIdenticon:
+      result = newQVariant(item.isIdenticon)
+    of ModelRole.Color: 
+      result = newQVariant(item.color)
+
+  proc addItem*(self: Model, item: Item) =
+    let parentModelIndex = newQModelIndex()
+    defer: parentModelIndex.delete
+
+    self.beginInsertRows(parentModelIndex, self.items.len, self.items.len)
+    self.items.add(item)
+    self.endInsertRows()
+
+    self.countChanged()
+
+  proc getItemIdxById*(self: Model, id: string): int =
+    var idx = 0
+    for it in self.items:
+      if(it.id == id):
+        return idx
+      idx.inc
+    return -1
+    
+  proc removeItemById*(self: Model, id: string) =
+    let idx = self.getItemIdxById(id)
+    if idx == -1:
+      return
+
+    let parentModelIndex = newQModelIndex()
+    defer: parentModelIndex.delete
+
+    self.beginRemoveRows(parentModelIndex, idx, idx)
+    self.items.delete(idx)
+    self.endRemoveRows()
+
+    self.countChanged()

--- a/src/app/modules/main/profile_section/notifications/module.nim
+++ b/src/app/modules/main/profile_section/notifications/module.nim
@@ -1,0 +1,86 @@
+import NimQml, chronicles
+import io_interface
+import ../io_interface as delegate_interface
+import view, controller, model, item
+
+import ../../../../../app_service/service/chat/service as chat_service
+
+import eventemitter
+
+export io_interface
+
+logScope:
+  topics = "profile-section-notifications-module"
+
+type 
+  Module* = ref object of io_interface.AccessInterface
+    delegate: delegate_interface.AccessInterface
+    controller: controller.AccessInterface
+    view: View
+    viewVariant: QVariant    
+    moduleLoaded: bool
+
+proc newModule*(delegate: delegate_interface.AccessInterface, 
+  events: EventEmitter,
+  chatService: chat_service.Service): Module =
+  result = Module()
+  result.delegate = delegate
+  result.view = view.newView(result)
+  result.viewVariant = newQVariant(result.view)
+  result.controller = controller.newController(result, events, chatService)
+  result.moduleLoaded = false
+  
+method delete*(self: Module) =
+  self.view.delete
+  self.viewVariant.delete
+  self.controller.delete
+
+method load*(self: Module) =
+  self.controller.init()
+  self.view.load()
+
+method isLoaded*(self: Module): bool =
+  return self.moduleLoaded
+
+proc initModel(self: Module) =
+  let chats = self.controller.getAllChats()
+  for c in chats:
+    if(not c.muted):
+      continue
+
+    if(c.chatType == ChatType.OneToOne):
+      let (chatName, chatImage, isIdenticon) = self.controller.getOneToOneChatNameAndImage(c.id)
+      let item = initItem(c.id, chatName, chatImage, isIdenticon, c.color)
+      self.view.mutedContactsModel().addItem(item)
+    else:
+      let item = initItem(c.id, c.name, c.identicon, false, c.color)
+      self.view.mutedChatsModel().addItem(item)
+
+method viewDidLoad*(self: Module) =
+  self.initModel()
+  self.moduleLoaded = true
+  self.delegate.notificationsModuleDidLoad()
+
+method getModuleAsVariant*(self: Module): QVariant =
+  return self.viewVariant
+
+method unmuteChat*(self: Module, chatId: string) =
+  self.controller.unmuteChat(chatId)
+
+method onChatMuted*(self: Module, chatId: string) =
+  let chat = self.controller.getChatDetails(chatId)
+  if(chat.chatType == ChatType.OneToOne):
+    let (chatName, chatImage, isIdenticon) = self.controller.getOneToOneChatNameAndImage(chat.id)
+    let item = initItem(chat.id, chatName, chatImage, isIdenticon, chat.color)
+    self.view.mutedContactsModel().addItem(item)
+  else:
+    let item = initItem(chat.id, chat.name, chat.identicon, false, chat.color)
+    self.view.mutedChatsModel().addItem(item)
+
+method onChatUnmuted*(self: Module, chatId: string) =
+  self.view.mutedContactsModel().removeItemById(chatId)
+  self.view.mutedChatsModel().removeItemById(chatId)
+
+method onChatLeft*(self: Module, chatId: string) =
+  self.view.mutedContactsModel().removeItemById(chatId)
+  self.view.mutedChatsModel().removeItemById(chatId)

--- a/src/app/modules/main/profile_section/notifications/private_interfaces/module_access_interface.nim
+++ b/src/app/modules/main/profile_section/notifications/private_interfaces/module_access_interface.nim
@@ -1,0 +1,13 @@
+import NimQml
+
+method delete*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method load*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method isLoaded*(self: AccessInterface): bool {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method getModuleAsVariant*(self: AccessInterface): QVariant {.base.} =
+  raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/profile_section/notifications/private_interfaces/module_base_interface.nim
+++ b/src/app/modules/main/profile_section/notifications/private_interfaces/module_base_interface.nim
@@ -1,0 +1,5 @@
+type 
+  AccessInterface* {.pure inheritable.} = ref object of RootObj
+
+# Since nim doesn't support using concepts in second level nested types we 
+# define delegate interfaces within access interface. 

--- a/src/app/modules/main/profile_section/notifications/private_interfaces/module_controller_delegate_interface.nim
+++ b/src/app/modules/main/profile_section/notifications/private_interfaces/module_controller_delegate_interface.nim
@@ -1,0 +1,8 @@
+method onChatMuted*(self: AccessInterface, chatId: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method onChatUnmuted*(self: AccessInterface, chatId: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method onChatLeft*(self: AccessInterface, chatId: string) {.base.} =
+  raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/profile_section/notifications/private_interfaces/module_view_delegate_interface.nim
+++ b/src/app/modules/main/profile_section/notifications/private_interfaces/module_view_delegate_interface.nim
@@ -1,0 +1,5 @@
+method viewDidLoad*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available") 
+
+method unmuteChat*(self: AccessInterface, chatId: string) {.base.} =
+  raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/profile_section/notifications/view.nim
+++ b/src/app/modules/main/profile_section/notifications/view.nim
@@ -1,0 +1,53 @@
+import NimQml
+import io_interface, model
+
+QtObject:
+  type
+    View* = ref object of QObject
+      delegate: io_interface.AccessInterface
+      mutedContactsModel: Model
+      mutedContactsModelVariant: QVariant
+      mutedChatsModel: Model
+      mutedChatsModelVariant: QVariant
+      
+  proc delete*(self: View) =
+    self.mutedContactsModel.delete
+    self.mutedContactsModelVariant.delete
+    self.mutedChatsModel.delete
+    self.mutedChatsModelVariant.delete
+    self.QObject.delete
+
+  proc newView*(delegate: io_interface.AccessInterface): View =
+    new(result, delete)
+    result.QObject.setup
+    result.delegate = delegate
+    result.mutedContactsModel = newModel()
+    result.mutedContactsModelVariant = newQVariant(result.mutedContactsModel)
+    result.mutedChatsModel = newModel()
+    result.mutedChatsModelVariant = newQVariant(result.mutedChatsModel)
+
+  proc load*(self: View) =
+    self.delegate.viewDidLoad()
+
+  proc mutedContactsModel*(self: View): Model =
+    return self.mutedContactsModel
+
+  proc mutedContactsModelChanged*(self: View) {.signal.}
+  proc getMutedContactsModel(self: View): QVariant {.slot.} =
+    return self.mutedContactsModelVariant
+  QtProperty[QVariant] mutedContactsModel:
+    read = getMutedContactsModel
+    notify = mutedContactsModelChanged
+
+  proc mutedChatsModel*(self: View): Model =
+    return self.mutedChatsModel
+
+  proc mutedChatsModelChanged*(self: View) {.signal.}
+  proc getMutedChatsModel(self: View): QVariant {.slot.} =
+    return self.mutedChatsModelVariant
+  QtProperty[QVariant] mutedChatsModel:
+    read = getMutedChatsModel
+    notify = mutedChatsModelChanged
+
+  proc unmuteChat*(self: View, chatId: string) {.slot.} =
+    self.delegate.unmuteChat(chatId)

--- a/src/app/modules/main/profile_section/view.nim
+++ b/src/app/modules/main/profile_section/view.nim
@@ -35,3 +35,8 @@ QtObject:
     return self.delegate.getSyncModule()
   QtProperty[QVariant] syncModule:
     read = getSyncModule
+
+  proc getNotificationsModule(self: View): QVariant {.slot.} =
+    return self.delegate.getNotificationsModule()
+  QtProperty[QVariant] notificationsModule:
+    read = getNotificationsModule

--- a/src/app_service/service/chat/service.nim
+++ b/src/app_service/service/chat/service.nim
@@ -303,6 +303,10 @@ QtObject:
 
   proc muteChat*(self: Service, chatId: string) =
     try:
+      if(chatId.len == 0):
+        error "error trying to mute chat with an empty id"
+        return
+
       let response = status_chat.muteChat(chatId)
       if(not response.error.isNil):
         let msg = response.error.message & " chatId=" & chatId 
@@ -317,6 +321,10 @@ QtObject:
 
   proc unmuteChat*(self: Service, chatId: string) =
     try:
+      if(chatId.len == 0):
+        error "error trying to unmute chat with an empty id"
+        return
+
       let response = status_chat.unmuteChat(chatId)
       if(not response.error.isNil):
         let msg = response.error.message & " chatId=" & chatId 

--- a/ui/app/AppLayouts/Profile/ProfileLayout.qml
+++ b/ui/app/AppLayouts/Profile/ProfileLayout.qml
@@ -83,7 +83,7 @@ StatusAppTwoPanelLayout {
         }
 
         NotificationsView {
-            store: profileView.store
+            notificationsStore: profileView.store.notificationsStore
             profileContentWidth: _internal.profileContentWidth
         }
 

--- a/ui/app/AppLayouts/Profile/popups/MutedChatsModal.qml
+++ b/ui/app/AppLayouts/Profile/popups/MutedChatsModal.qml
@@ -19,8 +19,11 @@ ModalPopup {
     id: root
     //% "Muted chats"
     title: qsTrId("muted-chats")
-    property bool showMutedContacts: false
+
+    property var model: []
     property string noContentText: ""
+
+    signal unmuteChat(string chatId)
 
     onClosed: {
         root.destroy()
@@ -28,12 +31,8 @@ ModalPopup {
 
     ListView {
         id: mutedChatsList
-        anchors.top: parent.top
-        visible: true
-        anchors.left: parent.left
-        anchors.right: parent.right
-        // Not Refactored Yet
-//        model: root.showMutedContacts ? profileModel.mutedChats.contacts : profileModel.mutedChats.chats
+        anchors.fill: parent
+        model: root.model
         delegate: Rectangle {
             id: channelItem
             property bool isHovered: false
@@ -50,8 +49,8 @@ ModalPopup {
                 image: StatusImageSettings {
                     width: 40
                     height: 40
-                    source: model.identicon
-                    isIdenticon: true
+                    source: model.icon
+                    isIdenticon: model.isIdenticon
                 }
                 icon: StatusIconSettings {
                     width: 40
@@ -64,9 +63,7 @@ ModalPopup {
 
             StyledText {
                 id: contactInfo
-                text: model.chatType !== Constants.chatType.publicChat ?
-                    Emoji.parse(Utils.removeStatusEns(Utils.filterXSS(model.name)), "26x26") :
-              "#" + Utils.filterXSS(model.name)
+                text: model.name
                 anchors.right: unmuteButton.left
                 anchors.rightMargin: Style.current.smallPadding
                 elide: Text.ElideRight
@@ -100,8 +97,7 @@ ModalPopup {
                         channelItem.isHovered = true
                     }
                     onClicked: {
-                        // Not Refactored Yet
-//                        chatsModel.channelView.unmuteChatItem(model.id)
+                        root.unmuteChat(model.itemId)
                     }
                 }
             }

--- a/ui/app/AppLayouts/Profile/stores/NotificationsStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/NotificationsStore.qml
@@ -1,0 +1,15 @@
+import QtQuick 2.13
+import utils 1.0
+
+QtObject {
+    id: root
+
+    property var notificationsModule
+
+    property var mutedContactsModel: notificationsModule.mutedContactsModel
+    property var mutedChatsModel: notificationsModule.mutedChatsModel
+
+    function unmuteChat(chatId) {
+        return root.notificationsModule.unmuteChat(chatId)
+    }
+}

--- a/ui/app/AppLayouts/Profile/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/RootStore.qml
@@ -24,6 +24,10 @@ QtObject {
         syncModule: profileModuleInst.syncModule
     }
 
+    property NotificationsStore notificationsStore: NotificationsStore {
+        notificationsModule: profileModuleInst.notificationsModule
+    }
+
     // Not Refactored Yet
 //    property var chatsModelInst: chatsModel
     // Not Refactored Yet

--- a/ui/app/AppLayouts/Profile/views/NotificationsView.qml
+++ b/ui/app/AppLayouts/Profile/views/NotificationsView.qml
@@ -19,7 +19,8 @@ import "./"
 ScrollView {
     id: root
 
-    property var store
+    property var notificationsStore
+
     property int profileContentWidth
 
     height: parent.height
@@ -285,17 +286,22 @@ ScrollView {
             StatusSettingsLineButton {
                 //% "Muted users"
                 text: qsTrId("muted-users")
-                //% "None"
-                currentValue: root.store.mutedChatsContacts.rowCount() > 0 ? root.store.mutedChatsContacts.rowCount() : qsTrId("none")
+                currentValue: root.notificationsStore.mutedContactsModel.count > 0 ?
+                                  //% "None"
+                                  root.notificationsStore.mutedContactsModel.count : qsTrId("none")
                 isSwitch: false
                 onClicked: {
-                    const mutedChatsModal = notificationsContainer.mutedChatsModalComponent.createObject(notificationsContainer, {
-                        showMutedContacts: true
-                    })
+                    const mutedChatsModal = notificationsContainer.mutedChatsModalComponent.createObject(notificationsContainer)
+                    mutedChatsModal.model = root.notificationsStore.notificationsModule.mutedContactsModel
                     //% "Muted contacts"
                     mutedChatsModal.title = qsTrId("muted-contacts");
                     //% "Muted contacts will appear here"
                     mutedChatsModal.noContentText = qsTrId("muted-contacts-will-appear-here");
+
+                    mutedChatsModal.unmuteChat.connect(function(chatId){
+                        root.notificationsStore.unmuteChat(chatId)
+                    })
+
                     mutedChatsModal.open();
                 }
             }
@@ -304,17 +310,22 @@ ScrollView {
             StatusSettingsLineButton {
                 //% "Muted chats"
                 text: qsTrId("muted-chats")
-                //% "None"
-                currentValue: root.store.mutedChats.rowCount() > 0 ? root.store.mutedChats.rowCount() : qsTrId("none")
+                currentValue: root.notificationsStore.mutedChatsModel.count > 0 ?
+                                  //% "None"
+                                  root.notificationsStore.mutedChatsModel.count : qsTrId("none")
                 isSwitch: false
                 onClicked: {
-                    const mutedChatsModal = notificationsContainer.mutedChatsModalComponent.createObject(notificationsContainer, {
-                        showMutedContacts: false
-                    })
+                    const mutedChatsModal = notificationsContainer.mutedChatsModalComponent.createObject(notificationsContainer)
+                    mutedChatsModal.model = root.notificationsStore.notificationsModule.mutedChatsModel
                     //% "Muted chats"
                     mutedChatsModal.title = qsTrId("muted-chats");
                     //% "Muted chats will appear here"
                     mutedChatsModal.noContentText = qsTrId("muted-chats-will-appear-here");
+
+                    mutedChatsModal.unmuteChat.connect(function(chatId){
+                        root.notificationsStore.unmuteChat(chatId)
+                    })
+
                     mutedChatsModal.open();
                 }
 


### PR DESCRIPTION
This PR moved `Profile/Notifications Settings` section to a new structure.

**Note**: This PR is branched off #4343 so please review it first.

@anastasiyaig  just for a reference, I noticed that the following don't work in master:
- `Profile/Notifications Settings` list of muted/unmuted chats is not loaded well after app restart if there are muted chats
- if we have more than one chat only one is displayed in a list
- those lists are not updated on leaving chat action

All that is fixed in `base_bc` (in this PR).