### PR TITLE
fix(CreateChatView): updated layout spacing and sizes

### DIFF
--- a/ui/app/AppLayouts/Chat/views/CreateChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/CreateChatView.qml
@@ -85,6 +85,7 @@ Page {
         anchors.topMargin: Style.current.halfPadding
         height: tagSelector.height
         clip: true
+        spacing: Style.current.padding
         StatusTagSelector {
             id: tagSelector
             Layout.fillWidth: true
@@ -112,6 +113,7 @@ Page {
 
         StatusButton {
             id: confirmButton
+            implicitWidth: 106
             implicitHeight: 44
             Layout.alignment: Qt.AlignTop
             enabled: tagSelector.namesModel.count > 0
@@ -124,13 +126,13 @@ Page {
         }
 
         Item {
+            implicitHeight: 32
+            implicitWidth: 32
             Layout.alignment: Qt.AlignTop
-            implicitHeight: 44
-            implicitWidth: 44
 
             StatusActivityCenterButton {
                 id: notificationButton
-                anchors.centerIn: parent
+                anchors.right: parent.right
                 unreadNotificationsCount: activityCenter.unreadNotificationsCount
                 onClicked: activityCenter.open()
             }
@@ -175,8 +177,11 @@ Page {
         }
 
         StatusBaseText {
-            width: parent.width*.66
-            anchors.centerIn: parent
+            anchors.left: parent.left
+            anchors.leftMargin: 252
+            anchors.right: parent.right
+            anchors.rightMargin: 252
+            anchors.verticalCenter: parent.verticalCenter
             anchors.verticalCenterOffset: -(headerRow.height/2)
             horizontalAlignment: Text.AlignHCenter
             verticalAlignment: Text.AlignVCenter
@@ -184,9 +189,8 @@ Page {
             wrapMode: Text.WordWrap
             font.pixelSize: 15
             color: Theme.palette.baseColor1
-            text: qsTr("You can only send direct messages to your Contacts.\n\n
-Send a contact request to the person you would like to chat with, you will be able to \
-chat with them once they have accepted your contact request.")
+            text: qsTr("You can only send direct messages to your Contacts.\n
+Send a contact request to the person you would like to chat with, you will be able to chat with them once they have accepted your contact request.")
             Component.onCompleted: {
                 if (visible) {
                     tagSelector.enabled = false;


### PR DESCRIPTION
Closes #6452

### What does the PR do
CreateChatView updated layout spacing and sizes

### Affected areas
CreateChatView

### Screenshot of functionality (including design for comparison)
<img width="992" alt="da" src="https://user-images.githubusercontent.com/31625338/179249082-9c227abd-3ec9-4e85-9659-09428578b790.png">

*Figma at top, app at the bottom
*Screenshot is taken in combination with this https://github.com/status-im/StatusQ/pull/780 change

TEXT
<img width="1379" alt="txt" src="https://user-images.githubusercontent.com/31625338/179251672-cd528410-9916-45d5-b912-4d2ea5cbde83.png">

