### PR TITLE
fix(CreateChatView): fixed big text goes outside text edit

### DIFF
--- a/ui/app/AppLayouts/Chat/views/CreateChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/CreateChatView.qml
@@ -92,7 +92,7 @@ Page {
         anchors.topMargin: 8
         anchors.right: parent.right
         anchors.rightMargin: 8
-
+        clip: true
         StatusTagSelector {
             id: tagSelector
             Layout.fillWidth: true


### PR DESCRIPTION
Depends on: https://github.com/status-im/StatusQ/pull/633

Closes #5294

### What does the PR do
fixed big text goes outside text edit

### Affected areas
create new chat

### Screenshot of functionality
<img width="693" alt="txtin" src="https://user-images.githubusercontent.com/31625338/162261128-cb7f73d0-aedf-4361-b1db-7c6666755ae3.png">

