### PR TITLE
fix(@desktop/chat): adding a contact with chat key should not immediately open a 1 on 1 chat or should block input

### DIFF
--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -591,7 +591,6 @@ method acceptContactRequest*(self: Module, publicKey: string) =
 method onContactAccepted*(self: Module, publicKey: string) =
   self.view.contactRequestsModel().removeItemWithPubKey(publicKey)
   self.updateParentBadgeNotifications()
-  self.createOneToOneChat(communityID = "" , publicKey, ensName = "")
 
 method acceptAllContactRequests*(self: Module) =
   let pubKeys = self.view.contactRequestsModel().getPublicKeys()

--- a/src/app/modules/main/profile_section/contacts/controller.nim
+++ b/src/app/modules/main/profile_section/contacts/controller.nim
@@ -2,20 +2,24 @@ import io_interface
 
 import ../../../../core/eventemitter
 import ../../../../../app_service/service/contacts/service as contacts_service
+import ../../../../../app_service/service/chat/service as chat_service
 
 type
   Controller* = ref object of RootObj
     delegate: io_interface.AccessInterface
     events: EventEmitter
     contactsService: contacts_service.Service
+    chatService: chat_service.Service
 
 proc newController*(delegate: io_interface.AccessInterface,
   events: EventEmitter,
-  contactsService: contacts_service.Service): Controller =
+  contactsService: contacts_service.Service,
+  chatService: chat_service.Service): Controller =
   result = Controller()
   result.delegate = delegate
   result.events = events
   result.contactsService = contactsService
+  result.chatService = chatService
 
 proc delete*(self: Controller) =
   discard
@@ -79,3 +83,6 @@ proc rejectContactRequest*(self: Controller, publicKey: string) =
 
 proc removeContactRequestRejection*(self: Controller, publicKey: string) =
   self.contactsService.removeContactRequestRejection(publicKey)
+
+proc switchToOrCreateOneToOneChat*(self: Controller, chatId: string) =
+  self.chatService.switchToOrCreateOneToOneChat(chatId, "")

--- a/src/app/modules/main/profile_section/contacts/io_interface.nim
+++ b/src/app/modules/main/profile_section/contacts/io_interface.nim
@@ -25,6 +25,9 @@ method viewDidLoad*(self: AccessInterface) {.base.} =
 method addContact*(self: AccessInterface, publicKey: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method switchToOrCreateOneToOneChat*(self: AccessInterface, publicKey: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method acceptContactRequests*(self: AccessInterface, publicKeysJSON: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/profile_section/contacts/module.nim
+++ b/src/app/modules/main/profile_section/contacts/module.nim
@@ -8,6 +8,7 @@ import ../../../../global/global_singleton
 
 import ../../../../core/eventemitter
 import ../../../../../app_service/service/contacts/service as contacts_service
+import ../../../../../app_service/service/chat/service as chat_service
 
 export io_interface
 
@@ -24,13 +25,14 @@ type
 
 proc newModule*(delegate: delegate_interface.AccessInterface,
   events: EventEmitter,
-  contactsService: contacts_service.Service):
+  contactsService: contacts_service.Service,
+  chatService: chat_service.Service):
   Module =
   result = Module()
   result.delegate = delegate
   result.view = newView(result)
   result.viewVariant = newQVariant(result.view)
-  result.controller = controller.newController(result, events, contactsService)
+  result.controller = controller.newController(result, events, contactsService, chatService)
   result.moduleLoaded = false
 
 method delete*(self: Module) =
@@ -76,6 +78,9 @@ method getModuleAsVariant*(self: Module): QVariant =
 
 method addContact*(self: Module, publicKey: string) =
   self.controller.addContact(publicKey)
+
+method switchToOrCreateOneToOneChat*(self: Module, publicKey: string) =
+  self.controller.switchToOrCreateOneToOneChat(publicKey)
 
 method rejectContactRequest*(self: Module, publicKey: string) =
   self.controller.rejectContactRequest(publicKey)

--- a/src/app/modules/main/profile_section/contacts/view.nim
+++ b/src/app/modules/main/profile_section/contacts/view.nim
@@ -126,6 +126,9 @@ QtObject:
   proc addContact*(self: View, publicKey: string) {.slot.} =
     self.delegate.addContact(publicKey)
 
+  proc switchToOrCreateOneToOneChat*(self: View, publicKey: string) {.slot.} =
+    self.delegate.switchToOrCreateOneToOneChat(publicKey)
+
   proc rejectContactRequest*(self: View, publicKey: string) {.slot.} =
     self.delegate.rejectContactRequest(publicKey)
 

--- a/src/app/modules/main/profile_section/module.nim
+++ b/src/app/modules/main/profile_section/module.nim
@@ -77,7 +77,7 @@ proc newModule*(delegate: delegate_interface.AccessInterface,
   result.moduleLoaded = false
 
   result.profileModule = profile_module.newModule(result, profileService)
-  result.contactsModule = contacts_module.newModule(result, events, contactsService)
+  result.contactsModule = contacts_module.newModule(result, events, contactsService, chatService)
   result.languageModule = language_module.newModule(result, languageService)
   result.privacyModule = privacy_module.newModule(result, events, settingsService, privacyService, generalService)
   result.aboutModule = about_module.newModule(result, events, aboutService)

--- a/ui/app/AppLayouts/Profile/stores/ContactsStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/ContactsStore.qml
@@ -38,7 +38,7 @@ QtObject {
 
     function joinPrivateChat(pubKey) {
         Global.changeAppSectionBySectionType(Constants.appSection.chat)
-        root.contactsModule.addContact(pubKey)
+        root.contactsModule.switchToOrCreateOneToOneChat(pubKey)
     }
 
     function addContact(pubKey) {


### PR DESCRIPTION
Now... once we add a contact, only request is sent, when added contact accept our request it will be moved to "Contacts" tab in `profile -> messaging -> contacts` and from there we can either click on "chat" icon or from the menu on three dots select "send a message" to start 1:1 chat with added contact. 

Fixes #5767