### PR TITLE
fix(StatusTextMessage): Links not clickable in a long collapsed message

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusTextMessage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusTextMessage.qml
@@ -63,7 +63,7 @@ Item {
 
         width: parent.width
         height: effectiveHeight + d.showMoreHeight / 2
-        visible: !opMask.active
+        opacity: opMask.active ? 0 : 1
         clip: true
         text: d.text
         selectedTextColor: Theme.palette.directColor1
@@ -87,7 +87,7 @@ Item {
     Loader {
         id: mask
         anchors.fill: chatText
-        active: showMoreLoader.active
+        active: showMoreLoader.active && !d.readMore
         visible: false
         sourceComponent: LinearGradient {
             start: Qt.point(0, 0)


### PR DESCRIPTION
Setting `visible` or `enabled` to `false` stops mouse events from being propagated -> hide the original message using `opacity` instead

Fixes links being unclickable when the gradient/mask is in effect

Closes #8116

### What does the PR do

Fixes text messages being non interactive

### Affected areas

StatusTextMessage

### Screenshot of functionality (including design for comparison)

- [N/A] I've checked the design and this PR matches it
