### PR TITLE
fix(StatusChatInput): 'Unblock' is not vertically aligned in 1-1 chat

### DIFF
--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -1254,11 +1254,9 @@ Rectangle {
     StatusQ.StatusButton {
         id: unblockBtn
         visible: control.isContactBlocked
-        height: messageInput.height - Style.current.halfPadding
         anchors.right: parent.right
         anchors.rightMargin: Style.current.halfPadding
-        anchors.bottom: parent.bottom
-        anchors.bottomMargin: Style.current.padding
+        anchors.bottom: messageInput.bottom
         text: qsTr("Unblock")
         type: StatusQ.StatusBaseButton.Type.Danger
         onClicked: function (event) {


### PR DESCRIPTION
Fixes #6298

### What does the PR do

`StatusButton` is now used correctly. There are 3 different button variations with preset heights/widths and paddings. The consumer cannot change the height without altering the expected behaviour and display of the button.

Button height is now consistent with chat input height.

### Affected areas

1:1 Chat / Blocked user

### Screenshot of functionality

![Screenshot 2022-07-15 at 11 32 58](https://user-images.githubusercontent.com/97019400/179198569-32326c55-bafd-4e0e-b15e-a8a521cbf5c7.png)

