### PR TITLE
fix(CommunitiesGridView): don't display header labels when section empty

### DIFF
--- a/ui/app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml
+++ b/ui/app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml
@@ -162,6 +162,7 @@ StatusSectionLayout {
                 clip: true
 
                 CommunitiesGridView {
+                    id: communitiesGrid
                     anchors.fill: parent
                     anchors.rightMargin: d.preventShadowClipMargin
                     anchors.leftMargin: d.preventShadowClipMargin
@@ -180,7 +181,7 @@ StatusSectionLayout {
                     anchors.top: parent.top
                     anchors.horizontalCenter: parent.horizontalCenter
                     anchors.topMargin: parent.height / 3.1
-                    visible: d.searchMode && filteredCommunitiesModel.count === 0
+                    visible: (d.searchMode && filteredCommunitiesModel.count === 0) || communitiesGrid.isEmpty
                     text: qsTr("No communities found")
                     color: Theme.palette.baseColor1
                     font.pixelSize: 15

--- a/ui/app/AppLayouts/CommunitiesPortal/views/CommunitiesGridView.qml
+++ b/ui/app/AppLayouts/CommunitiesPortal/views/CommunitiesGridView.qml
@@ -17,6 +17,8 @@ StatusScrollView {
     property var model
     property bool searchLayout: false
 
+    readonly property bool isEmpty: !featuredRepeater.count && !popularRepeater.count
+
     signal cardClicked(string communityId)
 
     clip: false
@@ -83,7 +85,7 @@ StatusScrollView {
 
         StatusBaseText {
             id: featuredLabel
-            visible: !root.searchLayout
+            visible: !root.searchLayout && featuredRepeater.count
             Layout.topMargin: d.scrollViewTopMargin
             text: qsTr("Featured")
             font.weight: Font.Bold
@@ -98,15 +100,17 @@ StatusScrollView {
             columns: 3
             columnSpacing: Style.current.padding
             rowSpacing: Style.current.padding
+            visible: featuredRepeater.count
 
             Repeater {
+                id: featuredRepeater
                 model: root.searchLayout ? root.model : featuredModel
                 delegate: communityCardDelegate
             }
         }
 
         StatusBaseText {
-            visible: !root.searchLayout
+            visible: !root.searchLayout && popularRepeater.count
             Layout.topMargin: 20
             text: qsTr("Popular")
             font.weight: Font.Bold
@@ -121,6 +125,7 @@ StatusScrollView {
             rowSpacing: Style.current.padding
 
             Repeater {
+                id: popularRepeater
                 model: popularModel
                 delegate: communityCardDelegate
             }


### PR DESCRIPTION
Do not display the Featured/Popular labels when the corresponding section is emtpy

Fixes: #7946

### What does the PR do

Fixes wrong section labels

### Affected areas

CommunitiesGridView

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![Snímek obrazovky z 2022-10-20 08-46-35](https://user-images.githubusercontent.com/5377645/196876712-9a31b285-b1bc-4f10-9723-9b42203c1385.png)

![Snímek obrazovky z 2022-10-20 08-46-30](https://user-images.githubusercontent.com/5377645/196876718-3bfffe45-cb73-4716-874a-835c85b16ca6.png)
