### PR TITLE
fix(Input): Change `TextEdit` to `StatusBaseText` in `Input.qml`

### DIFF
--- a/ui/imports/shared/controls/Input.qml
+++ b/ui/imports/shared/controls/Input.qml
@@ -3,6 +3,7 @@ import QtQuick.Controls 2.13
 
 import StatusQ.Controls 0.1
 import StatusQ.Popups 0.1
+import StatusQ.Core 0.1
 
 import utils 1.0
 
@@ -193,15 +194,13 @@ Item {
         }
     }
 
-    TextEdit {
+    StatusBaseText {
         visible: !!validationError
         id: validationErrorText
         text: validationError
         anchors.top: inputField.bottom
         anchors.topMargin: validationErrorTopMargin
         anchors.right: inputField.right
-        selectByMouse: true
-        readOnly: true
         font.pixelSize: 12
         height: 16
         color: validationErrorColor


### PR DESCRIPTION
Closes: #5188

### What does the PR do

Because of rendering issue spaces between `,` and next character was too small. I change base component for validation string to `StatusBaseText` which fixed it by standard font family usage.

### Affected areas

Input.qml

### Screenshot of functionality
<img width="498" alt="Снимок экрана 2022-03-28 в 14 31 32" src="https://user-images.githubusercontent.com/82511785/160389077-7d715492-87c8-4e6f-a03e-7c628f466e5e.png">
