### PR TITLE
Improve ChatContentView loading and duplication

### DIFF
--- a/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
@@ -131,8 +131,20 @@ Item {
     // This is kind of a solution for applying backend refactored changes with the minimal qml changes.
     // The best would be if we made qml to follow the struct we have on the backend side.
     Repeater {
+        id: chatRepeater
         model: parentModule && parentModule.model
         delegate: delegateChooser
+
+        function isChatActive(chatContentModule, activeChatId, activeSubItemId, isSectionActive) {
+            if(!chatContentModule || !isSectionActive)
+                return false
+
+            let myChatId = chatContentModule.getMyChatId()
+            if(myChatId === activeChatId || myChatId === activeSubItemId)
+                return true
+
+            return false
+        }
 
         DelegateChooser {
             id: delegateChooser
@@ -149,6 +161,8 @@ Item {
                     delegate: ChatContentView {
                         width: parent.width
                         clip: true
+                        // dynamically calculate the height of the view, if the active one is the current one
+                        // then set the height to parent otherwise set it to 0
                         height: isActiveChannel ? parent.height : 0
                         rootStore: root.rootStore
                         contactsStore: root.contactsStore
@@ -157,18 +171,7 @@ Item {
                         sendTransactionWithEnsModal: cmpSendTransactionWithEns
                         stickersLoaded: root.stickersLoaded
                         isBlocked: model.blocked
-                        isActiveChannel: {
-                            // dynamically calculate the height of the view, if the active one is the current one
-                            // then set the height to parent otherwise set it to 0
-                            if(!chatContentModule || !isSectionActive)
-                                return false
-
-                            let myChatId = chatContentModule.getMyChatId()
-                            if(myChatId === root.activeChatId || myChatId === root.activeSubItemId)
-                                return true
-
-                            return false
-                        }
+                        isActiveChannel: chatRepeater.isChatActive(chatContentModule, root.activeChatId, root.activeSubItemId, root.isSectionActive)
                         Component.onCompleted: {
                             parentModule.prepareChatContentModuleForChatId(model.itemId)
                             chatContentModule = parentModule.getChatContentModule()
@@ -188,18 +191,7 @@ Item {
                     sendTransactionWithEnsModal: cmpSendTransactionWithEns
                     stickersLoaded: root.stickersLoaded
                     isBlocked: model.blocked
-                    isActiveChannel: {
-                        // dynamically calculate the height of the view, if the active one is the current one
-                        // then set the height to parent otherwise set it to 0
-                        if(!chatContentModule || !isSectionActive)
-                            return false
-
-                        let myChatId = chatContentModule.getMyChatId()
-                        if(myChatId === root.activeChatId || myChatId === root.activeSubItemId)
-                            return true
-
-                        return false
-                    }
+                    isActiveChannel: chatRepeater.isChatActive(chatContentModule, root.activeChatId, root.activeSubItemId, root.isSectionActive)
                     Component.onCompleted: {
                         parentModule.prepareChatContentModuleForChatId(itemId)
                         chatContentModule = parentModule.getChatContentModule()


### PR DESCRIPTION
Removes some duplication for the category and normal channels that was suggested here: https://github.com/status-im/status-desktop/pull/4929#discussion_r818429901

Also, and more importantly, in the second commit, I put the `ChatContentView` in a Loader that is disabled by default.
What this does is speeding up the initial app load since only one channel will be loaded. It also reduces the initial memory usage.
We retain the channel switching speed improvement we implemented last time, because once a channel is loaded, we don't unload it when switching, we just hide it like before.

The only downside of this change is that the first load of a clicked channel can have a mini delay, since it loads the content. However, once it is loaded, you can go back and forth between it and another and it will be instant.

For QAs, there is no issue attached, but what you can test is the channels and switching work as before, aka there is no regression with channel switching.