### PR TITLE
fix(Communities): Remove duplications of channel when category removed

### DIFF
--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -485,6 +485,7 @@ method onCommunityCategoryDeleted*(self: Module, cat: Category) =
       chatDto.color, chatDto.emoji, chatDto.description, chatDto.chatType.int, amIChatAdmin,
       hasNotification, notificationsCount, chatDto.muted, false, active = false,
       chatDto.position, categoryId="")
+    self.view.chatsModel().removeItemById(c.id)
     self.view.chatsModel().appendItem(channelItem)
 
   self.view.chatsModel().removeItemById(cat.id)


### PR DESCRIPTION
Closes: #5933

### What does the PR do

Remove channels duplication after deleting category

### Affected areas

Communities

