### PR TITLE
fix(@desktop/communities): Remove sending invites when user select members for inviting to community

### DIFF
--- a/ui/app/AppLayouts/Chat/popups/community/InviteFriendsToCommunityPopup.qml
+++ b/ui/app/AppLayouts/Chat/popups/community/InviteFriendsToCommunityPopup.qml
@@ -42,13 +42,6 @@ StatusModal {
         communitySectionModule: popup.communitySectionModule
         contactsStore: popup.contactsStore
         community: popup.community
-        contactListSearch.onUserClicked: {
-            if (isAddedContact) {
-                // those are just added to the list to be added by the bunch
-                return
-            }
-            contactFieldAndList.sendInvites([pubKey])
-        }
     }
 
     leftButtons: [


### PR DESCRIPTION
Closes: #5343

### What does the PR do

Remove sending invites to members when they selected by user in list

### Affected areas

Invite friends to community popup
