### PR TITLE
fix(@desktop/general): Fix sections switching shortcuts

### DIFF
--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -575,7 +575,6 @@ method setActiveSection*[T](self: Module[T], item: SectionItem) =
   if(item.isEmpty()):
     echo "section is empty and cannot be made as active one"
     return
-
   self.controller.setActiveSection(item.id)
 
 proc notifySubModulesAboutChange[T](self: Module[T], sectionId: string) =

--- a/src/app/modules/main/view.nim
+++ b/src/app/modules/main/view.nim
@@ -145,6 +145,10 @@ QtObject:
     self.activeSection.setActiveSectionData(item)
     self.activeSectionChanged()
 
+  proc setNthEnabledSectionActive*(self: View, nth: int) {.slot.} =
+    let item = self.model.getNthEnabledItem(nth)
+    self.delegate.setActiveSection(item)
+
   proc setActiveSectionById*(self: View, sectionId: string) {.slot.} =
     let item = self.model.getItemById(sectionId)
     self.delegate.setActiveSection(item)

--- a/src/app/modules/shared_models/section_model.nim
+++ b/src/app/modules/shared_models/section_model.nim
@@ -280,6 +280,17 @@ QtObject:
       ModelRole.BannedMembersModel.int
       ])
 
+  proc getNthEnabledItem*(self: SectionModel, nth: int): SectionItem =
+    if nth >= 0 and nth < self.items.len:
+      var counter = 0
+      for i in 0 ..< self.items.len:
+        if self.items[i].enabled:
+          if counter == nth:
+            return self.items[i]
+          else:
+            counter = counter + 1
+    return SectionItem()
+
   proc getItemById*(self: SectionModel, id: string): SectionItem =
     for it in self.items:
       if(it.id == id):

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -1027,20 +1027,59 @@ Item {
 
         Action {
             shortcut: "Ctrl+1"
-            onTriggered: Global.changeAppSectionBySectionType(Constants.appSection.chat)
+            onTriggered: {
+                Global.setNthEnabledSectionActive(0)
+            }
         }
         Action {
             shortcut: "Ctrl+2"
-            onTriggered: Global.changeAppSectionBySectionType(Constants.appSection.browser)
+            onTriggered: {
+                Global.setNthEnabledSectionActive(1)
+            }
         }
         Action {
             shortcut: "Ctrl+3"
-            onTriggered: Global.changeAppSectionBySectionType(Constants.appSection.wallet)
+            onTriggered: {
+                Global.setNthEnabledSectionActive(2)
+            }
         }
         Action {
-            shortcut: "Ctrl+4, Ctrl+,"
-            onTriggered: Global.changeAppSectionBySectionType(Constants.appSection.profile)
+            shortcut: "Ctrl+4"
+            onTriggered: {
+                Global.setNthEnabledSectionActive(3)
+            }
         }
+        Action {
+            shortcut: "Ctrl+5"
+            onTriggered: {
+                Global.setNthEnabledSectionActive(4)
+            }
+        }
+        Action {
+            shortcut: "Ctrl+6"
+            onTriggered: {
+                Global.setNthEnabledSectionActive(5)
+            }
+        }
+        Action {
+            shortcut: "Ctrl+7"
+            onTriggered: {
+                Global.setNthEnabledSectionActive(6)
+            }
+        }
+        Action {
+            shortcut: "Ctrl+8"
+            onTriggered: {
+                Global.setNthEnabledSectionActive(7)
+            }
+        }
+        Action {
+            shortcut: "Ctrl+9"
+            onTriggered: {
+                Global.setNthEnabledSectionActive(8)
+            }
+        }
+
         Action {
             shortcut: "Ctrl+K"
             onTriggered: {

--- a/ui/imports/utils/Global.qml
+++ b/ui/imports/utils/Global.qml
@@ -69,6 +69,12 @@ QtObject {
         }
     }
 
+    function setNthEnabledSectionActive(nthSection) {
+        if(!root.mainModuleInst)
+            return
+        mainModuleInst.setNthEnabledSectionActive(nthSection)
+    }
+
     function getProfileImage(pubkey, isCurrentUser, useLargeImage) {
         if (isCurrentUser || (isCurrentUser === undefined && pubkey === userProfile.pubKey)) {
             return userProfile.icon;


### PR DESCRIPTION
Fix #7478

### What does the PR do

Ctrl+n shortcut changes enabled section.
User can switch only to sections which are visible on the left panel.

### Affected areas

Sections panel.

### Screenshot of functionality (including design for comparison)

https://user-images.githubusercontent.com/61889657/192762618-071f8a33-3ccf-45e7-8c54-531dd951f328.mov


