### PR TITLE
ci: lock windows Go version at 1.18.8

### DIFF
--- a/scripts/windows_build_setup.ps1
+++ b/scripts/windows_build_setup.ps1
@@ -15,7 +15,10 @@ function Install-Scoop {
 # Install Git and other dependencies
 function Install-Dependencies {
     Write-Host "Installing dependencies..."
-    scoop install --global 7zip git dos2unix findutils wget make cmake gcc go rcedit inno-setup
+    scoop install --global `
+        7zip git dos2unix findutils `
+        wget rcedit inno-setup `
+        make cmake gcc go@1.18.8
     scoop bucket add extras
     scoop install --global vcredist2017
 }


### PR DESCRIPTION
Fixes the following build error:
```
protocol\messenger.go:5957:6: missing function body
protocol\messenger.go:5957:16: syntax error: unexpected [, expecting (
protocol\messenger.go:5959:2: syntax error: non-declaration statement outside function body
note: module requires Go 1.18
```