### PR TITLE
Fix 1-1 mentions not updating nickname + rearrange events

### DIFF
--- a/src/app/modules/main/chat_section/chat_content/users/io_interface.nim
+++ b/src/app/modules/main/chat_section/chat_content/users/io_interface.nim
@@ -19,7 +19,7 @@ method isLoaded*(self: AccessInterface): bool {.base.} =
 method getModuleAsVariant*(self: AccessInterface): QVariant {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method newMessagesLoaded*(self: AccessInterface, messages: seq[MessageDto]) {.base.} =
+method onNewMessagesLoaded*(self: AccessInterface, messages: seq[MessageDto]) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method contactNicknameChanged*(self: AccessInterface, publicKey: string) {.base.} =

--- a/src/app/modules/main/chat_section/chat_content/users/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/users/module.nim
@@ -62,11 +62,7 @@ method viewDidLoad*(self: Module) =
 method getModuleAsVariant*(self: Module): QVariant =
   return self.viewVariant
 
-method newMessagesLoaded*(self: Module, messages: seq[MessageDto]) =
-  let chat = self.controller.getChat()
-  if not chat.isPublicChat():
-    return
-
+method onNewMessagesLoaded*(self: Module, messages: seq[MessageDto]) =
   for m in messages:
     if(self.view.model().isContactWithIdAdded(m.`from`)):
       continue

--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -115,10 +115,9 @@ proc buildChatUI(self: Module, events: EventEmitter,
     var chatImage = ""
     var colorHash: ColorHashDto = @[]
     var colorId: int = 0
-    var isUsersListAvailable = true
+    let isUsersListAvailable = (c.chatType != ChatType.OneToOne and c.chatType != ChatType.Public)
     var blocked = false
     if(c.chatType == ChatType.OneToOne):
-      isUsersListAvailable = false
       let contactDetails = self.controller.getContactDetails(c.id)
       chatName = contactDetails.displayName
       chatImage = contactDetails.icon

--- a/src/app_service/service/chat/dto/chat.nim
+++ b/src/app_service/service/chat/dto/chat.nim
@@ -259,3 +259,6 @@ proc toChatDto*(jsonObj: JsonNode, communityId: string): ChatDto =
 
 proc isPublicChat*(chatDto: ChatDto): bool =
   return chatDto.chatType == ChatType.Public
+
+proc isOneToOneChat*(chatDto: ChatDto): bool =
+  return chatDto.chatType == ChatType.OneToOne


### PR DESCRIPTION
Fixes #5462

The problem was that the event to update the nickname in the mentions was blocked by the `isUsersListAvailable` condition. What I did is I rearranged the events behind better conditions. 

The user status (online, offline, etc) and member adds and  removed are only needed when `isUsersListAvailable`.

The events about messages are only needed for public chats, because they use the messages to build the member list.

Finally, the events about contact changed, nickname changed and image changed are needed for every type of chat. That's how the 1-1 bug is fixed.

Finally, I made it so that `isUsersListAvailable` is set to `false` for public chats as well, since we no longer show it in public chats.