### PR TITLE
feature(desktop/internal): Improve log file naming convention

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -195,6 +195,9 @@ VERSIONFILE=VERSION
 DESKTOP_VERSION=`cat $(VERSIONFILE)`
 NIM_PARAMS += -d:DESKTOP_VERSION="$(DESKTOP_VERSION)"
 
+GIT_COMMIT=`git log --pretty=format:'%h' -n 1`
+NIM_PARAMS += -d:GIT_COMMIT="$(GIT_COMMIT)"
+
 $(DOTHERSIDE): | deps
 	echo -e $(BUILD_MSG) "DOtherSide"
 	+ cd vendor/DOtherSide && \

--- a/src/app_service/service/about/service.nim
+++ b/src/app_service/service/about/service.nim
@@ -2,6 +2,7 @@ import NimQml, json, chronicles
 
 import ../../../app/core/eventemitter
 import ../../../app/core/tasks/[qt, threadpool]
+import ../../../constants
 
 import ../settings/service as settings_service
 import ../network/types
@@ -12,9 +13,6 @@ include async_tasks
 
 logScope:
   topics = "about-service"
-
-# This is changed during compilation by reading the VERSION file
-const DESKTOP_VERSION {.strdefine.} = "0.0.0"
 
 type
   VersionArgs* = ref object of Args

--- a/src/constants.nim
+++ b/src/constants.nim
@@ -64,3 +64,8 @@ proc ensureDirectories*(dataDir, tmpDir, logDir: string) =
   createDir(dataDir)
   createDir(tmpDir)
   createDir(logDir)
+
+# This is changed during compilation by reading the VERSION file
+const DESKTOP_VERSION* {.strdefine.} = "0.0.0"
+# This is changed during compilation by executing git command
+const GIT_COMMIT* {.strdefine.} = ""

--- a/src/nim_status_client.nim
+++ b/src/nim_status_client.nim
@@ -49,7 +49,8 @@ proc prepareLogging() =
         except:
           logLoggingFailure(cstring(msg), getCurrentException())
 
-  let logFile = fmt"app_{getTime().toUnix}.log"
+  let formattedDate = now().format("yyyyMMdd'_'HHmmss")
+  let logFile = fmt"app_{formattedDate}.log"
   discard defaultChroniclesStream.outputs[1].open(LOGDIR & logFile, fmAppend)
 
 proc setupRemoteSignalsHandling() =
@@ -133,6 +134,10 @@ proc mainProc() =
   if singleInstance.secondInstance():
     info "Terminating the app as the second instance"
     quit()
+
+  info fmt("Version: {DESKTOP_VERSION}")
+  info fmt("Commit: {GIT_COMMIT}")
+  info "Current date:", currentDateTime=now()
 
   info "starting application controller..."
   appController.start()


### PR DESCRIPTION
Logs are named app_yyyyMMdd_HHmmss.log
Version, commit and start date information are displayed in logs at the begining.
Injecting commit version from Makefile.
Moving DESKTOP_VERSION const to constants.nim

Fix #3611

### Affected areas

Desktop / log files

![image](https://user-images.githubusercontent.com/61889657/159911535-75882bf1-2b64-4c6a-a116-a66ea7bb19eb.png)

