### PR TITLE
fix(Chat): Messages with GIF not display the url

### DIFF
--- a/ui/app/AppLayouts/Profile/views/EnsListView.qml
+++ b/ui/app/AppLayouts/Profile/views/EnsListView.qml
@@ -318,6 +318,7 @@ Item {
 
                 ChatTextView {
                     id: chatText
+                    message: root.message
                     anchors.top: parent.top
                     anchors.topMargin: chatBox.chatVerticalPadding
                     anchors.left: parent.left

--- a/ui/imports/shared/views/chat/ChatTextView.qml
+++ b/ui/imports/shared/views/chat/ChatTextView.qml
@@ -11,6 +11,7 @@ import StatusQ.Core.Utils 0.1 as StatusQUtils
 Item {
     id: root
 
+    property string message: ""
     property var store
     property bool longChatText: true
     property bool veryLongChatText: globalUtils.plainText(message).length > Constants.limitLongChatTextCompactMode

--- a/ui/imports/shared/views/chat/CompactMessageView.qml
+++ b/ui/imports/shared/views/chat/CompactMessageView.qml
@@ -64,6 +64,8 @@ Item {
     property bool editModeOn: false
     property string linkUrls: ""
 
+    property string message: ""
+
     property var transactionParams
 
     signal openStickerPackPopup(string stickerPackId)
@@ -513,6 +515,7 @@ Item {
                 readonly property int leftPadding: chatImage.anchors.leftMargin + chatImage.width + chatHorizontalPadding
                 visible: isText || isEmoji || isImage
 
+                message: Utils.removeGifUrls(root.message)
                 anchors.top: parent.top
                 anchors.topMargin: isEmoji ? 2 : 0
                 anchors.left: parent.left

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -334,6 +334,7 @@ Column {
         CompactMessageView {
             container: root
             store: root.store
+            message: root.message
             messageStore: root.messageStore
             usersStore: root.usersStore
             contactsStore: root.contactsStore

--- a/ui/imports/utils/Utils.qml
+++ b/ui/imports/utils/Utils.qml
@@ -542,6 +542,10 @@ QtObject {
         return Constants.acceptedImageExtensions.some(ext => url.toLowerCase().includes(ext))
     }
 
+    function removeGifUrls(message) {
+        return message.replace(/(?:https?|ftp):\/\/[\n\S]*(\.gif)+/gm, '');
+    }
+
     function hasDragNDropImageExtension(url) {
         return Constants.acceptedDragNDropImageExtensions.some(ext => url.toLowerCase().includes(ext))
     }


### PR DESCRIPTION
Closes: #6005

### What does the PR do

Removing displaying urls from messages with gif's

### Affected areas

Chat

### Screenshot of functionality

<img width="1316" alt="Снимок экрана 2022-06-07 в 17 47 07" src="https://user-images.githubusercontent.com/82511785/172411062-3268cd4c-50e6-412f-bea7-200659ca485c.png">

