### PR TITLE
refactor(@desktop/general): dependencies to the `status-lib` removed

### DIFF
--- a/src/app/core/eventemitter.nim
+++ b/src/app/core/eventemitter.nim
@@ -1,0 +1,60 @@
+import # system libs
+  tables
+
+import # deps
+  uuids
+
+type 
+  Args* = ref object of RootObj # ...args
+  Handler* = proc (args: Args) {.closure.} # callback function type
+  EventEmitter* = ref object
+    events: Table[string, Table[UUID, Handler]]
+
+proc createEventEmitter*(): EventEmitter = 
+  result.new
+  result.events = initTable[string, Table[UUID, Handler]]()
+
+
+proc on(this: EventEmitter, name: string, handlerId: UUID, handler: Handler): void =
+  if this.events.hasKey(name):
+    this.events[name].add handlerId, handler
+    return
+  
+  this.events[name] = [(handlerId, handler)].toTable
+
+proc on*(this: EventEmitter, name: string, handler: Handler): void = 
+  var uuid: UUID
+  this.on(name, uuid, handler)
+
+proc once*(this:EventEmitter, name:string, handler:Handler): void =
+  var handlerId = genUUID()
+  this.on(name, handlerId) do(a: Args):
+    handler(a)
+    this.events[name].del handlerId
+
+proc emit*(this:EventEmitter, name:string, args:Args): void  =
+  if this.events.hasKey(name):
+    # collect the handlers before executing them
+    # because of 'once' proc, we also mutate
+    # this.events. This can cause unexpected behaviour
+    # while having an iterator on this.events
+    var handlers: seq[Handler] = @[]
+    for (id, handler) in this.events[name].pairs:
+      handlers.add(handler)
+
+    for i in 0..len(handlers)-1:
+      handlers[i](args)
+
+when isMainModule:
+  block:
+    type ReadyArgs = ref object of Args
+      text: string
+    var evts = createEventEmitter()
+    evts.on("ready") do(a: Args):
+      var args = ReadyArgs(a)
+      echo args.text, ": from [1st] handler"
+    evts.once("ready") do(a: Args):
+      var args = ReadyArgs(a)
+      echo args.text, ": from [2nd] handler"
+    evts.emit("ready", ReadyArgs(text:"Hello, World"))
+    evts.emit("ready", ReadyArgs(text:"Hello, World"))

--- a/src/app/core/signals/remote_signals/base.nim
+++ b/src/app/core/signals/remote_signals/base.nim
@@ -1,8 +1,7 @@
-import json
 import json_serialization
 import signal_type
 
-import eventemitter
+import ../../eventemitter
 
 export signal_type
 

--- a/src/app/core/signals/remote_signals/messages.nim
+++ b/src/app/core/signals/remote_signals/messages.nim
@@ -2,11 +2,7 @@ import json
 
 import base
 
-# Step by step we should remove all these types from `status-lib`
-import status/types/[activity_center_notification, removed_message]
-import status/types/community as old_community
-
-import ../../../../app_service/service/message/dto/[message, pinned_message_update, reaction]
+import ../../../../app_service/service/message/dto/[message, pinned_message_update, reaction, removed_message]
 import ../../../../app_service/service/chat/dto/[chat]
 import ../../../../app_service/service/community/dto/[community]
 import ../../../../app_service/service/activity_center/dto/[notification]
@@ -21,10 +17,10 @@ type MessageSignal* = ref object of Signal
   devices*: seq[DeviceDto]
   emojiReactions*: seq[ReactionDto]
   communities*: seq[CommunityDto]
-  membershipRequests*: seq[old_community.CommunityMembershipRequest]
+  membershipRequests*: seq[CommunityMembershipRequestDto]
   activityCenterNotifications*: seq[ActivityCenterNotificationDto]
   statusUpdates*: seq[StatusUpdateDto]
-  deletedMessages*: seq[RemovedMessage]
+  deletedMessages*: seq[RemovedMessageDto]
 
 proc fromEvent*(T: type MessageSignal, event: JsonNode): MessageSignal = 
   var signal:MessageSignal = MessageSignal()
@@ -64,11 +60,11 @@ proc fromEvent*(T: type MessageSignal, event: JsonNode): MessageSignal =
 
   if event["event"]{"requestsToJoinCommunity"} != nil:
     for jsonCommunity in event["event"]["requestsToJoinCommunity"]:
-      signal.membershipRequests.add(jsonCommunity.toCommunityMembershipRequest)
+      signal.membershipRequests.add(jsonCommunity.toCommunityMembershipRequestDto())
 
   if event["event"]{"removedMessages"} != nil:
     for jsonRemovedMessage in event["event"]["removedMessages"]:
-      signal.deletedMessages.add(jsonRemovedMessage.toRemovedMessage)
+      signal.deletedMessages.add(jsonRemovedMessage.toRemovedMessageDto())
 
   if event["event"]{"activityCenterNotifications"} != nil:
     for jsonNotification in event["event"]["activityCenterNotifications"]:

--- a/src/app/core/signals/signals_manager.nim
+++ b/src/app/core/signals/signals_manager.nim
@@ -1,5 +1,5 @@
 import NimQml, json, strutils, chronicles, json_serialization
-import eventemitter
+import ../eventemitter
 
 include types
 

--- a/src/app/core/tasks/marathon/mailserver/controller.nim
+++ b/src/app/core/tasks/marathon/mailserver/controller.nim
@@ -1,5 +1,6 @@
 import NimQml, times, strutils, json, json_serialization, chronicles
 
+import ../../../eventemitter
 import ../../../fleets/fleet_configuration
 import ../../../../../app_service/service/settings/service_interface as settings_service
 import ../../../../../app_service/service/node_configuration/service_interface as node_config_service
@@ -11,8 +12,6 @@ import status/statusgo_backend_new/general as status_general
 
 import events
 import ../../common as task_runner_common
-
-import eventemitter
 
 logScope:
   topics = "mailserver controller"

--- a/src/app/core/tasks/marathon/mailserver/events.nim
+++ b/src/app/core/tasks/marathon/mailserver/events.nim
@@ -1,8 +1,6 @@
-import # vendor libs
-  NimQml, json_serialization
+import NimQml, json_serialization
 
-import # status-desktop libs
-  eventemitter
+import ../../../eventemitter
 
 type
   MailserverEvents* = ref object

--- a/src/app/core/tasks/marathon/worker.nim
+++ b/src/app/core/tasks/marathon/worker.nim
@@ -1,6 +1,3 @@
-import # std libs
-  json
-
 import # vendor libs
   chronicles, chronos, json_serialization, task_runner
 

--- a/src/app/global/app_signals.nim
+++ b/src/app/global/app_signals.nim
@@ -1,6 +1,6 @@
 from  ../modules/shared_models/section_item import SectionType
 
-import eventemitter
+import ../core/eventemitter
 
 export SectionType
 

--- a/src/app/modules/main/activity_center/controller.nim
+++ b/src/app/modules/main/activity_center/controller.nim
@@ -1,9 +1,9 @@
 import Tables, stint
-import eventemitter
 import ./controller_interface
 import ./io_interface
 
-import ../../../../app/core/signals/types
+import ../../../core/eventemitter
+import ../../../core/signals/types
 import ../../../../app_service/service/activity_center/service as activity_center_service
 import ../../../../app_service/service/contacts/service as contacts_service
 import ../../../../app_service/service/chat/service as chat_service

--- a/src/app/modules/main/activity_center/module.nim
+++ b/src/app/modules/main/activity_center/module.nim
@@ -1,11 +1,11 @@
 import NimQml, Tables, stint, sugar, sequtils
 
-import eventemitter
 import ./io_interface, ./view, ./controller
 import ./item as notification_item
 import ../../shared_models/message_item as message_item
 import ../../shared_models/message_item_qobject as message_item_qobject
 import ../../../global/global_singleton
+import ../../../core/eventemitter
 import ../../../../app_service/service/activity_center/service as activity_center_service
 import ../../../../app_service/service/contacts/service as contacts_service
 

--- a/src/app/modules/main/app_search/controller.nim
+++ b/src/app/modules/main/app_search/controller.nim
@@ -8,7 +8,7 @@ import ../../../../app_service/service/community/service as community_service
 import ../../../../app_service/service/message/service as message_service
 
 import ../../../core/signals/types
-import eventemitter
+import ../../../core/eventemitter
 
 export controller_interface
 

--- a/src/app/modules/main/app_search/module.nim
+++ b/src/app/modules/main/app_search/module.nim
@@ -10,12 +10,11 @@ import ../../shared_models/message_item
 
 import ../../../global/global_singleton
 import ../../../global/app_sections_config as conf
+import ../../../core/eventemitter
 import ../../../../app_service/service/contacts/service as contact_service
 import ../../../../app_service/service/chat/service as chat_service
 import ../../../../app_service/service/community/service as community_service
 import ../../../../app_service/service/message/service as message_service
-
-import eventemitter
 
 export io_interface
 

--- a/src/app/modules/main/chat_section/chat_content/controller.nim
+++ b/src/app/modules/main/chat_section/chat_content/controller.nim
@@ -10,7 +10,7 @@ import ../../../../../app_service/service/community/service as community_service
 import ../../../../../app_service/service/message/service as message_service
 
 import ../../../../core/signals/types
-import eventemitter
+import ../../../../core/eventemitter
 
 export controller_interface
 

--- a/src/app/modules/main/chat_section/chat_content/messages/controller.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/controller.nim
@@ -7,7 +7,7 @@ import ../../../../../../app_service/service/community/service as community_serv
 import ../../../../../../app_service/service/chat/service as chat_service
 import ../../../../../../app_service/service/message/service as message_service
 
-import eventemitter
+import ../../../../../core/eventemitter
 
 export controller_interface
 

--- a/src/app/modules/main/chat_section/chat_content/messages/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/module.nim
@@ -6,13 +6,11 @@ import ../../../../shared_models/message_model
 import ../../../../shared_models/message_item
 import ../../../../shared_models/message_reaction_item
 import ../../../../../global/global_singleton
-
+import ../../../../../core/eventemitter
 import ../../../../../../app_service/service/contacts/service as contact_service
 import ../../../../../../app_service/service/community/service as community_service
 import ../../../../../../app_service/service/chat/service as chat_service
 import ../../../../../../app_service/service/message/service as message_service
-
-import eventemitter
 
 export io_interface
 

--- a/src/app/modules/main/chat_section/chat_content/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/module.nim
@@ -6,6 +6,7 @@ import ../../../shared_models/message_model as pinned_msg_model
 import ../../../shared_models/message_item as pinned_msg_item
 import ../../../shared_models/message_reaction_item as pinned_msg_reaction_item
 import ../../../../global/global_singleton
+import ../../../../core/eventemitter
 
 import input_area/module as input_area_module
 import messages/module as messages_module
@@ -16,8 +17,6 @@ import ../../../../../app_service/service/contacts/service as contact_service
 import ../../../../../app_service/service/chat/service as chat_service
 import ../../../../../app_service/service/community/service as community_service
 import ../../../../../app_service/service/message/service as message_service
-
-import eventemitter
 
 export io_interface
 

--- a/src/app/modules/main/chat_section/chat_content/users/controller.nim
+++ b/src/app/modules/main/chat_section/chat_content/users/controller.nim
@@ -6,7 +6,7 @@ import ../../../../../../app_service/service/contacts/service as contact_service
 import ../../../../../../app_service/service/community/service as community_service
 import ../../../../../../app_service/service/message/service as message_service
 
-import eventemitter
+import ../../../../../core/eventemitter
 
 export controller_interface
 

--- a/src/app/modules/main/chat_section/chat_content/users/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/users/module.nim
@@ -3,12 +3,10 @@ import io_interface
 import ../io_interface as delegate_interface
 import view, item, model, controller
 import ../../../../../global/global_singleton
-
+import ../../../../../core/eventemitter
 import ../../../../../../app_service/service/contacts/service as contact_service
 import ../../../../../../app_service/service/community/service as community_service
 import ../../../../../../app_service/service/message/service as message_service
-
-import eventemitter
 
 export io_interface
 

--- a/src/app/modules/main/chat_section/controller.nim
+++ b/src/app/modules/main/chat_section/controller.nim
@@ -9,7 +9,7 @@ import ../../../../app_service/service/chat/service as chat_service
 import ../../../../app_service/service/community/service as community_service
 import ../../../../app_service/service/message/service as message_service
 
-import eventemitter
+import ../../../core/eventemitter
 
 export controller_interface
 

--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -8,13 +8,12 @@ import ../../shared_models/contacts_model as contacts_model
 import chat_content/module as chat_content_module
 
 import ../../../global/global_singleton
+import ../../../core/eventemitter
 import ../../../../app_service/service/settings/service_interface as settings_service
 import ../../../../app_service/service/contacts/service as contact_service
 import ../../../../app_service/service/chat/service as chat_service
 import ../../../../app_service/service/community/service as community_service
 import ../../../../app_service/service/message/service as message_service
-
-import eventemitter
 
 export io_interface
 

--- a/src/app/modules/main/chat_section/private_interfaces/module_access_interface.nim
+++ b/src/app/modules/main/chat_section/private_interfaces/module_access_interface.nim
@@ -6,7 +6,7 @@ import ../../../../../app_service/service/chat/service as chat_service
 import ../../../../../app_service/service/community/service as community_service
 import ../../../../../app_service/service/message/service as message_service
 
-import eventemitter
+import ../../../../core/eventemitter
 
 method delete*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/communities/controller.nim
+++ b/src/app/modules/main/communities/controller.nim
@@ -1,9 +1,9 @@
 import Tables, stint
-import eventemitter
 import ./controller_interface
 import ./io_interface
 
-import ../../../../app/core/signals/types
+import ../../../core/signals/types
+import ../../../core/eventemitter
 import ../../../../app_service/service/community/service as community_service
 
 export controller_interface

--- a/src/app/modules/main/communities/module.nim
+++ b/src/app/modules/main/communities/module.nim
@@ -1,12 +1,12 @@
 import NimQml, json, sequtils, sugar
 
-import eventemitter
 import ./io_interface
 import ../io_interface as delegate_interface
 import ./view, ./controller
 import ../../shared_models/section_item
 import ../../shared_models/member_item
 import ../../../global/global_singleton
+import ../../../core/eventemitter
 import ../../../../app_service/service/community/service as community_service
 
 export io_interface

--- a/src/app/modules/main/controller.nim
+++ b/src/app/modules/main/controller.nim
@@ -1,6 +1,8 @@
 import ../shared_models/section_item, controller_interface, io_interface, chronicles
 import ../../global/global_singleton
 import ../../global/app_signals
+import ../../core/signals/types
+import ../../core/eventemitter
 import ../../../app_service/service/settings/service_interface as settings_service
 import ../../../app_service/service/keychain/service as keychain_service
 import ../../../app_service/service/accounts/service_interface as accounts_service
@@ -8,9 +10,6 @@ import ../../../app_service/service/chat/service as chat_service
 import ../../../app_service/service/community/service as community_service
 import ../../../app_service/service/contacts/service as contacts_service
 import ../../../app_service/service/message/service as message_service
-
-import ../../core/signals/types
-import eventemitter
 
 export controller_interface
 

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -42,7 +42,7 @@ import ../../../app_service/service/node_configuration/service_interface as node
 import ../../../app_service/service/devices/service as devices_service
 import ../../../app_service/service/mailservers/service as mailservers_service
 
-import eventemitter
+import ../../core/eventemitter
 
 export io_interface
 

--- a/src/app/modules/main/node_section/controller.nim
+++ b/src/app/modules/main/node_section/controller.nim
@@ -6,8 +6,8 @@ import ../../../../app_service/service/settings/service_interface as settings_se
 import ../../../../app_service/service/node/service as node_service
 import ../../../../app_service/service/node_configuration/service as node_configuration_service
 
-import eventemitter
 import ../../../core/signals/types
+import ../../../core/eventemitter
 import ../../../core/fleets/fleet_configuration
 
 export controller_interface

--- a/src/app/modules/main/node_section/module.nim
+++ b/src/app/modules/main/node_section/module.nim
@@ -5,14 +5,11 @@ import ../io_interface as delegate_interface
 import view, controller
 
 import ../../../global/global_singleton
-
+import ../../../core/signals/types
+import ../../../core/eventemitter
 import ../../../../app_service/service/settings/service_interface as settings_service
 import ../../../../app_service/service/node/service as node_service
 import ../../../../app_service/service/node_configuration/service as node_configuration_service
-
-import ../../../core/signals/types
-
-import eventemitter
 
 export io_interface
 

--- a/src/app/modules/main/private_interfaces/module_access_interface.nim
+++ b/src/app/modules/main/private_interfaces/module_access_interface.nim
@@ -4,7 +4,7 @@ import ../../../../app_service/service/chat/service as chat_service
 import ../../../../app_service/service/community/service as community_service
 import ../../../../app_service/service/message/service as message_service
 
-import eventemitter
+import ../../../core/eventemitter
 
 method delete*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/profile_section/about/controller.nim
+++ b/src/app/modules/main/profile_section/about/controller.nim
@@ -1,7 +1,7 @@
 import ./controller_interface
-import eventemitter
 import io_interface
 import ../../../../../app_service/service/about/service as about_service
+import ../../../../core/eventemitter
 
 export controller_interface
 

--- a/src/app/modules/main/profile_section/about/module.nim
+++ b/src/app/modules/main/profile_section/about/module.nim
@@ -1,10 +1,9 @@
 import NimQml
-import eventemitter
 
 import ./io_interface, ./view, ./controller
 import ../io_interface as delegate_interface
 import ../../../../global/global_singleton
-
+import ../../../../core/eventemitter
 import ../../../../../app_service/service/about/service as about_service
 
 export io_interface

--- a/src/app/modules/main/profile_section/advanced/controller.nim
+++ b/src/app/modules/main/profile_section/advanced/controller.nim
@@ -2,12 +2,11 @@ import Tables, chronicles
 import controller_interface
 import io_interface
 
-import ../../../../core/fleets/fleet_configuration
 import ../../../../global/app_signals
+import ../../../../core/eventemitter
+import ../../../../core/fleets/fleet_configuration
 import ../../../../../app_service/service/settings/service_interface as settings_service
 import ../../../../../app_service/service/node_configuration/service_interface as node_configuration_service
-
-import eventemitter
 
 export controller_interface
 

--- a/src/app/modules/main/profile_section/advanced/module.nim
+++ b/src/app/modules/main/profile_section/advanced/module.nim
@@ -4,11 +4,10 @@ import ../io_interface as delegate_interface
 import view, controller, custom_networks_model
 
 import ../../../../../constants
+import ../../../../core/eventemitter
 import ../../../../global/global_singleton
 import ../../../../../app_service/service/settings/service_interface as settings_service
 import ../../../../../app_service/service/node_configuration/service_interface as node_configuration_service
-
-import eventemitter
 
 export io_interface
 

--- a/src/app/modules/main/profile_section/contacts/controller.nim
+++ b/src/app/modules/main/profile_section/contacts/controller.nim
@@ -1,9 +1,8 @@
 import ./controller_interface
 import io_interface
 
+import ../../../../core/eventemitter
 import ../../../../../app_service/service/contacts/service as contacts_service
-
-import eventemitter
 
 export controller_interface
 

--- a/src/app/modules/main/profile_section/contacts/module.nim
+++ b/src/app/modules/main/profile_section/contacts/module.nim
@@ -5,9 +5,8 @@ import ../../../shared_models/contacts_item
 import ../../../shared_models/contacts_model
 import ../io_interface as delegate_interface
 
+import ../../../../core/eventemitter
 import ../../../../../app_service/service/contacts/service as contacts_service
-
-import eventemitter
 
 export io_interface
 

--- a/src/app/modules/main/profile_section/devices/controller.nim
+++ b/src/app/modules/main/profile_section/devices/controller.nim
@@ -2,10 +2,9 @@ import Tables, chronicles
 import controller_interface
 import io_interface
 
+import ../../../../core/eventemitter
 import ../../../../../app_service/service/settings/service_interface as settings_service
 import ../../../../../app_service/service/devices/service as devices_service
-
-import eventemitter
 
 export controller_interface
 

--- a/src/app/modules/main/profile_section/devices/module.nim
+++ b/src/app/modules/main/profile_section/devices/module.nim
@@ -3,10 +3,9 @@ import io_interface
 import ../io_interface as delegate_interface
 import view, controller, model, item
 
+import ../../../../core/eventemitter
 import ../../../../../app_service/service/settings/service_interface as settings_service
 import ../../../../../app_service/service/devices/service as devices_service
-
-import eventemitter
 
 export io_interface
 

--- a/src/app/modules/main/profile_section/module.nim
+++ b/src/app/modules/main/profile_section/module.nim
@@ -1,7 +1,7 @@
 import NimQml
 import io_interface, view, controller
 import ../../../global/global_singleton
-
+import ../../../core/eventemitter
 import ../../../../app_service/service/profile/service as profile_service
 import ../../../../app_service/service/accounts/service as accounts_service
 import ../../../../app_service/service/settings/service_interface as settings_service
@@ -23,8 +23,6 @@ import ./advanced/module as advanced_module
 import ./devices/module as devices_module
 import ./sync/module as sync_module
 import ./notifications/module as notifications_module
-
-import eventemitter
 
 export io_interface
 

--- a/src/app/modules/main/profile_section/notifications/controller.nim
+++ b/src/app/modules/main/profile_section/notifications/controller.nim
@@ -2,9 +2,8 @@ import Tables, chronicles
 import controller_interface
 import io_interface
 
+import ../../../../core/eventemitter
 import ../../../../../app_service/service/chat/service as chat_service
-
-import eventemitter
 
 export controller_interface
 

--- a/src/app/modules/main/profile_section/notifications/module.nim
+++ b/src/app/modules/main/profile_section/notifications/module.nim
@@ -3,9 +3,8 @@ import io_interface
 import ../io_interface as delegate_interface
 import view, controller, model, item
 
+import ../../../../core/eventemitter
 import ../../../../../app_service/service/chat/service as chat_service
-
-import eventemitter
 
 export io_interface
 

--- a/src/app/modules/main/profile_section/privacy/controller.nim
+++ b/src/app/modules/main/profile_section/privacy/controller.nim
@@ -1,10 +1,9 @@
 import ./controller_interface
 import io_interface
 
+import ../../../../core/eventemitter
 import ../../../../../app_service/service/settings/service_interface as settings_service
 import ../../../../../app_service/service/privacy/service as privacy_service
-
-import eventemitter
 
 export controller_interface
 

--- a/src/app/modules/main/profile_section/privacy/module.nim
+++ b/src/app/modules/main/profile_section/privacy/module.nim
@@ -3,10 +3,9 @@ import NimQml, chronicles
 import ./io_interface, ./view, ./controller
 import ../io_interface as delegate_interface
 
+import ../../../../core/eventemitter
 import ../../../../../app_service/service/settings/service_interface as settings_service
 import ../../../../../app_service/service/privacy/service as privacy_service
-
-import eventemitter
 
 export io_interface
 

--- a/src/app/modules/main/profile_section/sync/controller.nim
+++ b/src/app/modules/main/profile_section/sync/controller.nim
@@ -2,11 +2,10 @@ import Tables, chronicles
 import controller_interface
 import io_interface
 
+import ../../../../core/eventemitter
 import ../../../../core/fleets/fleet_configuration
 import ../../../../../app_service/service/settings/service_interface as settings_service
 import ../../../../../app_service/service/mailservers/service as mailservers_service
-
-import eventemitter
 
 export controller_interface
 

--- a/src/app/modules/main/profile_section/sync/module.nim
+++ b/src/app/modules/main/profile_section/sync/module.nim
@@ -3,10 +3,9 @@ import io_interface
 import ../io_interface as delegate_interface
 import view, controller, model, item
 
+import ../../../../core/eventemitter
 import ../../../../../app_service/service/settings/service_interface as settings_service
 import ../../../../../app_service/service/mailservers/service as mailservers_service
-
-import eventemitter
 
 export io_interface
 

--- a/src/app/modules/main/stickers/controller.nim
+++ b/src/app/modules/main/stickers/controller.nim
@@ -1,7 +1,9 @@
 import Tables, stint
-import eventemitter
+
 import ./controller_interface
 import ./io_interface
+
+import ../../../core/eventemitter
 import ../../../../app_service/service/stickers/service as stickers_service
 import ../../../../app_service/service/eth/utils as eth_utils
 

--- a/src/app/modules/main/stickers/module.nim
+++ b/src/app/modules/main/stickers/module.nim
@@ -1,8 +1,8 @@
 import NimQml, Tables, stint, sugar, sequtils
 
-import eventemitter
 import ./io_interface, ./view, ./controller, ./item
 import ../../../global/global_singleton
+import ../../../core/eventemitter
 import ../../../../app_service/service/stickers/service as stickers_service
 
 export io_interface

--- a/src/app/modules/main/wallet_section/account_tokens/module.nim
+++ b/src/app/modules/main/wallet_section/account_tokens/module.nim
@@ -1,8 +1,9 @@
 import NimQml, sequtils, sugar
-import eventemitter
+
 import ./io_interface, ./view, ./controller, ./item
 import ../io_interface as delegate_interface
 import ../../../../global/global_singleton
+import ../../../../core/eventemitter
 import ../../../../../app_service/service/wallet_account/service as wallet_account_service
 
 export io_interface

--- a/src/app/modules/main/wallet_section/accounts/module.nim
+++ b/src/app/modules/main/wallet_section/accounts/module.nim
@@ -1,9 +1,9 @@
 import NimQml, sequtils, sugar
-import eventemitter
 
 import ./io_interface, ./view, ./item, ./controller
 import ../io_interface as delegate_interface
 import ../../../../global/global_singleton
+import ../../../../core/eventemitter
 import ../../../../../app_service/service/wallet_account/service as wallet_account_service
 import ../account_tokens/model as account_tokens
 import ../account_tokens/item as account_tokens_item

--- a/src/app/modules/main/wallet_section/all_tokens/controller.nim
+++ b/src/app/modules/main/wallet_section/all_tokens/controller.nim
@@ -1,6 +1,7 @@
 import ./controller_interface
 import ./io_interface
-import eventemitter
+
+import ../../../../core/eventemitter
 import ../../../../../app_service/service/token/service as token_service
 import ../../../../../app_service/service/wallet_account/service as wallet_account_service
 

--- a/src/app/modules/main/wallet_section/all_tokens/module.nim
+++ b/src/app/modules/main/wallet_section/all_tokens/module.nim
@@ -1,10 +1,10 @@
 import NimQml, sequtils, sugar
 
-import eventemitter
-
 import ./io_interface, ./view, ./controller, ./item
 import ../io_interface as delegate_interface
+
 import ../../../../global/global_singleton
+import ../../../../core/eventemitter
 import ../../../../../app_service/service/token/service as token_service
 import ../../../../../app_service/service/wallet_account/service as wallet_account_service
 

--- a/src/app/modules/main/wallet_section/collectibles/module.nim
+++ b/src/app/modules/main/wallet_section/collectibles/module.nim
@@ -1,7 +1,6 @@
-import eventemitter
-
 import ./io_interface, ./controller
 import ../io_interface as delegate_interface
+import ../../../../core/eventemitter
 import ../../../../../app_service/service/collectible/service as collectible_service
 import ../../../../../app_service/service/wallet_account/service as wallet_account_service
 

--- a/src/app/modules/main/wallet_section/current_account/module.nim
+++ b/src/app/modules/main/wallet_section/current_account/module.nim
@@ -1,6 +1,7 @@
 import NimQml
-import eventemitter
+
 import ../../../../global/global_singleton
+import ../../../../core/eventemitter
 import ../../../../../app_service/service/wallet_account/service as wallet_account_service
 
 import ./io_interface, ./view, ./controller

--- a/src/app/modules/main/wallet_section/module.nim
+++ b/src/app/modules/main/wallet_section/module.nim
@@ -1,9 +1,7 @@
 import NimQml
-import eventemitter
 
 import ./controller, ./view
 import ./io_interface as io_interface
-import ../../../global/global_singleton
 
 import ./account_tokens/module as account_tokens_module
 import ./accounts/module as accountsModule
@@ -13,7 +11,8 @@ import ./current_account/module as current_account_module
 import ./transactions/module as transactions_module
 import ./saved_addresses/module as saved_addresses_module
 
-
+import ../../../global/global_singleton
+import ../../../core/eventemitter
 import ../../../../app_service/service/token/service as token_service
 import ../../../../app_service/service/transaction/service as transaction_service
 import ../../../../app_service/service/collectible/service as collectible_service

--- a/src/app/modules/main/wallet_section/saved_addresses/controller.nim
+++ b/src/app/modules/main/wallet_section/saved_addresses/controller.nim
@@ -1,6 +1,6 @@
-import eventemitter
 import ./controller_interface
 import io_interface
+import ../../../../core/eventemitter
 import ../../../../../app_service/service/saved_address/service as saved_address_service
 
 export controller_interface

--- a/src/app/modules/main/wallet_section/saved_addresses/module.nim
+++ b/src/app/modules/main/wallet_section/saved_addresses/module.nim
@@ -1,7 +1,8 @@
 import NimQml, sugar, sequtils
-import eventemitter
 import ../io_interface as delegate_interface
+
 import ../../../../global/global_singleton
+import ../../../../core/eventemitter
 import ../../../../../app_service/service/saved_address/service as saved_address_service
 
 import ./io_interface, ./view, ./controller, ./item

--- a/src/app/modules/main/wallet_section/transactions/controller.nim
+++ b/src/app/modules/main/wallet_section/transactions/controller.nim
@@ -1,15 +1,10 @@
-import NimQml, json, json_serialization, stint, tables, eventemitter, sugar, sequtils
+import NimQml, json, json_serialization, stint, tables, sugar, sequtils
 import ./controller_interface
 import io_interface
 import ../../../../../app_service/service/transaction/service as transaction_service
 import ../../../../../app_service/service/wallet_account/service as wallet_account_service
 
-import
-  status/[status, wallet]
-
 export controller_interface
-
-import status/types/transaction
 
 import ../../../../core/[main]
 import ../../../../core/tasks/[qt, threadpool]

--- a/src/app/modules/main/wallet_section/transactions/model.nim
+++ b/src/app/modules/main/wallet_section/transactions/model.nim
@@ -1,7 +1,7 @@
 import NimQml, Tables, strutils, strformat, sequtils, tables, sugar, algorithm
 
-import status/utils
 import ./item
+import ../../../../../app_service/service/eth/utils as eth_service_utils
 import ../../../../../app_service/service/transaction/dto
 
 type
@@ -174,7 +174,7 @@ QtObject:
 
       var allTxs = self.items.concat(newTxItems)
       allTxs.sort(cmpTransactions, SortOrder.Descending)
-      allTxs.deduplicate(tx => tx.getId())
+      eth_service_utils.deduplicate(allTxs, tx => tx.getId())
       
       self.setItems(allTxs)
       self.setHasMore(true)

--- a/src/app/modules/main/wallet_section/transactions/module.nim
+++ b/src/app/modules/main/wallet_section/transactions/module.nim
@@ -1,8 +1,9 @@
-import NimQml, eventemitter, stint
+import NimQml, stint
 
 import ./io_interface, ./view, ./controller
 import ../io_interface as delegate_interface
 import ../../../../global/global_singleton
+import ../../../../core/eventemitter
 import ../../../../../app_service/service/transaction/service as transaction_service
 import ../../../../../app_service/service/wallet_account/service as wallet_account_service
 

--- a/src/app/modules/startup/controller.nim
+++ b/src/app/modules/startup/controller.nim
@@ -3,11 +3,10 @@ import Tables, chronicles
 import controller_interface
 import io_interface
 
+import ../../core/signals/types
+import ../../core/eventemitter
 import ../../../app_service/service/keychain/service as keychain_service
 import ../../../app_service/service/accounts/service_interface as accounts_service
-
-import ../../core/signals/types
-import eventemitter
 
 export controller_interface
 

--- a/src/app/modules/startup/login/controller.nim
+++ b/src/app/modules/startup/login/controller.nim
@@ -3,12 +3,10 @@ import NimQml, Tables
 import controller_interface
 import io_interface
 import ../../../global/global_singleton
-
+import ../../../core/signals/types
+import ../../../core/eventemitter
 import ../../../../app_service/service/keychain/service as keychain_service
 import ../../../../app_service/service/accounts/service_interface as accounts_service
-
-import ../../../core/signals/types
-import eventemitter
 
 export controller_interface
 

--- a/src/app/modules/startup/login/module.nim
+++ b/src/app/modules/startup/login/module.nim
@@ -3,11 +3,9 @@ import io_interface
 import ../io_interface as delegate_interface
 import view, controller, item
 import ../../../global/global_singleton
-
+import ../../../core/eventemitter
 import ../../../../app_service/service/keychain/service as keychain_service
 import ../../../../app_service/service/accounts/service_interface as accounts_service
-
-import eventemitter
 
 export io_interface
 

--- a/src/app/modules/startup/module.nim
+++ b/src/app/modules/startup/module.nim
@@ -3,14 +3,12 @@ import NimQml
 import io_interface
 import view, controller
 import ../../global/global_singleton
-
+import ../../core/eventemitter
 import onboarding/module as onboarding_module
 import login/module as login_module
 
 import ../../../app_service/service/keychain/service as keychain_service
 import ../../../app_service/service/accounts/service_interface as accounts_service
-
-import eventemitter
 
 export io_interface
 

--- a/src/app/modules/startup/onboarding/controller.nim
+++ b/src/app/modules/startup/onboarding/controller.nim
@@ -3,10 +3,9 @@ import Tables, chronicles
 import controller_interface
 import io_interface
 
-import ../../../../app_service/service/accounts/service_interface as accounts_service
-
 import ../../../core/signals/types
-import eventemitter
+import ../../../core/eventemitter
+import ../../../../app_service/service/accounts/service_interface as accounts_service
 
 export controller_interface
 

--- a/src/app/modules/startup/onboarding/module.nim
+++ b/src/app/modules/startup/onboarding/module.nim
@@ -3,10 +3,8 @@ import io_interface
 import ../io_interface as delegate_interface
 import view, controller, item
 import ../../../global/global_singleton
-
+import ../../../core/eventemitter
 import ../../../../app_service/service/accounts/service_interface as accounts_service
-
-import eventemitter
 
 export io_interface
 

--- a/src/app_service/service/about/service.nim
+++ b/src/app_service/service/about/service.nim
@@ -1,6 +1,6 @@
 import NimQml, json, chronicles
 
-import eventemitter
+import ../../../app/core/eventemitter
 import ../../../app/core/tasks/[qt, threadpool]
 
 import ../settings/service as settings_service

--- a/src/app_service/service/activity_center/service.nim
+++ b/src/app_service/service/activity_center/service.nim
@@ -1,6 +1,6 @@
 import NimQml, json, sequtils, chronicles, strutils, strutils, stint
 
-import eventemitter
+import ../../../app/core/eventemitter
 import ../../../app/core/[main]
 import ../../../app/core/tasks/[qt, threadpool]
 

--- a/src/app_service/service/chat/service.nim
+++ b/src/app_service/service/chat/service.nim
@@ -7,15 +7,10 @@ import ../contacts/service as contact_service
 import status/statusgo_backend_new/chat as status_chat
 import status/statusgo_backend_new/chatCommands as status_chat_commands
 import ../../../app/global/global_singleton
+import ../../../app/core/eventemitter
 import ../../../constants
 
 from ../../common/account_constants import ZERO_ADDRESS
-
-# TODO: We need to remove these `status-lib` types from here
-import status/types/[message]
-import status/types/chat as chat_type
-
-import eventemitter
 
 export chat_dto
 

--- a/src/app_service/service/community/service.nim
+++ b/src/app_service/service/community/service.nim
@@ -1,12 +1,14 @@
 import NimQml, Tables, json, sequtils, std/algorithm, strformat, chronicles, json_serialization
 
-import eventemitter
 import ./dto/community as community_dto
-export community_dto
-import ../../../app/global/global_singleton
+
 import ../chat/service as chat_service
 
+import ../../../app/global/global_singleton
+import ../../../app/core/eventemitter
 import status/statusgo_backend_new/communities as status_go
+
+export community_dto
 
 logScope:
   topics = "community-service"

--- a/src/app_service/service/contacts/async_tasks.nim
+++ b/src/app_service/service/contacts/async_tasks.nim
@@ -1,5 +1,5 @@
 import os
-import status/ens as status_ens
+import ../ens/utils as ens_utils
 
 include ../../common/json_utils
 include ../../../app/core/tasks/common
@@ -19,8 +19,8 @@ const lookupContactTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
   var address = ""
   if not pubkey.startsWith("0x"):
     # TODO refactor those calls to use the new backend and also do it in a signle call
-    pubkey = status_ens.pubkey(arg.value)
-    address = status_ens.address(arg.value)
+    pubkey = ens_utils.pubkey(arg.value)
+    address = ens_utils.address(arg.value)
   
   let output = %*{
     "id": pubkey,

--- a/src/app_service/service/contacts/service.nim
+++ b/src/app_service/service/contacts/service.nim
@@ -2,6 +2,7 @@ import NimQml, Tables, json, sequtils, strformat, chronicles, strutils, times, s
 
 import ../../../app/global/global_singleton
 import ../../../app/core/signals/types
+import ../../../app/core/eventemitter
 import ../../../app/core/tasks/[qt, threadpool]
 
 import ./dto/contacts as contacts_dto
@@ -11,8 +12,6 @@ import status/statusgo_backend_new/contacts as status_contacts
 import status/statusgo_backend_new/accounts as status_accounts
 import status/statusgo_backend_new/chat as status_chat
 import status/statusgo_backend_new/utils as status_utils
-
-import eventemitter
 
 export contacts_dto, status_update_dto, contact_details
 

--- a/src/app_service/service/devices/service.nim
+++ b/src/app_service/service/devices/service.nim
@@ -1,11 +1,11 @@
 import NimQml, json, sequtils, system, chronicles
 
-import ../../../app/core/signals/types
 import ./dto/device as device_dto
 import ../settings/service as settings_service
-import status/statusgo_backend_new/installations as status_installations
 
-import eventemitter
+import ../../../app/core/signals/types
+import ../../../app/core/eventemitter
+import status/statusgo_backend_new/installations as status_installations
 
 export device_dto
 

--- a/src/app_service/service/eth/dto/contract.nim
+++ b/src/app_service/service/eth/dto/contract.nim
@@ -4,7 +4,10 @@ import
 import
   web3/ethtypes, stew/byteutils, nimcrypto, json_serialization, chronicles
 import json, tables, json_serialization
+import web3/[ethtypes, conversions], stint
 import ./method_dto
+
+import status/statusgo_backend_new/eth as status_eth
 
 include  ../../../common/json_utils
 
@@ -33,3 +36,37 @@ proc newErc20Contract*(chainId: int, address: Address): Erc20ContractDto =
 
 proc newErc721Contract*(name: string, chainId: int, address: Address, symbol: string, hasIcon: bool, addlMethods: seq[tuple[name: string, meth: MethodDto]] = @[]): Erc721ContractDto =
   Erc721ContractDto(name: name, chainId: chainId, address: address, symbol: symbol, hasIcon: hasIcon, methods: ERC721_ENUMERABLE_METHODS.concat(addlMethods).toTable)
+
+proc tokenDecimals*(contract: ContractDto): int =
+  let payload = %* [{
+      "to": $contract.address,
+      "data": contract.methods["decimals"].encodeAbi()
+    }, "latest"]
+
+  let response = status_eth.doEthCall(payload)
+  if not response.error.isNil:
+    raise newException(RpcException, "Error getting token decimals: " & response.error.message)
+  if response.result.getStr == "0x":
+    return 0
+  result = parseHexInt(response.result.getStr)
+
+proc getTokenString*(contract: ContractDto, methodName: string): string =
+  let payload = %* [{
+      "to": $contract.address,
+      "data": contract.methods[methodName].encodeAbi()
+    }, "latest"]
+
+  let response = status_eth.doEthCall(payload)
+  if not response.error.isNil:
+    raise newException(RpcException, "Error getting token string - " & methodName & ": " & response.error.message)
+  if response.result.getStr == "0x":
+    return ""
+
+  let size = fromHex(Stuint[256], response.result.getStr[66..129]).truncate(int)
+  result = response.result.getStr[130..129+size*2].parseHexStr
+
+proc tokenName*(contract: ContractDto): string = 
+  getTokenString(contract, "name")
+
+proc tokenSymbol*(contract: ContractDto): string = 
+  getTokenString(contract, "symbol")

--- a/src/app_service/service/eth/dto/method_dto.nim
+++ b/src/app_service/service/eth/dto/method_dto.nim
@@ -6,14 +6,9 @@ import
 
 import status/statusgo_backend_new/eth as status_eth
 
-import 
-  status/types/rpc_response,
-  status/statusgo_backend/eth
-
 import
   ./transaction,
   ./coder
-
 
 
 type MethodDto* = object
@@ -83,8 +78,9 @@ proc estimateGas*(self: MethodDto, tx: var TransactionDataDto, methodDescriptor:
   success = true
   tx.data = self.encodeAbi(methodDescriptor)
   try:
-    let response = eth.estimateGas(%*[%tx])
-    result = response.result # gas estimate in hex
+    # this call should not be part of this file, we need to move it to appropriate place, or this should not be a DTO class.
+    let response = status_eth.estimateGas(%*[%tx])
+    result = response.result.getStr # gas estimate in hex
   except RpcException as e:
     success = false
     result = e.msg
@@ -95,15 +91,17 @@ proc getEstimateGasData*(self: MethodDto, tx: var TransactionDataDto, methodDesc
 
 proc send*(self: MethodDto, tx: var TransactionDataDto, methodDescriptor: object, password: string, success: var bool): string =
   tx.data = self.encodeAbi(methodDescriptor)
+  # this call should not be part of this file, we need to move it to appropriate place, or this should not be a DTO class.
   let response = status_eth.sendTransaction($(%tx), password)
   return $response.result
 
-proc call*[T](self: MethodDto, tx: var TransactionDataDto, methodDescriptor: object, success: var bool): T =
+proc call[T](self: MethodDto, tx: var TransactionDataDto, methodDescriptor: object, success: var bool): T =
   success = true
   tx.data = self.encodeAbi(methodDescriptor)
   let response: RpcResponse
   try:
-    response = eth.call(tx)
+    # this call should not be part of this file, we need to move it to appropriate place, or this should not be a DTO class.
+    response = status_eth.doEthCall(tx)
   except RpcException as e:
     success = false
     result = e.msg

--- a/src/app_service/service/eth/dto/transaction.nim
+++ b/src/app_service/service/eth/dto/transaction.nim
@@ -1,30 +1,14 @@
 import strutils, json
 import web3/ethtypes, web3/conversions, options, stint
+import ../utils
 
-type
-  TransactionDto* = ref object
-    id*: string
-    typeValue*: string
-    address*: string
-    blockNumber*: string
-    blockHash*: string
-    contract*: string
-    timestamp*: string
-    gasPrice*: string
-    gasLimit*: string
-    gasUsed*: string
-    nonce*: string
-    txStatus*: string
-    value*: string
-    fromAddress*: string
-    to*: string
-  
-type PendingTransactionTypeDto* {.pure.} = enum
-  RegisterENS = "RegisterENS",
-  SetPubKey = "SetPubKey",
-  ReleaseENS = "ReleaseENS",
-  BuyStickerPack = "BuyStickerPack"
-  WalletTransfer = "WalletTransfer" 
+type 
+  PendingTransactionTypeDto* {.pure.} = enum
+    RegisterENS = "RegisterENS",
+    SetPubKey = "SetPubKey",
+    ReleaseENS = "ReleaseENS",
+    BuyStickerPack = "BuyStickerPack"
+    WalletTransfer = "WalletTransfer" 
 
 type 
   TransactionDataDto* = object
@@ -38,21 +22,6 @@ type
     data*: string                # the compiled code of a contract OR the hash of the invoked method signature and encoded parameters. For details see Ethereum Contract ABI.
     nonce*: Option[Nonce]        # (optional) integer of a nonce. This allows to overwrite your own pending transactions that use the same nonce
     txType*: string
-
-proc cmpTransactions*(x, y: TransactionDto): int =
-  # Sort proc to compare transactions from a single account.
-  # Compares first by block number, then by nonce
-  result = cmp(x.blockNumber.parseHexInt, y.blockNumber.parseHexInt)
-  if result == 0:
-    result = cmp(x.nonce, y.nonce)
-
-# TODO: make this public in nim-web3 lib
-template stripLeadingZeros*(value: string): string =
-  var cidx = 0
-  # ignore the last character so we retain '0' on zero value
-  while cidx < value.len - 1 and value[cidx] == '0':
-    cidx.inc
-  value[cidx .. ^1]
 
 proc `%`*(x: TransactionDataDto): JsonNode =
   result = newJobject()

--- a/src/app_service/service/eth/service.nim
+++ b/src/app_service/service/eth/service.nim
@@ -1,12 +1,9 @@
 import json, sequtils, chronicles, macros, sugar, strutils, stint
-import
-  web3/ethtypes, json_serialization, chronicles, tables
+import web3/ethtypes, json_serialization, chronicles, tables
 
 import status/statusgo_backend_new/eth
 
-# TODO remove those
-import status/utils
-
+import utils
 import ./dto/contract
 import ./dto/method_dto
 import ./dto/network

--- a/src/app_service/service/eth/utils.nim
+++ b/src/app_service/service/eth/utils.nim
@@ -237,3 +237,11 @@ proc isUnique*[T](key: T, existingKeys: var seq[T]): bool =
 proc deduplicate*[T](txs: var seq[T], key: (T) -> string) =
   var existingKeys: seq[string] = @[]
   txs.keepIf(tx => tx.key().isUnique(existingKeys))
+
+# TODO: make this public in nim-web3 lib
+proc stripLeadingZeros*(value: string): string =
+  var cidx = 0
+  # ignore the last character so we retain '0' on zero value
+  while cidx < value.len - 1 and value[cidx] == '0':
+    cidx.inc
+  value[cidx .. ^1]

--- a/src/app_service/service/general/service.nim
+++ b/src/app_service/service/general/service.nim
@@ -1,0 +1,43 @@
+import json, chronicles
+
+import service_interface
+import status/statusgo_backend_new/general as status_general
+import status/statusgo_backend_new/keycard as status_keycard
+
+import ../../../constants as app_constants
+
+export service_interface
+
+logScope:
+  topics = "general-app-service"
+
+type
+  Service* = ref object of service_interface.ServiceInterface
+
+method delete*(self: Service) =
+  discard
+
+proc newService*(): Service =
+  result = Service()
+
+method initKeycard(self: Service) =
+  ## This should not be part of the "general service", but part of the "keystore service", but since we don't have
+  ## keycard in place for the refactored part yet but `status-go` part requires keycard to be initialized on the app 
+  ## start. This call is added as a part of the "global service".
+  try:
+    discard status_keycard.initKeycard(app_constants.KEYSTOREDIR)
+  except Exception as e:
+    let errDesription = e.msg
+    error "error: ", errDesription
+    return
+  
+method init*(self: Service) =
+  self.initKeycard()
+
+method startMessenger*(self: Service) =
+  try:
+    discard status_general.startMessenger()
+  except Exception as e:
+    let errDesription = e.msg
+    error "error: ", errDesription
+    return

--- a/src/app_service/service/general/service_interface.nim
+++ b/src/app_service/service/general/service_interface.nim
@@ -1,0 +1,12 @@
+type 
+  ServiceInterface* {.pure inheritable.} = ref object of RootObj
+  ## Abstract class for this service access.
+
+method delete*(self: ServiceInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method init*(self: ServiceInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method startMessenger*(self: ServiceInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")

--- a/src/app_service/service/keychain/service.nim
+++ b/src/app_service/service/keychain/service.nim
@@ -1,6 +1,6 @@
 import NimQml, chronicles
 
-import eventemitter
+import ../../../app/core/eventemitter
 
 logScope:
   topics = "keychain-service"

--- a/src/app_service/service/mailservers/service.nim
+++ b/src/app_service/service/mailservers/service.nim
@@ -9,8 +9,6 @@ import ../settings/service_interface as settings_service
 import ../node_configuration/service_interface as node_configuration_service
 import status/statusgo_backend_new/mailservers as status_mailservers
 
-import eventemitter
-
 logScope:
   topics = "mailservers-service"
 

--- a/src/app_service/service/message/dto/removed_message.nim
+++ b/src/app_service/service/message/dto/removed_message.nim
@@ -1,0 +1,14 @@
+{.used.}
+
+import json
+
+include ../../../common/json_utils
+
+type RemovedMessageDto* = object
+  chatId*: string
+  messageId*: string
+
+proc toRemovedMessageDto*(jsonObj: JsonNode): RemovedMessageDto =
+  result = RemovedMessageDto()
+  discard jsonObj.getProp("chatId", result.chatId)
+  discard jsonObj.getProp("messageId", result.messageId)

--- a/src/app_service/service/message/service.nim
+++ b/src/app_service/service/message/service.nim
@@ -1,9 +1,8 @@
 import NimQml, tables, json, sequtils, chronicles
 
-import eventemitter
 import ../../../app/core/tasks/[qt, threadpool]
 import ../../../app/core/signals/types
-
+import ../../../app/core/eventemitter
 import status/statusgo_backend_new/messages as status_go
 
 import ./dto/message as message_dto

--- a/src/app_service/service/node/service.nim
+++ b/src/app_service/service/node/service.nim
@@ -1,9 +1,8 @@
 import NimQml, chronicles, strutils, json, nimcrypto
-import status/utils
-import eventemitter
 
 import ../settings/service as settings_service
 
+import ../../../app/core/eventemitter
 import ../../../app/core/tasks/[qt, threadpool]
 import ../../../app/core/fleets/fleet_configuration
 

--- a/src/app_service/service/os_notification/service.nim
+++ b/src/app_service/service/os_notification/service.nim
@@ -1,6 +1,7 @@
 import NimQml, json, chronicles
 import details
-import eventemitter
+
+import ../../../app/core/eventemitter
 
 logScope:
   topics = "os-notification-service"

--- a/src/app_service/service/privacy/service.nim
+++ b/src/app_service/service/privacy/service.nim
@@ -3,11 +3,11 @@ import NimQml, json, strutils, chronicles
 import ../settings/service_interface as settings_service
 import ../accounts/service_interface as accounts_service
 
+import ../../../app/core/eventemitter
+
 import status/statusgo_backend_new/accounts as status_account
 import status/statusgo_backend_new/eth as status_eth
 import status/statusgo_backend_new/privacy as status_privacy
-
-import eventemitter
 
 logScope:
   topics = "privacy-service"

--- a/src/app_service/service/saved_address/service.nim
+++ b/src/app_service/service/saved_address/service.nim
@@ -1,6 +1,8 @@
 import chronicles, sequtils, json
-import eventemitter
+
 import ./service_interface, ./dto
+
+import ../../../app/core/eventemitter
 import status/statusgo_backend_new/saved_addresses as backend
 
 export service_interface

--- a/src/app_service/service/stickers/service.nim
+++ b/src/app_service/service/stickers/service.nim
@@ -1,7 +1,7 @@
 import NimQml, Tables, json, sequtils, chronicles, strutils, atomics, sets, strutils, tables, stint
 
 import httpclient
-import eventemitter
+
 import ../../../app/core/[main]
 import ../../../app/core/tasks/[qt, threadpool]
 

--- a/src/app_service/service/token/async_tasks.nim
+++ b/src/app_service/service/token/async_tasks.nim
@@ -1,7 +1,8 @@
 # include strformat, json
 include ../../common/json_utils
 include ../../../app/core/tasks/common
-import status/[utils, tokens]
+import ../eth/dto/contract
+import ../eth/utils
 
 #################################################
 # Async load transactions

--- a/src/app_service/service/token/service.nim
+++ b/src/app_service/service/token/service.nim
@@ -1,10 +1,12 @@
 import NimQml, json, sequtils, chronicles, strformat, strutils
-import eventemitter
+
 from sugar import `=>`
 import web3/ethtypes
 from web3/conversions import `$`
 import status/statusgo_backend_new/custom_tokens as custom_tokens
 import ../settings/service_interface as settings_service
+
+import ../../../app/core/eventemitter
 import ../../../app/core/tasks/[qt, threadpool]
 import ./dto, ./static_token
 

--- a/src/app_service/service/transaction/async_tasks.nim
+++ b/src/app_service/service/transaction/async_tasks.nim
@@ -1,5 +1,6 @@
 include ../../common/json_utils
 include ../../../app/core/tasks/common
+import strutils
 
 #################################################
 # Async load transactions
@@ -15,9 +16,10 @@ type
 const loadTransactionsTask*: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
   let
     arg = decode[LoadTransactionsTaskArg](argEncoded)
+    limitAsHex = "0x" & eth_utils.stripLeadingZeros(arg.limit.toHex)
     output = %*{
       "address": arg.address,
-      "history": transactions.getTransfersByAddress(arg.address, arg.toBlock, arg.limit, arg.loadMore),
+      "history": transactions.getTransfersByAddress(arg.address, arg.toBlock, limitAsHex, arg.loadMore),
       "loadMore": arg.loadMore
     }
   arg.finish(output)

--- a/src/app_service/service/transaction/dto.nim
+++ b/src/app_service/service/transaction/dto.nim
@@ -36,3 +36,11 @@ proc toTransactionDto*(jsonObj: JsonNode): TransactionDto =
   discard jsonObj.getProp("value", result.value)
   discard jsonObj.getProp("from", result.fromAddress)
   discard jsonObj.getProp("to", result.to)
+
+proc cmpTransactions*(x, y: TransactionDto): int =
+  # Sort proc to compare transactions from a single account.
+  # Compares first by block number, then by nonce
+  result = cmp(x.blockNumber.parseHexInt, y.blockNumber.parseHexInt)
+  if result == 0:
+    result = cmp(x.nonce, y.nonce)
+

--- a/src/app_service/service/wallet_account/service.nim
+++ b/src/app_service/service/wallet_account/service.nim
@@ -1,6 +1,5 @@
 import Tables, json, sequtils, sugar, chronicles, strformat, stint, httpclient, net, strutils
 import web3/[ethtypes, conversions]
-import eventemitter
 
 import ../settings/service_interface as settings_service
 import ../accounts/service_interface as accounts_service
@@ -8,6 +7,8 @@ import ../token/service as token_service
 import ../../common/account_constants
 
 import ./service_interface, ./dto
+
+import ../../../app/core/eventemitter
 import status/statusgo_backend_new/accounts as status_go_accounts
 import status/statusgo_backend_new/eth as status_go_eth
 


### PR DESCRIPTION
This PR removed all `status-lib` unnecessary dependencies we had in the `status-desktop`.

`EventEmitter` is part of the `status-desktop`

Corresponding `status-lib` part:
- https://github.com/status-im/status-lib/pull/160


An idea is when we have `base_bc` merged into the `master` branch to remove everything from the `status-lib` and make "statusgo_backend_new" part from there the main part of the `status-lib`. After this PR we are free to delete all unnecessary files from the `status-lib`. This is just an intermediate step to get there.

Fixes #4395