### PR TITLE
fix: Fixed group and channel mention notifications

### DIFF
--- a/src/app/modules/main/activity_center/io_interface.nim
+++ b/src/app/modules/main/activity_center/io_interface.nim
@@ -71,3 +71,6 @@ method switchTo*(self: AccessInterface, sectionId, chatId, messageId: string) {.
 
 method getDetails*(self: AccessInterface, sectionId: string, chatId: string): string {.base.} =
   raise newException(ValueError, "No implementation available")
+
+method getChatDetailsAsJson*(self: AccessInterface, chatId: string): string {.base.} = 
+  raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/activity_center/item.nim
+++ b/src/app/modules/main/activity_center/item.nim
@@ -1,6 +1,7 @@
 import strformat, stint
 import ../../shared_models/message_item_qobject
 import ../../../../app_service/service/activity_center/dto/notification
+import ../../../../app_service/service/chat/dto/chat
 
 const CONTACT_REQUEST_PENDING_STATE = 1
 
@@ -19,6 +20,7 @@ type Item* = ref object
   accepted: bool
   messageItem: MessageItem
   repliedMessageItem: MessageItem
+  chatType: ChatType
 
 proc initItem*(
   id: string,
@@ -34,7 +36,8 @@ proc initItem*(
   dismissed: bool,
   accepted: bool,
   messageItem: MessageItem,
-  repliedMessageItem: MessageItem
+  repliedMessageItem: MessageItem,
+  chatType: ChatType
 ): Item =
   result = Item()
   result.id = id
@@ -51,6 +54,7 @@ proc initItem*(
   result.accepted = accepted
   result.messageItem = messageItem
   result.repliedMessageItem = repliedMessageItem
+  result.chatType = chatType
 
 proc `$`*(self: Item): string =
   result = fmt"""StickerItem(
@@ -81,6 +85,10 @@ proc author*(self: Item): string =
 
 proc chatId*(self: Item): string =
   return self.chatId
+
+
+proc chatType*(self: Item): ChatType =
+  return self.chatType
 
 proc communityId*(self: Item): string =
   return self.communityId

--- a/src/app/modules/main/activity_center/model.nim
+++ b/src/app/modules/main/activity_center/model.nim
@@ -17,6 +17,7 @@ type
     Accepted
     Author
     RepliedMessage
+    ChatType
 
 QtObject:
   type
@@ -70,23 +71,24 @@ QtObject:
     if index.row < 0 or index.row >= self.activityCenterNotifications.len:
       return
 
-    let acitivityNotificationItem = self.activityCenterNotifications[index.row]
+    let activityNotificationItem = self.activityCenterNotifications[index.row]
     let communityItemRole = role.NotifRoles
     case communityItemRole:
-      of NotifRoles.Id: result = newQVariant(acitivityNotificationItem.id)
-      of NotifRoles.ChatId: result = newQVariant(acitivityNotificationItem.chatId)
-      of NotifRoles.CommunityId: result = newQVariant(acitivityNotificationItem.communityId)
-      of NotifRoles.MembershipStatus: result = newQVariant(acitivityNotificationItem.membershipStatus.int)
-      of NotifRoles.SectionId: result = newQVariant(acitivityNotificationItem.sectionId)
-      of NotifRoles.Name: result = newQVariant(acitivityNotificationItem.name)
-      of NotifRoles.Author: result = newQVariant(acitivityNotificationItem.author)
-      of NotifRoles.NotificationType: result = newQVariant(acitivityNotificationItem.notificationType.int)
-      of NotifRoles.Message: result = newQVariant(acitivityNotificationItem.messageItem)
-      of NotifRoles.Timestamp: result = newQVariant(acitivityNotificationItem.timestamp)
-      of NotifRoles.Read: result = newQVariant(acitivityNotificationItem.read.bool)
-      of NotifRoles.Dismissed: result = newQVariant(acitivityNotificationItem.dismissed.bool)
-      of NotifRoles.Accepted: result = newQVariant(acitivityNotificationItem.accepted.bool)
-      of NotifRoles.RepliedMessage: result = newQVariant(acitivityNotificationItem.repliedMessageItem)
+      of NotifRoles.Id: result = newQVariant(activityNotificationItem.id)
+      of NotifRoles.ChatId: result = newQVariant(activityNotificationItem.chatId)
+      of NotifRoles.CommunityId: result = newQVariant(activityNotificationItem.communityId)
+      of NotifRoles.MembershipStatus: result = newQVariant(activityNotificationItem.membershipStatus.int)
+      of NotifRoles.SectionId: result = newQVariant(activityNotificationItem.sectionId)
+      of NotifRoles.Name: result = newQVariant(activityNotificationItem.name)
+      of NotifRoles.Author: result = newQVariant(activityNotificationItem.author)
+      of NotifRoles.NotificationType: result = newQVariant(activityNotificationItem.notificationType.int)
+      of NotifRoles.Message: result = newQVariant(activityNotificationItem.messageItem)
+      of NotifRoles.Timestamp: result = newQVariant(activityNotificationItem.timestamp)
+      of NotifRoles.Read: result = newQVariant(activityNotificationItem.read.bool)
+      of NotifRoles.Dismissed: result = newQVariant(activityNotificationItem.dismissed.bool)
+      of NotifRoles.Accepted: result = newQVariant(activityNotificationItem.accepted.bool)
+      of NotifRoles.RepliedMessage: result = newQVariant(activityNotificationItem.repliedMessageItem)
+      of NotifRoles.ChatType: result = newQVariant(activityNotificationItem.chatType.int)
 
   proc getNotificationData(self: Model, index: int, data: string): string {.slot.} =
     if index < 0 or index >= self.activityCenterNotifications.len: return ("")
@@ -105,6 +107,7 @@ QtObject:
     of "read": result = $(notif.read)
     of "dismissed": result = $(notif.dismissed)
     of "accepted": result = $(notif.accepted)
+    of "chatType": result = $(notif.chatType)
     else: result = ("")
 
   method roleNames(self: Model): Table[int, string] =
@@ -122,7 +125,8 @@ QtObject:
       NotifRoles.Read.int: "read",
       NotifRoles.Dismissed.int: "dismissed",
       NotifRoles.Accepted.int: "accepted",
-      NotifRoles.RepliedMessage.int: "repliedMessage"
+      NotifRoles.RepliedMessage.int: "repliedMessage",
+      NotifRoles.ChatType.int: "chatType"
     }.toTable
 
   proc markActivityCenterNotificationUnread*(self: Model, notificationId: string) =

--- a/src/app/modules/main/activity_center/module.nim
+++ b/src/app/modules/main/activity_center/module.nim
@@ -138,7 +138,8 @@ method convertToItems*(
         n.dismissed,
         n.accepted,
         messageItem,
-        repliedMessageItem
+        repliedMessageItem,
+        chatDetails.chatType
       )
     )
 
@@ -247,3 +248,12 @@ method getDetails*(self: Module, sectionId: string, chatId: string): string =
       jsonObject["cColor"] = %* c.color
       jsonObject["cEmoji"] = %* c.emoji
       return $jsonObject
+
+method getChatDetailsAsJson*(self: Module, chatId: string): string =
+  let chatDto = self.controller.getChatDetails(chatId)
+  var jsonObject = newJObject()
+  jsonObject["name"] = %* chatDto.name
+  jsonObject["icon"] = %* chatDto.icon
+  jsonObject["color"] = %* chatDto.color
+  jsonObject["emoji"] = %* chatDto.emoji
+  return $jsonObject

--- a/src/app/modules/main/activity_center/view.nim
+++ b/src/app/modules/main/activity_center/view.nim
@@ -126,3 +126,6 @@ QtObject:
 
   proc getDetails*(self: View, sectionId: string, chatId: string): string {.slot.} =
     return self.delegate.getDetails(sectionId, chatId)
+
+  proc getChatDetailsAsJson*(self: View, chatId: string): string {.slot.} =
+    return self.delegate.getChatDetailsAsJson(chatId)

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -348,13 +348,23 @@ QtObject {
     }
 
     function getCommunityDetailsAsJson(id) {
-        let jsonObj = communitiesModuleInst.getCommunityDetails(id)
+        const jsonObj = communitiesModuleInst.getCommunityDetails(id)
         try {
-            let obj = JSON.parse(jsonObj)
-            return obj
+            return JSON.parse(jsonObj)
         }
         catch (e) {
             console.warn("error parsing community by id: ", id, " error: ", e.message)
+            return {}
+        }
+    }
+
+    function getChatDetails(id) {
+        const jsonObj = activityCenterModule.getChatDetailsAsJson(id)
+        try {
+            return JSON.parse(jsonObj)
+        }
+        catch (e) {
+            console.warn("error parsing chat by id: ", id, " error: ", e.message)
             return {}
         }
     }

--- a/ui/app/mainui/activitycenter/controls/ChannelBadge.qml
+++ b/ui/app/mainui/activitycenter/controls/ChannelBadge.qml
@@ -6,54 +6,67 @@ import Qt.labs.platform 1.1
 import utils 1.0
 import shared 1.0
 import shared.panels 1.0
+import shared.controls 1.0
 
 import StatusQ.Components 0.1
 import StatusQ.Core 0.1
 import StatusQ.Core.Utils 0.1 as StatusQUtils
+import StatusQ.Core.Theme 0.1
 
 Badge {
     id: root
 
     signal channelNameClicked()
 
-    property int realChatType: -1
+    property int chatType: -1
     property string name: "channelName"
     property color textColor
-    property string profileImage: ""
 
-    SVGImage {
-        id: channelIcon
+    property StatusAssetSettings asset: StatusAssetSettings {
         width: 16
         height: 16
-        fillMode: Image.PreserveAspectFit
-        source: Style.svg("channel-icon-" + (realChatType === Constants.chatType.publicChat ? "public-chat" : "group"))
-        anchors.left: parent.left
-        anchors.verticalCenter:parent.verticalCenter
+        letterSize: 11
     }
 
-    StatusSmartIdenticon {
-        id: contactImage
-        anchors.left: channelIcon.right
-        anchors.leftMargin: 4
-        anchors.verticalCenter: parent.verticalCenter
-        asset.name: profileImage
-        asset.isImage: profileImage !== ""
-        asset.width: 16
-        asset.height: 16
-        asset.letterSize: 11
-        name: root.name
+    implicitWidth: layout.implicitWidth + layout.anchors.leftMargin + layout.anchors.rightMargin
+    implicitHeight: layout.implicitHeight + layout.anchors.topMargin + layout.anchors.bottomMargin
+
+    RowLayout {
+        id: layout
+
+        anchors {
+            fill: parent
+            leftMargin: 8
+            rightMargin: 8
+            topMargin: 3
+            bottomMargin: 3
+        }
+
+        spacing: 4
+
+        StatusIcon {
+            Layout.preferredWidth: 16
+            Layout.preferredHeight: 16
+            icon: chatType === Constants.chatType.publicChat ? "tiny/public-chat"
+                                                             : "tiny/group"
+            color: Theme.palette.baseColor1
+        }
+
+        StatusSmartIdenticon {
+            Layout.alignment: Qt.AlignVCenter
+            asset: root.asset
+            name: root.name
+        }
+        StyledText {
+            Layout.alignment: Qt.AlignVCenter
+            text: chatType !== Constants.chatType.publicChat ?
+                      StatusQUtils.Emoji.parse(Utils.removeStatusEns(StatusQUtils.Utils.filterXSS(name))) :
+                      "#" + StatusQUtils.Utils.filterXSS(name)
+
+            color: Theme.palette.baseColor1
+            font.weight: Font.Medium
+            font.pixelSize: 13
+        }
     }
 
-    StyledText {
-        id: contactInfo
-        text: realChatType !== Constants.chatType.publicChat ?
-                  StatusQUtils.Emoji.parse(Utils.removeStatusEns(StatusQUtils.Utils.filterXSS(name))) :
-                  "#" + StatusQUtils.Utils.filterXSS(name)
-        anchors.left: contactImage.right
-        anchors.leftMargin: 4
-        color: textColor
-        font.weight: Font.Medium
-        font.pixelSize: 13
-        anchors.verticalCenter: parent.verticalCenter
-    }
 }

--- a/ui/app/mainui/activitycenter/controls/CommunityBadge.qml
+++ b/ui/app/mainui/activitycenter/controls/CommunityBadge.qml
@@ -1,6 +1,9 @@
 import QtQuick 2.3
+import QtQuick.Layouts 1.3
 import QtGraphicalEffects 1.13
 
+import StatusQ.Core.Theme 0.1
+import StatusQ.Core 0.1
 import StatusQ.Components 0.1
 
 import utils 1.0
@@ -22,74 +25,80 @@ Badge {
     signal communityNameClicked()
     signal channelNameClicked()
 
-    SVGImage {
-        id: communityIcon
-        anchors.left: parent.left
-        anchors.leftMargin: Style.current.smallPadding
-        anchors.verticalCenter:parent.verticalCenter
-        width: 16
-        height: 16
-        source: Style.svg("communities")
-    }
+    implicitWidth: layout.implicitWidth + layout.anchors.leftMargin + layout.anchors.rightMargin
+    implicitHeight: layout.implicitHeight + layout.anchors.topMargin + layout.anchors.bottomMargin
 
-    StatusSmartIdenticon {
-        id: identicon
-        anchors.left: communityIcon.right
-        anchors.leftMargin: Style.current.smallPadding
-        anchors.verticalCenter: parent.verticalCenter
-        name: root.communityName
-        asset.width: 16
-        asset.height: 16
-        asset.color: root.communityColor
-        asset.letterSize: width / 2.4
-        asset.name: root.communityImage
-        asset.isImage: true
-    }
+    RowLayout {
+        id: layout
 
-    StyledTextEdit {
-        id: communityNameText
-        width: implicitWidth > 300 ? 300 : implicitWidth
-        height: 18
-        anchors.left: identicon.right
-        anchors.leftMargin: 4
-        anchors.verticalCenter: parent.verticalCenter
-        text: Utils.getLinkStyle(root.communityName, hoveredLink, root.communityColor)
-        readOnly: true
-        textFormat: Text.RichText
-        clip: true
-        color: root.communityColor
-        font.pixelSize: 13
-        onLinkActivated: root.communityNameClicked()
-    }
-
-    SVGImage {
-        id: caretImage
-        source: Style.svg("show-category")
-        width: 16
-        height: 16
-        visible: root.channelName.length
-        anchors.left: communityNameText.right
-        anchors.verticalCenter: parent.verticalCenter
-
-        ColorOverlay {
-            anchors.fill: parent
-            source: parent
-            color: root.communityColor
+        anchors {
+            fill: parent
+            leftMargin: 8
+            rightMargin: 8
+            topMargin: 3
+            bottomMargin: 3
         }
-    }
 
-    StyledTextEdit {
-        id: channelNameText
-        width: implicitWidth > 300 ? 300 : implicitWidth
-        height: 18
-        anchors.left: caretImage.right
-        anchors.verticalCenter: parent.verticalCenter
-        text: Utils.getLinkStyle(root.channelName || name, hoveredLink, root.channelColor)
-        readOnly: true
-        textFormat: Text.RichText
-        clip: true
-        color: root.communityColor
-        font.pixelSize: 13
-        onLinkActivated: root.channelNameClicked()
+        spacing: 4
+
+        StatusIcon {
+            Layout.preferredWidth: 16
+            Layout.preferredHeight: 16
+            icon: "tiny/community"
+            color: Theme.palette.baseColor1
+        }
+
+        StatusSmartIdenticon {
+            Layout.alignment: Qt.AlignVCenter
+            name: root.communityName
+            asset.width: 16
+            asset.height: 16
+            asset.letterSize: 11
+            asset.color: root.communityColor
+            asset.name: root.communityImage
+            asset.isImage: true
+        }
+
+        RowLayout {
+            Layout.alignment: Qt.AlignVCenter
+            spacing: 0
+
+            StyledTextEdit {
+                Layout.maximumWidth: 300
+                Layout.alignment: Qt.AlignVCenter
+                text: Utils.getLinkStyle(root.communityName, hoveredLink, Theme.palette.baseColor1)
+                readOnly: true
+                textFormat: Text.RichText
+                clip: true
+                color: Theme.palette.baseColor1
+                font.pixelSize: 13
+                font.weight: Font.Medium
+                onLinkActivated: {
+                    root.communityNameClicked()
+                }
+            }
+
+            StatusIcon {
+                Layout.preferredWidth: 16
+                Layout.preferredHeight: 16
+                icon: "tiny/chevron-right"
+                color: Theme.palette.baseColor1
+            }
+
+            StyledTextEdit {
+                Layout.maximumWidth: 300
+                Layout.alignment: Qt.AlignVCenter
+                text: Utils.getLinkStyle("#" + root.channelName, hoveredLink, Theme.palette.baseColor1)
+                readOnly: true
+                textFormat: Text.RichText
+                clip: true
+                color: Theme.palette.baseColor1
+                font.pixelSize: 13
+                font.weight: Font.Medium
+                onLinkActivated: {
+                    root.channelNameClicked()
+                }
+            }
+        }
     }
 }

--- a/ui/app/mainui/activitycenter/views/ActivityNotificationMention.qml
+++ b/ui/app/mainui/activitycenter/views/ActivityNotificationMention.qml
@@ -13,7 +13,17 @@ import "../controls"
 ActivityNotificationMessage {
     id: root
 
-    badgeComponent: notification.message.communityId ? communityBadgeComponent : notification.chatId ? groupChatBadgeComponent : null
+    badgeComponent: {
+        switch (notification.chatType)
+        {
+        case Constants.chatType.communityChat:
+            return communityBadgeComponent
+        case Constants.chatType.privateGroupChat:
+            return groupChatBadgeComponent
+        default:
+            return null
+        }
+    }
 
     Component {
         id: communityBadgeComponent
@@ -22,14 +32,12 @@ ActivityNotificationMessage {
             id: communityBadge
 
             property var community: root.store.getCommunityDetailsAsJson(notification.message.communityId)
-            // TODO: here i need chanel
-            // property var channel: root.store.getItemAsJson(notification.chatId)
+            property var channel: root.store.getChatDetails(notification.chatId)
 
             communityName: community.name
             communityImage: community.image
             communityColor: community.color
-
-            // channelName: channel.name
+            channelName: channel.name
 
             onCommunityNameClicked: {
                 root.store.setActiveCommunity(notification.message.communityId)
@@ -45,10 +53,14 @@ ActivityNotificationMessage {
         id: groupChatBadgeComponent
 
         ChannelBadge {
-            realChatType: root.realChatType
-            textColor: Utils.colorForPubkey(notification.message.senderId)
-            name: root.name
-            profileImage: Global.getProfileImage(notification.message.chatId)
+            property var group: root.store.getChatDetails(notification.chatId)
+
+            chatType: notification.chatType
+            name: group.name
+            asset.isImage: asset.name != ""
+            asset.name: group.icon
+            asset.emoji: group.emoji
+            asset.color: group.color
         }
     }
 }


### PR DESCRIPTION
Fixes:
- https://github.com/status-im/status-desktop/issues/7536
- https://github.com/status-im/status-desktop/issues/7529

### What does the PR do

Activity center mention notifications:
- Show group name
- Show channel name
- Design rework: colors, icons, layout

### Affected areas

Activity center

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [x] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

<img width="1274" alt="Снимок экрана 2022-10-28 в 17 25 32" src="https://user-images.githubusercontent.com/25482501/198645275-40c77a39-db56-4093-b399-04b56ee4a965.png">
