### PR TITLE
tests for adding wallet accounts updated according to the latest changes (`Authentication` flow)

### DIFF
--- a/src/app/boot/app_controller.nim
+++ b/src/app/boot/app_controller.nim
@@ -390,7 +390,7 @@ proc buildAndRegisterUserProfile(self: AppController) =
     info "login account name and display name stored in settings differ"
     displayName = loggedInAccount.name
 
-  singletonInstance.userProfile.setFixedData(alias, loggedInAccount.keyUid, pubKey)
+  singletonInstance.userProfile.setFixedData(alias, loggedInAccount.keyUid, pubKey, loggedInAccount.keycardPairing.len > 0)
   singletonInstance.userProfile.setDisplayName(displayName)
   singletonInstance.userProfile.setPreferredName(preferredName)
   singletonInstance.userProfile.setEnsName(firstEnsName)

--- a/src/app/global/global_singleton.nim
+++ b/src/app/global/global_singleton.nim
@@ -48,7 +48,7 @@ proc localAppSettings*(self: GlobalSingleton): LocalAppSettings =
 proc userProfile*(self: GlobalSingleton): UserProfile =
   var userProfile {.global.}: UserProfile
   if (userProfile.isNil):
-    userProfile = newUserProfile()
+    userProfile = newUserProfile(singletonInstance.localAccountSettings)
   return userProfile
 
 proc utils*(self: GlobalSingleton): Utils =

--- a/src/app/global/user_profile.nim
+++ b/src/app/global/user_profile.nim
@@ -2,8 +2,11 @@ import NimQml
 
 import ../../app_service/common/utils
 
+import local_account_settings
+
 QtObject:
   type UserProfile* = ref object of QObject
+    localAccountSettings: LocalAccountSettings
     # fields which cannot change
     username: string
     keyUid: string
@@ -24,9 +27,10 @@ QtObject:
   proc delete*(self: UserProfile) =
     self.QObject.delete
 
-  proc newUserProfile*(): UserProfile =
+  proc newUserProfile*(localAccountSettings: LocalAccountSettings): UserProfile =
     new(result, delete)
     result.setup
+    result.localAccountSettings = localAccountSettings
 
   proc setFixedData*(self: UserProfile, username: string, keyUid: string, pubKey: string, isKeycardUser: bool) =
     self.username = username
@@ -49,6 +53,14 @@ QtObject:
     self.isKeycardUser
   QtProperty[bool] isKeycardUser:
     read = getIsKeycardUser
+
+  proc getUsingBiometricLogin*(self: UserProfile): bool {.slot.} =
+    if(not defined(macosx)):
+      return false
+    return self.localAccountSettings.getStoreToKeychainValue() == LS_VALUE_STORE
+  QtProperty[bool] usingBiometricLogin:
+    read = getUsingBiometricLogin
+
 
   proc nameChanged*(self: UserProfile) {.signal.}
 

--- a/src/app/global/user_profile.nim
+++ b/src/app/global/user_profile.nim
@@ -8,6 +8,7 @@ QtObject:
     username: string
     keyUid: string
     pubKey: string
+    isKeycardUser: bool
     # fields which may change during runtime
     ensName: string
     displayName: string
@@ -27,23 +28,27 @@ QtObject:
     new(result, delete)
     result.setup
 
-  proc setFixedData*(self: UserProfile, username: string, keyUid: string, pubKey: string) =
+  proc setFixedData*(self: UserProfile, username: string, keyUid: string, pubKey: string, isKeycardUser: bool) =
     self.username = username
     self.keyUid = keyUid
     self.pubKey = pubKey
+    self.isKeycardUser = isKeycardUser
 
   proc getKeyUid*(self: UserProfile): string {.slot.} =
     self.keyUid
-
   QtProperty[string] keyUid:
     read = getKeyUid
 
 
   proc getPubKey*(self: UserProfile): string {.slot.} =
     self.pubKey
-
   QtProperty[string] pubKey:
     read = getPubKey
+
+  proc getIsKeycardUser*(self: UserProfile): bool {.slot.} =
+    self.isKeycardUser
+  QtProperty[bool] isKeycardUser:
+    read = getIsKeycardUser
 
   proc nameChanged*(self: UserProfile) {.signal.}
 

--- a/src/app/modules/main/controller.nim
+++ b/src/app/modules/main/controller.nim
@@ -240,8 +240,11 @@ proc init*(self: Controller) =
       self.authenticateUserFlowRequestedBy.len == 0:
         return
     self.delegate.onSharedKeycarModuleFlowTerminated(args.lastStepInTheCurrentFlow)
+    var password = args.password
+    if password.len == 0 and args.keyUid.len > 0:
+      password = args.keyUid
     let data = SharedKeycarModuleArgs(uniqueIdentifier: self.authenticateUserFlowRequestedBy,
-      data: args.data,
+      password: password,
       keyUid: args.keyUid,
       txR: args.txR,
       txS: args.txS,

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -167,7 +167,7 @@ proc newModule*[T](
   result.walletSectionModule = wallet_section_module.newModule(
     result, events, tokenService,
     transactionService, collectible_service, walletAccountService,
-    settingsService, savedAddressService, networkService,
+    settingsService, savedAddressService, networkService, accountsService
   )
   result.browserSectionModule = browser_section_module.newModule(
     result, events, bookmarkService, settingsService, networkService,

--- a/src/app/modules/main/profile_section/keycard/io_interface.nim
+++ b/src/app/modules/main/profile_section/keycard/io_interface.nim
@@ -28,6 +28,15 @@ method onSharedKeycarModuleFlowTerminated*(self: AccessInterface, lastStepInTheC
 method runSetupKeycardPopup*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method runGenerateSeedPhrasePopup*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method runImportOrRestoreViaSeedPhrasePopup*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method runImportFromKeycardToAppPopup*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method runUnlockKeycardPopup*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/profile_section/keycard/module.nim
+++ b/src/app/modules/main/profile_section/keycard/module.nim
@@ -104,6 +104,15 @@ method runSetupKeycardPopup*(self: Module) =
     return
   self.keycardSharedModule.runFlow(keycard_shared_module.FlowType.SetupNewKeycard)
 
+method runGenerateSeedPhrasePopup*(self: Module) =
+  info "TODO: Generate a seed phrase..."
+
+method runImportOrRestoreViaSeedPhrasePopup*(self: Module) =
+  info "TODO: Import or restore via a seed phrase..."
+  
+method runImportFromKeycardToAppPopup*(self: Module) =
+  info "TODO: Import from Keycard to Status Desktop..."
+
 method runUnlockKeycardPopup*(self: Module) =
   self.createSharedKeycardModule()
   if self.keycardSharedModule.isNil:
@@ -111,7 +120,10 @@ method runUnlockKeycardPopup*(self: Module) =
   self.keycardSharedModule.runFlow(keycard_shared_module.FlowType.UnlockKeycard)
 
 method runDisplayKeycardContentPopup*(self: Module) =
-  info "TODO: Run display keycard content..."
+  self.createSharedKeycardModule()
+  if self.keycardSharedModule.isNil:
+    return
+  self.keycardSharedModule.runFlow(keycard_shared_module.FlowType.DisplayKeycardContent)
 
 method runFactoryResetPopup*(self: Module) =
   self.createSharedKeycardModule()

--- a/src/app/modules/main/profile_section/keycard/view.nim
+++ b/src/app/modules/main/profile_section/keycard/view.nim
@@ -34,6 +34,15 @@ QtObject:
   proc runSetupKeycardPopup*(self: View) {.slot.} =
     self.delegate.runSetupKeycardPopup()
 
+  proc runGenerateSeedPhrasePopup*(self: View) {.slot.} =
+    self.delegate.runGenerateSeedPhrasePopup()
+
+  proc runImportOrRestoreViaSeedPhrasePopup*(self: View) {.slot.} =
+    self.delegate.runImportOrRestoreViaSeedPhrasePopup()
+
+  proc runImportFromKeycardToAppPopup*(self: View) {.slot.} =
+    self.delegate.runImportFromKeycardToAppPopup()
+
   proc runUnlockKeycardPopup*(self: View) {.slot.} =
     self.delegate.runUnlockKeycardPopup()
 

--- a/src/app/modules/main/wallet_section/accounts/controller.nim
+++ b/src/app/modules/main/wallet_section/accounts/controller.nim
@@ -77,9 +77,6 @@ proc loggedInUserUsesBiometricLogin*(self: Controller): bool =
     return false
   return true
 
-proc getLoggedInAccount*(self: Controller): AccountDto =
-  return self.accountsService.getLoggedInAccount()
-
 proc authenticateUser*(self: Controller, keyUid = "") =
   let data = SharedKeycarModuleAuthenticationArgs(uniqueIdentifier: UNIQUE_WALLET_SECTION_ACCOUNTS_MODULE_IDENTIFIER,
     keyUid: keyUid)

--- a/src/app/modules/main/wallet_section/accounts/controller.nim
+++ b/src/app/modules/main/wallet_section/accounts/controller.nim
@@ -69,14 +69,6 @@ proc validSeedPhrase*(self: Controller, seedPhrase: string): bool =
   let err = self.accountsService.validateMnemonic(seedPhrase)
   return err.len == 0
 
-proc loggedInUserUsesBiometricLogin*(self: Controller): bool =
-  if(not defined(macosx)):
-    return false
-  let value = singletonInstance.localAccountSettings.getStoreToKeychainValue()
-  if (value != LS_VALUE_STORE):
-    return false
-  return true
-
 proc authenticateUser*(self: Controller, keyUid = "") =
   let data = SharedKeycarModuleAuthenticationArgs(uniqueIdentifier: UNIQUE_WALLET_SECTION_ACCOUNTS_MODULE_IDENTIFIER,
     keyUid: keyUid)

--- a/src/app/modules/main/wallet_section/accounts/controller.nim
+++ b/src/app/modules/main/wallet_section/accounts/controller.nim
@@ -1,18 +1,23 @@
 import io_interface
 import ../../../../../app_service/service/wallet_account/service as wallet_account_service
+import ../../../../../app_service/service/accounts/service as accounts_service
 
 type
   Controller* = ref object of RootObj
     delegate: io_interface.AccessInterface
     walletAccountService: wallet_account_service.Service
+    accountsService: accounts_service.Service
 
 proc newController*(
   delegate: io_interface.AccessInterface,
   walletAccountService: wallet_account_service.Service
+  walletAccountService: wallet_account_service.Service,
+  accountsService: accounts_service.Service
 ): Controller =
   result = Controller()
   result.delegate = delegate
   result.walletAccountService = walletAccountService
+  result.accountsService = accountsService
 
 proc delete*(self: Controller) =
   discard
@@ -47,4 +52,7 @@ method getDerivedAddressListForMnemonic*(self: Controller, mnemonic: string, pat
 method getDerivedAddressForPrivateKey*(self: Controller, privateKey: string) =
   self.walletAccountService.getDerivedAddressForPrivateKey(privateKey)
 
+proc validSeedPhrase*(self: Controller, seedPhrase: string): bool =
+  let err = self.accountsService.validateMnemonic(seedPhrase)
+  return err.len == 0
 

--- a/src/app/modules/main/wallet_section/accounts/io_interface.nim
+++ b/src/app/modules/main/wallet_section/accounts/io_interface.nim
@@ -54,6 +54,3 @@ method authenticateUser*(self: AccessInterface) {.base.} =
 
 method onUserAuthenticated*(self: AccessInterface, password: string) {.base.} =
   raise newException(ValueError, "No implementation available")
-
-method loggedInUserUsesBiometricLogin*(self: AccessInterface): bool {.base.} =
-  raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/wallet_section/accounts/io_interface.nim
+++ b/src/app/modules/main/wallet_section/accounts/io_interface.nim
@@ -48,3 +48,15 @@ method viewDidLoad*(self: AccessInterface) {.base.} =
 
 method validSeedPhrase*(self: AccessInterface, value: string): bool {.base.} =
   raise newException(ValueError, "No implementation available")
+
+method authenticateUser*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method onUserAuthenticated*(self: AccessInterface, password: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method loggedInUserUsesBiometricLogin*(self: AccessInterface): bool {.base.} =
+  raise newException(ValueError, "No implementation available")
+    
+method isProfileKeyPairMigrated*(self: AccessInterface): bool {.base.} =
+  raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/wallet_section/accounts/io_interface.nim
+++ b/src/app/modules/main/wallet_section/accounts/io_interface.nim
@@ -45,3 +45,6 @@ method getDerivedAddressForPrivateKey*(self: AccessInterface, privateKey: string
 # inheritance, which is not well supported in Nim.
 method viewDidLoad*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
+
+method validSeedPhrase*(self: AccessInterface, value: string): bool {.base.} =
+  raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/wallet_section/accounts/io_interface.nim
+++ b/src/app/modules/main/wallet_section/accounts/io_interface.nim
@@ -57,6 +57,3 @@ method onUserAuthenticated*(self: AccessInterface, password: string) {.base.} =
 
 method loggedInUserUsesBiometricLogin*(self: AccessInterface): bool {.base.} =
   raise newException(ValueError, "No implementation available")
-    
-method isProfileKeyPairMigrated*(self: AccessInterface): bool {.base.} =
-  raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/wallet_section/accounts/module.nim
+++ b/src/app/modules/main/wallet_section/accounts/module.nim
@@ -173,9 +173,6 @@ method getDerivedAddressForPrivateKey*(self: Module, privateKey: string) =
 method validSeedPhrase*(self: Module, value: string): bool =
   return self.controller.validSeedPhrase(value)
 
-method loggedInUserUsesBiometricLogin*(self: Module): bool =
-  return self.controller.loggedInUserUsesBiometricLogin()
-    
 method authenticateUser*(self: Module) =
   if singletonInstance.userProfile.getIsKeycardUser():
     let keyUid = singletonInstance.userProfile.getKeyUid()

--- a/src/app/modules/main/wallet_section/accounts/module.nim
+++ b/src/app/modules/main/wallet_section/accounts/module.nim
@@ -172,3 +172,22 @@ method getDerivedAddressForPrivateKey*(self: Module, privateKey: string) =
 
 method validSeedPhrase*(self: Module, value: string): bool =
   return self.controller.validSeedPhrase(value)
+
+method loggedInUserUsesBiometricLogin*(self: Module): bool =
+  return self.controller.loggedInUserUsesBiometricLogin()
+    
+method isProfileKeyPairMigrated*(self: Module): bool =
+  return self.controller.getLoggedInAccount().keycardPairing.len > 0
+
+method authenticateUser*(self: Module) =
+  if self.isProfileKeyPairMigrated():
+    let keyUid = singletonInstance.userProfile.getKeyUid()
+    self.controller.authenticateUser(keyUid)
+  else:
+    self.controller.authenticateUser()
+
+method onUserAuthenticated*(self: Module, password: string) =
+  if password.len > 0:
+    self.view.userAuthenticaionSuccess(password)
+  else:
+    self.view.userAuthentiactionFail()

--- a/src/app/modules/main/wallet_section/accounts/module.nim
+++ b/src/app/modules/main/wallet_section/accounts/module.nim
@@ -176,11 +176,8 @@ method validSeedPhrase*(self: Module, value: string): bool =
 method loggedInUserUsesBiometricLogin*(self: Module): bool =
   return self.controller.loggedInUserUsesBiometricLogin()
     
-method isProfileKeyPairMigrated*(self: Module): bool =
-  return self.controller.getLoggedInAccount().keycardPairing.len > 0
-
 method authenticateUser*(self: Module) =
-  if self.isProfileKeyPairMigrated():
+  if singletonInstance.userProfile.getIsKeycardUser():
     let keyUid = singletonInstance.userProfile.getKeyUid()
     self.controller.authenticateUser(keyUid)
   else:

--- a/src/app/modules/main/wallet_section/accounts/module.nim
+++ b/src/app/modules/main/wallet_section/accounts/module.nim
@@ -5,6 +5,7 @@ import ../io_interface as delegate_interface
 import ../../../../global/global_singleton
 import ../../../../core/eventemitter
 import ../../../../../app_service/service/wallet_account/service as wallet_account_service
+import ../../../../../app_service/service/accounts/service as accounts_service
 import ../../../shared_models/token_model as token_model
 import ../../../shared_models/token_item as token_item
 import ./compact_item as compact_item
@@ -24,12 +25,13 @@ proc newModule*(
   delegate: delegate_interface.AccessInterface,
   events: EventEmitter,
   walletAccountService: wallet_account_service.Service,
+  accountsService: accounts_service.Service
 ): Module =
   result = Module()
   result.delegate = delegate
   result.events = events
   result.view = newView(result)
-  result.controller = controller.newController(result, walletAccountService)
+  result.controller = controller.newController(result, events, walletAccountService, accountsService)
   result.moduleLoaded = false
 
 method delete*(self: Module) =
@@ -168,6 +170,5 @@ method getDerivedAddressListForMnemonic*(self: Module, mnemonic: string, path: s
 method getDerivedAddressForPrivateKey*(self: Module, privateKey: string) =
   self.controller.getDerivedAddressForPrivateKey(privateKey)
 
-
-
-
+method validSeedPhrase*(self: Module, value: string): bool =
+  return self.controller.validSeedPhrase(value)

--- a/src/app/modules/main/wallet_section/accounts/view.nim
+++ b/src/app/modules/main/wallet_section/accounts/view.nim
@@ -277,3 +277,15 @@ QtObject:
 
   proc validSeedPhrase*(self: View, value: string): bool {.slot.} =
     return self.delegate.validSeedPhrase(value)
+  
+  proc userAuthenticaionSuccess*(self: View, password: string) {.signal.}
+  proc userAuthentiactionFail*(self: View) {.signal.}
+
+  proc authenticateUser*(self: View) {.slot.} =
+    self.delegate.authenticateUser()
+
+  proc loggedInUserUsesBiometricLogin*(self: View): bool {.slot.} =
+    return self.delegate.loggedInUserUsesBiometricLogin()
+    
+  proc isProfileKeyPairMigrated*(self: View): bool {.slot.} =
+    return self.delegate.isProfileKeyPairMigrated()

--- a/src/app/modules/main/wallet_section/accounts/view.nim
+++ b/src/app/modules/main/wallet_section/accounts/view.nim
@@ -283,6 +283,3 @@ QtObject:
 
   proc authenticateUser*(self: View) {.slot.} =
     self.delegate.authenticateUser()
-
-  proc loggedInUserUsesBiometricLogin*(self: View): bool {.slot.} =
-    return self.delegate.loggedInUserUsesBiometricLogin()

--- a/src/app/modules/main/wallet_section/accounts/view.nim
+++ b/src/app/modules/main/wallet_section/accounts/view.nim
@@ -286,6 +286,3 @@ QtObject:
 
   proc loggedInUserUsesBiometricLogin*(self: View): bool {.slot.} =
     return self.delegate.loggedInUserUsesBiometricLogin()
-    
-  proc isProfileKeyPairMigrated*(self: View): bool {.slot.} =
-    return self.delegate.isProfileKeyPairMigrated()

--- a/src/app/modules/main/wallet_section/accounts/view.nim
+++ b/src/app/modules/main/wallet_section/accounts/view.nim
@@ -275,3 +275,5 @@ QtObject:
   proc getNextSelectableDerivedAddressIndex*(self: View): int {.slot.} =
     return self.derivedAddresses.getNextSelectableDerivedAddressIndex()
 
+  proc validSeedPhrase*(self: View, value: string): bool {.slot.} =
+    return self.delegate.validSeedPhrase(value)

--- a/src/app/modules/main/wallet_section/module.nim
+++ b/src/app/modules/main/wallet_section/module.nim
@@ -21,6 +21,7 @@ import ../../../../app_service/service/wallet_account/service as wallet_account_
 import ../../../../app_service/service/settings/service as settings_service
 import ../../../../app_service/service/saved_address/service as saved_address_service
 import ../../../../app_service/service/network/service as network_service
+import ../../../../app_service/service/accounts/service as accounts_service
 
 import io_interface
 export io_interface
@@ -40,6 +41,7 @@ type
     transactionsModule: transactions_module.AccessInterface
     savedAddressesModule: saved_addresses_module.AccessInterface
     buySellCryptoModule: buy_sell_crypto_module.AccessInterface
+    accountsService: accounts_service.Service
 
 proc newModule*(
   delegate: delegate_interface.AccessInterface,
@@ -51,6 +53,7 @@ proc newModule*(
   settingsService: settings_service.Service,
   savedAddressService: saved_address_service.Service,
   networkService: network_service.Service,
+  accountsService: accounts_service.Service
 ): Module =
   result = Module()
   result.delegate = delegate
@@ -59,7 +62,7 @@ proc newModule*(
   result.controller = newController(result, settingsService, walletAccountService, networkService)
   result.view = newView(result)
 
-  result.accountsModule = accounts_module.newModule(result, events, walletAccountService)
+  result.accountsModule = accounts_module.newModule(result, events, walletAccountService, accountsService)
   result.allTokensModule = all_tokens_module.newModule(result, events, tokenService, walletAccountService)
   result.collectiblesModule = collectibles_module.newModule(result, events, collectibleService, walletAccountService)
   result.currentAccountModule = current_account_module.newModule(result, events, walletAccountService)

--- a/src/app/modules/shared_modules/keycard_popup/controller.nim
+++ b/src/app/modules/shared_modules/keycard_popup/controller.nim
@@ -44,6 +44,7 @@ type
     tmpKeyUidWhichIsBeingAuthenticating: string
     tmpKeyUidWhichIsBeingUnlocking: string
     tmpUsePinFromBiometrics: bool
+    tmpOfferToStoreUpdatedPinToKeychain: bool
     tmpKeycardUid: string
 
 proc newController*(delegate: io_interface.AccessInterface,
@@ -125,7 +126,7 @@ proc init*(self: Controller) =
     if args.uniqueIdentifier != self.uniqueIdentifier:
       return
     self.connectKeycardReponseSignal()
-    self.delegate.onUserAuthenticated(args.data)
+    self.delegate.onUserAuthenticated(args.password)
   self.connectionIds.add(handlerId)
 
 proc getKeycardData*(self: Controller): string =
@@ -169,6 +170,12 @@ proc setPinMatch*(self: Controller, value: bool) =
 
 proc getPinMatch*(self: Controller): bool =
   return self.tmpPinMatch
+
+proc setOfferToStoreUpdatedPinToKeychain*(self: Controller, value: bool) =
+  self.tmpOfferToStoreUpdatedPinToKeychain = value
+
+proc offerToStoreUpdatedPinToKeychain*(self: Controller): bool =
+  return self.tmpOfferToStoreUpdatedPinToKeychain
 
 proc setPassword*(self: Controller, value: string) =
   self.tmpPassword = value
@@ -307,7 +314,7 @@ proc terminateCurrentFlow*(self: Controller, lastStepInTheCurrentFlow: bool) =
   var data = SharedKeycarModuleFlowTerminatedArgs(uniqueIdentifier: self.uniqueIdentifier,
     lastStepInTheCurrentFlow: lastStepInTheCurrentFlow)
   if lastStepInTheCurrentFlow:
-    data.data = self.tmpPassword
+    data.password = self.tmpPassword
     data.keyUid = flowEvent.keyUid
     data.txR = flowEvent.txSignature.r
     data.txS = flowEvent.txSignature.s

--- a/src/app/modules/shared_modules/keycard_popup/controller.nim
+++ b/src/app/modules/shared_modules/keycard_popup/controller.nim
@@ -412,16 +412,8 @@ proc getMnemonicWordAtIndex*(self: Controller, index: int): string =
     return
   return self.privacyService.getMnemonicWordAtIndex(index)
 
-proc loggedInUserUsesBiometricLogin*(self: Controller): bool =
-  if(not defined(macosx)):
-    return false
-  let value = singletonInstance.localAccountSettings.getStoreToKeychainValue()
-  if (value != LS_VALUE_STORE):
-    return false
-  return true
-
 proc tryToObtainDataFromKeychain*(self: Controller) =
-  if(not self.loggedInUserUsesBiometricLogin()):
+  if(not singletonInstance.userProfile.getUsingBiometricLogin()):
     return
   let loggedInAccount = self.getLoggedInAccount()
   self.keychainService.tryToObtainData(loggedInAccount.name)

--- a/src/app/modules/shared_modules/keycard_popup/internal/biometrics_pin_invalid_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/biometrics_pin_invalid_state.nim
@@ -15,6 +15,7 @@ method executePrimaryCommand*(self: BiometricsPinInvalidState, controller: Contr
 method executeSecondaryCommand*(self: BiometricsPinInvalidState, controller: Controller) =
   if self.flowType == FlowType.Authentication:
     controller.setUsePinFromBiometrics(true)
+    controller.setOfferToStoreUpdatedPinToKeychain(true)
 
 method getNextSecondaryState*(self: BiometricsPinInvalidState, controller: Controller): State =
   if self.flowType == FlowType.Authentication:

--- a/src/app/modules/shared_modules/keycard_popup/internal/enter_pin_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/enter_pin_state.nim
@@ -98,6 +98,8 @@ method resolveKeycardNextState*(self: EnterPinState, keycardFlowType: string, ke
           return createState(StateType.MaxPinRetriesReached, self.flowType, nil)
     if keycardFlowType == ResponseTypeValueKeycardFlowResult:
       if keycardEvent.error.len == 0:
+        if controller.offerToStoreUpdatedPinToKeychain():
+          controller.tryToStoreDataToKeychain(controller.getPin())
         controller.terminateCurrentFlow(lastStepInTheCurrentFlow = true)
         return nil
   if self.flowType == FlowType.DisplayKeycardContent:

--- a/src/app/modules/shared_modules/keycard_popup/internal/enter_pin_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/enter_pin_state.nim
@@ -85,7 +85,7 @@ method resolveKeycardNextState*(self: EnterPinState, keycardFlowType: string, ke
       keycardEvent.error == ErrorPIN:
       controller.setKeycardData($keycardEvent.pinRetries)
       if keycardEvent.pinRetries > 0:
-        if controller.loggedInUserUsesBiometricLogin() and not controller.usePinFromBiometrics():
+        if singletonInstance.userProfile.getUsingBiometricLogin() and not controller.usePinFromBiometrics():
           return createState(StateType.WrongKeychainPin, self.flowType, nil)
         return createState(StateType.WrongPin, self.flowType, nil)
       return createState(StateType.MaxPinRetriesReached, self.flowType, nil)

--- a/src/app/modules/shared_modules/keycard_popup/internal/insert_keycard_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/insert_keycard_state.nim
@@ -17,7 +17,8 @@ method executeTertiaryCommand*(self: InsertKeycardState, controller: Controller)
   if self.flowType == FlowType.FactoryReset or
     self.flowType == FlowType.SetupNewKeycard or
     self.flowType == FlowType.Authentication or
-    self.flowType == FlowType.UnlockKeycard:
+    self.flowType == FlowType.UnlockKeycard or
+    self.flowType == FlowType.DisplayKeycardContent:
       controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)
 
 method resolveKeycardNextState*(self: InsertKeycardState, keycardFlowType: string, keycardEvent: KeycardEvent, 

--- a/src/app/modules/shared_modules/keycard_popup/internal/keycard_empty_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/keycard_empty_state.nim
@@ -8,9 +8,16 @@ proc newKeycardEmptyState*(flowType: FlowType, backState: State): KeycardEmptySt
 proc delete*(self: KeycardEmptyState) =
   self.State.delete
 
+method executePrimaryCommand*(self: KeycardEmptyState, controller: Controller) =
+  if self.flowType == FlowType.FactoryReset or
+    self.flowType == FlowType.Authentication or
+    self.flowType == FlowType.UnlockKeycard or
+    self.flowType == FlowType.DisplayKeycardContent:
+      controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)
+
 method executeTertiaryCommand*(self: KeycardEmptyState, controller: Controller) =
   if self.flowType == FlowType.FactoryReset or
-    self.flowType == FlowType.SetupNewKeycard or
     self.flowType == FlowType.Authentication or
-    self.flowType == FlowType.UnlockKeycard:
+    self.flowType == FlowType.UnlockKeycard or
+    self.flowType == FlowType.DisplayKeycardContent:
       controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)

--- a/src/app/modules/shared_modules/keycard_popup/internal/keycard_inserted_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/keycard_inserted_state.nim
@@ -24,5 +24,6 @@ method executeTertiaryCommand*(self: KeycardInsertedState, controller: Controlle
   if self.flowType == FlowType.FactoryReset or
     self.flowType == FlowType.SetupNewKeycard or
     self.flowType == FlowType.Authentication or
-    self.flowType == FlowType.UnlockKeycard:
+    self.flowType == FlowType.UnlockKeycard or
+    self.flowType == FlowType.DisplayKeycardContent:
       controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)

--- a/src/app/modules/shared_modules/keycard_popup/internal/keycard_metadata_display_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/keycard_metadata_display_state.nim
@@ -12,9 +12,11 @@ method getNextPrimaryState*(self: KeycardMetadataDisplayState, controller: Contr
   if self.flowType == FlowType.FactoryReset or
     self.flowType == FlowType.SetupNewKeycard:
       return createState(StateType.FactoryResetConfirmationDisplayMetadata, self.flowType, self)
-  return nil
+  if self.flowType == FlowType.DisplayKeycardContent:
+    controller.terminateCurrentFlow(lastStepInTheCurrentFlow = true)
 
 method executeTertiaryCommand*(self: KeycardMetadataDisplayState, controller: Controller) =
   if self.flowType == FlowType.FactoryReset or
-    self.flowType == FlowType.SetupNewKeycard:
+    self.flowType == FlowType.SetupNewKeycard or
+    self.flowType == FlowType.DisplayKeycardContent:
       controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)

--- a/src/app/modules/shared_modules/keycard_popup/internal/max_pairing_slots_reached_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/max_pairing_slots_reached_state.nim
@@ -12,13 +12,15 @@ method getNextPrimaryState*(self: MaxPairingSlotsReachedState, controller: Contr
   if self.flowType == FlowType.FactoryReset or
     self.flowType == FlowType.SetupNewKeycard:
       return createState(StateType.FactoryResetConfirmation, self.flowType, self)
-  if self.flowType == FlowType.Authentication:
-    controller.runSharedModuleFlow(FlowType.UnlockKeycard)
+  if self.flowType == FlowType.Authentication or
+    self.flowType == FlowType.DisplayKeycardContent:
+      controller.runSharedModuleFlow(FlowType.UnlockKeycard)
   return nil
 
 method executeTertiaryCommand*(self: MaxPairingSlotsReachedState, controller: Controller) =
   if self.flowType == FlowType.FactoryReset or
     self.flowType == FlowType.SetupNewKeycard or
     self.flowType == FlowType.Authentication or
-    self.flowType == FlowType.UnlockKeycard:
+    self.flowType == FlowType.UnlockKeycard or
+    self.flowType == FlowType.DisplayKeycardContent:
       controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)

--- a/src/app/modules/shared_modules/keycard_popup/internal/max_pin_retries_reached_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/max_pin_retries_reached_state.nim
@@ -9,7 +9,8 @@ proc delete*(self: MaxPinRetriesReachedState) =
   self.State.delete
 
 method getNextPrimaryState*(self: MaxPinRetriesReachedState, controller: Controller): State =
-  if self.flowType == FlowType.FactoryReset:
+  if self.flowType == FlowType.FactoryReset or
+    self.flowType == FlowType.DisplayKeycardContent:
     controller.runSharedModuleFlow(FlowType.UnlockKeycard)
   if self.flowType == FlowType.SetupNewKeycard:
     let currValue = extractPredefinedKeycardDataToNumber(controller.getKeycardData())
@@ -23,7 +24,8 @@ method getNextPrimaryState*(self: MaxPinRetriesReachedState, controller: Control
 
 method executeTertiaryCommand*(self: MaxPinRetriesReachedState, controller: Controller) =
   if self.flowType == FlowType.FactoryReset or
-    self.flowType == FlowType.Authentication:
+    self.flowType == FlowType.Authentication or
+    self.flowType == FlowType.DisplayKeycardContent:
       controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)
   if self.flowType == FlowType.SetupNewKeycard:
     controller.setKeycardData(updatePredefinedKeycardData(controller.getKeycardData(), PredefinedKeycardData.UseUnlockLabelForLockedState, add = false))

--- a/src/app/modules/shared_modules/keycard_popup/internal/max_puk_retries_reached_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/max_puk_retries_reached_state.nim
@@ -12,8 +12,9 @@ method getNextPrimaryState*(self: MaxPukRetriesReachedState, controller: Control
   if self.flowType == FlowType.FactoryReset or
     self.flowType == FlowType.SetupNewKeycard:
       return createState(StateType.FactoryResetConfirmation, self.flowType, self)
-  if self.flowType == FlowType.Authentication:
-    controller.runSharedModuleFlow(FlowType.UnlockKeycard)
+  if self.flowType == FlowType.Authentication or
+    self.flowType == FlowType.DisplayKeycardContent:
+      controller.runSharedModuleFlow(FlowType.UnlockKeycard)
   if self.flowType == FlowType.UnlockKeycard:
     return createState(StateType.EnterSeedPhrase, self.flowType, self)
 
@@ -21,5 +22,6 @@ method executeTertiaryCommand*(self: MaxPukRetriesReachedState, controller: Cont
   if self.flowType == FlowType.FactoryReset or
     self.flowType == FlowType.SetupNewKeycard or
     self.flowType == FlowType.Authentication or
-    self.flowType == FlowType.UnlockKeycard:
+    self.flowType == FlowType.UnlockKeycard or
+    self.flowType == FlowType.DisplayKeycardContent:
       controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)

--- a/src/app/modules/shared_modules/keycard_popup/internal/not_keycard_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/not_keycard_state.nim
@@ -12,5 +12,6 @@ method executeTertiaryCommand*(self: NotKeycardState, controller: Controller) =
   if self.flowType == FlowType.FactoryReset or
     self.flowType == FlowType.SetupNewKeycard or
     self.flowType == FlowType.Authentication or
-    self.flowType == FlowType.UnlockKeycard:
+    self.flowType == FlowType.UnlockKeycard or
+    self.flowType == FlowType.DisplayKeycardContent:
       controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)

--- a/src/app/modules/shared_modules/keycard_popup/internal/pin_verified_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/pin_verified_state.nim
@@ -10,11 +10,13 @@ proc delete*(self: PinVerifiedState) =
 
 method getNextPrimaryState*(self: PinVerifiedState, controller: Controller): State =
   if self.flowType == FlowType.FactoryReset or
-    self.flowType == FlowType.SetupNewKeycard:
+    self.flowType == FlowType.SetupNewKeycard or
+    self.flowType == FlowType.DisplayKeycardContent:
       return createState(StateType.KeycardMetadataDisplay, self.flowType, nil)
   return nil
 
 method executeTertiaryCommand*(self: PinVerifiedState, controller: Controller) =
   if self.flowType == FlowType.FactoryReset or
-    self.flowType == FlowType.SetupNewKeycard:
+    self.flowType == FlowType.SetupNewKeycard or
+    self.flowType == FlowType.DisplayKeycardContent:
       controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)

--- a/src/app/modules/shared_modules/keycard_popup/internal/plugin_reader_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/plugin_reader_state.nim
@@ -17,7 +17,8 @@ method executeTertiaryCommand*(self: PluginReaderState, controller: Controller) 
   if self.flowType == FlowType.FactoryReset or
     self.flowType == FlowType.SetupNewKeycard or
     self.flowType == FlowType.Authentication or
-    self.flowType == FlowType.UnlockKeycard:
+    self.flowType == FlowType.UnlockKeycard or
+    self.flowType == FlowType.DisplayKeycardContent:
       controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)
 
 method resolveKeycardNextState*(self: PluginReaderState, keycardFlowType: string, keycardEvent: KeycardEvent, 

--- a/src/app/modules/shared_modules/keycard_popup/internal/reading_keycard_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/reading_keycard_state.nim
@@ -17,7 +17,8 @@ method executeTertiaryCommand*(self: ReadingKeycardState, controller: Controller
   if self.flowType == FlowType.FactoryReset or
     self.flowType == FlowType.SetupNewKeycard or
     self.flowType == FlowType.Authentication or
-    self.flowType == FlowType.UnlockKeycard:
+    self.flowType == FlowType.UnlockKeycard or
+    self.flowType == FlowType.DisplayKeycardContent:
       controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)
 
 method getNextSecondaryState*(self: ReadingKeycardState, controller: Controller): State =

--- a/src/app/modules/shared_modules/keycard_popup/internal/recognized_keycard_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/recognized_keycard_state.nim
@@ -23,9 +23,12 @@ method getNextSecondaryState*(self: RecognizedKeycardState, controller: Controll
     return createState(StateType.CreatePin, self.flowType, self.getBackState)
   if self.flowType == FlowType.UnlockKeycard:
     return createState(StateType.UnlockKeycardOptions, self.flowType, nil)
+  if self.flowType == FlowType.DisplayKeycardContent:
+    return createState(StateType.EnterPin, self.flowType, nil)
 
 method executeTertiaryCommand*(self: RecognizedKeycardState, controller: Controller) =
   if self.flowType == FlowType.FactoryReset or
     self.flowType == FlowType.SetupNewKeycard or
-    self.flowType == FlowType.UnlockKeycard:
+    self.flowType == FlowType.UnlockKeycard or
+    self.flowType == FlowType.DisplayKeycardContent:
       controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)

--- a/src/app/modules/shared_modules/keycard_popup/internal/state_factory.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/state_factory.nim
@@ -1,9 +1,10 @@
 import parseutils, sequtils, sugar, chronicles
+import ../../../../global/global_singleton
 import ../../../../../app_service/service/keycard/constants
-import ../controller
 from ../../../../../app_service/service/keycard/service import KCSFlowType
 from ../../../../../app_service/service/keycard/service import PINLengthForStatusApp
 from ../../../../../app_service/service/keycard/service import PUKLengthForStatusApp
+import ../controller
 import state
 
 logScope:
@@ -325,7 +326,7 @@ proc ensureReaderAndCardPresenceAndResolveNextState*(state: State, keycardFlowTy
           return createState(StateType.MaxPukRetriesReached, state.flowType, nil)
     if keycardFlowType == ResponseTypeValueEnterPIN:
       if keycardEvent.keyUid == controller.getKeyUidWhichIsBeingAuthenticating():
-        if controller.loggedInUserUsesBiometricLogin():
+        if singletonInstance.userProfile.getUsingBiometricLogin():
           if keycardEvent.error.len > 0 and
             keycardEvent.error == ErrorPIN:
               controller.setKeycardData($keycardEvent.pinRetries)

--- a/src/app/modules/shared_modules/keycard_popup/io_interface.nim
+++ b/src/app/modules/shared_modules/keycard_popup/io_interface.nim
@@ -36,6 +36,7 @@ type FlowType* {.pure.} = enum
   SetupNewKeycard = "SetupNewKeycard"
   Authentication = "Authentication"
   UnlockKeycard = "UnlockKeycard"
+  DisplayKeycardContent = "DisplayKeycardContent"
 
 type
   AccessInterface* {.pure inheritable.} = ref object of RootObj

--- a/src/app/modules/shared_modules/keycard_popup/io_interface.nim
+++ b/src/app/modules/shared_modules/keycard_popup/io_interface.nim
@@ -127,9 +127,6 @@ method loggedInUserUsesBiometricLogin*(self: AccessInterface): bool {.base.} =
 method migratingProfileKeyPair*(self: AccessInterface): bool {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method isProfileKeyPairMigrated*(self: AccessInterface): bool {.base.} =
-  raise newException(ValueError, "No implementation available")
-
 method getSigningPhrase*(self: AccessInterface): string {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/shared_modules/keycard_popup/io_interface.nim
+++ b/src/app/modules/shared_modules/keycard_popup/io_interface.nim
@@ -121,9 +121,6 @@ method setSelectedKeyPair*(self: AccessInterface, item: KeyPairItem) {.base.} =
 method setKeyPairStoredOnKeycard*(self: AccessInterface, cardMetadata: CardMetadata) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method loggedInUserUsesBiometricLogin*(self: AccessInterface): bool {.base.} =
-  raise newException(ValueError, "No implementation available")
-
 method migratingProfileKeyPair*(self: AccessInterface): bool {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/shared_modules/keycard_popup/module.nim
+++ b/src/app/modules/shared_modules/keycard_popup/module.nim
@@ -102,9 +102,6 @@ method getSeedPhrase*[T](self: Module[T]): string =
 method validSeedPhrase*[T](self: Module[T], value: string): bool =
   return self.controller.validSeedPhrase(value)
 
-method loggedInUserUsesBiometricLogin*[T](self: Module[T]): bool =
-  return self.controller.loggedInUserUsesBiometricLogin()
-
 method migratingProfileKeyPair*[T](self: Module[T]): bool =
   return self.controller.getSelectedKeyPairIsProfile()
 
@@ -332,7 +329,7 @@ method runFlow*[T](self: Module[T], flowToRun: FlowType, keyUid = "", bip44Path 
       self.tmpLocalState = newReadingKeycardState(flowToRun, nil)
       self.controller.runSignFlow(keyUid, bip44Path, txHash)
       return
-    if self.controller.loggedInUserUsesBiometricLogin():
+    if singletonInstance.userProfile.getUsingBiometricLogin():
       self.controller.tryToObtainDataFromKeychain()
       return
     self.view.setCurrentState(newEnterPasswordState(flowToRun, nil))

--- a/src/app/modules/shared_modules/keycard_popup/module.nim
+++ b/src/app/modules/shared_modules/keycard_popup/module.nim
@@ -317,13 +317,13 @@ method runFlow*[T](self: Module[T], flowToRun: FlowType, keyUid = "", bip44Path 
     self.initialized = true
     self.controller.init()
   if flowToRun == FlowType.FactoryReset:
-    let items = self.buildKeyPairsList(excludeAlreadyMigratedPairs = false)
-    self.view.createKeyPairModel(items)
+    self.view.createKeyPairStoredOnKeycard()
     self.tmpLocalState = newReadingKeycardState(flowToRun, nil)
     self.controller.runGetMetadataFlow(resolveAddress = true)
     return
   if flowToRun == FlowType.SetupNewKeycard:
     let items = self.buildKeyPairsList(excludeAlreadyMigratedPairs = true)
+    self.view.createKeyPairStoredOnKeycard()
     self.view.createKeyPairModel(items)
     self.view.setCurrentState(newSelectExistingKeyPairState(flowToRun, nil))
     self.controller.readyToDisplayPopup()
@@ -343,6 +343,11 @@ method runFlow*[T](self: Module[T], flowToRun: FlowType, keyUid = "", bip44Path 
     self.controller.readyToDisplayPopup()
     return
   if flowToRun == FlowType.UnlockKeycard:
+    self.tmpLocalState = newReadingKeycardState(flowToRun, nil)
+    self.controller.runGetMetadataFlow(resolveAddress = true)
+    return
+  if flowToRun == FlowType.DisplayKeycardContent:
+    self.view.createKeyPairStoredOnKeycard()
     self.tmpLocalState = newReadingKeycardState(flowToRun, nil)
     self.controller.runGetMetadataFlow(resolveAddress = true)
     return

--- a/src/app/modules/shared_modules/keycard_popup/module.nim
+++ b/src/app/modules/shared_modules/keycard_popup/module.nim
@@ -108,9 +108,6 @@ method loggedInUserUsesBiometricLogin*[T](self: Module[T]): bool =
 method migratingProfileKeyPair*[T](self: Module[T]): bool =
   return self.controller.getSelectedKeyPairIsProfile()
 
-method isProfileKeyPairMigrated*[T](self: Module[T]): bool =
-  return self.controller.getLoggedInAccount().keycardPairing.len > 0
-
 method getSigningPhrase*[T](self: Module[T]): string =
   return self.controller.getSigningPhrase()
 

--- a/src/app/modules/shared_modules/keycard_popup/view.nim
+++ b/src/app/modules/shared_modules/keycard_popup/view.nim
@@ -100,6 +100,12 @@ QtObject:
     read = getKeyPairModel
     notify = keyPairModelChanged
 
+  proc createKeyPairStoredOnKeycard*(self: View) =
+    if self.keyPairStoredOnKeycard.isNil:
+      self.keyPairStoredOnKeycard = newKeyPairSelectedItem()
+    if self.keyPairStoredOnKeycardVariant.isNil:
+      self.keyPairStoredOnKeycardVariant = newQVariant(self.keyPairStoredOnKeycard)
+
   proc createKeyPairModel*(self: View, items: seq[KeyPairItem]) =
     if self.keyPairModel.isNil:
       self.keyPairModel = newKeyPairModel()
@@ -109,10 +115,6 @@ QtObject:
       self.selectedKeyPairItem = newKeyPairSelectedItem()
     if self.selectedKeyPairItemVariant.isNil:
       self.selectedKeyPairItemVariant = newQVariant(self.selectedKeyPairItem)
-    if self.keyPairStoredOnKeycard.isNil:
-      self.keyPairStoredOnKeycard = newKeyPairSelectedItem()
-    if self.keyPairStoredOnKeycardVariant.isNil:
-      self.keyPairStoredOnKeycardVariant = newQVariant(self.keyPairStoredOnKeycard)
     self.keyPairModel.setItems(items)
     self.keyPairModelChanged()
 

--- a/src/app/modules/shared_modules/keycard_popup/view.nim
+++ b/src/app/modules/shared_modules/keycard_popup/view.nim
@@ -188,9 +188,6 @@ QtObject:
   proc validSeedPhrase*(self: View, value: string): bool {.slot.} =
     return self.delegate.validSeedPhrase(value)
   
-  proc loggedInUserUsesBiometricLogin*(self: View): bool {.slot.} =
-    return self.delegate.loggedInUserUsesBiometricLogin()
-
   proc migratingProfileKeyPair*(self: View): bool {.slot.} =
     return self.delegate.migratingProfileKeyPair()
 

--- a/src/app/modules/shared_modules/keycard_popup/view.nim
+++ b/src/app/modules/shared_modules/keycard_popup/view.nim
@@ -194,8 +194,5 @@ QtObject:
   proc migratingProfileKeyPair*(self: View): bool {.slot.} =
     return self.delegate.migratingProfileKeyPair()
 
-  proc isProfileKeyPairMigrated*(self: View): bool {.slot.} =
-    return self.delegate.isProfileKeyPairMigrated()
-
   proc getSigningPhrase*(self: View): string {.slot.} =
     return self.delegate.getSigningPhrase()

--- a/src/app/modules/startup/internal/login_keycard_insert_keycard_state.nim
+++ b/src/app/modules/startup/internal/login_keycard_insert_keycard_state.nim
@@ -16,7 +16,7 @@ method executePrimaryCommand*(self: LoginKeycardInsertKeycardState, controller: 
       controller.enterKeycardPin(controller.getPin())
 
 method getNextPrimaryState*(self: LoginKeycardInsertKeycardState, controller: Controller): State =
-  if controller.keychainErrorOccurred():
+  if controller.keychainErrorOccurred() or controller.getPin().len != PINLengthForStatusApp:
     return createState(StateType.LoginKeycardEnterPin, self.flowType, nil)
 
 method getNextSecondaryState*(self: LoginKeycardInsertKeycardState, controller: Controller): State =

--- a/src/app/modules/startup/internal/login_keycard_reading_keycard_state.nim
+++ b/src/app/modules/startup/internal/login_keycard_reading_keycard_state.nim
@@ -18,7 +18,7 @@ method executePrimaryCommand*(self: LoginKeycardReadingKeycardState, controller:
       controller.enterKeycardPin(controller.getPin())
 
 method getNextPrimaryState*(self: LoginKeycardReadingKeycardState, controller: Controller): State =
-  if controller.keychainErrorOccurred():
+  if controller.keychainErrorOccurred() or controller.getPin().len != PINLengthForStatusApp:
     return createState(StateType.LoginKeycardEnterPin, self.flowType, nil)
 
 method getNextSecondaryState*(self: LoginKeycardReadingKeycardState, controller: Controller): State =

--- a/src/app/modules/startup/internal/login_keycard_wrong_keycard.nim
+++ b/src/app/modules/startup/internal/login_keycard_wrong_keycard.nim
@@ -16,7 +16,7 @@ method executePrimaryCommand*(self: LoginKeycardWrongKeycardState, controller: C
       controller.enterKeycardPin(controller.getPin())
 
 method getNextPrimaryState*(self: LoginKeycardWrongKeycardState, controller: Controller): State =
-  if controller.keychainErrorOccurred():
+  if controller.keychainErrorOccurred() or controller.getPin().len != PINLengthForStatusApp:
     return createState(StateType.LoginKeycardEnterPin, self.flowType, nil)
 
 method getNextSecondaryState*(self: LoginKeycardWrongKeycardState, controller: Controller): State =

--- a/src/app/modules/startup/internal/login_keycard_wrong_pin_state.nim
+++ b/src/app/modules/startup/internal/login_keycard_wrong_pin_state.nim
@@ -18,7 +18,7 @@ method executePrimaryCommand*(self: LoginKeycardWrongPinState, controller: Contr
       controller.enterKeycardPin(controller.getPin())
 
 method getNextPrimaryState*(self: LoginKeycardWrongPinState, controller: Controller): State =
-  if controller.keychainErrorOccurred():
+  if controller.keychainErrorOccurred() or controller.getPin().len != PINLengthForStatusApp:
     return createState(StateType.LoginKeycardEnterPin, self.flowType, nil)
 
 method getNextSecondaryState*(self: LoginKeycardWrongPinState, controller: Controller): State =

--- a/src/app/modules/startup/internal/login_plugin_state.nim
+++ b/src/app/modules/startup/internal/login_plugin_state.nim
@@ -16,7 +16,7 @@ method executePrimaryCommand*(self: LoginPluginState, controller: Controller) =
       controller.enterKeycardPin(controller.getPin())
 
 method getNextPrimaryState*(self: LoginPluginState, controller: Controller): State =
-  if controller.keychainErrorOccurred():
+  if controller.keychainErrorOccurred() or controller.getPin().len != PINLengthForStatusApp:
     return createState(StateType.LoginKeycardEnterPin, self.flowType, nil)
 
 method getNextSecondaryState*(self: LoginPluginState, controller: Controller): State =

--- a/src/app/modules/startup/internal/login_state.nim
+++ b/src/app/modules/startup/internal/login_state.nim
@@ -16,7 +16,7 @@ method executePrimaryCommand*(self: LoginState, controller: Controller) =
       controller.enterKeycardPin(controller.getPin())
 
 method getNextPrimaryState*(self: LoginState, controller: Controller): State =
-  if controller.keychainErrorOccurred():
+  if controller.keychainErrorOccurred() or controller.getPin().len != PINLengthForStatusApp:
     return createState(StateType.LoginKeycardEnterPin, self.flowType, nil)
 
 method getNextSecondaryState*(self: LoginState, controller: Controller): State =

--- a/src/app_service/service/accounts/service.nim
+++ b/src/app_service/service/accounts/service.nim
@@ -590,8 +590,6 @@ proc verifyAccountPassword*(self: Service, account: string, password: string): b
 
 proc convertToKeycardAccount*(self: Service, keyUid: string, password: string): bool = 
   try:
-    self.setKeyStoreDir(keyUid)
-
     var accountDataJson = %* {
       "name": self.getLoggedInAccount().name,
       "key-uid": keyUid

--- a/test/ui-test/src/screens/StatusWalletScreen.py
+++ b/test/ui-test/src/screens/StatusWalletScreen.py
@@ -69,8 +69,14 @@ class AddAccountPopup(Enum):
     TYPE_PRIVATE_KEY: str = "mainWallet_Add_Account_Popup_Type_Private_Key"
     ADDRESS_INPUT: str = "mainWallet_Add_Account_Popup_Watch_Only_Address"
     PRIVATE_KEY_INPUT: str = "mainWallet_Add_Account_Popup_Private_Key"
+    AUTHENTICATE_BUTTON: str = "mainWallet_Authenticate_Popup_Footer_Add_Account"
     ADD_ACCOUNT_BUTTON: str = "mainWallet_Add_Account_Popup_Footer_Add_Account"
     SEED_PHRASE_INPUT_TEMPLATE: str = "mainWindow_Add_Account_Popup_Seed_Phrase_"
+    
+class SharedPopup(Enum):
+    POPUP_CONTENT: str = "sharedPopup_Popup_Content"
+    PASSWORD_INPUT: str = "sharedPopup_Password_Input"
+    PRIMARY_BUTTON: str = "sharedPopup_Primary_Button"
     
 class CollectiblesView(Enum):
     COLLECTIONS_REPEATER: str =  "mainWallet_Collections_Repeater"  
@@ -89,12 +95,11 @@ class StatusWalletScreen:
     def add_watch_only_account(self, account_name: str, address: str):
         click_obj_by_name(MainWalletScreen.ADD_ACCOUNT_BUTTON.value)
         
-        type(AddAccountPopup.ACCOUNT_NAME_INPUT.value, account_name)
-
         click_obj_by_name(AddAccountPopup.ADVANCE_SECTION.value)
         click_obj_by_name(AddAccountPopup.TYPE_SELECTOR.value)
         time.sleep(1)
         click_obj_by_name(AddAccountPopup.TYPE_WATCH_ONLY.value)
+        type(AddAccountPopup.ACCOUNT_NAME_INPUT.value, account_name)
         
         type(AddAccountPopup.ADDRESS_INPUT.value, address)
         click_obj_by_name(AddAccountPopup.ADD_ACCOUNT_BUTTON.value)
@@ -102,13 +107,16 @@ class StatusWalletScreen:
     def import_private_key(self, account_name: str, password: str, private_key: str):
         click_obj_by_name(MainWalletScreen.ADD_ACCOUNT_BUTTON.value)
         
-        type(AddAccountPopup.PASSWORD_INPUT.value, password)
-        type(AddAccountPopup.ACCOUNT_NAME_INPUT.value, account_name)
-
+        click_obj_by_name(AddAccountPopup.AUTHENTICATE_BUTTON.value)
+        
+        wait_for_object_and_type(SharedPopup.PASSWORD_INPUT.value, password)
+        click_obj_by_name(SharedPopup.PRIMARY_BUTTON.value)
+        
         click_obj_by_name(AddAccountPopup.ADVANCE_SECTION.value)
         click_obj_by_name(AddAccountPopup.TYPE_SELECTOR.value)
         time.sleep(1)
         click_obj_by_name(AddAccountPopup.TYPE_PRIVATE_KEY.value)
+        type(AddAccountPopup.ACCOUNT_NAME_INPUT.value, account_name)
         
         type(AddAccountPopup.PRIVATE_KEY_INPUT.value, private_key)
         click_obj_by_name(AddAccountPopup.ADD_ACCOUNT_BUTTON.value)
@@ -116,14 +124,17 @@ class StatusWalletScreen:
     def import_seed_phrase(self, account_name: str, password: str, mnemonic: str):
         click_obj_by_name(MainWalletScreen.ADD_ACCOUNT_BUTTON.value)
         
-        type(AddAccountPopup.PASSWORD_INPUT.value, password)
-        type(AddAccountPopup.ACCOUNT_NAME_INPUT.value, account_name)
+        click_obj_by_name(AddAccountPopup.AUTHENTICATE_BUTTON.value)
+        
+        wait_for_object_and_type(SharedPopup.PASSWORD_INPUT.value, password)
+        click_obj_by_name(SharedPopup.PRIMARY_BUTTON.value)
         
         click_obj_by_name(AddAccountPopup.ADVANCE_SECTION.value)
         click_obj_by_name(AddAccountPopup.TYPE_SELECTOR.value)
         time.sleep(1)
         click_obj_by_name(AddAccountPopup.TYPE_SEED_PHRASE.value)
-        
+        type(AddAccountPopup.ACCOUNT_NAME_INPUT.value, account_name)
+                
         words = mnemonic.split()
         scroll_obj_by_name(AddAccountPopup.SCROLL_BAR.value)
         time.sleep(1)
@@ -147,10 +158,12 @@ class StatusWalletScreen:
     def generate_new_account(self, account_name: str, password: str):
         click_obj_by_name(MainWalletScreen.ADD_ACCOUNT_BUTTON.value)
         
-        type(AddAccountPopup.PASSWORD_INPUT.value, password)
+        click_obj_by_name(AddAccountPopup.AUTHENTICATE_BUTTON.value)
+        
+        wait_for_object_and_type(SharedPopup.PASSWORD_INPUT.value, password)
+        click_obj_by_name(SharedPopup.PRIMARY_BUTTON.value)
+        
         type(AddAccountPopup.ACCOUNT_NAME_INPUT.value, account_name)
-
-        time.sleep(2)
         click_obj_by_name(AddAccountPopup.ADD_ACCOUNT_BUTTON.value)
          
     def verify_account_name_is_present(self, account_name: str):

--- a/test/ui-test/testSuites/suite_status/shared/scripts/sections/wallet_names.py
+++ b/test/ui-test/testSuites/suite_status/shared/scripts/sections/wallet_names.py
@@ -40,7 +40,7 @@ mainWallet_Send_Popup_GasSelector_HighGas_Button = {"container": statusDesktop_m
 # Add account popup:
 mainWallet_Add_Account_Popup_Main = {"container": statusDesktop_mainWindow, "objectName": "AddAccountModalContent", "type": "StatusScrollView", "visible": True}
 mainWallet_Add_Account_Popup_Password = {"container": mainWallet_Add_Account_Popup_Main, "text": "Enter your password...", "type": "PlaceholderText", "unnamed": 1, "visible": True}
-mainWallet_Add_Account_Popup_Advanced = {"container": mainWallet_Add_Account_Popup_Main, "text": "Advanced", "type": "StatusBaseText", "unnamed": 1, "visible": True}
+mainWallet_Add_Account_Popup_Advanced = {"container": mainWallet_Add_Account_Popup_Main, "objectName": "ExpandableItem", "type": "MouseArea", "visible": True}
 mainWallet_Add_Account_Popup_Type_Selector = {"container": mainWallet_Add_Account_Popup_Main, "text": "Default", "type": "StatusBaseText", "unnamed": 1, "visible": True}
 mainWallet_Add_Account_Popup_Type_Watch_Only = {"container": statusDesktop_mainWindow, "text": "Add a watch-only address", "type": "StatusBaseText", "unnamed": 1, "visible": True}
 mainWallet_Add_Account_Popup_Type_Private_Key = {"container": statusDesktop_mainWindow, "text": "Generate from Private key", "type": "StatusBaseText", "unnamed": 1, "visible": True}
@@ -62,6 +62,7 @@ mainWindow_Add_Account_Popup_Seed_Phrase_11 = {"container": mainWallet_Add_Accou
 mainWindow_Add_Account_Popup_Seed_Phrase_12 = {"container": mainWallet_Add_Account_Popup_Main, "type": "StatusBaseText", "objectName": "seedPhraseInputPlaceholder11", "visible": True}
 
 mainWallet_Add_Account_Popup_Footer = {"container": statusDesktop_mainWindow, "type": "StatusModalFooter", "unnamed": 1, "visible": True}
+mainWallet_Authenticate_Popup_Footer_Add_Account = {"container": mainWallet_Add_Account_Popup_Footer, "text": "Authenticate", "type": "StatusBaseText", "unnamed": 1, "visible": True}
 mainWallet_Add_Account_Popup_Footer_Add_Account = {"container": mainWallet_Add_Account_Popup_Footer, "text": "Add account", "type": "StatusBaseText", "unnamed": 1, "visible": True}
 
 # saved address view
@@ -79,3 +80,8 @@ mainWallet_Saved_Addreses_Popup_Address_Add_Button = {"container": statusDesktop
 # Collectibles view
 mainWallet_Collections_Repeater = {"container": statusDesktop_mainWindow, "objectName": "collectionsRepeater", "type": "Repeater"}
 mainWallet_Collectibles_Repeater = {"container": statusDesktop_mainWindow, "objectName": "collectiblesRepeater", "type": "Repeater"}
+
+# Shared Popup
+sharedPopup_Popup_Content = {"container": statusDesktop_mainWindow, "objectName": "KeycardSharedPopupContent", "type": "Item"}
+sharedPopup_Password_Input = {"container": sharedPopup_Popup_Content, "objectName": "Password", "type": "TextField"}
+sharedPopup_Primary_Button = {"container": statusDesktop_mainWindow, "objectName": "PrimaryButton", "type": "StatusButton"}

--- a/ui/StatusQ/src/StatusQ/Components/StatusExpandableItem.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusExpandableItem.qml
@@ -160,6 +160,7 @@ Rectangle {
 
         MouseArea {
             id: sensor
+            objectName: "ExpandableItem"
             anchors.fill: parent
             onClicked: {
                 if(expandable) {

--- a/ui/StatusQ/src/StatusQ/Controls/StatusInput.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusInput.qml
@@ -245,6 +245,7 @@ Item {
     */
     function reset() {
         statusBaseInput.valid = false
+        statusBaseInput.dirty = false
         statusBaseInput.pristine = true
         statusBaseInput.text = ""
         root.errorMessage = ""

--- a/ui/StatusQ/src/StatusQ/Controls/StatusInput.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusInput.qml
@@ -244,11 +244,11 @@ Item {
         This function resets the text input validation and text.
     */
     function reset() {
+        statusBaseInput.text = ""
+        root.errorMessage = ""
         statusBaseInput.valid = false
         statusBaseInput.dirty = false
         statusBaseInput.pristine = true
-        statusBaseInput.text = ""
-        root.errorMessage = ""
     }
 
     property string _previousText: text

--- a/ui/app/AppLayouts/Onboarding/views/LoginView.qml
+++ b/ui/app/AppLayouts/Onboarding/views/LoginView.qml
@@ -35,6 +35,7 @@ Item {
     }
 
     onStateChanged: {
+        d.loading = false
         pinInputField.statesInitialization()
         pinInputField.forceFocus()
     }
@@ -424,7 +425,6 @@ Item {
         StatusButton {
             id: button
             Layout.alignment: Qt.AlignHCenter
-            focus: true
             onClicked: {
                 root.startupStore.doPrimaryAction()
             }

--- a/ui/app/AppLayouts/Profile/stores/KeycardStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/KeycardStore.qml
@@ -10,6 +10,18 @@ QtObject {
         root.keycardModule.runSetupKeycardPopup()
     }
 
+    function runGenerateSeedPhrasePopup() {
+        root.keycardModule.runGenerateSeedPhrasePopup()
+    }
+
+    function runImportOrRestoreViaSeedPhrasePopup() {
+        root.keycardModule.runImportOrRestoreViaSeedPhrasePopup()
+    }
+
+    function runImportFromKeycardToAppPopup() {
+        root.keycardModule.runImportFromKeycardToAppPopup()
+    }
+
     function runUnlockKeycardPopup() {
         root.keycardModule.runUnlockKeycardPopup()
     }

--- a/ui/app/AppLayouts/Profile/views/KeycardView.qml
+++ b/ui/app/AppLayouts/Profile/views/KeycardView.qml
@@ -115,7 +115,7 @@ SettingsContentBase {
                 }
             ]
             onClicked: {
-                console.warn("TODO: Generate a seed phrase...")
+                root.keycardStore.runGenerateSeedPhrasePopup()
             }
         }
 
@@ -130,7 +130,7 @@ SettingsContentBase {
                 }
             ]
             onClicked: {
-                console.warn("TODO: Import or restore via a seed phrase...")
+                root.keycardStore.runImportOrRestoreViaSeedPhrasePopup()
             }
         }
 
@@ -145,7 +145,7 @@ SettingsContentBase {
                 }
             ]
             onClicked: {
-                console.warn("TODO: Import from Keycard to Status Desktop...")
+                root.keycardStore.runImportFromKeycardToAppPopup()
             }
         }
 

--- a/ui/app/AppLayouts/Profile/views/MyProfileView.qml
+++ b/ui/app/AppLayouts/Profile/views/MyProfileView.qml
@@ -28,6 +28,7 @@ SettingsContentBase {
     titleRowComponentLoader.sourceComponent: StatusButton {
         text: qsTr("Change Password")
         onClicked: changePasswordModal.open()
+        enabled: !userProfile.isKeycardUser
     }
 
     dirty: settingsView.dirty

--- a/ui/app/AppLayouts/Wallet/panels/ImportSeedPhrasePanel.qml
+++ b/ui/app/AppLayouts/Wallet/panels/ImportSeedPhrasePanel.qml
@@ -37,7 +37,7 @@ StatusGridView {
         if (!Utils.isMnemonic(mnemonicString)) {
             _internal.errorString = qsTr("Invalid seed phrase")
         } else {
-            if (!RootStore.validMnemonic(mnemonicString)) {
+            if (!RootStore.validSeedPhrase(mnemonicString)) {
                 _internal.errorString = qsTr("Invalid seed phrase") + '. ' +
                     qsTr("This seed phrase doesn't match our supported dictionary. Check for misspelled words.")
             }

--- a/ui/app/AppLayouts/Wallet/panels/ImportSeedPhrasePanel.qml
+++ b/ui/app/AppLayouts/Wallet/panels/ImportSeedPhrasePanel.qml
@@ -120,6 +120,9 @@ StatusGridView {
             for (let i = 0; i < words.length; i++) {
                 try {
                     grid.itemAtIndex(i).setWord(words[i])
+                    if (words[i].length === 3) {
+                        grid.addWord(i + 1, words[i])
+                    }
                 } catch (e) {
                     // Getting items outside of the current view might not work
                 }

--- a/ui/app/AppLayouts/Wallet/panels/ImportSeedPhrasePanel.qml
+++ b/ui/app/AppLayouts/Wallet/panels/ImportSeedPhrasePanel.qml
@@ -6,6 +6,7 @@ import StatusQ.Controls 0.1
 
 import utils 1.0
 import shared.stores 1.0
+import shared.controls 1.0
 
 import "../stores"
 
@@ -51,7 +52,7 @@ StatusGridView {
         property int seedPhraseInputHeight: 48
         property var mnemonicInput: []
         property string errorString:  ""
-        readonly property var seedPhraseWordsOptions: ([12, 18, 24])
+        readonly property var seedPhraseWordsOptions: [12, 18, 24]
 
         function getSeedPhraseString() {
             var seedPhrase = ""
@@ -82,6 +83,10 @@ StatusGridView {
                          menmonicInputTemp[i].seed,
                          true)
         }
+    }
+
+    Timer {
+        id: timer
     }
 
 

--- a/ui/app/AppLayouts/Wallet/popups/AddAccountModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/AddAccountModal.qml
@@ -281,7 +281,7 @@ StatusModal {
                 if (d.authenticationNeeded) {
                     if (RootStore.loggedInUserUsesBiometricLogin())
                         return "touch-id"
-                    if (RootStore.isProfileKeyPairMigrated())
+                    if (RootStore.loggedInUserIsKeycardUser())
                         return "keycard"
                     return "password"
                 }

--- a/ui/app/AppLayouts/Wallet/popups/AddAccountModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/AddAccountModal.qml
@@ -63,6 +63,7 @@ StatusModal {
         property int selectedAccountType: SelectGeneratedAccount.AddAccountType.GenerateNew
         readonly property bool authenticationNeeded: d.selectedAccountType !== SelectGeneratedAccount.AddAccountType.WatchOnly &&
                                                      d.password === ""
+        property string addAccountIcon: ""
 
 
 
@@ -133,6 +134,14 @@ StatusModal {
     }
 
     onOpened: {
+        d.addAccountIcon = "password"
+        if (RootStore.loggedInUserUsesBiometricLogin()) {
+            d.addAccountIcon = "touch-id"
+        }
+        else if (RootStore.loggedInUserIsKeycardUser()) {
+            d.addAccountIcon =  "keycard"
+        }
+
         accountNameInput.input.asset.emoji = StatusQUtils.Emoji.getRandomEmoji(StatusQUtils.Emoji.size.verySmall)
         colorSelectionGrid.selectedColorIndex = Math.floor(Math.random() * colorSelectionGrid.model.length)
         accountNameInput.input.edit.forceActiveFocus()
@@ -277,17 +286,7 @@ StatusModal {
                 return accountNameInput.text !== "" && advancedSelection.isValid
             }
 
-            icon.name: {
-                if (d.authenticationNeeded) {
-                    if (RootStore.loggedInUserUsesBiometricLogin())
-                        return "touch-id"
-                    if (RootStore.loggedInUserIsKeycardUser())
-                        return "keycard"
-                    return "password"
-                }
-                return ""
-            }
-
+            icon.name: d.authenticationNeeded? d.addAccountIcon : ""
             highlighted: focus
 
             Keys.onReturnPressed: d.nextButtonClicked()

--- a/ui/app/AppLayouts/Wallet/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Wallet/stores/RootStore.qml
@@ -222,4 +222,16 @@ QtObject {
     function getNextSelectableDerivedAddressIndex() {
         return walletSectionAccounts.getNextSelectableDerivedAddressIndex()
     }
+
+    function authenticateUser() {
+        walletSectionAccounts.authenticateUser()
+    }
+
+    function loggedInUserUsesBiometricLogin() {
+        return walletSectionAccounts.loggedInUserUsesBiometricLogin()
+    }
+
+    function isProfileKeyPairMigrated() {
+        return walletSectionAccounts.isProfileKeyPairMigrated()
+    }
 }

--- a/ui/app/AppLayouts/Wallet/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Wallet/stores/RootStore.qml
@@ -228,7 +228,7 @@ QtObject {
     }
 
     function loggedInUserUsesBiometricLogin() {
-        return walletSectionAccounts.loggedInUserUsesBiometricLogin()
+        return userProfile.usingBiometricLogin
     }
 
     function loggedInUserIsKeycardUser() {

--- a/ui/app/AppLayouts/Wallet/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Wallet/stores/RootStore.qml
@@ -231,7 +231,7 @@ QtObject {
         return walletSectionAccounts.loggedInUserUsesBiometricLogin()
     }
 
-    function isProfileKeyPairMigrated() {
-        return walletSectionAccounts.isProfileKeyPairMigrated()
+    function loggedInUserIsKeycardUser() {
+        return userProfile.isKeycardUser
     }
 }

--- a/ui/app/AppLayouts/Wallet/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Wallet/stores/RootStore.qml
@@ -215,8 +215,8 @@ QtObject {
         walletSectionAccounts.resetDerivedAddressModel()
     }
 
-    function validMnemonic(mnemonic) {
-        return startupModule.validMnemonic(mnemonic)
+    function validSeedPhrase(mnemonic) {
+        return walletSectionAccounts.validSeedPhrase(mnemonic)
     }
 
     function getNextSelectableDerivedAddressIndex() {

--- a/ui/imports/shared/popups/keycard/KeycardPopup.qml
+++ b/ui/imports/shared/popups/keycard/KeycardPopup.qml
@@ -439,10 +439,11 @@ StatusModal {
                                 root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.biometricsReadyToSign ||
                                 root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.notKeycard ||
                                 root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.biometricsPinFailed ||
-                                root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.biometricsPinInvalid ||
                                 root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.wrongKeycard ||
                                 root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardEmpty)
                             return qsTr("Use PIN")
+                        if (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.biometricsPinInvalid)
+                            return qsTr("Update PIN")
                     }
                 }
                 if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.unlockKeycard) {

--- a/ui/imports/shared/popups/keycard/KeycardPopup.qml
+++ b/ui/imports/shared/popups/keycard/KeycardPopup.qml
@@ -423,7 +423,7 @@ StatusModal {
             height: Constants.keycard.general.footerButtonsHeight
             text: {
                 if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.authentication) {
-                    if (root.sharedKeycardModule.loggedInUserUsesBiometricLogin()) {
+                    if (userProfile.usingBiometricLogin) {
                         if (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.enterPassword ||
                                 root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.wrongPassword)
                             return qsTr("Use biometrics instead")
@@ -462,7 +462,7 @@ StatusModal {
                     }
                 }
                 if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.authentication) {
-                    if (root.sharedKeycardModule.loggedInUserUsesBiometricLogin() &&
+                    if (userProfile.usingBiometricLogin &&
                             (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.pluginReader ||
                              root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.insertKeycard ||
                              root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardInserted ||
@@ -704,18 +704,18 @@ StatusModal {
             }
             icon.name: {
                 if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.setupNewKeycard) {
-                    if (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.seedPhraseEnterWords ||
-                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.enterSeedPhrase) {
-                            if (root.sharedKeycardModule.loggedInUserUsesBiometricLogin())
-                                return "touch-id"
-                            if (userProfile.isKeycardUser())
-                                return "keycard"
-                            return "password"
+                    if (root.sharedKeycardModule.migratingProfileKeyPair() &&
+                            (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.seedPhraseEnterWords ||
+                             root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.enterSeedPhrase)) {
+                        if (userProfile.usingBiometricLogin)
+                            return "touch-id"
                         if (userProfile.isKeycardUser)
+                            return "keycard"
+                        return "password"
                     }
                 }
                 if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.authentication) {
-                    if (root.sharedKeycardModule.loggedInUserUsesBiometricLogin()) {
+                    if (userProfile.usingBiometricLogin) {
                         if (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.pluginReader ||
                                 root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.insertKeycard ||
                                 root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardInserted ||

--- a/ui/imports/shared/popups/keycard/KeycardPopup.qml
+++ b/ui/imports/shared/popups/keycard/KeycardPopup.qml
@@ -81,6 +81,8 @@ StatusModal {
     }
 
     contentItem: Item {
+        objectName: "KeycardSharedPopupContent"
+
         Loader {
             id: loader
             anchors.fill: parent
@@ -485,6 +487,7 @@ StatusModal {
         },
         StatusButton {
             id: primaryButton
+            objectName: "PrimaryButton"
             height: Constants.keycard.general.footerButtonsHeight
             text: {
                 if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.setupNewKeycard) {

--- a/ui/imports/shared/popups/keycard/KeycardPopup.qml
+++ b/ui/imports/shared/popups/keycard/KeycardPopup.qml
@@ -30,6 +30,11 @@ StatusModal {
                     return Constants.keycard.general.popupBiggerHeight
                 }
             }
+            if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.displayKeycardContent) {
+                if (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardMetadataDisplay) {
+                    return Constants.keycard.general.popupBiggerHeight
+                }
+            }
         }
         return Constants.keycard.general.popupHeight
     }
@@ -49,6 +54,9 @@ StatusModal {
         }
         if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.unlockKeycard) {
             return qsTr("Unlock Keycard")
+        }
+        if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.displayKeycardContent) {
+            return qsTr("Check what’s on a Keycard")
         }
         return ""
     }
@@ -327,7 +335,6 @@ StatusModal {
                             root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.insertKeycard ||
                             root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardInserted ||
                             root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.recognizedKeycard ||
-                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardEmpty ||
                             root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.notKeycard ||
                             root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.pinVerified ||
                             root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.enterPin ||
@@ -347,7 +354,6 @@ StatusModal {
                             root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.readingKeycard ||
                             root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.insertKeycard ||
                             root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardInserted ||
-                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardEmpty ||
                             root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.wrongPin ||
                             root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.wrongKeychainPin ||
                             root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.biometricsReadyToSign ||
@@ -374,10 +380,24 @@ StatusModal {
                             root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.recognizedKeycard ||
                             root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.enterPuk ||
                             root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.wrongPuk ||
-                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardEmpty ||
                             root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.notKeycard ||
                             root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.unlockKeycardOptions ||
                             root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.enterSeedPhrase)
+                        return qsTr("Cancel")
+                }
+                if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.displayKeycardContent) {
+                    if (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.pluginReader ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.readingKeycard ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.insertKeycard ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardInserted ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.recognizedKeycard ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.enterPin ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.wrongPin ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.notKeycard ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.pinVerified ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPinRetriesReached ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPukRetriesReached ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPairingSlotsReached)
                         return qsTr("Cancel")
                 }
 
@@ -508,7 +528,6 @@ StatusModal {
                     if (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPinRetriesReached ||
                             root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPukRetriesReached ||
                             root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPairingSlotsReached) {
-                        let a = root.sharedKeycardModule.keycardData & Constants.predefinedKeycardData.useUnlockLabelForLockedState
                         if (root.sharedKeycardModule.keycardData & Constants.predefinedKeycardData.useUnlockLabelForLockedState)
                             return qsTr("Unlock Keycard")
                         return qsTr("Next")
@@ -542,7 +561,8 @@ StatusModal {
                             root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPairingSlotsReached) {
                         return qsTr("Unlock Keycard")
                     }
-                    if (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.factoryResetSuccess) {
+                    if (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardEmpty ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.factoryResetSuccess) {
                         return qsTr("Done")
                     }
                 }
@@ -551,7 +571,6 @@ StatusModal {
                             root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.readingKeycard ||
                             root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.insertKeycard ||
                             root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardInserted ||
-                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardEmpty ||
                             root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.wrongPin ||
                             root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.notKeycard ||
                             root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.biometricsReadyToSign ||
@@ -560,6 +579,9 @@ StatusModal {
                             root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.wrongPassword ||
                             root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.enterPin) {
                         return qsTr("Authenticate")
+                    }
+                    if (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardEmpty) {
+                        return qsTr("Done")
                     }
                     if (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.enterBiometricsPassword ||
                             root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.wrongBiometricsPassword) {
@@ -580,7 +602,8 @@ StatusModal {
                     }
                 }
                 if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.unlockKeycard) {
-                    if (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardAlreadyUnlocked ||
+                    if (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardEmpty ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardAlreadyUnlocked ||
                             root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.unlockKeycardSuccess)
                         return qsTr("Done")
                     if (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.unlockKeycardOptions)
@@ -596,6 +619,23 @@ StatusModal {
                         return qsTr("Try entering seed phrase again")
                     }
                     if (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPukRetriesReached) {
+                        return qsTr("Unlock Keycard")
+                    }
+                }
+                if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.displayKeycardContent) {
+                    if (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardEmpty ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardMetadataDisplay) {
+                        return qsTr("Done")
+                    }
+                    if (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.wrongPin) {
+                        return qsTr("I don’t know the PIN")
+                    }
+                    if (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.pinVerified) {
+                        return qsTr("Next")
+                    }
+                    if (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPinRetriesReached ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPukRetriesReached ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPairingSlotsReached) {
                         return qsTr("Unlock Keycard")
                     }
                 }
@@ -638,7 +678,6 @@ StatusModal {
                             root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.readingKeycard ||
                             root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.insertKeycard ||
                             root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardInserted ||
-                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardEmpty ||
                             root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.wrongPin ||
                             root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.wrongKeychainPin ||
                             root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.notKeycard ||
@@ -684,8 +723,7 @@ StatusModal {
                                 root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.biometricsPinInvalid ||
                                 root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.biometricsReadyToSign ||
                                 root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.notKeycard ||
-                                root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.wrongKeycard ||
-                                root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardEmpty)
+                                root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.wrongKeycard)
                             return "touch-id"
                     }
                 }

--- a/ui/imports/shared/popups/keycard/KeycardPopup.qml
+++ b/ui/imports/shared/popups/keycard/KeycardPopup.qml
@@ -708,9 +708,10 @@ StatusModal {
                             root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.enterSeedPhrase) {
                             if (root.sharedKeycardModule.loggedInUserUsesBiometricLogin())
                                 return "touch-id"
-                            if (root.sharedKeycardModule.isProfileKeyPairMigrated())
+                            if (userProfile.isKeycardUser())
                                 return "keycard"
                             return "password"
+                        if (userProfile.isKeycardUser)
                     }
                 }
                 if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.authentication) {

--- a/ui/imports/shared/popups/keycard/states/EnterPassword.qml
+++ b/ui/imports/shared/popups/keycard/states/EnterPassword.qml
@@ -79,6 +79,7 @@ Item {
 
         StatusPasswordInput {
             id: password
+            objectName: "Password"
             Layout.alignment: Qt.AlignHCenter
             signingPhrase: root.sharedKeycardModule.getSigningPhrase()
             placeholderText: qsTr("Password")

--- a/ui/imports/shared/popups/keycard/states/KeycardInit.qml
+++ b/ui/imports/shared/popups/keycard/states/KeycardInit.qml
@@ -182,6 +182,11 @@ Item {
                         return true
                     }
                 }
+                if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.displayKeycardContent) {
+                    if(root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardMetadataDisplay) {
+                        return true
+                    }
+                }
                 return false
             }
 
@@ -224,6 +229,14 @@ Item {
                             root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.biometricsPinInvalid ||
                             root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.wrongKeycard) {
                         return keyPairForAuthenticationComponent
+                    }
+                }
+                if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.displayKeycardContent) {
+                    if(root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardMetadataDisplay) {
+                        if (root.sharedKeycardModule.keyPairStoredOnKeycardIsKnown) {
+                            return knownKeyPairComponent
+                        }
+                        return unknownKeyPairCompontnt
                     }
                 }
 
@@ -513,10 +526,11 @@ Item {
             PropertyChanges {
                 target: message
                 text: {
-                    if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.setupNewKeycard)
-                        return qsTr("The Keycard you have inserted is locked,\nyou will need to factory reset it before proceeding")
-                    if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.authentication)
+                    if (root.sharedKeycardModule.keycardData & Constants.predefinedKeycardData.useGeneralMessageForLockedState) {
+                        if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.setupNewKeycard)
+                            return qsTr("The Keycard you have inserted is locked,\nyou will need to factory reset it before proceeding")
                         return qsTr("You will need to unlock it before proceeding")
+                    }
                     if (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPinRetriesReached)
                         return qsTr("Pin entered incorrectly too many times")
                     if (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.maxPukRetriesReached)

--- a/ui/imports/shared/popups/keycard/states/KeycardInit.qml
+++ b/ui/imports/shared/popups/keycard/states/KeycardInit.qml
@@ -826,7 +826,9 @@ Item {
             }
             PropertyChanges {
                 target: message
-                text: ""
+                text: qsTr("The PIN length doesn't match Keycard's PIN length")
+                font.pixelSize: Constants.keycard.general.fontSize2
+                color: Theme.palette.baseColor1
             }
         }
     ]

--- a/ui/imports/shared/popups/keycard/states/SelectKeyPair.qml
+++ b/ui/imports/shared/popups/keycard/states/SelectKeyPair.qml
@@ -59,7 +59,7 @@ Item {
         }
 
         StatusBaseText {
-            visible: !root.sharedKeycardModule.isProfileKeyPairMigrated()
+            visible: !userProfile.isKeycardUser
             Layout.preferredWidth: parent.width - 2 * Style.current.padding
             Layout.leftMargin: Style.current.padding
             Layout.alignment: Qt.AlignLeft
@@ -70,7 +70,7 @@ Item {
         }
 
         KeyPairList {
-            visible: !root.sharedKeycardModule.isProfileKeyPairMigrated()
+            visible: !userProfile.isKeycardUser
             Layout.fillWidth: true
             Layout.preferredHeight: 100
             Layout.fillHeight: visible && root.sharedKeycardModule.keyPairModel.count === 1
@@ -88,8 +88,8 @@ Item {
         }
 
         StatusBaseText {
-            visible: root.sharedKeycardModule.isProfileKeyPairMigrated() && root.sharedKeycardModule.keyPairModel.count > 0 ||
-                     !root.sharedKeycardModule.isProfileKeyPairMigrated() && root.sharedKeycardModule.keyPairModel.count > 1
+            visible: userProfile.isKeycardUser && root.sharedKeycardModule.keyPairModel.count > 0 ||
+                     !userProfile.isKeycardUser && root.sharedKeycardModule.keyPairModel.count > 1
             Layout.preferredWidth: parent.width - 2 * Style.current.padding
             Layout.leftMargin: Style.current.padding
             Layout.alignment: Qt.AlignLeft
@@ -100,8 +100,8 @@ Item {
         }
 
         KeyPairList {
-            visible: root.sharedKeycardModule.isProfileKeyPairMigrated() && root.sharedKeycardModule.keyPairModel.count > 0 ||
-                     !root.sharedKeycardModule.isProfileKeyPairMigrated() && root.sharedKeycardModule.keyPairModel.count > 1
+            visible: userProfile.isKeycardUser && root.sharedKeycardModule.keyPairModel.count > 0 ||
+                     !userProfile.isKeycardUser && root.sharedKeycardModule.keyPairModel.count > 1
             Layout.fillWidth: true
             Layout.fillHeight: true
             Layout.alignment: Qt.AlignLeft

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -76,6 +76,7 @@ QtObject {
         readonly property int wrongPassword: 8
         readonly property int offerPukForUnlock: 16
         readonly property int useUnlockLabelForLockedState: 32
+        readonly property int useGeneralMessageForLockedState: 64
     }
 
     readonly property QtObject keycardSharedFlow: QtObject {
@@ -84,6 +85,7 @@ QtObject {
         readonly property string setupNewKeycard: "SetupNewKeycard"
         readonly property string authentication: "Authentication"
         readonly property string unlockKeycard: "UnlockKeycard"
+        readonly property string displayKeycardContent: "DisplayKeycardContent"
     }
 
     readonly property QtObject keycardSharedState: QtObject {

--- a/ui/imports/utils/Utils.qml
+++ b/ui/imports/utils/Utils.qml
@@ -400,19 +400,19 @@ QtObject {
       function validatePINs(item, firstPINField, repeatPINField) {
         switch (item) {
             case "first":
-                if (firstPINField.text === "") {
+                if (firstPINField.pinInput === "") {
                     return [false, qsTr("You need to enter a PIN")];
-                } else if (!/^\d+$/.test(firstPINField.text)) {
+                } else if (!/^\d+$/.test(firstPINField.pinInput)) {
                     return [false, qsTr("The PIN must contain only digits")];
-                } else if (firstPINField.text.length != 6) {
-                    return [false, qsTr("The PIN must be exactly 6 digits")];
+                } else if (firstPINField.pinInput.length != Constants.keycard.general.keycardPinLength) {
+                    return [false, qsTr("The PIN must be exactly %1 digits").arg(Constants.keycard.general.keycardPinLength)];
                 }
                 return [true, ""];
 
             case "repeat":
-                if (repeatPINField.text === "") {
+                if (repeatPINField.pinInput === "") {
                     return [false, qsTr("You need to repeat your PIN")];
-                } else if (repeatPINField.text !== firstPINField.text) {
+                } else if (repeatPINField.pinInput !== firstPINField.pinInput) {
                     return [false, qsTr("PIN don't match")];
                 }
                 return [true, ""];


### PR DESCRIPTION
Tests for adding accounts to the wallet updated according to the latest changes when we introduced `Authentication` flow instead of entering pass in the add account popup.