### PR TITLE
fix(@chat): handle image placeholder

### DIFF
--- a/ui/imports/shared/views/chat/CompactMessageView.qml
+++ b/ui/imports/shared/views/chat/CompactMessageView.qml
@@ -514,7 +514,7 @@ Item {
             ChatTextView {
                 id: chatText
                 readonly property int leftPadding: chatImage.anchors.leftMargin + chatImage.width + chatHorizontalPadding
-                visible: isText || isEmoji || isImage
+                visible: isText || isEmoji || (isImage && root.message !== "<p>Update to latest version to see a nice image here!</p>")
 
                 message: Utils.removeGifUrls(root.message)
                 anchors.top: parent.top


### PR DESCRIPTION
fixes #5934

Mobile still send the placeholder so we need to handle this case
manually by removing text if this is exactly equal to the placeholder
