### PR TITLE
fix(ContactPanel): updated right button colors when hovered

### DIFF
--- a/ui/app/AppLayouts/Profile/panels/ContactPanel.qml
+++ b/ui/app/AppLayouts/Profile/panels/ContactPanel.qml
@@ -53,7 +53,7 @@ StatusListItem {
             width: visible ? 32 : 0
             height: visible ? 32 : 0
             icon.name: "chat"
-            type: StatusFlatRoundButton.Type.Secondary
+            icon.color: Theme.palette.directColor1
             onClicked: container.sendMessageActionTriggered(container.publicKey)
         },
         StatusFlatRoundButton {
@@ -100,7 +100,7 @@ StatusListItem {
             width: 32
             height: 32
             icon.name: "more"
-            type: StatusFlatRoundButton.Type.Secondary
+            icon.color: Theme.palette.directColor1
             onClicked: {
                 highlighted = true
                 contactContextMenu.popup(-contactContextMenu.width+menuButton.width, menuButton.height + 4)


### PR DESCRIPTION
Closes #5246

### What does the PR do
Updates right buttons colors when those are hovered

### Affected areas
Contacts Panel

### Screenshot of functionality
<img width="188" alt="1" src="https://user-images.githubusercontent.com/31625338/171170794-f686cb6d-8e1b-4c8f-9c3d-363872fa72d1.png">
<img width="108" alt="2" src="https://user-images.githubusercontent.com/31625338/171170821-8efc272b-a588-44ea-aa77-cac4bb95f149.png">

