### PR TITLE
fix(communities): allow actual import errors to come through

### DIFF
--- a/src/app/modules/main/communities/models/discord_import_task_item.nim
+++ b/src/app/modules/main/communities/models/discord_import_task_item.nim
@@ -43,7 +43,7 @@ proc initDiscordImportTaskItem*(
   # We only show the first 3 errors per task, then we add another
   # "#n more issues" item in the UI
   for i, error in errors:
-    if i < MAX_VISIBLE_ERROR_ITEMS:
+    if i < MAX_VISIBLE_ERROR_ITEMS or error.code > ord(DiscordImportErrorCode.Warning):
       result.errors.addItem(initDiscordImportErrorItem(`type`, error.code, error.message))
 
 proc getType*(self: DiscordImportTaskItem): string =

--- a/src/app/modules/main/communities/models/discord_import_tasks_model.nim
+++ b/src/app/modules/main/communities/models/discord_import_tasks_model.nim
@@ -102,10 +102,10 @@ QtObject:
 
       let errorItemsCount = self.items[idx].errors.items.len
 
-      # We only show the first 3 errors per task, then we add another
-      # "#n more issues" item in the UI
+      # We only show the first 3 warnings + any error per task,
+      # then we add another "#n more issues" item in the UI
       for i, error in item.errors:
-        if errorItemsCount + i < taskItem.MAX_VISIBLE_ERROR_ITEMS:
+        if (errorItemsCount + i < taskItem.MAX_VISIBLE_ERROR_ITEMS) or error.code > ord(DiscordImportErrorCode.Warning):
           let errorItem = initDiscordImportErrorItem(item.`type`, error.code, error.message)
           self.items[idx].errors.addItem(errorItem)
 

--- a/src/app_service/service/community/dto/community.nim
+++ b/src/app_service/service/community/dto/community.nim
@@ -90,9 +90,9 @@ type DiscordChannelDto* = object
   filePath*: string
 
 type DiscordImportErrorCode* {.pure.}= enum
-  Unknown = 0,
-  Warning = 1,
-  Error = 2
+  Unknown = 1,
+  Warning = 2,
+  Error = 3
 
 type DiscordImportError* = object
   code*: int


### PR DESCRIPTION
This commit enures we render proper errors during an import, even if we've reached the maximum of warning/error items to render.

