### PR TITLE
fix(@desktop/chat): chat content overlapping with Start Chat dialog

### DIFF
--- a/ui/app/AppLayouts/Chat/views/ChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatView.qml
@@ -42,7 +42,8 @@ StatusAppThreePanelLayout {
 
     Connections {
         target: root.rootStore.stickersStore.stickersModule
-        onStickerPacksLoaded: {
+
+        function onStickerPacksLoaded() {
             root.stickersLoaded = true;
         }
     }
@@ -50,15 +51,9 @@ StatusAppThreePanelLayout {
     Connections {
         target: root.rootStore.chatCommunitySectionModule
         ignoreUnknownSignals: true
-        onActiveItemChanged: {
-            root.rootStore.openCreateChat = false;
-        }
-    }
 
-    Connections {
-        target: Global
-        onCloseCreateChatView: {
-            root.rootStore.openCreateChat = false
+        function onActiveItemChanged() {
+            Global.closeCreateChatView()
         }
     }
 

--- a/ui/app/AppLayouts/Chat/views/CommunityColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/CommunityColumnView.qml
@@ -64,8 +64,7 @@ Item {
         checked: root.store.openCreateChat
         highlighted: root.store.openCreateChat
         onClicked: {
-            root.store.openCreateChat = !root.store.openCreateChat;
-            if (!root.store.openCreateChat) {
+            if (root.store.openCreateChat) {
                 Global.closeCreateChatView()
             } else {
                 Global.openCreateChatView()
@@ -163,7 +162,11 @@ Item {
             draggableCategories: communityData.amISectionAdmin
 
             model: root.communitySectionModule.model
+            highlightItem: !root.store.openCreateChat
+
             onChatItemSelected: {
+                Global.closeCreateChatView()
+
                 if(categoryId === "")
                     root.communitySectionModule.setActiveItem(id, "")
                 else

--- a/ui/app/AppLayouts/Chat/views/ContactsColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ContactsColumnView.qml
@@ -86,11 +86,10 @@ Item {
                 checked: root.store.openCreateChat
                 highlighted: checked
                 onClicked: {
-                    root.store.openCreateChat = !root.store.openCreateChat
                     if (root.store.openCreateChat) {
-                        Global.openCreateChatView()
-                    } else {
                         Global.closeCreateChatView()
+                    } else {
+                        Global.openCreateChatView()
                     }
                 }
 

--- a/ui/app/AppLayouts/Chat/views/CreateChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/CreateChatView.qml
@@ -20,10 +20,7 @@ Page {
     property var rootStore
     property var emojiPopup: null
 
-    Keys.onEscapePressed: {
-        Global.closeCreateChatView()
-        root.rootStore.openCreateChat = false;
-    }
+    Keys.onEscapePressed: Global.closeCreateChatView()
 
     StatusListView {
         id: contactsModelListView

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -513,6 +513,7 @@ Item {
 
                         contactsStore: appMain.rootStore.contactStore
                         rootStore.emojiReactionsModel: appMain.rootStore.emojiReactionsModel
+                        rootStore.openCreateChat: createChatView.opened
 
                         chatView.onProfileButtonClicked: {
                             Global.changeAppSectionBySectionType(Constants.appSection.profile);
@@ -617,6 +618,7 @@ Item {
 
                                     contactsStore: appMain.rootStore.contactStore
                                     rootStore.emojiReactionsModel: appMain.rootStore.emojiReactionsModel
+                                    rootStore.openCreateChat: createChatView.opened
 
                                     chatView.onProfileButtonClicked: {
                                         Global.changeAppSectionBySectionType(Constants.appSection.profile);
@@ -639,9 +641,10 @@ Item {
                 }
 
                 CreateChatView {
+                    id: createChatView
+
                     property bool opened: false
 
-                    id: createChatView
                     rootStore: chatLayoutContainer.rootStore
                     emojiPopup: statusEmojiPopup
                     anchors.top: parent.top
@@ -654,13 +657,16 @@ Item {
 
                     Connections {
                         target: Global
-                        onOpenCreateChatView: {
+
+                        function onOpenCreateChatView() {
                             createChatView.opened = true
                         }
-                        onCloseCreateChatView: {
+
+                        function onCloseCreateChatView() {
                             createChatView.opened = false
                         }
                     }
+
                     Connections {
                         target: mainModule
                         onActiveSectionChanged: {


### PR DESCRIPTION
### What does the PR do

#fixes #6542 

- problem with overlapping Start Chat view fixed for both Chat and Communities sections
- highlight handled properly in CommunityColumnView when Start Chat opened
- flow simplified, stores modified exclusively from AppMain

### Affected areas

`ChatView`, `CommunityColumnView`, `ContactColumnView`, `CreatChatView`, `AppMain`

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

https://user-images.githubusercontent.com/20650004/180431962-0fd3be73-723e-4dcc-a65f-47c19624c712.mp4
