### PR TITLE
fix(@desktop) emoji hash icons are very big

### DIFF
--- a/ui/imports/shared/controls/EmojiHash.qml
+++ b/ui/imports/shared/controls/EmojiHash.qml
@@ -9,9 +9,10 @@ import shared.panels 1.0
 Item {
     id: root
 
+    property bool compact: false
     property string publicKey
 
-    property real size: 16
+    readonly property real size: compact ? 10 : 15
 
     implicitHeight: positioner.implicitHeight
     implicitWidth: positioner.implicitWidth

--- a/ui/imports/shared/controls/EmojiHash.qml
+++ b/ui/imports/shared/controls/EmojiHash.qml
@@ -21,8 +21,8 @@ Item {
         id: positioner
 
         rows: 2
-        columnSpacing: Math.ceil(root.size / 16)
-        rowSpacing: columnSpacing + 6
+        columnSpacing: 0
+        rowSpacing: root.compact ? 4 : 6
 
         Repeater {
             model: Utils.getEmojiHashAsJson(root.publicKey)

--- a/ui/imports/shared/controls/EmojiHash.qml
+++ b/ui/imports/shared/controls/EmojiHash.qml
@@ -21,7 +21,7 @@ Item {
         id: positioner
 
         rows: 2
-        columnSpacing: 0
+        columnSpacing: 0.2
         rowSpacing: root.compact ? 4 : 6
 
         Repeater {

--- a/ui/imports/shared/controls/chat/ProfileHeader.qml
+++ b/ui/imports/shared/controls/chat/ProfileHeader.qml
@@ -199,8 +199,8 @@ Item {
             id: emojiHash
             Layout.alignment: Qt.AlignHCenter
             visible: root.emojiHashVisible
+            compact: root.compact
             publicKey: root.pubkey
-            size: root.compact ? 16 : 20
         }
     }
 }


### PR DESCRIPTION
Fixes: #6300

### What does the PR do

Reduce size and spaces between Emoji Icons visible in InsertDetailsView and ProfileHeader
<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas
1. Onboarding (when new user is created - InsertDetailsView.qml
2. Chat, when browsing user profile - ProfileHeader.qml
<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Screenshot of functionality

**1. Onboarding:**
_on left: Designs, on right: implementation including this fix_
![onboardingView](https://user-images.githubusercontent.com/84290812/177357527-375a7b2c-ded2-4992-b90c-fff3f12d7a99.PNG)

_implementation including this fix(opacity = 0.5) over designs_ :
![onboardingView_overlapped](https://user-images.githubusercontent.com/84290812/177357564-4184680d-b654-4dd9-8039-4acd455ec5fe.PNG)

**2. ProfilHeader small:**
_on left: Designs, on right: implementation including this fix_
![nextto_small](https://user-images.githubusercontent.com/84290812/177357937-4bdbcc49-9f89-4b59-b67b-9a4496f4aff8.PNG)

_implementation including this fix(opacity = 0.5) over designs_ :
![overlapped_small](https://user-images.githubusercontent.com/84290812/177357964-98b47522-7d92-4721-8148-6e32bb0ae3b3.PNG)


**2a. ProfilHeader:**
_on left: Designs, on right: implementation including this fix_
![nextto](https://user-images.githubusercontent.com/84290812/177358075-c1b5a3e7-4282-4dd2-8970-ab8b65899e0f.PNG)

_implementation including this fix(opacity = 0.5) over designs_ :
![overlapped](https://user-images.githubusercontent.com/84290812/177358095-be79511f-2c98-49c5-a3c2-7dc92ce6fba9.PNG)



<!-- screenshot (or gif/video) that demonstrates the functionality, specially important if it's a bug fix. -->

### Cool Spaceship Picture

This is my very first PR in here, so I would like to say Hi! 👋
<!-- optional but cool ->