### PR TITLE
fix(InviteFriendsToCommunityPopup): adaptive popup height, consistent footer height

### DIFF
--- a/storybook/pages/CommunityProfilePopupInviteFriendsPanelPage.qml
+++ b/storybook/pages/CommunityProfilePopupInviteFriendsPanelPage.qml
@@ -18,6 +18,10 @@ Item {
                                    {colorId: 19, segmentLength: 2}])
         }
 
+        function isCompressedPubKey() {
+            return true
+        }
+
         Component.onCompleted: {
             Utils.globalUtilsInst = this
             globalUtilsReady = true

--- a/storybook/pages/CommunityProfilePopupInviteMessagePanelPage.qml
+++ b/storybook/pages/CommunityProfilePopupInviteMessagePanelPage.qml
@@ -13,6 +13,10 @@ Item {
             return "compressed"
         }
 
+        function isCompressedPubKey() {
+            return true
+        }
+
         function getColorHashAsJson(publicKey) {
             return JSON.stringify([{colorId: 0, segmentLength: 1},
                                    {colorId: 19, segmentLength: 2}])

--- a/storybook/pages/InviteFriendsToCommunityPopupPage.qml
+++ b/storybook/pages/InviteFriendsToCommunityPopupPage.qml
@@ -93,7 +93,7 @@ SplitView {
                 }
 
                 communitySectionModule: QtObject {
-                    function inviteUsersToCommunity() {
+                    function inviteUsersToCommunity(keys, message) {
                         logs.logEvent("communitySectionModule::inviteUsersToCommunity",
                                       ["keys", "message"], arguments)
                     }

--- a/storybook/pages/InviteFriendsToCommunityPopupPage.qml
+++ b/storybook/pages/InviteFriendsToCommunityPopupPage.qml
@@ -1,96 +1,137 @@
 import QtQuick 2.14
+import QtQuick.Controls 2.14
 
 import AppLayouts.Chat.popups 1.0
 import utils 1.0
 
-Item {
-    Rectangle {
-        color: 'lightgray'
-        anchors.fill: parent
-    }
+import Storybook 1.0
+
+SplitView {
+    orientation: Qt.Vertical
+
+    Logs { id: logs }
 
     property bool globalUtilsReady: false
     property bool mainModuleReady: false
 
-    QtObject {
-        function getCompressedPk(publicKey) {
-            return "compressed"
+    Item {
+
+        SplitView.fillWidth: true
+        SplitView.fillHeight: true
+
+        Rectangle {
+            color: 'lightgray'
+            anchors.fill: parent
         }
 
-        function getColorHashAsJson(publicKey) {
-            return JSON.stringify([{colorId: 0, segmentLength: 1},
-                                   {colorId: 19, segmentLength: 2}])
-        }
-
-        Component.onCompleted: {
-            Utils.globalUtilsInst = this
-            globalUtilsReady = true
-
-        }
-        Component.onDestruction: {
-            globalUtilsReady = false
-            Utils.globalUtilsInst = {}
-        }
-    }
-
-    QtObject {
-        function getContactDetailsAsJson() {
-            return JSON.stringify({})
-        }
-
-        Component.onCompleted: {
-            mainModuleReady = true
-            Utils.mainModuleInst = this
-        }
-        Component.onDestruction: {
-            mainModuleReady = false
-            Utils.mainModuleInst = {}
-        }
-    }
-
-    Loader {
-        active: globalUtilsReady && mainModuleReady
-        anchors.fill: parent
-
-        sourceComponent: InviteFriendsToCommunityPopup {
-            parent: parent
-            modal: false
+        Button {
             anchors.centerIn: parent
+            text: "Reopen"
 
-            community: ({
-                id: "communityId",
-                name: "community-name"
-            })
+            onClicked: loader.item.open()
+        }
 
-            rootStore: QtObject {
-                function communityHasMember(communityId, pubKey) {
-                    return false
-                }
+        QtObject {
+            function getCompressedPk(publicKey) {
+                return "compressed"
             }
 
-            contactsStore: QtObject {
-                readonly property ListModel myContactsModel: ListModel {
-                    Component.onCompleted: {
-                        for (let i = 0; i < 20; i++) {
-                            const key = `pub_key_${i}`
+            function isCompressedPubKey() {
+                return true
+            }
 
-                            append({
-                                alias: "",
-                                colorId: "1",
-                                displayName: `contact ${i}`,
-                                ensName: "",
-                                icon: "",
-                                isContact: true,
-                                localNickname: "",
-                                onlineStatus: 1,
-                                pubKey: key
-                            })
+            function getColorHashAsJson(publicKey) {
+                return JSON.stringify([{colorId: 0, segmentLength: 1},
+                                       {colorId: 19, segmentLength: 2}])
+            }
+
+            Component.onCompleted: {
+                Utils.globalUtilsInst = this
+                globalUtilsReady = true
+
+            }
+            Component.onDestruction: {
+                globalUtilsReady = false
+                Utils.globalUtilsInst = {}
+            }
+        }
+
+        QtObject {
+            function getContactDetailsAsJson() {
+                return JSON.stringify({})
+            }
+
+            Component.onCompleted: {
+                mainModuleReady = true
+                Utils.mainModuleInst = this
+            }
+            Component.onDestruction: {
+                mainModuleReady = false
+                Utils.mainModuleInst = {}
+            }
+        }
+
+        Loader {
+            id: loader
+            active: globalUtilsReady && mainModuleReady
+            anchors.fill: parent
+
+            sourceComponent: InviteFriendsToCommunityPopup {
+                parent: parent
+                modal: false
+                anchors.centerIn: parent
+
+                community: ({
+                    id: "communityId",
+                    name: "community-name"
+                })
+
+                rootStore: QtObject {
+                    function communityHasMember(communityId, pubKey) {
+                        return false
+                    }
+                }
+
+                communitySectionModule: QtObject {
+                    function inviteUsersToCommunity() {
+                        logs.logEvent("communitySectionModule::inviteUsersToCommunity",
+                                      ["keys", "message"], arguments)
+                    }
+                }
+
+                contactsStore: QtObject {
+                    readonly property ListModel myContactsModel: ListModel {
+                        Component.onCompleted: {
+                            for (let i = 0; i < 20; i++) {
+                                const key = `pub_key_${i}`
+
+                                append({
+                                    alias: "",
+                                    colorId: "1",
+                                    displayName: `contact ${i}`,
+                                    ensName: "",
+                                    icon: "",
+                                    isContact: true,
+                                    localNickname: "",
+                                    onlineStatus: 1,
+                                    pubKey: key
+                                })
+                            }
                         }
                     }
                 }
-            }
 
-            Component.onCompleted: open()
+                Component.onCompleted: open()
+            }
         }
+    }
+
+    LogsAndControlsPanel {
+        id: logsAndControlsPanel
+
+        SplitView.minimumHeight: 100
+        SplitView.preferredHeight: 200
+
+        logsView.logText: logs.logText
     }
 }

--- a/storybook/src/Storybook/PagesList.qml
+++ b/storybook/src/Storybook/PagesList.qml
@@ -15,6 +15,8 @@ ListView {
 
         text: model.title
         checked: root.currentPage === model.title
+
         onClicked: root.pageSelected(model.title)
+        onCheckableChanged: checkable = false
     }
 }

--- a/ui/app/AppLayouts/Chat/popups/community/InviteFriendsToCommunityPopup.qml
+++ b/ui/app/AppLayouts/Chat/popups/community/InviteFriendsToCommunityPopup.qml
@@ -27,6 +27,10 @@ StatusStackModal {
     QtObject {
         id: d
 
+        // values from Figma design
+        readonly property int footerButtonsHeight: 44
+        readonly property int popupContentHeight: 551
+
         function sendInvites(pubKeys, inviteMessage) {
             const error = root.communitySectionModule.inviteUsersToCommunity(JSON.stringify(pubKeys), inviteMessage);
             d.processInviteResult(error);
@@ -51,7 +55,6 @@ StatusStackModal {
 
     stackTitle: qsTr("Invite Contacts to %1").arg(community.name)
     width: 640
-    implicitHeight: 700
 
     padding: 0
     leftPadding: 0
@@ -59,6 +62,7 @@ StatusStackModal {
 
     nextButton: StatusButton {
         objectName: "InviteFriendsToCommunityPopup_NextButton"
+        implicitHeight: d.footerButtonsHeight
         text: qsTr("Next")
         enabled: root.pubKeys.length
         onClicked: {
@@ -68,6 +72,7 @@ StatusStackModal {
 
     finishButton: StatusButton {
         objectName: "InviteFriendsToCommunityPopup_SendButton"
+        implicitHeight: d.footerButtonsHeight
         enabled: root.pubKeys.length > 0
         text: qsTr("Send Invites")
         onClicked: {
@@ -87,6 +92,8 @@ StatusStackModal {
 
     stackItems: [
         Item {
+            implicitHeight: d.popupContentHeight
+
             CommunityProfilePopupInviteFriendsPanel {
                 anchors.fill: parent
                 anchors.topMargin: 16


### PR DESCRIPTION
### What does the PR do

Fixes problems with improper size and inconsistent footer of `InviteFriendsToCommunityPopup`.

Closes: https://github.com/status-im/status-desktop/issues/7604
Closes: https://github.com/status-im/status-desktop/issues/7605

### Affected areas
`InviteFriendsToCommunityPopup`

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

[Kazam_screencast_00078.webm](https://user-images.githubusercontent.com/20650004/200326982-4ad1e3c2-5ecc-417e-8b63-d5103380ccae.webm)
