### PR TITLE
fix(Makefile): ensure `pkg` target rebuilds status client

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -547,7 +547,11 @@ $(STATUS_CLIENT_7Z): $(STATUS_CLIENT_EXE)
 	echo -e $(BUILD_MSG) "7z"
 	7z a $(STATUS_CLIENT_7Z) ./$(OUTPUT)
 
-pkg: $(PKG_TARGET)
+# pkg target rebuilds status client
+# this is to ensure production version of the app is deployed
+pkg:
+	rm $(NIM_STATUS_CLIENT) | :
+	$(MAKE) $(PKG_TARGET)
 
 pkg-linux: check-pkg-target-linux $(STATUS_CLIENT_APPIMAGE)
 


### PR DESCRIPTION
Otherwise `make pkg` would deploy already built status client,
regardless of its initial configuration.

`make clean` is not required before `make pkg` anymore.

fixes: #6241