### PR TITLE
fix(CommunitySettingsView): Fixed sending community invitations

### DIFF
--- a/ui/app/AppLayouts/Chat/views/CommunitySettingsView.qml
+++ b/ui/app/AppLayouts/Chat/views/CommunitySettingsView.qml
@@ -242,7 +242,7 @@ StatusSectionLayout {
             }
 
             onSendInvites: (pubKeys, inviteMessage) => {
-                const error = root.communitySectionModule.inviteUsersToCommunity(JSON.stringify(pubKeys), inviteMessage);
+                const error = root.chatCommunitySectionModule.inviteUsersToCommunity(JSON.stringify(pubKeys), inviteMessage);
                 processInviteResult(error);
             }
         }


### PR DESCRIPTION
FIxes https://github.com/status-im/status-desktop/issues/7436

### What does the PR do

Fixed that community invitations weren't sent.

Note: 
I also reported this bug, but it's unrelated to this PR: https://github.com/status-im/status-desktop/issues/7455
The but seems to be in status-go.

### Affected areas

Community settings

### Screenshot of functionality (including design for comparison)

https://user-images.githubusercontent.com/25482501/191323354-e560029f-ebd5-4089-a795-d255fe7547b1.mov
