### PR TITLE
fix(community-chat): don't switch to the first channel when reordering

### DIFF
--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -502,7 +502,6 @@ method setFirstChannelAsActive*(self: Module) =
 
 method onReorderChatOrCategory*(self: Module, chatOrCatId: string, position: int) =
   self.view.chatsModel().reorder(chatOrCatId, position)
-  self.setFirstChannelAsActive()
 
 method onCategoryNameChanged*(self: Module, category: Category) =
   self.view.chatsModel().renameItem(category.id, category.name)


### PR DESCRIPTION
Fixes #6574

We were switching to the first channel on reorder, which is annoying and not necessary. Now we stay on the same channel we were on.

This will also fix the problem where if the owner switches the order, you would get your channel switched as well.