### PR TITLE
chore(debug): use WAKUV2_PORT environment variable to change Waku V2 ports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -609,6 +609,7 @@ ICON_TOOL := node_modules/.bin/fileicon
 
 # Will only work at password login. Keycard login doesn't forward the configuration
 # STATUS_PORT ?= 30306
+# WAKUV2_PORT ?= 30307
 
 run-linux: nim_status_client
 	echo -e "\e[92mRunning:\e[39m bin/nim_status_client"

--- a/src/app_service/service/accounts/service.nim
+++ b/src/app_service/service/accounts/service.nim
@@ -518,7 +518,16 @@ proc login*(self: Service, account: AccountDto, password: string): string =
 
     # Source the connection port from the environment for debugging or if default port not accessible
     if existsEnv("STATUS_PORT"):
-      nodeCfg["ListenAddr"] = newJString("0.0.0.0:" & $getEnv("STATUS_PORT"))
+      let wV1Port = $getEnv("STATUS_PORT")
+      # Waku V1 config
+      nodeCfg["ListenAddr"] = newJString("0.0.0.0:" & wV1Port)
+    if existsEnv("WAKUV2_PORT"):
+      let wV2Port = parseInt($getEnv("WAKUV2_PORT"))
+      # Waku V2 config
+      nodeCfg.add("WakuV2Config", %* {
+        "Port": wV2Port,
+        "UDPPort": wV2Port,
+      })
 
     let response = status_account.login(account.name, account.keyUid, hashedPassword, thumbnailImage,
       largeImage, $nodeCfg)


### PR DESCRIPTION
The environment variable overrides libp2p protocol TCP port and discovery v5 UDP with the same value