### PR TITLE
feat(Communities): Add ephemerial notification when request to join was accepted

### DIFF
--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -730,6 +730,7 @@ method communityJoined*[T](
     community.joined):
     singletonInstance.globalEvents.myRequestToJoinCommunityAcccepted("Community Request Accepted",
       fmt "Your request to join community {community.name} is accepted", community.id)
+    self.displayEphemeralNotification(fmt "{community.name} membership approved ", "", conf.COMMUNITIESPORTAL_SECTION_ICON, false, EphemeralNotificationType.Success.int, "")
 
   if setActive:
     self.setActiveSection(communitySectionItem)


### PR DESCRIPTION
Part of: #7072

### What does the PR do

 Add ephemerial notification when request to join was accepted

### Affected areas

Communities

### Screenshot of functionality (including design for comparison)

- [ ] I've checked the design and this PR matches it


<img width="472" alt="Снимок экрана 2022-09-07 в 17 46 45" src="https://user-images.githubusercontent.com/82511785/188909054-d0a49b13-8ca0-4695-88ed-233ffbaeea95.png">
