### PR TITLE
fix(@desktop/chat): Pinned messages ui adjustments

### DIFF
--- a/ui/imports/shared/panels/chat/ChatReplyPanel.qml
+++ b/ui/imports/shared/panels/chat/ChatReplyPanel.qml
@@ -66,7 +66,7 @@ Loader {
             Shape {
                 id: replyCorner
                 anchors.left: parent.left
-                anchors.leftMargin: 20 - 1
+                anchors.leftMargin: 24 - 1
                 anchors.top: parent.top
                 anchors.topMargin: Style.current.smallPadding
                 width: 20


### PR DESCRIPTION
### What does the PR do

Fixes: #6851 

- `Pinned by` message next to the profile image
- `Pinned by` the username is demi-bold
- `Pinned by` background adjusted - left bottom corner has different radius
- user image enlarged to match design

### Affected areas

CompactMessageView

### Screenshot of functionality (including design for comparison)
- [x] I've checked the design and this PR matches it

![Screenshot from 2022-08-16 18-54-27](https://user-images.githubusercontent.com/20650004/184935653-20901f64-7a45-409b-a644-cd82345d9abb.png)


