### PR TITLE
fix(@desktop/chat): [base_bc] Start new chat modal has text overlapped, also it is not possible to start new chat at all

### DIFF
--- a/ui/imports/shared/controls/ContactsListAndSearch.qml
+++ b/ui/imports/shared/controls/ContactsListAndSearch.qml
@@ -111,7 +111,7 @@ Item {
                         //% "Can't chat with yourself"
                         root.validationError = qsTrId("can-t-chat-with-yourself");
                     } else {
-                        searchResults.username = chatsModel.ensView.formatENSUsername(chatKey.text)
+                        searchResults.username = Utils.addStatusEns(chatKey.text.trim())
                         let userAlias = globalUtils.generateAlias(resolvedPubKey)
                         userAlias = userAlias.length > 20 ? userAlias.substring(0, 19) + "..." : userAlias
                         searchResults.userAlias =  userAlias + " • " + Utils.compactAddress(resolvedPubKey, 4)
@@ -225,7 +225,8 @@ Item {
     NoFriendsRectangle {
         id: noContactsRect
         visible: showContactList
-        anchors.top: chatKey.top
+        anchors.top: chatKey.bottom
+        anchors.topMargin: Style.current.xlPadding * 3
         anchors.horizontalCenter: parent.horizontalCenter
         anchors.verticalCenter: parent.verticalCenter
     }

--- a/ui/imports/shared/stores/RootStore.qml
+++ b/ui/imports/shared/stores/RootStore.qml
@@ -6,10 +6,11 @@ QtObject {
     id: root
 //    property var utilsModelInst: !!utilsModel ? utilsModel :  null
 //    property var chatsModelInst: !!chatsModel ?chatsModel : null
-//    property var userProfileInst: !!userProfile ? userProfile : null
 //    property var walletModelInst: !!walletModel ? walletModel : null
 //    property var keycardModelInst: !!keycardModel ? keycardModel : null
 //    property var profileModelInst: !!profileModel ? profileModel : null
+
+    property var userProfileInst: !!userProfile ? userProfile : null
     property var walletSectionInst: !!walletSection ? walletSection : null
     property var appSettings: !!localAppSettings ? localAppSettings : null
     property var accountSensitiveSettings: !!localAccountSensitiveSettings ? localAccountSensitiveSettings : null


### PR DESCRIPTION
Fixes #4530