### PR TITLE
fix(MyProfileSettingsView): adjust biometrics switch padding

### DIFF
--- a/ui/app/AppLayouts/Profile/views/profile/MyProfileSettingsView.qml
+++ b/ui/app/AppLayouts/Profile/views/profile/MyProfileSettingsView.qml
@@ -127,8 +127,6 @@ ColumnLayout {
     StatusListItem {
         Layout.fillWidth: true
         visible: Qt.platform.os == "osx"
-        leftPadding: 0
-        rightPadding: 0
         title: qsTr("Biometric login and transaction authentication")
         asset.name: "touch-id"
         components: [ StatusSwitch {


### PR DESCRIPTION
Fixes #7306

### What does the PR do

Fixes the biometrics switch entry's horizontal padding

### Affected areas

MyProfileSettingsView

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

Before:
![Snímek obrazovky z 2022-09-20 13-15-11](https://user-images.githubusercontent.com/5377645/191245571-4626a4de-b62e-429b-a0de-04a531efe491.png)

After:
![Snímek obrazovky z 2022-09-20 13-21-41](https://user-images.githubusercontent.com/5377645/191245614-6ce58d89-f0c8-4a6a-a3a0-a33f03c43b80.png)
