### PR TITLE
fix(Chat): The text and emoji are not vertically aligned in the chat message

### DIFF
--- a/ui/imports/shared/views/chat/CompactMessageView.qml
+++ b/ui/imports/shared/views/chat/CompactMessageView.qml
@@ -507,6 +507,7 @@ Item {
             anchors.leftMargin: chatImage.imageWidth + Style.current.padding + root.chatHorizontalPadding
             anchors.right: parent.right
             anchors.rightMargin: root.chatHorizontalPadding
+            anchors.topMargin: (!chatName.visible || !chatReply.active  || !pinnedRectangleLoader.active) ? Style.current.halfPadding : 0
             visible: !editModeOn
             ChatTextView {
                 id: chatText


### PR DESCRIPTION
Fixes #5953

### What does the PR do
Added top margin in message text.

### Affected areas
Chat messages

### Screenshot of functionality
![Screenshot 2022-06-13 at 13 12 10](https://user-images.githubusercontent.com/97019400/173342250-f1b45029-9844-41e5-8620-f22261447cda.png)

![Screenshot 2022-06-13 at 13 12 00](https://user-images.githubusercontent.com/97019400/173342265-fcbf059d-9b11-4e08-956f-b45c1a0a64c8.png)

