### PR TITLE
fix(PinnedMessagesPopup): pinned messages modal design issues

### DIFF
--- a/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
@@ -54,7 +54,6 @@ Item {
     property var contactDetails: Utils.getContactDetailsAsJson(root.activeChatId)
     property bool isUserAdded: root.contactDetails.isAdded
     property bool contactRequestReceived: root.contactDetails.requestReceived
-    property Component pinnedMessagesListPopupComponent
 
     signal openAppSearch()
     signal openStickerPackPopup(string stickerPackId)
@@ -222,7 +221,6 @@ Item {
                             stickersLoaded: root.stickersLoaded
                             isBlocked: model.blocked
                             isActiveChannel: categoryChatLoader.isActiveChannel
-                            pinnedMessagesPopupComponent: root.pinnedMessagesListPopupComponent
                             onOpenStickerPackPopup: {
                                 root.openStickerPackPopup(stickerPackId)
                             }
@@ -271,7 +269,6 @@ Item {
                         stickersLoaded: root.stickersLoaded
                         isBlocked: model.blocked
                         isActiveChannel: chatLoader.isActiveChannel
-                        pinnedMessagesPopupComponent: root.pinnedMessagesListPopupComponent
                         onOpenStickerPackPopup: {
                             root.openStickerPackPopup(stickerPackId)
                         }

--- a/ui/app/AppLayouts/Chat/views/ChatContentView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatContentView.qml
@@ -38,7 +38,6 @@ ColumnLayout {
     property var emojiPopup
     property alias textInputField: chatInput
     property UsersStore usersStore: UsersStore {}
-    property Component pinnedMessagesPopupComponent
 
     onChatContentModuleChanged: {
         root.usersStore.usersModule = root.chatContentModule.usersModule

--- a/ui/app/AppLayouts/Chat/views/ChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatView.qml
@@ -29,7 +29,6 @@ StatusSectionLayout {
 
     property RootStore rootStore
 
-    property Component pinnedMessagesListPopupComponent
     property Component membershipRequestPopup
     property var emojiPopup
     property bool stickersLoaded: false
@@ -84,7 +83,6 @@ StatusSectionLayout {
         parentModule: root.rootStore.chatCommunitySectionModule
         rootStore: root.rootStore
         contactsStore: root.contactsStore
-        pinnedMessagesListPopupComponent: root.pinnedMessagesListPopupComponent
         stickersLoaded: root.stickersLoaded
         emojiPopup: root.emojiPopup
         onOpenStickerPackPopup: {
@@ -160,7 +158,6 @@ StatusSectionLayout {
             store: root.rootStore
             emojiPopup: root.emojiPopup
             hasAddedContacts: root.hasAddedContacts
-            pinnedMessagesPopupComponent: root.pinnedMessagesListPopupComponent
             membershipRequestPopup: root.membershipRequestPopup
             onInfoButtonClicked: root.communityInfoButtonClicked()
             onManageButtonClicked: root.communityManageButtonClicked()

--- a/ui/app/AppLayouts/Chat/views/CommunityColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/CommunityColumnView.qml
@@ -32,7 +32,6 @@ Item {
     property var store
     property bool hasAddedContacts: false
     property var communityData: store.mainModuleInst ? store.mainModuleInst.activeSection || {} : {}
-    property Component pinnedMessagesPopupComponent
     property Component membershipRequestPopup
 
     signal infoButtonClicked

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -428,7 +428,8 @@ Loader {
 
             hideQuickActions: root.isChatBlocked ||
                               root.placeholderMessage ||
-                              root.activityCenterMessage
+                              root.activityCenterMessage ||
+                              root.isInPinnedPopup
 
             overrideBackground: root.activityCenterMessage || root.placeholderMessage
             overrideBackgroundColor: {


### PR DESCRIPTION
- align the dialog to design
- fix radio button logic (it was possible to uncheck a mutually exclusive checked button eventhough it's inside the button group, leaving the Unpin button in an undefined state)
- port to StatusDialog and layouts, dropping a lot of needless code
- remove dead code for passing around the `property Component pinnedMessagesListPopupComponent`; the popup is being invoked via `Global.openPopup()`
- hide quick (hover button) actions inside this popup

Fixes #7315 
Fixes #7316 

### What does the PR do

Fixes various issues with PinnedMessagesPopup

### Affected areas

PinnedMessagesPopup

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

Pinned messages overview:
![Snímek obrazovky z 2022-09-15 00-36-33](https://user-images.githubusercontent.com/5377645/190275077-ca88b96d-036d-43fc-9495-d9ac68cecca2.png)

Choosing a message to unpin (nothing selected yet):
![Snímek obrazovky z 2022-09-15 00-38-02](https://user-images.githubusercontent.com/5377645/190275205-d65c8c9b-f275-4b67-8dc7-4a02b1122f62.png)

Message to unpin selected:
![Snímek obrazovky z 2022-09-15 00-39-30](https://user-images.githubusercontent.com/5377645/190275406-4f211a3a-163d-4855-bf9d-4c6c3cfa17b1.png)

