### PR TITLE
fix(tests): make onboarding test steps workflow working

### DIFF
--- a/test/ui-test/src/drivers/SquishDriver.py
+++ b/test/ui-test/src/drivers/SquishDriver.py
@@ -165,13 +165,18 @@ def scroll_obj_by_name(objName: str):
     obj = squish.waitForObject(getattr(names, objName))
     squish.mouseWheel(obj, 206, 35, 0, -1, squish.Qt.ControlModifier)
 
-def scroll_item_until_item_is_visible(itemToScrollObjName: str, itemToBeVisibleObjName: str, timeoutMs: int=_MAX_WAIT_OBJ_TIMEOUT * 2):
-    # get current time
+# execute do_fn until validation_fn returns True or timeout is reached
+def do_until_validation_with_timeout(do_fn, validation_fn, message: str, timeout_ms: int=_MAX_WAIT_OBJ_TIMEOUT * 2):
     start_time = time.time()
-    while(not is_loaded_visible_and_enabled(itemToBeVisibleObjName, 10)[0]):
-        if ((time.time() - start_time) * 1000) > timeoutMs:
-            raise Exception(f'Timeout scrolling and waiting for item "{itemToBeVisibleObjName}" to be visible')
-        scroll_obj_by_name(itemToScrollObjName)
+    while(not validation_fn()):
+        if ((time.time() - start_time) * 1000) > timeout_ms:
+            raise Exception("Timeout reached while validating: " + message)
+        do_fn()
+
+def scroll_item_until_item_is_visible(itemToScrollObjName: str, itemToBeVisibleObjName: str, timeout_ms: int=_MAX_WAIT_OBJ_TIMEOUT * 2):
+    is_item_visible_fn = lambda: is_loaded_visible_and_enabled(itemToBeVisibleObjName, 10)[0]
+    scroll_item_fn = lambda: scroll_obj_by_name(itemToScrollObjName)
+    do_until_validation_with_timeout(scroll_item_fn, is_item_visible_fn, f'Scrolling {itemToScrollObjName} until {itemToBeVisibleObjName} is visible', timeout_ms)
 
 def check_obj_by_name(objName: str):
     obj = squish.waitForObject(getattr(names, objName))

--- a/test/ui-test/src/screens/StatusWelcomeScreen.py
+++ b/test/ui-test/src/screens/StatusWelcomeScreen.py
@@ -40,6 +40,7 @@ class SignUpComponents(Enum):
     PROFILE_IMAGE_CROP_WORKFLOW_ITEM: str = "mainWindow_WelcomeScreen_Image_Crop_Workflow_Item"
     PROFILE_IMAGE_CROPPER_ACCEPT_BUTTON: str = "mainWindow_WelcomeScreen_Image_Cropper_Accept_Button"
     WELCOME_SCREEN_USER_PROFILE_IMAGE: str = "mainWindow_WelcomeScreen_User_Profile_Image"
+    WELCOME_SCREEN_CHAT_KEY_TEXT: str = "mainWindow_WelcomeScreen_ChatKeyText"
     
 class SeedPhraseComponents(Enum):
     IMPORT_A_SEED_TEXT: str = "import_a_seed_phrase_StatusBaseText"
@@ -105,24 +106,41 @@ class StatusWelcomeScreen:
         self.input_confirmation_password(password)
 
         if sys.platform == "darwin":
-            click_obj_by_name(SignUpComponents.PASSWORD_PREFERENCE.value)
+            do_until_validation_with_timeout(
+                do_fn = lambda: click_obj_by_name(SignUpComponents.PASSWORD_PREFERENCE.value),
+                validation_fn = lambda: not is_loaded_visible_and_enabled(SignUpComponents.PASSWORD_PREFERENCE.value, 50)[0],
+                message = 'Try clicking "I prefer to use password" until not visible and enabled (moved to the next screen)')
 
     def input_username(self, username: str):
         type(SignUpComponents.USERNAME_INPUT.value, username)
         click_obj_by_name(SignUpComponents.DETAILS_NEXT_BUTTON.value)
-                
+
+        # The next click will move too fast sometime
+        verify(is_loaded_visible_and_enabled(SignUpComponents.WELCOME_SCREEN_CHAT_KEY_TEXT.value, 10)[0], 'User Profile Chat Key is visible so the "next" press will jump to the right key')
+
         # There is another page with the same Next button
-        click_obj_by_name(SignUpComponents.DETAILS_NEXT_BUTTON.value)
+        do_until_validation_with_timeout(
+            do_fn = lambda: click_obj_by_name(SignUpComponents.DETAILS_NEXT_BUTTON.value),
+            validation_fn = lambda: is_loaded_visible_and_enabled(SignUpComponents.NEW_PSW_INPUT.value, 50)[0],
+            message = 'Try clicking "Next" until new password screen is visible')
 
     def input_password(self, password: str):
+        verify(is_loaded_visible_and_enabled(SignUpComponents.NEW_PSW_INPUT.value, 10)[0], 'New Password input is visible')
         type(SignUpComponents.NEW_PSW_INPUT.value, password)
         type(SignUpComponents.CONFIRM_PSW_INPUT.value, password)
-        click_obj_by_name(SignUpComponents.CREATE_PSW_BUTTON.value)
-        
+        do_until_validation_with_timeout(
+            do_fn = lambda: click_obj_by_name(SignUpComponents.CREATE_PSW_BUTTON.value),
+            validation_fn = lambda: not is_loaded_visible_and_enabled(SignUpComponents.CREATE_PSW_BUTTON.value, 50)[0],
+            message = 'Try clicking "Create Password" until button not visible (moved to the next screen)')
+
     def input_confirmation_password(self, password: str):
+        verify(is_loaded_visible_and_enabled(SignUpComponents.CONFIRM_PSW_AGAIN_INPUT.value, 10)[0], 'Reconfirm password is visible')
         type(SignUpComponents.CONFIRM_PSW_AGAIN_INPUT.value, password)
-        click_obj_by_name(SignUpComponents.FINALIZE_PSW_BUTTON.value)
-        
+        do_until_validation_with_timeout(
+            do_fn = lambda: click_obj_by_name(SignUpComponents.FINALIZE_PSW_BUTTON.value),
+            validation_fn = lambda: not is_loaded_visible_and_enabled(SignUpComponents.FINALIZE_PSW_BUTTON.value, 50)[0],
+            message = 'Try clicking "Finalize" until button not visible (moved to the next screen')
+
     def _agree_terms_and_conditions(self):
         if sys.platform == "darwin":
             click_obj_by_name(AgreementPopUp.OK_GOT_IT_BUTTON.value)

--- a/test/ui-test/testSuites/global_shared/scripts/onboarding_names.py
+++ b/test/ui-test/testSuites/global_shared/scripts/onboarding_names.py
@@ -18,6 +18,7 @@ onboarding_DetailsView_NextButton = {"container": statusDesktop_mainWindow, "obj
 mainWindow_I_prefer_to_use_my_password_StatusBaseText = {"container": statusDesktop_mainWindow, "objectName": "touchIdIPreferToUseMyPasswordText", "type": "StatusBaseText"}
 mainWindow_Ok_got_it_StatusBaseText = {"container": statusDesktop_mainWindow, "type": "StatusButton", "objectName": "allowNotificationsOnboardingOkButton", "visible": True}
 mainWindow_WelcomeScreen_User_Profile_Image = {"container": statusDesktop_mainWindow, "type": "StatusSmartIdenticon", "objectName": "welcomeScreenUserProfileImage"}
+mainWindow_WelcomeScreen_ChatKeyText = {"container": statusDesktop_mainWindow, "type": "StyledText", "objectName": "insertDetailsViewChatKeyTxt"}
 mainWindow_WelcomeScreen_Image_Crop_Workflow_Item= {"container": statusDesktop_mainWindow, "type": "Item", "objectName": "imageCropWorkflow"}
 mainWindow_WelcomeScreen_Image_Cropper_Accept_Button= {"container": statusDesktop_mainWindow, "type": "StatusButton", "objectName": "imageCropperAcceptButton"}
 

--- a/ui/app/AppLayouts/Onboarding/views/InsertDetailsView.qml
+++ b/ui/app/AppLayouts/Onboarding/views/InsertDetailsView.qml
@@ -158,6 +158,7 @@ Item {
 
         StyledText {
             id: chatKeyTxt
+            objectName: "insertDetailsViewChatKeyTxt"
             Layout.preferredHeight: 22
             color: Style.current.secondaryText
             text: qsTr("Chatkey:") + " " + Utils.getCompressedPk(root.pubKey)


### PR DESCRIPTION
It seems due to the latest changes there are additional delays in transitioning to enable some of the controls that drive the onboarding workflow. This PR accounts for that and waits for components to become ready.

Still, it will be great to find out why are tests failing now. Why there is more delay in between some screen transitions?