### PR TITLE
tests(chat): adapt gif test and add image unfurling test

### DIFF
--- a/test/ui-test/src/drivers/SquishDriver.py
+++ b/test/ui-test/src/drivers/SquishDriver.py
@@ -165,6 +165,13 @@ def scroll_obj_by_name(objName: str):
     obj = squish.waitForObject(getattr(names, objName))
     squish.mouseWheel(obj, 206, 35, 0, -1, squish.Qt.ControlModifier)
 
+def scroll_item_until_item_is_visible(itemToScrollObjName: str, itemToBeVisibleObjName: str, timeoutMs: int=_MAX_WAIT_OBJ_TIMEOUT * 2):
+    # get current time
+    start_time = time.time()
+    while(not is_loaded_visible_and_enabled(itemToBeVisibleObjName, 10)[0]):
+        if ((time.time() - start_time) * 1000) > timeoutMs:
+            raise Exception(f'Timeout scrolling and waiting for item "{itemToBeVisibleObjName}" to be visible')
+        scroll_obj_by_name(itemToScrollObjName)
 
 def check_obj_by_name(objName: str):
     obj = squish.waitForObject(getattr(names, objName))

--- a/test/ui-test/src/screens/SettingsScreen.py
+++ b/test/ui-test/src/screens/SettingsScreen.py
@@ -13,6 +13,7 @@ from enum import Enum
 import random
 import time
 import string
+from wsgiref import validate
 from drivers.SquishDriver import *
 from drivers.SquishDriverVerification import *
 from .StatusMainScreen import MainScreenComponents
@@ -48,8 +49,9 @@ class ENSScreen(Enum):
 class MessagingOptionScreen(Enum):
     ACTIVATE_OR_DEACTIVATE_LINK_PREVIEW: str = "displayMessageLinkPreviewItem"
     ACTIVATE_OR_DECTIVATE_IMAGE_UNFURLING: str = "imageUnfurlingItem"
+    TENOR_GIFS_PREVIEW_SWITCH_ITEM: str = "tenorGifsPreviewSwitchItem"
     SCROLLVIEW: str = "settingsContentBase_ScrollView"
- 
+
 
 class WalletSettingsScreen(Enum):
     GENERATED_ACCOUNTS: str = "settings_Wallet_MainView_GeneratedAccounts"
@@ -144,18 +146,26 @@ class SettingsScreen:
         accounts = get_obj(WalletSettingsScreen.GENERATED_ACCOUNTS.value)
         verify_text_matching_insensitive(accounts.itemAtIndex(0).statusListItemSubTitle, address)
 
+    # Post condition: Messaging Settings is visible (@see StatusMainScreen.open_settings)
     def open_messaging_settings(self):
         click_obj_by_name(SidebarComponents.MESSAGING_ITEM.value)
-    
+
     def activate_link_preview(self):
         click_obj_by_name(SidebarComponents.MESSAGING_ITEM.value)
-        scroll_obj_by_name(MessagingOptionScreen.SCROLLVIEW.value)
-        scroll_obj_by_name(MessagingOptionScreen.SCROLLVIEW.value)        
-        scroll_obj_by_name(MessagingOptionScreen.SCROLLVIEW.value)
+        scroll_item_until_item_is_visible(MessagingOptionScreen.SCROLLVIEW.value, MessagingOptionScreen.ACTIVATE_OR_DEACTIVATE_LINK_PREVIEW.value)
         click_obj_by_name(MessagingOptionScreen.ACTIVATE_OR_DEACTIVATE_LINK_PREVIEW.value)
-        scroll_obj_by_name(MessagingOptionScreen.SCROLLVIEW.value)
+
+    # Post condition: Messaging Settings and Link Preview are visible (@see open_messaging_settings and activate_link_preview)
+    def activate_image_unfurling(self):
+        scroll_item_until_item_is_visible(MessagingOptionScreen.SCROLLVIEW.value, MessagingOptionScreen.ACTIVATE_OR_DECTIVATE_IMAGE_UNFURLING.value)
         click_obj_by_name(MessagingOptionScreen.ACTIVATE_OR_DECTIVATE_IMAGE_UNFURLING.value)
-        
+
+    # Post condition: Messaging Settings and Link Preview are visible (@see open_messaging_settings and activate_link_preview)
+    def check_tenor_gif_preview_is_enabled(self):
+        scroll_item_until_item_is_visible(MessagingOptionScreen.SCROLLVIEW.value, MessagingOptionScreen.TENOR_GIFS_PREVIEW_SWITCH_ITEM.value)
+        tenorSwitch = wait_and_get_obj(MessagingOptionScreen.TENOR_GIFS_PREVIEW_SWITCH_ITEM.value)
+        verify(tenorSwitch.enabled, "Tenor GIFs preview is enabled")
+
     def toggle_test_networks(self):
         click_obj_by_name(WalletSettingsScreen.NETWORKS_ITEM.value)
         click_obj_by_name(WalletSettingsScreen.TESTNET_TOGGLE.value)

--- a/test/ui-test/src/screens/StatusChatScreen.py
+++ b/test/ui-test/src/screens/StatusChatScreen.py
@@ -67,7 +67,11 @@ class ChatComponents(Enum):
     ENABLE_GIF_BUTTON = "gifPopup_enableGifButton"
     GIF_MOUSEAREA = "gifPopup_gifMouseArea"
     CHAT_INPUT_STICKER_BUTTON = "chat_Input_Stickers_Button"
-    
+
+    LINK_PREVIEW_UNFURLED_IMAGE = "chatView_unfurledImageComponent_linkImage"
+    LINK_PREVIEW_UNFURLED_LINK_IMAGE = "chatView_unfurledLinkComponent_linkImage"
+    LINK_PREVIEW_OPEN_SETTINGS = "chatView_LinksMessageView_enableBtn"
+
 class ChatStickerPopup(Enum):
     STICKERS_POPUP_GET_STICKERS_BUTTON = "chat_StickersPopup_GetStickers_Button"
     STICKERS_POPUP_MARKET_GRID_VIEW = "chat_StickersPopup_StickerMarket_GridView"
@@ -402,3 +406,20 @@ class StatusChatScreen:
                 click_obj(chat)
                 return
         verify(False, "Chat switched")
+
+    def _verify_image_unfurled_status_for_component(self, objectName: str, image_link: str, unfurled: bool):
+        if not unfurled:
+            verify_false(is_loaded_visible_and_enabled(objectName, 10)[0], "Image link preview component is not loaded")
+        else:
+            chat_image_loader = wait_and_get_obj(objectName)
+            # Didn't find a way to convert squish QUrls to string
+            verify(str(chat_image_loader.source.path) in image_link, "The url is most probably the one expected")
+
+    def verify_image_unfurled_status(self, image_link: str, unfurled: bool):
+        self._verify_image_unfurled_status_for_component(ChatComponents.LINK_PREVIEW_UNFURLED_IMAGE.value, image_link, unfurled)
+
+    def verify_link_image_unfurled_status(self, image_link: str, unfurled: bool):
+        self._verify_image_unfurled_status_for_component(ChatComponents.LINK_PREVIEW_UNFURLED_LINK_IMAGE.value, image_link, unfurled)
+
+    def open_settings_from_message(self):
+        click_obj_by_name(ChatComponents.LINK_PREVIEW_OPEN_SETTINGS.value)

--- a/test/ui-test/testSuites/suite_status/shared/scripts/sections/chat_names.py
+++ b/test/ui-test/testSuites/suite_status/shared/scripts/sections/chat_names.py
@@ -26,6 +26,9 @@ chatInput_Emoji_Button = {"container": statusDesktop_mainWindow, "objectName": "
 chatView_ChatToolbarMoreOptionsButton = {"container": statusDesktop_mainWindow, "objectName": "chatToolbarMoreOptionsButton", "type": "StatusFlatRoundButton", "visible": True}
 chatInput_Root = {"container": statusDesktop_mainWindow, "objectName": "statusChatInput", "type": "Rectangle", "visible": True}
 chatView_gifPopupButton = {"container": statusDesktop_mainWindow, "objectName": "gifPopupButton", "type": "StatusFlatRoundButton", "visible": True}
+chatView_unfurledImageComponent_linkImage = {"container": chatView_log, "objectName": "LinksMessageView_unfurledImageComponent_linkImage", "type": "StatusChatImageLoader",  "visible": True}
+chatView_unfurledLinkComponent_linkImage = {"container": chatView_log, "objectName": "LinksMessageView_unfurledLinkComponent_linkImage", "type": "StatusChatImageLoader", "visible": True}
+chatView_LinksMessageView_enableBtn = {"container": chatView_log, "objectName": "LinksMessageView_enableBtn", "type": "StatusFlatButton", "visible": True}
 
 # More options menu
 clearHistoryMenuItem = {"container": statusDesktop_mainWindow_overlay, "objectName": "clearHistoryMenuItem", "type": "StatusMenuItemDelegate", "visible": True}

--- a/test/ui-test/testSuites/suite_status/shared/scripts/sections/settings_names.py
+++ b/test/ui-test/testSuites/suite_status/shared/scripts/sections/settings_names.py
@@ -88,6 +88,7 @@ generatedAccounts_ListView = {"container": statusDesktop_mainWindow, "objectName
 settingsContentBase_ScrollView = {"container": statusDesktop_mainWindow, "objectName": "settingsContentBaseScrollView", "type": "StatusScrollView", "visible": True}
 displayMessageLinkPreviewItem = {"container": statusDesktop_mainWindow, "objectName": "displayMessageLinkPreviewsItem", "type": "StatusListItem"}
 imageUnfurlingItem = {"container": statusDesktop_mainWindow, "objectName": "imageUnfurlingItem", "type": "StatusListItem"}
+tenorGifsPreviewSwitchItem = {"container": statusDesktop_mainWindow, "objectName": "MessagingView_sitesListView_StatusListItem_tenor_gifs_subdomain", "type": "StatusListItem"}
 
 # Communities Settings:
 settings_Communities_MainView_LeaveCommunityButtons = {"container": statusDesktop_mainWindow, "objectName":"CommunitiesListPanel_leaveCommunityPopupButton", "type": "StatusBaseButton", "visible": True}

--- a/test/ui-test/testSuites/suite_status/shared/steps/chatSteps.py
+++ b/test/ui-test/testSuites/suite_status/shared/steps/chatSteps.py
@@ -76,7 +76,19 @@ def step(context):
 def step(context):
     _statusChat.send_gif()
     _statusChat.verify_last_message_sent("tenor.gif")
-    
+
+@When("the user opens app settings screen from chat")
+def step(context):
+    _statusChat.open_settings_from_message()
+
+@Then("the image |any| is unfurled in the chat")
+def step(context: any, image_link: str):
+    _statusChat.verify_image_unfurled_status(image_link, True)
+
+@Then("the image |any| is not unfurled in the chat")
+def step(context: any, image_link: str):
+    _statusChat.verify_image_unfurled_status(image_link, False)
+
 @Then("the user selects emoji in the suggestion list")
 def step(contenxt):
     _statusChat.select_the_emoji_in_suggestion_list()

--- a/test/ui-test/testSuites/suite_status/shared/steps/settingsSteps.py
+++ b/test/ui-test/testSuites/suite_status/shared/steps/settingsSteps.py
@@ -19,11 +19,19 @@ def step(context: any):
 @When("the user opens the messaging settings")
 def step(context: any):
     _settingsScreen.open_messaging_settings()
-    
+
 @When("the user activates link preview")
 def step(context: any):
     _settingsScreen.activate_link_preview()
-    
+
+@When("the user activates image unfurling")
+def step(context: any):
+    _settingsScreen.activate_image_unfurling()
+
+@Then("tenor GIFs preview is enabled")
+def step(context: any):
+    _settingsScreen.check_tenor_gif_preview_is_enabled()
+
 @When("the user activates wallet and opens the wallet settings")
 def step(context: any):
     _settingsScreen.activate_open_wallet_settings()

--- a/test/ui-test/testSuites/suite_status/tst_ChatFlow/test.feature
+++ b/test/ui-test/testSuites/suite_status/tst_ChatFlow/test.feature
@@ -68,12 +68,28 @@ Feature: Status Desktop Chat
         Then the chat is cleared
 
     Scenario: User can send a gif
-         When the user opens app settings screen
-         And the user opens the messaging settings
-         And the user activates link preview
-         And the user opens the chat section
-         And user joins chat room automation-test
-         Then The user is able to send a gif message
+          When the user opens the chat section
+          And user joins chat room automation-test
+          Then The user is able to send a gif message
+          When the user opens app settings screen
+          And the user opens the messaging settings
+          Then tenor GIFs preview is enabled
+
+    Scenario Outline: User can activate image unfurling
+          When the user opens the chat section
+          And user joins chat room automation-test
+          And the user sends the chat message <image_url>
+          Then the image <image_url> is not unfurled in the chat
+          When the user opens app settings screen from chat
+          And the user opens the messaging settings
+          And the user activates link preview
+          And the user activates image unfurling
+          And the user opens the chat section
+          Then the image <image_url> is unfurled in the chat
+
+          Examples:
+               | image_url                                                                                      |
+               | https://github.com/status-im/status-desktop/raw/master/test/ui-test/fixtures/images/doggo.jpeg |
 
     Scenario: The user is able to use emoji suggestions
          When user joins chat room automation-test

--- a/ui/app/AppLayouts/Profile/views/MessagingView.qml
+++ b/ui/app/AppLayouts/Profile/views/MessagingView.qml
@@ -346,6 +346,7 @@ SettingsContentBase {
 
                 delegate: Component {
                     StatusListItem {
+                        objectName: "MessagingView_sitesListView_StatusListItem_" + model.title.replace(/ /g, "_").toLowerCase()
                         property alias whitelistSwitch: siteSwitch
                         width: parent.width
                         implicitHeight: 64

--- a/ui/imports/shared/views/chat/LinksMessageView.qml
+++ b/ui/imports/shared/views/chat/LinksMessageView.qml
@@ -223,6 +223,7 @@ Column {
             isCurrentUser: root.isCurrentUser
             StatusChatImageLoader {
                 id: linkImage
+                objectName: "LinksMessageView_unfurledImageComponent_linkImage"
                 anchors.centerIn: parent
                 container: root.container
                 source: linkData.thumbnailUrl
@@ -258,6 +259,7 @@ Column {
 
             StatusChatImageLoader {
                 id: linkImage
+                objectName: "LinksMessageView_unfurledLinkComponent_linkImage"
                 container: root.container
                 source: linkData.thumbnailUrl
                 visible: linkData.thumbnailUrl.length
@@ -380,6 +382,7 @@ Column {
 
             StatusFlatButton {
                 id: enableBtn
+                objectName: "LinksMessageView_enableBtn"
                 text: qsTr("Enable in Settings")
                 onClicked: {
                     Global.changeAppSectionBySectionType(Constants.appSection.profile, Constants.settingsSubsection.messaging);


### PR DESCRIPTION
The gif test was manually activating the unfurling, which is no longer necessary. Now check that enabling gifs will enable tenor unfurling

Also
- add a test for image unfurling and validate the unfurling image links components and preview settings.
- improve the scrolling API by adding an option to search for a specific component instead of hardcoding the count of steps