### PR TITLE
fix(wallet-test): fix balance test

### DIFF
--- a/test/ui-test/src/screens/SettingsScreen.py
+++ b/test/ui-test/src/screens/SettingsScreen.py
@@ -97,6 +97,7 @@ class SettingsScreen:
         verify_screen(SidebarComponents.ADVANCED_OPTION.value)
     
     def open_wallet_settings(self):
+        StatusMainScreen.wait_for_banner_to_disappear()
         click_obj_by_name(SidebarComponents.WALLET_OPTION.value)
 
     def activate_wallet_option(self):
@@ -137,7 +138,6 @@ class SettingsScreen:
         
     def toggle_test_networks(self):
         click_obj_by_name(WalletSettingsScreen.NETWORKS_ITEM.value)
-        get_and_click_obj(WalletSettingsScreen.TESTNET_TOGGLE.value)
         click_obj_by_name(WalletSettingsScreen.TESTNET_TOGGLE.value)
         
     def open_language_and_currency_settings(self):

--- a/test/ui-test/src/screens/StatusMainScreen.py
+++ b/test/ui-test/src/screens/StatusMainScreen.py
@@ -45,10 +45,14 @@ class StatusMainScreen:
 
     # Wait for the banner to disappear otherwise the click might land badly
     @staticmethod
-    def wait_for_banner_to_disappear():
-        [bannerLoaded, _] = is_loaded_visible_and_enabled(MainScreenComponents.MODULE_WARNING_BANNER.value)
-        if (bannerLoaded):
-            StatusMainScreen.wait_for_banner_to_disappear()
+    def wait_for_banner_to_disappear(retry = 0):
+        if (retry > 5):
+            verify_failure("Banner did not disappear")
+        [bannerLoaded, _] = is_loaded_visible_and_enabled(MainScreenComponents.MODULE_WARNING_BANNER.value, 500)
+        time.sleep(1)
+        if (not bannerLoaded):
+            return
+        StatusMainScreen.wait_for_banner_to_disappear(retry + 1)
 
     def join_chat_room(self, room: str):
         click_obj_by_name(MainScreenComponents.PUBLIC_CHAT_ICON.value)

--- a/test/ui-test/src/screens/StatusWalletScreen.py
+++ b/test/ui-test/src/screens/StatusWalletScreen.py
@@ -242,9 +242,9 @@ class StatusWalletScreen:
     def verify_positive_balance(self, symbol: str):
         list = get_obj(AssetView.LIST.value)
         for index in range(list.count):
-            if list.itemAtIndex(index).objectName == symbol:
-                balance = list.itemAtIndex(index).children.at(2).text
-                assert balance != f"0 {symbol}", f"balance is not positive, balance: {balance}"
+            tokenListItem = list.itemAtIndex(index)
+            if tokenListItem.objectName == "AssetView_TokenListItem_" + symbol:
+                assert tokenListItem.balance != f"0 {symbol}", f"balance is not positive, balance: {balance}"
                 return
             
         assert False, "symbol not found"

--- a/ui/imports/shared/views/AssetsView.qml
+++ b/ui/imports/shared/views/AssetsView.qml
@@ -40,6 +40,8 @@ Item {
             ]
         }
         delegate: StatusListItem {
+            readonly property int balance: enabledNetworkBalance // Needed for the tests
+            objectName: "AssetView_TokenListItem_" + symbol
             width: parent.width
             title: name
             subTitle: qsTr("%1 %2").arg(Utils.toLocaleString(enabledNetworkBalance, RootStore.locale, {"currency": true})).arg(symbol)


### PR DESCRIPTION
The test network was toggled twice. The banner was impeding with the wallet setting click. The asset list item was missing the objectName and also checking the balance was not resilient