### PR TITLE
fix(ProfilePopup): fixed display name on block popup

### DIFF
--- a/ui/imports/shared/popups/ProfilePopup.qml
+++ b/ui/imports/shared/popups/ProfilePopup.qml
@@ -140,13 +140,13 @@ StatusDialog {
     }
 
     function blockUser() {
-        profileView.blockContactConfirmationDialog.contactName = userName;
+        profileView.blockContactConfirmationDialog.contactName = userDisplayName;
         profileView.blockContactConfirmationDialog.contactAddress = userPublicKey;
         profileView.blockContactConfirmationDialog.open();
     }
 
     function unblockUser() {
-        profileView.unblockContactConfirmationDialog.contactName = userName;
+        profileView.unblockContactConfirmationDialog.contactName = userDisplayName;
         profileView.unblockContactConfirmationDialog.contactAddress = userPublicKey;
         profileView.unblockContactConfirmationDialog.open();
     }


### PR DESCRIPTION
Closes #7521

### What does the PR do
Block contacts popup fixed display name

### Affected areas
Block contacts popup

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)
<img width="520" alt="d" src="https://user-images.githubusercontent.com/31625338/192577981-17d3eadf-aa2d-483b-830e-822da15edef7.png">

