### PR TITLE
fix(@desktop/chat): unify view user profile menu item

### DIFF
--- a/ui/app/AppLayouts/Chat/panels/AcceptRejectOptionsButtonsPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/AcceptRejectOptionsButtonsPanel.qml
@@ -6,6 +6,7 @@ import StatusQ.Controls 0.1
 import StatusQ.Popups 0.1
 
 import utils 1.0
+import shared.controls.chat.menuItems 1.0
 
 Row {
     signal acceptClicked()
@@ -59,9 +60,7 @@ Row {
                 menuButton.highlighted = false
             }
 
-            StatusMenuItem {
-                text: qsTr("View Profile")
-                icon.name: "profile"
+            ViewProfileMenuItem {
                 onTriggered: root.profileClicked()
             }
 

--- a/ui/app/AppLayouts/Chat/views/ChatContextMenuView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatContextMenuView.qml
@@ -7,6 +7,7 @@ import utils 1.0
 import StatusQ.Popups 0.1
 
 import shared.popups 1.0
+import shared.controls.chat.menuItems 1.0
 import "../popups"
 import "../popups/community"
 
@@ -48,30 +49,16 @@ StatusPopupMenu {
 
     width: root.amIChatAdmin && (root.chatType === Constants.chatType.privateGroupChat) ? 207 : implicitWidth
 
+    ViewProfileMenuItem {
+        enabled: root.chatType === Constants.chatType.oneToOne
+        onTriggered: root.displayProfilePopup(root.chatId)
+    }
+
     StatusMenuItem {
-        id: viewProfileMenuItem
-        text: {
-            switch (root.chatType) {
-            case Constants.chatType.oneToOne:
-                //% "View Profile"
-                return qsTrId("view-profile")
-            case Constants.chatType.privateGroupChat:
-                return qsTr("View Members")
-            default:
-                return ""
-            }
-        }
+        text: qsTr("View Members")
         icon.name: "group-chat"
-        enabled: root.chatType === Constants.chatType.oneToOne ||
-            root.chatType === Constants.chatType.privateGroupChat
-        onTriggered: {
-            if (root.chatType === Constants.chatType.oneToOne) {
-                root.displayProfilePopup(root.chatId)
-            }
-            if (root.chatType === Constants.chatType.privateGroupChat) {
-                root.displayGroupInfoPopup(root.chatId)
-            }
-        }
+        enabled: root.chatType === Constants.chatType.privateGroupChat
+        onTriggered: root.displayGroupInfoPopup(root.chatId)
     }
 
     StatusMenuItem {
@@ -82,12 +69,12 @@ StatusPopupMenu {
     }
 
     StatusMenuSeparator {
-        visible: viewProfileMenuItem.enabled
+        visible: root.chatType === Constants.chatType.oneToOne || root.chatType === Constants.chatType.privateGroupChat
     }
 
     Action {
         enabled: root.currentFleet === Constants.waku_prod   ||
-                 root.currentFleet === Constants.waku_test   || 
+                 root.currentFleet === Constants.waku_test   ||
                  root.currentFleet === Constants.status_test ||
                  root.currentFleet === Constants.status_prod
 
@@ -120,13 +107,8 @@ StatusPopupMenu {
         }
     }
 
-    StatusMenuItem {
-        text: root.chatMuted ?
-              //% "Unmute chat"
-              qsTrId("unmute-chat") :
-              //% "Mute chat"
-              qsTrId("mute-chat")
-        icon.name: "notification"
+    MuteChatMenuItem {
+        muted: root.chatMuted
         onTriggered: {
             if(root.chatMuted)
                 root.unmuteChat(root.chatId)

--- a/ui/app/AppLayouts/Profile/panels/ContactPanel.qml
+++ b/ui/app/AppLayouts/Profile/panels/ContactPanel.qml
@@ -14,6 +14,7 @@ import shared.panels 1.0
 import shared.status 1.0
 import shared.views 1.0
 import shared.controls.chat 1.0
+import shared.controls.chat.menuItems 1.0
 
 StatusListItem {
     id: container
@@ -128,9 +129,7 @@ StatusListItem {
 
                 Separator {}
 
-                StatusMenuItem {
-                    text: qsTr("View Profile")
-                    icon.name: "profile"
+                ViewProfileMenuItem {
                     icon.width: 16
                     icon.height: 16
                     onTriggered: {
@@ -139,9 +138,7 @@ StatusListItem {
                     }
                 }
 
-                StatusMenuItem {
-                    text: qsTr("Send message")
-                    icon.name: "chat"
+                SendMessageMenuItem {
                     icon.width: 16
                     icon.height: 16
                     onTriggered: {

--- a/ui/imports/shared/controls/chat/menuItems/MuteChatMenuItem.qml
+++ b/ui/imports/shared/controls/chat/menuItems/MuteChatMenuItem.qml
@@ -1,0 +1,10 @@
+import QtQuick 2.14
+
+import StatusQ.Popups 0.1
+
+StatusMenuItem {
+    property bool muted: false
+
+    text: !muted ? qsTr("Mute chat") : qsTr("Unmute chat")
+    icon.name: "notification"
+}

--- a/ui/imports/shared/controls/chat/menuItems/SendMessageMenuItem.qml
+++ b/ui/imports/shared/controls/chat/menuItems/SendMessageMenuItem.qml
@@ -1,0 +1,8 @@
+import QtQuick 2.14
+
+import StatusQ.Popups 0.1
+
+StatusMenuItem {
+    text: qsTr("Send message")
+    icon.name: "chat"
+}

--- a/ui/imports/shared/controls/chat/menuItems/ViewProfileMenuItem.qml
+++ b/ui/imports/shared/controls/chat/menuItems/ViewProfileMenuItem.qml
@@ -1,0 +1,8 @@
+import QtQuick 2.14
+
+import StatusQ.Popups 0.1
+
+StatusMenuItem {
+    text: qsTr("View Profile")
+    icon.name: "profile"
+}

--- a/ui/imports/shared/controls/chat/menuItems/qmldir
+++ b/ui/imports/shared/controls/chat/menuItems/qmldir
@@ -1,0 +1,3 @@
+ViewProfileMenuItem 1.0 ViewProfileMenuItem.qml
+MuteChatMenuItem 1.0 MuteChatMenuItem.qml
+SendMessageMenuItem 1.0 SendMessageMenuItem.qml

--- a/ui/imports/shared/views/chat/MessageContextMenuView.qml
+++ b/ui/imports/shared/views/chat/MessageContextMenuView.qml
@@ -13,6 +13,7 @@ import shared.panels 1.0
 import shared.popups 1.0
 import shared.status 1.0
 import shared.controls.chat 1.0
+import shared.controls.chat.menuItems 1.0
 
 StatusPopupMenu {
     id: root
@@ -160,36 +161,33 @@ StatusPopupMenu {
         enabled: root.isRightClickOnImage && !root.pinnedPopup
     }
 
-    StatusMenuItem {
+    ViewProfileMenuItem {
         id: viewProfileAction
-        //% "View Profile"
-        text: qsTrId("view-profile")
         onTriggered: {
             root.openProfileClicked(root.selectedUserPublicKey)
             root.close()
         }
-        icon.name: "profile"
         enabled: root.isProfile && !root.pinnedPopup
     }
 
-    StatusMenuItem {
-        id: sendMessageOrReplyTo
-        text: root.isProfile ?
-                  //% "Send message"
-                  qsTrId("send-message") :
-                  //% "Reply to"
-                  qsTrId("reply-to")
+    SendMessageMenuItem {
+        id: sendMessageMenuItem
+        enabled: root.isProfile && root.store.contactsStore.isMyMutualContact(root.selectedUserPublicKey)
         onTriggered: {
-            if (root.isProfile) {
-                root.createOneToOneChat("", root.selectedUserPublicKey, "")
-            } else {
-                root.showReplyArea()
-            }
+            root.createOneToOneChat("", root.selectedUserPublicKey, "")
             root.close()
         }
+    }
+
+    StatusMenuItem {
+        id: replyToMenuItem
+        text: qsTr("Reply to")
         icon.name: "chat"
-        enabled: root.isProfile && root.store.contactsStore.isMyMutualContact(root.selectedUserPublicKey) ||
-                 (!root.hideEmojiPicker &&
+        onTriggered: {
+            root.showReplyArea()
+            root.close()
+        }
+        enabled: (!root.hideEmojiPicker &&
                   !root.isEmoji &&
                   !root.isProfile &&
                   !root.pinnedPopup &&
@@ -274,7 +272,8 @@ StatusPopupMenu {
     StatusMenuSeparator {
         visible: deleteMessageAction.enabled &&
                  (viewProfileAction.enabled ||
-                  sendMessageOrReplyTo.enabled ||
+                  sendMessageMenuItem.enabled ||
+                  replyToMenuItem.enabled ||
                   editMessageAction.enabled ||
                   pinAction.enabled)
     }


### PR DESCRIPTION
[fix(@desktop/chat): extract chat menu items](https://github.com/status-im/status-desktop/pull/6064/commits/d39213a959ced6593a2682d4aae68a6238e4fbd7) 

It removes duplication and unifies menu items across the app.

fixes: #5985