### PR TITLE
fix(Chat/CompactMessageView): removed space above image in msg

### DIFF
--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -1015,7 +1015,7 @@ Rectangle {
                         var symbols = ":='xX><0O;*dB8-D#%\\";
                         if ((length > 1) && (symbols.indexOf(getText((cursorPosition - 2), (cursorPosition - 1))) !== -1)
                                 && (!getText((cursorPosition - 7), cursorPosition).includes("http"))) {
-                            const emojis = EmojiJSON.emoji_json.filter(function (emoji) {
+                            const emojis = StatusQUtils.Emoji.emojiJSON.emoji_json.filter(function (emoji) {
                                 if (emoji.aliases_ascii.includes(getText((cursorPosition - 2), cursorPosition)) ||
                                         emoji.aliases_ascii.includes(getText((cursorPosition - 3), cursorPosition))) {
                                     var has2Chars = emoji.aliases_ascii.includes(getText((cursorPosition - 2), cursorPosition));

--- a/ui/imports/shared/views/chat/ChatTextView.qml
+++ b/ui/imports/shared/views/chat/ChatTextView.qml
@@ -24,7 +24,17 @@ Item {
 
     z: 51
 
-    implicitHeight: visible ? (showMoreLoader.active ? childrenRect.height - 10 : chatText.height) : 0
+    implicitHeight: {
+        if (!visible)
+           return 0;
+        if (!chatText.visible && showMoreLoader.active)
+            return childrenRect.height - 10;
+        if (root.veryLongChatText && !root.readMore)
+            return Math.min(chatText.contentHeight, 200);
+        if (chatText.getText(0, chatText.text.length) !== "")
+            return chatText.contentHeight;
+        return 0;
+    }
 
     // This function is to avoid the binding loop warning
     function setWidths() {
@@ -44,14 +54,12 @@ Item {
     StyledTextEdit {
         id: chatText
         objectName: "chatText"
-        visible: !showMoreLoader.active || root.readMore
         textFormat: Text.RichText
         wrapMode: Text.Wrap
         font.pixelSize: Style.current.primaryTextFontSize
         readOnly: true
         selectByMouse: true
         color: Style.current.textColor
-        height: root.veryLongChatText && !root.readMore ? Math.min(implicitHeight, 200) : implicitHeight
         clip: height < implicitHeight
         onLinkActivated: {
             root.linkActivated(link)

--- a/ui/imports/shared/views/chat/CompactMessageView.qml
+++ b/ui/imports/shared/views/chat/CompactMessageView.qml
@@ -537,6 +537,7 @@ Item {
             anchors.rightMargin: root.chatHorizontalPadding
             anchors.topMargin: (!chatName.visible || !chatReply.active  || !pinnedRectangleLoader.active) ? 4 : 0
             visible: !editModeOn
+
             ChatTextView {
                 id: chatText
                 readonly property int leftPadding: chatImage.anchors.leftMargin + chatImage.width + chatHorizontalPadding
@@ -547,11 +548,7 @@ Item {
                 anchors.topMargin: isEmoji ? 2 : 0
                 anchors.left: parent.left
                 anchors.right: parent.right
-                // using a padding instead of a margin let's us select text more easily
-                anchors.leftMargin: -leftPadding
-                textField.leftPadding: leftPadding
                 textField.rightPadding: Style.current.bigPadding
-
                 onLinkActivated: {
                     if (activityCenterMessage) {
                         root.clickMessage(false, isSticker, false, null, false, false, false, false, "")


### PR DESCRIPTION
Closes #6855

### What does the PR do

Chat/CompactMessageView: removed space above image in msg

### Affected areas
Chat/CompactMessageView

### Screenshot of functionality (including design for comparison)
<img width="386" alt="f" src="https://user-images.githubusercontent.com/31625338/183887942-d4367efd-8166-43fd-a935-e86ad14b5d31.png">

