### PR TITLE
fix(ProfileDialogView): Use compressed chat key in "Copy Link To Profile

### DIFF
--- a/ui/imports/shared/views/ProfileDialogView.qml
+++ b/ui/imports/shared/views/ProfileDialogView.qml
@@ -75,7 +75,7 @@ Pane {
             else
                 user = contactDetails.name
             if (!user)
-                user = root.publicKey
+                user = Utils.getCompressedPk(root.publicKey)
             return Constants.userLinkPrefix + user
         }
 


### PR DESCRIPTION
Fixes #7988

### What does the PR do

Uses compressed key to create the link to profile

### Affected areas

ProfileDialogView

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

Own profile:
![image](https://user-images.githubusercontent.com/5377645/197157677-1fab19bf-5938-42ea-a4f2-76ab58b493af.png)

Other profile:
![image](https://user-images.githubusercontent.com/5377645/197157968-71452bd3-b6aa-4feb-8dee-94036b353673.png)


