### PR TITLE
fix(accounts-service): use WAKUV2_PORT env var for account creation too

### DIFF
--- a/src/app_service/service/accounts/service.nim
+++ b/src/app_service/service/accounts/service.nim
@@ -304,6 +304,12 @@ proc getDefaultNodeConfig*(self: Service, installationId: string): JsonNode =
 
   result["WakuConfig"]["Enabled"] = false.newJBool()
 
+  if existsEnv("WAKUV2_PORT"):
+    let wV2Port = parseInt($getEnv("WAKUV2_PORT"))
+    # Waku V2 config
+    result["WakuV2Config"]["Port"] = wV2Port.newJInt()
+    result["WakuV2Config"]["UDPPort"] = wV2Port.newJInt()
+
   if TEST_PEER_ENR != "":
     result["ClusterConfig"]["BootNodes"] = %* @[TEST_PEER_ENR]
     result["ClusterConfig"]["TrustedMailServers"] = %* @[TEST_PEER_ENR]


### PR DESCRIPTION
The WAKUV2_PORT env var was only being used during login, so the account creation would be saved, but it wouldn't let you in the app, you needed to close and retry, this time with a login.

Now, the WAKUV2_PORT var is used for both so it's possible to run tests for example with it.