### PR TITLE
fix(TabBar): fix community tab button color to match the community color

### DIFF
--- a/ui/app/AppMain.qml
+++ b/ui/app/AppMain.qml
@@ -239,6 +239,8 @@ Item {
                 checked: model.active
                 badge.value: model.notificationsCount
                 badge.visible: model.hasNotification
+                icon.color: model.color
+                hoveredColor: model.color
                 badge.border.color: hovered ? Theme.palette.statusBadge.hoverBorderColor : Theme.palette.statusBadge.borderColor
                 badge.border.width: 2
                 onClicked: {


### PR DESCRIPTION
Fixes #4497

Pretty! 
![image](https://user-images.githubusercontent.com/11926403/150188235-b9182b9b-f32d-49b5-afd1-1c70adb533da.png)

Needs https://github.com/status-im/StatusQ/pull/536