### PR TITLE
fix(@wallet): send modal in browser/wallet

### DIFF
--- a/src/app/modules/main/browser_section/current_account/module.nim
+++ b/src/app/modules/main/browser_section/current_account/module.nim
@@ -41,8 +41,6 @@ method delete*(self: Module) =
 proc setAssets(self: Module, tokens: seq[WalletTokenDto]) =
   var items: seq[Item]
   for t in tokens:
-    if(t.totalBalance.balance == 0):
-      continue
     let item = token_item.initItem(t.name, t.symbol, t.totalBalance.balance, t.address, t.totalBalance.currencyBalance)
     items.add(item)
     

--- a/src/app/modules/main/wallet_section/current_account/module.nim
+++ b/src/app/modules/main/wallet_section/current_account/module.nim
@@ -72,8 +72,6 @@ proc setAssetsAndBalance(self: Module, tokens: seq[WalletTokenDto]) =
   var totalCurrencyBalanceForAllAssets = 0.0
   var items: seq[Item]
   for t in tokens:
-    if(t.totalBalance.balance == 0):
-      continue
     let item = token_item.initItem(t.name, t.symbol, t.totalBalance.balance, t.address, t.totalBalance.currencyBalance)
     items.add(item)
     totalCurrencyBalanceForAllAssets += t.totalBalance.currencyBalance

--- a/ui/imports/shared/controls/AssetDelegate.qml
+++ b/ui/imports/shared/controls/AssetDelegate.qml
@@ -12,8 +12,11 @@ Item {
     property string currency: ""
 
     anchors.right: parent.right
+
     anchors.left: parent.left
-    height: 40
+    visible: balance > 0
+    height: visible ? 40 + 2 * Style.current.padding : 0
+
 
     Image {
         id: assetInfoImage
@@ -41,8 +44,7 @@ Item {
     StyledText {
         id: assetFullTokenName
         text: name
-        anchors.bottom: parent.bottom
-        anchors.bottomMargin: 0
+        anchors.top: assetSymbol.bottom
         anchors.left: assetInfoImage.right
         anchors.leftMargin: Style.current.smallPadding
         color: Style.current.secondaryText
@@ -51,6 +53,8 @@ Item {
     StyledText {
         id: assetBalance
         text: Utils.toLocaleString(balance, locale) + " " + symbol.toUpperCase()
+        anchors.top: assetInfoImage.top
+        anchors.topMargin: 0
         anchors.right: parent.right
         anchors.rightMargin: 0
         font.pixelSize: 15
@@ -62,8 +66,7 @@ Item {
         text: Utils.toLocaleString(currencyBalance.toFixed(2), locale) + " " + assetDelegate.currency.toUpperCase()
         anchors.right: parent.right
         anchors.rightMargin: 0
-        anchors.bottom: parent.bottom
-        anchors.bottomMargin: 0
+        anchors.top: assetBalance.bottom
         font.pixelSize: 15
     }
 }

--- a/ui/imports/shared/views/AssetsView.qml
+++ b/ui/imports/shared/views/AssetsView.qml
@@ -22,7 +22,6 @@ Item {
 
         ListView {
             id: assetListView
-            spacing: Style.current.padding * 2
             anchors.fill: parent
             model: account.assets
             delegate: AssetDelegate {


### PR DESCRIPTION
fixes #5937

The send modal reuse the asset list so it needs to be fully populated
with all token, but the token is only visible if the balance > 0

