### PR TITLE
fix(ChatMessage): hide "edit" option when right click on sticker

### DIFF
--- a/ui/imports/shared/views/chat/MessageContextMenuView.qml
+++ b/ui/imports/shared/views/chat/MessageContextMenuView.qml
@@ -42,6 +42,7 @@ StatusPopupMenu {
     property bool pinnedPopup: false
     property bool isDebugEnabled: false
     property bool isEmoji: false
+    property bool isSticker: false
     property bool hideEmojiPicker: true
     property bool pinnedMessage: false
     property bool canPin: false
@@ -205,6 +206,7 @@ StatusPopupMenu {
         enabled: root.isMyMessage &&
                  !root.hideEmojiPicker &&
                  !root.isEmoji &&
+                 !root.isSticker &&
                  !root.isProfile &&
                  !root.pinnedPopup &&
                  !root.isRightClickOnImage

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -180,6 +180,7 @@ Column {
         messageContextMenu.isProfile = !!isProfileClick
         messageContextMenu.isRightClickOnImage = isRightClickOnImage
         messageContextMenu.isEmoji = isEmoji
+        messageContextMenu.isSticker = isSticker
         messageContextMenu.hideEmojiPicker = hideEmojiPicker
 
         if(isReply){


### PR DESCRIPTION
Closes #5766

### What does the PR do
Hides "edit" option from message context menu when message is sticker

### Affected areas
Message context menu

### Screenshot of functionality
https://user-images.githubusercontent.com/31625338/168820728-7b4f5be6-e5e9-4bbd-bf6c-c6048234a7de.mov


