### PR TITLE
fix(CommunitiesListPanel): set uniform icon size

### DIFF
--- a/ui/app/AppLayouts/Profile/panels/CommunitiesListPanel.qml
+++ b/ui/app/AppLayouts/Profile/panels/CommunitiesListPanel.qml
@@ -35,6 +35,8 @@ StatusListView {
         asset.isImage: asset.name.includes("data")
         asset.isLetterIdenticon: !model.image
         asset.bgColor: model.color || Theme.palette.primaryColor1
+        asset.width: 40
+        asset.height: 40
         visible: model.joined
         height: visible ? implicitHeight: 0
 


### PR DESCRIPTION
we want same icon sizes here, no matter if there's an image or not

Fixes: #7285

### What does the PR do

Unifies icon sizes in the communities list

### Affected areas

CommunitiesListPanel

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![Snímek obrazovky z 2022-09-21 13-24-29](https://user-images.githubusercontent.com/5377645/191491902-d8253bbb-cc6e-4188-a9f3-c118316573f2.png)
