### PR TITLE
fix(@desktop/chat): Block 'Done' btn when nickname is invalid

### DIFF
--- a/ui/imports/shared/popups/NicknamePopup.qml
+++ b/ui/imports/shared/popups/NicknamePopup.qml
@@ -13,17 +13,18 @@ import StatusQ.Controls.Validators 0.1
 import StatusQ.Popups 0.1
 
 StatusModal {
-    anchors.centerIn: parent
-
     id: popup
+
     width: 400
     height: 340
+    anchors.centerIn: parent
+
     header.title: qsTr("Nickname")
 
-    property string nickname: ""
-    property int nicknameLength: nicknameInput.text.length
+    property alias nickname: nicknameInput.text
+    readonly property int nicknameLength: nicknameInput.text.length
     readonly property int maxNicknameLength: 32
-    property bool nicknameTooLong: nicknameLength > maxNicknameLength
+
     signal editDone(string newNickname)
 
     onOpened: {
@@ -53,7 +54,6 @@ StatusModal {
             StatusInput {
                 id: nicknameInput
                 input.placeholderText: qsTr("Nickname")
-                text: nickname
 
                 width: parent.width
 
@@ -77,7 +77,7 @@ StatusModal {
         StatusButton {
             id: doneBtn
             text: qsTr("Done")
-            enabled: !popup.nicknameTooLong
+            enabled: nicknameInput.valid
             onClicked: editDone(nicknameInput.text)
         }
     ]


### PR DESCRIPTION
### What does the PR do

fixes #5930

- block "Done" when the input is invalid (it can be done by selecting existing text and pasting forbidden characters)
- some minor style fixes

### Affected areas

NicknamePopup.qml

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![Screenshot from 2022-07-20 12-49-59](https://user-images.githubusercontent.com/20650004/179965899-5ac477f4-a7f4-4bd7-8f9d-5c09298a6aa6.png)
