### PR TITLE
fix(Chat): improve gif confirmation popup and fix preview whitelisting

### DIFF
--- a/ui/app/AppLayouts/Profile/views/MessagingView.qml
+++ b/ui/app/AppLayouts/Profile/views/MessagingView.qml
@@ -9,6 +9,7 @@ import shared.panels 1.0
 import shared.popups 1.0
 import shared.status 1.0
 import shared.controls 1.0
+import shared.stores 1.0
 
 import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
@@ -263,7 +264,7 @@ SettingsContentBase {
             previewableSites.clear()
             var oneEntryIsActive = false
             whitelist.forEach(entry => {
-                                  entry.isWhitelisted = localAccountSensitiveSettings.whitelistedUnfurlingSites[entry.address] || false
+                                  entry.isWhitelisted = !!localAccountSensitiveSettings.whitelistedUnfurlingSites[entry.address]
                                   if (entry.isWhitelisted) {
                                       oneEntryIsActive = true
                                   }
@@ -301,6 +302,11 @@ SettingsContentBase {
                 onSettingsLoaded: {
                     generalColumn.populatePreviewableSites()
                 }
+            }
+
+            Connections {
+                target: localAccountSensitiveSettings
+                onWhitelistedUnfurlingSitesChanged: generalColumn.populatePreviewableSites()
             }
 
             // Manually add switch for the image unfurling
@@ -356,6 +362,7 @@ SettingsContentBase {
                             case "medium":
                                 filename = "medium"; break;
                             case "tenor gifs":
+                            case "tenor gifs subdomain":
                                 filename = "tenor"; break;
                             case "giphy gifs":
                             case "giphy gifs shortener":
@@ -375,20 +382,7 @@ SettingsContentBase {
                             StatusSwitch {
                                 id: siteSwitch
                                 checked: !!model.isWhitelisted
-                                onCheckedChanged: {
-                                    let settings = localAccountSensitiveSettings.whitelistedUnfurlingSites
-
-                                    if (!settings) {
-                                        settings = {}
-                                    }
-
-                                    if (settings[address] === this.checked) {
-                                        return
-                                    }
-
-                                    settings[address] = this.checked
-                                    localAccountSensitiveSettings.whitelistedUnfurlingSites = settings
-                                }
+                                onCheckedChanged: RootStore.updateWhitelistedUnfurlingSites(model.address, checked)
                             }
                         ]
                         onClicked: {

--- a/ui/imports/shared/status/StatusGifPopup/ConfirmationPopup.qml
+++ b/ui/imports/shared/status/StatusGifPopup/ConfirmationPopup.qml
@@ -1,0 +1,87 @@
+import QtQuick 2.13
+import QtQuick.Controls 2.13
+import QtGraphicalEffects 1.0
+
+import StatusQ.Core 0.1
+import StatusQ.Controls 0.1
+
+import utils 1.0
+import shared.panels 1.0
+import shared.stores 1.0
+import shared.controls 1.0
+
+Popup {
+    id: root
+
+    anchors.centerIn: parent
+    height: 278
+    width: 291
+
+    horizontalPadding: 6
+    verticalPadding: 32
+
+    modal: false
+    closePolicy: Popup.NoAutoClose
+
+    background: Rectangle {
+        radius: Style.current.radius
+        color: Style.current.background
+        border.color: Style.current.border
+        layer.enabled: true
+        layer.effect: DropShadow {
+            verticalOffset: 3
+            radius: 8
+            samples: 15
+            fast: true
+            cached: true
+            color: "#22000000"
+        }
+    }
+
+    SVGImage {
+        id: gifImage
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.top: parent.top
+        source: Style.svg(`gifs-${Style.current.name}`)
+    }
+
+    StatusBaseText {
+        id: title
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.top: gifImage.bottom
+        anchors.topMargin: 8
+        text: qsTr("Enable Tenor GIFs?")
+        font.weight: Font.Medium
+        font.pixelSize: Style.current.primaryTextFontSize
+    }
+
+    StatusBaseText {
+        id: headline
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.top: title.bottom
+        anchors.topMargin: 4
+
+        text: qsTr("Once enabled, GIFs posted in the chat may share your metadata with Tenor.")
+        width: parent.width
+        horizontalAlignment: Text.AlignHCenter
+        wrapMode: Text.WordWrap
+        font.pixelSize: 13
+        color: Style.current.secondaryText
+    }
+
+    StatusButton {
+        id: removeBtn
+        objectName: "enableGifsButton"
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.bottom: parent.bottom
+        text: qsTr("Enable")
+
+        size: StatusBaseButton.Size.Small
+
+        onClicked: {
+            RootStore.setIsTenorWarningAccepted(true)
+            RootStore.getTrendingsGifs()
+            root.close()
+        }
+    }
+}

--- a/ui/imports/shared/status/StatusGifPopup/ConfirmationPopup.qml
+++ b/ui/imports/shared/status/StatusGifPopup/ConfirmationPopup.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.13
-import QtQuick.Controls 2.13
+import QtQuick 2.14
+import QtQuick.Controls 2.14
 import QtGraphicalEffects 1.0
 
 import StatusQ.Core 0.1
@@ -80,6 +80,7 @@ Popup {
 
         onClicked: {
             RootStore.setIsTenorWarningAccepted(true)
+            RootStore.updateWhitelistedUnfurlingSites("media.tenor.com", true)
             RootStore.getTrendingsGifs()
             root.close()
         }

--- a/ui/imports/shared/status/StatusGifPopup/EmptyPlaceholder.qml
+++ b/ui/imports/shared/status/StatusGifPopup/EmptyPlaceholder.qml
@@ -1,0 +1,48 @@
+import QtQuick 2.13
+import QtQuick.Controls 2.13
+import QtGraphicalEffects 1.0
+
+import StatusQ.Core 0.1
+import StatusQ.Controls 0.1
+
+import utils 1.0
+
+Rectangle {
+    id: root
+
+    /*required*/ property int currentCategory: GifPopupDefinitions.Category.Trending
+
+    signal doRetry()
+
+    height: parent.height
+    width: parent.width
+    color: Style.current.background
+
+    StatusBaseText {
+        id: emptyText
+        anchors.centerIn: parent
+        text: {
+            if(root.currentCategory === GifPopupDefinitions.Category.Favorite) {
+                return qsTr("Favorite GIFs will appear here")
+            } else if(root.currentCategory === GifPopupDefinitions.Category.Recent) {
+                return qsTr("Recent GIFs will appear here")
+            }
+
+            return qsTr("Error while contacting Tenor API, please retry.")
+        }
+        font.pixelSize: 15
+        color: Style.current.secondaryText
+    }
+
+    StatusButton {
+        text: qsTr("Retry")
+
+        visible: root.currentCategory === GifPopupDefinitions.Category.Trending || root.currentCategory === GifPopupDefinitions.Category.Search
+
+        anchors.top: emptyText.bottom
+        anchors.topMargin: Style.current.padding
+        anchors.horizontalCenter: parent.horizontalCenter
+
+        onClicked: root.doRetry()
+    }
+}

--- a/ui/imports/shared/status/StatusGifPopup/EmptyPlaceholder.qml
+++ b/ui/imports/shared/status/StatusGifPopup/EmptyPlaceholder.qml
@@ -14,8 +14,6 @@ Rectangle {
 
     signal doRetry()
 
-    height: parent.height
-    width: parent.width
     color: Style.current.background
 
     StatusBaseText {

--- a/ui/imports/shared/status/StatusGifPopup/GifPopupDefinitions.qml
+++ b/ui/imports/shared/status/StatusGifPopup/GifPopupDefinitions.qml
@@ -1,0 +1,10 @@
+import QtQml 2.14
+
+QtObject {
+    enum Category {
+        Trending,
+        Recent,
+        Favorite,
+        Search
+    }
+}

--- a/ui/imports/shared/status/StatusGifPopup/StatusGifColumn.qml
+++ b/ui/imports/shared/status/StatusGifPopup/StatusGifColumn.qml
@@ -118,9 +118,3 @@ Column {
         }
     }
 }
-
-/*##^##
-Designer {
-    D{i:0;formeditorColor:"#ffffff";height:440;width:360}
-}
-##^##*/

--- a/ui/imports/shared/status/qmldir
+++ b/ui/imports/shared/status/qmldir
@@ -14,7 +14,6 @@ StatusEmojiSection 1.0 StatusEmojiSection.qml
 StatusEmojiSuggestionPopup 1.0 StatusEmojiSuggestionPopup.qml
 StatusETHTransactionModal 1.0 StatusETHTransactionModal.qml
 StatusExpandableAddress 1.0 StatusExpandableAddress.qml
-StatusGifColumn 1.0 StatusGifColumn.qml
 StatusGifPopup 1.0 StatusGifPopup.qml
 StatusImageModal 1.0 StatusImageModal.qml
 StatusImageRadioButton 1.0 StatusImageRadioButton.qml

--- a/ui/imports/shared/stores/RootStore.qml
+++ b/ui/imports/shared/stores/RootStore.qml
@@ -106,6 +106,22 @@ QtObject {
         chatSectionChatContentInputArea.getTrendingsGifs()
     }
 
+    function updateWhitelistedUnfurlingSites(hostname, whitelisted) {
+        // no way to send update notification for individual array entries
+        let settings = localAccountSensitiveSettings.whitelistedUnfurlingSites
+
+        if (!settings)
+            settings = {}
+
+        if (settings[hostname] === whitelisted)
+            return
+
+        settings[hostname] = whitelisted
+        localAccountSensitiveSettings.whitelistedUnfurlingSites = settings
+        if(hostname === "media.tenor.com" && whitelisted === false)
+            RootStore.setIsTenorWarningAccepted(false)
+    }
+
     function getRecentsGifs() {
         chatSectionChatContentInputArea.getRecentsGifs()
     }

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -637,6 +637,9 @@ Loader {
                     messageStore: root.messageStore
                     store: root.rootStore
                     isCurrentUser: root.amISender
+                    onImageClicked: {
+                        root.imageClicked(image);
+                    }
                 }
             }
 


### PR DESCRIPTION
### Closes #6829

Depends on the [status-go PR](https://github.com/status-im/status-go/pull/2832)

Enable preview for gifs after enabling the gif functionality
Disable gif functionality if the preview was disabled

Addition fixes
- The gifs weren't checked if all images weren't enabled
- The subdomain wasn't checked for whitelisting if the main domain wasn't enabled

### Affected areas

Chat workflow for gif popup and link unfurling

### Screenshot of functionality (including design for comparison)

https://user-images.githubusercontent.com/47554641/187740744-adcfff22-3c2d-4958-9bf7-5df4888b39f7.mov

- [x] ~~I've checked the design and this PR matches it~~

### Considerations
I considered having the "gif enabled" - "tenor unfurling" relation embedded in the controller but it would require extensive refactoring by implementing a data-model for unfurling whitelisted domains