### PR TITLE
fix(search): fix profile popup opened on search title clicked

### DIFF
--- a/src/app/modules/main/app_search/view.nim
+++ b/src/app/modules/main/app_search/view.nim
@@ -7,15 +7,11 @@ QtObject:
     View* = ref object of QObject
       delegate: io_interface.AccessInterface
       searchResultModel: result_model.Model
-      searchResultModelVariant: QVariant
       locationMenuModel: location_menu_model.Model
-      locationMenuModelVariant: QVariant
 
   proc delete*(self: View) =
     self.searchResultModel.delete
-    self.searchResultModelVariant.delete
     self.locationMenuModel.delete
-    self.locationMenuModelVariant.delete
     self.QObject.delete
 
   proc newView*(delegate: io_interface.AccessInterface): View =
@@ -23,9 +19,7 @@ QtObject:
     result.QObject.setup
     result.delegate = delegate
     result.searchResultModel = result_model.newModel()
-    result.searchResultModelVariant = newQVariant(result.searchResultModel)
     result.locationMenuModel = location_menu_model.newModel()
-    result.locationMenuModelVariant = newQVariant(result.locationMenuModel)
 
   proc load*(self: View) =
     self.delegate.viewDidLoad()

--- a/ui/app/AppLayouts/Chat/popups/GroupInfoPopup.qml
+++ b/ui/app/AppLayouts/Chat/popups/GroupInfoPopup.qml
@@ -254,7 +254,7 @@ StatusModal {
                         }
                     }
                 ]
-                onTitleClicked:  {
+                onTitleClicked: {
                     Global.openProfilePopup(model.publicKey, popup)
                 }
             }

--- a/ui/app/AppMain.qml
+++ b/ui/app/AppMain.qml
@@ -197,7 +197,7 @@ Item {
         store: rootStore
     }
 
-    AppSearch{
+    AppSearch {
         id: appSearch
         store: appMain.rootStore.appSearchStore
     }
@@ -695,10 +695,22 @@ Item {
         Action {
             shortcut: "Ctrl+K"
             onTriggered: {
+                // FIXME the focus is no longer on the AppMain when the popup is opened, so this does not work to close
                 if (channelPicker.opened) {
                     channelPicker.close()
                 } else {
                     channelPicker.open()
+                }
+            }
+        }
+        Action {
+            shortcut: "Ctrl+F"
+            onTriggered: {
+                // FIXME the focus is no longer on the AppMain when the popup is opened, so this does not work to close
+                if (appSearch.opened) {
+                    appSearch.closeSearchPopup()
+                } else {
+                    appSearch.openSearchPopup()
                 }
             }
         }

--- a/ui/app/AppSearch.qml
+++ b/ui/app/AppSearch.qml
@@ -11,19 +11,22 @@ Item {
     readonly property var searchMessages: Backpressure.debounce(searchPopup, 400, function (value) {
         appSearch.store.searchMessages(value)
     })
+    property alias opened: searchPopup.opened
 
     function openSearchPopup(){
         searchPopup.open()
     }
 
+    function closeSearchPopup(){
+        searchPopup.close()
+    }
+
     Connections {
         target: appSearch.store.locationMenuModel
         onModelAboutToBeReset: {
-            for (var i = 2; i <= searchPopupMenu.count; i++) {
-                //clear menu
-                if (!!searchPopupMenu.takeItem(i)) {
-                    searchPopupMenu.removeItem(searchPopupMenu.takeItem(i));
-                }
+             while (searchPopupMenu.takeItem(searchPopupMenu.numDefaultItems)) {
+                // Delete the item right after the default items
+                // If takeItem returns null, it means there was nothing to remove
             }
         }
     }
@@ -124,9 +127,9 @@ Item {
             searchPopup.close()
             appSearch.store.resultItemClicked(itemId)
         }
-
-        onResultItemTitleClicked: {
-            return Global.openProfilePopup(titleId)
+        acceptsTitleClick: function (titleId) {
+            return Utils.isChatKey(titleId)
         }
+        onResultItemTitleClicked: Global.openProfilePopup(titleId)
     }
 }


### PR DESCRIPTION
Fixes #4795

Makes sure to only open the profile popup if the click is a pubkey.
Also opens the popup on ctrl+f