### PR TITLE
fix(community): community would appear even if not activated

### DIFF
--- a/src/app/modules/main/controller.nim
+++ b/src/app/modules/main/controller.nim
@@ -105,6 +105,7 @@ proc init*(self: Controller) =
       self.messageService,
       self.gifService,
       self.mailserversService,
+      setActive = args.fromUserAction
     )
 
   self.events.on(TOGGLE_SECTION) do(e:Args):
@@ -123,6 +124,7 @@ proc init*(self: Controller) =
       self.messageService,
       self.gifService,
       self.mailserversService,
+      setActive = true
     )
 
   self.events.on(SIGNAL_COMMUNITY_IMPORTED) do(e:Args):
@@ -139,6 +141,7 @@ proc init*(self: Controller) =
       self.messageService,
       self.gifService,
       self.mailserversService,
+      setActive = false
     )
 
   self.events.on(SIGNAL_COMMUNITY_LEFT) do(e:Args):
@@ -229,12 +232,12 @@ proc getActiveSectionId*(self: Controller): string =
   result = self.activeSectionId
 
 proc setActiveSection*(self: Controller, sectionId: string, sectionType: SectionType) =
-  self.activeSectionId = sectionId
+  if sectionType == SectionType.Community and
+      not singletonInstance.localAccountSensitiveSettings.getCommunitiesEnabled():
+    # Communities are not supposed to be shown
+    return
 
-  if(sectionType == SectionType.Chat or sectionType == SectionType.Community):
-    # We need to take other actions here, in case of Chat or Community sections like
-    # notify status go that unviewed mentions count is updated and so...
-    echo "deal with appropriate service..."
+  self.activeSectionId = sectionId
 
   singletonInstance.localAccountSensitiveSettings.setActiveSection(self.activeSectionId)
 

--- a/src/app/modules/main/io_interface.nim
+++ b/src/app/modules/main/io_interface.nim
@@ -103,7 +103,8 @@ method communityJoined*(self: AccessInterface, community: CommunityDto, events: 
   communityService: community_service.Service,
   messageService: message_service.Service,
   gifService: gif_service.Service,
-  mailserversService: mailservers_service.Service) {.base.} =
+  mailserversService: mailservers_service.Service,
+  setActive: bool = false,) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method communityEdited*(self: AccessInterface, community: CommunityDto) {.base.} =

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -560,6 +560,7 @@ method communityJoined*[T](
   messageService: message_service.Service,
   gifService: gif_service.Service,
   mailserversService: mailservers_service.Service,
+  setActive: bool = false,
 ) =
   var firstCommunityJoined = false
   if (self.channelGroupModules.len == 1): # First one is personal chat section
@@ -588,7 +589,9 @@ method communityJoined*[T](
       self.view.model().getItemIndex(singletonInstance.userProfile.getPubKey()) + 1)
   else:
     self.view.model().addItem(communitySectionItem)
-  self.setActiveSection(communitySectionItem)
+
+  if setActive:
+    self.setActiveSection(communitySectionItem)
 
 method communityLeft*[T](self: Module[T], communityId: string) =
   if(not self.channelGroupModules.contains(communityId)):

--- a/src/app_service/service/community/service.nim
+++ b/src/app_service/service/community/service.nim
@@ -24,6 +24,7 @@ type
   CommunityArgs* = ref object of Args
     community*: CommunityDto
     error*: string
+    fromUserAction*: bool
 
   CommunitiesArgs* = ref object of Args
     communities*: seq[CommunityDto]
@@ -199,7 +200,7 @@ QtObject:
     if(not self.joinedCommunities.hasKey(community.id)):
       if (community.joined and community.isMember):
         self.joinedCommunities[community.id] = community
-        self.events.emit(SIGNAL_COMMUNITY_JOINED, CommunityArgs(community: community))
+        self.events.emit(SIGNAL_COMMUNITY_JOINED, CommunityArgs(community: community, fromUserAction: false))
       return
 
     let prev_community = self.joinedCommunities[community.id]
@@ -444,7 +445,7 @@ QtObject:
         self.chatService.updateOrAddChat(chatDto)
 
       self.events.emit(SIGNAL_COMMUNITIES_UPDATE, CommunitiesArgs(communities: @[updatedCommunity]))
-      self.events.emit(SIGNAL_COMMUNITY_JOINED, CommunityArgs(community: updatedCommunity))
+      self.events.emit(SIGNAL_COMMUNITY_JOINED, CommunityArgs(community: updatedCommunity, fromUserAction: true))
     except Exception as e:
       error "Error joining the community", msg = e.msg
       result = fmt"Error joining the community: {e.msg}"


### PR DESCRIPTION
Fixes #5454

So this was a bug/feature. We never knew that if you are admin of a community, lose your data, re-import and then receive a new signal for that community, it would come back. It,s pretty cool.

However, if you have the community flag off in Advanced settings, it would appear randomly and remove the setting cog button.

Now we make sure the Communities are enabled before showing it.