### PR TITLE
fix(Settings/Profile/Edit): The form for editing Display name looks incorrect

### DIFF
--- a/ui/app/AppLayouts/Profile/views/MyProfileView.qml
+++ b/ui/app/AppLayouts/Profile/views/MyProfileView.qml
@@ -1,4 +1,5 @@
 import QtQuick 2.13
+import QtQuick.Controls 2.3
 import QtQuick.Layouts 1.13
 import QtGraphicalEffects 1.13
 
@@ -160,9 +161,8 @@ ColumnLayout {
         id: displayNamePopupComponent
         DisplayNamePopup {
             profileStore: root.profileStore
-            onClosed: {
-                destroy()
-            }
+            anchors.centerIn: Overlay.overlay
+            onClosed: { destroy() }
         }
     }
 


### PR DESCRIPTION
Closes #5110 and #5193.

### What does the PR do

It has been used a `StatusInput` component from `StatusQ`.

`placeholderText`property updated to "Display Name" and button / content layout redefined to be shown correctly.

It incorporates the same validation rules as in the current onboarding process:

- Min and max length validation.
- Regular expression.
- Ends with '.eth' or '_eth' or '-eth'.
- Alias validation.

### Affected areas

Settings / Profile / Edit

### Screenshot of functionality

https://user-images.githubusercontent.com/97019400/160372018-02c023a9-f323-4eaa-addc-e9620a219a8e.mov


