### PR TITLE
feat: add backend code to retrieve curated communities

### DIFF
--- a/src/app/global/local_account_sensitive_settings.nim
+++ b/src/app/global/local_account_sensitive_settings.nim
@@ -24,6 +24,8 @@ const LSS_KEY_IS_GIF_WIDGET_ENABLED* = "isGifWidgetEnabled"
 const DEFAULT_IS_GIF_WIDGET_ENABLED = true
 const LSS_KEY_IS_MULTI_NETWORK_ENABLED* = "isMultiNetworkEnabled"
 const DEFAULT_IS_MULTI_NETWORK_ENABLED = false
+const LSS_KEY_IS_COMMUNITIES_PORTAL_ENABLED* = "isCommunitiesPortalEnabled"
+const DEFAULT_IS_COMMUNITIES_PORTAL_ENABLED = false
 const LSS_KEY_IS_TENOR_WARNING_ACCEPTED* = "isTenorWarningAccepted"
 const DEFAULT_IS_TENOR_WARNING_ACCEPTED = false
 const LSS_KEY_DISPLAY_CHAT_IMAGES* = "displayChatImages"
@@ -344,6 +346,18 @@ QtObject:
     read = getIsMultiNetworkEnabled
     write = setIsMultiNetworkEnabled
     notify = isMultiNetworkEnabledChanged
+
+  proc isCommunitiesPortalEnabledChanged*(self: LocalAccountSensitiveSettings) {.signal.}
+  proc getIsCommunitiesPortalEnabled*(self: LocalAccountSensitiveSettings): bool {.slot.} =
+    getSettingsProp[bool](self, LSS_KEY_IS_COMMUNITIES_PORTAL_ENABLED, newQVariant(DEFAULT_IS_COMMUNITIES_PORTAL_ENABLED))
+  proc setIsCommunitiesPortalEnabled*(self: LocalAccountSensitiveSettings, value: bool) {.slot.} =
+    setSettingsProp(self, LSS_KEY_IS_COMMUNITIES_PORTAL_ENABLED, newQVariant(value)):
+      self.isCommunitiesPortalEnabledChanged()
+
+  QtProperty[bool] isCommunitiesPortalEnabled:
+    read = getIsCommunitiesPortalEnabled
+    write = setIsCommunitiesPortalEnabled
+    notify = isCommunitiesPortalEnabledChanged
 
 
   proc isTenorWarningAcceptedChanged*(self: LocalAccountSensitiveSettings) {.signal.}
@@ -965,6 +979,7 @@ QtObject:
       of LSS_KEY_EXPAND_USERS_LIST: self.expandUsersListChanged()
       of LSS_KEY_IS_GIF_WIDGET_ENABLED: self.isGifWidgetEnabledChanged()
       of LSS_KEY_IS_MULTI_NETWORK_ENABLED: self.isMultiNetworkEnabledChanged()
+      of LSS_KEY_IS_COMMUNITIES_PORTAL_ENABLED: self.isCommunitiesPortalEnabledChanged()
       of LSS_KEY_IS_TENOR_WARNING_ACCEPTED: self.isTenorWarningAcceptedChanged()
       of LSS_KEY_DISPLAY_CHAT_IMAGES: self.displayChatImagesChanged()
       of LSS_KEY_RECENT_EMOJIS: self.recentEmojisChanged()

--- a/src/app/modules/main/communities/controller.nim
+++ b/src/app/modules/main/communities/controller.nim
@@ -37,6 +37,10 @@ proc init*(self: Controller) =
     let args = CommunityArgs(e)
     self.delegate.communityAdded(args.community)
 
+  self.events.on(SIGNAL_CURATED_COMMUNITY_FOUND) do(e:Args):
+    let args = CuratedCommunityArgs(e)
+    self.delegate.curatedCommunityAdded(args.curatedCommunity)
+
   self.events.on(SIGNAL_COMMUNITY_ADDED) do(e:Args):
     let args = CommunityArgs(e)
     self.delegate.communityAdded(args.community)
@@ -52,9 +56,13 @@ proc init*(self: Controller) =
     let args = CommunitiesArgs(e)
     for community in args.communities:
       self.delegate.communityEdited(community)
+      self.delegate.curatedCommunityEdited(CuratedCommunity(communityId: community.id, available: true, community:community))
 
 proc getAllCommunities*(self: Controller): seq[CommunityDto] =
   result = self.communityService.getAllCommunities()
+
+proc getCuratedCommunities*(self: Controller): seq[CuratedCommunity] =
+  result = self.communityService.getCuratedCommunities()
 
 proc joinCommunity*(self: Controller, communityId: string): string =
   self.communityService.joinCommunity(communityId)

--- a/src/app/modules/main/communities/io_interface.nim
+++ b/src/app/modules/main/communities/io_interface.nim
@@ -16,6 +16,9 @@ method isLoaded*(self: AccessInterface): bool {.base.} =
 method setAllCommunities*(self: AccessInterface, communities: seq[CommunityDto]) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method setCuratedCommunities*(self: AccessInterface, curatedCommunities: seq[CommunityDto]) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method getCommunityItem*(self: AccessInterface, community: CommunityDto): SectionItem {.base.} =
   raise newException(ValueError, "No implementation available")
 
@@ -80,6 +83,12 @@ method communityEdited*(self: AccessInterface, community: CommunityDto) {.base.}
   raise newException(ValueError, "No implementation available")
 
 method communityAdded*(self: AccessInterface, community: CommunityDto) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method curatedCommunityAdded*(self: AccessInterface, community: CuratedCommunity) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method curatedCommunityEdited*(self: AccessInterface, community: CuratedCommunity) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method communityImported*(self: AccessInterface, community: CommunityDto) {.base.} =

--- a/src/app/modules/main/communities/models/curated_community_item.nim
+++ b/src/app/modules/main/communities/models/curated_community_item.nim
@@ -7,26 +7,34 @@ type
     description: string
     available: bool
     icon: string
+    color: string
+    members: int
     
 proc initCuratedCommunityItem*(
   id: string,
   name: string,
   description: string,
   available: bool,
-  icon: string
+  icon: string,
+  color: string,
+  members: int
 ): CuratedCommunityItem =
   result.id = id
   result.name = name
   result.description = description
   result.available = available
   result.icon = icon
+  result.color = color
+  result.members = members
 
 proc `$`*(self: CuratedCommunityItem): string =
   result = fmt"""CuratedCommunityItem(
     id: {self.id},
     name: {self.name},
     description: {self.description},
-    available: {self.available}
+    available: {self.available},
+    color: {self.color},
+    members: {self.members}
     ]"""
 
 proc getId*(self: CuratedCommunityItem): string =
@@ -43,3 +51,9 @@ proc isAvailable*(self: CuratedCommunityItem): bool =
 
 proc getIcon*(self: CuratedCommunityItem): string =
   return self.icon
+
+proc getMembers*(self: CuratedCommunityItem): int =
+  return self.members
+
+proc getColor*(self: CuratedCommunityItem): string =
+  return self.color

--- a/src/app/modules/main/communities/models/curated_community_item.nim
+++ b/src/app/modules/main/communities/models/curated_community_item.nim
@@ -1,0 +1,39 @@
+import strformat
+
+type
+  CuratedCommunityItem* = object
+    id: string
+    name: string
+    description: string
+    available: bool
+    
+proc initCuratedCommunityItem*(
+  id: string,
+  name: string,
+  description: string,
+  available: bool
+): CuratedCommunityItem =
+  result.id = id
+  result.name = name
+  result.description = description
+  result.available = available
+
+proc `$`*(self: CuratedCommunityItem): string =
+  result = fmt"""CuratedCommunityItem(
+    id: {self.id},
+    name: {self.name},
+    description: {self.description},
+    available: {self.available}
+    ]"""
+
+proc getId*(self: CuratedCommunityItem): string =
+  return self.id
+
+proc getName*(self: CuratedCommunityItem): string =
+  return self.name
+
+proc getDescription*(self: CuratedCommunityItem): string =
+  return self.description
+
+proc isAvailable*(self: CuratedCommunityItem): bool =
+  return self.available

--- a/src/app/modules/main/communities/models/curated_community_item.nim
+++ b/src/app/modules/main/communities/models/curated_community_item.nim
@@ -6,17 +6,20 @@ type
     name: string
     description: string
     available: bool
+    icon: string
     
 proc initCuratedCommunityItem*(
   id: string,
   name: string,
   description: string,
-  available: bool
+  available: bool,
+  icon: string
 ): CuratedCommunityItem =
   result.id = id
   result.name = name
   result.description = description
   result.available = available
+  result.icon = icon
 
 proc `$`*(self: CuratedCommunityItem): string =
   result = fmt"""CuratedCommunityItem(
@@ -37,3 +40,6 @@ proc getDescription*(self: CuratedCommunityItem): string =
 
 proc isAvailable*(self: CuratedCommunityItem): bool =
   return self.available
+
+proc getIcon*(self: CuratedCommunityItem): string =
+  return self.icon

--- a/src/app/modules/main/communities/models/curated_community_model.nim
+++ b/src/app/modules/main/communities/models/curated_community_model.nim
@@ -1,0 +1,111 @@
+import NimQml, Tables
+import curated_community_item
+
+type
+  ModelRole {.pure.} = enum
+    Id = UserRole + 1
+    Available
+    Name
+    Description
+
+QtObject:
+  type CuratedCommunityModel* = ref object of QAbstractListModel
+    items*: seq[CuratedCommunityItem]
+
+  proc setup(self: CuratedCommunityModel) =
+    self.QAbstractListModel.setup
+
+  proc delete(self: CuratedCommunityModel) =
+    self.items = @[]
+    self.QAbstractListModel.delete
+
+  proc newCuratedCommunityModel*(): CuratedCommunityModel =
+    new(result, delete)
+    result.setup
+
+  proc countChanged(self: CuratedCommunityModel) {.signal.}
+
+  proc setItems*(self: CuratedCommunityModel, items: seq[CuratedCommunityItem]) =
+    self.beginResetModel()
+    self.items = items
+    self.endResetModel()
+    self.countChanged()
+
+  proc getCount(self: CuratedCommunityModel): int {.slot.} =
+    self.items.len
+  QtProperty[int] count:
+    read = getCount
+    notify = countChanged
+
+  method rowCount(self: CuratedCommunityModel, index: QModelIndex = nil): int =
+    return self.items.len
+
+  method roleNames(self: CuratedCommunityModel): Table[int, string] =
+    {
+      ModelRole.Id.int:"id",
+      ModelRole.Name.int:"name",
+      ModelRole.Available.int:"available",
+      ModelRole.Description.int:"description"
+    }.toTable
+
+  method data(self: CuratedCommunityModel, index: QModelIndex, role: int): QVariant =
+    if not index.isValid:
+      return
+    if index.row < 0 or index.row >= self.items.len:
+      return
+    let item = self.items[index.row]
+    let enumRole = role.ModelRole
+
+    case enumRole:
+      of ModelRole.Id:
+        result = newQVariant(item.getId())
+      of ModelRole.Name:
+        result = newQVariant(item.getName())
+      of ModelRole.Description:
+        result = newQVariant(item.getDescription())
+      of ModelRole.Available:
+        result = newQVariant(item.isAvailable())
+
+  proc findIndexById(self: CuratedCommunityModel, id: string): int =
+    for i in 0 ..< self.items.len:
+      if(self.items[i].getId() == id):
+        return i
+    return -1
+
+  proc addItems*(self: CuratedCommunityModel, items: seq[CuratedCommunityItem]) =
+    if(items.len == 0):
+      return
+
+    let parentModelIndex = newQModelIndex()
+    defer: parentModelIndex.delete
+
+    let first = self.items.len
+    let last = first + items.len - 1
+    self.beginInsertRows(parentModelIndex, first, last)
+    self.items.add(items)
+    self.endInsertRows()
+    self.countChanged()
+
+  proc addItem*(self: CuratedCommunityModel, item: CuratedCommunityItem) =
+    let parentModelIndex = newQModelIndex()
+    defer: parentModelIndex.delete
+    self.beginInsertRows(parentModelIndex, self.items.len, self.items.len)
+    self.items.add(item)
+    self.endInsertRows()
+    self.countChanged()
+
+  proc containsItemWithId*(self: CuratedCommunityModel, id: string): bool =
+    return self.findIndexById(id) != -1
+
+  proc removeItemWithId*(self: CuratedCommunityModel, id: string) =
+    let ind = self.findIndexById(id)
+    if(ind == -1):
+      return
+
+    let parentModelIndex = newQModelIndex()
+    defer: parentModelIndex.delete
+
+    self.beginRemoveRows(parentModelIndex, ind, ind)
+    self.items.delete(ind)
+    self.endRemoveRows()
+    self.countChanged()

--- a/src/app/modules/main/communities/models/curated_community_model.nim
+++ b/src/app/modules/main/communities/models/curated_community_model.nim
@@ -75,28 +75,6 @@ QtObject:
         return i
     return -1
 
-  proc addItems*(self: CuratedCommunityModel, items: seq[CuratedCommunityItem]) =
-    if(items.len == 0):
-      return
-
-    let parentModelIndex = newQModelIndex()
-    defer: parentModelIndex.delete
-
-    let first = self.items.len
-    let last = first + items.len - 1
-    self.beginInsertRows(parentModelIndex, first, last)
-    self.items.add(items)
-    self.endInsertRows()
-    self.countChanged()
-
-  proc addItem*(self: CuratedCommunityModel, item: CuratedCommunityItem) =
-    let parentModelIndex = newQModelIndex()
-    defer: parentModelIndex.delete
-    self.beginInsertRows(parentModelIndex, self.items.len, self.items.len)
-    self.items.add(item)
-    self.endInsertRows()
-    self.countChanged()
-
   proc containsItemWithId*(self: CuratedCommunityModel, id: string): bool =
     return self.findIndexById(id) != -1
 
@@ -111,4 +89,15 @@ QtObject:
     self.beginRemoveRows(parentModelIndex, ind, ind)
     self.items.delete(ind)
     self.endRemoveRows()
+    self.countChanged()
+
+
+  proc addItem*(self: CuratedCommunityModel, item: CuratedCommunityItem) =
+    self.removeItemWithId(item.getId())
+
+    let parentModelIndex = newQModelIndex()
+    defer: parentModelIndex.delete
+    self.beginInsertRows(parentModelIndex, self.items.len, self.items.len)
+    self.items.add(item)
+    self.endInsertRows()
     self.countChanged()

--- a/src/app/modules/main/communities/models/curated_community_model.nim
+++ b/src/app/modules/main/communities/models/curated_community_model.nim
@@ -112,13 +112,24 @@ QtObject:
     self.endRemoveRows()
     self.countChanged()
 
-
   proc addItem*(self: CuratedCommunityModel, item: CuratedCommunityItem) =
-    self.removeItemWithId(item.getId())
-
-    let parentModelIndex = newQModelIndex()
-    defer: parentModelIndex.delete
-    self.beginInsertRows(parentModelIndex, self.items.len, self.items.len)
-    self.items.add(item)
-    self.endInsertRows()
-    self.countChanged()
+    let idx = self.findIndexById(item.getId())
+    if idx > -1:
+      let index = self.createIndex(idx, 0, nil)
+      self.items[idx] = item
+      self.dataChanged(index, index, @[ModelRole.Name.int,
+                                       ModelRole.Available.int,
+                                       ModelRole.Description.int,
+                                       ModelRole.Icon.int,
+                                       ModelRole.Featured.int,
+                                       ModelRole.Members.int,
+                                       ModelRole.Color.int,
+                                       ModelRole.Popularity.int])
+    else:
+      let parentModelIndex = newQModelIndex()
+      defer: parentModelIndex.delete
+      self.beginInsertRows(parentModelIndex, self.items.len, self.items.len)
+      self.items.add(item)
+      self.endInsertRows()
+      self.countChanged()
+    

--- a/src/app/modules/main/communities/models/curated_community_model.nim
+++ b/src/app/modules/main/communities/models/curated_community_model.nim
@@ -7,6 +7,7 @@ type
     Available
     Name
     Description
+    Icon
 
 QtObject:
   type CuratedCommunityModel* = ref object of QAbstractListModel
@@ -45,7 +46,8 @@ QtObject:
       ModelRole.Id.int:"id",
       ModelRole.Name.int:"name",
       ModelRole.Available.int:"available",
-      ModelRole.Description.int:"description"
+      ModelRole.Description.int:"description",
+      ModelRole.Icon.int:"icon"
     }.toTable
 
   method data(self: CuratedCommunityModel, index: QModelIndex, role: int): QVariant =
@@ -55,7 +57,6 @@ QtObject:
       return
     let item = self.items[index.row]
     let enumRole = role.ModelRole
-
     case enumRole:
       of ModelRole.Id:
         result = newQVariant(item.getId())
@@ -65,6 +66,8 @@ QtObject:
         result = newQVariant(item.getDescription())
       of ModelRole.Available:
         result = newQVariant(item.isAvailable())
+      of ModelRole.Icon:
+        result = newQVariant(item.getIcon())
 
   proc findIndexById(self: CuratedCommunityModel, id: string): int =
     for i in 0 ..< self.items.len:

--- a/src/app/modules/main/communities/models/curated_community_model.nim
+++ b/src/app/modules/main/communities/models/curated_community_model.nim
@@ -8,6 +8,10 @@ type
     Name
     Description
     Icon
+    Featured
+    Members
+    Popularity
+    Color
 
 QtObject:
   type CuratedCommunityModel* = ref object of QAbstractListModel
@@ -47,7 +51,11 @@ QtObject:
       ModelRole.Name.int:"name",
       ModelRole.Available.int:"available",
       ModelRole.Description.int:"description",
-      ModelRole.Icon.int:"icon"
+      ModelRole.Icon.int:"icon",
+      ModelRole.Featured.int:"featured",
+      ModelRole.Members.int:"members",
+      ModelRole.Color.int:"color",
+      ModelRole.Popularity.int:"popularity"
     }.toTable
 
   method data(self: CuratedCommunityModel, index: QModelIndex, role: int): QVariant =
@@ -68,6 +76,19 @@ QtObject:
         result = newQVariant(item.isAvailable())
       of ModelRole.Icon:
         result = newQVariant(item.getIcon())
+      of ModelRole.Members:
+        result = newQVariant(item.getMembers())
+      of ModelRole.Color:
+        result = newQVariant(item.getColor())
+      of ModelRole.Popularity:
+        # TODO: replace this with a real value
+        result = newQVariant(index.row)
+      of ModelRole.Featured:
+        # TODO: replace this with a real value
+        var featured = false
+        if index.row < 3:
+          featured = true
+        result = newQVariant(featured)
 
   proc findIndexById(self: CuratedCommunityModel, id: string): int =
     for i in 0 ..< self.items.len:

--- a/src/app/modules/main/communities/module.nim
+++ b/src/app/modules/main/communities/module.nim
@@ -3,6 +3,8 @@ import NimQml, json, sequtils, sugar
 import ./io_interface
 import ../io_interface as delegate_interface
 import ./view, ./controller
+import ./models/curated_community_item
+import ./models/curated_community_model
 import ../../shared_models/section_item
 import ../../shared_models/[user_item, user_model, section_model]
 import ../../../global/global_singleton
@@ -29,6 +31,7 @@ type
 
 # Forward declaration
 method setAllCommunities*(self: Module, communities: seq[CommunityDto])
+method setCuratedCommunities*(self: Module, curatedCommunities: seq[CuratedCommunity])
 
 proc newModule*(
     delegate: delegate_interface.AccessInterface,
@@ -64,6 +67,7 @@ method viewDidLoad*(self: Module) =
   self.moduleLoaded = true
 
   self.setAllCommunities(self.controller.getAllCommunities())
+  self.setCuratedCommunities(self.controller.getCuratedCommunities())
 
   self.delegate.communitiesModuleDidLoad()
 
@@ -103,6 +107,13 @@ method getCommunityItem(self: Module, c: CommunityDto): SectionItem =
       historyArchiveSupportEnabled = c.settings.historyArchiveSupportEnabled
     )
 
+method getCuratedCommunityItem(self: Module, c: CuratedCommunity): CuratedCommunityItem =
+  return initCuratedCommunityItem(
+      c.communityId,
+      c.community.name,
+      c.community.description,
+      c.available)
+
 method setAllCommunities*(self: Module, communities: seq[CommunityDto]) =
   for community in communities:
     self.view.addItem(self.getCommunityItem(community))
@@ -116,6 +127,18 @@ method joinCommunity*(self: Module, communityId: string): string =
 method communityEdited*(self: Module, community: CommunityDto) =
   self.view.model().editItem(self.getCommunityItem(community))
   self.view.communityChanged(community.id)
+
+method setCuratedCommunities*(self: Module, curatedCommunities: seq[CuratedCommunity]) =
+  for community in curatedCommunities:
+    self.view.curatedCommunitiesModel().addItem(self.getCuratedCommunityItem(community))
+
+method curatedCommunityAdded*(self: Module, community: CuratedCommunity) =
+  self.view.curatedCommunitiesModel().addItem(self.getCuratedCommunityItem(community))
+
+method curatedCommunityEdited*(self: Module, community: CuratedCommunity) =
+  if self.view.curatedCommunitiesModel().containsItemWithId(community.communityId):
+    self.view.curatedCommunitiesModel().removeItemWithId(community.communityId)
+    self.view.curatedCommunitiesModel().addItem(self.getCuratedCommunityItem(community))
 
 method requestAdded*(self: Module) =
   # TODO to model or view

--- a/src/app/modules/main/communities/module.nim
+++ b/src/app/modules/main/communities/module.nim
@@ -112,7 +112,8 @@ method getCuratedCommunityItem(self: Module, c: CuratedCommunity): CuratedCommun
       c.communityId,
       c.community.name,
       c.community.description,
-      c.available)
+      c.available,
+      c.community.images.thumbnail)
 
 method setAllCommunities*(self: Module, communities: seq[CommunityDto]) =
   for community in communities:

--- a/src/app/modules/main/communities/module.nim
+++ b/src/app/modules/main/communities/module.nim
@@ -113,7 +113,9 @@ method getCuratedCommunityItem(self: Module, c: CuratedCommunity): CuratedCommun
       c.community.name,
       c.community.description,
       c.available,
-      c.community.images.thumbnail)
+      c.community.images.thumbnail,
+      c.community.color,
+      len(c.community.members))
 
 method setAllCommunities*(self: Module, communities: seq[CommunityDto]) =
   for community in communities:

--- a/src/app/modules/main/communities/module.nim
+++ b/src/app/modules/main/communities/module.nim
@@ -137,9 +137,7 @@ method curatedCommunityAdded*(self: Module, community: CuratedCommunity) =
   self.view.curatedCommunitiesModel().addItem(self.getCuratedCommunityItem(community))
 
 method curatedCommunityEdited*(self: Module, community: CuratedCommunity) =
-  if self.view.curatedCommunitiesModel().containsItemWithId(community.communityId):
-    self.view.curatedCommunitiesModel().removeItemWithId(community.communityId)
-    self.view.curatedCommunitiesModel().addItem(self.getCuratedCommunityItem(community))
+  self.view.curatedCommunitiesModel().addItem(self.getCuratedCommunityItem(community))
 
 method requestAdded*(self: Module) =
   # TODO to model or view

--- a/src/app/modules/main/communities/view.nim
+++ b/src/app/modules/main/communities/view.nim
@@ -4,6 +4,8 @@ import ./io_interface
 import ../../shared_models/section_model
 import ../../shared_models/section_item
 import ../../shared_models/active_section
+import ./models/curated_community_item
+import ./models/curated_community_model
 
 QtObject:
   type
@@ -12,11 +14,15 @@ QtObject:
       model: SectionModel
       modelVariant: QVariant
       observedItem: ActiveSection
+      curatedCommunitiesModel: CuratedCommunityModel
+      curatedCommunitiesModelVariant: QVariant
 
   proc delete*(self: View) =
     self.model.delete
     self.modelVariant.delete
     self.observedItem.delete
+    self.curatedCommunitiesModel.delete
+    self.curatedCommunitiesModelVariant.delete
     self.QObject.delete
 
   proc newView*(delegate: io_interface.AccessInterface): View =
@@ -25,6 +31,8 @@ QtObject:
     result.delegate = delegate
     result.model = newModel()
     result.modelVariant = newQVariant(result.model)
+    result.curatedCommunitiesModel = newCuratedCommunityModel()
+    result.curatedCommunitiesModelVariant = newQVariant(result.curatedCommunitiesModel)
     result.observedItem = newActiveSection()
 
   proc load*(self: View) =
@@ -45,6 +53,15 @@ QtObject:
 
   QtProperty[QVariant] model:
     read = getModel
+
+  proc curatedCommunitiesModel*(self: View): CuratedCommunityModel =
+    result = self.curatedCommunitiesModel
+
+  proc getCuratedCommunitiesModel(self: View): QVariant {.slot.} =
+    return self.curatedCommunitiesModelVariant
+
+  QtProperty[QVariant] curatedCommunities:
+    read = getCuratedCommunitiesModel
 
   proc observedItemChanged*(self:View) {.signal.}
 

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -288,7 +288,7 @@ method load*[T](
   hasNotification = false,
   notificationsCount = 0,
   active = false,
-  enabled = true) #singletonInstance.localAccountSensitiveSettings.getIsCommunitiesPortalEnabled())
+  enabled = singletonInstance.localAccountSensitiveSettings.getIsCommunitiesPortalEnabled())
   self.view.model().addItem(communitiesPortalSectionItem)
   if(activeSectionId == communitiesPortalSectionItem.id):
     activeSection = communitiesPortalSectionItem
@@ -524,6 +524,10 @@ method toggleSection*[T](self: Module[T], sectionType: SectionType) =
     let enabled = singletonInstance.localAccountSensitiveSettings.getNodeManagementEnabled()
     self.setSectionAvailability(sectionType, not enabled)
     singletonInstance.localAccountSensitiveSettings.setNodeManagementEnabled(not enabled)
+  elif (sectionType == SectionType.CommunitiesPortal):
+    let enabled = singletonInstance.localAccountSensitiveSettings.getIsCommunitiesPortalEnabled()
+    self.setSectionAvailability(sectionType, not enabled)
+    singletonInstance.localAccountSensitiveSettings.setIsCommunitiesPortalEnabled(not enabled)
 
 method setUserStatus*[T](self: Module[T], status: bool) =
   self.controller.setUserStatus(status)

--- a/src/app/modules/main/profile_section/advanced/controller.nim
+++ b/src/app/modules/main/profile_section/advanced/controller.nim
@@ -160,8 +160,8 @@ proc addCustomNetwork*(self: Controller, network: settings_service.Network) =
 
   self.delegate.onCustomNetworkAdded(network)
 
-#proc toggleCommunitiesPortalSection*(self: Controller) =
-#  self.events.emit(TOGGLE_SECTION, ToggleSectionArgs(sectionType: SectionType.CommunitiesPortal))
+proc toggleCommunitiesPortalSection*(self: Controller) =
+  self.events.emit(TOGGLE_SECTION, ToggleSectionArgs(sectionType: SectionType.CommunitiesPortal))
 
 proc toggleWalletSection*(self: Controller) =
   self.events.emit(TOGGLE_SECTION, ToggleSectionArgs(sectionType: SectionType.Wallet))

--- a/src/app/modules/main/profile_section/advanced/io_interface.nim
+++ b/src/app/modules/main/profile_section/advanced/io_interface.nim
@@ -99,8 +99,8 @@ method addCustomNetwork*(self: AccessInterface, name: string, endpoint: string, 
   {.slot.} =
   raise newException(ValueError, "No implementation available")
 
-#method toggleCommunitiesPortalSection*(self: AccessInterface) {.base.} =
-#  raise newException(ValueError, "No implementation available")
+method toggleCommunitiesPortalSection*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")
 
 method toggleWalletSection*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/profile_section/advanced/module.nim
+++ b/src/app/modules/main/profile_section/advanced/module.nim
@@ -156,6 +156,9 @@ method toggleBrowserSection*(self: Module) =
 method toggleCommunitySection*(self: Module) =
   self.controller.toggleCommunitySection()
 
+method toggleCommunitiesPortalSection*(self: Module) =
+  self.controller.toggleCommunitiesPortalSection()
+
 method toggleNodeManagementSection*(self: Module) =
   self.controller.toggleNodeManagementSection()
 

--- a/src/app/modules/main/profile_section/advanced/view.nim
+++ b/src/app/modules/main/profile_section/advanced/view.nim
@@ -169,3 +169,6 @@ QtObject:
 
   proc enableDeveloperFeatures*(self: View) {.slot.} =
     self.delegate.enableDeveloperFeatures()
+
+  proc toggleCommunitiesPortalSection*(self: View) {.slot.} =
+    self.delegate.toggleCommunitiesPortalSection()

--- a/src/app_service/common/network_constants.nim
+++ b/src/app_service/common/network_constants.nim
@@ -174,6 +174,19 @@ let NETWORKS* = %* [
     "isTest":  false,
     "layer":   2,
     "enabled": true,
+  },
+  {
+    "chainId": 69,
+    "chainName": "Optimistic Ethereum (Kovan)",
+    "rpcUrl": "https://kovan.optimism.io",
+    "blockExplorerUrl": "https://kovan-optimistic.etherscan.io/",
+    "iconUrl": "",
+    "nativeCurrencyName": "Ether",
+    "nativeCurrencySymbol": "ETH",
+    "nativeCurrencyDecimals": 18,
+    "isTest":  true,
+    "layer":   2,
+    "enabled": true,
   }
 ]
 

--- a/src/app_service/service/community/dto/community.nim
+++ b/src/app_service/service/community/dto/community.nim
@@ -66,6 +66,11 @@ type CommunityDto* = object
   settings*: CommunitySettingsDto
   adminSettings*: CommunityAdminSettingsDto
 
+type CuratedCommunity* = object
+    available*: bool
+    communityId*: string
+    community*: CommunityDto
+
 proc toCommunityAdminSettingsDto*(jsonObj: JsonNode): CommunityAdminSettingsDto =
   result = CommunityAdminSettingsDto()
   discard jsonObj.getProp("pinMessageAllMembersEnabled", result.pinMessageAllMembersEnabled)
@@ -133,6 +138,21 @@ proc parseCommunities*(response: RpcResponse[JsonNode]): seq[CommunityDto] =
   result = map(response.result.getElems(),
     proc(x: JsonNode): CommunityDto = x.toCommunityDto())
 
+proc parseCuratedCommunities*(response: RpcResponse[JsonNode]): seq[CuratedCommunity] =
+  if (response.result["communities"].kind == JObject):
+    for (communityId, communityJson) in response.result["communities"].pairs():
+      result.add(CuratedCommunity(
+        available: true,
+        communityId: communityId,
+        community: communityJson.toCommunityDto()
+      ))
+  if (response.result["unknownCommunities"].kind == JArray):
+    for communityId in response.result["unknownCommunities"].items():
+      result.add(CuratedCOmmunity(
+        available: false,
+        communityId: communityId.getStr()
+      ))
+  
 proc contains(arrayToSearch: seq[int], searched: int): bool =
   for element in arrayToSearch:
     if element == searched:

--- a/src/backend/communities.nim
+++ b/src/backend/communities.nim
@@ -8,6 +8,10 @@ proc getJoinedComunities*(): RpcResponse[JsonNode] {.raises: [Exception].} =
   let payload = %* []
   result = callPrivateRPC("joinedCommunities".prefix, payload)
 
+proc getCuratedCommunities*(): RpcResponse[JsonNode] {.raises: [Exception].} =
+  let payload = %* []
+  result = callPrivateRPC("curatedCommunities".prefix, payload)
+
 proc getAllCommunities*(): RpcResponse[JsonNode] {.raises: [Exception].} =
   result = callPrivateRPC("communities".prefix)
 

--- a/ui/app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml
+++ b/ui/app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml
@@ -87,6 +87,19 @@ ScrollView {
             }
         }
 
+        Row {
+            width: 1234
+            Text {
+                text: "CURATED COMMUNITY LIST ========="
+            }
+            Repeater {
+                model: root.communitiesStore.curatedCommunitiesModel
+                delegate:  Text {
+                    text: model.name + " " + model.description + " " + model.icon + " " + model.available
+                }
+            }
+        }
+
         // Tags definition - Now hidden - Out of scope
         // TODO: Replace by `StatusListItemTagRow`
         Row {

--- a/ui/app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml
+++ b/ui/app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml
@@ -92,10 +92,14 @@ ScrollView {
             Text {
                 text: "CURATED COMMUNITY LIST ========="
             }
-            Repeater {
-                model: root.communitiesStore.curatedCommunitiesModel
-                delegate:  Text {
-                    text: model.name + " " + model.description + " " + model.icon + " " + model.available
+            ColumnLayout {
+                Repeater {
+                    model: root.communitiesStore.curatedCommunitiesModel
+                    delegate:  Row {
+                        Text {
+                            text: model.name + " " + model.description + " " + model.icon + " " + model.available
+                        }
+                    }
                 }
             }
         }

--- a/ui/app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml
+++ b/ui/app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml
@@ -13,13 +13,11 @@ import "stores"
 ScrollView {
     id: root
 
-    property CommunitiesStore communitiesStore: CommunitiesStore {}        
+    property CommunitiesStore communitiesStore: CommunitiesStore {}
 
     QtObject {
         id: d
 
-        property ListModel featuredCommunitiesModel: root.communitiesStore.featuredCommunitiesModel
-        property ListModel popularCommunitiesModel: root.communitiesStore.popularCommunitiesModel
         property ListModel tagsModel: root.communitiesStore.tagsModel
 
         property string searchText: ""
@@ -87,23 +85,6 @@ ScrollView {
             }
         }
 
-        Row {
-            width: 1234
-            Text {
-                text: "CURATED COMMUNITY LIST ========="
-            }
-            ColumnLayout {
-                Repeater {
-                    model: root.communitiesStore.curatedCommunitiesModel
-                    delegate:  Row {
-                        Text {
-                            text: model.name + " " + model.description + " " + model.icon + " " + model.available
-                        }
-                    }
-                }
-            }
-        }
-
         // Tags definition - Now hidden - Out of scope
         // TODO: Replace by `StatusListItemTagRow`
         Row {
@@ -153,10 +134,11 @@ ScrollView {
             rowSpacing: Style.current.padding
 
             Repeater {
-                model: d.featuredCommunitiesModel
+                model: root.communitiesStore.curatedCommunitiesModel
                 delegate: StatusCommunityCard {
+                    visible: model.featured
                     locale: communitiesStore.locale
-                    communityId: model.communityId
+                    communityId: model.id
                     loaded: model.available
                     logo: model.icon
                     name: model.name
@@ -186,10 +168,11 @@ ScrollView {
             rowSpacing: Style.current.padding
 
             Repeater {
-                model: d.popularCommunitiesModel
+                model: root.communitiesStore.curatedCommunitiesModel
                 delegate: StatusCommunityCard {
+                    visible: !model.featured
                     locale: communitiesStore.locale
-                    communityId: model.communityId
+                    communityId: model.id
                     loaded: model.available
                     logo: model.icon
                     name: model.name

--- a/ui/app/AppLayouts/CommunitiesPortal/stores/CommunitiesStore.qml
+++ b/ui/app/AppLayouts/CommunitiesPortal/stores/CommunitiesStore.qml
@@ -6,7 +6,7 @@ QtObject {
 
     property var communitiesModuleInst: communitiesModule
     property var curatedCommunitiesModel: root.communitiesModuleInst.curatedCommunities
-    property var locale: appSettings.locale
+    property var locale: localAppSettings.locale
 
     // TODO: Could the backend provide directly 2 filtered models??
     //property var featuredCommunitiesModel: root.communitiesModuleInst.curatedFeaturedCommunities

--- a/ui/app/AppLayouts/CommunitiesPortal/stores/CommunitiesStore.qml
+++ b/ui/app/AppLayouts/CommunitiesPortal/stores/CommunitiesStore.qml
@@ -1,4 +1,5 @@
 import QtQuick 2.13
+import QtQml.Models 2.2
 
 QtObject {
     id: root
@@ -7,33 +8,13 @@ QtObject {
     property var curatedCommunitiesModel: root.communitiesModuleInst.curatedCommunities
     property var locale: appSettings.locale
 
-    property ListModel featuredCommunitiesModel: root.featuredTestCommunitiesModel //[]
-    property ListModel popularCommunitiesModel: root.popularTestCommunitiesModel //[]
-    property ListModel tagsModel: root.tagsTestModel
+    // TODO: Could the backend provide directly 2 filtered models??
+    //property var featuredCommunitiesModel: root.communitiesModuleInst.curatedFeaturedCommunities
+    //property var popularCommunitiesModel: root.communitiesModuleInst.curatedPopularCommunities
+    property ListModel tagsModel: ListModel {}//root.notionsTagsModel
 
-    function updateCommunitiesClassification() {
-        root.featuredCommunitiesModel.clear()
-        root.popularCommunitiesModel.clear()
-
-        if(root.curatedCommunitiesModel) {
-            for(var i = 0; i < root.curatedCommunitiesModel.count; i++) {
-                var entry = root.curatedCommunitiesModel.get(i)
-                if(entry.featured) {
-                    root.featuredCommunitiesModel.append(entry)
-                }
-                else {
-                    root.popularCommunitiesModel.append(entry)
-                }
-            }
-        }
-    }
-
-    // COMMENTED FOR TESTING:
-    //onCuratedCommunitiesModelChanged: { root.updateCommunitiesClassification() }
-
-    // Test models:
     // TO DO: Complete list can be added in backend or here: https://www.notion.so/Category-tags-339b2e699e7c4d36ab0608ab00b99111
-    property ListModel tagsTestModel : ListModel {
+    property ListModel notionsTagsModel : ListModel {
         ListElement { name: "gaming"; emoji: "🎮"}
         ListElement { name: "art"; emoji: "🖼️️"}
         ListElement { name: "crypto"; emoji: "💸"}
@@ -46,101 +27,5 @@ QtObject {
         ListElement { name: "food"; emoji: "🥑"}
         ListElement { name: "enviroment"; emoji: "☠️"}
         ListElement { name: "privacy"; emoji: "👻"}
-    }
-
-    property ListModel featuredTestCommunitiesModel : ListModel {
-        ListElement {
-            name: "CryptoKitties";
-            description: "A community of cat lovers, meow!";
-            icon: "../../../../imports/assets/png/collectibles/CryptoKitties.png";
-            members: 1000;
-            categories: [];
-            communityId: "1";
-            available: true;
-            popularity: 1
-        }
-        ListElement {
-            name: "Friends with Benefits";
-            description: "A group chat full of out favorite thinkers and creators.";
-            icon: "../../../../imports/assets/png/collectibles/FriendsBenefits.png";
-            members: 452;
-            categories: [];
-            communityId: "2";
-            available: true;
-            popularity: 2
-        }
-        ListElement {
-            name: "Teller";
-            description: "A community of P2P crypto trades";
-            icon: "../../../../imports/assets/png/collectibles/P2PCrypto.png";
-            members: 50;
-            categories: [];
-            communityId: "3";
-            available: true;
-            popularity: 3
-        }
-    }
-
-    property ListModel popularTestCommunitiesModel : ListModel {
-        ListElement {
-            name: "Status";
-            description: "Community description goes here.";
-            icon: "../../../../imports/assets/png/collectibles/SNT.png";
-            members: 5288;
-            categories: [];
-            communityId: "4";
-            available: true;
-            popularity: 4
-        }
-        ListElement {
-            name: "Status Punks";
-            description: "Community description goes here.";
-            icon: "../../../../imports/assets/png/collectibles/StatusPunks.png";
-            members: 4125;
-            categories: [];
-            communityId: "5";
-            available: false;
-            popularity: 5
-        }
-        ListElement {
-            name: "Uniswap";
-            description: "Community description goes here.";
-            icon: "../../../../imports/assets/png/collectibles/CryptoKitties.png";
-            members: 45;
-            categories: [];
-            communityId: "6";
-            available: false;
-            popularity: 6
-        }
-        ListElement {
-            name: "Dragonereum";
-            description: "Community description goes here.";
-            icon: "../../../../imports/assets/png/collectibles/Dragonerum.png";
-            members: 968;
-            categories: [];
-            communityId: "7";
-            available: true;
-            popularity: 7
-        }
-        ListElement {
-            name: "CryptoPunks";
-            description: "Community description goes here.";
-            icon: "../../../../imports/assets/png/collectibles/CryptoPunks.png";
-            members: 4200;
-            categories: [];
-            communityId: "8";
-            available: true;
-            popularity: 8
-        }
-        ListElement {
-            name: "Socks";
-            description: "Community description goes here.";
-            icon: "../../../../imports/assets/png/collectibles/Socks.png";
-            members: 12;
-            categories: [];
-            communityId: "9";
-            available: true;
-            popularity: 9
-        }
     }
 }

--- a/ui/app/AppLayouts/Profile/stores/AdvancedStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/AdvancedStore.qml
@@ -35,6 +35,7 @@ QtObject {
         readonly property string keycard: "keycard"
         readonly property string multiNetwork: "multiNetwork"
         readonly property string communityHistoryArchiveSupport: "communityHistoryArchiveSupport"
+        readonly property string communitiesPortal: "communitiesPortal"
     }
 
     function setGlobalNetworkId() {
@@ -130,6 +131,9 @@ QtObject {
         else if (feature === experimentalFeatures.communities) {
             advancedModule.toggleCommunitySection()
         }
+        else if (feature === experimentalFeatures.communitiesPortal) {
+            advancedModule.toggleCommunitiesPortalSection()
+        }
         else if (feature === experimentalFeatures.communityHistoryArchiveSupport) {
           // toggle history archive support
           advancedModule.toggleCommunityHistoryArchiveSupport()
@@ -152,5 +156,6 @@ QtObject {
         else if (feature === experimentalFeatures.multiNetwork) {
             localAccountSensitiveSettings.isMultiNetworkEnabled = !localAccountSensitiveSettings.isMultiNetworkEnabled
         }
+        
     }
 }

--- a/ui/app/AppLayouts/Profile/views/AdvancedView.qml
+++ b/ui/app/AppLayouts/Profile/views/AdvancedView.qml
@@ -246,6 +246,24 @@ SettingsContentBase {
                 }
             }
 
+            // TODO: replace with StatusQ component
+            StatusSettingsLineButton {
+                anchors.leftMargin: 0
+                anchors.rightMargin: 0
+                text: qsTr("Communities Portal")
+                isSwitch: true
+                switchChecked: localAccountSensitiveSettings.isCommunitiesPortalEnabled
+                onClicked: {
+                    if (localAccountSensitiveSettings.isCommunitiesPortalEnabled) {
+                        root.advancedStore.toggleExperimentalFeature(root.advancedStore.experimentalFeatures.communitiesPortal)
+                    } else {
+                        confirmationPopup.experimentalFeature = root.advancedStore.experimentalFeatures.communitiesPortal
+                        confirmationPopup.open()
+                    }
+                }
+            }
+
+
             StatusSectionHeadline {
                 anchors.left: parent.left
                 anchors.right: parent.right

--- a/ui/app/AppLayouts/stores/RootStore.qml
+++ b/ui/app/AppLayouts/stores/RootStore.qml
@@ -54,6 +54,8 @@ QtObject {
 
     property bool isMultiNetworkEnabled: localAccountSensitiveSettings.isMultiNetworkEnabled
 
+    property bool isCommunitiesPortalEnabled: localAccountSensitiveSettings.isCommunitiesPortalEnabled
+
     property var savedAddressesModel: walletSectionSavedAddresses.model
 
     function getEtherscanLink() {

--- a/ui/imports/shared/stores/RootStore.qml
+++ b/ui/imports/shared/stores/RootStore.qml
@@ -24,6 +24,7 @@ QtObject {
     property bool isGifWidgetEnabled: !!accountSensitiveSettings ? accountSensitiveSettings.isGifWidgetEnabled : false
     property bool isTenorWarningAccepted: !!accountSensitiveSettings ? accountSensitiveSettings.isTenorWarningAccepted : false
     property bool displayChatImages: !!accountSensitiveSettings ? accountSensitiveSettings.displayChatImages : false
+    property bool isCommunitiesPortalEnabled: !!accountSensitiveSettings ? accountSensitiveSettings.isCommunitiesPortalEnabled : false
 
     property string locale: !!appSettings ? appSettings.locale : ""
 //    property string signingPhrase: !!walletModelInst ? walletModelInst.utilsView.signingPhrase : ""


### PR DESCRIPTION
Requires:
- https://github.com/status-im/status-go/pull/2685

Adds a model with curated communities. To access it in QML: `communitiesModule.curatedCommunities`
The following attributes are available:
- `available`: indicates if the community info is available or not. (We should display a loading indicator or something if a commnity is not available)
- `name`
- `description`
- `id`