### PR TITLE
fix(group-chats): wrong group name in a subsequent edit attempt

### DIFF
--- a/ui/app/AppLayouts/Chat/popups/GroupInfoPopup.qml
+++ b/ui/app/AppLayouts/Chat/popups/GroupInfoPopup.qml
@@ -296,7 +296,7 @@ StatusModal {
 
     RenameGroupPopup {
         id: renameGroupPopup
-        activeChannelName: popup.chatSectionModule.activeItem.name
+        activeChannelName: popup.chatDetails ? popup.chatDetails.name : ""
         onDoRename: {
             popup.chatSectionModule.renameGroupChat(popup.chatSectionModule.activeItem.id, groupName)
             popup.header.title = groupName


### PR DESCRIPTION
### What does the PR do
    
Root cause: the name used as input for the naming edit field was sourced from the active group entry which is updated only hen switching the active group.

fixes #4910

### Affected areas

Group Chats

### Screenshot of functionality

### Cool Spaceship Picture
