### PR TITLE
fix(@desktop/chat): add a blocked bar for blocked user profile

### DIFF
--- a/src/app/modules/main/chat_section/active_item.nim
+++ b/src/app/modules/main/chat_section/active_item.nim
@@ -125,9 +125,15 @@ QtObject:
     if(self.item.isNil):
       return false
     return self.item.muted
-
   QtProperty[bool] muted:
     read = getMuted
+
+  proc getBlocked(self: ActiveItem): bool {.slot.} = 
+    if(self.item.isNil):
+      return false
+    return self.item.blocked
+  QtProperty[bool] blocked:
+    read = getBlocked
 
   proc getPosition(self: ActiveItem): int {.slot.} = 
     if(self.item.isNil):

--- a/src/app/modules/main/chat_section/active_sub_item.nim
+++ b/src/app/modules/main/chat_section/active_sub_item.nim
@@ -94,9 +94,15 @@ QtObject:
     if(self.item.isNil):
       return false
     return self.item.muted
-
   QtProperty[bool] muted:
     read = getMuted
+
+  proc getBlocked(self: ActiveSubItem): bool {.slot.} = 
+    if(self.item.isNil):
+      return false
+    return self.item.blocked
+  QtProperty[bool] blocked:
+    read = getBlocked
 
   proc getPosition(self: ActiveSubItem): int {.slot.} = 
     if(self.item.isNil):

--- a/src/app/modules/main/chat_section/base_item.nim
+++ b/src/app/modules/main/chat_section/base_item.nim
@@ -11,12 +11,13 @@ type
     hasUnreadMessages: bool
     notificationsCount: int
     muted: bool
+    blocked: bool
     active: bool
     position: int
     categoryId: string
 
 proc setup*(self: BaseItem, id, name, icon: string, isIdenticon: bool, color, description: string,
-  `type`: int, amIChatAdmin: bool, hasUnreadMessages: bool, notificationsCount: int, muted, active: bool,
+  `type`: int, amIChatAdmin: bool, hasUnreadMessages: bool, notificationsCount: int, muted, blocked, active: bool,
     position: int, categoryId: string = "") =
   self.id = id
   self.name = name
@@ -29,16 +30,17 @@ proc setup*(self: BaseItem, id, name, icon: string, isIdenticon: bool, color, de
   self.hasUnreadMessages = hasUnreadMessages
   self.notificationsCount = notificationsCount
   self.muted = muted
+  self.blocked = blocked
   self.active = active
   self.position = position
   self.categoryId = categoryId
 
 proc initBaseItem*(id, name, icon: string, isIdenticon: bool, color, description: string, `type`: int, 
-    amIChatAdmin: bool, hasUnreadMessages: bool, notificationsCount: int, muted, active: bool,
+    amIChatAdmin: bool, hasUnreadMessages: bool, notificationsCount: int, muted, blocked, active: bool,
     position: int, categoryId: string = ""): BaseItem =
   result = BaseItem()
   result.setup(id, name, icon, isIdenticon, color, description, `type`, amIChatAdmin, hasUnreadMessages, 
-  notificationsCount, muted, active, position, categoryId)
+  notificationsCount, muted, blocked, active, position, categoryId)
 
 proc delete*(self: BaseItem) = 
   discard
@@ -96,6 +98,12 @@ method muted*(self: BaseItem): bool {.inline base.} =
 
 method `muted=`*(self: var BaseItem, value: bool) {.inline base.} = 
   self.muted = value
+
+method blocked*(self: BaseItem): bool {.inline base.} = 
+  self.blocked
+
+method `blocked=`*(self: var BaseItem, value: bool) {.inline base.} = 
+  self.blocked = value
 
 method active*(self: BaseItem): bool {.inline base.} = 
   self.active

--- a/src/app/modules/main/chat_section/controller.nim
+++ b/src/app/modules/main/chat_section/controller.nim
@@ -89,6 +89,10 @@ method init*(self: Controller) =
     var args = ContactArgs(e)
     self.delegate.onContactBlocked(args.contactId)
 
+  self.events.on(SIGNAL_CONTACT_UNBLOCKED) do(e: Args):
+    var args = ContactArgs(e)
+    self.delegate.onContactUnblocked(args.contactId)
+
   if (self.isCommunitySection):
     self.events.on(SIGNAL_COMMUNITY_CHANNEL_CREATED) do(e:Args):
       let args = CommunityChatArgs(e)

--- a/src/app/modules/main/chat_section/item.nim
+++ b/src/app/modules/main/chat_section/item.nim
@@ -6,10 +6,10 @@ type
     subItems: SubModel
 
 proc initItem*(id, name, icon: string, isIdenticon: bool, color, description: string, `type`: int, amIChatAdmin: bool,
-  hasUnreadMessages: bool, notificationsCount: int, muted, active: bool, position: int, categoryId: string): Item =
+  hasUnreadMessages: bool, notificationsCount: int, muted, blocked, active: bool, position: int, categoryId: string): Item =
   result = Item()
   result.setup(id, name, icon, isIdenticon, color, description, `type`, amIChatAdmin, hasUnreadMessages, 
-  notificationsCount, muted, active, position, categoryId)
+  notificationsCount, muted, blocked, active, position, categoryId)
   result.subItems = newSubModel()
 
 proc delete*(self: Item) = 
@@ -32,6 +32,7 @@ proc `$`*(self: Item): string =
     hasUnreadMessages: {self.hasUnreadMessages}, 
     notificationsCount: {self.notificationsCount},
     muted: {self.muted},
+    blocked: {self.blocked},
     active: {self.active},
     position: {self.position},
     categoryId: {self.categoryId},
@@ -52,6 +53,7 @@ proc toJsonNode*(self: Item): JsonNode =
     "hasUnreadMessages": self.hasUnreadMessages, 
     "notificationsCount": self.notificationsCount,
     "muted": self.muted,
+    "blocked": self.blocked,
     "active": self.active,
     "position": self.position,
     "categoryId": self.categoryId

--- a/src/app/modules/main/chat_section/model.nim
+++ b/src/app/modules/main/chat_section/model.nim
@@ -15,6 +15,7 @@ type
     HasUnreadMessages
     NotificationsCount
     Muted
+    Blocked
     Active
     Position
     SubItems
@@ -75,6 +76,7 @@ QtObject:
       ModelRole.HasUnreadMessages.int:"hasUnreadMessages",
       ModelRole.NotificationsCount.int:"notificationsCount",
       ModelRole.Muted.int:"muted",
+      ModelRole.Blocked.int:"blocked",
       ModelRole.Active.int:"active",
       ModelRole.Position.int:"position",
       ModelRole.SubItems.int:"subItems",
@@ -114,7 +116,9 @@ QtObject:
       result = newQVariant(item.notificationsCount)
     of ModelRole.Muted: 
       result = newQVariant(item.muted)
-    of ModelRole.Active: 
+    of ModelRole.Blocked: 
+      result = newQVariant(item.blocked)
+    of ModelRole.Active:
       result = newQVariant(item.active)
     of ModelRole.Position: 
       result = newQVariant(item.position)
@@ -215,6 +219,17 @@ QtObject:
         return
 
       if self.items[i].subItems.muteUnmuteItemById(id, mute):
+        return
+
+  proc blockUnblockItemOrSubItemById*(self: Model, id: string, blocked: bool) =
+    for i in 0 ..< self.items.len:
+      if(self.items[i].id == id):
+        let index = self.createIndex(i, 0, nil)
+        self.items[i].BaseItem.blocked = blocked
+        self.dataChanged(index, index, @[ModelRole.Blocked.int])
+        return
+
+      if self.items[i].subItems.blockUnblockItemById(id, blocked):
         return
 
   proc updateItemDetails*(self: Model, id, name, icon: string, isIdenticon: bool) =

--- a/src/app/modules/main/chat_section/private_interfaces/module_controller_delegate_interface.nim
+++ b/src/app/modules/main/chat_section/private_interfaces/module_controller_delegate_interface.nim
@@ -33,6 +33,9 @@ method onContactRejected*(self: AccessInterface, publicKey: string) {.base.} =
 method onContactBlocked*(self: AccessInterface, publicKey: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method onContactUnblocked*(self: AccessInterface, publicKey: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method onContactDetailsUpdated*(self: AccessInterface, contactId: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/chat_section/sub_item.nim
+++ b/src/app/modules/main/chat_section/sub_item.nim
@@ -8,10 +8,10 @@ type
     parentId: string
 
 proc initSubItem*(id, parentId, name, icon: string, isIdenticon: bool, color, description: string, `type`: int, 
-  amIChatAdmin: bool, hasUnreadMessages: bool, notificationsCount: int, muted, active: bool, position: int): SubItem =
+  amIChatAdmin: bool, hasUnreadMessages: bool, notificationsCount: int, muted, blocked, active: bool, position: int): SubItem =
   result = SubItem()
   result.setup(id, name, icon, isIdenticon, color, description, `type`, amIChatAdmin, hasUnreadMessages, 
-  notificationsCount, muted, active, position)
+  notificationsCount, muted, blocked, active, position)
   result.parentId = parentId
 
 proc delete*(self: SubItem) = 
@@ -34,6 +34,7 @@ proc `$`*(self: SubItem): string =
     hasUnreadMessages: {self.hasUnreadMessages}, 
     notificationsCount: {self.notificationsCount},
     muted: {self.muted},
+    blocked: {self.blocked},
     active: {self.active},
     position: {self.position},
     ]"""
@@ -51,6 +52,7 @@ proc toJsonNode*(self: SubItem): JsonNode =
     "hasUnreadMessages": self.hasUnreadMessages, 
     "notificationsCount": self.notificationsCount,
     "muted": self.muted,
+    "blocked": self.blocked,
     "active": self.active,
     "position": self.position
   }

--- a/src/app/modules/main/chat_section/sub_model.nim
+++ b/src/app/modules/main/chat_section/sub_model.nim
@@ -16,6 +16,7 @@ type
     HasUnreadMessages
     NotificationsCount
     Muted
+    Blocked
     Active
     Position
 
@@ -70,6 +71,7 @@ QtObject:
       ModelRole.HasUnreadMessages.int:"hasUnreadMessages",
       ModelRole.NotificationsCount.int:"notificationsCount",
       ModelRole.Muted.int:"muted",
+      ModelRole.Blocked.int:"blocked",
       ModelRole.Active.int:"active",
       ModelRole.Position.int:"position",
     }.toTable
@@ -109,6 +111,8 @@ QtObject:
       result = newQVariant(item.notificationsCount)
     of ModelRole.Muted: 
       result = newQVariant(item.muted)
+    of ModelRole.Blocked:
+      result = newQVariant(item.blocked)
     of ModelRole.Active: 
       result = newQVariant(item.active)
     of ModelRole.Position: 
@@ -194,6 +198,17 @@ QtObject:
         let index = self.createIndex(i, 0, nil)
         self.items[i].BaseItem.muted = mute
         self.dataChanged(index, index, @[ModelRole.Muted.int])
+        return true
+    return false
+
+  proc blockUnblockItemById*(self: SubModel, id: string, blocked: bool): bool =
+    ## even we're not able to block specific channel of community now, this is here more as a predisposition 
+    ## for that feature, which may be added easy later.
+    for i in 0 ..< self.items.len:
+      if(self.items[i].id == id):
+        let index = self.createIndex(i, 0, nil)
+        self.items[i].BaseItem.blocked = blocked
+        self.dataChanged(index, index, @[ModelRole.Blocked.int])
         return true
     return false
 

--- a/src/app/modules/main/chat_section/view.nim
+++ b/src/app/modules/main/chat_section/view.nim
@@ -40,7 +40,7 @@ QtObject:
     result.contactRequestsModel = contacts_model.newModel()
     result.contactRequestsModelVariant = newQVariant(result.contactRequestsModel)
     result.listOfMyContacts = contacts_model.newModel()
-    result.listOfMyContactsVariant = newQVariant(result.listOfMyContacts)      
+    result.listOfMyContactsVariant = newQVariant(result.listOfMyContacts)
 
   proc load*(self: View) =
     self.delegate.viewDidLoad()

--- a/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
@@ -54,7 +54,6 @@ Item {
     property var userList
 
     property var contactDetails: Utils.getContactDetailsAsJson(root.activeChatId)
-    property bool isBlocked: root.contactDetails.isBlocked
     property bool isContact: root.contactDetails.isContact
     property bool contactRequestReceived: root.contactDetails.requestReceived
 
@@ -179,6 +178,7 @@ Item {
                         receiveTransactionModal: cmpReceiveTransaction
                         sendTransactionWithEnsModal: cmpSendTransactionWithEns
                         stickersLoaded: root.stickersLoaded
+                        isBlocked: model.blocked
                         Component.onCompleted: {
                             parentModule.prepareChatContentModuleForChatId(model.itemId)
                             chatContentModule = parentModule.getChatContentModule()
@@ -208,6 +208,7 @@ Item {
                     receiveTransactionModal: cmpReceiveTransaction
                     sendTransactionWithEnsModal: cmpSendTransactionWithEns
                     stickersLoaded: root.stickersLoaded
+                    isBlocked: model.blocked
                     Component.onCompleted: {
                         parentModule.prepareChatContentModuleForChatId(itemId)
                         chatContentModule = parentModule.getChatContentModule()

--- a/ui/app/AppLayouts/Chat/views/ChatContentView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatContentView.qml
@@ -36,6 +36,8 @@ ColumnLayout {
     property Component receiveTransactionModal
     property Component sendTransactionWithEnsModal
 
+    property bool isBlocked: false
+
     property bool stickersLoaded: false
 
     // NOTE: Used this property change as it is the current way used for displaying new channel/chat data of content view.
@@ -272,25 +274,11 @@ ColumnLayout {
         //        }
     }
 
-    Item {
+    StatusBanner {
         Layout.fillWidth: true
-        Layout.preferredHeight: 40
-        Layout.alignment: Qt.AlignHCenter
-        visible: isBlocked
-
-        Rectangle {
-            id: blockedBanner
-            anchors.fill: parent
-            color: Style.current.red
-            opacity: 0.1
-        }
-
-        Text {
-            id: blockedText
-            anchors.centerIn: blockedBanner
-            color: Style.current.red
-            text: qsTr("Blocked")
-        }
+        visible: chatContentRoot.isBlocked
+        type: StatusBanner.Type.Danger
+        statusText: qsTr("Blocked")
     }
 
     MessageStore {
@@ -405,8 +393,8 @@ ColumnLayout {
                     //                        chatContentRoot.rootStore.chatsModelInst.channelView.activeChannel.canPost
                 }
                 messageContextMenu: contextmenu
-                isContactBlocked: isBlocked
-                chatInputPlaceholder: isBlocked ?
+                isContactBlocked: chatContentRoot.isBlocked
+                chatInputPlaceholder: chatContentRoot.isBlocked ?
                                           //% "This user has been blocked."
                                           qsTrId("this-user-has-been-blocked-") :
                                           //% "Type a message."

--- a/ui/imports/shared/popups/ProfilePopup.qml
+++ b/ui/imports/shared/popups/ProfilePopup.qml
@@ -96,6 +96,13 @@ StatusModal {
             anchors.top: parent.top
             width: parent.width
 
+            StatusBanner {
+                width: parent.width
+                visible: popup.userIsBlocked
+                type: StatusBanner.Type.Danger
+                statusText: qsTr("Blocked")
+            }
+
             Item {
                 height: 16
                 width: parent.width
@@ -130,11 +137,6 @@ StatusModal {
                 width: parent.width
             }
 
-            StatusModalDivider {
-                topPadding: 12
-                bottomPadding: 16
-            }
-
             StatusDescriptionListItem {
                 title: qsTr("Share Profile URL")
                 subTitle: {
@@ -165,12 +167,6 @@ StatusModal {
                     tooltip.visible = !tooltip.visible
                 }
                 width: parent.width
-            }
-
-            StatusModalDivider {
-                visible: !isCurrentUser
-                topPadding: 8
-                bottomPadding: 12
             }
 
             StatusDescriptionListItem {


### PR DESCRIPTION
- blocked bar is added for profile popup
- blocked bar is added for a chat

Within this pr new field `blocked` is added to the item and subItem of the `chatsModel` and it is updated correctly in case of `Chat` section. Adding `blocked` to subItem gives us possibility to easily add "blocking" feature to community's channels later (when that become a request), but till then `blocked` prop is set to `false` in case of community for all channels.

Fixes #4673