### PR TITLE
fix(@desktop/community) adjust Image Upload popup

### DIFF
--- a/ui/app/AppLayouts/Chat/controls/community/CommunityLogoPicker.qml
+++ b/ui/app/AppLayouts/Chat/controls/community/CommunityLogoPicker.qml
@@ -48,7 +48,7 @@ Item {
 
             imageFileDialogTitle: qsTr("Choose an image as logo")
             title: qsTr("Community logo")
-            acceptButtonText: qsTr("Make this my community logo")
+            acceptButtonText: qsTr("Make this my Community logo")
 
             dataImage: root.imageData
 

--- a/ui/imports/shared/popups/ImageCropWorkflow.qml
+++ b/ui/imports/shared/popups/ImageCropWorkflow.qml
@@ -56,8 +56,8 @@ Item {
 
             anchors {
                  fill: parent
-                 leftMargin: Style.current.padding * 2
-                 rightMargin: Style.current.padding * 2
+                 leftMargin: Style.current.bigPadding + Style.current.halfPadding / 2
+                 rightMargin: Style.current.bigPadding + Style.current.halfPadding / 2
                  topMargin: Style.current.bigPadding
                  bottomMargin: Style.current.bigPadding
             }


### PR DESCRIPTION
Fixes #6835

Requires https://github.com/status-im/StatusQ/pull/839
Requires https://github.com/status-im/StatusQ/pull/848

### What does the PR do

Adjust ImageUpload popup and use updated StatusQ version

### Affected areas

Desktop Community

### Screenshot of functionality (including design for comparison)

- [X] I've checked the design and this PR matches it

![Screenshot from 2022-08-10 13-01-25](https://user-images.githubusercontent.com/6445843/183874347-8ed41527-a45e-496a-9307-de71a12676dc.png)

