### PR TITLE
fix(contacts): fix `getVerificationRequestFrom`  API

### DIFF
--- a/src/backend/contacts.nim
+++ b/src/backend/contacts.nim
@@ -93,7 +93,7 @@ proc getVerificationRequestSentTo*(pubkey: string): RpcResponse[JsonNode] {.rais
 
 proc getVerificationRequestFrom*(pubkey: string): RpcResponse[JsonNode] {.raises: [Exception].} =
   let payload = %* [pubkey]
-  result = callPrivateRPC("getVerificationRequestFrom".prefix, payload)
+  result = callPrivateRPC("getLatestVerificationRequestFrom".prefix, payload)
 
 proc getReceivedVerificationRequests*(): RpcResponse[JsonNode] {.raises: [Exception].} =
   let payload = %* []


### PR DESCRIPTION
The underlying API was mistakenly removed in status-go, then reintroduced, but as `getLatestVerficiationRequestFrom`.

This commit fixes the RPC call.

Needs https://github.com/status-im/status-go/pull/2934

