### PR TITLE
feat(@desktop/chat): Add sections to members tab of the community management

### DIFF
--- a/src/app/modules/main/chat_section/controller.nim
+++ b/src/app/modules/main/chat_section/controller.nim
@@ -402,6 +402,9 @@ proc removeUserFromCommunity*(self: Controller, pubKey: string) =
 proc banUserFromCommunity*(self: Controller, pubKey: string) =
   self.communityService.banUserFromCommunity(self.sectionId, pubKey)
 
+proc unbanUserFromCommunity*(self: Controller, pubKey: string) =
+  self.communityService.unbanUserFromCommunity(self.sectionId, pubKey)
+
 proc editCommunity*(
     self: Controller,
     name: string,

--- a/src/app/modules/main/chat_section/io_interface.nim
+++ b/src/app/modules/main/chat_section/io_interface.nim
@@ -269,6 +269,9 @@ method editCommunity*(self: AccessInterface, name: string, description, introMes
                       historyArchiveSupportEnabled: bool, pinMessageAllMembersEnabled: bool) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method unbanUserFromCommunity*(self: AccessInterface, pubKey: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method exportCommunity*(self: AccessInterface): string {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -757,6 +757,9 @@ method removeUserFromCommunity*(self: Module, pubKey: string) =
 method banUserFromCommunity*(self: Module, pubKey: string) =
   self.controller.banUserFromCommunity(pubkey)
 
+method unbanUserFromCommunity*(self: Module, pubKey: string) =
+  self.controller.unbanUserFromCommunity(pubkey)
+
 method editCommunity*(self: Module, name: string,
                         description, introMessage, outroMessage: string,
                         access: int, color: string, tags: string,

--- a/src/app/modules/main/chat_section/view.nim
+++ b/src/app/modules/main/chat_section/view.nim
@@ -259,6 +259,9 @@ QtObject:
     self.delegate.editCommunity(name, description, introMessage, outroMessage, access, color, tags,
                                 logoJsonData, bannerJsonData, historyArchiveSupportEnabled, pinMessageAllMembersEnabled)
 
+  proc unbanUserFromCommunity*(self: View, pubKey: string) {.slot.} =
+    self.delegate.unbanUserFromCommunity(pubKey)
+
   proc exportCommunity*(self: View): string {.slot.} =
     self.delegate.exportCommunity()
 

--- a/src/app/modules/main/communities/module.nim
+++ b/src/app/modules/main/communities/module.nim
@@ -111,7 +111,20 @@ method getCommunityItem(self: Module, c: CommunityDto): SectionItem =
           onlineStatus = toOnlineStatus(self.controller.getStatusForContactWithId(member.id).statusType),
           isContact = contactDetails.details.isContact,
           )),
-      historyArchiveSupportEnabled = c.settings.historyArchiveSupportEnabled
+      historyArchiveSupportEnabled = c.settings.historyArchiveSupportEnabled,
+      bannedMembers = c.bannedMembersIds.map(proc(bannedMemberId: string): MemberItem =
+        let contactDetails = self.controller.getContactDetails(bannedMemberId)
+        result = initMemberItem(
+          pubKey = bannedMemberId,
+          displayName = contactDetails.displayName,
+          ensName = contactDetails.details.name,
+          localNickname = contactDetails.details.localNickname,
+          alias = contactDetails.details.alias,
+          icon = contactDetails.icon,
+          onlineStatus = toOnlineStatus(self.controller.getStatusForContactWithId(bannedMemberId).statusType),
+          isContact = contactDetails.details.added, # FIXME
+        )
+      ),
     )
 
 method getCuratedCommunityItem(self: Module, c: CuratedCommunity): CuratedCommunityItem =

--- a/src/app/modules/shared_models/active_section.nim
+++ b/src/app/modules/shared_models/active_section.nim
@@ -17,11 +17,13 @@ QtObject:
     result.setup
 
   proc membersChanged*(self: ActiveSection) {.signal.}
+  proc bannedMembersChanged*(self: ActiveSection) {.signal.}
   proc pendingRequestsToJoinChanged*(self: ActiveSection) {.signal.}
 
   proc setActiveSectionData*(self: ActiveSection, item: SectionItem) =
     self.item = item
     self.membersChanged()
+    self.bannedMembersChanged()
     self.pendingRequestsToJoinChanged()
 
   proc getId*(self: ActiveSection): string {.slot.} =
@@ -171,6 +173,17 @@ QtObject:
   QtProperty[QVariant] members:
     read = members
     notify = membersChanged
+
+
+  proc bannedMembers(self: ActiveSection): QVariant {.slot.} =
+    if (self.item.id == ""):
+      # FIXME (Jo) I don't know why but the Item is sometimes empty and doing anything here crashes the app
+      return newQVariant("")
+    return newQVariant(self.item.bannedMembers)
+
+  QtProperty[QVariant] bannedMembers:
+    read = bannedMembers
+    notify = bannedMembersChanged
 
   proc hasMember(self: ActiveSection, pubkey: string): bool {.slot.} =
     return self.item.hasMember(pubkey)

--- a/src/app/modules/shared_models/section_item.nim
+++ b/src/app/modules/shared_models/section_item.nim
@@ -42,6 +42,7 @@ type
     pendingRequestsToJoinModel: PendingRequestModel
     historyArchiveSupportEnabled: bool
     pinMessageAllMembersEnabled: bool
+    bannedMembersModel: member_model.Model
 
 proc initItem*(
     id: string,
@@ -71,7 +72,8 @@ proc initItem*(
     members: seq[MemberItem] = @[],
     pendingRequestsToJoin: seq[PendingRequestItem] = @[],
     historyArchiveSupportEnabled = false,
-    pinMessageAllMembersEnabled = false
+    pinMessageAllMembersEnabled = false,
+    bannedMembers: seq[MemberItem] = @[],
     ): SectionItem =
   result.id = id
   result.sectionType = sectionType
@@ -103,6 +105,8 @@ proc initItem*(
   result.pendingRequestsToJoinModel.setItems(pendingRequestsToJoin)
   result.historyArchiveSupportEnabled = historyArchiveSupportEnabled
   result.pinMessageAllMembersEnabled = pinMessageAllMembersEnabled
+  result.bannedMembersModel = newModel()
+  result.bannedMembersModel.setItems(bannedMembers)
 
 proc isEmpty*(self: SectionItem): bool =
   return self.id.len == 0
@@ -136,6 +140,7 @@ proc `$`*(self: SectionItem): string =
     members:{self.membersModel},
     historyArchiveSupportEnabled:{self.historyArchiveSupportEnabled},
     pinMessageAllMembersEnabled:{self.pinMessageAllMembersEnabled},
+    bannedMembers:{self.bannedMembersModel},
     ]"""
 
 proc id*(self: SectionItem): string {.inline.} =
@@ -247,6 +252,9 @@ proc updateMember*(
     isUntrustworthy: bool) =
   self.membersModel.updateItem(pubkey, name, ensName, nickname, alias, image, isContact,
     isUntrustworthy)
+
+proc bannedMembers*(self: SectionItem): member_model.Model {.inline.} =
+  self.bannedMembersModel
 
 proc pendingRequestsToJoin*(self: SectionItem): PendingRequestModel {.inline.} =
   self.pendingRequestsToJoinModel

--- a/src/app/modules/shared_models/section_model.nim
+++ b/src/app/modules/shared_models/section_model.nim
@@ -34,6 +34,7 @@ type
     PendingRequestsToJoinModel
     HistoryArchiveSupportEnabled
     PinMessageAllMembersEnabled
+    BannedMembersModel
 
 QtObject:
   type
@@ -99,6 +100,7 @@ QtObject:
       ModelRole.PendingRequestsToJoinModel.int:"pendingRequestsToJoin",
       ModelRole.HistoryArchiveSupportEnabled.int:"historyArchiveSupportEnabled",
       ModelRole.PinMessageAllMembersEnabled.int:"pinMessageAllMembersEnabled",
+      ModelRole.BannedMembersModel.int:"bannedMembers",
     }.toTable
 
   method data(self: SectionModel, index: QModelIndex, role: int): QVariant =
@@ -168,6 +170,8 @@ QtObject:
       result = newQVariant(item.historyArchiveSupportEnabled)
     of ModelRole.PinMessageAllMembersEnabled:
       result = newQVariant(item.pinMessageAllMembersEnabled)
+    of ModelRole.BannedMembersModel:
+      result = newQVariant(item.bannedMembers)
 
   proc isItemExist(self: SectionModel, id: string): bool =
     for it in self.items:
@@ -241,7 +245,8 @@ QtObject:
       ModelRole.Muted.int, 
       ModelRole.MembersModel.int,
       ModelRole.PendingRequestsToJoinModel.int,
-      ModelRole.HistoryArchiveSupportEnabled.int
+      ModelRole.HistoryArchiveSupportEnabled.int,
+      ModelRole.BannedMembersModel.int
       ])
 
 
@@ -271,7 +276,8 @@ QtObject:
       ModelRole.MembersModel.int,
       ModelRole.PendingRequestsToJoinModel.int,
       ModelRole.HistoryArchiveSupportEnabled.int,
-      ModelRole.PinMessageAllMembersEnabled.int
+      ModelRole.PinMessageAllMembersEnabled.int,
+      ModelRole.BannedMembersModel.int
       ])
 
   proc getItemById*(self: SectionModel, id: string): SectionItem =

--- a/src/app_service/service/community/service.nim
+++ b/src/app_service/service/community/service.nim
@@ -1124,6 +1124,12 @@ QtObject:
     except Exception as e:
       error "Error banning user from community", msg = e.msg
 
+  proc unbanUserFromCommunity*(self: Service, communityId: string, pubKey: string)  =
+    try:
+      discard status_go.unbanUserFromCommunity(communityId, pubKey)
+    except Exception as e:
+      error "Error banning user from community", msg = e.msg
+
   proc setCommunityMuted*(self: Service, communityId: string, muted: bool) =
     try:
       discard status_go.setCommunityMuted(communityId, muted)

--- a/src/backend/communities.nim
+++ b/src/backend/communities.nim
@@ -259,6 +259,12 @@ proc banUserFromCommunity*(communityId: string, pubKey: string): RpcResponse[Jso
     "user": pubKey
   }])
 
+proc unbanUserFromCommunity*(communityId: string, pubKey: string): RpcResponse[JsonNode] {.raises: [Exception].}  =
+  return callPrivateRPC("unbanUserFromCommunity".prefix, %*[{
+    "communityId": communityId,
+    "user": pubKey
+  }])
+
 proc setCommunityMuted*(communityId: string, muted: bool): RpcResponse[JsonNode] {.raises: [Exception].}  =
   return callPrivateRPC("setCommunityMuted".prefix, %*[communityId, muted])
 

--- a/ui/app/AppLayouts/Chat/panels/communities/CommunityMembersSettingsPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/CommunityMembersSettingsPanel.qml
@@ -17,6 +17,8 @@ SettingsPageLayout {
     id: root
 
     property var membersModel
+    property var bannedMembersModel
+    property string communityName
 
     property bool editable: true
     property int pendingRequests
@@ -25,138 +27,183 @@ SettingsPageLayout {
     signal userProfileClicked(string id)
     signal kickUserClicked(string id)
     signal banUserClicked(string id)
+    signal unbanUserClicked(string id)
 
     title: qsTr("Members")
 
     content: ColumnLayout {
         spacing: 8
 
-        StatusInput {
-            id: memberSearch
-
+        StatusTabBar {
+            id: membersTabBar
             Layout.fillWidth: true
 
-            leftPadding: 0
-            rightPadding: 0
-            placeholderText: qsTr("Member name")
-        }
+            StatusTabButton {
+                id: allMembersBtn
+                width: implicitWidth
+                text: qsTr("All Members")
+            }
 
-        StatusContactRequestsIndicatorListItem {
-            id: memberRequestsButton
+// TODO will be added in next phase
+//            StatusTabButton {
+//                id: pendingRequestsBtn
+//                width: implicitWidth
+//                text: qsTr("Pending Requests")
+//                enabled: false
+//            }
+// Temporary commented until we provide appropriate flags on the `status-go` side to cover all sections.
+//            StatusTabButton {
+//                id: rejectedRequestsBtn
+//                width: implicitWidth
+//                enabled: root.contactsStore.receivedButRejectedContactRequestsModel.count > 0 ||
+//                         root.contactsStore.sentButRejectedContactRequestsModel.count > 0
+//                btnText: qsTr("Rejected Requests")
+//            }
 
-            Layout.fillWidth: true
-
-            visible: root.editable && root.pendingRequests > 0
-            title: qsTr("Membership requests")
-            requestsCount: root.pendingRequests
-            sensor.onClicked: root.membershipRequestsClicked()
-        }
-
-        Rectangle {
-            Layout.fillWidth: true
-
-            implicitHeight: 1
-            visible: memberRequestsButton.visible
-            color: Theme.palette.statusPopupMenu.separatorColor
-        }
-
-        StatusBaseText {
-            Layout.alignment: Qt.AlignHCenter
-
-            visible: memberList.count === 0
-            text: qsTr("Community members will appear here")
-            font.pixelSize: 15
-            color: Theme.palette.baseColor1
-        }
-
-        StatusBaseText {
-            Layout.alignment: Qt.AlignHCenter
-
-            visible: !!memberSearch.input.text && memberList.height == 0
-            text: qsTr("No contacts found")
-            font.pixelSize: 15
-            color: Theme.palette.baseColor1
-        }
-
-        StatusListView {
-            id: memberList
-
-            Layout.fillWidth: true
-            Layout.fillHeight: true
-
-            model: root.membersModel
-
-            // TODO: use StatusMemberListItem (it does not behave correctly right now)
-            delegate: StatusListItem {
-                id: memberItem
-
-                readonly property bool itsMe: model.pubKey.toLowerCase() === userProfile.pubKey.toLowerCase()
-                readonly property bool isOnline: model.onlineStatus === Constants.onlineStatus.online
-
-                width: memberList.width
-
-                // FIXME: use QSortFilterProxyModel instead
-                visible: memberSearch.input.text === "" || title.toLowerCase().includes(memberSearch.input.text.toLowerCase())
-                height: visible ? implicitHeight : 0
-
-                title: {
-                    if (memberItem.itsMe) {
-                        return qsTr("You")
-                    }
-                    return !model.displayName.endsWith(".eth") ? model.displayName : Utils.removeStatusEns(model.displayName)
-                }
-                subTitle: Utils.getElidedCompressedPk(model.pubKey)
-
-                statusListItemIcon {
-                    name: model.displayName
-                    badge {
-                        visible: true
-                        color: memberItem.isOnline ? Theme.palette.successColor1 : Theme.palette.baseColor1
-                    }
-                }
-
-                image {
-                    width: 40
-                    height: 40
-                    source: model.icon
-                }
-
-                icon {
-                    width: 40
-                    height: 40
-                    color: Utils.colorForPubkey(model.pubKey)
-                    letterSize: Math.max(4, root.imageWidth / 2.4)
-                    charactersLen: 2
-                    isLetterIdenticon: true
-                }
-
-                ringSettings {
-                    ringSpecModel: Utils.getColorHashAsJson(model.pubKey)
-                    ringPxSize: Math.max(icon.width / 24.0)
-                }
-
-                onClicked: root.userProfileClicked(model.pubKey)
-
-                components: [
-                    StatusButton {
-                        visible: root.editable && !memberItem.itsMe
-                        text: qsTr("Ban")
-                        type: StatusBaseButton.Type.Danger
-                        size: StatusBaseButton.Size.Tiny
-
-                        onClicked: root.banUserClicked(model.pubKey)
-                    },
-
-                    StatusButton {
-                        visible: root.editable && !memberItem.itsMe
-                        text: qsTr("Kick")
-                        type: StatusBaseButton.Type.Danger
-                        size: StatusBaseButton.Size.Tiny
-
-                        onClicked: root.kickUserClicked(model.pubKey)
-                    }
-                ]
+            StatusTabButton {
+                id: bannedBtn
+                width: implicitWidth
+                enabled: bannedMembersModel.count > 0
+                text: qsTr("Banned")
             }
         }
+
+        StackLayout {
+            id: stackLayout
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            currentIndex: membersTabBar.currentIndex
+
+            CommunityMembersTabPanel {
+                model: root.membersModel
+                placeholderText: {
+                    if (root.membersModel.count === 0) {
+                        return qsTr("No members to search")
+                    } else {
+                        return qsTr("Search %1's %2 member%3").arg(root.communityName)
+                                                              .arg(root.membersModel.count)
+                                                              .arg(root.membersModel.count > 1 ? "s" : "")
+                    }
+                }
+                panelType: CommunityMembersTabPanel.TabType.AllMembers
+
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+
+                onUserProfileClicked: root.userProfileClicked(id)
+                onKickUserClicked: {
+                    kickModal.userNameToKick = name
+                    kickModal.userIdToKick = id
+                    kickModal.open()
+                }
+
+                onBanUserClicked: {
+                    banModal.userNameToBan = name
+                    banModal.userIdToBan = id
+                    banModal.open()
+                }
+            }
+
+            CommunityMembersTabPanel {
+                model: root.bannedMembersModel
+                placeholderText: {
+                    if (root.bannedMembersModel.count === 0) {
+                        return qsTr("No banned members to search")
+                    } else {
+                        return qsTr("Search %1's %2 banned member%3").arg(root.communityName)
+                                                              .arg(root.bannedMembersModel.count)
+                                                              .arg(root.bannedMembersModel.count > 1 ? "s" : "")
+                    }
+                }
+                panelType: CommunityMembersTabPanel.TabType.BannedMembers
+
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+
+                onUserProfileClicked: root.userProfileClicked(id)
+                onUnbanUserClicked: root.unbanUserClicked(id)
+            }
+        }
+    }
+
+    StatusModal {
+        id: banModal
+
+        property string userNameToBan: ""
+        property string userIdToBan: ""
+
+        readonly property string text: qsTr("Are you sure you ban <b>%1</b> from %2?").arg(userNameToBan).arg(root.communityName)
+
+        anchors.centerIn: parent
+        width: 400
+        header.title: qsTr("Ban %1").arg(userNameToBan)
+
+        contentItem: StatusBaseText {
+            id: banContentText
+            anchors.centerIn: parent
+            font.pixelSize: 15
+            color: Theme.palette.directColor1
+            padding: 15
+            wrapMode: Text.WordWrap
+            text: banModal.text
+        }
+
+        rightButtons: [
+            StatusButton {
+                text: qsTr("Cancel")
+                onClicked: banModal.close()
+                normalColor: "transparent"
+                hoverColor: "transparent"
+            },
+            StatusButton {
+                id: banButton
+                text: qsTr("Ban")
+                type: StatusBaseButton.Type.Danger
+                onClicked: {
+                    root.banUserClicked(banModal.userIdToBan)
+                    banModal.close()
+                }
+            }
+        ]
+    }
+
+    StatusModal {
+        id: kickModal
+
+        property string userNameToKick: ""
+        property string userIdToKick: ""
+
+        readonly property string text : qsTr("Are you sure you kick <b>%1</b> from %2?").arg(userNameToKick).arg(communityName)
+
+        anchors.centerIn: parent
+        width: 400
+        header.title: qsTr("Kick %1").arg(userNameToKick)
+
+        contentItem: StatusBaseText {
+            id: kickContentText
+            anchors.centerIn: parent
+            font.pixelSize: 15
+            color: Theme.palette.directColor1
+            padding: 15
+            wrapMode: Text.WordWrap
+            text: kickModal.text
+        }
+
+        rightButtons: [
+            StatusButton {
+                text: qsTr("Cancel")
+                onClicked: kickModal.close()
+                normalColor: "transparent"
+                hoverColor: "transparent"
+            },
+            StatusButton {
+                text: qsTr("Kick")
+                type: StatusBaseButton.Type.Danger
+                onClicked: {
+                    root.kickUserClicked(kickModal.userIdToKick)
+                    kickModal.close()
+                }
+            }
+        ]
     }
 }

--- a/ui/app/AppLayouts/Chat/panels/communities/CommunityMembersTabPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/CommunityMembersTabPanel.qml
@@ -1,0 +1,119 @@
+import QtQuick 2.14
+import QtQuick.Layouts 1.14
+import QtQuick.Controls 2.14
+
+import StatusQ.Core 0.1
+import StatusQ.Core.Theme 0.1
+import StatusQ.Controls 0.1
+import StatusQ.Components 0.1
+import StatusQ.Popups 0.1
+
+import utils 1.0
+import shared.controls.chat 1.0
+
+import "../../layouts"
+
+Item {
+    id: root
+
+    property string placeholderText
+    property var model
+
+    signal userProfileClicked(string id)
+    signal kickUserClicked(string id, string name)
+    signal banUserClicked(string id, string name)
+    signal unbanUserClicked(string id)
+
+    enum TabType {
+        AllMembers,
+        BannedMembers
+    }
+
+    property int panelType: CommunityMembersTabPanel.TabType.AllMembers
+
+    ColumnLayout {
+        anchors.fill: parent
+        spacing: 25
+
+        StatusInput {
+            id: memberSearch
+            Layout.preferredWidth: 350
+            maximumHeight: 36
+            topPadding: 0
+            bottomPadding: 0
+            rightPadding: 0
+            placeholderText: root.placeholderText
+            input.icon.name: "search"
+            enabled: model.count > 0
+        }
+
+        ListView {
+            id: membersList
+
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+
+            model: root.model
+            clip: true
+
+            delegate: StatusMemberListItem {
+                id: memberItem
+
+                readonly property bool itsMe: model.pubKey.toLowerCase() === userProfile.pubKey.toLowerCase()
+                readonly property bool showButton: !memberItem.itsMe && !model.isAdmin
+                                                    && memberItem.sensor.containsMouse
+
+                statusListItemComponentsSlot.spacing: 16
+                rightPadding: 80
+
+                components: [
+                    StatusButton {
+                        visible: (root.panelType === CommunityMembersTabPanel.TabType.AllMembers) && showButton
+                        text: qsTr("Kick")
+                        type: StatusBaseButton.Type.Danger
+                        size: StatusBaseButton.Size.Small
+                        onClicked: root.kickUserClicked(model.pubKey, model.displayName)
+                    },
+
+                    StatusButton {
+                        visible: (root.panelType === CommunityMembersTabPanel.TabType.AllMembers) && showButton
+                        text: qsTr("Ban")
+                        type: StatusBaseButton.Type.Danger
+                        size: StatusBaseButton.Size.Small
+                        onClicked: root.banUserClicked(model.pubKey, model.displayName)
+                    },
+
+                    StatusButton {
+                        visible: (root.panelType === CommunityMembersTabPanel.TabType.BannedMembers) && showButton
+                        text: qsTr("Unban")
+                        type: StatusBaseButton.Type.Normal
+                        size: StatusBaseButton.Size.Small
+                        onClicked: root.unbanUserClicked(model.pubKey)
+                        width: 95
+                    }
+                ]
+
+                width: membersList.width
+                visible: memberSearch.text === "" || title.toLowerCase().includes(memberSearch.text.toLowerCase())
+                height: visible ? implicitHeight : 0
+                color: "transparent"
+
+                pubKey: Utils.getElidedCompressedPk(model.pubKey)
+                nickName: model.localNickname
+                userName: model.displayName
+                status: model.onlineStatus
+                icon.color: Theme.palette.userCustomizationColors[Utils.colorIdForPubkey(model.pubKey)] // FIXME: use model.colorId
+                image.source: model.icon
+                image.isIdenticon: false
+                image.width: 36
+                image.height: 36
+                icon.height: 36
+                icon.width: 36
+                ringSettings.ringSpecModel: Utils.getColorHashAsJson(model.pubKey)
+                statusListItemIcon.badge.visible: (root.panelType === CommunityMembersTabPanel.TabType.AllMembers)
+
+                onClicked: root.userProfileClicked(model.pubKey)
+            }
+        }
+    }
+}

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -279,6 +279,10 @@ QtObject {
         chatCommunitySectionModule.banUserFromCommunity(pubKey);
     }
 
+    function unbanUserFromCommunity(pubKey) {
+        chatCommunitySectionModule.unbanUserFromCommunity(pubKey);
+    }
+
     function createCommunityChannel(channelName, channelDescription, channelEmoji, channelColor,
             categoryId) {
         chatCommunitySectionModule.createCommunityChannel(channelName, channelDescription,

--- a/ui/app/AppLayouts/Chat/views/CommunitySettingsView.qml
+++ b/ui/app/AppLayouts/Chat/views/CommunitySettingsView.qml
@@ -183,12 +183,15 @@ StatusAppTwoPanelLayout {
 
             CommunityMembersSettingsPanel {
                 membersModel: root.community.members
+                bannedMembersModel: root.community.bannedMembers
                 editable: root.community.amISectionAdmin
                 pendingRequests: root.community.pendingRequestsToJoin ? root.community.pendingRequestsToJoin.count : 0
+                communityName: root.community.name
 
                 onUserProfileClicked: Global.openProfilePopup(id)
                 onKickUserClicked: root.rootStore.removeUserFromCommunity(id)
                 onBanUserClicked: root.rootStore.banUserFromCommunity(id)
+                onUnbanUserClicked: root.rootStore.unbanUserFromCommunity(id)
                 onMembershipRequestsClicked: Global.openPopup(root.membershipRequestPopup, {
                     communitySectionModule: root.chatCommunitySectionModule
                 })


### PR DESCRIPTION
Issue #5979

### What does the PR do

According to Figma design: https://www.figma.com/file/17fc13UBFvInrLgNUKJJg5/Kuba%E2%8E%9CDesktop?node-id=3113%3A356327
new tabs are added: "All members" and "Banned". Also unban functionality is added.
The scope is described in the issue.

### Affected areas

Community settings / members

### Screenshot of functionality

https://user-images.githubusercontent.com/61889657/176382827-c215566b-65a1-4550-b6a3-9a9875767fdb.mov


