### PR TITLE
fix(BackupSeedModal): fix the confirmation/final page UI

### DIFF
--- a/ui/app/AppLayouts/Profile/popups/backupseed/ConfirmStoringSeedPhrasePanel.qml
+++ b/ui/app/AppLayouts/Profile/popups/backupseed/ConfirmStoringSeedPhrasePanel.qml
@@ -9,41 +9,55 @@ import shared.panels 1.0
 BackupSeedStepBase {
     id: root
 
-    property bool seedStored: storeCheck.checked
+    readonly property alias seedStored: storeCheck.checked
 
     titleText: qsTr("Complete back up")
 
-    StyledText {
-        id: txtTitle
-        horizontalAlignment: Text.AlignHCenter
-        wrapMode: Text.WordWrap
-        font.bold: true
-        font.pixelSize: 17
-        text: qsTr("Store Your Phrase Offline and Complete Your Back Up")
+    ColumnLayout {
         Layout.fillWidth: true
-    }
+        Layout.leftMargin: 44
+        Layout.rightMargin: 44
+        Layout.topMargin: Style.current.bigPadding
+        spacing: Style.current.padding
 
-    StyledText {
-        id: txtDesc
-        horizontalAlignment: Text.AlignHCenter
-        wrapMode: Text.WordWrap
-        font.pixelSize: Style.current.primaryTextFontSize
-        text: qsTr("By completing this process, you will remove your seed phrase from this application’s storage. This makes your funds more secure.")
-        Layout.fillWidth: true
-    }
+        StyledText {
+            id: txtTitle
+            horizontalAlignment: Text.AlignHCenter
+            wrapMode: Text.WordWrap
+            font.bold: true
+            font.pixelSize: 17
+            lineHeight: 1.2
+            text: qsTr("Store Your Phrase Offline and Complete Your Back Up")
+            Layout.fillWidth: true
+        }
 
-    StyledText {
-        id: secondTxtDesc
-        horizontalAlignment: Text.AlignHCenter
-        wrapMode: Text.WordWrap
-        font.pixelSize: Style.current.primaryTextFontSize
-        text: qsTr("You will remain logged in, and your seed phrase will be entirely in your hands.")
-        Layout.fillWidth: true
-    }
+        StyledText {
+            id: txtDesc
+            horizontalAlignment: Text.AlignHCenter
+            wrapMode: Text.WordWrap
+            font.pixelSize: Style.current.primaryTextFontSize
+            lineHeight: 1.2
+            text: qsTr("By completing this process, you will remove your seed phrase from this application’s storage. This makes your funds more secure.")
+            Layout.fillWidth: true
+        }
 
-    StatusCheckBox {
-        id: storeCheck
-        text: qsTr("I aknowledge that Status will not be able to show me my seed phrase again.")
-        Layout.fillWidth: true
+        StyledText {
+            id: secondTxtDesc
+            horizontalAlignment: Text.AlignHCenter
+            wrapMode: Text.WordWrap
+            font.pixelSize: Style.current.primaryTextFontSize
+            lineHeight: 1.2
+            text: qsTr("You will remain logged in, and your seed phrase will be entirely in your hands.")
+            Layout.fillWidth: true
+        }
+
+        StatusCheckBox {
+            id: storeCheck
+            spacing: Style.current.padding
+            font.pixelSize: Style.current.primaryTextFontSize
+            text: qsTr("I acknowledge that Status will not be able to show me my seed phrase again.")
+            Layout.fillWidth: true
+            Layout.topMargin: Style.current.bigPadding
+        }
     }
 }


### PR DESCRIPTION
Follow up to PR #6467, just a few minor UI tweaks to align it to the
intended design

### What does the PR do

Fixes UI issues in the confirmation/final  page of the BackupSeed modal

### Affected areas

BackupSeedModal/ConfirmStoringSeedPhrasePanel

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

Side by side comparison:
![Snímek obrazovky z 2022-07-15 15-20-18](https://user-images.githubusercontent.com/5377645/179232611-5a5983f9-48a3-431a-ba3b-4d3afe55272f.png)

