### PR TITLE
fix(ChatInput): Mentions have very bad color/contrast ratio in dark mode

### DIFF
--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -302,7 +302,7 @@ QtObject {
     readonly property var acceptedImageExtensions: [".png", ".jpg", ".jpeg", ".svg", ".gif"]
     readonly property var acceptedDragNDropImageExtensions: [".png", ".jpg", ".jpeg", ".heif", "tif", ".tiff"]
 
-    readonly property string mentionSpanTag: `<span style="color:${Style.current.mentionColor}; background-color: ${Style.current.mentionBgColor};"><a style="text-decoration:none" href='http://'>`
+    readonly property string mentionSpanTag: `<span style="background-color: ${Style.current.mentionBgColor};"><a style="color:${Style.current.mentionColor};text-decoration:none" href='http://'>`
 
     readonly property string ens_taken: "taken"
     readonly property string ens_taken_custom: "taken-custom"


### PR DESCRIPTION
Fixes #5877

### What does the PR do

Modified color text into the corresponding tag.

### Affected areas

Chat Input / Mentions color in dark mode

### Screenshot of functionality

https://user-images.githubusercontent.com/97019400/171430634-8892141a-3396-4dcf-b744-8d90cb3f1432.mov
