### PR TITLE
fix(@desktop): Fixing setting contacts statuses

### DIFF
--- a/src/app/core/signals/remote_signals/signal_type.nim
+++ b/src/app/core/signals/remote_signals/signal_type.nim
@@ -40,6 +40,7 @@ type SignalType* {.pure.} = enum
   HistoryArchiveDownloaded = "community.historyArchiveDownloaded"
   UpdateAvailable = "update.available"
   DiscordCategoriesAndChannelsExtracted = "community.discordCategoriesAndChannelsExtracted"
+  StatusUpdatesTimedout = "status.updates.timedout"
   Unknown
 
 proc event*(self:SignalType):string =

--- a/src/app/core/signals/remote_signals/status_updates.nim
+++ b/src/app/core/signals/remote_signals/status_updates.nim
@@ -1,0 +1,17 @@
+import json
+
+import base
+import signal_type
+
+import ../../../../app_service/service/contacts/dto/status_update
+
+
+type StatusUpdatesTimedoutSignal* = ref object of Signal
+  statusUpdates*: seq[StatusUpdateDto]
+
+proc fromEvent*(T: type StatusUpdatesTimedoutSignal, jsonSignal: JsonNode): StatusUpdatesTimedoutSignal =
+  result = StatusUpdatesTimedoutSignal()
+  result.signalType = SignalType.StatusUpdatesTimedout
+  for jsonStatusUpdate in jsonSignal["event"]:
+    var statusUpdate = jsonStatusUpdate.toStatusUpdateDto()
+    result.statusUpdates.add(statusUpdate)

--- a/src/app/core/signals/signals_manager.nim
+++ b/src/app/core/signals/signals_manager.nim
@@ -94,6 +94,7 @@ QtObject:
       of SignalType.HistoryArchiveDownloaded: HistoryArchivesSignal.historyArchiveDownloadedFromEvent(jsonSignal)
       of SignalType.UpdateAvailable: UpdateAvailableSignal.fromEvent(jsonSignal)
       of SignalType.DiscordCategoriesAndChannelsExtracted: DiscordCategoriesAndChannelsExtractedSignal.fromEvent(jsonSignal)
+      of SignalType.StatusUpdatesTimedout: StatusUpdatesTimedoutSignal.fromEvent(jsonSignal)
       else: Signal()
 
     result.signalType = signalType

--- a/src/app/core/signals/types.nim
+++ b/src/app/core/signals/types.nim
@@ -1,7 +1,7 @@
 {.used.}
 
 import ./remote_signals/[base, chronicles_logs, community, discovery_summary, envelope, expired, mailserver, messages,
-peerstats, signal_type, stats, wallet, whisper_filter, keycard, update_available]
+peerstats, signal_type, stats, wallet, whisper_filter, keycard, update_available, status_updates]
 
 export base, chronicles_logs, community, discovery_summary, envelope, expired, mailserver, messages, peerstats,
-  signal_type, stats, wallet, whisper_filter, keycard, update_available
+  signal_type, stats, wallet, whisper_filter, keycard, update_available, status_updates


### PR DESCRIPTION
Issue #6403

### What does the PR do

Remove timers logic since the logic was moved to status-go.
Handle additional status.updates.timedout signal. This signal inform about Inactive state of contacts with Automatic statuses which has been offline for more than 5 minutes.

Testing scenario:
1. Start 2 application instances. Both accounts should be contacts
2. Set Automatic status in 1st account and close the application
3. The 2nd account should see 1st account as online for 5 minutes.
4. After that time the status of 1st account should change to Inactive.

🍺 
