### PR TITLE
fix(CreateChannelPopup): cursor not jumping to the end 

### DIFF
--- a/storybook/main.qml
+++ b/storybook/main.qml
@@ -59,6 +59,9 @@ ApplicationWindow {
         ListElement {
              title: "BrowserSettings"
         }
+        ListElement {
+             title: "CreateChannelPopup"
+        }
     }
 
     SplitView {

--- a/storybook/pages/CreateChannelPopupPage.qml
+++ b/storybook/pages/CreateChannelPopupPage.qml
@@ -1,0 +1,89 @@
+import QtQuick 2.14
+import QtQuick.Controls 2.14
+import QtQuick.Layouts 1.14
+
+import Storybook 1.0
+
+import AppLayouts.Chat.popups.community 1.0
+
+SplitView {
+    id: root
+
+    Logs { id: logs }
+
+    orientation: Qt.Vertical
+
+    Item {
+        SplitView.fillWidth: true
+        SplitView.fillHeight: true
+
+        PopupBackground {
+            anchors.fill: parent
+        }
+
+        CreateChannelPopup {
+            anchors.centerIn: parent
+            modal: false
+            closePolicy: Popup.NoAutoClose
+
+            isEdit: isEditCheckBox.checked
+            isDeleteable: isDeleteableCheckBox.checked
+
+            emojiPopup: Popup {
+                id: emojiPopup
+
+                parent: root
+
+                property var emojiSize
+
+                Button {
+                    text: "😃"
+                    onClicked: {
+                        emojiPopup.emojiSelected(text, false)
+                        emojiPopup.close()
+                    }
+                }
+
+                signal emojiSelected(string emoji, bool atCu)
+            }
+
+
+            onCreateCommunityChannel: (chName, chDescription, chEmoji, chColor, chCategoryId) => {
+                logs.logEvent("onCreateCommunityChannel",
+                              ["chName", "chDescription", "chEmoji", "chColor", "chCategoryId"], arguments)
+            }
+
+            onEditCommunityChannel: (chName, chDescription, chEmoji, chColor, chCategoryId) => {
+                logs.logEvent("onEditCommunityChannel",
+                              ["chName", "chDescription", "chEmoji", "chColor", "chCategoryId"], arguments)
+            }
+
+            onDeleteCommunityChannel: () => {
+                logs.logEvent("onDeleteCommunityChannel")
+            }
+
+            Component.onCompleted: open()
+        }
+    }
+
+    LogsAndControlsPanel {
+        SplitView.minimumHeight: 100
+        SplitView.preferredHeight: 200
+
+        logsView.logText: logs.logText
+
+        RowLayout {
+            CheckBox {
+                id: isEditCheckBox
+
+                text: "isEdit"
+            }
+            CheckBox {
+                id: isDeleteableCheckBox
+
+                enabled: isEditCheckBox.checked
+                text: "isDeleteable"
+            }
+        }
+    }
+}

--- a/storybook/pages/InviteFriendsToCommunityPopupPage.qml
+++ b/storybook/pages/InviteFriendsToCommunityPopupPage.qml
@@ -19,8 +19,7 @@ SplitView {
         SplitView.fillWidth: true
         SplitView.fillHeight: true
 
-        Rectangle {
-            color: 'lightgray'
+        PopupBackground {
             anchors.fill: parent
         }
 

--- a/storybook/src/Storybook/LogsAndControlsPanel.qml
+++ b/storybook/src/Storybook/LogsAndControlsPanel.qml
@@ -2,6 +2,8 @@ import QtQuick 2.14
 import QtQuick.Controls 2.14
 import QtQuick.Layouts 1.14
 
+import Qt.labs.settings 1.0
+
 ColumnLayout {
     readonly property alias logsView: logsView
     default property alias controls: controlsPane.contentData
@@ -13,6 +15,8 @@ ColumnLayout {
 
         Layout.fillWidth: true
         contentHeight: 30
+
+        currentIndex: settings.logsOrControlsTab
 
         TabButton {
             text: "Events"
@@ -39,5 +43,11 @@ ColumnLayout {
         Pane {
             id: controlsPane
         }
+    }
+
+    Settings {
+        id: settings
+
+        property alias logsOrControlsTab: tabs.currentIndex
     }
 }

--- a/storybook/src/Storybook/PopupBackground.qml
+++ b/storybook/src/Storybook/PopupBackground.qml
@@ -1,0 +1,5 @@
+import QtQuick 2.14
+
+Rectangle {
+    color: 'lightgray'
+}

--- a/storybook/src/Storybook/qmldir
+++ b/storybook/src/Storybook/qmldir
@@ -9,5 +9,6 @@ Logs 1.0 Logs.qml
 LogsAndControlsPanel 1.0 LogsAndControlsPanel.qml
 LogsView 1.0 LogsView.qml
 PagesList 1.0 PagesList.qml
+PopupBackground 1.0 PopupBackground.qml
 SourceCodeBox 1.0 SourceCodeBox.qml
 singleton StorybookUtils 1.0 StorybookUtils.qml

--- a/ui/app/AppLayouts/Chat/popups/community/CreateChannelPopup.qml
+++ b/ui/app/AppLayouts/Chat/popups/community/CreateChannelPopup.qml
@@ -98,7 +98,6 @@ StatusDialog {
 
         Column {
             id: content
-            width: parent.width
 
             StatusInput {
                 id: nameInput
@@ -108,8 +107,9 @@ StatusDialog {
                 placeholderText: qsTr("# Name the channel")
 
                 input.onTextChanged: {
-                    input.text = Utils.convertSpacesToDashesAndUpperToLowerCase(input.text);
-                    input.cursorPosition = input.text.length
+                    const cursorPosition = input.cursorPosition
+                    input.text = Utils.convertSpacesToDashesAndUpperToLowerCase(input.text)
+                    input.cursorPosition = cursorPosition
                     if (root.channelEmoji === "") {
                         input.letterIconName = text;
                     }

--- a/ui/app/AppLayouts/Chat/popups/community/qmldir
+++ b/ui/app/AppLayouts/Chat/popups/community/qmldir
@@ -1,0 +1,1 @@
+CreateChannelPopup 1.0 CreateChannelPopup.qml

--- a/ui/imports/utils/Utils.qml
+++ b/ui/imports/utils/Utils.qml
@@ -7,8 +7,8 @@ import StatusQ.Core.Theme 0.1
 import StatusQ.Core.Utils 0.1 as StatusQUtils
 
 QtObject {
-    property var mainModuleInst: mainModule
-    property var globalUtilsInst: globalUtils
+    property var mainModuleInst: typeof mainModule !== "undefined" ? mainModule : null
+    property var globalUtilsInst: typeof globalUtils !== "undefined" ? globalUtils : null
 
     function isDigit(value) {
       return /^\d$/.test(value);


### PR DESCRIPTION
### What does the PR do

When typing at non-end position (in channel name filed) cursor is no longer jumping to the end. Additionally binding loop on "contentWidth" is fixed.

`CreateChannelPopup` has been added to the Storybook.

Closes: https://github.com/status-im/status-desktop/issues/7805

### Affected areas
`CreateChannelPopup`

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

[Kazam_screencast_00081.webm](https://user-images.githubusercontent.com/20650004/200682950-5800545d-a780-4850-ba1a-25460597127d.webm)
