### PR TITLE
fix(Privacy): handle sync setting of `show-profile-pictures-to`

### DIFF
--- a/src/app/core/signals/remote_signals/messages.nim
+++ b/src/app/core/signals/remote_signals/messages.nim
@@ -8,6 +8,7 @@ import ../../../../app_service/service/community/dto/[community]
 import ../../../../app_service/service/activity_center/dto/[notification]
 import ../../../../app_service/service/contacts/dto/[contacts, status_update]
 import ../../../../app_service/service/devices/dto/[device]
+import ../../../../app_service/service/settings/dto/[settings]
 
 type MessageSignal* = ref object of Signal
   messages*: seq[MessageDto]
@@ -23,6 +24,7 @@ type MessageSignal* = ref object of Signal
   statusUpdates*: seq[StatusUpdateDto]
   deletedMessages*: seq[RemovedMessageDto]
   currentStatus*: seq[StatusUpdateDto]
+  settings*: seq[SettingsFieldDto]
 
 proc fromEvent*(T: type MessageSignal, event: JsonNode): MessageSignal =
   var signal:MessageSignal = MessageSignal()
@@ -83,6 +85,10 @@ proc fromEvent*(T: type MessageSignal, event: JsonNode): MessageSignal =
   if event["event"]{"pinMessages"} != nil:
     for jsonPinnedMessage in event["event"]["pinMessages"]:
       signal.pinnedMessages.add(jsonPinnedMessage.toPinnedMessageUpdateDto())
+
+  if event["event"]{"settings"} != nil:
+    for jsonSettingsField in event["event"]["settings"]:
+      signal.settings.add(jsonSettingsField.toSettingsFieldDto())
 
   result = signal
 

--- a/src/app/modules/main/profile_section/privacy/controller.nim
+++ b/src/app/modules/main/profile_section/privacy/controller.nim
@@ -41,6 +41,10 @@ proc init*(self: Controller) =
     var args = SettingProfilePictureArgs(e)
     self.delegate.emitProfilePicturesShowToChanged(args.value)
 
+  self.events.on(SIGNAL_SETTING_PROFILE_PICTURES_VISIBILITY_CHANGED) do(e: Args):
+    var args = SettingProfilePictureArgs(e)
+    self.delegate.emitProfilePicturesVisibilityChanged(args.value)
+
 proc isMnemonicBackedUp*(self: Controller): bool =
   return self.privacyService.isMnemonicBackedUp()
 

--- a/src/app/modules/main/profile_section/privacy/controller.nim
+++ b/src/app/modules/main/profile_section/privacy/controller.nim
@@ -37,6 +37,10 @@ proc init*(self: Controller) =
     var args = OperationSuccessArgs(e)
     self.delegate.onPasswordChanged(args.success, args.errorMsg)
 
+  self.events.on(SIGNAL_SETTING_PROFILE_PICTURES_SHOW_TO_CHANGED) do(e: Args):
+    var args = SettingProfilePictureArgs(e)
+    self.delegate.emitProfilePicturesShowToChanged(args.value)
+
 proc isMnemonicBackedUp*(self: Controller): bool =
   return self.privacyService.isMnemonicBackedUp()
 

--- a/src/app/modules/main/profile_section/privacy/io_interface.nim
+++ b/src/app/modules/main/profile_section/privacy/io_interface.nim
@@ -70,3 +70,7 @@ method setProfilePicturesVisibility*(self: AccessInterface, value: int) {.base.}
 
 method getPasswordStrengthScore*(self: AccessInterface, password: string): int {.base.} =
   raise newException(ValueError, "No implementation available")
+
+method emitProfilePicturesShowToChanged*(self: AccessInterface, value: int) {.base.} =
+  raise newException(ValueError, "No implementation available")
+

--- a/src/app/modules/main/profile_section/privacy/io_interface.nim
+++ b/src/app/modules/main/profile_section/privacy/io_interface.nim
@@ -74,3 +74,6 @@ method getPasswordStrengthScore*(self: AccessInterface, password: string): int {
 method emitProfilePicturesShowToChanged*(self: AccessInterface, value: int) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method emitProfilePicturesVisibilityChanged*(self: AccessInterface, value: int) {.base.} =
+  raise newException(ValueError, "No implementation available")
+

--- a/src/app/modules/main/profile_section/privacy/module.nim
+++ b/src/app/modules/main/profile_section/privacy/module.nim
@@ -93,6 +93,9 @@ method setProfilePicturesShowTo*(self: Module, value: int) =
 method emitProfilePicturesShowToChanged*(self: Module, value: int) =
   self.view.profilePicturesShowToChanged()
 
+method emitProfilePicturesVisibilityChanged*(self: Module, value: int) =
+  self.view.profilePicturesVisibilityChanged()
+
 method getProfilePicturesVisibility*(self: Module): int =
   self.controller.getProfilePicturesVisibility()
 

--- a/src/app/modules/main/profile_section/privacy/module.nim
+++ b/src/app/modules/main/profile_section/privacy/module.nim
@@ -90,6 +90,9 @@ method setProfilePicturesShowTo*(self: Module, value: int) =
   if (self.controller.setProfilePicturesShowTo(value)):
     self.view.profilePicturesShowToChanged()
 
+method emitProfilePicturesShowToChanged*(self: Module, value: int) =
+  self.view.profilePicturesShowToChanged()
+
 method getProfilePicturesVisibility*(self: Module): int =
   self.controller.getProfilePicturesVisibility()
 

--- a/src/app_service/service/settings/dto/settings.nim
+++ b/src/app_service/service/settings/dto/settings.nim
@@ -93,6 +93,11 @@ type CurrentUserStatus* = object
   text*: string
 
 type
+  SettingsFieldDto* = object
+    name*: string
+    value*: string
+
+type
   SettingsDto* = object # There is no point to keep all these info as settings, but we must follow status-go response
     address*: string
     currency*: string
@@ -169,6 +174,17 @@ proc toCurrentUserStatus*(jsonObj: JsonNode): CurrentUserStatus =
   discard jsonObj.getProp("statusType", result.statusType)
   discard jsonObj.getProp("clock", result.clock)
   discard jsonObj.getProp("text", result.text)
+
+proc toSettingsFieldDto*(jsonObj: JsonNode): SettingsFieldDto =
+  var field = SettingsFieldDto()
+  field.name = jsonObj["name"].getStr()
+
+  case field.name:
+    of KEY_PROFILE_PICTURES_SHOW_TO:
+      field.value = jsonObj["value"].getInt().intToStr
+    else:
+      field.value = jsonObj["value"].getStr()
+  result = field
 
 proc toSettingsDto*(jsonObj: JsonNode): SettingsDto =
   discard jsonObj.getProp(KEY_ADDRESS, result.address)

--- a/src/app_service/service/settings/dto/settings.nim
+++ b/src/app_service/service/settings/dto/settings.nim
@@ -180,7 +180,7 @@ proc toSettingsFieldDto*(jsonObj: JsonNode): SettingsFieldDto =
   field.name = jsonObj["name"].getStr()
 
   case field.name:
-    of KEY_PROFILE_PICTURES_SHOW_TO:
+    of KEY_PROFILE_PICTURES_SHOW_TO, KEY_PROFILE_PICTURES_VISIBILITY:
       field.value = jsonObj["value"].getInt().intToStr
     else:
       field.value = jsonObj["value"].getStr()

--- a/src/app_service/service/settings/service.nim
+++ b/src/app_service/service/settings/service.nim
@@ -22,6 +22,7 @@ const DEFAULT_FLEET* = $Fleet.Prod
 
 const SIGNAL_CURRENT_USER_STATUS_UPDATED* = "currentUserStatusUpdated"
 const SIGNAL_SETTING_PROFILE_PICTURES_SHOW_TO_CHANGED* = "profilePicturesShowToChanged"
+const SIGNAL_SETTING_PROFILE_PICTURES_VISIBILITY_CHANGED* = "profilePicturesVisibilityChanged"
 
 logScope:
   topics = "settings-service"
@@ -34,7 +35,6 @@ type
 type
   SettingProfilePictureArgs* = ref object of Args
     value*: int
-
 
 QtObject:
   type Service* = ref object of QObject
@@ -70,6 +70,10 @@ QtObject:
           if settingsField.name == KEY_PROFILE_PICTURES_SHOW_TO:
             self.settings.profilePicturesShowTo = settingsfield.value.parseInt
             self.events.emit(SIGNAL_SETTING_PROFILE_PICTURES_SHOW_TO_CHANGED, SettingProfilePictureArgs(value: self.settings.profilePicturesShowTo))
+
+          if settingsField.name == KEY_PROFILE_PICTURES_VISIBILITY:
+            self.settings.profilePicturesVisibility = settingsfield.value.parseInt
+            self.events.emit(SIGNAL_SETTING_PROFILE_PICTURES_VISIBILITY_CHANGED, SettingProfilePictureArgs(value: self.settings.profilePicturesVisibility))
 
   proc saveSetting(self: Service, attribute: string, value: string | JsonNode | bool | int): bool =
     try:

--- a/src/app_service/service/settings/service.nim
+++ b/src/app_service/service/settings/service.nim
@@ -21,6 +21,7 @@ const DEFAULT_TELEMETRY_SERVER_URL* = "https://telemetry.status.im"
 const DEFAULT_FLEET* = $Fleet.Prod
 
 const SIGNAL_CURRENT_USER_STATUS_UPDATED* = "currentUserStatusUpdated"
+const SIGNAL_SETTING_PROFILE_PICTURES_SHOW_TO_CHANGED* = "profilePicturesShowToChanged"
 
 logScope:
   topics = "settings-service"
@@ -29,6 +30,11 @@ type
   CurrentUserStatusArgs* = ref object of Args
     statusType*: StatusType
     text*: string
+
+type
+  SettingProfilePictureArgs* = ref object of Args
+    value*: int
+
 
 QtObject:
   type Service* = ref object of QObject
@@ -57,6 +63,13 @@ QtObject:
       if receivedData.currentStatus.len > 0:
         var statusUpdate = receivedData.currentStatus[0]
         self.events.emit(SIGNAL_CURRENT_USER_STATUS_UPDATED, CurrentUserStatusArgs(statusType: statusUpdate.statusType, text: statusUpdate.text))
+
+      if receivedData.settings.len > 0:
+        for settingsField in receivedData.settings:
+
+          if settingsField.name == KEY_PROFILE_PICTURES_SHOW_TO:
+            self.settings.profilePicturesShowTo = settingsfield.value.parseInt
+            self.events.emit(SIGNAL_SETTING_PROFILE_PICTURES_SHOW_TO_CHANGED, SettingProfilePictureArgs(value: self.settings.profilePicturesShowTo))
 
   proc saveSetting(self: Service, attribute: string, value: string | JsonNode | bool | int): bool =
     try:


### PR DESCRIPTION
There are a bunch of settings which are synced an not handled by
desktop, one of them being the `profile-pictures-show-to` setting.

This commit introduces a new `SettingsFieldDto` so we can react to
message signals that include individual setting fields that originate
from syncing.

The first setting hanlded is the one mentioned above, so a new
application signal is introduced to inform the app that there was an
update in that particular setting, so it can re-render the view.

Partially addresses #5201
