### PR TITLE
fix(Chat): don't override chatdetails name with pubkey substr

### DIFF
--- a/src/app/modules/main/chat_section/chat_content/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/module.nim
@@ -325,7 +325,7 @@ method onNotificationsUpdated*(self: Module, hasUnreadMessages: bool, notificati
   self.view.updateChatDetailsNotifications(hasUnreadMessages, notificationCount)
 
 method onChatEdited*(self: Module, chatDto: ChatDto) =
-  self.view.updateChatDetails(chatDto.name, chatDto.description, chatDto.emoji, chatDto.color)
+  self.view.updateChatDetails(chatDto.name, chatDto.description, chatDto.emoji, chatDto.color, chatDto.chatType == ChatType.OneToOne)
   self.messagesModule.updateChatIdentifier()
 
 method onChatRenamed*(self: Module, newName: string) =

--- a/src/app/modules/main/chat_section/chat_content/view.nim
+++ b/src/app/modules/main/chat_section/chat_content/view.nim
@@ -111,8 +111,9 @@ QtObject:
   proc amIChatAdmin*(self: View): bool {.slot.} =
     return self.delegate.amIChatAdmin()
 
-  proc updateChatDetails*(self: View, name, description, emoji, color: string) =
-    self.chatDetails.setName(name)
+  proc updateChatDetails*(self: View, name, description, emoji, color: string, ignoreName: bool) =
+    if not ignoreName:
+      self.chatDetails.setName(name)
     self.chatDetails.setDescription(description)
     self.chatDetails.setEmoji(emoji)
     self.chatDetails.setColor(color)

--- a/src/app/modules/main/chat_section/model.nim
+++ b/src/app/modules/main/chat_section/model.nim
@@ -269,7 +269,7 @@ QtObject:
 
   proc renameItem*(self: Model, id: string, name: string) =
     for i in 0 ..< self.items.len:
-      if(self.items[i].id == id):
+      if self.items[i].id == id:
         self.items[i].BaseItem.name = name
         let index = self.createIndex(i, 0, nil)
         self.dataChanged(index, index, @[ModelRole.Name.int])

--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -785,7 +785,8 @@ method addChatIfDontExist*(self: Module,
     return
 
   if self.doesCatOrChatExist(chat.id):
-    self.onChatRenamed(chat.id, chat.name)
+    if chat.chatType != ChatType.OneToOne:
+      self.onChatRenamed(chat.id, chat.name)
     return
 
   self.addNewChat(chat, belongsToCommunity, events, settingsService, contactService, chatService,


### PR DESCRIPTION
The issue is that, after an account accepts a contact request, the
sender of the request receives a message signal where the
chat's name in the response is the first 8 characters of the chat's
public key. This is because status-go doesn't actually try to keep
the chat's `name` up-to-date if it's a one on one chat.

This results in chat details being updated with a name that is
incorrect. This commit ensures we only update the name of the chat
details if we indeed don't deal with a 1-on-1 chat.

Fixes https://github.com/status-im/status-desktop/issues/5738
