### PR TITLE
fix(Wallet/AddAccountModal): fix status-go error messages

### DIFF
--- a/ui/app/AppLayouts/Wallet/panels/DerivedAddressesPanel.qml
+++ b/ui/app/AppLayouts/Wallet/panels/DerivedAddressesPanel.qml
@@ -186,7 +186,7 @@ Item {
                                         selectedDerivedAddress.pathSubFix = actualIndex
                                         selectedDerivedAddress.hasActivity = element.hasActivity
                                         derivedAddressPopup.close()
-                                    }                                    
+                                    }
                                     Component.onCompleted: {
                                         if(RootStore.derivedAddressesList.count === 1 && index === 0) {
                                             selectedDerivedAddress.title = title

--- a/ui/app/AppLayouts/Wallet/popups/AddAccountModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/AddAccountModal.qml
@@ -32,13 +32,6 @@ StatusModal {
 
     signal afterAddAccount()
 
-    MessageDialog {
-        id: accountError
-        title: qsTr("Adding the account failed")
-        icon: StandardIcon.Critical
-        standardButtons: StandardButton.Ok
-    }
-
     Timer {
         id: waitTimer
 
@@ -98,8 +91,7 @@ StatusModal {
                     d.passwordValidationError = qsTr("Wrong password")
                     scroll.contentY = -scroll.padding
                 } else {
-                    accountError.text = errMessage
-                    accountError.open()
+                    console.warn(`Unhandled error case. Status-go message: ${errMessage}`)
                 }
             }
         }

--- a/ui/imports/utils/Utils.qml
+++ b/ui/imports/utils/Utils.qml
@@ -685,6 +685,10 @@ QtObject {
         );
     }
 
+    function isInvalidPrivateKey(msg) {
+        return msg.includes("invalid private key");
+    }
+
     function isInvalidPath(msg) {
         return msg.includes("error parsing derivation path")
     }


### PR DESCRIPTION
## Fixes: #6984

Remove the unneeded native error dialog showing internal status-go
error strings. Instead redirect the error message for wrong private key
as a specific error message.

Notes:

- I find the back and forth of data and states between `AddAccountModal` , `AdvancedAddAccountView` and `ImportPrivateKey` cumbersome. However, I consider the big refactoring not worth the effort given the upcoming redesign and the importance of the Private Key Import feature.
- `StatusAsyncValidator` has a complex pulling mechanism and something else would have been better alternative, though not worth the investigation due to low feature importance.

### Affected areas

Wallet - Add a private key account

![image](https://user-images.githubusercontent.com/47554641/187270539-95d96273-793a-4cfc-b4ed-ebae1f703b80.png)

- [ ] ~~I've checked the design and this PR matches it~~