### PR TITLE
feat:(@desktop/activity-center): AC notification categories according new designs

### DIFF
--- a/ui/app/AppLayouts/Chat/popups/ActivityCenterPopup.qml
+++ b/ui/app/AppLayouts/Chat/popups/ActivityCenterPopup.qml
@@ -18,13 +18,18 @@ import "../panels"
 Popup {
     id: root
 
-    enum Filter {
+    enum ActivityCategory {
         All,
+        Admin,
         Mentions,
         Replies,
-        ContactRequests
+        ContactRequests,
+        IdentityVerification,
+        Transactions,
+        Membership,
+        System
     }
-    property int currentFilter: ActivityCenterPopup.Filter.All
+    property int currentActivityCategory: ActivityCenterPopup.ActivityCategory.All
     property bool hasMentions: false
     property bool hasReplies: false
 //    property bool hasContactRequests: false
@@ -74,24 +79,13 @@ Popup {
 
     ActivityCenterPopupTopBarPanel {
         id: activityCenterTopBar
+        width: parent.width
         hasReplies: root.hasReplies
         hasMentions: root.hasMentions
         hideReadNotifications: root.hideReadNotifications
-        allBtnHighlighted: root.currentFilter === ActivityCenterPopup.Filter.All
-        mentionsBtnHighlighted: root.currentFilter === ActivityCenterPopup.Filter.Mentions
-        repliesBtnHighlighted: root.currentFilter === ActivityCenterPopup.Filter.Replies
-        onAllBtnClicked: {
-            root.currentFilter = ActivityCenterPopup.Filter.All;
-        }
-        onRepliesBtnClicked: {
-            root.currentFilter = ActivityCenterPopup.Filter.Replies;
-        }
-        onMentionsBtnClicked: {
-            root.currentFilter = ActivityCenterPopup.Filter.Mentions;
-        }
-        onPreferencesClicked: {
-            root.close()
-            Global.changeAppSectionBySectionType(Constants.appSection.profile, Constants.settingsSubsection.notifications);
+        currentActivityCategory: root.currentActivityCategory
+        onCategoryTriggered: {
+            root.currentActivityCategory = category;
         }
         onMarkAllReadClicked: {
             errorText = root.store.activityCenterModuleInst.markAllActivityCenterNotificationsRead()
@@ -100,6 +94,8 @@ Popup {
 
     StatusScrollView {
         id: scrollView
+        anchors.left: parent.left
+        anchors.right: parent.right
         anchors.top: activityCenterTopBar.bottom
         anchors.topMargin: 13
         anchors.bottom: parent.bottom
@@ -110,7 +106,7 @@ Popup {
 
         Column {
             id: notificationsContainer
-            width: parent.width
+            width: scrollView.availableWidth
             spacing: 0
 
             // TODO remove this once it is handled by the activity center
@@ -120,7 +116,8 @@ Popup {
 
 //                delegate: ContactRequest {
 //                    visible: !hideReadNotifications &&
-//                             (root.currentFilter === ActivityCenter.Filter.All || root.currentFilter === ActivityCenter.Filter.ContactRequests)
+//                             (root.currentActivityCategory === ActivityCenter.ActivityCategory.All ||
+//                              root.currentActivityCategory === ActivityCenter.ActivityCategory.ContactRequests)
 //                    name: Utils.removeStatusEns(model.name)
 //                    address: model.address
 //                    localNickname: model.localNickname
@@ -154,7 +151,7 @@ Popup {
 
                 delegate: Item {
                     id: notificationDelegate
-                    width: parent.width
+                    width: parent.availableWidth
                     height: notifLoader.active ? childrenRect.height : 0
 
                     property int idx: DelegateModel.itemsIndex
@@ -188,7 +185,8 @@ Popup {
                             }
                             return -1;
                         }
-                        property string previousNotificationTimestamp: notificationDelegate.idx === 0 ? "" : root.store.activityCenterList.getNotificationData(previousNotificationIndex, "timestamp")
+                        readonly property string previousNotificationTimestamp: notificationDelegate.idx === 0 ? "" :
+                                                       root.store.activityCenterList.getNotificationData(previousNotificationIndex, "timestamp")
                         onPreviousNotificationTimestampChanged: {
                             root.store.messageStore.prevMsgTimestamp = previousNotificationTimestamp;
                         }
@@ -221,7 +219,7 @@ Popup {
                         ActivityCenterMessageComponentView {
                             id: activityCenterMessageView
                             store: root.store
-                            acCurrentFilter: root.currentFilter
+                            acCurrentActivityCategory: root.currentActivityCategory
                             chatSectionModule: root.chatSectionModule
                             messageContextMenu: root.messageContextMenu
                             hideReadNotifications: root.hideReadNotifications
@@ -244,7 +242,7 @@ Popup {
                         ActivityCenterGroupRequest {
                             store: root.store
                             hideReadNotifications: root.hideReadNotifications
-                            acCurrentFilterAll: root.currentFilter === ActivityCenter.Filter.All
+                            acCurrentActivityCategoryAll: root.currentActivityCategory === ActivityCenter.ActivityCategory.All
                         }
                     }
                 }

--- a/ui/app/AppLayouts/Chat/views/ActivityCenterGroupRequest.qml
+++ b/ui/app/AppLayouts/Chat/views/ActivityCenterGroupRequest.qml
@@ -23,7 +23,7 @@ Item {
     property int previousNotificationIndex
     property int previousNotificationTimestamp
     property bool hideReadNotifications: false
-    property bool acCurrentFilterAll: false
+    property bool acCurrentActivityCategoryAll: false
 
     StatusDateGroupLabel {
         id: dateGroupLbl
@@ -47,7 +47,7 @@ Item {
                 return false
             }
 
-            return acCurrentFilterAll;
+            return acCurrentActivityCategoryAll;
         }
         width: parent.width
         height: visible ? 60 : 0

--- a/ui/app/AppLayouts/Chat/views/ActivityCenterMessageComponentView.qml
+++ b/ui/app/AppLayouts/Chat/views/ActivityCenterMessageComponentView.qml
@@ -24,14 +24,14 @@ Item {
         if (hideReadNotifications && model.read) {
             return false
         }
-        return  acCurrentFilter === ActivityCenterPopup.Filter.All ||
-                (model.notificationType === Constants.activityCenterNotificationTypeMention && acCurrentFilter === ActivityCenterPopup.Filter.Mentions) ||
-                (model.notificationType === Constants.activityCenterNotificationTypeOneToOne && acCurrentFilter === ActivityCenterPopup.Filter.ContactRequests) ||
-                (model.notificationType === Constants.activityCenterNotificationTypeReply && acCurrentFilter === ActivityCenterPopup.Filter.Replies)
+        return acCurrentActivityCategory === ActivityCenterPopup.ActivityCategory.All ||
+                (model.notificationType === Constants.activityCenterNotificationTypeMention && acCurrentActivityCategory === ActivityCenterPopup.ActivityCategory.Mentions) ||
+                (model.notificationType === Constants.activityCenterNotificationTypeOneToOne && acCurrentActivityCategory === ActivityCenterPopup.ActivityCategory.ContactRequests) ||
+                (model.notificationType === Constants.activityCenterNotificationTypeReply && acCurrentActivityCategory === ActivityCenterPopup.ActivityCategory.Replies)
     }
 
     property var store
-    property int acCurrentFilter
+    property int acCurrentActivityCategory
     property var chatSectionModule
     property int previousNotificationIndex
     property bool hideReadNotifications


### PR DESCRIPTION
Close #7161

### What does the PR do

This PR contains is a preparation for new notification categories listed in this epic: *[***](https://github.com/status-im/status-desktop/issues/7070)

### Affected areas

Activity Center

### Screenshot of functionality (including design for comparison)
<img width="585" alt="Screenshot 2022-09-12 at 16 53 14" src="https://user-images.githubusercontent.com/2522130/189659400-3727a51e-2df7-4177-ad28-1c23ed27078e.png">


