### PR TITLE
fix(Communities): Fix channels reordering

### DIFF
--- a/src/app/modules/main/chat_section/model.nim
+++ b/src/app/modules/main/chat_section/model.nim
@@ -312,10 +312,16 @@ QtObject:
 
       result.hasNotifications = result.hasNotifications or self.items[i].BaseItem.hasUnreadMessages
       result.notificationsCount = result.notificationsCount + self.items[i].BaseItem.notificationsCount
-
+ 
+  proc reorderSubModel(self: Model, chatId: string, position: int) =
+    for it in self.items:
+      if(it.subItems.getCount() > 0):
+        it.subItems.reorder(chatId, position)
+    
   proc reorder*(self: Model, chatOrCategoryId: string, position: int) =
     let index = self.getItemIdxById(chatOrCategoryId)
     if(index == -1):
+      self.reorderSubModel(chatOrCategoryId, position)
       return
 
     self.items[index].BaseItem.position = position

--- a/src/app/modules/main/chat_section/sub_model.nim
+++ b/src/app/modules/main/chat_section/sub_model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, strformat, json
+import NimQml, Tables, strformat, json, algorithm
 
 import sub_item
 
@@ -245,3 +245,19 @@ QtObject:
         self.dataChanged(index, index, @[ModelRole.HasUnreadMessages.int, ModelRole.NotificationsCount.int])
         return true
     return false
+
+  proc sortChats(x, y: SubItem): int =
+    if x.position < y.position: -1
+    elif x.position == y.position: 0
+    else: 1
+
+  proc reorder*(self: SubModel, id: string, position: int) =
+    let idx = self.getItemIdxById(id)
+    if idx == -1:
+      return
+
+    self.items[idx].BaseItem.position = position
+
+    self.beginResetModel()
+    self.items.sort(sortChats)
+    self.endResetModel()

--- a/src/app_service/service/community/service.nim
+++ b/src/app_service/service/community/service.nim
@@ -313,7 +313,7 @@ QtObject:
           # Handle position changes
           if(chat.id == prev_chat.id and chat.position != prev_chat.position):
             self.events.emit(SIGNAL_COMMUNITY_CHANNEL_REORDERED, CommunityChatOrderArgs(communityId: community.id,
-            chatId: community.id&chat.id, categoryId: chat.categoryId, position: chat.position))
+            chatId: chat.id, categoryId: chat.categoryId, position: chat.position))
 
           # Handle name/description changes
           if(chat.id == prev_chat.id and (chat.name != prev_chat.name or chat.description != prev_chat.description)):
@@ -804,7 +804,7 @@ QtObject:
               self.joinedCommunities[communityId].chats[prev_chat_idx].position = chat.position
               chatDetails.updateMissingFields(self.joinedCommunities[communityId].chats[prev_chat_idx])
               self.chatService.updateOrAddChat(chatDetails) # we have to update chats stored in the chat service.
-              self.events.emit(SIGNAL_COMMUNITY_CHANNEL_REORDERED, CommunityChatOrderArgs(communityId: updatedCommunity.id, chatId: fullChatId, categoryId: chat.categoryId, position: chat.position))
+              self.events.emit(SIGNAL_COMMUNITY_CHANNEL_REORDERED, CommunityChatOrderArgs(communityId: updatedCommunity.id, chatId: chat.id, categoryId: chat.categoryId, position: chat.position))
 
     except Exception as e:
       error "Error reordering community channel", msg = e.msg, communityId, chatId, position, procName="reorderCommunityChat"


### PR DESCRIPTION
Closes: #6292

### What does the PR do

Add `reorder` method to `SubModel` and remove prepended communityID to chatID.

### Affected areas

Communities 
