### PR TITLE
fix(communities): Fix `try/catch` block in communities service

### DIFF
--- a/ui/app/AppLayouts/Profile/panels/CommunitiesListPanel.qml
+++ b/ui/app/AppLayouts/Profile/panels/CommunitiesListPanel.qml
@@ -12,11 +12,10 @@ import utils 1.0
 ListView {
     id: root
 
-    property var communitySectionModule
-    property var communityProfileModule
     property bool hasAddedContacts: false
 
     signal inviteFriends(var communityData)
+    signal leaveCommunityClicked(var communityId)
 
     interactive: false
     implicitHeight: contentItem.childrenRect.height
@@ -100,7 +99,7 @@ ListView {
                 type: StatusBaseButton.Type.Danger
                 text: qsTr("Leave community")
                 onClicked: {
-                    root.communityProfileModule.leaveCommunity(leavePopup.communityId)
+                    root.leaveCommunityClicked(leavePopup.communityId)
                     leavePopup.close()
                 }
             }

--- a/ui/app/AppLayouts/Profile/views/CommunitiesView.qml
+++ b/ui/app/AppLayouts/Profile/views/CommunitiesView.qml
@@ -55,9 +55,9 @@ SettingsContentBase {
             CommunitiesListPanel {
                 width: parent.width
                 model: root.profileSectionStore.communitiesList
-                communitySectionModule: root.profileSectionStore.communitiesModuleInst
-                communityProfileModule: root.profileSectionStore.communitiesProfileModule
-
+                onLeaveCommunityClicked: {
+                    root.profileSectionStore.communitiesProfileModule.leaveCommunity(leavePopup.communityId)
+                }
                 onInviteFriends: {
                     Global.openPopup(inviteFriendsToCommunityPopup, {
                                          community: communityData,


### PR DESCRIPTION
Closes: #6074

### What does the PR do

When `curatedCommunities` request is failed that affected all requests in `init` method cos of `try/catch` block. I moved `try` block to every each request method.

### Affected areas

Communities
