### PR TITLE
fix(@desktop/browser): [base_bc] renaming bookmark is not persistent

### DIFF
--- a/src/app_service/service/bookmarks/service.nim
+++ b/src/app_service/service/bookmarks/service.nim
@@ -67,6 +67,7 @@ method updateBookmark*(self: Service, oldUrl, newUrl, newName: string): R =
 
     let response = status_go.updateBookmark(oldUrl, newUrl, newName).result
     self.bookmarks.del(oldUrl)
+    self.bookmarks[newUrl] = BookmarkDto()
     self.bookmarks[newUrl].url = newUrl
     self.bookmarks[newUrl].name = newName
     discard response.getProp("imageUrl", self.bookmarks[newurl].imageUrl)

--- a/ui/app/AppLayouts/Browser/popups/FavoriteMenu.qml
+++ b/ui/app/AppLayouts/Browser/popups/FavoriteMenu.qml
@@ -39,7 +39,11 @@ PopupMenu {
         icon.source: Style.svg("edit")
         icon.width: 16
         icon.height: 16
-        onTriggered: editFavoriteTriggered()
+        onTriggered: {
+            // Force reloading current favorite as it could have been modified when edited:
+            favoritePopupMenu.currentFavorite = BookmarksStore.getCurrentFavorite(url)
+            editFavoriteTriggered()
+        }
     }
 
     Action {


### PR DESCRIPTION
Fixes #4549

### What does the PR do

Edit existing bookmark name is now correctly updated in the view.

### Affected areas

Browser / Edit existing bookmark