### PR TITLE
fix(profile): the profile image is blurred in different places

### DIFF
--- a/ui/app/AppLayouts/Profile/views/profile/MyProfileSettingsView.qml
+++ b/ui/app/AppLayouts/Profile/views/profile/MyProfileSettingsView.qml
@@ -60,7 +60,7 @@ ColumnLayout {
 
         displayName: profileStore.name
         pubkey: profileStore.pubkey
-        icon: profileStore.icon
+        icon: profileStore.profileLargeImage
         imageSize: ProfileHeader.ImageSize.Big
         
         displayNameVisible: false

--- a/ui/imports/shared/controls/chat/ProfileHeader.qml
+++ b/ui/imports/shared/controls/chat/ProfileHeader.qml
@@ -32,7 +32,7 @@ Item {
     property bool pubkeyVisibleWithCopy: false
     property bool emojiHashVisible: true
     property bool editImageButtonVisible: false
-    readonly property bool compact: root.imageSize == ProfileHeader.ImageSize.Compact
+    readonly property bool compact: root.imageSize === ProfileHeader.ImageSize.Compact
 
     signal clicked()
     signal editClicked()
@@ -47,7 +47,6 @@ Item {
                 case ProfileHeader.ImageSize.Compact: return compact;
                 case ProfileHeader.ImageSize.Middle: return normal;
                 case ProfileHeader.ImageSize.Big: return big;
-                return normal;
             }
         }
     }

--- a/ui/imports/shared/popups/ProfilePopup.qml
+++ b/ui/imports/shared/popups/ProfilePopup.qml
@@ -77,7 +77,7 @@ StatusModal {
         userName = contactDetails.alias;
         userNickname = contactDetails.localNickname;
         userEnsName = contactDetails.name;
-        userIcon = contactDetails.displayIcon;
+        userIcon = contactDetails.largeImage;
         userIsEnsVerified = contactDetails.ensVerified;
         userIsBlocked = contactDetails.isBlocked;
         isAddedContact = contactDetails.isContact;

--- a/ui/imports/shared/views/ProfileView.qml
+++ b/ui/imports/shared/views/ProfileView.qml
@@ -160,7 +160,7 @@ Rectangle {
 
             displayName: root.userDisplayName
             pubkey: root.userPublicKey
-            icon: root.isCurrentUser ? root.profileStore.icon : root.userIcon
+            icon: root.isCurrentUser ? root.profileStore.profileLargeImage : root.userIcon
             trustStatus: root.userTrustStatus
             isContact: root.isAddedContact
             store: root.profileStore


### PR DESCRIPTION
Closes #6295

- use the recently introduced `profileLargeImage` property for bigger user
images
- fix some QML(lint) warnings

### What does the PR do

It fixes blurry profile picture images in several places (My Profile, Profile View)

### Affected areas

My Profile, Profile View, Chat View (with big profile image)

### Screenshot of functionality

![Snímek obrazovky z 2022-07-06 21-05-54](https://user-images.githubusercontent.com/5377645/177625265-67903191-f0b1-4420-85fa-20f73acc58eb.png)
![Snímek obrazovky z 2022-07-06 21-04-53](https://user-images.githubusercontent.com/5377645/177625268-dea6105b-b20e-4e04-a15f-57723a3094bd.png)
![Snímek obrazovky z 2022-07-06 21-02-37](https://user-images.githubusercontent.com/5377645/177625272-3c36723e-b9b2-4053-9570-d051ece97f55.png)
![Snímek obrazovky z 2022-07-06 21-02-34](https://user-images.githubusercontent.com/5377645/177625273-ae0ade60-d5a9-4061-b8d2-cb7fc5e1211c.png)

