### PR TITLE
refactor(@desktop/chat): loading messages on join public chat

### DIFF
--- a/src/app/core/eventemitter.nim
+++ b/src/app/core/eventemitter.nim
@@ -57,4 +57,3 @@ when isMainModule:
       var args = ReadyArgs(a)
       echo args.text, ": from [2nd] handler"
     evts.emit("ready", ReadyArgs(text:"Hello, World"))
-    evts.emit("ready", ReadyArgs(text:"Hello, World"))

--- a/src/app/modules/main/chat_section/chat_content/controller.nim
+++ b/src/app/modules/main/chat_section/chat_content/controller.nim
@@ -51,7 +51,7 @@ method delete*(self: Controller) =
 method init*(self: Controller) = 
   self.events.on(SIGNAL_MESSAGES_LOADED) do(e:Args):
     let args = MessagesLoadedArgs(e)
-    if(self.chatId != args.chatId):
+    if(self.chatId != args.chatId or args.pinnedMessages.len == 0):
       return
     self.delegate.newPinnedMessagesLoaded(args.pinnedMessages)
 

--- a/src/app/modules/main/chat_section/chat_content/messages/controller.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/controller.nim
@@ -52,8 +52,10 @@ method init*(self: Controller) =
     self.delegate.newMessagesLoaded(args.messages, args.reactions, args.pinnedMessages)
 
   self.events.on(SIGNAL_NEW_MESSAGE_RECEIVED) do(e: Args):
-    var evArgs = MessagesArgs(e)
-    for message in evArgs.messages:
+    var args = MessagesArgs(e)
+    if(self.chatId != args.chatId):
+      return
+    for message in args.messages:
       self.delegate.messageAdded(message)
 
   self.events.on(SIGNAL_SENDING_SUCCESS) do(e:Args):

--- a/src/app/modules/main/chat_section/chat_content/messages/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/module.nim
@@ -125,7 +125,7 @@ method messageAdded*(self: Module, message: MessageDto) =
   sender.icon, sender.isIdenticon, sender.isCurrentUser, message.outgoingStatus, message.text, message.image, 
   message.seen, message.timestamp, message.contentType.ContentType, message.messageType)
 
-  self.view.model().prependItem(item)
+  self.view.model().insertItemBasedOnTimestamp(item)
 
 method onSendingMessageSuccess*(self: Module, message: MessageDto) =
   self.messageAdded(message)

--- a/src/app/modules/shared_models/message_model.nim
+++ b/src/app/modules/shared_models/message_model.nim
@@ -145,8 +145,13 @@ QtObject:
     for i in 0 ..< self.items.len:
       if(self.items[i].id == messageId):
         return i
-
     return -1
+
+  proc findIndexBasedOnTimestampToInsertTo(self: Model, timestamp: int64): int = 
+    for i in 0 ..< self.items.len:
+      if(timestamp > self.items[i].timestamp):
+        return i
+    return 0
 
   proc prependItems*(self: Model, items: seq[Item]) =
     if(items.len == 0):
@@ -191,6 +196,17 @@ QtObject:
 
     self.beginInsertRows(parentModelIndex, 0, 0)
     self.items.insert(item, 0)
+    self.endInsertRows()
+    self.countChanged()
+
+  proc insertItemBasedOnTimestamp*(self: Model, item: Item) =
+    let parentModelIndex = newQModelIndex()
+    defer: parentModelIndex.delete
+
+    let position = self.findIndexBasedOnTimestampToInsertTo(item.timestamp)
+
+    self.beginInsertRows(parentModelIndex, position, position)
+    self.items.insert(item, position)
     self.endInsertRows()
     self.countChanged()
 


### PR DESCRIPTION
@iurimatias faced 2 issues:
1. initial messages have not been loaded when user joins a public chat
2. messages sent to a certain chat are visible into other chats as well

The second issue is fixed here and received new messages are now filtered by the chat id they belong to.

The first issue is something we need to figure out why it's happening, we have mailserver signals added to the log so we can follow easier what's happening. Added logging refers to the following signals:
- `SignalType.HistoryRequestStarted`
- `SignalType.HistoryRequestBatchProcessed`
- `SignalType.HistoryRequestCompleted`
- `SignalType.HistoryRequestFailed`

Out of 10 tries (starting from an empty Status data and joining public chat) I didn't get initial messages loaded in ~30% cases. If you receive initial history messages for the first joined public chat on the app start you may join more chats and all of them will receive initial history messages, but if history messages are not received for the first chat they won't be received for other chats you are joining as well. In that case the following will be received:
- info that history request started: `jsonSignal: {"type":"history.request.started","event":{"requestId":"2c6379ca-9d4c-4fa8-a115-73953dc22a51","batchIndex":0,"numBatches":1}}`
- and then that it failed: `{"type":"history.request.failed","event":{"requestId":"2c6379ca-9d4c-4fa8-a115-73953dc22a51","batchIndex":0,"errorMessage":"could not find peer with ID: 2721ca3e5c87d73ce892bd0710f9a78eef4c800f92aeaa7feec8b9b86b62c131"}}`

On the side of `status-desktop` all should be good in terms of requesting data/handling response, so maybe @richard-ramos may help somehow?

Actually when user joins new public chat we do `wakuext_createPublicChat` first and after that do `wakuext_chatMessages` call which returns `{"messages":null,"cursor":""}` always, what is ok (the same as `master` branch work) and we expect to received messages via `messages.new` signal sent from `status-go` but that missed due to we couldn't find a peer with ID appropriate id.

That, most likely, means if initial history messages are not loaded when you joined a chat they won't be loaded later as well   since we don't have them in the DB.

Maybe we should think about trying to fetch data from other peer/s in that case?