### PR TITLE
show compressed multiformat public keys

### DIFF
--- a/src/app/global/utils.nim
+++ b/src/app/global/utils.nim
@@ -141,3 +141,6 @@ QtObject:
 
   proc getColorHashAsJson*(self: Utils, publicKey: string): string {.slot.} =
     procs_from_visual_identity_service.getColorHashAsJson(publicKey)
+
+  proc getCompressedPk*(self: Utils, publicKey: string): string {.slot.} =
+    procs_from_accounts.compressPk(publicKey)

--- a/src/app_service/service/accounts/service.nim
+++ b/src/app_service/service/accounts/service.nim
@@ -46,6 +46,16 @@ proc getImportedAccount*(self: Service): GeneratedAccountDto =
 proc isFirstTimeAccountLogin*(self: Service): bool =
   return self.isFirstTimeAccountLogin
 
+proc compressPk*(publicKey: string): string =
+  try:
+    let response = status_account.compressPk(publicKey)
+    if(not response.error.isNil):
+      error "error compressPk: ", errDescription = response.error.message
+    result = response.result
+
+  except Exception as e:
+    error "error: ", procName="compressPk", errName = e.name, errDesription = e.msg
+
 proc generateAliasFromPk*(publicKey: string): string =
   return status_account.generateAlias(publicKey).result.getStr
 

--- a/ui/app/AppLayouts/Chat/panels/communities/CommunityMembersSettingsPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/CommunityMembersSettingsPanel.qml
@@ -110,7 +110,7 @@ SettingsPageLayout {
                     }
                     return !model.name.endsWith(".eth") ? model.name : Utils.removeStatusEns(model.name)
                 }
-                subTitle: model.id.substring(0, 5) + "..." + model.id.substring(model.id.length - 3)
+                subTitle: Utils.getElidedCompressedPk(model.id)
 
                 statusListItemIcon {
                     name: model.name

--- a/ui/app/AppLayouts/Onboarding/views/InsertDetailsView.qml
+++ b/ui/app/AppLayouts/Onboarding/views/InsertDetailsView.qml
@@ -80,6 +80,7 @@ Item {
                 icon.letterSize: 32
                 icon.color: Theme.palette.miscColor5
                 icon.charactersLen: 2
+                image.isIdenticon: false
                 image.source: uploadProfilePicPopup.selectedImage
                 ringSettings { ringSpecModel: Utils.getColorHashAsJson(root.pubKey) }
             }
@@ -122,7 +123,7 @@ Item {
         StyledText {
             id: chatKeyTxt
             color: Style.current.secondaryText
-            text: "Chatkey:" + root.pubKey
+            text: qsTr("Chatkey:") + " " + Utils.getCompressedPk(root.pubKey)
             horizontalAlignment: Text.AlignHCenter
             wrapMode: Text.WordWrap
             Layout.alignment: Qt.AlignHCenter

--- a/ui/app/AppLayouts/Profile/views/MyProfileView.qml
+++ b/ui/app/AppLayouts/Profile/views/MyProfileView.qml
@@ -130,7 +130,7 @@ ColumnLayout {
         Layout.preferredWidth: root.profileContentWidth
 
         title: qsTr("Chat key")
-        subTitle: root.profileStore.pubkey
+        subTitle: Utils.getCompressedPk(root.profileStore.pubkey)
         subTitleComponent.elide: Text.ElideMiddle
         subTitleComponent.width: 320
         subTitleComponent.font.family: Theme.palette.monoFont.name

--- a/ui/imports/shared/controls/chat/ProfileHeader.qml
+++ b/ui/imports/shared/controls/chat/ProfileHeader.qml
@@ -79,8 +79,7 @@ Item {
 
             visible: root.pubkeyVisible
 
-            text: pubkey.substring(0, 10) + "..." + pubkey.substring(
-                      pubkey.length - 4)
+            text: Utils.getElidedCompressedPk(pubkey)
 
             horizontalAlignment: Text.AlignHCenter
             font.pixelSize: Style.current.asideTextFontSize

--- a/ui/imports/shared/popups/ProfilePopup.qml
+++ b/ui/imports/shared/popups/ProfilePopup.qml
@@ -71,7 +71,7 @@ StatusModal {
     }
 
     header.title: userDisplayName
-    header.subTitle: userIsEnsVerified ? userName : userPublicKey
+    header.subTitle: userIsEnsVerified ? userName : Utils.getElidedCompressedPk(userPublicKey)
     header.subTitleElide: Text.ElideMiddle
 
     headerActionButton: StatusFlatRoundButton {
@@ -171,7 +171,7 @@ StatusModal {
 
             StatusDescriptionListItem {
                 title: qsTr("Chat key")
-                subTitle: userPublicKey
+                subTitle: Utils.getCompressedPk(userPublicKey)
                 subTitleComponent.elide: Text.ElideMiddle
                 subTitleComponent.width: 320
                 subTitleComponent.font.family: Theme.palette.monoFont.name

--- a/ui/imports/utils/Utils.qml
+++ b/ui/imports/utils/Utils.qml
@@ -630,7 +630,7 @@ QtObject {
             return ""
         }
         let compressedPk = getCompressedPk(publicKey)
-        return compressedPk.substr(3, 3) + "..." + compressedPk.substr(compressedPk.length - 3)
+        return compressedPk.substr(0, 6) + "..." + compressedPk.substr(compressedPk.length - 3)
     }
 
     function getTimeDifference(d1, d2) {

--- a/ui/imports/utils/Utils.qml
+++ b/ui/imports/utils/Utils.qml
@@ -618,6 +618,21 @@ QtObject {
         return JSON.parse(jsonObj)
     }
 
+    function getCompressedPk(publicKey) {
+        if (publicKey === "") {
+            return ""
+        }
+        return globalUtils.getCompressedPk(publicKey)
+    }
+
+    function getElidedCompressedPk(publicKey) {
+        if (publicKey === "") {
+            return ""
+        }
+        let compressedPk = getCompressedPk(publicKey)
+        return compressedPk.substr(3, 3) + "..." + compressedPk.substr(compressedPk.length - 3)
+    }
+
     function getTimeDifference(d1, d2) {
         var timeString = ""
         var day1Year = d1.getFullYear()


### PR DESCRIPTION
closes: https://github.com/status-im/status-desktop/issues/5181
![image](https://user-images.githubusercontent.com/33099791/160783085-704e57cc-4b27-4bde-8879-79bc8c600c91.png)

### note
Share Profile URL was not adapted -> `https://join.status.im/u/0x04ccb45ffb964e4e0b856c88f30002c85bd68ce0c98842811e3f37cbdf32dc542ea7f876d6e64089f4e3d1f779aa1f9d510c34753091327a16632f058d45866162`

### acceptance criteria
"when we display the fragment in the chat view e.g. next to a user's name in small text (above the message the user has typed), we should not grey the first 3 characters there.  But wherever a chat key fragment is displayed in the UI, from this point onwards it should always be  the first 6 characters then the last 3 characters e.g. zQ3k83...t5N" @John-44 