### PR TITLE
fix(Global): 'Open in Browser' doesn't work in chat

### DIFF
--- a/ui/imports/utils/Global.qml
+++ b/ui/imports/utils/Global.qml
@@ -85,6 +85,8 @@ QtObject {
     }
 
     function openLink(link) {
+        // Qt sometimes inserts random HTML tags; and this will break on invalid URL inside QDesktopServices::openUrl(link)
+        link = globalUtils.plainText(link);
         if (localAccountSensitiveSettings.showBrowserSelector) {
             openChooseBrowserPopup(link);
         } else {


### PR DESCRIPTION
strip the URL from any HTML tags before trying to open it; Qt sometimes
likes to leave some HTML tags there and that breaks the URL validity
checks further on

Fixes: #7170

### What does the PR do

Fixes opening URLs in browser in some cases

### Affected areas

Global/openLink()

### Screenshot of functionality (including design for comparison)

- [N/A] I've checked the design and this PR matches it
