### PR TITLE
ci: remove caching of dependencies

### DIFF
--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -53,14 +53,8 @@ pipeline {
       steps {
         /* trigger fetching of git submodules */
         sh 'make check-pkg-target-linux'
-        /* avoid re-compiling Nim by using cache */
-        cache(maxCacheSize: 250, caches: [[
-          $class: 'ArbitraryFileCache',
-          includes: '**/*',
-          path: 'vendor/nimbus-build-system/vendor/Nim/bin'
-        ]]) {
-          sh 'make deps'
-        }
+        /* TODO: Re-add caching of Nim compiler. */
+        sh 'make deps'
       }
     }
 

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -50,21 +50,15 @@ pipeline {
       steps { 
         /* trigger fetching of git submodules */
         sh 'make check-pkg-target-macos'
-        /* avoid re-compiling Nim by using cache */
-        cache(maxCacheSize: 250, caches: [[
-          $class: 'ArbitraryFileCache',
-          includes: '**/*',
-          path: 'vendor/nimbus-build-system/vendor/Nim/bin'
-        ]]) {
-          withCredentials([
-            usernamePassword( /* For fetching HomeBrew bottles. */
-              credentialsId: "status-im-auto-pkgs",
-              usernameVariable: 'GITHUB_USER',
-              passwordVariable: 'GITHUB_TOKEN'
-            )
-          ]) {
-            sh 'make deps'
-          }
+        /* TODO: Re-add caching of Nim compiler. */
+        withCredentials([
+          usernamePassword( /* For fetching HomeBrew bottles. */
+            credentialsId: "status-im-auto-pkgs",
+            usernameVariable: 'GITHUB_USER',
+            passwordVariable: 'GITHUB_TOKEN'
+          )
+        ]) {
+          sh 'make deps'
         }
       }
     }

--- a/ci/Jenkinsfile.windows
+++ b/ci/Jenkinsfile.windows
@@ -47,14 +47,8 @@ pipeline {
       steps {
         /* trigger fetching of git submodules */
         sh 'make check-pkg-target-windows'
-        /* avoid re-compiling Nim by using cache */
-        cache(maxCacheSize: 250, caches: [[
-          $class: 'ArbitraryFileCache',
-          includes: '**/*',
-          path: 'vendor/nimbus-build-system/vendor/Nim/bin'
-        ]]) {
-          sh 'make deps'
-        }
+        /* TODO: Re-add caching of Nim compiler. */
+        sh 'make deps'
       }
     }
 


### PR DESCRIPTION
Upgrade of Jenkins to `2.343` has introduced a security fix that breaks caching plugin when it's configured to store cache on Master host: https://issues.jenkins.io/browse/JENKINS-67173

Sine the [Caching plugin](https://plugins.jenkins.io/jobcacher/) hasn't been upgraded in 5 years the only good temporary workaround is just drop caching of dependencies like Nim compiler entirely.

In the future we can try some other caching methods.

Related: https://github.com/status-im/nimbus-eth2/pull/3594