### PR TITLE
fix(AllowNotificationsView): The page 'Allow notifications' differs from the Design

### DIFF
--- a/ui/app/AppLayouts/Onboarding/views/AllowNotificationsView.qml
+++ b/ui/app/AppLayouts/Onboarding/views/AllowNotificationsView.qml
@@ -39,6 +39,7 @@ Item {
         anchors.verticalCenter: parent.verticalCenter
         font.letterSpacing: d.titleLetterSpacing
         font.pixelSize: d.titlePixelSize
+        lineHeight: 1.2
     }
 
     StyledText {
@@ -50,6 +51,7 @@ Item {
         anchors.top: txtTitle.bottom
         anchors.topMargin: Style.current.padding
         font.pixelSize: Style.current.primaryTextFontSize
+        lineHeight: 1.2
     }
 
     StatusButton {
@@ -57,6 +59,9 @@ Item {
         anchors.top: txtDesc.bottom
         anchors.topMargin: d.okButtonTopMargin
         anchors.horizontalCenter: parent.horizontalCenter
+        leftPadding: Style.current.padding
+        rightPadding: Style.current.padding
+        font.weight: Font.Medium
         text: qsTr("Ok, got it")
         onClicked: {
             root.startupStore.doPrimaryAction()


### PR DESCRIPTION
Closes: #6514

### What does the PR do

Fixes minor issues in the "Allow notifications" onboarding page

### Affected areas

AllowNotificationsView

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![Snímek obrazovky z 2022-07-26 16-13-51](https://user-images.githubusercontent.com/5377645/181028636-34d50748-8875-4f8d-a097-d3cb06852e6b.png)

