### PR TITLE
fix(@desktop/wallet): Send Popup - Can't scroll outside the list of accounts after selecting one

### DIFF
--- a/ui/imports/shared/controls/AmountInputWithCursor.qml
+++ b/ui/imports/shared/controls/AmountInputWithCursor.qml
@@ -17,7 +17,7 @@ StatusInput {
     input.edit.cursorVisible: true
     input.edit.font.pixelSize: 32
     input.placeholderFont.pixelSize: 32
-    input.leftPadding: 0
+    input.leftPadding: -1
     input.rightPadding: 0
     input.topPadding: 0
     input.bottomPadding: 0

--- a/ui/imports/shared/popups/SendModal.qml
+++ b/ui/imports/shared/popups/SendModal.qml
@@ -115,9 +115,7 @@ StatusModal {
    TransactionStackView {
         id: stack
         property alias currentGroup: stack.currentGroup
-        anchors.leftMargin: Style.current.xlPadding
         anchors.topMargin: Style.current.xlPadding
-        anchors.rightMargin: Style.current.xlPadding
         anchors.bottomMargin: popup.showAdvancedFooter  && !!advancedFooter ? advancedFooter.height : Style.current.padding
         TransactionFormGroup {
             id: group1
@@ -128,6 +126,9 @@ StatusModal {
                 anchors.top: parent.top
                 anchors.right: parent.right
                 anchors.left: parent.left
+                anchors.leftMargin: Style.current.xlPadding
+                anchors.rightMargin: Style.current.xlPadding
+
                 RowLayout {
                     spacing: 16
                     StatusBaseText {
@@ -242,9 +243,8 @@ StatusModal {
                 anchors.top: assetAndAmmountSelector.bottom
                 anchors.topMargin: Style.current.padding
                 anchors.left: parent.left
-                anchors.leftMargin: -Style.current.xlPadding
+                anchors.right: parent.right
 
-                width: popup.width
                 height: 1
                 color: Theme.palette.directColor8
                 visible: false
@@ -266,11 +266,14 @@ StatusModal {
                 width: parent.width
                 anchors.top: border.bottom
                 anchors.topMargin: Style.current.halfPadding
+                anchors.left: parent.left
 
                 ColumnLayout {
                     width: scrollView.availableWidth
                     spacing: Style.current.halfPadding
-                // To-do use standard StatusInput component once the flow for ens name resolution is clear
+                    anchors.left: parent.left
+
+                    // To-do use standard StatusInput component once the flow for ens name resolution is clear
                     RecipientSelector {
                         id: recipientSelector
                         accounts: popup.store.accounts
@@ -279,13 +282,17 @@ StatusModal {
                         input.placeholderText: qsTr("Enter an ENS name or address")
                         input.anchors.leftMargin: 0
                         input.anchors.rightMargin: 0
+                        input.textField.anchors.rightMargin: 0
                         labelFont.pixelSize: 15
                         labelFont.weight: Font.Normal
                         input.height: 56
+                        inputWidth: parent.width
                         isSelectorVisible: false
                         addContactEnabled: false
                         onSelectedRecipientChanged: gasSelector.estimateGas()
                         Layout.fillWidth: true
+                        Layout.leftMargin: Style.current.bigPadding
+                        Layout.rightMargin: Style.current.bigPadding
                     }
 
                     TabAddressSelectorView {
@@ -295,6 +302,8 @@ StatusModal {
                             recipientSelector.input.text = address
                         }
                         Layout.fillWidth: true
+                        Layout.leftMargin: Style.current.bigPadding
+                        Layout.rightMargin: Style.current.bigPadding
                     }
 
                     NetworkSelector {
@@ -311,6 +320,8 @@ StatusModal {
                         }
                         onReCalculateSuggestedRoute: popup.recalculateRoutesAndFees(disabledChainIds)
                         Layout.fillWidth: true
+                        Layout.leftMargin: Style.current.bigPadding
+                        Layout.rightMargin: Style.current.bigPadding
                     }
 
                     Rectangle {
@@ -319,6 +330,8 @@ StatusModal {
                         color: Theme.palette.indirectColor1
                         implicitHeight: gasSelector.visible || gasValidator.visible ? feesLayout.height + gasValidator.height : 0
                         Layout.fillWidth: true
+                        Layout.leftMargin: Style.current.bigPadding
+                        Layout.rightMargin: Style.current.bigPadding
 
                         RowLayout {
                             id: feesLayout

--- a/ui/imports/shared/views/TabAddressSelectorView.qml
+++ b/ui/imports/shared/views/TabAddressSelectorView.qml
@@ -29,6 +29,7 @@ Item {
         id: accountSelectionTabBar
         anchors.top: parent.top
         anchors.topMargin: 20
+        anchors.left: parent.left
         width: parent.width
         
         StatusTabButton {
@@ -186,7 +187,7 @@ Item {
 
                 delegate: StatusListItem {
                     property bool isIncoming: to === store.currentAccount.address
-                    width: visible ? recents.availableWidth : 0
+                    implicitWidth: parent.width
                     height: visible ? 64 : 0
                     title: isIncoming ? from : to
                     subTitle: Utils.getTimeDifference(new Date(parseInt(timestamp) * 1000), new Date())


### PR DESCRIPTION
fix(@desktop/wallet): Send Popup - Can't scroll outside the list of accounts after selecting one
fixes #6196

### What does the PR do

Created a border width for scroll view so that it can be scrolled separately from the account list

### Affected areas

wallet

### Screenshot of functionality (including design for comparison)

https://user-images.githubusercontent.com/60327365/179049747-45f035b9-d3ad-4051-8f17-1f5b02b3d3ba.mov


