### PR TITLE
fix(@desktop/community) Community portal adjustment

### DIFF
--- a/ui/app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml
+++ b/ui/app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml
@@ -20,6 +20,7 @@ StatusScrollView {
     property CommunitiesStore communitiesStore: CommunitiesStore {}
     property var importCommunitiesPopup: importCommunitiesPopupComponent
     property var createCommunitiesPopup: createCommunitiesPopupComponent
+    property int contentPrefferedWidth: 100
 
     QtObject {
         id: d
@@ -38,7 +39,7 @@ StatusScrollView {
     }
 
     contentHeight: column.height + d.layoutVMargin
-    contentWidth: column.width + d.layoutHMargin
+    contentWidth: root.contentPrefferedWidth - d.layoutHMargin
 
     ColumnLayout {
         id: column
@@ -87,7 +88,7 @@ StatusScrollView {
             StatusButton {
                 id: importBtn
                 Layout.fillHeight: true
-                text: qsTr("Import Community")
+                text: qsTr("Import using key")
                 onClicked: Global.openPopup(importCommunitiesPopupComponent)
             }
 

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -547,6 +547,7 @@ Item {
                         Layout.fillWidth: true
                         Layout.alignment: Qt.AlignLeft | Qt.AlignTop
                         Layout.fillHeight: true
+                        contentPrefferedWidth: appView.width
                     }
 
                     WalletLayout {


### PR DESCRIPTION
Fixes #6723

### What does the PR do

- update button text
- add contentPrefferedWidth property to CommunitiesPortalLayout which changes contentWidth of StatusScrollView(Flickable) 

### Affected areas

Desktop Community

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it


https://user-images.githubusercontent.com/6445843/182700146-9cb742d4-6c6c-4c10-a669-39291293fb3d.mp4


