### PR TITLE
fix(MyProfileSettingsView): fingerprint entry should fill the full width

### DIFF
--- a/ui/app/AppLayouts/Profile/views/profile/MyProfileSettingsView.qml
+++ b/ui/app/AppLayouts/Profile/views/profile/MyProfileSettingsView.qml
@@ -82,10 +82,13 @@ ColumnLayout {
     StatusListItem {
         Layout.fillWidth: true
         visible: Qt.platform.os == "osx"
+        leftPadding: 0
+        rightPadding: 0
         title: qsTr("Biometric login and transaction authentication")
         icon.name: "touch-id"
         components: [ StatusSwitch {
             id: biometricsSwitch
+            horizontalPadding: 0
             readonly property bool currentStoredValue: localAccountSettings.storeToKeychainValue === Constants.storeToKeychainValueStore
             checked: currentStoredValue
         } ]


### PR DESCRIPTION
Fixes #6361

### What does the PR do

Try harder to have the 'Biometric login and transaction authentication' entry fill the whole width

### Affected areas

MyProfileSettingsView

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![Snímek obrazovky z 2022-07-13 11-11-43](https://user-images.githubusercontent.com/5377645/178699151-ca2d942f-41d7-44db-afb5-854ad18a4734.png)
