### PR TITLE
fix(@desktop/onboarding): make account name area clickable

### DIFF
--- a/ui/app/AppLayouts/Onboarding/views/LoginView.qml
+++ b/ui/app/AppLayouts/Onboarding/views/LoginView.qml
@@ -163,6 +163,7 @@ Item {
 
               anchors.fill: parent
               anchors.margins: -10
+              cursorShape: Qt.PointingHandCursor
               hoverEnabled: true
               onEntered: {
                   accountPopupOpened = accountsPopup.opened

--- a/ui/app/AppLayouts/Onboarding/views/LoginView.qml
+++ b/ui/app/AppLayouts/Onboarding/views/LoginView.qml
@@ -158,6 +158,23 @@ Item {
               color: Theme.palette.directColor1
           }
 
+          MouseArea {
+              property bool accountPopupOpened: false
+
+              anchors.fill: parent
+              anchors.margins: -10
+              hoverEnabled: true
+              onEntered: {
+                  accountPopupOpened = accountsPopup.opened
+              }
+              onPressed: {
+                  if (!accountPopupOpened) {
+                      changeAccountBtn.clicked(mouse)
+                  }
+                  accountPopupOpened = accountsPopup.opened
+              }
+          }
+
           StatusQControls.StatusFlatRoundButton {
               icon.name: "chevron-down"
               type: StatusQControls.StatusFlatRoundButton.Type.Tertiary

--- a/ui/app/AppLayouts/Onboarding/views/LoginView.qml
+++ b/ui/app/AppLayouts/Onboarding/views/LoginView.qml
@@ -159,20 +159,22 @@ Item {
           }
 
           MouseArea {
-              property bool accountPopupOpened: false
+              property bool accountPopupWasOpened: false
 
               anchors.fill: parent
               anchors.margins: -10
               cursorShape: Qt.PointingHandCursor
               hoverEnabled: true
               onEntered: {
-                  accountPopupOpened = accountsPopup.opened
+                  // cache opened state, because it is always false in onClicked
+                  // because of CloseOnPressOutsideParent policy of accountsPopup
+                  accountPopupWasOpened = accountsPopup.opened
               }
-              onPressed: {
-                  if (!accountPopupOpened) {
+              onClicked: {
+                  if (!accountPopupWasOpened) {
                       changeAccountBtn.clicked(mouse)
                   }
-                  accountPopupOpened = accountsPopup.opened
+                  accountPopupWasOpened = accountsPopup.opened
               }
           }
 


### PR DESCRIPTION
Closes: #6518

### What does the PR do

Make the account name area to be clickable on the Log in page and open accounts menu

### Affected areas

Desktop onboarding

### Screenshot of functionality 

https://user-images.githubusercontent.com/6445843/181278580-c3eb44fa-2ba1-49f8-a78e-826764ae40c2.mp4



