### PR TITLE
fix(@desktop/onboarding): Align text on Biometrics page with design

### DIFF
--- a/ui/app/AppLayouts/Onboarding/views/TouchIDAuthView.qml
+++ b/ui/app/AppLayouts/Onboarding/views/TouchIDAuthView.qml
@@ -66,7 +66,7 @@ OnboardingBasePage {
             anchors.top: txtTitle.bottom
             anchors.topMargin: Style.current.padding
             color: Style.current.secondaryText
-            text: qsTr("Would you like to use your Touch ID to login to Status?")
+            text: qsTr("Would you like to use Touch ID\nto login to Status?")
             horizontalAlignment: Text.AlignHCenter
             wrapMode: Text.WordWrap
             font.pixelSize: 15

--- a/ui/i18n/qml_en.ts
+++ b/ui/i18n/qml_en.ts
@@ -8627,8 +8627,10 @@ device, so only you can use them.</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Onboarding/views/TouchIDAuthView.qml" line="69" />
-        <source>Would you like to use your Touch ID to login to Status?</source>
-        <translation>Would you like to use your Touch ID to login to Status?</translation>
+        <source>Would you like to use Touch ID
+to login to Status?</source>
+        <translation>Would you like to use Touch ID
+to login to Status?</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Onboarding/views/TouchIDAuthView.qml" line="82" />


### PR DESCRIPTION
### What does the PR do

fixes #6024 

- text on Biometrics page aligned with design, line break added
- translation adjusted

### Affected areas

TouchIDAuthView component

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![Screenshot from 2022-07-18 12-21-14](https://user-images.githubusercontent.com/20650004/179500416-27d13ce8-c87f-4a7b-844d-5ac22fe213ea.png)

