### PR TITLE
fix(ProfileDialogView): hide contact request buttons when removed

### DIFF
--- a/ui/app/AppLayouts/Chat/panels/communities/CommunityWelcomeBannerPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/CommunityWelcomeBannerPanel.qml
@@ -89,7 +89,8 @@ Rectangle {
         anchors.topMargin: Style.current.padding
         onClicked: {
             Global.openInviteFriendsToCommunityPopup(root.activeCommunity,
-                                                     root.communitySectionModule)
+                                                     root.communitySectionModule,
+                                                     null)
         }
     }
 

--- a/ui/app/AppLayouts/Chat/views/CommunityColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/CommunityColumnView.qml
@@ -192,7 +192,8 @@ Item {
             enabled: communityData.canManageUsers && adminPopupMenu.showInviteButton
             onTriggered: {
                 Global.openInviteFriendsToCommunityPopup(root.communityData,
-                                                         root.communitySectionModule)
+                                                         root.communitySectionModule,
+                                                         null)
             }
         }
     }
@@ -267,7 +268,8 @@ Item {
                     enabled: communityData.canManageUsers
                     onTriggered: {
                         Global.openInviteFriendsToCommunityPopup(root.communityData,
-                                                                 root.communitySectionModule)
+                                                                 root.communitySectionModule,
+                                                                 null)
                     }
                 }
             }

--- a/ui/app/AppLayouts/Chat/views/CommunitySettingsView.qml
+++ b/ui/app/AppLayouts/Chat/views/CommunitySettingsView.qml
@@ -209,7 +209,8 @@ StatusSectionLayout {
 
                 onInviteNewPeopleClicked: {
                     Global.openInviteFriendsToCommunityPopup(root.community,
-                                                             root.chatCommunitySectionModule)
+                                                             root.chatCommunitySectionModule,
+                                                             null)
                 }
 
                 onAirdropTokensClicked: { /* TODO in future */ }

--- a/ui/app/AppLayouts/Profile/views/CommunitiesView.qml
+++ b/ui/app/AppLayouts/Profile/views/CommunitiesView.qml
@@ -69,7 +69,8 @@ SettingsContentBase {
 
                 onInviteFriends: {
                     Global.openInviteFriendsToCommunityPopup(communityData,
-                                                             root.profileSectionStore.communitiesProfileModule)
+                                                             root.profileSectionStore.communitiesProfileModule,
+                                                             null)
                 }
             }
 

--- a/ui/app/AppLayouts/Profile/views/ContactsView.qml
+++ b/ui/app/AppLayouts/Profile/views/ContactsView.qml
@@ -207,7 +207,7 @@ SettingsContentBase {
                     }
 
                     onShowVerificationRequest: {
-                        Global.openIncomingIDRequestPopup(publicKey)
+                        Global.openIncomingIDRequestPopup(publicKey, null)
                     }
                 }
 

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -383,7 +383,8 @@ Item {
                         enabled: model.canManageUsers
                         onTriggered: {
                             Global.openInviteFriendsToCommunityPopup(model,
-                                                                     communityContextMenu.chatCommunitySectionModule)
+                                                                     communityContextMenu.chatCommunitySectionModule,
+                                                                     null)
                         }
                     }
 

--- a/ui/imports/shared/views/ProfileDialogView.qml
+++ b/ui/imports/shared/views/ProfileDialogView.qml
@@ -329,7 +329,7 @@ Pane {
                         return txtPendingContactRequestComponent
 
                     // contact request, incoming, pending
-                    if (!d.isContact && d.isContactRequestReceived)
+                    if (!d.isContact && d.isContactRequestReceived && !d.contactDetails.removed)
                         return btnAcceptContactRequestComponent
 
                     // contact request, incoming, rejected

--- a/ui/imports/shared/views/chat/MessageContextMenuView.qml
+++ b/ui/imports/shared/views/chat/MessageContextMenuView.qml
@@ -61,7 +61,7 @@ StatusPopupMenu {
     readonly property bool isContact: {
         return root.selectedUserPublicKey !== "" && !!contactDetails.isContact
     }
-    readonly property bool isBlockedContact: !!d.contactDetails && d.contactDetails.isBlocked
+    readonly property bool isBlockedContact: (!!d.contactDetails && d.contactDetails.isBlocked) || false
 
     readonly property int outgoingVerificationStatus: {
         if (root.selectedUserPublicKey === "" || root.isMe || !root.isContact) {
@@ -197,7 +197,7 @@ StatusPopupMenu {
                                                                       : Constants.trustStatus.unknown
         isContact: root.isContact
         isCurrentUser: root.isMe
-        userIsEnsVerified: !!d.contactDetails && d.contactDetails.ensVerified
+        userIsEnsVerified: (!!d.contactDetails && d.contactDetails.ensVerified) || false
     }
 
     Item {
@@ -256,7 +256,7 @@ StatusPopupMenu {
         enabled: root.isProfile && !root.isMe && !root.isContact
                                 && !root.isBlockedContact && !root.hasPendingContactRequest
         onTriggered: {
-            Global.openContactRequestPopup(root.selectedUserPublicKey)
+            Global.openContactRequestPopup(root.selectedUserPublicKey, null)
             root.close()
         }
     }
@@ -269,7 +269,7 @@ StatusPopupMenu {
                                 && root.outgoingVerificationStatus === Constants.verificationStatus.unverified
                                 && !root.hasReceivedVerificationRequestFrom
         onTriggered: {
-            Global.openSendIDRequestPopup(root.selectedUserPublicKey)
+            Global.openSendIDRequestPopup(root.selectedUserPublicKey, null)
             root.close()
         }
     }
@@ -286,9 +286,9 @@ StatusPopupMenu {
                                     || root.isVerificationRequestSent)
         onTriggered: {
             if (hasReceivedVerificationRequestFrom) {
-                Global.openIncomingIDRequestPopup(root.selectedUserPublicKey)
+                Global.openIncomingIDRequestPopup(root.selectedUserPublicKey, null)
             } else if (root.isVerificationRequestSent) {
-                Global.openOutgoingIDRequestPopup(root.selectedUserPublicKey)
+                Global.openOutgoingIDRequestPopup(root.selectedUserPublicKey, null)
             }
 
             root.close()


### PR DESCRIPTION
We were showing the contact request buttons (accept or reject) in the profile popup even when the user had removed the other.

It would be better if we had better handling of contact requests with more statuses. This requires a refactor. This issue should cover it: https://github.com/status-im/status-desktop/issues/7734