### PR TITLE
fix(@desktop/wallet): Send Transaction modal colors need to be adjusted to match designs

### DIFF
--- a/ui/imports/shared/controls/AmountInputWithCursor.qml
+++ b/ui/imports/shared/controls/AmountInputWithCursor.qml
@@ -17,7 +17,7 @@ StatusInput {
     input.edit.cursorVisible: true
     input.edit.font.pixelSize: 32
     input.placeholderFont.pixelSize: 32
-    input.leftPadding: -1
+    input.leftPadding: 0
     input.rightPadding: 0
     input.topPadding: 0
     input.bottomPadding: 0

--- a/ui/imports/shared/controls/GasValidator.qml
+++ b/ui/imports/shared/controls/GasValidator.qml
@@ -59,6 +59,7 @@ Column {
     }
     StyledText {
         id: txtValidationError
+        anchors.horizontalCenter: parent.horizontalCenter
         text: qsTr("Not enough ETH for gas")
         verticalAlignment: Text.AlignVCenter
         horizontalAlignment: Text.AlignHCenter

--- a/ui/imports/shared/popups/SendModal.qml
+++ b/ui/imports/shared/popups/SendModal.qml
@@ -88,6 +88,7 @@ StatusModal {
     showFooter: false
     showAdvancedFooter: d.isReady && !isNaN(parseFloat(amountToSendInput.text)) && gasValidator.isValid
     showAdvancedHeader: true
+    backgroundColor: Theme.palette.baseColor3
 
     onSelectedAccountChanged: popup.recalculateRoutesAndFees()
 
@@ -120,6 +121,7 @@ StatusModal {
         TransactionFormGroup {
             id: group1
             anchors.fill: parent
+            color: Theme.palette.baseColor3
 
             ColumnLayout {
                 id: assetAndAmmountSelector
@@ -154,6 +156,7 @@ StatusModal {
                         id: amountToSendInput
                         anchors.verticalCenter: parent.verticalCenter
                         anchors.left: parent.left
+                        anchors.leftMargin: -Style.current.padding
                         width: parent.width - assetSelector.width
                         placeholderText: "0.00" + " " + assetSelector.selectedAsset.symbol
                         errorMessageCmp.anchors.rightMargin: -100
@@ -283,6 +286,7 @@ StatusModal {
                         input.anchors.leftMargin: 0
                         input.anchors.rightMargin: 0
                         input.textField.anchors.rightMargin: 0
+                        input.bgColor: Theme.palette.indirectColor1
                         labelFont.pixelSize: 15
                         labelFont.weight: Font.Normal
                         input.height: 56
@@ -347,10 +351,11 @@ StatusModal {
                                 icon.name: "fees"
                             }
                             ColumnLayout {
-                                Layout.alignment: Qt.AlignTop
+                                Layout.alignment: Qt.AlignTop | Qt.AlignHCenter
+                                Layout.preferredWidth: fees.width - feesIcon.width - Style.current.xlPadding
                                 GasSelector {
                                     id: gasSelector
-                                    Layout.preferredWidth: fees.width - feesIcon.width - Style.current.xlPadding
+                                    Layout.fillWidth: true
                                     getGasEthValue: popup.store.getGasEthValue
                                     getFiatValue: popup.store.getFiatValue
                                     getEstimatedTime: popup.store.getEstimatedTime
@@ -377,7 +382,7 @@ StatusModal {
                                                                         ""))
 
                                         if (!gasEstimate.success) {
-                                            console.warn("error estimating gas: %1").arg(gasEstimate.error.message)
+                                            console.warn("error estimating gas: ", gasEstimate.error.message)
                                             return
                                         }
 
@@ -387,7 +392,7 @@ StatusModal {
                                 }
                                 GasValidator {
                                     id: gasValidator
-                                    anchors.horizontalCenter: undefined
+                                    Layout.fillWidth: true
                                     Layout.alignment: Qt.AlignHCenter
                                     selectedAccount: popup.selectedAccount
                                     selectedAmount: amountToSendInput.text === "" ? 0.0 :
@@ -404,6 +409,8 @@ StatusModal {
         }
         TransactionFormGroup {
             id: group4
+
+            color: Theme.palette.baseColor3
 
             StackView.onActivated: {
                 transactionSigner.forceActiveFocus(Qt.MouseFocusReason)

--- a/ui/imports/shared/views/SendModalFooter.qml
+++ b/ui/imports/shared/views/SendModalFooter.qml
@@ -27,7 +27,7 @@ Rectangle {
     width: parent.width
     height: 82
     radius: 8
-    color: Theme.palette.statusModal.backgroundColor
+    color: Theme.palette.baseColor3
 
     Rectangle {
         anchors.top: parent.top

--- a/ui/imports/shared/views/SendModalHeader.qml
+++ b/ui/imports/shared/views/SendModalHeader.qml
@@ -32,7 +32,7 @@ StatusFloatingButtonsSelector {
         height: button.height
         radius: 8
         visible: floatingHeader.visibleIndices.includes(index) && walletType !== Constants.watchWalletType
-        color: Theme.palette.statusAppLayout.backgroundColor
+        color: Theme.palette.baseColor3
         StatusButton {
             id: button
             topPadding: 8
@@ -44,6 +44,7 @@ StatusFloatingButtonsSelector {
             icon.emojiSize: StatusQUtils.Emoji.size.middle
             icon.name: !emoji ? "filled-account": ""
             normalColor: "transparent"
+            hoverColor: Theme.palette.statusFloatingButtonHighlight
             highlighted: index === floatingHeader.currentIndex
             onClicked: {
                 updatedSelectedAccount(model)


### PR DESCRIPTION
fix(@desktop/wallet): Send Transaction modal colors need to be adjusted to match designs
fixes #6497

StatusQ: https://github.com/status-im/StatusQ/pull/807

### What does the PR do

Updated the background color for send modal and also updated necessary components on StatusQ side

### Affected areas

Wallet

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

https://user-images.githubusercontent.com/60327365/181081972-a2aa35b9-2f50-409c-baef-83e9d61053ba.mov


