### PR TITLE
test(chat): Emoji autoreplace

### DIFF
--- a/test/ui-test/testSuites/suite_status/shared/steps/chatSteps.py
+++ b/test/ui-test/testSuites/suite_status/shared/steps/chatSteps.py
@@ -60,6 +60,10 @@ def step(context):
 @Then("the user selects emoji in the suggestion list")
 def step(contenxt):
     _statusChat.select_the_emoji_in_suggestion_list()
+    
+@Then("the user is able to send chat message \"|any|\"")
+def step(context, message):
+     _statusChat.send_message(message)
 
 @Then("the user is able to send a random chat message")
 def step(context):
@@ -135,7 +139,7 @@ def step(context, emoji_short_name, message):
 
 @Then("the emoji |any| is displayed in the last message")
 def step(context, emoji):
-    _statusChat.verify_last_message_sent(emoji)
+     _statusChat.verify_last_message_sent(emoji)
 
 @Then("the message |any| is displayed in the last message")
 def step(context, message):

--- a/test/ui-test/testSuites/suite_status/tst_ChatFlow/test.feature
+++ b/test/ui-test/testSuites/suite_status/tst_ChatFlow/test.feature
@@ -132,3 +132,8 @@ Feature: Status Desktop Chat
           | second-chat |
           | third-chat  |
           | first-chat  |
+          
+     Scenario: User can type message with emoji autoreplace
+         When user joins chat room automation-test
+         Then the user is able to send chat message "Hello :)"
+         Then the message Hello 🙂 is displayed in the last message


### PR DESCRIPTION
Closes: #7019

The original `send message` will be failed if `:)` replaced by 🙂. I add method to send a message without verification

### What does the PR do

Add test for emoji auto replacing 

### Affected areas

UI tests
