### PR TITLE
fix(chatlistcolumn): fixed alignment in chats list

### DIFF
--- a/ui/app/AppLayouts/Chat/views/CommunityColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/CommunityColumnView.qml
@@ -111,12 +111,8 @@ Item {
         anchors.top: membershipRequests.bottom
         anchors.topMargin: Style.current.padding
         anchors.bottom: parent.bottom
-        anchors.horizontalCenter: parent.horizontalCenter
 
         width: parent.width
-
-        leftPadding: Style.current.halfPadding
-        rightPadding: Style.current.halfPadding
 
         ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
         clip: true
@@ -126,10 +122,7 @@ Item {
 
         StatusChatListAndCategories {
             id: communityChatListAndCategories
-
             anchors.horizontalCenter: parent.horizontalCenter
-            width: root.width
-
             draggableItems: communityData.amISectionAdmin
             draggableCategories: communityData.amISectionAdmin
 

--- a/ui/app/AppLayouts/Chat/views/ContactsColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ContactsColumnView.qml
@@ -60,19 +60,16 @@ Item {
 
     RowLayout {
         id: searchInputWrapper
-        width: parent.width
+        width: 288
         height: searchInput.height
         anchors.top: headline.bottom
         anchors.topMargin: 16
-        anchors.right: parent.right
-        anchors.rightMargin: 8
-
+        anchors.horizontalCenter: parent.horizontalCenter
 
         StatusBaseInput {
             id: searchInput
             Layout.fillWidth: true
-            Layout.alignment: Qt.AlignVCenter | Qt.AlignLeft
-            Layout.leftMargin: 17
+            Layout.alignment: Qt.AlignVCenter
             implicitHeight: 36
             topPadding: 9
             //% "Search"
@@ -161,10 +158,6 @@ Item {
         anchors.topMargin: Style.current.padding
         anchors.bottom: root.bottom
         contentHeight: channelList.childrenRect.height + emptyViewAndSuggestions.childrenRect.height
-        anchors.horizontalCenter: parent.horizontalCenter
-
-        leftPadding: Style.current.halfPadding
-        rightPadding: Style.current.halfPadding
 
         ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
 
@@ -172,6 +165,7 @@ Item {
 
         StatusChatList {
             id: channelList
+            anchors.horizontalCenter: parent.horizontalCenter
             model: root.chatSectionModule.model
             highlightItem: !root.store.openCreateChat
             onChatItemSelected: {


### PR DESCRIPTION
Closes #5211

Depends on: https://github.com/status-im/StatusQ/pull/680

### What does the PR do
 fixed alignment of chats list in left column

### Affected areas
chats list

### Screenshot of functionality
<img width="1216" alt="chat" src="https://user-images.githubusercontent.com/31625338/168850175-267e5315-cf40-4748-825e-8ddddde4eb22.png">
<img width="1216" alt="commu" src="https://user-images.githubusercontent.com/31625338/168850190-24fa9064-497e-45de-98a8-6e3f3a8afd16.png">


