### PR TITLE
Fix missing context menu on right click in the community column + tests

### DIFF
--- a/test/ui-test/src/drivers/SquishDriver.py
+++ b/test/ui-test/src/drivers/SquishDriver.py
@@ -82,6 +82,11 @@ def get_obj(objName: str):
 def click_obj_by_name(objName: str):
         obj = squish.waitForObject(getattr(names, objName))
         squish.mouseClick(obj, squish.Qt.LeftButton)
+        
+# It executes the right-click action into object with given object name:
+def right_click_obj_by_name(objName: str):
+        obj = squish.waitForObject(getattr(names, objName))
+        squish.mouseClick(obj, squish.Qt.RightButton)
 
 
 def scroll_obj_by_name(objName: str):

--- a/test/ui-test/src/screens/StatusCommunityScreen.py
+++ b/test/ui-test/src/screens/StatusCommunityScreen.py
@@ -14,6 +14,10 @@ import time
 from drivers.SquishDriver import *
 from drivers.SquishDriverVerification import *
 
+class CommunityCreateMethods(Enum):
+    BOTTOM_MENU = "bottom_menu"
+    RIGHT_CLICK_MENU = "right_click_menu"
+    
 class CommunityScreenComponents(Enum):
     COMMUNITY_HEADER_BUTTON = "mainWindow_communityHeader_StatusChatInfoButton"
     COMMUNITY_HEADER_NAME_TEXT= "community_ChatInfo_Name_Text"
@@ -23,6 +27,7 @@ class CommunityScreenComponents(Enum):
     CHAT_IDENTIFIER_CHANNEL_NAME = "msgDelegate_channelIdentifierNameText_StyledText"
     CHAT_MORE_OPTIONS_BUTTON = "chat_moreOptions_menuButton"
     EDIT_CHANNEL_MENU_ITEM = "edit_Channel_StatusMenuItemDelegate"
+    COMMUNITY_COLUMN_VIEW = "mainWindow_communityColumnView_CommunityColumnView"
 
 class CreateOrEditCommunityChannelPopup(Enum):
     COMMUNITY_CHANNEL_NAME_INPUT: str = "createOrEditCommunityChannelNameInput_TextEdit"
@@ -37,8 +42,14 @@ class StatusCommunityScreen:
     def verify_community_name(self, communityName: str):
         verify_text_matching(CommunityScreenComponents.COMMUNITY_HEADER_NAME_TEXT.value, communityName)
     
-    def create_community_channel(self, communityChannelName: str, communityChannelDescription: str):
-        click_obj_by_name(CommunityScreenComponents.COMMUNITY_CREATE_CHANNEL_OR_CAT_BUTTON.value)
+    def create_community_channel(self, communityChannelName: str, communityChannelDescription: str, method: str):
+        if (method == CommunityCreateMethods.BOTTOM_MENU.value):
+            click_obj_by_name(CommunityScreenComponents.COMMUNITY_CREATE_CHANNEL_OR_CAT_BUTTON.value)
+        elif (method == CommunityCreateMethods.RIGHT_CLICK_MENU.value):
+            right_click_obj_by_name(CommunityScreenComponents.COMMUNITY_COLUMN_VIEW.value)
+        else:
+            print("Unknown method to create a channel: ", method)
+        
         click_obj_by_name(CommunityScreenComponents.COMMUNITY_CREATE_CHANNEL__MENU_ITEM.value)
         
         wait_for_object_and_type(CreateOrEditCommunityChannelPopup.COMMUNITY_CHANNEL_NAME_INPUT.value, communityChannelName)
@@ -48,7 +59,7 @@ class StatusCommunityScreen:
     def verify_channel_name(self, communityChannelName: str):
         verify_text_matching(CommunityScreenComponents.CHAT_IDENTIFIER_CHANNEL_NAME.value, communityChannelName)
         
-    def editCommunityChannel(self, communityChannelName: str, newCommunityChannelName: str):
+    def edit_community_channel(self, communityChannelName: str, newCommunityChannelName: str):
         click_obj_by_name(CommunityScreenComponents.CHAT_MORE_OPTIONS_BUTTON.value)
         click_obj_by_name(CommunityScreenComponents.EDIT_CHANNEL_MENU_ITEM.value)
 
@@ -57,5 +68,3 @@ class StatusCommunityScreen:
         type(CreateOrEditCommunityChannelPopup.COMMUNITY_CHANNEL_NAME_INPUT.value, newCommunityChannelName)
         click_obj_by_name(CreateOrEditCommunityChannelPopup.COMMUNITY_CHANNEL_BUTTON.value)
         time.sleep(0.5)
-        
-        

--- a/test/ui-test/testSuites/suite_status/shared/scripts/names.py
+++ b/test/ui-test/testSuites/suite_status/shared/scripts/names.py
@@ -210,3 +210,4 @@ mainWallet_Add_Account_Popup_Footer_Add_Account = {"container": mainWallet_Add_A
 settings_Wallet_MainView_GeneratedAccounts = {"container": statusDesktop_mainWindow, "objectName":'generatedAccounts', "type": 'ListView'}
 settings_Wallet_AccountView_DeleteAccount = {"container": statusDesktop_mainWindow, "type": "StatusButton", "objectName": "deleteAccountButton"}
 settings_Wallet_AccountView_DeleteAccount_Confirm = {"container": statusDesktop_mainWindow, "type": "StatusButton", "objectName": "confirmDeleteAccountButton"}
+mainWindow_communityColumnView_CommunityColumnView = {"container": statusDesktop_mainWindow, "objectName": "communityColumnView", "type": "CommunityColumnView"}

--- a/test/ui-test/testSuites/suite_status/shared/steps/communitySteps.py
+++ b/test/ui-test/testSuites/suite_status/shared/steps/communitySteps.py
@@ -25,13 +25,13 @@ def step(context, community_name):
     StatusCommunityScreen()
     _statusCommunityScreen.verify_community_name(community_name)
     
-@When("the admin creates a community channel named |any|, with description |any|")
-def step(context, community_channel_name, community_channel_description):
-    _statusCommunityScreen.create_community_channel(community_channel_name, community_channel_description)
+@When("the admin creates a community channel named |any|, with description |any| with the method |any|")
+def step(context, community_channel_name, community_channel_description, method):
+    _statusCommunityScreen.create_community_channel(community_channel_name, community_channel_description, method)
     
 @When("the admin edits a community channel named |any| to the name |any|")
 def step(context, community_channel_name, new_community_channel_name):
-    _statusCommunityScreen.editCommunityChannel(community_channel_name, new_community_channel_name)
+    _statusCommunityScreen.edit_community_channel(community_channel_name, new_community_channel_name)
     
 @Then("the user lands on the community channel named |any|")
 def step(context, community_channel_name): 

--- a/test/ui-test/testSuites/suite_status/tst_communityFlows/test.feature
+++ b/test/ui-test/testSuites/suite_status/tst_communityFlows/test.feature
@@ -27,28 +27,30 @@ Feature: Status Desktop community
         Then the user lands on the community named <community_name>
 
         Examples:
-        	| community_name    | community_description   | community_intro  | community_outro  |
-        	| testCommunity1    | Community tested 1      | My intro for the community | My community outro  |
+            | community_name    | community_description   | community_intro  | community_outro  |
+            | testCommunity1    | Community tested 1      | My intro for the community | My community outro  |
 
 
     Scenario Outline: Admin creates a community channel
         When the user creates a community named myCommunity, with description My community description, intro Community Intro and outro Community Outro
         Then the user lands on the community named myCommunity
-        When the admin creates a community channel named <community_channel_name>, with description <community_channel_description>
+        When the admin creates a community channel named <community_channel_name>, with description <community_channel_description> with the method <method>
         Then the user lands on the community channel named <community_channel_name>
 
         Examples:
-        	| community_channel_name    | community_channel_description   |
-        	| test-channel    | Community channel description tested 1      |
+        	| community_channel_name    | community_channel_description     | method           |
+        	| test-channel    | Community channel description tested 1      | bottom_menu      |
+            | test-channel2   | Community channel description tested 2      | right_click_menu |
 
     Scenario Outline: Admin edits a community channel
         When the user creates a community named myCommunity, with description My community description, intro Community Intro and outro Community Outro
         Then the user lands on the community named myCommunity
-        When the admin creates a community channel named test-channel, with description My description
+        When the admin creates a community channel named test-channel, with description My description with the method bottom_menu
         Then the user lands on the community channel named test-channel
         When the admin edits a community channel named <community_channel_name> to the name <new_community_channel_name>
         Then the user lands on the community channel named <new_community_channel_name>
 
         Examples:
         	| community_channel_name    | community_channel_description   | new_community_channel_name  |
-        	| test-channel    | Community channel description tested 1    | new-test-channel            |
+            | test-channel    | Community channel description tested 1    | new-test-channel            |
+

--- a/ui/app/AppLayouts/Chat/views/CommunityColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/CommunityColumnView.qml
@@ -37,6 +37,19 @@ Item {
     signal infoButtonClicked
     signal manageButtonClicked
 
+    MouseArea {
+        enabled: communityData.amISectionAdmin
+        anchors.fill: parent
+        z: 0
+        acceptedButtons: Qt.RightButton
+        onClicked: {
+            adminPopupMenu.showInviteButton = true
+            adminPopupMenu.x = mouse.x + 4
+            adminPopupMenu.y = mouse.y + 4
+            adminPopupMenu.open()
+        }
+    }
+
     StatusChatInfoButton {
         id: communityHeader
         objectName: "communityHeaderButton"
@@ -76,7 +89,7 @@ Item {
             text: qsTr("Start chat")
             visible: parent.hovered
         }
-    } // StatusChatInfoToolBar
+    }
 
     Loader {
         id: membershipRequests
@@ -100,6 +113,45 @@ Item {
         }
     }
 
+    StatusPopupMenu {
+        property bool showInviteButton: false
+
+        id: adminPopupMenu
+        enabled: communityData.amISectionAdmin
+
+        onClosed: adminPopupMenu.showInviteButton = false
+
+        StatusMenuItem {
+            objectName: "createCommunityChannelBtn"
+            text: qsTr("Create channel")
+            icon.name: "channel"
+            onTriggered: Global.openPopup(createChannelPopup)
+        }
+
+        StatusMenuItem {
+            objectName: "createCommunityCategoryBtn"
+            text: qsTr("Create category")
+            icon.name: "channel-category"
+            onTriggered: Global.openPopup(createCategoryPopup)
+        }
+
+        StatusMenuSeparator {
+            visible: invitePeopleBtn.enabled
+        }
+
+        StatusMenuItem {
+            id: invitePeopleBtn
+            text: qsTr("Invite people")
+            icon.name: "share-ios"
+            enabled: communityData.canManageUsers && adminPopupMenu.showInviteButton
+            onTriggered: Global.openPopup(inviteFriendsToCommunityPopup, {
+                                            community: communityData,
+                                            hasAddedContacts: root.hasAddedContacts,
+                                            communitySectionModule: root.communitySectionModule
+                                        })
+        }
+    }
+
     StatusScrollView {
         id: scrollView
         anchors.top: membershipRequests.bottom
@@ -115,46 +167,6 @@ Item {
         contentHeight: communityChatListAndCategories.height
                        + bannerColumn.height
                        + Style.current.bigPadding
-
-        background: MouseArea {
-            acceptedButtons: Qt.RightButton
-            onClicked: {
-                if (communityData.amISectionAdmin) {
-                    popup.x = mouse.x + 4
-                    popup.y = mouse.y + 4
-                    popup.open()
-                }
-            }
-
-        property var popup: StatusPopupMenu {
-            StatusMenuItem {
-                text: qsTr("Create channel")
-                icon.name: "channel"
-                enabled: communityData.amISectionAdmin
-                onTriggered: Global.openPopup(createChannelPopup)
-            }
-
-            StatusMenuItem {
-                text: qsTr("Create category")
-                icon.name: "channel-category"
-                enabled: communityData.amISectionAdmin
-                onTriggered: Global.openPopup(createCategoryPopup)
-            }
-
-            StatusMenuSeparator {}
-
-            StatusMenuItem {
-                text: qsTr("Invite people")
-                icon.name: "share-ios"
-                enabled: communityData.canManageUsers
-                onTriggered: Global.openPopup(inviteFriendsToCommunityPopup, {
-                                                  community: communityData,
-                                                  hasAddedContacts: root.hasAddedContacts,
-                                                  communitySectionModule: root.communitySectionModule
-                                              })
-            }
-        }
-    } // MouseArea
 
         StatusChatListAndCategories {
             id: communityChatListAndCategories
@@ -192,7 +204,6 @@ Item {
                 StatusMenuItem {
                     text: qsTr("Create channel")
                     icon.name: "channel"
-                    // Not Refactored Yet
                     enabled: communityData.amISectionAdmin
                     onTriggered: Global.openPopup(createChannelPopup)
                 }
@@ -484,6 +495,7 @@ Item {
         active: communityData.amISectionAdmin
         sourceComponent: Component {
             StatusBaseText {
+                id: createChannelOrCategoryBtn
                 objectName: "createChannelOrCategoryBtn"
                 color: Theme.palette.baseColor1
                 height: visible ? implicitHeight : 0
@@ -496,30 +508,11 @@ Item {
                     anchors.fill: parent
                     cursorShape: Qt.PointingHandCursor
                     onClicked: {
-                        if (createChatOrCatMenu.opened) {
-                            createChatOrCatMenu.close()
-                            return
-                        }
-                        createChatOrCatMenu.open()
-                        createChatOrCatMenu.y = - createChatOrCatMenu.height - 5
-                    }
-                }
-
-                StatusPopupMenu {
-                    id: createChatOrCatMenu
-                    closePolicy: Popup.CloseOnPressOutsideParent
-                    StatusMenuItem {
-                        objectName: "createCommunityChannelBtn"
-                        text: qsTr("Create channel")
-                        icon.name: "channel"
-                        onTriggered: Global.openPopup(createChannelPopup)
-                    }
-
-                    StatusMenuItem {
-                        objectName: "createCommunityCategoryBtn"
-                        text: qsTr("Create category")
-                        icon.name: "channel-category"
-                        onTriggered: Global.openPopup(createCategoryPopup)
+                        adminPopupMenu.showInviteButton = false
+                        adminPopupMenu.popup()
+                        adminPopupMenu.y = Qt.binding(function () {
+                            return root.height - adminPopupMenu.height - createChannelOrCategoryBtn.height - 20
+                        })
                     }
                 }
             }

--- a/ui/app/AppLayouts/Chat/views/CommunityColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/CommunityColumnView.qml
@@ -19,6 +19,7 @@ import "../panels/communities"
 
 Item {
     id: root
+    objectName: "communityColumnView"
     width: 304
     height: parent.height
 
@@ -114,10 +115,10 @@ Item {
     }
 
     StatusPopupMenu {
-        property bool showInviteButton: false
-
         id: adminPopupMenu
         enabled: communityData.amISectionAdmin
+
+        property bool showInviteButton: false
 
         onClosed: adminPopupMenu.showInviteButton = false
 
@@ -510,9 +511,8 @@ Item {
                     onClicked: {
                         adminPopupMenu.showInviteButton = false
                         adminPopupMenu.popup()
-                        adminPopupMenu.y = Qt.binding(function () {
-                            return root.height - adminPopupMenu.height - createChannelOrCategoryBtn.height - 20
-                        })
+                        adminPopupMenu.y = Qt.binding(() => root.height - adminPopupMenu.height
+                            - createChannelOrCategoryBtn.height - 20)
                     }
                 }
             }


### PR DESCRIPTION
Fixes #6609

The menu was lost because it used to be set as part of the ScrollView background, but it got changed to  a Flickable as part of the fix to the scrolls being not smooth.
Anyway, background doesn't exist on Flickables, so I removed it and moved the MouseArea to the CommunityColumnView instead.

Second commit adds integration tests

StatusQ PR: https://github.com/status-im/StatusQ/pull/802