### PR TITLE
fix(@desktop/general): Fix community deep links

### DIFF
--- a/src/app/core/custom_urls/urls_manager.nim
+++ b/src/app/core/custom_urls/urls_manager.nim
@@ -6,29 +6,15 @@ import ../../global/app_signals
 logScope:
   topics = "urls-manager"
 
-const UriFormatBrowserShort = "status-im://b/"
-const UriFormatBrowserLong = "status-im://browser/"
+const UriFormatUserProfile = "status-im://u/"
 
-const UriFormatUserProfileShort = "status-im://u/"
-const UriFormatUserProfileLong = "status-im://user/"
+const UriFormatCommunity = "status-im://c/"
 
-const UriFormatPrivateChatShort = "status-im://pm/"
-const UriFormatPrivateChatLong = "status-im://private-message/"
+const UriFormatCommunityChannel = "status-im://cc/"
 
-const UriFormatPublicChatShort = "status-im://p/"
-const UriFormatPublicChatLong = "status-im://public/"
+const UriFormatGroupChat = "status-im://g/"
 
-const UriFormatGroupChatShort = "status-im://g/"
-const UriFormatGroupChatLong = "status-im://group/"
-
-const UriFormatCommunityRequestsShort = "status-im://cr/"
-const UriFormatCommunityRequestsLong = "status-im://community-requests/"
-
-const UriFormatCommunityShort = "status-im://c/"
-const UriFormatCommunityLong = "status-im://community/"
-
-const UriFormatCommunityChannelShort = "status-im://cc/"
-const UriFormatCommunityChannelLong = "status-im://community-channel/"
+const UriFormatBrowser = "status-im://b/"
 
 QtObject:
   type UrlsManager* = ref object of QObject
@@ -55,16 +41,6 @@ QtObject:
     result.protocolUriOnStart = protocolUriOnStart
     result.loggedIn = false
 
-  proc prepareGroupChatDetails(self: UrlsManager, urlQuery: string,
-       data: var StatusUrlArgs) =
-    var urlParams = rsplit(urlQuery, "/u/")
-    if(urlParams.len > 0):
-      data.groupName = urlParams[0]
-      urlParams.delete(0)
-      data.listOfUserIds = urlParams
-    else:
-      info "wrong url format for group chat"
-
   proc onUrlActivated*(self: UrlsManager, urlRaw: string) {.slot.} =
     if not self.loggedIn:
       self.protocolUriOnStart = urlRaw
@@ -75,72 +51,26 @@ QtObject:
       .multiReplace(("\r\n", ""))
       .multiReplace(("\n", ""))
 
-    # Open `url` in the app's browser
-    if url.startsWith(UriFormatBrowserShort):
-      data.action = StatusUrlAction.OpenLinkInBrowser
-      data.url = url[UriFormatBrowserShort.len .. url.len-1]
-    elif url.startsWith(UriFormatBrowserLong):
-      data.action = StatusUrlAction.OpenLinkInBrowser
-      data.url = url[UriFormatBrowserLong.len .. url.len-1]
-    
     # Display user profile popup for user with `user_pk` or `ens_name`
-    elif url.startsWith(UriFormatUserProfileShort):
+    if url.startsWith(UriFormatUserProfile):
       data.action = StatusUrlAction.DisplayUserProfile
-      data.userId = url[UriFormatUserProfileShort.len .. url.len-1]
-    elif url.startsWith(UriFormatUserProfileLong):
-      data.action = StatusUrlAction.DisplayUserProfile
-      data.userId = url[UriFormatUserProfileLong.len .. url.len-1]
-    
-    # Open or create 1:1 chat with user with `user_pk` or `ens_name`
-    elif url.startsWith(UriFormatPrivateChatShort):
-      data.action = StatusUrlAction.OpenOrCreatePrivateChat
-      data.chatId = url[UriFormatPrivateChatShort.len .. url.len-1]
-    elif url.startsWith(UriFormatPrivateChatLong):
-      data.action = StatusUrlAction.OpenOrCreatePrivateChat
-      data.chatId = url[UriFormatPrivateChatLong.len .. url.len-1]
-
-    # Open public chat with `chat_key`
-    elif url.startsWith(UriFormatPublicChatShort):
-      data.action = StatusUrlAction.OpenOrJoinPublicChat
-      data.chatId = url[UriFormatPublicChatShort.len .. url.len-1]
-    elif url.startsWith(UriFormatPublicChatLong):
-      data.action = StatusUrlAction.OpenOrJoinPublicChat
-      data.chatId = url[UriFormatPublicChatLong.len .. url.len-1]
-
-    # Open a group chat with named `group_name`, adding up to 19 participants with their `user_pk` or `ens_name`. 
-    # Group chat may have up to 20 participants including the admin of a group
-    elif url.startsWith(UriFormatGroupChatShort):
-      data.action = StatusUrlAction.OpenOrCreateGroupChat
-      let urlQuery = url[UriFormatGroupChatShort.len .. url.len-1]
-      self.prepareGroupChatDetails(urlQuery, data)
-    elif url.startsWith(UriFormatGroupChatLong):
-      data.action = StatusUrlAction.OpenOrCreateGroupChat
-      let urlQuery = url[UriFormatGroupChatLong.len .. url.len-1]
-      self.prepareGroupChatDetails(urlQuery, data)
-
-    # Send a join community request to a community with `community_key`
-    elif url.startsWith(UriFormatCommunityRequestsShort):
-      data.action = StatusUrlAction.RequestToJoinCommunity
-      data.communityId = url[UriFormatCommunityRequestsShort.len .. url.len-1]
-    elif url.startsWith(UriFormatCommunityRequestsLong):
-      data.action = StatusUrlAction.RequestToJoinCommunity
-      data.communityId = url[UriFormatCommunityRequestsLong.len .. url.len-1]
+      data.userId = url[UriFormatUserProfile.len .. url.len-1]
 
     # Open community with `community_key`
-    elif url.startsWith(UriFormatCommunityShort):
+    elif url.startsWith(UriFormatCommunity):
       data.action = StatusUrlAction.OpenCommunity
-      data.communityId = url[UriFormatCommunityShort.len .. url.len-1]
-    elif url.startsWith(UriFormatCommunityLong):
-      data.action = StatusUrlAction.OpenCommunity
-      data.communityId = url[UriFormatCommunityLong.len .. url.len-1]
+      data.communityId = url[UriFormatCommunity.len .. url.len-1]
 
     # Open community which has a channel with `channel_key` and makes that channel active
-    elif url.startsWith(UriFormatCommunityChannelShort):
+    elif url.startsWith(UriFormatCommunityChannel):
       data.action = StatusUrlAction.OpenCommunityChannel
-      data.chatId = url[UriFormatCommunityChannelShort.len .. url.len-1]
-    elif url.startsWith(UriFormatCommunityChannelLong):
-      data.action = StatusUrlAction.OpenCommunityChannel
-      data.chatId = url[UriFormatCommunityChannelLong.len .. url.len-1]
+      data.chatId = url[UriFormatCommunityChannel.len .. url.len-1]
+
+    # Open `url` in the app's browser
+    # Enable after MVP
+    #elif url.startsWith(UriFormatBrowser):
+    #  data.action = StatusUrlAction.OpenLinkInBrowser
+    #  data.url = url[UriFormatBrowser.len .. url.len-1]
 
     else:
       info "Unsupported deep link structure: ", url

--- a/src/app/global/app_signals.nim
+++ b/src/app/global/app_signals.nim
@@ -28,10 +28,6 @@ type
   StatusUrlAction* {.pure.} = enum
     OpenLinkInBrowser = 0
     DisplayUserProfile,
-    OpenOrCreatePrivateChat,
-    OpenOrJoinPublicChat,
-    OpenOrCreateGroupChat,
-    RequestToJoinCommunity,
     OpenCommunity,
     OpenCommunityChannel
 
@@ -42,7 +38,5 @@ type
     chatId*: string
     url*: string
     userId*: string # can be public key or ens name
-    groupName*: string
-    listOfUserIds*: seq[string] # used for creating group chat
 
 const SIGNAL_STATUS_URL_REQUESTED* = "statusUrlRequested"

--- a/src/app/modules/main/controller.nim
+++ b/src/app/modules/main/controller.nim
@@ -170,6 +170,10 @@ proc init*(self: Controller) =
       setActive = false
     )
 
+  self.events.on(SIGNAL_COMMUNITY_DATA_IMPORTED) do(e:Args):
+    let args = CommunityArgs(e)
+    self.delegate.communityDataImported(args.community)
+
   self.events.on(SIGNAL_COMMUNITY_LEFT) do(e:Args):
     let args = CommunityIdArgs(e)
     self.delegate.communityLeft(args.communityId)
@@ -220,8 +224,7 @@ proc init*(self: Controller) =
 
   self.events.on(SIGNAL_STATUS_URL_REQUESTED) do(e: Args):
     var args = StatusUrlArgs(e)
-    self.delegate.onStatusUrlRequested(args.action, args.communityId, args.chatId, args.url, args.userId, 
-      args.groupName, args.listOfUserIds)
+    self.delegate.onStatusUrlRequested(args.action, args.communityId, args.chatId, args.url, args.userId)
 
   self.events.on(SIGNAL_OS_NOTIFICATION_CLICKED) do(e: Args):
     var args = ClickedNotificationArgs(e)

--- a/src/app/modules/main/io_interface.nim
+++ b/src/app/modules/main/io_interface.nim
@@ -189,6 +189,9 @@ method getAppSearchModule*(self: AccessInterface): QVariant {.base.} =
 method getContactDetailsAsJson*(self: AccessInterface, publicKey: string, getVerificationRequest: bool): string {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method communityDataImported*(self: AccessInterface, community: CommunityDto) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method resolveENS*(self: AccessInterface, ensName: string, uuid: string, reason: string = "") {.base.} =
   raise newException(ValueError, "No implementation available")
 
@@ -202,7 +205,7 @@ method isConnected*(self: AccessInterface): bool {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method onStatusUrlRequested*(self: AccessInterface, action: StatusUrlAction, communityId: string, chatId: string, 
-  url: string, userId: string, groupName: string, listOfUserIds: seq[string]) {.base.} =
+  url: string, userId: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method getVerificationRequestFrom*(self: AccessInterface, publicKey: string): VerificationRequest {.base.} =


### PR DESCRIPTION
### What does the PR do

Cleanups in deep links - removing not needed link handlers, according to new specs: https://github.com/status-im/specs/blob/feature/url-shema/docs/draft/17-url-scheme.md
Improving `open community` and `open channel` deep links - spectate community if not a member.

join.status.im does not handle community deep links. This ticket is for internal deep links ("status-im://")

Fix #7892

### Affected areas

Deep links

### Testing

Testing requires installing a package.
Use your dogfooding account, so you are a member of Status community. 

Community you are a member of:
status-im://c/0x032aa2439b14eb2caaf724223951da89de1530fbfa5d5a639b93b82cd5341713fd - Status community
Channel in community you are a member of:
status-im://cc/0x032aa2439b14eb2caaf724223951da89de1530fbfa5d5a639b93b82cd5341713fd67ee9155-7a5a-4229-8612-690320f9ad34 - Status community / watercooler channel

Unknown community:
status-im://c/0x0330c53d3fbda83361cf61e84b2b159bcfc7da999f637fbed065e79335131a85f6 - Pidgeon community
Unknown channel:
status-im://cc/0x0330c53d3fbda83361cf61e84b2b159bcfc7da999f637fbed065e79335131a85f687bc8982-9316-4e36-aba3-de719313ae74 - Pidgeon community / konga channel

For unknown community, community should be opened as a spectated community.

