### PR TITLE
fix(gifs): Change `Image` to `AnimatedImage` in StatusImageModal

### DIFF
--- a/ui/imports/shared/status/StatusImageModal.qml
+++ b/ui/imports/shared/status/StatusImageModal.qml
@@ -47,7 +47,7 @@ Popup {
         root.open();
     }
 
-    contentItem: Image {
+    contentItem: AnimatedImage {
         id: messageImage
         asynchronous: true
         fillMode: Image.PreserveAspectFit
@@ -56,6 +56,7 @@ Popup {
         mipmap: true
         smooth: false
 
+        onStatusChanged: playing = (status == AnimatedImage.Ready)
         MouseArea {
             anchors.fill: parent
             acceptedButtons: Qt.LeftButton | Qt.RightButton


### PR DESCRIPTION
Closes: #5251

### What does the PR do

Change `Image` to `AnimatedImage` in StatusImageModal

### Affected areas

StatusImageModal.qml

### Screenshot of functionality

https://user-images.githubusercontent.com/82511785/168687738-ea0d85ae-be42-424f-8845-16c261c78ec9.mov



