### PR TITLE
fix(@desktop/communities): Newly created Community remains highlighted

### DIFF
--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -165,6 +165,7 @@ proc createCommunityItem[T](self: Module[T], c: CommunityDto): SectionItem =
   let (unviewedCount, mentionsCount) = self.controller.getNumOfNotificationsForCommunity(c.id)
   let hasNotification = unviewedCount > 0 or mentionsCount > 0
   let notificationsCount = mentionsCount # we need to add here number of requests
+  let active = self.getActiveSectionId() == c.id # We must pass on if the current item section is currently active to keep that property as it is
   result = initItem(
     c.id,
     SectionType.Community,
@@ -176,7 +177,7 @@ proc createCommunityItem[T](self: Module[T], c: CommunityDto): SectionItem =
     c.color,
     hasNotification,
     notificationsCount,
-    active = false,
+    active,
     enabled = singletonInstance.localAccountSensitiveSettings.getCommunitiesEnabled(),
     c.joined,
     c.canJoin,


### PR DESCRIPTION
Fixes #4519

### What does the PR do

Fixed switching/highlight between community and regular navigation button after a newly **created** and/or **edited** community.

Active property value in `createCommunityItem(..)` has been set depending on if the current active section corresponds with the item we are going to create.

### Affected areas

Community navigation bar

### Screenshot of functionality
https://user-images.githubusercontent.com/97019400/152738261-cda02d95-7daa-45aa-82a3-a1113ee45baf.mov