### PR TITLE
fix(@desktop/wallet): Wallet balance is 0 when enabling multinetwork toggle

### DIFF
--- a/src/app/modules/main/wallet_section/accounts/module.nim
+++ b/src/app/modules/main/wallet_section/accounts/module.nim
@@ -95,6 +95,9 @@ method load*(self: Module) =
     var args = DerivedAddressesArgs(e)
     self.view.setDerivedAddresses(args.derivedAddresses, args.error)
 
+  self.events.on(SIGNAL_WALLET_ACCOUNT_TOKENS_REBUILT) do(e:Args):
+    self.refreshWalletAccounts()
+
   self.controller.init()
   self.view.load()
 

--- a/src/app/modules/main/wallet_section/module.nim
+++ b/src/app/modules/main/wallet_section/module.nim
@@ -110,6 +110,8 @@ method load*(self: Module) =
     self.setTotalCurrencyBalance()
   self.events.on(SIGNAL_WALLET_ACCOUNT_NETWORK_ENABLED_UPDATED) do(e:Args):
     self.setTotalCurrencyBalance()
+  self.events.on(SIGNAL_WALLET_ACCOUNT_TOKENS_REBUILT) do(e:Args):
+    self.setTotalCurrencyBalance()
 
   self.controller.init()
   self.view.load()


### PR DESCRIPTION

fixes #6013 

### What does the PR do

Refresh account list and total currency when tokens are retrieved

### Affected areas

Wallet

### Screenshot of functionality


https://user-images.githubusercontent.com/60327365/172840764-390e9e44-b036-446e-baea-9bf8b4181f45.mov


