### PR TITLE
fix(BeforeGetStartedModal): fix padding and (line) spacings

### DIFF
--- a/ui/StatusQ/src/StatusQ/Controls/StatusCheckBox.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusCheckBox.qml
@@ -1,16 +1,15 @@
 import QtQuick 2.14
 import QtQuick.Controls 2.14
-import QtGraphicalEffects 1.14
 
 import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
-import StatusQ.Components 0.1
-
 
 CheckBox {
     id: root
 
     property bool leftSide: true
+
+    font.family: Theme.palette.baseFont.name
 
     indicator: Rectangle {
         anchors.left: root.leftSide? parent.left : undefined
@@ -36,12 +35,13 @@ CheckBox {
 
     contentItem: StatusBaseText {
         text: root.text
-        font.pixelSize: root.font.pixelSize
+        font: root.font
         opacity: enabled ? 1.0 : 0.3
         verticalAlignment: Text.AlignVCenter
         wrapMode: Text.WordWrap
         width: parent.width
         color: Theme.palette.directColor1
+        lineHeight: 1.2
         leftPadding: root.leftSide? (!!root.text ? root.indicator.width + root.spacing
                                  : root.indicator.width) : 0
         rightPadding: !root.leftSide? (!!root.text ? root.indicator.width + root.spacing

--- a/ui/StatusQ/src/StatusQ/Controls/StatusRadioButton.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusRadioButton.qml
@@ -3,7 +3,6 @@ import QtQuick.Controls 2.14
 
 import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
-import StatusQ.Components 0.1
 
 RadioButton {
     id: root
@@ -21,6 +20,8 @@ RadioButton {
         Small,
         Large
     }
+
+    font.family: Theme.palette.baseFont.name
 
     indicator: Rectangle {
         implicitWidth: root.size === StatusRadioButton.Size.Large ? 20 : 14

--- a/ui/app/AppLayouts/Onboarding/popups/BeforeGetStartedModal.qml
+++ b/ui/app/AppLayouts/Onboarding/popups/BeforeGetStartedModal.qml
@@ -14,6 +14,8 @@ StatusDialog {
     id: root
 
     width: 480
+    topPadding: Style.current.bigPadding
+    bottomPadding: Style.current.bigPadding
     closePolicy: Popup.NoAutoClose
 
     header: StatusDialogHeader {
@@ -37,13 +39,13 @@ StatusDialog {
     contentItem: Item {
         Column {
             width: 416
-            spacing: 16
+            spacing: Style.current.padding
             anchors.centerIn: parent
 
             StatusCheckBox {
                 id: acknowledge
                 objectName: "acknowledgeCheckBox"
-                spacing: 8
+                spacing: Style.current.halfPadding
                 font.pixelSize: 15
                 width: parent.width
                 text: qsTr("I acknowledge that Status Desktop is in Beta and by using it I take the full responsibility for all risks concerning my data and funds.")


### PR DESCRIPTION
additionally correct the way a font is propagated from a QQC2 Control down to our components

Fixes #6515

### What does the PR do

Fixes some minor UI defects (margins/padding/spacing)

### Affected areas

BeforeGetStartedModal

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![Snímek obrazovky z 2022-10-28 12-53-34](https://user-images.githubusercontent.com/5377645/198571584-ca1dbdc5-6ba8-49ab-b235-8d64262bd5a9.png)
