### PR TITLE
refactor(community): move membership functions to chat_section

### DIFF
--- a/src/app/modules/main/chat_section/controller.nim
+++ b/src/app/modules/main/chat_section/controller.nim
@@ -231,3 +231,18 @@ method rejectContactRequest*(self: Controller, publicKey: string) =
 
 method blockContact*(self: Controller, publicKey: string) =
   self.contactService.blockContact(publicKey)
+
+method acceptRequestToJoinCommunity*(self: Controller, requestId: string) =
+  self.communityService.acceptRequestToJoinCommunity(self.sectionId, requestId)
+
+method declineRequestToJoinCommunity*(self: Controller, requestId: string) =
+  self.communityService.declineRequestToJoinCommunity(self.sectionId, requestId)
+
+method createCommunityChannel*(
+    self: Controller,
+    name: string,
+    description: string) =
+  self.communityService.createCommunityChannel(self.sectionId, name, description)
+
+method leaveCommunity*(self: Controller) =
+  self.communityService.leaveCommunity(self.sectionId)

--- a/src/app/modules/main/chat_section/controller_interface.nim
+++ b/src/app/modules/main/chat_section/controller_interface.nim
@@ -91,3 +91,15 @@ method rejectContactRequest*(self: AccessInterface, publicKey: string): void {.b
 
 method blockContact*(self: AccessInterface, publicKey: string): void {.base.} =
   raise newException(ValueError, "No implementation available")
+
+method acceptRequestToJoinCommunity*(self: AccessInterface, requestId: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method declineRequestToJoinCommunity*(self: AccessInterface, requestId: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method createCommunityChannel*(self: AccessInterface, name: string, description: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method leaveCommunity*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -444,3 +444,15 @@ method onNewMessagesReceived*(self: Module, chatId: string, unviewedMessagesCoun
     self.controller.markAllMessagesRead(chatId)
   else:
     self.updateNotifications(chatId, unviewedMessagesCount, unviewedMentionsCount)
+
+method acceptRequestToJoinCommunity*(self: Module, requestId: string) =
+  self.controller.acceptRequestToJoinCommunity(requestId)
+
+method declineRequestToJoinCommunity*(self: Module, requestId: string) =
+  self.controller.declineRequestToJoinCommunity(requestId)
+
+method createCommunityChannel*(self: Module, name, description: string,) =
+  self.controller.createCommunityChannel(name, description)
+
+method leaveCommunity*(self: Module) =
+  self.controller.leaveCommunity() 

--- a/src/app/modules/main/chat_section/private_interfaces/module_view_delegate_interface.nim
+++ b/src/app/modules/main/chat_section/private_interfaces/module_view_delegate_interface.nim
@@ -56,3 +56,15 @@ method rejectAllContactRequests*(self: AccessInterface) {.base.} =
 
 method blockContact*(self: AccessInterface, publicKey: string) {.base.} =
   raise newException(ValueError, "No implementation available")
+
+method acceptRequestToJoinCommunity*(self: AccessInterface, requestId: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method declineRequestToJoinCommunity*(self: AccessInterface, requestId: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method createCommunityChannel*(self: AccessInterface, name: string, description: string) {.base.} =
+  raise newException(ValueError, "No implementation available") 
+
+method leaveCommunity*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available") 

--- a/src/app/modules/main/chat_section/view.nim
+++ b/src/app/modules/main/chat_section/view.nim
@@ -131,3 +131,15 @@ QtObject:
 
   proc blockContact*(self: View, publicKey: string) {.slot.} =
     self.delegate.blockContact(publicKey)
+
+  proc acceptRequestToJoinCommunity*(self: View, requestId: string) {.slot.} =
+    self.delegate.acceptRequestToJoinCommunity(requestId)
+
+  proc declineRequestToJoinCommunity*(self: View, requestId: string) {.slot.} =
+    self.delegate.declineRequestToJoinCommunity(requestId)
+
+  proc createCommunityChannel*(self: View, name: string, description: string) {.slot.} =
+    self.delegate.createCommunityChannel(name, description)
+
+  proc leaveCommunity*(self: View) {.slot.} =
+    self.delegate.leaveCommunity()

--- a/src/app/modules/main/communities/controller.nim
+++ b/src/app/modules/main/communities/controller.nim
@@ -69,9 +69,6 @@ method joinCommunity*(self: Controller, communityId: string): string =
 method requestToJoinCommunity*(self: Controller, communityId: string, ensName: string) =
   self.communityService.requestToJoinCommunity(communityId, ensName)
 
-method leaveCommunity*(self: Controller, communityId: string) =
-  self.communityService.leaveCommunity(communityId)
-
 method createCommunity*(
     self: Controller,
     name: string,
@@ -109,13 +106,6 @@ method editCommunity*(
     color,
     imageUrl,
     aX, aY, bX, bY)
-
-method createCommunityChannel*(
-    self: Controller,
-    communityId: string,
-    name: string,
-    description: string) =
-  self.communityService.createCommunityChannel(communityId, name, description)
 
 method editCommunityChannel*(
     self: Controller,
@@ -180,12 +170,6 @@ method importCommunity*(self: Controller, communityKey: string) =
 
 method exportCommunity*(self: Controller, communityId: string): string =
   self.communityService.exportCommunity(communityId)
-
-method acceptRequestToJoinCommunity*(self: Controller, communityId: string, requestId: string) =
-  self.communityService.acceptRequestToJoinCommunity(communityId, requestId)
-
-method declineRequestToJoinCommunity*(self: Controller, communityId: string, requestId: string) =
-  self.communityService.declineRequestToJoinCommunity(communityId, requestId)
 
 method inviteUsersToCommunityById*(self: Controller, communityId: string, pubKeys: string): string =
   result = self.communityService.inviteUsersToCommunityById(communityId, pubKeys)

--- a/src/app/modules/main/communities/controller_interface.nim
+++ b/src/app/modules/main/communities/controller_interface.nim
@@ -16,16 +16,10 @@ method joinCommunity*(self: AccessInterface, communityId: string): string {.base
 method requestToJoinCommunity*(self: AccessInterface, communityId: string, ensName: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method leaveCommunity*(self: AccessInterface, communityId: string) {.base.} =
-  raise newException(ValueError, "No implementation available")
-
 method createCommunity*(self: AccessInterface, name: string, description: string, access: int, ensOnly: bool, color: string, imageUrl: string, aX: int, aY: int, bX: int, bY: int) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method editCommunity*(self: AccessInterface, id: string, name: string, description: string, access: int, ensOnly: bool, color: string, imageUrl: string, aX: int, aY: int, bX: int, bY: int) {.base.} =
-  raise newException(ValueError, "No implementation available")
-
-method createCommunityChannel*(self: AccessInterface, communityId: string, name: string, description: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method editCommunityChannel*(self: AccessInterface, communityId: string, chatId: string, name: string, description: string, categoryId: string, position: int) {.base.} =
@@ -53,12 +47,6 @@ method importCommunity*(self: AccessInterface, communityKey: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method exportCommunity*(self: AccessInterface, communityId: string): string {.base.} =
-  raise newException(ValueError, "No implementation available")
-
-method acceptRequestToJoinCommunity*(self: AccessInterface, communityId: string, requestId: string) {.base.} =
-  raise newException(ValueError, "No implementation available")
-
-method declineRequestToJoinCommunity*(self: AccessInterface, communityId: string, requestId: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method inviteUsersToCommunityById*(self: AccessInterface, communityId: string, pubKeys: string): string {.base.} =

--- a/src/app/modules/main/communities/module.nim
+++ b/src/app/modules/main/communities/module.nim
@@ -135,9 +135,6 @@ method editCommunity*(self: Module, id: string, name: string, description: strin
                         aX: int, aY: int, bX: int, bY: int) =
   self.controller.editCommunity(id, name, description, access, ensOnly, color, imagePath, aX, aY, bX, bY)
 
-method createCommunityChannel*(self: Module, communityId, name, description: string,) =
-  self.controller.createCommunityChannel(communityId, name, description)
-
 method createCommunityCategory*(self: Module, communityId: string, name: string, channels: string) =
   let channelsSeq = map(parseJson(channels).getElems(), proc(x:JsonNode):string = x.getStr())
   self.controller.createCommunityCategory(communityId, name, channelsSeq)
@@ -157,9 +154,6 @@ method removeUserFromCommunity*(self: Module, communityId: string, categoryId: s
   # self.controller.reorderCommunityChannel(communityId, categoryId, chatId, position)
   discard
 
-method leaveCommunity*(self: Module, communityId: string) =
-  self.controller.leaveCommunity(communityId) 
-
 method inviteUsersToCommunityById*(self: Module, communityId: string, pubKeysJSON: string): string =
   result = self.controller.inviteUsersToCommunityById(communityId, pubKeysJSON)
   
@@ -171,12 +165,6 @@ method banUserFromCommunity*(self: Module, pubKey: string, communityId: string) 
 
 method requestToJoinCommunity*(self: Module, communityId: string, ensName: string) =
   self.controller.requestToJoinCommunity(communityId, ensName)
-   
-method acceptRequestToJoinCommunity*(self: Module, communityId: string, requestId: string) =
-  self.controller.acceptRequestToJoinCommunity(communityId, requestId)
-
-method declineRequestToJoinCommunity*(self: Module, communityId: string, requestId: string) =
-  self.controller.declineRequestToJoinCommunity(communityId, requestId)
 
 method requestCommunityInfo*(self: Module, communityId: string) =
   self.controller.requestCommunityInfo(communityId)

--- a/src/app/modules/main/communities/private_interfaces/module_access_interface.nim
+++ b/src/app/modules/main/communities/private_interfaces/module_access_interface.nim
@@ -31,9 +31,6 @@ method editCommunity*(self: AccessInterface, id: string, name: string, descripti
 method createCommunityCategory*(self: AccessInterface, communityId: string, name: string, channels: string) {.base.} =
   raise newException(ValueError, "No implementation available") 
 
-method createCommunityChannel*(self: AccessInterface, communityId: string, name: string, description: string) {.base.} =
-  raise newException(ValueError, "No implementation available") 
-
 method editCommunityCategory*(self: AccessInterface, communityId: string, categoryId: string, name: string, channels: string) {.base.} =
   raise newException(ValueError, "No implementation available") 
 
@@ -46,9 +43,6 @@ method reorderCommunityCategories*(self: AccessInterface, communityId: string, c
 method reorderCommunityChannel*(self: AccessInterface, communityId: string, categoryId: string, chatId: string, position: int) {.base} =
   raise newException(ValueError, "No implementation available") 
 
-method leaveCommunity*(self: AccessInterface, communityId: string) {.base.} =
-  raise newException(ValueError, "No implementation available") 
-
 method inviteUsersToCommunityById*(self: AccessInterface, communityId: string, pubKeysJSON: string): string {.base.} =
   raise newException(ValueError, "No implementation available") 
 
@@ -59,12 +53,6 @@ method banUserFromCommunity*(self: AccessInterface, pubKey: string, communityId:
   raise newException(ValueError, "No implementation available") 
 
 method requestToJoinCommunity*(self: AccessInterface, communityId: string, ensName: string) {.base.} =
-  raise newException(ValueError, "No implementation available") 
-  
-method acceptRequestToJoinCommunity*(self: AccessInterface, communityId: string, requestId: string) {.base.} =
-  raise newException(ValueError, "No implementation available") 
-
-method declineRequestToJoinCommunity*(self: AccessInterface, communityId: string, requestId: string) {.base.} =
   raise newException(ValueError, "No implementation available") 
 
 method requestCommunityInfo*(self: AccessInterface, communityId: string) {.base.} =

--- a/src/app/modules/main/communities/view.nim
+++ b/src/app/modules/main/communities/view.nim
@@ -70,9 +70,6 @@ QtObject:
   proc editCommunity*(self: View, id: string, name: string, description: string, access: int, ensOnly: bool, color: string, imagePath: string, aX: int, aY: int, bX: int, bY: int) {.slot.} =
     self.delegate.editCommunity(id, name, description, access, ensOnly, color, imagePath, aX, aY, bX, bY)
   
-  proc createCommunityChannel*(self: View, communityId: string, name: string, description: string) {.slot.} =
-    self.delegate.createCommunityChannel(communityId, name, description)
-  
   proc createCommunityCategory*(self: View, communityId: string, name: string, channels: string) {.slot.} =
     self.delegate.createCommunityCategory(communityId, name, channels)
 
@@ -88,9 +85,6 @@ QtObject:
   proc reorderCommunityChannel*(self: View, communityId: string, categoryId: string, chatId: string, position: int): string {.slot} =
     self.delegate.reorderCommunityChannel(communityId, categoryId, chatId, position)
 
-  proc leaveCommunity*(self: View, communityId: string) {.slot.} =
-    self.delegate.leaveCommunity(communityId)
-
   proc inviteUsersToCommunityById*(self: View, communityId: string, pubKeysJSON: string): string {.slot.} =
     result = self.delegate.inviteUsersToCommunityById(communityId, pubKeysJSON)
   
@@ -102,12 +96,6 @@ QtObject:
 
   proc requestToJoinCommunity*(self: View, communityId: string, ensName: string) {.slot.} =
     self.delegate.requestToJoinCommunity(communityId, ensName)
-   
-  proc acceptRequestToJoinCommunity*(self: View, communityId: string, requestId: string) {.slot.} =
-    self.delegate.acceptRequestToJoinCommunity(communityId, requestId)
-
-  proc declineRequestToJoinCommunity*(self: View, communityId: string, requestId: string) {.slot.} =
-    self.delegate.declineRequestToJoinCommunity(communityId, requestId)
 
   proc requestCommunityInfo*(self: View, communityId: string) {.slot.} =
     self.delegate.requestCommunityInfo(communityId)

--- a/src/app/modules/shared_models/section_model.nim
+++ b/src/app/modules/shared_models/section_model.nim
@@ -18,6 +18,13 @@ type
     Enabled
     Joined
     IsMember
+    CanJoin
+    CanManageUsers
+    CanRequestAccess
+    Access
+    EnsOnly
+    MembersModel
+    PendingRequestsToJoinModel
 
 QtObject:
   type
@@ -68,7 +75,14 @@ QtObject:
       ModelRole.Active.int:"active",
       ModelRole.Enabled.int:"enabled",
       ModelRole.Joined.int:"joined",
-      ModelRole.IsMember.int:"isMember"
+      ModelRole.IsMember.int:"isMember",
+      ModelRole.CanJoin.int:"canJoin",
+      ModelRole.CanManageUsers.int:"canManageUsers",
+      ModelRole.CanRequestAccess.int:"canRequestAccess",
+      ModelRole.Access.int:"access",
+      ModelRole.EnsOnly.int:"ensOnly",
+      ModelRole.MembersModel.int:"members",
+      ModelRole.PendingRequestsToJoinModel.int:"pendingRequestsToJoin",
     }.toTable
 
   method data(self: SectionModel, index: QModelIndex, role: int): QVariant =
@@ -110,6 +124,20 @@ QtObject:
       result = newQVariant(item.joined)
     of ModelRole.IsMember: 
       result = newQVariant(item.isMember)
+    of ModelRole.CanJoin: 
+      result = newQVariant(item.canJoin)
+    of ModelRole.CanManageUsers: 
+      result = newQVariant(item.canManageUsers)
+    of ModelRole.CanRequestAccess: 
+      result = newQVariant(item.canRequestAccess)
+    of ModelRole.Access: 
+      result = newQVariant(item.access)
+    of ModelRole.EnsOnly: 
+      result = newQVariant(item.ensOnly)
+    of ModelRole.MembersModel: 
+      result = newQVariant(item.members)
+    of ModelRole.PendingRequestsToJoinModel: 
+      result = newQVariant(item.pendingRequestsToJoin)
 
   proc addItem*(self: SectionModel, item: SectionItem) =
     let parentModelIndex = newQModelIndex()
@@ -155,7 +183,14 @@ QtObject:
       ModelRole.Description.int,
       ModelRole.Image.int,
       ModelRole.Icon.int,
-      ModelRole.Color.int
+      ModelRole.Color.int,
+      ModelRole.HasNotification.int,
+      ModelRole.NotificationsCount.int,
+      ModelRole.IsMember.int,
+      ModelRole.CanJoin.int,
+      ModelRole.Joined.int,
+      ModelRole.MembersModel.int,
+      ModelRole.PendingRequestsToJoinModel.int
       ])
 
   proc getItemById*(self: SectionModel, id: string): SectionItem =

--- a/ui/app/AppLayouts/Chat/panels/communities/CommunityProfilePopupMembersListPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/CommunityProfilePopupMembersListPanel.qml
@@ -26,6 +26,7 @@ Item {
     property alias members: memberList.model
     property var community
     property var store
+    property var communitySectionModule
 
     signal inviteButtonClicked()
 
@@ -41,7 +42,7 @@ Item {
         StatusListItem {
             id: inviteButton
             anchors.horizontalCenter: parent.horizontalCenter
-            visible: !!(root.community.admin || root.community.isAdmin)
+            visible: root.community.amISectionAdmin
             //% "Invite People"
             title: qsTrId("invite-people")
             icon.name: "share-ios"
@@ -67,7 +68,9 @@ Item {
             //% "Membership requests"
             title: qsTrId("membership-requests")
             requestsCount: nbRequests
-            sensor.onClicked: Global.openPopup(membershipRequestPopup)
+            sensor.onClicked: Global.openPopup(membershipRequestPopup, {
+                communitySectionModule: root.communitySectionModule
+            })
         }
 
         StatusModalDivider {
@@ -179,7 +182,7 @@ Item {
                                 }
 
                                 StatusMenuSeparator {
-                                    visible: root.community.admin
+                                    visible: root.community.amISectionAdmin
                                 }
 
                                 StatusMenuItem {
@@ -188,7 +191,7 @@ Item {
                                     icon.name: "arrow-right"
                                     iconRotation: 180
                                     type: StatusMenuItem.Type.Danger
-                                    enabled: root.community.admin
+                                    enabled: root.community.amISectionAdmin
                                     // Not Refactored Yet
 //                                    onTriggered: chatsModel.communities.removeUserFromCommunity(model.pubKey)
                                 }
@@ -198,7 +201,7 @@ Item {
                                     text: qsTrId("ban")
                                     icon.name: "cancel"
                                     type: StatusMenuItem.Type.Danger
-                                    enabled: root.community.admin
+                                    enabled: root.community.amISectionAdmin
                                     // Not Refactored Yet
 //                                    onTriggered: chatsModel.communities.banUserFromCommunity(model.pubKey, root.community.id)
                                 }

--- a/ui/app/AppLayouts/Chat/panels/communities/CommunityWelcomeBannerPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/CommunityWelcomeBannerPanel.qml
@@ -23,6 +23,7 @@ Rectangle {
     color: Style.current.transparent
     property var activeCommunity
     property var store
+    property var communitySectionModule
     property bool hasAddedContacts
 
     MouseArea {
@@ -104,7 +105,8 @@ Rectangle {
         anchors.bottomMargin: Style.current.padding
         onClicked: Global.openPopup(communityProfilePopup, {
             store: rootStore,
-            community: root.activeCommunity
+            community: root.activeCommunity,
+            communitySectionModule: root.communitySectionModule
         })
     }
 }

--- a/ui/app/AppLayouts/Chat/popups/community/CommunityProfilePopup.qml
+++ b/ui/app/AppLayouts/Chat/popups/community/CommunityProfilePopup.qml
@@ -14,6 +14,7 @@ StatusModal {
 
     property var store
     property var community
+    property var communitySectionModule
 
     onClosed: {
         while (contentItem.depth > 1) {
@@ -73,7 +74,7 @@ StatusModal {
                     store: root.store
                 })
                 onLeaveButtonClicked: {
-                    root.store.leaveCommunity(root.community.id);
+                    communitySectionModule.leaveCommunity();
                     root.close();
                 }
                 onCopyToClipboard: {
@@ -114,6 +115,7 @@ StatusModal {
                 headerTitle: qsTrId("members-label")
                 headerSubtitle: root.community.members.count.toString()
                 community: root.community
+                communitySectionModule: root.communitySectionModule
                 onInviteButtonClicked: root.contentItem.push(inviteFriendsView)
             }
         }

--- a/ui/app/AppLayouts/Chat/popups/community/MembershipRequestsPopup.qml
+++ b/ui/app/AppLayouts/Chat/popups/community/MembershipRequestsPopup.qml
@@ -14,6 +14,7 @@ import shared 1.0
 StatusModal {
     id: popup
     property var store
+    property var communitySectionModule
     property var pendingRequestsToJoin
     onOpened: {
         contentItem.errorText.text = ""
@@ -86,7 +87,7 @@ StatusModal {
                                 hoverEnabled: true
                                 anchors.fill: parent
                                 cursorShape: Qt.PointingHandCursor
-                                onClicked: popup.store.acceptRequestToJoinCommunity(model.communityId, id)
+                                onClicked: communitySectionModule.acceptRequestToJoinCommunity(id)
                             }
                         },
                         StatusRoundIcon {
@@ -100,7 +101,7 @@ StatusModal {
                                 hoverEnabled: true
                                 anchors.fill: parent
                                 cursorShape: Qt.PointingHandCursor
-                                onClicked: popup.store.declineRequestToJoinCommunity(model.communityId, id)
+                                onClicked: communitySectionModule.declineRequestToJoinCommunity(id)
                             }
                         }
                     ]

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -148,8 +148,8 @@ QtObject {
 //        chatsModelInst.communities.deleteCommunityCategory(chatsModelInst.communities.activeCommunity.id, categoryId);
     }
 
-    function leaveCommunity(communityId) {
-        communitiesModuleInst.leaveCommunity(communityId);
+    function leaveCommunity() {
+        chatCommunitySectionModule.leaveCommunity();
     }
 
     function setCommunityMuted(communityId, checked) {
@@ -160,8 +160,8 @@ QtObject {
         return communitiesModuleInst.exportCommunity(communityId);
     }
 
-    function createCommunityChannel(communityId, channelName, channelDescription) {
-        communitiesModuleInst.createCommunityChannel(communityId, channelName, channelDescription);
+    function createCommunityChannel(channelName, channelDescription) {
+        chatCommunitySectionModule.createCommunityChannel(channelName, channelDescription);
     }
 
     function editCommunityChannel(communityId, channelId, channelName, channelDescription, channelCategoryId, popupPosition) {
@@ -172,12 +172,12 @@ QtObject {
 //        chatsModelInst.editCommunityChannel(communityId, channelId, channelName, channelDescription, channelCategoryId, popupPosition);
     }
 
-    function acceptRequestToJoinCommunity(communityId, requestId) {
-        communitiesModuleInst.acceptRequestToJoinCommunity(communityId, requestId)
+    function acceptRequestToJoinCommunity(requestId) {
+        chatCommunitySectionModule.acceptRequestToJoinCommunity(requestId)
     }
 
-    function declineRequestToJoinCommunity(communityId, requestId) {
-        communitiesModuleInst.declineRequestToJoinCommunity(communityId, requestId)
+    function declineRequestToJoinCommunity(requestId) {
+        chatCommunitySectionModule.declineRequestToJoinCommunity(requestId)
     }
 
     function userNameOrAlias(pk) {

--- a/ui/app/AppLayouts/Chat/views/CommunityColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/CommunityColumnView.qml
@@ -48,10 +48,10 @@ Item {
         chatInfoButton.image.source: communityData.image
         chatInfoButton.icon.color: communityData.color
         menuButton.visible: communityData.amISectionAdmin && communityData.canManageUsers
-        // TODO remove dynamic scoping of popup component
         chatInfoButton.onClicked: Global.openPopup(communityProfilePopup, {
             store: root.store,
-            community: communityData
+            community: communityData,
+            communitySectionModule: root.communitySectionModule
         })
 
         popupMenu: StatusPopupMenu {
@@ -102,7 +102,9 @@ Item {
                 //% "Membership requests"
                 title: qsTrId("membership-requests")
                 requestsCount: membershipRequests.nbRequests
-                sensor.onClicked: Global.openPopup(membershipRequestPopup)
+                sensor.onClicked: Global.openPopup(membershipRequestPopup, {
+                    communitySectionModule: root.communitySectionModule
+                })
             }
         }
     }
@@ -348,6 +350,7 @@ Item {
                     activeCommunity: communityData
                     store: root.store
                     hasAddedContacts: root.hasAddedContacts
+                    communitySectionModule: root.communitySectionModule
                 }
             }
         }
@@ -395,7 +398,7 @@ Item {
         CreateChannelPopup {
             anchors.centerIn: parent
             onCreateCommunityChannel: function (chName, chDescription) {
-                root.store.createCommunityChannel(communityData.id, chName, chDescription)
+                root.store.createCommunityChannel(chName, chDescription)
             }
             onClosed: {
                 destroy()

--- a/ui/app/AppLayouts/Chat/views/ContactsColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ContactsColumnView.qml
@@ -372,7 +372,7 @@ Item {
 //                root.store.chatsModelInst.communities.setActiveCommunity(id)
 //            }
            onSetObservedCommunity: {
-               root.store.communitiesModuleInst.setObservedCommunity(id)
+               root.store.setObservedCommunity(id)
            }
             onClosed: {
                 destroy()

--- a/ui/app/AppLayouts/stores/RootStore.qml
+++ b/ui/app/AppLayouts/stores/RootStore.qml
@@ -47,10 +47,6 @@ QtObject {
         return communitiesModuleInst.exportCommunity(communityId);
     }
 
-    function leaveCommunity(communityId) {
-        communitiesModuleInst.leaveCommunity(communityId);
-    }
-
     function createCommunity(communityName, communityDescription, checkedMembership, ensOnlySwitchChecked, communityColor, communityImage, imageCropperModalaX, imageCropperModalaY, imageCropperModalbX, imageCropperModalbY) {
         communitiesModuleInst.createCommunity(communityName, communityDescription, checkedMembership, ensOnlySwitchChecked, communityColor, communityImage, imageCropperModalaX, imageCropperModalaY, imageCropperModalbX, imageCropperModalbY);
     }
@@ -65,5 +61,13 @@ QtObject {
 
     function copyToClipboard(text) {
         globalUtils.copyToClipboard(text)
+    }
+
+    function generateAlias(pk) {
+        return globalUtils.generateAlias(pk);
+    }
+
+    function generateIdenticon(pk) {
+        return globalUtils.generateIdenticon(pk);
     }
 }

--- a/ui/app/AppMain.qml
+++ b/ui/app/AppMain.qml
@@ -247,17 +247,23 @@ Item {
                 popupMenu: StatusPopupMenu {
                     id: communityContextMenu
 
+                    property var chatCommunitySectionModule
+
                     openHandler: function () {
-                        appMain.rootStore.setObservedCommunity(model.id)
+                        // // we cannot return QVariant if we pass another parameter in a function call
+                        // // that's why we're using it this way
+                        mainModule.prepareCommunitySectionModuleForCommunityId(model.id)
+                        communityContextMenu.chatCommunitySectionModule = mainModule.getCommunitySectionModule()
+                        
                     }
 
                     StatusMenuItem {
                         //% "Invite People"
                         text: qsTrId("invite-people")
                         icon.name: "share-ios"
-                        enabled: appMain.rootStore.observedCommunity.canManageUsers
+                        enabled: model.canManageUsers
                         onTriggered: Global.openPopup(inviteFriendsToCommunityPopup, {
-                            community: appMain.rootStore.observedCommunity,
+                            community: model,
                             hasAddedContacts: appMain.rootStore.hasAddedContacts
                         })
                     }
@@ -268,18 +274,19 @@ Item {
                         icon.name: "group-chat"
                         onTriggered: Global.openPopup(communityProfilePopup, {
                             store: appMain.rootStore,
-                            community: appMain.rootStore.observedCommunity
+                            community: model,
+                            communitySectionModule: communityContextMenu.chatCommunitySectionModule
                         })
                     }
 
                     StatusMenuItem {
-                        enabled: appMain.rootStore.observedCommunity.amISectionAdmin
+                        enabled: model.amISectionAdmin
                         //% "Edit Community"
                         text: qsTrId("edit-community")
                         icon.name: "edit"
                         onTriggered: Global.openPopup(editCommunityPopup, {
                             store: appMain.rootStore,
-                            community: appMain.rootStore.observedCommunity
+                            community: model
                         })
                     }
 
@@ -292,7 +299,7 @@ Item {
                         icon.width: 14
                         iconRotation: 180
                         type: StatusMenuItem.Type.Danger
-                        onTriggered: appMain.rootStore.leaveCommunity(model.id)
+                        onTriggered: communityContextMenu.chatCommunitySectionModule.leaveCommunity()
                     }
                 }
             }


### PR DESCRIPTION
Fixes #4473 and #4485

This moves the membership request function as well as two others to the chat_section module, since they are for that specific section (community), therefore, we can remove the community_id from the function calls and use `sectionId`.

It also removes the use of `observedCommunity` from AppMain, instead, for the community context menu, we use the communitySectionModule and community model.

Sadly, this didn't fix the active_setion crash (see https://github.com/status-im/status-desktop/pull/4465#discussion_r785491337)