### PR TITLE
fix(ChatButtonsPanel): Added pin/unpin and delete buttons

### DIFF
--- a/ui/imports/shared/panels/chat/ChatButtonsPanel.qml
+++ b/ui/imports/shared/panels/chat/ChatButtonsPanel.qml
@@ -4,6 +4,7 @@ import QtGraphicalEffects 1.13
 import StatusQ.Controls 0.1
 
 import utils 1.0
+import shared.popups 1.0
 
 Rectangle {
     id: buttonsContainer
@@ -14,12 +15,15 @@ Rectangle {
     property bool isCurrentUser: false
     property bool isMessageActive: false
     property var messageContextMenu
-    property bool showMoreButton: true
     property bool isInPinnedPopup: false
     property bool activityCenterMsg
     property bool placeholderMsg
     property string fromAuthor
     property bool editBtnActive: false
+    property bool pinButtonActive: false
+    property bool deleteButtonActive: false
+    property bool pinnedMessage: false
+    property bool canPin: false
     signal replyClicked(string messageId, string author)
     signal hoverChanged(bool hovered)
     signal setMessageActive(string messageId, bool active)
@@ -78,8 +82,7 @@ Rectangle {
                 height: 32
                 icon.name: "reaction-b"
                 type: StatusFlatRoundButton.Type.Tertiary
-                //% "Add reaction"
-                tooltip.text: qsTrId("add-reaction")
+                tooltip.text: qsTr("Add reaction")
                 onClicked: {
                     setMessageActive(messageId, true)
                     // Set parent, X & Y positions for the messageContextMenu
@@ -100,8 +103,7 @@ Rectangle {
                 height: 32
                 icon.name: "reply"
                 type: StatusFlatRoundButton.Type.Tertiary
-                //% "Reply"
-                tooltip.text: qsTrId("message-reply")
+                tooltip.text: qsTr("Reply")
                 onClicked: {
                     buttonsContainer.replyClicked(messageId, fromAuthor);
                     if (messageContextMenu.closeParentPopup) {
@@ -112,43 +114,97 @@ Rectangle {
             }
         }
 
-
         Loader {
-            id: editBtn
             active: buttonsContainer.editBtnActive && !buttonsContainer.isInPinnedPopup
             sourceComponent: StatusFlatRoundButton {
-                id: btn
+                id: editButton
                 width: 32
                 height: 32
                 icon.source: Style.svg("edit-message")
                 type: StatusFlatRoundButton.Type.Tertiary
-                //% "Edit"
-                tooltip.text: qsTrId("edit")
+                tooltip.text: qsTr("Edit")
                 onClicked: messageStore.setEditModeOn(messageId)
-                onHoveredChanged: buttonsContainer.hoverChanged(btn.hovered)
+                onHoveredChanged: buttonsContainer.hoverChanged(editButton.hovered)
             }
         }
 
-        StatusFlatRoundButton {
-            id: otherBtn
-            width: 32
-            height: 32
-            visible: buttonsContainer.showMoreButton
-            icon.name: "more"
-            type: StatusFlatRoundButton.Type.Tertiary
-            //% "More"
-            tooltip.text: qsTrId("more")
-            onClicked: {
-                if (typeof isMessageActive !== "undefined") {
-                    setMessageActive(messageId, true)
+        Loader {
+            active: buttonsContainer.pinButtonActive
+            sourceComponent: StatusFlatRoundButton {
+                id: pinButton
+                width: 32
+                height: 32
+                icon.name: buttonsContainer.pinnedMessage ? "unpin" : "pin"
+                type: StatusFlatRoundButton.Type.Tertiary
+                tooltip.text: buttonsContainer.pinnedMessage ? qsTr("Unpin") : qsTr("Pin")
+                onHoveredChanged: buttonsContainer.hoverChanged(pinButton.hovered)
+                onClicked: {
+                    if (buttonsContainer.pinnedMessage) {
+                        messageStore.unpinMessage(messageId)
+                        return;
+                    }
+
+                    if (buttonsContainer.canPin) {
+                        messageStore.pinMessage(messageId)
+                        return;
+                    }
+
+                    if (!chatContentModule) {
+                        console.warn("error on open pinned messages limit reached from message context menu - chat content module is not set")
+                        return;
+                    }
+
+                    Global.openPopup(pinnedMessagesPopupComponent, {
+                                         store: rootStore,
+                                         messageStore: messageStore,
+                                         pinnedMessagesModel: chatContentModule.pinnedMessagesModel,
+                                         messageToPin: buttonsContainer.messageId
+                                     });
                 }
-                // Set parent, X & Y positions for the messageContextMenu
-                buttonsContainer.messageContextMenu.parent = buttonsContainer
-                buttonsContainer.messageContextMenu.setXPosition = function() { return (-Math.abs(buttonsContainer.width - 176))}
-                buttonsContainer.messageContextMenu.setYPosition = function() { return (-buttonsContainer.messageContextMenu.height - 4)}
-                buttonsContainer.clickMessage(false, isSticker, false, null, false, true);
             }
-            onHoveredChanged: buttonsContainer.hoverChanged(this.hovered)
+        }
+
+        Loader {
+            active: buttonsContainer.deleteButtonActive && !buttonsContainer.isInPinnedPopup
+            sourceComponent: StatusFlatRoundButton {
+                id: deleteButton
+                width: 32
+                height: 32
+                type: StatusFlatRoundButton.Type.Tertiary
+                icon.name: "delete"
+                tooltip.text: qsTr("Delete")
+                onHoveredChanged: buttonsContainer.hoverChanged(deleteButton.hovered)
+                onClicked: {
+                    if (!localAccountSensitiveSettings.showDeleteMessageWarning) {
+                        messageStore.deleteMessage(messageId)
+                    }
+                    else {
+                        Global.openPopup(deleteMessageConfirmationDialogComponent)
+                    }
+                }
+            }
+        }
+
+        Component {
+            id: deleteMessageConfirmationDialogComponent
+
+            ConfirmationDialog {
+                header.title: qsTrId("Confirm deleting this message")
+                confirmationText: qsTrId("Are you sure you want to delete this message? Be aware that other clients are not guaranteed to delete the message as well.")
+                height: 260
+                checkbox.visible: true
+                executeConfirm: function () {
+                    if (checkbox.checked) {
+                        localAccountSensitiveSettings.showDeleteMessageWarning = false
+                    }
+
+                    close()
+                    messageStore.deleteMessage(messageId)
+                }
+                onClosed: {
+                    destroy()
+                }
+            }
         }
     }
 }

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -350,6 +350,8 @@ Column {
             editModeOn: root.editModeOn
             linkUrls: root.linkUrls
             isInPinnedPopup: root.isInPinnedPopup
+            pinnedMessage: root.pinnedMessage
+            canPin: messageStore.getNumberOfPinnedMessages() < Constants.maxNumberOfPins
 
             transactionParams: root.transactionParams
 


### PR DESCRIPTION
Fixes #6112
Requires https://github.com/status-im/StatusQ/pull/738

### What does the PR do

Replaced meatball menu `...` with buttons for pin/unpin and delete messages.

### Affected areas

chat

### Screenshot of functionality

https://user-images.githubusercontent.com/25482501/174884293-65e673c2-2672-4b3d-89b9-91f05e406fce.mov

