### PR TITLE
fix(@desktop/chat): Show badge and message in activity center for reply elements

### DIFF
--- a/src/app/modules/main/activity_center/controller.nim
+++ b/src/app/modules/main/activity_center/controller.nim
@@ -117,3 +117,9 @@ proc getChannelGroups*(self: Controller): seq[ChannelGroupDto] =
 
 proc getOneToOneChatNameAndImage*(self: Controller, chatId: string): tuple[name: string, image: string] =
   return self.chatService.getOneToOneChatNameAndImage(chatId)
+
+proc getMessageById*(self: Controller, chatId, messageId: string): MessageDto =
+  let (message, _, err) = self.messageService.getDetailsForMessage(chatId, messageId)
+  if(err.len > 0):
+    return MessageDto()
+  return message

--- a/src/app/modules/main/activity_center/item.nim
+++ b/src/app/modules/main/activity_center/item.nim
@@ -13,6 +13,7 @@ type Item* = ref object
   dismissed: bool
   accepted: bool
   messageItem: MessageItem
+  repliedMessageItem: MessageItem
 
 proc initItem*(
   id: string,
@@ -25,7 +26,8 @@ proc initItem*(
   read: bool,
   dismissed: bool,
   accepted: bool,
-  messageItem: MessageItem
+  messageItem: MessageItem,
+  repliedMessageItem: MessageItem
 ): Item =
   result = Item()
   result.id = id
@@ -39,6 +41,7 @@ proc initItem*(
   result.dismissed = dismissed
   result.accepted = accepted
   result.messageItem = messageItem
+  result.repliedMessageItem = repliedMessageItem
 
 proc `$`*(self: Item): string =
   result = fmt"""StickerItem(
@@ -53,6 +56,7 @@ proc `$`*(self: Item): string =
     dismissed: {$self.dismissed},
     accepted: {$self.accepted},
     # messageItem: {$self.messageItem},
+    # repliedMessageItem: {$self.repliedMessageItem},
     ]"""
 
 proc id*(self: Item): string =
@@ -90,3 +94,6 @@ proc accepted*(self: Item): bool =
 
 proc messageItem*(self: Item): MessageItem =
   return self.messageItem
+
+proc repliedMessageItem*(self: Item): MessageItem =
+  return self.repliedMessageItem

--- a/src/app/modules/main/activity_center/model.nim
+++ b/src/app/modules/main/activity_center/model.nim
@@ -14,6 +14,7 @@ type
     Dismissed
     Accepted
     Author
+    RepliedMessage
 
 QtObject:
   type
@@ -80,6 +81,7 @@ QtObject:
       of NotifRoles.Read: result = newQVariant(acitivityNotificationItem.read.bool)
       of NotifRoles.Dismissed: result = newQVariant(acitivityNotificationItem.dismissed.bool)
       of NotifRoles.Accepted: result = newQVariant(acitivityNotificationItem.accepted.bool)
+      of NotifRoles.RepliedMessage: result = newQVariant(acitivityNotificationItem.repliedMessageItem)
 
   proc getNotificationData(self: Model, index: int, data: string): string {.slot.} =
     if index < 0 or index >= self.activityCenterNotifications.len: return ("")
@@ -110,7 +112,8 @@ QtObject:
       NotifRoles.Timestamp.int: "timestamp",
       NotifRoles.Read.int: "read",
       NotifRoles.Dismissed.int: "dismissed",
-      NotifRoles.Accepted.int: "accepted"
+      NotifRoles.Accepted.int: "accepted",
+      NotifRoles.RepliedMessage.int: "repliedMessage"
     }.toTable
 
   proc reduceUnreadCount(self: Model, numberNotifs: int) =

--- a/ui/app/AppLayouts/Chat/controls/activityCenter/ReplyComponent.qml
+++ b/ui/app/AppLayouts/Chat/controls/activityCenter/ReplyComponent.qml
@@ -12,11 +12,11 @@ import StatusQ.Core.Utils 0.1 as StatusQUtils
 Item {
     id: replyComponent
 
-    property int replyMessageIndex: wrapper.replyMessageIndex
+    property int repliedMessageId: wrapper.repliedMessageId
     property string repliedMessageContent: wrapper.repliedMessageContent
 
-    onReplyMessageIndexChanged: {
-        wrapper.visible = replyMessageIndex > -1
+    onRepliedMessageIdChanged: {
+        wrapper.visible = (repliedMessageId.length > 0)
     }
 
     SVGImage {

--- a/ui/app/AppLayouts/Chat/panels/ActivityChannelBadgePanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/ActivityChannelBadgePanel.qml
@@ -20,7 +20,7 @@ Rectangle {
     property string communityName: ""
     property string communityColor: ""
     property string communityThumbnailImage: ""
-    property int replyMessageIndex: -1
+    property string repliedMessageId: ""
     property string repliedMessageContent: ""
     property int notificationType
     property string profileImage: ""
@@ -56,7 +56,7 @@ Rectangle {
         ActivityCenter.ReplyComponent {
             width: childrenRect.width
             height: parent.height
-            replyMessageIndex: wrapper.replyMessageIndex
+            repliedMessageId: wrapper.repliedMessageId
             repliedMessageContent: wrapper.repliedMessageContent
         }
     }

--- a/ui/app/AppLayouts/Chat/views/ActivityCenterMessageComponentView.qml
+++ b/ui/app/AppLayouts/Chat/views/ActivityCenterMessageComponentView.qml
@@ -43,7 +43,7 @@ Item {
 
     function reevaluateItemBadge() {
         let details = root.store.getBadgeDetails(model.sectionId, model.chatId)
-        badge.isCommunity = details.sType == "community"
+        badge.isCommunity = (details.sType === "community")
         badge.name = details.cName
         badge.channelName = details.cName
         badge.communityName = details.sName
@@ -185,6 +185,8 @@ Item {
             visible: model.notificationType !== Constants.activityCenterNotificationTypeOneToOne
             notificationType: model.notificationType
             profileImage: realChatType === Constants.chatType.oneToOne ? Global.getProfileImage(chatId) || ""  : ""
+            repliedMessageContent: model.repliedMessage.messageText
+            repliedMessageId: model.message.responseToMessageWithId
 
             onCommunityNameClicked: {
                 root.store.activityCenterModuleInst.switchTo(model.sectionId, "", "")


### PR DESCRIPTION
Fix #5523

### What does the PR do

Shows badge with message text for reply elements.

### Affected areas

Chat / Activity center

### Screenshot of functionality

![image](https://user-images.githubusercontent.com/61889657/168319153-b7cd5560-329b-43d0-b105-78735b807318.png)

