### PR TITLE
fix(communities): Chat model reordering refactored, updates fixed 

### DIFF
--- a/src/app/modules/main/chat_section/model.nim
+++ b/src/app/modules/main/chat_section/model.nim
@@ -52,11 +52,6 @@ QtObject:
       [{i}]:({$self.items[i]})
       """
 
-  proc sortChats(x, y: Item): int =
-    if x.position < y.position: -1
-    elif x.position == y.position: 0
-    else: 1
-
   proc countChanged(self: Model) {.signal.}
 
   proc getCount*(self: Model): int {.slot.} =
@@ -180,16 +175,6 @@ QtObject:
     self.beginRemoveRows(parentModelIndex, idx, idx)
     self.items.delete(idx)
     self.endRemoveRows()
-
-    self.countChanged()
-
-  proc prependItem*(self: Model, item: Item) =
-    let parentModelIndex = newQModelIndex()
-    defer: parentModelIndex.delete
-
-    self.beginInsertRows(parentModelIndex, 0, 0)
-    self.items = item & self.items
-    self.endInsertRows()
 
     self.countChanged()
 
@@ -334,11 +319,13 @@ QtObject:
     if(index == -1):
       return
 
+    if(self.items[index].BaseItem.position == position):
+      return
+
     self.items[index].BaseItem.position = position
 
-    self.beginResetModel()
-    self.items.sort(sortChats)
-    self.endResetModel()
+    let modelIndex = self.createIndex(index, 0, nil)
+    self.dataChanged(modelIndex, modelIndex, @[ModelRole.Position.int])
 
   proc clearItems*(self: Model) =
     self.beginResetModel()

--- a/src/app/modules/main/view.nim
+++ b/src/app/modules/main/view.nim
@@ -163,7 +163,7 @@ QtObject:
 
   # Since we cannot return QVariant from the proc which has arguments, so cannot have proc like this:
   # prepareCommunitySectionModuleForCommunityId(self: View, communityId: string): QVariant {.slot.}
-  # we're using combinaiton of
+  # we're using combination of
   # prepareCommunitySectionModuleForCommunityId/getCommunitySectionModule procs
   proc prepareCommunitySectionModuleForCommunityId*(self: View, communityId: string) {.slot.} =
     self.tmpCommunityId = communityId


### PR DESCRIPTION
### What does the PR do

Fixes: #6597
Fixes: #6722
Fixes: #6777

The chats model is not reordered internally in backend, reordering is done on qml side by SortFilterProxyModel. When user requests reorder, only position is updated in the model instead of sorting items and resetting the whole model.

### Affected areas

chat section model, community service

### Screenshot of functionality (including design for comparison)

https://user-images.githubusercontent.com/20650004/182590609-f951dafc-a718-41f2-afb7-418951ed65e2.mp4


