### PR TITLE
fix(BackupSeed): backup seed phrase form is not centered

### DIFF
--- a/ui/app/AppLayouts/Profile/popups/BackupSeedModal.qml
+++ b/ui/app/AppLayouts/Profile/popups/BackupSeedModal.qml
@@ -72,10 +72,10 @@ StatusStackModal {
             switch (root.currentIndex) {
             case 0:
             case 1:
-                return  qsTr("Confirm Seed Phrase");
+                return qsTr("Confirm Seed Phrase");
             case 2:
             case 3:
-                return qsTr("Continue");;
+                return qsTr("Continue");
             default:
                 return "";
             }

--- a/ui/app/AppLayouts/Profile/popups/backupseed/BackupSeedStepBase.qml
+++ b/ui/app/AppLayouts/Profile/popups/backupseed/BackupSeedStepBase.qml
@@ -55,4 +55,6 @@ Flickable {
             Layout.fillWidth: true
         }
     }
+
+    ScrollIndicator.vertical: ScrollIndicator {}
 }

--- a/ui/app/AppLayouts/Profile/popups/backupseed/ConfirmSeedPhrasePanel.qml
+++ b/ui/app/AppLayouts/Profile/popups/backupseed/ConfirmSeedPhrasePanel.qml
@@ -22,24 +22,28 @@ BackupSeedStepBase {
 
         GridView {
             id: grid
-            anchors.fill: parent
+            leftMargin: grid.spacing/2
+            width: cellWidth*2
+            height: parent.height
+            anchors.centerIn: parent
             visible: !hideSeed
             flow: GridView.FlowTopToBottom
             cellWidth: 208
             cellHeight: 48
             interactive: false
             model: 12
-            property var wordIndex: ["1", "3", "5", "7", "9", "11", "2", "4", "6", "8", "10", "12"]
+            readonly property var wordIndex: ["1", "3", "5", "7", "9", "11", "2", "4", "6", "8", "10", "12"]
+            readonly property int spacing: 4
             delegate: StatusSeedPhraseInput {
                 id: seedWordInput
-                width: (grid.cellWidth - 4)
-                height: (grid.cellHeight - 4)
+                width: (grid.cellWidth - grid.spacing)
+                height: (grid.cellHeight - grid.spacing)
                 textEdit.input.edit.enabled: false
                 text: {
-                    var index = parseInt(leftComponentText) - 1;
-                    if (!root.seedPhrase || index < 0 || index > root.seedPhrase.length - 1)
+                    const idx = parseInt(leftComponentText) - 1;
+                    if (!root.seedPhrase || idx < 0 || idx > root.seedPhrase.length - 1)
                         return "";
-                    return root.seedPhrase[index];
+                    return root.seedPhrase[idx];
                 }
                 leftComponentText: grid.wordIndex[index]
             }
@@ -52,6 +56,7 @@ BackupSeedStepBase {
             source: grid
             radius: 16
             samples: 16
+            transparentBorder: true
         }
 
         StatusButton {


### PR DESCRIPTION
Fixes #6387

TLDR; since this is a GridView, it needs a width/height set and then
centered on top of the parent component (as opposed to `anchors.fill`)

Also added a scroll indicator in case the window height is not tall
enough and fixed some small warnings

### What does the PR do

Fixes some small visual issues in the backup seed dialog

### Affected areas

Backup Seed modal

### Screenshot of functionality (including design for comparison)

#### Obscured
![Snímek obrazovky z 2022-07-11 17-13-23](https://user-images.githubusercontent.com/5377645/178299546-1bd71843-9cf8-437f-b16d-59edb53fdd10.png)

#### Revealed
![Snímek obrazovky z 2022-07-11 17-13-27](https://user-images.githubusercontent.com/5377645/178299687-4f484c37-2607-48ba-b66f-d48b153b218e.png)


- [x] I've checked the design and this PR matches it