### PR TITLE
fix(StatusQ) scrolling on macOS if mouse pointer is over StatusBaseInput

### DIFF
--- a/ui/StatusQ/src/StatusQ/Controls/StatusBaseInput.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusBaseInput.qml
@@ -35,6 +35,9 @@ import StatusQ.Core.Utils 0.1
       \image status_base_input.png
 
       For a list of components available see StatusQ.
+
+      \note The scrolling behavior of the \c StatusBaseInput is disabled for non-multiline configurations.
+        This is to prevent the \c StatusBaseInput capturing the macOS trackpad input from being propagated.
 */
 
 Item {
@@ -337,6 +340,7 @@ Item {
                         enabled: multiline
                     }
                     clip: true
+                    interactive: multiline
 
                     TextEdit {
                         id: edit


### PR DESCRIPTION
### Fixes #5355

This commit fixes scrolling on macOS using trackpad in the context of Add Wallet Account using seed-phrase.

#### Considerations:

The scrolling of advanced input with seed-phrase selected was failing when mouse pointer was moving over a word phrase.

Scrolling of the popup content in `AddAccountModal` would not work when the mouse pointer was over the `StatusSeedPhraseInput` form the `ImportSeedPhrasePanel`

The identified root cause is `StatusBaseInput`'s `Flickable` which captures the specially generated mouse wheel event. It seems the trackpad wheel events are handled differently on `macOS` by the `Flickable` and are not propagated to the parent.

The fix disables user interactions for single-line items where there should be no need

### Affected areas

Add Account Wallet and all the panels and views that might rely on the StatusQ custom input controls that rely on the base input to stop mouse scroll events.

### Debugging Review

The issue was hard to find due to `StatusBaseInput` having too many responsibilities: it provides the specific text input, additional decorations and scrolling the view inside its container. I found this approach unintuitive. A StatusDecoratedScrollableBaseInput would have been a more appropriate name.

### StatusQ checklist

- [x] add documentation if necessary (new component, new feature)
- [x] ~~update sandbox app~~
  - I looked to add it to the corner cases for the input panel but none was found and no time left to build it