### PR TITLE
fix(@desktop/onboarding) update logo size

### DIFF
--- a/ui/app/AppLayouts/Onboarding/views/LoginView.qml
+++ b/ui/app/AppLayouts/Onboarding/views/LoginView.qml
@@ -431,8 +431,8 @@ Item {
             PropertyChanges {
                 target: image
                 source: Style.png("status-logo")
-                Layout.preferredHeight: 140
-                Layout.preferredWidth: 140
+                Layout.preferredHeight: 128
+                Layout.preferredWidth: 128
             }
             PropertyChanges {
                 target: title


### PR DESCRIPTION
Fixes #6821

### What does the PR do

Updated logo size on Welcome page

### Affected areas

Desktop Onboarding

### Screenshot of functionality (including design for comparison)

- [X] I've checked the design and this PR matches it

![Screenshot from 2022-08-10 16-44-23](https://user-images.githubusercontent.com/6445843/183917327-cf00be2d-ecda-4ca5-b040-ecfa1e716055.png)


### Cool Spaceship Picture
![mass-effect-mass-effect-2-mass-effect-3-normandy-sr-2-wallpaper-preview](https://user-images.githubusercontent.com/6445843/183918143-7887ee89-1e3c-48ba-825b-b31a37e9e46e.jpg)


