### PR TITLE
fix: "Remove contact" button in ProfilePopup doesn't work

### DIFF
--- a/ui/imports/shared/popups/ConfirmationDialog.qml
+++ b/ui/imports/shared/popups/ConfirmationDialog.qml
@@ -11,7 +11,7 @@ StatusModal {
     id: confirmationDialog
     anchors.centerIn: parent
 
-    property Popup parentPopup
+    property var parentPopup
     property var value
     property var executeConfirm
     property var executeReject


### PR DESCRIPTION
Closes: #7519

### What does the PR do

Fixes the Remove Contact dialog being unavailable

### Affected areas

ProfilePopup

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it
![Snímek obrazovky z 2022-09-23 12-58-29](https://user-images.githubusercontent.com/5377645/191946729-f7a2ca1d-da3c-4347-a88b-cd9bb1e0b694.png)

