### PR TITLE
fix(PublicChatPopup): sug channels were missaligned

### DIFF
--- a/ui/app/AppLayouts/Chat/panels/SuggestedChannelsPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/SuggestedChannelsPanel.qml
@@ -26,11 +26,9 @@ Repeater {
             font.pixelSize: 16
         }
         Flow {
+            width: parent.width
             anchors.top: sectionTitle.bottom
             anchors.topMargin: Style.current.smallPadding
-            Layout.fillHeight: true
-            Layout.fillWidth: true
-            width: parent.width
             spacing: 10
             Repeater {
                 model: modelData.channels

--- a/ui/app/AppLayouts/Chat/popups/PublicChatPopup.qml
+++ b/ui/app/AppLayouts/Chat/popups/PublicChatPopup.qml
@@ -83,11 +83,8 @@ ModalPopup {
         anchors.left: parent.left
         anchors.right: parent.right
         anchors.bottom: parent.bottom
-
         ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
         ScrollBar.vertical.policy: ScrollBar.AlwaysOn
-        Layout.fillHeight: true
-        Layout.fillWidth: true
         contentHeight: {
             var totalHeight = 0
             for (let i = 0; i < sectionRepeater.count; i++) {
@@ -98,7 +95,7 @@ ModalPopup {
 
         SuggestedChannelsPanel {
             id: sectionRepeater
-            width: parent.width
+            width: sview.width
             onSuggestedMessageClicked: {
                 popup.suggestedMessageClicked(channel);
             }


### PR DESCRIPTION
Closes #6632

### What does the PR do
PublicChatPopup featured channels were aligned in a column

### Affected areas
PublicChatPopup

### Screenshot of functionality (including design for comparison)
<img width="1084" alt="fs" src="https://user-images.githubusercontent.com/31625338/182628813-77c70494-aa97-4fd9-af3d-fcf24448344b.png">


