### PR TITLE
Add admin member request feature for communities

### DIFF
--- a/src/app/modules/main/chat_section/controller.nim
+++ b/src/app/modules/main/chat_section/controller.nim
@@ -260,3 +260,18 @@ method joinGroupChatFromInvitation*(self: Controller, groupName: string, chatId:
   if(response.success):
     self.delegate.addNewChat(response.chatDto, false, self.events, self.settingsService, self.contactService, self.chatService, 
     self.communityService, self.messageService, self.gifService)
+
+method acceptRequestToJoinCommunity*(self: Controller, requestId: string) =
+  self.communityService.acceptRequestToJoinCommunity(self.sectionId, requestId)
+
+method declineRequestToJoinCommunity*(self: Controller, requestId: string) =
+  self.communityService.declineRequestToJoinCommunity(self.sectionId, requestId)
+
+method createCommunityChannel*(
+    self: Controller,
+    name: string,
+    description: string) =
+  self.communityService.createCommunityChannel(self.sectionId, name, description)
+
+method leaveCommunity*(self: Controller) =
+  self.communityService.leaveCommunity(self.sectionId)

--- a/src/app/modules/main/chat_section/controller.nim
+++ b/src/app/modules/main/chat_section/controller.nim
@@ -275,3 +275,31 @@ method createCommunityChannel*(
 
 method leaveCommunity*(self: Controller) =
   self.communityService.leaveCommunity(self.sectionId)
+  
+method editCommunity*(
+    self: Controller,
+    name: string,
+    description: string,
+    access: int,
+    ensOnly: bool,
+    color: string,
+    imageUrl: string,
+    aX: int, aY: int, bX: int, bY: int) =
+  self.communityService.editCommunity(
+    self.sectionId,
+    name,
+    description,
+    access,
+    ensOnly,
+    color,
+    imageUrl,
+    aX, aY, bX, bY)
+
+method exportCommunity*(self: Controller): string =
+  self.communityService.exportCommunity(self.sectionId)
+
+method setCommunityMuted*(self: Controller, muted: bool) =
+  self.communityService.setCommunityMuted(self.sectionId, muted)
+
+method inviteUsersToCommunity*(self: Controller, pubKeys: string): string =
+  result = self.communityService.inviteUsersToCommunityById(self.sectionId, pubKeys)

--- a/src/app/modules/main/chat_section/controller_interface.nim
+++ b/src/app/modules/main/chat_section/controller_interface.nim
@@ -115,3 +115,16 @@ method joinGroup*(self: AccessInterface) {.base.} =
 
 method joinGroupChatFromInvitation*(self: AccessInterface, groupName: string, chatId: string, adminPK: string) {.base.} =
   raise newException(ValueError, "No implementation available")
+
+
+method acceptRequestToJoinCommunity*(self: AccessInterface, requestId: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method declineRequestToJoinCommunity*(self: AccessInterface, requestId: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method createCommunityChannel*(self: AccessInterface, name: string, description: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method leaveCommunity*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/chat_section/controller_interface.nim
+++ b/src/app/modules/main/chat_section/controller_interface.nim
@@ -128,3 +128,15 @@ method createCommunityChannel*(self: AccessInterface, name: string, description:
 
 method leaveCommunity*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
+
+method editCommunity*(self: AccessInterface, name: string, description: string, access: int, ensOnly: bool, color: string, imageUrl: string, aX: int, aY: int, bX: int, bY: int) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method exportCommunity*(self: AccessInterface): string {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method setCommunityMuted*(self: AccessInterface, muted: bool) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method inviteUsersToCommunity*(self: AccessInterface, pubKeys: string): string {.base.} =
+  raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -511,3 +511,15 @@ method onChatRenamed*(self: Module, chatId: string, newName: string) =
 
 method reorderChannels*(self: Module, chatId, categoryId: string, position: int) =
   self.view.chatsModel().reorder(chatId, categoryId, position)
+
+method acceptRequestToJoinCommunity*(self: Module, requestId: string) =
+  self.controller.acceptRequestToJoinCommunity(requestId)
+
+method declineRequestToJoinCommunity*(self: Module, requestId: string) =
+  self.controller.declineRequestToJoinCommunity(requestId)
+
+method createCommunityChannel*(self: Module, name, description: string,) =
+  self.controller.createCommunityChannel(name, description)
+
+method leaveCommunity*(self: Module) =
+  self.controller.leaveCommunity() 

--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -522,4 +522,19 @@ method createCommunityChannel*(self: Module, name, description: string,) =
   self.controller.createCommunityChannel(name, description)
 
 method leaveCommunity*(self: Module) =
-  self.controller.leaveCommunity() 
+  self.controller.leaveCommunity()
+
+method editCommunity*(self: Module, name: string, description: string, 
+                        access: int, ensOnly: bool, color: string,
+                        imagePath: string,
+                        aX: int, aY: int, bX: int, bY: int) =
+  self.controller.editCommunity(name, description, access, ensOnly, color, imagePath, aX, aY, bX, bY)
+
+method exportCommunity*(self: Module): string =
+  self.controller.exportCommunity()
+
+method setCommunityMuted*(self: Module, muted: bool) =
+  self.controller.setCommunityMuted(muted)  
+
+method inviteUsersToCommunity*(self: Module, pubKeysJSON: string): string =
+  result = self.controller.inviteUsersToCommunity(pubKeysJSON)

--- a/src/app/modules/main/chat_section/private_interfaces/module_view_delegate_interface.nim
+++ b/src/app/modules/main/chat_section/private_interfaces/module_view_delegate_interface.nim
@@ -92,7 +92,19 @@ method declineRequestToJoinCommunity*(self: AccessInterface, requestId: string) 
   raise newException(ValueError, "No implementation available")
 
 method createCommunityChannel*(self: AccessInterface, name: string, description: string) {.base.} =
-  raise newException(ValueError, "No implementation available") 
+  raise newException(ValueError, "No implementation available")
 
 method leaveCommunity*(self: AccessInterface) {.base.} =
-  raise newException(ValueError, "No implementation available") 
+  raise newException(ValueError, "No implementation available")
+
+method editCommunity*(self: AccessInterface, name: string, description: string, access: int, ensOnly: bool, color: string, imagePath: string, aX: int, aY: int, bX: int, bY: int) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method exportCommunity*(self: AccessInterface): string {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method setCommunityMuted*(self: AccessInterface, muted: bool) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method inviteUsersToCommunity*(self: AccessInterface, pubKeysJSON: string): string {.base.} =
+  raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/chat_section/private_interfaces/module_view_delegate_interface.nim
+++ b/src/app/modules/main/chat_section/private_interfaces/module_view_delegate_interface.nim
@@ -83,3 +83,16 @@ method initListOfMyContacts*(self: AccessInterface) {.base.}  =
 
 method clearListOfMyContacts*(self: AccessInterface) {.base.}  =
   raise newException(ValueError, "No implementation available")
+
+
+method acceptRequestToJoinCommunity*(self: AccessInterface, requestId: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method declineRequestToJoinCommunity*(self: AccessInterface, requestId: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method createCommunityChannel*(self: AccessInterface, name: string, description: string) {.base.} =
+  raise newException(ValueError, "No implementation available") 
+
+method leaveCommunity*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available") 

--- a/src/app/modules/main/chat_section/view.nim
+++ b/src/app/modules/main/chat_section/view.nim
@@ -180,3 +180,16 @@ QtObject:
 
   proc joinGroupChatFromInvitation*(self: View, groupName: string, chatId: string, adminPK: string) {.slot.} =
     self.delegate.joinGroupChatFromInvitation(groupName, chatId, adminPK)
+
+
+  proc acceptRequestToJoinCommunity*(self: View, requestId: string) {.slot.} =
+    self.delegate.acceptRequestToJoinCommunity(requestId)
+
+  proc declineRequestToJoinCommunity*(self: View, requestId: string) {.slot.} =
+    self.delegate.declineRequestToJoinCommunity(requestId)
+
+  proc createCommunityChannel*(self: View, name: string, description: string) {.slot.} =
+    self.delegate.createCommunityChannel(name, description)
+
+  proc leaveCommunity*(self: View) {.slot.} =
+    self.delegate.leaveCommunity()

--- a/src/app/modules/main/chat_section/view.nim
+++ b/src/app/modules/main/chat_section/view.nim
@@ -193,3 +193,15 @@ QtObject:
 
   proc leaveCommunity*(self: View) {.slot.} =
     self.delegate.leaveCommunity()
+
+  proc editCommunity*(self: View, name: string, description: string, access: int, ensOnly: bool, color: string, imagePath: string, aX: int, aY: int, bX: int, bY: int) {.slot.} =
+    self.delegate.editCommunity(name, description, access, ensOnly, color, imagePath, aX, aY, bX, bY)
+
+  proc exportCommunity*(self: View): string {.slot.} =
+    self.delegate.exportCommunity()
+
+  proc setCommunityMuted*(self: View, muted: bool) {.slot.} =
+    self.delegate.setCommunityMuted(muted)
+
+  proc inviteUsersToCommunity*(self: View, pubKeysJSON: string): string {.slot.} =
+    result = self.delegate.inviteUsersToCommunity(pubKeysJSON)

--- a/src/app/modules/main/communities/controller.nim
+++ b/src/app/modules/main/communities/controller.nim
@@ -87,26 +87,6 @@ method createCommunity*(
     imageUrl,
     aX, aY, bX, bY)
 
-method editCommunity*(
-    self: Controller,
-    id: string,
-    name: string,
-    description: string,
-    access: int,
-    ensOnly: bool,
-    color: string,
-    imageUrl: string,
-    aX: int, aY: int, bX: int, bY: int) =
-  self.communityService.editCommunity(
-    id,
-    name,
-    description,
-    access,
-    ensOnly,
-    color,
-    imageUrl,
-    aX, aY, bX, bY)
-
 method editCommunityChannel*(
     self: Controller,
     communityId: string,
@@ -168,17 +148,8 @@ method requestCommunityInfo*(self: Controller, communityId: string) =
 method importCommunity*(self: Controller, communityKey: string) =
   self.communityService.importCommunity(communityKey)
 
-method exportCommunity*(self: Controller, communityId: string): string =
-  self.communityService.exportCommunity(communityId)
-
-method inviteUsersToCommunityById*(self: Controller, communityId: string, pubKeys: string): string =
-  result = self.communityService.inviteUsersToCommunityById(communityId, pubKeys)
-
 method removeUserFromCommunity*(self: Controller, communityId: string, pubKeys: string) =
   self.communityService.removeUserFromCommunity(communityId, pubKeys)
 
 method banUserFromCommunity*(self: Controller, communityId: string, pubKey: string) =
   self.communityService.removeUserFromCommunity(communityId, pubKey)
-
-method setCommunityMuted*(self: Controller, communityId: string, muted: bool) =
-  self.communityService.setCommunityMuted(communityId, muted)

--- a/src/app/modules/main/communities/controller.nim
+++ b/src/app/modules/main/communities/controller.nim
@@ -182,10 +182,10 @@ method exportCommunity*(self: Controller, communityId: string): string =
   self.communityService.exportCommunity(communityId)
 
 method acceptRequestToJoinCommunity*(self: Controller, communityId: string, requestId: string) =
-  self.communityService.acceptRequestToJoinCommunity(requestId)
+  self.communityService.acceptRequestToJoinCommunity(communityId, requestId)
 
 method declineRequestToJoinCommunity*(self: Controller, communityId: string, requestId: string) =
-  self.communityService.declineRequestToJoinCommunity(requestId)
+  self.communityService.declineRequestToJoinCommunity(communityId, requestId)
 
 method inviteUsersToCommunityById*(self: Controller, communityId: string, pubKeys: string): string =
   result = self.communityService.inviteUsersToCommunityById(communityId, pubKeys)

--- a/src/app/modules/main/communities/controller.nim
+++ b/src/app/modules/main/communities/controller.nim
@@ -69,9 +69,6 @@ method joinCommunity*(self: Controller, communityId: string): string =
 method requestToJoinCommunity*(self: Controller, communityId: string, ensName: string) =
   self.communityService.requestToJoinCommunity(communityId, ensName)
 
-method leaveCommunity*(self: Controller, communityId: string) =
-  self.communityService.leaveCommunity(communityId)
-
 method createCommunity*(
     self: Controller,
     name: string,
@@ -109,13 +106,6 @@ method editCommunity*(
     color,
     imageUrl,
     aX, aY, bX, bY)
-
-method createCommunityChannel*(
-    self: Controller,
-    communityId: string,
-    name: string,
-    description: string) =
-  self.communityService.createCommunityChannel(communityId, name, description)
 
 method editCommunityChannel*(
     self: Controller,
@@ -180,12 +170,6 @@ method importCommunity*(self: Controller, communityKey: string) =
 
 method exportCommunity*(self: Controller, communityId: string): string =
   self.communityService.exportCommunity(communityId)
-
-method acceptRequestToJoinCommunity*(self: Controller, communityId: string, requestId: string) =
-  self.communityService.acceptRequestToJoinCommunity(communityId, requestId)
-
-method declineRequestToJoinCommunity*(self: Controller, communityId: string, requestId: string) =
-  self.communityService.declineRequestToJoinCommunity(communityId, requestId)
 
 method inviteUsersToCommunityById*(self: Controller, communityId: string, pubKeys: string): string =
   result = self.communityService.inviteUsersToCommunityById(communityId, pubKeys)

--- a/src/app/modules/main/communities/controller_interface.nim
+++ b/src/app/modules/main/communities/controller_interface.nim
@@ -19,9 +19,6 @@ method requestToJoinCommunity*(self: AccessInterface, communityId: string, ensNa
 method createCommunity*(self: AccessInterface, name: string, description: string, access: int, ensOnly: bool, color: string, imageUrl: string, aX: int, aY: int, bX: int, bY: int) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method editCommunity*(self: AccessInterface, id: string, name: string, description: string, access: int, ensOnly: bool, color: string, imageUrl: string, aX: int, aY: int, bX: int, bY: int) {.base.} =
-  raise newException(ValueError, "No implementation available")
-
 method editCommunityChannel*(self: AccessInterface, communityId: string, chatId: string, name: string, description: string, categoryId: string, position: int) {.base.} =
   raise newException(ValueError, "No implementation available")
 
@@ -46,19 +43,10 @@ method requestCommunityInfo*(self: AccessInterface, communityId: string) {.base.
 method importCommunity*(self: AccessInterface, communityKey: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method exportCommunity*(self: AccessInterface, communityId: string): string {.base.} =
-  raise newException(ValueError, "No implementation available")
-
-method inviteUsersToCommunityById*(self: AccessInterface, communityId: string, pubKeys: string): string {.base.} =
-  raise newException(ValueError, "No implementation available")
-
 method removeUserFromCommunity*(self: AccessInterface, communityId: string, pubKeys: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method banUserFromCommunity*(self: AccessInterface, communityId: string, pubKey: string) {.base.} =
-  raise newException(ValueError, "No implementation available")
-
-method setCommunityMuted*(self: AccessInterface, communityId: string, muted: bool) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 type

--- a/src/app/modules/main/communities/controller_interface.nim
+++ b/src/app/modules/main/communities/controller_interface.nim
@@ -16,16 +16,10 @@ method joinCommunity*(self: AccessInterface, communityId: string): string {.base
 method requestToJoinCommunity*(self: AccessInterface, communityId: string, ensName: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method leaveCommunity*(self: AccessInterface, communityId: string) {.base.} =
-  raise newException(ValueError, "No implementation available")
-
 method createCommunity*(self: AccessInterface, name: string, description: string, access: int, ensOnly: bool, color: string, imageUrl: string, aX: int, aY: int, bX: int, bY: int) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method editCommunity*(self: AccessInterface, id: string, name: string, description: string, access: int, ensOnly: bool, color: string, imageUrl: string, aX: int, aY: int, bX: int, bY: int) {.base.} =
-  raise newException(ValueError, "No implementation available")
-
-method createCommunityChannel*(self: AccessInterface, communityId: string, name: string, description: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method editCommunityChannel*(self: AccessInterface, communityId: string, chatId: string, name: string, description: string, categoryId: string, position: int) {.base.} =
@@ -53,12 +47,6 @@ method importCommunity*(self: AccessInterface, communityKey: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method exportCommunity*(self: AccessInterface, communityId: string): string {.base.} =
-  raise newException(ValueError, "No implementation available")
-
-method acceptRequestToJoinCommunity*(self: AccessInterface, communityId: string, requestId: string) {.base.} =
-  raise newException(ValueError, "No implementation available")
-
-method declineRequestToJoinCommunity*(self: AccessInterface, communityId: string, requestId: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method inviteUsersToCommunityById*(self: AccessInterface, communityId: string, pubKeys: string): string {.base.} =

--- a/src/app/modules/main/communities/models/pending_request_item.nim
+++ b/src/app/modules/main/communities/models/pending_request_item.nim
@@ -1,0 +1,42 @@
+type 
+  PendingRequestItem* = ref object
+    id: string
+    publicKey: string
+    chatId: string
+    communityId: string
+    state: int
+    our: string
+
+proc initItem*(
+    id: string,
+    publicKey: string,
+    chatId: string,
+    communityId: string,
+    state: int,
+    our: string
+    ): PendingRequestItem =
+  result = PendingRequestItem()
+  result.id = id
+  result.publicKey = publicKey
+  result.chatId = chatId
+  result.communityId = communityId
+  result.state = state
+  result.our = our
+
+proc id*(self: PendingRequestItem): string = 
+  self.id
+
+proc pubKey*(self: PendingRequestItem): string = 
+  self.publicKey
+
+proc chatId*(self: PendingRequestItem): string = 
+  self.chatId
+
+proc communityId*(self: PendingRequestItem): string = 
+  self.communityId
+
+proc state*(self: PendingRequestItem): int = 
+  self.state
+
+proc our*(self: PendingRequestItem): string = 
+  self.our

--- a/src/app/modules/main/communities/models/pending_request_model.nim
+++ b/src/app/modules/main/communities/models/pending_request_model.nim
@@ -1,0 +1,114 @@
+import NimQml, Tables
+import pending_request_item
+
+type
+  ModelRole {.pure.} = enum
+    Id = UserRole + 1
+    PubKey
+    ChatId
+    CommunityId
+    State
+    Our
+
+QtObject:
+  type PendingRequestModel* = ref object of QAbstractListModel
+    items*: seq[PendingRequestItem]
+
+  proc setup(self: PendingRequestModel) = 
+    self.QAbstractListModel.setup
+
+  proc delete(self: PendingRequestModel) =
+    self.items = @[]
+    self.QAbstractListModel.delete
+
+  proc newPendingRequestModel*(pendingRequestsToJoin: seq[PendingRequestItem]): PendingRequestModel =
+    new(result, delete)
+    result.items = pendingRequestsToJoin
+    result.setup
+
+  proc countChanged(self: PendingRequestModel) {.signal.}
+  proc getCount(self: PendingRequestModel): int {.slot.} =
+    self.items.len
+  QtProperty[int] count:
+    read = getCount
+    notify = countChanged
+
+  method rowCount(self: PendingRequestModel, index: QModelIndex = nil): int =
+    return self.items.len
+
+  method roleNames(self: PendingRequestModel): Table[int, string] =
+    {
+      ModelRole.Id.int:"id",
+      ModelRole.PubKey.int:"pubKey",
+      ModelRole.ChatId.int:"chatId",
+      ModelRole.CommunityId.int:"communityId",
+      ModelRole.State.int:"state",
+      ModelRole.Our.int:"our"
+    }.toTable
+
+  method data(self: PendingRequestModel, index: QModelIndex, role: int): QVariant =
+    if not index.isValid:
+      return
+    if index.row < 0 or index.row >= self.items.len:
+      return
+    let item = self.items[index.row]
+    let enumRole = role.ModelRole
+
+    case enumRole:
+      of ModelRole.Id: 
+        result = newQVariant(item.id)
+      of ModelRole.PubKey: 
+        result = newQVariant(item.pubKey)
+      of ModelRole.ChatId: 
+        result = newQVariant(item.chatId)
+      of ModelRole.CommunityId: 
+        result = newQVariant(item.communityId)
+      of ModelRole.State: 
+        result = newQVariant(item.state)
+      of ModelRole.Our: 
+        result = newQVariant(item.our)
+
+  proc findIndexById(self: PendingRequestModel, id: string): int = 
+    for i in 0 ..< self.items.len:
+      if(self.items[i].id == id):
+        return i
+    return -1
+
+  proc addItems*(self: PendingRequestModel, items: seq[PendingRequestItem]) =
+    if(items.len == 0):
+      return
+      
+    let parentModelIndex = newQModelIndex()
+    defer: parentModelIndex.delete
+
+    let first = self.items.len
+    let last = first + items.len - 1
+    self.beginInsertRows(parentModelIndex, first, last)
+    self.items.add(items)
+    self.endInsertRows()
+    self.countChanged()
+
+  proc addItem*(self: PendingRequestModel, item: PendingRequestItem) =
+    let parentModelIndex = newQModelIndex()
+    defer: parentModelIndex.delete
+
+    self.beginInsertRows(parentModelIndex, self.items.len, self.items.len)
+    self.items.add(item)
+    self.endInsertRows()
+    self.countChanged()
+
+  proc containsItemWithId*(self: PendingRequestModel, id: string): bool = 
+    return self.findIndexById(id) != -1
+
+  proc removeItemWithId*(self: PendingRequestModel, id: string) =
+    let ind = self.findIndexById(id)
+    if(ind == -1):
+      return
+
+    let parentModelIndex = newQModelIndex()
+    defer: parentModelIndex.delete
+
+    self.beginRemoveRows(parentModelIndex, ind, ind)
+    self.items.delete(ind)
+    self.endRemoveRows()
+    self.countChanged()

--- a/src/app/modules/main/communities/module.nim
+++ b/src/app/modules/main/communities/module.nim
@@ -129,12 +129,6 @@ method createCommunity*(self: Module, name: string, description: string,
                         aX: int, aY: int, bX: int, bY: int) =
   self.controller.createCommunity(name, description, access, ensOnly, color, imagePath, aX, aY, bX, bY)
 
-method editCommunity*(self: Module, id: string, name: string, description: string, 
-                        access: int, ensOnly: bool, color: string,
-                        imagePath: string,
-                        aX: int, aY: int, bX: int, bY: int) =
-  self.controller.editCommunity(id, name, description, access, ensOnly, color, imagePath, aX, aY, bX, bY)
-
 method createCommunityCategory*(self: Module, communityId: string, name: string, channels: string) =
   let channelsSeq = map(parseJson(channels).getElems(), proc(x:JsonNode):string = x.getStr())
   self.controller.createCommunityCategory(communityId, name, channelsSeq)
@@ -154,9 +148,6 @@ method removeUserFromCommunity*(self: Module, communityId: string, categoryId: s
   # self.controller.reorderCommunityChannel(communityId, categoryId, chatId, position)
   discard
 
-method inviteUsersToCommunityById*(self: Module, communityId: string, pubKeysJSON: string): string =
-  result = self.controller.inviteUsersToCommunityById(communityId, pubKeysJSON)
-  
 method removeUserFromCommunity*(self: Module, communityId: string, pubKey: string) =
   self.controller.removeUserFromCommunity(communityId, pubKey)
 
@@ -172,11 +163,5 @@ method requestCommunityInfo*(self: Module, communityId: string) =
 method deleteCommunityChat*(self: Module, communityId: string, channelId: string) =
   self.controller.deleteCommunityChat(communityId, channelId)
 
-method setCommunityMuted*(self: Module, communityId: string, muted: bool) =
-  self.controller.setCommunityMuted(communityId, muted)  
-
 method importCommunity*(self: Module, communityKey: string) =
   self.controller.importCommunity(communityKey)
-
-method exportCommunity*(self: Module, communityId: string): string =
-  self.controller.exportCommunity(communityId)

--- a/src/app/modules/main/communities/module.nim
+++ b/src/app/modules/main/communities/module.nim
@@ -135,9 +135,6 @@ method editCommunity*(self: Module, id: string, name: string, description: strin
                         aX: int, aY: int, bX: int, bY: int) =
   self.controller.editCommunity(id, name, description, access, ensOnly, color, imagePath, aX, aY, bX, bY)
 
-method createCommunityChannel*(self: Module, communityId, name, description: string,) =
-  self.controller.createCommunityChannel(communityId, name, description)
-
 method createCommunityCategory*(self: Module, communityId: string, name: string, channels: string) =
   let channelsSeq = map(parseJson(channels).getElems(), proc(x:JsonNode):string = x.getStr())
   self.controller.createCommunityCategory(communityId, name, channelsSeq)
@@ -157,9 +154,6 @@ method removeUserFromCommunity*(self: Module, communityId: string, categoryId: s
   # self.controller.reorderCommunityChannel(communityId, categoryId, chatId, position)
   discard
 
-method leaveCommunity*(self: Module, communityId: string) =
-  self.controller.leaveCommunity(communityId) 
-
 method inviteUsersToCommunityById*(self: Module, communityId: string, pubKeysJSON: string): string =
   result = self.controller.inviteUsersToCommunityById(communityId, pubKeysJSON)
   
@@ -171,12 +165,6 @@ method banUserFromCommunity*(self: Module, pubKey: string, communityId: string) 
 
 method requestToJoinCommunity*(self: Module, communityId: string, ensName: string) =
   self.controller.requestToJoinCommunity(communityId, ensName)
-   
-method acceptRequestToJoinCommunity*(self: Module, communityId: string, requestId: string) =
-  self.controller.acceptRequestToJoinCommunity(communityId, requestId)
-
-method declineRequestToJoinCommunity*(self: Module, communityId: string, requestId: string) =
-  self.controller.declineRequestToJoinCommunity(communityId, requestId)
 
 method requestCommunityInfo*(self: Module, communityId: string) =
   self.controller.requestCommunityInfo(communityId)

--- a/src/app/modules/main/communities/private_interfaces/module_access_interface.nim
+++ b/src/app/modules/main/communities/private_interfaces/module_access_interface.nim
@@ -31,9 +31,6 @@ method editCommunity*(self: AccessInterface, id: string, name: string, descripti
 method createCommunityCategory*(self: AccessInterface, communityId: string, name: string, channels: string) {.base.} =
   raise newException(ValueError, "No implementation available") 
 
-method createCommunityChannel*(self: AccessInterface, communityId: string, name: string, description: string) {.base.} =
-  raise newException(ValueError, "No implementation available") 
-
 method editCommunityCategory*(self: AccessInterface, communityId: string, categoryId: string, name: string, channels: string) {.base.} =
   raise newException(ValueError, "No implementation available") 
 
@@ -46,9 +43,6 @@ method reorderCommunityCategories*(self: AccessInterface, communityId: string, c
 method reorderCommunityChannel*(self: AccessInterface, communityId: string, categoryId: string, chatId: string, position: int) {.base} =
   raise newException(ValueError, "No implementation available") 
 
-method leaveCommunity*(self: AccessInterface, communityId: string) {.base.} =
-  raise newException(ValueError, "No implementation available") 
-
 method inviteUsersToCommunityById*(self: AccessInterface, communityId: string, pubKeysJSON: string): string {.base.} =
   raise newException(ValueError, "No implementation available") 
 
@@ -59,12 +53,6 @@ method banUserFromCommunity*(self: AccessInterface, pubKey: string, communityId:
   raise newException(ValueError, "No implementation available") 
 
 method requestToJoinCommunity*(self: AccessInterface, communityId: string, ensName: string) {.base.} =
-  raise newException(ValueError, "No implementation available") 
-  
-method acceptRequestToJoinCommunity*(self: AccessInterface, communityId: string, requestId: string) {.base.} =
-  raise newException(ValueError, "No implementation available") 
-
-method declineRequestToJoinCommunity*(self: AccessInterface, communityId: string, requestId: string) {.base.} =
   raise newException(ValueError, "No implementation available") 
 
 method requestCommunityInfo*(self: AccessInterface, communityId: string) {.base.} =

--- a/src/app/modules/main/communities/private_interfaces/module_access_interface.nim
+++ b/src/app/modules/main/communities/private_interfaces/module_access_interface.nim
@@ -25,9 +25,6 @@ method joinCommunity*(self: AccessInterface, communityId: string): string {.base
 method createCommunity*(self: AccessInterface, name: string, description: string, access: int, ensOnly: bool, color: string, imagePath: string, aX: int, aY: int, bX: int, bY: int) {.base.} =
   raise newException(ValueError, "No implementation available") 
 
-method editCommunity*(self: AccessInterface, id: string, name: string, description: string, access: int, ensOnly: bool, color: string, imagePath: string, aX: int, aY: int, bX: int, bY: int) {.base.} =
-  raise newException(ValueError, "No implementation available") 
-
 method createCommunityCategory*(self: AccessInterface, communityId: string, name: string, channels: string) {.base.} =
   raise newException(ValueError, "No implementation available") 
 
@@ -41,10 +38,7 @@ method reorderCommunityCategories*(self: AccessInterface, communityId: string, c
   raise newException(ValueError, "No implementation available") 
 
 method reorderCommunityChannel*(self: AccessInterface, communityId: string, categoryId: string, chatId: string, position: int) {.base} =
-  raise newException(ValueError, "No implementation available") 
-
-method inviteUsersToCommunityById*(self: AccessInterface, communityId: string, pubKeysJSON: string): string {.base.} =
-  raise newException(ValueError, "No implementation available") 
+  raise newException(ValueError, "No implementation available")
 
 method removeUserFromCommunity*(self: AccessInterface, communityId: string, pubKey: string) {.base.} =
   raise newException(ValueError, "No implementation available") 
@@ -61,11 +55,5 @@ method requestCommunityInfo*(self: AccessInterface, communityId: string) {.base.
 method deleteCommunityChat*(self: AccessInterface, communityId: string, channelId: string) {.base.} =
   raise newException(ValueError, "No implementation available") 
 
-method setCommunityMuted*(self: AccessInterface, communityId: string, muted: bool) {.base.} =
-  raise newException(ValueError, "No implementation available") 
-
 method importCommunity*(self: AccessInterface, communityKey: string) {.base.} =
-  raise newException(ValueError, "No implementation available") 
-
-method exportCommunity*(self: AccessInterface, communityId: string): string {.base.} =
   raise newException(ValueError, "No implementation available") 

--- a/src/app/modules/main/communities/view.nim
+++ b/src/app/modules/main/communities/view.nim
@@ -70,9 +70,6 @@ QtObject:
   proc editCommunity*(self: View, id: string, name: string, description: string, access: int, ensOnly: bool, color: string, imagePath: string, aX: int, aY: int, bX: int, bY: int) {.slot.} =
     self.delegate.editCommunity(id, name, description, access, ensOnly, color, imagePath, aX, aY, bX, bY)
   
-  proc createCommunityChannel*(self: View, communityId: string, name: string, description: string) {.slot.} =
-    self.delegate.createCommunityChannel(communityId, name, description)
-  
   proc createCommunityCategory*(self: View, communityId: string, name: string, channels: string) {.slot.} =
     self.delegate.createCommunityCategory(communityId, name, channels)
 
@@ -88,9 +85,6 @@ QtObject:
   proc reorderCommunityChannel*(self: View, communityId: string, categoryId: string, chatId: string, position: int): string {.slot} =
     self.delegate.reorderCommunityChannel(communityId, categoryId, chatId, position)
 
-  proc leaveCommunity*(self: View, communityId: string) {.slot.} =
-    self.delegate.leaveCommunity(communityId)
-
   proc inviteUsersToCommunityById*(self: View, communityId: string, pubKeysJSON: string): string {.slot.} =
     result = self.delegate.inviteUsersToCommunityById(communityId, pubKeysJSON)
   
@@ -102,12 +96,6 @@ QtObject:
 
   proc requestToJoinCommunity*(self: View, communityId: string, ensName: string) {.slot.} =
     self.delegate.requestToJoinCommunity(communityId, ensName)
-   
-  proc acceptRequestToJoinCommunity*(self: View, communityId: string, requestId: string) {.slot.} =
-    self.delegate.acceptRequestToJoinCommunity(communityId, requestId)
-
-  proc declineRequestToJoinCommunity*(self: View, communityId: string, requestId: string) {.slot.} =
-    self.delegate.declineRequestToJoinCommunity(communityId, requestId)
 
   proc requestCommunityInfo*(self: View, communityId: string) {.slot.} =
     self.delegate.requestCommunityInfo(communityId)

--- a/src/app/modules/main/communities/view.nim
+++ b/src/app/modules/main/communities/view.nim
@@ -104,7 +104,7 @@ QtObject:
     self.delegate.requestToJoinCommunity(communityId, ensName)
    
   proc acceptRequestToJoinCommunity*(self: View, communityId: string, requestId: string) {.slot.} =
-    self.delegate.acceptRequestToJoinCommunity(communityId, requestid)
+    self.delegate.acceptRequestToJoinCommunity(communityId, requestId)
 
   proc declineRequestToJoinCommunity*(self: View, communityId: string, requestId: string) {.slot.} =
     self.delegate.declineRequestToJoinCommunity(communityId, requestId)

--- a/src/app/modules/main/communities/view.nim
+++ b/src/app/modules/main/communities/view.nim
@@ -67,9 +67,6 @@ QtObject:
                         aX: int, aY: int, bX: int, bY: int) {.slot.} =
     self.delegate.createCommunity(name, description, access, ensOnly, color, imagePath, aX, aY, bX, bY)
   
-  proc editCommunity*(self: View, id: string, name: string, description: string, access: int, ensOnly: bool, color: string, imagePath: string, aX: int, aY: int, bX: int, bY: int) {.slot.} =
-    self.delegate.editCommunity(id, name, description, access, ensOnly, color, imagePath, aX, aY, bX, bY)
-  
   proc createCommunityCategory*(self: View, communityId: string, name: string, channels: string) {.slot.} =
     self.delegate.createCommunityCategory(communityId, name, channels)
 
@@ -85,9 +82,6 @@ QtObject:
   proc reorderCommunityChannel*(self: View, communityId: string, categoryId: string, chatId: string, position: int): string {.slot} =
     self.delegate.reorderCommunityChannel(communityId, categoryId, chatId, position)
 
-  proc inviteUsersToCommunityById*(self: View, communityId: string, pubKeysJSON: string): string {.slot.} =
-    result = self.delegate.inviteUsersToCommunityById(communityId, pubKeysJSON)
-  
   proc removeUserFromCommunity*(self: View, communityId: string, pubKey: string) {.slot.} =
     self.delegate.removeUserFromCommunity(communityId, pubKey)
 
@@ -103,17 +97,5 @@ QtObject:
   proc deleteCommunityChat*(self: View, communityId: string, channelId: string) {.slot.} =
     self.delegate.deleteCommunityChat(communityId, channelId)
 
-  proc setCommunityMuted*(self: View, communityId: string, muted: bool) {.slot.} =
-    self.delegate.setCommunityMuted(communityId, muted)
-
-  # proc markNotificationsAsRead*(self: View, markAsReadProps: MarkAsReadNotificationProperties) =
-  #   # todo
-  #   discard
-
   proc importCommunity*(self: View, communityKey: string) {.slot.} =
     self.delegate.importCommunity(communityKey)
-
-  proc exportCommunity*(self: View, communityId: string): string {.slot.} =
-    self.delegate.exportCommunity(communityId)
-
-  

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -2,6 +2,7 @@ import NimQml, tables, json, sugar, sequtils
 
 import io_interface, view, controller, ../shared_models/section_item,../shared_models/section_model
 import ../shared_models/member_item, ../shared_models/members_model
+import ./communities/models/[pending_request_item, pending_request_model]
 import ../../global/app_sections_config as conf
 import ../../global/app_signals
 import ../../global/global_singleton
@@ -177,7 +178,15 @@ proc createCommunityItem[T](self: Module[T], c: CommunityDto): SectionItem =
     c.isMember,
     c.permissions.access,
     c.permissions.ensOnly,
-    c.members.map(x => member_item.initItem(x.id, x.roles))
+    c.members.map(x => member_item.initItem(x.id, x.roles)),
+    c.pendingRequestsToJoin.map(x => pending_request_item.initItem(
+      x.id,
+      x.publicKey,
+      x.chatId,
+      x.communityId,
+      x.state,
+      x.our
+    ))
   )
 
 method load*[T](

--- a/src/app/modules/shared_models/active_section.nim
+++ b/src/app/modules/shared_models/active_section.nim
@@ -131,3 +131,12 @@ QtObject:
 
   proc hasMember(self: ActiveSection, pubkey: string): bool {.slot.} =
     return self.item.hasMember(pubkey)
+
+  proc pendingRequestsToJoin(self: ActiveSection): QVariant {.slot.} =
+    if (self.item.id == ""):
+      # FIXME (Jo) I don't know why but the Item is sometimes empty and doing anything here crashes the app
+      return newQVariant("")
+    return newQVariant(self.item.pendingRequestsToJoin)
+
+  QtProperty[QVariant] pendingRequestsToJoin:
+    read = pendingRequestsToJoin

--- a/src/app/modules/shared_models/section_item.nim
+++ b/src/app/modules/shared_models/section_item.nim
@@ -1,5 +1,6 @@
 import strformat
 import ./members_model, ./member_item
+import ../main/communities/models/[pending_request_item, pending_request_model]
 
 type
   SectionType* {.pure.} = enum
@@ -33,6 +34,7 @@ type
     access: int
     ensOnly: bool
     membersModel: MembersModel
+    pendingRequestsToJoinModel: PendingRequestModel
 
 proc initItem*(
     id: string,
@@ -54,7 +56,8 @@ proc initItem*(
     isMember = false,
     access: int = 0,
     ensOnly = false,
-    members: seq[MemberItem] = @[]
+    members: seq[MemberItem] = @[],
+    pendingRequestsToJoin: seq[PendingRequestItem] = @[]
     ): SectionItem =
   result.id = id
   result.sectionType = sectionType
@@ -76,6 +79,7 @@ proc initItem*(
   result.access = access
   result.ensOnly = ensOnly
   result.membersModel = newMembersModel(members)
+  result.pendingRequestsToJoinModel = newPendingRequestModel(pendingRequestsToJoin)
 
 proc isEmpty*(self: SectionItem): bool =
   return self.id.len == 0
@@ -178,3 +182,6 @@ proc members*(self: SectionItem): MembersModel {.inline.} =
 
 proc hasMember*(self: SectionItem, pubkey: string): bool =
   self.membersModel.hasMember(pubkey)
+
+proc pendingRequestsToJoin*(self: SectionItem): PendingRequestModel {.inline.} = 
+  self.pendingRequestsToJoinModel

--- a/src/app/modules/shared_models/section_model.nim
+++ b/src/app/modules/shared_models/section_model.nim
@@ -18,6 +18,13 @@ type
     Enabled
     Joined
     IsMember
+    CanJoin
+    CanManageUsers
+    CanRequestAccess
+    Access
+    EnsOnly
+    MembersModel
+    PendingRequestsToJoinModel
 
 QtObject:
   type
@@ -68,7 +75,14 @@ QtObject:
       ModelRole.Active.int:"active",
       ModelRole.Enabled.int:"enabled",
       ModelRole.Joined.int:"joined",
-      ModelRole.IsMember.int:"isMember"
+      ModelRole.IsMember.int:"isMember",
+      ModelRole.CanJoin.int:"canJoin",
+      ModelRole.CanManageUsers.int:"canManageUsers",
+      ModelRole.CanRequestAccess.int:"canRequestAccess",
+      ModelRole.Access.int:"access",
+      ModelRole.EnsOnly.int:"ensOnly",
+      ModelRole.MembersModel.int:"members",
+      ModelRole.PendingRequestsToJoinModel.int:"pendingRequestsToJoin",
     }.toTable
 
   method data(self: SectionModel, index: QModelIndex, role: int): QVariant =
@@ -110,6 +124,20 @@ QtObject:
       result = newQVariant(item.joined)
     of ModelRole.IsMember: 
       result = newQVariant(item.isMember)
+    of ModelRole.CanJoin: 
+      result = newQVariant(item.canJoin)
+    of ModelRole.CanManageUsers: 
+      result = newQVariant(item.canManageUsers)
+    of ModelRole.CanRequestAccess: 
+      result = newQVariant(item.canRequestAccess)
+    of ModelRole.Access: 
+      result = newQVariant(item.access)
+    of ModelRole.EnsOnly: 
+      result = newQVariant(item.ensOnly)
+    of ModelRole.MembersModel: 
+      result = newQVariant(item.members)
+    of ModelRole.PendingRequestsToJoinModel: 
+      result = newQVariant(item.pendingRequestsToJoin)
 
   proc addItem*(self: SectionModel, item: SectionItem) =
     let parentModelIndex = newQModelIndex()
@@ -155,7 +183,14 @@ QtObject:
       ModelRole.Description.int,
       ModelRole.Image.int,
       ModelRole.Icon.int,
-      ModelRole.Color.int
+      ModelRole.Color.int,
+      ModelRole.HasNotification.int,
+      ModelRole.NotificationsCount.int,
+      ModelRole.IsMember.int,
+      ModelRole.CanJoin.int,
+      ModelRole.Joined.int,
+      ModelRole.MembersModel.int,
+      ModelRole.PendingRequestsToJoinModel.int
       ])
 
   proc getItemById*(self: SectionModel, id: string): SectionItem =

--- a/src/app_service/service/community/dto/community.nim
+++ b/src/app_service/service/community/dto/community.nim
@@ -36,6 +36,14 @@ type Member* = object
   id*: string
   roles*: seq[int]
 
+type CommunityMembershipRequestDto* = object
+  id*: string
+  publicKey*: string
+  chatId*: string
+  communityId*: string
+  state*: int
+  our*: string
+
 type CommunityDto* = object
   id*: string
   admin*: bool
@@ -56,14 +64,7 @@ type CommunityDto* = object
   requestedToJoinAt*: int64
   isMember*: bool
   muted*: bool
-
-type CommunityMembershipRequestDto* = object
-  id*: string
-  publicKey*: string
-  chatId*: string
-  communityId*: string
-  state*: int
-  our*: string
+  pendingRequestsToJoin*: seq[CommunityMembershipRequestDto]
 
 proc toPermission(jsonObj: JsonNode): Permission =
   result = Permission()

--- a/src/app_service/service/community/service.nim
+++ b/src/app_service/service/community/service.nim
@@ -686,23 +686,23 @@ QtObject:
       let response =  status_go.inviteUsersToCommunity(communityId, pubKeys)
       discard self.chatService.processMessageUpdateAfterSend(response)
     except Exception as e:
-      error "Error exporting community", msg = e.msg
+      error "Error inviting to community", msg = e.msg
       result = "Error exporting community: " & e.msg
 
   proc removeUserFromCommunity*(self: Service, communityId: string, pubKeys: string)  =
     try:
       discard status_go.removeUserFromCommunity(communityId, pubKeys)
     except Exception as e:
-      error "Error exporting community", msg = e.msg
+      error "Error removing user from community", msg = e.msg
 
   proc banUserFromCommunity*(self: Service, communityId: string, pubKey: string)  =
     try:
       discard status_go.banUserFromCommunity(communityId, pubKey)
     except Exception as e:
-      error "Error exporting community", msg = e.msg
+      error "Error banning user from community", msg = e.msg
 
   proc setCommunityMuted*(self: Service, communityId: string, muted: bool) =
     try:
       discard status_go.setCommunityMuted(communityId, muted)
     except Exception as e:
-      error "Error exporting community", msg = e.msg
+      error "Error setting community un/muted", msg = e.msg

--- a/src/app_service/service/community/service.nim
+++ b/src/app_service/service/community/service.nim
@@ -74,6 +74,8 @@ QtObject:
   proc loadAllCommunities(self: Service): seq[CommunityDto]
   proc loadJoinedComunities(self: Service): seq[CommunityDto]
   proc loadMyPendingRequestsToJoin*(self: Service)
+  proc handleCommunityUpdates(self: Service, communities: seq[CommunityDto], updatedChats: seq[ChatDto])
+  proc pendingRequestsToJoinForCommunity*(self: Service, communityId: string): seq[CommunityMembershipRequestDto]
 
   proc delete*(self: Service) =
     discard
@@ -85,6 +87,30 @@ QtObject:
     result.joinedCommunities = initTable[string, CommunityDto]()
     result.allCommunities = initTable[string, CommunityDto]()
     result.myCommunityRequests = @[]
+
+  proc doConnect(self: Service) =
+    self.events.on(SignalType.Message.event) do(e: Args):
+      var receivedData = MessageSignal(e)
+
+      # Handling community updates
+      if (receivedData.communities.len > 0):
+        # Channel added removed is notified in the chats param
+        if (receivedData.chats.len > 0):
+          self.handleCommunityUpdates(receivedData.communities, receivedData.chats)
+
+        self.events.emit(SIGNAL_COMMUNITIES_UPDATE, CommunitiesArgs(communities: receivedData.communities))
+
+    self.events.on(SignalType.Message.event) do(e:Args):
+      var receivedData = MessageSignal(e)
+      if(receivedData.membershipRequests.len > 0):
+        for membershipRequest in receivedData.membershipRequests:
+          if (not self.joinedCommunities.contains(membershipRequest.communityId)):
+            error "Received a membership request for an unknown community", communityId=membershipRequest.communityId
+            continue
+          var community = self.joinedCommunities[membershipRequest.communityId]
+          community.pendingRequestsToJoin.add(membershipRequest)
+          self.joinedCommunities[membershipRequest.communityId] = community
+          self.events.emit(SIGNAL_COMMUNITY_EDITED, CommunityArgs(community: community))
 
   proc mapChatToChatDto(chat: Chat): ChatDto =
     result = ChatDto()
@@ -165,10 +191,14 @@ QtObject:
     self.joinedCommunities[community.id].chats = community.chats
 
   proc init*(self: Service) =
+    self.doConnect()
+
     try:
       let joinedCommunities = self.loadJoinedComunities()
       for community in joinedCommunities:
         self.joinedCommunities[community.id] = community
+        if (community.admin):
+          self.joinedCommunities[community.id].pendingRequestsToJoin = self.pendingRequestsToJoinForCommunity(community.id)
 
       let allCommunities = self.loadAllCommunities()
       for community in allCommunities:
@@ -180,18 +210,6 @@ QtObject:
       let errDesription = e.msg
       error "error: ", errDesription
       return
-
-    self.events.on(SignalType.Message.event) do(e: Args):
-      var receivedData = MessageSignal(e)
-
-      # Handling community updates
-      if (receivedData.communities.len > 0):
-
-        # Channel added removed is notified in the chats param
-        if (receivedData.chats.len > 0):
-          self.handleCommunityUpdates(receivedData.communities, receivedData.chats)
-
-        self.events.emit(SIGNAL_COMMUNITIES_UPDATE, CommunitiesArgs(communities: receivedData.communities))
 
   proc loadAllCommunities(self: Service): seq[CommunityDto] =
     let response = status_go.getAllCommunities()
@@ -324,6 +342,17 @@ QtObject:
           self.events.emit(SIGNAL_COMMUNITY_MY_REQUEST_ADDED, CommunityRequestArgs(communityRequest: communityRequest))
     except Exception as e:
       error "Error fetching my community requests", msg = e.msg
+
+  proc pendingRequestsToJoinForCommunity*(self: Service, communityId: string): seq[CommunityMembershipRequestDto] =
+    try:
+      let response = status_go.pendingRequestsToJoinForCommunity(communityId)
+
+      result = @[]
+      if response.result.kind != JNull:
+        for jsonCommunityReqest in response.result:
+          result.add(jsonCommunityReqest.toCommunityMembershipRequestDto())
+    except Exception as e:
+      error "Error fetching community requests", msg = e.msg
 
   proc leaveCommunity*(self: Service, communityId: string) =
     try:
@@ -608,17 +637,45 @@ QtObject:
     except Exception as e:
       error "Error exporting community", msg = e.msg
 
-  proc acceptRequestToJoinCommunity*(self: Service, requestId: string) =
+  proc getPendingRequestIndex*(self: Service, communityId: string, requestId: string): int =
+    let community = self.joinedCommunities[communityId]
+    var i = 0
+    for pendingRequest in community.pendingRequestsToJoin:
+      if (pendingRequest.id == requestId):
+        return i
+      i.inc()
+    return -1
+
+  proc removeMembershipRequestFromCommunity*(self: Service, communityId: string, requestId: string) =
+    let index = self.getPendingRequestIndex(communityId, requestId)
+
+    if (index == -1):
+      raise newException(RpcException, fmt"Community request not found: {requestId}")
+
+    var community = self.joinedCommunities[communityId]
+    community.pendingRequestsToJoin.delete(index)
+
+    self.joinedCommunities[communityId] = community
+
+  proc acceptRequestToJoinCommunity*(self: Service, communityId: string, requestId: string) =
     try:
       discard status_go.acceptRequestToJoinCommunity(requestId)
-    except Exception as e:
-      error "Error exporting community", msg = e.msg
 
-  proc declineRequestToJoinCommunity*(self: Service, requestId: string) =
+      self.removeMembershipRequestFromCommunity(communityId, requestId)
+
+      self.events.emit(SIGNAL_COMMUNITY_EDITED, CommunityArgs(community: self.joinedCommunities[communityId]))
+    except Exception as e:
+      error "Error accepting request to join community", msg = e.msg
+
+  proc declineRequestToJoinCommunity*(self: Service, communityId: string, requestId: string) =
     try:
       discard status_go.declineRequestToJoinCommunity(requestId)
+
+      self.removeMembershipRequestFromCommunity(communityId, requestId)
+
+      self.events.emit(SIGNAL_COMMUNITY_EDITED, CommunityArgs(community: self.joinedCommunities[communityId]))
     except Exception as e:
-      error "Error exporting community", msg = e.msg
+      error "Error declining request to join community", msg = e.msg
 
   proc inviteUsersToCommunityById*(self: Service, communityId: string, pubKeysJson: string): string =
     try:

--- a/ui/app/AppLayouts/Chat/panels/communities/CommunityProfilePopupInviteFriendsPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/CommunityProfilePopupInviteFriendsPanel.qml
@@ -19,11 +19,12 @@ Column {
 
     property var rootStore
     property var contactsStore
+    property var communitySectionModule
     property var community
     property alias contactListSearch: contactFieldAndList
 
     function sendInvites(pubKeys) {
-       const error = root.rootStore.inviteUsersToCommunityById(root.community.id, JSON.stringify(pubKeys))
+       const error = communitySectionModule.inviteUsersToCommunity(JSON.stringify(pubKeys))
        if (error) {
            console.error('Error inviting', error)
            contactFieldAndList.validationError = error

--- a/ui/app/AppLayouts/Chat/panels/communities/CommunityProfilePopupMembersListPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/CommunityProfilePopupMembersListPanel.qml
@@ -26,6 +26,7 @@ Item {
     property alias members: memberList.model
     property var community
     property var store
+    property var communitySectionModule
 
     signal inviteButtonClicked()
 
@@ -41,7 +42,7 @@ Item {
         StatusListItem {
             id: inviteButton
             anchors.horizontalCenter: parent.horizontalCenter
-            visible: !!(root.community.admin || root.community.isAdmin)
+            visible: root.community.amISectionAdmin
             //% "Invite People"
             title: qsTrId("invite-people")
             icon.name: "share-ios"
@@ -67,7 +68,9 @@ Item {
             //% "Membership requests"
             title: qsTrId("membership-requests")
             requestsCount: nbRequests
-            sensor.onClicked: Global.openPopup(membershipRequestPopup)
+            sensor.onClicked: Global.openPopup(membershipRequestPopup, {
+                communitySectionModule: root.communitySectionModule
+            })
         }
 
         StatusModalDivider {
@@ -179,7 +182,7 @@ Item {
                                 }
 
                                 StatusMenuSeparator {
-                                    visible: root.community.admin
+                                    visible: root.community.amISectionAdmin
                                 }
 
                                 StatusMenuItem {
@@ -188,7 +191,7 @@ Item {
                                     icon.name: "arrow-right"
                                     iconRotation: 180
                                     type: StatusMenuItem.Type.Danger
-                                    enabled: root.community.admin
+                                    enabled: root.community.amISectionAdmin
                                     // Not Refactored Yet
 //                                    onTriggered: chatsModel.communities.removeUserFromCommunity(model.pubKey)
                                 }
@@ -198,7 +201,7 @@ Item {
                                     text: qsTrId("ban")
                                     icon.name: "cancel"
                                     type: StatusMenuItem.Type.Danger
-                                    enabled: root.community.admin
+                                    enabled: root.community.amISectionAdmin
                                     // Not Refactored Yet
 //                                    onTriggered: chatsModel.communities.banUserFromCommunity(model.pubKey, root.community.id)
                                 }

--- a/ui/app/AppLayouts/Chat/panels/communities/CommunityProfilePopupMembersListPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/CommunityProfilePopupMembersListPanel.qml
@@ -59,9 +59,9 @@ Item {
 
             id: memberRequestsButton
 
-            property int nbRequests: root.community.communityMembershipRequests.nbRequests
+            property int nbRequests: root.community.pendingRequestsToJoin.count
             width: parent.width - 32
-            visible: (root.community.isAdmin || root.community.admin) && nbRequests > 0
+            visible: root.community.amISectionAdmin && nbRequests > 0
             anchors.horizontalCenter: parent.horizontalCenter
 
             //% "Membership requests"
@@ -213,6 +213,8 @@ Item {
     Component {
         id: membershipRequestPopup
         MembershipRequestsPopup {
+            store: root.store
+            pendingRequestsToJoin: root.community.pendingRequestsToJoin
             anchors.centerIn: parent
             onClosed: {
                 destroy()

--- a/ui/app/AppLayouts/Chat/panels/communities/CommunityProfilePopupOverviewPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/CommunityProfilePopupOverviewPanel.qml
@@ -70,7 +70,7 @@ Column {
         id: membersListItem
         anchors.horizontalCenter: parent.horizontalCenter
 
-        property int nbRequests: root.community.communityMembershipRequests.nbRequests
+        property int nbRequests: root.community.pendingRequestsToJoin.count
 
         //% "Members"
         title: qsTrId("members-label")

--- a/ui/app/AppLayouts/Chat/panels/communities/CommunityWelcomeBannerPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/CommunityWelcomeBannerPanel.qml
@@ -23,6 +23,7 @@ Rectangle {
     color: Style.current.transparent
     property var activeCommunity
     property var store
+    property var communitySectionModule
     property bool hasAddedContacts
 
     MouseArea {
@@ -104,7 +105,8 @@ Rectangle {
         anchors.bottomMargin: Style.current.padding
         onClicked: Global.openPopup(communityProfilePopup, {
             store: rootStore,
-            community: root.activeCommunity
+            community: root.activeCommunity,
+            communitySectionModule: root.communitySectionModule
         })
     }
 }

--- a/ui/app/AppLayouts/Chat/panels/communities/CommunityWelcomeBannerPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/CommunityWelcomeBannerPanel.qml
@@ -92,7 +92,8 @@ Rectangle {
         anchors.bottomMargin: Style.current.halfPadding
         onClicked: Global.openPopup(inviteFriendsToCommunityPopup, {
             community: root.activeCommunity,
-            hasAddedContacts: root.hasAddedContacts
+            hasAddedContacts: root.hasAddedContacts,
+            communitySectionModule: root.communitySectionModule
         })
     }
 

--- a/ui/app/AppLayouts/Chat/popups/community/CommunityProfilePopup.qml
+++ b/ui/app/AppLayouts/Chat/popups/community/CommunityProfilePopup.qml
@@ -14,6 +14,8 @@ StatusModal {
 
     property var store
     property var community
+    property var contactsStore
+    property bool hasAddedContacts
     property var communitySectionModule
 
     onClosed: {
@@ -61,16 +63,15 @@ StatusModal {
                 community: root.community
 
                 onMembersListButtonClicked: root.contentItem.push(membersList)
-                onNotificationsButtonClicked: {
-                    root.store.setCommunityMuted(root.community.id, checked);
-                }
+                onNotificationsButtonClicked: root.communitySectionModule.setCommunityMuted(checked)
                 onEditButtonClicked: Global.openPopup(editCommunityroot, {
                     store: root.store,
                     community: root.community,
+                    communitySectionModule: root.communitySectionModule,
                     onSave: root.close
                 })
                 onTransferOwnershipButtonClicked: Global.openPopup(transferOwnershiproot, {
-                    privateKey: root.store.exportCommunity(root.community.id),
+                    privateKey: communitySectionModule.exportCommunity(root.community.id),
                     store: root.store
                 })
                 onLeaveButtonClicked: {
@@ -127,13 +128,14 @@ StatusModal {
                 //% "Invite friends"
                 headerTitle: qsTrId("invite-friends")
                 community: root.community
+                communitySectionModule: root.communitySectionModule
+                contactsStore: root.contactsStore
 
                 contactListSearch.chatKey.text: ""
                 contactListSearch.pubKey: ""
                 contactListSearch.pubKeys: []
                 contactListSearch.ensUsername: ""
-                // Not Refactored Yet
-//                contactListSearch.existingContacts.visible: root.store.allContacts.hasAddedContacts()
+                contactListSearch.existingContacts.visible: root.hasAddedContacts
                 contactListSearch.noContactsRect.visible: !contactListSearch.existingContacts.visible
             }
         }

--- a/ui/app/AppLayouts/Chat/popups/community/CommunityProfilePopup.qml
+++ b/ui/app/AppLayouts/Chat/popups/community/CommunityProfilePopup.qml
@@ -14,6 +14,7 @@ StatusModal {
 
     property var store
     property var community
+    property var communitySectionModule
 
     onClosed: {
         while (contentItem.depth > 1) {
@@ -73,7 +74,7 @@ StatusModal {
                     store: root.store
                 })
                 onLeaveButtonClicked: {
-                    root.store.leaveCommunity(root.community.id);
+                    communitySectionModule.leaveCommunity();
                     root.close();
                 }
                 onCopyToClipboard: {
@@ -114,6 +115,7 @@ StatusModal {
                 headerTitle: qsTrId("members-label")
                 headerSubtitle: root.community.members.count.toString()
                 community: root.community
+                communitySectionModule: root.communitySectionModule
                 onInviteButtonClicked: root.contentItem.push(inviteFriendsView)
             }
         }

--- a/ui/app/AppLayouts/Chat/popups/community/CreateCommunityPopup.qml
+++ b/ui/app/AppLayouts/Chat/popups/community/CreateCommunityPopup.qml
@@ -19,6 +19,7 @@ StatusModal {
     height: 509
 
     property var store
+    property var communitySectionModule
     property bool isEdit: false
     // Not Refactored Yet
     property QtObject community: null //popup.store.chatsModelInst.communities.activeCommunity
@@ -408,8 +409,7 @@ StatusModal {
 
                 let error = false;
                 if(isEdit) {
-                    error = popup.store.editCommunity(
-                        community.id,
+                    error = communitySectionModule.editCommunity(
                         Utils.filterXSS(popup.contentItem.communityName.input.text),
                         Utils.filterXSS(popup.contentItem.communityDescription.input.text),
                         membershipRequirementSettingPopup.checkedMembership,

--- a/ui/app/AppLayouts/Chat/popups/community/InviteFriendsToCommunityPopup.qml
+++ b/ui/app/AppLayouts/Chat/popups/community/InviteFriendsToCommunityPopup.qml
@@ -18,6 +18,7 @@ StatusModal {
     property var rootStore
     property var contactsStore
     property var community
+    property var communitySectionModule
     property bool hasAddedContacts
 
     onOpened: {
@@ -38,6 +39,7 @@ StatusModal {
     contentItem: CommunityProfilePopupInviteFriendsPanel {
         id: contactFieldAndList
         rootStore: popup.rootStore
+        communitySectionModule: popup.communitySectionModule
         contactsStore: popup.contactsStore
         community: popup.community
         contactListSearch.onUserClicked: {

--- a/ui/app/AppLayouts/Chat/popups/community/MembershipRequestsPopup.qml
+++ b/ui/app/AppLayouts/Chat/popups/community/MembershipRequestsPopup.qml
@@ -14,6 +14,7 @@ import shared 1.0
 StatusModal {
     id: popup
     property var store
+    property var communitySectionModule
     property var pendingRequestsToJoin
     onOpened: {
         contentItem.errorText.text = ""
@@ -86,7 +87,7 @@ StatusModal {
                                 hoverEnabled: true
                                 anchors.fill: parent
                                 cursorShape: Qt.PointingHandCursor
-                                onClicked: popup.store.acceptRequestToJoinCommunity(model.communityId, id)
+                                onClicked: communitySectionModule.acceptRequestToJoinCommunity(id)
                             }
                         },
                         StatusRoundIcon {
@@ -100,7 +101,7 @@ StatusModal {
                                 hoverEnabled: true
                                 anchors.fill: parent
                                 cursorShape: Qt.PointingHandCursor
-                                onClicked: popup.store.declineRequestToJoinCommunity(model.communityId, id)
+                                onClicked: communitySectionModule.declineRequestToJoinCommunity(id)
                             }
                         }
                     ]

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -157,8 +157,8 @@ QtObject {
 //        chatsModelInst.communities.deleteCommunityCategory(chatsModelInst.communities.activeCommunity.id, categoryId);
     }
 
-    function leaveCommunity(communityId) {
-        communitiesModuleInst.leaveCommunity(communityId);
+    function leaveCommunity() {
+        chatCommunitySectionModule.leaveCommunity();
     }
 
     function setCommunityMuted(communityId, checked) {
@@ -169,8 +169,8 @@ QtObject {
         return communitiesModuleInst.exportCommunity(communityId);
     }
 
-    function createCommunityChannel(communityId, channelName, channelDescription) {
-        communitiesModuleInst.createCommunityChannel(communityId, channelName, channelDescription);
+    function createCommunityChannel(channelName, channelDescription) {
+        chatCommunitySectionModule.createCommunityChannel(channelName, channelDescription);
     }
 
     function editCommunityChannel(communityId, channelId, channelName, channelDescription, channelCategoryId, popupPosition) {
@@ -181,12 +181,12 @@ QtObject {
 //        chatsModelInst.editCommunityChannel(communityId, channelId, channelName, channelDescription, channelCategoryId, popupPosition);
     }
 
-    function acceptRequestToJoinCommunity(communityId, requestId) {
-        communitiesModuleInst.acceptRequestToJoinCommunity(communityId, requestId)
+    function acceptRequestToJoinCommunity(requestId) {
+        chatCommunitySectionModule.acceptRequestToJoinCommunity(requestId)
     }
 
-    function declineRequestToJoinCommunity(communityId, requestId) {
-        communitiesModuleInst.declineRequestToJoinCommunity(communityId, requestId)
+    function declineRequestToJoinCommunity(requestId) {
+        chatCommunitySectionModule.declineRequestToJoinCommunity(requestId)
     }
 
     function userNameOrAlias(pk) {

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -194,12 +194,12 @@ QtObject {
 //        return chatsModelInst.userNameOrAlias(pk);
     }
 
-    function generateIdenticon(pk) {
-        return globalUtils.generateIdenticon(pk)
+    function generateAlias(pk) {
+        return globalUtils.generateAlias(pk);
     }
 
-    function generateAlias(pk) {
-        return globalUtils.generateAlias(pk)
+    function generateIdenticon(pk) {
+        return globalUtils.generateIdenticon(pk);
     }
 
     function plainText(text) {

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -139,10 +139,6 @@ QtObject {
         communitiesModuleInst.createCommunity(communityName, communityDescription, checkedMembership, ensOnlySwitchChecked, communityColor, communityImage, imageCropperModalaX, imageCropperModalaY, imageCropperModalbX, imageCropperModalbY);
     }
 
-    function editCommunity(communityId, communityName, communityDescription, checkedMembership, ensOnlySwitchChecked, communityColor, communityImage, imageCropperModalaX, imageCropperModalaY, imageCropperModalbX, imageCropperModalbY) {
-        communitiesModuleInst.editCommunity(communityId, communityName, communityDescription, checkedMembership, ensOnlySwitchChecked, communityColor, communityImage, imageCropperModalaX, imageCropperModalaY, imageCropperModalbX, imageCropperModalbY);
-    }
-
     function createCommunityCategory(communityId, categoryName, channels) {
         // Not Refactored Yet
 //        chatsModelInst.communities.createCommunityCategory(communityId, categoryName, channels);
@@ -159,14 +155,6 @@ QtObject {
 
     function leaveCommunity() {
         chatCommunitySectionModule.leaveCommunity();
-    }
-
-    function setCommunityMuted(communityId, checked) {
-        communitiesModuleInst.setCommunityMuted(communityId, checked);
-    }
-
-    function exportCommunity(communityId) {
-        return communitiesModuleInst.exportCommunity(communityId);
     }
 
     function createCommunityChannel(channelName, channelDescription) {

--- a/ui/app/AppLayouts/Chat/views/CommunityColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/CommunityColumnView.qml
@@ -89,17 +89,13 @@ Item {
     Loader {
         id: membershipRequests
 
-        // Not Refactored Yet
-        property int nbRequests: 0
-        //property int nbRequests: root.store.chatsModelInst.communities.activeCommunity.communityMembershipRequests.nbRequests
+        property int nbRequests: root.communityData.pendingRequestsToJoin.count
 
         anchors.top: communityHeader.bottom
         anchors.topMargin: active ? 8 : 0
         anchors.horizontalCenter: parent.horizontalCenter
 
-        // Not Refactored Yet
-        active: nbRequests > 0
-        //active: communityData.amISectionAdmin && nbRequests > 0
+        active: communityData.amISectionAdmin && nbRequests > 0
         height: nbRequests > 0 ? 64 : 0
         sourceComponent: Component {
             StatusContactRequestsIndicatorListItem {
@@ -454,6 +450,7 @@ Item {
         MembershipRequestsPopup {
             anchors.centerIn: parent
             store: root.store
+            pendingRequestsToJoin: root.communityData.pendingRequestsToJoin
             onClosed: {
                 destroy()
             }

--- a/ui/app/AppLayouts/Chat/views/CommunityColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/CommunityColumnView.qml
@@ -81,7 +81,8 @@ Item {
                 enabled: communityData.canManageUsers
                 onTriggered: Global.openPopup(inviteFriendsToCommunityPopup, {
                     community: communityData,
-                    hasAddedContacts: root.hasAddedContacts
+                    hasAddedContacts: root.hasAddedContacts,
+                    communitySectionModule: root.communitySectionModule
                 })
             }
         }
@@ -200,7 +201,8 @@ Item {
                     enabled: communityData.canManageUsers
                     onTriggered: Global.openPopup(inviteFriendsToCommunityPopup, {
                         community: communityData,
-                        hasAddedContacts: root.hasAddedContacts
+                        hasAddedContacts: root.hasAddedContacts,
+                        communitySectionModule: root.communitySectionModule
                     })
                 }
             }
@@ -373,7 +375,7 @@ Item {
                         activeCommunity: communityData
                         onBackupButtonClicked: {
                             Global.openPopup(transferOwnershipPopup, {
-                                privateKey: root.store.exportCommunity(communityData.id),
+                                privateKey: communitySectionModule.exportCommunity(communityData.id),
                                 store: root.store
                             })
                         }

--- a/ui/app/AppLayouts/Chat/views/CommunityColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/CommunityColumnView.qml
@@ -48,10 +48,10 @@ Item {
         chatInfoButton.image.source: communityData.image
         chatInfoButton.icon.color: communityData.color
         menuButton.visible: communityData.amISectionAdmin && communityData.canManageUsers
-        // TODO remove dynamic scoping of popup component
         chatInfoButton.onClicked: Global.openPopup(communityProfilePopup, {
             store: root.store,
-            community: communityData
+            community: communityData,
+            communitySectionModule: root.communitySectionModule
         })
 
         popupMenu: StatusPopupMenu {
@@ -102,7 +102,9 @@ Item {
                 //% "Membership requests"
                 title: qsTrId("membership-requests")
                 requestsCount: membershipRequests.nbRequests
-                sensor.onClicked: Global.openPopup(membershipRequestPopup)
+                sensor.onClicked: Global.openPopup(membershipRequestPopup, {
+                    communitySectionModule: root.communitySectionModule
+                })
             }
         }
     }
@@ -347,6 +349,7 @@ Item {
                     activeCommunity: communityData
                     store: root.store
                     hasAddedContacts: root.hasAddedContacts
+                    communitySectionModule: root.communitySectionModule
                 }
             }
         }
@@ -394,7 +397,7 @@ Item {
         CreateChannelPopup {
             anchors.centerIn: parent
             onCreateCommunityChannel: function (chName, chDescription) {
-                root.store.createCommunityChannel(communityData.id, chName, chDescription)
+                root.store.createCommunityChannel(chName, chDescription)
             }
             onClosed: {
                 destroy()

--- a/ui/app/AppLayouts/Chat/views/ContactsColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ContactsColumnView.qml
@@ -374,7 +374,7 @@ Item {
 //                root.store.chatsModelInst.communities.setActiveCommunity(id)
 //            }
            onSetObservedCommunity: {
-               root.store.communitiesModuleInst.setObservedCommunity(id)
+               root.store.setObservedCommunity(id)
            }
             onClosed: {
                 destroy()

--- a/ui/app/AppLayouts/stores/RootStore.qml
+++ b/ui/app/AppLayouts/stores/RootStore.qml
@@ -39,24 +39,8 @@ QtObject {
         communitiesModuleInst.setObservedCommunity(communityId);
     }
 
-    function setCommunityMuted(communityId, checked) {
-        communitiesModuleInst.setCommunityMuted(communityId, checked);
-    }
-
-    function exportCommunity(communityId) {
-        return communitiesModuleInst.exportCommunity(communityId);
-    }
-
     function createCommunity(communityName, communityDescription, checkedMembership, ensOnlySwitchChecked, communityColor, communityImage, imageCropperModalaX, imageCropperModalaY, imageCropperModalbX, imageCropperModalbY) {
         communitiesModuleInst.createCommunity(communityName, communityDescription, checkedMembership, ensOnlySwitchChecked, communityColor, communityImage, imageCropperModalaX, imageCropperModalaY, imageCropperModalbX, imageCropperModalbY);
-    }
-
-    function editCommunity(communityId, communityName, communityDescription, checkedMembership, ensOnlySwitchChecked, communityColor, communityImage, imageCropperModalaX, imageCropperModalaY, imageCropperModalbX, imageCropperModalbY) {
-        communitiesModuleInst.editCommunity(communityId, communityName, communityDescription, checkedMembership, ensOnlySwitchChecked, communityColor, communityImage, imageCropperModalaX, imageCropperModalaY, imageCropperModalbX, imageCropperModalbY);
-    }
-
-    function inviteUsersToCommunityById(communityId, pubkeysJson) {
-        communitiesModuleInst.inviteUsersToCommunityById(communityId, pubkeysJson);
     }
 
     function copyToClipboard(text) {

--- a/ui/app/AppLayouts/stores/RootStore.qml
+++ b/ui/app/AppLayouts/stores/RootStore.qml
@@ -47,10 +47,6 @@ QtObject {
         return communitiesModuleInst.exportCommunity(communityId);
     }
 
-    function leaveCommunity(communityId) {
-        communitiesModuleInst.leaveCommunity(communityId);
-    }
-
     function createCommunity(communityName, communityDescription, checkedMembership, ensOnlySwitchChecked, communityColor, communityImage, imageCropperModalaX, imageCropperModalaY, imageCropperModalbX, imageCropperModalbY) {
         communitiesModuleInst.createCommunity(communityName, communityDescription, checkedMembership, ensOnlySwitchChecked, communityColor, communityImage, imageCropperModalaX, imageCropperModalaY, imageCropperModalbX, imageCropperModalbY);
     }
@@ -65,5 +61,13 @@ QtObject {
 
     function copyToClipboard(text) {
         globalUtils.copyToClipboard(text)
+    }
+
+    function generateAlias(pk) {
+        return globalUtils.generateAlias(pk);
+    }
+
+    function generateIdenticon(pk) {
+        return globalUtils.generateIdenticon(pk);
     }
 }

--- a/ui/app/AppMain.qml
+++ b/ui/app/AppMain.qml
@@ -248,17 +248,23 @@ Item {
                 popupMenu: StatusPopupMenu {
                     id: communityContextMenu
 
+                    property var chatCommunitySectionModule
+
                     openHandler: function () {
-                        appMain.rootStore.setObservedCommunity(model.id)
+                        // // we cannot return QVariant if we pass another parameter in a function call
+                        // // that's why we're using it this way
+                        mainModule.prepareCommunitySectionModuleForCommunityId(model.id)
+                        communityContextMenu.chatCommunitySectionModule = mainModule.getCommunitySectionModule()
+                        
                     }
 
                     StatusMenuItem {
                         //% "Invite People"
                         text: qsTrId("invite-people")
                         icon.name: "share-ios"
-                        enabled: appMain.rootStore.observedCommunity.canManageUsers
+                        enabled: model.canManageUsers
                         onTriggered: Global.openPopup(inviteFriendsToCommunityPopup, {
-                            community: appMain.rootStore.observedCommunity,
+                            community: model,
                             hasAddedContacts: appMain.rootStore.hasAddedContacts
                         })
                     }
@@ -269,18 +275,19 @@ Item {
                         icon.name: "group-chat"
                         onTriggered: Global.openPopup(communityProfilePopup, {
                             store: appMain.rootStore,
-                            community: appMain.rootStore.observedCommunity
+                            community: model,
+                            communitySectionModule: communityContextMenu.chatCommunitySectionModule
                         })
                     }
 
                     StatusMenuItem {
-                        enabled: appMain.rootStore.observedCommunity.amISectionAdmin
+                        enabled: model.amISectionAdmin
                         //% "Edit Community"
                         text: qsTrId("edit-community")
                         icon.name: "edit"
                         onTriggered: Global.openPopup(editCommunityPopup, {
                             store: appMain.rootStore,
-                            community: appMain.rootStore.observedCommunity
+                            community: model
                         })
                     }
 
@@ -293,7 +300,7 @@ Item {
                         icon.width: 14
                         iconRotation: 180
                         type: StatusMenuItem.Type.Danger
-                        onTriggered: appMain.rootStore.leaveCommunity(model.id)
+                        onTriggered: communityContextMenu.chatCommunitySectionModule.leaveCommunity()
                     }
                 }
             }

--- a/ui/app/AppMain.qml
+++ b/ui/app/AppMain.qml
@@ -265,7 +265,8 @@ Item {
                         enabled: model.canManageUsers
                         onTriggered: Global.openPopup(inviteFriendsToCommunityPopup, {
                             community: model,
-                            hasAddedContacts: appMain.rootStore.hasAddedContacts
+                            hasAddedContacts: appMain.rootStore.hasAddedContacts,
+                            communitySectionModule: communityContextMenu.chatCommunitySectionModule
                         })
                     }
 
@@ -287,7 +288,8 @@ Item {
                         icon.name: "edit"
                         onTriggered: Global.openPopup(editCommunityPopup, {
                             store: appMain.rootStore,
-                            community: model
+                            community: model,
+                            communitySectionModule: communityContextMenu.chatCommunitySectionModule
                         })
                     }
 
@@ -644,6 +646,8 @@ Item {
 
             CommunityProfilePopup {
                 anchors.centerIn: parent
+                contactsStore: appMain.rootStore.contactStore
+                hasAddedContacts: appMain.rootStore.hasAddedContacts
 
                 onClosed: {
                     destroy()


### PR DESCRIPTION
Fixes #4442

The issue itself could have been solved by just commenting stuff, but instead I implemented the feature on the fron-end.

Now, community admins can receive membership requests for "on-request" communities.
In the modal, they can accept of decline those requests.

To test this, I used a test mobile account. I sent the community link in a public chat, and opened the link in mobile. If the community data is not fetched, you can edit the community (just change the description) on desktop and the community data should propagate.
From there, just Request access on mobile. The Membership request will appear on desktop.

Depends on https://github.com/status-im/status-lib/pull/164