### PR TITLE
fix(SeedPhraseInputView): sug list was clipped at bottom row

### DIFF
--- a/ui/app/AppLayouts/Onboarding/views/SeedPhraseInputView.qml
+++ b/ui/app/AppLayouts/Onboarding/views/SeedPhraseInputView.qml
@@ -120,6 +120,7 @@ Item {
                  "3", "7", "11", "15", "19", "23", "4", "8", "12", "16", "20", "24"]
             ]
             height: 312
+            clip: false
             anchors.left: parent.left
             anchors.leftMargin: 12
             anchors.top: switchTabBar.bottom


### PR DESCRIPTION
Closes 	#6608

### What does the PR do
Fixes Suggestions are not displayed for last row in seed modal

### Affected areas
SeedPhraseInputView

### Screenshot of functionality (including design for comparison)
<img width="1369" alt="seed" src="https://user-images.githubusercontent.com/31625338/182342424-b14f1ead-7f95-4890-ac8e-8839215ea63d.png">

