### PR TITLE
feat(CreateCommunityPopup): Add Community Banner to Create Community Modal

### DIFF
--- a/src/app/modules/main/communities/controller.nim
+++ b/src/app/modules/main/communities/controller.nim
@@ -89,7 +89,8 @@ proc createCommunity*(
     imageUrl: string,
     aX: int, aY: int, bX: int, bY: int,
     historyArchiveSupportEnabled: bool,
-    pinMessageAllMembersEnabled: bool) =
+    pinMessageAllMembersEnabled: bool,
+    bannerJsonStr: string) =
   self.communityService.createCommunity(
     name,
     description,
@@ -101,7 +102,8 @@ proc createCommunity*(
     imageUrl,
     aX, aY, bX, bY,
     historyArchiveSupportEnabled,
-    pinMessageAllMembersEnabled)
+    pinMessageAllMembersEnabled,
+    bannerJsonStr)
 
 proc reorderCommunityChat*(
     self: Controller,

--- a/src/app/modules/main/communities/io_interface.nim
+++ b/src/app/modules/main/communities/io_interface.nim
@@ -30,7 +30,7 @@ method joinCommunity*(self: AccessInterface, communityId: string): string {.base
 
 method createCommunity*(self: AccessInterface, name: string, description, introMessage, outroMessage: string, access: int,
                         color: string, tags: string, imagePath: string, aX: int, aY: int, bX: int, bY: int,
-                        historyArchiveSupportEnabled: bool, pinMessageAllMembersEnabled: bool) {.base.} =
+                        historyArchiveSupportEnabled: bool, pinMessageAllMembersEnabled: bool, bannerJsonStr: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method deleteCommunityCategory*(self: AccessInterface, communityId: string, categoryId: string) {.base.} =

--- a/src/app/modules/main/communities/module.nim
+++ b/src/app/modules/main/communities/module.nim
@@ -199,9 +199,10 @@ method createCommunity*(self: Module, name: string,
                         imagePath: string,
                         aX: int, aY: int, bX: int, bY: int,
                         historyArchiveSupportEnabled: bool,
-                        pinMessageAllMembersEnabled: bool) =
+                        pinMessageAllMembersEnabled: bool,
+                        bannerJsonStr: string) =
   self.controller.createCommunity(name, description, introMessage, outroMessage, access, color, tags,
-                                  imagePath, aX, aY, bX, bY, historyArchiveSupportEnabled, pinMessageAllMembersEnabled)
+                                  imagePath, aX, aY, bX, bY, historyArchiveSupportEnabled, pinMessageAllMembersEnabled, bannerJsonStr)
 
 method deleteCommunityCategory*(self: Module, communityId: string, categoryId: string) =
   self.controller.deleteCommunityCategory(communityId, categoryId)

--- a/src/app/modules/main/communities/view.nim
+++ b/src/app/modules/main/communities/view.nim
@@ -101,9 +101,9 @@ QtObject:
                         imagePath: string,
                         aX: int, aY: int, bX: int, bY: int,
                         historyArchiveSupportEnabled: bool,
-                        pinMessageAllMembersEnabled: bool) {.slot.} =
+                        pinMessageAllMembersEnabled: bool, bannerJsonStr: string) {.slot.} =
     self.delegate.createCommunity(name, description, introMessage, outroMessage, access, color, tags,
-                                  imagePath, aX, aY, bX, bY, historyArchiveSupportEnabled, pinMessageAllMembersEnabled)
+                                  imagePath, aX, aY, bX, bY, historyArchiveSupportEnabled, pinMessageAllMembersEnabled, bannerJsonStr)
 
   proc deleteCommunityCategory*(self: View, communityId: string, categoryId: string): string {.slot.} =
     self.delegate.deleteCommunityCategory(communityId, categoryId)

--- a/src/app_service/service/community/service.nim
+++ b/src/app_service/service/community/service.nim
@@ -615,7 +615,8 @@ QtObject:
       imageUrl: string,
       aX: int, aY: int, bX: int, bY: int,
       historyArchiveSupportEnabled: bool,
-      pinMessageAllMembersEnabled: bool) =
+      pinMessageAllMembersEnabled: bool,
+      bannerJsonStr: string) =
     try:
       var image = singletonInstance.utils.formatImagePath(imageUrl)
       var tagsString = tags
@@ -633,7 +634,8 @@ QtObject:
         image,
         aX, aY, bX, bY,
         historyArchiveSupportEnabled,
-        pinMessageAllMembersEnabled)
+        pinMessageAllMembersEnabled,
+        bannerJsonStr)
 
       if response.error != nil:
         let error = Json.decode($response.error, RpcError)

--- a/src/backend/communities.nim
+++ b/src/backend/communities.nim
@@ -57,8 +57,10 @@ proc createCommunity*(
     imageUrl: string,
     aX: int, aY: int, bX: int, bY: int,
     historyArchiveSupportEnabled: bool,
-    pinMessageAllMembersEnabled: bool
+    pinMessageAllMembersEnabled: bool,
+    bannerJsonStr: string
     ): RpcResponse[JsonNode] {.raises: [Exception].} =
+  let bannerImage = newCroppedImage(bannerJsonStr)
   result = callPrivateRPC("createCommunity".prefix, %*[{
       # TODO this will need to be renamed membership (small m)
       "Membership": access,
@@ -75,7 +77,8 @@ proc createCommunity*(
       "imageBx": bX,
       "imageBy": bY,
       "historyArchiveSupportEnabled": historyArchiveSupportEnabled,
-      "pinMessageAllMembersEnabled": pinMessageAllMembersEnabled
+      "pinMessageAllMembersEnabled": pinMessageAllMembersEnabled,
+      "banner": bannerImage
     }])
 
 proc editCommunity*(

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -240,13 +240,14 @@ QtObject {
                                     historyArchiveSupportEnabled: false,
                                     checkedMembership: false,
                                     pinMessagesAllowedForMembers: false
-                                }
+                                },
+                                bannerJsonStr: ""
                              }) {
         return communitiesModuleInst.createCommunity(
                     args.name, args.description, args.introMessage, args.outroMessage,
                     args.options.checkedMembership, args.color, args.tags,
                     args.image.src, args.image.AX, args.image.AY, args.image.BX, args.image.BY,
-                    args.options.historyArchiveSupportEnabled, args.options.pinMessagesAllowedForMembers);
+                    args.options.historyArchiveSupportEnabled, args.options.pinMessagesAllowedForMembers, args.bannerJsonStr);
     }
 
     function importCommunity(communityKey) {

--- a/ui/app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml
+++ b/ui/app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml
@@ -71,6 +71,11 @@ StatusStackModal {
                     Layout.fillWidth: true
                 }
 
+                CommunityBannerPicker {
+                    id: bannerPicker
+                    Layout.fillWidth: true
+                }
+
                 CommunityColorPicker {
                     id: colorPicker
                     onPick: root.replace(colorPanel)
@@ -172,7 +177,8 @@ StatusStackModal {
                         historyArchiveSupportEnabled: options.archiveSupportEnabled,
                         checkedMembership: options.requestToJoinEnabled ? Constants.communityChatOnRequestAccess : Constants.communityChatPublicAccess,
                         pinMessagesAllowedForMembers: options.pinMessagesEnabled
-                    }
+                    },
+                    bannerJsonStr: JSON.stringify({imagePath: String(bannerPicker.source).replace("file://", ""), cropRect: bannerPicker.cropRect})
             })
             if (error) {
                 errorDialog.text = error.error

--- a/ui/app/AppLayouts/CommunitiesPortal/stores/CommunitiesStore.qml
+++ b/ui/app/AppLayouts/CommunitiesPortal/stores/CommunitiesStore.qml
@@ -51,13 +51,14 @@ QtObject {
                                     historyArchiveSupportEnabled: false,
                                     checkedMembership: false,
                                     pinMessagesAllowedForMembers: false
-                                }
+                                },
+                                bannerJsonStr: ""
                              }) {
         return communitiesModuleInst.createCommunity(
                     args.name, args.description, args.introMessage, args.outroMessage, args.options.checkedMembership,
                     args.color, args.tags,
                     args.image.src, args.image.AX, args.image.AY, args.image.BX, args.image.BY,
-                    args.options.historyArchiveSupportEnabled, args.options.pinMessagesAllowedForMembers);
+                    args.options.historyArchiveSupportEnabled, args.options.pinMessagesAllowedForMembers, args.bannerJsonStr);
     }
 
     function importCommunity(communityKey) {

--- a/ui/app/AppLayouts/stores/RootStore.qml
+++ b/ui/app/AppLayouts/stores/RootStore.qml
@@ -104,10 +104,12 @@ QtObject {
     }
 
     function createCommunity(communityName, communityDescription, checkedMembership, communityColor, communityTags,
-                             communityImage, imageCropperModalaX, imageCropperModalaY, imageCropperModalbX, imageCropperModalbY) {
+                             communityImage, imageCropperModalaX, imageCropperModalaY, imageCropperModalbX, imageCropperModalbY,
+                             historyArchiveSupportEnabled, pinMessagesAllowedForMembers, bannerJsonStr) {
         communitiesModuleInst.createCommunity(communityName, communityDescription, checkedMembership, communityColor,
                                               communityTags, communityImage, imageCropperModalaX, imageCropperModalaY,
-                                              imageCropperModalbX, imageCropperModalbY);
+                                              imageCropperModalbX, imageCropperModalbY,
+                                              historyArchiveSupportEnabled, pinMessagesAllowedForMembers, bannerJsonStr);
     }
 
     function copyToClipboard(text) {

--- a/ui/nim-status-client.pro
+++ b/ui/nim-status-client.pro
@@ -23,6 +23,7 @@ TRANSLATIONS += \
 
 OTHER_FILES += $$files("$$PWD/*.qml", true)
 OTHER_FILES += $$files("$$PWD/*.js", true)
+OTHER_FILES += $$files("$$PWD/../src/*.nim", true)
 
 # Additional import path used to resolve QML modules in Qt Creator's code model
 QML_IMPORT_PATH = $$PWD/imports \


### PR DESCRIPTION
as status-go already supports parsing the banner JSON string, just pass
it along the NIM backend

Closes #6726

### What does the PR do

Implements support for adding community banner on its creation

### Affected areas

CreateCommunityPopup

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

Create community:
![Snímek obrazovky z 2022-08-17 14-26-51](https://user-images.githubusercontent.com/5377645/185133133-cd63a904-b22a-4862-824c-2344de00845f.png)

Edit community (for verification):
![Snímek obrazovky z 2022-08-17 14-27-15](https://user-images.githubusercontent.com/5377645/185133465-235f4505-e950-45e4-89e4-55a3f1453cfd.png)


