### PR TITLE
fix(CreateChatView): Members should show online status

### DIFF
--- a/ui/app/AppLayouts/Chat/views/CreateChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/CreateChatView.qml
@@ -107,6 +107,12 @@ Page {
             listLabel: qsTr("Contacts")
             toLabelText: qsTr("To: ")
             warningText: qsTr("USER LIMIT REACHED")
+            ringSpecModelGetter: function(pubKey) {
+                return Utils.getColorHashAsJson(pubKey);
+            }
+            compressedKeyGetter: function(pubKey) {
+                return Utils.getCompressedPk(pubKey);
+            }
             onTextChanged: {
                 sortModel(root.contactsModel);
             }


### PR DESCRIPTION
Closes #5625
Depends on: https://github.com/status-im/StatusQ/pull/676

### What does the PR do
Fixes members list should show online status in create new DM/group chat

### Affected areas
create new DM/group chat view

### Screenshot of functionality
<img width="1176" alt="ck" src="https://user-images.githubusercontent.com/31625338/169038796-7d16acd3-cc10-435b-9aea-0ef90d0639af.png">

