### PR TITLE
fix(ActivityCenter): Activity center button is not active when activity center is opened

### DIFF
--- a/ui/app/AppLayouts/Chat/views/ChatContentView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatContentView.qml
@@ -188,6 +188,7 @@ ColumnLayout {
 
         onMembersButtonClicked: localAccountSensitiveSettings.expandUsersList = !localAccountSensitiveSettings.expandUsersList
         onNotificationButtonClicked: activityCenter.open()
+        notificationButton.highlighted: activityCenter.visible
 
         popupMenu: ChatContextMenuView {
             emojiPopup: chatContentRoot.emojiPopup


### PR DESCRIPTION
Fixes #6119

### What does the PR do

The button is now in highlighted state when it's active.

### Affected areas

Activity Center button

### Screenshot of functionality

https://user-images.githubusercontent.com/97019400/175263418-53d9ed80-1ef4-4184-93bf-61e5194c6ca2.mov
