### PR TITLE
fix(CommunityService): ensure communitySettings aren't mistakenly

### DIFF
--- a/src/app_service/service/community/service.nim
+++ b/src/app_service/service/community/service.nim
@@ -204,6 +204,13 @@ QtObject:
 
     let prev_community = self.joinedCommunities[community.id]
 
+    # If there's settings without `id` it means the original
+    # signal didn't include actual communitySettings, hence we
+    # assign the settings we already have, otherwise we risk our
+    # settings to be overridden with wrong defaults.
+    if community.settings.id == "":
+      community.settings = prev_community.settings
+
     # category was added
     if(community.categories.len > prev_community.categories.len):
       for category in community.categories:


### PR DESCRIPTION
overwritten

When communities are edited, status-go sends a signal with the community
description, to ensure the network is updated to the latest changes.

However, that community description doesn't include `communitySettings`.
When we then compose the `CommunityDto` object from that signal, it will have
a default certain settings to `false` which might actually be `true`.

The result is that data in memory is incorrect.

To ensure we don't run into this issue, we check whether the attached
settings have an id, if they don't, we know the settings do not
originate from the signal data, meaning we can use the settings we
already have.
