### PR TITLE
fix(LoginView): Fixed arrow icon size

### DIFF
--- a/ui/app/AppLayouts/Onboarding/views/LoginView.qml
+++ b/ui/app/AppLayouts/Onboarding/views/LoginView.qml
@@ -244,8 +244,6 @@ Item {
             height: 40
             type: StatusQControls.StatusRoundButton.Type.Secondary
             icon.name: "arrow-right"
-            icon.width: 18
-            icon.height: 14
             opacity: (loading || txtPassword.text.length > 0) ? 1 : 0
             anchors.left: txtPassword.right
             anchors.leftMargin: (loading || txtPassword.text.length > 0) ? Style.current.padding : Style.current.smallPadding


### PR DESCRIPTION
### What does the PR do

Fixed the arrow icon in the login button

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas

login

### Before

<img width="1012" alt="image" src="https://user-images.githubusercontent.com/25482501/178280401-25d57396-cc75-4f2b-93ca-0d9029b3303f.png">

### After

<img width="1012" alt="image" src="https://user-images.githubusercontent.com/25482501/178280159-30c136e3-4e7d-462c-92db-3921916a456c.png">