### PR TITLE
fix(CompactMessageView): disable hovering while scrolling

### DIFF
--- a/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
@@ -250,6 +250,7 @@ Item {
             contactsStore: root.contactsStore
             channelEmoji: root.channelEmoji
             emojiPopup: root.emojiPopup
+            chatLogView: ListView.view
 
             isActiveChannel: root.isActiveChannel
             isChatBlocked: root.isChatBlocked

--- a/ui/imports/shared/views/chat/CompactMessageView.qml
+++ b/ui/imports/shared/views/chat/CompactMessageView.qml
@@ -21,6 +21,7 @@ Item {
     property var usersStore
     property var contactsStore
 
+    property var chatLogView
     property var emojiPopup
 
     property var messageContextMenu
@@ -736,7 +737,7 @@ Item {
     }
 
     HoverHandler {
-        enabled: !activityCenterMessage &&
+        enabled: !activityCenterMessage && !chatLogView.flickingVertically &&
                  (forceHoverHandler || (typeof root.messageContextMenu !== "undefined" && typeof Global.profilePopupOpened !== "undefined" &&
                                         !root.messageContextMenu.opened && !Global.profilePopupOpened && !Global.popupOpened))
         onHoveredChanged: {

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -40,6 +40,7 @@ Loader {
     property string channelEmoji
     property bool isActiveChannel: false
 
+    property var chatLogView
     property var emojiPopup
 
     // Once we redo qml we will know all section/chat related details in each message form the parent components
@@ -332,6 +333,7 @@ Loader {
             isActiveChannel: root.isActiveChannel
             emojiPopup: root.emojiPopup
             senderTrustStatus: root.senderTrustStatus
+            chatLogView: root.chatLogView
 
             communityId: root.communityId
             stickersLoaded: root.stickersLoaded


### PR DESCRIPTION
Fixes #6576

### What does the PR do

Disables highlighting the message under the mouse cursor while scrolling thru the message list

### Affected areas

CompactMessageView

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![Snímek obrazovky z 2022-07-25 14-42-31](https://user-images.githubusercontent.com/5377645/180780301-c992962d-4096-4fe5-95c1-62fa20b3c5ec.png)
