### PR TITLE
fix(@dekstop/chat): timestamp for `Fetch messages` is wrong

### DIFF
--- a/src/app/modules/main/chat_section/chat_content/messages/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/module.nim
@@ -215,6 +215,10 @@ method newMessagesLoaded*(self: Module, messages: seq[MessageDto], reactions: se
       if m.editedAt != 0:
         item.isEdited = true
 
+      if(m.contentType.ContentType == ContentType.Gap):
+        item.gapFrom = m.gapParameters.`from`
+        item.gapTo = m.gapParameters.to
+
       # messages are sorted from the most recent to the least recent one
       viewItems.add(item)
 

--- a/src/app/modules/shared_models/message_item.nim
+++ b/src/app/modules/shared_models/message_item.nim
@@ -84,6 +84,8 @@ proc initItem*(
   result.isEdited = false
   result.links = links
   result.transactionParameters = transactionParameters
+  result.gapFrom = 0
+  result.gapTo = 0
 
 proc `$`*(self: Item): string =
   result = fmt"""Item(
@@ -265,4 +267,15 @@ proc isEdited*(self: Item): bool {.inline.} =
 proc `isEdited=`*(self: Item, value: bool) {.inline.} =
   self.isEdited = value
 
+proc gapFrom*(self: Item): int64 {.inline.} =
+  self.gapFrom
+
+proc `gapFrom=`*(self: Item, value: int64) {.inline.} =
+  self.gapFrom = value
+
+proc gapTo*(self: Item): int64 {.inline.} =
+  self.gapTo
+
+proc `gapTo=`*(self: Item, value: int64) {.inline.} =
+  self.gapTo = value
 

--- a/src/app/modules/shared_models/message_model.nim
+++ b/src/app/modules/shared_models/message_model.nim
@@ -24,8 +24,8 @@ type
     MessageType
     Sticker
     StickerPack
-    # GapFrom
-    # GapTo
+    GapFrom
+    GapTo
     Pinned
     PinnedBy
     Reactions
@@ -94,8 +94,8 @@ QtObject:
       ModelRole.MessageType.int:"messageType",
       ModelRole.Sticker.int:"sticker",
       ModelRole.StickerPack.int:"stickerPack",
-      # ModelRole.GapFrom.int:"gapFrom",
-      # ModelRole.GapTo.int:"gapTo",
+      ModelRole.GapFrom.int:"gapFrom",
+      ModelRole.GapTo.int:"gapTo",
       ModelRole.Pinned.int:"pinned",
       ModelRole.PinnedBy.int:"pinnedBy",
       ModelRole.Reactions.int:"reactions",
@@ -154,10 +154,10 @@ QtObject:
       result = newQVariant(item.sticker)
     of ModelRole.StickerPack:
       result = newQVariant(item.stickerPack)
-    # of ModelRole.GapFrom:
-    #   result = newQVariant(item.gapFrom)
-    # of ModelRole.GapTo:
-    #   result = newQVariant(item.gapTo)
+    of ModelRole.GapFrom:
+      result = newQVariant(item.gapFrom)
+    of ModelRole.GapTo:
+      result = newQVariant(item.gapTo)
     of ModelRole.Pinned:
       result = newQVariant(item.pinned)
     of ModelRole.PinnedBy:

--- a/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
@@ -272,6 +272,9 @@ Item {
             linkUrls: model.links
             transactionParams: model.transactionParameters
 
+            gapFrom: model.gapFrom
+            gapTo: model.gapTo
+
             // This is possible since we have all data loaded before we load qml.
             // When we fetch messages to fulfill a gap we have to set them at once.
             // Also one important thing here is that messages are set in descending order

--- a/ui/imports/shared/controls/chat/GapComponent.qml
+++ b/ui/imports/shared/controls/chat/GapComponent.qml
@@ -5,10 +5,16 @@ import utils 1.0
 
 Item {
     id: root
+
+    property int gapFrom: 0
+    property int gapTo: 0
+
+    signal clicked()
+
     height: childrenRect.height + Style.current.smallPadding * 2
     anchors.left: parent.left
     anchors.right: parent.right
-    signal clicked()
+
     Separator {
         id: sep1
     }
@@ -35,9 +41,11 @@ Item {
         anchors.top: fetchMoreButton.bottom
         anchors.topMargin: 3
         anchors.horizontalCenter: parent.horizontalCenter
+        width: parent.width
+        wrapMode: Text.WordWrap
         horizontalAlignment: Text.AlignHCenter
         color: Style.current.secondaryText
-        text: qsTrId("between--1-and--2").arg(new Date(gapFrom * 1000)).arg(new Date(gapTo * 1000))
+        text: qsTrId("between--1-and--2").arg(new Date(root.gapFrom * 1000)).arg(new Date(root.gapTo * 1000))
     }
     Separator {
         anchors.top: fetchDate.bottom

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -48,6 +48,9 @@ Column {
     property bool isInPinnedPopup: false // The pinned popup limits the number of buttons shown
     property var transactionParams
 
+    property int gapFrom: 0
+    property int gapTo: 0
+
     property int prevMessageIndex: -1
     property var prevMessageAsJsonObj
     property int nextMessageIndex: -1
@@ -118,8 +121,6 @@ Column {
     property bool activityCenterMessage: false
     property bool read: true
     property bool forceHoverHandler: false // Used to force the HoverHandler to be active (useful for messages in popups)
-    property int gapFrom: 0
-    property int gapTo: 0
     property string replaces: ""
     property bool isEdited: false
     property bool stickersLoaded: false
@@ -255,6 +256,8 @@ Column {
     Component {
         id: gapComponent
         GapComponent {
+            gapFrom: root.gapFrom
+            gapTo: root.gapTo
             onClicked: {
                 messageStore.fillGaps(messageId)
                 root.visible = false;


### PR DESCRIPTION
Issue with wrong timestamp is fixed and another UI issue is fixed also where to long text of the `Fetch messages` message was cut and its ends were not visible if you reduce the app with, now it is displayed as multiline text in that case.
 
Fixes #4850