### PR TITLE
fix(community/section): fix new community order in the sections

### DIFF
--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -241,14 +241,14 @@ method load*[T](
   notificationsCount, 
   active = false, 
   enabled = true)
-  self.view.addItem(chatSectionItem)
+  self.view.model().addItem(chatSectionItem)
   if(activeSectionId == chatSectionItem.id):
     activeSection = chatSectionItem
 
   # Community Section
   for c in joinedCommunities:
     let communitySectionItem = self.createCommunityItem(c)
-    self.view.addItem(communitySectionItem)
+    self.view.model().addItem(communitySectionItem)
     if(activeSectionId == communitySectionItem.id):
       activeSection = communitySectionItem
 
@@ -263,7 +263,7 @@ method load*[T](
   notificationsCount = 0, 
   active = false,
   enabled = singletonInstance.localAccountSensitiveSettings.getIsWalletEnabled())
-  self.view.addItem(walletSectionItem)
+  self.view.model().addItem(walletSectionItem)
   if(activeSectionId == walletSectionItem.id):
     activeSection = walletSectionItem
 
@@ -278,7 +278,7 @@ method load*[T](
   notificationsCount = 0, 
   active = false, 
   enabled = singletonInstance.localAccountSensitiveSettings.getIsWalletV2Enabled())
-  self.view.addItem(walletV2SectionItem)
+  self.view.model().addItem(walletV2SectionItem)
   if(activeSectionId == walletV2SectionItem.id):
     activeSection = walletV2SectionItem
 
@@ -293,7 +293,7 @@ method load*[T](
   notificationsCount = 0, 
   active = false,
   enabled = singletonInstance.localAccountSensitiveSettings.getIsBrowserEnabled())
-  self.view.addItem(browserSectionItem)
+  self.view.model().addItem(browserSectionItem)
   if(activeSectionId == browserSectionItem.id):
     activeSection = browserSectionItem
 
@@ -309,7 +309,7 @@ method load*[T](
   notificationsCount = 0, 
   active = false, 
   enabled = singletonInstance.localAccountSensitiveSettings.getNodeManagementEnabled())
-  self.view.addItem(nodeManagementSectionItem)
+  self.view.model().addItem(nodeManagementSectionItem)
   if(activeSectionId == nodeManagementSectionItem.id):
     activeSection = nodeManagementSectionItem
 
@@ -325,7 +325,7 @@ method load*[T](
   notificationsCount = 0, 
   active = false, 
   enabled = true)
-  self.view.addItem(profileSettingsSectionItem)
+  self.view.model().addItem(profileSettingsSectionItem)
   if(activeSectionId == profileSettingsSectionItem.id):
     activeSection = profileSettingsSectionItem
 
@@ -519,6 +519,9 @@ method communityJoined*[T](
   messageService: message_service.Service,
   gifService: gif_service.Service,
 ) =
+  var firstCommunityJoined = false
+  if (self.communitySectionsModule.len == 0):
+    firstCommunityJoined = true
   self.communitySectionsModule[community.id] = chat_section_module.newModule(
       self,
       events,
@@ -534,7 +537,11 @@ method communityJoined*[T](
   self.communitySectionsModule[community.id].load(events, settingsService, contactsService, chatService, communityService, messageService, gifService)
 
   let communitySectionItem = self.createCommunityItem(community)
-  self.view.addItem(communitySectionItem)
+  if (firstCommunityJoined):
+    # If there are no other communities, add the first community after the Chat section in the model so that the order is respected
+    self.view.model().addItem(communitySectionItem, self.view.model().getItemIndex(conf.CHAT_SECTION_ID) + 1)
+  else:
+    self.view.model().addItem(communitySectionItem)
   self.setActiveSection(communitySectionItem)
 
 method communityLeft*[T](self: Module[T], communityId: string) =

--- a/src/app/modules/main/view.nim
+++ b/src/app/modules/main/view.nim
@@ -36,9 +36,6 @@ QtObject:
     # In some point, here, we will setup some exposed main module related things.
     self.delegate.viewDidLoad()
 
-  proc addItem*(self: View, item: SectionItem) =
-    self.model.addItem(item)
-
   proc editItem*(self: View, item: SectionItem) =
     self.model.editItem(item)
     if (self.activeSection.getId() == item.id):

--- a/src/app/modules/shared_models/section_model.nim
+++ b/src/app/modules/shared_models/section_model.nim
@@ -149,6 +149,16 @@ QtObject:
 
     self.countChanged()
 
+  proc addItem*(self: SectionModel, item: SectionItem, index: int) =
+    let parentModelIndex = newQModelIndex()
+    defer: parentModelIndex.delete
+
+    self.beginInsertRows(parentModelIndex, index, index)
+    self.items.insert(item, index)
+    self.endInsertRows()
+
+    self.countChanged()
+
   proc getItemIndex*(self: SectionModel, id: string): int =
     var i = 0
     for item in self.items:


### PR DESCRIPTION
Fixes #4566

The problem was that when no community exists, there were no community section in the model, so the new section was added last.
There might be a follow up StatusQ fix to make the StatusAppNavBar a bit smarter or order better in a later case were we want the communities always second, but this fix works.