### PR TITLE
feat(@desktop/communities) Permissions - holdings edit and remove

### DIFF
--- a/ui/app/AppLayouts/Chat/controls/community/HoldingTypes.qml
+++ b/ui/app/AppLayouts/Chat/controls/community/HoldingTypes.qml
@@ -1,0 +1,7 @@
+import QtQml 2.14
+
+QtObject {
+    enum Type {
+        Token, Collectible, Ens
+    }
+}

--- a/ui/app/AppLayouts/Chat/controls/community/HoldingsTabs.qml
+++ b/ui/app/AppLayouts/Chat/controls/community/HoldingsTabs.qml
@@ -1,20 +1,41 @@
 import QtQuick 2.14
 
-import StatusQ.Core 0.1
-import StatusQ.Components 0.1
 import StatusQ.Controls 0.1
 
 
 Item {
-    property alias addButtonEnabled: addButton.enabled
+    id: root
+
+    property int mode: HoldingsTabs.Mode.Add
     property alias tabLabels: tabLabelsRepeater.model
+    property alias sourceComponent: tabsLoader.sourceComponent
+    property alias addOrUpdateButtonEnabled: addOrUpdateButton.enabled
 
     property alias currentIndex: tabBar.currentIndex
-    property alias sourceComponent: tabsLoader.sourceComponent
-
     readonly property alias item: tabsLoader.item
 
     signal addClicked
+    signal updateClicked
+    signal removeClicked
+
+    enum Mode {
+        Add, Update
+    }
+
+    function setCurrentIndex(index) {
+        tabBar.setCurrentIndex(index)
+    }
+
+    QtObject {
+        id: d
+
+        // values from design
+        readonly property int tabBarHeight: 36
+        readonly property int tabBarFontPixelSize: 13
+        readonly property int contentTopMargin: 16
+        readonly property int buttonsHeight: 44
+        readonly property int buttonsSpacing: 8
+    }
 
     StatusSwitchTabBar {
         id: tabBar
@@ -23,14 +44,14 @@ Item {
         anchors.right: parent.right
         anchors.left: parent.left
 
-        height: 36 // by design
+        height: d.tabBarHeight
 
         Repeater {
             id: tabLabelsRepeater
 
             StatusSwitchTabButton {
                 text: modelData
-                fontPixelSize: 13
+                fontPixelSize: d.tabBarFontPixelSize
             }
         }
     }
@@ -41,19 +62,34 @@ Item {
         anchors.top: tabBar.bottom
         anchors.right: parent.right
         anchors.left: parent.left
-        anchors.topMargin: 16
+        anchors.topMargin: d.contentTopMargin
     }
 
-    StatusButton {
-        id: addButton
-
-        text: qsTr("Add")
-        height: 44
+    Column {
+        spacing: d.buttonsSpacing
 
         anchors.bottom: parent.bottom
         anchors.right: parent.right
         anchors.left: parent.left
 
-        onClicked: addClicked()
+        StatusButton {
+            id: addOrUpdateButton
+
+            text: (root.mode === HoldingsTabs.Mode.Add ? qsTr("Add") : qsTr("Update"))
+            height: d.buttonsHeight
+            width: parent.width
+            onClicked: root.mode === HoldingsTabs.Mode.Add
+                       ? root.addClicked() : root.updateClicked()
+        }
+
+        StatusFlatButton {
+            text: qsTr("Remove")
+            height: d.buttonsHeight
+            width: parent.width
+            visible: root.mode === HoldingsTabs.Mode.Update
+            type: StatusBaseButton.Type.Danger
+
+            onClicked: root.removeClicked()
+        }
     }
 }

--- a/ui/app/AppLayouts/Chat/stores/CommunitiesStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/CommunitiesStore.qml
@@ -71,6 +71,40 @@ QtObject {
         }
     }
 
+    readonly property QtObject _d: QtObject {
+        id: d
+
+        function getByKey(model, key) {
+            for (let i = 0; i < model.count; i++) {
+                const item = model.get(i)
+                if (item.key === key)
+                    return item
+            }
+
+            return null
+        }
+    }
+
+    function getTokenByKey(key) {
+        return d.getByKey(tokensModel, key)
+    }
+
+    function getCollectibleByKey(key) {
+        for (let i = 0; i < collectiblesModel.count; i++) {
+            const item = collectiblesModel.get(i)
+
+            if (!!item.subItems) {
+                const sub = d.getByKey(item.subItems, key)
+                if (sub)
+                    return sub
+            } else if (item.key === key) {
+                return item
+            }
+        }
+
+        return null
+    }
+
     function createPermissions(permissions) {
         console.log("TODO: Create permissions - backend call")
     }


### PR DESCRIPTION
### What does the PR do

Adds possibility to edit and remove items from the "Who holds" section of the "New permission" page.

Closes #6339
Depends on https://github.com/status-im/StatusQ/pull/887

### Affected areas

Community settings -> permissions, HoldingsDropdown component

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

https://user-images.githubusercontent.com/20650004/188904493-20f90696-922c-4474-884a-b83c0b55687c.mp4
