### PR TITLE
fix(@chat): Fixed blurry emojis

### DIFF
--- a/ui/imports/shared/controls/EmojiHash.qml
+++ b/ui/imports/shared/controls/EmojiHash.qml
@@ -28,8 +28,7 @@ Item {
             SVGImage {
                 width: root.size
                 height: root.size
-
-                source: StatusQUtils.Emoji.parse(modelData).match('src="(.*\\.svg)')[1]
+                source: Style.emoji(StatusQUtils.Emoji.iconId(modelData))
             }
         }
     }

--- a/ui/imports/shared/status/StatusEmojiPopup.qml
+++ b/ui/imports/shared/status/StatusEmojiPopup.qml
@@ -247,7 +247,7 @@ Popup {
                     delegate: SVGImage {
                         width: 22
                         height: 22
-                        source: Style.emoji("72x72/" + modelData)
+                        source: Style.emoji(modelData)
                         MouseArea {
                             cursorShape: Qt.PointingHandCursor
                             anchors.fill: parent
@@ -268,7 +268,7 @@ Popup {
                 anchors.right: parent.right
                 anchors.rightMargin: emojiHeader.headerMargin
                 visible: !skinToneEmoji.expandSkinColorOptions
-                source: Style.emoji("72x72/1f590" + ((localAccountSensitiveSettings.skinColor !== "" && visible) ? ("-" + localAccountSensitiveSettings.skinColor) : ""))
+                source: Style.emoji("1f590" + ((localAccountSensitiveSettings.skinColor !== "" && visible) ? ("-" + localAccountSensitiveSettings.skinColor) : ""))
                 MouseArea {
                     cursorShape: Qt.PointingHandCursor
                     anchors.fill: parent

--- a/ui/imports/shared/status/StatusEmojiSection.qml
+++ b/ui/imports/shared/status/StatusEmojiSection.qml
@@ -92,8 +92,7 @@ Item {
                 SVGImage {
                     width: emojiSection.imageWidth
                     height: emojiSection.imageWidth
-                    //TODO EMOJI SVG?
-                    source: "qrc:/StatusQ/src/assets/twemoji/svg/" + modelData.filename + "?22x22"
+                    source: Style.emoji(modelData.filename)
 
                     MouseArea {
                         cursorShape: Qt.PointingHandCursor

--- a/ui/imports/shared/views/chat/ChatTextView.qml
+++ b/ui/imports/shared/views/chat/ChatTextView.qml
@@ -112,17 +112,16 @@ Item {
         }
 
         text: {
-            if(contentType === Constants.messageContentType.stickerType) return "";
+            if (contentType === Constants.messageContentType.stickerType) return "";
             let msg = Utils.linkifyAndXSS(message);
-            if(isEmoji) {
-                return StatusQUtils.Emoji.parse(msg, StatusQUtils.Emoji.size.middle);
-            } else {
-                if(isEdited){
-                    let index = msg.endsWith("code>") ? msg.length : msg.length - 4
-                    return Utils.getMessageWithStyle(StatusQUtils.Emoji.parse(msg.slice(0, index) + Constants.editLabel + msg.slice(index)), isCurrentUser, hoveredLink)
-                }
-                return Utils.getMessageWithStyle(StatusQUtils.Emoji.parse(msg), isCurrentUser, hoveredLink)
+            if (isEmoji)
+                return StatusQUtils.Emoji.parse(msg, StatusQUtils.Emoji.size.middle, StatusQUtils.Emoji.format.png);
+            if (isEdited) {
+                let index = msg.endsWith("code>") ? msg.length : msg.length - 4
+                return Utils.getMessageWithStyle(StatusQUtils.Emoji.parse(msg.slice(0, index) + Constants.editLabel + msg.slice(index)), isCurrentUser, hoveredLink)
             }
+            return Utils.getMessageWithStyle(StatusQUtils.Emoji.parse(msg), isCurrentUser, hoveredLink)
+        
         }
     }
 

--- a/ui/imports/utils/Style.qml
+++ b/ui/imports/utils/Style.qml
@@ -47,7 +47,7 @@ QtObject {
         return assetPath + "icons/" + name + ".svg";
     }
     function emoji(name) {
-        return "qrc:/StatusQ/src/assets/twemoji/" + name + ".png";
+        return "qrc:/StatusQ/src/assets/twemoji/svg/" + name + ".svg";
     }
     function lottie(name) {
         return assetPath + "lottie/" + name + ".json";


### PR DESCRIPTION
Corresponding StatusQ PR:

- https://github.com/status-im/StatusQ/pull/673

### What does the PR do

Fixes #5259.
Emojis are loaded as SVG everywhere except `ChatMessage` (it used PNG because Qt `TextEdit` doesn't render SVG in good quality)

### Affected areas

Chat

### Screenshot of functionality

<img width="666" alt="image" src="https://user-images.githubusercontent.com/25482501/168313542-0b94748e-7e45-40d9-bf59-d8e75d862fd1.png">