### PR TITLE
fix(ChatHeaderContentView): don't display "Contact" subtitle

### DIFF
--- a/ui/app/AppLayouts/Chat/views/ChatHeaderContentView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatHeaderContentView.qml
@@ -259,10 +259,6 @@ RowLayout {
                 // In some moment in future this should be part of the backend logic.
                 // (once we add transaltion on the backend side)
                 switch (chatContentModule.chatDetails.type) {
-                case Constants.chatType.oneToOne:
-                    return (chatContentModule.isMyContact(chatContentModule.chatDetails.id) ?
-                                qsTr("Contact") :
-                                qsTr("Not a contact"))
                 case Constants.chatType.publicChat:
                     return qsTr("Public chat")
                 case Constants.chatType.privateGroupChat:


### PR DESCRIPTION
for 1-to-1 chats; makes sense as you can't have chats with non-contacts anyway.

Other types of chats unaffected

Fixes: #7419

### Affected areas

ChatHeaderContentView

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

1-to-1 chat:
![Snímek obrazovky z 2022-09-20 17-22-51](https://user-images.githubusercontent.com/5377645/191298977-21b34f90-0215-465e-aaf8-8b844e2b4263.png)

Community chat:
![Snímek obrazovky z 2022-09-20 17-23-03](https://user-images.githubusercontent.com/5377645/191299060-290cbdec-20ed-4285-9149-c85dc5b2c488.png)


