### PR TITLE
fix(Chat): Remove extra button to clear text in gif search

### DIFF
--- a/ui/imports/shared/status/StatusGifPopup.qml
+++ b/ui/imports/shared/status/StatusGifPopup.qml
@@ -114,22 +114,6 @@ Popup {
                     Qt.callLater(searchGif, searchBox.text);
                 }
             }
-
-            StatusFlatRoundButton {
-                id: clearBtn
-                implicitWidth: 14
-                implicitHeight: 14
-                anchors.right: searchBox.right
-                anchors.rightMargin: Style.current.padding
-                anchors.verticalCenter: searchBox.verticalCenter
-                icon.name: "clear"
-                visible: searchBox.text !== ""
-                icon.width: 14
-                icon.height: 14
-                type: StatusFlatRoundButton.Type.Tertiary
-                color: "transparent"
-                onClicked: toggleCategory(previousCategory)
-            }
         }
 
         StyledText {


### PR DESCRIPTION
### What does the PR do

Removes extra clear button in the StatusGifPopup because similar button is already existing in the SearchBox

### Affected areas

Chat

### Screenshot of functionality

![image](https://user-images.githubusercontent.com/2522130/166265088-c1863942-c6f0-4403-ae08-e6e0c521562a.png)

