### PR TITLE
fix(CreateChatView): disable confirm button if no tags added

### DIFF
--- a/ui/app/AppLayouts/Chat/panels/InlineSelectorPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/InlineSelectorPanel.qml
@@ -164,6 +164,7 @@ Item {
 
         StatusButton {
             Layout.alignment: Qt.AlignVCenter
+            enabled: (listView.count > 0)
             text: qsTr("Confirm")
             onClicked: root.confirmed()
         }


### PR DESCRIPTION
Closes #7493

### What does the PR do
CreateChatView, disable confirm button if no tags added

### Affected areas
CreateChatView

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)
https://user-images.githubusercontent.com/31625338/192315035-70dd3648-0366-4aeb-ad8f-1202a0335479.mov

