### PR TITLE
fix(ChatHeaderContentView): Unreachable buttons in community header at min width

### DIFF
--- a/ui/app/AppLayouts/Chat/views/ChatHeaderContentView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatHeaderContentView.qml
@@ -12,9 +12,8 @@ import utils 1.0
 import "../panels"
 import "../stores"
 
-RowLayout {
+Item {
     id: root
-    spacing: padding / 2
 
     property alias menuButton: menuButton
     property alias membersButton: membersButton
@@ -44,17 +43,29 @@ RowLayout {
 
     Loader {
         id: loader
-        Layout.fillWidth: d.selectingMembers
-        Layout.fillHeight: true
-        sourceComponent: {
-            if (d.selectingMembers) return membersSelector
-            return statusChatInfoButton
-        }
+
+        anchors.top: parent.top
+        anchors.bottom: parent.bottom
+        anchors.left: parent.left
+        anchors.right: d.selectingMembers ? parent.right : undefined
+
+        sourceComponent: d.selectingMembers ? membersSelector : statusChatInfoButton
+    }
+
+    Rectangle {
+        anchors.fill: actionButtons
+        visible: actionButtons.visible
+        opacity: 0.8
+        color: Style.current.background
     }
 
     RowLayout {
         id: actionButtons
-        Layout.alignment: Qt.AlignRight
+
+        anchors.top: parent.top
+        anchors.bottom: parent.bottom
+        anchors.right: parent.right
+
         spacing: 8
         visible: !d.selectingMembers
 


### PR DESCRIPTION
### What does the PR do

Instead of being unreachable under bell icon, icons are placed over chat name with some semi transparent background for readability.

Closes: #7647

### Affected areas

`ChatHeaderContentView`

### Screenshot of functionality (including design for comparison)

- [x] test changes in both light and dark theme?
- [x] I've checked the design and this PR matches it

[Kazam_screencast_00037.webm](https://user-images.githubusercontent.com/20650004/194289416-be90ae60-27e5-4db4-ba75-b6abdbd78190.webm)

