### PR TITLE
fix(@desktop/wallet): Assign an emoji to the default wallet account during onboarding

### DIFF
--- a/src/app/modules/startup/controller.nim
+++ b/src/app/modules/startup/controller.nim
@@ -140,6 +140,9 @@ proc getDisplayName*(self: Controller): string =
 proc setPassword*(self: Controller, value: string) =
   self.tmpPassword = value
 
+proc setDefaultWalletEmoji*(self: Controller, emoji: string) =
+  self.accountsService.setDefaultWalletEmoji(emoji)
+
 proc getPassword*(self: Controller): string =
   return self.tmpPassword
 
@@ -202,6 +205,7 @@ proc cleanTmpData*(self: Controller) =
   self.tmpKeychainErrorOccurred = true
   self.setDisplayName("")
   self.setPassword("")
+  self.setDefaultWalletEmoji("")
   self.setPin("")
   self.setPinMatch(false)
   self.setPuk("")

--- a/src/app/modules/startup/io_interface.nim
+++ b/src/app/modules/startup/io_interface.nim
@@ -61,6 +61,9 @@ method getDisplayName*(self: AccessInterface): string {.base.} =
 method setPassword*(self: AccessInterface, value: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method setDefaultWalletEmoji*(self: AccessInterface, emoji: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method getPassword*(self: AccessInterface): string {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/startup/module.nim
+++ b/src/app/modules/startup/module.nim
@@ -189,6 +189,9 @@ method getDisplayName*[T](self: Module[T]): string =
 method setPassword*[T](self: Module[T], value: string) =
   self.controller.setPassword(value)
 
+method setDefaultWalletEmoji*[T](self: Module[T], emoji: string) =
+  self.controller.setDefaultWalletEmoji(emoji)
+
 method getPassword*[T](self: Module[T]): string =
   return self.controller.getPassword()
 

--- a/src/app/modules/startup/view.nim
+++ b/src/app/modules/startup/view.nim
@@ -154,6 +154,9 @@ QtObject:
   proc setPassword*(self: View, value: string) {.slot.} =
     self.delegate.setPassword(value)
 
+  proc setDefaultWalletEmoji*(self: View, emoji: string) {.slot.} =
+    self.delegate.setDefaultWalletEmoji(emoji)
+
   proc getPassword*(self: View): string {.slot.} =
     return self.delegate.getPassword()
 

--- a/src/app_service/service/accounts/service.nim
+++ b/src/app_service/service/accounts/service.nim
@@ -33,6 +33,7 @@ type
     importedAccount: GeneratedAccountDto
     isFirstTimeAccountLogin: bool
     keyStoreDir: string
+    defaultWalletEmoji: string
 
 proc delete*(self: Service) =
   discard
@@ -42,6 +43,7 @@ proc newService*(fleetConfiguration: FleetConfiguration): Service =
   result.fleetConfiguration = fleetConfiguration
   result.isFirstTimeAccountLogin = false
   result.keyStoreDir = main_constants.ROOTKEYSTOREDIR
+  result.defaultWalletEmoji = ""
 
 proc getLoggedInAccount*(self: Service): AccountDto =
   return self.loggedInAccount
@@ -55,6 +57,9 @@ proc isFirstTimeAccountLogin*(self: Service): bool =
 proc setKeyStoreDir(self: Service, key: string) = 
   self.keyStoreDir = joinPath(main_constants.ROOTKEYSTOREDIR, key) & main_constants.sep
   discard status_general.initKeystore(self.keyStoreDir)
+
+proc setDefaultWalletEmoji*(self: Service, emoji: string) =
+  self.defaultWalletEmoji = emoji
 
 proc init*(self: Service) =
   try:
@@ -190,7 +195,8 @@ proc prepareSubaccountJsonObject(self: Service, account: GeneratedAccountDto, di
       "wallet": true,
       "path": PATH_DEFAULT_WALLET,
       "name": "Status account",
-      "derived-from": account.address
+      "derived-from": account.address,
+      "emoji": self.defaultWalletEmoji
     },
     {
       "public-key": account.derivedAccounts.whisper.publicKey,
@@ -360,6 +366,7 @@ proc setupAccountKeycard*(self: Service, keycardData: KeycardEvent) =
         "path": PATH_DEFAULT_WALLET,
         "name": "Status account",
         "derived-from": keycardData.masterKey.address,
+        "emoji": self.defaultWalletEmoji,
       },
       {
         "public-key": keycardData.whisperKey.publicKey,

--- a/ui/app/AppLayouts/Onboarding/stores/StartupStore.qml
+++ b/ui/app/AppLayouts/Onboarding/stores/StartupStore.qml
@@ -51,6 +51,10 @@ QtObject {
         root.startupModuleInst.setPassword(value)
     }
 
+    function setDefaultWalletEmoji(emoji) {
+        root.startupModuleInst.setDefaultWalletEmoji(emoji)
+    }
+
     function getPassword() {
         return root.startupModuleInst.getPassword()
     }

--- a/ui/app/AppLayouts/Onboarding/views/CreatePasswordView.qml
+++ b/ui/app/AppLayouts/Onboarding/views/CreatePasswordView.qml
@@ -3,6 +3,7 @@ import QtQuick.Controls 2.13
 import QtQuick.Layouts 1.12
 import StatusQ.Controls 0.1
 import StatusQ.Core.Theme 0.1
+import StatusQ.Core.Utils 0.1 as StatusQUtils
 import utils 1.0
 import shared.views 1.0
 
@@ -27,6 +28,7 @@ Item {
         readonly property int zFront: 100
 
         function submit() {
+            root.startupStore.setDefaultWalletEmoji(StatusQUtils.Emoji.getRandomEmoji(StatusQUtils.Emoji.size.verySmall))
             root.startupStore.setPassword(view.newPswText)
             root.startupStore.doPrimaryAction()
         }


### PR DESCRIPTION
fix(@desktop/wallet): Assign an emoji to the default wallet account during onboarding

fixes #6694

### What does the PR do

Sets a random emoji for the default wallet during onboarding. This is done by setting it during the create password step from the UI.

### Affected areas

Wallet

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

https://user-images.githubusercontent.com/60327365/186653142-0640eadb-3831-4465-86c4-c2f32e34f2f7.mov


