### PR TITLE
feat(CommunitiesPortal): Enable Communities portal & update chat menu

### DIFF
--- a/src/app/global/local_account_sensitive_settings.nim
+++ b/src/app/global/local_account_sensitive_settings.nim
@@ -20,8 +20,6 @@ const LSS_KEY_IS_GIF_WIDGET_ENABLED* = "isGifWidgetEnabled"
 const DEFAULT_IS_GIF_WIDGET_ENABLED = true
 const LSS_KEY_IS_MULTI_NETWORK_ENABLED* = "isMultiNetworkEnabled"
 const DEFAULT_IS_MULTI_NETWORK_ENABLED = false
-const LSS_KEY_IS_COMMUNITIES_PORTAL_ENABLED* = "isCommunitiesPortalEnabled"
-const DEFAULT_IS_COMMUNITIES_PORTAL_ENABLED = false
 const LSS_KEY_IS_TENOR_WARNING_ACCEPTED* = "isTenorWarningAccepted"
 const DEFAULT_IS_TENOR_WARNING_ACCEPTED = false
 const LSS_KEY_DISPLAY_CHAT_IMAGES* = "displayChatImages"
@@ -280,19 +278,6 @@ QtObject:
     read = getIsMultiNetworkEnabled
     write = setIsMultiNetworkEnabled
     notify = isMultiNetworkEnabledChanged
-
-  proc isCommunitiesPortalEnabledChanged*(self: LocalAccountSensitiveSettings) {.signal.}
-  proc getIsCommunitiesPortalEnabled*(self: LocalAccountSensitiveSettings): bool {.slot.} =
-    getSettingsProp[bool](self, LSS_KEY_IS_COMMUNITIES_PORTAL_ENABLED, newQVariant(DEFAULT_IS_COMMUNITIES_PORTAL_ENABLED))
-  proc setIsCommunitiesPortalEnabled*(self: LocalAccountSensitiveSettings, value: bool) {.slot.} =
-    setSettingsProp(self, LSS_KEY_IS_COMMUNITIES_PORTAL_ENABLED, newQVariant(value)):
-      self.isCommunitiesPortalEnabledChanged()
-
-  QtProperty[bool] isCommunitiesPortalEnabled:
-    read = getIsCommunitiesPortalEnabled
-    write = setIsCommunitiesPortalEnabled
-    notify = isCommunitiesPortalEnabledChanged
-
 
   proc isTenorWarningAcceptedChanged*(self: LocalAccountSensitiveSettings) {.signal.}
   proc getIsTenorWarningAccepted*(self: LocalAccountSensitiveSettings): bool {.slot.} =
@@ -774,7 +759,6 @@ QtObject:
       of LSS_KEY_EXPAND_USERS_LIST: self.expandUsersListChanged()
       of LSS_KEY_IS_GIF_WIDGET_ENABLED: self.isGifWidgetEnabledChanged()
       of LSS_KEY_IS_MULTI_NETWORK_ENABLED: self.isMultiNetworkEnabledChanged()
-      of LSS_KEY_IS_COMMUNITIES_PORTAL_ENABLED: self.isCommunitiesPortalEnabledChanged()
       of LSS_KEY_IS_TENOR_WARNING_ACCEPTED: self.isTenorWarningAcceptedChanged()
       of LSS_KEY_DISPLAY_CHAT_IMAGES: self.displayChatImagesChanged()
       of LSS_KEY_RECENT_EMOJIS: self.recentEmojisChanged()

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -299,7 +299,7 @@ method load*[T](
   hasNotification = false,
   notificationsCount = 0,
   active = false,
-  enabled = singletonInstance.localAccountSensitiveSettings.getIsCommunitiesPortalEnabled())
+  enabled = true)
   self.view.model().addItem(communitiesPortalSectionItem)
   if(activeSectionId == communitiesPortalSectionItem.id):
     activeSection = communitiesPortalSectionItem
@@ -527,10 +527,6 @@ proc setSectionAvailability[T](self: Module[T], sectionType: SectionType, availa
     self.view.model().disableSection(sectionType)
 
 method toggleSection*[T](self: Module[T], sectionType: SectionType) =
-  #if (sectionType == SectionType.CommunitiesPortal):
-  #  let enabled = true #singletonInstance.localAccountSensitiveSettings.getIsCommunitiesPortalEnabled()
-  #  self.setSectionAvailability(sectionType, not enabled)
-  #  singletonInstance.localAccountSensitiveSettings.setIsWalletEnabled(not enabled)
   if (sectionType == SectionType.Wallet):
     let enabled = singletonInstance.localAccountSensitiveSettings.getIsWalletEnabled()
     self.setSectionAvailability(sectionType, not enabled)
@@ -543,10 +539,6 @@ method toggleSection*[T](self: Module[T], sectionType: SectionType) =
     let enabled = singletonInstance.localAccountSensitiveSettings.getNodeManagementEnabled()
     self.setSectionAvailability(sectionType, not enabled)
     singletonInstance.localAccountSensitiveSettings.setNodeManagementEnabled(not enabled)
-  elif (sectionType == SectionType.CommunitiesPortal):
-    let enabled = singletonInstance.localAccountSensitiveSettings.getIsCommunitiesPortalEnabled()
-    self.setSectionAvailability(sectionType, not enabled)
-    singletonInstance.localAccountSensitiveSettings.setIsCommunitiesPortalEnabled(not enabled)
 
 method setUserStatus*[T](self: Module[T], status: bool) =
   self.controller.setUserStatus(status)

--- a/ui/app/AppLayouts/Chat/popups/qmldir
+++ b/ui/app/AppLayouts/Chat/popups/qmldir
@@ -2,4 +2,3 @@ PinnedMessagesPopup 1.0 PinnedMessagesPopup.qml
 ChooseBrowserPopup 1.0 ChooseBrowserPopup.qml
 InviteFriendsToCommunityPopup 1.0 community/InviteFriendsToCommunityPopup.qml
 CommunityProfilePopup 1.0 community/CommunityProfilePopup.qml
-CreateCommunityPopup 1.0 community/CreateCommunityPopup.qml

--- a/ui/app/AppLayouts/Chat/views/ContactsColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ContactsColumnView.qml
@@ -84,37 +84,24 @@ Item {
             }
         }
 
-        StatusIconTabButton {
+        StatusRoundButton {
             icon.name: "public-chat"
-            checked: publicChatCommunityContextMenu.visible
-            highlighted: publicChatCommunityContextMenu.visible
-            onClicked: { publicChatCommunityContextMenu.popup(); }
-            StatusPopupMenu {
-                 id: publicChatCommunityContextMenu
-                 closePolicy: Popup.CloseOnReleaseOutsideParent | Popup.CloseOnEscape
-                 StatusMenuItem {
-                     //% "Join public chat"
-                     text: qsTrId("new-public-group-chat")
-                     icon.name: "public-chat"
-                     onTriggered: Global.openPopup(publicChatPopupComponent)
-                 }
+            icon.height: editBtn.icon.height
+            icon.width: editBtn.icon.width
+            implicitWidth: editBtn.implicitWidth
+            implicitHeight: editBtn.implicitHeight
+            type: StatusRoundButton.Type.Tertiary
 
-                 StatusMenuItem {
-                     //% "Communities"
-                     text: qsTrId("communities")
-                     icon.name: "communities"
-                     onTriggered: Global.openPopup(communitiesPopupComponent)
-                 }
-            }
+            onClicked: { Global.openPopup(publicChatPopupComponent) }
 
             StatusToolTip {
-              text: qsTr("Public chats & communities")
+              text: qsTr("Join public chats")
               visible: parent.hovered
             }
         }
 
-
         StatusIconTabButton {
+            id: editBtn
             icon.name: "edit"
             checked: root.store.openCreateChat
             highlighted: root.store.openCreateChat
@@ -315,28 +302,6 @@ Item {
             onSetObservedCommunity: {
                 root.store.setObservedCommunity(id)
             }
-            onClosed: {
-                destroy()
-            }
-        }
-    }
-
-    Component {
-        id: createCommunitiesPopupComponent
-        CreateCommunityPopup {
-            anchors.centerIn: parent
-            store: root.store
-            onClosed: {
-                destroy()
-            }
-        }
-    }
-
-    Component {
-        id: importCommunitiesPopupComponent
-        ImportCommunityPopup {
-            anchors.centerIn: parent
-            store: root.store
             onClosed: {
                 destroy()
             }

--- a/ui/app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml
+++ b/ui/app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml
@@ -8,7 +8,10 @@ import StatusQ.Controls 0.1
 import StatusQ.Components 0.1
 
 import utils 1.0
+import shared.popups 1.0
+
 import "stores"
+import "popups"
 
 ScrollView {
     id: root
@@ -27,7 +30,7 @@ ScrollView {
         property int subtitlePixelSize: 17
 
         function navigateToCommunity(communityId) {
-            console.warn("TODO: Navigate to community ID: " + communityId)
+            root.communitiesStore.setActiveCommunity(communityId)
         }
     }
 
@@ -75,13 +78,13 @@ ScrollView {
             StatusButton {
                 id: importBtn
                 text: qsTr("Import Community")
-                enabled: false // Out of scope
+                onClicked: Global.openPopup(importCommunitiesPopupComponent)
             }
 
             StatusButton {
                 id: createBtn
-                text: qsTr("Creat New Community")
-                enabled: false // Out of scope
+                text: qsTr("Create New Community")
+                onClicked: Global.openPopup(createCommunitiesPopupComponent)
             }
         }
 
@@ -183,6 +186,28 @@ ScrollView {
 
                     onClicked: { d.navigateToCommunity(communityId) }
                 }
+            }
+        }
+    }
+
+    Component {
+        id: importCommunitiesPopupComponent
+        ImportCommunityPopup {
+            anchors.centerIn: parent
+            store: root.communitiesStore
+            onClosed: {
+                destroy()
+            }
+        }
+    }
+
+    Component {
+        id: createCommunitiesPopupComponent
+        CreateCommunityPopup {
+            anchors.centerIn: parent
+            store: root.communitiesStore
+            onClosed: {
+                destroy()
             }
         }
     }

--- a/ui/app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml
+++ b/ui/app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml
@@ -15,7 +15,7 @@ import StatusQ.Controls 0.1
 import StatusQ.Controls.Validators 0.1
 import StatusQ.Popups 0.1
 
-import "../../controls/community"
+import "../../Chat/controls/community"
 
 StatusModal {
     id: root

--- a/ui/app/AppLayouts/CommunitiesPortal/stores/CommunitiesStore.qml
+++ b/ui/app/AppLayouts/CommunitiesPortal/stores/CommunitiesStore.qml
@@ -7,6 +7,8 @@ QtObject {
     property var communitiesModuleInst: communitiesModule
     property var curatedCommunitiesModel: root.communitiesModuleInst.curatedCommunities
     property var locale: localAppSettings.locale
+    property var advancedModule: profileSectionModule.advancedModule
+    property bool isCommunityHistoryArchiveSupportEnabled: advancedModule? advancedModule.isCommunityHistoryArchiveSupportEnabled : false
 
     // TODO: Could the backend provide directly 2 filtered models??
     //property var featuredCommunitiesModel: root.communitiesModuleInst.curatedFeaturedCommunities
@@ -27,5 +29,38 @@ QtObject {
         ListElement { name: "food"; emoji: "🥑"}
         ListElement { name: "enviroment"; emoji: "☠️"}
         ListElement { name: "privacy"; emoji: "👻"}
+    }
+
+    function createCommunity(args = {
+                                name: "",
+                                description: "",
+                                introMessage: "",
+                                outroMessage: "",
+                                color: "",
+                                image: {
+                                    src: "",
+                                    AX: 0,
+                                    AY: 0,
+                                    BX: 0,
+                                    BY: 0,
+                                },
+                                options: {
+                                    historyArchiveSupportEnabled: false,
+                                    checkedMembership: false,
+                                    pinMessagesAllowedForMembers: false
+                                }
+                             }) {
+        return communitiesModuleInst.createCommunity(
+                    args.name, args.description, args.introMessage, args.outroMessage, args.options.checkedMembership, args.color,
+                    args.image.src, args.image.AX, args.image.AY, args.image.BX, args.image.BY,
+                    args.options.historyArchiveSupportEnabled, args.options.pinMessagesAllowedForMembers);
+    }
+
+    function importCommunity(communityKey) {
+        root.communitiesModuleInst.importCommunity(communityKey);
+    }
+
+    function setActiveCommunity(communityId) {
+        mainModule.setActiveSectionById(communityId);
     }
 }

--- a/ui/app/AppLayouts/Profile/views/AdvancedView.qml
+++ b/ui/app/AppLayouts/Profile/views/AdvancedView.qml
@@ -209,24 +209,6 @@ SettingsContentBase {
                 }
             }
 
-            // TODO: replace with StatusQ component
-            StatusSettingsLineButton {
-                anchors.leftMargin: 0
-                anchors.rightMargin: 0
-                text: qsTr("Communities Portal")
-                isSwitch: true
-                switchChecked: localAccountSensitiveSettings.isCommunitiesPortalEnabled
-                onClicked: {
-                    if (localAccountSensitiveSettings.isCommunitiesPortalEnabled) {
-                        root.advancedStore.toggleExperimentalFeature(root.advancedStore.experimentalFeatures.communitiesPortal)
-                    } else {
-                        confirmationPopup.experimentalFeature = root.advancedStore.experimentalFeatures.communitiesPortal
-                        confirmationPopup.open()
-                    }
-                }
-            }
-
-
             StatusSectionHeadline {
                 anchors.left: parent.left
                 anchors.right: parent.right

--- a/ui/app/AppLayouts/stores/RootStore.qml
+++ b/ui/app/AppLayouts/stores/RootStore.qml
@@ -54,8 +54,6 @@ QtObject {
 
     property bool isMultiNetworkEnabled: localAccountSensitiveSettings.isMultiNetworkEnabled
 
-    property bool isCommunitiesPortalEnabled: localAccountSensitiveSettings.isCommunitiesPortalEnabled
-
     property var savedAddressesModel: walletSectionSavedAddresses.model
 
     function getEtherscanLink() {

--- a/ui/imports/shared/stores/RootStore.qml
+++ b/ui/imports/shared/stores/RootStore.qml
@@ -24,7 +24,6 @@ QtObject {
     property bool isGifWidgetEnabled: !!accountSensitiveSettings ? accountSensitiveSettings.isGifWidgetEnabled : false
     property bool isTenorWarningAccepted: !!accountSensitiveSettings ? accountSensitiveSettings.isTenorWarningAccepted : false
     property bool displayChatImages: !!accountSensitiveSettings ? accountSensitiveSettings.displayChatImages : false
-    property bool isCommunitiesPortalEnabled: !!accountSensitiveSettings ? accountSensitiveSettings.isCommunitiesPortalEnabled : false
 
     property string locale: !!appSettings ? appSettings.locale : ""
 //    property string signingPhrase: !!walletModelInst ? walletModelInst.utilsView.signingPhrase : ""


### PR DESCRIPTION
Closes #6099

### What does the PR do

- Removed 'Communities Portal' toggle from the advanced settings and enable it by default.
- Removed dropdown menu. The button opens directly the join public chat modal.
- In the portal, "Import community" button is now clickable and opens the import community modal.
- In the portal, "Create community" button is now clickable and opens the create community modal.
- Enabled navigation to the clicked community.

### Affected areas

Chat / Join Chat & Communities dropdown
Comunities Portal

### Screenshot of functionality

https://user-images.githubusercontent.com/97019400/175099639-fe29be04-9681-44c9-8606-fb11b19f1067.mov




