### PR TITLE
Fix duplicate channels on community signals for edits and category changes (implements all category signal)

### DIFF
--- a/src/app/modules/main/chat_section/controller.nim
+++ b/src/app/modules/main/chat_section/controller.nim
@@ -136,10 +136,20 @@ method init*(self: Controller) =
       if (args.communityId == self.sectionId):
         self.delegate.onCommunityCategoryEdited(args.category, args.chats)
 
+    self.events.on(SIGNAL_COMMUNITY_CATEGORY_REORDERED) do(e:Args):
+      let args = CommunityChatOrderArgs(e)
+      if (args.communityId == self.sectionId):
+        self.delegate.onReorderChatOrCategory(args.categoryId, args.position)
+
+    self.events.on(SIGNAL_COMMUNITY_CATEGORY_NAME_EDITED) do(e:Args):
+      let args = CommunityCategoryArgs(e)
+      if (args.communityId == self.sectionId):
+        self.delegate.onCategoryNameChanged(args.category)
+
     self.events.on(SIGNAL_COMMUNITY_CHANNEL_REORDERED) do(e:Args):
       let args = CommunityChatOrderArgs(e)
       if (args.communityId == self.sectionId):
-        self.delegate.reorderChannels(args.chatId, args.categoryId, args.position)
+        self.delegate.onReorderChatOrCategory(args.chatId, args.position)
 
   self.events.on(SIGNAL_CONTACT_NICKNAME_CHANGED) do(e: Args):
     var args = ContactArgs(e)

--- a/src/app/modules/main/chat_section/model.nim
+++ b/src/app/modules/main/chat_section/model.nim
@@ -304,8 +304,8 @@ QtObject:
       result.notificationsCount = result.notificationsCount + self.items[i].BaseItem.notificationsCount
 
 
-  proc reorder*(self: Model, chatId, categoryId: string, position: int) =
-    let index = self.getItemIdxById(chatId)
+  proc reorder*(self: Model, chatOrCategoryId: string, position: int) =
+    let index = self.getItemIdxById(chatOrCategoryId)
     if(index == -1):
       return
 

--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -745,13 +745,14 @@ method addChatIfDontExist*(self: Module,
     gifService: gif_service.Service,
     mailserversService: mailservers_service.Service,
     setChatAsActive: bool = true) =
-  
-    if(belongsToCommunity and self.controller.getMySectionId() != chat.communityId or
-      not belongsToCommunity and self.controller.getMySectionId() != conf.CHAT_SECTION_ID):
-      return
 
-    if self.doesChatExist(chat.id):
-      return
+  let sectionId = self.controller.getMySectionId()
+  if(belongsToCommunity and sectionId != chat.communityId or
+    not belongsToCommunity and sectionId != conf.CHAT_SECTION_ID):
+    return
+
+  if self.doesChatExist(chat.id):
+    return
       
-    self.addNewChat(chat, belongsToCommunity, events, settingsService, contactService, chatService,
-      communityService, messageService, gifService, mailserversService, setChatAsActive)
+  self.addNewChat(chat, belongsToCommunity, events, settingsService, contactService, chatService,
+    communityService, messageService, gifService, mailserversService, setChatAsActive)

--- a/src/app/modules/main/chat_section/private_interfaces/module_controller_delegate_interface.nim
+++ b/src/app/modules/main/chat_section/private_interfaces/module_controller_delegate_interface.nim
@@ -11,7 +11,10 @@ method addNewChat*(self: AccessInterface, chatDto: ChatDto, belongsToCommunity: 
   mailserversService: mailservers_service.Service, setChatAsActive: bool = true) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method doesChatExist*(self: AccessInterface, chatId: string): bool {.base.} =
+method doesCatOrChatExist*(self: AccessInterface, chatId: string): bool {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method doesTopLevelChatExist*(self: AccessInterface, chatId: string): bool {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method addChatIfDontExist*(self: AccessInterface,
@@ -65,7 +68,7 @@ method onChatRenamed*(self: AccessInterface, chatId: string, newName: string) {.
 method onCommunityChannelEdited*(self: AccessInterface, chat: ChatDto) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method reorderChannels*(self: AccessInterface, chatId, categoryId: string, position: int) {.base.} =
+method onReorderChatOrCategory*(self: AccessInterface, chatOrCatId: string, position: int) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method onCommunityCategoryCreated*(self: AccessInterface, category: Category, chats: seq[ChatDto]) {.base.} =
@@ -75,6 +78,9 @@ method onCommunityCategoryDeleted*(self: AccessInterface, category: Category) {.
   raise newException(ValueError, "No implementation available")
 
 method onCommunityCategoryEdited*(self: AccessInterface, category: Category, chats: seq[ChatDto]) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method onCategoryNameChanged*(self: AccessInterface, category: Category) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method setLoadingHistoryMessagesInProgress*(self: AccessInterface, isLoading: bool) {.base.} =

--- a/src/app/modules/main/chat_section/sub_model.nim
+++ b/src/app/modules/main/chat_section/sub_model.nim
@@ -215,15 +215,25 @@ QtObject:
         return true
     return false
 
+  proc getItemIdxById*(self: SubModel, id: string): int =
+    var idx = 0
+    for it in self.items:
+      if(it.id == id):
+        return idx
+      idx.inc
+    return -1
+
   proc removeItemById*(self: SubModel, id: string) =
-    for i in 0 ..< self.items.len:
-      if(self.items[i].id == id):
-        let parentModelIndex = newQModelIndex()
-        defer: parentModelIndex.delete
-        self.beginRemoveRows(parentModelIndex, i, i)
-        self.items.delete(i)
-        self.endRemoveRows()
-        self.countChanged()
+    let idx = self.getItemIdxById(id)
+    if idx == -1:
+      return
+
+    let parentModelIndex = newQModelIndex()
+    defer: parentModelIndex.delete
+    self.beginRemoveRows(parentModelIndex, idx, idx)
+    self.items.delete(idx)
+    self.endRemoveRows()
+    self.countChanged()
 
   proc updateNotificationsForItemById*(self: SubModel, id: string, hasUnreadMessages: bool,
     notificationsCount: int): bool =

--- a/src/app_service/service/chat/dto/chat.nim
+++ b/src/app_service/service/chat/dto/chat.nim
@@ -100,6 +100,8 @@ proc toChatDto*(jsonObj: JsonNode): ChatDto =
   discard jsonObj.getProp("alias", result.alias)
   discard jsonObj.getProp("identicon", result.identicon)
   discard jsonObj.getProp("muted", result.muted)
+  discard jsonObj.getProp("categoryId", result.categoryId)
+  discard jsonObj.getProp("position", result.position)
   discard jsonObj.getProp("communityId", result.communityId)
   discard jsonObj.getProp("profile", result.profile)
   discard jsonObj.getProp("joined", result.joined)

--- a/src/app_service/service/community/service.nim
+++ b/src/app_service/service/community/service.nim
@@ -626,6 +626,18 @@ QtObject:
       if response.result.isNil or response.result.kind == JNull:
         error "response is invalid", methodName="editCommunityChannel"
 
+      var chatsJArr: JsonNode
+      if(not response.result.getProp("chats", chatsJArr)):
+        raise newException(RpcException, fmt"editCommunityChannel; there is no `chats` key in the response for community id: {communityId}")
+
+      for chatObj in chatsJArr:
+        var chatDto = chatObj.toChatDto()
+
+        self.chatService.updateOrAddChat(chatDto) # we have to update chats stored in the chat service.
+
+        let data = CommunityChatArgs(chat: chatDto)
+        self.events.emit(SIGNAL_COMMUNITY_CHANNEL_EDITED, data)
+
     except Exception as e:
       error "Error editing community channel", msg = e.msg, communityId, channelId, methodName="editCommunityChannel"
 

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -178,12 +178,17 @@ QtObject {
         chatCommunitySectionModule.createCommunityChannel(channelName, channelDescription, categoryId);
     }
 
-    function editCommunityChannel(communityId, channelId, channelName, channelDescription, channelCategoryId, popupPosition) {
+    function editCommunityChannel(chatId, newName, newDescription, newCategory, channelPosition) {
         // TODO: pass the private value when private channels
         // are implemented
         //privateSwitch.checked)
-        // Not Refactored Yet
-//        chatsModelInst.editCommunityChannel(communityId, channelId, channelName, channelDescription, channelCategoryId, popupPosition);
+        chatCommunitySectionModule.editCommunityChannel(
+                    chatId,
+                    newName,
+                    newDescription,
+                    newCategory,
+                    channelPosition
+                )
     }
 
     function acceptRequestToJoinCommunity(requestId) {

--- a/ui/app/AppLayouts/Chat/views/ChatContentView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatContentView.qml
@@ -172,6 +172,7 @@ ColumnLayout {
                 chatDescription = chatContentModule.chatDetails.description
                 chatType = chatContentModule.chatDetails.type
                 chatMuted = chatContentModule.chatDetails.muted
+                channelPosition = chatContentModule.chatDetails.position
             }
 
             onMuteChat: {
@@ -233,6 +234,16 @@ ColumnLayout {
                                      chatContentModule: chatContentModule,
                                      chatDetails: chatContentModule.chatDetails
                                  })
+            }
+
+            onEditCommunityChannel: {
+                root.rootStore.editCommunityChannel(
+                    chatId,
+                    newName,
+                    newDescription,
+                    newCategory,
+                    channelPosition // TODO change this to the signal once it is modifiable
+                )
             }
         }
     }


### PR DESCRIPTION
Fixes #4859, #4858, #4865, #4753

The problem was that signals were received with chat updates, but we didn't check the communityId correctly, and also we didn't check if the chat wasn't added yet.

This also implements the community category signal handling, making it possible to update the categories and chats within it when updating from another device. It also fixes issues of duplication when doing that.