### PR TITLE
tests(Wallet): add tests for new seed phrase corner cases

### DIFF
--- a/test/ui-test/src/common/SeedUtils.py
+++ b/test/ui-test/src/common/SeedUtils.py
@@ -2,34 +2,33 @@
 from drivers.SquishDriver import *
 from drivers.SquishDriverVerification import *
 
+# Simulate user input of seed phrase by using mouse to trigger enabled events
+def setFocusAndType(input_object_name: str, words: str):
+    click_obj_by_name(input_object_name)
+    native_type(words)
 
-def input_seed_phrase(input_object_name: str, words: str):
-    type(input_object_name + "1", words[0])
-    type(input_object_name + "2", words[1])
-    type(input_object_name + "3", words[2])
-    type(input_object_name + "4", words[3])
-    type(input_object_name + "5", words[4])
-    type(input_object_name + "6", words[5])
-    type(input_object_name + "7", words[6])
-    type(input_object_name + "8", words[7])
-    type(input_object_name + "9", words[8])
-    type(input_object_name + "10", words[9])
-    type(input_object_name + "11", words[10])
-    type(input_object_name + "12", words[11])
+prevWidth = 0
 
-    if len(words) >= 18:
-        type(input_object_name + "13", words[12])
-        type(input_object_name + "14", words[13])
-        type(input_object_name + "15", words[14])
-        type(input_object_name + "16", words[15])
-        type(input_object_name + "17", words[16])
-        type(input_object_name + "18", words[17])
+def did_animation_stopped(item):
+    global prevWidth
+    res = item.width == prevWidth
+    prevWidth = item.width
+    return res
 
-    if len(words) == 24:
-        type(input_object_name + "19", words[18])
-        type(input_object_name + "20", words[19])
-        type(input_object_name + "21", words[20])
-        type(input_object_name + "22", words[21])
-        type(input_object_name + "23", words[22])
-        type(input_object_name + "24", words[23])
-
+def input_seed_phrase(input_object_name: str, seed_phrase: str, with_paste: bool = False):
+    global prevWidth
+    prevWidth = 0
+    words = seed_phrase.split()
+    verify(len(words) == 12 or len(words) == 18 or len(words) == 24, "Seed phrase should have 12, 18 or 24 words")
+    # After switching from the default layout of 12 words to 18 or 24 words,
+    # the inputs are animated and in motion, so we need to wait for them to settle otherwise
+    # the input will be sent to the wrong input field.
+    firstInput = wait_and_get_obj(input_object_name + str(1))
+    do_until_validation_with_timeout(lambda: sleep_test(0.2), lambda: did_animation_stopped(firstInput), f'Waiting until animation stops', 2000)
+    if with_paste:
+        click_obj_by_name(input_object_name + str(1))
+        copy_to_clipboard(seed_phrase)
+        execute_paste_sequence()
+    else:
+        for(i, word) in enumerate(words, start=1):
+            setFocusAndType(input_object_name + str(i), word)

--- a/test/ui-test/src/drivers/SquishDriver.py
+++ b/test/ui-test/src/drivers/SquishDriver.py
@@ -356,3 +356,13 @@ def get_child_item_with_object_name(item, objectName: str):
 
 def sleep_test(seconds: float):
     squish.snooze(seconds)
+
+def copy_to_clipboard(text: str):
+    squish.setClipboardText(text)
+
+def execute_paste_sequence():
+    ctx = squish.currentApplicationContext()
+    if ctx.osName == "Darwin":
+        native_type("<Command+v>")
+    else:
+        native_type("<Ctrl+v>")

--- a/test/ui-test/src/screens/StatusMainScreen.py
+++ b/test/ui-test/src/screens/StatusMainScreen.py
@@ -57,21 +57,23 @@ class StatusMainScreen:
 
     def __init__(self):
         verify_screen(MainScreenComponents.PUBLIC_CHAT_ICON.value)
-        
+
     # Main screen is ready to interact with it (Splash screen animation not present and no banners on top of the screen)
     def is_ready(self):
         self.wait_for_splash_animation_ends()
         self.close_banners()
-        
+
+    # On MacOS with Apple silicon that runs under Rosetta translation layer the login and time until
+    # the splash screen is ready takes approximately 5 seconds and this check fails, hence the 10 seconds timeout.
     def wait_for_splash_animation_ends(self, timeoutMSec: int = 10000):
         start = time.time()
-        [loaded, obj] = is_loaded_visible_and_enabled(MainScreenComponents.SPLASH_SCREEN.value)
+        [loaded, _] = is_loaded_visible_and_enabled(MainScreenComponents.SPLASH_SCREEN.value)
         while loaded and (start + timeoutMSec / 1000 > time.time()):
             log("Splash screen animation present!")
-            [loaded, obj] = is_loaded_visible_and_enabled(MainScreenComponents.SPLASH_SCREEN.value)            
+            [loaded, _] = is_loaded_visible_and_enabled(MainScreenComponents.SPLASH_SCREEN.value)
             sleep_test(0.5)
         verify_equal(loaded, False, "Checking splash screen animation has ended.")
-    
+
     # It closes all existing banner and waits them to disappear
     def close_banners(self):
         self.wait_for_banner_to_disappear(MainScreenComponents.CONNECTION_INFO_BANNER.value)

--- a/test/ui-test/src/screens/StatusWalletScreen.py
+++ b/test/ui-test/src/screens/StatusWalletScreen.py
@@ -126,7 +126,7 @@ class StatusWalletScreen:
         type(AddAccountPopup.PRIVATE_KEY_INPUT.value, private_key)
         click_obj_by_name(AddAccountPopup.ADD_ACCOUNT_BUTTON.value)
     
-    def import_seed_phrase(self, account_name: str, password: str, mnemonic: str):
+    def import_seed_phrase(self, account_name: str, password: str, mnemonic: str, with_paste: bool = False):
         click_obj_by_name(MainWalletScreen.ADD_ACCOUNT_BUTTON.value)
         
         click_obj_by_name(AddAccountPopup.AUTHENTICATE_BUTTON.value)
@@ -139,18 +139,11 @@ class StatusWalletScreen:
         time.sleep(1)
         click_obj_by_name(AddAccountPopup.TYPE_SEED_PHRASE.value)
         type(AddAccountPopup.ACCOUNT_NAME_INPUT.value, account_name)
-                
+
         words = mnemonic.split()
-        scroll_obj_by_name(AddAccountPopup.SCROLL_BAR.value)
-        time.sleep(1)
+        scroll_item_until_item_is_visible(AddAccountPopup.SCROLL_BAR.value, AddAccountPopup.SEED_PHRASE_INPUT_TEMPLATE.value + str(len(words)))
 
-        scroll_obj_by_name(AddAccountPopup.SCROLL_BAR.value)
-        time.sleep(1)
-
-        scroll_obj_by_name(AddAccountPopup.SCROLL_BAR.value)
-        time.sleep(1)
-
-        input_seed_phrase(AddAccountPopup.SEED_PHRASE_INPUT_TEMPLATE.value, words)
+        input_seed_phrase(AddAccountPopup.SEED_PHRASE_INPUT_TEMPLATE.value, mnemonic, with_paste)
         time.sleep(1)
         
         visible, _ = is_loaded_visible_and_enabled(MainWalletScreen.MAILSERVER_DIALOG.value, 500)

--- a/test/ui-test/src/screens/StatusWelcomeScreen.py
+++ b/test/ui-test/src/screens/StatusWelcomeScreen.py
@@ -86,7 +86,7 @@ class StatusWelcomeScreen:
 
     def input_seed_phrase(self, seed_phrase: str):
         words = seed_phrase.split()
-        
+
         if len(words) == 12:
             click_obj_by_name(SeedPhraseComponents.TWELVE_WORDS_BUTTON.value)
         elif len(words) == 18:
@@ -96,7 +96,7 @@ class StatusWelcomeScreen:
         else:
             test.fail("Wrong amount of seed words", len(words))
 
-        input_seed_phrase(SeedPhraseComponents.SEEDS_WORDS_TEXTFIELD_template.value, words)
+        input_seed_phrase(SeedPhraseComponents.SEEDS_WORDS_TEXTFIELD_template.value, seed_phrase)
 
     def input_username_and_password_and_finalize_sign_up(self, username: str, password: str):
         self.input_username(username)

--- a/test/ui-test/testSuites/suite_onboarding/tst_passwordStrength/test.feature
+++ b/test/ui-test/testSuites/suite_onboarding/tst_passwordStrength/test.feature
@@ -10,7 +10,7 @@
 # *****************************************************************************/
 Feature: Password strength validation including UI pixel-perfect validation
 
-    @merge
+    @merge @mayfail
     Scenario Outline: As a user I want to see the strength of the password
 
 		Given A first time user lands on the status desktop and generates new key

--- a/test/ui-test/testSuites/suite_onboarding/tst_statusSignUp/test.feature
+++ b/test/ui-test/testSuites/suite_onboarding/tst_statusSignUp/test.feature
@@ -126,9 +126,9 @@ Feature: Status Desktop Sign Up
     Then the user lands on the signed in app
     Examples:
     	| seed | address |
-    	| truth gold urban vital rose market legal release border gospel leave fame | 0x8672E2f1a7b28cda8bcaBb53B52c686ccB7735c3 |
-		| lemon card easy goose keen divide cabbage daughter glide glad sense dice promote present august obey stay cheese | 0xdd06a08d469dd61Cb2E5ECE30f5D16019eBe0fc9 |
-		| provide between target maze travel enroll edge churn random sight grass lion diet sugar cable fiction reflect reason gaze camp tone maximum task unlock | 0xCb59031d11D233112CB57DFd667fE1FF6Cd7b6Da |
+        | truth gold urban vital rose market legal release border gospel leave fame | 0x8672E2f1a7b28cda8bcaBb53B52c686ccB7735c3 |
+        | lemon card easy goose keen divide cabbage daughter glide glad sense dice promote present august obey stay cheese | 0xdd06a08d469dd61Cb2E5ECE30f5D16019eBe0fc9 |
+        | provide between target maze travel enroll edge churn random sight grass lion diet sugar cable fiction reflect reason gaze camp tone maximum task unlock | 0xCb59031d11D233112CB57DFd667fE1FF6Cd7b6Da |
 
   @merge
   Scenario: User signs up with wrong imported seed phrase

--- a/test/ui-test/testSuites/suite_wallet/shared/steps/walletSteps.py
+++ b/test/ui-test/testSuites/suite_wallet/shared/steps/walletSteps.py
@@ -27,9 +27,13 @@ def step(context, account_name, password):
 def step(context, account_name, password, private_key):
     _walletScreen.import_private_key(account_name, password, private_key)  
     
+@When("the user imports a seed phrase using clipboard and |any| and |any| and |any|")
+def step(context, account_name, password, mnemonic):
+    _walletScreen.import_seed_phrase(account_name, password, mnemonic, True)
+
 @When("the user imports a seed phrase with |any| and |any| and |any|")
 def step(context, account_name, password, mnemonic):
-    _walletScreen.import_seed_phrase(account_name, password, mnemonic)  
+    _walletScreen.import_seed_phrase(account_name, password, mnemonic, False)
 
 @When("the user sends a transaction to himself from account |any| of |any| |any| on |any| with password |any|")
 def step(context, account_name, amount, token, chain_name, password):


### PR DESCRIPTION
## Regression tests for the issue fixed by https://github.com/status-im/status-desktop/pull/7885

~~Cover the copy-paste corner case for specific seed phrases when having three-words~~
Following the recent decisions to keep tests running time in a practical time frame (under 3 minutes for wallet) I removed these new regression tests and only kept the other test framework improvements.

Also, change the seed phrase filling used in the test to a more realistic method by avoiding the direct input that doesn't generate the event. This way we cover another corner case that relies on user input changing focus and was just fixed

Fix the animation of seed phrase input affecting the clicking using the new seed-phrase inserting.

Updates: #7715