### PR TITLE
fix(Profile): ensure backup seedphrase warning disappears

### DIFF
--- a/ui/app/AppLayouts/Profile/ProfileLayout.qml
+++ b/ui/app/AppLayouts/Profile/ProfileLayout.qml
@@ -229,8 +229,15 @@ StatusAppTwoPanelLayout {
     ModuleWarning {
         id: secureYourSeedPhrase
         width: parent.width
-        visible: profileContainer.currentIndex === Constants.settingsSubsection.profile &&
-                 !profileView.store.profileStore.userDeclinedBackupBanner
+        visible: {
+          if (profileContainer.currentIndex !== Constants.settingsSubsection.profile) {
+            return false
+          }
+          if (profileView.store.profileStore.userDeclinedBackupBanner) {
+            return false
+          }
+          return !profileView.store.profileStore.privacyStore.mnemonicBackedUp
+        }
         color: Style.current.red
         btnWidth: 100
         text: qsTr("Secure your seed phrase")

--- a/ui/app/AppLayouts/Profile/stores/ProfileStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/ProfileStore.qml
@@ -14,6 +14,8 @@ QtObject {
     property string profileLargeImage: userProfile.largeImage
     property string icon: userProfile.icon
     property bool userDeclinedBackupBanner: localAccountSensitiveSettings.userDeclinedBackupBanner
+    property var privacyStore: profileSectionModule.privacyModule
+
     onUserDeclinedBackupBannerChanged: {
         if (userDeclinedBackupBanner !== localAccountSensitiveSettings.userDeclinedBackupBanner) {
             localAccountSensitiveSettings.userDeclinedBackupBanner = userDeclinedBackupBanner


### PR DESCRIPTION
The warning to back up the seedphrase should disappear after either
dismissing the message, or in fact backing up the seed phrase.

The latter was not happening because the banner didn't take that
information into account. This commit fixes this by ensuring we let the
banner know whether the seed phrase was already backed up.

Notice that we don't want to render the banner when the seed phrase has
*not* been backed up yet, but was dismissed by the user.

Fixes #6255

