### PR TITLE
fix(users): user not added when joining group + only show joined users

### DIFF
--- a/src/app/modules/main/chat_section/chat_content/users/controller.nim
+++ b/src/app/modules/main/chat_section/chat_content/users/controller.nim
@@ -103,6 +103,12 @@ proc init*(self: Controller) =
       if (args.chatId == self.chatId):
         self.delegate.onChatMembersAdded(args.ids)
 
+    self.events.on(SIGNAL_CHAT_UPDATE) do(e: Args):
+      var args = ChatUpdateArgsNew(e)
+      for chat in args.chats:
+        if (chat.id == self.chatId):
+          self.delegate.onChatUpdated(chat)
+
     self.events.on(SIGNAL_CHAT_MEMBER_REMOVED) do(e: Args):
       let args = ChatMemberRemovedArgs(e)
       if (args.chatId == self.chatId):
@@ -124,13 +130,11 @@ proc init*(self: Controller) =
 proc getChat*(self: Controller): ChatDto =
   return self.chatService.getChatById(self.chatId)
 
-proc getChatMemberInfo*(self: Controller, id: string): (bool, bool) =
+proc getChatMember*(self: Controller, id: string): ChatMember =
   let chat = self.getChat()
   for member in chat.members:
     if (member.id == id):
-      return (member.admin, member.joined)
-
-  return (false, false)
+      return member
 
 proc getChatMembers*(self: Controller): seq[ChatMember] =
   var communityId = ""

--- a/src/app/modules/main/chat_section/chat_content/users/io_interface.nim
+++ b/src/app/modules/main/chat_section/chat_content/users/io_interface.nim
@@ -1,5 +1,6 @@
 import NimQml
 
+import ../../../../../../app_service/service/chat/service as chat_service
 import ../../../../../../app_service/service/message/dto/[message]
 import ../../../../../../app_service/service/contacts/dto/[status_update]
 
@@ -33,7 +34,13 @@ method contactUpdated*(self: AccessInterface, publicKey: string) {.base.} =
 method loggedInUserImageChanged*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method addChatMember*(self: AccessInterface, member: ChatMember) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method onChatMembersAdded*(self: AccessInterface, ids: seq[string]) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method onChatUpdated*(self: AccessInterface, chat: ChatDto) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method onChatMemberRemoved*(self: AccessInterface, ids: string) {.base.} =


### PR DESCRIPTION
Fixes #5202

You had to restart the app to see newly joined users in a group chat. Now they are added when they join.

**Note**: This also changes the behaviour of the user list. Only `joined` users (of a group or a community) will show in the list.
First, it fixes the weird behaviour of group chats where on creating them, the list would be empty, but on restarting, every user would be there, even if they didn't join.
Second, it also makes sense, because the user isn't actually in the group chat or community, so seeing them in the list is misleading.
I tested public chats as well, and it didn't affect them.