### PR TITLE
fix(InsertDetailsView): use force flag for getColorHashAsJson to skip ENS check

### DIFF
--- a/ui/app/AppLayouts/Onboarding/views/InsertDetailsView.qml
+++ b/ui/app/AppLayouts/Onboarding/views/InsertDetailsView.qml
@@ -97,7 +97,7 @@ Item {
                 asset.isImage: !!asset.name
                 asset.imgIsIdenticon: false
                 ringSettings {
-                    ringSpecModel: Utils.getColorHashAsJson(root.pubKey)
+                    ringSpecModel: Utils.getColorHashAsJson(root.pubKey, true)
                 }
             }
             StatusRoundButton {
@@ -198,7 +198,7 @@ Item {
                 asset.width: 44
                 asset.height: 44
                 asset.color: "transparent"
-                ringSettings { ringSpecModel: Utils.getColorHashAsJson(root.pubKey) }
+                ringSettings { ringSpecModel: Utils.getColorHashAsJson(root.pubKey, true) }
             }
         }
 


### PR DESCRIPTION
### What does the PR do

During on-boarding `mainModule` is unavailable therefore getColorHashAsJson should skip checking if ens is verified.

Closes: #7671

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas

`InsertDetailsView`

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![Screenshot from 2022-10-03 10-57-13](https://user-images.githubusercontent.com/20650004/193539047-4819d78e-a576-41fd-a677-a515df385236.png)
![Screenshot from 2022-10-03 10-57-18](https://user-images.githubusercontent.com/20650004/193539051-729dc3bd-0846-40c8-a427-9cd83e693561.png)



<!-- screenshot (or gif/video) that demonstrates the functionality, specially important if it's a bug fix. -->

### Cool Spaceship Picture

<!-- optional but cool ->
