### PR TITLE
fix(@desktop/onboarding): use system theme while onboarding

### DIFF
--- a/ui/main.qml
+++ b/ui/main.qml
@@ -158,6 +158,8 @@ StatusWindow {
                 }
                 startupOnboarding.unload()
                 startupOnboarding.visible = false
+
+                Style.changeTheme(localAppSettings.theme, systemPalette.isCurrentSystemThemeDark())
             }
         }
     }
@@ -207,12 +209,13 @@ StatusWindow {
     }
 
     function changeThemeFromOutside() {
-        Style.changeTheme(localAppSettings.theme, systemPalette.isCurrentSystemThemeDark())
+        Style.changeTheme(startupOnboarding.visible ? Universal.System : localAppSettings.theme,
+                          systemPalette.isCurrentSystemThemeDark())
     }
 
     Component.onCompleted: {
         Global.applicationWindow = this;
-        Style.changeTheme(localAppSettings.theme, systemPalette.isCurrentSystemThemeDark());
+        Style.changeTheme(Universal.System, systemPalette.isCurrentSystemThemeDark());
 
         restoreAppState();
     }


### PR DESCRIPTION
Fixes #6630

### What does the PR do

Use system theme while onboarding visible.

### Affected areas

Desktop Onboarding

### Screenshot of functionality 

https://user-images.githubusercontent.com/6445843/187663392-7885b78f-7ac8-43d0-ad5a-48c643c22f94.mov

