### PR TITLE
fix(@desktop/wallet): Added squish test for the user being able to turn his state to online and/or offline

### DIFF
--- a/test/ui-test/src/screens/StatusMainScreen.py
+++ b/test/ui-test/src/screens/StatusMainScreen.py
@@ -28,6 +28,9 @@ class MainScreenComponents(Enum):
     COMMUNITY_NAVBAR_BUTTONS = "navBarListView_All_Community_Buttons"
     MODULE_WARNING_BANNER = "moduleWarning_Banner"
     PROFILE_NAVBAR_BUTTON = "mainWindow_ProfileNavBarButton"
+    USERSTATUSMENU_ALWAYS_ACTIVE_ACTION = "userContextmenu_AlwaysActiveButton"
+    USERSTATUSMENU_INACTIVE_ACTION = "userContextmenu_InActiveButton"
+    USERSTATUSMENU_AUTOMATIC_ACTION = "userContextmenu_AutomaticButton"
 
 class ChatNamePopUp(Enum):
     CHAT_NAME_TEXT = "chat_name_PlaceholderText"
@@ -96,3 +99,23 @@ class StatusMainScreen:
     def user_is_online(self):
         profileButton = squish.waitForObject(getattr(names, MainScreenComponents.PROFILE_NAVBAR_BUTTON.value))
         verify_equal(profileButton.badge.color.name, "#4ebc60", "The user is not online by default")
+
+    def user_is_offline(self):
+        profileButton = squish.waitForObject(getattr(names, MainScreenComponents.PROFILE_NAVBAR_BUTTON.value))
+        verify_equal(profileButton.badge.color.name, "#7f8990", "The user is not offline")
+        
+    def user_is_set_to_automatic(self):
+        profileButton = squish.waitForObject(getattr(names, MainScreenComponents.PROFILE_NAVBAR_BUTTON.value))
+        verify_equal(profileButton.badge.color.name, "#4ebc60", "The user is not online by default")
+        
+    def set_user_state_offline(self):
+        click_obj_by_name(MainScreenComponents.PROFILE_NAVBAR_BUTTON.value)
+        click_obj_by_name(MainScreenComponents.USERSTATUSMENU_INACTIVE_ACTION.value)
+        
+    def set_user_state_online(self):
+        click_obj_by_name(MainScreenComponents.PROFILE_NAVBAR_BUTTON.value)
+        click_obj_by_name(MainScreenComponents.USERSTATUSMENU_ALWAYS_ACTIVE_ACTION.value)
+        
+    def set_user_state_to_automatic(self):
+        click_obj_by_name(MainScreenComponents.PROFILE_NAVBAR_BUTTON.value)
+        click_obj_by_name(MainScreenComponents.USERSTATUSMENU_AUTOMATIC_ACTION.value)

--- a/test/ui-test/testSuites/suite_status/shared/scripts/sections/settings_names.py
+++ b/test/ui-test/testSuites/suite_status/shared/scripts/sections/settings_names.py
@@ -114,3 +114,9 @@ backup_seed_phrase_popup_BackupSeedStepBase_confirmSecondWord = {"container": st
 backup_seed_phrase_popup_BackupSeedStepBase_confirmSecondWord_inputText = {"container": backup_seed_phrase_popup_BackupSeedStepBase_confirmSecondWord, "objectName": "BackupSeedStepBase_inputText", "type": "TextEdit", "visible": True}
 backup_seed_phrase_popup_ConfirmStoringSeedPhrasePanel_storeCheck = {"container": statusDesktop_mainWindow_overlay, "objectName": "ConfirmStoringSeedPhrasePanel_storeCheck", "type": "StatusCheckBox", "checkable": True, "visible": True}
 backup_seed_phrase_popup_BackupSeedModal_completeAndDeleteSeedPhraseButton = {"container": statusDesktop_mainWindow_overlay, "objectName": "BackupSeedModal_completeAndDeleteSeedPhraseButton", "type": "StatusButton", "visible": True}
+
+# User Status Profile Menu
+userContextmenu_AlwaysActiveButton= {"container": statusDesktop_mainWindow_overlay, "objectName": "userStatusMenuAlwaysOnlineAction", "type": "StatusMenuItemDelegate", "visible": True}
+userContextmenu_InActiveButton= {"container": statusDesktop_mainWindow_overlay, "objectName": "userStatusMenuInactiveAction", "type": "StatusMenuItemDelegate", "visible": True}
+userContextmenu_AutomaticButton= {"container": statusDesktop_mainWindow_overlay, "objectName": "userStatusMenuAutomaticAction", "type": "StatusMenuItemDelegate", "visible": True}
+

--- a/test/ui-test/testSuites/suite_status/shared/steps/settingsSteps.py
+++ b/test/ui-test/testSuites/suite_status/shared/steps/settingsSteps.py
@@ -142,3 +142,27 @@ def step(context):
 @Then("the backup seed phrase indicator is not displayed")
 def step(context):
     _settingsScreen.verify_seed_phrase_indicator_not_visible()
+
+@When("the users switches his state to offline")
+def step(context: any):
+    _statusMain.set_user_state_offline()
+        
+@When("the users switches his state to online")
+def step(context: any):
+    _statusMain.set_user_state_online()
+            
+@When("the users switches his state to automatic")
+def step(context: any):
+    _statusMain.set_user_state_to_automatic()
+    
+@Then("the user appears offline")
+def step(context: any):
+    _statusMain.user_is_offline()
+        
+@Then("the user appears online")
+def step(context: any):
+    _statusMain.user_is_online()
+         
+@Then("the user status is automatic")
+def step(context: any):
+    _statusMain.user_is_set_to_automatic()   

--- a/test/ui-test/testSuites/suite_status/tst_settingsMenu/test.feature
+++ b/test/ui-test/testSuites/suite_status/tst_settingsMenu/test.feature
@@ -17,3 +17,28 @@ Feature: Status Desktop Settings Menu
         When the user activates wallet and opens the wallet settings
         And the user backs up the wallet seed phrase
         Then the backup seed phrase indicator is not displayed
+
+    Scenario: The user can switch his state to offline
+    	When the users switches his state to offline
+    	Then the user appears offline
+    	When the user restarts the app
+    	And the user tester123 logs in with password TesTEr16843/!@00
+    	Then the user appears offline
+
+    Scenario: The user can switch his state to online
+        When the users switches his state to offline
+    	And the user restarts the app
+    	And the user tester123 logs in with password TesTEr16843/!@00
+    	Then the user appears offline
+    	When the users switches his state to online
+    	Then the user appears online
+    	When the user restarts the app
+    	And the user tester123 logs in with password TesTEr16843/!@00
+    	Then the user appears online
+
+Scenario: The user can switch his state to automatic
+    	When the users switches his state to automatic
+    	Then the user status is automatic
+    	When the user restarts the app
+    	And the user tester123 logs in with password TesTEr16843/!@00
+    	Then the user status is automatic

--- a/ui/imports/shared/popups/UserStatusContextMenu.qml
+++ b/ui/imports/shared/popups/UserStatusContextMenu.qml
@@ -42,6 +42,7 @@ StatusPopupMenu {
 
     StatusMenuItem {
         id: alwaysOnlineAction
+        objectName: "userStatusMenuAlwaysOnlineAction"
         text: qsTr("Always online")
         image.source: Style.svg("statuses/online")
         image.width: 12
@@ -55,6 +56,7 @@ StatusPopupMenu {
 
     StatusMenuItem {
         id: inactiveAction
+        objectName: "userStatusMenuInactiveAction"
         text: qsTr("Inactive")
         image.source: Style.svg("statuses/inactive")
         image.width: 12
@@ -68,6 +70,7 @@ StatusPopupMenu {
 
     StatusMenuItem {
         id: automaticAction
+        objectName: "userStatusMenuAutomaticAction"
         text: qsTr("Set status automatically")
         image.source: Style.svg("statuses/automatic")
         fontSettings.bold: root.store.userProfileInst.currentUserStatus === Constants.currentUserStatus.automatic


### PR DESCRIPTION
fix(@desktop/wallet): Added squish test for the user being able to turn his state to online and/or offline

fixes #6895 

### What does the PR do

Added test case to make sure user is able to suceesfully set is status to online and offline

### Affected areas

Wallet

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it
