### PR TITLE
fix(Settings/ProfileLayout): TestNet banner overlaps left panel

### DIFF
--- a/ui/app/AppLayouts/Profile/ProfileLayout.qml
+++ b/ui/app/AppLayouts/Profile/ProfileLayout.qml
@@ -60,12 +60,7 @@ StatusAppTwoPanelLayout {
             visible: profileContainer.currentIndex === Constants.settingsSubsection.wallet &&
                      profileView.store.walletStore.areTestNetworksEnabled
             type: StatusBanner.Type.Danger
-            statusText: {
-                if(profileContainer.currentIndex === Constants.settingsSubsection.wallet &&
-                        profileView.store.walletStore.areTestNetworksEnabled)
-                    return qsTr("Testnet mode is enabled. All balances, transactions and dApp interactions will be on testnets.")
-                return ""
-            }
+            statusText: qsTr("Testnet mode is enabled. All balances, transactions and dApp interactions will be on testnets.")
         }
 
         StackLayout {


### PR DESCRIPTION
Fixes: #6600

Needs: status-im/StatusQ#798

### What does the PR do

Fixes the testnet warning banner overflowing the profile layout width

### Affected areas

Settings/ProfileLayout

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![Snímek obrazovky z 2022-07-25 11-18-11](https://user-images.githubusercontent.com/5377645/180757910-e0a4cf86-5f43-4b13-b2f7-41876b522801.png)
