### PR TITLE
fix(@dekstop/chat): clicking on a mention or reply in the activity centre notifications list, does not take the user to the correct Community chat window

### DIFF
--- a/src/app/modules/main/activity_center/controller.nim
+++ b/src/app/modules/main/activity_center/controller.nim
@@ -8,6 +8,7 @@ import ../../../../app_service/service/activity_center/service as activity_cente
 import ../../../../app_service/service/contacts/service as contacts_service
 import ../../../../app_service/service/message/service as message_service
 import ../../../../app_service/service/eth/utils as eth_utils
+import ../../../../app_service/service/chat/service as chat_service
 
 export controller_interface
 
@@ -18,13 +19,15 @@ type
     activityCenterService: activity_center_service.Service
     contactsService: contacts_service.Service
     messageService: message_service.Service
+    chatService: chat_service.Service
 
 proc newController*[T](
     delegate: io_interface.AccessInterface,
     events: EventEmitter,
     activityCenterService: activity_center_service.Service,
     contactsService: contacts_service.Service,
-    messageService: message_service.Service
+    messageService: message_service.Service,
+    chatService: chat_service.Service
     ): Controller[T] =
   result = Controller[T]()
   result.delegate = delegate
@@ -32,6 +35,7 @@ proc newController*[T](
   result.activityCenterService = activityCenterService
   result.contactsService = contactsService
   result.messageService = messageService
+  result.chatService = chatService
 
 method delete*[T](self: Controller[T]) =
   discard
@@ -107,3 +111,6 @@ method decodeContentHash*[T](self: Controller[T], hash: string): string =
 method switchTo*[T](self: Controller[T], sectionId, chatId, messageId: string) =
   let data = ActiveSectionChatArgs(sectionId: sectionId, chatId: chatId, messageId: messageId)
   self.events.emit(SIGNAL_MAKE_SECTION_CHAT_ACTIVE, data)
+
+method getChatDetails*[T](self: Controller[T], chatId: string): ChatDto =
+  return self.chatService.getChatById(chatId)

--- a/src/app/modules/main/activity_center/controller_interface.nim
+++ b/src/app/modules/main/activity_center/controller_interface.nim
@@ -1,6 +1,7 @@
 import ../../../../app_service/service/contacts/service as contacts_service
 import ../../../../app_service/service/activity_center/service as activity_center_service
 import ../../../../app_service/service/message/dto/[message]
+import ../../../../app_service/service/chat/dto/[chat]
 
 type
   AccessInterface* {.pure inheritable.} = ref object of RootObj
@@ -46,6 +47,9 @@ method decodeContentHash*(self: AccessInterface, hash: string): string {.base.} 
   raise newException(ValueError, "No implementation available")
 
 method switchTo*(self: AccessInterface, sectionId, chatId, messageId: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method getChatDetails*(self: AccessInterface, chatId: string): ChatDto {.base.} =
   raise newException(ValueError, "No implementation available")
 
 

--- a/src/app/modules/main/activity_center/item.nim
+++ b/src/app/modules/main/activity_center/item.nim
@@ -4,6 +4,7 @@ import ../../shared_models/message_item_qobject
 type Item* = ref object
   id: string # ID is the id of the chat, for public chats it is the name e.g. status, for one-to-one is the hex encoded public key and for group chats is a random uuid appended with the hex encoded pk of the creator of the chat
   chatId: string
+  sectionId: string
   name: string
   author: string
   notificationType: int
@@ -16,6 +17,7 @@ type Item* = ref object
 proc initItem*(
   id: string,
   chatId: string,
+  sectionId: string,
   name: string,
   author: string,
   notificationType: int,
@@ -28,6 +30,7 @@ proc initItem*(
   result = Item()
   result.id = id
   result.chatId = chatId
+  result.sectionId = sectionId
   result.name = name
   result.author = author
   result.notificationType = notificationType
@@ -42,6 +45,7 @@ proc `$`*(self: Item): string =
     id: {self.id},
     name: {$self.name},
     chatId: {$self.chatId},
+    sectionId: {$self.sectionId},
     author: {$self.author},
     notificationType: {$self.notificationType},
     timestamp: {$self.timestamp},
@@ -62,6 +66,9 @@ proc author*(self: Item): string =
 
 proc chatId*(self: Item): string =
   return self.chatId
+
+proc sectionId*(self: Item): string =
+  return self.sectionId
 
 proc notificationType*(self: Item): int =
   return self.notificationType

--- a/src/app/modules/main/activity_center/model.nim
+++ b/src/app/modules/main/activity_center/model.nim
@@ -4,15 +4,16 @@ import ./item
 type
   NotifRoles {.pure.} = enum
     Id = UserRole + 1
-    ChatId = UserRole + 2
-    Name = UserRole + 3
-    NotificationType = UserRole + 4
-    Message = UserRole + 5
-    Timestamp = UserRole + 6
-    Read = UserRole + 7
-    Dismissed = UserRole + 8
-    Accepted = UserRole + 9
-    Author = UserRole + 10
+    ChatId
+    SectionId
+    Name
+    NotificationType
+    Message
+    Timestamp
+    Read
+    Dismissed
+    Accepted
+    Author
 
 QtObject:
   type
@@ -70,6 +71,7 @@ QtObject:
     case communityItemRole:
       of NotifRoles.Id: result = newQVariant(acitivityNotificationItem.id)
       of NotifRoles.ChatId: result = newQVariant(acitivityNotificationItem.chatId)
+      of NotifRoles.SectionId: result = newQVariant(acitivityNotificationItem.sectionId)
       of NotifRoles.Name: result = newQVariant(acitivityNotificationItem.name)
       of NotifRoles.Author: result = newQVariant(acitivityNotificationItem.author)
       of NotifRoles.NotificationType: result = newQVariant(acitivityNotificationItem.notificationType.int)
@@ -86,6 +88,7 @@ QtObject:
     case data:
     of "id": result = notif.id
     of "chatId": result = notif.chatId
+    of "sectionId": result = notif.sectionId
     of "name": result = notif.name
     of "author": result = notif.author
     of "notificationType": result = $(notif.notificationType.int)
@@ -99,6 +102,7 @@ QtObject:
     {
       NotifRoles.Id.int:"id",
       NotifRoles.ChatId.int:"chatId",
+      NotifRoles.SectionId.int: "sectionId",
       NotifRoles.Name.int: "name",
       NotifRoles.Author.int: "author",
       NotifRoles.NotificationType.int: "notificationType",

--- a/src/app/modules/main/activity_center/module.nim
+++ b/src/app/modules/main/activity_center/module.nim
@@ -2,14 +2,17 @@ import NimQml, Tables, stint, sugar, sequtils
 
 import ./io_interface, ./view, ./controller
 import ./item as notification_item
-import ../../shared_models/message_item as message_item
-import ../../shared_models/message_item_qobject as message_item_qobject
+import ../../shared_models/message_item as msg_item
+import ../../shared_models/message_item_qobject as msg_item_qobj
 import ../../shared_models/message_transaction_parameters_item
 import ../../../global/global_singleton
 import ../../../core/eventemitter
 import ../../../../app_service/service/activity_center/service as activity_center_service
 import ../../../../app_service/service/contacts/service as contacts_service
 import ../../../../app_service/service/message/service as message_service
+import ../../../../app_service/service/chat/service as chat_service
+
+import ../../../global/app_sections_config as conf
 
 export io_interface
 
@@ -26,7 +29,8 @@ proc newModule*[T](
     events: EventEmitter,
     activityCenterService: activity_center_service.Service,
     contactsService: contacts_service.Service,
-    messageService: message_service.Service
+    messageService: message_service.Service,
+    chatService: chat_service.Service
     ): Module[T] =
   result = Module[T]()
   result.delegate = delegate
@@ -37,7 +41,8 @@ proc newModule*[T](
     events,
     activityCenterService,
     contactsService,
-    messageService
+    messageService,
+    chatService
   )
   result.moduleLoaded = false
 
@@ -67,14 +72,19 @@ method convertToItems*[T](
   activityCenterNotifications: seq[ActivityCenterNotificationDto]
   ): seq[notification_item.Item] =
   result = activityCenterNotifications.map(
-    proc(n: ActivityCenterNotificationDto): Item =
-      var messageItem = MessageItem()
+    proc(n: ActivityCenterNotificationDto): notification_item.Item =
+      var messageItem =  msg_item_qobj.newMessageItem(nil)
+
+      let chatDetails = self.controller.getChatDetails(n.chatId)
+      # default section id is `Chat` section
+      let sectionId = if(chatDetails.communityId.len > 0): chatDetails.communityId else: conf.CHAT_SECTION_ID
+
       if (n.message.id != ""):
         # If there is a message in the Notification, transfer it to a MessageItem (QObject)
         let contactDetails = self.controller.getContactDetails(n.message.`from`)
-        messageItem = message_item_qobject.newMessageItem(initItem(
+        messageItem = msg_item_qobj.newMessageItem(msg_item.initItem(
           n.message.id,
-          n.message.communityId,
+          chatDetails.communityId, # we don't received community id via `activityCenterNotifications` api call
           n.message.responseTo,
           n.message.`from`,
           contactDetails.displayName,
@@ -93,12 +103,13 @@ method convertToItems*[T](
           self.controller.decodeContentHash(n.message.sticker.hash),
           n.message.sticker.pack,
           n.message.links,
-          initTransactionParametersItem("","","","","","",-1,""),
+          newTransactionParametersItem("","","","","","",-1,""),
         ))
 
       return notification_item.initItem(
         n.id,
         n.chatId,
+        sectionId,
         n.name,
         n.author,
         n.notificationType.int,

--- a/src/app/modules/main/chat_section/chat_content/messages/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/module.nim
@@ -92,7 +92,7 @@ proc createFetchMoreMessagesItem(self: Module): Item =
     sticker = "",
     stickerPack = -1,
     @[],
-    initTransactionParametersItem("","","","","","",-1,""),
+    newTransactionParametersItem("","","","","","",-1,""),
   )
 
 proc createChatIdentifierItem(self: Module): Item =
@@ -124,7 +124,7 @@ proc createChatIdentifierItem(self: Module): Item =
     sticker = "",
     stickerPack = -1,
     @[],
-    initTransactionParametersItem("","","","","","",-1,""),
+    newTransactionParametersItem("","","","","","",-1,""),
   )
 
 proc checkIfMessageLoadedAndScrollToItIfItIs(self: Module): bool =
@@ -186,7 +186,7 @@ method newMessagesLoaded*(self: Module, messages: seq[MessageDto], reactions: se
         sticker = self.controller.decodeContentHash(m.sticker.hash),
         m.sticker.pack,
         m.links,
-        initTransactionParametersItem(m.transactionParameters.id,
+        newTransactionParametersItem(m.transactionParameters.id,
           m.transactionParameters.fromAddress,
           m.transactionParameters.address,
           transactionContract,
@@ -272,7 +272,7 @@ method messageAdded*(self: Module, message: MessageDto) =
     sticker = self.controller.decodeContentHash(message.sticker.hash),
     message.sticker.pack,
     message.links,
-    initTransactionParametersItem(message.transactionParameters.id,
+    newTransactionParametersItem(message.transactionParameters.id,
                     message.transactionParameters.fromAddress,
                     message.transactionParameters.address,
                     transactionContract,

--- a/src/app/modules/main/chat_section/chat_content/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/module.nim
@@ -176,7 +176,7 @@ proc buildPinnedMessageItem(self: Module, messageId: string, actionInitiatedBy: 
     self.controller.decodeContentHash(m.sticker.hash),
     m.sticker.pack,
     m.links,
-    initTransactionParametersItem(m.transactionParameters.id,
+    newTransactionParametersItem(m.transactionParameters.id,
       m.transactionParameters.fromAddress,
       m.transactionParameters.address,
       transactionContract,

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -148,7 +148,7 @@ proc newModule*[T](
   )
   result.stickersModule = stickers_module.newModule(result, events, stickersService)
   result.activityCenterModule = activity_center_module.newModule(result, events, activityCenterService, contactsService,
-  messageService)
+  messageService, chatService)
   result.communitiesModule = communities_module.newModule(result, events, communityService, contactsService)
   result.appSearchModule = app_search_module.newModule(result, events, contactsService, chatService, communityService,
   messageService)

--- a/src/app/modules/shared_models/message_item_qobject.nim
+++ b/src/app/modules/shared_models/message_item_qobject.nim
@@ -13,8 +13,8 @@ QtObject:
 
   proc newMessageItem*(message: message_item.Item): MessageItem =
     new(result, delete)
-    result.messageItem = message
     result.setup
+    result.messageItem = message
 
   proc `$`*(self: MessageItem): string =
     result = $self.messageItem
@@ -121,3 +121,12 @@ QtObject:
   proc isEdited*(self: MessageItem): bool {.slot.} = result = ?.self.messageItem.isEdited
   QtProperty[int] bool:
     read = bool
+
+  # this is not the greatest approach, but aligns with the rest of the code
+  proc communityId*(self: MessageItem): string {.slot.} = result = ?.self.messageItem.communityId
+  QtProperty[string] communityId:
+    read = communityId
+
+  proc reactionsModel*(self: MessageItem): QVariant {.slot.} = result = newQVariant(?.self.messageItem.reactionsModel)
+  QtProperty[QVariant] reactionsModel:
+    read = reactionsModel

--- a/src/app/modules/shared_models/message_transaction_parameters_item.nim
+++ b/src/app/modules/shared_models/message_transaction_parameters_item.nim
@@ -12,7 +12,13 @@ QtObject:
       commandState: int
       signature: string
 
-  proc initTransactionParametersItem*(
+  proc setup(self: TransactionParametersItem) =
+    self.QObject.setup
+
+  proc delete*(self: TransactionParametersItem) =
+    self.QObject.delete
+
+  proc newTransactionParametersItem*(
       id: string,
       fromAddress: string,
       address: string,
@@ -22,7 +28,8 @@ QtObject:
       commandState: int,
       signature: string,
       ): TransactionParametersItem =
-    result = TransactionParametersItem()
+    new(result, delete)
+    result.setup
     result.id = id
     result.fromAddress = fromAddress
     result.address = address

--- a/ui/app/AppLayouts/Chat/popups/GroupInfoPopup.qml
+++ b/ui/app/AppLayouts/Chat/popups/GroupInfoPopup.qml
@@ -36,7 +36,7 @@ StatusModal {
 
     property var chatContentModule
 
-    readonly property int maxMembers: 10
+    readonly property int maxMembers: 20
 
     function resetSelectedMembers() {
         contactList.selectedPubKeys = []
@@ -58,8 +58,7 @@ StatusModal {
     header.title: addMembers ? qsTrId("add-members") : (popup.chatDetails ? popup.chatDetails.name : "")
     header.subTitle:  {
         if (addMembers) {
-            //% "%1 / 10 members"
-            return qsTrId("%1-/-10-members").arg(memberCount)
+            return qsTr("%1/%2 members").arg(memberCount).arg(maxMembers)
         } else {
             //% "%1 members"
             if (currMemberCount > 1) {
@@ -134,7 +133,7 @@ StatusModal {
             Layout.alignment: Qt.AlignVCenter
             Layout.bottomMargin: childrenRect.height
 
-            visible: chatSectionModule.listOfMyContacts.rowCount() === 0
+            visible: chatSectionModule.listOfMyContacts.count === 0
             //% "All your contacts are already in the group"
             text: qsTrId("group-chat-all-contacts-invited")
             textColor: Style.current.textColor
@@ -146,12 +145,12 @@ StatusModal {
             Layout.fillHeight: true
             Layout.fillWidth: true
 
-            visible: popup.addMembers && chatSectionModule.listOfMyContacts.rowCount() > 0
+            visible: popup.addMembers && chatSectionModule.listOfMyContacts.count > 0
             model: chatSectionModule.listOfMyContacts
             selectMode: memberCount < maxMembers
             searchString: searchBox.text.toLowerCase()
             onSelectedPubKeysChanged: {
-                memberCount = popup.chatContentModule.usersModule.model.rowCount() + selectedPubKeys.length;
+                memberCount = popup.chatContentModule.usersModule.model.count + selectedPubKeys.length;
                 btnSelectMembers.enabled = selectedPubKeys.length > 0
             }
         }

--- a/ui/app/AppLayouts/Chat/views/ActivityCenterMessageComponentView.qml
+++ b/ui/app/AppLayouts/Chat/views/ActivityCenterMessageComponentView.qml
@@ -140,11 +140,7 @@ Item {
                 }
 
                 activityCenter.close()
-                var sectionId = "chat"
-                if (model.message.communityId) {
-                    sectionId = model.message.communityId
-                }
-                root.store.activityCenterModuleInst.switchTo(sectionId, model.chatId, model.id)
+                root.store.activityCenterModuleInst.switchTo(model.sectionId, model.chatId, model.id)
             }
             prevMessageIndex: root.previousNotificationIndex
             prevMsgTimestamp: root.previousNotificationTimestamp


### PR DESCRIPTION
In the first commit here an issue adding members to the already created group chat is fixed (I noticed that when I was creating group chat for testing this issue and fixed).

We weren't able to switch to appropriate section cause `activityCenterNotifications` rpc call which should return list of notifications doesn't have `communityId` set but we were referring to it. Should be fixed now.

Some issues creating `ref` objects are fixed within this PR as well.

Fixes #4966 