### PR TITLE
fix(StatusMessage): Reduced top+bottom margins based on figma spec

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
@@ -209,8 +209,8 @@ Rectangle {
     ColumnLayout {
         id: messageLayout
         anchors.fill: parent
-        anchors.topMargin: 8
-        anchors.bottomMargin: 8
+        anchors.topMargin: 2
+        anchors.bottomMargin: 2
 
         Loader {
             Layout.fillWidth: true


### PR DESCRIPTION
Closes #7318

### What does the PR do
StatusMessage - reduces top+bottom margins to 2px based on figma spec

### Affected areas
StatusMessage

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it
<img width="458" alt="figma" src="https://user-images.githubusercontent.com/31625338/197806298-98899ed0-710f-4c60-a270-a40ab9eb2572.png">

<img width="643" alt="26" src="https://user-images.githubusercontent.com/31625338/197806326-4a8ab6fd-6b26-46ad-bc1f-6901f1ce2821.png">
