### PR TITLE
fix(Chat): big space between username and time

### DIFF
--- a/ui/imports/shared/controls/chat/VerificationLabel.qml
+++ b/ui/imports/shared/controls/chat/VerificationLabel.qml
@@ -7,8 +7,8 @@ import utils 1.0
 
 SVGImage {
     id: root
-    width: 10
-    height: 10
+    width: visible ?  10 : 0
+    height: visible ?  10 : 0
 
     property int trustStatus: Constants.trustStatus.unknown
 

--- a/ui/imports/shared/views/chat/CompactMessageView.qml
+++ b/ui/imports/shared/views/chat/CompactMessageView.qml
@@ -393,7 +393,7 @@ Item {
         VerificationLabel {
             id: trustStatus
             anchors.left: chatName.right
-            anchors.leftMargin: 4
+            anchors.leftMargin: visible ? 4 : 0
             anchors.bottom: chatName.bottom
             anchors.bottomMargin: 4
             visible: !root.amISender && chatName.visible


### PR DESCRIPTION
Closes #6832

### What does the PR do
fixes big space between username and time

### Affected areas
chat message

### Screenshot of functionality (including design for comparison)
<img width="348" alt="j" src="https://user-images.githubusercontent.com/31625338/183697895-6cb956c0-d922-41f4-b580-ffce72e3bcf0.png">

