### PR TITLE
Fix slow chat switching because of height recalculation

### DIFF
--- a/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
@@ -21,7 +21,6 @@ import "../controls"
 
 Item {
     id: root
-    //anchors.fill: parent
 
     property var store
     property var messageStore
@@ -44,19 +43,6 @@ Item {
     property int countOnStartUp: 0
     signal openStickerPackPopup(string stickerPackId)
     signal showReplyArea(string messageId, string author)
-
-    property bool allMessagesLoaded: false
-
-    onIsActiveChannelChanged: {
-        if (!isActiveChannel) {
-            return
-        }
-        // We wait to load all messages, because switching back to chats makes
-        // the scroll go crazy so it loads way too many messages making it slow
-        timer.setTimeout(function() {
-            root.allMessagesLoaded = true
-        }, 5);
-    }
 
     Connections {
         target: root.messageStore.messageModule
@@ -103,21 +89,6 @@ Item {
                     width: 18
                     height: 18
                 }
-            }
-        }
-    }
-
-    Loader {
-        active: !root.allMessagesLoaded
-        anchors.centerIn: parent
-        sourceComponent: Item {
-            StatusBaseText {
-                id: loadingText
-                text: qsTr("Loading...")
-            }
-            StatusLoadingIndicator {
-                anchors.left: loadingText.right
-                anchors.leftMargin: 8
             }
         }
     }
@@ -272,10 +243,6 @@ Item {
 
         delegate: MessageView {
             id: msgDelegate
-
-            // We wait to load all messages, because switching back to chats makes
-            // the scroll go crazy so it loads way too many messages making it slow
-            visible:  root.allMessagesLoaded
 
             store: root.store
             messageStore: root.messageStore

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -10,12 +10,27 @@ import shared.panels.chat 1.0
 import shared.views.chat 1.0
 import shared.controls.chat 1.0
 
-Column {
+Loader {
     id: root
 
     width: parent.width
-    anchors.right: !isCurrentUser ? undefined : parent.right
     z: (typeof chatLogView === "undefined") ? 1 : (chatLogView.count - index)
+
+    sourceComponent: {
+        switch(contentType) {
+            case Constants.messageContentType.chatIdentifier:
+                return channelIdentifierComponent
+            case Constants.messageContentType.fetchMoreMessagesButton:
+                return fetchMoreMessagesButtonComponent
+            case Constants.messageContentType.systemMessagePrivateGroupType:
+                return privateGroupHeaderComponent
+            case Constants.messageContentType.gapType:
+                return gapComponent
+            default:
+                return compactMessageComponent
+
+        }
+    }
 
     property var store
     property var messageStore
@@ -211,7 +226,7 @@ Column {
 //    }
 
     function startMessageFoundAnimation() {
-        messageLoader.item.startMessageFoundAnimation();
+        root.item.startMessageFoundAnimation();
     }
     /////////////////////////////////////////////
 
@@ -235,27 +250,6 @@ Column {
 //            }
 //        }
 //    }
-
-    Loader {
-        id: messageLoader
-        active: root.visible
-        width: parent.width
-        sourceComponent: {
-            switch(contentType) {
-                case Constants.messageContentType.chatIdentifier:
-                    return channelIdentifierComponent
-                case Constants.messageContentType.fetchMoreMessagesButton:
-                    return fetchMoreMessagesButtonComponent
-                case Constants.messageContentType.systemMessagePrivateGroupType:
-                    return privateGroupHeaderComponent
-                case Constants.messageContentType.gapType:
-                    return gapComponent
-                default:
-                    return compactMessageComponent
-
-            }
-        }
-    }
 
     Component {
         id: gapComponent


### PR DESCRIPTION
The problem was that the messages were re-rendered completely when switching, mostly because of the `active` on the loader being reset to false.
Then, since it needed re-render, the  height needed to be re-calculated, and since the height defaults to 0 when starting, the list though that it needed to render **everything**, hence it took an awful lot of time to switch back.

This should all be fixed. I tested in Windows and Linux and it felt very fast to me. Please test it out yourselves.