### PR TITLE
fix: duplicated channels when joining a community

### DIFF
--- a/src/app_service/service/chat/dto/chat.nim
+++ b/src/app_service/service/chat/dto/chat.nim
@@ -256,6 +256,8 @@ proc toChatDto*(jsonObj: JsonNode, communityId: string): ChatDto =
   result = jsonObj.toChatDto()
   result.chatType = ChatType.CommunityChat
   result.communityId = communityId
+  if communityId != "":
+    result.id = communityId & result.id.replace(communityId, "") # Adding communityID prefix in case it's not available
 
 proc isPublicChat*(chatDto: ChatDto): bool =
   return chatDto.chatType == ChatType.Public


### PR DESCRIPTION
### What does the PR do

Fixes #5729

### Affected areas

Community chat creation / edition / importing a community / rejoining a community

### Screenshot of functionality

https://user-images.githubusercontent.com/1106587/168635149-3feb2a1d-bf76-41e4-91a1-f28e6b084b79.mp4


