### PR TITLE
fix: handle sync currency settings

### DIFF
--- a/src/app/modules/main/wallet_section/module.nim
+++ b/src/app/modules/main/wallet_section/module.nim
@@ -102,6 +102,7 @@ method load*(self: Module) =
     self.switchAccount(0)
     self.setTotalCurrencyBalance()
   self.events.on(SIGNAL_WALLET_ACCOUNT_CURRENCY_UPDATED) do(e:Args):
+    self.view.setCurrentCurrency(self.controller.getCurrency())
     self.setTotalCurrencyBalance()
   self.events.on(SIGNAL_WALLET_ACCOUNT_TOKEN_VISIBILITY_UPDATED) do(e:Args):
     self.setTotalCurrencyBalance()

--- a/src/app/modules/main/wallet_section/view.nim
+++ b/src/app/modules/main/wallet_section/view.nim
@@ -70,6 +70,10 @@ QtObject:
     self.totalCurrencyBalance = totalCurrencyBalance
     self.totalCurrencyBalanceChanged()
 
+  proc setCurrentCurrency*(self: View, currency: string) =
+    self.currentCurrency = currency
+    self.currentCurrencyChanged()
+
   proc setData*(self: View, currency, signingPhrase: string, mnemonicBackedUp: bool) =
     self.currentCurrency = currency
     self.signingPhrase = signingPhrase

--- a/src/app_service/service/settings/service.nim
+++ b/src/app_service/service/settings/service.nim
@@ -75,6 +75,9 @@ QtObject:
             self.settings.profilePicturesVisibility = settingsfield.value.parseInt
             self.events.emit(SIGNAL_SETTING_PROFILE_PICTURES_VISIBILITY_CHANGED, SettingProfilePictureArgs(value: self.settings.profilePicturesVisibility))
 
+          if settingsField.name == KEY_CURRENCY:
+            self.settings.currency = settingsField.value
+
   proc saveSetting(self: Service, attribute: string, value: string | JsonNode | bool | int): bool =
     try:
       let response = status_settings.saveSettings(attribute, value)

--- a/src/app_service/service/wallet_account/service.nim
+++ b/src/app_service/service/wallet_account/service.nim
@@ -12,6 +12,7 @@ import dto
 import derived_address
 
 import ../../../app/core/eventemitter
+import ../../../app/core/signals/types
 import ../../../app/core/tasks/[qt, threadpool]
 import ../../../backend/accounts as status_go_accounts
 import ../../../backend/backend as backend
@@ -156,6 +157,13 @@ QtObject:
       let errDesription = e.msg
       error "error: ", errDesription
       return
+
+    self.events.on(SignalType.Message.event) do(e: Args):
+      var receivedData = MessageSignal(e)
+      if receivedData.settings.len > 0:
+        for settingsField in receivedData.settings:
+          if settingsField.name == KEY_CURRENCY:
+            self.events.emit(SIGNAL_WALLET_ACCOUNT_CURRENCY_UPDATED, CurrencyUpdated())
 
   proc getAccountByAddress*(self: Service, address: string): WalletAccountDto =
     if not self.walletAccounts.hasKey(address):

--- a/ui/app/AppLayouts/Wallet/stores/CurrenciesStore.qml
+++ b/ui/app/AppLayouts/Wallet/stores/CurrenciesStore.qml
@@ -922,8 +922,7 @@ QtObject {
         var isSelected = false
         for(var i = 0; i < currenciesModel.count; i++) {
             if(root.currentCurrency === root.currenciesModel.get(i).key) {
-                isSelected = true
-                root.currenciesModel.get(i).selected = true
+                root.currenciesModel.get(i).selected = isSelected = true
             }
             else {
                 root.currenciesModel.get(i).selected = false


### PR DESCRIPTION
This updates the desktop client with a newly emitted currency settings
that might originate from synchronization

Partially addresses #5201
