### PR TITLE
Contact lists should only shown mutual contacts

### DIFF
--- a/src/app/modules/main/chat_section/chat_content/controller.nim
+++ b/src/app/modules/main/chat_section/chat_content/controller.nim
@@ -149,8 +149,8 @@ proc getMessageDetails*(self: Controller, messageId: string):
 proc isUsersListAvailable*(self: Controller): bool =
   return self.isUsersListAvailable
 
-proc getMyAddedContacts*(self: Controller): seq[ContactsDto] =
-  return self.contactService.getAddedContacts()
+proc getMyMutualContacts*(self: Controller): seq[ContactsDto] =
+  return self.contactService.getContactsByGroup(ContactsGroup.MyMutualContacts)
 
 proc muteChat*(self: Controller) =
   self.chatService.muteChat(self.chatId)

--- a/src/app/modules/main/chat_section/chat_content/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/module.nim
@@ -234,7 +234,7 @@ method getMyChatId*(self: Module): string =
   self.controller.getMyChatId()
 
 method isMyContact*(self: Module, contactId: string): bool =
-  self.controller.getMyAddedContacts().filter(x => x.id == contactId).len > 0
+  self.controller.getMyMutualContacts().filter(x => x.id == contactId).len > 0
 
 method muteChat*(self: Module) =
   self.controller.muteChat()

--- a/src/app/modules/main/chat_section/controller.nim
+++ b/src/app/modules/main/chat_section/controller.nim
@@ -267,8 +267,8 @@ proc clearChatHistory*(self: Controller, chatId: string) =
 proc getCurrentFleet*(self: Controller): string =
   return self.settingsService.getFleetAsString()
 
-proc getContacts*(self: Controller): seq[ContactsDto] =
-  return self.contactService.getContacts()
+proc getContacts*(self: Controller, group: ContactsGroup): seq[ContactsDto] =
+  return self.contactService.getContactsByGroup(group)
 
 proc getContactDetails*(self: Controller, id: string): ContactDetails =
   return self.contactService.getContactDetails(id)

--- a/src/app/modules/main/controller.nim
+++ b/src/app/modules/main/controller.nim
@@ -265,8 +265,8 @@ proc setUserStatus*(self: Controller, status: bool) =
 proc getContact*(self: Controller, id: string): ContactsDto =
   return self.contactsService.getContactById(id)
 
-proc getContacts*(self: Controller): seq[ContactsDto] =
-  return self.contactsService.getContacts()
+proc getContacts*(self: Controller, group: ContactsGroup): seq[ContactsDto] =
+  return self.contactsService.getContactsByGroup(group)
 
 proc getContactNameAndImage*(self: Controller, contactId: string):
   tuple[name: string, image: string, isIdenticon: bool] =

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -261,7 +261,7 @@ method load*[T](
   var activeSectionId = singletonInstance.localAccountSensitiveSettings.getActiveSection()
 
   # Chat Section
-  let receivedContactRequests = self.controller.getContacts().filter(x => x.requestReceived() and not x.isContact() and not x.isBlocked())
+  let receivedContactRequests = self.controller.getContacts(ContactsGroup.IncomingPendingContactRequests)
   let (unviewedCount, mentionsCount) = self.controller.getNumOfNotificaitonsForChat()
   let notificationsCount = mentionsCount + receivedContactRequests.len
   let hasNotification = unviewedCount > 0 or notificationsCount > 0

--- a/src/app/modules/main/profile_section/contacts/controller.nim
+++ b/src/app/modules/main/profile_section/contacts/controller.nim
@@ -37,6 +37,10 @@ proc init*(self: Controller) =
     var args = ContactArgs(e)
     self.delegate.contactRemoved(args.contactId)
 
+  self.events.on(SIGNAL_CONTACT_REJECTION_REMOVED) do(e: Args):
+    var args = ContactArgs(e)
+    self.delegate.contactRequestRejectionRemoved(args.contactId)
+
   self.events.on(SIGNAL_CONTACT_NICKNAME_CHANGED) do(e: Args):
     var args = ContactArgs(e)
     self.delegate.contactNicknameChanged(args.contactId)
@@ -45,8 +49,8 @@ proc init*(self: Controller) =
     var args = ContactArgs(e)
     self.delegate.contactUpdated(args.contactId)
 
-proc getContacts*(self: Controller): seq[ContactsDto] =
-  return self.contactsService.getContacts()
+proc getContacts*(self: Controller, group: ContactsGroup): seq[ContactsDto] =
+  return self.contactsService.getContactsByGroup(group)
 
 proc getContact*(self: Controller, id: string): ContactsDto =
   return self.contactsService.getContactById(id)
@@ -69,3 +73,9 @@ proc removeContact*(self: Controller, publicKey: string) =
 
 proc changeContactNickname*(self: Controller, publicKey: string, nickname: string) =
   self.contactsService.changeContactNickname(publicKey, nickname)
+
+proc rejectContactRequest*(self: Controller, publicKey: string) =
+  self.contactsService.rejectContactRequest(publicKey)
+
+proc removeContactRequestRejection*(self: Controller, publicKey: string) =
+  self.contactsService.removeContactRequestRejection(publicKey)

--- a/src/app/modules/main/profile_section/contacts/io_interface.nim
+++ b/src/app/modules/main/profile_section/contacts/io_interface.nim
@@ -46,6 +46,8 @@ method blockContact*(self: AccessInterface, publicKey: string) {.base.} =
 method removeContact*(self: AccessInterface, publicKey: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method removeContactRequestRejection*(self: AccessInterface, publicKey: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
 
 # Controller Delegate Interface
 
@@ -65,4 +67,7 @@ method contactNicknameChanged*(self: AccessInterface, publicKey: string) {.base.
   raise newException(ValueError, "No implementation available")
 
 method contactUpdated*(self: AccessInterface, publicKey: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method contactRequestRejectionRemoved*(self: AccessInterface, publicKey: string) {.base.} =
   raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/profile_section/contacts/module.nim
+++ b/src/app/modules/main/profile_section/contacts/module.nim
@@ -40,22 +40,17 @@ proc createItemFromPublicKey(self: Module, publicKey: string): Item =
   let contact =  self.controller.getContact(publicKey)
   let (name, image, isIdenticon) = self.controller.getContactNameAndImage(contact.id)
 
-  return initItem(contact.id, name, image, isIdenticon, contact.isContact(), contact.isBlocked(),
-  contact.requestReceived())
+  return initItem(contact.id, name, image, isIdenticon, contact.isMutualContact(), contact.isBlocked(),
+  contact.isContactVerified(), contact.isContactUntrustworthy())
 
-proc initModels(self: Module) =
-  var myContacts: seq[Item]
-  var blockedContacts: seq[Item]
-  let contacts =  self.controller.getContacts()
+proc buildModel(self: Module, model: Model, group: ContactsGroup) =
+  var items: seq[Item]
+  let contacts =  self.controller.getContacts(group)
   for c in contacts:
     let item = self.createItemFromPublicKey(c.id)
-    if(item.isContact() and c.id != singletonInstance.userProfile.getPubKey()):
-      myContacts.add(item)
-    if(item.isBlocked()):
-      blockedContacts.add(item)
+    items.add(item)
 
-  self.view.myContactsModel().addItems(myContacts)
-  self.view.blockedContactsModel().addItems(blockedContacts)
+  model.addItems(items)
 
 method load*(self: Module) =
   self.controller.init()
@@ -65,7 +60,13 @@ method isLoaded*(self: Module): bool =
   return self.moduleLoaded
 
 method viewDidLoad*(self: Module) =
-  self.initModels()
+  self.buildModel(self.view.myMutualContactsModel(), ContactsGroup.MyMutualContacts)
+  self.buildModel(self.view.blockedContactsModel(), ContactsGroup.BlockedContacts)
+  self.buildModel(self.view.receivedContactRequestsModel(), ContactsGroup.IncomingPendingContactRequests)
+  self.buildModel(self.view.sentContactRequestsModel(), ContactsGroup.OutgoingPendingContactRequests)
+  self.buildModel(self.view.receivedButRejectedContactRequestsModel(), ContactsGroup.IncomingRejectedContactRequests)
+  self.buildModel(self.view.sentButRejectedContactRequestsModel(), ContactsGroup.IncomingRejectedContactRequests)
+
   self.moduleLoaded = true
   self.delegate.contactsModuleDidLoad()
 
@@ -75,34 +76,8 @@ method getModuleAsVariant*(self: Module): QVariant =
 method addContact*(self: Module, publicKey: string) =
   self.controller.addContact(publicKey)
 
-method contactAdded*(self: Module, publicKey: string) =
-  let item = self.createItemFromPublicKey(publicKey)
-  self.view.myContactsModel().addItem(item)
-  self.view.blockedContactsModel().removeItemWithPubKey(publicKey)
-
-method contactBlocked*(self: Module, publicKey: string) =
-  let item = self.createItemFromPublicKey(publicKey)
-  self.view.myContactsModel().removeItemWithPubKey(publicKey)
-  self.view.blockedContactsModel().addItem(item)
-
-method contactUnblocked*(self: Module, publicKey: string) =
-  let item = self.createItemFromPublicKey(publicKey)
-  self.view.myContactsModel().addItem(item)
-  self.view.blockedContactsModel().removeItemWithPubKey(publicKey)
-
-method contactRemoved*(self: Module, publicKey: string) =
-  self.view.myContactsModel().removeItemWithPubKey(publicKey)
-  self.view.blockedContactsModel().removeItemWithPubKey(publicKey)
-
-method contactNicknameChanged*(self: Module, publicKey: string) =
-  let (name, _, _) = self.controller.getContactNameAndImage(publicKey)
-  self.view.myContactsModel().updateName(publicKey, name)
-  self.view.blockedContactsModel().updateName(publicKey, name)
-
-method contactUpdated*(self: Module, publicKey: string) =
-  let item = self.createItemFromPublicKey(publicKey)
-  self.view.myContactsModel().updateItem(item)
-  self.view.blockedContactsModel().updateItem(item)
+method rejectContactRequest*(self: Module, publicKey: string) =
+  self.controller.rejectContactRequest(publicKey)
 
 method unblockContact*(self: Module, publicKey: string) =
   self.controller.unblockContact(publicKey)
@@ -115,3 +90,62 @@ method removeContact*(self: Module, publicKey: string) =
 
 method changeContactNickname*(self: Module, publicKey: string, nickname: string) =
   self.controller.changeContactNickname(publicKey, nickname)
+
+method removeContactRequestRejection*(self: Module, publicKey: string) =
+  self.controller.removeContactRequestRejection(publicKey)
+
+proc addItemToAppropriateModel(self: Module, item: Item) =
+  if(item.isBlocked()):
+    self.view.blockedContactsModel().addItem(item)
+  elif(item.isMutualContact()):
+    self.view.myMutualContactsModel().addItem(item)
+  else:
+    let contact =  self.controller.getContact(item.pubKey())
+    if(contact.isContactRequestReceived() and not contact.isContactRequestSent() and not contact.isReceivedContactRequestRejected()):
+      self.view.receivedContactRequestsModel().addItem(item)
+    elif(contact.isContactRequestSent() and not contact.isContactRequestReceived() and not contact.isSentContactRequestRejected()):
+      self.view.sentContactRequestsModel().addItem(item)
+    elif(contact.isContactRequestReceived() and contact.isReceivedContactRequestRejected()):
+      self.view.receivedButRejectedContactRequestsModel().addItem(item)
+    elif(contact.isContactRequestSent() and contact.isSentContactRequestRejected()):
+      self.view.sentButRejectedContactRequestsModel().addItem(item)
+
+proc removeItemWithPubKeyFromAllModels(self: Module, publicKey: string) =
+  self.view.myMutualContactsModel().removeItemWithPubKey(publicKey)
+  self.view.receivedContactRequestsModel().removeItemWithPubKey(publicKey)
+  self.view.sentContactRequestsModel().removeItemWithPubKey(publicKey)
+  self.view.receivedButRejectedContactRequestsModel().removeItemWithPubKey(publicKey)
+  self.view.sentButRejectedContactRequestsModel().removeItemWithPubKey(publicKey)
+  self.view.blockedContactsModel().removeItemWithPubKey(publicKey)
+
+method removeIfExistsAndAddToAppropriateModel*(self: Module, publicKey: string) =
+  self.removeItemWithPubKeyFromAllModels(publicKey)
+  let item = self.createItemFromPublicKey(publicKey)
+  self.addItemToAppropriateModel(item)
+
+method contactAdded*(self: Module, publicKey: string) =
+  self.removeIfExistsAndAddToAppropriateModel(publicKey)
+
+method contactBlocked*(self: Module, publicKey: string) =
+  self.removeIfExistsAndAddToAppropriateModel(publicKey)
+
+method contactUnblocked*(self: Module, publicKey: string) =
+  self.removeIfExistsAndAddToAppropriateModel(publicKey)
+
+method contactRemoved*(self: Module, publicKey: string) =
+  self.removeIfExistsAndAddToAppropriateModel(publicKey)
+
+method contactRequestRejectionRemoved*(self: Module, publicKey: string) =
+  self.removeIfExistsAndAddToAppropriateModel(publicKey)
+
+method contactUpdated*(self: Module, publicKey: string) =
+  self.removeIfExistsAndAddToAppropriateModel(publicKey)
+
+method contactNicknameChanged*(self: Module, publicKey: string) =
+  let (name, _, _) = self.controller.getContactNameAndImage(publicKey)
+  self.view.myMutualContactsModel().updateName(publicKey, name)
+  self.view.receivedContactRequestsModel().updateName(publicKey, name)
+  self.view.sentContactRequestsModel().updateName(publicKey, name)
+  self.view.receivedButRejectedContactRequestsModel().updateName(publicKey, name)
+  self.view.sentButRejectedContactRequestsModel().updateName(publicKey, name)
+  self.view.blockedContactsModel().updateName(publicKey, name)

--- a/src/app/modules/main/profile_section/contacts/view.nim
+++ b/src/app/modules/main/profile_section/contacts/view.nim
@@ -115,6 +115,9 @@ QtObject:
     read = getSentButRejectedContactRequestsModel
     notify = sentButRejectedContactRequestsModelChanged
 
+  proc isMyMutualContact*(self: View, publicKey: string): bool {.slot.} =
+    return self.myMutualContactsModel.containsItemWithPubKey(publicKey)
+
   proc addContact*(self: View, publicKey: string) {.slot.} =
     self.delegate.addContact(publicKey)
 

--- a/src/app/modules/main/profile_section/contacts/view.nim
+++ b/src/app/modules/main/profile_section/contacts/view.nim
@@ -7,42 +7,78 @@ QtObject:
   type
     View* = ref object of QObject
       delegate: io_interface.AccessInterface
-      myContactsModel: Model
-      myContactsModelVariant: QVariant
+      myMutualContactsModel: Model
+      myMutualContactsModelVariant: QVariant
       blockedContactsModel: Model
       blockedContactsModelVariant: QVariant
+      receivedContactRequestsModel: Model
+      receivedContactRequestsModelVariant: QVariant
+      sentContactRequestsModel: Model
+      sentContactRequestsModelVariant: QVariant
+      receivedButRejectedContactRequestsModel: Model
+      receivedButRejectedContactRequestsModelVariant: QVariant
+      sentButRejectedContactRequestsModel: Model
+      sentButRejectedContactRequestsModelVariant: QVariant
 
   proc delete*(self: View) =
-    self.myContactsModel.delete
-    self.myContactsModelVariant.delete
+    self.myMutualContactsModel.delete
+    self.myMutualContactsModelVariant.delete
     self.blockedContactsModel.delete
     self.blockedContactsModelVariant.delete
+    self.receivedContactRequestsModel.delete
+    self.receivedContactRequestsModelVariant.delete
+    self.sentContactRequestsModel.delete
+    self.sentContactRequestsModelVariant.delete
+    self.receivedButRejectedContactRequestsModel.delete
+    self.receivedButRejectedContactRequestsModelVariant.delete
+    self.sentButRejectedContactRequestsModel.delete
+    self.sentButRejectedContactRequestsModelVariant.delete
     self.QObject.delete
 
   proc newView*(delegate: io_interface.AccessInterface): View =
     new(result, delete)
     result.QObject.setup
     result.delegate = delegate
-    result.myContactsModel = newModel()
-    result.myContactsModelVariant = newQVariant(result.myContactsModel)
+    result.myMutualContactsModel = newModel()
+    result.myMutualContactsModelVariant = newQVariant(result.myMutualContactsModel)
     result.blockedContactsModel = newModel()
     result.blockedContactsModelVariant = newQVariant(result.blockedContactsModel)
+    result.receivedContactRequestsModel = newModel()
+    result.receivedContactRequestsModelVariant = newQVariant(result.receivedContactRequestsModel)
+    result.sentContactRequestsModel = newModel()
+    result.sentContactRequestsModelVariant = newQVariant(result.sentContactRequestsModel)
+    result.receivedButRejectedContactRequestsModel = newModel()
+    result.receivedButRejectedContactRequestsModelVariant = newQVariant(result.receivedButRejectedContactRequestsModel)
+    result.sentButRejectedContactRequestsModel = newModel()
+    result.sentButRejectedContactRequestsModelVariant = newQVariant(result.sentButRejectedContactRequestsModel)
 
   proc load*(self: View) =
     self.delegate.viewDidLoad()
 
-  proc myContactsModel*(self: View): Model =
-    return self.myContactsModel
+  proc myMutualContactsModel*(self: View): Model =
+    return self.myMutualContactsModel
 
   proc blockedContactsModel*(self: View): Model =
     return self.blockedContactsModel
 
-  proc myContactsModelChanged(self: View) {.signal.}
-  proc getMyContactsModel(self: View): QVariant {.slot.} =
-    return self.myContactsModelVariant
-  QtProperty[QVariant] myContactsModel:
-    read = getMyContactsModel
-    notify = myContactsModelChanged
+  proc receivedContactRequestsModel*(self: View): Model =
+    return self.receivedContactRequestsModel
+  
+  proc sentContactRequestsModel*(self: View): Model =
+    return self.sentContactRequestsModel
+
+  proc receivedButRejectedContactRequestsModel*(self: View): Model =
+    return self.receivedButRejectedContactRequestsModel
+
+  proc sentButRejectedContactRequestsModel*(self: View): Model =
+    return self.sentButRejectedContactRequestsModel
+
+  proc myMutualContactsModelChanged(self: View) {.signal.}
+  proc getMyMutualContactsModel(self: View): QVariant {.slot.} =
+    return self.myMutualContactsModelVariant
+  QtProperty[QVariant] myMutualContactsModel:
+    read = getMyMutualContactsModel
+    notify = myMutualContactsModelChanged
 
   proc blockedContactsModelChanged(self: View) {.signal.}
   proc getBlockedContactsModel(self: View): QVariant {.slot.} =
@@ -51,8 +87,39 @@ QtObject:
     read = getBlockedContactsModel
     notify = blockedContactsModelChanged
 
+  proc receivedContactRequestsModelChanged(self: View) {.signal.}
+  proc getReceivedContactRequestsModel(self: View): QVariant {.slot.} =
+    return self.receivedContactRequestsModelVariant
+  QtProperty[QVariant] receivedContactRequestsModel:
+    read = getReceivedContactRequestsModel
+    notify = receivedContactRequestsModelChanged
+
+  proc sentContactRequestsModelChanged(self: View) {.signal.}
+  proc getSentContactRequestsModel(self: View): QVariant {.slot.} =
+    return self.sentContactRequestsModelVariant
+  QtProperty[QVariant] sentContactRequestsModel:
+    read = getSentContactRequestsModel
+    notify = sentContactRequestsModelChanged
+
+  proc receivedButRejectedContactRequestsModelChanged(self: View) {.signal.}
+  proc getReceivedButRejectedContactRequestsModel(self: View): QVariant {.slot.} =
+    return self.receivedButRejectedContactRequestsModelVariant
+  QtProperty[QVariant] receivedButRejectedContactRequestsModel:
+    read = getReceivedButRejectedContactRequestsModel
+    notify = receivedButRejectedContactRequestsModelChanged
+
+  proc sentButRejectedContactRequestsModelChanged(self: View) {.signal.}
+  proc getSentButRejectedContactRequestsModel(self: View): QVariant {.slot.} =
+    return self.sentButRejectedContactRequestsModelVariant
+  QtProperty[QVariant] sentButRejectedContactRequestsModel:
+    read = getSentButRejectedContactRequestsModel
+    notify = sentButRejectedContactRequestsModelChanged
+
   proc addContact*(self: View, publicKey: string) {.slot.} =
     self.delegate.addContact(publicKey)
+
+  proc rejectContactRequest*(self: View, publicKey: string) {.slot.} =
+    self.delegate.rejectContactRequest(publicKey)
 
   proc changeContactNickname*(self: View, publicKey: string, nickname: string) {.slot.} =
     self.delegate.changeContactNickname(publicKey, nickname)
@@ -65,3 +132,6 @@ QtObject:
 
   proc removeContact*(self: View, publicKey: string) {.slot.} =
     self.delegate.removeContact(publicKey)
+
+  proc removeContactRequestRejection*(self: View, publicKey: string) {.slot.} =
+    self.delegate.removeContactRequestRejection(publicKey)

--- a/src/app/modules/shared_models/contacts_item.nim
+++ b/src/app/modules/shared_models/contacts_item.nim
@@ -1,22 +1,34 @@
 type
+  ContactVerificationState* {.pure.} = enum
+    NotMarked = 0
+    Verified    
+    Untrustworthy
+
+type
   Item* = ref object
     pubKey: string
     name: string
     icon: string
     isIdenticon: bool
-    isContact: bool
     isBlocked: bool
-    requestReceived: bool
+    isMutualContact: bool
+    verificationState: ContactVerificationState
 
-proc initItem*(pubKey, name, icon: string, isIdenticon, isContact, isBlocked, requestReceived: bool): Item =
+proc initItem*(pubKey, name, icon: string, isIdenticon, isMutualContact, isBlocked: bool, 
+  isContactVerified, isContactUntrustworthy: bool): Item =
   result = Item()
   result.pubKey = pubKey
   result.name = name
   result.icon = icon
   result.isIdenticon = isIdenticon
-  result.isContact = isContact
+  result.isMutualContact = isMutualContact
   result.isBlocked = isBlocked
-  result.requestReceived = requestReceived
+  if(isContactVerified):
+    result.verificationState = ContactVerificationState.Verified
+  elif(isContactUntrustworthy):
+    result.verificationState = ContactVerificationState.Untrustworthy
+  else:
+    result.verificationState = ContactVerificationState.NotMarked
 
 proc pubKey*(self: Item): string =
   self.pubKey
@@ -33,11 +45,11 @@ proc icon*(self: Item): string =
 proc isIdenticon*(self: Item): bool =
   self.isIdenticon
 
-proc isContact*(self: Item): bool =
-  self.isContact
+proc isMutualContact*(self: Item): bool =
+  self.isMutualContact
 
 proc isBlocked*(self: Item): bool =
   self.isBlocked
 
-proc requestReceived*(self: Item): bool =
-  self.requestReceived
+proc verificationState*(self: Item): ContactVerificationState =
+  self.verificationState

--- a/src/app/modules/shared_models/contacts_model.nim
+++ b/src/app/modules/shared_models/contacts_model.nim
@@ -7,9 +7,9 @@ type
     Name
     Icon
     IsIdenticon
-    IsContact
+    IsMutualContact
     IsBlocked
-    RequestReceived
+    VerificationState
 
 QtObject:
   type Model* = ref object of QAbstractListModel
@@ -42,9 +42,9 @@ QtObject:
       ModelRole.Name.int:"name",
       ModelRole.Icon.int:"icon",
       ModelRole.IsIdenticon.int:"isIdenticon",
-      ModelRole.IsContact.int:"isContact",
+      ModelRole.IsMutualContact.int:"isMutualContact",
       ModelRole.IsBlocked.int:"isBlocked",
-      ModelRole.RequestReceived.int:"requestReceived"
+      ModelRole.VerificationState.int:"verificationState"
     }.toTable
 
   method data(self: Model, index: QModelIndex, role: int): QVariant =
@@ -64,12 +64,12 @@ QtObject:
         result = newQVariant(item.icon)
       of ModelRole.IsIdenticon:
         result = newQVariant(item.isIdenticon)
-      of ModelRole.IsContact:
-        result = newQVariant(item.isContact)
+      of ModelRole.IsMutualContact:
+        result = newQVariant(item.isMutualContact)
       of ModelRole.IsBlocked:
         result = newQVariant(item.isBlocked)
-      of ModelRole.RequestReceived:
-        result = newQVariant(item.requestReceived)
+      of ModelRole.VerificationState:
+        result = newQVariant(item.verificationState.int)
 
   proc findIndexByPubKey(self: Model, pubKey: string): int =
     for i in 0 ..< self.items.len:
@@ -130,9 +130,9 @@ QtObject:
       ModelRole.Name.int,
       ModelRole.Icon.int,
       ModelRole.IsIdenticon.int,
-      ModelRole.IsContact.int,
+      ModelRole.IsMutualContact.int,
       ModelRole.IsBlocked.int,
-      ModelRole.RequestReceived.int
+      ModelRole.VerificationState.int
       ]
     )
 

--- a/src/app_service/service/chat/service.nim
+++ b/src/app_service/service/chat/service.nim
@@ -294,7 +294,7 @@ QtObject:
     preferredUsername: string = "",
     communityId: string = "") =
     try:
-      let allKnownContacts = self.contactService.getContacts()
+      let allKnownContacts = self.contactService.getContactsByGroup(ContactsGroup.AllKnownContacts)
       let processedMsg = message_common.replaceMentionsWithPubKeys(allKnownContacts, msg)
 
       let response = status_chat.sendChatMessage(

--- a/src/app_service/service/contacts/dto/contacts.nim
+++ b/src/app_service/service/contacts/dto/contacts.nim
@@ -97,11 +97,36 @@ proc userNameOrAlias*(contact: ContactsDto): string =
   else:
     result = contact.alias
 
-proc isContact*(self: ContactsDto): bool =
-  result = self.added
+proc isContactRequestReceived*(self: ContactsDto): bool =
+  return self.hasAddedUs
+
+proc isContactRequestSent*(self: ContactsDto): bool =
+  return self.added
+
+proc isSentContactRequestRejected*(self: ContactsDto): bool =
+  # TODO not implemented in `status-go` yet
+  # We don't have this prop for now.
+  return false
+
+proc isReceivedContactRequestRejected*(self: ContactsDto): bool =
+  # We need to check this.
+  return self.removed
 
 proc isBlocked*(self: ContactsDto): bool =
-  result = self.blocked
+  return self.blocked
 
-proc requestReceived*(self: ContactsDto): bool =
-  result = self.hasAddedUs
+proc isMutualContact*(self: ContactsDto): bool =
+  # TODO not implemented in `status-go` yet
+  # But for now we consider that contact is mutual contact if I added him and he added me.
+  return self.hasAddedUs and self.added
+
+proc isContactVerified*(self: ContactsDto): bool =
+  # TODO not implemented in `status-go` yet
+  return false
+
+proc isContactUntrustworthy*(self: ContactsDto): bool =
+  # TODO not implemented in `status-go` yet
+  return false
+
+proc isContactMarked*(self: ContactsDto): bool =
+  return self.isContactVerified() or self.isContactUntrustworthy()

--- a/src/app_service/service/message/service.nim
+++ b/src/app_service/service/message/service.nim
@@ -683,7 +683,7 @@ proc deleteMessage*(self: Service, messageId: string) =
 
 proc editMessage*(self: Service, messageId: string, msg: string) =
   try:
-    let allKnownContacts = self.contactService.getContacts()
+    let allKnownContacts = self.contactService.getContactsByGroup(ContactsGroup.AllKnownContacts)
     let processedMsg = message_common.replaceMentionsWithPubKeys(allKnownContacts, msg)
 
     let response = status_go.editMessage(messageId, processedMsg)

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -16,7 +16,7 @@ QtObject {
     property string createChatStickerHashId: ""
     property string createChatStickerPackId: ""
 
-    property var contactsModel: profileSectionModule.contactsModule.myContactsModel
+    property var contactsModel: root.contactsStore.myContactsModel
 
     // Important:
     // Each `ChatLayout` has its own chatCommunitySectionModule

--- a/ui/app/AppLayouts/Profile/panels/ContactPanel.qml
+++ b/ui/app/AppLayouts/Profile/panels/ContactPanel.qml
@@ -43,9 +43,9 @@ StatusListItem {
     signal openProfilePopup(string publicKey)
     signal openChangeNicknamePopup(string publicKey)
     signal sendMessageActionTriggered(string publicKey)
-    signal acceptContactRequest(string publicKey)
-    signal rejectContactRequest(string publicKey)
-    signal removeRejection(string publicKey)
+    signal contactRequestAccepted(string publicKey)
+    signal contactRequestRejected(string publicKey)
+    signal rejectionRemoved(string publicKey)
     signal textClicked(string publicKey)
 
     components: [
@@ -63,7 +63,7 @@ StatusListItem {
             height: visible ? 32 : 0
             icon.name: "close-circle"
             icon.color: Style.current.danger
-            onClicked: container.rejectContactRequest(container.publicKey)
+            onClicked: container.contactRequestRejected(container.publicKey)
         },
         StatusFlatRoundButton {
             visible: showAcceptContactRequestButton
@@ -71,7 +71,7 @@ StatusListItem {
             height: visible ? 32 : 0
             icon.name: "checkmark-circle"
             icon.color: Style.current.success
-            onClicked: container.acceptContactRequest(container.publicKey)
+            onClicked: container.contactRequestAccepted(container.publicKey)
         },
         StatusFlatRoundButton {
             visible: showRemoveRejectionButton
@@ -79,7 +79,7 @@ StatusListItem {
             height: visible ? 32 : 0
             icon.name: "cancel"
             icon.color: Style.current.danger
-            onClicked: container.removeRejection(container.publicKey)
+            onClicked: container.rejectionRemoved(container.publicKey)
         },
         StatusBaseText {
             text: container.contactText

--- a/ui/app/AppLayouts/Profile/panels/ContactsListPanel.qml
+++ b/ui/app/AppLayouts/Profile/panels/ContactsListPanel.qml
@@ -1,57 +1,163 @@
 import QtQuick 2.13
 import QtQuick.Controls 2.13
 import QtQuick.Layouts 1.13
+import QtQml.Models 2.13
 
 import utils 1.0
 import shared 1.0
 import shared.popups 1.0
+import shared.panels 1.0
 import "../../Chat/popups"
 
 import "."
 
-ListView {
-    id: contactList
-    property var contactsModel
+Item {
+    id: contactListRoot
 
-    property string searchStr: ""
+    property var contactsModel
+    property int panelUsage: Constants.contactsPanelUsage.unknownPosition
+
+    property string title: ""
     property string searchString: ""
     property string lowerCaseSearchString: searchString.toLowerCase()
-    property string contactToRemove: ""
-    property bool hideBlocked: false
-    property bool showSendMessageButton
 
-    signal contactClicked(var contact)
-    signal openProfilePopup(var contact)
-    signal sendMessageActionTriggered(var contact)
-    signal openChangeNicknamePopup(var contact)
+    signal contactClicked(string publicKey)
+    signal openProfilePopup(string publicKey)
+    signal sendMessageActionTriggered(string publicKey)
+    signal openChangeNicknamePopup(string publicKey)
+    signal acceptContactRequest(string publicKey)
+    signal rejectContactRequest(string publicKey)
+    signal removeRejection(string publicKey)
+    signal textClicked(string publicKey)
 
-    width: parent.width
+    visible: contactsList.count > 0
 
-    model: contactList.contactsModel
+    StyledText {
+        id: title
+        anchors.top: parent.top
+        anchors.left: parent.left
+        visible: contactListRoot.title !== ""
+        text: contactListRoot.title
+        font.weight: Font.Medium
+        font.pixelSize: 15
+        color: Style.current.secondaryText
+    }
 
-    delegate: ContactPanel {
-        id: panelDelegate
-        name: model.name
-        publicKey: model.pubKey
-        icon: model.icon
-        isIdenticon: model.isIdenticon
-        isContact: model.isContact
-        isBlocked: model.isBlocked
-        showSendMessageButton: contactList.showSendMessageButton
+    DelegateModel {
+        id: delegateModel
 
-        onClicked: contactList.contactClicked(model)
-        onOpenProfilePopup: contactList.openProfilePopup(model)
-        onSendMessageActionTriggered: contactList.sendMessageActionTriggered(model)
-        onOpenChangeNicknamePopup: contactList.openChangeNicknamePopup(model)
+        function update() {
+            var visible = [];
+            for (var i = 0; i < items.count; ++i) {
+                var item = items.get(i);
+                if (panelUsage === Constants.contactsPanelUsage.verifiedMutualContacts) {
+                    if(item.model.verificationState === Constants.contactVerificationState.verified)
+                        visible.push(item);
+                }
+                else if (panelUsage === Constants.contactsPanelUsage.mutualContacts) {
+                    if(item.model.verificationState !== Constants.contactVerificationState.verified)
+                        visible.push(item);
+                }
+                else {
+                    visible.push(item);
+                }
+            }
 
-        visible: {
-          if (hideBlocked && model.isBlocked) {
-            return false
-          }
+            for (i = 0; i < visible.length; ++i) {
+                item = visible[i];
+                item.inVisible = true;
+                if (item.visibleIndex !== i) {
+                    visibleItems.move(item.visibleIndex, i, 1);
+                }
+            }
+        }
 
-          return searchString === "" ||
-            panelDelegate.name.toLowerCase().includes(lowerCaseSearchString) ||
-            panelDelegate.publicKey.toLowerCase().includes(lowerCaseSearchString)
+        model: contactListRoot.contactsModel
+
+        groups: [DelegateModelGroup {
+                id: visibleItems
+                name: "visible"
+                includeByDefault: false
+            }]
+
+        filterOnGroup: "visible"
+        items.onChanged: update()
+        delegate: contactPanelComponent
+    }
+
+    ListView {
+        id: contactsList
+        anchors.top: title.bottom
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.bottom: parent.bottom
+
+        model: delegateModel
+    }
+
+    Component {
+        id: contactPanelComponent
+
+        ContactPanel {
+            id: panelDelegate
+            name: model.name
+            publicKey: model.pubKey
+            icon: model.icon
+            isIdenticon: model.isIdenticon
+            isMutualContact: model.isMutualContact
+            isBlocked: model.isBlocked
+            verificationState: model.verificationState
+
+            searchStr: contactListRoot.searchString
+
+            showSendMessageButton: model.isMutualContact
+            showRejectContactRequestButton: {
+                if (contactListRoot.panelUsage === Constants.contactsPanelUsage.receivedContactRequest) {
+                    return true
+                }
+
+                return false
+            }
+            showAcceptContactRequestButton: {
+                if (contactListRoot.panelUsage === Constants.contactsPanelUsage.receivedContactRequest) {
+                    return true
+                }
+
+                return false
+            }
+            showRemoveRejectionButton: {
+                if (contactListRoot.panelUsage === Constants.contactsPanelUsage.rejectedReceivedContactRequest) {
+                    return true
+                }
+
+                return false
+            }
+            contactText: {
+                if (contactListRoot.panelUsage === Constants.contactsPanelUsage.sentContactRequest) {
+                    return qsTr("Contact Request Sent")
+                }
+                else if (contactListRoot.panelUsage === Constants.contactsPanelUsage.rejectedSentContactRequest) {
+                    return qsTr("Contact Request Rejected")
+                }
+
+                return ""
+            }
+            contactTextClickable: {
+                return false
+            }
+
+            onClicked: contactListRoot.contactClicked(model.pubKey)
+            onOpenProfilePopup: contactListRoot.openProfilePopup(publicKey)
+            onSendMessageActionTriggered: contactListRoot.sendMessageActionTriggered(publicKey)
+            onOpenChangeNicknamePopup: contactListRoot.openChangeNicknamePopup(publicKey)
+            onAcceptContactRequest: contactListRoot.acceptContactRequest(publicKey)
+            onRejectContactRequest: contactListRoot.rejectContactRequest(publicKey)
+            onRemoveRejection: contactListRoot.removeRejection(publicKey)
+            onTextClicked: contactListRoot.textClicked(publicKey)
+
+            visible: searchString === "" ||
+                     panelDelegate.name.toLowerCase().includes(lowerCaseSearchString) ||
+                     panelDelegate.publicKey.toLowerCase().includes(lowerCaseSearchString)
         }
     }
 }

--- a/ui/app/AppLayouts/Profile/panels/ContactsListPanel.qml
+++ b/ui/app/AppLayouts/Profile/panels/ContactsListPanel.qml
@@ -25,9 +25,9 @@ Item {
     signal openProfilePopup(string publicKey)
     signal sendMessageActionTriggered(string publicKey)
     signal openChangeNicknamePopup(string publicKey)
-    signal acceptContactRequest(string publicKey)
-    signal rejectContactRequest(string publicKey)
-    signal removeRejection(string publicKey)
+    signal contactRequestAccepted(string publicKey)
+    signal contactRequestRejected(string publicKey)
+    signal rejectionRemoved(string publicKey)
     signal textClicked(string publicKey)
 
     visible: contactsList.count > 0
@@ -150,9 +150,9 @@ Item {
             onOpenProfilePopup: contactListRoot.openProfilePopup(publicKey)
             onSendMessageActionTriggered: contactListRoot.sendMessageActionTriggered(publicKey)
             onOpenChangeNicknamePopup: contactListRoot.openChangeNicknamePopup(publicKey)
-            onAcceptContactRequest: contactListRoot.acceptContactRequest(publicKey)
-            onRejectContactRequest: contactListRoot.rejectContactRequest(publicKey)
-            onRemoveRejection: contactListRoot.removeRejection(publicKey)
+            onContactRequestAccepted: contactListRoot.contactRequestAccepted(publicKey)
+            onContactRequestRejected: contactListRoot.contactRequestRejected(publicKey)
+            onRejectionRemoved: contactListRoot.rejectionRemoved(publicKey)
             onTextClicked: contactListRoot.textClicked(publicKey)
 
             visible: searchString === "" ||

--- a/ui/app/AppLayouts/Profile/stores/ContactsStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/ContactsStore.qml
@@ -10,13 +10,13 @@ QtObject {
     property var mainModuleInst: mainModule
 
     property string myPublicKey: userProfile.pubKey
-    property var myContactsModel: contactsModule.myContactsModel
-    property var blockedContactsModel: contactsModule.blockedContactsModel
 
-    // TODO move contact requests back to the contacts module since we need them in the Profile 
-    // also, having them in the chat section creates some waste, since no community has it
-    property var chatSectionModule: mainModule.getChatSectionModule()
-    property var contactRequestsModel: chatSectionModule.contactRequestsModel
+    property var myContactsModel: contactsModule.myMutualContactsModel
+    property var blockedContactsModel: contactsModule.blockedContactsModel
+    property var receivedContactRequestsModel: contactsModule.receivedContactRequestsModel
+    property var sentContactRequestsModel: contactsModule.sentContactRequestsModel
+    property var receivedButRejectedContactRequestsModel: contactsModule.receivedButRejectedContactRequestsModel
+    property var sentButRejectedContactRequestsModel: contactsModule.sentButRejectedContactRequestsModel
 
     function resolveENS(value) {
         root.mainModuleInst.resolveENS(value, "")
@@ -32,8 +32,7 @@ QtObject {
 
     function joinPrivateChat(pubKey) {
         Global.changeAppSectionBySectionType(Constants.appSection.chat)
-        let chatCommunitySectionModule = root.mainModuleInst.getChatSectionModule()
-        chatCommunitySectionModule.createOneToOneChat("", pubKey, "")
+        root.contactsModule.addContact(pubKey)
     }
 
     function addContact(pubKey) {
@@ -57,18 +56,14 @@ QtObject {
     }
     
     function acceptContactRequest(pubKey) {
-        chatSectionModule.acceptContactRequest(pubKey)
-    }
-
-    function acceptAllContactRequests() {
-        chatSectionModule.acceptAllContactRequests()
+        root.contactsModule.addContact(pubKey)
     }
 
     function rejectContactRequest(pubKey) {
-        chatSectionModule.rejectContactRequest(pubKey)
+        root.contactsModule.rejectContactRequest(pubKey)
     }
 
-    function rejectAllContactRequests() {
-        chatSectionModule.rejectAllContactRequests()
+    function removeContactRequestRejection(pubKey) {
+        root.contactsModule.removeContactRequestRejection(pubKey)
     }
 }

--- a/ui/app/AppLayouts/Profile/stores/ContactsStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/ContactsStore.qml
@@ -30,6 +30,10 @@ QtObject {
        return root.globalUtilsInst.getFromClipboard()
     }
 
+    function isMyMutualContact(pubKey) {
+       return root.contactsModule.isMyMutualContact(pubKey)
+    }
+
     function joinPrivateChat(pubKey) {
         Global.changeAppSectionBySectionType(Constants.appSection.chat)
         root.contactsModule.addContact(pubKey)

--- a/ui/app/AppLayouts/Profile/views/ContactsView.qml
+++ b/ui/app/AppLayouts/Profile/views/ContactsView.qml
@@ -221,11 +221,11 @@ Item {
                             Global.openProfilePopup(publicKey, null, true)
                         }
 
-                        onAcceptContactRequest: {
+                        onContactRequestAccepted: {
                             root.contactsStore.acceptContactRequest(publicKey)
                         }
 
-                        onRejectContactRequest: {
+                        onContactRequestRejected: {
                             root.contactsStore.rejectContactRequest(publicKey)
                         }
                     }
@@ -280,7 +280,7 @@ Item {
                             Global.openProfilePopup(publicKey, null, true)
                         }
 
-                        onRemoveRejection: {
+                        onRejectionRemoved: {
                             root.contactsStore.removeContactRequestRejection(publicKey)
                         }
                     }

--- a/ui/imports/shared/controls/StatusTabButton.qml
+++ b/ui/imports/shared/controls/StatusTabButton.qml
@@ -10,11 +10,15 @@ import StatusQ.Components 0.1
 
 TabButton {
     property string btnText: "Default Button"
+    property int addToWidth: 0
+
     property alias badge: statusBadge
 
     id: tabButton
     width: tabBtnText.width +
-        (statusBadge.visible ? statusBadge.width + statusBadge.anchors.leftMargin : 0)
+           (statusBadge.visible ? statusBadge.width + statusBadge.anchors.leftMargin : 0) +
+           addToWidth
+
     height: tabBtnText.height + 11
     text: ""
     padding: 0
@@ -25,6 +29,7 @@ TabButton {
 
     StyledText {
         id: tabBtnText
+        anchors.horizontalCenter: parent.horizontalCenter
         text: btnText
         font.weight: Font.Medium
         font.pixelSize: 15

--- a/ui/imports/shared/views/chat/MessageContextMenuView.qml
+++ b/ui/imports/shared/views/chat/MessageContextMenuView.qml
@@ -188,8 +188,7 @@ StatusPopupMenu {
             root.close()
         }
         icon.name: "chat"
-        enabled: (root.myPublicKey !== root.selectedUserPublicKey) &&
-                 root.isProfile && !root.isMyMessage ||
+        enabled: root.isProfile && root.store.contactsStore.isMyMutualContact(root.selectedUserPublicKey) ||
                  (!root.hideEmojiPicker &&
                   !root.emojiOnly &&
                   !root.isProfile &&

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -91,6 +91,23 @@ QtObject {
         readonly property int noOne: 3
     }
 
+    readonly property QtObject contactVerificationState: QtObject {
+        readonly property int notMarked: 0
+        readonly property int verified: 1
+        readonly property int untrustworthy: 2
+    }
+
+    readonly property QtObject contactsPanelUsage: QtObject {
+        readonly property int unknownPosition: -1
+        readonly property int mutualContacts: 0
+        readonly property int verifiedMutualContacts: 1
+        readonly property int sentContactRequest: 2
+        readonly property int receivedContactRequest: 3
+        readonly property int rejectedSentContactRequest: 4
+        readonly property int rejectedReceivedContactRequest: 5
+        readonly property int blockedContacts: 6
+    }
+
     readonly property int communityImported: 0
     readonly property int communityImportingInProgress: 1
     readonly property int communityImportingError: 2


### PR DESCRIPTION
In [this video](https://drive.google.com/file/d/1vPup0U377AKIQr4q6x-CTFtCpcC3XkHh/view?usp=sharing) you may see that `settings->messaging->contacts` section roughly match requested design. Once we have details set up on the `status-go` side we will just updated them in `contact service`, so far I dealt with contact's properties which we currently have on disposal to simulate what we will have at the end (I mean to procs attached to `ContactsDto`).

@richard-ramos you may be interested in this PR since @iurimatias said that you're working on adding new props for contacts on the `status-go` side.

The first commit solves point 3 form the description of the ticket.
The second commit solves points 1, 2 and 4.

Fixes #5117 