### PR TITLE
fix(@profile): copy chat key rather than transformed key

### DIFF
--- a/ui/app/AppLayouts/Profile/views/MyProfileView.qml
+++ b/ui/app/AppLayouts/Profile/views/MyProfileView.qml
@@ -129,7 +129,7 @@ SettingsContentBase {
             tooltip.text: qsTr("Copy to clipboard")
             icon.name: "copy"
             iconButton.onClicked: {
-                root.profileStore.copyToClipboard(subTitle)
+                root.profileStore.copyToClipboard(root.profileStore.pubkey)
                 tooltip.visible = !tooltip.visible
             }
         }

--- a/ui/imports/shared/popups/ProfilePopup.qml
+++ b/ui/imports/shared/popups/ProfilePopup.qml
@@ -174,7 +174,7 @@ StatusModal {
                 tooltip.text: qsTr("Copy to clipboard")
                 icon.name: "copy"
                 iconButton.onClicked: {
-                    globalUtils.copyToClipboard(subTitle)
+                    globalUtils.copyToClipboard(userPublicKey)
                     tooltip.visible = !tooltip.visible
                 }
                 width: parent.width


### PR DESCRIPTION
fixes #5775

the copy needs to be on the real chat key, not the transformed one used
for UI
