### PR TITLE
fix(@desktop/chat): adjust chat name placement

### DIFF
--- a/ui/imports/shared/views/chat/ChannelIdentifierView.qml
+++ b/ui/imports/shared/views/chat/ChannelIdentifierView.qml
@@ -42,12 +42,13 @@ Column {
     StyledText {
         id: channelName
         objectName: "channelIdentifierNameText"
+        width: parent.width
         wrapMode: Text.Wrap
         text: root.chatName
         font.weight: Font.Bold
         font.pixelSize: 22
         color: Style.current.textColor
-        anchors.horizontalCenter: parent.horizontalCenter
+        horizontalAlignment: Text.AlignHCenter
     }
 
     StatusBaseText {


### PR DESCRIPTION
Fixes #7353

### What does the PR do

Adjust chat name properties to wrap on small width

### Affected areas

Desktop Chat

### Screenshot of functionality 

https://user-images.githubusercontent.com/6445843/191476243-0c5dfcb0-b2d9-4971-87d1-f6c5e72c9be9.mp4



