### PR TITLE
Fix/issue 4524: [base_bc] selecting a channel does not auto-focus on the text input field

### DIFF
--- a/ui/app/AppLayouts/Chat/views/ChatContentView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatContentView.qml
@@ -38,6 +38,14 @@ ColumnLayout {
 
     property bool stickersLoaded: false
 
+    // NOTE: Used this property change as it is the current way used for displaying new channel/chat data of content view.
+    // If in the future content is loaded dynamically, input focus should be activated when loaded / created content view.
+    onHeightChanged: {
+        if(chatContentRoot.height > 0) {
+            chatInput.forceInputActiveFocus()
+        }
+    }
+
     StatusChatToolBar {
         id: topBar
         Layout.fillWidth: true

--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -563,6 +563,10 @@ Rectangle {
         messageInputField.forceActiveFocus();
     }
 
+    function forceInputActiveFocus() {
+        messageInputField.forceActiveFocus();
+    }
+
     Connections {
         target: Global.applicationWindow.dragAndDrop
         onDroppedOnValidScreen: (drop) => {


### PR DESCRIPTION
Fixes #4524

### What does the PR do

When new channel/chat is selected, text input field focus is forced properly.

### Affected areas

Chat-Channel / Input Message focus
