### PR TITLE
fix(community): Send community invitation fixed

### DIFF
--- a/ui/app/AppLayouts/Chat/views/CommunitySettingsView.qml
+++ b/ui/app/AppLayouts/Chat/views/CommunitySettingsView.qml
@@ -228,7 +228,7 @@ StatusAppTwoPanelLayout {
             }
 
             onSendInvites: {
-                const error = root.communitySectionModule.inviteUsersToCommunity(JSON.stringify(pubKeys))
+                const error = root.chatCommunitySectionModule.inviteUsersToCommunity(JSON.stringify(pubKeys))
                 processInviteResult(error)
             }
         }


### PR DESCRIPTION
### What does the PR do

Fixes #6696 

Invitation message is sent as expected.

### Affected areas

CommunitySettingsView

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

https://user-images.githubusercontent.com/20650004/181734333-0e0ecbd6-aadf-43ec-b709-baf9beffc671.mp4


