### PR TITLE
ci: abort old PR builds to make queue shorter

### DIFF
--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -1,5 +1,8 @@
 library 'status-jenkins-lib@v1.5.6'
 
+/* Options section can't access functions in objects. */
+def isPRBuild = utils.isPRBuild()
+
 pipeline {
   agent {
     docker {
@@ -33,6 +36,10 @@ pipeline {
       daysToKeepStr: '30',
       artifactNumToKeepStr: '3',
     ))
+    /* Abort old PR builds. */
+    disableConcurrentBuilds(
+      abortPrevious: isPRBuild
+    )
   }
 
   environment {

--- a/ci/Jenkinsfile.linux-cpp
+++ b/ci/Jenkinsfile.linux-cpp
@@ -1,5 +1,8 @@
 library 'status-jenkins-lib@v1.5.6'
 
+/* Options section can't access functions in objects. */
+def isPRBuild = utils.isPRBuild()
+
 pipeline {
   agent {
     dockerfile {
@@ -29,6 +32,10 @@ pipeline {
       daysToKeepStr: '30',
       artifactNumToKeepStr: '3',
     ))
+    /* Abort old PR builds. */
+    disableConcurrentBuilds(
+      abortPrevious: isPRBuild
+    )
   }
 
   environment {

--- a/ci/Jenkinsfile.linux-cpp
+++ b/ci/Jenkinsfile.linux-cpp
@@ -74,22 +74,12 @@ pipeline {
       }
     }
 
-    // TODO: enable after generating the AppImage
-    // stage('Parallel Upload') {
-    //   parallel {
-    //     stage('Upload') {
-    //       steps { script {
-    //         env.PKG_URL = s3.uploadArtifact(env.STATUS_CLIENT_APPIMAGE)
-    //         jenkins.setBuildDesc(AppImage: env.PKG_URL)
-    //       } }
-    //     }
-    //     stage('Archive') {
-    //       steps { script {
-    //         archiveArtifacts("${env.STATUS_CLIENT_APPIMAGE}*")
-    //       } }
-    //     }
-    //   }
-    // }
+    stage('Upload') {
+      steps { script {
+        /* TODO: Enable after generating the AppImage. */
+        env.PKG_URL = "${currentBuild.absoluteUrl}/consoleText"
+      } }
+    }
   }
 
   post {

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -1,5 +1,8 @@
 library 'status-jenkins-lib@v1.5.6'
 
+/* Options section can't access functions in objects. */
+def isPRBuild = utils.isPRBuild()
+
 pipeline {
   agent {
     label 'macos && x86_64'
@@ -28,6 +31,10 @@ pipeline {
       daysToKeepStr: '30',
       artifactNumToKeepStr: '3',
     ))
+    /* Abort old PR builds. */
+    disableConcurrentBuilds(
+      abortPrevious: isPRBuild
+    )
   }
 
   environment {

--- a/ci/Jenkinsfile.macos-cpp.todo
+++ b/ci/Jenkinsfile.macos-cpp.todo
@@ -1,5 +1,8 @@
 library 'status-jenkins-lib@v1.5.6'
 
+/* Options section can't access functions in objects. */
+def isPRBuild = utils.isPRBuild()
+
 pipeline {
   agent {
     docker {
@@ -26,6 +29,10 @@ pipeline {
       daysToKeepStr: '30',
       artifactNumToKeepStr: '3',
     ))
+    /* Abort old PR builds. */
+    disableConcurrentBuilds(
+      abortPrevious: isPRBuild
+    )
   }
 
   environment {

--- a/ci/Jenkinsfile.uitests
+++ b/ci/Jenkinsfile.uitests
@@ -1,5 +1,8 @@
 library 'status-jenkins-lib@v1.5.1'
 
+/* Options section can't access functions in objects. */
+def isPRBuild = utils.isPRBuild()
+
 pipeline {
   agent { label 'linux' }
 
@@ -33,6 +36,10 @@ pipeline {
       categories: ['status-desktop-e2e-tests'],
       maxConcurrentPerNode: 1,
       maxConcurrentTotal: 1
+    )
+    /* Abort old PR builds. */
+    disableConcurrentBuilds(
+      abortPrevious: isPRBuild
     )
   }
 

--- a/ci/Jenkinsfile.windows
+++ b/ci/Jenkinsfile.windows
@@ -1,5 +1,8 @@
 library 'status-jenkins-lib@v1.5.6'
 
+/* Options section can't access functions in objects. */
+def isPRBuild = utils.isPRBuild()
+
 pipeline {
   agent { label 'windows' }
 
@@ -26,6 +29,10 @@ pipeline {
       daysToKeepStr: '30',
       artifactNumToKeepStr: '3',
     ))
+    /* Abort old PR builds. */
+    disableConcurrentBuilds(
+      abortPrevious: isPRBuild
+    )
   }
 
   environment {

--- a/ci/Jenkinsfile.windows-cpp.todo
+++ b/ci/Jenkinsfile.windows-cpp.todo
@@ -1,5 +1,8 @@
 library 'status-jenkins-lib@v1.5.6'
 
+/* Options section can't access functions in objects. */
+def isPRBuild = utils.isPRBuild()
+
 pipeline {
   agent {
     docker {
@@ -26,6 +29,10 @@ pipeline {
       daysToKeepStr: '30',
       artifactNumToKeepStr: '3',
     ))
+    /* Abort old PR builds. */
+    disableConcurrentBuilds(
+      abortPrevious: isPRBuild
+    )
   }
 
   environment {


### PR DESCRIPTION
In most cases developers only care about the most recent version.