### PR TITLE
ci: bump macos job timeout to 25 minutes

### DIFF
--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -21,7 +21,7 @@ pipeline {
   options {
     timestamps()
     /* Prevent Jenkins jobs from running forever */
-    timeout(time: 20, unit: 'MINUTES')
+    timeout(time: 25, unit: 'MINUTES')
     /* manage how many builds we keep */
     buildDiscarder(logRotator(
       numToKeepStr: '10',


### PR DESCRIPTION
For some release builds the notarization step fails because Apple backend takes too long to return results. But the timeout triggered is the Jenkins job timeout and no the notarization timeout.