### PR TITLE
fix(@desktop/chat-messages): [base_bc] adding emoji to a message does not reflect on desktop

### DIFF
--- a/src/app/modules/main/chat_section/chat_content/controller.nim
+++ b/src/app/modules/main/chat_section/chat_content/controller.nim
@@ -92,6 +92,12 @@ method init*(self: Controller) =
       return
     self.delegate.onReactionRemoved(args.messageId, args.emojiId, args.reactionId)
 
+  self.events.on(SIGNAL_MESSAGE_REACTION_FROM_OTHERS) do(e:Args):
+    let args = MessageAddRemoveReactionArgs(e)
+    if(self.chatId != args.chatId):
+      return
+    self.delegate.toggleReactionFromOthers(args.messageId, args.emojiId, args.reactionId, args.reactionFrom)
+
   self.events.on(SIGNAL_CONTACT_NICKNAME_CHANGED) do(e: Args):
     var args = ContactArgs(e)
     self.delegate.onContactDetailsUpdated(args.contactId)

--- a/src/app/modules/main/chat_section/chat_content/messages/controller.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/controller.nim
@@ -95,6 +95,12 @@ method init*(self: Controller) =
       return
     self.delegate.onReactionRemoved(args.messageId, args.emojiId, args.reactionId)
 
+  self.events.on(SIGNAL_MESSAGE_REACTION_FROM_OTHERS) do(e:Args):
+    let args = MessageAddRemoveReactionArgs(e)
+    if(self.chatId != args.chatId):
+      return
+    self.delegate.toggleReactionFromOthers(args.messageId, args.emojiId, args.reactionId, args.reactionFrom)
+
   self.events.on(SIGNAL_CONTACT_NICKNAME_CHANGED) do(e: Args):
     var args = ContactArgs(e)
     self.delegate.updateContactDetails(args.contactId)

--- a/src/app/modules/main/chat_section/chat_content/messages/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/module.nim
@@ -132,7 +132,7 @@ method newMessagesLoaded*(self: Module, messages: seq[MessageDto], reactions: se
             item.addReaction(emojiIdAsEnum, didIReactWithThisEmoji, userWhoAddedThisReaction.id, 
             userWhoAddedThisReaction.userNameOrAlias(), r.id)
           else:
-            error "wrong emoji id found when loading messages"
+            error "wrong emoji id found when loading messages", methodName="newMessagesLoaded"
 
       for p in pinnedMessages:
         if(p.message.id == m.id):
@@ -205,23 +205,41 @@ method toggleReaction*(self: Module, messageId: string, emojiId: int) =
       let reactionId = item.getReactionId(emojiIdAsEnum, myPublicKey)
       self.controller.removeReaction(messageId, emojiId, reactionId)
   else:
-    error "wrong emoji id found on reaction added response", emojiId
+    error "wrong emoji id found on reaction added response", emojiId, methodName="toggleReaction"
 
 method onReactionAdded*(self: Module, messageId: string, emojiId: int, reactionId: string) =
   var emojiIdAsEnum: EmojiId
   if(message_reaction_item.toEmojiIdAsEnum(emojiId, emojiIdAsEnum)):
     let myPublicKey = singletonInstance.userProfile.getPubKey()
     let myName = singletonInstance.userProfile.getName()
-    self.view.model().addReaction(messageId, emojiIdAsEnum, true, myPublicKey, myName, reactionId)
+    self.view.model().addReaction(messageId, emojiIdAsEnum, didIReactWithThisEmoji = true, myPublicKey, myName, 
+    reactionId)
   else:
-    error "wrong emoji id found on reaction added response", emojiId
+    error "wrong emoji id found on reaction added response", emojiId, methodName="onReactionAdded"
 
 method onReactionRemoved*(self: Module, messageId: string, emojiId: int, reactionId: string) =
   var emojiIdAsEnum: EmojiId
   if(message_reaction_item.toEmojiIdAsEnum(emojiId, emojiIdAsEnum)):
-    self.view.model().removeReaction(messageId, emojiIdAsEnum, reactionId)
+    self.view.model().removeReaction(messageId, emojiIdAsEnum, reactionId, didIRemoveThisReaction = true)
   else:
-    error "wrong emoji id found on reaction remove response", emojiId
+    error "wrong emoji id found on reaction remove response", emojiId, methodName="onReactionRemoved"
+
+method toggleReactionFromOthers*(self: Module, messageId: string, emojiId: int, reactionId: string, 
+  reactionFrom: string) =
+  var emojiIdAsEnum: EmojiId
+  if(message_reaction_item.toEmojiIdAsEnum(emojiId, emojiIdAsEnum)):
+    let item = self.view.model().getItemWithMessageId(messageId)
+    if(item.isNil):
+      info "message with this id is not loaded yet ", msgId=messageId, methodName="toggleReactionFromOthers"
+      return
+    if(item.shouldAddReaction(emojiIdAsEnum, reactionFrom)):
+      let userWhoAddedThisReaction = self.controller.getContactById(reactionFrom)
+      self.view.model().addReaction(messageId, emojiIdAsEnum, didIReactWithThisEmoji = false, 
+      userWhoAddedThisReaction.id, userWhoAddedThisReaction.userNameOrAlias(), reactionId)
+    else:
+      self.view.model().removeReaction(messageId, emojiIdAsEnum, reactionId, didIRemoveThisReaction = false)
+  else:
+    error "wrong emoji id found on reaction added response", emojiId, methodName="toggleReactionFromOthers"
 
 method pinUnpinMessage*(self: Module, messageId: string, pin: bool) =
   self.controller.pinUnpinMessage(messageId, pin)

--- a/src/app/modules/main/chat_section/chat_content/messages/private_interfaces/module_controller_delegate_interface.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/private_interfaces/module_controller_delegate_interface.nim
@@ -10,6 +10,10 @@ method onReactionAdded*(self: AccessInterface, messageId: string, emojiId: int, 
 method onReactionRemoved*(self: AccessInterface, messageId: string, emojiId: int, reactionId: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method toggleReactionFromOthers*(self: AccessInterface, messageId: string, emojiId: int, reactionId: string, 
+  reactionFrom: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method onPinMessage*(self: AccessInterface, messageId: string, actionInitiatedBy: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/chat_section/chat_content/private_interfaces/module_controller_delegate_interface.nim
+++ b/src/app/modules/main/chat_section/chat_content/private_interfaces/module_controller_delegate_interface.nim
@@ -22,6 +22,10 @@ method onReactionAdded*(self: AccessInterface, messageId: string, emojiId: int, 
 method onReactionRemoved*(self: AccessInterface, messageId: string, emojiId: int, reactionId: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method toggleReactionFromOthers*(self: AccessInterface, messageId: string, emojiId: int, reactionId: string, 
+  reactionFrom: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method onContactDetailsUpdated*(self: AccessInterface, contactId: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/shared_models/message_item.nim
+++ b/src/app/modules/shared_models/message_item.nim
@@ -196,8 +196,8 @@ proc addReaction*(self: Item, emojiId: EmojiId, didIReactWithThisEmoji: bool, us
   userDisplayName: string, reactionId: string) = 
   self.reactionsModel.addReaction(emojiId, didIReactWithThisEmoji, userPublicKey, userDisplayName, reactionId)
 
-proc removeReaction*(self: Item, emojiId: EmojiId, reactionId: string) = 
-  self.reactionsModel.removeReaction(emojiId, reactionId)
+proc removeReaction*(self: Item, emojiId: EmojiId, reactionId: string, didIRemoveThisReaction: bool) = 
+  self.reactionsModel.removeReaction(emojiId, reactionId, didIRemoveThisReaction)
 
 proc toJsonNode*(self: Item): JsonNode =
   result = %* {

--- a/src/app/modules/shared_models/message_model.nim
+++ b/src/app/modules/shared_models/message_model.nim
@@ -270,12 +270,12 @@ QtObject:
     let index = self.createIndex(ind, 0, nil)
     self.dataChanged(index, index, @[ModelRole.Reactions.int])
 
-  proc removeReaction*(self: Model, messageId: string, emojiId: EmojiId, reactionId: string) = 
+  proc removeReaction*(self: Model, messageId: string, emojiId: EmojiId, reactionId: string, didIRemoveThisReaction: bool) = 
     let ind = self.findIndexForMessageId(messageId)
     if(ind == -1):
       return
 
-    self.items[ind].removeReaction(emojiId, reactionId)
+    self.items[ind].removeReaction(emojiId, reactionId, didIRemoveThisReaction)
     
     let index = self.createIndex(ind, 0, nil)
     self.dataChanged(index, index, @[ModelRole.Reactions.int])

--- a/src/app/modules/shared_models/message_reaction_item.nim
+++ b/src/app/modules/shared_models/message_reaction_item.nim
@@ -29,6 +29,7 @@ proc toEmojiIdAsEnum*(emojiId: int, emojiIdAsEnum: var EmojiId): bool =
 
 proc initMessageReactionItem*(emojiId: EmojiId): MessageReactionItem =
   result.emojiId = emojiId
+  result.didIReactWithThisEmoji = false
 
 proc `$`*(self: MessageReactionItem): string =
   var reactions = ""
@@ -72,16 +73,20 @@ proc getReactionId*(self: MessageReactionItem, userPublicKey: string): string =
 
 proc addReaction*(self: var MessageReactionItem, didIReactWithThisEmoji: bool, userPublicKey: string, 
   userDisplayName: string, reactionId: string) =
-  self.didIReactWithThisEmoji = didIReactWithThisEmoji
+  if(didIReactWithThisEmoji):
+    self.didIReactWithThisEmoji = true
   self.reactions.add(ReactionDetails(publicKey: userPublicKey, displayName: userDisplayName, reactionId: reactionId))
 
-proc removeReaction*(self: var MessageReactionItem, reactionId: string) = 
+proc removeReaction*(self: var MessageReactionItem, reactionId: string, didIRemoveThisReaction: bool) = 
   var index = -1
   for i in 0..<self.reactions.len:
     if (self.reactions[i].reactionId == reactionId):
       index = i
       break
   
+  if(didIRemoveThisReaction):
+    self.didIReactWithThisEmoji = false
+
   if(index == -1):
     return
 

--- a/src/app/modules/shared_models/message_reaction_model.nim
+++ b/src/app/modules/shared_models/message_reaction_model.nim
@@ -114,7 +114,8 @@ QtObject:
         return
       self.items[ind].addReaction(didIReactWithThisEmoji, userPublicKey, userDisplayName, reactionId)
       let index = self.createIndex(ind, 0, nil)
-      self.dataChanged(index, index, @[]) # all roles
+      self.dataChanged(index, index, @[ModelRole.EmojiId.int, ModelRole.DidIReactWithThisEmoji.int, 
+      ModelRole.NumberOfReactions.int, ModelRole.JsonArrayOfUsersReactedWithThisEmoji.int])
     else:
       let parentModelIndex = newQModelIndex()
       defer: parentModelIndex.delete
@@ -129,11 +130,11 @@ QtObject:
 
     self.countChanged()
 
-  proc removeReaction*(self: MessageReactionModel, emojiId: EmojiId, reactionId: string) = 
+  proc removeReaction*(self: MessageReactionModel, emojiId: EmojiId, reactionId: string, didIRemoveThisReaction: bool) = 
     let ind = self.getIndexOfTheItemWithEmojiId(emojiId)
     if(ind == -1):
       return
-    self.items[ind].removeReaction(reactionId)
+    self.items[ind].removeReaction(reactionId, didIRemoveThisReaction)
 
     if(self.items[ind].numberOfReactions() == 0):
       # remove item if there are no reactions for this emoji id
@@ -144,3 +145,7 @@ QtObject:
       self.items.delete(ind)
       self.endRemoveRows()
       self.countChanged()
+    else:
+      let index = self.createIndex(ind, 0, nil)
+      self.dataChanged(index, index, @[ModelRole.EmojiId.int, ModelRole.DidIReactWithThisEmoji.int, 
+      ModelRole.NumberOfReactions.int, ModelRole.JsonArrayOfUsersReactedWithThisEmoji.int])


### PR DESCRIPTION
Desktop app does handle message reactions properly now.
Reactions are properly handled by the pinned messages model as well.

Fixes #4525