### PR TITLE
fix(Onboarding): align the 'Before you get started' popup with design

### DIFF
--- a/ui/app/AppLayouts/Onboarding/popups/BeforeGetStartedModal.qml
+++ b/ui/app/AppLayouts/Onboarding/popups/BeforeGetStartedModal.qml
@@ -12,33 +12,36 @@ import StatusQ.Popups 0.1
 StatusModal {
     id: popup
 
+    width: 480
+    height: 318
     anchors.centerIn: parent
-    header.title: qsTr("Before you get started")
+    header.title: qsTr("Before you get started...")
     hasCloseButton: false
     closePolicy: Popup.NoAutoClose
 
     contentItem: Item {
-        implicitHeight: childrenRect.height
-        width: popup.width
         Column {
             spacing: 12
-            anchors.left: parent.left
-            anchors.right: parent.right
+            anchors.fill: parent
             anchors.leftMargin: 32
             anchors.rightMargin: 32
-
-            Item { height: 12;  width: parent.width }
+            anchors.topMargin: 24
+            anchors.bottomMargin: 24
 
             StatusCheckBox {
                 id: acknowledge
                 objectName: "acknowledgeCheckBox"
+                spacing: 8
+                font.pixelSize: 15
                 width: parent.width
-                text: qsTr("I acknowledge that status desktop is in beta and by using it I take the full responsibility for all risks concerning my data and funds")
+                text: qsTr("I acknowledge that Status Desktop is in Beta and by using it I take the full responsibility for all risks concerning my data and funds.")
             }
 
             StatusCheckBox {
                 id: termsOfUse
                 objectName: "termsOfUseCheckBox"
+                width: parent.width
+                font.pixelSize: 15
 
                 contentItem: Row {
                     spacing: 4
@@ -46,13 +49,15 @@ StatusModal {
 
                     StatusBaseText {
                         text: qsTr("I accept Status")
-                        color: Theme.palette.directColor1
+                        font.pixelSize: 15
                     }
 
                     StatusBaseText {
                         objectName: "termsOfUseLink"
-                        text: qsTr("Terms of service")
+                        text: qsTr("Terms of Use")
                         color: Theme.palette.primaryColor1
+                        font.pixelSize: 15
+                        font.weight: Font.Medium
 
                         MouseArea {
                             anchors.fill: parent
@@ -65,20 +70,22 @@ StatusModal {
                                 parent.font.underline = false
                             }
                             onClicked: {
-                                Qt.openUrlExternally("https://status.im/terms-of-service/")
+                                Qt.openUrlExternally("https://status.im/terms-of-use/")
                             }
                         }
                     }
 
                     StatusBaseText {
-                        text: " & "
-                        color: Theme.palette.directColor1
+                        text: "&"
+                        font.pixelSize: 15
                     }
 
                     StatusBaseText {
                         objectName: "privacyPolicyLink"
                         text: qsTr("Privacy Policy")
                         color: Theme.palette.primaryColor1
+                        font.pixelSize: 15
+                        font.weight: Font.Medium
 
                         MouseArea {
                             anchors.fill: parent
@@ -97,8 +104,6 @@ StatusModal {
                     }
                 }
             }
-
-            Item { height: 12;  width: parent.width }
         }
     }
 
@@ -107,7 +112,9 @@ StatusModal {
             id: getStartedButton
             objectName: "getStartedStatusButton"
             enabled: acknowledge.checked && termsOfUse.checked
-            text: qsTr("Get started")
+            size: StatusBaseButton.Size.Large
+            font.weight: Font.Medium
+            text: qsTr("Get Started")
             onClicked: {
                 popup.close()
             }

--- a/ui/app/AppLayouts/Onboarding/popups/BeforeGetStartedModal.qml
+++ b/ui/app/AppLayouts/Onboarding/popups/BeforeGetStartedModal.qml
@@ -1,32 +1,46 @@
 import QtQuick 2.13
 import QtQuick.Controls 2.13
 import QtQuick.Layouts 1.14
+import QtQml.Models 2.14
 
 import utils 1.0
 
 import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
 import StatusQ.Controls 0.1
-import StatusQ.Popups 0.1
+import StatusQ.Popups.Dialog 0.1
 
-StatusModal {
+StatusDialog {
     id: popup
 
     width: 480
     height: 318
     anchors.centerIn: parent
-    header.title: qsTr("Before you get started...")
-    hasCloseButton: false
     closePolicy: Popup.NoAutoClose
+
+    header: StatusDialogHeader {
+        headline.title: qsTr("Before you get started...")
+        actions.closeButton.visible: false
+    }
+
+    footer: StatusDialogFooter {
+        rightButtons: ObjectModel {
+            StatusButton {
+                objectName: "getStartedStatusButton"
+                enabled: acknowledge.checked && termsOfUse.checked
+                size: StatusBaseButton.Size.Large
+                font.weight: Font.Medium
+                text: qsTr("Get Started")
+                onClicked: popup.close()
+            }
+        }
+    }
 
     contentItem: Item {
         Column {
-            spacing: 12
-            anchors.fill: parent
-            anchors.leftMargin: 32
-            anchors.rightMargin: 32
-            anchors.topMargin: 24
-            anchors.bottomMargin: 24
+            width: 416
+            spacing: 16
+            anchors.centerIn: parent
 
             StatusCheckBox {
                 id: acknowledge
@@ -106,18 +120,4 @@ StatusModal {
             }
         }
     }
-
-    rightButtons: [
-        StatusButton {
-            id: getStartedButton
-            objectName: "getStartedStatusButton"
-            enabled: acknowledge.checked && termsOfUse.checked
-            size: StatusBaseButton.Size.Large
-            font.weight: Font.Medium
-            text: qsTr("Get Started")
-            onClicked: {
-                popup.close()
-            }
-        }
-    ]
 }

--- a/ui/app/AppLayouts/Onboarding/popups/BeforeGetStartedModal.qml
+++ b/ui/app/AppLayouts/Onboarding/popups/BeforeGetStartedModal.qml
@@ -11,10 +11,9 @@ import StatusQ.Controls 0.1
 import StatusQ.Popups.Dialog 0.1
 
 StatusDialog {
-    id: popup
+    id: root
 
     width: 480
-    height: 318
     anchors.centerIn: parent
     closePolicy: Popup.NoAutoClose
 
@@ -31,7 +30,7 @@ StatusDialog {
                 size: StatusBaseButton.Size.Large
                 font.weight: Font.Medium
                 text: qsTr("Get Started")
-                onClicked: popup.close()
+                onClicked: root.close()
             }
         }
     }


### PR DESCRIPTION
correct sizing, fonts, spacings, margins, etc

Fixes #6020

Needs status-im/StatusQ#776

### What does the PR do

Aligns the 'Before you get started' popup with design

### Affected areas

Onboarding/BeforeGetStarted

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

Actual app:
![Snímek obrazovky z 2022-07-14 14-29-17](https://user-images.githubusercontent.com/5377645/178990753-99b230d9-2ffd-4418-aa5c-f15485d1fd22.png)

Design:
![Snímek obrazovky z 2022-07-14 15-17-22](https://user-images.githubusercontent.com/5377645/178991478-e1773938-916a-413d-88f0-b31be21fa425.png)


