### PR TITLE
refactor: re-hook disconnected and re-connected signals and banner

### DIFF
--- a/src/app/modules/main/controller.nim
+++ b/src/app/modules/main/controller.nim
@@ -15,6 +15,7 @@ import ../../../app_service/service/message/service as message_service
 import ../../../app_service/service/gif/service as gif_service
 import ../../../app_service/service/mailservers/service as mailservers_service
 import ../../../app_service/service/privacy/service as privacy_service
+import ../../../app_service/service/node/service as node_service
 
 export controller_interface
 
@@ -35,6 +36,7 @@ type
     gifService: gif_service.Service
     privacyService: privacy_service.Service
     mailserversService: mailservers_service.Service
+    nodeService: node_service.Service
     activeSectionId: string
 
 proc newController*(delegate: io_interface.AccessInterface,
@@ -48,7 +50,8 @@ proc newController*(delegate: io_interface.AccessInterface,
   messageService: message_service.Service,
   gifService: gif_service.Service,
   privacyService: privacy_service.Service,
-  mailserversService: mailservers_service.Service
+  mailserversService: mailservers_service.Service,
+  nodeService: node_service.Service
 ):
   Controller =
   result = Controller()
@@ -63,7 +66,7 @@ proc newController*(delegate: io_interface.AccessInterface,
   result.messageService = messageService
   result.gifService = gifService
   result.privacyService = privacyService
-  result.mailserversService = mailserversService
+  result.nodeService = nodeService
 
 method delete*(self: Controller) =
   discard
@@ -177,6 +180,15 @@ method init*(self: Controller) =
   self.events.on(SIGNAL_NEW_REQUEST_TO_JOIN_COMMUNITY) do(e: Args):
     var args = CommunityRequestArgs(e)
     self.delegate.newCommunityMembershipRequestReceived(args.communityRequest)  
+
+  self.events.on(SIGNAL_NETWORK_CONNECTED) do(e: Args):
+    self.delegate.onNetworkConnected()  
+
+  self.events.on(SIGNAL_NETWORK_DISCONNECTED) do(e: Args):
+    self.delegate.onNetworkDisconnected()  
+
+method isConnected*(self: Controller): bool =
+  return self.nodeService.isConnected()
 
 method getJoinedCommunities*(self: Controller): seq[CommunityDto] =
   return self.communityService.getJoinedCommunities()

--- a/src/app/modules/main/controller_interface.nim
+++ b/src/app/modules/main/controller_interface.nim
@@ -62,3 +62,6 @@ method switchTo*(self: AccessInterface, sectionId, chatId, messageId: string) {.
 
 method getCommunityById*(self: AccessInterface, communityId: string): CommunityDto {.base.} =
   raise newException(ValueError, "No implementation available")
+
+method isConnected*(self: AccessInterface): bool {.base.} =
+  raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -125,7 +125,8 @@ proc newModule*[T](
     messageService,
     gifService,
     privacyService,
-    mailserversService
+    mailserversService,
+    nodeService
   )
   result.moduleLoaded = false
 
@@ -549,6 +550,15 @@ method onActiveChatChange*[T](self: Module[T], sectionId: string, chatId: string
 method onNotificationsUpdated[T](self: Module[T], sectionId: string, sectionHasUnreadMessages: bool,
   sectionNotificationCount: int) =
   self.view.model().udpateNotifications(sectionId, sectionHasUnreadMessages, sectionNotificationCount)
+
+method onNetworkConnected[T](self: Module[T]) =
+  self.view.setConnected(true)
+
+method onNetworkDisconnected[T](self: Module[T]) =
+  self.view.setConnected(false)
+
+method isConnected[T](self: Module[T]): bool =
+  self.controller.isConnected()
 
 method getAppSearchModule*[T](self: Module[T]): QVariant =
   self.appSearchModule.getModuleAsVariant()

--- a/src/app/modules/main/private_interfaces/module_controller_delegate_interface.nim
+++ b/src/app/modules/main/private_interfaces/module_controller_delegate_interface.nim
@@ -47,3 +47,9 @@ method osNotificationClicked*(self: AccessInterface, details: NotificationDetail
 method newCommunityMembershipRequestReceived*(self: AccessInterface, membershipRequest: CommunityMembershipRequestDto) 
   {.base.} =
   raise newException(ValueError, "No implementation available")
+
+method onNetworkConnected*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method onNetworkDisconnected*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/private_interfaces/module_view_delegate_interface.nim
+++ b/src/app/modules/main/private_interfaces/module_view_delegate_interface.nim
@@ -34,3 +34,6 @@ method rebuildChatSearchModel*(self: AccessInterface) {.base.} =
 
 method switchTo*(self: AccessInterface, sectionId, chatId: string) {.base.} =
   raise newException(ValueError, "No implementation available")
+
+method isConnected*(self: AccessInterface): bool {.base.} =
+  raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/view.nim
+++ b/src/app/modules/main/view.nim
@@ -165,3 +165,15 @@ QtObject:
   proc openCommunityMembershipRequestsPopup*(self: View, sectionId: string) {.signal.}
   proc emitOpenCommunityMembershipRequestsPopupSignal*(self: View, sectionId: string) =
     self.openCommunityMembershipRequestsPopup(sectionId)
+
+  proc onlineStatusChanged(self: View, connected: bool) {.signal.}
+
+  proc isConnected*(self: View): bool {.slot.} =
+    result = self.delegate.isConnected()
+
+  proc setConnected*(self: View, connected: bool) = # Not a slot
+    self.onlineStatusChanged(connected)
+
+  QtProperty[bool] isOnline:
+    read = isConnected
+    notify = onlineStatusChanged

--- a/src/app_service/service/node/service.nim
+++ b/src/app_service/service/node/service.nim
@@ -96,3 +96,5 @@ QtObject:
         self.peers = peers
 
     proc peerCount*(self: Service): int = self.peers.len
+
+    proc isConnected*(self: Service): bool = self.connected

--- a/ui/app/AppLayouts/Chat/views/ChatContentView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatContentView.qml
@@ -268,27 +268,26 @@ ColumnLayout {
                       qsTrId("disconnected")
         }
 
-        // Not Refactored Yet
-        //        Connections {
-        //            target: chatContentRoot.rootStore.chatsModelInst
-        //            onOnlineStatusChanged: {
-        //                if (connected == isConnected) return;
-        //                isConnected = connected;
-        //                if(isConnected){
-        //                    timer.setTimeout(function(){
-        //                        connectedStatusRect.visible = false;
-        //                    }, 5000);
-        //                } else {
-        //                    connectedStatusRect.visible = true;
-        //                }
-        //            }
-        //        }
-        //        Component.onCompleted: {
-        //            isConnected = chatContentRoot.rootStore.chatsModelInst.isOnline
-        //            if(!isConnected){
-        //                connectedStatusRect.visible = true
-        //            }
-        //        }
+        Connections {
+            target: mainModule
+            onOnlineStatusChanged: {
+                if (connected == isConnected) return;
+                isConnected = connected;
+                if(isConnected){
+                    timer.setTimeout(function(){
+                        connectedStatusRect.visible = false;
+                    }, 5000);
+                } else {
+                    connectedStatusRect.visible = true;
+                }
+            }
+        }
+        Component.onCompleted: {
+            isConnected = mainModule.isOnline
+            if(!isConnected){
+                connectedStatusRect.visible = true
+            }
+        }
     }
 
     StatusBanner {

--- a/ui/imports/shared/panels/ImageLoader.qml
+++ b/ui/imports/shared/panels/ImageLoader.qml
@@ -52,17 +52,17 @@ Rectangle {
         }
     ]
 
-//    Connections {
-//        target: RootStore.chatsModelInst
-//        onOnlineStatusChanged: {
-//            if (connected && root.state !== "ready" &&
-//                root.visible &&
-//                root.source &&
-//                root.source.startsWith("http")) {
-//                root.reload()
-//            }
-//        }
-//    }
+    Connections {
+        target: mainModule
+        onOnlineStatusChanged: {
+            if (connected && root.state !== "ready" &&
+                root.visible &&
+                root.source &&
+                root.source.startsWith("http")) {
+                root.reload()
+            }
+        }
+    }
 
     function reload() {
         // From the documentation (https://doc.qt.io/qt-5/qml-qtquick-image.html#sourceSize-prop)

--- a/ui/imports/shared/status/StatusStickersPopup.qml
+++ b/ui/imports/shared/status/StatusStickersPopup.qml
@@ -41,12 +41,12 @@ Popup {
         footerContent.visible = true
         stickersContainer.visible = true
     }
-//    Connections {
-//        target: chatsModel
-//        onOnlineStatusChanged: {
-//            root.close()
-//        }
-//    }
+    Connections {
+        target: mainModule
+        onOnlineStatusChanged: {
+            root.close()
+        }
+    }
 
     Component.onCompleted: {
         if (stickersModule.packsLoaded) {


### PR DESCRIPTION
I started this as a possible fix to https://github.com/status-im/status-desktop/issues/4810, but it seems like the events to re-fetch was already there. The banner however wasn't so now we have a UI element to show we reconnected