### PR TITLE
fix(chat/textInput): prevent break mentions when ctrl+left is pressed

### DIFF
--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -976,12 +976,16 @@ Rectangle {
                                     messageInputField.remove(mentionsPos[i].rightIndex, mentionsPos[i].leftIndex);
                                     mentionsPos.pop(i);
                                 }
-                            }
-                            if ((keyEvent.key === Qt.Key_Up) || (keyEvent.key === Qt.Key_Down)) {
+                            } else if (((messageInputField.cursorPosition > mentionsPos[i].leftIndex) &&
+                                        (messageInputField.cursorPosition  < mentionsPos[i].rightIndex)) &&
+                                       ((keyEvent.key === Qt.Key_Left) && ((keyEvent.modifiers & Qt.AltModifier) ||
+                                                                           (keyEvent.modifiers & Qt.ControlModifier)))) {
+                                messageInputField.cursorPosition = mentionsPos[i].leftIndex;
+                            } else if ((keyEvent.key === Qt.Key_Up) || (keyEvent.key === Qt.Key_Down)) {
                                 if (messageInputField.cursorPosition >= mentionsPos[i].leftIndex &&
                                     messageInputField.cursorPosition <= (((mentionsPos[i].leftIndex + mentionsPos[i].rightIndex)/2))) {
                                     messageInputField.cursorPosition = mentionsPos[i].leftIndex;
-                                } else if (messageInputField.cursorPosition <= mentionsPos[i].rightIndex &&
+                                  } else if (messageInputField.cursorPosition <= mentionsPos[i].rightIndex &&
                                            messageInputField.cursorPosition > (((mentionsPos[i].leftIndex + mentionsPos[i].rightIndex)/2))) {
                                     messageInputField.cursorPosition = mentionsPos[i].rightIndex;
                                 }


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/4981

### What does the PR do
It was still possible for the cursor to get inside mentions when ctrl+left was pressed. Added condition to preven this.

### Affected areas
chat text input / mentions
