### PR TITLE
fix(contacts): retract the contact request when removing a contact

### DIFF
--- a/src/app_service/service/contacts/service.nim
+++ b/src/app_service/service/contacts/service.nim
@@ -490,6 +490,10 @@ QtObject:
 
   proc removeContact*(self: Service, publicKey: string) =
     var contact = self.getContactById(publicKey)
+
+    if contact.added:
+      discard status_contacts.retractContactRequest(publicKey)
+
     contact.removed = true
     contact.added = false
 

--- a/src/backend/contacts.nim
+++ b/src/backend/contacts.nim
@@ -102,3 +102,9 @@ proc getReceivedVerificationRequests*(): RpcResponse[JsonNode] {.raises: [Except
 proc cancelVerificationRequest*(pubkey: string): RpcResponse[JsonNode] {.raises: [Exception].} =
   let payload = %* [pubkey]
   result = callPrivateRPC("cancelVerificationRequest".prefix, payload)
+
+proc retractContactRequest*(pubkey: string): RpcResponse[JsonNode] {.raises: [Exception].} =
+  let payload = %*[{
+    "contactId": pubkey
+  }]
+  result = callPrivateRPC("retractContactRequest".prefix, payload)


### PR DESCRIPTION
Fixes #7791

Adds the retractContactRequest status-go api call. Calling it when removing a contact makes sure to send a signal to that other user so they can understand that we are no longer mutual contacts or don't have a request anymore

(sorry for the bad branch names. I was fixing the #7791 issue and found some small bugs in doing so and I split my PRs accordingly but forgot to rename the branch for those :shrug: )