### PR TITLE
fix(Onboarding/ConfirmationPassword): Remove validation error and enable button only when pw is the expected

### DIFF
--- a/ui/app/AppLayouts/Onboarding/views/ConfirmPasswordView.qml
+++ b/ui/app/AppLayouts/Onboarding/views/ConfirmPasswordView.qml
@@ -110,21 +110,19 @@ OnboardingBasePage {
                     else filler.visible = false
                 }
             }
+        }
 
-            // Just a column filler to keep the component height althought errorTxt.text is ""
-            Item {
-                id: filler
-                width: root.width
-                visible: true
-                height: errorTxt.height
-            }
+        // Just a column filler to fit the design
+        Item {
+            height: Style.current.padding
+            width: parent.width
         }
 
         StatusButton {
             id: submitBtn
             anchors.horizontalCenter: parent.horizontalCenter
             text: qsTr("Finalise Status Password Creation")
-            enabled:!submitBtn.loading && confPswInput.text.length >= 6
+            enabled: !submitBtn.loading && (confPswInput.text === root.password)
 
             property Timer sim: Timer {
                 id: pause
@@ -136,19 +134,7 @@ OnboardingBasePage {
                 }
             }
 
-            function checkPasswordMatches() {
-                if (confPswInput.text !== root.password) {
-                    errorTxt.text = qsTr("Passwords don't match")
-                    return false
-                }
-                return true
-            }
-
             onClicked: {
-                if (!checkPasswordMatches()) {
-                    return
-                }
-
                 if (OnboardingStore.accountCreated) {
                     if (root.password !== root.tmpPass) {
                         OnboardingStore.changePassword(root.tmpPass, root.password);


### PR DESCRIPTION
Fixes #5611

### What does the PR do
Since this screen is just a confirmation one, it has been agreed with designer that it should not display any error message and the only way of enabling the finalize button is if it is exactly the same password than created in the previous screen.

So:
- Removed code related to validation.
- Modified enable button condition (just only when password is exactly the same than the previous introduced one).

### Affected areas
https://user-images.githubusercontent.com/97019400/167431011-1bb0b75f-c61e-43cb-b780-8ceaca733652.mov


