### PR TITLE
Feat: Add a Blocked bar for blocked user profile

### DIFF
--- a/ui/app/AppLayouts/Chat/popups/ProfilePopup.qml
+++ b/ui/app/AppLayouts/Chat/popups/ProfilePopup.qml
@@ -89,12 +89,21 @@ StatusModal {
             anchors.top: parent.top
             width: parent.width
 
+            // Blocked User Status Bar
+            StatusBanner {
+                id: blockedUsrBar               
+                width: parent.width
+                visible: isBlocked
+                type: StatusBanner.Type.Danger
+                statusText: qsTr("Blocked")
+            }           
+
             Item {
                 height: 16
                 width: parent.width
             }
 
-            StatusDescriptionListItem {
+            StatusDescriptionListItem {               
                 title: ((isCurrentUser && profileModel.ens.preferredUsername) || isEnsVerified) ? qsTr("ENS username") : qsTr("Username")
                 subTitle: isCurrentUser ? profileModel.ens.preferredUsername || userName : userName
                 tooltip.text: qsTr("Copy to clipboard")
@@ -119,11 +128,6 @@ StatusModal {
                     tooltip.visible = !tooltip.visible
                 }
                 width: parent.width
-            }
-
-            StatusModalDivider {
-                topPadding: 12
-                bottomPadding: 16
             }
 
             StatusDescriptionListItem {
@@ -161,12 +165,6 @@ StatusModal {
                     tooltip.visible = !tooltip.visible
                 }
                 width: parent.width
-            }
-
-            StatusModalDivider {
-                visible: !isCurrentUser
-                topPadding: 8
-                bottomPadding: 12
             }
 
             StatusDescriptionListItem {

--- a/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
@@ -261,25 +261,13 @@ Item {
                 }
             }
 
-            Item {
-                Layout.fillWidth: true
-                Layout.preferredHeight: 40
-                Layout.alignment: Qt.AlignHCenter
+            // Blocked User Status Bar
+            StatusBanner {
+                id: blockedUsrBar
+                width: parent.width
                 visible: isBlocked
-
-                Rectangle {
-                    id: blockedBanner
-                    anchors.fill: parent
-                    color: Style.current.red
-                    opacity: 0.1
-                }
-
-                Text {
-                    id: blockedText
-                    anchors.centerIn: blockedBanner
-                    color: Style.current.red
-                    text: qsTr("Blocked")
-                }
+                type: StatusBanner.Type.Danger
+                statusText: qsTr("Blocked")
             }
 
             StackLayout {


### PR DESCRIPTION
Closes [#3547](https://github.com/status-im/status-desktop/issues/3547)

### What does the PR do

Using a new UI component from [#513](https://github.com/status-im/StatusQ/pull/513) it displays a status bar for blocked users in the user profile view.

### Affected areas

Contacts/Blocked Contacts/View Profile

### Screenshot of functionality

![PRBlockedBar](https://user-images.githubusercontent.com/97019400/148761248-1894b5e8-ce55-49cd-b127-6540bb9a5947.PNG)

### Considerations
It must be approved PR [#513](https://github.com/status-im/StatusQ/pull/513) before merging the current one

