### PR TITLE
fix(@communities/InviteFriends): [base_bc] invite friends button is misplaced

### DIFF
--- a/ui/imports/shared/controls/ContactsListAndSearch.qml
+++ b/ui/imports/shared/controls/ContactsListAndSearch.qml
@@ -225,8 +225,7 @@ Item {
     NoFriendsRectangle {
         id: noContactsRect
         visible: showContactList
-        anchors.top: chatKey.bottom
-        anchors.topMargin: Style.current.xlPadding * 3
+        anchors.top: chatKey.top
         anchors.horizontalCenter: parent.horizontalCenter
         anchors.verticalCenter: parent.verticalCenter
     }


### PR DESCRIPTION
Closes #4416

### What does the PR do

Invite friends button placed to be consistent with other views like in GroupChat/Add members popup.

### Affected areas

Community/Add Members

### Screenshot of functionality

![image](https://user-images.githubusercontent.com/97019400/149922563-541a7c36-6a90-4286-b038-54a99c73f94c.png)

Example of another view to be consistent:
![image](https://user-images.githubusercontent.com/97019400/149922818-46b3f1d6-be32-4848-930c-753c817b65f1.png)

