### PR TITLE
fix: chat header fixes

### DIFF
--- a/ui/app/AppLayouts/Chat/panels/communities/BackUpCommuntyBannerPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/BackUpCommuntyBannerPanel.qml
@@ -10,7 +10,7 @@ import utils 1.0
 
 Rectangle {
     property string communityId
-    signal backupButtonClicked(var mouse)
+    signal backupButtonClicked()
 
     id: root
     height: childrenRect.height + Style.current.padding
@@ -83,7 +83,7 @@ Rectangle {
         anchors.horizontalCenter: parent.horizontalCenter
         anchors.top: backUpText.bottom
         anchors.topMargin: Style.current.padding
-        onClicked: root.backupButtonClicked(mouse)
+        onClicked: root.backupButtonClicked()
     }
 }
 

--- a/ui/app/AppLayouts/Chat/views/ChatHeaderContentView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatHeaderContentView.qml
@@ -21,6 +21,7 @@ RowLayout {
 
     property var rootStore
     property var chatContentModule: root.rootStore.currentChatContentModule()
+    property var emojiPopup
     property int padding: 8
 
     signal searchButtonClicked()

--- a/ui/app/AppLayouts/Chat/views/ChatHeaderContentView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatHeaderContentView.qml
@@ -251,7 +251,6 @@ RowLayout {
 
         StatusChatInfoButton {
             objectName: "chatInfoBtnInHeader"
-            width: Math.min(implicitWidth, parent.width)
             title: chatContentModule? chatContentModule.chatDetails.name : ""
             subTitle: {
                 if(!chatContentModule)
@@ -310,7 +309,7 @@ RowLayout {
                 chatContentModule.unmuteChat()
             }
 
-            sensor.enabled: {
+            hoverEnabled: {
                 if(!chatContentModule)
                     return false
 

--- a/ui/app/AppLayouts/Chat/views/ChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatView.qml
@@ -67,6 +67,7 @@ StatusSectionLayout {
         id: headerContent
         visible: !!root.rootStore.currentChatContentModule()
         rootStore: root.rootStore
+        emojiPopup: root.emojiPopup
         onSearchButtonClicked: root.openAppSearch()
     }
 
@@ -178,7 +179,6 @@ StatusSectionLayout {
 
     ConfirmationDialog {
         id: removeContactConfirmationDialog
-        // % "Remove contact"
         header.title: qsTr("Remove contact")
         confirmationText: qsTr("Are you sure you want to remove this contact?")
         onConfirmButtonClicked: {

--- a/ui/app/AppLayouts/Chat/views/CommunityColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/CommunityColumnView.qml
@@ -55,9 +55,7 @@ Item {
         id: communityHeader
         objectName: "communityHeaderButton"
         title: communityData.name
-        subTitle: communityData.members.count <= 1 ?
-                                     qsTr("1 Member") :
-                                     qsTr("%1 Members").arg(communityData.members.count)
+        subTitle: qsTr("%n Member(s)", "", communityData.members.count)
         asset.name: communityData.image
         asset.color: communityData.color
         asset.isImage: true
@@ -91,6 +89,8 @@ Item {
         StatusToolTip {
             text: qsTr("Start chat")
             visible: parent.hovered
+            orientation: StatusToolTip.Orientation.Bottom
+            y: parent.height + 12
         }
     }
 


### PR DESCRIPTION
### What does the PR do

Small fixes for various issues related to chat header functionality (split into separate commits for better legibility)

- a StatusButton porting leftover (Backup community dialog was broken)
- fix for the Edit community popup emoji selector
- tooltip fix for the community Start chat button
- port changes for StatusChatInfoButton (fixes #7313)

### Affected areas

Chat/ChatHeader

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

Pin counter and new StatusChatInfoButton in the chat toolbar:
![Snímek obrazovky z 2022-09-14 12-48-41](https://user-images.githubusercontent.com/5377645/190134852-2a8e626f-b97d-4796-baf2-0ed669293ca9.png)

Emoji selector in the Edit channel dialog:
![Snímek obrazovky z 2022-09-14 12-48-52](https://user-images.githubusercontent.com/5377645/190134847-08031123-8433-4297-b78e-cd7c7efeaa65.png)

Backup community dialog:
![Snímek obrazovky z 2022-09-14 12-49-11](https://user-images.githubusercontent.com/5377645/190134839-6f306836-ffab-4c8b-8730-7ee93518c463.png)

Start chat tooltip fixed:
![Snímek obrazovky z 2022-09-14 12-53-08](https://user-images.githubusercontent.com/5377645/190135608-a6d9b3e9-9b71-479c-882c-5654dfa60cad.png)
