### PR TITLE
test(suite_messaging/tst_ChatFlow): Added tag `mayfail` bc it is weak on the CI

### DIFF
--- a/test/ui-test/testSuites/suite_messaging/tst_ChatFlow/test.feature
+++ b/test/ui-test/testSuites/suite_messaging/tst_ChatFlow/test.feature
@@ -163,6 +163,8 @@ Feature: Status Desktop Chat Basic Flows
     	Then the last chat message contains "🙂"
     	And the last chat message contains "Hello"
 
+ 	@mayfail
+	# TODO: It works standalone but when it runs as part of the sequence and mostly in the CI, the action of verification doesn't work.
     Scenario: The user can send a sticker after installing a free pack
          Given the user installs the sticker pack at position 4
          When the user sends the sticker at position 2 in the list


### PR DESCRIPTION
Created task to address the issue:  https://github.com/status-im/status-desktop/issues/7995

### What does the PR do

Disabled test case since it is weak on the CI. It works standalone but when it runs as part of the sequence and mostly in the CI, the action of verification doesn't work.

### Affected areas
`suite_messaging/tst_ChatFlow`
