### PR TITLE
fix(@desktop/community): update new category handling

### DIFF
--- a/src/app_service/service/community/service.nim
+++ b/src/app_service/service/community/service.nim
@@ -238,8 +238,8 @@ QtObject:
     result = @[]
     for chat in community.chats:
       if (chat.categoryId == categoryId):
-        let fullChatId = community.id & chat.id
-        var chatDetails = self.chatService.getChatById(fullChatId)
+        # TODO: chat.id already contains community.id here but it was not expected, this requires investigation
+        var chatDetails = self.chatService.getChatById(chat.id)
         result.add(chatDetails)
 
   proc handleCommunitiesSettingsUpdates(self: Service, communitiesSettings: seq[CommunitySettingsDto]) =


### PR DESCRIPTION

Fixes #7380

### What does the PR do

After some investigation I found out that getChatById for new category channels is using wrong parameter.
Looks like old channels moved to new category already have correct chat.id and no need to search by fullChatId.

### Affected areas

Desktop Community

### Screenshot of functionality 

https://user-images.githubusercontent.com/6445843/190864893-4cd5f9d8-a49b-4adb-8dc8-9065c4114501.mp4




