### PR TITLE
feat: handling `mailserver.not.working` signal

### DIFF
--- a/src/app/core/signals/remote_signals/mailserver.nim
+++ b/src/app/core/signals/remote_signals/mailserver.nim
@@ -36,6 +36,8 @@ type MailserverAvailableSignal* = ref object of Signal
 type MailserverChangedSignal* = ref object of Signal
   address*: string
 
+type MailserverNotWorkingSignal* = ref object of Signal
+
 proc fromEvent*(T: type MailserverRequestCompletedSignal, jsonSignal: JsonNode): MailserverRequestCompletedSignal =
   result = MailserverRequestCompletedSignal()
   result.signalType = SignalType.MailserverRequestCompleted
@@ -86,3 +88,7 @@ proc fromEvent*(T: type MailserverChangedSignal, jsonSignal: JsonNode): Mailserv
   result = MailserverChangedSignal()
   result.signalType = SignalType.MailserverChanged
   result.address = jsonSignal["event"]{"address"}.getStr()
+
+proc fromEvent*(T: type MailserverNotWorkingSignal, jsonSignal: JsonNode): MailserverNotWorkingSignal =
+  result = MailserverNotWorkingSignal()
+  result.signalType = SignalType.MailseverNotWorking

--- a/src/app/core/signals/remote_signals/signal_type.nim
+++ b/src/app/core/signals/remote_signals/signal_type.nim
@@ -29,6 +29,7 @@ type SignalType* {.pure.} = enum
   KeycardConnected = "keycard.connected"
   MailserverAvailable = "mailserver.available"
   MailserverChanged = "mailserver.changed"
+  MailserverNotWorking = "mailserver.not.working"
   HistoryArchivesProtocolEnabled = "community.historyArchivesProtocolEnabled"
   HistoryArchivesProtocolDisabled = "community.historyArchivesProtocolDisabled"
   CreatingHistoryArchives = "community.creatingHistoryArchives"

--- a/src/app/modules/main/controller.nim
+++ b/src/app/modules/main/controller.nim
@@ -81,6 +81,9 @@ proc init*(self: Controller) =
     # requestAllHistoricMessagesResult
     # requestMissingCommunityInfos
 
+  self.events.on(SIGNAL_MAILSERVER_NOT_WORKING) do(e: Args):
+    self.delegate.emitMailserverNotWorking()
+
   if(defined(macosx)):
     let account = self.accountsService.getLoggedInAccount()
     singletonInstance.localAccountSettings.setFileName(account.name)

--- a/src/app/modules/main/io_interface.nim
+++ b/src/app/modules/main/io_interface.nim
@@ -90,6 +90,9 @@ method emitStoringPasswordError*(self: AccessInterface, errorDescription: string
 method emitStoringPasswordSuccess*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method emitMailserverNotWorking*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method activeSectionSet*(self: AccessInterface, sectionId: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -443,6 +443,9 @@ method emitStoringPasswordError*[T](self: Module[T], errorDescription: string) =
 method emitStoringPasswordSuccess*[T](self: Module[T]) =
   self.view.emitStoringPasswordSuccess()
 
+method emitMailserverNotWorking*[T](self: Module[T]) =
+  self.view.emitMailserverNotWorking()
+
 method getActiveSectionId*[T](self: Module[T]): string =
   return self.controller.getActiveSectionId()
 

--- a/src/app/modules/main/view.nim
+++ b/src/app/modules/main/view.nim
@@ -94,6 +94,11 @@ QtObject:
   proc emitStoringPasswordSuccess*(self: View) =
     self.storingPasswordSuccess()
 
+  proc mailserverNotWorking*(self:View) {.signal.}
+
+  proc emitMailservernotWorking*(self: View) =
+    self.mailserverNotWorking()
+
   proc activeSection*(self: View): ActiveSection =
     return self.activeSection
 

--- a/src/app_service/service/mailservers/service.nim
+++ b/src/app_service/service/mailservers/service.nim
@@ -28,6 +28,7 @@ type
 # Signals which may be emitted by this service:
 const SIGNAL_ACTIVE_MAILSERVER_CHANGED* = "activeMailserverChanged"
 const SIGNAL_MAILSERVER_AVAILABLE* = "mailserverAvailable"
+const SIGNAL_MAILSERVER_NOT_WORKING* = "mailserverNotWorking"
 
 const requestMoreMessagesTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[RequestMoreMessagesTaskArg](argEncoded)
@@ -108,6 +109,10 @@ QtObject:
       info "mailserver available"
       let data = MailserverAvailableArgs()
       self.events.emit(SIGNAL_MAILSERVER_AVAILABLE, data)
+
+    self.events.on(SignalType.MailserverNotWorking.event) do(e: Args):
+      info "mailserver not working"
+      self.events.emit(SIGNAL_MAILSERVER_NOT_WORKING, Args())
 
     self.events.on(SignalType.HistoryRequestStarted.event) do(e: Args):
       let h = HistoryRequestStartedSignal(e)

--- a/src/backend/signals.nim
+++ b/src/backend/signals.nim
@@ -32,6 +32,7 @@ proc decode*(jsonSignal: JsonNode): Signal =
     of SignalType.KeycardConnected: KeycardConnectedSignal.fromEvent(jsonSignal)
     of SignalType.MailserverAvailable: MailserverAvailableSignal.fromEvent(jsonSignal)
     of SignalType.MailserverChanged: MailserverChangedSignal.fromEvent(jsonSignal)
+    of SignalType.MailserverNotWorking: MailserverNotWorkingSignal.fromEvent(jsonSignal)
     of SignalType.HistoryArchivesProtocolEnabled: historyArchivesProtocolEnabledFromEvent(jsonSignal)
     of SignalType.HistoryArchivesProtocolDisabled: historyArchivesProtocolDisabledFromEvent(jsonSignal)
     of SignalType.CreatingHistoryArchives: creatingHistoryArchivesFromEvent(jsonSignal)

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -626,7 +626,55 @@ Item {
                     }
                 }
             }
+
+            Connections {
+                target: rootStore.mainModuleInst
+                onMailserverNotWorking: {
+                    Global.openPopup(mailserverNotWorkingPopupComponent);
+                }
+            }
         }
+
+        Component {
+            id: mailserverNotWorkingPopupComponent
+            StatusModal {
+                id: msNotWorkingPopup
+                anchors.centerIn: parent
+                header.title: qsTr("Can not connect to mailserver")
+                onClosed: {
+                    destroy()
+                }
+
+                contentItem: Item {
+                    width: msNotWorkingPopup.width
+                    implicitHeight: 100
+
+                    StatusBaseText {
+                      text: qsTr("The mailserver you're connecting to is unavailable.")
+                      color: Theme.palette.directColor1
+                      anchors.centerIn: parent
+                    }
+                }
+
+                rightButtons: [
+                    StatusButton {
+                      text: qsTr("Pick another")
+                      onClicked: {
+                          Global.changeAppSectionBySectionType(Constants.appSection.profile, Constants.settingsSubsection.messaging)
+                          msNotWorkingPopup.close()
+                      }
+                    },
+                    StatusButton {
+                      text: qsTr("Retry")
+                      onClicked: {
+                        // Retrying already happens automatically, so doing nothing
+                        // here is the same as retrying...
+                        msNotWorkingPopup.close()
+                      }
+                    }
+                ]
+            }
+          }
 
         Component {
             id: chooseBrowserPopupComponent


### PR DESCRIPTION
This makes Status Desktop aware of the `mailserver.not.working` signal.
When emitted by status-go, desktop will show a popup that informs the
user about the connection failure.

Furthermore, users can then decide to either retry (same as just closing
the popup as retrying already happens by default), or pick another
pinned mailserver, for which they'll get redirected to the messaging
settings panel.

Closes #5166
