### PR TITLE
fix(@desktop/wallet) adjust network dropdown

### DIFF
--- a/ui/app/AppLayouts/Wallet/controls/NetworkFilter.qml
+++ b/ui/app/AppLayouts/Wallet/controls/NetworkFilter.qml
@@ -94,7 +94,8 @@ Item {
 
     NetworkSelectPopup {
         id: selectPopup
-        x: (parent.width - width)
+        x: (parent.width - width + 5)
+        y: (selectRectangle.height + 5)
         layer1Networks: store.layer1Networks
         layer2Networks: store.layer2Networks
         testNetworks: store.testNetworks

--- a/ui/app/AppLayouts/Wallet/popups/NetworkSelectPopup.qml
+++ b/ui/app/AppLayouts/Wallet/popups/NetworkSelectPopup.qml
@@ -16,6 +16,10 @@ Popup {
     modal: false
     width: 360
     height: 432
+
+    horizontalPadding: 5
+    verticalPadding: 5
+
     closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutsideParent
     property var layer1Networks
     property var layer2Networks
@@ -43,13 +47,14 @@ Popup {
         contentHeight: content.height
         width: popup.width
         height: popup.height
+        padding: 0
 
         ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
 
         Column {
             id: content
             width: scrollView.availableWidth
-            spacing: Style.current.padding
+            spacing: 4
 
             Repeater {
                 id: chainRepeater1
@@ -62,6 +67,11 @@ Popup {
                 font.pixelSize: Style.current.primaryTextFontSize
                 color: Theme.palette.baseColor1
                 text: qsTr("Layer 2")
+                height: 40
+                leftPadding: 16
+                topPadding: 10
+                verticalAlignment: Text.AlignVCenter
+
                 visible: chainRepeater2.count > 0
             }
 
@@ -84,8 +94,11 @@ Popup {
     Component {
         id: chainItem
         StatusListItem {
+            implicitHeight: 48
             implicitWidth: scrollView.width
             title: model.chainName
+            image.height: 24
+            image.width: 24
             image.source: Style.svg(model.iconUrl)
             onClicked:  {
                 checkBox.checked = !checkBox.checked


### PR DESCRIPTION
Fixes #6486

### What does the PR do

Adjust Wallet Network dropdown paddings and sizes

### Affected areas

Desktop Wallet

### Screenshot of functionality (including design for comparison)

- [X] I've checked the design and this PR matches it

**! highlight is forced just for comparison here !**
![6486_designCompare 2022-08-08 10-05-29](https://user-images.githubusercontent.com/6445843/183362966-bae9f769-c91a-4c21-969f-6affd20dc4e8.png)

https://user-images.githubusercontent.com/6445843/183363141-336fefa2-8447-490e-9e11-51f5d02f1629.mp4



