### PR TITLE
fix(CreateNewChat): Increased name tag limit to 20

### DIFF
--- a/ui/app/AppLayouts/Chat/views/CreateChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/CreateChatView.qml
@@ -103,6 +103,7 @@ Page {
             Layout.alignment: Qt.AlignVCenter | Qt.AlignLeft
             Layout.leftMargin: 17
             maxHeight: root.height
+            nameCountLimit: 20
             listLabel: qsTr("Contacts")
             toLabelText: qsTr("To: ")
             warningText: qsTr("USER LIMIT REACHED")


### PR DESCRIPTION
Closes #5643

### What does the PR do
 Increased name tag limit from 5 to 20 in create new 1-1/group chat tag selector

### Affected areas
Create new chat

Depends on: https://github.com/status-im/StatusQ/pull/653
