### PR TITLE
fix(@desktop/chat): Fix 1:1 chat

### DIFF
--- a/src/app_service/service/message/service.nim
+++ b/src/app_service/service/message/service.nim
@@ -169,7 +169,7 @@ QtObject:
 
     for msg in messages:
       if(msg.editedAt > 0):
-        let data = MessageEditedArgs(chatId: msg.chatId, message: msg)
+        let data = MessageEditedArgs(chatId: msg.localChatId, message: msg)
         self.events.emit(SIGNAL_MESSAGE_EDITED, data)
       if msg.responseTo.len > 0:
         messagesOneRepliedTo.add(msg.responseTo)
@@ -184,7 +184,7 @@ QtObject:
 
       var chatMessages: seq[MessageDto]
       for msg in messages:
-        if (msg.chatId == chats[i].id):
+        if (msg.localChatId == chats[i].id):
           chatMessages.add(msg)
       
       if chats[i].communityId.len == 0:


### PR DESCRIPTION
Fix #5858

### What does the PR do

Incoming messages and edited messages are shown correctly in 1:1 chat.
Previously, they showed up only after restarting the application.

### Affected areas

1:1 chat

### Screenshot of functionality

![image](https://user-images.githubusercontent.com/61889657/170009116-aca17790-73f6-4b0a-9851-fda3940d8f6a.png)

