### PR TITLE
fix(chat): Show beam mouse cursor over the chat message field

### DIFF
--- a/ui/imports/shared/popups/NicknamePopup.qml
+++ b/ui/imports/shared/popups/NicknamePopup.qml
@@ -23,7 +23,7 @@ StatusModal {
     property int nicknameLength: nicknameInput.textField.text.length
     readonly property int maxNicknameLength: 32
     property bool nicknameTooLong: nicknameLength > maxNicknameLength
-    signal doneClicked(string newNickname)
+    signal editDone(string newNickname)
 
     onOpened: {
         nicknameInput.forceActiveFocus(Qt.MouseFocusReason);
@@ -59,7 +59,7 @@ StatusModal {
                 validationError: popup.nicknameTooLong ? qsTrId("your-nickname-is-too-long") : ""
                 Keys.onReleased: {
                     if (event.key === Qt.Key_Return) {
-                        doneBtn.onClicked();
+                        editDone()
                     }
                 }
 
@@ -82,9 +82,7 @@ StatusModal {
             //% "Done"
             text: qsTrId("done")
             enabled: !popup.nicknameTooLong
-            onClicked: {
-                doneClicked(nicknameInput.textField.text)
-            }
+            onClicked: editDone(nicknameInput.textField.text)
         }
     ]
 }

--- a/ui/imports/shared/popups/ProfilePopup.qml
+++ b/ui/imports/shared/popups/ProfilePopup.qml
@@ -251,7 +251,7 @@ StatusModal {
             nickname: popup.userNickname
             header.subTitle: popup.header.subTitle
             header.subTitleElide: popup.header.subTitleElide
-            onDoneClicked: {
+            onEditDone: {
                 if(popup.userNickname !== newNickname)
                 {
                     popup.userNickname = newNickname;

--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -1039,7 +1039,7 @@ Rectangle {
                     anchors.fill: parent
                     acceptedButtons: Qt.NoButton
                     enabled: parent.hoveredLink
-                    cursorShape: parent.hoveredLink ? Qt.PointingHandCursor : Qt.ArrowCursor
+                    cursorShape: parent.hoveredLink ? Qt.PointingHandCursor : Qt.IBeamCursor
                 }
                 StatusTextFormatMenu {
                     id: textFormatMenu


### PR DESCRIPTION
### What does the PR do

Changes
- Show beam mouse cursor over the chat message field
- Fix applying edit of nickname using the enter key

### Affected areas

Chat edit control, Nickname edit control

### Screenshot of functionality

![right_cursor](https://user-images.githubusercontent.com/47554641/157227663-9bb50435-9f1c-4f00-9191-b9a112646b70.jpeg)

### Cool Spaceship Picture

<!-- optional but cool ->
