### PR TITLE
fix(communities): Cannot leave community, invite, mute from Settings/Communities

### DIFF
--- a/ui/app/AppLayouts/Profile/panels/CommunitiesListPanel.qml
+++ b/ui/app/AppLayouts/Profile/panels/CommunitiesListPanel.qml
@@ -15,7 +15,9 @@ StatusListView {
     property bool hasAddedContacts: false
 
     signal inviteFriends(var communityData)
-    signal leaveCommunityClicked(var communityId)
+    signal leaveCommunityClicked(string communityId)
+    signal setCommunityMutedClicked(string communityId, bool muted)
+    signal setActiveCommunityClicked(string communityId)
 
     interactive: false
     implicitHeight: contentItem.childrenRect.height
@@ -36,6 +38,10 @@ StatusListView {
 
         sensor.hoverEnabled: false
 
+        onClicked: {
+            setActiveCommunityClicked(model.id)
+        }
+
         components: [
             StatusFlatButton {
                 size: StatusBaseButton.Size.Small
@@ -55,7 +61,7 @@ StatusListView {
                 height: 44
                 icon.source: model.muted ? Style.svg("communities/notifications-muted")
                                          : Style.svg("communities/notifications")
-                onClicked: root.communityProfileModule.setCommunityMuted(model.id, !model.muted)
+                onClicked: root.setCommunityMutedClicked(model.id, !model.muted)
             },
 
             StatusFlatRoundButton {
@@ -70,8 +76,10 @@ StatusListView {
 
     property Component leaveCommunityPopup: StatusModal {
         id: leavePopup
+
         property string community: ""
-        property var communityId
+        property string communityId: ""
+
         anchors.centerIn: parent
         header.title: qsTr("Leave %1").arg(community)
         contentItem: Item {

--- a/ui/app/AppLayouts/Profile/views/CommunitiesView.qml
+++ b/ui/app/AppLayouts/Profile/views/CommunitiesView.qml
@@ -55,14 +55,24 @@ SettingsContentBase {
             CommunitiesListPanel {
                 width: parent.width
                 model: root.profileSectionStore.communitiesList
+
                 onLeaveCommunityClicked: {
-                    root.profileSectionStore.communitiesProfileModule.leaveCommunity(leavePopup.communityId)
+                    root.profileSectionStore.communitiesProfileModule.leaveCommunity(communityId)
                 }
+
+                onSetCommunityMutedClicked: {
+                    root.profileSectionStore.communitiesProfileModule.setCommunityMuted(communityId, muted)
+                }
+
+                onSetActiveCommunityClicked: {
+                    rootStore.setActiveCommunity(communityId)
+                }
+
                 onInviteFriends: {
                     Global.openPopup(inviteFriendsToCommunityPopup, {
                                          community: communityData,
                                          hasAddedContacts: root.contactStore.myContactsModel.count > 0,
-                                         communitySectionModule: communityProfileModule
+                                         communitySectionModule: root.profileSectionStore.communitiesProfileModule
                                      })
                 }
             }
@@ -87,7 +97,8 @@ SettingsContentBase {
         }
 
         onSendInvites: {
-            const error = communitySectionModule.inviteUsersToCommunity(communty.id, JSON.stringify(pubKeys))
+            const error = root.profileSectionStore.communitiesProfileModule.inviteUsersToCommunity(
+                            community.id, JSON.stringify(pubKeys))
             processInviteResult(error)
         }
     }

--- a/ui/app/AppLayouts/stores/RootStore.qml
+++ b/ui/app/AppLayouts/stores/RootStore.qml
@@ -166,4 +166,8 @@ QtObject {
             mainModuleInst.setCurrentUserStatus(newStatus)
         }
     }
+
+    function setActiveCommunity(communityId) {
+        mainModule.setActiveSectionById(communityId);
+    }
 }


### PR DESCRIPTION
### What does the PR do

fixes #6305

- clicking on community entry moves to the corresponding community
  **Note: it required adding `setActiveCommunity` to `AppLayouts/store/RootStore`, so now `setActiveCommunity` is duplicated, it occurs in 3 different places (RootStore, another RootStore and CommunityStore), because there is no common `RootStore` accessible from the whole app. Are there some plans to refactor those stores?**
- muting community works as expected
- invite icon opens invite dialog, Invite button sends invitations


### Affected areas

`CommunitiesListPanel`, `CommunitiesView`, `AppLayouts/store/RootStore`

### Screenshot of functionality (including design for comparison)

https://user-images.githubusercontent.com/20650004/180821070-f780a82a-daed-4369-a99b-b8bf2e2e3db3.mp4

- [x] I've checked the design and this PR matches it