### PR TITLE
fix(ChatMessagesView): Loading spinner and scroll to bottom button overlap

### DIFF
--- a/ui/app/AppLayouts/Chat/views/ChatContentView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatContentView.qml
@@ -167,19 +167,6 @@ ColumnLayout {
                                     + chatInput.anchors.topMargin
                                     + chatInput.anchors.bottomMargin
 
-            Loader {
-                id: loadingMessagesIndicator
-                active: root.rootStore.loadingHistoryMessagesInProgress
-                visible: root.rootStore.loadingHistoryMessagesInProgress
-                sourceComponent: LoadingAnimation { }
-                anchors {
-                    right: parent.right
-                    bottom: chatInput.top
-                    rightMargin: Style.current.padding
-                    bottomMargin: Style.current.padding
-                }
-            }
-
             StatusChatInput {
                 id: chatInput
 

--- a/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
@@ -213,21 +213,15 @@ Item {
                 anchors.leftMargin: Style.current.halfPadding
             }
 
-            SVGImage {
+            StatusIcon {
                 id: arrowImage
                 width: 24
                 height: 24
                 anchors.verticalCenter: parent.verticalCenter
                 anchors.left: nbMessages.right
-                source: Style.svg("leave_chat")
+                icon: "arrow-down"
                 anchors.leftMargin: nbMessages.visible ? scrollDownButton.buttonPadding : 0
-                rotation: -90
-
-                ColorOverlay {
-                    anchors.fill: parent
-                    source: parent
-                    color: Style.current.pillButtonTextColor
-                }
+                color: Style.current.pillButtonTextColor
             }
 
             MouseArea {

--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -1,8 +1,6 @@
 import QtQuick 2.13
 import QtQuick.Controls 2.13
-import QtGraphicalEffects 1.13
 import QtQuick.Layouts 1.13
-import QtMultimedia 5.13
 import QtQuick.Dialogs 1.3
 import DotherSide 0.1
 

--- a/ui/imports/shared/status/StatusChatInputReplyArea.qml
+++ b/ui/imports/shared/status/StatusChatInputReplyArea.qml
@@ -1,11 +1,11 @@
 import QtQuick 2.13
 import QtQuick.Controls 2.13
-import QtGraphicalEffects 1.13
 
 import utils 1.0
 import shared 1.0
 import shared.panels 1.0
 
+import StatusQ.Core 0.1
 import StatusQ.Core.Utils 0.1 as StatusQUtils
 
 Rectangle {
@@ -108,18 +108,13 @@ Rectangle {
         anchors.topMargin: 4
         anchors.right: parent.right
         anchors.rightMargin: 4
-        contentItem: SVGImage {
+        contentItem: StatusIcon {
             id: iconImg
             source: Style.svg("close")
+            color: Style.current.textColor
+            sourceSize: Qt.size(width, height)
             width: closeBtn.width
             height: closeBtn.height
-
-            ColorOverlay {
-                anchors.fill: iconImg
-                source: iconImg
-                color: Style.current.textColor
-                antialiasing: true
-            }
         }
         background: Rectangle {
             color: "transparent"


### PR DESCRIPTION
- remove the extra spinner (ok'ed by John and Benj)
- use the more modern StatusIcon, w/o the unconditional ColorOverlay
- some minor cleanup

Closes: #7645

### What does the PR do

Fixes visual glitch in the bottom right corner

### Affected areas

ChatMessagesView

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

Before:
![Snímek obrazovky z 2022-10-03 13-35-36](https://user-images.githubusercontent.com/5377645/193574842-7be5bd7a-458c-4d64-90e1-781de0686194.png)

After:
![image](https://user-images.githubusercontent.com/5377645/193609976-85483777-7d13-4e10-8231-e5caef6b4dca.png)

