### PR TITLE
chore(@desktop/general): min height increased to 800px

### DIFF
--- a/ui/main.qml
+++ b/ui/main.qml
@@ -25,7 +25,7 @@ StatusWindow {
     id: applicationWindow
     objectName: "mainWindow"
     minimumWidth: 900
-    minimumHeight: 680
+    minimumHeight: 800
     color: Style.current.background
     title: {
         // Set application settings


### PR DESCRIPTION
Mainly because of the height of some keycard flows we have to increase the min app height so those flows do not look cut.

Example for the factory reset flow before, min app height 680:
![AppMinHeight680](https://user-images.githubusercontent.com/86303051/195531563-fd1ec0b9-e320-461c-9c56-446456393d4d.png)

Now, min app height 800px:
![AppMinHeight800](https://user-images.githubusercontent.com/86303051/195531583-98ca7af7-9d8c-4e34-b4ae-b15ec6c3350a.png)
