### PR TITLE
fix(chat-test): fix ChatFlow test that blocked because of the inputs

### DIFF
--- a/test/ui-test/src/screens/StatusMainScreen.py
+++ b/test/ui-test/src/screens/StatusMainScreen.py
@@ -26,7 +26,7 @@ class MainScreenComponents(Enum):
 
 class ChatNamePopUp(Enum):
     CHAT_NAME_TEXT = "chat_name_PlaceholderText"
-    INPUT_ROOM_TOPIC_TEXT = "inputValue_StyledTextField"
+    INPUT_ROOM_TOPIC_TEXT = "joinPublicChat_input"
     START_CHAT_BTN = "startChat_Btn"
 
 

--- a/test/ui-test/testSuites/suite_status/shared/scripts/names.py
+++ b/test/ui-test/testSuites/suite_status/shared/scripts/names.py
@@ -43,7 +43,7 @@ o_Rectangle_2 = {"container": statusDesktop_mainWindow_overlay, "type": "Rectang
 mainWindow_statusIcon_StatusIcon = {"container": statusDesktop_mainWindow, "id": "statusIcon", "source": "qrc:/StatusQ/src/assets/img/icons/arrow-right.svg", "type": "StatusIcon", "unnamed": 1, "visible": True}
 join_public_chat_StatusMenuItemDelegate = {"checkable": False, "container": statusDesktop_mainWindow_overlay, "enabled": True, "text": "Join public chat", "type": "StatusMenuItemDelegate", "unnamed": 1, "visible": True}
 chat_name_PlaceholderText = {"container": statusDesktop_mainWindow_overlay, "text": "chat-name", "type": "PlaceholderText", "unnamed": 1, "visible": True}
-inputValue_StyledTextField = {"container": statusDesktop_mainWindow_overlay, "echoMode": 0, "id": "inputValue", "type": "StyledTextField", "unnamed": 1, "visible": True}
+joinPublicChat_input = {"container": statusDesktop_mainWindow_overlay, "objectName": "joinPublicChannelInput", "type": "TextEdit", "visible": True}
 reactionImage_SVGImage = {"container": statusDesktop_mainWindow_overlay, "id": "reactionImage", "source": "qrc:/imports/assets/icons/emojiReactions/heart.svg", "type": "SVGImage", "unnamed": 1, "visible": True}
 mainWindow_statusIcon_StatusIcon_2 = {"container": statusDesktop_mainWindow, "id": "statusIcon", "source": "qrc:/StatusQ/src/assets/img/icons/public-chat.svg", "type": "StatusIcon", "unnamed": 1, "visible": True}
 import_a_seed_phrase_StatusBaseText = {"container": statusDesktop_mainWindow, "text": "Import a seed phrase", "type": "StatusBaseText", "unnamed": 1, "visible": True}
@@ -224,7 +224,7 @@ createChatView_confirmBtn = {"container": statusDesktop_mainWindow, "objectName"
 # Chat view region:
 chatView_log = {"container": statusDesktop_mainWindow, "objectName": "chatLogView", "type": "StatusListView", "visible": True}
 chatView_StatusChatInfoButton = {"container": statusDesktop_mainWindow, "objectName": "chatInfoBtnInHeader", "type": "StatusChatInfoButton"}
-chatView_messageInput = {"container": mainWindow_scrollView_ScrollView, "objectName": "messageInputField", "type": "TextArea", "visible": True}
+chatView_messageInput = {"container": statusDesktop_mainWindow, "objectName": "messageInputField", "type": "TextArea", "visible": True}
 
 # Community chat region
 mainWindow_communityHeader_StatusChatInfoButton = {"container": statusDesktop_mainWindow, "objectName": "communityHeaderButton", "type": "StatusChatInfoButton", "visible": True}

--- a/ui/app/AppLayouts/Chat/popups/PublicChatPopup.qml
+++ b/ui/app/AppLayouts/Chat/popups/PublicChatPopup.qml
@@ -7,6 +7,7 @@ import shared.controls 1.0
 
 import StatusQ.Core 0.1
 import StatusQ.Controls 0.1
+import StatusQ.Controls.Validators 0.1
 
 import shared.panels 1.0
 import shared.popups 1.0
@@ -15,19 +16,11 @@ import "../panels"
 
 // TODO: replace with StatusModal
 ModalPopup {
-    property string channelNameValidationError: ""
     signal joinPublicChat(string name)
     signal suggestedMessageClicked(string channel)
     function validate() {
-        if (channelName.text === "") {
-            channelNameValidationError = qsTr("You need to enter a channel name")
-        } else if (!Utils.isValidChannelName(channelName.text)) {
-            channelNameValidationError = qsTr("The channel name can only contain lowercase letters, numbers and dashes")
-        } else {
-            channelNameValidationError = ""
-        }
-
-        return channelNameValidationError === ""
+        channelName.validate(true)
+        return channelName.valid
     }
 
     function doJoin() {
@@ -43,7 +36,7 @@ ModalPopup {
 
     onOpened: {
         channelName.text = "";
-        channelName.forceActiveFocus(Qt.MouseFocusReason)
+        channelName.input.edit.forceActiveFocus(Qt.MouseFocusReason)
     }
 
     Row {
@@ -61,15 +54,25 @@ ModalPopup {
         }
     }
 
-    Input {
+    StatusInput {
         id: channelName
+        input.edit.objectName: "joinPublicChannelInput"
         anchors.top: description.bottom
         anchors.topMargin: Style.current.padding
         placeholderText: qsTr("chat-name")
         Keys.onEnterPressed: doJoin()
         Keys.onReturnPressed: doJoin()
-        icon: Style.svg("hash")
-        validationError: channelNameValidationError
+        input.icon.name: "channel"
+        validators: [StatusMinLengthValidator {
+            minLength: 1
+            errorMessage: qsTr("You need to enter a channel name")
+        },
+        StatusValidator {
+            name: "validChannelNameValidator"
+            validate: function (t) { return Utils.isValidChannelName(t) }
+            errorMessage: qsTr("The channel name can only contain lowercase letters, numbers and dashes")
+        }]
+        validationMode: StatusInput.ValidationMode.OnlyWhenDirty
     }
 
     StatusScrollView {


### PR DESCRIPTION
Fixes the ChatFlow tets that were failing because the name for the channel name wasn't set and because the container for the message input wasn't valid.

For the channel name, I changed the type of Input to StatusInput, since Input is deprecated.

StatusQ PR: https://github.com/status-im/StatusQ/pull/813