### PR TITLE
Fix/storybook build

### DIFF
--- a/storybook/CMakeLists.txt
+++ b/storybook/CMakeLists.txt
@@ -10,6 +10,11 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+if (APPLE)
+    set(MACOS_VERSION_MIN_FLAGS -mmacosx-version-min=10.14)
+    set(CMAKE_OSX_ARCHITECTURES "x86_64")
+endif()
+
 find_package(
   Qt5
   COMPONENTS Core Quick QuickControls2

--- a/storybook/CMakeLists.txt
+++ b/storybook/CMakeLists.txt
@@ -17,18 +17,11 @@ find_package(
 
 file(GLOB_RECURSE QML_FILES "stubs/*.qml" "Storybook/*.qml" "../ui/StatusQ/*.qml" "../ui/app/*.qml")
 file(GLOB_RECURSE JS_FILES "../ui/StatusQ/*.js" "../ui/app/*.js")
-file(GLOB_RECURSE HEADERS *.h)
-if(APPLE)
-  file(GLOB_RECURSE SOURCES *.cpp *.mm)
-else()
-  file(GLOB_RECURSE SOURCES *.cpp)
-endif()
 
 add_executable(
   ${PROJECT_NAME}
+  main.cpp
   qml.qrc
-  ${HEADERS}
-  ${SOURCES}
   ${QML_FILES}
   ${JS_FILES}
 )

--- a/storybook/main.cpp
+++ b/storybook/main.cpp
@@ -8,9 +8,9 @@ int main(int argc, char *argv[])
     QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
 #endif
     QGuiApplication app(argc, argv);
-    app.setOrganizationName("Status");
-    app.setOrganizationDomain("status.im");
-    app.setApplicationName("Status Desktop Storybook");
+    QGuiApplication::setOrganizationName("Status");
+    QGuiApplication::setOrganizationDomain("status.im");
+    QGuiApplication::setApplicationName("Status Desktop Storybook");
 
     QQmlApplicationEngine engine;
 
@@ -28,5 +28,5 @@ int main(int argc, char *argv[])
     }, Qt::QueuedConnection);
     engine.load(url);
 
-    return app.exec();
+    return QGuiApplication::exec();
 }


### PR DESCRIPTION
CMake's GLOB is capturing source files from `build/*` resulting in
multiple `main` definitions.

Generally, usage of GLOB is discouraged.

Linking error:
```
[build] /usr/bin/ld: CMakeFiles/Storybook.dir/main.cpp.o: in function `main':

[build] main.cpp:(.text.startup+0x0): multiple definition of `main'; CMakeFiles/Storybook.dir/CMakeFiles/3.22.5/CompilerIdCXX/CMakeCXXCompilerId.cpp.o:CMakeCXXCompilerId.cpp:(.text.startup+0x0): first defined here

[build] collect2: error: ld returned 1 exit status
```