### PR TITLE
ui: revamp login view to match latest designs

### DIFF
--- a/ui/app/AppLayouts/Onboarding/panels/AccountMenuItemPanel.qml
+++ b/ui/app/AppLayouts/Onboarding/panels/AccountMenuItemPanel.qml
@@ -1,0 +1,69 @@
+import QtQuick 2.13
+import QtQuick.Controls 2.13
+import QtQuick.Dialogs 1.3
+
+import StatusQ.Core 0.1
+import StatusQ.Core.Theme 0.1
+import StatusQ.Components 0.1
+import StatusQ.Popups 0.1
+
+import shared.controls.chat 1.0
+import utils 1.0
+
+MenuItem {
+    id: root
+
+    property string label: ""
+    property string colorId: ""
+    property var colorHash
+    property url image: ""
+    signal clicked()
+
+    width: parent.width
+    height: 64
+    background: Rectangle {
+        color: root.hovered ? Theme.palette.statusSelect.menuItemHoverBackgroundColor : Theme.palette.statusSelect.menuItemBackgroundColor
+    }
+    MouseArea {
+        cursorShape: Qt.PointingHandCursor
+        anchors.fill: root
+        onClicked: {
+            root.clicked()
+        }
+    }
+
+    Loader {
+        id: userImageOrIcon
+        sourceComponent: !!root.image.toString() || !!root.colorId ? userImage : addIcon
+        anchors.leftMargin: Style.current.padding
+        anchors.left: parent.left
+        anchors.verticalCenter: parent.verticalCenter
+    }
+
+    Component {
+        id: addIcon
+        StatusRoundIcon {
+            icon.name: "add"
+        }
+    }
+
+    Component {
+        id: userImage
+        UserImage {
+            name: root.label
+            image: root.image
+            colorId: root.colorId
+            colorHash: root.colorHash
+        }
+    }
+
+    StatusBaseText {
+        text: root.label
+        font.pixelSize: 15
+        anchors.verticalCenter: parent.verticalCenter
+        anchors.left: userImageOrIcon.right
+        anchors.leftMargin: 16
+        color: !!root.colorId ? Theme.palette.directColor1 : Theme.palette.primaryColor1
+    }
+}
+


### PR DESCRIPTION
This includes changing the account selector from being a modal to
a drop down menu, which also includes an option to generate a new
account.

In addition, it adds the status logo plus a dedicated headline.

![Screenshot from 2022-05-06 08-41-52](https://user-images.githubusercontent.com/445106/167081174-575a666b-e99c-48db-b1b1-86021c4683de.png)
![Screenshot from 2022-05-06 08-41-59](https://user-images.githubusercontent.com/445106/167081182-1a0ffc52-32c6-44fa-bd88-d18ca0d59e4a.png)


![Screenshot from 2022-05-06 08-41-01](https://user-images.githubusercontent.com/445106/167081194-614d694d-eacf-413a-ba84-da2311698e34.png)
![Screenshot from 2022-05-06 08-41-07](https://user-images.githubusercontent.com/445106/167081205-b850eb9c-41bc-45f9-a34f-3958b5cfedef.png)

Closes: #5623 #5624
