### PR TITLE
fix(@desktop/contacts): Do not show pending identity request when use…

### DIFF
--- a/ui/imports/shared/views/chat/MessageContextMenuView.qml
+++ b/ui/imports/shared/views/chat/MessageContextMenuView.qml
@@ -89,7 +89,9 @@ StatusPopupMenu {
         if (!root.selectedUserPublicKey || root.isMe || !root.isContact) {
             return false
         }
-        return root.outgoingVerificationStatus !== Constants.verificationStatus.unverified
+        return root.outgoingVerificationStatus !== Constants.verificationStatus.unverified &&
+                root.outgoingVerificationStatus !== Constants.verificationStatus.verified &&
+                root.outgoingVerificationStatus !== Constants.verificationStatus.trusted
     }
     readonly property bool isTrusted: {
         if (!root.selectedUserPublicKey || root.isMe || !root.isContact) {
@@ -264,7 +266,8 @@ StatusPopupMenu {
         text: qsTr("Verify Identity")
         icon.name: "checkmark-circle"
         enabled: root.isProfile && !root.isMe && root.isContact
-                                && !root.isBlockedContact && !root.isVerificationRequestSent
+                                && !root.isBlockedContact
+                                && root.outgoingVerificationStatus === Constants.verificationStatus.unverified
                                 && !root.hasReceivedVerificationRequestFrom
         onTriggered: {
             root.openProfileClicked(root.selectedUserPublicKey,


### PR DESCRIPTION
Fixes #7376

Do not show pending identity request when user is verified.

How to reproduce: described in the ticket

### Affected areas

Contacts

### Screenshot of functionality (including design for comparison)

![image](https://user-images.githubusercontent.com/61889657/192253734-21b73842-90d1-4f6c-890c-511897deb4e4.png)

