### PR TITLE
fix(wallet): fix never fetching transactions

### DIFF
--- a/ui/app/AppLayouts/Wallet/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Wallet/stores/RootStore.qml
@@ -147,7 +147,7 @@ QtObject {
     }
 
     function checkRecentHistory() {
-        walletSection.checkRecentHistory()
+        walletSectionTransactions.checkRecentHistory()
     }
 
      function fetchCollectionCollectiblesList(slug) {


### PR DESCRIPTION
### Fixes: #7266

The `RootStore` was calling `checkRecentHistory` on the wallet section `View` instead of the transaction `View`.

Still, the workflow is broken due to the 20 minutes timer that calls the `checkRecentHistory` and hangs the main thread (UI) for a long time

Required changes
- [x] fix `checkRecentHistory` call
- [x] ~~request transaction update only for the sender account~~ followup issue: https://github.com/status-im/status-desktop/issues/7530
  - We do this on demand when `Load More` button is pressed which doesn't work for the newly sent transaction
    - The button calls `transactions.view.nim->loadTransactionsForAccount` which doesn't update to include new transaction

Required improvements
- [x] ~~`checkRecentHistory` should not block the UI with many accounts to watch for~~
  - follow up issue https://github.com/status-im/status-desktop/issues/7530

### Affected areas

Wallet activity tab view (transactions)

### StatusQ checklist

- [x] ~~add documentation if necessary (new component, new feature)~~
- [x] ~~update sandbox app~~
- [x] ~~test changes in both light and dark theme?~~
