### PR TITLE
fix(signals_manager): ensure `savedAddresses` event has `JNull` check

### DIFF
--- a/src/app/core/signals/remote_signals/messages.nim
+++ b/src/app/core/signals/remote_signals/messages.nim
@@ -120,7 +120,7 @@ proc fromEvent*(T: type MessageSignal, event: JsonNode): MessageSignal =
     for jsonVerificationRequest in event["event"]["verificationRequests"]:
       signal.verificationRequests.add(jsonVerificationRequest.toVerificationRequest())
 
-  if event["event"]{"savedAddresses"} != nil:
+  if event["event"]{"savedAddresses"} != nil and event["event"]{"savedAddresses"}.kind != JNull:
     for jsonSavedAddress in event["event"]["savedAddresses"]:
       signal.savedAddresses.add(jsonSavedAddress.toSavedAddressDto())
 


### PR DESCRIPTION
There's something off with the `savedAddresses` signal data, which causes it to be `JNull` instead of an empty array (`JArray`) and breaks signal decoding.

Ultimately this should be fixed in status-go, but this unblocks Desktop.
