### PR TITLE
fix(@desktop/chat): Accept profile deep link in "Send Contact Request to chat key"

### DIFF
--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -444,12 +444,8 @@ QtObject {
         return result
     }
 
-    function isStatusDeepLink(link) {
-        return link.includes(Constants.deepLinkPrefix) || link.includes(Constants.joinStatusLink)
-    }
-
     function getLinkDataForStatusLinks(link) {
-        if (!isStatusDeepLink(link)) {
+        if (!Utils.isStatusDeepLink(link)) {
             return
         }
 

--- a/ui/app/AppLayouts/Profile/popups/SendContactRequestModal.qml
+++ b/ui/app/AppLayouts/Profile/popups/SendContactRequestModal.qml
@@ -56,6 +56,9 @@ StatusModal {
                 return
             }
 
+            if (Utils.isStatusDeepLink(text)) {
+                text = Utils.getChatKeyFromShareLink(text)
+            }
             Qt.callLater(d.lookupContact, text);
         }
     }

--- a/ui/imports/utils/Utils.qml
+++ b/ui/imports/utils/Utils.qml
@@ -451,6 +451,10 @@ QtObject {
         return matches[0].substring(3)
     }
 
+    function isStatusDeepLink(link) {
+        return link.includes(Constants.deepLinkPrefix) || link.includes(Constants.joinStatusLink)
+    }
+
     function hasImageExtension(url) {
         return Constants.acceptedImageExtensions.some(ext => url.toLowerCase().includes(ext))
     }
@@ -602,6 +606,14 @@ QtObject {
     function colorForPubkey(publicKey) {
         const pubKeyColorId = colorIdForPubkey(publicKey)
         return colorForColorId(pubKeyColorId)
+    }
+
+    function getChatKeyFromShareLink(link) {
+        let index = link.lastIndexOf("/u/")
+        if (index === -1) {
+            return link
+        }
+        return link.substring(index + 3)
     }
 
     function getCompressedPk(publicKey) {


### PR DESCRIPTION
Fix #8070

### What does the PR do

Accept a profile deep link in "Send Contact Request to chat key" in Settings/Messaging/Contacts

### Affected areas

Settings/Messaging/Contacts

### Screenshot of functionality (including design for comparison)

https://user-images.githubusercontent.com/61889657/198548143-40fda901-7ab3-4ff1-855c-62bdb34846ea.mov

