### PR TITLE
fix(StatusChatInput): paste mentions without changing msg content

### DIFF
--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -603,7 +603,7 @@ Rectangle {
 
         if (d.internalPaste) {
             if (d.copiedTextPlain.includes("@")) {
-                d.copiedTextFormatted = d.copiedTextFormatted.replace(/underline/g, "none").replace(/span style="/g, "span style=\" text-decoration:none;")
+                d.copiedTextFormatted = d.copiedTextFormatted.replace(/span style="/g, "span style=\" text-decoration:none;")
 
                 let lastFoundIndex = -1
                 for (let j = 0; j < d.copiedMentionsPos.length; j++) {


### PR DESCRIPTION
### What does the PR do

It fixes the issue causing that copying text in `StatusChatInput` containing `@` resulted in replacing `underline` to `none`.

Closes: #7109

### Affected areas

`StatusChatInput`

### Screenshot of functionality (including design for comparison)

[simplescreenrecorder-2022-10-12_10.27.53.webm](https://user-images.githubusercontent.com/20650004/195292658-22f2f297-5913-48c1-9597-3ad56f34aae5.webm)
