### PR TITLE
fix(Messaging/Contacts): The titles of folders in Settings-Messaging are shown very close to the search field

### DIFF
--- a/ui/app/AppLayouts/Profile/views/ContactsView.qml
+++ b/ui/app/AppLayouts/Profile/views/ContactsView.qml
@@ -55,7 +55,7 @@ SettingsContentBase {
             Layout.fillWidth: true
             Layout.leftMargin: Style.current.padding
             Layout.rightMargin: Style.current.padding
-            Layout.topMargin: Style.current.padding
+            Layout.topMargin: 2 * Style.current.padding
             height: contactsBtn.height
             background: Rectangle {
                 color: Style.current.transparent


### PR DESCRIPTION
Fixes #5288

### What does the PR do

Added more top margin in tab component.

### Affected areas

Messaging/Contacts

### Screenshot of functionality
![Screenshot 2022-04-06 at 11 22 42](https://user-images.githubusercontent.com/97019400/161943122-3b403f19-61b2-4da1-af5e-8f07d2bded04.png)
