### PR TITLE
fix(Chat): Corrected click behavior in members list

### DIFF
--- a/ui/app/AppLayouts/Chat/controls/UserDelegate.qml
+++ b/ui/app/AppLayouts/Chat/controls/UserDelegate.qml
@@ -111,10 +111,7 @@ Item {
                 wrapper.hovered = false
             }
             onClicked: {
-                if (mouse.button === Qt.LeftButton) {
-                    Global.openProfilePopup(wrapper.publicKey);
-                }
-                 else if (mouse.button === Qt.RightButton && !!messageContextMenu) {
+                if (mouse.button === Qt.RightButton) {
                     // Set parent, X & Y positions for the messageContextMenu
                     messageContextMenu.parent = rectangle
                     messageContextMenu.setXPosition = function() { return 0}
@@ -126,6 +123,8 @@ Item {
                     messageContextMenu.selectedUserDisplayName = wrapper.name
                     messageContextMenu.selectedUserIcon = wrapper.iconToShow
                     messageContextMenu.popup()
+                } else if (mouse.button === Qt.LeftButton && !!messageContextMenu) {
+                    Global.openProfilePopup(wrapper.publicKey);
                 }
             }
         }


### PR DESCRIPTION
Closes #5637

### What does the PR do
Corrected click behavior in members list
- Left click should launch profile popup
- Right click should open context menu

### Affected areas
Chat Members list

### Screenshot of functionality
https://user-images.githubusercontent.com/31625338/167629458-6a26a61d-4bec-4b78-aca0-b73a9b506611.mov


