### PR TITLE
fix(@desktop): correct spelling of you-r

### DIFF
--- a/ui/app/AppLayouts/Onboarding/views/ConfirmPasswordView.qml
+++ b/ui/app/AppLayouts/Onboarding/views/ConfirmPasswordView.qml
@@ -111,7 +111,7 @@ OnboardingBasePage {
 
                 width: parent.width
                 enabled: !submitBtn.loading
-                placeholderText: qsTr("Confirm you password (again)")
+                placeholderText: qsTr("Confirm your password (again)")
                 textField.echoMode: showPassword ? TextInput.Normal : TextInput.Password
                 textField.validator: RegExpValidator { regExp: /^[!-~]{0,64}$/ } // That incudes NOT extended ASCII printable characters less space and a maximum of 64 characters allowed
                 keepHeight: true


### PR DESCRIPTION
fixes: #6229

### What does the PR do

Makes "your" not "you" in _Confirm **your** password (again)_ sentence.

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas

When app asks user for re-input password during creating a new user account - ConfirmPasswordView.qml
<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Screenshot of functionality

Appearance after fix:
![afterFix](https://user-images.githubusercontent.com/84290812/177367165-0804a0ee-215b-4e16-b18c-1489ed0e613e.PNG)

<!-- screenshot (or gif/video) that demonstrates the functionality, specially important if it's a bug fix. -->
