### PR TITLE
fix(@dekstop/chat): mentioning oneself display the full key instead of username

### DIFF
--- a/src/app/modules/main/chat_section/chat_content/users/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/users/module.nim
@@ -51,7 +51,7 @@ method isLoaded*(self: Module): bool =
 method viewDidLoad*(self: Module) =
   # add me as the first user to the list
   let (admin, joined) = self.controller.getChatMemberInfo(singletonInstance.userProfile.getPubKey())
-  let loggedInUserDisplayName = singletonInstance.userProfile.getName() & "(You)"
+  let loggedInUserDisplayName = singletonInstance.userProfile.getName() & " (You)"
   self.view.model().addItem(initItem(
     singletonInstance.userProfile.getPubKey(),
     loggedInUserDisplayName,

--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -142,6 +142,11 @@ Rectangle {
     property var mentionsPos: []
 
     function insertMention(aliasName, lastAtPosition, lastCursorPosition) {
+        let startInd = aliasName.indexOf("(");
+        if (startInd > 0){
+            aliasName = aliasName.substring(0, startInd-1)
+        }
+
         const hasEmoji = StatusQUtils.Emoji.hasEmoji(messageInputField.text)
         const spanPlusAlias = `${Constants.mentionSpanTag}@${aliasName}</a></span> `;
 


### PR DESCRIPTION
Fixes #4897 