### PR TITLE
Fix build2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,7 @@
 [submodule "vendor/nimbus-build-system"]
 	path = vendor/nimbus-build-system
-	url = https://github.com/status-im/nimbus-build-system.git
+	url = https://github.com/status-im/nimbus-build-system-desktop.git
+	branch = desktop
 [submodule "vendor/DOtherSide"]
 	path = vendor/DOtherSide
 	url = https://github.com/status-im/DOtherSide.git


### PR DESCRIPTION
### What does the PR do

Build system recently broke due to Nimbus updating the nim version to 1.6 in nimbus-build-system and vendor/nim. Since nimbus-build-system is pointing to a branch `nimbus` it automatically updates everywhere to this latest changes no matter what. This PR uses a fork of `nimbus-build-system` that points to the correct commit and modifies the build script to always use the correct commit so we don't have this issue again.