### PR TITLE
fix(Chat/ReactionDialog): The reaction dialog is shown in different places

### DIFF
--- a/ui/imports/shared/views/chat/CompactMessageView.qml
+++ b/ui/imports/shared/views/chat/CompactMessageView.qml
@@ -764,11 +764,14 @@ Item {
                 onAddEmojiClicked: {
                     if(root.isChatBlocked)
                         return
+
+                    // First set parent, X & Y positions for the messageContextMenu
+                    root.messageContextMenu.parent = emojiRect
+                    root.messageContextMenu.setXPosition = function() { return (root.messageContextMenu.parent.x + root.messageContextMenu.parent.width + 4) }
+                    root.messageContextMenu.setYPosition = function() { return  (-root.messageContextMenu.height - 4) }
+
+                    // Second, add emoji that also triggers setXYPosition methods / open popup:
                     root.addEmoji(false, false, false, null, true, false);
-                    // Set parent, X & Y positions for the messageContextMenu
-                    root.messageContextMenu.parent = emojiReactionLoader
-                    root.messageContextMenu.setXPosition = function() { return (root.messageContextMenu.parent.x + 4)}
-                    root.messageContextMenu.setYPosition = function() { return (-root.messageContextMenu.height - 4)}
                 }
 
                 onToggleReaction: {

--- a/ui/imports/shared/views/chat/MessageContextMenuView.qml
+++ b/ui/imports/shared/views/chat/MessageContextMenuView.qml
@@ -102,6 +102,11 @@ StatusPopupMenu {
 
     onHeightChanged: { root.y = setYPosition(); }
     onWidthChanged: { root.x = setXPosition(); }
+    onOpened: {
+        // Trigger x and y position:
+        x = setXPosition()
+        y = setYPosition()
+    }
 
     width: Math.max(emojiContainer.visible ? emojiContainer.width : 0, 200)
 

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -212,10 +212,6 @@ Loader {
             messageContextMenu.selectedUserIcon = obj.senderIconToShow
         }
 
-
-        messageContextMenu.x = messageContextMenu.setXPosition()
-        messageContextMenu.y = messageContextMenu.setYPosition()
-
         messageContextMenu.popup()
     }
 


### PR DESCRIPTION
Fixes #6264

### What does the PR do

Changed x and y assignment trigger to get the correct value once the position depends on the own popup height.

### Affected areas

Chat / Context menu  - Emoji reaction

### Screenshot of functionality (including design for comparison)

https://user-images.githubusercontent.com/97019400/178258104-0d9954ab-5838-40f2-968c-09ebbb8a425c.mov
