### PR TITLE
fix(@desktop/wallet): Fix the emoji and text placement in the SendModal

### DIFF
--- a/ui/imports/shared/views/SendModalHeader.qml
+++ b/ui/imports/shared/views/SendModalHeader.qml
@@ -38,14 +38,12 @@ StatusFloatingButtonsSelector {
         color: Theme.palette.baseColor3
         StatusButton {
             id: button
-            topPadding: 8
-            bottomPadding: 0
+            size: StatusBaseButton.Size.Tiny
             implicitHeight: 32
             leftPadding: 4
             text: name
             objectName: name
             asset.emoji: !!emoji ? emoji: ""
-            asset.emojiSize: StatusQUtils.Emoji.size.middle
             icon.name: !emoji ? "filled-account": ""
             normalColor: "transparent"
             hoverColor: Theme.palette.statusFloatingButtonHighlight


### PR DESCRIPTION
fixes #7427

### What does the PR do

Updated usage of the StatusButton in the SendModalHeader to make the text and emoji centre-aligned 

### Affected areas

Wallet

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

<img width="1514" alt="Screenshot 2022-09-19 at 2 27 27 PM" src="https://user-images.githubusercontent.com/60327365/191017604-dfe9321e-8aa8-4c06-a7dd-0ec17d813549.png">

