### PR TITLE
feat(chat): handle sync clear history messages

### DIFF
--- a/src/app/core/signals/remote_signals/messages.nim
+++ b/src/app/core/signals/remote_signals/messages.nim
@@ -27,6 +27,7 @@ type MessageSignal* = ref object of Signal
   deletedMessages*: seq[RemovedMessageDto]
   currentStatus*: seq[StatusUpdateDto]
   settings*: seq[SettingsFieldDto]
+  clearedHistories*: seq[ClearedHistoryDto]
 
 proc fromEvent*(T: type MessageSignal, event: JsonNode): MessageSignal =
   var signal:MessageSignal = MessageSignal()
@@ -46,6 +47,11 @@ proc fromEvent*(T: type MessageSignal, event: JsonNode): MessageSignal =
     for jsonChat in event["event"]["chats"]:
       var chat = jsonChat.toChatDto()
       signal.chats.add(chat)
+
+  if event["event"]{"clearedHistories"} != nil:
+    for jsonClearedHistory in event["event"]{"clearedHistories"}:
+      var clearedHistoryDto = jsonClearedHistory.toClearedHistoryDto()
+      signal.clearedHistories.add(clearedHistoryDto)
 
   if event["event"]{"statusUpdates"} != nil:
     for jsonStatusUpdate in event["event"]["statusUpdates"]:

--- a/src/app_service/service/chat/dto/chat.nim
+++ b/src/app_service/service/chat/dto/chat.nim
@@ -93,6 +93,10 @@ type ChannelGroupDto* = object
   historyArchiveSupportEnabled*: bool
   pinMessageAllMembersEnabled*: bool
 
+type ClearedHistoryDto* = object
+  chatId*: string
+  clearedAt*: int
+
 proc `$`*(self: ChatDto): string =
   result = fmt"""ChatDto(
     id: {self.id},
@@ -122,6 +126,11 @@ proc `$`*(self: ChatDto): string =
     position: {self.position},
     highlight: {self.highlight}
     )"""
+
+proc toClearedHistoryDto*(jsonObj: JsonNode): ClearedHistoryDto =
+  result = ClearedHistoryDto()
+  discard jsonObj.getProp("chatId", result.chatId)
+  discard jsonObj.getProp("clearedAt", result.clearedAt)
 
 proc toPermission*(jsonObj: JsonNode): Permission =
   result = Permission()

--- a/src/app_service/service/chat/service.nim
+++ b/src/app_service/service/chat/service.nim
@@ -118,6 +118,10 @@ QtObject:
             chats.add(chatDto)
             self.updateOrAddChat(chatDto)
         self.events.emit(SIGNAL_CHAT_UPDATE, ChatUpdateArgsNew(messages: receivedData.messages, chats: chats))
+
+      if (receivedData.clearedHistories.len > 0):
+        for clearedHistoryDto in receivedData.clearedHistories:
+          self.events.emit(SIGNAL_CHAT_HISTORY_CLEARED, ChatArgs(chatId: clearedHistoryDto.chatId))
   
   proc sortPersonnalChatAsFirst[T, D](x, y: (T, D)): int =
     if (x[1].channelGroupType == Personal): return -1
@@ -303,7 +307,7 @@ QtObject:
       discard status_chat.deactivateChat(chatId)
 
       self.chats.del(chatId)
-      discard status_chat.clearChatHistory(chatId)
+      discard status_chat.deleteMessagesByChatId(chatId)
       self.events.emit(SIGNAL_CHAT_LEFT, ChatArgs(chatId: chatId))
     except Exception as e:
       error "Error deleting channel", chatId, msg = e.msg
@@ -436,7 +440,7 @@ QtObject:
 
   proc clearChatHistory*(self: Service, chatId: string) =
     try:
-      let response = status_chat.deleteMessagesByChatId(chatId)
+      let response = status_chat.clearChatHistory(chatId)
       if(not response.error.isNil):
         let msg = response.error.message & " chatId=" & chatId
         error "error while clearing chat history ", msg

--- a/src/backend/chat.nim
+++ b/src/backend/chat.nim
@@ -52,7 +52,7 @@ proc deactivateChat*(chatId: string): RpcResponse[JsonNode] {.raises: [Exception
   callPrivateRPC("deactivateChat".prefix, %* [{ "ID": chatId }])
 
 proc clearChatHistory*(chatId: string): RpcResponse[JsonNode] {.raises: [Exception].} =
-  callPrivateRPC("deleteMessagesByChatID".prefix, %* [chatId])
+  callPrivateRPC("clearHistory".prefix, %* [{ "id": chatId }])
 
 proc sendChatMessage*(
     chatId: string,


### PR DESCRIPTION
When histories are cleared on a paired devices, that clearance should be
synced and reflected in other paired devices as well.

This commit ensures desktop calls the correct API to clear histories,
which will then cause an implicit sync.
Partially addresses #5201

