### PR TITLE
fix(@desktop/wallet): Wallet account generation popup doesn't support tab navigation

### DIFF
--- a/ui/app/AppLayouts/Wallet/views/LeftTabView.qml
+++ b/ui/app/AppLayouts/Wallet/views/LeftTabView.qml
@@ -80,6 +80,7 @@ Rectangle {
 
         ScrollView {
             Layout.fillWidth: true
+            Layout.fillHeight: true
             Layout.topMargin: Style.current.halfPadding
             ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
             ScrollBar.vertical.policy: listView.contentHeight > listView.height ? ScrollBar.AlwaysOn : ScrollBar.AlwaysOff


### PR DESCRIPTION
fix(@desktop/wallet): Wallet account generation popup doesn't support tab navigation

Please not tab access for advanced view is not implemented

fixes #6388

### What does the PR do

Added tab navigation between password, account name and confirm buttons on the add account modal

### Affected areas

Wallet

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

https://user-images.githubusercontent.com/60327365/179791355-b71caa5c-0fc0-4e5e-93d6-ff24d55ea864.mov


