### PR TITLE
fix(@desktop/groups): group modal is missing context menu options

### DIFF
--- a/src/app/modules/main/chat_section/controller.nim
+++ b/src/app/modules/main/chat_section/controller.nim
@@ -176,7 +176,7 @@ proc init*(self: Controller) =
     let args = ChatExtArgs(e)
     if (self.isCommunitySection):
       return
-    self.delegate.createOneToOneChat(args.communityId, args.chatId, args.ensName)
+    self.delegate.createOneToOneChat(args.chatId, args.ensName)
 
   self.events.on(SignalType.HistoryRequestStarted.event) do(e: Args):
     self.delegate.setLoadingHistoryMessagesInProgress(true)
@@ -242,8 +242,8 @@ proc createPublicChat*(self: Controller, chatId: string) =
       self.contactService, self.chatService, self.communityService, self.messageService,
       self.gifService, self.mailserversService)
 
-proc createOneToOneChat*(self: Controller, communityID: string, chatId: string, ensName: string) =
-  let response = self.chatService.createOneToOneChat(communityID, chatId, ensName)
+proc createOneToOneChat*(self: Controller, chatId: string, ensName: string) =
+  let response = self.chatService.createOneToOneChat(chatId, ensName)
   if(response.success):
     self.delegate.addChatIfDontExist(response.chatDto, false, self.events, self.settingsService,
       self.contactService, self.chatService, self.communityService, self.messageService,
@@ -285,20 +285,20 @@ proc rejectContactRequest*(self: Controller, publicKey: string) =
 proc blockContact*(self: Controller, publicKey: string) =
   self.contactService.blockContact(publicKey)
 
-proc addGroupMembers*(self: Controller, communityID: string, chatId: string, pubKeys: seq[string]) =
-  self.chatService.addGroupMembers(communityID, chatId, pubKeys)
+proc addGroupMembers*(self: Controller, chatId: string, pubKeys: seq[string]) =
+  self.chatService.addGroupMembers(chatId, pubKeys)
 
-proc removeMemberFromGroupChat*(self: Controller, communityID: string, chatId: string, pubKey: string) =
-   self.chatService.removeMemberFromGroupChat(communityID, chatId, pubKey)
+proc removeMemberFromGroupChat*(self: Controller, chatId: string, pubKey: string) =
+  self.chatService.removeMemberFromGroupChat(chatId, pubKey)
 
-proc renameGroupChat*(self: Controller, communityID: string, chatId: string, newName: string) =
-  self.chatService.renameGroupChat(communityID, chatId, newName)
+proc renameGroupChat*(self: Controller, chatId: string, newName: string) =
+  self.chatService.renameGroupChat(chatId, newName)
 
-proc makeAdmin*(self: Controller, communityID: string, chatId: string, pubKey: string) =
-  self.chatService.makeAdmin(communityID, chatId, pubKey)
+proc makeAdmin*(self: Controller, chatId: string, pubKey: string) =
+  self.chatService.makeAdmin(chatId, pubKey)
 
-proc createGroupChat*(self: Controller, communityID: string, groupName: string, pubKeys: seq[string]) =
-  let response = self.chatService.createGroupChat(communityID, groupName, pubKeys)
+proc createGroupChat*(self: Controller, groupName: string, pubKeys: seq[string]) =
+  let response = self.chatService.createGroupChat(groupName, pubKeys)
   if(response.success):
     self.delegate.addChatIfDontExist(response.chatDto, false, self.events, self.settingsService,
       self.contactService, self.chatService, self.communityService, self.messageService,

--- a/src/app/modules/main/chat_section/io_interface.nim
+++ b/src/app/modules/main/chat_section/io_interface.nim
@@ -152,7 +152,7 @@ method getMySectionId*(self: AccessInterface): string {.base.} =
 method createPublicChat*(self: AccessInterface, chatId: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method createOneToOneChat*(self: AccessInterface, communityID: string, chatId: string, ensName: string) {.base.} =
+method createOneToOneChat*(self: AccessInterface, chatId: string, ensName: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method leaveChat*(self: AccessInterface, chatId: string) {.base.} =
@@ -194,19 +194,19 @@ method rejectAllContactRequests*(self: AccessInterface) {.base.} =
 method blockContact*(self: AccessInterface, publicKey: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method addGroupMembers*(self: AccessInterface, communityID: string, chatId: string, pubKeys: string) {.base.} =
+method addGroupMembers*(self: AccessInterface, chatId: string, pubKeys: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method removeMemberFromGroupChat*(self: AccessInterface, communityID: string, chatId: string, pubKey: string) {.base.} =
+method removeMemberFromGroupChat*(self: AccessInterface, chatId: string, pubKey: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method renameGroupChat*(self: AccessInterface, communityID: string, chatId: string, newName: string) {.base.} =
+method renameGroupChat*(self: AccessInterface, chatId: string, newName: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method makeAdmin*(self: AccessInterface, communityID: string, chatId: string, pubKey: string) {.base.} =
+method makeAdmin*(self: AccessInterface, chatId: string, pubKey: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method createGroupChat*(self: AccessInterface, communityID: string, groupName: string, pubKeys: string) {.base.} =
+method createGroupChat*(self: AccessInterface, groupName: string, pubKeys: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method joinGroupChatFromInvitation*(self: AccessInterface, groupName: string, chatId: string, adminPK: string) {.base.} =

--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -549,7 +549,7 @@ method onCommunityChannelEdited*(self: Module, chat: ChatDto) =
   self.view.chatsModel().updateItemDetails(chat.id, chat.name, chat.description, chat.emoji,
     chat.color)
 
-method createOneToOneChat*(self: Module, communityID: string, chatId: string, ensName: string) =
+method createOneToOneChat*(self: Module, chatId: string, ensName: string) =
   if(self.controller.isCommunity()):
     # initiate chat creation in the `Chat` seciton module.
     self.controller.switchToOrCreateOneToOneChat(chatId, ensName)
@@ -559,7 +559,7 @@ method createOneToOneChat*(self: Module, communityID: string, chatId: string, en
     self.setActiveItemSubItem(chatId, "")
     return
 
-  self.controller.createOneToOneChat(communityID, chatId, ensName)
+  self.controller.createOneToOneChat(chatId, ensName)
 
 method leaveChat*(self: Module, chatId: string) =
   self.controller.leaveChat(chatId)
@@ -594,7 +594,7 @@ method acceptContactRequest*(self: Module, publicKey: string) =
 method onContactAccepted*(self: Module, publicKey: string) =
   self.view.contactRequestsModel().removeItemWithPubKey(publicKey)
   self.updateParentBadgeNotifications()
-  self.createOneToOneChat(communityID = "" , publicKey, ensName = "")
+  self.createOneToOneChat(publicKey, ensName = "")
 
 method acceptAllContactRequests*(self: Module) =
   let pubKeys = self.view.contactRequestsModel().getPublicKeys()
@@ -669,20 +669,20 @@ method onMeMentionedInEditedMessage*(self: Module, chatId: string, editedMessage
   var (sectionHasUnreadMessages, sectionNotificationCount) = self.view.chatsModel().getAllNotifications()
   self.updateBadgeNotifications(chatId, sectionHasUnreadMessages, sectionNotificationCount + 1)
 
-method addGroupMembers*(self: Module, communityID: string, chatId: string, pubKeys: string) =
-  self.controller.addGroupMembers(communityID, chatId, self.convertPubKeysToJson(pubKeys))
+method addGroupMembers*(self: Module, chatId: string, pubKeys: string) =
+  self.controller.addGroupMembers(chatId, self.convertPubKeysToJson(pubKeys))
 
-method removeMemberFromGroupChat*(self: Module, communityID: string, chatId: string, pubKey: string) =
-  self.controller.removeMemberFromGroupChat(communityID, chatId, pubKey)
+method removeMemberFromGroupChat*(self: Module, chatId: string, pubKey: string) =
+  self.controller.removeMemberFromGroupChat(chatId, pubKey)
 
-method renameGroupChat*(self: Module, communityID: string, chatId: string, newName: string) =
-  self.controller.renameGroupChat(communityID, chatId, newName)
+method renameGroupChat*(self: Module, chatId: string, newName: string) =
+  self.controller.renameGroupChat(chatId, newName)
 
-method makeAdmin*(self: Module, communityID: string, chatId: string, pubKey: string) =
-  self.controller.makeAdmin(communityID, chatId, pubKey)
+method makeAdmin*(self: Module, chatId: string, pubKey: string) =
+  self.controller.makeAdmin(chatId, pubKey)
 
-method createGroupChat*(self: Module, communityID: string, groupName: string, pubKeys: string) =
-  self.controller.createGroupChat(communityID, groupName, self.convertPubKeysToJson(pubKeys))
+method createGroupChat*(self: Module, groupName: string, pubKeys: string) =
+  self.controller.createGroupChat(groupName, self.convertPubKeysToJson(pubKeys))
 
 method joinGroupChatFromInvitation*(self: Module, groupName: string, chatId: string, adminPK: string) =
   self.controller.joinGroupChatFromInvitation(groupName, chatId, adminPK)

--- a/src/app/modules/main/chat_section/view.nim
+++ b/src/app/modules/main/chat_section/view.nim
@@ -138,8 +138,8 @@ QtObject:
   proc createPublicChat*(self: View, chatId: string) {.slot.} =
     self.delegate.createPublicChat(chatId)
 
-  proc createOneToOneChat*(self: View, communityID: string, chatId: string, ensName: string) {.slot.} =
-    self.delegate.createOneToOneChat(communityID, chatId, ensName)
+  proc createOneToOneChat*(self: View, chatId: string, ensName: string) {.slot.} =
+    self.delegate.createOneToOneChat(chatId, ensName)
 
   proc leaveChat*(self: View, id: string) {.slot.} =
     self.delegate.leaveChat(id)
@@ -181,20 +181,20 @@ QtObject:
   proc removeCommunityChat*(self: View, chatId: string) {.slot} =
     self.delegate.removeCommunityChat(chatId)
 
-  proc addGroupMembers*(self: View, communityID: string, chatId: string, pubKeys: string) {.slot.} =
-    self.delegate.addGroupMembers(communityID, chatId, pubKeys)
+  proc addGroupMembers*(self: View, chatId: string, pubKeys: string) {.slot.} =
+    self.delegate.addGroupMembers(chatId, pubKeys)
 
-  proc removeMemberFromGroupChat*(self: View, communityID: string, chatId: string, pubKey: string) {.slot.} =
-    self.delegate.removeMemberFromGroupChat(communityID, chatId, pubKey)
+  proc removeMemberFromGroupChat*(self: View, chatId: string, pubKey: string) {.slot.} =
+    self.delegate.removeMemberFromGroupChat(chatId, pubKey)
 
-  proc renameGroupChat*(self: View, communityID: string, chatId: string, newName: string) {.slot.} =
-    self.delegate.renameGroupChat(communityID, chatId, newName)
+  proc renameGroupChat*(self: View, chatId: string, newName: string) {.slot.} =
+    self.delegate.renameGroupChat(chatId, newName)
 
-  proc makeAdmin*(self: View, communityID: string, chatId: string, pubKey: string) {.slot.} =
-    self.delegate.makeAdmin(communityID, chatId, pubKey)
+  proc makeAdmin*(self: View, chatId: string, pubKey: string) {.slot.} =
+    self.delegate.makeAdmin(chatId, pubKey)
 
-  proc createGroupChat*(self: View, communityID: string, groupName: string, pubKeys: string) {.slot.} =
-    self.delegate.createGroupChat(communityID, groupName, pubKeys)
+  proc createGroupChat*(self: View, groupName: string, pubKeys: string) {.slot.} =
+    self.delegate.createGroupChat(groupName, pubKeys)
 
   proc joinGroupChatFromInvitation*(self: View, groupName: string, chatId: string, adminPK: string) {.slot.} =
     self.delegate.joinGroupChatFromInvitation(groupName, chatId, adminPK)

--- a/src/app_service/service/chat/dto/chat.nim
+++ b/src/app_service/service/chat/dto/chat.nim
@@ -36,6 +36,7 @@ type ChatMember* = object
   id*: string
   admin*: bool
   joined*: bool
+  roles*: seq[int]
 
 type ChatDto* = object
   id*: string # ID is the id of the chat, for public chats it is the name e.g. status,
@@ -145,6 +146,11 @@ proc toChatMember*(jsonObj: JsonNode): ChatMember =
   discard jsonObj.getProp("id", result.id)
   discard jsonObj.getProp("admin", result.admin)
   discard jsonObj.getProp("joined", result.joined)
+  
+  var rolesObj: JsonNode
+  if(jsonObj.getProp("roles", rolesObj) and rolesObj.kind == JArray):
+    for role in rolesObj:
+      result.roles.add(role.getInt)
 
 proc toChatMember(jsonObj: JsonNode, memberId: string): ChatMember =
   # Mapping this DTO is not strightforward since only keys are used for id. We
@@ -193,9 +199,13 @@ proc toChatDto*(jsonObj: JsonNode): ChatDto =
       result.chatType = ChatType(chatTypeInt)
 
   var membersObj: JsonNode
-  if(jsonObj.getProp("members", membersObj) and membersObj.kind == JArray):
-    for memberObj in membersObj:
-      result.members.add(toChatMember(memberObj))
+  if(jsonObj.getProp("members", membersObj)):
+    if(membersObj.kind == JArray):
+      for memberObj in membersObj:
+        result.members.add(toChatMember(memberObj))
+    elif(membersObj.kind == JObject):
+      for memberId, memberObj in membersObj:
+        result.members.add(toChatMember(memberObj, memberId))
 
   # Add community ID if needed
   if (result.communityId != "" and not result.id.contains(result.communityId)):

--- a/src/app_service/service/chat/service.nim
+++ b/src/app_service/service/chat/service.nim
@@ -239,19 +239,19 @@ QtObject:
       error "error: ", errDesription
       return
 
-  proc createOneToOneChat*(self: Service, communityID: string, chatId: string, ensName: string): tuple[chatDto: ChatDto, success: bool] =
+  proc createOneToOneChat*(self: Service, chatId: string, ensName: string): tuple[chatDto: ChatDto, success: bool] =
     try:
       if self.hasChannel(chatId):
         # We want to show the chat to the user and for that we activate the chat
         discard status_group_chat.createOneToOneChat(
-          communityID,
+          "",
           chatId,
           ensName=ensName)
         result.success = true
         result.chatDto = self.chats[chatId]
         return
 
-      let response =  status_group_chat.createOneToOneChat(communityID, chatId, ensName)
+      let response =  status_group_chat.createOneToOneChat("", chatId, ensName)
       result = self.createChatFromResponse(response)
     except Exception as e:
       let errDesription = e.msg
@@ -422,26 +422,26 @@ QtObject:
       error "error: ", errDesription
       return
 
-  proc addGroupMembers*(self: Service, communityID: string, chatID: string, members: seq[string]) =
+  proc addGroupMembers*(self: Service, chatID: string, members: seq[string]) =
     try:
-      let response = status_group_chat.addMembers(communityID, chatId, members)
+      let response = status_group_chat.addMembers("", chatId, members)
       if (response.error.isNil):
         self.events.emit(SIGNAL_CHAT_MEMBERS_ADDED, ChatMembersAddedArgs(chatId: chatId, ids: members))
     except Exception as e:
       error "error while adding group members: ", msg = e.msg
 
-  proc removeMemberFromGroupChat*(self: Service, communityID: string, chatID: string, member: string) =
+  proc removeMemberFromGroupChat*(self: Service, chatID: string, member: string) =
     try:
-      let response = status_group_chat.removeMember(communityID, chatId, member)
+      let response = status_group_chat.removeMember("", chatId, member)
       if (response.error.isNil):
         self.events.emit(SIGNAL_CHAT_MEMBER_REMOVED, ChatMemberRemovedArgs(chatId: chatId, id: member))
     except Exception as e:
       error "error while removing member from group: ", msg = e.msg
 
 
-  proc renameGroupChat*(self: Service, communityID: string, chatID: string, name: string) =
+  proc renameGroupChat*(self: Service, chatID: string, name: string) =
     try:
-      let response = status_group_chat.renameChat(communityID, chatId, name)
+      let response = status_group_chat.renameChat("", chatId, name)
       if (not response.error.isNil):
         let msg = response.error.message & " chatId=" & chatId
         error "error while renaming group chat", msg
@@ -452,9 +452,9 @@ QtObject:
       error "error while renaming group chat: ", msg = e.msg
 
 
-  proc makeAdmin*(self: Service, communityID: string, chatID: string, memberId: string) =
+  proc makeAdmin*(self: Service, chatID: string, memberId: string) =
     try:
-      discard status_group_chat.makeAdmin(communityID, chatId, memberId)
+      discard status_group_chat.makeAdmin("", chatId, memberId)
       for member in self.chats[chatId].members.mitems:
         if (member.id == memberId):
           member.admin = true
@@ -481,9 +481,9 @@ QtObject:
     except Exception as e:
       error "error while creating group from invitation: ", msg = e.msg
 
-  proc createGroupChat*(self: Service, communityID: string, name: string, members: seq[string]): tuple[chatDto: ChatDto, success: bool] =
+  proc createGroupChat*(self: Service, name: string, members: seq[string]): tuple[chatDto: ChatDto, success: bool] =
     try:
-      let response = status_group_chat.createGroupChat(communityID, name, members)
+      let response = status_group_chat.createGroupChat("", name, members)
       result = self.createChatFromResponse(response)
     except Exception as e:
       error "error while creating group chat", msg = e.msg

--- a/ui/app/AppLayouts/Chat/popups/GroupInfoPopup.qml
+++ b/ui/app/AppLayouts/Chat/popups/GroupInfoPopup.qml
@@ -31,7 +31,7 @@ StatusModal {
 
     property int channelType: GroupInfoPopup.ChannelType.ActiveChannel
     property var chatDetails
-    property bool isAdmin: popup.chatSectionModule.activeItem.amIChatAdmin
+    property bool isAdmin: popup.chatContentModule.amIChatAdmin()
     property Component pinnedMessagesPopupComponent
 
     property var chatContentModule
@@ -241,9 +241,10 @@ StatusModal {
                                 icon.name: "admin"
                                 icon.width: 16
                                 icon.height: 16
+                                enabled: !model.isAdmin
                                 //% "Make Admin"
                                 text: qsTrId("make-admin")
-                                onTriggered: popup.chatSectionModule.makeAdmin("", popup.chatDetails.id,  model.id)
+                                onTriggered: popup.chatSectionModule.makeAdmin(popup.chatDetails.id, model.id)
                             }
                             StatusMenuItem {
                                 icon.name: "remove-contact"
@@ -252,7 +253,7 @@ StatusModal {
                                 type: StatusMenuItem.Type.Danger
                                 //% "Remove From Group"
                                 text: qsTrId("remove-from-group")
-                                onTriggered: popup.chatSectionModule.removeMemberFromGroupChat("", popup.chatDetails.id,  model.id)
+                                onTriggered: popup.chatSectionModule.removeMemberFromGroupChat(popup.chatDetails.id, model.id)
                             }
                         }
                     }

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -337,7 +337,7 @@ QtObject {
                             .arg(isChatKey(pk) ? globalUtils.generateAlias(pk) : ("@" + removeStatusEns(pk)))
             result.callback = function () {
                 if (isChatKey(pk)) {
-                    chatCommunitySectionModule.createOneToOneChat("", pk, "")
+                    chatCommunitySectionModule.createOneToOneChat(pk, "")
                 } else {
                 // Not Refactored Yet
 //                    chatsModel.channelView.joinWithENS(pk);

--- a/ui/app/AppLayouts/Chat/views/ChatContentView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatContentView.qml
@@ -366,7 +366,7 @@ ColumnLayout {
 
         onCreateOneToOneChat: {
             Global.changeAppSectionBySectionType(Constants.appSection.chat)
-            root.rootStore.chatCommunitySectionModule.createOneToOneChat("", chatId, ensName)
+            root.rootStore.chatCommunitySectionModule.createOneToOneChat(chatId, ensName)
         }
     }
 

--- a/ui/app/AppLayouts/Chat/views/ChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatView.qml
@@ -193,7 +193,7 @@ StatusAppThreePanelLayout {
         }
         onCreateOneToOneChat: {
             Global.changeAppSectionBySectionType(Constants.appSection.chat)
-            root.rootStore.chatCommunitySectionModule.createOneToOneChat(communityId, chatId, ensName)
+            root.rootStore.chatCommunitySectionModule.createOneToOneChat(chatId, ensName)
         }
     }
 }

--- a/ui/app/AppLayouts/Chat/views/ContactsColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ContactsColumnView.qml
@@ -276,7 +276,7 @@ Item {
             store: root.store
             contactsStore: root.contactsStore
             onJoinPrivateChat: {
-                chatSectionModule.createOneToOneChat("", publicKey, ensName)
+                chatSectionModule.createOneToOneChat(publicKey, ensName)
             }
             onClosed: {
                 destroy()

--- a/ui/app/AppLayouts/Chat/views/CreateChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/CreateChatView.qml
@@ -54,7 +54,7 @@ Page {
     function createChat() {
         if (tagSelector.namesModel.count === 1) {
             var ensName = tagSelector.namesModel.get(0).name.includes(".eth") ? tagSelector.namesModel.get(0).name : "";
-            root.rootStore.chatCommunitySectionModule.createOneToOneChat("", tagSelector.namesModel.get(0).publicId, ensName);
+            root.rootStore.chatCommunitySectionModule.createOneToOneChat(tagSelector.namesModel.get(0).publicId, ensName);
         } else {
             var groupName = "";
             var publicIds = [];
@@ -62,7 +62,7 @@ Page {
                 groupName += (tagSelector.namesModel.get(i).name + (i === tagSelector.namesModel.count - 1 ? "" : "&"));
                 publicIds.push(tagSelector.namesModel.get(i).publicId);
             }
-            root.rootStore.chatCommunitySectionModule.createGroupChat("",groupName, JSON.stringify(publicIds));
+            root.rootStore.chatCommunitySectionModule.createGroupChat(groupName, JSON.stringify(publicIds));
         }
 
         chatInput.textInput.clear();

--- a/ui/imports/shared/views/chat/MessageContextMenuView.qml
+++ b/ui/imports/shared/views/chat/MessageContextMenuView.qml
@@ -57,7 +57,7 @@ StatusPopupMenu {
     signal pinnedMessagesLimitReached(string messageId)
     signal jumpToMessage(string messageId)
     signal shouldCloseParentPopup()
-    signal createOneToOneChat(string communityId, string chatId, string ensName)
+    signal createOneToOneChat(string chatId, string ensName)
     signal showReplyArea()
     signal toggleReaction(string messageId, int emojiId)
     signal deleteMessage(string messageId)
@@ -179,7 +179,7 @@ StatusPopupMenu {
                   qsTrId("reply-to")
         onTriggered: {
             if (root.isProfile) {
-                root.createOneToOneChat("", root.selectedUserPublicKey, "")
+                root.createOneToOneChat(root.selectedUserPublicKey, "")
             } else {
                 root.showReplyArea()
             }


### PR DESCRIPTION
This branch branches off #5479

Within this PR members list issue is fixed, since during the received channel groups data mapping list of members was not populated correctly, and it was always empty (we should pay attention that list of members for "community group" is always the same as one for community's channels, but list of members for "personal group" is always empty, but each chat of personal group has its own list of members, that was the main issue).

Also within this ticket `communityID` parameter which was required by functions like `createOneToOneChat`, `createGroupChat` and others is removed, since it's completely unnecessary there since those calls are possible only within "Chat section" and having them only brings confusion, also if we have them on the qml side, as it was before this pr, just requires accessing `communityID` in components which do not need to know/have that info.

Fixes #5467