### PR TITLE
feat: add custom waku2 nodes

### DIFF
--- a/src/app/core/fleets/fleet_configuration.nim
+++ b/src/app/core/fleets/fleet_configuration.nim
@@ -64,7 +64,7 @@ proc getMailservers*(self: FleetConfiguration, fleet: Fleet, isWakuV2: bool): Ta
   # TODO: If using wakuV2, this assumes that Waku nodes in fleet.status.json are also store nodes.
   # Maybe it make senses to add a "waku-store" section in case we want to have separate node types?
   # Discuss with @iurimatias, @cammellos and Vac team
-  let fleetKey = if isWakuV2: $FleetNodes.Waku else: $FleetNodes.Mailservers
+  let fleetKey = if isWakuV2: $FleetNodes.TCP_P2P_Waku else: $FleetNodes.Mailservers
   if not self.fleet[$fleet].hasKey(fleetKey) :
     result = initTable[string,string]()
     return

--- a/src/app/modules/main/profile_section/io_interface.nim
+++ b/src/app/modules/main/profile_section/io_interface.nim
@@ -65,7 +65,13 @@ method getDevicesModule*(self: AccessInterface): QVariant {.base.} =
 method syncModuleDidLoad*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method wakuModuleDidLoad*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method getSyncModule*(self: AccessInterface): QVariant {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method getWakuModule*(self: AccessInterface): QVariant {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method notificationsModuleDidLoad*(self: AccessInterface) {.base.} =

--- a/src/app/modules/main/profile_section/module.nim
+++ b/src/app/modules/main/profile_section/module.nim
@@ -32,6 +32,7 @@ import ./about/module as about_module
 import ./advanced/module as advanced_module
 import ./devices/module as devices_module
 import ./sync/module as sync_module
+import ./waku/module as waku_module
 import ./notifications/module as notifications_module
 import ./ens_usernames/module as ens_usernames_module
 import ./communities/module as communities_module
@@ -55,6 +56,7 @@ type
     advancedModule: advanced_module.AccessInterface
     devicesModule: devices_module.AccessInterface
     syncModule: sync_module.AccessInterface
+    wakuModule: waku_module.AccessInterface
     notificationsModule: notifications_module.AccessInterface
     ensUsernamesModule: ens_usernames_module.AccessInterface
     communitiesModule: communities_module.AccessInterface
@@ -98,6 +100,7 @@ proc newModule*(delegate: delegate_interface.AccessInterface,
   result.advancedModule = advanced_module.newModule(result, events, settingsService, stickersService, nodeConfigurationService)
   result.devicesModule = devices_module.newModule(result, events, settingsService, devicesService)
   result.syncModule = sync_module.newModule(result, events, settingsService, nodeConfigurationService, mailserversService)
+  result.wakuModule = waku_module.newModule(result, events, settingsService, nodeConfigurationService)
   result.notificationsModule = notifications_module.newModule(result, events, settingsService, chatService, contactsService)
   result.ensUsernamesModule = ens_usernames_module.newModule(
     result, events, settingsService, ensService, walletAccountService, networkService, tokenService
@@ -117,6 +120,7 @@ method delete*(self: Module) =
   self.advancedModule.delete
   self.devicesModule.delete
   self.syncModule.delete
+  self.wakuModule.delete
   self.communitiesModule.delete
   self.keycardModule.delete
 
@@ -134,6 +138,7 @@ method load*(self: Module) =
   self.advancedModule.load()
   self.devicesModule.load()
   self.syncModule.load()
+  self.wakuModule.load()
   self.notificationsModule.load()
   self.ensUsernamesModule.load()
   self.communitiesModule.load()
@@ -165,6 +170,9 @@ proc checkIfModuleDidLoad(self: Module) =
     return
 
   if(not self.syncModule.isLoaded()):
+    return
+
+  if(not self.wakuModule.isLoaded()):
     return
 
   if(not self.notificationsModule.isLoaded()):
@@ -227,8 +235,14 @@ method getDevicesModule*(self: Module): QVariant =
 method syncModuleDidLoad*(self: Module) =
   self.checkIfModuleDidLoad()
 
+method wakuModuleDidLoad*(self: Module) =
+  self.checkIfModuleDidLoad()
+
 method getSyncModule*(self: Module): QVariant =
   self.syncModule.getModuleAsVariant()
+
+method getWakuModule*(self: Module): QVariant =
+  self.wakuModule.getModuleAsVariant()
 
 method notificationsModuleDidLoad*(self: Module) =
   self.checkIfModuleDidLoad()

--- a/src/app/modules/main/profile_section/view.nim
+++ b/src/app/modules/main/profile_section/view.nim
@@ -51,6 +51,11 @@ QtObject:
   QtProperty[QVariant] syncModule:
     read = getSyncModule
 
+  proc getWakuModule(self: View): QVariant {.slot.} =
+    return self.delegate.getWakuModule()
+  QtProperty[QVariant] wakuModule:
+    read = getWakuModule
+
   proc getNotificationsModule(self: View): QVariant {.slot.} =
     return self.delegate.getNotificationsModule()
   QtProperty[QVariant] notificationsModule:

--- a/src/app/modules/main/profile_section/waku/controller.nim
+++ b/src/app/modules/main/profile_section/waku/controller.nim
@@ -1,0 +1,39 @@
+import Tables, chronicles
+import io_interface
+
+import ../../../../core/eventemitter
+import ../../../../core/fleets/fleet_configuration
+import ../../../../../app_service/service/settings/service as settings_service
+import ../../../../../app_service/service/node_configuration/service as node_configuration_service
+
+logScope:
+  topics = "profile-section-waku-module-controller"
+
+type
+  Controller* = ref object of RootObj
+    delegate: io_interface.AccessInterface
+    events: EventEmitter
+    settingsService: settings_service.Service
+    nodeConfigurationService: node_configuration_service.Service
+
+proc newController*(delegate: io_interface.AccessInterface,
+  events: EventEmitter,
+  settingsService: settings_service.Service,
+  nodeConfigurationService: node_configuration_service.Service): Controller =
+  result = Controller()
+  result.delegate = delegate
+  result.events = events
+  result.settingsService = settingsService
+  result.nodeConfigurationService = nodeConfigurationService
+
+proc delete*(self: Controller) =
+  discard
+
+proc init*(self: Controller) =
+  discard
+
+proc getAllWakuNodes*(self: Controller): seq[string] =
+  return self.nodeConfigurationService.getAllWakuNodes()
+
+proc saveNewWakuNode*(self: Controller, nodeAddress: string) =
+  self.nodeConfigurationService.saveNewWakuNode(nodeAddress)

--- a/src/app/modules/main/profile_section/waku/io_interface.nim
+++ b/src/app/modules/main/profile_section/waku/io_interface.nim
@@ -1,0 +1,25 @@
+import NimQml
+
+type
+  AccessInterface* {.pure inheritable.} = ref object of RootObj
+
+method delete*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method load*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method isLoaded*(self: AccessInterface): bool {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method getModuleAsVariant*(self: AccessInterface): QVariant {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method viewDidLoad*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method isAutomaticSelection*(self: AccessInterface): bool {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method saveNewWakuNode*(self: AccessInterface, nodeAddress: string) {.base.} =
+  raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/profile_section/waku/item.nim
+++ b/src/app/modules/main/profile_section/waku/item.nim
@@ -1,0 +1,11 @@
+
+type
+  Item* = ref object
+    nodeAddress: string
+
+proc initItem*(nodeAddress: string): Item =
+  result = Item()
+  result.nodeAddress = nodeAddress
+
+proc nodeAddress*(self: Item): string =
+  self.nodeAddress

--- a/src/app/modules/main/profile_section/waku/model.nim
+++ b/src/app/modules/main/profile_section/waku/model.nim
@@ -1,0 +1,62 @@
+import NimQml, Tables
+import item
+
+type
+  ModelRole {.pure.} = enum
+    NodeAddress = UserRole + 1
+
+QtObject:
+  type Model* = ref object of QAbstractListModel
+    items*: seq[Item]
+
+  proc setup(self: Model) =
+    self.QAbstractListModel.setup
+
+  proc delete(self: Model) =
+    self.items = @[]
+    self.QAbstractListModel.delete
+
+  proc newModel*(): Model =
+    new(result, delete)
+    result.setup
+
+  method rowCount(self: Model, index: QModelIndex = nil): int =
+    return self.items.len
+
+  method roleNames(self: Model): Table[int, string] =
+    {
+      ModelRole.NodeAddress.int:"nodeAddress"
+    }.toTable
+
+  method data(self: Model, index: QModelIndex, role: int): QVariant =
+    if not index.isValid:
+      return
+    if index.row < 0 or index.row >= self.items.len:
+      return
+    let item = self.items[index.row]
+    let enumRole = role.ModelRole
+
+    case enumRole:
+      of ModelRole.NodeAddress:
+        result = newQVariant(item.nodeAddress)
+
+  proc addItem*(self: Model, item: Item) =
+    let parentModelIndex = newQModelIndex()
+    defer: parentModelIndex.delete
+
+    self.beginInsertRows(parentModelIndex, self.items.len, self.items.len)
+    self.items.add(item)
+    self.endInsertRows()
+
+  proc addItems*(self: Model, items: seq[Item]) =
+    if(items.len == 0):
+      return
+
+    let parentModelIndex = newQModelIndex()
+    defer: parentModelIndex.delete
+
+    let first = self.items.len
+    let last = first + items.len - 1
+    self.beginInsertRows(parentModelIndex, first, last)
+    self.items.add(items)
+    self.endInsertRows()

--- a/src/app/modules/main/profile_section/waku/module.nim
+++ b/src/app/modules/main/profile_section/waku/module.nim
@@ -1,0 +1,66 @@
+import NimQml, chronicles
+import io_interface
+import ../io_interface as delegate_interface
+import view, controller, model, item
+
+import ../../../../core/eventemitter
+import ../../../../../app_service/service/settings/service as settings_service
+import ../../../../../app_service/service/node_configuration/service as node_configuration_service
+
+export io_interface
+
+logScope:
+  topics = "profile-section-waku-module"
+
+type
+  Module* = ref object of io_interface.AccessInterface
+    delegate: delegate_interface.AccessInterface
+    controller: Controller
+    view: View
+    viewVariant: QVariant
+    moduleLoaded: bool
+
+proc newModule*(delegate: delegate_interface.AccessInterface,
+  events: EventEmitter,
+  settingsService: settings_service.Service,
+  nodeConfigurationService: node_configuration_service.Service): Module =
+  result = Module()
+  result.delegate = delegate
+  result.view = view.newView(result)
+  result.viewVariant = newQVariant(result.view)
+  result.controller = controller.newController(result, events, settingsService, nodeConfigurationService)
+  result.moduleLoaded = false
+
+method delete*(self: Module) =
+  self.view.delete
+  self.viewVariant.delete
+  self.controller.delete
+
+method load*(self: Module) =
+  self.controller.init()
+  self.view.load()
+
+method isLoaded*(self: Module): bool =
+  return self.moduleLoaded
+
+proc initModel(self: Module) =
+  var items: seq[Item]
+  let allWakuNodes = self.controller.getAllWakuNodes()
+  for w in allWakuNodes:
+    let item = initItem(w)
+    items.add(item)
+
+  self.view.model().addItems(items)
+
+method viewDidLoad*(self: Module) =
+  self.initModel()
+  self.moduleLoaded = true
+  self.delegate.wakuModuleDidLoad()
+
+method getModuleAsVariant*(self: Module): QVariant =
+  return self.viewVariant
+
+method saveNewWakuNode*(self: Module, nodeAddress: string) =
+  self.controller.saveNewWakuNode(nodeAddress)
+  let item = initItem(nodeAddress)
+  self.view.model().addItem(item)

--- a/src/app/modules/main/profile_section/waku/view.nim
+++ b/src/app/modules/main/profile_section/waku/view.nim
@@ -1,0 +1,39 @@
+import NimQml
+import io_interface, model
+
+QtObject:
+  type
+    View* = ref object of QObject
+      delegate: io_interface.AccessInterface
+      activeMailserver: string
+      model: Model
+      modelVariant: QVariant
+
+  proc delete*(self: View) =
+    self.model.delete
+    self.modelVariant.delete
+    self.QObject.delete
+
+  proc newView*(delegate: io_interface.AccessInterface): View =
+    new(result, delete)
+    result.QObject.setup
+    result.delegate = delegate
+    result.activeMailserver = ""
+    result.model = newModel()
+    result.modelVariant = newQVariant(result.model)
+
+  proc load*(self: View) =
+    self.delegate.viewDidLoad()
+
+  proc model*(self: View): Model =
+    return self.model
+
+  proc modelChanged*(self: View) {.signal.}
+  proc getModel(self: View): QVariant {.slot.} =
+    return self.modelVariant
+  QtProperty[QVariant] model:
+    read = getModel
+    notify = modelChanged
+
+  proc saveNewWakuNode(self: View, address: string) {.slot.} =
+    self.delegate.saveNewWakuNode(address)

--- a/ui/app/AppLayouts/Profile/popups/AddWakuNodeModal.qml
+++ b/ui/app/AppLayouts/Profile/popups/AddWakuNodeModal.qml
@@ -26,8 +26,7 @@ StatusModal {
     }
 
     onOpened: {
-        nameInput.text = "";
-        enodeInput.text = "";
+        addrInput.text = "";
     }
     
     contentItem: StatusScrollView {
@@ -37,29 +36,19 @@ StatusModal {
         Column {
             id: nodesColumn
             width: parent.width
-            StatusInput {
-                id: nameInput
-                label: qsTr("Name")
-                placeholderText: qsTr("Specify a name")
-                validators: [StatusMinLengthValidator {
-                    minLength: 1
-                    errorMessage: qsTr("You need to enter a name")
-                }]
-                validationMode: StatusInput.ValidationMode.Always
-            }
 
             StatusInput {
-                id: enodeInput
-                label: popup.advancedStore.isWakuV2 ? qsTr("Storenode multiaddress") : qsTr("History node address")
-                placeholderText: popup.advancedStore.isWakuV2 ? "/ip4/0.0.0.0/tcp/123/..." : "enode://{enode-id}:{password}@{ip-address}:{port-number}"
+                id: addrInput
+                label: qsTr("Node multiaddress or DNS Discovery address")
+                placeholderText: "/ipv4/0.0.0.0/tcp/123/..."
                 validators: [
                 StatusMinLengthValidator {
                     minLength: 1
-                    errorMessage: popup.advancedStore.isWakuV2 ? qsTr("You need to enter the storenode multiaddress") : qsTr("You need to enter the enode address")
+                    errorMessage: qsTr("You need to enter a value")
                 },
                 StatusRegularExpressionValidator {
-                    errorMessage: popup.advancedStore.isWakuV2 ? qsTr('Multiaddress must start with a "/"') : qsTr("The format must be: enode://{enode-id}:{password}@{ip-address}:{port}")
-                    regularExpression: popup.advancedStore.isWakuV2 ? /\/.+/ : /enode:\/\/[a-z0-9]+:[a-z0-9]+@(\b25[0-5]|\b2[0-4][0-9]|\b[01]?[0-9][0-9]?)(\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}:[0-9]+/
+                    errorMessage: qsTr("Value should start with '/' or 'enr:'")
+                    regularExpression: /(\/|enr:).+/
                 }]
                 validationMode: StatusInput.ValidationMode.Always
             }
@@ -69,10 +58,9 @@ StatusModal {
     rightButtons: [
        StatusButton {
             text: qsTr("Save")
-            enabled: nameInput.valid && enodeInput.valid
-            // enabled: nameInput.text !== "" && enodeInput.text !== ""
+            enabled: addrInput.valid
             onClicked: {
-                root.messagingStore.saveNewMailserver(nameInput.text, enodeInput.text)
+                root.messagingStore.saveNewWakuNode(addrInput.text)
                 popup.close()
             }
         }

--- a/ui/app/AppLayouts/Profile/popups/AddWakuStoreModal.qml
+++ b/ui/app/AppLayouts/Profile/popups/AddWakuStoreModal.qml
@@ -1,0 +1,80 @@
+import QtQuick 2.12
+import QtQuick.Controls 2.3
+
+import StatusQ.Core 0.1
+import StatusQ.Core.Theme 0.1
+import StatusQ.Components 0.1
+import StatusQ.Controls 0.1
+import StatusQ.Controls.Validators 0.1
+import StatusQ.Popups 0.1
+
+
+import utils 1.0
+
+StatusModal {
+    id: popup
+
+    anchors.centerIn: parent
+    height: 560
+    header.title: qsTr("Waku nodes")
+
+    property var messagingStore
+    property var advancedStore
+
+    onClosed: {
+        destroy()
+    }
+
+    onOpened: {
+        nameInput.text = "";
+        enodeInput.text = "";
+    }
+    
+    contentItem: StatusScrollView {
+        height: parent.height
+        width: parent.width
+
+        Column {
+            id: nodesColumn
+            width: parent.width
+            StatusInput {
+                id: nameInput
+                label: qsTr("Name")
+                placeholderText: qsTr("Specify a name")
+                validators: [StatusMinLengthValidator {
+                    minLength: 1
+                    errorMessage: qsTr("You need to enter a name")
+                }]
+                validationMode: StatusInput.ValidationMode.Always
+            }
+
+            StatusInput {
+                id: enodeInput
+                label: popup.advancedStore.isWakuV2 ? qsTr("Storenode multiaddress") : qsTr("History node address")
+                placeholderText: popup.advancedStore.isWakuV2 ? "/ip4/0.0.0.0/tcp/123/..." : "enode://{enode-id}:{password}@{ip-address}:{port-number}"
+                validators: [
+                StatusMinLengthValidator {
+                    minLength: 1
+                    errorMessage: popup.advancedStore.isWakuV2 ? qsTr("You need to enter the storenode multiaddress") : qsTr("You need to enter the enode address")
+                },
+                StatusRegularExpressionValidator {
+                    errorMessage: popup.advancedStore.isWakuV2 ? qsTr('Multiaddress must start with a "/"') : qsTr("The format must be: enode://{enode-id}:{password}@{ip-address}:{port}")
+                    regularExpression: popup.advancedStore.isWakuV2 ? /\/.+/ : /enode:\/\/[a-z0-9]+:[a-z0-9]+@(\b25[0-5]|\b2[0-4][0-9]|\b[01]?[0-9][0-9]?)(\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}:[0-9]+/
+                }]
+                validationMode: StatusInput.ValidationMode.Always
+            }
+        }
+    }
+
+    rightButtons: [
+       StatusButton {
+            text: qsTr("Save")
+            enabled: nameInput.valid && enodeInput.valid
+            // enabled: nameInput.text !== "" && enodeInput.text !== ""
+            onClicked: {
+                root.messagingStore.saveNewMailserver(nameInput.text, enodeInput.text)
+                popup.close()
+            }
+        }
+    ]
+}

--- a/ui/app/AppLayouts/Profile/popups/WakuNodesModal.qml
+++ b/ui/app/AppLayouts/Profile/popups/WakuNodesModal.qml
@@ -26,9 +26,7 @@ StatusModal {
 
     property var messagingStore
     property var advancedStore
-    property string nameValidationError: ""
-    property string enodeValidationError: ""
-
+    
     onClosed: {
         destroy()
     }
@@ -41,74 +39,16 @@ StatusModal {
             id: nodesColumn
             width: parent.width
 
-            StatusListItem {
-                width: parent.width
-                title: qsTr("Use Waku nodes")
-                components: [
-                    StatusSwitch {
-                        checked: root.messagingStore.useMailservers
-                        onCheckedChanged: root.messagingStore.toggleUseMailservers(checked)
-                    }
-                ]
-                onClicked: {
-                    root.messagingStore.toggleUseMailservers(!root.messagingStore.useMailservers)
-                }
-            }
-
-            Separator {
-               width: parent.width
-            }
-
-            StatusListItem {
-                width: parent.width
-                title: qsTr("Select node automatically")
-                components: [
-                    StatusSwitch {
-                        id: automaticSelectionSwitch
-                        checked: root.messagingStore.automaticMailserverSelection
-                        onCheckedChanged: root.messagingStore.enableAutomaticMailserverSelection(checked)
-                    }
-                ]
-                onClicked: {
-                    automaticSelectionSwitch.checked = !automaticSelectionSwitch.checked
-                }
-            }
-
-            StatusSectionHeadline {
-                text: qsTr("Waku Nodes")
-                visible: !automaticSelectionSwitch.checked
-                width: parent.width
-                height: visible ? implicitHeight : 0
-            }
-
-            ButtonGroup {
-                id: nodesButtonGroup
-            }
-
             Repeater {
-                id: mailServersListView
-                model: root.messagingStore.mailservers
+                id: wakunodesListView
+                model: root.messagingStore.wakunodes
                 delegate: Component {
                     StatusListItem {
                         title: qsTr("Node %1").arg(index + 1)
-                        subTitle: model.name
-                        visible: !automaticSelectionSwitch.checked
-                        height: visible ? implicitHeight : 0
+                        subTitle: model.nodeAddress
                         components: [
-                            StatusRadioButton {
-                                id: nodeRadioBtn
-                                ButtonGroup.group: nodesButtonGroup
-                                checked: model.nodeAddress === root.messagingStore.activeMailserver
-                                onCheckedChanged: {
-                                     if (checked) {
-                                        root.messagingStore.setActiveMailserver(model.name)
-                                    }
-                                }
-                            }
+                            // TODO: add a button to delete nodes and restore default fleet nodes if necessary
                         ]
-                        onClicked: {
-                            nodeRadioBtn.checked = true
-                        }
                     }
                 }
             }

--- a/ui/app/AppLayouts/Profile/popups/WakuStoreModal.qml
+++ b/ui/app/AppLayouts/Profile/popups/WakuStoreModal.qml
@@ -1,0 +1,136 @@
+import QtQuick 2.12
+import QtQuick.Controls 2.3
+
+import StatusQ.Core 0.1
+import StatusQ.Core.Theme 0.1
+import StatusQ.Components 0.1
+import StatusQ.Controls 0.1
+import StatusQ.Controls.Validators 0.1
+import StatusQ.Popups 0.1
+
+import "."
+
+import utils 1.0
+import shared 1.0
+import shared.panels 1.0
+import shared.popups 1.0
+import shared.status 1.0
+import shared.controls 1.0
+
+StatusModal {
+    id: root
+
+    anchors.centerIn: parent
+    height: 560
+    header.title: qsTr("History Nodes")
+
+    property var messagingStore
+    property var advancedStore
+    property string nameValidationError: ""
+    property string enodeValidationError: ""
+
+    onClosed: {
+        destroy()
+    }
+    
+    contentItem: StatusScrollView {
+        height: parent.height
+        width: parent.width
+
+        Column {
+            id: nodesColumn
+            width: parent.width
+
+            StatusListItem {
+                width: parent.width
+                title: qsTr("Use Waku nodes")
+                components: [
+                    StatusSwitch {
+                        checked: root.messagingStore.useMailservers
+                        onCheckedChanged: root.messagingStore.toggleUseMailservers(checked)
+                    }
+                ]
+                onClicked: {
+                    root.messagingStore.toggleUseMailservers(!root.messagingStore.useMailservers)
+                }
+            }
+
+            Separator {
+               width: parent.width
+            }
+
+            StatusListItem {
+                width: parent.width
+                title: qsTr("Select node automatically")
+                components: [
+                    StatusSwitch {
+                        id: automaticSelectionSwitch
+                        checked: root.messagingStore.automaticMailserverSelection
+                        onCheckedChanged: root.messagingStore.enableAutomaticMailserverSelection(checked)
+                    }
+                ]
+                onClicked: {
+                    automaticSelectionSwitch.checked = !automaticSelectionSwitch.checked
+                }
+            }
+
+            StatusSectionHeadline {
+                text: qsTr("Waku Nodes")
+                visible: !automaticSelectionSwitch.checked
+                width: parent.width
+                height: visible ? implicitHeight : 0
+            }
+
+            ButtonGroup {
+                id: nodesButtonGroup
+            }
+
+            Repeater {
+                id: mailServersListView
+                model: root.messagingStore.mailservers
+                delegate: Component {
+                    StatusListItem {
+                        title: qsTr("Node %1").arg(index + 1)
+                        subTitle: model.name
+                        visible: !automaticSelectionSwitch.checked
+                        height: visible ? implicitHeight : 0
+                        components: [
+                            StatusRadioButton {
+                                id: nodeRadioBtn
+                                ButtonGroup.group: nodesButtonGroup
+                                checked: model.nodeAddress === root.messagingStore.activeMailserver
+                                onCheckedChanged: {
+                                     if (checked) {
+                                        root.messagingStore.setActiveMailserver(model.name)
+                                    }
+                                }
+                            }
+                        ]
+                        onClicked: {
+                            nodeRadioBtn.checked = true
+                        }
+                    }
+                }
+            }
+
+            StatusBaseText {
+                text: qsTr("Add a new node")
+                color: Theme.palette.primaryColor1
+                width: parent.width
+                MouseArea {
+                    anchors.fill: parent
+                    cursorShape: Qt.PointingHandCursor
+                    onClicked: Global.openPopup(wakuNodeModalComponent)
+                }
+            }
+        }
+    }
+
+    Component {
+        id: wakuNodeModalComponent
+        AddWakuNodeModal {
+            messagingStore: root.messagingStore
+            advancedStore: root.advancedStore
+        }
+    }
+}

--- a/ui/app/AppLayouts/Profile/stores/MessagingStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/MessagingStore.qml
@@ -6,8 +6,10 @@ QtObject {
 
     property var privacyModule
     property var syncModule
+    property var wakuModule
 
     property var mailservers: syncModule.model
+    property var wakunodes: wakuModule.model
 
     property bool useMailservers: syncModule.useMailservers
 
@@ -29,6 +31,10 @@ QtObject {
 
     function saveNewMailserver(name, nodeAddress) {
         root.syncModule.saveNewMailserver(name, nodeAddress)
+    }
+
+    function saveNewWakuNode(nodeAddress) {
+        root.wakuModule.saveNewWakuNode(nodeAddress)
     }
 
     function enableAutomaticMailserverSelection(checked) {

--- a/ui/app/AppLayouts/Profile/stores/ProfileSectionStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/ProfileSectionStore.qml
@@ -25,6 +25,7 @@ QtObject {
     property MessagingStore messagingStore: MessagingStore {
         privacyModule: profileSectionModuleInst.privacyModule
         syncModule: profileSectionModuleInst.syncModule
+        wakuModule: profileSectionModuleInst.wakuModule
     }
 
     property DevicesStore devicesStore: DevicesStore {

--- a/ui/app/AppLayouts/Profile/views/MessagingView.qml
+++ b/ui/app/AppLayouts/Profile/views/MessagingView.qml
@@ -335,7 +335,7 @@ SettingsContentBase {
 
         StatusListItem {
             Layout.fillWidth: true
-            title: qsTr("Waku nodes")
+            title: qsTr("History nodes")
             label: root.messagingStore.getMailserverNameForNodeAddress(root.messagingStore.activeMailserver)
             components: [
                 StatusIcon {
@@ -344,11 +344,33 @@ SettingsContentBase {
                     color: Theme.palette.baseColor1
                 }
             ]
-            onClicked: Global.openPopup(wakuNodeModalComponent)
+            onClicked: Global.openPopup(wakuStoreModalComponent)
         }
 
         Component {
-            id: wakuNodeModalComponent
+            id: wakuStoreModalComponent
+            WakuStoreModal {
+                messagingStore: root.messagingStore
+                advancedStore: root.advancedStore
+            }
+        }
+
+        StatusListItem {
+            Layout.fillWidth: true
+            title: qsTr("Waku Nodes")
+            visible: root.advancedStore.isWakuV2
+            components: [
+                StatusIcon {
+                    icon: "chevron-down"
+                    rotation: 270
+                    color: Theme.palette.baseColor1
+                }
+            ]
+            onClicked: Global.openPopup(wakuNodesModalComponent)
+        }
+
+        Component {
+            id: wakuNodesModalComponent
             WakuNodesModal {
                 messagingStore: root.messagingStore
                 advancedStore: root.advancedStore


### PR DESCRIPTION
Adds a new option in the settings: Settings > Messaging > Waku Nodes, only active for waku2 fleets. It can be used to see the list of nodes from the current fleet, as well as adding new nodes.

In addition to that, it displays the current active storenode when using waku2