### PR TITLE
fix(Profile): Wallet connected dapps count label

### DIFF
--- a/ui/app/AppLayouts/Profile/views/wallet/MainView.qml
+++ b/ui/app/AppLayouts/Profile/views/wallet/MainView.qml
@@ -56,6 +56,7 @@ Column {
         height: 64
         width: parent.width
         onClicked: goToDappPermissionsView()
+        label: qsTr("%n DApp(s) connected", "", root.walletStore.dappList.count)
         components: [
             StatusIcon {
                 icon: "chevron-down"


### PR DESCRIPTION
FIxes https://github.com/status-im/status-desktop/issues/6661

### What does the PR do

Added label showing number of connected DApps to Profiels Wallet settings.

### Affected areas

Profile settings

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

<img width="1127" alt="Снимок экрана 2022-08-07 в 23 18 41" src="https://user-images.githubusercontent.com/25482501/183309680-9b4a0075-9274-4663-a67d-543ec61936d8.png">
<img width="1127" alt="Снимок экрана 2022-08-07 в 23 19 21" src="https://user-images.githubusercontent.com/25482501/183309684-f87cccca-ce03-4e4a-91ca-1040b80c150b.png">
<img width="1127" alt="Снимок экрана 2022-08-07 в 23 19 24" src="https://user-images.githubusercontent.com/25482501/183309687-9ff65c38-5a4b-4c4c-9814-02a3e843b8c1.png">

