### PR TITLE
fix(wallet-emoji): fix wallet emoji save by only saving the utf char

### DIFF
--- a/ui/app/AppLayouts/Chat/popups/community/CreateChannelPopup.qml
+++ b/ui/app/AppLayouts/Chat/popups/community/CreateChannelPopup.qml
@@ -23,7 +23,6 @@ StatusModal {
     property string channelColor: ""
     property bool emojiPopupOpened: false
     property var emojiPopup: null
-    readonly property string emojiRegexStr: 'alt="(\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff])"'
     readonly property var communityColorValidator: Utils.Validate.NoEmpty
                                                    | Utils.Validate.TextHexColor
 
@@ -279,12 +278,7 @@ StatusModal {
                     return
                 }
                 let error = "";
-                let emoji =  popup.contentItem.channelName.input.icon.emoji
-                // Extract the UTF emoji from the `img` tag so that we only store the emoi and not the full image
-                const found = RegExp(emojiRegexStr, 'g').exec(emoji);
-                if (found) {
-                    emoji = found[1]
-                }
+                let emoji =  StatusQUtils.Emoji.deparseFromParse(popup.contentItem.channelName.input.icon.emoji)
 
                 if (!isEdit) {
                     //popup.contentItem.communityColor.color.toString().toUpperCase()

--- a/ui/app/AppLayouts/Wallet/popups/AddAccountModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/AddAccountModal.qml
@@ -187,24 +187,26 @@ StatusModal {
                     return loading = false
                 }
 
+                let emoji =  StatusQUtils.Emoji.deparseFromParse(accountNameInput.input.icon.emoji)
+
                 var errMessage = ""
                 if(advancedSelection.expandableItem) {
                     switch(advancedSelection.expandableItem.addAccountType) {
                     case AdvancedAddAccountView.AddAccountType.GenerateNew:
-                        errMessage = RootStore.generateNewAccount(passwordInput.text, accountNameInput.text, colorSelectionGrid.selectedColor, accountNameInput.input.icon.emoji)
+                        errMessage = RootStore.generateNewAccount(passwordInput.text, accountNameInput.text, colorSelectionGrid.selectedColor, emoji)
                         break
                     case AdvancedAddAccountView.AddAccountType.ImportSeedPhrase:
-                        errMessage = RootStore.addAccountsFromSeed(advancedSelection.expandableItem.mnemonicText, passwordInput.text, accountNameInput.text, colorSelectionGrid.selectedColor, accountNameInput.input.icon.emoji)
+                        errMessage = RootStore.addAccountsFromSeed(advancedSelection.expandableItem.mnemonicText, passwordInput.text, accountNameInput.text, colorSelectionGrid.selectedColor, emoji)
                         break
                     case AdvancedAddAccountView.AddAccountType.ImportPrivateKey:
-                        errMessage = RootStore.addAccountsFromPrivateKey(advancedSelection.expandableItem.privateKey, passwordInput.text, accountNameInput.text, colorSelectionGrid.selectedColor, accountNameInput.input.icon.emoji)
+                        errMessage = RootStore.addAccountsFromPrivateKey(advancedSelection.expandableItem.privateKey, passwordInput.text, accountNameInput.text, colorSelectionGrid.selectedColor, emoji)
                         break
                     case AdvancedAddAccountView.AddAccountType.WatchOnly:
                         errMessage = RootStore.addWatchOnlyAccount(advancedSelection.expandableItem.watchAddress, accountNameInput.text, colorSelectionGrid.selectedColor, accountNameInput.input.icon.emoji)
                         break
                     }
                 } else {
-                    errMessage = RootStore.generateNewAccount(passwordInput.text, accountNameInput.text, colorSelectionGrid.selectedColor, accountNameInput.input.icon.emoji)
+                    errMessage = RootStore.generateNewAccount(passwordInput.text, accountNameInput.text, colorSelectionGrid.selectedColor, emoji)
                 }
 
                 loading = false


### PR DESCRIPTION
Fixes #5161

Also, changes the chat one to use `deparse` instead. It's basically the same thing, just in the Emoji file.

For testers, just see that saving the emoji for chats and wallets works as before. In the backend, it saves in a simpler format.