### PR TITLE
fix(Settings/Messaging): Spacing is wrong between “System Default Browser” and separator

### DIFF
--- a/ui/app/AppLayouts/Profile/views/MessagingView.qml
+++ b/ui/app/AppLayouts/Profile/views/MessagingView.qml
@@ -27,7 +27,7 @@ SettingsContentBase {
 
     ColumnLayout {
         id: generalColumn
-        spacing: Constants.settingsSection.itemSpacing
+        spacing: 2 * Constants.settingsSection.itemSpacing
         width: root.contentWidth
 
         ButtonGroup {
@@ -118,14 +118,9 @@ SettingsContentBase {
                            )
         }
 
-        Item {
-            id: spacer1
-            Layout.fillWidth: true
-            Layout.preferredHeight: 6
-        }
-
         // SEE PROFILTE PICTURES FROM
         StatusBaseText {
+            Layout.topMargin: Constants.settingsSection.itemSpacing
             Layout.fillWidth: true
             Layout.leftMargin: Style.current.padding
             Layout.rightMargin: Style.current.padding
@@ -173,14 +168,9 @@ SettingsContentBase {
                            )
         }
 
-        Item {
-            id: spacer2
-            Layout.fillWidth: true
-            Layout.preferredHeight: 6
-        }
-
         // Open Message Links With
         StatusBaseText {
+            Layout.topMargin: Constants.settingsSection.itemSpacing
             Layout.fillWidth: true
             Layout.leftMargin: Style.current.padding
             Layout.rightMargin: Style.current.padding
@@ -202,6 +192,7 @@ SettingsContentBase {
         }
 
         SettingsRadioButton {
+            Layout.topMargin: Constants.settingsSection.itemSpacing / 2
             Layout.fillWidth: true
             Layout.leftMargin: Style.current.padding
             Layout.rightMargin: Style.current.padding
@@ -215,6 +206,7 @@ SettingsContentBase {
 
         Separator {
             id: separator1
+            Layout.topMargin: Constants.settingsSection.itemSpacing
             Layout.fillWidth: true
         }
 


### PR DESCRIPTION
Closes #5847

### What does the PR do

Improved spacing between elements in `MessagingView.qml`

Here figma reference file: https://www.figma.com/file/idUoxN7OIW2Jpp3PMJ1Rl8/%E2%9A%99%EF%B8%8F-Settings-%7C-Desktop?node-id=427%3A34461

### Affected areas

Settings / Messaging

### Screenshot of functionality
![Screenshot 2022-05-26 at 18 05 05](https://user-images.githubusercontent.com/97019400/170527846-29f5f692-1415-489b-bbe8-362abd19d13c.png)

