### PR TITLE
fix(Chat): Deactivate channel when create chat is opened

### DIFF
--- a/ui/app/AppLayouts/Chat/views/ContactsColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ContactsColumnView.qml
@@ -172,8 +172,8 @@ Item {
 
         StatusChatList {
             id: channelList
-
             model: root.chatSectionModule.model
+            highlightItem: !root.store.openCreateChat
             onChatItemSelected: {
                 root.chatSectionModule.setActiveItem(id, "")
             }


### PR DESCRIPTION
Closes #5627

### What does the PR do
Fixed channel stays highlighted when create chat view is opened

### Affected areas
chat

### Screenshot of functionality
https://user-images.githubusercontent.com/31625338/166701494-5a7ebbc2-22c4-4632-9f1a-7d0ef7a7ac0f.mov


