### PR TITLE
fix(CreateChatView): icon color was not correct

### DIFF
--- a/ui/app/AppLayouts/Chat/views/CreateChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/CreateChatView.qml
@@ -114,6 +114,9 @@ Page {
             compressedKeyGetter: function(pubKey) {
                 return Utils.getCompressedPk(pubKey);
             }
+            colorIdForPubkeyGetter: function (pubKey) {
+                return Utils.colorIdForPubkey(pubKey);
+            }
             onTextChanged: {
                 sortModel(root.contactsModel);
             }


### PR DESCRIPTION
Closes #5875

Depends on: https://github.com/status-im/StatusQ/pull/702

### What does the PR do
Fixed icon color was not correct in create chat view contacts list

### Affected areas
Create chat view contacts list

### Screenshot of functionality
<img width="1002" alt="mem" src="https://user-images.githubusercontent.com/31625338/171158633-7bb9109f-439f-43e9-9bcb-6ede44b381ec.png">

