### PR TITLE
fix(@desktop): enable the hover effects by default

### DIFF
--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -199,7 +199,7 @@ proc createChannelGroupItem[T](self: Module[T], c: ChannelGroupDto): SectionItem
   result = initItem(
     c.id,
     if isCommunity: SectionType.Community else: SectionType.Chat,
-    c.name,
+    if isCommunity: c.name else: "Chat",
     c.admin,
     c.description,
     c.introMessage,

--- a/src/nim_status_client.nim
+++ b/src/nim_status_client.nim
@@ -95,6 +95,7 @@ proc mainProc() =
   installSelfSignedCertificate(imageCert)
 
   let app = newQGuiApplication()
+  os.putEnv("QT_QUICK_CONTROLS_HOVER_ENABLED", "1")
   let appController = newAppController(statusFoundation)
   let singleInstance = newSingleInstance($toMD5(DATADIR), openUri)
   let networkAccessFactory = newQNetworkAccessManagerFactory(TMPDIR & "netcache")


### PR DESCRIPTION
Close #6254

- since Qt 5.xy, hover is not enabled by default for QQC2, so enable it
unconditionally as we are a desktop app anyway
- this fixes several hover effects being broken, mostly for builtin
components like MenuItem and some buttons (eg. the leftmost NavBar)
where we haven't enabled those with `hoverEnabled: true` explicitely
- additionally, provide a tooltip for the default "chat" section which
doesn't seem to supply its own (unlike the other sections)

### What does the PR do

Fixes mouse over (hover) effects being (mostly) broken

### Affected areas

All areas of status-desktop

### Screenshot of functionality
![Snímek obrazovky z 2022-07-04 12-41-28](https://user-images.githubusercontent.com/5377645/177146645-0dbb08b3-166d-479c-8810-9825fbe1ef74.png)
![Snímek obrazovky z 2022-07-04 12-42-10](https://user-images.githubusercontent.com/5377645/177146649-035e9e51-29a3-4c95-8c8e-065c47f8fe81.png)



