### PR TITLE
fix(@desktop/community) adjust color picker

### DIFF
--- a/ui/app/AppLayouts/CommunitiesPortal/panels/CommunityColorPanel.qml
+++ b/ui/app/AppLayouts/CommunitiesPortal/panels/CommunityColorPanel.qml
@@ -84,7 +84,7 @@ StatusScrollView {
         }
 
         StatusBaseText {
-            text: qsTr("White text should be legible on top of this color")
+            text: qsTr("Preview")
             font.pixelSize: 15
         }
 
@@ -98,7 +98,7 @@ StatusScrollView {
                 id: preview
                 x: 16
                 y: 16
-                text: root.color.toString()
+                text: qsTr("White text should be legible on top of this color")
                 color: Theme.palette.white
                 font.pixelSize: 15
             }


### PR DESCRIPTION
Fixes #6728

### What does the PR do

Adjust the text in Community color picker

### Affected areas

Desktop Community 

### Screenshot of functionality (including design for comparison)

Expected

![image](https://user-images.githubusercontent.com/6445843/182609336-48aea1bb-2be7-44a8-a8c8-d00a8cedca4a.png)

- [x] I've checked the design and this PR matches it

Actual

https://user-images.githubusercontent.com/6445843/182609173-957daa75-4af7-4aed-8bdc-5ee8332314ee.mp4


