### PR TITLE
ci: fix Xvfb conflicts due to parallel builds

### DIFF
--- a/ci/Jenkinsfile.uitests
+++ b/ci/Jenkinsfile.uitests
@@ -64,7 +64,11 @@ pipeline {
 
     stage('Tests') {
       steps {
-        wrap([$class: 'Xvfb']) {
+        wrap([
+          $class: 'Xvfb',
+          autoDisplayName: true,
+          parallelBuild: true,
+        ]) {
           script {
             def res = squish([
               extraOptions: '''


### PR DESCRIPTION
By default these settings are disable:
```java
    /** Let Xvfb pick display number */
    private boolean autoDisplayName = false;
```
https://github.com/jenkinsci/xvfb-plugin/blob/88cb84e0/src/main/java/org/jenkinsci/plugins/xvfb/Xvfb.java#L434-L435
```java
    /** Run on same node in parallel */
    private boolean parallelBuild = false;
```
https://github.com/jenkinsci/xvfb-plugin/blob/88cb84e0/src/main/java/org/jenkinsci/plugins/xvfb/Xvfb.java#L440-L441

Which means that this code doesn't have an effect by default:
https://github.com/jenkinsci/xvfb-plugin/blob/88cb84e0/src/main/java/org/jenkinsci/plugins/xvfb/Xvfb.java#L637-L647

And causes errors like this:
```
$ /usr/bin/Xvfb :0 -screen 0 1024x768x24 -fbdir /home/jenkins/workspace/desktop_branches_uitests_PR-6952/.xvfb-3-..fbdir7194278924155710961
Xvfb starting(EE)
Fatal server error:
(EE) Server is already active for display 0
```