### PR TITLE
feat: output messages to csv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ status-react-translations/
 notarization.log
 status-desktop.log
 nim_status_client.log
+*.csv
 
 # Squish test ================================================================
 

--- a/Makefile
+++ b/Makefile
@@ -211,6 +211,12 @@ NIM_PARAMS += -d:DESKTOP_VERSION="$(DESKTOP_VERSION)"
 GIT_COMMIT=`git log --pretty=format:'%h' -n 1`
 NIM_PARAMS += -d:GIT_COMMIT="$(GIT_COMMIT)"
 
+OUTPUT_CSV ?= false
+ifeq ($(OUTPUT_CSV), true)
+  NIM_PARAMS += -d:output_csv
+  $(shell touch .update.timestamp)
+endif
+
 $(DOTHERSIDE): | deps
 	echo -e $(BUILD_MSG) "DOtherSide"
 	+ cd vendor/DOtherSide && \

--- a/src/app_service/service/accounts/service.nim
+++ b/src/app_service/service/accounts/service.nim
@@ -21,8 +21,10 @@ logScope:
 
 const PATHS = @[PATH_WALLET_ROOT, PATH_EIP_1581, PATH_WHISPER, PATH_DEFAULT_WALLET]
 const ACCOUNT_ALREADY_EXISTS_ERROR =  "account already exists"
+const output_csv {.booldefine.} = false
 
 include utils
+
 
 type
   Service* = ref object of RootObj
@@ -486,6 +488,7 @@ proc login*(self: Service, account: AccountDto, password: string): string =
         "Port": DEFAULT_TORRENT_CONFIG_PORT
       },
       "Networks": NETWORKS,
+      "OutputMessageCSVEnabled": output_csv
     }
 
     let response = status_account.login(account.name, account.keyUid, hashedPassword, thumbnailImage,


### PR DESCRIPTION
To output the messages to a csv file, execute:
`make run OUTPUT_CSV=true`

Requires
- https://github.com/status-im/status-go/pull/2737

