### PR TITLE
fix(CommunitPortal): Scroll doesn't work correctly on the Community Portal page

### DIFF
--- a/ui/app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml
+++ b/ui/app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml
@@ -13,7 +13,7 @@ import shared.popups 1.0
 import "stores"
 import "popups"
 
-ScrollView {
+StatusScrollView {
     id: root
 
     property CommunitiesStore communitiesStore: CommunitiesStore {}


### PR DESCRIPTION
Fixes #6356

Depends on https://github.com/status-im/StatusQ/pull/766

### What does the PR do

- Replaced `ScrollView` to new component in `StatusQ` -> `StatusScrollView`.
- Bump `StatusQ`.

### Affected areas

Community Portal

### Screenshot of functionality (including design for comparison)

https://user-images.githubusercontent.com/97019400/178980150-a6bcc755-c743-4790-9051-9cace28d450c.mov


