### PR TITLE
feat(@desktop/keycard): sign transaction using `Authenticate` flow

### DIFF
--- a/src/app/modules/main/wallet_section/transactions/io_interface.nim
+++ b/src/app/modules/main/wallet_section/transactions/io_interface.nim
@@ -43,10 +43,13 @@ method setIsNonArchivalNode*(self: AccessInterface, isNonArchivalNode: bool) {.b
 method estimateGas*(self: AccessInterface, from_addr: string, to: string, assetSymbol: string, value: string, data: string): string {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method transfer*(self: AccessInterface, from_addr: string, to_addr: string,
+method onUserAuthenticated*(self: AccessInterface, password: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method authenticateAndTransfer*(self: AccessInterface, from_addr: string, to_addr: string,
     tokenSymbol: string, value: string, gas: string, gasPrice: string,
-    maxPriorityFeePerGas: string, maxFeePerGas: string, password: string,
-    chainId: string, uuid: string, eip1559Enabled: bool): bool {.base.} =
+    maxPriorityFeePerGas: string, maxFeePerGas: string, chainId: string, uuid: string, 
+    eip1559Enabled: bool) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method transactionWasSent*(self: AccessInterface, result: string) {.base.} =

--- a/src/app/modules/main/wallet_section/transactions/view.nim
+++ b/src/app/modules/main/wallet_section/transactions/view.nim
@@ -116,11 +116,11 @@ QtObject:
   proc transactionWasSent*(self: View,txResult: string) {.slot} =
     self.transactionSent(txResult)
 
-  proc transfer*(self: View, from_addr: string, to_addr: string, tokenSymbol: string,
-      value: string, gas: string, gasPrice: string, maxPriorityFeePerGas: string,
-      maxFeePerGas: string, password: string, chainId: string, uuid: string, eip1559Enabled: bool): bool {.slot.} =
-    result = self.delegate.transfer(from_addr, to_addr, tokenSymbol, value, gas, gasPrice,
-      maxPriorityFeePerGas, maxFeePerGas, password, chainId, uuid, eip1559Enabled)
+  proc authenticateAndTransfer*(self: View, from_addr: string, to_addr: string, tokenSymbol: string,
+    value: string, gas: string, gasPrice: string, maxPriorityFeePerGas: string,
+    maxFeePerGas: string, chainId: string, uuid: string, eip1559Enabled: bool) {.slot.} =
+      self.delegate.authenticateAndTransfer(from_addr, to_addr, tokenSymbol, value, gas, gasPrice,
+        maxPriorityFeePerGas, maxFeePerGas, chainId, uuid, eip1559Enabled)
 
   proc suggestedFees*(self: View, chainId: int): string {.slot.} =
     return self.delegate.suggestedFees(chainId)

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -563,9 +563,9 @@ QtObject {
     }
 
     function transfer(from, to, address, tokenSymbol, amount, gasLimit, gasPrice, tipLimit, overallLimit, password, chainId, uuid, eip1559Enabled) {
-        return walletSectionTransactions.transfer(
+        return walletSectionTransactions.authenticateAndTransfer(
             from, to, address, tokenSymbol, amount, gasLimit,
-            gasPrice, tipLimit, overallLimit, password, chainId, uuid,
+            gasPrice, tipLimit, overallLimit, chainId, uuid,
             eip1559Enabled
         );
     }

--- a/ui/app/AppLayouts/stores/RootStore.qml
+++ b/ui/app/AppLayouts/stores/RootStore.qml
@@ -137,11 +137,10 @@ QtObject {
         return profileSectionStore.ensUsernamesStore.getGasEthValue(gweiValue, gasLimit)
     }
 
-
-    function transfer(from, to, tokenSymbol, amount, gasLimit, gasPrice, tipLimit, overallLimit, password, chainId, uuid, eip1559Enabled) {
-        return walletSectionTransactions.transfer(
+    function authenticateAndTransfer(from, to, tokenSymbol, amount, gasLimit, gasPrice, tipLimit, overallLimit, chainId, uuid, eip1559Enabled) {
+        walletSectionTransactions.authenticateAndTransfer(
             from, to, tokenSymbol, amount, gasLimit,
-            gasPrice, tipLimit, overallLimit, password, chainId, uuid,
+            gasPrice, tipLimit, overallLimit, chainId, uuid,
             eip1559Enabled
         );
     }


### PR DESCRIPTION
Actually this is not a signing transaction, but rather authenticating logged in user when he wants to send a transaction. An authentication is done by entering password(regular user) or pin(keycard user).

A real signing transaction feature will be (hopefully) added in a near future where we're going to sign a transaction on a keycard which corresponds to a certain account, a user wants to send a transaction from.

To sum up... this change just removes password from the send modal and introduces `Authenticate` flow instead.

Fixes: #7510