### PR TITLE
fix(pins): only enable jump to and unpin buttons from the pinned popup

### DIFF
--- a/ui/app/AppLayouts/Chat/popups/PinnedMessagesPopup.qml
+++ b/ui/app/AppLayouts/Chat/popups/PinnedMessagesPopup.qml
@@ -130,6 +130,7 @@ ModalPopup {
                     messagePinnedBy: model.pinnedBy
                     reactionsModel: model.reactions
                     linkUrls: model.links
+                    isInPinnedPopup: true
 
                     // This is possible since we have all data loaded before we load qml.
                     // When we fetch messages to fulfill a gap we have to set them at once.

--- a/ui/imports/shared/panels/chat/ChatButtonsPanel.qml
+++ b/ui/imports/shared/panels/chat/ChatButtonsPanel.qml
@@ -14,10 +14,11 @@ Rectangle {
     property bool isMessageActive: false
     property var messageContextMenu
     property bool showMoreButton: true
+    property bool isInPinnedPopup: false
     property bool activityCenterMsg
     property bool placeholderMsg
     property string fromAuthor
-    property alias editBtnActive: editBtn.active
+    property bool editBtnActive: false
     signal replyClicked(string messageId, string author)
     signal hoverChanged(bool hovered)
     signal setMessageActive(string messageId, bool active)
@@ -67,45 +68,52 @@ Rectangle {
         anchors.verticalCenter: buttonsContainer.verticalCenter
         height: parent.height - 2 * buttonsContainer.containerMargin
 
-        StatusFlatRoundButton {
-            id: emojiBtn
-            width: 32
-            height: 32
-            icon.name: "reaction-b"
-            type: StatusFlatRoundButton.Type.Tertiary
-            //% "Add reaction"
-            tooltip.text: qsTrId("add-reaction")
-            onClicked: {
-                setMessageActive(messageId, true)
-                // Set parent, X & Y positions for the messageContextMenu
-                buttonsContainer.messageContextMenu.parent = buttonsContainer
-                buttonsContainer.messageContextMenu.setXPosition = function() { return (-Math.abs(buttonsContainer.width - buttonsContainer.messageContextMenu.emojiContainer.width))}
-                buttonsContainer.messageContextMenu.setYPosition = function() { return (-buttonsContainer.messageContextMenu.height - 4)}
-                buttonsContainer.clickMessage(false, false, false, null, true, false)
-            }
-            onHoveredChanged: buttonsContainer.hoverChanged(this.hovered)
-        }
-
-        StatusFlatRoundButton {
-            id: replyBtn
-            width: 32
-            height: 32
-            icon.name: "reply"
-            type: StatusFlatRoundButton.Type.Tertiary
-            //% "Reply"
-            tooltip.text: qsTrId("message-reply")
-            onClicked: {
-                buttonsContainer.replyClicked(messageId, fromAuthor);
-                if (messageContextMenu.closeParentPopup) {
-                    messageContextMenu.closeParentPopup()
+        Loader {
+            active: !buttonsContainer.isInPinnedPopup
+            sourceComponent: StatusFlatRoundButton {
+                id: emojiBtn
+                width: 32
+                height: 32
+                icon.name: "reaction-b"
+                type: StatusFlatRoundButton.Type.Tertiary
+                //% "Add reaction"
+                tooltip.text: qsTrId("add-reaction")
+                onClicked: {
+                    setMessageActive(messageId, true)
+                    // Set parent, X & Y positions for the messageContextMenu
+                    buttonsContainer.messageContextMenu.parent = buttonsContainer
+                    buttonsContainer.messageContextMenu.setXPosition = function() { return (-Math.abs(buttonsContainer.width - buttonsContainer.messageContextMenu.emojiContainer.width))}
+                    buttonsContainer.messageContextMenu.setYPosition = function() { return (-buttonsContainer.messageContextMenu.height - 4)}
+                    buttonsContainer.clickMessage(false, false, false, null, true, false)
                 }
+                onHoveredChanged: buttonsContainer.hoverChanged(this.hovered)
             }
-            onHoveredChanged: buttonsContainer.hoverChanged(this.hovered)
         }
 
         Loader {
+            active: !buttonsContainer.isInPinnedPopup
+            sourceComponent: StatusFlatRoundButton {
+                id: replyBtn
+                width: 32
+                height: 32
+                icon.name: "reply"
+                type: StatusFlatRoundButton.Type.Tertiary
+                //% "Reply"
+                tooltip.text: qsTrId("message-reply")
+                onClicked: {
+                    buttonsContainer.replyClicked(messageId, fromAuthor);
+                    if (messageContextMenu.closeParentPopup) {
+                        messageContextMenu.closeParentPopup()
+                    }
+                }
+                onHoveredChanged: buttonsContainer.hoverChanged(this.hovered)
+            }
+        }
+        
+
+        Loader {
             id: editBtn
-            active: false
+            active: buttonsContainer.editBtnActive && !buttonsContainer.isInPinnedPopup
             sourceComponent: StatusFlatRoundButton {
                 id: btn
                 width: 32

--- a/ui/imports/shared/views/chat/CompactMessageView.qml
+++ b/ui/imports/shared/views/chat/CompactMessageView.qml
@@ -31,6 +31,7 @@ Item {
     property bool isMessageActive: false
     property bool isCurrentUser: false
     property bool isHovered: false
+    property bool isInPinnedPopup: false
     property bool showMoreButton: {
         if(!root.messageStore)
             return false
@@ -100,6 +101,7 @@ Item {
         anchors.topMargin: -Style.current.halfPadding
         messageContextMenu: root.messageContextMenu
         showMoreButton: root.showMoreButton
+        isInPinnedPopup: root.isInPinnedPopup
         fromAuthor: senderId
         editBtnActive: isText && !editModeOn && root.isCurrentUser
         activityCenterMsg: activityCenterMessage

--- a/ui/imports/shared/views/chat/MessageContextMenuView.qml
+++ b/ui/imports/shared/views/chat/MessageContextMenuView.qml
@@ -93,7 +93,7 @@ StatusPopupMenu {
         id: emojiContainer
         width: emojiRow.width
         height: visible ? emojiRow.height : 0
-        visible: !root.hideEmojiPicker && (root.emojiOnly || !root.isProfile)
+        visible: !root.hideEmojiPicker && (root.emojiOnly || !root.isProfile) && !root.pinnedPopup
         Row {
             id: emojiRow
             spacing: Style.current.halfPadding
@@ -167,7 +167,7 @@ StatusPopupMenu {
 
     Separator {
         anchors.bottom: viewProfileAction.top
-        visible: !root.emojiOnly && !root.hideEmojiPicker
+        visible: !root.emojiOnly && !root.hideEmojiPicker && !pinnedPopup
     }
 
     StatusMenuItem {
@@ -180,7 +180,7 @@ StatusPopupMenu {
             root.close()
         }
         icon.name: "copy"
-        enabled: root.isRightClickOnImage
+        enabled: root.isRightClickOnImage && !root.pinnedPopup
     }
 
     StatusMenuItem {
@@ -191,7 +191,7 @@ StatusPopupMenu {
             root.close()
         }
         icon.name: "download"
-        enabled: root.isRightClickOnImage
+        enabled: root.isRightClickOnImage && !root.pinnedPopup
     }
 
     StatusMenuItem {
@@ -203,7 +203,7 @@ StatusPopupMenu {
             root.close()
         }
         icon.name: "profile"
-        enabled: root.isProfile
+        enabled: root.isProfile && !root.pinnedPopup
     }
 
     StatusMenuItem {
@@ -226,6 +226,7 @@ StatusPopupMenu {
                  (!root.hideEmojiPicker &&
                   !root.emojiOnly &&
                   !root.isProfile &&
+                  !root.pinnedPopup &&
                   !root.isRightClickOnImage)
     }
 
@@ -241,6 +242,7 @@ StatusPopupMenu {
                  !root.hideEmojiPicker &&
                  !root.emojiOnly &&
                  !root.isProfile &&
+                 !root.pinnedPopup &&
                  !root.isRightClickOnImage
     }
 
@@ -248,7 +250,7 @@ StatusPopupMenu {
         id: copyMessageIdAction
         text: qsTr("Copy Message Id")
         icon.name: "chat"
-        enabled: root.isDebugEnabled
+        enabled: root.isDebugEnabled && !pinnedPopup
         onTriggered: {
             root.store.copyToClipboard(SelectedMessage.messageId)
             close()

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -38,6 +38,7 @@ Column {
     property string messagePinnedBy: ""
     property var reactionsModel: []
     property string linkUrls: ""
+    property bool isInPinnedPopup: false // The pinned popup limits the number of buttons shown
 
     property int prevMessageIndex: -1
     property var prevMessageAsJsonObj
@@ -355,6 +356,7 @@ Column {
             isHovered: root.isHovered
             editModeOn: root.editModeOn
             linkUrls: root.linkUrls
+            isInPinnedPopup: root.isInPinnedPopup
 
             onAddEmoji: {
                 root.clickMessage(isProfileClick, isSticker, isImage , image, emojiOnly, hideEmojiPicker)


### PR DESCRIPTION
Fixes #4540

This fits the design on Figma (at least the old one that we still have)

![image](https://user-images.githubusercontent.com/11926403/152031475-ee18e094-cdd3-40d5-b660-a6a1221ca561.png)
