### PR TITLE
Fix/issue 8118

### DIFF
--- a/ui/app/AppLayouts/Profile/views/MessagingView.qml
+++ b/ui/app/AppLayouts/Profile/views/MessagingView.qml
@@ -144,8 +144,8 @@ SettingsContentBase {
                             RootStore.updateWhitelistedUnfurlingSites(item.address, false)
                         }
                     }
-                    checked: false
-                    onCheckedChanged: {
+                    checked: previewableSites.anyWhitelisted || localAccountSensitiveSettings.displayChatImages
+                    onToggled: {
                         if (checked === false) {
                             switchOffPreviewableSites()
                         }
@@ -153,7 +153,10 @@ SettingsContentBase {
                 }
             ]
             onClicked: {
-                showMessageLinksSwitch.checked = !showMessageLinksSwitch.checked
+                showMessageLinksSwitch.toggle()
+                if (showMessageLinksSwitch.checked === false) {
+                    showMessageLinksSwitch.switchOffPreviewableSites()
+                }
             }
         }
 
@@ -177,8 +180,8 @@ SettingsContentBase {
 
         function populatePreviewableSites() {
             const [anyWhitelisted, whitelist] = buildPreviewablesSitesJSON()
-            showMessageLinksSwitch.checked = anyWhitelisted
             previewableSites.populateModel(whitelist)
+            previewableSites.anyWhitelisted = anyWhitelisted
         }
 
         Component.onCompleted: {
@@ -219,6 +222,8 @@ SettingsContentBase {
                         previewableSites.remove(jsonModel.length - 1, rowsToDelete)
                     }
                 }
+                
+                property bool anyWhitelisted: false
             }
 
             Connections {
@@ -243,11 +248,6 @@ SettingsContentBase {
                 // TODO find a better icon for this
                 asset.name: Style.svg('globe')
                 asset.isImage: true
-                Component.onCompleted: {
-                    if (localAccountSensitiveSettings.displayChatImages) {
-                        showMessageLinksSwitch.checked = true
-                    }
-                }
                 components: [
                     StatusSwitch {
                         id: imageSwitch

--- a/ui/app/AppLayouts/Profile/views/MessagingView.qml
+++ b/ui/app/AppLayouts/Profile/views/MessagingView.qml
@@ -154,7 +154,7 @@ SettingsContentBase {
             ]
             onClicked: {
                 showMessageLinksSwitch.toggle()
-                if (showMessageLinksSwitch.checked === false) {
+                if (!showMessageLinksSwitch.checked) {
                     showMessageLinksSwitch.switchOffPreviewableSites()
                 }
             }


### PR DESCRIPTION
There are two main changes in the model -> view relationship:
1. The model coming from the store becomes the only source of truth and the UI will only change when the model changes. This means that when another UI component from settings menu wants to change some setting it needs to update the model, not UI components directly.
2. When the store will provide a new model we will update only rows that are different in the current model.

+ Fix Display message links preview switch that was not being disabled if the last disabled item was the Image Unfurling

### What does the PR do
Fixing bug #8118 
### Affected areas
Messaging settings view
Display message links preview in the chat
Save messaging settings to perssistancy
### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [x] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

- [ ] I've checked the design and this PR matches it

https://user-images.githubusercontent.com/47811206/200347703-11a85aff-caa5-47bb-aeed-d3891e7ff7a3.mov



### Cool Spaceship Picture

<!-- optional but cool ->
