### PR TITLE
ci: fix upload speeds on Windows

### DIFF
--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.5.1'
+library 'status-jenkins-lib@v1.5.6'
 
 pipeline {
   agent { label 'linux' }

--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.5.1'
+library 'status-jenkins-lib@v1.5.6'
 
 pipeline {
   agent {
@@ -59,7 +59,9 @@ pipeline {
     }
 
     stage('status-go') {
-      steps { sh 'make status-go' }
+      steps {
+        sh 'make status-go'
+      }
     }
 
     stage('Package') {

--- a/ci/Jenkinsfile.linux-cpp
+++ b/ci/Jenkinsfile.linux-cpp
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.5.1'
+library 'status-jenkins-lib@v1.5.6'
 
 pipeline {
   agent {

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.5.1'
+library 'status-jenkins-lib@v1.5.6'
 
 pipeline {
   agent {
@@ -64,12 +64,14 @@ pipeline {
     }
 
     stage('status-go') {
-      steps { sh 'make status-go' }
+      steps {
+        sh 'make status-go'
+      }
     }
 
     stage('Package') {
       steps { script {
-        macos.bundle()
+        macos.bundle('pkg-macos')
       } }
     }
 

--- a/ci/Jenkinsfile.macos-cpp.todo
+++ b/ci/Jenkinsfile.macos-cpp.todo
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.5.1'
+library 'status-jenkins-lib@v1.5.6'
 
 pipeline {
   agent {

--- a/ci/Jenkinsfile.windows
+++ b/ci/Jenkinsfile.windows
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.5.1'
+library 'status-jenkins-lib@v1.5.6'
 
 pipeline {
   agent { label 'windows' }
@@ -31,7 +31,7 @@ pipeline {
   environment {
     TARGET = 'windows'
     /* Improve make performance */
-    MAKEFLAGS = "-j4 V=${params.VERBOSE}"
+    MAKEFLAGS = "-j${utils.getProcCount()} V=${params.VERBOSE}"
     /* Disable colors in Nim compiler logs */
     NIMFLAGS = '--colors:off'
     /* Control output the filename */
@@ -53,7 +53,9 @@ pipeline {
     }
 
     stage('status-go') {
-      steps { sh 'make status-go' }
+      steps {
+        sh 'make status-go'
+      }
     }
 
     stage('Package') {
@@ -63,22 +65,28 @@ pipeline {
     }
 
     stage('Parallel Upload') {
+      /* Uploads on Windows are slow. */
       parallel {
-        stage('Upload') {
+        stage('Upload 7Z') {
           steps { script {
             zip_url = s3.uploadArtifact(env.STATUS_CLIENT_7Z)
-            exe_url = s3.uploadArtifact(env.STATUS_CLIENT_EXE)            
-            env.PKG_URL = exe_url
-            jenkins.setBuildDesc(Zip: zip_url, Exe: exe_url)
           } }
         }
-        stage('Archive') {
+        stage('Upload EXE') {
           steps { script {
-            archiveArtifacts(env.STATUS_CLIENT_EXE)
-            archiveArtifacts(env.STATUS_CLIENT_7Z)
+            exe_url = s3.uploadArtifact(env.STATUS_CLIENT_EXE)
           } }
         }
       }
+    }
+
+    stage('Archive') {
+      steps { script {
+        archiveArtifacts(env.STATUS_CLIENT_EXE)
+        archiveArtifacts(env.STATUS_CLIENT_7Z)
+        env.PKG_URL = exe_url
+        jenkins.setBuildDesc(Zip: zip_url, Exe: exe_url)
+      } }
     }
   }
   post {

--- a/ci/Jenkinsfile.windows-cpp.todo
+++ b/ci/Jenkinsfile.windows-cpp.todo
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.5.1'
+library 'status-jenkins-lib@v1.5.6'
 
 pipeline {
   agent {


### PR DESCRIPTION
By using `s3cmd` through PowerShell instead of Git Bash we improve upload speeds on Windows slightly, as described here:

* https://github.com/status-im/infra-ci/issues/40

We also split uploads of 7z and EXE files into parallel steps. Though honestly I'd rather avoid uploading the duplicate EXE.
This should cut down the upload step to ~3 minutes instead of the usual ~6 minutes.

Requires:

* https://github.com/status-im/status-jenkins-lib/pull/43