### PR TITLE
chore: setup a mailserver as part of UI tests run in CI

### DIFF
--- a/ci/Jenkinsfile.uitests
+++ b/ci/Jenkinsfile.uitests
@@ -22,7 +22,7 @@ pipeline {
   options {
     timestamps()
     /* Prevent Jenkins jobs from running forever */
-    timeout(time: 60, unit: 'MINUTES')
+    timeout(time: 120, unit: 'MINUTES')
     /* manage how many builds we keep */
     buildDiscarder(logRotator(
       numToKeepStr: '10',
@@ -84,23 +84,30 @@ pipeline {
           def goerli_rpc_port = 855 + env.EXECUTOR_NUMBER
           def mnemonic = "pelican chief sudden oval media rare swamp elephant lawsuit wheat knife initial"
           def goerli_db_path = "$WORKSPACE/test/ui-test/fixtures/ganache-dbs/goerli"
+          def rpc_port = 864 + env.EXECUTOR_NUMBER
+          def geth_port = 3131 + env.EXECUTOR_NUMBER
           docker.image('trufflesuite/ganache:v7.4.1').withRun(
             "-p 127.0.0.1:${goerli_rpc_port}:8545 -v ${goerli_db_path}:/goerli-db",
             "-e 10 -m='${mnemonic}' --chain.chainId 5 --database.dbPath /goerli-db"
           ) { c ->
             sh "docker logs ${c.id}"
-            withEnv(["GOERLI_NETWORK_RPC_URL=http://0.0.0.0:${goerli_rpc_port}"]){
-              wrap([
-                $class: 'Xvfb',
-                autoDisplayName: true,
-                parallelBuild: true,
-                screen: '2560x1440x24',
-              ]) {
-                script {
-                  def res = squish([
-                    extraOptions: '''
-                      --retry
-                      2
+            docker.image('statusteam/status-go:v0.84.0').withRun(
+              "-p 127.0.0.1:${rpc_port}:8545 -p 127.0.0.1:${geth_port}:30303/tcp -p 127.0.0.1:${geth_port}:30303/udp -v ${env.WORKSPACE}/ci/mailserver/config.json:/config.json",
+              "-log=INFO -log-without-color -c=/config.json -dir=/tmp"
+            ) { c2 ->
+              env.PEER_ENR = sh(script:"RPC_PORT=${rpc_port} MAILSERVER_PORT=${geth_port} ${env.WORKSPACE}/ci/mailserver/get_enode.sh", returnStdout:true).trim()
+              withEnv(["TEST_PEER_ENR=${env.PEER_ENR}", "GOERLI_NETWORK_RPC_URL=http://0.0.0.0:${goerli_rpc_port}"]){
+                wrap([
+                  $class: 'Xvfb',
+                  autoDisplayName: true,
+                  parallelBuild: true,
+                  screen: '2560x1440x24',
+                ]) {
+                  script {
+                    def res = squish([
+                      extraOptions: '''
+                        --retry
+                        2
 
                       --tags
                       ~mayfail
@@ -115,11 +122,12 @@ pipeline {
                     ''',
                     squishPackageName: 'squish-6.7.2-qt514x-linux64',
                     testSuite: '${WORKSPACE}/test/ui-test/testSuites/*',
-                  ])
-                  if ( res == "SUCCESS" || res == "UNSTABLE" ) {
-                    return 
+                    ])
+                    if ( res == "SUCCESS" || res == "UNSTABLE" ) {
+                      return 
+                    }
+                    throw new Exception("squish test didn't end with success")
                   }
-                  throw new Exception("squish test didn't end with success")
                 }
               }
             }

--- a/ci/mailserver/config.json
+++ b/ci/mailserver/config.json
@@ -1,0 +1,29 @@
+{
+  "Rendezvous": false,
+  "NoDiscovery": true,
+  "ClusterConfig": {
+    "Enabled": true,
+    "Fleet": "eth.prod",
+    "BootNodes": [],
+    "TrustedMailServers": [],
+    "PushNotificationsServers": [],
+    "StaticNodes": []
+  },
+  "ListenAddr": "0.0.0.0:30303",
+  "HTTPEnabled": true,
+  "HTTPHost": "0.0.0.0",
+  "HTTPPort": 8545,
+  "MaxPeers": 50,
+  "DataDir": "/var/tmp/status-go-mailserver",
+  "APIModules": "eth,web3,admin,waku,wakuext",
+  "RegisterTopics": [
+    "whispermail"
+  ],
+  "WakuConfig": {
+    "Enabled": true,
+    "EnableMailServer": true,
+    "DataDir": "/var/tmp/status-go-mailserver/waku",
+    "MailServerPassword": "status-offline-inbox",
+    "MailServerDataRetention": 30
+  }
+}

--- a/ci/mailserver/get_enode.sh
+++ b/ci/mailserver/get_enode.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+RPC_ADDR="${RPC_ADDR:-localhost}"
+RPC_PORT="${RPC_PORT:-8545}"
+MAILSERVER_PORT="${MAILSERVER_PORT:-30303}"
+# might be provided by parent
+if [[ -z "${PUBLIC_IP}" ]]; then
+    PUBLIC_IP=$(curl -s https://ipecho.net/plain)
+fi
+
+# query local 
+RESP_JSON=$(
+    curl -sS --retry 3 --retry-connrefused \
+        -X POST http://${RPC_ADDR}:${RPC_PORT}/ \
+        -H 'Content-type: application/json' \
+        -d '{"jsonrpc":"2.0","method":"admin_nodeInfo","params":[],"id":1}'
+)
+if [[ "$?" -ne 0 ]]; then
+    echo "RPC port not up, unable to query enode address!" 1>&2
+    exit 1
+fi
+
+# extract enode from JSON response
+ENODE_RAW=$(echo "${RESP_JSON}" | jq -r '.result.enode')
+# drop arguments at the end of enode address
+ENODE_CLEAN=$(echo "${ENODE_RAW}" | grep -oP '\Kenode://[^?]+')
+
+ENODE=$(echo "${ENODE_CLEAN}" | sed \
+    -e "s/:30303/:${MAILSERVER_PORT}/")
+
+echo "${ENODE}"

--- a/src/app/modules/main/profile_section/sync/controller.nim
+++ b/src/app/modules/main/profile_section/sync/controller.nim
@@ -46,7 +46,7 @@ proc pinMailserver*(self: Controller, nodeAddress: string) =
   discard self.settingsService.pinMailserver(nodeAddress, fleet)
 
 proc saveNewMailserver*(self: Controller, name: string, nodeAddress: string) =
-  self.mailserversService.saveMailserver(name, nodeAddress)
+  discard self.mailserversService.saveMailserver(name, nodeAddress)
 
 proc enableAutomaticSelection*(self: Controller, value: bool) =
   self.mailserversService.enableAutomaticSelection(value)

--- a/test/ui-test/testSuites/suite_status/tst_groupChat/test.feature
+++ b/test/ui-test/testSuites/suite_status/tst_groupChat/test.feature
@@ -8,7 +8,6 @@ Feature: Status Desktop Group Chat
     When the user tester123 logs in with password TesTEr16843/!@00
     Then the user lands on the signed in app
 
-    @mayfail
  	Scenario: As an admin user I want to create a group chat with my contacts and the invited users can send messages
 
        When the user creates a group chat adding users


### PR DESCRIPTION
fixes #6999
- Creates a mailserver as part of the uitests
- Adds the `TEST_PEER_ENR` environment variable which should contain the enode address that will be added as a peer, bootnode and pinned mailserver.