### PR TITLE
fix(@desktop/chat) keep message hover effect while context menu open

### DIFF
--- a/ui/imports/shared/views/chat/CompactMessageView.qml
+++ b/ui/imports/shared/views/chat/CompactMessageView.qml
@@ -113,6 +113,10 @@ Item {
         onHoverChanged: {
             hovered && setHovered(messageId, hovered)
         }
+        onSetMessageActive: {
+            root.setMessageActive(messageId, active)
+        }
+
         anchors.right: parent.right
         anchors.rightMargin: 20
         anchors.top: messageContainer.top
@@ -160,15 +164,11 @@ Item {
         }
     }
 
-    Loader {
-        active: typeof root.messageContextMenu !== "undefined"
-        sourceComponent: Component {
-            Connections {
-                enabled: isMessageActive
-                target: root.messageContextMenu
-                onClosed: root.setMessageActive(messageId, false)
-            }
-        }
+    Connections {
+        enabled: isHovered || isMessageActive
+        target: typeof root.messageContextMenu !== "undefined" ? root.messageContextMenu : null
+        onOpened: root.setMessageActive(messageId, true)
+        onClosed: root.setMessageActive(messageId, false)
     }
 
     DateGroup {

--- a/ui/imports/shared/views/chat/MessageContextMenuView.qml
+++ b/ui/imports/shared/views/chat/MessageContextMenuView.qml
@@ -185,7 +185,6 @@ StatusPopupMenu {
                     reactedByUser: !!root.emojiReactionsReactedByUser[model.emojiId]
                     onCloseModal: {
                         root.toggleReaction(root.messageId, emojiId)
-                        root.close()
                     }
                 }
             }


### PR DESCRIPTION
- keep context menu when emoji reaction clicked

Fixes #6633

### What does the PR do

Add missing handlers with setMessageActive calls.
Remove close call from emoji click handler.

### Affected areas

Desktop Chat

### Screenshot of functionality

https://user-images.githubusercontent.com/6445843/182192578-caa78873-badf-4366-93a2-7dfc32ce05c5.mp4


