### PR TITLE
fix(profile): set ens name correctly

### DIFF
--- a/src/app/boot/app_controller.nim
+++ b/src/app/boot/app_controller.nim
@@ -369,12 +369,10 @@ proc buildAndRegisterUserProfile(self: AppController) =
     elif(img.imgType == "thumbnail"):
       thumbnail = img.uri
 
-  let meAsContact = self.contactsService.getContactById(pubKey)
-
   singletonInstance.userProfile.setFixedData(loggedInAccount.name, loggedInAccount.keyUid, pubKey)
   singletonInstance.userProfile.setDisplayName(displayName)
   singletonInstance.userProfile.setPreferredName(preferredName)
-  singletonInstance.userProfile.setEnsName(meAsContact.name)
+  singletonInstance.userProfile.setEnsName(firstEnsName)
   singletonInstance.userProfile.setFirstEnsName(firstEnsName)
   singletonInstance.userProfile.setThumbnailImage(thumbnail)
   singletonInstance.userProfile.setLargeImage(large)


### PR DESCRIPTION
Fixes #5574

The problem was that ensName wasn't set correctly in the profile singleton.

The issue about the login screen not showing the ENS name however is not really fixable, since we don't haver access to that data when we have not logged in yet. The accounts DB only gives us the name, which is either the 3 word name or the display name.