### PR TITLE
fix: make mentions work with ensname, alias and nickname

### DIFF
--- a/src/app/modules/main/chat_section/chat_content/users/controller.nim
+++ b/src/app/modules/main/chat_section/chat_content/users/controller.nim
@@ -116,5 +116,8 @@ method getContactNameAndImage*(self: Controller, contactId: string):
   tuple[name: string, image: string, isIdenticon: bool] =
   return self.contactService.getContactNameAndImage(contactId)
 
+method getContactDetails*(self: Controller, contactId: string): ContactDetails =
+  return self.contactService.getContactDetails(contactId)
+
 method getStatusForContact*(self: Controller, contactId: string): StatusUpdateDto =
   return self.contactService.getStatusForContactWithId(contactId)

--- a/src/app/modules/main/chat_section/chat_content/users/controller_interface.nim
+++ b/src/app/modules/main/chat_section/chat_content/users/controller_interface.nim
@@ -21,6 +21,9 @@ method getContactNameAndImage*(self: AccessInterface, contactId: string):
   tuple[name: string, image: string, isIdenticon: bool] {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method getContactDetails*(self: AccessInterface, contactId: string): ContactDetails {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method getStatusForContact*(self: AccessInterface, contactId: string): StatusUpdateDto {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/chat_section/chat_content/users/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/users/module.nim
@@ -55,6 +55,9 @@ method viewDidLoad*(self: Module) =
   self.view.model().addItem(initItem(
     singletonInstance.userProfile.getPubKey(),
     loggedInUserDisplayName,
+    singletonInstance.userProfile.getEnsName(),
+    localNickname = "",
+    alias = singletonInstance.userProfile.getUsername(),
     OnlineStatus.Online,
     singletonInstance.userProfile.getIcon(),
     singletonInstance.userProfile.getIsIdenticon(),
@@ -69,10 +72,21 @@ method viewDidLoad*(self: Module) =
       continue
 
     let (admin, joined) = self.controller.getChatMemberInfo(publicKey)
-    let (name, image, isIdenticon) = self.controller.getContactNameAndImage(publicKey)
+    let contactDetails = self.controller.getContactDetails(publicKey)
     let statusUpdateDto = self.controller.getStatusForContact(publicKey)
     let status = statusUpdateDto.statusType.int.OnlineStatus
-    self.view.model().addItem(initItem(publicKey, name, status, image, isidenticon, admin, joined))
+    self.view.model().addItem(initItem(
+      publicKey,
+      contactDetails.displayName,
+      contactDetails.details.name,
+      contactDetails.details.localNickname,
+      contactDetails.details.alias,
+      status,
+      contactDetails.icon,
+      contactDetails.isidenticon,
+      admin, 
+      joined
+      ))
 
   self.moduleLoaded = true
   self.delegate.usersDidLoad()
@@ -89,14 +103,28 @@ method newMessagesLoaded*(self: Module, messages: seq[MessageDto]) =
     if(self.view.model().isContactWithIdAdded(m.`from`)):
       continue
 
-    let (name, image, isIdenticon) = self.controller.getContactNameAndImage(m.`from`)
+    let contactDetails = self.controller.getContactDetails(m.`from`)
     let statusUpdateDto = self.controller.getStatusForContact(m.`from`)
     let status = statusUpdateDto.statusType.int.OnlineStatus
-    self.view.model().addItem(initItem(m.`from`, name, status, image, isidenticon))
+    self.view.model().addItem(initItem(
+      m.`from`,
+      contactDetails.displayName,
+      contactDetails.details.name,
+      contactDetails.details.localNickname,
+      contactDetails.details.alias,
+      status,
+      contactDetails.icon,
+      contactDetails.isidenticon,
+      ))
 
 method contactNicknameChanged*(self: Module, publicKey: string) =
-  let (name, _, _) = self.controller.getContactNameAndImage(publicKey)
-  self.view.model().setName(publicKey, name)
+  let contactDetails = self.controller.getContactDetails(publicKey)
+  self.view.model().setName(
+    publicKey,
+    contactDetails.displayName,
+    contactDetails.details.name,
+    contactDetails.details.localNickname
+    )
 
 method contactsStatusUpdated*(self: Module, statusUpdates: seq[StatusUpdateDto]) =
   for s in statusUpdates:
@@ -104,8 +132,16 @@ method contactsStatusUpdated*(self: Module, statusUpdates: seq[StatusUpdateDto])
     self.view.model().setOnlineStatus(s.publicKey, status)
 
 method contactUpdated*(self: Module, publicKey: string) =
-  let (name, image, isIdenticon) = self.controller.getContactNameAndImage(publicKey)
-  self.view.model().updateItem(publicKey, name, image, isIdenticon)
+  let contactDetails = self.controller.getContactDetails(publicKey)
+  self.view.model().updateItem(
+    publicKey,
+    contactDetails.displayName,
+    contactDetails.details.name,
+    contactDetails.details.localNickname,
+    contactDetails.details.alias,
+    contactDetails.icon,
+    contactDetails.isidenticon,
+  )
 
 method loggedInUserImageChanged*(self: Module) =
   self.view.model().setIcon(singletonInstance.userProfile.getPubKey(), singletonInstance.userProfile.getIcon(),
@@ -117,14 +153,34 @@ method onChatMembersAdded*(self: Module,  ids: seq[string]) =
       continue
 
     let (admin, joined) = self.controller.getChatMemberInfo(id)
-    let (name, image, isIdenticon) = self.controller.getContactNameAndImage(id)
+    let contactDetails = self.controller.getContactDetails(id)
     let statusUpdateDto = self.controller.getStatusForContact(id)
     let status = statusUpdateDto.statusType.int.OnlineStatus
-    self.view.model().addItem(initItem(id, name, status, image, isidenticon, admin, joined))
+    self.view.model().addItem(initItem(
+      id,
+      contactDetails.displayName,
+      contactDetails.details.name,
+      contactDetails.details.localNickname,
+      contactDetails.details.alias,
+      status,
+      contactDetails.icon,
+      contactDetails.isidenticon,
+      admin, 
+      joined
+      ))
 
 method onChatMemberRemoved*(self: Module, id: string) =
   self.view.model().removeItemById(id)
 
 method onChatMemberUpdated*(self: Module, publicKey: string, admin: bool, joined: bool) =
-  let (name, image, isIdenticon) = self.controller.getContactNameAndImage(publicKey)
-  self.view.model().updateItem(publicKey, name, image, isIdenticon, admin, joined)
+  let contactDetails = self.controller.getContactDetails(publicKey)
+  self.view.model().updateItem(
+    publicKey,
+    contactDetails.displayName,
+    contactDetails.details.name,
+    contactDetails.details.localNickname,
+    contactDetails.details.alias,
+    contactDetails.icon,
+    contactDetails.isidenticon,
+    admin,
+    joined)

--- a/src/app/modules/main/communities/controller.nim
+++ b/src/app/modules/main/communities/controller.nim
@@ -122,6 +122,9 @@ method getContactNameAndImage*(self: Controller, contactId: string):
     tuple[name: string, image: string, isIdenticon: bool] =
   return self.contactsService.getContactNameAndImage(contactId)
 
+method getContactDetails*(self: Controller, contactId: string): ContactDetails =
+  return self.contactsService.getContactDetails(contactId)
+
 method isUserMemberOfCommunity*(self: Controller, communityId: string): bool =
   return self.communityService.isUserMemberOfCommunity(communityId)
 

--- a/src/app/modules/main/communities/controller_interface.nim
+++ b/src/app/modules/main/communities/controller_interface.nim
@@ -1,4 +1,5 @@
 import ../../../../app_service/service/community/service as community_service
+import ../../../../app_service/service/contacts/service as contacts_service
 
 type
   AccessInterface* {.pure inheritable.} = ref object of RootObj
@@ -60,6 +61,9 @@ method setCommunityMuted*(self: AccessInterface, communityId: string, muted: boo
 
 method getContactNameAndImage*(self: AccessInterface, contactId: string):
     tuple[name: string, image: string, isIdenticon: bool] {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method getContactDetails*(self: AccessInterface, contactId: string): ContactDetails {.base.} =
   raise newException(ValueError, "No implementation available")
 
 type

--- a/src/app/modules/main/communities/module.nim
+++ b/src/app/modules/main/communities/module.nim
@@ -89,8 +89,17 @@ method getCommunityItem(self: Module, c: CommunityDto): SectionItem =
       c.permissions.access,
       c.permissions.ensOnly,
       c.members.map(proc(member: Member): user_item.Item =
-        let (name, image, isIdenticon) = self.controller.getContactNameAndImage(member.id)
-        result = user_item.initItem(member.id, name, OnlineStatus.Offline, image, isIdenticon))
+        let contactDetails = self.controller.getContactDetails(member.id)
+        result = user_item.initItem(
+          member.id,
+          contactDetails.displayName,
+          contactDetails.details.name,
+          contactDetails.details.localNickname,
+          contactDetails.details.alias,
+          OnlineStatus.Offline, # TODO get the actual status?
+          contactDetails.icon,
+          contactDetails.isidenticon,
+          ))
     )
 
 method setAllCommunities*(self: Module, communities: seq[CommunityDto]) =

--- a/src/app/modules/main/controller.nim
+++ b/src/app/modules/main/controller.nim
@@ -247,6 +247,9 @@ method getContactNameAndImage*(self: Controller, contactId: string):
   tuple[name: string, image: string, isIdenticon: bool] =
   return self.contactsService.getContactNameAndImage(contactId)
 
+method getContactDetails*(self: Controller, contactId: string): ContactDetails =
+  return self.contactsService.getContactDetails(contactId)
+
 method resolveENS*(self: Controller, ensName: string, uuid: string = "") =
   self.contactsService.resolveENS(ensName, uuid)
 

--- a/src/app/modules/main/controller_interface.nim
+++ b/src/app/modules/main/controller_interface.nim
@@ -1,4 +1,5 @@
 import ../shared_models/section_item
+import ../../../app_service/service/contacts/dto/contact_details as contact_details
 import ../../../app_service/service/contacts/dto/contacts as contacts_dto
 import ../../../app_service/service/community/service as community_service
 
@@ -42,6 +43,9 @@ method getContact*(self: AccessInterface, id: string): ContactsDto {.base.} =
 
 method getContactNameAndImage*(self: AccessInterface, contactId: string):
   tuple[name: string, image: string, isIdenticon: bool] {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method getContactDetails*(self: AccessInterface, contactId: string): ContactDetails {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method resolveENS*(self: AccessInterface, ensName: string, uuid: string = "") {.base.} =

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -190,8 +190,17 @@ proc createCommunityItem[T](self: Module[T], c: CommunityDto): SectionItem =
     c.permissions.access,
     c.permissions.ensOnly,
     c.members.map(proc(member: Member): user_item.Item =
-      let (name, image, isIdenticon) = self.controller.getContactNameAndImage(member.id)
-      result = user_item.initItem(member.id, name, OnlineStatus.Offline, image, isIdenticon)),
+      let contactDetails = self.controller.getContactDetails(member.id)
+      result = user_item.initItem(
+        member.id,
+        contactDetails.displayName,
+        contactDetails.details.name,
+        contactDetails.details.localNickname,
+        contactDetails.details.alias,
+        OnlineStatus.Offline,
+        contactDetails.icon,
+        contactDetails.isidenticon,
+        )),
     c.pendingRequestsToJoin.map(x => pending_request_item.initItem(
       x.id,
       x.publicKey,
@@ -634,8 +643,16 @@ method resolvedENS*[T](self: Module[T], publicKey: string, address: string, uuid
   self.view.emitResolvedENSSignal(publicKey, address, uuid)
 
 method contactUpdated*[T](self: Module[T], publicKey: string) =
-  let (name, image, isIdenticon) = self.controller.getContactNameAndImage(publicKey)
-  self.view.activeSection().updateMember(publicKey, name, image, isIdenticon)
+  let contactDetails = self.controller.getContactDetails(publicKey)
+  self.view.activeSection().updateMember(
+    publicKey,
+    contactDetails.displayName,
+    contactDetails.details.name,
+    contactDetails.details.localNickname,
+    contactDetails.details.alias,
+    contactDetails.icon,
+    contactDetails.isidenticon,
+    )
 
 method calculateProfileSectionHasNotification*[T](self: Module[T]): bool =
   return not self.controller.isMnemonicBackedUp()

--- a/src/app/modules/shared_models/active_section.nim
+++ b/src/app/modules/shared_models/active_section.nim
@@ -136,9 +136,12 @@ QtObject:
       self: ActiveSection,
       pubkey: string,
       name: string,
+      ensName: string,
+      localNickname: string,
+      alias: string,
       image: string,
       isIdenticon: bool) =
-    self.item.updateMember(pubkey, name, image, isIdenticon)
+    self.item.updateMember(pubkey, name, ensName, localNickname, alias, image, isIdenticon)
 
   proc pendingRequestsToJoin(self: ActiveSection): QVariant {.slot.} =
     if (self.item.id == ""):

--- a/src/app/modules/shared_models/section_item.nim
+++ b/src/app/modules/shared_models/section_item.nim
@@ -189,9 +189,12 @@ proc updateMember*(
     self: SectionItem,
     pubkey: string,
     name: string,
+    ensName: string,
+    nickname: string,
+    alias: string,
     image: string,
     isIdenticon: bool) =
-  self.membersModel.updateItem(pubkey, name, image, isIdenticon)
+  self.membersModel.updateItem(pubkey, name, ensName, nickname, alias, image, isIdenticon)
 
 proc pendingRequestsToJoin*(self: SectionItem): PendingRequestModel {.inline.} =
   self.pendingRequestsToJoinModel

--- a/src/app/modules/shared_models/user_item.nim
+++ b/src/app/modules/shared_models/user_item.nim
@@ -12,7 +12,10 @@ type
 type
   Item* = ref object
     id: string
-    name: string
+    displayName: string
+    ensName: string
+    localNickname: string
+    alias: string
     onlineStatus: OnlineStatus
     icon: string
     isIdenticon: bool
@@ -21,7 +24,10 @@ type
 
 proc initItem*(
   id: string,
-  name: string,
+  displayName: string,
+  ensName: string,
+  localNickname: string,
+  alias: string,
   onlineStatus: OnlineStatus,
   icon: string,
   isidenticon: bool,
@@ -30,7 +36,10 @@ proc initItem*(
 ): Item =
   result = Item()
   result.id = id
-  result.name = name
+  result.displayName = displayName
+  result.ensName = ensName
+  result.localNickname = localNickname
+  result.alias = alias
   result.onlineStatus = onlineStatus
   result.icon = icon
   result.isIdenticon = isidenticon
@@ -40,7 +49,9 @@ proc initItem*(
 proc `$`*(self: Item): string =
   result = fmt"""User Item(
     id: {self.id},
-    name: {self.name},
+    displayName: {self.displayName},
+    localNickname: {self.localNickname},
+    alias: {self.alias},
     onlineStatus: {$self.onlineStatus.int},
     icon: {self.icon},
     isIdenticon: {$self.isIdenticon}
@@ -52,10 +63,28 @@ proc id*(self: Item): string {.inline.} =
   self.id
 
 proc name*(self: Item): string {.inline.} =
-  self.name
+  self.displayName
 
 proc `name=`*(self: Item, value: string) {.inline.} =
-  self.name = value
+  self.displayName = value
+
+proc ensName*(self: Item): string {.inline.} =
+  self.ensName
+
+proc `ensName=`*(self: Item, value: string) {.inline.} =
+  self.ensName = value
+
+proc localNickname*(self: Item): string {.inline.} =
+  self.localNickname
+
+proc `localNickname=`*(self: Item, value: string) {.inline.} =
+  self.localNickname = value
+
+proc alias*(self: Item): string {.inline.} =
+  self.alias
+
+proc `alias=`*(self: Item, value: string) {.inline.} =
+  self.alias = value
 
 proc onlineStatus*(self: Item): OnlineStatus {.inline.} =
   self.onlineStatus

--- a/src/app/modules/shared_models/user_model.nim
+++ b/src/app/modules/shared_models/user_model.nim
@@ -6,6 +6,9 @@ type
   ModelRole {.pure.} = enum
     Id = UserRole + 1
     Name
+    EnsName
+    Nickname
+    Alias
     OnlineStatus
     Icon
     IsIdenticon
@@ -54,6 +57,9 @@ QtObject:
     {
       ModelRole.Id.int:"id",
       ModelRole.Name.int:"name",
+      ModelRole.EnsName.int:"ensName",
+      ModelRole.Nickname.int:"nickname",
+      ModelRole.Alias.int:"alias",
       ModelRole.OnlineStatus.int:"onlineStatus",
       ModelRole.Icon.int:"icon",
       ModelRole.IsIdenticon.int:"isIdenticon",
@@ -76,6 +82,12 @@ QtObject:
       result = newQVariant(item.id)
     of ModelRole.Name:
       result = newQVariant(item.name)
+    of ModelRole.EnsName:
+      result = newQVariant(item.ensName)
+    of ModelRole.Nickname:
+      result = newQVariant(item.localNickname)
+    of ModelRole.Alias:
+      result = newQVariant(item.alias)
     of ModelRole.OnlineStatus:
       result = newQVariant(item.onlineStatus.int)
     of ModelRole.Icon:
@@ -127,15 +139,21 @@ QtObject:
   proc isContactWithIdAdded*(self: Model, id: string): bool =
     return self.findIndexForMessageId(id) != -1
 
-  proc setName*(self: Model, id: string, name: string) =
+  proc setName*(self: Model, id: string, name: string, ensName: string, nickname: string) =
     let ind = self.findIndexForMessageId(id)
     if(ind == -1):
       return
 
     self.items[ind].name = name
+    self.items[ind].ensName = ensName
+    self.items[ind].localNickname = nickname
 
     let index = self.createIndex(ind, 0, nil)
-    self.dataChanged(index, index, @[ModelRole.Name.int])
+    self.dataChanged(index, index, @[
+      ModelRole.Name.int,
+      ModelRole.EnsName.int,
+      ModelRole.Nickname.int,
+      ])
 
   proc setIcon*(self: Model, id: string, icon: string, isIdenticon: bool) =
     let ind = self.findIndexForMessageId(id)
@@ -149,14 +167,25 @@ QtObject:
     self.dataChanged(index, index, @[ModelRole.Icon.int, ModelRole.IsIdenticon.int])
 
   proc updateItem*(
-    self: Model, id: string, name: string, icon: string, isIdenticon: bool,
-    isAdmin: bool = false, joined: bool = false
-  ) =
+      self: Model,
+      id: string,
+      name: string,
+      ensName: string,
+      localNickname: string,
+      alias: string,
+      icon: string,
+      isIdenticon: bool,
+      isAdmin: bool = false,
+      joined: bool = false
+      ) =
     let ind = self.findIndexForMessageId(id)
     if(ind == -1):
       return
 
     self.items[ind].name = name
+    self.items[ind].ensName = ensName
+    self.items[ind].localNickname = localNickname
+    self.items[ind].alias = alias
     self.items[ind].icon = icon
     self.items[ind].isIdenticon = isIdenticon
     self.items[ind].isAdmin = isAdmin
@@ -164,7 +193,14 @@ QtObject:
 
     let index = self.createIndex(ind, 0, nil)
     self.dataChanged(index, index, @[
-      ModelRole.Name.int, ModelRole.Icon.int, ModelRole.IsIdenticon.int, ModelRole.IsAdmin.int, ModelRole.Joined.int,
+      ModelRole.Name.int,
+      ModelRole.EnsName.int,
+      ModelRole.Nickname.int,
+      ModelRole.Alias.int,
+      ModelRole.Icon.int,
+      ModelRole.IsIdenticon.int,
+      ModelRole.IsAdmin.int,
+      ModelRole.Joined.int,
     ])
 
   proc setOnlineStatus*(self: Model, id: string, onlineStatus: OnlineStatus) =

--- a/ui/app/AppLayouts/Chat/panels/SuggestionFilterPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/SuggestionFilterPanel.qml
@@ -29,6 +29,9 @@ Item {
         delegate: Item {
             property string publicKey: model.id
             property string name: model.name
+            property string nickname: model.nickname
+            property string alias: model.alias
+            property string ensName: model.ensName
             property string icon: model.icon
             property bool isIdenticon: model.isIdenticon
         }
@@ -65,6 +68,9 @@ Item {
             const item = {
                 publicKey: listItem.publicKey,
                 name: listItem.name,
+                nickname: listItem.nickname,
+                alias: listItem.alias,
+                ensName: listItem.ensName,
                 icon: listItem.icon,
                 isIdenticon: listItem.isIdenticon
             }

--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -644,7 +644,7 @@ Rectangle {
         width: messageInput.width
         filter: messageInputField.text
         cursorPosition: messageInputField.cursorPosition
-        property: ["name"]
+        property: ["name", "nickname", "ensName", "alias"]
         onItemSelected: function (item, lastAtPosition, lastCursorPosition) {
             let name = item.name.replace("@", "")
             insertMention(name, lastAtPosition, lastCursorPosition)


### PR DESCRIPTION
Fixes #3707

I upgraded the item and model to contain the ensname, nickname and alias. That way the filter can check any of those when searching the mention