### PR TITLE
feat(CreateCommunityPopup): add discord import progress panel and discord message handling

### DIFF
--- a/src/app/core/signals/remote_signals/signal_type.nim
+++ b/src/app/core/signals/remote_signals/signal_type.nim
@@ -39,9 +39,12 @@ type SignalType* {.pure.} = enum
   HistoryArchivesSeeding = "community.historyArchivesSeeding"
   HistoryArchivesUnseeded = "community.historyArchivesUnseeded"
   HistoryArchiveDownloaded = "community.historyArchiveDownloaded"
+  DownloadingHistoryArchivesFinished = "community.downloadingHistoryArchivesFinished"
   UpdateAvailable = "update.available"
   DiscordCategoriesAndChannelsExtracted = "community.discordCategoriesAndChannelsExtracted"
   StatusUpdatesTimedout = "status.updates.timedout"
+  DiscordCommunityImportFinished = "community.discordCommunityImportFinished"
+  DiscordCommunityImportProgress = "community.discordCommunityImportProgress"
   Unknown
 
 proc event*(self:SignalType):string =

--- a/src/app/core/signals/signals_manager.nim
+++ b/src/app/core/signals/signals_manager.nim
@@ -93,9 +93,12 @@ QtObject:
       of SignalType.HistoryArchivesSeeding: HistoryArchivesSignal.historyArchivesSeedingFromEvent(jsonSignal)
       of SignalType.HistoryArchivesUnseeded: HistoryArchivesSignal.historyArchivesUnseededFromEvent(jsonSignal)
       of SignalType.HistoryArchiveDownloaded: HistoryArchivesSignal.historyArchiveDownloadedFromEvent(jsonSignal)
+      of SignalType.DownloadingHistoryArchivesFinished: HistoryArchivesSignal.downloadingHistoryArchivesFinishedFromEvent(jsonSignal)
       of SignalType.UpdateAvailable: UpdateAvailableSignal.fromEvent(jsonSignal)
       of SignalType.DiscordCategoriesAndChannelsExtracted: DiscordCategoriesAndChannelsExtractedSignal.fromEvent(jsonSignal)
       of SignalType.StatusUpdatesTimedout: StatusUpdatesTimedoutSignal.fromEvent(jsonSignal)
+      of SignalType.DiscordCommunityImportFinished: DiscordCommunityImportFinishedSignal.fromEvent(jsonSignal)
+      of SignalType.DiscordCommunityImportProgress: DiscordCommunityImportProgressSignal.fromEvent(jsonSignal)
       else: Signal()
 
     result.signalType = signalType

--- a/src/app/modules/main/activity_center/module.nim
+++ b/src/app/modules/main/activity_center/module.nim
@@ -96,7 +96,8 @@ proc createMessageItemFromDto(self: Module, message: MessageDto, chatDetails: Ch
     newTransactionParametersItem("","","","","","",-1,""),
     message.mentionedUsersPks,
     contactDetails.details.trustStatus,
-    contactDetails.details.ensVerified
+    contactDetails.details.ensVerified,
+    message.discordMessage
     ))
 
 method convertToItems*(

--- a/src/app/modules/main/chat_section/chat_content/messages/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/module.nim
@@ -97,7 +97,8 @@ proc createFetchMoreMessagesItem(self: Module): Item =
     transactionParameters = newTransactionParametersItem("","","","","","",-1,""),
     mentionedUsersPks = @[],
     senderTrustStatus = TrustStatus.Unknown,
-    senderEnsVerified = false
+    senderEnsVerified = false,
+    DiscordMessage()
   )
 
 proc createChatIdentifierItem(self: Module): Item =
@@ -136,7 +137,8 @@ proc createChatIdentifierItem(self: Module): Item =
     transactionParameters = newTransactionParametersItem("","","","","","",-1,""),
     mentionedUsersPks = @[],
     senderTrustStatus = TrustStatus.Unknown,
-    senderEnsVerified = false
+    senderEnsVerified = false,
+    DiscordMessage()
   )
 
 proc checkIfMessageLoadedAndScrollToItIfItIs(self: Module): bool =
@@ -185,7 +187,7 @@ method newMessagesLoaded*(self: Module, messages: seq[MessageDto], reactions: se
         sender.defaultDisplayName,
         sender.optionalName,
         sender.icon,
-        isCurrentUser,
+        (isCurrentUser and m.contentType.ContentType != ContentType.DiscordMessage),
         sender.details.added,
         m.outgoingStatus,
         renderedMessageText,
@@ -209,7 +211,8 @@ method newMessagesLoaded*(self: Module, messages: seq[MessageDto], reactions: se
           m.transactionParameters.signature),
         m.mentionedUsersPks(),
         sender.details.trustStatus,
-        sender.details.ensVerified
+        sender.details.ensVerified,
+        m.discordMessage
         )
 
       for r in reactions:
@@ -277,7 +280,7 @@ method messageAdded*(self: Module, message: MessageDto) =
     sender.defaultDisplayName,
     sender.optionalName,
     sender.icon,
-    isCurrentUser,
+    (isCurrentUser and message.contentType.ContentType != ContentType.DiscordMessage),
     sender.details.added,
     message.outgoingStatus,
     renderedMessageText,
@@ -301,7 +304,8 @@ method messageAdded*(self: Module, message: MessageDto) =
                     message.transactionParameters.signature),
     message.mentionedUsersPks,
     sender.details.trustStatus,
-    sender.details.ensVerified
+    sender.details.ensVerified,
+    message.discordMessage
   )
 
   self.view.model().insertItemBasedOnTimestamp(item)

--- a/src/app/modules/main/chat_section/chat_content/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/module.nim
@@ -194,7 +194,8 @@ proc buildPinnedMessageItem(self: Module, messageId: string, actionInitiatedBy: 
       m.transactionParameters.signature),
     m.mentionedUsersPks,
     contactDetails.details.trustStatus,
-    contactDetails.details.ensVerified
+    contactDetails.details.ensVerified,
+    m.discordMessage
   )
   item.pinned = true
   item.pinnedBy = actionInitiatedBy

--- a/src/app/modules/main/communities/controller.nim
+++ b/src/app/modules/main/communities/controller.nim
@@ -70,6 +70,10 @@ proc init*(self: Controller) =
     let args = DiscordCategoriesAndChannelsArgs(e)
     self.delegate.discordCategoriesAndChannelsExtracted(args.categories, args.channels, args.oldestMessageTimestamp, args.errors, args.errorsCount)
 
+  self.events.on(SIGNAL_DISCORD_COMMUNITY_IMPORT_PROGRESS) do(e:Args):
+    let args = DiscordImportProgressArgs(e)
+    self.delegate.discordImportProgressUpdated(args.communityId, args.communityName, args.tasks, args.progress, args.errorsCount, args.warningsCount, args.stopped)
+
 proc getCommunityTags*(self: Controller): string =
   result = self.communityService.getCommunityTags()
 
@@ -112,6 +116,36 @@ proc createCommunity*(
     historyArchiveSupportEnabled,
     pinMessageAllMembersEnabled,
     bannerJsonStr)
+
+proc requestImportDiscordCommunity*(
+    self: Controller,
+    name: string,
+    description: string,
+    introMessage: string,
+    outroMessage: string,
+    access: int,
+    color: string,
+    tags: string,
+    imageUrl: string,
+    aX: int, aY: int, bX: int, bY: int,
+    historyArchiveSupportEnabled: bool,
+    pinMessageAllMembersEnabled: bool,
+    filesToImport: seq[string],
+    fromTimestamp: int) =
+  self.communityService.requestImportDiscordCommunity(
+    name,
+    description,
+    introMessage,
+    outroMessage,
+    access,
+    color,
+    tags,
+    imageUrl,
+    aX, aY, bX, bY,
+    historyArchiveSupportEnabled,
+    pinMessageAllMembersEnabled,
+    filesToImport,
+    fromTimestamp)
 
 proc reorderCommunityChat*(
     self: Controller,
@@ -167,3 +201,6 @@ proc getStatusForContactWithId*(self: Controller, publicKey: string): StatusUpda
 
 proc requestExtractDiscordChannelsAndCategories*(self: Controller, filesToImport: seq[string]) =
   self.communityService.requestExtractDiscordChannelsAndCategories(filesToImport)
+
+proc requestCancelDiscordCommunityImport*(self: Controller, id: string) =
+  self.communityService.requestCancelDiscordCommunityImport(id)

--- a/src/app/modules/main/communities/io_interface.nim
+++ b/src/app/modules/main/communities/io_interface.nim
@@ -34,6 +34,11 @@ method createCommunity*(self: AccessInterface, name: string, description, introM
                         historyArchiveSupportEnabled: bool, pinMessageAllMembersEnabled: bool, bannerJsonStr: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method requestImportDiscordCommunity*(self: AccessInterface, name: string, description, introMessage, outroMessage: string, access: int,
+                        color: string, tags: string, imagePath: string, aX: int, aY: int, bX: int, bY: int,
+                        historyArchiveSupportEnabled: bool, pinMessageAllMembersEnabled: bool, filesToImport: seq[string], fromTimestamp: int) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method deleteCommunityCategory*(self: AccessInterface, communityId: string, categoryId: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
@@ -116,4 +121,10 @@ method requestExtractDiscordChannelsAndCategories*(self: AccessInterface, filesT
   raise newException(ValueError, "No implementation available")
 
 method discordCategoriesAndChannelsExtracted*(self: AccessInterface, categories: seq[DiscordCategoryDto], channels: seq[DiscordChannelDto], oldestMessageTimestamp: int, errors: Table[string, DiscordImportError], errorsCount: int) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method discordImportProgressUpdated*(self: AccessInterface, communityId: string, communityName: string, tasks: seq[DiscordImportTaskProgress], progress: float, errorsCount: int, warningsCount: int, stopped: bool) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method requestCancelDiscordCommunityImport*(self: AccessInterface, id: string) {.base.} =
   raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/communities/models/discord_import_error_item.nim
+++ b/src/app/modules/main/communities/models/discord_import_error_item.nim
@@ -1,0 +1,31 @@
+import strformat
+type
+  DiscordImportErrorItem* = object
+    taskId*: string
+    code*: int
+    message*: string
+
+proc initDiscordImportErrorItem*(
+  taskId: string,
+  code: int,
+  message: string,
+): DiscordImportErrorItem =
+  result.taskId = taskId
+  result.code = code
+  result.message = message
+
+proc `$`*(self: DiscordImportErrorItem): string =
+  result = fmt"""DiscordImportErrorItem(
+    taskId: {self.taskId},
+    code: {self.code},
+    message: {self.message}
+    ]"""
+
+proc getTaskId*(self: DiscordImportErrorItem): string =
+  return self.taskId
+
+proc getCode*(self: DiscordImportErrorItem): int =
+  return self.code
+
+proc getMessage*(self: DiscordImportErrorItem): string =
+  return self.message

--- a/src/app/modules/main/communities/models/discord_import_errors_model.nim
+++ b/src/app/modules/main/communities/models/discord_import_errors_model.nim
@@ -1,0 +1,60 @@
+import NimQml, Tables
+import discord_import_error_item
+
+type
+  ModelRole {.pure.} = enum
+    TaskId = UserRole + 1
+    Code
+    Message
+
+QtObject:
+  type DiscordImportErrorsModel* = ref object of QAbstractListModel
+    items*: seq[DiscordImportErrorItem]
+
+  proc setup(self: DiscordImportErrorsModel) =
+    self.QAbstractListModel.setup
+
+  proc delete(self: DiscordImportErrorsModel) =
+    self.items = @[]
+    self.QAbstractListModel.delete
+
+  proc newDiscordDiscordImportErrorsModel*(): DiscordImportErrorsModel =
+    new(result, delete)
+    result.setup
+
+  method roleNames(self: DiscordImportErrorsModel): Table[int, string] =
+    {
+      ModelRole.TaskId.int:"taskId",
+      ModelRole.Code.int:"code",
+      ModelRole.Message.int:"message",
+    }.toTable
+
+  method rowCount(self: DiscordImportErrorsModel, index: QModelIndex = nil): int =
+    return self.items.len
+
+  method data(self: DiscordImportErrorsModel, index: QModelIndex, role: int): QVariant =
+    if not index.isValid:
+      return
+    if index.row < 0 or index.row >= self.items.len:
+      return
+    let item = self.items[index.row]
+    let enumRole = role.ModelRole
+    case enumRole:
+      of ModelRole.TaskId:
+        result = newQVariant(item.getTaskId())
+      of ModelRole.Code:
+        result = newQVariant(item.getCode())
+      of ModelRole.Message:
+        result = newQVariant(item.getMessage())
+
+  proc setItems*(self: DiscordImportErrorsModel, items: seq[DiscordImportErrorItem]) =
+    self.beginResetModel()
+    self.items = items
+    self.endResetModel()
+
+  proc addItem*(self: DiscordImportErrorsModel, item: DiscordImportErrorItem) =
+    let parentModelIndex = newQModelIndex()
+    defer: parentModelIndex.delete
+    self.beginInsertRows(parentModelIndex, self.items.len, self.items.len)
+    self.items.add(item)
+    self.endInsertRows()

--- a/src/app/modules/main/communities/models/discord_import_progress_item.nim
+++ b/src/app/modules/main/communities/models/discord_import_progress_item.nim
@@ -1,0 +1,45 @@
+import strformat
+type
+  DiscordImportProgressItem* = object
+    communityId*: string
+    progress*: float
+    errorsCount*: int
+    warningsCount*: int
+    stopped*: bool
+
+proc initDiscordImportProgressItem*(
+  communityId: string,
+  progress: float,
+  errorsCount: int,
+  warningsCount: int,
+  stopped: bool,
+): DiscordImportProgressItem =
+  result.communityId = communityId
+  result.progress = progress
+  result.errorsCount = errorsCount
+  result.warningsCount = warningsCount
+  result.stopped = stopped
+
+proc `$`*(self: DiscordImportProgressItem): string =
+  result = fmt"""DiscordImportProgressItem(
+    communityId: {self.communityId},
+    progress: {self.progress},
+    errorsCount: {self.errorsCount},
+    warningsCount: {self.warningsCount},
+    stopped: {self.stopped}
+    ]"""
+
+proc getCommunitId*(self: DiscordImportProgressItem): string =
+  return self.communityId
+
+proc getProgress*(self: DiscordImportProgressItem): float =
+  return self.progress
+
+proc getErrorsCount*(self: DiscordImportProgressItem): int =
+  return self.errorsCount
+
+proc getWarningsCount*(self: DiscordImportProgressItem): int =
+  return self.warningsCount
+
+proc getStopped*(self: DiscordImportProgressItem): bool =
+  return self.stopped

--- a/src/app/modules/main/communities/models/discord_import_task_item.nim
+++ b/src/app/modules/main/communities/models/discord_import_task_item.nim
@@ -1,0 +1,68 @@
+import strformat
+import discord_import_errors_model, discord_import_error_item
+import ../../../../../app_service/service/community/dto/community
+
+
+const MAX_VISIBLE_ERROR_ITEMS* = 3
+
+type
+  DiscordImportTaskItem* = object
+    `type`*: string
+    progress*: float
+    state*: string
+    errors*: DiscordImportErrorsModel
+    stopped*: bool
+    errorsCount*: int
+    warningsCount*: int
+
+proc `$`*(self: DiscordImportTaskItem): string =
+  result = fmt"""DiscordImportTaskItem(
+    type: {self.type},
+    state: {self.state},
+    progress: {self.progress},
+    stopped: {self.stopped},
+    ]"""
+
+proc initDiscordImportTaskItem*(
+  `type`: string,
+  progress: float,
+  state: string,
+  errors: seq[DiscordImportError],
+  stopped: bool,
+  errorsCount: int,
+  warningsCount: int
+): DiscordImportTaskItem =
+  result.type = type
+  result.progress = progress
+  result.state = state
+  result.errors = newDiscordDiscordImportErrorsModel()
+  result.stopped = stopped
+  result.errorsCount = errorsCount
+  result.warningsCount = warningsCount
+
+  # We only show the first 3 errors per task, then we add another
+  # "#n more issues" item in the UI
+  for i, error in errors:
+    if i < MAX_VISIBLE_ERROR_ITEMS:
+      result.errors.addItem(initDiscordImportErrorItem(`type`, error.code, error.message))
+
+proc getType*(self: DiscordImportTaskItem): string =
+  return self.type
+
+proc getProgress*(self: DiscordImportTaskItem): float =
+  return self.progress
+
+proc getState*(self: DiscordImportTaskItem): string =
+  return self.state
+
+proc getErrors*(self: DiscordImportTaskItem): DiscordImportErrorsModel =
+  return self.errors
+
+proc getStopped*(self: DiscordImportTaskItem): bool =
+  return self.stopped
+
+proc getErrorsCount*(self: DiscordImportTaskItem): int =
+  return self.errorsCount
+
+proc getWarningsCount*(self: DiscordImportTaskItem): int =
+  return self.warningsCount

--- a/src/app/modules/main/communities/models/discord_import_tasks_model.nim
+++ b/src/app/modules/main/communities/models/discord_import_tasks_model.nim
@@ -1,0 +1,125 @@
+import NimQml, Tables
+import discord_import_error_item, discord_import_errors_model
+import discord_import_task_item as taskItem 
+import ../../../../../app_service/service/community/dto/community
+
+type
+  ModelRole {.pure.} = enum
+    Type = UserRole + 1
+    Progress
+    State
+    Errors
+    Stopped
+    ErrorsCount
+    WarningsCount
+
+QtObject:
+  type DiscordImportTasksModel* = ref object of QAbstractListModel
+    items*: seq[DiscordImportTaskItem]
+
+  proc setup(self: DiscordImportTasksModel) =
+    self.QAbstractListModel.setup
+
+  proc delete(self: DiscordImportTasksModel) =
+    self.items = @[]
+    self.QAbstractListModel.delete
+
+  proc newDiscordDiscordImportTasksModel*(): DiscordImportTasksmodel =
+    new(result, delete)
+    result.setup
+
+  method roleNames(self: DiscordImportTasksModel): Table[int, string] =
+    {
+      ModelRole.Type.int:"type",
+      ModelRole.Progress.int:"progress",
+      ModelRole.State.int:"state",
+      ModelRole.Errors.int:"errors",
+      ModelRole.Stopped.int:"stopped",
+      ModelRole.ErrorsCount.int:"errorsCount",
+      ModelRole.WarningsCount.int:"warningsCount",
+    }.toTable
+
+  method data(self: DiscordImportTasksModel, index: QModelIndex, role: int): QVariant =
+    if not index.isValid:
+      return
+    if index.row < 0 or index.row >= self.items.len:
+      return
+    let item = self.items[index.row]
+    let enumRole = role.ModelRole
+    case enumRole:
+      of ModelRole.Type:
+        result = newQVariant(item.getType())
+      of ModelRole.Progress:
+        result = newQVariant(item.getProgress())
+      of ModelRole.State:
+        result = newQVariant(item.getState())
+      of ModelRole.Errors:
+        result = newQVariant(item.getErrors())
+      of ModelRole.Stopped:
+        result = newQVariant(item.getStopped())
+      of ModelRole.ErrorsCount:
+        result = newQVariant(item.getErrorsCount())
+      of ModelRole.WarningsCount:
+        result = newQVariant(item.getWarningsCount())
+
+  method rowCount(self: DiscordImportTasksModel, index: QModelIndex = nil): int =
+    return self.items.len
+
+  proc setItems*(self: DiscordImportTasksModel, items: seq[DiscordImportTaskItem]) =
+    self.beginResetModel()
+    self.items = items
+    self.endResetModel()
+
+  proc hasItemByType*(self: DiscordImportTasksModel, `type`: string): bool =
+    for i, item in self.items:
+      if self.items[i].`type` == `type`:
+        return true
+    return false
+
+  proc addItem*(self: DiscordImportTasksModel, item: DiscordImportTaskItem) =
+    let parentModelIndex = newQModelIndex()
+    defer: parentModelIndex.delete
+    self.beginInsertRows(parentModelIndex, self.items.len, self.items.len)
+    self.items.add(item)
+    self.endInsertRows()
+
+  proc findIndexByType(self: DiscordImportTasksModel, `type`: string): int =
+    for i in 0 ..< self.items.len:
+      if(self.items[i].`type` == `type`):
+        return i
+    return -1
+
+  proc updateItem*(self: DiscordImportTasksModel, item: DiscordImportTaskProgress) =
+    let idx = self.findIndexByType(item.`type`)
+    if idx > -1:
+      let index = self.createIndex(idx, 0, nil)
+      let errorsAndWarningsCount = self.items[idx].warningsCount + self.items[idx].errorsCount
+      self.items[idx].progress = item.progress
+      self.items[idx].state = item.state
+      self.items[idx].stopped = item.stopped
+      self.items[idx].errorsCount = item.errorsCount
+      self.items[idx].warningsCount = item.warningsCount
+
+      let errorItemsCount = self.items[idx].errors.items.len
+
+      # We only show the first 3 errors per task, then we add another
+      # "#n more issues" item in the UI
+      for i, error in item.errors:
+        if errorItemsCount + i < taskItem.MAX_VISIBLE_ERROR_ITEMS:
+          let errorItem = initDiscordImportErrorItem(item.`type`, error.code, error.message)
+          self.items[idx].errors.addItem(errorItem)
+
+      self.dataChanged(index, index, @[
+        ModelRole.Progress.int,
+        ModelRole.State.int,
+        ModelRole.Errors.int,
+        ModelRole.Stopped.int,
+        ModelRole.ErrorsCount.int,
+        ModelRole.WarningsCount.int
+      ])
+
+
+  proc clearItems*(self: DiscordImportTasksModel) =
+    self.beginResetModel()
+    self.items = @[]
+    self.endResetModel()

--- a/src/app/modules/shared_models/discord_message_item.nim
+++ b/src/app/modules/shared_models/discord_message_item.nim
@@ -1,0 +1,68 @@
+import Nimqml, json, strformat
+
+import ../../../app_service/service/message/dto/message
+
+QtObject:
+  type
+    DiscordMessageItem* = ref object of QObject
+      id: string
+      timestamp: string
+      timestampEdited: string
+      content: string
+      author: DiscordMessageAuthor
+
+  proc setup(self: DiscordMessageItem) =
+    self.QObject.setup
+
+  proc delete*(self: DiscordMessageItem) =
+    self.QObject.delete
+
+  proc newDiscordMessageItem*(
+      id: string,
+      timestamp: string,
+      timestampEdited: string,
+      content: string,
+      author: DiscordMessageAuthor
+      ): DiscordMessageItem =
+    new(result, delete)
+    result.setup
+    result.id = id
+    result.timestamp = timestamp
+    result.timestampEdited = timestampEdited
+    result.content = content
+    result.author = author
+
+  proc `$`*(self: DiscordMessageItem): string =
+    result = fmt"""DiscordMessageItem(
+      id: {$self.id},
+      timestamp: {$self.timestamp},
+      timestampEdited: {$self.timestampEdited},
+      content: {$self.content},
+      )"""
+
+  proc id*(self: DiscordMessageItem): string {.inline.} =
+    self.id
+
+  QtProperty[string] id:
+    read = id
+
+  proc timestamp*(self: DiscordMessageItem): string {.inline.} =
+    self.timestamp
+
+  QtProperty[string] timestamp:
+    read = timestamp
+
+  proc timestampEdited*(self: DiscordMessageItem): string {.inline.} =
+    self.timestampEdited
+
+  QtProperty[string] timestampEdited:
+    read = timestampEdited
+
+  proc content*(self: DiscordMessageItem): string {.inline.} =
+    self.content
+
+  QtProperty[string] content:
+    read = content
+
+  proc author*(self: DiscordMessageItem): DiscordMessageAuthor {.inline.} =
+    self.author

--- a/src/app/modules/shared_models/message_model.nim
+++ b/src/app/modules/shared_models/message_model.nim
@@ -41,6 +41,7 @@ type
     MentionedUsersPks
     SenderTrustStatus
     SenderEnsVerified
+    MessageAttachments
 
 QtObject:
   type
@@ -116,7 +117,8 @@ QtObject:
       ModelRole.TransactionParameters.int: "transactionParameters",
       ModelRole.MentionedUsersPks.int: "mentionedUsersPks",
       ModelRole.SenderTrustStatus.int: "senderTrustStatus",
-      ModelRole.SenderEnsVerified.int: "senderEnsVerified"
+      ModelRole.SenderEnsVerified.int: "senderEnsVerified",
+      ModelRole.MessageAttachments.int: "messageAttachments"
     }.toTable
 
   method data(self: Model, index: QModelIndex, role: int): QVariant =
@@ -211,6 +213,8 @@ QtObject:
       result = newQVariant(item.mentionedUsersPks.join(" "))
     of ModelRole.SenderEnsVerified:
       result = newQVariant(item.senderEnsVerified)
+    of ModelRole.MessageAttachments:
+      result = newQVariant(item.messageAttachments.join(" "))
 
   proc updateItemAtIndex(self: Model, index: int) =
     let ind = self.createIndex(index, 0, nil)

--- a/src/app_service/common/types.nim
+++ b/src/app_service/common/types.nim
@@ -14,6 +14,7 @@ type
     Community = 9
     Gap = 10
     Edit = 11
+    DiscordMessage = 12
 
 type
   StatusType* {.pure.} = enum

--- a/src/app_service/service/community/dto/community.nim
+++ b/src/app_service/service/community/dto/community.nim
@@ -96,6 +96,15 @@ type DiscordImportError* = object
   code*: int
   message*: string
 
+type DiscordImportTaskProgress* = object
+  `type`*: string
+  progress*: float
+  errors*: seq[DiscordImportError]
+  errorsCount*: int
+  warningsCount*: int
+  stopped*: bool
+  state*: string
+
 proc toCommunityAdminSettingsDto*(jsonObj: JsonNode): CommunityAdminSettingsDto =
   result = CommunityAdminSettingsDto()
   discard jsonObj.getProp("pinMessageAllMembersEnabled", result.pinMessageAllMembersEnabled)
@@ -117,6 +126,21 @@ proc toDiscordImportError*(jsonObj: JsonNode): DiscordImportError =
   result = DiscordImportError()
   discard jsonObj.getProp("code", result.code)
   discard jsonObj.getProp("message", result.message)
+
+proc toDiscordImportTaskProgress*(jsonObj: JsonNode): DiscordImportTaskProgress =
+  result = DiscordImportTaskProgress()
+  result.`type` = jsonObj{"type"}.getStr()
+  result.progress = jsonObj{"progress"}.getFloat()
+  result.stopped = jsonObj{"stopped"}.getBool()
+  result.errorsCount = jsonObj{"errorsCount"}.getInt()
+  result.warningsCount = jsonObj{"warningsCount"}.getInt()
+  result.state = jsonObj{"state"}.getStr()
+
+  var importErrorsObj: JsonNode
+  if(jsonObj.getProp("errors", importErrorsObj) and importErrorsObj.kind == JArray):
+    for error in importErrorsObj:
+      let importError = error.toDiscordImportError()
+      result.errors.add(importError)
 
 proc toCommunityDto*(jsonObj: JsonNode): CommunityDto =
   result = CommunityDto()

--- a/src/app_service/service/message/service.nim
+++ b/src/app_service/service/message/service.nim
@@ -296,11 +296,13 @@ QtObject:
       if (receivedData.emojiReactions.len > 0):
         self.handleEmojiReactionsUpdate(receivedData.emojiReactions)
 
-    self.events.on(SignalType.HistoryArchiveDownloaded.event) do(e: Args):
+    self.events.on(SignalType.DownloadingHistoryArchivesFinished.event) do(e: Args):
       var receivedData = HistoryArchivesSignal(e)
-      if  now().toTime().toUnix()-receivedData.begin <= WEEK_AS_MILLISECONDS:
-        # we don't need to reload the messages for archives older than 7 days
-        self.handleMessagesReload(receivedData.communityId)
+      self.handleMessagesReload(receivedData.communityId)
+
+    self.events.on(SignalType.DiscordCommunityImportFinished.event) do(e: Args):
+      var receivedData = DiscordCommunityImportFinishedSignal(e)
+      self.handleMessagesReload(receivedData.communityId)
 
   proc initialMessagesFetched(self: Service, chatId: string): bool =
     return self.msgCursor.hasKey(chatId)

--- a/src/backend/communities.nim
+++ b/src/backend/communities.nim
@@ -123,6 +123,45 @@ proc editCommunity*(
     "pinMessageAllMembersEnabled": pinMessageAllMembersEnabled
   }])
 
+proc requestImportDiscordCommunity*(
+    name: string,
+    description: string,
+    introMessage: string,
+    outroMessage: string,
+    access: int,
+    color: string,
+    tags: string,
+    imageUrl: string,
+    aX: int, aY: int, bX: int, bY: int,
+    historyArchiveSupportEnabled: bool,
+    pinMessageAllMembersEnabled: bool,
+    filesToImport: seq[string],
+    fromTimestamp: int
+    ): RpcResponse[JsonNode] {.raises: [Exception].} =
+  result = callPrivateRPC("requestImportDiscordCommunity".prefix, %*[{
+      # TODO this will need to be renamed membership (small m)
+      "Membership": access,
+      "name": name,
+      "description": description,
+      "introMessage": introMessage,
+      "outroMessage": outroMessage,
+      "ensOnly": false, # TODO ensOnly is no longer supported. Remove this when we remove it in status-go
+      "color": color,
+      "tags": parseJson(tags),
+      "image": imageUrl,
+      "imageAx": aX,
+      "imageAy": aY,
+      "imageBx": bX,
+      "imageBy": bY,
+      "historyArchiveSupportEnabled": historyArchiveSupportEnabled,
+      "pinMessageAllMembersEnabled": pinMessageAllMembersEnabled,
+      "from": fromTimestamp,
+      "filesToImport": filesToImport
+    }])
+
+proc requestCancelDiscordCommunityImport*(communityId: string): RpcResponse[JsonNode] {.raises: [Exception].} =
+  result = callPrivateRPC("requestCancelDiscordCommunityImport".prefix, %*[communityId])
+
 proc createCommunityChannel*(
     communityId: string,
     name: string,

--- a/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
@@ -284,6 +284,7 @@ Item {
             editModeOn: model.editMode
             isEdited: model.isEdited
             linkUrls: model.links
+            messageAttachments: model.messageAttachments
             transactionParams: model.transactionParameters
             hasMention: model.mentionedUsersPks.split(" ").includes(root.rootStore.userProfileInst.pubKey)
 

--- a/ui/app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml
+++ b/ui/app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml
@@ -29,6 +29,7 @@ StatusSectionLayout {
     property var importCommunitiesPopup: importCommunitiesPopupComponent
     property var createCommunitiesPopup: createCommunitiesPopupComponent
     property int contentPrefferedWidth: 100
+    property var discordImportProgressPopup: discordImportProgressDialog
 
     notificationCount: root.communitiesStore.unreadNotificationsCount
     onNotificationButtonClicked: Global.openActivityCenterPopup()
@@ -219,15 +220,27 @@ StatusSectionLayout {
                     }
                 }
                 CommunityBanner {
-                    text: qsTr("Import existing Discord community into Status")
+                    property bool importInProgress: root.communitiesStore.discordImportInProgress && !root.communitiesStore.discordImportCancelled
+                    text: importInProgress ?
+                        qsTr("'%1' import in progress...").arg(root.communitiesStore.discordImportCommunityName) : 
+                        qsTr("Import existing Discord community into Status")
                     buttonText: qsTr("Import existing")
                     icon.name: "download"
+                    buttonTooltipText: qsTr("Your current import must finished or be cancelled before a new import can be started.")
+                    buttonLoading: importInProgress
                     onButtonClicked: {
                         chooseCommunityCreationTypePopup.close()
                         Global.openPopup(createCommunitiesPopupComponent, {isDiscordImport: true})
                     }
                 }
             }
+        }
+    }
+
+    Component {
+        id: discordImportProgressDialog
+        DiscordImportProgressDialog {
+            store: root.communitiesStore
         }
     }
 }

--- a/ui/app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml
+++ b/ui/app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml
@@ -125,9 +125,16 @@ StatusStackModal {
                 }
                 IssuePill {
                     type: root.store.discordImportErrorsCount ? IssuePill.Type.Error : IssuePill.Type.Warning
-                    count: root.store.discordImportErrorsCount ? root.store.discordImportErrorsCount :
-                                                                 root.store.discordImportWarningsCount ? root.store.discordImportWarningsCount : 0
-                    visible: count
+                    count: {
+                      if (root.store.discordImportErrorsCount > 0) {
+                        return root.store.discordImportErrorsCount
+                      }
+                      if (root.store.discordImportWarningsCount > 0) {
+                        return root.store.discordImportWarningsCount
+                      }
+                      return 0
+                    }
+                    visible: !!count
                 }
                 Item { Layout.fillWidth: true }
                 StatusButton {
@@ -243,6 +250,20 @@ StatusStackModal {
 
             readonly property bool canGoNext: root.store.discordChannelsModel.hasSelectedItems
             readonly property var nextAction: function () {
+                d.requestImportDiscordCommunity()
+                // replace ourselves with the progress dialog, no way back
+                root.leftButtons[0].visible = false
+                root.backgroundColor = Theme.palette.baseColor4
+                root.replace(progressComponent)
+            }
+
+            Component {
+                id: progressComponent
+                DiscordImportProgressContents {
+                    width: root.availableWidth
+                    store: root.store
+                    onClose: root.close()
+                }
             }
 
             Item {
@@ -456,33 +477,45 @@ StatusStackModal {
     QtObject {
         id: d
 
+        function _getCommunityConfig() {
+            return {
+                name: StatusQUtils.Utils.filterXSS(nameInput.input.text),
+                description: StatusQUtils.Utils.filterXSS(descriptionTextInput.input.text),
+                introMessage: StatusQUtils.Utils.filterXSS(introMessageInput.input.text),
+                outroMessage: StatusQUtils.Utils.filterXSS(outroMessageInput.input.text),
+                color: colorPicker.color.toString().toUpperCase(),
+                tags: communityTagsPicker.selectedTags,
+                image: {
+                    src: logoPicker.source,
+                    AX: logoPicker.cropRect.x,
+                    AY: logoPicker.cropRect.y,
+                    BX: logoPicker.cropRect.x + logoPicker.cropRect.width,
+                    BY: logoPicker.cropRect.y + logoPicker.cropRect.height,
+                },
+                options: {
+                    historyArchiveSupportEnabled: options.archiveSupportEnabled,
+                    checkedMembership: options.requestToJoinEnabled ? Constants.communityChatOnRequestAccess : Constants.communityChatPublicAccess,
+                    pinMessagesAllowedForMembers: options.pinMessagesEnabled
+                },
+                bannerJsonStr: JSON.stringify({imagePath: String(bannerPicker.source).replace("file://", ""), cropRect: bannerPicker.cropRect})
+            }
+        }
+
         function createCommunity() {
-            const error = store.createCommunity({
-                    name: StatusQUtils.Utils.filterXSS(nameInput.input.text),
-                    description: StatusQUtils.Utils.filterXSS(descriptionTextInput.input.text),
-                    introMessage: StatusQUtils.Utils.filterXSS(introMessageInput.input.text),
-                    outroMessage: StatusQUtils.Utils.filterXSS(outroMessageInput.input.text),
-                    color: colorPicker.color.toString().toUpperCase(),
-                    tags: communityTagsPicker.selectedTags,
-                    image: {
-                        src: logoPicker.source,
-                        AX: logoPicker.cropRect.x,
-                        AY: logoPicker.cropRect.y,
-                        BX: logoPicker.cropRect.x + logoPicker.cropRect.width,
-                        BY: logoPicker.cropRect.y + logoPicker.cropRect.height,
-                    },
-                    options: {
-                        historyArchiveSupportEnabled: options.archiveSupportEnabled,
-                        checkedMembership: options.requestToJoinEnabled ? Constants.communityChatOnRequestAccess : Constants.communityChatPublicAccess,
-                        pinMessagesAllowedForMembers: options.pinMessagesEnabled
-                    },
-                    bannerJsonStr: JSON.stringify({imagePath: String(bannerPicker.source).replace("file://", ""), cropRect: bannerPicker.cropRect})
-            })
+            const error = root.store.createCommunity(_getCommunityConfig())
             if (error) {
                 errorDialog.text = error.error
                 errorDialog.open()
             }
             root.close()
+        }
+
+        function requestImportDiscordCommunity() {
+            const error = root.store.requestImportDiscordCommunity(_getCommunityConfig(), datePicker.selectedDate.valueOf()/1000)
+            if (error) {
+                errorDialog.text = error.error
+                errorDialog.open()
+            }
         }
     }
 

--- a/ui/app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml
+++ b/ui/app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml
@@ -1,0 +1,356 @@
+import QtQuick 2.14
+import QtQuick.Controls 2.14
+import QtQuick.Layouts 1.14
+
+import utils 1.0
+import shared.popups 1.0
+
+import StatusQ.Core 0.1
+import StatusQ.Core.Theme 0.1
+import StatusQ.Controls 0.1
+import StatusQ.Components 0.1
+import StatusQ.Popups.Dialog 0.1
+
+import SortFilterProxyModel 0.2
+
+import "../controls"
+
+StatusScrollView {
+    id: root
+
+    property var store
+
+    signal close()
+
+    implicitWidth: childrenRect.width
+    padding: 0
+
+    enum ImportStatus {
+        Unknown,
+        InProgress,
+        Stopped,
+        StoppedWithErrors,
+        CompletedWithWarnings,
+        CompletedSuccessfully
+    }
+
+    readonly property list<StatusBaseButton> rightButtons: [
+        StatusButton {
+            visible: d.status === DiscordImportProgressContents.ImportStatus.CompletedWithWarnings ||
+                     d.status === DiscordImportProgressContents.ImportStatus.StoppedWithErrors
+            type: StatusButton.Danger
+            font.weight: Font.Medium
+            text: qsTr("Delete community & restart import")
+            onClicked: {
+                // TODO display a confirmation and open CreateCommunityPopup again
+                root.close()
+            }
+        },
+        StatusButton {
+            visible: d.status === DiscordImportProgressContents.ImportStatus.InProgress
+            type: StatusButton.Danger
+            font.weight: Font.Medium
+            text: qsTr("Cancel import")
+            onClicked: {
+                Global.openPopup(cancelConfirmationPopupCmp)
+            }
+        },
+        StatusButton {
+            visible: d.status === DiscordImportProgressContents.ImportStatus.Stopped // TODO find out exactly when to display this button
+            type: StatusButton.Danger
+            font.weight: Font.Medium
+            text: qsTr("Restart import")
+            onClicked: {
+                // TODO open CreateCommunityPopup again
+                root.store.resetDiscordImport()
+                root.close()
+            }
+        },
+        StatusButton {
+            visible: d.status === DiscordImportProgressContents.ImportStatus.InProgress
+            font.weight: Font.Medium
+            text: qsTr("Hide window")
+            onClicked: root.close()
+        },
+        StatusButton {
+            visible: d.status === DiscordImportProgressContents.ImportStatus.CompletedSuccessfully ||
+                     d.status === DiscordImportProgressContents.ImportStatus.CompletedWithWarnings
+            font.weight: Font.Medium
+            text: qsTr("Visit your new community")
+            onClicked: {
+                root.close()
+                root.store.setActiveCommunity(root.store.discordImportCommunityId)
+            }
+        }
+    ]
+
+    QtObject {
+        id: d
+
+        readonly property var helperInfo: {
+            "import.communityCreation": {
+                icon: "network",
+                text: qsTr("Setting up your community")
+            },
+            "import.channelsCreation": {
+                icon: "channel",
+                text: qsTr("Importing channels")
+            },
+            "import.importMessages": {
+                icon: "receive",
+                text: qsTr("Importing messages")
+            },
+            "import.downloadAssets": {
+                icon: "image",
+                text: qsTr("Downloading assets")
+            },
+            "import.initializeCommunity": {
+                icon: "communities",
+                text: qsTr("Initializing community")
+            }
+        }
+
+        readonly property int importProgress: root.store.discordImportProgress // FIXME for now it is 0..100
+        readonly property bool importStopped: root.store.discordImportProgressStopped
+        readonly property bool hasErrors: root.store.discordImportErrorsCount
+        readonly property bool hasWarnings: root.store.discordImportWarningsCount
+
+        readonly property int status: {
+            if (importStopped) {
+                if (hasErrors)
+                    return DiscordImportProgressContents.ImportStatus.StoppedWithErrors
+                return DiscordImportProgressContents.ImportStatus.Stopped
+            }
+            if (importProgress >= 100) {
+                if (hasWarnings)
+                    return DiscordImportProgressContents.ImportStatus.CompletedWithWarnings
+                return DiscordImportProgressContents.ImportStatus.CompletedSuccessfully
+            }
+            if (importProgress > 0 && importProgress < 100)
+                return DiscordImportProgressContents.ImportStatus.InProgress
+            return DiscordImportProgressContents.ImportStatus.Unknown
+        }
+
+        function getSubtaskDescription(progress, stopped, state) {
+            if (progress >= 1.0)
+                return qsTr("✓ Complete")
+            if (progress > 0 && stopped)
+                return qsTr("Import stopped...")
+            if (importStopped)
+                return ""
+            if (progress <= 0.0)
+              return qsTr("Pending...")
+
+            return state == "import.taskState.saving" ?
+              qsTr("Saving... This can take a moment, almost done!") :
+              qsTr("Working...")
+        }
+    }
+
+    Component {
+        id: subtaskComponent
+        ColumnLayout {
+            id: subtaskDelegate
+            spacing: 40
+            width: parent.width
+
+            readonly property int errorsAndWarningsCount: model.errorsCount + model.warningsCount
+            readonly property string type: model.type
+            readonly property var errors: model.errors
+
+            RowLayout {
+                id: subtaskRow
+                spacing: 12
+                Layout.fillWidth: true
+                Layout.preferredHeight: 42
+
+                StatusRoundIcon {
+                    id: subtaskIcon
+                    Layout.alignment: Qt.AlignVCenter
+                    Layout.preferredWidth: 40
+                    Layout.preferredHeight: 40
+                    asset.name: d.helperInfo[model.type].icon
+                }
+                ColumnLayout {
+                    spacing: 4
+                    Layout.fillWidth: true
+                    Layout.fillHeight: true
+                    Layout.alignment: Qt.AlignVCenter
+                    StatusBaseText {
+                        font.pixelSize: 15
+                        text: d.helperInfo[model.type].text
+                    }
+                    StatusBaseText {
+                        font.pixelSize: 12
+                        color: {
+                            if (model.progress >= 1)
+                                return Theme.palette.successColor1
+                            if (model.progress > 0 && d.hasErrors)
+                                return Theme.palette.dangerColor1
+                            return Theme.palette.baseColor1
+                        }
+                        text: d.getSubtaskDescription(model.progress, model.stopped, model.state)
+                    }
+                }
+                Item { Layout.fillWidth: true }
+                StatusBaseText {
+                    Layout.alignment: Qt.AlignVCenter
+                    font.pixelSize: 13
+                    font.weight: Font.Medium
+                    visible: subtaskProgressBar.visible
+                    text: qsTr("%1%").arg(Math.round(model.progress*100))
+                }
+                StatusProgressBar {
+                    id: subtaskProgressBar
+                    Layout.alignment: Qt.AlignVCenter
+                    Layout.preferredWidth: 130
+                    Layout.preferredHeight: 10
+                    visible: value > 0 && value <= 1 && d.status !== DiscordImportProgressContents.ImportStatus.StoppedWithErrors
+                    fillColor: Theme.palette.primaryColor1
+                    backgroundColor: Theme.palette.directColor8
+                    value: model.progress
+                }
+            }
+            ColumnLayout {
+                Layout.fillWidth: true
+                Layout.leftMargin: subtaskIcon.width + subtaskRow.spacing
+                spacing: 12
+
+                Repeater {
+                    model: SortFilterProxyModel {
+                        sourceModel: subtaskDelegate.errors
+                        sorters: RoleSorter { roleName: "code"; sortOrder: Qt.DescendingOrder } // errors first
+                    }
+                    delegate: IssuePill {
+                        Layout.fillWidth: true
+                        horizontalPadding: 12
+                        verticalPadding: 8
+                        bgCornerRadius: 8
+                        visible: text
+                        type: model.code === Constants.DiscordImportErrorCode.Error ? IssuePill.Type.Error : IssuePill.Type.Warning
+                        text: model.message
+                    }
+                }
+
+                Loader {
+                    active: subtaskDelegate.errorsAndWarningsCount > 3
+                    Layout.fillWidth: true
+                    sourceComponent: IssuePill {
+                        width: parent.width
+                        horizontalPadding: 12
+                        verticalPadding: 8
+                        bgCornerRadius: 8
+                        visible: text
+                        type: IssuePill.Type.Warning
+                        text: qsTr("%1 more issue(s) downloading assets").arg(errorsAndWarningsCount - 3)
+                    }
+                }
+            }
+            StatusDialogDivider {
+                Layout.fillWidth: true
+                Layout.leftMargin: -24 // compensate for Control.horizontalPadding -> full width
+                Layout.rightMargin: -24 // compensate for Control.horizontalPadding -> full width
+                visible: !parent.Positioner.isLastItem
+            }
+        }
+    }
+
+    ColumnLayout {
+        width: parent.width
+        spacing: 20
+
+        RowLayout {
+            Layout.fillWidth: true
+            spacing: 12
+
+            Image {
+                Layout.preferredWidth: 36
+                Layout.preferredHeight: 36
+                sourceSize: Qt.size(36, 36)
+                source: Style.svg("contact") // TODO community icon
+            }
+            StatusBaseText {
+                Layout.fillWidth: true
+                font.pixelSize: 15
+                text: {
+                    switch (d.status) {
+                    case DiscordImportProgressContents.ImportStatus.InProgress:
+                        return qsTr("Importing ‘%1’ from Discord...").arg(root.store.discordImportCommunityName)
+                    case DiscordImportProgressContents.ImportStatus.Stopped:
+                        return qsTr("Importing ‘%1’ from Discord stopped...").arg(root.store.discordImportCommunityName)
+                    case DiscordImportProgressContents.ImportStatus.StoppedWithErrors:
+                        return qsTr("Importing ‘%1’ stopped due to a critical issue...").arg(root.store.discordImportCommunityName)
+                    case DiscordImportProgressContents.ImportStatus.CompletedWithWarnings:
+                        return qsTr("‘%1’ was imported with %n issue(s).", "", root.store.discordImportWarningsCount).arg(root.store.discordImportCommunityName)
+                    case DiscordImportProgressContents.ImportStatus.CompletedSuccessfully:
+                        return qsTr("‘%1’ was successfully imported from Discord.").arg(root.store.discordImportCommunityName)
+                    default:
+                        return qsTr("Your Discord community import is in progress...")
+                    }
+                }
+            }
+            Item { Layout.fillWidth: true }
+            IssuePill {
+                type: d.hasErrors ? IssuePill.Type.Error : IssuePill.Type.Warning
+                count: d.hasErrors ? root.store.discordImportErrorsCount :
+                                     d.hasWarnings ? root.store.discordImportWarningsCount : 0
+                visible: count
+            }
+        }
+
+        Control {
+            Layout.fillWidth: true
+            horizontalPadding: 24
+            verticalPadding: 40
+            background: Rectangle {
+                radius: 16
+                color: Theme.palette.indirectColor1
+                border.width: 1
+                border.color: Theme.palette.directColor8
+            }
+            contentItem: Column {
+                spacing: 40
+
+                Repeater {
+                    model: root.store.discordImportTasks
+                    delegate: subtaskComponent
+                }
+            }
+        }
+
+        StatusBaseText {
+            Layout.fillWidth: true
+            Layout.alignment: Qt.AlignHCenter
+            horizontalAlignment: Qt.AlignHCenter
+            wrapMode: Text.WordWrap
+            font.pixelSize: 13
+            text: d.status === DiscordImportProgressContents.ImportStatus.InProgress ?
+                      qsTr("This process can take a while. Feel free to hide this window and use Status normally in the meantime. We’ll notify you when the Community is ready for you.") :
+                      qsTr("If there were any issues with your import you can upload new JSON files via the community page at any time.")
+        }
+    }
+
+    Component {
+        id: cancelConfirmationPopupCmp
+        ConfirmationDialog {
+            id: cancelConfirmationPopup
+            header.title: qsTr("Are you sure you want to cancel the import?")
+            confirmationText: qsTr("Your new Status community will be deleted and all information entered will be lost.")
+            showCancelButton: true
+            cancelBtnType: "default"
+            confirmButtonLabel: qsTr("Delete community")
+            cancelButtonLabel: qsTr("Continue importing")
+            onConfirmButtonClicked: {
+                root.store.requestCancelDiscordCommunityImport(root.store.discordImportCommunityId)
+                cancelConfirmationPopup.close()
+                root.close()
+            }
+            onCancelButtonClicked: {
+                cancelConfirmationPopup.close()
+            }
+            onClosed: {
+                destroy()
+            }
+        }
+    }
+}

--- a/ui/app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressDialog.qml
+++ b/ui/app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressDialog.qml
@@ -1,0 +1,51 @@
+import QtQuick 2.14
+import QtQuick.Controls 2.14
+import QtQuick.Layouts 1.14
+import QtQml.Models 2.14
+
+import utils 1.0
+
+import StatusQ.Core 0.1
+import StatusQ.Core.Theme 0.1
+import StatusQ.Controls 0.1
+import StatusQ.Components 0.1
+import StatusQ.Popups.Dialog 0.1
+
+import "../controls"
+
+StatusDialog {
+    id: root
+
+    property var store
+
+    title: qsTr("Import a community from Discord into Status")
+
+    horizontalPadding: 16
+    verticalPadding: 20
+    width: 640
+
+    onClosed: destroy()
+
+    Component.onCompleted: {
+        const buttons = contents.rightButtons
+        for (let i = 0; i < buttons.length; i++) {
+            footer.rightButtons.append(buttons[i])
+        }
+    }
+
+    footer: StatusDialogFooter {
+        id: footer
+        rightButtons: ObjectModel {}
+    }
+
+    background: StatusDialogBackground {
+        color: Theme.palette.baseColor4
+    }
+
+    contentItem: DiscordImportProgressContents {
+        id: contents
+        width: root.availableWidth
+        store: root.store
+        onClose: root.close()
+    }
+}

--- a/ui/app/AppLayouts/CommunitiesPortal/stores/CommunitiesStore.qml
+++ b/ui/app/AppLayouts/CommunitiesPortal/stores/CommunitiesStore.qml
@@ -17,6 +17,13 @@ QtObject {
     property bool discordDataExtractionInProgress: root.communitiesModuleInst.discordDataExtractionInProgress
     property int discordImportErrorsCount: root.communitiesModuleInst.discordImportErrorsCount
     property int discordImportWarningsCount: root.communitiesModuleInst.discordImportWarningsCount
+    property int discordImportProgress: root.communitiesModuleInst.discordImportProgress
+    property bool discordImportInProgress: root.communitiesModuleInst.discordImportInProgress
+    property bool discordImportCancelled: root.communitiesModuleInst.discordImportCancelled
+    property bool discordImportProgressStopped: root.communitiesModuleInst.discordImportProgressStopped
+    property string discordImportCommunityId: root.communitiesModuleInst.discordImportCommunityId
+    property string discordImportCommunityName: root.communitiesModuleInst.discordImportCommunityName
+    property var discordImportTasks: root.communitiesModuleInst.discordImportTasks
     property string locale: localAppSettings.language
     property var advancedModule: profileSectionModule.advancedModule
     property bool isCommunityHistoryArchiveSupportEnabled: advancedModule? advancedModule.isCommunityHistoryArchiveSupportEnabled : false
@@ -105,5 +112,40 @@ QtObject {
 
     function toggleDiscordChannel(id, selected) {
         root.communitiesModuleInst.toggleDiscordChannel(id, selected)
+      }
+
+    function requestCancelDiscordCommunityImport(id) {
+        root.communitiesModuleInst.requestCancelDiscordCommunityImport(id)
+    }
+
+    function resetDiscordImport() {
+        root.communitiesModuleInst.resetDiscordImport(false)
+    }
+
+    function requestImportDiscordCommunity(args = {
+                                name: "",
+                                description: "",
+                                introMessage: "",
+                                outroMessage: "",
+                                color: "",
+                                tags: "",
+                                image: {
+                                    src: "",
+                                    AX: 0,
+                                    AY: 0,
+                                    BX: 0,
+                                    BY: 0,
+                                },
+                                options: {
+                                    historyArchiveSupportEnabled: false,
+                                    checkedMembership: false,
+                                    pinMessagesAllowedForMembers: false
+                                }
+                             }, from = 0) {
+        return communitiesModuleInst.requestImportDiscordCommunity(
+                    args.name, args.description, args.introMessage, args.outroMessage, args.options.checkedMembership,
+                    args.color, args.tags,
+                    args.image.src, args.image.AX, args.image.AY, args.image.BX, args.image.BY,
+                    args.options.historyArchiveSupportEnabled, args.options.pinMessagesAllowedForMembers, from);
     }
 }

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -498,6 +498,57 @@ Item {
                     }
                 }
 
+
+                ModuleWarning {
+                    Layout.fillWidth: true
+                    readonly property int progress: communitiesPortalLayoutContainer.communitiesStore.discordImportProgress
+                    readonly property bool inProgress: progress > 0 && progress < 100
+                    readonly property bool finished: progress >= 100
+                    readonly property bool cancelled: communitiesPortalLayoutContainer.communitiesStore.discordImportCancelled
+                    readonly property bool stopped: communitiesPortalLayoutContainer.communitiesStore.discordImportProgressStopped
+                    readonly property int errors: communitiesPortalLayoutContainer.communitiesStore.discordImportErrorsCount
+                    readonly property int warnings: communitiesPortalLayoutContainer.communitiesStore.discordImportWarningsCount
+                    readonly property string communityId: communitiesPortalLayoutContainer.communitiesStore.discordImportCommunityId
+                    readonly property string communityName: communitiesPortalLayoutContainer.communitiesStore.discordImportCommunityName
+
+                    active: !cancelled && (inProgress || finished || stopped)
+                    type: errors ? ModuleWarning.Type.Danger : ModuleWarning.Type.Success
+                    text: {
+                        if (finished || stopped) {
+                            if (errors)
+                                return qsTr("The import of ‘%1’ from Discord to Status was stopped: <a href='#'>Critical issues found</a>").arg(communityName)
+
+                            let result = qsTr("‘%1’ was successfully imported from Discord to Status").arg(communityName) + "  <a href='#'>"
+                            if (warnings)
+                                result += qsTr("Details (%1)").arg(qsTr("%n issue(s)", "", warnings))
+                            else
+                                result += qsTr("Details")
+                            result += "</a>"
+                            return result
+                        }
+                        if (inProgress) {
+                            let result = qsTr("Importing ‘%1’ from Discord to Status").arg(communityName) + "  <a href='#'>"
+                            if (warnings)
+                                result += qsTr("Check progress (%1)").arg(qsTr("%n issue(s)", "", warnings))
+                            else
+                                result += qsTr("Check progress")
+                            result += "</a>"
+                            return result
+                        }
+                    }
+                    onLinkActivated: Global.openPopup(communitiesPortalLayoutContainer.discordImportProgressPopup)
+                    progressValue: progress
+                    closeBtnVisible: finished || stopped
+                    buttonText: finished && !errors ? qsTr("Visit your Community") : ""
+                    onClicked: function() {
+                        communitiesPortalLayoutContainer.communitiesStore.setActiveCommunity(communityId)
+                    }
+                    onCloseClicked: {
+                        hide();
+                    }
+                }
+
+
                 Component {
                     id: connectedBannerComponent
 

--- a/ui/imports/shared/controls/chat/UserImage.qml
+++ b/ui/imports/shared/controls/chat/UserImage.qml
@@ -18,6 +18,7 @@ Loader {
     property string image
     property bool showRing: true
     property bool interactive: true
+    property bool disabled: false
 
     property int colorId: Utils.colorIdForPubkey(pubkey)
     property var colorHash: Utils.getColorHashAsJson(pubkey)
@@ -44,10 +45,12 @@ Loader {
             active: root.interactive
 
             sourceComponent: MouseArea {
-                cursorShape: Qt.PointingHandCursor
-                hoverEnabled: true
+                cursorShape: hoverEnabled ? Qt.PointingHandCursor : Qt.ArrowCursor
+                hoverEnabled: !root.disabled
                 onClicked: {
-                    root.clicked()
+                    if (!root.disabled) {
+                        root.clicked()
+                    }
                 }
             }
         }

--- a/ui/imports/shared/controls/chat/UsernameLabel.qml
+++ b/ui/imports/shared/controls/chat/UsernameLabel.qml
@@ -15,6 +15,7 @@ Item {
     property string displayName
     property string localName
     property bool amISender
+    property bool disabled
 
     signal clickMessage(bool isProfileClick)
 
@@ -24,15 +25,15 @@ Item {
         color: text.startsWith("@") || root.amISender || localName !== "" ? Style.current.blue : Style.current.secondaryText
         font.weight: Font.Medium
         font.pixelSize: Style.current.secondaryTextFontSize
-        font.underline: root.isHovered
+        font.underline: root.isHovered && !root.disabled
         readOnly: true
         wrapMode: Text.WordWrap
         selectByMouse: true
         MouseArea {
-            cursorShape: Qt.PointingHandCursor
+            cursorShape: hoverEnabled ? Qt.PointingHandCursor : Qt.ArrowCursor
             acceptedButtons: Qt.LeftButton | Qt.RightButton
             anchors.fill: parent
-            hoverEnabled: true
+            hoverEnabled: !root.disabled
             onEntered: {
                 root.isHovered = true
             }
@@ -40,7 +41,9 @@ Item {
                 root.isHovered = false
             }
             onClicked: {
-                root.clickMessage(true);
+                if (!root.disabled) {
+                    root.clickMessage(true);
+                }
             }
         }
     }

--- a/ui/imports/shared/panels/CommunityBanner.qml
+++ b/ui/imports/shared/panels/CommunityBanner.qml
@@ -18,6 +18,8 @@ Rectangle {
     property alias text: bannerText.text
     property alias buttonText: bannerButton.text
     property alias icon: bannerIcon.asset
+    property string buttonTooltipText: ""
+    property bool buttonLoading: false
 
     implicitWidth: 272
     implicitHeight: 168
@@ -74,7 +76,17 @@ Rectangle {
         anchors.bottom: parent.bottom
         anchors.bottomMargin: 16
         font.weight: Font.Medium
-        onClicked: root.buttonClicked()
+        onClicked: {
+            if (!root.buttonLoading) {
+                root.buttonClicked()
+            }
+        }
+        loading: root.buttonLoading
+
+        StatusQControls.StatusToolTip {
+            text: root.buttonTooltipText
+            visible: !!root.buttonTooltipText && bannerButton.loading && bannerButton.hovered
+        }
     }
 }
 

--- a/ui/imports/shared/panels/ModuleWarning.qml
+++ b/ui/imports/shared/panels/ModuleWarning.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.13
-import QtQuick.Controls 2.13
+import QtQuick 2.14
+import QtQuick.Controls 2.14
 import QtQuick.Layouts 1.13
 import QtGraphicalEffects 1.13
 
@@ -7,8 +7,9 @@ import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
 
 import utils 1.0
-import "../"
-import "./"
+
+import StatusQ.Core 0.1
+import StatusQ.Core.Theme 0.1
 
 Item {
     id: root
@@ -20,8 +21,10 @@ Item {
 
     property bool active: false
     property int type: ModuleWarning.Danger
+    property int progressValue: -1 // 0..100, -1 not visible
     property string text: ""
     property alias buttonText: button.text
+    property alias closeBtnVisible: closeImg.visible
 
     signal clicked()
     signal closeClicked()
@@ -48,6 +51,8 @@ Item {
     function close() {
         closeButtonMouseArea.clicked(null)
     }
+
+    signal linkActivated(string link)
 
     implicitHeight: root.active ? content.implicitHeight : 0
     visible: implicitHeight > 0
@@ -123,14 +128,24 @@ Item {
             id: layout
 
             spacing: 12
-            anchors.horizontalCenter: parent.horizontalCenter
-            anchors.verticalCenter: parent.verticalCenter
+            anchors.centerIn: parent
 
             StatusBaseText {
                 text: root.text
-                Layout.alignment: Qt.AlignVCenter
                 font.pixelSize: 13
+                font.weight: Font.Medium
+                anchors.verticalCenter: parent.verticalCenter
                 color: Theme.palette.indirectColor1
+                linkColor: color
+                onLinkActivated: root.linkActivated(link)
+                HoverHandler {
+                    id: handler1
+                }
+                MouseArea {
+                    anchors.fill: parent
+                    acceptedButtons: Qt.NoButton
+                    cursorShape: handler1.hovered && parent.hoveredLink ? Qt.PointingHandCursor : Qt.ArrowCursor
+                }
             }
 
             Button {
@@ -140,9 +155,9 @@ Item {
                 onClicked: {
                     root.clicked()
                 }
-                contentItem: Text {
+                contentItem: StatusBaseText {
                     text: button.text
-                    font.pixelSize: 12
+                    font.pixelSize: 13
                     font.weight: Font.Medium
                     font.family: Style.current.baseFont.name
                     horizontalAlignment: Text.AlignHCenter
@@ -160,6 +175,42 @@ Item {
                     acceptedButtons: Qt.NoButton
                     cursorShape: Qt.PointingHandCursor
                 }
+            }
+        }
+
+        StatusBaseText {
+            anchors.verticalCenter: parent.verticalCenter
+            anchors.right: progressBar.left
+            anchors.rightMargin: Style.current.halfPadding
+            text: qsTr("%1%").arg(progressBar.value)
+            visible: progressBar.visible
+            font.pixelSize: 12
+            verticalAlignment: Text.AlignVCenter
+            color: Theme.palette.white
+        }
+
+        ProgressBar {
+            id: progressBar
+            anchors.verticalCenter: parent.verticalCenter
+            anchors.right: closeImg.left
+            anchors.rightMargin: Style.current.bigPadding
+            from: 0
+            to: 100
+            visible: root.progressValue > -1
+            value: root.progressValue
+            background: Rectangle {
+                implicitWidth: 64
+                implicitHeight: 8
+                radius: 8
+                color: "transparent"
+                border.width: 1
+                border.color: Theme.palette.white
+            }
+            contentItem: Rectangle {
+                width: progressBar.width*progressBar.position
+                implicitHeight: 8
+                radius: 8
+                color: Theme.palette.white
             }
         }
 
@@ -185,5 +236,4 @@ Item {
             }
         }
     }
-
 }

--- a/ui/imports/shared/popups/ConfirmationDialog.qml
+++ b/ui/imports/shared/popups/ConfirmationDialog.qml
@@ -18,6 +18,7 @@ StatusModal {
     property var executeCancel
     property string confirmButtonObjectName: ""
     property string btnType: "warn"
+    property string cancelBtnType: "warn"
     property string confirmButtonLabel: qsTr("Confirm")
     property string rejectButtonLabel: qsTr("Reject")
     property string cancelButtonLabel: qsTr("Cancel")
@@ -81,6 +82,14 @@ StatusModal {
             id: cancelButton
             visible: showCancelButton
             text: confirmationDialog.cancelButtonLabel
+            type: {
+                switch (confirmationDialog.cancelBtnType) {
+                    case "warn":
+                        return StatusBaseButton.Type.Danger
+                    default:
+                        return StatusBaseButton.Type.Normal
+                }
+            }
             onClicked: {
                 if (executeCancel && typeof executeCancel === "function") {
                     executeCancel()
@@ -106,7 +115,7 @@ StatusModal {
                     case "warn":
                         return StatusBaseButton.Type.Danger
                     default:
-                        return StatusBaseButton.Type.Primary
+                        return StatusBaseButton.Type.Normal
                 }
             }
             text: confirmationDialog.confirmButtonLabel

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -232,6 +232,7 @@ QtObject {
         readonly property int communityInviteType: 9
         readonly property int gapType: 10
         readonly property int editType: 11
+        readonly property int discordMessageType: 12
     }
 
     readonly property QtObject profilePicturesVisibility: QtObject {


### PR DESCRIPTION
This adds the UI plus all necessary models and signal handling to render
discord import progress in the desktop application.

It also introduces message handling for discord chat message types.

**Requires https://github.com/status-im/status-go/pull/2826 to function**

Co-authored with @caybro

