### PR TITLE
feat(@desktop/wallet): greying out already imported/derived addresses  in address list and also choosing next available as default one

### DIFF
--- a/src/app/modules/main/wallet_section/accounts/derived_address_item.nim
+++ b/src/app/modules/main/wallet_section/accounts/derived_address_item.nim
@@ -5,21 +5,25 @@ type
     address: string
     path: string
     hasActivity: bool
+    alreadyCreated: bool
 
 proc initDerivedAddressItem*(
   address: string,
   path: string,
-  hasActivity: bool
+  hasActivity: bool,
+  alreadyCreated: bool
 ): DerivedAddressItem =
   result.address = address
   result.path = path
   result.hasActivity = hasActivity
+  result.alreadyCreated = alreadyCreated
 
 proc `$`*(self: DerivedAddressItem): string =
   result = fmt"""DerivedAddressItem(
     address: {self.address},
     path: {self.path},
     hasActivity: {self.hasActivity}
+    alreadyCreated: {self.alreadyCreated}
     ]"""
 
 proc getAddress*(self: DerivedAddressItem): string =
@@ -30,4 +34,8 @@ proc getPath*(self: DerivedAddressItem): string =
 
 proc getHasActivity*(self: DerivedAddressItem): bool =
   return self.hasActivity
+
+proc getAlreadyCreated*(self: DerivedAddressItem): bool =
+  return self.alreadyCreated
+
 

--- a/src/app/modules/main/wallet_section/accounts/derived_address_model.nim
+++ b/src/app/modules/main/wallet_section/accounts/derived_address_model.nim
@@ -7,6 +7,7 @@ type
     Address = UserRole + 1,
     Path,
     HasActivity,
+    AlreadyCreated,
 
 QtObject:
   type
@@ -45,6 +46,7 @@ QtObject:
       ModelRole.Address.int: "address",
       ModelRole.Path.int: "path",
       ModelRole.HasActivity.int: "hasActivity",
+      ModelRole.AlreadyCreated.int: "alreadyCreated"
     }.toTable
 
   method data(self: DerivedAddressModel, index: QModelIndex, role: int): QVariant =
@@ -64,6 +66,8 @@ QtObject:
       result = newQVariant(item.getPath())
     of ModelRole.HasActivity:
       result = newQVariant(item.getHasActivity())
+    of ModelRole.AlreadyCreated:
+      result = newQVariant(item.getAlreadyCreated())
 
   proc setItems*(self: DerivedAddressModel, items: seq[DerivedAddressItem]) =
     self.beginResetModel()
@@ -90,5 +94,18 @@ QtObject:
       return
     let item = self.derivedWalletAddresses[index]
     result = item.getHasActivity()
+
+  proc getDerivedAddressAlreadyCreatedAtIndex*(self: DerivedAddressModel, index: int): bool =
+    if (index < 0 or index > self.getCount()):
+      return
+    let item = self.derivedWalletAddresses[index]
+    result = item.getAlreadyCreated()
+
+  proc getNextSelectableDerivedAddressIndex*(self: DerivedAddressModel): int =
+    for i in 0 ..< self.derivedWalletAddresses.len:
+      if(not self.derivedWalletAddresses[i].getAlreadyCreated()):
+        return i
+    return -1
+
 
 

--- a/src/app/modules/main/wallet_section/accounts/view.nim
+++ b/src/app/modules/main/wallet_section/accounts/view.nim
@@ -188,7 +188,7 @@ QtObject:
     var items: seq[DerivedAddressItem] = @[]
     let (result, error) = self.delegate.getDerivedAddressList(password, derivedfrom, path, pageSize, pageNumber)
     for item in result:
-      items.add(initDerivedAddressItem(item.address, item.path, item.hasActivity))
+      items.add(initDerivedAddressItem(item.address, item.path, item.hasActivity, item.alreadyCreated))
     self.derivedAddresses.setItems(items)
     self.derivedAddressesChanged()
     return error
@@ -197,7 +197,7 @@ QtObject:
     var items: seq[DerivedAddressItem] = @[]
     let (result, error) = self.delegate.getDerivedAddressListForMnemonic(mnemonic, path, pageSize, pageNumber)
     for item in result:
-      items.add(initDerivedAddressItem(item.address, item.path, item.hasActivity))
+      items.add(initDerivedAddressItem(item.address, item.path, item.hasActivity, item.alreadyCreated))
     self.derivedAddresses.setItems(items)
     self.derivedAddressesChanged()
     return error
@@ -215,4 +215,10 @@ QtObject:
 
   proc getDerivedAddressHasActivityAtIndex*(self: View, index: int): bool {.slot.} =
     return self.derivedAddresses.getDerivedAddressHasActivityAtIndex(index)
+
+  proc getDerivedAddressAlreadyCreatedAtIndex*(self: View, index: int): bool {.slot.} =
+    return self.derivedAddresses.getDerivedAddressAlreadyCreatedAtIndex(index)
+
+  proc getNextSelectableDerivedAddressIndex*(self: View): int {.slot.} =
+    return self.derivedAddresses.getNextSelectableDerivedAddressIndex()
 

--- a/src/app_service/service/wallet_account/derived_address.nim
+++ b/src/app_service/service/wallet_account/derived_address.nim
@@ -6,9 +6,11 @@ type DerivedAddressDto* = object
   address*: string
   path*: string
   hasActivity*: bool
+  alreadyCreated*: bool
 
 proc toDerivedAddressDto*(jsonObj: JsonNode): DerivedAddressDto =
   result = DerivedAddressDto()
   discard jsonObj.getProp("address", result.address)
   discard jsonObj.getProp("path", result.path)
   discard jsonObj.getProp("hasActivity", result.hasActivity)
+  discard jsonObj.getProp("alreadyCreated", result.alreadyCreated)

--- a/ui/app/AppLayouts/Wallet/panels/DerivedAddressesPanel.qml
+++ b/ui/app/AppLayouts/Wallet/panels/DerivedAddressesPanel.qml
@@ -17,6 +17,7 @@ Item {
     property string pathSubFix: ""
     function reset() {
         RootStore.resetDerivedAddressModel()
+        _internal.nextSelectableAddressIndex = 0
         selectedDerivedAddress.pathSubFix = 0
         selectedDerivedAddress.title = "---"
         selectedDerivedAddress.subTitle = qsTr("No activity")
@@ -28,6 +29,17 @@ Item {
         property int noOfPages: Math.ceil(RootStore.derivedAddressesList.count/pageSize)
         property int lastPageSize: RootStore.derivedAddressesList.count - ((noOfPages -1) * pageSize)
         property bool isLastPage: stackLayout.currentIndex == (noOfPages - 1)
+        property int nextSelectableAddressIndex: RootStore.getNextSelectableDerivedAddressIndex()
+
+        onNextSelectableAddressIndexChanged: {
+            stackLayout.currentIndex = nextSelectableAddressIndex/_internal.pageSize
+            if(nextSelectableAddressIndex >= 0 && nextSelectableAddressIndex < RootStore.derivedAddressesList.count) {
+                selectedDerivedAddress.title = RootStore.getDerivedAddressData(nextSelectableAddressIndex)
+                selectedDerivedAddress.subTitle = RootStore.getDerivedAddressHasActivityData(nextSelectableAddressIndex) ? qsTr("Has Activity"): qsTr("No Activity")
+                selectedDerivedAddress.enabled = !RootStore.getDerivedAddressAlreadyCreatedData(nextSelectableAddressIndex)
+                selectedDerivedAddress.pathSubFix = nextSelectableAddressIndex
+            }
+        }
 
         // dimensions
         property int popupWidth: 359
@@ -39,6 +51,8 @@ Item {
         onModelReset: {
             _internal.pageSize = 0
             _internal.pageSize = 6
+            _internal.nextSelectableAddressIndex = -1
+            _internal.nextSelectableAddressIndex = RootStore.getNextSelectableDerivedAddressIndex()
         }
     }
 
@@ -109,6 +123,7 @@ Item {
                                     statusListItemTitle.anchors.right: undefined
                                     title: RootStore.getDerivedAddressData(actualIndex)
                                     subTitle: RootStore.getDerivedAddressHasActivityData(actualIndex) ? qsTr("Has Activity"): qsTr("No Activity")
+                                    enabled: !RootStore.getDerivedAddressAlreadyCreatedData(actualIndex)
                                     components: [
                                         StatusBaseText {
                                             text: element.actualIndex
@@ -121,14 +136,6 @@ Item {
                                         selectedDerivedAddress.subTitle = subTitle
                                         selectedDerivedAddress.pathSubFix = actualIndex
                                         derivedAddressPopup.close()
-                                    }
-                                    Component.onCompleted: {
-                                        if(index === 0) {
-                                            selectedDerivedAddress.title = title
-                                            selectedDerivedAddress.subTitle = subTitle
-                                            selectedDerivedAddress.pathSubFix = actualIndex
-                                            stackLayout.currentIndex = 0
-                                        }
                                     }
                                 }
                             }

--- a/ui/app/AppLayouts/Wallet/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Wallet/stores/RootStore.qml
@@ -192,6 +192,10 @@ QtObject {
         return walletSectionAccounts.getDerivedAddressHasActivityAtIndex(index)
     }
 
+    function getDerivedAddressAlreadyCreatedData(index) {
+        return walletSectionAccounts.getDerivedAddressAlreadyCreatedAtIndex(index)
+    }
+
     function getDerivedAddressListForMnemonic(mnemonic, path, pageSize , pageNumber) {
         return walletSectionAccounts.getDerivedAddressListForMnemonic(mnemonic, path, pageSize , pageNumber)
     }
@@ -202,5 +206,9 @@ QtObject {
 
     function vaildateMnemonic(mnemonic) {
         return onboardingModule.validateMnemonic(mnemonic)
+    }
+
+    function getNextSelectableDerivedAddressIndex() {
+        return walletSectionAccounts.getNextSelectableDerivedAddressIndex()
     }
 }


### PR DESCRIPTION
feat(@desktop/wallet): greying out already imported/derived addresses  in address list and also choosing next available as default one

fixes #5539

### What does the PR do

Greys out derived addresses that have already been used by user and selects the next available one by default

### Affected areas

Wallet

### Screenshot of functionality

https://user-images.githubusercontent.com/60327365/163185930-d92fa7e8-f9c0-401b-b1df-84072bd8265f.mov


