### PR TITLE
hotfix(@desktop/chat): Removed the condition that was causing the chat highlight animation to run each time it was visible

### DIFF
--- a/ui/imports/shared/views/chat/CompactMessageView.qml
+++ b/ui/imports/shared/views/chat/CompactMessageView.qml
@@ -172,7 +172,6 @@ Item {
 
     SequentialAnimation {
         id: messageFoundAnimation
-        running: visible
         PauseAnimation {
             duration: 600
         }


### PR DESCRIPTION
Removed the condition that was causing the chat highlight animation to run each time it was visible

### What does the PR do

Removes the condition -` running = visible`, which was causing the chat background to animate each time its visibility turned to true

### Affected areas

Chat

### Screenshot of functionality

https://user-images.githubusercontent.com/60327365/176479094-8d282cf2-3d84-4ccd-8031-cad4a19d860b.mov


