### PR TITLE
fix(chat): fix switching back to chats is very slow

### DIFF
--- a/ui/app/AppLayouts/Chat/views/ChatContentView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatContentView.qml
@@ -429,6 +429,7 @@ ColumnLayout {
             stickersLoaded: chatContentRoot.stickersLoaded
             isChatBlocked: chatContentRoot.isBlocked
             channelEmoji: chatContentModule.chatDetails.emoji || ""
+            isActiveChannel: chatContentRoot.isActiveChannel
             onShowReplyArea: {
                 let obj = messageStore.getMessageByIdAsJson(messageId)
                 if (!obj) {

--- a/ui/imports/shared/controls/chat/UserImage.qml
+++ b/ui/imports/shared/controls/chat/UserImage.qml
@@ -24,7 +24,7 @@ Loader {
 
     signal clicked()
 
-    height: active ? item.height : 0
+    height: active && item ? item.height : 0
 
     sourceComponent: StatusSmartIdenticon {
         name: root.name

--- a/ui/imports/utils/Utils.qml
+++ b/ui/imports/utils/Utils.qml
@@ -229,7 +229,6 @@ QtObject {
         if(Number.isInteger(value) && value > 0) {
             return true;
         }
-        console.error(qsTr("timestamp must be type of int and greater than 0 (%1)").arg(errorLocation));
         return false;
     }
 


### PR DESCRIPTION
Fixes #5615

This fixes some QML warnings that I thought might have a effect, but also makes the message loading more "async".

The fix I did is a bit hackish, but what is does is only show the first 10 messages in the first 10 milliseconds, and then enable the rest.

The reason why it was so slow was that the scroll goes wild when switching. I haven't been able to find the reason for that sadly.
Anyway, since the scroll goes crazy, it loads messages that shouldn't be loaded, so that's why it's slow.

Now, by loading only 10 at the start and waiting a fraction of a second to "load" the rest, the scroll has time to settle and switching is faster.

I tested on Windows and it made a good difference. The switch is not instantaneous, but on Windows it was always a bit slow. I would think that on Linux and Mac it should be very fast.