### PR TITLE
fix(MessageView): fix opening URL links

### DIFF
--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -520,7 +520,7 @@ Loader {
                     } else if (link.startsWith('#')) {
                         rootStore.chatCommunitySectionModule.switchToChannel(link.replace("#", ""))
                         return
-                    } else if (rootStore.isStatusDeepLink(link)) {
+                    } else if (Utils.isStatusDeepLink(link)) {
                         rootStore.activateStatusDeepLink(link)
                         return
                     }


### PR DESCRIPTION
The referenced method does not exist; use the correct one from Utils

Fixes: #8123

### What does the PR do

Fixes clicking URL links in any chat

### Affected areas

MessageView

### Screenshot of functionality (including design for comparison)

- [N/A] I've checked the design and this PR matches it
