### PR TITLE
fix(desktop/chat): Notifies when the user is mentioned in edited message #4475

### DIFF
--- a/src/app/modules/main/activity_center/module.nim
+++ b/src/app/modules/main/activity_center/module.nim
@@ -107,6 +107,7 @@ method convertToItems*(
           n.message.sticker.pack,
           n.message.links,
           newTransactionParametersItem("","","","","","",-1,""),
+          n.message.mentionedUsersPks
         ))
 
       return notification_item.initItem(

--- a/src/app/modules/main/chat_section/chat_content/messages/controller.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/controller.nim
@@ -258,3 +258,7 @@ proc joinGroupChat*(self: Controller) =
 
 proc leaveChat*(self: Controller) =
   self.chatService.leaveChat(self.chatId)
+
+method checkEditedMessageForMentions*(self: Controller, chatId: string,
+  editedMessage: MessageDto, oldMentions: seq[string]) =
+  self.messageService.checkEditedMessageForMentions(chatId, editedMessage, oldMentions)

--- a/src/app/modules/main/chat_section/chat_content/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/module.nim
@@ -185,7 +185,8 @@ proc buildPinnedMessageItem(self: Module, messageId: string, actionInitiatedBy: 
       transactionValue,
       m.transactionParameters.transactionHash,
       m.transactionParameters.commandState,
-      m.transactionParameters.signature)
+      m.transactionParameters.signature),
+      m.mentionedUsersPks
   )
   item.pinned = true
   item.pinnedBy = actionInitiatedBy

--- a/src/app/modules/main/chat_section/controller.nim
+++ b/src/app/modules/main/chat_section/controller.nim
@@ -61,6 +61,10 @@ proc init*(self: Controller) =
     self.delegate.onNewMessagesReceived(args.chatId, args.unviewedMessagesCount, args.unviewedMentionsCount,
     args.messages)
 
+  self.events.on(message_service.SIGNAL_MENTIONED_IN_EDITED_MESSAGE) do(e: Args):
+    let args = MessageEditedArgs(e)
+    self.delegate.onMeMentionedInEditedMessage(args.chatId, args.message)
+
   self.events.on(chat_service.SIGNAL_CHAT_MUTED) do(e:Args):
     let args = chat_service.ChatArgs(e)
     self.delegate.onChatMuted(args.chatId)

--- a/src/app/modules/main/chat_section/io_interface.nim
+++ b/src/app/modules/main/chat_section/io_interface.nim
@@ -267,3 +267,6 @@ method reorderCommunityCategories*(self: AccessInterface, categoryId: string, po
 
 method reorderCommunityChat*(self: AccessInterface, categoryId: string, chatId: string, position: int): string =
   raise newException(ValueError, "No implementation available")
+
+method onMeMentionedInEditedMessage*(self: AccessInterface, chatId: string, editedMessage : MessageDto) {.base.} =
+  raise newException(ValueError, "No implementation available")

--- a/src/app/modules/shared_models/message_item.nim
+++ b/src/app/modules/shared_models/message_item.nim
@@ -36,6 +36,7 @@ type
     isEdited: bool
     links: seq[string]
     transactionParameters: TransactionParametersItem
+    mentionedUsersPks: seq[string]
 
 proc initItem*(
     id,
@@ -61,6 +62,7 @@ proc initItem*(
     stickerPack: int,
     links: seq[string],
     transactionParameters: TransactionParametersItem,
+    mentionedUsersPks: seq[string],
     ): Item =
   result = Item()
   result.id = id
@@ -90,6 +92,7 @@ proc initItem*(
   result.isEdited = false
   result.links = links
   result.transactionParameters = transactionParameters
+  result.mentionedUsersPks = mentionedUsersPks
   result.gapFrom = 0
   result.gapTo = 0
 
@@ -118,6 +121,7 @@ proc `$`*(self: Item): string =
     isEdited:{$self.isEdited},
     links:{$self.links},
     transactionParameters:{$self.transactionParameters},
+    mentionedUsersPks:{$self.mentionedUsersPks},
     )"""
 
 proc id*(self: Item): string {.inline.} =
@@ -238,6 +242,12 @@ proc links*(self: Item): seq[string] {.inline.} =
 proc `links=`*(self: Item, links: seq[string]) {.inline.} =
   self.links = links
 
+proc mentionedUsersPks*(self: Item): seq[string] {.inline.} =
+  self.mentionedUsersPks
+
+proc `mentionedUsersPks=`*(self: Item, mentionedUsersPks: seq[string]) {.inline.} =
+  self.mentionedUsersPks = mentionedUsersPks
+
 proc transactionParameters*(self: Item): TransactionParametersItem {.inline.} =
   self.transactionParameters
 
@@ -270,7 +280,8 @@ proc toJsonNode*(self: Item): JsonNode =
     "pinnedBy": self.pinnedBy,
     "editMode": self.editMode,
     "isEdited": self.isEdited,
-    "links": self.links
+    "links": self.links,
+    "mentionedUsersPks": self.mentionedUsersPks
   }
 
 proc editMode*(self: Item): bool {.inline.} =

--- a/src/app/modules/shared_models/message_model.nim
+++ b/src/app/modules/shared_models/message_model.nim
@@ -35,6 +35,7 @@ type
     IsEdited
     Links
     TransactionParameters
+    MentionedUsersPks
 
 QtObject:
   type
@@ -107,6 +108,7 @@ QtObject:
       ModelRole.IsEdited.int: "isEdited",
       ModelRole.Links.int: "links",
       ModelRole.TransactionParameters.int: "transactionParameters",
+      ModelRole.MentionedUsersPks.int: "mentionedUsersPks"
     }.toTable
 
   method data(self: Model, index: QModelIndex, role: int): QVariant =
@@ -189,6 +191,8 @@ QtObject:
         "commandState": item.transactionParameters.commandState,
         "signature": item.transactionParameters.signature
       }))
+    of ModelRole.MentionedUsersPks:
+      result = newQVariant(item.mentionedUsersPks.join(" "))
 
   proc findIndexForMessageId*(self: Model, messageId: string): int =
     for i in 0 ..< self.items.len:
@@ -384,7 +388,8 @@ QtObject:
       messageId: string, 
       updatedMsg: string,
       messageContainsMentions: bool,
-      links: seq[string]
+      links: seq[string],
+      mentionedUsersPks: seq[string]
       ) =
     let ind = self.findIndexForMessageId(messageId)
     if(ind == -1):
@@ -394,13 +399,15 @@ QtObject:
     self.items[ind].messageContainsMentions = messageContainsMentions
     self.items[ind].isEdited = true
     self.items[ind].links = links
+    self.items[ind].mentionedUsersPks = mentionedUsersPks
 
     let index = self.createIndex(ind, 0, nil)
     self.dataChanged(index, index, @[
       ModelRole.MessageText.int,
       ModelRole.MessageContainsMentions.int,
       ModelRole.IsEdited.int,
-      ModelRole.Links.int
+      ModelRole.Links.int,
+      ModelRole.MentionedUsersPks.int
       ])
 
   proc clear*(self: Model) =

--- a/src/app_service/service/message/dto/message.nim
+++ b/src/app_service/service/message/dto/message.nim
@@ -182,3 +182,9 @@ proc isUserWithPkMentioned*(self: MessageDto, publicKey: string): bool =
       if (child.type == PARSED_TEXT_CHILD_TYPE_MENTION and child.literal.contains(publicKey)):
         return true
   return false
+
+proc mentionedUsersPks*(self: MessageDto): seq[string] =
+  for pText in self.parsedText:
+    for child in pText.children:
+      if (child.type == PARSED_TEXT_CHILD_TYPE_MENTION):
+        result.add(child.literal)

--- a/src/app_service/service/message/service.nim
+++ b/src/app_service/service/message/service.nim
@@ -48,6 +48,7 @@ const SIGNAL_MESSAGE_REACTION_FROM_OTHERS* = "messageReactionFromOthers"
 const SIGNAL_MESSAGE_DELETION* = "messageDeleted"
 const SIGNAL_MESSAGE_EDITED* = "messageEdited"
 const SIGNAL_MESSAGE_LINK_PREVIEW_DATA_LOADED* = "messageLinkPreviewDataLoaded"
+const SIGNAL_MENTIONED_IN_EDITED_MESSAGE* = "mentionedInEditedMessage"
 
 include async_tasks
 
@@ -708,3 +709,9 @@ proc editMessage*(self: Service, messageId: string, msg: string) =
 
 proc getWalletAccounts*(self: Service): seq[wallet_account_service.WalletAccountDto] =
   return self.walletAccountService.getWalletAccounts()
+
+proc checkEditedMessageForMentions*(self: Service, chatId: string, editedMessage: MessageDto, oldMentions: seq[string]) =
+  let myPubKey = singletonInstance.userProfile.getPubKey()
+  if not oldMentions.contains(myPubKey) and editedMessage.mentionedUsersPks().contains(myPubKey):
+    let data = MessageEditedArgs(chatId: chatId, message: editedMessage)
+    self.events.emit(SIGNAL_MENTIONED_IN_EDITED_MESSAGE, data)


### PR DESCRIPTION
When the user is mentioned in edited message he is notified about it.

### What does the PR do

Technical details (discussed with @saledjenic):

Introduce new signal in message service: SIGNAL_MENTIONED_IN_EDITED_MESSAGE.
Keeping mentioned users public keys in message item/model.
When message is edited, message module sends request to message service to
check if the current user is mentioned and emit SIGNAL_MENTIONED_IN_EDITED_MESSAGE.
The new signal is caught in chat_section module and badges are updated.

### Affected areas

Chat section.

### Screenshot of functionality

https://user-images.githubusercontent.com/61889657/159040501-ba71548e-3bb9-47ea-a10d-dbe5b58b723f.mov



