### PR TITLE
fix(@desktop/settings) contacts search doesn't work by compressed pk

### DIFF
--- a/ui/app/AppLayouts/Profile/panels/ContactsListPanel.qml
+++ b/ui/app/AppLayouts/Profile/panels/ContactsListPanel.qml
@@ -18,12 +18,12 @@ Item {
 
     property var contactsModel
     property int panelUsage: Constants.contactsPanelUsage.unknownPosition
-    property int contactsListHeight: ((contactsList.count * contactsList.itemAtIndex(0).implicitHeight)+title.height)
     property bool scrollbarOn: false
+    readonly property int contactsListHeight: ((contactsList.count * contactsList.itemAtIndex(0).implicitHeight)+title.height)
 
     property string title: ""
     property string searchString: ""
-    property string lowerCaseSearchString: searchString.toLowerCase()
+    readonly property string lowerCaseSearchString: searchString.toLowerCase()
     readonly property int count: contactsList.count
 
     signal contactClicked(string publicKey)
@@ -167,9 +167,12 @@ Item {
             onTextClicked: contactListRoot.textClicked(publicKey)
             onShowVerificationRequest: contactListRoot.showVerificationRequest(publicKey)
 
+            readonly property string compressedPkLowerCase: Utils.getCompressedPk(publicKey).toLowerCase()
+
             visible: searchString === "" ||
-                     panelDelegate.name.toLowerCase().includes(lowerCaseSearchString) ||
-                     panelDelegate.publicKey.toLowerCase().includes(lowerCaseSearchString)
+                     name.toLowerCase().includes(lowerCaseSearchString) ||
+                     publicKey.toLowerCase().includes(lowerCaseSearchString) ||
+                     compressedPkLowerCase.includes(lowerCaseSearchString)
         }
     }
 }


### PR DESCRIPTION
### What does the PR do

fixes #5928

- contacts can be searched by name, uncompressed pk and compressed pk

### Affected areas

ContactsListPanel

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

https://user-images.githubusercontent.com/20650004/180462843-6dfe64cd-3755-41bb-9fd7-553d88aa8dec.mp4

