### PR TITLE
fix(CommunityIntroMessageInput): input height was set to 0

### DIFF
--- a/ui/app/AppLayouts/Chat/controls/community/CommunityIntroMessageInput.qml
+++ b/ui/app/AppLayouts/Chat/controls/community/CommunityIntroMessageInput.qml
@@ -15,11 +15,9 @@ StatusInput {
     label: qsTr("Community introduction and rules")
     charLimit: 1400
 
-    input.multiline: true
-    minimumHeight: 400
-    maximumHeight: 400
+    multiline: true
 
-    input.placeholder.text: qsTr("What new members will read before joining (eg. community rules, welcome message, etc.). Members will need to tick a check box agreeing to these rules before they are allowed to join your community.")
+    placeholderText: qsTr("What new members will read before joining (eg. community rules, welcome message, etc.). Members will need to tick a check box agreeing to these rules before they are allowed to join your community.")
     input.placeholder.wrapMode: Text.WordWrap
 
     input.verticalAlignment: TextEdit.AlignTop

--- a/ui/app/AppLayouts/Chat/controls/community/CommunityOutroMessageInput.qml
+++ b/ui/app/AppLayouts/Chat/controls/community/CommunityOutroMessageInput.qml
@@ -15,7 +15,7 @@ StatusInput {
     label: qsTr("Leaving community message")
     charLimit: 80
 
-    input.placeholder.text: qsTr("The message a member will see when they leave your community")
+    placeholderText: qsTr("The message a member will see when they leave your community")
     input.placeholder.wrapMode: Text.WordWrap
 
     validators: [

--- a/ui/app/AppLayouts/Chat/panels/communities/CommunityEditSettingsPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/CommunityEditSettingsPanel.qml
@@ -142,6 +142,8 @@ StatusScrollView {
         CommunityIntroMessageInput {
             id: introMessageTextInput
             Layout.fillWidth: true
+            minimumHeight: 108
+            maximumHeight: 108
         }
 
         CommunityOutroMessageInput {

--- a/ui/app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml
+++ b/ui/app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml
@@ -128,8 +128,7 @@ StatusStackModal {
         },
         ColumnLayout {
             id: introOutroMessageView
-            spacing: 12
-
+            spacing: 11
             CommunityIntroMessageInput {
                 id: introMessageInput
                 input.edit.objectName: "createCommunityIntroMessageInput"
@@ -137,7 +136,8 @@ StatusStackModal {
                 Layout.fillWidth: true
                 Layout.fillHeight: true
 
-                maximumHeight: 0
+                minimumHeight: height
+                maximumHeight: (height - Style.current.xlPadding)
             }
 
             CommunityOutroMessageInput {


### PR DESCRIPTION
Closes #6697

### What does the PR do
fixed CommunityIntroMessageInput input height was set to 0

### Affected areas
create communities

### Screenshot of functionality (including design for comparison)
https://user-images.githubusercontent.com/31625338/181811770-e83e5b91-4f15-43e8-85bc-aae5d0afae46.mov


