### PR TITLE
fix(Keycard): disable onboarding keycard login feature

### DIFF
--- a/ui/app/AppLayouts/Onboarding/views/KeysMainView.qml
+++ b/ui/app/AppLayouts/Onboarding/views/KeysMainView.qml
@@ -149,10 +149,11 @@ Item {
                 //TODO remove when sync code is implemented
                 opacity: 0.0
             }
-            PropertyChanges {
-                target: keycardLink
-                text: qsTr("Login with Keycard")
-            }
+            // TODO: Functionality is not completed. Missing saving of keystore files which blocks wallet account creation. @see #7867
+            // PropertyChanges {
+            //     target: keycardLink
+            //     text: qsTr("Login with Keycard")
+            // }
             PropertyChanges {
                 target: seedLink
                 text: qsTr("Enter a seed phrase")


### PR DESCRIPTION
This workflow doesn't save the keystore files which are required in order to create new wallet accounts. It is not yet clear how to proceed with saving the keystore files without an `accountId`. See `setupAccountKeycard` which is missing `storeAccount*` calls vs working workflow done in `setupAccount`

Closes: #7867

New onboarding flow:
![image](https://user-images.githubusercontent.com/47554641/195335239-97967501-ef66-4bb9-a523-fa8a36a7f42e.png)
