### PR TITLE
sort display names in UserListPanel

### DIFF
--- a/ui/app/AppLayouts/Chat/panels/UserListPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/UserListPanel.qml
@@ -54,10 +54,16 @@ Item {
 
         model: SortFilterProxyModel {
             sourceModel: usersModule.model
-            sorters: StringSorter {
-                roleName: "displayName"
-                caseSensitivity: Qt.CaseInsensitive
-            }
+            sorters: [
+                RoleSorter {
+                    roleName: "onlineStatus"
+                    sortOrder: Qt.DescendingOrder
+                },
+                StringSorter {
+                    roleName: "displayName"
+                    caseSensitivity: Qt.CaseInsensitive
+                }
+            ]
         }
         section.property: "onlineStatus"
         section.delegate: (root.width > 58) ? sectionDelegateComponent : null

--- a/ui/app/AppLayouts/Chat/panels/UserListPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/UserListPanel.qml
@@ -12,6 +12,8 @@ import utils 1.0
 
 import "../controls"
 
+import SortFilterProxyModel 0.2
+
 Item {
     id: root
     anchors.fill: parent
@@ -50,7 +52,13 @@ Item {
             bottomMargin: Style.current.bigPadding
         }
 
-        model: usersModule.model
+        model: SortFilterProxyModel {
+            sourceModel: usersModule.model
+            sorters: StringSorter {
+                roleName: "displayName"
+                caseSensitivity: Qt.CaseInsensitive
+            }
+        }
         section.property: "onlineStatus"
         section.delegate: (root.width > 58) ? sectionDelegateComponent : null
         delegate: StatusMemberListItem {


### PR DESCRIPTION
- [bump DOtherSide](https://github.com/status-im/status-desktop/pull/6562/commits/60e318ad958fb1fd11164b1aababa39e55adec65)

- [fix(@desktop/chat): sort display names in UserListPanel](https://github.com/status-im/status-desktop/commit/0fc4a5f11b03db2d3b296a9097110fb76c3bf14e)
   - fixes: https://github.com/status-im/status-desktop/issues/6185
- [fix(@desktop/chat): sort users by online status](https://github.com/status-im/status-desktop/pull/6562/commits/51282ece0b18694dcb5bd4e14cdbdfa356776ac1)
   -  fixes: https://github.com/status-im/status-desktop/issues/6563
   Users model has to be sorted by online status first, otherwise
`UserListPanel` sections will be duplicated. That's because:

   > Note: Adding sections to a ListView does not automatically re-order
the list items by the section criteria. If the model is not ordered by
section, then it is possible that the sections created will not be
unique; each boundary between differing sections will result in a
section header being created even if that section exists elsewhere.

![image](https://user-images.githubusercontent.com/33099791/180194275-632c0a69-63ee-4d14-a618-c28e1d8cf164.png)
