### PR TITLE
fix(chat): fix loading chats when joining them

### DIFF
--- a/src/app/modules/main/chat_section/chat_content/view.nim
+++ b/src/app/modules/main/chat_section/chat_content/view.nim
@@ -12,6 +12,8 @@ QtObject:
       chatDetails: ChatDetails
       chatDetailsVariant: QVariant
       
+  proc chatDetailsChanged*(self:View) {.signal.}
+
   proc delete*(self: View) =
     self.pinnedMessagesModel.delete
     self.pinnedMessagesModelVariant.delete
@@ -33,6 +35,7 @@ QtObject:
     self.chatDetails.setChatDetails(id, `type`, belongsToCommunity, isUsersListAvailable, name, icon, isIdenticon, 
     color, description, hasUnreadMessages, notificationsCount, muted)
     self.delegate.viewDidLoad()
+    self.chatDetailsChanged()
 
   proc pinnedModel*(self: View): pinned_msg_model.Model =
     return self.pinnedMessagesModel
@@ -95,6 +98,7 @@ QtObject:
     return self.chatDetailsVariant
   QtProperty[QVariant] chatDetails:
     read = getChatDetails
+    notify = chatDetailsChanged
 
   proc getCurrentFleet*(self: View): string {.slot.} =
     self.delegate.getCurrentFleet()

--- a/src/app/modules/main/chat_section/controller.nim
+++ b/src/app/modules/main/chat_section/controller.nim
@@ -78,10 +78,10 @@ method init*(self: Controller) =
     self.events.on(SIGNAL_COMMUNITY_CHANNEL_CREATED) do(e:Args):
       let args = CommunityChatArgs(e)
       if (args.communityId == self.sectionId):
-        self.delegate.addNewChat(
-          ChatDto(
+        let chatDto = ChatDto(
             id: args.chat.id,
             name: args.chat.name,
+            chatType: ChatType.CommunityChat,
             color: args.chat.color,
             emoji: args.chat.emoji,
             description: args.chat.description,
@@ -90,7 +90,12 @@ method init*(self: Controller) =
             position: args.chat.position,
             categoryId: args.chat.categoryId,
             communityId: args.communityId
-          ),
+          )
+
+        self.chatService.updateOrAddChat(chatDto)
+        
+        self.delegate.addNewChat(
+          chatDto,
           self.events,
           self.settingsService,
           self.contactService,

--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -314,9 +314,10 @@ method addNewChat*(
   let amIChatAdmin = self.amIMarkedAsAdminUser(chatDto.members)
   let item = initItem(chatDto.id, chatName, chatImage, isIdenticon, chatDto.color, chatDto.description, 
   chatDto.chatType.int, amIChatAdmin, hasNotification, notificationsCount, chatDto.muted, false, 0)
-  self.view.appendItem(item)
   self.addSubmodule(chatDto.id, false, isUsersListAvailable, events, settingsService, contactService, chatService, 
   communityService, messageService)
+  self.chatContentModules[chatDto.id].load()
+  self.view.appendItem(item)
 
   # make new added chat active one
   self.setActiveItemSubItem(item.id, "")

--- a/src/app_service/service/chat/service.nim
+++ b/src/app_service/service/chat/service.nim
@@ -94,6 +94,9 @@ QtObject:
   proc hasChannel*(self: Service, chatId: string): bool =
     self.chats.hasKey(chatId)
 
+  proc updateOrAddChat*(self: Service, chat: ChatDto) =
+    self.chats[chat.id] = chat
+
   proc parseChatResponse*(self: Service, response: RpcResponse[JsonNode]): (seq[ChatDto], seq[MessageDto]) =
     var chats: seq[ChatDto] = @[]
     var messages: seq[MessageDto] = @[]
@@ -104,7 +107,7 @@ QtObject:
       for jsonChat in response.result["chats"]:
         let chat = chat_dto.toChatDto(jsonChat)
         # TODO add the channel back to `chat` when it is refactored
-        self.chats[chat.id] = chat
+        self.updateOrAddChat(chat)
         chats.add(chat) 
     result = (chats, messages)
 
@@ -164,6 +167,7 @@ QtObject:
       return
 
     result.chatDto = chats[0]
+    self.updateOrAddChat(result.chatDto)
     result.success = true
 
   proc createPublicChat*(self: Service, chatId: string): tuple[chatDto: ChatDto, success: bool] =

--- a/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
@@ -197,7 +197,12 @@ Item {
                 DelegateChoice { // In case of category
                     roleValue: Constants.chatType.unknown
                     delegate: Repeater {
-                        model: subItems
+                        model: {
+                            if (!subItems) {
+                                console.error("We got a category with no subitems. It is possible that the channel had a type unknown")
+                            }
+                            return subItems
+                        }
                         delegate: ChatContentView {
                             rootStore: root.rootStore
                             contactsStore: root.contactsStore


### PR DESCRIPTION
https://github.com/status-im/status-desktop/issues/4367

There were 3 small problems, that all compounded in the chat to be empty and unusable when joining (but worked when rebooting)
1. The call to `appendItem` was called before adding the module in the list, so the UI reacted to the new Item, but asked for the module details, but it didn't exist yet
2. The chatDetails weren't loaded on new chats. Now called after the appendItem (plus added the signal to say the details changed)
3. The new chat was not added in the table in the service, resulting in no return