### PR TITLE
Move community specific functions to chat_section

### DIFF
--- a/src/app/modules/main/chat_section/controller.nim
+++ b/src/app/modules/main/chat_section/controller.nim
@@ -246,3 +246,31 @@ method createCommunityChannel*(
 
 method leaveCommunity*(self: Controller) =
   self.communityService.leaveCommunity(self.sectionId)
+  
+method editCommunity*(
+    self: Controller,
+    name: string,
+    description: string,
+    access: int,
+    ensOnly: bool,
+    color: string,
+    imageUrl: string,
+    aX: int, aY: int, bX: int, bY: int) =
+  self.communityService.editCommunity(
+    self.sectionId,
+    name,
+    description,
+    access,
+    ensOnly,
+    color,
+    imageUrl,
+    aX, aY, bX, bY)
+
+method exportCommunity*(self: Controller): string =
+  self.communityService.exportCommunity(self.sectionId)
+
+method setCommunityMuted*(self: Controller, muted: bool) =
+  self.communityService.setCommunityMuted(self.sectionId, muted)
+
+method inviteUsersToCommunity*(self: Controller, pubKeys: string): string =
+  result = self.communityService.inviteUsersToCommunityById(self.sectionId, pubKeys)

--- a/src/app/modules/main/chat_section/controller_interface.nim
+++ b/src/app/modules/main/chat_section/controller_interface.nim
@@ -103,3 +103,15 @@ method createCommunityChannel*(self: AccessInterface, name: string, description:
 
 method leaveCommunity*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
+
+method editCommunity*(self: AccessInterface, name: string, description: string, access: int, ensOnly: bool, color: string, imageUrl: string, aX: int, aY: int, bX: int, bY: int) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method exportCommunity*(self: AccessInterface): string {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method setCommunityMuted*(self: AccessInterface, muted: bool) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method inviteUsersToCommunity*(self: AccessInterface, pubKeys: string): string {.base.} =
+  raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -455,4 +455,19 @@ method createCommunityChannel*(self: Module, name, description: string,) =
   self.controller.createCommunityChannel(name, description)
 
 method leaveCommunity*(self: Module) =
-  self.controller.leaveCommunity() 
+  self.controller.leaveCommunity()
+
+method editCommunity*(self: Module, name: string, description: string, 
+                        access: int, ensOnly: bool, color: string,
+                        imagePath: string,
+                        aX: int, aY: int, bX: int, bY: int) =
+  self.controller.editCommunity(name, description, access, ensOnly, color, imagePath, aX, aY, bX, bY)
+
+method exportCommunity*(self: Module): string =
+  self.controller.exportCommunity()
+
+method setCommunityMuted*(self: Module, muted: bool) =
+  self.controller.setCommunityMuted(muted)  
+
+method inviteUsersToCommunity*(self: Module, pubKeysJSON: string): string =
+  result = self.controller.inviteUsersToCommunity(pubKeysJSON)

--- a/src/app/modules/main/chat_section/private_interfaces/module_view_delegate_interface.nim
+++ b/src/app/modules/main/chat_section/private_interfaces/module_view_delegate_interface.nim
@@ -64,7 +64,19 @@ method declineRequestToJoinCommunity*(self: AccessInterface, requestId: string) 
   raise newException(ValueError, "No implementation available")
 
 method createCommunityChannel*(self: AccessInterface, name: string, description: string) {.base.} =
-  raise newException(ValueError, "No implementation available") 
+  raise newException(ValueError, "No implementation available")
 
 method leaveCommunity*(self: AccessInterface) {.base.} =
-  raise newException(ValueError, "No implementation available") 
+  raise newException(ValueError, "No implementation available")
+
+method editCommunity*(self: AccessInterface, name: string, description: string, access: int, ensOnly: bool, color: string, imagePath: string, aX: int, aY: int, bX: int, bY: int) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method exportCommunity*(self: AccessInterface): string {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method setCommunityMuted*(self: AccessInterface, muted: bool) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method inviteUsersToCommunity*(self: AccessInterface, pubKeysJSON: string): string {.base.} =
+  raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/chat_section/view.nim
+++ b/src/app/modules/main/chat_section/view.nim
@@ -143,3 +143,15 @@ QtObject:
 
   proc leaveCommunity*(self: View) {.slot.} =
     self.delegate.leaveCommunity()
+
+  proc editCommunity*(self: View, name: string, description: string, access: int, ensOnly: bool, color: string, imagePath: string, aX: int, aY: int, bX: int, bY: int) {.slot.} =
+    self.delegate.editCommunity(name, description, access, ensOnly, color, imagePath, aX, aY, bX, bY)
+
+  proc exportCommunity*(self: View): string {.slot.} =
+    self.delegate.exportCommunity()
+
+  proc setCommunityMuted*(self: View, muted: bool) {.slot.} =
+    self.delegate.setCommunityMuted(muted)
+
+  proc inviteUsersToCommunity*(self: View, pubKeysJSON: string): string {.slot.} =
+    result = self.delegate.inviteUsersToCommunity(pubKeysJSON)

--- a/src/app/modules/main/communities/controller.nim
+++ b/src/app/modules/main/communities/controller.nim
@@ -87,26 +87,6 @@ method createCommunity*(
     imageUrl,
     aX, aY, bX, bY)
 
-method editCommunity*(
-    self: Controller,
-    id: string,
-    name: string,
-    description: string,
-    access: int,
-    ensOnly: bool,
-    color: string,
-    imageUrl: string,
-    aX: int, aY: int, bX: int, bY: int) =
-  self.communityService.editCommunity(
-    id,
-    name,
-    description,
-    access,
-    ensOnly,
-    color,
-    imageUrl,
-    aX, aY, bX, bY)
-
 method editCommunityChannel*(
     self: Controller,
     communityId: string,
@@ -168,17 +148,8 @@ method requestCommunityInfo*(self: Controller, communityId: string) =
 method importCommunity*(self: Controller, communityKey: string) =
   self.communityService.importCommunity(communityKey)
 
-method exportCommunity*(self: Controller, communityId: string): string =
-  self.communityService.exportCommunity(communityId)
-
-method inviteUsersToCommunityById*(self: Controller, communityId: string, pubKeys: string): string =
-  result = self.communityService.inviteUsersToCommunityById(communityId, pubKeys)
-
 method removeUserFromCommunity*(self: Controller, communityId: string, pubKeys: string) =
   self.communityService.removeUserFromCommunity(communityId, pubKeys)
 
 method banUserFromCommunity*(self: Controller, communityId: string, pubKey: string) =
   self.communityService.removeUserFromCommunity(communityId, pubKey)
-
-method setCommunityMuted*(self: Controller, communityId: string, muted: bool) =
-  self.communityService.setCommunityMuted(communityId, muted)

--- a/src/app/modules/main/communities/controller_interface.nim
+++ b/src/app/modules/main/communities/controller_interface.nim
@@ -19,9 +19,6 @@ method requestToJoinCommunity*(self: AccessInterface, communityId: string, ensNa
 method createCommunity*(self: AccessInterface, name: string, description: string, access: int, ensOnly: bool, color: string, imageUrl: string, aX: int, aY: int, bX: int, bY: int) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method editCommunity*(self: AccessInterface, id: string, name: string, description: string, access: int, ensOnly: bool, color: string, imageUrl: string, aX: int, aY: int, bX: int, bY: int) {.base.} =
-  raise newException(ValueError, "No implementation available")
-
 method editCommunityChannel*(self: AccessInterface, communityId: string, chatId: string, name: string, description: string, categoryId: string, position: int) {.base.} =
   raise newException(ValueError, "No implementation available")
 
@@ -46,19 +43,10 @@ method requestCommunityInfo*(self: AccessInterface, communityId: string) {.base.
 method importCommunity*(self: AccessInterface, communityKey: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method exportCommunity*(self: AccessInterface, communityId: string): string {.base.} =
-  raise newException(ValueError, "No implementation available")
-
-method inviteUsersToCommunityById*(self: AccessInterface, communityId: string, pubKeys: string): string {.base.} =
-  raise newException(ValueError, "No implementation available")
-
 method removeUserFromCommunity*(self: AccessInterface, communityId: string, pubKeys: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method banUserFromCommunity*(self: AccessInterface, communityId: string, pubKey: string) {.base.} =
-  raise newException(ValueError, "No implementation available")
-
-method setCommunityMuted*(self: AccessInterface, communityId: string, muted: bool) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 type

--- a/src/app/modules/main/communities/module.nim
+++ b/src/app/modules/main/communities/module.nim
@@ -129,12 +129,6 @@ method createCommunity*(self: Module, name: string, description: string,
                         aX: int, aY: int, bX: int, bY: int) =
   self.controller.createCommunity(name, description, access, ensOnly, color, imagePath, aX, aY, bX, bY)
 
-method editCommunity*(self: Module, id: string, name: string, description: string, 
-                        access: int, ensOnly: bool, color: string,
-                        imagePath: string,
-                        aX: int, aY: int, bX: int, bY: int) =
-  self.controller.editCommunity(id, name, description, access, ensOnly, color, imagePath, aX, aY, bX, bY)
-
 method createCommunityCategory*(self: Module, communityId: string, name: string, channels: string) =
   let channelsSeq = map(parseJson(channels).getElems(), proc(x:JsonNode):string = x.getStr())
   self.controller.createCommunityCategory(communityId, name, channelsSeq)
@@ -154,9 +148,6 @@ method removeUserFromCommunity*(self: Module, communityId: string, categoryId: s
   # self.controller.reorderCommunityChannel(communityId, categoryId, chatId, position)
   discard
 
-method inviteUsersToCommunityById*(self: Module, communityId: string, pubKeysJSON: string): string =
-  result = self.controller.inviteUsersToCommunityById(communityId, pubKeysJSON)
-  
 method removeUserFromCommunity*(self: Module, communityId: string, pubKey: string) =
   self.controller.removeUserFromCommunity(communityId, pubKey)
 
@@ -172,11 +163,5 @@ method requestCommunityInfo*(self: Module, communityId: string) =
 method deleteCommunityChat*(self: Module, communityId: string, channelId: string) =
   self.controller.deleteCommunityChat(communityId, channelId)
 
-method setCommunityMuted*(self: Module, communityId: string, muted: bool) =
-  self.controller.setCommunityMuted(communityId, muted)  
-
 method importCommunity*(self: Module, communityKey: string) =
   self.controller.importCommunity(communityKey)
-
-method exportCommunity*(self: Module, communityId: string): string =
-  self.controller.exportCommunity(communityId)

--- a/src/app/modules/main/communities/private_interfaces/module_access_interface.nim
+++ b/src/app/modules/main/communities/private_interfaces/module_access_interface.nim
@@ -25,9 +25,6 @@ method joinCommunity*(self: AccessInterface, communityId: string): string {.base
 method createCommunity*(self: AccessInterface, name: string, description: string, access: int, ensOnly: bool, color: string, imagePath: string, aX: int, aY: int, bX: int, bY: int) {.base.} =
   raise newException(ValueError, "No implementation available") 
 
-method editCommunity*(self: AccessInterface, id: string, name: string, description: string, access: int, ensOnly: bool, color: string, imagePath: string, aX: int, aY: int, bX: int, bY: int) {.base.} =
-  raise newException(ValueError, "No implementation available") 
-
 method createCommunityCategory*(self: AccessInterface, communityId: string, name: string, channels: string) {.base.} =
   raise newException(ValueError, "No implementation available") 
 
@@ -41,10 +38,7 @@ method reorderCommunityCategories*(self: AccessInterface, communityId: string, c
   raise newException(ValueError, "No implementation available") 
 
 method reorderCommunityChannel*(self: AccessInterface, communityId: string, categoryId: string, chatId: string, position: int) {.base} =
-  raise newException(ValueError, "No implementation available") 
-
-method inviteUsersToCommunityById*(self: AccessInterface, communityId: string, pubKeysJSON: string): string {.base.} =
-  raise newException(ValueError, "No implementation available") 
+  raise newException(ValueError, "No implementation available")
 
 method removeUserFromCommunity*(self: AccessInterface, communityId: string, pubKey: string) {.base.} =
   raise newException(ValueError, "No implementation available") 
@@ -61,11 +55,5 @@ method requestCommunityInfo*(self: AccessInterface, communityId: string) {.base.
 method deleteCommunityChat*(self: AccessInterface, communityId: string, channelId: string) {.base.} =
   raise newException(ValueError, "No implementation available") 
 
-method setCommunityMuted*(self: AccessInterface, communityId: string, muted: bool) {.base.} =
-  raise newException(ValueError, "No implementation available") 
-
 method importCommunity*(self: AccessInterface, communityKey: string) {.base.} =
-  raise newException(ValueError, "No implementation available") 
-
-method exportCommunity*(self: AccessInterface, communityId: string): string {.base.} =
   raise newException(ValueError, "No implementation available") 

--- a/src/app/modules/main/communities/view.nim
+++ b/src/app/modules/main/communities/view.nim
@@ -67,9 +67,6 @@ QtObject:
                         aX: int, aY: int, bX: int, bY: int) {.slot.} =
     self.delegate.createCommunity(name, description, access, ensOnly, color, imagePath, aX, aY, bX, bY)
   
-  proc editCommunity*(self: View, id: string, name: string, description: string, access: int, ensOnly: bool, color: string, imagePath: string, aX: int, aY: int, bX: int, bY: int) {.slot.} =
-    self.delegate.editCommunity(id, name, description, access, ensOnly, color, imagePath, aX, aY, bX, bY)
-  
   proc createCommunityCategory*(self: View, communityId: string, name: string, channels: string) {.slot.} =
     self.delegate.createCommunityCategory(communityId, name, channels)
 
@@ -85,9 +82,6 @@ QtObject:
   proc reorderCommunityChannel*(self: View, communityId: string, categoryId: string, chatId: string, position: int): string {.slot} =
     self.delegate.reorderCommunityChannel(communityId, categoryId, chatId, position)
 
-  proc inviteUsersToCommunityById*(self: View, communityId: string, pubKeysJSON: string): string {.slot.} =
-    result = self.delegate.inviteUsersToCommunityById(communityId, pubKeysJSON)
-  
   proc removeUserFromCommunity*(self: View, communityId: string, pubKey: string) {.slot.} =
     self.delegate.removeUserFromCommunity(communityId, pubKey)
 
@@ -103,17 +97,5 @@ QtObject:
   proc deleteCommunityChat*(self: View, communityId: string, channelId: string) {.slot.} =
     self.delegate.deleteCommunityChat(communityId, channelId)
 
-  proc setCommunityMuted*(self: View, communityId: string, muted: bool) {.slot.} =
-    self.delegate.setCommunityMuted(communityId, muted)
-
-  # proc markNotificationsAsRead*(self: View, markAsReadProps: MarkAsReadNotificationProperties) =
-  #   # todo
-  #   discard
-
   proc importCommunity*(self: View, communityKey: string) {.slot.} =
     self.delegate.importCommunity(communityKey)
-
-  proc exportCommunity*(self: View, communityId: string): string {.slot.} =
-    self.delegate.exportCommunity(communityId)
-
-  

--- a/src/app_service/service/community/service.nim
+++ b/src/app_service/service/community/service.nim
@@ -570,23 +570,23 @@ QtObject:
       let response =  status_go.inviteUsersToCommunity(communityId, pubKeys)
       discard self.chatService.processMessageUpdateAfterSend(response)
     except Exception as e:
-      error "Error exporting community", msg = e.msg
+      error "Error inviting to community", msg = e.msg
       result = "Error exporting community: " & e.msg
 
   proc removeUserFromCommunity*(self: Service, communityId: string, pubKeys: string)  =
     try:
       discard status_go.removeUserFromCommunity(communityId, pubKeys)
     except Exception as e:
-      error "Error exporting community", msg = e.msg
+      error "Error removing user from community", msg = e.msg
 
   proc banUserFromCommunity*(self: Service, communityId: string, pubKey: string)  =
     try:
       discard status_go.banUserFromCommunity(communityId, pubKey)
     except Exception as e:
-      error "Error exporting community", msg = e.msg
+      error "Error banning user from community", msg = e.msg
 
   proc setCommunityMuted*(self: Service, communityId: string, muted: bool) =
     try:
       discard status_go.setCommunityMuted(communityId, muted)
     except Exception as e:
-      error "Error exporting community", msg = e.msg
+      error "Error setting community un/muted", msg = e.msg

--- a/ui/app/AppLayouts/Chat/panels/communities/CommunityProfilePopupInviteFriendsPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/CommunityProfilePopupInviteFriendsPanel.qml
@@ -19,11 +19,12 @@ Column {
 
     property var rootStore
     property var contactsStore
+    property var communitySectionModule
     property var community
     property alias contactListSearch: contactFieldAndList
 
     function sendInvites(pubKeys) {
-       const error = root.rootStore.inviteUsersToCommunityById(root.community.id, JSON.stringify(pubKeys))
+       const error = communitySectionModule.inviteUsersToCommunity(JSON.stringify(pubKeys))
        if (error) {
            console.error('Error inviting', error)
            contactFieldAndList.validationError = error

--- a/ui/app/AppLayouts/Chat/panels/communities/CommunityWelcomeBannerPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/CommunityWelcomeBannerPanel.qml
@@ -92,7 +92,8 @@ Rectangle {
         anchors.bottomMargin: Style.current.halfPadding
         onClicked: Global.openPopup(inviteFriendsToCommunityPopup, {
             community: root.activeCommunity,
-            hasAddedContacts: root.hasAddedContacts
+            hasAddedContacts: root.hasAddedContacts,
+            communitySectionModule: root.communitySectionModule
         })
     }
 

--- a/ui/app/AppLayouts/Chat/popups/community/CommunityProfilePopup.qml
+++ b/ui/app/AppLayouts/Chat/popups/community/CommunityProfilePopup.qml
@@ -14,6 +14,8 @@ StatusModal {
 
     property var store
     property var community
+    property var contactsStore
+    property bool hasAddedContacts
     property var communitySectionModule
 
     onClosed: {
@@ -61,16 +63,15 @@ StatusModal {
                 community: root.community
 
                 onMembersListButtonClicked: root.contentItem.push(membersList)
-                onNotificationsButtonClicked: {
-                    root.store.setCommunityMuted(root.community.id, checked);
-                }
+                onNotificationsButtonClicked: root.communitySectionModule.setCommunityMuted(checked)
                 onEditButtonClicked: Global.openPopup(editCommunityroot, {
                     store: root.store,
                     community: root.community,
+                    communitySectionModule: root.communitySectionModule,
                     onSave: root.close
                 })
                 onTransferOwnershipButtonClicked: Global.openPopup(transferOwnershiproot, {
-                    privateKey: root.store.exportCommunity(root.community.id),
+                    privateKey: communitySectionModule.exportCommunity(root.community.id),
                     store: root.store
                 })
                 onLeaveButtonClicked: {
@@ -127,13 +128,14 @@ StatusModal {
                 //% "Invite friends"
                 headerTitle: qsTrId("invite-friends")
                 community: root.community
+                communitySectionModule: root.communitySectionModule
+                contactsStore: root.contactsStore
 
                 contactListSearch.chatKey.text: ""
                 contactListSearch.pubKey: ""
                 contactListSearch.pubKeys: []
                 contactListSearch.ensUsername: ""
-                // Not Refactored Yet
-//                contactListSearch.existingContacts.visible: root.store.allContacts.hasAddedContacts()
+                contactListSearch.existingContacts.visible: root.hasAddedContacts
                 contactListSearch.noContactsRect.visible: !contactListSearch.existingContacts.visible
             }
         }

--- a/ui/app/AppLayouts/Chat/popups/community/CreateCommunityPopup.qml
+++ b/ui/app/AppLayouts/Chat/popups/community/CreateCommunityPopup.qml
@@ -19,6 +19,7 @@ StatusModal {
     height: 509
 
     property var store
+    property var communitySectionModule
     property bool isEdit: false
     // Not Refactored Yet
     property QtObject community: null //popup.store.chatsModelInst.communities.activeCommunity
@@ -406,8 +407,7 @@ StatusModal {
 
                 let error = false;
                 if(isEdit) {
-                    error = popup.store.editCommunity(
-                        community.id,
+                    error = communitySectionModule.editCommunity(
                         Utils.filterXSS(popup.contentItem.communityName.input.text),
                         Utils.filterXSS(popup.contentItem.communityDescription.input.text),
                         membershipRequirementSettingPopup.checkedMembership,

--- a/ui/app/AppLayouts/Chat/popups/community/InviteFriendsToCommunityPopup.qml
+++ b/ui/app/AppLayouts/Chat/popups/community/InviteFriendsToCommunityPopup.qml
@@ -18,6 +18,7 @@ StatusModal {
     property var rootStore
     property var contactsStore
     property var community
+    property var communitySectionModule
     property bool hasAddedContacts
 
     onOpened: {
@@ -38,6 +39,7 @@ StatusModal {
     contentItem: CommunityProfilePopupInviteFriendsPanel {
         id: contactFieldAndList
         rootStore: popup.rootStore
+        communitySectionModule: popup.communitySectionModule
         contactsStore: popup.contactsStore
         community: popup.community
         contactListSearch.onUserClicked: {

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -130,10 +130,6 @@ QtObject {
         communitiesModuleInst.createCommunity(communityName, communityDescription, checkedMembership, ensOnlySwitchChecked, communityColor, communityImage, imageCropperModalaX, imageCropperModalaY, imageCropperModalbX, imageCropperModalbY);
     }
 
-    function editCommunity(communityId, communityName, communityDescription, checkedMembership, ensOnlySwitchChecked, communityColor, communityImage, imageCropperModalaX, imageCropperModalaY, imageCropperModalbX, imageCropperModalbY) {
-        communitiesModuleInst.editCommunity(communityId, communityName, communityDescription, checkedMembership, ensOnlySwitchChecked, communityColor, communityImage, imageCropperModalaX, imageCropperModalaY, imageCropperModalbX, imageCropperModalbY);
-    }
-
     function createCommunityCategory(communityId, categoryName, channels) {
         // Not Refactored Yet
 //        chatsModelInst.communities.createCommunityCategory(communityId, categoryName, channels);
@@ -150,14 +146,6 @@ QtObject {
 
     function leaveCommunity() {
         chatCommunitySectionModule.leaveCommunity();
-    }
-
-    function setCommunityMuted(communityId, checked) {
-        communitiesModuleInst.setCommunityMuted(communityId, checked);
-    }
-
-    function exportCommunity(communityId) {
-        return communitiesModuleInst.exportCommunity(communityId);
     }
 
     function createCommunityChannel(channelName, channelDescription) {

--- a/ui/app/AppLayouts/Chat/views/CommunityColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/CommunityColumnView.qml
@@ -81,7 +81,8 @@ Item {
                 enabled: communityData.canManageUsers
                 onTriggered: Global.openPopup(inviteFriendsToCommunityPopup, {
                     community: communityData,
-                    hasAddedContacts: root.hasAddedContacts
+                    hasAddedContacts: root.hasAddedContacts,
+                    communitySectionModule: root.communitySectionModule
                 })
             }
         }
@@ -200,7 +201,8 @@ Item {
                     enabled: communityData.canManageUsers
                     onTriggered: Global.openPopup(inviteFriendsToCommunityPopup, {
                         community: communityData,
-                        hasAddedContacts: root.hasAddedContacts
+                        hasAddedContacts: root.hasAddedContacts,
+                        communitySectionModule: root.communitySectionModule
                     })
                 }
             }
@@ -374,7 +376,7 @@ Item {
                         activeCommunity: communityData
                         onBackupButtonClicked: {
                             Global.openPopup(transferOwnershipPopup, {
-                                privateKey: root.store.exportCommunity(communityData.id),
+                                privateKey: communitySectionModule.exportCommunity(communityData.id),
                                 store: root.store
                             })
                         }

--- a/ui/app/AppLayouts/stores/RootStore.qml
+++ b/ui/app/AppLayouts/stores/RootStore.qml
@@ -39,24 +39,8 @@ QtObject {
         communitiesModuleInst.setObservedCommunity(communityId);
     }
 
-    function setCommunityMuted(communityId, checked) {
-        communitiesModuleInst.setCommunityMuted(communityId, checked);
-    }
-
-    function exportCommunity(communityId) {
-        return communitiesModuleInst.exportCommunity(communityId);
-    }
-
     function createCommunity(communityName, communityDescription, checkedMembership, ensOnlySwitchChecked, communityColor, communityImage, imageCropperModalaX, imageCropperModalaY, imageCropperModalbX, imageCropperModalbY) {
         communitiesModuleInst.createCommunity(communityName, communityDescription, checkedMembership, ensOnlySwitchChecked, communityColor, communityImage, imageCropperModalaX, imageCropperModalaY, imageCropperModalbX, imageCropperModalbY);
-    }
-
-    function editCommunity(communityId, communityName, communityDescription, checkedMembership, ensOnlySwitchChecked, communityColor, communityImage, imageCropperModalaX, imageCropperModalaY, imageCropperModalbX, imageCropperModalbY) {
-        communitiesModuleInst.editCommunity(communityId, communityName, communityDescription, checkedMembership, ensOnlySwitchChecked, communityColor, communityImage, imageCropperModalaX, imageCropperModalaY, imageCropperModalbX, imageCropperModalbY);
-    }
-
-    function inviteUsersToCommunityById(communityId, pubkeysJson) {
-        communitiesModuleInst.inviteUsersToCommunityById(communityId, pubkeysJson);
     }
 
     function copyToClipboard(text) {

--- a/ui/app/AppMain.qml
+++ b/ui/app/AppMain.qml
@@ -265,7 +265,8 @@ Item {
                         enabled: model.canManageUsers
                         onTriggered: Global.openPopup(inviteFriendsToCommunityPopup, {
                             community: model,
-                            hasAddedContacts: appMain.rootStore.hasAddedContacts
+                            hasAddedContacts: appMain.rootStore.hasAddedContacts,
+                            communitySectionModule: communityContextMenu.chatCommunitySectionModule
                         })
                     }
 
@@ -287,7 +288,8 @@ Item {
                         icon.name: "edit"
                         onTriggered: Global.openPopup(editCommunityPopup, {
                             store: appMain.rootStore,
-                            community: model
+                            community: model,
+                            communitySectionModule: communityContextMenu.chatCommunitySectionModule
                         })
                     }
 
@@ -644,6 +646,8 @@ Item {
 
             CommunityProfilePopup {
                 anchors.centerIn: parent
+                contactsStore: appMain.rootStore.contactStore
+                hasAddedContacts: appMain.rootStore.hasAddedContacts
 
                 onClosed: {
                     destroy()


### PR DESCRIPTION
Fixes #4489

This moves the remaining community functions that are not general to the chat_section. It also fixes some small missing hooks (for members for example) 

There are other functions that will need to be moved, like the category ones and some others, but they are not yet fully implemented on the front-end, and in the case of categories, are being worked on by @borismelnik so I don't want to conflict with his work.