### PR TITLE
fix(@dekstop/chat): editing a message does not update the reply

### DIFF
--- a/src/app/modules/main/chat_section/chat_content/messages/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/module.nim
@@ -421,6 +421,13 @@ method onMessageEdited*(self: Module, message: MessageDto) =
     message.links
     )
 
+  let messagesIds = self.view.model().findIdsOfTheMessagesWhichRespondedToMessageWithId(message.id)
+  for msgId in messagesIds:
+    # refreshing an item calling `self.view.model().refreshItemWithId(msgId)` doesn't work from some very weird reason
+    # and that would be the correct way of updating item instead sending this signal. We should check this once we refactor
+    # qml part.
+    self.view.emitRefreshAMessageUserRespondedToSignal(msgId)
+
 method onHistoryCleared*(self: Module) =
   self.view.model().clear()
 

--- a/src/app/modules/main/chat_section/chat_content/messages/view.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/view.nim
@@ -162,3 +162,7 @@ QtObject:
 
   proc didIJoinedChat(self: View): bool {.slot.} =
     return self.delegate.didIJoinedChat()
+
+  proc refreshAMessageUserRespondedTo(self: View, msgId: string) {.signal.}
+  proc emitRefreshAMessageUserRespondedToSignal*(self: View, msgId: string) =
+    self.refreshAMessageUserRespondedTo(msgId)

--- a/src/app/modules/shared_models/message_model.nim
+++ b/src/app/modules/shared_models/message_model.nim
@@ -196,6 +196,11 @@ QtObject:
         return i
     return -1
 
+  proc findIdsOfTheMessagesWhichRespondedToMessageWithId*(self: Model, messageId: string): seq[string] =
+    for i in 0 ..< self.items.len:
+      if(self.items[i].responseToMessageWithId == messageId):
+        result.add(self.items[i].id)
+
   proc findIndexBasedOnTimestampToInsertTo(self: Model, timestamp: int64): int =
     for i in 0 ..< self.items.len:
       if(timestamp > self.items[i].timestamp):

--- a/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
@@ -248,6 +248,7 @@ Item {
             isChatBlocked: root.isChatBlocked
             messageContextMenu: messageContextMenuInst
 
+            itemIndex: index
             messageId: model.id
             communityId: model.communityId
             responseToMessageWithId: model.responseToMessageWithId

--- a/ui/imports/shared/views/chat/CompactMessageView.qml
+++ b/ui/imports/shared/views/chat/CompactMessageView.qml
@@ -74,6 +74,15 @@ Item {
     height: messageContainer.height + messageContainer.anchors.topMargin
             + (dateGroupLbl.visible ? dateGroupLbl.height + dateGroupLbl.anchors.topMargin : 0)
 
+    Connections {
+        target: root.messageStore.messageModule
+        enabled: responseTo !== ""
+        onRefreshAMessageUserRespondedTo: {
+            if(msgId === messageId)
+                chatReply.resetOriginalMessage()
+        }
+    }
+
     Timer {
         id: ensureMessageFullyVisibleTimer
         interval: 1
@@ -283,7 +292,7 @@ Item {
 //            stickerData: !!rootStore ? rootStore.chatsModelInst.messageView.messageList.getMessageData(replyMessageIndex, "sticker") : null
             active: responseTo !== "" && !activityCenterMessage
 
-            Component.onCompleted: {
+            function resetOriginalMessage() {
                 if(!root.messageStore)
                     return
                 let obj = root.messageStore.getMessageByIdAsJson(responseTo)
@@ -300,6 +309,11 @@ Item {
                 repliedMessageContent = obj.messageText
                 repliedMessageImage = obj.messageImage
             }
+
+            Component.onCompleted: {
+                resetOriginalMessage()
+            }
+
             onScrollToBottom: {
                 // Not Refactored Yet
 //                messageStore.scrollToBottom(isit, root.container);

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -27,6 +27,7 @@ Column {
     // without an explicit need to fetch those details via message store/module.
     property bool isChatBlocked: false
 
+    property int itemIndex: -1
     property string messageId: ""
     property string communityId: ""
     property string responseToMessageWithId: ""


### PR DESCRIPTION
There are multiple ways of fixing this, but the correct one is sending `dataChanged` signal with `ResponseToMessageWithId` role set for the items which have id of the edited message set for their `ResponseToMessageWithId` property. And I spent some time trying to make it work, but not sure if that's because of Nim or some hidden issue on the qml side an item doesn't receive update for that property. At the end I decided to sent a signal explicitly and connect to it on the qml side and do the necessary update. We should check this when we move that part to c++.

Fixes #4891