### PR TITLE
fix(@desktop/profile): first login shows state offline in the sidebar fixes #6854

### DIFF
--- a/src/app_service/service/accounts/service.nim
+++ b/src/app_service/service/accounts/service.nim
@@ -233,7 +233,13 @@ proc prepareAccountSettingsJsonObject(self: Service, account: GeneratedAccountDt
     "wallet/visible-tokens": {},
     "waku-enabled": true,
     "appearance": 0,
-    "installation-id": installationId
+    "installation-id": installationId,
+    "current-user-status": %* {
+        "publicKey": account.derivedAccounts.whisper.publicKey,
+        "statusType": 1,
+        "clock": 0,
+        "text": ""
+      }
   }
 
 proc getAccountSettings(self: Service, accountId: string,
@@ -384,7 +390,13 @@ proc setupAccountKeycard*(self: Service, keycardData: KeycardEvent) =
       "wallet/visible-tokens": {},
       "waku-enabled": true,
       "appearance": 0,
-      "installation-id": installationId
+      "installation-id": installationId,
+      "current-user-status": {
+        "publicKey": keycardData.whisperKey.publicKey,
+        "statusType": 1,
+        "clock": 0,
+        "text": ""
+      }
     }
 
     self.addKeycardDetails(settingsJson, accountDataJson)

--- a/test/ui-test/src/screens/StatusMainScreen.py
+++ b/test/ui-test/src/screens/StatusMainScreen.py
@@ -27,6 +27,7 @@ class MainScreenComponents(Enum):
     MARK_AS_READ_BUTTON = "mark_as_Read_StatusMenuItemDelegate"
     COMMUNITY_NAVBAR_BUTTONS = "navBarListView_All_Community_Buttons"
     MODULE_WARNING_BANNER = "moduleWarning_Banner"
+    PROFILE_NAVBAR_BUTTON = "mainWindow_ProfileNavBarButton"
 
 class ChatNamePopUp(Enum):
     CHAT_NAME_TEXT = "chat_name_PlaceholderText"
@@ -91,3 +92,7 @@ class StatusMainScreen:
     def verify_communities_count(self, expected_count: int):
         objects = get_objects(MainScreenComponents.COMMUNITY_NAVBAR_BUTTONS.value)
         verify_equals(len(objects), int(expected_count))
+
+    def user_is_online(self):
+        profileButton = squish.waitForObject(getattr(names, MainScreenComponents.PROFILE_NAVBAR_BUTTON.value))
+        verify_equal(profileButton.badge.color.name, "#4ebc60", "The user is not online by default")

--- a/test/ui-test/testSuites/global_shared/scripts/global_names.py
+++ b/test/ui-test/testSuites/global_shared/scripts/global_names.py
@@ -8,6 +8,7 @@ moduleWarning_Banner = {"container": statusDesktop_mainWindow, "objectName": "mo
 statusDesktop_mainWindow_AppMain_EmojiPopup_SearchTextInput = {"container": statusDesktop_mainWindow_overlay, "objectName": "StatusEmojiPopup_searchBox", "type": "TextEdit", "visible": True}
 mainWindow_ScrollView = {"container": statusDesktop_mainWindow, "type": "StatusScrollView", "unnamed": 1, "visible": True}
 mainWindow_ScrollView_2 = {"container": statusDesktop_mainWindow, "occurrence": 2, "type": "StatusScrollView", "unnamed": 1, "visible": True}
+mainWindow_ProfileNavBarButton = {"container": statusDesktop_mainWindow, "objectName": "statusProfileNavBarTabButton", "type": "StatusNavBarTabButton", "visible": True}
 
 # popups
 close_popup_StatusFlatRoundButton = {"container": statusDesktop_mainWindow_overlay, "id": "closeButton", "type": "StatusFlatRoundButton", "unnamed": 1, "visible": True}

--- a/test/ui-test/testSuites/suite_onboarding/shared/steps/signUpSteps.py
+++ b/test/ui-test/testSuites/suite_onboarding/shared/steps/signUpSteps.py
@@ -2,6 +2,8 @@ from screens.StatusWelcomeScreen import StatusWelcomeScreen
 from screens.StatusMainScreen import StatusMainScreen
 
 _welcomeScreen = StatusWelcomeScreen()
+_mainScreen = StatusMainScreen()
+
 
 
 @Given("A first time user lands on the status desktop and generates new key")
@@ -30,7 +32,7 @@ def step(context, username):
 
 @Then("the user lands on the signed in app")
 def step(context): 
-    StatusMainScreen()
+    _mainScreen
     
     
 @When("The user inputs the seed phrase |any|")
@@ -41,3 +43,7 @@ def step(context, seed_phrase):
 @Then("the invalid seed text is visible")
 def step(context):
     _welcomeScreen.seed_phrase_visible()
+    
+@Then("the user is online")
+def step(context):
+    _mainScreen.user_is_online()

--- a/test/ui-test/testSuites/suite_onboarding/tst_statusSignUp/test.feature
+++ b/test/ui-test/testSuites/suite_onboarding/tst_statusSignUp/test.feature
@@ -131,3 +131,7 @@ Feature: Status Desktop Sign Up
     Then the following ui-component seedPhraseView_Submit_Button is not enabled
     And the invalid seed text is visible
 
+  Scenario: After Signing up the Profile state should be online
+    Given A first time user lands on the status desktop and generates new key
+    When user signs up with username tester123 and password TesTEr16843/!@00
+    Then the user is online

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -348,6 +348,7 @@ Item {
 
             navBarProfileButton: StatusNavBarTabButton {
                 id: profileButton
+                objectName: "statusProfileNavBarTabButton"
                 property bool opened: false
 
                 name: appMain.rootStore.userProfileInst.name


### PR DESCRIPTION
fix(@desktop/profile): Can set own online state to online, offline

fixes #6854 

status-go: https://github.com/status-im/status-go/pull/2798

### What does the PR do

Implements a fix for and test case for User should be online after first time login

### Affected areas

Wallet

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it
