### PR TITLE
fix(cpp): make libraries which are not dynamically loaded static

### DIFF
--- a/resources/CMakeLists.txt
+++ b/resources/CMakeLists.txt
@@ -16,6 +16,7 @@ qt6_standard_project_setup()
 qt6_add_qml_module(${PROJECT_NAME}
     URI Status.StaticConfig
     VERSION 1.0
+    STATIC
     RESOURCES
         default-networks.json
         fleets.json

--- a/ui/fonts/CMakeLists.txt
+++ b/ui/fonts/CMakeLists.txt
@@ -15,6 +15,7 @@ qt6_standard_project_setup()
 qt6_add_qml_module(${PROJECT_NAME}
     URI Status.FontsAssets
     VERSION 1.0
+    STATIC
     # TODO: temporary until we make qt_target_qml_sources work
     RESOURCES
         Inter/Inter-Regular.otf

--- a/ui/imports/assets/CMakeLists.txt
+++ b/ui/imports/assets/CMakeLists.txt
@@ -15,6 +15,7 @@ qt6_standard_project_setup()
 qt6_add_qml_module(${PROJECT_NAME}
     URI Status.UiAssets
     VERSION 1.0
+    STATIC
     # TODO: temporary until we make qt_target_qml_sources work
     RESOURCES
         gif/status_splash_dark.gif


### PR DESCRIPTION
Otherwise, linker will optimize resources registration code on Linux,
resulting in resources loading failure.
