### PR TITLE
chore: remove .gitignore from build dir

### DIFF
--- a/build/.gitignore
+++ b/build/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore


### PR DESCRIPTION
- build directory is already ignored by main .gitignore
- removing build directory shows build/.gitignore in git status
which is annoying
