### PR TITLE
refactor: always request access to join community

### DIFF
--- a/src/app/modules/main/communities/view.nim
+++ b/src/app/modules/main/communities/view.nim
@@ -90,8 +90,10 @@ QtObject:
     self.observedItem.setActiveSectionData(item)
     self.observedItemChanged()
 
-  proc joinCommunity*(self: View, communityId: string): string {.slot.} =
-    result = self.delegate.joinCommunity(communityId)
+  proc joinCommunity*(self: View, communityId: string, ensName: string) {.slot.} =
+    # Users always have to request to join a community but might 
+    # get automatically accepted.
+    self.delegate.requestToJoinCommunity(communityId, ensName)
 
   proc createCommunity*(self: View, name: string,
                         description: string, introMessage: string, outroMessage: string,

--- a/src/app_service/service/community/service.nim
+++ b/src/app_service/service/community/service.nim
@@ -1072,11 +1072,13 @@ QtObject:
       var pubKeys: seq[string] = @[]
       for pubKey in pubKeysParsed:
         pubKeys.add(pubKey.getStr)
-      let response =  status_go.inviteUsersToCommunity(communityId, pubKeys)
+      # We no longer send invites, but merely share the community so 
+      # users can request access (with automatic acception)
+      let response =  status_go.shareCommunityToUsers(communityId, pubKeys)
       discard self.chatService.processMessageUpdateAfterSend(response)
     except Exception as e:
-      error "Error inviting to community", msg = e.msg
-      result = "Error exporting community: " & e.msg
+      error "Error sharing community", msg = e.msg
+      result = "Error sharing community: " & e.msg
 
   proc muteCategory*(self: Service, communityId: string, categoryId: string) =
     try:

--- a/src/backend/communities.nim
+++ b/src/backend/communities.nim
@@ -268,5 +268,11 @@ proc inviteUsersToCommunity*(communityId: string, pubKeys: seq[string]): RpcResp
     "users": pubKeys
   }])
 
+proc shareCommunityToUsers*(communityId: string, pubKeys: seq[string]): RpcResponse[JsonNode] {.raises: [Exception].} =
+  return callPrivateRPC("shareCommunity".prefix, %*[{
+    "communityId": communityId,
+    "users": pubKeys
+  }])
+
 proc getCommunitiesSettings*(): RpcResponse[JsonNode] {.raises: [Exception].} =
   return callPrivateRPC("getCommunitiesSettings".prefix, %*[])

--- a/ui/app/AppLayouts/Chat/popups/community/CommunityDetailPopup.qml
+++ b/ui/app/AppLayouts/Chat/popups/community/CommunityDetailPopup.qml
@@ -202,7 +202,7 @@ StatusModal {
                 //        text = qsTr("Pending")
                 //    }
                } else {
-                   error = root.store.communitiesModuleInst.joinCommunity(root.communityId)
+                   error = root.store.communitiesModuleInst.joinCommunity(root.communityId, root.store.userProfileInst.ensName)
                }
 
                if (error) {

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -341,8 +341,8 @@ QtObject {
         chatCommunitySectionModule.reorderCommunityChat(categoryId, chatId, to)
     }
 
-    function joinCommunity(id) {
-        return communitiesModuleInst.joinCommunity(id)
+    function joinCommunity(id, ensName) {
+        return communitiesModuleInst.joinCommunity(id, ensName)
     }
 
     function requestToJoinCommunity(id, ensName) {
@@ -423,7 +423,7 @@ QtObject {
                 const userCanJoin = userCanJoin(communityId)
                 // TODO find what to do when you can't join
                 if (userCanJoin) {
-                    joinCommunity(communityId, true)
+                    joinCommunity(communityId, userProfileInst.ensName)
                 }
             }
             return result

--- a/ui/imports/shared/views/chat/InvitationBubbleView.qml
+++ b/ui/imports/shared/views/chat/InvitationBubbleView.qml
@@ -262,7 +262,7 @@ Item {
                                 }
                                 if (rectangleBubble.state === "unjoined") {
                                     Global.openPopup(communityIntroDialog, { joinMethod: () => {
-                                                                let error = root.store.joinCommunity(communityId)
+                                                                let error = root.store.joinCommunity(communityId, userProfile.name)
                                                                 if (error) joiningError.showError(error)
                                                             } });
                                 }


### PR DESCRIPTION
We no longer send community invites to users, instead we just share the
community and let users request access.

That request will either be automatically or manually accepted by the owner/admin.

Depends on https://github.com/status-im/status-go/pull/2682

Closes #5115