### PR TITLE
fix(desktop/chat): Update copy button tooltip text in communities

### DIFF
--- a/ui/app/AppLayouts/Chat/panels/communities/CommunityProfilePopupInviteFriendsPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/CommunityProfilePopupInviteFriendsPanel.qml
@@ -38,7 +38,6 @@ Column {
         //% "Share community"
         title: qsTrId("share-community")
         subTitle: `${Constants.communityLinkPrefix}${root.community && root.community.id.substring(0, 4)}...${root.community && root.community.id.substring(root.community.id.length -2)}`
-        //% "Copy to clipboard"
         tooltip.text: qsTr("Copied!")
         icon.name: "copy"
         iconButton.onClicked: {

--- a/ui/app/AppLayouts/Chat/panels/communities/CommunityProfilePopupInviteFriendsPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/CommunityProfilePopupInviteFriendsPanel.qml
@@ -39,7 +39,7 @@ Column {
         title: qsTrId("share-community")
         subTitle: `${Constants.communityLinkPrefix}${root.community && root.community.id.substring(0, 4)}...${root.community && root.community.id.substring(root.community.id.length -2)}`
         //% "Copy to clipboard"
-        tooltip.text: qsTrId("copy-to-clipboard")
+        tooltip.text: qsTr("Copied!")
         icon.name: "copy"
         iconButton.onClicked: {
             let link = `${Constants.communityLinkPrefix}${root.community.id}`

--- a/ui/app/AppLayouts/Chat/panels/communities/CommunityProfilePopupOverviewPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/CommunityProfilePopupOverviewPanel.qml
@@ -51,7 +51,7 @@ Column {
         title: qsTrId("share-community")
         subTitle: `${Constants.communityLinkPrefix}${root.community.id.substring(0, 4)}...${root.community.id.substring(root.community.id.length -2)}`
         //% "Copy to clipboard"
-        tooltip.text: qsTrId("copy-to-clipboard")
+        tooltip.text: qsTr("Copied!")
         icon.name: "copy"
         iconButton.onClicked: {
             let link = `${Constants.communityLinkPrefix}${root.community.id}`

--- a/ui/app/AppLayouts/Chat/panels/communities/CommunityProfilePopupOverviewPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/CommunityProfilePopupOverviewPanel.qml
@@ -50,7 +50,6 @@ Column {
         //% "Share community"
         title: qsTrId("share-community")
         subTitle: `${Constants.communityLinkPrefix}${root.community.id.substring(0, 4)}...${root.community.id.substring(root.community.id.length -2)}`
-        //% "Copy to clipboard"
         tooltip.text: qsTr("Copied!")
         icon.name: "copy"
         iconButton.onClicked: {


### PR DESCRIPTION
Change copy buttons tooltip text from “Copy to clipboard” into “Copied!” in panels: "Add members" and "Manage community"

Fixes #3520

### Affected areas

Chat / communities

### Screenshot of functionality

![image](https://user-images.githubusercontent.com/61889657/157027349-1beb85c3-29a1-4bc8-9a51-207ab38a7e22.png)

![image](https://user-images.githubusercontent.com/61889657/157027645-fe737e09-854f-458d-9629-ea310f6fe2a3.png)


