### PR TITLE
fix: unbreak "fetch more messages..."

### DIFF
--- a/ui/imports/shared/controls/chat/FetchMoreMessagesButton.qml
+++ b/ui/imports/shared/controls/chat/FetchMoreMessagesButton.qml
@@ -20,8 +20,8 @@ Item {
 
     QtObject {
         id: d
-         property string formattedDate: nextMessageIndex > -1 ? Utils.formatLongDate(nextMsgTimestamp * 1, RootStore.accountSensitiveSettings.isDDMMYYDateFormat) :
-                                                                Utils.formatLongDate(undefined, RootStore.accountSensitiveSettings.isDDMMYYDateFormat)
+         readonly property string formattedDate: nextMessageIndex > -1 ? Utils.formatLongDate(nextMsgTimestamp * 1, RootStore.accountSensitiveSettings.isDDMMYYDateFormat) :
+                                                                         Utils.formatLongDate(undefined, RootStore.accountSensitiveSettings.isDDMMYYDateFormat)
     }
 
     Timer {
@@ -80,7 +80,7 @@ Item {
         anchors.horizontalCenter: parent.horizontalCenter
         horizontalAlignment: Text.AlignHCenter
         color: Style.current.secondaryText
-        text: qsTr("before--%1").arg(d.formattedDate)
+        text: qsTr("Before %1").arg(d.formattedDate)
         visible: d.formattedDate
     }
 

--- a/ui/imports/shared/controls/chat/GapComponent.qml
+++ b/ui/imports/shared/controls/chat/GapComponent.qml
@@ -1,6 +1,7 @@
 import QtQuick 2.13
 import shared 1.0
 import shared.panels 1.0
+import shared.stores 1.0
 import utils 1.0
 
 Item {
@@ -23,7 +24,7 @@ Item {
         font.weight: Font.Medium
         font.pixelSize: Style.current.primaryTextFontSize
         color: Style.current.blue
-        text: qsTr("fetch-messages")
+        text: qsTr("Fetch messages")
         horizontalAlignment: Text.AlignHCenter
         anchors.horizontalCenter: parent.horizontalCenter
         anchors.top: sep1.bottom
@@ -45,7 +46,8 @@ Item {
         wrapMode: Text.WordWrap
         horizontalAlignment: Text.AlignHCenter
         color: Style.current.secondaryText
-        text: qsTr("between--1-and--2").arg(new Date(root.gapFrom * 1000)).arg(new Date(root.gapTo * 1000))
+        text: qsTr("Between %1 and %2").arg(Utils.formatLongDate(root.gapFrom * 1000, RootStore.accountSensitiveSettings.isDDMMYYDateFormat))
+            .arg(Utils.formatLongDate(root.gapTo * 1000, RootStore.accountSensitiveSettings.isDDMMYYDateFormat))
     }
     Separator {
         anchors.top: fetchDate.bottom


### PR DESCRIPTION
leftover from the qsTrId() -> qsTr() transition; obey the locale
settings a bit more

### What does the PR do

Fixes the date/date range being displayed under "Fetch more messages..."; it got broken due to missing format placeholders (`%1`)

### Affected areas

Chat view

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![Snímek obrazovky z 2022-07-12 10-25-37](https://user-images.githubusercontent.com/5377645/178445553-9de8f5bb-9692-48f3-a128-3eb2e760c29b.png)

