### PR TITLE
fix(@desktop/chat): Do not show chat identicons

### DIFF
--- a/src/app_service/service/chat/dto/chat.nim
+++ b/src/app_service/service/chat/dto/chat.nim
@@ -237,8 +237,6 @@ proc toChatDto*(jsonObj: JsonNode): ChatDto =
   discard jsonObj.getProp("image", chatImage)
   if (result.chatType == ChatType.PrivateGroupChat and len(chatImage) > 0):
     result.icon = chatImage
-  else:
-    discard jsonObj.getProp("identicon", result.icon)
 
   var membersObj: JsonNode
   if(jsonObj.getProp("members", membersObj)):


### PR DESCRIPTION
Fix #7371

### What does the PR do

Do not show default chat identicon created by status-go.
Identicons can't be removed from status-go now, because they are still needed in mobile apps.

### Affected areas

Chat

### Screenshot of functionality (including design for comparison)

User w/o icon:

![image](https://user-images.githubusercontent.com/61889657/191002157-b04f9fb5-de10-487f-8be6-2ee72df12d6e.png)

User with icon:

![image](https://user-images.githubusercontent.com/61889657/191002254-d2c00703-1ab0-4464-93a0-da633c859695.png)

