### PR TITLE
fix(@desktop/wallet): Disconnect button doesnt disconnect Wallet from Browser

### DIFF
--- a/src/app/modules/main/browser_section/provider/controller.nim
+++ b/src/app/modules/main/browser_section/provider/controller.nim
@@ -37,6 +37,9 @@ method setDappsAddress*(self: Controller, address: string) =
 method getCurrentNetworkId*(self: Controller): int =
   return self.settingsService.getCurrentNetworkId()
 
+method getCurrentNetwork*(self: Controller): string =
+  return self.settingsService.getCurrentNetwork()
+
 method postMessage*(self: Controller, requestType: string, message: string): string =
   return self.providerService.postMessage(requestType, message)
 

--- a/src/app/modules/main/browser_section/provider/controller_interface.nim
+++ b/src/app/modules/main/browser_section/provider/controller_interface.nim
@@ -17,6 +17,9 @@ method setDappsAddress*(self: AccessInterface, address: string) {.base.} =
 method getCurrentNetworkId*(self: AccessInterface): int {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method getCurrentNetwork*(self: AccessInterface): string {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method postMessage*(self: AccessInterface, requestType: string, message: string): string {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/browser_section/provider/module.nim
+++ b/src/app/modules/main/browser_section/provider/module.nim
@@ -35,6 +35,7 @@ method load*(self: Module) =
   singletonInstance.engine.setRootContextProperty("providerModule", self.viewVariant)
   self.view.dappsAddress = self.controller.getDappsAddress()
   self.view.networkId = self.controller.getCurrentNetworkId()
+  self.view.currentNetwork = self.controller.getCurrentNetwork()
   self.view.load()
 
 method isLoaded*(self: Module): bool =

--- a/src/app/modules/main/browser_section/provider/view.nim
+++ b/src/app/modules/main/browser_section/provider/view.nim
@@ -8,6 +8,7 @@ QtObject:
       delegate: io_interface.AccessInterface
       dappsAddress: string
       networkId: int
+      currentNetwork: string
 
   proc delete*(self: View) =
     self.QObject.delete
@@ -49,6 +50,19 @@ QtObject:
   QtProperty[int] networkId:
     read = networkId
     notify = networkIdChanged
+
+  proc currentNetworkChanged(self: View) {.signal.}
+
+  proc `currentNetwork=`*(self: View, value: string) =
+    self.currentNetwork = value
+    self.currentNetworkChanged()
+
+  proc currentNetwork*(self: View): string {.slot.} =
+    result = self.currentNetwork
+
+  QtProperty[string] currentNetwork:
+    read = currentNetwork
+    notify = currentNetworkChanged
 
   proc replaceHostByENS*(self: View, url: string, ens: string): string {.slot.} =
     result = url_replaceHostAndAddPath(url, ens)

--- a/ui/app/AppLayouts/Browser/BrowserLayout.qml
+++ b/ui/app/AppLayouts/Browser/BrowserLayout.qml
@@ -492,8 +492,9 @@ Rectangle {
             }
         }
         onDisconnect: {
-            Web3ProviderStore.web3ProviderInst.disconnect()
+            Web3ProviderStore.disconnect(Utils.getHostname(_internal.currentWebView.url))
             provider.postMessage("web3-disconnect-account", "{}");
+            _internal.currentWebView.reload()
             close()
         }
     }
@@ -601,6 +602,7 @@ Rectangle {
         target: _internal.currentWebView
         onUrlChanged: {
             browserHeader.addressBar.text = Web3ProviderStore.obtainAddress(_internal.currentWebView.url)
+            RootStore.currentTabConnected = Web3ProviderStore.hasWalletConnected(Utils.getHostname(_internal.currentWebView.url))
         }
     }
 

--- a/ui/app/AppLayouts/Browser/popups/BrowserWalletMenu.qml
+++ b/ui/app/AppLayouts/Browser/popups/BrowserWalletMenu.qml
@@ -59,7 +59,7 @@ Popup {
             height: 8
             radius: width / 2
             color: {
-                switch (RootStore.currentNetwork) {
+                switch (Web3ProviderStore.currentNetwork) {
                 case Constants.networkMainnet: return Style.current.green;
                 case Constants.networkRopsten: return Style.current.turquoise;
                 default: return Style.current.red
@@ -71,7 +71,7 @@ Popup {
         StatusBaseText {
             id: networkText
             text: {
-                switch (RootStore.currentNetwork) {
+                switch (Web3ProviderStore.currentNetwork) {
                 //% "Mainnet"
                 case Constants.networkMainnet: return qsTrId("mainnet");
                 //% "Ropsten"
@@ -94,6 +94,7 @@ Popup {
             anchors.verticalCenter: parent.verticalCenter
             anchors.right: parent.right
             color: Style.current.danger
+            visible: RootStore.currentTabConnected
 
             MouseArea {
                 cursorShape: Qt.PointingHandCursor

--- a/ui/app/AppLayouts/Browser/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Browser/stores/RootStore.qml
@@ -10,9 +10,6 @@ QtObject {
     // Not Refactored Yet
 //    property string activeChannelName: chatsModel.channelView.activeChannel.name
 
-    // Not Refactored Yet
-//    property var currentNetwork: profileModel.network.current
-
     property bool currentTabConnected: false
 
     function getUrlFromUserInput(input) {

--- a/ui/app/AppLayouts/Browser/stores/Web3ProviderStore.qml
+++ b/ui/app/AppLayouts/Browser/stores/Web3ProviderStore.qml
@@ -2,6 +2,8 @@ pragma Singleton
 
 import QtQuick 2.13
 
+import utils 1.0
+
 QtObject {
     id: root
 
@@ -9,9 +11,14 @@ QtObject {
     property var urlENSDictionary: ({})
 
     property int networkId: providerModule.networkId
+    property string currentNetwork: providerModule.currentNetwork
 
     function disconnectAddress(dappName, address){
-        dappPermissionsModule.disconnectAddress(address)
+        dappPermissionsModule.disconnectAddress(dappName, address)
+    }
+
+    function disconnect(hostname) {
+        dappPermissionsModule.disconnect(hostname)
     }
 
     function addPermission(hostname, address, permission){
@@ -20,6 +27,10 @@ QtObject {
 
     function hasPermission(hostname, address, permission){
         return dappPermissionsModule.hasPermission(hostname, address, permission)
+    }
+
+    function hasWalletConnected(hostname) {
+        return hasPermission(hostname, WalletStore.dappBrowserAccount.address, "web3")
     }
 
     function determineRealURL(text){

--- a/ui/app/AppLayouts/Browser/views/WebProviderObj.qml
+++ b/ui/app/AppLayouts/Browser/views/WebProviderObj.qml
@@ -43,7 +43,7 @@ QtObject {
         }
 
         if (requestType === Constants.web3DisconnectAccount) {
-            RootStore.currentTabConnected = true
+            RootStore.currentTabConnected = false
             web3Response(JSON.stringify({type: Constants.web3DisconnectAccount}));
         } else if (requestType === Constants.api_request) {
             if (!Web3ProviderStore.hasPermission(request.hostname, request.address, request.permission)) {


### PR DESCRIPTION
fixes #4053

### What does the PR do

This removes the account after disconnect is clicked.
1. On switching a a url check if wallet was connected/disconnected and update the button in the header
2. on disconnect reload url and revoke permission

### Affected areas

Browser

### Screenshot of functionality

https://user-images.githubusercontent.com/60327365/158219583-95d2de48-572f-4e9b-906e-9c32f587781a.mov


