### PR TITLE
fix(@desktop/keycard): clicking `Get Keycard` button should direct to purchase page

### DIFF
--- a/ui/app/AppLayouts/Profile/views/KeycardView.qml
+++ b/ui/app/AppLayouts/Profile/views/KeycardView.qml
@@ -20,7 +20,7 @@ SettingsContentBase {
     titleRowComponentLoader.sourceComponent: StatusButton {
         text: qsTr("Get Keycard")
         onClicked: {
-            console.warn("TODO: Go to purchase page...")
+            Global.openLink(Constants.keycard.general.purchasePage)
         }
     }
 

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -385,6 +385,7 @@ QtObject {
     readonly property QtObject keycard: QtObject {
 
         readonly property QtObject general: QtObject {
+            readonly property string purchasePage: "https://get.keycard.tech"
             readonly property int onboardingHeight: 460
             readonly property int loginHeight: 460
             readonly property int imageWidth: 240


### PR DESCRIPTION
Fixes: #7027
