### PR TITLE
Revert "fix(ChatMessagesView): unbreak closing reply bubble"

### DIFF
--- a/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
@@ -250,6 +250,7 @@ Item {
             id: msgDelegate
 
             width: ListView.view.width
+            height: implicitHeight
 
             objectName: "chatMessageViewDelegate"
             rootStore: root.rootStore


### PR DESCRIPTION
Reverts status-im/status-desktop#7485

It requires further investigation because https://github.com/status-im/status-desktop/pull/7485 fixes some issues is some environments and breaks things in another.
It's needed to collect some further info about evns in which the revert works and in which it reintroduces problem fixed in https://github.com/status-im/status-desktop/pull/7485

Potentially closes: https://github.com/status-im/status-desktop/issues/7618