### PR TITLE
fix(Communities): Fix import community without chats

### DIFF
--- a/src/app_service/service/community/service.nim
+++ b/src/app_service/service/community/service.nim
@@ -932,19 +932,17 @@ QtObject:
       if(communitiesSettingsJArr.len == 0):
         raise newException(RpcException, fmt"`communitiesSettings` array is empty in the response for community id: {communityKey}")
 
-      var chatsJArr: JsonNode
-      if(not response.result.getProp("chats", chatsJArr)):
-        raise newException(RpcException, fmt"there is no `chats` key in the response for community id: {communityKey}")
-
       var communityDto = communityJArr[0].toCommunityDto()
       let communitySettingsDto = communitiesSettingsJArr[0].toCommunitySettingsDto()
 
       communityDto.settings = communitySettingsDto
       self.joinedCommunities[communityDto.id] = communityDto
 
-      for chatObj in chatsJArr:
-        let chatDto = chatObj.toChatDto(communityDto.id)
-        self.chatService.updateOrAddChat(chatDto) # we have to update chats stored in the chat service.
+      var chatsJArr: JsonNode
+      if(response.result.getProp("chats", chatsJArr)):
+        for chatObj in chatsJArr:
+          let chatDto = chatObj.toChatDto(communityDto.id)
+          self.chatService.updateOrAddChat(chatDto) # we have to update chats stored in the chat service.
 
       for chat in communityDto.chats:
         let fullChatId = communityDto.id & chat.id


### PR DESCRIPTION
Closes: #5818

### What does the PR do

Add possibility to import community without chats
should be merged after [status-go PR](https://github.com/status-im/status-go/pull/2694). Otherwise, after import app stuck on login.

### Affected areas

Communities

