### PR TITLE
fix(@desktop/wallet): Wallet - Send - Crash after opening send modal

### DIFF
--- a/src/app_service/service/transaction/service.nim
+++ b/src/app_service/service/transaction/service.nim
@@ -370,22 +370,28 @@ QtObject:
     return self.transferTokens(from_addr, to_addr, assetSymbol, value, gas, gasPrice, maxPriorityFeePerGas, maxFeePerGas, password, chainId, uuid, eip1559Enabled)
 
   proc suggestedFees*(self: Service, chainId: int): SuggestedFees =
-    let response = eth.suggestedFees(chainId).result
-    return SuggestedFees(
-      gasPrice: parseFloat(response{"gasPrice"}.getStr),
-      baseFee: parseFloat(response{"baseFee"}.getStr),
-      maxPriorityFeePerGas: parseFloat(response{"maxPriorityFeePerGas"}.getStr),
-      maxFeePerGasL: parseFloat(response{"maxFeePerGasLow"}.getStr),
-      maxFeePerGasM: parseFloat(response{"maxFeePerGasMedium"}.getStr),
-      maxFeePerGasH: parseFloat(response{"maxFeePerGasHigh"}.getStr),
-      eip1559Enabled: response{"eip1559Enabled"}.getbool,
-    )
+    try:
+      let response = eth.suggestedFees(chainId).result
+      return SuggestedFees(
+        gasPrice: parseFloat(response{"gasPrice"}.getStr),
+        baseFee: parseFloat(response{"baseFee"}.getStr),
+        maxPriorityFeePerGas: parseFloat(response{"maxPriorityFeePerGas"}.getStr),
+        maxFeePerGasL: parseFloat(response{"maxFeePerGasLow"}.getStr),
+        maxFeePerGasM: parseFloat(response{"maxFeePerGasMedium"}.getStr),
+        maxFeePerGasH: parseFloat(response{"maxFeePerGasHigh"}.getStr),
+        eip1559Enabled: response{"eip1559Enabled"}.getbool,
+      )
+    except Exception as e:
+      error "Error getting suggested fees", msg = e.msg
 
   proc suggestedRoutes*(self: Service, account: string, amount: float64, token: string, disabledChainIDs: seq[uint64]): SuggestedRoutes =
-    let response = eth.suggestedRoutes(account, amount, token, disabledChainIDs)
-    return SuggestedRoutes(
-      networks: Json.decode($response.result{"networks"}, seq[NetworkDto])
-    )
+    try:
+      let response = eth.suggestedRoutes(account, amount, token, disabledChainIDs)
+      return SuggestedRoutes(
+        networks: Json.decode($response.result{"networks"}, seq[NetworkDto])
+      )
+    except Exception as e:
+      error "Error getting suggested routes", msg = e.msg
 
   proc fetchCryptoServices*(self: Service): seq[CryptoRampDto] =
     try:


### PR DESCRIPTION
The error seen in the bug is linked to getSuggestedFees returning an rpc error that was unhandled, I think this should resolve this issue.

fixes #6801

### What does the PR do

The error seen in the bug is linked to getSuggestedFees returning an rpc error that was unhandled, I think this should resolve this issue.

### Affected areas

Wallet