### PR TITLE
fix(StatusMessageReply): Remove overwrite for text height

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusMessageReply.qml
+++ b/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusMessageReply.qml
@@ -86,7 +86,6 @@ Item {
                 textField.text: replyDetails.messageText
                 textField.font.pixelSize: Theme.secondaryTextFontSize
                 textField.color: Theme.palette.baseColor1
-                textField.height: 18
                 clip: true
                 visible: !!replyDetails.messageText && replyDetails.contentType !== StatusMessage.ContentType.Sticker
                 allowShowMore: false


### PR DESCRIPTION
Closes: #7750

### What does the PR do

Remove overwritten height for reply text. 

### Affected areas

StatusMessageReply

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

- [ ] I've checked the design and this PR matches it

<img width="1379" alt="Снимок экрана 2022-10-05 в 13 29 29" src="https://user-images.githubusercontent.com/82511785/194040445-57bd631f-f6b6-49ec-b252-463cc8be886b.png">

