### PR TITLE
feature(Onboarding/Profile Image): use image cropper to set the initial profile picture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,9 @@ _deps
 # QtCreator shadow builds
 build-*/
 
+# CMake builds
+build/
+
 # https://github.com/github/gitignore/blob/master/C%2B%2B.gitignore
 # Prerequisites
 *.d

--- a/.gitignore
+++ b/.gitignore
@@ -51,7 +51,8 @@ CTestTestfile.cmake
 _deps
 .cache/
 
-
+# QtCreator shadow builds
+build-*/
 
 # https://github.com/github/gitignore/blob/master/C%2B%2B.gitignore
 # Prerequisites

--- a/ui/app/AppLayouts/Onboarding/popups/UploadProfilePicModal.qml
+++ b/ui/app/AppLayouts/Onboarding/popups/UploadProfilePicModal.qml
@@ -19,64 +19,38 @@ StatusModal {
     height: 510
     header.title: qsTr("Upload profile picture")
 
-    readonly property alias aX: cropImageModal.aX
-    readonly property alias aY: cropImageModal.aY
-    readonly property alias bX: cropImageModal.bX
-    readonly property alias bY: cropImageModal.bY
-
-    property string selectedImage
     property string currentProfileImg: ""
     property string croppedImg: ""
-    property string uploadError
 
     signal setProfileImage(string image)
 
-    onClosed: {
-        popup.selectedImage = ""
-        popup.croppedImg = ""
-    }
+    // Internals
+    //
+    onOpened: imageEditor.userSelectedImage = false
+    onClosed: popup.croppedImg = ""
 
     contentItem: Item {
         anchors.fill: parent
-        StatusRoundedImage {
-            id: profilePic
+
+        EditCroppedImagePanel {
+            id: imageEditor
+
             width: 160
             height: 160
-            anchors.verticalCenter: parent.verticalCenter
-            anchors.horizontalCenter: parent.horizontalCenter
-            image.source: popup.croppedImg || popup.currentProfileImg
-            showLoadingIndicator: true
-            border.width: 1
-            border.color: Style.current.border
+            anchors.centerIn: parent
 
-            MouseArea {
-                anchors.fill: parent
-                cursorShape: Qt.PointingHandCursor
-                hoverEnabled: true
-                onClicked: imageDialog.open()
-            }
-        }
+            imageFileDialogTitle: qsTr("Choose an image for profile picture")
+            title: qsTr("Profile picture")
+            acceptButtonText: qsTr("Make this my profile picture")
 
-        StyledText {
-            visible: !!uploadError
-            text: uploadError
-            anchors.left: parent.left
-            anchors.right: parent.right
-            anchors.top: profilePic.bottom
-            horizontalAlignment: Text.AlignHCenter
-            font.pixelSize: 13
-            wrapMode: Text.WordWrap
-            anchors.topMargin: 13
-            font.weight: Font.Thin
-            color: Style.current.danger
-        }
+            aspectRatio: 1
 
-        ImageCropperModal {
-            id: cropImageModal
-            ratio: "1:1"
-            selectedImage: popup.selectedImage
-            onCropFinished: {
-                popup.croppedImg = OnboardingStore.generateImage(popup.selectedImage, aX, aY, bX, bY);
+            dataImage: popup.currentProfileImg
+
+            NoImageUploadedPanel {
+                anchors.centerIn: parent
+
+                visible: imageEditor.nothingToShow
             }
         }
     }
@@ -94,29 +68,17 @@ StatusModal {
         },
         StatusButton {
             id: uploadBtn
-            text: popup.croppedImg? qsTr("Done") : qsTr("Upload")
+            text: imageEditor.userSelectedImage ? qsTr("Upload") : qsTr("Done")
             onClicked: {
-                if (popup.croppedImg) {
-                    OnboardingStore.setImageProps(popup.selectedImage, aX, aY, bX, bY)
+                if (imageEditor.userSelectedImage) {
+                    popup.croppedImg = OnboardingStore.generateImage(imageEditor.source,
+                                             imageEditor.cropRect.x.toFixed(),
+                                             imageEditor.cropRect.y.toFixed(),
+                                             (imageEditor.cropRect.x + imageEditor.cropRect.width).toFixed(),
+                                             (imageEditor.cropRect.y + imageEditor.cropRect.height).toFixed())
                     popup.setProfileImage(popup.croppedImg)
-                    close();
-                } else {
-                    imageDialog.open();
                 }
-            }
-            FileDialog {
-                id: imageDialog
-                title: qsTrId("please-choose-an-image")
-                folder: shortcuts.pictures
-                nameFilters: [
-                    qsTrId("image-files----jpg---jpeg---png-")
-                ]
-                onAccepted: {
-                    if(imageDialog.fileUrls.length > 0) {
-                        popup.selectedImage = imageDialog.fileUrls[0];
-                        cropImageModal.open()
-                    }
-                }
+                close();
             }
         }
     ]

--- a/ui/imports/shared/panels/EditCroppedImagePanel.qml
+++ b/ui/imports/shared/panels/EditCroppedImagePanel.qml
@@ -205,9 +205,9 @@ Item {
                         enabled: bannerCropper.sourceSize.width > 0 && bannerCropper.sourceSize.height > 0
 
                         onClicked: {
-                            bannerCropperModal.close()
-                            bannerPreview.setCropRect(bannerCropper.cropRect)
                             bannerPreview.source = bannerCropper.source
+                            bannerPreview.setCropRect(bannerCropper.cropRect)
+                            bannerCropperModal.close()
                             root.userSelectedImage = true
                         }
                     }

--- a/ui/imports/shared/panels/EditCroppedImagePanel.qml
+++ b/ui/imports/shared/panels/EditCroppedImagePanel.qml
@@ -1,0 +1,218 @@
+import QtQuick 2.14
+import QtQuick.Layouts 1.14
+import QtQuick.Controls 2.14
+import QtQuick.Dialogs 1.3
+
+import utils 1.0
+import shared.panels 1.0
+import shared.popups 1.0
+
+import StatusQ.Core 0.1
+import StatusQ.Core.Theme 0.1
+import StatusQ.Layout 0.1
+import StatusQ.Components 0.1
+import StatusQ.Controls 0.1
+import StatusQ.Controls.Validators 0.1
+import StatusQ.Popups 0.1
+
+Item {
+    id: root
+
+    property alias source: bannerPreview.source
+    property alias cropRect: bannerPreview.cropRect
+    /*required*/ property alias aspectRatio: bannerPreview.aspectRatio
+
+    property bool roundedImage: true
+
+    /*required*/ property string imageFileDialogTitle: ""
+    /*required*/ property string title: ""
+    /*required*/ property string acceptButtonText: ""
+
+    property string dataImage: ""
+
+    property bool userSelectedImage: false
+    readonly property bool nothingToShow: state === d.noImageState
+
+    implicitWidth: mainLayout.implicitWidth
+    implicitHeight: mainLayout.implicitHeight
+
+
+    states: [
+        State {
+            name: d.dataImageState
+            when: root.dataImage.length > 0 && !userSelectedImage
+        },
+        State {
+            name: d.noImageState
+            when: root.dataImage.length === 0 && !userSelectedImage
+        },
+        State {
+            name: d.imageSelectedState
+            when: userSelectedImage
+        }
+    ]
+
+    QtObject {
+        id: d
+
+        readonly property string dataImageState: "dataImage"
+        readonly property string noImageState: "noImage"
+        readonly property string imageSelectedState: "imageSelected"
+    }
+
+    ColumnLayout {
+        id: mainLayout
+
+        anchors.fill: parent
+
+        Item {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+
+            visible: !bannerEditor.visible
+
+            StatusRoundedImage {
+                id: profilePic
+
+                anchors.fill: parent
+
+                visible: root.state === d.dataImageState
+
+                image.source: root.dataImage
+                showLoadingIndicator: true
+                border.width: 1
+                border.color: Style.current.border
+            }
+
+            StatusImageCropPanel
+            {
+                id: bannerPreview
+
+                anchors.fill: parent
+
+                visible: root.state === d.imageSelectedState
+
+                interactive: false
+                wallColor: Theme.palette.statusAppLayout.backgroundColor
+                wallTransparency: 1
+                margins: 0
+
+                windowStyle: roundedImage ? StatusImageCrop.WindowStyle.Rounded : StatusImageCrop.WindowStyle.Rectangular
+            }
+
+            StatusRoundButton {
+                id: editButton
+
+                icon.name: "edit"
+
+                // bottom-right corner
+                x: root.userSelectedImage
+                    ? bannerPreview.cropWindow.x + bannerPreview.cropWindow.width - (roundedImage ? editButton.width : editButton.width/2 + bannerPreview.radius)
+                    : parent.width - editButton.width
+                y: (root.userSelectedImage
+                    ? bannerPreview.cropWindow.y + bannerPreview.cropWindow.height - (roundedImage ? editButton.height + Style.current.smallPadding : editButton.height/2)
+                    : parent.width - editButton.height) - Style.current.smallPadding
+
+                type: StatusRoundButton.Type.Secondary
+
+                onClicked: bannerFileDialog.open()
+            }
+        }
+
+        Rectangle {
+            id: bannerEditor
+
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+
+            visible: root.state === d.noImageState
+
+            radius: roundedImage ? Math.max(width, height)/2 : bannerPreview.radius
+            color: Style.current.inputBackground
+
+            StatusRoundButton {
+                id: addButton
+
+                icon.name: "add"
+
+                // top-right corner
+                x: parent.width - (roundedImage ? editButton.width : editButton.width/2 + bannerEditor.radius)
+                y: roundedImage ? addButton.height/2 : -addButton.height/2 + bannerEditor.radius
+
+                type: StatusRoundButton.Type.Secondary
+
+                onClicked: bannerFileDialog.open()
+                z: bannerEditor.z + 1
+            }
+
+            FileDialog {
+                id: bannerFileDialog
+
+                title: root.imageFileDialogTitle
+                folder: root.userSelectedImage ? bannerCropper.source.substr(0, bannerCropper.source.lastIndexOf("/")) : shortcuts.pictures
+                nameFilters: [qsTr("Image files (*.jpg *.jpeg, *.jfif, *.png *.tiff *.heif)")]
+                onAccepted: {
+                    if(bannerFileDialog.fileUrls.length > 0) {
+                        bannerCropper.source = bannerFileDialog.fileUrls[0]
+                        bannerCropperModal.open()
+                    }
+                }
+                onRejected: {
+                    if(root.userSelectedImage)
+                        bannerCropperModal.open()
+                }
+            }
+
+            StatusModal {
+                id: bannerCropperModal
+
+                header.title: root.title
+
+                anchors.centerIn: Overlay.overlay
+
+                Item {
+                    implicitWidth: 480
+                    implicitHeight: 350
+
+                    anchors.fill: parent
+
+                    ColumnLayout {
+                        anchors.fill: parent
+
+                        StatusImageCropPanel {
+                            id: bannerCropper
+
+                            Layout.fillWidth: true
+                            Layout.fillHeight: true
+                            Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
+                            Layout.leftMargin: Style.current.padding * 2
+                            Layout.topMargin: Style.current.bigPadding
+                            Layout.rightMargin: Layout.leftMargin
+                            Layout.bottomMargin: Layout.topMargin
+
+                            windowStyle: bannerPreview.windowStyle
+                            aspectRatio: bannerPreview.aspectRatio
+
+                            enableCheckers: true
+                        }
+                    }
+                }
+
+                rightButtons: [
+                    StatusButton {
+                        text: root.acceptButtonText
+
+                        enabled: bannerCropper.sourceSize.width > 0 && bannerCropper.sourceSize.height > 0
+
+                        onClicked: {
+                            bannerCropperModal.close()
+                            bannerPreview.setCropRect(bannerCropper.cropRect)
+                            bannerPreview.source = bannerCropper.source
+                            root.userSelectedImage = true
+                        }
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/ui/imports/shared/panels/NoImageUploadedPanel.qml
+++ b/ui/imports/shared/panels/NoImageUploadedPanel.qml
@@ -21,11 +21,14 @@ Item {
     ColumnLayout {
         id: mainLayout
 
-        SVGImage {
+        Image {
             id: imageImg
             source: Style.svg("images_icon")
             width: 20
             height: 18
+            sourceSize.width: width || undefined
+            sourceSize.height: height || undefined
+            fillMode: Image.PreserveAspectFit
             Layout.alignment: Qt.AlignVCenter | Qt.AlignHCenter
         }
 

--- a/ui/imports/shared/panels/NoImageUploadedPanel.qml
+++ b/ui/imports/shared/panels/NoImageUploadedPanel.qml
@@ -1,0 +1,51 @@
+import QtQuick 2.14
+import QtQuick.Layouts 1.14
+
+import utils 1.0
+import shared.panels 1.0
+
+import StatusQ.Core 0.1
+import StatusQ.Core.Theme 0.1
+
+/*!
+  /brief Image icon and ulopad text hints for banner and logo
+ */
+Item {
+    id: root
+
+    implicitWidth: mainLayout.implicitWidth
+    implicitHeight: mainLayout.implicitHeight
+
+    property bool showARHint: false
+
+    ColumnLayout {
+        id: mainLayout
+
+        SVGImage {
+            id: imageImg
+            source: Style.svg("images_icon")
+            width: 20
+            height: 18
+            Layout.alignment: Qt.AlignVCenter | Qt.AlignHCenter
+        }
+
+        StatusBaseText {
+            id: uploadText
+            text: qsTr("Upload")
+            Layout.alignment: Qt.AlignVCenter | Qt.AlignHCenter
+            Layout.topMargin: 5
+            font.pixelSize: 15
+            color: Theme.palette.baseColor1
+        }
+
+        StatusBaseText {
+            id: optimalARText
+            text: qsTr("Wide aspect ratio is optimal")
+            Layout.alignment: Qt.AlignVCenter | Qt.AlignHCenter
+            visible: root.showARHint
+            Layout.topMargin: 5
+            font.pixelSize: 15
+            color: Theme.palette.baseColor1
+        }
+    }
+}

--- a/ui/imports/shared/panels/qmldir
+++ b/ui/imports/shared/panels/qmldir
@@ -16,3 +16,5 @@ SplitViewHandle 1.0 SplitViewHandle.qml
 StyledText 1.0 StyledText.qml
 SVGImage 1.0 SVGImage.qml
 TextWithLabel 1.0 TextWithLabel.qml
+EditCroppedImagePanel 1.0 EditCroppedImagePanel.qml
+NoImageUploadedPanel 1.0 NoImageUploadedPanel.qml


### PR DESCRIPTION
Depends on https://github.com/status-im/StatusQ/pull/615

Based on:
- [Profile picture designs](https://www.figma.com/file/17fc13UBFvInrLgNUKJJg5/Kuba%E2%8E%9CDesktop?node-id=1197%3A314660)
- [Community logo new design](https://www.figma.com/file/17fc13UBFvInrLgNUKJJg5/Kuba%E2%8E%9CDesktop?node-id=4662%3A406927)
- [x] Don't allow cropping outside image (transparent borders) https://github.com/status-im/StatusQ/pull/666
- [x] Fix slider drag area: https://github.com/status-im/StatusQ/pull/665

### Affected areas

Onboarding, profile image

### Screenshot of functionality

<img width="690" alt="image" src="https://user-images.githubusercontent.com/47554641/166977453-20a44dee-f545-4d88-8640-decf9592e78b.png">

![image](https://user-images.githubusercontent.com/47554641/166804345-7f99a480-6d62-46c8-b8af-6a6f9aa09dbd.png)

<img width="690" alt="image" src="https://user-images.githubusercontent.com/47554641/166977617-7c221446-5366-463e-8628-b427130c1df1.png">

![image](https://user-images.githubusercontent.com/47554641/166804463-c56f3ec4-9dcf-4fe8-95c4-0c95deffecca.png)
