### PR TITLE
fix(Chat): `ReplyTo` messages with missing message information

### DIFF
--- a/src/app_service/service/message/service.nim
+++ b/src/app_service/service/message/service.nim
@@ -158,24 +158,10 @@ QtObject:
     # if (not chats[0].active):
     #   return
 
-
-    # In case of reply to a message we're receiving 2 messages in the `messages` array (replied message
-    # and a message one replied to) but we actually need only a new replied message, that's why we need to filter
-    # messages here.
-    # We are not sure if we can receive more replies here, also ordering in the `messages` array is not
-    # the same (once we may have replied messages before once after the messages one replied to), that's why we are
-    # covering the most general case here.
-    var messagesOneRepliedTo: seq[string]
-
     for msg in messages:
       if(msg.editedAt > 0):
         let data = MessageEditedArgs(chatId: msg.localChatId, message: msg)
         self.events.emit(SIGNAL_MESSAGE_EDITED, data)
-      if msg.responseTo.len > 0:
-        messagesOneRepliedTo.add(msg.responseTo)
-
-    for msgId in messagesOneRepliedTo:
-      removeMessageWithId(messages, msgId)
 
     for i in 0 ..< chats.len:
       if(chats[i].chatType == ChatType.Unknown):


### PR DESCRIPTION
Fixes #6138

### What does the PR do

Removed code that removes messages marked as `repliedTo` in the corresponding service `handleMessagesUpdate` method.

**IMPORTANT:** 
Statements related to deleting `replied messages` have been removed since these statements were causing the issue fixed in this PR, but in the code there was a comment saying there were duplicated messages and that's why a filter to `replied messages` was applied but I've been testing it now and can't see this duplicity. Please, I request a review from teammates who are more familiar with `status-go` and the `chat` management itself to see if this removal may cause any other side effects.

### Affected areas

Public channel / replied messages:

It solves the following use case (see issue description #6138):
- New account, join public channel, reply massages shown there.