### PR TITLE
fix(Popups): clipping area fixed in various popups

### DIFF
--- a/ui/StatusQ/src/StatusQ/Popups/StatusStackModal.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/StatusStackModal.qml
@@ -85,25 +85,45 @@ StatusModal {
             clip: true
         }
 
-        StatusAnimatedStack {
-            id: stackLayout
+        Item {
+            anchors.left: parent.left
+            anchors.right: parent.right
             anchors.top: subHeaderLoader.bottom
-            anchors.topMargin: subHeaderLoader.item && subHeaderLoader.item.visible ? root.subHeaderPadding : 0
             anchors.bottom: parent.bottom
-            width: root.availableWidth
-            visible: !replaceItem
-            clip: true
-        }
 
-        Loader {
-            id: replaceLoader
-            anchors.fill: parent
-            visible: item
             clip: true
-            onItemChanged: {
-                root.rightButtons = item ? item.rightButtons : [ nextButton, finishButton ]
-                if (!item && root.itemsCount == 0) {
-                    root.close();
+
+            anchors.bottomMargin: -root.padding
+            anchors.leftMargin: -root.leftPadding
+            anchors.rightMargin: -root.rightPadding
+            anchors.topMargin: subHeaderLoader.item && subHeaderLoader.item.visible ? 0 : -root.padding
+
+            StatusAnimatedStack {
+                id: stackLayout
+
+                anchors.fill: parent
+
+                anchors.bottomMargin: root.padding
+                anchors.leftMargin: root.leftPadding
+                anchors.rightMargin: root.rightPadding
+                anchors.topMargin: (subHeaderLoader.item && subHeaderLoader.item.visible ? root.subHeaderPadding : root.padding)
+
+                visible: !replaceItem
+                clip: false
+            }
+
+
+            Loader {
+                id: replaceLoader
+                anchors.fill: parent
+                anchors.margins: root.padding
+                visible: item
+                clip: false
+                onItemChanged: {
+                    root.rightButtons = item ? item.rightButtons : [ nextButton, finishButton ]
+                    if (!item && root.itemsCount == 0) {
+                        root.close();
+                    }
                 }
             }
         }

--- a/ui/app/AppLayouts/Chat/ChatLayout.qml
+++ b/ui/app/AppLayouts/Chat/ChatLayout.qml
@@ -55,7 +55,6 @@ StackLayout {
         active: root.rootStore.chatCommunitySectionModule.isCommunity()
 
         sourceComponent: CommunitySettingsView {
-            membershipRequestPopup: membershipRequestPopupComponent
             rootStore: root.rootStore
             hasAddedContacts: root.contactsStore.myContactsModel.count > 0
             chatCommunitySectionModule: root.rootStore.chatCommunitySectionModule

--- a/ui/app/AppLayouts/Chat/popups/PublicChatPopup.qml
+++ b/ui/app/AppLayouts/Chat/popups/PublicChatPopup.qml
@@ -39,6 +39,8 @@ ModalPopup {
         channelName.input.edit.forceActiveFocus(Qt.MouseFocusReason)
     }
 
+    contentWrapper.anchors.bottomMargin: 0
+
     Row {
         id: description
         Layout.fillHeight: false

--- a/ui/app/AppLayouts/Chat/popups/community/CreateCategoryPopup.qml
+++ b/ui/app/AppLayouts/Chat/popups/community/CreateCategoryPopup.qml
@@ -13,6 +13,8 @@ import StatusQ.Popups 0.1
 import utils 1.0
 import shared.popups 1.0
 
+import SortFilterProxyModel 0.2
+
 StatusModal {
     id: root
 
@@ -71,56 +73,54 @@ StatusModal {
             bottomPadding: 8
         }
 
-        StatusScrollView {
-            id: scrollView
-
+        Item {
             width: root.width
-            height: Math.min(content.height, 300)
-            anchors.horizontalCenter: parent.horizontalCenter
-
-            property ScrollBar vScrollBar: ScrollBar.vertical
-
-            contentHeight: content.height
-            ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
-
-            function scrollBackUp() {
-                vScrollBar.setPosition(0)
-            }
+            height: Math.min(communityChannelList.contentHeight, 300)
 
             Item {
-                id: content
-                width: parent.width
-                height: channelsLabel.height + communityChannelList.height
-
-                Item {
-                    id: channelsLabel
-                    anchors.horizontalCenter: parent.horizontalCenter
-                    width: parent.width - 32
-                    height: 34
-                    StatusBaseText {
-                        text: qsTr("Channels")
-                        anchors.bottom: parent.bottom
-                        anchors.bottomMargin: 4
-                        font.pixelSize: 15
-                        color: Theme.palette.baseColor1
-                    }
-                }
+                anchors.fill: parent
+                anchors.margins: -8
+                clip: true
 
                 StatusListView {
                     id: communityChannelList
                     objectName: "createOrEditCommunityCategoryChannelList"
 
-                    anchors.top: channelsLabel.bottom
-                    height: childrenRect.height
-                    width: parent.width
-                    model: isEdit ? root.store.chatCommunitySectionModule.editCategoryChannelsModel : root.store.chatCommunitySectionModule.model
-                    interactive: false
+                    anchors.fill: parent
+                    anchors.margins: -parent.anchors.margins
+                    displayMarginBeginning: anchors.margins
+                    displayMarginEnd: anchors.margins
+                    clip: false
+
+                    model: SortFilterProxyModel {
+                        sourceModel: root.isEdit ? root.store.chatCommunitySectionModule.editCategoryChannelsModel
+                                                 : root.store.chatCommunitySectionModule.model
+                        // filter out categories
+                        filters: ValueFilter {
+                            roleName: "type"
+                            value: Constants.chatType.unknown
+                            inverted: true
+                        }
+                    }
+
+                    header: Item {
+                        id: channelsLabel
+                        anchors.horizontalCenter: parent.horizontalCenter
+                        width: parent.width - 32
+                        height: 34
+                        StatusBaseText {
+                            text: qsTr("Channels")
+                            anchors.bottom: parent.bottom
+                            anchors.bottomMargin: 4
+                            font.pixelSize: 15
+                            color: Theme.palette.baseColor1
+                        }
+                    }
 
                     delegate: StatusListItem {
                         readonly property bool checked: channelItemCheckbox.checked
                         objectName: model.name
                         anchors.horizontalCenter: parent.horizontalCenter
-                        visible: model.type != Constants.chatType.unknown
                         height: visible ? implicitHeight : 0
                         title: "#" + model.name
                         asset.emoji: model.emoji

--- a/ui/app/AppLayouts/Chat/views/CommunitySettingsView.qml
+++ b/ui/app/AppLayouts/Chat/views/CommunitySettingsView.qml
@@ -41,7 +41,6 @@ StatusSectionLayout {
     property var community
     property var chatCommunitySectionModule
     property bool hasAddedContacts: false
-    property Component membershipRequestPopup
 
     readonly property string filteredSelectedTags: {
         if (!community || !community.tags)

--- a/ui/app/AppLayouts/CommunitiesPortal/panels/CommunityColorPanel.qml
+++ b/ui/app/AppLayouts/CommunitiesPortal/panels/CommunityColorPanel.qml
@@ -37,6 +37,7 @@ StatusScrollView {
     }
 
     padding: 0
+    clip: false
 
     ColumnLayout {
         id: column

--- a/ui/app/AppLayouts/CommunitiesPortal/panels/CommunityTagsPanel.qml
+++ b/ui/app/AppLayouts/CommunitiesPortal/panels/CommunityTagsPanel.qml
@@ -64,6 +64,7 @@ StatusScrollView {
 
     padding: 0
     contentWidth: column.width
+    clip: false
 
     QtObject {
         id: d

--- a/ui/app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml
+++ b/ui/app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml
@@ -338,6 +338,8 @@ StatusStackModal {
 
             readonly property bool canGoNext: nameInput.valid && descriptionTextInput.valid
 
+            clip: false
+
             ColumnLayout {
                 id: generalViewLayout
                 width: generalView.availableWidth

--- a/ui/app/AppLayouts/Profile/popups/BackupSeedModal.qml
+++ b/ui/app/AppLayouts/Profile/popups/BackupSeedModal.qml
@@ -96,12 +96,20 @@ StatusStackModal {
         }
     }
 
+    // split subHeaderPadding into clip and non-clip parts
+    subHeaderPadding: 8
+    readonly property int nonClipSubHeaderPadding: 8
+
     subHeaderItem: SubheaderTabBar {
         // Count without Acknowledgements
         steps: root.itemsCount - 1
         currentIndex: root.currentIndex - 1
         visible: root.currentIndex > 0
-        height: visible ? implicitHeight : 0
+        height: visible ? implicitHeight + nonClipSubHeaderPadding - spacing : 0
+
+        Item {
+            Layout.fillHeight: true
+        }
     }
 
     stackItems: [

--- a/ui/app/AppLayouts/Profile/popups/backupseed/Acknowledgements.qml
+++ b/ui/app/AppLayouts/Profile/popups/backupseed/Acknowledgements.qml
@@ -15,94 +15,111 @@ ColumnLayout {
 
     spacing: Style.current.padding
 
-    StatusScrollView {
-        id: flick
+    Item {
         Layout.fillWidth: true
         Layout.fillHeight: true
 
-        ColumnLayout {
-            id: flickLayout
-            width: flick.availableWidth
-            spacing: Style.current.padding
+        Item {
+            anchors.fill: parent
+            anchors.margins: -1000
+            anchors.bottomMargin: -root.spacing
 
-            Image {
-                id: keysImg
-                fillMode: Image.PreserveAspectFit
-                source: Style.png("onboarding/keys")
-                mipmap: true
-                Layout.alignment: Qt.AlignHCenter
-                Layout.preferredWidth: 120
-                Layout.preferredHeight: width
-            }
+            clip: true
 
-            StyledText {
-                id: txtTitle
-                text: qsTr("Secure Your Assets and Funds")
-                horizontalAlignment: Text.AlignHCenter
-                wrapMode: Text.WordWrap
-                font.bold: true
-                font.pixelSize: 22
-                Layout.fillWidth: true
-            }
+            StatusScrollView {
+                id: flick
 
-            ColumnLayout {
-                Layout.fillWidth: true
-                Layout.leftMargin: Style.current.padding
-                Layout.rightMargin: Style.current.padding
-                spacing: Style.current.bigPadding
+                anchors.fill: parent
+                anchors.margins: -parent.anchors.margins
+                anchors.bottomMargin: -parent.anchors.bottomMargin
 
-                StyledText {
-                    id: txtDesc
-                    font.pixelSize: Style.current.primaryTextFontSize
-                    horizontalAlignment: Text.AlignHCenter
-                    text: qsTr("Your seed phrase is a 12-word passcode to your funds.")
-                    Layout.fillWidth: true
-                }
+                clip: false
 
-                StyledText {
-                    id: secondTxtDesc
-                    horizontalAlignment: Text.AlignHCenter
-                    wrapMode: Text.WordWrap
-                    textFormat: Text.RichText
-                    font.pixelSize: Style.current.primaryTextFontSize
-                    lineHeight: 1.2
-                    text: qsTr("Your seed phrase cannot be recovered if lost. Therefore, you <b>must</b> back it up. The simplest way is to <b>write it down offline and store it somewhere secure.</b>")
-                    Layout.fillWidth: true
-                }
-            }
-
-            ColumnLayout {
-                Layout.fillWidth: true
-                Layout.leftMargin: Style.current.xlPadding
-                Layout.rightMargin: Style.current.xlPadding
-                Layout.topMargin: Style.current.bigPadding
-                spacing: Style.current.bigPadding/2
-
-                StatusCheckBox {
-                    id: havePen
-                    objectName: "Acknowledgements_havePen"
+                ColumnLayout {
+                    id: flickLayout
+                    width: flick.availableWidth
                     spacing: Style.current.padding
-                    text: qsTr("I have a pen and paper")
-                    font.pixelSize: Style.current.primaryTextFontSize
-                    Layout.fillWidth: true
-                }
 
-                StatusCheckBox {
-                    id: writeDown
-                    objectName: "Acknowledgements_writeDown"
-                    spacing: Style.current.padding
-                    text: qsTr("I am ready to write down my seed phrase")
-                    font.pixelSize: Style.current.primaryTextFontSize
-                    Layout.fillWidth: true
-                }
+                    Image {
+                        id: keysImg
+                        fillMode: Image.PreserveAspectFit
+                        source: Style.png("onboarding/keys")
+                        mipmap: true
+                        Layout.alignment: Qt.AlignHCenter
+                        Layout.preferredWidth: 120
+                        Layout.preferredHeight: width
+                    }
 
-                StatusCheckBox {
-                    id: storeIt
-                    objectName: "Acknowledgements_storeIt"
-                    spacing: Style.current.padding
-                    text: qsTr("I know where I’ll store it")
-                    font.pixelSize: Style.current.primaryTextFontSize
-                    Layout.fillWidth: true
+                    StyledText {
+                        id: txtTitle
+                        text: qsTr("Secure Your Assets and Funds")
+                        horizontalAlignment: Text.AlignHCenter
+                        wrapMode: Text.WordWrap
+                        font.bold: true
+                        font.pixelSize: 22
+                        Layout.fillWidth: true
+                    }
+
+                    ColumnLayout {
+                        Layout.fillWidth: true
+                        Layout.leftMargin: Style.current.padding
+                        Layout.rightMargin: Style.current.padding
+                        spacing: Style.current.bigPadding
+
+                        StyledText {
+                            id: txtDesc
+                            font.pixelSize: Style.current.primaryTextFontSize
+                            horizontalAlignment: Text.AlignHCenter
+                            text: qsTr("Your seed phrase is a 12-word passcode to your funds.")
+                            Layout.fillWidth: true
+                        }
+
+                        StyledText {
+                            id: secondTxtDesc
+                            horizontalAlignment: Text.AlignHCenter
+                            wrapMode: Text.WordWrap
+                            textFormat: Text.RichText
+                            font.pixelSize: Style.current.primaryTextFontSize
+                            lineHeight: 1.2
+                            text: qsTr("Your seed phrase cannot be recovered if lost. Therefore, you <b>must</b> back it up. The simplest way is to <b>write it down offline and store it somewhere secure.</b>")
+                            Layout.fillWidth: true
+                        }
+                    }
+
+                    ColumnLayout {
+                        Layout.fillWidth: true
+                        Layout.leftMargin: Style.current.xlPadding
+                        Layout.rightMargin: Style.current.xlPadding
+                        Layout.topMargin: Style.current.bigPadding
+                        spacing: Style.current.bigPadding/2
+
+                        StatusCheckBox {
+                            id: havePen
+                            objectName: "Acknowledgements_havePen"
+                            spacing: Style.current.padding
+                            text: qsTr("I have a pen and paper")
+                            font.pixelSize: Style.current.primaryTextFontSize
+                            Layout.fillWidth: true
+                        }
+
+                        StatusCheckBox {
+                            id: writeDown
+                            objectName: "Acknowledgements_writeDown"
+                            spacing: Style.current.padding
+                            text: qsTr("I am ready to write down my seed phrase")
+                            font.pixelSize: Style.current.primaryTextFontSize
+                            Layout.fillWidth: true
+                        }
+
+                        StatusCheckBox {
+                            id: storeIt
+                            objectName: "Acknowledgements_storeIt"
+                            spacing: Style.current.padding
+                            text: qsTr("I know where I’ll store it")
+                            font.pixelSize: Style.current.primaryTextFontSize
+                            Layout.fillWidth: true
+                        }
+                    }
                 }
             }
         }

--- a/ui/app/AppLayouts/Profile/popups/backupseed/BackupSeedStepBase.qml
+++ b/ui/app/AppLayouts/Profile/popups/backupseed/BackupSeedStepBase.qml
@@ -21,6 +21,7 @@ StatusScrollView {
     default property alias content: column.children
 
     implicitHeight: 520
+    clip: false
 
     ColumnLayout {
         id: column


### PR DESCRIPTION
### What does the PR do

In various popups with scrollable content, scrolled elements are cut-off too early because of clipping on Flickable directly. The clipping bounds are extended to achieve desired behavior.

Closes #7293

### Affected areas

<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![Screenshot from 2022-09-26 17-31-41](https://user-images.githubusercontent.com/20650004/192481646-8b7b267e-9177-4cd1-81f5-b58e2980256d.png)
![Screenshot from 2022-09-26 17-32-10](https://user-images.githubusercontent.com/20650004/192481676-919d4159-8da8-48d8-b1be-e108d276baed.png)
![Screenshot from 2022-09-26 17-32-24](https://user-images.githubusercontent.com/20650004/192481740-8822a03c-3d53-48de-ac09-afa49c474104.png)
![Screenshot from 2022-09-26 18-27-05](https://user-images.githubusercontent.com/20650004/192481807-0f3d10be-8398-493e-8efd-92db04b55120.png)
![Screenshot from 2022-09-26 18-47-50](https://user-images.githubusercontent.com/20650004/192481849-0ba3f7f4-1627-49d5-b4a9-6344bb0933bc.png)
![Screenshot from 2022-09-26 18-57-56](https://user-images.githubusercontent.com/20650004/192481898-faca6fae-46a1-4fbb-855d-63b257f1e72b.png)
![Screenshot from 2022-09-27 00-19-58](https://user-images.githubusercontent.com/20650004/192482010-fbafea90-891d-46f1-bc22-e32bdb2b8b10.png)
![Screenshot from 2022-09-27 00-20-25](https://user-images.githubusercontent.com/20650004/192482184-1957b53e-a32a-43f0-9bcb-c565832dbea3.png)
![Screenshot from 2022-09-27 00-41-21](https://user-images.githubusercontent.com/20650004/192482216-e7140b2a-5ad8-4873-8651-3a88efbbfa83.png)
![Screenshot from 2022-09-29 10-21-13](https://user-images.githubusercontent.com/20650004/193015696-231db4f6-0857-4a33-b1e0-dd2be8f7093e.png)

