### PR TITLE
fix(gif popup): fix the popup after sending a GIF

### DIFF
--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -35,7 +35,7 @@ Rectangle {
     property var emojiPopup: null
     // Use this to only enable the Connections only when this Input opens the Emoji popup
     property bool emojiPopupOpened: false
-    property bool closeGifPopupAfterSelection: false
+    property bool closeGifPopupAfterSelection: true
 
     property bool emojiEvent: false;
     property bool paste: false;


### PR DESCRIPTION
Close #6083

### What does the PR do

By default, enable automatically closing the GIF popup after having sent a GIF to the chat

### Affected areas

Chat, chat input

### Screenshot of functionality

<!-- screenshot (or gif/video) that demonstrates the functionality, specially important if it's a bug fix. -->
[Záznam obrazovky z 5.7.2022 10:53:33.webm](https://user-images.githubusercontent.com/5377645/177290058-f6ec5488-36ca-453f-b7e2-85a8ae9f4b68.webm)

