### PR TITLE
feat(wallet): favorites for saved addresses

### DIFF
--- a/src/app/modules/main/wallet_section/saved_addresses/controller.nim
+++ b/src/app/modules/main/wallet_section/saved_addresses/controller.nim
@@ -29,8 +29,8 @@ proc init*(self: Controller) =
 proc getSavedAddresses*(self: Controller): seq[saved_address_service.SavedAddressDto] =
   return self.savedAddressService.getSavedAddresses()
 
-proc createOrUpdateSavedAddress*(self: Controller, name, address: string): string =
-  return self.savedAddressService.createOrUpdateSavedAddress(name, address)
+proc createOrUpdateSavedAddress*(self: Controller, name: string, address: string, favourite: bool): string =
+  return self.savedAddressService.createOrUpdateSavedAddress(name, address, favourite)
 
 proc deleteSavedAddress*(self: Controller, address: string): string =
   return self.savedAddressService.deleteSavedAddress(address)

--- a/src/app/modules/main/wallet_section/saved_addresses/io_interface.nim
+++ b/src/app/modules/main/wallet_section/saved_addresses/io_interface.nim
@@ -17,7 +17,7 @@ method viewDidLoad*(self: AccessInterface) {.base.} =
 method loadSavedAddresses*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method createOrUpdateSavedAddress*(self: AccessInterface, name, address: string): string {.base.} =
+method createOrUpdateSavedAddress*(self: AccessInterface, name: string, address: string, favourite: bool): string {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method deleteSavedAddress*(self: AccessInterface, address: string): string {.base.} =

--- a/src/app/modules/main/wallet_section/saved_addresses/item.nim
+++ b/src/app/modules/main/wallet_section/saved_addresses/item.nim
@@ -4,18 +4,22 @@ type
   Item* = object
     name: string
     address: string
+    favourite: bool
 
 proc initItem*(
   name: string,
   address: string,
+  favourite: bool
 ): Item =
   result.name = name
   result.address = address
+  result.favourite = favourite
 
 proc `$`*(self: Item): string =
   result = fmt"""AllTokensItem(
     name: {self.name},
     address: {self.address},
+    favourite: {self.favourite},
     ]"""
 
 proc getName*(self: Item): string =
@@ -23,3 +27,6 @@ proc getName*(self: Item): string =
 
 proc getAddress*(self: Item): string =
   return self.address
+
+proc getFavourite*(self: Item): bool =
+  return self.favourite

--- a/src/app/modules/main/wallet_section/saved_addresses/model.nim
+++ b/src/app/modules/main/wallet_section/saved_addresses/model.nim
@@ -6,6 +6,7 @@ type
   ModelRole {.pure.} = enum
     Name = UserRole + 1,
     Address
+    Favourite
 
 QtObject:
   type
@@ -43,6 +44,7 @@ QtObject:
     {
       ModelRole.Name.int:"name",
       ModelRole.Address.int:"address",
+      ModelRole.Favourite.int:"favourite",
     }.toTable
 
   method data(self: Model, index: QModelIndex, role: int): QVariant =
@@ -60,6 +62,8 @@ QtObject:
       result = newQVariant(item.getName())
     of ModelRole.Address:
       result = newQVariant(item.getAddress())
+    of ModelRole.Favourite:
+      result = newQVariant(item.getFavourite())
 
   proc rowData(self: Model, index: int, column: string): string {.slot.} =
     if (index >= self.items.len):
@@ -68,6 +72,7 @@ QtObject:
     case column:
       of "name": result = $item.getName()
       of "address": result = $item.getAddress()
+      of "favourite": result = $item.getFavourite()
 
   proc setItems*(self: Model, items: seq[Item]) =
     self.beginResetModel()

--- a/src/app/modules/main/wallet_section/saved_addresses/module.nim
+++ b/src/app/modules/main/wallet_section/saved_addresses/module.nim
@@ -36,6 +36,7 @@ method loadSavedAddresses*(self: Module) =
     savedAddresses.map(s => initItem(
       s.name,
       s.address,
+      s.favourite
     ))
   )
 
@@ -53,8 +54,8 @@ method viewDidLoad*(self: Module) =
   self.moduleLoaded = true
   self.delegate.savedAddressesModuleDidLoad()
 
-method createOrUpdateSavedAddress*(self: Module, name: string, address: string): string =
-  return self.controller.createOrUpdateSavedAddress(name, address)
+method createOrUpdateSavedAddress*(self: Module, name: string, address: string, favourite: bool): string =
+  return self.controller.createOrUpdateSavedAddress(name, address, favourite)
 
 method deleteSavedAddress*(self: Module, address: string): string =
   return self.controller.deleteSavedAddress(address)

--- a/src/app/modules/main/wallet_section/saved_addresses/view.nim
+++ b/src/app/modules/main/wallet_section/saved_addresses/view.nim
@@ -37,8 +37,8 @@ QtObject:
   proc setItems*(self: View, items: seq[Item]) =
     self.model.setItems(items)
 
-  proc createOrUpdateSavedAddress*(self: View, name: string, address: string): string {.slot.} =
-    return self.delegate.createOrUpdateSavedAddress(name, address)
+  proc createOrUpdateSavedAddress*(self: View, name: string, address: string, favourite: bool): string {.slot.} =
+    return self.delegate.createOrUpdateSavedAddress(name, address, favourite)
 
   proc deleteSavedAddress*(self: View, address: string): string {.slot.} =
     return self.delegate.deleteSavedAddress(address)

--- a/src/app_service/service/saved_address/dto.nim
+++ b/src/app_service/service/saved_address/dto.nim
@@ -6,17 +6,21 @@ type
   SavedAddressDto* = ref object of RootObj
     name*: string
     address*: string
+    favourite*: bool
 
 proc newSavedAddressDto*(
   name: string,
   address: string,
+  favourite: bool
 ): SavedAddressDto =
   return SavedAddressDto(
     name: name,
     address: address,
+    favourite: favourite
   )
 
 proc toSavedAddressDto*(jsonObj: JsonNode): SavedAddressDto =
   result = SavedAddressDto()
   discard jsonObj.getProp("name", result.name)
   discard jsonObj.getProp("address", result.address)
+  discard jsonObj.getProp("favourite", result.favourite)

--- a/src/backend/backend.nim
+++ b/src/backend/backend.nim
@@ -28,6 +28,7 @@ type
   SavedAddress* = ref object of RootObj
     name* {.serializedFieldName("name").}: string
     address* {.serializedFieldName("address").}: string
+    favourite* {.serializedFieldName("favourite").}: bool
 
   Network* = ref object of RootObj
     chainId* {.serializedFieldName("chainId").}: int

--- a/ui/app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml
+++ b/ui/app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml
@@ -20,6 +20,7 @@ StatusDialog {
     property bool edit: false
     property string address
     property alias name: nameInput.text
+    property bool favourite: false
     property var contactsStore
 
     signal save(string name, string address)

--- a/ui/app/AppLayouts/Wallet/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Wallet/stores/RootStore.qml
@@ -167,8 +167,8 @@ QtObject {
 //            walletModelV2Inst.collectiblesView.collections.getCollectionTraitMaxValue(collectionIndex, traitType).toString();
     }
 
-    function createOrUpdateSavedAddress(name, address) {
-        return walletSectionSavedAddresses.createOrUpdateSavedAddress(name, address)
+    function createOrUpdateSavedAddress(name, address, favourite) {
+        return walletSectionSavedAddresses.createOrUpdateSavedAddress(name, address, favourite)
     }
 
     function deleteSavedAddress(address) {

--- a/ui/app/AppLayouts/Wallet/views/SavedAddressesView.qml
+++ b/ui/app/AppLayouts/Wallet/views/SavedAddressesView.qml
@@ -6,6 +6,7 @@ import utils 1.0
 import StatusQ.Controls 0.1
 import StatusQ.Components 0.1
 import StatusQ.Core 0.1
+import StatusQ.Core.Utils 0.1
 import StatusQ.Core.Theme 0.1
 import StatusQ.Popups 0.1
 import shared.controls 1.0
@@ -26,9 +27,9 @@ Item {
         id: _internal
         property bool loading: false
         property string error: ""
-        function saveAddress(name, address) {
+        function saveAddress(name, address, favourite) {
             loading = true
-            error = RootStore.createOrUpdateSavedAddress(name, address)
+            error = RootStore.createOrUpdateSavedAddress(name, address, favourite)
             loading = false
         }
         function deleteSavedAddress(address) {
@@ -106,11 +107,12 @@ Item {
         delegate: SavedAddressesDelegate {
             name: model.name
             address: model.address
+            favourite: model.favourite
             store: RootStore
             contactsStore: root.contactsStore
             onOpenSendModal: root.sendModal.open(address);
-            saveAddress: function(name, address) {
-                _internal.saveAddress(name, address)
+            saveAddress: function(name, address, favourite) {
+                _internal.saveAddress(name, address, favourite)
             }
             deleteSavedAddress: function(address) {
                 _internal.deleteSavedAddress(address)
@@ -126,7 +128,7 @@ Item {
             onClosed: destroy()
             contactsStore: root.contactsStore
             onSave: {
-                 _internal.saveAddress(name, address)
+                 _internal.saveAddress(name, address, favourite)
                 close()
             }
         }

--- a/ui/imports/shared/popups/AddEditSavedAddressPopup.qml
+++ b/ui/imports/shared/popups/AddEditSavedAddressPopup.qml
@@ -21,6 +21,7 @@ StatusDialog {
     property bool addAddress: false
     property string address
     property alias name: nameInput.text
+    property bool favourite: false
     property var contactsStore
 
     signal save(string name, string address)

--- a/ui/imports/shared/stores/RootStore.qml
+++ b/ui/imports/shared/stores/RootStore.qml
@@ -184,8 +184,8 @@ QtObject {
         return walletSectionSavedAddresses.getNameByAddress(address)
     }
 
-    function createOrUpdateSavedAddress(name, address) {
-        return walletSectionSavedAddresses.createOrUpdateSavedAddress(name, address)
+    function createOrUpdateSavedAddress(name, address, favourite) {
+        return walletSectionSavedAddresses.createOrUpdateSavedAddress(name, address, favourite)
     }
 
     function deleteSavedAddress(address) {

--- a/ui/imports/shared/views/TransactionDetailView.qml
+++ b/ui/imports/shared/views/TransactionDetailView.qml
@@ -100,8 +100,8 @@ Item {
                 store: RootStore
                 contactsStore: root.contactsStore
                 onOpenSendModal: root.sendModal.open(address);
-                saveAddress: function(name, address) {
-                    RootStore.createOrUpdateSavedAddress(name, address)
+                saveAddress: function(name, address, favourite) {
+                    RootStore.createOrUpdateSavedAddress(name, address, favourite)
                 }
                 deleteSavedAddress: function(address) {
                     RootStore.deleteSavedAddress(address)


### PR DESCRIPTION
### Implements: #6546

Depends on `status-go`'s API change [in review PR #2844](https://github.com/status-im/status-go/pull/2844)

Notes

- Remove duplicate name instead of ESN
- Fixes elide address

### Affected areas

Wallet - Saved Addresses

### Screenshot of functionality (including design for comparison)

![image](https://user-images.githubusercontent.com/47554641/185461226-31fae312-f6a8-46b2-9e43-c183655ddb94.png)

| Implementation | Design |
| :-: | :-: |
| ![image](https://user-images.githubusercontent.com/47554641/185463363-d46d1833-d0a6-40d0-a1b8-9afe37817faa.png) | ![image](https://user-images.githubusercontent.com/47554641/185463531-920b7675-181b-490d-a355-28ee27d14759.png) |