### PR TITLE
fix(@desktop/wallet): add account - password checking adjusted

### DIFF
--- a/ui/app/AppLayouts/Wallet/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Wallet/stores/RootStore.qml
@@ -181,8 +181,8 @@ QtObject {
         globalUtils.copyToClipboard(text)
     }
 
-    function getDerivedAddressList(password, derivedFrom, path, pageSize , pageNumber) {
-        walletSectionAccounts.getDerivedAddressList(password, derivedFrom, path, pageSize , pageNumber)
+    function getDerivedAddressList(password, derivedFrom, path, pageSize, pageNumber) {
+        walletSectionAccounts.getDerivedAddressList(password, derivedFrom, path, pageSize, pageNumber)
     }
 
     function getDerivedAddressData(index) {


### PR DESCRIPTION
### What does the PR do

Fixes #6625 
Fixes #6983

Fixes issues regarding password checking and disabling "Add account" button, depending on used origin:
- Default / Imported
  The "Add account" button is disabled always when password is incorrect (password is needed to fetch the derived addresses ist)
- Import new Seed Phrase / Generate from Private key
  The password is checked when "Add account" is pressed and error label is set in the password is wrong

Moreover:
- js code modernized, "readonly" modifier added to properties where applicable
- some unnecessary checks removed
- password field cleared on close instead on open

### Affected areas

`AddAccountModal`

### Screenshot of functionality (including design for comparison)

https://user-images.githubusercontent.com/20650004/184322788-1706d451-b2d6-4feb-a271-03a9f46bf355.mp4

https://user-images.githubusercontent.com/20650004/184322793-3c15e8aa-8578-48b4-8b22-f71b8a53e218.mp4
