### PR TITLE
fix(@desktop/BlockedContacts): [restore after rebase] Add a blocked bar for blocked user profile

### DIFF
--- a/ui/app/AppLayouts/Chat/views/ChatContentView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatContentView.qml
@@ -285,25 +285,13 @@ ColumnLayout {
         //        }
     }
 
-    Item {
-        Layout.fillWidth: true
-        Layout.preferredHeight: 40
-        Layout.alignment: Qt.AlignHCenter
+    // Blocked Status Bar
+    StatusBanner {
+        id: blockedBanner
+        width: chatContentRoot.width
         visible: isBlocked
-
-        Rectangle {
-            id: blockedBanner
-            anchors.fill: parent
-            color: Style.current.red
-            opacity: 0.1
-        }
-
-        Text {
-            id: blockedText
-            anchors.centerIn: blockedBanner
-            color: Style.current.red
-            text: qsTr("Blocked")
-        }
+        type: StatusBanner.Type.Danger
+        statusText: qsTr("Blocked")
     }
 
     MessageStore {

--- a/ui/imports/shared/popups/ProfilePopup.qml
+++ b/ui/imports/shared/popups/ProfilePopup.qml
@@ -96,6 +96,15 @@ StatusModal {
             anchors.top: parent.top
             width: parent.width
 
+            // Blocked User Status Bar
+           StatusBanner {
+               id: blockedUsrBar
+               width: parent.width
+               visible: popup.userIsBlocked
+               type: StatusBanner.Type.Danger
+               statusText: qsTr("Blocked")
+           }
+
             Item {
                 height: 16
                 width: parent.width
@@ -130,11 +139,6 @@ StatusModal {
                 width: parent.width
             }
 
-            StatusModalDivider {
-                topPadding: 12
-                bottomPadding: 16
-            }
-
             StatusDescriptionListItem {
                 title: qsTr("Share Profile URL")
                 subTitle: {
@@ -165,12 +169,6 @@ StatusModal {
                     tooltip.visible = !tooltip.visible
                 }
                 width: parent.width
-            }
-
-            StatusModalDivider {
-                visible: !isCurrentUser
-                topPadding: 8
-                bottomPadding: 12
             }
 
             StatusDescriptionListItem {


### PR DESCRIPTION
### What does the PR do

It restores job done in PR #4392 - Task #3547 after base_bc rebase.

### Affected areas
- Contacts/Blocked Contacts/View Profile
- Blocked chat content

### Screenshot of functionality
Blocked user:
![image](https://user-images.githubusercontent.com/97019400/152126309-753e42f7-c260-4e9e-8d0d-22042819c983.png)

Blocked chat content:
![image](https://user-images.githubusercontent.com/97019400/152307931-f799bb16-ee10-4ee9-a836-4d017f75af52.png)