### PR TITLE
fix(@desktop/chat): update toast message logic

### DIFF
--- a/src/app/modules/main/ephemeral_notification_item.nim
+++ b/src/app/modules/main/ephemeral_notification_item.nim
@@ -8,6 +8,7 @@ type
 type
   Item* = object
     id: int64
+    timestamp: string
     title: string
     durationInMs: int
     subTitle: string
@@ -28,6 +29,7 @@ proc initItem*(id: int64,
     details: NotificationDetails): Item =
   result = Item()
   result.id = id
+  result.timestamp = $id
   result.durationInMs = durationInMs
   result.title = title
   result.subTitle = subTitle
@@ -39,6 +41,9 @@ proc initItem*(id: int64,
 
 proc id*(self: Item): int64 =
   self.id
+
+proc timestamp*(self: Item): string =
+  self.timestamp
 
 proc title*(self: Item): string =
   self.title

--- a/src/app/modules/main/ephemeral_notification_model.nim
+++ b/src/app/modules/main/ephemeral_notification_model.nim
@@ -4,6 +4,7 @@ import ephemeral_notification_item
 type
   ModelRole {.pure.} = enum
     Id = UserRole + 1
+    Timestamp
     DurationInMs
     Title
     SubTitle
@@ -33,6 +34,7 @@ QtObject:
   method roleNames(self: Model): Table[int, string] =
     {
       ModelRole.Id.int:"id",
+      ModelRole.Timestamp.int:"timestamp",
       ModelRole.DurationInMs.int:"durationInMs",
       ModelRole.Title.int:"title",
       ModelRole.SubTitle.int:"subTitle",
@@ -53,6 +55,8 @@ QtObject:
     case enumRole:
       of ModelRole.Id:
         result = newQVariant(item.id)
+      of ModelRole.Timestamp:
+        result = newQVariant(item.timestamp)
       of ModelRole.DurationInMs:
         result = newQVariant(item.durationInMs)
       of ModelRole.Title:

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -1148,7 +1148,7 @@ Item {
             linkUrl: model.url
             duration: model.durationInMs
             onClicked: {
-                appMain.rootStore.mainModuleInst.ephemeralNotificationClicked(model.id)
+                appMain.rootStore.mainModuleInst.ephemeralNotificationClicked(model.timestamp)
                 this.open = false
             }
             onLinkActivated: {
@@ -1156,7 +1156,7 @@ Item {
             }
 
             onClose: {
-                appMain.rootStore.mainModuleInst.removeEphemeralNotification(model.id)
+                appMain.rootStore.mainModuleInst.removeEphemeralNotification(model.timestamp)
             }
         }
     }


### PR DESCRIPTION
Fixes #7487
Fixes #7613

### What does the PR do

Change usage of id(int64) to timestamp(string) for EphemeralNotification because there is an issue with passing int64 from Nim to QML, which was resulting in incorrect ids when using them for interaction with Nim from QML

### Affected areas

Desktop Chat

### Screenshot of functionality 

https://user-images.githubusercontent.com/6445843/193087297-52272aff-112b-41d4-b923-93484d7e0bfd.mp4

NOTE: In video you can see model.id and model.timestamp in Toast messages.

