### PR TITLE
fix(chat): add signal to display new messages received

### DIFF
--- a/src/app/boot/app_controller.nim
+++ b/src/app/boot/app_controller.nim
@@ -260,6 +260,7 @@ proc load(self: AppController) =
   self.nodeConfigurationService.init()
   self.contactsService.init()
   self.chatService.init()
+  self.messageService.init()
   self.communityService.init()
   self.bookmarkService.init()
   self.tokenService.init()

--- a/src/app/modules/main/app_search/controller.nim
+++ b/src/app/modules/main/app_search/controller.nim
@@ -42,7 +42,7 @@ method delete*(self: Controller) =
 
 method init*(self: Controller) = 
   self.events.on(SIGNAL_SEARCH_MESSAGES_LOADED) do(e:Args):
-    let args = SearchMessagesLoadedArgs(e)
+    let args = MessagesArgs(e)
     self.delegate.onSearchMessagesDone(args.messages)
 
 method activeSectionId*(self: Controller): string =

--- a/src/app/modules/main/chat_section/chat_content/messages/controller.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/controller.nim
@@ -7,7 +7,6 @@ import ../../../../../../app_service/service/community/service as community_serv
 import ../../../../../../app_service/service/chat/service as chat_service
 import ../../../../../../app_service/service/message/service as message_service
 
-import ../../../../../core/signals/types
 import eventemitter
 
 export controller_interface
@@ -51,6 +50,11 @@ method init*(self: Controller) =
     if(self.chatId != args.chatId):
       return
     self.delegate.newMessagesLoaded(args.messages, args.reactions, args.pinnedMessages)
+
+  self.events.on(SIGNAL_NEW_MESSAGE_RECEIVED) do(e: Args):
+    var evArgs = MessagesArgs(e)
+    for message in evArgs.messages:
+      self.delegate.messageAdded(message)
 
   self.events.on(SIGNAL_SENDING_SUCCESS) do(e:Args):
     let args = MessageSendingSuccess(e)

--- a/src/app/modules/main/chat_section/chat_content/messages/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/module.nim
@@ -126,7 +126,7 @@ method newMessagesLoaded*(self: Module, messages: seq[MessageDto], reactions: se
    
   self.view.setLoadingHistoryMessagesInProgress(false)
 
-method onSendingMessageSuccess*(self: Module, message: MessageDto) =
+method messageAdded*(self: Module, message: MessageDto) =
   let sender = self.controller.getContactById(message.`from`)
   let senderDisplayName = sender.userNameOrAlias()
   let amISender = message.`from` == singletonInstance.userProfile.getPubKey()
@@ -141,6 +141,9 @@ method onSendingMessageSuccess*(self: Module, message: MessageDto) =
   message.timestamp, message.contentType.ContentType, message.messageType)
 
   self.view.model().prependItem(item)
+
+method onSendingMessageSuccess*(self: Module, message: MessageDto) =
+  self.messageAdded(message)
   self.view.emitSendingMessageSuccessSignal()
 
 method onSendingMessageError*(self: Module) =

--- a/src/app/modules/main/chat_section/chat_content/messages/private_interfaces/module_controller_delegate_interface.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/private_interfaces/module_controller_delegate_interface.nim
@@ -13,6 +13,9 @@ method onReactionRemoved*(self: AccessInterface, messageId: string, emojiId: int
 method onPinUnpinMessage*(self: AccessInterface, messageId: string, pin: bool) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method messageAdded*(self: AccessInterface, message: MessageDto) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method onSendingMessageSuccess*(self: AccessInterface, message: MessageDto) {.base.} =
   raise newException(ValueError, "No implementation available")
 


### PR DESCRIPTION
Fixes #4370

Adds the signal for new messages received

It seems like other signals like reactions and pins might not be there yet as well, but they can be added later since they aren't as needed