### PR TITLE
fix(mentions): fix showing .eth for normal ENS names in chat

### DIFF
--- a/src/app_service/common/message.nim
+++ b/src/app_service/common/message.nim
@@ -3,7 +3,7 @@ import ../service/contacts/dto/contacts
 
 proc replaceMentionsWithPubKeys*(allKnownContacts: seq[ContactsDto], message: string): string =
   let aliasPattern = re(r"(@[A-z][a-z]+ [A-z][a-z]* [A-z][a-z]*)", flags = {reStudy, reIgnoreCase})
-  let ensPattern = re(r"(@\w+(?=(\.stateofus)?\.eth))", flags = {reStudy, reIgnoreCase})
+  let ensPattern = re(r"(@\w+((\.stateofus)?\.eth))", flags = {reStudy, reIgnoreCase})
   let namePattern = re(r"(@\w+)", flags = {reStudy, reIgnoreCase})
 
   let aliasMentions = findAll(message, aliasPattern)
@@ -15,21 +15,17 @@ proc replaceMentionsWithPubKeys*(allKnownContacts: seq[ContactsDto], message: st
   # in the mentions suggestion list.
   for mention in aliasMentions:
     let listOfMatched = allKnownContacts.filter(x => "@" & x.userNameOrAlias().toLowerAscii == mention.toLowerAscii)
-    echo "EX1: mention: ", mention, "  list: ", repr(listOfMatched)
     if(listOfMatched.len > 0):
       updatedMessage = updatedMessage.replaceWord(mention, '@' & listOfMatched[0].id)
 
   for mention in ensMentions:
-    let listOfMatched = allKnownContacts.filter(x => "@" & x.userNameOrAlias().toLowerAscii == mention.toLowerAscii)
-    echo "EX2: mention: ", mention, "  list: ", repr(listOfMatched)
+    let listOfMatched = allKnownContacts.filter(x => "@" & x.name.toLowerAscii == mention.toLowerAscii)
     if(listOfMatched.len > 0):
       updatedMessage = updatedMessage.replaceWord(mention, '@' & listOfMatched[0].id)
 
   for mention in nameMentions:
     let listOfMatched = allKnownContacts.filter(x => x.userNameOrAlias().toLowerAscii == mention.toLowerAscii or
       "@" & x.userNameOrAlias().toLowerAscii == mention.toLowerAscii)
-    echo "EX3: mention: ", mention, "  list: ", repr(listOfMatched)
     if(listOfMatched.len > 0):
       updatedMessage = updatedMessage.replaceWord(mention, '@' & listOfMatched[0].id)
-
   return updatedMessage

--- a/src/app_service/common/utils.nim
+++ b/src/app_service/common/utils.nim
@@ -2,6 +2,9 @@ import json, random, times, strutils, os
 import nimcrypto
 import signing_phrases
 
+const STATUS_DOMAIN* = ".stateofus.eth"
+const ETH_DOMAIN* = ".eth"
+
 proc hashPassword*(password: string): string =
   result = "0x" & $keccak_256.digest(password)
 
@@ -25,8 +28,10 @@ proc first*(jArray: JsonNode, fieldName, id: string): JsonNode =
       return child
 
 proc prettyEnsName*(ensName: string): string =
-  if ensName.endsWith(".eth"):
+  if ensName.endsWith(STATUS_DOMAIN):
     return "@" & ensName.split(".")[0]
+  elif ensName.endsWith(ETH_DOMAIN):
+    return "@" & ensName
   return ensName
 
 const sep = when defined(windows): "\\" else: "/"

--- a/src/app_service/service/ens/utils.nim
+++ b/src/app_service/service/ens/utils.nim
@@ -10,13 +10,13 @@ import ../eth/dto/contract as eth_contract_dto
 import ../../../backend/eth as status_eth
 import ../../../backend/ens as status_ens
 import ../../common/account_constants
+import ../../common/utils
 
 logScope:
   topics = "ens-utils"
 
 include ../../common/json_utils
 
-const STATUS_DOMAIN* = ".stateofus.eth"
 const ENS_REGISTRY* = "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e"
 const RESOLVER_SIGNATURE* = "0x0178b8bf"
 const CONTENTHASH_SIGNATURE* = "0xbc1c58d1" # contenthash(bytes32)
@@ -40,7 +40,7 @@ type
     UNKNOWN
 
 proc addDomain*(username: string): string =
-  if username.endsWith(".eth"):
+  if username.endsWith(ETH_DOMAIN):
     return username
   else:
     return username & STATUS_DOMAIN


### PR DESCRIPTION
Fixes #3634

As discussed internally, names with `stateofus.eth` will only show `@name`
Names with only `.eth` or other subdomain will show the whole name `@name.eth`
Three word names show as before as well as nicknames.

![image](https://user-images.githubusercontent.com/11926403/153438032-c092794a-d366-4fad-9f23-ea7367a6ca2d.png)
