### PR TITLE
ci: drop unused BUILD_TYPE, add useful RELEASE param

### DIFF
--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -16,6 +16,11 @@ pipeline {
       description: 'Decides whether binaries are built with debug symbols.',
       defaultValue: params.RELEASE ?: false
     )
+    choice(
+      name: 'VERBOSE',
+      description: 'Level of verbosity based on nimbus-build-system setup.',
+      choices: ['0', '1', '2']
+    )
   }
 
   options {
@@ -33,7 +38,7 @@ pipeline {
   environment {
     TARGET = 'linux'
     /* Improve make performance */
-    MAKEFLAGS = '-j4'
+    MAKEFLAGS = "-j4 V=${params.VERBOSE}"
     /* Disable colors in Nim compiler logs */
     NIMFLAGS = '--colors:off'
     /* Makefile assumes the compiler folder is included */

--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -11,10 +11,10 @@ pipeline {
   }
 
   parameters {
-    string(
-      name: 'BUILD_TYPE',
-      description: 'Specify build type. Values: pr / nightly / release',
-      defaultValue: 'pr',
+    booleanParam(
+      name: 'RELEASE',
+      description: 'Decides whether binaries are built with debug symbols.',
+      defaultValue: params.RELEASE ?: false
     )
   }
 

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -11,6 +11,11 @@ pipeline {
       description: 'Decides whether binaries are built with debug symbols.',
       defaultValue: params.RELEASE ?: false
     )
+    choice(
+      name: 'VERBOSE',
+      description: 'Level of verbosity based on nimbus-build-system setup.',
+      choices: ['0', '1', '2']
+    )
   }
 
   options {
@@ -28,7 +33,7 @@ pipeline {
   environment {
     TARGET = 'macos'
     /* Improve make performance */
-    MAKEFLAGS = '-j4'
+    MAKEFLAGS = "-j4 V=${params.VERBOSE}"
     /* Disable colors in Nim compiler logs */
     NIMFLAGS = '--colors:off'
     /* Qt location is pre-defined */

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -6,10 +6,10 @@ pipeline {
   }
 
   parameters {
-    string(
-      name: 'BUILD_TYPE',
-      description: 'Specify build type. Values: pr / nightly / release',
-      defaultValue: 'pr',
+    booleanParam(
+      name: 'RELEASE',
+      description: 'Decides whether binaries are built with debug symbols.',
+      defaultValue: params.RELEASE ?: false
     )
   }
 

--- a/ci/Jenkinsfile.windows
+++ b/ci/Jenkinsfile.windows
@@ -4,10 +4,10 @@ pipeline {
   agent { label 'windows' }
 
   parameters {
-    string(
-      name: 'BUILD_TYPE',
-      description: 'Specify build type. Values: pr / nightly / release',
-      defaultValue: 'pr',
+    booleanParam(
+      name: 'RELEASE',
+      description: 'Decides whether binaries are built with debug symbols.',
+      defaultValue: params.RELEASE ?: false
     )
   }
 

--- a/ci/Jenkinsfile.windows
+++ b/ci/Jenkinsfile.windows
@@ -9,6 +9,11 @@ pipeline {
       description: 'Decides whether binaries are built with debug symbols.',
       defaultValue: params.RELEASE ?: false
     )
+    choice(
+      name: 'VERBOSE',
+      description: 'Level of verbosity based on nimbus-build-system setup.',
+      choices: ['0', '1', '2']
+    )
   }
 
   options {
@@ -26,7 +31,7 @@ pipeline {
   environment {
     TARGET = 'windows'
     /* Improve make performance */
-    MAKEFLAGS = '-j4'
+    MAKEFLAGS = "-j4 V=${params.VERBOSE}"
     /* Disable colors in Nim compiler logs */
     NIMFLAGS = '--colors:off'
     /* Control output the filename */


### PR DESCRIPTION
It appears this was some leftover from ancient times and wasn't being used.

On the other hand the `RELEASE` environment variable controls if Nim builds
of the client binary include debug symbols:
https://github.com/status-im/status-desktop/blob/ba7a6d5d341d273d0a1e48439dd19ae0ded95cfe/Makefile#L177-L184

The shorthand `?:` symbol means that if this is changed for a given job it stays changed.

Thanks to @abhi-status who noticed the confusing inconsistency.

__EDIT:__ Also added `VERBOSE` parameter because it's convenient.