### PR TITLE
fix(@desktop/chat): cannot create a group chat by hitting `Confirm`

### DIFF
--- a/ui/app/AppLayouts/Chat/ChatLayout.qml
+++ b/ui/app/AppLayouts/Chat/ChatLayout.qml
@@ -46,6 +46,13 @@ StatusAppThreePanelLayout {
         }
     }
 
+    Connections {
+        target: root.rootStore.chatCommunitySectionModule
+        onActiveItemChanged: {
+            root.rootStore.openCreateChat = false;
+        }
+    }
+
 //    property var onActivated: function () {
 //        root.rootStore.chatsModelInst.channelView.restorePreviousActiveChannel();
 //        chatColumn.onActivated();
@@ -74,14 +81,12 @@ StatusAppThreePanelLayout {
         onOpenAppSearch: {
             root.openAppSearch();
         }
-        CreateChatView {
-            activeChatId: chatColumn.activeChatId
-            rootStore: root.rootStore
-        }
     }
 
     showRightPanel: {
-        if (!localAccountSensitiveSettings.showOnlineUsers || !localAccountSensitiveSettings.expandUsersList) {
+        if (root.rootStore.openCreateChat ||
+                !localAccountSensitiveSettings.showOnlineUsers ||
+                !localAccountSensitiveSettings.expandUsersList) {
             return false
         }
 

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -1,18 +1,23 @@
 import QtQuick 2.13
 
 import utils 1.0
+import StatusQ.Core.Utils 0.1 as StatusQUtils
 
 QtObject {
     id: root
 
     property var contactsStore
+
     property bool openCreateChat: false
-    property bool hideInput: false
-    property string createChatInitMessage
-    property var chatTextInput
+    property string createChatInitMessage: ""
+    property var createChatFileUrls: []
+    property bool createChatStartSendTransactionProcess: false
+    property bool createChatStartReceiveTransactionProcess: false
+    property string createChatStickerHashId: ""
+    property string createChatStickerPackId: ""
+
     property var contactsModel: profileSectionModule.contactsModule.myContactsModel
-    signal addRemoveGroupMember()
-    signal createChatWithMessage()
+
     // Important:
     // Each `ChatLayout` has its own chatCommunitySectionModule
     // (on the backend chat and community sections share the same module since they are actually the same)
@@ -65,6 +70,40 @@ QtObject {
 
     function blockContact(pubKey) {
         chatCommunitySectionModule.blockContact(pubKey)
+    }
+
+    function interpretMessage(msg) {
+        if (msg.startsWith("/shrug")) {
+            return  msg.replace("/shrug", "") + " ¯\\\\\\_(ツ)\\_/¯"
+        }
+        if (msg.startsWith("/tableflip")) {
+            return msg.replace("/tableflip", "") + " (╯°□°）╯︵ ┻━┻"
+        }
+
+        return msg
+    }
+
+    function sendMessage(event, text, replyMessageId, fileUrls) {
+        var chatContentModule = currentChatContentModule()
+        if (fileUrls.length > 0){
+            chatContentModule.inputAreaModule.sendImages(JSON.stringify(fileUrls));
+        }
+        let msg = globalUtils.plainText(StatusQUtils.Emoji.deparse(text))
+        if (msg.length > 0) {
+            msg = interpretMessage(msg)
+
+            chatContentModule.inputAreaModule.sendMessage(
+                        msg,
+                        replyMessageId,
+                        Utils.isOnlyEmoji(msg) ? Constants.messageContentType.emojiType : Constants.messageContentType.messageType,
+                        false)
+
+            if (event)
+                event.accepted = true
+
+            return true
+        }
+        return false
     }
 
 

--- a/ui/app/AppLayouts/Chat/views/ContactsColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ContactsColumnView.qml
@@ -160,7 +160,6 @@ Item {
             model: root.chatSectionModule.model
             onChatItemSelected: {
                 root.chatSectionModule.setActiveItem(id, "")
-                root.store.openCreateChat = false;
             }
             onChatItemUnmuted: root.chatSectionModule.unmuteChat(id)
 

--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -161,17 +161,6 @@ Rectangle {
         mentionsPos.push({"name": aliasName,"leftIndex": lastAtPosition, "rightIndex": (lastAtPosition+aliasName.length+1)});
     }
 
-    property var interpretMessage: function (msg) {
-        if (msg.startsWith("/shrug")) {
-            return  msg.replace("/shrug", "") + " ¯\\\\\\_(ツ)\\_/¯"
-        }
-        if (msg.startsWith("/tableflip")) {
-            return msg.replace("/tableflip", "") + " (╯°□°）╯︵ ┻━┻"
-        }
-
-        return msg
-    }
-
     function isUploadFilePressed(event) {
         return (event.key === Qt.Key_U) && (event.modifiers & Qt.ControlModifier) && imageBtn.visible && !imageDialog.visible
     }


### PR DESCRIPTION
While I was checking what's wrong with this Issue #5094, I noticed multiple things which we need to improve/update/fix. Going to list them now:
1. The same `CreateChatView` component is shared between "create chat" and "edit chat" functionalities even those two belong to different context and different use cases.
2. `StatusChatInput` component which is subcomponent of `ChatContentView` is used from the 2 levels up and borrowed to `CreateChatView` in case we're creating new chat, what is a big misuse and bring lot of confusion. 
3. Furthermore point 2. brings another issue where displayed `StatusChatInput` depends on selected chat, but not on selected contacts for `1:1` or `group chat` (request is if there is a single contact selected except sending message, image, gif, emoji or sticker we need to have option for sending/receiving transactions).
4. Activity center button is taken from the `StatusChatToolBar` which is part of the `ChatContentView` component by simply setting `anchors.rightMargin: 32` of the `CreateChatView` component which is placed above `ChatContentView` which is not what we want. That's inappropriate use which will hit (or already hit us as boomerang). 
5. Colors for dark theme are missed.
6. In case of "Add/Remove from group" action, we don't need list of contacts, but just `StatusTagSelector` with suggestions up to 5 contacts.

I did some changes based on the code which was already there but there is much more to do.

In this PR `StatusChatInput` is added to `CreateChatView` and `CreateChatView` is configured to support creation chat either by clicking on `Confirm` button or sending message, image, gif, emoji or sticker or in case a single contact is selected sending/receiving transactions. Colors are updated so they match dark theme now.

What remains to be done is:
- We need to add `Activity Center` button to the `CreateChatView` (as it's by design).
- We need to deal with "Add/Remove from group" action, but through new component which may be named `EditGroupChatView` and it should be part of `ChatContentView`, most likely we need to update `StatusChatToolBar` cause `EditGroupChatView` should be part of it.
- Actually... we need to restructure a bit that part on the qml side.

Fixes #5094