### PR TITLE
fix: create channel popup create button was enabled always

### DIFF
--- a/ui/app/AppLayouts/Chat/popups/community/CreateChannelPopup.qml
+++ b/ui/app/AppLayouts/Chat/popups/community/CreateChannelPopup.qml
@@ -41,8 +41,8 @@ StatusModal {
     onClosed: destroy()
 
     function isFormValid() {
-        return contentItem.channelName.valid &&
-               contentItem.channelDescription.valid
+        return (scrollView.channelName.valid &&
+               scrollView.channelDescription.valid)
     }
 
     contentItem: ScrollView {
@@ -77,6 +77,7 @@ StatusModal {
                     input.text = Utils.convertSpacesToDashesAndUpperToLowerCase(input.text);
                     input.cursorPosition = input.text.length
                 }
+                validationMode: StatusInput.ValidationMode.Always
                 validators: [StatusMinLengthValidator {
                     minLength: 1
                     errorMessage: Utils.getErrorMessage(nameInput.errors, qsTr("channel name"))
@@ -96,6 +97,7 @@ StatusModal {
                 input.placeholderText: qsTr("Describe the channel")
                 input.multiline: true
                 input.implicitHeight: 88
+                validationMode: StatusInput.ValidationMode.Always
                 validators: [StatusMinLengthValidator {
                     minLength: 1
                     errorMessage:  Utils.getErrorMessage(descriptionTextArea.errors, qsTr("channel description"))


### PR DESCRIPTION
Closes #4444

### What does the PR do
Fixed create button to be disabled when name and description
text fields are empty in create channel popup

### Affected areas
Create channel popup

### Screenshot of functionality
<img width="1249" alt="createChannel" src="https://user-images.githubusercontent.com/31625338/149425244-11044abf-a10e-4e53-b4f7-d6e7b3c4ff23.png">

