### PR TITLE
ci: use git clean instead of cleanWs() function

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -608,6 +608,10 @@ clean: | clean-common
 	rm -rf bin/* node_modules bottles/* pkg/* tmp/* $(STATUSGO) $(STATUSKEYCARDGO)
 	+ $(MAKE) -C vendor/DOtherSide/build --no-print-directory clean
 
+clean-git:
+	git clean -fdx
+	git submodule foreach --recursive git clean -fdx
+
 force-rebuild-status-go:
 	bash ./scripts/force-rebuild-status-go.sh $(STATUSGO)
 

--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -96,6 +96,6 @@ pipeline {
   post {
     success { script { github.notifyPR(true) } }
     failure { script { github.notifyPR(false) } }
-    cleanup { cleanWs() }
+    cleanup { sh 'make clean-git' }
   }
 }

--- a/ci/Jenkinsfile.linux-cpp
+++ b/ci/Jenkinsfile.linux-cpp
@@ -85,6 +85,6 @@ pipeline {
   post {
     success { script { github.notifyPR(true) } }
     failure { script { github.notifyPR(false) } }
-    cleanup { cleanWs() }
+    cleanup { sh 'make clean-git' }
   }
 }

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -108,6 +108,6 @@ pipeline {
   post {
     success { script { github.notifyPR(true) } }
     failure { script { github.notifyPR(false) } }
-    cleanup { cleanWs() }
+    cleanup { sh 'make clean-git' }
   }
 }

--- a/ci/Jenkinsfile.macos-cpp.todo
+++ b/ci/Jenkinsfile.macos-cpp.todo
@@ -77,6 +77,6 @@ pipeline {
   post {
     success { script { github.notifyPR(true) } }
     failure { script { github.notifyPR(false) } }
-    cleanup { cleanWs() }
+    cleanup { sh 'make clean-git' }
   }
 }

--- a/ci/Jenkinsfile.uitests
+++ b/ci/Jenkinsfile.uitests
@@ -145,6 +145,6 @@ pipeline {
   post {
     success { script { github.notifyPR(true) } }
     failure { script { github.notifyPR(false) } }
-    cleanup { cleanWs() }
+    cleanup { sh 'make clean-git' }
   }
 }

--- a/ci/Jenkinsfile.windows
+++ b/ci/Jenkinsfile.windows
@@ -99,6 +99,6 @@ pipeline {
   post {
     success { script { github.notifyPR(true) } }
     failure { script { github.notifyPR(false) } }
-    cleanup { cleanWs(disableDeferredWipeout: true, deleteDirs: true) }
+    cleanup { sh 'make clean-git' }
   }
 }

--- a/ci/Jenkinsfile.windows-cpp.todo
+++ b/ci/Jenkinsfile.windows-cpp.todo
@@ -78,6 +78,6 @@ pipeline {
   post {
     success { script { github.notifyPR(true) } }
     failure { script { github.notifyPR(false) } }
-    cleanup { cleanWs() }
+    cleanup { sh 'make clean-git' }
   }
 }


### PR DESCRIPTION
This is a continuation of attempts to fix provlems with Windows CI hosts getting into a broken state due to `.git` directory becoming a file for random submodules for unknown reason.

Instead of relying on Jenkins functionality of `cleanWs()` function provided by the [Workspace Cleanup Plugin](https://plugins.jenkins.io/ws-cleanup) we use Git which should be more reliable, and possibly also speed up the initial checkout of the repo and submodules.

A nice side-effect is that the repo checkout on all builds after the first one takes ~1 minute instead of ~5 minutes.

Previous issues:
- https://github.com/status-im/status-desktop/pull/7968
- https://github.com/status-im/status-desktop/pull/8046