### PR TITLE
fix(@chat/members): display member's picture according to settings

### DIFF
--- a/ui/app/AppLayouts/Chat/panels/UserListPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/UserListPanel.qml
@@ -81,13 +81,15 @@ Item {
             isUntrustworthy: model.isUntrustworthy
             isAdmin: model.isAdmin
             asset.name: {
-                if ((!model.isContact &&
-                    Global.privacyModuleInst.profilePicturesVisibility !==
-                    Constants.profilePicturesVisibility.everyone)) {
-                    return "";
-                }
-                //TODO check if icon is rendered correctly
-                return model.icon;
+                const isCurrentUser = model.pubKey === root.rootStore.getPubkey()
+                const visibility = Global.privacyModuleInst.profilePicturesVisibility
+
+                if (isCurrentUser
+                        || visibility === Constants.profilePicturesVisibility.everyone
+                        || (visibility === Constants.profilePicturesVisibility.contactsOnly && model.isContact))
+                    return model.icon
+
+                return ""
             }
             asset.isImage: (asset.name !== "")
             asset.isLetterIdenticon: (asset.name === "")


### PR DESCRIPTION
### What does the PR do

Closes: #7309

Two fixes:
- current user's picture is always visible
- hide pictures off all members (excluding self) when "noOne" options is set

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas

`UserListPanel`

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it


https://user-images.githubusercontent.com/20650004/190635568-16a6a0df-3291-4411-b98d-192a402802e4.mp4


