### PR TITLE
fix(desktop/chat): Do not display "Send message" to logged-in user

### DIFF
--- a/ui/imports/shared/views/chat/MessageContextMenuView.qml
+++ b/ui/imports/shared/views/chat/MessageContextMenuView.qml
@@ -222,7 +222,8 @@ StatusPopupMenu {
             root.close()
         }
         icon.name: "chat"
-        enabled: root.isProfile && !root.isMyMessage ||
+        enabled: (root.myPublicKey !== root.selectedUserPublicKey) &&
+                 root.isProfile && !root.isMyMessage ||
                  (!root.hideEmojiPicker &&
                   !root.emojiOnly &&
                   !root.isProfile &&


### PR DESCRIPTION
Fixes #4907

### What does the PR do

Do not display "Send message" action when right-clicking community member which 
is logged-in.

### Affected areas

Communities / members list

### Screenshot of functionality

https://user-images.githubusercontent.com/61889657/157437853-0b13b477-a2ba-4631-88d2-0c96aa389b69.mov



