### PR TITLE
feat(ActivityCenter): Force sorting notifications by timestamp

### DIFF
--- a/ui/app/mainui/activitycenter/popups/ActivityCenterPopup.qml
+++ b/ui/app/mainui/activitycenter/popups/ActivityCenterPopup.qml
@@ -148,6 +148,13 @@ Popup {
 
             filters: ExpressionFilter { expression: filterActivityCategories(model.notificationType) &&
                                                     !(acStore.hideReadNotifications && model.read) }
+
+            sorters: [
+                RoleSorter {
+                    roleName: "timestamp"
+                    sortOrder: Qt.DescendingOrder
+                }
+            ]
         }
 
         delegate: DelegateChooser {
@@ -161,7 +168,7 @@ Popup {
                     store: root.store
                     notification: model
                     messageContextMenu: root.messageContextMenu
-                    previousNotificationIndex: Math.max(0, index - 1)
+                    previousNotificationIndex: Math.min(listView.count - 1, index + 1)
                     onActivityCenterClose: root.close()
                 }
             }
@@ -173,7 +180,7 @@ Popup {
                     store: root.store
                     notification: model
                     messageContextMenu: root.messageContextMenu
-                    previousNotificationIndex: Math.max(0, index - 1)
+                    previousNotificationIndex: Math.min(listView.count - 1, index + 1)
                     onActivityCenterClose: root.close()
                 }
             }
@@ -185,7 +192,7 @@ Popup {
                     store: root.store
                     notification: model
                     messageContextMenu: root.messageContextMenu
-                    previousNotificationIndex: Math.max(0, index - 1)
+                    previousNotificationIndex: Math.min(listView.count - 1, index + 1)
                     onActivityCenterClose: root.close()
                 }
             }


### PR DESCRIPTION
Close #7492

### What does the PR do

Fix ordering notifications

### Affected areas

ActivityCenter

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

<img width="559" alt="Screenshot 2022-09-26 at 19 49 26" src="https://user-images.githubusercontent.com/2522130/192323278-b23baec8-0a19-4b27-811c-6cbfa6c25b63.png">
