### PR TITLE
fix(chat): fix removal of emojis in reply preview

### DIFF
--- a/ui/imports/shared/status/StatusChatInputReplyArea.qml
+++ b/ui/imports/shared/status/StatusChatInputReplyArea.qml
@@ -62,7 +62,7 @@ Rectangle {
 
         StyledText {
             id: replyText
-            text: Utils.getMessageWithStyle(Utils.linkifyAndXSS(StatusQUtils.Emoji.parse(message)), false)
+            text: Utils.getMessageWithStyle(StatusQUtils.Emoji.parse(Utils.linkifyAndXSS(message)), false)
             anchors.fill: parent
             elide: Text.ElideRight
             font.pixelSize: 13


### PR DESCRIPTION
## Fixes #4899

Emojis are parsed in a message to transform from special emojis characters in qml image links. After this transformation, an XSS filter was applied that "fixes" all the image URLs introduced by the previous stage.
Reversing the order of these operations fixed the issue.

### Affected areas

Chat message list

### Screenshot of functionality

![image](https://user-images.githubusercontent.com/47554641/159650909-28a92696-f9be-4a32-9b05-9bcf05151ba1.png)
