### PR TITLE
fix(communities): add missing community image to import process

### DIFF
--- a/src/app/core/signals/remote_signals/community.nim
+++ b/src/app/core/signals/remote_signals/community.nim
@@ -2,6 +2,7 @@ import json, tables
 import base
 
 import ../../../../app_service/service/community/dto/[community]
+import ../../../../app_service/service/chat/dto/[chat]
 import signal_type
 
 type CommunitySignal* = ref object of Signal
@@ -21,6 +22,7 @@ type DiscordCategoriesAndChannelsExtractedSignal* = ref object of Signal
 
 type DiscordCommunityImportProgressSignal* = ref object of Signal
   communityId*: string
+  communityImages*: Images
   communityName*: string
   tasks*: seq[DiscordImportTaskProgress]
   progress*: float
@@ -72,6 +74,9 @@ proc fromEvent*(T: type DiscordCommunityImportProgressSignal, event: JsonNode): 
     result.errorsCount = importProgressObj{"errorsCount"}.getInt()
     result.warningsCount = importProgressObj{"warningsCount"}.getInt()
     result.stopped = importProgressObj{"stopped"}.getBool()
+
+    if importProgressObj["communityImages"].kind == JObject:
+      result.communityImages = chat.toImages(importProgressObj["communityImages"])
 
     if importProgressObj["tasks"].kind == JArray:
       for task in importProgressObj["tasks"]:

--- a/src/app/modules/main/communities/controller.nim
+++ b/src/app/modules/main/communities/controller.nim
@@ -72,7 +72,7 @@ proc init*(self: Controller) =
 
   self.events.on(SIGNAL_DISCORD_COMMUNITY_IMPORT_PROGRESS) do(e:Args):
     let args = DiscordImportProgressArgs(e)
-    self.delegate.discordImportProgressUpdated(args.communityId, args.communityName, args.tasks, args.progress, args.errorsCount, args.warningsCount, args.stopped)
+    self.delegate.discordImportProgressUpdated(args.communityId, args.communityName, args.communityImage, args.tasks, args.progress, args.errorsCount, args.warningsCount, args.stopped)
 
 proc getCommunityTags*(self: Controller): string =
   result = self.communityService.getCommunityTags()

--- a/src/app/modules/main/communities/io_interface.nim
+++ b/src/app/modules/main/communities/io_interface.nim
@@ -128,7 +128,7 @@ method requestExtractDiscordChannelsAndCategories*(self: AccessInterface, filesT
 method discordCategoriesAndChannelsExtracted*(self: AccessInterface, categories: seq[DiscordCategoryDto], channels: seq[DiscordChannelDto], oldestMessageTimestamp: int, errors: Table[string, DiscordImportError], errorsCount: int) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method discordImportProgressUpdated*(self: AccessInterface, communityId: string, communityName: string, tasks: seq[DiscordImportTaskProgress], progress: float, errorsCount: int, warningsCount: int, stopped: bool) {.base.} =
+method discordImportProgressUpdated*(self: AccessInterface, communityId: string, communityName: string, communityImage: string, tasks: seq[DiscordImportTaskProgress], progress: float, errorsCount: int, warningsCount: int, stopped: bool) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method requestCancelDiscordCommunityImport*(self: AccessInterface, id: string) {.base.} =

--- a/src/app/modules/main/communities/module.nim
+++ b/src/app/modules/main/communities/module.nim
@@ -309,6 +309,7 @@ method requestImportDiscordCommunity*(self: Module, name: string, description, i
                         color: string, tags: string, imagePath: string, aX: int, aY: int, bX: int, bY: int,
                         historyArchiveSupportEnabled: bool, pinMessageAllMembersEnabled: bool, filesToImport: seq[string], 
                         fromTimestamp: int, encrypted: bool) =
+  self.view.setDiscordImportHasCommunityImage(imagePath != "")
   self.controller.requestImportDiscordCommunity(name, description, introMessage, outroMessage, access, color, tags, imagePath, aX, aY, bX, bY, historyArchiveSupportEnabled, pinMessageAllMembersEnabled, filesToImport, fromTimestamp, encrypted)
 
 method getDiscordImportTaskItem(self: Module, t: DiscordImportTaskProgress): DiscordImportTaskItem =
@@ -321,7 +322,7 @@ method getDiscordImportTaskItem(self: Module, t: DiscordImportTaskProgress): Dis
       t.errorsCount,
       t.warningsCount)
 
-method discordImportProgressUpdated*(self: Module, communityId: string, communityName: string, tasks: seq[DiscordImportTaskProgress], progress: float, errorsCount: int, warningsCount: int, stopped: bool) =
+method discordImportProgressUpdated*(self: Module, communityId: string, communityName: string, communityImage: string, tasks: seq[DiscordImportTaskProgress], progress: float, errorsCount: int, warningsCount: int, stopped: bool) =
 
   var taskItems: seq[DiscordImportTaskItem] = @[]
 
@@ -333,6 +334,7 @@ method discordImportProgressUpdated*(self: Module, communityId: string, communit
 
   self.view.setDiscordImportCommunityId(communityId)
   self.view.setDiscordImportCommunityName(communityName)
+  self.view.setDiscordImportCommunityImage(communityImage)
   self.view.setDiscordImportErrorsCount(errorsCount)
   self.view.setDiscordImportWarningsCount(warningsCount)
   # For some reason, exposing the global `progress` as QtProperty[float]`

--- a/src/app/modules/main/communities/view.nim
+++ b/src/app/modules/main/communities/view.nim
@@ -43,6 +43,8 @@ QtObject:
       discordDataExtractionInProgress: bool
       discordImportCommunityId: string
       discordImportCommunityName: string
+      discordImportCommunityImage: string
+      discordImportHasCommunityImage: bool
 
   proc delete*(self: View) =
     self.model.delete
@@ -83,6 +85,7 @@ QtObject:
     result.discordImportInProgress = false
     result.discordImportCancelled = false
     result.discordImportProgressStopped = false
+    result.discordImportHasCommunityImage = false
     result.discordImportTasksModel = newDiscordDiscordImportTasksModel()
     result.discordImportTasksModelVariant = newQVariant(result.discordImportTasksModel)
     result.observedItem = newActiveSection()
@@ -110,6 +113,20 @@ QtObject:
   QtProperty[int] discordOldestMessageTimestamp:
     read = getDiscordOldestMessageTimestamp
     notify = discordOldestMessageTimestampChanged
+
+  proc discordImportHasCommunityImageChanged*(self: View) {.signal.}
+
+  proc setDiscordImportHasCommunityImage*(self: View, hasImage: bool) {.slot.} =
+    if (self.discordImportHasCommunityImage == hasImage): return
+    self.discordImportHasCommunityImage = hasImage
+    self.discordImportHasCommunityImageChanged()
+
+  proc getDiscordImportHasCommunityImage*(self: View): bool {.slot.} =
+    return self.discordImportHasCommunityImage
+
+  QtProperty[bool] discordImportHasCommunityImage:
+    read = getDiscordImportHasCommunityImage
+    notify = discordImportHasCommunityImageChanged
 
   proc discordImportWarningsCountChanged*(self: View) {.signal.}
 
@@ -301,6 +318,20 @@ QtObject:
     read = getDiscordImportCommunityId
     notify = discordImportCommunityIdChanged
 
+  proc discordImportCommunityImageChanged*(self: View) {.signal.}
+
+  proc getDiscordImportCommunityImage(self: View): string {.slot.} =
+    return self.discordImportCommunityImage
+
+  proc setDiscordImportCommunityImage*(self: View, image: string) {.slot.} =
+    if (self.discordImportCommunityImage == image): return
+    self.discordImportCommunityImage = image
+    self.discordImportCommunityImageChanged()
+
+  QtProperty[string] discordImportCommunityImage:
+    read = getDiscordImportCommunityImage
+    notify = discordImportCommunityImageChanged
+
   proc discordImportCommunityNameChanged*(self: View) {.signal.}
 
   proc getDiscordImportCommunityName(self: View): string {.slot.} =
@@ -352,6 +383,8 @@ QtObject:
     self.setDiscordImportWarningsCount(0)
     self.setDiscordImportCommunityId("")
     self.setDiscordImportCommunityName("")
+    self.setDiscordImportCommunityImage("")
+    self.setDiscordImportHasCommunityImage(false)
     self.setDiscordImportInProgress(false)
     self.setDiscordImportCancelled(cancelled)
 

--- a/src/app_service/service/community/service.nim
+++ b/src/app_service/service/community/service.nim
@@ -83,6 +83,7 @@ type
 
   DiscordImportProgressArgs* = ref object of Args
     communityId*: string
+    communityImage*: string
     communityName*: string
     tasks*: seq[DiscordImportTaskProgress]
     progress*: float
@@ -222,6 +223,7 @@ QtObject:
       var receivedData = DiscordCommunityImportProgressSignal(e)
       self.events.emit(SIGNAL_DISCORD_COMMUNITY_IMPORT_PROGRESS, DiscordImportProgressArgs(
         communityId: receivedData.communityId,
+        communityImage: receivedData.communityImages.thumbnail,
         communityName: receivedData.communityName,
         tasks: receivedData.tasks,
         progress: receivedData.progress,

--- a/ui/app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml
+++ b/ui/app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml
@@ -259,11 +259,18 @@ StatusScrollView {
             Layout.fillWidth: true
             spacing: 12
 
-            Image {
+            StatusLoadingIndicator {
+                Layout.preferredHeight: 24
+                Layout.preferredWidth: 24
+                Layout.alignment: Qt.AlignHCenter
+                visible: root.store.discordImportHasCommunityImage && root.store.discordImportCommunityImage.toString() == ""
+            }
+            StatusRoundedImage {
                 Layout.preferredWidth: 36
                 Layout.preferredHeight: 36
-                sourceSize: Qt.size(36, 36)
-                source: Style.svg("contact") // TODO community icon
+                image.sourceSize: Qt.size(36, 36)
+                image.source: root.store.discordImportCommunityImage
+                visible: root.store.discordImportCommunityImage.toString() !== ""
             }
             StatusBaseText {
                 Layout.fillWidth: true

--- a/ui/app/AppLayouts/CommunitiesPortal/stores/CommunitiesStore.qml
+++ b/ui/app/AppLayouts/CommunitiesPortal/stores/CommunitiesStore.qml
@@ -21,6 +21,8 @@ QtObject {
     property bool discordImportProgressStopped: root.communitiesModuleInst.discordImportProgressStopped
     property string discordImportCommunityId: root.communitiesModuleInst.discordImportCommunityId
     property string discordImportCommunityName: root.communitiesModuleInst.discordImportCommunityName
+    property url discordImportCommunityImage: root.communitiesModuleInst.discordImportCommunityImage
+    property bool discordImportHasCommunityImage: root.communitiesModuleInst.discordImportHasCommunityImage
     property var discordImportTasks: root.communitiesModuleInst.discordImportTasks
     property string locale: localAppSettings.language
     property var advancedModule: profileSectionModule.advancedModule


### PR DESCRIPTION
This needs https://github.com/status-im/status-go/pull/2947

![Screenshot from 2022-11-04 15-04-15](https://user-images.githubusercontent.com/445106/199992794-a017f250-d663-4206-b3ea-229764b50610.png)

There's one issue here though:

We only get the image from the backend when the community has been created which takes a short moment.
So we should ideally show a loading indicator instead of the image.

@caybro if you have ideas how to make that work with our existing components, feel free to update the PR