### PR TITLE
feat(Communities): support tags in community edit page

### DIFF
--- a/src/app/modules/main/communities/models/curated_community_item.nim
+++ b/src/app/modules/main/communities/models/curated_community_item.nim
@@ -8,8 +8,9 @@ type
     available: bool
     icon: string
     color: string
+    tags: string
     members: int
-    
+
 proc initCuratedCommunityItem*(
   id: string,
   name: string,
@@ -17,6 +18,7 @@ proc initCuratedCommunityItem*(
   available: bool,
   icon: string,
   color: string,
+  tags: string,
   members: int
 ): CuratedCommunityItem =
   result.id = id
@@ -25,6 +27,7 @@ proc initCuratedCommunityItem*(
   result.available = available
   result.icon = icon
   result.color = color
+  result.tags  = tags
   result.members = members
 
 proc `$`*(self: CuratedCommunityItem): string =
@@ -34,6 +37,7 @@ proc `$`*(self: CuratedCommunityItem): string =
     description: {self.description},
     available: {self.available},
     color: {self.color},
+    tags: {self.tags},
     members: {self.members}
     ]"""
 
@@ -57,3 +61,6 @@ proc getMembers*(self: CuratedCommunityItem): int =
 
 proc getColor*(self: CuratedCommunityItem): string =
   return self.color
+
+proc getTags*(self: CuratedCommunityItem): string =
+  return self.tags

--- a/src/app/modules/main/communities/module.nim
+++ b/src/app/modules/main/communities/module.nim
@@ -86,6 +86,7 @@ method getCommunityItem(self: Module, c: CommunityDto): SectionItem =
       c.images.banner,
       icon = "",
       c.color,
+      c.tags,
       hasNotification = false,
       notificationsCount = 0,
       active = false,
@@ -121,6 +122,7 @@ method getCuratedCommunityItem(self: Module, c: CuratedCommunity): CuratedCommun
       c.available,
       c.community.images.thumbnail,
       c.community.color,
+      c.community.tags,
       len(c.community.members))
 
 method setCommunityTags*(self: Module, communityTags: string) =

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -210,6 +210,7 @@ proc createChannelGroupItem[T](self: Module[T], c: ChannelGroupDto): SectionItem
     c.images.banner,
     icon = if (isCommunity): "" else: conf.CHAT_SECTION_ICON,
     c.color,
+    if isCommunity: communityDetails.tags else: "",
     hasNotification,
     notificationsCount,
     active,

--- a/src/app/modules/shared_models/active_section.nim
+++ b/src/app/modules/shared_models/active_section.nim
@@ -89,6 +89,12 @@ QtObject:
   QtProperty[string] color:
     read = getColor
 
+  proc getTags(self: ActiveSection): string {.slot.} =
+    return self.item.tags
+
+  QtProperty[string] tags:
+    read = getTags
+
   proc getHasNotification(self: ActiveSection): bool {.slot.} =
     return self.item.hasNotification
 

--- a/src/app/modules/shared_models/section_item.nim
+++ b/src/app/modules/shared_models/section_item.nim
@@ -5,7 +5,7 @@ import ../main/communities/models/[pending_request_item, pending_request_model]
 type
   SectionType* {.pure.} = enum
     Chat = 0
-    Community,    
+    Community,
     Wallet,
     Browser,
     ProfileSettings,
@@ -25,6 +25,7 @@ type
     bannerImageData: string
     icon: string
     color: string
+    tags: string
     hasNotification: bool
     notificationsCount: int
     active: bool
@@ -54,6 +55,7 @@ proc initItem*(
     bannerImageData = "",
     icon = "",
     color = "",
+    tags = "",
     hasNotification = false,
     notificationsCount: int = 0,
     active = false,
@@ -82,6 +84,7 @@ proc initItem*(
   result.bannerImageData = bannerImageData
   result.icon = icon
   result.color = color
+  result.tags = tags
   result.hasNotification = hasNotification
   result.notificationsCount = notificationsCount
   result.active = active
@@ -117,6 +120,7 @@ proc `$`*(self: SectionItem): string =
     bannerImageData: {self.bannerImageData},
     icon: {self.icon},
     color: {self.color},
+    tags: {self.tags},
     hasNotification: {self.hasNotification},
     notificationsCount:{self.notificationsCount},
     active:{self.active},
@@ -166,6 +170,9 @@ proc icon*(self: SectionItem): string {.inline.} =
 
 proc color*(self: SectionItem): string {.inline.} =
   self.color
+
+proc tags*(self: SectionItem): string {.inline.} =
+  self.tags
 
 proc hasNotification*(self: SectionItem): bool {.inline.} =
   self.hasNotification

--- a/src/app/modules/shared_models/section_model.nim
+++ b/src/app/modules/shared_models/section_model.nim
@@ -17,6 +17,7 @@ type
     BannerImageData
     Icon
     Color
+    Tags
     HasNotification
     NotificationsCount
     Active
@@ -81,6 +82,7 @@ QtObject:
       ModelRole.BannerImageData.int:"bannerImageData",
       ModelRole.Icon.int:"icon",
       ModelRole.Color.int:"color",
+      ModelRole.Tags.int:"tags",
       ModelRole.HasNotification.int:"hasNotification",
       ModelRole.NotificationsCount.int:"notificationsCount",
       ModelRole.Active.int:"active",
@@ -132,6 +134,8 @@ QtObject:
       result = newQVariant(item.icon)
     of ModelRole.Color:
       result = newQVariant(item.color)
+    of ModelRole.Tags:
+      result = newQVariant(item.tags)
     of ModelRole.HasNotification:
       result = newQVariant(item.hasNotification)
     of ModelRole.NotificationsCount:
@@ -257,6 +261,7 @@ QtObject:
       ModelRole.BannerImageData.int,
       ModelRole.Icon.int,
       ModelRole.Color.int,
+      ModelRole.Tags.int,
       ModelRole.HasNotification.int,
       ModelRole.NotificationsCount.int,
       ModelRole.IsMember.int,
@@ -362,6 +367,7 @@ QtObject:
           "bannerImageData": item.bannerImageData,
           "icon": item.icon,
           "color": item.color,
+          "tags": item.tags,
           "hasNotification": item.hasNotification,
           "notificationsCount": item.notificationsCount,
           "active": item.active,

--- a/src/app_service/service/community/dto/community.nim
+++ b/src/app_service/service/community/dto/community.nim
@@ -117,11 +117,17 @@ proc toCommunityDto*(jsonObj: JsonNode): CommunityDto =
     for memberId, memberObj in membersObj:
       result.members.add(toMember(memberObj, memberId))
 
+  var tagsObj: JsonNode
+  if(jsonObj.getProp("tags", tagsObj)):
+    toUgly(result.tags, tagsObj)
+  else:
+    result.tags = "[]"
+
   discard jsonObj.getProp("canRequestAccess", result.canRequestAccess)
   discard jsonObj.getProp("canManageUsers", result.canManageUsers)
   discard jsonObj.getProp("canJoin", result.canJoin)
   discard jsonObj.getProp("color", result.color)
-  discard jsonObj.getProp("tags", result.tags)
+
   discard jsonObj.getProp("requestedToJoinAt", result.requestedToJoinAt)
   discard jsonObj.getProp("isMember", result.isMember)
   discard jsonObj.getProp("muted", result.muted)

--- a/ui/app/AppLayouts/Chat/views/CommunitySettingsView.qml
+++ b/ui/app/AppLayouts/Chat/views/CommunitySettingsView.qml
@@ -38,6 +38,17 @@ StatusAppTwoPanelLayout {
     property bool hasAddedContacts: false
     property Component membershipRequestPopup
 
+    readonly property string filteredSelectedTags: {
+        if (!community || !community.tags)
+            return "";
+
+        const json = JSON.parse(community.tags);
+        const tagsArray = json.map(tag => {
+            return tag.name;
+        });
+        return tagsArray;
+    }
+
     signal backToCommunityClicked
     signal openLegacyPopupClicked // TODO: remove me when migration to new settings is done
 
@@ -126,7 +137,7 @@ StatusAppTwoPanelLayout {
                 bannerImageData: root.community.bannerImageData
                 color: root.community.color
                 tags: root.rootStore.communityTags
-                selectedTags: root.community.tags
+                selectedTags: root.filteredSelectedTags
                 archiveSupportEnabled: root.community.historyArchiveSupportEnabled
                 requestToJoinEnabled: root.community.access === Constants.communityChatOnRequestAccess
                 pinMessagesEnabled: root.community.pinMessageAllMembersEnabled

--- a/ui/app/AppLayouts/CommunitiesPortal/controls/CommunityTagsPicker.qml
+++ b/ui/app/AppLayouts/CommunitiesPortal/controls/CommunityTagsPicker.qml
@@ -18,8 +18,8 @@ ColumnLayout {
     signal pick()
 
     onSelectedTagsChanged: {
-        var obj = JSON.parse(tags);
-        var array = JSON.parse(selectedTags);
+        const obj = JSON.parse(tags);
+        const array = selectedTags.length ? JSON.parse(selectedTags) : [];
 
         d.tagsModel.clear();
         for (const key of Object.keys(obj)) {


### PR DESCRIPTION
Close #6089
Requires https://github.com/status-im/status-go/pull/2739

### What does the PR do

Add display and edit tags functionality to community edit page

### Affected areas

Communities

### Screenshot of functionality

<img width="646" alt="Screenshot 2022-07-01 at 15 01 27" src="https://user-images.githubusercontent.com/2522130/176890598-19a2fbf0-9721-4002-95a4-e5923c6cc082.png">

