### PR TITLE
test(Settings/Language): Can change language

### DIFF
--- a/test/ui-test/src/drivers/SquishDriverVerification.py
+++ b/test/ui-test/src/drivers/SquishDriverVerification.py
@@ -27,8 +27,8 @@ def verify_text_matching(objName: str, text: str):
 def verify_text_matching_insensitive(obj, text: str):
     test.verify(is_text_matching_insensitive(obj, text), "text does not match")
     
-def verify_equal(result: object, expected: object, msg: str = "objects are not equal"):
-    test.verify(result == expected, msg)
+def verify_equal(result: object, expected: object):
+    test.verify(result == expected, "Checking if objects are equal")
 
 def verify(result: bool, msg: str):
     test.verify(result, msg)

--- a/test/ui-test/src/screens/SettingsScreen.py
+++ b/test/ui-test/src/screens/SettingsScreen.py
@@ -19,17 +19,16 @@ class SettingsScreenComponents(Enum):
     SAVE_BUTTON: str = "settingsSave_StatusButton"
 
 class SidebarComponents(Enum):
-    ADVANCED_OPTION: str = "advanced_StatusBaseText"
-    WALLET_ITEM: str = "wallet_AppMenu_StatusNavigationListItem"
-    SIGN_OUT_AND_QUIT: str = "sign_out_Quit_ExtraMenu_StatusNavigationListItem"
-    COMMUNITIES_ITEM: str = "communities_AppMenu_StatusNavigationListItem"
-    PROFILE_ITEM: str = "profile_MainMenu_StatusNavigationListItem"
-
+    ADVANCED_OPTION: str = "advanced_StatusNavigationListItem"
+    WALLET_OPTION: str = "wallet_StatusNavigationListItem"
+    LANGUAGE_CURRENCY_OPTION: str = "language_StatusNavigationListItem"
+    SIGN_OUT_AND_QUIT_OPTION: str = "sign_out_Quit_StatusNavigationListItem"
+    COMMUNITIES_OPTION: str = "communities_StatusNavigationListItem"
+    PROFILE_OPTION: str = "profile_StatusNavigationListItem"
 
 class AdvancedOptionScreen(Enum):
     ACTIVATE_OR_DEACTIVATE_WALLET: str = "walletSettingsLineButton"
     I_UNDERSTAND_POP_UP: str = "i_understand_StatusBaseText"
-
 
 class WalletSettingsScreen(Enum):
     GENERATED_ACCOUNTS: str = "settings_Wallet_MainView_GeneratedAccounts"
@@ -63,9 +62,6 @@ class CommunitiesSettingsScreen(Enum):
     LEAVE_COMMUNITY_BUTTONS: str = "settings_Communities_MainView_LeaveCommunityButtons"
     LEAVE_COMMUNITY_POPUP_LEAVE_BUTTON: str = "settings_Communities_MainView_LeavePopup_LeaveCommunityButton"
 
-
-
-
 class SettingsScreen:
     __pid = 0
     
@@ -73,28 +69,25 @@ class SettingsScreen:
         verify_screen(SidebarComponents.ADVANCED_OPTION.value)
     
     def open_wallet_settings(self):
-        click_obj_by_name(SidebarComponents.WALLET_ITEM.value)
-        
-    def activate_open_wallet_settings(self):
-        if not (is_found(SidebarComponents.WALLET_ITEM.value)) :
+        click_obj_by_name(SidebarComponents.WALLET_OPTION.value)
+
+    def activate_wallet_option(self):
+        if not (is_found(SidebarComponents.WALLET_OPTION.value)):
             click_obj_by_name(SidebarComponents.ADVANCED_OPTION.value)
             click_obj_by_name(AdvancedOptionScreen.ACTIVATE_OR_DEACTIVATE_WALLET.value)
             click_obj_by_name(AdvancedOptionScreen.I_UNDERSTAND_POP_UP.value)
-            verify_object_enabled(SidebarComponents.WALLET_ITEM.value)
-           
+            verify_object_enabled(SidebarComponents.WALLET_OPTION.value)
+
+    def activate_open_wallet_settings(self):
+        self.activate_wallet_option()
         self.open_wallet_settings()
 
     def activate_open_wallet_section(self):
-        if not (is_found(SidebarComponents.WALLET_ITEM.value)):
-            click_obj_by_name(SidebarComponents.ADVANCED_OPTION.value)
-            click_obj_by_name(AdvancedOptionScreen.ACTIVATE_OR_DEACTIVATE_WALLET.value)
-            click_obj_by_name(AdvancedOptionScreen.I_UNDERSTAND_POP_UP.value)
-            verify_object_enabled(SidebarComponents.WALLET_ITEM.value)
-           
+        self.activate_wallet_option()           
         click_obj_by_name(MainScreenComponents.WALLET_BUTTON.value)
     
     def delete_account(self, account_name: str):
-        click_obj_by_name(SidebarComponents.WALLET_ITEM.value)
+        self.open_wallet_settings()
         
         index = self._find_account_index(account_name)
             
@@ -117,6 +110,10 @@ class SettingsScreen:
     def toggle_test_networks(self):
         click_obj_by_name(WalletSettingsScreen.NETWORKS_ITEM.value)
         get_and_click_obj(WalletSettingsScreen.TESTNET_TOGGLE.value)
+        click_obj_by_name(WalletSettingsScreen.TESTNET_TOGGLE.value)
+        
+    def open_language_and_currency_settings(self):
+        click_obj_by_name(SidebarComponents.LANGUAGE_CURRENCY_OPTION.value)
     
     def _find_account_index(self, account_name: str) -> int:
         accounts = get_obj(WalletSettingsScreen.GENERATED_ACCOUNTS.value)
@@ -127,7 +124,7 @@ class SettingsScreen:
     
     def sign_out_and_quit_the_app(self, pid: int):
         SettingsScreen.__pid = pid
-        click_obj_by_name(SidebarComponents.SIGN_OUT_AND_QUIT.value)
+        click_obj_by_name(SidebarComponents.SIGN_OUT_AND_QUIT_OPTION.value)
         click_obj_by_name(ConfirmationDialog.SIGN_OUT_CONFIRMATION.value)
         
     def verify_the_app_is_closed(self):
@@ -148,7 +145,6 @@ class SettingsScreen:
 
         click_obj_by_name(WalletSettingsScreen.EDIT_ACCOUNT_SAVE_BUTTON.value)
 
-
     def verify_editedAccount(self, new_name: str, new_color: str):
         accountName = get_obj(WalletSettingsScreen.ACCOUNT_VIEW_ACCOUNT_NAME.value)
         iconSettings = get_obj(WalletSettingsScreen.ACCOUNT_VIEW_ICON_SETTINGS.value)
@@ -156,7 +152,7 @@ class SettingsScreen:
         verify_values_equal(str(iconSettings.icon.color.name), str(new_color.lower()), "Edited account color not updated")
 
     def open_communities_section(self):
-        click_obj_by_name(SidebarComponents.COMMUNITIES_ITEM.value)
+        click_obj_by_name(SidebarComponents.COMMUNITIES_OPTION.value)
 
     def leave_community(self):
         StatusMainScreen.wait_for_banner_to_disappear()
@@ -165,8 +161,8 @@ class SettingsScreen:
         click_obj_by_name(CommunitiesSettingsScreen.LEAVE_COMMUNITY_POPUP_LEAVE_BUTTON.value)
 
     def open_profile_settings(self):
-        verify_object_enabled(SidebarComponents.PROFILE_ITEM.value)
-        click_obj_by_name(SidebarComponents.PROFILE_ITEM.value)
+        verify_object_enabled(SidebarComponents.PROFILE_OPTION.value)
+        click_obj_by_name(SidebarComponents.PROFILE_OPTION.value)
 
     def verify_display_name(self, display_name: str):
         verify_text_matching(ProfileSettingsScreen.DISPLAY_NAME.value, display_name)
@@ -215,4 +211,3 @@ class SettingsScreen:
         verify_text_matching(ProfileSettingsScreen.CUSTOM_LINK_IN_DIALOG.value, custom_link_name)
         verify_text_matching(ProfileSettingsScreen.CUSTOM_URL_IN_DIALOG.value, custom_link)
         click_obj_by_name(ProfileSettingsScreen.CLOSE_SOCIAL_LINKS_DIALOG.value)
-

--- a/test/ui-test/src/screens/StatusLanguageScreen.py
+++ b/test/ui-test/src/screens/StatusLanguageScreen.py
@@ -1,0 +1,51 @@
+import time
+from enum import Enum
+from drivers.SquishDriver import *
+from drivers.SquishDriverVerification import *
+
+class LanguageSettings(Enum):
+    MAIN_VIEW: str = "settings_LanguageView"
+    LIST_PICKER: str = "languageView_language_StatusListPicker"
+    PICKER_BUTTON: str = "languageView_language_StatusPickerButton"
+    LIST_VIEW: str = "languageView_language_ListView"
+    SEARCHER_INPUT: str = "languageView_language_StatusInput"
+
+class StatusLanguageScreen:
+    
+    def is_screen_loaded(self):
+        verify(is_loaded_visible_and_enabled(LanguageSettings.MAIN_VIEW.value), "Checking Language & Currency view is displayed.") 
+        
+    def open_language_combobox(self):
+        click_obj_by_name(LanguageSettings.LIST_PICKER.value)
+        
+    def select_language(self, language: str):
+        [found, language_obj] = self._scroll_and_find_language(language)
+        if found:
+            return click_obj(language_obj)       
+        return verify(found, "Checking if language found: " + language)
+    
+    def search_language(self, language: str):
+        [loaded, language_list] = is_loaded(LanguageSettings.LIST_VIEW.value)
+        initial_count = language_list.count
+        wait_for_object_focused_and_type(LanguageSettings.SEARCHER_INPUT.value, language)
+        filtered_count = language_list.count        
+        verify(loaded and filtered_count < initial_count, "Checking if searcher filters something")        
+        
+        
+    def verify_current_language(self, language: str):           
+        obj = get_obj(LanguageSettings.PICKER_BUTTON.value)        
+        verify_text(str(obj.text), language)
+        
+    def _scroll_and_find_language(self, language):
+        [loaded, language_list] = is_loaded(LanguageSettings.LIST_VIEW.value)
+        if not loaded: 
+            return False, None       
+        else:                
+            for index in range(language_list.count): 
+                # First scroll at specific index to be sure it is visible and it is possible to get its content:
+                if scroll_list_view_at_index(language_list, index):                
+                    # Get the object, it is already visible and loaded: 
+                    language_obj = language_list.itemAtIndex(index)
+                             
+                    if(language_obj.shortName == language):
+                        return True, language_obj

--- a/test/ui-test/testSuites/suite_status/shared/scripts/sections/settings_names.py
+++ b/test/ui-test/testSuites/suite_status/shared/scripts/sections/settings_names.py
@@ -1,16 +1,45 @@
-
 from sections.global_names import *
+from enum import Enum
+
+# Side bar section items object name helpers:
+_MAIN_MENU_ITEM_OBJ_NAME = "-MainMenuItem"
+_APP_MENU_ITEM_OBJ_NAME = "-AppMenuItem"
+_SETTINGS_MENU_ITEM_OBJ_NAME = "-SettingsMenuItem"
+_EXTRA_MENU_ITEM_OBJ_NAME = "-ExtraMenuItem"
+
+# This is the exact enum definition done in app `Constants.qml` to determine each subsection itemId of each navigation list item
+# These values are used to determine the dynamic `objectName` of the subsection item instead of using "design" properties like `text`.
+class SettingsSubsection(Enum):
+    PROFILE: str = "0" + _MAIN_MENU_ITEM_OBJ_NAME
+    CONTACTS: str = "1" + _MAIN_MENU_ITEM_OBJ_NAME
+    ENS_USERNAMES: str = "2" + _MAIN_MENU_ITEM_OBJ_NAME
+    MESSAGING: str = "3" + _APP_MENU_ITEM_OBJ_NAME
+    WALLET: str = "4" + _APP_MENU_ITEM_OBJ_NAME
+    APPEARANCE: str = "5" + _SETTINGS_MENU_ITEM_OBJ_NAME
+    LANGUAGE: str = "6" + _SETTINGS_MENU_ITEM_OBJ_NAME
+    NOTIFICATIONS: str = "7" + _SETTINGS_MENU_ITEM_OBJ_NAME
+    DEVICE_SETTINGS: str = "8" + _SETTINGS_MENU_ITEM_OBJ_NAME
+    BROWSER: str = "9" + _APP_MENU_ITEM_OBJ_NAME
+    ADVANCED: str = "10" + _SETTINGS_MENU_ITEM_OBJ_NAME
+    ABOUT: str = "11" + _EXTRA_MENU_ITEM_OBJ_NAME
+    COMMUNITY: str = "12" + _APP_MENU_ITEM_OBJ_NAME
+    SIGNOUT: str = "13" + _EXTRA_MENU_ITEM_OBJ_NAME
+    BACKUP_SEED: str = "14" + _MAIN_MENU_ITEM_OBJ_NAME
 
 # Main:
 navBarListView_Settings_navbar_StatusNavBarTabButton = {"checkable": True, "container": mainWindow_navBarListView_ListView, "objectName": "Settings-navbar", "type": "StatusNavBarTabButton", "visible": True}
 settings_navbar_settings_icon_StatusIcon = {"container": navBarListView_Settings_navbar_StatusNavBarTabButton, "objectName": "settings-icon", "type": "StatusIcon", "visible": True}
-advanced_StatusBaseText = {"container": statusDesktop_mainWindow, "text": "Advanced", "type": "StatusBaseText", "unnamed": 1, "visible": True}
 mainWindow_ScrollView = {"container": statusDesktop_mainWindow, "type": "StatusScrollView", "unnamed": 1, "visible": True}
 mainWindow_ScrollView_2 = {"container": statusDesktop_mainWindow, "occurrence": 2, "type": "StatusScrollView", "unnamed": 1, "visible": True}
-wallet_AppMenu_StatusNavigationListItem = {"container": mainWindow_ScrollView, "objectName": "Wallet-AppMenu", "type": "StatusNavigationListItem", "visible": True}
-communities_AppMenu_StatusNavigationListItem = {"container": mainWindow_ScrollView, "objectName": "Communities-AppMenu", "type": "StatusNavigationListItem", "visible": True}
-profile_MainMenu_StatusNavigationListItem = {"container": mainWindow_ScrollView, "objectName": "Profile-MainMenu", "type": "StatusNavigationListItem", "visible": True}
 settingsSave_StatusButton = {"container": statusDesktop_mainWindow, "objectName": "settingsDirtyToastMessageSaveButton", "type": "StatusButton", "visible": True}
+
+# Side bar items:
+wallet_StatusNavigationListItem = {"container": mainWindow_ScrollView, "objectName": SettingsSubsection.WALLET.value, "type": "StatusNavigationListItem", "visible": True}
+language_StatusNavigationListItem = {"container": mainWindow_ScrollView, "objectName": SettingsSubsection.LANGUAGE.value, "type": "StatusNavigationListItem", "visible": True}
+advanced_StatusNavigationListItem = {"container": mainWindow_ScrollView, "objectName": SettingsSubsection.ADVANCED.value, "type": "StatusNavigationListItem", "visible": True}
+sign_out_Quit_StatusNavigationListItem = {"container": mainWindow_ScrollView, "objectName": SettingsSubsection.SIGNOUT.value, "type": "StatusNavigationListItem", "visible": True}
+communities_StatusNavigationListItem = {"container": mainWindow_ScrollView, "objectName": SettingsSubsection.COMMUNITY.value, "type": "StatusNavigationListItem", "visible": True}
+profile_StatusNavigationListItem = {"container": mainWindow_ScrollView, "objectName": SettingsSubsection.PROFILE.value, "type": "StatusNavigationListItem", "visible": True}
 
 # Profile Settings:
 displayName_StatusInput = {"container": mainWindow_ScrollView_2, "objectName": "displayNameInput", "type": "StatusInput", "visible": True}
@@ -53,5 +82,11 @@ walletSettingsLineButton = {"container": statusDesktop_mainWindow, "objectName":
 i_understand_StatusBaseText = {"container": statusDesktop_mainWindow_overlay, "text": "I understand", "type": "StatusBaseText", "unnamed": 1, "visible": True}
 
 # Extra Settings:
-sign_out_Quit_ExtraMenu_StatusNavigationListItem = {"container": mainWindow_ScrollView, "objectName": "Sign out & Quit-ExtraMenu", "type": "StatusNavigationListItem", "visible": True}
 signOutConfirmation_StatusButton = {"container": statusDesktop_mainWindow_overlay, "objectName": "signOutConfirmation", "type": "StatusButton", "visible": True}
+
+# Language Settings:
+settings_LanguageView = {"container": statusDesktop_mainWindow, "objectName": "languageView", "type": "LanguageView"}
+languageView_language_StatusListPicker = {"container": statusDesktop_mainWindow, "objectName": "languagePicker", "type": "StatusListPicker"}
+languageView_language_StatusPickerButton = {"container": languageView_language_StatusListPicker,  "type": "StatusPickerButton", "unnamed": 1}
+languageView_language_ListView = {"container": languageView_language_StatusListPicker,  "type": "ListView", "unnamed": 1}
+languageView_language_StatusInput = {"container": languageView_language_ListView,  "type": "StatusInput", "unnamed": 1}

--- a/test/ui-test/testSuites/suite_status/shared/steps/settingsSteps.py
+++ b/test/ui-test/testSuites/suite_status/shared/steps/settingsSteps.py
@@ -1,9 +1,11 @@
 
 from screens.StatusMainScreen import StatusMainScreen
 from screens.SettingsScreen import SettingsScreen
+from screens.StatusLanguageScreen import StatusLanguageScreen
 
 _statusMain = StatusMainScreen()
 _settingsScreen = SettingsScreen()
+_languageScreen = StatusLanguageScreen()
 
 
 @When("the user opens app settings screen")
@@ -40,10 +42,27 @@ def step(context: any, account_name: str,  account_color: str):
     _settingsScreen.edit_account(account_name, account_color)
 
     
+@When("the user clicks on Language & Currency")
+def step(context):
+    _settingsScreen.open_language_and_currency_settings() 
+    _languageScreen.is_screen_loaded()
+    
+@When("the user opens the language selector")
+def step(context):
+    _languageScreen.open_language_combobox()
+    
+@When("the user selects the language |any|")
+def step(context, native):
+    _languageScreen.select_language(native)
+    snooze(5) # TODO: Wait until language has changed
+    
+@When("the user searches the language |any|")
+def step(context, native):
+    _languageScreen.search_language(native)
+    
 @Then("the address |any| is displayed in the wallet")
 def step(context: any, address: str):
     _settingsScreen.verify_address(address)
-
 
 @Then("the account |any| is not in the list of accounts")
 def step(context: any, account_name):
@@ -105,3 +124,9 @@ def step(context):
 @Then("the user's social links should be: \"|any|\", personal site: \"|any|\", \"|any|\": \"|any|\"")
 def step(context, twitter, personal_site, custom_link_name, custom_link):
     _settingsScreen.verify_social_links(twitter, personal_site, custom_link_name, custom_link)
+
+@Then("the application displays |any| as the selected language")
+def step(context, native):
+    _languageScreen.verify_current_language(native)
+    # TODO: Verify some texts have been changed in the application (not done now bc translations are inconsistent 
+    # and not all expected languages have the same texts translated

--- a/test/ui-test/testSuites/suite_status/suite.conf
+++ b/test/ui-test/testSuites/suite_status/suite.conf
@@ -5,6 +5,6 @@ HOOK_SUB_PROCESSES=false
 IMPLICITAUTSTART=0
 LANGUAGE=Python
 OBJECTMAPSTYLE=script
-TEST_CASES=tst_statusLoginPassword tst_basicChatFlow tst_wallet tst_communityFlows tst_groupChat tst_transaction tst_settingsMenu tst_userIdentity
+TEST_CASES=tst_statusLoginPassword tst_basicChatFlow tst_wallet tst_communityFlows tst_groupChat tst_transaction tst_settingsMenu tst_userIdentity tst_languageSettings
 VERSION=3
 WRAPPERS=Qt

--- a/test/ui-test/testSuites/suite_status/tst_languageSettings/test.feature
+++ b/test/ui-test/testSuites/suite_status/tst_languageSettings/test.feature
@@ -1,0 +1,98 @@
+#******************************************************************************
+# Status.im
+#*****************************************************************************/
+#/**
+# * \file	test.feature
+# *
+# * \test	Status Language Settings
+# * \date	August 2022
+# **
+# *****************************************************************************/
+Feature: Status Language Settings
+
+    As a user I want to change the application language.
+
+    The following scenarios cover basic language changed validations
+
+    Background:
+
+    	Given A first time user lands on the status desktop and generates new key
+    	When user signs up with username tester123 and password TesTEr16843/!@00
+    	Then the user lands on the signed in app
+    	When the user opens app settings screen
+    	And the user clicks on Language & Currency
+
+	# Each language run takes 30 seconds, so only some of them are enabled until we can parallelize executions
+    Scenario Outline: The user is able to select a specific language and after a restart, the language is kept
+		When the user opens the language selector
+		And the user selects the language <native>
+		Then the application displays <native> as the selected language
+		When the user restarts the app
+		And the user tester123 logs in with password TesTEr16843/!@00
+		Then the user lands on the signed in app
+		When the user opens app settings screen
+		And the user clicks on Language & Currency
+		Then the application displays <native> as the selected language
+	Examples:
+	        | language                | native                  |
+	        #| English                 | English                 |
+	        | Arabic                  | العربية                 |
+	        #| Bengali                 | বাংলা                    |
+	        #| Chinese (China)         | 中文（中國）              |
+	        | Chinese (Taiwan)        | 中文（台灣）              |
+	        #| Dutch                   | Nederlands              |
+	        #| French                  | Français                |
+	        #| German                  | Deutsch                 |
+	        #| Hindi                   | हिन्दी                     |
+	        #| Indonesian              | Bahasa Indonesia        |
+	        #| Italian                 | Italiano                |
+	        | Japanese                | 日本語                   |
+	        #| Korean                  | 한국어                    |
+	        #| Malay                   | Bahasa Melayu           |
+	        #| Polish                  | Polski                  |
+	        #| Portuguese              | Português               |
+	        | Portuguese (Brazil) 	  | Português (Brasil)      |
+	        #| Russian                 | Русский                 |
+	        #| Spanish                 | Español                 |
+	        #| Spanish (Latin America) | Español (Latinoamerica) |
+	        #| Spanish (Argentina)     | Español (Argentina)     |
+	        #| Tagalog                 | Tagalog                 |
+	        | Turkish                 | Türkçe                  |
+
+	# Each language run takes 30 seconds, so only some of them are enabled until we can parallelize executions
+	Scenario Outline: The user is able to search and select a specific language and after a restart, the language is kept
+		When the user opens the language selector
+		And the user searches the language <native>
+		And the user selects the language <native>
+		Then the application displays <native> as the selected language
+		When the user restarts the app
+		And the user tester123 logs in with password TesTEr16843/!@00
+		Then the user lands on the signed in app
+		When the user opens app settings screen
+		And the user clicks on Language & Currency
+		Then the application displays <native> as the selected language
+	Examples:
+	        | language                | native                  |
+	        | English                 | English                 |
+	        #| Arabic                  | العربية                 |
+	        #| Bengali                 | বাংলা                    |
+	        #| Chinese (China)         | 中文（中國）              |
+	        #| Chinese (Taiwan)        | 中文（台灣）              |
+	        #| Dutch                   | Nederlands              |
+	        #| French                  | Français                |
+	        #| German                  | Deutsch                 |
+	        #| Hindi                   | हिन्दी                     |
+	        | Indonesian              | Bahasa Indonesia        |
+	        #| Italian                 | Italiano                |
+	        #| Japanese                | 日本語                   |
+	        #| Korean                  | 한국어                    |
+	        #| Malay                   | Bahasa Melayu           |
+	        | Polish                  | Polski                  |
+	        #| Portuguese              | Português               |
+	        #| Portuguese (Brazil) 	  | Português (Brasil)      |
+	        #| Russian                 | Русский                 |
+	        #| Spanish                 | Español                 |
+	        #| Spanish (Latin America) | Español (Latinoamerica) |
+	        #| Spanish (Argentina)     | Español (Argentina)     |
+	        | Tagalog                 | Tagalog                 |
+	        #| Turkish                 | Türkçe                  |

--- a/test/ui-test/testSuites/suite_status/tst_languageSettings/test.py
+++ b/test/ui-test/testSuites/suite_status/tst_languageSettings/test.py
@@ -1,0 +1,8 @@
+source(findFile('scripts', 'python/bdd.py'))
+
+setupHooks('../shared/scripts/bdd_hooks.py')
+collectStepDefinitions('./steps', '../shared/steps', '../shared/settingsSteps')
+
+def main():
+    testSettings.throwOnFailure = True
+    runFeatureFile('test.feature')

--- a/ui/app/AppLayouts/Profile/panels/MenuPanel.qml
+++ b/ui/app/AppLayouts/Profile/panels/MenuPanel.qml
@@ -25,7 +25,7 @@ Column {
     Repeater {
         id: mainMenuItems
         delegate: StatusNavigationListItem {
-            objectName:  model.text + "-MainMenu"
+            objectName: itemId + "-MainMenuItem"
             itemId: model.subsection
             title: model.text
             icon.name: model.icon
@@ -58,7 +58,7 @@ Column {
         id: appsMenuItems
         delegate: StatusNavigationListItem {
             id: appsMenuDelegate
-            objectName:  model.text + "-AppMenu"
+            objectName: itemId + "-AppMenuItem"
             itemId: model.subsection
             title: model.text
             icon.name: model.icon
@@ -86,7 +86,7 @@ Column {
         id: settingsMenuItems
         delegate: StatusNavigationListItem {
             id: settingsMenuDelegate
-            objectName:  model.text + "-SettingsMenu"
+            objectName:  itemId + "-SettingsMenuItem"
             itemId: model.subsection
             title: model.text
             icon.name: model.icon
@@ -101,7 +101,7 @@ Column {
     Repeater {
         id: extraMenuItems
         delegate: StatusNavigationListItem {
-            objectName:  model.text + "-ExtraMenu"
+            objectName:  itemId + "-ExtraMenuItem"
             itemId: model.subsection
             title: model.text
             icon.name: model.icon
@@ -111,4 +111,3 @@ Column {
         }
     }
 }
-

--- a/ui/app/AppLayouts/Profile/views/LanguageView.qml
+++ b/ui/app/AppLayouts/Profile/views/LanguageView.qml
@@ -23,6 +23,7 @@ SettingsContentBase {
     property LanguageStore languageStore
     property var currencyStore
 
+    objectName: "languageView"
     onVisibleChanged: { if(!visible) root.setViewIdleState()}
     onBaseAreaClicked: { root.setViewIdleState() }
 
@@ -33,6 +34,11 @@ SettingsContentBase {
     function setViewIdleState() {
         currencyPicker.close()
         languagePicker.close()
+    }
+
+    function changeLanguage(key) {
+        languagePicker.newKey = key
+        languagePause.start()
     }
 
     ColumnLayout {
@@ -118,7 +124,7 @@ SettingsContentBase {
                         root.languageStore.changeLanguage(languagePicker.newKey)
                     }
                 }
-
+                objectName: "languagePicker"
                 inputList: SortFilterProxyModel {
                     sourceModel: root.languageStore.languageModel
 
@@ -164,13 +170,13 @@ SettingsContentBase {
                     if(selected && root.languageStore.currentLanguage !== key) {
                         // TEMPORARY: It should be removed as it is only used in Linux OS but it must be investigated how to change language in execution time, as well, in Linux (will be addressed in another task)
                         if (Qt.platform.os === Constants.linux) {
+                            root.changeLanguage(key)
                             linuxConfirmationDialog.active = true
                             linuxConfirmationDialog.item.newLocale = key
                             linuxConfirmationDialog.item.open()
                         }
                         else {
-                            languagePicker.newKey = key
-                            languagePause.start()
+                            root.changeLanguage(key)
                         }
                     }
                 }
@@ -260,7 +266,6 @@ SettingsContentBase {
                 confirmationText: qsTr("Display language has been changed. You must restart the application for changes to take effect.")
                 confirmButtonLabel: qsTr("Close the app now")
                 onConfirmButtonClicked: {
-                    root.languageStore.changeLanguage(newLocale)
                     loader.active = false
                     Qt.quit()
                 }


### PR DESCRIPTION
Closes #6903

### What does the PR do

`tst_languageSettings`:
- Feature and basic scenarios definition: Change language by selection and change language by search.
- Added `StatusLanguageScreen` class and related methods to change and validate language.

`SquishDriver`:
- Added support to scroll at a specific list view index.
- Added support  to directly type into a focused element.

`settings_names.py`:
- Added support for object names related to `side bar` options.
- Unified some nomenclature related to settings objects.

### Affected areas

tst_languageSettings

### Screenshot of functionality (including design for comparison)

- **Scenario 1:** Select by click, restart and validate

https://user-images.githubusercontent.com/97019400/184405485-e3f02350-5eca-440b-bd8f-f6741f864353.mov

- **Scenario 2:** Search and then select by click

https://user-images.githubusercontent.com/97019400/184405208-983f443a-246a-425e-8f07-b9459472c2bf.mov