### PR TITLE
fix(AppSearch): ensure app search loader is deactivated when popup is

### DIFF
--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -286,11 +286,13 @@ Item {
         function closeSearchPopup() {
             if (item)
                 item.closeSearchPopup()
+
             active = false
         }
 
         sourceComponent: AppSearch {
             store: appMain.rootStore.appSearchStore
+            onClosed: appSearch.active = false
         }
     }
 

--- a/ui/app/mainui/AppSearch.qml
+++ b/ui/app/mainui/AppSearch.qml
@@ -14,6 +14,8 @@ Item {
     })
     property alias opened: searchPopup.opened
 
+    signal closed()
+
     function openSearchPopup(){
         searchPopup.open()
     }
@@ -72,6 +74,7 @@ Item {
         }
         onClosed: {
             searchPopupMenu.dismiss();
+            appSearch.closed();
         }
         onResetSearchLocationClicked: {
             searchPopup.resetSearchSelection();


### PR DESCRIPTION
closed

Otherwise, the loader stays active, which requires users to hit CTRL-F twice to reopen it again (because it'll first deactivate, then activate again).

Fixes #7989

