### PR TITLE
ci: Discord notification for master build failrues

### DIFF
--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -74,6 +74,28 @@ pipeline {
       } }
     }
   }
+  post {
+    failure { script {
+      withCredentials([
+        string(
+          credentialsId: 'discord-status-desktop-webhook',
+          variable: 'DISCORD_WEBHOOK'
+        ),
+      ]) {
+        discordSend(
+          title: "${env.JOB_NAME}#${env.BUILD_NUMBER}",
+          description: """
+            CI Desktop build Failure!
+            Branch: `${GIT_BRANCH}`
+            Commit: `${GIT_COMMIT.take(8)}`
+          """,
+          link: env.BUILD_URL,
+          result: currentBuild.currentResult,
+          webhookURL: env.DISCORD_WEBHOOK
+        )
+      }
+    } }
+  }
 }
 
 /* Helper that makes PUBLISH default to 'false' unless:


### PR DESCRIPTION
To make this not send 3 notifications for each platform we build for I've created a special job just for building `master` branch:
https://ci.status.im/job/status-desktop/job/master/

For more details see: https://plugins.jenkins.io/discord-notifier/

This is blocked by issue with Jenkins GitHub plugin:

* https://github.com/status-im/infra-ci/issues/55