### PR TITLE
fix(CreateChatView): clicking new group chat duplicates contacts

### DIFF
--- a/ui/app/AppLayouts/Chat/views/CreateChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/CreateChatView.qml
@@ -49,6 +49,7 @@ Page {
                 }
                 tagSelector.sortModel(root.contactsModel);
             } else {
+                contactsModel.clear();
                 tagSelector.namesModel.clear();
             }
         }


### PR DESCRIPTION
Closes #6135

### What does the PR do
Fixed clicking new group chat keeps increase possible contacts

### Affected areas
CreateChatView

### Screenshot of functionality
https://user-images.githubusercontent.com/31625338/174584161-027ea22e-281d-4c94-b561-28ee74c8b900.mov


