### PR TITLE
fix: Cannot download uploaded or embed images in private chat

### DIFF
--- a/ui/imports/shared/views/chat/CompactMessageView.qml
+++ b/ui/imports/shared/views/chat/CompactMessageView.qml
@@ -482,7 +482,7 @@ Item {
                                 messageContextMenu.parent = root
                                 messageContextMenu.setXPosition = function() { return (mouse.x)}
                                 messageContextMenu.setYPosition = function() { return (mouse.y)}
-                                root.clickMessage(false, false, true, image, false, true, false, true, imageSource)
+                                clickMessage(false, false, true, image, false, true, false, true, imageSource)
                             }
                         }
                         container: root.container


### PR DESCRIPTION
Closes #4143

### What does the PR do
Download an image to a local folder was not working as
clickMessage function was called from root. and root has
no such function. Switched to use clickMessage via dynamic
scoping.

TODO: remove dynamic scoping

### Affected areas
chat messages
