### PR TITLE
fix(@desktop/chat): Fixing display community invitation bubble with l…

### DIFF
--- a/ui/imports/shared/views/chat/InvitationBubbleView.qml
+++ b/ui/imports/shared/views/chat/InvitationBubbleView.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.3
+import QtQuick 2.14
 import QtQuick.Dialogs 1.3
 import QtQuick.Layouts 1.14
 
@@ -171,26 +171,49 @@ Item {
                         spacing: 2
 
                         StatusBaseText {
+                            id: communityNameText
                             Layout.fillWidth: true
-
                             text: d.invitedCommunity.name
                             font.weight: Font.Bold
-                            wrapMode: Text.WrapAtWordBoundaryOrAnywhere
+                            maximumLineCount: 1
+                            elide: Text.ElideRight
                             font.pixelSize: 17
                             color: Theme.palette.directColor1
+
+                            StatusToolTip {
+                                id: communityNameTooltip
+                                enabled: communityNameText.truncated
+                                text: communityNameText.text
+                                visible: nameHoverHandler.hovered
+                            }
+
+                            HoverHandler {
+                                id: nameHoverHandler
+                            }
                         }
 
                         StatusBaseText {
+                            id: communityDescriptionText
                             Layout.fillWidth: true
-
+                            maximumLineCount: 1
                             text: d.invitedCommunity.description
-                            wrapMode: Text.WrapAtWordBoundaryOrAnywhere
+                            elide: Text.ElideRight
                             color: Theme.palette.directColor1
+
+                            StatusToolTip {
+                                id: communityDescriptionTooltip
+                                enabled: communityDescriptionText.truncated
+                                text: communityDescriptionText.text
+                                visible: descHoverHandler.hovered
+                            }
+
+                            HoverHandler {
+                                id: descHoverHandler
+                            }
                         }
 
                         StatusBaseText {
                             Layout.fillWidth: true
-
                             text: qsTr("%n member(s)", "", d.invitedCommunity.nbMembers)
                             font.pixelSize: 13
                             font.weight: Font.Medium


### PR DESCRIPTION
Fix #8101

### What does the PR do

Fixing displaying community invitation bubble with long name and description

Name can have only 1 line and is elided.
Description can have only 1 line and is elided.
Tooltips are added to display whole text.

### Affected areas

Chat / community invitation bubble

### Screenshot of functionality (including design for comparison)

![image](https://user-images.githubusercontent.com/61889657/201156901-f1bbd1d3-484c-48db-b748-aca8ee1cb692.png)

![image](https://user-images.githubusercontent.com/61889657/201156949-3e1f7ae7-0781-4609-9750-32d9c0a470d9.png)


