### PR TITLE
fix(Language): App crashes when language is changed

### DIFF
--- a/src/app_service/service/language/service.nim
+++ b/src/app_service/service/language/service.nim
@@ -26,7 +26,7 @@ proc delete*(self: Service) =
 proc newService*(events: EventEmitter): Service =
   result = Service()
   result.events = events
-  result.shouldRetranslate = not defined(linux)
+  result.shouldRetranslate = false #not defined(linux)
 
 proc obtainLanguages(dir: string): seq[string] =
   let localeRe = re".*qml_(.*).qm"

--- a/ui/app/AppLayouts/Profile/views/LanguageView.qml
+++ b/ui/app/AppLayouts/Profile/views/LanguageView.qml
@@ -168,16 +168,19 @@ SettingsContentBase {
 
                 onItemPickerChanged: {
                     if(selected && root.languageStore.currentLanguage !== key) {
+                        // IMPORTANT: Workaround to temporary resolve the crash we have when language is changed (`startupModule` is null and some qml bindings are still calling this dead pointer) so, change language will not retranslate
+                        // and instead, also on mac and win, the app will quit to apply the new language
                         // TEMPORARY: It should be removed as it is only used in Linux OS but it must be investigated how to change language in execution time, as well, in Linux (will be addressed in another task)
-                        if (Qt.platform.os === Constants.linux) {
+                        //if (Qt.platform.os === Constants.linux) {
                             root.changeLanguage(key)
                             linuxConfirmationDialog.active = true
                             linuxConfirmationDialog.item.newLocale = key
                             linuxConfirmationDialog.item.open()
-                        }
-                        else {
-                            root.changeLanguage(key)
-                        }
+                        // }
+
+                        //else {
+                        //    root.changeLanguage(key)
+                        //}
                     }
                 }
             }


### PR DESCRIPTION
Will temporary fix #7709

### What does the PR do

- Enabled restart info popup after language is changed --> Workaround to temporary resolve the crash we have when language is changed (`startupModule` is null and some qml bindings are still calling this dead pointer) so, change language will not retranslate and instead, also on mac and win, the app will need a restart to apply the new language.

- Disabled retranslations for all os on the corresponding service.

### Affected areas

Language change / windows and mac

### Screenshot of functionality 

![Screenshot 2022-10-07 at 16 11 34](https://user-images.githubusercontent.com/97019400/194573934-a85a83ed-b851-43e3-84da-92c7cc938aec.png)
