### PR TITLE
fix(ProfilePopup): Process declined incoming verification request

### DIFF
--- a/ui/imports/shared/popups/ContactVerificationRequestPopup.qml
+++ b/ui/imports/shared/popups/ContactVerificationRequestPopup.qml
@@ -120,8 +120,9 @@ StatusModal {
     }
 
     rightButtons: [
-        StatusButton {
+        StatusFlatButton {
             visible: !root.responseText
+            type: StatusBaseButton.Type.Danger
             text: qsTr("Refuse Verification")
             onClicked: {
                 root.verificationRefused(root.senderPublicKey)


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/7377

### What does the PR do

There's no design for what to do when verification was declined.
I've notified @John-44 about this 🙂 

As for now, I implemented own quick solution:
If incoming verification was declined (refused), then we hide "Verify identity pending..." button and show "Verify Identity" instead. Also we automatically close the `ProfilePopup` when the verification was refused.

This is definitely a strange solution, but at least it gives user some response.

### Affected areas

Profile popup

### Screenshot of functionality (including design for comparison)

https://user-images.githubusercontent.com/25482501/195680232-cd834291-aec7-42eb-9b0c-3d67b0854fc9.mov
