### PR TITLE
fix(@desktop/chat): handle same name mentions

### DIFF
--- a/ui/app/AppLayouts/Chat/views/ChatContentView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatContentView.qml
@@ -235,10 +235,10 @@ ColumnLayout {
                     }
 
                     if(root.rootStore.sendMessage(event,
-                                                             chatInput.textInput.text,
-                                                             chatInput.isReply? chatInput.replyMessageId : "",
-                                                             chatInput.fileUrls
-                                                             ))
+                                                  chatInput.getTextWithPublicKeys(),
+                                                  chatInput.isReply? chatInput.replyMessageId : "",
+                                                  chatInput.fileUrls
+                                                  ))
                     {
                         Global.sendMessageSound.stop();
                         Qt.callLater(Global.sendMessageSound.play);


### PR DESCRIPTION
Fixes #7220

### What does the PR do

After investigation I found that `replaceMentionsWithPubKeys` from `message.nim` always uses first known contact with some name which appears in message, and in case you have two or more contacts with same name the second one will never be used for replacing name with publicKey in message.
In order to have correct publicKeys instead of names I am adding `publicKey` into `mentionsPos` when inserting mentions into text. And instead of `textInput.text` I am using  `getTextWithPublicKeys` function when passing message to Chat RootStore. This function replaces names with publicKeys based on information from 'mentionPos' which has information about name, publicKey, leftIndex and rightIndex.

### Affected areas

Desktop Chat

### Screenshot of functionality

https://user-images.githubusercontent.com/6445843/191431123-1a31c74f-0137-4497-b637-164da59870be.mp4



