### PR TITLE
chore: update status-go

### DIFF
--- a/src/app/core/signals/remote_signals/messages.nim
+++ b/src/app/core/signals/remote_signals/messages.nim
@@ -120,7 +120,7 @@ proc fromEvent*(T: type MessageSignal, event: JsonNode): MessageSignal =
     for jsonVerificationRequest in event["event"]["verificationRequests"]:
       signal.verificationRequests.add(jsonVerificationRequest.toVerificationRequest())
 
-  if event["event"]{"savedAddresses"} != nil and event["event"]{"savedAddresses"}.kind != JNull:
+  if event["event"]{"savedAddresses"} != nil:
     for jsonSavedAddress in event["event"]["savedAddresses"]:
       signal.savedAddresses.add(jsonSavedAddress.toSavedAddressDto())
 


### PR DESCRIPTION
This includes a fix in message signals that would otherwise break Desktop's signal encoding.

See: https://github.com/status-im/status-desktop/pull/7888

Hence, it reverts the now unnecessary fix introduced in:

Revert "fix(signals_manager): ensure `savedAddresses` event has `JNull` check"

This reverts commit 013e226c66fc9de26575b5bd55acc64c45a5566e.

