### PR TITLE
wip idea(Profile): workaround to increase emoji sharpness in Profile

### DIFF
--- a/ui/app/AppLayouts/Profile/views/MyProfileView.qml
+++ b/ui/app/AppLayouts/Profile/views/MyProfileView.qml
@@ -85,7 +85,8 @@ ColumnLayout {
 
         imageWidth: 80
         imageHeight: 80
-        emojiSize: "20x20"
+        emojiSize: Qt.size(20,20)
+        supersampling: true
 
         imageOverlay: Item {
             StatusFlatRoundButton {

--- a/ui/imports/shared/controls/chat/ProfileHeader.qml
+++ b/ui/imports/shared/controls/chat/ProfileHeader.qml
@@ -20,7 +20,8 @@ Item {
 
     property alias imageWidth: userImage.imageWidth
     property alias imageHeight: userImage.imageHeight
-    property alias emojiSize: emojihash.size
+    property size emojiSize: Qt.size(14, 14)
+    property bool supersampling: true
 
     property alias imageOverlay: imageOverlay.sourceComponent
 
@@ -90,10 +91,12 @@ Item {
         Text {
             id: emojihash
 
-            property string size: "14x14"
+            readonly property size finalSize: supersampling ? Qt.size(emojiSize.width * 2, emojiSize.height * 2) : emojiSize
+            property string size: `${finalSize.width}x${finalSize.height}`
 
             Layout.fillWidth: true
             renderType: Text.NativeRendering
+            scale: supersampling ? 0.5 : 1
 
             text: {
                 const emojiHash = Utils.getEmojiHashAsJson(root.pubkey)

--- a/ui/imports/shared/popups/ProfilePopup.qml
+++ b/ui/imports/shared/popups/ProfilePopup.qml
@@ -122,8 +122,9 @@ StatusModal {
 
                 displayNameVisible: false
                 pubkeyVisible: false
+                supersampling: true
+                emojiSize: Qt.size(20,20)
 
-                emojiSize: "20x20"
                 imageWidth: 80
                 imageHeight: 80
 


### PR DESCRIPTION
Note that the PR is targeting and include changes in #5125 for clarity.
Further investigations are required to check if this can be achieved without a workaround or high effort.

## Attempt to improve #5133

 Add "supersampling" option to the ProfileHeader. Enabling the option will draw the emojis at double the resolution and downsample them by scaling down the text control by half to compensate for the resolution increase

- [ ] fix space introduced by scaling

### Affected areas

Profile preview

### Screenshot of functionality

| Before         | After     |
|--------------|-----------|
| ![supersampling_off](https://user-images.githubusercontent.com/47554641/159808989-3e4d1ddb-2956-45b1-8850-3e1ac6aa7bfd.png) | ![supersampling_on](https://user-images.githubusercontent.com/47554641/159808986-edc3f653-0474-415d-adfc-edf073aa07e2.png)|
| ![14-supersampling-off](https://user-images.githubusercontent.com/47554641/159809107-84cf6592-0e91-4647-b5b2-c3e79f6c8ffd.png) | ![14-supersampling-on](https://user-images.githubusercontent.com/47554641/159809108-85e62402-8ade-4243-9a86-485316ddd88c.png)|