### PR TITLE
fix(@desktop/wallet): Allow entering private keys with and without 0x prefix

### DIFF
--- a/ui/app/AppLayouts/Wallet/views/AdvancedAddAccountView.qml
+++ b/ui/app/AppLayouts/Wallet/views/AdvancedAddAccountView.qml
@@ -168,7 +168,7 @@ ColumnLayout {
         id: privateKey
         //% "Private key"
         label: qsTrId("private-key")
-        charLimit: 64
+        charLimit: 66
         input.multiline: true
         input.minimumHeight: 80
         input.maximumHeight: 108


### PR DESCRIPTION
fix #5406

### What does the PR do

Makes the limit for chars to be entered when importing a private key to 66 from 64. Allowing users to import private key with and without 0x prefix

### Affected areas

wallet

### Screenshot of functionality
<img width="1458" alt="image" src="https://user-images.githubusercontent.com/60327365/162155560-efc39854-ed02-4add-8024-5d8a197c71d6.png">
