### PR TITLE
fix(@desktop/chat): Group members list must show only 5

### DIFF
--- a/ui/app/AppLayouts/Chat/popups/GroupInfoPopup.qml
+++ b/ui/app/AppLayouts/Chat/popups/GroupInfoPopup.qml
@@ -162,7 +162,7 @@ StatusModal {
         id: groupInfoItem
 
         width: parent.width - 2*Style.current.padding
-        height: parent.height
+        height: parent.height - 2*Style.current.padding
         anchors.top: parent.top
         anchors.topMargin: Style.current.padding
         anchors.horizontalCenter: parent.horizontalCenter
@@ -205,9 +205,9 @@ StatusModal {
 
         ListView {
             id: memberList
-            spacing: Style.current.padding
             Layout.fillWidth: true
             Layout.fillHeight: true
+            clip: true
             model: popup.channel? popup.channel.members : []
             delegate: StatusListItem {
                 id: contactRow


### PR DESCRIPTION
Closes #4386

### What does the PR do

The members list modal containing the list of profiles within a group chat visualizes 5 members at a time and when scrolling, the new members are bounded inside the corresponding area.

### Affected areas

Group Chat / View Group

### Screenshot of functionality

Scrolling action:
![image](https://user-images.githubusercontent.com/97019400/149501935-a95448f9-6fb6-413b-a79c-80667a217396.png)
