### PR TITLE
fix(invitation-bubble): Add maximum line count to description and elide

### DIFF
--- a/ui/imports/shared/views/chat/InvitationBubbleView.qml
+++ b/ui/imports/shared/views/chat/InvitationBubbleView.qml
@@ -190,6 +190,8 @@ Item {
 
                             text: d.invitedCommunity.description
                             wrapMode: Text.WrapAtWordBoundaryOrAnywhere
+                            elide: Text.ElideRight
+                            maximumLineCount: 3
                             font.pixelSize: 15
                             color: Theme.palette.directColor1
                         }


### PR DESCRIPTION
Closes: #8120

### What does the PR do

Fix description sizes

### Affected areas

InvitationBubbleView

### Screenshot of functionality (including design for comparison)

- [ ] I've checked the design and this PR matches it


<img width="585" alt="Снимок экрана 2022-11-11 в 15 39 11" src="https://user-images.githubusercontent.com/82511785/201342796-3273efec-5012-449e-98ba-0ffefcb98b07.png">

