### PR TITLE
fix(@desktop/onboarding): users can save an empty "Display Name" in new onboarding

### DIFF
--- a/ui/app/AppLayouts/Onboarding/views/InsertDetailsView.qml
+++ b/ui/app/AppLayouts/Onboarding/views/InsertDetailsView.qml
@@ -102,6 +102,7 @@ Item {
         StatusInput {
             id: nameInput
             implicitWidth: 328
+            Layout.preferredHeight: 78
             Layout.alignment: Qt.AlignHCenter
             input.placeholderText: qsTr("Display name")
             input.edit.font.capitalization: Font.Capitalize
@@ -116,6 +117,7 @@ Item {
                     nameInput.input.edit.clear();
                 }
             }
+            validators: Constants.validators.displayName
             onTextChanged: {
                 userImage.name = text;
             }
@@ -157,7 +159,7 @@ Item {
         StatusButton {
             Layout.alignment: Qt.AlignHCenter | Qt.AlignTop
             Layout.topMargin: 125
-            enabled: !!nameInput.text
+            enabled: !!nameInput.text && nameInput.valid
             text: qsTr("Next")
             onClicked: {
                 if (root.state === "username") {

--- a/ui/app/AppLayouts/Profile/views/DisplayNamePopup.qml
+++ b/ui/app/AppLayouts/Profile/views/DisplayNamePopup.qml
@@ -29,42 +29,7 @@ StatusModal {
             anchors.horizontalCenter: parent.horizontalCenter
             input.placeholderText: qsTr("Display Name")
             input.text: root.profileStore.displayName
-            validators: [
-                StatusMinLengthValidator {
-                    minLength: 5
-                    errorMessage: qsTr("Username must be at least 5 characters")
-                },
-                StatusRegularExpressionValidator {
-                    regularExpression: /^[a-zA-Z0-9\-_]+$/
-                    errorMessage: qsTr("Only letters, numbers, underscores and hyphens allowed")
-                },
-                // TODO: Create `StatusMaxLengthValidator` in StatusQ
-                StatusValidator {
-                    name: "maxLengthValidator"
-                    validate: function (t) { return displayNameInput.input.text.length <= 24 }
-                    errorMessage: qsTr("24 character username limit")
-                },
-                StatusValidator {
-                    name: "endsWith-ethValidator"
-                    validate: function (t) { return !displayNameInput.input.text.endsWith("-eth") }
-                    errorMessage: qsTr("Usernames ending with '-eth' are not allowed")
-                },
-                StatusValidator {
-                    name: "endsWith_ethValidator"
-                    validate: function (t) { return !displayNameInput.input.text.endsWith("_eth") }
-                    errorMessage: qsTr("Usernames ending with '_eth' are not allowed")
-                },
-                StatusValidator {
-                    name: "endsWith.ethValidator"
-                    validate: function (t) { return !displayNameInput.input.text.endsWith(".eth") }
-                    errorMessage: qsTr("Usernames ending with '.eth' are not allowed")
-                },
-                StatusValidator {
-                    name: "isAliasValidator"
-                    validate: function (t) { return !globalUtils.isAlias(displayNameInput.input.text) }
-                    errorMessage: qsTr("Sorry, the name you have chosen is not allowed, try picking another username")
-                }
-            ]
+            validators: Constants.validators.displayName
         }
     }
 
@@ -72,9 +37,9 @@ StatusModal {
         StatusButton {
             id: doneBtn
             text: qsTr("Ok")
-            enabled: displayNameInput.valid
+            enabled: !!displayNameInput.text && displayNameInput.valid
             onClicked: {
-                root.profileStore.setDisplayName(displayNameInput.input.text)
+                root.profileStore.setDisplayName(displayNameInput.text)
                 root.close()
             }
         }

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -2,6 +2,8 @@ pragma Singleton
 
 import QtQuick 2.13
 
+import StatusQ.Controls.Validators 0.1
+
 QtObject {
     readonly property QtObject appState: QtObject {
         readonly property int onboarding: 0
@@ -106,6 +108,45 @@ QtObject {
         readonly property int rejectedSentContactRequest: 4
         readonly property int rejectedReceivedContactRequest: 5
         readonly property int blockedContacts: 6
+    }
+
+    readonly property QtObject validators: QtObject {
+        readonly property list<StatusValidator> displayName: [
+            StatusMinLengthValidator {
+                minLength: 5
+                errorMessage: qsTr("Username must be at least 5 characters")
+            },
+            StatusRegularExpressionValidator {
+                regularExpression: /^[a-zA-Z0-9\-_]+$/
+                errorMessage: qsTr("Only letters, numbers, underscores and hyphens allowed")
+            },
+            // TODO: Create `StatusMaxLengthValidator` in StatusQ
+            StatusValidator {
+                name: "maxLengthValidator"
+                validate: function (t) { return t.length <= 24 }
+                errorMessage: qsTr("24 character username limit")
+            },
+            StatusValidator {
+                name: "endsWith-ethValidator"
+                validate: function (t) { return !t.endsWith("-eth") }
+                errorMessage: qsTr("Usernames ending with '-eth' are not allowed")
+            },
+            StatusValidator {
+                name: "endsWith_ethValidator"
+                validate: function (t) { return !t.endsWith("_eth") }
+                errorMessage: qsTr("Usernames ending with '_eth' are not allowed")
+            },
+            StatusValidator {
+                name: "endsWith.ethValidator"
+                validate: function (t) { return !t.endsWith(".eth") }
+                errorMessage: qsTr("Usernames ending with '.eth' are not allowed")
+            },
+            StatusValidator {
+                name: "isAliasValidator"
+                validate: function (t) { return !globalUtils.isAlias(t) }
+                errorMessage: qsTr("Sorry, the name you have chosen is not allowed, try picking another username")
+            }
+        ]
     }
 
     readonly property int communityImported: 0


### PR DESCRIPTION
- validators included for the display name field in the onboarding process
- in display name popup "Ok" button disabled by default

Fixes #5236