### PR TITLE
fix(@desktop/communities): Show only not community members

### DIFF
--- a/ui/imports/shared/views/ExistingContacts.qml
+++ b/ui/imports/shared/views/ExistingContacts.qml
@@ -76,7 +76,7 @@ Item {
                     model.localNickname.toLowerCase().includes(root.filterText.toLowerCase()) ||
                     model.pubKey.toLowerCase().includes(root.filterText.toLowerCase())) &&
                     (!root.hideCommunityMembers ||
-                    !root.rootStore.communityHasMember(model.pubKey, root.communityId));
+                    !root.rootStore.communityHasMember(root.communityId, model.pubKey));
             }
 
             onClicked: {

--- a/ui/imports/shared/views/PickedContacts.qml
+++ b/ui/imports/shared/views/PickedContacts.qml
@@ -54,7 +54,8 @@ Item {
             status: model.onlineStatus
             userName: model.displayName
             asset.name: model.icon
-            asset.isImage: true
+            asset.isImage: (asset.name !== "")
+            asset.isLetterIdenticon: (asset.name === "")
             asset.width: 40
             asset.height: 40
             color: "transparent"


### PR DESCRIPTION
Fix #7477

### What does the PR do

Shows only members which are not community members.
Fixes member icons in the invitation message panel

### Affected areas

Community , members list

### Screenshot

![image](https://user-images.githubusercontent.com/61889657/192825929-253cf0e2-b588-4731-be60-9b402020e8e3.png)

