### PR TITLE
fix(ContactsListPanel/ContactsView): clipped width and action fixes

### DIFF
--- a/ui/app/AppLayouts/Profile/panels/ContactsListPanel.qml
+++ b/ui/app/AppLayouts/Profile/panels/ContactsListPanel.qml
@@ -121,7 +121,7 @@ Item {
 
             searchStr: contactListRoot.searchString
 
-            showSendMessageButton: model.isContact
+            showSendMessageButton: isContact && !isBlocked
             showRejectContactRequestButton: {
                 if (contactListRoot.panelUsage === Constants.contactsPanelUsage.receivedContactRequest && !model.verificationRequestStatus) {
                     return true

--- a/ui/app/AppLayouts/Profile/panels/ContactsListPanel.qml
+++ b/ui/app/AppLayouts/Profile/panels/ContactsListPanel.qml
@@ -98,9 +98,7 @@ Item {
         anchors.right: parent.right
         anchors.bottom: parent.bottom
         interactive: false
-        ScrollBar.vertical: ScrollBar {
-            policy: contactListRoot.scrollbarOn ? ScrollBar.AlwaysOn : ScrollBar.AsNeeded
-        }
+        ScrollBar.vertical.policy: contactListRoot.scrollbarOn ? ScrollBar.AlwaysOn : ScrollBar.AsNeeded
         model: delegateModel
     }
 
@@ -109,7 +107,7 @@ Item {
 
         ContactPanel {
             id: panelDelegate
-            width: (parent.width-10)
+            width: ListView.view.width
             name: model.displayName
             publicKey: model.pubKey
             iconSource: model.icon

--- a/ui/app/AppLayouts/Profile/views/ContactsView.qml
+++ b/ui/app/AppLayouts/Profile/views/ContactsView.qml
@@ -20,7 +20,7 @@ import "../popups"
 
 SettingsContentBase {
     id: root
-    onWidthChanged: { contentItem.width = width; }
+    onWidthChanged: { contentItem.width = contentWidth; }
     onHeightChanged: { contentItem.height = height; }
     property ContactsStore contactsStore
 


### PR DESCRIPTION
### What does the PR do

Fixes #6299: 'Send message' and icon for 1-1 chat are shown for a Blocked contact and they don't work 

Fixes #6669: Contact settings items have their right side options hidden (clipped)

### Affected areas

ContactsListPanel/ContactsView

- [x] I've checked the design and this PR matches it

Unblocked contact:
![Snímek obrazovky z 2022-07-27 19-25-06](https://user-images.githubusercontent.com/5377645/181347347-0a3c8233-c7d8-4029-a07f-bf9eb6373991.png)

Blocked contact:
![Snímek obrazovky z 2022-07-27 19-27-40](https://user-images.githubusercontent.com/5377645/181347416-3be5aa4e-4e45-44c7-96f5-bee944076a51.png)

