### PR TITLE
fix(@desktop/chat): Fix showing groupchat image in a few places

### DIFF
--- a/ui/app/AppLayouts/Chat/popups/GroupInfoPopup.qml
+++ b/ui/app/AppLayouts/Chat/popups/GroupInfoPopup.qml
@@ -66,13 +66,8 @@ StatusModal {
         }
     }
     header.editable: !addMembers && popup.isAdmin
-    header.asset.isLetterIdenticon: {
-        if (popup.chatDetails && popup.chatDetails.icon !== "") {
-            return false
-        }
-        return true
-    }
-    header.asset.name: popup.chatDetails ? popup.chatDetails.name || popup.chatDetails.icon : ""
+    header.asset.isLetterIdenticon: (popup.chatDetails.icon === "")
+    header.asset.name: (popup.chatDetails.icon !== "") ? popup.chatDetails.icon : popup.chatDetails.name
     header.asset.isImage: (popup.chatDetails.icon !== "")
     header.asset.bgColor: popup.chatDetails ? popup.chatDetails.color : "transparent"
 

--- a/ui/app/AppLayouts/Chat/views/ChatHeaderContentView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatHeaderContentView.qml
@@ -125,6 +125,7 @@ RowLayout {
                     chatDescription = chatContentModule.chatDetails.description
                     chatEmoji = chatContentModule.chatDetails.emoji
                     chatColor = chatContentModule.chatDetails.color
+                    chatIcon = chatContentModule.chatDetails.icon
                     chatType = chatContentModule.chatDetails.type
                     chatMuted = chatContentModule.chatDetails.muted
                     channelPosition = chatContentModule.chatDetails.position
@@ -259,9 +260,7 @@ RowLayout {
                 case Constants.chatType.publicChat:
                     return qsTr("Public chat")
                 case Constants.chatType.privateGroupChat:
-                    let cnt = root.usersStore.usersModule.model.count
-                    if(cnt > 1) return qsTr("%n member(s)", "", cnt);
-                    return qsTr("1 member");
+                    return qsTr("%n member(s)", "", chatContentModule.usersModule.model.count)
                 case Constants.chatType.communityChat:
                     return Utils.linkifyAndXSS(chatContentModule.chatDetails.description).trim()
                 default:
@@ -269,6 +268,8 @@ RowLayout {
                 }
             }
             asset.name: chatContentModule? chatContentModule.chatDetails.icon : ""
+            asset.isImage: chatContentModule.chatDetails.icon !== ""
+            asset.isLetterIdenticon: chatContentModule.chatDetails.icon === ""
             ringSettings.ringSpecModel: chatContentModule && chatContentModule.chatDetails.type === Constants.chatType.oneToOne ?
                                             Utils.getColorHashAsJson(chatContentModule.chatDetails.id) : ""
             asset.color: chatContentModule?
@@ -289,7 +290,7 @@ RowLayout {
                 }
                 Global.openPopup(pinnedMessagesPopupComponent, {
                                      store: rootStore,
-                                     messageStore: messageStore,
+                                     messageStore: root.rootStore.messageStore,
                                      pinnedMessagesModel: chatContentModule.pinnedMessagesModel,
                                      messageToPin: ""
                                  })


### PR DESCRIPTION
Fix #7242 and #7247

Shows group chat image correctly in a few places.

### How to test:
1. Create a group chat
2. Set group chat image (chat context menu -> "Edit name and image")
3. Verify if image was set
4. Pin some messages in a chat
5. Click on pin icon in chat info button
6. Pin icon should work correctly 

### Screenshot of functionality (including design for comparison)

![image](https://user-images.githubusercontent.com/61889657/188852777-be239003-3358-425f-99ad-6fbce7e3769b.png)

Pinned messages button fixed

![image](https://user-images.githubusercontent.com/61889657/189127869-28c7bf73-bafe-4d35-8997-a79619ce5b57.png)


🍺 