### PR TITLE
fix(@desktop): Fix optional parametr in signals

### DIFF
--- a/ui/app/AppLayouts/Chat/panels/communities/CommunityWelcomeBannerPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/CommunityWelcomeBannerPanel.qml
@@ -89,7 +89,8 @@ Rectangle {
         anchors.topMargin: Style.current.padding
         onClicked: {
             Global.openInviteFriendsToCommunityPopup(root.activeCommunity,
-                                                     root.communitySectionModule)
+                                                     root.communitySectionModule,
+                                                     null)
         }
     }
 

--- a/ui/app/AppLayouts/Chat/views/CommunityColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/CommunityColumnView.qml
@@ -192,7 +192,8 @@ Item {
             enabled: communityData.canManageUsers && adminPopupMenu.showInviteButton
             onTriggered: {
                 Global.openInviteFriendsToCommunityPopup(root.communityData,
-                                                         root.communitySectionModule)
+                                                         root.communitySectionModule,
+                                                         null)
             }
         }
     }
@@ -267,7 +268,8 @@ Item {
                     enabled: communityData.canManageUsers
                     onTriggered: {
                         Global.openInviteFriendsToCommunityPopup(root.communityData,
-                                                                 root.communitySectionModule)
+                                                                 root.communitySectionModule,
+                                                                 null)
                     }
                 }
             }

--- a/ui/app/AppLayouts/Chat/views/CommunitySettingsView.qml
+++ b/ui/app/AppLayouts/Chat/views/CommunitySettingsView.qml
@@ -209,7 +209,8 @@ StatusSectionLayout {
 
                 onInviteNewPeopleClicked: {
                     Global.openInviteFriendsToCommunityPopup(root.community,
-                                                             root.chatCommunitySectionModule)
+                                                             root.chatCommunitySectionModule,
+                                                             null)
                 }
 
                 onAirdropTokensClicked: { /* TODO in future */ }

--- a/ui/app/AppLayouts/Profile/views/CommunitiesView.qml
+++ b/ui/app/AppLayouts/Profile/views/CommunitiesView.qml
@@ -69,7 +69,8 @@ SettingsContentBase {
 
                 onInviteFriends: {
                     Global.openInviteFriendsToCommunityPopup(communityData,
-                                                             root.profileSectionStore.communitiesProfileModule)
+                                                             root.profileSectionStore.communitiesProfileModule,
+                                                             null)
                 }
             }
 

--- a/ui/app/AppLayouts/Profile/views/ContactsView.qml
+++ b/ui/app/AppLayouts/Profile/views/ContactsView.qml
@@ -207,7 +207,7 @@ SettingsContentBase {
                     }
 
                     onShowVerificationRequest: {
-                        Global.openIncomingIDRequestPopup(publicKey)
+                        Global.openIncomingIDRequestPopup(publicKey, null)
                     }
                 }
 

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -383,7 +383,8 @@ Item {
                         enabled: model.canManageUsers
                         onTriggered: {
                             Global.openInviteFriendsToCommunityPopup(model,
-                                                                     communityContextMenu.chatCommunitySectionModule)
+                                                                     communityContextMenu.chatCommunitySectionModule,
+                                                                     null)
                         }
                     }
 

--- a/ui/app/mainui/Popups.qml
+++ b/ui/app/mainui/Popups.qml
@@ -10,7 +10,7 @@ QtObject {
 
     /* required */ property var rootStore
 
-    function openSendIDRequestPopup(publicKey, cb) {
+    function openSendIDRequestPopup(publicKey, callback = null) {
         const contactDetails = Utils.getContactDetailsAsJson(publicKey)
         const popup = Global.openPopup(sendIDRequestPopupComponent, {
             userPublicKey: publicKey,
@@ -21,11 +21,11 @@ QtObject {
             challengeText: qsTr("Ask a question that only the real %1 will be able to answer e.g. a question about a shared experience, or ask %1 to enter a code or phrase you have sent to them via a different communication channel (phone, post, etc...).").arg(contactDetails.displayName),
             buttonText: qsTr("Send verification request")
         })
-        if (cb)
-            cb(popup)
+        if (callback)
+            callback(popup)
     }
 
-    function openOutgoingIDRequestPopup(publicKey, cb) {
+    function openOutgoingIDRequestPopup(publicKey, callback = null) {
         try {
             const verificationDetails = root.rootStore.profileSectionStore.contactsStore.getSentVerificationDetailsAsJson(publicKey)
             const popupProperties = {
@@ -39,14 +39,14 @@ QtObject {
                 verificationRepliedAt: verificationDetails.repliedAt
             }
             const popup = Global.openPopup(contactOutgoingVerificationRequestPopupComponent, popupProperties)
-            if (cb)
-                cb(popup)
+            if (callback)
+                callback(popup)
         } catch (e) {
             console.error("Error getting or parsing verification data", e)
         }
     }
 
-    function openIncomingIDRequestPopup(publicKey, cb) {
+    function openIncomingIDRequestPopup(publicKey, callback = null) {
         try {
             const request = root.rootStore.profileSectionStore.contactsStore.getVerificationDetailsFromAsJson(publicKey)
             const popupProperties = {
@@ -60,20 +60,20 @@ QtObject {
             }
 
             const popup = Global.openPopup(contactVerificationRequestPopupComponent, popupProperties)
-            if (cb)
-                cb(popup)
+            if (callback)
+                callback(popup)
         } catch (e) {
             console.error("Error getting or parsing verification data", e)
         }
     }
 
-    function openInviteFriendsToCommunityPopup(community, communitySectionModule, cb) {
+    function openInviteFriendsToCommunityPopup(community, communitySectionModule, callback = null) {
         const popup = Global.openPopup(inviteFriendsToCommunityPopup, { community, communitySectionModule })
-        if (cb)
-            cb(popup)
+        if (callback)
+            callback(popup)
     }
 
-    function openContactRequestPopup(publicKey, cb) {
+    function openContactRequestPopup(publicKey, callback = null) {
         const contactDetails = Utils.getContactDetailsAsJson(publicKey)
         const popupProperties = {
             userPublicKey: publicKey,
@@ -83,8 +83,8 @@ QtObject {
         }
 
         const popup = Global.openPopup(sendContactRequestPopupComponent, popupProperties)
-        if (cb)
-            cb(popup)
+        if (callback)
+            callback(popup)
     }
 
     readonly property list<Component> _d: [

--- a/ui/imports/shared/views/chat/MessageContextMenuView.qml
+++ b/ui/imports/shared/views/chat/MessageContextMenuView.qml
@@ -256,7 +256,7 @@ StatusPopupMenu {
         enabled: root.isProfile && !root.isMe && !root.isContact
                                 && !root.isBlockedContact && !root.hasPendingContactRequest
         onTriggered: {
-            Global.openContactRequestPopup(root.selectedUserPublicKey)
+            Global.openContactRequestPopup(root.selectedUserPublicKey, null)
             root.close()
         }
     }
@@ -269,7 +269,7 @@ StatusPopupMenu {
                                 && root.outgoingVerificationStatus === Constants.verificationStatus.unverified
                                 && !root.hasReceivedVerificationRequestFrom
         onTriggered: {
-            Global.openSendIDRequestPopup(root.selectedUserPublicKey)
+            Global.openSendIDRequestPopup(root.selectedUserPublicKey, null)
             root.close()
         }
     }
@@ -286,9 +286,9 @@ StatusPopupMenu {
                                     || root.isVerificationRequestSent)
         onTriggered: {
             if (hasReceivedVerificationRequestFrom) {
-                Global.openIncomingIDRequestPopup(root.selectedUserPublicKey)
+                Global.openIncomingIDRequestPopup(root.selectedUserPublicKey, null)
             } else if (root.isVerificationRequestSent) {
-                Global.openOutgoingIDRequestPopup(root.selectedUserPublicKey)
+                Global.openOutgoingIDRequestPopup(root.selectedUserPublicKey, null)
             }
 
             root.close()

--- a/ui/imports/utils/Global.qml
+++ b/ui/imports/utils/Global.qml
@@ -49,15 +49,15 @@ QtObject {
     signal openEditDisplayNamePopup()
     signal openActivityCenterPopupRequested
 
-    signal openContactRequestPopup(string publicKey, var cb)
+    signal openContactRequestPopup(string publicKey, var callback)
 
-    signal openInviteFriendsToCommunityPopup(var community, var communitySectionModule, var cb)
+    signal openInviteFriendsToCommunityPopup(var community, var communitySectionModule, var callback)
 
-    signal openSendIDRequestPopup(string publicKey, var cb)
+    signal openSendIDRequestPopup(string publicKey, var callback)
 
-    signal openIncomingIDRequestPopup(string publicKey, var cb)
+    signal openIncomingIDRequestPopup(string publicKey, var callback)
 
-    signal openOutgoingIDRequestPopup(string publicKey, var cb)
+    signal openOutgoingIDRequestPopup(string publicKey, var callback)
 
     function openProfilePopup(publicKey, parentPopup) {
         openProfilePopupRequested(publicKey, parentPopup)


### PR DESCRIPTION
Closes: #8048

### What does the PR do

QML Signals can't have "optional" parameters. I add `null` to every signal calls with `cb` (and rename it to `callback`).

### Affected areas

Popups

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

