### PR TITLE
fix(community): fix qml errors when creating a community

### DIFF
--- a/ui/app/AppLayouts/Chat/ChatLayout.qml
+++ b/ui/app/AppLayouts/Chat/ChatLayout.qml
@@ -77,9 +77,16 @@ StatusAppThreePanelLayout {
     }
 
     showRightPanel: {
-        // Check if user list is available as an option for particular chat content module.
-        let usersListAvailable = root.rootStore.currentChatContentModule().chatDetails.isUsersListAvailable
-        return localAccountSensitiveSettings.showOnlineUsers && usersListAvailable && localAccountSensitiveSettings.expandUsersList
+        if (!localAccountSensitiveSettings.showOnlineUsers || !localAccountSensitiveSettings.expandUsersList) {
+            return false
+        }
+        let chatContentModule = root.rootStore.currentChatContentModule()
+        if (!chatContentModule) {
+            // New communities have no chats, so no chatContentModule
+            return false
+        }
+        // Check if user list is available as an option for particular chat content module
+        return chatContentModule.chatDetails.isUsersListAvailable
     }
 
     rightPanel: localAccountSensitiveSettings.communitiesEnabled && root.rootStore.chatCommunitySectionModule.isCommunity()?
@@ -92,6 +99,10 @@ StatusAppThreePanelLayout {
             messageContextMenu: quickActionMessageOptionsMenu
             usersModule: {
                 let chatContentModule = root.rootStore.currentChatContentModule()
+                if (!chatContentModule || !chatContentModule.usersModule) {
+                    // New communities have no chats, so no chatContentModule
+                    return {}
+                }
                 return chatContentModule.usersModule
             }
         }

--- a/ui/app/AppLayouts/Chat/views/CommunityColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/CommunityColumnView.qml
@@ -342,7 +342,7 @@ Item {
             width: parent.width
             height: {
                 // I dont know why, the binding doesn't work well if this isn't here
-                item.height
+                item && item.height
                 return this.active ? item.height : 0
             }
             anchors.top: communityChatListAndCategories.bottom


### PR DESCRIPTION
Fixes #4440

Most of the problems were because the community starts with no chat, so `chatContentModule` is empty.