### PR TITLE
fix(@desktop/wallet): Fix visual issues in add account modal

### DIFF
--- a/ui/app/AppLayouts/Wallet/panels/DerivedAddressesPanel.qml
+++ b/ui/app/AppLayouts/Wallet/panels/DerivedAddressesPanel.qml
@@ -199,6 +199,12 @@ Item {
                                 }
                             }
                         }
+                        background: Rectangle {
+                            implicitWidth: stackLayout.width
+                            implicitHeight: stackLayout.height
+                            color: Theme.palette.statusPopupMenu.backgroundColor
+                            radius: 8
+                        }
                     }
                 }
             }

--- a/ui/app/AppLayouts/Wallet/panels/ImportPrivateKeyPanel.qml
+++ b/ui/app/AppLayouts/Wallet/panels/ImportPrivateKeyPanel.qml
@@ -82,7 +82,6 @@ ColumnLayout {
         StatusBaseText {
             id: inputLabel
             Layout.alignment: Qt.AlignLeft
-            Layout.leftMargin: 16
             Layout.fillWidth: true
             text: qsTr("Public address")
             font.pixelSize: 15

--- a/ui/app/AppLayouts/Wallet/views/AdvancedAddAccountView.qml
+++ b/ui/app/AppLayouts/Wallet/views/AdvancedAddAccountView.qml
@@ -111,7 +111,7 @@ ColumnLayout {
     ImportSeedPhrasePanel {
         id: importSeedPhrasePanel
         Layout.preferredWidth: parent.width
-        Layout.preferredHeight: importSeedPhrasePanel.preferredHeight
+        Layout.preferredHeight: visible ? importSeedPhrasePanel.preferredHeight: 0
         Layout.leftMargin: (Style.current.halfPadding/4)
         visible: advancedSection.addAccountType === SelectGeneratedAccount.AddAccountType.ImportSeedPhrase && advancedSection.visible
         onMnemonicStringChanged: {


### PR DESCRIPTION
fixes #6257

### What does the PR do
fix(@desktop/wallet): Fix visual issues in add account modal:

1. Alignment of the Inputs
2. Background color of the derived address panel

**NOTE: There is another issue pending which is already reported separately as https://github.com/status-im/status-desktop/issues/6315**

### Affected areas

Wallet

### Screenshot of functionality (including design for comparison)

https://user-images.githubusercontent.com/60327365/177967189-102d4802-9f45-4ead-951f-28a97debfc32.mov


