### PR TITLE
fix(Chat): renamed members section to "Members" instead of "Last seen"

### DIFF
--- a/ui/app/AppLayouts/Chat/views/ChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatView.qml
@@ -102,11 +102,7 @@ StatusAppThreePanelLayout {
         id: userListComponent
         UserListPanel {
             rootStore: root.rootStore
-            label: localAccountSensitiveSettings.communitiesEnabled &&
-                root.rootStore.chatCommunitySectionModule.isCommunity() ?
-                //% "Members"
-                qsTrId("members-label") :
-                qsTr("Last seen")
+            label: qsTrId("members-label")
             messageContextMenu: quickActionMessageOptionsMenu
             usersModule: {
                 let chatContentModule = root.rootStore.currentChatContentModule()


### PR DESCRIPTION
Closes #5645

### What does the PR do
Renamed members section to "Members" instead of "Last seen"

### Affected areas
Chat member list title
