### PR TITLE
feat(chat): Add crow to admins in group chat

### DIFF
--- a/ui/app/AppLayouts/Chat/panels/UserListPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/UserListPanel.qml
@@ -67,6 +67,7 @@ Item {
             chatKey: model.id
             trustIndicator: model.trustIndicator
             isMutualContact: model.isMutualContact
+            isAdmin: model.isAdmin
             image.source: {
                 if ((!model.isAdded &&
                     Global.privacyModuleInst.profilePicturesVisibility !==


### PR DESCRIPTION
Closes: #5897

### What does the PR do

Add crown to admins

### Affected areas

Members in chat view

### Screenshot of functionality

<img width="1315" alt="Снимок экрана 2022-05-30 в 12 59 59" src="https://user-images.githubusercontent.com/82511785/170969120-73e0b956-94e3-4713-ac19-f2669819535f.png">

