### PR TITLE
Fix(Chat): Reset MessageContextMenuView state on close

### DIFF
--- a/src/app_service/service/contacts/service.nim
+++ b/src/app_service/service/contacts/service.nim
@@ -365,25 +365,27 @@ QtObject:
 
   proc unblockContact*(self: Service, publicKey: string) =
     var contact = self.getContactById(publicKey)
-    contact.blocked = false
 
     let response = status_contacts.unblockContact(contact.id)
     if(not response.error.isNil):
       let msg = response.error.message
       error "error unblocking contact ", msg
       return
+
+    contact.blocked = false
     self.saveContact(contact)
     self.events.emit(SIGNAL_CONTACT_UNBLOCKED, ContactArgs(contactId: contact.id))
 
   proc blockContact*(self: Service, publicKey: string) =
     var contact = self.getContactById(publicKey)
-    contact.blocked = true
 
     let response = status_contacts.blockContact(contact.id)
     if(not response.error.isNil):
       let msg = response.error.message
       error "error blocking contact ", msg
       return
+
+    contact.blocked = true
     self.saveContact(contact)
     self.events.emit(SIGNAL_CONTACT_BLOCKED, ContactArgs(contactId: contact.id))
 

--- a/ui/imports/shared/views/chat/MessageContextMenuView.qml
+++ b/ui/imports/shared/views/chat/MessageContextMenuView.qml
@@ -97,6 +97,7 @@ StatusPopupMenu {
 
     onHeightChanged: { root.y = setYPosition(); }
     onWidthChanged: { root.x = setXPosition(); }
+    onClosed: selectedUserPublicKey = ""
 
     width: Math.max(emojiContainer.visible ? emojiContainer.width : 0, 200)
 


### PR DESCRIPTION
Close #5289

### What does the PR do

This handler needed because we set contact data on menu open, but not reset it on close. This caused not to update menu state when we click on the same contact.

### Affected areas

Chat
