### PR TITLE
feat(@desktop/general): Change user statuses

### DIFF
--- a/src/app/boot/app_controller.nim
+++ b/src/app/boot/app_controller.nim
@@ -362,9 +362,7 @@ proc buildAndRegisterUserProfile(self: AppController) =
   var displayName = self.settingsService.getDisplayName()
   let ensUsernames = self.settingsService.getEnsUsernames()
   let firstEnsName = if (ensUsernames.len > 0): ensUsernames[0] else: ""
-  let sendUserStatus = self.settingsService.getSendStatusUpdates()
-  ## This is still not in use. Read a comment in UserProfile.
-  ## let currentUserStatus = self.settingsService.getCurrentUserStatus()
+  let currentUserStatus = self.settingsService.getCurrentUserStatus()
 
   let loggedInAccount = self.accountsService.getLoggedInAccount()
   var thumbnail, large: string
@@ -386,6 +384,6 @@ proc buildAndRegisterUserProfile(self: AppController) =
   singletonInstance.userProfile.setFirstEnsName(firstEnsName)
   singletonInstance.userProfile.setThumbnailImage(thumbnail)
   singletonInstance.userProfile.setLargeImage(large)
-  singletonInstance.userProfile.setUserStatus(sendUserStatus)
+  singletonInstance.userProfile.setCurrentUserStatus(currentUserStatus.statusType.int)
 
   singletonInstance.engine.setRootContextProperty("userProfile", self.userProfileVariant)

--- a/src/app/global/user_profile.nim
+++ b/src/app/global/user_profile.nim
@@ -15,8 +15,7 @@ QtObject:
     preferredName: string
     thumbnailImage: string
     largeImage: string
-    userStatus: bool
-    #currentUserStatus: int
+    currentUserStatus: int
 
   proc setup(self: UserProfile) =
     self.QObject.setup
@@ -183,50 +182,18 @@ QtObject:
     read = getLargeImage
     notify = largeImageChanged
 
+  proc currentUserStatusChanged*(self: UserProfile) {.signal.}
 
-  proc userStatusChanged*(self: UserProfile) {.signal.}
-
-  proc getUserStatus*(self: UserProfile): bool {.slot.} =
-    self.userStatus
+  proc getCurrentUserStatus*(self: UserProfile): int {.slot.} =
+    self.currentUserStatus
 
   # this is not a slot
-  proc setUserStatus*(self: UserProfile, status: bool) =
-    if(self.userStatus == status):
+  proc setCurrentUserStatus*(self: UserProfile, status: int) =
+    if(self.currentUserStatus == status):
       return
-    self.userStatus = status
-    self.userStatusChanged()
+    self.currentUserStatus = status
+    self.currentUserStatusChanged()
 
-  QtProperty[bool] userStatus:
-    read = getUserStatus
-    notify = userStatusChanged
-
-
-  ## This is still not in use.
-  ## Once we decide to differ more than Online/Offline statuses we shouldn't use this code below,
-  ## but update current `userStatus` which is a bool to something like the code bellow (`currentUserStatus`).
-  ##
-  ## Proposal - some statuses we may have:
-  ## type
-  ##   OnlineStatus* {.pure.} = enum
-  ##     Online = 0
-  ##     Idle
-  ##     DoNotDisturb
-  ##     Invisible
-  ##     Offline
-  ##
-  ##
-  ## proc currentUserStatusChanged*(self: UserProfile) {.signal.}
-
-  ## proc getCurrentUserStatus*(self: UserProfile): int {.slot.} =
-  ##   self.currentUserStatus
-
-  ## # this is not a slot
-  ## proc setCurrentUserStatus*(self: UserProfile, status: int) =
-  ##   if(self.currentUserStatus == status):
-  ##     return
-  ##   self.currentUserStatus = status
-  ##   self.currentUserStatusChanged()
-
-  ## QtProperty[int] currentUserStatus:
-  ##   read = getCurrentUserStatus
-  ##   notify = currentUserStatusChanged
+  QtProperty[int] currentUserStatus:
+    read = getCurrentUserStatus
+    notify = currentUserStatusChanged

--- a/src/app/modules/main/communities/controller.nim
+++ b/src/app/modules/main/communities/controller.nim
@@ -151,3 +151,6 @@ proc userCanJoin*(self: Controller, communityId: string): bool =
 
 proc isCommunityRequestPending*(self: Controller, communityId: string): bool =
   return self.communityService.isCommunityRequestPending(communityId)
+
+proc getStatusForContactWithId*(self: Controller, publicKey: string): StatusUpdateDto =
+  return self.contactsService.getStatusForContactWithId(publicKey)

--- a/src/app/modules/main/communities/module.nim
+++ b/src/app/modules/main/communities/module.nim
@@ -107,7 +107,7 @@ method getCommunityItem(self: Module, c: CommunityDto): SectionItem =
           localNickname = contactDetails.details.localNickname,
           alias = contactDetails.details.alias,
           icon = contactDetails.icon,
-          onlineStatus = OnlineStatus.Offline, # TODO get the actual status?
+          onlineStatus = toOnlineStatus(self.controller.getStatusForContactWithId(member.id).statusType),
           isContact = contactDetails.details.added, # FIXME
           )),
       historyArchiveSupportEnabled = c.settings.historyArchiveSupportEnabled

--- a/src/app/modules/main/controller.nim
+++ b/src/app/modules/main/controller.nim
@@ -2,9 +2,10 @@ import ../shared_models/section_item, io_interface, chronicles
 import ../../global/app_sections_config as conf
 import ../../global/global_singleton
 import ../../global/app_signals
-import ../../core/signals/types
+import ../../core/signals/types as signal_types
 import ../../core/eventemitter
 import ../../core/notifications/notifications_manager
+import ../../../app_service/common/types
 import ../../../app_service/service/settings/service as settings_service
 import ../../../app_service/service/keychain/service as keychain_service
 import ../../../app_service/service/accounts/service as accounts_service
@@ -205,10 +206,7 @@ proc init*(self: Controller) =
 
   self.events.on(SIGNAL_CURRENT_USER_STATUS_UPDATED) do (e: Args):
     var args = CurrentUserStatusArgs(e)
-    var status = true
-    if args.statusType == StatusType.Invisible:
-      status = false
-    singletonInstance.userProfile.setUserStatus(status)
+    singletonInstance.userProfile.setCurrentUserStatus(args.statusType.int)
 
 proc isConnected*(self: Controller): bool =
   return self.nodeService.isConnected()
@@ -272,9 +270,10 @@ proc getNumOfNotificationsForCommunity*(self: Controller, communityId: string): 
     result.unviewed += chat.unviewedMessagesCount
     result.mentions += chat.unviewedMentionsCount
 
-proc setUserStatus*(self: Controller, status: bool) =
+proc setCurrentUserStatus*(self: Controller, status: StatusType) =
   if(self.settingsService.saveSendStatusUpdates(status)):
-    singletonInstance.userProfile.setUserStatus(status)
+    singletonInstance.userProfile.setCurrentUserStatus(status.int)
+    self.contactsService.emitCurrentUserStatusChanged(self.settingsService.getCurrentUserStatus())
   else:
     error "error updating user status"
 
@@ -303,3 +302,6 @@ proc switchTo*(self: Controller, sectionId, chatId, messageId: string) =
 
 proc getCommunityById*(self: Controller, communityId: string): CommunityDto =
   return self.communityService.getCommunityById(communityId)
+
+proc getStatusForContactWithId*(self: Controller, publicKey: string): StatusUpdateDto =
+  return self.contactsService.getStatusForContactWithId(publicKey)

--- a/src/app/modules/main/io_interface.nim
+++ b/src/app/modules/main/io_interface.nim
@@ -7,12 +7,12 @@ import ../../../app_service/service/community/service as community_service
 import ../../../app_service/service/message/service as message_service
 import ../../../app_service/service/gif/service as gif_service
 import ../../../app_service/service/mailservers/service as mailservers_service
+from ../../../app_service/common/types import StatusType
 
 import ../../global/app_signals
 import ../../core/eventemitter
 import ../../core/notifications/details
 import ../shared_models/section_item
-import chat_search_item
 
 type
   AccessInterface* {.pure inheritable.} = ref object of RootObj
@@ -162,7 +162,7 @@ method storePassword*(self: AccessInterface, password: string) {.base.} =
 method setActiveSection*(self: AccessInterface, item: SectionItem) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method setUserStatus*(self: AccessInterface, status: bool) {.base.} =
+method setCurrentUserStatus*(self: AccessInterface, status: StatusType) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method getChatSectionModuleAsVariant*(self: AccessInterface): QVariant {.base.} =

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -51,6 +51,7 @@ import ../../../app_service/service/gif/service as gif_service
 import ../../../app_service/service/ens/service as ens_service
 import ../../../app_service/service/network/service as network_service
 import ../../../app_service/service/general/service as general_service
+from ../../../app_service/common/types import StatusType
 
 import ../../core/notifications/details
 import ../../core/eventemitter
@@ -231,7 +232,7 @@ proc createChannelGroupItem[T](self: Module[T], c: ChannelGroupDto): SectionItem
         localNickname = contactDetails.details.localNickname,
         alias = contactDetails.details.alias,
         icon = contactDetails.icon,
-        onlineStatus = OnlineStatus.Offline,
+        onlineStatus = toOnlineStatus(self.controller.getStatusForContactWithId(member.id).statusType),
         isContact = contactDetails.details.added # FIXME
         )),
     if (isCommunity): communityDetails.pendingRequestsToJoin.map(x => pending_request_item.initItem(
@@ -542,8 +543,8 @@ method toggleSection*[T](self: Module[T], sectionType: SectionType) =
     self.setSectionAvailability(sectionType, not enabled)
     singletonInstance.localAccountSensitiveSettings.setNodeManagementEnabled(not enabled)
 
-method setUserStatus*[T](self: Module[T], status: bool) =
-  self.controller.setUserStatus(status)
+method setCurrentUserStatus*[T](self: Module[T], status: StatusType) =
+  self.controller.setCurrentUserStatus(status)
 
 proc getChatSectionModule*[T](self: Module[T]): chat_section_module.AccessInterface =
   return self.channelGroupModules[singletonInstance.userProfile.getPubKey()]

--- a/src/app/modules/main/view.nim
+++ b/src/app/modules/main/view.nim
@@ -5,6 +5,8 @@ import ../shared_models/active_section
 import io_interface
 import chat_search_model
 import ephemeral_notification_model
+from ../../../app_service/common/conversion import intToEnum
+from ../../../app_service/common/types import StatusType
 
 QtObject:
   type
@@ -153,8 +155,8 @@ QtObject:
   proc switchTo*(self: View, sectionId: string, chatId: string) {.slot.} =
     self.delegate.switchTo(sectionId, chatId)
 
-  proc setUserStatus*(self: View, status: bool) {.slot.} =
-    self.delegate.setUserStatus(status)
+  proc setCurrentUserStatus*(self: View, status: int) {.slot.} =
+    self.delegate.setCurrentUserStatus(intToEnum(status, StatusType.Unknown))
 
   # Since we cannot return QVariant from the proc which has arguments, so cannot have proc like this:
   # prepareCommunitySectionModuleForCommunityId(self: View, communityId: string): QVariant {.slot.}

--- a/src/app/modules/shared_models/member_item.nim
+++ b/src/app/modules/shared_models/member_item.nim
@@ -18,7 +18,7 @@ proc initMemberItem*(
   icon: string,
   colorId: int = 0,
   colorHash: string = "",
-  onlineStatus: OnlineStatus = OnlineStatus.Offline,
+  onlineStatus: OnlineStatus = OnlineStatus.Inactive,
   isContact: bool = false,
   isVerified: bool = false,
   isUntrustworthy: bool = false,

--- a/src/app/modules/shared_models/member_model.nim
+++ b/src/app/modules/shared_models/member_model.nim
@@ -141,7 +141,7 @@ QtObject:
     # if we add an item with offline status we add it as the first offline item (after the last online item)
     var position = -1
     for i in 0 ..< self.items.len:
-      if(self.items[i].onlineStatus == OnlineStatus.Offline):
+      if(self.items[i].onlineStatus == OnlineStatus.Inactive):
         position = i
         break
 

--- a/src/app/modules/shared_models/user_item.nim
+++ b/src/app/modules/shared_models/user_item.nim
@@ -1,12 +1,10 @@
 import strformat
+import ../../../app_service/common/types
 
 type
   OnlineStatus* {.pure.} = enum
-    Offline = 0
+    Inactive = 0
     Online
-    DoNotDisturb
-    Idle
-    Invisible
 
   ContactRequest* {.pure.} = enum
     None = 0
@@ -83,7 +81,7 @@ proc initUserItem*(
   icon: string,
   colorId: int = 0,
   colorHash: string = "",
-  onlineStatus: OnlineStatus = OnlineStatus.Offline,
+  onlineStatus: OnlineStatus = OnlineStatus.Inactive,
   isContact: bool,
   isVerified: bool,
   isUntrustworthy: bool,
@@ -110,6 +108,12 @@ proc initUserItem*(
     contactRequest = contactRequest,
     incomingVerification = incomingVerification,
     outcomingVerification = outcomingVerification)
+
+proc toOnlineStatus*(statusType: StatusType): OnlineStatus =
+  if(statusType == StatusType.AlwaysOnline or statusType == StatusType.Automatic):
+    return OnlineStatus.Online
+  else:
+    return OnlineStatus.Inactive
 
 proc `$`*(self: UserItem): string =
   result = fmt"""User Item(

--- a/src/app/modules/shared_models/user_model.nim
+++ b/src/app/modules/shared_models/user_model.nim
@@ -143,7 +143,7 @@ QtObject:
     # if we add an item with offline status we add it as the first offline item (after the last online item)
     var position = -1
     for i in 0 ..< self.items.len:
-      if(self.items[i].onlineStatus == OnlineStatus.Offline):
+      if(self.items[i].onlineStatus == OnlineStatus.Inactive):
         position = i
         break
 

--- a/src/app_service/common/conversion.nim
+++ b/src/app_service/common/conversion.nim
@@ -63,3 +63,7 @@ proc wei2Eth*(input: string, decimals: int): string =
 
 proc wei2Gwei*(input: string): string =
   result = wei2Eth(input, 9)
+
+proc intToEnum*[T](intVal: int, defaultVal: T): T =
+  result = if (intVal >= ord(low(T)) and intVal <= ord(high(T))): T(intVal) else: defaultVal
+

--- a/src/app_service/common/types.nim
+++ b/src/app_service/common/types.nim
@@ -14,3 +14,10 @@ type
     Community = 9
     Gap = 10
     Edit = 11
+
+type StatusType* {.pure.} = enum
+  Unknown = 0
+  Automatic
+  DoNotDisturb
+  AlwaysOnline
+  Inactive

--- a/src/app_service/service/contacts/dto/status_update.nim
+++ b/src/app_service/service/contacts/dto/status_update.nim
@@ -1,12 +1,7 @@
 import json
 include ../../../common/json_utils
-
-type StatusType* {.pure.} = enum
-  Offline = 0
-  Online
-  DoNotDisturb
-  Idle
-  Invisible
+from ../../../common/types import StatusType
+from ../../../common/conversion import intToEnum
 
 type StatusUpdateDto* = object
   publicKey*: string
@@ -19,8 +14,7 @@ proc toStatusUpdateDto*(jsonObj: JsonNode): StatusUpdateDto =
   discard jsonObj.getProp("clock", result.clock)
   discard jsonObj.getProp("text", result.text)
 
-  result.statusType = StatusType.Offline
+  result.statusType = StatusType.Unknown
   var statusTypeInt: int
-  if (jsonObj.getProp("statusType", statusTypeInt) and
-    (statusTypeInt >= ord(low(StatusType)) or statusTypeInt <= ord(high(StatusType)))):
-      result.statusType = StatusType(statusTypeInt)
+  if (jsonObj.getProp("statusType", statusTypeInt)):
+      result.statusType = intToEnum(statusTypeInt, StatusType.Unknown)

--- a/src/app_service/service/settings/dto/settings.nim
+++ b/src/app_service/service/settings/dto/settings.nim
@@ -2,6 +2,8 @@ import Tables, json, options, tables, strutils
 import ../../stickers/dto/stickers
 
 include  ../../../common/json_utils
+from ../../../common/types import StatusType
+from ../../../common/conversion import intToEnum
 
 # Setting keys:
 const KEY_ADDRESS* = "address"
@@ -74,7 +76,7 @@ type PinnedMailserver* = object
   statusProd*: string
 
 type CurrentUserStatus* = object
-  statusType*: int
+  statusType*: StatusType
   clock*: int64
   text*: string
 
@@ -134,7 +136,9 @@ proc toPinnedMailserver*(jsonObj: JsonNode): PinnedMailserver =
   discard jsonObj.getProp("status.prod", result.statusProd)
 
 proc toCurrentUserStatus*(jsonObj: JsonNode): CurrentUserStatus =
-  discard jsonObj.getProp("statusType", result.statusType)
+  var statusTypeInt: int
+  discard jsonObj.getProp("statusType", statusTypeInt)
+  result.statusType = intToEnum(statusTypeInt, StatusType.Unknown)
   discard jsonObj.getProp("clock", result.clock)
   discard jsonObj.getProp("text", result.text)
 

--- a/src/app_service/service/settings/service.nim
+++ b/src/app_service/service/settings/service.nim
@@ -1,6 +1,7 @@
 import NimQml, chronicles, json, strutils, sequtils, tables, sugar
 
 import ../../common/[network_constants]
+import ../../common/types as common_types
 import ../../../app/core/eventemitter
 import ../../../app/core/fleets/fleet_configuration
 import ../../../app/core/signals/types
@@ -8,7 +9,6 @@ import ../../../backend/settings as status_settings
 import ../../../backend/status_update as status_update
 
 import ./dto/settings as settings_dto
-import ../contacts/dto/status_update as status_update_dto
 import ../stickers/dto/stickers as stickers_dto
 
 export settings_dto
@@ -330,23 +330,20 @@ QtObject:
   proc getTelemetryServerUrl*(self: Service): string =
     return self.settings.telemetryServerUrl
 
-  proc saveSendStatusUpdates*(self: Service, value: bool): bool =
-    var newStatus = StatusType.Online
-    if not value:
-      # This looks unintuitive, but `StatusType.Offline` is interpreted
-      # as `StatusUpdate.UNKNOWN_STATUS_TYPE` in status-go, which causes an error.
-      # Hence `Invisible` (= 4 [which is `INACTIVE` in status-go]) is considerd offline.
-      newStatus = StatusType.Invisible
-
+  proc saveSendStatusUpdates*(self: Service, newStatus: StatusType): bool =
     try:
       # The new user status needs to always be broadcast, so we need to update
-      # the settings accordingly and might turn it off afterwards (if user has 
-      # set status to "offline"
-      if (self.saveSetting(KEY_SEND_STATUS_UPDATES, true)):
-        let r = status_update.setUserStatus(int(newStatus))
-        if(self.saveSetting(KEY_SEND_STATUS_UPDATES, value)):
-          self.settings.sendStatusUpdates = value
-          return true
+      # the settings accordingly and might turn it off afterwards (if user has
+      # set status to "inactive")
+      const propagateStatus = true
+      if(self.saveSetting(KEY_SEND_STATUS_UPDATES, propagateStatus) != true):
+          return false
+      discard status_update.setUserStatus(newStatus.int)
+      self.settings.currentUserStatus.statusType = newStatus
+      let sendPingsWithStatusUpdates = (newStatus == StatusType.AlwaysOnline or newStatus == StatusType.Automatic)
+      if(self.saveSetting(KEY_SEND_STATUS_UPDATES, sendPingsWithStatusUpdates)):
+        self.settings.sendStatusUpdates = sendPingsWithStatusUpdates
+        return true
       return false
     except:
       return false

--- a/ui/app/AppLayouts/Chat/panels/UserListPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/UserListPanel.qml
@@ -114,10 +114,10 @@ Item {
                 color: Theme.palette.baseColor1
                 text: {
                     switch(parseInt(section)) {
-                        case Constants.userStatus.offline: return qsTr("Offline")
-                        case Constants.userStatus.online: return qsTr("Online")
-                        case Constants.userStatus.doNotDisturb: return qsTr("Do not disturb")
-                        case Constants.userStatus.idle: return qsTr("Idle")
+                        case Constants.onlineStatus.online:
+                            return qsTr("Online")
+                        default:
+                             return qsTr("Inactive")
                     }
                 }
             }

--- a/ui/app/AppLayouts/Chat/panels/communities/CommunityMembersSettingsPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/CommunityMembersSettingsPanel.qml
@@ -95,7 +95,7 @@ SettingsPageLayout {
                 id: memberItem
 
                 readonly property bool itsMe: model.pubKey.toLowerCase() === userProfile.pubKey.toLowerCase()
-                readonly property bool isOnline: model.onlineStatus === Constants.userStatus.online
+                readonly property bool isOnline: model.onlineStatus === Constants.onlineStatus.online
 
                 width: memberList.width
 

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -369,18 +369,15 @@ Item {
                 badge.implicitHeight: 15
                 badge.implicitWidth: 15
                 badge.border.color: hovered ? Theme.palette.statusBadge.hoverBorderColor : Theme.palette.statusAppNavBar.backgroundColor
-                /*
-                //This is still not in use. Read a comment for `currentUserStatus` in UserProfile on the nim side.
-                // Use this code once support for custom user status is added
-                switch(userProfile.currentUserStatus){
-                    case Constants.userStatus.online:
-                        return Style.current.green;
-                    case Constants.userStatus.doNotDisturb:
-                        return Style.current.red;
-                    default:
-                        return Style.current.midGrey;
-                }*/
-                badge.color: appMain.rootStore.userProfileInst.userStatus ? Style.current.green : Style.current.midGrey
+                badge.color: {
+                    switch(appMain.rootStore.userProfileInst.currentUserStatus){
+                        case Constants.currentUserStatus.automatic:
+                        case Constants.currentUserStatus.alwaysOnline:
+                            return Style.current.green;
+                        default:
+                            return Style.current.midGrey;
+                    }
+                }
                 badge.border.width: 3
                 onClicked: {
                     userStatusContextMenu.opened ?

--- a/ui/imports/shared/popups/UserStatusContextMenu.qml
+++ b/ui/imports/shared/popups/UserStatusContextMenu.qml
@@ -52,14 +52,15 @@ PopupMenu {
     }
 
     Action {
-        text: qsTr("Online")
+        text: qsTr("Always online")
         onTriggered: {
             //TODO move this to the store as soon as #4274 is merged
-            if (userProfile.userStatus !== true) {
-                mainModule.setUserStatus(true);
+            if (userProfile.currentUserStatus !== Constants.currentUserStatus.alwaysOnline) {
+                mainModule.setCurrentUserStatus(Constants.currentUserStatus.alwaysOnline);
             }
             root.close();
         }
+
         icon.color: Style.current.green
         icon.source: Style.svg("online")
         icon.width: 16
@@ -67,17 +68,33 @@ PopupMenu {
     }
 
     Action {
-        text: qsTr("Offline")
+        text: qsTr("Inactive")
         onTriggered: {
             //TODO move this to the store as soon as #4274 is merged
-            if (userProfile.userStatus !== false) {
-                mainModule.setUserStatus(false);
+            if (userProfile.currentUserStatus !== Constants.currentUserStatus.inactive) {
+                mainModule.setCurrentUserStatus(Constants.currentUserStatus.inactive);
             }
             root.close();
         }
 
         icon.color: Style.current.midGrey
         icon.source: Style.svg("offline")
+        icon.width: 16
+        icon.height: 16
+    }
+
+    Action {
+        text: qsTr("Set status automatically")
+        onTriggered: {
+            //TODO move this to the store as soon as #4274 is merged
+            if (userProfile.currentUserStatus !== Constants.currentUserStatus.automatic) {
+                mainModule.setCurrentUserStatus(Constants.currentUserStatus.automatic);
+            }
+            root.close();
+        }
+
+        icon.color: Style.current.green
+        icon.source: Style.svg("online")
         icon.width: 16
         icon.height: 16
     }

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -50,11 +50,17 @@ QtObject {
         property int backUpSeed: 15
     }
 
-    readonly property QtObject userStatus: QtObject{
-        readonly property int offline: 0
-        readonly property int online: 1
+    readonly property QtObject currentUserStatus: QtObject{
+        readonly property int unknown: 0
+        readonly property int automatic: 1
         readonly property int doNotDisturb: 2
-        readonly property int idle: 3
+        readonly property int alwaysOnline: 3
+        readonly property int inactive: 4
+    }
+
+    readonly property QtObject onlineStatus: QtObject{
+        readonly property int inactive: 0
+        readonly property int online: 1
     }
 
     readonly property QtObject chatType: QtObject{


### PR DESCRIPTION
Issue #5886

### What does the PR do

Make user statuses enum the same as in status-go.
User can choose 3 statuses (like in mobile): Always Online, Automatic, Inactive.
Handling updating own status on member list (Online/Inactive)

Always online - the status is broadcasted every 5 minutes. After finishing application user is visible as online for 2 weeks.
Automatic - the status is broadcasted every 5 minutes. After finishing application user is visible as Inactive.
Inactive - no broadcast, user is visible as Inactive :)

TODO:
Updating choose status menu to Figma design will be done in next task #6090

### Screenshot of functionality

Changing statuses:

https://user-images.githubusercontent.com/61889657/173034614-6773dc8a-28eb-4606-b02d-67e06d7b35a2.mov

Update after 5 minutes (Automatic status):

https://user-images.githubusercontent.com/61889657/173034706-d6f91a39-10d4-4b19-a722-df61841556b4.mov


