### PR TITLE
fix(@desktop/wallet): [base_bc] can't copy wallet address

### DIFF
--- a/ui/app/AppLayouts/Wallet/WalletLayout.qml
+++ b/ui/app/AppLayouts/Wallet/WalletLayout.qml
@@ -16,6 +16,7 @@ Item {
     id: walletView
 
     property bool hideSignPhraseModal: false
+    property var store
 
     function showSigningPhrasePopup(){
         if(!hideSignPhraseModal && !RootStore.hideSignPhraseModal){
@@ -74,6 +75,7 @@ Item {
             id: walletContainer
             anchors.fill: parent
             changeSelectedAccount: leftTab.changeSelectedAccount
+            store: walletView.store
         }
     }
 }

--- a/ui/app/AppLayouts/Wallet/panels/WalletHeader.qml
+++ b/ui/app/AppLayouts/Wallet/panels/WalletHeader.qml
@@ -19,6 +19,7 @@ Item {
     property string currency: ""
     property var currentAccount
     property var changeSelectedAccount
+    property var store
 
     height: walletAddress.y + walletAddress.height
     anchors.right: parent.right
@@ -72,6 +73,7 @@ Item {
         addressWidth: 180
         anchors.leftMargin: 0
         anchors.topMargin: 0
+        store: walletHeader.store
     }
 
     Component {

--- a/ui/app/AppLayouts/Wallet/views/RightTabView.qml
+++ b/ui/app/AppLayouts/Wallet/views/RightTabView.qml
@@ -18,6 +18,7 @@ Item {
 
     property var changeSelectedAccount
     property alias currentTabIndex: walletTabBar.currentIndex
+    property var store
 
     WalletHeader {
         id: walletHeader
@@ -25,6 +26,7 @@ Item {
         currency: RootStore.currentCurrency
         currentAccount: RootStore.currentAccount
         changeSelectedAccount: walletContainer.changeSelectedAccount
+        store: walletContainer.store
     }
 
     RowLayout {

--- a/ui/app/AppLayouts/WalletV2/WalletV2Layout.qml
+++ b/ui/app/AppLayouts/WalletV2/WalletV2Layout.qml
@@ -97,6 +97,7 @@ Item {
                         id: walletInfoContent
                         WalletHeaderPanel {
                             id: walletHeader
+                            store: walletView.store
                             // Not Refactored Yet
 //                            accountsModel: walletView.store.walletModelV2Inst.accountsView.accounts
 //                            currentAccount: walletView.store.walletModelV2Inst.accountsView.currentAccount

--- a/ui/app/AppLayouts/WalletV2/panels/WalletHeaderPanel.qml
+++ b/ui/app/AppLayouts/WalletV2/panels/WalletHeaderPanel.qml
@@ -22,6 +22,7 @@ Item {
     property var currentAccount
     property var enabledNetworksModel
     property var allNetworksModel
+    property var store
     signal copyText(string text)
     signal toggleNetwork(int chainId)
 
@@ -73,6 +74,7 @@ Item {
         anchors.left: accountRow.left
         addressWidth: 180
         address: walletHeader.currentAccount? walletHeader.currentAccount.address : ""
+        store: walletHeader.store
     }
 
     NetworkSelectPanel {

--- a/ui/app/AppMain.qml
+++ b/ui/app/AppMain.qml
@@ -482,6 +482,7 @@ Item {
                     Layout.fillWidth: true
                     Layout.alignment: Qt.AlignLeft | Qt.AlignTop
                     Layout.fillHeight: true
+                    store: appMain.rootStore
                 }
 
                 Component {
@@ -490,6 +491,7 @@ Item {
                         globalStore: appMain.rootStore
                         sendTransactionModal: sendModal
                     }
+
                 }
 
                 Loader {

--- a/ui/imports/shared/status/StatusExpandableAddress.qml
+++ b/ui/imports/shared/status/StatusExpandableAddress.qml
@@ -16,6 +16,7 @@ Item {
     property bool expanded: false
     property int addressWidth
     property int originalButtonWidth
+    property var store
 
     Button {
         id: control
@@ -81,6 +82,7 @@ Item {
         anchors.leftMargin: Style.current.smallPadding
         anchors.verticalCenter: parent.verticalCenter
         textToCopy: root.address
+        store: root.store
         MouseArea {
             anchors.fill: parent
             propagateComposedEvents: true


### PR DESCRIPTION
Fixes #4636

### What does the PR do

Store propagation in order to use the global `copyToClipboard` method.

It is also applied in WalletV2.

### Affected areas

Wallet / Wallet address copy to clipboard