### PR TITLE
fix(CreateCommunityPopup): reset discord filelist when modal is opened

### DIFF
--- a/ui/app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml
+++ b/ui/app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml
@@ -74,16 +74,13 @@ StatusStackModal {
     onAboutToShow: {
         nameInput.input.edit.forceActiveFocus()
         if (root.isDiscordImport) {
+            if (!root.store.discordImportInProgress) {
+                root.store.clearFileList()
+                root.store.clearDiscordCategoriesAndChannels()
+            }
             for (let i = 0; i < discordPages.length; i++) {
                 stackItems.push(discordPages[i])
             }
-        }
-    }
-
-    onClosed: {
-        if (root.isDiscordImport) {
-            root.store.clearFileList()
-            root.store.clearDiscordCategoriesAndChannels()
         }
     }
 


### PR DESCRIPTION
Prior to this commit we would reset the file list (and categories and channels) whenever the `CreateCommunityPopup` was closed.

This made sense because at that point we could assume that the user has decided to somehow stop the process of an import, so the next time the modal is opened again, we want that data to be reset.

However, it turned out that this introduced a bug in the scenario where and import is running, and while it's running, when the user decides to hide the progress modal, it would reset the warnings count, resulting in the progress banner to show an invalid state until the next progress signal was emitted.

We don't want to reset this data every time we close the modal. We only want to reset it when we know there's no import in progress.

Fixes #7787

