### PR TITLE
fix(@desktop/onboarding): Hide current account from accounts list

### DIFF
--- a/ui/app/AppLayouts/Onboarding/panels/AccountMenuItemPanel.qml
+++ b/ui/app/AppLayouts/Onboarding/panels/AccountMenuItemPanel.qml
@@ -10,7 +10,7 @@ import StatusQ.Popups 0.1
 import shared.controls.chat 1.0
 import utils 1.0
 
-MenuItem {
+Item {
     id: root
 
     property string label: ""
@@ -25,12 +25,17 @@ MenuItem {
 
     width: parent.width
     height: 64
-    background: Rectangle {
-        color: root.hovered ? Theme.palette.statusSelect.menuItemHoverBackgroundColor : Theme.palette.statusSelect.menuItemBackgroundColor
+    Rectangle {
+        anchors.fill: root
+        color: sensor.containsMouse ? Theme.palette.statusSelect.menuItemHoverBackgroundColor : Theme.palette.statusSelect.menuItemBackgroundColor
     }
+
     MouseArea {
+        id: sensor
         cursorShape: Qt.PointingHandCursor
         anchors.fill: root
+        hoverEnabled: true
+
         onClicked: {
             root.clicked()
         }

--- a/ui/app/AppLayouts/Onboarding/views/LoginView.qml
+++ b/ui/app/AppLayouts/Onboarding/views/LoginView.qml
@@ -11,6 +11,8 @@ import StatusQ.Controls 0.1
 import StatusQ.Controls.Validators 0.1
 import StatusQ.Popups 0.1
 
+import SortFilterProxyModel 0.2
+
 import shared.panels 1.0
 import shared.popups 1.0
 import shared.status 1.0
@@ -263,37 +265,53 @@ Item {
                 closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutsideParent
                 width: parent.width + Style.current.bigPadding
                 dim: false
-                Repeater {
-                    id: accounts
-                    model: root.startupStore.startupModuleInst.loginAccountsModel
-                    delegate: AccountMenuItemPanel {
-                        label: model.username
-                        image: model.thumbnailImage
-                        colorId: model.colorId
-                        colorHash: model.colorHash
-                        keycardCreatedAccount: model.keycardCreatedAccount
-                        onClicked: {
-                            root.startupStore.setSelectedLoginAccountByIndex(index)
-                            d.resetLogin()
-                            accountsPopup.close()
+
+                SortFilterProxyModel {
+                    id: proxyModel
+                    sourceModel: root.startupStore.startupModuleInst.loginAccountsModel
+                    filters: ValueFilter {
+                        roleName: "keyUid"
+                        value: root.startupStore.selectedLoginAccount.keyUid
+                        inverted: true
+                    }
+                }
+
+                Column {
+                    width: parent.width
+
+                    Repeater {
+                        model: proxyModel
+
+                        delegate: AccountMenuItemPanel {
+                            label: model.username
+                            image: model.thumbnailImage
+                            colorId: model.colorId
+                            colorHash: model.colorHash
+                            keycardCreatedAccount: model.keycardCreatedAccount
+                            onClicked: {
+                                d.resetLogin()
+                                accountsPopup.close()
+                                const realIndex = proxyModel.mapToSource(index)
+                                root.startupStore.setSelectedLoginAccountByIndex(realIndex)
+                            }
                         }
                     }
-                }
 
-                AccountMenuItemPanel {
-                    label: qsTr("Add new user")
-                    onClicked: {
-                        accountsPopup.close()
-                        root.startupStore.doSecondaryAction()
+                    AccountMenuItemPanel {
+                        label: qsTr("Add new user")
+                        onClicked: {
+                            accountsPopup.close()
+                            root.startupStore.doSecondaryAction()
+                        }
                     }
-                }
 
-                AccountMenuItemPanel {
-                    label: qsTr("Add existing Status user")
-                    iconSettings.name: "wallet"
-                    onClicked: {
-                        accountsPopup.close()
-                        root.startupStore.doTertiaryAction()
+                    AccountMenuItemPanel {
+                        label: qsTr("Add existing Status user")
+                        iconSettings.name: "wallet"
+                        onClicked: {
+                            accountsPopup.close()
+                            root.startupStore.doTertiaryAction()
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Fix #7045

### What does the PR do

Hides chosen account from the accounts list

### Affected areas

Onboarding

### Screenshot of functionality (including design for comparison)

![image](https://user-images.githubusercontent.com/61889657/185962059-59351f7e-4cbc-48bd-a7fc-971c3e3df6cd.png)
