### PR TITLE
fix(image-modal): fix having to click multiple times to close the image

### DIFF
--- a/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
@@ -137,27 +137,6 @@ Item {
         store: root.rootStore
         reactionModel: root.rootStore.emojiReactionsModel
     }
-
-    StatusImageModal {
-        id: imagePopup
-        onClicked: {
-            if (button === Qt.LeftButton) {
-                imagePopup.close()
-            } else if(button === Qt.RightButton) {
-                contextmenu.imageSource = imagePopup.imageSource
-                contextmenu.hideEmojiPicker = true
-                contextmenu.isRightClickOnImage = true;
-                contextmenu.show()
-            }
-        }
-        Connections {
-            target: Global
-            onOpenImagePopup: {
-                imagePopup.openPopup(image);
-            }
-        }
-    }
-
     
     EmptyChatPanel {
         anchors.fill: parent

--- a/ui/app/AppMain.qml
+++ b/ui/app/AppMain.qml
@@ -136,6 +136,26 @@ Item {
         }
     }
 
+    StatusImageModal {
+        id: imagePopup
+        onClicked: {
+            if (button === Qt.LeftButton) {
+                imagePopup.close()
+            } else if(button === Qt.RightButton) {
+                contextmenu.imageSource = imagePopup.imageSource
+                contextmenu.hideEmojiPicker = true
+                contextmenu.isRightClickOnImage = true;
+                contextmenu.show()
+            }
+        }
+        Connections {
+            target: Global
+            onOpenImagePopup: {
+                imagePopup.openPopup(image);
+            }
+        }
+    }
+
     property Component profilePopupComponent: ProfilePopup {
         id: profilePopup
         profileStore: appMain.rootStore.profileSectionStore.profileStore


### PR DESCRIPTION
Fixes #4586

The problem was that the popup was put in the `ChatColumnView` and the `ChatColumnView` is repeated for each community, plus the normal chat section. So if you have joined 3 community, clicking an image triggered the image opening 4 times, so you would have had to close it 4 times (4 clicks)