### PR TITLE
fix(statustagselector): contacts list was not visible

### DIFF
--- a/ui/app/AppLayouts/Chat/views/CreateChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/CreateChatView.qml
@@ -44,6 +44,7 @@ Page {
                     {"publicId": entry.publicId, "name": entry.name,
                      "icon": entry.icon, "isIdenticon": entry.isIdenticon});
                 }
+                tagSelector.sortModel(root.contactsModel);
             } else {
                 tagSelector.namesModel.clear();
                 contactsModel.clear();
@@ -105,7 +106,6 @@ Page {
             onTextChanged: {
                 sortModel(root.contactsModel);
             }
-            Component.onCompleted: { sortModel(root.contactsModel); }
         }
 
         StatusButton {


### PR DESCRIPTION
Closes #5199
Closes #5258 
Depends on: https://github.com/status-im/StatusQ/pull/606

### What does the PR do
Fixed the contacts list was not visible in start chat contact list

### Affected areas
start a new chat

### Screenshot of functionality
<img width="822" alt="cn" src="https://user-images.githubusercontent.com/31625338/160480475-05b9efc8-4997-4204-bfce-96f3d58be060.png">
