### PR TITLE
fix(@desktop/chat): add autoscroll to cursor in chat input

### DIFF
--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -1033,6 +1033,8 @@ Rectangle {
                                         }
                                     }
                                 }
+
+                                inputScrollView.ensureVisible(cursorRectangle)
                             }
 
                             onTextChanged: {


### PR DESCRIPTION
Requires https://github.com/status-im/StatusQ/pull/868

Fixes #7093
Fixes #7171

### What does the PR do

Calls ensureVisible for Flickable container of ChatInput to ensure cursor is visible.

### Affected areas

Desktop Chat

### Screenshot of functionality 

https://user-images.githubusercontent.com/6445843/186673886-f46e48c2-89f6-48f6-946d-2d3690878210.mp4


