### PR TITLE
fix(community): fix creating channels in a new community does not work

### DIFF
--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -491,9 +491,11 @@ method communityJoined*[T](
       communityService,
       messageService
     )
+  self.communitySectionsModule[community.id].load(events, settingsService, contactsService, chatService, communityService, messageService)
 
+  let communitySectionItem = self.createCommunityItem(community)
   self.view.addItem(self.createCommunityItem(community))
-  # TODO do we need to set it as active
+  self.setActiveSection(communitySectionItem)
 
 method communityEdited*[T](
     self: Module[T],


### PR DESCRIPTION
This was because the community when created was not loaded, so it didn't listen to events.