### PR TITLE
fix(@desktop/onboarding): Align LoginView incorrect pass msg with design

### DIFF
--- a/ui/app/AppLayouts/Onboarding/views/LoginView.qml
+++ b/ui/app/AppLayouts/Onboarding/views/LoginView.qml
@@ -286,7 +286,7 @@ Item {
 
         StyledText {
             id: errMsg
-            readonly property string incorrectPasswordMsg: qsTr("Login failed. Please re-enter your password and try again.")
+            readonly property string incorrectPasswordMsg: qsTr("Password incorrect")
             anchors.top: txtPassword.bottom
             anchors.topMargin: Style.current.padding
             anchors.horizontalCenter: parent.horizontalCenter

--- a/ui/i18n/qml_en.ts
+++ b/ui/i18n/qml_en.ts
@@ -5745,14 +5745,14 @@ device, so only you can use them.</translation>
         <translation>Enter password</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="280" />
+        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="278" />
         <source>Login failed: %1</source>
         <translation>Login failed: %1</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="291" />
-        <source>Login failed. Please re-enter your password and try again.</source>
-        <translation>Login failed. Please re-enter your password and try again.</translation>
+        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="289" />
+        <source>Password incorrect</source>
+        <translation>Password incorrect</translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
### What does the PR do

fixes #6053 

- incorrect password message aligned with design
- translation updated, some locations fixed

### Affected areas

LoginView component

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![Screenshot 2022-07-15 10:22:19](https://user-images.githubusercontent.com/20650004/179188279-fcca1c28-cd26-49b8-9b2f-5ec37d89f38c.png)



