### PR TITLE
feature(desktop/general): Configurable logs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -367,7 +367,9 @@ $(FCITX5_QT): | deps
 			.. $(HANDLE_OUTPUT) && \
 		$(FCITX5_QT_BUILD_CMD)
 
-$(STATUS_CLIENT_APPIMAGE): override RESOURCES_LAYOUT := -d:production
+PRODUCTION_PARAMETERS := -d:production -d:chronicles_enabled=off
+
+$(STATUS_CLIENT_APPIMAGE): override RESOURCES_LAYOUT := $(PRODUCTION_PARAMETERS)
 $(STATUS_CLIENT_APPIMAGE): nim_status_client $(APPIMAGE_TOOL) nim-status.desktop $(FCITX5_QT)
 	rm -rf pkg/*.AppImage
 	rm -rf tmp/linux/dist
@@ -431,7 +433,7 @@ MACOS_INNER_BUNDLE := $(MACOS_OUTER_BUNDLE)/Contents/Frameworks/QtWebEngineCore.
 
 STATUS_CLIENT_DMG ?= pkg/Status.dmg
 
-$(STATUS_CLIENT_DMG): override RESOURCES_LAYOUT := -d:production
+$(STATUS_CLIENT_DMG): override RESOURCES_LAYOUT := $(PRODUCTION_PARAMETERS)
 $(STATUS_CLIENT_DMG): nim_status_client $(DMG_TOOL)
 	rm -rf tmp/macos pkg/*.dmg
 	mkdir -p $(MACOS_OUTER_BUNDLE)/Contents/MacOS
@@ -503,7 +505,7 @@ nim_windows_launcher: | deps
 STATUS_CLIENT_EXE ?= pkg/Status.exe
 STATUS_CLIENT_7Z ?= pkg/Status.7z
 
-$(STATUS_CLIENT_EXE): override RESOURCES_LAYOUT := -d:production
+$(STATUS_CLIENT_EXE): override RESOURCES_LAYOUT := $(PRODUCTION_PARAMETERS)
 $(STATUS_CLIENT_EXE): OUTPUT := tmp/windows/dist/Status
 $(STATUS_CLIENT_EXE): INSTALLER_OUTPUT := pkg
 $(STATUS_CLIENT_EXE): nim_status_client nim_windows_launcher $(NIM_WINDOWS_PREBUILT_DLLS)

--- a/src/nim_status_client.nim
+++ b/src/nim_status_client.nim
@@ -1,4 +1,4 @@
-import NimQml, chronicles, os, strformat, times, md5, json
+import NimQml, chronicles, os, strformat, strutils, times, md5, json
 
 import status_go
 import app/core/main
@@ -40,6 +40,16 @@ proc determineStatusAppIconPath(): string =
       return "/../status-dev.svg"
 
 proc prepareLogging() =
+  # do not create log file
+  if defined(production):
+    return
+
+  # log level can be overriden by LOG_LEVEL env parameter
+  let logLvl = try: parseEnum[LogLevel](getEnv("LOG_LEVEL"))
+                    except: NONE
+
+  setLogLevel(logLvl)
+
   when compiles(defaultChroniclesStream.output.writer):
     defaultChroniclesStream.output.writer =
       proc (logLevel: LogLevel, msg: LogOutputStr) {.gcsafe, raises: [Defect].} =


### PR DESCRIPTION
Log level can be chosen during application startup.
Logs are disabled for production build.

Fix #3609

### What does the PR do

Logs are disabled for production builds - no log file, no logging.
Logs are configurable during development. Need to pass LOG_LEVEL parameter,
eg. make run LOG_LEVEL=ERROR.
Possible levels are taken from Nim chronicles:
TRACE, DEBUG, INFO, NOTICE, WARN, ERROR, FATAL, and NONE.

### Affected areas

Desktop / logs

### Screenshot of functionality

Log only errors:
![image](https://user-images.githubusercontent.com/61889657/160155902-35e49384-20d0-4901-91b6-e5510deb2d17.png)

