### PR TITLE
chore: add safeguards when checking for community data in response

### DIFF
--- a/src/app/modules/shared_models/active_section.nim
+++ b/src/app/modules/shared_models/active_section.nim
@@ -17,13 +17,11 @@ QtObject:
 
   proc membersChanged*(self: ActiveSection) {.signal.}
   proc pendingRequestsToJoinChanged*(self: ActiveSection) {.signal.}
-  proc historyArchiveSupportEnabledChanged*(self: ActiveSection) {.signal.}
 
   proc setActiveSectionData*(self: ActiveSection, item: SectionItem) =
     self.item = item
     self.membersChanged()
     self.pendingRequestsToJoinChanged()
-    self.historyArchiveSupportEnabledChanged()
 
   proc getId*(self: ActiveSection): string {.slot.} =
     return self.item.id

--- a/src/app_service/service/community/service.nim
+++ b/src/app_service/service/community/service.nim
@@ -424,6 +424,14 @@ QtObject:
         error "error: ", procName="joinCommunity", errDesription = "result is nil"
         return
 
+      if not response.result.hasKey("communities") or response.result["communities"].kind != JArray or response.result["communities"].len == 0:
+        error "error: ", procName="joinCommunity", errDesription = "no 'communities' key in response"
+        return
+
+      if not response.result.hasKey("communitiesSettings") or response.result["communitiesSettings"].kind != JArray or response.result["communitiesSettings"].len == 0:
+        error "error: ", procName="joinCommunity", errDesription = "no 'communitiesSettings' key in response"
+        return
+        
       var updatedCommunity = response.result["communities"][0].toCommunityDto()
       let communitySettings = response.result["communitiesSettings"][0].toCommunitySettingsDto()
 


### PR DESCRIPTION
Also remove unnecessary signals

Those changes were supposed to go into a PR that was already merged.
