### PR TITLE
fix(Communities): Open `#general` channel by default on creation

### DIFF
--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -602,6 +602,9 @@ method communityJoined*[T](
 
   if setActive:
     self.setActiveSection(communitySectionItem)
+    if(channelGroup.chats.len > 0):
+      let chatId = channelGroup.chats[0].id
+      self.channelGroupModules[community.id].setActiveItemSubItem(chatId, "")
 
 method communityLeft*[T](self: Module[T], communityId: string) =
   if(not self.channelGroupModules.contains(communityId)):


### PR DESCRIPTION
Closes: #5841

### What does the PR do

Open `#general` channel by default in community

### Affected areas

Main module

