### PR TITLE
fix(MessageView): missing popup from when pin limit is reached

### DIFF
--- a/ui/app/AppLayouts/Chat/views/ChatContentView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatContentView.qml
@@ -90,7 +90,7 @@ ColumnLayout {
 
         onPinnedMessagesLimitReached: {
             if(!chatContentModule) {
-                console.debug("error on open pinned messages limit reached from message context menu - chat content module is not set")
+                console.warn("error on open pinned messages limit reached from message context menu - chat content module is not set")
                 return
             }
             Global.openPopup(Global.pinnedMessagesPopup, {

--- a/ui/app/AppLayouts/Chat/views/ChatHeaderContentView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatHeaderContentView.qml
@@ -5,6 +5,7 @@ import QtQuick.Layouts 1.13
 import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
 import StatusQ.Controls 0.1
+import StatusQ.Core.Utils 0.1 as SQUtils
 
 import utils 1.0
 
@@ -262,7 +263,7 @@ RowLayout {
                 case Constants.chatType.privateGroupChat:
                     return qsTr("%n member(s)", "", chatContentModule.usersModule.model.count)
                 case Constants.chatType.communityChat:
-                    return Utils.linkifyAndXSS(chatContentModule.chatDetails.description).trim()
+                    return SQUtils.Utils.linkifyAndXSS(chatContentModule.chatDetails.description).trim()
                 default:
                     return ""
                 }
@@ -288,7 +289,7 @@ RowLayout {
                     console.debug("error on open pinned messages - chat content module is not set")
                     return
                 }
-                Global.openPopup(pinnedMessagesPopupComponent, {
+                Global.openPopup(Global.pinnedMessagesPopup, {
                                      store: rootStore,
                                      messageStore: root.rootStore.messageStore,
                                      pinnedMessagesModel: chatContentModule.pinnedMessagesModel,

--- a/ui/imports/shared/views/chat/MessageContextMenuView.qml
+++ b/ui/imports/shared/views/chat/MessageContextMenuView.qml
@@ -193,7 +193,7 @@ StatusPopupMenu {
         icon: root.selectedUserIcon
         trustStatus: d.contactDetails && d.contactDetails.trustStatus ? d.contactDetails.trustStatus
                                                                       : Constants.trustStatus.unknown
-        isContact: root.isMyMutualContact
+        isContact: root.isContact
         isCurrentUser: root.isMe
     }
 

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -150,7 +150,7 @@ Loader {
         messageContextMenu.messageSenderId = root.senderId
         messageContextMenu.messageContentType = root.messageContentType
         messageContextMenu.pinnedMessage = root.pinnedMessage
-        messageContextMenu.canPin = d.canPin
+        messageContextMenu.canPin = !!root.messageStore && root.messageStore.getNumberOfPinnedMessages() < Constants.maxNumberOfPins
 
         messageContextMenu.selectedUserPublicKey = root.senderId
         messageContextMenu.selectedUserDisplayName = root.senderDisplayName
@@ -232,8 +232,6 @@ Loader {
     QtObject {
         id: d
 
-        readonly property bool canPin: !!messageStore &&
-                                       messageStore.getNumberOfPinnedMessages() < Constants.maxNumberOfPins
         readonly property int chatButtonSize: 32
 
         property string activeMessage
@@ -732,7 +730,7 @@ Loader {
                                 return;
                             }
 
-                            if (d.canPin) {
+                            if (!!root.messageStore && root.messageStore.getNumberOfPinnedMessages() < Constants.maxNumberOfPins) {
                                 messageStore.pinMessage(root.messageId)
                                 return;
                             }
@@ -742,7 +740,7 @@ Loader {
                                 return;
                             }
 
-                            Global.openPopup(pinnedMessagesPopupComponent, {
+                            Global.openPopup(Global.pinnedMessagesPopup, {
                                                  store: root.rootStore,
                                                  messageStore: messageStore,
                                                  pinnedMessagesModel: chatContentModule.pinnedMessagesModel,


### PR DESCRIPTION
### What does the PR do

Fixes wrong binding/condition when calculating whether (un)pinning of messages is allowed and some warnings when invoking the check (quick button, context menu)

### Affected areas

MessageView

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

Already at the limit (3), can only Unpin:
![Snímek obrazovky z 2022-09-12 18-49-20](https://user-images.githubusercontent.com/5377645/189711212-b29079b9-1154-4000-884b-ea52026a1489.png)

Below limit (2), can Pin:
![Snímek obrazovky z 2022-09-12 18-50-06](https://user-images.githubusercontent.com/5377645/189711348-cf7dfc18-1a4c-4a3d-9eb4-b530b74b9678.png)

Trying to Pin over limit:
![Snímek obrazovky z 2022-09-12 18-51-02](https://user-images.githubusercontent.com/5377645/189711563-d707f663-3a77-44c4-8b14-127102951911.png)

