### PR TITLE
hotfix: unbreak opening URLs in the builtin browser

### DIFF
--- a/ui/app/AppLayouts/Browser/BrowserLayout.qml
+++ b/ui/app/AppLayouts/Browser/BrowserLayout.qml
@@ -29,6 +29,11 @@ StatusSectionLayout {
     property var globalStore
     property var sendTransactionModal
 
+    function openUrlInNewTab(url) {
+        var tab = _internal.addNewTab()
+        tab.item.url = _internal.determineRealURL(url)
+    }
+
     onNotificationButtonClicked: Global.openActivityCenterPopup()
     QtObject {
         id: _internal
@@ -140,12 +145,6 @@ StatusSectionLayout {
         id: browserWindow
         anchors.fill: parent
         color: Style.current.inputBackground
-
-
-        function openUrlInNewTab(url) {
-            var tab = _internal.addNewTab()
-            tab.item.url = _internal.determineRealURL(url)
-        }
 
         WebProviderObj {
             id: provider
@@ -323,7 +322,7 @@ StatusSectionLayout {
         FavoriteMenu {
             id: favoriteMenu
             openInNewTab: function (url) {
-                browserWindow.openUrlInNewTab(url)
+                root.openUrlInNewTab(url)
             }
             onEditFavoriteTriggered: {
                 Global.openPopup(addFavoriteModal, {
@@ -614,7 +613,7 @@ StatusSectionLayout {
     Connections {
         target: browserSection
         onOpenUrl: {
-            browserWindow.openUrlInNewTab(url);
+            root.openUrlInNewTab(url);
         }
     }
 }


### PR DESCRIPTION
The functions needs to stay at the toplevel to be accessible from AppMain

`qrc:/app/mainui/AppMain.qml:70: TypeError: Property 'openUrlInNewTab' of object BrowserLayout_QMLTYPE_1747(0x60000f69da20) is not a function`

Fixes: #7434

### What does the PR do

Fixes opening links in the builtin browser

### Affected areas

BrowserLayout, AppMain

### Screenshot of functionality (including design for comparison)

- [N/A] I've checked the design and this PR matches it

