### PR TITLE
Replied messages styling and behavior fixes

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
@@ -80,6 +80,7 @@ Rectangle {
     signal profilePictureClicked(var sender, var mouse)
     signal senderNameClicked(var sender, var mouse)
     signal replyProfileClicked(var sender, var mouse)
+    signal replyMessageClicked(var mouse)
 
     signal addReactionClicked(var sender, var mouse)
     signal toggleReactionClicked(int emojiId)
@@ -219,11 +220,9 @@ Rectangle {
             sourceComponent: StatusMessageReply {
                 replyDetails: root.replyDetails
                 profileClickable: root.profileClickable
-                onReplyProfileClicked: root.replyProfileClicked(sender, mouse)
                 audioMessageInfoText: root.audioMessageInfoText
-                onLinkActivated: {
-                    root.linkActivated(link);
-                }
+                onReplyProfileClicked: root.replyProfileClicked(sender, mouse)
+                onMessageClicked: root.replyMessageClicked(mouse)
             }
         }
 

--- a/ui/StatusQ/src/StatusQ/Core/Utils/Utils.qml
+++ b/ui/StatusQ/src/StatusQ/Core/Utils/Utils.qml
@@ -222,6 +222,10 @@ QtObject {
         return text.replace(/<br\s*\/>/gm, " ")
     }
 
+    function stripHtmlTags(text) {
+        return text.replace(/<[^>]*>?/gm, '')
+    }
+
     function delegateModelSort(srcGroup, dstGroup, lessThan) {
         const insertPosition = (lessThan, item) => {
             let lower = 0

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -539,6 +539,10 @@ Loader {
                     root.messageClickHandler(sender, Qt.point(mouse.x, mouse.y), true, false, false, null, false, false, true);
                 }
 
+                onReplyMessageClicked: {
+                    root.messageStore.messageModule.jumpToMessage(root.responseToMessageWithId)
+                }
+
                 onSenderNameClicked: {
                     d.setMessageActive(root.messageId, true);
                     root.messageClickHandler(sender, Qt.point(mouse.x, mouse.y), true);

--- a/ui/imports/utils/Utils.qml
+++ b/ui/imports/utils/Utils.qml
@@ -58,23 +58,6 @@ QtObject {
         return Style.current.accountColors[colorIndex]
     }
 
-    function getReplyMessageStyle(msg, isCurrentUser) {
-        return `<style type="text/css">`+
-                    `a {`+
-                        `color: ${Style.current.textColor};`+
-                    `}`+
-                    `a.mention {`+
-                        `color: ${isCurrentUser ? Style.current.mentionColor : Style.current.turquoise};`+
-                        `background-color: ${Style.current.mentionBgColor};` +
-                    `}`+
-               `</style>`+
-               `</head>`+
-               `<body>`+
-                   `${msg}`+
-               `</body>`+
-            `</html>`
-    }
-
     function getLinkStyle(link, hoveredLink, textColor) {
         return `<style type="text/css">` +
                 `a {` +


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/7673

### What does the PR do

- Click on a replied message to jump to it
- Remove text styling in replied messages
- Replied messages smooth fade out instead of clipping

### Affected areas

chat

### Screenshot of functionality (including design for comparison)

NOTE:
As discussed with design team, there should be no code styling in the text of relied messages, even that we have "mentions" styling in designs.

<img width="1126" alt="Снимок экрана 2022-11-08 в 20 33 11" src="https://user-images.githubusercontent.com/25482501/201308383-a2d0cbfe-2b40-4b5d-bcee-24fed178f9f2.png">