### PR TITLE
fix: invalid pubkey error

### DIFF
--- a/ui/app/AppLayouts/Profile/views/NotificationsView.qml
+++ b/ui/app/AppLayouts/Profile/views/NotificationsView.qml
@@ -120,7 +120,7 @@ SettingsContentBase {
 
                     // Maybe we need to redo `StatusListItem` to display identicon ring, but that's not in Figma design for now.
                     image.source: model.image
-                    ringSettings.ringSpecModel: Utils.getColorHashAsJson(model.itemId)
+                    ringSettings.ringSpecModel: model.type === Constants.settingsSection.exemptions.oneToOneChat ? Utils.getColorHashAsJson(model.itemId) : undefined
                     icon: StatusIconSettings {
                         color: model.type === Constants.settingsSection.exemptions.oneToOneChat?
                                    Theme.palette.userCustomizationColors[Utils.colorIdForPubkey(model.itemId)] :


### PR DESCRIPTION
### What does the PR do

Removes an error seen in the terminal when receiving messages:
```
ERR 2022-05-17 14:27:03.953-04:00 error colorHashOf:                         tid=303181 file=service.nim:26 errDescription="invalid pubkey: 0x02032ea19a8ac74c0495effdea0a999f27cf3b17e22a7d28e76d4d6a4721864fc5"
```
