### PR TITLE
fix(@desktop/wallet): correct error message when adding own ENS name to saved addresses

### DIFF
--- a/ui/app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml
+++ b/ui/app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml
@@ -99,6 +99,7 @@ StatusDialog {
             }
             readOnly: root.edit
             wrongInputValidationError: qsTr("Please enter a valid ENS name OR Ethereum Address")
+            ownAddressError: qsTr("Can't add yourself as a saved address")
         }
     }
 

--- a/ui/imports/shared/controls/AddressInput.qml
+++ b/ui/imports/shared/controls/AddressInput.qml
@@ -21,6 +21,7 @@ Item {
     property int parentWidth
     property bool addContactEnabled: true
     property alias wrongInputValidationError: contactFieldAndList.wrongInputValidationError
+    property alias ownAddressError: contactFieldAndList.ownAddressError
 
     height: contactFieldAndList.chatKey.height
 

--- a/ui/imports/shared/controls/ContactsListAndSearch.qml
+++ b/ui/imports/shared/controls/ContactsListAndSearch.qml
@@ -37,6 +37,7 @@ Item {
     property bool hideCommunityMembers: false
     property bool addContactEnabled: true
     property string wrongInputValidationError: qsTr("Enter a valid chat key or ENS username");
+    property string ownAddressError: qsTr("Can't chat with yourself");
 
     readonly property var resolveENS: Backpressure.debounce(root, 500, function (ensName) {
         noContactsRect.visible = false
@@ -51,7 +52,7 @@ Item {
             pubKey = ""
             ensUsername = "";
         } else if (RootStore.userProfileInst.pubKey === chatKey.text) {
-            root.validationError = qsTr("Can't chat with yourself");
+            root.validationError = ownAddressError;
         } else {
             root.validationError = "";
         }
@@ -126,7 +127,7 @@ Item {
                         searchResults.showProfileNotFoundMessage = root.showContactList
                     } else {
                         if (userProfile.pubKey === resolvedPubKey) {
-                            root.validationError = qsTr("Can't chat with yourself");
+                            root.validationError = ownAddressError;
                         } else {
                             chatKey.hasValidSearchResult = true
                             searchResults.username = chatKey.text.trim()

--- a/ui/imports/shared/controls/RecipientSelector.qml
+++ b/ui/imports/shared/controls/RecipientSelector.qml
@@ -27,6 +27,7 @@ Item {
     property bool readOnly: false
     readonly property string addressValidationError: qsTr("Invalid ethereum address")
     property alias wrongInputValidationError: inpAddress.wrongInputValidationError
+    property alias ownAddressError: inpAddress.ownAddressError
     property bool isValid: false
     property bool isSelectorVisible: true
     property bool addContactEnabled: true

--- a/ui/imports/shared/popups/AddEditSavedAddressPopup.qml
+++ b/ui/imports/shared/popups/AddEditSavedAddressPopup.qml
@@ -100,6 +100,7 @@ StatusDialog {
             }
             readOnly: root.edit || root.addAddress
             wrongInputValidationError: qsTr("Please enter a valid ENS name OR Ethereum Address")
+            ownAddressError: qsTr("Can't add yourself as a saved address")
         }
     }
 


### PR DESCRIPTION
### What does the PR do

This fixes #8114
The error message shown when the user's ENS name is entered in component `ContactsListAndSearch.qml` is now a property. By default it keeps the old value ("Can't chat with yourself"). Particularly in `AddEditSavedAddressPopup.qml` it is now changed with "Can't add yourself as a saved address".

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas

Wallet. Change was also included in shared resource.

### Screenshot

Before:
![image](https://user-images.githubusercontent.com/11161531/201404530-d1aefb5f-0480-4603-83bf-c168e8276115.png)

After:
![Screenshot_20221111_135715](https://user-images.githubusercontent.com/11161531/201404608-333b5221-fda0-46cf-9957-f9ec6c2760c4.png)
