### PR TITLE
feat(Storybook): Allow loading pages asynchronously

### DIFF
--- a/storybook/main.qml
+++ b/storybook/main.qml
@@ -31,8 +31,16 @@ ApplicationWindow {
             anchors.topMargin: 48
 
             Column {
-                id: navigation
                 spacing: 0
+
+                CheckBox {
+                    text: "Load asynchronously"
+                    checked: storeSettings.loadAsynchronously
+
+                    onToggled: storeSettings.loadAsynchronously = checked
+                }
+
+                Item { width: 1; height: 30 }
 
                 StatusNavigationListItem {
                     title: "CommunitiesPortalLayout"
@@ -43,20 +51,37 @@ ApplicationWindow {
         }
 
         centerPanel: Item {
-            id: centerPanel
             anchors.fill: parent
 
             Loader {
                 id: viewLoader
+
                 anchors.fill: parent
                 clip: true
+
                 source: storeSettings.selected
+                asynchronous: storeSettings.loadAsynchronously
+                visible: status === Loader.Ready
+
+                // force reload when `asynchronous` changes
+                onAsynchronousChanged: {
+                    const tmp = storeSettings.selected
+                    storeSettings.selected = ""
+                    storeSettings.selected = tmp
+                }
+            }
+
+            BusyIndicator {
+                anchors.centerIn: parent
+                visible: viewLoader.status === Loader.Loading
             }
         }
     }
 
     Settings {
         id: storeSettings
+
         property string selected: ""
+        property bool loadAsynchronously: false
     }
 }


### PR DESCRIPTION
### What does the PR do

It adds possibility of loading pages in Storybook asynchronously.

Note: As presented in the video it unveils problem in `StatusCommunityTags` component. It also causes problems with size of this component in the app, it's reported as a separate issue - https://github.com/status-im/status-desktop/issues/7870.

Closes: #7868

### Affected areas
`Storybook`

### Screenshot of functionality (including design for comparison)

[Kazam_screencast_00049.webm](https://user-images.githubusercontent.com/20650004/195329645-914e755f-b3e7-4158-9714-2983a28683fe.webm)

