### PR TITLE
fix: consecutive discord messages should be grouped like status messages

### DIFF
--- a/src/app/modules/shared_models/message_item.nim
+++ b/src/app/modules/shared_models/message_item.nim
@@ -134,6 +134,7 @@ proc initItem*(
 
   if ContentType.DiscordMessage == contentType:
     result.messageText = discordMessage.content
+    result.senderId = discordMessage.author.id
     result.senderDisplayName = discordMessage.author.name
     result.senderIcon = discordMessage.author.localUrl
     result.timestamp = parseInt(discordMessage.timestamp)*1000

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -90,7 +90,7 @@ Loader {
     property double prevMsgTimestamp: prevMessageAsJsonObj ? prevMessageAsJsonObj.timestamp : 0
     property double nextMsgTimestamp: nextMessageAsJsonObj ? nextMessageAsJsonObj.timestamp : 0
 
-    property bool shouldRepeatHeader: ((messageTimestamp - prevMsgTimestamp) / 60 / 1000) > Constants.repeatHeaderInterval || isDiscordMessage
+    property bool shouldRepeatHeader: ((messageTimestamp - prevMsgTimestamp) / 60 / 1000) > Constants.repeatHeaderInterval
 
     property bool hasMention: false
 

--- a/ui/imports/utils/Utils.qml
+++ b/ui/imports/utils/Utils.qml
@@ -562,13 +562,13 @@ QtObject {
     }
 
     function isEnsVerified(publicKey, getVerificationRequest=true) {
-        if (!publicKey)
-            return false
+        if (publicKey === "" || !isChatKey(publicKey) )
+            return
         return getContactDetailsAsJson(publicKey, getVerificationRequest).ensVerified
     }
 
     function getEmojiHashAsJson(publicKey) {
-        if (publicKey === "") {
+        if (publicKey === "" || !isChatKey(publicKey)) {
             return ""
         }
         let jsonObj = globalUtilsInst.getEmojiHashAsJson(publicKey)
@@ -576,7 +576,7 @@ QtObject {
     }
 
     function getColorHashAsJson(publicKey, force=false, getVerificationRequest=true) {
-        if (publicKey === "")
+        if (publicKey === "" || !isChatKey(publicKey) )
             return
         if (!force && isEnsVerified(publicKey, getVerificationRequest))
             return
@@ -585,7 +585,7 @@ QtObject {
     }
 
     function colorIdForPubkey(publicKey) {
-        if (publicKey === "") {
+        if (publicKey === "" || !isChatKey(publicKey)) {
             return 0
         }
         return globalUtilsInst.getColorId(publicKey)
@@ -608,6 +608,8 @@ QtObject {
         if (publicKey === "") {
             return ""
         }
+        if (!isChatKey(publicKey))
+            return publicKey
         return globalUtilsInst.getCompressedPk(publicKey)
     }
 


### PR DESCRIPTION
- fill the senderId just like other messages
- add some checks in Utils since the "publicKey" (ID) coming Discord isn't in the format we'd normally expect

Closes #6678

### What does the PR do

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas

MessageView

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

Imported community from Discord (read only):

![Snímek obrazovky z 2022-10-26 14-51-11](https://user-images.githubusercontent.com/5377645/198247187-22349cd8-b8e2-4eb5-bc42-66d508f26358.png)
