### PR TITLE
fix(@desktop/chat): Remove notifications section from community management

### DIFF
--- a/ui/app/AppLayouts/Chat/views/CommunitySettingsView.qml
+++ b/ui/app/AppLayouts/Chat/views/CommunitySettingsView.qml
@@ -23,14 +23,15 @@ StatusAppTwoPanelLayout {
     id: root
 
     // TODO: get this model from backend?
-    property var settingsMenuModel: [{name: qsTr("Overview"), icon: "help"},
-                        {name: qsTr("Members"), icon: "group-chat"},
-//                        {name: qsTr("Permissions"), icon: "objects"},
-//                        {name: qsTr("Tokens"), icon: "token"},
-//                        {name: qsTr("Airdrops"), icon: "airdrop"},
-//                        {name: qsTr("Token sales"), icon: "token-sale"},
-//                        {name: qsTr("Subscriptions"), icon: "subscription"},
-                        {name: qsTr("Notifications"), icon: "notification"}]
+    property var settingsMenuModel: [
+        {name: qsTr("Overview"), icon: "help"},
+        {name: qsTr("Members"), icon: "group-chat"},
+//        {name: qsTr("Permissions"), icon: "objects"},
+//        {name: qsTr("Tokens"), icon: "token"},
+//        {name: qsTr("Airdrops"), icon: "airdrop"},
+//        {name: qsTr("Token sales"), icon: "token-sale"},
+//        {name: qsTr("Subscriptions"), icon: "subscription"}
+    ]
 
     property var rootStore
     property var community
@@ -78,7 +79,7 @@ StatusAppTwoPanelLayout {
                 width: listView.width
                 title: modelData.name
                 icon.name: modelData.icon
-                selected: d.currentIndex == index
+                selected: d.currentIndex === index
                 onClicked: d.currentIndex = index
             }
         }
@@ -191,30 +192,6 @@ StatusAppTwoPanelLayout {
                 onMembershipRequestsClicked: Global.openPopup(root.membershipRequestPopup, {
                     communitySectionModule: root.chatCommunitySectionModule
                 })
-            }
-
-            SettingsPageLayout {
-                title: qsTr("Notifications")
-
-                content: ColumnLayout {
-                    StatusListItem {
-                        Layout.fillWidth: true
-
-                        title: qsTr("Enabled")
-                        icon.name: "notification"
-                        sensor.cursorShape: Qt.ArrowCursor
-                        components: [
-                            StatusSwitch {
-                                checked: !root.community.muted
-                                onClicked: root.chatCommunitySectionModule.setCommunityMuted(!checked)
-                            }
-                        ]
-                    }
-
-                    Item {
-                        Layout.fillHeight: true
-                    }
-                }
             }
         }
     }

--- a/ui/i18n/qml_en.ts
+++ b/ui/i18n/qml_en.ts
@@ -2549,43 +2549,32 @@ Do you wish to override the security check and continue?</translation>
 <context>
     <name>CommunitySettingsView</name>
     <message>
-        <location filename="../app/AppLayouts/Chat/views/CommunitySettingsView.qml" line="26" />
+        <location filename="../app/AppLayouts/Chat/views/CommunitySettingsView.qml" line="27" />
         <source>Overview</source>
         <translation>Overview</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/views/CommunitySettingsView.qml" line="27" />
+        <location filename="../app/AppLayouts/Chat/views/CommunitySettingsView.qml" line="28" />
         <source>Members</source>
         <translation>Members</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/views/CommunitySettingsView.qml" line="33" />
-        <location filename="../app/AppLayouts/Chat/views/CommunitySettingsView.qml" line="197" />
-        <source>Notifications</source>
-        <translation>Notifications</translation>
-    </message>
-    <message>
-        <location filename="../app/AppLayouts/Chat/views/CommunitySettingsView.qml" line="67" />
+        <location filename="../app/AppLayouts/Chat/views/CommunitySettingsView.qml" line="68" />
         <source>Settings</source>
         <translation>Settings</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/views/CommunitySettingsView.qml" line="93" />
+        <location filename="../app/AppLayouts/Chat/views/CommunitySettingsView.qml" line="94" />
         <source>Open legacy popup (to be removed)</source>
         <translation>Open legacy popup (to be removed)</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/views/CommunitySettingsView.qml" line="107" />
+        <location filename="../app/AppLayouts/Chat/views/CommunitySettingsView.qml" line="108" />
         <source>Back to community</source>
         <translation>Back to community</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/views/CommunitySettingsView.qml" line="203" />
-        <source>Enabled</source>
-        <translation>Enabled</translation>
-    </message>
-    <message>
-        <location filename="../app/AppLayouts/Chat/views/CommunitySettingsView.qml" line="230" />
+        <location filename="../app/AppLayouts/Chat/views/CommunitySettingsView.qml" line="207" />
         <source>Error editing the community</source>
         <translation>Error editing the community</translation>
     </message>


### PR DESCRIPTION
### What does the PR do

fixes #6381 

- notifications section removed
- minor fix (== to ===)
- translation file fixed (line numbers, one unused entry removed)

### Affected areas

Community management, CommunitySettingsView component

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![Screenshot 2022-07-18 14:59:47](https://user-images.githubusercontent.com/20650004/179518675-82504813-46ce-4203-ac69-6f37825c8f0a.png)

