### PR TITLE
fix(@desktop/community) add delete button to edit channel popup

### DIFF
--- a/ui/app/AppLayouts/Chat/popups/community/CreateChannelPopup.qml
+++ b/ui/app/AppLayouts/Chat/popups/community/CreateChannelPopup.qml
@@ -21,6 +21,7 @@ StatusDialog {
     height: 509
 
     property bool isEdit: false
+    property bool isDeleteable: false
     property string chatId: ""
     property string categoryId: ""
     property string channelName: ""
@@ -37,6 +38,7 @@ StatusDialog {
 
     signal createCommunityChannel(string chName, string chDescription, string chEmoji, string chColor, string chCategoryId)
     signal editCommunityChannel(string chName, string chDescription, string chEmoji, string chColor, string chCategoryId)
+    signal deleteCommunityChannel()
 
     title: qsTr("New channel")
 
@@ -278,11 +280,20 @@ StatusDialog {
     footer: StatusDialogFooter {
         rightButtons: ObjectModel {
             StatusButton {
+                objectName: "deleteCommunityChannelBtn"
+                visible: isEdit && isDeleteable
+                text: qsTr("Delete channel")
+                type: StatusBaseButton.Type.Danger
+                onClicked: {
+                    root.deleteCommunityChannel()
+                }
+            }
+            StatusButton {
                 objectName: "createOrEditCommunityChannelBtn"
                 enabled: isFormValid()
                 text: isEdit ?
-                          qsTr("Save") :
-                          qsTr("Create")
+                          qsTr("Save changes") :
+                          qsTr("Create channel")
                 onClicked: {
                     if (!isFormValid()) {
                         scrollView.scrollBackUp()

--- a/ui/app/AppLayouts/Chat/views/ChatContextMenuView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatContextMenuView.qml
@@ -189,6 +189,7 @@ StatusPopupMenu {
         CreateChannelPopup {
             anchors.centerIn: parent
             isEdit: true
+            isDeleteable: root.isCommunityChat
             emojiPopup: root.emojiPopup
             onCreateCommunityChannel: {
                 root.createCommunityChannel(root.chatId, chName, chDescription, chEmoji, chColor);
@@ -196,6 +197,10 @@ StatusPopupMenu {
             onEditCommunityChannel: {
                 root.editCommunityChannel(root.chatId, chName, chDescription, chEmoji, chColor,
                     chCategoryId);
+            }
+            onDeleteCommunityChannel: {
+                Global.openPopup(deleteChatConfirmationDialogComponent)
+                close()
             }
             onClosed: {
                 destroy()


### PR DESCRIPTION

Fixes #6732

### What does the PR do

Add Delete channel button to Edit Channel popup
Update labels for other buttons in Edit Channel popup

### Affected areas

Desktop Community

### Screenshot of functionality (including design for comparison)

- [ ] I've checked the design and this PR matches it

Expected
![image](https://user-images.githubusercontent.com/6445843/182875001-722cffab-0354-4b4d-b126-10e7a6b56a8e.png)

Implemented

https://user-images.githubusercontent.com/6445843/182875213-e3acbd20-6de2-423e-ab94-54c69799e18a.mp4



