### PR TITLE
fix: unbreak User List Panel context menu

### DIFF
--- a/ui/app/AppLayouts/Chat/panels/UserListPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/UserListPanel.qml
@@ -102,7 +102,7 @@ Item {
                     messageContextMenu.myPublicKey = userProfile.pubKey
                     messageContextMenu.selectedUserPublicKey = model.pubKey
                     messageContextMenu.selectedUserDisplayName = model.displayName
-                    messageContextMenu.selectedUserIcon = image.source
+                    messageContextMenu.selectedUserIcon = asset.source
                     messageContextMenu.popup(4, 4)
                 } else if (mouse.button === Qt.LeftButton && !!messageContextMenu) {
                     Global.openProfilePopup(model.pubKey);

--- a/ui/app/AppLayouts/Chat/panels/UserListPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/UserListPanel.qml
@@ -44,15 +44,14 @@ Item {
     StatusListView {
         id: userListView
         objectName: "userListPanel"
-        clip: true
-        ScrollBar.vertical: ScrollBar {
-            policy: ScrollBar.AsNeeded
-        }
+
         anchors {
             top: titleText.bottom
             topMargin: Style.current.padding
             left: parent.left
+            leftMargin: Style.current.halfPadding
             right: parent.right
+            rightMargin: Style.current.halfPadding
             bottom: parent.bottom
             bottomMargin: Style.current.bigPadding
         }
@@ -73,10 +72,7 @@ Item {
         section.property: "onlineStatus"
         section.delegate: (root.width > 58) ? sectionDelegateComponent : null
         delegate: StatusMemberListItem {
-            anchors.left: parent.left
-            anchors.leftMargin: 8
-            anchors.right: parent.right
-            anchors.rightMargin: 8
+            width: ListView.view.width
             nickName: model.localNickname
             userName: model.displayName
             pubKey: Utils.getCompressedPk(model.pubKey)
@@ -95,7 +91,7 @@ Item {
             }
             asset.isImage: (asset.name !== "")
             asset.isLetterIdenticon: (asset.name === "")
-            asset.color:  Utils.colorForColorId(model.colorId)
+            asset.color: Utils.colorForColorId(model.colorId)
             status: model.onlineStatus
             ringSettings.ringSpecModel: Utils.getColorHashAsJson(model.pubKey) // FIXME: use model.colorHash
             onClicked: {
@@ -131,7 +127,7 @@ Item {
                         case Constants.onlineStatus.online:
                             return qsTr("Online")
                         default:
-                             return qsTr("Inactive")
+                            return qsTr("Inactive")
                     }
                 }
             }


### PR DESCRIPTION
### What does the PR do

Unbreaks the context menu of UserListPanel

StatusAssetSettings porting leftover (split into 2 commits for better legibility)

Closes #7302

### Affected areas

UserListPanel

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![Snímek obrazovky z 2022-09-12 18-05-17](https://user-images.githubusercontent.com/5377645/189702365-5ef7d96f-8d99-42c1-9b5b-802e4c032062.png)
