### PR TITLE
fix(@desktop/ProfilePopup): [base_bc] share profile url in profile modal is incorrect

### DIFF
--- a/ui/app/AppMain.qml
+++ b/ui/app/AppMain.qml
@@ -138,6 +138,7 @@ Item {
 
     property Component profilePopupComponent: ProfilePopup {
         id: profilePopup
+        profileStore: appMain.rootStore.profileSectionStore.profileStore
         contactsStore: appMain.rootStore.profileSectionStore.contactsStore
         onClosed: {
             if  (profilePopup.parentPopup) {

--- a/ui/imports/shared/popups/ProfilePopup.qml
+++ b/ui/imports/shared/popups/ProfilePopup.qml
@@ -20,6 +20,7 @@ StatusModal {
 
     property Popup parentPopup
 
+    property var profileStore
     property var contactsStore
 
     property string userPublicKey: ""
@@ -60,7 +61,7 @@ StatusModal {
         isAddedContact = contactDetails.isContact
 
         text = "" // this is most likely unneeded
-        isCurrentUser = userProfile.pubKey === publicKey
+        isCurrentUser = popup.profileStore.pubkey === publicKey
         showFooter = !isCurrentUser
         popup.open()
     }
@@ -137,14 +138,15 @@ StatusModal {
             StatusDescriptionListItem {
                 title: qsTr("Share Profile URL")
                 subTitle: {
+
                     let user = ""
                     if (isCurrentUser) {
-                         user = userProfile.name
-                    } else {
-                        if (userIsEnsVerified) {
-                            user = userEnsName
-                        }
+                        user = popup.profileStore.ensName !== "" ? popup.profileStore.ensName :
+                                                                   (popup.profileStore.pubkey.substring(0, 5) + "..." + popup.profileStore.pubkey.substring(popup.profileStore.pubkey.length - 5))
+                    } else if (userIsEnsVerified) {
+                        user = userEnsName
                     }
+
                     if (user === ""){
                         user = userPublicKey.substr(0, 4) + "..." + userPublicKey.substr(userPublicKey.length - 5)
                     }
@@ -155,17 +157,11 @@ StatusModal {
                 iconButton.onClicked: {
                     let user = ""
                     if (isCurrentUser) {
-                         user = userProfile.name
+                        user = popup.profileStore.ensName !== "" ? popup.profileStore.ensName : popup.profileStore.pubkey
                     } else {
-                        if (userIsEnsVerified) {
-                            user = userName.startsWith("@") ? userName.substring(1) : userName
-                        }
+                        user = (userEnsName !== "" ? userEnsName : userPublicKey)
                     }
-                    if (user === ""){
-                        user = userPublicKey
-                    }
-
-                    globalUtils.copyToClipboard(subTitle)
+                    popup.profileStore.copyToClipboard(Constants.userLinkPrefix + user)
                     tooltip.visible = !tooltip.visible
                 }
                 width: parent.width


### PR DESCRIPTION
Closes #4419

### What does the PR do

Using `profileStore` property  _profile modal_ shows  ENS name or public key.
_Copy to clipboard_ action copies, as well, the same information.
It also fixes the same issue but in Contact/ViewProfile/ShareProfileURL. It was also showing incorrect info.

### Affected areas
ProfileModal/ViewProfile/ShareProfileURL
Contact/ViewProfile/ShareProfileURL

### Screenshot of functionality
PROFILE MODAL:
![image](https://user-images.githubusercontent.com/97019400/149793420-014bfa73-2ad5-4d83-a6fc-d97dd33afce0.png)

CONTACT/VIEW PROFILE:
![image](https://user-images.githubusercontent.com/97019400/149793549-ff9cb5b3-1816-4c53-94e1-3bc27d1a8bc3.png)

