### PR TITLE
fix(ActivityCenter): Fix positioning AC popup

### DIFF
--- a/ui/StatusQ/src/StatusQ/Controls/StatusActivityCenterButton.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusActivityCenterButton.qml
@@ -36,7 +36,7 @@ StatusFlatRoundButton {
     type: StatusFlatRoundButton.Type.Secondary
 
     // initializing the tooltip
-    tooltip.text: qsTr("Activity")
+    tooltip.text: qsTr("Notifications")
     tooltip.orientation: StatusToolTip.Orientation.Bottom
     tooltip.y: parent.height + 12
 

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -992,8 +992,12 @@ Item {
             id: activityCenterPopupComponent
             ActivityCenterPopup {
                 id: activityCenter
-                height: appView.height - 56 * 2 // TODO get screen size // Taken from old code top bar height was fixed there to 56
-                y: 56
+                // TODO get screen size // Taken from old code top bar height was fixed there to 56
+                property int _buttonSize: 56
+
+                x: parent.width - width - Style.current.smallPadding
+                y: parent.y + _buttonSize
+                height: appView.height - _buttonSize * 2
                 store: chatLayoutContainer.rootStore
                 activityCenterStore: appMain.activityCenterStore
                 onClosed: {


### PR DESCRIPTION
Close #8030, #8124

Fix positioning AC popup & tooltip text

### Affected areas

Activity Center, all screens

### Screenshot of functionality (including design for comparison)

<img width="584" alt="Screenshot 2022-11-04 at 17 25 44" src="https://user-images.githubusercontent.com/2522130/199999029-40c82a0d-0411-4298-894b-9e38296406e7.png">
