### PR TITLE
Revert "fix(ChatMessagesView): unbreak closing reply bubble"

### DIFF
--- a/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
@@ -250,6 +250,7 @@ Item {
             id: msgDelegate
 
             width: ListView.view.width
+            height: implicitHeight
 
             objectName: "chatMessageViewDelegate"
             rootStore: root.rootStore


### PR DESCRIPTION
Reverts status-im/status-desktop#7485

This PR was solving problem of overlapping messages in 5.15 but introduces that problem to builds based on 5.14, which is currently used for building packages on CI.