### PR TITLE
fix(Communities/ChatsList): chats order updates handled correctly, subitems reordering fixed

### DIFF
--- a/src/app/modules/main/chat_section/item.nim
+++ b/src/app/modules/main/chat_section/item.nim
@@ -73,13 +73,5 @@ proc appendSubItem*(self: Item, item: SubItem) =
   self.subItems.appendItem(item)
   self.BaseItem.muted = self.subItems.isAllMuted()
 
-proc prependSubItems*(self: Item, items: seq[SubItem]) =
-  self.subItems.prependItems(items)
-  self.BaseItem.muted = self.subItems.isAllMuted()
-
-proc prependSubItem*(self: Item, item: SubItem) =
-  self.subItems.prependItem(item)
-  self.BaseItem.muted = self.subItems.isAllMuted()
-
 proc setActiveSubItem*(self: Item, subItemId: string) =
   self.subItems.setActiveItem(subItemId)

--- a/src/app/modules/main/chat_section/model.nim
+++ b/src/app/modules/main/chat_section/model.nim
@@ -314,9 +314,15 @@ QtObject:
       result.hasNotifications = result.hasNotifications or self.items[i].BaseItem.hasUnreadMessages
       result.notificationsCount = result.notificationsCount + self.items[i].BaseItem.notificationsCount
 
+  proc reorderSubModel(self: Model, chatId: string, position: int) =
+    for it in self.items:
+      if(it.subItems.getCount() > 0):
+        it.subItems.reorder(chatId, position)
+
   proc reorder*(self: Model, chatOrCategoryId: string, position: int) =
     let index = self.getItemIdxById(chatOrCategoryId)
     if(index == -1):
+      self.reorderSubModel(chatOrCategoryId, position)
       return
 
     if(self.items[index].BaseItem.position == position):

--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -196,7 +196,7 @@ proc buildChatSectionUI(
       description="", ChatType.Unknown.int, amIChatAdmin=false, hasNotificationPerCategory,
       notificationsCountPerCategory, muted=false, blocked=false, active=false,
       cat.position, cat.id)
-    categoryItem.prependSubItems(categoryChannels)
+    categoryItem.appendSubItems(categoryChannels)
     self.view.chatsModel().appendItem(categoryItem)
 
   self.setActiveItemSubItem(selectedItemId, selectedSubItemId)
@@ -473,7 +473,7 @@ method onCommunityCategoryCreated*(self: Module, cat: Category, chats: seq[ChatD
     self.view.chatsModel().removeItemById(chatDto.id)
     categoryChannels.add(channelItem)
 
-  categoryItem.prependSubItems(categoryChannels)
+  categoryItem.appendSubItems(categoryChannels)
   self.view.chatsModel().appendItem(categoryItem)
 
 method onCommunityCategoryDeleted*(self: Module, cat: Category) =
@@ -529,7 +529,7 @@ method onCommunityCategoryEdited*(self: Module, cat: Category, chats: seq[ChatDt
         chatDto.color, chatDto.emoji, chatDto.description, chatDto.chatType.int,
         amIChatAdmin=true, hasNotification, notificationsCount, chatDto.muted, blocked=false,
         active=false, chatDto.position)
-      categoryItem.prependSubItem(channelItem)
+      categoryItem.appendSubItem(channelItem)
     else:
       let channelItem = initItem(chatDto.id, chatDto.name, chatDto.icon,
         chatDto.color, chatDto.emoji, chatDto.description, chatDto.chatType.int, amIChatAdmin,

--- a/src/app/modules/main/chat_section/sub_model.nim
+++ b/src/app/modules/main/chat_section/sub_model.nim
@@ -143,28 +143,6 @@ QtObject:
 
     self.countChanged()
 
-  proc prependItems*(self: SubModel, items: seq[SubItem]) =
-    let parentModelIndex = newQModelIndex()
-    defer: parentModelIndex.delete
-
-    let first = 0
-    let last = items.len - 1
-    self.beginInsertRows(parentModelIndex, first, last)
-    self.items = items & self.items
-    self.endInsertRows()
-
-    self.countChanged()
-
-  proc prependItem*(self: SubModel, item: SubItem) =
-    let parentModelIndex = newQModelIndex()
-    defer: parentModelIndex.delete
-
-    self.beginInsertRows(parentModelIndex, 0, 0)
-    self.items = item & self.items
-    self.endInsertRows()
-
-    self.countChanged()
-
   proc getItemById*(self: SubModel, id: string): SubItem =
     for it in self.items:
       if(it.id == id):
@@ -246,6 +224,16 @@ QtObject:
     self.items.delete(idx)
     self.endRemoveRows()
     self.countChanged()
+
+  proc reorder*(self: SubModel, id: string, position: int) =
+    let index = self.getItemIdxById(id)
+    if index == -1:
+      return
+
+    self.items[index].BaseItem.position = position
+
+    let modelIndex = self.createIndex(index, 0, nil)
+    self.dataChanged(modelIndex, modelIndex, @[ModelRole.Position.int])
 
   proc updateNotificationsForItemById*(self: SubModel, id: string, hasUnreadMessages: bool,
     notificationsCount: int): bool =

--- a/src/app_service/service/community/service.nim
+++ b/src/app_service/service/community/service.nim
@@ -320,7 +320,7 @@ QtObject:
           # Handle position changes
           if(chat.id == prev_chat.id and chat.position != prev_chat.position):
             self.events.emit(SIGNAL_COMMUNITY_CHANNEL_REORDERED, CommunityChatOrderArgs(communityId: community.id,
-            chatId: community.id&chat.id, categoryId: chat.categoryId, position: chat.position))
+            chatId: chat.id, categoryId: chat.categoryId, position: chat.position))
 
           # Handle name/description changes
           if(chat.id == prev_chat.id and (chat.name != prev_chat.name or chat.description != prev_chat.description)):


### PR DESCRIPTION
### What does the PR do

fixes #6292

it's based on some earlier works: https://github.com/status-im/status-desktop/pull/6371

Current approach is based on changes regarding reordering (https://github.com/status-im/status-desktop/pull/6792). UI no longer relies directly on the order of items in the chat section model - UI is inteded to rely on `position` role and use it for sorting.

- add reorder method to SubModel
- remove prepended communityID to chatID when emitting SIGNAL_COMMUNITY_CHANNEL_REORDERED
- remove prependItem/prependItems methods because ordering is now intended to be done on ui side

### Affected areas

community service, chat section model

### Screenshot of functionality (including design for comparison)

https://user-images.githubusercontent.com/20650004/183056551-4b52a7b7-e6a5-4d28-82c0-ccb47b03262d.mp4

