### PR TITLE
fix(AppSearch): Fix `forceActiveFocus` in StatusSearchPopup

### DIFF
--- a/ui/app/mainui/AppSearch.qml
+++ b/ui/app/mainui/AppSearch.qml
@@ -79,7 +79,6 @@ Item {
         }
         onOpened: {
             searchPopup.resetSearchSelection();
-            searchPopup.forceActiveFocus()
             appSearch.store.prepareLocationMenuModel()
 
             const jsonObj = appSearch.store.getSearchLocationObject()


### PR DESCRIPTION
Closes: #6638

[StatusQ PR](https://github.com/status-im/StatusQ/pull/818)

### What does the PR do

Fix warning in `onOpen` slot which stops method 

### Affected areas

AppSearch

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

<img width="760" alt="Снимок экрана 2022-08-01 в 17 48 52" src="https://user-images.githubusercontent.com/82511785/182176906-6d71526b-e8f0-414f-aad5-fc8cdfce2bcc.png">

