### PR TITLE
test(chat): add test to delete messages

### DIFF
--- a/test/ui-test/src/drivers/SquishDriverVerification.py
+++ b/test/ui-test/src/drivers/SquishDriverVerification.py
@@ -30,5 +30,11 @@ def verify_text_contains(text: str, substring: str):
         found = True
     verify(found, "Given substring: " + substring + " and complete text: " + text)
     
+def verify_text_does_not_contain(text: str, substring: str):
+    found = False
+    if substring in text:
+        found = True
+    verify(not found, "Given substring: " + substring + " and complete text: " + text)
+    
 def verify_text(text1: str, text2: str):
     test.compare(text1, text2, "Text 1: " + text1 + "\nText 2: " + text2)

--- a/test/ui-test/src/screens/StatusChatScreen.py
+++ b/test/ui-test/src/screens/StatusChatScreen.py
@@ -13,6 +13,7 @@ from enum import Enum
 from drivers.SquishDriver import *
 from drivers.SquishDriverVerification import *
 from drivers.SDKeyboardCommands import *
+from common.Common import *
 
 
 class ChatComponents(Enum):
@@ -22,6 +23,8 @@ class ChatComponents(Enum):
     LAST_MESSAGE_TEXT = "chatView_lastChatText_Text"
     MEMBERS_LISTVIEW = "chatView_chatMembers_ListView"
     REPLY_TO_MESSAGE_BUTTON = "chatView_replyToMessageButton"
+    DELETE_MESSAGE_BUTTON = "chatView_DeleteMessageButton"
+    CONFIRM_DELETE_MESSAGE_BUTTON = "chatButtonsPanelConfirmDeleteMessageButton_StatusButton"
 
 class ChatMessagesHistory(Enum):
     CHAT_CREATED_TEXT = 1
@@ -43,6 +46,13 @@ class StatusChatScreen:
         [loaded, last_message_obj] = is_loaded_visible_and_enabled(ChatComponents.LAST_MESSAGE_TEXT.value)
         verify(loaded, "Checking last message sent: " + message)
         verify_text_contains(str(last_message_obj.text), str(message))
+
+    def verify_last_message_sent_is_not(self, message: str):
+        [loaded, last_message_obj] = is_loaded_visible_and_enabled(ChatComponents.LAST_MESSAGE_TEXT.value)
+        if not loaded:
+            test.passes("Success: No message was found")
+            return
+        verify_text_does_not_contain(str(last_message_obj.text), str(message))
         
     def verify_chat_title(self, title: str):
         info_btn = get_obj(ChatComponents.TOOLBAR_INFO_BUTTON.value)
@@ -91,5 +101,19 @@ class StatusChatScreen:
                 user = membersList.itemAtIndex(index)
                 if(user.userName == member):
                     found = True
-                    break        
+                    break
         return found
+
+    def delete_message_at_index(self, index: int):
+        message_object_to_delete = get_obj(ChatComponents.CHAT_LOG.value).itemAtIndex(int(index))
+        hover_obj(message_object_to_delete)
+        click_obj_by_name(ChatComponents.DELETE_MESSAGE_BUTTON.value)
+        click_obj_by_name(ChatComponents.CONFIRM_DELETE_MESSAGE_BUTTON.value)
+
+    def cannot_delete_last_message(self):
+        [loaded, last_message_obj] = is_loaded_visible_and_enabled(ChatComponents.LAST_MESSAGE_TEXT.value)
+        if not loaded:
+            test.fail("No message found")
+            return 
+        hover_obj(last_message_obj)
+        object_not_enabled(ChatComponents.DELETE_MESSAGE_BUTTON.value)

--- a/test/ui-test/testSuites/suite_status/shared/scripts/sections/chat_names.py
+++ b/test/ui-test/testSuites/suite_status/shared/scripts/sections/chat_names.py
@@ -14,7 +14,9 @@ mainWindow_scrollView_ScrollView = {"container": statusDesktop_mainWindow, "id":
 chatView_messageInput = {"container": statusDesktop_mainWindow, "objectName": "messageInputField", "type": "TextArea", "visible": True}
 chatView_chatLogView_lastMsg_MessageView = {"container": chatView_log, "index": 0, "type": "MessageView"}
 chatView_lastChatText_Text = {"container": chatView_chatLogView_lastMsg_MessageView, "objectName": "chatText", "type": "StyledTextEdit"}
-chatView_replyToMessageButton = {"container": chatView_log, "objectName": "replyToMessageButton", "type": "StatusFlatRoundButton", "visible": True}
+chatView_replyToMessageButton = {"container": chatView_log, "objectName": "replyToMessageButton", "type": "StatusFlatRoundButton"}
+chatView_DeleteMessageButton = {"container": chatView_log, "objectName": "chatDeleteMessageButton", "type": "StatusFlatRoundButton"}
+chatButtonsPanelConfirmDeleteMessageButton_StatusButton = {"container": statusDesktop_mainWindow_overlay, "objectName": "chatButtonsPanelConfirmDeleteMessageButton", "type": "StatusButton"}
 mark_as_Read_StatusMenuItemDelegate = {"container": statusDesktop_mainWindow_overlay, "objectName": "chatMarkAsReadMenuItem", "type": "StatusMenuItemDelegate", "visible": True}
 
 # Join chat popup:

--- a/test/ui-test/testSuites/suite_status/shared/steps/chatSteps.py
+++ b/test/ui-test/testSuites/suite_status/shared/steps/chatSteps.py
@@ -1,4 +1,5 @@
 
+from drivers.SquishDriver import *
 from screens.StatusMainScreen import StatusMainScreen
 from screens.StatusChatScreen import StatusChatScreen
 from screens.StatusCreateChatScreen import StatusCreateChatScreen
@@ -57,3 +58,16 @@ def step(context, message_index, message):
 @Then("the user can mark the channel |any| as read")
 def step(context, channel):
     _statusMain.mark_as_read(channel)
+
+@Then("the user can delete the message at index |any|")
+def step(context, message_index):
+    _statusChat.delete_message_at_index(message_index)
+
+@Then("the user cannot delete the last message")
+def step(context):
+    _statusChat.cannot_delete_last_message()
+    
+@Then("the last message is not \"|any|\"")
+def step(context, message):
+    _statusChat.verify_last_message_sent_is_not(message)
+    

--- a/test/ui-test/testSuites/suite_status/tst_ChatFlow/test.feature
+++ b/test/ui-test/testSuites/suite_status/tst_ChatFlow/test.feature
@@ -41,3 +41,18 @@ Feature: Status Desktop Chat
 		 When user joins chat room test
 		 Then the user can mark the channel test as read
          # TODO find a way to validate that it worked
+
+
+    Scenario: User can delete their own message
+         When user joins chat room automation-test
+         Then user is able to send chat message
+         | message               |
+         | Delete this message   |
+         Then the user can delete the message at index 0
+         Then the last message is not "Delete this message"
+
+
+    # TODO This test has a chance to fail since it relies on the mailserver. Until we host a local mailserver for the tests, this test is at risk
+    Scenario: User cannot delete another user's message
+         When user joins chat room test
+         Then the user cannot delete the last message

--- a/ui/imports/shared/panels/chat/ChatButtonsPanel.qml
+++ b/ui/imports/shared/panels/chat/ChatButtonsPanel.qml
@@ -169,6 +169,7 @@ Rectangle {
             active: buttonsContainer.deleteButtonActive && !buttonsContainer.isInPinnedPopup
             sourceComponent: StatusFlatRoundButton {
                 id: deleteButton
+                objectName: "chatDeleteMessageButton"
                 width: 32
                 height: 32
                 type: StatusFlatRoundButton.Type.Tertiary
@@ -190,6 +191,7 @@ Rectangle {
             id: deleteMessageConfirmationDialogComponent
 
             ConfirmationDialog {
+                confirmButtonObjectName: "chatButtonsPanelConfirmDeleteMessageButton"
                 header.title: qsTr("Confirm deleting this message")
                 confirmationText: qsTr("Are you sure you want to delete this message? Be aware that other clients are not guaranteed to delete the message as well.")
                 height: 260


### PR DESCRIPTION
Fixes #6757

Same as with the reply test, there is a chance that the second test will fail because it relies on mailservers.

Branched on top of https://github.com/status-im/status-desktop/pull/6735