### PR TITLE
feat(Community): Add ephemeral notification when request to join was sent

### DIFF
--- a/src/app/modules/main/controller.nim
+++ b/src/app/modules/main/controller.nim
@@ -233,6 +233,9 @@ proc init*(self: Controller) =
   self.events.on(chat_service.SIGNAL_CHAT_LEFT) do(e: Args):
     let args = chat_service.ChatArgs(e)
     self.delegate.onChatLeft(args.chatId)
+  
+  self.events.on(SIGNAL_COMMUNITY_MY_REQUEST_ADDED) do(e: Args):
+    self.delegate.onMyRequestAdded();
 
   self.events.on(SIGNAL_SHARED_KEYCARD_MODULE_FLOW_TERMINATED) do(e: Args):
     let args = SharedKeycarModuleFlowTerminatedArgs(e)

--- a/src/app/modules/main/io_interface.nim
+++ b/src/app/modules/main/io_interface.nim
@@ -216,6 +216,9 @@ method onSharedKeycarModuleFlowTerminated*(self: AccessInterface, lastStepInTheC
 
 method runAuthenticationPopup*(self: AccessInterface, keyUid: string, bip44Path: string, txHash: string) {.base.} =
   raise newException(ValueError, "No implementation available")
+  
+method onMyRequestAdded*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")
 
 # This way (using concepts) is used only for the modules managed by AppController
 type

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -901,6 +901,10 @@ method ephemeralNotificationClicked*[T](self: Module[T], id: int64) =
   else:
     self.osNotificationClicked(item.details)
 
+method onMyRequestAdded*[T](self: Module[T]) =
+    self.displayEphemeralNotification("Your Request has been submitted", "" , "checkmark-circle", false, EphemeralNotificationType.Success.int, "")
+
+
 method onStatusUrlRequested*[T](self: Module[T], action: StatusUrlAction, communityId: string, chatId: string, 
   url: string, userId: string, groupName: string, listOfUserIds: seq[string]) =
   


### PR DESCRIPTION
Part of: #7072

### What does the PR do

Add ephemeral notification when request to join was sent

### Affected areas

Community

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

<img width="850" alt="Снимок экрана 2022-09-07 в 16 33 36" src="https://user-images.githubusercontent.com/82511785/188891484-ea3de8d4-ad0c-41c5-b1dd-d7d694e022d8.png">
