### PR TITLE
fix(@desktop/wallet): Fix for Wallet icon background color seems off in wallet settings under dark mode

### DIFF
--- a/ui/app/AppLayouts/Profile/controls/WalletAccountDelegate.qml
+++ b/ui/app/AppLayouts/Profile/controls/WalletAccountDelegate.qml
@@ -18,7 +18,7 @@ StatusListItem {
     icon.name: !account.emoji ? "filled-account": ""
     icon.letterSize: 14
     icon.isLetterIdenticon: !!account.emoji
-    icon.background.color: Theme.palette.indirectColor1
+    icon.background.color: Theme.palette.primaryColor3
     width: parent.width
     
     components: !showShevronIcon ? [] : [ shevronIcon ]

--- a/ui/app/AppLayouts/Wallet/views/LeftTabView.qml
+++ b/ui/app/AppLayouts/Wallet/views/LeftTabView.qml
@@ -112,7 +112,7 @@ Rectangle {
                 icon.name: !model.emoji ? "filled-account": ""
                 icon.letterSize: 14
                 icon.isLetterIdenticon: !!model.emoji ? true : false
-                icon.background.color: Theme.palette.indirectColor1
+                icon.background.color: Theme.palette.primaryColor3
                 onClicked: {
                     changeSelectedAccount(index)
                     showSavedAddresses(false)


### PR DESCRIPTION
Fix for Wallet icon background color seems off in wallet settings under dark mode

fixes #6059

### What does the PR do

Uses the correct background color for the wallet icon

### Affected areas

wallet, settings

### Screenshot of functionality (including design for comparison)

https://user-images.githubusercontent.com/60327365/178507871-75b2241a-b18c-493b-bc91-d3105f256e4c.mov



