### PR TITLE
fix(InviteFriendsToCommunityPopup): Invite candidates list made scrollable

### DIFF
--- a/storybook/directorieswatcher.cpp
+++ b/storybook/directorieswatcher.cpp
@@ -13,7 +13,8 @@ DirectoriesWatcher::DirectoriesWatcher(QObject *parent)
 void DirectoriesWatcher::addPaths(const QStringList &paths)
 {
     for (auto& path : paths) {
-        QDirIterator it(path, QDir::AllDirs | QDir::NoDotAndDotDot, QDirIterator::Subdirectories);
+        QDirIterator it(path, QDir::AllDirs | QDir::NoDotAndDotDot,
+                        QDirIterator::Subdirectories);
 
         while (it.hasNext()) {
             const auto& subpath = it.filePath();

--- a/storybook/main.qml
+++ b/storybook/main.qml
@@ -47,6 +47,15 @@ ApplicationWindow {
         ListElement {
             title: "LanguageCurrencySettings"
         }
+        ListElement {
+            title: "CommunityProfilePopupInviteFriendsPanel"
+        }
+        ListElement {
+            title: "CommunityProfilePopupInviteMessagePanel"
+        }
+        ListElement {
+            title: "InviteFriendsToCommunityPopup"
+        }
     }
 
     SplitView {

--- a/storybook/pages/CommunityProfilePopupInviteFriendsPanelPage.qml
+++ b/storybook/pages/CommunityProfilePopupInviteFriendsPanelPage.qml
@@ -1,0 +1,89 @@
+import QtQuick 2.14
+import QtQuick.Controls 2.14
+
+import AppLayouts.Chat.panels.communities 1.0
+import utils 1.0
+
+Item {
+    property bool globalUtilsReady: false
+    property bool mainModuleReady: false
+
+    QtObject {
+        function getCompressedPk(publicKey) {
+            return "compressed"
+        }
+
+        function getColorHashAsJson(publicKey) {
+            return JSON.stringify([{colorId: 0, segmentLength: 1},
+                                   {colorId: 19, segmentLength: 2}])
+        }
+
+        Component.onCompleted: {
+            Utils.globalUtilsInst = this
+            globalUtilsReady = true
+
+        }
+        Component.onDestruction: {
+            globalUtilsReady = false
+            Utils.globalUtilsInst = {}
+        }
+    }
+
+    QtObject {
+        function getContactDetailsAsJson() {
+            return JSON.stringify({})
+        }
+
+        Component.onCompleted: {
+            mainModuleReady = true
+            Utils.mainModuleInst = this
+        }
+        Component.onDestruction: {
+            mainModuleReady = false
+            Utils.mainModuleInst = {}
+        }
+    }
+
+    Frame {
+        anchors.centerIn: parent
+
+        Loader {
+            active: globalUtilsReady && mainModuleReady
+            sourceComponent: CommunityProfilePopupInviteFriendsPanel {
+                id: panel
+
+                community: ({ id: "communityId" })
+
+                rootStore: QtObject {
+                    function communityHasMember(communityId, pubKey) {
+                        return false
+                    }
+                }
+
+                contactsStore: QtObject {
+                    readonly property ListModel myContactsModel: ListModel {
+                        Component.onCompleted: {
+                            const keys = []
+
+                            for (let i = 0; i < 20; i++) {
+                                const key = `pub_key_${i}`
+
+                                append({
+                                    alias: "",
+                                    colorId: "1",
+                                    displayName: `contact ${i}`,
+                                    ensName: "",
+                                    icon: "",
+                                    isContact: true,
+                                    localNickname: "",
+                                    onlineStatus: 1,
+                                    pubKey: key
+                                })
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/storybook/pages/CommunityProfilePopupInviteMessagePanelPage.qml
+++ b/storybook/pages/CommunityProfilePopupInviteMessagePanelPage.qml
@@ -1,0 +1,89 @@
+import QtQuick 2.14
+import QtQuick.Controls 2.14
+
+import AppLayouts.Chat.panels.communities 1.0
+import utils 1.0
+
+Item {
+    property bool globalUtilsReady: false
+    property bool mainModuleReady: false
+
+    QtObject {
+        function getCompressedPk(publicKey) {
+            return "compressed"
+        }
+
+        function getColorHashAsJson(publicKey) {
+            return JSON.stringify([{colorId: 0, segmentLength: 1},
+                                   {colorId: 19, segmentLength: 2}])
+        }
+
+        Component.onCompleted: {
+            Utils.globalUtilsInst = this
+            globalUtilsReady = true
+        }
+
+        Component.onDestruction: {
+            globalUtilsReady = false
+            Utils.globalUtilsInst = {}
+        }
+    }
+
+    QtObject {
+        function getContactDetailsAsJson() {
+            return JSON.stringify({})
+        }
+
+        Component.onCompleted: {
+            Utils.mainModuleInst = this
+            mainModuleReady = true
+        }
+
+        Component.onDestruction: {
+            mainModuleReady = false
+            Utils.mainModuleInst = {}
+        }
+    }
+
+    Frame {
+        anchors.centerIn: parent
+
+        height: parent.height * 0.8
+        width: parent.width * 0.8
+
+        Loader {
+            active: globalUtilsReady && mainModuleReady
+
+            anchors.fill: parent
+
+            sourceComponent: CommunityProfilePopupInviteMessagePanel {
+                id: panel
+
+                contactsStore: QtObject {
+                    readonly property ListModel myContactsModel: ListModel {
+                        Component.onCompleted: {
+                            const keys = []
+
+                            for (let i = 0; i < 20; i++) {
+                                const key = `pub_key_${i}`
+
+                                append({
+                                    isContact: true,
+                                    onlineStatus: 1,
+                                    displayName: `contact ${i}`,
+                                    icon: "",
+                                    colorId: "1",
+                                    pubKey: key
+                                })
+
+                                keys.push(key)
+                            }
+
+                            panel.pubKeys = keys
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/storybook/pages/InviteFriendsToCommunityPopupPage.qml
+++ b/storybook/pages/InviteFriendsToCommunityPopupPage.qml
@@ -1,0 +1,96 @@
+import QtQuick 2.14
+
+import AppLayouts.Chat.popups 1.0
+import utils 1.0
+
+Item {
+    Rectangle {
+        color: 'lightgray'
+        anchors.fill: parent
+    }
+
+    property bool globalUtilsReady: false
+    property bool mainModuleReady: false
+
+    QtObject {
+        function getCompressedPk(publicKey) {
+            return "compressed"
+        }
+
+        function getColorHashAsJson(publicKey) {
+            return JSON.stringify([{colorId: 0, segmentLength: 1},
+                                   {colorId: 19, segmentLength: 2}])
+        }
+
+        Component.onCompleted: {
+            Utils.globalUtilsInst = this
+            globalUtilsReady = true
+
+        }
+        Component.onDestruction: {
+            globalUtilsReady = false
+            Utils.globalUtilsInst = {}
+        }
+    }
+
+    QtObject {
+        function getContactDetailsAsJson() {
+            return JSON.stringify({})
+        }
+
+        Component.onCompleted: {
+            mainModuleReady = true
+            Utils.mainModuleInst = this
+        }
+        Component.onDestruction: {
+            mainModuleReady = false
+            Utils.mainModuleInst = {}
+        }
+    }
+
+    Loader {
+        active: globalUtilsReady && mainModuleReady
+        anchors.fill: parent
+
+        sourceComponent: InviteFriendsToCommunityPopup {
+            parent: parent
+            modal: false
+            anchors.centerIn: parent
+
+            community: ({
+                id: "communityId",
+                name: "community-name"
+            })
+
+            rootStore: QtObject {
+                function communityHasMember(communityId, pubKey) {
+                    return false
+                }
+            }
+
+            contactsStore: QtObject {
+                readonly property ListModel myContactsModel: ListModel {
+                    Component.onCompleted: {
+                        for (let i = 0; i < 20; i++) {
+                            const key = `pub_key_${i}`
+
+                            append({
+                                alias: "",
+                                colorId: "1",
+                                displayName: `contact ${i}`,
+                                ensName: "",
+                                icon: "",
+                                isContact: true,
+                                localNickname: "",
+                                onlineStatus: 1,
+                                pubKey: key
+                            })
+                        }
+                    }
+                }
+            }
+
+            Component.onCompleted: open()
+        }
+    }
+}

--- a/storybook/src/Storybook/LogsView.qml
+++ b/storybook/src/Storybook/LogsView.qml
@@ -1,7 +1,5 @@
 import QtQuick 2.14
 
-import StatusQ.Core.Theme 0.1
-
 Flickable {
     id: root
 
@@ -17,7 +15,7 @@ Flickable {
 
     TextEdit {
         id: logTextEdit
-        font.family: Theme.palette.monoFont.name
+        font.family: "courier"
         font.letterSpacing: 1.2
         readOnly: true
         selectByMouse: true

--- a/ui/app/AppLayouts/Chat/panels/communities/CommunityProfilePopupInviteMessagePanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/CommunityProfilePopupInviteMessagePanel.qml
@@ -58,7 +58,6 @@ ColumnLayout {
 
     PickedContacts {
         id: existingContacts
-        enabled: false
         contactsStore: root.contactsStore
         pubKeys: root.pubKeys
         Layout.fillWidth: true

--- a/ui/app/AppLayouts/Chat/panels/communities/qmldir
+++ b/ui/app/AppLayouts/Chat/panels/communities/qmldir
@@ -1,0 +1,2 @@
+CommunityProfilePopupInviteFriendsPanel 1.0 CommunityProfilePopupInviteFriendsPanel.qml
+CommunityProfilePopupInviteMessagePanel 1.0 CommunityProfilePopupInviteMessagePanel.qml

--- a/ui/app/AppLayouts/Chat/popups/community/InviteFriendsToCommunityPopup.qml
+++ b/ui/app/AppLayouts/Chat/popups/community/InviteFriendsToCommunityPopup.qml
@@ -52,6 +52,8 @@ StatusStackModal {
     stackTitle: qsTr("Invite Contacts to %1").arg(community.name)
     width: 640
     implicitHeight: 700
+
+    padding: 0
     leftPadding: 0
     rightPadding: 0
 
@@ -82,18 +84,28 @@ StatusStackModal {
     }
 
     stackItems: [
-        CommunityProfilePopupInviteFriendsPanel {
-            width: parent.width
-            rootStore: root.rootStore
-            contactsStore: root.contactsStore
-            community: root.community
-            onPubKeysChanged: root.pubKeys = pubKeys
+        Item {
+            CommunityProfilePopupInviteFriendsPanel {
+                anchors.fill: parent
+                anchors.topMargin: 16
+                anchors.bottomMargin: 16
+
+                rootStore: root.rootStore
+                contactsStore: root.contactsStore
+                community: root.community
+                onPubKeysChanged: root.pubKeys = pubKeys
+            }
         },
-        CommunityProfilePopupInviteMessagePanel {
-            width: parent.width
-            contactsStore: root.contactsStore
-            pubKeys: root.pubKeys
-            onInviteMessageChanged: root.inviteMessage = inviteMessage
+
+        Item {
+            CommunityProfilePopupInviteMessagePanel {
+                anchors.fill: parent
+                anchors.topMargin: 16
+
+                contactsStore: root.contactsStore
+                pubKeys: root.pubKeys
+                onInviteMessageChanged: root.inviteMessage = inviteMessage
+            }
         }
     ]
 }

--- a/ui/imports/shared/views/PickedContacts.qml
+++ b/ui/imports/shared/views/PickedContacts.qml
@@ -30,9 +30,6 @@ Item {
         return parts.some(p => p.startsWith(filter))
     }
 
-    implicitWidth: contactGridView.implicitWidth + contactGridView.margins
-    implicitHeight: visible ? contactGridView.contentHeight : 0
-
     StatusGridView {
         id: contactGridView
         anchors.fill: parent
@@ -65,6 +62,8 @@ Item {
             statusListItemIcon.badge.border.color: Theme.palette.baseColor4
             statusListItemIcon.badge.implicitHeight: 14 // 10 px + 2 px * 2 borders
             statusListItemIcon.badge.implicitWidth: 14 // 10 px + 2 px * 2 borders
+
+            sensor.enabled: false
         }
     }
 }


### PR DESCRIPTION
### What does the PR do

Invite candidates list made scrollable. Additionally, bottom padding is fixed to avoid cutting-off the list
too early. Relevant components are added to the Storybook.

Closes: #8004 
Closes: #7603 

### Affected areas

`Storybook`, `InviteFriendsToCommunityPopup`

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

[Kazam_screencast_00073.webm](https://user-images.githubusercontent.com/20650004/197735150-5e5b3695-85e7-45d1-be35-103cc7d6e7ae.webm)
