### PR TITLE
feat: use a higher kdf number for DB encryption

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -320,6 +320,12 @@ DEFAULT_TENOR_API_KEY := DU7DWZ27STB2
 TENOR_API_KEY ?= $(DEFAULT_TENOR_API_KEY)
 NIM_PARAMS += -d:TENOR_API_KEY:"$(TENOR_API_KEY)"
 
+# used to override the default number of kdf iterations for sqlcipher
+KDF_ITERATIONS ?= 0
+ifeq ($(shell test $(KDF_ITERATIONS) -gt 0; echo $$?),0)
+  NIM_PARAMS += -d:KDF_ITERATIONS:"$(KDF_ITERATIONS)"
+endif
+
 NIM_PARAMS += -d:chronicles_sinks=textlines[stdout],textlines[nocolors,dynamic],textlines[file,nocolors] -d:chronicles_runtime_filtering=on -d:chronicles_default_output_device=dynamic
 
 RESOURCES_LAYOUT := -d:development

--- a/src/app_service/service/accounts/dto/accounts.nim
+++ b/src/app_service/service/accounts/dto/accounts.nim
@@ -23,6 +23,7 @@ type AccountDto* = object
   images*: seq[Image]
   colorHash*: ColorHashDto
   colorId*: int
+  kdfIterations*: int
 
 proc isValid*(self: AccountDto): bool =
   result = self.name.len > 0 and self.keyUid.len > 0
@@ -44,6 +45,8 @@ proc toAccountDto*(jsonObj: JsonNode): AccountDto =
   discard jsonObj.getProp("keycard-pairing", result.keycardPairing)
   discard jsonObj.getProp("key-uid", result.keyUid)
   discard jsonObj.getProp("colorId", result.colorId)
+  discard jsonObj.getProp("kdfIterations", result.kdfIterations)
+
   if jsonObj.hasKey("colorHash"):
     result.colorHash = toColorHashDto(jsonObj["colorHash"])
 

--- a/src/app_service/service/accounts/service.nim
+++ b/src/app_service/service/accounts/service.nim
@@ -22,6 +22,7 @@ logScope:
 const PATHS = @[PATH_WALLET_ROOT, PATH_EIP_1581, PATH_WHISPER, PATH_DEFAULT_WALLET]
 const ACCOUNT_ALREADY_EXISTS_ERROR =  "account already exists"
 const output_csv {.booldefine.} = false
+const KDF_ITERATIONS* {.intdefine.} = 256_000
 
 include utils
 

--- a/src/app_service/service/accounts/service.nim
+++ b/src/app_service/service/accounts/service.nim
@@ -176,7 +176,8 @@ proc prepareAccountJsonObject(self: Service, account: GeneratedAccountDto, displ
     "name": if displayName == "": account.alias else: displayName,
     "address": account.address,
     "key-uid": account.keyUid,
-    "keycard-pairing": nil
+    "keycard-pairing": nil,
+    "kdfIterations": KDF_ITERATIONS,
   }
 
 proc getAccountDataForAccountId(self: Service, accountId: string, displayName: string): JsonNode =
@@ -530,7 +531,7 @@ proc login*(self: Service, account: AccountDto, password: string): string =
         "UDPPort": wV2Port,
       })
 
-    let response = status_account.login(account.name, account.keyUid, hashedPassword, thumbnailImage,
+    let response = status_account.login(account.name, account.keyUid, account.kdfIterations, hashedPassword, thumbnailImage,
       largeImage, $nodeCfg)
     var error = "response doesn't contain \"error\""
     if(response.result.contains("error")):

--- a/src/backend/accounts.nim
+++ b/src/backend/accounts.nim
@@ -251,7 +251,7 @@ proc convertToKeycardAccount*(keyStoreDir: string, account: JsonNode, settings: 
     error "error doing rpc request", methodName = "convertToKeycardAccount", exception=e.msg
     raise newException(RpcException, e.msg)
 
-proc login*(name, keyUid, hashedPassword, thumbnail, large: string, nodeCfgObj: string):
+proc login*(name, keyUid: string, kdfIterations: int, hashedPassword, thumbnail, large: string, nodeCfgObj: string):
   RpcResponse[JsonNode]
   {.raises: [Exception].} =
   try:
@@ -259,6 +259,7 @@ proc login*(name, keyUid, hashedPassword, thumbnail, large: string, nodeCfgObj: 
       "name": name,
       "key-uid": keyUid,
       "identityImage": newJNull(),
+      "kdfIterations": kdfIterations,
     }
 
     if(thumbnail.len>0 and large.len > 0):


### PR DESCRIPTION
The following scenarios must be tested:

Login with an existing account
Login after changing the password
Exporting a database
New account creation
Creating an account with seed phrase
Creating an account with keycard
Login with keycard

Requires
- https://github.com/status-im/status-go/pull/2796