### PR TITLE
fix(@desktop/browser): Unable to sign message from simepledapp.eth

### DIFF
--- a/src/app_service/service/provider/async_tasks.nim
+++ b/src/app_service/service/provider/async_tasks.nim
@@ -9,13 +9,7 @@ type
 const postMessageTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[PostMessageTaskArg](argEncoded)
 
-  let jsonMessage = arg.message.parseJson
-  let password = jsonMessage{"payload"}{"password"}.getStr
-  if password != "":
-    let hashedPassword = hashPassword(password)
-    jsonMessage["payload"]["password"] = newJString(hashedPassword)
-
-  let result = status_go_provider.providerRequest(arg.requestType, $jsonMessage).result
+  let result = status_go_provider.providerRequest(arg.requestType, arg.message).result
   let responseJson = %* {
     "payloadMethod": arg.payloadMethod,
     "result": $result,

--- a/ui/app/AppLayouts/Browser/views/WebProviderObj.qml
+++ b/ui/app/AppLayouts/Browser/views/WebProviderObj.qml
@@ -45,15 +45,10 @@ QtObject {
                 }
                 
             } catch (e) {
-                if (Utils.isInvalidPasswordMessage(e.message)){
-                    //% "Wrong password"
-                    sendDialog.transactionSigner.validationError = qsTrId("wrong-password")
-                    return
-                }
                 if (isTx) {
                     showSendingError(e.message)
                 } else if (isSign) {
-                    showSigningError(e.message)
+                    showSigningError(e.message.message)
                 }
             }
         }

--- a/ui/imports/utils/Utils.qml
+++ b/ui/imports/utils/Utils.qml
@@ -724,15 +724,16 @@ QtObject {
             .replace(/'/g, "&#039;");
     }
 
-    // Leave this function at the bottom of the file as QT Creator messes up the code color after this
-    function isPunct(c) {
-        return /(!|\@|#|\$|%|\^|&|\*|\(|\)|_|\+|\||-|=|\\|{|}|[|]|"|;|'|<|>|\?|,|\.|\/)/.test(c)
-    }
-
     function isInvalidPasswordMessage(msg) {
         return (
             msg.includes("could not decrypt key with given password") ||
             msg.includes("invalid password")
         );
     }
+
+    // Leave this function at the bottom of the file as QT Creator messes up the code color after this
+    function isPunct(c) {
+        return /(!|\@|#|\$|%|\^|&|\*|\(|\)|_|\+|\||-|=|\\|{|}|[|]|"|;|'|<|>|\?|,|\.|\/)/.test(c)
+    }
+
 }


### PR DESCRIPTION
### What does the PR do

Removes the logic to convert a password into a hashPassword which was causing the issue

### Affected areas

Browser

### Screenshot of functionality

https://user-images.githubusercontent.com/60327365/161793990-f0c9e73e-69c9-4b70-9e98-33ddfbb25a83.mov


