### PR TITLE
chore: use enrtrees for status.* fleets instead of connecting directly to the nodes

### DIFF
--- a/src/app_service/service/node_configuration/service.nim
+++ b/src/app_service/service/node_configuration/service.nim
@@ -190,44 +190,26 @@ proc setFleet*(self: Service, fleet: string): bool =
   newConfiguration.ClusterConfig.RendezvousNodes = self.fleetConfiguration.getNodes(fleetType, FleetNodes.Rendezvous)
 
   var wakuVersion = 2
+  var dnsDiscoveryURL: seq[string] = @[]
   case fleetType:
     of Fleet.WakuV2Prod:
-      newConfiguration.ClusterConfig.RelayNodes = @["enrtree://ANTL4SLG2COUILKAPE7EF2BYNL2SHSHVCHLRD5J7ZJLN5R3PRJD2Y@prod.waku.nodes.status.im"]
-      newConfiguration.ClusterConfig.StoreNodes = @["enrtree://ANTL4SLG2COUILKAPE7EF2BYNL2SHSHVCHLRD5J7ZJLN5R3PRJD2Y@prod.waku.nodes.status.im"]
-      newConfiguration.ClusterConfig.FilterNodes = @["enrtree://ANTL4SLG2COUILKAPE7EF2BYNL2SHSHVCHLRD5J7ZJLN5R3PRJD2Y@prod.waku.nodes.status.im"]
-      newConfiguration.ClusterConfig.LightpushNodes = @["enrtree://ANTL4SLG2COUILKAPE7EF2BYNL2SHSHVCHLRD5J7ZJLN5R3PRJD2Y@prod.waku.nodes.status.im"]
+      dnsDiscoveryURL.add("enrtree://AOGECG2SPND25EEFMAJ5WF3KSGJNSGV356DSTL2YVLLZWIV6SAYBM@prod.waku.nodes.status.im")
     of Fleet.WakuV2Test:
-      newConfiguration.ClusterConfig.RelayNodes = @["enrtree://AOFTICU2XWDULNLZGRMQS4RIZPAZEHYMV4FYHAPW563HNRAOERP7C@test.waku.nodes.status.im"]
-      newConfiguration.ClusterConfig.StoreNodes = @["enrtree://AOFTICU2XWDULNLZGRMQS4RIZPAZEHYMV4FYHAPW563HNRAOERP7C@test.waku.nodes.status.im"]
-      newConfiguration.ClusterConfig.FilterNodes = @["enrtree://AOFTICU2XWDULNLZGRMQS4RIZPAZEHYMV4FYHAPW563HNRAOERP7C@test.waku.nodes.status.im"]
-      newConfiguration.ClusterConfig.LightpushNodes = @["enrtree://AOFTICU2XWDULNLZGRMQS4RIZPAZEHYMV4FYHAPW563HNRAOERP7C@test.waku.nodes.status.im"]
-    of Fleet.StatusTest, Fleet.StatusProd:
-      newConfiguration.ClusterConfig.RelayNodes = self.fleetConfiguration.getNodes(fleetType, FleetNodes.TCP_P2P_Waku)
-      newConfiguration.ClusterConfig.StoreNodes = self.fleetConfiguration.getNodes(fleetType, FleetNodes.TCP_P2P_Waku)
-      newConfiguration.ClusterConfig.FilterNodes = self.fleetConfiguration.getNodes(fleetType, FleetNodes.TCP_P2P_Waku)
-      newConfiguration.ClusterConfig.LightpushNodes = self.fleetConfiguration.getNodes(fleetType, FleetNodes.TCP_P2P_Waku)
+      dnsDiscoveryURL.add("enrtree://AOGECG2SPND25EEFMAJ5WF3KSGJNSGV356DSTL2YVLLZWIV6SAYBM@test.waku.nodes.status.im")
+    of Fleet.StatusTest:
+      dnsDiscoveryURL.add("enrtree://AOGECG2SPND25EEFMAJ5WF3KSGJNSGV356DSTL2YVLLZWIV6SAYBM@test.nodes.status.im")
+    of Fleet.StatusProd:
+      dnsDiscoveryURL.add("enrtree://AOGECG2SPND25EEFMAJ5WF3KSGJNSGV356DSTL2YVLLZWIV6SAYBM@prod.nodes.status.im")
     else:
       wakuVersion = 1
 
-  if fleetType == Fleet.StatusTest:
-    newConfiguration.ClusterConfig.DiscV5BootstrapNodes = @[
-      "enr:-JK4QM2ylZVUhVPqXrqhWWi38V46bF2XZXPSHh_D7f2PmUHbIw-4DidCBnBnm-IbxtjXOFbdMMgpHUv4dYVH6TgnkucBgmlkgnY0gmlwhCJ6_HaJc2VjcDI1NmsxoQM06FsT6EJ57mzR_wiLu2Bz1dER2nUFSCpaXzCccQtnhYN0Y3CCdl-DdWRwgiMohXdha3UyDw",
-      "enr:-JK4QAi2yenhIbflVpUtkLDAM7yR5qeinZSQ_TNxfAWxdffkQWlstXyspEUlapiLl-S_MTPyp5V1uiV14ATjcVU_iLoBgmlkgnY0gmlwhC_y6SSJc2VjcDI1NmsxoQJkb7I6j5X1-zjieMeBdxgDqQWuMuDUEqDR419lyKNZb4N0Y3CCdl-DdWRwgiMohXdha3UyDw",
-      "enr:-JK4QIGyJyjSlponBZqe9XZ75b5ePSU9fWw5UtxEF1vsYXTLYkTa4psnUxJPmOcJGVt9XCYpC2h2kNoowl1t5KzuW6wBgmlkgnY0gmlwhEDhUe2Jc2VjcDI1NmsxoQIE3HkSvDkl2zD64j2kGMH9XZHpuu-5VYT4wnBgJApW_oN0Y3CCdl-DdWRwgiMohXdha3UyDw"
-    ]
-
-  if fleetType == Fleet.StatusProd:
-    newConfiguration.ClusterConfig.DiscV5BootstrapNodes = @[     
-      "enr:-JK4QM_67uA3pGij4m6J0Bka7-Hzb7HdHXVfopgOD8HAMvD_YlPz9nJ9WLsXJMsG8naD8cRwpzx56bojkwKnX24-UwMBgmlkgnY0gmlwhCPKN5mJc2VjcDI1NmsxoQIaKnT5AGTbzUbsxHnAxsJ7eVGxffKsDNej2RtyZlupFIN0Y3CCdl-DdWRwgiMohXdha3UyDw",
-      "enr:-JK4QHlrYkod8u0NYpBV_1iVCeiU6jVn80UJtbbyOMuO5gkIUGmfSxfMjNrcxkApxHGGiVDizs_6_SzoOAxS6zMxg7YBgmlkgnY0gmlwhCKE1emJc2VjcDI1NmsxoQMLQEj6Ys-Rqt87hblheDE74kFYqYtx2kBsrRfuMH23b4N0Y3CCdl-DdWRwgiMohXdha3UyDw",
-      "enr:-JK4QF8RVwcRLTV0hfSwvpZECy1j8YKu7uy8z7X82qoQC_5LbdTkfRdPiuCgdjydbR3Bti6rvG4hqGtwSlIWDVZDadcBgmlkgnY0gmlwhC_zgIaJc2VjcDI1NmsxoQMxOGCAazyuaE__TL2BHoIJmg3dtOYlODZ9TAIVOcamOYN0Y3CCdl-DdWRwgiMohXdha3UyDw"
-    ]
-
-  # Disabling go-waku rendezvous
-  # newConfiguration.ClusterConfig.WakuRendezvousNodes = self.fleetConfiguration.getNodes(Fleet.GoWakuTest, FleetNodes.LibP2P)
+  newConfiguration.ClusterConfig.RelayNodes = dnsDiscoveryURL
+  newConfiguration.ClusterConfig.StoreNodes = dnsDiscoveryURL
+  newConfiguration.ClusterConfig.FilterNodes = dnsDiscoveryURL
+  newConfiguration.ClusterConfig.LightpushNodes = dnsDiscoveryURL
+  newConfiguration.ClusterConfig.DiscV5BootstrapNodes = dnsDiscoveryURL
 
   newConfiguration = setWakuConfig(newConfiguration, wakuVersion)
-
 
   try:
     discard status_node_config.switchFleet(fleet, newConfiguration.toJsonNode())


### PR DESCRIPTION
Desktop should still connect to the waku2 nodes described in fleets.status.im