### PR TITLE
feat(CreateChatView): Support pasting chat key

### DIFF
--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -753,7 +753,7 @@ method getVerificationRequestFrom*[T](self: Module[T], publicKey: string): Verif
   self.controller.getVerificationRequestFrom(publicKey)
 
 method getContactDetailsAsJson*[T](self: Module[T], publicKey: string): string =
-  let contact =  self.controller.getContact(publicKey)
+  let contact = self.controller.getContact(publicKey)
   let (name, _, _) = self.controller.getContactNameAndImage(contact.id)
   let request = self.getVerificationRequestFrom(publicKey)
   let jsonObj = %* {

--- a/ui/app/AppLayouts/Chat/panels/InlineSelectorPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/InlineSelectorPanel.qml
@@ -29,6 +29,7 @@ Item {
 
     signal entryAccepted(var suggestionsDelegate)
     signal entryRemoved(var delegate)
+    signal textPasted(string text)
 
     implicitWidth: mainLayout.implicitWidth
     implicitHeight: mainLayout.implicitHeight
@@ -89,6 +90,11 @@ Item {
                                 verticalAlignment: Text.AlignVCenter
                                 font.pixelSize: 15
                                 color: Theme.palette.directColor1
+
+                                selectByMouse: true
+                                selectionColor: Theme.palette.primaryColor2
+                                selectedTextColor: color
+
                                 cursorDelegate: Rectangle {
                                     color: Theme.palette.primaryColor1
                                     implicitWidth: 2
@@ -103,6 +109,16 @@ Item {
                                 }
 
                                 Keys.onPressed: {
+                                    if (event.matches(StandardKey.Paste)) {
+                                        event.accepted = true
+                                        const previousText = text;
+                                        const previousSelectedText = selectedText;
+                                        paste()
+                                        if (previousText === "" || previousSelectedText.length === previousText.length)
+                                            root.textPasted(text)
+                                        return;
+                                    }
+
                                     if (suggestionsDialog.visible) {
                                         if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
                                             root.entryAccepted(suggestionsListView.itemAtIndex(suggestionsListView.currentIndex))

--- a/ui/app/AppLayouts/Chat/views/CreateChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/CreateChatView.qml
@@ -41,7 +41,6 @@ Page {
                 Layout.leftMargin: Style.current.halfPadding
                 Layout.rightMargin: Style.current.halfPadding
                 rootStore: root.rootStore
-                enabled: root.rootStore.contactsModel.count > 0
 
                 function createChat() {
                     if (model.count === 0) {
@@ -78,7 +77,10 @@ Page {
                     Global.closeCreateChatView()
                 }
 
-                onVisibleChanged: if (visible) edit.forceActiveFocus()
+                onVisibleChanged: {
+                    if (visible)
+                        edit.forceActiveFocus()
+                }
             }
 
             StatusActivityCenterButton {
@@ -110,6 +112,7 @@ Page {
             StatusListView {
                 id: contactsList
 
+                Layout.fillWidth: true
                 Layout.fillHeight: true
 
                 visible: membersSelector.suggestionsModel.count &&
@@ -117,6 +120,7 @@ Page {
                 implicitWidth: contentItem.childrenRect.width
                 model: membersSelector.suggestionsModel
                 delegate: ContactListItemDelegate {
+                    width: ListView.view.width
                     onClicked: membersSelector.entryAccepted(this)
                 }
             }

--- a/ui/app/AppLayouts/Chat/views/MembersSelectorView.qml
+++ b/ui/app/AppLayouts/Chat/views/MembersSelectorView.qml
@@ -7,6 +7,8 @@ import StatusQ.Components 0.1
 
 import "private"
 
+import utils 1.0
+
 import SortFilterProxyModel 0.2
 
 MembersSelectorBase {
@@ -20,14 +22,18 @@ MembersSelectorBase {
     }
 
     onEntryAccepted: {
-        if (!root.limitReached) {
-            d.addMember(suggestionsDelegate._pubKey, suggestionsDelegate.userName)
+        if (root.limitReached)
+            return
+        if (d.addMember(suggestionsDelegate._pubKey, suggestionsDelegate.userName))
             root.edit.clear()
-        }
     }
 
     onEntryRemoved: {
         d.removeMember(delegate._pubKey)
+    }
+
+    onTextPasted: {
+        d.lookupContact(text);
     }
 
     model: SortFilterProxyModel {
@@ -47,12 +53,25 @@ MembersSelectorBase {
 
         property ListModel selectedMembers: ListModel {}
 
+        function lookupContact(value) {
+            if (value.startsWith(Constants.userLinkPrefix))
+                value = value.slice(Constants.userLinkPrefix.length)
+            root.rootStore.contactsStore.resolveENS(value)
+        }
+
         function addMember(pubKey, displayName) {
+            for (let i = 0; i < d.selectedMembers.count; ++i) {
+                if (d.selectedMembers.get(i).pubKey === pubKey)
+                    return false
+            }
+
             d.selectedMembers.append({
                                          "pubKey": pubKey,
                                          "displayName": displayName
                                      })
+            return true
         }
+
         function removeMember(pubKey) {
             for(var i = 0; i < d.selectedMembers.count; i++) {
                 const obj = d.selectedMembers.get(i)
@@ -60,6 +79,36 @@ MembersSelectorBase {
                     d.selectedMembers.remove(i)
                     return
                 }
+            }
+        }
+    }
+
+    Connections {
+        enabled: root.visible
+        target: root.rootStore.contactsStore.mainModuleInst
+        onResolvedENS: {
+
+            if (resolvedPubKey === "")
+                return
+
+            const contactDetails = Utils.getContactDetailsAsJson(resolvedPubKey)
+
+            if (contactDetails.publicKey === root.rootStore.contactsStore.myPublicKey)
+                return;
+
+            if (contactDetails.isBlocked)
+                return;
+
+            if (contactDetails.isContact) {
+                if (d.addMember(contactDetails.publicKey, contactDetails.displayName))
+                    root.cleanup()
+                return
+            }
+
+            if (root.model.count === 0) {
+                const popup = Global.openContactRequestPopup(contactDetails.publicKey)
+                popup.closed.connect(root.rejected)
+                return
             }
         }
     }

--- a/ui/imports/shared/popups/ProfilePopup.qml
+++ b/ui/imports/shared/popups/ProfilePopup.qml
@@ -124,7 +124,7 @@ StatusDialog {
         if (state === Constants.profilePopupStates.openNickname) {
             profileView.nicknamePopup.open();
         } else if (state === Constants.profilePopupStates.contactRequest) {
-            sendContactRequestModal.open()
+            d.openContactRequestPopup()
         } else if (state === Constants.profilePopupStates.blockUser) {
             blockUser();
         } else if (state === Constants.profilePopupStates.unblockUser) {
@@ -165,6 +165,15 @@ StatusDialog {
             })
         } catch (e) {
             console.error("Error getting or parsing verification data", e)
+        }
+    }
+
+    QtObject {
+        id: d
+
+        function openContactRequestPopup() {
+            let contactRequestPopup = Global.openContactRequestPopup(popup.userPublicKey)
+            contactRequestPopup.closed.connect(popup.close)
         }
     }
 
@@ -238,7 +247,7 @@ StatusDialog {
             StatusButton {
                 text: qsTr("Send Contact Request")
                 visible: !userIsBlocked && !isAddedContact
-                onClicked: sendContactRequestModal.open()
+                onClicked: d.openContactRequestPopup()
             }
 
             StatusButton {
@@ -449,21 +458,6 @@ StatusDialog {
                 popup.close()
             }
         }
-    }
-
-    // TODO: replace with StatusStackModal
-    SendContactRequestModal {
-        id: sendContactRequestModal
-        anchors.centerIn: parent
-        width: popup.width
-        visible: false
-        header.title: qsTr("Send Contact Request to %1").arg(userDisplayName)
-        userPublicKey: popup.userPublicKey
-        userDisplayName: popup.userDisplayName
-        userIcon: popup.userIcon
-        userIsEnsVerified: popup.userIsEnsVerified
-        onAccepted: popup.contactsStore.sendContactRequest(userPublicKey, message)
-        onClosed: popup.close()
     }
 
     Component {

--- a/ui/imports/shared/popups/SendContactRequestModal.qml
+++ b/ui/imports/shared/popups/SendContactRequestModal.qml
@@ -22,6 +22,7 @@ StatusModal {
     signal accepted(string message)
 
     padding: 16
+    header.title: qsTr("Send Contact Request to %1").arg(userDisplayName)
 
     QtObject {
         id: d

--- a/ui/imports/shared/popups/qmldir
+++ b/ui/imports/shared/popups/qmldir
@@ -22,3 +22,4 @@ ImageCropWorkflow 1.0 ImageCropWorkflow.qml
 ImportCommunityPopup 1.0 ImportCommunityPopup.qml
 DisplayNamePopup 1.0 DisplayNamePopup.qml
 AddEditSavedAddressPopup 1.0 AddEditSavedAddressPopup.qml
+SendContactRequestModal 1.0 SendContactRequestModal.qml

--- a/ui/imports/utils/Global.qml
+++ b/ui/imports/utils/Global.qml
@@ -3,7 +3,9 @@ pragma Singleton
 import QtQuick 2.13
 import AppLayouts.Chat.popups 1.0
 
-QtObject {
+import shared.popups 1.0
+
+Item {
     id: root
 
     property var applicationWindow
@@ -40,6 +42,16 @@ QtObject {
     signal displayToastMessage(string title, string subTitle, string icon, bool loading, int ephNotifType, string url)
     signal openEditDisplayNamePopup()
     signal openActivityCenterPopupRequested
+
+    function openContactRequestPopup(publicKey) {
+        const contactDetails = Utils.getContactDetailsAsJson(publicKey);
+        return openPopup(sendContactRequestPopupComponent, {
+            userPublicKey: publicKey,
+            userDisplayName: contactDetails.displayName,
+            userIcon: contactDetails.largeImage,
+            userIsEnsVerified: contactDetails.ensVerified,
+        })
+    }
 
     function openProfilePopup(publicKey, parentPopup, state = "") {
         openProfilePopupRequested(publicKey, parentPopup, state);
@@ -106,5 +118,14 @@ QtObject {
 
     function settingsHasLoaded() {
         settingsLoaded()
+    }
+
+    Component {
+        id: sendContactRequestPopupComponent
+        SendContactRequestModal {
+            anchors.centerIn: parent
+            onAccepted: appMain.rootStore.profileSectionStore.contactsStore.sendContactRequest(userPublicKey, message)
+            onClosed: destroy()
+        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/7176

### What does the PR do

Open a "Send contact request" popup when user pastes a valid chat key to "create chat" text field.
Supported values are:
- Public key
- Public key wrapped in a URL
- Compressed key
- Compressed key wrapped in a URL

⚠️  I also made an important (but not a breaking) change - I switched `Global` root item from `QtObject` to `Item`, so that Components could be create right there. This is needed so that we could get the reference to created popup whenever we use `Global.openContactRequestPopup`. In this particular case we bind to it's `closed` signal.

⚠️ Also I made changes to Nim contacts service:
`getContactById` now supports compressed keys.

### Affected areas

CreateChat, ProfilePopup

### Screenshot of functionality (including design for comparison)

https://user-images.githubusercontent.com/25482501/190861714-7213eeb0-42bc-41bd-8d9c-3b7be2e9726b.mov

