### PR TITLE
fix(chat): fix gifs staying active in the background when switching chat

### DIFF
--- a/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
@@ -49,14 +49,13 @@ Item {
 
     onIsActiveChannelChanged: {
         if (!isActiveChannel) {
-            root.allMessagesLoaded = false
             return
         }
         // We wait to load all messages, because switching back to chats makes
         // the scroll go crazy so it loads way too many messages making it slow
         timer.setTimeout(function() {
             root.allMessagesLoaded = true
-        }, 10);
+        }, 5);
     }
 
     Connections {
@@ -117,7 +116,6 @@ Item {
                 text: qsTr("Loading...")
             }
             StatusLoadingIndicator {
-                color: Theme.palette.directColor4
                 anchors.left: loadingText.right
                 anchors.leftMargin: 8
             }
@@ -286,6 +284,7 @@ Item {
             channelEmoji: root.channelEmoji
             emojiPopup: root.emojiPopup
 
+            isActiveChannel: root.isActiveChannel
             isChatBlocked: root.isChatBlocked
             messageContextMenu: messageContextMenuInst
 

--- a/ui/imports/shared/status/StatusChatImageLoader.qml
+++ b/ui/imports/shared/status/StatusChatImageLoader.qml
@@ -10,7 +10,8 @@ Item {
     property int imageWidth: 350
     property bool isCurrentUser: false
     property url source
-    property bool playing: Global.applicationWindow.active
+    property bool isActiveChannel: false
+    property bool playing: Global.applicationWindow.active && isChatActive
     property bool isAnimated: !!source && source.toString().endsWith('.gif')
     signal clicked(var image, var mouse)
     property var container

--- a/ui/imports/shared/views/chat/CompactMessageView.qml
+++ b/ui/imports/shared/views/chat/CompactMessageView.qml
@@ -27,6 +27,7 @@ Item {
     property var container
     property int contentType
     property bool isChatBlocked: false
+    property bool isActiveChannel: false
 
     property int chatHorizontalPadding: Style.current.halfPadding
     property int chatVerticalPadding: 7
@@ -546,6 +547,7 @@ Item {
                         playing: root.messageStore.playAnimation
                         imageSource: messageImage
                         imageWidth: 200
+                        isActiveChannel: root.isActiveChannel
                         onClicked: {
                             if (mouse.button === Qt.LeftButton) {
                                 root.imageClicked(image)

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -23,6 +23,7 @@ Column {
     property var contactsStore
     property var messageContextMenu
     property string channelEmoji
+    property bool isActiveChannel: false
 
     property var emojiPopup
 
@@ -337,6 +338,7 @@ Column {
             messageContextMenu: root.messageContextMenu
             contentType: root.messageContentType
             isChatBlocked: root.isChatBlocked
+            isActiveChannel: root.isActiveChannel
             emojiPopup: root.emojiPopup
 
             communityId: root.communityId


### PR DESCRIPTION
Sets playing to `false` on gifs when the channel is no longer active.

Also doesn't set `allMessagesLoaded` to false when switching channel in the same group, because we want to keep the fast switching for that.