### PR TITLE
fix(Onboarding/DisplayName): User is forced to use display name with first case uppercase

### DIFF
--- a/ui/app/AppLayouts/Onboarding/views/InsertDetailsView.qml
+++ b/ui/app/AppLayouts/Onboarding/views/InsertDetailsView.qml
@@ -113,7 +113,6 @@ Item {
             Layout.preferredHeight: 78
             Layout.alignment: Qt.AlignHCenter
             input.placeholderText: qsTr("Display name")
-            input.edit.font.capitalization: Font.Capitalize
             input.rightComponent: RoundedIcon {
                 width: 14
                 height: 14


### PR DESCRIPTION
Fixes #5761

### What does the PR do

Removed capitalization: User can insert a display name starting with lowercase char.

### Affected areas

Onboarding / InsertDetailsView.qml

### Screenshot of functionality

https://user-images.githubusercontent.com/97019400/168759931-0a20120b-6d9a-40ce-ae43-82324f6731bf.mov



