### PR TITLE
fix(create/join chat): icon buttons were highlighted always

### DIFF
--- a/ui/app/AppLayouts/Chat/views/ContactsColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ContactsColumnView.qml
@@ -88,6 +88,7 @@ Item {
 
         StatusIconTabButton {
             icon.name: "public-chat"
+            checked: publicChatCommunityContextMenu.visible
             onClicked: { publicChatCommunityContextMenu.popup(); }
             StatusPopupMenu {
                  id: publicChatCommunityContextMenu
@@ -112,6 +113,7 @@ Item {
 
         StatusIconTabButton {
             icon.name: "edit"
+            checked: root.store.openCreateChat
             onClicked: {
                 root.store.openCreateChat = !root.store.openCreateChat;
             }


### PR DESCRIPTION
Closes #5146
Closes #5137 

### What does the PR do
icon buttons for join public chat and create new chat were remaining highlighted even though unselected.

### Affected areas
create / join chat icon buttons
