### PR TITLE
fix(@desktop/chat): adjust search member input

### DIFF
--- a/ui/app/AppLayouts/Chat/popups/GroupInfoPopup.qml
+++ b/ui/app/AppLayouts/Chat/popups/GroupInfoPopup.qml
@@ -110,6 +110,8 @@ StatusModal {
             input.icon.name: "search"
             input.icon.width: 17
             input.icon.height: 17
+            topPadding: 0
+            bottomPadding: 0
         }
 
         NoFriendsRectangle {


### PR DESCRIPTION
Fixes #6970

### What does the PR do

Adjust Search member input paddings to exclude scrolling 

### Affected areas

Desktop Chat

### Screenshot of functionality

![Screenshot from 2022-08-18 16-45-53](https://user-images.githubusercontent.com/6445843/185412166-8fe4284e-e279-463c-aa33-ff7b5fe2ec4b.png)

