### PR TITLE
fix(@desktop/profile) fix renaming popup calls

### DIFF
--- a/ui/imports/shared/popups/ProfilePopup.qml
+++ b/ui/imports/shared/popups/ProfilePopup.qml
@@ -113,7 +113,7 @@ StatusModal {
         popup.open();
 
         if (state == "openNickname") {
-            nicknamePopup.open();
+            profileView.nicknamePopup.open();
         } else if (state == "contactRequest") {
             sendContactRequestModal.open()
         } else if (state == "blockUser") {
@@ -409,7 +409,7 @@ StatusModal {
             visible: showIdentityVerified || showIdentityVerifiedUntrustworthy
             text: qsTr("Rename")
             onClicked: {
-                nicknamePopup.open()
+                profileView.nicknamePopup.open()
             }
         },
 

--- a/ui/imports/shared/views/ProfileView.qml
+++ b/ui/imports/shared/views/ProfileView.qml
@@ -69,6 +69,7 @@ Rectangle {
     readonly property alias unblockContactConfirmationDialog: unblockContactConfirmationDialog
     readonly property alias blockContactConfirmationDialog: blockContactConfirmationDialog
     readonly property alias removeContactConfirmationDialog: removeContactConfirmationDialog
+    readonly property alias nicknamePopup: nicknamePopup
     readonly property alias wizardAnimation: wizardAnimation
     readonly property alias challengeTxt: challengeTxt
     readonly property alias stepsListModel: stepsListModel


### PR DESCRIPTION
Fixes #6541

### What does the PR do

Add missing alias to ProfileView in order to have possibility to open NicknamePopup from ProfilePopup.

### Affected areas

Desktop Chat

### Screenshot of functionality 

https://user-images.githubusercontent.com/6445843/181737903-1aa04ab6-67ce-4340-8079-da9f99cce8f3.mp4



