### PR TITLE
fix(@desktop/chat): The asset name is overlapped by an arrow

### DIFF
--- a/ui/imports/shared/controls/AssetAndAmountInput.qml
+++ b/ui/imports/shared/controls/AssetAndAmountInput.qml
@@ -161,7 +161,6 @@ Item {
 
     StatusAssetSelector {
          id: selectAsset
-         width: 86
          height: 28
          anchors.top: inputAmount.top
          anchors.topMargin: Style.current.bigPadding + 14


### PR DESCRIPTION
fixes #6056

### What does the PR do

Fixes the issue of text overlapping with the arrow when it is long

### Affected areas

wallet, chat

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it
  - doesnt exactly match design but not sure what to do.

https://user-images.githubusercontent.com/60327365/178745691-6990790d-dd50-48b9-9181-24fb622c603b.mov


