### PR TITLE
fix(@desktop/chat): the @mention emblem isn't being displayed on the channel list

### DIFF
--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -438,6 +438,9 @@ method emitStoringPasswordError*[T](self: Module[T], errorDescription: string) =
 method emitStoringPasswordSuccess*[T](self: Module[T]) =
   self.view.emitStoringPasswordSuccess()
 
+method getActiveSectionId*[T](self: Module[T]): string =
+  return self.controller.getActiveSectionId()
+
 method setActiveSection*[T](self: Module[T], item: SectionItem) =
   if(item.isEmpty()):
     echo "section is empty and cannot be made as active one"

--- a/src/app/modules/main/private_interfaces/module_chat_section_delegate_interface.nim
+++ b/src/app/modules/main/private_interfaces/module_chat_section_delegate_interface.nim
@@ -10,3 +10,6 @@ method onActiveChatChange*(self: AccessInterface, sectionId: string, chatId: str
 method onNotificationsUpdated*(self: AccessInterface, sectionId: string, sectionHasUnreadMessages: bool, 
   sectionNotificationCount: int) {.base.} =
   raise newException(ValueError, "No implementation available")
+
+method getActiveSectionId*(self: AccessInterface): string {.base.} =
+  raise newException(ValueError, "No implementation available")


### PR DESCRIPTION
This issue was mostly fixed in `base_bc`, but now I rechecked it and improved it a bit more handling some edge cases.

Here is a [video](https://drive.google.com/file/d/1JUDp9jOBALbLhi-cByh2Ef7bOo4E33Ne/view?usp=sharing) where I tested the behaviour. I used mobile app and firstly added normal messages in community, for both channels that's the reason why blue dot was added. Then I opened community where after marking second channel in the community blue dot for community went away. Then I tested mentions and you may see in the video what is mentions behaviuor.

Fixes #3630