### PR TITLE
fix(@desktop/chat): Fix activity center icon badge displaying

### DIFF
--- a/src/app/modules/main/activity_center/model.nim
+++ b/src/app/modules/main/activity_center/model.nim
@@ -184,6 +184,7 @@ QtObject:
 
     if (addToCount and not activityCenterNotification.read):
       self.nbUnreadNotifications = self.nbUnreadNotifications + 1
+      self.unreadCountChanged()
 
   proc updateUnreadCount*(self: Model, count: int) =
     self.nbUnreadNotifications = count

--- a/ui/app/AppLayouts/Chat/popups/ActivityCenterPopup.qml
+++ b/ui/app/AppLayouts/Chat/popups/ActivityCenterPopup.qml
@@ -28,6 +28,8 @@ Popup {
     property var chatSectionModule
     property var messageContextMenu
 
+    readonly property int unreadNotificationsCount : activityCenter.store.activityCenterList.unreadCount
+
     id: activityCenter
     modal: false
 

--- a/ui/app/AppLayouts/Chat/views/ChatContentView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatContentView.qml
@@ -158,12 +158,7 @@ ColumnLayout {
         notificationButton.visible: localAccountSensitiveSettings.isActivityCenterEnabled
         notificationButton.tooltip.offset: localAccountSensitiveSettings.expandUsersList && membersButton.visible ? 0 : 14
 
-        notificationCount: {
-            if(!chatContentModule)
-                return 0
-
-            return chatContentModule.chatDetails.notificationCount
-        }
+        notificationCount: activityCenter.unreadNotificationsCount
 
         onSearchButtonClicked: root.openAppSearch()
 


### PR DESCRIPTION
Fix #5739

### What does the PR do

Activity center icon displays a badge with a number of unchecked items in the list.

### Affected areas

Activity center

### Screenshot of functionality

![image](https://user-images.githubusercontent.com/61889657/169295063-0e8a9024-697e-4c1f-ab57-e5f853cc6b25.png)
