### PR TITLE
fix(@desktop/chat): Improve SearchBox default height to display text correctly

### DIFF
--- a/ui/imports/shared/controls/SearchBox.qml
+++ b/ui/imports/shared/controls/SearchBox.qml
@@ -11,7 +11,6 @@ StatusInput {
     //% "Search"
     input.placeholderText: qsTrId("search")
     input.icon.name: "search"
-    input.implicitHeight: 36
     input.clearable: true
     leftPadding: 0
     rightPadding: 0


### PR DESCRIPTION
Fix #5381

### What does the PR do

Removed implicitHeight which was too small and overrode original implicitHeight.
The height was too small to display text correctly.

### Affected areas

Places where SearchBox is used:
- Edit channel / search emoji
- Chat / search gif
- Settings / Wallet / Manage Assets 

### Screenshot of functionality

![image](https://user-images.githubusercontent.com/61889657/162208536-1f11b980-5dd1-4f33-9b57-247b8837cba2.png)
