### PR TITLE
fix(Input): unable to place cursor using mouse

### DIFF
--- a/ui/imports/shared/controls/Input.qml
+++ b/ui/imports/shared/controls/Input.qml
@@ -110,14 +110,6 @@ Item {
             Keys.onPressed: {
                 inputBox.keyPressed(event);
             }
-
-            MouseArea {
-                anchors.fill: parent
-                acceptedButtons: Qt.RightButton | Qt.LeftButton
-                onClicked: {
-                    inputValue.forceActiveFocus(Qt.MouseFocusReason)
-                }
-            }
         }
 
         SVGImage {


### PR DESCRIPTION
drop a defunct MouseArea that was being used for a context menu which got
removed in the meantime; it breaks clicking inside the TextField

Closes: #5167

### What does the PR do

Fixes being unable to place cursor in (esp. password) fields 

### Affected areas

Input

### Screenshot of functionality (including design for comparison)

- [n/a] I've checked the design and this PR matches it
