### PR TITLE
fix(@wallet): address input keep loading

### DIFF
--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -707,7 +707,7 @@ method resolveENS*[T](self: Module[T], ensName: string, uuid: string, reason: st
   self.controller.resolveENS(ensName, uuid, reason)
 
 method resolvedENS*[T](self: Module[T], publicKey: string, address: string, uuid: string, reason: string) =
-  if(publicKey.len == 0):
+  if(reason.len > 0 and publicKey.len == 0):
     self.displayEphemeralNotification("Unexisting contact", "Wrong public key or ens name", "", false, EphemeralNotificationType.Default.int, "")
     return
   

--- a/ui/imports/shared/controls/ContactsListAndSearch.qml
+++ b/ui/imports/shared/controls/ContactsListAndSearch.qml
@@ -114,7 +114,7 @@ Item {
                     ensUsername.text = "";
                     searchResults.pubKey = pubKey = "";
                     searchResults.address = "";
-                    searchResults.showProfileNotFoundMessage = true
+                    searchResults.showProfileNotFoundMessage = root.showContactList
                 } else {
                     if (userProfile.pubKey === resolvedPubKey) {
                         //% "Can't chat with yourself"


### PR DESCRIPTION
In case of a public key, the loader was always visible and an ephemeral
notification was display but it should not

Also, the show not found is disabled if there is no contact list being
displayed

fixes #6194