### PR TITLE
fix(StatusChatInfoButton): space between # and channel name

### DIFF
--- a/ui/StatusQ/src/StatusQ/Controls/StatusChatInfoButton.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusChatInfoButton.qml
@@ -74,7 +74,7 @@ Button {
             RowLayout {
                 Layout.fillWidth: true
                 Layout.alignment: Qt.AlignLeading | Qt.AlignBottom
-                spacing: root.spacing
+                spacing: 1
 
                 StatusIcon {
                     visible: root.type !== StatusChatInfoButton.Type.OneToOneChat


### PR DESCRIPTION
lower the spacing to better match the designs

Closes #7592

### Affected areas

StatusChatInfoButton

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [x] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![Snímek obrazovky z 2022-09-28 16-17-06](https://user-images.githubusercontent.com/5377645/192805888-f98b4594-9fa5-4a54-a546-bc0831fc774b.png)

