### PR TITLE
fix(AppMain): User profile image on sidebar should be a bit bigger larger

### DIFF
--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -221,12 +221,10 @@ Item {
     StatusAppLayout {
         id: appLayout
 
-        width: parent.width
-        anchors.top: parent.top
-        anchors.bottom: parent.bottom
+        anchors.fill: parent
 
         appNavBar: StatusAppNavBar {
-            height: appMain.height
+            height: parent.height
             communityTypeRole: "sectionType"
             communityTypeValue: Constants.appSection.community
             sectionModel: mainModule.sectionsModel
@@ -346,15 +344,27 @@ Item {
 
                 name: appMain.rootStore.userProfileInst.name
                 icon.source: appMain.rootStore.userProfileInst.icon
+                width: 32
+                height: 32
+                identicon.width: width
+                identicon.height: height
                 identicon.icon.charactersLen: 2
                 identicon.icon.color: Utils.colorForPubkey(appMain.rootStore.userProfileInst.pubKey)
                 identicon.ringSettings.ringSpecModel: Utils.getColorHashAsJson(appMain.rootStore.userProfileInst.pubKey)
 
                 badge.visible: true
-                badge.anchors.rightMargin: 4
-                badge.anchors.topMargin: 25
-                badge.implicitHeight: 15
-                badge.implicitWidth: 15
+                badge.anchors {
+                    left: undefined
+                    top: undefined
+                    right: profileButton.right
+                    bottom: profileButton.bottom
+                    margins: 0
+                    rightMargin: -badge.border.width
+                    bottomMargin: -badge.border.width
+                }
+                badge.implicitHeight: 12
+                badge.implicitWidth: 12
+                badge.border.width: 2
                 badge.border.color: hovered ? Theme.palette.statusBadge.hoverBorderColor : Theme.palette.statusAppNavBar.backgroundColor
                 badge.color: {
                     switch(appMain.rootStore.userProfileInst.currentUserStatus){
@@ -365,12 +375,8 @@ Item {
                             return Style.current.midGrey;
                     }
                 }
-                badge.border.width: 3
-                onClicked: {
-                    userStatusContextMenu.opened ?
-                        userStatusContextMenu.close() :
-                        userStatusContextMenu.open()
-                }
+
+                onClicked: userStatusContextMenu.opened ? userStatusContextMenu.close() : userStatusContextMenu.open()
 
                 UserStatusContextMenu {
                     id: userStatusContextMenu


### PR DESCRIPTION
make the profile image + badge look as designed

Closes: #6622

### What does the PR do

Aligns the user profile icon with design

### Affected areas

AppMain/StatusAppNavBar

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![Snímek obrazovky z 2022-07-26 09-42-26](https://user-images.githubusercontent.com/5377645/180960363-6e15740e-9c75-4a36-984e-5552ecaa5ba3.png)

