### PR TITLE
fix(Settings/Messaging/Contacts): Contacts label shows up twice

### DIFF
--- a/ui/app/AppLayouts/Profile/views/ContactsView.qml
+++ b/ui/app/AppLayouts/Profile/views/ContactsView.qml
@@ -131,7 +131,6 @@ SettingsContentBase {
                         Layout.preferredHeight: root.height * 0.5
                         contactsModel: root.contactsStore.myContactsModel
                         clip: true
-                        title: qsTr("Contacts")
                         searchString: searchBox.text
                         panelUsage: Constants.contactsPanelUsage.mutualContacts
 


### PR DESCRIPTION
Fixes #5731

### What does the PR do

Removed "Contacts" title in ContactsView.qml.

### Affected areas

Settings / Messaging / Contacts

### Screenshot of functionality
![Screenshot 2022-05-17 at 10 14 33](https://user-images.githubusercontent.com/97019400/168763732-7dede9d4-1c02-4a19-beaf-9567e401c058.png)

