### PR TITLE
ci: add deleteDirs:true for cleanWs to fix cleanup

### DIFF
--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -96,6 +96,6 @@ pipeline {
   post {
     success { script { github.notifyPR(true) } }
     failure { script { github.notifyPR(false) } }
-    always { cleanWs() }
+    cleanup { cleanWs() }
   }
 }

--- a/ci/Jenkinsfile.linux-cpp
+++ b/ci/Jenkinsfile.linux-cpp
@@ -85,6 +85,6 @@ pipeline {
   post {
     success { script { github.notifyPR(true) } }
     failure { script { github.notifyPR(false) } }
-    always { cleanWs() }
+    cleanup { cleanWs() }
   }
 }

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -108,6 +108,6 @@ pipeline {
   post {
     success { script { github.notifyPR(true) } }
     failure { script { github.notifyPR(false) } }
-    always { cleanWs() }
+    cleanup { cleanWs() }
   }
 }

--- a/ci/Jenkinsfile.macos-cpp.todo
+++ b/ci/Jenkinsfile.macos-cpp.todo
@@ -77,6 +77,6 @@ pipeline {
   post {
     success { script { github.notifyPR(true) } }
     failure { script { github.notifyPR(false) } }
-    always { cleanWs() }
+    cleanup { cleanWs() }
   }
 }

--- a/ci/Jenkinsfile.uitests
+++ b/ci/Jenkinsfile.uitests
@@ -144,6 +144,6 @@ pipeline {
   post {
     success { script { github.notifyPR(true) } }
     failure { script { github.notifyPR(false) } }
-    always { cleanWs() }
+    cleanup { cleanWs() }
   }
 }

--- a/ci/Jenkinsfile.windows
+++ b/ci/Jenkinsfile.windows
@@ -99,6 +99,6 @@ pipeline {
   post {
     success { script { github.notifyPR(true) } }
     failure { script { github.notifyPR(false) } }
-    cleanup { cleanWs(disableDeferredWipeout: true) }
+    cleanup { cleanWs(disableDeferredWipeout: true, deleteDirs: true) }
   }
 }

--- a/ci/Jenkinsfile.windows
+++ b/ci/Jenkinsfile.windows
@@ -99,6 +99,6 @@ pipeline {
   post {
     success { script { github.notifyPR(true) } }
     failure { script { github.notifyPR(false) } }
-    always { cleanWs(disableDeferredWipeout: true) }
+    cleanup { cleanWs(disableDeferredWipeout: true) }
   }
 }

--- a/ci/Jenkinsfile.windows-cpp.todo
+++ b/ci/Jenkinsfile.windows-cpp.todo
@@ -78,6 +78,6 @@ pipeline {
   post {
     success { script { github.notifyPR(true) } }
     failure { script { github.notifyPR(false) } }
-    always { cleanWs() }
+    cleanup { cleanWs() }
   }
 }


### PR DESCRIPTION
This is a continuation of a fix done in: https://github.com/status-im/status-desktop/pull/7968

This adds `deleteDirs` option to delete the whole workspace:

>When deferred wipeout is disabled, the old implementation of filesystem content deletion is used. If you want the same behavior as with deferred wipeout, you have to set the plugin attribute `deleteDirs` to true as well.

https://github.com/jenkinsci/ws-cleanup-plugin#deferred-wipeout

Because otherwise the `vendor` folder remains and causes issues when `.git` is a file.

Also use `cleanup` instead of `always` step in post section.
https://www.jenkins.io/doc/book/pipeline/syntax/#post