### PR TITLE
feat(AdvancedView): introduce feature flag for discord import tool

### DIFF
--- a/src/app/global/local_account_sensitive_settings.nim
+++ b/src/app/global/local_account_sensitive_settings.nim
@@ -93,6 +93,8 @@ const LSS_KEY_IS_24H_TIME_FORMAT* = "is_24h_time_format"
 const DEFAULT_IS_24H_TIME_FORMAT = false
 const LSS_KEY_USER_DECLINED_BACKUP_BANNER* = "userDeclinedBackupBanner"
 const DEFAULT_USER_DECLINED_BACKUP_BANNER = false
+const LSS_KEY_IS_DISCORD_IMPORT_TOOL_ENABLED* = "isDiscordImportToolEnabled"
+const DEFAULT_IS_DISCORD_IMPORT_TOOL_ENABLED = false
 
 
 logScope:
@@ -229,6 +231,17 @@ QtObject:
     write = setNodeManagementEnabled
     notify = nodeManagementEnabledChanged
 
+  proc isDiscordImportToolEnabledChanged*(self: LocalAccountSensitiveSettings) {.signal.}
+  proc getIsDiscordImportToolEnabled*(self: LocalAccountSensitiveSettings): bool {.slot.} =
+    getSettingsProp[bool](self, LSS_KEY_IS_DISCORD_IMPORT_TOOL_ENABLED, newQVariant(DEFAULT_IS_DISCORD_IMPORT_TOOL_ENABLED))
+  proc setIsDiscordImportToolEnabled*(self: LocalAccountSensitiveSettings, value: bool) {.slot.} =
+    setSettingsProp(self, LSS_KEY_IS_DISCORD_IMPORT_TOOL_ENABLED, newQVariant(value)):
+      self.isDiscordImportToolEnabledChanged()
+
+  QtProperty[bool] isDiscordImportToolEnabled:
+    read = getIsDiscordImportToolEnabled
+    write = setIsDiscordImportToolEnabled
+    notify = isDiscordImportToolEnabledChanged
 
   proc isBrowserEnabledChanged*(self: LocalAccountSensitiveSettings) {.signal.}
   proc getIsBrowserEnabled*(self: LocalAccountSensitiveSettings): bool {.slot.} =

--- a/ui/app/AppLayouts/Chat/panels/communities/CommunityOverviewSettingsPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/CommunityOverviewSettingsPanel.qml
@@ -138,7 +138,7 @@ StackLayout {
                 CommunityBanner {
                     text: qsTr("Welcome to your community!")
                     buttonText: qsTr("Invite new people")
-                    icon: Style.svg("chatEmptyHeader")
+                    icon.name: "invite-users"
                     onButtonClicked: root.inviteNewPeopleClicked()
                 }
                 Item {
@@ -147,7 +147,7 @@ StackLayout {
                 CommunityBanner {
                     text: qsTr("Try an airdrop to reward your community for engagement!")
                     buttonText: qsTr("Airdrop Tokens")
-                    icon: Style.svg("communities/airdrop")
+                    icon.name: "airdrop"
                     onButtonClicked: root.airdropTokensClicked()
                 }
 
@@ -158,7 +158,7 @@ StackLayout {
                 CommunityBanner {
                     text: qsTr("Back up community key")
                     buttonText: qsTr("Back up")
-                    icon: Style.svg("communities/backup-community")
+                    icon.name: "objects"
                     onButtonClicked: root.backUpClicked()
                 }
             }

--- a/ui/app/AppLayouts/Chat/panels/communities/CommunityOverviewSettingsPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/CommunityOverviewSettingsPanel.qml
@@ -10,6 +10,7 @@ import StatusQ.Components 0.1
 import "../../layouts"
 
 import utils 1.0
+import shared.panels 1.0
 
 StackLayout {
     id: root

--- a/ui/app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml
+++ b/ui/app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml
@@ -9,6 +9,7 @@ import StatusQ.Components 0.1
 
 import utils 1.0
 import shared.popups 1.0
+import shared.panels 1.0
 
 import "controls"
 import "stores"

--- a/ui/app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml
+++ b/ui/app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml
@@ -6,6 +6,8 @@ import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
 import StatusQ.Controls 0.1
 import StatusQ.Components 0.1
+import StatusQ.Popups 0.1
+import StatusQ.Popups.Dialog 0.1
 
 import utils 1.0
 import shared.popups 1.0
@@ -97,7 +99,13 @@ StatusScrollView {
                 objectName: "createCommunityButton"
                 Layout.fillHeight: true
                 text: qsTr("Create New Community")
-                onClicked: Global.openPopup(createCommunitiesPopupComponent)
+                onClicked: {
+                    if (localAccountSensitiveSettings.isDiscordImportToolEnabled) {
+                      Global.openPopup(chooseCommunityCreationTypePopupComponent)
+                    } else {
+                      Global.openPopup(createCommunitiesPopupComponent)
+                    }
+                }
             }
         }
 
@@ -193,8 +201,39 @@ StatusScrollView {
         CreateCommunityPopup {
             anchors.centerIn: parent
             store: root.communitiesStore
-            onClosed: {
-                destroy()
+        }
+    }
+
+    Component {
+        id: chooseCommunityCreationTypePopupComponent
+        StatusDialog {
+            id: chooseCommunityCreationTypePopup
+            title: qsTr("Create new community")
+            horizontalPadding: 40
+            verticalPadding: 60
+            footer: null
+            onClosed: destroy()
+
+            contentItem: RowLayout {
+                spacing: 20
+                CommunityBanner {
+                    text: qsTr("Create a new Status community")
+                    buttonText: qsTr("Create new")
+                    icon.name: "favourite"
+                    onButtonClicked: {
+                        chooseCommunityCreationTypePopup.close()
+                        Global.openPopup(createCommunitiesPopupComponent)
+                    }
+                }
+                CommunityBanner {
+                    text: qsTr("Import existing Discord community into Status")
+                    buttonText: qsTr("Import existing")
+                    icon.name: "download"
+                    onButtonClicked: {
+                        chooseCommunityCreationTypePopup.close()
+                        Global.openPopup(createCommunitiesPopupComponent, {isDiscordImport: true})
+                    }
+                }
             }
         }
     }

--- a/ui/app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml
+++ b/ui/app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml
@@ -1,5 +1,5 @@
 import QtQuick 2.14
-import QtQuick.Controls 2.4
+import QtQuick.Controls 2.14
 import QtQuick.Layouts 1.14
 import QtQuick.Dialogs 1.3
 
@@ -24,8 +24,10 @@ StatusStackModal {
     id: root
 
     property var store
+    property bool isDiscordImport // creating new or importing from discord?
 
-    stackTitle: qsTr("Create New Community")
+    stackTitle: isDiscordImport ? qsTr("Import a community from Discord into Status") :
+                                  qsTr("Create New Community")
     width: 640
 
     nextButton: StatusButton {

--- a/ui/app/AppLayouts/Profile/stores/AdvancedStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/AdvancedStore.qml
@@ -34,6 +34,7 @@ QtObject {
         readonly property string communityHistoryArchiveSupport: "communityHistoryArchiveSupport"
         readonly property string communitiesPortal: "communitiesPortal"
         readonly property string communityPermissions: "communityPermissions"
+        readonly property string discordImportTool: "discordImportTool"
     }
 
     function logDir() {
@@ -133,6 +134,9 @@ QtObject {
         }
         else if (feature === experimentalFeatures.communityPermissions) {
             localAccountSensitiveSettings.isCommunityPermissionsEnabled = !localAccountSensitiveSettings.isCommunityPermissionsEnabled
+        }
+        else if (feature === experimentalFeatures.discordImportTool) {
+            localAccountSensitiveSettings.isDiscordImportToolEnabled = !localAccountSensitiveSettings.isDiscordImportToolEnabled
         }
     }
 }

--- a/ui/app/AppLayouts/Profile/views/AdvancedView.qml
+++ b/ui/app/AppLayouts/Profile/views/AdvancedView.qml
@@ -9,6 +9,8 @@ import shared.panels 1.0
 import shared.popups 1.0
 import shared.status 1.0
 
+import StatusQ.Core 0.1
+
 import "../stores"
 import "../controls"
 import "../popups"
@@ -51,8 +53,7 @@ SettingsContentBase {
                 }
             }
 
-            // TODO: replace with StatusQ component
-            StyledText {
+            StatusBaseText {
                 anchors.left: parent.left
                 anchors.right: parent.right
                 anchors.leftMargin: Style.current.padding
@@ -100,7 +101,7 @@ SettingsContentBase {
                 anchors.leftMargin: 0
                 anchors.rightMargin: 0
                 text: qsTr("Wallet")
-                objectName: qsTr("WalletSettingsLineButton")
+                objectName: "WalletSettingsLineButton"
                 isSwitch: true
                 switchChecked: localAccountSensitiveSettings.isWalletEnabled
                 onClicked: {
@@ -176,6 +177,23 @@ SettingsContentBase {
                         confirmationPopup.open()
                     } else {
                         root.advancedStore.toggleExperimentalFeature(root.advancedStore.experimentalFeatures.communityPermissions)
+                    }
+                }
+            }
+
+            StatusSettingsLineButton {
+                anchors.leftMargin: 0
+                anchors.rightMargin: 0
+                text: qsTr("Discord Import Tool")
+                objectName: "DiscordImportToolSettingsLineButton"
+                isSwitch: true
+                switchChecked: localAccountSensitiveSettings.isDiscordImportToolEnabled
+                onClicked: {
+                    if (!localAccountSensitiveSettings.isDiscordImportToolEnabled) {
+                        confirmationPopup.experimentalFeature = root.advancedStore.experimentalFeatures.discordImportTool
+                        confirmationPopup.open()
+                    } else {
+                        root.advancedStore.toggleExperimentalFeature(root.advancedStore.experimentalFeatures.discordImportTool)
                     }
                 }
             }

--- a/ui/imports/shared/panels/CommunityBanner.qml
+++ b/ui/imports/shared/panels/CommunityBanner.qml
@@ -3,6 +3,7 @@ import QtQuick.Controls 2.13
 import QtGraphicalEffects 1.13
 
 import StatusQ.Core 0.1
+import StatusQ.Components 0.1
 import StatusQ.Core.Theme 0.1
 import StatusQ.Controls 0.1 as StatusQControls
 
@@ -16,11 +17,10 @@ Rectangle {
 
     property alias text: bannerText.text
     property alias buttonText: bannerButton.text
-    property alias icon: bannerIcon.source
-
+    property alias icon: bannerIcon.icon
 
     implicitWidth: 272
-    implicitHeight: 182
+    implicitHeight: 168
     border.color: Style.current.border
     radius: 16
     color: Style.current.transparent
@@ -47,19 +47,17 @@ Rectangle {
         anchors.horizontalCenter: parent.horizontalCenter
     }
 
-    SVGImage {
+    StatusRoundIcon {
         id: bannerIcon
         anchors.top: parent.top
-        anchors.topMargin: -6
+        anchors.topMargin: -8
         anchors.horizontalCenter: parent.horizontalCenter
-        width: 66
-        height: 50
     }
 
     StatusBaseText {
         id: bannerText
         anchors.top: parent.top
-        anchors.topMargin: 60
+        anchors.topMargin: 48
         horizontalAlignment: Text.AlignHCenter
         font.pixelSize: 15
         color: Theme.palette.directColor1
@@ -74,7 +72,8 @@ Rectangle {
         id: bannerButton
         anchors.horizontalCenter: parent.horizontalCenter
         anchors.bottom: parent.bottom
-        anchors.bottomMargin: 22
+        anchors.bottomMargin: 16
+        font.weight: Font.Medium
         onClicked: root.buttonClicked()
     }
 }

--- a/ui/imports/shared/panels/CommunityBanner.qml
+++ b/ui/imports/shared/panels/CommunityBanner.qml
@@ -78,3 +78,4 @@ Rectangle {
         onClicked: root.buttonClicked()
     }
 }
+

--- a/ui/imports/shared/panels/qmldir
+++ b/ui/imports/shared/panels/qmldir
@@ -1,6 +1,7 @@
 Address 1.0 Address.qml
 AddressRequiredValidator 1.0 AddressRequiredValidator.qml
 BalanceValidator 1.0 BalanceValidator.qml
+CommunityBanner 1.0 CommunityBanner.qml
 GlossaryEntry 1.0 GlossaryEntry.qml
 GlossaryLetter 1.0 GlossaryLetter.qml
 ImageLoader 1.0 ImageLoader.qml


### PR DESCRIPTION
This adds a feature flag for the discord import tool so we can start
landing individual pieces of the feature without it being fully
implemented.

It also introduces the modal chooser for creating new communities but
it doesn't do anything more than that, as of this commit

Co-authored with @caybro 

Closes #6843
