### PR TITLE
fix(@desktop/settings-contacts): it is not possible to add new contacts after the first one is added

### DIFF
--- a/src/app_service/service/contacts/async_tasks.nim
+++ b/src/app_service/service/contacts/async_tasks.nim
@@ -21,9 +21,6 @@ const lookupContactTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
     # TODO refactor those calls to use the new backend and also do it in a signle call
     pubkey = ens_utils.pubkey(arg.value)
     address = ens_utils.address(arg.value)
-  else:
-    pubkey = ""
-    address = ""
   
   let output = %*{
     "id": pubkey,

--- a/ui/app/AppLayouts/Profile/views/ContactsView.qml
+++ b/ui/app/AppLayouts/Profile/views/ContactsView.qml
@@ -213,7 +213,7 @@ Item {
 
                 Connections {
                     target: root.contactsStore.mainModuleInst
-                    onResolvedENS: function (resolvedPubKey) {
+                    onResolvedENS: {
                         if (resolvedPubKey === "") {
                             searchResults.pubKey = ""
                             searchResults.showProfileNotFoundMessage = true

--- a/ui/imports/shared/views/SearchResults.qml
+++ b/ui/imports/shared/views/SearchResults.qml
@@ -19,6 +19,8 @@ import StatusQ.Components 0.1
 Item {
     id: root
     height: 64
+    width: parent.width
+
     property bool hasExistingContacts: false
     property bool showProfileNotFoundMessage: false
     property bool loading: false
@@ -28,12 +30,7 @@ Item {
     property string address: ""
     property bool resultClickable: true
     property bool addContactEnabled: true
-
-    property bool isAddedContact: root.isContactAdded()
-
-    function isContactAdded() {
-        return root.pubKey != "" ? Utils.getContactDetailsAsJson(root.pubKey).isContact : false
-    }
+    property bool isAddedContact: false
 
     signal resultClicked(string pubKey, bool isAddedContact, string username)
     signal addToContactsButtonClicked(string pubKey)
@@ -44,9 +41,16 @@ Item {
         username = ""
         userAlias = ""
         pubKey = ""
+        isAddedContact = false
     }
 
-    width: parent.width
+    function isContactAdded() {
+        return root.pubKey != "" ? Utils.getContactDetailsAsJson(root.pubKey).isContact : false
+    }
+
+    onPubKeyChanged: {
+        root.isAddedContact = root.isContactAdded()
+    }
 
     StyledText {
         id: nonContactsLabel


### PR DESCRIPTION
@Khushboo-dev-cpp please check in the app do changes I did here (in `contacts/async_tasks.nim`) affect somehow what you fixed in your PR regarding searching for user's address when you want to send him a transaction. If it does affect please give me the steps how to reproduce it, since I tried and it looked ok for me.

Fixes #4658