### PR TITLE
fix: [re-add] The text entry box shouldn't highlight invalid @mentions

### DIFF
--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -237,11 +237,19 @@ Rectangle {
 
         isColonPressed = (event.key === Qt.Key_Colon) && (event.modifiers & Qt.ShiftModifier);
 
-        if (event.key === Qt.Key_Space && suggestionsBox.formattedPlainTextFilter.length > 1 && suggestionsBox.formattedPlainTextFilter.trim().split(" ").length === 1) {
-            let aliasName = suggestionsBox.formattedPlainTextFilter
-            let lastCursorPosition = suggestionsBox.suggestionFilter.cursorPosition
-            let lastAtPosition = suggestionsBox.suggestionFilter.lastAtPosition
-            insertMention(aliasName, lastAtPosition, lastCursorPosition)
+        if (suggestionsBox.visible) {
+            let aliasName = suggestionsBox.formattedPlainTextFilter;
+            let lastCursorPosition = suggestionsBox.suggestionFilter.cursorPosition;
+            let lastAtPosition = suggestionsBox.suggestionFilter.lastAtPosition;
+            if (aliasName.toLowerCase() === suggestionsBox.suggestionsModel.get(suggestionsBox.listView.currentIndex).name.toLowerCase()
+                && (event.key !== Qt.Key_Backspace) && (event.key !== Qt.Key_Delete)) {
+                insertMention(aliasName, lastAtPosition, lastCursorPosition);
+            } else if (event.key === Qt.Key_Space) {
+                var plainTextToReplace = messageInputField.getText(lastAtPosition, lastCursorPosition);
+                messageInputField.remove(lastAtPosition, lastCursorPosition);
+                messageInputField.insert(lastAtPosition, plainTextToReplace);
+                suggestionsBox.hide();
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #4678

The text input in chat was highlighting whatever was starting
with @. Fixed to highlight only valid user mentions.

Also fixes an issue where mentioning yourself would make writing text and a space emptied the input