### PR TITLE
fix(Onboarding/Password): Add/correct hard keys behaviour in Password related onboarding screens

### DIFF
--- a/ui/app/AppLayouts/Onboarding/views/CreatePasswordView.qml
+++ b/ui/app/AppLayouts/Onboarding/views/CreatePasswordView.qml
@@ -20,6 +20,12 @@ OnboardingBasePage {
         id: d
         readonly property int zBehind: 1
         readonly property int zFront: 100
+
+        function submit() {
+            root.newPassword = view.newPswText
+            root.confirmationPassword = view.confirmationPswText
+            root.exit()
+        }
     }
 
     Column {
@@ -31,6 +37,7 @@ OnboardingBasePage {
             onboarding: true
             newPswText: root.newPassword
             confirmationPswText: root.confirmationPassword
+            onReturnPressed: { if(view.ready) d.submit() }
         }
         StatusButton {
             id: submitBtn
@@ -38,11 +45,7 @@ OnboardingBasePage {
             anchors.horizontalCenter: parent.horizontalCenter
             text: qsTr("Create password")
             enabled: view.ready
-            onClicked: {
-                root.newPassword = view.newPswText
-                root.confirmationPassword = view.confirmationPswText
-                root.exit()
-            }
+            onClicked: { d.submit() }
         }
     }
 

--- a/ui/app/AppLayouts/Profile/popups/ChangePasswordModal.qml
+++ b/ui/app/AppLayouts/Profile/popups/ChangePasswordModal.qml
@@ -33,6 +33,17 @@ StatusModal {
         submitBtn.loading = false
     }
 
+    QtObject {
+        id: d
+
+        function submit() {
+            submitBtn.loading = true
+            // ChangePassword operation blocks the UI so loading = true; will never have any affect until changePassword/createPassword is done.
+            // Getting around it with a small pause (timer) in order to get the desired behavior
+            pause.start()
+        }
+    }
+
     Connections {
         target: root.privacyStore.privacyModule
         onPasswordChanged: onChangePasswordResponse(success, errorMsg)
@@ -52,6 +63,7 @@ StatusModal {
         titleVisible: false
         introText: qsTr("Change password used to unlock Status on this device & sign transactions.")
         createNewPsw: false
+        onReturnPressed: if(submitBtn.enabled) d.submit()
     }
 
     rightButtons: [
@@ -69,12 +81,7 @@ StatusModal {
                 }
             }
 
-            onClicked: {
-                submitBtn.loading = true;
-                // ChangePassword operation blocks the UI so loading = true; will never have any affect until changePassword/createPassword is done.
-                // Getting around it with a small pause (timer) in order to get the desired behavior
-                pause.start();
-            }
+            onClicked: { d.submit() }
         }
     ]
 

--- a/ui/imports/shared/views/PasswordView.qml
+++ b/ui/imports/shared/views/PasswordView.qml
@@ -32,6 +32,8 @@ Column {
     property alias confirmationPswText: confirmPswInput.text
     property alias errorMsgText: errorTxt.text
 
+    signal returnPressed()
+
     function forceNewPswInputFocus() { newPswInput.forceActiveFocus(Qt.MouseFocusReason) }
 
     function reset() {
@@ -176,6 +178,7 @@ Column {
         textField.validator: d.validator
         keepHeight: true
         textField.rightPadding: showHideCurrentIcon.width + showHideCurrentIcon.anchors.rightMargin + Style.current.padding / 2
+        Keys.onReturnPressed: { root.returnPressed() }
 
         StatusFlatRoundButton {
             id: showHideCurrentIcon
@@ -220,6 +223,7 @@ Column {
                 // Update strength indicator:
                 strengthInditactor.strength = d.convertStrength(RootStore.getPasswordStrengthScore(newPswInput.text, root.onboarding))
             }
+            Keys.onReturnPressed: { root.returnPressed() }
 
             StatusFlatRoundButton {
                 id: showHideNewIcon
@@ -322,6 +326,7 @@ Column {
                 root.checkPasswordMatches(false)
             }
         }
+        Keys.onReturnPressed: { root.returnPressed() }
 
         StatusFlatRoundButton {
             id: showHideConfirmIcon


### PR DESCRIPTION
Fixes #5626

### What does the PR do
- Pressing enter in forms should submit the form if view is ready to submit.
- Pressing tab in inputs should jump to next one.

### Affected areas
`ConfirmPasswordView`, `CreatePasswordView` and `ChangePasswordModal`.