### PR TITLE
fix(PinnedMessagesPopup): “Jump to” button doesn’t work in pinned messages popup

### DIFF
--- a/src/app/modules/main/chat_section/chat_content/messages/view.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/view.nim
@@ -166,3 +166,6 @@ QtObject:
   proc refreshAMessageUserRespondedTo(self: View, msgId: string) {.signal.}
   proc emitRefreshAMessageUserRespondedToSignal*(self: View, msgId: string) =
     self.refreshAMessageUserRespondedTo(msgId)
+
+  proc jumpToMessage*(self: View, messageId: string) {.slot.} =
+    self.delegate.scrollToMessage(messageId)

--- a/ui/app/AppLayouts/Chat/popups/PinnedMessagesPopup.qml
+++ b/ui/app/AppLayouts/Chat/popups/PinnedMessagesPopup.qml
@@ -15,6 +15,7 @@ StatusDialog {
 
     property var store
     property var messageStore
+    property var messagesModule
     property var pinnedMessagesModel //this doesn't belong to the messageStore, it is a part of the ChatContentStore, but we didn't introduce it yet.
     property string messageToPin
     property string messageToUnpin
@@ -149,6 +150,10 @@ StatusDialog {
 
             onOpenProfileClicked: {
                 Global.openProfilePopup(publicKey, null, state)
+            }
+
+            onJumpToMessage: {
+                root.messagesModule.jumpToMessage(messageId);
             }
         }
     }

--- a/ui/app/AppLayouts/Chat/views/ChatContentView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatContentView.qml
@@ -95,6 +95,7 @@ ColumnLayout {
             Global.openPopup(Global.pinnedMessagesPopup, {
                                  store: rootStore,
                                  messageStore: messageStore,
+                                 messagesModule: chatContentModule.messagesModule,
                                  pinnedMessagesModel: chatContentModule.pinnedMessagesModel,
                                  messageToPin: messageId
                              })

--- a/ui/app/AppLayouts/Chat/views/ChatHeaderContentView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatHeaderContentView.qml
@@ -291,12 +291,13 @@ RowLayout {
 
             onPinnedMessagesCountClicked: {
                 if(!chatContentModule) {
-                    console.debug("error on open pinned messages - chat content module is not set")
+                    console.warn("error on open pinned messages - chat content module is not set")
                     return
                 }
                 Global.openPopup(Global.pinnedMessagesPopup, {
                                      store: rootStore,
                                      messageStore: root.rootStore.messageStore,
+                                     messagesModule: chatContentModule.messagesModule,
                                      pinnedMessagesModel: chatContentModule.pinnedMessagesModel,
                                      messageToPin: ""
                                  })

--- a/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
@@ -7,6 +7,7 @@ import QtGraphicalEffects 1.13
 import QtQuick.Dialogs 1.3
 
 import StatusQ.Core 0.1
+import StatusQ.Core.Theme 0.1
 import StatusQ.Controls 0.1
 import StatusQ.Components 0.1
 
@@ -18,11 +19,6 @@ import shared.popups 1.0
 import shared.status 1.0
 import shared.controls 1.0
 import shared.views.chat 1.0
-
-import StatusQ.Core 0.1
-import StatusQ.Core.Theme 0.1
-import StatusQ.Controls 0.1
-import StatusQ.Components 0.1
 
 import "../controls"
 

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -744,6 +744,7 @@ Loader {
                             Global.openPopup(Global.pinnedMessagesPopup, {
                                                  store: root.rootStore,
                                                  messageStore: messageStore,
+                                                 messagesModule: chatContentModule.messagesModule,
                                                  pinnedMessagesModel: chatContentModule.pinnedMessagesModel,
                                                  messageToPin: root.messageId
                                              });


### PR DESCRIPTION
This was never implemented, eventhough a similar approach is used with the global AppSearch. Expose the method `scrollToMessage(messageId)` so that it can be called from QML directly.

Fixes #7375

### Affected areas

PinnedMessagesPopup

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

Selecting the message to jump to:
![Snímek obrazovky z 2022-09-19 10-44-50](https://user-images.githubusercontent.com/5377645/190981119-3c68cd85-59ae-415d-839e-942772682c43.png)

Message selected & highlighted:
![Snímek obrazovky z 2022-09-19 10-44-54](https://user-images.githubusercontent.com/5377645/190981177-94ae0003-70e9-4aaa-9144-50af09de747a.png)

