### PR TITLE
hotfix: make sure to remove all references to pinnedMessagesListPopup

### DIFF
--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -657,7 +657,6 @@ Item {
                         Layout.fillWidth: true
                         Layout.fillHeight: true
 
-                        chatView.pinnedMessagesListPopupComponent: pinnedMessagesPopupComponent
                         chatView.emojiPopup: statusEmojiPopup
 
                         contactsStore: appMain.rootStore.contactStore
@@ -758,7 +757,6 @@ Item {
                                     Layout.alignment: Qt.AlignLeft | Qt.AlignTop
                                     Layout.fillHeight: true
 
-                                    chatView.pinnedMessagesListPopupComponent: pinnedMessagesPopupComponent
                                     chatView.emojiPopup: statusEmojiPopup
 
                                     contactsStore: appMain.rootStore.contactStore


### PR DESCRIPTION
Fixes app startup

### What does the PR do

Unbreaks app startup

### Affected areas

AppMain

### Screenshot of functionality (including design for comparison)

- [N/A] I've checked the design and this PR matches it
