### PR TITLE
feat(Message): fallback to import message content if necessary

### DIFF
--- a/src/app/modules/shared_models/message_item.nim
+++ b/src/app/modules/shared_models/message_item.nim
@@ -133,7 +133,8 @@ proc initItem*(
   result.messageAttachments = @[]
 
   if ContentType.DiscordMessage == contentType:
-    result.messageText = discordMessage.content
+    if result.messageText == "":
+      result.messageText = discordMessage.content
     result.senderId = discordMessage.author.id
     result.senderDisplayName = discordMessage.author.name
     result.senderIcon = discordMessage.author.localUrl


### PR DESCRIPTION
Messages are parsed to transform markdown to something that can be rendered in a formatted way.

When this happens, the parsed text is applied to a message's `text` property inside desktop.

There was no formatted message support for imported discord messages, so we were relying purely on `discordMessage.content`.

However, now formatting support is pending in status-go here: https://github.com/status-im/status-go/pull/2933

This means, once this lands, we can simply rely on `messsageItem.text`.

I'm adding this guard here such that this will continue to work without the feature in status-go, but once the feature in status-go lands, desktop will automatically adapt.

Closes #8086

