### PR TITLE
fix(@desktop/app-search): [base_bc] can't jump to a message from search results

### DIFF
--- a/src/app/modules/main/app_search/controller.nim
+++ b/src/app/modules/main/app_search/controller.nim
@@ -38,7 +38,7 @@ type
     searchLocation: string
     searchSubLocation: string
     searchTerm: string
-    resultItems: Table[string, ResultItemDetails] # [resuiltItemId, ResultItemDetails]
+    resultItems: Table[string, ResultItemDetails] # [resultItemId, ResultItemDetails]
 
 proc newController*(delegate: io_interface.AccessInterface, events: EventEmitter, contactsService: contact_service.Service,
   chatService: chat_service.Service, communityService: community_service.Service, 

--- a/src/app/modules/main/app_search/controller_interface.nim
+++ b/src/app/modules/main/app_search/controller_interface.nim
@@ -58,3 +58,10 @@ method getOneToOneChatNameAndImage*(self: AccessInterface, chatId: string):
 method getContactNameAndImage*(self: AccessInterface, contactId: string): 
   tuple[name: string, image: string, isIdenticon: bool] {.base.} =
   raise newException(ValueError, "No implementation available")
+
+method addResultItemDetails*(self: AccessInterface, itemId: string, sectionId = "", channelId = "", messageId = "") 
+  {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method resultItemClicked*(self: AccessInterface, itemId: string)  {.base.} =
+  raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/app_search/module.nim
+++ b/src/app/modules/main/app_search/module.nim
@@ -158,6 +158,7 @@ method onSearchMessagesDone*(self: Module, messages: seq[MessageDto]) =
       let item = result_item.initItem(co.id, "", "", co.id, co.name, SEARCH_RESULT_COMMUNITIES_SECTION_NAME, 
         co.images.thumbnail, co.color, "", "", co.images.thumbnail, co.color, false)
 
+      self.controller.addResultItemDetails(co.id, co.id)
       items.add(item)
 
     # Add channels
@@ -170,6 +171,7 @@ method onSearchMessagesDone*(self: Module, messages: seq[MessageDto]) =
           SEARCH_RESULT_CHANNELS_SECTION_NAME, chatDto.identicon, chatDto.color, "", "", chatDto.identicon, chatDto.color, 
           false)
 
+          self.controller.addResultItemDetails(chatDto.id, co.id, chatDto.id)
           channels.add(item)
 
   # Add chats
@@ -193,6 +195,7 @@ method onSearchMessagesDone*(self: Module, messages: seq[MessageDto]) =
         let item = result_item.initItem(c.id, "", "", c.id, chatName, SEARCH_RESULT_CHATS_SECTION_NAME, chatImage, 
         c.color, "", "", chatImage, c.color, isIdenticon)
 
+        self.controller.addResultItemDetails(c.id, conf.CHAT_SECTION_ID, c.id)
         items.add(item)
 
   # Add channels in order as requested by the design
@@ -218,6 +221,7 @@ method onSearchMessagesDone*(self: Module, messages: seq[MessageDto]) =
       let item = result_item.initItem(m.id, m.text, $m.timestamp, m.`from`, senderName, 
       SEARCH_RESULT_MESSAGES_SECTION_NAME, senderImage, "", chatName, "", chatImage, chatDto.color, isIdenticon)
 
+      self.controller.addResultItemDetails(m.id, conf.CHAT_SECTION_ID, chatDto.id, m.id)
       items.add(item)
     else:
       let community = self.controller.getCommunityById(chatDto.communityId)
@@ -227,6 +231,11 @@ method onSearchMessagesDone*(self: Module, messages: seq[MessageDto]) =
       SEARCH_RESULT_MESSAGES_SECTION_NAME, senderImage, "", community.name, channelName, community.images.thumbnail, 
       community.color, false)
 
+      self.controller.addResultItemDetails(m.id, chatDto.communityId, chatDto.id, m.id)
       items.add(item)
 
   self.view.searchResultModel().set(items)
+  self.view.emitAppSearchCompletedSignal()
+
+method resultItemClicked*(self: Module, itemId: string) =
+  self.controller.resultItemClicked(itemId)

--- a/src/app/modules/main/app_search/private_interfaces/module_view_delegate_interface.nim
+++ b/src/app/modules/main/app_search/private_interfaces/module_view_delegate_interface.nim
@@ -12,3 +12,6 @@ method getSearchLocationObject*(self: AccessInterface): string {.base.} =
 
 method searchMessages*(self: AccessInterface, searchTerm: string) {.base.} =
   raise newException(ValueError, "No implementation available")
+
+method resultItemClicked*(self: AccessInterface, itemId: string) {.base.} =
+  raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/app_search/result_model.nim
+++ b/src/app/modules/main/app_search/result_model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, strutils
+import NimQml, Tables, strutils, strformat
 
 import result_item
 
@@ -33,15 +33,15 @@ QtObject:
     new(result, delete)
     result.setup()
 
-  #################################################
-  # Properties
-  #################################################
+  proc `$`*(self: Model): string =
+    for i in 0 ..< self.resultList.len:
+      result &= fmt"""SearchResultMessageModel:
+      [{i}]:({$self.resultList[i]})
+      """
   
   proc countChanged*(self: Model) {.signal.}
-
   proc count*(self: Model): int {.slot.}  =
     self.resultList.len
-
   QtProperty[int] count:
     read = count
     notify = countChanged

--- a/src/app/modules/main/app_search/view.nim
+++ b/src/app/modules/main/app_search/view.nim
@@ -59,3 +59,10 @@ QtObject:
 
   proc searchMessages*(self: View, searchTerm: string) {.slot.} = 
     self.delegate.searchMessages(searchTerm)
+
+  proc resultItemClicked*(self: View, itemId: string) {.slot.} = 
+    self.delegate.resultItemClicked(itemId)
+
+  proc appSearchCompleted(self: View) {.signal.}
+  proc emitAppSearchCompletedSignal*(self: View) =
+    self.appSearchCompleted()

--- a/src/app/modules/main/chat_section/chat_content/messages/controller.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/controller.nim
@@ -22,6 +22,7 @@ type
     sectionId: string
     chatId: string
     belongsToCommunity: bool
+    searchedMessageId: string
     contactService: contact_service.Service
     communityService: community_service.Service
     chatService: chat_service.Service
@@ -140,6 +141,12 @@ method init*(self: Controller) =
     let args = LinkPreviewDataArgs(e)
     self.delegate.onPreviewDataLoaded(args.response)
 
+  self.events.on(SIGNAL_MAKE_SECTION_CHAT_ACTIVE) do(e: Args):
+    var args = ActiveSectionChatArgs(e)
+    if(self.sectionId != args.sectionId or self.chatId != args.chatId):
+      return
+    self.delegate.switchToMessage(args.messageId)
+
 method getMySectionId*(self: Controller): string =
   return self.sectionId
 
@@ -197,3 +204,12 @@ method editMessage*(self: Controller, messageId: string, updatedMsg: string) =
 
 method getLinkPreviewData*(self: Controller, link: string, uuid: string): string = 
   self.messageService.asyncGetLinkPreviewData(link, uuid)
+
+method getSearchedMessageId*(self: Controller): string =
+  return self.searchedMessageId
+
+method setSearchedMessageId*(self: Controller, searchedMessageId: string) =
+  self.searchedMessageId = searchedMessageId
+
+method clearSearchedMessageId*(self: Controller) =
+  self.setSearchedMessageId("")

--- a/src/app/modules/main/chat_section/chat_content/messages/controller.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/controller.nim
@@ -23,6 +23,7 @@ type
     chatId: string
     belongsToCommunity: bool
     searchedMessageId: string
+    loadingMessagesPerPageFactor: int
     contactService: contact_service.Service
     communityService: community_service.Service
     chatService: chat_service.Service
@@ -37,6 +38,7 @@ proc newController*(delegate: io_interface.AccessInterface, events: EventEmitter
   result.events = events
   result.sectionId = sectionId
   result.chatId = chatId
+  result.loadingMessagesPerPageFactor = 1
   result.belongsToCommunity = belongsToCommunity
   result.contactService = contactService
   result.communityService = communityService
@@ -145,7 +147,7 @@ method init*(self: Controller) =
     var args = ActiveSectionChatArgs(e)
     if(self.sectionId != args.sectionId or self.chatId != args.chatId):
       return
-    self.delegate.switchToMessage(args.messageId)
+    self.delegate.scrollToMessage(args.messageId)
 
 method getMySectionId*(self: Controller): string =
   return self.sectionId
@@ -166,7 +168,8 @@ method belongsToCommunity*(self: Controller): bool =
   return self.belongsToCommunity
 
 method loadMoreMessages*(self: Controller) =
-  self.messageService.asyncLoadMoreMessagesForChat(self.chatId)
+  let limit = self.loadingMessagesPerPageFactor * MESSAGES_PER_PAGE
+  self.messageService.asyncLoadMoreMessagesForChat(self.chatId, limit)
 
 method addReaction*(self: Controller, messageId: string, emojiId: int) =
   self.messageService.addReaction(self.chatId, messageId, emojiId)
@@ -213,3 +216,12 @@ method setSearchedMessageId*(self: Controller, searchedMessageId: string) =
 
 method clearSearchedMessageId*(self: Controller) =
   self.setSearchedMessageId("")
+
+method getLoadingMessagesPerPageFactor*(self: Controller): int =
+  return self.loadingMessagesPerPageFactor
+
+method increaseLoadingMessagesPerPageFactor*(self: Controller) =
+  self.loadingMessagesPerPageFactor = self.loadingMessagesPerPageFactor + 1
+
+method resetLoadingMessagesPerPageFactor*(self: Controller) =
+  self.loadingMessagesPerPageFactor = 1

--- a/src/app/modules/main/chat_section/chat_content/messages/controller_interface.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/controller_interface.nim
@@ -80,3 +80,12 @@ method setSearchedMessageId*(self: AccessInterface, searchedMessageId: string) {
 
 method clearSearchedMessageId*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
+
+method getLoadingMessagesPerPageFactor*(self: AccessInterface): int {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method increaseLoadingMessagesPerPageFactor*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method resetLoadingMessagesPerPageFactor*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/chat_section/chat_content/messages/controller_interface.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/controller_interface.nim
@@ -71,3 +71,12 @@ method editMessage*(self: AccessInterface, messageId: string, updatedMsg: string
 
 method getLinkPreviewData*(self: AccessInterface, link: string, uuid: string): string {.base.} =
   raise newException(ValueError, "No implementation available")
+
+method getSearchedMessageId*(self: AccessInterface): string {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method setSearchedMessageId*(self: AccessInterface, searchedMessageId: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method clearSearchedMessageId*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/chat_section/chat_content/messages/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/module.nim
@@ -156,6 +156,11 @@ method newMessagesLoaded*(self: Module, messages: seq[MessageDto], reactions: se
 
   if(not self.view.getInitialMessagesLoaded()):
     self.view.initialMessagesAreLoaded()
+
+  # check if this loading was caused by the click on a messages from the app search result
+  let searchedMessageId = self.controller.getSearchedMessageId()
+  if(searchedMessageId.len > 0):
+    self.switchToMessage(searchedMessageId)
    
 method messageAdded*(self: Module, message: MessageDto) =
   let sender = self.controller.getContactDetails(message.`from`)
@@ -317,3 +322,12 @@ method getLinkPreviewData*(self: Module, link: string, uuid: string): string =
 
 method onPreviewDataLoaded*(self: Module, previewData: string) =
   self.view.onPreviewDataLoaded(previewData)
+
+method switchToMessage*(self: Module, messageId: string) =
+  let index = self.view.model().findIndexForMessageId(messageId)
+  if(index != -1):
+    self.controller.clearSearchedMessageId()
+    self.view.emitSwitchToMessageSignal(index)
+  else:
+    self.controller.setSearchedMessageId(messageId)
+    self.loadMoreMessages()

--- a/src/app/modules/main/chat_section/chat_content/messages/private_interfaces/module_controller_delegate_interface.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/private_interfaces/module_controller_delegate_interface.nim
@@ -38,5 +38,5 @@ method onMessageEdited*(self: AccessInterface, message: MessageDto) {.base.} =
 method setLoadingHistoryMessagesInProgress*(self: AccessInterface, isLoading: bool) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method switchToMessage*(self: AccessInterface, messageId: string) {.base.} =
+method scrollToMessage*(self: AccessInterface, messageId: string) {.base.} =
   raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/chat_section/chat_content/messages/private_interfaces/module_controller_delegate_interface.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/private_interfaces/module_controller_delegate_interface.nim
@@ -37,3 +37,6 @@ method onMessageEdited*(self: AccessInterface, message: MessageDto) {.base.} =
 
 method setLoadingHistoryMessagesInProgress*(self: AccessInterface, isLoading: bool) {.base.} =
   raise newException(ValueError, "No implementation available")
+
+method switchToMessage*(self: AccessInterface, messageId: string) {.base.} =
+  raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/chat_section/chat_content/messages/view.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/view.nim
@@ -103,7 +103,6 @@ QtObject:
     self.delegate.loadMoreMessages()
 
   proc messageSuccessfullySent*(self: View) {.signal.}
-
   proc emitSendingMessageSuccessSignal*(self: View) =
     self.messageSuccessfullySent()
 
@@ -131,3 +130,7 @@ QtObject:
 
   proc onPreviewDataLoaded*(self: View, previewData: string) {.slot.} =
     self.linkPreviewDataWasReceived(previewData)
+
+  proc switchToMessage(self: View, messageIndex: int) {.signal.}
+  proc emitSwitchToMessageSignal*(self: View, messageIndex: int) =
+    self.switchToMessage(messageIndex)

--- a/src/app/modules/main/chat_section/chat_content/messages/view.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/view.nim
@@ -134,3 +134,11 @@ QtObject:
   proc switchToMessage(self: View, messageIndex: int) {.signal.}
   proc emitSwitchToMessageSignal*(self: View, messageIndex: int) =
     self.switchToMessage(messageIndex)
+
+  proc scrollToMessage(self: View, messageIndex: int) {.signal.}
+  proc emitScrollToMessageSignal*(self: View, messageIndex: int) =
+    self.scrollToMessage(messageIndex)
+
+  proc scrollMessagesUp(self: View) {.signal.}
+  proc emitScrollMessagesUpSignal*(self: View) =
+    self.scrollMessagesUp()

--- a/src/app/modules/main/chat_section/controller.nim
+++ b/src/app/modules/main/chat_section/controller.nim
@@ -130,6 +130,12 @@ method init*(self: Controller) =
     var args = ChatRenameArgs(e)
     self.delegate.onChatRenamed(args.id, args.newName)
 
+  self.events.on(SIGNAL_MAKE_SECTION_CHAT_ACTIVE) do(e: Args):
+    var args = ActiveSectionChatArgs(e)
+    if (self.sectionId != args.sectionId):
+      return
+    self.delegate.makeChatWithIdActive(args.chatId)
+
 method getMySectionId*(self: Controller): string =
   return self.sectionId
 

--- a/src/app/modules/main/chat_section/private_interfaces/module_controller_delegate_interface.nim
+++ b/src/app/modules/main/chat_section/private_interfaces/module_controller_delegate_interface.nim
@@ -1,6 +1,9 @@
 method activeItemSubItemSet*(self: AccessInterface, itemId: string, subItemId: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method makeChatWithIdActive*(self: AccessInterface, chatId: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method addNewChat*(self: AccessInterface, chatDto: ChatDto, belongsToCommunity: bool, events: EventEmitter,
   settingsService: settings_service.ServiceInterface, contactService: contact_service.Service, 
   chatService: chat_service.Service, communityService: community_service.Service, 

--- a/src/app/modules/main/controller.nim
+++ b/src/app/modules/main/controller.nim
@@ -1,4 +1,5 @@
 import ../shared_models/section_item, controller_interface, io_interface, chronicles
+import ../../global/app_sections_config as conf
 import ../../global/global_singleton
 import ../../global/app_signals
 import ../../core/signals/types
@@ -140,6 +141,11 @@ method init*(self: Controller) =
 
   self.events.on(SIGNAL_MNEMONIC_REMOVAL) do(e: Args):
     self.delegate.mnemonicBackedUp()
+
+  self.events.on(SIGNAL_MAKE_SECTION_CHAT_ACTIVE) do(e: Args):
+    var args = ActiveSectionChatArgs(e)
+    let sectionType = if args.sectionId == conf.CHAT_SECTION_ID: SectionType.Chat else: SectionType.Community
+    self.setActiveSection(args.sectionId, sectionType)
 
 method getJoinedCommunities*(self: Controller): seq[CommunityDto] =
   return self.communityService.getJoinedCommunities()

--- a/src/app/modules/shared_models/message_model.nim
+++ b/src/app/modules/shared_models/message_model.nim
@@ -49,8 +49,9 @@ QtObject:
     result.setup
 
   proc `$`*(self: Model): string =
+    result = "MessageModel:\n"
     for i in 0 ..< self.items.len:
-      result &= fmt"""MessageModel:
+      result &= fmt"""
       [{i}]:({$self.items[i]})
       """
 
@@ -158,7 +159,7 @@ QtObject:
     of ModelRole.Links:
       result = newQVariant(item.links.join(" "))
 
-  proc findIndexForMessageId(self: Model, messageId: string): int = 
+  proc findIndexForMessageId*(self: Model, messageId: string): int = 
     for i in 0 ..< self.items.len:
       if(self.items[i].id == messageId):
         return i

--- a/src/app_service/service/chat/service.nim
+++ b/src/app_service/service/chat/service.nim
@@ -157,7 +157,7 @@ QtObject:
 
   proc getChatById*(self: Service, chatId: string): ChatDto =
     if(not self.chats.contains(chatId)):
-      error "trying to get chat data for an unexisting chat id"
+      error "trying to get chat data for an unexisting chat id", chatId
       return
 
     return self.chats[chatId]

--- a/src/app_service/service/message/service.nim
+++ b/src/app_service/service/message/service.nim
@@ -36,6 +36,7 @@ const SIGNAL_MESSAGE_REACTION_FROM_OTHERS* = "messageReactionFromOthers"
 const SIGNAL_MESSAGE_DELETION* = "messageDeleted"
 const SIGNAL_MESSAGE_EDITED* = "messageEdited"
 const SIGNAL_MESSAGE_LINK_PREVIEW_DATA_LOADED* = "messageLinkPreviewDataLoaded"
+const SIGNAL_MAKE_SECTION_CHAT_ACTIVE* = "makeSectionChatActive"
 
 include async_tasks
 
@@ -80,6 +81,11 @@ type
 
   LinkPreviewDataArgs* = ref object of Args
     response*: string
+
+  ActiveSectionChatArgs* = ref object of Args
+    sectionId*: string
+    chatId*: string
+    messageId*: string
 
 QtObject:
   type Service* = ref object of QObject
@@ -653,3 +659,12 @@ proc editMessage*(self: Service, messageId: string, updatedMsg: string) =
 
   except Exception as e:
     error "error: ", methodName="editMessage", errName = e.name, errDesription = e.msg
+
+proc switchTo*(self: Service, sectionId: string, chatId: string, messageId: string) =
+  ## Calling this proc the app will switch to passed `sectionId`, after that if `chatId` is set
+  ## it will make that chat an active one and at the end if `messageId` is set it will point to
+  ## that message.
+  ## We should use this proc (or just emit a signal bellow) when we want to switch to certain
+  ## section and/or chat and/or message
+  let data = ActiveSectionChatArgs(sectionId: sectionId, chatId: chatId, messageId: messageId)
+  self.events.emit(SIGNAL_MAKE_SECTION_CHAT_ACTIVE, data)

--- a/src/app_service/service/message/service.nim
+++ b/src/app_service/service/message/service.nim
@@ -20,7 +20,8 @@ logScope:
   topics = "messages-service"
 
 let NEW_LINE = re"\n|\r" #must be defined as let, not const
-const MESSAGES_PER_PAGE = 20
+const MESSAGES_PER_PAGE* = 20
+const MESSAGES_PER_PAGE_MAX* = 300
 const CURSOR_VALUE_IGNORE = "ignore"
 
 # Signals which may be emitted by this service:
@@ -271,7 +272,7 @@ QtObject:
     self.events.emit(SIGNAL_MESSAGES_LOADED, data)
 
 
-  proc asyncLoadMoreMessagesForChat*(self: Service, chatId: string) =
+  proc asyncLoadMoreMessagesForChat*(self: Service, chatId: string, limit = MESSAGES_PER_PAGE) =
     if (chatId.len == 0):
       error "empty chat id", methodName="asyncLoadMoreMessagesForChat"
       return
@@ -297,7 +298,7 @@ QtObject:
       chatId: chatId,
       msgCursor: msgCursor,
       pinnedMsgCursor: pinnedMsgCursor,
-      limit: MESSAGES_PER_PAGE
+      limit: if(limit <= MESSAGES_PER_PAGE_MAX): limit else: MESSAGES_PER_PAGE_MAX
     )
 
     self.threadpool.start(arg)

--- a/ui/app/AppLayouts/Chat/views/ActivityCenterMessageComponentView.qml
+++ b/ui/app/AppLayouts/Chat/views/ActivityCenterMessageComponentView.qml
@@ -145,7 +145,12 @@ Item {
 //                }
 
 //                root.chatSectionModule.setActiveChannel(model.chatId);
-                positionAtMessage(model.id);
+
+                // To position to appropriate message check how it's done in AppSearch module,
+                // similar may be done here, corresponding module for activity center just need to
+                // use the mechanism done there, send the signal form message service and
+                // and the rest is already handled.
+//                positionAtMessage(model.id);
             }
             prevMessageIndex: root.previousNotificationIndex
             prevMsgTimestamp: root.previousNotificationTimestamp

--- a/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
@@ -117,11 +117,6 @@ Item {
         Global.applicationWindow.requestActivate()
     }
 
-    function positionAtMessage(messageId, isSearch = false) {
-        // Not Refactored Yet
-//        stackLayoutChatMessages.children[stackLayoutChatMessages.currentIndex].message.scrollToMessage(messageId, isSearch);
-    }
-
     Timer {
         interval: 60000; // 1 min
         running: true
@@ -340,10 +335,6 @@ Item {
         // Not Refactored Yet
 //        Connections {
 //            target: root.rootStore.chatsModelInst.messageView
-
-//            onSearchedMessageLoaded: {
-//                positionAtMessage(messageId, true);
-//            }
 
 //            onMessageNotificationPushed: function(messageId, communityId, chatId, msg, contentType, chatType, timestamp, identicon, username, hasMention, isAddedContact, channelName) {
 //                if (localAccountSensitiveSettings.notificationSetting == Constants.notifyAllMessages ||

--- a/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
@@ -48,7 +48,11 @@ Item {
             sendingMsgFailedPopup.open();
         }
 
-        onSwitchToMessage: {
+        onScrollMessagesUp: {
+            chatLogView.positionViewAtEnd()
+        }
+
+        onScrollToMessage: {
             chatLogView.positionViewAtIndex(messageIndex, ListView.Center);
             chatLogView.itemAtIndex(messageIndex).startMessageFoundAnimation();
         }

--- a/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
@@ -27,7 +27,6 @@ Item {
 
     property bool stickersLoaded: false
     property alias chatLogView: chatLogView
-    property alias scrollToMessage: chatLogView.scrollToMessage
 
     property var messageContextMenuInst
 
@@ -37,6 +36,30 @@ Item {
     property int countOnStartUp: 0
     signal openStickerPackPopup(string stickerPackId)
     signal showReplyArea(string messageId, string author)
+
+    Connections {
+        target: root.messageStore.messageModule
+
+        onMessageSuccessfullySent: {
+            chatLogView.scrollToBottom(true)
+        }
+
+        onSendingMessageFailed: {
+            sendingMsgFailedPopup.open();
+        }
+
+        onSwitchToMessage: {
+            chatLogView.positionViewAtIndex(messageIndex, ListView.Center);
+            chatLogView.itemAtIndex(messageIndex).startMessageFoundAnimation();
+        }
+
+        // Not Refactored Yet
+//            onNewMessagePushed: {
+//                if (!chatLogView.scrollToBottom()) {
+//                    newMessages++
+//                }
+//            }
+    }
 
     Item {
         id: loadingMessagesIndicator
@@ -89,34 +112,6 @@ Item {
                 chatLogView.headerItem.height = 0
             }
         }
-
-        property var scrollToMessage: function (messageId, isSearch = false) {
-            // Not Refactored Yet
-//            delayPositioningViewTimer.msgId = messageId;
-//            delayPositioningViewTimer.isSearch = isSearch;
-//            delayPositioningViewTimer.restart();
-        }
-
-//        Timer {
-//            id: delayPositioningViewTimer
-//            interval: 1000
-//            property string msgId
-//            property bool isSearch
-//            onTriggered: {
-//                let item
-//                for (let i = 0; i < messages.rowCount(); i++) {
-//                    item = messageListDelegate.items.get(i);
-//                    if (item.model.messageId === msgId) {
-//                        chatLogView.positionViewAtIndex(i, ListView.Beginning);
-//                        if (isSearch) {
-//                            chatLogView.itemAtIndex(i).startMessageFoundAnimation();
-//                        }
-//                    }
-//                }
-//                msgId = "";
-//                isSearch = false;
-//            }
-//        }
 
         ScrollBar.vertical: ScrollBar {
             visible: chatLogView.visibleArea.heightRatio < 1
@@ -222,25 +217,6 @@ Item {
 //                chatLogView.scrollToBottom(true)
 //            }
 //        }
-
-        Connections {
-            target: messageStore.messageModule
-
-            onMessageSuccessfullySent: {
-                chatLogView.scrollToBottom(true)
-            }
-
-            onSendingMessageFailed: {
-                sendingMsgFailedPopup.open();
-            }
-
-            // Not Refactored Yet
-//            onNewMessagePushed: {
-//                if (!chatLogView.scrollToBottom()) {
-//                    newMessages++
-//                }
-//            }
-        }
 
 //        Connections {
         // Not Refactored Yet

--- a/ui/app/AppLayouts/stores/AppSearchStore.qml
+++ b/ui/app/AppLayouts/stores/AppSearchStore.qml
@@ -1,0 +1,40 @@
+import QtQuick 2.13
+
+QtObject {
+    id: root
+
+    property var appSearchModule
+
+    property var locationMenuModel: root.appSearchModule.locationMenuModel
+    property var resultModel: root.appSearchModule.resultModel
+
+    function searchMessages(searchTerm) {
+        if(!root.appSearchModule)
+            return
+        root.appSearchModule.searchMessages(searchTerm)
+    }
+
+    function setSearchLocation(location, subLocation) {
+        if(!root.appSearchModule)
+            return
+        root.appSearchModule.setSearchLocation(location, subLocation)
+    }
+
+    function prepareLocationMenuModel() {
+        if(!root.appSearchModule)
+            return
+        root.appSearchModule.prepareLocationMenuModel()
+    }
+
+    function getSearchLocationObject() {
+        if(!root.appSearchModule)
+            return ""
+        root.appSearchModule.getSearchLocationObject()
+    }
+
+    function resultItemClicked(itemId) {
+        if(!root.appSearchModule)
+            return
+        root.appSearchModule.resultItemClicked(itemId)
+    }
+}

--- a/ui/app/AppLayouts/stores/RootStore.qml
+++ b/ui/app/AppLayouts/stores/RootStore.qml
@@ -9,6 +9,10 @@ QtObject {
     property var communitiesModuleInst: communitiesModule
     property var observedCommunity: communitiesModuleInst.observedCommunity
 
+    property AppSearchStore appSearchStore: AppSearchStore {
+        appSearchModule: root.mainModuleInst.appSearchModule
+    }
+
     property ProfileSectionStore profileSectionStore: ProfileSectionStore {
     }
 

--- a/ui/app/AppMain.qml
+++ b/ui/app/AppMain.qml
@@ -189,7 +189,7 @@ Item {
 
     AppSearch{
         id: appSearch
-        store: mainModule.appSearchModule
+        store: appMain.rootStore.appSearchStore
     }
 
     StatusAppLayout {

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -193,9 +193,9 @@ Column {
 //        return root.rootStore.showReactionAuthors(fromAccounts, emojiId)
 //    }
 
-//    function startMessageFoundAnimation() {
-//        messageLoader.item.startMessageFoundAnimation();
-//    }
+    function startMessageFoundAnimation() {
+        messageLoader.item.startMessageFoundAnimation();
+    }
     /////////////////////////////////////////////
 
 


### PR DESCRIPTION
This PR fixes:
- broken "jump to a section/chat/message" feature
- added loading indicator while searching is in progress
- animation when we point to the searched message is in place again

Fixes #4577

**Note**:
When db is a bigger one (has lot of chats/messages...) searching lasts for a while, maybe we should improve a query on the `status-go` side and/or do some indexing in db and/or add some pagination in the search result panel (display only the newest 20 messages at first and scrolling down to load more and more as needed).