### PR TITLE
fix(desktop/profile): Does not apply avatar icon if quitted popup

### DIFF
--- a/ui/app/AppLayouts/Onboarding/popups/UploadProfilePicModal.qml
+++ b/ui/app/AppLayouts/Onboarding/popups/UploadProfilePicModal.qml
@@ -20,11 +20,10 @@ StatusModal {
     property string selectedImage
     property string uploadError
 
-    onSelectedImageChanged: {
-        if (!selectedImage) {
-            return;
-        }
-        cropImageModal.open();
+    signal accepted()
+
+    onOpened: {
+        selectedImage = ""
     }
 
     contentItem: Item {
@@ -57,9 +56,9 @@ StatusModal {
 
         ImageCropperModal {
             id: cropImageModal
-            selectedImage: popup.selectedImage
             ratio: "1:1"
             onCropFinished: {
+                popup.selectedImage = selectedImage
                 OnboardingStore.uploadImage(selectedImage, aX, aY, bX, bY);
             }
         }
@@ -71,6 +70,7 @@ StatusModal {
             text: !!selectedImage ? qsTr("Done") : qsTr("Upload")
             onClicked: {
                 if (!!selectedImage) {
+                    popup.accepted()
                     close();
                 } else {
                     imageDialog.open();
@@ -84,7 +84,8 @@ StatusModal {
                     qsTrId("image-files----jpg---jpeg---png-")
                 ]
                 onAccepted: {
-                    selectedImage = imageDialog.fileUrls[0];
+                    cropImageModal.selectedImage = imageDialog.fileUrls[0];
+                    cropImageModal.open()
                 }
             }
         }

--- a/ui/app/AppLayouts/Onboarding/popups/UploadProfilePicModal.qml
+++ b/ui/app/AppLayouts/Onboarding/popups/UploadProfilePicModal.qml
@@ -10,8 +10,6 @@ import shared 1.0
 import shared.panels 1.0
 import shared.popups 1.0
 
-import "../stores"
-
 StatusModal {
     id: popup
     height: 510
@@ -59,7 +57,6 @@ StatusModal {
             ratio: "1:1"
             onCropFinished: {
                 popup.selectedImage = selectedImage
-                OnboardingStore.uploadImage(selectedImage, aX, aY, bX, bY);
             }
         }
     }

--- a/ui/app/AppLayouts/Onboarding/popups/UploadProfilePicModal.qml
+++ b/ui/app/AppLayouts/Onboarding/popups/UploadProfilePicModal.qml
@@ -12,17 +12,19 @@ import shared.popups 1.0
 
 StatusModal {
     id: popup
+
     height: 510
     header.title: qsTr("Upload profile picture")
+
+    readonly property alias aX: cropImageModal.aX
+    readonly property alias aY: cropImageModal.aY
+    readonly property alias bX: cropImageModal.bX
+    readonly property alias bY: cropImageModal.bY
 
     property string selectedImage
     property string uploadError
 
     signal accepted()
-
-    onOpened: {
-        selectedImage = ""
-    }
 
     contentItem: Item {
         anchors.fill: parent

--- a/ui/app/AppLayouts/Onboarding/popups/UploadProfilePicModal.qml
+++ b/ui/app/AppLayouts/Onboarding/popups/UploadProfilePicModal.qml
@@ -81,8 +81,10 @@ StatusModal {
                     qsTrId("image-files----jpg---jpeg---png-")
                 ]
                 onAccepted: {
-                    cropImageModal.selectedImage = imageDialog.fileUrls[0];
-                    cropImageModal.open()
+                    if(imageDialog.fileUrls.length > 0) {
+                        cropImageModal.selectedImage = imageDialog.fileUrls[0];
+                        cropImageModal.open()
+                    }
                 }
             }
         }

--- a/ui/app/AppLayouts/Onboarding/views/InsertDetailsView.qml
+++ b/ui/app/AppLayouts/Onboarding/views/InsertDetailsView.qml
@@ -180,6 +180,7 @@ Item {
             anchors.centerIn: parent
             onAccepted: {
                 userImage.image.source = uploadProfilePicPopup.selectedImage
+                OnboardingStore.uploadImage(selectedImage, aX, aY, bX, bY);
             }
         }
     }

--- a/ui/app/AppLayouts/Onboarding/views/InsertDetailsView.qml
+++ b/ui/app/AppLayouts/Onboarding/views/InsertDetailsView.qml
@@ -81,7 +81,6 @@ Item {
                 icon.color: Theme.palette.miscColor5
                 icon.charactersLen: 2
                 image.isIdenticon: false
-                image.source: uploadProfilePicPopup.selectedImage
                 ringSettings { ringSpecModel: Utils.getColorHashAsJson(root.pubKey) }
             }
             StatusRoundButton {
@@ -179,6 +178,9 @@ Item {
         UploadProfilePicModal {
             id: uploadProfilePicPopup
             anchors.centerIn: parent
+            onAccepted: {
+                userImage.image.source = uploadProfilePicPopup.selectedImage
+            }
         }
     }
 

--- a/ui/app/AppLayouts/Onboarding/views/InsertDetailsView.qml
+++ b/ui/app/AppLayouts/Onboarding/views/InsertDetailsView.qml
@@ -92,6 +92,7 @@ Item {
                 type: StatusFlatRoundButton.Type.Secondary
                 icon.name: "add"
                 onClicked: {
+                    uploadProfilePicPopup.selectedImage = userImage.image.source
                     uploadProfilePicPopup.open();
                 }
             }
@@ -179,7 +180,7 @@ Item {
             id: uploadProfilePicPopup
             anchors.centerIn: parent
             onAccepted: {
-                userImage.image.source = uploadProfilePicPopup.selectedImage
+                userImage.image.source = selectedImage
                 OnboardingStore.uploadImage(selectedImage, aX, aY, bX, bY);
             }
         }

--- a/ui/imports/shared/popups/ModalPopup.qml
+++ b/ui/imports/shared/popups/ModalPopup.qml
@@ -67,10 +67,11 @@ Popup {
                 objectName: "titleText"
                 anchors.verticalCenter: parent.verticalCenter
                 anchors.left: parent.left
+                anchors.right: parent.right
+                anchors.rightMargin: 44
                 font.bold: true
                 font.pixelSize: 17
                 height: visible ? 24 : 0
-                width: visible ? parent.width - 44 : 0
                 elide: Text.ElideRight
                 visible: !!title
                 verticalAlignment: Text.AlignVCenter


### PR DESCRIPTION
Apply avatar icon only if the user accepts it.

Fix #5238

### What does the PR do

Fixes setting avatar image icon process - if the user quit the image popup, or cropping popup,
the icon will not be applied.

### Affected areas

Profile / onboarding 

### Screenshot of functionality

https://user-images.githubusercontent.com/61889657/161555042-ea0461b9-fe66-4266-a102-2c2adf22a089.mov



