### PR TITLE
fix(@desktop/onboarding): not remove seed phrases when changing number of words

### DIFF
--- a/ui/app/AppLayouts/Onboarding/views/SeedPhraseInputView.qml
+++ b/ui/app/AppLayouts/Onboarding/views/SeedPhraseInputView.qml
@@ -20,7 +20,6 @@ OnboardingBasePage {
 
     property bool existingUser: (root.state === "existingUser")
     property var mnemonicInput: []
-    property string mnemonicString
 
     signal seedValidated()
 
@@ -121,9 +120,10 @@ OnboardingBasePage {
                 }
             }
             onCurrentIndexChanged: {
-                root.mnemonicString = "";
-                root.mnemonicInput = [];
-                submitButton.enabled = false;
+                root.mnemonicInput = root.mnemonicInput.filter(function(value) {
+                    return value.pos <= root.tabs[switchTabBar.currentIndex]
+                })
+                submitButton.checkMnemonicLength()
             }
         }
         clip: true
@@ -292,20 +292,19 @@ OnboardingBasePage {
             anchors.topMargin: 24
             enabled: false
             function checkMnemonicLength() {
-                submitButton.enabled = (root.mnemonicInput.length >= grid.count);
+                submitButton.enabled = (root.mnemonicInput.length === root.tabs[switchTabBar.currentIndex])
             }
             text: root.existingUser ? qsTr("Restore Status Profile") : qsTr("Import")
             onClicked: {
-                root.mnemonicString = "";
+                let mnemonicString = "";
                 var sortTable = mnemonicInput.sort(function (a, b) {
                     return a.pos - b.pos;
                 });
                 for (var i = 0; i < mnemonicInput.length; i++) {
-                    root.mnemonicString += sortTable[i].seed + ((i === (grid.count-1)) ? "" : " ");
+                    mnemonicString += sortTable[i].seed + ((i === (grid.count-1)) ? "" : " ");
                 }
-                if (Utils.isMnemonic(root.mnemonicString) && !OnboardingStore.validateMnemonic(root.mnemonicString)) {
-                    OnboardingStore.importMnemonic(root.mnemonicString)
-                    root.mnemonicString = "";
+                if (Utils.isMnemonic(mnemonicString) && !OnboardingStore.validateMnemonic(mnemonicString)) {
+                    OnboardingStore.importMnemonic(mnemonicString)
                     root.mnemonicInput = [];
                 } else {
                     invalidSeedTxt.visible = true;
@@ -316,7 +315,6 @@ OnboardingBasePage {
     }
 
     onBackClicked: {
-        root.mnemonicString = "";
         root.mnemonicInput = [];
         root.exit();
     }

--- a/ui/app/AppLayouts/Wallet/panels/ImportSeedPhrasePanel.qml
+++ b/ui/app/AppLayouts/Wallet/panels/ImportSeedPhrasePanel.qml
@@ -79,7 +79,17 @@ GridView {
 
     onModelChanged: {
         mnemonicString = "";
-        _internal.mnemonicInput = [];
+        let menmonicInputTemp = _internal.mnemonicInput.filter(function(value) {
+                        return value.pos <= grid.count
+                    })
+        _internal.mnemonicInput = []
+        for (let i = 0; i < menmonicInputTemp.length; i++) {
+            // .pos starts with 1
+            grid.itemAtIndex(menmonicInputTemp[i].pos - 1).setWord(menmonicInputTemp[i].seed)
+            grid.addWord(menmonicInputTemp[i].pos,
+                         menmonicInputTemp[i].seed,
+                         true)
+        }
     }
 
 
@@ -162,7 +172,6 @@ GridView {
         width: _internal.seedPhraseInputWidth
         height: _internal.seedPhraseInputHeight
         textEdit.errorMessageCmp.visible: false
-        textEdit.input.anchors.topMargin: 11
         leftComponentText: index + 1
         inputList: BIP39_en { }
         property int itemIndex: index


### PR DESCRIPTION
Fix #5613

### What does the PR do

The page remembers seed phrases when switching to different seed phrase modes.

### Affected areas

Onboarding: Add existing user/ Enter seed phrase

### Screenshot of functionality

https://user-images.githubusercontent.com/61889657/169807592-91b323b5-0b33-46d2-90ed-5eae18ffbb87.mov


