### PR TITLE
fix(Chat/UserImage): corrected user image dimensions

### DIFF
--- a/ui/imports/shared/controls/chat/UserImage.qml
+++ b/ui/imports/shared/controls/chat/UserImage.qml
@@ -10,8 +10,8 @@ import StatusQ.Core.Theme 0.1
 Loader {
     id: root
 
-    property int imageHeight: 36
-    property int imageWidth: 36
+    property int imageHeight: 44
+    property int imageWidth: 44
 
     property string name
     property string pubkey


### PR DESCRIPTION
Closes #6852

### What does the PR do
Chat/UserImage: corrected user image dimensions

### Affected areas
Chat/UserImage

### Screenshot of functionality (including design for comparison)
<img width="243" alt="i" src="https://user-images.githubusercontent.com/31625338/183921816-7af94611-2473-4fb5-902d-91b20fb16c1f.png">

Design:
https://user-images.githubusercontent.com/176720/183133173-32a68277-5eb5-4f46-a64d-ca60751e7a85.png