### PR TITLE
fix(@desktop/group-chat): restore missing removeMembersFromGroupChat

### DIFF
--- a/src/app/modules/main/chat_section/view.nim
+++ b/src/app/modules/main/chat_section/view.nim
@@ -187,6 +187,9 @@ QtObject:
   proc removeMemberFromGroupChat*(self: View, communityID: string, chatId: string, pubKey: string) {.slot.} =
     self.delegate.removeMemberFromGroupChat(communityID, chatId, pubKey)
 
+  proc removeMembersFromGroupChat*(self: View, communityID: string, chatId: string, pubKeys: string) {.slot.} =
+    self.delegate.removeMembersFromGroupChat(communityID, chatId, pubKeys)
+
   proc renameGroupChat*(self: View, chatId: string, newName: string) {.slot.} =
     self.delegate.renameGroupChat(chatId, newName)
 


### PR DESCRIPTION
Without it, removing users from the group doesn't work.
