### PR TITLE
fix(@desktop/communities): member list is empty when joining a community one is not an admin of

### DIFF
--- a/src/app_service/service/chat/dto/chat.nim
+++ b/src/app_service/service/chat/dto/chat.nim
@@ -252,10 +252,12 @@ proc toChannelGroupDto*(jsonObj: JsonNode): ChannelGroupDto =
   discard jsonObj.getProp("muted", result.muted)
 
 # To parse Community chats to ChatDto, we need to add the commuity ID and type
-proc toChatDto*(jsonObj: JsonNode, communityId: string): ChatDto =
+proc communityChatToChatDto*(jsonObj: JsonNode, communityId: string): ChatDto =
+  jsonObj["communityId"] = %* communityId
+  jsonObj["chatType"] = %* 6
+  # It's very important to update jsonNode properly before `toChatDto` proc call.
+  # `chatId` should be composed of `communityId` + `chatId` and used in that form across the app.
   result = jsonObj.toChatDto()
-  result.chatType = ChatType.CommunityChat
-  result.communityId = communityId
 
 proc isPublicChat*(chatDto: ChatDto): bool =
   return chatDto.chatType == ChatType.Public

--- a/src/app_service/service/community/dto/community.nim
+++ b/src/app_service/service/community/dto/community.nim
@@ -75,7 +75,7 @@ proc toCommunityDto*(jsonObj: JsonNode): CommunityDto =
   var chatsObj: JsonNode
   if(jsonObj.getProp("chats", chatsObj)):
     for _, chatObj in chatsObj:
-      result.chats.add(chatObj.toChatDto(result.id))
+      result.chats.add(chatObj.communityChatToChatDto(result.id))
 
   var categoriesObj: JsonNode
   if(jsonObj.getProp("categories", categoriesObj)):

--- a/src/app_service/service/community/service.nim
+++ b/src/app_service/service/community/service.nim
@@ -621,7 +621,7 @@ QtObject:
         raise newException(RpcException, fmt"createCommunityChannel; there is no `chats` key in the response for community id: {communityId}")
 
       for chatObj in chatsJArr:
-        var chatDto = chatObj.toChatDto(communityId)
+        var chatDto = chatObj.communityChatToChatDto(communityId)
         self.chatService.updateOrAddChat(chatDto)
         let data = CommunityChatArgs(chat: chatDto)
         self.events.emit(SIGNAL_COMMUNITY_CHANNEL_CREATED, data)
@@ -661,7 +661,7 @@ QtObject:
         raise newException(RpcException, fmt"editCommunityChannel; there is no `chats` key in the response for community id: {communityId}")
 
       for chatObj in chatsJArr:
-        var chatDto = chatObj.toChatDto(communityId)
+        var chatDto = chatObj.communityChatToChatDto(communityId)
 
         self.chatService.updateOrAddChat(chatDto) # we have to update chats stored in the chat service.
 
@@ -892,7 +892,7 @@ QtObject:
       self.joinedCommunities[communityDto.id] = communityDto
 
       for chatObj in chatsJArr:
-        let chatDto = chatObj.toChatDto(communityDto.id)
+        let chatDto = chatObj.communityChatToChatDto(communityDto.id)
         self.chatService.updateOrAddChat(chatDto) # we have to update chats stored in the chat service.
 
       for chat in communityDto.chats:


### PR DESCRIPTION
Within this commit an issue with duplicated channels is fixed. Cause the fix is applied
globally it could be that many other issues are fixed as well.

The initial issue, with empty members list was not an issue (it could be that it's
fixed in meantime).

Fixes #5770