### PR TITLE
fix(browser-provider): fix browser provider not asking for authorization

### DIFF
--- a/src/app/modules/main/browser_section/provider/controller.nim
+++ b/src/app/modules/main/browser_section/provider/controller.nim
@@ -1,4 +1,4 @@
-import tables
+import strutils
 import controller_interface
 import io_interface
 
@@ -45,7 +45,7 @@ method disconnect*(self: Controller) =
   discard self.dappPermissionsService.revoke("web3".toPermission())
 
 method postMessage*(self: Controller, requestType: string, message: string): string =
-  return self.providerService.postMessage(requestType, message)
+  return self.providerService.postMessage(parseEnum[RequestTypes](requestType), message)
 
 method hasPermission*(self: Controller, hostname: string, permission: string): bool =
   return self.dappPermissionsService.hasPermission(hostname, permission.toPermission())

--- a/src/app_service/service/provider/dto.nim
+++ b/src/app_service/service/provider/dto.nim
@@ -1,0 +1,35 @@
+import json
+import ../dapp_permissions/service as dapp_permissions_service
+
+const HTTPS_SCHEME* = "https"
+const IPFS_GATEWAY* =  ".infura.status.im"
+const SWARM_GATEWAY* = "swarm-gateways.net"
+
+type
+  RequestTypes* {.pure.} = enum
+    Web3SendAsyncReadOnly = "web3-send-async-read-only",
+    HistoryStateChanged = "history-state-changed",
+    APIRequest = "api-request"
+    Unknown = "unknown"
+
+  ResponseTypes* {.pure.} = enum
+    Web3SendAsyncCallback = "web3-send-async-callback",
+    APIResponse = "api-response",
+    Web3ResponseError = "web3-response-error"
+
+type
+  Payload* = ref object
+    id*: JsonNode
+    rpcMethod*: string
+
+  Web3SendAsyncReadOnly* = ref object
+    messageId*: JsonNode
+    payload*: Payload
+    request*: string
+    hostname*: string
+
+  APIRequest* = ref object
+    isAllowed*: bool
+    messageId*: JsonNode
+    permission*: Permission
+    hostname*: string

--- a/src/app_service/service/provider/service.nim
+++ b/src/app_service/service/provider/service.nim
@@ -21,39 +21,6 @@ export service_interface
 logScope:
   topics = "provider-service"
 
-const HTTPS_SCHEME* = "https"
-const IPFS_GATEWAY* =  ".infura.status.im"
-const SWARM_GATEWAY* = "swarm-gateways.net"
-
-type
-  RequestTypes {.pure.} = enum
-    Web3SendAsyncReadOnly = "web3-send-async-read-only",
-    HistoryStateChanged = "history-state-changed",
-    APIRequest = "api-request"
-    Unknown = "unknown"
-
-  ResponseTypes {.pure.} = enum
-    Web3SendAsyncCallback = "web3-send-async-callback",
-    APIResponse = "api-response",
-    Web3ResponseError = "web3-response-error"
-
-type
-  Payload = ref object
-    id: JsonNode
-    rpcMethod: string
-
-  Web3SendAsyncReadOnly = ref object
-    messageId: JsonNode
-    payload: Payload
-    request: string
-    hostname: string
-
-  APIRequest = ref object
-    isAllowed: bool
-    messageId: JsonNode
-    permission: Permission
-    hostname: string
-
 const AUTH_METHODS = toHashSet(["eth_accounts", "eth_coinbase", "eth_sendTransaction", "eth_sign", "keycard_signTypedData", "eth_signTypedData", "eth_signTypedData_v3", "personal_sign", "personal_ecRecover"])
 const SIGN_METHODS = toHashSet(["eth_sign", "personal_sign", "eth_signTypedData", "eth_signTypedData_v3"])
 const ACC_METHODS = toHashSet(["eth_accounts", "eth_coinbase"])
@@ -289,8 +256,8 @@ proc process(self: Service, data: APIRequest): string =
     "data": value
   }
 
-method postMessage*(self: Service, message: string): string =
-  case message.requestType():
+method postMessage*(self: Service, requestType: RequestTypes, message: string): string =
+  case requestType:
   of RequestTypes.Web3SendAsyncReadOnly: self.process(message.toWeb3SendAsyncReadOnly())
   of RequestTypes.HistoryStateChanged: """{"type":"TODO-IMPLEMENT-THIS"}""" ############# TODO:
   of RequestTypes.APIRequest: self.process(message.toAPIRequest())

--- a/src/app_service/service/provider/service_interface.nim
+++ b/src/app_service/service/provider/service_interface.nim
@@ -1,3 +1,6 @@
+import dto
+export dto
+
 type 
   ServiceInterface* {.pure inheritable.} = ref object of RootObj
   ## Abstract class for this service access.
@@ -8,7 +11,7 @@ method delete*(self: ServiceInterface) {.base.} =
 method init*(self: ServiceInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method postMessage*(self: ServiceInterface, requestType: string, message: string): string {.base.} =
+method postMessage*(self: ServiceInterface, requestType: RequestTypes, message: string): string {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method ensResourceURL*(self: ServiceInterface, ens: string, url: string): (string, string, string, string, bool) =

--- a/ui/app/AppLayouts/Browser/popups/BrowserConnectionModal.qml
+++ b/ui/app/AppLayouts/Browser/popups/BrowserConnectionModal.qml
@@ -33,7 +33,7 @@ StatusModal {
         interactedWith = true
         request.isAllowed = isAllowed;
         RootStore.currentTabConnected = isAllowed
-        web3Response(Web3ProviderStore.web3ProviderInst.postMessage(JSON.stringify(request)))
+        web3Response(Web3ProviderStore.web3ProviderInst.postMessage(Constants.api_request, JSON.stringify(request)))
     }
 
     onClosed: {


### PR DESCRIPTION
Fixes #4721

This was hard to debug, because it hapended with the merge/clash of master and base_bc.

Basically, both master and base_bc sent the provider calls correctly, but when they merged, they both had small mistakes that compounded in each other, making it totally explode.
Also, tracking bugs with the provider is hard.

Anyway, the issue was that we passed 1 parameter at one place, and two at an other, so the call ended up not working. Also, I hit the "No implementation available" issue, but again, I didn't have that message, it just crashed.