### PR TITLE
fix(StatusEmojiPopup): various UI fixes

### DIFF
--- a/ui/imports/shared/controls/SearchBox.qml
+++ b/ui/imports/shared/controls/SearchBox.qml
@@ -1,16 +1,11 @@
-import QtQuick 2.13
+import QtQuick 2.14
 
-import utils 1.0
-import "."
-
-import StatusQ.Core 0.1
 import StatusQ.Controls 0.1
 
 StatusInput {
-    id: searchBox
     placeholderText: qsTr("Search")
     input.icon.name: "search"
     input.clearable: true
     leftPadding: 0
-    rightPadding: 0
+    rightPadding: 4
 }

--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -1216,7 +1216,7 @@ Rectangle {
                                     control.emojiPopupOpened = true
                                     togglePopup(emojiPopup, emojiBtn)
                                     emojiPopup.x = Global.applicationWindow.width - emojiPopup.width - Style.current.halfPadding
-                                    emojiPopup.y = Global.applicationWindow.height - emojiPopup.height - control.height
+                                    emojiPopup.y = Global.applicationWindow.height - emojiPopup.height - control.height - Style.current.halfPadding
                                 }
                             }
 

--- a/ui/imports/shared/status/StatusEmojiPopup.qml
+++ b/ui/imports/shared/status/StatusEmojiPopup.qml
@@ -183,19 +183,10 @@ Popup {
         }
 
         categories = newCategories;
-    }
 
-    Connections {
-        id: connectionSettings
-        target: Global
-        onSettingsLoaded: {
-            connectionSettings.enabled = false
-            // Add recent
-            if (!localAccountSensitiveSettings.recentEmojis || !localAccountSensitiveSettings.recentEmojis.length) {
-                return
-            }
-            categories[0] = localAccountSensitiveSettings.recentEmojis
-            emojiSectionsRepeater.itemAt(0).allEmojis = localAccountSensitiveSettings.recentEmojis
+        const recent = localAccountSensitiveSettings.recentEmojis;
+        if (!!recent) {
+            emojiSectionsRepeater.itemAt(0).allEmojis = recent;
         }
     }
 

--- a/ui/imports/shared/status/StatusEmojiPopup.qml
+++ b/ui/imports/shared/status/StatusEmojiPopup.qml
@@ -202,10 +202,10 @@ Popup {
 
     contentItem: ColumnLayout {
         anchors.fill: parent
-        spacing: 0
+        spacing: Style.current.smallPadding
 
         Item {
-            property int headerMargin: 8
+            readonly property int headerMargin: 8
 
             id: emojiHeader
             Layout.fillWidth: true
@@ -278,13 +278,9 @@ Popup {
             property int activeCategory: 0
 
             id: scrollView
-            leftPadding: Style.current.smallPadding
-            rightPadding: Style.current.smallPadding / 2
+            padding: Style.current.smallPadding
             Layout.fillWidth: true
-            Layout.rightMargin: Style.current.smallPadding / 2
-            Layout.topMargin: Style.current.smallPadding
-            Layout.alignment: Qt.AlignTop | Qt.AlignLeft
-            Layout.preferredHeight: 400 - Style.current.smallPadding - emojiHeader.height
+            Layout.fillHeight: true
             ScrollBar.vertical.policy: ScrollBar.AlwaysOn
             ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
 
@@ -316,7 +312,7 @@ Popup {
                 })
 
                 categrorySectionHeightRatios = ratios
-                return totalHeight
+                return totalHeight - scrollView.topPadding - scrollView.bottomPadding
             }
 
             Repeater {
@@ -334,12 +330,10 @@ Popup {
         Row {
             Layout.fillWidth: true
             height: 40
-            leftPadding: Style.current.smallPadding / 2
-            rightPadding: Style.current.smallPadding / 2
             spacing: 0
 
             Repeater {
-                model: EmojiJSON.emojiCategories
+                model: StatusQUtils.Emoji.emojiJSON.emojiCategories
 
                 StatusTabBarIconButton {
                     icon.name: modelData
@@ -353,8 +347,3 @@ Popup {
         }
     }
 }
-/*##^##
-Designer {
-    D{i:0;formeditorColor:"#ffffff";height:440;width:360}
-}
-##^##*/

--- a/ui/imports/shared/status/StatusEmojiSection.qml
+++ b/ui/imports/shared/status/StatusEmojiSection.qml
@@ -23,8 +23,7 @@ Item {
     anchors.top: index === 0 ? parent.top : parent.children[index - 1].bottom
     anchors.topMargin: 0
 
-    // childrenRect caused a binding loop here
-    height: this.visible ? emojiGrid.height + categoryText.height + noRecentText.height + Style.current.padding : 0
+    implicitHeight: visible ? childrenRect.height + Style.current.padding : 0
 
     StyledText {
         id: categoryText


### PR DESCRIPTION
### What does the PR do

Please see the individual commits for the bug fixes; it made sense to group these fixes in one PR as they all happen in one file and the individual changes would conflict with each other

Closes #7174
Closes #7175

### Affected areas

StatusEmojiPopup

### Screenshot of functionality (including design for comparison)
Clear button margins fixed:
![Snímek obrazovky z 2022-09-01 11-33-52](https://user-images.githubusercontent.com/5377645/187890319-df0d0bb1-fec0-4162-8b0b-b341097606e5.png)

Flags section aligned correctly:
![Snímek obrazovky z 2022-09-01 11-33-28](https://user-images.githubusercontent.com/5377645/187890323-7a2dc9b9-5504-42fc-ba2a-004dfedd91f3.png)

Overall emoji popup alignment (y-pos) fixed:
![Snímek obrazovky z 2022-09-01 11-33-25](https://user-images.githubusercontent.com/5377645/187890325-e9a562d4-f2f1-415a-a24a-7693a7e90bfa.png)

- [x] I've checked the design and this PR matches it

