### PR TITLE
fix(CreateChatView): activity center button issues

### DIFF
--- a/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
@@ -58,6 +58,8 @@ Item {
     property bool contactRequestReceived: root.contactDetails.requestReceived
     property Component pinnedMessagesListPopupComponent
 
+    property alias activityCenter: activityCenter
+
     signal openAppSearch()
     signal openStickerPackPopup(string stickerPackId)
 

--- a/ui/app/AppLayouts/Chat/views/ChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatView.qml
@@ -25,6 +25,7 @@ StatusAppThreePanelLayout {
 
     property var contactsStore
     property bool hasAddedContacts: root.contactsStore.myContactsModel.count > 0
+    property alias activityCenter: chatColumn.activityCenter
 
     property RootStore rootStore
 

--- a/ui/app/AppLayouts/Chat/views/CreateChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/CreateChatView.qml
@@ -18,6 +18,7 @@ Page {
 
     property ListModel contactsModel: ListModel { }
     property var rootStore
+    property var activityCenter: null
     property var emojiPopup: null
 
     Keys.onEscapePressed: Global.closeCreateChatView()
@@ -78,9 +79,10 @@ Page {
     // TODO: Could it be replaced to `GroupChatPanel`?
     header: RowLayout {
         id: headerRow
+        width: parent.width
+        height: tagSelector.height
         anchors.top: parent.top
         anchors.topMargin: Style.current.halfPadding
-        height: tagSelector.height
         clip: true
         spacing: Style.current.padding
         StatusTagSelector {
@@ -124,13 +126,15 @@ Page {
         }
 
         Item {
-            implicitHeight: 32
-            implicitWidth: 32
+            Layout.preferredWidth: 32
+            Layout.preferredHeight: 32
             Layout.alignment: Qt.AlignTop
-
+            Layout.topMargin: 5
             StatusActivityCenterButton {
                 id: notificationButton
-                anchors.right: parent.right
+                width: parent.width
+                height: parent.height
+                tooltip.offset: width/2
                 unreadNotificationsCount: activityCenter.unreadNotificationsCount
                 onClicked: activityCenter.open()
             }

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -652,13 +652,14 @@ Item {
                     property bool opened: false
 
                     rootStore: chatLayoutContainer.rootStore
+                    activityCenter: chatLayoutContainer.chatView.activityCenter
                     emojiPopup: statusEmojiPopup
                     anchors.top: parent.top
                     anchors.topMargin: 8
                     anchors.rightMargin: 8
                     anchors.bottom: parent.bottom
                     anchors.right: parent.right
-                    width: chatLayoutContainer.chatView.width - chatLayoutContainer.chatView.leftPanel.width - anchors.rightMargin - anchors.leftMargin
+                    width: parent.width - chatLayoutContainer.chatView.leftPanel.width - anchors.rightMargin - anchors.leftMargin
                     visible: createChatView.opened
 
                     Connections {


### PR DESCRIPTION
Closes #6700

### What does the PR do
Fixes various activity center button issues
- tooltip arrow was missaligned
- activity center was not opening

** Also fixed create chat view width to follow its parent

### Affected areas
CreateChatView

### Screenshot of functionality (including design for comparison)
https://user-images.githubusercontent.com/31625338/182383518-afb5109d-852f-4910-bb83-43d968f7f83e.mov


