### PR TITLE
fix: port to StatusButton changes in master

### DIFF
--- a/ui/app/AppLayouts/Browser/popups/AddFavoriteModal.qml
+++ b/ui/app/AppLayouts/Browser/popups/AddFavoriteModal.qml
@@ -86,8 +86,7 @@ ModalPopup {
             placeholderText: qsTr("Paste URL")
             input.rightComponent: StatusButton {
                 anchors.verticalCenter: parent.verticalCenter
-                border.width: 1
-                border.color: Theme.palette.primaryColor1
+                borderColor: Theme.palette.primaryColor1
                 size: StatusBaseButton.Size.Tiny
                 text: qsTr("Paste")
                 onClicked: {

--- a/ui/app/AppLayouts/Chat/popups/community/TransferOwnershipPopup.qml
+++ b/ui/app/AppLayouts/Chat/popups/community/TransferOwnershipPopup.qml
@@ -43,8 +43,7 @@ StatusModal {
             }
             input.rightComponent: StatusButton {
                 anchors.verticalCenter: parent.verticalCenter
-                border.width: 1
-                border.color: Theme.palette.primaryColor1
+                borderColor: Theme.palette.primaryColor1
                 size: StatusBaseButton.Size.Tiny
                 text: qsTr("Copy")
                 onClicked: {

--- a/ui/app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml
+++ b/ui/app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml
@@ -101,6 +101,7 @@ StatusSectionLayout {
                         id: importBtn
                         Layout.fillHeight: true
                         text: qsTr("Import using key")
+                        verticalPadding: 0
                         onClicked: Global.openPopup(importCommunitiesPopupComponent)
                     }
 
@@ -108,6 +109,7 @@ StatusSectionLayout {
                         id: createBtn
                         objectName: "createCommunityButton"
                         Layout.fillHeight: true
+                        verticalPadding: 0
                         text: qsTr("Create New Community")
                         onClicked: {
                             if (localAccountSensitiveSettings.isDiscordImportToolEnabled) {

--- a/ui/app/AppLayouts/Profile/panels/CommunitiesListPanel.qml
+++ b/ui/app/AppLayouts/Profile/panels/CommunitiesListPanel.qml
@@ -48,7 +48,7 @@ StatusListView {
                 objectName: "CommunitiesListPanel_leaveCommunityPopupButton"
                 size: StatusBaseButton.Size.Small
                 type: StatusBaseButton.Type.Danger
-                border.color: "transparent"
+                borderColor: "transparent"
                 text: qsTr("Leave community")
                 onClicked: {
                     Global.openPopup(leaveCommunityPopup, {

--- a/ui/app/AppLayouts/Profile/popups/BackupSeedModal.qml
+++ b/ui/app/AppLayouts/Profile/popups/BackupSeedModal.qml
@@ -40,7 +40,7 @@ StatusStackModal {
         readonly property Item skipButton: StatusButton {
             visible: currentIndex === 0
             normalColor: "transparent"
-            border.color: Theme.palette.baseColor2
+            borderColor: Theme.palette.baseColor2
             text: qsTr("Not Now")
             onClicked: root.close()
         }

--- a/ui/app/AppLayouts/Profile/popups/SendContactRequestModal.qml
+++ b/ui/app/AppLayouts/Profile/popups/SendContactRequestModal.qml
@@ -71,8 +71,7 @@ StatusModal {
         id: pasteButtonComponent
         StatusButton {
             anchors.verticalCenter: parent.verticalCenter
-            border.width: 1
-            border.color: Theme.palette.primaryColor1
+            borderColor: Theme.palette.primaryColor1
             size: StatusBaseButton.Size.Tiny
             text: qsTr("Paste")
             onClicked: {

--- a/ui/app/AppLayouts/Wallet/panels/DerivationPathsPanel.qml
+++ b/ui/app/AppLayouts/Wallet/panels/DerivationPathsPanel.qml
@@ -49,11 +49,8 @@ ColumnLayout {
             size: StatusBaseButton.Size.Tiny
             text: qsTr("Reset")
             font.pixelSize: 15
-            defaultLeftPadding: 0
-            defaultRightPadding: 0
-            defaultTopPadding: 0
-            defaultBottomPadding: 0
-            color: "transparent"
+            padding: 0
+            normalColor: "transparent"
             onClicked: derivationPathSelect.reset()
         }
     }

--- a/ui/app/AppLayouts/Wallet/popups/ReceiveModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/ReceiveModal.qml
@@ -63,10 +63,10 @@ StatusModal {
                 topPadding: 8
                 bottomPadding: 0
                 implicitHeight: 32
-                defaultLeftPadding: 4
+                leftPadding: 4
                 text: name
-                icon.emoji: !!emoji ? emoji: ""
-                icon.emojiSize: Emoji.size.middle
+                asset.emoji: !!emoji ? emoji: ""
+                asset.emojiSize: Emoji.size.middle
                 icon.name: !emoji ? "filled-account": ""
                 normalColor: "transparent"
                 highlighted: index === floatingHeader.currentIndex

--- a/ui/imports/shared/controls/GasSelector.qml
+++ b/ui/imports/shared/controls/GasSelector.qml
@@ -196,8 +196,7 @@ Item {
         anchors.right: parent.right
         anchors.rightMargin: Style.current.bigPadding
         height: 22
-        defaultTopPadding: 2
-        defaultBottomPadding: 2
+        verticalPadding: 2
         size: StatusBaseButton.Size.Tiny
         visible: root.suggestedFees.eip1559Enabled
         text: advancedMode ?

--- a/ui/imports/shared/popups/SendModal.qml
+++ b/ui/imports/shared/popups/SendModal.qml
@@ -312,8 +312,7 @@ StatusDialog {
                         input.rightComponent: RowLayout {
                             StatusButton {
                                 visible: recipientSelector.text === ""
-                                border.width: 1
-                                border.color: Theme.palette.primaryColor1
+                                borderColor: Theme.palette.primaryColor1
                                 size: StatusBaseButton.Size.Tiny
                                 text: qsTr("Paste")
                                 onClicked: recipientSelector.input.edit.paste()

--- a/ui/imports/shared/status/StatusGifPopup/StatusGifColumn.qml
+++ b/ui/imports/shared/status/StatusGifPopup/StatusGifColumn.qml
@@ -63,7 +63,7 @@ Column {
                 rightPadding: (6/104) * thumb.width
                 bottomPadding: (6/104) * thumb.width
                 leftPadding: (6/104) * thumb.width
-                color: "transparent"
+                normalColor: "transparent"
                 visible: !loader.visible && model.id === root.lastHoveredId
                 anchors.right: parent.right
                 anchors.bottom: parent.bottom

--- a/ui/imports/shared/views/NetworksAdvancedCustomRoutingView.qml
+++ b/ui/imports/shared/views/NetworksAdvancedCustomRoutingView.qml
@@ -56,8 +56,7 @@ ColumnLayout {
                 StatusButton {
                     Layout.alignment: Qt.AlignRight
                     Layout.preferredHeight: 22
-                    defaultTopPadding: 0
-                    defaultBottomPadding: 0
+                    verticalPadding: 0
                     size: StatusBaseButton.Size.Small
                     icon.name: "hide"
                     text: qsTr("Show Unpreferred Networks")

--- a/ui/imports/shared/views/SendModalFooter.qml
+++ b/ui/imports/shared/views/SendModalFooter.qml
@@ -94,7 +94,7 @@ Rectangle {
                 objectName: "sendModalFooterSendButton"
                 size: StatusBaseButton.Size.Large
                 normalColor: Theme.palette.primaryColor2
-                disaledColor: Theme.palette.baseColor2
+                disabledColor: Theme.palette.baseColor2
                 enabled: currentGroupValid && !currentGroupPending
                 loading: currentGroupPending
                 onClicked: nextButtonClicked()

--- a/ui/imports/shared/views/SendModalHeader.qml
+++ b/ui/imports/shared/views/SendModalHeader.qml
@@ -41,11 +41,11 @@ StatusFloatingButtonsSelector {
             topPadding: 8
             bottomPadding: 0
             implicitHeight: 32
-            defaultLeftPadding: 4
+            leftPadding: 4
             text: name
             objectName: name
-            icon.emoji: !!emoji ? emoji: ""
-            icon.emojiSize: StatusQUtils.Emoji.size.middle
+            asset.emoji: !!emoji ? emoji: ""
+            asset.emojiSize: StatusQUtils.Emoji.size.middle
             icon.name: !emoji ? "filled-account": ""
             normalColor: "transparent"
             hoverColor: Theme.palette.statusFloatingButtonHighlight

--- a/ui/imports/shared/views/chat/InvitationBubbleView.qml
+++ b/ui/imports/shared/views/chat/InvitationBubbleView.qml
@@ -261,7 +261,6 @@ Item {
                             id: joinBtn
                             anchors.fill: parent
                             anchors.verticalCenter: parent.verticalCenter
-                            radius: 16
                             enabled: true
                             text: qsTr("Unsupported state")
                             onClicked: {


### PR DESCRIPTION
### What does the PR do

unbreaks the startup due to changes in StatusQ/master StatusButton implementation

### Affected areas

ALL

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![Snímek obrazovky z 2022-09-13 10-17-44](https://user-images.githubusercontent.com/5377645/189849037-153914c7-c85d-4374-b654-f1a33873275f.png)
