### PR TITLE
fix(@desktop/settings): remove the `Manage Assets & Lists` functionality from `Settings/Wallet`

### DIFF
--- a/ui/app/AppLayouts/Profile/views/wallet/MainView.qml
+++ b/ui/app/AppLayouts/Profile/views/wallet/MainView.qml
@@ -20,19 +20,22 @@ Column {
     signal goToAccountView(address: string)
     signal goToDappPermissionsView()
 
-    StatusListItem {
-        title: qsTr("Manage Assets & List")
-        height: 64
-        width: parent.width
-        onClicked: Global.openPopup(tokenSettingsModalComponent)
-        components: [
-            StatusIcon {
-                icon: "chevron-down"
-                rotation: 270
-                color: Theme.palette.baseColor1
-            }
-        ]
-    }
+    // Temporary commented, we need to bring it back after MVP
+    // https://github.com/status-im/status-desktop/issues/5856
+
+//    StatusListItem {
+//        title: qsTr("Manage Assets & List")
+//        height: 64
+//        width: parent.width
+//        onClicked: Global.openPopup(tokenSettingsModalComponent)
+//        components: [
+//            StatusIcon {
+//                icon: "chevron-down"
+//                rotation: 270
+//                color: Theme.palette.baseColor1
+//            }
+//        ]
+//    }
 
     Component {
         id: tokenSettingsModalComponent


### PR DESCRIPTION
Temporary commented, we need to bring it back after MVP.

Fixes #5856