### PR TITLE
fix(@desktop/profile): Clip user list when dragging

### DIFF
--- a/ui/app/AppLayouts/Profile/views/ContactsView.qml
+++ b/ui/app/AppLayouts/Profile/views/ContactsView.qml
@@ -135,6 +135,7 @@ Item {
             ContactsListPanel {
                 anchors.top: parent.top
                 anchors.bottom: parent.bottom
+                clip: true
                 contactsModel: root.contactsStore.blockedContactsModel
 
                 onOpenProfilePopup: {
@@ -256,6 +257,7 @@ Item {
             anchors.topMargin: Style.current.bigPadding
             anchors.bottom: parent.bottom
             contactsModel: root.contactsStore.myContactsModel
+            clip: true
             hideBlocked: true
             searchString: searchBox.text
 


### PR DESCRIPTION
Fixes #3747

### What does the PR do

When dragging user list, the content will not overlay other items.

### Affected areas

Settings / Contact list and Blocked contact list

### Screenshot of functionality

https://user-images.githubusercontent.com/61889657/157877199-b7d954c7-3a22-44ee-a69b-5ce0fee42939.mov

