### PR TITLE
feat(@desktop/wallet): Send modal should work as a wizard

### DIFF
--- a/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
@@ -390,7 +390,6 @@ Item {
         id: cmpSendTransactionWithEns
         SendModal {
             id: sendTransactionWithEns
-            anchors.centerIn: parent
             store: root.rootStore
             contactsStore: root.contactsStore
             onClosed: {

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -857,7 +857,6 @@ Item {
             }
             property var selectedAccount
             sourceComponent: SendModal {
-                anchors.centerIn: parent
                 store: appMain.rootStore
                 contactsStore: appMain.rootStore.profileSectionStore.contactsStore
                 onClosed: {

--- a/ui/imports/shared/controls/BalanceExceeded.qml
+++ b/ui/imports/shared/controls/BalanceExceeded.qml
@@ -16,15 +16,18 @@ ColumnLayout {
     property bool transferPossible: false
     property double amountToSend: 0
 
+    visible: !balancedExceededError.transferPossible && balancedExceededError.amountToSend > 0
+
     StatusIcon {
+        Layout.preferredHeight: 20
+        Layout.preferredWidth: 20
         Layout.alignment: Qt.AlignHCenter
-        visible: !balancedExceededError.transferPossible && balancedExceededError.amountToSend > 0
         icon: "cancel"
         color: Theme.palette.dangerColor1
     }
     StatusBaseText {
         Layout.alignment: Qt.AlignHCenter
-        font.pixelSize: 15
+        font.pixelSize: 13
         verticalAlignment: Text.AlignVCenter
         horizontalAlignment: Text.AlignHCenter
         color: Theme.palette.dangerColor1

--- a/ui/imports/shared/controls/GasSelector.qml
+++ b/ui/imports/shared/controls/GasSelector.qml
@@ -176,6 +176,7 @@ Item {
         font.weight: Font.Medium
         font.pixelSize: 13
         color: Style.current.textColor
+        visible: root.suggestedFees.eip1559Enabled && advancedMode
     }
 
     StyledText {
@@ -193,6 +194,7 @@ Item {
     StatusButton {
         anchors.verticalCenter: prioritytext.verticalCenter
         anchors.right: parent.right
+        anchors.rightMargin: Style.current.bigPadding
         height: 22
         defaultTopPadding: 2
         defaultBottomPadding: 2

--- a/ui/imports/shared/controls/GasValidator.qml
+++ b/ui/imports/shared/controls/GasValidator.qml
@@ -2,6 +2,9 @@ import QtQuick 2.13
 import QtQuick.Controls 2.13
 import QtQuick.Layouts 1.13
 
+import StatusQ.Core 0.1
+import StatusQ.Core.Theme 0.1
+
 import utils 1.0
 import "../status"
 import "../"
@@ -10,7 +13,7 @@ import "../panels"
 // TODO: use StatusQ components here
 Column {
     id: root
-    anchors.horizontalCenter: parent.horizontalCenter
+
     visible: !isValid
     spacing: 5
 
@@ -29,11 +32,10 @@ Column {
     onSelectedNetworkChanged: validate()
 
     function validate() {
-        let isValid = true
+        let isValid = false
         if (!(selectedAccount && selectedAccount.assets && selectedAsset && selectedGasEthValue > 0)) {
             return root.isValid
         }
-        isValid = true
         let gasTotal = selectedGasEthValue
         if (selectedAsset && selectedAsset.symbol && selectedAsset.symbol.toUpperCase() === "ETH") {
             gasTotal += selectedAmount
@@ -41,21 +43,18 @@ Column {
         const chainId = (selectedNetwork && selectedNetwork.chainId) || Global.currentChainId
 
         const currAcctGasAsset = Utils.findAssetByChainAndSymbol(chainId, selectedAccount.assets, "ETH")
-        if (currAcctGasAsset && currAcctGasAsset.totalBalance < gasTotal) {
-            isValid = false
+        if (currAcctGasAsset && currAcctGasAsset.totalBalance > gasTotal) {
+            isValid = true
         }
         root.isValid = isValid
         return isValid
     }
-    SVGImage {
-        id: imgExclamation
-        width: 13.33
-        height: 13.33
-        sourceSize.height: height * 2
-        sourceSize.width: width * 2
+    StatusIcon {
         anchors.horizontalCenter: parent.horizontalCenter
-        fillMode: Image.PreserveAspectFit
-        source: Style.svg("exclamation_outline")
+        height: 20
+        width: 20
+        icon: "cancel"
+        color: Theme.palette.dangerColor1
     }
     StyledText {
         id: txtValidationError

--- a/ui/imports/shared/popups/SignTransactionModal.qml
+++ b/ui/imports/shared/popups/SignTransactionModal.qml
@@ -179,6 +179,7 @@ StatusModal {
                 GasValidator {
                     id: gasValidator
                     anchors.top: gasSelector.bottom
+                    anchors.horizontalCenter: parent.horizontalCenter
                     selectedAccount: selectFromAccount.selectedAccount
                     selectedAmount: parseFloat(root.selectedAmount)
                     selectedAsset: root.selectedAsset

--- a/ui/imports/shared/status/StatusETHTransactionModal.qml
+++ b/ui/imports/shared/status/StatusETHTransactionModal.qml
@@ -133,6 +133,7 @@ ModalPopup {
             GasValidator {
                 id: gasValidator
                 anchors.top: gasSelector.bottom
+                anchors.horizontalCenter: parent.horizontalCenter
                 selectedAccount: selectFromAccount.selectedAccount
                 selectedAsset: root.asset
                 selectedAmount: 0

--- a/ui/imports/shared/status/StatusSNTTransactionModal.qml
+++ b/ui/imports/shared/status/StatusSNTTransactionModal.qml
@@ -151,6 +151,7 @@ ModalPopup {
             GasValidator {
                 id: gasValidator
                 anchors.top: gasSelector.bottom
+                anchors.horizontalCenter: parent.horizontalCenter
                 selectedAccount: selectFromAccount.selectedAccount
                 selectedAsset: root.asset
                 selectedAmount: parseFloat(root.assetPrice)

--- a/ui/imports/shared/views/NetworkSelector.qml
+++ b/ui/imports/shared/views/NetworkSelector.qml
@@ -70,6 +70,7 @@ Item {
                 anchors.top: parent.top
                 anchors.left: parent.left
                 anchors.margins: Style.current.padding
+                width: stackLayout.width  - Style.current.bigPadding
                 selectedNetwork: root.selectedNetwork
                 suggestedRoutes: root.suggestedRoutes
                 amountToSend: root.amountToSend

--- a/ui/imports/shared/views/NetworksSimpleRoutingView.qml
+++ b/ui/imports/shared/views/NetworksSimpleRoutingView.qml
@@ -30,6 +30,7 @@ RowLayout {
     }
     ColumnLayout {
         Layout.alignment: Qt.AlignTop
+        Layout.preferredWidth: networksSimpleRoutingView.width
         StatusBaseText {
             Layout.maximumWidth: 410
             font.pixelSize: 15
@@ -46,8 +47,9 @@ RowLayout {
             wrapMode: Text.WordWrap
         }
         BalanceExceeded {
+            Layout.fillWidth: true
+            Layout.alignment: Qt.AlignHCenter
             Layout.topMargin: Style.current.bigPadding
-            Layout.alignment: Qt.AlignCenter
             visible: !transferPossible
             transferPossible: networksSimpleRoutingView.suggestedRoutes ? networksSimpleRoutingView.suggestedRoutes.length > 0 : false
             amountToSend: networksSimpleRoutingView.amountToSend

--- a/ui/imports/shared/views/TabAddressSelectorView.qml
+++ b/ui/imports/shared/views/TabAddressSelectorView.qml
@@ -25,6 +25,11 @@ Item {
 
     signal contactSelected(string address, int type)
 
+    QtObject {
+        id: d
+        readonly property int maxHeightForList: 281
+    }
+
     StatusTabBar {
         id: accountSelectionTabBar
         anchors.top: parent.top
@@ -68,7 +73,7 @@ Item {
                 anchors.horizontalCenter: parent.horizontalCenter
                 anchors.top: parent.top
                 implicitWidth: parent.width
-                height: Math.min(288, savedAddresses.contentHeight)
+                height: Math.min(d.maxHeightForList, savedAddresses.contentHeight)
 
                 model: root.store.savedAddressesModel
                 header:  savedAddresses.count > 0 ? search : nothingInList
@@ -139,7 +144,7 @@ Item {
                 anchors.horizontalCenter: parent.horizontalCenter
                 anchors.top: parent.top
                 width: parent.width
-                height: Math.min(288, myAccounts.contentHeight)
+                height: Math.min(d.maxHeightForList, myAccounts.contentHeight)
 
                 delegate: StatusListItem {
                     implicitWidth: parent.width
@@ -172,7 +177,7 @@ Item {
                 anchors.horizontalCenter: parent.horizontalCenter
                 anchors.top: parent.top
                 width: parent.width
-                height: Math.min(288, recents.contentHeight)
+                height: Math.min(d.maxHeightForList, recents.contentHeight)
 
                 header: StatusBaseText {
                     height: visible ? 56 : 0


### PR DESCRIPTION
fixes #6587

statusQ PR : https://github.com/status-im/StatusQ/pull/809

### What does the PR do

Use new StatusDialog instead of StatusModal which is deprecated now
Make the SendModal work as a wizard.

### Affected areas

Wallet

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

https://user-images.githubusercontent.com/60327365/181508724-1879ea66-77c6-4135-980e-aa68b6f5beeb.mov


