### PR TITLE
fix(general): buttons font fixed, font loading refactored

### DIFF
--- a/ui/app/AppLayouts/Onboarding/controls/AccountViewDelegate.qml
+++ b/ui/app/AppLayouts/Onboarding/controls/AccountViewDelegate.qml
@@ -69,7 +69,7 @@ Rectangle {
         id: addressText
         width: 108
         text: address
-        font.family: Style.current.fontHexRegular.name
+        font.family: Style.current.monoFont.name
         elide: Text.ElideMiddle
         anchors.bottom: accountImage.bottom
         anchors.bottomMargin: 0

--- a/ui/app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml
+++ b/ui/app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml
@@ -165,7 +165,7 @@ Item {
                     wrapMode: Text.WordWrap
                     anchors.left: parent.left
                     anchors.right: parent.right
-                    font.family: Style.current.fontHexRegular.name
+                    font.family: Style.current.monoFont.name
                     color: Theme.palette.directColor1
                 }
 
@@ -189,7 +189,7 @@ Item {
                     wrapMode: Text.WordWrap
                     anchors.left: parent.left
                     anchors.right: parent.right
-                    font.family: Style.current.fontHexRegular.name
+                    font.family: Style.current.monoFont.name
                     color: Theme.palette.directColor1
                 }
 

--- a/ui/app/AppLayouts/Wallet/controls/HeaderButton.qml
+++ b/ui/app/AppLayouts/Wallet/controls/HeaderButton.qml
@@ -47,7 +47,7 @@ Rectangle {
         anchors.leftMargin: headerButton.margin
         anchors.verticalCenter: parent.verticalCenter
         font.pixelSize: 13
-        font.family: Style.current.fontMedium.name
+        font.family: Style.current.baseFont.name
         font.weight: Font.Medium
         color: Style.current.blue
     }

--- a/ui/app/AppLayouts/Wallet/panels/SeedPhraseBackupWarning.qml
+++ b/ui/app/AppLayouts/Wallet/panels/SeedPhraseBackupWarning.qml
@@ -35,7 +35,7 @@ Rectangle {
                     text: qsTr("Back up")
                     font.pixelSize: 13
                     font.weight: Font.Medium
-                    font.family: Style.current.fontRegular.name
+                    font.family: Style.current.baseFont.name
                     horizontalAlignment: Text.AlignHCenter
                     verticalAlignment: Text.AlignVCenter
                     anchors.top: parent.top

--- a/ui/imports/Themes/Theme.qml
+++ b/ui/imports/Themes/Theme.qml
@@ -2,17 +2,19 @@ import QtQuick 2.13
 import utils 1.0
 
 QtObject {
-    property QtObject fontMedium: FontLoader { id: _fontMedium; source: "../../fonts/Inter/Inter-Medium.otf"; }
-    property QtObject fontBold: FontLoader { id: _fontBold; source: "../../fonts/Inter/Inter-Bold.otf"; }
-    property QtObject fontLight: FontLoader { id: _fontLight; source: "../../fonts/Inter/Inter-Light.otf"; }
-    property QtObject fontRegular: FontLoader { id: _fontRegular; source: "../../fonts/Inter/Inter-Regular.otf"; }
+    readonly property FontLoader baseFont: FontLoader { source: "../../fonts/Inter/Inter-Regular.otf" }
+    readonly property FontLoader monoFont: FontLoader { source: "../../fonts/InterStatus/InterStatus-Regular.otf" }
+    readonly property FontLoader codeFont: FontLoader { source: "../../fonts/RobotoMono/RobotoMono-Regular.ttf" }
 
-    property QtObject fontHexMedium: FontLoader { id: _fontHexMedium; source: "../../fonts/InterStatus/InterStatus-Medium.otf"; }
-    property QtObject fontHexBold: FontLoader { id: _fontHexBold; source: "../../fonts/InterStatus/InterStatus-Bold.otf"; }
-    property QtObject fontHexLight: FontLoader { id: _fontHexLight; source: "../../fonts/InterStatus/InterStatus-Light.otf"; }
-    property QtObject fontHexRegular: FontLoader { id: _fontHexRegular; source: "../../fonts/InterStatus/InterStatus-Regular.otf"; }
+    readonly property QtObject _d: QtObject {
+        readonly property FontLoader baseFontMedium: FontLoader { source: "../../fonts/Inter/Inter-Medium.otf" }
+        readonly property FontLoader baseFontBold: FontLoader { source: "../../fonts/Inter/Inter-Bold.otf" }
+        readonly property FontLoader baseFontLight: FontLoader { source: "../../fonts/Inter/Inter-Light.otf" }
 
-    property QtObject fontCodeRegular: FontLoader { id: _fontCodeRegular; source: "../../fonts/RobotoMono/RobotoMono-Regular.ttf"; }
+        readonly property FontLoader monoFontMedium: FontLoader { source: "../../fonts/InterStatus/InterStatus-Medium.otf" }
+        readonly property FontLoader monoFontBold: FontLoader { source: "../../fonts/InterStatus/InterStatus-Bold.otf" }
+        readonly property FontLoader monoFontLight: FontLoader { source: "../../fonts/InterStatus/InterStatus-Light.otf" }
+    }
 
     property string name
 

--- a/ui/imports/shared/controls/RecipientSelector.qml
+++ b/ui/imports/shared/controls/RecipientSelector.qml
@@ -120,7 +120,7 @@ Item {
         visible: label !== ""
         text: qsTr("Recipient")
         font.pixelSize: 13
-        font.family: Style.current.fontRegular.name
+        font.family: Style.current.baseFont.name
         font.weight: Font.Medium
         color: Style.current.textColor
         height: 18
@@ -131,7 +131,7 @@ Item {
         visible: text !== ""
         text: ""
         font.pixelSize: 13
-        font.family: Style.current.fontRegular.name
+        font.family: Style.current.baseFont.name
         font.weight: Font.Medium
         color: Style.current.danger
         height: 18

--- a/ui/imports/shared/controls/StyledTextArea.qml
+++ b/ui/imports/shared/controls/StyledTextArea.qml
@@ -60,7 +60,7 @@ Item {
             anchors.bottomMargin: Style.current.smallPadding
             anchors.topMargin: Style.current.smallPadding
             anchors.fill: parent
-            font.family: Style.current.fontRegular.name
+            font.family: Style.current.baseFont.name
             color: Style.current.textColor
             placeholderTextColor: Style.current.secondaryText
             selectionColor: Style.current.primarySelectionColor

--- a/ui/imports/shared/controls/StyledTextEdit.qml
+++ b/ui/imports/shared/controls/StyledTextEdit.qml
@@ -3,7 +3,7 @@ import QtQuick 2.13
 import utils 1.0
 
 TextEdit {
-    font.family: Style.current.fontRegular.name
+    font.family: Style.current.baseFont.name
     color: Style.current.textColor
     selectedTextColor: Style.current.textColor
     selectionColor: Style.current.primarySelectionColor

--- a/ui/imports/shared/controls/StyledTextField.qml
+++ b/ui/imports/shared/controls/StyledTextField.qml
@@ -4,7 +4,7 @@ import QtQuick.Controls 2.13
 import utils 1.0
 
 TextField {
-    font.family: Style.current.fontRegular.name
+    font.family: Style.current.baseFont.name
     color: readOnly ? Style.current.secondaryText : Style.current.textColor
     selectByMouse: !readOnly
     selectedTextColor: Style.current.textColor

--- a/ui/imports/shared/panels/Address.qml
+++ b/ui/imports/shared/panels/Address.qml
@@ -10,7 +10,7 @@ StyledText {
     id: addressComponent
     text: "0x9ce0056c5fc6bb9459a4dcfa35eaad8c1fee5ce9"
     font.pixelSize: 13
-    font.family: Style.current.fontHexRegular.name
+    font.family: Style.current.monoFont.name
     elide: Text.ElideMiddle
     color: Style.current.secondaryText
 

--- a/ui/imports/shared/panels/ModuleWarning.qml
+++ b/ui/imports/shared/panels/ModuleWarning.qml
@@ -145,7 +145,7 @@ Item {
                     text: button.text
                     font.pixelSize: 12
                     font.weight: Font.Medium
-                    font.family: Style.current.fontRegular.name
+                    font.family: Style.current.baseFont.name
                     horizontalAlignment: Text.AlignHCenter
                     verticalAlignment: Text.AlignVCenter
                     color: Theme.palette.indirectColor1

--- a/ui/imports/shared/panels/StyledText.qml
+++ b/ui/imports/shared/panels/StyledText.qml
@@ -3,6 +3,6 @@ import QtQuick 2.13
 import utils 1.0
 
 Text {
-    font.family: Style.current.fontRegular.name
+    font.family: Style.current.baseFont.name
     color: Style.current.textColor
 }

--- a/ui/imports/shared/panels/TextWithLabel.qml
+++ b/ui/imports/shared/panels/TextWithLabel.qml
@@ -11,7 +11,7 @@ import "./"
 Item {
     property string text: "My Text"
     property string label: "My Label"
-    property string fontFamily: Style.current.fontRegular.name
+    property string fontFamily: Style.current.baseFont.name
     property string textToCopy: ""
     property alias value: textItem
     property bool wrap: false

--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -1072,7 +1072,7 @@ Rectangle {
 
                             textFormat: Text.RichText
                             font.pixelSize: 15
-                            font.family: Style.current.fontRegular.name
+                            font.family: Style.current.baseFont.name
                             wrapMode: TextArea.Wrap
                             placeholderText: control.chatInputPlaceholder
                             placeholderTextColor: Style.current.secondaryText

--- a/ui/imports/shared/status/StatusExpandableAddress.qml
+++ b/ui/imports/shared/status/StatusExpandableAddress.qml
@@ -27,7 +27,7 @@ Item {
             id: addressText
             text: root.address
             font.pixelSize: 13
-            font.family: Style.current.fontHexRegular.name
+            font.family: Style.current.monoFont.name
             color: Style.current.secondaryText
             elide: Text.ElideMiddle
             horizontalAlignment: Text.AlignHCenter

--- a/ui/imports/shared/status/StatusStickerButton.qml
+++ b/ui/imports/shared/status/StatusStickerButton.qml
@@ -127,7 +127,7 @@ Item {
     TextMetrics {
         id: textMetrics
         font.weight: Font.Medium
-        font.family: Style.current.fontBold.name
+        font.family: Style.current.baseFont.name
         font.pixelSize: 15
         text: root.text
     }
@@ -215,7 +215,7 @@ Item {
             anchors.verticalCenter: parent.verticalCenter
             text: root.text
             font.weight: Font.Medium
-            font.family: Style.current.fontBold.name
+            font.family: Style.current.baseFont.name
             font.pixelSize: 15
             states: [
                 State {

--- a/ui/imports/shared/status/StatusStickerPackDetails.qml
+++ b/ui/imports/shared/status/StatusStickerPackDetails.qml
@@ -31,14 +31,14 @@ Item {
         StyledText {
             id: txtPackName
             text: packName
-            font.family: Style.current.fontBold.name
+            font.family: Style.current.baseFont.name
             font.weight: Font.Bold
             font.pixelSize: packNameFontSize
         }
         StyledText {
             color: Style.current.secondaryText
             text: packAuthor
-            font.family: Style.current.fontRegular.name
+            font.family: Style.current.baseFont.name
             font.pixelSize: 15
         }
     }


### PR DESCRIPTION
### What does the PR do

Updates StatusQ to version with StatusBaseButton font fixed. Additionally refactors fonts loading by hiding font variants and using single reference for given font in components regardless what weight is used.

Fixes: #7389
Fixes: #7359

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas

StatusQ, ThemePalette

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![Screenshot from 2022-09-15 17-30-10](https://user-images.githubusercontent.com/20650004/190445138-b2ebb4f0-f3e4-4afd-88ff-27efdc9c2138.png)

<!-- optional but cool ->
