### PR TITLE
fix(@desktop/chat): adjust message length check condition

### DIFF
--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -264,7 +264,7 @@ Rectangle {
                 event.accepted = true;
                 return
             }
-            if (messageInputField.length < messageLimit) {
+            if (messageInputField.length <= messageLimit) {
                 control.sendMessage(event)
                 control.hideExtendedArea();
                 event.accepted = true


### PR DESCRIPTION
Fixes #7131

### What does the PR do

Change message length check condition to allow sending 2000 chars message.

### Affected areas

Desktop Chat

### Screenshot of functionality
https://user-images.githubusercontent.com/6445843/189399107-2b9b3b2e-c0a3-4b23-a953-f4b3e6ae0e78.mp4



