### PR TITLE
fix(toast-notifications): Fix notifcations listview sizes

### DIFF
--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -976,15 +976,16 @@ Item {
 
     StatusListView {
         id: toastArea
-        anchors.top: parent.top
-        anchors.topMargin: 60
         anchors.right: parent.right
         anchors.rightMargin: 8
         anchors.bottom: parent.bottom
         anchors.bottomMargin: 60
+        width: 343
+        height: Math.min(parent.height - 120, toastArea.contentHeight)
         spacing: 8
         verticalLayoutDirection: ListView.BottomToTop
         model: appMain.rootStore.mainModuleInst.ephemeralNotificationModel
+
         delegate: StatusToastMessage {
             primaryText: model.title
             secondaryText: model.subTitle
@@ -1000,6 +1001,7 @@ Item {
             onLinkActivated: {
                 Qt.openUrlExternally(link);
             }
+
             onClose: {
                 appMain.rootStore.mainModuleInst.removeEphemeralNotification(model.id)
             }


### PR DESCRIPTION
Closes: #6767

### What does the PR do

In general, `toastArea` (which is `StatusListView`) missed `width` and also I it use `anchors` to parent - it block mouse clicks under toast notifications area.

### Affected areas

AppMain

### Screenshot of functionality (including design for comparison)

- [ ] I've checked the design and this PR matches it

