### PR TITLE
fix(contacts): remove isContact, use isMutualContact or isAdded indead

### DIFF
--- a/src/app/modules/main/chat_section/chat_content/chat_details.nim
+++ b/src/app/modules/main/chat_section/chat_content/chat_details.nim
@@ -19,7 +19,7 @@ QtObject:
     muted: bool
     position: int
     isUntrustworthy: bool
-    isMutualContact: bool
+    isContact: bool
 
   proc delete*(self: ChatDetails) =
     self.QObject.delete
@@ -31,7 +31,7 @@ QtObject:
   proc setChatDetails*(self: ChatDetails, id: string, `type`: int, belongsToCommunity,
       isUsersListAvailable: bool, name, icon: string, color, description,
       emoji: string, hasUnreadMessages: bool, notificationsCount: int, muted: bool, position: int,
-      isUntrustworthy: bool, isMutualContact: bool = false) =
+      isUntrustworthy: bool, isContact: bool = false) =
     self.id = id
     self.`type` = `type`
     self.belongsToCommunity = belongsToCommunity
@@ -46,7 +46,7 @@ QtObject:
     self.muted = muted
     self.position = position
     self.isUntrustworthy = isUntrustworthy
-    self.isMutualContact = isMutualContact
+    self.isContact = isContact
 
   proc getId(self: ChatDetails): string {.slot.} =
     return self.id
@@ -169,13 +169,13 @@ QtObject:
 
   proc isMutualContactChanged(self: ChatDetails) {.signal.}
   proc getIsMutualContact(self: ChatDetails): bool {.slot.} =
-    return self.isMutualContact
-  QtProperty[bool] isMutualContact:
+    return self.isContact
+  QtProperty[bool] isContact:
     read = getIsMutualContact
     notify = isMutualContactChanged
 
   proc setIsMutualContact*(self: ChatDetails, value: bool) = # this is not a slot
-    self.isMutualContact = value
+    self.isContact = value
     self.isMutualContactChanged()
 
   proc isUntrustworthyChanged(self: ChatDetails) {.signal.}

--- a/src/app/modules/main/chat_section/chat_content/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/module.nim
@@ -75,12 +75,12 @@ method load*(self: Module) =
   let notificationsCount = chatDto.unviewedMentionsCount
   var chatName = chatDto.name
   var chatImage = chatDto.icon
-  var isMutualContact = false
+  var isContact = false
   var trustStatus = TrustStatus.Unknown
   if(chatDto.chatType == ChatType.OneToOne):
     let contactDto = self.controller.getContactById(self.controller.getMyChatId())
     chatName = contactDto.userNameOrAlias()
-    isMutualContact = contactDto.isMutualContact
+    isContact = contactDto.isContact
     trustStatus = contactDto.trustStatus
     if(contactDto.image.thumbnail.len > 0):
       chatImage = contactDto.image.thumbnail
@@ -89,7 +89,7 @@ method load*(self: Module) =
     self.controller.isUsersListAvailable(), chatName, chatImage,
     chatDto.color, chatDto.description, chatDto.emoji, hasNotification, notificationsCount,
     chatDto.muted, chatDto.position, isUntrustworthy = trustStatus == TrustStatus.Untrustworthy,
-    isMutualContact)
+    isContact)
 
   self.inputAreaModule.load()
   self.messagesModule.load()
@@ -349,8 +349,8 @@ method downloadMessages*(self: Module, filePath: string) =
 
 method onMutualContactChanged*(self: Module) =
   let contactDto = self.controller.getContactById(self.controller.getMyChatId())
-  let isMutualContact = contactDto.isMutualContact
-  self.view.onMutualContactChanged(isMutualContact)
+  let isContact = contactDto.isContact
+  self.view.onMutualContactChanged(isContact)
 
 method contactTrustStatusChanged*(self: Module, publicKey: string, isUntrustworthy: bool) =
     self.view.updateTrustStatus(isUntrustworthy)

--- a/src/app/modules/main/chat_section/chat_content/users/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/users/module.nim
@@ -81,7 +81,7 @@ method onNewMessagesLoaded*(self: Module, messages: seq[MessageDto]) =
       alias = contactDetails.details.alias,
       icon = contactDetails.icon,
       onlineStatus = status,
-      isContact = contactDetails.details.added,
+      isContact = contactDetails.details.isContact,
       isUntrustworthy = contactDetails.details.trustStatus == TrustStatus.Untrustworthy,
       )
     )
@@ -109,7 +109,7 @@ method contactUpdated*(self: Module, publicKey: string) =
     localNickname = contactDetails.details.localNickname,
     alias = contactDetails.details.alias,
     icon = contactDetails.icon,
-    isContact = contactDetails.details.added, #FIXME
+    isContact = contactDetails.details.isContact,
     isUntrustworthy = contactDetails.details.trustStatus == TrustStatus.Untrustworthy,
   )
 
@@ -149,7 +149,7 @@ method addChatMember*(self: Module,  member: ChatMember) =
     alias = contactDetails.details.alias,
     icon = contactDetails.icon,
     onlineStatus = status,
-    isContact = contactDetails.details.added, #FIXME
+    isContact = contactDetails.details.isContact,
     isAdmin = member.admin,
     joined = member.joined,
     isUntrustworthy = contactDetails.details.trustStatus == TrustStatus.Untrustworthy
@@ -186,7 +186,7 @@ method onChatMemberUpdated*(self: Module, publicKey: string, admin: bool, joined
     localNickname = contactDetails.details.localNickname,
     alias = contactDetails.details.alias,
     icon = contactDetails.icon,
-    isContact = contactDetails.details.added,
+    isContact = contactDetails.details.isContact,
     isAdmin = admin,
     joined = joined,
     isUntrustworthy = contactDetails.details.trustStatus == TrustStatus.Untrustworthy,

--- a/src/app/modules/main/chat_section/chat_content/view.nim
+++ b/src/app/modules/main/chat_section/chat_content/view.nim
@@ -35,10 +35,10 @@ QtObject:
   proc load*(self: View, id: string, `type`: int, belongsToCommunity, isUsersListAvailable: bool,
       name, icon: string, color, description, emoji: string, hasUnreadMessages: bool,
       notificationsCount: int, muted: bool, position: int, isUntrustworthy: bool,
-      isMutualContact: bool) =
+      isContact: bool) =
     self.chatDetails.setChatDetails(id, `type`, belongsToCommunity, isUsersListAvailable, name,
       icon, color, description, emoji, hasUnreadMessages, notificationsCount, muted, position,
-      isUntrustworthy, isMutualContact)
+      isUntrustworthy, isContact)
     self.delegate.viewDidLoad()
     self.chatDetailsChanged()
 

--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -208,7 +208,7 @@ proc createItemFromPublicKey(self: Module, publicKey: string): UserItem =
     pubKey = contactDetails.details.id,
     displayName = contactDetails.displayName,
     icon = contactDetails.icon,
-    isContact = contactDetails.details.isMutualContact(),
+    isContact = contactDetails.details.isContact(),
     isVerified = contactDetails.details.isContactVerified(),
     isUntrustworthy = contactDetails.details.isContactUntrustworthy(),
     isBlocked = contactDetails.details.isBlocked(),
@@ -614,7 +614,7 @@ method onContactAdded*(self: Module, publicKey: string) =
   self.view.contactRequestsModel().removeItemById(publicKey)
 
   let contact = self.controller.getContactById(publicKey)
-  if (contact.isMutualContact):
+  if (contact.isContact):
     self.switchToOrCreateOneToOneChat(publicKey)
 
   self.updateParentBadgeNotifications()

--- a/src/app/modules/main/communities/module.nim
+++ b/src/app/modules/main/communities/module.nim
@@ -109,7 +109,7 @@ method getCommunityItem(self: Module, c: CommunityDto): SectionItem =
           alias = contactDetails.details.alias,
           icon = contactDetails.icon,
           onlineStatus = toOnlineStatus(self.controller.getStatusForContactWithId(member.id).statusType),
-          isContact = contactDetails.details.added, # FIXME
+          isContact = contactDetails.details.isContact,
           )),
       historyArchiveSupportEnabled = c.settings.historyArchiveSupportEnabled
     )

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -237,7 +237,7 @@ proc createChannelGroupItem[T](self: Module[T], c: ChannelGroupDto): SectionItem
         alias = contactDetails.details.alias,
         icon = contactDetails.icon,
         onlineStatus = toOnlineStatus(self.controller.getStatusForContactWithId(member.id).statusType),
-        isContact = contactDetails.details.added # FIXME
+        isContact = contactDetails.details.isContact
         )),
     if (isCommunity): communityDetails.pendingRequestsToJoin.map(x => pending_request_item.initItem(
       x.id,
@@ -691,11 +691,12 @@ method getContactDetailsAsJson*[T](self: Module[T], publicKey: string): string =
     "localNickname": contact.localNickname,
     "thumbnailImage": contact.image.thumbnail,
     "largeImage": contact.image.large,
-    "isContact":contact.added,
-    "isBlocked":contact.blocked,
-    "requestReceived":contact.hasAddedUs,
-    "isSyncing":contact.isSyncing,
-    "removed":contact.removed,
+    "isContact": contact.isContact,
+    "isBlocked": contact.blocked,
+    "requestReceived": contact.hasAddedUs,
+    "isAdded": contact.isContactRequestSent,
+    "isSyncing": contact.isSyncing,
+    "removed": contact.removed,
     "trustStatus": contact.trustStatus.int,
     "verificationStatus": contact.verificationStatus.int,
     "hasAddedUs": contact.hasAddedUs
@@ -747,6 +748,7 @@ method contactUpdated*[T](self: Module[T], publicKey: string) =
     contactDetails.details.localNickname,
     contactDetails.details.alias,
     contactDetails.icon,
+    isContact = contactDetails.details.isContact,
     isUntrustworthy = contactDetails.details.isContactUntrustworthy(),
     )
 

--- a/src/app/modules/main/profile_section/contacts/module.nim
+++ b/src/app/modules/main/profile_section/contacts/module.nim
@@ -47,7 +47,7 @@ proc createItemFromPublicKey(self: Module, publicKey: string): UserItem =
     pubKey = contact.id,
     displayName = name,
     icon = image,
-    isContact = contact.isMutualContact(),
+    isContact = contact.isContact(),
     isBlocked = contact.isBlocked(),
     isVerified = contact.isContactVerified(),
     isUntrustworthy = contact.isContactUntrustworthy()
@@ -129,7 +129,7 @@ proc addItemToAppropriateModel(self: Module, item: UserItem) =
     return
   elif(contact.isBlocked()):
     self.view.blockedContactsModel().addItem(item)
-  elif(contact.isMutualContact()):
+  elif(contact.isContact()):
     self.view.myMutualContactsModel().addItem(item)
   else:
     if(contact.isContactRequestReceived() and not contact.isContactRequestSent()):

--- a/src/app/modules/shared_models/active_section.nim
+++ b/src/app/modules/shared_models/active_section.nim
@@ -187,8 +187,10 @@ QtObject:
       localNickname: string,
       alias: string,
       image: string,
+      isContact: bool,
       isUntrustworthy: bool) =
-    self.item.updateMember(pubkey, name, ensName, localNickname, alias, image, isUntrustworthy)
+    self.item.updateMember(pubkey, name, ensName, localNickname, alias, image, isContact,
+      isUntrustworthy)
 
   proc pendingRequestsToJoin(self: ActiveSection): QVariant {.slot.} =
     if (self.item.id == ""):

--- a/src/app/modules/shared_models/member_model.nim
+++ b/src/app/modules/shared_models/member_model.nim
@@ -203,7 +203,6 @@ QtObject:
     let index = self.createIndex(ind, 0, nil)
     self.dataChanged(index, index, @[ModelRole.Icon.int])
 
-# FIXME: remove defaults
   proc updateItem*(
       self: Model,
       pubKey: string,
@@ -212,10 +211,10 @@ QtObject:
       localNickname: string,
       alias: string,
       icon: string,
-      isContact: bool = false,
-      isAdmin: bool = false,
-      joined: bool = false,
-      isUntrustworthy: bool = false,
+      isContact: bool,
+      isAdmin: bool,
+      joined: bool,
+      isUntrustworthy: bool,
       ) =
     let ind = self.findIndexForMessageId(pubKey)
     if(ind == -1):
@@ -241,6 +240,40 @@ QtObject:
       ModelRole.IsContact.int,
       ModelRole.IsAdmin.int,
       ModelRole.Joined.int,
+      ModelRole.IsUntrustworthy.int,
+    ])
+
+  proc updateItem*(
+      self: Model,
+      pubKey: string,
+      displayName: string,
+      ensName: string,
+      localNickname: string,
+      alias: string,
+      icon: string,
+      isContact: bool,
+      isUntrustworthy: bool,
+      ) =
+    let ind = self.findIndexForMessageId(pubKey)
+    if(ind == -1):
+      return
+
+    self.items[ind].displayName = displayName
+    self.items[ind].ensName = ensName
+    self.items[ind].localNickname = localNickname
+    self.items[ind].alias = alias
+    self.items[ind].icon = icon
+    self.items[ind].isContact = isContact
+    self.items[ind].isUntrustworthy = isUntrustworthy
+
+    let index = self.createIndex(ind, 0, nil)
+    self.dataChanged(index, index, @[
+      ModelRole.DisplayName.int,
+      ModelRole.EnsName.int,
+      ModelRole.LocalNickname.int,
+      ModelRole.Alias.int,
+      ModelRole.Icon.int,
+      ModelRole.IsContact.int,
       ModelRole.IsUntrustworthy.int,
     ])
 

--- a/src/app/modules/shared_models/section_item.nim
+++ b/src/app/modules/shared_models/section_item.nim
@@ -243,8 +243,10 @@ proc updateMember*(
     nickname: string,
     alias: string,
     image: string,
+    isContact: bool,
     isUntrustworthy: bool) =
-  self.membersModel.updateItem(pubkey, name, ensName, nickname, alias, image, isUntrustworthy)
+  self.membersModel.updateItem(pubkey, name, ensName, nickname, alias, image, isContact,
+    isUntrustworthy)
 
 proc pendingRequestsToJoin*(self: SectionItem): PendingRequestModel {.inline.} =
   self.pendingRequestsToJoinModel

--- a/src/app_service/service/contacts/dto/contacts.nim
+++ b/src/app_service/service/contacts/dto/contacts.nim
@@ -174,7 +174,7 @@ proc isContactRemoved*(self: ContactsDto): bool =
 proc isBlocked*(self: ContactsDto): bool =
   return self.blocked
 
-proc isMutualContact*(self: ContactsDto): bool =
+proc isContact*(self: ContactsDto): bool =
   # TODO not implemented in `status-go` yet
   # But for now we consider that contact is mutual contact if I added him and he added me.
   return self.hasAddedUs and self.added and not self.removed and not self.blocked

--- a/src/app_service/service/contacts/service.nim
+++ b/src/app_service/service/contacts/service.nim
@@ -248,7 +248,7 @@ QtObject:
     elif (group == ContactsGroup.MyMutualContacts):
       # we need to revise this when we introduce "identity verification" feature
       return contacts.filter(x => x.id != myPubKey and 
-        x.isMutualContact())
+        x.isContact())
     elif (group == ContactsGroup.AllKnownContacts):
       return contacts
 
@@ -363,10 +363,9 @@ QtObject:
         return
 
       var contact = self.getContactById(publicKey)
-      if not contact.added:
-        contact.added = true
-      else:
-        contact.blocked = false
+      contact.added = true
+      contact.blocked = false
+      contact.removed = false
       self.saveContact(contact)
       self.events.emit(SIGNAL_CONTACT_ADDED, ContactArgs(contactId: contact.id))
     except Exception as e:

--- a/ui/app/AppLayouts/Chat/panels/ChatRequestMessagePanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/ChatRequestMessagePanel.qml
@@ -12,7 +12,7 @@ Item {
     width: parent.width
     height: childrenRect.height
 
-    property bool isContact
+    property bool isUserAdded
     signal addContactClicked()
 
     Image {
@@ -26,8 +26,6 @@ Item {
     StatusBaseText {
         id: contactText1
         text: qsTr("You need to be mutual contacts with this person for them to receive your messages")
-        // text: !isContact ? qsTr("You need to be mutual contacts with this person for them to receive your messages") :
-        // qsTr("Waiting for %1 to accept your request").arg(Utils.removeStatusEns(chatsModel.channelView.activeChannel.name))
         anchors.top: waveImg.bottom
         horizontalAlignment: Text.AlignHCenter
         wrapMode: Text.WordWrap
@@ -39,7 +37,7 @@ Item {
 
     StatusBaseText {
         id: contactText2
-        visible: !isContact
+        visible: !isUserAdded
         text: qsTr("Just click this button to add them as contact. They will receive a notification. Once they accept the request, you'll be able to chat")
         horizontalAlignment: Text.AlignHCenter
         wrapMode: Text.WordWrap
@@ -51,7 +49,7 @@ Item {
     }
 
     StatusButton {
-        visible: !isContact
+        visible: !isUserAdded
         text: qsTr("Add to contacts")
         anchors.top: contactText2.bottom
         anchors.topMargin: Style.current.smallPadding

--- a/ui/app/AppLayouts/Chat/panels/SuggestionFilterPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/SuggestionFilterPanel.qml
@@ -33,7 +33,6 @@ Item {
             property string alias: model.alias
             property string ensName: model.ensName
             property string icon: model.icon
-            property bool isAdded: model.isContact
         }
     }
 
@@ -71,8 +70,7 @@ Item {
                 nickname: listItem.nickname,
                 alias: listItem.alias,
                 ensName: listItem.ensName,
-                icon: listItem.icon,
-                isAdded: listItem.isAdded
+                icon: listItem.icon
             }
             if (all || isAcceptedItem(filter, item)) {
                 filterModel.append(item)

--- a/ui/app/AppLayouts/Chat/popups/ChatCommandModal.qml
+++ b/ui/app/AppLayouts/Chat/popups/ChatCommandModal.qml
@@ -22,7 +22,6 @@ StatusModal {
     property string finalButtonLabel: "Request address"
     property var sendChatCommand: function () {}
     property bool isRequested: false
-    property bool isContact: false
 
     id: root
     anchors.centerIn: parent

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -140,20 +140,6 @@ QtObject {
 
     property string communityTags: communitiesModule.tags
 
-    function reCalculateAddToGroupContacts(channel) {
-        const contacts = getContactListObject()
-
-        if (channel) {
-            contacts.forEach(function (contact) {
-                if(channel.contains(contact.pubKey) ||
-                        !contact.isContact) {
-                    return;
-                }
-                addToGroupContacts.append(contact)
-            })
-        }
-    }
-
     property var stickersModuleInst: stickersModule
 
     property var stickersStore: StickersStore {

--- a/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
@@ -55,7 +55,7 @@ Item {
     property Timer timer: Timer { }
     property var userList
     property var contactDetails: Utils.getContactDetailsAsJson(root.activeChatId)
-    property bool isContact: root.contactDetails.isContact
+    property bool isUserAdded: root.contactDetails.isAdded
     property bool contactRequestReceived: root.contactDetails.requestReceived
 
     signal openAppSearch()
@@ -294,8 +294,8 @@ Item {
         Layout.alignment: Qt.AlignHCenter | Qt.AlignBottom
         Layout.fillWidth: true
         Layout.bottomMargin: Style.current.bigPadding
-        isContact: root.isContact
-        visible: root.activeChatType === Constants.chatType.oneToOne && (!root.isContact /*|| !contactRequestReceived*/)
+        isUserAdded: root.isUserAdded
+        visible: root.activeChatType === Constants.chatType.oneToOne && !root.isUserAdded
         onAddContactClicked: {
             root.rootStore.addContact(root.activeChatId);
         }
@@ -307,7 +307,6 @@ Item {
             id: sendTransactionNoEns
             store: root.rootStore
             contactsStore: root.contactsStore
-            isContact: root.isContact
             onClosed: {
                 destroy()
             }
@@ -340,7 +339,6 @@ Item {
             id: receiveTransaction
             store: root.rootStore
             contactsStore: root.contactsStore
-            isContact: root.isContact
             onClosed: {
                 destroy()
             }

--- a/ui/app/AppLayouts/Chat/views/ChatContentView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatContentView.qml
@@ -461,21 +461,6 @@ ColumnLayout {
                 store: chatContentRoot.rootStore
                 usersStore: chatContentRoot.usersStore
 
-                visible: {
-                    return true
-                        // Not Refactored Yet
-                        //                if (chatContentRoot.rootStore.chatsModelInst.channelView.activeChannel.chatType === Constants.chatType.privateGroupChat) {
-                        //                    return chatContentRoot.rootStore.chatsModelInst.channelView.activeChannel.isMember
-                        //                }
-                        //                if (chatContentRoot.rootStore.chatsModelInst.channelView.activeChannel.chatType === Constants.chatType.oneToOne) {
-                        //                    return isContact
-                        //                }
-                        //                const community = chatContentRoot.rootStore.chatsModelInst.communities.activeCommunity
-                        //                return !community.active ||
-                        //                        community.access === Constants.communityChatPublicAccess ||
-                        //                        community.admin ||
-                        //                        chatContentRoot.rootStore.chatsModelInst.channelView.activeChannel.canPost
-                }
                 messageContextMenu: contextmenu
                 emojiPopup: chatContentRoot.emojiPopup
                 isContactBlocked: chatContentRoot.isBlocked

--- a/ui/app/AppLayouts/Chat/views/ChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatView.qml
@@ -177,7 +177,7 @@ StatusAppThreePanelLayout {
         confirmationText: qsTr("Are you sure you want to remove this contact?")
         onConfirmButtonClicked: {
             let pk = chatColumn.contactToRemove
-            if (Utils.getContactDetailsAsJson(pk).isContact) {
+            if (Utils.getContactDetailsAsJson(pk).isAdded) {
                 root.contactsStore.removeContact(pk)
             }
             removeContactConfirmationDialog.parentPopup.close();

--- a/ui/app/AppLayouts/Profile/panels/ContactPanel.qml
+++ b/ui/app/AppLayouts/Profile/panels/ContactPanel.qml
@@ -19,7 +19,7 @@ import shared.controls.chat.menuItems 1.0
 StatusListItem {
     id: container
     width: parent.width
-    visible: container.isMutualContact && (container.searchStr == "" || container.name.includes(container.searchStr))
+    visible: container.isContact && (container.searchStr == "" || container.name.includes(container.searchStr))
     height: visible ? implicitHeight : 0
     title: container.name
     image.source: container.icon
@@ -27,7 +27,7 @@ StatusListItem {
     property string name: "Jotaro Kujo"
     property string publicKey: "0x04d8c07dd137bd1b73a6f51df148b4f77ddaa11209d36e43d8344c0a7d6db1cad6085f27cfb75dd3ae21d86ceffebe4cf8a35b9ce8d26baa19dc264efe6d8f221b"
     property string icon: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="
-    property bool isMutualContact: false
+    property bool isContact: false
     property bool isBlocked: false
     property bool isVerified: false
     property bool isUntrustworthy: false
@@ -158,7 +158,7 @@ StatusListItem {
                         container.sendMessageActionTriggered(container.publicKey)
                         menuButton.highlighted = false
                     }
-                    enabled: container.isMutualContact
+                    enabled: container.isContact
                 }
 
                 StatusMenuItem {

--- a/ui/app/AppLayouts/Profile/panels/ContactsListPanel.qml
+++ b/ui/app/AppLayouts/Profile/panels/ContactsListPanel.qml
@@ -112,7 +112,7 @@ Item {
             name: model.displayName
             publicKey: model.pubKey
             icon: model.icon
-            isMutualContact: model.isContact
+            isContact: model.isContact
             isBlocked: model.isBlocked
             isVerified: model.isVerified
             isUntrustworthy: model.isUntrustworthy

--- a/ui/app/AppLayouts/Profile/views/ContactsView.qml
+++ b/ui/app/AppLayouts/Profile/views/ContactsView.qml
@@ -312,7 +312,7 @@ SettingsContentBase {
             header.title: qsTr("Remove contact")
             confirmationText: qsTr("Are you sure you want to remove this contact?")
             onConfirmButtonClicked: {
-                if (Utils.getContactDetailsAsJson(removeContactConfirmationDialog.value).isContact) {
+                if (Utils.getContactDetailsAsJson(removeContactConfirmationDialog.value).isAdded) {
                     root.contactsStore.removeContact(removeContactConfirmationDialog.value);
                 }
                 removeContactConfirmationDialog.close()

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -107,38 +107,6 @@ Item {
         mainModule.setActiveSectionById(sectionId)
     }
 
-    function getContactListObject(dataModel) {
-        // Not Refactored Yet - This should be resolved in a proper way in Chat Section Module most likely
-
-//        const nbContacts = appMain.rootStore.contactsModuleInst.model.list.rowCount()
-//        const contacts = []
-//        let contact
-//        for (let i = 0; i < nbContacts; i++) {
-//            if (appMain.rootStore.contactsModuleInst.model.list.rowData(i, "isBlocked") === "true") {
-//                continue
-//            }
-
-//            contact = {
-//                name: appMain.rootStore.contactsModuleInst.model.list.rowData(i, "name"),
-//                localNickname: appMain.rootStore.contactsModuleInst.model.list.rowData(i, "localNickname"),
-//                pubKey: appMain.rootStore.contactsModuleInst.model.list.rowData(i, "pubKey"),
-//                address: appMain.rootStore.contactsModuleInst.model.list.rowData(i, "address"),
-//                identicon: appMain.rootStore.contactsModuleInst.model.list.rowData(i, "identicon"),
-//                thumbnailImage: appMain.rootStore.contactsModuleInst.model.list.rowData(i, "thumbnailImage"),
-//                isUser: false,
-//                isContact: appMain.rootStore.contactsModuleInst.model.list.rowData(i, "isContact") !== "false"
-//            }
-
-//            contacts.push(contact)
-//            if (dataModel) {
-//                dataModel.append(contact);
-//            }
-//        }
-//        return contacts
-
-        return []
-    }
-
     property Component backupSeedModalComponent: BackupSeedModal {
         id: backupSeedModal
         anchors.centerIn: parent

--- a/ui/imports/shared/controls/ContactSelector.qml
+++ b/ui/imports/shared/controls/ContactSelector.qml
@@ -29,7 +29,6 @@ Item {
     property bool isResolvedAddress: false
     property string selectAContact: qsTr("Select a contact")
     property string noEnsAddressMessage: qsTr("Contact does not have an ENS address. Please send a transaction in chat.")
-    property bool isContact: false
 
     function resolveEns() {
         if (selectedContact.ensVerified) {

--- a/ui/imports/shared/popups/ProfilePopup.qml
+++ b/ui/imports/shared/popups/ProfilePopup.qml
@@ -43,7 +43,7 @@ StatusModal {
     property bool userTrustIsUnknown: false
     property bool isCurrentUser: false
     property bool isAddedContact: false
-    property bool isMutualContact: false
+    property bool isContact: false
     property bool isVerificationSent: false
     property bool isVerified: false
     property bool isTrusted: false
@@ -80,19 +80,19 @@ StatusModal {
         userIcon = contactDetails.largeImage;
         userIsEnsVerified = contactDetails.ensVerified;
         userIsBlocked = contactDetails.isBlocked;
-        isAddedContact = contactDetails.isContact;
-        isMutualContact = contactDetails.isContact && contactDetails.hasAddedUs
+        isAddedContact = contactDetails.isAdded;
+        isContact = contactDetails.isContact
         userTrustStatus = contactDetails.trustStatus
         userTrustIsUnknown = contactDetails.trustStatus === Constants.trustStatus.unknown
         userIsUntrustworthy = contactDetails.trustStatus === Constants.trustStatus.untrustworthy
         verificationStatus = contactDetails.verificationStatus
         isVerificationSent = verificationStatus !== Constants.verificationStatus.unverified
 
-        if (isMutualContact && popup.contactsStore.hasReceivedVerificationRequestFrom(publicKey)) {
+        if (isContact && popup.contactsStore.hasReceivedVerificationRequestFrom(publicKey)) {
             popup.hasReceivedVerificationRequest = true
         }
 
-        if(isMutualContact && isVerificationSent) {
+        if(isContact && isVerificationSent) {
             let verificationDetails = popup.contactsStore.getSentVerificationDetailsAsJson(publicKey);
 
             verificationStatus = verificationDetails.requestStatus;
@@ -176,7 +176,7 @@ StatusModal {
         isAddedContact: popup.isAddedContact
         isCurrentUser: popup.isCurrentUser
 
-        isMutualContact: popup.isMutualContact
+        isContact: popup.isContact
         isVerificationSent: popup.isVerificationSent
         isVerified: popup.isVerified
         isTrusted: popup.isTrusted
@@ -244,7 +244,7 @@ StatusModal {
     leftButtons:[
         StatusButton {
             text: qsTr("Cancel verification")
-            visible: !isVerified && isMutualContact && isVerificationSent && showVerificationPendingSection
+            visible: !isVerified && isContact && isVerificationSent && showVerificationPendingSection
             onClicked: {
                 popup.contactsStore.cancelVerificationRequest(userPublicKey);
                 popup.close()
@@ -337,7 +337,7 @@ StatusModal {
         StatusButton {
             text: qsTr("Verify Identity")
             visible: !showIdentityVerifiedUntrustworthy && !showIdentityVerified &&
-                !showVerifyIdentitySection && isMutualContact  && !isVerificationSent
+                !showVerifyIdentitySection && isContact  && !isVerificationSent
                 && !hasReceivedVerificationRequest
             onClicked: {
                 popup.showVerifyIdentitySection = true
@@ -347,7 +347,7 @@ StatusModal {
         StatusButton {
             text: qsTr("Verify Identity pending...")
             visible: (!showIdentityVerifiedUntrustworthy && !showIdentityVerified && !isTrusted
-                && isMutualContact && isVerificationSent && !showVerificationPendingSection) ||
+                && isContact && isVerificationSent && !showVerificationPendingSection) ||
                 (hasReceivedVerificationRequest && !isTrusted)
             onClicked: {
                 if (hasReceivedVerificationRequest) {
@@ -375,7 +375,7 @@ StatusModal {
 
         StatusButton {
             text: qsTr("Send verification request")
-            visible: showVerifyIdentitySection && isMutualContact  && !isVerificationSent
+            visible: showVerifyIdentitySection && isContact  && !isVerificationSent
             onClicked: {
                 popup.contactsStore.sendVerificationRequest(userPublicKey, Utils.escapeHtml(profileView.challengeTxt.input.text));
                 profileView.stepsListModel.setProperty(1, "stepCompleted", true);
@@ -391,7 +391,7 @@ StatusModal {
 
         StatusButton {
             text: qsTr("Confirm Identity")
-            visible: isMutualContact  && isVerificationSent && !isTrusted && showVerificationPendingSection
+            visible: isContact  && isVerificationSent && !isTrusted && showVerificationPendingSection
             enabled: verificationChallenge !== "" && verificationResponse !== ""
             onClicked: {
                 popup.showIdentityVerified = true;

--- a/ui/imports/shared/views/ProfileView.qml
+++ b/ui/imports/shared/views/ProfileView.qml
@@ -46,7 +46,7 @@ Rectangle {
 
     property bool userIsUntrustworthy: false
     property bool userTrustIsUnknown: false
-    property bool isMutualContact: false
+    property bool isContact: false
     property bool isVerificationSent: false
     property bool isVerified: false
     property bool isTrusted: false
@@ -162,7 +162,7 @@ Rectangle {
             pubkey: root.userPublicKey
             icon: root.isCurrentUser ? root.profileStore.profileLargeImage : root.userIcon
             trustStatus: root.userTrustStatus
-            isContact: root.isAddedContact
+            isContact: root.isContact
             store: root.profileStore
 
             displayNameVisible: false

--- a/ui/imports/shared/views/SearchResults.qml
+++ b/ui/imports/shared/views/SearchResults.qml
@@ -42,12 +42,12 @@ Item {
         isAddedContact = false
     }
 
-    function isContactAdded() {
-        return root.pubKey != "" ? Utils.getContactDetailsAsJson(root.pubKey).isContact : false
+    function isUserAdded() {
+        return root.pubKey != "" ? Utils.getContactDetailsAsJson(root.pubKey).isAdded : false
     }
 
     onPubKeyChanged: {
-        root.isAddedContact = root.isContactAdded()
+        root.isAddedContact = root.isUserAdded()
     }
 
     StyledText {

--- a/ui/imports/shared/views/chat/MessageContextMenuView.qml
+++ b/ui/imports/shared/views/chat/MessageContextMenuView.qml
@@ -95,9 +95,13 @@ StatusPopupMenu {
         popup()
     }
 
+    onClosed: {
+        // Reset selectedUserPublicKey so that associated properties get recalculated on re-open
+        selectedUserPublicKey = ""
+    }
+
     onHeightChanged: { root.y = setYPosition(); }
     onWidthChanged: { root.x = setXPosition(); }
-    onClosed: selectedUserPublicKey = ""
 
     width: Math.max(emojiContainer.visible ? emojiContainer.width : 0, 200)
 

--- a/ui/imports/utils/Global.qml
+++ b/ui/imports/utils/Global.qml
@@ -63,7 +63,7 @@ QtObject {
         let contactDetails = Utils.getContactDetailsAsJson(pubkey)
         
         if (root.privacyModuleInst.profilePicturesVisibility !==
-            Constants.profilePicturesVisibility.everyone && !contactDetails.isContact) {
+            Constants.profilePicturesVisibility.everyone && !contactDetails.isAdded) {
             return;
         }
 

--- a/ui/imports/utils/Utils.qml
+++ b/ui/imports/utils/Utils.qml
@@ -597,6 +597,7 @@ QtObject {
                 thumbnailImage: "",
                 largeImage: "",
                 isContact: false,
+                isAdded: false,
                 isBlocked: false,
                 requestReceived: false,
                 isSyncing: false,


### PR DESCRIPTION
Fixes #6220

Fixes the issue with the mutual contact icon showing when just added.
It also does a huge cleanup of the codebase to remove isContact and replace it with either isAdded, when we care only about if we added, or isMutualContact if we want the contact to be mutual
Also fixes an issue with the MessageContextMenu not reflecting the added state correctly.

Asking for QA testing on this one, since it touches contacts all over the app. I made sure to double check my changes to make sure to use isAdded and isMutualContact appropriately, but the reason why I did this change is because `isContact` was used in both contexts, so it was confusing.
Anyway, all that to say, make sure the contact list, states and other interactions still work as expected.