### PR TITLE
fix(MessageContextMenuView): context menu fixes

### DIFF
--- a/ui/imports/shared/controls/chat/ProfileHeader.qml
+++ b/ui/imports/shared/controls/chat/ProfileHeader.qml
@@ -33,6 +33,7 @@ Item {
     property bool pubkeyVisibleWithCopy: false
     property bool emojiHashVisible: true
     property bool editImageButtonVisible: false
+    property bool editButtonVisible: displayNamePlusIconsVisible
     readonly property bool compact: root.imageSize === ProfileHeader.ImageSize.Compact
 
     signal clicked()
@@ -115,11 +116,14 @@ Item {
         }
 
         RowLayout {
-            spacing: Style.current.halfPadding
+            spacing: compact ? 4 : Style.current.halfPadding
+            Layout.fillWidth: true
             Layout.alignment: Qt.AlignHCenter
             visible: root.displayNamePlusIconsVisible
             StyledText {
+                Layout.maximumWidth: root.width - Style.current.xlPadding
                 text: root.displayName
+                elide: Text.ElideRight
                 font {
                     weight: Font.Medium
                     pixelSize: Style.current.primaryTextFontSize
@@ -128,8 +132,8 @@ Item {
 
             Loader {
                 sourceComponent: SVGImage {
-                    height: 16
-                    width: 16
+                    height: compact ? 10 : 16
+                    width: compact ? 10 : 16
                     source: Style.svg("contact")
                 }
                 active: isContact && !root.isCurrentUser
@@ -138,27 +142,30 @@ Item {
 
             Loader {
                 sourceComponent: VerificationLabel {
-                    id: trustStatus
                     trustStatus: root.trustStatus
-                    height: 16
-                    width: 16
+                    height: compact ? 10 : 16
+                    width: compact ? 10 : 16
                 }
                 active: root.trustStatus !== Constants.trustStatus.unknown && !root.isCurrentUser
                 visible: active
             }
 
-            SVGImage {
-                height: 16
-                width: 16
-                source: Style.svg("edit-message")
-                MouseArea {
-                    anchors.fill: parent
-                    cursorShape: Qt.PointingHandCursor
-                    acceptedButtons: Qt.LeftButton
-                    onClicked: {
-                        root.editClicked()
+            Loader {
+                sourceComponent: SVGImage {
+                    height: compact ? 10 : 16
+                    width: compact ? 10 : 16
+                    source: Style.svg("edit-message")
+                    MouseArea {
+                        anchors.fill: parent
+                        cursorShape: Qt.PointingHandCursor
+                        acceptedButtons: Qt.LeftButton
+                        onClicked: {
+                            root.editClicked()
+                        }
                     }
                 }
+                active: root.editButtonVisible
+                visible: active
             }
         }
 

--- a/ui/imports/shared/controls/chat/UserImage.qml
+++ b/ui/imports/shared/controls/chat/UserImage.qml
@@ -18,6 +18,7 @@ Loader {
     property string image
     property bool showRing: true
     property bool interactive: true
+    property var messageContextMenu
 
     property int colorId: Utils.colorIdForPubkey(pubkey)
     property var colorHash: Utils.getColorHashAsJson(pubkey)
@@ -49,7 +50,15 @@ Loader {
             sourceComponent: MouseArea {
                 cursorShape: Qt.PointingHandCursor
                 hoverEnabled: true
-                onClicked: root.clicked()
+                onClicked: {
+                    if (!!root.messageContextMenu) {
+                        // Set parent, X & Y positions for the messageContextMenu
+                        root.messageContextMenu.parent = root
+                        root.messageContextMenu.setXPosition = function() { return root.width + 4 }
+                        root.messageContextMenu.setYPosition = function() { return 0 }
+                    }
+                    root.clicked()
+                }
             }
         }
     }

--- a/ui/imports/shared/views/chat/CompactMessageView.qml
+++ b/ui/imports/shared/views/chat/CompactMessageView.qml
@@ -365,6 +365,7 @@ Item {
             image: root.senderIcon
             pubkey: senderId
             name: senderDisplayName
+            messageContextMenu: root.messageContextMenu
 
             onClicked: root.clickMessage(true, false, false, null, false, false, false, false, "")
         }

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -209,7 +209,7 @@ Loader {
             messageContextMenu.messageSenderId = obj.senderId
             messageContextMenu.selectedUserPublicKey = obj.senderId
             messageContextMenu.selectedUserDisplayName = obj.senderDisplayName
-            messageContextMenu.selectedUserIcon = obj.senderIconToShow
+            messageContextMenu.selectedUserIcon = obj.senderIcon
         }
 
         messageContextMenu.popup()


### PR DESCRIPTION
### What does the PR do

Fixes a couple of issues with the MessageContextMenuView, namely:

- add the "(Un)Mark as Untrustworthy" action to the menu
- fix the placement and visuals of the "(Un)Block" menu item
- add a missing separator above these
- store the blocked and trust details in `d.contactDetails` and properly
  refresh it upon opening the menu
- some other smaller UI fixes to align the menu to the design

Closes #6538: Stranger's (untrustworthy) menu doesn't match the Design

Closes #6535: The stranger's card doesn't match the Design

Also fixes issue with UserImage and the overall popup placement (see the individual commits for more details)

### Affected areas

MessageContextMenuView, ProfileHeader, UserImage

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

Regular account:
![Snímek obrazovky z 2022-07-21 14-22-13](https://user-images.githubusercontent.com/5377645/180212793-ec1e3203-f5ae-43a0-bf86-c0e68288eaf8.png)

Untrustworthy, not blocked:
![Snímek obrazovky z 2022-07-21 14-22-58](https://user-images.githubusercontent.com/5377645/180212787-a6c0c259-df88-4bfd-8c13-b8cddcdd1d72.png)

Untrustworthy, blocked:
![Snímek obrazovky z 2022-07-21 14-22-19](https://user-images.githubusercontent.com/5377645/180212791-e098e78a-723a-4f0e-9574-53710ffeabe2.png)

My profile menu:
![Snímek obrazovky z 2022-07-21 14-23-05](https://user-images.githubusercontent.com/5377645/180212784-bf1a2106-6524-412e-8732-6a91deb2d433.png)

A random profile popup:
![Snímek obrazovky z 2022-07-21 14-23-34](https://user-images.githubusercontent.com/5377645/180212778-654771c0-24ab-4b73-ba21-00c6c5a356ca.png)
