### PR TITLE
fix(@desktop/settings): update display name validation to unblock saveability

### DIFF
--- a/ui/app/AppLayouts/Profile/views/profile/MyProfileSettingsView.qml
+++ b/ui/app/AppLayouts/Profile/views/profile/MyProfileSettingsView.qml
@@ -109,6 +109,7 @@ ColumnLayout {
         }
 
         displayName.text: profileStore.displayName
+        displayName.validationMode: StatusInput.ValidationMode.Always
         bio.text: profileStore.bio
         socialLinksModel: staticSocialLinksSubsetModel
 


### PR DESCRIPTION

Fix #7177

### What does the PR do

Change Profile display name validationMode to force validation of name.

### Affected areas

Desktop Settings

### Screenshot of functionality 

https://user-images.githubusercontent.com/6445843/189145573-4b17c371-3cd8-4e96-93bb-c508c9603059.mp4



