### PR TITLE
feat(Communities): Add checking access type in Welcome modal

### DIFF
--- a/ui/app/AppLayouts/Chat/views/CommunityColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/CommunityColumnView.qml
@@ -133,6 +133,7 @@ Item {
             name: communityData.name
             introMessage: communityData.introMessage
             imageSrc: communityData.image
+            accessType: communityData.access
 
             onJoined: root.store.requestToJoinCommunity(communityData.id, root.store.userProfileInst.name)
         }

--- a/ui/imports/shared/popups/CommunityIntroDialog.qml
+++ b/ui/imports/shared/popups/CommunityIntroDialog.qml
@@ -3,6 +3,8 @@ import QtQuick.Controls 2.14
 import QtQuick.Layouts 1.1
 import QtQml.Models 2.14
 
+import utils 1.0
+
 import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
 import StatusQ.Controls 0.1
@@ -14,6 +16,7 @@ StatusDialog {
 
     property string name
     property string introMessage
+    property int accessType
     property url imageSrc
 
     signal joined
@@ -23,7 +26,9 @@ StatusDialog {
     footer: StatusDialogFooter {
         rightButtons: ObjectModel {
             StatusButton {
-                text: qsTr("Join %1").arg(root.name)
+                text: root.accessType === Constants.communityChatOnRequestAccess
+                      ? qsTr("Request to join %1").arg(root.name)
+                      : qsTr("Join %1").arg(root.name)
                 enabled: checkBox.checked
                 onClicked: {
                     root.joined()


### PR DESCRIPTION
Part of: #7072

### What does the PR do

Add checking access type in Welcome modal

### Affected areas

Communities

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it
<img width="704" alt="Снимок экрана 2022-09-08 в 21 13 01" src="https://user-images.githubusercontent.com/82511785/189196097-b824fef8-6468-4418-b8c6-0323b6c48331.png">
<img width="704" alt="Снимок экрана 2022-09-08 в 21 13 12" src="https://user-images.githubusercontent.com/82511785/189196118-de5f90d2-fa7a-42ba-9202-ac64ac8b35ba.png">


