### PR TITLE
fix(@dekstop/chat): trying to unblock a contact by hitting 'Unblock' via the chat view does not do anything

### DIFF
--- a/src/app/modules/main/chat_section/chat_content/controller.nim
+++ b/src/app/modules/main/chat_section/chat_content/controller.nim
@@ -160,6 +160,9 @@ method muteChat*(self: Controller) =
 method unmuteChat*(self: Controller) =
   self.chatService.unmuteChat(self.chatId)
 
+method unblockChat*(self: Controller) =
+  self.contactService.unblockContact(self.chatId)
+
 method markAllMessagesRead*(self: Controller) =
   self.messageService.markAllMessagesRead(self.chatId)
 

--- a/src/app/modules/main/chat_section/chat_content/controller_interface.nim
+++ b/src/app/modules/main/chat_section/chat_content/controller_interface.nim
@@ -50,6 +50,9 @@ method muteChat*(self: AccessInterface) {.base.} =
 method unmuteChat*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method unblockChat*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method markAllMessagesRead*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
@@ -77,5 +80,5 @@ method decodeContentHash*(self: AccessInterface, hash: string): string {.base.} 
 method getTransactionDetails*(self: AccessInterface, message: MessageDto): (string,string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method getWalletAccounts*(self: AccessInterface): seq[WalletAccountDto] =
+method getWalletAccounts*(self: AccessInterface): seq[WalletAccountDto] {.base.} =
   raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/chat_section/chat_content/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/module.nim
@@ -238,6 +238,9 @@ method muteChat*(self: Module) =
 method unmuteChat*(self: Module) =
   self.controller.unmuteChat()
 
+method unblockChat*(self: Module) =
+  self.controller.unblockChat()
+
 method markAllMessagesRead*(self: Module) =
   self.controller.markAllMessagesRead()
 

--- a/src/app/modules/main/chat_section/chat_content/private_interfaces/module_view_delegate_interface.nim
+++ b/src/app/modules/main/chat_section/chat_content/private_interfaces/module_view_delegate_interface.nim
@@ -27,6 +27,9 @@ method muteChat*(self: AccessInterface) {.base.} =
 method unmuteChat*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method unblockChat*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method markAllMessagesRead*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/chat_section/chat_content/view.nim
+++ b/src/app/modules/main/chat_section/chat_content/view.nim
@@ -43,28 +43,21 @@ QtObject:
 
   proc getInputAreaModule(self: View): QVariant {.slot.} =
     return self.delegate.getInputAreaModule()
-
   QtProperty[QVariant] inputAreaModule:
     read = getInputAreaModule
 
-
   proc getMessagesModule(self: View): QVariant {.slot.} =
     return self.delegate.getMessagesModule()
-
   QtProperty[QVariant] messagesModule:
     read = getMessagesModule
 
-
   proc getUsersModule(self: View): QVariant {.slot.} =
     return self.delegate.getUsersModule()
-
   QtProperty[QVariant] usersModule:
     read = getUsersModule
 
-
   proc getPinnedMessagesModel(self: View): QVariant {.slot.} =
     return self.pinnedMessagesModelVariant
-
   QtProperty[QVariant] pinnedMessagesModel:
     read = getPinnedMessagesModel
 
@@ -82,6 +75,9 @@ QtObject:
 
   proc unmuteChat*(self: View) {.slot.} =
     self.delegate.unmuteChat()
+
+  proc unblockChat*(self: View): string {.slot.} =
+    self.delegate.unblockChat()
 
   proc markAllMessagesRead*(self: View) {.slot.} =
     self.delegate.markAllMessagesRead()

--- a/ui/app/AppLayouts/Chat/views/ChatContentView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatContentView.qml
@@ -353,6 +353,7 @@ ColumnLayout {
             messageStore: messageStore
             usersStore: chatContentRoot.usersStore
             stickersLoaded: chatContentRoot.stickersLoaded
+            isChatBlocked: chatContentRoot.isBlocked
             onShowReplyArea: {
                 let obj = messageStore.getMessageByIdAsJson(messageId)
                 if (!obj) {
@@ -462,6 +463,10 @@ ColumnLayout {
                         chatInput.textInput.textFormat = TextEdit.PlainText;
                         chatInput.textInput.textFormat = TextEdit.RichText;
                     }
+                }
+
+                onUnblockChat: {
+                    chatContentModule.unblockChat()
                 }
             }
         }

--- a/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
@@ -28,6 +28,7 @@ Item {
 
     property bool stickersLoaded: false
     property alias chatLogView: chatLogView
+    property bool isChatBlocked: false
 
     property var messageContextMenuInst
 
@@ -244,6 +245,7 @@ Item {
             usersStore: root.usersStore
             contactsStore: root.contactsStore
 
+            isChatBlocked: root.isChatBlocked
             messageContextMenu: messageContextMenuInst
 
             messageId: model.id

--- a/ui/imports/shared/panels/chat/ChatButtonsPanel.qml
+++ b/ui/imports/shared/panels/chat/ChatButtonsPanel.qml
@@ -8,6 +8,7 @@ import utils 1.0
 Rectangle {
     id: buttonsContainer
     property bool parentIsHovered: false
+    property bool isChatBlocked: false
     property int containerMargin: 2
     property int contentType: 2
     property bool isCurrentUser: false
@@ -24,7 +25,8 @@ Rectangle {
     signal setMessageActive(string messageId, bool active)
     signal clickMessage(bool isProfileClick, bool isSticker, bool isImage, var image, bool emojiOnly, bool hideEmojiPicker)
 
-    visible: !buttonsContainer.placeholderMsg && !buttonsContainer.activityCenterMsg &&
+    visible: !buttonsContainer.isChatBlocked &&
+             !buttonsContainer.placeholderMsg && !buttonsContainer.activityCenterMsg &&
              (buttonsContainer.parentIsHovered || isMessageActive)
              && contentType !== Constants.messageContentType.transactionType
     width: buttonRow.width + buttonsContainer.containerMargin * 2

--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -27,6 +27,7 @@ Rectangle {
     signal receiveTransactionCommandButtonClicked()
     signal stickerSelected(string hashId, string packId)
     signal sendMessage(var event)
+    signal unblockChat()
 
     property var usersStore
 
@@ -1159,8 +1160,7 @@ Rectangle {
         text: qsTr("Unblock")
         type: StatusQ.StatusBaseButton.Type.Danger
         onClicked: function (event) {
-        // Not Refactored Yet
-//            RootStore.contactsModuleInst.unblockContact(RootStore.chatsModelInst.channelView.activeChannel.id)
+            control.unblockChat()
         }
     }
 }

--- a/ui/imports/shared/views/chat/CompactMessageView.qml
+++ b/ui/imports/shared/views/chat/CompactMessageView.qml
@@ -22,6 +22,7 @@ Item {
     property var messageContextMenu
     property var container
     property int contentType
+    property bool isChatBlocked: false
 
     property int chatHorizontalPadding: Style.current.halfPadding
     property int chatVerticalPadding: 7
@@ -78,7 +79,7 @@ Item {
     }
 
     MessageMouseArea {
-        enabled: !placeholderMessage && !isImage
+        enabled: !root.isChatBlocked && !placeholderMessage && !isImage
         anchors.fill: messageContainer
         acceptedButtons: activityCenterMessage ? Qt.LeftButton : Qt.RightButton
         messageContextMenu: root.messageContextMenu
@@ -95,6 +96,7 @@ Item {
     ChatButtonsPanel {
         contentType: messageContentType
         parentIsHovered: !editModeOn && isHovered
+        isChatBlocked: root.isChatBlocked
         onHoverChanged: {
             hovered && setHovered(messageId, hovered)
         }
@@ -569,6 +571,7 @@ Item {
                 id: messageMouseArea
                 anchors.fill: stickerLoader.active ? stickerLoader : chatText
                 z: activityCenterMessage ? chatText.z + 1 : chatText.z -1
+                enabled: !root.isChatBlocked && !placeholderMessage
                 messageContextMenu: root.messageContextMenu
                 messageContextMenuParent: root
                 isHovered: root.isHovered
@@ -710,6 +713,8 @@ Item {
                 isMessageActive: isMessageActive
                 isCurrentUser: root.amISender
                 onAddEmojiClicked: {
+                    if(root.isChatBlocked)
+                        return
                     root.addEmoji(false, false, false, null, true, false);
                     // Set parent, X & Y positions for the messageContextMenu
                     root.messageContextMenu.parent = emojiReactionLoader
@@ -718,6 +723,9 @@ Item {
                 }
 
                 onToggleReaction: {
+                    if(root.isChatBlocked)
+                        return
+
                     if(!root.messageStore)
                     {
                         console.error("reaction cannot be toggled, message store is not valid")

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -23,6 +23,10 @@ Column {
     property var contactsStore
     property var messageContextMenu
 
+    // Once we redo qml we will know all section/chat related details in each message form the parent components
+    // without an explicit need to fetch those details via message store/module.
+    property bool isChatBlocked: false
+
     property string messageId: ""
     property string responseToMessageWithId: ""
     property string senderId: ""
@@ -359,6 +363,7 @@ Column {
             contactsStore: root.contactsStore
             messageContextMenu: root.messageContextMenu
             contentType: root.messageContentType
+            isChatBlocked: root.isChatBlocked
 
             stickersLoaded: root.stickersLoaded
             sticker: root.sticker


### PR DESCRIPTION
Apart that `Unblock` option form the chat view is working now, I disabled context menus on messages in case 1:1 chat is blocked (leaded by logic that it's a bit weird to edit message or add reaction or delete a message if you blocked someone). If that's not a desirable behaviour, let me know and I will revert that part.

Fixes #4835 