### PR TITLE
fix(@desktop/chat): adjust emoji popup behaviour

### DIFF
--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -132,6 +132,21 @@ Rectangle {
 
         // set to true when pasted text comes from this component (was copied within this component)
         property bool internalPaste: false
+
+        readonly property StateGroup emojiPopupTakeover: StateGroup {
+            states: State {
+                when: control.emojiPopupOpened
+
+                PropertyChanges {
+                    target: emojiPopup
+
+                    parent: control
+                    closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutsideParent
+                    x: control.width - emojiPopup.width - Style.current.halfPadding
+                    y: -emojiPopup.height
+                }
+            }
+        }
     }
 
     function insertInTextInput(start, text) {
@@ -1239,7 +1254,6 @@ Rectangle {
                             StatusQ.StatusFlatRoundButton {
                                 id: emojiBtn
                                 objectName: "statusChatInputEmojiButton"
-                                enabled: !control.emojiPopupOpened
                                 implicitHeight: 32
                                 implicitWidth: 32
                                 icon.name: "emojis"
@@ -1249,9 +1263,8 @@ Rectangle {
                                 color: "transparent"
                                 onClicked: {
                                     control.emojiPopupOpened = true
+
                                     togglePopup(emojiPopup, emojiBtn)
-                                    emojiPopup.x = Global.applicationWindow.width - emojiPopup.width - Style.current.halfPadding
-                                    emojiPopup.y = Global.applicationWindow.height - emojiPopup.height - control.height - Style.current.halfPadding
                                 }
                             }
 


### PR DESCRIPTION
Fixes #7094

### What does the PR do

Add logic to capture emoji popup by changing parent and close policy on emoji popup open from Chat input, also release by reverting those properties when emoji popup is closed.

### Affected areas

Desktop Chat

### Screenshot of functionality

https://user-images.githubusercontent.com/6445843/187939475-0e81ad72-8fb3-403d-8fab-75b51df9db69.mp4


