### PR TITLE
fix(node): enable bandwith reporting in node view

### DIFF
--- a/resources/node-config.json
+++ b/resources/node-config.json
@@ -38,7 +38,8 @@
     "VerifyENSContractAddress": "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e",
     "VerifyENSURL": "https://mainnet.infura.io/v3/%INFURA_KEY%",
     "VerifyTransactionChainID": 1,
-    "VerifyTransactionURL": "https://mainnet.infura.io/v3/%INFURA_KEY%"
+    "VerifyTransactionURL": "https://mainnet.infura.io/v3/%INFURA_KEY%",
+    "BandwidthStatsEnabled": true
   },
   "StatusAccountsConfig": {
     "Enabled": true

--- a/src/app_service/common/network_constants.nim
+++ b/src/app_service/common/network_constants.nim
@@ -147,7 +147,8 @@ var NODE_CONFIG* = %* {
     "VerifyENSContractAddress": "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e",
     "VerifyENSURL": "https://mainnet.infura.io/v3/" & INFURA_TOKEN_RESOLVED,
     "VerifyTransactionChainID": 1,
-    "VerifyTransactionURL": "https://mainnet.infura.io/v3/" & INFURA_TOKEN_RESOLVED
+    "VerifyTransactionURL": "https://mainnet.infura.io/v3/" & INFURA_TOKEN_RESOLVED,
+    "BandwidthStatsEnabled": true
   },
   "Web3ProviderConfig": {
     "Enabled": true
@@ -162,7 +163,7 @@ var NODE_CONFIG* = %* {
     "Enabled": true,
     "URL": "https://mainnet.infura.io/v3/" & INFURA_TOKEN_RESOLVED
   },
-   "WakuConfig": {
+  "WakuConfig": {
     "BloomFilterMode": true,
     "Enabled": true,
     "LightClient": true,

--- a/src/app_service/service/accounts/service.nim
+++ b/src/app_service/service/accounts/service.nim
@@ -311,6 +311,9 @@ proc login*(self: Service, account: AccountDto, password: string): string =
     # While this is fixed, you can add here any missing attribute on the node config, and it will be merged with whatever
     # the account has in the db
     var nodeCfg = %* {
+      "ShhextConfig": %* {
+        "BandwidthStatsEnabled": true
+      },
       "Web3ProviderConfig": %* {
         "Enabled": true
       },


### PR DESCRIPTION
## Fixes #4990

Also, add an entry to `services.nim` to upgrade the existing user configuration missing this value.

Affected areas

- Node page
- User config migration

Tried on: linux, windows

### Screenshot of functionality

![image](https://user-images.githubusercontent.com/47554641/159348997-5d0dcf14-b119-4fb5-8c3b-5e4994ad618b.png)

### Cool Spaceship Picture

No
