### PR TITLE
fix(Wallet): fix import seed in account creation

### DIFF
--- a/ui/app/AppLayouts/Wallet/panels/ImportSeedPhrasePanel.qml
+++ b/ui/app/AppLayouts/Wallet/panels/ImportSeedPhrasePanel.qml
@@ -31,6 +31,7 @@ StatusGridView {
                 grid.itemAtIndex(i).textEdit.reset()
             }
         }
+        grid.isValid = false
     }
 
     function validate() {
@@ -118,14 +119,9 @@ StatusGridView {
         timer.setTimeout(function(){
             _internal.mnemonicInput = []
             for (let i = 0; i < words.length; i++) {
-                try {
-                    grid.itemAtIndex(i).setWord(words[i])
-                    if (words[i].length === 3) {
-                        grid.addWord(i + 1, words[i])
-                    }
-                } catch (e) {
-                    // Getting items outside of the current view might not work
-                }
+                const item = grid.itemAtIndex(i)
+                if (item && item.leftComponentText)
+                    item.setWord(words[i])
             }
         }, timeout);
         
@@ -220,7 +216,7 @@ StatusGridView {
                 var wordIndex = _internal.mnemonicInput.findIndex(x => x.pos === leftComponentText);
                 if (wordIndex > -1) {
                     _internal.mnemonicInput.splice(wordIndex , 1);
-                    grid.isValid = _internal.mnemonicInput.length ===  grid.model
+                    grid.isValid = _internal.mnemonicInput.length === grid.model
                 }
             }
 


### PR DESCRIPTION
## Fixes: #7715, #6909

Remove the workaround to the approach of using the "complete last word" event for three-letter seed words. The three letters condition introduced another side effect when completing the "sentence" and made the `_internal.mnemonicInput` contain an extra duplicate word.

Unify the event `doneInsertingWord` generation for the internal purpose with the external. This will trigger a secondary for some users but I see no problem with even in other usages.

Fix the corner case when the user enters a correct seed word that is not singular and uses the mouse to jump. In that case, the `doneInsertingWord` is not triggered and the sentence is not validated

Regression tests for the fixed issues: https://github.com/status-im/status-desktop/pull/7893

### Affected areas

All the places where we use a seed phrase. Checked only the onboarding for side effects.