### PR TITLE
feat(PinnedMessagesPopup): enable Unpin context menu entry

### DIFF
--- a/ui/app/AppLayouts/Chat/popups/PinnedMessagesPopup.qml
+++ b/ui/app/AppLayouts/Chat/popups/PinnedMessagesPopup.qml
@@ -136,24 +136,12 @@ StatusDialog {
                 root.close()
             }
 
-            onPinMessage: {
-                root.messageStore.pinMessage(messageId)
-            }
-
             onUnpinMessage: {
-                root.messageStore.unpinMessage(messageId)
-            }
-
-            onToggleReaction: {
-                root.messageStore.toggleReaction(messageId, emojiId)
-            }
-
-            onOpenProfileClicked: {
-                Global.openProfilePopup(publicKey, null, state)
+                root.messagesModule.unpinMessage(messageId)
             }
 
             onJumpToMessage: {
-                root.messagesModule.jumpToMessage(messageId);
+                root.messagesModule.jumpToMessage(messageId)
             }
         }
     }

--- a/ui/imports/shared/views/chat/MessageContextMenuView.qml
+++ b/ui/imports/shared/views/chat/MessageContextMenuView.qml
@@ -410,6 +410,9 @@ StatusPopupMenu {
         }
         icon.name: "pin"
         enabled: {
+            if (root.pinnedPopup)
+                return true
+
             if(root.isProfile || root.isEmoji || root.isRightClickOnImage)
                 return false
 


### PR DESCRIPTION
and remove the context actions we do not actually use

Fixes: #7439

### What does the PR do

Adds the "Unpin" action to the messages' context menu in this popup

### Affected areas

PinnedMessagesPopup

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

Context menu:
![Snímek obrazovky z 2022-09-20 11-42-11](https://user-images.githubusercontent.com/5377645/191225063-67e3cef5-e399-4a82-a7d2-0a32e48d870e.png)

Unpin action performed:
![Snímek obrazovky z 2022-09-20 11-42-15](https://user-images.githubusercontent.com/5377645/191225157-0e4d0363-7906-4dba-8d43-3a0ac557c770.png)

