### PR TITLE
fix(groups): fix first message of group chats not appearing

### DIFF
--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -80,8 +80,11 @@ Column {
     property string outgoingStatus: messageOutgoingStatus
     property string authorCurrentMsg: senderId
     property string authorPrevMsg: {
-        if(!prevMessageAsJsonObj)
+        if(!prevMessageAsJsonObj ||
+            // The system message for private groups appear as created by the group host, but it shouldn't
+            prevMessageAsJsonObj.contentType === Constants.messageContentType.systemMessagePrivateGroupType) {
             return ""
+        }  
 
         return prevMessageAsJsonObj.senderId
     }


### PR DESCRIPTION
Fixes #4852

The problem happened when the admin wrote first, because the system text saying "X invited Y to the group" was counted as being made by the host, even though it's not really. 
Since we have a condition that hides the image and username of the message if the user wrote twice, or more, in a row, in a short period of time, then in this case, the name and image didn't appear, because the code considered the last message to be made by the same user.