### PR TITLE
fix(AppMain): Made all banners global and stacked

### DIFF
--- a/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
@@ -38,7 +38,6 @@ Item {
     property bool isReply: false
     property bool isImage: false
     property bool isExtendedInput: isReply || isImage
-    property bool isConnected: false
     property string contactToRemove: ""
     property bool isSectionActive: mainModule.activeSection.id === parentModule.getMySectionId()
     property string activeChatId: parentModule && parentModule.activeItem.id
@@ -217,7 +216,6 @@ Item {
                             rootStore: root.rootStore
                             contactsStore: root.contactsStore
                             emojiPopup: root.emojiPopup
-                            isConnected: root.isConnected
                             sendTransactionNoEnsModal: cmpSendTransactionNoEns
                             receiveTransactionModal: cmpReceiveTransaction
                             sendTransactionWithEnsModal: cmpSendTransactionWithEns
@@ -266,7 +264,6 @@ Item {
                         clip: true
                         rootStore: root.rootStore
                         contactsStore: root.contactsStore
-                        isConnected: root.isConnected
                         emojiPopup: root.emojiPopup
                         sendTransactionNoEnsModal: cmpSendTransactionNoEns
                         receiveTransactionModal: cmpReceiveTransaction

--- a/ui/app/AppLayouts/Chat/views/ChatContentView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatContentView.qml
@@ -35,7 +35,6 @@ ColumnLayout {
     property var rootStore
     property var contactsStore
     property bool isActiveChannel: false
-    property bool isConnected: false
     property var emojiPopup
     property alias textInputField: chatInput
     property UsersStore usersStore: UsersStore {}
@@ -61,52 +60,6 @@ ColumnLayout {
     onHeightChanged: {
         if(root.height > 0) {
             chatInput.forceInputActiveFocus()
-        }
-    }
-
-    Rectangle {
-        id: connectedStatusRect
-        Layout.fillWidth: true
-        height: 40
-        Layout.alignment: Qt.AlignHCenter
-        z: 60
-        visible: false
-        color: isConnected ? Style.current.green : Style.current.darkGrey
-        Text {
-            anchors.horizontalCenter: parent.horizontalCenter
-            anchors.verticalCenter: parent.verticalCenter
-            color: Style.current.white
-            id: connectedStatusLbl
-            text: isConnected ?
-                      qsTr("Connected") :
-                      qsTr("Disconnected")
-        }
-
-        Connections {
-            target: mainModule
-            onOnlineStatusChanged: {
-                if (connected === isConnected) return;
-                isConnected = connected;
-                if(isConnected) {
-                    onlineStatusTimer.start();
-                } else {
-                    connectedStatusRect.visible = true;
-                }
-            }
-        }
-        Component.onCompleted: {
-            isConnected = mainModule.isOnline
-            if(!isConnected){
-                connectedStatusRect.visible = true
-            }
-        }
-    }
-
-    Timer {
-        id: onlineStatusTimer
-        interval: 5000
-        onTriggered: {
-            connectedStatusRect.visible = false;
         }
     }
 

--- a/ui/app/AppLayouts/Profile/ProfileLayout.qml
+++ b/ui/app/AppLayouts/Profile/ProfileLayout.qml
@@ -30,7 +30,7 @@ StatusSectionLayout {
     QtObject {
         id: d
 
-        readonly property int topMargin: secureYourSeedPhrase.visible ? secureYourSeedPhrase.height : 0
+        readonly property int topMargin: 0
         readonly property int bottomMargin: 56
         readonly property int leftMargin: 48
         readonly property int rightMargin: 48
@@ -53,50 +53,13 @@ StatusSectionLayout {
 
     centerPanel: Item {
         anchors.fill: parent
-        ModuleWarning {
-            id: secureYourSeedPhrase
-            width: parent.width
-            visible: {
-              if (profileContainer.currentIndex !== Constants.settingsSubsection.profile) {
-                return false
-              }
-              if (root.store.profileStore.userDeclinedBackupBanner) {
-                return false
-              }
-              return !root.store.profileStore.privacyStore.mnemonicBackedUp
-            }
-            color: Style.current.red
-            btnWidth: 100
-            text: qsTr("Secure your seed phrase")
-            btnText: qsTr("Back up now")
-
-            onClick: function(){
-                Global.openBackUpSeedPopup();
-            }
-
-            onClosed: {
-                root.store.profileStore.userDeclinedBackupBanner = true
-            }
-        }
-
-        StatusBanner {
-            id: banner
-            anchors.top: parent.top
-            anchors.left: parent.left
-            anchors.right: parent.right
-            height: visible ? childrenRect.height : 0
-            visible: profileContainer.currentIndex === Constants.settingsSubsection.wallet &&
-                     root.store.walletStore.areTestNetworksEnabled
-            type: StatusBanner.Type.Danger
-            statusText: qsTr("Testnet mode is enabled. All balances, transactions and dApp interactions will be on testnets.")
-        }
 
         StackLayout {
             id: profileContainer
 
             readonly property var currentItem: (currentIndex >= 0 && currentIndex < children.length) ? children[currentIndex] : null
 
-            anchors.top: banner.visible? banner.bottom : parent.top
+            anchors.top: parent.top
             anchors.left: parent.left
             anchors.right: parent.right
             anchors.bottom: parent.bottom

--- a/ui/imports/shared/panels/ModuleWarning.qml
+++ b/ui/imports/shared/panels/ModuleWarning.qml
@@ -3,111 +3,188 @@ import QtQuick.Controls 2.13
 import QtQuick.Layouts 1.13
 import QtGraphicalEffects 1.13
 
+import StatusQ.Core 0.1
+import StatusQ.Core.Theme 0.1
+
 import utils 1.0
 import "../"
 import "./"
 
-Rectangle {
+Item {
     id: root
     objectName: "moduleWarningBanner"
-    height: visible ? 32 : 0
-    implicitHeight: height
-    color: Style.current.red
 
-    property string text: ""
-    property string btnText: ""
-    property int btnWidth: 58
-    property bool closing: false
-
-    property var onClick: function() {}
-
-    signal closed()
-
-    function close() {
-        closeBtn.clicked(null)
-        closed();
+    enum Type {
+        Danger,
+        Success
     }
 
-    Row {
-        spacing: Style.current.halfPadding
-        anchors.horizontalCenter: parent.horizontalCenter
-        anchors.verticalCenter: parent.verticalCenter
+    property bool active: false
+    property int type: ModuleWarning.Danger
+    property string text: ""
+    property alias buttonText: button.text
 
-        StyledText {
-            text: root.text
-            font.pixelSize: 13
-            anchors.verticalCenter: parent.verticalCenter
-            color: Style.current.white
+    signal clicked()
+    signal closeClicked()
+    signal showStarted()
+    signal showFinihsed()
+    signal hideStarted()
+    signal hideFinished()
+
+    function show() {
+        hideTimer.stop()
+        active = true;
+    }
+
+    function showFor(duration = 5000) {
+        show();
+        hide(duration);
+    }
+
+    function hide(timeout = 0) {
+        hideTimer.interval = timeout
+        hideTimer.start()
+    }
+
+    function close() {
+        closeButtonMouseArea.clicked(null)
+    }
+
+    implicitHeight: root.active ? content.implicitHeight : 0
+    visible: implicitHeight > 0
+
+    onActiveChanged: {
+        active ? showAnimation.start() : hideAnimation.start()
+    }
+
+    NumberAnimation {
+        id: showAnimation
+        target: root
+        property: "implicitHeight"
+        from: 0
+        to: content.implicitHeight
+        duration: 500
+        easing.type: Easing.OutCubic
+        onStarted: {
+            root.showStarted()
+        }
+        onFinished: {
+            root.showFinihsed()
+        }
+    }
+
+    NumberAnimation {
+        id: hideAnimation
+        target: root
+        property: "implicitHeight"
+        to: 0
+        from: content.implicitHeight
+        duration: 500
+        easing.type: Easing.OutCubic
+        onStarted: {
+            root.hideStarted()
+        }
+        onFinished: {
+            root.hideFinished()
+        }
+    }
+
+    Timer {
+        id: hideTimer
+        repeat: false
+        running: false
+        onTriggered: {
+            root.active = false
+        }
+    }
+
+    Rectangle {
+        id: content
+        anchors.bottom: parent.bottom
+        width: parent.width
+        implicitHeight: 32
+
+        readonly property color baseColor: {
+            switch (root.type) {
+            case ModuleWarning.Danger: return Theme.palette.dangerColor1
+            case ModuleWarning.Success: return Theme.palette.successColor1
+            default: return Theme.palette.baseColor1
+            }
         }
 
-        Button {
-            width: btnWidth
-            height: 24
-            contentItem: Item {
-                anchors.fill: parent
-                Text {
-                    text: btnText
-                    font.pixelSize: 13
+        color: baseColor
+
+        Behavior on color {
+            ColorAnimation {
+                duration: 150
+            }
+        }
+
+        RowLayout {
+            id: layout
+
+            spacing: 12
+            anchors.horizontalCenter: parent.horizontalCenter
+            anchors.verticalCenter: parent.verticalCenter
+
+            StatusBaseText {
+                text: root.text
+                Layout.alignment: Qt.AlignVCenter
+                font.pixelSize: 13
+                color: Theme.palette.indirectColor1
+            }
+
+            Button {
+                id: button
+                visible: text != ""
+                padding: 5
+                onClicked: {
+                    root.clicked()
+                }
+                contentItem: Text {
+                    text: button.text
+                    font.pixelSize: 12
                     font.weight: Font.Medium
                     font.family: Style.current.fontRegular.name
                     horizontalAlignment: Text.AlignHCenter
                     verticalAlignment: Text.AlignVCenter
-                    anchors.top: parent.top
-                    anchors.bottom: parent.bottom
-                    anchors.left: parent.left
-                    anchors.right: parent.right
-                    color: Style.current.white
+                    color: Theme.palette.indirectColor1
+                }
+                background: Rectangle {
+                    radius: 4
+                    border.width: 1
+                    border.color: Theme.palette.indirectColor3
+                    color: Theme.palette.getColor("white", button.hovered ? 0.4 : 0.1)
+                }
+                MouseArea {
+                    anchors.fill: parent
+                    acceptedButtons: Qt.NoButton
+                    cursorShape: Qt.PointingHandCursor
                 }
             }
-            background: Rectangle {
-                radius: 4
-                anchors.fill: parent
-                border.color: Style.current.white
-                color: "#19FFFFFF"
-            }
+        }
+
+        StatusIcon {
+            id: closeImg
+            anchors.verticalCenter: parent.verticalCenter
+            anchors.right: parent.right
+            anchors.rightMargin: 18
+            height: 20
+            width: 20
+            icon: "close-circle"
+            color: Theme.palette.indirectColor1
+            opacity: closeButtonMouseArea.containsMouse ? 1 : 0.7
+
             MouseArea {
-                cursorShape: Qt.PointingHandCursor
+                id: closeButtonMouseArea
                 anchors.fill: parent
-                onClicked: root.onClick()
+                hoverEnabled: true
+                cursorShape: Qt.PointingHandCursor
+                onClicked: {
+                    root.closeClicked()
+                }
             }
         }
     }
 
-    SVGImage {
-        id: closeImg
-        anchors.top: parent.top
-        anchors.topMargin: 6
-        anchors.right: parent.right
-        anchors.rightMargin: 18
-        source: Style.svg("close-white")
-        height: 20
-        width: 20
-    }
-    ColorOverlay {
-        anchors.fill: closeImg
-        source: closeImg
-        color: Style.current.white
-        opacity: 0.7
-    }
-    MouseArea {
-        id: closeBtn
-        anchors.fill: closeImg
-        cursorShape: Qt.PointingHandCursor
-        onClicked: {
-            closing = true
-        }
-    }
-
-    ParallelAnimation {
-        running: closing
-        PropertyAnimation { target: root; property: "visible"; to: false; }
-        PropertyAnimation { target: root; property: "y"; to: -1 * root.height }
-        onRunningChanged: {
-            if(!running){
-                closing = false;
-                root.y = 0;
-                root.closed();
-            }
-        }
-    }
 }


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/6636

## What does the PR do
### Banners

Banners are now global and stacked:
1. Backup seed phrase [[Figma link]](https://www.figma.com/file/idUoxN7OIW2Jpp3PMJ1Rl8/%E2%9A%99%EF%B8%8F-Settings-%7C-Desktop?node-id=884%3A93419)
2. TestNet mode enabled [[Figma link]](https://www.figma.com/file/idUoxN7OIW2Jpp3PMJ1Rl8/%E2%9A%99%EF%B8%8F-Settings-%7C-Desktop?node-id=1930%3A136721)
3. New version available [[Figma link]](https://www.figma.com/file/17fc13UBFvInrLgNUKJJg5/Kuba%E2%8E%9CDesktop?node-id=305%3A65943)
4. Connection lost / restored (design not found) 

NOTE: Import from Discord [[Figma link]](https://www.figma.com/file/HOCnvlM62U8ASbtI5wwcgv/Status-Desktop---Import-Discord-Community-Flow?node-id=13%3A55603) - implemented [here](https://github.com/status-im/status-desktop/issues/6934), out of scope of this pr

All banners are divided into 2 types:

- signal-driven (Connection, Update) - always fixed to the top
- property-driven (TestNet, Backup) - appended below the last banner on signal

Stacked banners design: https://www.figma.com/file/17fc13UBFvInrLgNUKJJg5/Kuba%E2%8E%9CDesktop?node-id=15853%3A474834

### Testnet disable confirmation dialog
Implemented per [design](https://www.figma.com/file/idUoxN7OIW2Jpp3PMJ1Rl8/%E2%9A%99%EF%B8%8F-Settings-%7C-Desktop?node-id=1938%3A135119).

## Affected areas

AppMain

## Some logic behind this

"Import from Discord" is currently out of scope, since it's not merged to master yet.
I also noted that the "Update available" banner doesn't match designs a bit, but it's better to update it in a separate PR.

All banners are divided into 2 types:
- signal-driven (Connection, Update) - always fixed to the top
- property-driven (TestNet, Backup) - appended below the last banner on signal

## Screenshots

This one show the actual banners separation. Did this at late stage, don't want to recreate all the screenshots 🙂 
![image](https://user-images.githubusercontent.com/25482501/188621586-49c8fa44-bde8-422f-9ca5-7c6bb651222a.png)

<img width="1012" alt="image" src="https://user-images.githubusercontent.com/25482501/188173149-889aa501-6969-40df-95a2-93c3616e7468.png">
<img width="1012" alt="image" src="https://user-images.githubusercontent.com/25482501/188173183-b141a56f-733f-48e9-a4fe-93e430a045b4.png">
<img width="1012" alt="image" src="https://user-images.githubusercontent.com/25482501/188173223-75615e73-b43f-4361-b8f0-8f3595e8895a.png">
<img width="1012" alt="image" src="https://user-images.githubusercontent.com/25482501/188176696-6d8557ea-6cb2-41d8-af9d-dcced7c0ad14.png">

## Screencast

https://user-images.githubusercontent.com/25482501/188175779-4005e6c5-8ee3-4e79-9dd2-ff6901d271bf.mov