### PR TITLE
refactor(@desktop/chat): username is misplaced when sending messages in the channel

### DIFF
--- a/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
@@ -339,10 +339,13 @@ Item {
 
             // This is possible since we have all data loaded before we load qml.
             // When we fetch messages to fulfill a gap we have to set them at once.
-            prevMessageIndex: index - 1
-            prevMessageAsJsonObj: messageStore.getMessageByIndexAsJson(index - 1)
-            nextMessageIndex: index + 1
-            nextMessageAsJsonObj: messageStore.getMessageByIndexAsJson(index + 1)
+            // Also one important thing here is that messages are set in descending order
+            // in terms of `timestamp` of a message, that means a message with the most
+            // recent time is added at index 0.
+            prevMessageIndex: index + 1
+            prevMessageAsJsonObj: messageStore.getMessageByIndexAsJson(index + 1)
+            nextMessageIndex: index - 1
+            nextMessageAsJsonObj: messageStore.getMessageByIndexAsJson(index - 1)
             onOpenStickerPackPopup: {
                 root.openStickerPackPopup(stickerPackId);
             }

--- a/ui/imports/shared/views/chat/CompactMessageView.qml
+++ b/ui/imports/shared/views/chat/CompactMessageView.qml
@@ -446,10 +446,10 @@ Item {
             anchors.top: chatName.visible ? chatName.bottom :
                                             chatReply.active ? chatReply.bottom :
                                                 pinnedRectangleLoader.active ? pinnedRectangleLoader.bottom : parent.top
-            anchors.left: chatImage.right
-            anchors.leftMargin: chatHorizontalPadding
+            anchors.left: parent.left
+            anchors.leftMargin: chatImage.imageWidth + Style.current.padding + root.chatHorizontalPadding
             anchors.right: parent.right
-            anchors.rightMargin: chatHorizontalPadding
+            anchors.rightMargin: root.chatHorizontalPadding
             visible: !isEdit
             ChatTextView {
                 id: chatText


### PR DESCRIPTION
A reason why this issue was happening is that prev and next message
were set in a wrong way. An important thing is that list of messages is set
in descending order in terms of `timestamp` of a message, that means a
message with the most recent time is added at index 0.

That further means that getting an index of the previous message from the
current one is defined as `currentIndex + 1` and getting an index of the next
one is defined as `currentIndex - 1`.

Fixes #4417