### PR TITLE
fix(@desktop/wallet): Multinetwork QR code sometimes doesn't update when there is only 1 network left

### DIFF
--- a/ui/app/AppLayouts/Wallet/popups/ReceiveModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/ReceiveModal.qml
@@ -41,6 +41,15 @@ StatusModal {
     showHeader: false
     showAdvancedHeader: true
 
+    // When no network is selected reset the prefix to empty string
+    Connections {
+        target: RootStore.enabledNetworks
+        function onModelReset() {
+            if(RootStore.enabledNetworks.count === 0)
+                popup.networkPrefix = ""
+        }
+    }
+
     hasFloatingButtons: true
     advancedHeaderComponent: StatusFloatingButtonsSelector {
         id: floatingHeader


### PR DESCRIPTION
fix(@desktop/wallet): Multinetwork QR code sometimes doesn't update when there is only 1 network left

fixes #6496

### What does the PR do

When model is empty prefix is not calculated so check for empty model and reset it to empty string

### Affected areas

Wallet

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it


https://user-images.githubusercontent.com/60327365/179807727-b5bcf957-9793-4ad0-9a81-c0fa7b405a59.mov


