### PR TITLE
fix(SeedPhraseInputView): Submit button should disable when switching tabs

### DIFF
--- a/ui/app/AppLayouts/Onboarding/views/SeedPhraseInputView.qml
+++ b/ui/app/AppLayouts/Onboarding/views/SeedPhraseInputView.qml
@@ -39,6 +39,7 @@ OnboardingBasePage {
             onCurrentIndexChanged: {
                 root.mnemonicString = "";
                 root.mnemonicInput = [];
+                submitButton.enabled = false;
             }
         }
         clip: true


### PR DESCRIPTION
Closes #5388

### What does the PR do
The submit / restore status profile was staying enabled even when switching between seed word count tabs

### Affected areas
Onboarding/StatusSeedPhraseInput
