### PR TITLE
fix(edit-message): Add content-type to edit message request

### DIFF
--- a/src/app/modules/main/chat_section/chat_content/messages/controller.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/controller.nim
@@ -247,8 +247,8 @@ proc getMessageDetails*(self: Controller, messageId: string):
 proc deleteMessage*(self: Controller, messageId: string) =
   self.messageService.deleteMessage(messageId)
 
-proc editMessage*(self: Controller, messageId: string, updatedMsg: string) =
-  self.messageService.editMessage(messageId, updatedMsg)
+proc editMessage*(self: Controller, messageId: string, contentType: int, updatedMsg: string) =
+  self.messageService.editMessage(messageId, contentType, updatedMsg)
 
 proc getLinkPreviewData*(self: Controller, link: string, uuid: string): string =
   self.messageService.asyncGetLinkPreviewData(link, uuid)

--- a/src/app/modules/main/chat_section/chat_content/messages/io_interface.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/io_interface.nim
@@ -116,7 +116,7 @@ method deleteMessage*(self: AccessInterface, messageId: string) {.base.} =
 method onMessageDeleted*(self: AccessInterface, messageId: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method editMessage*(self: AccessInterface, messageId: string, updatedMsg: string) {.base.} =
+method editMessage*(self: AccessInterface, messageId: string, contentType: int, updatedMsg: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method onHistoryCleared*(self: AccessInterface) {.base.} =

--- a/src/app/modules/main/chat_section/chat_content/messages/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/module.nim
@@ -450,8 +450,8 @@ method deleteMessage*(self: Module, messageId: string) =
 method onMessageDeleted*(self: Module, messageId: string) =
   self.view.model().removeItem(messageId)
 
-method editMessage*(self: Module, messageId: string, updatedMsg: string) =
-  self.controller.editMessage(messageId, updatedMsg)
+method editMessage*(self: Module, messageId: string, contentType: int, updatedMsg: string) =
+  self.controller.editMessage(messageId, contentType, updatedMsg)
 
 method onMessageEdited*(self: Module, message: MessageDto) =
   let itemBeforeChange = self.view.model().getItemWithMessageId(message.id)

--- a/src/app/modules/main/chat_section/chat_content/messages/view.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/view.nim
@@ -131,8 +131,8 @@ QtObject:
   proc setEditModeOff*(self: View, messageId: string) {.slot.} =
    self.model.setEditModeOff(messageId)
 
-  proc editMessage*(self: View, messageId: string, updatedMsg: string) {.slot.} =
-    self.delegate.editMessage(messageId, updatedMsg)
+  proc editMessage*(self: View, messageId: string, contentType: int, updatedMsg: string) {.slot.} =
+    self.delegate.editMessage(messageId, contentType, updatedMsg)
 
   proc getLinkPreviewData*(self: View, link: string, uuid: string): string {.slot.} =
     return self.delegate.getLinkPreviewData(link, uuid)

--- a/src/app_service/service/message/service.nim
+++ b/src/app_service/service/message/service.nim
@@ -784,12 +784,12 @@ proc deleteMessage*(self: Service, messageId: string) =
   except Exception as e:
     error "error: ", procName="deleteMessage", errName = e.name, errDesription = e.msg
 
-proc editMessage*(self: Service, messageId: string, msg: string) =
+proc editMessage*(self: Service, messageId: string, contentType: int, msg: string) =
   try:
     let allKnownContacts = self.contactService.getContactsByGroup(ContactsGroup.AllKnownContacts)
     let processedMsg = message_common.replaceMentionsWithPubKeys(allKnownContacts, msg)
 
-    let response = status_go.editMessage(messageId, processedMsg)
+    let response = status_go.editMessage(messageId, contentType, processedMsg)
 
     var messagesArr: JsonNode
     var messages: seq[MessageDto]

--- a/src/backend/messages.nim
+++ b/src/backend/messages.nim
@@ -62,5 +62,5 @@ proc markCertainMessagesFromChatWithIdAsRead*(chatId: string, messageIds: seq[st
 proc deleteMessageAndSend*(messageID: string): RpcResponse[JsonNode] {.raises: [Exception].} =
   result = callPrivateRPC("deleteMessageAndSend".prefix, %* [messageID])
 
-proc editMessage*(messageId: string, msg: string): RpcResponse[JsonNode] {.raises: [Exception].} =
-  result = callPrivateRPC("editMessage".prefix, %* [{"id": messageId, "text": msg}])
+proc editMessage*(messageId: string, contentType: int, msg: string): RpcResponse[JsonNode] {.raises: [Exception].} =
+  result = callPrivateRPC("editMessage".prefix, %* [{"id": messageId, "text": msg, "content-type": contentType}])

--- a/ui/app/AppLayouts/Chat/stores/MessageStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/MessageStore.qml
@@ -162,10 +162,10 @@ QtObject {
         messageModule.setEditModeOff(messageId)
     }
 
-    function editMessage(messageId, updatedMsg) {
+    function editMessage(messageId, contentType, updatedMsg) {
         if(!messageModule)
             return
-        messageModule.editMessage(messageId, updatedMsg)
+        messageModule.editMessage(messageId, contentType, updatedMsg)
     }
 
     function interpretMessage(msg) {

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -432,7 +432,7 @@ Loader {
 
                     const interpretedMessage = root.messageStore.interpretMessage(message)
                     root.messageStore.setEditModeOff(root.messageId)
-                    root.messageStore.editMessage(root.messageId, interpretedMessage)
+                    root.messageStore.editMessage(root.messageId, root.messageContentType, interpretedMessage)
                 }
 
                 audioMessageInfoText: qsTr("Audio Message")


### PR DESCRIPTION
Closes: #7879

In general, status-go validation is wrong when user trying to edit the message. If content type of message was not set, status-go replace message content type with `ChatMessage_UNKNOWN_CONTENT_TYPE` successfully.

### What does the PR do

Provide `ContentType` of edited message in request.

### Affected areas

Edit messages 
