### PR TITLE
fix(l10n): fix strings extraction

### DIFF
--- a/scripts/translationScripts/update-en-ts.py
+++ b/scripts/translationScripts/update-en-ts.py
@@ -15,8 +15,9 @@ def fixupTranslations(enTsFile: str):
     for messageNode in messageNodes:
         enString = messageNode.find('source').text
         trNode = messageNode.find('translation')
-        trNode.text = enString  # add translation
-        trNode.attrib = {}  # remove 'type="unfinished"'
+        if not trNode.text:
+            trNode.text = enString  # add translation
+            trNode.attrib = {}  # remove 'type="unfinished"'
 
     tsXmlTree.write(enTsFile)
 

--- a/ui/i18n/qml_en.ts
+++ b/ui/i18n/qml_en.ts
@@ -3,66 +3,79 @@
     <name>AboutView</name>
     <message>
         <location filename="../app/AppLayouts/Profile/views/AboutView.qml" line="23" />
+        <location filename="../app/AppLayouts/Profile/views/AboutView.qml" line="23" />
         <source>Check for updates</source>
         <translation>Check for updates</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/AboutView.qml" line="58" />
+        <location filename="../app/AppLayouts/Profile/views/AboutView.qml" line="56" />
+        <location filename="../app/AppLayouts/Profile/views/AboutView.qml" line="56" />
         <source>Current Version</source>
         <translation>Current Version</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/AboutView.qml" line="67" />
+        <location filename="../app/AppLayouts/Profile/views/AboutView.qml" line="65" />
+        <location filename="../app/AppLayouts/Profile/views/AboutView.qml" line="65" />
         <source>Release Notes</source>
         <translation>Release Notes</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/AboutView.qml" line="72" />
+        <location filename="../app/AppLayouts/Profile/views/AboutView.qml" line="70" />
+        <location filename="../app/AppLayouts/Profile/views/AboutView.qml" line="70" />
         <source>Our Principles</source>
         <translation>Our Principles</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/AboutView.qml" line="88" />
+        <location filename="../app/AppLayouts/Profile/views/AboutView.qml" line="86" />
+        <location filename="../app/AppLayouts/Profile/views/AboutView.qml" line="86" />
         <source>Status desktop&#8217;s GitHub Repositories</source>
         <translation>Status desktop&#8217;s GitHub Repositories</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/AboutView.qml" line="99" />
+        <location filename="../app/AppLayouts/Profile/views/AboutView.qml" line="97" />
+        <location filename="../app/AppLayouts/Profile/views/AboutView.qml" line="97" />
         <source>Status Desktop</source>
         <translation>Status Desktop</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/AboutView.qml" line="110" />
+        <location filename="../app/AppLayouts/Profile/views/AboutView.qml" line="108" />
+        <location filename="../app/AppLayouts/Profile/views/AboutView.qml" line="108" />
         <source>Status Go</source>
         <translation>Status Go</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/AboutView.qml" line="121" />
+        <location filename="../app/AppLayouts/Profile/views/AboutView.qml" line="119" />
+        <location filename="../app/AppLayouts/Profile/views/AboutView.qml" line="119" />
         <source>StatusQ</source>
         <translation>StatusQ</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/AboutView.qml" line="132" />
+        <location filename="../app/AppLayouts/Profile/views/AboutView.qml" line="130" />
+        <location filename="../app/AppLayouts/Profile/views/AboutView.qml" line="130" />
         <source>go-waku</source>
         <translation>go-waku</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/AboutView.qml" line="146" />
+        <location filename="../app/AppLayouts/Profile/views/AboutView.qml" line="144" />
+        <location filename="../app/AppLayouts/Profile/views/AboutView.qml" line="144" />
         <source>Legal &amp; Privacy Documents</source>
         <translation>Legal &amp; Privacy Documents</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/AboutView.qml" line="155" />
+        <location filename="../app/AppLayouts/Profile/views/AboutView.qml" line="153" />
+        <location filename="../app/AppLayouts/Profile/views/AboutView.qml" line="153" />
         <source>Terms of Use</source>
         <translation>Terms of Use</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/AboutView.qml" line="163" />
+        <location filename="../app/AppLayouts/Profile/views/AboutView.qml" line="164" />
+        <location filename="../app/AppLayouts/Profile/views/AboutView.qml" line="164" />
         <source>Privacy Policy</source>
         <translation>Privacy Policy</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/AboutView.qml" line="174" />
+        <location filename="../app/AppLayouts/Profile/views/AboutView.qml" line="175" />
+        <location filename="../app/AppLayouts/Profile/views/AboutView.qml" line="175" />
         <source>Software License</source>
         <translation>Software License</translation>
     </message>
@@ -70,6 +83,7 @@
 <context>
     <name>AcceptRejectOptionsButtonsPanel</name>
     <message>
+        <location filename="../app/AppLayouts/Chat/panels/AcceptRejectOptionsButtonsPanel.qml" line="70" />
         <location filename="../app/AppLayouts/Chat/panels/AcceptRejectOptionsButtonsPanel.qml" line="70" />
         <source>Decline and block</source>
         <translation>Decline and block</translation>
@@ -79,15 +93,19 @@
     <name>AcceptTransactionView</name>
     <message>
         <location filename="../imports/shared/views/chat/AcceptTransactionView.qml" line="33" />
+        <location filename="../imports/shared/views/chat/AcceptTransactionView.qml" line="33" />
         <source>Accept and share address</source>
         <translation>Accept and share address</translation>
     </message>
     <message>
         <location filename="../imports/shared/views/chat/AcceptTransactionView.qml" line="34" />
+        <location filename="../imports/shared/views/chat/AcceptTransactionView.qml" line="34" />
         <source>Accept and send</source>
         <translation>Accept and send</translation>
     </message>
     <message>
+        <location filename="../imports/shared/views/chat/AcceptTransactionView.qml" line="66" />
+        <location filename="../imports/shared/views/chat/AcceptTransactionView.qml" line="108" />
         <location filename="../imports/shared/views/chat/AcceptTransactionView.qml" line="66" />
         <location filename="../imports/shared/views/chat/AcceptTransactionView.qml" line="108" />
         <source>Decline</source>
@@ -98,55 +116,66 @@
     <name>AccountView</name>
     <message>
         <location filename="../app/AppLayouts/Profile/views/wallet/AccountView.qml" line="102" />
+        <location filename="../app/AppLayouts/Profile/views/wallet/AccountView.qml" line="102" />
         <source>Type</source>
         <translation>Type</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/wallet/AccountView.qml" line="114" />
         <location filename="../app/AppLayouts/Profile/views/wallet/AccountView.qml" line="114" />
         <source>Watch-Only Account</source>
         <translation>Watch-Only Account</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/wallet/AccountView.qml" line="116" />
+        <location filename="../app/AppLayouts/Profile/views/wallet/AccountView.qml" line="116" />
         <source>Generated by your Status seed phrase profile</source>
         <translation>Generated by your Status seed phrase profile</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/wallet/AccountView.qml" line="118" />
         <location filename="../app/AppLayouts/Profile/views/wallet/AccountView.qml" line="118" />
         <source>Imported Account</source>
         <translation>Imported Account</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/wallet/AccountView.qml" line="143" />
+        <location filename="../app/AppLayouts/Profile/views/wallet/AccountView.qml" line="143" />
         <source>Storage</source>
         <translation>Storage</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/wallet/AccountView.qml" line="152" />
         <location filename="../app/AppLayouts/Profile/views/wallet/AccountView.qml" line="152" />
         <source>On Device</source>
         <translation>On Device</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/wallet/AccountView.qml" line="179" />
+        <location filename="../app/AppLayouts/Profile/views/wallet/AccountView.qml" line="179" />
         <source>Derivation Path</source>
         <translation>Derivation Path</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/wallet/AccountView.qml" line="202" />
         <location filename="../app/AppLayouts/Profile/views/wallet/AccountView.qml" line="202" />
         <source>Remove from your profile</source>
         <translation>Remove from your profile</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/wallet/AccountView.qml" line="207" />
+        <location filename="../app/AppLayouts/Profile/views/wallet/AccountView.qml" line="207" />
         <source>Confirm %1 Removal</source>
         <translation>Confirm %1 Removal</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/wallet/AccountView.qml" line="208" />
+        <location filename="../app/AppLayouts/Profile/views/wallet/AccountView.qml" line="208" />
         <source>You will not be able to restore viewing access to this account in the future unless you enter this account&#8217;s address again.</source>
         <translation>You will not be able to restore viewing access to this account in the future unless you enter this account&#8217;s address again.</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/wallet/AccountView.qml" line="209" />
         <location filename="../app/AppLayouts/Profile/views/wallet/AccountView.qml" line="209" />
         <source>Remove Account</source>
         <translation>Remove Account</translation>
@@ -155,37 +184,44 @@
 <context>
     <name>Acknowledgements</name>
     <message>
-        <location filename="../app/AppLayouts/Profile/popups/backupseed/Acknowledgements.qml" line="26" />
+        <location filename="../app/AppLayouts/Profile/popups/backupseed/Acknowledgements.qml" line="43" />
+        <location filename="../app/AppLayouts/Profile/popups/backupseed/Acknowledgements.qml" line="43" />
         <source>Secure Your Assets and Funds</source>
         <translation>Secure Your Assets and Funds</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/popups/backupseed/Acknowledgements.qml" line="44" />
+        <location filename="../app/AppLayouts/Profile/popups/backupseed/Acknowledgements.qml" line="61" />
+        <location filename="../app/AppLayouts/Profile/popups/backupseed/Acknowledgements.qml" line="61" />
         <source>Your seed phrase is a 12-word passcode to your funds.</source>
         <translation>Your seed phrase is a 12-word passcode to your funds.</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/popups/backupseed/Acknowledgements.qml" line="59" />
+        <location filename="../app/AppLayouts/Profile/popups/backupseed/Acknowledgements.qml" line="72" />
+        <location filename="../app/AppLayouts/Profile/popups/backupseed/Acknowledgements.qml" line="72" />
         <source>Your seed phrase cannot be recovered if lost. Therefore, you &lt;b&gt;must&lt;/b&gt; back it up. The simplest way is to &lt;b&gt;write it down offline and store it somewhere secure.&lt;/b&gt;</source>
         <translation>Your seed phrase cannot be recovered if lost. Therefore, you &lt;b&gt;must&lt;/b&gt; back it up. The simplest way is to &lt;b&gt;write it down offline and store it somewhere secure.&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/popups/backupseed/Acknowledgements.qml" line="70" />
+        <location filename="../app/AppLayouts/Profile/popups/backupseed/Acknowledgements.qml" line="87" />
+        <location filename="../app/AppLayouts/Profile/popups/backupseed/Acknowledgements.qml" line="87" />
         <source>I have a pen and paper</source>
         <translation>I have a pen and paper</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/popups/backupseed/Acknowledgements.qml" line="75" />
+        <location filename="../app/AppLayouts/Profile/popups/backupseed/Acknowledgements.qml" line="95" />
+        <location filename="../app/AppLayouts/Profile/popups/backupseed/Acknowledgements.qml" line="95" />
         <source>I am ready to write down my seed phrase</source>
         <translation>I am ready to write down my seed phrase</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/popups/backupseed/Acknowledgements.qml" line="80" />
+        <location filename="../app/AppLayouts/Profile/popups/backupseed/Acknowledgements.qml" line="103" />
+        <location filename="../app/AppLayouts/Profile/popups/backupseed/Acknowledgements.qml" line="103" />
         <source>I know where I&#8217;ll store it</source>
         <translation>I know where I&#8217;ll store it</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/popups/backupseed/Acknowledgements.qml" line="97" />
+        <location filename="../app/AppLayouts/Profile/popups/backupseed/Acknowledgements.qml" line="125" />
+        <location filename="../app/AppLayouts/Profile/popups/backupseed/Acknowledgements.qml" line="125" />
         <source>You can only complete this process once. Status will not store your seed phrase and can never help you recover it.</source>
         <translation>You can only complete this process once. Status will not store your seed phrase and can never help you recover it.</translation>
     </message>
@@ -193,12 +229,14 @@
 <context>
     <name>ActivityCenterMessageComponentView</name>
     <message>
-        <location filename="../app/AppLayouts/Chat/views/ActivityCenterMessageComponentView.qml" line="66" />
+        <location filename="../app/AppLayouts/Chat/views/ActivityCenterMessageComponentView.qml" line="69" />
+        <location filename="../app/AppLayouts/Chat/views/ActivityCenterMessageComponentView.qml" line="69" />
         <source>Mark as Read</source>
         <translation>Mark as Read</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/views/ActivityCenterMessageComponentView.qml" line="67" />
+        <location filename="../app/AppLayouts/Chat/views/ActivityCenterMessageComponentView.qml" line="70" />
+        <location filename="../app/AppLayouts/Chat/views/ActivityCenterMessageComponentView.qml" line="70" />
         <source>Mark as Unread</source>
         <translation>Mark as Unread</translation>
     </message>
@@ -206,7 +244,8 @@
 <context>
     <name>ActivityCenterPopup</name>
     <message>
-        <location filename="../app/AppLayouts/Chat/popups/ActivityCenterPopup.qml" line="244" />
+        <location filename="../app/AppLayouts/Chat/popups/ActivityCenterPopup.qml" line="250" />
+        <location filename="../app/AppLayouts/Chat/popups/ActivityCenterPopup.qml" line="250" />
         <source>Show more</source>
         <translation>Show more</translation>
     </message>
@@ -214,37 +253,44 @@
 <context>
     <name>ActivityCenterPopupTopBarPanel</name>
     <message>
-        <location filename="../app/AppLayouts/Chat/panels/ActivityCenterPopupTopBarPanel.qml" line="40" />
+        <location filename="../app/AppLayouts/Chat/panels/ActivityCenterPopupTopBarPanel.qml" line="42" />
+        <location filename="../app/AppLayouts/Chat/panels/ActivityCenterPopupTopBarPanel.qml" line="42" />
         <source>All</source>
         <translation>All</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/panels/ActivityCenterPopupTopBarPanel.qml" line="48" />
+        <location filename="../app/AppLayouts/Chat/panels/ActivityCenterPopupTopBarPanel.qml" line="50" />
+        <location filename="../app/AppLayouts/Chat/panels/ActivityCenterPopupTopBarPanel.qml" line="50" />
         <source>Mentions</source>
         <translation>Mentions</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/panels/ActivityCenterPopupTopBarPanel.qml" line="59" />
+        <location filename="../app/AppLayouts/Chat/panels/ActivityCenterPopupTopBarPanel.qml" line="61" />
+        <location filename="../app/AppLayouts/Chat/panels/ActivityCenterPopupTopBarPanel.qml" line="61" />
         <source>Replies</source>
         <translation>Replies</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/panels/ActivityCenterPopupTopBarPanel.qml" line="96" />
+        <location filename="../app/AppLayouts/Chat/panels/ActivityCenterPopupTopBarPanel.qml" line="98" />
+        <location filename="../app/AppLayouts/Chat/panels/ActivityCenterPopupTopBarPanel.qml" line="98" />
         <source>Mark all as Read</source>
         <translation>Mark all as Read</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/panels/ActivityCenterPopupTopBarPanel.qml" line="117" />
+        <location filename="../app/AppLayouts/Chat/panels/ActivityCenterPopupTopBarPanel.qml" line="119" />
+        <location filename="../app/AppLayouts/Chat/panels/ActivityCenterPopupTopBarPanel.qml" line="119" />
         <source>Show read notifications</source>
         <translation>Show read notifications</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/panels/ActivityCenterPopupTopBarPanel.qml" line="118" />
+        <location filename="../app/AppLayouts/Chat/panels/ActivityCenterPopupTopBarPanel.qml" line="120" />
+        <location filename="../app/AppLayouts/Chat/panels/ActivityCenterPopupTopBarPanel.qml" line="120" />
         <source>Hide read notifications</source>
         <translation>Hide read notifications</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/panels/ActivityCenterPopupTopBarPanel.qml" line="124" />
+        <location filename="../app/AppLayouts/Chat/panels/ActivityCenterPopupTopBarPanel.qml" line="126" />
+        <location filename="../app/AppLayouts/Chat/panels/ActivityCenterPopupTopBarPanel.qml" line="126" />
         <source>Notification settings</source>
         <translation>Notification settings</translation>
     </message>
@@ -253,67 +299,81 @@
     <name>AddAccountModal</name>
     <message>
         <location filename="../app/AppLayouts/Wallet/popups/AddAccountModal.qml" line="34" />
+        <location filename="../app/AppLayouts/Wallet/popups/AddAccountModal.qml" line="34" />
         <source>Generate an account</source>
         <translation>Generate an account</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Wallet/popups/AddAccountModal.qml" line="59" />
         <location filename="../app/AppLayouts/Wallet/popups/AddAccountModal.qml" line="65" />
+        <location filename="../app/AppLayouts/Wallet/popups/AddAccountModal.qml" line="59" />
+        <location filename="../app/AppLayouts/Wallet/popups/AddAccountModal.qml" line="65" />
         <source>Wrong password</source>
         <translation>Wrong password</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/popups/AddAccountModal.qml" line="88" />
+        <location filename="../app/AppLayouts/Wallet/popups/AddAccountModal.qml" line="125" />
+        <location filename="../app/AppLayouts/Wallet/popups/AddAccountModal.qml" line="125" />
         <source>You need to enter a password</source>
         <translation>You need to enter a password</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/popups/AddAccountModal.qml" line="90" />
+        <location filename="../app/AppLayouts/Wallet/popups/AddAccountModal.qml" line="127" />
+        <location filename="../app/AppLayouts/Wallet/popups/AddAccountModal.qml" line="127" />
         <source>Password needs to be 6 characters or more</source>
         <translation>Password needs to be 6 characters or more</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/popups/AddAccountModal.qml" line="143" />
+        <location filename="../app/AppLayouts/Wallet/popups/AddAccountModal.qml" line="180" />
+        <location filename="../app/AppLayouts/Wallet/popups/AddAccountModal.qml" line="180" />
         <source>Enter your password&#8230;</source>
         <translation>Enter your password&#8230;</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/popups/AddAccountModal.qml" line="144" />
+        <location filename="../app/AppLayouts/Wallet/popups/AddAccountModal.qml" line="181" />
+        <location filename="../app/AppLayouts/Wallet/popups/AddAccountModal.qml" line="181" />
         <source>Password</source>
         <translation>Password</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/popups/AddAccountModal.qml" line="158" />
+        <location filename="../app/AppLayouts/Wallet/popups/AddAccountModal.qml" line="201" />
+        <location filename="../app/AppLayouts/Wallet/popups/AddAccountModal.qml" line="201" />
         <source>Enter an account name...</source>
         <translation>Enter an account name...</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/popups/AddAccountModal.qml" line="159" />
+        <location filename="../app/AppLayouts/Wallet/popups/AddAccountModal.qml" line="202" />
+        <location filename="../app/AppLayouts/Wallet/popups/AddAccountModal.qml" line="202" />
         <source>Account name</source>
         <translation>Account name</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/popups/AddAccountModal.qml" line="171" />
+        <location filename="../app/AppLayouts/Wallet/popups/AddAccountModal.qml" line="214" />
+        <location filename="../app/AppLayouts/Wallet/popups/AddAccountModal.qml" line="214" />
         <source>You need to enter an account name</source>
         <translation>You need to enter an account name</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/popups/AddAccountModal.qml" line="180" />
+        <location filename="../app/AppLayouts/Wallet/popups/AddAccountModal.qml" line="231" />
+        <location filename="../app/AppLayouts/Wallet/popups/AddAccountModal.qml" line="231" />
         <source>color</source>
         <translation>color</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/popups/AddAccountModal.qml" line="203" />
+        <location filename="../app/AppLayouts/Wallet/popups/AddAccountModal.qml" line="254" />
+        <location filename="../app/AppLayouts/Wallet/popups/AddAccountModal.qml" line="254" />
         <source>Advanced</source>
         <translation>Advanced</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/popups/AddAccountModal.qml" line="226" />
+        <location filename="../app/AppLayouts/Wallet/popups/AddAccountModal.qml" line="276" />
+        <location filename="../app/AppLayouts/Wallet/popups/AddAccountModal.qml" line="276" />
         <source>Loading...</source>
         <translation>Loading...</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/popups/AddAccountModal.qml" line="227" />
+        <location filename="../app/AppLayouts/Wallet/popups/AddAccountModal.qml" line="277" />
+        <location filename="../app/AppLayouts/Wallet/popups/AddAccountModal.qml" line="277" />
         <source>Add account</source>
         <translation>Add account</translation>
     </message>
@@ -322,55 +382,66 @@
     <name>AddEditSavedAddressPopup</name>
     <message>
         <location filename="../app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml" line="38" />
+        <location filename="../app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml" line="38" />
         <source>Edit saved address</source>
         <translation>Edit saved address</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml" line="38" />
         <location filename="../app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml" line="38" />
         <source>Add saved address</source>
         <translation>Add saved address</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml" line="62" />
+        <location filename="../app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml" line="62" />
         <source>Enter a name</source>
         <translation>Enter a name</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml" line="63" />
         <location filename="../app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml" line="63" />
         <source>Name</source>
         <translation>Name</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml" line="67" />
+        <location filename="../app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml" line="67" />
         <source>Name must not be blank</source>
         <translation>Name must not be blank</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml" line="71" />
         <location filename="../app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml" line="71" />
         <source>This is not a valid account name</source>
         <translation>This is not a valid account name</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml" line="90" />
+        <location filename="../app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml" line="90" />
         <source>Address</source>
         <translation>Address</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml" line="91" />
         <location filename="../app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml" line="91" />
         <source>Enter ENS Name or Ethereum Address</source>
         <translation>Enter ENS Name or Ethereum Address</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml" line="101" />
+        <location filename="../app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml" line="101" />
         <source>Please enter a valid ENS name OR Ethereum Address</source>
         <translation>Please enter a valid ENS name OR Ethereum Address</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml" line="108" />
+        <location filename="../app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml" line="108" />
         <source>Save</source>
         <translation>Save</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml" line="108" />
         <location filename="../app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml" line="108" />
         <source>Add address</source>
         <translation>Add address</translation>
@@ -380,75 +451,90 @@
     <name>AddFavoriteModal</name>
     <message>
         <location filename="../app/AppLayouts/Browser/popups/AddFavoriteModal.qml" line="70" />
+        <location filename="../app/AppLayouts/Browser/popups/AddFavoriteModal.qml" line="70" />
         <source>Favorite added</source>
         <translation>Favorite added</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Browser/popups/AddFavoriteModal.qml" line="71" />
         <location filename="../app/AppLayouts/Browser/popups/AddFavoriteModal.qml" line="71" />
         <source>Edit</source>
         <translation>Edit</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Browser/popups/AddFavoriteModal.qml" line="72" />
+        <location filename="../app/AppLayouts/Browser/popups/AddFavoriteModal.qml" line="72" />
         <source>Add favorite</source>
         <translation>Add favorite</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Browser/popups/AddFavoriteModal.qml" line="84" />
         <location filename="../app/AppLayouts/Browser/popups/AddFavoriteModal.qml" line="84" />
         <source>URL</source>
         <translation>URL</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Browser/popups/AddFavoriteModal.qml" line="86" />
+        <location filename="../app/AppLayouts/Browser/popups/AddFavoriteModal.qml" line="86" />
         <source>Paste URL</source>
         <translation>Paste URL</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Browser/popups/AddFavoriteModal.qml" line="92" />
         <location filename="../app/AppLayouts/Browser/popups/AddFavoriteModal.qml" line="92" />
         <source>Paste</source>
         <translation>Paste</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Browser/popups/AddFavoriteModal.qml" line="94" />
+        <location filename="../app/AppLayouts/Browser/popups/AddFavoriteModal.qml" line="94" />
         <source>Pasted</source>
         <translation>Pasted</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Browser/popups/AddFavoriteModal.qml" line="100" />
         <location filename="../app/AppLayouts/Browser/popups/AddFavoriteModal.qml" line="100" />
         <source>Please enter a valid URL</source>
         <translation>Please enter a valid URL</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Browser/popups/AddFavoriteModal.qml" line="111" />
+        <location filename="../app/AppLayouts/Browser/popups/AddFavoriteModal.qml" line="111" />
         <source>Name</source>
         <translation>Name</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Browser/popups/AddFavoriteModal.qml" line="113" />
         <location filename="../app/AppLayouts/Browser/popups/AddFavoriteModal.qml" line="113" />
         <source>Name of the website</source>
         <translation>Name of the website</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Browser/popups/AddFavoriteModal.qml" line="116" />
+        <location filename="../app/AppLayouts/Browser/popups/AddFavoriteModal.qml" line="116" />
         <source>Please enter a name</source>
         <translation>Please enter a name</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Browser/popups/AddFavoriteModal.qml" line="132" />
         <location filename="../app/AppLayouts/Browser/popups/AddFavoriteModal.qml" line="132" />
         <source>Remove</source>
         <translation>Remove</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Browser/popups/AddFavoriteModal.qml" line="146" />
+        <location filename="../app/AppLayouts/Browser/popups/AddFavoriteModal.qml" line="146" />
         <source>Done</source>
         <translation>Done</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Browser/popups/AddFavoriteModal.qml" line="147" />
+        <location filename="../app/AppLayouts/Browser/popups/AddFavoriteModal.qml" line="147" />
         <source>Add</source>
         <translation>Add</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Browser/popups/AddFavoriteModal.qml" line="155" />
         <location filename="../app/AppLayouts/Browser/popups/AddFavoriteModal.qml" line="155" />
         <source>Add Favorite</source>
         <translation>Add Favorite</translation>
@@ -458,60 +544,72 @@
     <name>AddShowTokenModal</name>
     <message>
         <location filename="../app/AppLayouts/Profile/popups/AddShowTokenModal.qml" line="22" />
+        <location filename="../app/AppLayouts/Profile/popups/AddShowTokenModal.qml" line="22" />
         <source>Add custom token</source>
         <translation>Add custom token</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/popups/AddShowTokenModal.qml" line="55" />
         <location filename="../app/AppLayouts/Profile/popups/AddShowTokenModal.qml" line="55" />
         <source>This needs to be a valid address</source>
         <translation>This needs to be a valid address</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/popups/AddShowTokenModal.qml" line="81" />
+        <location filename="../app/AppLayouts/Profile/popups/AddShowTokenModal.qml" line="81" />
         <source>Invalid ERC20 address</source>
         <translation>Invalid ERC20 address</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/popups/AddShowTokenModal.qml" line="102" />
         <location filename="../app/AppLayouts/Profile/popups/AddShowTokenModal.qml" line="102" />
         <source>Enter contract address...</source>
         <translation>Enter contract address...</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/popups/AddShowTokenModal.qml" line="103" />
+        <location filename="../app/AppLayouts/Profile/popups/AddShowTokenModal.qml" line="103" />
         <source>Contract address</source>
         <translation>Contract address</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/popups/AddShowTokenModal.qml" line="113" />
         <location filename="../app/AppLayouts/Profile/popups/AddShowTokenModal.qml" line="113" />
         <source>The name of your token...</source>
         <translation>The name of your token...</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/popups/AddShowTokenModal.qml" line="114" />
+        <location filename="../app/AppLayouts/Profile/popups/AddShowTokenModal.qml" line="114" />
         <source>Name</source>
         <translation>Name</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/popups/AddShowTokenModal.qml" line="120" />
         <location filename="../app/AppLayouts/Profile/popups/AddShowTokenModal.qml" line="120" />
         <source>ABC</source>
         <translation>ABC</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/popups/AddShowTokenModal.qml" line="121" />
+        <location filename="../app/AppLayouts/Profile/popups/AddShowTokenModal.qml" line="121" />
         <source>Symbol</source>
         <translation>Symbol</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/popups/AddShowTokenModal.qml" line="133" />
         <location filename="../app/AppLayouts/Profile/popups/AddShowTokenModal.qml" line="133" />
         <source>Decimals</source>
         <translation>Decimals</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/popups/AddShowTokenModal.qml" line="145" />
+        <location filename="../app/AppLayouts/Profile/popups/AddShowTokenModal.qml" line="145" />
         <source>Changing settings failed</source>
         <translation>Changing settings failed</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/popups/AddShowTokenModal.qml" line="152" />
         <location filename="../app/AppLayouts/Profile/popups/AddShowTokenModal.qml" line="152" />
         <source>Add</source>
         <translation>Add</translation>
@@ -521,40 +619,48 @@
     <name>AddWakuNodeModal</name>
     <message>
         <location filename="../app/AppLayouts/Profile/popups/AddWakuNodeModal.qml" line="19" />
+        <location filename="../app/AppLayouts/Profile/popups/AddWakuNodeModal.qml" line="19" />
         <source>Waku nodes</source>
         <translation>Waku nodes</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/popups/AddWakuNodeModal.qml" line="38" />
         <location filename="../app/AppLayouts/Profile/popups/AddWakuNodeModal.qml" line="38" />
         <source>Name</source>
         <translation>Name</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/popups/AddWakuNodeModal.qml" line="39" />
+        <location filename="../app/AppLayouts/Profile/popups/AddWakuNodeModal.qml" line="39" />
         <source>Specify a name</source>
         <translation>Specify a name</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/popups/AddWakuNodeModal.qml" line="42" />
         <location filename="../app/AppLayouts/Profile/popups/AddWakuNodeModal.qml" line="42" />
         <source>You need to enter a name</source>
         <translation>You need to enter a name</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/popups/AddWakuNodeModal.qml" line="49" />
+        <location filename="../app/AppLayouts/Profile/popups/AddWakuNodeModal.qml" line="49" />
         <source>History node address</source>
         <translation>History node address</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/popups/AddWakuNodeModal.qml" line="53" />
         <location filename="../app/AppLayouts/Profile/popups/AddWakuNodeModal.qml" line="53" />
         <source>You need to enter the enode address</source>
         <translation>You need to enter the enode address</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/popups/AddWakuNodeModal.qml" line="56" />
+        <location filename="../app/AppLayouts/Profile/popups/AddWakuNodeModal.qml" line="56" />
         <source>The format must be: enode://{enode-id}:{password}@{ip-address}:{port}</source>
         <translation>The format must be: enode://{enode-id}:{password}@{ip-address}:{port}</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/popups/AddWakuNodeModal.qml" line="67" />
         <location filename="../app/AppLayouts/Profile/popups/AddWakuNodeModal.qml" line="67" />
         <source>Save</source>
         <translation>Save</translation>
@@ -592,22 +698,26 @@ Assets won&#8217;t be sent yet.</translation>
 <context>
     <name>AdvancedAddAccountView</name>
     <message>
-        <location filename="../app/AppLayouts/Wallet/views/AdvancedAddAccountView.qml" line="131" />
+        <location filename="../app/AppLayouts/Wallet/views/AdvancedAddAccountView.qml" line="129" />
+        <location filename="../app/AppLayouts/Wallet/views/AdvancedAddAccountView.qml" line="129" />
         <source>Enter address...</source>
         <translation>Enter address...</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/views/AdvancedAddAccountView.qml" line="132" />
+        <location filename="../app/AppLayouts/Wallet/views/AdvancedAddAccountView.qml" line="130" />
+        <location filename="../app/AppLayouts/Wallet/views/AdvancedAddAccountView.qml" line="130" />
         <source>Account address</source>
         <translation>Account address</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/views/AdvancedAddAccountView.qml" line="135" />
+        <location filename="../app/AppLayouts/Wallet/views/AdvancedAddAccountView.qml" line="133" />
+        <location filename="../app/AppLayouts/Wallet/views/AdvancedAddAccountView.qml" line="133" />
         <source>This needs to be a valid address (starting with 0x)</source>
         <translation>This needs to be a valid address (starting with 0x)</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/views/AdvancedAddAccountView.qml" line="138" />
+        <location filename="../app/AppLayouts/Wallet/views/AdvancedAddAccountView.qml" line="136" />
+        <location filename="../app/AppLayouts/Wallet/views/AdvancedAddAccountView.qml" line="136" />
         <source>You need to enter an address</source>
         <translation>You need to enter an address</translation>
     </message>
@@ -616,154 +726,193 @@ Assets won&#8217;t be sent yet.</translation>
     <name>AdvancedView</name>
     <message>
         <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="37" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="37" />
         <source>Fleet</source>
         <translation>Fleet</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="46" />
         <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="46" />
         <source>Minimize on close</source>
         <translation>Minimize on close</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="60" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="60" />
         <source>Application Logs</source>
         <translation>Application Logs</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="92" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="92" />
         <source>Experimental features</source>
         <translation>Experimental features</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="101" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="102" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="102" />
         <source>Wallet</source>
         <translation>Wallet</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="118" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="103" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="103" />
+        <source>WalletSettingsLineButton</source>
+        <translation>WalletSettingsLineButton</translation>
+    </message>
+    <message>
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="120" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="120" />
         <source>Dapp Browser</source>
         <translation>Dapp Browser</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="134" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="136" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="136" />
         <source>Community History Archive Protocol</source>
         <translation>Community History Archive Protocol</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="151" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="153" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="153" />
         <source>Node Management</source>
         <translation>Node Management</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="168" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="170" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="170" />
         <source>Keycard</source>
         <translation>Keycard</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="182" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="184" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="184" />
         <source>Bloom filter level</source>
         <translation>Bloom filter level</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="201" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="203" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="203" />
         <source>Warning!</source>
         <translation>Warning!</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="202" />
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="288" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="204" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="290" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="204" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="290" />
         <source>The account will be logged out. When you login again, the selected mode will be enabled</source>
         <translation>The account will be logged out. When you login again, the selected mode will be enabled</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="225" />
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="311" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="227" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="313" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="227" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="313" />
         <source>Light Node</source>
         <translation>Light Node</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="239" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="241" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="241" />
         <source>Normal</source>
         <translation>Normal</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="253" />
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="325" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="255" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="327" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="255" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="327" />
         <source>Full Node</source>
         <translation>Full Node</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="270" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="272" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="272" />
         <source>WakuV2 mode</source>
         <translation>WakuV2 mode</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="341" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="343" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="343" />
         <source>Developer features</source>
         <translation>Developer features</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="353" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="355" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="355" />
         <source>Full developer mode</source>
         <translation>Full developer mode</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="373" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="375" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="375" />
         <source>Download messages</source>
         <translation>Download messages</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="385" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="387" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="387" />
         <source>Telemetry</source>
         <translation>Telemetry</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="397" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="399" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="399" />
         <source>Debug</source>
         <translation>Debug</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="409" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="411" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="411" />
         <source>Auto message</source>
         <translation>Auto message</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="430" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="432" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="432" />
         <source>Are you sure you want to enable all the develoer features? The app will be restarted.</source>
         <translation>Are you sure you want to enable all the develoer features? The app will be restarted.</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="449" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="451" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="451" />
         <source>Are you sure you want to enable telemetry? This will reduce your privacy level while using Status. You need to restart the app for this change to take effect.</source>
         <translation>Are you sure you want to enable telemetry? This will reduce your privacy level while using Status. You need to restart the app for this change to take effect.</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="467" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="469" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="469" />
         <source>Are you sure you want to enable auto message? You need to restart the app for this change to take effect.</source>
         <translation>Are you sure you want to enable auto message? You need to restart the app for this change to take effect.</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="485" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="487" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="487" />
         <source>Are you sure you want to %1 debug mode? You need to restart the app for this change to take effect.</source>
         <translation>Are you sure you want to %1 debug mode? You need to restart the app for this change to take effect.</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="486" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="488" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="488" />
         <source>disable</source>
         <translation>disable</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="487" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="489" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="489" />
         <source>enable</source>
         <translation>enable</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="502" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="504" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="504" />
         <source>This feature is experimental and is meant for testing purposes by core contributors and the community. It's not meant for real use and makes no claims of security or integrity of funds or data. Use at your own risk.</source>
         <translation>This feature is experimental and is meant for testing purposes by core contributors and the community. It's not meant for real use and makes no claims of security or integrity of funds or data. Use at your own risk.</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="503" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="505" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="505" />
         <source>I understand</source>
         <translation>I understand</translation>
     </message>
@@ -772,10 +921,12 @@ Assets won&#8217;t be sent yet.</translation>
     <name>AllowNotificationsView</name>
     <message>
         <location filename="../app/AppLayouts/Onboarding/views/AllowNotificationsView.qml" line="38" />
+        <location filename="../app/AppLayouts/Onboarding/views/AllowNotificationsView.qml" line="38" />
         <source>Allow notifications</source>
         <translation>Allow notifications</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Onboarding/views/AllowNotificationsView.qml" line="49" />
         <location filename="../app/AppLayouts/Onboarding/views/AllowNotificationsView.qml" line="49" />
         <source>Status will notify you about new messages. You can
 edit your notification preferences later in settings.</source>
@@ -784,6 +935,7 @@ edit your notification preferences later in settings.</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Onboarding/views/AllowNotificationsView.qml" line="62" />
+        <location filename="../app/AppLayouts/Onboarding/views/AllowNotificationsView.qml" line="62" />
         <source>Ok, got it</source>
         <translation>Ok, got it</translation>
     </message>
@@ -791,72 +943,78 @@ edit your notification preferences later in settings.</translation>
 <context>
     <name>AppMain</name>
     <message>
-        <location filename="../app/mainui/AppMain.qml" line="200" />
+        <location filename="../app/mainui/AppMain.qml" line="171" />
+        <location filename="../app/mainui/AppMain.qml" line="171" />
         <source>Profile Picture</source>
         <translation>Profile Picture</translation>
     </message>
     <message>
-        <location filename="../app/mainui/AppMain.qml" line="201" />
+        <location filename="../app/mainui/AppMain.qml" line="172" />
+        <location filename="../app/mainui/AppMain.qml" line="172" />
         <source>Make this my Profile Pic</source>
         <translation>Make this my Profile Pic</translation>
     </message>
     <message>
-        <location filename="../app/mainui/AppMain.qml" line="328" />
+        <location filename="../app/mainui/AppMain.qml" line="310" />
+        <location filename="../app/mainui/AppMain.qml" line="310" />
         <source>Invite People</source>
         <translation>Invite People</translation>
     </message>
     <message>
-        <location filename="../app/mainui/AppMain.qml" line="339" />
+        <location filename="../app/mainui/AppMain.qml" line="321" />
+        <location filename="../app/mainui/AppMain.qml" line="321" />
         <source>View Community</source>
         <translation>View Community</translation>
     </message>
     <message>
-        <location filename="../app/mainui/AppMain.qml" line="351" />
+        <location filename="../app/mainui/AppMain.qml" line="333" />
+        <location filename="../app/mainui/AppMain.qml" line="333" />
         <source>Leave Community</source>
         <translation>Leave Community</translation>
     </message>
     <message>
-        <location filename="../app/mainui/AppMain.qml" line="411" />
+        <location filename="../app/mainui/AppMain.qml" line="394" />
+        <location filename="../app/mainui/AppMain.qml" line="394" />
         <source>A new version of Status (%1) is available</source>
         <translation>A new version of Status (%1) is available</translation>
     </message>
     <message>
-        <location filename="../app/mainui/AppMain.qml" line="412" />
+        <location filename="../app/mainui/AppMain.qml" line="395" />
+        <location filename="../app/mainui/AppMain.qml" line="395" />
         <source>Download</source>
         <translation>Download</translation>
     </message>
     <message>
-        <location filename="../app/mainui/AppMain.qml" line="429" />
+        <location filename="../app/mainui/AppMain.qml" line="415" />
+        <location filename="../app/mainui/AppMain.qml" line="415" />
         <source>Your version is up to date</source>
         <translation>Your version is up to date</translation>
     </message>
     <message>
-        <location filename="../app/mainui/AppMain.qml" line="430" />
+        <location filename="../app/mainui/AppMain.qml" line="416" />
+        <location filename="../app/mainui/AppMain.qml" line="416" />
         <source>Close</source>
         <translation>Close</translation>
     </message>
     <message>
-        <location filename="../app/mainui/AppMain.qml" line="695" />
         <source>Can not connect to mailserver</source>
-        <translation>Can not connect to mailserver</translation>
+        <translation type="vanished">Can not connect to mailserver</translation>
     </message>
     <message>
-        <location filename="../app/mainui/AppMain.qml" line="706" />
         <source>The mailserver you're connecting to is unavailable.</source>
-        <translation>The mailserver you're connecting to is unavailable.</translation>
+        <translation type="vanished">The mailserver you're connecting to is unavailable.</translation>
     </message>
     <message>
-        <location filename="../app/mainui/AppMain.qml" line="714" />
         <source>Pick another</source>
-        <translation>Pick another</translation>
+        <translation type="vanished">Pick another</translation>
     </message>
     <message>
-        <location filename="../app/mainui/AppMain.qml" line="721" />
         <source>Retry</source>
-        <translation>Retry</translation>
+        <translation type="vanished">Retry</translation>
     </message>
     <message>
-        <location filename="../app/mainui/AppMain.qml" line="950" />
+        <location filename="../app/mainui/AppMain.qml" line="907" />
+        <location filename="../app/mainui/AppMain.qml" line="907" />
         <source>Where do you want to go?</source>
         <translation>Where do you want to go?</translation>
     </message>
@@ -865,10 +1023,12 @@ edit your notification preferences later in settings.</translation>
     <name>AppSearch</name>
     <message>
         <location filename="../app/mainui/AppSearch.qml" line="54" />
+        <location filename="../app/mainui/AppSearch.qml" line="54" />
         <source>No results</source>
         <translation>No results</translation>
     </message>
     <message>
+        <location filename="../app/mainui/AppSearch.qml" line="55" />
         <location filename="../app/mainui/AppSearch.qml" line="55" />
         <source>Anywhere</source>
         <translation>Anywhere</translation>
@@ -878,95 +1038,114 @@ edit your notification preferences later in settings.</translation>
     <name>AppearanceView</name>
     <message>
         <location filename="../app/AppLayouts/Profile/views/AppearanceView.qml" line="62" />
+        <location filename="../app/AppLayouts/Profile/views/AppearanceView.qml" line="62" />
         <source>Preview</source>
         <translation>Preview</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/AppearanceView.qml" line="91" />
         <location filename="../app/AppLayouts/Profile/views/AppearanceView.qml" line="91" />
         <source>Blockchains will drop search costs, causing a kind of decomposition that allows you to have markets of entities that are horizontally segregated and vertically segregated.</source>
         <translation>Blockchains will drop search costs, causing a kind of decomposition that allows you to have markets of entities that are horizontally segregated and vertically segregated.</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/AppearanceView.qml" line="99" />
+        <location filename="../app/AppLayouts/Profile/views/AppearanceView.qml" line="99" />
         <source>Size</source>
         <translation>Size</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/AppearanceView.qml" line="112" />
         <location filename="../app/AppLayouts/Profile/views/AppearanceView.qml" line="112" />
         <source>Change font size</source>
         <translation>Change font size</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/AppearanceView.qml" line="121" />
+        <location filename="../app/AppLayouts/Profile/views/AppearanceView.qml" line="121" />
         <source>XS</source>
         <translation>XS</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/AppearanceView.qml" line="121" />
         <location filename="../app/AppLayouts/Profile/views/AppearanceView.qml" line="121" />
         <source>S</source>
         <translation>S</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/AppearanceView.qml" line="121" />
+        <location filename="../app/AppLayouts/Profile/views/AppearanceView.qml" line="121" />
         <source>M</source>
         <translation>M</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/AppearanceView.qml" line="121" />
         <location filename="../app/AppLayouts/Profile/views/AppearanceView.qml" line="121" />
         <source>L</source>
         <translation>L</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/AppearanceView.qml" line="121" />
+        <location filename="../app/AppLayouts/Profile/views/AppearanceView.qml" line="121" />
         <source>XL</source>
         <translation>XL</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/AppearanceView.qml" line="121" />
         <location filename="../app/AppLayouts/Profile/views/AppearanceView.qml" line="121" />
         <source>XXL</source>
         <translation>XXL</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/AppearanceView.qml" line="137" />
+        <location filename="../app/AppLayouts/Profile/views/AppearanceView.qml" line="137" />
         <source>Change Zoom (requires restart)</source>
         <translation>Change Zoom (requires restart)</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/AppearanceView.qml" line="160" />
         <location filename="../app/AppLayouts/Profile/views/AppearanceView.qml" line="160" />
         <source>50%</source>
         <translation>50%</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/AppearanceView.qml" line="160" />
+        <location filename="../app/AppLayouts/Profile/views/AppearanceView.qml" line="160" />
         <source>100%</source>
         <translation>100%</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/AppearanceView.qml" line="160" />
         <location filename="../app/AppLayouts/Profile/views/AppearanceView.qml" line="160" />
         <source>150%</source>
         <translation>150%</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/AppearanceView.qml" line="160" />
+        <location filename="../app/AppLayouts/Profile/views/AppearanceView.qml" line="160" />
         <source>200%</source>
         <translation>200%</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/AppearanceView.qml" line="183" />
         <location filename="../app/AppLayouts/Profile/views/AppearanceView.qml" line="183" />
         <source>Appearance</source>
         <translation>Appearance</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/AppearanceView.qml" line="204" />
+        <location filename="../app/AppLayouts/Profile/views/AppearanceView.qml" line="204" />
         <source>Light</source>
         <translation>Light</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/AppearanceView.qml" line="219" />
+        <location filename="../app/AppLayouts/Profile/views/AppearanceView.qml" line="219" />
         <source>Dark</source>
         <translation>Dark</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/AppearanceView.qml" line="234" />
         <location filename="../app/AppLayouts/Profile/views/AppearanceView.qml" line="234" />
         <source>System</source>
         <translation>System</translation>
@@ -1021,10 +1200,12 @@ edit your notification preferences later in settings.</translation>
     <name>BackUpCommuntyBannerPanel</name>
     <message>
         <location filename="../app/AppLayouts/Chat/panels/communities/BackUpCommuntyBannerPanel.qml" line="67" />
+        <location filename="../app/AppLayouts/Chat/panels/communities/BackUpCommuntyBannerPanel.qml" line="67" />
         <source>Back up community key</source>
         <translation>Back up community key</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Chat/panels/communities/BackUpCommuntyBannerPanel.qml" line="82" />
         <location filename="../app/AppLayouts/Chat/panels/communities/BackUpCommuntyBannerPanel.qml" line="82" />
         <source>Back up</source>
         <translation>Back up</translation>
@@ -1033,38 +1214,78 @@ edit your notification preferences later in settings.</translation>
 <context>
     <name>BackupSeedModal</name>
     <message>
-        <location filename="../app/AppLayouts/Profile/popups/BackupSeedModal.qml" line="21" />
+        <location filename="../app/AppLayouts/Profile/popups/BackupSeedModal.qml" line="44" />
+        <location filename="../app/AppLayouts/Profile/popups/BackupSeedModal.qml" line="44" />
+        <source>Not Now</source>
+        <translation>Not Now</translation>
+    </message>
+    <message>
+        <location filename="../app/AppLayouts/Profile/popups/BackupSeedModal.qml" line="55" />
+        <location filename="../app/AppLayouts/Profile/popups/BackupSeedModal.qml" line="55" />
         <source>Back up your seed phrase</source>
         <translation>Back up your seed phrase</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/popups/BackupSeedModal.qml" line="56" />
-        <location filename="../app/AppLayouts/Profile/popups/BackupSeedModal.qml" line="64" />
+        <location filename="../app/AppLayouts/Profile/popups/BackupSeedModal.qml" line="77" />
+        <location filename="../app/AppLayouts/Profile/popups/BackupSeedModal.qml" line="77" />
         <source>Confirm Seed Phrase</source>
         <translation>Confirm Seed Phrase</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/popups/BackupSeedModal.qml" line="59" />
+        <location filename="../app/AppLayouts/Profile/popups/BackupSeedModal.qml" line="80" />
+        <location filename="../app/AppLayouts/Profile/popups/BackupSeedModal.qml" line="80" />
         <source>Continue</source>
         <translation>Continue</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/popups/BackupSeedModal.qml" line="61" />
+        <location filename="../app/AppLayouts/Profile/popups/BackupSeedModal.qml" line="89" />
+        <location filename="../app/AppLayouts/Profile/popups/BackupSeedModal.qml" line="89" />
         <source>Complete &amp; Delete My Seed Phrase</source>
         <translation>Complete &amp; Delete My Seed Phrase</translation>
+    </message>
+    <message>
+        <location filename="../app/AppLayouts/Profile/popups/BackupSeedModal.qml" line="115" />
+        <location filename="../app/AppLayouts/Profile/popups/BackupSeedModal.qml" line="121" />
+        <location filename="../app/AppLayouts/Profile/popups/BackupSeedModal.qml" line="115" />
+        <location filename="../app/AppLayouts/Profile/popups/BackupSeedModal.qml" line="121" />
+        <source>Confirm word #%1 of your seed phrase</source>
+        <translation>Confirm word #%1 of your seed phrase</translation>
     </message>
 </context>
 <context>
     <name>BackupSeedStepBase</name>
     <message>
-        <location filename="../app/AppLayouts/Profile/popups/backupseed/BackupSeedStepBase.qml" line="34" />
+        <location filename="../app/AppLayouts/Profile/popups/backupseed/BackupSeedStepBase.qml" line="47" />
+        <location filename="../app/AppLayouts/Profile/popups/backupseed/BackupSeedStepBase.qml" line="47" />
+        <source>Word #%1</source>
+        <translation>Word #%1</translation>
+    </message>
+    <message>
+        <location filename="../app/AppLayouts/Profile/popups/backupseed/BackupSeedStepBase.qml" line="48" />
+        <location filename="../app/AppLayouts/Profile/popups/backupseed/BackupSeedStepBase.qml" line="48" />
         <source>Enter word</source>
         <translation>Enter word</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/popups/backupseed/BackupSeedStepBase.qml" line="38" />
+        <location filename="../app/AppLayouts/Profile/popups/backupseed/BackupSeedStepBase.qml" line="52" />
+        <location filename="../app/AppLayouts/Profile/popups/backupseed/BackupSeedStepBase.qml" line="52" />
         <source>Wrong word</source>
         <translation>Wrong word</translation>
+    </message>
+</context>
+<context>
+    <name>BalanceExceeded</name>
+    <message>
+        <location filename="../imports/shared/controls/BalanceExceeded.qml" line="31" />
+        <location filename="../imports/shared/controls/BalanceExceeded.qml" line="31" />
+        <source>Balance exceeded</source>
+        <translation>Balance exceeded</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/controls/BalanceExceeded.qml" line="31" />
+        <location filename="../imports/shared/controls/BalanceExceeded.qml" line="31" />
+        <source>No networks available</source>
+        <translation type="unfinished">No networks available</translation>
     </message>
 </context>
 <context>
@@ -1084,34 +1305,56 @@ edit your notification preferences later in settings.</translation>
         <translation />
     </message>
     <message>
-        <location filename="../app/AppLayouts/Onboarding/popups/BeforeGetStartedModal.qml" line="16" />
         <source>Before you get started</source>
-        <translation>Before you get started</translation>
+        <translation type="vanished">Before you get started</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Onboarding/popups/BeforeGetStartedModal.qml" line="36" />
         <source>I acknowledge that status desktop is in beta and by using it I take the full responsibility for all risks concerning my data and funds</source>
-        <translation>I acknowledge that status desktop is in beta and by using it I take the full responsibility for all risks concerning my data and funds</translation>
+        <translation type="vanished">I acknowledge that status desktop is in beta and by using it I take the full responsibility for all risks concerning my data and funds</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Onboarding/popups/BeforeGetStartedModal.qml" line="48" />
+        <location filename="../app/AppLayouts/Onboarding/popups/BeforeGetStartedModal.qml" line="21" />
+        <location filename="../app/AppLayouts/Onboarding/popups/BeforeGetStartedModal.qml" line="21" />
+        <source>Before you get started...</source>
+        <translation>Before you get started...</translation>
+    </message>
+    <message>
+        <location filename="../app/AppLayouts/Onboarding/popups/BeforeGetStartedModal.qml" line="32" />
+        <location filename="../app/AppLayouts/Onboarding/popups/BeforeGetStartedModal.qml" line="32" />
+        <source>Get Started</source>
+        <translation>Get Started</translation>
+    </message>
+    <message>
+        <location filename="../app/AppLayouts/Onboarding/popups/BeforeGetStartedModal.qml" line="50" />
+        <location filename="../app/AppLayouts/Onboarding/popups/BeforeGetStartedModal.qml" line="50" />
+        <source>I acknowledge that Status Desktop is in Beta and by using it I take the full responsibility for all risks concerning my data and funds.</source>
+        <translation>I acknowledge that Status Desktop is in Beta and by using it I take the full responsibility for all risks concerning my data and funds.</translation>
+    </message>
+    <message>
+        <location filename="../app/AppLayouts/Onboarding/popups/BeforeGetStartedModal.qml" line="64" />
+        <location filename="../app/AppLayouts/Onboarding/popups/BeforeGetStartedModal.qml" line="64" />
         <source>I accept Status</source>
         <translation>I accept Status</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Onboarding/popups/BeforeGetStartedModal.qml" line="54" />
-        <source>Terms of service</source>
-        <translation>Terms of service</translation>
+        <location filename="../app/AppLayouts/Onboarding/popups/BeforeGetStartedModal.qml" line="70" />
+        <location filename="../app/AppLayouts/Onboarding/popups/BeforeGetStartedModal.qml" line="70" />
+        <source>Terms of Use</source>
+        <translation type="unfinished">Terms of Use</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Onboarding/popups/BeforeGetStartedModal.qml" line="80" />
+        <source>Terms of service</source>
+        <translation type="vanished">Terms of service</translation>
+    </message>
+    <message>
+        <location filename="../app/AppLayouts/Onboarding/popups/BeforeGetStartedModal.qml" line="98" />
+        <location filename="../app/AppLayouts/Onboarding/popups/BeforeGetStartedModal.qml" line="98" />
         <source>Privacy Policy</source>
         <translation>Privacy Policy</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Onboarding/popups/BeforeGetStartedModal.qml" line="110" />
         <source>Get started</source>
-        <translation>Get started</translation>
+        <translation type="vanished">Get started</translation>
     </message>
 </context>
 <context>
@@ -1135,6 +1378,7 @@ edit your notification preferences later in settings.</translation>
     <name>BloomSelectorButton</name>
     <message>
         <location filename="../app/AppLayouts/Profile/controls/BloomSelectorButton.qml" line="13" />
+        <location filename="../app/AppLayouts/Profile/controls/BloomSelectorButton.qml" line="13" />
         <source>TODO</source>
         <translation>TODO</translation>
     </message>
@@ -1143,25 +1387,30 @@ edit your notification preferences later in settings.</translation>
     <name>BrowserConnectionModal</name>
     <message>
         <location filename="../app/AppLayouts/Browser/popups/BrowserConnectionModal.qml" line="97" />
+        <location filename="../app/AppLayouts/Browser/popups/BrowserConnectionModal.qml" line="97" />
         <source>'%1' would like to connect to</source>
         <translation>'%1' would like to connect to</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Browser/popups/BrowserConnectionModal.qml" line="142" />
         <location filename="../app/AppLayouts/Browser/popups/BrowserConnectionModal.qml" line="142" />
         <source>Allowing authorizes this DApp to retrieve your wallet address and enable Web3</source>
         <translation>Allowing authorizes this DApp to retrieve your wallet address and enable Web3</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Browser/popups/BrowserConnectionModal.qml" line="143" />
+        <location filename="../app/AppLayouts/Browser/popups/BrowserConnectionModal.qml" line="143" />
         <source>Granting access authorizes this DApp to retrieve your chat key</source>
         <translation>Granting access authorizes this DApp to retrieve your chat key</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Browser/popups/BrowserConnectionModal.qml" line="163" />
+        <location filename="../app/AppLayouts/Browser/popups/BrowserConnectionModal.qml" line="163" />
         <source>Deny</source>
         <translation>Deny</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Browser/popups/BrowserConnectionModal.qml" line="174" />
         <location filename="../app/AppLayouts/Browser/popups/BrowserConnectionModal.qml" line="174" />
         <source>Allow</source>
         <translation>Allow</translation>
@@ -1170,6 +1419,7 @@ edit your notification preferences later in settings.</translation>
 <context>
     <name>BrowserHeader</name>
     <message>
+        <location filename="../app/AppLayouts/Browser/panels/BrowserHeader.qml" line="108" />
         <location filename="../app/AppLayouts/Browser/panels/BrowserHeader.qml" line="108" />
         <source>Enter URL</source>
         <translation>Enter URL</translation>
@@ -1226,45 +1476,54 @@ Do you wish to override the security check and continue?</translation>
     <name>BrowserSettingsMenu</name>
     <message>
         <location filename="../app/AppLayouts/Browser/popups/BrowserSettingsMenu.qml" line="30" />
+        <location filename="../app/AppLayouts/Browser/popups/BrowserSettingsMenu.qml" line="30" />
         <source>New Tab</source>
         <translation>New Tab</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Browser/popups/BrowserSettingsMenu.qml" line="39" />
         <location filename="../app/AppLayouts/Browser/popups/BrowserSettingsMenu.qml" line="39" />
         <source>Exit Incognito mode</source>
         <translation>Exit Incognito mode</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Browser/popups/BrowserSettingsMenu.qml" line="40" />
+        <location filename="../app/AppLayouts/Browser/popups/BrowserSettingsMenu.qml" line="40" />
         <source>Go Incognito</source>
         <translation>Go Incognito</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Browser/popups/BrowserSettingsMenu.qml" line="50" />
         <location filename="../app/AppLayouts/Browser/popups/BrowserSettingsMenu.qml" line="50" />
         <source>Zoom In</source>
         <translation>Zoom In</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Browser/popups/BrowserSettingsMenu.qml" line="56" />
+        <location filename="../app/AppLayouts/Browser/popups/BrowserSettingsMenu.qml" line="56" />
         <source>Zoom Out</source>
         <translation>Zoom Out</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Browser/popups/BrowserSettingsMenu.qml" line="69" />
         <location filename="../app/AppLayouts/Browser/popups/BrowserSettingsMenu.qml" line="69" />
         <source>Find</source>
         <translation>Find</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Browser/popups/BrowserSettingsMenu.qml" line="75" />
+        <location filename="../app/AppLayouts/Browser/popups/BrowserSettingsMenu.qml" line="75" />
         <source>Compatibility mode</source>
         <translation>Compatibility mode</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Browser/popups/BrowserSettingsMenu.qml" line="82" />
+        <location filename="../app/AppLayouts/Browser/popups/BrowserSettingsMenu.qml" line="82" />
         <source>Developer Tools</source>
         <translation>Developer Tools</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Browser/popups/BrowserSettingsMenu.qml" line="92" />
         <location filename="../app/AppLayouts/Browser/popups/BrowserSettingsMenu.qml" line="92" />
         <source>Settings</source>
         <translation>Settings</translation>
@@ -1274,6 +1533,7 @@ Do you wish to override the security check and continue?</translation>
     <name>BrowserTabStyle</name>
     <message>
         <location filename="../app/AppLayouts/Browser/controls/styles/BrowserTabStyle.qml" line="78" />
+        <location filename="../app/AppLayouts/Browser/controls/styles/BrowserTabStyle.qml" line="78" />
         <source>Start Page</source>
         <translation>Start Page</translation>
     </message>
@@ -1282,15 +1542,18 @@ Do you wish to override the security check and continue?</translation>
     <name>BrowserTabView</name>
     <message>
         <location filename="../app/AppLayouts/Browser/panels/BrowserTabView.qml" line="29" />
+        <location filename="../app/AppLayouts/Browser/panels/BrowserTabView.qml" line="29" />
         <source>Start Page</source>
         <translation>Start Page</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Browser/panels/BrowserTabView.qml" line="32" />
+        <location filename="../app/AppLayouts/Browser/panels/BrowserTabView.qml" line="32" />
         <source>New Tab</source>
         <translation>New Tab</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Browser/panels/BrowserTabView.qml" line="52" />
         <location filename="../app/AppLayouts/Browser/panels/BrowserTabView.qml" line="52" />
         <source>Downloads Page</source>
         <translation>Downloads Page</translation>
@@ -1300,30 +1563,36 @@ Do you wish to override the security check and continue?</translation>
     <name>BrowserView</name>
     <message>
         <location filename="../app/AppLayouts/Profile/views/BrowserView.qml" line="52" />
+        <location filename="../app/AppLayouts/Profile/views/BrowserView.qml" line="52" />
         <source>Search engine used in the address bar</source>
         <translation>Search engine used in the address bar</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/BrowserView.qml" line="59" />
         <location filename="../app/AppLayouts/Profile/views/BrowserView.qml" line="59" />
         <source>None</source>
         <translation>None</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/BrowserView.qml" line="76" />
+        <location filename="../app/AppLayouts/Profile/views/BrowserView.qml" line="76" />
         <source>Show Favorites Bar</source>
         <translation>Show Favorites Bar</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/BrowserView.qml" line="95" />
         <location filename="../app/AppLayouts/Profile/views/BrowserView.qml" line="95" />
         <source>Connected DApps</source>
         <translation>Connected DApps</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/BrowserView.qml" line="121" />
+        <location filename="../app/AppLayouts/Profile/views/BrowserView.qml" line="121" />
         <source>No connected dApps</source>
         <translation>No connected dApps</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/BrowserView.qml" line="131" />
         <location filename="../app/AppLayouts/Profile/views/BrowserView.qml" line="131" />
         <source>Connecting a dApp grants it permission to view your address and balances, and to send you transaction requests</source>
         <translation>Connecting a dApp grants it permission to view your address and balances, and to send you transaction requests</translation>
@@ -1333,30 +1602,36 @@ Do you wish to override the security check and continue?</translation>
     <name>BrowserWalletMenu</name>
     <message>
         <location filename="../app/AppLayouts/Browser/popups/BrowserWalletMenu.qml" line="74" />
+        <location filename="../app/AppLayouts/Browser/popups/BrowserWalletMenu.qml" line="74" />
         <source>Mainnet</source>
         <translation>Mainnet</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Browser/popups/BrowserWalletMenu.qml" line="75" />
         <location filename="../app/AppLayouts/Browser/popups/BrowserWalletMenu.qml" line="75" />
         <source>Ropsten</source>
         <translation>Ropsten</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Browser/popups/BrowserWalletMenu.qml" line="76" />
+        <location filename="../app/AppLayouts/Browser/popups/BrowserWalletMenu.qml" line="76" />
         <source>Unknown</source>
         <translation>Unknown</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Browser/popups/BrowserWalletMenu.qml" line="87" />
         <location filename="../app/AppLayouts/Browser/popups/BrowserWalletMenu.qml" line="87" />
         <source>Disconnect</source>
         <translation>Disconnect</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Browser/popups/BrowserWalletMenu.qml" line="188" />
+        <location filename="../app/AppLayouts/Browser/popups/BrowserWalletMenu.qml" line="188" />
         <source>Assets</source>
         <translation>Assets</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Browser/popups/BrowserWalletMenu.qml" line="193" />
         <location filename="../app/AppLayouts/Browser/popups/BrowserWalletMenu.qml" line="193" />
         <source>History</source>
         <translation>History</translation>
@@ -1366,6 +1641,7 @@ Do you wish to override the security check and continue?</translation>
     <name>BrowserWebEngineView</name>
     <message>
         <location filename="../app/AppLayouts/Browser/views/BrowserWebEngineView.qml" line="158" />
+        <location filename="../app/AppLayouts/Browser/views/BrowserWebEngineView.qml" line="158" />
         <source>Add Favorite</source>
         <translation>Add Favorite</translation>
     </message>
@@ -1374,15 +1650,18 @@ Do you wish to override the security check and continue?</translation>
     <name>ChangePasswordModal</name>
     <message>
         <location filename="../app/AppLayouts/Profile/popups/ChangePasswordModal.qml" line="64" />
+        <location filename="../app/AppLayouts/Profile/popups/ChangePasswordModal.qml" line="64" />
         <source>Change password</source>
         <translation>Change password</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/popups/ChangePasswordModal.qml" line="73" />
+        <location filename="../app/AppLayouts/Profile/popups/ChangePasswordModal.qml" line="73" />
         <source>Change password used to unlock Status on this device &amp; sign transactions.</source>
         <translation>Change password used to unlock Status on this device &amp; sign transactions.</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/popups/ChangePasswordModal.qml" line="81" />
         <location filename="../app/AppLayouts/Profile/popups/ChangePasswordModal.qml" line="81" />
         <source>Change Password</source>
         <translation>Change Password</translation>
@@ -1392,15 +1671,18 @@ Do you wish to override the security check and continue?</translation>
     <name>ChangePasswordSuccessModal</name>
     <message>
         <location filename="../app/AppLayouts/Profile/popups/ChangePasswordSuccessModal.qml" line="34" />
+        <location filename="../app/AppLayouts/Profile/popups/ChangePasswordSuccessModal.qml" line="34" />
         <source>&lt;b&gt;Password changed&lt;/b&gt;</source>
         <translation>&lt;b&gt;Password changed&lt;/b&gt;</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/popups/ChangePasswordSuccessModal.qml" line="41" />
+        <location filename="../app/AppLayouts/Profile/popups/ChangePasswordSuccessModal.qml" line="41" />
         <source>You need to sign in again using the new password.</source>
         <translation>You need to sign in again using the new password.</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/popups/ChangePasswordSuccessModal.qml" line="47" />
         <location filename="../app/AppLayouts/Profile/popups/ChangePasswordSuccessModal.qml" line="47" />
         <source>Sign out &amp; Quit</source>
         <translation>Sign out &amp; Quit</translation>
@@ -1410,25 +1692,30 @@ Do you wish to override the security check and continue?</translation>
     <name>ChangeProfilePicModal</name>
     <message>
         <location filename="../app/AppLayouts/Profile/popups/ChangeProfilePicModal.qml" line="15" />
+        <location filename="../app/AppLayouts/Profile/popups/ChangeProfilePicModal.qml" line="15" />
         <source>Profile picture</source>
         <translation>Profile picture</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/popups/ChangeProfilePicModal.qml" line="83" />
         <location filename="../app/AppLayouts/Profile/popups/ChangeProfilePicModal.qml" line="83" />
         <source>Remove</source>
         <translation>Remove</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/popups/ChangeProfilePicModal.qml" line="94" />
+        <location filename="../app/AppLayouts/Profile/popups/ChangeProfilePicModal.qml" line="94" />
         <source>Upload</source>
         <translation>Upload</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/popups/ChangeProfilePicModal.qml" line="103" />
+        <location filename="../app/AppLayouts/Profile/popups/ChangeProfilePicModal.qml" line="103" />
         <source>Please choose an image</source>
         <translation>Please choose an image</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/popups/ChangeProfilePicModal.qml" line="106" />
         <location filename="../app/AppLayouts/Profile/popups/ChangeProfilePicModal.qml" line="106" />
         <source>Image files (*.jpg *.jpeg *.png)</source>
         <translation>Image files (*.jpg *.jpeg *.png)</translation>
@@ -1438,10 +1725,12 @@ Do you wish to override the security check and continue?</translation>
     <name>ChannelIdentifierView</name>
     <message>
         <location filename="../imports/shared/views/chat/ChannelIdentifierView.qml" line="61" />
+        <location filename="../imports/shared/views/chat/ChannelIdentifierView.qml" line="61" />
         <source>Welcome to the beginning of the &lt;span style='color: %1'&gt;%2&lt;/span&gt; group!</source>
         <translation>Welcome to the beginning of the &lt;span style='color: %1'&gt;%2&lt;/span&gt; group!</translation>
     </message>
     <message>
+        <location filename="../imports/shared/views/chat/ChannelIdentifierView.qml" line="63" />
         <location filename="../imports/shared/views/chat/ChannelIdentifierView.qml" line="63" />
         <source>Any messages you send here are encrypted and can only be read by you and &lt;span style='color: %1'&gt;%2&lt;/span&gt;</source>
         <translation>Any messages you send here are encrypted and can only be read by you and &lt;span style='color: %1'&gt;%2&lt;/span&gt;</translation>
@@ -1451,40 +1740,48 @@ Do you wish to override the security check and continue?</translation>
     <name>ChatButtonsPanel</name>
     <message>
         <location filename="../imports/shared/panels/chat/ChatButtonsPanel.qml" line="85" />
+        <location filename="../imports/shared/panels/chat/ChatButtonsPanel.qml" line="85" />
         <source>Add reaction</source>
         <translation>Add reaction</translation>
     </message>
     <message>
+        <location filename="../imports/shared/panels/chat/ChatButtonsPanel.qml" line="106" />
         <location filename="../imports/shared/panels/chat/ChatButtonsPanel.qml" line="106" />
         <source>Reply</source>
         <translation>Reply</translation>
     </message>
     <message>
         <location filename="../imports/shared/panels/chat/ChatButtonsPanel.qml" line="125" />
+        <location filename="../imports/shared/panels/chat/ChatButtonsPanel.qml" line="125" />
         <source>Edit</source>
         <translation>Edit</translation>
     </message>
     <message>
+        <location filename="../imports/shared/panels/chat/ChatButtonsPanel.qml" line="139" />
         <location filename="../imports/shared/panels/chat/ChatButtonsPanel.qml" line="139" />
         <source>Unpin</source>
         <translation>Unpin</translation>
     </message>
     <message>
         <location filename="../imports/shared/panels/chat/ChatButtonsPanel.qml" line="139" />
+        <location filename="../imports/shared/panels/chat/ChatButtonsPanel.qml" line="139" />
         <source>Pin</source>
         <translation>Pin</translation>
     </message>
     <message>
+        <location filename="../imports/shared/panels/chat/ChatButtonsPanel.qml" line="175" />
         <location filename="../imports/shared/panels/chat/ChatButtonsPanel.qml" line="175" />
         <source>Delete</source>
         <translation>Delete</translation>
     </message>
     <message>
         <location filename="../imports/shared/panels/chat/ChatButtonsPanel.qml" line="192" />
+        <location filename="../imports/shared/panels/chat/ChatButtonsPanel.qml" line="192" />
         <source>Confirm deleting this message</source>
         <translation>Confirm deleting this message</translation>
     </message>
     <message>
+        <location filename="../imports/shared/panels/chat/ChatButtonsPanel.qml" line="193" />
         <location filename="../imports/shared/panels/chat/ChatButtonsPanel.qml" line="193" />
         <source>Are you sure you want to delete this message? Be aware that other clients are not guaranteed to delete the message as well.</source>
         <translation>Are you sure you want to delete this message? Be aware that other clients are not guaranteed to delete the message as well.</translation>
@@ -1493,18 +1790,22 @@ Do you wish to override the security check and continue?</translation>
 <context>
     <name>ChatColumnView</name>
     <message>
-        <location filename="../app/AppLayouts/Chat/views/ChatColumnView.qml" line="316" />
+        <location filename="../app/AppLayouts/Chat/views/ChatColumnView.qml" line="337" />
+        <location filename="../app/AppLayouts/Chat/views/ChatColumnView.qml" line="337" />
         <source>Send</source>
         <translation>Send</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/views/ChatColumnView.qml" line="318" />
+        <location filename="../app/AppLayouts/Chat/views/ChatColumnView.qml" line="339" />
+        <location filename="../app/AppLayouts/Chat/views/ChatColumnView.qml" line="339" />
         <source>Request Address</source>
         <translation>Request Address</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/views/ChatColumnView.qml" line="349" />
-        <location filename="../app/AppLayouts/Chat/views/ChatColumnView.qml" line="351" />
+        <location filename="../app/AppLayouts/Chat/views/ChatColumnView.qml" line="369" />
+        <location filename="../app/AppLayouts/Chat/views/ChatColumnView.qml" line="371" />
+        <location filename="../app/AppLayouts/Chat/views/ChatColumnView.qml" line="369" />
+        <location filename="../app/AppLayouts/Chat/views/ChatColumnView.qml" line="371" />
         <source>Request</source>
         <translation>Request</translation>
     </message>
@@ -1512,48 +1813,58 @@ Do you wish to override the security check and continue?</translation>
 <context>
     <name>ChatCommandModal</name>
     <message>
-        <location filename="../app/AppLayouts/Chat/popups/ChatCommandModal.qml" line="51" />
+        <location filename="../app/AppLayouts/Chat/popups/ChatCommandModal.qml" line="50" />
+        <location filename="../app/AppLayouts/Chat/popups/ChatCommandModal.qml" line="50" />
         <source>Continue</source>
         <translation>Continue</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/popups/ChatCommandModal.qml" line="67" />
+        <location filename="../app/AppLayouts/Chat/popups/ChatCommandModal.qml" line="66" />
+        <location filename="../app/AppLayouts/Chat/popups/ChatCommandModal.qml" line="66" />
         <source>Receive on account</source>
         <translation>Receive on account</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/popups/ChatCommandModal.qml" line="68" />
+        <location filename="../app/AppLayouts/Chat/popups/ChatCommandModal.qml" line="67" />
+        <location filename="../app/AppLayouts/Chat/popups/ChatCommandModal.qml" line="67" />
         <source>From account</source>
         <translation>From account</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/popups/ChatCommandModal.qml" line="83" />
+        <location filename="../app/AppLayouts/Chat/popups/ChatCommandModal.qml" line="82" />
+        <location filename="../app/AppLayouts/Chat/popups/ChatCommandModal.qml" line="82" />
         <source>Address request required</source>
         <translation>Address request required</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/popups/ChatCommandModal.qml" line="93" />
+        <location filename="../app/AppLayouts/Chat/popups/ChatCommandModal.qml" line="92" />
+        <location filename="../app/AppLayouts/Chat/popups/ChatCommandModal.qml" line="92" />
         <source>From</source>
         <translation>From</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/popups/ChatCommandModal.qml" line="94" />
+        <location filename="../app/AppLayouts/Chat/popups/ChatCommandModal.qml" line="93" />
+        <location filename="../app/AppLayouts/Chat/popups/ChatCommandModal.qml" line="93" />
         <source>To</source>
         <translation>To</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/popups/ChatCommandModal.qml" line="106" />
-        <location filename="../app/AppLayouts/Chat/popups/ChatCommandModal.qml" line="122" />
+        <location filename="../app/AppLayouts/Chat/popups/ChatCommandModal.qml" line="105" />
+        <location filename="../app/AppLayouts/Chat/popups/ChatCommandModal.qml" line="121" />
+        <location filename="../app/AppLayouts/Chat/popups/ChatCommandModal.qml" line="105" />
+        <location filename="../app/AppLayouts/Chat/popups/ChatCommandModal.qml" line="121" />
         <source>Preview</source>
         <translation>Preview</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/popups/ChatCommandModal.qml" line="123" />
+        <location filename="../app/AppLayouts/Chat/popups/ChatCommandModal.qml" line="122" />
+        <location filename="../app/AppLayouts/Chat/popups/ChatCommandModal.qml" line="122" />
         <source>Transaction preview</source>
         <translation>Transaction preview</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/popups/ChatCommandModal.qml" line="162" />
+        <location filename="../app/AppLayouts/Chat/popups/ChatCommandModal.qml" line="161" />
+        <location filename="../app/AppLayouts/Chat/popups/ChatCommandModal.qml" line="161" />
         <source>Next</source>
         <translation>Next</translation>
     </message>
@@ -1576,47 +1887,56 @@ Do you wish to override the security check and continue?</translation>
 <context>
     <name>ChatContentView</name>
     <message>
-        <location filename="../app/AppLayouts/Chat/views/ChatContentView.qml" line="80" />
+        <location filename="../app/AppLayouts/Chat/views/ChatContentView.qml" line="87" />
+        <location filename="../app/AppLayouts/Chat/views/ChatContentView.qml" line="87" />
         <source>Contact</source>
         <translation>Contact</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/views/ChatContentView.qml" line="81" />
+        <location filename="../app/AppLayouts/Chat/views/ChatContentView.qml" line="88" />
+        <location filename="../app/AppLayouts/Chat/views/ChatContentView.qml" line="88" />
         <source>Not a contact</source>
         <translation>Not a contact</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/views/ChatContentView.qml" line="83" />
+        <location filename="../app/AppLayouts/Chat/views/ChatContentView.qml" line="90" />
+        <location filename="../app/AppLayouts/Chat/views/ChatContentView.qml" line="90" />
         <source>Public chat</source>
         <translation>Public chat</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/views/ChatContentView.qml" line="86" />
+        <location filename="../app/AppLayouts/Chat/views/ChatContentView.qml" line="93" />
+        <location filename="../app/AppLayouts/Chat/views/ChatContentView.qml" line="93" />
         <source>%1 members</source>
         <translation>%1 members</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/views/ChatContentView.qml" line="87" />
+        <location filename="../app/AppLayouts/Chat/views/ChatContentView.qml" line="94" />
+        <location filename="../app/AppLayouts/Chat/views/ChatContentView.qml" line="94" />
         <source>1 member</source>
         <translation>1 member</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/views/ChatContentView.qml" line="316" />
+        <location filename="../app/AppLayouts/Chat/views/ChatContentView.qml" line="322" />
+        <location filename="../app/AppLayouts/Chat/views/ChatContentView.qml" line="322" />
         <source>Connected</source>
         <translation>Connected</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/views/ChatContentView.qml" line="317" />
+        <location filename="../app/AppLayouts/Chat/views/ChatContentView.qml" line="323" />
+        <location filename="../app/AppLayouts/Chat/views/ChatContentView.qml" line="323" />
         <source>Disconnected</source>
         <translation>Disconnected</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/views/ChatContentView.qml" line="346" />
+        <location filename="../app/AppLayouts/Chat/views/ChatContentView.qml" line="358" />
+        <location filename="../app/AppLayouts/Chat/views/ChatContentView.qml" line="358" />
         <source>Blocked</source>
         <translation>Blocked</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/views/ChatContentView.qml" line="475" />
+        <location filename="../app/AppLayouts/Chat/views/ChatContentView.qml" line="487" />
+        <location filename="../app/AppLayouts/Chat/views/ChatContentView.qml" line="487" />
         <source>This user has been blocked.</source>
         <translation>This user has been blocked.</translation>
     </message>
@@ -1625,55 +1945,67 @@ Do you wish to override the security check and continue?</translation>
     <name>ChatContextMenuView</name>
     <message>
         <location filename="../app/AppLayouts/Chat/views/ChatContextMenuView.qml" line="58" />
+        <location filename="../app/AppLayouts/Chat/views/ChatContextMenuView.qml" line="58" />
         <source>View Members</source>
         <translation>View Members</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Chat/views/ChatContextMenuView.qml" line="65" />
         <location filename="../app/AppLayouts/Chat/views/ChatContextMenuView.qml" line="65" />
         <source>Add / remove from group</source>
         <translation>Add / remove from group</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Chat/views/ChatContextMenuView.qml" line="81" />
+        <location filename="../app/AppLayouts/Chat/views/ChatContextMenuView.qml" line="81" />
         <source>Test WakuV2 - requestAllHistoricMessages</source>
         <translation>Test WakuV2 - requestAllHistoricMessages</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Chat/views/ChatContextMenuView.qml" line="88" />
         <location filename="../app/AppLayouts/Chat/views/ChatContextMenuView.qml" line="88" />
         <source>Edit name</source>
         <translation>Edit name</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Chat/views/ChatContextMenuView.qml" line="120" />
+        <location filename="../app/AppLayouts/Chat/views/ChatContextMenuView.qml" line="120" />
         <source>Mark as Read</source>
         <translation>Mark as Read</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Chat/views/ChatContextMenuView.qml" line="162" />
         <location filename="../app/AppLayouts/Chat/views/ChatContextMenuView.qml" line="162" />
         <source>Clear history</source>
         <translation>Clear history</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Chat/views/ChatContextMenuView.qml" line="170" />
+        <location filename="../app/AppLayouts/Chat/views/ChatContextMenuView.qml" line="170" />
         <source>Edit Channel</source>
         <translation>Edit Channel</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Chat/views/ChatContextMenuView.qml" line="205" />
         <location filename="../app/AppLayouts/Chat/views/ChatContextMenuView.qml" line="205" />
         <source>Download</source>
         <translation>Download</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Chat/views/ChatContextMenuView.qml" line="219" />
+        <location filename="../app/AppLayouts/Chat/views/ChatContextMenuView.qml" line="219" />
         <source>Delete Channel</source>
         <translation>Delete Channel</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Chat/views/ChatContextMenuView.qml" line="222" />
+        <location filename="../app/AppLayouts/Chat/views/ChatContextMenuView.qml" line="222" />
         <source>Leave group</source>
         <translation>Leave group</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Chat/views/ChatContextMenuView.qml" line="225" />
+        <location filename="../app/AppLayouts/Chat/views/ChatContextMenuView.qml" line="263" />
         <location filename="../app/AppLayouts/Chat/views/ChatContextMenuView.qml" line="225" />
         <location filename="../app/AppLayouts/Chat/views/ChatContextMenuView.qml" line="263" />
         <source>Delete chat</source>
@@ -1682,40 +2014,49 @@ Do you wish to override the security check and continue?</translation>
     <message>
         <location filename="../app/AppLayouts/Chat/views/ChatContextMenuView.qml" line="226" />
         <location filename="../app/AppLayouts/Chat/views/ChatContextMenuView.qml" line="264" />
+        <location filename="../app/AppLayouts/Chat/views/ChatContextMenuView.qml" line="226" />
+        <location filename="../app/AppLayouts/Chat/views/ChatContextMenuView.qml" line="264" />
         <source>Leave chat</source>
         <translation>Leave chat</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Chat/views/ChatContextMenuView.qml" line="246" />
         <location filename="../app/AppLayouts/Chat/views/ChatContextMenuView.qml" line="246" />
         <source>Save</source>
         <translation>Save</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Chat/views/ChatContextMenuView.qml" line="248" />
+        <location filename="../app/AppLayouts/Chat/views/ChatContextMenuView.qml" line="248" />
         <source>Download messages</source>
         <translation>Download messages</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Chat/views/ChatContextMenuView.qml" line="261" />
         <location filename="../app/AppLayouts/Chat/views/ChatContextMenuView.qml" line="261" />
         <source>Delete #%1</source>
         <translation>Delete #%1</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Chat/views/ChatContextMenuView.qml" line="265" />
+        <location filename="../app/AppLayouts/Chat/views/ChatContextMenuView.qml" line="265" />
         <source>Delete</source>
         <translation>Delete</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Chat/views/ChatContextMenuView.qml" line="266" />
         <location filename="../app/AppLayouts/Chat/views/ChatContextMenuView.qml" line="266" />
         <source>Are you sure you want to delete #%1 channel?</source>
         <translation>Are you sure you want to delete #%1 channel?</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Chat/views/ChatContextMenuView.qml" line="268" />
+        <location filename="../app/AppLayouts/Chat/views/ChatContextMenuView.qml" line="268" />
         <source>Are you sure you want to delete this chat?</source>
         <translation>Are you sure you want to delete this chat?</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Chat/views/ChatContextMenuView.qml" line="269" />
         <location filename="../app/AppLayouts/Chat/views/ChatContextMenuView.qml" line="269" />
         <source>Are you sure you want to leave this chat?</source>
         <translation>Are you sure you want to leave this chat?</translation>
@@ -1724,12 +2065,12 @@ Do you wish to override the security check and continue?</translation>
 <context>
     <name>ChatMessagesView</name>
     <message>
-        <location filename="../app/AppLayouts/Chat/views/ChatMessagesView.qml" line="116" />
         <source>Loading...</source>
-        <translation>Loading...</translation>
+        <translation type="vanished">Loading...</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/views/ChatMessagesView.qml" line="350" />
+        <location filename="../app/AppLayouts/Chat/views/ChatMessagesView.qml" line="318" />
+        <location filename="../app/AppLayouts/Chat/views/ChatMessagesView.qml" line="318" />
         <source>Failed to send message.</source>
         <translation>Failed to send message.</translation>
     </message>
@@ -1738,16 +2079,19 @@ Do you wish to override the security check and continue?</translation>
     <name>ChatRequestMessagePanel</name>
     <message>
         <location filename="../app/AppLayouts/Chat/panels/ChatRequestMessagePanel.qml" line="28" />
+        <location filename="../app/AppLayouts/Chat/panels/ChatRequestMessagePanel.qml" line="28" />
         <source>You need to be mutual contacts with this person for them to receive your messages</source>
         <translation>You need to be mutual contacts with this person for them to receive your messages</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/panels/ChatRequestMessagePanel.qml" line="43" />
+        <location filename="../app/AppLayouts/Chat/panels/ChatRequestMessagePanel.qml" line="41" />
+        <location filename="../app/AppLayouts/Chat/panels/ChatRequestMessagePanel.qml" line="41" />
         <source>Just click this button to add them as contact. They will receive a notification. Once they accept the request, you'll be able to chat</source>
         <translation>Just click this button to add them as contact. They will receive a notification. Once they accept the request, you'll be able to chat</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/panels/ChatRequestMessagePanel.qml" line="55" />
+        <location filename="../app/AppLayouts/Chat/panels/ChatRequestMessagePanel.qml" line="53" />
+        <location filename="../app/AppLayouts/Chat/panels/ChatRequestMessagePanel.qml" line="53" />
         <source>Add to contacts</source>
         <translation>Add to contacts</translation>
     </message>
@@ -1755,17 +2099,20 @@ Do you wish to override the security check and continue?</translation>
 <context>
     <name>ChatView</name>
     <message>
-        <location filename="../app/AppLayouts/Chat/views/ChatView.qml" line="110" />
+        <location filename="../app/AppLayouts/Chat/views/ChatView.qml" line="112" />
+        <location filename="../app/AppLayouts/Chat/views/ChatView.qml" line="112" />
         <source>Members</source>
         <translation>Members</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/views/ChatView.qml" line="176" />
+        <location filename="../app/AppLayouts/Chat/views/ChatView.qml" line="183" />
+        <location filename="../app/AppLayouts/Chat/views/ChatView.qml" line="183" />
         <source>Remove contact</source>
         <translation>Remove contact</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/views/ChatView.qml" line="177" />
+        <location filename="../app/AppLayouts/Chat/views/ChatView.qml" line="184" />
+        <location filename="../app/AppLayouts/Chat/views/ChatView.qml" line="184" />
         <source>Are you sure you want to remove this contact?</source>
         <translation>Are you sure you want to remove this contact?</translation>
     </message>
@@ -1774,20 +2121,24 @@ Do you wish to override the security check and continue?</translation>
     <name>ChooseBrowserPopup</name>
     <message>
         <location filename="../app/AppLayouts/Chat/popups/ChooseBrowserPopup.qml" line="15" />
+        <location filename="../app/AppLayouts/Chat/popups/ChooseBrowserPopup.qml" line="15" />
         <source>Choose browser</source>
         <translation>Choose browser</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Chat/popups/ChooseBrowserPopup.qml" line="31" />
         <location filename="../app/AppLayouts/Chat/popups/ChooseBrowserPopup.qml" line="31" />
         <source>Open in Status</source>
         <translation>Open in Status</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Chat/popups/ChooseBrowserPopup.qml" line="45" />
+        <location filename="../app/AppLayouts/Chat/popups/ChooseBrowserPopup.qml" line="45" />
         <source>Open in my default browser</source>
         <translation>Open in my default browser</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Chat/popups/ChooseBrowserPopup.qml" line="60" />
         <location filename="../app/AppLayouts/Chat/popups/ChooseBrowserPopup.qml" line="60" />
         <source>Remember my choice. To override it, go to settings.</source>
         <translation>Remember my choice. To override it, go to settings.</translation>
@@ -1797,6 +2148,7 @@ Do you wish to override the security check and continue?</translation>
     <name>ClosedEmptyPanel</name>
     <message>
         <location filename="../app/AppLayouts/Chat/panels/ClosedEmptyPanel.qml" line="16" />
+        <location filename="../app/AppLayouts/Chat/panels/ClosedEmptyPanel.qml" line="16" />
         <source>Your chats will appear here. To start new chats press the &#57695; button at the top</source>
         <translation>Your chats will appear here. To start new chats press the &#57695; button at the top</translation>
     </message>
@@ -1804,6 +2156,7 @@ Do you wish to override the security check and continue?</translation>
 <context>
     <name>CollectibleCollectionView</name>
     <message>
+        <location filename="../app/AppLayouts/Wallet/views/collectibles/CollectibleCollectionView.qml" line="74" />
         <location filename="../app/AppLayouts/Wallet/views/collectibles/CollectibleCollectionView.qml" line="74" />
         <source>No collectibles available</source>
         <translation>No collectibles available</translation>
@@ -1813,15 +2166,18 @@ Do you wish to override the security check and continue?</translation>
     <name>CollectibleDetailView</name>
     <message>
         <location filename="../app/AppLayouts/Wallet/views/collectibles/CollectibleDetailView.qml" line="86" />
+        <location filename="../app/AppLayouts/Wallet/views/collectibles/CollectibleDetailView.qml" line="86" />
         <source>Properties</source>
         <translation>Properties</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Wallet/views/collectibles/CollectibleDetailView.qml" line="86" />
+        <location filename="../app/AppLayouts/Wallet/views/collectibles/CollectibleDetailView.qml" line="86" />
         <source>Levels</source>
         <translation>Levels</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Wallet/views/collectibles/CollectibleDetailView.qml" line="86" />
         <location filename="../app/AppLayouts/Wallet/views/collectibles/CollectibleDetailView.qml" line="86" />
         <source>Stats</source>
         <translation>Stats</translation>
@@ -1831,6 +2187,7 @@ Do you wish to override the security check and continue?</translation>
     <name>CollectibleDetailsHeader</name>
     <message>
         <location filename="../app/AppLayouts/Wallet/controls/CollectibleDetailsHeader.qml" line="81" />
+        <location filename="../app/AppLayouts/Wallet/controls/CollectibleDetailsHeader.qml" line="81" />
         <source>Send</source>
         <translation>Send</translation>
     </message>
@@ -1839,20 +2196,24 @@ Do you wish to override the security check and continue?</translation>
     <name>CollectibleModal</name>
     <message>
         <location filename="../app/AppLayouts/Wallet/popups/CollectibleModal.qml" line="12" />
+        <location filename="../app/AppLayouts/Wallet/popups/CollectibleModal.qml" line="12" />
         <source>unnamed</source>
         <translation>unnamed</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Wallet/popups/CollectibleModal.qml" line="44" />
         <location filename="../app/AppLayouts/Wallet/popups/CollectibleModal.qml" line="44" />
         <source>id</source>
         <translation>id</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Wallet/popups/CollectibleModal.qml" line="54" />
+        <location filename="../app/AppLayouts/Wallet/popups/CollectibleModal.qml" line="54" />
         <source>description</source>
         <translation>description</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Wallet/popups/CollectibleModal.qml" line="62" />
         <location filename="../app/AppLayouts/Wallet/popups/CollectibleModal.qml" line="62" />
         <source>View in Opensea</source>
         <translation>View in Opensea</translation>
@@ -1862,10 +2223,12 @@ Do you wish to override the security check and continue?</translation>
     <name>CollectiblesContent</name>
     <message>
         <location filename="../app/AppLayouts/Wallet/panels/CollectiblesContent.qml" line="51" />
+        <location filename="../app/AppLayouts/Wallet/panels/CollectiblesContent.qml" line="51" />
         <source>Something went wrong</source>
         <translation>Something went wrong</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Wallet/panels/CollectiblesContent.qml" line="58" />
         <location filename="../app/AppLayouts/Wallet/panels/CollectiblesContent.qml" line="58" />
         <source>Reload</source>
         <translation>Reload</translation>
@@ -1875,6 +2238,7 @@ Do you wish to override the security check and continue?</translation>
     <name>CollectiblesHeader</name>
     <message>
         <location filename="../app/AppLayouts/Wallet/controls/CollectiblesHeader.qml" line="45" />
+        <location filename="../app/AppLayouts/Wallet/controls/CollectiblesHeader.qml" line="45" />
         <source>Maximum number of collectibles to display reached</source>
         <translation>Maximum number of collectibles to display reached</translation>
     </message>
@@ -1883,10 +2247,12 @@ Do you wish to override the security check and continue?</translation>
     <name>CollectiblesModal</name>
     <message>
         <location filename="../app/AppLayouts/Wallet/popups/CollectiblesModal.qml" line="24" />
+        <location filename="../app/AppLayouts/Wallet/popups/CollectiblesModal.qml" line="24" />
         <source>View</source>
         <translation>View</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Wallet/popups/CollectiblesModal.qml" line="30" />
         <location filename="../app/AppLayouts/Wallet/popups/CollectiblesModal.qml" line="30" />
         <source>Unnamed</source>
         <translation>Unnamed</translation>
@@ -1896,10 +2262,12 @@ Do you wish to override the security check and continue?</translation>
     <name>CollectiblesModalContent</name>
     <message>
         <location filename="../app/AppLayouts/Wallet/panels/CollectiblesModalContent.qml" line="29" />
+        <location filename="../app/AppLayouts/Wallet/panels/CollectiblesModalContent.qml" line="29" />
         <source>ID</source>
         <translation>ID</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Wallet/panels/CollectiblesModalContent.qml" line="39" />
         <location filename="../app/AppLayouts/Wallet/panels/CollectiblesModalContent.qml" line="39" />
         <source>Description</source>
         <translation>Description</translation>
@@ -1909,6 +2277,7 @@ Do you wish to override the security check and continue?</translation>
     <name>CollectiblesStore</name>
     <message>
         <location filename="../app/AppLayouts/Wallet/stores/CollectiblesStore.qml" line="11" />
+        <location filename="../app/AppLayouts/Wallet/stores/CollectiblesStore.qml" line="11" />
         <source>Collectibles</source>
         <translation>Collectibles</translation>
     </message>
@@ -1916,6 +2285,7 @@ Do you wish to override the security check and continue?</translation>
 <context>
     <name>CollectiblesView</name>
     <message>
+        <location filename="../app/AppLayouts/Wallet/views/CollectiblesView.qml" line="40" />
         <location filename="../app/AppLayouts/Wallet/views/CollectiblesView.qml" line="40" />
         <source>Collectibles will appear here</source>
         <translation>Collectibles will appear here</translation>
@@ -1926,20 +2296,25 @@ Do you wish to override the security check and continue?</translation>
     <message>
         <location filename="../app/AppLayouts/Profile/panels/CommunitiesListPanel.qml" line="44" />
         <location filename="../app/AppLayouts/Profile/panels/CommunitiesListPanel.qml" line="100" />
+        <location filename="../app/AppLayouts/Profile/panels/CommunitiesListPanel.qml" line="44" />
+        <location filename="../app/AppLayouts/Profile/panels/CommunitiesListPanel.qml" line="100" />
         <source>Leave community</source>
         <translation>Leave community</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/panels/CommunitiesListPanel.qml" line="76" />
         <location filename="../app/AppLayouts/Profile/panels/CommunitiesListPanel.qml" line="76" />
         <source>Leave %1</source>
         <translation>Leave %1</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/panels/CommunitiesListPanel.qml" line="87" />
+        <location filename="../app/AppLayouts/Profile/panels/CommunitiesListPanel.qml" line="87" />
         <source>Are you sure you want to leave? Once you leave, you will have to request to rejoin if you change your mind.</source>
         <translation>Are you sure you want to leave? Once you leave, you will have to request to rejoin if you change your mind.</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/panels/CommunitiesListPanel.qml" line="95" />
         <location filename="../app/AppLayouts/Profile/panels/CommunitiesListPanel.qml" line="95" />
         <source>Cancel</source>
         <translation>Cancel</translation>
@@ -1948,27 +2323,32 @@ Do you wish to override the security check and continue?</translation>
 <context>
     <name>CommunitiesPopup</name>
     <message>
-        <location filename="../app/AppLayouts/Chat/popups/community/CommunitiesPopup.qml" line="27" />
+        <location filename="../app/AppLayouts/Chat/popups/community/CommunitiesPopup.qml" line="30" />
+        <location filename="../app/AppLayouts/Chat/popups/community/CommunitiesPopup.qml" line="30" />
         <source>Communities</source>
         <translation>Communities</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/popups/community/CommunitiesPopup.qml" line="41" />
+        <location filename="../app/AppLayouts/Chat/popups/community/CommunitiesPopup.qml" line="44" />
+        <location filename="../app/AppLayouts/Chat/popups/community/CommunitiesPopup.qml" line="44" />
         <source>Access existing community</source>
         <translation>Access existing community</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/popups/community/CommunitiesPopup.qml" line="61" />
+        <location filename="../app/AppLayouts/Chat/popups/community/CommunitiesPopup.qml" line="66" />
+        <location filename="../app/AppLayouts/Chat/popups/community/CommunitiesPopup.qml" line="66" />
         <source>Search for communities or topics</source>
         <translation>Search for communities or topics</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/popups/community/CommunitiesPopup.qml" line="122" />
+        <location filename="../app/AppLayouts/Chat/popups/community/CommunitiesPopup.qml" line="127" />
+        <location filename="../app/AppLayouts/Chat/popups/community/CommunitiesPopup.qml" line="127" />
         <source>%1 members</source>
         <translation>%1 members</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/popups/community/CommunitiesPopup.qml" line="146" />
+        <location filename="../app/AppLayouts/Chat/popups/community/CommunitiesPopup.qml" line="151" />
+        <location filename="../app/AppLayouts/Chat/popups/community/CommunitiesPopup.qml" line="151" />
         <source>Create a community</source>
         <translation>Create a community</translation>
     </message>
@@ -1976,32 +2356,38 @@ Do you wish to override the security check and continue?</translation>
 <context>
     <name>CommunitiesPortalLayout</name>
     <message>
-        <location filename="../app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml" line="48" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml" line="50" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml" line="50" />
         <source>Find community</source>
         <translation>Find community</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml" line="64" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml" line="66" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml" line="66" />
         <source>Search</source>
         <translation>Search</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml" line="80" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml" line="82" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml" line="82" />
         <source>Import Community</source>
         <translation>Import Community</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml" line="86" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml" line="88" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml" line="88" />
         <source>Create New Community</source>
         <translation>Create New Community</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml" line="126" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml" line="128" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml" line="128" />
         <source>Featured</source>
         <translation>Featured</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml" line="161" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml" line="163" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml" line="163" />
         <source>Popular</source>
         <translation>Popular</translation>
     </message>
@@ -2010,10 +2396,12 @@ Do you wish to override the security check and continue?</translation>
     <name>CommunitiesView</name>
     <message>
         <location filename="../app/AppLayouts/Profile/views/CommunitiesView.qml" line="30" />
+        <location filename="../app/AppLayouts/Profile/views/CommunitiesView.qml" line="30" />
         <source>Import community</source>
         <translation>Import community</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/CommunitiesView.qml" line="51" />
         <location filename="../app/AppLayouts/Profile/views/CommunitiesView.qml" line="51" />
         <source>Communities you've joined</source>
         <translation>Communities you've joined</translation>
@@ -2024,15 +2412,19 @@ Do you wish to override the security check and continue?</translation>
     <message>
         <location filename="../app/AppLayouts/Chat/controls/community/CommunityBannerPicker.qml" line="37" />
         <location filename="../app/AppLayouts/Chat/controls/community/CommunityBannerPicker.qml" line="51" />
+        <location filename="../app/AppLayouts/Chat/controls/community/CommunityBannerPicker.qml" line="37" />
+        <location filename="../app/AppLayouts/Chat/controls/community/CommunityBannerPicker.qml" line="51" />
         <source>Community banner</source>
         <translation>Community banner</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Chat/controls/community/CommunityBannerPicker.qml" line="50" />
+        <location filename="../app/AppLayouts/Chat/controls/community/CommunityBannerPicker.qml" line="50" />
         <source>Choose an image for banner</source>
         <translation>Choose an image for banner</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Chat/controls/community/CommunityBannerPicker.qml" line="52" />
         <location filename="../app/AppLayouts/Chat/controls/community/CommunityBannerPicker.qml" line="52" />
         <source>Make this my Community banner</source>
         <translation>Make this my Community banner</translation>
@@ -2041,17 +2433,20 @@ Do you wish to override the security check and continue?</translation>
 <context>
     <name>CommunityChannelsAndCategoriesBannerPanel</name>
     <message>
-        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityChannelsAndCategoriesBannerPanel.qml" line="70" />
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityChannelsAndCategoriesBannerPanel.qml" line="73" />
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityChannelsAndCategoriesBannerPanel.qml" line="73" />
         <source>Expand your community by adding more channels and categories</source>
         <translation>Expand your community by adding more channels and categories</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityChannelsAndCategoriesBannerPanel.qml" line="85" />
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityChannelsAndCategoriesBannerPanel.qml" line="88" />
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityChannelsAndCategoriesBannerPanel.qml" line="88" />
         <source>Add channels</source>
         <translation>Add channels</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityChannelsAndCategoriesBannerPanel.qml" line="94" />
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityChannelsAndCategoriesBannerPanel.qml" line="99" />
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityChannelsAndCategoriesBannerPanel.qml" line="99" />
         <source>Add categories</source>
         <translation>Add categories</translation>
     </message>
@@ -2060,25 +2455,30 @@ Do you wish to override the security check and continue?</translation>
     <name>CommunityColorPanel</name>
     <message>
         <location filename="../app/AppLayouts/CommunitiesPortal/panels/CommunityColorPanel.qml" line="15" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/panels/CommunityColorPanel.qml" line="15" />
         <source>Community Colour</source>
         <translation>Community Colour</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/CommunitiesPortal/panels/CommunityColorPanel.qml" line="18" />
         <location filename="../app/AppLayouts/CommunitiesPortal/panels/CommunityColorPanel.qml" line="18" />
         <source>Select Community Colour</source>
         <translation>Select Community Colour</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/CommunitiesPortal/panels/CommunityColorPanel.qml" line="73" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/panels/CommunityColorPanel.qml" line="73" />
         <source>This is not a valid colour</source>
         <translation>This is not a valid colour</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/CommunitiesPortal/panels/CommunityColorPanel.qml" line="90" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/panels/CommunityColorPanel.qml" line="90" />
         <source>White text should be legable on top of this colour</source>
         <translation>White text should be legable on top of this colour</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/CommunitiesPortal/panels/CommunityColorPanel.qml" line="111" />
         <location filename="../app/AppLayouts/CommunitiesPortal/panels/CommunityColorPanel.qml" line="111" />
         <source>Standard colours</source>
         <translation>Standard colours</translation>
@@ -2088,6 +2488,7 @@ Do you wish to override the security check and continue?</translation>
     <name>CommunityColorPicker</name>
     <message>
         <location filename="../app/AppLayouts/CommunitiesPortal/controls/CommunityColorPicker.qml" line="22" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/controls/CommunityColorPicker.qml" line="22" />
         <source>Community colour</source>
         <translation>Community colour</translation>
     </message>
@@ -2096,71 +2497,101 @@ Do you wish to override the security check and continue?</translation>
     <name>CommunityColumnView</name>
     <message>
         <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="44" />
+        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="44" />
         <source>1 Member</source>
         <translation>1 Member</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="45" />
         <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="45" />
         <source>%1 Members</source>
         <translation>%1 Members</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="76" />
+        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="76" />
         <source>Start chat</source>
         <translation>Start chat</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="94" />
+        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="94" />
         <source>Membership requests</source>
         <translation>Membership requests</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="130" />
-        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="188" />
-        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="488" />
+        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="132" />
+        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="190" />
+        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="508" />
+        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="132" />
+        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="190" />
+        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="508" />
         <source>Create channel</source>
         <translation>Create channel</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="137" />
-        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="196" />
-        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="494" />
+        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="139" />
+        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="198" />
+        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="514" />
+        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="139" />
+        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="198" />
+        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="514" />
         <source>Create category</source>
         <translation>Create category</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="146" />
-        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="205" />
+        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="148" />
+        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="207" />
+        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="148" />
+        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="207" />
         <source>Invite people</source>
         <translation>Invite people</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="233" />
+        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="234" />
+        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="234" />
+        <source>Unmute category</source>
+        <translation>Unmute category</translation>
+    </message>
+    <message>
+        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="234" />
+        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="234" />
+        <source>Mute category</source>
+        <translation>Mute category</translation>
+    </message>
+    <message>
+        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="247" />
+        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="247" />
         <source>Edit Category</source>
         <translation>Edit Category</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="251" />
+        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="265" />
+        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="265" />
         <source>Delete Category</source>
         <translation>Delete Category</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="256" />
+        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="270" />
+        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="270" />
         <source>Delete %1 category</source>
         <translation>Delete %1 category</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="257" />
+        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="271" />
+        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="271" />
         <source>Are you sure you want to delete %1 category? Channels inside the category won&#8217;t be deleted.</source>
         <translation>Are you sure you want to delete %1 category? Channels inside the category won&#8217;t be deleted.</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="466" />
+        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="486" />
+        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="486" />
         <source>Create channel or category</source>
         <translation>Create channel or category</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="555" />
+        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="575" />
+        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="575" />
         <source>Error deleting the category</source>
         <translation>Error deleting the category</translation>
     </message>
@@ -2169,10 +2600,12 @@ Do you wish to override the security check and continue?</translation>
     <name>CommunityDelegate</name>
     <message>
         <location filename="../app/AppLayouts/Profile/controls/CommunityDelegate.qml" line="9" />
+        <location filename="../app/AppLayouts/Profile/controls/CommunityDelegate.qml" line="9" />
         <source>Admin</source>
         <translation>Admin</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/controls/CommunityDelegate.qml" line="9" />
         <location filename="../app/AppLayouts/Profile/controls/CommunityDelegate.qml" line="9" />
         <source>Member</source>
         <translation>Member</translation>
@@ -2182,15 +2615,18 @@ Do you wish to override the security check and continue?</translation>
     <name>CommunityDescriptionInput</name>
     <message>
         <location filename="../app/AppLayouts/Chat/controls/community/CommunityDescriptionInput.qml" line="15" />
+        <location filename="../app/AppLayouts/Chat/controls/community/CommunityDescriptionInput.qml" line="15" />
         <source>Description</source>
         <translation>Description</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Chat/controls/community/CommunityDescriptionInput.qml" line="18" />
+        <location filename="../app/AppLayouts/Chat/controls/community/CommunityDescriptionInput.qml" line="18" />
         <source>What your community is about</source>
         <translation>What your community is about</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Chat/controls/community/CommunityDescriptionInput.qml" line="26" />
         <location filename="../app/AppLayouts/Chat/controls/community/CommunityDescriptionInput.qml" line="26" />
         <source>community description</source>
         <translation>community description</translation>
@@ -2200,63 +2636,77 @@ Do you wish to override the security check and continue?</translation>
     <name>CommunityDetailPopup</name>
     <message>
         <location filename="../app/AppLayouts/Chat/popups/community/CommunityDetailPopup.qml" line="36" />
+        <location filename="../app/AppLayouts/Chat/popups/community/CommunityDetailPopup.qml" line="36" />
         <source>Public community</source>
         <translation>Public community</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Chat/popups/community/CommunityDetailPopup.qml" line="39" />
         <location filename="../app/AppLayouts/Chat/popups/community/CommunityDetailPopup.qml" line="39" />
         <source>Invitation only community</source>
         <translation>Invitation only community</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Chat/popups/community/CommunityDetailPopup.qml" line="42" />
+        <location filename="../app/AppLayouts/Chat/popups/community/CommunityDetailPopup.qml" line="42" />
         <source>On request community</source>
         <translation>On request community</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Chat/popups/community/CommunityDetailPopup.qml" line="45" />
-        <location filename="../app/AppLayouts/Chat/popups/community/CommunityDetailPopup.qml" line="175" />
+        <location filename="../app/AppLayouts/Chat/popups/community/CommunityDetailPopup.qml" line="174" />
+        <location filename="../app/AppLayouts/Chat/popups/community/CommunityDetailPopup.qml" line="45" />
+        <location filename="../app/AppLayouts/Chat/popups/community/CommunityDetailPopup.qml" line="174" />
         <source>Unknown community</source>
         <translation>Unknown community</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Chat/popups/community/CommunityDetailPopup.qml" line="49" />
         <location filename="../app/AppLayouts/Chat/popups/community/CommunityDetailPopup.qml" line="49" />
         <source> - ENS only</source>
         <translation> - ENS only</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Chat/popups/community/CommunityDetailPopup.qml" line="85" />
+        <location filename="../app/AppLayouts/Chat/popups/community/CommunityDetailPopup.qml" line="85" />
         <source>%1 members</source>
         <translation>%1 members</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Chat/popups/community/CommunityDetailPopup.qml" line="105" />
+        <location filename="../app/AppLayouts/Chat/popups/community/CommunityDetailPopup.qml" line="105" />
         <source>Channels</source>
         <translation>Channels</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/popups/community/CommunityDetailPopup.qml" line="166" />
-        <location filename="../app/AppLayouts/Chat/popups/community/CommunityDetailPopup.qml" line="172" />
+        <location filename="../app/AppLayouts/Chat/popups/community/CommunityDetailPopup.qml" line="165" />
+        <location filename="../app/AppLayouts/Chat/popups/community/CommunityDetailPopup.qml" line="171" />
+        <location filename="../app/AppLayouts/Chat/popups/community/CommunityDetailPopup.qml" line="165" />
+        <location filename="../app/AppLayouts/Chat/popups/community/CommunityDetailPopup.qml" line="171" />
         <source>Join &#8216;%1&#8217;</source>
         <translation>Join &#8216;%1&#8217;</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/popups/community/CommunityDetailPopup.qml" line="169" />
+        <location filename="../app/AppLayouts/Chat/popups/community/CommunityDetailPopup.qml" line="168" />
+        <location filename="../app/AppLayouts/Chat/popups/community/CommunityDetailPopup.qml" line="168" />
         <source>Pending</source>
         <translation>Pending</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/popups/community/CommunityDetailPopup.qml" line="173" />
+        <location filename="../app/AppLayouts/Chat/popups/community/CommunityDetailPopup.qml" line="172" />
+        <location filename="../app/AppLayouts/Chat/popups/community/CommunityDetailPopup.qml" line="172" />
         <source>You need to be invited</source>
         <translation>You need to be invited</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/popups/community/CommunityDetailPopup.qml" line="174" />
+        <location filename="../app/AppLayouts/Chat/popups/community/CommunityDetailPopup.qml" line="173" />
+        <location filename="../app/AppLayouts/Chat/popups/community/CommunityDetailPopup.qml" line="173" />
         <source>Request to join &#8216;%1&#8217;</source>
         <translation>Request to join &#8216;%1&#8217;</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/popups/community/CommunityDetailPopup.qml" line="220" />
+        <location filename="../app/AppLayouts/Chat/popups/community/CommunityDetailPopup.qml" line="219" />
+        <location filename="../app/AppLayouts/Chat/popups/community/CommunityDetailPopup.qml" line="219" />
         <source>Error joining the community</source>
         <translation>Error joining the community</translation>
     </message>
@@ -2264,14 +2714,14 @@ Do you wish to override the security check and continue?</translation>
 <context>
     <name>CommunityIntroDialog</name>
     <message>
-        <location filename="../imports/shared/popups/CommunityIntroDialog.qml" line="23" />
-        <location filename="../imports/shared/popups/CommunityIntroDialog.qml" line="23" />
+        <location filename="../imports/shared/popups/CommunityIntroDialog.qml" line="21" />
+        <location filename="../imports/shared/popups/CommunityIntroDialog.qml" line="21" />
         <source>Welcome to %1</source>
         <translation>Welcome to %1</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/CommunityIntroDialog.qml" line="27" />
-        <location filename="../imports/shared/popups/CommunityIntroDialog.qml" line="27" />
+        <location filename="../imports/shared/popups/CommunityIntroDialog.qml" line="26" />
+        <location filename="../imports/shared/popups/CommunityIntroDialog.qml" line="26" />
         <source>Join %1</source>
         <translation>Join %1</translation>
     </message>
@@ -2292,15 +2742,18 @@ Do you wish to override the security check and continue?</translation>
     <name>CommunityIntroMessageInput</name>
     <message>
         <location filename="../app/AppLayouts/Chat/controls/community/CommunityIntroMessageInput.qml" line="15" />
+        <location filename="../app/AppLayouts/Chat/controls/community/CommunityIntroMessageInput.qml" line="15" />
         <source>Community introduction and rules</source>
         <translation>Community introduction and rules</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Chat/controls/community/CommunityIntroMessageInput.qml" line="21" />
+        <location filename="../app/AppLayouts/Chat/controls/community/CommunityIntroMessageInput.qml" line="21" />
         <source>What new members will read before joining (eg. community rules, welcome message, etc.). Members will need to tick a check box agreeing to these rules before they are allowed to join your community.</source>
         <translation>What new members will read before joining (eg. community rules, welcome message, etc.). Members will need to tick a check box agreeing to these rules before they are allowed to join your community.</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Chat/controls/community/CommunityIntroMessageInput.qml" line="30" />
         <location filename="../app/AppLayouts/Chat/controls/community/CommunityIntroMessageInput.qml" line="30" />
         <source>community intro message</source>
         <translation>community intro message</translation>
@@ -2311,15 +2764,19 @@ Do you wish to override the security check and continue?</translation>
     <message>
         <location filename="../app/AppLayouts/Chat/controls/community/CommunityLogoPicker.qml" line="37" />
         <location filename="../app/AppLayouts/Chat/controls/community/CommunityLogoPicker.qml" line="50" />
+        <location filename="../app/AppLayouts/Chat/controls/community/CommunityLogoPicker.qml" line="37" />
+        <location filename="../app/AppLayouts/Chat/controls/community/CommunityLogoPicker.qml" line="50" />
         <source>Community logo</source>
         <translation>Community logo</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Chat/controls/community/CommunityLogoPicker.qml" line="49" />
+        <location filename="../app/AppLayouts/Chat/controls/community/CommunityLogoPicker.qml" line="49" />
         <source>Choose an image as logo</source>
         <translation>Choose an image as logo</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Chat/controls/community/CommunityLogoPicker.qml" line="51" />
         <location filename="../app/AppLayouts/Chat/controls/community/CommunityLogoPicker.qml" line="51" />
         <source>Make this my Community logo</source>
         <translation>Make this my Community logo</translation>
@@ -2329,40 +2786,48 @@ Do you wish to override the security check and continue?</translation>
     <name>CommunityMembersSettingsPanel</name>
     <message>
         <location filename="../app/AppLayouts/Chat/panels/communities/CommunityMembersSettingsPanel.qml" line="29" />
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityMembersSettingsPanel.qml" line="29" />
         <source>Members</source>
         <translation>Members</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityMembersSettingsPanel.qml" line="41" />
         <location filename="../app/AppLayouts/Chat/panels/communities/CommunityMembersSettingsPanel.qml" line="41" />
         <source>Member name</source>
         <translation>Member name</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Chat/panels/communities/CommunityMembersSettingsPanel.qml" line="50" />
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityMembersSettingsPanel.qml" line="50" />
         <source>Membership requests</source>
         <translation>Membership requests</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityMembersSettingsPanel.qml" line="67" />
         <location filename="../app/AppLayouts/Chat/panels/communities/CommunityMembersSettingsPanel.qml" line="67" />
         <source>Community members will appear here</source>
         <translation>Community members will appear here</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Chat/panels/communities/CommunityMembersSettingsPanel.qml" line="76" />
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityMembersSettingsPanel.qml" line="76" />
         <source>No contacts found</source>
         <translation>No contacts found</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityMembersSettingsPanel.qml" line="105" />
         <location filename="../app/AppLayouts/Chat/panels/communities/CommunityMembersSettingsPanel.qml" line="105" />
         <source>You</source>
         <translation>You</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Chat/panels/communities/CommunityMembersSettingsPanel.qml" line="144" />
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityMembersSettingsPanel.qml" line="144" />
         <source>Ban</source>
         <translation>Ban</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityMembersSettingsPanel.qml" line="153" />
         <location filename="../app/AppLayouts/Chat/panels/communities/CommunityMembersSettingsPanel.qml" line="153" />
         <source>Kick</source>
         <translation>Kick</translation>
@@ -2372,15 +2837,18 @@ Do you wish to override the security check and continue?</translation>
     <name>CommunityNameInput</name>
     <message>
         <location filename="../app/AppLayouts/Chat/controls/community/CommunityNameInput.qml" line="15" />
+        <location filename="../app/AppLayouts/Chat/controls/community/CommunityNameInput.qml" line="15" />
         <source>Community name</source>
         <translation>Community name</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Chat/controls/community/CommunityNameInput.qml" line="17" />
+        <location filename="../app/AppLayouts/Chat/controls/community/CommunityNameInput.qml" line="17" />
         <source>A catchy name</source>
         <translation>A catchy name</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Chat/controls/community/CommunityNameInput.qml" line="22" />
         <location filename="../app/AppLayouts/Chat/controls/community/CommunityNameInput.qml" line="22" />
         <source>community name</source>
         <translation>community name</translation>
@@ -2390,15 +2858,18 @@ Do you wish to override the security check and continue?</translation>
     <name>CommunityOptions</name>
     <message>
         <location filename="../app/AppLayouts/Chat/controls/community/CommunityOptions.qml" line="31" />
+        <location filename="../app/AppLayouts/Chat/controls/community/CommunityOptions.qml" line="31" />
         <source>Community history service</source>
         <translation>Community history service</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Chat/controls/community/CommunityOptions.qml" line="48" />
+        <location filename="../app/AppLayouts/Chat/controls/community/CommunityOptions.qml" line="48" />
         <source>Request to join required</source>
         <translation>Request to join required</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Chat/controls/community/CommunityOptions.qml" line="65" />
         <location filename="../app/AppLayouts/Chat/controls/community/CommunityOptions.qml" line="65" />
         <source>Any member can pin a message</source>
         <translation>Any member can pin a message</translation>
@@ -2408,15 +2879,18 @@ Do you wish to override the security check and continue?</translation>
     <name>CommunityOutroMessageInput</name>
     <message>
         <location filename="../app/AppLayouts/Chat/controls/community/CommunityOutroMessageInput.qml" line="15" />
+        <location filename="../app/AppLayouts/Chat/controls/community/CommunityOutroMessageInput.qml" line="15" />
         <source>Leaving community message</source>
         <translation>Leaving community message</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Chat/controls/community/CommunityOutroMessageInput.qml" line="18" />
+        <location filename="../app/AppLayouts/Chat/controls/community/CommunityOutroMessageInput.qml" line="18" />
         <source>The message a member will see when they leave your community</source>
         <translation>The message a member will see when they leave your community</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Chat/controls/community/CommunityOutroMessageInput.qml" line="25" />
         <location filename="../app/AppLayouts/Chat/controls/community/CommunityOutroMessageInput.qml" line="25" />
         <source>community intro message</source>
         <translation>community intro message</translation>
@@ -2427,10 +2901,14 @@ Do you wish to override the security check and continue?</translation>
     <message>
         <location filename="../app/AppLayouts/Chat/panels/communities/CommunityOverviewSettingsPanel.qml" line="45" />
         <location filename="../app/AppLayouts/Chat/panels/communities/CommunityOverviewSettingsPanel.qml" line="166" />
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityOverviewSettingsPanel.qml" line="45" />
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityOverviewSettingsPanel.qml" line="166" />
         <source>Overview</source>
         <translation>Overview</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityOverviewSettingsPanel.qml" line="97" />
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityOverviewSettingsPanel.qml" line="167" />
         <location filename="../app/AppLayouts/Chat/panels/communities/CommunityOverviewSettingsPanel.qml" line="97" />
         <location filename="../app/AppLayouts/Chat/panels/communities/CommunityOverviewSettingsPanel.qml" line="167" />
         <source>Edit Community</source>
@@ -2438,35 +2916,42 @@ Do you wish to override the security check and continue?</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Chat/panels/communities/CommunityOverviewSettingsPanel.qml" line="121" />
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityOverviewSettingsPanel.qml" line="121" />
         <source>This node is the Community Owner Node. For your Community to function correctly try to keep this computer with Status running and onlinie as much as possible.</source>
         <translation>This node is the Community Owner Node. For your Community to function correctly try to keep this computer with Status running and onlinie as much as possible.</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityOverviewSettingsPanel.qml" line="134" />
         <location filename="../app/AppLayouts/Chat/panels/communities/CommunityOverviewSettingsPanel.qml" line="134" />
         <source>Welcome to your community!</source>
         <translation>Welcome to your community!</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Chat/panels/communities/CommunityOverviewSettingsPanel.qml" line="135" />
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityOverviewSettingsPanel.qml" line="135" />
         <source>Invite new people</source>
         <translation>Invite new people</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityOverviewSettingsPanel.qml" line="143" />
         <location filename="../app/AppLayouts/Chat/panels/communities/CommunityOverviewSettingsPanel.qml" line="143" />
         <source>Try an airdrop to reward your community for engagement!</source>
         <translation>Try an airdrop to reward your community for engagement!</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Chat/panels/communities/CommunityOverviewSettingsPanel.qml" line="144" />
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityOverviewSettingsPanel.qml" line="144" />
         <source>Airdrop Tokens</source>
         <translation>Airdrop Tokens</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Chat/panels/communities/CommunityOverviewSettingsPanel.qml" line="154" />
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityOverviewSettingsPanel.qml" line="154" />
         <source>Back up community key</source>
         <translation>Back up community key</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityOverviewSettingsPanel.qml" line="155" />
         <location filename="../app/AppLayouts/Chat/panels/communities/CommunityOverviewSettingsPanel.qml" line="155" />
         <source>Back up</source>
         <translation>Back up</translation>
@@ -2476,30 +2961,36 @@ Do you wish to override the security check and continue?</translation>
     <name>CommunityProfilePopup</name>
     <message>
         <location filename="../app/AppLayouts/Chat/popups/community/CommunityProfilePopup.qml" line="52" />
+        <location filename="../app/AppLayouts/Chat/popups/community/CommunityProfilePopup.qml" line="52" />
         <source>Public community</source>
         <translation>Public community</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Chat/popups/community/CommunityProfilePopup.qml" line="53" />
         <location filename="../app/AppLayouts/Chat/popups/community/CommunityProfilePopup.qml" line="53" />
         <source>Invitation only community</source>
         <translation>Invitation only community</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Chat/popups/community/CommunityProfilePopup.qml" line="54" />
+        <location filename="../app/AppLayouts/Chat/popups/community/CommunityProfilePopup.qml" line="54" />
         <source>On request community</source>
         <translation>On request community</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Chat/popups/community/CommunityProfilePopup.qml" line="55" />
         <location filename="../app/AppLayouts/Chat/popups/community/CommunityProfilePopup.qml" line="55" />
         <source>Unknown community</source>
         <translation>Unknown community</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Chat/popups/community/CommunityProfilePopup.qml" line="89" />
+        <location filename="../app/AppLayouts/Chat/popups/community/CommunityProfilePopup.qml" line="89" />
         <source>Invite friends</source>
         <translation>Invite friends</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Chat/popups/community/CommunityProfilePopup.qml" line="121" />
         <location filename="../app/AppLayouts/Chat/popups/community/CommunityProfilePopup.qml" line="121" />
         <source>Invite</source>
         <translation>Invite</translation>
@@ -2509,15 +3000,18 @@ Do you wish to override the security check and continue?</translation>
     <name>CommunityProfilePopupInviteFriendsPanel</name>
     <message>
         <location filename="../app/AppLayouts/Chat/panels/communities/CommunityProfilePopupInviteFriendsPanel.qml" line="26" />
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityProfilePopupInviteFriendsPanel.qml" line="26" />
         <source>Share community</source>
         <translation>Share community</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Chat/panels/communities/CommunityProfilePopupInviteFriendsPanel.qml" line="28" />
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityProfilePopupInviteFriendsPanel.qml" line="28" />
         <source>Copied!</source>
         <translation>Copied!</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityProfilePopupInviteFriendsPanel.qml" line="44" />
         <location filename="../app/AppLayouts/Chat/panels/communities/CommunityProfilePopupInviteFriendsPanel.qml" line="44" />
         <source>Contacts</source>
         <translation>Contacts</translation>
@@ -2527,20 +3021,24 @@ Do you wish to override the security check and continue?</translation>
     <name>CommunityProfilePopupOverviewPanel</name>
     <message>
         <location filename="../app/AppLayouts/Chat/panels/communities/CommunityProfilePopupOverviewPanel.qml" line="48" />
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityProfilePopupOverviewPanel.qml" line="48" />
         <source>Share community</source>
         <translation>Share community</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityProfilePopupOverviewPanel.qml" line="50" />
         <location filename="../app/AppLayouts/Chat/panels/communities/CommunityProfilePopupOverviewPanel.qml" line="50" />
         <source>Copied!</source>
         <translation>Copied!</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Chat/panels/communities/CommunityProfilePopupOverviewPanel.qml" line="68" />
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityProfilePopupOverviewPanel.qml" line="68" />
         <source>Transfer ownership</source>
         <translation>Transfer ownership</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityProfilePopupOverviewPanel.qml" line="76" />
         <location filename="../app/AppLayouts/Chat/panels/communities/CommunityProfilePopupOverviewPanel.qml" line="76" />
         <source>Leave community</source>
         <translation>Leave community</translation>
@@ -2550,30 +3048,36 @@ Do you wish to override the security check and continue?</translation>
     <name>CommunitySettingsView</name>
     <message>
         <location filename="../app/AppLayouts/Chat/views/CommunitySettingsView.qml" line="27" />
+        <location filename="../app/AppLayouts/Chat/views/CommunitySettingsView.qml" line="27" />
         <source>Overview</source>
         <translation>Overview</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Chat/views/CommunitySettingsView.qml" line="28" />
         <location filename="../app/AppLayouts/Chat/views/CommunitySettingsView.qml" line="28" />
         <source>Members</source>
         <translation>Members</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Chat/views/CommunitySettingsView.qml" line="68" />
+        <location filename="../app/AppLayouts/Chat/views/CommunitySettingsView.qml" line="68" />
         <source>Settings</source>
         <translation>Settings</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Chat/views/CommunitySettingsView.qml" line="94" />
         <location filename="../app/AppLayouts/Chat/views/CommunitySettingsView.qml" line="94" />
         <source>Open legacy popup (to be removed)</source>
         <translation>Open legacy popup (to be removed)</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Chat/views/CommunitySettingsView.qml" line="108" />
+        <location filename="../app/AppLayouts/Chat/views/CommunitySettingsView.qml" line="108" />
         <source>Back to community</source>
         <translation>Back to community</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Chat/views/CommunitySettingsView.qml" line="207" />
         <location filename="../app/AppLayouts/Chat/views/CommunitySettingsView.qml" line="207" />
         <source>Error editing the community</source>
         <translation>Error editing the community</translation>
@@ -2583,25 +3087,30 @@ Do you wish to override the security check and continue?</translation>
     <name>CommunityTagsPanel</name>
     <message>
         <location filename="../app/AppLayouts/CommunitiesPortal/panels/CommunityTagsPanel.qml" line="20" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/panels/CommunityTagsPanel.qml" line="20" />
         <source>Community Tags</source>
         <translation>Community Tags</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/CommunitiesPortal/panels/CommunityTagsPanel.qml" line="23" />
         <location filename="../app/AppLayouts/CommunitiesPortal/panels/CommunityTagsPanel.qml" line="23" />
         <source>Confirm Community Tags</source>
         <translation>Confirm Community Tags</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/CommunitiesPortal/panels/CommunityTagsPanel.qml" line="85" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/panels/CommunityTagsPanel.qml" line="85" />
         <source>Select tags that will fit your Community</source>
         <translation>Select tags that will fit your Community</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/CommunitiesPortal/panels/CommunityTagsPanel.qml" line="87" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/panels/CommunityTagsPanel.qml" line="87" />
         <source>Search tags</source>
         <translation>Search tags</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/CommunitiesPortal/panels/CommunityTagsPanel.qml" line="108" />
         <location filename="../app/AppLayouts/CommunitiesPortal/panels/CommunityTagsPanel.qml" line="108" />
         <source>Selected tags</source>
         <translation>Selected tags</translation>
@@ -2611,6 +3120,7 @@ Do you wish to override the security check and continue?</translation>
     <name>CommunityTagsPicker</name>
     <message>
         <location filename="../app/AppLayouts/CommunitiesPortal/controls/CommunityTagsPicker.qml" line="41" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/controls/CommunityTagsPicker.qml" line="41" />
         <source>Tags</source>
         <translation>Tags</translation>
     </message>
@@ -2619,15 +3129,18 @@ Do you wish to override the security check and continue?</translation>
     <name>CommunityWelcomeBannerPanel</name>
     <message>
         <location filename="../app/AppLayouts/Chat/panels/communities/CommunityWelcomeBannerPanel.qml" line="84" />
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityWelcomeBannerPanel.qml" line="84" />
         <source>Welcome to your community!</source>
         <translation>Welcome to your community!</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Chat/panels/communities/CommunityWelcomeBannerPanel.qml" line="99" />
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityWelcomeBannerPanel.qml" line="99" />
         <source>Add members</source>
         <translation>Add members</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityWelcomeBannerPanel.qml" line="112" />
         <location filename="../app/AppLayouts/Chat/panels/communities/CommunityWelcomeBannerPanel.qml" line="112" />
         <source>Manage community</source>
         <translation>Manage community</translation>
@@ -2636,18 +3149,22 @@ Do you wish to override the security check and continue?</translation>
 <context>
     <name>CompactMessageView</name>
     <message>
-        <location filename="../imports/shared/views/chat/CompactMessageView.qml" line="284" />
-        <location filename="../imports/shared/views/chat/CompactMessageView.qml" line="422" />
+        <location filename="../imports/shared/views/chat/CompactMessageView.qml" line="286" />
+        <location filename="../imports/shared/views/chat/CompactMessageView.qml" line="434" />
+        <location filename="../imports/shared/views/chat/CompactMessageView.qml" line="286" />
+        <location filename="../imports/shared/views/chat/CompactMessageView.qml" line="434" />
         <source>Pinned by %1</source>
         <translation>Pinned by %1</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/chat/CompactMessageView.qml" line="483" />
+        <location filename="../imports/shared/views/chat/CompactMessageView.qml" line="495" />
+        <location filename="../imports/shared/views/chat/CompactMessageView.qml" line="495" />
         <source>Cancel</source>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/chat/CompactMessageView.qml" line="496" />
+        <location filename="../imports/shared/views/chat/CompactMessageView.qml" line="508" />
+        <location filename="../imports/shared/views/chat/CompactMessageView.qml" line="508" />
         <source>Save</source>
         <translation>Save</translation>
     </message>
@@ -2656,23 +3173,39 @@ Do you wish to override the security check and continue?</translation>
     <name>ConfirmAddExistingKeyModal</name>
     <message>
         <location filename="../app/AppLayouts/Onboarding/popups/ConfirmAddExistingKeyModal.qml" line="14" />
+        <location filename="../app/AppLayouts/Onboarding/popups/ConfirmAddExistingKeyModal.qml" line="14" />
         <source>Enter seed phrase</source>
         <translation>Enter seed phrase</translation>
+    </message>
+    <message>
+        <location filename="../app/AppLayouts/Onboarding/popups/ConfirmAddExistingKeyModal.qml" line="19" />
+        <location filename="../app/AppLayouts/Onboarding/popups/ConfirmAddExistingKeyModal.qml" line="19" />
+        <source>Do you want to add another existing key?</source>
+        <translation>Do you want to add another existing key?</translation>
+    </message>
+    <message>
+        <location filename="../app/AppLayouts/Onboarding/popups/ConfirmAddExistingKeyModal.qml" line="29" />
+        <location filename="../app/AppLayouts/Onboarding/popups/ConfirmAddExistingKeyModal.qml" line="29" />
+        <source>Add another existing key</source>
+        <translation type="unfinished">Add another existing key</translation>
     </message>
 </context>
 <context>
     <name>ConfirmAppRestartModal</name>
     <message>
         <location filename="../app/AppLayouts/Profile/popups/ConfirmAppRestartModal.qml" line="20" />
+        <location filename="../app/AppLayouts/Profile/popups/ConfirmAppRestartModal.qml" line="20" />
         <source>Application Restart</source>
         <translation>Application Restart</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/popups/ConfirmAppRestartModal.qml" line="23" />
+        <location filename="../app/AppLayouts/Profile/popups/ConfirmAppRestartModal.qml" line="23" />
         <source>Please restart the application to apply the changes.</source>
         <translation>Please restart the application to apply the changes.</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/popups/ConfirmAppRestartModal.qml" line="39" />
         <location filename="../app/AppLayouts/Profile/popups/ConfirmAppRestartModal.qml" line="39" />
         <source>Restart</source>
         <translation>Restart</translation>
@@ -2682,45 +3215,58 @@ Do you wish to override the security check and continue?</translation>
     <name>ConfirmPasswordView</name>
     <message>
         <location filename="../app/AppLayouts/Onboarding/views/ConfirmPasswordView.qml" line="31" />
+        <location filename="../app/AppLayouts/Onboarding/views/ConfirmPasswordView.qml" line="31" />
         <source>Passwords don't match</source>
         <translation>Passwords don't match</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Onboarding/views/ConfirmPasswordView.qml" line="69" />
         <location filename="../app/AppLayouts/Onboarding/views/ConfirmPasswordView.qml" line="69" />
         <source>Have you written down your password?</source>
         <translation>Have you written down your password?</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Onboarding/views/ConfirmPasswordView.qml" line="81" />
+        <location filename="../app/AppLayouts/Onboarding/views/ConfirmPasswordView.qml" line="81" />
         <source>You will never be able to recover your password if you lose it.</source>
         <translation>You will never be able to recover your password if you lose it.</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Onboarding/views/ConfirmPasswordView.qml" line="88" />
         <location filename="../app/AppLayouts/Onboarding/views/ConfirmPasswordView.qml" line="88" />
         <source>If you need to, write it using pen and paper and keep in a safe place.</source>
         <translation>If you need to, write it using pen and paper and keep in a safe place.</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Onboarding/views/ConfirmPasswordView.qml" line="95" />
+        <location filename="../app/AppLayouts/Onboarding/views/ConfirmPasswordView.qml" line="95" />
         <source>If you lose your password you will lose access to your Status profile.</source>
         <translation>If you lose your password you will lose access to your Status profile.</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Onboarding/views/ConfirmPasswordView.qml" line="114" />
-        <source>Confirm you password (again)</source>
-        <translation>Confirm you password (again)</translation>
+        <location filename="../app/AppLayouts/Onboarding/views/ConfirmPasswordView.qml" line="114" />
+        <source>Confirm your password (again)</source>
+        <translation>Confirm your password (again)</translation>
     </message>
     <message>
+        <source>Confirm you password (again)</source>
+        <translation type="vanished">Confirm you password (again)</translation>
+    </message>
+    <message>
+        <location filename="../app/AppLayouts/Onboarding/views/ConfirmPasswordView.qml" line="158" />
         <location filename="../app/AppLayouts/Onboarding/views/ConfirmPasswordView.qml" line="158" />
         <source>Finalise Status Password Creation</source>
         <translation>Finalise Status Password Creation</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Onboarding/views/ConfirmPasswordView.qml" line="177" />
+        <location filename="../app/AppLayouts/Onboarding/views/ConfirmPasswordView.qml" line="177" />
         <source>Keys for this account already exist</source>
         <translation>Keys for this account already exist</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Onboarding/views/ConfirmPasswordView.qml" line="178" />
         <location filename="../app/AppLayouts/Onboarding/views/ConfirmPasswordView.qml" line="178" />
         <source>Keys for this account already exist and can't be added again. If you've lost your password, passcode or Keycard, uninstall the app, reinstall and access your keys by entering your seed phrase</source>
         <translation>Keys for this account already exist and can't be added again. If you've lost your password, passcode or Keycard, uninstall the app, reinstall and access your keys by entering your seed phrase</translation>
@@ -2728,10 +3274,14 @@ Do you wish to override the security check and continue?</translation>
     <message>
         <location filename="../app/AppLayouts/Onboarding/views/ConfirmPasswordView.qml" line="180" />
         <location filename="../app/AppLayouts/Onboarding/views/ConfirmPasswordView.qml" line="189" />
+        <location filename="../app/AppLayouts/Onboarding/views/ConfirmPasswordView.qml" line="180" />
+        <location filename="../app/AppLayouts/Onboarding/views/ConfirmPasswordView.qml" line="189" />
         <source>Login failed</source>
         <translation>Login failed</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Onboarding/views/ConfirmPasswordView.qml" line="181" />
+        <location filename="../app/AppLayouts/Onboarding/views/ConfirmPasswordView.qml" line="190" />
         <location filename="../app/AppLayouts/Onboarding/views/ConfirmPasswordView.qml" line="181" />
         <location filename="../app/AppLayouts/Onboarding/views/ConfirmPasswordView.qml" line="190" />
         <source>Login failed. Please re-enter your password and try again.</source>
@@ -2741,17 +3291,20 @@ Do you wish to override the security check and continue?</translation>
 <context>
     <name>ConfirmSeedPhrasePanel</name>
     <message>
-        <location filename="../app/AppLayouts/Profile/popups/backupseed/ConfirmSeedPhrasePanel.qml" line="14" />
+        <location filename="../app/AppLayouts/Profile/popups/backupseed/ConfirmSeedPhrasePanel.qml" line="17" />
+        <location filename="../app/AppLayouts/Profile/popups/backupseed/ConfirmSeedPhrasePanel.qml" line="17" />
         <source>Write down your 12-word seed phrase to keep offline</source>
         <translation>Write down your 12-word seed phrase to keep offline</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/popups/backupseed/ConfirmSeedPhrasePanel.qml" line="53" />
+        <location filename="../app/AppLayouts/Profile/popups/backupseed/ConfirmSeedPhrasePanel.qml" line="66" />
+        <location filename="../app/AppLayouts/Profile/popups/backupseed/ConfirmSeedPhrasePanel.qml" line="66" />
         <source>Reveal seed phrase</source>
         <translation>Reveal seed phrase</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/popups/backupseed/ConfirmSeedPhrasePanel.qml" line="74" />
+        <location filename="../app/AppLayouts/Profile/popups/backupseed/ConfirmSeedPhrasePanel.qml" line="82" />
+        <location filename="../app/AppLayouts/Profile/popups/backupseed/ConfirmSeedPhrasePanel.qml" line="82" />
         <source>The next screen contains your seed phrase.
 &lt;b&gt;Anyone&lt;/b&gt; who sees it can use it to access to your funds.</source>
         <translation>The next screen contains your seed phrase.
@@ -2761,29 +3314,38 @@ Do you wish to override the security check and continue?</translation>
 <context>
     <name>ConfirmStoringSeedPhrasePanel</name>
     <message>
-        <location filename="../app/AppLayouts/Profile/popups/backupseed/ConfirmStoringSeedPhrasePanel.qml" line="7" />
+        <location filename="../app/AppLayouts/Profile/popups/backupseed/ConfirmStoringSeedPhrasePanel.qml" line="14" />
+        <location filename="../app/AppLayouts/Profile/popups/backupseed/ConfirmStoringSeedPhrasePanel.qml" line="14" />
         <source>Complete back up</source>
         <translation>Complete back up</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/popups/backupseed/ConfirmStoringSeedPhrasePanel.qml" line="20" />
+        <location filename="../app/AppLayouts/Profile/popups/backupseed/ConfirmStoringSeedPhrasePanel.qml" line="30" />
+        <location filename="../app/AppLayouts/Profile/popups/backupseed/ConfirmStoringSeedPhrasePanel.qml" line="30" />
         <source>Store Your Phrase Offline and Complete Your Back Up</source>
         <translation>Store Your Phrase Offline and Complete Your Back Up</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/popups/backupseed/ConfirmStoringSeedPhrasePanel.qml" line="32" />
+        <location filename="../app/AppLayouts/Profile/popups/backupseed/ConfirmStoringSeedPhrasePanel.qml" line="40" />
+        <location filename="../app/AppLayouts/Profile/popups/backupseed/ConfirmStoringSeedPhrasePanel.qml" line="40" />
         <source>By completing this process, you will remove your seed phrase from this application&#8217;s storage. This makes your funds more secure.</source>
         <translation>By completing this process, you will remove your seed phrase from this application&#8217;s storage. This makes your funds more secure.</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/popups/backupseed/ConfirmStoringSeedPhrasePanel.qml" line="44" />
+        <location filename="../app/AppLayouts/Profile/popups/backupseed/ConfirmStoringSeedPhrasePanel.qml" line="50" />
+        <location filename="../app/AppLayouts/Profile/popups/backupseed/ConfirmStoringSeedPhrasePanel.qml" line="50" />
         <source>You will remain logged in, and your seed phrase will be entirely in your hands.</source>
         <translation>You will remain logged in, and your seed phrase will be entirely in your hands.</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/popups/backupseed/ConfirmStoringSeedPhrasePanel.qml" line="52" />
+        <location filename="../app/AppLayouts/Profile/popups/backupseed/ConfirmStoringSeedPhrasePanel.qml" line="58" />
+        <location filename="../app/AppLayouts/Profile/popups/backupseed/ConfirmStoringSeedPhrasePanel.qml" line="58" />
+        <source>I acknowledge that Status will not be able to show me my seed phrase again.</source>
+        <translation>I acknowledge that Status will not be able to show me my seed phrase again.</translation>
+    </message>
+    <message>
         <source>I aknowledge that Status will not be able to show me my seed phrase again.</source>
-        <translation>I aknowledge that Status will not be able to show me my seed phrase again.</translation>
+        <translation type="vanished">I aknowledge that Status will not be able to show me my seed phrase again.</translation>
     </message>
 </context>
 <context>
@@ -2828,77 +3390,92 @@ Do you wish to override the security check and continue?</translation>
 <context>
     <name>Constants</name>
     <message>
-        <location filename="../imports/utils/Constants.qml" line="124" />
+        <location filename="../imports/utils/Constants.qml" line="133" />
+        <location filename="../imports/utils/Constants.qml" line="133" />
         <source>Username must be at least 5 characters</source>
         <translation>Username must be at least 5 characters</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Constants.qml" line="128" />
+        <location filename="../imports/utils/Constants.qml" line="137" />
+        <location filename="../imports/utils/Constants.qml" line="137" />
         <source>Only letters, numbers, underscores and hyphens allowed</source>
         <translation>Only letters, numbers, underscores and hyphens allowed</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Constants.qml" line="134" />
+        <location filename="../imports/utils/Constants.qml" line="143" />
+        <location filename="../imports/utils/Constants.qml" line="143" />
         <source>24 character username limit</source>
         <translation>24 character username limit</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Constants.qml" line="139" />
+        <location filename="../imports/utils/Constants.qml" line="148" />
+        <location filename="../imports/utils/Constants.qml" line="148" />
         <source>Usernames ending with '-eth' are not allowed</source>
         <translation>Usernames ending with '-eth' are not allowed</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Constants.qml" line="144" />
+        <location filename="../imports/utils/Constants.qml" line="153" />
+        <location filename="../imports/utils/Constants.qml" line="153" />
         <source>Usernames ending with '_eth' are not allowed</source>
         <translation>Usernames ending with '_eth' are not allowed</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Constants.qml" line="149" />
+        <location filename="../imports/utils/Constants.qml" line="158" />
+        <location filename="../imports/utils/Constants.qml" line="158" />
         <source>Usernames ending with '.eth' are not allowed</source>
         <translation>Usernames ending with '.eth' are not allowed</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Constants.qml" line="154" />
+        <location filename="../imports/utils/Constants.qml" line="163" />
+        <location filename="../imports/utils/Constants.qml" line="163" />
         <source>Sorry, the name you have chosen is not allowed, try picking another username</source>
         <translation>Sorry, the name you have chosen is not allowed, try picking another username</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Constants.qml" line="331" />
+        <location filename="../imports/utils/Constants.qml" line="341" />
+        <location filename="../imports/utils/Constants.qml" line="341" />
         <source>(edited)</source>
         <translation>(edited)</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Constants.qml" line="336" />
+        <location filename="../imports/utils/Constants.qml" line="346" />
+        <location filename="../imports/utils/Constants.qml" line="346" />
         <source>Username already taken :(</source>
         <translation>Username already taken :(</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Constants.qml" line="337" />
+        <location filename="../imports/utils/Constants.qml" line="347" />
+        <location filename="../imports/utils/Constants.qml" line="347" />
         <source>Username doesn&#8217;t belong to you :(</source>
         <translation>Username doesn&#8217;t belong to you :(</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Constants.qml" line="338" />
+        <location filename="../imports/utils/Constants.qml" line="348" />
+        <location filename="../imports/utils/Constants.qml" line="348" />
         <source>Continuing will connect this username with your chat key.</source>
         <translation>Continuing will connect this username with your chat key.</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Constants.qml" line="339" />
+        <location filename="../imports/utils/Constants.qml" line="349" />
+        <location filename="../imports/utils/Constants.qml" line="349" />
         <source>&#10003; Username available!</source>
         <translation>&#10003; Username available!</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Constants.qml" line="340" />
+        <location filename="../imports/utils/Constants.qml" line="350" />
+        <location filename="../imports/utils/Constants.qml" line="350" />
         <source>Username is already connected with your chat key and can be used inside Status.</source>
         <translation>Username is already connected with your chat key and can be used inside Status.</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Constants.qml" line="341" />
+        <location filename="../imports/utils/Constants.qml" line="351" />
+        <location filename="../imports/utils/Constants.qml" line="351" />
         <source>This user name is owned by you and connected with your chat key. Continue to set `Show my ENS username in chats`.</source>
         <translation>This user name is owned by you and connected with your chat key. Continue to set `Show my ENS username in chats`.</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Constants.qml" line="342" />
+        <location filename="../imports/utils/Constants.qml" line="352" />
+        <location filename="../imports/utils/Constants.qml" line="352" />
         <source>Continuing will require a transaction to connect the username with your current chat key.</source>
         <translation>Continuing will require a transaction to connect the username with your current chat key.</translation>
     </message>
@@ -2907,6 +3484,7 @@ Do you wish to override the security check and continue?</translation>
     <name>Contact</name>
     <message>
         <location filename="../app/AppLayouts/Chat/controls/Contact.qml" line="82" />
+        <location filename="../app/AppLayouts/Chat/controls/Contact.qml" line="82" />
         <source>Admin</source>
         <translation>Admin</translation>
     </message>
@@ -2914,7 +3492,20 @@ Do you wish to override the security check and continue?</translation>
 <context>
     <name>ContactPanel</name>
     <message>
-        <location filename="../app/AppLayouts/Profile/panels/ContactPanel.qml" line="152" />
+        <location filename="../app/AppLayouts/Profile/panels/ContactPanel.qml" line="61" />
+        <location filename="../app/AppLayouts/Profile/panels/ContactPanel.qml" line="61" />
+        <source>Respond to ID Request</source>
+        <translation>Respond to ID Request</translation>
+    </message>
+    <message>
+        <location filename="../app/AppLayouts/Profile/panels/ContactPanel.qml" line="62" />
+        <location filename="../app/AppLayouts/Profile/panels/ContactPanel.qml" line="62" />
+        <source>See ID Request</source>
+        <translation>See ID Request</translation>
+    </message>
+    <message>
+        <location filename="../app/AppLayouts/Profile/panels/ContactPanel.qml" line="165" />
+        <location filename="../app/AppLayouts/Profile/panels/ContactPanel.qml" line="165" />
         <source>Rename</source>
         <translation>Rename</translation>
     </message>
@@ -2923,35 +3514,42 @@ Do you wish to override the security check and continue?</translation>
     <name>ContactRequestsPopup</name>
     <message>
         <location filename="../app/AppLayouts/Chat/popups/ContactRequestsPopup.qml" line="20" />
+        <location filename="../app/AppLayouts/Chat/popups/ContactRequestsPopup.qml" line="20" />
         <source>Contact requests</source>
         <translation>Contact requests</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Chat/popups/ContactRequestsPopup.qml" line="68" />
         <location filename="../app/AppLayouts/Chat/popups/ContactRequestsPopup.qml" line="68" />
         <source>Decline all contacts</source>
         <translation>Decline all contacts</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Chat/popups/ContactRequestsPopup.qml" line="69" />
+        <location filename="../app/AppLayouts/Chat/popups/ContactRequestsPopup.qml" line="69" />
         <source>Are you sure you want to decline all these contact requests</source>
         <translation>Are you sure you want to decline all these contact requests</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Chat/popups/ContactRequestsPopup.qml" line="79" />
         <location filename="../app/AppLayouts/Chat/popups/ContactRequestsPopup.qml" line="79" />
         <source>Accept all contacts</source>
         <translation>Accept all contacts</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Chat/popups/ContactRequestsPopup.qml" line="80" />
+        <location filename="../app/AppLayouts/Chat/popups/ContactRequestsPopup.qml" line="80" />
         <source>Are you sure you want to accept all these contact requests</source>
         <translation>Are you sure you want to accept all these contact requests</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Chat/popups/ContactRequestsPopup.qml" line="95" />
+        <location filename="../app/AppLayouts/Chat/popups/ContactRequestsPopup.qml" line="95" />
         <source>Decline all</source>
         <translation>Decline all</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Chat/popups/ContactRequestsPopup.qml" line="103" />
         <location filename="../app/AppLayouts/Chat/popups/ContactRequestsPopup.qml" line="103" />
         <source>Accept all</source>
         <translation>Accept all</translation>
@@ -2978,52 +3576,110 @@ Do you wish to override the security check and continue?</translation>
         <translation>Contact does not have an ENS address. Please send a transaction in chat.</translation>
     </message>
     <message>
-        <location filename="../imports/shared/controls/ContactSelector.qml" line="74" />
-        <location filename="../imports/shared/controls/ContactSelector.qml" line="74" />
+        <location filename="../imports/shared/controls/ContactSelector.qml" line="73" />
+        <location filename="../imports/shared/controls/ContactSelector.qml" line="73" />
         <source>No contact selected</source>
         <translation>No contact selected</translation>
     </message>
     <message>
-        <location filename="../imports/shared/controls/ContactSelector.qml" line="122" />
-        <location filename="../imports/shared/controls/ContactSelector.qml" line="122" />
+        <location filename="../imports/shared/controls/ContactSelector.qml" line="121" />
+        <location filename="../imports/shared/controls/ContactSelector.qml" line="121" />
         <source>You don&#8217;t have any contacts yet</source>
         <translation>You don&#8217;t have any contacts yet</translation>
     </message>
 </context>
 <context>
+    <name>ContactVerificationRequestPopup</name>
+    <message>
+        <location filename="../imports/shared/popups/ContactVerificationRequestPopup.qml" line="29" />
+        <location filename="../imports/shared/popups/ContactVerificationRequestPopup.qml" line="29" />
+        <source>%1 is asking you to verify your identity</source>
+        <translation>%1 is asking you to verify your identity</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/popups/ContactVerificationRequestPopup.qml" line="57" />
+        <location filename="../imports/shared/popups/ContactVerificationRequestPopup.qml" line="57" />
+        <source>%1 would like to verify your identity. Answer the question to prove your identity to %2</source>
+        <translation>%1 would like to verify your identity. Answer the question to prove your identity to %2</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/popups/ContactVerificationRequestPopup.qml" line="82" />
+        <location filename="../imports/shared/popups/ContactVerificationRequestPopup.qml" line="82" />
+        <source>Provide answer to verification request from this contact.</source>
+        <translation>Provide answer to verification request from this contact.</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/popups/ContactVerificationRequestPopup.qml" line="113" />
+        <location filename="../imports/shared/popups/ContactVerificationRequestPopup.qml" line="113" />
+        <source>Your answer has been sent to %1.</source>
+        <translation>Your answer has been sent to %1.</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/popups/ContactVerificationRequestPopup.qml" line="122" />
+        <location filename="../imports/shared/popups/ContactVerificationRequestPopup.qml" line="122" />
+        <source>Refuse Verification</source>
+        <translation>Refuse Verification</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/popups/ContactVerificationRequestPopup.qml" line="129" />
+        <location filename="../imports/shared/popups/ContactVerificationRequestPopup.qml" line="129" />
+        <source>Send Answer</source>
+        <translation>Send Answer</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/popups/ContactVerificationRequestPopup.qml" line="140" />
+        <location filename="../imports/shared/popups/ContactVerificationRequestPopup.qml" line="140" />
+        <source>Change answer</source>
+        <translation>Change answer</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/popups/ContactVerificationRequestPopup.qml" line="147" />
+        <location filename="../imports/shared/popups/ContactVerificationRequestPopup.qml" line="147" />
+        <source>Close</source>
+        <translation type="unfinished">Close</translation>
+    </message>
+</context>
+<context>
     <name>ContactsColumnView</name>
     <message>
-        <location filename="../app/AppLayouts/Chat/views/ContactsColumnView.qml" line="58" />
+        <location filename="../app/AppLayouts/Chat/views/ContactsColumnView.qml" line="55" />
+        <location filename="../app/AppLayouts/Chat/views/ContactsColumnView.qml" line="55" />
         <source>Chat</source>
         <translation>Chat</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/views/ContactsColumnView.qml" line="75" />
+        <location filename="../app/AppLayouts/Chat/views/ContactsColumnView.qml" line="112" />
+        <location filename="../app/AppLayouts/Chat/views/ContactsColumnView.qml" line="112" />
         <source>Search</source>
         <translation>Search</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/views/ContactsColumnView.qml" line="96" />
+        <location filename="../app/AppLayouts/Chat/views/ContactsColumnView.qml" line="75" />
+        <location filename="../app/AppLayouts/Chat/views/ContactsColumnView.qml" line="75" />
         <source>Join public chats</source>
         <translation>Join public chats</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/views/ContactsColumnView.qml" line="116" />
+        <location filename="../app/AppLayouts/Chat/views/ContactsColumnView.qml" line="99" />
+        <location filename="../app/AppLayouts/Chat/views/ContactsColumnView.qml" line="99" />
         <source>Start chat</source>
         <translation>Start chat</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/views/ContactsColumnView.qml" line="135" />
+        <location filename="../app/AppLayouts/Chat/views/ContactsColumnView.qml" line="134" />
+        <location filename="../app/AppLayouts/Chat/views/ContactsColumnView.qml" line="134" />
         <source>Contact requests</source>
         <translation>Contact requests</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/views/ContactsColumnView.qml" line="337" />
+        <location filename="../app/AppLayouts/Chat/views/ContactsColumnView.qml" line="332" />
+        <location filename="../app/AppLayouts/Chat/views/ContactsColumnView.qml" line="332" />
         <source>Community imported</source>
         <translation>Community imported</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/views/ContactsColumnView.qml" line="341" />
+        <location filename="../app/AppLayouts/Chat/views/ContactsColumnView.qml" line="336" />
+        <location filename="../app/AppLayouts/Chat/views/ContactsColumnView.qml" line="336" />
         <source>Importing community is in progress</source>
         <translation>Importing community is in progress</translation>
     </message>
@@ -3054,12 +3710,14 @@ Do you wish to override the security check and continue?</translation>
 <context>
     <name>ContactsListPanel</name>
     <message>
-        <location filename="../app/AppLayouts/Profile/panels/ContactsListPanel.qml" line="145" />
+        <location filename="../app/AppLayouts/Profile/panels/ContactsListPanel.qml" line="147" />
+        <location filename="../app/AppLayouts/Profile/panels/ContactsListPanel.qml" line="147" />
         <source>Contact Request Sent</source>
         <translation>Contact Request Sent</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/panels/ContactsListPanel.qml" line="148" />
+        <location filename="../app/AppLayouts/Profile/panels/ContactsListPanel.qml" line="150" />
+        <location filename="../app/AppLayouts/Profile/panels/ContactsListPanel.qml" line="150" />
         <source>Contact Request Rejected</source>
         <translation>Contact Request Rejected</translation>
     </message>
@@ -3067,58 +3725,70 @@ Do you wish to override the security check and continue?</translation>
 <context>
     <name>ContactsView</name>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/ContactsView.qml" line="34" />
+        <location filename="../app/AppLayouts/Profile/views/ContactsView.qml" line="32" />
+        <location filename="../app/AppLayouts/Profile/views/ContactsView.qml" line="32" />
         <source>Send contact request to chat key</source>
         <translation>Send contact request to chat key</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/ContactsView.qml" line="49" />
+        <location filename="../app/AppLayouts/Profile/views/ContactsView.qml" line="47" />
+        <location filename="../app/AppLayouts/Profile/views/ContactsView.qml" line="47" />
         <source>Search by a display name or chat key</source>
         <translation>Search by a display name or chat key</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/ContactsView.qml" line="62" />
-        <location filename="../app/AppLayouts/Profile/views/ContactsView.qml" line="126" />
+        <location filename="../app/AppLayouts/Profile/views/ContactsView.qml" line="60" />
+        <location filename="../app/AppLayouts/Profile/views/ContactsView.qml" line="124" />
+        <location filename="../app/AppLayouts/Profile/views/ContactsView.qml" line="60" />
+        <location filename="../app/AppLayouts/Profile/views/ContactsView.qml" line="124" />
         <source>Contacts</source>
         <translation>Contacts</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/ContactsView.qml" line="69" />
+        <location filename="../app/AppLayouts/Profile/views/ContactsView.qml" line="67" />
+        <location filename="../app/AppLayouts/Profile/views/ContactsView.qml" line="67" />
         <source>Pending Requests</source>
         <translation>Pending Requests</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/ContactsView.qml" line="84" />
+        <location filename="../app/AppLayouts/Profile/views/ContactsView.qml" line="82" />
+        <location filename="../app/AppLayouts/Profile/views/ContactsView.qml" line="82" />
         <source>Blocked</source>
         <translation>Blocked</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/ContactsView.qml" line="104" />
+        <location filename="../app/AppLayouts/Profile/views/ContactsView.qml" line="102" />
+        <location filename="../app/AppLayouts/Profile/views/ContactsView.qml" line="102" />
         <source>Identity Verified Contacts</source>
         <translation>Identity Verified Contacts</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/ContactsView.qml" line="148" />
+        <location filename="../app/AppLayouts/Profile/views/ContactsView.qml" line="146" />
+        <location filename="../app/AppLayouts/Profile/views/ContactsView.qml" line="146" />
         <source>You don&#8217;t have any contacts yet</source>
         <translation>You don&#8217;t have any contacts yet</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/ContactsView.qml" line="163" />
+        <location filename="../app/AppLayouts/Profile/views/ContactsView.qml" line="161" />
+        <location filename="../app/AppLayouts/Profile/views/ContactsView.qml" line="161" />
         <source>Received</source>
         <translation>Received</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/ContactsView.qml" line="192" />
+        <location filename="../app/AppLayouts/Profile/views/ContactsView.qml" line="207" />
+        <location filename="../app/AppLayouts/Profile/views/ContactsView.qml" line="207" />
         <source>Sent</source>
         <translation>Sent</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/ContactsView.qml" line="297" />
+        <location filename="../app/AppLayouts/Profile/views/ContactsView.qml" line="312" />
+        <location filename="../app/AppLayouts/Profile/views/ContactsView.qml" line="312" />
         <source>Remove contact</source>
         <translation>Remove contact</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/ContactsView.qml" line="298" />
+        <location filename="../app/AppLayouts/Profile/views/ContactsView.qml" line="313" />
+        <location filename="../app/AppLayouts/Profile/views/ContactsView.qml" line="313" />
         <source>Are you sure you want to remove this contact?</source>
         <translation>Are you sure you want to remove this contact?</translation>
     </message>
@@ -3127,50 +3797,60 @@ Do you wish to override the security check and continue?</translation>
     <name>Controls</name>
     <message>
         <location filename="../StatusQ/sandbox/controls/Controls.qml" line="194" />
+        <location filename="../StatusQ/sandbox/controls/Controls.qml" line="194" />
         <source>XS</source>
         <translation>XS</translation>
     </message>
     <message>
+        <location filename="../StatusQ/sandbox/controls/Controls.qml" line="194" />
         <location filename="../StatusQ/sandbox/controls/Controls.qml" line="194" />
         <source>S</source>
         <translation>S</translation>
     </message>
     <message>
         <location filename="../StatusQ/sandbox/controls/Controls.qml" line="194" />
+        <location filename="../StatusQ/sandbox/controls/Controls.qml" line="194" />
         <source>M</source>
         <translation>M</translation>
     </message>
     <message>
+        <location filename="../StatusQ/sandbox/controls/Controls.qml" line="194" />
         <location filename="../StatusQ/sandbox/controls/Controls.qml" line="194" />
         <source>L</source>
         <translation>L</translation>
     </message>
     <message>
         <location filename="../StatusQ/sandbox/controls/Controls.qml" line="194" />
+        <location filename="../StatusQ/sandbox/controls/Controls.qml" line="194" />
         <source>XL</source>
         <translation>XL</translation>
     </message>
     <message>
+        <location filename="../StatusQ/sandbox/controls/Controls.qml" line="194" />
         <location filename="../StatusQ/sandbox/controls/Controls.qml" line="194" />
         <source>XXL</source>
         <translation>XXL</translation>
     </message>
     <message>
         <location filename="../StatusQ/sandbox/controls/Controls.qml" line="199" />
+        <location filename="../StatusQ/sandbox/controls/Controls.qml" line="199" />
         <source>50%</source>
         <translation>50%</translation>
     </message>
     <message>
+        <location filename="../StatusQ/sandbox/controls/Controls.qml" line="199" />
         <location filename="../StatusQ/sandbox/controls/Controls.qml" line="199" />
         <source>100%</source>
         <translation>100%</translation>
     </message>
     <message>
         <location filename="../StatusQ/sandbox/controls/Controls.qml" line="199" />
+        <location filename="../StatusQ/sandbox/controls/Controls.qml" line="199" />
         <source>150%</source>
         <translation>150%</translation>
     </message>
     <message>
+        <location filename="../StatusQ/sandbox/controls/Controls.qml" line="199" />
         <location filename="../StatusQ/sandbox/controls/Controls.qml" line="199" />
         <source>200%</source>
         <translation>200%</translation>
@@ -3189,65 +3869,78 @@ Do you wish to override the security check and continue?</translation>
     <name>CreateCategoryPopup</name>
     <message>
         <location filename="../app/AppLayouts/Chat/popups/community/CreateCategoryPopup.qml" line="45" />
+        <location filename="../app/AppLayouts/Chat/popups/community/CreateCategoryPopup.qml" line="45" />
         <source>Edit category</source>
         <translation>Edit category</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Chat/popups/community/CreateCategoryPopup.qml" line="46" />
         <location filename="../app/AppLayouts/Chat/popups/community/CreateCategoryPopup.qml" line="46" />
         <source>New category</source>
         <translation>New category</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Chat/popups/community/CreateCategoryPopup.qml" line="60" />
+        <location filename="../app/AppLayouts/Chat/popups/community/CreateCategoryPopup.qml" line="60" />
         <source>Category title</source>
         <translation>Category title</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Chat/popups/community/CreateCategoryPopup.qml" line="62" />
         <location filename="../app/AppLayouts/Chat/popups/community/CreateCategoryPopup.qml" line="62" />
         <source>Name the category</source>
         <translation>Name the category</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Chat/popups/community/CreateCategoryPopup.qml" line="65" />
+        <location filename="../app/AppLayouts/Chat/popups/community/CreateCategoryPopup.qml" line="65" />
         <source>category name</source>
         <translation>category name</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Chat/popups/community/CreateCategoryPopup.qml" line="102" />
         <location filename="../app/AppLayouts/Chat/popups/community/CreateCategoryPopup.qml" line="102" />
         <source>Channels</source>
         <translation>Channels</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Chat/popups/community/CreateCategoryPopup.qml" line="166" />
+        <location filename="../app/AppLayouts/Chat/popups/community/CreateCategoryPopup.qml" line="166" />
         <source>Delete category</source>
         <translation>Delete category</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Chat/popups/community/CreateCategoryPopup.qml" line="171" />
         <location filename="../app/AppLayouts/Chat/popups/community/CreateCategoryPopup.qml" line="171" />
         <source>Delete %1 category</source>
         <translation>Delete %1 category</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Chat/popups/community/CreateCategoryPopup.qml" line="172" />
+        <location filename="../app/AppLayouts/Chat/popups/community/CreateCategoryPopup.qml" line="172" />
         <source>Are you sure you want to delete %1 category? Channels inside the category won&#8217;t be deleted.</source>
         <translation>Are you sure you want to delete %1 category? Channels inside the category won&#8217;t be deleted.</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Chat/popups/community/CreateCategoryPopup.qml" line="211" />
         <location filename="../app/AppLayouts/Chat/popups/community/CreateCategoryPopup.qml" line="211" />
         <source>Save</source>
         <translation>Save</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Chat/popups/community/CreateCategoryPopup.qml" line="212" />
+        <location filename="../app/AppLayouts/Chat/popups/community/CreateCategoryPopup.qml" line="212" />
         <source>Create</source>
         <translation>Create</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Chat/popups/community/CreateCategoryPopup.qml" line="239" />
+        <location filename="../app/AppLayouts/Chat/popups/community/CreateCategoryPopup.qml" line="239" />
         <source>Error editing the category</source>
         <translation>Error editing the category</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Chat/popups/community/CreateCategoryPopup.qml" line="240" />
         <location filename="../app/AppLayouts/Chat/popups/community/CreateCategoryPopup.qml" line="240" />
         <source>Error creating the category</source>
         <translation>Error creating the category</translation>
@@ -3257,65 +3950,78 @@ Do you wish to override the security check and continue?</translation>
     <name>CreateChannelPopup</name>
     <message>
         <location filename="../app/AppLayouts/Chat/popups/community/CreateChannelPopup.qml" line="38" />
+        <location filename="../app/AppLayouts/Chat/popups/community/CreateChannelPopup.qml" line="38" />
         <source>New channel</source>
         <translation>New channel</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Chat/popups/community/CreateChannelPopup.qml" line="45" />
         <location filename="../app/AppLayouts/Chat/popups/community/CreateChannelPopup.qml" line="45" />
         <source>Edit #%1</source>
         <translation>Edit #%1</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Chat/popups/community/CreateChannelPopup.qml" line="111" />
+        <location filename="../app/AppLayouts/Chat/popups/community/CreateChannelPopup.qml" line="111" />
         <source>Channel name</source>
         <translation>Channel name</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Chat/popups/community/CreateChannelPopup.qml" line="113" />
         <location filename="../app/AppLayouts/Chat/popups/community/CreateChannelPopup.qml" line="113" />
         <source>Name the channel</source>
         <translation>Name the channel</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Chat/popups/community/CreateChannelPopup.qml" line="141" />
+        <location filename="../app/AppLayouts/Chat/popups/community/CreateChannelPopup.qml" line="141" />
         <source>channel name</source>
         <translation>channel name</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Chat/popups/community/CreateChannelPopup.qml" line="153" />
         <location filename="../app/AppLayouts/Chat/popups/community/CreateChannelPopup.qml" line="153" />
         <source>Channel colour</source>
         <translation>Channel colour</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Chat/popups/community/CreateChannelPopup.qml" line="182" />
+        <location filename="../app/AppLayouts/Chat/popups/community/CreateChannelPopup.qml" line="182" />
         <source>Pick a color</source>
         <translation>Pick a color</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Chat/popups/community/CreateChannelPopup.qml" line="217" />
         <location filename="../app/AppLayouts/Chat/popups/community/CreateChannelPopup.qml" line="217" />
         <source>Description</source>
         <translation>Description</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Chat/popups/community/CreateChannelPopup.qml" line="220" />
+        <location filename="../app/AppLayouts/Chat/popups/community/CreateChannelPopup.qml" line="220" />
         <source>Describe the channel</source>
         <translation>Describe the channel</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Chat/popups/community/CreateChannelPopup.qml" line="226" />
         <location filename="../app/AppLayouts/Chat/popups/community/CreateChannelPopup.qml" line="226" />
         <source>channel description</source>
         <translation>channel description</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Chat/popups/community/CreateChannelPopup.qml" line="291" />
+        <location filename="../app/AppLayouts/Chat/popups/community/CreateChannelPopup.qml" line="291" />
         <source>Save</source>
         <translation>Save</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Chat/popups/community/CreateChannelPopup.qml" line="292" />
+        <location filename="../app/AppLayouts/Chat/popups/community/CreateChannelPopup.qml" line="292" />
         <source>Create</source>
         <translation>Create</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Chat/popups/community/CreateChannelPopup.qml" line="330" />
         <location filename="../app/AppLayouts/Chat/popups/community/CreateChannelPopup.qml" line="330" />
         <source>Error creating the community</source>
         <translation>Error creating the community</translation>
@@ -3324,32 +4030,49 @@ Do you wish to override the security check and continue?</translation>
 <context>
     <name>CreateChatView</name>
     <message>
-        <location filename="../StatusQ/sandbox/demoapp/CreateChatView.qml" line="30" />
-        <location filename="../app/AppLayouts/Chat/views/CreateChatView.qml" line="97" />
+        <location filename="../StatusQ/sandbox/demoapp/CreateChatView.qml" line="31" />
+        <location filename="../app/AppLayouts/Chat/views/CreateChatView.qml" line="98" />
+        <location filename="../StatusQ/sandbox/demoapp/CreateChatView.qml" line="31" />
+        <location filename="../app/AppLayouts/Chat/views/CreateChatView.qml" line="98" />
         <source>To: </source>
         <translation>To: </translation>
     </message>
     <message>
-        <location filename="../StatusQ/sandbox/demoapp/CreateChatView.qml" line="31" />
-        <location filename="../app/AppLayouts/Chat/views/CreateChatView.qml" line="98" />
+        <location filename="../StatusQ/sandbox/demoapp/CreateChatView.qml" line="32" />
+        <location filename="../app/AppLayouts/Chat/views/CreateChatView.qml" line="99" />
+        <location filename="../StatusQ/sandbox/demoapp/CreateChatView.qml" line="32" />
+        <location filename="../app/AppLayouts/Chat/views/CreateChatView.qml" line="99" />
         <source>USER LIMIT REACHED</source>
         <translation>USER LIMIT REACHED</translation>
     </message>
     <message>
-        <location filename="../StatusQ/sandbox/demoapp/CreateChatView.qml" line="32" />
+        <location filename="../StatusQ/sandbox/demoapp/CreateChatView.qml" line="33" />
+        <location filename="../app/AppLayouts/Chat/views/CreateChatView.qml" line="96" />
+        <location filename="../StatusQ/sandbox/demoapp/CreateChatView.qml" line="33" />
         <location filename="../app/AppLayouts/Chat/views/CreateChatView.qml" line="96" />
         <source>Contacts</source>
         <translation>Contacts</translation>
     </message>
     <message>
-        <location filename="../StatusQ/sandbox/demoapp/CreateChatView.qml" line="94" />
+        <location filename="../StatusQ/sandbox/demoapp/CreateChatView.qml" line="112" />
+        <location filename="../app/AppLayouts/Chat/views/CreateChatView.qml" line="192" />
+        <location filename="../StatusQ/sandbox/demoapp/CreateChatView.qml" line="112" />
+        <location filename="../app/AppLayouts/Chat/views/CreateChatView.qml" line="192" />
+        <source>You can only send direct messages to your Contacts.
+
+Send a contact request to the person you would like to chat with, you will be able to chat with them once they have accepted your contact request.</source>
+        <translation>You can only send direct messages to your Contacts.
+
+Send a contact request to the person you would like to chat with, you will be able to chat with them once they have accepted your contact request.</translation>
+    </message>
+    <message>
         <source>You can only send direct messages to your Contacts. 
 
 
 Send a contact request to the person you would like to chat with, you will be
  able to
 chat with them once they have accepted your contact request.</source>
-        <translation>You can only send direct messages to your Contacts. 
+        <translation type="vanished">You can only send direct messages to your Contacts. 
 
 
 Send a contact request to the person you would like to chat with, you will be
@@ -3357,33 +4080,47 @@ Send a contact request to the person you would like to chat with, you will be
 chat with them once they have accepted your contact request.</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/views/CreateChatView.qml" line="190" />
         <source>You can only send direct messages to your Contacts.
 
 
 Send a contact request to the person you would like to chat with, you will be able to
 chat with them once they have accepted your contact request.</source>
-        <translation>You can only send direct messages to your Contacts.
+        <translation type="vanished">You can only send direct messages to your Contacts.
 
 
 Send a contact request to the person you would like to chat with, you will be able to
 chat with them once they have accepted your contact request.</translation>
+    </message>
+    <message>
+        <location filename="../app/AppLayouts/Chat/views/CreateChatView.qml" line="120" />
+        <location filename="../app/AppLayouts/Chat/views/CreateChatView.qml" line="120" />
+        <source>Confirm</source>
+        <translation type="unfinished">Confirm</translation>
     </message>
 </context>
 <context>
     <name>CreateCommunityPopup</name>
     <message>
         <location filename="../app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml" line="28" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml" line="28" />
         <source>Create New Community</source>
         <translation>Create New Community</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml" line="31" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml" line="32" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml" line="32" />
+        <source>Next</source>
+        <translation type="unfinished">Next</translation>
+    </message>
+    <message>
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml" line="38" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml" line="38" />
         <source>Create Community</source>
         <translation>Create Community</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml" line="183" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml" line="186" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml" line="186" />
         <source>Error creating the community</source>
         <translation>Error creating the community</translation>
     </message>
@@ -3393,60 +4130,73 @@ chat with them once they have accepted your contact request.</translation>
     <message>
         <location filename="../app/AppLayouts/Onboarding/shared/CreatePasswordModal.qml" line="29" />
         <location filename="../app/AppLayouts/Onboarding/shared/CreatePasswordModal.qml" line="123" />
+        <location filename="../app/AppLayouts/Onboarding/shared/CreatePasswordModal.qml" line="29" />
+        <location filename="../app/AppLayouts/Onboarding/shared/CreatePasswordModal.qml" line="123" />
         <source>Store password</source>
         <translation>Store password</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Onboarding/shared/CreatePasswordModal.qml" line="30" />
         <location filename="../app/AppLayouts/Onboarding/shared/CreatePasswordModal.qml" line="30" />
         <source>Create a password</source>
         <translation>Create a password</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Onboarding/shared/CreatePasswordModal.qml" line="45" />
+        <location filename="../app/AppLayouts/Onboarding/shared/CreatePasswordModal.qml" line="45" />
         <source>Current password...</source>
         <translation>Current password...</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Onboarding/shared/CreatePasswordModal.qml" line="46" />
         <location filename="../app/AppLayouts/Onboarding/shared/CreatePasswordModal.qml" line="46" />
         <source>New password...</source>
         <translation>New password...</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Onboarding/shared/CreatePasswordModal.qml" line="65" />
+        <location filename="../app/AppLayouts/Onboarding/shared/CreatePasswordModal.qml" line="65" />
         <source>Confirm password&#8230;</source>
         <translation>Confirm password&#8230;</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Onboarding/shared/CreatePasswordModal.qml" line="98" />
         <location filename="../app/AppLayouts/Onboarding/shared/CreatePasswordModal.qml" line="98" />
         <source>At least 6 characters. You will use this password to unlock status on this device &amp; sign transactions.</source>
         <translation>At least 6 characters. You will use this password to unlock status on this device &amp; sign transactions.</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Onboarding/shared/CreatePasswordModal.qml" line="124" />
+        <location filename="../app/AppLayouts/Onboarding/shared/CreatePasswordModal.qml" line="124" />
         <source>Create password</source>
         <translation>Create password</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Onboarding/shared/CreatePasswordModal.qml" line="130" />
         <location filename="../app/AppLayouts/Onboarding/shared/CreatePasswordModal.qml" line="130" />
         <source>Error importing account</source>
         <translation>Error importing account</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Onboarding/shared/CreatePasswordModal.qml" line="131" />
+        <location filename="../app/AppLayouts/Onboarding/shared/CreatePasswordModal.qml" line="131" />
         <source>An error occurred while importing your account: </source>
         <translation>An error occurred while importing your account: </translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Onboarding/shared/CreatePasswordModal.qml" line="141" />
         <location filename="../app/AppLayouts/Onboarding/shared/CreatePasswordModal.qml" line="141" />
         <source>Login failed</source>
         <translation>Login failed</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Onboarding/shared/CreatePasswordModal.qml" line="142" />
+        <location filename="../app/AppLayouts/Onboarding/shared/CreatePasswordModal.qml" line="142" />
         <source>Login failed. Please re-enter your password and try again.</source>
         <translation>Login failed. Please re-enter your password and try again.</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Onboarding/shared/CreatePasswordModal.qml" line="164" />
         <location filename="../app/AppLayouts/Onboarding/shared/CreatePasswordModal.qml" line="164" />
         <source>Incorrect password</source>
         <translation>Incorrect password</translation>
@@ -3456,6 +4206,7 @@ chat with them once they have accepted your contact request.</translation>
     <name>CreatePasswordView</name>
     <message>
         <location filename="../app/AppLayouts/Onboarding/views/CreatePasswordView.qml" line="46" />
+        <location filename="../app/AppLayouts/Onboarding/views/CreatePasswordView.qml" line="46" />
         <source>Create password</source>
         <translation>Create password</translation>
     </message>
@@ -3464,10 +4215,12 @@ chat with them once they have accepted your contact request.</translation>
     <name>CryptoServicesModal</name>
     <message>
         <location filename="../app/AppLayouts/Wallet/popups/CryptoServicesModal.qml" line="19" />
+        <location filename="../app/AppLayouts/Wallet/popups/CryptoServicesModal.qml" line="19" />
         <source>Buy / Sell crypto</source>
         <translation>Buy / Sell crypto</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Wallet/popups/CryptoServicesModal.qml" line="40" />
         <location filename="../app/AppLayouts/Wallet/popups/CryptoServicesModal.qml" line="40" />
         <source>Choose a service you'd like to use to buy crypto</source>
         <translation>Choose a service you'd like to use to buy crypto</translation>
@@ -3477,415 +4230,662 @@ chat with them once they have accepted your contact request.</translation>
     <name>CurrenciesStore</name>
     <message>
         <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="12" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="12" />
         <source>US Dollars</source>
         <translation>US Dollars</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="22" />
         <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="22" />
         <source>British Pound</source>
         <translation>British Pound</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="32" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="32" />
         <source>Euros</source>
         <translation>Euros</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="42" />
         <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="42" />
         <source>Russian ruble</source>
         <translation>Russian ruble</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="52" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="52" />
         <source>South Korean won</source>
         <translation>South Korean won</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="62" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="62" />
         <source>Ethereum</source>
         <translation>Ethereum</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="64" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="74" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="84" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="94" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="64" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="74" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="84" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="94" />
+        <source>Tokens</source>
+        <translation>Tokens</translation>
+    </message>
+    <message>
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="72" />
         <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="72" />
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="82" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="82" />
         <source>Status Network Token</source>
         <translation>Status Network Token</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="92" />
         <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="92" />
         <source>Dai</source>
         <translation>Dai</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="102" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="102" />
         <source>United Arab Emirates dirham</source>
         <translation>United Arab Emirates dirham</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="104" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="114" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="124" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="134" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="144" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="154" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="164" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="174" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="184" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="194" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="204" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="214" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="224" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="234" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="244" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="254" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="264" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="274" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="284" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="294" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="304" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="314" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="324" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="334" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="344" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="354" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="364" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="374" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="384" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="394" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="404" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="414" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="424" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="434" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="444" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="454" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="464" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="474" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="484" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="494" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="504" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="514" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="524" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="534" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="544" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="554" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="564" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="574" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="584" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="594" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="604" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="614" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="624" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="634" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="644" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="654" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="664" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="674" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="684" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="694" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="704" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="714" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="724" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="734" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="744" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="754" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="764" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="774" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="784" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="794" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="804" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="814" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="824" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="834" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="104" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="114" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="124" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="134" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="144" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="154" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="164" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="174" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="184" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="194" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="204" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="214" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="224" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="234" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="244" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="254" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="264" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="274" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="284" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="294" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="304" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="314" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="324" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="334" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="344" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="354" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="364" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="374" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="384" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="394" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="404" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="414" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="424" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="434" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="444" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="454" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="464" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="474" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="484" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="494" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="504" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="514" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="524" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="534" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="544" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="554" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="564" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="574" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="584" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="594" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="604" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="614" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="624" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="634" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="644" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="654" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="664" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="674" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="684" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="694" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="704" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="714" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="724" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="734" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="744" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="754" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="764" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="774" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="784" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="794" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="804" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="814" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="824" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="834" />
+        <source>Other Fiat</source>
+        <translation>Other Fiat</translation>
+    </message>
+    <message>
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="112" />
         <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="112" />
         <source>Afghan afghani</source>
         <translation>Afghan afghani</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="122" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="122" />
         <source>Argentine peso</source>
         <translation>Argentine peso</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="132" />
         <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="132" />
         <source>Australian dollar</source>
         <translation>Australian dollar</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="142" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="142" />
         <source>Barbadian dollar</source>
         <translation>Barbadian dollar</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="152" />
         <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="152" />
         <source>Bangladeshi taka</source>
         <translation>Bangladeshi taka</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="162" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="162" />
         <source>Bulgarian lev</source>
         <translation>Bulgarian lev</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="172" />
         <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="172" />
         <source>Bahraini dinar</source>
         <translation>Bahraini dinar</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="182" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="182" />
         <source>Brunei dollar</source>
         <translation>Brunei dollar</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="192" />
         <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="192" />
         <source>Bolivian boliviano</source>
         <translation>Bolivian boliviano</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="202" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="202" />
         <source>Brazillian real</source>
         <translation>Brazillian real</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="212" />
         <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="212" />
         <source>Bhutanese ngultrum</source>
         <translation>Bhutanese ngultrum</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="222" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="222" />
         <source>Canadian dollar</source>
         <translation>Canadian dollar</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="232" />
         <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="232" />
         <source>Swiss franc</source>
         <translation>Swiss franc</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="242" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="242" />
         <source>Chilean peso</source>
         <translation>Chilean peso</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="252" />
         <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="252" />
         <source>Chinese yuan</source>
         <translation>Chinese yuan</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="262" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="262" />
         <source>Colombian peso</source>
         <translation>Colombian peso</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="272" />
         <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="272" />
         <source>Costa Rican col&#243;n</source>
         <translation>Costa Rican col&#243;n</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="282" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="282" />
         <source>Czech koruna</source>
         <translation>Czech koruna</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="292" />
         <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="292" />
         <source>Danish krone</source>
         <translation>Danish krone</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="302" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="302" />
         <source>Dominican peso</source>
         <translation>Dominican peso</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="312" />
         <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="312" />
         <source>Egyptian pound</source>
         <translation>Egyptian pound</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="322" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="322" />
         <source>Ethiopian birr</source>
         <translation>Ethiopian birr</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="332" />
         <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="332" />
         <source>Georgian lari</source>
         <translation>Georgian lari</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="342" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="342" />
         <source>Ghanaian cedi</source>
         <translation>Ghanaian cedi</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="352" />
         <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="352" />
         <source>Hong Kong dollar</source>
         <translation>Hong Kong dollar</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="362" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="362" />
         <source>Croatian kuna</source>
         <translation>Croatian kuna</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="372" />
         <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="372" />
         <source>Hungarian forint</source>
         <translation>Hungarian forint</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="382" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="382" />
         <source>Indonesian rupiah</source>
         <translation>Indonesian rupiah</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="392" />
         <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="392" />
         <source>Israeli new shekel</source>
         <translation>Israeli new shekel</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="402" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="402" />
         <source>Indian rupee</source>
         <translation>Indian rupee</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="412" />
         <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="412" />
         <source>Icelandic kr&#243;na</source>
         <translation>Icelandic kr&#243;na</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="422" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="422" />
         <source>Jamaican dollar</source>
         <translation>Jamaican dollar</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="432" />
         <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="432" />
         <source>Japanese yen</source>
         <translation>Japanese yen</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="442" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="442" />
         <source>Kenyan shilling</source>
         <translation>Kenyan shilling</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="452" />
         <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="452" />
         <source>Kuwaiti dinar</source>
         <translation>Kuwaiti dinar</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="462" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="462" />
         <source>Kazakhstani tenge</source>
         <translation>Kazakhstani tenge</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="472" />
         <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="472" />
         <source>Sri Lankan rupee</source>
         <translation>Sri Lankan rupee</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="482" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="482" />
         <source>Moroccan dirham</source>
         <translation>Moroccan dirham</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="492" />
         <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="492" />
         <source>Moldovan leu</source>
         <translation>Moldovan leu</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="502" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="502" />
         <source>Mauritian rupee</source>
         <translation>Mauritian rupee</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="512" />
         <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="512" />
         <source>Malawian kwacha</source>
         <translation>Malawian kwacha</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="522" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="522" />
         <source>Mexican peso</source>
         <translation>Mexican peso</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="532" />
         <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="532" />
         <source>Malaysian ringgit</source>
         <translation>Malaysian ringgit</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="542" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="542" />
         <source>Mozambican metical</source>
         <translation>Mozambican metical</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="552" />
         <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="552" />
         <source>Namibian dollar</source>
         <translation>Namibian dollar</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="562" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="562" />
         <source>Nigerian naira</source>
         <translation>Nigerian naira</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="572" />
         <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="572" />
         <source>Norwegian krone</source>
         <translation>Norwegian krone</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="582" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="582" />
         <source>Nepalese rupee</source>
         <translation>Nepalese rupee</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="592" />
         <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="592" />
         <source>New Zealand dollar</source>
         <translation>New Zealand dollar</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="602" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="602" />
         <source>Omani rial</source>
         <translation>Omani rial</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="612" />
         <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="612" />
         <source>Peruvian sol</source>
         <translation>Peruvian sol</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="622" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="622" />
         <source>Papua New Guinean kina</source>
         <translation>Papua New Guinean kina</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="632" />
         <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="632" />
         <source>Philippine peso</source>
         <translation>Philippine peso</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="642" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="642" />
         <source>Pakistani rupee</source>
         <translation>Pakistani rupee</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="652" />
         <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="652" />
         <source>Polish z&#322;oty</source>
         <translation>Polish z&#322;oty</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="662" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="662" />
         <source>Paraguayan guaran&#237;</source>
         <translation>Paraguayan guaran&#237;</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="672" />
         <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="672" />
         <source>Qatari riyal</source>
         <translation>Qatari riyal</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="682" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="682" />
         <source>Romanian leu</source>
         <translation>Romanian leu</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="692" />
         <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="692" />
         <source>Serbian dinar</source>
         <translation>Serbian dinar</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="702" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="702" />
         <source>Saudi riyal</source>
         <translation>Saudi riyal</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="712" />
         <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="712" />
         <source>Swedish krona</source>
         <translation>Swedish krona</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="722" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="722" />
         <source>Singapore dollar</source>
         <translation>Singapore dollar</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="732" />
         <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="732" />
         <source>Thai baht</source>
         <translation>Thai baht</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="742" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="742" />
         <source>Trinidad and Tobago dollar</source>
         <translation>Trinidad and Tobago dollar</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="752" />
         <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="752" />
         <source>New Taiwan dollar</source>
         <translation>New Taiwan dollar</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="762" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="762" />
         <source>Tanzanian shilling</source>
         <translation>Tanzanian shilling</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="772" />
         <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="772" />
         <source>Turkish lira</source>
         <translation>Turkish lira</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="782" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="782" />
         <source>Ukrainian hryvnia</source>
         <translation>Ukrainian hryvnia</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="792" />
         <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="792" />
         <source>Ugandan shilling</source>
         <translation>Ugandan shilling</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="802" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="802" />
         <source>Uruguayan peso</source>
         <translation>Uruguayan peso</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="812" />
         <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="812" />
         <source>Venezuelan bol&#237;var</source>
         <translation>Venezuelan bol&#237;var</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="822" />
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="822" />
         <source>Vietnamese &#273;&#7891;ng</source>
         <translation>Vietnamese &#273;&#7891;ng</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="832" />
         <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="832" />
         <source>South African rand</source>
         <translation>South African rand</translation>
@@ -3895,70 +4895,84 @@ chat with them once they have accepted your contact request.</translation>
     <name>DateGroup</name>
     <message>
         <location filename="../imports/shared/controls/chat/DateGroup.qml" line="38" />
+        <location filename="../imports/shared/controls/chat/DateGroup.qml" line="38" />
         <source>Today</source>
         <translation>Today</translation>
     </message>
     <message>
+        <location filename="../imports/shared/controls/chat/DateGroup.qml" line="40" />
         <location filename="../imports/shared/controls/chat/DateGroup.qml" line="40" />
         <source>Yesterday</source>
         <translation>Yesterday</translation>
     </message>
     <message>
         <location filename="../imports/shared/controls/chat/DateGroup.qml" line="43" />
+        <location filename="../imports/shared/controls/chat/DateGroup.qml" line="43" />
         <source>January</source>
         <translation>January</translation>
     </message>
     <message>
+        <location filename="../imports/shared/controls/chat/DateGroup.qml" line="44" />
         <location filename="../imports/shared/controls/chat/DateGroup.qml" line="44" />
         <source>February</source>
         <translation>February</translation>
     </message>
     <message>
         <location filename="../imports/shared/controls/chat/DateGroup.qml" line="45" />
+        <location filename="../imports/shared/controls/chat/DateGroup.qml" line="45" />
         <source>March</source>
         <translation>March</translation>
     </message>
     <message>
+        <location filename="../imports/shared/controls/chat/DateGroup.qml" line="46" />
         <location filename="../imports/shared/controls/chat/DateGroup.qml" line="46" />
         <source>April</source>
         <translation>April</translation>
     </message>
     <message>
         <location filename="../imports/shared/controls/chat/DateGroup.qml" line="47" />
+        <location filename="../imports/shared/controls/chat/DateGroup.qml" line="47" />
         <source>May</source>
         <translation>May</translation>
     </message>
     <message>
+        <location filename="../imports/shared/controls/chat/DateGroup.qml" line="48" />
         <location filename="../imports/shared/controls/chat/DateGroup.qml" line="48" />
         <source>June</source>
         <translation>June</translation>
     </message>
     <message>
         <location filename="../imports/shared/controls/chat/DateGroup.qml" line="49" />
+        <location filename="../imports/shared/controls/chat/DateGroup.qml" line="49" />
         <source>July</source>
         <translation>July</translation>
     </message>
     <message>
+        <location filename="../imports/shared/controls/chat/DateGroup.qml" line="50" />
         <location filename="../imports/shared/controls/chat/DateGroup.qml" line="50" />
         <source>August</source>
         <translation>August</translation>
     </message>
     <message>
         <location filename="../imports/shared/controls/chat/DateGroup.qml" line="51" />
+        <location filename="../imports/shared/controls/chat/DateGroup.qml" line="51" />
         <source>September</source>
         <translation>September</translation>
     </message>
     <message>
+        <location filename="../imports/shared/controls/chat/DateGroup.qml" line="52" />
         <location filename="../imports/shared/controls/chat/DateGroup.qml" line="52" />
         <source>October</source>
         <translation>October</translation>
     </message>
     <message>
         <location filename="../imports/shared/controls/chat/DateGroup.qml" line="53" />
+        <location filename="../imports/shared/controls/chat/DateGroup.qml" line="53" />
         <source>November</source>
         <translation>November</translation>
     </message>
     <message>
+        <location filename="../imports/shared/controls/chat/DateGroup.qml" line="54" />
         <location filename="../imports/shared/controls/chat/DateGroup.qml" line="54" />
         <source>December</source>
         <translation>December</translation>
@@ -3968,10 +4982,12 @@ chat with them once they have accepted your contact request.</translation>
     <name>DefaultDAppExplorerView</name>
     <message>
         <location filename="../app/AppLayouts/Profile/views/browser/DefaultDAppExplorerView.qml" line="16" />
+        <location filename="../app/AppLayouts/Profile/views/browser/DefaultDAppExplorerView.qml" line="16" />
         <source>Default DApp explorer</source>
         <translation>Default DApp explorer</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/browser/DefaultDAppExplorerView.qml" line="37" />
         <location filename="../app/AppLayouts/Profile/views/browser/DefaultDAppExplorerView.qml" line="37" />
         <source>none</source>
         <translation>none</translation>
@@ -3981,20 +4997,24 @@ chat with them once they have accepted your contact request.</translation>
     <name>DemoApp</name>
     <message>
         <location filename="../StatusQ/sandbox/DemoApp.qml" line="158" />
+        <location filename="../StatusQ/sandbox/DemoApp.qml" line="158" />
         <source>Invite People</source>
         <translation>Invite People</translation>
     </message>
     <message>
+        <location filename="../StatusQ/sandbox/DemoApp.qml" line="163" />
         <location filename="../StatusQ/sandbox/DemoApp.qml" line="163" />
         <source>View Community</source>
         <translation>View Community</translation>
     </message>
     <message>
         <location filename="../StatusQ/sandbox/DemoApp.qml" line="168" />
+        <location filename="../StatusQ/sandbox/DemoApp.qml" line="168" />
         <source>Edit Community</source>
         <translation>Edit Community</translation>
     </message>
     <message>
+        <location filename="../StatusQ/sandbox/DemoApp.qml" line="176" />
         <location filename="../StatusQ/sandbox/DemoApp.qml" line="176" />
         <source>Leave Community</source>
         <translation>Leave Community</translation>
@@ -4004,10 +5024,12 @@ chat with them once they have accepted your contact request.</translation>
     <name>DerivationPathsPanel</name>
     <message>
         <location filename="../app/AppLayouts/Wallet/panels/DerivationPathsPanel.qml" line="43" />
+        <location filename="../app/AppLayouts/Wallet/panels/DerivationPathsPanel.qml" line="43" />
         <source>Derivation Path</source>
         <translation>Derivation Path</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Wallet/panels/DerivationPathsPanel.qml" line="50" />
         <location filename="../app/AppLayouts/Wallet/panels/DerivationPathsPanel.qml" line="50" />
         <source>Reset</source>
         <translation>Reset</translation>
@@ -4017,20 +5039,26 @@ chat with them once they have accepted your contact request.</translation>
     <name>DerivedAddressesPanel</name>
     <message>
         <location filename="../app/AppLayouts/Wallet/panels/DerivedAddressesPanel.qml" line="26" />
+        <location filename="../app/AppLayouts/Wallet/panels/DerivedAddressesPanel.qml" line="26" />
         <source>No activity</source>
         <translation>No activity</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Wallet/panels/DerivedAddressesPanel.qml" line="31" />
         <location filename="../app/AppLayouts/Wallet/panels/DerivedAddressesPanel.qml" line="31" />
         <source>Pending</source>
         <translation>Pending</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Wallet/panels/DerivedAddressesPanel.qml" line="38" />
+        <location filename="../app/AppLayouts/Wallet/panels/DerivedAddressesPanel.qml" line="38" />
         <source>Invalid path</source>
         <translation>Invalid path</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Wallet/panels/DerivedAddressesPanel.qml" line="56" />
+        <location filename="../app/AppLayouts/Wallet/panels/DerivedAddressesPanel.qml" line="97" />
+        <location filename="../app/AppLayouts/Wallet/panels/DerivedAddressesPanel.qml" line="160" />
         <location filename="../app/AppLayouts/Wallet/panels/DerivedAddressesPanel.qml" line="56" />
         <location filename="../app/AppLayouts/Wallet/panels/DerivedAddressesPanel.qml" line="97" />
         <location filename="../app/AppLayouts/Wallet/panels/DerivedAddressesPanel.qml" line="160" />
@@ -4041,10 +5069,14 @@ chat with them once they have accepted your contact request.</translation>
         <location filename="../app/AppLayouts/Wallet/panels/DerivedAddressesPanel.qml" line="56" />
         <location filename="../app/AppLayouts/Wallet/panels/DerivedAddressesPanel.qml" line="97" />
         <location filename="../app/AppLayouts/Wallet/panels/DerivedAddressesPanel.qml" line="160" />
+        <location filename="../app/AppLayouts/Wallet/panels/DerivedAddressesPanel.qml" line="56" />
+        <location filename="../app/AppLayouts/Wallet/panels/DerivedAddressesPanel.qml" line="97" />
+        <location filename="../app/AppLayouts/Wallet/panels/DerivedAddressesPanel.qml" line="160" />
         <source>No Activity</source>
         <translation>No Activity</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Wallet/panels/DerivedAddressesPanel.qml" line="84" />
         <location filename="../app/AppLayouts/Wallet/panels/DerivedAddressesPanel.qml" line="84" />
         <source>Account</source>
         <translation>Account</translation>
@@ -4054,45 +5086,54 @@ chat with them once they have accepted your contact request.</translation>
     <name>DevicesView</name>
     <message>
         <location filename="../app/AppLayouts/Profile/views/DevicesView.qml" line="40" />
+        <location filename="../app/AppLayouts/Profile/views/DevicesView.qml" line="40" />
         <source>Please set a name for your device.</source>
         <translation>Please set a name for your device.</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/DevicesView.qml" line="47" />
         <location filename="../app/AppLayouts/Profile/views/DevicesView.qml" line="47" />
         <source>Specify a name</source>
         <translation>Specify a name</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/DevicesView.qml" line="57" />
+        <location filename="../app/AppLayouts/Profile/views/DevicesView.qml" line="57" />
         <source>Continue</source>
         <translation>Continue</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/DevicesView.qml" line="98" />
         <location filename="../app/AppLayouts/Profile/views/DevicesView.qml" line="98" />
         <source>Advertise device</source>
         <translation>Advertise device</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/DevicesView.qml" line="108" />
+        <location filename="../app/AppLayouts/Profile/views/DevicesView.qml" line="108" />
         <source>Pair your devices to sync contacts and chats between them</source>
         <translation>Pair your devices to sync contacts and chats between them</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/DevicesView.qml" line="127" />
         <location filename="../app/AppLayouts/Profile/views/DevicesView.qml" line="127" />
         <source>Learn more</source>
         <translation>Learn more</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/DevicesView.qml" line="152" />
+        <location filename="../app/AppLayouts/Profile/views/DevicesView.qml" line="152" />
         <source>Paired devices</source>
         <translation>Paired devices</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/DevicesView.qml" line="216" />
+        <location filename="../app/AppLayouts/Profile/views/DevicesView.qml" line="216" />
         <source>Syncing...</source>
         <translation>Syncing...</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/DevicesView.qml" line="217" />
         <location filename="../app/AppLayouts/Profile/views/DevicesView.qml" line="217" />
         <source>Sync all devices</source>
         <translation>Sync all devices</translation>
@@ -4101,34 +5142,44 @@ chat with them once they have accepted your contact request.</translation>
 <context>
     <name>DisplayNamePopup</name>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/DisplayNamePopup.qml" line="22" />
+        <location filename="../imports/shared/popups/DisplayNamePopup.qml" line="22" />
+        <location filename="../imports/shared/popups/DisplayNamePopup.qml" line="22" />
         <source>Edit</source>
         <translation>Edit</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/DisplayNamePopup.qml" line="30" />
+        <location filename="../imports/shared/popups/DisplayNamePopup.qml" line="30" />
+        <location filename="../imports/shared/popups/DisplayNamePopup.qml" line="30" />
         <source>Display Name</source>
         <translation>Display Name</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/DisplayNamePopup.qml" line="39" />
+        <location filename="../imports/shared/popups/DisplayNamePopup.qml" line="39" />
+        <location filename="../imports/shared/popups/DisplayNamePopup.qml" line="39" />
+        <source>OK</source>
+        <translation>OK</translation>
+    </message>
+    <message>
         <source>Ok</source>
-        <translation>Ok</translation>
+        <translation type="vanished">Ok</translation>
     </message>
 </context>
 <context>
     <name>DownloadBar</name>
     <message>
         <location filename="../app/AppLayouts/Browser/panels/DownloadBar.qml" line="62" />
+        <location filename="../app/AppLayouts/Browser/panels/DownloadBar.qml" line="62" />
         <source>Cancelled</source>
         <translation>Cancelled</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Browser/panels/DownloadBar.qml" line="65" />
+        <location filename="../app/AppLayouts/Browser/panels/DownloadBar.qml" line="65" />
         <source>Paused</source>
         <translation>Paused</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Browser/panels/DownloadBar.qml" line="98" />
         <location filename="../app/AppLayouts/Browser/panels/DownloadBar.qml" line="98" />
         <source>Show All</source>
         <translation>Show All</translation>
@@ -4138,25 +5189,30 @@ chat with them once they have accepted your contact request.</translation>
     <name>DownloadMenu</name>
     <message>
         <location filename="../app/AppLayouts/Browser/popups/DownloadMenu.qml" line="26" />
+        <location filename="../app/AppLayouts/Browser/popups/DownloadMenu.qml" line="26" />
         <source>Open</source>
         <translation>Open</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Browser/popups/DownloadMenu.qml" line="33" />
         <location filename="../app/AppLayouts/Browser/popups/DownloadMenu.qml" line="33" />
         <source>Show in folder</source>
         <translation>Show in folder</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Browser/popups/DownloadMenu.qml" line="41" />
+        <location filename="../app/AppLayouts/Browser/popups/DownloadMenu.qml" line="41" />
         <source>Pause</source>
         <translation>Pause</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Browser/popups/DownloadMenu.qml" line="51" />
+        <location filename="../app/AppLayouts/Browser/popups/DownloadMenu.qml" line="51" />
         <source>Resume</source>
         <translation>Resume</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Browser/popups/DownloadMenu.qml" line="64" />
         <location filename="../app/AppLayouts/Browser/popups/DownloadMenu.qml" line="64" />
         <source>Cancel</source>
         <translation>Cancel</translation>
@@ -4193,15 +5249,18 @@ chat with them once they have accepted your contact request.</translation>
     <name>DownloadView</name>
     <message>
         <location filename="../app/AppLayouts/Browser/panels/DownloadView.qml" line="37" />
+        <location filename="../app/AppLayouts/Browser/panels/DownloadView.qml" line="37" />
         <source>Cancelled</source>
         <translation>Cancelled</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Browser/panels/DownloadView.qml" line="40" />
+        <location filename="../app/AppLayouts/Browser/panels/DownloadView.qml" line="40" />
         <source>Paused</source>
         <translation>Paused</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Browser/panels/DownloadView.qml" line="74" />
         <location filename="../app/AppLayouts/Browser/panels/DownloadView.qml" line="74" />
         <source>Downloaded files will appear here.</source>
         <translation>Downloaded files will appear here.</translation>
@@ -4211,15 +5270,18 @@ chat with them once they have accepted your contact request.</translation>
     <name>ENSPopup</name>
     <message>
         <location filename="../app/AppLayouts/Profile/popups/ENSPopup.qml" line="15" />
+        <location filename="../app/AppLayouts/Profile/popups/ENSPopup.qml" line="15" />
         <source>Primary username</source>
         <translation>Primary username</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/popups/ENSPopup.qml" line="29" />
+        <location filename="../app/AppLayouts/Profile/popups/ENSPopup.qml" line="29" />
         <source>Your messages are displayed to others with this username:</source>
         <translation>Your messages are displayed to others with this username:</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/popups/ENSPopup.qml" line="31" />
         <location filename="../app/AppLayouts/Profile/popups/ENSPopup.qml" line="31" />
         <source>Once you select a username, you won&#8217;t be able to disable it afterwards. You will only be able choose a different username to display.</source>
         <translation>Once you select a username, you won&#8217;t be able to disable it afterwards. You will only be able choose a different username to display.</translation>
@@ -4229,6 +5291,7 @@ chat with them once they have accepted your contact request.</translation>
     <name>EmojiReactionsPanel</name>
     <message>
         <location filename="../imports/shared/panels/chat/EmojiReactionsPanel.qml" line="188" />
+        <location filename="../imports/shared/panels/chat/EmojiReactionsPanel.qml" line="188" />
         <source>Add reaction</source>
         <translation>Add reaction</translation>
     </message>
@@ -4237,20 +5300,24 @@ chat with them once they have accepted your contact request.</translation>
     <name>EmptyChatPanel</name>
     <message>
         <location filename="../app/AppLayouts/Chat/panels/EmptyChatPanel.qml" line="35" />
+        <location filename="../app/AppLayouts/Chat/panels/EmptyChatPanel.qml" line="35" />
         <source>Share your chat key</source>
         <translation>Share your chat key</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Chat/panels/EmptyChatPanel.qml" line="55" />
         <location filename="../app/AppLayouts/Chat/panels/EmptyChatPanel.qml" line="55" />
         <source>or</source>
         <translation>or</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Chat/panels/EmptyChatPanel.qml" line="65" />
+        <location filename="../app/AppLayouts/Chat/panels/EmptyChatPanel.qml" line="65" />
         <source>invite</source>
         <translation>invite</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Chat/panels/EmptyChatPanel.qml" line="90" />
         <location filename="../app/AppLayouts/Chat/panels/EmptyChatPanel.qml" line="90" />
         <source>friends to start messaging in Status</source>
         <translation>friends to start messaging in Status</translation>
@@ -4260,20 +5327,24 @@ chat with them once they have accepted your contact request.</translation>
     <name>EnsAddedView</name>
     <message>
         <location filename="../app/AppLayouts/Profile/views/EnsAddedView.qml" line="17" />
+        <location filename="../app/AppLayouts/Profile/views/EnsAddedView.qml" line="17" />
         <source>ENS usernames</source>
         <translation>ENS usernames</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/EnsAddedView.qml" line="52" />
         <location filename="../app/AppLayouts/Profile/views/EnsAddedView.qml" line="52" />
         <source>Username added</source>
         <translation>Username added</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/EnsAddedView.qml" line="66" />
+        <location filename="../app/AppLayouts/Profile/views/EnsAddedView.qml" line="66" />
         <source>%1 is now connected with your chat key and can be used in Status.</source>
         <translation>%1 is now connected with your chat key and can be used in Status.</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/EnsAddedView.qml" line="82" />
         <location filename="../app/AppLayouts/Profile/views/EnsAddedView.qml" line="82" />
         <source>Ok, got it</source>
         <translation>Ok, got it</translation>
@@ -4283,25 +5354,30 @@ chat with them once they have accepted your contact request.</translation>
     <name>EnsConnectedView</name>
     <message>
         <location filename="../app/AppLayouts/Profile/views/EnsConnectedView.qml" line="17" />
+        <location filename="../app/AppLayouts/Profile/views/EnsConnectedView.qml" line="17" />
         <source>ENS usernames</source>
         <translation>ENS usernames</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/EnsConnectedView.qml" line="52" />
         <location filename="../app/AppLayouts/Profile/views/EnsConnectedView.qml" line="52" />
         <source>Username added</source>
         <translation>Username added</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/EnsConnectedView.qml" line="66" />
+        <location filename="../app/AppLayouts/Profile/views/EnsConnectedView.qml" line="66" />
         <source>%1 will be connected once the transaction is complete.</source>
         <translation>%1 will be connected once the transaction is complete.</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/EnsConnectedView.qml" line="79" />
+        <location filename="../app/AppLayouts/Profile/views/EnsConnectedView.qml" line="79" />
         <source>You can follow the progress in the Transaction History section of your wallet.</source>
         <translation>You can follow the progress in the Transaction History section of your wallet.</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/EnsConnectedView.qml" line="96" />
         <location filename="../app/AppLayouts/Profile/views/EnsConnectedView.qml" line="96" />
         <source>Ok, got it</source>
         <translation>Ok, got it</translation>
@@ -4311,10 +5387,13 @@ chat with them once they have accepted your contact request.</translation>
     <name>EnsDetailsView</name>
     <message>
         <location filename="../app/AppLayouts/Profile/views/EnsDetailsView.qml" line="78" />
+        <location filename="../app/AppLayouts/Profile/views/EnsDetailsView.qml" line="78" />
         <source>Wallet address</source>
         <translation>Wallet address</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/EnsDetailsView.qml" line="83" />
+        <location filename="../app/AppLayouts/Profile/views/EnsDetailsView.qml" line="96" />
         <location filename="../app/AppLayouts/Profile/views/EnsDetailsView.qml" line="83" />
         <location filename="../app/AppLayouts/Profile/views/EnsDetailsView.qml" line="96" />
         <source>Copied to clipboard!</source>
@@ -4322,25 +5401,30 @@ chat with them once they have accepted your contact request.</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/EnsDetailsView.qml" line="91" />
+        <location filename="../app/AppLayouts/Profile/views/EnsDetailsView.qml" line="91" />
         <source>Key</source>
         <translation>Key</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/EnsDetailsView.qml" line="110" />
         <location filename="../app/AppLayouts/Profile/views/EnsDetailsView.qml" line="110" />
         <source>Connect username with your pubkey</source>
         <translation>Connect username with your pubkey</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/EnsDetailsView.qml" line="142" />
+        <location filename="../app/AppLayouts/Profile/views/EnsDetailsView.qml" line="142" />
         <source>Release username</source>
         <translation>Release username</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/EnsDetailsView.qml" line="154" />
+        <location filename="../app/AppLayouts/Profile/views/EnsDetailsView.qml" line="154" />
         <source>Username locked. You won't be able to release it until %1</source>
         <translation>Username locked. You won't be able to release it until %1</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/EnsDetailsView.qml" line="163" />
         <location filename="../app/AppLayouts/Profile/views/EnsDetailsView.qml" line="163" />
         <source>Back</source>
         <translation>Back</translation>
@@ -4350,10 +5434,13 @@ chat with them once they have accepted your contact request.</translation>
     <name>EnsListView</name>
     <message>
         <location filename="../app/AppLayouts/Profile/views/EnsListView.qml" line="32" />
+        <location filename="../app/AppLayouts/Profile/views/EnsListView.qml" line="32" />
         <source>Hey</source>
         <translation>Hey</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/EnsListView.qml" line="55" />
+        <location filename="../app/AppLayouts/Profile/views/EnsListView.qml" line="74" />
         <location filename="../app/AppLayouts/Profile/views/EnsListView.qml" line="55" />
         <location filename="../app/AppLayouts/Profile/views/EnsListView.qml" line="74" />
         <source>(pending)</source>
@@ -4361,35 +5448,42 @@ chat with them once they have accepted your contact request.</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/EnsListView.qml" line="134" />
+        <location filename="../app/AppLayouts/Profile/views/EnsListView.qml" line="134" />
         <source>ENS usernames</source>
         <translation>ENS usernames</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/EnsListView.qml" line="162" />
         <location filename="../app/AppLayouts/Profile/views/EnsListView.qml" line="162" />
         <source>Add username</source>
         <translation>Add username</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/EnsListView.qml" line="180" />
+        <location filename="../app/AppLayouts/Profile/views/EnsListView.qml" line="180" />
         <source>Your usernames</source>
         <translation>Your usernames</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/EnsListView.qml" line="225" />
         <location filename="../app/AppLayouts/Profile/views/EnsListView.qml" line="225" />
         <source>Chat settings</source>
         <translation>Chat settings</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/EnsListView.qml" line="245" />
+        <location filename="../app/AppLayouts/Profile/views/EnsListView.qml" line="245" />
         <source>Primary Username</source>
         <translation>Primary Username</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/EnsListView.qml" line="254" />
+        <location filename="../app/AppLayouts/Profile/views/EnsListView.qml" line="254" />
         <source>None selected</source>
         <translation>None selected</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/EnsListView.qml" line="340" />
         <location filename="../app/AppLayouts/Profile/views/EnsListView.qml" line="340" />
         <source>You&#8217;re displaying your ENS username in chats</source>
         <translation>You&#8217;re displaying your ENS username in chats</translation>
@@ -4399,25 +5493,30 @@ chat with them once they have accepted your contact request.</translation>
     <name>EnsRegisteredView</name>
     <message>
         <location filename="../app/AppLayouts/Profile/views/EnsRegisteredView.qml" line="17" />
+        <location filename="../app/AppLayouts/Profile/views/EnsRegisteredView.qml" line="17" />
         <source>ENS usernames</source>
         <translation>ENS usernames</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/EnsRegisteredView.qml" line="52" />
         <location filename="../app/AppLayouts/Profile/views/EnsRegisteredView.qml" line="52" />
         <source>Username added</source>
         <translation>Username added</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/EnsRegisteredView.qml" line="66" />
+        <location filename="../app/AppLayouts/Profile/views/EnsRegisteredView.qml" line="66" />
         <source>Nice! You own %1.stateofus.eth once the transaction is complete.</source>
         <translation>Nice! You own %1.stateofus.eth once the transaction is complete.</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/EnsRegisteredView.qml" line="79" />
+        <location filename="../app/AppLayouts/Profile/views/EnsRegisteredView.qml" line="79" />
         <source>You can follow the progress in the Transaction History section of your wallet.</source>
         <translation>You can follow the progress in the Transaction History section of your wallet.</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/EnsRegisteredView.qml" line="96" />
         <location filename="../app/AppLayouts/Profile/views/EnsRegisteredView.qml" line="96" />
         <source>Ok, got it</source>
         <translation>Ok, got it</translation>
@@ -4427,25 +5526,30 @@ chat with them once they have accepted your contact request.</translation>
     <name>EnsReleasedView</name>
     <message>
         <location filename="../app/AppLayouts/Profile/views/EnsReleasedView.qml" line="17" />
+        <location filename="../app/AppLayouts/Profile/views/EnsReleasedView.qml" line="17" />
         <source>ENS usernames</source>
         <translation>ENS usernames</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/EnsReleasedView.qml" line="52" />
         <location filename="../app/AppLayouts/Profile/views/EnsReleasedView.qml" line="52" />
         <source>Username removed</source>
         <translation>Username removed</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/EnsReleasedView.qml" line="66" />
+        <location filename="../app/AppLayouts/Profile/views/EnsReleasedView.qml" line="66" />
         <source>The username %1 will be removed and your deposit will be returned once the transaction is mined</source>
         <translation>The username %1 will be removed and your deposit will be returned once the transaction is mined</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/EnsReleasedView.qml" line="79" />
+        <location filename="../app/AppLayouts/Profile/views/EnsReleasedView.qml" line="79" />
         <source>You can follow the progress in the Transaction History section of your wallet.</source>
         <translation>You can follow the progress in the Transaction History section of your wallet.</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/EnsReleasedView.qml" line="96" />
         <location filename="../app/AppLayouts/Profile/views/EnsReleasedView.qml" line="96" />
         <source>Ok, got it</source>
         <translation>Ok, got it</translation>
@@ -4455,35 +5559,42 @@ chat with them once they have accepted your contact request.</translation>
     <name>EnsSearchView</name>
     <message>
         <location filename="../app/AppLayouts/Profile/views/EnsSearchView.qml" line="41" />
+        <location filename="../app/AppLayouts/Profile/views/EnsSearchView.qml" line="41" />
         <source>At least 4 characters. Latin letters, numbers, and lowercase only.</source>
         <translation>At least 4 characters. Latin letters, numbers, and lowercase only.</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/EnsSearchView.qml" line="43" />
         <location filename="../app/AppLayouts/Profile/views/EnsSearchView.qml" line="43" />
         <source>Letters and numbers only.</source>
         <translation>Letters and numbers only.</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/EnsSearchView.qml" line="45" />
+        <location filename="../app/AppLayouts/Profile/views/EnsSearchView.qml" line="45" />
         <source>Type the entire username including the custom domain like username.domain.eth</source>
         <translation>Type the entire username including the custom domain like username.domain.eth</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/EnsSearchView.qml" line="64" />
         <location filename="../app/AppLayouts/Profile/views/EnsSearchView.qml" line="64" />
         <source>Connect username with your pubkey</source>
         <translation>Connect username with your pubkey</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/EnsSearchView.qml" line="229" />
+        <location filename="../app/AppLayouts/Profile/views/EnsSearchView.qml" line="229" />
         <source>Custom domain</source>
         <translation>Custom domain</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/EnsSearchView.qml" line="240" />
+        <location filename="../app/AppLayouts/Profile/views/EnsSearchView.qml" line="240" />
         <source>I want a stateofus.eth domain</source>
         <translation>I want a stateofus.eth domain</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/EnsSearchView.qml" line="242" />
         <location filename="../app/AppLayouts/Profile/views/EnsSearchView.qml" line="242" />
         <source>I own a name on another domain</source>
         <translation>I own a name on another domain</translation>
@@ -4493,55 +5604,66 @@ chat with them once they have accepted your contact request.</translation>
     <name>EnsTermsAndConditionsView</name>
     <message>
         <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="28" />
+        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="28" />
         <source>ENS usernames</source>
         <translation>ENS usernames</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="83" />
         <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="83" />
         <source>Terms of name registration</source>
         <translation>Terms of name registration</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="99" />
+        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="99" />
         <source>Funds are deposited for 1 year. Your SNT will be locked, but not spent.</source>
         <translation>Funds are deposited for 1 year. Your SNT will be locked, but not spent.</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="107" />
         <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="107" />
         <source>After 1 year, you can release the name and get your deposit back, or take no action to keep the name.</source>
         <translation>After 1 year, you can release the name and get your deposit back, or take no action to keep the name.</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="115" />
+        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="115" />
         <source>If terms of the contract change &#8212; e.g. Status makes contract upgrades &#8212; user has the right to release the username regardless of time held.</source>
         <translation>If terms of the contract change &#8212; e.g. Status makes contract upgrades &#8212; user has the right to release the username regardless of time held.</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="123" />
         <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="123" />
         <source>The contract controller cannot access your deposited funds. They can only be moved back to the address that sent them.</source>
         <translation>The contract controller cannot access your deposited funds. They can only be moved back to the address that sent them.</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="131" />
+        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="131" />
         <source>Your address(es) will be publicly associated with your ENS name.</source>
         <translation>Your address(es) will be publicly associated with your ENS name.</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="139" />
         <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="139" />
         <source>Usernames are created as subdomain nodes of stateofus.eth and are subject to the ENS smart contract terms.</source>
         <translation>Usernames are created as subdomain nodes of stateofus.eth and are subject to the ENS smart contract terms.</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="147" />
+        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="147" />
         <source>You authorize the contract to transfer SNT on your behalf. This can only occur when you approve a transaction to authorize the transfer.</source>
         <translation>You authorize the contract to transfer SNT on your behalf. This can only occur when you approve a transaction to authorize the transfer.</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="155" />
+        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="155" />
         <source>These terms are guaranteed by the smart contract logic at addresses:</source>
         <translation>These terms are guaranteed by the smart contract logic at addresses:</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="164" />
         <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="164" />
         <source>%1 (Status UsernameRegistrar).</source>
         <translation>%1 (Status UsernameRegistrar).</translation>
@@ -4549,15 +5671,19 @@ chat with them once they have accepted your contact request.</translation>
     <message>
         <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="173" />
         <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="197" />
+        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="173" />
+        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="197" />
         <source>&lt;a href='%1%2'&gt;Look up on Etherscan&lt;/a&gt;</source>
         <translation>&lt;a href='%1%2'&gt;Look up on Etherscan&lt;/a&gt;</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="188" />
+        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="188" />
         <source>%1 (ENS Registry).</source>
         <translation>%1 (ENS Registry).</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="268" />
         <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="268" />
         <source>Wallet address</source>
         <translation>Wallet address</translation>
@@ -4565,40 +5691,49 @@ chat with them once they have accepted your contact request.</translation>
     <message>
         <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="270" />
         <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="287" />
+        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="270" />
+        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="287" />
         <source>Copied to clipboard!</source>
         <translation>Copied to clipboard!</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="282" />
         <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="282" />
         <source>Key</source>
         <translation>Key</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="306" />
+        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="306" />
         <source>Agree to &lt;a href="#"&gt;Terms of name registration.&lt;/a&gt; I understand that my wallet address will be publicly connected to my username.</source>
         <translation>Agree to &lt;a href="#"&gt;Terms of name registration.&lt;/a&gt; I understand that my wallet address will be publicly connected to my username.</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="327" />
         <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="327" />
         <source>Back</source>
         <translation>Back</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="347" />
+        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="347" />
         <source>10 SNT</source>
         <translation>10 SNT</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="356" />
         <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="356" />
         <source>Deposit</source>
         <translation>Deposit</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="373" />
+        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="373" />
         <source>Not enough SNT</source>
         <translation>Not enough SNT</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="374" />
         <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="374" />
         <source>Register</source>
         <translation>Register</translation>
@@ -4609,10 +5744,14 @@ chat with them once they have accepted your contact request.</translation>
     <message>
         <location filename="../app/AppLayouts/Profile/views/EnsView.qml" line="327" />
         <location filename="../app/AppLayouts/Profile/views/EnsView.qml" line="362" />
+        <location filename="../app/AppLayouts/Profile/views/EnsView.qml" line="327" />
+        <location filename="../app/AppLayouts/Profile/views/EnsView.qml" line="362" />
         <source>Transaction pending...</source>
         <translation>Transaction pending...</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/EnsView.qml" line="328" />
+        <location filename="../app/AppLayouts/Profile/views/EnsView.qml" line="363" />
         <location filename="../app/AppLayouts/Profile/views/EnsView.qml" line="328" />
         <location filename="../app/AppLayouts/Profile/views/EnsView.qml" line="363" />
         <source>View on etherscan</source>
@@ -4620,20 +5759,24 @@ chat with them once they have accepted your contact request.</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/EnsView.qml" line="339" />
+        <location filename="../app/AppLayouts/Profile/views/EnsView.qml" line="339" />
         <source>ENS Registration failed</source>
         <translation>ENS Registration failed</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/EnsView.qml" line="341" />
         <location filename="../app/AppLayouts/Profile/views/EnsView.qml" line="341" />
         <source>ENS Registration completed</source>
         <translation>ENS Registration completed</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/EnsView.qml" line="345" />
+        <location filename="../app/AppLayouts/Profile/views/EnsView.qml" line="345" />
         <source>Updating ENS pubkey failed</source>
         <translation>Updating ENS pubkey failed</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/EnsView.qml" line="347" />
         <location filename="../app/AppLayouts/Profile/views/EnsView.qml" line="347" />
         <source>Updating ENS pubkey completed</source>
         <translation>Updating ENS pubkey completed</translation>
@@ -4643,75 +5786,90 @@ chat with them once they have accepted your contact request.</translation>
     <name>EnsWelcomeView</name>
     <message>
         <location filename="../app/AppLayouts/Profile/views/EnsWelcomeView.qml" line="46" />
+        <location filename="../app/AppLayouts/Profile/views/EnsWelcomeView.qml" line="46" />
         <source>Get a universal username</source>
         <translation>Get a universal username</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/EnsWelcomeView.qml" line="60" />
         <location filename="../app/AppLayouts/Profile/views/EnsWelcomeView.qml" line="60" />
         <source>ENS names transform those crazy-long addresses into unique usernames.</source>
         <translation>ENS names transform those crazy-long addresses into unique usernames.</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/EnsWelcomeView.qml" line="85" />
+        <location filename="../app/AppLayouts/Profile/views/EnsWelcomeView.qml" line="85" />
         <source>Customize your chat name</source>
         <translation>Customize your chat name</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/EnsWelcomeView.qml" line="99" />
         <location filename="../app/AppLayouts/Profile/views/EnsWelcomeView.qml" line="99" />
         <source>An ENS name can replace your random 3-word name in chat. Be @yourname instead of %1.</source>
         <translation>An ENS name can replace your random 3-word name in chat. Be @yourname instead of %1.</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/EnsWelcomeView.qml" line="124" />
+        <location filename="../app/AppLayouts/Profile/views/EnsWelcomeView.qml" line="124" />
         <source>Simplify your ETH address</source>
         <translation>Simplify your ETH address</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/EnsWelcomeView.qml" line="138" />
         <location filename="../app/AppLayouts/Profile/views/EnsWelcomeView.qml" line="138" />
         <source>You can receive funds to your easy-to-share ENS name rather than your hexadecimal hash (0x...).</source>
         <translation>You can receive funds to your easy-to-share ENS name rather than your hexadecimal hash (0x...).</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/EnsWelcomeView.qml" line="163" />
+        <location filename="../app/AppLayouts/Profile/views/EnsWelcomeView.qml" line="163" />
         <source>Receive transactions in chat</source>
         <translation>Receive transactions in chat</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/EnsWelcomeView.qml" line="177" />
         <location filename="../app/AppLayouts/Profile/views/EnsWelcomeView.qml" line="177" />
         <source>Others can send you funds via chat in one simple step.</source>
         <translation>Others can send you funds via chat in one simple step.</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/EnsWelcomeView.qml" line="202" />
+        <location filename="../app/AppLayouts/Profile/views/EnsWelcomeView.qml" line="202" />
         <source>10 SNT to register</source>
         <translation>10 SNT to register</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/EnsWelcomeView.qml" line="216" />
         <location filename="../app/AppLayouts/Profile/views/EnsWelcomeView.qml" line="216" />
         <source>Register once to keep the name forever. After 1 year you can release the name and get your SNT back.</source>
         <translation>Register once to keep the name forever. After 1 year you can release the name and get your SNT back.</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/EnsWelcomeView.qml" line="242" />
+        <location filename="../app/AppLayouts/Profile/views/EnsWelcomeView.qml" line="242" />
         <source>Already own a username?</source>
         <translation>Already own a username?</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/EnsWelcomeView.qml" line="256" />
         <location filename="../app/AppLayouts/Profile/views/EnsWelcomeView.qml" line="256" />
         <source>You can verify and add any usernames you own in the next steps.</source>
         <translation>You can verify and add any usernames you own in the next steps.</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/EnsWelcomeView.qml" line="269" />
+        <location filename="../app/AppLayouts/Profile/views/EnsWelcomeView.qml" line="269" />
         <source>Powered by Ethereum Name Services</source>
         <translation>Powered by Ethereum Name Services</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/EnsWelcomeView.qml" line="288" />
+        <location filename="../app/AppLayouts/Profile/views/EnsWelcomeView.qml" line="288" />
         <source>Start</source>
         <translation>Start</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/EnsWelcomeView.qml" line="289" />
         <location filename="../app/AppLayouts/Profile/views/EnsWelcomeView.qml" line="289" />
         <source>Only available on Mainnet</source>
         <translation>Only available on Mainnet</translation>
@@ -4721,35 +5879,42 @@ chat with them once they have accepted your contact request.</translation>
     <name>ExemptionNotificationsModal</name>
     <message>
         <location filename="../app/AppLayouts/Profile/popups/ExemptionNotificationsModal.qml" line="32" />
+        <location filename="../app/AppLayouts/Profile/popups/ExemptionNotificationsModal.qml" line="32" />
         <source>%1 exemption</source>
         <translation>%1 exemption</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/popups/ExemptionNotificationsModal.qml" line="69" />
         <location filename="../app/AppLayouts/Profile/popups/ExemptionNotificationsModal.qml" line="69" />
         <source>Mute all messages</source>
         <translation>Mute all messages</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/popups/ExemptionNotificationsModal.qml" line="91" />
+        <location filename="../app/AppLayouts/Profile/popups/ExemptionNotificationsModal.qml" line="91" />
         <source>Personal @ Mentions</source>
         <translation>Personal @ Mentions</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/popups/ExemptionNotificationsModal.qml" line="106" />
         <location filename="../app/AppLayouts/Profile/popups/ExemptionNotificationsModal.qml" line="106" />
         <source>Global @ Mentions</source>
         <translation>Global @ Mentions</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/popups/ExemptionNotificationsModal.qml" line="121" />
+        <location filename="../app/AppLayouts/Profile/popups/ExemptionNotificationsModal.qml" line="121" />
         <source>Other Messages</source>
         <translation>Other Messages</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/popups/ExemptionNotificationsModal.qml" line="137" />
+        <location filename="../app/AppLayouts/Profile/popups/ExemptionNotificationsModal.qml" line="137" />
         <source>Clear Exemptions</source>
         <translation>Clear Exemptions</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/popups/ExemptionNotificationsModal.qml" line="148" />
         <location filename="../app/AppLayouts/Profile/popups/ExemptionNotificationsModal.qml" line="148" />
         <source>Done</source>
         <translation>Done</translation>
@@ -4759,15 +5924,18 @@ chat with them once they have accepted your contact request.</translation>
     <name>FavoriteMenu</name>
     <message>
         <location filename="../app/AppLayouts/Browser/popups/FavoriteMenu.qml" line="24" />
+        <location filename="../app/AppLayouts/Browser/popups/FavoriteMenu.qml" line="24" />
         <source>Open in new Tab</source>
         <translation>Open in new Tab</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Browser/popups/FavoriteMenu.qml" line="36" />
+        <location filename="../app/AppLayouts/Browser/popups/FavoriteMenu.qml" line="36" />
         <source>Edit</source>
         <translation>Edit</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Browser/popups/FavoriteMenu.qml" line="48" />
         <location filename="../app/AppLayouts/Browser/popups/FavoriteMenu.qml" line="48" />
         <source>Remove</source>
         <translation>Remove</translation>
@@ -4777,23 +5945,31 @@ chat with them once they have accepted your contact request.</translation>
     <name>FetchMoreMessagesButton</name>
     <message>
         <location filename="../imports/shared/controls/chat/FetchMoreMessagesButton.qml" line="59" />
+        <location filename="../imports/shared/controls/chat/FetchMoreMessagesButton.qml" line="59" />
         <source>&#8595; Fetch more messages</source>
         <translation>&#8595; Fetch more messages</translation>
     </message>
     <message>
         <location filename="../imports/shared/controls/chat/FetchMoreMessagesButton.qml" line="83" />
+        <location filename="../imports/shared/controls/chat/FetchMoreMessagesButton.qml" line="83" />
+        <source>Before %1</source>
+        <translation>Before %1</translation>
+    </message>
+    <message>
         <source>before--%1</source>
-        <translation>before--%1</translation>
+        <translation type="vanished">before--%1</translation>
     </message>
 </context>
 <context>
     <name>FleetRadioSelector</name>
     <message>
         <location filename="../app/AppLayouts/Profile/controls/FleetRadioSelector.qml" line="33" />
+        <location filename="../app/AppLayouts/Profile/controls/FleetRadioSelector.qml" line="33" />
         <source>Warning!</source>
         <translation>Warning!</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/controls/FleetRadioSelector.qml" line="34" />
         <location filename="../app/AppLayouts/Profile/controls/FleetRadioSelector.qml" line="34" />
         <source>Change fleet to %1</source>
         <translation>Change fleet to %1</translation>
@@ -4803,6 +5979,7 @@ chat with them once they have accepted your contact request.</translation>
     <name>FleetsModal</name>
     <message>
         <location filename="../app/AppLayouts/Profile/popups/FleetsModal.qml" line="15" />
+        <location filename="../app/AppLayouts/Profile/popups/FleetsModal.qml" line="15" />
         <source>Fleet</source>
         <translation>Fleet</translation>
     </message>
@@ -4810,143 +5987,153 @@ chat with them once they have accepted your contact request.</translation>
 <context>
     <name>GapComponent</name>
     <message>
-        <location filename="../imports/shared/controls/chat/GapComponent.qml" line="26" />
         <source>fetch-messages</source>
-        <translation>fetch-messages</translation>
+        <translation type="vanished">fetch-messages</translation>
     </message>
     <message>
-        <location filename="../imports/shared/controls/chat/GapComponent.qml" line="48" />
         <source>between--1-and--2</source>
-        <translation>between--1-and--2</translation>
+        <translation type="vanished">between--1-and--2</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/controls/chat/GapComponent.qml" line="27" />
+        <location filename="../imports/shared/controls/chat/GapComponent.qml" line="27" />
+        <source>Fetch messages</source>
+        <translation>Fetch messages</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/controls/chat/GapComponent.qml" line="49" />
+        <location filename="../imports/shared/controls/chat/GapComponent.qml" line="49" />
+        <source>Between %1 and %2</source>
+        <translation>Between %1 and %2</translation>
     </message>
 </context>
 <context>
     <name>GasSelector</name>
     <message>
-        <location filename="../imports/shared/controls/GasSelector.qml" line="39" />
-        <location filename="../imports/shared/controls/GasSelector.qml" line="39" />
+        <location filename="../imports/shared/controls/GasSelector.qml" line="38" />
+        <location filename="../imports/shared/controls/GasSelector.qml" line="38" />
         <source>Must be greater than 0</source>
         <translation>Must be greater than 0</translation>
     </message>
     <message>
-        <location filename="../imports/shared/controls/GasSelector.qml" line="40" />
-        <location filename="../imports/shared/controls/GasSelector.qml" line="40" />
+        <location filename="../imports/shared/controls/GasSelector.qml" line="39" />
+        <location filename="../imports/shared/controls/GasSelector.qml" line="39" />
         <source>This needs to be a number</source>
         <translation>This needs to be a number</translation>
     </message>
     <message>
-        <location filename="../imports/shared/controls/GasSelector.qml" line="41" />
-        <location filename="../imports/shared/controls/GasSelector.qml" line="41" />
+        <location filename="../imports/shared/controls/GasSelector.qml" line="40" />
+        <location filename="../imports/shared/controls/GasSelector.qml" line="40" />
         <source>Please enter an amount</source>
         <translation>Please enter an amount</translation>
     </message>
     <message>
-        <location filename="../imports/shared/controls/GasSelector.qml" line="94" />
-        <location filename="../imports/shared/controls/GasSelector.qml" line="94" />
+        <location filename="../imports/shared/controls/GasSelector.qml" line="93" />
+        <location filename="../imports/shared/controls/GasSelector.qml" line="93" />
         <source>Min 21000 units</source>
         <translation>Min 21000 units</translation>
     </message>
     <message>
-        <location filename="../imports/shared/controls/GasSelector.qml" line="96" />
-        <location filename="../imports/shared/controls/GasSelector.qml" line="96" />
+        <location filename="../imports/shared/controls/GasSelector.qml" line="95" />
+        <location filename="../imports/shared/controls/GasSelector.qml" line="95" />
         <source>Not enough gas</source>
         <translation>Not enough gas</translation>
     </message>
     <message>
-        <location filename="../imports/shared/controls/GasSelector.qml" line="101" />
-        <location filename="../imports/shared/controls/GasSelector.qml" line="101" />
+        <location filename="../imports/shared/controls/GasSelector.qml" line="100" />
+        <location filename="../imports/shared/controls/GasSelector.qml" line="100" />
         <source>Miners will currently not process transactions with a tip below %1 Gwei, the average is %2 Gwei</source>
         <translation>Miners will currently not process transactions with a tip below %1 Gwei, the average is %2 Gwei</translation>
     </message>
     <message>
-        <location filename="../imports/shared/controls/GasSelector.qml" line="104" />
-        <location filename="../imports/shared/controls/GasSelector.qml" line="104" />
+        <location filename="../imports/shared/controls/GasSelector.qml" line="103" />
+        <location filename="../imports/shared/controls/GasSelector.qml" line="103" />
         <source>The average miner tip is %1 Gwei</source>
         <translation>The average miner tip is %1 Gwei</translation>
     </message>
     <message>
-        <location filename="../imports/shared/controls/GasSelector.qml" line="176" />
-        <location filename="../imports/shared/controls/GasSelector.qml" line="176" />
+        <location filename="../imports/shared/controls/GasSelector.qml" line="175" />
+        <location filename="../imports/shared/controls/GasSelector.qml" line="175" />
         <source>Priority</source>
         <translation>Priority</translation>
     </message>
     <message>
-        <location filename="../imports/shared/controls/GasSelector.qml" line="176" />
-        <location filename="../imports/shared/controls/GasSelector.qml" line="176" />
+        <location filename="../imports/shared/controls/GasSelector.qml" line="175" />
+        <location filename="../imports/shared/controls/GasSelector.qml" line="175" />
         <source>Gas Price</source>
         <translation>Gas Price</translation>
     </message>
     <message>
-        <location filename="../imports/shared/controls/GasSelector.qml" line="188" />
-        <location filename="../imports/shared/controls/GasSelector.qml" line="188" />
+        <location filename="../imports/shared/controls/GasSelector.qml" line="187" />
+        <location filename="../imports/shared/controls/GasSelector.qml" line="187" />
         <source>Current base fee: %1 %2</source>
         <translation>Current base fee: %1 %2</translation>
     </message>
     <message>
-        <location filename="../imports/shared/controls/GasSelector.qml" line="200" />
-        <location filename="../imports/shared/controls/GasSelector.qml" line="200" />
+        <location filename="../imports/shared/controls/GasSelector.qml" line="202" />
+        <location filename="../imports/shared/controls/GasSelector.qml" line="202" />
         <source>Use suggestions</source>
         <translation>Use suggestions</translation>
     </message>
     <message>
-        <location filename="../imports/shared/controls/GasSelector.qml" line="201" />
-        <location filename="../imports/shared/controls/GasSelector.qml" line="201" />
+        <location filename="../imports/shared/controls/GasSelector.qml" line="203" />
+        <location filename="../imports/shared/controls/GasSelector.qml" line="203" />
         <source>Use custom</source>
         <translation>Use custom</translation>
     </message>
     <message>
-        <location filename="../imports/shared/controls/GasSelector.qml" line="221" />
-        <location filename="../imports/shared/controls/GasSelector.qml" line="221" />
+        <location filename="../imports/shared/controls/GasSelector.qml" line="217" />
+        <location filename="../imports/shared/controls/GasSelector.qml" line="217" />
         <source>Low</source>
         <translation>Low</translation>
     </message>
     <message>
-        <location filename="../imports/shared/controls/GasSelector.qml" line="244" />
-        <location filename="../imports/shared/controls/GasSelector.qml" line="244" />
+        <location filename="../imports/shared/controls/GasSelector.qml" line="242" />
+        <location filename="../imports/shared/controls/GasSelector.qml" line="242" />
         <source>Optimal</source>
         <translation>Optimal</translation>
     </message>
     <message>
-        <location filename="../imports/shared/controls/GasSelector.qml" line="273" />
-        <location filename="../imports/shared/controls/GasSelector.qml" line="273" />
+        <location filename="../imports/shared/controls/GasSelector.qml" line="272" />
+        <location filename="../imports/shared/controls/GasSelector.qml" line="272" />
         <source>High</source>
         <translation>High</translation>
     </message>
     <message>
-        <location filename="../imports/shared/controls/GasSelector.qml" line="305" />
-        <location filename="../imports/shared/controls/GasSelector.qml" line="305" />
+        <location filename="../imports/shared/controls/GasSelector.qml" line="306" />
+        <location filename="../imports/shared/controls/GasSelector.qml" line="306" />
         <source>Gas amount limit</source>
         <translation>Gas amount limit</translation>
     </message>
     <message>
-        <location filename="../imports/shared/controls/GasSelector.qml" line="329" />
-        <location filename="../imports/shared/controls/GasSelector.qml" line="329" />
+        <location filename="../imports/shared/controls/GasSelector.qml" line="330" />
+        <location filename="../imports/shared/controls/GasSelector.qml" line="330" />
         <source>Per-gas tip limit</source>
         <translation>Per-gas tip limit</translation>
     </message>
     <message>
-        <location filename="../imports/shared/controls/GasSelector.qml" line="350" />
-        <location filename="../imports/shared/controls/GasSelector.qml" line="379" />
-        <location filename="../imports/shared/controls/GasSelector.qml" line="350" />
-        <location filename="../imports/shared/controls/GasSelector.qml" line="379" />
+        <location filename="../imports/shared/controls/GasSelector.qml" line="351" />
+        <location filename="../imports/shared/controls/GasSelector.qml" line="380" />
+        <location filename="../imports/shared/controls/GasSelector.qml" line="351" />
+        <location filename="../imports/shared/controls/GasSelector.qml" line="380" />
         <source>Gwei</source>
         <translation>Gwei</translation>
     </message>
     <message>
-        <location filename="../imports/shared/controls/GasSelector.qml" line="361" />
-        <location filename="../imports/shared/controls/GasSelector.qml" line="361" />
+        <location filename="../imports/shared/controls/GasSelector.qml" line="362" />
+        <location filename="../imports/shared/controls/GasSelector.qml" line="362" />
         <source>Per-gas overall limit</source>
         <translation>Per-gas overall limit</translation>
     </message>
     <message>
-        <location filename="../imports/shared/controls/GasSelector.qml" line="408" />
-        <location filename="../imports/shared/controls/GasSelector.qml" line="408" />
+        <location filename="../imports/shared/controls/GasSelector.qml" line="409" />
+        <location filename="../imports/shared/controls/GasSelector.qml" line="409" />
         <source>Maximum priority fee: %1 ETH</source>
         <translation>Maximum priority fee: %1 ETH</translation>
     </message>
     <message>
-        <location filename="../imports/shared/controls/GasSelector.qml" line="430" />
-        <location filename="../imports/shared/controls/GasSelector.qml" line="430" />
+        <location filename="../imports/shared/controls/GasSelector.qml" line="431" />
+        <location filename="../imports/shared/controls/GasSelector.qml" line="431" />
         <source>Maximum overall price for the transaction. If the block base fee exceeds this, it will be included in a following block with a lower base fee.</source>
         <translation>Maximum overall price for the transaction. If the block base fee exceeds this, it will be included in a following block with a lower base fee.</translation>
     </message>
@@ -4954,7 +6141,8 @@ chat with them once they have accepted your contact request.</translation>
 <context>
     <name>GasSelectorButton</name>
     <message>
-        <location filename="../imports/shared/controls/chat/GasSelectorButton.qml" line="13" />
+        <location filename="../imports/shared/controls/chat/GasSelectorButton.qml" line="14" />
+        <location filename="../imports/shared/controls/chat/GasSelectorButton.qml" line="14" />
         <source>Low</source>
         <translation>Low</translation>
     </message>
@@ -4972,70 +6160,90 @@ chat with them once they have accepted your contact request.</translation>
     <name>GroupChatPanel</name>
     <message>
         <location filename="../app/AppLayouts/Chat/panels/GroupChatPanel.qml" line="151" />
+        <location filename="../app/AppLayouts/Chat/panels/GroupChatPanel.qml" line="151" />
         <source>To: </source>
         <translation>To: </translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Chat/panels/GroupChatPanel.qml" line="152" />
+        <location filename="../app/AppLayouts/Chat/panels/GroupChatPanel.qml" line="152" />
         <source>USER LIMIT REACHED</source>
         <translation>USER LIMIT REACHED</translation>
+    </message>
+    <message>
+        <location filename="../app/AppLayouts/Chat/panels/GroupChatPanel.qml" line="168" />
+        <location filename="../app/AppLayouts/Chat/panels/GroupChatPanel.qml" line="168" />
+        <source>Confirm</source>
+        <translation type="unfinished">Confirm</translation>
     </message>
 </context>
 <context>
     <name>GroupInfoPopup</name>
     <message>
-        <location filename="../app/AppLayouts/Chat/popups/GroupInfoPopup.qml" line="58" />
-        <location filename="../app/AppLayouts/Chat/popups/GroupInfoPopup.qml" line="275" />
+        <location filename="../app/AppLayouts/Chat/popups/GroupInfoPopup.qml" line="57" />
+        <location filename="../app/AppLayouts/Chat/popups/GroupInfoPopup.qml" line="274" />
+        <location filename="../app/AppLayouts/Chat/popups/GroupInfoPopup.qml" line="57" />
+        <location filename="../app/AppLayouts/Chat/popups/GroupInfoPopup.qml" line="274" />
         <source>Add members</source>
         <translation>Add members</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/popups/GroupInfoPopup.qml" line="61" />
+        <location filename="../app/AppLayouts/Chat/popups/GroupInfoPopup.qml" line="60" />
+        <location filename="../app/AppLayouts/Chat/popups/GroupInfoPopup.qml" line="60" />
         <source>%1/%2 members</source>
         <translation>%1/%2 members</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/popups/GroupInfoPopup.qml" line="64" />
+        <location filename="../app/AppLayouts/Chat/popups/GroupInfoPopup.qml" line="63" />
+        <location filename="../app/AppLayouts/Chat/popups/GroupInfoPopup.qml" line="63" />
         <source>%1 members</source>
         <translation>%1 members</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/popups/GroupInfoPopup.qml" line="66" />
+        <location filename="../app/AppLayouts/Chat/popups/GroupInfoPopup.qml" line="65" />
+        <location filename="../app/AppLayouts/Chat/popups/GroupInfoPopup.qml" line="65" />
         <source>1 member</source>
         <translation>1 member</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/popups/GroupInfoPopup.qml" line="110" />
+        <location filename="../app/AppLayouts/Chat/popups/GroupInfoPopup.qml" line="109" />
+        <location filename="../app/AppLayouts/Chat/popups/GroupInfoPopup.qml" line="109" />
         <source>Search</source>
         <translation>Search</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/popups/GroupInfoPopup.qml" line="134" />
+        <location filename="../app/AppLayouts/Chat/popups/GroupInfoPopup.qml" line="133" />
+        <location filename="../app/AppLayouts/Chat/popups/GroupInfoPopup.qml" line="133" />
         <source>All your contacts are already in the group</source>
         <translation>All your contacts are already in the group</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/popups/GroupInfoPopup.qml" line="173" />
+        <location filename="../app/AppLayouts/Chat/popups/GroupInfoPopup.qml" line="172" />
+        <location filename="../app/AppLayouts/Chat/popups/GroupInfoPopup.qml" line="172" />
         <source>Pinned messages</source>
         <translation>Pinned messages</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/popups/GroupInfoPopup.qml" line="209" />
+        <location filename="../app/AppLayouts/Chat/popups/GroupInfoPopup.qml" line="208" />
+        <location filename="../app/AppLayouts/Chat/popups/GroupInfoPopup.qml" line="208" />
         <source>Admin</source>
         <translation>Admin</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/popups/GroupInfoPopup.qml" line="237" />
+        <location filename="../app/AppLayouts/Chat/popups/GroupInfoPopup.qml" line="236" />
+        <location filename="../app/AppLayouts/Chat/popups/GroupInfoPopup.qml" line="236" />
         <source>Make Admin</source>
         <translation>Make Admin</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/popups/GroupInfoPopup.qml" line="245" />
+        <location filename="../app/AppLayouts/Chat/popups/GroupInfoPopup.qml" line="244" />
+        <location filename="../app/AppLayouts/Chat/popups/GroupInfoPopup.qml" line="244" />
         <source>Remove From Group</source>
         <translation>Remove From Group</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/popups/GroupInfoPopup.qml" line="284" />
+        <location filename="../app/AppLayouts/Chat/popups/GroupInfoPopup.qml" line="283" />
+        <location filename="../app/AppLayouts/Chat/popups/GroupInfoPopup.qml" line="283" />
         <source>Add selected</source>
         <translation>Add selected</translation>
     </message>
@@ -5065,20 +6273,24 @@ chat with them once they have accepted your contact request.</translation>
     <name>HomePageView</name>
     <message>
         <location filename="../app/AppLayouts/Profile/views/browser/HomePageView.qml" line="18" />
+        <location filename="../app/AppLayouts/Profile/views/browser/HomePageView.qml" line="18" />
         <source>homepage</source>
         <translation>homepage</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/browser/HomePageView.qml" line="34" />
         <location filename="../app/AppLayouts/Profile/views/browser/HomePageView.qml" line="34" />
         <source>System default</source>
         <translation>System default</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/browser/HomePageView.qml" line="42" />
+        <location filename="../app/AppLayouts/Profile/views/browser/HomePageView.qml" line="42" />
         <source>Other</source>
         <translation>Other</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/browser/HomePageView.qml" line="50" />
         <location filename="../app/AppLayouts/Profile/views/browser/HomePageView.qml" line="50" />
         <source>Example: duckduckgo.com</source>
         <translation>Example: duckduckgo.com</translation>
@@ -5140,10 +6352,14 @@ chat with them once they have accepted your contact request.</translation>
     <message>
         <location filename="../app/AppLayouts/Wallet/panels/ImportPrivateKeyPanel.qml" line="27" />
         <location filename="../app/AppLayouts/Wallet/panels/ImportPrivateKeyPanel.qml" line="58" />
+        <location filename="../app/AppLayouts/Wallet/panels/ImportPrivateKeyPanel.qml" line="27" />
+        <location filename="../app/AppLayouts/Wallet/panels/ImportPrivateKeyPanel.qml" line="58" />
         <source>You need to enter a private key</source>
         <translation>You need to enter a private key</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Wallet/panels/ImportPrivateKeyPanel.qml" line="29" />
+        <location filename="../app/AppLayouts/Wallet/panels/ImportPrivateKeyPanel.qml" line="64" />
         <location filename="../app/AppLayouts/Wallet/panels/ImportPrivateKeyPanel.qml" line="29" />
         <location filename="../app/AppLayouts/Wallet/panels/ImportPrivateKeyPanel.qml" line="64" />
         <source>Enter a valid private key (64 characters hexadecimal string)</source>
@@ -5151,36 +6367,43 @@ chat with them once they have accepted your contact request.</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Wallet/panels/ImportPrivateKeyPanel.qml" line="48" />
+        <location filename="../app/AppLayouts/Wallet/panels/ImportPrivateKeyPanel.qml" line="48" />
         <source>Private key</source>
         <translation>Private key</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Wallet/panels/ImportPrivateKeyPanel.qml" line="53" />
+        <location filename="../app/AppLayouts/Wallet/panels/ImportPrivateKeyPanel.qml" line="53" />
         <source>Paste the contents of your private key</source>
         <translation>Paste the contents of your private key</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/panels/ImportPrivateKeyPanel.qml" line="87" />
+        <location filename="../app/AppLayouts/Wallet/panels/ImportPrivateKeyPanel.qml" line="86" />
+        <location filename="../app/AppLayouts/Wallet/panels/ImportPrivateKeyPanel.qml" line="86" />
         <source>Public address</source>
         <translation>Public address</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/panels/ImportPrivateKeyPanel.qml" line="101" />
+        <location filename="../app/AppLayouts/Wallet/panels/ImportPrivateKeyPanel.qml" line="100" />
+        <location filename="../app/AppLayouts/Wallet/panels/ImportPrivateKeyPanel.qml" line="100" />
         <source>Account already added</source>
         <translation>Account already added</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/panels/ImportPrivateKeyPanel.qml" line="101" />
+        <location filename="../app/AppLayouts/Wallet/panels/ImportPrivateKeyPanel.qml" line="100" />
+        <location filename="../app/AppLayouts/Wallet/panels/ImportPrivateKeyPanel.qml" line="100" />
         <source>Pending</source>
         <translation>Pending</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/panels/ImportPrivateKeyPanel.qml" line="102" />
+        <location filename="../app/AppLayouts/Wallet/panels/ImportPrivateKeyPanel.qml" line="101" />
+        <location filename="../app/AppLayouts/Wallet/panels/ImportPrivateKeyPanel.qml" line="101" />
         <source>Has Activity</source>
         <translation>Has Activity</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/panels/ImportPrivateKeyPanel.qml" line="102" />
+        <location filename="../app/AppLayouts/Wallet/panels/ImportPrivateKeyPanel.qml" line="101" />
+        <location filename="../app/AppLayouts/Wallet/panels/ImportPrivateKeyPanel.qml" line="101" />
         <source>No Activity</source>
         <translation>No Activity</translation>
     </message>
@@ -5190,16 +6413,20 @@ chat with them once they have accepted your contact request.</translation>
     <message>
         <location filename="../app/AppLayouts/Wallet/panels/ImportSeedPhrasePanel.qml" line="38" />
         <location filename="../app/AppLayouts/Wallet/panels/ImportSeedPhrasePanel.qml" line="43" />
+        <location filename="../app/AppLayouts/Wallet/panels/ImportSeedPhrasePanel.qml" line="38" />
+        <location filename="../app/AppLayouts/Wallet/panels/ImportSeedPhrasePanel.qml" line="43" />
         <source>Invalid seed phrase</source>
         <translation>Invalid seed phrase</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Wallet/panels/ImportSeedPhrasePanel.qml" line="44" />
+        <location filename="../app/AppLayouts/Wallet/panels/ImportSeedPhrasePanel.qml" line="44" />
         <source>This seed phrase doesn't match our supported dictionary. Check for misspelled words.</source>
         <translation>This seed phrase doesn't match our supported dictionary. Check for misspelled words.</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/panels/ImportSeedPhrasePanel.qml" line="258" />
+        <location filename="../app/AppLayouts/Wallet/panels/ImportSeedPhrasePanel.qml" line="256" />
+        <location filename="../app/AppLayouts/Wallet/panels/ImportSeedPhrasePanel.qml" line="256" />
         <source>%1 words</source>
         <translation>%1 words</translation>
     </message>
@@ -5207,28 +6434,26 @@ chat with them once they have accepted your contact request.</translation>
 <context>
     <name>Input</name>
     <message>
-        <location filename="../imports/shared/controls/Input.qml" line="170" />
-        <location filename="../imports/shared/controls/Input.qml" line="170" />
+        <location filename="../imports/shared/controls/Input.qml" line="165" />
+        <location filename="../imports/shared/controls/Input.qml" line="165" />
         <source>Copied</source>
         <translation>Copied</translation>
     </message>
     <message>
-        <location filename="../imports/shared/controls/Input.qml" line="171" />
-        <location filename="../imports/shared/controls/Input.qml" line="171" />
+        <location filename="../imports/shared/controls/Input.qml" line="166" />
+        <location filename="../imports/shared/controls/Input.qml" line="166" />
         <source>Pasted</source>
         <translation>Pasted</translation>
     </message>
     <message>
-        <location filename="../imports/shared/controls/Input.qml" line="174" />
-        <location filename="../imports/shared/controls/Input.qml" line="174" />
+        <location filename="../imports/shared/controls/Input.qml" line="169" />
+        <location filename="../imports/shared/controls/Input.qml" line="169" />
         <source>Copy</source>
         <translation>Copy</translation>
     </message>
     <message>
-        <location filename="../imports/shared/controls/Input.qml" line="175" />
-        <location filename="../imports/shared/controls/Input.qml" line="216" />
-        <location filename="../imports/shared/controls/Input.qml" line="175" />
-        <location filename="../imports/shared/controls/Input.qml" line="216" />
+        <location filename="../imports/shared/controls/Input.qml" line="170" />
+        <location filename="../imports/shared/controls/Input.qml" line="170" />
         <source>Paste</source>
         <translation>Paste</translation>
     </message>
@@ -5253,10 +6478,14 @@ chat with them once they have accepted your contact request.</translation>
     <message>
         <location filename="../app/AppLayouts/Onboarding/views/InsertDetailsView.qml" line="62" />
         <location filename="../app/AppLayouts/Onboarding/views/InsertDetailsView.qml" line="249" />
+        <location filename="../app/AppLayouts/Onboarding/views/InsertDetailsView.qml" line="62" />
+        <location filename="../app/AppLayouts/Onboarding/views/InsertDetailsView.qml" line="249" />
         <source>Your profile</source>
         <translation>Your profile</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Onboarding/views/InsertDetailsView.qml" line="75" />
+        <location filename="../app/AppLayouts/Onboarding/views/InsertDetailsView.qml" line="253" />
         <location filename="../app/AppLayouts/Onboarding/views/InsertDetailsView.qml" line="75" />
         <location filename="../app/AppLayouts/Onboarding/views/InsertDetailsView.qml" line="253" />
         <source>Longer and unusual names are better as they are less likely to be used by someone else.</source>
@@ -5264,40 +6493,48 @@ chat with them once they have accepted your contact request.</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Onboarding/views/InsertDetailsView.qml" line="129" />
+        <location filename="../app/AppLayouts/Onboarding/views/InsertDetailsView.qml" line="129" />
         <source>Display name</source>
         <translation>Display name</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Onboarding/views/InsertDetailsView.qml" line="164" />
         <location filename="../app/AppLayouts/Onboarding/views/InsertDetailsView.qml" line="164" />
         <source>Chatkey:</source>
         <translation>Chatkey:</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Onboarding/views/InsertDetailsView.qml" line="213" />
+        <location filename="../app/AppLayouts/Onboarding/views/InsertDetailsView.qml" line="213" />
         <source>Next</source>
         <translation>Next</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Onboarding/views/InsertDetailsView.qml" line="230" />
         <location filename="../app/AppLayouts/Onboarding/views/InsertDetailsView.qml" line="230" />
         <source>Choose an image for profile picture</source>
         <translation>Choose an image for profile picture</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Onboarding/views/InsertDetailsView.qml" line="231" />
+        <location filename="../app/AppLayouts/Onboarding/views/InsertDetailsView.qml" line="231" />
         <source>Profile picture</source>
         <translation>Profile picture</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Onboarding/views/InsertDetailsView.qml" line="232" />
         <location filename="../app/AppLayouts/Onboarding/views/InsertDetailsView.qml" line="232" />
         <source>Make this my profile picture</source>
         <translation>Make this my profile picture</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Onboarding/views/InsertDetailsView.qml" line="280" />
+        <location filename="../app/AppLayouts/Onboarding/views/InsertDetailsView.qml" line="280" />
         <source>Your emojihash and identicon ring</source>
         <translation>Your emojihash and identicon ring</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Onboarding/views/InsertDetailsView.qml" line="284" />
         <location filename="../app/AppLayouts/Onboarding/views/InsertDetailsView.qml" line="284" />
         <source>This set of emojis and coloured ring around your avatar are unique and represent your chat key, so your friends can easily distinguish you from potential impersonators.</source>
         <translation>This set of emojis and coloured ring around your avatar are unique and represent your chat key, so your friends can easily distinguish you from potential impersonators.</translation>
@@ -5307,55 +6544,66 @@ chat with them once they have accepted your contact request.</translation>
     <name>InvitationBubbleView</name>
     <message>
         <location filename="../imports/shared/views/chat/InvitationBubbleView.qml" line="92" />
+        <location filename="../imports/shared/views/chat/InvitationBubbleView.qml" line="92" />
         <source>Membership requires an ENS username</source>
         <translation>Membership requires an ENS username</translation>
     </message>
     <message>
+        <location filename="../imports/shared/views/chat/InvitationBubbleView.qml" line="101" />
         <location filename="../imports/shared/views/chat/InvitationBubbleView.qml" line="101" />
         <source>You need to be invited</source>
         <translation>You need to be invited</translation>
     </message>
     <message>
         <location filename="../imports/shared/views/chat/InvitationBubbleView.qml" line="111" />
+        <location filename="../imports/shared/views/chat/InvitationBubbleView.qml" line="111" />
         <source>Pending</source>
         <translation>Pending</translation>
     </message>
     <message>
+        <location filename="../imports/shared/views/chat/InvitationBubbleView.qml" line="122" />
         <location filename="../imports/shared/views/chat/InvitationBubbleView.qml" line="122" />
         <source>View</source>
         <translation>View</translation>
     </message>
     <message>
         <location filename="../imports/shared/views/chat/InvitationBubbleView.qml" line="132" />
+        <location filename="../imports/shared/views/chat/InvitationBubbleView.qml" line="132" />
         <source>Request Access</source>
         <translation>Request Access</translation>
     </message>
     <message>
+        <location filename="../imports/shared/views/chat/InvitationBubbleView.qml" line="144" />
         <location filename="../imports/shared/views/chat/InvitationBubbleView.qml" line="144" />
         <source>Join</source>
         <translation>Join</translation>
     </message>
     <message>
         <location filename="../imports/shared/views/chat/InvitationBubbleView.qml" line="169" />
+        <location filename="../imports/shared/views/chat/InvitationBubbleView.qml" line="169" />
         <source>Verified community invitation</source>
         <translation>Verified community invitation</translation>
     </message>
     <message>
+        <location filename="../imports/shared/views/chat/InvitationBubbleView.qml" line="170" />
         <location filename="../imports/shared/views/chat/InvitationBubbleView.qml" line="170" />
         <source>Community invitation</source>
         <translation>Community invitation</translation>
     </message>
     <message>
         <location filename="../imports/shared/views/chat/InvitationBubbleView.qml" line="232" />
+        <location filename="../imports/shared/views/chat/InvitationBubbleView.qml" line="232" />
         <source>%1 members</source>
         <translation>%1 members</translation>
     </message>
     <message>
         <location filename="../imports/shared/views/chat/InvitationBubbleView.qml" line="255" />
+        <location filename="../imports/shared/views/chat/InvitationBubbleView.qml" line="255" />
         <source>Unsupported state</source>
         <translation>Unsupported state</translation>
     </message>
     <message>
+        <location filename="../imports/shared/views/chat/InvitationBubbleView.qml" line="288" />
         <location filename="../imports/shared/views/chat/InvitationBubbleView.qml" line="288" />
         <source>Error joining the community</source>
         <translation>Error joining the community</translation>
@@ -5386,15 +6634,18 @@ chat with them once they have accepted your contact request.</translation>
     <name>InviteFriendsToCommunityPopup</name>
     <message>
         <location filename="../app/AppLayouts/Chat/popups/community/InviteFriendsToCommunityPopup.qml" line="41" />
+        <location filename="../app/AppLayouts/Chat/popups/community/InviteFriendsToCommunityPopup.qml" line="41" />
         <source>Invite friends</source>
         <translation>Invite friends</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Chat/popups/community/InviteFriendsToCommunityPopup.qml" line="49" />
+        <location filename="../app/AppLayouts/Chat/popups/community/InviteFriendsToCommunityPopup.qml" line="49" />
         <source>Invite successfully sent</source>
         <translation>Invite successfully sent</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Chat/popups/community/InviteFriendsToCommunityPopup.qml" line="74" />
         <location filename="../app/AppLayouts/Chat/popups/community/InviteFriendsToCommunityPopup.qml" line="74" />
         <source>Invite</source>
         <translation>Invite</translation>
@@ -5404,10 +6655,12 @@ chat with them once they have accepted your contact request.</translation>
     <name>JSDialogWindow</name>
     <message>
         <location filename="../app/AppLayouts/Browser/popups/JSDialogWindow.qml" line="66" />
+        <location filename="../app/AppLayouts/Browser/popups/JSDialogWindow.qml" line="66" />
         <source>Ok</source>
         <translation>Ok</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Browser/popups/JSDialogWindow.qml" line="78" />
         <location filename="../app/AppLayouts/Browser/popups/JSDialogWindow.qml" line="78" />
         <source>Cancel</source>
         <translation>Cancel</translation>
@@ -5418,20 +6671,25 @@ chat with them once they have accepted your contact request.</translation>
     <message>
         <location filename="../app/AppLayouts/Onboarding/popups/KeycardCreatePINModal.qml" line="26" />
         <location filename="../app/AppLayouts/Onboarding/popups/KeycardCreatePINModal.qml" line="105" />
+        <location filename="../app/AppLayouts/Onboarding/popups/KeycardCreatePINModal.qml" line="26" />
+        <location filename="../app/AppLayouts/Onboarding/popups/KeycardCreatePINModal.qml" line="105" />
         <source>Create PIN</source>
         <translation>Create PIN</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Onboarding/popups/KeycardCreatePINModal.qml" line="43" />
         <location filename="../app/AppLayouts/Onboarding/popups/KeycardCreatePINModal.qml" line="43" />
         <source>New PIN</source>
         <translation>New PIN</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Onboarding/popups/KeycardCreatePINModal.qml" line="60" />
+        <location filename="../app/AppLayouts/Onboarding/popups/KeycardCreatePINModal.qml" line="60" />
         <source>Confirm PIN</source>
         <translation>Confirm PIN</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Onboarding/popups/KeycardCreatePINModal.qml" line="90" />
         <location filename="../app/AppLayouts/Onboarding/popups/KeycardCreatePINModal.qml" line="90" />
         <source>Create a 6 digit long PIN</source>
         <translation>Create a 6 digit long PIN</translation>
@@ -5441,35 +6699,42 @@ chat with them once they have accepted your contact request.</translation>
     <name>KeysMainView</name>
     <message>
         <location filename="../app/AppLayouts/Onboarding/views/KeysMainView.qml" line="48" />
+        <location filename="../app/AppLayouts/Onboarding/views/KeysMainView.qml" line="48" />
         <source>intro-wizard-title1</source>
         <translation>intro-wizard-title1</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Onboarding/views/KeysMainView.qml" line="65" />
         <location filename="../app/AppLayouts/Onboarding/views/KeysMainView.qml" line="65" />
         <source>a-set-of-keys-controls-your-account.-your-keys-live-on-your-device,-so-only-you-can-use-them.</source>
         <translation>a-set-of-keys-controls-your-account.-your-keys-live-on-your-device,-so-only-you-can-use-them.</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Onboarding/views/KeysMainView.qml" line="138" />
+        <location filename="../app/AppLayouts/Onboarding/views/KeysMainView.qml" line="138" />
         <source>Connect your keys</source>
         <translation>Connect your keys</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Onboarding/views/KeysMainView.qml" line="142" />
         <location filename="../app/AppLayouts/Onboarding/views/KeysMainView.qml" line="142" />
         <source>Use your existing Status keys to login to this device.</source>
         <translation>Use your existing Status keys to login to this device.</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Onboarding/views/KeysMainView.qml" line="156" />
+        <location filename="../app/AppLayouts/Onboarding/views/KeysMainView.qml" line="156" />
         <source>Enter a seed phrase</source>
         <translation>Enter a seed phrase</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Onboarding/views/KeysMainView.qml" line="168" />
+        <location filename="../app/AppLayouts/Onboarding/views/KeysMainView.qml" line="168" />
         <source>Get your keys</source>
         <translation>Get your keys</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Onboarding/views/KeysMainView.qml" line="172" />
         <location filename="../app/AppLayouts/Onboarding/views/KeysMainView.qml" line="172" />
         <source>A set of keys controls your account. Your keys live on your
 device, so only you can use them.</source>
@@ -5478,10 +6743,14 @@ device, so only you can use them.</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Onboarding/views/KeysMainView.qml" line="176" />
+        <location filename="../app/AppLayouts/Onboarding/views/KeysMainView.qml" line="176" />
         <source>Generate new keys</source>
         <translation>Generate new keys</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Onboarding/views/KeysMainView.qml" line="186" />
+        <location filename="../app/AppLayouts/Onboarding/views/KeysMainView.qml" line="198" />
+        <location filename="../app/AppLayouts/Onboarding/views/KeysMainView.qml" line="213" />
         <location filename="../app/AppLayouts/Onboarding/views/KeysMainView.qml" line="186" />
         <location filename="../app/AppLayouts/Onboarding/views/KeysMainView.qml" line="198" />
         <location filename="../app/AppLayouts/Onboarding/views/KeysMainView.qml" line="213" />
@@ -5490,73 +6759,114 @@ device, so only you can use them.</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Onboarding/views/KeysMainView.qml" line="208" />
+        <location filename="../app/AppLayouts/Onboarding/views/KeysMainView.qml" line="208" />
         <source>Seed phrases are used to back up and restore your keys. Only use this option if you already have a seed phrase.</source>
         <translation>Seed phrases are used to back up and restore your keys. Only use this option if you already have a seed phrase.</translation>
+    </message>
+</context>
+<context>
+    <name>LanguageStore</name>
+    <message>
+        <location filename="../app/AppLayouts/Profile/stores/LanguageStore.qml" line="19" />
+        <location filename="../app/AppLayouts/Profile/stores/LanguageStore.qml" line="20" />
+        <location filename="../app/AppLayouts/Profile/stores/LanguageStore.qml" line="21" />
+        <location filename="../app/AppLayouts/Profile/stores/LanguageStore.qml" line="22" />
+        <location filename="../app/AppLayouts/Profile/stores/LanguageStore.qml" line="23" />
+        <location filename="../app/AppLayouts/Profile/stores/LanguageStore.qml" line="24" />
+        <location filename="../app/AppLayouts/Profile/stores/LanguageStore.qml" line="25" />
+        <location filename="../app/AppLayouts/Profile/stores/LanguageStore.qml" line="26" />
+        <location filename="../app/AppLayouts/Profile/stores/LanguageStore.qml" line="27" />
+        <location filename="../app/AppLayouts/Profile/stores/LanguageStore.qml" line="28" />
+        <location filename="../app/AppLayouts/Profile/stores/LanguageStore.qml" line="19" />
+        <location filename="../app/AppLayouts/Profile/stores/LanguageStore.qml" line="20" />
+        <location filename="../app/AppLayouts/Profile/stores/LanguageStore.qml" line="21" />
+        <location filename="../app/AppLayouts/Profile/stores/LanguageStore.qml" line="22" />
+        <location filename="../app/AppLayouts/Profile/stores/LanguageStore.qml" line="23" />
+        <location filename="../app/AppLayouts/Profile/stores/LanguageStore.qml" line="24" />
+        <location filename="../app/AppLayouts/Profile/stores/LanguageStore.qml" line="25" />
+        <location filename="../app/AppLayouts/Profile/stores/LanguageStore.qml" line="26" />
+        <location filename="../app/AppLayouts/Profile/stores/LanguageStore.qml" line="27" />
+        <location filename="../app/AppLayouts/Profile/stores/LanguageStore.qml" line="28" />
+        <source>Beta Languages</source>
+        <translation>Beta Languages</translation>
     </message>
 </context>
 <context>
     <name>LanguageView</name>
     <message>
         <location filename="../app/AppLayouts/Profile/views/LanguageView.qml" line="49" />
+        <location filename="../app/AppLayouts/Profile/views/LanguageView.qml" line="49" />
         <source>Set Display Currency</source>
         <translation>Set Display Currency</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/LanguageView.qml" line="74" />
         <location filename="../app/AppLayouts/Profile/views/LanguageView.qml" line="74" />
         <source>Search Currencies</source>
         <translation>Search Currencies</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/LanguageView.qml" line="95" />
+        <location filename="../app/AppLayouts/Profile/views/LanguageView.qml" line="95" />
         <source>Language</source>
         <translation>Language</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/LanguageView.qml" line="119" />
         <location filename="../app/AppLayouts/Profile/views/LanguageView.qml" line="119" />
         <source>Search Languages</source>
         <translation>Search Languages</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/LanguageView.qml" line="151" />
+        <location filename="../app/AppLayouts/Profile/views/LanguageView.qml" line="151" />
         <source>Date Format</source>
         <translation>Date Format</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/LanguageView.qml" line="160" />
         <location filename="../app/AppLayouts/Profile/views/LanguageView.qml" line="160" />
         <source>DD/MM/YY</source>
         <translation>DD/MM/YY</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/LanguageView.qml" line="169" />
+        <location filename="../app/AppLayouts/Profile/views/LanguageView.qml" line="169" />
         <source>MM/DD/YY</source>
         <translation>MM/DD/YY</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/LanguageView.qml" line="185" />
         <location filename="../app/AppLayouts/Profile/views/LanguageView.qml" line="185" />
         <source>Time Format</source>
         <translation>Time Format</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/LanguageView.qml" line="194" />
+        <location filename="../app/AppLayouts/Profile/views/LanguageView.qml" line="194" />
         <source>24-Hour Time</source>
         <translation>24-Hour Time</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/LanguageView.qml" line="203" />
         <location filename="../app/AppLayouts/Profile/views/LanguageView.qml" line="203" />
         <source>12-Hour Time</source>
         <translation>12-Hour Time</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/LanguageView.qml" line="218" />
+        <location filename="../app/AppLayouts/Profile/views/LanguageView.qml" line="218" />
         <source>Change language</source>
         <translation>Change language</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/LanguageView.qml" line="219" />
+        <location filename="../app/AppLayouts/Profile/views/LanguageView.qml" line="219" />
         <source>Display language has been changed. You must restart the application for changes to take effect.</source>
         <translation>Display language has been changed. You must restart the application for changes to take effect.</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/LanguageView.qml" line="220" />
         <location filename="../app/AppLayouts/Profile/views/LanguageView.qml" line="220" />
         <source>Close the app now</source>
         <translation>Close the app now</translation>
@@ -5566,15 +6876,21 @@ device, so only you can use them.</translation>
     <name>Layout</name>
     <message>
         <location filename="../StatusQ/sandbox/controls/Layout.qml" line="99" />
+        <location filename="../StatusQ/sandbox/controls/Layout.qml" line="99" />
         <source>To: </source>
         <translation>To: </translation>
     </message>
     <message>
         <location filename="../StatusQ/sandbox/controls/Layout.qml" line="100" />
+        <location filename="../StatusQ/sandbox/controls/Layout.qml" line="100" />
         <source>USER LIMIT REACHED</source>
         <translation>USER LIMIT REACHED</translation>
     </message>
     <message>
+        <location filename="../StatusQ/sandbox/controls/Layout.qml" line="207" />
+        <location filename="../StatusQ/sandbox/controls/Layout.qml" line="292" />
+        <location filename="../StatusQ/sandbox/controls/Layout.qml" line="382" />
+        <location filename="../StatusQ/sandbox/controls/Layout.qml" line="477" />
         <location filename="../StatusQ/sandbox/controls/Layout.qml" line="207" />
         <location filename="../StatusQ/sandbox/controls/Layout.qml" line="292" />
         <location filename="../StatusQ/sandbox/controls/Layout.qml" line="382" />
@@ -5587,10 +6903,18 @@ device, so only you can use them.</translation>
         <location filename="../StatusQ/sandbox/controls/Layout.qml" line="297" />
         <location filename="../StatusQ/sandbox/controls/Layout.qml" line="387" />
         <location filename="../StatusQ/sandbox/controls/Layout.qml" line="482" />
+        <location filename="../StatusQ/sandbox/controls/Layout.qml" line="212" />
+        <location filename="../StatusQ/sandbox/controls/Layout.qml" line="297" />
+        <location filename="../StatusQ/sandbox/controls/Layout.qml" line="387" />
+        <location filename="../StatusQ/sandbox/controls/Layout.qml" line="482" />
         <source>View Community</source>
         <translation>View Community</translation>
     </message>
     <message>
+        <location filename="../StatusQ/sandbox/controls/Layout.qml" line="217" />
+        <location filename="../StatusQ/sandbox/controls/Layout.qml" line="302" />
+        <location filename="../StatusQ/sandbox/controls/Layout.qml" line="392" />
+        <location filename="../StatusQ/sandbox/controls/Layout.qml" line="487" />
         <location filename="../StatusQ/sandbox/controls/Layout.qml" line="217" />
         <location filename="../StatusQ/sandbox/controls/Layout.qml" line="302" />
         <location filename="../StatusQ/sandbox/controls/Layout.qml" line="392" />
@@ -5603,6 +6927,10 @@ device, so only you can use them.</translation>
         <location filename="../StatusQ/sandbox/controls/Layout.qml" line="310" />
         <location filename="../StatusQ/sandbox/controls/Layout.qml" line="400" />
         <location filename="../StatusQ/sandbox/controls/Layout.qml" line="495" />
+        <location filename="../StatusQ/sandbox/controls/Layout.qml" line="225" />
+        <location filename="../StatusQ/sandbox/controls/Layout.qml" line="310" />
+        <location filename="../StatusQ/sandbox/controls/Layout.qml" line="400" />
+        <location filename="../StatusQ/sandbox/controls/Layout.qml" line="495" />
         <source>Leave Community</source>
         <translation>Leave Community</translation>
     </message>
@@ -5611,41 +6939,49 @@ device, so only you can use them.</translation>
     <name>LeftTabView</name>
     <message>
         <location filename="../app/AppLayouts/Profile/views/LeftTabView.qml" line="19" />
+        <location filename="../app/AppLayouts/Profile/views/LeftTabView.qml" line="19" />
         <source>Settings</source>
         <translation>Settings</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/LeftTabView.qml" line="72" />
         <location filename="../app/AppLayouts/Profile/views/LeftTabView.qml" line="72" />
         <source>Sign out</source>
         <translation>Sign out</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/LeftTabView.qml" line="73" />
+        <location filename="../app/AppLayouts/Profile/views/LeftTabView.qml" line="73" />
         <source>Make sure you have your account password and seed phrase stored. Without them you can lock yourself out of your account and lose funds.</source>
         <translation>Make sure you have your account password and seed phrase stored. Without them you can lock yourself out of your account and lose funds.</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/LeftTabView.qml" line="74" />
+        <location filename="../app/AppLayouts/Profile/views/LeftTabView.qml" line="74" />
         <source>Sign out &amp; Quit</source>
         <translation>Sign out &amp; Quit</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/views/LeftTabView.qml" line="34" />
+        <location filename="../app/AppLayouts/Wallet/views/LeftTabView.qml" line="47" />
+        <location filename="../app/AppLayouts/Wallet/views/LeftTabView.qml" line="47" />
         <source>Wallet</source>
         <translation>Wallet</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/views/LeftTabView.qml" line="69" />
+        <location filename="../app/AppLayouts/Wallet/views/LeftTabView.qml" line="73" />
+        <location filename="../app/AppLayouts/Wallet/views/LeftTabView.qml" line="73" />
         <source>Total value</source>
         <translation>Total value</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/views/LeftTabView.qml" line="130" />
+        <location filename="../app/AppLayouts/Wallet/views/LeftTabView.qml" line="129" />
+        <location filename="../app/AppLayouts/Wallet/views/LeftTabView.qml" line="129" />
         <source>Add account</source>
         <translation>Add account</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/views/LeftTabView.qml" line="150" />
+        <location filename="../app/AppLayouts/Wallet/views/LeftTabView.qml" line="148" />
+        <location filename="../app/AppLayouts/Wallet/views/LeftTabView.qml" line="148" />
         <source>Saved addresses</source>
         <translation>Saved addresses</translation>
     </message>
@@ -5654,25 +6990,30 @@ device, so only you can use them.</translation>
     <name>LinksMessageView</name>
     <message>
         <location filename="../imports/shared/views/chat/LinksMessageView.qml" line="347" />
+        <location filename="../imports/shared/views/chat/LinksMessageView.qml" line="347" />
         <source>Enable automatic image unfurling</source>
         <translation>Enable automatic image unfurling</translation>
     </message>
     <message>
+        <location filename="../imports/shared/views/chat/LinksMessageView.qml" line="348" />
         <location filename="../imports/shared/views/chat/LinksMessageView.qml" line="348" />
         <source>Enable link previews in chat?</source>
         <translation>Enable link previews in chat?</translation>
     </message>
     <message>
         <location filename="../imports/shared/views/chat/LinksMessageView.qml" line="360" />
+        <location filename="../imports/shared/views/chat/LinksMessageView.qml" line="360" />
         <source>Once enabled, links posted in the chat may share your metadata with their owners</source>
         <translation>Once enabled, links posted in the chat may share your metadata with their owners</translation>
     </message>
     <message>
         <location filename="../imports/shared/views/chat/LinksMessageView.qml" line="377" />
+        <location filename="../imports/shared/views/chat/LinksMessageView.qml" line="377" />
         <source>Enable in Settings</source>
         <translation>Enable in Settings</translation>
     </message>
     <message>
+        <location filename="../imports/shared/views/chat/LinksMessageView.qml" line="392" />
         <location filename="../imports/shared/views/chat/LinksMessageView.qml" line="392" />
         <source>Don't ask me again</source>
         <translation>Don't ask me again</translation>
@@ -5681,74 +7022,119 @@ device, so only you can use them.</translation>
 <context>
     <name>LoginView</name>
     <message>
-        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="77" />
+        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="78" />
+        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="78" />
         <source>Ok</source>
         <translation>Ok</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="106" />
+        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="107" />
+        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="107" />
         <source>Welcome back</source>
         <translation>Welcome back</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="200" />
+        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="201" />
+        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="201" />
         <source>Add new user</source>
         <translation>Add new user</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="208" />
+        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="209" />
+        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="209" />
         <source>Add existing Status user</source>
         <translation>Add existing Status user</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="229" />
+        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="230" />
+        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="230" />
         <source>Connecting...</source>
         <translation>Connecting...</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="230" />
-        <source>Enter password</source>
-        <translation>Enter password</translation>
+        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="231" />
+        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="231" />
+        <source>Password</source>
+        <translation type="unfinished">Password</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="278" />
+        <source>Enter password</source>
+        <translation type="vanished">Enter password</translation>
+    </message>
+    <message>
+        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="279" />
+        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="279" />
         <source>Login failed: %1</source>
         <translation>Login failed: %1</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="289" />
+        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="290" />
+        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="290" />
         <source>Password incorrect</source>
         <translation>Password incorrect</translation>
+    </message>
+</context>
+<context>
+    <name>MailserverConnectionDialog</name>
+    <message>
+        <location filename="../app/mainui/popups/MailserverConnectionDialog.qml" line="15" />
+        <location filename="../app/mainui/popups/MailserverConnectionDialog.qml" line="15" />
+        <source>Can not connect to mailserver</source>
+        <translation type="unfinished">Can not connect to mailserver</translation>
+    </message>
+    <message>
+        <location filename="../app/mainui/popups/MailserverConnectionDialog.qml" line="19" />
+        <location filename="../app/mainui/popups/MailserverConnectionDialog.qml" line="19" />
+        <source>The mailserver you're connecting to is unavailable.</source>
+        <translation type="unfinished">The mailserver you're connecting to is unavailable.</translation>
+    </message>
+    <message>
+        <location filename="../app/mainui/popups/MailserverConnectionDialog.qml" line="25" />
+        <location filename="../app/mainui/popups/MailserverConnectionDialog.qml" line="25" />
+        <source>Pick another</source>
+        <translation type="unfinished">Pick another</translation>
+    </message>
+    <message>
+        <location filename="../app/mainui/popups/MailserverConnectionDialog.qml" line="32" />
+        <location filename="../app/mainui/popups/MailserverConnectionDialog.qml" line="32" />
+        <source>Retry</source>
+        <translation type="unfinished">Retry</translation>
     </message>
 </context>
 <context>
     <name>MainView</name>
     <message>
         <location filename="../app/AppLayouts/Profile/views/wallet/MainView.qml" line="55" />
+        <location filename="../app/AppLayouts/Profile/views/wallet/MainView.qml" line="55" />
         <source>DApp Permissions</source>
         <translation>DApp Permissions</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/wallet/MainView.qml" line="73" />
         <location filename="../app/AppLayouts/Profile/views/wallet/MainView.qml" line="73" />
         <source>Networks</source>
         <translation>Networks</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/wallet/MainView.qml" line="92" />
+        <location filename="../app/AppLayouts/Profile/views/wallet/MainView.qml" line="92" />
         <source>Accounts</source>
         <translation>Accounts</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/wallet/MainView.qml" line="96" />
         <location filename="../app/AppLayouts/Profile/views/wallet/MainView.qml" line="96" />
         <source>Generated from Your Seed Phrase</source>
         <translation>Generated from Your Seed Phrase</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/wallet/MainView.qml" line="113" />
+        <location filename="../app/AppLayouts/Profile/views/wallet/MainView.qml" line="113" />
         <source>Imported</source>
         <translation>Imported</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/wallet/MainView.qml" line="130" />
         <location filename="../app/AppLayouts/Profile/views/wallet/MainView.qml" line="130" />
         <source>Watch-Only</source>
         <translation>Watch-Only</translation>
@@ -5758,6 +7144,7 @@ device, so only you can use them.</translation>
     <name>MembershipRequestsPopup</name>
     <message>
         <location filename="../app/AppLayouts/Chat/popups/community/MembershipRequestsPopup.qml" line="23" />
+        <location filename="../app/AppLayouts/Chat/popups/community/MembershipRequestsPopup.qml" line="23" />
         <source>Membership requests</source>
         <translation>Membership requests</translation>
     </message>
@@ -5766,16 +7153,19 @@ device, so only you can use them.</translation>
     <name>MenuPanel</name>
     <message>
         <location filename="../app/AppLayouts/Profile/panels/MenuPanel.qml" line="53" />
+        <location filename="../app/AppLayouts/Profile/panels/MenuPanel.qml" line="53" />
         <source>Apps</source>
         <translation>Apps</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/panels/MenuPanel.qml" line="81" />
+        <location filename="../app/AppLayouts/Profile/panels/MenuPanel.qml" line="82" />
+        <location filename="../app/AppLayouts/Profile/panels/MenuPanel.qml" line="82" />
         <source>Settings</source>
         <translation>Settings</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/panels/MenuPanel.qml" line="96" />
+        <location filename="../app/AppLayouts/Profile/panels/MenuPanel.qml" line="98" />
+        <location filename="../app/AppLayouts/Profile/panels/MenuPanel.qml" line="98" />
         <source>About &amp; Help</source>
         <translation>About &amp; Help</translation>
     </message>
@@ -5783,77 +7173,92 @@ device, so only you can use them.</translation>
 <context>
     <name>MessageContextMenuView</name>
     <message>
-        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="151" />
+        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="161" />
+        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="161" />
         <source>Copy image</source>
         <translation>Copy image</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="164" />
+        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="174" />
+        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="174" />
         <source>Download image</source>
         <translation>Download image</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="201" />
+        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="211" />
+        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="211" />
         <source>Block User</source>
         <translation>Block User</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="212" />
+        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="222" />
+        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="222" />
         <source>Unblock User</source>
         <translation>Unblock User</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="222" />
+        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="232" />
+        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="232" />
         <source>Rename</source>
         <translation>Rename</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="233" />
+        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="243" />
+        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="243" />
         <source>Reply to</source>
         <translation>Reply to</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="248" />
+        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="258" />
+        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="258" />
         <source>Edit message</source>
         <translation>Edit message</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="264" />
+        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="274" />
+        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="274" />
         <source>Copy Message Id</source>
         <translation>Copy Message Id</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="277" />
+        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="287" />
+        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="287" />
         <source>Unpin</source>
         <translation>Unpin</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="279" />
+        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="289" />
+        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="289" />
         <source>Pin</source>
         <translation>Pin</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="339" />
+        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="349" />
+        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="349" />
         <source>Delete message</source>
         <translation>Delete message</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="355" />
+        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="365" />
+        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="365" />
         <source>Jump to</source>
         <translation>Jump to</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="366" />
+        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="376" />
+        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="376" />
         <source>Please choose a directory</source>
         <translation>Please choose a directory</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="383" />
+        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="393" />
+        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="393" />
         <source>Confirm deleting this message</source>
         <translation>Confirm deleting this message</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="384" />
+        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="394" />
+        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="394" />
         <source>Are you sure you want to delete this message? Be aware that other clients are not guaranteed to delete the message as well.</source>
         <translation>Are you sure you want to delete this message? Be aware that other clients are not guaranteed to delete the message as well.</translation>
     </message>
@@ -5862,20 +7267,24 @@ device, so only you can use them.</translation>
     <name>MessageStore</name>
     <message>
         <location filename="../app/AppLayouts/Chat/stores/MessageStore.qml" line="139" />
+        <location filename="../app/AppLayouts/Chat/stores/MessageStore.qml" line="139" />
         <source> and </source>
         <translation> and </translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Chat/stores/MessageStore.qml" line="165" />
         <location filename="../app/AppLayouts/Chat/stores/MessageStore.qml" line="165" />
         <source>%1 more</source>
         <translation>%1 more</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Chat/stores/MessageStore.qml" line="173" />
+        <location filename="../app/AppLayouts/Chat/stores/MessageStore.qml" line="173" />
         <source> reacted with </source>
         <translation> reacted with </translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/stores/MessageStore.qml" line="46" />
         <location filename="../app/AppLayouts/stores/MessageStore.qml" line="46" />
         <source>You</source>
         <translation>You</translation>
@@ -5884,90 +7293,110 @@ device, so only you can use them.</translation>
 <context>
     <name>MessagingView</name>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="51" />
+        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="52" />
+        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="52" />
         <source>Allow new contact requests</source>
         <translation>Allow new contact requests</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="76" />
+        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="77" />
+        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="77" />
         <source>Show My Profile Picture To</source>
         <translation>Show My Profile Picture To</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="85" />
-        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="135" />
+        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="86" />
+        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="136" />
+        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="86" />
+        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="136" />
         <source>Everyone</source>
         <translation>Everyone</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="98" />
-        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="148" />
+        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="99" />
+        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="149" />
+        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="99" />
+        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="149" />
         <source>Contacts</source>
         <translation>Contacts</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="111" />
-        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="161" />
+        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="112" />
+        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="162" />
+        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="112" />
+        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="162" />
         <source>No One</source>
         <translation>No One</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="126" />
+        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="127" />
+        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="127" />
         <source>See Profile Pictures From</source>
         <translation>See Profile Pictures From</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="176" />
+        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="177" />
+        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="177" />
         <source>Open Message Links With</source>
         <translation>Open Message Links With</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="185" />
+        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="186" />
+        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="186" />
         <source>Status Browser</source>
         <translation>Status Browser</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="198" />
+        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="199" />
+        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="199" />
         <source>System Default Browser</source>
         <translation>System Default Browser</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="215" />
+        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="216" />
+        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="216" />
         <source>Contacts, Requests, and Blocked Users</source>
         <translation>Contacts, Requests, and Blocked Users</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="229" />
+        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="230" />
+        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="230" />
         <source>Display Message Link Previews</source>
         <translation>Display Message Link Previews</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="284" />
+        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="285" />
+        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="285" />
         <source>Fine tune which sites to allow link previews</source>
         <translation>Fine tune which sites to allow link previews</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="307" />
+        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="308" />
+        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="308" />
         <source>Image unfurling</source>
         <translation>Image unfurling</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="308" />
+        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="309" />
+        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="309" />
         <source>All images (links that contain an image extension) will be downloaded and displayed</source>
         <translation>All images (links that contain an image extension) will be downloaded and displayed</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="407" />
+        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="408" />
+        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="408" />
         <source>Message syncing</source>
         <translation>Message syncing</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="412" />
+        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="413" />
+        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="413" />
         <source>Waku nodes</source>
         <translation>Waku nodes</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="435" />
+        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="436" />
+        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="436" />
         <source>For security reasons, private chat history won't be synced.</source>
         <translation>For security reasons, private chat history won't be synced.</translation>
     </message>
@@ -5976,10 +7405,12 @@ device, so only you can use them.</translation>
     <name>MuteChatMenuItem</name>
     <message>
         <location filename="../imports/shared/controls/chat/menuItems/MuteChatMenuItem.qml" line="8" />
+        <location filename="../imports/shared/controls/chat/menuItems/MuteChatMenuItem.qml" line="8" />
         <source>Mute chat</source>
         <translation>Mute chat</translation>
     </message>
     <message>
+        <location filename="../imports/shared/controls/chat/menuItems/MuteChatMenuItem.qml" line="8" />
         <location filename="../imports/shared/controls/chat/menuItems/MuteChatMenuItem.qml" line="8" />
         <source>Unmute chat</source>
         <translation>Unmute chat</translation>
@@ -5989,10 +7420,12 @@ device, so only you can use them.</translation>
     <name>MutedChatsModal</name>
     <message>
         <location filename="../app/AppLayouts/Profile/popups/MutedChatsModal.qml" line="20" />
+        <location filename="../app/AppLayouts/Profile/popups/MutedChatsModal.qml" line="20" />
         <source>Muted chats</source>
         <translation>Muted chats</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/popups/MutedChatsModal.qml" line="87" />
         <location filename="../app/AppLayouts/Profile/popups/MutedChatsModal.qml" line="87" />
         <source>Unmute</source>
         <translation>Unmute</translation>
@@ -6002,36 +7435,43 @@ device, so only you can use them.</translation>
     <name>MyProfileSettingsView</name>
     <message>
         <location filename="../app/AppLayouts/Profile/views/profile/MyProfileSettingsView.qml" line="75" />
+        <location filename="../app/AppLayouts/Profile/views/profile/MyProfileSettingsView.qml" line="75" />
         <source>Display name</source>
         <translation>Display name</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/profile/MyProfileSettingsView.qml" line="76" />
+        <location filename="../app/AppLayouts/Profile/views/profile/MyProfileSettingsView.qml" line="76" />
         <source>Display Name</source>
         <translation>Display Name</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/profile/MyProfileSettingsView.qml" line="85" />
+        <location filename="../app/AppLayouts/Profile/views/profile/MyProfileSettingsView.qml" line="87" />
+        <location filename="../app/AppLayouts/Profile/views/profile/MyProfileSettingsView.qml" line="87" />
         <source>Biometric login and transaction authentication</source>
         <translation>Biometric login and transaction authentication</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/profile/MyProfileSettingsView.qml" line="115" />
+        <location filename="../app/AppLayouts/Profile/views/profile/MyProfileSettingsView.qml" line="118" />
+        <location filename="../app/AppLayouts/Profile/views/profile/MyProfileSettingsView.qml" line="118" />
         <source>Communities</source>
         <translation>Communities</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/profile/MyProfileSettingsView.qml" line="122" />
+        <location filename="../app/AppLayouts/Profile/views/profile/MyProfileSettingsView.qml" line="125" />
+        <location filename="../app/AppLayouts/Profile/views/profile/MyProfileSettingsView.qml" line="125" />
         <source>Accounts</source>
         <translation>Accounts</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/profile/MyProfileSettingsView.qml" line="140" />
+        <location filename="../app/AppLayouts/Profile/views/profile/MyProfileSettingsView.qml" line="143" />
+        <location filename="../app/AppLayouts/Profile/views/profile/MyProfileSettingsView.qml" line="143" />
         <source>You haven't joined any communities yet</source>
         <translation>You haven't joined any communities yet</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/profile/MyProfileSettingsView.qml" line="163" />
+        <location filename="../app/AppLayouts/Profile/views/profile/MyProfileSettingsView.qml" line="166" />
+        <location filename="../app/AppLayouts/Profile/views/profile/MyProfileSettingsView.qml" line="166" />
         <source>You don't have any wallet accounts yet</source>
         <translation>You don't have any wallet accounts yet</translation>
     </message>
@@ -6040,30 +7480,69 @@ device, so only you can use them.</translation>
     <name>MyProfileView</name>
     <message>
         <location filename="../app/AppLayouts/Profile/views/MyProfileView.qml" line="29" />
+        <location filename="../app/AppLayouts/Profile/views/MyProfileView.qml" line="29" />
         <source>Change Password</source>
         <translation>Change Password</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/MyProfileView.qml" line="50" />
         <location filename="../app/AppLayouts/Profile/views/MyProfileView.qml" line="50" />
         <source>Edit</source>
         <translation>Edit</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/MyProfileView.qml" line="54" />
+        <location filename="../app/AppLayouts/Profile/views/MyProfileView.qml" line="54" />
         <source>Preview</source>
         <translation>Preview</translation>
     </message>
 </context>
 <context>
+    <name>NetworkCardsComponent</name>
+    <message>
+        <location filename="../imports/shared/views/NetworkCardsComponent.qml" line="73" />
+        <location filename="../imports/shared/views/NetworkCardsComponent.qml" line="73" />
+        <source>Your Balances</source>
+        <translation>Your Balances</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/views/NetworkCardsComponent.qml" line="83" />
+        <location filename="../imports/shared/views/NetworkCardsComponent.qml" line="83" />
+        <source>No Balance</source>
+        <translation>No Balance</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/views/NetworkCardsComponent.qml" line="83" />
+        <location filename="../imports/shared/views/NetworkCardsComponent.qml" line="83" />
+        <source>No Gas</source>
+        <translation>No Gas</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/views/NetworkCardsComponent.qml" line="86" />
+        <location filename="../imports/shared/views/NetworkCardsComponent.qml" line="86" />
+        <source>BALANCE: </source>
+        <translation>BALANCE: </translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/views/NetworkCardsComponent.qml" line="89" />
+        <location filename="../imports/shared/views/NetworkCardsComponent.qml" line="140" />
+        <location filename="../imports/shared/views/NetworkCardsComponent.qml" line="89" />
+        <location filename="../imports/shared/views/NetworkCardsComponent.qml" line="140" />
+        <source>Disabled</source>
+        <translation>Disabled</translation>
+    </message>
+</context>
+<context>
     <name>NetworkFilter</name>
     <message>
-        <location filename="../app/AppLayouts/Wallet/controls/NetworkFilter.qml" line="27" />
+        <location filename="../app/AppLayouts/Wallet/controls/NetworkFilter.qml" line="34" />
+        <location filename="../app/AppLayouts/Wallet/controls/NetworkFilter.qml" line="34" />
         <source>All networks</source>
         <translation>All networks</translation>
     </message>
     <message numerus="yes">
-        <location filename="../app/AppLayouts/Wallet/controls/NetworkFilter.qml" line="34"/>
-        <location filename="../app/AppLayouts/Wallet/controls/NetworkFilter.qml" line="34"/>
+        <location filename="../app/AppLayouts/Wallet/controls/NetworkFilter.qml" line="34" />
+        <location filename="../app/AppLayouts/Wallet/controls/NetworkFilter.qml" line="34" />
         <source>%n network(s)</source>
         <translation>
             <numerusform>%n network</numerusform>
@@ -6075,6 +7554,7 @@ device, so only you can use them.</translation>
     <name>NetworkSelectPopup</name>
     <message>
         <location filename="../app/AppLayouts/Wallet/popups/NetworkSelectPopup.qml" line="65" />
+        <location filename="../app/AppLayouts/Wallet/popups/NetworkSelectPopup.qml" line="65" />
         <source>Layer 2</source>
         <translation>Layer 2</translation>
     </message>
@@ -6082,32 +7562,82 @@ device, so only you can use them.</translation>
 <context>
     <name>NetworkSelector</name>
     <message>
-        <location filename="../imports/shared/views/NetworkSelector.qml" line="65" />
-        <location filename="../imports/shared/views/NetworkSelector.qml" line="65" />
         <source>Networks</source>
-        <translation>Networks</translation>
+        <translation type="vanished">Networks</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/NetworkSelector.qml" line="72" />
-        <location filename="../imports/shared/views/NetworkSelector.qml" line="72" />
         <source>Choose a network to use for the transaction</source>
-        <translation>Choose a network to use for the transaction</translation>
+        <translation type="vanished">Choose a network to use for the transaction</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/NetworkSelector.qml" line="83" />
-        <location filename="../imports/shared/views/NetworkSelector.qml" line="83" />
         <source>No networks available</source>
-        <translation>No networks available</translation>
+        <translation type="vanished">No networks available</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/views/NetworkSelector.qml" line="44" />
+        <location filename="../imports/shared/views/NetworkSelector.qml" line="44" />
+        <source>Simple</source>
+        <translation>Simple</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/views/NetworkSelector.qml" line="47" />
+        <location filename="../imports/shared/views/NetworkSelector.qml" line="47" />
+        <source>Advanced</source>
+        <translation type="unfinished">Advanced</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/views/NetworkSelector.qml" line="50" />
+        <location filename="../imports/shared/views/NetworkSelector.qml" line="50" />
+        <source>Custom</source>
+        <translation type="unfinished">Custom</translation>
+    </message>
+</context>
+<context>
+    <name>NetworksAdvancedCustomRoutingView</name>
+    <message>
+        <location filename="../imports/shared/views/NetworksAdvancedCustomRoutingView.qml" line="53" />
+        <location filename="../imports/shared/views/NetworksAdvancedCustomRoutingView.qml" line="53" />
+        <source>Networks</source>
+        <translation type="unfinished">Networks</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/views/NetworksAdvancedCustomRoutingView.qml" line="63" />
+        <location filename="../imports/shared/views/NetworksAdvancedCustomRoutingView.qml" line="63" />
+        <source>Show Unpreferred Networks</source>
+        <translation>Show Unpreferred Networks</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/views/NetworksAdvancedCustomRoutingView.qml" line="70" />
+        <location filename="../imports/shared/views/NetworksAdvancedCustomRoutingView.qml" line="70" />
+        <source>The networks where the receipient will receive tokens. Amounts calculated automatically for the lowest cost.</source>
+        <translation>The networks where the receipient will receive tokens. Amounts calculated automatically for the lowest cost.</translation>
+    </message>
+</context>
+<context>
+    <name>NetworksSimpleRoutingView</name>
+    <message>
+        <location filename="../imports/shared/views/NetworksSimpleRoutingView.qml" line="38" />
+        <location filename="../imports/shared/views/NetworksSimpleRoutingView.qml" line="38" />
+        <source>Networks</source>
+        <translation type="unfinished">Networks</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/views/NetworksSimpleRoutingView.qml" line="45" />
+        <location filename="../imports/shared/views/NetworksSimpleRoutingView.qml" line="45" />
+        <source>Choose a network to use for the transaction</source>
+        <translation type="unfinished">Choose a network to use for the transaction</translation>
     </message>
 </context>
 <context>
     <name>NetworksView</name>
     <message>
         <location filename="../app/AppLayouts/Profile/views/wallet/NetworksView.qml" line="35" />
+        <location filename="../app/AppLayouts/Profile/views/wallet/NetworksView.qml" line="35" />
         <source>Layer 2</source>
         <translation>Layer 2</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/wallet/NetworksView.qml" line="60" />
         <location filename="../app/AppLayouts/Profile/views/wallet/NetworksView.qml" line="60" />
         <source>Add Custom Network</source>
         <translation>Add Custom Network</translation>
@@ -6116,16 +7646,16 @@ device, so only you can use them.</translation>
 <context>
     <name>NicknamePopup</name>
     <message>
-        <location filename="../imports/shared/popups/NicknamePopup.qml" line="21" />
-        <location filename="../imports/shared/popups/NicknamePopup.qml" line="55" />
-        <location filename="../imports/shared/popups/NicknamePopup.qml" line="21" />
-        <location filename="../imports/shared/popups/NicknamePopup.qml" line="55" />
+        <location filename="../imports/shared/popups/NicknamePopup.qml" line="22" />
+        <location filename="../imports/shared/popups/NicknamePopup.qml" line="56" />
+        <location filename="../imports/shared/popups/NicknamePopup.qml" line="22" />
+        <location filename="../imports/shared/popups/NicknamePopup.qml" line="56" />
         <source>Nickname</source>
         <translation>Nickname</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/NicknamePopup.qml" line="46" />
-        <location filename="../imports/shared/popups/NicknamePopup.qml" line="46" />
+        <location filename="../imports/shared/popups/NicknamePopup.qml" line="47" />
+        <location filename="../imports/shared/popups/NicknamePopup.qml" line="47" />
         <source>Nicknames help you identify others in Status. Only you can see the nicknames you&#8217;ve added</source>
         <translation>Nicknames help you identify others in Status. Only you can see the nicknames you&#8217;ve added</translation>
     </message>
@@ -6185,43 +7715,61 @@ device, so only you can use them.</translation>
     <name>NotificationSelect</name>
     <message>
         <location filename="../app/AppLayouts/Profile/controls/NotificationSelect.qml" line="23" />
+        <location filename="../app/AppLayouts/Profile/controls/NotificationSelect.qml" line="23" />
         <source>Send Alerts</source>
         <translation>Send Alerts</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/controls/NotificationSelect.qml" line="24" />
         <location filename="../app/AppLayouts/Profile/controls/NotificationSelect.qml" line="24" />
         <source>Deliver Quietly</source>
         <translation>Deliver Quietly</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/controls/NotificationSelect.qml" line="25" />
+        <location filename="../app/AppLayouts/Profile/controls/NotificationSelect.qml" line="25" />
         <source>Turn Off</source>
         <translation>Turn Off</translation>
+    </message>
+</context>
+<context>
+    <name>NotificationWindow</name>
+    <message>
+        <location filename="../imports/shared/panels/NotificationWindow.qml" line="17" />
+        <location filename="../imports/shared/panels/NotificationWindow.qml" line="17" />
+        <source>Everything is connected</source>
+        <translation>Everything is connected</translation>
     </message>
 </context>
 <context>
     <name>NotificationsView</name>
     <message>
         <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="69" />
+        <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="69" />
         <source>Community</source>
         <translation>Community</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="71" />
         <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="71" />
         <source>1:1 Chat</source>
         <translation>1:1 Chat</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="73" />
+        <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="73" />
         <source>Group Chat</source>
         <translation>Group Chat</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="83" />
+        <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="83" />
         <source>Muted</source>
         <translation>Muted</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="91" />
+        <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="100" />
         <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="91" />
         <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="100" />
         <source>Off</source>
@@ -6231,130 +7779,158 @@ device, so only you can use them.</translation>
         <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="92" />
         <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="101" />
         <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="110" />
+        <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="92" />
+        <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="101" />
+        <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="110" />
         <source>Quiet</source>
         <translation>Quiet</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="93" />
         <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="93" />
         <source>Personal @ Mentions %1</source>
         <translation>Personal @ Mentions %1</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="102" />
+        <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="102" />
         <source>Global @ Mentions %1</source>
         <translation>Global @ Mentions %1</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="109" />
         <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="109" />
         <source>Alerts</source>
         <translation>Alerts</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="111" />
+        <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="111" />
         <source>Other Messages %1</source>
         <translation>Other Messages %1</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="115" />
         <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="115" />
         <source>Multiple Exemptions</source>
         <translation>Multiple Exemptions</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="181" />
+        <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="181" />
         <source>Enable Notifications in macOS Settings</source>
         <translation>Enable Notifications in macOS Settings</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="191" />
         <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="191" />
         <source>To receive Status notifications, make sure you've enabled them in your computer's settings under &lt;b&gt;System Preferences &gt; Notifications&lt;/b&gt;</source>
         <translation>To receive Status notifications, make sure you've enabled them in your computer's settings under &lt;b&gt;System Preferences &gt; Notifications&lt;/b&gt;</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="218" />
+        <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="218" />
         <source>Sync your devices to share notifications preferences</source>
         <translation>Sync your devices to share notifications preferences</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="226" />
         <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="226" />
         <source>Syncing &gt;</source>
         <translation>Syncing &gt;</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="244" />
+        <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="244" />
         <source>Allow Notifications</source>
         <translation>Allow Notifications</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="262" />
         <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="262" />
         <source>Messages</source>
         <translation>Messages</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="269" />
+        <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="269" />
         <source>1:1 Chats</source>
         <translation>1:1 Chats</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="282" />
         <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="282" />
         <source>Group Chats</source>
         <translation>Group Chats</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="295" />
+        <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="295" />
         <source>Personal @ Mentions</source>
         <translation>Personal @ Mentions</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="296" />
         <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="296" />
         <source>Messages containing @%1</source>
         <translation>Messages containing @%1</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="309" />
+        <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="309" />
         <source>Global @ Mentions</source>
         <translation>Global @ Mentions</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="310" />
         <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="310" />
         <source>Messages containing @here and @channel</source>
         <translation>Messages containing @here and @channel</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="323" />
+        <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="323" />
         <source>All Messages</source>
         <translation>All Messages</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="337" />
         <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="337" />
         <source>Others</source>
         <translation>Others</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="344" />
+        <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="344" />
         <source>Contact Requests</source>
         <translation>Contact Requests</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="357" />
         <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="357" />
         <source>Identity Verification Requests</source>
         <translation>Identity Verification Requests</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="376" />
+        <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="376" />
         <source>Notification Content</source>
         <translation>Notification Content</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="385" />
         <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="385" />
         <source>Show Name and Message</source>
         <translation>Show Name and Message</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="387" />
+        <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="387" />
         <source>Hi there! So EIP-1559 will defini...</source>
         <translation>Hi there! So EIP-1559 will defini...</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="400" />
         <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="400" />
         <source>Name Only</source>
         <translation>Name Only</translation>
@@ -6362,40 +7938,49 @@ device, so only you can use them.</translation>
     <message>
         <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="402" />
         <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="417" />
+        <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="402" />
+        <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="417" />
         <source>You have a new message</source>
         <translation>You have a new message</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="415" />
         <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="415" />
         <source>Anonymous</source>
         <translation>Anonymous</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="429" />
+        <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="429" />
         <source>Play a Sound When Receiving a Notification</source>
         <translation>Play a Sound When Receiving a Notification</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="447" />
         <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="447" />
         <source>Volume</source>
         <translation>Volume</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="501" />
+        <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="501" />
         <source>Send a Test Notification</source>
         <translation>Send a Test Notification</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="516" />
         <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="516" />
         <source>Exemptions</source>
         <translation>Exemptions</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="527" />
+        <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="527" />
         <source>Search Communities, Group Chats and 1:1 Chats</source>
         <translation>Search Communities, Group Chats and 1:1 Chats</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="533" />
         <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="533" />
         <source>Most recent</source>
         <translation>Most recent</translation>
@@ -6582,10 +8167,12 @@ device, so only you can use them.</translation>
     <name>PermissionsListView</name>
     <message>
         <location filename="../app/AppLayouts/Profile/views/wallet/PermissionsListView.qml" line="38" />
+        <location filename="../app/AppLayouts/Profile/views/wallet/PermissionsListView.qml" line="38" />
         <source>Disconnect All</source>
         <translation>Disconnect All</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/wallet/PermissionsListView.qml" line="38" />
         <location filename="../app/AppLayouts/Profile/views/wallet/PermissionsListView.qml" line="38" />
         <source>Disconnect</source>
         <translation>Disconnect</translation>
@@ -6595,36 +8182,43 @@ device, so only you can use them.</translation>
     <name>PinnedMessagesPopup</name>
     <message>
         <location filename="../app/AppLayouts/Chat/popups/PinnedMessagesPopup.qml" line="35" />
+        <location filename="../app/AppLayouts/Chat/popups/PinnedMessagesPopup.qml" line="35" />
         <source>Pin limit reached</source>
         <translation>Pin limit reached</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Chat/popups/PinnedMessagesPopup.qml" line="36" />
         <location filename="../app/AppLayouts/Chat/popups/PinnedMessagesPopup.qml" line="36" />
         <source>Pinned messages</source>
         <translation>Pinned messages</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Chat/popups/PinnedMessagesPopup.qml" line="49" />
+        <location filename="../app/AppLayouts/Chat/popups/PinnedMessagesPopup.qml" line="49" />
         <source>Unpin a previous message first</source>
         <translation>Unpin a previous message first</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Chat/popups/PinnedMessagesPopup.qml" line="52" />
         <location filename="../app/AppLayouts/Chat/popups/PinnedMessagesPopup.qml" line="52" />
         <source>%1 messages</source>
         <translation>%1 messages</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Chat/popups/PinnedMessagesPopup.qml" line="53" />
+        <location filename="../app/AppLayouts/Chat/popups/PinnedMessagesPopup.qml" line="53" />
         <source>%1 message</source>
         <translation>%1 message</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Chat/popups/PinnedMessagesPopup.qml" line="77" />
+        <location filename="../app/AppLayouts/Chat/popups/PinnedMessagesPopup.qml" line="77" />
         <source>Pinned messages will appear here.</source>
         <translation>Pinned messages will appear here.</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/popups/PinnedMessagesPopup.qml" line="202" />
+        <location filename="../app/AppLayouts/Chat/popups/PinnedMessagesPopup.qml" line="203" />
+        <location filename="../app/AppLayouts/Chat/popups/PinnedMessagesPopup.qml" line="203" />
         <source>Unpin</source>
         <translation>Unpin</translation>
     </message>
@@ -6633,13 +8227,24 @@ device, so only you can use them.</translation>
     <name>PrivateChatPopup</name>
     <message>
         <location filename="../app/AppLayouts/Chat/popups/PrivateChatPopup.qml" line="16" />
+        <location filename="../app/AppLayouts/Chat/popups/PrivateChatPopup.qml" line="16" />
         <source>New chat</source>
         <translation>New chat</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Chat/popups/PrivateChatPopup.qml" line="79" />
+        <location filename="../app/AppLayouts/Chat/popups/PrivateChatPopup.qml" line="79" />
         <source>My Profile</source>
         <translation>My Profile</translation>
+    </message>
+</context>
+<context>
+    <name>ProfileHeader</name>
+    <message>
+        <location filename="../imports/shared/controls/chat/ProfileHeader.qml" line="182" />
+        <location filename="../imports/shared/controls/chat/ProfileHeader.qml" line="182" />
+        <source>Chatkey:%1...</source>
+        <translation>Chatkey:%1...</translation>
     </message>
 </context>
 <context>
@@ -6657,14 +8262,14 @@ device, so only you can use them.</translation>
         <translation>Contacts</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/ProfileLayout.qml" line="237" />
-        <location filename="../app/AppLayouts/Profile/ProfileLayout.qml" line="237" />
+        <location filename="../app/AppLayouts/Profile/ProfileLayout.qml" line="245" />
+        <location filename="../app/AppLayouts/Profile/ProfileLayout.qml" line="245" />
         <source>Secure your seed phrase</source>
         <translation>Secure your seed phrase</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/ProfileLayout.qml" line="238" />
-        <location filename="../app/AppLayouts/Profile/ProfileLayout.qml" line="238" />
+        <location filename="../app/AppLayouts/Profile/ProfileLayout.qml" line="246" />
+        <location filename="../app/AppLayouts/Profile/ProfileLayout.qml" line="246" />
         <source>Back up now</source>
         <translation>Back up now</translation>
     </message>
@@ -6672,110 +8277,222 @@ device, so only you can use them.</translation>
 <context>
     <name>ProfilePopup</name>
     <message>
-        <location filename="../imports/shared/popups/ProfilePopup.qml" line="82" />
-        <location filename="../imports/shared/popups/ProfilePopup.qml" line="82" />
         <source>'s Profile</source>
-        <translation>'s Profile</translation>
+        <translation type="vanished">'s Profile</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/ProfilePopup.qml" line="154" />
-        <location filename="../imports/shared/popups/ProfilePopup.qml" line="154" />
         <source>Send Contact Request to</source>
-        <translation>Send Contact Request to</translation>
+        <translation type="vanished">Send Contact Request to</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/ProfilePopup.qml" line="165" />
-        <location filename="../imports/shared/popups/ProfilePopup.qml" line="165" />
+        <location filename="../imports/shared/popups/ProfilePopup.qml" line="142" />
+        <location filename="../imports/shared/popups/ProfilePopup.qml" line="142" />
+        <source>Verify %1's Identity</source>
+        <translation>Verify %1's Identity</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/popups/ProfilePopup.qml" line="144" />
+        <location filename="../imports/shared/popups/ProfilePopup.qml" line="144" />
+        <source>My Profile</source>
+        <translation type="unfinished">My Profile</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/popups/ProfilePopup.qml" line="145" />
+        <location filename="../imports/shared/popups/ProfilePopup.qml" line="145" />
+        <source>%1's Profile</source>
+        <translation>%1's Profile</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/popups/ProfilePopup.qml" line="237" />
+        <location filename="../imports/shared/popups/ProfilePopup.qml" line="237" />
+        <source>Send Contact Request to %1</source>
+        <translation>Send Contact Request to %1</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/popups/ProfilePopup.qml" line="247" />
+        <location filename="../imports/shared/popups/ProfilePopup.qml" line="247" />
+        <source>Cancel verification</source>
+        <translation>Cancel verification</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/popups/ProfilePopup.qml" line="259" />
+        <location filename="../imports/shared/popups/ProfilePopup.qml" line="259" />
         <source>Unblock User</source>
         <translation>Unblock User</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/ProfilePopup.qml" line="166" />
-        <location filename="../imports/shared/popups/ProfilePopup.qml" line="166" />
+        <location filename="../imports/shared/popups/ProfilePopup.qml" line="260" />
+        <location filename="../imports/shared/popups/ProfilePopup.qml" line="260" />
         <source>Block User</source>
         <translation>Block User</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/ProfilePopup.qml" line="174" />
-        <location filename="../imports/shared/popups/ProfilePopup.qml" line="174" />
+        <location filename="../imports/shared/popups/ProfilePopup.qml" line="269" />
+        <location filename="../imports/shared/popups/ProfilePopup.qml" line="269" />
         <source>Remove Contact</source>
         <translation>Remove Contact</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/ProfilePopup.qml" line="182" />
-        <location filename="../imports/shared/popups/ProfilePopup.qml" line="182" />
+        <location filename="../imports/shared/popups/ProfilePopup.qml" line="277" />
+        <location filename="../imports/shared/popups/ProfilePopup.qml" line="277" />
         <source>Send Contact Request</source>
         <translation>Send Contact Request</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/popups/ProfilePopup.qml" line="283" />
+        <location filename="../imports/shared/popups/ProfilePopup.qml" line="283" />
+        <source>Mark Untrustworthy</source>
+        <translation>Mark Untrustworthy</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/popups/ProfilePopup.qml" line="303" />
+        <location filename="../imports/shared/popups/ProfilePopup.qml" line="303" />
+        <source>Remove 'Identity Verified' status</source>
+        <translation>Remove 'Identity Verified' status</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/popups/ProfilePopup.qml" line="312" />
+        <location filename="../imports/shared/popups/ProfilePopup.qml" line="312" />
+        <source>No</source>
+        <translation>No</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/popups/ProfilePopup.qml" line="321" />
+        <location filename="../imports/shared/popups/ProfilePopup.qml" line="321" />
+        <source>Yes</source>
+        <translation>Yes</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/popups/ProfilePopup.qml" line="330" />
+        <location filename="../imports/shared/popups/ProfilePopup.qml" line="330" />
+        <source>Remove Untrustworthy Mark</source>
+        <translation>Remove Untrustworthy Mark</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/popups/ProfilePopup.qml" line="339" />
+        <location filename="../imports/shared/popups/ProfilePopup.qml" line="339" />
+        <source>Verify Identity</source>
+        <translation>Verify Identity</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/popups/ProfilePopup.qml" line="349" />
+        <location filename="../imports/shared/popups/ProfilePopup.qml" line="349" />
+        <source>Verify Identity pending...</source>
+        <translation>Verify Identity pending...</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/popups/ProfilePopup.qml" line="378" />
+        <location filename="../imports/shared/popups/ProfilePopup.qml" line="378" />
+        <source>Send verification request</source>
+        <translation>Send verification request</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/popups/ProfilePopup.qml" line="383" />
+        <location filename="../imports/shared/popups/ProfilePopup.qml" line="383" />
+        <source>Verification request sent</source>
+        <translation>Verification request sent</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/popups/ProfilePopup.qml" line="394" />
+        <location filename="../imports/shared/popups/ProfilePopup.qml" line="394" />
+        <source>Confirm Identity</source>
+        <translation>Confirm Identity</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/popups/ProfilePopup.qml" line="410" />
+        <location filename="../imports/shared/popups/ProfilePopup.qml" line="410" />
+        <source>Rename</source>
+        <translation type="unfinished">Rename</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/popups/ProfilePopup.qml" line="418" />
+        <location filename="../imports/shared/popups/ProfilePopup.qml" line="418" />
+        <source>Close</source>
+        <translation type="unfinished">Close</translation>
     </message>
 </context>
 <context>
     <name>ProfileSectionStore</name>
     <message>
         <location filename="../app/AppLayouts/Profile/stores/ProfileSectionStore.qml" line="73" />
+        <location filename="../app/AppLayouts/Profile/stores/ProfileSectionStore.qml" line="73" />
         <source>Back up seed phrase</source>
         <translation>Back up seed phrase</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/stores/ProfileSectionStore.qml" line="76" />
         <location filename="../app/AppLayouts/Profile/stores/ProfileSectionStore.qml" line="76" />
         <source>Profile</source>
         <translation>Profile</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/stores/ProfileSectionStore.qml" line="79" />
+        <location filename="../app/AppLayouts/Profile/stores/ProfileSectionStore.qml" line="79" />
         <source>ENS usernames</source>
         <translation>ENS usernames</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/stores/ProfileSectionStore.qml" line="87" />
         <location filename="../app/AppLayouts/Profile/stores/ProfileSectionStore.qml" line="87" />
         <source>Messaging</source>
         <translation>Messaging</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/stores/ProfileSectionStore.qml" line="90" />
+        <location filename="../app/AppLayouts/Profile/stores/ProfileSectionStore.qml" line="90" />
         <source>Wallet</source>
         <translation>Wallet</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/stores/ProfileSectionStore.qml" line="93" />
         <location filename="../app/AppLayouts/Profile/stores/ProfileSectionStore.qml" line="93" />
         <source>Browser</source>
         <translation>Browser</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/stores/ProfileSectionStore.qml" line="96" />
+        <location filename="../app/AppLayouts/Profile/stores/ProfileSectionStore.qml" line="96" />
         <source>Communities</source>
         <translation>Communities</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/stores/ProfileSectionStore.qml" line="104" />
         <location filename="../app/AppLayouts/Profile/stores/ProfileSectionStore.qml" line="104" />
         <source>Appearance</source>
         <translation>Appearance</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/stores/ProfileSectionStore.qml" line="107" />
+        <location filename="../app/AppLayouts/Profile/stores/ProfileSectionStore.qml" line="107" />
         <source>Notifications &amp; Sounds</source>
         <translation>Notifications &amp; Sounds</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/stores/ProfileSectionStore.qml" line="110" />
         <location filename="../app/AppLayouts/Profile/stores/ProfileSectionStore.qml" line="110" />
         <source>Language &amp; Currency</source>
         <translation>Language &amp; Currency</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/stores/ProfileSectionStore.qml" line="113" />
+        <location filename="../app/AppLayouts/Profile/stores/ProfileSectionStore.qml" line="113" />
         <source>Devices settings</source>
         <translation>Devices settings</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/stores/ProfileSectionStore.qml" line="116" />
         <location filename="../app/AppLayouts/Profile/stores/ProfileSectionStore.qml" line="116" />
         <source>Advanced</source>
         <translation>Advanced</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/stores/ProfileSectionStore.qml" line="124" />
+        <location filename="../app/AppLayouts/Profile/stores/ProfileSectionStore.qml" line="124" />
         <source>About</source>
         <translation>About</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/stores/ProfileSectionStore.qml" line="127" />
         <location filename="../app/AppLayouts/Profile/stores/ProfileSectionStore.qml" line="127" />
         <source>Sign out &amp; Quit</source>
         <translation>Sign out &amp; Quit</translation>
@@ -6784,72 +8501,108 @@ device, so only you can use them.</translation>
 <context>
     <name>ProfileView</name>
     <message>
-        <location filename="../imports/shared/views/ProfileView.qml" line="88" />
-        <location filename="../imports/shared/views/ProfileView.qml" line="88" />
+        <location filename="../imports/shared/views/ProfileView.qml" line="188" />
+        <location filename="../imports/shared/views/ProfileView.qml" line="188" />
         <source>Blocked</source>
         <translation>Blocked</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/ProfileView.qml" line="98" />
-        <location filename="../imports/shared/views/ProfileView.qml" line="98" />
+        <location filename="../imports/shared/views/ProfileView.qml" line="242" />
+        <location filename="../imports/shared/views/ProfileView.qml" line="242" />
+        <source>Send Request</source>
+        <translation>Send Request</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/views/ProfileView.qml" line="243" />
+        <location filename="../imports/shared/views/ProfileView.qml" line="243" />
+        <source>Receive Response</source>
+        <translation>Receive Response</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/views/ProfileView.qml" line="244" />
+        <location filename="../imports/shared/views/ProfileView.qml" line="244" />
+        <source>Confirm Identity</source>
+        <translation>Confirm Identity</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/views/ProfileView.qml" line="263" />
+        <location filename="../imports/shared/views/ProfileView.qml" line="263" />
+        <source>You have confirmed %1's identity. From now on this verification emblem will always be displayed alongside %1's nickname.</source>
+        <translation>You have confirmed %1's identity. From now on this verification emblem will always be displayed alongside %1's nickname.</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/views/ProfileView.qml" line="275" />
+        <location filename="../imports/shared/views/ProfileView.qml" line="275" />
+        <source>You have marked %1 as Untrustworthy. From now on this Untrustworthy emblem will always be displayed alongside %1's nickname.</source>
+        <translation>You have marked %1 as Untrustworthy. From now on this Untrustworthy emblem will always be displayed alongside %1's nickname.</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/views/ProfileView.qml" line="306" />
+        <location filename="../imports/shared/views/ProfileView.qml" line="306" />
         <source>ENS username</source>
         <translation>ENS username</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/ProfileView.qml" line="98" />
-        <location filename="../imports/shared/views/ProfileView.qml" line="98" />
+        <location filename="../imports/shared/views/ProfileView.qml" line="306" />
+        <location filename="../imports/shared/views/ProfileView.qml" line="306" />
         <source>Username</source>
         <translation>Username</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/ProfileView.qml" line="100" />
-        <location filename="../imports/shared/views/ProfileView.qml" line="116" />
-        <location filename="../imports/shared/views/ProfileView.qml" line="142" />
-        <location filename="../imports/shared/views/ProfileView.qml" line="100" />
-        <location filename="../imports/shared/views/ProfileView.qml" line="116" />
-        <location filename="../imports/shared/views/ProfileView.qml" line="142" />
+        <location filename="../imports/shared/views/ProfileView.qml" line="346" />
+        <location filename="../imports/shared/views/ProfileView.qml" line="346" />
+        <source>Ask a question that only the real %1 will be able to answer e.g. a question about a shared experience, or ask Mark to enter a code or phrase you have sent to them via a different communication channel (phone, post, etc...).</source>
+        <translation>Ask a question that only the real %1 will be able to answer e.g. a question about a shared experience, or ask Mark to enter a code or phrase you have sent to them via a different communication channel (phone, post, etc...).</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/views/ProfileView.qml" line="386" />
+        <location filename="../imports/shared/views/ProfileView.qml" line="386" />
+        <source>Waiting for %1's response...</source>
+        <translation>Waiting for %1's response...</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/views/ProfileView.qml" line="199" />
+        <location filename="../imports/shared/views/ProfileView.qml" line="225" />
+        <location filename="../imports/shared/views/ProfileView.qml" line="308" />
+        <location filename="../imports/shared/views/ProfileView.qml" line="199" />
+        <location filename="../imports/shared/views/ProfileView.qml" line="225" />
+        <location filename="../imports/shared/views/ProfileView.qml" line="308" />
         <source>Copied to clipboard</source>
         <translation>Copied to clipboard</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/ProfileView.qml" line="111" />
-        <location filename="../imports/shared/views/ProfileView.qml" line="111" />
+        <location filename="../imports/shared/views/ProfileView.qml" line="194" />
+        <location filename="../imports/shared/views/ProfileView.qml" line="194" />
         <source>Chat key</source>
         <translation>Chat key</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/ProfileView.qml" line="127" />
-        <location filename="../imports/shared/views/ProfileView.qml" line="127" />
+        <location filename="../imports/shared/views/ProfileView.qml" line="211" />
+        <location filename="../imports/shared/views/ProfileView.qml" line="211" />
         <source>Share Profile URL</source>
         <translation>Share Profile URL</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/ProfileView.qml" line="160" />
-        <location filename="../imports/shared/views/ProfileView.qml" line="160" />
         <source>Chat settings</source>
-        <translation>Chat settings</translation>
+        <translation type="vanished">Chat settings</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/ProfileView.qml" line="161" />
-        <location filename="../imports/shared/views/ProfileView.qml" line="161" />
         <source>Nickname</source>
-        <translation>Nickname</translation>
+        <translation type="vanished">Nickname</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/ProfileView.qml" line="162" />
-        <location filename="../imports/shared/views/ProfileView.qml" line="162" />
         <source>None</source>
-        <translation>None</translation>
+        <translation type="vanished">None</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/ProfileView.qml" line="213" />
-        <location filename="../imports/shared/views/ProfileView.qml" line="213" />
+        <location filename="../imports/shared/views/ProfileView.qml" line="438" />
+        <location filename="../imports/shared/views/ProfileView.qml" line="438" />
         <source>Remove contact</source>
         <translation>Remove contact</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/ProfileView.qml" line="214" />
-        <location filename="../imports/shared/views/ProfileView.qml" line="214" />
+        <location filename="../imports/shared/views/ProfileView.qml" line="439" />
+        <location filename="../imports/shared/views/ProfileView.qml" line="439" />
         <source>Are you sure you want to remove this contact?</source>
         <translation>Are you sure you want to remove this contact?</translation>
     </message>
@@ -6858,30 +8611,36 @@ device, so only you can use them.</translation>
     <name>PublicChatPopup</name>
     <message>
         <location filename="../app/AppLayouts/Chat/popups/PublicChatPopup.qml" line="22" />
+        <location filename="../app/AppLayouts/Chat/popups/PublicChatPopup.qml" line="22" />
         <source>You need to enter a channel name</source>
         <translation>You need to enter a channel name</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Chat/popups/PublicChatPopup.qml" line="24" />
         <location filename="../app/AppLayouts/Chat/popups/PublicChatPopup.qml" line="24" />
         <source>The channel name can only contain lowercase letters, numbers and dashes</source>
         <translation>The channel name can only contain lowercase letters, numbers and dashes</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Chat/popups/PublicChatPopup.qml" line="41" />
+        <location filename="../app/AppLayouts/Chat/popups/PublicChatPopup.qml" line="41" />
         <source>Join public chat</source>
         <translation>Join public chat</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Chat/popups/PublicChatPopup.qml" line="57" />
         <location filename="../app/AppLayouts/Chat/popups/PublicChatPopup.qml" line="57" />
         <source>A public chat is where you get to hang out with others, make friends and talk about subjects of your interest.</source>
         <translation>A public chat is where you get to hang out with others, make friends and talk about subjects of your interest.</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Chat/popups/PublicChatPopup.qml" line="67" />
+        <location filename="../app/AppLayouts/Chat/popups/PublicChatPopup.qml" line="67" />
         <source>chat-name</source>
         <translation>chat-name</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Chat/popups/PublicChatPopup.qml" line="109" />
         <location filename="../app/AppLayouts/Chat/popups/PublicChatPopup.qml" line="109" />
         <source>Start chat</source>
         <translation>Start chat</translation>
@@ -6891,10 +8650,12 @@ device, so only you can use them.</translation>
     <name>RateView</name>
     <message>
         <location filename="../app/AppLayouts/Node/views/RateView.qml" line="20" />
+        <location filename="../app/AppLayouts/Node/views/RateView.qml" line="20" />
         <source>Bandwidth</source>
         <translation>Bandwidth</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Node/views/RateView.qml" line="29" />
         <location filename="../app/AppLayouts/Node/views/RateView.qml" line="29" />
         <source>Upload</source>
         <translation>Upload</translation>
@@ -6902,10 +8663,13 @@ device, so only you can use them.</translation>
     <message>
         <location filename="../app/AppLayouts/Node/views/RateView.qml" line="50" />
         <location filename="../app/AppLayouts/Node/views/RateView.qml" line="80" />
+        <location filename="../app/AppLayouts/Node/views/RateView.qml" line="50" />
+        <location filename="../app/AppLayouts/Node/views/RateView.qml" line="80" />
         <source>Kb/s</source>
         <translation>Kb/s</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Node/views/RateView.qml" line="59" />
         <location filename="../app/AppLayouts/Node/views/RateView.qml" line="59" />
         <source>Download</source>
         <translation>Download</translation>
@@ -6915,26 +8679,31 @@ device, so only you can use them.</translation>
     <name>ReceiveModal</name>
     <message>
         <location filename="../app/AppLayouts/Wallet/popups/ReceiveModal.qml" line="37" />
+        <location filename="../app/AppLayouts/Wallet/popups/ReceiveModal.qml" line="37" />
         <source>Receive</source>
         <translation>Receive</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/popups/ReceiveModal.qml" line="105" />
+        <location filename="../app/AppLayouts/Wallet/popups/ReceiveModal.qml" line="114" />
+        <location filename="../app/AppLayouts/Wallet/popups/ReceiveModal.qml" line="114" />
         <source>Legacy</source>
         <translation>Legacy</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/popups/ReceiveModal.qml" line="108" />
+        <location filename="../app/AppLayouts/Wallet/popups/ReceiveModal.qml" line="117" />
+        <location filename="../app/AppLayouts/Wallet/popups/ReceiveModal.qml" line="117" />
         <source>Multichain</source>
         <translation>Multichain</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/popups/ReceiveModal.qml" line="231" />
+        <location filename="../app/AppLayouts/Wallet/popups/ReceiveModal.qml" line="240" />
+        <location filename="../app/AppLayouts/Wallet/popups/ReceiveModal.qml" line="240" />
         <source>Your Address</source>
         <translation>Your Address</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/popups/ReceiveModal.qml" line="271" />
+        <location filename="../app/AppLayouts/Wallet/popups/ReceiveModal.qml" line="280" />
+        <location filename="../app/AppLayouts/Wallet/popups/ReceiveModal.qml" line="280" />
         <source>Copy</source>
         <translation>Copy</translation>
     </message>
@@ -6976,35 +8745,42 @@ device, so only you can use them.</translation>
     <name>RenameAccontModal</name>
     <message>
         <location filename="../app/AppLayouts/Profile/popups/RenameAccontModal.qml" line="26" />
+        <location filename="../app/AppLayouts/Profile/popups/RenameAccontModal.qml" line="26" />
         <source>Rename %1</source>
         <translation>Rename %1</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/popups/RenameAccontModal.qml" line="52" />
         <location filename="../app/AppLayouts/Profile/popups/RenameAccontModal.qml" line="52" />
         <source>Enter an account name...</source>
         <translation>Enter an account name...</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/popups/RenameAccontModal.qml" line="64" />
+        <location filename="../app/AppLayouts/Profile/popups/RenameAccontModal.qml" line="64" />
         <source>You need to enter an account name</source>
         <translation>You need to enter an account name</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/popups/RenameAccontModal.qml" line="69" />
         <location filename="../app/AppLayouts/Profile/popups/RenameAccontModal.qml" line="69" />
         <source>This is not a valid account name</source>
         <translation>This is not a valid account name</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/popups/RenameAccontModal.qml" line="80" />
+        <location filename="../app/AppLayouts/Profile/popups/RenameAccontModal.qml" line="80" />
         <source>color</source>
         <translation>color</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/popups/RenameAccontModal.qml" line="105" />
+        <location filename="../app/AppLayouts/Profile/popups/RenameAccontModal.qml" line="105" />
         <source>Change Name</source>
         <translation>Change Name</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/popups/RenameAccontModal.qml" line="111" />
         <location filename="../app/AppLayouts/Profile/popups/RenameAccontModal.qml" line="111" />
         <source>Changing settings failed</source>
         <translation>Changing settings failed</translation>
@@ -7013,20 +8789,22 @@ device, so only you can use them.</translation>
 <context>
     <name>RenameGroupPopup</name>
     <message>
-        <location filename="../app/AppLayouts/Chat/popups/RenameGroupPopup.qml" line="17" />
-        <location filename="../app/AppLayouts/Chat/popups/RenameGroupPopup.qml" line="38" />
+        <location filename="../app/AppLayouts/Chat/popups/RenameGroupPopup.qml" line="18" />
+        <location filename="../app/AppLayouts/Chat/popups/RenameGroupPopup.qml" line="33" />
+        <location filename="../app/AppLayouts/Chat/popups/RenameGroupPopup.qml" line="18" />
+        <location filename="../app/AppLayouts/Chat/popups/RenameGroupPopup.qml" line="33" />
         <source>Group name</source>
         <translation>Group name</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/popups/RenameGroupPopup.qml" line="47" />
         <source>Save</source>
-        <translation>Save</translation>
+        <translation type="vanished">Save</translation>
     </message>
 </context>
 <context>
     <name>Retry</name>
     <message>
+        <location filename="../imports/shared/controls/chat/Retry.qml" line="10" />
         <location filename="../imports/shared/controls/chat/Retry.qml" line="10" />
         <source>Resend</source>
         <translation>Resend</translation>
@@ -7035,40 +8813,51 @@ device, so only you can use them.</translation>
 <context>
     <name>RightTabView</name>
     <message>
-        <location filename="../app/AppLayouts/Wallet/views/RightTabView.qml" line="57" />
+        <location filename="../app/AppLayouts/Wallet/views/RightTabView.qml" line="48" />
+        <location filename="../app/AppLayouts/Wallet/views/RightTabView.qml" line="48" />
         <source>Assets</source>
         <translation>Assets</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/views/RightTabView.qml" line="62" />
+        <location filename="../app/AppLayouts/Wallet/views/RightTabView.qml" line="52" />
+        <location filename="../app/AppLayouts/Wallet/views/RightTabView.qml" line="52" />
         <source>Collectibles</source>
         <translation>Collectibles</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/views/RightTabView.qml" line="67" />
+        <location filename="../app/AppLayouts/Wallet/views/RightTabView.qml" line="57" />
+        <location filename="../app/AppLayouts/Wallet/views/RightTabView.qml" line="57" />
+        <source>Activity</source>
+        <translation type="unfinished">Activity</translation>
+    </message>
+    <message>
         <source>History</source>
-        <translation>History</translation>
+        <translation type="vanished">History</translation>
     </message>
 </context>
 <context>
     <name>RootStore</name>
     <message>
-        <location filename="../app/AppLayouts/Chat/stores/RootStore.qml" line="207" />
+        <location filename="../app/AppLayouts/Chat/stores/RootStore.qml" line="196" />
+        <location filename="../app/AppLayouts/Chat/stores/RootStore.qml" line="196" />
         <source>You</source>
         <translation>You</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/stores/RootStore.qml" line="386" />
+        <location filename="../app/AppLayouts/Chat/stores/RootStore.qml" line="375" />
+        <location filename="../app/AppLayouts/Chat/stores/RootStore.qml" line="375" />
         <source>Start a 1-on-1 chat with %1</source>
         <translation>Start a 1-on-1 chat with %1</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/stores/RootStore.qml" line="414" />
+        <location filename="../app/AppLayouts/Chat/stores/RootStore.qml" line="403" />
+        <location filename="../app/AppLayouts/Chat/stores/RootStore.qml" line="403" />
         <source>Join the %1 community</source>
         <translation>Join the %1 community</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/stores/RootStore.qml" line="441" />
+        <location filename="../app/AppLayouts/Chat/stores/RootStore.qml" line="430" />
+        <location filename="../app/AppLayouts/Chat/stores/RootStore.qml" line="430" />
         <source>Join the %1 group chat</source>
         <translation>Join the %1 group chat</translation>
     </message>
@@ -7076,27 +8865,52 @@ device, so only you can use them.</translation>
 <context>
     <name>SavedAddressesView</name>
     <message>
-        <location filename="../app/AppLayouts/Wallet/views/SavedAddressesView.qml" line="53" />
+        <location filename="../app/AppLayouts/Wallet/views/SavedAddressesView.qml" line="42" />
+        <location filename="../app/AppLayouts/Wallet/views/SavedAddressesView.qml" line="42" />
         <source>Saved addresses</source>
         <translation>Saved addresses</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/views/SavedAddressesView.qml" line="147" />
+        <location filename="../app/AppLayouts/Wallet/views/SavedAddressesView.qml" line="54" />
+        <location filename="../app/AppLayouts/Wallet/views/SavedAddressesView.qml" line="54" />
+        <source>Add new address</source>
+        <translation>Add new address</translation>
+    </message>
+    <message>
+        <location filename="../app/AppLayouts/Wallet/views/SavedAddressesView.qml" line="131" />
+        <location filename="../app/AppLayouts/Wallet/views/SavedAddressesView.qml" line="131" />
+        <source>Edit</source>
+        <translation type="unfinished">Edit</translation>
+    </message>
+    <message>
+        <location filename="../app/AppLayouts/Wallet/views/SavedAddressesView.qml" line="178" />
+        <location filename="../app/AppLayouts/Wallet/views/SavedAddressesView.qml" line="178" />
         <source>Are you sure you want to remove '%1' from your saved addresses?</source>
         <translation>Are you sure you want to remove '%1' from your saved addresses?</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/views/SavedAddressesView.qml" line="165" />
+        <location filename="../app/AppLayouts/Wallet/views/SavedAddressesView.qml" line="180" />
+        <location filename="../app/AppLayouts/Wallet/views/SavedAddressesView.qml" line="180" />
+        <source>Are you sure?</source>
+        <translation type="unfinished">Are you sure?</translation>
+    </message>
+    <message>
+        <location filename="../app/AppLayouts/Wallet/views/SavedAddressesView.qml" line="196" />
+        <location filename="../app/AppLayouts/Wallet/views/SavedAddressesView.qml" line="196" />
         <source>Cancel</source>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/views/SavedAddressesView.qml" line="170" />
+        <location filename="../app/AppLayouts/Wallet/views/SavedAddressesView.qml" line="144" />
+        <location filename="../app/AppLayouts/Wallet/views/SavedAddressesView.qml" line="201" />
+        <location filename="../app/AppLayouts/Wallet/views/SavedAddressesView.qml" line="144" />
+        <location filename="../app/AppLayouts/Wallet/views/SavedAddressesView.qml" line="201" />
         <source>Delete</source>
         <translation>Delete</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/views/SavedAddressesView.qml" line="198" />
+        <location filename="../app/AppLayouts/Wallet/views/SavedAddressesView.qml" line="225" />
+        <location filename="../app/AppLayouts/Wallet/views/SavedAddressesView.qml" line="225" />
         <source>No saved addresses</source>
         <translation>No saved addresses</translation>
     </message>
@@ -7114,10 +8928,12 @@ device, so only you can use them.</translation>
     <name>SearchEngineModal</name>
     <message>
         <location filename="../app/AppLayouts/Profile/popups/SearchEngineModal.qml" line="12" />
+        <location filename="../app/AppLayouts/Profile/popups/SearchEngineModal.qml" line="12" />
         <source>Search engine</source>
         <translation>Search engine</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/popups/SearchEngineModal.qml" line="31" />
         <location filename="../app/AppLayouts/Profile/popups/SearchEngineModal.qml" line="31" />
         <source>None</source>
         <translation>None</translation>
@@ -7142,49 +8958,70 @@ device, so only you can use them.</translation>
     <name>SeedPhraseBackupWarning</name>
     <message>
         <location filename="../app/AppLayouts/Wallet/panels/SeedPhraseBackupWarning.qml" line="23" />
+        <location filename="../app/AppLayouts/Wallet/panels/SeedPhraseBackupWarning.qml" line="23" />
         <source>Back up your seed phrase</source>
         <translation>Back up your seed phrase</translation>
+    </message>
+    <message>
+        <location filename="../app/AppLayouts/Wallet/panels/SeedPhraseBackupWarning.qml" line="35" />
+        <location filename="../app/AppLayouts/Wallet/panels/SeedPhraseBackupWarning.qml" line="35" />
+        <source>Back up</source>
+        <translation type="unfinished">Back up</translation>
     </message>
 </context>
 <context>
     <name>SeedPhraseInputView</name>
     <message>
         <location filename="../app/AppLayouts/Onboarding/views/SeedPhraseInputView.qml" line="77" />
+        <location filename="../app/AppLayouts/Onboarding/views/SeedPhraseInputView.qml" line="77" />
         <source>Keys for this account already exist</source>
         <translation>Keys for this account already exist</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Onboarding/views/SeedPhraseInputView.qml" line="78" />
         <location filename="../app/AppLayouts/Onboarding/views/SeedPhraseInputView.qml" line="78" />
         <source>Keys for this account already exist and can't be added again. If you've lost your password, passcode or Keycard, uninstall the app, reinstall and access your keys by entering your seed phrase</source>
         <translation>Keys for this account already exist and can't be added again. If you've lost your password, passcode or Keycard, uninstall the app, reinstall and access your keys by entering your seed phrase</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Onboarding/views/SeedPhraseInputView.qml" line="80" />
+        <location filename="../app/AppLayouts/Onboarding/views/SeedPhraseInputView.qml" line="80" />
         <source>Error importing seed</source>
         <translation>Error importing seed</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Onboarding/views/SeedPhraseInputView.qml" line="108" />
+        <location filename="../app/AppLayouts/Onboarding/views/SeedPhraseInputView.qml" line="109" />
+        <location filename="../app/AppLayouts/Onboarding/views/SeedPhraseInputView.qml" line="109" />
         <source>Enter seed phrase</source>
         <translation>Enter seed phrase</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Onboarding/views/SeedPhraseInputView.qml" line="119" />
+        <location filename="../app/AppLayouts/Onboarding/views/SeedPhraseInputView.qml" line="120" />
+        <location filename="../app/AppLayouts/Onboarding/views/SeedPhraseInputView.qml" line="120" />
         <source>%1 words</source>
         <translation>%1 words</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Onboarding/views/SeedPhraseInputView.qml" line="285" />
+        <location filename="../app/AppLayouts/Onboarding/views/SeedPhraseInputView.qml" line="122" />
+        <location filename="../app/AppLayouts/Onboarding/views/SeedPhraseInputView.qml" line="122" />
+        <source>%1SeedButton</source>
+        <translation>%1SeedButton</translation>
+    </message>
+    <message>
+        <location filename="../app/AppLayouts/Onboarding/views/SeedPhraseInputView.qml" line="288" />
+        <location filename="../app/AppLayouts/Onboarding/views/SeedPhraseInputView.qml" line="288" />
         <source>Invalid seed</source>
         <translation>Invalid seed</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Onboarding/views/SeedPhraseInputView.qml" line="297" />
+        <location filename="../app/AppLayouts/Onboarding/views/SeedPhraseInputView.qml" line="300" />
+        <location filename="../app/AppLayouts/Onboarding/views/SeedPhraseInputView.qml" line="300" />
         <source>Restore Status Profile</source>
         <translation>Restore Status Profile</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Onboarding/views/SeedPhraseInputView.qml" line="297" />
+        <location filename="../app/AppLayouts/Onboarding/views/SeedPhraseInputView.qml" line="300" />
+        <location filename="../app/AppLayouts/Onboarding/views/SeedPhraseInputView.qml" line="300" />
         <source>Import</source>
         <translation>Import</translation>
     </message>
@@ -7237,10 +9074,12 @@ device, so only you can use them.</translation>
     <name>SelectAnotherAccountModal</name>
     <message>
         <location filename="../app/AppLayouts/Onboarding/popups/SelectAnotherAccountModal.qml" line="18" />
+        <location filename="../app/AppLayouts/Onboarding/popups/SelectAnotherAccountModal.qml" line="18" />
         <source>Your keys</source>
         <translation>Your keys</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Onboarding/popups/SelectAnotherAccountModal.qml" line="39" />
         <location filename="../app/AppLayouts/Onboarding/popups/SelectAnotherAccountModal.qml" line="39" />
         <source>Add another existing key</source>
         <translation>Add another existing key</translation>
@@ -7250,30 +9089,36 @@ device, so only you can use them.</translation>
     <name>SelectGeneratedAccount</name>
     <message>
         <location filename="../app/AppLayouts/Wallet/panels/SelectGeneratedAccount.qml" line="40" />
+        <location filename="../app/AppLayouts/Wallet/panels/SelectGeneratedAccount.qml" line="40" />
         <source>Import new Seed Phrase</source>
         <translation>Import new Seed Phrase</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Wallet/panels/SelectGeneratedAccount.qml" line="41" />
         <location filename="../app/AppLayouts/Wallet/panels/SelectGeneratedAccount.qml" line="41" />
         <source>Generate from Private key</source>
         <translation>Generate from Private key</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Wallet/panels/SelectGeneratedAccount.qml" line="42" />
+        <location filename="../app/AppLayouts/Wallet/panels/SelectGeneratedAccount.qml" line="42" />
         <source>Add a watch-only address</source>
         <translation>Add a watch-only address</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Wallet/panels/SelectGeneratedAccount.qml" line="60" />
         <location filename="../app/AppLayouts/Wallet/panels/SelectGeneratedAccount.qml" line="60" />
         <source>Imported</source>
         <translation>Imported</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Wallet/panels/SelectGeneratedAccount.qml" line="64" />
+        <location filename="../app/AppLayouts/Wallet/panels/SelectGeneratedAccount.qml" line="64" />
         <source>Add new</source>
         <translation>Add new</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Wallet/panels/SelectGeneratedAccount.qml" line="72" />
         <location filename="../app/AppLayouts/Wallet/panels/SelectGeneratedAccount.qml" line="72" />
         <source>Origin</source>
         <translation>Origin</translation>
@@ -7283,6 +9128,7 @@ device, so only you can use them.</translation>
     <name>SendContactRequestMenuItem</name>
     <message>
         <location filename="../imports/shared/controls/chat/menuItems/SendContactRequestMenuItem.qml" line="6" />
+        <location filename="../imports/shared/controls/chat/menuItems/SendContactRequestMenuItem.qml" line="6" />
         <source>Send Contact Request</source>
         <translation>Send Contact Request</translation>
     </message>
@@ -7291,15 +9137,18 @@ device, so only you can use them.</translation>
     <name>SendContactRequestModal</name>
     <message>
         <location filename="../app/AppLayouts/Profile/popups/SendContactRequestModal.qml" line="18" />
+        <location filename="../app/AppLayouts/Profile/popups/SendContactRequestModal.qml" line="18" />
         <source>Send Contact Request to chat key</source>
         <translation>Send Contact Request to chat key</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/popups/SendContactRequestModal.qml" line="77" />
+        <location filename="../app/AppLayouts/Profile/popups/SendContactRequestModal.qml" line="77" />
         <source>Paste</source>
         <translation>Paste</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/popups/SendContactRequestModal.qml" line="96" />
         <location filename="../app/AppLayouts/Profile/popups/SendContactRequestModal.qml" line="96" />
         <source>Enter chat key here</source>
         <translation>Enter chat key here</translation>
@@ -7307,6 +9156,7 @@ device, so only you can use them.</translation>
     <message>
         <location filename="../app/AppLayouts/Profile/popups/SendContactRequestModal.qml" line="130" />
         <location filename="../imports/shared/popups/SendContactRequestModal.qml" line="56" />
+        <location filename="../app/AppLayouts/Profile/popups/SendContactRequestModal.qml" line="130" />
         <location filename="../imports/shared/popups/SendContactRequestModal.qml" line="56" />
         <source>Say who you are / why you want to become a contact...</source>
         <translation>Say who you are / why you want to become a contact...</translation>
@@ -7314,6 +9164,7 @@ device, so only you can use them.</translation>
     <message>
         <location filename="../app/AppLayouts/Profile/popups/SendContactRequestModal.qml" line="137" />
         <location filename="../imports/shared/popups/SendContactRequestModal.qml" line="63" />
+        <location filename="../app/AppLayouts/Profile/popups/SendContactRequestModal.qml" line="137" />
         <location filename="../imports/shared/popups/SendContactRequestModal.qml" line="63" />
         <source>who are you</source>
         <translation>who are you</translation>
@@ -7321,6 +9172,7 @@ device, so only you can use them.</translation>
     <message>
         <location filename="../app/AppLayouts/Profile/popups/SendContactRequestModal.qml" line="148" />
         <location filename="../imports/shared/popups/SendContactRequestModal.qml" line="72" />
+        <location filename="../app/AppLayouts/Profile/popups/SendContactRequestModal.qml" line="148" />
         <location filename="../imports/shared/popups/SendContactRequestModal.qml" line="72" />
         <source>Send Contact Request</source>
         <translation>Send Contact Request</translation>
@@ -7330,6 +9182,7 @@ device, so only you can use them.</translation>
     <name>SendMessageMenuItem</name>
     <message>
         <location filename="../imports/shared/controls/chat/menuItems/SendMessageMenuItem.qml" line="6" />
+        <location filename="../imports/shared/controls/chat/menuItems/SendMessageMenuItem.qml" line="6" />
         <source>Send message</source>
         <translation>Send message</translation>
     </message>
@@ -7337,26 +9190,26 @@ device, so only you can use them.</translation>
 <context>
     <name>SendModal</name>
     <message>
-        <location filename="../imports/shared/popups/SendModal.qml" line="33" />
-        <location filename="../imports/shared/popups/SendModal.qml" line="33" />
+        <location filename="../imports/shared/popups/SendModal.qml" line="34" />
+        <location filename="../imports/shared/popups/SendModal.qml" line="34" />
         <source>Error sending the transaction</source>
         <translation>Error sending the transaction</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/SendModal.qml" line="137" />
-        <location filename="../imports/shared/popups/SendModal.qml" line="137" />
+        <location filename="../imports/shared/popups/SendModal.qml" line="134" />
+        <location filename="../imports/shared/popups/SendModal.qml" line="134" />
         <source>Send</source>
         <translation>Send</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/SendModal.qml" line="143" />
-        <location filename="../imports/shared/popups/SendModal.qml" line="143" />
+        <location filename="../imports/shared/popups/SendModal.qml" line="140" />
+        <location filename="../imports/shared/popups/SendModal.qml" line="140" />
         <source>Max: </source>
         <translation>Max: </translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/SendModal.qml" line="143" />
-        <location filename="../imports/shared/popups/SendModal.qml" line="143" />
+        <location filename="../imports/shared/popups/SendModal.qml" line="140" />
+        <location filename="../imports/shared/popups/SendModal.qml" line="140" />
         <source>No balances active</source>
         <translation>No balances active</translation>
     </message>
@@ -7367,38 +9220,36 @@ device, so only you can use them.</translation>
         <translation>Please enter a valid amount</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/SendModal.qml" line="285" />
-        <location filename="../imports/shared/popups/SendModal.qml" line="285" />
+        <location filename="../imports/shared/popups/SendModal.qml" line="286" />
+        <location filename="../imports/shared/popups/SendModal.qml" line="286" />
         <source>To</source>
         <translation>To</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/SendModal.qml" line="287" />
-        <location filename="../imports/shared/popups/SendModal.qml" line="287" />
+        <location filename="../imports/shared/popups/SendModal.qml" line="288" />
+        <location filename="../imports/shared/popups/SendModal.qml" line="288" />
         <source>Enter an ENS name or address</source>
         <translation>Enter an ENS name or address</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/SendModal.qml" line="349" />
-        <location filename="../imports/shared/popups/SendModal.qml" line="349" />
         <source>Error estimating gas: %1</source>
-        <translation>Error estimating gas: %1</translation>
+        <translation type="vanished">Error estimating gas: %1</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/SendModal.qml" line="440" />
-        <location filename="../imports/shared/popups/SendModal.qml" line="440" />
+        <location filename="../imports/shared/popups/SendModal.qml" line="474" />
+        <location filename="../imports/shared/popups/SendModal.qml" line="474" />
         <source>Wrong password</source>
         <translation>Wrong password</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/SendModal.qml" line="448" />
-        <location filename="../imports/shared/popups/SendModal.qml" line="448" />
+        <location filename="../imports/shared/popups/SendModal.qml" line="482" />
+        <location filename="../imports/shared/popups/SendModal.qml" line="482" />
         <source>Transaction pending...</source>
         <translation>Transaction pending...</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/SendModal.qml" line="449" />
-        <location filename="../imports/shared/popups/SendModal.qml" line="449" />
+        <location filename="../imports/shared/popups/SendModal.qml" line="483" />
+        <location filename="../imports/shared/popups/SendModal.qml" line="483" />
         <source>View on etherscan</source>
         <translation>View on etherscan</translation>
     </message>
@@ -7437,6 +9288,7 @@ device, so only you can use them.</translation>
     <name>SendTransactionButton</name>
     <message>
         <location filename="../imports/shared/controls/chat/SendTransactionButton.qml" line="28" />
+        <location filename="../imports/shared/controls/chat/SendTransactionButton.qml" line="28" />
         <source>Sign and send</source>
         <translation>Sign and send</translation>
     </message>
@@ -7466,35 +9318,42 @@ device, so only you can use them.</translation>
     <name>SignMessageModal</name>
     <message>
         <location filename="../app/AppLayouts/Browser/popups/SignMessageModal.qml" line="37" />
+        <location filename="../app/AppLayouts/Browser/popups/SignMessageModal.qml" line="37" />
         <source>Signature request</source>
         <translation>Signature request</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Browser/popups/SignMessageModal.qml" line="98" />
         <location filename="../app/AppLayouts/Browser/popups/SignMessageModal.qml" line="98" />
         <source>From</source>
         <translation>From</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Browser/popups/SignMessageModal.qml" line="140" />
+        <location filename="../app/AppLayouts/Browser/popups/SignMessageModal.qml" line="140" />
         <source>Data</source>
         <translation>Data</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Browser/popups/SignMessageModal.qml" line="148" />
         <location filename="../app/AppLayouts/Browser/popups/SignMessageModal.qml" line="148" />
         <source>Message</source>
         <translation>Message</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Browser/popups/SignMessageModal.qml" line="211" />
+        <location filename="../app/AppLayouts/Browser/popups/SignMessageModal.qml" line="211" />
         <source>Reject</source>
         <translation>Reject</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Browser/popups/SignMessageModal.qml" line="221" />
+        <location filename="../app/AppLayouts/Browser/popups/SignMessageModal.qml" line="221" />
         <source>Sign</source>
         <translation>Sign</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Browser/popups/SignMessageModal.qml" line="222" />
         <location filename="../app/AppLayouts/Browser/popups/SignMessageModal.qml" line="222" />
         <source>Sign with password</source>
         <translation>Sign with password</translation>
@@ -7504,30 +9363,36 @@ device, so only you can use them.</translation>
     <name>SignPhraseModal</name>
     <message>
         <location filename="../app/AppLayouts/Wallet/popups/SignPhraseModal.qml" line="20" />
+        <location filename="../app/AppLayouts/Wallet/popups/SignPhraseModal.qml" line="20" />
         <source>Signing phrase</source>
         <translation>Signing phrase</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Wallet/popups/SignPhraseModal.qml" line="30" />
         <location filename="../app/AppLayouts/Wallet/popups/SignPhraseModal.qml" line="30" />
         <source>This is your signing phrase</source>
         <translation>This is your signing phrase</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Wallet/popups/SignPhraseModal.qml" line="39" />
+        <location filename="../app/AppLayouts/Wallet/popups/SignPhraseModal.qml" line="39" />
         <source>You should see these 3 words before signing each transaction</source>
         <translation>You should see these 3 words before signing each transaction</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Wallet/popups/SignPhraseModal.qml" line="76" />
         <location filename="../app/AppLayouts/Wallet/popups/SignPhraseModal.qml" line="76" />
         <source>If you see a different combination, cancel the transaction and sign out</source>
         <translation>If you see a different combination, cancel the transaction and sign out</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Wallet/popups/SignPhraseModal.qml" line="94" />
+        <location filename="../app/AppLayouts/Wallet/popups/SignPhraseModal.qml" line="94" />
         <source>Ok, got it</source>
         <translation>Ok, got it</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Wallet/popups/SignPhraseModal.qml" line="104" />
         <location filename="../app/AppLayouts/Wallet/popups/SignPhraseModal.qml" line="104" />
         <source>Remind me later</source>
         <translation>Remind me later</translation>
@@ -7624,50 +9489,60 @@ device, so only you can use them.</translation>
     <name>StateBubble</name>
     <message>
         <location filename="../imports/shared/controls/chat/StateBubble.qml" line="61" />
+        <location filename="../imports/shared/controls/chat/StateBubble.qml" line="61" />
         <source>Pending</source>
         <translation>Pending</translation>
     </message>
     <message>
+        <location filename="../imports/shared/controls/chat/StateBubble.qml" line="62" />
         <location filename="../imports/shared/controls/chat/StateBubble.qml" line="62" />
         <source>Confirmed</source>
         <translation>Confirmed</translation>
     </message>
     <message>
         <location filename="../imports/shared/controls/chat/StateBubble.qml" line="63" />
+        <location filename="../imports/shared/controls/chat/StateBubble.qml" line="63" />
         <source>Unknown token</source>
         <translation>Unknown token</translation>
     </message>
     <message>
+        <location filename="../imports/shared/controls/chat/StateBubble.qml" line="64" />
         <location filename="../imports/shared/controls/chat/StateBubble.qml" line="64" />
         <source>Address requested</source>
         <translation>Address requested</translation>
     </message>
     <message>
         <location filename="../imports/shared/controls/chat/StateBubble.qml" line="65" />
+        <location filename="../imports/shared/controls/chat/StateBubble.qml" line="65" />
         <source>Waiting to accept</source>
         <translation>Waiting to accept</translation>
     </message>
     <message>
+        <location filename="../imports/shared/controls/chat/StateBubble.qml" line="67" />
         <location filename="../imports/shared/controls/chat/StateBubble.qml" line="67" />
         <source>Address shared</source>
         <translation>Address shared</translation>
     </message>
     <message>
         <location filename="../imports/shared/controls/chat/StateBubble.qml" line="68" />
+        <location filename="../imports/shared/controls/chat/StateBubble.qml" line="68" />
         <source>Address received</source>
         <translation>Address received</translation>
     </message>
     <message>
+        <location filename="../imports/shared/controls/chat/StateBubble.qml" line="70" />
         <location filename="../imports/shared/controls/chat/StateBubble.qml" line="70" />
         <source>Transaction declined</source>
         <translation>Transaction declined</translation>
     </message>
     <message>
         <location filename="../imports/shared/controls/chat/StateBubble.qml" line="71" />
+        <location filename="../imports/shared/controls/chat/StateBubble.qml" line="71" />
         <source>failure</source>
         <translation>failure</translation>
     </message>
     <message>
+        <location filename="../imports/shared/controls/chat/StateBubble.qml" line="72" />
         <location filename="../imports/shared/controls/chat/StateBubble.qml" line="72" />
         <source>Unknown state</source>
         <translation>Unknown state</translation>
@@ -7677,6 +9552,7 @@ device, so only you can use them.</translation>
     <name>StatusActivityCenterButton</name>
     <message>
         <location filename="../StatusQ/src/StatusQ/Controls/StatusActivityCenterButton.qml" line="39" />
+        <location filename="../StatusQ/src/StatusQ/Controls/StatusActivityCenterButton.qml" line="39" />
         <source>Activity</source>
         <translation>Activity</translation>
     </message>
@@ -7684,6 +9560,7 @@ device, so only you can use them.</translation>
 <context>
     <name>StatusAddressOrEnsValidator</name>
     <message>
+        <location filename="../StatusQ/src/StatusQ/Controls/Validators/StatusAddressOrEnsValidator.qml" line="7" />
         <location filename="../StatusQ/src/StatusQ/Controls/Validators/StatusAddressOrEnsValidator.qml" line="7" />
         <source>Please enter a valid address or ENS name.</source>
         <translation>Please enter a valid address or ENS name.</translation>
@@ -7693,23 +9570,42 @@ device, so only you can use them.</translation>
     <name>StatusAddressValidator</name>
     <message>
         <location filename="../StatusQ/src/StatusQ/Controls/Validators/StatusAddressValidator.qml" line="7" />
+        <location filename="../StatusQ/src/StatusQ/Controls/Validators/StatusAddressValidator.qml" line="7" />
         <source>Please enter a valid address.</source>
         <translation>Please enter a valid address.</translation>
+    </message>
+</context>
+<context>
+    <name>StatusAppChatView</name>
+    <message>
+        <location filename="../StatusQ/sandbox/demoapp/StatusAppChatView.qml" line="45" />
+        <location filename="../StatusQ/sandbox/demoapp/StatusAppChatView.qml" line="45" />
+        <source>Join public chats</source>
+        <translation type="unfinished">Join public chats</translation>
+    </message>
+    <message>
+        <location filename="../StatusQ/sandbox/demoapp/StatusAppChatView.qml" line="62" />
+        <location filename="../StatusQ/sandbox/demoapp/StatusAppChatView.qml" line="62" />
+        <source>Start chat</source>
+        <translation type="unfinished">Start chat</translation>
     </message>
 </context>
 <context>
     <name>StatusAppCommunitiesPortalView</name>
     <message>
         <location filename="../StatusQ/sandbox/demoapp/StatusAppCommunitiesPortalView.qml" line="46" />
+        <location filename="../StatusQ/sandbox/demoapp/StatusAppCommunitiesPortalView.qml" line="46" />
         <source>Find community</source>
         <translation>Find community</translation>
     </message>
     <message>
         <location filename="../StatusQ/sandbox/demoapp/StatusAppCommunitiesPortalView.qml" line="84" />
+        <location filename="../StatusQ/sandbox/demoapp/StatusAppCommunitiesPortalView.qml" line="84" />
         <source>Featured</source>
         <translation>Featured</translation>
     </message>
     <message>
+        <location filename="../StatusQ/sandbox/demoapp/StatusAppCommunitiesPortalView.qml" line="123" />
         <location filename="../StatusQ/sandbox/demoapp/StatusAppCommunitiesPortalView.qml" line="123" />
         <source>Popular</source>
         <translation>Popular</translation>
@@ -7719,6 +9615,7 @@ device, so only you can use them.</translation>
     <name>StatusAppCommunityView</name>
     <message>
         <location filename="../StatusQ/sandbox/demoapp/StatusAppCommunityView.qml" line="254" />
+        <location filename="../StatusQ/sandbox/demoapp/StatusAppCommunityView.qml" line="254" />
         <source>Members</source>
         <translation>Members</translation>
     </message>
@@ -7726,6 +9623,7 @@ device, so only you can use them.</translation>
 <context>
     <name>StatusAsyncEnsValidator</name>
     <message>
+        <location filename="../StatusQ/src/StatusQ/Controls/Validators/StatusAsyncEnsValidator.qml" line="9" />
         <location filename="../StatusQ/src/StatusQ/Controls/Validators/StatusAsyncEnsValidator.qml" line="9" />
         <source>ENS name could not be resolved in to an address</source>
         <translation>ENS name could not be resolved in to an address</translation>
@@ -7735,6 +9633,7 @@ device, so only you can use them.</translation>
     <name>StatusAsyncValidator</name>
     <message>
         <location filename="../StatusQ/src/StatusQ/Controls/Validators/StatusAsyncValidator.qml" line="8" />
+        <location filename="../StatusQ/src/StatusQ/Controls/Validators/StatusAsyncValidator.qml" line="8" />
         <source>invalid input</source>
         <translation>invalid input</translation>
     </message>
@@ -7742,7 +9641,8 @@ device, so only you can use them.</translation>
 <context>
     <name>StatusBadge</name>
     <message>
-        <location filename="../StatusQ/src/StatusQ/Components/StatusBadge.qml" line="35" />
+        <location filename="../StatusQ/src/StatusQ/Components/StatusBadge.qml" line="37" />
+        <location filename="../StatusQ/src/StatusQ/Components/StatusBadge.qml" line="37" />
         <source>99+</source>
         <translation>99+</translation>
     </message>
@@ -7858,8 +9758,8 @@ device, so only you can use them.</translation>
         <translation>Send</translation>
     </message>
     <message>
-        <location filename="../imports/shared/status/StatusChatInput.qml" line="1262" />
-        <location filename="../imports/shared/status/StatusChatInput.qml" line="1262" />
+        <location filename="../imports/shared/status/StatusChatInput.qml" line="1260" />
+        <location filename="../imports/shared/status/StatusChatInput.qml" line="1260" />
         <source>Unblock</source>
         <translation>Unblock</translation>
     </message>
@@ -7868,10 +9768,12 @@ device, so only you can use them.</translation>
     <name>StatusChatListAndCategories</name>
     <message>
         <location filename="../StatusQ/src/StatusQ/Components/StatusChatListAndCategories.qml" line="17" />
+        <location filename="../StatusQ/src/StatusQ/Components/StatusChatListAndCategories.qml" line="17" />
         <source>Add channel inside category</source>
         <translation>Add channel inside category</translation>
     </message>
     <message>
+        <location filename="../StatusQ/src/StatusQ/Components/StatusChatListAndCategories.qml" line="20" />
         <location filename="../StatusQ/src/StatusQ/Components/StatusChatListAndCategories.qml" line="20" />
         <source>More</source>
         <translation>More</translation>
@@ -7881,10 +9783,12 @@ device, so only you can use them.</translation>
     <name>StatusChatListCategoryItem</name>
     <message>
         <location filename="../StatusQ/src/StatusQ/Components/StatusChatListCategoryItem.qml" line="46" />
+        <location filename="../StatusQ/src/StatusQ/Components/StatusChatListCategoryItem.qml" line="46" />
         <source>Add channel inside category</source>
         <translation>Add channel inside category</translation>
     </message>
     <message>
+        <location filename="../StatusQ/src/StatusQ/Components/StatusChatListCategoryItem.qml" line="56" />
         <location filename="../StatusQ/src/StatusQ/Components/StatusChatListCategoryItem.qml" line="56" />
         <source>More</source>
         <translation>More</translation>
@@ -7894,6 +9798,7 @@ device, so only you can use them.</translation>
     <name>StatusChatListItem</name>
     <message>
         <location filename="../StatusQ/src/StatusQ/Components/StatusChatListItem.qml" line="183" />
+        <location filename="../StatusQ/src/StatusQ/Components/StatusChatListItem.qml" line="183" />
         <source>Unmute</source>
         <translation>Unmute</translation>
     </message>
@@ -7902,15 +9807,18 @@ device, so only you can use them.</translation>
     <name>StatusChatToolBar</name>
     <message>
         <location filename="../StatusQ/src/StatusQ/Components/StatusChatToolBar.qml" line="65" />
+        <location filename="../StatusQ/src/StatusQ/Components/StatusChatToolBar.qml" line="65" />
         <source>Search</source>
         <translation>Search</translation>
     </message>
     <message>
         <location filename="../StatusQ/src/StatusQ/Components/StatusChatToolBar.qml" line="79" />
+        <location filename="../StatusQ/src/StatusQ/Components/StatusChatToolBar.qml" line="79" />
         <source>Members</source>
         <translation>Members</translation>
     </message>
     <message>
+        <location filename="../StatusQ/src/StatusQ/Components/StatusChatToolBar.qml" line="94" />
         <location filename="../StatusQ/src/StatusQ/Components/StatusChatToolBar.qml" line="94" />
         <source>More</source>
         <translation>More</translation>
@@ -7920,20 +9828,24 @@ device, so only you can use them.</translation>
     <name>StatusColorDialog</name>
     <message>
         <location filename="../StatusQ/src/StatusQ/Popups/StatusColorDialog.qml" line="80" />
+        <location filename="../StatusQ/src/StatusQ/Popups/StatusColorDialog.qml" line="80" />
         <source>This is not a valid color</source>
         <translation>This is not a valid color</translation>
     </message>
     <message>
+        <location filename="../StatusQ/src/StatusQ/Popups/StatusColorDialog.qml" line="97" />
         <location filename="../StatusQ/src/StatusQ/Popups/StatusColorDialog.qml" line="97" />
         <source>Preview</source>
         <translation>Preview</translation>
     </message>
     <message>
         <location filename="../StatusQ/src/StatusQ/Popups/StatusColorDialog.qml" line="118" />
+        <location filename="../StatusQ/src/StatusQ/Popups/StatusColorDialog.qml" line="118" />
         <source>Standart colours</source>
         <translation>Standart colours</translation>
     </message>
     <message>
+        <location filename="../StatusQ/src/StatusQ/Popups/StatusColorDialog.qml" line="138" />
         <location filename="../StatusQ/src/StatusQ/Popups/StatusColorDialog.qml" line="138" />
         <source>Select Colour</source>
         <translation>Select Colour</translation>
@@ -7943,30 +9855,36 @@ device, so only you can use them.</translation>
     <name>StatusColorSpacePage</name>
     <message>
         <location filename="../StatusQ/sandbox/pages/StatusColorSpacePage.qml" line="18" />
+        <location filename="../StatusQ/sandbox/pages/StatusColorSpacePage.qml" line="18" />
         <source>Thickness</source>
         <translation>Thickness</translation>
     </message>
     <message>
+        <location filename="../StatusQ/sandbox/pages/StatusColorSpacePage.qml" line="30" />
         <location filename="../StatusQ/sandbox/pages/StatusColorSpacePage.qml" line="30" />
         <source>Min saturate: </source>
         <translation>Min saturate: </translation>
     </message>
     <message>
         <location filename="../StatusQ/sandbox/pages/StatusColorSpacePage.qml" line="42" />
+        <location filename="../StatusQ/sandbox/pages/StatusColorSpacePage.qml" line="42" />
         <source>Max saturate: </source>
         <translation>Max saturate: </translation>
     </message>
     <message>
+        <location filename="../StatusQ/sandbox/pages/StatusColorSpacePage.qml" line="54" />
         <location filename="../StatusQ/sandbox/pages/StatusColorSpacePage.qml" line="54" />
         <source>Min value: </source>
         <translation>Min value: </translation>
     </message>
     <message>
         <location filename="../StatusQ/sandbox/pages/StatusColorSpacePage.qml" line="66" />
+        <location filename="../StatusQ/sandbox/pages/StatusColorSpacePage.qml" line="66" />
         <source>Max value: </source>
         <translation>Max value: </translation>
     </message>
     <message>
+        <location filename="../StatusQ/sandbox/pages/StatusColorSpacePage.qml" line="88" />
         <location filename="../StatusQ/sandbox/pages/StatusColorSpacePage.qml" line="88" />
         <source>Color</source>
         <translation>Color</translation>
@@ -7976,18 +9894,108 @@ device, so only you can use them.</translation>
     <name>StatusCommunityTagsPage</name>
     <message>
         <location filename="../StatusQ/sandbox/pages/StatusCommunityTagsPage.qml" line="38" />
+        <location filename="../StatusQ/sandbox/pages/StatusCommunityTagsPage.qml" line="38" />
         <source>Select tags that will fit your Community</source>
         <translation>Select tags that will fit your Community</translation>
     </message>
     <message>
+        <location filename="../StatusQ/sandbox/pages/StatusCommunityTagsPage.qml" line="40" />
         <location filename="../StatusQ/sandbox/pages/StatusCommunityTagsPage.qml" line="40" />
         <source>Search tags</source>
         <translation>Search tags</translation>
     </message>
     <message>
         <location filename="../StatusQ/sandbox/pages/StatusCommunityTagsPage.qml" line="57" />
+        <location filename="../StatusQ/sandbox/pages/StatusCommunityTagsPage.qml" line="57" />
         <source>Selected tags</source>
         <translation>Selected tags</translation>
+    </message>
+</context>
+<context>
+    <name>StatusDialog</name>
+    <message>
+        <location filename="../StatusQ/src/StatusQ/Popups/Dialog/StatusDialog.qml" line="52" />
+        <location filename="../StatusQ/src/StatusQ/Popups/Dialog/StatusDialog.qml" line="52" />
+        <source>Close</source>
+        <translation type="unfinished">Close</translation>
+    </message>
+    <message>
+        <location filename="../StatusQ/src/StatusQ/Popups/Dialog/StatusDialog.qml" line="53" />
+        <location filename="../StatusQ/src/StatusQ/Popups/Dialog/StatusDialog.qml" line="53" />
+        <source>Abort</source>
+        <translation>Abort</translation>
+    </message>
+    <message>
+        <location filename="../StatusQ/src/StatusQ/Popups/Dialog/StatusDialog.qml" line="54" />
+        <location filename="../StatusQ/src/StatusQ/Popups/Dialog/StatusDialog.qml" line="54" />
+        <source>Cancel</source>
+        <translation type="unfinished">Cancel</translation>
+    </message>
+    <message>
+        <location filename="../StatusQ/src/StatusQ/Popups/Dialog/StatusDialog.qml" line="64" />
+        <location filename="../StatusQ/src/StatusQ/Popups/Dialog/StatusDialog.qml" line="64" />
+        <source>No to all</source>
+        <translation>No to all</translation>
+    </message>
+    <message>
+        <location filename="../StatusQ/src/StatusQ/Popups/Dialog/StatusDialog.qml" line="65" />
+        <location filename="../StatusQ/src/StatusQ/Popups/Dialog/StatusDialog.qml" line="65" />
+        <source>No</source>
+        <translation>No</translation>
+    </message>
+    <message>
+        <location filename="../StatusQ/src/StatusQ/Popups/Dialog/StatusDialog.qml" line="74" />
+        <location filename="../StatusQ/src/StatusQ/Popups/Dialog/StatusDialog.qml" line="74" />
+        <source>Open</source>
+        <translation type="unfinished">Open</translation>
+    </message>
+    <message>
+        <location filename="../StatusQ/src/StatusQ/Popups/Dialog/StatusDialog.qml" line="75" />
+        <location filename="../StatusQ/src/StatusQ/Popups/Dialog/StatusDialog.qml" line="75" />
+        <source>Save</source>
+        <translation type="unfinished">Save</translation>
+    </message>
+    <message>
+        <location filename="../StatusQ/src/StatusQ/Popups/Dialog/StatusDialog.qml" line="76" />
+        <location filename="../StatusQ/src/StatusQ/Popups/Dialog/StatusDialog.qml" line="76" />
+        <source>Save all</source>
+        <translation>Save all</translation>
+    </message>
+    <message>
+        <location filename="../StatusQ/src/StatusQ/Popups/Dialog/StatusDialog.qml" line="77" />
+        <location filename="../StatusQ/src/StatusQ/Popups/Dialog/StatusDialog.qml" line="77" />
+        <source>Retry</source>
+        <translation type="unfinished">Retry</translation>
+    </message>
+    <message>
+        <location filename="../StatusQ/src/StatusQ/Popups/Dialog/StatusDialog.qml" line="78" />
+        <location filename="../StatusQ/src/StatusQ/Popups/Dialog/StatusDialog.qml" line="78" />
+        <source>Ignore</source>
+        <translation>Ignore</translation>
+    </message>
+    <message>
+        <location filename="../StatusQ/src/StatusQ/Popups/Dialog/StatusDialog.qml" line="79" />
+        <location filename="../StatusQ/src/StatusQ/Popups/Dialog/StatusDialog.qml" line="79" />
+        <source>Ok</source>
+        <translation type="unfinished">Ok</translation>
+    </message>
+    <message>
+        <location filename="../StatusQ/src/StatusQ/Popups/Dialog/StatusDialog.qml" line="89" />
+        <location filename="../StatusQ/src/StatusQ/Popups/Dialog/StatusDialog.qml" line="89" />
+        <source>Yes to all</source>
+        <translation>Yes to all</translation>
+    </message>
+    <message>
+        <location filename="../StatusQ/src/StatusQ/Popups/Dialog/StatusDialog.qml" line="90" />
+        <location filename="../StatusQ/src/StatusQ/Popups/Dialog/StatusDialog.qml" line="90" />
+        <source>Yes</source>
+        <translation>Yes</translation>
+    </message>
+    <message>
+        <location filename="../StatusQ/src/StatusQ/Popups/Dialog/StatusDialog.qml" line="98" />
+        <location filename="../StatusQ/src/StatusQ/Popups/Dialog/StatusDialog.qml" line="98" />
+        <source>Apply</source>
+        <translation>Apply</translation>
     </message>
 </context>
 <context>
@@ -8050,10 +10058,12 @@ device, so only you can use them.</translation>
     <name>StatusExpandableSettingsItemPage</name>
     <message>
         <location filename="../StatusQ/sandbox/pages/StatusExpandableSettingsItemPage.qml" line="32" />
+        <location filename="../StatusQ/sandbox/pages/StatusExpandableSettingsItemPage.qml" line="32" />
         <source>Back up seed phrase</source>
         <translation>Back up seed phrase</translation>
     </message>
     <message>
+        <location filename="../StatusQ/sandbox/pages/StatusExpandableSettingsItemPage.qml" line="148" />
         <location filename="../StatusQ/sandbox/pages/StatusExpandableSettingsItemPage.qml" line="148" />
         <source>Not Implemented</source>
         <translation>Not Implemented</translation>
@@ -8062,7 +10072,8 @@ device, so only you can use them.</translation>
 <context>
     <name>StatusFloatValidator</name>
     <message>
-        <location filename="../StatusQ/src/StatusQ/Controls/Validators/StatusFloatValidator.qml" line="48" />
+        <location filename="../StatusQ/src/StatusQ/Controls/Validators/StatusFloatValidator.qml" line="54" />
+        <location filename="../StatusQ/src/StatusQ/Controls/Validators/StatusFloatValidator.qml" line="54" />
         <source>Please enter a valid numeric value.</source>
         <translation>Please enter a valid numeric value.</translation>
     </message>
@@ -8155,13 +10166,30 @@ device, so only you can use them.</translation>
     <name>StatusIntValidator</name>
     <message>
         <location filename="../StatusQ/src/StatusQ/Controls/Validators/StatusIntValidator.qml" line="50" />
+        <location filename="../StatusQ/src/StatusQ/Controls/Validators/StatusIntValidator.qml" line="50" />
         <source>Please enter a valid numeric value.</source>
         <translation>Please enter a valid numeric value.</translation>
     </message>
 </context>
 <context>
+    <name>StatusItemSelector</name>
+    <message>
+        <location filename="../StatusQ/src/StatusQ/Components/StatusItemSelector.qml" line="98" />
+        <location filename="../StatusQ/src/StatusQ/Components/StatusItemSelector.qml" line="98" />
+        <source>and</source>
+        <translation>and</translation>
+    </message>
+    <message>
+        <location filename="../StatusQ/src/StatusQ/Components/StatusItemSelector.qml" line="103" />
+        <location filename="../StatusQ/src/StatusQ/Components/StatusItemSelector.qml" line="103" />
+        <source>or</source>
+        <translation type="unfinished">or</translation>
+    </message>
+</context>
+<context>
     <name>StatusListPicker</name>
     <message>
+        <location filename="../StatusQ/src/StatusQ/Components/StatusListPicker.qml" line="84" />
         <location filename="../StatusQ/src/StatusQ/Components/StatusListPicker.qml" line="84" />
         <source>Search</source>
         <translation>Search</translation>
@@ -8172,10 +10200,14 @@ device, so only you can use them.</translation>
     <message>
         <location filename="../StatusQ/sandbox/pages/StatusListPickerPage.qml" line="27" />
         <location filename="../StatusQ/sandbox/pages/StatusListPickerPage.qml" line="35" />
+        <location filename="../StatusQ/sandbox/pages/StatusListPickerPage.qml" line="27" />
+        <location filename="../StatusQ/sandbox/pages/StatusListPickerPage.qml" line="35" />
         <source>Search Languages</source>
         <translation>Search Languages</translation>
     </message>
     <message>
+        <location filename="../StatusQ/sandbox/pages/StatusListPickerPage.qml" line="42" />
+        <location filename="../StatusQ/sandbox/pages/StatusListPickerPage.qml" line="49" />
         <location filename="../StatusQ/sandbox/pages/StatusListPickerPage.qml" line="42" />
         <location filename="../StatusQ/sandbox/pages/StatusListPickerPage.qml" line="49" />
         <source>Search Currencies</source>
@@ -8186,12 +10218,14 @@ device, so only you can use them.</translation>
     <name>StatusMacNotification</name>
     <message>
         <location filename="../StatusQ/src/StatusQ/Platform/StatusMacNotification.qml" line="13" />
+        <location filename="../StatusQ/src/StatusQ/Platform/StatusMacNotification.qml" line="13" />
         <source>My latest message
  with a return</source>
         <translation>My latest message
  with a return</translation>
     </message>
     <message>
+        <location filename="../StatusQ/src/StatusQ/Platform/StatusMacNotification.qml" line="123" />
         <location filename="../StatusQ/src/StatusQ/Platform/StatusMacNotification.qml" line="123" />
         <source>Open</source>
         <translation>Open</translation>
@@ -8210,25 +10244,30 @@ device, so only you can use them.</translation>
     <name>StatusPasswordStrengthIndicator</name>
     <message>
         <location filename="../StatusQ/src/StatusQ/Controls/StatusPasswordStrengthIndicator.qml" line="63" />
+        <location filename="../StatusQ/src/StatusQ/Controls/StatusPasswordStrengthIndicator.qml" line="63" />
         <source>Very weak</source>
         <translation>Very weak</translation>
     </message>
     <message>
+        <location filename="../StatusQ/src/StatusQ/Controls/StatusPasswordStrengthIndicator.qml" line="70" />
         <location filename="../StatusQ/src/StatusQ/Controls/StatusPasswordStrengthIndicator.qml" line="70" />
         <source>Weak</source>
         <translation>Weak</translation>
     </message>
     <message>
         <location filename="../StatusQ/src/StatusQ/Controls/StatusPasswordStrengthIndicator.qml" line="77" />
+        <location filename="../StatusQ/src/StatusQ/Controls/StatusPasswordStrengthIndicator.qml" line="77" />
         <source>So-so</source>
         <translation>So-so</translation>
     </message>
     <message>
         <location filename="../StatusQ/src/StatusQ/Controls/StatusPasswordStrengthIndicator.qml" line="84" />
+        <location filename="../StatusQ/src/StatusQ/Controls/StatusPasswordStrengthIndicator.qml" line="84" />
         <source>Good</source>
         <translation>Good</translation>
     </message>
     <message>
+        <location filename="../StatusQ/src/StatusQ/Controls/StatusPasswordStrengthIndicator.qml" line="91" />
         <location filename="../StatusQ/src/StatusQ/Controls/StatusPasswordStrengthIndicator.qml" line="91" />
         <source>Great</source>
         <translation>Great</translation>
@@ -8303,7 +10342,8 @@ device, so only you can use them.</translation>
 <context>
     <name>StatusSearchLocationMenu</name>
     <message>
-        <location filename="../StatusQ/src/StatusQ/Popups/StatusSearchLocationMenu.qml" line="19" />
+        <location filename="../StatusQ/src/StatusQ/Popups/StatusSearchLocationMenu.qml" line="20" />
+        <location filename="../StatusQ/src/StatusQ/Popups/StatusSearchLocationMenu.qml" line="20" />
         <source>Anywhere</source>
         <translation>Anywhere</translation>
     </message>
@@ -8312,28 +10352,43 @@ device, so only you can use them.</translation>
     <name>StatusSearchPopup</name>
     <message>
         <location filename="../StatusQ/src/StatusQ/Popups/StatusSearchPopup.qml" line="21" />
+        <location filename="../StatusQ/src/StatusQ/Popups/StatusSearchPopup.qml" line="21" />
         <source>No results</source>
         <translation>No results</translation>
     </message>
     <message>
         <location filename="../StatusQ/src/StatusQ/Popups/StatusSearchPopup.qml" line="22" />
+        <location filename="../StatusQ/src/StatusQ/Popups/StatusSearchPopup.qml" line="22" />
         <source>Anywhere</source>
         <translation>Anywhere</translation>
     </message>
     <message>
-        <location filename="../StatusQ/src/StatusQ/Popups/StatusSearchPopup.qml" line="129" />
+        <location filename="../StatusQ/src/StatusQ/Popups/StatusSearchPopup.qml" line="105" />
+        <location filename="../StatusQ/src/StatusQ/Popups/StatusSearchPopup.qml" line="105" />
+        <source>Search</source>
+        <translation type="unfinished">Search</translation>
+    </message>
+    <message>
+        <location filename="../StatusQ/src/StatusQ/Popups/StatusSearchPopup.qml" line="178" />
+        <location filename="../StatusQ/src/StatusQ/Popups/StatusSearchPopup.qml" line="178" />
+        <source>In: </source>
+        <translation>In: </translation>
+    </message>
+    <message>
         <source>In</source>
-        <translation>In</translation>
+        <translation type="vanished">In</translation>
     </message>
 </context>
 <context>
     <name>StatusSpellcheckingMenuItems</name>
     <message>
         <location filename="../StatusQ/src/StatusQ/Popups/StatusSpellcheckingMenuItems.qml" line="62" />
+        <location filename="../StatusQ/src/StatusQ/Popups/StatusSpellcheckingMenuItems.qml" line="62" />
         <source>Add to dictionary</source>
         <translation>Add to dictionary</translation>
     </message>
     <message>
+        <location filename="../StatusQ/src/StatusQ/Popups/StatusSpellcheckingMenuItems.qml" line="89" />
         <location filename="../StatusQ/src/StatusQ/Popups/StatusSpellcheckingMenuItems.qml" line="89" />
         <source>Disable Spellchecking</source>
         <translation>Disable Spellchecking</translation>
@@ -8342,17 +10397,20 @@ device, so only you can use them.</translation>
 <context>
     <name>StatusStackModal</name>
     <message>
-        <location filename="../StatusQ/src/StatusQ/Popups/StatusStackModal.qml" line="22" />
+        <location filename="../StatusQ/src/StatusQ/Popups/StatusStackModal.qml" line="11" />
+        <location filename="../StatusQ/src/StatusQ/Popups/StatusStackModal.qml" line="11" />
         <source>StackModal</source>
         <translation>StackModal</translation>
     </message>
     <message>
-        <location filename="../StatusQ/src/StatusQ/Popups/StatusStackModal.qml" line="32" />
+        <location filename="../StatusQ/src/StatusQ/Popups/StatusStackModal.qml" line="23" />
+        <location filename="../StatusQ/src/StatusQ/Popups/StatusStackModal.qml" line="23" />
         <source>Next</source>
         <translation>Next</translation>
     </message>
     <message>
-        <location filename="../StatusQ/src/StatusQ/Popups/StatusStackModal.qml" line="38" />
+        <location filename="../StatusQ/src/StatusQ/Popups/StatusStackModal.qml" line="28" />
+        <location filename="../StatusQ/src/StatusQ/Popups/StatusStackModal.qml" line="28" />
         <source>Finish</source>
         <translation>Finish</translation>
     </message>
@@ -8442,10 +10500,12 @@ device, so only you can use them.</translation>
     <name>StatusTagSelectorPage</name>
     <message>
         <location filename="../StatusQ/sandbox/pages/StatusTagSelectorPage.qml" line="63" />
+        <location filename="../StatusQ/sandbox/pages/StatusTagSelectorPage.qml" line="63" />
         <source>To: </source>
         <translation>To: </translation>
     </message>
     <message>
+        <location filename="../StatusQ/sandbox/pages/StatusTagSelectorPage.qml" line="64" />
         <location filename="../StatusQ/sandbox/pages/StatusTagSelectorPage.qml" line="64" />
         <source>USER LIMIT REACHED</source>
         <translation>USER LIMIT REACHED</translation>
@@ -8455,15 +10515,18 @@ device, so only you can use them.</translation>
     <name>StatusTokenInlineSelector</name>
     <message>
         <location filename="../StatusQ/src/StatusQ/Controls/StatusTokenInlineSelector.qml" line="45" />
+        <location filename="../StatusQ/src/StatusQ/Controls/StatusTokenInlineSelector.qml" line="45" />
         <source>Hold</source>
         <translation>Hold</translation>
     </message>
     <message>
         <location filename="../StatusQ/src/StatusQ/Controls/StatusTokenInlineSelector.qml" line="59" />
+        <location filename="../StatusQ/src/StatusQ/Controls/StatusTokenInlineSelector.qml" line="59" />
         <source>or</source>
         <translation>or</translation>
     </message>
     <message>
+        <location filename="../StatusQ/src/StatusQ/Controls/StatusTokenInlineSelector.qml" line="74" />
         <location filename="../StatusQ/src/StatusQ/Controls/StatusTokenInlineSelector.qml" line="74" />
         <source>to post</source>
         <translation>to post</translation>
@@ -8473,6 +10536,7 @@ device, so only you can use them.</translation>
     <name>StatusUrlValidator</name>
     <message>
         <location filename="../StatusQ/src/StatusQ/Controls/Validators/StatusUrlValidator.qml" line="8" />
+        <location filename="../StatusQ/src/StatusQ/Controls/Validators/StatusUrlValidator.qml" line="8" />
         <source>Please enter a valid URL</source>
         <translation>Please enter a valid URL</translation>
     </message>
@@ -8480,6 +10544,7 @@ device, so only you can use them.</translation>
 <context>
     <name>StatusValidator</name>
     <message>
+        <location filename="../StatusQ/src/StatusQ/Controls/Validators/StatusValidator.qml" line="8" />
         <location filename="../StatusQ/src/StatusQ/Controls/Validators/StatusValidator.qml" line="8" />
         <source>invalid input</source>
         <translation>invalid input</translation>
@@ -8489,6 +10554,7 @@ device, so only you can use them.</translation>
     <name>StatusWalletColorSelect</name>
     <message>
         <location filename="../StatusQ/src/StatusQ/Controls/StatusWalletColorSelect.qml" line="13" />
+        <location filename="../StatusQ/src/StatusQ/Controls/StatusWalletColorSelect.qml" line="13" />
         <source>Account color</source>
         <translation>Account color</translation>
     </message>
@@ -8497,8 +10563,18 @@ device, so only you can use them.</translation>
     <name>StatusWindowsTitleBar</name>
     <message>
         <location filename="../StatusQ/src/StatusQ/Platform/StatusWindowsTitleBar.qml" line="37" />
+        <location filename="../StatusQ/src/StatusQ/Platform/StatusWindowsTitleBar.qml" line="37" />
         <source>Status</source>
         <translation>Status</translation>
+    </message>
+</context>
+<context>
+    <name>SubheaderTabBar</name>
+    <message>
+        <location filename="../app/AppLayouts/Profile/popups/backupseed/SubheaderTabBar.qml" line="25" />
+        <location filename="../app/AppLayouts/Profile/popups/backupseed/SubheaderTabBar.qml" line="25" />
+        <source>Step %1 of %2</source>
+        <translation>Step %1 of %2</translation>
     </message>
 </context>
 <context>
@@ -8561,10 +10637,12 @@ device, so only you can use them.</translation>
     <name>TokenSettingsModal</name>
     <message>
         <location filename="../app/AppLayouts/Profile/popups/TokenSettingsModal.qml" line="18" />
+        <location filename="../app/AppLayouts/Profile/popups/TokenSettingsModal.qml" line="18" />
         <source>Manage Assets</source>
         <translation>Manage Assets</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/popups/TokenSettingsModal.qml" line="22" />
         <location filename="../app/AppLayouts/Profile/popups/TokenSettingsModal.qml" line="22" />
         <source>Add custom token</source>
         <translation>Add custom token</translation>
@@ -8574,20 +10652,24 @@ device, so only you can use them.</translation>
     <name>TokenSettingsModalContent</name>
     <message>
         <location filename="../app/AppLayouts/Profile/panels/TokenSettingsModalContent.qml" line="54" />
+        <location filename="../app/AppLayouts/Profile/panels/TokenSettingsModalContent.qml" line="54" />
         <source>Token details</source>
         <translation>Token details</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/panels/TokenSettingsModalContent.qml" line="63" />
         <location filename="../app/AppLayouts/Profile/panels/TokenSettingsModalContent.qml" line="63" />
         <source>Remove token</source>
         <translation>Remove token</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/panels/TokenSettingsModalContent.qml" line="107" />
+        <location filename="../app/AppLayouts/Profile/panels/TokenSettingsModalContent.qml" line="107" />
         <source>Custom</source>
         <translation>Custom</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/panels/TokenSettingsModalContent.qml" line="130" />
         <location filename="../app/AppLayouts/Profile/panels/TokenSettingsModalContent.qml" line="130" />
         <source>Default</source>
         <translation>Default</translation>
@@ -8597,10 +10679,12 @@ device, so only you can use them.</translation>
     <name>TouchIDAuthView</name>
     <message>
         <location filename="../app/AppLayouts/Onboarding/views/TouchIDAuthView.qml" line="54" />
+        <location filename="../app/AppLayouts/Onboarding/views/TouchIDAuthView.qml" line="54" />
         <source>Biometrics</source>
         <translation>Biometrics</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Onboarding/views/TouchIDAuthView.qml" line="69" />
         <location filename="../app/AppLayouts/Onboarding/views/TouchIDAuthView.qml" line="69" />
         <source>Would you like to use Touch ID
 to login to Status?</source>
@@ -8609,10 +10693,12 @@ to login to Status?</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Onboarding/views/TouchIDAuthView.qml" line="82" />
+        <location filename="../app/AppLayouts/Onboarding/views/TouchIDAuthView.qml" line="82" />
         <source>Yes, use Touch ID</source>
         <translation>Yes, use Touch ID</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Onboarding/views/TouchIDAuthView.qml" line="93" />
         <location filename="../app/AppLayouts/Onboarding/views/TouchIDAuthView.qml" line="93" />
         <source>I prefer to use my password</source>
         <translation>I prefer to use my password</translation>
@@ -8622,20 +10708,24 @@ to login to Status?</translation>
     <name>TransactionBubbleView</name>
     <message>
         <location filename="../imports/shared/views/chat/TransactionBubbleView.qml" line="99" />
+        <location filename="../imports/shared/views/chat/TransactionBubbleView.qml" line="99" />
         <source>Transaction request</source>
         <translation>Transaction request</translation>
     </message>
     <message>
+        <location filename="../imports/shared/views/chat/TransactionBubbleView.qml" line="103" />
         <location filename="../imports/shared/views/chat/TransactionBubbleView.qml" line="103" />
         <source>&#8593; Outgoing transaction</source>
         <translation>&#8593; Outgoing transaction</translation>
     </message>
     <message>
         <location filename="../imports/shared/views/chat/TransactionBubbleView.qml" line="104" />
+        <location filename="../imports/shared/views/chat/TransactionBubbleView.qml" line="104" />
         <source>&#8595; Incoming transaction</source>
         <translation>&#8595; Incoming transaction</translation>
     </message>
     <message>
+        <location filename="../imports/shared/views/chat/TransactionBubbleView.qml" line="127" />
         <location filename="../imports/shared/views/chat/TransactionBubbleView.qml" line="127" />
         <source>Token not found on your current network</source>
         <translation>Token not found on your current network</translation>
@@ -8918,30 +11008,36 @@ to login to Status?</translation>
     <name>TransferOwnershipPopup</name>
     <message>
         <location filename="../app/AppLayouts/Chat/popups/community/TransferOwnershipPopup.qml" line="20" />
+        <location filename="../app/AppLayouts/Chat/popups/community/TransferOwnershipPopup.qml" line="20" />
         <source>Transfer ownership</source>
         <translation>Transfer ownership</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Chat/popups/community/TransferOwnershipPopup.qml" line="37" />
         <location filename="../app/AppLayouts/Chat/popups/community/TransferOwnershipPopup.qml" line="37" />
         <source>Community private key</source>
         <translation>Community private key</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Chat/popups/community/TransferOwnershipPopup.qml" line="49" />
+        <location filename="../app/AppLayouts/Chat/popups/community/TransferOwnershipPopup.qml" line="49" />
         <source>Copy</source>
         <translation>Copy</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Chat/popups/community/TransferOwnershipPopup.qml" line="51" />
         <location filename="../app/AppLayouts/Chat/popups/community/TransferOwnershipPopup.qml" line="51" />
         <source>Copied</source>
         <translation>Copied</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Chat/popups/community/TransferOwnershipPopup.qml" line="60" />
+        <location filename="../app/AppLayouts/Chat/popups/community/TransferOwnershipPopup.qml" line="60" />
         <source>You should keep it safe and only share it with people you trust to take ownership of your community</source>
         <translation>You should keep it safe and only share it with people you trust to take ownership of your community</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Chat/popups/community/TransferOwnershipPopup.qml" line="69" />
         <location filename="../app/AppLayouts/Chat/popups/community/TransferOwnershipPopup.qml" line="69" />
         <source>You can also use this key to import your community on another device</source>
         <translation>You can also use this key to import your community on another device</translation>
@@ -8968,35 +11064,42 @@ to login to Status?</translation>
     <name>UploadProfilePicModal</name>
     <message>
         <location filename="../app/AppLayouts/Onboarding/popups/UploadProfilePicModal.qml" line="20" />
+        <location filename="../app/AppLayouts/Onboarding/popups/UploadProfilePicModal.qml" line="20" />
         <source>Upload profile picture</source>
         <translation>Upload profile picture</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Onboarding/popups/UploadProfilePicModal.qml" line="42" />
         <location filename="../app/AppLayouts/Onboarding/popups/UploadProfilePicModal.qml" line="42" />
         <source>Choose an image for profile picture</source>
         <translation>Choose an image for profile picture</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Onboarding/popups/UploadProfilePicModal.qml" line="43" />
+        <location filename="../app/AppLayouts/Onboarding/popups/UploadProfilePicModal.qml" line="43" />
         <source>Profile picture</source>
         <translation>Profile picture</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Onboarding/popups/UploadProfilePicModal.qml" line="44" />
         <location filename="../app/AppLayouts/Onboarding/popups/UploadProfilePicModal.qml" line="44" />
         <source>Make this my profile picture</source>
         <translation>Make this my profile picture</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Onboarding/popups/UploadProfilePicModal.qml" line="62" />
+        <location filename="../app/AppLayouts/Onboarding/popups/UploadProfilePicModal.qml" line="62" />
         <source>Remove</source>
         <translation>Remove</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Onboarding/popups/UploadProfilePicModal.qml" line="71" />
+        <location filename="../app/AppLayouts/Onboarding/popups/UploadProfilePicModal.qml" line="71" />
         <source>Upload</source>
         <translation>Upload</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Onboarding/popups/UploadProfilePicModal.qml" line="71" />
         <location filename="../app/AppLayouts/Onboarding/popups/UploadProfilePicModal.qml" line="71" />
         <source>Done</source>
         <translation>Done</translation>
@@ -9006,65 +11109,68 @@ to login to Status?</translation>
     <name>UserListPanel</name>
     <message>
         <source>Offline</source>
-        <translation>Offline</translation>
+        <translation type="vanished">Offline</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/panels/UserListPanel.qml" line="118" />
+        <location filename="../app/AppLayouts/Chat/panels/UserListPanel.qml" line="117" />
+        <location filename="../app/AppLayouts/Chat/panels/UserListPanel.qml" line="117" />
         <source>Online</source>
         <translation>Online</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/panels/UserListPanel.qml" line="120" />
+        <location filename="../app/AppLayouts/Chat/panels/UserListPanel.qml" line="119" />
+        <location filename="../app/AppLayouts/Chat/panels/UserListPanel.qml" line="119" />
         <source>Inactive</source>
         <translation>Inactive</translation>
     </message>
     <message>
         <source>Do not disturb</source>
-        <translation>Do not disturb</translation>
+        <translation type="vanished">Do not disturb</translation>
     </message>
     <message>
         <source>Idle</source>
-        <translation>Idle</translation>
+        <translation type="vanished">Idle</translation>
     </message>
 </context>
 <context>
     <name>UserStatusContextMenu</name>
     <message>
-        <location filename="../imports/shared/popups/UserStatusContextMenu.qml" line="39" />
-        <location filename="../imports/shared/popups/UserStatusContextMenu.qml" line="39" />
+        <location filename="../imports/shared/popups/UserStatusContextMenu.qml" line="32" />
+        <location filename="../imports/shared/popups/UserStatusContextMenu.qml" line="32" />
         <source>View My Profile</source>
         <translation>View My Profile</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/UserStatusContextMenu.qml" line="55" />
-        <location filename="../imports/shared/popups/UserStatusContextMenu.qml" line="55" />
+        <location filename="../imports/shared/popups/UserStatusContextMenu.qml" line="45" />
+        <location filename="../imports/shared/popups/UserStatusContextMenu.qml" line="45" />
         <source>Always online</source>
         <translation>Always online</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/UserStatusContextMenu.qml" line="71" />
-        <location filename="../imports/shared/popups/UserStatusContextMenu.qml" line="71" />
+        <location filename="../imports/shared/popups/UserStatusContextMenu.qml" line="58" />
+        <location filename="../imports/shared/popups/UserStatusContextMenu.qml" line="58" />
         <source>Inactive</source>
         <translation>Inactive</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/UserStatusContextMenu.qml" line="87" />
-        <location filename="../imports/shared/popups/UserStatusContextMenu.qml" line="87" />
+        <location filename="../imports/shared/popups/UserStatusContextMenu.qml" line="71" />
+        <location filename="../imports/shared/popups/UserStatusContextMenu.qml" line="71" />
         <source>Set status automatically</source>
         <translation>Set status automatically</translation>
     </message>
     <message>
         <source>Online</source>
-        <translation>Online</translation>
+        <translation type="vanished">Online</translation>
     </message>
     <message>
         <source>Offline</source>
-        <translation>Offline</translation>
+        <translation type="vanished">Offline</translation>
     </message>
 </context>
 <context>
     <name>UsernameLabel</name>
     <message>
+        <location filename="../imports/shared/controls/chat/UsernameLabel.qml" line="24" />
         <location filename="../imports/shared/controls/chat/UsernameLabel.qml" line="24" />
         <source>You</source>
         <translation>You</translation>
@@ -9074,327 +11180,399 @@ to login to Status?</translation>
     <name>Utils</name>
     <message>
         <location filename="../imports/utils/Utils.qml" line="256" />
+        <location filename="../imports/utils/Utils.qml" line="256" />
         <source>Sun</source>
         <translation>Sun</translation>
     </message>
     <message>
+        <location filename="../imports/utils/Utils.qml" line="257" />
         <location filename="../imports/utils/Utils.qml" line="257" />
         <source>Mon</source>
         <translation>Mon</translation>
     </message>
     <message>
         <location filename="../imports/utils/Utils.qml" line="258" />
+        <location filename="../imports/utils/Utils.qml" line="258" />
         <source>Tue</source>
         <translation>Tue</translation>
     </message>
     <message>
+        <location filename="../imports/utils/Utils.qml" line="259" />
         <location filename="../imports/utils/Utils.qml" line="259" />
         <source>Wed</source>
         <translation>Wed</translation>
     </message>
     <message>
         <location filename="../imports/utils/Utils.qml" line="260" />
+        <location filename="../imports/utils/Utils.qml" line="260" />
         <source>Thu</source>
         <translation>Thu</translation>
     </message>
     <message>
+        <location filename="../imports/utils/Utils.qml" line="261" />
         <location filename="../imports/utils/Utils.qml" line="261" />
         <source>Fri</source>
         <translation>Fri</translation>
     </message>
     <message>
         <location filename="../imports/utils/Utils.qml" line="262" />
+        <location filename="../imports/utils/Utils.qml" line="262" />
         <source>Sat</source>
         <translation>Sat</translation>
     </message>
     <message>
+        <location filename="../imports/utils/Utils.qml" line="264" />
         <location filename="../imports/utils/Utils.qml" line="264" />
         <source>Jan</source>
         <translation>Jan</translation>
     </message>
     <message>
         <location filename="../imports/utils/Utils.qml" line="265" />
+        <location filename="../imports/utils/Utils.qml" line="265" />
         <source>Feb</source>
         <translation>Feb</translation>
     </message>
     <message>
+        <location filename="../imports/utils/Utils.qml" line="266" />
         <location filename="../imports/utils/Utils.qml" line="266" />
         <source>Mar</source>
         <translation>Mar</translation>
     </message>
     <message>
         <location filename="../imports/utils/Utils.qml" line="267" />
+        <location filename="../imports/utils/Utils.qml" line="267" />
         <source>Apr</source>
         <translation>Apr</translation>
     </message>
     <message>
+        <location filename="../imports/utils/Utils.qml" line="268" />
         <location filename="../imports/utils/Utils.qml" line="268" />
         <source>May</source>
         <translation>May</translation>
     </message>
     <message>
         <location filename="../imports/utils/Utils.qml" line="269" />
+        <location filename="../imports/utils/Utils.qml" line="269" />
         <source>Jun</source>
         <translation>Jun</translation>
     </message>
     <message>
+        <location filename="../imports/utils/Utils.qml" line="270" />
         <location filename="../imports/utils/Utils.qml" line="270" />
         <source>Jul</source>
         <translation>Jul</translation>
     </message>
     <message>
         <location filename="../imports/utils/Utils.qml" line="271" />
+        <location filename="../imports/utils/Utils.qml" line="271" />
         <source>Aug</source>
         <translation>Aug</translation>
     </message>
     <message>
+        <location filename="../imports/utils/Utils.qml" line="272" />
         <location filename="../imports/utils/Utils.qml" line="272" />
         <source>Sep</source>
         <translation>Sep</translation>
     </message>
     <message>
         <location filename="../imports/utils/Utils.qml" line="273" />
+        <location filename="../imports/utils/Utils.qml" line="273" />
         <source>Oct</source>
         <translation>Oct</translation>
     </message>
     <message>
+        <location filename="../imports/utils/Utils.qml" line="274" />
         <location filename="../imports/utils/Utils.qml" line="274" />
         <source>Nov</source>
         <translation>Nov</translation>
     </message>
     <message>
         <location filename="../imports/utils/Utils.qml" line="275" />
+        <location filename="../imports/utils/Utils.qml" line="275" />
         <source>Dec</source>
         <translation>Dec</translation>
     </message>
     <message>
+        <location filename="../imports/utils/Utils.qml" line="322" />
         <location filename="../imports/utils/Utils.qml" line="322" />
         <source>Yesterday</source>
         <translation>Yesterday</translation>
     </message>
     <message>
         <location filename="../imports/utils/Utils.qml" line="324" />
+        <location filename="../imports/utils/Utils.qml" line="324" />
         <source>Sunday</source>
         <translation>Sunday</translation>
     </message>
     <message>
+        <location filename="../imports/utils/Utils.qml" line="325" />
         <location filename="../imports/utils/Utils.qml" line="325" />
         <source>Monday</source>
         <translation>Monday</translation>
     </message>
     <message>
         <location filename="../imports/utils/Utils.qml" line="326" />
+        <location filename="../imports/utils/Utils.qml" line="326" />
         <source>Tuesday</source>
         <translation>Tuesday</translation>
     </message>
     <message>
+        <location filename="../imports/utils/Utils.qml" line="327" />
         <location filename="../imports/utils/Utils.qml" line="327" />
         <source>Wednesday</source>
         <translation>Wednesday</translation>
     </message>
     <message>
         <location filename="../imports/utils/Utils.qml" line="328" />
+        <location filename="../imports/utils/Utils.qml" line="328" />
         <source>Thursday</source>
         <translation>Thursday</translation>
     </message>
     <message>
+        <location filename="../imports/utils/Utils.qml" line="329" />
         <location filename="../imports/utils/Utils.qml" line="329" />
         <source>Friday</source>
         <translation>Friday</translation>
     </message>
     <message>
         <location filename="../imports/utils/Utils.qml" line="330" />
+        <location filename="../imports/utils/Utils.qml" line="330" />
         <source>Saturday</source>
         <translation>Saturday</translation>
     </message>
     <message>
+        <location filename="../imports/utils/Utils.qml" line="345" />
         <location filename="../imports/utils/Utils.qml" line="345" />
         <source>NOW</source>
         <translation>NOW</translation>
     </message>
     <message>
         <location filename="../imports/utils/Utils.qml" line="349" />
+        <location filename="../imports/utils/Utils.qml" line="349" />
         <source>%1M</source>
         <translation>%1M</translation>
     </message>
     <message>
+        <location filename="../imports/utils/Utils.qml" line="353" />
         <location filename="../imports/utils/Utils.qml" line="353" />
         <source>%1H</source>
         <translation>%1H</translation>
     </message>
     <message>
         <location filename="../imports/utils/Utils.qml" line="355" />
+        <location filename="../imports/utils/Utils.qml" line="355" />
         <source>%1D</source>
         <translation>%1D</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="419" />
+        <location filename="../imports/utils/Utils.qml" line="420" />
+        <location filename="../imports/utils/Utils.qml" line="420" />
         <source>words</source>
         <translation>words</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="431" />
+        <location filename="../imports/utils/Utils.qml" line="432" />
+        <location filename="../imports/utils/Utils.qml" line="432" />
         <source>You need to enter a password</source>
         <translation>You need to enter a password</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="433" />
+        <location filename="../imports/utils/Utils.qml" line="434" />
+        <location filename="../imports/utils/Utils.qml" line="434" />
         <source>Password needs to be 6 characters or more</source>
         <translation>Password needs to be 6 characters or more</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="439" />
+        <location filename="../imports/utils/Utils.qml" line="440" />
+        <location filename="../imports/utils/Utils.qml" line="440" />
         <source>You need to repeat your password</source>
         <translation>You need to repeat your password</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="441" />
+        <location filename="../imports/utils/Utils.qml" line="442" />
+        <location filename="../imports/utils/Utils.qml" line="442" />
         <source>Passwords don't match</source>
         <translation>Passwords don't match</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="454" />
+        <location filename="../imports/utils/Utils.qml" line="455" />
+        <location filename="../imports/utils/Utils.qml" line="455" />
         <source>You need to enter a PIN</source>
         <translation>You need to enter a PIN</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="456" />
+        <location filename="../imports/utils/Utils.qml" line="457" />
+        <location filename="../imports/utils/Utils.qml" line="457" />
         <source>The PIN must contain only digits</source>
         <translation>The PIN must contain only digits</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="458" />
+        <location filename="../imports/utils/Utils.qml" line="459" />
+        <location filename="../imports/utils/Utils.qml" line="459" />
         <source>The PIN must be exactly 6 digits</source>
         <translation>The PIN must be exactly 6 digits</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="464" />
+        <location filename="../imports/utils/Utils.qml" line="465" />
+        <location filename="../imports/utils/Utils.qml" line="465" />
         <source>You need to repeat your PIN</source>
         <translation>You need to repeat your PIN</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="466" />
+        <location filename="../imports/utils/Utils.qml" line="467" />
+        <location filename="../imports/utils/Utils.qml" line="467" />
         <source>PIN don't match</source>
         <translation>PIN don't match</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="532" />
-        <location filename="../imports/utils/Utils.qml" line="554" />
+        <location filename="../imports/utils/Utils.qml" line="533" />
+        <location filename="../imports/utils/Utils.qml" line="555" />
+        <location filename="../imports/utils/Utils.qml" line="533" />
+        <location filename="../imports/utils/Utils.qml" line="555" />
         <source>You need to enter a %1</source>
         <translation>You need to enter a %1</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="536" />
+        <location filename="../imports/utils/Utils.qml" line="537" />
+        <location filename="../imports/utils/Utils.qml" line="537" />
         <source>The %1 cannot exceed %2 characters</source>
         <translation>The %1 cannot exceed %2 characters</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="540" />
+        <location filename="../imports/utils/Utils.qml" line="541" />
+        <location filename="../imports/utils/Utils.qml" line="541" />
         <source>Must be an hexadecimal color (eg: #4360DF)</source>
         <translation>Must be an hexadecimal color (eg: #4360DF)</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="544" />
+        <location filename="../imports/utils/Utils.qml" line="545" />
+        <location filename="../imports/utils/Utils.qml" line="545" />
         <source>Use only lowercase letters (a to z), numbers &amp; dashes (-). Do not use chat keys.</source>
         <translation>Use only lowercase letters (a to z), numbers &amp; dashes (-). Do not use chat keys.</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="555" />
+        <location filename="../imports/utils/Utils.qml" line="556" />
+        <location filename="../imports/utils/Utils.qml" line="556" />
         <source>Value has to be at least %1 characters long</source>
         <translation>Value has to be at least %1 characters long</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="565" />
+        <location filename="../imports/utils/Utils.qml" line="566" />
+        <location filename="../imports/utils/Utils.qml" line="566" />
+        <source>Unknown</source>
+        <translation type="unfinished">Unknown</translation>
+    </message>
+    <message>
+        <location filename="../imports/utils/Utils.qml" line="570" />
+        <location filename="../imports/utils/Utils.qml" line="570" />
         <source>&lt; 1 min</source>
         <translation>&lt; 1 min</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="568" />
+        <location filename="../imports/utils/Utils.qml" line="573" />
+        <location filename="../imports/utils/Utils.qml" line="573" />
         <source>&lt; 3 mins</source>
         <translation>&lt; 3 mins</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="571" />
+        <location filename="../imports/utils/Utils.qml" line="576" />
+        <location filename="../imports/utils/Utils.qml" line="576" />
         <source>&lt; 5 mins</source>
         <translation>&lt; 5 mins</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="574" />
+        <location filename="../imports/utils/Utils.qml" line="579" />
+        <location filename="../imports/utils/Utils.qml" line="579" />
         <source>&gt; 5 mins</source>
         <translation>&gt; 5 mins</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="667" />
+        <location filename="../imports/utils/Utils.qml" line="675" />
+        <location filename="../imports/utils/Utils.qml" line="675" />
         <source>years ago</source>
         <translation>years ago</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="667" />
+        <location filename="../imports/utils/Utils.qml" line="675" />
+        <location filename="../imports/utils/Utils.qml" line="675" />
         <source>year ago</source>
         <translation>year ago</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="674" />
+        <location filename="../imports/utils/Utils.qml" line="682" />
+        <location filename="../imports/utils/Utils.qml" line="682" />
         <source>months ago</source>
         <translation>months ago</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="674" />
+        <location filename="../imports/utils/Utils.qml" line="682" />
+        <location filename="../imports/utils/Utils.qml" line="682" />
         <source>month ago</source>
         <translation>month ago</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="681" />
+        <location filename="../imports/utils/Utils.qml" line="689" />
+        <location filename="../imports/utils/Utils.qml" line="689" />
         <source>weeks ago</source>
         <translation>weeks ago</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="681" />
+        <location filename="../imports/utils/Utils.qml" line="689" />
+        <location filename="../imports/utils/Utils.qml" line="689" />
         <source>week ago</source>
         <translation>week ago</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="688" />
+        <location filename="../imports/utils/Utils.qml" line="696" />
+        <location filename="../imports/utils/Utils.qml" line="696" />
         <source>days ago</source>
         <translation>days ago</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="688" />
+        <location filename="../imports/utils/Utils.qml" line="696" />
+        <location filename="../imports/utils/Utils.qml" line="696" />
         <source>day ago</source>
         <translation>day ago</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="695" />
+        <location filename="../imports/utils/Utils.qml" line="703" />
+        <location filename="../imports/utils/Utils.qml" line="703" />
         <source>hours ago</source>
         <translation>hours ago</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="695" />
+        <location filename="../imports/utils/Utils.qml" line="703" />
+        <location filename="../imports/utils/Utils.qml" line="703" />
         <source>hour ago</source>
         <translation>hour ago</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="702" />
+        <location filename="../imports/utils/Utils.qml" line="710" />
+        <location filename="../imports/utils/Utils.qml" line="710" />
         <source>mins ago</source>
         <translation>mins ago</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="702" />
+        <location filename="../imports/utils/Utils.qml" line="710" />
+        <location filename="../imports/utils/Utils.qml" line="710" />
         <source>min ago</source>
         <translation>min ago</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="709" />
+        <location filename="../imports/utils/Utils.qml" line="717" />
+        <location filename="../imports/utils/Utils.qml" line="717" />
         <source>secs ago</source>
         <translation>secs ago</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="709" />
+        <location filename="../imports/utils/Utils.qml" line="717" />
+        <location filename="../imports/utils/Utils.qml" line="717" />
         <source>sec ago</source>
         <translation>sec ago</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="713" />
+        <location filename="../imports/utils/Utils.qml" line="721" />
+        <location filename="../imports/utils/Utils.qml" line="721" />
         <source>now</source>
         <translation>now</translation>
     </message>
@@ -9402,6 +11580,7 @@ to login to Status?</translation>
 <context>
     <name>ViewProfileMenuItem</name>
     <message>
+        <location filename="../imports/shared/controls/chat/menuItems/ViewProfileMenuItem.qml" line="6" />
         <location filename="../imports/shared/controls/chat/menuItems/ViewProfileMenuItem.qml" line="6" />
         <source>View Profile</source>
         <translation>View Profile</translation>
@@ -9411,30 +11590,36 @@ to login to Status?</translation>
     <name>WakuNodesModal</name>
     <message>
         <location filename="../app/AppLayouts/Profile/popups/WakuNodesModal.qml" line="25" />
+        <location filename="../app/AppLayouts/Profile/popups/WakuNodesModal.qml" line="25" />
         <source>Waku nodes</source>
         <translation>Waku nodes</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/popups/WakuNodesModal.qml" line="53" />
         <location filename="../app/AppLayouts/Profile/popups/WakuNodesModal.qml" line="53" />
         <source>Use Waku nodes</source>
         <translation>Use Waku nodes</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/popups/WakuNodesModal.qml" line="77" />
+        <location filename="../app/AppLayouts/Profile/popups/WakuNodesModal.qml" line="77" />
         <source>Select node automatically</source>
         <translation>Select node automatically</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/popups/WakuNodesModal.qml" line="91" />
         <location filename="../app/AppLayouts/Profile/popups/WakuNodesModal.qml" line="91" />
         <source>Waku Nodes</source>
         <translation>Waku Nodes</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/popups/WakuNodesModal.qml" line="106" />
+        <location filename="../app/AppLayouts/Profile/popups/WakuNodesModal.qml" line="106" />
         <source>Node %1</source>
         <translation>Node %1</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/popups/WakuNodesModal.qml" line="130" />
         <location filename="../app/AppLayouts/Profile/popups/WakuNodesModal.qml" line="130" />
         <source>Add a new node</source>
         <translation>Add a new node</translation>
@@ -9444,15 +11629,18 @@ to login to Status?</translation>
     <name>WalletFooter</name>
     <message>
         <location filename="../app/AppLayouts/Wallet/panels/WalletFooter.qml" line="33" />
+        <location filename="../app/AppLayouts/Wallet/panels/WalletFooter.qml" line="33" />
         <source>Send</source>
         <translation>Send</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Wallet/panels/WalletFooter.qml" line="41" />
+        <location filename="../app/AppLayouts/Wallet/panels/WalletFooter.qml" line="41" />
         <source>Receive</source>
         <translation>Receive</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Wallet/panels/WalletFooter.qml" line="50" />
         <location filename="../app/AppLayouts/Wallet/panels/WalletFooter.qml" line="50" />
         <source>Buy / Sell</source>
         <translation>Buy / Sell</translation>
@@ -9465,20 +11653,27 @@ to login to Status?</translation>
         <location filename="../app/AppLayouts/Profile/views/WalletView.qml" line="47" />
         <location filename="../app/AppLayouts/Profile/views/WalletView.qml" line="53" />
         <location filename="../app/AppLayouts/Profile/views/WalletView.qml" line="57" />
+        <location filename="../app/AppLayouts/Profile/views/WalletView.qml" line="43" />
+        <location filename="../app/AppLayouts/Profile/views/WalletView.qml" line="47" />
+        <location filename="../app/AppLayouts/Profile/views/WalletView.qml" line="53" />
+        <location filename="../app/AppLayouts/Profile/views/WalletView.qml" line="57" />
         <source>Wallet</source>
         <translation>Wallet</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/WalletView.qml" line="48" />
         <location filename="../app/AppLayouts/Profile/views/WalletView.qml" line="48" />
         <source>Networks</source>
         <translation>Networks</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/WalletView.qml" line="58" />
+        <location filename="../app/AppLayouts/Profile/views/WalletView.qml" line="58" />
         <source>DApp Permissions</source>
         <translation>DApp Permissions</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Profile/views/WalletView.qml" line="107" />
         <location filename="../app/AppLayouts/Profile/views/WalletView.qml" line="107" />
         <source>Testnet Mode</source>
         <translation>Testnet Mode</translation>
@@ -9488,20 +11683,24 @@ to login to Status?</translation>
     <name>WelcomeView</name>
     <message>
         <location filename="../app/AppLayouts/Onboarding/views/WelcomeView.qml" line="55" />
+        <location filename="../app/AppLayouts/Onboarding/views/WelcomeView.qml" line="55" />
         <source>Welcome to Status</source>
         <translation>Welcome to Status</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Onboarding/views/WelcomeView.qml" line="67" />
         <location filename="../app/AppLayouts/Onboarding/views/WelcomeView.qml" line="67" />
         <source>Your fully decentralized gateway to Ethereum and Web3. Crypto wallet, privacy first group chat, and dApp browser.</source>
         <translation>Your fully decentralized gateway to Ethereum and Web3. Crypto wallet, privacy first group chat, and dApp browser.</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Onboarding/views/WelcomeView.qml" line="82" />
+        <location filename="../app/AppLayouts/Onboarding/views/WelcomeView.qml" line="82" />
         <source>I am new to Status</source>
         <translation>I am new to Status</translation>
     </message>
     <message>
+        <location filename="../app/AppLayouts/Onboarding/views/WelcomeView.qml" line="90" />
         <location filename="../app/AppLayouts/Onboarding/views/WelcomeView.qml" line="90" />
         <source>I already use Status</source>
         <translation>I already use Status</translation>
@@ -9510,6 +11709,7 @@ to login to Status?</translation>
 <context>
     <name>main</name>
     <message>
+        <location filename="../StatusQ/sandbox/main.qml" line="26" />
         <location filename="../StatusQ/sandbox/main.qml" line="26" />
         <source>StatusQ Documentation App</source>
         <translation>StatusQ Documentation App</translation>

--- a/ui/nim-status-client.pro
+++ b/ui/nim-status-client.pro
@@ -13,41 +13,8 @@ DEFINES += QT_DEPRECATED_WARNINGS
 #DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0x060000    # disables all the APIs deprecated before Qt 6.0.0
 
 lupdate_only{
-SOURCES = *.qml \
-          app/*.qml \
-          imports/*.qml \
-          imports/shared/*.qml \
-          imports/shared/controls/*.qml \
-          imports/shared/keycard/*.qml \
-          imports/shared/panels/*.qml \
-          imports/shared/popups/*.qml \
-          imports/shared/status/*.qml \
-          imports/shared/views/*.qml \
-          app/AppLayouts/*.qml \
-          app/AppLayouts/Browser/*.qml \
-          app/AppLayouts/Chat/*.qml \
-          app/AppLayouts/Chat/CommunityComponents/*.qml \
-          app/AppLayouts/Chat/ChatColumn/*.qml \
-          app/AppLayouts/Chat/ChatColumn/ChatComponents/*.qml \
-          app/AppLayouts/Chat/ChatColumn/MessageComponents/*.qml \
-          app/AppLayouts/Chat/ChatColumn/MessageComponents/TransactionComponents/*.qml \
-          app/AppLayouts/CommunitiesPortalLayout/*.qml \
-          app/AppLayouts/Chat/ContactsColumn/*.qml \
-          app/AppLayouts/Chat/components/*.qml \
-          app/AppLayouts/Node/*.qml \
-          app/AppLayouts/Profile/*.qml \
-          app/AppLayouts/Profile/LeftTab/*.qml \
-          app/AppLayouts/Profile/LeftTab/components/*.qml \
-          app/AppLayouts/Profile/Sections/*.qml \
-          app/AppLayouts/Profile/Sections/BrowserModals/*.qml \
-          app/AppLayouts/Profile/Sections/Contacts/*.qml \
-          app/AppLayouts/Profile/Sections/Data/*.qml \
-          app/AppLayouts/Profile/Sections/Ens/*.qml \
-          app/AppLayouts/Profile/Sections/Privileges/*.qml \
-          app/AppLayouts/Wallet/*.qml \
-          app/AppLayouts/Wallet/components/*.qml \
-          app/AppLayouts/Wallet/components/collectiblesComponents/*.qml \
-          app/AppLayouts/Wallet/data/Currencies.qml \          
+SOURCES += $$files("$$PWD/*.qml", true)
+SOURCES += $$files("$$PWD/*.js", true)
 }
 
 # Other *.ts files will be provided by Lokalise platform


### PR DESCRIPTION
- handle `SOURCES` recursively, rather than spelling all the paths out;
most of them were outdated and some still missing
- include JS files too
- let the Python script skip existing translations (in case we need to
manually add plurals)
- updated qml_en.ts as a result of these changes

Stats:
```
Updating '../../ui/i18n/qml_en.ts'...
    Found 1703 source text(s) (109 new and 1594 already existing)
    Kept 35 obsolete entries
    Same-text heuristic provided 35 translation(s)
```

### What does the PR do

It fixes issues with the way we extract strings for translations

### Affected areas

Scripts

### Screenshot of functionality (including design for comparison)

N/A