### PR TITLE
fix(@desktop/chat): on right click no option to pin/unpin messages

### DIFF
--- a/ui/imports/shared/views/chat/CompactMessageView.qml
+++ b/ui/imports/shared/views/chat/CompactMessageView.qml
@@ -59,12 +59,18 @@ Item {
         }
     }
 
-    MouseArea {
+    MessageMouseArea {
         enabled: !placeholderMessage
         anchors.fill: messageContainer
         acceptedButtons: activityCenterMessage ? Qt.LeftButton : Qt.RightButton
-        onClicked: {
-            messageMouseArea.clicked(mouse)
+        messageContextMenu: root.messageContextMenu
+        messageContextMenuParent: root
+        isHovered: root.isHovered
+        isMessageActive: root.isMessageActive
+        isActivityCenterMessage: activityCenterMessage
+        stickersLoaded: root.stickersLoaded
+        onClickMessage: {
+            root.clickMessage(isProfileClick, isSticker, isImage, null, false, false, false, false, "");
         }
     }
 


### PR DESCRIPTION
fixes #4413

### What does the PR do

The issue is caused because of the way the mouse area is implemented for overall mouse area, using the MessageMouseArea to handle this fixes the issue. 

### Affected areas

Chat, community

### Screenshot of functionality

