### PR TITLE
fix: correct the spacing in "Pinned by @author" message

### DIFF
--- a/ui/app/AppLayouts/Chat/popups/PinnedMessagesPopup.qml
+++ b/ui/app/AppLayouts/Chat/popups/PinnedMessagesPopup.qml
@@ -102,7 +102,7 @@ StatusDialog {
 
                 MouseArea {
                     anchors.fill: parent
-                    enabled: !!popup.messageToPin
+                    enabled: !!root.messageToPin
                     cursorShape: Qt.PointingHandCursor
                     z: 55
                     onClicked: {


### PR DESCRIPTION
- sync StatusQ (corrects the spacing in "Pinned by author" message)
- and fix a typo

Fixes: #7305

### What does the PR do

Corrects the spacing in "Pinned by @author" message

### Affected areas

StatusQ/StatusPinMessageDetails

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![Snímek obrazovky z 2022-09-16 10-43-32](https://user-images.githubusercontent.com/5377645/190608979-23f3b3be-6884-4489-9bae-0f9fbceca98f.png)

