### PR TITLE
Add member list model and hook it + updates to community

### DIFF
--- a/src/app/modules/main/communities/module.nim
+++ b/src/app/modules/main/communities/module.nim
@@ -5,6 +5,7 @@ import ../io_interface as delegate_interface
 import ./view, ./controller
 import ../../shared_models/section_item
 import ../../shared_models/member_item
+import ../../shared_models/members_model
 import ../../../global/global_singleton
 import ../../../core/eventemitter
 import ../../../../app_service/service/community/service as community_service
@@ -73,7 +74,8 @@ method getCommunityItem(self: Module, c: CommunityDto): SectionItem =
       c.isMember,
       c.permissions.access,
       c.permissions.ensOnly,
-      c.members.map(x => member_item.initItem(x.id, x.roles)))
+      c.members.map(x => member_item.initItem(x.id, x.roles))
+    )
 
 method setAllCommunities*(self: Module, communities: seq[CommunityDto]) =
   for community in communities:

--- a/src/app/modules/main/controller.nim
+++ b/src/app/modules/main/controller.nim
@@ -117,6 +117,11 @@ method init*(self: Controller) =
     let args = CommunityArgs(e)
     self.delegate.communityEdited(args.community)
 
+  self.events.on(SIGNAL_COMMUNITIES_UPDATE) do(e:Args):
+    let args = CommunitiesArgs(e)
+    for community in args.communities:
+      self.delegate.communityEdited(community)
+
   self.events.on(SIGNAL_ENS_RESOLVED) do(e: Args):
     var args = ResolvedContactArgs(e)
     self.delegate.resolvedENS(args.pubkey, args.address, args.uuid)

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -1,7 +1,7 @@
 import NimQml, tables, json, sugar, sequtils
 
-import io_interface, view, controller, ../shared_models/section_item, ../shared_models/section_model
-import ../shared_models/member_item
+import io_interface, view, controller, ../shared_models/section_item,../shared_models/section_model
+import ../shared_models/member_item, ../shared_models/members_model
 import ../../global/app_sections_config as conf
 import ../../global/app_signals
 import ../../global/global_singleton
@@ -177,7 +177,8 @@ proc createCommunityItem[T](self: Module[T], c: CommunityDto): SectionItem =
     c.isMember,
     c.permissions.access,
     c.permissions.ensOnly,
-    c.members.map(x => member_item.initItem(x.id, x.roles)))
+    c.members.map(x => member_item.initItem(x.id, x.roles))
+  )
 
 method load*[T](
   self: Module[T],

--- a/src/app/modules/shared_models/active_section.nim
+++ b/src/app/modules/shared_models/active_section.nim
@@ -120,11 +120,14 @@ QtObject:
   QtProperty[bool] ensOnly:
     read = ensOnly
 
-  proc nbMembers(self: ActiveSection): int {.slot.} = 
-    return self.item.members.len
+  proc members(self: ActiveSection): QVariant {.slot.} =
+    if (self.item.id == ""):
+      # FIXME (Jo) I don't know why but the Item is sometimes empty and doing anything here crashes the app
+      return newQVariant("")
+    return newQVariant(self.item.members)
 
-  QtProperty[int] nbMembers:
-    read = nbMembers
+  QtProperty[QVariant] members:
+    read = members
 
   proc hasMember(self: ActiveSection, pubkey: string): bool {.slot.} =
     return self.item.hasMember(pubkey)

--- a/src/app/modules/shared_models/members_model.nim
+++ b/src/app/modules/shared_models/members_model.nim
@@ -1,0 +1,109 @@
+import NimQml, Tables, strformat
+import  ./member_item
+import ../../global/global_singleton
+
+type
+  MembersRoles {.pure.} = enum
+    PubKey = UserRole + 1
+    # LastSeen = UserRole,
+    # StatusType = UserRole,
+    # Online = UserRole,
+    # SortKey = UserRole
+
+QtObject:
+  type
+    MembersModel* = ref object of QAbstractListModel
+      members*: seq[MemberItem]
+
+  proc setup(self: MembersModel) = self.QAbstractListModel.setup
+
+  proc delete(self: MembersModel) =
+    self.QAbstractListModel.delete
+
+  proc newMembersModel*(members: seq[MemberItem]): MembersModel =
+    new(result, delete)
+    result.members = members
+    result.setup()
+
+  proc `$`*(self: MembersModel): string =
+    for i in 0 ..< self.members.len:
+      result &= fmt"""MembersModel:
+      [{i}]:({$self.members[i]})
+      """
+
+  proc getIndexFromPubKey*(self: MembersModel, pubKey: string): int =
+    var i = 0
+    for member in self.members:
+      if (member.id == pubKey):
+        return i
+      i = i + 1
+    return -1
+
+  proc hasMember*(self: MembersModel, pubkey: string): bool =
+    for member in self.members:
+      if (member.id == pubkey):
+        return true
+    return false
+
+  proc removeMember*(self: MembersModel, pubKey: string) =
+    let memberIndex = self.getIndexFromPubKey(pubKey)
+    if (memberIndex == -1):
+      return
+    self.beginRemoveRows(newQModelIndex(), memberIndex, memberIndex)
+    self.members.delete(memberIndex)
+    self.endRemoveRows()
+
+  proc countChanged*(self: MembersModel) {.signal.}
+  proc count*(self: MembersModel): int {.slot.} =
+    self.members.len
+
+  QtProperty[int] count:
+    read = count
+    notify = countChanged
+
+  method rowCount(self: MembersModel, index: QModelIndex = nil): int = 
+    self.members.len
+
+  # proc memberStatus(self: MembersModel, pk: string): int =
+  #   if self.membersStatus.hasKey(pk):
+  #     result = self.membersStatus[pk].statusType.int
+
+  # proc isOnline(self: MembersModel, pk: string): bool =
+  #   if self.myPubKey == pk:
+  #     return true
+  #   if self.membersStatus.hasKey(pk):
+  #     result = self.membersStatus[pk].statusType.int == StatusUpdateType.Online.int
+
+  # proc sortKey(self: MembersModel, pk: string): string =
+  #   let name = self.userName(pk, self.alias(pk))
+  #   if self.isOnline(pk):
+  #     return "A" & name
+  #   return "B" & name
+
+  method data(self: MembersModel, index: QModelIndex, role: int): QVariant =
+    if not index.isValid:
+      return
+    if index.row < 0 or index.row >= self.members.len:
+      return
+
+    let member = self.members[index.row]
+    let memberRole = role.MembersRoles
+    case memberRole:
+      of MembersRoles.PubKey: result = newQVariant(member.id)
+      # of MembersRoles.LastSeen: result = newQVariant(self.memberLastSeen(member.id))
+      # of MembersRoles.StatusType: result = newQVariant(self.memberStatus(member.id))
+      # of MembersRoles.Online: result = newQVariant(self.isOnline(member.id))
+      # of MembersRoles.SortKey: result = newQVariant(self.sortKey(member.id))
+
+  method roleNames(self: MembersModel): Table[int, string] =
+    {
+      MembersRoles.PubKey.int:"pubKey"
+      # MembersRoles.LastSeen.int:"lastSeen",
+      # MembersRoles.StatusType.int:"statusType",
+      # MembersRoles.Online.int:"online",
+      # MembersRoles.SortKey.int:"sortKey"
+    }.toTable
+
+  # proc triggerUpdate*(self: MembersModel) =
+  #   self.beginResetModel()
+  #   self.endResetModel()

--- a/src/app/modules/shared_models/section_item.nim
+++ b/src/app/modules/shared_models/section_item.nim
@@ -1,5 +1,5 @@
 import strformat
-import ./member_item
+import ./members_model, ./member_item
 
 type
   SectionType* {.pure.} = enum
@@ -32,7 +32,7 @@ type
     canRequestAccess: bool
     access: int
     ensOnly: bool
-    members: seq[MemberItem]
+    membersModel: MembersModel
 
 proc initItem*(
     id: string,
@@ -75,7 +75,7 @@ proc initItem*(
   result.isMember = isMember
   result.access = access
   result.ensOnly = ensOnly
-  result.members = members
+  result.membersModel = newMembersModel(members)
 
 proc isEmpty*(self: SectionItem): bool =
   return self.id.len == 0
@@ -101,7 +101,7 @@ proc `$`*(self: SectionItem): string =
     isMember:{self.isMember},
     access:{self.access},
     ensOnly:{self.ensOnly},
-    members:{self.members},
+    members:{self.membersModel},
     ]"""
 
 proc id*(self: SectionItem): string {.inline.} = 
@@ -173,11 +173,8 @@ proc access*(self: SectionItem): int {.inline.} =
 proc ensOnly*(self: SectionItem): bool {.inline.} = 
   self.ensOnly
 
-proc members*(self: SectionItem): seq[MemberItem] {.inline.} = 
-  self.members
+proc members*(self: SectionItem): MembersModel {.inline.} =
+  self.membersModel
 
 proc hasMember*(self: SectionItem, pubkey: string): bool =
-  for member in self.members:
-    if (member.id == pubkey):
-      return true
-  return false
+  self.membersModel.hasMember(pubkey)

--- a/src/app_service/service/community/dto/community.nim
+++ b/src/app_service/service/community/dto/community.nim
@@ -141,7 +141,7 @@ proc toCommunityDto*(jsonObj: JsonNode): CommunityDto =
     result.permissions = toPermission(permissionObj)
 
   var membersObj: JsonNode
-  if(jsonObj.getProp("members", membersObj) and membersObj.kind == JArray):
+  if(jsonObj.getProp("members", membersObj) and membersObj.kind == JObject):
     for memberId, memberObj in membersObj:
       result.members.add(toMember(memberObj, memberId))
 

--- a/src/app_service/service/community/service.nim
+++ b/src/app_service/service/community/service.nim
@@ -5,6 +5,7 @@ import ./dto/community as community_dto
 import ../chat/service as chat_service
 
 import ../../../app/global/global_singleton
+import ../../../app/core/signals/types
 import ../../../app/core/eventemitter
 import status/statusgo_backend_new/communities as status_go
 
@@ -16,6 +17,9 @@ logScope:
 type
   CommunityArgs* = ref object of Args
     community*: CommunityDto
+
+  CommunitiesArgs* = ref object of Args
+    communities*: seq[CommunityDto]
 
   CommunityChatArgs* = ref object of Args
     communityId*: string
@@ -48,6 +52,7 @@ const SIGNAL_COMMUNITY_MY_REQUEST_ADDED* = "communityMyRequestAdded"
 const SIGNAL_COMMUNITY_LEFT* = "communityLeft"
 const SIGNAL_COMMUNITY_CREATED* = "communityCreated"
 const SIGNAL_COMMUNITY_EDITED* = "communityEdited"
+const SIGNAL_COMMUNITIES_UPDATE* = "communityUpdated"
 const SIGNAL_COMMUNITY_CHANNEL_CREATED* = "communityChannelCreated"
 const SIGNAL_COMMUNITY_CHANNEL_EDITED* = "communityChannelEdited"
 const SIGNAL_COMMUNITY_CHANNEL_REORDERED* = "communityChannelReordered"
@@ -97,6 +102,13 @@ QtObject:
       let errDesription = e.msg
       error "error: ", errDesription
       return
+
+    self.events.on(SignalType.Message.event) do(e: Args):
+      var receivedData = MessageSignal(e)
+
+      # Handling community updates
+      if (receivedData.communities.len > 0):
+        self.events.emit(SIGNAL_COMMUNITIES_UPDATE, CommunitiesArgs(communities: receivedData.communities))
 
   proc loadAllCommunities(self: Service): seq[CommunityDto] =
     let response = status_go.getAllCommunities()

--- a/ui/app/AppLayouts/Browser/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Browser/stores/RootStore.qml
@@ -35,6 +35,10 @@ QtObject {
         return globalUtils.generateIdenticon(pk)
     }
 
+    function generateAlias(pk) {
+        return globalUtils.generateAlias(pk)
+    }
+
     function get0xFormedUrl(browserExplorer, url) {
         var tempUrl = ""
         switch (browserExplorer) {

--- a/ui/app/AppLayouts/Chat/panels/communities/CommunityProfilePopupMembersListPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/CommunityProfilePopupMembersListPanel.qml
@@ -127,21 +127,24 @@ Item {
 
                     id: memberItem
 
-                    property string nickname: Utils.getContactDetailsAsJson(model.pubKey).localNickname
+                    property var contactDetail: Utils.getContactDetailsAsJson(model.pubKey)
+                    property string identicon: contactDetail.identicon || root.store.generateIdenticon(model.pubKey)
+                    property string username: contactDetail.name || root.store.generateAlias(model.pubKey)
+                    property string nickname: contactDetail.localNickname || ""
                     property string profileImage: Global.getProfileImage(model.pubKey) || ""
 
                     visible: !!!memberSearch.input.text || 
-                        model.userName.toLowerCase().includes(memberSearch.input.text.toLowerCase()) ||
+                        contactDetail.name.toLowerCase().includes(memberSearch.input.text.toLowerCase()) ||
                         nickname.toLowerCase().includes(memberSearch.input.text.toLowerCase())
                     anchors.horizontalCenter: parent.horizontalCenter
 
                     image.isIdenticon: !profileImage
-                    image.source: profileImage || model.identicon
+                    image.source: profileImage || identicon
 
                     title: {
                         if (menuButton.visible) {
-                            return !model.userName.endsWith(".eth") && !!nickname ?
-                                nickname : Utils.removeStatusEns(model.userName)
+                            return !username.endsWith(".eth") && !!nickname ?
+                                nickname : Utils.removeStatusEns(username)
                         }
                         //% "You"
                         return qsTrId("You")

--- a/ui/app/AppLayouts/Chat/panels/communities/CommunityProfilePopupOverviewPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/CommunityProfilePopupOverviewPanel.qml
@@ -75,7 +75,7 @@ Column {
         //% "Members"
         title: qsTrId("members-label")
         icon.name: "group-chat"
-        label: root.community.nbMembers.toString()
+        label: root.community.members.count.toString()
         sensor.onClicked: root.membersListButtonClicked()
 
         components: [

--- a/ui/app/AppLayouts/Chat/popups/community/CommunityDetailPopup.qml
+++ b/ui/app/AppLayouts/Chat/popups/community/CommunityDetailPopup.qml
@@ -21,8 +21,7 @@ StatusModal {
     property string description: community.description
     property int access: community.access
     property string source: community.image
-    // TODO members needs to be refactored on the backend
-    property int nbMembers: 0//community.nbMembers
+    property int nbMembers: community.members.count
     property bool ensOnly: community.ensOnly
     property bool canJoin: community.canJoin
     property bool canRequestAccess: community.canRequestAccess

--- a/ui/app/AppLayouts/Chat/popups/community/CommunityProfilePopup.qml
+++ b/ui/app/AppLayouts/Chat/popups/community/CommunityProfilePopup.qml
@@ -112,7 +112,7 @@ StatusModal {
                 width: stack.width
                 //% "Members"
                 headerTitle: qsTrId("members-label")
-                headerSubtitle: root.community.nbMembers.toString()
+                headerSubtitle: root.community.members.count.toString()
                 community: root.community
                 onInviteButtonClicked: root.contentItem.push(inviteFriendsView)
             }

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -186,7 +186,10 @@ QtObject {
     }
 
     function generateIdenticon(pk) {
-        // Not Refactored Yet
-//        return utilsModelInst.generateIdenticon(pk);
+        return globalUtils.generateIdenticon(pk)
+    }
+
+    function generateAlias(pk) {
+        return globalUtils.generateAlias(pk)
     }
 }

--- a/ui/app/AppLayouts/Chat/views/CommunityColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/CommunityColumnView.qml
@@ -39,11 +39,11 @@ Item {
         anchors.horizontalCenter: parent.horizontalCenter
 
         chatInfoButton.title: communityData.name
-        chatInfoButton.subTitle: communityData.nbMembers <= 1 ?
+        chatInfoButton.subTitle: communityData.members.count <= 1 ?
                                      //% "1 Member"
                                      qsTrId("1-member") :
                                      //% "%1 Members"
-                                     qsTrId("-1-members").arg(communityData.nbMembers)
+                                     qsTrId("-1-members").arg(communityData.members.count)
 
         chatInfoButton.image.source: communityData.image
         chatInfoButton.icon.color: communityData.color

--- a/ui/imports/shared/views/chat/InvitationBubbleView.qml
+++ b/ui/imports/shared/views/chat/InvitationBubbleView.qml
@@ -272,7 +272,7 @@ Item {
                     id: communityNbMembers
                     // TODO add the plural support
                     //% "%1 members"
-                    text: qsTrId("-1-members").arg(invitedCommunity.nbMembers)
+                    text: qsTrId("-1-members").arg(invitedCommunity.members.count)
                     anchors.top: communityDesc.bottom
                     anchors.topMargin: 2
                     anchors.left: parent.left


### PR DESCRIPTION
Adds the member list model and hooks it to the popup and front end so that the number of members now works from the model.
Also hooks the event for community updates, so if the community changes from a signal, the changes are reflected.