### PR TITLE
fix(PinnedMessagesPopup): don't show empty replies and reactions

### DIFF
--- a/ui/app/AppLayouts/Chat/popups/PinnedMessagesPopup.qml
+++ b/ui/app/AppLayouts/Chat/popups/PinnedMessagesPopup.qml
@@ -70,11 +70,11 @@ StatusDialog {
                     messageContextMenu: msgContextMenu
 
                     messageId: model.id
-                    responseToMessageWithId: model.responseToMessageWithId
                     senderId: model.senderId
                     senderDisplayName: model.senderDisplayName
                     senderOptionalName: model.senderOptionalName
                     senderIsEnsVerified: model.senderEnsVerified
+                    senderIsAdded: model.senderIsAdded
                     senderIcon: model.senderIcon
                     amISender: model.amISender
                     messageText: model.messageText
@@ -84,7 +84,6 @@ StatusDialog {
                     messageContentType: model.contentType
                     pinnedMessage: model.pinned
                     messagePinnedBy: model.pinnedBy
-                    reactionsModel: model.reactions
                     senderTrustStatus: model.senderTrustStatus
                     linkUrls: model.links
                     transactionParams: model.transactionParameters


### PR DESCRIPTION
Fixes: #7498

### What does the PR do

Removes empty reply and reaction elements

### Affected areas

PinnedMessagesPopup

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![Snímek obrazovky z 2022-09-22 01-16-22](https://user-images.githubusercontent.com/5377645/191629999-9a2c012b-a4b2-4f79-92b7-f444dbb34ba0.png)

