### PR TITLE
fix(@desktop/CopyToClipboard): [base_bc] can't copy from Invite friends as well as App Version and Node Version

### DIFF
--- a/ui/app/AppLayouts/Chat/panels/EmptyChatPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/EmptyChatPanel.qml
@@ -12,6 +12,7 @@ Item {
     Layout.fillHeight: true
     Layout.fillWidth: true
 
+    property var rootStore
 
     signal shareChatKeyClicked()
 
@@ -99,5 +100,6 @@ Item {
 
     InviteFriendsPopup {
         id: inviteFriendsPopup
+        rootStore: element.rootStore
     }
 }

--- a/ui/app/AppLayouts/Chat/panels/EmptyViewPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/EmptyViewPanel.qml
@@ -20,6 +20,8 @@ Rectangle {
     Layout.fillHeight: true
     Layout.fillWidth: true
 
+    property var rootStore
+
     signal suggestedMessageClicked(string channel)
 
     height: suggestionContainer.height + inviteFriendsContainer.height + Style.current.padding * 2
@@ -98,7 +100,8 @@ Rectangle {
 
         InviteFriendsPopup {
             id: inviteFriendsPopup
-        }
+            rootStore: emptyView.rootStore
+        }        
     }
 
     Separator {

--- a/ui/app/AppLayouts/Chat/panels/communities/CommunityProfilePopupInviteFriendsPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/CommunityProfilePopupInviteFriendsPanel.qml
@@ -71,5 +71,6 @@ Column {
         showCheckbox: true
         hideCommunityMembers: true
         showSearch: false
+        rootStore: root.rootStore
     }
 }

--- a/ui/app/AppLayouts/Chat/popups/PrivateChatPopup.qml
+++ b/ui/app/AppLayouts/Chat/popups/PrivateChatPopup.qml
@@ -43,6 +43,7 @@ ModalPopup {
         addContactEnabled: false
 
         contactsStore: popup.contactsStore
+        rootStore: popup.store
 
         onUserClicked: function (pubKey, isAddedContact, username) {
             popup.doJoin(pubKey, username);

--- a/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
@@ -141,6 +141,7 @@ Item {
     EmptyChatPanel {
         anchors.fill: parent
         visible: root.activeChatId === ""
+        rootStore: root.rootStore
         onShareChatKeyClicked: Global.openProfilePopup(userProfile.pubKey);
     }
 

--- a/ui/app/AppLayouts/Chat/views/ContactsColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ContactsColumnView.qml
@@ -316,6 +316,7 @@ Item {
             width: parent.width
             anchors.top: channelList.bottom
             anchors.topMargin: Style.current.padding
+            rootStore: root.store
             onSuggestedMessageClicked: chatSectionModule.createPublicChat(channel)
         }
     }

--- a/ui/app/AppLayouts/Profile/ProfileLayout.qml
+++ b/ui/app/AppLayouts/Profile/ProfileLayout.qml
@@ -111,6 +111,7 @@ StatusAppTwoPanelLayout {
 
         AboutView {
             store: profileView.store
+            globalStore: profileView.globalStore
             profileContentWidth: _internal.profileContentWidth
         }
     }

--- a/ui/app/AppLayouts/Profile/views/AboutView.qml
+++ b/ui/app/AppLayouts/Profile/views/AboutView.qml
@@ -16,6 +16,7 @@ Item {
     clip: true
 
     property var store
+    property var globalStore
     property int profileContentWidth
 
     Column {
@@ -33,6 +34,7 @@ Item {
             //% "Version: %1"
             description: qsTrId("version---1").arg(root.store.getCurrentVersion())
             tooltipUnder: true
+            store: root.globalStore
         }
 
         // TODO: replace with StatusListItem
@@ -40,6 +42,7 @@ Item {
             //% "Node version "
             name: qsTrId("node-version-")
             description: root.store.nodeVersion()
+            store: root.globalStore
         }
 
         StatusBaseText {

--- a/ui/imports/shared/controls/ContactsListAndSearch.qml
+++ b/ui/imports/shared/controls/ContactsListAndSearch.qml
@@ -17,6 +17,7 @@ Item {
     id: root
     height: childrenRect.height + 24
 
+    property var rootStore
     property var contactsStore
     property var community
 
@@ -229,5 +230,6 @@ Item {
         anchors.topMargin: Style.current.xlPadding * 3
         anchors.horizontalCenter: parent.horizontalCenter
         anchors.verticalCenter: parent.verticalCenter
+        rootStore: root.rootStore
     }
 }

--- a/ui/imports/shared/controls/CopyToClipBoardButton.qml
+++ b/ui/imports/shared/controls/CopyToClipBoardButton.qml
@@ -19,6 +19,7 @@ Rectangle {
     property var onClick: function() {}
     property string textToCopy: ""
     property bool tooltipUnder: false
+    property var store
 
     Image {
         width: 20
@@ -58,8 +59,7 @@ Rectangle {
         }
         onClicked: {
             if (textToCopy) {
-                // Not Refactored Yet
-                //RootStore.copyToClipboard(textToCopy)
+                copyToClipboardButton.store.copyToClipboard(textToCopy)
             }
             onClick()
         }

--- a/ui/imports/shared/popups/InviteFriendsPopup.qml
+++ b/ui/imports/shared/popups/InviteFriendsPopup.qml
@@ -1,32 +1,28 @@
-import QtQuick 2.12
-import QtQuick.Controls 2.3
-
+import StatusQ.Components 0.1
+import StatusQ.Popups 0.1
 import utils 1.0
-import "../controls"
-import "../panels"
-import "../"
-import "."
 
-// TODO: replace with StatusModal
-ModalPopup {
-    id: popup
+StatusModal {
+    id: root
+    anchors.centerIn: parent
+
     //% "Get Status at https://status.im"
     readonly property string getStatusText: qsTrId("get-status-at-https---status-im")
 
+    property var rootStore
+
     //% "Download Status link"
-    title: qsTrId("download-status-link")
+    header.title: qsTrId("download-status-link")
     height: 156
 
-    StyledText {
-        id: linkText
-        text: popup.getStatusText
-    }
-
-    CopyToClipBoardButton {
-        anchors.left: linkText.right
-        anchors.leftMargin: Style.current.smallPadding
-        anchors.verticalCenter: linkText.verticalCenter
-        textToCopy: popup.getStatusText.substr(popup.getStatusText.indexOf("https"))
+    StatusDescriptionListItem {
+        subTitle: root.getStatusText
+        tooltip.text: qsTr("Copy to clipboard")
+        icon.name: "copy"
+        iconButton.onClicked: {
+            root.rootStore.copyToClipboard(Constants.statusLinkPrefix)
+            tooltip.visible = !tooltip.visible
+        }
+        width: parent.width
     }
 }
-

--- a/ui/imports/shared/status/StatusSectionDescItem.qml
+++ b/ui/imports/shared/status/StatusSectionDescItem.qml
@@ -13,6 +13,7 @@ Item {
     property string name
     property string description
     property alias tooltipUnder: copyToClipboardBtn.tooltipUnder
+    property var store
 
     id: root
     width: parent.width
@@ -42,6 +43,7 @@ Item {
             anchors.verticalCenter: parent.verticalCenter
             anchors.left: parent.right
             anchors.leftMargin: Style.current.smallPadding
+            store: root.store
         }
     }
 }

--- a/ui/imports/shared/views/NoFriendsRectangle.qml
+++ b/ui/imports/shared/views/NoFriendsRectangle.qml
@@ -11,9 +11,13 @@ import "../popups"
 Item {
     id: noContactsRect
     width: 260
+
     //% "You don’t have any contacts yet. Invite your friends to start chatting."
     property string text: qsTrId("you-don-t-have-any-contacts-yet--invite-your-friends-to-start-chatting-")
     property alias textColor: noContacts.color
+    property var rootStore
+
+
     StatusBaseText {
         id: noContacts
         text: noContactsRect.text
@@ -36,5 +40,6 @@ Item {
     }
     InviteFriendsPopup {
         id: inviteFriendsPopup
+        rootStore: noContactsRect.rootStore
     }
 }

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -179,6 +179,7 @@ QtObject {
     readonly property string joinStatusLink: 'join.status.im'
     readonly property string communityLinkPrefix: 'https://join.status.im/c/'
     readonly property string userLinkPrefix: 'https://join.status.im/u/'
+    readonly property string statusLinkPrefix: 'https://status.im/'
 
     readonly property int maxUploadFiles: 5
     readonly property double maxUploadFilesizeMB: 10


### PR DESCRIPTION
Fixes #4529

### What does the PR do

It has been added root store propagation in order to use the global `copyToClipboard` method.

`InviteFriendsPopup` has been refactored to use StatusQ components.

### Affected areas

Chat / InviteFriends button

Settings / About / App version and Node version

### Screenshot of functionality

- **Invite Friends button**

![image](https://user-images.githubusercontent.com/97019400/151524600-a80d3450-2c44-4007-900e-2834d2f26a36.png)

- **App version and Node version**

![image](https://user-images.githubusercontent.com/97019400/151524511-4d175bc2-8232-4789-958b-9398e1ec0bef.png)


