### PR TITLE
fix(@desktop/general): use utf-8 text for calculating 'StatusBaseInpu…

### DIFF
--- a/ui/StatusQ/src/StatusQ/Controls/StatusBaseInput.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusBaseInput.qml
@@ -371,7 +371,8 @@ Item {
                             }
                             root.dirty = true
                             if (root.maximumLength > 0) {
-                                if (text.length > root.maximumLength) {
+                                let utf8Length = Utils.encodeUtf8(text).length
+                                if (utf8Length > root.maximumLength) {
                                     var cursor = cursorPosition
                                     text = previousText
                                     if (cursor > text.length) {

--- a/ui/StatusQ/src/StatusQ/Controls/StatusInput.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusInput.qml
@@ -6,6 +6,7 @@ import StatusQ.Core.Backpressure 1.0
 import StatusQ.Core.Theme 0.1
 import StatusQ.Controls 0.1
 import StatusQ.Controls.Validators 0.1
+import StatusQ.Core.Utils 0.1
 
 /*!
    \qmltype StatusInput
@@ -256,10 +257,12 @@ Item {
         \qmlmethod
         This function validates the text input's text.
     */
+
     function validate(force) {
         if (!force && !statusBaseInput.dirty && validationMode === StatusInput.ValidationMode.OnlyWhenDirty) {
             return
         }
+
         statusBaseInput.valid = true
         if (validators.length) {
             for (let idx in validators) {
@@ -403,7 +406,7 @@ Item {
                 Layout.alignment: Qt.AlignVCenter
                 height: visible ? contentHeight : 0
                 visible: root.charLimit > 0
-                text: "%1 / %2".arg(statusBaseInput.text.length).arg(root.charLimit)
+                text: "%1 / %2".arg(Utils.encodeUtf8(statusBaseInput.text).length).arg(root.charLimit)
                 font.pixelSize: 12
                 color: statusBaseInput.enabled ? Theme.palette.baseColor1 : Theme.palette.directColor6
             }

--- a/ui/StatusQ/src/StatusQ/Core/Utils/Utils.qml
+++ b/ui/StatusQ/src/StatusQ/Core/Utils/Utils.qml
@@ -267,7 +267,7 @@ QtObject {
     }
 
     function encodeUtf8(str){
-        return unescape( encodeURIComponent(str));
+        return unescape(encodeURIComponent(str));
     }
 }
 

--- a/ui/StatusQ/src/StatusQ/Core/Utils/Utils.qml
+++ b/ui/StatusQ/src/StatusQ/Core/Utils/Utils.qml
@@ -265,6 +265,10 @@ QtObject {
         else if (flickableBottom <= rectBottom)
             flickable.contentY = rectBottom - flickable.height
     }
+
+    function encodeUtf8(str){
+        return unescape( encodeURIComponent(str));
+    }
 }
 
 


### PR DESCRIPTION
…t' text length and current length in 'StatusInput'

### What does the PR do

- convert utf16 text to utf8 text inside `StatusBaseInput` in order to correctly count input length for text with emoji
- count current input length as utf8 text for `StatusInput`

### Affected areas

All places, where `StatusBaseInput` and `StatusInput` are used

