### PR TITLE
fix(@desktop/general): the default profile picture and profile emojis are blurred on the Profile page

### DIFF
--- a/ui/app/AppLayouts/Profile/views/MyProfileView.qml
+++ b/ui/app/AppLayouts/Profile/views/MyProfileView.qml
@@ -85,7 +85,8 @@ ColumnLayout {
 
         imageWidth: 80
         imageHeight: 80
-        emojiSize: "20x20"
+        emojiSize: Qt.size(20,20)
+        supersampling: true
 
         imageOverlay: Item {
             StatusFlatRoundButton {

--- a/ui/imports/shared/controls/chat/ProfileHeader.qml
+++ b/ui/imports/shared/controls/chat/ProfileHeader.qml
@@ -93,6 +93,7 @@ Item {
             property string size: "14x14"
 
             Layout.fillWidth: true
+            renderType: Text.NativeRendering
 
             text: {
                 const emojiHash = Utils.getEmojiHashAsJson(root.pubkey)

--- a/ui/imports/shared/controls/chat/ProfileHeader.qml
+++ b/ui/imports/shared/controls/chat/ProfileHeader.qml
@@ -20,7 +20,8 @@ Item {
 
     property alias imageWidth: userImage.imageWidth
     property alias imageHeight: userImage.imageHeight
-    property alias emojiSize: emojihash.size
+    property size emojiSize: Qt.size(14, 14)
+    property bool supersampling: true
 
     property alias imageOverlay: imageOverlay.sourceComponent
 
@@ -90,10 +91,12 @@ Item {
         Text {
             id: emojihash
 
-            property string size: "14x14"
+            readonly property size finalSize: supersampling ? Qt.size(emojiSize.width * 2, emojiSize.height * 2) : emojiSize
+            property string size: `${finalSize.width}x${finalSize.height}`
 
             Layout.fillWidth: true
             renderType: Text.NativeRendering
+            scale: supersampling ? 0.5 : 1
 
             text: {
                 const emojiHash = Utils.getEmojiHashAsJson(root.pubkey)

--- a/ui/imports/shared/controls/chat/UserImage.qml
+++ b/ui/imports/shared/controls/chat/UserImage.qml
@@ -30,7 +30,7 @@ Loader {
             width: root.imageWidth
             height: root.imageHeight
             source: root.isIdenticon ? "" : root.icon
-            isIdenticon: false
+            isIdenticon: root.isIdenticon
         }
         icon {
             width: root.imageWidth

--- a/ui/imports/shared/popups/ProfilePopup.qml
+++ b/ui/imports/shared/popups/ProfilePopup.qml
@@ -122,8 +122,9 @@ StatusModal {
 
                 displayNameVisible: false
                 pubkeyVisible: false
+                supersampling: true
+                emojiSize: Qt.size(20,20)
 
-                emojiSize: "20x20"
                 imageWidth: 80
                 imageHeight: 80
 


### PR DESCRIPTION
@elina2015 I think that emojis rendering in are slightly better now.

As of profile image... I checked what's happening and I could do literally nothing cause by default identicons are generated in size of 50x50 pixels and in that "change profile picture" popup we display them in size of 160x160 pixels, and that's the reason of poor quality in that view. For comparison if you check the same identicon on the login screen you will see that it is displayed far better, but that's because we display it there in 40x40 pixels.

To check that, just open any identicon and download that image from your browser, for example open this in your browser:
`data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADIAAAAyCAYAAAAeP4ixAAAAjUlEQVR4nOzWwQmAMAxAURV30QEdwwF1Gr0Xi8mh8An/nUvhEwhZpiIMoTGExhAaQ2jKhKzRh+d9PZmPj22fR/7TKjMRQ2gMoTGExhAaQ2jCt1ZP9Bb6e5+9wVplJmIIjSE0qY3zpbdtstspu/1aZSZiCI0hGqTMRAyhMYTGEBpDaAyhMYTGEJo3AAD//4uOFSpUpwuKAAAAAElFTkSuQmCC`

Fixes #5109