### PR TITLE
fix(@desktop/comminities) adjust Community members tab

### DIFF
--- a/ui/app/AppLayouts/Chat/layouts/SettingsPageLayout.qml
+++ b/ui/app/AppLayouts/Chat/layouts/SettingsPageLayout.qml
@@ -65,7 +65,7 @@ Item {
         }
 
         StatusBaseText {
-            Layout.leftMargin: 32
+            Layout.leftMargin: 36
 
             text: root.title
             color: Theme.palette.directColor1

--- a/ui/app/AppLayouts/Chat/panels/communities/CommunityMembersSettingsPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/CommunityMembersSettingsPanel.qml
@@ -32,11 +32,12 @@ SettingsPageLayout {
     title: qsTr("Members")
 
     content: ColumnLayout {
-        spacing: 8
+        spacing: 19
 
         StatusTabBar {
             id: membersTabBar
             Layout.fillWidth: true
+            Layout.topMargin: 5
 
             StatusTabButton {
                 id: allMembersBtn

--- a/ui/app/AppLayouts/Chat/panels/communities/CommunityMembersTabPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/CommunityMembersTabPanel.qml
@@ -33,11 +33,12 @@ Item {
 
     ColumnLayout {
         anchors.fill: parent
-        spacing: 25
+        spacing: 30
 
         StatusInput {
             id: memberSearch
             Layout.preferredWidth: 350
+            Layout.leftMargin: 12
             maximumHeight: 36
             topPadding: 0
             bottomPadding: 0
@@ -55,6 +56,7 @@ Item {
 
             model: root.model
             clip: true
+            spacing: 15
 
             delegate: StatusMemberListItem {
                 id: memberItem
@@ -65,6 +67,7 @@ Item {
 
                 statusListItemComponentsSlot.spacing: 16
                 rightPadding: 80
+                leftPadding: 12
 
                 components: [
                     StatusButton {
@@ -105,10 +108,10 @@ Item {
                 icon.color: Theme.palette.userCustomizationColors[Utils.colorIdForPubkey(model.pubKey)] // FIXME: use model.colorId
                 image.source: model.icon
                 image.isIdenticon: false
-                image.width: 36
-                image.height: 36
-                icon.height: 36
-                icon.width: 36
+                image.width: 40
+                image.height: 40
+                icon.height: 40
+                icon.width: 40
                 ringSettings.ringSpecModel: Utils.getColorHashAsJson(model.pubKey)
                 statusListItemIcon.badge.visible: (root.panelType === CommunityMembersTabPanel.TabType.AllMembers)
 

--- a/ui/app/AppLayouts/Chat/views/CommunitySettingsView.qml
+++ b/ui/app/AppLayouts/Chat/views/CommunitySettingsView.qml
@@ -121,6 +121,8 @@ StatusAppTwoPanelLayout {
 
     rightPanel: Loader {
         anchors.fill: parent
+        anchors.leftMargin: 28
+        anchors.topMargin: 23
         anchors.margins: 16
 
         active: root.community


### PR DESCRIPTION
Fixes #6786

Requires https://github.com/status-im/StatusQ/pull/842

### What does the PR do

Adjust Community Members tab

### Affected areas

Desktop Community

### Screenshot of functionality (including design for comparison)

- [X] I've checked the design and this PR matches it

![Screenshot from 2022-08-08 18-43-41](https://user-images.githubusercontent.com/6445843/183464983-6858c3f0-2060-4717-9c6b-33542ea6b14e.png)

![Screenshot from 2022-08-08 18-49-12](https://user-images.githubusercontent.com/6445843/183465023-221fab37-30e2-4bc5-9b3e-6bca45368421.png)

