### PR TITLE
fix(AppMain): Fixed typo that lead to hiding "Back up seed" banner

### DIFF
--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -469,7 +469,7 @@ Item {
                 ModuleWarning {
                     id: secureYourSeedPhrase
                     Layout.fillWidth: true
-                    active: !appMain.rootStore.profileSectionStore.profileStoree.userDeclinedBackupBanner
+                    active: !appMain.rootStore.profileSectionStore.profileStore.userDeclinedBackupBanner
                               && !appMain.rootStore.profileSectionStore.profileStore.privacyStore.mnemonicBackedUp
                     type: ModuleWarning.Danger
                     text: qsTr("Secure your seed phrase")


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/7384

### What does the PR do

There was a typo, so "Back up seed" banner was never visible

### Affected areas

AppMain

### Screenshot of functionality (including design for comparison)

<img width="1012" alt="image" src="https://user-images.githubusercontent.com/25482501/190241153-10d7fd40-a224-4eea-982e-45837c96495e.png">
