### PR TITLE
fix(WalletHeader): wallet section header UI fixes

### DIFF
--- a/ui/app/AppLayouts/Wallet/WalletLayout.qml
+++ b/ui/app/AppLayouts/Wallet/WalletLayout.qml
@@ -101,6 +101,9 @@ Item {
         rightPanel: StackView {
             id: rightPanelStackView
             anchors.fill: parent
+            anchors.topMargin: 49
+            anchors.leftMargin: 49
+            anchors.rightMargin: 49
             initialItem: walletContainer
             replaceEnter: Transition {
                 NumberAnimation { property: "opacity"; from: 0; to: 1; duration: 400; easing.type: Easing.OutCubic }

--- a/ui/app/AppLayouts/Wallet/panels/WalletHeader.qml
+++ b/ui/app/AppLayouts/Wallet/panels/WalletHeader.qml
@@ -2,80 +2,93 @@ import QtQuick 2.13
 import QtQuick.Controls 2.13
 import QtQuick.Layouts 1.13
 
+import StatusQ.Core 0.1
+import StatusQ.Controls 0.1
+import StatusQ.Core.Theme 0.1
+
 import utils 1.0
 
 import shared 1.0
 import shared.panels 1.0
-import shared.popups 1.0
 import shared.status 1.0
-import "../popups"
 import "../controls"
 import "../stores"
 
 Item {
-    id: walletHeader
+    id: root
 
     property string locale: ""
     property string currency: ""
     property var currentAccount
-    property var changeSelectedAccount
     property var store
     property var walletStore
-    property var emojiPopup
 
-    height: walletAddress.y + walletAddress.height
+    implicitHeight: childrenRect.height
 
-    StyledText {
-        id: title
-        text: currentAccount.name
-        anchors.top: parent.top
-        anchors.topMargin: 56
-        anchors.left: parent.left
-        anchors.leftMargin: 24
-        font.weight: Font.Medium
-        font.pixelSize: 28
-    }
+    GridLayout {
+        width: parent.width
+        rowSpacing: Style.current.halfPadding
+        columns: 2
 
-    Rectangle {
-        id: separatorDot
-        width: 8
-        height: 8
-        color: Style.current.primary
-        anchors.top: title.verticalCenter
-        anchors.topMargin: -3
-        anchors.left: title.right
-        anchors.leftMargin: 8
-        radius: 50
-    }
-
-    StyledText {
-        id: walletBalance
-        text: {
-            Utils.toLocaleString(currentAccount.currencyBalance.toFixed(2), locale, {"currency": true}) + " " + walletHeader.currency.toUpperCase()
+        // account + balance
+        Row {
+            spacing: Style.current.halfPadding
+            StatusBaseText {
+                font.pixelSize: 28
+                font.bold: true
+                text: currentAccount.name
+            }
+            StatusBaseText {
+                font.pixelSize: 28
+                font.bold: true
+                color: Theme.palette.baseColor1
+                text: "%1 %2".arg(Utils.toLocaleString(root.currentAccount.currencyBalance.toFixed(2), root.locale, {"currency": true})).arg(root.currency.toUpperCase())
+            }
         }
-        anchors.left: separatorDot.right
-        anchors.leftMargin: 8
-        anchors.verticalCenter: title.verticalCenter
-        font.pixelSize: 22
-    }
 
-    StatusExpandableAddress {
-        id: walletAddress
-        address: currentAccount.mixedcaseAddress
-        anchors.top: title.bottom
-        anchors.left: title.left
-        addressWidth: 180
-        anchors.leftMargin: 0
-        anchors.topMargin: 0
-        store: walletHeader.store
-    }
+        // network filter
+        NetworkFilter {
+            id: networkFilter
+            Layout.alignment: Qt.AlignTrailing
+            Layout.fillHeight: true
+            Layout.rowSpan: 2
+            store: root.walletStore
+        }
 
-    NetworkFilter {
-        id: networkFilter
-        anchors.top: parent.top
-        anchors.topMargin: 56
-        anchors.right: parent.right
-        anchors.rightMargin: 63
-        store: walletHeader.walletStore
+        // account address button
+        Button {
+            horizontalPadding: Style.current.halfPadding
+            verticalPadding: 5
+            Layout.preferredWidth: 150
+            background: Rectangle {
+                implicitWidth: 150
+                implicitHeight: 32
+                color: "transparent"
+                border.width: 1
+                border.color: Theme.palette.baseColor2
+                radius: 36
+            }
+
+            contentItem: RowLayout {
+                spacing: 4
+                StatusIcon {
+                    Layout.alignment: Qt.AlignVCenter
+                    Layout.preferredWidth: 22
+                    Layout.preferredHeight: 22
+                    icon: "address"
+                    color: Theme.palette.baseColor2
+                }
+                StatusBaseText {
+                    Layout.alignment: Qt.AlignVCenter
+                    Layout.fillWidth: true
+                    text: currentAccount.mixedcaseAddress
+                    color: Theme.palette.directColor5
+                    elide: Text.ElideMiddle
+                    font.pixelSize: Style.current.primaryTextFontSize
+                    font.weight: Font.Medium
+                }
+            }
+            onClicked: store.copyToClipboard(currentAccount.mixedcaseAddress)
+        }
     }
- }
+}

--- a/ui/app/AppLayouts/Wallet/views/RightTabView.qml
+++ b/ui/app/AppLayouts/Wallet/views/RightTabView.qml
@@ -1,7 +1,6 @@
 import QtQuick 2.13
 import QtQuick.Controls 2.13
 import QtQuick.Layouts 1.13
-import QtGraphicalEffects 1.13
 
 import StatusQ.Controls 0.1
 
@@ -17,86 +16,68 @@ import "../views"
 import "../panels"
 
 Item {
-    id: walletContainer
+    id: root
 
     property alias currentTabIndex: walletTabBar.currentIndex
     property var store
     property var sendModal
 
     ColumnLayout {
-        width: parent.width
-        height: parent.height
+       anchors.fill: parent
 
         WalletHeader {
-            id: walletHeader
             Layout.fillWidth: true
+            Layout.leftMargin: Style.current.padding
+            Layout.rightMargin: Style.current.padding
             locale: RootStore.locale
             currency: RootStore.currentCurrency
             currentAccount: RootStore.currentAccount
-            store: walletContainer.store
+            store: root.store
             walletStore: RootStore
         }
 
-        Item {
-            id: walletInfoContent
-            Layout.fillHeight: true
+        StatusTabBar {
+            id: walletTabBar
+            horizontalPadding: Style.current.padding
             Layout.fillWidth: true
+            Layout.topMargin: Style.current.padding
 
-            StatusTabBar {
-                id: walletTabBar
-                anchors.right: parent.right
-                anchors.rightMargin: Style.current.bigPadding
-                anchors.left: parent.left
-                anchors.leftMargin: Style.current.bigPadding
-                anchors.top: parent.top
-                anchors.topMargin: Style.current.padding
-                
-                StatusTabButton {
-                    id: assetBtn
-                    width: implicitWidth
-                    text: qsTr("Assets")
-                }
-                StatusTabButton {
-                    id: collectiblesBtn
-                    width: implicitWidth
-                    text: qsTr("Collectibles")
-                }
-                StatusTabButton {
-                    id: historyBtn
-                    width: implicitWidth
-                    text: qsTr("History")
-                }
+            StatusTabButton {
+                leftPadding: 0
+                width: implicitWidth
+                text: qsTr("Assets")
             }
+            StatusTabButton {
+                width: implicitWidth
+                text: qsTr("Collectibles")
+            }
+            StatusTabButton {
+                rightPadding: 0
+                width: implicitWidth
+                text: qsTr("Activity")
+            }
+        }
 
-            StackLayout {
-                id: stackLayout
-                anchors.rightMargin: Style.current.bigPadding
-                anchors.leftMargin: Style.current.bigPadding
-                anchors.top: walletTabBar.bottom
-                anchors.right: parent.right
-                anchors.bottom: parent.bottom
-                anchors.left: parent.left
-                anchors.topMargin: Style.current.bigPadding
-                currentIndex: walletTabBar.currentIndex
+        StackLayout {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            Layout.margins: Style.current.padding
+            currentIndex: walletTabBar.currentIndex
 
-                AssetsView {
-                    id: assetsTab
-                    account: RootStore.currentAccount
-                }
-                CollectiblesView {
-                    id: collectiblesTab
-                }
-                HistoryView {
-                    id: historyTab
-                    account: RootStore.currentAccount
-                }
+            AssetsView {
+                account: RootStore.currentAccount
+            }
+            CollectiblesView {}
+            HistoryView {
+                account: RootStore.currentAccount
             }
         }
 
         WalletFooter {
-            id: walletFooter
             Layout.fillWidth: true
-            sendModal: walletContainer.sendModal
+            Layout.leftMargin: -root.StackView.view.anchors.leftMargin
+            Layout.rightMargin: -root.StackView.view.anchors.rightMargin
+            sendModal: root.sendModal
         }
     }
 }

--- a/ui/app/AppLayouts/Wallet/views/SavedAddressesView.qml
+++ b/ui/app/AppLayouts/Wallet/views/SavedAddressesView.qml
@@ -1,6 +1,5 @@
 import QtQuick 2.13
 import QtQuick.Controls 2.13
-import QtQuick.Layouts 1.13
 
 import utils 1.0
 
@@ -16,9 +15,8 @@ import "../stores"
 
 Item {
     id: root
-    anchors.leftMargin: 80
-    anchors.rightMargin: 80
-    anchors.topMargin: 62
+    anchors.leftMargin: Style.current.padding
+    anchors.rightMargin: Style.current.padding
 
     property var contactsStore
 
@@ -35,35 +33,23 @@ Item {
         anchors.top: parent.top
         height: btnAdd.height
 
-        Row {
+        StatusBaseText {
             anchors.left: parent.left
-            anchors.top: parent.top
-            anchors.right: btnAdd.left
-            spacing: 10
-
-            StatusIcon {
-                icon: "address"
-                color: Theme.palette.primaryColor1
-                width: undefined
-                height: 35
-                anchors.verticalCenter: parent.verticalCenter
-            }
-            StatusBaseText {
-                id: title
-                text: qsTr("Saved addresses")
-                font.weight: Font.Medium
-                font.pixelSize: 28
-                anchors.verticalCenter: parent.verticalCenter
-                color: Theme.palette.directColor1
-            }
+            anchors.verticalCenter: parent.verticalCenter
+            id: title
+            text: qsTr("Saved addresses")
+            font.weight: Font.Bold
+            font.pixelSize: 28
+            color: Theme.palette.directColor1
         }
         StatusButton {
             id: btnAdd
             anchors.right: parent.right
             anchors.top: parent.top
-            text: "Add new   +"
-            leftPadding: 8
-            rightPadding: 11
+            anchors.verticalCenter: parent.verticalCenter
+            size: StatusBaseButton.Size.Small
+            font.weight: Font.Medium
+            text: qsTr("Add new address")
             visible: !_internal.loading
             onClicked: {
                 Global.openPopup(addEditSavedAddress)
@@ -146,7 +132,7 @@ Item {
         // caused no text to render
         property string text: qsTr("Are you sure you want to remove '%1' from your saved addresses?").arg(name)
         anchors.centerIn: parent
-        header.title: "Are you sure?"
+        header.title: qsTr("Are you sure?")
         header.subTitle: name
         contentItem: StatusBaseText {
             anchors.centerIn: parent
@@ -188,11 +174,7 @@ Item {
     }
 
     StatusBaseText {
-        anchors.top: errorMessage.bottom
-        anchors.topMargin: Style.current.padding
         anchors.centerIn: parent
-        Layout.fillWidth: true
-        Layout.fillHeight: true
         visible: listView.count === 0
         color: Theme.palette.baseColor1
         text: qsTr("No saved addresses")
@@ -206,8 +188,6 @@ Item {
         anchors.right: parent.right
         anchors.left: parent.left
         visible: listView.count > 0
-        Layout.fillWidth: true
-        Layout.fillHeight: true
         ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
 
         ListView {


### PR DESCRIPTION
### What does the PR do

Fixes various issues in the wallet/account header section

Closes #6484: Account header is different from design

Closes #6485: Account layout needs margins adjusted to match design

Closes #6493: Saved addresses header should look like designs

### Affected areas

Wallet/WalletHeader,SavedAddressesView

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

Side by side:
![Snímek obrazovky z 2022-07-19 15-10-56](https://user-images.githubusercontent.com/5377645/179760599-4a13c682-7f64-48b4-8529-1268db86de92.png)

Overall view:
![Snímek obrazovky z 2022-07-19 15-11-10](https://user-images.githubusercontent.com/5377645/179760744-b91a4754-2b3e-49aa-9bd3-bdaff454fcab.png)

Saved addresses:
![Snímek obrazovky z 2022-07-19 15-11-16](https://user-images.githubusercontent.com/5377645/179760816-8857b888-de97-4ae9-895b-c1687130d28f.png)
