### PR TITLE
fix: continue showing loading indicator when store fetching failed

### DIFF
--- a/src/app/modules/main/chat_section/chat_content/messages/controller.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/controller.nim
@@ -134,15 +134,6 @@ method init*(self: Controller) =
       return
     self.delegate.onHistoryCleared()
 
-  self.events.on(SignalType.HistoryRequestStarted.event) do(e: Args):
-    self.delegate.setLoadingHistoryMessagesInProgress(true)
-
-  self.events.on(SignalType.HistoryRequestCompleted.event) do(e:Args):
-    self.delegate.setLoadingHistoryMessagesInProgress(false)
-
-  self.events.on(SignalType.HistoryRequestFailed.event) do(e:Args):
-    self.delegate.setLoadingHistoryMessagesInProgress(false)
-
   self.events.on(SIGNAL_MESSAGE_LINK_PREVIEW_DATA_LOADED) do(e: Args):
     let args = LinkPreviewDataArgs(e)
     self.delegate.onPreviewDataLoaded(args.response)

--- a/src/app/modules/main/chat_section/chat_content/messages/controller_interface.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/controller_interface.nim
@@ -108,3 +108,6 @@ method joinGroupChat*(self: AccessInterface) {.base.} =
 
 method leaveChat*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
+
+method setLoadingHistoryMessagesInProgress*(self: AccessInterface, isLoading: bool) {.base.} =
+  raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/chat_section/chat_content/messages/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/module.nim
@@ -225,8 +225,6 @@ method newMessagesLoaded*(self: Module, messages: seq[MessageDto], reactions: se
   if(not self.view.getInitialMessagesLoaded()):
     self.view.initialMessagesAreLoaded()
 
-  self.setLoadingHistoryMessagesInProgress(false)
-
   # check if this loading was caused by the click on a messages from the app search result
   discard self.checkIfMessageLoadedAndScrollToItIfItIs()
 
@@ -286,7 +284,6 @@ method onSendingMessageError*(self: Module) =
   self.view.emitSendingMessageErrorSignal()
 
 method loadMoreMessages*(self: Module) =
-  self.setLoadingHistoryMessagesInProgress(true)
   self.controller.loadMoreMessages()
 
 method toggleReaction*(self: Module, messageId: string, emojiId: int) =
@@ -407,9 +404,6 @@ method updateChatIdentifier*(self: Module) =
   self.view.model().removeItem(CHAT_IDENTIFIER_MESSAGE_ID)
   # Add new loaded messages
   self.view.model().appendItem(self.createChatIdentifierItem())
-
-method setLoadingHistoryMessagesInProgress*(self: Module, isLoading: bool) =
-  self.view.setLoadingHistoryMessagesInProgress(isLoading)
 
 method getLinkPreviewData*(self: Module, link: string, uuid: string): string =
   return self.controller.getLinkPreviewData(link, uuid)

--- a/src/app/modules/main/chat_section/chat_content/messages/private_interfaces/module_controller_delegate_interface.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/private_interfaces/module_controller_delegate_interface.nim
@@ -35,9 +35,6 @@ method updateContactDetails*(self: AccessInterface, contactId: string) {.base.} 
 method onMessageEdited*(self: AccessInterface, message: MessageDto) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method setLoadingHistoryMessagesInProgress*(self: AccessInterface, isLoading: bool) {.base.} =
-  raise newException(ValueError, "No implementation available")
-
 method scrollToMessage*(self: AccessInterface, messageId: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/chat_section/chat_content/messages/view.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/view.nim
@@ -23,7 +23,6 @@ QtObject:
     result.model = newModel()
     result.modelVariant = newQVariant(result.model)
     result.initialMessagesLoaded = false
-    result.loadingHistoryMessagesInProgress = false
 
   proc load*(self: View) =
     self.delegate.viewDidLoad()

--- a/src/app/modules/main/chat_section/controller.nim
+++ b/src/app/modules/main/chat_section/controller.nim
@@ -11,6 +11,7 @@ import ../../../../app_service/service/message/service as message_service
 import ../../../../app_service/service/gif/service as gif_service
 import ../../../../app_service/service/mailservers/service as mailservers_service
 
+import ../../../core/signals/types
 import ../../../core/eventemitter
 
 export controller_interface
@@ -157,6 +158,15 @@ method init*(self: Controller) =
     if (self.sectionId != args.sectionId):
       return
     self.delegate.makeChatWithIdActive(args.chatId)
+
+  self.events.on(SignalType.HistoryRequestStarted.event) do(e: Args):
+    self.delegate.setLoadingHistoryMessagesInProgress(true)
+
+  self.events.on(SignalType.HistoryRequestCompleted.event) do(e:Args):
+    self.delegate.setLoadingHistoryMessagesInProgress(false)
+
+  self.events.on(SignalType.HistoryRequestFailed.event) do(e:Args):
+    discard
 
 method getMySectionId*(self: Controller): string =
   return self.sectionId

--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -688,3 +688,6 @@ method reorderCommunityCategories*(self: Module, categoryId: string, position: i
 
 method reorderCommunityChat*(self: Module, categoryId: string, chatId: string, position: int): string =
   self.controller.reorderCommunityChat(categoryId, chatId, position)
+  
+method setLoadingHistoryMessagesInProgress*(self: Module, isLoading: bool) =
+  self.view.setLoadingHistoryMessagesInProgress(isLoading)

--- a/src/app/modules/main/chat_section/private_interfaces/module_controller_delegate_interface.nim
+++ b/src/app/modules/main/chat_section/private_interfaces/module_controller_delegate_interface.nim
@@ -59,3 +59,6 @@ method onCommunityCategoryDeleted*(self: AccessInterface, category: Category) {.
 
 method onCommunityCategoryEdited*(self: AccessInterface, category: Category, chats: seq[ChatDto]) {.base.} =
   raise newException(ValueError, "No implementation available")
+
+method setLoadingHistoryMessagesInProgress*(self: AccessInterface, isLoading: bool) {.base.} =
+  raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/chat_section/view.nim
+++ b/src/app/modules/main/chat_section/view.nim
@@ -19,7 +19,8 @@ QtObject:
       listOfMyContactsVariant: QVariant
       editCategoryChannelsModel: chats_model.Model
       editCategoryChannelsVariant: QVariant
-
+      loadingHistoryMessagesInProgress: bool 
+      
   proc delete*(self: View) =
     self.model.delete
     self.modelVariant.delete
@@ -47,6 +48,7 @@ QtObject:
     result.contactRequestsModelVariant = newQVariant(result.contactRequestsModel)
     result.listOfMyContacts = contacts_model.newModel()
     result.listOfMyContactsVariant = newQVariant(result.listOfMyContacts)
+    result.loadingHistoryMessagesInProgress = false
 
   proc load*(self: View) =
     self.delegate.viewDidLoad()
@@ -256,3 +258,18 @@ QtObject:
 
   proc reorderCommunityChat*(self: View, categoryId: string, chatId: string, position: int): string {.slot} =
     self.delegate.reorderCommunityChat(categoryId, chatId, position)
+    
+  proc loadingHistoryMessagesInProgressChanged*(self: View) {.signal.}
+
+  proc getLoadingHistoryMessagesInProgress*(self: View): bool {.slot.} =
+    return self.loadingHistoryMessagesInProgress
+  
+  QtProperty[bool] loadingHistoryMessagesInProgress:
+    read = getLoadingHistoryMessagesInProgress
+    notify = loadingHistoryMessagesInProgressChanged
+
+  proc setLoadingHistoryMessagesInProgress*(self: View, value: bool) = # this is not a slot
+    if (value == self.loadingHistoryMessagesInProgress):
+      return
+    self.loadingHistoryMessagesInProgress = value
+    self.loadingHistoryMessagesInProgressChanged()

--- a/ui/app/AppLayouts/Chat/stores/MessageStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/MessageStore.qml
@@ -16,7 +16,8 @@ QtObject {
     function loadMoreMessages () {
         if(!messageModule)
             return
-        if(!messageModule.initialMessagesLoaded || messageModule.loadingHistoryMessagesInProgress)
+
+        if(!messageModule.initialMessagesLoaded || chatCommunitySectionModule.loadingHistoryMessagesInProgress)
             return
 
         messageModule.loadMoreMessages()

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -26,6 +26,8 @@ QtObject {
     // Contact requests related part
     property var contactRequestsModel: chatCommunitySectionModule.contactRequestsModel
 
+    property var loadingHistoryMessagesInProgress: chatCommunitySectionModule.loadingHistoryMessagesInProgress
+
     function setActiveCommunity(communityId) {
         mainModule.setActiveSectionById(communityId);
     }

--- a/ui/app/AppLayouts/Chat/views/ChatContentView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatContentView.qml
@@ -372,7 +372,7 @@ ColumnLayout {
 
             Loader {
                 id: loadingMessagesIndicator
-                active: messageStore.messageModule? messageStore.messageModule.loadingHistoryMessagesInProgress : false
+                active: chatContentRoot.rootStore.loadingHistoryMessagesInProgress
                 sourceComponent: LoadingAnimation { }
                 anchors {
                     right: parent.right

--- a/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
@@ -68,14 +68,14 @@ Item {
 
     Item {
         id: loadingMessagesIndicator
-        visible: messageStore.messageModule? messageStore.messageModule.loadingHistoryMessagesInProgress : false
+        visible: root.store.loadingHistoryMessagesInProgress
         anchors.top: parent.top
         anchors.left: parent.left
         height: visible? 20 : 0
         width: parent.width
 
         Loader {
-            active: messageStore.messageModule? messageStore.messageModule.loadingHistoryMessagesInProgress : false
+            active: root.store.loadingHistoryMessagesInProgress
             anchors.horizontalCenter: parent.horizontalCenter
             anchors.verticalCenter: parent.verticalCenter
             sourceComponent: Component {


### PR DESCRIPTION
I also moved the loading indicator code in nim one level up because it applies to all chats, not only to the current active chat.
Fixes #4733
