### PR TITLE
fix(onboarding): create pwd view was white in dark mode

### DIFF
--- a/ui/app/AppLayouts/Onboarding/views/ConfirmPasswordView.qml
+++ b/ui/app/AppLayouts/Onboarding/views/ConfirmPasswordView.qml
@@ -21,6 +21,7 @@ Page {
     signal backClicked()
 
     anchors.fill: parent
+    background: null
 
     Component.onCompleted: confPswInput.forceActiveFocus(Qt.MouseFocusReason)
 

--- a/ui/app/AppLayouts/Onboarding/views/CreatePasswordView.qml
+++ b/ui/app/AppLayouts/Onboarding/views/CreatePasswordView.qml
@@ -19,7 +19,7 @@ Page {
     signal backClicked()
 
     Component.onCompleted: { view.forceNewPswInputFocus() }
-
+    background: null
     QtObject {
         id: d
         readonly property int zBehind: 1


### PR DESCRIPTION
Closes #5065

### What does the PR do
fixes the create password view is white on dark mode

### Affected areas
onboarding

### Screenshot of functionality
<img width="1109" alt="cpwd" src="https://user-images.githubusercontent.com/31625338/159589744-ae930748-983e-417a-9025-5873dfe194d4.png">
<img width="1109" alt="cfpwd" src="https://user-images.githubusercontent.com/31625338/159589749-9610bed8-91bb-452a-81a4-366894300eb8.png">


