### PR TITLE
fix(Chat): ensure profile image with base64 sources are working

### DIFF
--- a/ui/StatusQ/src/StatusQ/Core/StatusProfileImageSettings.qml
+++ b/ui/StatusQ/src/StatusQ/Core/StatusProfileImageSettings.qml
@@ -19,7 +19,7 @@ QtObject {
         width: root.width
         height: root.height
         name: root.name
-        isImage: name.includes("data")
+        isImage: name.startsWith("data")
         isLetterIdenticon: (name === "")
         imgIsIdenticon: root.isIdenticon
         color: Theme.palette.userCustomizationColors[root.colorId]

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -578,7 +578,7 @@ Loader {
                     width: 40
                     height: 40
                     name: root.senderIcon || ""
-                    assetSettings.isImage: root.isDiscordMessage
+                    assetSettings.isImage: root.isDiscordMessage || root.senderIcon.startsWith("data")
                     pubkey: root.senderId
                     colorId: Utils.colorIdForPubkey(root.senderId)
                     colorHash: Utils.getColorHashAsJson(root.senderId, false, !root.isDiscordMessage)
@@ -611,7 +611,7 @@ Loader {
                     width: 20
                     height: 20
                     name:  delegate.replyMessage ? delegate.replyMessage.senderIcon : ""
-                    assetSettings.isImage: delegate.replyMessage && delegate.replyMessage.messageContentType == Constants.discordMessageType
+                    assetSettings.isImage: delegate.replyMessage && (delegate.replyMessage.messageContentType == Constants.discordMessageType || delegate.replyMessage.senderIcon.startsWith("data"))
                     showRing: delegate.replyMessage && delegate.replyMessage.messageContentType != Constants.discordMessageType
                     pubkey: delegate.replySenderId
                     colorId: Utils.colorIdForPubkey(delegate.replySenderId)


### PR DESCRIPTION
This broke with the introduction of discord messages because we were setting the `assetSettings.isImage = true` when `isDiscordMessage`.

This has overriden the default config for all non discord messages which check for whether the asset source includes `("data")`.

