### PR TITLE
fix(TransferOwnershipPopup): copy button right margin

### DIFF
--- a/ui/app/AppLayouts/Chat/popups/community/TransferOwnershipPopup.qml
+++ b/ui/app/AppLayouts/Chat/popups/community/TransferOwnershipPopup.qml
@@ -8,6 +8,7 @@ import StatusQ.Core.Utils 0.1
 import StatusQ.Controls 0.1
 import StatusQ.Popups 0.1
 
+import utils 1.0
 import shared.controls 1.0
 import shared 1.0
 
@@ -42,6 +43,8 @@ StatusModal {
                 pKeyInput.input.text =  pKeyInput.input.edit.focus ? root.privateKey : elidedPkey
             }
             input.rightComponent: StatusButton {
+                anchors.right: parent.right
+                anchors.rightMargin: Style.current.halfPadding
                 anchors.verticalCenter: parent.verticalCenter
                 borderColor: Theme.palette.primaryColor1
                 size: StatusBaseButton.Size.Tiny


### PR DESCRIPTION
Closes #7412

### What does the PR do
Community/TransferOwnershipPopup: added right margin in copy button

### Affected areas
Community/TransferOwnershipPopup

### Screenshot of functionality (including design for comparison)
<img width="137" alt="cp" src="https://user-images.githubusercontent.com/31625338/191253278-f955e345-8462-4a6f-8771-b14b13e394a5.png">

