### PR TITLE
fix(CreateChatView): Move `ActivityCenterPopup` to appmain

### DIFF
--- a/ui/app/AppLayouts/Chat/popups/ActivityCenterPopup.qml
+++ b/ui/app/AppLayouts/Chat/popups/ActivityCenterPopup.qml
@@ -8,12 +8,16 @@ import StatusQ.Controls 0.1
 
 import shared 1.0
 import shared.popups 1.0
+import shared.views.chat 1.0
+
 import utils 1.0
 
 import "../views"
 import "../panels"
 
 Popup {
+    id: activityCenter
+
     enum Filter {
         All,
         Mentions,
@@ -28,11 +32,13 @@ Popup {
     property bool hideReadNotifications: false
     property var store
     property var chatSectionModule
-    property var messageContextMenu
+    property var messageContextMenu: MessageContextMenuView {
+        store: activityCenter.store
+        reactionModel: activityCenter.store.emojiReactionsModel
+    }
 
     readonly property int unreadNotificationsCount : activityCenter.store.activityCenterList.unreadCount
 
-    id: activityCenter
     modal: false
 
     closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside

--- a/ui/app/AppLayouts/Chat/popups/qmldir
+++ b/ui/app/AppLayouts/Chat/popups/qmldir
@@ -2,3 +2,4 @@ PinnedMessagesPopup 1.0 PinnedMessagesPopup.qml
 ChooseBrowserPopup 1.0 ChooseBrowserPopup.qml
 InviteFriendsToCommunityPopup 1.0 community/InviteFriendsToCommunityPopup.qml
 CommunityProfilePopup 1.0 community/CommunityProfilePopup.qml
+ActivityCenterPopup 1.0 ActivityCenterPopup.qml

--- a/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
@@ -153,12 +153,6 @@ Item {
         }
     }
 
-    MessageContextMenuView {
-        id: contextmenu
-        store: root.rootStore
-        reactionModel: root.rootStore.emojiReactionsModel
-    }
-
     EmptyChatPanel {
         anchors.fill: parent
         visible: root.activeChatId === "" || root.chatsCount == 0
@@ -231,14 +225,14 @@ Item {
                             stickersLoaded: root.stickersLoaded
                             isBlocked: model.blocked
                             isActiveChannel: categoryChatLoader.isActiveChannel
-                            activityCenterVisible: activityCenter.visible
-                            activityCenterNotificationsCount: activityCenter.unreadNotificationsCount
+                            activityCenterVisible: Global.activityCenterPopupOpened
+                            activityCenterNotificationsCount: root.rootStore.activityCenterList.unreadCount
                             pinnedMessagesPopupComponent: root.pinnedMessagesListPopupComponent
                             onOpenStickerPackPopup: {
                                 root.openStickerPackPopup(stickerPackId)
                             }
                             onNotificationButtonClicked: {
-                                activityCenter.open();
+                                Global.openActivityCenterPopup()
                             }
                             onOpenAppSearch: {
                                 root.openAppSearch();
@@ -295,7 +289,7 @@ Item {
                             root.openStickerPackPopup(stickerPackId)
                         }
                         onNotificationButtonClicked: {
-                            activityCenter.open();
+                            Global.openActivityCenterPopup()
                         }
                         onOpenAppSearch: {
                             root.openAppSearch();
@@ -411,15 +405,6 @@ Item {
                 }
             }
         }
-    }
-
-    ActivityCenterPopup {
-        id: activityCenter
-        height: root.height - 56 * 2 // TODO get screen size // Taken from old code top bar height was fixed there to 56
-        y: 56
-        store: root.rootStore
-        chatSectionModule: root.parentModule
-        messageContextMenu: contextmenu
     }
 
         // Not Refactored Yet

--- a/ui/app/AppLayouts/Chat/views/CreateChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/CreateChatView.qml
@@ -12,6 +12,8 @@ import StatusQ.Core.Theme 0.1
 import utils 1.0
 import shared.status 1.0
 
+import "../popups"
+
 Page {
     id: root
     Behavior on anchors.bottomMargin { NumberAnimation { duration: 30 }}
@@ -131,7 +133,7 @@ Page {
                 id: notificationButton
                 anchors.right: parent.right
                 unreadNotificationsCount: activityCenter.unreadNotificationsCount
-                onClicked: activityCenter.open()
+                onClicked: Global.openActivityCenterPopup()
             }
         }
     }

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -89,6 +89,12 @@ Item {
             popup.openPopup(publicKey, state);
             Global.profilePopupOpened = true;
         }
+
+        onOpenActivityCenterPopupRequested: {
+            Global.openPopup(activityCenterPopupComponent)
+            Global.activityCenterPopupOpened = true
+        }
+
         onOpenChangeProfilePicPopup: {
             var popup = changeProfilePicComponent.createObject(appMain);
             popup.chooseImageToCrop();
@@ -758,6 +764,20 @@ Item {
             ConfirmationDialog {
                 onClosed: {
                     destroy()
+                }
+            }
+        }
+
+        Component {
+            id: activityCenterPopupComponent
+            ActivityCenterPopup {
+                id: activityCenter
+                height: appView.height - 56 * 2 // TODO get screen size // Taken from old code top bar height was fixed there to 56
+                y: 56
+                store: chatLayoutContainer.rootStore
+                chatSectionModule: chatLayoutContainer.rootStore.chatCommunitySectionModule
+                onClosed: {
+                    Global.activityCenterPopupOpened = false
                 }
             }
         }

--- a/ui/imports/utils/Global.qml
+++ b/ui/imports/utils/Global.qml
@@ -19,6 +19,8 @@ QtObject {
     property var inviteFriendsToCommunityPopup
     property bool profilePopupOpened: false
 
+    property bool activityCenterPopupOpened: false
+
     property var sendMessageSound
     property var notificationSound
     property var errorSound
@@ -37,9 +39,14 @@ QtObject {
     signal openChangeProfilePicPopup()
     signal displayToastMessage(string title, string subTitle, string icon, bool loading, int ephNotifType, string url)
     signal openEditDisplayNamePopup()
+    signal openActivityCenterPopupRequested
 
     function openProfilePopup(publicKey, parentPopup, state = "") {
         openProfilePopupRequested(publicKey, parentPopup, state);
+    }
+
+    function openActivityCenterPopup() {
+        openActivityCenterPopupRequested()
     }
 
     function openPopup(popupComponent, params = {}) {


### PR DESCRIPTION
Closes: #6345

### What does the PR do

Move `ActivityCenterPopup` to `AppMain` and add creation method to `Global`

### Affected areas

ActivityCenter

