### PR TITLE
feat(CommunitySettings): add checkbox to allow members to pin messages

### DIFF
--- a/src/app/modules/main/chat_section/chat_content/messages/io_interface.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/io_interface.nim
@@ -88,6 +88,9 @@ method getChatColor*(self: AccessInterface): string {.base.} =
 method amIChatAdmin*(self: AccessInterface): bool {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method pinMessageAllowedForMembers*(self: AccessInterface): bool {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method getNumberOfPinnedMessages*(self: AccessInterface): int {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/chat_section/chat_content/messages/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/module.nim
@@ -380,6 +380,12 @@ method amIChatAdmin*(self: Module): bool =
     let communityDto = self.controller.getCommunityDetails()
     return communityDto.admin
 
+method pinMessageAllowedForMembers*(self: Module): bool =
+  if(self.controller.belongsToCommunity()):
+    let communityDto = self.controller.getCommunityDetails()
+    return communityDto.adminSettings.pinMessageAllMembersEnabled
+  return false
+
 method getNumberOfPinnedMessages*(self: Module): int =
   return self.controller.getNumOfPinnedMessages()
 

--- a/src/app/modules/main/chat_section/chat_content/messages/view.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/view.nim
@@ -71,6 +71,9 @@ QtObject:
   proc amIChatAdmin*(self: View): bool {.slot.} =
     return self.delegate.amIChatAdmin()
 
+  proc pinMessageAllowedForMembers*(self: View): bool {.slot.} =
+    return self.delegate.pinMessageAllowedForMembers()
+
   proc getNumberOfPinnedMessages*(self: View): int {.slot.} =
     return self.delegate.getNumberOfPinnedMessages()
 

--- a/src/app/modules/main/chat_section/controller.nim
+++ b/src/app/modules/main/chat_section/controller.nim
@@ -380,7 +380,8 @@ proc editCommunity*(
     color: string,
     imageUrl: string,
     aX: int, aY: int, bX: int, bY: int,
-    historyArchiveSupportEnabled: bool) =
+    historyArchiveSupportEnabled: bool,
+    pinMessageAllMembersEnabled: bool) =
   self.communityService.editCommunity(
     self.sectionId,
     name,
@@ -389,7 +390,8 @@ proc editCommunity*(
     color,
     imageUrl,
     aX, aY, bX, bY,
-    historyArchiveSupportEnabled)
+    historyArchiveSupportEnabled,
+    pinMessageAllMembersEnabled)
 
 proc exportCommunity*(self: Controller): string =
   self.communityService.exportCommunity(self.sectionId)

--- a/src/app/modules/main/chat_section/io_interface.nim
+++ b/src/app/modules/main/chat_section/io_interface.nim
@@ -243,7 +243,7 @@ method removeUserFromCommunity*(self: AccessInterface, pubKey: string) {.base.} 
 method banUserFromCommunity*(self: AccessInterface, pubKey: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method editCommunity*(self: AccessInterface, name: string, description: string, access: int, color: string, imagePath: string, aX: int, aY: int, bX: int, bY: int, historyArchiveSupportEnabled: bool) {.base.} =
+method editCommunity*(self: AccessInterface, name: string, description: string, access: int, color: string, imagePath: string, aX: int, aY: int, bX: int, bY: int, historyArchiveSupportEnabled: bool, pinMessageAllMembersEnabled: bool) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method exportCommunity*(self: AccessInterface): string {.base.} =

--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -721,8 +721,9 @@ method banUserFromCommunity*(self: Module, pubKey: string) =
 method editCommunity*(self: Module, name: string, description: string,
                         access: int, color: string,
                         imagePath: string,
-                        aX: int, aY: int, bX: int, bY: int, historyArchiveSupportEnabled: bool) =
-  self.controller.editCommunity(name, description, access, color, imagePath, aX, aY, bX, bY, historyArchiveSupportEnabled)
+                        aX: int, aY: int, bX: int, bY: int, historyArchiveSupportEnabled: bool,
+                        pinMessageAllMembersEnabled: bool) =
+  self.controller.editCommunity(name, description, access, color, imagePath, aX, aY, bX, bY, historyArchiveSupportEnabled, pinMessageAllMembersEnabled)
 
 method exportCommunity*(self: Module): string =
   self.controller.exportCommunity()

--- a/src/app/modules/main/chat_section/view.nim
+++ b/src/app/modules/main/chat_section/view.nim
@@ -244,8 +244,8 @@ QtObject:
   proc banUserFromCommunity*(self: View, pubKey: string) {.slot.} =
     self.delegate.banUserFromCommunity(pubKey)
 
-  proc editCommunity*(self: View, name: string, description: string, access: int, color: string, imagePath: string, aX: int, aY: int, bX: int, bY: int, historyArchiveSupportEnabled: bool) {.slot.} =
-    self.delegate.editCommunity(name, description, access, color, imagePath, aX, aY, bX, bY, historyArchiveSupportEnabled)
+  proc editCommunity*(self: View, name: string, description: string, access: int, color: string, imagePath: string, aX: int, aY: int, bX: int, bY: int, historyArchiveSupportEnabled: bool, pinMessageAllMembersEnabled: bool) {.slot.} =
+    self.delegate.editCommunity(name, description, access, color, imagePath, aX, aY, bX, bY, historyArchiveSupportEnabled, pinMessageAllMembersEnabled)
 
   proc exportCommunity*(self: View): string {.slot.} =
     self.delegate.exportCommunity()

--- a/src/app/modules/main/communities/controller.nim
+++ b/src/app/modules/main/communities/controller.nim
@@ -70,7 +70,8 @@ proc createCommunity*(
     color: string,
     imageUrl: string,
     aX: int, aY: int, bX: int, bY: int,
-    historyArchiveSupportEnabled: bool) =
+    historyArchiveSupportEnabled: bool,
+    pinMessageAllMembersEnabled: bool) =
   self.communityService.createCommunity(
     name,
     description,
@@ -78,7 +79,8 @@ proc createCommunity*(
     color,
     imageUrl,
     aX, aY, bX, bY,
-    historyArchiveSupportEnabled)
+    historyArchiveSupportEnabled,
+    pinMessageAllMembersEnabled)
 
 proc reorderCommunityChat*(
     self: Controller,

--- a/src/app/modules/main/communities/io_interface.nim
+++ b/src/app/modules/main/communities/io_interface.nim
@@ -22,7 +22,7 @@ method getCommunityItem*(self: AccessInterface, community: CommunityDto): Sectio
 method joinCommunity*(self: AccessInterface, communityId: string): string {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method createCommunity*(self: AccessInterface, name: string, description: string, access: int, color: string, imagePath: string, aX: int, aY: int, bX: int, bY: int, historyArchiveSupportEnabled: bool) {.base.} =
+method createCommunity*(self: AccessInterface, name: string, description: string, access: int, color: string, imagePath: string, aX: int, aY: int, bX: int, bY: int, historyArchiveSupportEnabled: bool, pinMessageAllMembersEnabled: bool) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method deleteCommunityCategory*(self: AccessInterface, communityId: string, categoryId: string) {.base.} =

--- a/src/app/modules/main/communities/module.nim
+++ b/src/app/modules/main/communities/module.nim
@@ -149,8 +149,9 @@ method createCommunity*(self: Module, name: string, description: string,
                         access: int, color: string,
                         imagePath: string,
                         aX: int, aY: int, bX: int, bY: int,
-                        historyArchiveSupportEnabled: bool) =
-  self.controller.createCommunity(name, description, access, color, imagePath, aX, aY, bX, bY, historyArchiveSupportEnabled)
+                        historyArchiveSupportEnabled: bool,
+                        pinMessageAllMembersEnabled: bool) =
+  self.controller.createCommunity(name, description, access, color, imagePath, aX, aY, bX, bY, historyArchiveSupportEnabled, pinMessageAllMembersEnabled)
 
 method deleteCommunityCategory*(self: Module, communityId: string, categoryId: string) =
   self.controller.deleteCommunityCategory(communityId, categoryId)

--- a/src/app/modules/main/communities/view.nim
+++ b/src/app/modules/main/communities/view.nim
@@ -69,8 +69,9 @@ QtObject:
                         access: int, color: string,
                         imagePath: string,
                         aX: int, aY: int, bX: int, bY: int,
-                        historyArchiveSupportEnabled: bool) {.slot.} =
-    self.delegate.createCommunity(name, description, access, color, imagePath, aX, aY, bX, bY, historyArchiveSupportEnabled)
+                        historyArchiveSupportEnabled: bool,
+                        pinMessageAllMembersEnabled: bool) {.slot.} =
+    self.delegate.createCommunity(name, description, access, color, imagePath, aX, aY, bX, bY, historyArchiveSupportEnabled, pinMessageAllMembersEnabled)
 
   proc deleteCommunityCategory*(self: View, communityId: string, categoryId: string): string {.slot.} =
     self.delegate.deleteCommunityCategory(communityId, categoryId)

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -227,7 +227,8 @@ proc createChannelGroupItem[T](self: Module[T], c: ChannelGroupDto): SectionItem
       x.state,
       x.our
     )) else: @[],
-    communityDetails.settings.historyArchiveSupportEnabled
+    communityDetails.settings.historyArchiveSupportEnabled,
+    communityDetails.adminSettings.pinMessageAllMembersEnabled
   )
 
 

--- a/src/app/modules/shared_models/active_section.nim
+++ b/src/app/modules/shared_models/active_section.nim
@@ -131,6 +131,12 @@ QtObject:
   QtProperty[bool] historyArchiveSupportEnabled:
     read = historyArchiveSupportEnabled
 
+  proc pinMessageAllMembersEnabled(self: ActiveSection): bool {.slot.} =
+    return self.item.pinMessageAllMembersEnabled
+
+  QtProperty[bool] pinMessageAllMembersEnabled:
+    read = pinMessageAllMembersEnabled
+
   proc members(self: ActiveSection): QVariant {.slot.} =
     if (self.item.id == ""):
       # FIXME (Jo) I don't know why but the Item is sometimes empty and doing anything here crashes the app

--- a/src/app/modules/shared_models/section_item.nim
+++ b/src/app/modules/shared_models/section_item.nim
@@ -35,6 +35,7 @@ type
     membersModel: user_model.Model
     pendingRequestsToJoinModel: PendingRequestModel
     historyArchiveSupportEnabled: bool
+    pinMessageAllMembersEnabled: bool
 
 proc initItem*(
     id: string,
@@ -58,7 +59,8 @@ proc initItem*(
     ensOnly = false,
     members: seq[user_item.Item] = @[],
     pendingRequestsToJoin: seq[PendingRequestItem] = @[],
-    historyArchiveSupportEnabled = false
+    historyArchiveSupportEnabled = false,
+    pinMessageAllMembersEnabled = false
     ): SectionItem =
   result.id = id
   result.sectionType = sectionType
@@ -84,6 +86,7 @@ proc initItem*(
   result.pendingRequestsToJoinModel = newPendingRequestModel()
   result.pendingRequestsToJoinModel.setItems(pendingRequestsToJoin)
   result.historyArchiveSupportEnabled = historyArchiveSupportEnabled
+  result.pinMessageAllMembersEnabled = pinMessageAllMembersEnabled
 
 proc isEmpty*(self: SectionItem): bool =
   return self.id.len == 0
@@ -111,6 +114,7 @@ proc `$`*(self: SectionItem): string =
     ensOnly:{self.ensOnly},
     members:{self.membersModel},
     historyArchiveSupportEnabled:{self.historyArchiveSupportEnabled},
+    pinMessageAllMembersEnabled:{self.pinMessageAllMembersEnabled},
     ]"""
 
 proc id*(self: SectionItem): string {.inline.} =
@@ -203,3 +207,6 @@ proc pendingRequestsToJoin*(self: SectionItem): PendingRequestModel {.inline.} =
 
 proc historyArchiveSupportEnabled*(self: SectionItem): bool {.inline.} =
   self.historyArchiveSupportEnabled
+
+proc pinMessageAllMembersEnabled*(self: SectionItem): bool {.inline.} =
+  self.pinMessageAllMembersEnabled

--- a/src/app/modules/shared_models/section_model.nim
+++ b/src/app/modules/shared_models/section_model.nim
@@ -28,6 +28,7 @@ type
     MembersModel
     PendingRequestsToJoinModel
     HistoryArchiveSupportEnabled
+    PinMessageAllMembersEnabled
 
 QtObject:
   type
@@ -87,6 +88,7 @@ QtObject:
       ModelRole.MembersModel.int:"members",
       ModelRole.PendingRequestsToJoinModel.int:"pendingRequestsToJoin",
       ModelRole.HistoryArchiveSupportEnabled.int:"historyArchiveSupportEnabled",
+      ModelRole.PinMessageAllMembersEnabled.int:"pinMessageAllMembersEnabled",
     }.toTable
 
   method data(self: SectionModel, index: QModelIndex, role: int): QVariant =
@@ -144,6 +146,8 @@ QtObject:
       result = newQVariant(item.pendingRequestsToJoin)
     of ModelRole.HistoryArchiveSupportEnabled:
       result = newQVariant(item.historyArchiveSupportEnabled)
+    of ModelRole.PinMessageAllMembersEnabled:
+      result = newQVariant(item.pinMessageAllMembersEnabled)
 
   proc isItemExist(self: SectionModel, id: string): bool =
     for it in self.items:
@@ -216,7 +220,8 @@ QtObject:
       ModelRole.Joined.int,
       ModelRole.MembersModel.int,
       ModelRole.PendingRequestsToJoinModel.int,
-      ModelRole.HistoryArchiveSupportEnabled.int
+      ModelRole.HistoryArchiveSupportEnabled.int,
+      ModelRole.PinMessageAllMembersEnabled.int
       ])
 
   proc getItemById*(self: SectionModel, id: string): SectionItem =

--- a/src/app_service/service/chat/dto/chat.nim
+++ b/src/app_service/service/chat/dto/chat.nim
@@ -88,6 +88,7 @@ type ChannelGroupDto* = object
   color*: string
   muted*: bool
   historyArchiveSupportEnabled*: bool
+  pinMessageAllMembersEnabled*: bool
 
 proc `$`*(self: ChatDto): string =
   result = fmt"""ChatDto(

--- a/src/app_service/service/community/dto/community.nim
+++ b/src/app_service/service/community/dto/community.nim
@@ -39,6 +39,9 @@ type CommunitySettingsDto* = object
   id*: string
   historyArchiveSupportEnabled*: bool
 
+type CommunityAdminSettingsDto* = object
+  pinMessageAllMembersEnabled*: bool
+
 type CommunityDto* = object
   id*: string
   admin*: bool
@@ -61,6 +64,11 @@ type CommunityDto* = object
   muted*: bool
   pendingRequestsToJoin*: seq[CommunityMembershipRequestDto]
   settings*: CommunitySettingsDto
+  adminSettings*: CommunityAdminSettingsDto
+
+proc toCommunityAdminSettingsDto*(jsonObj: JsonNode): CommunityAdminSettingsDto =
+  result = CommunityAdminSettingsDto()
+  discard jsonObj.getProp("pinMessageAllMembersEnabled", result.pinMessageAllMembersEnabled)
 
 proc toCommunityDto*(jsonObj: JsonNode): CommunityDto =
   result = CommunityDto()
@@ -89,6 +97,10 @@ proc toCommunityDto*(jsonObj: JsonNode): CommunityDto =
   var permissionObj: JsonNode
   if(jsonObj.getProp("permissions", permissionObj)):
     result.permissions = toPermission(permissionObj)
+
+  var adminSettingsObj: JsonNode
+  if(jsonObj.getProp("adminSettings", adminSettingsObj)):
+    result.adminSettings = toCommunityAdminSettingsDto(adminSettingsObj)
 
   var membersObj: JsonNode
   if(jsonObj.getProp("members", membersObj) and membersObj.kind == JObject):

--- a/src/app_service/service/community/service.nim
+++ b/src/app_service/service/community/service.nim
@@ -532,7 +532,8 @@ QtObject:
       color: string,
       imageUrl: string,
       aX: int, aY: int, bX: int, bY: int,
-      historyArchiveSupportEnabled: bool) =
+      historyArchiveSupportEnabled: bool,
+      pinMessageAllMembersEnabled: bool) =
     try:
       var image = singletonInstance.utils.formatImagePath(imageUrl)
       let response = status_go.createCommunity(
@@ -542,7 +543,8 @@ QtObject:
         color,
         image,
         aX, aY, bX, bY,
-        historyArchiveSupportEnabled)
+        historyArchiveSupportEnabled,
+        pinMessageAllMembersEnabled)
 
       if response.error != nil:
         let error = Json.decode($response.error, RpcError)
@@ -570,7 +572,8 @@ QtObject:
       color: string,
       imageUrl: string,
       aX: int, aY: int, bX: int, bY: int,
-      historyArchiveSupportEnabled: bool) =
+      historyArchiveSupportEnabled: bool,
+      pinMessageAllMembersEnabled: bool) =
     try:
       var image = singletonInstance.utils.formatImagePath(imageUrl)
       let response = status_go.editCommunity(
@@ -581,7 +584,8 @@ QtObject:
         color,
         image,
         aX, aY, bX, bY,
-        historyArchiveSupportEnabled)
+        historyArchiveSupportEnabled,
+        pinMessageAllMembersEnabled)
 
       if response.error != nil:
         let error = Json.decode($response.error, RpcError)

--- a/src/backend/communities.nim
+++ b/src/backend/communities.nim
@@ -36,7 +36,8 @@ proc createCommunity*(
     color: string,
     imageUrl: string,
     aX: int, aY: int, bX: int, bY: int,
-    historyArchiveSupportEnabled: bool
+    historyArchiveSupportEnabled: bool,
+    pinMessageAllMembersEnabled: bool
     ): RpcResponse[JsonNode] {.raises: [Exception].} =
   result = callPrivateRPC("createCommunity".prefix, %*[{
       # TODO this will need to be renamed membership (small m)
@@ -51,6 +52,7 @@ proc createCommunity*(
       "imageBx": bX,
       "imageBy": bY,
       "historyArchiveSupportEnabled": historyArchiveSupportEnabled,
+      "pinMessageAllMembersEnabled": pinMessageAllMembersEnabled
     }])
 
 proc editCommunity*(
@@ -64,7 +66,8 @@ proc editCommunity*(
     aY: int,
     bX: int,
     bY: int,
-    historyArchiveSupportEnabled: bool
+    historyArchiveSupportEnabled: bool,
+    pinMessageAllMembersEnabled: bool
     ): RpcResponse[JsonNode] {.raises: [Exception].} =
   result = callPrivateRPC("editCommunity".prefix, %*[{
     # TODO this will need to be renamed membership (small m)
@@ -79,7 +82,8 @@ proc editCommunity*(
     "imageAy": aY,
     "imageBx": bX,
     "imageBy": bY,
-    "historyArchiveSupportEnabled": historyArchiveSupportEnabled
+    "historyArchiveSupportEnabled": historyArchiveSupportEnabled,
+    "pinMessageAllMembersEnabled": pinMessageAllMembersEnabled
   }])
 
 proc createCommunityChannel*(

--- a/ui/app/AppLayouts/Chat/popups/community/CreateCommunityPopup.qml
+++ b/ui/app/AppLayouts/Chat/popups/community/CreateCommunityPopup.qml
@@ -65,6 +65,7 @@ StatusModal {
         property alias communityImage: addImageButton
         property alias imageCropperModal: imageCropperModal
         property alias historyArchiveSupportToggle: historyArchiveSupportToggle
+        property alias pinMessagesAllMembersCheckbox: pinMessagesAllMembersCheckbox
 
         contentHeight: content.height
         bottomPadding: 8
@@ -329,6 +330,20 @@ StatusModal {
                     }
                 ]
             }
+
+            StatusListItem {
+                anchors.horizontalCenter: parent.horizontalCenter
+                title: qsTr("Any member can pin a message")
+                sensor.onClicked: {
+                    pinMessagesAllMembersCheckbox.checked = !pinMessagesAllMembersCheckbox.checked
+                }
+                components: [
+                    StatusCheckBox {
+                        id: pinMessagesAllMembersCheckbox
+                        checked: isEdit ? community.pinMessageAllMembersEnabled : false
+                    }
+               ]
+            }
         }
 
     }
@@ -374,7 +389,8 @@ StatusModal {
                         popup.contentItem.imageCropperModal.aY,
                         popup.contentItem.imageCropperModal.bX,
                         popup.contentItem.imageCropperModal.bY,
-                        popup.contentItem.historyArchiveSupportToggle.checked
+                        popup.contentItem.historyArchiveSupportToggle.checked,
+                        popup.contentItem.pinMessagesAllMembersCheckbox.checked
                   )
                 } else {
                     error = popup.store.createCommunity(
@@ -387,7 +403,8 @@ StatusModal {
                         popup.contentItem.imageCropperModal.aY,
                         popup.contentItem.imageCropperModal.bX,
                         popup.contentItem.imageCropperModal.bY,
-                        popup.contentItem.historyArchiveSupportToggle.checked
+                        popup.contentItem.historyArchiveSupportToggle.checked,
+                        popup.contentItem.pinMessagesAllMembersCheckbox.checked
                     )
                 }
 

--- a/ui/app/AppLayouts/Chat/stores/MessageStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/MessageStore.qml
@@ -100,6 +100,13 @@ QtObject {
         return messageModule.amIChatAdmin()
     }
 
+    function pinMessageAllowedForMembers() {
+        if(!messageModule)
+            return false
+
+        return messageModule.pinMessageAllowedForMembers()
+    }
+
     function getNumberOfPinnedMessages () {
         if(!messageModule)
             return 0

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -230,8 +230,8 @@ QtObject {
     // Not Refactored Yet
     property var activeCommunityChatsModel: "" //chatsModelInst.communities.activeCommunity.chats
 
-    function createCommunity(communityName, communityDescription, checkedMembership, communityColor, communityImage, imageCropperModalaX, imageCropperModalaY, imageCropperModalbX, imageCropperModalbY, historyArchiveSupportEnabled) {
-        communitiesModuleInst.createCommunity(communityName, communityDescription, checkedMembership, communityColor, communityImage, imageCropperModalaX, imageCropperModalaY, imageCropperModalbX, imageCropperModalbY, historyArchiveSupportEnabled);
+    function createCommunity(communityName, communityDescription, checkedMembership, communityColor, communityImage, imageCropperModalaX, imageCropperModalaY, imageCropperModalbX, imageCropperModalbY, historyArchiveSupportEnabled, pinMessagesAllowedForMembers) {
+        communitiesModuleInst.createCommunity(communityName, communityDescription, checkedMembership, communityColor, communityImage, imageCropperModalaX, imageCropperModalaY, imageCropperModalbX, imageCropperModalbY, historyArchiveSupportEnabled, pinMessagesAllowedForMembers);
     }
 
     function importCommunity(communityKey) {

--- a/ui/imports/shared/views/chat/CompactMessageView.qml
+++ b/ui/imports/shared/views/chat/CompactMessageView.qml
@@ -54,7 +54,7 @@ Item {
         case Constants.chatType.publicChat:
             return amISender
         case Constants.chatType.communityChat:
-            return messageStore.amIChatAdmin() || amISender
+            return messageStore.amIChatAdmin() || amISender || messageStore.pinMessageAllowedForMembers()
         case Constants.chatType.profile:
             return false
         default:

--- a/ui/imports/shared/views/chat/MessageContextMenuView.qml
+++ b/ui/imports/shared/views/chat/MessageContextMenuView.qml
@@ -24,6 +24,7 @@ StatusPopupMenu {
 
     property string myPublicKey: ""
     property bool amIChatAdmin: false
+    property bool pinMessageAllowedForMembers: false
     property bool isMyMessage: {
         return root.messageSenderId !== "" && root.messageSenderId == root.myPublicKey
     }
@@ -261,7 +262,7 @@ StatusPopupMenu {
             case Constants.chatType.privateGroupChat:
                 return root.amIChatAdmin
             case Constants.chatType.communityChat:
-                return root.amIChatAdmin
+                return root.amIChatAdmin || root.pinMessageAllowedForMembers
             default:
                 return false
             }

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -171,6 +171,7 @@ Column {
 
         messageContextMenu.myPublicKey = userProfile.pubKey
         messageContextMenu.amIChatAdmin = messageStore.amIChatAdmin()
+        messageContextMenu.pinMessageAllowedForMembers = messageStore.pinMessageAllowedForMembers()
         messageContextMenu.chatType = messageStore.getChatType()
 
         messageContextMenu.messageId = root.messageId


### PR DESCRIPTION
This adds a checkbox to configure whether or not community members are
allowed to pin any message of a community channel, based on the newly
introduced `CommunityAdminSettings` that are introduced in https://github.com/status-im/status-go/pull/2668

Closes #5662
