### PR TITLE
fix(Communities): adjust discord import error codes

### DIFF
--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -501,9 +501,9 @@ QtObject {
     }
 
     enum DiscordImportErrorCode {
-        Unknown = 0,
-        Warning = 1,
-        Error = 2
+        Unknown = 1,
+        Warning = 2,
+        Error = 3
     }
 
     readonly property int communityImported: 0


### PR DESCRIPTION
Those have been changed in status-go, resulting in wrong visualization of import warnings and errors.

This commit adjusts them so they match the correct codes again.
