### PR TITLE
feat(utils): Adding Tracer component

### DIFF
--- a/ui/imports/utils/Tracer.qml
+++ b/ui/imports/utils/Tracer.qml
@@ -1,0 +1,7 @@
+import QtQuick 2.14
+
+Rectangle {
+    anchors.fill: parent
+    color: "transparent"
+    border.color: "red"
+}

--- a/ui/imports/utils/qmldir
+++ b/ui/imports/utils/qmldir
@@ -5,3 +5,4 @@ singleton Constants 1.0 Constants.qml
 singleton SelectedMessage 1.0 SelectedMessage.qml
 singleton Backpressure 1.0 Backpressure/Backpressure.qml
 Audio 1.0 Audio.qml
+Tracer 1.0 Tracer.qml


### PR DESCRIPTION
### What does the PR do
Adding Tracer component: Used to help determine UI components position and dimensions. Example photo attached

### Affected areas
utilities

### Screenshot of functionality (including design for comparison)
<img width="1328" alt="e" src="https://user-images.githubusercontent.com/31625338/183933913-bdad7a21-4648-45cd-93fb-5f1fd48cd6c0.png">

