### PR TITLE
refactor(@desktop/keycard): buttons' responibility in the keycard popup improved

### DIFF
--- a/src/app/modules/shared_modules/keycard_popup/internal/create_pin_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/create_pin_state.nim
@@ -15,11 +15,11 @@ method executeBackCommand*(self: CreatePinState, controller: Controller) =
     if not self.getBackState.isNil and self.getBackState.stateType == StateType.SelectExistingKeyPair:
       controller.cancelCurrentFlow()
 
-method executeSecondaryCommand*(self: CreatePinState, controller: Controller) =
+method executeTertiaryCommand*(self: CreatePinState, controller: Controller) =
   if self.flowType == FlowType.SetupNewKeycard:
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)
 
-method getNextTertiaryState*(self: CreatePinState, controller: Controller): State =
+method getNextSecondaryState*(self: CreatePinState, controller: Controller): State =
   if self.flowType == FlowType.SetupNewKeycard:
     if controller.getPin().len == PINLengthForStatusApp:
       return createState(StateType.RepeatPin, self.flowType, self)

--- a/src/app/modules/shared_modules/keycard_popup/internal/enter_pin_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/enter_pin_state.nim
@@ -17,20 +17,19 @@ method getNextPrimaryState*(self: EnterPinState, controller: Controller): State 
       controller.enterKeycardPin(controller.getPin())
 
 method executeSecondaryCommand*(self: EnterPinState, controller: Controller) =
-  if self.flowType == FlowType.FactoryReset or
-    self.flowType == FlowType.SetupNewKeycard:
-      controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)
+  if self.flowType == FlowType.SetupNewKeycard or
+    self.flowType == FlowType.FactoryReset:
+      if controller.getPin().len == PINLengthForStatusApp:
+        controller.enterKeycardPin(controller.getPin())  
   if self.flowType == FlowType.Authentication:
     controller.setUsePinFromBiometrics(false)
     controller.tryToObtainDataFromKeychain()
 
 method executeTertiaryCommand*(self: EnterPinState, controller: Controller) =
-  if self.flowType == FlowType.SetupNewKeycard or
-    self.flowType == FlowType.FactoryReset:
-      if controller.getPin().len == PINLengthForStatusApp:
-        controller.enterKeycardPin(controller.getPin())
-  if self.flowType == FlowType.Authentication:
-    controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)
+  if self.flowType == FlowType.FactoryReset or
+    self.flowType == FlowType.SetupNewKeycard or
+    self.flowType == FlowType.Authentication:
+      controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)
 
 method resolveKeycardNextState*(self: EnterPinState, keycardFlowType: string, keycardEvent: KeycardEvent, 
   controller: Controller): State =

--- a/src/app/modules/shared_modules/keycard_popup/internal/enter_seed_phrase_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/enter_seed_phrase_state.nim
@@ -19,7 +19,7 @@ method executePrimaryCommand*(self: EnterSeedPhraseState, controller: Controller
     else:
       controller.setKeycardData(getPredefinedKeycardData(controller.getKeycardData(), PredefinedKeycardData.WrongSeedPhrase, add = true))
 
-method executeSecondaryCommand*(self: EnterSeedPhraseState, controller: Controller) =
+method executeTertiaryCommand*(self: EnterSeedPhraseState, controller: Controller) =
   if self.flowType == FlowType.SetupNewKeycard:
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)
 

--- a/src/app/modules/shared_modules/keycard_popup/internal/factory_reset_confirmation_displayed_metadata_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/factory_reset_confirmation_displayed_metadata_state.nim
@@ -15,10 +15,10 @@ method executePrimaryCommand*(self: FactoryResetConfirmationDisplayMetadataState
     controller.setKeycardData(getPredefinedKeycardData(controller.getKeycardData(), PredefinedKeycardData.HideKeyPair, add = true))
     controller.runGetAppInfoFlow(factoryReset = true)
     
-method executeSecondaryCommand*(self: FactoryResetConfirmationDisplayMetadataState, controller: Controller) =
+method executeTertiaryCommand*(self: FactoryResetConfirmationDisplayMetadataState, controller: Controller) =
   if self.flowType == FlowType.FactoryReset or
     self.flowType == FlowType.SetupNewKeycard:
-    controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)
+      controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)
 
 method resolveKeycardNextState*(self: FactoryResetConfirmationDisplayMetadataState, keycardFlowType: string, keycardEvent: KeycardEvent, 
   controller: Controller): State =

--- a/src/app/modules/shared_modules/keycard_popup/internal/factory_reset_confirmation_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/factory_reset_confirmation_state.nim
@@ -15,7 +15,7 @@ method executePrimaryCommand*(self: FactoryResetConfirmationState, controller: C
     controller.setKeycardData(getPredefinedKeycardData(controller.getKeycardData(), PredefinedKeycardData.HideKeyPair, add = true))
     controller.runGetAppInfoFlow(factoryReset = true)
     
-method executeSecondaryCommand*(self: FactoryResetConfirmationState, controller: Controller) =
+method executeTertiaryCommand*(self: FactoryResetConfirmationState, controller: Controller) =
   if self.flowType == FlowType.FactoryReset or
     self.flowType == FlowType.SetupNewKeycard:
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)

--- a/src/app/modules/shared_modules/keycard_popup/internal/factory_reset_success_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/factory_reset_success_state.nim
@@ -14,7 +14,7 @@ method executePrimaryCommand*(self: FactoryResetSuccessState, controller: Contro
   elif self.flowType == FlowType.SetupNewKeycard:
     controller.runLoadAccountFlow()
 
-method executeSecondaryCommand*(self: FactoryResetSuccessState, controller: Controller) =
+method executeTertiaryCommand*(self: FactoryResetSuccessState, controller: Controller) =
   if self.flowType == FlowType.SetupNewKeycard:
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = true)
 

--- a/src/app/modules/shared_modules/keycard_popup/internal/insert_keycard_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/insert_keycard_state.nim
@@ -19,8 +19,10 @@ method executePrimaryCommand*(self: InsertKeycardState, controller: Controller) 
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)
 
 method executeTertiaryCommand*(self: InsertKeycardState, controller: Controller) =
-  if self.flowType == FlowType.Authentication:
-    controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)
+  if self.flowType == FlowType.FactoryReset or
+    self.flowType == FlowType.SetupNewKeycard or
+    self.flowType == FlowType.Authentication:
+      controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)
 
 method resolveKeycardNextState*(self: InsertKeycardState, keycardFlowType: string, keycardEvent: KeycardEvent, 
   controller: Controller): State =

--- a/src/app/modules/shared_modules/keycard_popup/internal/key_pair_migrate_failure_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/key_pair_migrate_failure_state.nim
@@ -8,6 +8,6 @@ proc newKeyPairMigrateFailureState*(flowType: FlowType, backState: State): KeyPa
 proc delete*(self: KeyPairMigrateFailureState) =
   self.State.delete
 
-method executePrimaryCommand*(self: KeyPairMigrateFailureState, controller: Controller) =
+method executeTertiaryCommand*(self: KeyPairMigrateFailureState, controller: Controller) =
   if self.flowType == FlowType.SetupNewKeycard:
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = true)

--- a/src/app/modules/shared_modules/keycard_popup/internal/keycard_empty_metadata_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/keycard_empty_metadata_state.nim
@@ -8,7 +8,7 @@ proc newKeycardEmptyMetadataState*(flowType: FlowType, backState: State): Keycar
 proc delete*(self: KeycardEmptyMetadataState) =
   self.State.delete
 
-method executeSecondaryCommand*(self: KeycardEmptyMetadataState, controller: Controller) =
+method executeTertiaryCommand*(self: KeycardEmptyMetadataState, controller: Controller) =
   if self.flowType == FlowType.FactoryReset or
     self.flowType == FlowType.SetupNewKeycard:
       controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)

--- a/src/app/modules/shared_modules/keycard_popup/internal/keycard_empty_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/keycard_empty_state.nim
@@ -8,11 +8,8 @@ proc newKeycardEmptyState*(flowType: FlowType, backState: State): KeycardEmptySt
 proc delete*(self: KeycardEmptyState) =
   self.State.delete
 
-method executePrimaryCommand*(self: KeycardEmptyState, controller: Controller) =
-  if self.flowType == FlowType.FactoryReset or
-    self.flowType == FlowType.SetupNewKeycard:
-    controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)
-
 method executeTertiaryCommand*(self: KeycardEmptyState, controller: Controller) =
-  if self.flowType == FlowType.Authentication:
-    controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)
+  if self.flowType == FlowType.FactoryReset or
+    self.flowType == FlowType.SetupNewKeycard or
+    self.flowType == FlowType.Authentication:
+      controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)

--- a/src/app/modules/shared_modules/keycard_popup/internal/keycard_inserted_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/keycard_inserted_state.nim
@@ -20,11 +20,8 @@ method getNextSecondaryState*(self: KeycardInsertedState, controller: Controller
     return createState(StateType.ReadingKeycard, self.flowType, self.getBackState)
   return createState(StateType.ReadingKeycard, self.flowType, nil)
 
-method executePrimaryCommand*(self: KeycardInsertedState, controller: Controller) =
-  if self.flowType == FlowType.FactoryReset or
-    self.flowType == FlowType.SetupNewKeycard:
-      controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)
-
 method executeTertiaryCommand*(self: KeycardInsertedState, controller: Controller) =
-  if self.flowType == FlowType.Authentication:
-    controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)
+  if self.flowType == FlowType.FactoryReset or
+    self.flowType == FlowType.SetupNewKeycard or
+    self.flowType == FlowType.Authentication:
+      controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)

--- a/src/app/modules/shared_modules/keycard_popup/internal/keycard_locked_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/keycard_locked_state.nim
@@ -12,6 +12,6 @@ method getNextPrimaryState*(self: KeycardLockedState, controller: Controller): S
   if self.flowType == FlowType.SetupNewKeycard:
     return createState(StateType.FactoryResetConfirmation, self.flowType, self)
 
-method executeSecondaryCommand*(self: KeycardLockedState, controller: Controller) =
+method executeTertiaryCommand*(self: KeycardLockedState, controller: Controller) =
   if self.flowType == FlowType.SetupNewKeycard:
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)

--- a/src/app/modules/shared_modules/keycard_popup/internal/keycard_metadata_display_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/keycard_metadata_display_state.nim
@@ -14,7 +14,7 @@ method getNextPrimaryState*(self: KeycardMetadataDisplayState, controller: Contr
       return createState(StateType.FactoryResetConfirmationDisplayMetadata, self.flowType, self)
   return nil
 
-method executeSecondaryCommand*(self: KeycardMetadataDisplayState, controller: Controller) =
+method executeTertiaryCommand*(self: KeycardMetadataDisplayState, controller: Controller) =
   if self.flowType == FlowType.FactoryReset or
     self.flowType == FlowType.SetupNewKeycard:
       controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)

--- a/src/app/modules/shared_modules/keycard_popup/internal/keycard_not_empty_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/keycard_not_empty_state.nim
@@ -13,7 +13,7 @@ method executePrimaryCommand*(self: KeycardNotEmptyState, controller: Controller
     controller.setKeycardData(getPredefinedKeycardData(controller.getKeycardData(), PredefinedKeycardData.HideKeyPair, add = true))
     controller.runGetMetadataFlow()
 
-method executeSecondaryCommand*(self: KeycardNotEmptyState, controller: Controller) =
+method executeTertiaryCommand*(self: KeycardNotEmptyState, controller: Controller) =
   if self.flowType == FlowType.SetupNewKeycard:
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)
 

--- a/src/app/modules/shared_modules/keycard_popup/internal/max_pin_retries_reached_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/max_pin_retries_reached_state.nim
@@ -17,11 +17,8 @@ method getNextPrimaryState*(self: MaxPinRetriesReachedState, controller: Control
       debug "Run Unlock Keycard flow... (not developed yet)"
   return nil
 
-method executeSecondaryCommand*(self: MaxPinRetriesReachedState, controller: Controller) =
-  if self.flowType == FlowType.FactoryReset or
-    self.flowType == FlowType.SetupNewKeycard:
-      controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)
-
 method executeTertiaryCommand*(self: MaxPinRetriesReachedState, controller: Controller) =
-  if self.flowType == FlowType.Authentication:
-    controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)
+  if self.flowType == FlowType.FactoryReset or
+    self.flowType == FlowType.SetupNewKeycard or
+    self.flowType == FlowType.Authentication:
+      controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)

--- a/src/app/modules/shared_modules/keycard_popup/internal/migrating_key_pair_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/migrating_key_pair_state.nim
@@ -10,7 +10,7 @@ proc newMigratingKeyPairState*(flowType: FlowType, backState: State): MigratingK
 proc delete*(self: MigratingKeyPairState) =
   self.State.delete
 
-method procDoMigration(self: MigratingKeyPairState, controller: Controller) =
+proc doMigration(self: MigratingKeyPairState, controller: Controller) =
   if self.flowType == FlowType.SetupNewKeycard:
     let password = controller.getPassword()
     controller.setPassword("")
@@ -34,11 +34,11 @@ method executePrimaryCommand*(self: MigratingKeyPairState, controller: Controlle
     if controller.getSelectedKeyPairIsProfile():
       controller.authenticateUser()
     else:
-      self.procDoMigration(controller)
+      self.doMigration(controller)
 
 method executeSecondaryCommand*(self: MigratingKeyPairState, controller: Controller) =
   if self.flowType == FlowType.SetupNewKeycard:
-    self.procDoMigration(controller)
+    self.doMigration(controller)
 
 method getNextSecondaryState*(self: MigratingKeyPairState, controller: Controller): State =
   if self.flowType == FlowType.SetupNewKeycard:

--- a/src/app/modules/shared_modules/keycard_popup/internal/not_keycard_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/not_keycard_state.nim
@@ -8,11 +8,8 @@ proc newNotKeycardState*(flowType: FlowType, backState: State): NotKeycardState 
 proc delete*(self: NotKeycardState) =
   self.State.delete
 
-method executePrimaryCommand*(self: NotKeycardState, controller: Controller) =
-  if self.flowType == FlowType.FactoryReset or
-    self.flowType == FlowType.SetupNewKeycard:
-      controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)
-
 method executeTertiaryCommand*(self: NotKeycardState, controller: Controller) =
-  if self.flowType == FlowType.Authentication:
-    controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)
+  if self.flowType == FlowType.FactoryReset or
+    self.flowType == FlowType.SetupNewKeycard or
+    self.flowType == FlowType.Authentication:
+      controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)

--- a/src/app/modules/shared_modules/keycard_popup/internal/pin_set_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/pin_set_state.nim
@@ -16,6 +16,6 @@ method getNextPrimaryState*(self: PinSetState, controller: Controller): State =
       return createState(StateType.SeedPhraseDisplay, self.flowType, nil)
   return nil
 
-method executeSecondaryCommand*(self: PinSetState, controller: Controller) =
+method executeTertiaryCommand*(self: PinSetState, controller: Controller) =
   if self.flowType == FlowType.SetupNewKeycard:
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)

--- a/src/app/modules/shared_modules/keycard_popup/internal/pin_verified_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/pin_verified_state.nim
@@ -14,7 +14,7 @@ method getNextPrimaryState*(self: PinVerifiedState, controller: Controller): Sta
       return createState(StateType.KeycardMetadataDisplay, self.flowType, nil)
   return nil
 
-method executeSecondaryCommand*(self: PinVerifiedState, controller: Controller) =
+method executeTertiaryCommand*(self: PinVerifiedState, controller: Controller) =
   if self.flowType == FlowType.FactoryReset or
     self.flowType == FlowType.SetupNewKeycard:
       controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)

--- a/src/app/modules/shared_modules/keycard_popup/internal/plugin_reader_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/plugin_reader_state.nim
@@ -13,14 +13,11 @@ method executeBackCommand*(self: PluginReaderState, controller: Controller) =
     if not self.getBackState.isNil and self.getBackState.stateType == StateType.SelectExistingKeyPair:
       controller.cancelCurrentFlow()
 
-method executePrimaryCommand*(self: PluginReaderState, controller: Controller) =
-  if self.flowType == FlowType.FactoryReset or
-    self.flowType == FlowType.SetupNewKeycard:
-    controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)
-
 method executeTertiaryCommand*(self: PluginReaderState, controller: Controller) =
-  if self.flowType == FlowType.Authentication:
-    controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)
+  if self.flowType == FlowType.FactoryReset or
+    self.flowType == FlowType.SetupNewKeycard or
+    self.flowType == FlowType.Authentication:
+      controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)
 
 method resolveKeycardNextState*(self: PluginReaderState, keycardFlowType: string, keycardEvent: KeycardEvent, 
   controller: Controller): State =

--- a/src/app/modules/shared_modules/keycard_popup/internal/reading_keycard_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/reading_keycard_state.nim
@@ -13,14 +13,11 @@ method executeBackCommand*(self: ReadingKeycardState, controller: Controller) =
     if not self.getBackState.isNil and self.getBackState.stateType == StateType.SelectExistingKeyPair:
       controller.cancelCurrentFlow()
 
-method executePrimaryCommand*(self: ReadingKeycardState, controller: Controller) =
-  if self.flowType == FlowType.FactoryReset or
-    self.flowType == FlowType.SetupNewKeycard:
-    controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)
-
 method executeTertiaryCommand*(self: ReadingKeycardState, controller: Controller) =
-  if self.flowType == FlowType.Authentication:
-    controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)
+  if self.flowType == FlowType.FactoryReset or
+    self.flowType == FlowType.SetupNewKeycard or
+    self.flowType == FlowType.Authentication:
+      controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)
 
 method getNextSecondaryState*(self: ReadingKeycardState, controller: Controller): State =
   let (flowType, flowEvent) = controller.getLastReceivedKeycardData()

--- a/src/app/modules/shared_modules/keycard_popup/internal/recognized_keycard_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/recognized_keycard_state.nim
@@ -13,10 +13,10 @@ method executeBackCommand*(self: RecognizedKeycardState, controller: Controller)
     if not self.getBackState.isNil and self.getBackState.stateType == StateType.SelectExistingKeyPair:
       controller.cancelCurrentFlow()
 
-method executePrimaryCommand*(self: RecognizedKeycardState, controller: Controller) =
+method executeTertiaryCommand*(self: RecognizedKeycardState, controller: Controller) =
   if self.flowType == FlowType.FactoryReset or
     self.flowType == FlowType.SetupNewKeycard:
-    controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)
+      controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)
 
 method getNextSecondaryState*(self: RecognizedKeycardState, controller: Controller): State =
   if self.flowType == FlowType.FactoryReset:

--- a/src/app/modules/shared_modules/keycard_popup/internal/repeat_pin_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/repeat_pin_state.nim
@@ -13,14 +13,14 @@ method executeBackCommand*(self: RepeatPinState, controller: Controller) =
   controller.setPinMatch(false)
 
 method executeSecondaryCommand*(self: RepeatPinState, controller: Controller) =
-  if self.flowType == FlowType.SetupNewKeycard:
-    controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)
-
-method executeTertiaryCommand*(self: RepeatPinState, controller: Controller) =
   if not controller.getPinMatch():
     return
   if self.flowType == FlowType.SetupNewKeycard:
-    controller.storePinToKeycard(controller.getPin(), controller.generateRandomPUK())
+    controller.storePinToKeycard(controller.getPin(), controller.generateRandomPUK())  
+
+method executeTertiaryCommand*(self: RepeatPinState, controller: Controller) =
+  if self.flowType == FlowType.SetupNewKeycard:
+    controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)
      
 method resolveKeycardNextState*(self: RepeatPinState, keycardFlowType: string, keycardEvent: KeycardEvent, 
   controller: Controller): State =

--- a/src/app/modules/shared_modules/keycard_popup/internal/seed_phrase_display_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/seed_phrase_display_state.nim
@@ -8,7 +8,7 @@ proc newSeedPhraseDisplayState*(flowType: FlowType, backState: State): SeedPhras
 proc delete*(self: SeedPhraseDisplayState) =
   self.State.delete
 
-method executeSecondaryCommand*(self: SeedPhraseDisplayState, controller: Controller) =
+method executeTertiaryCommand*(self: SeedPhraseDisplayState, controller: Controller) =
   if self.flowType == FlowType.SetupNewKeycard:
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)
 

--- a/src/app/modules/shared_modules/keycard_popup/internal/seed_phrase_enter_words_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/seed_phrase_enter_words_state.nim
@@ -14,7 +14,7 @@ method executePrimaryCommand*(self: SeedPhraseEnterWordsState, controller: Contr
   let mnemonic = controller.getMnemonic()
   controller.storeSeedPhraseToKeycard(mnemonic.split(" ").len, mnemonic)
 
-method executeSecondaryCommand*(self: SeedPhraseEnterWordsState, controller: Controller) =
+method executeTertiaryCommand*(self: SeedPhraseEnterWordsState, controller: Controller) =
   if self.flowType == FlowType.SetupNewKeycard:
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)
 

--- a/src/app/modules/shared_modules/keycard_popup/internal/select_existing_key_pair_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/select_existing_key_pair_state.nim
@@ -12,7 +12,7 @@ method executePrimaryCommand*(self: SelectExistingKeyPairState, controller: Cont
   if self.flowType == FlowType.SetupNewKeycard:
     controller.runLoadAccountFlow()
 
-method executeSecondaryCommand*(self: SelectExistingKeyPairState, controller: Controller) =
+method executeTertiaryCommand*(self: SelectExistingKeyPairState, controller: Controller) =
   if self.flowType == FlowType.SetupNewKeycard:
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)
 

--- a/src/app/modules/shared_modules/keycard_popup/internal/wrong_pin_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/wrong_pin_state.nim
@@ -20,18 +20,17 @@ method getNextPrimaryState*(self: WrongPinState, controller: Controller): State 
 method executeSecondaryCommand*(self: WrongPinState, controller: Controller) =
   if self.flowType == FlowType.FactoryReset or
     self.flowType == FlowType.SetupNewKeycard:
-      controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)
+      if controller.getPin().len == PINLengthForStatusApp:
+        controller.enterKeycardPin(controller.getPin())  
   if self.flowType == FlowType.Authentication:
     controller.setUsePinFromBiometrics(false)
     controller.tryToObtainDataFromKeychain()
 
 method executeTertiaryCommand*(self: WrongPinState, controller: Controller) =
   if self.flowType == FlowType.FactoryReset or
-    self.flowType == FlowType.SetupNewKeycard:
-      if controller.getPin().len == PINLengthForStatusApp:
-        controller.enterKeycardPin(controller.getPin())
-  if self.flowType == FlowType.Authentication:
-    controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)
+    self.flowType == FlowType.SetupNewKeycard or
+    self.flowType == FlowType.Authentication:
+      controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)
 
 method resolveKeycardNextState*(self: WrongPinState, keycardFlowType: string, keycardEvent: KeycardEvent, 
   controller: Controller): State =

--- a/src/app/modules/shared_modules/keycard_popup/internal/wrong_seed_phrase_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/wrong_seed_phrase_state.nim
@@ -23,7 +23,7 @@ method executePrimaryCommand*(self: WrongSeedPhraseState, controller: Controller
     else:
       controller.setKeycardData(getPredefinedKeycardData(controller.getKeycardData(), PredefinedKeycardData.WrongSeedPhrase, add = true))
 
-method executeSecondaryCommand*(self: WrongSeedPhraseState, controller: Controller) =
+method executeTertiaryCommand*(self: WrongSeedPhraseState, controller: Controller) =
   if self.flowType == FlowType.SetupNewKeycard:
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)
 

--- a/ui/imports/shared/popups/keycard/KeycardPopup.qml
+++ b/ui/imports/shared/popups/keycard/KeycardPopup.qml
@@ -55,6 +55,7 @@ StatusModal {
         property bool primaryButtonEnabled: false
         property bool seedPhraseRevealed: false
         readonly property bool disablePopupClose: root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.readingKeycard ||
+                                                  root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.recognizedKeycard ||
                                                   root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.migratingKeyPair ||
                                                   (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keyPairMigrateSuccess &&
                                                    root.sharedKeycardModule.migratingProfileKeyPair())
@@ -65,72 +66,7 @@ StatusModal {
     }
 
     onClosed: {
-        if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.setupNewKeycard) {
-            if (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.selectExistingKeyPair ||
-                    root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardNotEmpty ||
-                    root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardLocked ||
-                    root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardEmptyMetadata ||
-                    root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.createPin ||
-                    root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.repeatPin ||
-                    root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.pinSet ||
-                    root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.pinVerified ||
-                    root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.enterPin ||
-                    root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.wrongPin ||
-                    root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPinRetriesReached ||
-                    root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.factoryResetConfirmation ||
-                    root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.factoryResetConfirmationDisplayMetadata ||
-                    root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.factoryResetSuccess ||
-                    root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.seedPhraseDisplay ||
-                    root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.seedPhraseEnterWords ||
-                    root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardMetadataDisplay ||
-                    root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.enterSeedPhrase ||
-                    root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.wrongSeedPhrase)
-            {
-                root.sharedKeycardModule.currentState.doSecondaryAction()
-                return
-            }
-        }
-        if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.factoryReset) {
-            if (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.selectExistingKeyPair ||
-                    root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.pinVerified ||
-                    root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.enterPin ||
-                    root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.wrongPin ||
-                    root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPinRetriesReached ||
-                    root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardMetadataDisplay ||
-                    root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardEmptyMetadata ||
-                    root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.factoryResetConfirmationDisplayMetadata ||
-                    root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.factoryResetConfirmation)
-            {
-                root.sharedKeycardModule.currentState.doSecondaryAction()
-                return
-            }
-        }
-        if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.authentication) {
-            if (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.pluginReader ||
-                    root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.insertKeycard ||
-                    root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardInserted ||
-                    root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.readingKeycard ||
-                    root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.enterPin ||
-                    root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.wrongPin ||
-                    root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.enterPassword ||
-                    root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.biometricsPasswordFailed ||
-                    root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.biometricsPinFailed ||
-                    root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.biometricsPinInvalid ||
-                    root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.enterBiometricsPassword ||
-                    root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.wrongBiometricsPassword ||
-                    root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.wrongPassword ||
-                    root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardEmpty ||
-                    root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.wrongKeychainPin ||
-                    root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.biometricsReadyToSign ||
-                    root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPinRetriesReached ||
-                    root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.notKeycard ||
-                    root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.wrongKeycard)
-            {
-                root.sharedKeycardModule.currentState.doTertiaryAction()
-                return
-            }
-        }
-        root.sharedKeycardModule.currentState.doPrimaryAction()
+        root.sharedKeycardModule.currentState.doTertiaryAction()
     }
 
     contentItem: Item {
@@ -339,117 +275,7 @@ StatusModal {
         StatusButton {
             id: tertiaryButton
             height: Constants.keycard.general.footerButtonsHeight
-            text: {
-                if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.authentication) {
-                    if (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.pluginReader ||
-                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.readingKeycard ||
-                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.insertKeycard ||
-                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardInserted ||
-                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardEmpty ||
-                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.wrongPin ||
-                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.wrongKeychainPin ||
-                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.biometricsReadyToSign ||
-                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPinRetriesReached ||
-                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.notKeycard ||
-                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.wrongKeycard ||
-                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.enterPassword ||
-                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.wrongPassword ||
-                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.biometricsPasswordFailed ||
-                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.biometricsPinFailed ||
-                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.biometricsPinInvalid ||
-                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.enterBiometricsPassword ||
-                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.wrongBiometricsPassword ||
-                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.enterPin)
-                        return qsTr("Cancel")
-                }
-                return ""
-            }
-            visible: {
-                if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.authentication) {
-                    if (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.pluginReader ||
-                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.readingKeycard ||
-                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.insertKeycard ||
-                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardInserted ||
-                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardEmpty ||
-                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.wrongPin ||
-                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.wrongKeychainPin ||
-                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.biometricsReadyToSign ||
-                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPinRetriesReached ||
-                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.notKeycard ||
-                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.wrongKeycard ||
-                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.enterPassword ||
-                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.wrongPassword ||
-                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.biometricsPasswordFailed ||
-                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.biometricsPinFailed ||
-                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.biometricsPinInvalid ||
-                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.enterBiometricsPassword ||
-                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.wrongBiometricsPassword ||
-                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.enterPin)
-                        return true
-                }
-                return false
-            }
-
-            onClicked: {
-                root.sharedKeycardModule.currentState.doTertiaryAction()
-            }
-        },
-        StatusButton {
-            id: secondaryButton
-            height: Constants.keycard.general.footerButtonsHeight
-            text: {
-                if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.setupNewKeycard) {
-                    if (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.selectExistingKeyPair ||
-                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardNotEmpty ||
-                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardLocked ||
-                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardEmptyMetadata ||
-                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.enterPin ||
-                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.wrongPin ||
-                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPinRetriesReached ||
-                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.factoryResetConfirmation ||
-                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.factoryResetConfirmationDisplayMetadata ||
-                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.factoryResetSuccess ||
-                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.pinVerified ||
-                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardMetadataDisplay) {
-                        return qsTr("Cancel")
-                    }
-                }
-                if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.factoryReset) {
-                    if (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.pinVerified ||
-                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.enterPin ||
-                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.wrongPin ||
-                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPinRetriesReached ||
-                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardMetadataDisplay ||
-                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardEmptyMetadata ||
-                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.factoryResetConfirmationDisplayMetadata ||
-                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.factoryResetConfirmation)
-                        return qsTr("Cancel")
-                }
-                if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.authentication) {
-                    if (root.sharedKeycardModule.loggedInUserUsesBiometricLogin()) {
-                        if (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.enterPassword ||
-                                root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.wrongPassword)
-                            return qsTr("Use biometrics instead")
-                        if (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.biometricsPasswordFailed)
-                            return qsTr("Use password instead")
-                        if (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.enterPin ||
-                                root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.wrongPin)
-                            return qsTr("Use biometrics")
-                        if (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.pluginReader ||
-                                root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.insertKeycard ||
-                                root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardInserted ||
-                                root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.readingKeycard ||
-                                root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.biometricsReadyToSign ||
-                                root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.notKeycard ||
-                                root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.biometricsPinFailed ||
-                                root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.biometricsPinInvalid ||
-                                root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.wrongKeycard ||
-                                root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardEmpty)
-                            return qsTr("Use PIN")
-                    }
-                }
-                return ""
-            }
+            text: qsTr("Cancel")
             visible: {
                 if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.setupNewKeycard) {
                     if (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.selectExistingKeyPair ||
@@ -479,6 +305,66 @@ StatusModal {
                         return true
                     }
                 }
+                if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.authentication) {
+                    if (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.pluginReader ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.readingKeycard ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.insertKeycard ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardInserted ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardEmpty ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.wrongPin ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.wrongKeychainPin ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.biometricsReadyToSign ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPinRetriesReached ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.notKeycard ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.wrongKeycard ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.enterPassword ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.wrongPassword ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.biometricsPasswordFailed ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.biometricsPinFailed ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.biometricsPinInvalid ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.enterBiometricsPassword ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.wrongBiometricsPassword ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.enterPin)
+                        return true
+                }
+
+                return false
+            }
+
+            onClicked: {
+                root.sharedKeycardModule.currentState.doTertiaryAction()
+            }
+        },
+        StatusButton {
+            id: secondaryButton
+            height: Constants.keycard.general.footerButtonsHeight
+            text: {
+                if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.authentication) {
+                    if (root.sharedKeycardModule.loggedInUserUsesBiometricLogin()) {
+                        if (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.enterPassword ||
+                                root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.wrongPassword)
+                            return qsTr("Use biometrics instead")
+                        if (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.biometricsPasswordFailed)
+                            return qsTr("Use password instead")
+                        if (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.enterPin ||
+                                root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.wrongPin)
+                            return qsTr("Use biometrics")
+                        if (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.pluginReader ||
+                                root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.insertKeycard ||
+                                root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardInserted ||
+                                root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.readingKeycard ||
+                                root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.biometricsReadyToSign ||
+                                root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.notKeycard ||
+                                root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.biometricsPinFailed ||
+                                root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.biometricsPinInvalid ||
+                                root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.wrongKeycard ||
+                                root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardEmpty)
+                            return qsTr("Use PIN")
+                    }
+                }
+                return ""
+            }
+            visible: {
                 if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.authentication) {
                     if (root.sharedKeycardModule.loggedInUserUsesBiometricLogin()) {
                         if (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.pluginReader ||

--- a/ui/imports/shared/popups/keycard/states/KeycardPin.qml
+++ b/ui/imports/shared/popups/keycard/states/KeycardPin.qml
@@ -130,13 +130,13 @@ Item {
                     root.sharedKeycardModule.setPin(pinInput)
                     if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.authentication)
                         return
-                    root.sharedKeycardModule.currentState.doTertiaryAction()
+                    root.sharedKeycardModule.currentState.doSecondaryAction()
                 }
                 else if(root.state === Constants.keycardSharedState.repeatPin) {
                     let pinsMatch = root.sharedKeycardModule.checkRepeatedKeycardPinWhileTyping(pinInput)
                     if (pinsMatch) {
                         info.text = qsTr("It is very important that you do not lose this PIN")
-                        root.sharedKeycardModule.currentState.doTertiaryAction()
+                        root.sharedKeycardModule.currentState.doSecondaryAction()
                     } else {
                         info.text = qsTr("PINs don't match")
                         image.source = Style.png("keycard/plain-error")


### PR DESCRIPTION
A new rule introduced which should provide easier tracking/maintainig later. The rule says:
- popup contains up to 3 action buttons and one back button (optional)
- if 3 buttons are displayed in the popup then the most left button, but not back button, always triggers tertiary action, middle button always triggers secondary action and the most right button always triggers primary action
- if 2 buttons are displayed, then: 
  - if one of them is "Cancel" (left button) it should trigger tertiary action and the other one (right button) should trigger primary action 
  - if non of them is "Cancel" then the left button triggers secondary action and the right button triggers primary action
- if single button is displayed, then: 
  - if it's "Cancel" it triggers tertiary action
  - if it is not "Cancel" it triggers primary action
- tertiary action always reffers to the cancel action until otherwise set
- tertiary action will be always triggered by closing popup via keybord (esc key) or clicking on top right `x` button on the popup
