### PR TITLE
fix(chatMessages): line breaks in message were not respected when pasting text

### DIFF
--- a/ui/imports/utils/Utils.qml
+++ b/ui/imports/utils/Utils.qml
@@ -50,7 +50,7 @@ QtObject {
 
     function getMessageWithStyle(msg, isCurrentUser, hoveredLink = "") {
         return `<style type="text/css">` +
-                    `p, img, a, del, code, blockquote { margin: 0; padding: 0; }` +
+                    `img, a, del, code, blockquote { margin: 0; padding: 0; }` +
                     `code {` +
                         `font-family: ${Style.current.fontCodeRegular.name};` +
                         `font-weight: 400;` +


### PR DESCRIPTION
Closes #3510 
Depends on https://github.com/status-im/status-desktop/pull/4889

### What does the PR do
When pasting 
A
B

C

D

in text input ,
A
B
C
D
was received

### Affected areas
Chat messages

### Screenshot of functionality
https://user-images.githubusercontent.com/31625338/156405606-e9517525-9ba1-4a66-9b54-ff3135c24200.mov


