### PR TITLE
fix: Add a min cmake version for the cpp app

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.18)
 
 project(status-desktop
   VERSION 0.1.0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.20)
 
 project(status-desktop
   VERSION 0.1.0


### PR DESCRIPTION
fix: Add a min cmake version for the cpp app so that the user is prompted to install the latest cmake version instead of getting an ambiguous error