### PR TITLE
fix: don't save the node config twice when switching fleets

### DIFF
--- a/src/app/modules/main/profile_section/advanced/controller.nim
+++ b/src/app/modules/main/profile_section/advanced/controller.nim
@@ -57,15 +57,6 @@ proc changeFleetTo*(self: Controller, fleet: string) =
     error "an error occurred, we couldn't set fleet"
     return
 
-  var wakuVersion = WAKU_VERSION_1
-  if (fleet == $Fleet.WakuV2Prod or fleet == $Fleet.WakuV2Test or fleet == $Fleet.StatusTest or fleet == $Fleet.StatusProd):
-    wakuVersion = WAKU_VERSION_2
-
-  if (not self.nodeConfigurationService.setWakuVersion(wakuVersion)):
-    # in the future we may do a call from here to show a popup about this error
-    error "an error occurred, we couldn't set waku version for the fleet"
-    return
-
   self.delegate.onFleetSet()
 
 proc getBloomLevel*(self: Controller): string =


### PR DESCRIPTION
The node config state wasnt being updated when switching fleets, and we were saving  the config twice: first when saving the fleet and then, when determining if the fleet is for waku v1 or 2. 
With this change, the node config is saved only once, when the fleet is switched