### PR TITLE
fix(@wallet): Collection without assets

### DIFF
--- a/ui/app/AppLayouts/Wallet/views/collectibles/CollectibleCollectionView.qml
+++ b/ui/app/AppLayouts/Wallet/views/collectibles/CollectibleCollectionView.qml
@@ -4,6 +4,7 @@ import QtGraphicalEffects 1.13
 
 import StatusQ.Components 0.1
 import StatusQ.Core.Theme 0.1
+import shared.panels 1.0
 
 import "../../stores"
 
@@ -31,7 +32,15 @@ Item {
         anchors.top: parent.top
         anchors.topMargin: 16
         anchors.horizontalCenter: parent.horizontalCenter
-        sourceComponent: root.collectiblesLoaded ? loaded : loading
+        sourceComponent: {
+            if (!root.collectiblesLoaded) {
+                return loading
+            }
+            if (RootStore.getCollectionCollectiblesList(root.slug).count == 0) {
+                return empty
+            }
+            return loaded
+        }
     }
 
     Component {
@@ -45,6 +54,22 @@ Item {
                 height: 20
                 anchors.verticalCenter: parent.verticalCenter
                 anchors.horizontalCenter: parent.horizontalCenter
+            }
+        }
+    }
+
+    Component {
+        id: empty
+        
+        Item {
+            id: emptyContainer
+            height: 164
+            StyledText {
+                anchors.verticalCenter: parent.verticalCenter
+                anchors.horizontalCenter: parent.horizontalCenter
+                color: Style.current.secondaryText
+                text: qsTr("No collectibles available")
+                font.pixelSize: 15
             }
         }
     }


### PR DESCRIPTION
fixes #3808

In some cases, the opensea API return collection for an owner without
assets, we handle this case in the UI

![image](https://user-images.githubusercontent.com/491074/148062360-2b24a94b-5adf-43e1-a09b-31891e65e59d.png)

