### PR TITLE
fix(@desktop/wallet): Can't add an address to saved addresses

### DIFF
--- a/ui/app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml
+++ b/ui/app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml
@@ -88,6 +88,7 @@ StatusModal {
                 accounts: RootStore.accounts
                 contactsStore: root.contactsStore
                 label: qsTr("Address")
+                input.placeholderText: qsTr("Enter ENS Name or Ethereum Address")
                 labelFont.pixelSize: 15
                 labelFont.weight: Font.Normal
                 input.implicitHeight: 56
@@ -97,6 +98,7 @@ StatusModal {
                     root.address = selectedRecipient.address
                 }
                 readOnly: root.edit
+                wrongInputValidationError: qsTr("Please enter a valid ENS name OR Ethereum Address")
             }
         }
     }

--- a/ui/imports/shared/controls/AddressInput.qml
+++ b/ui/imports/shared/controls/AddressInput.qml
@@ -21,6 +21,7 @@ Item {
     property bool isResolvedAddress: false
     property int parentWidth
     property bool addContactEnabled: true
+    property alias wrongInputValidationError: contactFieldAndList.wrongInputValidationError
 
     height: contactFieldAndList.chatKey.height
 

--- a/ui/imports/shared/controls/ContactsListAndSearch.qml
+++ b/ui/imports/shared/controls/ContactsListAndSearch.qml
@@ -38,6 +38,7 @@ Item {
     property var pubKeys: ([])
     property bool hideCommunityMembers: false
     property bool addContactEnabled: true
+    property string wrongInputValidationError: qsTr("Enter a valid chat key or ENS username");
 
 
     property var resolveENS: Backpressure.debounce(root, 500, function (ensName) {
@@ -49,7 +50,7 @@ Item {
 
     function validate() {
         if (!Utils.isChatKey(chatKey.text) && !Utils.isValidETHNamePrefix(chatKey.text)) {
-            root.validationError = qsTr("Enter a valid chat key or ENS username");
+            root.validationError = wrongInputValidationError
             pubKey = ""
             ensUsername = "";
         } else if (RootStore.userProfileInst.pubKey === chatKey.text) {
@@ -223,11 +224,11 @@ Item {
         width: searchResultsWidth > 0 ? searchResultsWidth : parent.width
         addContactEnabled: root.addContactEnabled
         onResultClicked: {
+            chatKey.hasValidSearchResult = false
+            userClicked(pubKey, isAddedContact, username, searchResults.address)
             if (!validate()) {
                 return
             }
-            chatKey.hasValidSearchResult = false
-            userClicked(pubKey, isAddedContact, username, searchResults.address)
         }
         onAddToContactsButtonClicked: {
             root.contactsStore.addContact(pubKey)

--- a/ui/imports/shared/controls/RecipientSelector.qml
+++ b/ui/imports/shared/controls/RecipientSelector.qml
@@ -28,6 +28,7 @@ Item {
     height: inpAddress.height + txtLabel.height
     //% "Invalid ethereum address"
     readonly property string addressValidationError: qsTrId("invalid-ethereum-address")
+    property alias wrongInputValidationError: inpAddress.wrongInputValidationError
     property bool isValid: false
     property bool isSelectorVisible: true
     property bool addContactEnabled: true

--- a/ui/imports/utils/Utils.qml
+++ b/ui/imports/utils/Utils.qml
@@ -16,7 +16,7 @@ QtObject {
 
     function isChatKey(value) {
         return (startsWith0x(value) && isHex(value) && value.length === 132) || 
-               /^z[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]{48}$/.test(inputValue)
+               /^z[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]{48}$/.test(value)
     }
 
     function isValidETHNamePrefix(value) {


### PR DESCRIPTION
fixes #5534

### What does the PR do

Public key should not be allowed as a input when saving addresses. 
Placeholder text updated with correct message.
Updated to show correct error message in case anything else except for a wallet address or a ENS Name is entered.

### Affected areas

Wallet

### Screenshot of functionality

https://user-images.githubusercontent.com/60327365/163158292-84fabc71-ce09-40d6-b5e4-6cf81d5b2c9d.mov


