### PR TITLE
fix(@desktop/onboarding): Improve password validation and errors showing

### DIFF
--- a/ui/app/AppLayouts/Onboarding/views/CreatePasswordView.qml
+++ b/ui/app/AppLayouts/Onboarding/views/CreatePasswordView.qml
@@ -39,9 +39,11 @@ OnboardingBasePage {
             text: qsTr("Create password")
             enabled: view.ready
             onClicked: {
-                root.newPassword = view.newPswText
-                root.confirmationPassword = view.confirmationPswText
-                root.exit()
+                if (view.validatePassword()) {
+                    root.newPassword = view.newPswText
+                    root.confirmationPassword = view.confirmationPswText
+                    root.exit()
+                }
             }
         }
     }
@@ -55,11 +57,5 @@ OnboardingBasePage {
         anchors.bottomMargin: Style.current.padding
         icon.name: "arrow-left"
         onClicked: { root.backClicked() }
-    }
-    // By clicking anywhere outside password entries fields or focusable element in the view, it is needed to check if passwords entered matches
-    MouseArea {
-        anchors.fill: parent
-        z: d.zBehind // Behind focusable components
-        onClicked: { view.checkPasswordMatches() }
     }
 }

--- a/ui/app/AppLayouts/Profile/popups/ChangePasswordModal.qml
+++ b/ui/app/AppLayouts/Profile/popups/ChangePasswordModal.qml
@@ -70,10 +70,12 @@ StatusModal {
             }
 
             onClicked: {
-                submitBtn.loading = true;
-                // ChangePassword operation blocks the UI so loading = true; will never have any affect until changePassword/createPassword is done.
-                // Getting around it with a small pause (timer) in order to get the desired behavior
-                pause.start();
+                if (view.validatePassword()) {
+                    submitBtn.loading = true;
+                    // ChangePassword operation blocks the UI so loading = true; will never have any affect until changePassword/createPassword is done.
+                    // Getting around it with a small pause (timer) in order to get the desired behavior
+                    pause.start();
+                }
             }
         }
     ]


### PR DESCRIPTION
Fix #5319

### What does the PR do

Improving password validation and showing errors

- Panel is ready (Create button is unblocked) when the new password & confirmation has the same length and password’s length is >= 6
- Errors are displayed after clicking Create button
- Errors are cleared when password or confirmation are changed
- validatePassword() function is executed when the confirmation button is clicked

### Affected areas

Onboarding / creating password
Profile / changing password

### Screenshot of functionality

https://user-images.githubusercontent.com/61889657/162473086-d7b3a20d-3e7f-4e34-ab16-f56a6d139bed.mov



