### PR TITLE
fix(chat_section): reset activeItem when the last channel is removed

### DIFF
--- a/src/app/modules/main/chat_section/active_item.nim
+++ b/src/app/modules/main/chat_section/active_item.nim
@@ -24,12 +24,20 @@ QtObject:
   #################################################
   # Forward declaration section
   proc activeSubItemChanged(self: ActiveItem) {.signal.}
+  proc idChanged(self: ActiveItem) {.signal.}
 
   #################################################
 
   proc setActiveItemData*(self: ActiveItem, item: Item, subItem: SubItem) =
     self.item = item
     self.activeSubItem.setActiveSubItemData(subItem)
+    self.activeSubItemChanged()
+
+  # Used when there is no longer an active item (last channel was deleted)
+  proc resetActiveItemData*(self: ActiveItem) =
+    self.item = Item()
+    self.activeSubItem.setActiveSubItemData(SubItem())
+    self.idChanged()
     self.activeSubItemChanged()
 
   proc getId(self: ActiveItem): string {.slot.} =
@@ -39,6 +47,7 @@ QtObject:
 
   QtProperty[string] id:
     read = getId
+    notify = idChanged
 
   proc getIsSubItemActive(self: ActiveItem): bool {.slot.} =
     if(self.activeSubItem.getId().len > 0):

--- a/src/app/modules/main/chat_section/controller.nim
+++ b/src/app/modules/main/chat_section/controller.nim
@@ -252,7 +252,9 @@ proc setActiveItemSubItem*(self: Controller, itemId: string, subItemId: string) 
   self.activeItemId = itemId
   self.activeSubItemId = subItemId
 
-  self.messageService.asyncLoadInitialMessagesForChat(self.getActiveChatId())
+  let chatId = self.getActiveChatId()
+  if chatId != "":
+    self.messageService.asyncLoadInitialMessagesForChat(chatId)
 
   # We need to take other actions here like notify status go that unviewed mentions count is updated and so...
 

--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -2,7 +2,7 @@ import NimQml, Tables, chronicles, json, sequtils, strutils, strformat, sugar
 
 import io_interface
 import ../io_interface as delegate_interface
-import view, controller, item, sub_item, sub_model, base_item
+import view, controller, item, sub_item, sub_model, base_item, active_item
 import model as chats_model
 import ../../shared_models/user_item as user_item
 import ../../shared_models/user_model as user_model
@@ -310,6 +310,10 @@ method makeChatWithIdActive*(self: Module, chatId: string) =
   self.setActiveItemSubItem(item.BaseItem.id, subItemId)
 
 method activeItemSubItemSet*(self: Module, itemId: string, subItemId: string) =
+  if (itemId == "" and subItemId == ""):
+    self.view.activeItem().resetActiveItemData()
+    return
+
   let item = self.view.chatsModel().getItemById(itemId)
   if(item.isNil):
     # Should never be here
@@ -492,6 +496,7 @@ method onCommunityCategoryDeleted*(self: Module, cat: Category) =
 
 method setFirstChannelAsActive*(self: Module) =
   if(self.view.chatsModel().getCount() == 0):
+    self.setActiveItemSubItem("", "")
     return
   let item = self.view.chatsModel().getItemAtIndex(0)
   if(item.subItems.getCount() == 0):

--- a/src/app/modules/main/chat_section/view.nim
+++ b/src/app/modules/main/chat_section/view.nim
@@ -120,6 +120,9 @@ QtObject:
   proc setActiveItem*(self: View, itemId: string, subItemId: string = "") {.slot.} =
     self.delegate.setActiveItemSubItem(itemId, subItemId)
 
+  proc activeItem*(self: View): ActiveItem =
+    result = self.activeItem
+
   # Since we cannot return QVariant from the proc which has arguments, so cannot have proc like this:
   # prepareChatContentModuleForChatId(self: View, chatId: string): QVariant {.slot.}
   # we're using combinaiton of


### PR DESCRIPTION
### What does the PR do

Fixes #6536

This doesn't fix the exact issue stated in the ticket, because I couldn't reproduce the same symptom, but I did have a problem with the same step.

My problem was that when leaving a channel and then rejoining the same one, the right panel (messages) would stay empty.

The reason was that when we leave a channel, we usually change the active item to the first channel in the list, but if there is no other channel, because we left the last channel, the active item stays the same. ie if you left `#test` as the last channel you ever had, the active item `id` would stay as `#test`, so when rejoining `#test`, the activeChannel props wouldn't update, since the ID is the same.
