### PR TITLE
fix(AppMain): profile image doesn't look good after changing language

### DIFF
--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -354,8 +354,8 @@ Item {
                 icon.source: appMain.rootStore.userProfileInst.icon
                 width: 32
                 height: 32
-                identicon.width: width
-                identicon.height: height
+                identicon.asset.width: width
+                identicon.asset.height: height
                 identicon.asset.charactersLen: 2
                 identicon.asset.color: Utils.colorForPubkey(appMain.rootStore.userProfileInst.pubKey)
                 identicon.ringSettings.ringSpecModel: Utils.getColorHashAsJson(appMain.rootStore.userProfileInst.pubKey)


### PR DESCRIPTION
Fixes #7197

### What does the PR do

Fixes Profile button size after changing language in Settings

### Affected areas

AppMain/ProfileButton

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

English:
![Snímek obrazovky z 2022-09-05 11-26-43](https://user-images.githubusercontent.com/5377645/188416610-4540ecfb-1669-49a2-acd6-8d80b1249756.png)

Arabic:
![Snímek obrazovky z 2022-09-05 11-27-17](https://user-images.githubusercontent.com/5377645/188416600-3c006db3-3427-4658-a93b-eade1c5beca0.png)
