### PR TITLE
fix(communities): emit SIGNAL_COMMUNITY_JOINED for new communities

### DIFF
--- a/src/app_service/service/community/service.nim
+++ b/src/app_service/service/community/service.nim
@@ -284,6 +284,12 @@ QtObject:
     if(not self.allCommunities.hasKey(community.id)):
       self.allCommunities[community.id] = community
       self.events.emit(SIGNAL_COMMUNITY_ADDED, CommunityArgs(community: community))
+
+      if(not self.joinedCommunities.hasKey(community.id)):
+        if (community.joined and community.isMember):
+          self.joinedCommunities[community.id] = community
+          self.events.emit(SIGNAL_COMMUNITY_JOINED, CommunityArgs(community: community, fromUserAction: false))
+
       return
 
     if(self.curatedCommunities.hasKey(community.id)):


### PR DESCRIPTION
New community that appears through community update signal can also be the community we are already members of, in that case we need to emit SIGNAL_COMMUNITY_JOINED, so that it appears on the side bar.

### What does the PR do

It fixes the imported community not appearing on the sidebar.

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas

joining communities
