### PR TITLE
fix(ChatMessagesView): reverts in chat messages view

### DIFF
--- a/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
@@ -251,11 +251,6 @@ Item {
 
             width: ListView.view.width
 
-            Binding on height {
-                delayed: true
-                value: msgDelegate.implicitHeight
-            }
-
             objectName: "chatMessageViewDelegate"
             rootStore: root.rootStore
             messageStore: root.messageStore

--- a/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
@@ -250,6 +250,7 @@ Item {
             id: msgDelegate
 
             width: ListView.view.width
+            height: implicitHeight
 
             objectName: "chatMessageViewDelegate"
             rootStore: root.rootStore


### PR DESCRIPTION
### What does the PR do

Reverts https://github.com/status-im/status-desktop/pull/7721
It turned out that it doesn't work as expected - causes scrolling slow in both 5.14.2 and 5.15.

Reverts https://github.com/status-im/status-desktop/pull/7485
This PR was solving problem of overlapping messages in 5.15 but introduces that problem to builds based on 5.14, which is currently used for building packages on CI.

Original issues: https://github.com/status-im/status-desktop/issues/7703, https://github.com/status-im/status-desktop/issues/7481

### Affected areas
`ChatMessagesView`
