### PR TITLE
fix(desktop/chat): Using default height and padding for community search box

### DIFF
--- a/ui/app/AppLayouts/Chat/popups/community/CommunitiesPopup.qml
+++ b/ui/app/AppLayouts/Chat/popups/community/CommunitiesPopup.qml
@@ -58,8 +58,6 @@ StatusModal {
             id: searchBox
             input.placeholderText: qsTr("Search for communities or topics")
             input.icon.name: "search"
-            input.height: 36
-            input.topPadding: 9
         }
 
         StatusModalDivider { topPadding: 8 }


### PR DESCRIPTION
Fix #5200

### What does the PR do

Fixes wrong text alignment in communities search box.

### Affected areas

Chat / Search communities

### Screenshot of functionality

https://user-images.githubusercontent.com/61889657/160447570-d1be033a-d210-4304-b952-bf737c2c74da.mov


