### PR TITLE
fix(StatusChatInput): Fix emoji button click arguments

### DIFF
--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -1138,7 +1138,7 @@ Rectangle {
             Shortcut {
                 enabled: messageInputField.activeFocus
                 sequence: "Ctrl+Meta+Space"
-                onActivated: emojiBtn.clicked()
+                onActivated: emojiBtn.clicked(null)
             }
 
         }


### PR DESCRIPTION
Closes: #3565

Unfortunately, seems like standard Mac OS emoji popup shortcut not fixed in current Qt version. But I fix opening our emoji popup.

### What does the PR do

Fix `click` call for emoji shortcut

