### PR TITLE
fix(AppMain): Community color shown in left bar

### DIFF
--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -293,6 +293,7 @@ Item {
                 name: model.icon.length > 0? "" : model.name
                 icon.name: model.icon
                 icon.source: model.image
+                identicon.asset.color: (hovered || identicon.highlighted || checked) ? model.color : icon.color
                 tooltip.text: model.name
                 checked: model.active
                 badge.value: model.notificationsCount


### PR DESCRIPTION
### What does the PR do

Active/hovered communities have proper color.

Closes: #7763

### Affected areas
`AppMain`

![Screenshot from 2022-10-12 17-26-28](https://user-images.githubusercontent.com/20650004/195384337-3ee16d74-b5dc-480b-8565-4ff1f7018a2d.png)
