### PR TITLE
fix(@desktop/community): Only admin can open community settings

### DIFF
--- a/ui/app/AppLayouts/Chat/views/CommunityColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/CommunityColumnView.qml
@@ -58,7 +58,7 @@ Item {
         asset.name: communityData.image
         asset.color: communityData.color
         asset.isImage: true
-        onClicked: root.infoButtonClicked()
+        onClicked: if (communityData.amISectionAdmin) { root.infoButtonClicked() }
         anchors.top: parent.top
         anchors.topMargin: Style.current.smallPadding
         anchors.left: parent.left
@@ -66,6 +66,7 @@ Item {
         anchors.right: (implicitWidth > parent.width - 50) ? adHocChatButton.left : undefined
         anchors.rightMargin: Style.current.halfPadding
         type: StatusChatInfoButton.Type.OneToOneChat
+        hoverEnabled: communityData.amISectionAdmin
     }
 
     StatusIconTabButton {


### PR DESCRIPTION
Fix #7379

### What does the PR do

Only admin can open community settings.

### Affected areas

Community

### Screenshot of functionality (including design for comparison)

https://user-images.githubusercontent.com/61889657/191026430-05bc1d95-cb7e-4eab-897d-04cc82a6a09b.mov


