### PR TITLE
fix(ActivityCenter): Close activity center on click outside (via MouseArea)

### DIFF
--- a/ui/app/AppLayouts/Chat/popups/ActivityCenterPopup.qml
+++ b/ui/app/AppLayouts/Chat/popups/ActivityCenterPopup.qml
@@ -39,7 +39,9 @@ Popup {
     parent: Overlay.overlay
 
     dim: true
-    Overlay.modeless: MouseArea {}
+    Overlay.modeless: MouseArea {
+        onClicked: activityCenter.close()
+    }
 
     width: 560
     background: Rectangle {


### PR DESCRIPTION
Closes: #6628

### What does the PR do

ActivityCenterPopup use `MouseArea` as `modeless` component which blocks clicks outside of popup (sometimes). This PR add processing `click` signal for `MouseArea` component.

### Affected areas

ActivityCenterPopup

### Screenshot of functionality (including design for comparison)

- [ ] I've checked the design and this PR matches it