### PR TITLE
fix(ChatContentView): make replying to messages work again

### DIFF
--- a/ui/app/AppLayouts/Chat/views/ChatContentView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatContentView.qml
@@ -372,6 +372,13 @@ ColumnLayout {
             Global.changeAppSectionBySectionType(Constants.appSection.chat)
             root.rootStore.chatCommunitySectionModule.createOneToOneChat("", chatId, ensName)
         }
+        onShowReplyArea: {
+            let obj = messageStore.getMessageByIdAsJson(messageId)
+            if (!obj) {
+                return
+            }
+            chatInput.showReplyArea(messageId, obj.senderDisplayName, obj.messageText, obj.senderIcon, obj.contentType, obj.messageImage, obj.sticker)
+        }
     }
 
     ColumnLayout {


### PR DESCRIPTION
There was a bug that no handler was attached to the `onShowReply()`
signal, which is necessary to hydrate the chat input with reply data.

Fixes #5497

