### PR TITLE
fix(MessageView): unbreak showing identity ring in replies

### DIFF
--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -643,8 +643,8 @@ Loader {
                         width: 20
                         height: 20
                         name: delegate.replyMessage ? delegate.replyMessage.senderIcon : ""
-                        assetSettings.isImage: delegate.replyMessage && (delegate.replyMessage.messageContentType == Constants.discordMessageType || delegate.replyMessage.senderIcon.startsWith("data"))
-                        showRing: delegate.replyMessage && delegate.replyMessage.messageContentType != Constants.discordMessageType
+                        assetSettings.isImage: delegate.replyMessage && (delegate.replyMessage.contentType === Constants.messageContentType.discordMessageType || delegate.replyMessage.senderIcon.startsWith("data"))
+                        showRing: delegate.replyMessage && delegate.replyMessage.contentType !== Constants.messageContentType.discordMessageType
                         pubkey: delegate.replySenderId
                         colorId: Utils.colorIdForPubkey(delegate.replySenderId)
                         colorHash: Utils.getColorHashAsJson(delegate.replySenderId, false, !root.isDiscordMessage)


### PR DESCRIPTION
use the correct way to get the original message's content type and compare it with the correct Constant type

### What does the PR do

Fixes a bug when color ring was never shown in replies

### Affected areas

MessageView

### Screenshot of functionality (including design for comparison)

- [X] I've checked the design and this PR matches it

Before the fix (watch Michal's ring in the middle):
![Snímek obrazovky z 2022-10-26 11-22-34](https://user-images.githubusercontent.com/5377645/197990243-2adb0c2b-c3b2-4eb1-a19e-c20911a6943e.png)

After fix (Michal's ring in the reply is correct, cammellos' still correct too):
![Snímek obrazovky z 2022-10-26 11-21-34](https://user-images.githubusercontent.com/5377645/197990254-5239a40f-2bbf-4ecf-8dd9-33fc8855335b.png)
