### PR TITLE
test(chat): add test to mark as read

### DIFF
--- a/test/ui-test/src/drivers/SquishDriver.py
+++ b/test/ui-test/src/drivers/SquishDriver.py
@@ -73,6 +73,14 @@ def click_obj(obj):
     except LookupError:
         return False
 
+# It executes the right-click action into the given object:
+def right_click_obj(obj):
+    try:
+        squish.mouseClick(obj, squish.Qt.RightButton)
+        return True
+    except LookupError:
+        return False
+
 def get_obj(objName: str):
     obj = squish.findObject(getattr(names, objName))
     return obj

--- a/test/ui-test/src/screens/StatusMainScreen.py
+++ b/test/ui-test/src/screens/StatusMainScreen.py
@@ -23,6 +23,7 @@ class MainScreenComponents(Enum):
     WALLET_BUTTON = "wallet_navbar_wallet_icon_StatusIcon"
     START_CHAT_BTN = "mainWindow_startChat"
     CHAT_LIST = "chatList_Repeater"
+    MARK_AS_READ_BUTTON = "mark_as_Read_StatusMenuItemDelegate"
 
 class ChatNamePopUp(Enum):
     CHAT_NAME_TEXT = "chat_name_PlaceholderText"
@@ -54,7 +55,7 @@ class StatusMainScreen:
         [loaded, chat_button] = self._find_chat(chatName)
         if loaded:
             click_obj(chat_button)
-        verify(loaded, "Trying to get chat: " + chatName)     
+        verify(loaded, "Trying to get chat: " + chatName)
         
     def _find_chat(self, chatName: str):
         [loaded, chat_lists] = is_loaded(MainScreenComponents.CHAT_LIST.value)
@@ -65,3 +66,9 @@ class StatusMainScreen:
                     return True, chat        
         return False, None
 
+    def mark_as_read(self, chatName: str):
+        [loaded, chat_button] = self._find_chat(chatName)
+        if loaded:
+            right_click_obj(chat_button)
+        
+        click_obj_by_name(MainScreenComponents.MARK_AS_READ_BUTTON.value)

--- a/test/ui-test/testSuites/suite_status/shared/scripts/names.py
+++ b/test/ui-test/testSuites/suite_status/shared/scripts/names.py
@@ -213,6 +213,8 @@ accountsView_accountListPanel = {"container": statusDesktop_mainWindow, "type": 
 
 # Main Window - chat related:
 chatList_Repeater = {"container": statusDesktop_mainWindow, "objectName": "chatListItems", "type": "Repeater"}
+mark_as_Read_StatusMenuItemDelegate = {"container": statusDesktop_mainWindow_overlay, "objectName": "chatMarkAsReadMenuItem", "type": "StatusMenuItemDelegate", "visible": True}
+
 
 # Join chat popup:
 startChat_Btn = {"container": statusDesktop_mainWindow_overlay, "objectName": "startChatButton", "type": "StatusButton"}

--- a/test/ui-test/testSuites/suite_status/shared/steps/chatSteps.py
+++ b/test/ui-test/testSuites/suite_status/shared/steps/chatSteps.py
@@ -53,3 +53,7 @@ def step(context, message):
 def step(context, message_index, message):
     _statusChat.reply_to_message_at_index(message_index, message)
     _statusChat.verify_last_message_sent(message)
+
+@Then("the user can mark the channel |any| as read")
+def step(context, channel):
+    _statusMain.mark_as_read(channel)

--- a/test/ui-test/testSuites/suite_status/tst_ChatFlow/test.feature
+++ b/test/ui-test/testSuites/suite_status/tst_ChatFlow/test.feature
@@ -22,6 +22,7 @@ Feature: Status Desktop Chat
 		 | I am from status   	 |
 		 | tell me how you do?   |
 
+
     Scenario: User can reply to their own message
          When user joins chat room test
          Then user is able to send chat message
@@ -29,7 +30,14 @@ Feature: Status Desktop Chat
          | Reply to this         |
          Then the user can reply to the message at index 0 with "This is a reply"
 
+
     # TODO This test has a chance to fail since it relies on the mailserver. Until we host a local mailserver for the tests, this test is at risk
     Scenario: User can reply to another user's message
          When user joins chat room test
          Then the user can reply to the message at index 0 with "This is a reply to another user"
+
+
+    Scenario: User joins a room and marks it as read
+		 When user joins chat room test
+		 Then the user can mark the channel test as read
+         # TODO find a way to validate that it worked

--- a/ui/app/AppLayouts/Chat/views/ChatContextMenuView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatContextMenuView.qml
@@ -117,6 +117,7 @@ StatusPopupMenu {
     }
 
     StatusMenuItem {
+        objectName: "chatMarkAsReadMenuItem"
         text: qsTr("Mark as Read")
         icon.name: "checkmark-circle"
         onTriggered: {


### PR DESCRIPTION
Fixes #6671

Sadly,  I don't know how to test if it worked, since there is no indicator that the process worked.
We can check if the "new message" indicator is gone, but just joining the channel does that.
Maybe if we ever make it possible to have multiple instances at once, then we could send a message in the channel and then mark as read.

Branched on top of https://github.com/status-im/status-desktop/pull/6701
