### PR TITLE
fix(Profile/ContactsView): updated contacts layout

### DIFF
--- a/ui/app/AppLayouts/Profile/panels/ContactsListPanel.qml
+++ b/ui/app/AppLayouts/Profile/panels/ContactsListPanel.qml
@@ -17,12 +17,12 @@ import SortFilterProxyModel 0.2
 
 Item {
     id: root
+    implicitHeight: (title.height + contactsList.height)
 
     property var contactsStore
     property var contactsModel
+
     property int panelUsage: Constants.contactsPanelUsage.unknownPosition
-    property bool scrollbarOn: false
-    readonly property int contactsListHeight: ((contactsList.count * contactsList.itemAtIndex(0).implicitHeight)+title.height)
 
     property string title: ""
     property string searchString: ""
@@ -39,6 +39,7 @@ Item {
 
     StyledText {
         id: title
+        height: visible ? contentHeight : 0
         anchors.left: parent.left
         anchors.leftMargin: Style.current.padding
         visible: contactsList.count > 0 && root.title !== ""
@@ -53,9 +54,10 @@ Item {
         anchors.top: title.bottom
         anchors.left: parent.left
         anchors.right: parent.right
-        anchors.bottom: parent.bottom
+        onCountChanged: {
+            height = (count*64);
+        }
         interactive: false
-        ScrollBar.vertical.policy: root.scrollbarOn ? ScrollBar.AlwaysOn : ScrollBar.AsNeeded
         model: SortFilterProxyModel {
             id: filteredModel
 

--- a/ui/app/AppLayouts/Profile/views/SettingsContentBase.qml
+++ b/ui/app/AppLayouts/Profile/views/SettingsContentBase.qml
@@ -14,6 +14,7 @@ Item {
 
     property string sectionTitle
     property int contentWidth
+    readonly property int contentHeight: (root.height - d.topHeaderHeight - d.titleRowHeight)
 
     property string backButtonName: ""
 


### PR DESCRIPTION
Closes #6262

### What does the PR do
 All contacts should be shown in one long list, should the list is longer than the page, the page should scroll down

### Affected areas
ContactsView

### Screenshot of functionality (including design for comparison)
https://user-images.githubusercontent.com/31625338/189392161-7c795d4b-e851-48c3-b449-334505eb33a2.mov

https://user-images.githubusercontent.com/31625338/189392205-85d58715-62f2-4e6e-98b5-4208bbd0512c.mov


***The black images is list of dummy contacts


