### PR TITLE
fix(ChatMessagesView): unbreak closing reply bubble

### DIFF
--- a/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
@@ -250,7 +250,6 @@ Item {
             id: msgDelegate
 
             width: ListView.view.width
-            height: implicitHeight
 
             objectName: "chatMessageViewDelegate"
             rootStore: root.rootStore


### PR DESCRIPTION
remove the disastrous binding loop warning

Fixes: #7481

### What does the PR do

Fixes unclickable area at the bottom of the screen, overlapping messages, malfunctioning quick buttons and being unable to close the reply area

### Affected areas

ChatMessagesView

### Screenshot of functionality (including design for comparison)

- [N/A] I've checked the design and this PR matches it