### PR TITLE
fix(@desktop/wallet): Sign transaction accepts incorrect password

### DIFF
--- a/src/app_service/service/eth/dto/method_dto.nim
+++ b/src/app_service/service/eth/dto/method_dto.nim
@@ -93,7 +93,8 @@ proc send*(self: MethodDto, tx: var TransactionDataDto, methodDescriptor: object
   tx.data = self.encodeAbi(methodDescriptor)
   # this call should not be part of this file, we need to move it to appropriate place, or this should not be a DTO class.
   let response = status_eth.sendTransaction($(%tx), password)
-  return response.result.getStr
+  success = response.error.isNil
+  return $response
 
 proc call[T](self: MethodDto, tx: var TransactionDataDto, methodDescriptor: object, success: var bool): T =
   success = true

--- a/src/app_service/service/transaction/service.nim
+++ b/src/app_service/service/transaction/service.nim
@@ -277,13 +277,14 @@ QtObject:
 
       let json: JsonNode = %tx
       let response = eth.sendTransaction($json, password)
-      if response.error != nil:
-        raise newException(Exception, response.error.message)
+      # only till it is moved to another thred
+      # if response.error != nil:
+      #   raise newException(Exception, response.error.message)
 
-      let output = %* { "result": %response.result.getStr,  "success": %(response.error == nil), "uuid": %uuid }
+      let output = %* { "result": %($response),  "success": %(response.error.isNil), "uuid": %uuid }
       self.events.emit(SIGNAL_TRANSACTION_SENT, TransactionSentArgs(result: $output))
 
-      self.trackPendingTransaction(response.result.getStr, from_addr, to_addr,
+      self.trackPendingTransaction($response, from_addr, to_addr,
         $PendingTransactionTypeDto.WalletTransfer, data = "")
     except Exception as e:
       error "Error sending eth transfer transaction", msg = e.msg

--- a/ui/imports/shared/popups/SendModal.qml
+++ b/ui/imports/shared/popups/SendModal.qml
@@ -64,23 +64,12 @@ ModalPopup {
                         stack.uuid)
         }
 
-        if(!success){
-            //% "Invalid transaction parameters"
-            sendingError.text = qsTrId("invalid-transaction-parameters")
-            sendingError.open()
-        } else {
-            // TODO remove this else once the thread and connection are back
-            stack.currentGroup.isPending = false
-            //% "Transaction pending..."
-            Global.toastMessage.title = qsTrId("ens-transaction-pending")
-            Global.toastMessage.source = Style.svg("loading")
-            Global.toastMessage.iconColor = Style.current.primary
-            Global.toastMessage.iconRotates = true
-            // Refactor this
-            // Global.toastMessage.link = `${walletModel.utilsView.etherscanLink}/${response.result}`
-            Global.toastMessage.open()
-            root.close()
-        }
+        // Till the method is moved to thread this is handled by a signal to which connection is made in the end of the file
+//        if(!success){
+//            //% "Invalid transaction parameters"
+//            sendingError.text = qsTrId("invalid-transaction-parameters")
+//            sendingError.open()
+//        }
     }
 
     TransactionStackView {
@@ -302,39 +291,38 @@ ModalPopup {
         }
 
         // Not Refactored Yet
-//        Connections {
-//            target: RootStore.walletModelInst.transactionsView
-//            onTransactionWasSent: {
-//                try {
-//                    let response = JSON.parse(txResult)
+        Connections {
+            target: root.store.walletSectionTransactionsInst
+            onTransactionSent: {
+                try {
+                    let response = JSON.parse(txResult)
+                    if (response.uuid !== stack.uuid) return
 
-//                    if (response.uuid !== stack.uuid) return
+                    stack.currentGroup.isPending = false
 
-//                    stack.currentGroup.isPending = false
+                    if (!response.success) {
+                        if (Utils.isInvalidPasswordMessage(response.result)){
+                            //% "Wrong password"
+                            transactionSigner.validationError = qsTrId("wrong-password")
+                            return
+                        }
+                        sendingError.text = response.result
+                        return sendingError.open()
+                    }
 
-//                    if (!response.success) {
-//                        if (Utils.isInvalidPasswordMessage(response.result)){
-//                            //% "Wrong password"
-//                            transactionSigner.validationError = qsTrId("wrong-password")
-//                            return
-//                        }
-//                        sendingError.text = response.result
-//                        return sendingError.open()
-//                    }
-
-
-                    //% "Transaction pending..."
-//                    Global.toastMessage.title = qsTrId("ens-transaction-pending")
-//                    Global.toastMessage.source = Style.svg("loading")
-//                    Global.toastMessage.iconColor = Style.current.primary
-//                    Global.toastMessage.iconRotates = true
+                    // % "Transaction pending..."
+                    Global.toastMessage.title = qsTrId("ens-transaction-pending")
+                    Global.toastMessage.source = Style.svg("loading")
+                    Global.toastMessage.iconColor = Style.current.primary
+                    Global.toastMessage.iconRotates = true
+                    // Refactor this
 //                    Global.toastMessage.link = `${walletModel.utilsView.etherscanLink}/${response.result}`
-//                    Global.toastMessage.open()
-//                    root.close()
-//                } catch (e) {
-//                    console.error('Error parsing the response', e)
-//                }
-//            }
+                    Global.toastMessage.open()
+                    root.close()
+                } catch (e) {
+                    console.error('Error parsing the response', e)
+                }
+            }
 //            onTransactionCompleted: {
 //                if (success) {
 //                    //% "Transaction completed"
@@ -350,7 +338,7 @@ ModalPopup {
 //                Global.toastMessage.link = `${walletModel.utilsView.etherscanLink}/${txHash}`
 //                Global.toastMessage.open()
 //            }
-//        }
+        }
     }
 }
 

--- a/ui/imports/shared/popups/SignTransactionModal.qml
+++ b/ui/imports/shared/popups/SignTransactionModal.qml
@@ -30,6 +30,7 @@ StatusModal {
     property var selectedFiatAmount
     property var selectedType: RecipientSelector.Type.Address
     property bool outgoing: true
+    property bool isARequest: false
     property string msgId: ""
     property string trxData: ""
 
@@ -63,23 +64,12 @@ StatusModal {
                         stack.uuid)
         }
 
-        if(!success){
-            //% "Invalid transaction parameters"
-            sendingError.text = qsTrId("invalid-transaction-parameters")
-            sendingError.open()
-        } else {
-            // TODO remove this else once the thread and connection are back
-            stack.currentGroup.isPending = false
-            //% "Transaction pending..."
-            Global.toastMessage.title = qsTrId("ens-transaction-pending")
-            Global.toastMessage.source = Style.svg("loading")
-            Global.toastMessage.iconColor = Style.current.primary
-            Global.toastMessage.iconRotates = true
-            // Refactor this
-            // Global.toastMessage.link = `${walletModel.utilsView.etherscanLink}/${response.result}`
-            Global.toastMessage.open()
-            root.close()
-        }
+        // TODO remove this else once the thread and connection are back
+//        if(!success){
+//            //% "Invalid transaction parameters"
+//            sendingError.text = qsTrId("invalid-transaction-parameters")
+//            sendingError.open()
+//        }
     }
 
     property MessageDialog sendingError: MessageDialog {
@@ -354,6 +344,8 @@ StatusModal {
                 if (response.uuid !== stack.uuid)
                     return
 
+                stack.currentGroup.isPending = false
+
                 let transactionId = response.result
 
                 if (!response.success) {
@@ -365,7 +357,19 @@ StatusModal {
                     sendingError.text = transactionId
                     return sendingError.open()
                 }
-                root.store.acceptRequestTransaction(transactionId, msgId, root.store.getPubkey() + transactionId.substr(2))
+
+                if(isARequest)
+                    root.store.acceptRequestTransaction(transactionId, msgId, root.store.getPubkey() + transactionId.substr(2))
+
+                //% "Transaction pending..."
+                Global.toastMessage.title = qsTrId("ens-transaction-pending")
+                Global.toastMessage.source = Style.svg("loading")
+                Global.toastMessage.iconColor = Style.current.primary
+                Global.toastMessage.iconRotates = true
+                // Refactor this
+                // Global.toastMessage.link = `${walletModel.utilsView.etherscanLink}/${response.result}`
+                Global.toastMessage.open()
+
                 root.close()
             } catch (e) {
                 console.error('Error parsing the response', e)

--- a/ui/imports/shared/views/chat/AcceptTransactionView.qml
+++ b/ui/imports/shared/views/chat/AcceptTransactionView.qml
@@ -104,6 +104,7 @@ Item {
             store: root.store
             contactsStore: root.contactsStore
             msgId: messageId
+            isARequest: true
             onOpened: root.store.fetchGasPrice()
             onClosed: destroy()
             onOpenGasEstimateErrorPopup: {


### PR DESCRIPTION
Async methods for send transaction is not impolemented yet and this is a fix until the proper flow is implemented.
Also resolves the same issue observed in chat section.

fixes #4821

### What does the PR do

This fix emits a transaction sent event with the error when calling the send api from status_go to represent any error observed when sending a transaction.

### Affected areas

Wallet, Chat

### Screenshot of functionality

https://user-images.githubusercontent.com/60327365/155593694-fd609619-fbc7-442e-a3b5-d2e4db975037.mov


