### PR TITLE
fix(layout) Keep chat sidebar at a fixed width #4882

### DIFF
--- a/ui/app/AppLayouts/Chat/ChatLayout.qml
+++ b/ui/app/AppLayouts/Chat/ChatLayout.qml
@@ -23,8 +23,6 @@ import "stores"
 StatusAppThreePanelLayout {
     id: root
 
-    handle: SplitViewHandle { implicitWidth: 5 }
-
     property var contactsStore
     property bool hasAddedContacts: root.contactsStore.myContactsModel.count > 0
 


### PR DESCRIPTION
### What does the PR do

Don't allow the chat sidebar to be resized. Fixes  #4882

### Affected areas

The main interface. After this change user, won't see the cursor to drag the side of the sidebar