### PR TITLE
fix(@desktop/settings) align settings header and menu

### DIFF
--- a/ui/app/AppLayouts/Profile/views/LeftTabView.qml
+++ b/ui/app/AppLayouts/Profile/views/LeftTabView.qml
@@ -22,7 +22,8 @@ Item {
         text: qsTr("Settings")
         anchors.top: parent.top
         anchors.topMargin: Style.current.padding
-        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.left: parent.left
+        anchors.leftMargin: Style.current.bigPadding
     }
 
     StatusScrollView {
@@ -31,9 +32,9 @@ Item {
         anchors.right: parent.right
         anchors.rightMargin: Style.current.smallPadding
         anchors.left: parent.left
-        anchors.leftMargin: Style.current.smallPadding
+        anchors.leftMargin: 0
         anchors.top: title.bottom
-        anchors.topMargin: Style.current.padding
+        anchors.topMargin: Style.current.halfPadding
         anchors.bottom: parent.bottom
         ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
 


### PR DESCRIPTION
Fixes #6773

### What does the PR do

Change Settings header anchors and menu left margin to match Design

### Affected areas

Desktop Settings

### Screenshot of functionality (including design for comparison)

- [X] I've checked the design and this PR matches it

![Screenshot from 2022-08-10 10-15-34](https://user-images.githubusercontent.com/6445843/183841099-0386e900-6b65-4760-991c-8dc0b59657f7.png)

