### PR TITLE
test(chat): Can do a mention in a chat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,9 +42,7 @@ nim_status_client.log
 
 test/ui-test/testSuites/suite_status/config.xml
 test/ui-test/testSuites/suite_status/envvars
-test/ui-test/testSuites/suite_status/shared/scripts/__pycache__/*
-test/ui-test/testSuites/suite_status/shared/scripts/sections/__pycache__/*
-
+test/ui-test/**/__pycache__/*
 
 # CPP app =====================================================================
 

--- a/test/ui-test/src/drivers/SquishDriverVerification.py
+++ b/test/ui-test/src/drivers/SquishDriverVerification.py
@@ -88,3 +88,9 @@ def verify_the_app_is_closed(pid: int):
 
 def verify_equals(val1, val2):
     test.compare(val1, val2, "1st value [" + str(val1) + ("] equal to " if val1 == val2 else "] NOT equal to ") + "2nd value [" + str(val2) + "]")
+
+def verify_failure(errorMsg: str):
+    test.fail(errorMsg)
+    
+def log(text: str):
+    test.log(text)

--- a/test/ui-test/src/screens/SettingsScreen.py
+++ b/test/ui-test/src/screens/SettingsScreen.py
@@ -53,7 +53,7 @@ class SettingsScreen:
         click_obj_by_name(SidebarComponents.WALLET_ITEM.value)
         
     def activate_open_wallet_settings(self):
-        if not (is_Visible(SidebarComponents.WALLET_ITEM.value)) :
+        if not (is_found(SidebarComponents.WALLET_ITEM.value)) :
             click_obj_by_name(SidebarComponents.ADVANCED_OPTION.value)
             click_obj_by_name(AdvancedOptionScreen.ACTIVATE_OR_DEACTIVATE_WALLET.value)
             click_obj_by_name(AdvancedOptionScreen.I_UNDERSTAND_POP_UP.value)
@@ -62,7 +62,7 @@ class SettingsScreen:
         self.open_wallet_settings()
 
     def activate_open_wallet_section(self):
-        if not (is_Visible(SidebarComponents.WALLET_ITEM.value)):
+        if not (is_found(SidebarComponents.WALLET_ITEM.value)):
             click_obj_by_name(SidebarComponents.ADVANCED_OPTION.value)
             click_obj_by_name(AdvancedOptionScreen.ACTIVATE_OR_DEACTIVATE_WALLET.value)
             click_obj_by_name(AdvancedOptionScreen.I_UNDERSTAND_POP_UP.value)

--- a/test/ui-test/testSuites/suite_status/shared/scripts/sections/chat_names.py
+++ b/test/ui-test/testSuites/suite_status/shared/scripts/sections/chat_names.py
@@ -18,6 +18,9 @@ chatView_replyToMessageButton = {"container": chatView_log, "objectName": "reply
 chatView_DeleteMessageButton = {"container": chatView_log, "objectName": "chatDeleteMessageButton", "type": "StatusFlatRoundButton"}
 chatButtonsPanelConfirmDeleteMessageButton_StatusButton = {"container": statusDesktop_mainWindow_overlay, "objectName": "chatButtonsPanelConfirmDeleteMessageButton", "type": "StatusButton"}
 mark_as_Read_StatusMenuItemDelegate = {"container": statusDesktop_mainWindow_overlay, "objectName": "chatMarkAsReadMenuItem", "type": "StatusMenuItemDelegate", "visible": True}
+chatView_SuggestionBoxPanel ={"container": statusDesktop_mainWindow, "objectName": "suggestionsBox", "type": "SuggestionBoxPanel"}
+chatView_suggestion_ListView ={"container": chatView_SuggestionBoxPanel, "objectName": "suggestionBoxList", "type": "StatusListView"}
+chatView_userMentioned_ProfileView ={"container": statusDesktop_mainWindow_overlay, "objectName": "profileView", "type": "ProfileView"}
 
 # Join chat popup:
 startChat_Btn = {"container": statusDesktop_mainWindow_overlay, "objectName": "startChatButton", "type": "StatusButton"}

--- a/test/ui-test/testSuites/suite_status/shared/steps/chatSteps.py
+++ b/test/ui-test/testSuites/suite_status/shared/steps/chatSteps.py
@@ -13,6 +13,7 @@ _statusCreateChatView = StatusCreateChatScreen()
 @When("user joins chat room |any|")
 def step(context, room):
     _statusMain.join_chat_room(room)
+    _statusChat.chat_loaded()
     
 @When("the user creates a group chat adding users")
 def step(context):
@@ -22,6 +23,10 @@ def step(context):
 @When("the user clicks on |any| chat")
 def step(context, chatName):
     _statusMain.open_chat(chatName)
+    
+@When("the user inputs a mention to |any| with message |any|")
+def step(context,displayName,message):
+    _statusChat.send_message_with_mention(displayName, message)    
 
 @Then("user is able to send chat message")
 def step(context):
@@ -85,3 +90,10 @@ def step(context, message):
 def step(context):
     _statusChat.verify_last_message_sent_is_not(context.userData["randomMessage"])
     
+@Then("the user cannot input a mention to a not existing user |any|")
+def step(context, displayName):
+    _statusChat.cannot_do_mention(displayName)
+    
+@Then("the |any| mention with message |any| have been sent")
+def step(context,displayName,message):
+    _statusChat.verify_last_message_sent_contains_mention(displayName, message)

--- a/test/ui-test/testSuites/suite_status/tst_ChatFlow/test.feature
+++ b/test/ui-test/testSuites/suite_status/tst_ChatFlow/test.feature
@@ -4,7 +4,8 @@
 # https://cucumber.io/docs/gherkin/reference/
 Feature: Status Desktop Chat
 
-    As a user I want to join a room and chat.
+	# TODO The complete feature / all scenarios have a chance to fail since they rely on the mailserver (at least, to verify a chat is loaded, something in the history needs to be displayed).
+    As a user I want to join a room and chat and do basic interactions.
 
     The following scenarios cover basic chat flows.
 
@@ -13,7 +14,7 @@ Feature: Status Desktop Chat
     	 When user signs up with username tester123 and password TesTEr16843/!@00
     	 Then the user lands on the signed in app
 
-    Scenario: User joins a room and chats
+    Scenario: User joins a public room and chats
 		 When user joins chat room test
 		 Then user is able to send chat message
 		 | message  			 |
@@ -54,3 +55,19 @@ Feature: Status Desktop Chat
  #   Scenario: User cannot delete another user's message
  #        When user joins chat room test
  #        Then the user cannot delete the last message
+
+#	Scenario Outline: The user can do a mention
+#		When user joins chat room test
+#		And the user inputs a mention to <displayName> with message <message>
+#		Then the <displayName> mention with message <message> have been sent
+#	Examples:
+#		| displayName | message          |
+#		| tester123   |  testing mention |
+
+#	Scenario Outline: The user can not do a mention to not existing users
+#		When user joins chat room test
+#		Then the user cannot input a mention to a not existing user <displayName>
+#	Examples:
+#		| displayName        |
+#		| notExistingAccount |
+#		| asdfgNoNo          |

--- a/ui/app/AppLayouts/Chat/panels/SuggestionBoxPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/SuggestionBoxPanel.qml
@@ -119,6 +119,7 @@ Rectangle {
 
     StatusListView {
         id: listView
+        objectName: "suggestionBoxList"
         model: mentionsListDelegate
         keyNavigationEnabled: true
         anchors.fill: parent
@@ -194,6 +195,7 @@ Rectangle {
 
             delegate: Rectangle {
                 id: itemDelegate
+                objectName: model.name
                 color: ListView.isCurrentItem ? Style.current.backgroundHover : Style.current.transparent
                 border.width: 0
                 width: parent.width

--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -689,6 +689,7 @@ Rectangle {
 
     SuggestionBoxPanel {
         id: suggestionsBox
+        objectName: "suggestionsBox"
         model: control.usersStore ? control.usersStore.usersModel : []
         x : messageInput.x
         y: -height - Style.current.smallPadding

--- a/ui/imports/shared/views/ProfileView.qml
+++ b/ui/imports/shared/views/ProfileView.qml
@@ -82,6 +82,7 @@ Rectangle {
     signal contactRemoved(publicKey: string)
     signal nicknameEdited(publicKey: string)
 
+    objectName: "profileView"
     implicitWidth: modalContent.implicitWidth
     implicitHeight: modalContent.implicitHeight
 


### PR DESCRIPTION
Closes [#6879
](https://github.com/status-im/status-desktop/issues/6879)

**IMPORTANT: Weak test because it relys on `mailserver` and if the chat history is not loaded, it will fail!!!**

### What does the PR do
`tst_chatFlow`:
- Added basic test scenario for sending a mention in a public chat with needed validations.
- Added basic test scenario to check a mention cannot be done if it is a non existing user.

`StatusChatScreen` updates:
- Updated join room method to validate the chat is loaded.
- Added methods for doing and verifying a mention.

`SquishDriver` updates:
- Added support in `SquishDriver` to click into a link in a text or label component.
- Minor function renames.

### Affected areas
- `tst_chatFlow`

### Screenshot of functionality (including design for comparison)

- Can do mention:

https://user-images.githubusercontent.com/97019400/184088019-4a9bdf9f-7720-4654-8f6c-25d0df11b383.mov

- Cannot do mention:

https://user-images.githubusercontent.com/97019400/184087955-57a84751-741f-480c-af49-29786036008d.mov