### PR TITLE
fix(@desktop/onboarding): the profile image doesn't look good on the onboarding page

### DIFF
--- a/src/app/modules/startup/onboarding/controller.nim
+++ b/src/app/modules/startup/onboarding/controller.nim
@@ -68,6 +68,8 @@ proc importMnemonic*(self: Controller, mnemonic: string) =
   else:
     self.delegate.importAccountError(error)
 
-method getPasswordStrengthScore*(self: Controller, password, userName: string): int = 
+proc getPasswordStrengthScore*(self: Controller, password, userName: string): int = 
   return self.generalService.getPasswordStrengthScore(password, userName)
 
+proc generateImages*(self: Controller, image: string, aX: int, aY: int, bX: int, bY: int): seq[general_service.Image] =
+  return self.generalService.generateImages(image, aX, aY, bX, bY)

--- a/src/app/modules/startup/onboarding/io_interface.nim
+++ b/src/app/modules/startup/onboarding/io_interface.nim
@@ -46,3 +46,6 @@ method setDisplayName*(self: AccessInterface, displayName: string) {.base.} =
 
 method getPasswordStrengthScore*(self: AccessInterface, password: string, userName: string): int {.base.} =
   raise newException(ValueError, "No implementation available")
+
+method generateImage*(self: AccessInterface, imageUrl: string, aX: int, aY: int, bX: int, bY: int): string {.base.} =
+  raise newException(ValueError, "No implementation available")

--- a/src/app/modules/startup/onboarding/module.nim
+++ b/src/app/modules/startup/onboarding/module.nim
@@ -81,3 +81,13 @@ method importAccountSuccess*(self: Module) =
 
 method getPasswordStrengthScore*(self: Module, password, userName: string): int =
   return self.controller.getPasswordStrengthScore(password, userName)
+
+method generateImage*(self: Module, imageUrl: string, aX: int, aY: int, bX: int, bY: int): string =
+  let formatedImg = singletonInstance.utils.formatImagePath(imageUrl)
+  let images = self.controller.generateImages(formatedImg, aX, aY, bX, bY)
+  if(images.len == 0):
+    return
+
+  for img in images:
+    if(img.imgType == "large"):
+      return img.uri

--- a/src/app/modules/startup/onboarding/view.nim
+++ b/src/app/modules/startup/onboarding/view.nim
@@ -95,3 +95,6 @@ QtObject:
 
   proc getPasswordStrengthScore*(self: View, password: string, userName: string): int {.slot.} =
     return self.delegate.getPasswordStrengthScore(password, userName)
+
+  proc generateImage*(self: View, imageUrl: string, aX: int, aY: int, bX: int, bY: int): string {.slot.} =
+    self.delegate.generateImage(imageUrl, aX, aY, bX, bY)

--- a/src/app_service/service/general/service.nim
+++ b/src/app_service/service/general/service.nim
@@ -2,9 +2,11 @@ import json, chronicles
 
 import ../../../backend/general as status_general
 import ../../../backend/keycard as status_keycard
-
+import ../../../backend/accounts as status_accounts
 import ../../../constants as app_constants
 
+import ../profile/dto/profile as profile_dto
+export profile_dto
 
 logScope:
   topics = "general-app-service"
@@ -40,7 +42,7 @@ proc startMessenger*(self: Service) =
     error "error: ", errDesription
     return
 
-method getPasswordStrengthScore*(self: Service, password, userName: string): int =
+proc getPasswordStrengthScore*(self: Service, password, userName: string): int =
   try:    
     let response = status_general.getPasswordStrengthScore(password, @[userName])
     if(response.result.contains("error")):
@@ -51,3 +53,15 @@ method getPasswordStrengthScore*(self: Service, password, userName: string): int
     return response.result["score"].getInt()
   except Exception as e:
     error "error: ", methodName="getPasswordStrengthScore", errName = e.name, errDesription = e.msg
+
+proc generateImages*(self: Service, image: string, aX: int, aY: int, bX: int, bY: int): seq[Image] =
+  try:
+    let response = status_general.generateImages(image, aX, aY, bX, bY)
+    if(response.result.kind != JArray):
+      error "error: ", procName="generateImages", errDesription = "response is not an array"
+      return
+
+    for img in response.result:
+      result.add(profile_dto.toImage(img))
+  except Exception as e:
+    error "error: ", procName="generateImages", errName = e.name, errDesription = e.msg

--- a/src/backend/general.nim
+++ b/src/backend/general.nim
@@ -62,3 +62,11 @@ proc enableCommunityHistoryArchiveSupport*(): RpcResponse[JsonNode] {.raises: [E
 proc disableCommunityHistoryArchiveSupport*(): RpcResponse[JsonNode] {.raises: [Exception].} =
   let payload = %* []
   result = core.callPrivateRPC("disableCommunityHistoryArchiveProtocol", payload)
+
+proc generateImages*(imagePath: string, aX, aY, bX, bY: int): RpcResponse[JsonNode] {.raises: [Exception].} =
+  try:
+    let response = status_go.generateImages(imagePath, aX, aY, bX, bY)
+    result.result = Json.decode(response, JsonNode)
+  except RpcException as e:
+    error "error", methodName = "generateImages", exception=e.msg
+    raise newException(RpcException, e.msg)

--- a/ui/app/AppLayouts/Onboarding/popups/UploadProfilePicModal.qml
+++ b/ui/app/AppLayouts/Onboarding/popups/UploadProfilePicModal.qml
@@ -4,11 +4,14 @@ import QtQuick.Dialogs 1.3
 import utils 1.0
 
 import StatusQ.Controls 0.1
+import StatusQ.Components 0.1
 import StatusQ.Popups 0.1
 
 import shared 1.0
 import shared.panels 1.0
 import shared.popups 1.0
+
+import "../stores"
 
 StatusModal {
     id: popup
@@ -22,22 +25,35 @@ StatusModal {
     readonly property alias bY: cropImageModal.bY
 
     property string selectedImage
+    property string croppedImg: ""
     property string uploadError
 
-    signal accepted()
+    signal profileImageReady(string croppedImg)
+
+    onClosed: {
+        popup.selectedImage = ""
+        popup.croppedImg = ""
+    }
 
     contentItem: Item {
         anchors.fill: parent
-        RoundedImage {
+        StatusRoundedImage {
             id: profilePic
-            source: selectedImage
             width: 160
             height: 160
             anchors.verticalCenter: parent.verticalCenter
             anchors.horizontalCenter: parent.horizontalCenter
+            image.source: popup.croppedImg
+            showLoadingIndicator: true
             border.width: 1
             border.color: Style.current.border
-            onClicked: imageDialog.open();
+
+            MouseArea {
+                anchors.fill: parent
+                cursorShape: Qt.PointingHandCursor
+                hoverEnabled: true
+                onClicked: imageDialog.open()
+            }
         }
 
         StyledText {
@@ -58,7 +74,8 @@ StatusModal {
             id: cropImageModal
             ratio: "1:1"
             onCropFinished: {
-                popup.selectedImage = selectedImage
+                popup.croppedImg = OnboardingStore.uploadImage(selectedImage, aX, aY, bX, bY);
+                popup.selectedImage = ""
             }
         }
     }
@@ -66,10 +83,10 @@ StatusModal {
     rightButtons: [
         StatusButton {
             id: uploadBtn
-            text: !!selectedImage ? qsTr("Done") : qsTr("Upload")
+            text: popup.croppedImg? qsTr("Done") : qsTr("Upload")
             onClicked: {
-                if (!!selectedImage) {
-                    popup.accepted()
+                if (popup.croppedImg) {
+                    popup.profileImageReady(popup.croppedImg)
                     close();
                 } else {
                     imageDialog.open();

--- a/ui/app/AppLayouts/Onboarding/stores/OnboardingStore.qml
+++ b/ui/app/AppLayouts/Onboarding/stores/OnboardingStore.qml
@@ -22,6 +22,10 @@ QtObject {
 
     property bool showBeforeGetStartedPopup: true
 
+    function generateImage(source, aX, aY, bX, bY) {
+        return onboardingModuleInst.generateImage(source, aX, aY, bX, bY)
+    }
+
     function importMnemonic(mnemonic) {
         onboardingModuleInst.importMnemonic(mnemonic)
     }
@@ -50,6 +54,8 @@ QtObject {
         root.profImgAY = aY;
         root.profImgBX = bX;
         root.profImgBY = bY;
+
+        return root.generateImage(source, aX, aY, bX, bY)
     }
 
     function removeImage() {

--- a/ui/app/AppLayouts/Onboarding/views/InsertDetailsView.qml
+++ b/ui/app/AppLayouts/Onboarding/views/InsertDetailsView.qml
@@ -73,15 +73,23 @@ Item {
             Layout.alignment: Qt.AlignHCenter
             StatusSmartIdenticon {
                 id: userImage
-                image.width: 80
-                image.height: 80
-                icon.width: 80
-                icon.height: 80
-                icon.letterSize: 32
-                icon.color: Theme.palette.miscColor5
-                icon.charactersLen: 2
-                image.isIdenticon: false
-                ringSettings { ringSpecModel: Utils.getColorHashAsJson(root.pubKey) }
+                image {
+                    width: 80
+                    height: 80
+                    isIdenticon: false
+                }
+
+                icon {
+                    width: 80
+                    height: 80
+                    letterSize: 32
+                    color: Theme.palette.miscColor5
+                    charactersLen: 2
+                }
+
+                ringSettings {
+                    ringSpecModel: Utils.getColorHashAsJson(root.pubKey)
+                }
             }
             StatusRoundButton {
                 id: updatePicButton
@@ -180,9 +188,8 @@ Item {
         UploadProfilePicModal {
             id: uploadProfilePicPopup
             anchors.centerIn: parent
-            onAccepted: {
-                userImage.image.source = selectedImage
-                OnboardingStore.uploadImage(selectedImage, aX, aY, bX, bY);
+            onProfileImageReady: {
+                userImage.image.source = croppedImg
             }
         }
     }


### PR DESCRIPTION
The issue occurred cause image was not cropped properly, but used the original one. 

While I was working on this issue I noticed that we're using calls from some modules, like main module, profile module... that are available only after user logs in successfully, and that display some errors/warning in the log.

Corresponding `status-go` PR: 
- https://github.com/status-im/status-go/pull/2627

Corresponding `nim-status-go` PR: 
- https://github.com/status-im/nim-status-go/pull/12

Fixes #5241