### PR TITLE
fix(@desktop/chat): the app is crashed after sending gif to a group chat

### DIFF
--- a/ui/app/AppLayouts/Chat/views/CreateChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/CreateChatView.qml
@@ -137,6 +137,7 @@ Page {
             emojiPopup: root.emojiPopup
             recentStickers: root.rootStore.stickersModuleInst.recent
             stickerPackList: root.rootStore.stickersModuleInst.stickerPacks
+            closeGifPopupAfterSelection: true
 
             onSendTransactionCommandButtonClicked: {
                 root.rootStore.createChatStartSendTransactionProcess = true;

--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -35,6 +35,7 @@ Rectangle {
     property var emojiPopup: null
     // Use this to only enable the Connections only when this Input opens the Emoji popup
     property bool emojiPopupOpened: false
+    property bool closeGifPopupAfterSelection: false
 
     property bool emojiEvent: false;
     property bool paste: false;
@@ -742,7 +743,9 @@ Rectangle {
             messageInputField.text = url
             control.sendMessage(event)
             gifBtn.highlighted = false
-            messageInputField.forceActiveFocus();
+            messageInputField.forceActiveFocus()
+            if(control.closeGifPopupAfterSelection)
+                gifPopup.close()
         }
         onClosed: {
             gifBtn.highlighted = false

--- a/ui/imports/shared/status/StatusGifColumn.qml
+++ b/ui/imports/shared/status/StatusGifColumn.qml
@@ -110,8 +110,8 @@ Column {
                 anchors.fill: parent
                 hoverEnabled: true
                 onClicked: function (event) {
-                    root.gifSelected(event, model.url)
                     root.store.addToRecentsGif(model.id)
+                    root.gifSelected(event, model.url)
                 }
             }
         }


### PR DESCRIPTION
The issue was happening because adding gif to the recently used gifs model
was initiated after `gifSelected` action was fired and that action actually removed
the context within `addToRecentsGif` ought to be called and the app crashed.

That's fixed now updating the order of those two calls.

Fixes #5263