### PR TITLE
Fix Wallet send of ETH and tokens

### DIFF
--- a/src/app/modules/main/wallet_section/transactions/controller.nim
+++ b/src/app/modules/main/wallet_section/transactions/controller.nim
@@ -78,3 +78,9 @@ method loadTransactions*(self: Controller, address: string, toBlock: Uint256, li
 
 method estimateGas*(self: Controller, from_addr: string, to: string, assetAddress: string, value: string, data: string): string =
   result = self.transactionService.estimateGas(from_addr, to, assetAddress, value, data)
+
+method transferEth*(self: Controller, from_addr: string, to_addr: string, value: string,
+  gas: string, gasPrice: string, maxPriorityFeePerGas: string, maxFeePerGas: string,
+  password: string, uuid: string): bool =
+  result = self.transactionService.transferEth(from_addr, to_addr, value, gas, gasPrice,
+    maxPriorityFeePerGas, maxFeePerGas, password, uuid)

--- a/src/app/modules/main/wallet_section/transactions/controller.nim
+++ b/src/app/modules/main/wallet_section/transactions/controller.nim
@@ -84,3 +84,9 @@ method transferEth*(self: Controller, from_addr: string, to_addr: string, value:
   password: string, uuid: string): bool =
   result = self.transactionService.transferEth(from_addr, to_addr, value, gas, gasPrice,
     maxPriorityFeePerGas, maxFeePerGas, password, uuid)
+
+method transferTokens*(self: Controller, from_addr: string, to_addr: string, contractAddress: string,
+    value: string, gas: string, gasPrice: string, maxPriorityFeePerGas: string,maxFeePerGas: string,
+    password: string, uuid: string): bool =
+  result = self.transactionService.transferTokens(from_addr, to_addr, contractAddress, value, gas,
+    gasPrice, maxPriorityFeePerGas, maxFeePerGas, password, uuid)

--- a/src/app/modules/main/wallet_section/transactions/controller_interface.nim
+++ b/src/app/modules/main/wallet_section/transactions/controller_interface.nim
@@ -32,6 +32,11 @@ method setTrxHistoryResult*(self: AccessInterface, historyJSON: string) {.base.}
 method estimateGas*(self: AccessInterface, from_addr: string, to: string, assetAddress: string, value: string, data: string): string {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method transferEth*(self: AccessInterface, from_addr: string, to_addr: string, value: string,
+    gas: string, gasPrice: string, maxPriorityFeePerGas: string, maxFeePerGas: string,
+    password: string, uuid: string): bool {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 type
   ## Abstract class (concept) which must be implemented by object/s used in this 
   ## module.

--- a/src/app/modules/main/wallet_section/transactions/controller_interface.nim
+++ b/src/app/modules/main/wallet_section/transactions/controller_interface.nim
@@ -37,6 +37,12 @@ method transferEth*(self: AccessInterface, from_addr: string, to_addr: string, v
     password: string, uuid: string): bool {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method transferTokens*(self: AccessInterface, from_addr: string, to_addr: string,
+    contractAddress: string, value: string, gas: string, gasPrice: string,
+    maxPriorityFeePerGas: string, maxFeePerGas: string, password: string,
+    uuid: string): bool {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 type
   ## Abstract class (concept) which must be implemented by object/s used in this 
   ## module.

--- a/src/app/modules/main/wallet_section/transactions/io_interface.nim
+++ b/src/app/modules/main/wallet_section/transactions/io_interface.nim
@@ -48,6 +48,12 @@ method transferEth*(self: AccessInterface, from_addr: string, to_addr: string, v
     password: string, uuid: string): bool {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method transferTokens*(self: AccessInterface, from_addr: string, to_addr: string,
+    contractAddress: string, value: string, gas: string, gasPrice: string,
+    maxPriorityFeePerGas: string, maxFeePerGas: string, password: string,
+    uuid: string): bool {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 # View Delegate Interface
 # Delegate for the view must be declared here due to use of QtObject and multi 
 # inheritance, which is not well supported in Nim.

--- a/src/app/modules/main/wallet_section/transactions/io_interface.nim
+++ b/src/app/modules/main/wallet_section/transactions/io_interface.nim
@@ -43,6 +43,11 @@ method setIsNonArchivalNode*(self: AccessInterface, isNonArchivalNode: bool) {.b
 method estimateGas*(self: AccessInterface, from_addr: string, to: string, assetAddress: string, value: string, data: string): string {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method transferEth*(self: AccessInterface, from_addr: string, to_addr: string, value: string,
+    gas: string, gasPrice: string, maxPriorityFeePerGas: string, maxFeePerGas: string,
+    password: string, uuid: string): bool {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 # View Delegate Interface
 # Delegate for the view must be declared here due to use of QtObject and multi 
 # inheritance, which is not well supported in Nim.

--- a/src/app/modules/main/wallet_section/transactions/module.nim
+++ b/src/app/modules/main/wallet_section/transactions/module.nim
@@ -85,3 +85,9 @@ method estimateGas*(self: Module, from_addr: string, to: string, assetAddress: s
 
 method setIsNonArchivalNode*(self: Module, isNonArchivalNode: bool) =
   self.view.setIsNonArchivalNode(isNonArchivalNode)
+
+method transferEth*(self: Module, from_addr: string, to_addr: string, value: string, gas: string,
+    gasPrice: string, maxPriorityFeePerGas: string, maxFeePerGas: string, password: string,
+    uuid: string): bool =
+  result = self.controller.transferEth(from_addr, to_addr, value, gas, gasPrice,
+    maxPriorityFeePerGas, maxFeePerGas, password, uuid)

--- a/src/app/modules/main/wallet_section/transactions/module.nim
+++ b/src/app/modules/main/wallet_section/transactions/module.nim
@@ -91,3 +91,9 @@ method transferEth*(self: Module, from_addr: string, to_addr: string, value: str
     uuid: string): bool =
   result = self.controller.transferEth(from_addr, to_addr, value, gas, gasPrice,
     maxPriorityFeePerGas, maxFeePerGas, password, uuid)
+
+method transferTokens*(self: Module, from_addr: string, to_addr: string, contractAddress: string,
+    value: string, gas: string, gasPrice: string, maxPriorityFeePerGas: string,
+    maxFeePerGas: string, password: string, uuid: string): bool =
+  result = self.controller.transferTokens(from_addr, to_addr, contractAddress, value, gas, gasPrice,
+    maxPriorityFeePerGas, maxFeePerGas, password, uuid)

--- a/src/app/modules/main/wallet_section/transactions/view.nim
+++ b/src/app/modules/main/wallet_section/transactions/view.nim
@@ -103,6 +103,11 @@ QtObject:
     read = getIsNonArchivalNode
     notify = isNonArchivalNodeChanged
 
-
   proc estimateGas*(self: View, from_addr: string, to: string, assetAddress: string, value: string, data: string): string {.slot.} =
     result = self.delegate.estimateGas(from_addr, to, assetAddress, value, data)
+
+  proc transferEth*(self: View, from_addr: string, to_addr: string, value: string, gas: string,
+      gasPrice: string, maxPriorityFeePerGas: string, maxFeePerGas: string, password: string,
+      uuid: string): bool {.slot.} =
+    result = self.delegate.transferEth(from_addr, to_addr, value, gas, gasPrice,
+      maxPriorityFeePerGas, maxFeePerGas, password, uuid)

--- a/src/app/modules/main/wallet_section/transactions/view.nim
+++ b/src/app/modules/main/wallet_section/transactions/view.nim
@@ -105,9 +105,16 @@ QtObject:
 
   proc estimateGas*(self: View, from_addr: string, to: string, assetAddress: string, value: string, data: string): string {.slot.} =
     result = self.delegate.estimateGas(from_addr, to, assetAddress, value, data)
+    result = self.delegate.estimateGas(from_addr, to, assetAddress, value, data)
 
   proc transferEth*(self: View, from_addr: string, to_addr: string, value: string, gas: string,
       gasPrice: string, maxPriorityFeePerGas: string, maxFeePerGas: string, password: string,
       uuid: string): bool {.slot.} =
     result = self.delegate.transferEth(from_addr, to_addr, value, gas, gasPrice,
+      maxPriorityFeePerGas, maxFeePerGas, password, uuid)
+
+  proc transferTokens*(self: View, from_addr: string, to_addr: string, contractAddress: string,
+      value: string, gas: string, gasPrice: string, maxPriorityFeePerGas: string,
+      maxFeePerGas: string, password: string, uuid: string): bool {.slot.} =
+    result = self.delegate.transferTokens(from_addr, to_addr, contractAddress, value, gas, gasPrice,
       maxPriorityFeePerGas, maxFeePerGas, password, uuid)

--- a/src/app_service/service/eth/dto/contract.nim
+++ b/src/app_service/service/eth/dto/contract.nim
@@ -74,4 +74,4 @@ proc tokenSymbol*(contract: ContractDto): string =
   getTokenString(contract, "symbol")
 
 proc getMethod*(contract: ContractDto, methodName: string): MethodDto = 
-  return contract.methods["methodName"]
+  return contract.methods[methodName]

--- a/src/app_service/service/eth/dto/method_dto.nim
+++ b/src/app_service/service/eth/dto/method_dto.nim
@@ -93,7 +93,7 @@ proc send*(self: MethodDto, tx: var TransactionDataDto, methodDescriptor: object
   tx.data = self.encodeAbi(methodDescriptor)
   # this call should not be part of this file, we need to move it to appropriate place, or this should not be a DTO class.
   let response = status_eth.sendTransaction($(%tx), password)
-  return $response.result
+  return response.result.getStr
 
 proc call[T](self: MethodDto, tx: var TransactionDataDto, methodDescriptor: object, success: var bool): T =
   success = true

--- a/src/app_service/service/wallet_account/service.nim
+++ b/src/app_service/service/wallet_account/service.nim
@@ -48,6 +48,10 @@ proc fetchPrice(crypto: string, fiat: string): float64 =
     client.headers = newHttpHeaders({ "Content-Type": "application/json" })
 
     let response = client.request(url)
+    let parsedResponse = parseJson(response.body)
+    if (parsedResponse{"Response"} != nil and parsedResponse{"Response"}.getStr == "Error"):
+      error "Error while getting price", message = parsedResponse["Message"].getStr
+      return 0.0
     result = parsefloat($parseJson(response.body)[fiat.toUpper])
     priceCache[key] = result
   except Exception as e:

--- a/ui/app/AppLayouts/stores/RootStore.qml
+++ b/ui/app/AppLayouts/stores/RootStore.qml
@@ -73,4 +73,9 @@ QtObject {
        return walletSectionTransactions.transferEth(from, to, amount, gasLimit, gasPrice, tipLimit,
         overallLimit, password, uuid);
     }
+
+    function transferTokens(from, to, address, amount, gasLimit, gasPrice, tipLimit, overallLimit, password, uuid) {
+       return walletSectionTransactions.transferTokens(from, to, address, amount, gasLimit,
+        gasPrice, tipLimit, overallLimit, password, uuid);
+    }
 }

--- a/ui/app/AppLayouts/stores/RootStore.qml
+++ b/ui/app/AppLayouts/stores/RootStore.qml
@@ -68,4 +68,9 @@ QtObject {
     function getGasEthValue(gweiValue, gasLimit) {
         return profileSectionStore.ensUsernamesStore.getGasEthValue(gweiValue, gasLimit)
     }
+
+    function transferEth(from, to, amount, gasLimit, gasPrice, tipLimit, overallLimit, password, uuid) {
+       return walletSectionTransactions.transferEth(from, to, amount, gasLimit, gasPrice, tipLimit,
+        overallLimit, password, uuid);
+    }
 }

--- a/ui/imports/shared/popups/SendModal.qml
+++ b/ui/imports/shared/popups/SendModal.qml
@@ -51,18 +51,17 @@ ModalPopup {
                         transactionSigner.enteredPassword,
                         stack.uuid)
         } else {
-            // Not Refactored Yet
-            //            success = RootStore.transferTokens(
-            //                        selectFromAccount.selectedAccount.address,
-            //                        selectRecipient.selectedRecipient.address,
-            //                        txtAmount.selectedAsset.address,
-            //                        txtAmount.selectedAmount,
-            //                        gasSelector.selectedGasLimit,
-            //                        gasSelector.eip1599Enabled ? "" : gasSelector.selectedGasPrice,
-            //                        gasSelector.selectedTipLimit,
-            //                        gasSelector.selectedOverallLimit,
-            //                        transactionSigner.enteredPassword,
-            //                        stack.uuid)
+            success = root.store.transferTokens(
+                        selectFromAccount.selectedAccount.address,
+                        selectRecipient.selectedRecipient.address,
+                        txtAmount.selectedAsset.address,
+                        txtAmount.selectedAmount,
+                        gasSelector.selectedGasLimit,
+                        gasSelector.eip1599Enabled ? "" : gasSelector.selectedGasPrice,
+                        gasSelector.selectedTipLimit,
+                        gasSelector.selectedOverallLimit,
+                        transactionSigner.enteredPassword,
+                        stack.uuid)
         }
 
         if(!success){
@@ -144,6 +143,7 @@ ModalPopup {
                 id: txtAmount
                 selectedAccount: selectFromAccount.selectedAccount
                 currentCurrency: root.store.currentCurrency
+                // TODO make those use a debounce
                 getFiatValue: root.store.getFiatValue
 //                getCryptoValue: RootStore.cryptoValue
                 width: stack.width

--- a/ui/imports/shared/popups/SendModal.qml
+++ b/ui/imports/shared/popups/SendModal.qml
@@ -37,39 +37,51 @@ ModalPopup {
     }
 
     function sendTransaction() {
-// Not Refactored Yet
-//        stack.currentGroup.isPending = true
-//        let success = false
-//        if(txtAmount.selectedAsset.address === "" || txtAmount.selectedAsset.address === Constants.zeroAddress){
-//            success = RootStore.transferEth(
-//                        selectFromAccount.selectedAccount.address,
-//                        selectRecipient.selectedRecipient.address,
-//                        txtAmount.selectedAmount,
-//                        gasSelector.selectedGasLimit,
-//                        gasSelector.eip1599Enabled ? "" : gasSelector.selectedGasPrice,
-//                        gasSelector.selectedTipLimit,
-//                        gasSelector.selectedOverallLimit,
-//                        transactionSigner.enteredPassword,
-//                        stack.uuid)
-//        } else {
-//            success = RootStore.transferTokens(
-//                        selectFromAccount.selectedAccount.address,
-//                        selectRecipient.selectedRecipient.address,
-//                        txtAmount.selectedAsset.address,
-//                        txtAmount.selectedAmount,
-//                        gasSelector.selectedGasLimit,
-//                        gasSelector.eip1599Enabled ? "" : gasSelector.selectedGasPrice,
-//                        gasSelector.selectedTipLimit,
-//                        gasSelector.selectedOverallLimit,
-//                        transactionSigner.enteredPassword,
-//                        stack.uuid)
-//        }
+        stack.currentGroup.isPending = true
+        let success = false
+        if(txtAmount.selectedAsset.address === "" || txtAmount.selectedAsset.address === Constants.zeroAddress){
+            success = root.store.transferEth(
+                        selectFromAccount.selectedAccount.address,
+                        selectRecipient.selectedRecipient.address,
+                        txtAmount.selectedAmount,
+                        gasSelector.selectedGasLimit,
+                        gasSelector.eip1599Enabled ? "" : gasSelector.selectedGasPrice,
+                        gasSelector.selectedTipLimit,
+                        gasSelector.selectedOverallLimit,
+                        transactionSigner.enteredPassword,
+                        stack.uuid)
+        } else {
+            // Not Refactored Yet
+            //            success = RootStore.transferTokens(
+            //                        selectFromAccount.selectedAccount.address,
+            //                        selectRecipient.selectedRecipient.address,
+            //                        txtAmount.selectedAsset.address,
+            //                        txtAmount.selectedAmount,
+            //                        gasSelector.selectedGasLimit,
+            //                        gasSelector.eip1599Enabled ? "" : gasSelector.selectedGasPrice,
+            //                        gasSelector.selectedTipLimit,
+            //                        gasSelector.selectedOverallLimit,
+            //                        transactionSigner.enteredPassword,
+            //                        stack.uuid)
+        }
 
-//        if(!success){
-//            //% "Invalid transaction parameters"
-//            sendingError.text = qsTrId("invalid-transaction-parameters")
-//            sendingError.open()
-//        }
+        if(!success){
+            //% "Invalid transaction parameters"
+            sendingError.text = qsTrId("invalid-transaction-parameters")
+            sendingError.open()
+        } else {
+            // TODO remove this else once the thread and connection are back
+            stack.currentGroup.isPending = false
+            //% "Transaction pending..."
+            Global.toastMessage.title = qsTrId("ens-transaction-pending")
+            Global.toastMessage.source = Style.svg("loading")
+            Global.toastMessage.iconColor = Style.current.primary
+            Global.toastMessage.iconRotates = true
+            // Refactor this
+            // Global.toastMessage.link = `${walletModel.utilsView.etherscanLink}/${response.result}`
+            Global.toastMessage.open()
+            root.close()
+        }
     }
 
     TransactionStackView {

--- a/ui/imports/shared/stores/RootStore.qml
+++ b/ui/imports/shared/stores/RootStore.qml
@@ -62,14 +62,6 @@ QtObject {
         localAccountSensitiveSettings.isTenorWarningAccepted = value;
     }
 
-    function transferEth(from, to, amount, gasLimit, gasPrice, tipLimit, overallLimit, password, uuid) {
-//        return walletModelInst.transactionsView.transferEth(from, to, amount, gasLimit, gasPrice, tipLimit, overallLimit, password, uuid);
-    }
-
-    function transferTokens(from, to, address, amount, gasLimit, gasPrice, tipLimit, overallLimit, password, uuid) {
-//        return walletModelInst.transactionsView.transferTokens(from, to, address, amount, gasLimit, gasPrice, tipLimit, overallLimit, password, uuid);
-    }
-
     function copyToClipboard(text) {
         globalUtils.copyToClipboard(text)
     }


### PR DESCRIPTION
Fixes #4650 and more
 
This started as a fix for the Gas estimation, but I found that the whole wallet Send was not hooked, so I did it all before @anastasiyaig could go ahead and complain (jk... unless 🤫 )

There will still be remaining work, but the normal flow to send ETH and tokens (tested with STT) works.

The remaining work includes:
- Making the service functions async and hook the Connections again
- Adding a debounce to the calls for estimatingGas and getting the fiatPrice would be good too, because it causes a small lag when typing a value currently