### PR TITLE
fix(CreateChatView): hide the Contacts label when no contacts

### DIFF
--- a/ui/app/AppLayouts/Chat/panels/GroupChatPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/GroupChatPanel.qml
@@ -165,7 +165,7 @@ RowLayout {
          id: confirmButton
          implicitHeight: 44
          Layout.alignment: Qt.AlignTop
-         text: "Confirm"
+         text: qsTr("Confirm")
          onClicked: {
              if(root.chatContentModule.chatDetails.id &&((d.addedMembersIds.length > 0) || (d.removedMembersIds.length > 0))) {
                  // Add request:

--- a/ui/app/AppLayouts/Chat/views/CreateChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/CreateChatView.qml
@@ -81,9 +81,7 @@ Page {
     // TODO: Could it be replaced to `GroupChatPanel`?
     header: RowLayout {
         id: headerRow
-        width: parent.width
         height: tagSelector.height
-        anchors.top: parent.top
         anchors.topMargin: 8
         clip: true
         StatusTagSelector {
@@ -93,7 +91,8 @@ Page {
             Layout.leftMargin: 17
             maxHeight: root.height
             nameCountLimit: 20
-            listLabel: qsTr("Contacts")
+            listLabel: contactsModel.count ? qsTr("Contacts") : ""
+            textEdit.enabled: contactsModel.count
             toLabelText: qsTr("To: ")
             warningText: qsTr("USER LIMIT REACHED")
             ringSpecModelGetter: function(pubKey) {
@@ -114,8 +113,8 @@ Page {
             id: confirmButton
             implicitHeight: 44
             Layout.alignment: Qt.AlignTop
-            enabled: (tagSelector.namesModel.count > 0)
-            text: "Confirm"
+            enabled: tagSelector.namesModel.count > 0
+            text: qsTr("Confirm")
             onClicked: {
                 root.rootStore.createChatInitMessage = chatInput.textInput.text;
                 root.rootStore.createChatFileUrls = chatInput.fileUrls;
@@ -138,9 +137,6 @@ Page {
     }
 
     contentItem: Item {
-        anchors.fill: parent
-        anchors.topMargin: headerRow.height + 32
-
         StatusChatInput {
             id: chatInput
             anchors.bottom: parent.bottom
@@ -178,17 +174,16 @@ Page {
         }
 
         StatusBaseText {
-            width: parent.width
-            height: contentHeight
+            width: parent.width*.66
             anchors.centerIn: parent
             horizontalAlignment: Text.AlignHCenter
             verticalAlignment: Text.AlignVCenter
-            visible: (contactsModel.count === 0)
+            visible: contactsModel.count === 0
             wrapMode: Text.WordWrap
             font.pixelSize: 15
             color: Theme.palette.baseColor1
             text: qsTr("You can only send direct messages to your Contacts.\n\n
-Send a contact request to the person you would like to chat with, you will be able to
+Send a contact request to the person you would like to chat with, you will be able to \
 chat with them once they have accepted your contact request.")
             Component.onCompleted: {
                 if (visible) {


### PR DESCRIPTION
Fixes #6353

- hide the TagSelector's `listLabel` and disable the `textEdit` when the
  contacts model is empty
- add forgotten `qsTr()`
- remove some no-op positioniers/anchors/width/height bindings (these are
  handled automatically for QQC2 Control's header and contentItem)

### What does the PR do

It hides the Contacts label and disables the internal tag selector when the contacts model is empty

### Affected areas

CreateChatView

### Screenshot of functionality (including design for comparison)
- [x] I've checked the design and this PR matches it

#### Before fix
![Snímek obrazovky z 2022-07-07 16-03-42](https://user-images.githubusercontent.com/5377645/177796645-025045a1-1cee-4990-8219-7a881f2a60af.png)

#### After fix
![Snímek obrazovky z 2022-07-07 16-04-10](https://user-images.githubusercontent.com/5377645/177796725-af98825a-dd7e-435e-bca6-815ab601baef.png)
