### PR TITLE
fix(@desktop/onboarding): Password strength indicator fixes for 10-chars

### DIFF
--- a/ui/imports/shared/views/PasswordView.qml
+++ b/ui/imports/shared/views/PasswordView.qml
@@ -21,7 +21,7 @@ Column {
     property bool titleVisible: true
     property string introText: qsTr("Create a password to unlock Status on this device & sign transactions.")
     property string recoverText: qsTr("You will not be able to recover this password if it is lost.")
-    property string strengthenText: qsTr("Minimum 6 characters. To strengthen your password consider including:")
+    property string strengthenText: qsTr("Minimum %1 characters. To strengthen your password consider including:").arg(minPswLen)
     property bool onboarding: false
 
     readonly property int zBehind: 1
@@ -244,7 +244,7 @@ Column {
             id: strengthInditactor
             width: parent.width
             anchors.horizontalCenter: parent.horizontalCenter
-            value: newPswInput.text.length > root.minPswLen ? root.minPswLen : newPswInput.text.length
+            value: Math.min(root.minPswLen, newPswInput.text.length)
             from: 0
             to: root.minPswLen
             labelVeryWeak: qsTr("Very weak")


### PR DESCRIPTION
Close #5702

### What does the PR do

Update text from 6 to 10 chars
Set minimal non-zero value for progress bar

### Affected areas

Onboarding

### Screenshot of functionality

![pwd_ind-2022-05-13_11 27 06](https://user-images.githubusercontent.com/2522130/168244634-497ae08d-69a3-4d6e-a223-4a8d2bde6bcd.gif)