### PR TITLE
fix(@dekstop/chat): dogfooding_3 crash

### DIFF
--- a/src/app/modules/main/chat_section/controller.nim
+++ b/src/app/modules/main/chat_section/controller.nim
@@ -97,26 +97,19 @@ method init*(self: Controller) =
 
   self.events.on(SIGNAL_CHAT_UPDATE) do(e: Args):
     var args = ChatUpdateArgsNew(e)
-    self.delegate.addChatIfDontExist(args.chats, false, self.events, self.settingsService, self.contactService, self.chatService,
-        self.communityService, self.messageService, self.gifService, self.mailserversService, setChatAsActive = false)
-
+    for chat in args.chats:
+      let belongsToCommunity = chat.communityId.len > 0
+      self.delegate.addChatIfDontExist(chat, belongsToCommunity, self.events, self.settingsService, 
+        self.contactService, self.chatService, self.communityService, self.messageService, self.gifService, 
+        self.mailserversService, setChatAsActive = false)
 
   if (self.isCommunitySection):
     self.events.on(SIGNAL_COMMUNITY_CHANNEL_CREATED) do(e:Args):
       let args = CommunityChatArgs(e)
-      if (args.chat.communityId == self.sectionId):
-        self.delegate.addNewChat(
-          args.chat,
-          true,
-          self.events,
-          self.settingsService,
-          self.contactService,
-          self.chatService,
-          self.communityService,
-          self.messageService,
-          self.gifService,
-          self.mailserversService
-        )
+      let belongsToCommunity = args.chat.communityId.len > 0
+      self.delegate.addChatIfDontExist(args.chat, belongsToCommunity, self.events, self.settingsService, 
+        self.contactService, self.chatService, self.communityService, self.messageService, self.gifService, 
+        self.mailserversService, setChatAsActive = true)
 
     self.events.on(SIGNAL_COMMUNITY_CHANNEL_DELETED) do(e:Args):
       let args = CommunityChatIdArgs(e)

--- a/src/app/modules/main/chat_section/private_interfaces/module_controller_delegate_interface.nim
+++ b/src/app/modules/main/chat_section/private_interfaces/module_controller_delegate_interface.nim
@@ -15,7 +15,7 @@ method doesChatExist*(self: AccessInterface, chatId: string): bool {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method addChatIfDontExist*(self: AccessInterface,
-    chats: seq[ChatDto],
+    chat: ChatDto,
     belongsToCommunity: bool,
     events: EventEmitter,
     settingsService: settings_service.ServiceInterface,


### PR DESCRIPTION
A crash happened here because of wrong chat filtering most likely. At this moment adding new channel to one of community adds it twice and also add it to all other communities as well as to the Chat section. When that comes to chat section module of a certain community and `addNewChat` proc need to be executed for a channel which has `categoryId` set but a category with that id is not added to that community, we didn't have check if item is `nil` and that's the main reason of a crash.

Now the code is slightly updated that all chats/channels changes are being just ignored by the chat section module if they don't belong to it.

Fixes #4827 