### PR TITLE
fix(@chat): handle status being nil in stickers

### DIFF
--- a/src/app_service/service/stickers/dto/stickers.nim
+++ b/src/app_service/service/stickers/dto/stickers.nim
@@ -84,7 +84,7 @@ proc toStickerPackDto*(jsonObj: JsonNode): StickerPackDto =
   discard jsonObj.getProp("preview", result.preview)
   discard jsonObj.getProp("thumbnail", result.thumbnail)
 
-  result.status = jsonObj["status"].getInt(-1).toStickerPackStatus()
+  result.status = jsonObj{"status"}.getInt(0).toStickerPackStatus()
   result.price = jsonObj["price"].getStr().parse(Stuint[256])
   result.stickers = @[]
   for sticker in jsonObj["stickers"]:


### PR DESCRIPTION
fixes #5195

The attribute Status is marked as omit empty in backend