### PR TITLE
fix(@desktop/general): Fix import in ImageCropWorkflow

### DIFF
--- a/ui/imports/shared/popups/ImageCropWorkflow.qml
+++ b/ui/imports/shared/popups/ImageCropWorkflow.qml
@@ -1,6 +1,6 @@
 import QtQuick 2.14
 import QtQuick.Controls 2.14
-import Qt.labs.platform 1.1
+import QtQuick.Dialogs 1.3
 
 import StatusQ.Components 0.1
 import StatusQ.Controls 0.1


### PR DESCRIPTION
Issue #6866

### What does the PR do

Change import Qt.labs.platform into QtQuick.Dialogs.

FileDialog from Qt.labs.platform does not have needed functions.

### Affected areas

EditCropImagePanel

### Screenshot of functionality (including design for comparison)

Selected & cropped image is shown correctly

![image](https://user-images.githubusercontent.com/61889657/183390881-fe374d32-917d-4853-9b00-e49f87ec8639.png)

