### PR TITLE
fix(@desktop): Set minimum window size to 680px.

### DIFF
--- a/ui/main.qml
+++ b/ui/main.qml
@@ -27,7 +27,7 @@ StatusWindow {
     id: applicationWindow
     objectName: "mainWindow"
     minimumWidth: 900
-    minimumHeight: 600
+    minimumHeight: 680
     color: Style.current.background
     title: {
         // Set application settings


### PR DESCRIPTION
Solves 'Receive' pop-up doesn't look good in the minimised window

fixes #6320

### What does the PR do

Increase minimum width to 680 px.

### Affected areas

Wallet, Desktop screen size

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

https://user-images.githubusercontent.com/60327365/178846200-042a8c02-ae05-4fcd-a7bb-0ec1a9b14c45.mov


