### PR TITLE
fix(@dekstop/chat): higher cpu usage after opening gif selector

### DIFF
--- a/src/app/modules/main/chat_section/chat_content/messages/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/module.nim
@@ -342,6 +342,12 @@ method onPinMessage*(self: Module, messageId: string, actionInitiatedBy: string)
 method onUnpinMessage*(self: Module, messageId: string) =
   self.view.model().pinUnpinMessage(messageId, false, "")
 
+method getSectionId*(self: Module): string =
+  return self.controller.getMySectionId()
+
+method getChatId*(self: Module): string =
+  return self.controller.getMyChatId()
+
 method getChatType*(self: Module): int =
   let chatDto = self.controller.getChatDetails()
   return chatDto.chatType.int

--- a/src/app/modules/main/chat_section/chat_content/messages/private_interfaces/module_view_delegate_interface.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/private_interfaces/module_view_delegate_interface.nim
@@ -10,6 +10,12 @@ method toggleReaction*(self: AccessInterface, messageId: string, emojiId: int) {
 method pinUnpinMessage*(self: AccessInterface, messageId: string, pin: bool) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method getSectionId*(self: AccessInterface): string {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method getChatId*(self: AccessInterface): string {.base.} =
+  raise newException(ValueError, "No implementation available")
+  
 method getChatType*(self: AccessInterface): int {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/chat_section/chat_content/messages/view.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/view.nim
@@ -56,6 +56,12 @@ QtObject:
       return ""
     return $jsonObj
 
+  proc getSectionId*(self: View): string {.slot.} =
+    return self.delegate.getSectionId()
+
+  proc getChatId*(self: View): string {.slot.} =
+    return self.delegate.getChatId()
+    
   proc getChatType*(self: View): int {.slot.} =
     return self.delegate.getChatType()
 

--- a/ui/app/AppLayouts/Chat/ChatLayout.qml
+++ b/ui/app/AppLayouts/Chat/ChatLayout.qml
@@ -28,12 +28,9 @@ StatusAppThreePanelLayout {
     property var contactsStore
     property bool hasAddedContacts: root.contactsStore.myContactsModel.count > 0
 
-    // Not Refactored
-   property var messageStore
-
-   property RootStore rootStore: RootStore {
-      contactsStore: root.contactsStore
-   }
+    property RootStore rootStore: RootStore {
+        contactsStore: root.contactsStore
+    }
 
     property Component pinnedMessagesListPopupComponent
     property bool stickersLoaded: false

--- a/ui/app/AppLayouts/Chat/stores/MessageStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/MessageStore.qml
@@ -6,6 +6,9 @@ QtObject {
 
     property var messageModule
     property var messagesModel
+    property var chatSectionModule
+
+    property var loadingHistoryMessagesInProgress: root.chatSectionModule? root.chatSectionModule.loadingHistoryMessagesInProgress : false
 
     onMessageModuleChanged: {
         if(!messageModule)
@@ -17,7 +20,8 @@ QtObject {
         if(!messageModule)
             return
 
-        if(!messageModule.initialMessagesLoaded || chatCommunitySectionModule.loadingHistoryMessagesInProgress)
+        if(!messageModule.initialMessagesLoaded ||
+            root.loadingHistoryMessagesInProgress? root.loadingHistoryMessagesInProgress : false)
             return
 
         messageModule.loadMoreMessages()
@@ -57,6 +61,20 @@ QtObject {
         }
 
         return obj
+    }
+
+    function getSectionId () {
+        if(!messageModule)
+            return ""
+
+        return messageModule.getSectionId()
+    }
+
+    function getChatId () {
+        if(!messageModule)
+            return ""
+
+        return messageModule.getChatId()
     }
 
     function getChatType () {
@@ -223,5 +241,24 @@ QtObject {
          if(!messageModule)
             return true
         return messageModule.didIJoinedChat();
+    }
+
+    property bool playAnimation: {
+        if(!Global.applicationWindow.active)
+            return false
+
+        if(root.getSectionId() !== mainModule.activeSection.id)
+            return false
+
+        if(!root.chatSectionModule)
+            return false
+
+        if(root.chatSectionModule.activeItem.isSubItemActive &&
+                root.getChatId() !== root.chatSectionModule.activeItem.activeSubItem.id ||
+                !root.chatSectionModule.activeItem.isSubItemActive &&
+                root.getChatId() !== root.chatSectionModule.activeItem.id)
+            return false
+
+        return true
     }
 }

--- a/ui/app/AppLayouts/Chat/views/ChatContentView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatContentView.qml
@@ -290,6 +290,7 @@ ColumnLayout {
     MessageStore {
         id: messageStore
         messageModule: chatContentModule? chatContentModule.messagesModule : null
+        chatSectionModule: chatContentRoot.rootStore.chatCommunitySectionModule
     }
 
     MessageContextMenuView {

--- a/ui/imports/shared/panels/chat/ChatReplyPanel.qml
+++ b/ui/imports/shared/panels/chat/ChatReplyPanel.qml
@@ -131,6 +131,7 @@ Loader {
                 chatHorizontalPadding: 0
                 container: root.container
                 allCornersRounded: true
+                playing: false
             }
 
             Loader {

--- a/ui/imports/shared/status/StatusChatImageLoader.qml
+++ b/ui/imports/shared/status/StatusChatImageLoader.qml
@@ -21,23 +21,12 @@ Item {
     width: loadingImageLoader.active ? loadingImageLoader.width : imageMessage.width
     height: loadingImageLoader.active ? loadingImageLoader.height : imageMessage.paintedHeight
 
-    Connections {
-        target: Global.applicationWindow
-        onActiveChanged: {
-            if (Global.applicationWindow.active === false) {
-                imageMessage.playing = false
-            } else {
-                imageMessage.playing = Qt.binding(function () {return imageContainer.playing})
-            }
-        }
-    }
-
     AnimatedImage {
         id: imageMessage
         width: sourceSize.width > imageWidth ? imageWidth : sourceSize.width
         fillMode: Image.PreserveAspectFit
         source: imageContainer.source
-        playing: isAnimated
+        playing: imageContainer.isAnimated && imageContainer.playing
 
         layer.enabled: true
         layer.effect: OpacityMask {
@@ -77,12 +66,6 @@ Item {
             acceptedButtons: Qt.LeftButton | Qt.RightButton
             anchors.fill: parent
             onClicked: {
-                if (imageContainer.isAnimated) {
-                    // FIXME the ListView completely removes Items that scroll out of view
-                    // so when we scroll backto the image, it gets reloaded and playing is reset
-                    imageContainer.playing = !imageContainer.playing
-                    return
-                }
                 imageContainer.clicked(imageMessage, mouse)
             }
         }

--- a/ui/imports/shared/status/StatusChatInputReplyArea.qml
+++ b/ui/imports/shared/status/StatusChatInputReplyArea.qml
@@ -80,6 +80,7 @@ Rectangle {
         chatHorizontalPadding: 0
         container: root.container
         visible: root.contentType === Constants.messageContentType.imageType
+        playing: false
     }
 
     StatusSticker {

--- a/ui/imports/shared/status/StatusGifPopup.qml
+++ b/ui/imports/shared/status/StatusGifPopup.qml
@@ -152,6 +152,8 @@ Popup {
         }
 
         Loader {
+            id: gifsLoader
+            active: popup.opened
             Layout.fillWidth: true
             Layout.rightMargin: Style.current.smallPadding / 2
             Layout.leftMargin: Style.current.smallPadding / 2

--- a/ui/imports/shared/views/chat/CompactMessageView.qml
+++ b/ui/imports/shared/views/chat/CompactMessageView.qml
@@ -512,6 +512,7 @@ Item {
                 z: 51
                 sourceComponent: Component {
                     StatusChatImage {
+                        playing: root.messageStore.playAnimation
                         imageSource: messageImage
                         imageWidth: 200
                         onClicked: {

--- a/ui/imports/shared/views/chat/LinksMessageView.qml
+++ b/ui/imports/shared/views/chat/LinksMessageView.qml
@@ -222,7 +222,8 @@ Column {
                 source: linkData.thumbnailUrl
                 imageWidth: 300
                 isCurrentUser: root.isCurrentUser
-                onClicked: imageClick(linkImage.imageAlias)
+                onClicked: imageClicked(linkImage.imageAlias)
+                playing: root.messageStore.playAnimation
             }
         }
     }
@@ -253,6 +254,7 @@ Column {
                 anchors.horizontalCenter: parent.horizontalCenter
                 anchors.top: parent.top
                 anchors.topMargin: 1
+                playing: root.messageStore.playAnimation
             }
             StatusBaseText {
                 id: linkTitle

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -316,6 +316,7 @@ Column {
     Component {
         id: statusUpdateComponent
         StatusUpdateView {
+            messageStore: root.messageStore
             statusAgeEpoch: root.statusAgeEpoch
             container: root
             // Not Refactored Yet
@@ -348,6 +349,7 @@ Column {
         id: compactMessageComponent
 
         CompactMessageView {
+            container: root
             store: root.store
             messageStore: root.messageStore
             usersStore: root.usersStore

--- a/ui/imports/shared/views/chat/StatusUpdateView.qml
+++ b/ui/imports/shared/views/chat/StatusUpdateView.qml
@@ -14,6 +14,7 @@ import StatusQ.Controls 0.1
 MouseArea {
     id: root
 //    property var store
+    property var messageStore
     property bool hovered: containsMouse
     property var container
     property int statusAgeEpoch: 0
@@ -125,6 +126,7 @@ MouseArea {
 
             sourceComponent: Component {
                 StatusChatImage {
+                    playing: root.messageStore.playAnimation
                     imageSource: image
                     imageWidth: 200
                     container: root.container


### PR DESCRIPTION
If there are more chats containing gifs, only gifs displayed in the active chat will be playing and that will be only if the app is active, in case the app is not the active window all gifs will be paused.

Gif panel is now unloaded once it gets closed, so there are no placed gifs any more once we close gif panel.

Another improvement we can do here is to pause gifs if they go out of the visible area of the list view, but for that I am not fully sure if we can do it well with the current qml structure, but maybe we should try. But also I think that ListView unloads delegates if they go out of visible area (not completely sure).

Fixes #4829 