### PR TITLE
fix(@desktop/chat): If profile popup is opened close it before anothe…

### DIFF
--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -51,6 +51,8 @@ Item {
     // set from main.qml
     property var sysPalette
 
+    signal closeProfilePopup()
+
     Connections {
         target: rootStore.mainModuleInst
 
@@ -121,6 +123,9 @@ Item {
         }
 
         onOpenProfilePopupRequested: {
+            if (Global.profilePopupOpened) {
+                appMain.closeProfilePopup()
+            }
             Global.openPopup(profilePopupComponent, {publicKey: publicKey, parentPopup: parentPopup})
             Global.profilePopupOpened = true
         }
@@ -210,12 +215,17 @@ Item {
             id: profilePopup
             profileStore: appMain.rootStore.profileSectionStore.profileStore
             contactsStore: appMain.rootStore.profileSectionStore.contactsStore
+
             onClosed: {
                 if (profilePopup.parentPopup) {
                     profilePopup.parentPopup.close()
                 }
                 Global.profilePopupOpened = false
                 destroy()
+            }
+
+            Component.onCompleted: {
+                appMain.closeProfilePopup.connect(profilePopup.close)
             }
         }
     }


### PR DESCRIPTION
Fixes #6650

### What does the PR do

If profile popup is opened, close it before another opening.

### Affected areas

Profile popup

### Screenshot of functionality (including design for comparison)

https://user-images.githubusercontent.com/61889657/198257570-b2a5a18d-4969-480e-86fc-5acd6ca95de4.mov

