### PR TITLE
chore(general): fix gitignore not to shadow in source builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,16 +40,6 @@ nim_status_client.log
 
 # https://github.com/github/gitignore/blob/master/CMake.gitignore
 CMakeLists.txt.user
-CMakeCache.txt
-CMakeFiles
-CMakeScripts
-Testing
-Makefile
-cmake_install.cmake
-install_manifest.txt
-compile_commands.json
-CTestTestfile.cmake
-_deps
 .cache/
 
 # QtCreator shadow builds
@@ -62,32 +52,6 @@ build/
 # Prerequisites
 *.d
 
-# Compiled Object files
-*.slo
-*.lo
-*.o
-*.obj
-
-# Precompiled Headers
-*.gch
-*.pch
-
-# Compiled Dynamic libraries
-*.so
-*.dylib
-*.dll
-
 # Fortran module files
 *.mod
 *.smod
-
-# Compiled Static libraries
-*.lai
-*.la
-*.a
-*.lib
-
-# Executables
-*.exe
-*.out
-*.app


### PR DESCRIPTION
Don't ignore build files in the source tree.

The CMake doesn't allow in-source build and it is discouraged by the C++ developer community.

More precisely, without proper setup some tools (conan-CMake) default to in-source build which is error-prone: will override the Makefiles we have for nim app and the safe way of adding files (`git add --update`) will add to the index as unrelated changes.