### PR TITLE
fix(@desktop/community)!: missing error messages

### DIFF
--- a/ui/app/AppLayouts/Chat/controls/community/CommunityDescriptionInput.qml
+++ b/ui/app/AppLayouts/Chat/controls/community/CommunityDescriptionInput.qml
@@ -30,5 +30,4 @@ StatusInput {
                                                 qsTr("community description"))
         }
     ]
-    validationMode: StatusInput.ValidationMode.Always
 }

--- a/ui/app/AppLayouts/Chat/controls/community/CommunityIntroMessageInput.qml
+++ b/ui/app/AppLayouts/Chat/controls/community/CommunityIntroMessageInput.qml
@@ -29,5 +29,4 @@ StatusInput {
                                                 qsTr("community intro message"))
         }
     ]
-    validationMode: StatusInput.ValidationMode.Always
 }

--- a/ui/app/AppLayouts/Chat/controls/community/CommunityNameInput.qml
+++ b/ui/app/AppLayouts/Chat/controls/community/CommunityNameInput.qml
@@ -22,5 +22,4 @@ StatusInput {
                                                 qsTr("community name"))
         }
     ]
-    validationMode: StatusInput.ValidationMode.Always
 }

--- a/ui/app/AppLayouts/Chat/controls/community/CommunityOutroMessageInput.qml
+++ b/ui/app/AppLayouts/Chat/controls/community/CommunityOutroMessageInput.qml
@@ -25,5 +25,4 @@ StatusInput {
                                                 qsTr("community intro message"))
         }
     ]
-    validationMode: StatusInput.ValidationMode.Always
 }

--- a/ui/app/AppLayouts/Chat/popups/community/CreateChannelPopup.qml
+++ b/ui/app/AppLayouts/Chat/popups/community/CreateChannelPopup.qml
@@ -131,7 +131,6 @@ StatusDialog {
                         root.emojiPopup.y = root.y + root.header.height + root.topPadding + nameInput.height + Style.current.smallPadding;
                     }
                 }
-                validationMode: StatusInput.ValidationMode.Always
                 validators: [
                     StatusMinLengthValidator {
                         minLength: 1
@@ -214,7 +213,6 @@ StatusDialog {
                 input.multiline: true
                 minimumHeight: 88
                 maximumHeight: 88
-                validationMode: StatusInput.ValidationMode.Always
                 validators: [StatusMinLengthValidator {
                         minLength: 1
                         errorMessage:  Utils.getErrorMessage(descriptionTextArea.errors, qsTr("channel description"))

--- a/ui/app/AppLayouts/Profile/popups/SendContactRequestModal.qml
+++ b/ui/app/AppLayouts/Profile/popups/SendContactRequestModal.qml
@@ -137,7 +137,6 @@ StatusModal {
                         minLength: d.minMsgLength
                         errorMessage: Utils.getErrorMessage(messageInput.errors, qsTr("who are you"))
                     }]
-                validationMode: StatusInput.ValidationMode.Always
             }
         }
     }

--- a/ui/app/AppLayouts/Profile/popups/backupseed/BackupSeedStepBase.qml
+++ b/ui/app/AppLayouts/Profile/popups/backupseed/BackupSeedStepBase.qml
@@ -39,13 +39,12 @@ StatusScrollView {
             id: inputText
             visible: (wordRandomNumber > -1)
             implicitWidth: 448
-            validationMode: StatusInput.ValidationMode.Always
             label: qsTr("Word #%1").arg(wordRandomNumber + 1)
             placeholderText: qsTr("Enter word")
             validators: [
                 StatusValidator {
                     validate: function (t) { return (root.wordAtRandomNumber === inputText.text); }
-                    errorMessage: (inputText.text.length) > 0 ? qsTr("Wrong word") : ""
+                    errorMessage: qsTr("Wrong word")
                 }
             ]
             Layout.fillWidth: true

--- a/ui/imports/shared/popups/SendContactRequestModal.qml
+++ b/ui/imports/shared/popups/SendContactRequestModal.qml
@@ -63,7 +63,6 @@ StatusModal {
                 minLength: d.minMsgLength
                 errorMessage: Utils.getErrorMessage(messageInput.errors, qsTr("who are you"))
             }
-            validationMode: StatusInput.ValidationMode.Always
             Layout.fillWidth: true
         }
     }


### PR DESCRIPTION
Fixes #6825

Requires https://github.com/status-im/StatusQ/pull/858.

BREAKING CHANGE: many StatusInputs now validate on dirty and show error
when needed.

### What does the PR do

Use fixed version of StatusInput from StatusQ
Remove ValidationMode.Always for StatusInputs and use valid & dirty
instead to show error after any edit.
Remove condition from errorMessage of BackupSeedStepBase as not needed

### Affected areas

Desktop Community and other.

### Screenshot of functionality

- [X] I've checked the design and this PR matches it

https://user-images.githubusercontent.com/6445843/185095640-dbdb7c70-85b0-49e6-ba41-90ec232470e4.mp4





