### PR TITLE
fix(@desktop/chat): add message sent and delivered handler

### DIFF
--- a/src/app/core/signals/remote_signals/messages.nim
+++ b/src/app/core/signals/remote_signals/messages.nim
@@ -30,6 +30,16 @@ type MessageSignal* = ref object of Signal
   clearedHistories*: seq[ClearedHistoryDto]
   verificationRequests*: seq[VerificationRequest]
 
+type MessageDeliveredSignal* = ref object of Signal
+  chatId*: string
+  messageId*: string
+
+proc fromEvent*(T: type MessageDeliveredSignal, event: JsonNode): MessageDeliveredSignal =
+  result = MessageDeliveredSignal()
+  result.signalType = SignalType.MessageDelivered
+  result.chatId = event["event"]["chatID"].getStr
+  result.messageId = event["event"]["messageID"].getStr
+
 proc fromEvent*(T: type MessageSignal, event: JsonNode): MessageSignal =
   var signal:MessageSignal = MessageSignal()
   signal.messages = @[]

--- a/src/app/core/signals/remote_signals/signal_type.nim
+++ b/src/app/core/signals/remote_signals/signal_type.nim
@@ -2,6 +2,7 @@
 
 type SignalType* {.pure.} = enum
   Message = "messages.new"
+  MessageDelivered = "message.delivered"
   Wallet = "wallet"
   NodeReady = "node.ready"
   NodeCrashed = "node.crashed"

--- a/src/app/core/signals/signals_manager.nim
+++ b/src/app/core/signals/signals_manager.nim
@@ -65,6 +65,7 @@ QtObject:
 
     result = case signalType:
       of SignalType.Message: MessageSignal.fromEvent(jsonSignal)
+      of SignalType.MessageDelivered: MessageDeliveredSignal.fromEvent(jsonSignal)
       of SignalType.EnvelopeSent: EnvelopeSentSignal.fromEvent(jsonSignal)
       of SignalType.EnvelopeExpired: EnvelopeExpiredSignal.fromEvent(jsonSignal)
       of SignalType.WhisperFilterAdded: WhisperFilterSignal.fromEvent(jsonSignal)

--- a/src/app/modules/main/chat_section/chat_content/messages/controller.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/controller.nim
@@ -77,6 +77,16 @@ proc init*(self: Controller) =
       return
     self.delegate.onSendingMessageError()
 
+  self.events.on(SIGNAL_ENVELOPE_SENT) do(e:Args):
+    let args = EnvelopeSentArgs(e)
+    self.delegate.onEnvelopeSent(args.messagesIds)
+
+  self.events.on(SIGNAL_MESSAGE_DELIVERED) do(e:Args):
+    let args = MessageDeliveredArgs(e)
+    if(self.chatId != args.chatId):
+      return
+    self.delegate.onMessageDelivered(args.messageId)
+
   self.events.on(SIGNAL_MESSAGE_PINNED) do(e:Args):
     let args = MessagePinUnpinArgs(e)
     if(self.chatId != args.chatId):

--- a/src/app/modules/main/chat_section/chat_content/messages/io_interface.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/io_interface.nim
@@ -53,6 +53,12 @@ method onSendingMessageSuccess*(self: AccessInterface, message: MessageDto) {.ba
 method onSendingMessageError*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method onEnvelopeSent*(self: AccessInterface, messagesIds: seq[string]) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method onMessageDelivered*(self: AccessInterface, messageId: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method updateContactDetails*(self: AccessInterface, contactId: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/chat_section/chat_content/messages/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/module.nim
@@ -268,6 +268,7 @@ method messageAdded*(self: Module, message: MessageDto) =
   let index = self.view.model().findIndexForMessageId(message.replace)
   if(index != -1):
     self.view.model().removeItem(message.replace)
+
   var item = initItem(
     message.id,
     message.communityId,
@@ -311,6 +312,13 @@ method onSendingMessageSuccess*(self: Module, message: MessageDto) =
 
 method onSendingMessageError*(self: Module) =
   self.view.emitSendingMessageErrorSignal()
+
+method onEnvelopeSent*(self: Module, messagesIds: seq[string]) =
+  for messageId in messagesIds:
+    self.view.model().itemSent(messageId)
+
+method onMessageDelivered*(self: Module, messageId: string) =
+  self.view.model().itemDelivered(messageId)
 
 method loadMoreMessages*(self: Module) =
   self.controller.loadMoreMessages()

--- a/src/app/modules/shared_models/message_item.nim
+++ b/src/app/modules/shared_models/message_item.nim
@@ -209,6 +209,9 @@ proc `senderEnsVerified=`*(self: Item, value: bool) {.inline.} =
 proc outgoingStatus*(self: Item): string {.inline.} =
   self.outgoingStatus
 
+proc `outgoingStatus=`*(self: Item, value: string) {.inline.} =
+  self.outgoingStatus = value
+
 proc messageText*(self: Item): string {.inline.} =
   self.messageText
 

--- a/src/app/modules/shared_models/message_model.nim
+++ b/src/app/modules/shared_models/message_model.nim
@@ -2,6 +2,8 @@ import NimQml, Tables, json, strutils, strformat
 
 import message_item, message_reaction_item, message_transaction_parameters_item
 
+import ../../../app_service/service/message/dto/message# as message_dto
+
 type
   ModelRole {.pure.} = enum
     Id = UserRole + 1
@@ -351,6 +353,20 @@ QtObject:
       return
 
     return self.items[ind]
+
+  proc setOutgoingStatus(self: Model, messageId: string, status: string) =
+    let ind = self.findIndexForMessageId(messageId)
+    if(ind == -1):
+      return
+    self.items[ind].outgoingStatus = status
+    let index = self.createIndex(ind, 0, nil)
+    self.dataChanged(index, index, @[ModelRole.OutgoingStatus.int])
+
+  proc itemSent*(self: Model, messageId: string) =
+    self.setOutgoingStatus(messageId, PARSED_TEXT_OUTGOING_STATUS_SENT)
+
+  proc itemDelivered*(self: Model, messageId: string) =
+    self.setOutgoingStatus(messageId, PARSED_TEXT_OUTGOING_STATUS_DELIVERED)
 
   proc addReaction*(self: Model, messageId: string, emojiId: EmojiId, didIReactWithThisEmoji: bool,
     userPublicKey: string, userDisplayName: string, reactionId: string) =

--- a/src/app_service/service/message/dto/message.nim
+++ b/src/app_service/service/message/dto/message.nim
@@ -17,6 +17,10 @@ const PARSED_TEXT_CHILD_TYPE_STATUS_TAG* = "status-tag"
 const PARSED_TEXT_CHILD_TYPE_DEL* = "del"
 const PARSED_TEXT_CHILD_TYPE_LINK* = "link"
 
+const PARSED_TEXT_OUTGOING_STATUS_SENDING*   = "sending"
+const PARSED_TEXT_OUTGOING_STATUS_SENT*      = "sent"
+const PARSED_TEXT_OUTGOING_STATUS_DELIVERED* = "delivered"
+
 type ParsedText* = object
   `type`*: string
   literal*: string

--- a/src/app_service/service/message/service.nim
+++ b/src/app_service/service/message/service.nim
@@ -48,7 +48,9 @@ const SIGNAL_MESSAGE_REACTION_ADDED* = "messageReactionAdded"
 const SIGNAL_MESSAGE_REACTION_REMOVED* = "messageReactionRemoved"
 const SIGNAL_MESSAGE_REACTION_FROM_OTHERS* = "messageReactionFromOthers"
 const SIGNAL_MESSAGE_DELETION* = "messageDeleted"
+const SIGNAL_MESSAGE_DELIVERED* = "messageDelivered"
 const SIGNAL_MESSAGE_EDITED* = "messageEdited"
+const SIGNAL_ENVELOPE_SENT* = "envelopeSent"
 const SIGNAL_MESSAGE_LINK_PREVIEW_DATA_LOADED* = "messageLinkPreviewDataLoaded"
 const SIGNAL_MENTIONED_IN_EDITED_MESSAGE* = "mentionedInEditedMessage"
 const SIGNAL_RELOAD_MESSAGES* = "reloadMessages"
@@ -91,6 +93,13 @@ type
   MessageDeletedArgs* =  ref object of Args
     chatId*: string
     messageId*: string
+
+  MessageDeliveredArgs* = ref object of Args
+    chatId*: string
+    messageId*: string
+
+  EnvelopeSentArgs* = ref object of Args
+    messagesIds*: seq[string]
 
   MessageEditedArgs* = ref object of Args
     chatId*: string
@@ -261,6 +270,16 @@ QtObject:
     self.events.emit(SIGNAL_RELOAD_MESSAGES, ReloadMessagesArgs(communityId: communityId))
 
   proc init*(self: Service) =
+    self.events.on(SignalType.MessageDelivered.event) do(e: Args):
+      let receivedData = MessageDeliveredSignal(e)
+      let data = MessageDeliveredArgs(chatId: receivedData.chatId, messageId: receivedData.messageId)
+      self.events.emit(SIGNAL_MESSAGE_DELIVERED, data)
+
+    self.events.on(SignalType.EnvelopeSent.event) do(e: Args):
+      let receivedData = EnvelopeSentSignal(e)
+      let data = EnvelopeSentArgs(messagesIds: receivedData.messageIds)
+      self.events.emit(SIGNAL_ENVELOPE_SENT, data)
+
     self.events.on(SignalType.Message.event) do(e: Args):
       var receivedData = MessageSignal(e)
 


### PR DESCRIPTION
Fixes #7367

### What does the PR do

Add logic required to handle "message.delivered" signal for delivered messages.
Add logic required to handle "envelope.sent" signal for sent messages.

### Affected areas

Desktop Chat

### Screenshot of functionality 

https://user-images.githubusercontent.com/6445843/192495691-9c569192-ca6d-4ae6-a6b6-7843640ecb8e.mp4



