### PR TITLE
chore(waku2): add extra logging

### DIFF
--- a/src/app/core/signals/remote_signals/messages.nim
+++ b/src/app/core/signals/remote_signals/messages.nim
@@ -1,4 +1,4 @@
-import json
+import json, chronicles
 
 import base
 
@@ -55,6 +55,7 @@ proc fromEvent*(T: type MessageSignal, event: JsonNode): MessageSignal =
     for jsonMsg in event["event"]["messages"]:
       var message = jsonMsg.toMessageDto()
       signal.messages.add(message)
+      info "received", signal="messages.new", messageID=message.id
 
   if event["event"]{"chats"} != nil:
     for jsonChat in event["event"]["chats"]:


### PR DESCRIPTION
Fixes: #8099 

Instead of enabling this only on DEBUG as requested in original issue, I'm doing it on INFO, since debug adds a lot of noise in the geth.log file, while this only logs the envelope hashes and message IDs (there's a point to discuss whether this could expose unwanted data).

Requires:
- https://github.com/status-im/status-go/pull/2948

In go-waku, changes were done in https://github.com/status-im/go-waku/tree/status-go . This branch is meant only for tracing the missing messages and is not going to be merged on master.

Text to search for when tracing a message:
- `waku.store retrieved` - Contains an array of WakuMessage hashes of all messages retrieved from store node
- `waku.relay received` - Contains hash of WakuMessage received via waku relay
- `waku.relay published` - Contains hash of WakuMessage published via waku relay
- `waku.lightpush published` - Contains hash of WakuMessage published via waku lightpush
- `received waku2 store message` - Indicates that a message retrieved via waku store, was received in status-go
- `publishing message via lightpush` - Printed before sending a message with lightpush in status-go
- `publishing message via relay` - Printed before sending a message with relay in status-go
- `could not send message` - Contains details of any error while sending a message in status-go
- `received new envelope` - Indicates that a message arrived to status-go via a subscription
- `processing message` - called in handleRetrievedMessages in status-go, contains the WakuMessage hash, and the Status Message IDs contained in that WakuMessage
- `received` `signal="messages.new"` - Indicates which message IDs arrived to status-desktop via the `messages.new` signal

