### PR TITLE
fix(StatusStickerPopup): Bottom row layout issues

### DIFF
--- a/ui/imports/shared/status/StatusStickersPopup.qml
+++ b/ui/imports/shared/status/StatusStickersPopup.qml
@@ -203,10 +203,8 @@ Popup {
 
             StatusQControls.StatusFlatRoundButton {
                 id: btnAddStickerPack
-                implicitHeight: 24
+                implicitHeight: 40
                 implicitWidth: 24
-                anchors.bottom: parent.bottom
-                anchors.bottomMargin: Style.current.padding / 2
                 icon.name: "add"
                 type: StatusQControls.StatusFlatRoundButton.Type.Tertiary
                 color: "transparent"
@@ -231,8 +229,7 @@ Popup {
 
             StatusScrollView {
                 id: installedStickersSV
-                anchors.bottom: parent.bottom
-                height: 32
+                height: 40
 
                 RowLayout {
                     id: stickersRowLayout
@@ -272,6 +269,9 @@ Popup {
                             radius: width / 2
                             color: Style.current.backgroundHover
                         }
+                    }
+                    Item {
+                        Layout.fillWidth: true
                     }
                 }
             }


### PR DESCRIPTION
Closes #6833

### What does the PR do
StatusStickerPopup fixed Bottom row layout issues

### Affected areas
StatusStickerPopup

### Screenshot of functionality (including design for comparison)
<img width="323" alt="f" src="https://user-images.githubusercontent.com/31625338/183846246-05c68e08-c82a-40f3-bcf0-f41b33dde460.png">

