### PR TITLE
fix(Global): Popup components moved from Global.qml to dedicated non-singleton component

### DIFF
--- a/ui/app/AppLayouts/Chat/views/MembersSelectorView.qml
+++ b/ui/app/AppLayouts/Chat/views/MembersSelectorView.qml
@@ -106,8 +106,8 @@ MembersSelectorBase {
             }
 
             if (root.model.count === 0) {
-                const popup = Global.openContactRequestPopup(contactDetails.publicKey)
-                popup.closed.connect(root.rejected)
+                Global.openContactRequestPopup(contactDetails.publicKey,
+                                               popup => popup.closed.connect(root.rejected))
                 return
             }
         }

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -73,6 +73,18 @@ Item {
         }
     }
 
+    Popups {
+        rootStore: appMain.rootStore
+
+        Component.onCompleted: {
+            Global.openSendIDRequestPopup.connect(openSendIDRequestPopup)
+            Global.openOutgoingIDRequestPopup.connect(openOutgoingIDRequestPopup)
+            Global.openIncomingIDRequestPopup.connect(openIncomingIDRequestPopup)
+            Global.openInviteFriendsToCommunityPopup.connect(openInviteFriendsToCommunityPopup)
+            Global.openContactRequestPopup.connect(openContactRequestPopup)
+        }
+    }
+
     Connections {
         target: Global
         onOpenLinkInBrowser: {

--- a/ui/app/mainui/Popups.qml
+++ b/ui/app/mainui/Popups.qml
@@ -1,0 +1,150 @@
+import QtQuick 2.14
+
+import AppLayouts.Chat.popups 1.0
+import shared.popups 1.0
+
+import utils 1.0
+
+QtObject {
+    id: root
+
+    /* required */ property var rootStore
+
+    function openSendIDRequestPopup(publicKey, cb) {
+        const contactDetails = Utils.getContactDetailsAsJson(publicKey)
+        const popup = Global.openPopup(sendIDRequestPopupComponent, {
+            userPublicKey: publicKey,
+            userDisplayName: contactDetails.displayName,
+            userIcon: contactDetails.largeImage,
+            userIsEnsVerified: contactDetails.ensVerified,
+            "header.title": qsTr("Verify %1's Identity").arg(contactDetails.displayName),
+            challengeText: qsTr("Ask a question that only the real %1 will be able to answer e.g. a question about a shared experience, or ask %1 to enter a code or phrase you have sent to them via a different communication channel (phone, post, etc...).").arg(contactDetails.displayName),
+            buttonText: qsTr("Send verification request")
+        })
+        if (cb)
+            cb(popup)
+    }
+
+    function openOutgoingIDRequestPopup(publicKey, cb) {
+        try {
+            const verificationDetails = root.rootStore.profileSectionStore.contactsStore.getSentVerificationDetailsAsJson(publicKey)
+            const popupProperties = {
+                userPublicKey: publicKey,
+                verificationStatus: verificationDetails.requestStatus,
+                verificationChallenge: verificationDetails.challenge,
+                verificationResponse: verificationDetails.response,
+                verificationResponseDisplayName: verificationDetails.displayName,
+                verificationResponseIcon: verificationDetails.icon,
+                verificationRequestedAt: verificationDetails.requestedAt,
+                verificationRepliedAt: verificationDetails.repliedAt
+            }
+            const popup = Global.openPopup(contactOutgoingVerificationRequestPopupComponent, popupProperties)
+            if (cb)
+                cb(popup)
+        } catch (e) {
+            console.error("Error getting or parsing verification data", e)
+        }
+    }
+
+    function openIncomingIDRequestPopup(publicKey, cb) {
+        try {
+            const request = root.rootStore.profileSectionStore.contactsStore.getVerificationDetailsFromAsJson(publicKey)
+            const popupProperties = {
+                senderPublicKey: request.from,
+                senderDisplayName: request.displayName,
+                senderIcon: request.icon,
+                challengeText: request.challenge,
+                responseText: request.response,
+                messageTimestamp: request.requestedAt,
+                responseTimestamp: request.repliedAt
+            }
+
+            const popup = Global.openPopup(contactVerificationRequestPopupComponent, popupProperties)
+            if (cb)
+                cb(popup)
+        } catch (e) {
+            console.error("Error getting or parsing verification data", e)
+        }
+    }
+
+    function openInviteFriendsToCommunityPopup(community, communitySectionModule, cb) {
+        const popup = Global.openPopup(inviteFriendsToCommunityPopup, { community, communitySectionModule })
+        if (cb)
+            cb(popup)
+    }
+
+    function openContactRequestPopup(publicKey, cb) {
+        const contactDetails = Utils.getContactDetailsAsJson(publicKey)
+        const popupProperties = {
+            userPublicKey: publicKey,
+            userDisplayName: contactDetails.displayName,
+            userIcon: contactDetails.largeImage,
+            userIsEnsVerified: contactDetails.ensVerified
+        }
+
+        const popup = Global.openPopup(sendContactRequestPopupComponent, popupProperties)
+        if (cb)
+            cb(popup)
+    }
+
+    readonly property list<Component> _d: [
+        Component {
+            id: contactVerificationRequestPopupComponent
+            ContactVerificationRequestPopup {
+                onResponseSent: {
+                    root.rootStore.profileSectionStore.contactsStore.acceptVerificationRequest(senderPublicKey, response)
+                }
+                onVerificationRefused: {
+                    root.rootStore.profileSectionStore.contactsStore.declineVerificationRequest(senderPublicKey)
+                }
+                onClosed: destroy()
+            }
+        },
+
+        Component {
+            id: contactOutgoingVerificationRequestPopupComponent
+            OutgoingContactVerificationRequestPopup {
+                onVerificationRequestCanceled: {
+                    root.rootStore.profileSectionStore.contactsStore.cancelVerificationRequest(userPublicKey)
+                }
+                onUntrustworthyVerified: {
+                    root.rootStore.profileSectionStore.contactsStore.verifiedUntrustworthy(userPublicKey)
+                }
+                onTrustedVerified: {
+                    root.rootStore.profileSectionStore.contactsStore.verifiedTrusted(userPublicKey)
+                }
+                onClosed: destroy()
+            }
+        },
+
+        Component {
+            id: sendIDRequestPopupComponent
+            SendContactRequestModal {
+                anchors.centerIn: parent
+                onAccepted: root.rootStore.profileSectionStore.contactsStore.sendVerificationRequest(userPublicKey, message)
+                onClosed: destroy()
+            }
+        },
+
+        Component {
+            id: inviteFriendsToCommunityPopup
+
+            InviteFriendsToCommunityPopup {
+                anchors.centerIn: parent
+                rootStore: root.rootStore
+                contactsStore: root.rootStore.contactStore
+                onClosed: destroy()
+            }
+        },
+
+        Component {
+            id: sendContactRequestPopupComponent
+
+            SendContactRequestModal {
+                anchors.centerIn: parent
+                onAccepted: root.rootStore.profileSectionStore.contactsStore.sendContactRequest(userPublicKey, message)
+                onClosed: destroy()
+            }
+        }
+    ]
+}

--- a/ui/imports/Themes/Theme.qml
+++ b/ui/imports/Themes/Theme.qml
@@ -1,5 +1,4 @@
-import QtQuick 2.13
-import utils 1.0
+import QtQuick 2.14
 
 QtObject {
     readonly property FontLoader baseFont: FontLoader { source: "../../fonts/Inter/Inter-Regular.otf" }

--- a/ui/imports/shared/views/ProfileDialogView.qml
+++ b/ui/imports/shared/views/ProfileDialogView.qml
@@ -152,8 +152,8 @@ Pane {
             size: StatusButton.Size.Small
             text: qsTr("Send Contact Request")
             onClicked: {
-                let contactRequestPopup = Global.openContactRequestPopup(root.publicKey)
-                contactRequestPopup.accepted.connect(d.reload)
+                Global.openContactRequestPopup(root.publicKey,
+                                               popup => popup.accepted.connect(d.reload))
             }
         }
     }
@@ -205,8 +205,8 @@ Pane {
             size: StatusButton.Size.Small
             text: qsTr("Respond to ID Request")
             onClicked: {
-                let idRequestPopup = Global.openIncomingIDRequestPopup(root.publicKey)
-                idRequestPopup.closed.connect(d.reload)
+                Global.openIncomingIDRequestPopup(root.publicKey,
+                                                  popup => popup.closed.connect(d.reload))
             }
         }
     }
@@ -384,8 +384,8 @@ Pane {
                                  d.contactDetails.trustStatus === Constants.trustStatus.untrustworthy // we have an action button otherwise
                         onTriggered: {
                             moreMenu.close()
-                            let contactRequestPopup = Global.openContactRequestPopup(root.publicKey)
-                            contactRequestPopup.closed.connect(d.reload)
+                            Global.openContactRequestPopup(root.publicKey,
+                                                           popup => popup.closed.connect(d.reload))
                         }
                     }
                     StatusMenuItem {
@@ -396,8 +396,8 @@ Pane {
                                  !d.isVerificationRequestReceived
                         onTriggered: {
                             moreMenu.close()
-                            let idRequestPopup = Global.openSendIDRequestPopup(root.publicKey)
-                            idRequestPopup.accepted.connect(d.reload)
+                            Global.openSendIDRequestPopup(root.publicKey,
+                                                          popup => popup.accepted.connect(d.reload))
                         }
                     }
                     StatusMenuItem {
@@ -406,8 +406,8 @@ Pane {
                         enabled: d.isContact && !d.isBlocked && !d.isTrusted && d.isVerificationRequestSent
                         onTriggered: {
                             moreMenu.close()
-                            let idRequestPopup = Global.openOutgoingIDRequestPopup(root.publicKey)
-                            idRequestPopup.closed.connect(d.reload)
+                            Global.openOutgoingIDRequestPopup(root.publicKey,
+                                                              popup => popup.closed.connect(d.reload))
                         }
                     }
                     StatusMenuItem {


### PR DESCRIPTION
### What does the PR do

Having components definitions in singleton was enforcing loading popups code at very early stage, leading to some races. In 5.15 there are warnings about that. In 5.14 Storybook was hanging on loading some components e.g. `InviteFriendsToCommunityPopup`.

Closes: #7992