### PR TITLE
fix(ChatMessageView): delayed binding for proper msg height calculation

### DIFF
--- a/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
@@ -251,6 +251,11 @@ Item {
 
             width: ListView.view.width
 
+            Binding on height {
+                delayed: true
+                value: msgDelegate.implicitHeight
+            }
+
             objectName: "chatMessageViewDelegate"
             rootStore: root.rootStore
             messageStore: root.messageStore


### PR DESCRIPTION
Direct binding was causing problems with height calculation in some environments (qt 5.15) and lack of binding in other (5.14). This is a solution which seems to work in both cases.

Closes: #7703

### What does the PR do

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas

`ChagMessagesView`

### Screenshot of functionality (including design for comparison)

- [ ] I've checked the design and this PR matches it

<!-- screenshot (or gif/video) that demonstrates the functionality, specially important if it's a bug fix. -->

### Cool Spaceship Picture

![plutus-plutus-rocket](https://user-images.githubusercontent.com/20650004/193578629-c48f39fd-be75-4e6e-935f-6c5870effa16.gif)
