### PR TITLE
fix(@desktop/chat): can't reply to a reply

### DIFF
--- a/src/app_service/service/chat/service.nim
+++ b/src/app_service/service/chat/service.nim
@@ -128,14 +128,18 @@ QtObject:
       error "no chats or messages in the parsed response"
       return
 
-    # This fixes issue#3490
+    # The reason why we are sending all the messages with responseTo filled in is because
+    # the reposnse from status_go doesnt necessarily contain the last reply on the 0th position.
+    var isaReply = false
     var msg = messages[0]
     for m in messages:
       if(m.responseTo.len > 0):
+        isaReply = true
         msg = m
-        break
-    
-    self.events.emit(SIGNAL_SENDING_SUCCESS, MessageSendingSuccess(message: msg, chat: chats[0]))
+        self.events.emit(SIGNAL_SENDING_SUCCESS, MessageSendingSuccess(message: msg, chat: chats[0]))
+
+    if not isaReply:
+      self.events.emit(SIGNAL_SENDING_SUCCESS, MessageSendingSuccess(message: msg, chat: chats[0]))
 
   proc processUpdateForTransaction*(self: Service, messageId: string, response: RpcResponse[JsonNode]) =
     var (chats, messages) = self.processMessageUpdateAfterSend(response)


### PR DESCRIPTION
### What does the PR do

Reply to a reply is not visible sometimes, because we fetch for the last reply on the 0th index of the messages received in response to the sendMessage API. However the last reply may not be at 0th position but also at some other position.

In this fix, I am sending the event for the message to be updated for all messages that have a response to and as it correctly filters out the duplicate entries, the correct one is listed

### Affected areas

chat

### Screenshot of functionality

![image](https://user-images.githubusercontent.com/60327365/151330748-6c8ee987-84eb-4a9e-8dbe-08b718ac7705.png)
