### PR TITLE
fix(Contacts): use `ContactRequestState` to filter out rejected requests

### DIFF
--- a/src/app_service/service/contacts/service.nim
+++ b/src/app_service/service/contacts/service.nim
@@ -233,7 +233,7 @@ QtObject:
         x.isContactRequestReceived() and 
         not x.isContactRequestSent() and
         not x.isContactRemoved() and
-        # not x.isReceivedContactRequestRejected() and
+        not x.isReceivedContactRequestRejected() and
         not x.isBlocked())
     elif (group == ContactsGroup.OutgoingPendingContactRequests):
       return contacts.filter(x => x.id != myPubKey and 
@@ -242,12 +242,11 @@ QtObject:
         # not x.isSentContactRequestRejected() and
         not x.isContactRemoved() and
         not x.isBlocked())
-    # Temporary commented until we provide appropriate flags on the `status-go` side to cover all sections.
-    # elif (group == ContactsGroup.IncomingRejectedContactRequests):
-    #   return contacts.filter(x => x.id != myPubKey and 
-    #     x.isContactRequestReceived() and 
-    #     x.isReceivedContactRequestRejected() and
-    #     not x.isBlocked())
+    elif (group == ContactsGroup.IncomingRejectedContactRequests):
+      return contacts.filter(x => x.id != myPubKey and 
+        x.isContactRequestReceived() and 
+        x.isReceivedContactRequestRejected() and
+        not x.isBlocked())
     # elif (group == ContactsGroup.OutgoingRejectedContactRequests):
     #   return contacts.filter(x => x.id != myPubKey and 
     #     x.isContactRequestSent() and 


### PR DESCRIPTION
There's a bug in determining pending incoming contact requests where we don't honor already rejected ones.

Simply checking if a contact in question `hasAddedUs` isn't enough because that only tells us if the contact has sent us a request in the past. It doesn't tell is whether the request was rejected already.

As a result, rejected contact requests keep popping up in the UI after restarting the app. See #8156 for more information.

This commit introduces a `ContactRequestState` enum in Status Desktop, similar to how it exists in status-go. Using this as `requestState` on `ContactDto`, we can easily figure out what's the request state for any given contact.

Notices that this only makes use of `ContactRequestState` to check for whether a request was rejected.

We probably want to consider using this for all other states as well (instead of relying on system tags).

Closes #8156

