### PR TITLE
fix(CommunityColumnView): Mute button in the chat list is not working

### DIFF
--- a/ui/app/AppLayouts/Chat/views/CommunityColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/CommunityColumnView.qml
@@ -192,8 +192,7 @@ Item {
             showCategoryActionButtons: communityData.amISectionAdmin
             showPopupMenu: communityData.amISectionAdmin && communityData.canManageUsers
 
-            // onChatItemSelected: root.store.chatsModelInst.channelView.setActiveChannel(id)
-            // onChatItemUnmuted: root.store.chatsModelInst.channelView.unmuteChatItem(id)
+            onChatItemUnmuted: root.communitySectionModule.unmuteChat(id)
             onChatItemReordered: function(categoryId, chatId, from, to){
                 root.store.reorderCommunityChat(categoryId, chatId, to)
             }


### PR DESCRIPTION
Fixes #7370

### What does the PR do

Fixes unmuting a chat from the chat list

### Affected areas

CommunityColumnView

### Screenshot of functionality (including design for comparison)

- [N/A] I've checked the design and this PR matches it

