### PR TITLE
fix(@desktop/onboarding): adapt account dropdown

### DIFF
--- a/ui/app/AppLayouts/Onboarding/views/LoginView.qml
+++ b/ui/app/AppLayouts/Onboarding/views/LoginView.qml
@@ -242,6 +242,13 @@ Item {
                     if (accountsPopup.opened) {
                         accountsPopup.close()
                     } else {
+                        accountsPopup.topMargin =
+                                Qt.binding(function(){
+                                    return userInfo.mapToItem(
+                                                root,
+                                                root.height,
+                                                userInfo.height + Style.current.halfPadding).y
+                                    })
                         accountsPopup.popup(
                                     userInfo,
                                     (userInfo.width - accountsPopup.width) / 2,


### PR DESCRIPTION
-use StatusQ with updated PopupMenu

Fixes #6822

Requires https://github.com/status-im/StatusQ/pull/853

### What does the PR do

Add binding for accountsPopup.topMargin to maintain it on same place when window is resized

### Affected areas

Desktop Onboarding

### Screenshot of functionality (including design for comparison)

- [X] I've checked the design and this PR matches it
![Screenshot from 2022-08-15 11-18-12](https://user-images.githubusercontent.com/6445843/184600907-86cb4fe8-fcf8-410e-9235-1e7c6d19df76.png)

https://user-images.githubusercontent.com/6445843/184600928-2a3afffa-4032-4631-8863-051dfa00a015.mp4

Latest version with StatusListView
https://user-images.githubusercontent.com/6445843/184636638-5e5bb59b-63ac-4b98-a7e9-dbe468b7908b.mp4




