### PR TITLE
fix(StatusInput): Updated status input custom height leftovers

### DIFF
--- a/ui/app/AppLayouts/Chat/controls/community/CommunityDescriptionInput.qml
+++ b/ui/app/AppLayouts/Chat/controls/community/CommunityDescriptionInput.qml
@@ -17,7 +17,8 @@ StatusInput {
 
     placeholderText: qsTr("What your community is about")
     input.multiline: true
-    input.implicitHeight: 88
+    minimumHeight: 88
+    maximumHeight: 88
 
     validators: [
         StatusMinLengthValidator {

--- a/ui/app/AppLayouts/Chat/controls/community/CommunityIntroMessageInput.qml
+++ b/ui/app/AppLayouts/Chat/controls/community/CommunityIntroMessageInput.qml
@@ -16,7 +16,8 @@ StatusInput {
     charLimit: 1400
 
     input.multiline: true
-    input.implicitHeight: 400
+    minimumHeight: 400
+    maximumHeight: 400
 
     input.placeholder.text: qsTr("What new members will read before joining (eg. community rules, welcome message, etc.). Members will need to tick a check box agreeing to these rules before they are allowed to join your community.")
     input.placeholder.wrapMode: Text.WordWrap

--- a/ui/app/AppLayouts/Chat/popups/community/CreateChannelPopup.qml
+++ b/ui/app/AppLayouts/Chat/popups/community/CreateChannelPopup.qml
@@ -219,7 +219,8 @@ StatusModal {
 
                 placeholderText: qsTr("Describe the channel")
                 input.multiline: true
-                input.implicitHeight: 88
+                minimumHeight: 88
+                maximumHeight: 88
                 validationMode: StatusInput.ValidationMode.Always
                 validators: [StatusMinLengthValidator {
                     minLength: 1

--- a/ui/app/AppLayouts/Profile/popups/SendContactRequestModal.qml
+++ b/ui/app/AppLayouts/Profile/popups/SendContactRequestModal.qml
@@ -129,7 +129,8 @@ StatusModal {
 
                 placeholderText: qsTr("Say who you are / why you want to become a contact...")
                 input.multiline: true
-                input.implicitHeight: d.msgHeight
+                minimumHeight: d.msgHeight
+                maximumHeight: d.msgHeight
                 input.verticalAlignment: TextEdit.AlignTop
 
                 validators: [StatusMinLengthValidator {

--- a/ui/app/AppLayouts/Profile/popups/backupseed/BackupSeedStepBase.qml
+++ b/ui/app/AppLayouts/Profile/popups/backupseed/BackupSeedStepBase.qml
@@ -39,7 +39,6 @@ StatusScrollView {
             id: inputText
             visible: (wordRandomNumber > -1)
             implicitWidth: 448
-            input.implicitHeight: 44
             validationMode: StatusInput.ValidationMode.Always
             label: qsTr("Word #%1").arg(wordRandomNumber + 1)
             placeholderText: qsTr("Enter word")

--- a/ui/app/AppLayouts/Profile/views/ContactsView.qml
+++ b/ui/app/AppLayouts/Profile/views/ContactsView.qml
@@ -43,7 +43,6 @@ SettingsContentBase {
             id: searchBox
             anchors.left: parent.left
             anchors.right: parent.right
-            input.implicitHeight: 44
             placeholderText: qsTr("Search by a display name or chat key")
         }
 

--- a/ui/app/AppLayouts/Profile/views/NotificationsView.qml
+++ b/ui/app/AppLayouts/Profile/views/NotificationsView.qml
@@ -523,7 +523,6 @@ SettingsContentBase {
                         Layout.preferredWidth: root.contentWidth - 2 * Style.current.padding
                         Layout.leftMargin: Style.current.padding
                         Layout.rightMargin: Style.current.padding
-                        input.implicitHeight: 44
                         placeholderText: qsTr("Search Communities, Group Chats and 1:1 Chats")
                     }
 

--- a/ui/imports/shared/popups/ContactVerificationRequestPopup.qml
+++ b/ui/imports/shared/popups/ContactVerificationRequestPopup.qml
@@ -80,7 +80,8 @@ StatusModal {
             anchors.topMargin: 5
             input.multiline: true
             placeholderText: qsTr("Provide answer to verification request from this contact.")
-            input.implicitHeight: 152
+            minimumHeight: 152
+            maximumHeight: 152
             width: parent.width
             input.verticalAlignment: TextEdit.AlignTop
             leftPadding: 0

--- a/ui/imports/shared/popups/SendContactRequestModal.qml
+++ b/ui/imports/shared/popups/SendContactRequestModal.qml
@@ -55,7 +55,8 @@ StatusModal {
 
             placeholderText: qsTr("Say who you are / why you want to become a contact...")
             input.multiline: true
-            input.implicitHeight: d.msgHeight
+            minimumHeight: d.msgHeight
+            maximumHeight: d.msgHeight
             input.verticalAlignment: TextEdit.AlignTop
 
             validators: StatusMinLengthValidator {

--- a/ui/imports/shared/views/ProfileView.qml
+++ b/ui/imports/shared/views/ProfileView.qml
@@ -342,7 +342,8 @@ Rectangle {
             Layout.rightMargin: d.contentMargins
             Layout.leftMargin: d.contentMargins
             input.multiline: true
-            input.implicitHeight: 152
+            minimumHeight: 152
+            maximumHeight: 152
             placeholderText: qsTr("Ask a question that only the real %1 will be able to answer e.g. a question about a shared experience, or ask Mark to enter a code or phrase you have sent to them via a different communication channel (phone, post, etc...).").arg(userIsEnsVerified ? userEnsName : userDisplayName)
         }
 


### PR DESCRIPTION
Closes #6637

### What does the PR do
Fixes status input custom height leftovers that were not updated

### Affected areas
Modals that use status input
<img width="702" alt="1" src="https://user-images.githubusercontent.com/31625338/180988532-810c368c-109d-49ab-bca5-2add88606075.png">
<img width="873" alt="2" src="https://user-images.githubusercontent.com/31625338/180988541-804c4087-4194-41e7-b60d-46352353825b.png">
<img width="577" alt="3" src="https://user-images.githubusercontent.com/31625338/180988543-0371e0f3-4105-4ab4-94a8-dc60ffed9e8d.png">
<img width="550" alt="4" src="https://user-images.githubusercontent.com/31625338/180988547-c1b7c7f8-09f7-4e33-b505-8fff46bb0680.png">
<img width="682" alt="5" src="https://user-images.githubusercontent.com/31625338/180988550-f54e662c-37d8-4563-a5c7-4ca1109ef694.png">
<img width="506" alt="6" src="https://user-images.githubusercontent.com/31625338/180988559-7a7ed7fb-a931-4bbc-a334-286491e245e7.png">

