### PR TITLE
feat(communities): User is able to cancel membership request

### DIFF
--- a/src/app/modules/main/communities/controller.nim
+++ b/src/app/modules/main/communities/controller.nim
@@ -86,6 +86,9 @@ proc getCuratedCommunities*(self: Controller): seq[CuratedCommunity] =
 proc spectateCommunity*(self: Controller, communityId: string): string =
   self.communityService.spectateCommunity(communityId)
 
+proc cancelRequestToJoinCommunity*(self: Controller, communityId: string) =
+  self.communityService.cancelRequestToJoinCommunity(communityId)
+
 proc requestToJoinCommunity*(self: Controller, communityId: string, ensName: string) =
   self.communityService.requestToJoinCommunity(communityId, ensName)
 

--- a/src/app/modules/main/communities/io_interface.nim
+++ b/src/app/modules/main/communities/io_interface.nim
@@ -62,6 +62,9 @@ method userCanJoin*(self: AccessInterface, communityId: string): bool {.base.} =
 method isCommunityRequestPending*(self: AccessInterface, communityId: string): bool {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method cancelRequestToJoinCommunity*(self: AccessInterface, communityId: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method requestToJoinCommunity*(self: AccessInterface, communityId: string, ensName: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/communities/module.nim
+++ b/src/app/modules/main/communities/module.nim
@@ -272,6 +272,9 @@ method discordCategoriesAndChannelsExtracted*(self: Module, categories: seq[Disc
   self.view.setDiscordImportErrorsCount(errorsCount)
   self.view.discordChannelsModel().hasSelectedItemsChanged()
 
+method cancelRequestToJoinCommunity*(self: Module, communityId: string) =
+  self.controller.cancelRequestToJoinCommunity(communityId)
+
 method requestToJoinCommunity*(self: Module, communityId: string, ensName: string) =
   self.controller.requestToJoinCommunity(communityId, ensName)
 

--- a/src/app/modules/main/communities/view.nim
+++ b/src/app/modules/main/communities/view.nim
@@ -418,6 +418,9 @@ QtObject:
   proc reorderCommunityChannel*(self: View, communityId: string, categoryId: string, chatId: string, position: int): string {.slot} =
     self.delegate.reorderCommunityChannel(communityId, categoryId, chatId, position)
 
+  proc cancelRequestToJoinCommunity*(self: View, communityId: string) {.slot.} =
+    self.delegate.cancelRequestToJoinCommunity(communityId)
+
   proc requestToJoinCommunity*(self: View, communityId: string, ensName: string) {.slot.} =
     self.delegate.requestToJoinCommunity(communityId, ensName)
 

--- a/src/app_service/service/community/dto/community.nim
+++ b/src/app_service/service/community/dto/community.nim
@@ -8,9 +8,10 @@ include ../../../common/json_utils
 import ../../chat/dto/chat
 
 type RequestToJoinType* {.pure.}= enum
-  Pending = 0,
-  Declined = 1,
-  Accepted = 2
+  Pending = 1,
+  Declined = 2,
+  Accepted = 3,
+  Canceled = 4
 
 type Member* = object
   id*: string
@@ -72,6 +73,7 @@ type CommunityDto* = object
   bannedMembersIds*: seq[string]
   declinedRequestsToJoin*: seq[CommunityMembershipRequestDto]
   encrypted*: bool
+  canceledRequestsToJoin*: seq[CommunityMembershipRequestDto]  
 
 type CuratedCommunity* = object
     available*: bool

--- a/src/backend/communities.nim
+++ b/src/backend/communities.nim
@@ -40,11 +40,22 @@ proc requestToJoinCommunity*(communityId: string, ensName: string): RpcResponse[
 proc myPendingRequestsToJoin*(): RpcResponse[JsonNode] {.raises: [Exception].} =
   result =  callPrivateRPC("myPendingRequestsToJoin".prefix)
 
+proc myCanceledRequestsToJoin*(): RpcResponse[JsonNode] {.raises: [Exception].} =
+  result =  callPrivateRPC("myCanceledRequestsToJoin".prefix)
+
 proc pendingRequestsToJoinForCommunity*(communityId: string): RpcResponse[JsonNode] {.raises: [Exception].} =
   result = callPrivateRPC("pendingRequestsToJoinForCommunity".prefix, %*[communityId])
 
 proc declinedRequestsToJoinForCommunity*(communityId: string): RpcResponse[JsonNode] {.raises: [Exception].} =
   result = callPrivateRPC("declinedRequestsToJoinForCommunity".prefix, %*[communityId])
+
+proc canceledRequestsToJoinForCommunity*(communityId: string): RpcResponse[JsonNode] {.raises: [Exception].} =
+  result = callPrivateRPC("canceledRequestsToJoinForCommunity".prefix, %*[communityId])
+
+proc cancelRequestToJoinCommunity*(requestId: string): RpcResponse[JsonNode] {.raises: [Exception].} =
+  result = callPrivateRPC("cancelRequestToJoinCommunity".prefix, %*[{
+    "id": requestId
+  }])
 
 proc leaveCommunity*(communityId: string): RpcResponse[JsonNode] {.raises: [Exception].} =
   result = callPrivateRPC("leaveCommunity".prefix, %*[communityId])

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -335,6 +335,10 @@ QtObject {
         return communitiesModuleInst.isCommunityRequestPending(id)
     }
 
+    function cancelPendingRequest(id: string) {
+        communitiesModuleInst.cancelRequestToJoinCommunity(id)
+    }
+
     function getSectionNameById(id) {
         return communitiesList.getSectionNameById(id)
     }

--- a/ui/app/AppLayouts/Chat/views/CommunityColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/CommunityColumnView.qml
@@ -108,15 +108,16 @@ Item {
         anchors.horizontalCenter: parent.horizontalCenter
 
         visible: !communityData.joined
-        enabled: !invitationPending
 
         text: {
-            if (invitationPending) return qsTr("Pending")
+            if (invitationPending) return qsTr("Membership request pending...")
             return root.communityData.access === Constants.communityChatOnRequestAccess ?
                     qsTr("Request to join") : qsTr("Join Community")
         }
 
-        onClicked: communityIntroDialog.open()
+        onClicked: {
+            communityIntroDialog.open()
+        }
 
         Connections {
             target: root.store.communitiesModuleInst
@@ -130,12 +131,17 @@ Item {
         CommunityIntroDialog {
             id: communityIntroDialog
 
+            isInvitationPending: joinCommunityButton.invitationPending
             name: communityData.name
             introMessage: communityData.introMessage
             imageSrc: communityData.image
             accessType: communityData.access
 
             onJoined: root.store.requestToJoinCommunity(communityData.id, root.store.userProfileInst.name)
+            onCancelMembershipRequest: {
+                root.store.cancelPendingRequest(communityData.id)
+                joinCommunityButton.invitationPending = root.store.isCommunityRequestPending(communityData.id)
+            }
         }
     }
 

--- a/ui/imports/shared/popups/CommunityIntroDialog.qml
+++ b/ui/imports/shared/popups/CommunityIntroDialog.qml
@@ -18,20 +18,31 @@ StatusDialog {
     property string introMessage
     property int accessType
     property url imageSrc
+    property bool isInvitationPending: false
 
     signal joined
+    signal cancelMembershipRequest
 
     title: qsTr("Welcome to %1").arg(name)
 
     footer: StatusDialogFooter {
         rightButtons: ObjectModel {
             StatusButton {
-                text: root.accessType === Constants.communityChatOnRequestAccess
-                      ? qsTr("Request to join %1").arg(root.name)
-                      : qsTr("Join %1").arg(root.name)
-                enabled: checkBox.checked
+                text: root.isInvitationPending ? qsTr("Cancel Membership Request")
+                                               : (root.accessType === Constants.communityChatOnRequestAccess
+                                                  ? qsTr("Request to join %1").arg(root.name)
+                                                  : qsTr("Join %1").arg(root.name) )
+                type: root.isInvitationPending ? StatusBaseButton.Type.Danger
+                                               : StatusBaseButton.Type.Normal
+                enabled: checkBox.checked || root.isInvitationPending
+
                 onClicked: {
-                    root.joined()
+                    if (root.isInvitationPending) {
+                        root.cancelMembershipRequest()
+                    } else {
+                       root.joined()
+                    }
+
                     root.close()
                 }
             }
@@ -71,6 +82,7 @@ StatusDialog {
         StatusCheckBox {
             id: checkBox
             Layout.alignment: Qt.AlignCenter
+            visible: !root.isInvitationPending
             text: qsTr("I agree with the above")
         }
     }


### PR DESCRIPTION
Part of: #7072

[Status-go PR](https://github.com/status-im/status-go/pull/2915)

### What does the PR do

Add methods to cancel membership requests to community

### Affected areas

Communities

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it


https://user-images.githubusercontent.com/82511785/197172029-0cb4f83b-37c5-4df8-8d03-d4cb08dd0409.mov

UPDATE:
@caybro @PascalPrecht I update ui logic as expect:

https://user-images.githubusercontent.com/82511785/197408822-42345c19-f216-46a5-8501-543a6d7caa66.mov


