### PR TITLE
fix(@desktop/wallet): User stays on removed account view in wallet after account removal from settings

### DIFF
--- a/src/app/modules/main/browser_section/current_account/module.nim
+++ b/src/app/modules/main/browser_section/current_account/module.nim
@@ -1,6 +1,7 @@
 import NimQml
 
 import ../../../../global/global_singleton
+import ../../../../core/eventemitter
 import ../../../../../app_service/service/wallet_account/service as wallet_account_service
 
 import ./io_interface, ./view, ./controller
@@ -11,6 +12,7 @@ export io_interface
 type
   Module* = ref object of io_interface.AccessInterface
     delegate: delegate_interface.AccessInterface
+    events: EventEmitter
     view: View
     controller: Controller
     moduleLoaded: bool
@@ -18,10 +20,12 @@ type
 
 proc newModule*(
   delegate: delegate_interface.AccessInterface,
+  events: EventEmitter,
   walletAccountService: wallet_account_service.Service,
 ): Module =
   result = Module()
   result.delegate = delegate
+  result.events = events
   result.currentAccountIndex = 0
   result.view = newView(result)
   result.controller = newController(result, walletAccountService)
@@ -37,6 +41,11 @@ method switchAccount*(self: Module, accountIndex: int) =
 
 method load*(self: Module) =
   singletonInstance.engine.setRootContextProperty("browserSectionCurrentAccount", newQVariant(self.view))
+
+  self.events.on(SIGNAL_WALLET_ACCOUNT_DELETED) do(e:Args):
+    if(self.view.isAddressCurrentAccount(AccountDeleted(e).account.address)):
+      self.switchAccount(0)
+      self.view.connectedAccountDeleted()
 
   self.controller.init()
   self.view.load()

--- a/src/app/modules/main/browser_section/current_account/view.nim
+++ b/src/app/modules/main/browser_section/current_account/view.nim
@@ -128,6 +128,7 @@ QtObject:
     self.delegate.switchAccountByAddress(address)
 
 
+  proc connectedAccountDeleted*(self: View) {.signal.}
 
 proc setData*(self: View, dto: wallet_account_service.WalletAccountDto) =
     self.name = dto.name
@@ -162,4 +163,7 @@ proc setData*(self: View, dto: wallet_account_service.WalletAccountDto) =
     )
     self.assets = assets
     self.assetsChanged()
+
+proc isAddressCurrentAccount*(self: View, address: string): bool =
+  return self.address == address
 

--- a/src/app/modules/main/browser_section/module.nim
+++ b/src/app/modules/main/browser_section/module.nim
@@ -3,6 +3,7 @@ import io_interface
 import ../io_interface as delegate_interface
 import view
 import ../../../global/global_singleton
+import ../../../core/eventemitter
 import provider/module as provider_module
 import bookmark/module as bookmark_module
 import dapps/module as dapps_module
@@ -18,6 +19,7 @@ export io_interface
 type
   Module* = ref object of io_interface.AccessInterface
     delegate: delegate_interface.AccessInterface
+    events: EventEmitter
     view: View
     viewVariant: QVariant
     moduleLoaded: bool
@@ -27,6 +29,7 @@ type
     currentAccountModule: current_account_module.AccessInterface
 
 proc newModule*(delegate: delegate_interface.AccessInterface,
+    events: EventEmitter,
     bookmarkService: bookmark_service.Service,
     settingsService: settings_service.Service,
     dappPermissionsService: dapp_permissions_service.Service,
@@ -34,13 +37,14 @@ proc newModule*(delegate: delegate_interface.AccessInterface,
     walletAccountService: wallet_account_service.Service): Module =
   result = Module()
   result.delegate = delegate
+  result.events = events
   result.view = view.newView(result)
   result.viewVariant = newQVariant(result.view)
   result.moduleLoaded = false
   result.providerModule = provider_module.newModule(result, settingsService, providerService)
   result.bookmarkModule = bookmark_module.newModule(result, bookmarkService)
   result.dappsModule = dapps_module.newModule(result, dappPermissionsService, walletAccountService)
-  result.currentAccountModule = current_account_module.newModule(result, walletAccountService)
+  result.currentAccountModule = current_account_module.newModule(result, events, walletAccountService)
 
 method delete*(self: Module) =
   self.view.delete

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -139,7 +139,7 @@ proc newModule*[T](
     transactionService, collectible_service, walletAccountService,
     settingsService, savedAddressService, networkService,
   )
-  result.browserSectionModule = browser_section_module.newModule(result, bookmarkService, settingsService,
+  result.browserSectionModule = browser_section_module.newModule(result, events, bookmarkService, settingsService,
   dappPermissionsService, providerService, walletAccountService)
   result.profileSectionModule = profile_section_module.newModule(
     result, events, accountsService, settingsService, stickersService,

--- a/src/app/modules/main/wallet_section/module.nim
+++ b/src/app/modules/main/wallet_section/module.nim
@@ -107,6 +107,7 @@ method load*(self: Module) =
   self.events.on(SIGNAL_WALLET_ACCOUNT_SAVED) do(e:Args):
     self.setTotalCurrencyBalance()
   self.events.on(SIGNAL_WALLET_ACCOUNT_DELETED) do(e:Args):
+    self.switchAccount(0)
     self.setTotalCurrencyBalance()
   self.events.on(SIGNAL_WALLET_ACCOUNT_CURRENCY_UPDATED) do(e:Args):
     self.setTotalCurrencyBalance()

--- a/src/app_service/service/wallet_account/service.nim
+++ b/src/app_service/service/wallet_account/service.nim
@@ -66,8 +66,8 @@ proc fetchNativeChainBalance(network: NetworkDto, accountAddress: string): float
 type AccountSaved = ref object of Args
   account: WalletAccountDto
 
-type AccountDeleted = ref object of Args
-  account: WalletAccountDto
+type AccountDeleted* = ref object of Args
+  account*: WalletAccountDto
 
 type CurrencyUpdated = ref object of Args
 

--- a/ui/app/AppLayouts/Browser/popups/BrowserWalletMenu.qml
+++ b/ui/app/AppLayouts/Browser/popups/BrowserWalletMenu.qml
@@ -104,6 +104,18 @@ Popup {
         }
     }
 
+
+    Connections {
+        target: WalletStore.dappBrowserAccount
+        onConnectedAccountDeleted: {
+            popup.reload()
+            // This is done because when an account is deleted and the account is updated to default one,
+            // only the properties are updated and we need to listen to those events and update the selected account
+            accountSelectorRow.currentAddress = ""
+            accountSelector.selectedAccount =  Qt.binding(function () {return WalletStore.dappBrowserAccount})
+        }
+    }
+
     Item {
         property string currentAddress: ""
         id: accountSelectorRow

--- a/ui/app/AppLayouts/Wallet/WalletLayout.qml
+++ b/ui/app/AppLayouts/Wallet/WalletLayout.qml
@@ -86,7 +86,6 @@ Item {
                 if (newIndex > RootStore.accounts) {
                     return
                 }
-                selectedAccountIndex = newIndex
                 RootStore.switchAccount(newIndex)
 
             }

--- a/ui/app/AppLayouts/Wallet/views/LeftTabView.qml
+++ b/ui/app/AppLayouts/Wallet/views/LeftTabView.qml
@@ -18,7 +18,6 @@ import "../stores"
 Rectangle {
     id: walletInfoContainer
 
-    property int selectedAccountIndex: 0
     property var changeSelectedAccount: function(){}
     property var showSavedAddresses: function(showSavedAddresses){}
     property var emojiPopup: null
@@ -162,7 +161,7 @@ Rectangle {
 
             delegate: StatusListItem {
                 width: parent.width
-                highlighted: index === selectedAccountIndex
+                highlighted: RootStore.currentAccount.name === model.name
                 title: model.name
                 subTitle: Utils.toLocaleString(model.currencyBalance.toFixed(2), RootStore.locale, {"model.currency": true}) + " " + RootStore.currentCurrency.toUpperCase()
                 icon.emoji: !!model.emoji ? model.emoji: ""


### PR DESCRIPTION
User stays on removed account view in wallet after account removal from settings

fixes #5037

### What does the PR do

Switch account for wallet and browser when an account is deleted

### Affected areas

Wallet, Browser

### Screenshot of functionality

https://user-images.githubusercontent.com/60327365/159912379-4ab91883-7a2a-4948-8816-772b993ef94b.mov


