### PR TITLE
5197 search box input is cut in half

### DIFF
--- a/ui/app/mainui/AppSearch.qml
+++ b/ui/app/mainui/AppSearch.qml
@@ -62,8 +62,10 @@ Item {
         }
 
         onSearchTextChanged: {
-            searchPopup.loading = true
-            searchMessages(searchPopup.searchText);
+            if (searchPopup.searchText !== "") {
+                searchPopup.loading = true
+                searchMessages(searchPopup.searchText);
+            }
         }
         onAboutToHide: {
             if (searchPopupMenu.visible) {


### PR DESCRIPTION
### What does the PR do

The search text is displayed correctly. It is not cut anymore.
Also the loading icon is hidden if the user clears the search text.

### Affected areas

Chat / Search

### Screenshot of functionality

![image](https://user-images.githubusercontent.com/61889657/160400915-6451189a-1673-41b3-b826-db09be6d856b.png)
