### PR TITLE
fix(BackUpSeed): Confirm # word input had no focus

### DIFF
--- a/ui/app/AppLayouts/Profile/popups/BackupSeedModal.qml
+++ b/ui/app/AppLayouts/Profile/popups/BackupSeedModal.qml
@@ -19,6 +19,16 @@ StatusStackModal {
 
     property var privacyStore
 
+    onCurrentIndexChanged: {
+        //StatusAnimatedStack doesn't handle well items' visibility,
+        //keeping this solution for now until #8024 is fixed
+        if (currentIndex === 2) {
+            confirmFirstWord.forceInputFocus();
+        } else if (currentIndex === 3) {
+            confirmSecondWord.forceInputFocus();
+        }
+    }
+
     QtObject {
         id: d
 

--- a/ui/app/AppLayouts/Profile/popups/backupseed/BackupSeedStepBase.qml
+++ b/ui/app/AppLayouts/Profile/popups/backupseed/BackupSeedStepBase.qml
@@ -20,6 +20,10 @@ StatusScrollView {
 
     default property alias content: column.children
 
+    function forceInputFocus() {
+        inputText.input.edit.forceActiveFocus();
+    }
+
     implicitHeight: 520
     clip: false
 


### PR DESCRIPTION
Closes #7680

### What does the PR do
BackUpSeedPhrasePopup steps 2+3 had no focus in text input

### Affected areas
BackUpSeedPhrasePopup

### Screenshot of functionality (including design for comparison)
https://user-images.githubusercontent.com/31625338/196689138-6a0f895a-3da6-419b-befb-a3068cfcd416.mov

