### PR TITLE
fix(@desktop/onboarding): replace placeholder text to Password

### DIFF
--- a/ui/app/AppLayouts/Onboarding/views/LoginView.qml
+++ b/ui/app/AppLayouts/Onboarding/views/LoginView.qml
@@ -227,7 +227,7 @@ Item {
             enabled: !loading
             placeholderText: loading ?
                 qsTr("Connecting...") :
-                qsTr("Enter password")
+                qsTr("Password")
             textField.echoMode: TextInput.Password
             Keys.onReturnPressed: {
                 doLogin(textField.text)


### PR DESCRIPTION
fixes: #6052

### What does the PR do

Changes placeholder for password on LoginView, from 'Enter password' to 'Password' according to designs
<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas

Login screen, when app asks for password
<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Screenshot of functionality (including design for comparison)
Appearance after fix:
![after-fix](https://user-images.githubusercontent.com/84290812/177795897-1b57c156-9416-4a35-9cba-afb41b003524.PNG)

- [x] I've checked the design and this PR matches it

<!-- screenshot (or gif/video) that demonstrates the functionality, specially important if it's a bug fix. -->


