### PR TITLE
fix(@desktop/activityCenter): Activity Centre's Activity tool tip is slightly off

### DIFF
--- a/ui/app/AppLayouts/Chat/views/ChatContentView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatContentView.qml
@@ -156,7 +156,7 @@ ColumnLayout {
         }
         membersButton.highlighted: localAccountSensitiveSettings.expandUsersList
         notificationButton.visible: localAccountSensitiveSettings.isActivityCenterEnabled
-        notificationButton.tooltip.offset: localAccountSensitiveSettings.expandUsersList ? 0 : 14
+        notificationButton.tooltip.offset: localAccountSensitiveSettings.expandUsersList && membersButton.visible ? 0 : 14
 
         notificationCount: {
             if(!chatContentModule)


### PR DESCRIPTION
fix(@desktop/activityCenter): Activity Centre's Activity tool tip is slightly off
fixes #5508

### What does the PR do

Fixes the tooltip offset when its a one on one chat and no member list is available 

### Affected areas

activity centre

### Screenshot of functionality

https://user-images.githubusercontent.com/60327365/168576381-8968af9c-1a3b-4f4a-8e7e-d68e2a341402.mov


