### PR TITLE
chore(internal): raise awareness of brew bottle download failed

### DIFF
--- a/scripts/fetch-brew-bottle.sh
+++ b/scripts/fetch-brew-bottle.sh
@@ -3,8 +3,10 @@ set -eof pipefail
 
 # This script is used to fetch HomeBrew bottles for PCRE and OpenSSL.
 
+trap "echo 'Failed to download bottle. Check your authentication token and network connection.'" EXIT ERR INT QUIT
+
 function get_gh_pkgs_token() {
-    curl --fail -Ls -u "${GITHUB_USER}:${GITHUB_TOKEN}" https://ghcr.io/token | jq -r '.token'
+    curl --fail --show-error -Ls -u "${GITHUB_USER}:${GITHUB_TOKEN}" https://ghcr.io/token | jq -r '.token'
 }
 
 function get_bottle_json() {
@@ -20,7 +22,7 @@ function fetch_bottle() {
     else
         AUTH=("-u" "_:_") # WARNING: Unauthorized requests can be throttled.
     fi
-    curl --fail -Ls "${AUTH[@]}" -o "${1}" "${2}"
+    curl --fail --show-error -Ls "${AUTH[@]}" -o "${1}" "${2}"
 }
 
 if [[ $(uname) != "Darwin" ]]; then


### PR DESCRIPTION
My local build was failing due to expired `GITHUB_TOKEN` and spent some time figuring out why. I propose this PR to reaise awareness for the next poor soul that gets into the same issue.

Retrospective:
- No awareness that our build system downloads brew custom dependencies on MacOS
- The error was misleading that `bew update` failed due to permissions. After fixing permissions it was failing on bottles that I had already installed and reinstalled.
- `scripts/fetch-brew-bottle.sh` was silently failing with "Failed to fetch file" due to token expired [see fetch-brew-bottle.sh](https://github.com/status-im/status-desktop/blob/95326620c38f0e5a28e07afffeb6003dbabcfe1a/scripts/fetch-brew-bottle.sh#L2) and `curl` failed silently as requested [see fetch-brew-bottle.sh](https://github.com/status-im/status-desktop/blob/95326620c38f0e5a28e07afffeb6003dbabcfe1a/scripts/fetch-brew-bottle.sh#L23)

### Affected areas

Build on mac