### PR TITLE
fix(@desktop/onboarding): Improve password validation and showing don't match error

### DIFF
--- a/ui/imports/shared/views/PasswordView.qml
+++ b/ui/imports/shared/views/PasswordView.qml
@@ -48,7 +48,11 @@ Column {
             currentPswInput.forceActiveFocus(Qt.MouseFocusReason)
     }
 
-    function checkPasswordMatches() {
+    function checkPasswordMatches(onlyIfConfirmPasswordHasFocus = true) {
+        if (onlyIfConfirmPasswordHasFocus && !confirmPswInput.textField.focus) {
+            return
+        }
+
         if(newPswInput.text.length >= root.minPswLen) {
             errorTxt.text = ""
             if(confirmPswInput.text !== newPswInput.text) {
@@ -300,10 +304,13 @@ Column {
         onTextChanged: { if(textField.text.length === newPswInput.text.length) root.checkPasswordMatches() }
         textField.onFocusChanged: {
             // When clicking into the confirmation input, validate if new password:
-            if(textField.focus) d.passwordValidation()
-
+            if(textField.focus) {
+                d.passwordValidation()
+            }
             // When leaving the confirmation input because of the button or other input component is focused, check if password matches
-            else root.checkPasswordMatches(true)
+            else {
+                root.checkPasswordMatches(false)
+            }
         }
 
         StatusFlatRoundButton {


### PR DESCRIPTION
Fix #5319

### What does the PR do

Show "Passwords don't match" error message only in 2 cases:
- when there’s the same amount of letters in both inputs (and they don’t match)
- If user un-focuses the second password entry field and passwords don’t match

### Affected areas

Onboarding / creating password
Profile / changing password

### Screenshot of functionality

https://user-images.githubusercontent.com/61889657/167804331-2bb51e9c-c7b6-46d3-b460-00b29e753acd.mov

