### PR TITLE
refactor(@desktop/chat): reading a channel message does not mark it as read

### DIFF
--- a/src/app/modules/main/chat_section/chat_content/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/module.nim
@@ -253,4 +253,7 @@ method onContactDetailsUpdated*(self: Module, contactId: string) =
   self.view.pinnedModel().updateSenderDetails(contactId, updatedContact.displayName, updatedContact.details.localNickname,
   updatedContact.icon, updatedContact.isIdenticon)
   if(self.controller.getMyChatId() == contactId):
-    self.view.updateChatDetails(updatedContact.displayName, updatedContact.icon, updatedContact.isIdenticon)
+    self.view.updateChatDetailsNameAndIcon(updatedContact.displayName, updatedContact.icon, updatedContact.isIdenticon)
+
+method onNotificationsUpdated*(self: Module, hasUnreadMessages: bool, notificationCount: int) =
+  self.view.updateChatDetailsNotifications(hasUnreadMessages, notificationCount)

--- a/src/app/modules/main/chat_section/chat_content/private_interfaces/module_access_interface.nim
+++ b/src/app/modules/main/chat_section/chat_content/private_interfaces/module_access_interface.nim
@@ -11,3 +11,6 @@ method isLoaded*(self: AccessInterface): bool {.base.} =
 
 method getModuleAsVariant*(self: AccessInterface): QVariant {.base.} =
   raise newException(ValueError, "No implementation available")
+
+method onNotificationsUpdated*(self: AccessInterface, hasUnreadMessages: bool, notificationCount: int) {.base.} =
+  raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/chat_section/chat_content/view.nim
+++ b/src/app/modules/main/chat_section/chat_content/view.nim
@@ -94,9 +94,13 @@ QtObject:
   proc setMuted*(self: View, muted: bool) = 
     self.chatDetails.setMuted(muted)
 
-  proc updateChatDetails*(self: View, name, icon: string, isIdenticon: bool) =
+  proc updateChatDetailsNameAndIcon*(self: View, name, icon: string, isIdenticon: bool) =
     self.chatDetails.setName(name)
     self.chatDetails.setIcon(icon, isIdenticon)
+
+  proc updateChatDetailsNotifications*(self: View, hasUnreadMessages: bool, notificationCount: int) =
+    self.chatDetails.setHasUnreadMessages(hasUnreadMessages)
+    self.chatDetails.setNotificationCount(notificationCount)
 
   proc getChatDetails(self: View): QVariant {.slot.} =
     return self.chatDetailsVariant

--- a/src/app/modules/main/chat_section/controller.nim
+++ b/src/app/modules/main/chat_section/controller.nim
@@ -46,6 +46,14 @@ method delete*(self: Controller) =
   discard
 
 method init*(self: Controller) = 
+  self.events.on(SIGNAL_NEW_MESSAGE_RECEIVED) do(e: Args):
+    let args = MessagesArgs(e)
+    if(self.isCommunitySection and args.chatType != ChatType.CommunityChat or
+      not self.isCommunitySection and args.chatType == ChatType.CommunityChat):
+        return
+    self.delegate.onNewMessagesReceived(args.chatId, args.unviewedMessagesCount, args.unviewedMentionsCount, 
+    args.messages)
+
   self.events.on(chat_service.SIGNAL_CHAT_MUTED) do(e:Args):
     let args = chat_service.ChatArgs(e)
     self.delegate.onChatMuted(args.chatId)

--- a/src/app/modules/main/chat_section/private_interfaces/module_controller_delegate_interface.nim
+++ b/src/app/modules/main/chat_section/private_interfaces/module_controller_delegate_interface.nim
@@ -7,6 +7,10 @@ method addNewChat*(self: AccessInterface, chatDto: ChatDto, events: EventEmitter
   messageService: message_service.Service) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method onNewMessagesReceived*(self: AccessInterface, chatId: string, unviewedMessagesCount: int, 
+  unviewedMentionsCount: int, messages: seq[MessageDto]) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method onChatMuted*(self: AccessInterface, chatId: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/chat_section/sub_model.nim
+++ b/src/app/modules/main/chat_section/sub_model.nim
@@ -189,5 +189,15 @@ QtObject:
         self.items[i].BaseItem.muted = mute
         self.dataChanged(index, index, @[ModelRole.Muted.int])
         return true
+    return false
 
+  proc updateNotificationsForItemById*(self: SubModel, id: string, hasUnreadMessages: bool, 
+    notificationsCount: int): bool =
+    for i in 0 ..< self.items.len:
+      if(self.items[i].id == id):
+        let index = self.createIndex(i, 0, nil)
+        self.items[i].BaseItem.hasUnreadMessages = hasUnreadMessages
+        self.items[i].BaseItem.notificationsCount = notificationsCount
+        self.dataChanged(index, index, @[ModelRole.HasUnreadMessages.int, ModelRole.NotificationsCount.int])
+        return true
     return false

--- a/src/app/modules/main/chat_section/view.nim
+++ b/src/app/modules/main/chat_section/view.nim
@@ -58,15 +58,6 @@ QtObject:
   QtProperty[QVariant] contactRequestsModel:
     read = getContactRequestsModel
 
-  proc appendItem*(self: View, item: Item) =
-    self.model.appendItem(item)
-
-  proc removeItem*(self: View, id: string) =
-    self.model.removeItemById(id)
-
-  proc prependItem*(self: View, item: Item) =
-    self.model.prependItem(item)
-
   proc activeItemChanged*(self:View) {.signal.}
 
   proc getActiveItem(self: View): QVariant {.slot.} =

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -480,6 +480,10 @@ method getCommunitySectionModule*[T](self: Module[T], communityId: string): QVar
 method onActiveChatChange*[T](self: Module[T], sectionId: string, chatId: string) =
   self.appSearchModule.onActiveChatChange(sectionId, chatId)
 
+method onNotificationsUpdated[T](self: Module[T], sectionId: string, sectionHasUnreadMessages: bool, 
+  sectionNotificationCount: int) =
+  self.view.model().udpateNotifications(sectionId, sectionHasUnreadMessages, sectionNotificationCount)
+
 method getAppSearchModule*[T](self: Module[T]): QVariant =
   self.appSearchModule.getModuleAsVariant()
 

--- a/src/app/modules/main/private_interfaces/module_chat_section_delegate_interface.nim
+++ b/src/app/modules/main/private_interfaces/module_chat_section_delegate_interface.nim
@@ -6,3 +6,7 @@ method communitySectionDidLoad*(self: AccessInterface) {.base.} =
 
 method onActiveChatChange*(self: AccessInterface, sectionId: string, chatId: string) {.base.} =
   raise newException(ValueError, "No implementation available")
+
+method onNotificationsUpdated*(self: AccessInterface, sectionId: string, sectionHasUnreadMessages: bool, 
+  sectionNotificationCount: int) {.base.} =
+  raise newException(ValueError, "No implementation available")

--- a/src/app/modules/shared_models/section_model.nim
+++ b/src/app/modules/shared_models/section_model.nim
@@ -213,3 +213,12 @@ QtObject:
 
   proc disableSection*(self: SectionModel, sectionType: SectionType) =
     self.enableDisableSection(sectionType, false)
+
+  proc udpateNotifications*(self: SectionModel, id: string, hasNotification: bool, notificationsCount: int) =
+    for i in 0 ..< self.items.len:
+      if(self.items[i].id == id):
+        let index = self.createIndex(i, 0, nil)
+        self.items[i].hasNotification = hasNotification
+        self.items[i].notificationsCount = notificationsCount
+        self.dataChanged(index, index, @[ModelRole.HasNotification.int, ModelRole.NotificationsCount.int])
+        return


### PR DESCRIPTION
- non active chats/channels are made bold if there are new messages inside them
a dot badge is added to the chat/community section if it's needed in that case
- for non active chats/channels count badge is added if there are new mentions
inside them, a count badge is added to the chat/community section if it's needed in
that case
- selecting chat/channel marks messages from it as read and update its displaying
and dot/count badge of chat/community section accordingly

Fixes #4403