### PR TITLE
fix(receive) fix header alignment and network selection for ReceiveModal

### DIFF
--- a/src/app/modules/main/networks/model.nim
+++ b/src/app/modules/main/networks/model.nim
@@ -3,7 +3,7 @@ import NimQml, Tables, strutils, strformat
 import ./item
 
 type
-  ModelRole {.pure.} = enum
+  ModelRole* {.pure.} = enum
     ChainId = UserRole + 1,
     NativeCurrencyDecimals
     Layer
@@ -48,7 +48,7 @@ QtObject:
     read = getCount
     notify = countChanged
 
-  method rowCount(self: Model, index: QModelIndex = nil): int =
+  method rowCount*(self: Model, index: QModelIndex = nil): int =
     return self.items.len
 
   method roleNames(self: Model): Table[int, string] =
@@ -109,7 +109,7 @@ QtObject:
     of ModelRole.Balance:
       result = newQVariant(item.getBalance())
 
-  proc rowData(self: Model, index: int, column: string): string {.slot.} =
+  proc rowData*(self: Model, index: int, column: string): string {.slot.} =
     if (index >= self.items.len):
       return
     let item = self.items[index]

--- a/src/app/modules/main/networks/networks_extra_store_proxy.nim
+++ b/src/app/modules/main/networks/networks_extra_store_proxy.nim
@@ -1,0 +1,89 @@
+import NimQml, Tables, strutils
+
+import ./model
+
+# Proxy data model for the Networks data model with additional role; see isActiveRoleName
+# isEnabled values are copied from the original model into isActiveRoleName values
+const isActiveRoleName = "isActive"
+
+QtObject:
+  type
+    NetworksExtraStoreProxy* = ref object of QAbstractListModel
+      sourceModel: Model
+      activeNetworks: seq[bool]
+      extraRole: tuple[roleId: int, roleName: string]
+
+  proc delete(self: NetworksExtraStoreProxy) =
+    self.sourceModel = nil
+    self.activeNetworks = @[]
+    self.QAbstractListModel.delete
+
+  proc setup(self: NetworksExtraStoreProxy) =
+    self.QAbstractListModel.setup
+
+  proc updateActiveNetworks(self: NetworksExtraStoreProxy, sourceModel: Model) =
+    var tmpSeq = newSeq[bool](sourceModel.rowCount())
+    for i in 0 ..< sourceModel.rowCount():
+      tmpSeq[i] = sourceModel.data(sourceModel.index(i, 0, newQModelIndex()), ModelRole.IsEnabled.int).boolVal()
+    self.activeNetworks = tmpSeq
+
+  proc newNetworksExtraStoreProxy*(sourceModel: Model): NetworksExtraStoreProxy =
+    new(result, delete)
+
+    result.sourceModel = sourceModel
+    # assign past last role element
+    result.extraRole = (0, isActiveRoleName)
+    for k in sourceModel.roleNames().keys:
+      if k > result.extraRole.roleId:
+        result.extraRole.roleId = k
+    result.extraRole.roleId += 1
+
+    result.updateactiveNetworks(sourceModel)
+    result.setup
+
+    signalConnect(result.sourceModel, "countChanged()", result, "onCountChanged()")
+
+  proc countChanged(self: NetworksExtraStoreProxy) {.signal.}
+
+  # Nimqml doesn't support connecting signals to other signals
+  proc onCountChanged(self: NetworksExtraStoreProxy) {.slot.} =
+    self.updateActiveNetworks(self.sourceModel)
+    self.countChanged()
+
+  proc getCount(self: NetworksExtraStoreProxy): int {.slot.} =
+    return self.sourceModel.rowCount()
+
+  QtProperty[int] count:
+    read = getCount
+    notify = countChanged
+
+  method rowCount(self: NetworksExtraStoreProxy, index: QModelIndex = nil): int =
+    return self.sourceModel.rowCount()
+
+  method roleNames(self: NetworksExtraStoreProxy): Table[int, string] =
+    var srcRoles = self.sourceModel.roleNames()
+    srcRoles.add(self.extraRole.roleId, self.extraRole.roleName)
+    return srcRoles
+
+  method data(self: NetworksExtraStoreProxy, index: QModelIndex, role: int): QVariant =
+    if role == self.extraRole.roleId:
+      if index.row() < 0 or index.row() >= self.activeNetworks.len:
+        return QVariant()
+      return newQVariant(self.activeNetworks[index.row()])
+    return self.sourceModel.data(index, role)
+
+  method setData*(self: NetworksExtraStoreProxy, index: QModelIndex, value: QVariant, role: int): bool =
+    if role == self.extraRole.roleId:
+      if index.row() < 0 or index.row() >= self.activeNetworks.len:
+        return false
+      self.activeNetworks[index.row()] = value.boolVal()
+      self.dataChanged(index, index, [self.extraRole.roleId])
+      return true
+    return self.sourceModel.setData(index, value, role)
+
+  proc rowData(self: NetworksExtraStoreProxy, index: int, column: string): string {.slot.} =
+    if column == isActiveRoleName:
+      if index < 0 or index >= self.activeNetworks.len:
+        return ""
+      return $self.activeNetworks[index]
+    return self.sourceModel.rowData(index, column)

--- a/ui/app/AppLayouts/Profile/stores/AdvancedStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/AdvancedStore.qml
@@ -7,7 +7,6 @@ QtObject {
     property var advancedModule
 
     // Advanced Module Properties
-    property string currentChainId: advancedModule? advancedModule.currentChainId : 0
     property string fleet: advancedModule? advancedModule.fleet : ""
     property string bloomLevel: advancedModule? advancedModule.bloomLevel : ""
     property bool wakuV2LightClientEnabled: advancedModule? advancedModule.wakuV2LightClientEnabled : false

--- a/ui/app/AppLayouts/Wallet/popups/NetworkSelectPopup.qml
+++ b/ui/app/AppLayouts/Wallet/popups/NetworkSelectPopup.qml
@@ -12,7 +12,7 @@ import utils 1.0
 
 // TODO: replace with StatusModal
 Popup {
-    id: popup
+    id: root
     modal: false
     width: 360
     height: 432
@@ -24,6 +24,9 @@ Popup {
     property var layer1Networks
     property var layer2Networks
     property var testNetworks
+
+    // If true NetworksExtraStoreProxy expected for layer1Networks and layer2Networks properties
+    property bool useNetworksExtraStoreProxy: false
 
     signal toggleNetwork(int chainId)
 
@@ -45,8 +48,8 @@ Popup {
     contentItem: StatusScrollView {
         id: scrollView
         contentHeight: content.height
-        width: popup.width
-        height: popup.height
+        width: root.width
+        height: root.height
         padding: 0
 
         ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
@@ -61,7 +64,7 @@ Popup {
                 width: parent.width
                 height: parent.height
                 objectName: "networkSelectPopupChainRepeaterLayer1"
-                model: popup.layer1Networks
+                model: root.layer1Networks
 
                 delegate: chainItem
             }
@@ -80,14 +83,14 @@ Popup {
 
             Repeater {
                 id: chainRepeater2
-                model: popup.layer2Networks
+                model: root.layer2Networks
 
                 delegate: chainItem
             }
 
             Repeater {
                 id: chainRepeater3
-                model: popup.testNetworks
+                model: root.testNetworks
 
                 delegate: chainItem
             }
@@ -111,10 +114,12 @@ Popup {
             components: [
                 StatusCheckBox {
                     id: checkBox
-                    checked: model.isEnabled
+                    checked: root.useNetworksExtraStoreProxy ? model.isActive : model.isEnabled
                     onCheckedChanged: {
-                        if (model.isEnabled !== checked) {
-                            popup.toggleNetwork(model.chainId)
+                        if(root.useNetworksExtraStoreProxy && model.isActive !== checked) {
+                            model.isActive = checked
+                        } else if (model.isEnabled !== checked) {
+                            root.toggleNetwork(model.chainId)
                         }
                     }
                 }

--- a/ui/app/AppLayouts/Wallet/popups/ReceiveModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/ReceiveModal.qml
@@ -1,6 +1,7 @@
 import QtQuick 2.13
 import QtGraphicalEffects 1.13
 import QtQuick.Layouts 1.13
+import QtQuick.Controls 2.14
 
 import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
@@ -13,6 +14,7 @@ import StatusQ.Core.Utils 0.1
 import utils 1.0
 
 import shared.controls 1.0
+import shared.popups 1.0
 
 import "../stores"
 
@@ -25,7 +27,7 @@ StatusModal {
 
     onSelectedAccountChanged: {
         if (selectedAccount.address) {
-            txtWalletAddress.text = selectedAccount.mixedcaseAddress
+            txtWalletAddress.text = selectedAccount.address
         }
     }
 
@@ -50,53 +52,13 @@ StatusModal {
     }
 
     hasFloatingButtons: true
-    advancedHeaderComponent: StatusFloatingButtonsSelector {
-        id: floatingHeader
+    advancedHeaderComponent: AccountsModalHeader {
         model: RootStore.accounts
-        delegate: Rectangle {
-            width: button.width
-            height: button.height
-            radius: 8
-            visible: floatingHeader.visibleIndices.includes(index)
-            StatusButton {
-                id: button
-                topPadding: 8
-                bottomPadding: 0
-                implicitHeight: 32
-                leftPadding: 4
-                text: name
-                asset.emoji: !!emoji ? emoji: ""
-                asset.emojiSize: Emoji.size.middle
-                icon.name: !emoji ? "filled-account": ""
-                normalColor: "transparent"
-                highlighted: index === floatingHeader.currentIndex
-                onClicked: {
-                    popup.selectedAccount =  model
-                    floatingHeader.currentIndex = index
-                }
-                Component.onCompleted: {
-                    // On startup make the preseected wallet in the floating menu
-                    if(name === popup.selectedAccount.name)
-                        floatingHeader.currentIndex = index
-                }
-            }
+        selectedAccount: popup.selectedAccount
+        changeSelectedAccount: function(newAccount, newIndex) {
+            popup.selectedAccount = newAccount
         }
-        popupMenuDelegate: StatusListItem {
-            implicitWidth: 272
-            title: name
-            subTitle: currencyBalance
-            asset.emoji: !!emoji ? emoji: ""
-            asset.color: model.color
-            asset.name: !emoji ? "filled-account": ""
-            asset.letterSize: 14
-            asset.isLetterIdenticon: !!model.emoji
-            asset.bgColor: Theme.palette.indirectColor1
-            onClicked: {
-                popup.selectedAccount =  model
-                floatingHeader.itemSelected(index)
-            }
-            visible: !floatingHeader.visibleIndices.includes(index)
-        }
+        showAllWalletTypes: true
     }
 
     contentItem: Column {
@@ -286,9 +248,7 @@ StatusModal {
             testNetworks: RootStore.testNetworks
             closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
 
-            onToggleNetwork: {
-                RootStore.toggleNetwork(chainId)
-            }
+            onToggleNetwork: (chainId) => RootStore.toggleNetwork(chainId)
         }
 
         states: [

--- a/ui/app/AppLayouts/Wallet/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Wallet/stores/RootStore.qml
@@ -48,6 +48,8 @@ QtObject {
     property var testNetworks: networksModule.test
     property var enabledNetworks: networksModule.enabled
     property var allNetworks: networksModule.all
+    property var layer1NetworksProxy: networksModule.layer1Proxy
+    property var layer2NetworksProxy: networksModule.layer2Proxy
 
     property var cryptoRampServicesModel: walletSectionBuySellCrypto.model
 

--- a/ui/imports/shared/popups/AccountsModalHeader.qml
+++ b/ui/imports/shared/popups/AccountsModalHeader.qml
@@ -16,25 +16,31 @@ import "../controls"
 import "../views"
 
 StatusFloatingButtonsSelector {
-    id: floatingHeader
+    id: root
 
     property var selectedAccount
+    // Expected signature: function(newAccount, newIndex)
     property var changeSelectedAccount: function(){}
+    property bool showAllWalletTypes: false
 
     repeater.objectName: "accountsListFloatingHeader"
-    
+
     signal updatedSelectedAccount(var account)
 
     QtObject {
         id: d
         property var firstModelData: null
+
+        function isWalletTypeAccepted(walletType, index) {
+            return (root.showAllWalletTypes || walletType !== Constants.watchWalletType)
+        }
     }
 
     delegate: Rectangle {
         width: button.width
         height: button.height
         radius: 8
-        visible: floatingHeader.visibleIndices.includes(index) && walletType !== Constants.watchWalletType
+        visible: root.visibleIndices.includes(index) && d.isWalletTypeAccepted(walletType, index)
         color: Theme.palette.baseColor3
         StatusButton {
             id: button
@@ -47,10 +53,10 @@ StatusFloatingButtonsSelector {
             icon.name: !emoji ? "filled-account": ""
             normalColor: "transparent"
             hoverColor: Theme.palette.statusFloatingButtonHighlight
-            highlighted: index === floatingHeader.currentIndex
+            highlighted: index === root.currentIndex
             onClicked: {
-                changeSelectedAccount(index)
-                floatingHeader.currentIndex = index
+                changeSelectedAccount(model, index)
+                root.currentIndex = index
             }
             Component.onCompleted: {
                 // On startup make the preseected wallet in the floating menu,
@@ -59,21 +65,21 @@ StatusFloatingButtonsSelector {
                     d.firstModelData = model
                 }
 
-                if(name !== floatingHeader.selectedAccount.name) {
+                if(name !== root.selectedAccount.name) {
                     return
                 }
 
-                if(name === floatingHeader.selectedAccount.name) {
-                    if(walletType !== Constants.watchWalletType) {
+                if(name === root.selectedAccount.name) {
+                    if(d.isWalletTypeAccepted(walletType, index)) {
                         // If the selected index wont be displayed, added it to the visible indices
                         if(index > 2) {
                             visibleIndices = [0, 1, index]
                         }
-                        floatingHeader.currentIndex = index
+                        root.currentIndex = index
                     }
                     else {
-                        changeSelectedAccount(0)
-                        floatingHeader.currentIndex = 0
+                        changeSelectedAccount(root.selectedAccount, 0)
+                        root.currentIndex = 0
                     }
                 }
             }
@@ -90,10 +96,10 @@ StatusFloatingButtonsSelector {
         asset.isLetterIdenticon: !!model.emoji
         asset.bgColor: Theme.palette.indirectColor1
         onClicked: {
-            changeSelectedAccount(index)
-            floatingHeader.itemSelected(index)
+            changeSelectedAccount(model, index)
+            root.itemSelected(index)
         }
-        visible: !floatingHeader.visibleIndices.includes(index) && walletType !== Constants.watchWalletType
+        visible: !root.visibleIndices.includes(index) && d.isWalletTypeAccepted(walletType, index)
     }
 }
 

--- a/ui/imports/shared/popups/SendModal.qml
+++ b/ui/imports/shared/popups/SendModal.qml
@@ -160,12 +160,12 @@ StatusDialog {
         }
     }
 
-    header: SendModalHeader {
+    header: AccountsModalHeader {
         anchors.top: parent.top
         anchors.topMargin: -height - 18
         model: popup.store.accounts
         selectedAccount: popup.selectedAccount
-        changeSelectedAccount: function(newIndex) {
+        changeSelectedAccount: function(newAccount, newIndex) {
             if (newIndex > popup.store.accounts) {
                 return
             }

--- a/ui/imports/shared/popups/qmldir
+++ b/ui/imports/shared/popups/qmldir
@@ -24,3 +24,4 @@ ImportCommunityPopup 1.0 ImportCommunityPopup.qml
 DisplayNamePopup 1.0 DisplayNamePopup.qml
 AddEditSavedAddressPopup 1.0 AddEditSavedAddressPopup.qml
 SendContactRequestModal 1.0 SendContactRequestModal.qml
+AccountsModalHeader 1.0 AccountsModalHeader.qml


### PR DESCRIPTION
### Updates #8180

Add `AccountsModalHeader`, a reusable header control shared between Send and Receive modals

### Affected areas

Send and Receive Wallet modals

### StatusQ checklist

- [x] add documentation if necessary (new component, new feature)
- [x] ~~update sandbox app~~
  - Don't have them integrated
- [x] test changes in both light and dark themes?

### Screenshot of functionality (including design for comparison)

| Send | Receive | Design |
| ----- | -------- | ------- |
| ![image](https://user-images.githubusercontent.com/47554641/201630321-e4c27202-ef7a-4c83-b011-3540e0acb82e.png) | ![image](https://user-images.githubusercontent.com/47554641/201632180-bf8bf88f-0e70-415e-ad98-3859e6a31156.png) | ![image](https://user-images.githubusercontent.com/47554641/201631840-d444c582-0836-4054-91e4-147d23dd695a.png) |
| | ![image](https://user-images.githubusercontent.com/47554641/201630503-5161a0d7-c32c-4a87-8e9b-34c7325f6f31.png) |  |
| | ![image](https://user-images.githubusercontent.com/47554641/201630616-40062461-32ce-482d-b97d-f4e5107881f4.png) | |