### PR TITLE
fix(@desktop/wallet): To field is not showing address in wallet

### DIFF
--- a/ui/imports/shared/views/SendModalHeader.qml
+++ b/ui/imports/shared/views/SendModalHeader.qml
@@ -209,7 +209,7 @@ Rectangle {
             input.anchors.rightMargin: 0
             labelFont.pixelSize: 15
             labelFont.weight: Font.Normal
-            input.implicitHeight: 56
+            input.height: 56
             isSelectorVisible: false
             addContactEnabled: false
             onSelectedRecipientChanged: estimateGas()


### PR DESCRIPTION
fixes #5447

### What does the PR do

Sets the correct height for the to field

### Affected areas

Wallet

### Screenshot of functionality

<img width="743" alt="image" src="https://user-images.githubusercontent.com/60327365/162458893-86b72982-c353-4a66-ba35-4a918ddc963f.png">
