### PR TITLE
fix(@desktop/chat): endless search when user has no chats or communities

### DIFF
--- a/src/app/modules/main/app_search/controller.nim
+++ b/src/app/modules/main/app_search/controller.nim
@@ -127,6 +127,10 @@ proc searchMessages*(self: Controller, searchTerm: string) =
     for cId in communitiesIds:
       communities.add(cId)
 
+  if (communities.len == 0 and chats.len == 0):
+    self.delegate.onSearchMessagesDone(@[])
+    return
+
   self.messageService.asyncSearchMessages(communities, chats, self.searchTerm, false)
 
 proc getOneToOneChatNameAndImage*(self: Controller, chatId: string):

--- a/src/app_service/service/message/service.nim
+++ b/src/app_service/service/message/service.nim
@@ -526,8 +526,8 @@ QtObject:
       self.finishAsyncSearchMessagesWithError(chatId, "search messages response doesn't contain messages array")
       return
 
-    if (messagesArray.kind != JArray):
-      self.finishAsyncSearchMessagesWithError(chatId, "expected messages json array is not of JArray type")
+    if (messagesArray.kind notin {JArray, JNull}):
+      self.finishAsyncSearchMessagesWithError(chatId, "expected messages json array is neither of JArray nor JNull type")
       return
 
     var messages = map(messagesArray.getElems(), proc(x: JsonNode): MessageDto = x.toMessageDto())
@@ -542,6 +542,7 @@ QtObject:
       return
 
     if (searchTerm.len == 0):
+      error "the searched term cannot be empty", procName="asyncSearchMessages"
       return
 
     let arg = AsyncSearchMessagesInChatTaskArg(
@@ -564,6 +565,7 @@ QtObject:
       return
 
     if (searchTerm.len == 0):
+      error "the searched term cannot be empty", procName="asyncSearchMessages"
       return
 
     let arg = AsyncSearchMessagesInChatsAndCommunitiesTaskArg(


### PR DESCRIPTION
### What does the PR do

fixes #6427

- additional check added to the controller, if there is no chats or communities to search skip async search and return empty result
- go backend returns null when no messages found. It was causing error message - response validation fixed.
- some error messages added  for consistency

### Affected areas

app search controller, message service

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![Screenshot 2022-07-19 17:07:26](https://user-images.githubusercontent.com/20650004/179793810-e46e076e-f3a7-435a-93b4-298abac4201a.png)

