### PR TITLE
feat(Communities): Add button `Join community` to not joined communities

### DIFF
--- a/ui/app/AppLayouts/Chat/views/ChatContentView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatContentView.qml
@@ -54,6 +54,9 @@ ColumnLayout {
 
     property bool stickersLoaded: false
 
+    property var activeSectionData: rootStore.mainModuleInst ? rootStore.mainModuleInst.activeSection || {} : {}
+    property bool isJoined: activeSectionData.joined
+
     // NOTE: Used this property change as it is the current way used for displaying new channel/chat data of content view.
     // If in the future content is loaded dynamically, input focus should be activated when loaded / created content view.
     onHeightChanged: {
@@ -202,6 +205,16 @@ ColumnLayout {
                 Binding on chatInputPlaceholder {
                     when: root.isBlocked
                     value: qsTr("This user has been blocked.")
+                }
+
+                Binding on chatInputPlaceholder {
+                    when: !root.isJoined
+                    value: qsTr("You need to join this community to send messages ")
+                }
+
+                Binding on enabled {
+                    when: !root.isJoined
+                    value: false
                 }
 
                 onSendTransactionCommandButtonClicked: {

--- a/ui/app/AppLayouts/Chat/views/CommunityColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/CommunityColumnView.qml
@@ -94,12 +94,25 @@ Item {
         }
     }
 
+    StatusButton {
+        id: joinCommunityButton
+        text: root.communityData.access === Constants.communityChatOnRequestAccess
+              ? qsTr("Request to join")
+              : qsTr("Join Community")
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.top: communityHeader.bottom
+        anchors.topMargin: 8
+        anchors.bottomMargin: Style.current.halfPadding
+        visible: !communityData.joined
+        onClicked: root.store.requestToJoinCommunity(communityData.id, root.store.userProfileInst.name)
+    }
+
     Loader {
         id: membershipRequests
 
         property int nbRequests: root.communityData.pendingRequestsToJoin.count || 0
 
-        anchors.top: communityHeader.bottom
+        anchors.top: joinCommunityButton.visible ? joinCommunityButton.bottom : communityHeader.bottom
         anchors.topMargin: active ? 8 : 0
         anchors.horizontalCenter: parent.horizontalCenter
 


### PR DESCRIPTION
Part of: #7072

### What does the PR do

Add button `Join community` and block message input to not joined communities. 

### Affected areas

Communities

