### PR TITLE
test(Settings): adds a test that sends a contact request with chat key

### DIFF
--- a/test/ui-test/src/screens/SettingsScreen.py
+++ b/test/ui-test/src/screens/SettingsScreen.py
@@ -51,7 +51,15 @@ class MessagingOptionScreen(Enum):
     ACTIVATE_OR_DECTIVATE_IMAGE_UNFURLING: str = "imageUnfurlingItem"
     TENOR_GIFS_PREVIEW_SWITCH_ITEM: str = "tenorGifsPreviewSwitchItem"
     SCROLLVIEW: str = "settingsContentBase_ScrollView"
-
+    CONTACTS_BTN: str = "contacts_listItem_btn"
+   
+class ContactsViewScreen(Enum):
+    CONTACT_REQUEST_CHAT_KEY_BTN: str = "contact_request_to_chat_key_btn"
+    CONTACT_REQUEST_CHAT_KEY_INPUT: str = "contactRequest_ChatKey_Input"
+    CONTACT_REQUEST_SAY_WHO_YOU_ARE_INPUT: str = "contactRequest_SayWhoYouAre_Input"
+    CONTACT_REQUEST_SEND_BUTTON: str = "contactRequest_Send_Button"
+    CONTACT_REQUEST_PENDING_REQUEST_TAB_BUTTON: str = "contactRequest_PendingRequests_Button"
+    SENT_REQUESTS_CONTACT_PANEL_LIST_VIEW: str = "sentRequests_contactListPanel_ListView"
 
 class WalletSettingsScreen(Enum):
     GENERATED_ACCOUNTS: str = "settings_Wallet_MainView_GeneratedAccounts"
@@ -345,5 +353,26 @@ class SettingsScreen:
 
         click_obj_by_name(ChangePasswordMenu.CHANGE_PASSWORD_SUBMIT_BUTTON.value)
         click_obj_by_name(ChangePasswordMenu.CHANGE_PASSWORD_SUCCESS_MENU_SIGN_OUT_QUIT_BUTTON.value)
+        
+    def add_contact_by_chat_key(self, chat_key: str, who_you_are: str):
+        click_obj_by_name(MessagingOptionScreen.CONTACTS_BTN.value)
+        click_obj_by_name(ContactsViewScreen.CONTACT_REQUEST_CHAT_KEY_BTN.value)
+        
+        type(ContactsViewScreen.CONTACT_REQUEST_CHAT_KEY_INPUT.value, chat_key)
+        type(ContactsViewScreen.CONTACT_REQUEST_SAY_WHO_YOU_ARE_INPUT.value, who_you_are)
+        
+        click_obj_by_name(ContactsViewScreen.CONTACT_REQUEST_SEND_BUTTON.value)
 
+    def verify_contact_request(self, chat_key: str):
+        click_obj_by_name(ContactsViewScreen.CONTACT_REQUEST_PENDING_REQUEST_TAB_BUTTON.value)
+        contact_list = get_obj(ContactsViewScreen.SENT_REQUESTS_CONTACT_PANEL_LIST_VIEW.value)
+        contact_keys = []
+        for index in range(contact_list.count):
+            contact = contact_list.itemAtIndex(index)
+            contact_keys.append(str(contact.compressedPk))
+            if (contact.compressedPk == chat_key):
+                return
+        contact_keys_tr = ", ".join(contact_keys)
+        verify_failure(f'The list of pending contacts contains "{contact_keys_tr}"  but we wanted the key"{chat_key}"')
+        
         

--- a/test/ui-test/testSuites/global_shared/scripts/settings_names.py
+++ b/test/ui-test/testSuites/global_shared/scripts/settings_names.py
@@ -91,6 +91,16 @@ settingsContentBase_ScrollView = {"container": statusDesktop_mainWindow, "object
 displayMessageLinkPreviewItem = {"container": statusDesktop_mainWindow, "objectName": "displayMessageLinkPreviewsItem", "type": "StatusListItem"}
 imageUnfurlingItem = {"container": statusDesktop_mainWindow, "objectName": "imageUnfurlingItem", "type": "StatusListItem"}
 tenorGifsPreviewSwitchItem = {"container": statusDesktop_mainWindow, "objectName": "MessagingView_sitesListView_StatusListItem_tenor_gifs_subdomain", "type": "StatusListItem"}
+contacts_listItem_btn = {"container": statusDesktop_mainWindow, "objectName": "MessagingView_ContactsListItem_btn", "type": "StatusContactRequestsIndicatorListItem"}
+
+# Contacts View
+contact_request_to_chat_key_btn = {"container": statusDesktop_mainWindow, "objectName": "ContactsView_ContactRequest_Button", "type": "StatusButton"}
+contactRequest_ChatKey_Input = {"container": statusDesktop_mainWindow, "objectName": "SendContactRequestModal_ChatKey_Input", "type": "TextEdit"}
+contactRequest_SayWhoYouAre_Input = {"container": statusDesktop_mainWindow, "objectName": "SendContactRequestModal_SayWhoYouAre_Input", "type": "TextEdit"}
+contactRequest_Send_Button = {"container": statusDesktop_mainWindow, "objectName": "SendContactRequestModal_Send_Button", "type": "StatusButton"}
+contactRequest_PendingRequests_Button = {"container": statusDesktop_mainWindow, "objectName": "ContactsView_PendingRequest_Button", "type": "StatusTabButton"}
+sentRequests_ContactsListPanel = {"container": settingsContentBase_ScrollView, "objectName": "sentRequests_ContactsListPanel", "type": "ContactsListPanel"}
+sentRequests_contactListPanel_ListView = {"container": sentRequests_ContactsListPanel, "objectName": "ContactListPanel_ListView", "type": "StatusListView"}
 
 # Communities Settings:
 settings_Communities_MainView_LeaveCommunityButtons = {"container": statusDesktop_mainWindow, "objectName":"CommunitiesListPanel_leaveCommunityPopupButton", "type": "StatusBaseButton", "visible": True}

--- a/test/ui-test/testSuites/global_shared/steps/settingsSteps.py
+++ b/test/ui-test/testSuites/global_shared/steps/settingsSteps.py
@@ -161,6 +161,10 @@ def step(context, display_name):
 def step(context: any, oldPassword: str, newPassword: str):
     _settingsScreen.change_user_password(oldPassword, newPassword)
 
+@When("the user sends a contact request to the chat key \"|any|\" with the reason \"|any|\"")
+def step(context: any, chat_key: str, reason: str):
+    _settingsScreen.add_contact_by_chat_key(chat_key, reason)
+
 #########################
 ### VERIFICATIONS region:
 #########################
@@ -226,6 +230,10 @@ def step(context: any):
 @Then("in profile popup the user's display name should be \"|any|\"")
 def step(context, display_name):
     _statusMain.verify_profile_popup_display_name(display_name)
+
+@Then("the contact request for chat key \"|any|\" is present in the pending requests tab")
+def step(context, chat_key: str):
+    _settingsScreen.verify_contact_request(chat_key)
     
 ###########################################################################
 ### COMMON methods used in different steps given/when/then region:

--- a/test/ui-test/testSuites/suite_settings/suite.conf
+++ b/test/ui-test/testSuites/suite_settings/suite.conf
@@ -1,4 +1,5 @@
 AUT=nim_status_client
+ENVVARS=envvars
 LANGUAGE=Python
 OBJECTMAPSTYLE=script
 TEST_CASES=tst_mainSettingsSection tst_userIdentity tst_languageSettings tst_signUpAndQuit

--- a/test/ui-test/testSuites/suite_settings/tst_contactsFlow/test.feature
+++ b/test/ui-test/testSuites/suite_settings/tst_contactsFlow/test.feature
@@ -1,0 +1,16 @@
+Feature: Status Desktop Contacts Flows
+
+    As a user I want to login the app and interact with contacts (add, remove, etc)
+
+    Background: Sign up and open settings section
+        Given A first time user lands on the status desktop and generates new key
+        And the user signs up with username "tester123" and password "TesTEr16843/!@00"
+        And the user lands on the signed in app
+        And the user opens app settings screen
+
+
+    Scenario: The user can add a contact with a chat key
+    	When the user opens the messaging settings
+    	And the user sends a contact request to the chat key "zQ3shQihZMmciZWUrjvsY6kUoaqSKp9DFSjMPRkkKGty3XCKZ" with the reason "I am a fellow tester"
+        Then the contact request for chat key "zQ3shQihZMmciZWUrjvsY6kUoaqSKp9DFSjMPRkkKGty3XCKZ" is present in the pending requests tab
+        # TODO for future improvements: log into the other account and check that we received the request (will require some cleanup)

--- a/test/ui-test/testSuites/suite_settings/tst_contactsFlow/test.py
+++ b/test/ui-test/testSuites/suite_settings/tst_contactsFlow/test.py
@@ -1,0 +1,8 @@
+source(findFile('scripts', 'python/bdd.py'))
+
+setupHooks('../../global_shared/scripts/bdd_hooks.py')
+collectStepDefinitions('./steps', '../shared/steps/', '../../global_shared/steps/', '../../suite_onboarding/shared/steps/')
+
+def main():
+    testSettings.throwOnFailure = True
+    runFeatureFile('test.feature')

--- a/ui/app/AppLayouts/Profile/panels/ContactPanel.qml
+++ b/ui/app/AppLayouts/Profile/panels/ContactPanel.qml
@@ -25,9 +25,10 @@ StatusListItem {
 
     property var contactsStore
 
-    property string name: "Jotaro Kujo"
-    property string publicKey: "0x04d8c07dd137bd1b73a6f51df148b4f77ddaa11209d36e43d8344c0a7d6db1cad6085f27cfb75dd3ae21d86ceffebe4cf8a35b9ce8d26baa19dc264efe6d8f221b"
-    property string iconSource: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="
+    property string name
+    property string publicKey
+    property string compressedPk // Needed for the tests + probably gonna be used more in the future
+    property string iconSource
     property bool isContact: false
 
     property bool isBlocked: false

--- a/ui/app/AppLayouts/Profile/panels/ContactsListPanel.qml
+++ b/ui/app/AppLayouts/Profile/panels/ContactsListPanel.qml
@@ -51,6 +51,7 @@ Item {
 
     StatusListView {
         id: contactsList
+        objectName: "ContactListPanel_ListView"
         anchors.top: title.bottom
         anchors.left: parent.left
         anchors.right: parent.right
@@ -96,6 +97,7 @@ Item {
             contactsStore: root.contactsStore
             name: model.displayName
             publicKey: model.pubKey
+            compressedPk: Utils.getCompressedPk(model.pubKey)
             iconSource: model.icon
             isContact: model.isContact
             isBlocked: model.isBlocked

--- a/ui/app/AppLayouts/Profile/popups/SendContactRequestModal.qml
+++ b/ui/app/AppLayouts/Profile/popups/SendContactRequestModal.qml
@@ -114,6 +114,7 @@ StatusModal {
 
             StatusInput {
                 id: chatKeyInput
+                input.edit.objectName: "SendContactRequestModal_ChatKey_Input"
 
                 placeholderText: qsTr("Enter chat key here")
                 input.text: input.edit.focus? d.realChatKey : d.elidedChatKey
@@ -135,6 +136,7 @@ StatusModal {
 
             StatusInput {
                 id: messageInput
+                input.edit.objectName: "SendContactRequestModal_SayWhoYouAre_Input"
                 charLimit: d.maxMsgLength
 
                 placeholderText: qsTr("Say who you are / why you want to become a contact...")
@@ -155,6 +157,7 @@ StatusModal {
         StatusButton {
             id: btnCreateEdit
             enabled: d.validChatKey && messageInput.valid
+            objectName: "SendContactRequestModal_Send_Button"
             text: qsTr("Send Contact Request")
             onClicked: {
                 root.contactsStore.sendContactRequest(d.resolvedPubKey, messageInput.text)

--- a/ui/app/AppLayouts/Profile/views/ContactsView.qml
+++ b/ui/app/AppLayouts/Profile/views/ContactsView.qml
@@ -26,6 +26,7 @@ SettingsContentBase {
     property bool isPending: false
 
     titleRowComponentLoader.sourceComponent: StatusButton {
+        objectName: "ContactsView_ContactRequest_Button"
         text: qsTr("Send contact request to chat key")
         onClicked: {
             sendContactRequest.open()
@@ -81,6 +82,7 @@ SettingsContentBase {
             }
             StatusTabButton {
                 id: pendingRequestsBtn
+                objectName: "ContactsView_PendingRequest_Button"
                 width: implicitWidth
                 enabled: root.contactsStore.receivedContactRequestsModel.count > 0 ||
                          root.contactsStore.sentContactRequestsModel.count > 0
@@ -211,6 +213,7 @@ SettingsContentBase {
 
                 ContactsListPanel {
                     id: sentRequests
+                    objectName: "sentRequests_ContactsListPanel"
                     Layout.fillWidth: true
                     title: qsTr("Sent")
                     searchString: searchBox.text

--- a/ui/app/AppLayouts/Profile/views/MessagingView.qml
+++ b/ui/app/AppLayouts/Profile/views/MessagingView.qml
@@ -148,6 +148,7 @@ SettingsContentBase {
 
         // CONTACTS SECTION
         StatusContactRequestsIndicatorListItem {
+            objectName: "MessagingView_ContactsListItem_btn"
             Layout.fillWidth: true
             title: qsTr("Contacts, Requests, and Blocked Users")
             requestsCount: root.contactsStore.receivedContactRequestsModel.count


### PR DESCRIPTION
Partial fix of #6883 

This sends a contact request using the chat key

I'll create a new PR that uses a chat message to send a request