### PR TITLE
fix(MessageView): unbreak message reply update and found animation

### DIFF
--- a/ui/app/mainui/activitycenter/views/ActivityNotificationMessage.qml
+++ b/ui/app/mainui/activitycenter/views/ActivityNotificationMessage.qml
@@ -41,7 +41,6 @@ ActivityNotificationBase {
         activityCenterMessage: true
         activityCenterMessageRead: false
         onImageClicked: Global.openImagePopup(image, root.messageContextMenu)
-        scrollToBottom: null
         messageClickHandler: (sender, 
                               point,
                               isProfileClick,


### PR DESCRIPTION
due to the refactor, StatusMessage is no longer the toplevel item inside the delegate, so adjust the functions

some minor cleanups and dead code removals; striving for keeping the number of properties and bindings inside a ListView delegate at a minimum

### Affected areas

MessageView

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

Message reply + original msg edited:
![image](https://user-images.githubusercontent.com/5377645/197970997-5570bbc2-bf32-4270-940f-faf1a386eed3.png)

