### PR TITLE
fix: wrong menu items in pinned messages popup

### DIFF
--- a/ui/app/AppLayouts/Chat/popups/PinnedMessagesPopup.qml
+++ b/ui/app/AppLayouts/Chat/popups/PinnedMessagesPopup.qml
@@ -140,7 +140,7 @@ StatusDialog {
             }
 
             onJumpToMessage: {
-                root.messageStore.messagesModule.jumpToMessage(messageId)
+                root.messageStore.messageModule.jumpToMessage(messageId)
             }
         }
     }

--- a/ui/imports/shared/views/chat/MessageContextMenuView.qml
+++ b/ui/imports/shared/views/chat/MessageContextMenuView.qml
@@ -414,11 +414,11 @@ StatusPopupMenu {
         }
         icon.name: "pin"
         enabled: {
-            if (root.pinnedPopup)
-                return true
-
             if(root.isProfile || root.isEmoji || root.isRightClickOnImage)
                 return false
+
+            if (root.pinnedPopup)
+                return true
 
             switch (root.chatType) {
             case Constants.chatType.publicChat:
@@ -473,7 +473,7 @@ StatusPopupMenu {
 
     StatusMenuItem {
         id: jumpToAction
-        enabled: root.pinnedPopup
+        enabled: root.pinnedPopup && !root.isProfile
         text: qsTr("Jump to")
         onTriggered: {
             root.jumpToMessage(root.messageId)


### PR DESCRIPTION
### What does the PR do

Fixes wrong menu items in pinned messages popup

Additionally, unbreak the "Jump to" menu item functionality

Fixes #7853

### Affected areas

PinnedMessagesPopup

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

User context menu:
![Snímek obrazovky z 2022-10-11 12-28-32](https://user-images.githubusercontent.com/5377645/195066985-8693ed42-84e8-4706-a050-61846364b461.png)

Selecting the "Jump to" item:
![Snímek obrazovky z 2022-10-11 12-28-37](https://user-images.githubusercontent.com/5377645/195067054-aa8b1845-27b9-4b20-99e1-5bd193733b2c.png)

Message jumped to:
![Snímek obrazovky z 2022-10-11 12-28-41](https://user-images.githubusercontent.com/5377645/195067134-fe1e294e-0dad-445a-a5d8-7ffee955d16f.png)

