### PR TITLE
fix(@desktop/wallet): Crash when staying on Advanced screen for ~30 minutes

### DIFF
--- a/ui/app/AppLayouts/stores/RootStore.qml
+++ b/ui/app/AppLayouts/stores/RootStore.qml
@@ -1,5 +1,7 @@
 import QtQuick 2.13
 
+import utils 1.0
+
 import "../Profile/stores"
 
 QtObject {
@@ -169,5 +171,12 @@ QtObject {
 
     function setActiveCommunity(communityId) {
         mainModule.setActiveSectionById(communityId);
+    }
+
+    function switchAccount(newIndex) {
+        if(Constants.isCppApp)
+            walletSectionAccounts.switchAccount(newIndex)
+        else
+            walletSection.switchAccount(newIndex)
     }
 }

--- a/ui/imports/shared/popups/SendModal.qml
+++ b/ui/imports/shared/popups/SendModal.qml
@@ -111,8 +111,11 @@ StatusDialog {
         anchors.topMargin: -height - 18
         model: popup.store.accounts
         selectedAccount: popup.selectedAccount
-        onUpdatedSelectedAccount: {
-            popup.selectedAccount = account
+        changeSelectedAccount: function(newIndex) {
+            if (newIndex > popup.store.accounts) {
+                return
+            }
+            popup.store.switchAccount(newIndex)
         }
     }
 

--- a/ui/imports/shared/views/SendModalHeader.qml
+++ b/ui/imports/shared/views/SendModalHeader.qml
@@ -19,6 +19,7 @@ StatusFloatingButtonsSelector {
     id: floatingHeader
 
     property var selectedAccount
+    property var changeSelectedAccount: function(){}
 
     repeater.objectName: "accountsListFloatingHeader"
     
@@ -50,7 +51,7 @@ StatusFloatingButtonsSelector {
             hoverColor: Theme.palette.statusFloatingButtonHighlight
             highlighted: index === floatingHeader.currentIndex
             onClicked: {
-                updatedSelectedAccount(model)
+                changeSelectedAccount(index)
                 floatingHeader.currentIndex = index
             }
             Component.onCompleted: {
@@ -73,8 +74,8 @@ StatusFloatingButtonsSelector {
                         floatingHeader.currentIndex = index
                     }
                     else {
+                        changeSelectedAccount(0)
                         floatingHeader.currentIndex = 0
-                        updatedSelectedAccount(d.firstModelData)
                     }
                 }
             }
@@ -91,7 +92,7 @@ StatusFloatingButtonsSelector {
         icon.isLetterIdenticon: !!model.emoji
         icon.background.color: Theme.palette.indirectColor1
         onClicked: {
-            updatedSelectedAccount(model)
+            changeSelectedAccount(index)
             floatingHeader.itemSelected(index)
         }
         visible: !floatingHeader.visibleIndices.includes(index) && walletType !== Constants.watchWalletType


### PR DESCRIPTION


fixes #6474

### What does the PR do

Fixes crash caused by current account not being set correctly on the UI.

### Affected areas

Wallet

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it
