### PR TITLE
fix(Browser) Transaction Popup was misaligned

### DIFF
--- a/ui/app/AppLayouts/Browser/BrowserLayout.qml
+++ b/ui/app/AppLayouts/Browser/BrowserLayout.qml
@@ -56,6 +56,7 @@ Rectangle {
 
         // TODO we'll need a new dialog at one point because this one is not using the same call, but it's good for now
         property Component sendTransactionModalComponent: SignTransactionModal {
+            anchors.centerIn: parent
             store: browserWindow.globalStore
             contactsStore: browserWindow.globalStore.profileSectionStore.contactsStore
         }

--- a/ui/imports/shared/popups/ModalPopup.qml
+++ b/ui/imports/shared/popups/ModalPopup.qml
@@ -70,6 +70,8 @@ Popup {
                 font.bold: true
                 font.pixelSize: 17
                 height: visible ? 24 : 0
+                width: visible ? parent.width - 44 : 0
+                elide: Text.ElideRight
                 visible: !!title
                 verticalAlignment: Text.AlignVCenter
             }


### PR DESCRIPTION
Closes #4361

### What does the PR do
Fixed transaction popup position
Fixed JSDialogWindow title was going off popup boundaries


### Affected areas
Browser, ModalPopup

### Screenshot of functionality
<img width="1282" alt="transfixed" src="https://user-images.githubusercontent.com/31625338/153658953-33ecb1d2-7b3e-4f25-9dc1-1b840cb43900.png">
<img width="1282" alt="jswindow_" src="https://user-images.githubusercontent.com/31625338/153659702-222a402e-f00b-406d-8e15-4816844a2040.png">
<img width="1282" alt="jswindowfixed_" src="https://user-images.githubusercontent.com/31625338/153659823-923143e0-b302-4e5d-914a-89246023d910.png">


### Cool Spaceship Picture
![1509422154](https://user-images.githubusercontent.com/31625338/153658677-5dadfe85-9a54-4cc5-ada8-4edd9f2b4fdb.svg)

