### PR TITLE
fix(@desktop/keycard): migrating keypair looks somehow stucked for a while before switching to `Migrating key pair to Keycard` state

### DIFF
--- a/src/app/boot/app_controller.nim
+++ b/src/app/boot/app_controller.nim
@@ -138,7 +138,8 @@ proc newAppController*(statusFoundation: StatusFoundation): AppController =
   result.nodeConfigurationService = node_configuration_service.newService(statusFoundation.fleetConfiguration,
   result.settingsService)
   result.keychainService = keychain_service.newService(statusFoundation.events)
-  result.accountsService = accounts_service.newService(statusFoundation.fleetConfiguration)
+  result.accountsService = accounts_service.newService(statusFoundation.events, statusFoundation.threadpool, 
+    statusFoundation.fleetConfiguration)
   result.networkService = network_service.newService(statusFoundation.events, result.settingsService)
   result.contactsService = contacts_service.newService(
     statusFoundation.events, statusFoundation.threadpool, result.networkService, result.settingsService, 

--- a/src/app/global/user_profile.nim
+++ b/src/app/global/user_profile.nim
@@ -1,7 +1,5 @@
 import NimQml
 
-import ../../app_service/common/utils
-
 import local_account_settings
 
 QtObject:

--- a/src/app/modules/main/profile_section/keycard/controller.nim
+++ b/src/app/modules/main/profile_section/keycard/controller.nim
@@ -49,6 +49,8 @@ proc init*(self: Controller) =
 
   self.events.on(SIGNAL_NEW_KEYCARD_SET) do(e: Args):
     let args = KeycardActivityArgs(e)
+    if not args.success:
+      return
     self.delegate.onNewKeycardSet(args.keyPair)
 
   self.events.on(SIGNAL_KEYCARD_LOCKED) do(e: Args):

--- a/src/app/modules/main/wallet_section/accounts/module.nim
+++ b/src/app/modules/main/wallet_section/accounts/module.nim
@@ -167,6 +167,9 @@ method load*(self: Module) =
     self.refreshWalletAccounts()
 
   self.events.on(SIGNAL_NEW_KEYCARD_SET) do(e: Args):
+    let args = KeycardActivityArgs(e)
+    if not args.success:
+      return
     self.refreshWalletAccounts()
 
   self.controller.init()

--- a/src/app/modules/shared_modules/keycard_popup/internal/biometrics_password_failed_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/biometrics_password_failed_state.nim
@@ -8,7 +8,7 @@ proc newBiometricsPasswordFailedState*(flowType: FlowType, backState: State): Bi
 proc delete*(self: BiometricsPasswordFailedState) =
   self.State.delete
 
-method executePrimaryCommand*(self: BiometricsPasswordFailedState, controller: Controller) =
+method executePrePrimaryStateCommand*(self: BiometricsPasswordFailedState, controller: Controller) =
   if self.flowType == FlowType.Authentication:
     controller.tryToObtainDataFromKeychain()
 
@@ -16,7 +16,7 @@ method getNextSecondaryState*(self: BiometricsPasswordFailedState, controller: C
   if self.flowType == FlowType.Authentication:
     return createState(StateType.EnterPassword, self.flowType, nil)
 
-method executeTertiaryCommand*(self: BiometricsPasswordFailedState, controller: Controller) =
+method executePreTertiaryStateCommand*(self: BiometricsPasswordFailedState, controller: Controller) =
   if self.flowType == FlowType.Authentication:
     controller.setPassword("")
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)

--- a/src/app/modules/shared_modules/keycard_popup/internal/biometrics_password_failed_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/biometrics_password_failed_state.nim
@@ -16,7 +16,7 @@ method getNextSecondaryState*(self: BiometricsPasswordFailedState, controller: C
   if self.flowType == FlowType.Authentication:
     return createState(StateType.EnterPassword, self.flowType, nil)
 
-method executePreTertiaryStateCommand*(self: BiometricsPasswordFailedState, controller: Controller) =
+method executeCancelCommand*(self: BiometricsPasswordFailedState, controller: Controller) =
   if self.flowType == FlowType.Authentication:
     controller.setPassword("")
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)

--- a/src/app/modules/shared_modules/keycard_popup/internal/biometrics_pin_failed_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/biometrics_pin_failed_state.nim
@@ -20,7 +20,7 @@ method getNextSecondaryState*(self: BiometricsPinFailedState, controller: Contro
   if self.flowType == FlowType.Authentication:
     return createState(StateType.EnterPin, self.flowType, nil)
 
-method executePreTertiaryStateCommand*(self: BiometricsPinFailedState, controller: Controller) =
+method executeCancelCommand*(self: BiometricsPinFailedState, controller: Controller) =
   if self.flowType == FlowType.Authentication:
     controller.setPassword("")
     controller.setPin("")

--- a/src/app/modules/shared_modules/keycard_popup/internal/biometrics_pin_failed_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/biometrics_pin_failed_state.nim
@@ -8,11 +8,11 @@ proc newBiometricsPinFailedState*(flowType: FlowType, backState: State): Biometr
 proc delete*(self: BiometricsPinFailedState) =
   self.State.delete
 
-method executePrimaryCommand*(self: BiometricsPinFailedState, controller: Controller) =
+method executePrePrimaryStateCommand*(self: BiometricsPinFailedState, controller: Controller) =
   if self.flowType == FlowType.Authentication:
     controller.tryToObtainDataFromKeychain()
 
-method executeSecondaryCommand*(self: BiometricsPinFailedState, controller: Controller) =
+method executePreSecondaryStateCommand*(self: BiometricsPinFailedState, controller: Controller) =
   if self.flowType == FlowType.Authentication:
     controller.setUsePinFromBiometrics(true)
 
@@ -20,7 +20,7 @@ method getNextSecondaryState*(self: BiometricsPinFailedState, controller: Contro
   if self.flowType == FlowType.Authentication:
     return createState(StateType.EnterPin, self.flowType, nil)
 
-method executeTertiaryCommand*(self: BiometricsPinFailedState, controller: Controller) =
+method executePreTertiaryStateCommand*(self: BiometricsPinFailedState, controller: Controller) =
   if self.flowType == FlowType.Authentication:
     controller.setPassword("")
     controller.setPin("")

--- a/src/app/modules/shared_modules/keycard_popup/internal/biometrics_pin_invalid_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/biometrics_pin_invalid_state.nim
@@ -21,7 +21,7 @@ method getNextSecondaryState*(self: BiometricsPinInvalidState, controller: Contr
   if self.flowType == FlowType.Authentication:
     return createState(StateType.EnterPin, self.flowType, nil)
 
-method executePreTertiaryStateCommand*(self: BiometricsPinInvalidState, controller: Controller) =
+method executeCancelCommand*(self: BiometricsPinInvalidState, controller: Controller) =
   if self.flowType == FlowType.Authentication:
     controller.setPassword("")
     controller.setPin("")

--- a/src/app/modules/shared_modules/keycard_popup/internal/biometrics_pin_invalid_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/biometrics_pin_invalid_state.nim
@@ -8,11 +8,11 @@ proc newBiometricsPinInvalidState*(flowType: FlowType, backState: State): Biomet
 proc delete*(self: BiometricsPinInvalidState) =
   self.State.delete
 
-method executePrimaryCommand*(self: BiometricsPinInvalidState, controller: Controller) =
+method executePrePrimaryStateCommand*(self: BiometricsPinInvalidState, controller: Controller) =
   if self.flowType == FlowType.Authentication:
     controller.tryToObtainDataFromKeychain()
 
-method executeSecondaryCommand*(self: BiometricsPinInvalidState, controller: Controller) =
+method executePreSecondaryStateCommand*(self: BiometricsPinInvalidState, controller: Controller) =
   if self.flowType == FlowType.Authentication:
     controller.setUsePinFromBiometrics(true)
     controller.setOfferToStoreUpdatedPinToKeychain(true)
@@ -21,7 +21,7 @@ method getNextSecondaryState*(self: BiometricsPinInvalidState, controller: Contr
   if self.flowType == FlowType.Authentication:
     return createState(StateType.EnterPin, self.flowType, nil)
 
-method executeTertiaryCommand*(self: BiometricsPinInvalidState, controller: Controller) =
+method executePreTertiaryStateCommand*(self: BiometricsPinInvalidState, controller: Controller) =
   if self.flowType == FlowType.Authentication:
     controller.setPassword("")
     controller.setPin("")

--- a/src/app/modules/shared_modules/keycard_popup/internal/biometrics_ready_to_sign_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/biometrics_ready_to_sign_state.nim
@@ -8,11 +8,11 @@ proc newBiometricsReadyToSignState*(flowType: FlowType, backState: State): Biome
 proc delete*(self: BiometricsReadyToSignState) =
   self.State.delete
 
-method executePrimaryCommand*(self: BiometricsReadyToSignState, controller: Controller) =
+method executePrePrimaryStateCommand*(self: BiometricsReadyToSignState, controller: Controller) =
   if self.flowType == FlowType.Authentication:
     controller.tryToObtainDataFromKeychain()
 
-method executeSecondaryCommand*(self: BiometricsReadyToSignState, controller: Controller) =
+method executePreSecondaryStateCommand*(self: BiometricsReadyToSignState, controller: Controller) =
   if self.flowType == FlowType.Authentication:
     controller.setUsePinFromBiometrics(true)
 
@@ -20,7 +20,7 @@ method getNextSecondaryState*(self: BiometricsReadyToSignState, controller: Cont
   if self.flowType == FlowType.Authentication:
     return createState(StateType.EnterPin, self.flowType, nil)
 
-method executeTertiaryCommand*(self: BiometricsReadyToSignState, controller: Controller) =
+method executePreTertiaryStateCommand*(self: BiometricsReadyToSignState, controller: Controller) =
   if self.flowType == FlowType.Authentication:
     controller.setPassword("")
     controller.setPin("")

--- a/src/app/modules/shared_modules/keycard_popup/internal/biometrics_ready_to_sign_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/biometrics_ready_to_sign_state.nim
@@ -20,7 +20,7 @@ method getNextSecondaryState*(self: BiometricsReadyToSignState, controller: Cont
   if self.flowType == FlowType.Authentication:
     return createState(StateType.EnterPin, self.flowType, nil)
 
-method executePreTertiaryStateCommand*(self: BiometricsReadyToSignState, controller: Controller) =
+method executeCancelCommand*(self: BiometricsReadyToSignState, controller: Controller) =
   if self.flowType == FlowType.Authentication:
     controller.setPassword("")
     controller.setPin("")

--- a/src/app/modules/shared_modules/keycard_popup/internal/changing_keycard_pairing_code_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/changing_keycard_pairing_code_state.nim
@@ -8,7 +8,7 @@ proc newChangingKeycardPairingCodeState*(flowType: FlowType, backState: State): 
 proc delete*(self: ChangingKeycardPairingCodeState) =
   self.State.delete
 
-method executeSecondaryCommand*(self: ChangingKeycardPairingCodeState, controller: Controller) =
+method executePreSecondaryStateCommand*(self: ChangingKeycardPairingCodeState, controller: Controller) =
   if self.flowType == FlowType.ChangePairingCode:
     controller.storePairingCodeToKeycard(controller.getPairingCode())
 

--- a/src/app/modules/shared_modules/keycard_popup/internal/changing_keycard_pin_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/changing_keycard_pin_state.nim
@@ -8,7 +8,7 @@ proc newChangingKeycardPinState*(flowType: FlowType, backState: State): Changing
 proc delete*(self: ChangingKeycardPinState) =
   self.State.delete
 
-method executeSecondaryCommand*(self: ChangingKeycardPinState, controller: Controller) =
+method executePreSecondaryStateCommand*(self: ChangingKeycardPinState, controller: Controller) =
   if self.flowType == FlowType.ChangeKeycardPin:
     controller.storePinToKeycard(controller.getPin(), "")
 

--- a/src/app/modules/shared_modules/keycard_popup/internal/changing_keycard_puk_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/changing_keycard_puk_state.nim
@@ -8,7 +8,7 @@ proc newChangingKeycardPukState*(flowType: FlowType, backState: State): Changing
 proc delete*(self: ChangingKeycardPukState) =
   self.State.delete
 
-method executeSecondaryCommand*(self: ChangingKeycardPukState, controller: Controller) =
+method executePreSecondaryStateCommand*(self: ChangingKeycardPukState, controller: Controller) =
   if self.flowType == FlowType.ChangeKeycardPuk:
     controller.storePukToKeycard(controller.getPuk())
 

--- a/src/app/modules/shared_modules/keycard_popup/internal/create_pairing_code_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/create_pairing_code_state.nim
@@ -14,6 +14,6 @@ method getNextPrimaryState*(self: CreatePairingCodeState, controller: Controller
       return createState(StateType.ChangingKeycardPairingCode, self.flowType, nil)
     return createState(StateType.ChangingKeycardPairingCodeFailure, self.flowType, nil)
 
-method executeTertiaryCommand*(self: CreatePairingCodeState, controller: Controller) =
+method executePreTertiaryStateCommand*(self: CreatePairingCodeState, controller: Controller) =
   if self.flowType == FlowType.ChangePairingCode:
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)

--- a/src/app/modules/shared_modules/keycard_popup/internal/create_pairing_code_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/create_pairing_code_state.nim
@@ -14,6 +14,6 @@ method getNextPrimaryState*(self: CreatePairingCodeState, controller: Controller
       return createState(StateType.ChangingKeycardPairingCode, self.flowType, nil)
     return createState(StateType.ChangingKeycardPairingCodeFailure, self.flowType, nil)
 
-method executePreTertiaryStateCommand*(self: CreatePairingCodeState, controller: Controller) =
+method executeCancelCommand*(self: CreatePairingCodeState, controller: Controller) =
   if self.flowType == FlowType.ChangePairingCode:
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)

--- a/src/app/modules/shared_modules/keycard_popup/internal/create_pin_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/create_pin_state.nim
@@ -8,14 +8,14 @@ proc newCreatePinState*(flowType: FlowType, backState: State): CreatePinState =
 proc delete*(self: CreatePinState) =
   self.State.delete
   
-method executeBackCommand*(self: CreatePinState, controller: Controller) =
+method executePreBackStateCommand*(self: CreatePinState, controller: Controller) =
   controller.setPin("")
   controller.setPinMatch(false)
   if self.flowType == FlowType.SetupNewKeycard:
     if not self.getBackState.isNil and self.getBackState.stateType == StateType.SelectExistingKeyPair:
       controller.cancelCurrentFlow()
 
-method executeTertiaryCommand*(self: CreatePinState, controller: Controller) =
+method executePreTertiaryStateCommand*(self: CreatePinState, controller: Controller) =
   if self.flowType == FlowType.SetupNewKeycard or
     self.flowType == FlowType.UnlockKeycard or
     self.flowType == FlowType.ChangeKeycardPin:

--- a/src/app/modules/shared_modules/keycard_popup/internal/create_pin_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/create_pin_state.nim
@@ -15,7 +15,7 @@ method executePreBackStateCommand*(self: CreatePinState, controller: Controller)
     if not self.getBackState.isNil and self.getBackState.stateType == StateType.SelectExistingKeyPair:
       controller.cancelCurrentFlow()
 
-method executePreTertiaryStateCommand*(self: CreatePinState, controller: Controller) =
+method executeCancelCommand*(self: CreatePinState, controller: Controller) =
   if self.flowType == FlowType.SetupNewKeycard or
     self.flowType == FlowType.UnlockKeycard or
     self.flowType == FlowType.ChangeKeycardPin:

--- a/src/app/modules/shared_modules/keycard_popup/internal/create_puk_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/create_puk_state.nim
@@ -8,7 +8,7 @@ proc newCreatePukState*(flowType: FlowType, backState: State): CreatePukState =
 proc delete*(self: CreatePukState) =
   self.State.delete
   
-method executeTertiaryCommand*(self: CreatePukState, controller: Controller) =
+method executePreTertiaryStateCommand*(self: CreatePukState, controller: Controller) =
   if self.flowType == FlowType.ChangeKeycardPuk:
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)
 

--- a/src/app/modules/shared_modules/keycard_popup/internal/create_puk_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/create_puk_state.nim
@@ -8,7 +8,7 @@ proc newCreatePukState*(flowType: FlowType, backState: State): CreatePukState =
 proc delete*(self: CreatePukState) =
   self.State.delete
   
-method executePreTertiaryStateCommand*(self: CreatePukState, controller: Controller) =
+method executeCancelCommand*(self: CreatePukState, controller: Controller) =
   if self.flowType == FlowType.ChangeKeycardPuk:
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)
 

--- a/src/app/modules/shared_modules/keycard_popup/internal/enter_biometrics_password_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/enter_biometrics_password_state.nim
@@ -10,7 +10,7 @@ proc newEnterBiometricsPasswordState*(flowType: FlowType, backState: State): Ent
 proc delete*(self: EnterBiometricsPasswordState) =
   self.State.delete
 
-method executePrimaryCommand*(self: EnterBiometricsPasswordState, controller: Controller) =
+method executePrePrimaryStateCommand*(self: EnterBiometricsPasswordState, controller: Controller) =
   if self.flowType == FlowType.Authentication:
     let password = controller.getPassword()
     self.success = controller.verifyPassword(password)
@@ -25,7 +25,7 @@ method getNextPrimaryState*(self: EnterBiometricsPasswordState, controller: Cont
     if not self.success:
       return createState(StateType.WrongBiometricsPassword, self.flowType, nil)
 
-method executeTertiaryCommand*(self: EnterBiometricsPasswordState, controller: Controller) =
+method executePreTertiaryStateCommand*(self: EnterBiometricsPasswordState, controller: Controller) =
   if self.flowType == FlowType.Authentication:
     controller.setPassword("")
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)

--- a/src/app/modules/shared_modules/keycard_popup/internal/enter_biometrics_password_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/enter_biometrics_password_state.nim
@@ -25,7 +25,7 @@ method getNextPrimaryState*(self: EnterBiometricsPasswordState, controller: Cont
     if not self.success:
       return createState(StateType.WrongBiometricsPassword, self.flowType, nil)
 
-method executePreTertiaryStateCommand*(self: EnterBiometricsPasswordState, controller: Controller) =
+method executeCancelCommand*(self: EnterBiometricsPasswordState, controller: Controller) =
   if self.flowType == FlowType.Authentication:
     controller.setPassword("")
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)

--- a/src/app/modules/shared_modules/keycard_popup/internal/enter_keycard_name_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/enter_keycard_name_state.nim
@@ -14,7 +14,7 @@ method getNextPrimaryState*(self: EnterKeycardNameState, controller: Controller)
   if self.flowType == FlowType.RenameKeycard:
     return createState(StateType.RenamingKeycard, self.flowType, nil)
 
-method executePreTertiaryStateCommand*(self: EnterKeycardNameState, controller: Controller) =
+method executeCancelCommand*(self: EnterKeycardNameState, controller: Controller) =
   if self.flowType == FlowType.RenameKeycard:
     controller.setPassword("")
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)

--- a/src/app/modules/shared_modules/keycard_popup/internal/enter_keycard_name_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/enter_keycard_name_state.nim
@@ -14,7 +14,7 @@ method getNextPrimaryState*(self: EnterKeycardNameState, controller: Controller)
   if self.flowType == FlowType.RenameKeycard:
     return createState(StateType.RenamingKeycard, self.flowType, nil)
 
-method executeTertiaryCommand*(self: EnterKeycardNameState, controller: Controller) =
+method executePreTertiaryStateCommand*(self: EnterKeycardNameState, controller: Controller) =
   if self.flowType == FlowType.RenameKeycard:
     controller.setPassword("")
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)

--- a/src/app/modules/shared_modules/keycard_popup/internal/enter_password_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/enter_password_state.nim
@@ -28,7 +28,7 @@ method executePreSecondaryStateCommand*(self: EnterPasswordState, controller: Co
   if self.flowType == FlowType.Authentication:
     controller.tryToObtainDataFromKeychain()
 
-method executePreTertiaryStateCommand*(self: EnterPasswordState, controller: Controller) =
+method executeCancelCommand*(self: EnterPasswordState, controller: Controller) =
   if self.flowType == FlowType.Authentication:
     controller.setPassword("")
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)

--- a/src/app/modules/shared_modules/keycard_popup/internal/enter_password_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/enter_password_state.nim
@@ -10,7 +10,7 @@ proc newEnterPasswordState*(flowType: FlowType, backState: State): EnterPassword
 proc delete*(self: EnterPasswordState) =
   self.State.delete
 
-method executePrimaryCommand*(self: EnterPasswordState, controller: Controller) =
+method executePrePrimaryStateCommand*(self: EnterPasswordState, controller: Controller) =
   if self.flowType == FlowType.Authentication:
     let password = controller.getPassword()
     self.success = controller.verifyPassword(password)
@@ -24,11 +24,11 @@ method getNextPrimaryState*(self: EnterPasswordState, controller: Controller): S
     if not self.success:
       return createState(StateType.WrongPassword, self.flowType, nil)
 
-method executeSecondaryCommand*(self: EnterPasswordState, controller: Controller) =
+method executePreSecondaryStateCommand*(self: EnterPasswordState, controller: Controller) =
   if self.flowType == FlowType.Authentication:
     controller.tryToObtainDataFromKeychain()
 
-method executeTertiaryCommand*(self: EnterPasswordState, controller: Controller) =
+method executePreTertiaryStateCommand*(self: EnterPasswordState, controller: Controller) =
   if self.flowType == FlowType.Authentication:
     controller.setPassword("")
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)

--- a/src/app/modules/shared_modules/keycard_popup/internal/enter_pin_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/enter_pin_state.nim
@@ -30,7 +30,7 @@ method executePreSecondaryStateCommand*(self: EnterPinState, controller: Control
     controller.setUsePinFromBiometrics(false)
     controller.tryToObtainDataFromKeychain()
 
-method executePreTertiaryStateCommand*(self: EnterPinState, controller: Controller) =
+method executeCancelCommand*(self: EnterPinState, controller: Controller) =
   if self.flowType == FlowType.FactoryReset or
     self.flowType == FlowType.SetupNewKeycard or
     self.flowType == FlowType.Authentication or

--- a/src/app/modules/shared_modules/keycard_popup/internal/enter_pin_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/enter_pin_state.nim
@@ -16,7 +16,7 @@ method getNextPrimaryState*(self: EnterPinState, controller: Controller): State 
     if controller.getPin().len == PINLengthForStatusApp:
       controller.enterKeycardPin(controller.getPin())
 
-method executeSecondaryCommand*(self: EnterPinState, controller: Controller) =
+method executePreSecondaryStateCommand*(self: EnterPinState, controller: Controller) =
   if self.flowType == FlowType.SetupNewKeycard or
     self.flowType == FlowType.FactoryReset or
     self.flowType == FlowType.DisplayKeycardContent or
@@ -30,7 +30,7 @@ method executeSecondaryCommand*(self: EnterPinState, controller: Controller) =
     controller.setUsePinFromBiometrics(false)
     controller.tryToObtainDataFromKeychain()
 
-method executeTertiaryCommand*(self: EnterPinState, controller: Controller) =
+method executePreTertiaryStateCommand*(self: EnterPinState, controller: Controller) =
   if self.flowType == FlowType.FactoryReset or
     self.flowType == FlowType.SetupNewKeycard or
     self.flowType == FlowType.Authentication or

--- a/src/app/modules/shared_modules/keycard_popup/internal/enter_puk_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/enter_puk_state.nim
@@ -13,7 +13,7 @@ method executePrePrimaryStateCommand*(self: EnterPukState, controller: Controlle
     if controller.getPuk().len == PUKLengthForStatusApp:
       controller.enterKeycardPuk(controller.getPuk())
 
-method executePreTertiaryStateCommand*(self: EnterPukState, controller: Controller) =
+method executeCancelCommand*(self: EnterPukState, controller: Controller) =
   if self.flowType == FlowType.UnlockKeycard:
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)
 

--- a/src/app/modules/shared_modules/keycard_popup/internal/enter_puk_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/enter_puk_state.nim
@@ -8,12 +8,12 @@ proc newEnterPukState*(flowType: FlowType, backState: State): EnterPukState =
 proc delete*(self: EnterPukState) =
   self.State.delete
 
-method executePrimaryCommand*(self: EnterPukState, controller: Controller) =
+method executePrePrimaryStateCommand*(self: EnterPukState, controller: Controller) =
   if self.flowType == FlowType.UnlockKeycard:
     if controller.getPuk().len == PUKLengthForStatusApp:
       controller.enterKeycardPuk(controller.getPuk())
 
-method executeTertiaryCommand*(self: EnterPukState, controller: Controller) =
+method executePreTertiaryStateCommand*(self: EnterPukState, controller: Controller) =
   if self.flowType == FlowType.UnlockKeycard:
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)
 

--- a/src/app/modules/shared_modules/keycard_popup/internal/enter_seed_phrase_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/enter_seed_phrase_state.nim
@@ -10,7 +10,7 @@ proc newEnterSeedPhraseState*(flowType: FlowType, backState: State): EnterSeedPh
 proc delete*(self: EnterSeedPhraseState) =
   self.State.delete
 
-method executePrimaryCommand*(self: EnterSeedPhraseState, controller: Controller) =
+method executePrePrimaryStateCommand*(self: EnterSeedPhraseState, controller: Controller) =
   if self.flowType == FlowType.SetupNewKeycard:
     self.verifiedSeedPhrase = controller.validSeedPhrase(controller.getSeedPhrase()) and
       controller.seedPhraseRefersToSelectedKeyPair(controller.getSeedPhrase())
@@ -32,7 +32,7 @@ method getNextPrimaryState*(self: EnterSeedPhraseState, controller: Controller):
       if not self.verifiedSeedPhrase:
         return createState(StateType.WrongSeedPhrase, self.flowType, nil)
 
-method executeTertiaryCommand*(self: EnterSeedPhraseState, controller: Controller) =
+method executePreTertiaryStateCommand*(self: EnterSeedPhraseState, controller: Controller) =
   if self.flowType == FlowType.SetupNewKeycard or
     self.flowType == FlowType.UnlockKeycard:
       controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)

--- a/src/app/modules/shared_modules/keycard_popup/internal/enter_seed_phrase_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/enter_seed_phrase_state.nim
@@ -32,7 +32,7 @@ method getNextPrimaryState*(self: EnterSeedPhraseState, controller: Controller):
       if not self.verifiedSeedPhrase:
         return createState(StateType.WrongSeedPhrase, self.flowType, nil)
 
-method executePreTertiaryStateCommand*(self: EnterSeedPhraseState, controller: Controller) =
+method executeCancelCommand*(self: EnterSeedPhraseState, controller: Controller) =
   if self.flowType == FlowType.SetupNewKeycard or
     self.flowType == FlowType.UnlockKeycard:
       controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)

--- a/src/app/modules/shared_modules/keycard_popup/internal/factory_reset_confirmation_displayed_metadata_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/factory_reset_confirmation_displayed_metadata_state.nim
@@ -15,7 +15,7 @@ method executePrePrimaryStateCommand*(self: FactoryResetConfirmationDisplayMetad
     controller.setKeycardData(updatePredefinedKeycardData(controller.getKeycardData(), PredefinedKeycardData.HideKeyPair, add = true))
     controller.runGetAppInfoFlow(factoryReset = true)
     
-method executePreTertiaryStateCommand*(self: FactoryResetConfirmationDisplayMetadataState, controller: Controller) =
+method executeCancelCommand*(self: FactoryResetConfirmationDisplayMetadataState, controller: Controller) =
   if self.flowType == FlowType.FactoryReset or
     self.flowType == FlowType.SetupNewKeycard:
       controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)

--- a/src/app/modules/shared_modules/keycard_popup/internal/factory_reset_confirmation_displayed_metadata_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/factory_reset_confirmation_displayed_metadata_state.nim
@@ -8,14 +8,14 @@ proc newFactoryResetConfirmationDisplayMetadataState*(flowType: FlowType, backSt
 proc delete*(self: FactoryResetConfirmationDisplayMetadataState) =
   self.State.delete
 
-method executePrimaryCommand*(self: FactoryResetConfirmationDisplayMetadataState, controller: Controller) =
+method executePrePrimaryStateCommand*(self: FactoryResetConfirmationDisplayMetadataState, controller: Controller) =
   if self.flowType == FlowType.FactoryReset:
     controller.runGetAppInfoFlow(factoryReset = true)
   elif self.flowType == FlowType.SetupNewKeycard:
     controller.setKeycardData(updatePredefinedKeycardData(controller.getKeycardData(), PredefinedKeycardData.HideKeyPair, add = true))
     controller.runGetAppInfoFlow(factoryReset = true)
     
-method executeTertiaryCommand*(self: FactoryResetConfirmationDisplayMetadataState, controller: Controller) =
+method executePreTertiaryStateCommand*(self: FactoryResetConfirmationDisplayMetadataState, controller: Controller) =
   if self.flowType == FlowType.FactoryReset or
     self.flowType == FlowType.SetupNewKeycard:
       controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)

--- a/src/app/modules/shared_modules/keycard_popup/internal/factory_reset_confirmation_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/factory_reset_confirmation_state.nim
@@ -15,7 +15,7 @@ method executePrePrimaryStateCommand*(self: FactoryResetConfirmationState, contr
     controller.setKeycardData(updatePredefinedKeycardData(controller.getKeycardData(), PredefinedKeycardData.HideKeyPair, add = true))
     controller.runGetAppInfoFlow(factoryReset = true)
     
-method executePreTertiaryStateCommand*(self: FactoryResetConfirmationState, controller: Controller) =
+method executeCancelCommand*(self: FactoryResetConfirmationState, controller: Controller) =
   if self.flowType == FlowType.FactoryReset or
     self.flowType == FlowType.SetupNewKeycard:
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)

--- a/src/app/modules/shared_modules/keycard_popup/internal/factory_reset_confirmation_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/factory_reset_confirmation_state.nim
@@ -8,14 +8,14 @@ proc newFactoryResetConfirmationState*(flowType: FlowType, backState: State): Fa
 proc delete*(self: FactoryResetConfirmationState) =
   self.State.delete
 
-method executePrimaryCommand*(self: FactoryResetConfirmationState, controller: Controller) =
+method executePrePrimaryStateCommand*(self: FactoryResetConfirmationState, controller: Controller) =
   if self.flowType == FlowType.FactoryReset:
     controller.runGetAppInfoFlow(factoryReset = true)
   elif self.flowType == FlowType.SetupNewKeycard:
     controller.setKeycardData(updatePredefinedKeycardData(controller.getKeycardData(), PredefinedKeycardData.HideKeyPair, add = true))
     controller.runGetAppInfoFlow(factoryReset = true)
     
-method executeTertiaryCommand*(self: FactoryResetConfirmationState, controller: Controller) =
+method executePreTertiaryStateCommand*(self: FactoryResetConfirmationState, controller: Controller) =
   if self.flowType == FlowType.FactoryReset or
     self.flowType == FlowType.SetupNewKeycard:
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)

--- a/src/app/modules/shared_modules/keycard_popup/internal/factory_reset_success_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/factory_reset_success_state.nim
@@ -8,13 +8,13 @@ proc newFactoryResetSuccessState*(flowType: FlowType, backState: State): Factory
 proc delete*(self: FactoryResetSuccessState) =
   self.State.delete
 
-method executePrimaryCommand*(self: FactoryResetSuccessState, controller: Controller) =
+method executePrePrimaryStateCommand*(self: FactoryResetSuccessState, controller: Controller) =
   if self.flowType == FlowType.FactoryReset:
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = true)
   elif self.flowType == FlowType.SetupNewKeycard:
     controller.runLoadAccountFlow()
 
-method executeTertiaryCommand*(self: FactoryResetSuccessState, controller: Controller) =
+method executePreTertiaryStateCommand*(self: FactoryResetSuccessState, controller: Controller) =
   if self.flowType == FlowType.SetupNewKeycard:
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = true)
 

--- a/src/app/modules/shared_modules/keycard_popup/internal/factory_reset_success_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/factory_reset_success_state.nim
@@ -14,7 +14,7 @@ method executePrePrimaryStateCommand*(self: FactoryResetSuccessState, controller
   elif self.flowType == FlowType.SetupNewKeycard:
     controller.runLoadAccountFlow()
 
-method executePreTertiaryStateCommand*(self: FactoryResetSuccessState, controller: Controller) =
+method executeCancelCommand*(self: FactoryResetSuccessState, controller: Controller) =
   if self.flowType == FlowType.SetupNewKeycard:
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = true)
 

--- a/src/app/modules/shared_modules/keycard_popup/internal/insert_keycard_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/insert_keycard_state.nim
@@ -8,12 +8,12 @@ proc newInsertKeycardState*(flowType: FlowType, backState: State): InsertKeycard
 proc delete*(self: InsertKeycardState) =
   self.State.delete
 
-method executeBackCommand*(self: InsertKeycardState, controller: Controller) =
+method executePreBackStateCommand*(self: InsertKeycardState, controller: Controller) =
   if self.flowType == FlowType.SetupNewKeycard:
     if not self.getBackState.isNil and self.getBackState.stateType == StateType.SelectExistingKeyPair:
       controller.cancelCurrentFlow()
 
-method executeTertiaryCommand*(self: InsertKeycardState, controller: Controller) =
+method executePreTertiaryStateCommand*(self: InsertKeycardState, controller: Controller) =
   if self.flowType == FlowType.FactoryReset or
     self.flowType == FlowType.SetupNewKeycard or
     self.flowType == FlowType.Authentication or

--- a/src/app/modules/shared_modules/keycard_popup/internal/insert_keycard_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/insert_keycard_state.nim
@@ -13,7 +13,7 @@ method executePreBackStateCommand*(self: InsertKeycardState, controller: Control
     if not self.getBackState.isNil and self.getBackState.stateType == StateType.SelectExistingKeyPair:
       controller.cancelCurrentFlow()
 
-method executePreTertiaryStateCommand*(self: InsertKeycardState, controller: Controller) =
+method executeCancelCommand*(self: InsertKeycardState, controller: Controller) =
   if self.flowType == FlowType.FactoryReset or
     self.flowType == FlowType.SetupNewKeycard or
     self.flowType == FlowType.Authentication or

--- a/src/app/modules/shared_modules/keycard_popup/internal/key_pair_migrate_failure_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/key_pair_migrate_failure_state.nim
@@ -12,6 +12,6 @@ method executePrePrimaryStateCommand*(self: KeyPairMigrateFailureState, controll
   if self.flowType == FlowType.SetupNewKeycard:
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = true)
 
-method executePreTertiaryStateCommand*(self: KeyPairMigrateFailureState, controller: Controller) =
+method executeCancelCommand*(self: KeyPairMigrateFailureState, controller: Controller) =
   if self.flowType == FlowType.SetupNewKeycard:
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = true)

--- a/src/app/modules/shared_modules/keycard_popup/internal/key_pair_migrate_failure_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/key_pair_migrate_failure_state.nim
@@ -8,10 +8,10 @@ proc newKeyPairMigrateFailureState*(flowType: FlowType, backState: State): KeyPa
 proc delete*(self: KeyPairMigrateFailureState) =
   self.State.delete
 
-method executePrimaryCommand*(self: KeyPairMigrateFailureState, controller: Controller) =
+method executePrePrimaryStateCommand*(self: KeyPairMigrateFailureState, controller: Controller) =
   if self.flowType == FlowType.SetupNewKeycard:
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = true)
 
-method executeTertiaryCommand*(self: KeyPairMigrateFailureState, controller: Controller) =
+method executePreTertiaryStateCommand*(self: KeyPairMigrateFailureState, controller: Controller) =
   if self.flowType == FlowType.SetupNewKeycard:
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = true)

--- a/src/app/modules/shared_modules/keycard_popup/internal/key_pair_migrate_success_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/key_pair_migrate_success_state.nim
@@ -8,7 +8,7 @@ proc newKeyPairMigrateSuccessState*(flowType: FlowType, backState: State): KeyPa
 proc delete*(self: KeyPairMigrateSuccessState) =
   self.State.delete
 
-method executePrimaryCommand*(self: KeyPairMigrateSuccessState, controller: Controller) =
+method executePrePrimaryStateCommand*(self: KeyPairMigrateSuccessState, controller: Controller) =
   if self.flowType == FlowType.SetupNewKeycard:
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = true)
     if controller.getSelectedKeyPairIsProfile():

--- a/src/app/modules/shared_modules/keycard_popup/internal/keycard_already_unlocked_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/keycard_already_unlocked_state.nim
@@ -8,10 +8,10 @@ proc newKeycardAlreadyUnlockedState*(flowType: FlowType, backState: State): Keyc
 proc delete*(self: KeycardAlreadyUnlockedState) =
   self.State.delete
 
-method executePrimaryCommand*(self: KeycardAlreadyUnlockedState, controller: Controller) =
+method executePrePrimaryStateCommand*(self: KeycardAlreadyUnlockedState, controller: Controller) =
   if self.flowType == FlowType.UnlockKeycard:
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = true)
 
-method executeTertiaryCommand*(self: KeycardAlreadyUnlockedState, controller: Controller) =
+method executePreTertiaryStateCommand*(self: KeycardAlreadyUnlockedState, controller: Controller) =
   if self.flowType == FlowType.UnlockKeycard:
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)

--- a/src/app/modules/shared_modules/keycard_popup/internal/keycard_already_unlocked_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/keycard_already_unlocked_state.nim
@@ -12,6 +12,6 @@ method executePrePrimaryStateCommand*(self: KeycardAlreadyUnlockedState, control
   if self.flowType == FlowType.UnlockKeycard:
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = true)
 
-method executePreTertiaryStateCommand*(self: KeycardAlreadyUnlockedState, controller: Controller) =
+method executeCancelCommand*(self: KeycardAlreadyUnlockedState, controller: Controller) =
   if self.flowType == FlowType.UnlockKeycard:
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)

--- a/src/app/modules/shared_modules/keycard_popup/internal/keycard_change_pairing_code_failure_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/keycard_change_pairing_code_failure_state.nim
@@ -12,6 +12,6 @@ method executePrePrimaryStateCommand*(self: ChangingKeycardPairingCodeFailureSta
   if self.flowType == FlowType.ChangePairingCode:
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = true)
 
-method executePreTertiaryStateCommand*(self: ChangingKeycardPairingCodeFailureState, controller: Controller) =
+method executeCancelCommand*(self: ChangingKeycardPairingCodeFailureState, controller: Controller) =
   if self.flowType == FlowType.ChangePairingCode:
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = true)

--- a/src/app/modules/shared_modules/keycard_popup/internal/keycard_change_pairing_code_failure_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/keycard_change_pairing_code_failure_state.nim
@@ -8,10 +8,10 @@ proc newChangingKeycardPairingCodeFailureState*(flowType: FlowType, backState: S
 proc delete*(self: ChangingKeycardPairingCodeFailureState) =
   self.State.delete
 
-method executePrimaryCommand*(self: ChangingKeycardPairingCodeFailureState, controller: Controller) =
+method executePrePrimaryStateCommand*(self: ChangingKeycardPairingCodeFailureState, controller: Controller) =
   if self.flowType == FlowType.ChangePairingCode:
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = true)
 
-method executeTertiaryCommand*(self: ChangingKeycardPairingCodeFailureState, controller: Controller) =
+method executePreTertiaryStateCommand*(self: ChangingKeycardPairingCodeFailureState, controller: Controller) =
   if self.flowType == FlowType.ChangePairingCode:
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = true)

--- a/src/app/modules/shared_modules/keycard_popup/internal/keycard_change_pairing_code_success_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/keycard_change_pairing_code_success_state.nim
@@ -8,10 +8,10 @@ proc newChangingKeycardPairingCodeSuccessState*(flowType: FlowType, backState: S
 proc delete*(self: ChangingKeycardPairingCodeSuccessState) =
   self.State.delete
 
-method executePrimaryCommand*(self: ChangingKeycardPairingCodeSuccessState, controller: Controller) =
+method executePrePrimaryStateCommand*(self: ChangingKeycardPairingCodeSuccessState, controller: Controller) =
   if self.flowType == FlowType.ChangePairingCode:
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = true)
 
-method executeTertiaryCommand*(self: ChangingKeycardPairingCodeSuccessState, controller: Controller) =
+method executePreTertiaryStateCommand*(self: ChangingKeycardPairingCodeSuccessState, controller: Controller) =
   if self.flowType == FlowType.ChangePairingCode:
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = true)

--- a/src/app/modules/shared_modules/keycard_popup/internal/keycard_change_pairing_code_success_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/keycard_change_pairing_code_success_state.nim
@@ -12,6 +12,6 @@ method executePrePrimaryStateCommand*(self: ChangingKeycardPairingCodeSuccessSta
   if self.flowType == FlowType.ChangePairingCode:
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = true)
 
-method executePreTertiaryStateCommand*(self: ChangingKeycardPairingCodeSuccessState, controller: Controller) =
+method executeCancelCommand*(self: ChangingKeycardPairingCodeSuccessState, controller: Controller) =
   if self.flowType == FlowType.ChangePairingCode:
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = true)

--- a/src/app/modules/shared_modules/keycard_popup/internal/keycard_change_pin_failure_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/keycard_change_pin_failure_state.nim
@@ -8,10 +8,10 @@ proc newChangingKeycardPinFailureState*(flowType: FlowType, backState: State): C
 proc delete*(self: ChangingKeycardPinFailureState) =
   self.State.delete
 
-method executePrimaryCommand*(self: ChangingKeycardPinFailureState, controller: Controller) =
+method executePrePrimaryStateCommand*(self: ChangingKeycardPinFailureState, controller: Controller) =
   if self.flowType == FlowType.ChangeKeycardPin:
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = true)
 
-method executeTertiaryCommand*(self: ChangingKeycardPinFailureState, controller: Controller) =
+method executePreTertiaryStateCommand*(self: ChangingKeycardPinFailureState, controller: Controller) =
   if self.flowType == FlowType.ChangeKeycardPin:
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = true)

--- a/src/app/modules/shared_modules/keycard_popup/internal/keycard_change_pin_failure_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/keycard_change_pin_failure_state.nim
@@ -12,6 +12,6 @@ method executePrePrimaryStateCommand*(self: ChangingKeycardPinFailureState, cont
   if self.flowType == FlowType.ChangeKeycardPin:
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = true)
 
-method executePreTertiaryStateCommand*(self: ChangingKeycardPinFailureState, controller: Controller) =
+method executeCancelCommand*(self: ChangingKeycardPinFailureState, controller: Controller) =
   if self.flowType == FlowType.ChangeKeycardPin:
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = true)

--- a/src/app/modules/shared_modules/keycard_popup/internal/keycard_change_pin_success_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/keycard_change_pin_success_state.nim
@@ -12,6 +12,6 @@ method executePrePrimaryStateCommand*(self: ChangingKeycardPinSuccessState, cont
   if self.flowType == FlowType.ChangeKeycardPin:
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = true)
 
-method executePreTertiaryStateCommand*(self: ChangingKeycardPinSuccessState, controller: Controller) =
+method executeCancelCommand*(self: ChangingKeycardPinSuccessState, controller: Controller) =
   if self.flowType == FlowType.ChangeKeycardPin:
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = true)

--- a/src/app/modules/shared_modules/keycard_popup/internal/keycard_change_pin_success_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/keycard_change_pin_success_state.nim
@@ -8,10 +8,10 @@ proc newChangingKeycardPinSuccessState*(flowType: FlowType, backState: State): C
 proc delete*(self: ChangingKeycardPinSuccessState) =
   self.State.delete
 
-method executePrimaryCommand*(self: ChangingKeycardPinSuccessState, controller: Controller) =
+method executePrePrimaryStateCommand*(self: ChangingKeycardPinSuccessState, controller: Controller) =
   if self.flowType == FlowType.ChangeKeycardPin:
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = true)
 
-method executeTertiaryCommand*(self: ChangingKeycardPinSuccessState, controller: Controller) =
+method executePreTertiaryStateCommand*(self: ChangingKeycardPinSuccessState, controller: Controller) =
   if self.flowType == FlowType.ChangeKeycardPin:
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = true)

--- a/src/app/modules/shared_modules/keycard_popup/internal/keycard_change_puk_failure_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/keycard_change_puk_failure_state.nim
@@ -12,6 +12,6 @@ method executePrePrimaryStateCommand*(self: ChangingKeycardPukFailureState, cont
   if self.flowType == FlowType.ChangeKeycardPuk:
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = true)
 
-method executePreTertiaryStateCommand*(self: ChangingKeycardPukFailureState, controller: Controller) =
+method executeCancelCommand*(self: ChangingKeycardPukFailureState, controller: Controller) =
   if self.flowType == FlowType.ChangeKeycardPuk:
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = true)

--- a/src/app/modules/shared_modules/keycard_popup/internal/keycard_change_puk_failure_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/keycard_change_puk_failure_state.nim
@@ -8,10 +8,10 @@ proc newChangingKeycardPukFailureState*(flowType: FlowType, backState: State): C
 proc delete*(self: ChangingKeycardPukFailureState) =
   self.State.delete
 
-method executePrimaryCommand*(self: ChangingKeycardPukFailureState, controller: Controller) =
+method executePrePrimaryStateCommand*(self: ChangingKeycardPukFailureState, controller: Controller) =
   if self.flowType == FlowType.ChangeKeycardPuk:
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = true)
 
-method executeTertiaryCommand*(self: ChangingKeycardPukFailureState, controller: Controller) =
+method executePreTertiaryStateCommand*(self: ChangingKeycardPukFailureState, controller: Controller) =
   if self.flowType == FlowType.ChangeKeycardPuk:
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = true)

--- a/src/app/modules/shared_modules/keycard_popup/internal/keycard_change_puk_success_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/keycard_change_puk_success_state.nim
@@ -12,6 +12,6 @@ method executePrePrimaryStateCommand*(self: ChangingKeycardPukSuccessState, cont
   if self.flowType == FlowType.ChangeKeycardPuk:
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = true)
 
-method executePreTertiaryStateCommand*(self: ChangingKeycardPukSuccessState, controller: Controller) =
+method executeCancelCommand*(self: ChangingKeycardPukSuccessState, controller: Controller) =
   if self.flowType == FlowType.ChangeKeycardPuk:
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = true)

--- a/src/app/modules/shared_modules/keycard_popup/internal/keycard_change_puk_success_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/keycard_change_puk_success_state.nim
@@ -8,10 +8,10 @@ proc newChangingKeycardPukSuccessState*(flowType: FlowType, backState: State): C
 proc delete*(self: ChangingKeycardPukSuccessState) =
   self.State.delete
 
-method executePrimaryCommand*(self: ChangingKeycardPukSuccessState, controller: Controller) =
+method executePrePrimaryStateCommand*(self: ChangingKeycardPukSuccessState, controller: Controller) =
   if self.flowType == FlowType.ChangeKeycardPuk:
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = true)
 
-method executeTertiaryCommand*(self: ChangingKeycardPukSuccessState, controller: Controller) =
+method executePreTertiaryStateCommand*(self: ChangingKeycardPukSuccessState, controller: Controller) =
   if self.flowType == FlowType.ChangeKeycardPuk:
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = true)

--- a/src/app/modules/shared_modules/keycard_popup/internal/keycard_empty_metadata_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/keycard_empty_metadata_state.nim
@@ -8,7 +8,7 @@ proc newKeycardEmptyMetadataState*(flowType: FlowType, backState: State): Keycar
 proc delete*(self: KeycardEmptyMetadataState) =
   self.State.delete
 
-method executePreTertiaryStateCommand*(self: KeycardEmptyMetadataState, controller: Controller) =
+method executeCancelCommand*(self: KeycardEmptyMetadataState, controller: Controller) =
   if self.flowType == FlowType.FactoryReset or
     self.flowType == FlowType.SetupNewKeycard or
     self.flowType == FlowType.DisplayKeycardContent or

--- a/src/app/modules/shared_modules/keycard_popup/internal/keycard_empty_metadata_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/keycard_empty_metadata_state.nim
@@ -8,14 +8,14 @@ proc newKeycardEmptyMetadataState*(flowType: FlowType, backState: State): Keycar
 proc delete*(self: KeycardEmptyMetadataState) =
   self.State.delete
 
-method executeTertiaryCommand*(self: KeycardEmptyMetadataState, controller: Controller) =
+method executePreTertiaryStateCommand*(self: KeycardEmptyMetadataState, controller: Controller) =
   if self.flowType == FlowType.FactoryReset or
     self.flowType == FlowType.SetupNewKeycard or
     self.flowType == FlowType.DisplayKeycardContent or
     self.flowType == FlowType.RenameKeycard:
       controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)
 
-method executePrimaryCommand*(self: KeycardEmptyMetadataState, controller: Controller) =
+method executePrePrimaryStateCommand*(self: KeycardEmptyMetadataState, controller: Controller) =
   if self.flowType == FlowType.DisplayKeycardContent or
     self.flowType == FlowType.RenameKeycard:
       controller.terminateCurrentFlow(lastStepInTheCurrentFlow = true)

--- a/src/app/modules/shared_modules/keycard_popup/internal/keycard_empty_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/keycard_empty_state.nim
@@ -8,7 +8,7 @@ proc newKeycardEmptyState*(flowType: FlowType, backState: State): KeycardEmptySt
 proc delete*(self: KeycardEmptyState) =
   self.State.delete
 
-method executePrimaryCommand*(self: KeycardEmptyState, controller: Controller) =
+method executePrePrimaryStateCommand*(self: KeycardEmptyState, controller: Controller) =
   if self.flowType == FlowType.FactoryReset or
     self.flowType == FlowType.Authentication or
     self.flowType == FlowType.UnlockKeycard or
@@ -19,7 +19,7 @@ method executePrimaryCommand*(self: KeycardEmptyState, controller: Controller) =
     self.flowType == FlowType.ChangePairingCode:
       controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)
 
-method executeTertiaryCommand*(self: KeycardEmptyState, controller: Controller) =
+method executePreTertiaryStateCommand*(self: KeycardEmptyState, controller: Controller) =
   if self.flowType == FlowType.FactoryReset or
     self.flowType == FlowType.Authentication or
     self.flowType == FlowType.UnlockKeycard or

--- a/src/app/modules/shared_modules/keycard_popup/internal/keycard_empty_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/keycard_empty_state.nim
@@ -19,7 +19,7 @@ method executePrePrimaryStateCommand*(self: KeycardEmptyState, controller: Contr
     self.flowType == FlowType.ChangePairingCode:
       controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)
 
-method executePreTertiaryStateCommand*(self: KeycardEmptyState, controller: Controller) =
+method executeCancelCommand*(self: KeycardEmptyState, controller: Controller) =
   if self.flowType == FlowType.FactoryReset or
     self.flowType == FlowType.Authentication or
     self.flowType == FlowType.UnlockKeycard or

--- a/src/app/modules/shared_modules/keycard_popup/internal/keycard_inserted_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/keycard_inserted_state.nim
@@ -8,7 +8,7 @@ proc newKeycardInsertedState*(flowType: FlowType, backState: State): KeycardInse
 proc delete*(self: KeycardInsertedState) =
   self.State.delete
   
-method executeBackCommand*(self: KeycardInsertedState, controller: Controller) =
+method executePreBackStateCommand*(self: KeycardInsertedState, controller: Controller) =
   if self.flowType == FlowType.SetupNewKeycard:
     if not self.getBackState.isNil and self.getBackState.stateType == StateType.SelectExistingKeyPair:
       controller.cancelCurrentFlow()
@@ -20,7 +20,7 @@ method getNextSecondaryState*(self: KeycardInsertedState, controller: Controller
     return createState(StateType.ReadingKeycard, self.flowType, self.getBackState)
   return createState(StateType.ReadingKeycard, self.flowType, nil)
 
-method executeTertiaryCommand*(self: KeycardInsertedState, controller: Controller) =
+method executePreTertiaryStateCommand*(self: KeycardInsertedState, controller: Controller) =
   if self.flowType == FlowType.FactoryReset or
     self.flowType == FlowType.SetupNewKeycard or
     self.flowType == FlowType.Authentication or

--- a/src/app/modules/shared_modules/keycard_popup/internal/keycard_inserted_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/keycard_inserted_state.nim
@@ -20,7 +20,7 @@ method getNextSecondaryState*(self: KeycardInsertedState, controller: Controller
     return createState(StateType.ReadingKeycard, self.flowType, self.getBackState)
   return createState(StateType.ReadingKeycard, self.flowType, nil)
 
-method executePreTertiaryStateCommand*(self: KeycardInsertedState, controller: Controller) =
+method executeCancelCommand*(self: KeycardInsertedState, controller: Controller) =
   if self.flowType == FlowType.FactoryReset or
     self.flowType == FlowType.SetupNewKeycard or
     self.flowType == FlowType.Authentication or

--- a/src/app/modules/shared_modules/keycard_popup/internal/keycard_metadata_display_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/keycard_metadata_display_state.nim
@@ -17,7 +17,7 @@ method getNextPrimaryState*(self: KeycardMetadataDisplayState, controller: Contr
   if self.flowType == FlowType.RenameKeycard:
     return createState(StateType.EnterKeycardName, self.flowType, nil)
 
-method executePreTertiaryStateCommand*(self: KeycardMetadataDisplayState, controller: Controller) =
+method executeCancelCommand*(self: KeycardMetadataDisplayState, controller: Controller) =
   if self.flowType == FlowType.FactoryReset or
     self.flowType == FlowType.SetupNewKeycard or
     self.flowType == FlowType.DisplayKeycardContent or

--- a/src/app/modules/shared_modules/keycard_popup/internal/keycard_metadata_display_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/keycard_metadata_display_state.nim
@@ -17,7 +17,7 @@ method getNextPrimaryState*(self: KeycardMetadataDisplayState, controller: Contr
   if self.flowType == FlowType.RenameKeycard:
     return createState(StateType.EnterKeycardName, self.flowType, nil)
 
-method executeTertiaryCommand*(self: KeycardMetadataDisplayState, controller: Controller) =
+method executePreTertiaryStateCommand*(self: KeycardMetadataDisplayState, controller: Controller) =
   if self.flowType == FlowType.FactoryReset or
     self.flowType == FlowType.SetupNewKeycard or
     self.flowType == FlowType.DisplayKeycardContent or

--- a/src/app/modules/shared_modules/keycard_popup/internal/keycard_not_empty_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/keycard_not_empty_state.nim
@@ -8,12 +8,12 @@ proc newKeycardNotEmptyState*(flowType: FlowType, backState: State): KeycardNotE
 proc delete*(self: KeycardNotEmptyState) =
   self.State.delete
 
-method executePrimaryCommand*(self: KeycardNotEmptyState, controller: Controller) =
+method executePrePrimaryStateCommand*(self: KeycardNotEmptyState, controller: Controller) =
   if self.flowType == FlowType.SetupNewKeycard:
     controller.setKeycardData(updatePredefinedKeycardData(controller.getKeycardData(), PredefinedKeycardData.HideKeyPair, add = true))
     controller.runGetMetadataFlow(resolveAddress = true)
 
-method executeTertiaryCommand*(self: KeycardNotEmptyState, controller: Controller) =
+method executePreTertiaryStateCommand*(self: KeycardNotEmptyState, controller: Controller) =
   if self.flowType == FlowType.SetupNewKeycard:
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)
 

--- a/src/app/modules/shared_modules/keycard_popup/internal/keycard_not_empty_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/keycard_not_empty_state.nim
@@ -13,7 +13,7 @@ method executePrePrimaryStateCommand*(self: KeycardNotEmptyState, controller: Co
     controller.setKeycardData(updatePredefinedKeycardData(controller.getKeycardData(), PredefinedKeycardData.HideKeyPair, add = true))
     controller.runGetMetadataFlow(resolveAddress = true)
 
-method executePreTertiaryStateCommand*(self: KeycardNotEmptyState, controller: Controller) =
+method executeCancelCommand*(self: KeycardNotEmptyState, controller: Controller) =
   if self.flowType == FlowType.SetupNewKeycard:
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)
 

--- a/src/app/modules/shared_modules/keycard_popup/internal/keycard_rename_failure_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/keycard_rename_failure_state.nim
@@ -8,10 +8,10 @@ proc newKeycardRenameFailureState*(flowType: FlowType, backState: State): Keycar
 proc delete*(self: KeycardRenameFailureState) =
   self.State.delete
 
-method executePrimaryCommand*(self: KeycardRenameFailureState, controller: Controller) =
+method executePrePrimaryStateCommand*(self: KeycardRenameFailureState, controller: Controller) =
   if self.flowType == FlowType.RenameKeycard:
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = true)
 
-method executeTertiaryCommand*(self: KeycardRenameFailureState, controller: Controller) =
+method executePreTertiaryStateCommand*(self: KeycardRenameFailureState, controller: Controller) =
   if self.flowType == FlowType.RenameKeycard:
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = true)

--- a/src/app/modules/shared_modules/keycard_popup/internal/keycard_rename_failure_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/keycard_rename_failure_state.nim
@@ -12,6 +12,6 @@ method executePrePrimaryStateCommand*(self: KeycardRenameFailureState, controlle
   if self.flowType == FlowType.RenameKeycard:
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = true)
 
-method executePreTertiaryStateCommand*(self: KeycardRenameFailureState, controller: Controller) =
+method executeCancelCommand*(self: KeycardRenameFailureState, controller: Controller) =
   if self.flowType == FlowType.RenameKeycard:
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = true)

--- a/src/app/modules/shared_modules/keycard_popup/internal/keycard_rename_success_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/keycard_rename_success_state.nim
@@ -12,6 +12,6 @@ method executePrePrimaryStateCommand*(self: KeycardRenameSuccessState, controlle
   if self.flowType == FlowType.RenameKeycard:
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = true)
 
-method executePreTertiaryStateCommand*(self: KeycardRenameSuccessState, controller: Controller) =
+method executeCancelCommand*(self: KeycardRenameSuccessState, controller: Controller) =
   if self.flowType == FlowType.RenameKeycard:
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = true)

--- a/src/app/modules/shared_modules/keycard_popup/internal/keycard_rename_success_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/keycard_rename_success_state.nim
@@ -8,10 +8,10 @@ proc newKeycardRenameSuccessState*(flowType: FlowType, backState: State): Keycar
 proc delete*(self: KeycardRenameSuccessState) =
   self.State.delete
 
-method executePrimaryCommand*(self: KeycardRenameSuccessState, controller: Controller) =
+method executePrePrimaryStateCommand*(self: KeycardRenameSuccessState, controller: Controller) =
   if self.flowType == FlowType.RenameKeycard:
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = true)
 
-method executeTertiaryCommand*(self: KeycardRenameSuccessState, controller: Controller) =
+method executePreTertiaryStateCommand*(self: KeycardRenameSuccessState, controller: Controller) =
   if self.flowType == FlowType.RenameKeycard:
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = true)

--- a/src/app/modules/shared_modules/keycard_popup/internal/max_pairing_slots_reached_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/max_pairing_slots_reached_state.nim
@@ -21,7 +21,7 @@ method getNextPrimaryState*(self: MaxPairingSlotsReachedState, controller: Contr
       controller.runSharedModuleFlow(FlowType.UnlockKeycard)
   return nil
 
-method executeTertiaryCommand*(self: MaxPairingSlotsReachedState, controller: Controller) =
+method executePreTertiaryStateCommand*(self: MaxPairingSlotsReachedState, controller: Controller) =
   if self.flowType == FlowType.FactoryReset or
     self.flowType == FlowType.SetupNewKeycard or
     self.flowType == FlowType.Authentication or

--- a/src/app/modules/shared_modules/keycard_popup/internal/max_pairing_slots_reached_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/max_pairing_slots_reached_state.nim
@@ -21,7 +21,7 @@ method getNextPrimaryState*(self: MaxPairingSlotsReachedState, controller: Contr
       controller.runSharedModuleFlow(FlowType.UnlockKeycard)
   return nil
 
-method executePreTertiaryStateCommand*(self: MaxPairingSlotsReachedState, controller: Controller) =
+method executeCancelCommand*(self: MaxPairingSlotsReachedState, controller: Controller) =
   if self.flowType == FlowType.FactoryReset or
     self.flowType == FlowType.SetupNewKeycard or
     self.flowType == FlowType.Authentication or

--- a/src/app/modules/shared_modules/keycard_popup/internal/max_pin_retries_reached_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/max_pin_retries_reached_state.nim
@@ -26,7 +26,7 @@ method getNextPrimaryState*(self: MaxPinRetriesReachedState, controller: Control
       controller.runSharedModuleFlow(FlowType.UnlockKeycard)
   return nil
 
-method executePreTertiaryStateCommand*(self: MaxPinRetriesReachedState, controller: Controller) =
+method executeCancelCommand*(self: MaxPinRetriesReachedState, controller: Controller) =
   if self.flowType == FlowType.FactoryReset or
     self.flowType == FlowType.Authentication or
     self.flowType == FlowType.DisplayKeycardContent or

--- a/src/app/modules/shared_modules/keycard_popup/internal/max_pin_retries_reached_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/max_pin_retries_reached_state.nim
@@ -26,7 +26,7 @@ method getNextPrimaryState*(self: MaxPinRetriesReachedState, controller: Control
       controller.runSharedModuleFlow(FlowType.UnlockKeycard)
   return nil
 
-method executeTertiaryCommand*(self: MaxPinRetriesReachedState, controller: Controller) =
+method executePreTertiaryStateCommand*(self: MaxPinRetriesReachedState, controller: Controller) =
   if self.flowType == FlowType.FactoryReset or
     self.flowType == FlowType.Authentication or
     self.flowType == FlowType.DisplayKeycardContent or

--- a/src/app/modules/shared_modules/keycard_popup/internal/max_puk_retries_reached_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/max_puk_retries_reached_state.nim
@@ -22,7 +22,7 @@ method getNextPrimaryState*(self: MaxPukRetriesReachedState, controller: Control
   if self.flowType == FlowType.UnlockKeycard:
     return createState(StateType.EnterSeedPhrase, self.flowType, self)
 
-method executeTertiaryCommand*(self: MaxPukRetriesReachedState, controller: Controller) =
+method executePreTertiaryStateCommand*(self: MaxPukRetriesReachedState, controller: Controller) =
   if self.flowType == FlowType.FactoryReset or
     self.flowType == FlowType.SetupNewKeycard or
     self.flowType == FlowType.Authentication or

--- a/src/app/modules/shared_modules/keycard_popup/internal/max_puk_retries_reached_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/max_puk_retries_reached_state.nim
@@ -22,7 +22,7 @@ method getNextPrimaryState*(self: MaxPukRetriesReachedState, controller: Control
   if self.flowType == FlowType.UnlockKeycard:
     return createState(StateType.EnterSeedPhrase, self.flowType, self)
 
-method executePreTertiaryStateCommand*(self: MaxPukRetriesReachedState, controller: Controller) =
+method executeCancelCommand*(self: MaxPukRetriesReachedState, controller: Controller) =
   if self.flowType == FlowType.FactoryReset or
     self.flowType == FlowType.SetupNewKeycard or
     self.flowType == FlowType.Authentication or

--- a/src/app/modules/shared_modules/keycard_popup/internal/migrating_key_pair_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/migrating_key_pair_state.nim
@@ -29,14 +29,14 @@ proc doMigration(self: MigratingKeyPairState, controller: Controller) =
     controller.runStoreMetadataFlow(selectedKeyPairDto.keycardName, controller.getPin(), 
       controller.getSelectedKeyPairWalletPaths())
 
-method executePrimaryCommand*(self: MigratingKeyPairState, controller: Controller) =
+method executePrePrimaryStateCommand*(self: MigratingKeyPairState, controller: Controller) =
   if self.flowType == FlowType.SetupNewKeycard:
     if controller.getSelectedKeyPairIsProfile():
       controller.authenticateUser()
     else:
       self.doMigration(controller)
 
-method executeSecondaryCommand*(self: MigratingKeyPairState, controller: Controller) =
+method executePreSecondaryStateCommand*(self: MigratingKeyPairState, controller: Controller) =
   if self.flowType == FlowType.SetupNewKeycard:
     self.doMigration(controller)
 

--- a/src/app/modules/shared_modules/keycard_popup/internal/not_keycard_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/not_keycard_state.nim
@@ -8,7 +8,7 @@ proc newNotKeycardState*(flowType: FlowType, backState: State): NotKeycardState 
 proc delete*(self: NotKeycardState) =
   self.State.delete
 
-method executePreTertiaryStateCommand*(self: NotKeycardState, controller: Controller) =
+method executeCancelCommand*(self: NotKeycardState, controller: Controller) =
   if self.flowType == FlowType.FactoryReset or
     self.flowType == FlowType.SetupNewKeycard or
     self.flowType == FlowType.Authentication or

--- a/src/app/modules/shared_modules/keycard_popup/internal/not_keycard_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/not_keycard_state.nim
@@ -8,7 +8,7 @@ proc newNotKeycardState*(flowType: FlowType, backState: State): NotKeycardState 
 proc delete*(self: NotKeycardState) =
   self.State.delete
 
-method executeTertiaryCommand*(self: NotKeycardState, controller: Controller) =
+method executePreTertiaryStateCommand*(self: NotKeycardState, controller: Controller) =
   if self.flowType == FlowType.FactoryReset or
     self.flowType == FlowType.SetupNewKeycard or
     self.flowType == FlowType.Authentication or

--- a/src/app/modules/shared_modules/keycard_popup/internal/pin_set_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/pin_set_state.nim
@@ -22,6 +22,6 @@ method getNextPrimaryState*(self: PinSetState, controller: Controller): State =
     if controller.getCurrentKeycardServiceFlow() == KCSFlowType.StoreMetadata:
       return createState(StateType.UnlockKeycardSuccess, self.flowType, nil)
 
-method executeTertiaryCommand*(self: PinSetState, controller: Controller) =
+method executePreTertiaryStateCommand*(self: PinSetState, controller: Controller) =
   if self.flowType == FlowType.SetupNewKeycard:
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)

--- a/src/app/modules/shared_modules/keycard_popup/internal/pin_set_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/pin_set_state.nim
@@ -22,6 +22,6 @@ method getNextPrimaryState*(self: PinSetState, controller: Controller): State =
     if controller.getCurrentKeycardServiceFlow() == KCSFlowType.StoreMetadata:
       return createState(StateType.UnlockKeycardSuccess, self.flowType, nil)
 
-method executePreTertiaryStateCommand*(self: PinSetState, controller: Controller) =
+method executeCancelCommand*(self: PinSetState, controller: Controller) =
   if self.flowType == FlowType.SetupNewKeycard:
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)

--- a/src/app/modules/shared_modules/keycard_popup/internal/pin_verified_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/pin_verified_state.nim
@@ -21,7 +21,7 @@ method getNextPrimaryState*(self: PinVerifiedState, controller: Controller): Sta
   if self.flowType == FlowType.ChangePairingCode:
     return createState(StateType.CreatePairingCode, self.flowType, nil)
 
-method executePreTertiaryStateCommand*(self: PinVerifiedState, controller: Controller) =
+method executeCancelCommand*(self: PinVerifiedState, controller: Controller) =
   if self.flowType == FlowType.FactoryReset or
     self.flowType == FlowType.SetupNewKeycard or
     self.flowType == FlowType.DisplayKeycardContent or

--- a/src/app/modules/shared_modules/keycard_popup/internal/pin_verified_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/pin_verified_state.nim
@@ -21,7 +21,7 @@ method getNextPrimaryState*(self: PinVerifiedState, controller: Controller): Sta
   if self.flowType == FlowType.ChangePairingCode:
     return createState(StateType.CreatePairingCode, self.flowType, nil)
 
-method executeTertiaryCommand*(self: PinVerifiedState, controller: Controller) =
+method executePreTertiaryStateCommand*(self: PinVerifiedState, controller: Controller) =
   if self.flowType == FlowType.FactoryReset or
     self.flowType == FlowType.SetupNewKeycard or
     self.flowType == FlowType.DisplayKeycardContent or

--- a/src/app/modules/shared_modules/keycard_popup/internal/plugin_reader_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/plugin_reader_state.nim
@@ -13,7 +13,7 @@ method executePreBackStateCommand*(self: PluginReaderState, controller: Controll
     if not self.getBackState.isNil and self.getBackState.stateType == StateType.SelectExistingKeyPair:
       controller.cancelCurrentFlow()
 
-method executePreTertiaryStateCommand*(self: PluginReaderState, controller: Controller) =
+method executeCancelCommand*(self: PluginReaderState, controller: Controller) =
   if self.flowType == FlowType.FactoryReset or
     self.flowType == FlowType.SetupNewKeycard or
     self.flowType == FlowType.Authentication or

--- a/src/app/modules/shared_modules/keycard_popup/internal/plugin_reader_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/plugin_reader_state.nim
@@ -8,12 +8,12 @@ proc newPluginReaderState*(flowType: FlowType, backState: State): PluginReaderSt
 proc delete*(self: PluginReaderState) =
   self.State.delete
 
-method executeBackCommand*(self: PluginReaderState, controller: Controller) =
+method executePreBackStateCommand*(self: PluginReaderState, controller: Controller) =
   if self.flowType == FlowType.SetupNewKeycard:
     if not self.getBackState.isNil and self.getBackState.stateType == StateType.SelectExistingKeyPair:
       controller.cancelCurrentFlow()
 
-method executeTertiaryCommand*(self: PluginReaderState, controller: Controller) =
+method executePreTertiaryStateCommand*(self: PluginReaderState, controller: Controller) =
   if self.flowType == FlowType.FactoryReset or
     self.flowType == FlowType.SetupNewKeycard or
     self.flowType == FlowType.Authentication or

--- a/src/app/modules/shared_modules/keycard_popup/internal/reading_keycard_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/reading_keycard_state.nim
@@ -8,12 +8,12 @@ proc newReadingKeycardState*(flowType: FlowType, backState: State): ReadingKeyca
 proc delete*(self: ReadingKeycardState) =
   self.State.delete
 
-method executeBackCommand*(self: ReadingKeycardState, controller: Controller) =
+method executePreBackStateCommand*(self: ReadingKeycardState, controller: Controller) =
   if self.flowType == FlowType.SetupNewKeycard:
     if not self.getBackState.isNil and self.getBackState.stateType == StateType.SelectExistingKeyPair:
       controller.cancelCurrentFlow()
 
-method executeTertiaryCommand*(self: ReadingKeycardState, controller: Controller) =
+method executePreTertiaryStateCommand*(self: ReadingKeycardState, controller: Controller) =
   error "reading state must not be canceled"
 
 method getNextSecondaryState*(self: ReadingKeycardState, controller: Controller): State =

--- a/src/app/modules/shared_modules/keycard_popup/internal/reading_keycard_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/reading_keycard_state.nim
@@ -13,7 +13,7 @@ method executePreBackStateCommand*(self: ReadingKeycardState, controller: Contro
     if not self.getBackState.isNil and self.getBackState.stateType == StateType.SelectExistingKeyPair:
       controller.cancelCurrentFlow()
 
-method executePreTertiaryStateCommand*(self: ReadingKeycardState, controller: Controller) =
+method executeCancelCommand*(self: ReadingKeycardState, controller: Controller) =
   error "reading state must not be canceled"
 
 method getNextSecondaryState*(self: ReadingKeycardState, controller: Controller): State =

--- a/src/app/modules/shared_modules/keycard_popup/internal/recognized_keycard_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/recognized_keycard_state.nim
@@ -30,5 +30,5 @@ method getNextSecondaryState*(self: RecognizedKeycardState, controller: Controll
     self.flowType == FlowType.ChangePairingCode:
       return createState(StateType.EnterPin, self.flowType, nil)
 
-method executePreTertiaryStateCommand*(self: RecognizedKeycardState, controller: Controller) =
+method executeCancelCommand*(self: RecognizedKeycardState, controller: Controller) =
   error "recognized state must not be canceled"

--- a/src/app/modules/shared_modules/keycard_popup/internal/recognized_keycard_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/recognized_keycard_state.nim
@@ -8,7 +8,7 @@ proc newRecognizedKeycardState*(flowType: FlowType, backState: State): Recognize
 proc delete*(self: RecognizedKeycardState) =
   self.State.delete
 
-method executeBackCommand*(self: RecognizedKeycardState, controller: Controller) =
+method executePreBackStateCommand*(self: RecognizedKeycardState, controller: Controller) =
   if self.flowType == FlowType.SetupNewKeycard:
     if not self.getBackState.isNil and self.getBackState.stateType == StateType.SelectExistingKeyPair:
       controller.cancelCurrentFlow()
@@ -30,5 +30,5 @@ method getNextSecondaryState*(self: RecognizedKeycardState, controller: Controll
     self.flowType == FlowType.ChangePairingCode:
       return createState(StateType.EnterPin, self.flowType, nil)
 
-method executeTertiaryCommand*(self: RecognizedKeycardState, controller: Controller) =
+method executePreTertiaryStateCommand*(self: RecognizedKeycardState, controller: Controller) =
   error "recognized state must not be canceled"

--- a/src/app/modules/shared_modules/keycard_popup/internal/renaming_keycard_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/renaming_keycard_state.nim
@@ -10,7 +10,7 @@ proc newRenamingKeycardState*(flowType: FlowType, backState: State): RenamingKey
 proc delete*(self: RenamingKeycardState) =
   self.State.delete
 
-method executePrimaryCommand*(self: RenamingKeycardState, controller: Controller) =
+method executePrePrimaryStateCommand*(self: RenamingKeycardState, controller: Controller) =
   if self.flowType == FlowType.RenameKeycard:
     let md = controller.getMetadataFromKeycard()
     let paths = md.walletAccounts.map(a => a.path)

--- a/src/app/modules/shared_modules/keycard_popup/internal/repeat_pin_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/repeat_pin_state.nim
@@ -8,11 +8,11 @@ proc newRepeatPinState*(flowType: FlowType, backState: State): RepeatPinState =
 proc delete*(self: RepeatPinState) =
   self.State.delete
 
-method executeBackCommand*(self: RepeatPinState, controller: Controller) =
+method executePreBackStateCommand*(self: RepeatPinState, controller: Controller) =
   controller.setPin("")
   controller.setPinMatch(false)
 
-method executeSecondaryCommand*(self: RepeatPinState, controller: Controller) =
+method executePreSecondaryStateCommand*(self: RepeatPinState, controller: Controller) =
   if not controller.getPinMatch():
     return
   if self.flowType == FlowType.SetupNewKeycard:
@@ -26,7 +26,7 @@ method getNextSecondaryState*(self: RepeatPinState, controller: Controller): Sta
   if self.flowType == FlowType.ChangeKeycardPin:
     return createState(StateType.ChangingKeycardPin, self.flowType, nil)
 
-method executeTertiaryCommand*(self: RepeatPinState, controller: Controller) =
+method executePreTertiaryStateCommand*(self: RepeatPinState, controller: Controller) =
   if self.flowType == FlowType.SetupNewKeycard or
     self.flowType == FlowType.UnlockKeycard or
     self.flowType == FlowType.ChangeKeycardPin:

--- a/src/app/modules/shared_modules/keycard_popup/internal/repeat_pin_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/repeat_pin_state.nim
@@ -26,7 +26,7 @@ method getNextSecondaryState*(self: RepeatPinState, controller: Controller): Sta
   if self.flowType == FlowType.ChangeKeycardPin:
     return createState(StateType.ChangingKeycardPin, self.flowType, nil)
 
-method executePreTertiaryStateCommand*(self: RepeatPinState, controller: Controller) =
+method executeCancelCommand*(self: RepeatPinState, controller: Controller) =
   if self.flowType == FlowType.SetupNewKeycard or
     self.flowType == FlowType.UnlockKeycard or
     self.flowType == FlowType.ChangeKeycardPin:

--- a/src/app/modules/shared_modules/keycard_popup/internal/repeat_puk_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/repeat_puk_state.nim
@@ -18,6 +18,6 @@ method getNextSecondaryState*(self: RepeatPukState, controller: Controller): Sta
   if self.flowType == FlowType.ChangeKeycardPuk:
     return createState(StateType.ChangingKeycardPuk, self.flowType, nil)
 
-method executePreTertiaryStateCommand*(self: RepeatPukState, controller: Controller) =
+method executeCancelCommand*(self: RepeatPukState, controller: Controller) =
   if self.flowType == FlowType.ChangeKeycardPuk:
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)

--- a/src/app/modules/shared_modules/keycard_popup/internal/repeat_puk_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/repeat_puk_state.nim
@@ -8,7 +8,7 @@ proc newRepeatPukState*(flowType: FlowType, backState: State): RepeatPukState =
 proc delete*(self: RepeatPukState) =
   self.State.delete
 
-method executeBackCommand*(self: RepeatPukState, controller: Controller) =
+method executePreBackStateCommand*(self: RepeatPukState, controller: Controller) =
   controller.setPuk("")
   controller.setPukMatch(false)
 
@@ -18,6 +18,6 @@ method getNextSecondaryState*(self: RepeatPukState, controller: Controller): Sta
   if self.flowType == FlowType.ChangeKeycardPuk:
     return createState(StateType.ChangingKeycardPuk, self.flowType, nil)
 
-method executeTertiaryCommand*(self: RepeatPukState, controller: Controller) =
+method executePreTertiaryStateCommand*(self: RepeatPukState, controller: Controller) =
   if self.flowType == FlowType.ChangeKeycardPuk:
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)

--- a/src/app/modules/shared_modules/keycard_popup/internal/seed_phrase_display_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/seed_phrase_display_state.nim
@@ -8,7 +8,7 @@ proc newSeedPhraseDisplayState*(flowType: FlowType, backState: State): SeedPhras
 proc delete*(self: SeedPhraseDisplayState) =
   self.State.delete
 
-method executeTertiaryCommand*(self: SeedPhraseDisplayState, controller: Controller) =
+method executePreTertiaryStateCommand*(self: SeedPhraseDisplayState, controller: Controller) =
   if self.flowType == FlowType.SetupNewKeycard:
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)
 

--- a/src/app/modules/shared_modules/keycard_popup/internal/seed_phrase_display_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/seed_phrase_display_state.nim
@@ -8,7 +8,7 @@ proc newSeedPhraseDisplayState*(flowType: FlowType, backState: State): SeedPhras
 proc delete*(self: SeedPhraseDisplayState) =
   self.State.delete
 
-method executePreTertiaryStateCommand*(self: SeedPhraseDisplayState, controller: Controller) =
+method executeCancelCommand*(self: SeedPhraseDisplayState, controller: Controller) =
   if self.flowType == FlowType.SetupNewKeycard:
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)
 

--- a/src/app/modules/shared_modules/keycard_popup/internal/seed_phrase_enter_words_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/seed_phrase_enter_words_state.nim
@@ -15,7 +15,7 @@ method executePrePrimaryStateCommand*(self: SeedPhraseEnterWordsState, controlle
   controller.setSeedPhrase(mnemonic)
   controller.storeSeedPhraseToKeycard(mnemonic.split(" ").len, mnemonic)
 
-method executePreTertiaryStateCommand*(self: SeedPhraseEnterWordsState, controller: Controller) =
+method executeCancelCommand*(self: SeedPhraseEnterWordsState, controller: Controller) =
   if self.flowType == FlowType.SetupNewKeycard:
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)
 

--- a/src/app/modules/shared_modules/keycard_popup/internal/seed_phrase_enter_words_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/seed_phrase_enter_words_state.nim
@@ -10,12 +10,12 @@ proc newSeedPhraseEnterWordsState*(flowType: FlowType, backState: State): SeedPh
 proc delete*(self: SeedPhraseEnterWordsState) =
   self.State.delete
 
-method executePrimaryCommand*(self: SeedPhraseEnterWordsState, controller: Controller) =
+method executePrePrimaryStateCommand*(self: SeedPhraseEnterWordsState, controller: Controller) =
   let mnemonic = controller.getMnemonic()
   controller.setSeedPhrase(mnemonic)
   controller.storeSeedPhraseToKeycard(mnemonic.split(" ").len, mnemonic)
 
-method executeTertiaryCommand*(self: SeedPhraseEnterWordsState, controller: Controller) =
+method executePreTertiaryStateCommand*(self: SeedPhraseEnterWordsState, controller: Controller) =
   if self.flowType == FlowType.SetupNewKeycard:
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)
 

--- a/src/app/modules/shared_modules/keycard_popup/internal/select_existing_key_pair_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/select_existing_key_pair_state.nim
@@ -8,11 +8,11 @@ proc newSelectExistingKeyPairState*(flowType: FlowType, backState: State): Selec
 proc delete*(self: SelectExistingKeyPairState) =
   self.State.delete
 
-method executePrimaryCommand*(self: SelectExistingKeyPairState, controller: Controller) =
+method executePrePrimaryStateCommand*(self: SelectExistingKeyPairState, controller: Controller) =
   if self.flowType == FlowType.SetupNewKeycard:
     controller.runLoadAccountFlow()
 
-method executeTertiaryCommand*(self: SelectExistingKeyPairState, controller: Controller) =
+method executePreTertiaryStateCommand*(self: SelectExistingKeyPairState, controller: Controller) =
   if self.flowType == FlowType.SetupNewKeycard:
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)
 

--- a/src/app/modules/shared_modules/keycard_popup/internal/select_existing_key_pair_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/select_existing_key_pair_state.nim
@@ -12,7 +12,7 @@ method executePrePrimaryStateCommand*(self: SelectExistingKeyPairState, controll
   if self.flowType == FlowType.SetupNewKeycard:
     controller.runLoadAccountFlow()
 
-method executePreTertiaryStateCommand*(self: SelectExistingKeyPairState, controller: Controller) =
+method executeCancelCommand*(self: SelectExistingKeyPairState, controller: Controller) =
   if self.flowType == FlowType.SetupNewKeycard:
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)
 

--- a/src/app/modules/shared_modules/keycard_popup/internal/state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/state.nim
@@ -111,32 +111,48 @@ method getBackState*(self: State): State {.inline base.} =
 method displayBackButton*(self: State): bool {.inline base.} =
   return not self.backState.isNil
 
-## Returns next state instance in case the "primary" action is triggered
+## Returns next state instance if "primary" action is triggered
 method getNextPrimaryState*(self: State, controller: Controller): State  {.inline base.} =
   return nil
 
-## Returns next state instance in case the "secondary" action is triggered
+## Returns next state instance if "secondary" action is triggered
 method getNextSecondaryState*(self: State, controller: Controller): State {.inline base.} =
   return nil
 
-## Returns next state instance in case the "tertiary" action is triggered
+## Returns next state instance if "tertiary" action is triggered
 method getNextTertiaryState*(self: State, controller: Controller): State {.inline base.} =
   return nil
 
-## This method is executed in case "back" button is clicked
-method executeBackCommand*(self: State, controller: Controller) {.inline base.} =
+## This method is executed before back state is set, if "back" action is triggered
+method executePreBackStateCommand*(self: State, controller: Controller) {.inline base.} =
   discard
 
-## This method is executed in case "primary" action is triggered
-method executePrimaryCommand*(self: State, controller: Controller) {.inline base.} =
+## This method is executed after back state is set, if "back" action is triggered
+method executePostBackStateCommand*(self: State, controller: Controller) {.inline base.} =
   discard
 
-## This method is executed in case "secondary" action is triggered
-method executeSecondaryCommand*(self: State, controller: Controller) {.inline base.} =
+## This method is executed before primary state is set, if "primary" action is triggered
+method executePrePrimaryStateCommand*(self: State, controller: Controller) {.inline base.} =
   discard
 
-## This method is executed in case "tertiary" action is triggered
-method executeTertiaryCommand*(self: State, controller: Controller) {.inline base.} =
+## This method is executed after primary state is set, if "primary" action is triggered
+method executePostPrimaryStateCommand*(self: State, controller: Controller) {.inline base.} =
+  discard
+
+## This method is executed before secondary state is set, if "secondary" action is triggered
+method executePreSecondaryStateCommand*(self: State, controller: Controller) {.inline base.} =
+  discard
+
+## This method is executed after secondary state is set, if "secondary" action is triggered
+method executePostSecondaryStateCommand*(self: State, controller: Controller) {.inline base.} =
+  discard
+
+## This method is executed before tertiary state is set, if "tertiary" action is triggered
+method executePreTertiaryStateCommand*(self: State, controller: Controller) {.inline base.} =
+  discard
+
+## This method is executed after tertiary state is set, if "tertiary" action is triggered
+method executePostTertiaryStateCommand*(self: State, controller: Controller) {.inline base.} =
   discard
 
 ## This method is used for handling aync responses for keycard related states

--- a/src/app/modules/shared_modules/keycard_popup/internal/state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/state.nim
@@ -119,9 +119,9 @@ method getNextPrimaryState*(self: State, controller: Controller): State  {.inlin
 method getNextSecondaryState*(self: State, controller: Controller): State {.inline base.} =
   return nil
 
-## Returns next state instance if "tertiary" action is triggered
-method getNextTertiaryState*(self: State, controller: Controller): State {.inline base.} =
-  return nil
+## This method is executed if "cancel" action is triggered (invalidates current flow)
+method executeCancelCommand*(self: State, controller: Controller) {.inline base.} =
+  discard
 
 ## This method is executed before back state is set, if "back" action is triggered
 method executePreBackStateCommand*(self: State, controller: Controller) {.inline base.} =
@@ -145,14 +145,6 @@ method executePreSecondaryStateCommand*(self: State, controller: Controller) {.i
 
 ## This method is executed after secondary state is set, if "secondary" action is triggered
 method executePostSecondaryStateCommand*(self: State, controller: Controller) {.inline base.} =
-  discard
-
-## This method is executed before tertiary state is set, if "tertiary" action is triggered
-method executePreTertiaryStateCommand*(self: State, controller: Controller) {.inline base.} =
-  discard
-
-## This method is executed after tertiary state is set, if "tertiary" action is triggered
-method executePostTertiaryStateCommand*(self: State, controller: Controller) {.inline base.} =
   discard
 
 ## This method is used for handling aync responses for keycard related states

--- a/src/app/modules/shared_modules/keycard_popup/internal/state_wrapper.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/state_wrapper.nim
@@ -46,8 +46,12 @@ QtObject:
     notify = stateWrapperChanged
 
   proc backActionClicked*(self: StateWrapper) {.signal.}
-  proc backAction*(self: StateWrapper) {.slot.} =
+  proc doBackAction*(self: StateWrapper) {.slot.} =
     self.backActionClicked()
+
+  proc cancelActionClicked*(self: StateWrapper) {.signal.}
+  proc doCancelAction*(self: StateWrapper) {.slot.} =
+    self.cancelActionClicked()
 
   proc primaryActionClicked*(self: StateWrapper) {.signal.}
   proc doPrimaryAction*(self: StateWrapper) {.slot.} =
@@ -56,7 +60,3 @@ QtObject:
   proc secondaryActionClicked*(self: StateWrapper) {.signal.}
   proc doSecondaryAction*(self: StateWrapper) {.slot.} =
     self.secondaryActionClicked()
-
-  proc tertiaryActionClicked*(self: StateWrapper) {.signal.}
-  proc doTertiaryAction*(self: StateWrapper) {.slot.} =
-    self.tertiaryActionClicked()

--- a/src/app/modules/shared_modules/keycard_popup/internal/unlock_keycard_options_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/unlock_keycard_options_state.nim
@@ -16,6 +16,6 @@ method getNextSecondaryState*(self: UnlockKeycardOptionsState, controller: Contr
   if self.flowType == FlowType.UnlockKeycard:
     return createState(StateType.EnterPuk, self.flowType, self)
 
-method executeTertiaryCommand*(self: UnlockKeycardOptionsState, controller: Controller) =
+method executePreTertiaryStateCommand*(self: UnlockKeycardOptionsState, controller: Controller) =
   if self.flowType == FlowType.UnlockKeycard:
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)

--- a/src/app/modules/shared_modules/keycard_popup/internal/unlock_keycard_options_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/unlock_keycard_options_state.nim
@@ -16,6 +16,6 @@ method getNextSecondaryState*(self: UnlockKeycardOptionsState, controller: Contr
   if self.flowType == FlowType.UnlockKeycard:
     return createState(StateType.EnterPuk, self.flowType, self)
 
-method executePreTertiaryStateCommand*(self: UnlockKeycardOptionsState, controller: Controller) =
+method executeCancelCommand*(self: UnlockKeycardOptionsState, controller: Controller) =
   if self.flowType == FlowType.UnlockKeycard:
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)

--- a/src/app/modules/shared_modules/keycard_popup/internal/unlock_keycard_success_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/unlock_keycard_success_state.nim
@@ -12,6 +12,6 @@ method executePrePrimaryStateCommand*(self: UnlockKeycardSuccessState, controlle
   if self.flowType == FlowType.UnlockKeycard:
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = true)
 
-method executePreTertiaryStateCommand*(self: UnlockKeycardSuccessState, controller: Controller) =
+method executeCancelCommand*(self: UnlockKeycardSuccessState, controller: Controller) =
   if self.flowType == FlowType.UnlockKeycard:
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = true)

--- a/src/app/modules/shared_modules/keycard_popup/internal/unlock_keycard_success_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/unlock_keycard_success_state.nim
@@ -8,10 +8,10 @@ proc newUnlockKeycardSuccessState*(flowType: FlowType, backState: State): Unlock
 proc delete*(self: UnlockKeycardSuccessState) =
   self.State.delete
 
-method executePrimaryCommand*(self: UnlockKeycardSuccessState, controller: Controller) =
+method executePrePrimaryStateCommand*(self: UnlockKeycardSuccessState, controller: Controller) =
   if self.flowType == FlowType.UnlockKeycard:
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = true)
 
-method executeTertiaryCommand*(self: UnlockKeycardSuccessState, controller: Controller) =
+method executePreTertiaryStateCommand*(self: UnlockKeycardSuccessState, controller: Controller) =
   if self.flowType == FlowType.UnlockKeycard:
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = true)

--- a/src/app/modules/shared_modules/keycard_popup/internal/wrong_biometrics_password_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/wrong_biometrics_password_state.nim
@@ -10,7 +10,7 @@ proc newWrongBiometricsPasswordState*(flowType: FlowType, backState: State): Wro
 proc delete*(self: WrongBiometricsPasswordState) =
   self.State.delete
 
-method executePrimaryCommand*(self: WrongBiometricsPasswordState, controller: Controller) =
+method executePrePrimaryStateCommand*(self: WrongBiometricsPasswordState, controller: Controller) =
   if self.flowType == FlowType.Authentication:
     controller.setKeycardData(updatePredefinedKeycardData(controller.getKeycardData(), PredefinedKeycardData.WrongPassword, add = false))
     let password = controller.getPassword()
@@ -21,7 +21,7 @@ method executePrimaryCommand*(self: WrongBiometricsPasswordState, controller: Co
     else:
       controller.setKeycardData(updatePredefinedKeycardData(controller.getKeycardData(), PredefinedKeycardData.WrongPassword, add = true))
 
-method executeTertiaryCommand*(self: WrongBiometricsPasswordState, controller: Controller) =
+method executePreTertiaryStateCommand*(self: WrongBiometricsPasswordState, controller: Controller) =
   if self.flowType == FlowType.Authentication:
     controller.setPassword("")
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)

--- a/src/app/modules/shared_modules/keycard_popup/internal/wrong_biometrics_password_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/wrong_biometrics_password_state.nim
@@ -21,7 +21,7 @@ method executePrePrimaryStateCommand*(self: WrongBiometricsPasswordState, contro
     else:
       controller.setKeycardData(updatePredefinedKeycardData(controller.getKeycardData(), PredefinedKeycardData.WrongPassword, add = true))
 
-method executePreTertiaryStateCommand*(self: WrongBiometricsPasswordState, controller: Controller) =
+method executeCancelCommand*(self: WrongBiometricsPasswordState, controller: Controller) =
   if self.flowType == FlowType.Authentication:
     controller.setPassword("")
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)

--- a/src/app/modules/shared_modules/keycard_popup/internal/wrong_keycard_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/wrong_keycard_state.nim
@@ -16,7 +16,7 @@ method executePrePrimaryStateCommand*(self: WrongKeycardState, controller: Contr
     self.flowType == FlowType.ChangePairingCode:
       controller.terminateCurrentFlow(lastStepInTheCurrentFlow = true)
 
-method executePreTertiaryStateCommand*(self: WrongKeycardState, controller: Controller) =
+method executeCancelCommand*(self: WrongKeycardState, controller: Controller) =
   if self.flowType == FlowType.Authentication or
     self.flowType == FlowType.UnlockKeycard or
     self.flowType == FlowType.RenameKeycard or

--- a/src/app/modules/shared_modules/keycard_popup/internal/wrong_keycard_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/wrong_keycard_state.nim
@@ -8,7 +8,7 @@ proc newWrongKeycardState*(flowType: FlowType, backState: State): WrongKeycardSt
 proc delete*(self: WrongKeycardState) =
   self.State.delete
 
-method executePrimaryCommand*(self: WrongKeycardState, controller: Controller) =
+method executePrePrimaryStateCommand*(self: WrongKeycardState, controller: Controller) =
   if self.flowType == FlowType.UnlockKeycard or
     self.flowType == FlowType.RenameKeycard or
     self.flowType == FlowType.ChangeKeycardPin or
@@ -16,7 +16,7 @@ method executePrimaryCommand*(self: WrongKeycardState, controller: Controller) =
     self.flowType == FlowType.ChangePairingCode:
       controller.terminateCurrentFlow(lastStepInTheCurrentFlow = true)
 
-method executeTertiaryCommand*(self: WrongKeycardState, controller: Controller) =
+method executePreTertiaryStateCommand*(self: WrongKeycardState, controller: Controller) =
   if self.flowType == FlowType.Authentication or
     self.flowType == FlowType.UnlockKeycard or
     self.flowType == FlowType.RenameKeycard or

--- a/src/app/modules/shared_modules/keycard_popup/internal/wrong_keychain_pin_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/wrong_keychain_pin_state.nim
@@ -14,7 +14,7 @@ method getNextPrimaryState*(self: WrongKeychainPinState, controller: Controller)
       controller.enterKeycardPin(controller.getPin())
   return nil
 
-method executePreTertiaryStateCommand*(self: WrongKeychainPinState, controller: Controller) =
+method executeCancelCommand*(self: WrongKeychainPinState, controller: Controller) =
   if self.flowType == FlowType.Authentication:
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)
 

--- a/src/app/modules/shared_modules/keycard_popup/internal/wrong_keychain_pin_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/wrong_keychain_pin_state.nim
@@ -14,7 +14,7 @@ method getNextPrimaryState*(self: WrongKeychainPinState, controller: Controller)
       controller.enterKeycardPin(controller.getPin())
   return nil
 
-method executeTertiaryCommand*(self: WrongKeychainPinState, controller: Controller) =
+method executePreTertiaryStateCommand*(self: WrongKeychainPinState, controller: Controller) =
   if self.flowType == FlowType.Authentication:
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)
 

--- a/src/app/modules/shared_modules/keycard_popup/internal/wrong_password_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/wrong_password_state.nim
@@ -10,7 +10,7 @@ proc newWrongPasswordState*(flowType: FlowType, backState: State): WrongPassword
 proc delete*(self: WrongPasswordState) =
   self.State.delete
 
-method executePrimaryCommand*(self: WrongPasswordState, controller: Controller) =
+method executePrePrimaryStateCommand*(self: WrongPasswordState, controller: Controller) =
   if self.flowType == FlowType.Authentication:
     controller.setKeycardData(updatePredefinedKeycardData(controller.getKeycardData(), PredefinedKeycardData.WrongPassword, add = false))
     let password = controller.getPassword()
@@ -20,11 +20,11 @@ method executePrimaryCommand*(self: WrongPasswordState, controller: Controller) 
     else:
       controller.setKeycardData(updatePredefinedKeycardData(controller.getKeycardData(), PredefinedKeycardData.WrongPassword, add = true))
 
-method executeSecondaryCommand*(self: WrongPasswordState, controller: Controller) =
+method executePreSecondaryStateCommand*(self: WrongPasswordState, controller: Controller) =
   if self.flowType == FlowType.Authentication:
     controller.tryToObtainDataFromKeychain()
 
-method executeTertiaryCommand*(self: WrongPasswordState, controller: Controller) =
+method executePreTertiaryStateCommand*(self: WrongPasswordState, controller: Controller) =
   if self.flowType == FlowType.Authentication:
     controller.setPassword("")
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)

--- a/src/app/modules/shared_modules/keycard_popup/internal/wrong_password_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/wrong_password_state.nim
@@ -24,7 +24,7 @@ method executePreSecondaryStateCommand*(self: WrongPasswordState, controller: Co
   if self.flowType == FlowType.Authentication:
     controller.tryToObtainDataFromKeychain()
 
-method executePreTertiaryStateCommand*(self: WrongPasswordState, controller: Controller) =
+method executeCancelCommand*(self: WrongPasswordState, controller: Controller) =
   if self.flowType == FlowType.Authentication:
     controller.setPassword("")
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)

--- a/src/app/modules/shared_modules/keycard_popup/internal/wrong_pin_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/wrong_pin_state.nim
@@ -22,7 +22,7 @@ method getNextPrimaryState*(self: WrongPinState, controller: Controller): State 
     self.flowType == FlowType.ChangePairingCode:
       controller.runSharedModuleFlow(FlowType.FactoryReset)
 
-method executeSecondaryCommand*(self: WrongPinState, controller: Controller) =
+method executePreSecondaryStateCommand*(self: WrongPinState, controller: Controller) =
   if self.flowType == FlowType.FactoryReset or
     self.flowType == FlowType.SetupNewKeycard or
     self.flowType == FlowType.DisplayKeycardContent or
@@ -36,7 +36,7 @@ method executeSecondaryCommand*(self: WrongPinState, controller: Controller) =
     controller.setUsePinFromBiometrics(false)
     controller.tryToObtainDataFromKeychain()
 
-method executeTertiaryCommand*(self: WrongPinState, controller: Controller) =
+method executePreTertiaryStateCommand*(self: WrongPinState, controller: Controller) =
   if self.flowType == FlowType.FactoryReset or
     self.flowType == FlowType.SetupNewKeycard or
     self.flowType == FlowType.Authentication or

--- a/src/app/modules/shared_modules/keycard_popup/internal/wrong_pin_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/wrong_pin_state.nim
@@ -36,7 +36,7 @@ method executePreSecondaryStateCommand*(self: WrongPinState, controller: Control
     controller.setUsePinFromBiometrics(false)
     controller.tryToObtainDataFromKeychain()
 
-method executePreTertiaryStateCommand*(self: WrongPinState, controller: Controller) =
+method executeCancelCommand*(self: WrongPinState, controller: Controller) =
   if self.flowType == FlowType.FactoryReset or
     self.flowType == FlowType.SetupNewKeycard or
     self.flowType == FlowType.Authentication or

--- a/src/app/modules/shared_modules/keycard_popup/internal/wrong_puk_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/wrong_puk_state.nim
@@ -8,12 +8,12 @@ proc newWrongPukState*(flowType: FlowType, backState: State): WrongPukState =
 proc delete*(self: WrongPukState) =
   self.State.delete
 
-method executePrimaryCommand*(self: WrongPukState, controller: Controller) =
+method executePrePrimaryStateCommand*(self: WrongPukState, controller: Controller) =
   if self.flowType == FlowType.UnlockKeycard:
     if controller.getPuk().len == PUKLengthForStatusApp:
       controller.enterKeycardPuk(controller.getPuk())
 
-method executeTertiaryCommand*(self: WrongPukState, controller: Controller) =
+method executePreTertiaryStateCommand*(self: WrongPukState, controller: Controller) =
   if self.flowType == FlowType.UnlockKeycard:
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)
 

--- a/src/app/modules/shared_modules/keycard_popup/internal/wrong_puk_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/wrong_puk_state.nim
@@ -13,7 +13,7 @@ method executePrePrimaryStateCommand*(self: WrongPukState, controller: Controlle
     if controller.getPuk().len == PUKLengthForStatusApp:
       controller.enterKeycardPuk(controller.getPuk())
 
-method executePreTertiaryStateCommand*(self: WrongPukState, controller: Controller) =
+method executeCancelCommand*(self: WrongPukState, controller: Controller) =
   if self.flowType == FlowType.UnlockKeycard:
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)
 

--- a/src/app/modules/shared_modules/keycard_popup/internal/wrong_seed_phrase_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/wrong_seed_phrase_state.nim
@@ -12,7 +12,7 @@ proc newWrongSeedPhraseState*(flowType: FlowType, backState: State): WrongSeedPh
 proc delete*(self: WrongSeedPhraseState) =
   self.State.delete
 
-method executePrimaryCommand*(self: WrongSeedPhraseState, controller: Controller) =
+method executePrePrimaryStateCommand*(self: WrongSeedPhraseState, controller: Controller) =
   if self.flowType == FlowType.SetupNewKeycard:
     controller.setKeycardData(updatePredefinedKeycardData(controller.getKeycardData(), PredefinedKeycardData.WrongSeedPhrase, add = false))
     sleep(500) # just to shortly remove text on the UI side
@@ -32,7 +32,7 @@ method executePrimaryCommand*(self: WrongSeedPhraseState, controller: Controller
     else:
       controller.setKeycardData(updatePredefinedKeycardData(controller.getKeycardData(), PredefinedKeycardData.WrongSeedPhrase, add = true))
 
-method executeTertiaryCommand*(self: WrongSeedPhraseState, controller: Controller) =
+method executePreTertiaryStateCommand*(self: WrongSeedPhraseState, controller: Controller) =
   if self.flowType == FlowType.SetupNewKeycard or
     self.flowType == FlowType.UnlockKeycard:
       controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)

--- a/src/app/modules/shared_modules/keycard_popup/internal/wrong_seed_phrase_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/wrong_seed_phrase_state.nim
@@ -32,7 +32,7 @@ method executePrePrimaryStateCommand*(self: WrongSeedPhraseState, controller: Co
     else:
       controller.setKeycardData(updatePredefinedKeycardData(controller.getKeycardData(), PredefinedKeycardData.WrongSeedPhrase, add = true))
 
-method executePreTertiaryStateCommand*(self: WrongSeedPhraseState, controller: Controller) =
+method executeCancelCommand*(self: WrongSeedPhraseState, controller: Controller) =
   if self.flowType == FlowType.SetupNewKeycard or
     self.flowType == FlowType.UnlockKeycard:
       controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)

--- a/src/app/modules/shared_modules/keycard_popup/io_interface.nim
+++ b/src/app/modules/shared_modules/keycard_popup/io_interface.nim
@@ -90,7 +90,7 @@ method onPrimaryActionClicked*(self: AccessInterface) {.base.} =
 method onSecondaryActionClicked*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method onTertiaryActionClicked*(self: AccessInterface) {.base.} =
+method onCancelActionClicked*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method onKeycardResponse*(self: AccessInterface, keycardFlowType: string, keycardEvent: KeycardEvent) {.base.} =

--- a/src/app/modules/shared_modules/keycard_popup/module.nim
+++ b/src/app/modules/shared_modules/keycard_popup/module.nim
@@ -166,10 +166,11 @@ method onBackActionClicked*[T](self: Module[T]) =
     error "sm_cannot resolve current state"
     return
   debug "sm_back_action", currFlow=currStateObj.flowType(), currState=currStateObj.stateType()
-  currStateObj.executeBackCommand(self.controller)
+  currStateObj.executePreBackStateCommand(self.controller)
   let backState = currStateObj.getBackState()
   self.preStateActivities(backState.flowType(), backState.stateType())
   self.view.setCurrentState(backState)
+  currStateObj.executePostBackStateCommand(self.controller)
   debug "sm_back_action - set state", setCurrFlow=backState.flowType(), newCurrState=backState.stateType()
   currStateObj.delete()    
     
@@ -179,12 +180,13 @@ method onPrimaryActionClicked*[T](self: Module[T]) =
     error "sm_cannot resolve current state"
     return
   debug "sm_primary_action", currFlow=currStateObj.flowType(), currState=currStateObj.stateType()
-  currStateObj.executePrimaryCommand(self.controller)
+  currStateObj.executePrePrimaryStateCommand(self.controller)
   let nextState = currStateObj.getNextPrimaryState(self.controller)
   if nextState.isNil:
     return
   self.preStateActivities(nextState.flowType(), nextState.stateType())
   self.view.setCurrentState(nextState)
+  currStateObj.executePostPrimaryStateCommand(self.controller)
   debug "sm_primary_action - set state", setCurrFlow=nextState.flowType(), setCurrState=nextState.stateType()
 
 method onSecondaryActionClicked*[T](self: Module[T]) =
@@ -193,12 +195,13 @@ method onSecondaryActionClicked*[T](self: Module[T]) =
     error "sm_cannot resolve current state"
     return
   debug "sm_secondary_action", currFlow=currStateObj.flowType(), currState=currStateObj.stateType()
-  currStateObj.executeSecondaryCommand(self.controller)
+  currStateObj.executePreSecondaryStateCommand(self.controller)
   let nextState = currStateObj.getNextSecondaryState(self.controller)
   if nextState.isNil:
     return
   self.preStateActivities(nextState.flowType(), nextState.stateType())
   self.view.setCurrentState(nextState)
+  currStateObj.executePostSecondaryStateCommand(self.controller)
   debug "sm_secondary_action - set state", setCurrFlow=nextState.flowType(), setCurrState=nextState.stateType()
 
 method onTertiaryActionClicked*[T](self: Module[T]) =
@@ -207,12 +210,13 @@ method onTertiaryActionClicked*[T](self: Module[T]) =
     error "sm_cannot resolve current state"
     return
   debug "sm_tertiary_action", currFlow=currStateObj.flowType(), currState=currStateObj.stateType()
-  currStateObj.executeTertiaryCommand(self.controller)
+  currStateObj.executePreTertiaryStateCommand(self.controller)
   let nextState = currStateObj.getNextTertiaryState(self.controller)
   if nextState.isNil:
     return
   self.preStateActivities(nextState.flowType(), nextState.stateType())
   self.view.setCurrentState(nextState)
+  currStateObj.executePostTertiaryStateCommand(self.controller)
   debug "sm_tertiary_action - set state", setCurrFlow=nextState.flowType(), setCurrState=nextState.stateType()
 
 method onKeycardResponse*[T](self: Module[T], keycardFlowType: string, keycardEvent: KeycardEvent) =

--- a/src/app/modules/shared_modules/keycard_popup/module.nim
+++ b/src/app/modules/shared_modules/keycard_popup/module.nim
@@ -172,7 +172,15 @@ method onBackActionClicked*[T](self: Module[T]) =
   self.view.setCurrentState(backState)
   currStateObj.executePostBackStateCommand(self.controller)
   debug "sm_back_action - set state", setCurrFlow=backState.flowType(), newCurrState=backState.stateType()
-  currStateObj.delete()    
+  currStateObj.delete()
+
+method onCancelActionClicked*[T](self: Module[T]) =
+  let currStateObj = self.view.currentStateObj()
+  if currStateObj.isNil:
+    error "sm_cannot resolve current state"
+    return
+  debug "sm_cancel_action", currFlow=currStateObj.flowType(), currState=currStateObj.stateType()
+  currStateObj.executeCancelCommand(self.controller)
     
 method onPrimaryActionClicked*[T](self: Module[T]) =
   let currStateObj = self.view.currentStateObj()
@@ -203,21 +211,6 @@ method onSecondaryActionClicked*[T](self: Module[T]) =
   self.view.setCurrentState(nextState)
   currStateObj.executePostSecondaryStateCommand(self.controller)
   debug "sm_secondary_action - set state", setCurrFlow=nextState.flowType(), setCurrState=nextState.stateType()
-
-method onTertiaryActionClicked*[T](self: Module[T]) =
-  let currStateObj = self.view.currentStateObj()
-  if currStateObj.isNil:
-    error "sm_cannot resolve current state"
-    return
-  debug "sm_tertiary_action", currFlow=currStateObj.flowType(), currState=currStateObj.stateType()
-  currStateObj.executePreTertiaryStateCommand(self.controller)
-  let nextState = currStateObj.getNextTertiaryState(self.controller)
-  if nextState.isNil:
-    return
-  self.preStateActivities(nextState.flowType(), nextState.stateType())
-  self.view.setCurrentState(nextState)
-  currStateObj.executePostTertiaryStateCommand(self.controller)
-  debug "sm_tertiary_action - set state", setCurrFlow=nextState.flowType(), setCurrState=nextState.stateType()
 
 method onKeycardResponse*[T](self: Module[T], keycardFlowType: string, keycardEvent: KeycardEvent) =
   if self.derivingAccountDetails.deriveAddressAfterAuthentication and

--- a/src/app/modules/shared_modules/keycard_popup/view.nim
+++ b/src/app/modules/shared_modules/keycard_popup/view.nim
@@ -55,9 +55,9 @@ QtObject:
     result.currentStateVariant = newQVariant(result.currentState)
 
     signalConnect(result.currentState, "backActionClicked()", result, "onBackActionClicked()", 2)
+    signalConnect(result.currentState, "cancelActionClicked()", result, "onCancelActionClicked()", 2)
     signalConnect(result.currentState, "primaryActionClicked()", result, "onPrimaryActionClicked()", 2)
     signalConnect(result.currentState, "secondaryActionClicked()", result, "onSecondaryActionClicked()", 2)
-    signalConnect(result.currentState, "tertiaryActionClicked()", result, "onTertiaryActionClicked()", 2)
 
   proc currentStateObj*(self: View): State =
     return self.currentState.getStateObj()
@@ -85,14 +85,14 @@ QtObject:
   proc onBackActionClicked*(self: View) {.slot.} =
     self.delegate.onBackActionClicked()
 
+  proc onCancelActionClicked*(self: View) {.slot.} =
+    self.delegate.onCancelActionClicked()
+
   proc onPrimaryActionClicked*(self: View) {.slot.} =
     self.delegate.onPrimaryActionClicked()
 
   proc onSecondaryActionClicked*(self: View) {.slot.} =
     self.delegate.onSecondaryActionClicked()
-
-  proc onTertiaryActionClicked*(self: View) {.slot.} =
-    self.delegate.onTertiaryActionClicked()
 
   proc keyPairModel*(self: View): KeyPairModel =
     return self.keyPairModel

--- a/src/app_service/service/accounts/async_tasks.nim
+++ b/src/app_service/service/accounts/async_tasks.nim
@@ -1,0 +1,21 @@
+#################################################
+# Async convert profile keypair
+#################################################
+
+type
+  ConvertToKeycardAccountTaskArg* = ref object of QObjectTaskArg
+    accountDataJson: JsonNode 
+    settingsJson: JsonNode 
+    hashedCurrentPassword: string
+    newPassword: string
+    keyStoreDir: string
+
+const convertToKeycardAccountTask*: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+  let arg = decode[ConvertToKeycardAccountTaskArg](argEncoded)
+  try:
+    let response = status_account.convertToKeycardAccount(arg.keyStoreDir, arg.accountDataJson, arg.settingsJson, 
+      arg.hashedCurrentPassword, arg.newPassword)
+    arg.finish(response)
+  except Exception as e:
+    error "error converting profile keypair: ", message = e.msg  
+    arg.finish("")

--- a/src/app_service/service/accounts/service.nim
+++ b/src/app_service/service/accounts/service.nim
@@ -1,4 +1,4 @@
-import os, json, sequtils, strutils, uuids, times
+import NimQml, os, json, sequtils, strutils, uuids, times
 import json_serialization, chronicles
 
 import ../../../app/global/global_singleton
@@ -32,9 +32,8 @@ let TEST_PEER_ENR = getEnv("TEST_PEER_ENR").string
 
 include utils
 
-
-type
-  Service* = ref object of RootObj
+QtObject:
+  type Service* = ref object of QObject
     fleetConfiguration: FleetConfiguration
     generatedAccounts: seq[GeneratedAccountDto]
     accounts: seq[AccountDto]
@@ -44,419 +43,206 @@ type
     keyStoreDir: string
     defaultWalletEmoji: string
 
-proc delete*(self: Service) =
-  discard
+  proc delete*(self: Service) =
+    self.QObject.delete
 
-proc newService*(fleetConfiguration: FleetConfiguration): Service =
-  result = Service()
-  result.fleetConfiguration = fleetConfiguration
-  result.isFirstTimeAccountLogin = false
-  result.keyStoreDir = main_constants.ROOTKEYSTOREDIR
-  result.defaultWalletEmoji = ""
+  proc newService*(fleetConfiguration: FleetConfiguration): Service =
+    result = Service()
+    new(result, delete)
+    result.QObject.setup
+    result.fleetConfiguration = fleetConfiguration
+    result.isFirstTimeAccountLogin = false
+    result.keyStoreDir = main_constants.ROOTKEYSTOREDIR
+    result.defaultWalletEmoji = ""
 
-proc getLoggedInAccount*(self: Service): AccountDto =
-  return self.loggedInAccount
+  proc getLoggedInAccount*(self: Service): AccountDto =
+    return self.loggedInAccount
 
-proc getImportedAccount*(self: Service): GeneratedAccountDto =
-  return self.importedAccount
+  proc getImportedAccount*(self: Service): GeneratedAccountDto =
+    return self.importedAccount
 
-proc isFirstTimeAccountLogin*(self: Service): bool =
-  return self.isFirstTimeAccountLogin
+  proc isFirstTimeAccountLogin*(self: Service): bool =
+    return self.isFirstTimeAccountLogin
 
-proc setKeyStoreDir(self: Service, key: string) = 
-  self.keyStoreDir = joinPath(main_constants.ROOTKEYSTOREDIR, key) & main_constants.sep
-  discard status_general.initKeystore(self.keyStoreDir)
+  proc setKeyStoreDir(self: Service, key: string) = 
+    self.keyStoreDir = joinPath(main_constants.ROOTKEYSTOREDIR, key) & main_constants.sep
+    discard status_general.initKeystore(self.keyStoreDir)
 
-proc getKeyStoreDir*(self: Service): string = 
-  return self.keyStoreDir
+  proc getKeyStoreDir*(self: Service): string = 
+    return self.keyStoreDir
 
-proc setDefaultWalletEmoji*(self: Service, emoji: string) =
-  self.defaultWalletEmoji = emoji
+  proc setDefaultWalletEmoji*(self: Service, emoji: string) =
+    self.defaultWalletEmoji = emoji
 
-proc init*(self: Service) =
-  try:
-    let response = status_account.generateAddresses(PATHS)
+  proc init*(self: Service) =
+    try:
+      let response = status_account.generateAddresses(PATHS)
 
-    self.generatedAccounts = map(response.result.getElems(),
-    proc(x: JsonNode): GeneratedAccountDto = toGeneratedAccountDto(x))
+      self.generatedAccounts = map(response.result.getElems(),
+      proc(x: JsonNode): GeneratedAccountDto = toGeneratedAccountDto(x))
 
-    for account in self.generatedAccounts.mitems:
-      account.alias = generateAliasFromPk(account.derivedAccounts.whisper.publicKey)
+      for account in self.generatedAccounts.mitems:
+        account.alias = generateAliasFromPk(account.derivedAccounts.whisper.publicKey)
 
-  except Exception as e:
-    error "error: ", procName="init", errName = e.name, errDesription = e.msg
+    except Exception as e:
+      error "error: ", procName="init", errName = e.name, errDesription = e.msg
 
-proc clear*(self: Service) =
-  self.generatedAccounts = @[]
-  self.loggedInAccount = AccountDto()
-  self.importedAccount = GeneratedAccountDto()
-  self.isFirstTimeAccountLogin = false
+  proc clear*(self: Service) =
+    self.generatedAccounts = @[]
+    self.loggedInAccount = AccountDto()
+    self.importedAccount = GeneratedAccountDto()
+    self.isFirstTimeAccountLogin = false
 
-proc validateMnemonic*(self: Service, mnemonic: string): string =
-  try:
-    let response = status_general.validateMnemonic(mnemonic)
+  proc validateMnemonic*(self: Service, mnemonic: string): string =
+    try:
+      let response = status_general.validateMnemonic(mnemonic)
 
-    var error = "response doesn't contain \"error\""
-    if(response.result.contains("error")):
-      error = response.result["error"].getStr
+      var error = "response doesn't contain \"error\""
+      if(response.result.contains("error")):
+        error = response.result["error"].getStr
 
-    # An empty error means that mnemonic is valid.
-    return error
+      # An empty error means that mnemonic is valid.
+      return error
 
-  except Exception as e:
-    error "error: ", procName="validateMnemonic", errName = e.name, errDesription = e.msg
+    except Exception as e:
+      error "error: ", procName="validateMnemonic", errName = e.name, errDesription = e.msg
 
-proc generatedAccounts*(self: Service): seq[GeneratedAccountDto] =
-  if(self.generatedAccounts.len == 0):
-    error "There was some issue initiating account service"
-    return
+  proc generatedAccounts*(self: Service): seq[GeneratedAccountDto] =
+    if(self.generatedAccounts.len == 0):
+      error "There was some issue initiating account service"
+      return
 
-  result = self.generatedAccounts
+    result = self.generatedAccounts
 
-proc openedAccounts*(self: Service): seq[AccountDto] =
-  try:
-    let response = status_account.openedAccounts(main_constants.STATUSGODIR)
+  proc openedAccounts*(self: Service): seq[AccountDto] =
+    try:
+      let response = status_account.openedAccounts(main_constants.STATUSGODIR)
 
-    self.accounts = map(response.result.getElems(), proc(x: JsonNode): AccountDto = toAccountDto(x))
+      self.accounts = map(response.result.getElems(), proc(x: JsonNode): AccountDto = toAccountDto(x))
 
-    return self.accounts
+      return self.accounts
 
-  except Exception as e:
-    error "error: ", procName="openedAccounts", errName = e.name, errDesription = e.msg
+    except Exception as e:
+      error "error: ", procName="openedAccounts", errName = e.name, errDesription = e.msg
 
-proc storeDerivedAccounts(self: Service, accountId, hashedPassword: string,
-  paths: seq[string]): DerivedAccounts =
-  let response = status_account.storeDerivedAccounts(accountId, hashedPassword, paths)
+  proc storeDerivedAccounts(self: Service, accountId, hashedPassword: string,
+    paths: seq[string]): DerivedAccounts =
+    let response = status_account.storeDerivedAccounts(accountId, hashedPassword, paths)
 
-  if response.result.contains("error"):
-    raise newException(Exception, response.result["error"].getStr)
+    if response.result.contains("error"):
+      raise newException(Exception, response.result["error"].getStr)
 
-  result = toDerivedAccounts(response.result)
+    result = toDerivedAccounts(response.result)
 
-proc storeAccount(self: Service, accountId, hashedPassword: string): GeneratedAccountDto =
-  let response = status_account.storeAccounts(accountId, hashedPassword)
+  proc storeAccount(self: Service, accountId, hashedPassword: string): GeneratedAccountDto =
+    let response = status_account.storeAccounts(accountId, hashedPassword)
 
-  if response.result.contains("error"):
-    raise newException(Exception, response.result["error"].getStr)
+    if response.result.contains("error"):
+      raise newException(Exception, response.result["error"].getStr)
 
-  result = toGeneratedAccountDto(response.result)
+    result = toGeneratedAccountDto(response.result)
 
-proc saveAccountAndLogin(self: Service, hashedPassword: string, account,
-  subaccounts, settings, config: JsonNode): AccountDto =
-  try:
-    let response = status_account.saveAccountAndLogin(hashedPassword, account, subaccounts, settings, config)
+  proc saveAccountAndLogin(self: Service, hashedPassword: string, account,
+    subaccounts, settings, config: JsonNode): AccountDto =
+    try:
+      let response = status_account.saveAccountAndLogin(hashedPassword, account, subaccounts, settings, config)
 
-    var error = "response doesn't contain \"error\""
-    if(response.result.contains("error")):
-      error = response.result["error"].getStr
-      if error == "":
-        debug "Account saved succesfully"
-        self.isFirstTimeAccountLogin = true
-        result = toAccountDto(account)
-        return
+      var error = "response doesn't contain \"error\""
+      if(response.result.contains("error")):
+        error = response.result["error"].getStr
+        if error == "":
+          debug "Account saved succesfully"
+          self.isFirstTimeAccountLogin = true
+          result = toAccountDto(account)
+          return
 
-    let err = "Error saving account and logging in: " & error
-    error "error: ", procName="saveAccountAndLogin", errDesription = err
+      let err = "Error saving account and logging in: " & error
+      error "error: ", procName="saveAccountAndLogin", errDesription = err
 
-  except Exception as e:
-    error "error: ", procName="saveAccountAndLogin", errName = e.name, errDesription = e.msg
+    except Exception as e:
+      error "error: ", procName="saveAccountAndLogin", errName = e.name, errDesription = e.msg
 
-proc saveKeycardAccountAndLogin(self: Service, chatKey, password: string, account, subaccounts, settings, 
-  config: JsonNode): AccountDto =
-  try:
-    let response = status_account.saveAccountAndLoginWithKeycard(chatKey, password, account, subaccounts, settings, config)
+  proc saveKeycardAccountAndLogin(self: Service, chatKey, password: string, account, subaccounts, settings, 
+    config: JsonNode): AccountDto =
+    try:
+      let response = status_account.saveAccountAndLoginWithKeycard(chatKey, password, account, subaccounts, settings, config)
 
-    var error = "response doesn't contain \"error\""
-    if(response.result.contains("error")):
-      error = response.result["error"].getStr
-      if error == "":
-        debug "Account saved succesfully"
-        result = toAccountDto(account)
-        return
+      var error = "response doesn't contain \"error\""
+      if(response.result.contains("error")):
+        error = response.result["error"].getStr
+        if error == "":
+          debug "Account saved succesfully"
+          result = toAccountDto(account)
+          return
 
-    let err = "Error saving account and logging in via keycard : " & error
-    error "error: ", procName="saveKeycardAccountAndLogin", errDesription = err
+      let err = "Error saving account and logging in via keycard : " & error
+      error "error: ", procName="saveKeycardAccountAndLogin", errDesription = err
 
-  except Exception as e:
-    error "error: ", procName="saveKeycardAccountAndLogin", errName = e.name, errDesription = e.msg
+    except Exception as e:
+      error "error: ", procName="saveKeycardAccountAndLogin", errName = e.name, errDesription = e.msg
 
-proc prepareAccountJsonObject(self: Service, account: GeneratedAccountDto, displayName: string): JsonNode =
-  result = %* {
-    "name": if displayName == "": account.alias else: displayName,
-    "address": account.address,
-    "key-uid": account.keyUid,
-    "keycard-pairing": nil,
-    "kdfIterations": KDF_ITERATIONS,
-  }
-
-proc getAccountDataForAccountId(self: Service, accountId: string, displayName: string): JsonNode =
-  for acc in self.generatedAccounts:
-    if(acc.id == accountId):
-      return self.prepareAccountJsonObject(acc, displayName)
-
-  if(self.importedAccount.isValid()):
-    if(self.importedAccount.id == accountId):
-      return self.prepareAccountJsonObject(self.importedAccount, displayName)
-
-proc prepareSubaccountJsonObject(self: Service, account: GeneratedAccountDto, displayName: string):
-  JsonNode =
-  result = %* [
-    {
-      "public-key": account.derivedAccounts.defaultWallet.publicKey,
-      "address": account.derivedAccounts.defaultWallet.address,
-      "color": "#4360df",
-      "wallet": true,
-      "path": PATH_DEFAULT_WALLET,
-      "name": "Status account",
-      "derived-from": account.address,
-      "emoji": self.defaultWalletEmoji
-    },
-    {
-      "public-key": account.derivedAccounts.whisper.publicKey,
-      "address": account.derivedAccounts.whisper.address,
+  proc prepareAccountJsonObject(self: Service, account: GeneratedAccountDto, displayName: string): JsonNode =
+    result = %* {
       "name": if displayName == "": account.alias else: displayName,
-      "path": PATH_WHISPER,
-      "chat": true,
-      "derived-from": ""
-    }
-  ]
-
-proc getSubaccountDataForAccountId(self: Service, accountId: string, displayName: string): JsonNode =
-  for acc in self.generatedAccounts:
-    if(acc.id == accountId):
-      return self.prepareSubaccountJsonObject(acc, displayName)
-
-  if(self.importedAccount.isValid()):
-    if(self.importedAccount.id == accountId):
-      return self.prepareSubaccountJsonObject(self.importedAccount, displayName)
-
-proc prepareAccountSettingsJsonObject(self: Service, account: GeneratedAccountDto,
-  installationId: string, displayName: string): JsonNode =
-  result = %* {
-    "key-uid": account.keyUid,
-    "mnemonic": account.mnemonic,
-    "public-key": account.derivedAccounts.whisper.publicKey,
-    "name": account.alias,
-    "display-name": displayName,
-    "address": account.address,
-    "eip1581-address": account.derivedAccounts.eip1581.address,
-    "dapps-address": account.derivedAccounts.defaultWallet.address,
-    "wallet-root-address": account.derivedAccounts.walletRoot.address,
-    "preview-privacy?": true,
-    "signing-phrase": generateSigningPhrase(3),
-    "log-level": $LogLevel.INFO,
-    "latest-derived-path": 0,
-    "currency": "usd",
-    "networks/networks": @[],
-    "networks/current-network": "",
-    "wallet/visible-tokens": {},
-    "waku-enabled": true,
-    "appearance": 0,
-    "installation-id": installationId,
-    "current-user-status": %* {
-        "publicKey": account.derivedAccounts.whisper.publicKey,
-        "statusType": 1,
-        "clock": 0,
-        "text": ""
-      },
-    "profile-pictures-show-to": settings.PROFILE_PICTURES_SHOW_TO_EVERYONE,
-    "profile-pictures-visibility": settings.PROFILE_PICTURES_VISIBILITY_EVERYONE
-  }
-
-proc getAccountSettings(self: Service, accountId: string,
-  installationId: string,
-  displayName: string): JsonNode =
-  for acc in self.generatedAccounts:
-    if(acc.id == accountId):
-      return self.prepareAccountSettingsJsonObject(acc, installationId, displayName)
-
-  if(self.importedAccount.isValid()):
-    if(self.importedAccount.id == accountId):
-      return self.prepareAccountSettingsJsonObject(self.importedAccount, installationId, displayName)
-
-proc getDefaultNodeConfig*(self: Service, installationId: string): JsonNode =
-  let fleet = Fleet.StatusProd
-  let dnsDiscoveryURL = @["enrtree://AOGECG2SPND25EEFMAJ5WF3KSGJNSGV356DSTL2YVLLZWIV6SAYBM@prod.nodes.status.im"]
-
-  result = NODE_CONFIG.copy()
-  result["ClusterConfig"]["Fleet"] = newJString($fleet)
-  result["ClusterConfig"]["BootNodes"] = %* self.fleetConfiguration.getNodes(fleet, FleetNodes.Bootnodes)
-  result["ClusterConfig"]["TrustedMailServers"] = %* self.fleetConfiguration.getNodes(fleet, FleetNodes.Mailservers)
-  result["ClusterConfig"]["StaticNodes"] = %* self.fleetConfiguration.getNodes(fleet, FleetNodes.Whisper)
-  result["ClusterConfig"]["RendezvousNodes"] = %* self.fleetConfiguration.getNodes(fleet, FleetNodes.Rendezvous)
-  result["NetworkId"] = NETWORKS[0]{"chainId"}
-  result["DataDir"] = "ethereum".newJString()
-  result["UpstreamConfig"]["Enabled"] = true.newJBool()
-  result["UpstreamConfig"]["URL"] = NETWORKS[0]{"rpcUrl"}
-  result["ShhextConfig"]["InstallationID"] = newJString(installationId)
-  result["NoDiscovery"] = true.newJBool()
-  result["Rendezvous"] = false.newJBool()
-
-  # TODO: fleet.status.im should have different sections depending on the node type
-  #       or maybe it's not necessary because a node has the identify protocol
-  result["ClusterConfig"]["RelayNodes"] =  %* dnsDiscoveryURL
-  result["ClusterConfig"]["StoreNodes"] =  %* dnsDiscoveryURL
-  result["ClusterConfig"]["FilterNodes"] =  %* dnsDiscoveryURL
-  result["ClusterConfig"]["LightpushNodes"] =  %* dnsDiscoveryURL
-  result["ClusterConfig"]["DiscV5BootstrapNodes"] = %* dnsDiscoveryURL
-
-  result["WakuV2Config"]["EnableDiscV5"] = true.newJBool()
-  result["WakuV2Config"]["DiscoveryLimit"] = 20.newJInt()
-  result["WakuV2Config"]["Rendezvous"] = true.newJBool()
-  result["WakuV2Config"]["Enabled"] = true.newJBool()
-
-  result["WakuConfig"]["Enabled"] = false.newJBool()
-
-  if existsEnv("WAKUV2_PORT"):
-    let wV2Port = parseInt($getEnv("WAKUV2_PORT"))
-    # Waku V2 config
-    result["WakuV2Config"]["Port"] = wV2Port.newJInt()
-    result["WakuV2Config"]["UDPPort"] = wV2Port.newJInt()
-
-  if TEST_PEER_ENR != "":
-    let testPeerENRArr = %* @[TEST_PEER_ENR]
-    result["ClusterConfig"]["RelayNodes"] = testPeerENRArr
-    result["ClusterConfig"]["StoreNodes"] =  testPeerENRArr
-    result["ClusterConfig"]["FilterNodes"] =  testPeerENRArr
-    result["ClusterConfig"]["LightpushNodes"] = testPeerENRArr
-    result["ClusterConfig"]["BootNodes"] = %* testPeerENRArr
-    result["ClusterConfig"]["TrustedMailServers"] = testPeerENRArr
-    result["ClusterConfig"]["StaticNodes"] = testPeerENRArr
-    result["ClusterConfig"]["RendezvousNodes"] = %* (@[])
-    result["ClusterConfig"]["DiscV5BootstrapNodes"] = %* (@[])
-    result["Rendezvous"] = newJBool(false)
-
-  result["KeyStoreDir"] = newJString(self.keyStoreDir.replace(main_constants.STATUSGODIR, ""))
-
-proc setLocalAccountSettingsFile(self: Service) =
-  if(defined(macosx) and self.getLoggedInAccount.isValid()):
-    singletonInstance.localAccountSettings.setFileName(self.getLoggedInAccount.name)
-
-proc addKeycardDetails(self: Service, settingsJson: var JsonNode, accountData: var JsonNode) =
-  let keycardPairingJsonString = readFile(main_constants.KEYCARDPAIRINGDATAFILE)
-  let keycardPairingJsonObj = keycardPairingJsonString.parseJSON
-  let now = now().toTime().toUnix()
-  for instanceUid, kcDataObj in keycardPairingJsonObj:
-    if not settingsJson.isNil:
-      settingsJson["keycard-instance-uid"] = %* instanceUid
-      settingsJson["keycard-paired-on"] = %* now
-      settingsJson["keycard-pairing"] = kcDataObj{"key"}
-    if not accountData.isNil:
-      accountData["keycard-pairing"] = kcDataObj{"key"}
-
-proc setupAccount*(self: Service, accountId, password, displayName: string): string =
-  try:
-    let installationId = $genUUID()
-    var accountDataJson = self.getAccountDataForAccountId(accountId, displayName)
-    self.setKeyStoreDir(accountDataJson{"key-uid"}.getStr) # must be called before `getDefaultNodeConfig`
-    let subaccountDataJson = self.getSubaccountDataForAccountId(accountId, displayName)
-    var settingsJson = self.getAccountSettings(accountId, installationId, displayName)
-    let nodeConfigJson = self.getDefaultNodeConfig(installationId)
-
-    if(accountDataJson.isNil or subaccountDataJson.isNil or settingsJson.isNil or
-      nodeConfigJson.isNil):
-      let description = "at least one json object is not prepared well"
-      error "error: ", procName="setupAccount", errDesription = description
-      return description
-
-    let hashedPassword = hashString(password)
-    discard self.storeAccount(accountId, hashedPassword)
-    discard self.storeDerivedAccounts(accountId, hashedPassword, PATHS)
-    self.loggedInAccount = self.saveAccountAndLogin(hashedPassword, 
-      accountDataJson,
-      subaccountDataJson, 
-      settingsJson, 
-      nodeConfigJson)
-    
-    self.setLocalAccountSettingsFile()
-
-    if self.getLoggedInAccount.isValid():
-      return ""
-    else:
-      return "logged in account is not valid"
-  except Exception as e:
-    error "error: ", procName="setupAccount", errName = e.name, errDesription = e.msg
-    return e.msg
-
-proc setupAccountKeycard*(self: Service, keycardData: KeycardEvent, useImportedAcc: bool) = 
-  try:
-    var keyUid = keycardData.keyUid
-    var address = keycardData.masterKey.address
-    var whisperPrivateKey = keycardData.whisperKey.privateKey
-    var whisperPublicKey = keycardData.whisperKey.publicKey
-    var whisperAddress = keycardData.whisperKey.address
-    var walletPublicKey = keycardData.walletKey.publicKey
-    var walletAddress = keycardData.walletKey.address
-    var walletRootAddress = keycardData.walletRootKey.address
-    var eip1581Address = keycardData.eip1581Key.address
-    var encryptionPublicKey = keycardData.encryptionKey.publicKey
-    if useImportedAcc:
-      keyUid = self.importedAccount.keyUid
-      address = self.importedAccount.address
-      whisperPublicKey = self.importedAccount.derivedAccounts.whisper.publicKey
-      whisperAddress = self.importedAccount.derivedAccounts.whisper.address
-      walletPublicKey = self.importedAccount.derivedAccounts.defaultWallet.publicKey
-      walletAddress = self.importedAccount.derivedAccounts.defaultWallet.address
-      walletRootAddress = self.importedAccount.derivedAccounts.walletRoot.address
-      eip1581Address = self.importedAccount.derivedAccounts.eip1581.address
-      encryptionPublicKey = self.importedAccount.derivedAccounts.encryption.publicKey
-
-      whisperPrivateKey = self.importedAccount.derivedAccounts.whisper.privateKey
-      if whisperPrivateKey.startsWith("0x"):
-        whisperPrivateKey = whisperPrivateKey[2 .. ^1]
-
-    let installationId = $genUUID()
-    let alias = generateAliasFromPk(whisperPublicKey)
-    
-    let openedAccounts = self.openedAccounts()
-    var displayName: string
-    for acc in openedAccounts:
-      if acc.keyUid == keyUid:
-        displayName = acc.name
-        break
-    if displayName.len == 0:
-      displayName = self.getLoggedInAccount().name
-
-    var accountDataJson = %* {
-      "name": alias,
-      "display-name": displayName,
-      "address": address,
-      "key-uid": keyUid,
+      "address": account.address,
+      "key-uid": account.keyUid,
+      "keycard-pairing": nil,
       "kdfIterations": KDF_ITERATIONS,
     }
 
-    self.setKeyStoreDir(keyUid)
-    let nodeConfigJson = self.getDefaultNodeConfig(installationId)
-    let subaccountDataJson = %* [
+  proc getAccountDataForAccountId(self: Service, accountId: string, displayName: string): JsonNode =
+    for acc in self.generatedAccounts:
+      if(acc.id == accountId):
+        return self.prepareAccountJsonObject(acc, displayName)
+
+    if(self.importedAccount.isValid()):
+      if(self.importedAccount.id == accountId):
+        return self.prepareAccountJsonObject(self.importedAccount, displayName)
+
+  proc prepareSubaccountJsonObject(self: Service, account: GeneratedAccountDto, displayName: string):
+    JsonNode =
+    result = %* [
       {
-        "public-key": walletPublicKey,
-        "address": walletAddress,
+        "public-key": account.derivedAccounts.defaultWallet.publicKey,
+        "address": account.derivedAccounts.defaultWallet.address,
         "color": "#4360df",
         "wallet": true,
         "path": PATH_DEFAULT_WALLET,
         "name": "Status account",
-        "derived-from": address,
-        "emoji": self.defaultWalletEmoji,
+        "derived-from": account.address,
+        "emoji": self.defaultWalletEmoji
       },
       {
-        "public-key": whisperPublicKey,
-        "address": whisperAddress,
-        "name": alias,
+        "public-key": account.derivedAccounts.whisper.publicKey,
+        "address": account.derivedAccounts.whisper.address,
+        "name": if displayName == "": account.alias else: displayName,
         "path": PATH_WHISPER,
         "chat": true,
         "derived-from": ""
       }
     ]
 
-    var settingsJson = %* {
-      "key-uid": keyUid,
-      "public-key": whisperPublicKey,
-      "name": alias,
-      "display-name": "",
-      "address": whisperAddress,
-      "eip1581-address": eip1581Address,
-      "dapps-address":  walletAddress,
-      "wallet-root-address": walletRootAddress,
+  proc getSubaccountDataForAccountId(self: Service, accountId: string, displayName: string): JsonNode =
+    for acc in self.generatedAccounts:
+      if(acc.id == accountId):
+        return self.prepareSubaccountJsonObject(acc, displayName)
+
+    if(self.importedAccount.isValid()):
+      if(self.importedAccount.id == accountId):
+        return self.prepareSubaccountJsonObject(self.importedAccount, displayName)
+
+  proc prepareAccountSettingsJsonObject(self: Service, account: GeneratedAccountDto,
+    installationId: string, displayName: string): JsonNode =
+    result = %* {
+      "key-uid": account.keyUid,
+      "mnemonic": account.mnemonic,
+      "public-key": account.derivedAccounts.whisper.publicKey,
+      "name": account.alias,
+      "display-name": displayName,
+      "address": account.address,
+      "eip1581-address": account.derivedAccounts.eip1581.address,
+      "dapps-address": account.derivedAccounts.defaultWallet.address,
+      "wallet-root-address": account.derivedAccounts.walletRoot.address,
       "preview-privacy?": true,
       "signing-phrase": generateSigningPhrase(3),
       "log-level": $LogLevel.INFO,
@@ -468,250 +254,465 @@ proc setupAccountKeycard*(self: Service, keycardData: KeycardEvent, useImportedA
       "waku-enabled": true,
       "appearance": 0,
       "installation-id": installationId,
-      "current-user-status": {
-        "publicKey": whisperPublicKey,
-        "statusType": 1,
-        "clock": 0,
-        "text": ""
-      }
+      "current-user-status": %* {
+          "publicKey": account.derivedAccounts.whisper.publicKey,
+          "statusType": 1,
+          "clock": 0,
+          "text": ""
+        },
+      "profile-pictures-show-to": settings.PROFILE_PICTURES_SHOW_TO_EVERYONE,
+      "profile-pictures-visibility": settings.PROFILE_PICTURES_VISIBILITY_EVERYONE
     }
 
-    self.addKeycardDetails(settingsJson, accountDataJson)
-    
-    if(accountDataJson.isNil or subaccountDataJson.isNil or settingsJson.isNil or
-      nodeConfigJson.isNil):
-      let description = "at least one json object is not prepared well"
-      error "error: ", procName="setupAccountKeycard", errDesription = description
-      return
+  proc getAccountSettings(self: Service, accountId: string,
+    installationId: string,
+    displayName: string): JsonNode =
+    for acc in self.generatedAccounts:
+      if(acc.id == accountId):
+        return self.prepareAccountSettingsJsonObject(acc, installationId, displayName)
 
-    self.loggedInAccount = self.saveKeycardAccountAndLogin(chatKey = whisperPrivateKey, 
-      password = encryptionPublicKey, 
-      accountDataJson, 
-      subaccountDataJson, 
-      settingsJson, 
-      nodeConfigJson)
-    self.setLocalAccountSettingsFile()
-  except Exception as e:
-    error "error: ", procName="setupAccount", errName = e.name, errDesription = e.msg
+    if(self.importedAccount.isValid()):
+      if(self.importedAccount.id == accountId):
+        return self.prepareAccountSettingsJsonObject(self.importedAccount, installationId, displayName)
 
-proc createAccountFromMnemonic*(self: Service, mnemonic: string, includeEncryption = false, includeWhisper = false,
-  includeRoot = false, includeDefaultWallet = false, includeEip1581 = false): GeneratedAccountDto =
-  if mnemonic.len == 0:
-    error "empty mnemonic"
-    return
-  var paths: seq[string]
-  if includeEncryption:
-    paths.add(PATH_ENCRYPTION)
-  if includeWhisper:
-    paths.add(PATH_WHISPER)
-  if includeRoot:
-    paths.add(PATH_WALLET_ROOT)
-  if includeDefaultWallet:
-    paths.add(PATH_DEFAULT_WALLET)
-  if includeEip1581:
-    paths.add(PATH_EIP_1581)
-  try:
-    let response = status_account.createAccountFromMnemonicAndDeriveAccountsForPaths(mnemonic, paths)
-    return toGeneratedAccountDto(response.result)
-  except Exception as e:
-    error "error: ", procName="createAccountFromMnemonicAndDeriveAccountsForPaths", errName = e.name, errDesription = e.msg
+  proc getDefaultNodeConfig*(self: Service, installationId: string): JsonNode =
+    let fleet = Fleet.StatusProd
+    let dnsDiscoveryURL = @["enrtree://AOGECG2SPND25EEFMAJ5WF3KSGJNSGV356DSTL2YVLLZWIV6SAYBM@prod.nodes.status.im"]
 
-proc importMnemonic*(self: Service, mnemonic: string): string =
-  if mnemonic.len == 0:
-    return "empty mnemonic"
-  try:
-    let response = status_account.multiAccountImportMnemonic(mnemonic)
-    self.importedAccount = toGeneratedAccountDto(response.result)
+    result = NODE_CONFIG.copy()
+    result["ClusterConfig"]["Fleet"] = newJString($fleet)
+    result["ClusterConfig"]["BootNodes"] = %* self.fleetConfiguration.getNodes(fleet, FleetNodes.Bootnodes)
+    result["ClusterConfig"]["TrustedMailServers"] = %* self.fleetConfiguration.getNodes(fleet, FleetNodes.Mailservers)
+    result["ClusterConfig"]["StaticNodes"] = %* self.fleetConfiguration.getNodes(fleet, FleetNodes.Whisper)
+    result["ClusterConfig"]["RendezvousNodes"] = %* self.fleetConfiguration.getNodes(fleet, FleetNodes.Rendezvous)
+    result["NetworkId"] = NETWORKS[0]{"chainId"}
+    result["DataDir"] = "ethereum".newJString()
+    result["UpstreamConfig"]["Enabled"] = true.newJBool()
+    result["UpstreamConfig"]["URL"] = NETWORKS[0]{"rpcUrl"}
+    result["ShhextConfig"]["InstallationID"] = newJString(installationId)
+    result["NoDiscovery"] = true.newJBool()
+    result["Rendezvous"] = false.newJBool()
 
-    if (self.accounts.contains(self.importedAccount.keyUid)):
-      return ACCOUNT_ALREADY_EXISTS_ERROR
+    # TODO: fleet.status.im should have different sections depending on the node type
+    #       or maybe it's not necessary because a node has the identify protocol
+    result["ClusterConfig"]["RelayNodes"] =  %* dnsDiscoveryURL
+    result["ClusterConfig"]["StoreNodes"] =  %* dnsDiscoveryURL
+    result["ClusterConfig"]["FilterNodes"] =  %* dnsDiscoveryURL
+    result["ClusterConfig"]["LightpushNodes"] =  %* dnsDiscoveryURL
+    result["ClusterConfig"]["DiscV5BootstrapNodes"] = %* dnsDiscoveryURL
 
-    let responseDerived = status_account.deriveAccounts(self.importedAccount.id, PATHS)
-    self.importedAccount.derivedAccounts = toDerivedAccounts(responseDerived.result)
+    result["WakuV2Config"]["EnableDiscV5"] = true.newJBool()
+    result["WakuV2Config"]["DiscoveryLimit"] = 20.newJInt()
+    result["WakuV2Config"]["Rendezvous"] = true.newJBool()
+    result["WakuV2Config"]["Enabled"] = true.newJBool()
 
-    self.importedAccount.alias= generateAliasFromPk(self.importedAccount.derivedAccounts.whisper.publicKey)
+    result["WakuConfig"]["Enabled"] = false.newJBool()
 
-    if (not self.importedAccount.isValid()):
-      return "imported account is not valid"
-  except Exception as e:
-    error "error: ", procName="importMnemonic", errName = e.name, errDesription = e.msg
-    return e.msg
-
-proc login*(self: Service, account: AccountDto, password: string): string =
-  try:
-    let hashedPassword = hashString(password)
-    var thumbnailImage: string
-    var largeImage: string
-    for img in account.images:
-      if(img.imgType == "thumbnail"):
-        thumbnailImage = img.uri
-      elif(img.imgType == "large"):
-        largeImage = img.uri
-
-    let keyStoreDir = joinPath(main_constants.ROOTKEYSTOREDIR, account.keyUid) & main_constants.sep
-    if not dirExists(keyStoreDir):
-      os.createDir(keyStoreDir)
-      status_core.migrateKeyStoreDir($ %* {
-        "key-uid": account.keyUid
-      }, password, main_constants.ROOTKEYSTOREDIR, keyStoreDir)
-
-    self.setKeyStoreDir(account.keyUid)
-    # This is moved from `status-lib` here
-    # TODO:
-    # If you added a new value in the nodeconfig in status-go, old accounts will not have this value, since the node config
-    # is stored in the database, and it's not easy to migrate using .sql
-    # While this is fixed, you can add here any missing attribute on the node config, and it will be merged with whatever
-    # the account has in the db
-    var nodeCfg = %* {
-      "KeyStoreDir": self.keyStoreDir.replace(main_constants.STATUSGODIR, ""),
-      "ShhextConfig": %* {
-        "BandwidthStatsEnabled": true
-      },
-      "Web3ProviderConfig": %* {
-        "Enabled": true
-      },
-      "EnsConfig": %* {
-        "Enabled": true
-      },
-      "WalletConfig": {
-        "Enabled": true,
-        "OpenseaAPIKey": OPENSEA_API_KEY_RESOLVED
-      },
-      "TorrentConfig": {
-        "Enabled": false,
-        "DataDir": DEFAULT_TORRENT_CONFIG_DATADIR,
-        "TorrentDir": DEFAULT_TORRENT_CONFIG_TORRENTDIR,
-        "Port": DEFAULT_TORRENT_CONFIG_PORT
-      },
-      "Networks": NETWORKS,
-      "OutputMessageCSVEnabled": output_csv
-    }
-
-    # Source the connection port from the environment for debugging or if default port not accessible
-    if existsEnv("STATUS_PORT"):
-      let wV1Port = $getEnv("STATUS_PORT")
-      # Waku V1 config
-      nodeCfg["ListenAddr"] = newJString("0.0.0.0:" & wV1Port)
     if existsEnv("WAKUV2_PORT"):
       let wV2Port = parseInt($getEnv("WAKUV2_PORT"))
       # Waku V2 config
-      nodeCfg.add("WakuV2Config", %* {
-        "Port": wV2Port,
-        "UDPPort": wV2Port,
-      })
+      result["WakuV2Config"]["Port"] = wV2Port.newJInt()
+      result["WakuV2Config"]["UDPPort"] = wV2Port.newJInt()
 
     if TEST_PEER_ENR != "":
-      nodeCfg["Rendezvous"] = newJBool(false)
-      nodeCfg["ClusterConfig"] = %* {
-        "BootNodes": @[TEST_PEER_ENR],
-        "TrustedMailServers": @[TEST_PEER_ENR],
-        "StaticNodes": @[TEST_PEER_ENR],
-        "RendezvousNodes": @[],
-        "DiscV5BootstrapNodes": @[]
+      let testPeerENRArr = %* @[TEST_PEER_ENR]
+      result["ClusterConfig"]["RelayNodes"] = testPeerENRArr
+      result["ClusterConfig"]["StoreNodes"] =  testPeerENRArr
+      result["ClusterConfig"]["FilterNodes"] =  testPeerENRArr
+      result["ClusterConfig"]["LightpushNodes"] = testPeerENRArr
+      result["ClusterConfig"]["BootNodes"] = %* testPeerENRArr
+      result["ClusterConfig"]["TrustedMailServers"] = testPeerENRArr
+      result["ClusterConfig"]["StaticNodes"] = testPeerENRArr
+      result["ClusterConfig"]["RendezvousNodes"] = %* (@[])
+      result["ClusterConfig"]["DiscV5BootstrapNodes"] = %* (@[])
+      result["Rendezvous"] = newJBool(false)
+
+    result["KeyStoreDir"] = newJString(self.keyStoreDir.replace(main_constants.STATUSGODIR, ""))
+
+  proc setLocalAccountSettingsFile(self: Service) =
+    if(defined(macosx) and self.getLoggedInAccount.isValid()):
+      singletonInstance.localAccountSettings.setFileName(self.getLoggedInAccount.name)
+
+  proc addKeycardDetails(self: Service, settingsJson: var JsonNode, accountData: var JsonNode) =
+    let keycardPairingJsonString = readFile(main_constants.KEYCARDPAIRINGDATAFILE)
+    let keycardPairingJsonObj = keycardPairingJsonString.parseJSON
+    let now = now().toTime().toUnix()
+    for instanceUid, kcDataObj in keycardPairingJsonObj:
+      if not settingsJson.isNil:
+        settingsJson["keycard-instance-uid"] = %* instanceUid
+        settingsJson["keycard-paired-on"] = %* now
+        settingsJson["keycard-pairing"] = kcDataObj{"key"}
+      if not accountData.isNil:
+        accountData["keycard-pairing"] = kcDataObj{"key"}
+
+  proc setupAccount*(self: Service, accountId, password, displayName: string): string =
+    try:
+      let installationId = $genUUID()
+      var accountDataJson = self.getAccountDataForAccountId(accountId, displayName)
+      self.setKeyStoreDir(accountDataJson{"key-uid"}.getStr) # must be called before `getDefaultNodeConfig`
+      let subaccountDataJson = self.getSubaccountDataForAccountId(accountId, displayName)
+      var settingsJson = self.getAccountSettings(accountId, installationId, displayName)
+      let nodeConfigJson = self.getDefaultNodeConfig(installationId)
+
+      if(accountDataJson.isNil or subaccountDataJson.isNil or settingsJson.isNil or
+        nodeConfigJson.isNil):
+        let description = "at least one json object is not prepared well"
+        error "error: ", procName="setupAccount", errDesription = description
+        return description
+
+      let hashedPassword = hashString(password)
+      discard self.storeAccount(accountId, hashedPassword)
+      discard self.storeDerivedAccounts(accountId, hashedPassword, PATHS)
+      self.loggedInAccount = self.saveAccountAndLogin(hashedPassword, 
+        accountDataJson,
+        subaccountDataJson, 
+        settingsJson, 
+        nodeConfigJson)
+      
+      self.setLocalAccountSettingsFile()
+
+      if self.getLoggedInAccount.isValid():
+        return ""
+      else:
+        return "logged in account is not valid"
+    except Exception as e:
+      error "error: ", procName="setupAccount", errName = e.name, errDesription = e.msg
+      return e.msg
+
+  proc setupAccountKeycard*(self: Service, keycardData: KeycardEvent, useImportedAcc: bool) = 
+    try:
+      var keyUid = keycardData.keyUid
+      var address = keycardData.masterKey.address
+      var whisperPrivateKey = keycardData.whisperKey.privateKey
+      var whisperPublicKey = keycardData.whisperKey.publicKey
+      var whisperAddress = keycardData.whisperKey.address
+      var walletPublicKey = keycardData.walletKey.publicKey
+      var walletAddress = keycardData.walletKey.address
+      var walletRootAddress = keycardData.walletRootKey.address
+      var eip1581Address = keycardData.eip1581Key.address
+      var encryptionPublicKey = keycardData.encryptionKey.publicKey
+      if useImportedAcc:
+        keyUid = self.importedAccount.keyUid
+        address = self.importedAccount.address
+        whisperPublicKey = self.importedAccount.derivedAccounts.whisper.publicKey
+        whisperAddress = self.importedAccount.derivedAccounts.whisper.address
+        walletPublicKey = self.importedAccount.derivedAccounts.defaultWallet.publicKey
+        walletAddress = self.importedAccount.derivedAccounts.defaultWallet.address
+        walletRootAddress = self.importedAccount.derivedAccounts.walletRoot.address
+        eip1581Address = self.importedAccount.derivedAccounts.eip1581.address
+        encryptionPublicKey = self.importedAccount.derivedAccounts.encryption.publicKey
+
+        whisperPrivateKey = self.importedAccount.derivedAccounts.whisper.privateKey
+        if whisperPrivateKey.startsWith("0x"):
+          whisperPrivateKey = whisperPrivateKey[2 .. ^1]
+
+      let installationId = $genUUID()
+      let alias = generateAliasFromPk(whisperPublicKey)
+      
+      let openedAccounts = self.openedAccounts()
+      var displayName: string
+      for acc in openedAccounts:
+        if acc.keyUid == keyUid:
+          displayName = acc.name
+          break
+      if displayName.len == 0:
+        displayName = self.getLoggedInAccount().name
+
+      var accountDataJson = %* {
+        "name": alias,
+        "display-name": displayName,
+        "address": address,
+        "key-uid": keyUid,
+        "kdfIterations": KDF_ITERATIONS,
       }
 
-    let response = status_account.login(account.name, account.keyUid, account.kdfIterations, hashedPassword, thumbnailImage,
-      largeImage, $nodeCfg)
-    var error = "response doesn't contain \"error\""
-    if(response.result.contains("error")):
-      error = response.result["error"].getStr
-      if error == "":
-        debug "Account logged in"
-        self.loggedInAccount = account
-        self.setLocalAccountSettingsFile()
+      self.setKeyStoreDir(keyUid)
+      let nodeConfigJson = self.getDefaultNodeConfig(installationId)
+      let subaccountDataJson = %* [
+        {
+          "public-key": walletPublicKey,
+          "address": walletAddress,
+          "color": "#4360df",
+          "wallet": true,
+          "path": PATH_DEFAULT_WALLET,
+          "name": "Status account",
+          "derived-from": address,
+          "emoji": self.defaultWalletEmoji,
+        },
+        {
+          "public-key": whisperPublicKey,
+          "address": whisperAddress,
+          "name": alias,
+          "path": PATH_WHISPER,
+          "chat": true,
+          "derived-from": ""
+        }
+      ]
 
-    return error
+      var settingsJson = %* {
+        "key-uid": keyUid,
+        "public-key": whisperPublicKey,
+        "name": alias,
+        "display-name": "",
+        "address": whisperAddress,
+        "eip1581-address": eip1581Address,
+        "dapps-address":  walletAddress,
+        "wallet-root-address": walletRootAddress,
+        "preview-privacy?": true,
+        "signing-phrase": generateSigningPhrase(3),
+        "log-level": $LogLevel.INFO,
+        "latest-derived-path": 0,
+        "currency": "usd",
+        "networks/networks": @[],
+        "networks/current-network": "",
+        "wallet/visible-tokens": {},
+        "waku-enabled": true,
+        "appearance": 0,
+        "installation-id": installationId,
+        "current-user-status": {
+          "publicKey": whisperPublicKey,
+          "statusType": 1,
+          "clock": 0,
+          "text": ""
+        }
+      }
 
-  except Exception as e:
-    error "error: ", procName="login", errName = e.name, errDesription = e.msg
-    return e.msg
-
-proc loginAccountKeycard*(self: Service, keycardData: KeycardEvent): string = 
-  try:
-    self.setKeyStoreDir(keycardData.keyUid)
-
-    let openedAccounts = self.openedAccounts()
-    var accToBeLoggedIn: AccountDto
-    for acc in openedAccounts:
-      if acc.keyUid == keycardData.keyUid:
-        accToBeLoggedIn = acc
-        break
-
-    var accountDataJson = %* {
-      "name": accToBeLoggedIn.name,
-      "address": keycardData.masterKey.address,
-      "key-uid": keycardData.keyUid
-    }
-    var settingsJson: JsonNode
-    self.addKeycardDetails(settingsJson, accountDataJson)
-
-    let response = status_account.loginWithKeycard(keycardData.whisperKey.privateKey, 
-      keycardData.encryptionKey.publicKey,
-      accountDataJson)
-
-    var error = "response doesn't contain \"error\""
-    if(response.result.contains("error")):
-      error = response.result["error"].getStr
-      if error == "":
-        debug "Account logged in succesfully"
-        # this should be fetched later from waku
-        self.loggedInAccount = accToBeLoggedIn
-        self.loggedInAccount.keycardPairing = accountDataJson{"keycard-pairing"}.getStr
+      self.addKeycardDetails(settingsJson, accountDataJson)
+      
+      if(accountDataJson.isNil or subaccountDataJson.isNil or settingsJson.isNil or
+        nodeConfigJson.isNil):
+        let description = "at least one json object is not prepared well"
+        error "error: ", procName="setupAccountKeycard", errDesription = description
         return
-  except Exception as e:
-    error "error: ", procName="loginAccountKeycard", errName = e.name, errDesription = e.msg
-    return e.msg
 
-proc verifyAccountPassword*(self: Service, account: string, password: string): bool =
-  try:
-    let response = status_account.verifyAccountPassword(account, password, self.keyStoreDir)
-    if(response.result.contains("error")):
-      let errMsg = response.result["error"].getStr
-      if(errMsg.len == 0):
-        return true
-      else:
-        error "error: ", procName="verifyAccountPassword", errDesription = errMsg
-    return false
-  except Exception as e:
-    error "error: ", procName="verifyAccountPassword", errName = e.name, errDesription = e.msg
+      self.loggedInAccount = self.saveKeycardAccountAndLogin(chatKey = whisperPrivateKey, 
+        password = encryptionPublicKey, 
+        accountDataJson, 
+        subaccountDataJson, 
+        settingsJson, 
+        nodeConfigJson)
+      self.setLocalAccountSettingsFile()
+    except Exception as e:
+      error "error: ", procName="setupAccount", errName = e.name, errDesription = e.msg
 
-
-proc convertToKeycardAccount*(self: Service, keyUid: string, currentPassword: string, newPassword: string): bool = 
-  try:
-    var accountDataJson = %* {
-      "name": self.getLoggedInAccount().name,
-      "key-uid": keyUid
-    }
-    var settingsJson = %* {
-      "display-name": self.getLoggedInAccount().name
-    }
-
-    self.addKeycardDetails(settingsJson, accountDataJson)
-    
-    if(accountDataJson.isNil or settingsJson.isNil):
-      let description = "at least one json object is not prepared well"
-      error "error: ", procName="convertToKeycardAccount", errDesription = description
+  proc createAccountFromMnemonic*(self: Service, mnemonic: string, includeEncryption = false, includeWhisper = false,
+    includeRoot = false, includeDefaultWallet = false, includeEip1581 = false): GeneratedAccountDto =
+    if mnemonic.len == 0:
+      error "empty mnemonic"
       return
+    var paths: seq[string]
+    if includeEncryption:
+      paths.add(PATH_ENCRYPTION)
+    if includeWhisper:
+      paths.add(PATH_WHISPER)
+    if includeRoot:
+      paths.add(PATH_WALLET_ROOT)
+    if includeDefaultWallet:
+      paths.add(PATH_DEFAULT_WALLET)
+    if includeEip1581:
+      paths.add(PATH_EIP_1581)
+    try:
+      let response = status_account.createAccountFromMnemonicAndDeriveAccountsForPaths(mnemonic, paths)
+      return toGeneratedAccountDto(response.result)
+    except Exception as e:
+      error "error: ", procName="createAccountFromMnemonicAndDeriveAccountsForPaths", errName = e.name, errDesription = e.msg
 
-    let hashedCurrentPassword = hashString(currentPassword)
-    let response = status_account.convertToKeycardAccount(self.keyStoreDir, accountDataJson, settingsJson, 
-      hashedCurrentPassword, newPassword)
+  proc importMnemonic*(self: Service, mnemonic: string): string =
+    if mnemonic.len == 0:
+      return "empty mnemonic"
+    try:
+      let response = status_account.multiAccountImportMnemonic(mnemonic)
+      self.importedAccount = toGeneratedAccountDto(response.result)
 
-    if(response.result.contains("error")):
-      let errMsg = response.result["error"].getStr
-      if(errMsg.len == 0):
-        return true
-      else:
-        error "error: ", procName="convertToKeycardAccount", errDesription = errMsg
+      if (self.accounts.contains(self.importedAccount.keyUid)):
+        return ACCOUNT_ALREADY_EXISTS_ERROR
+
+      let responseDerived = status_account.deriveAccounts(self.importedAccount.id, PATHS)
+      self.importedAccount.derivedAccounts = toDerivedAccounts(responseDerived.result)
+
+      self.importedAccount.alias= generateAliasFromPk(self.importedAccount.derivedAccounts.whisper.publicKey)
+
+      if (not self.importedAccount.isValid()):
+        return "imported account is not valid"
+    except Exception as e:
+      error "error: ", procName="importMnemonic", errName = e.name, errDesription = e.msg
+      return e.msg
+
+  proc login*(self: Service, account: AccountDto, password: string): string =
+    try:
+      let hashedPassword = hashString(password)
+      var thumbnailImage: string
+      var largeImage: string
+      for img in account.images:
+        if(img.imgType == "thumbnail"):
+          thumbnailImage = img.uri
+        elif(img.imgType == "large"):
+          largeImage = img.uri
+
+      let keyStoreDir = joinPath(main_constants.ROOTKEYSTOREDIR, account.keyUid) & main_constants.sep
+      if not dirExists(keyStoreDir):
+        os.createDir(keyStoreDir)
+        status_core.migrateKeyStoreDir($ %* {
+          "key-uid": account.keyUid
+        }, password, main_constants.ROOTKEYSTOREDIR, keyStoreDir)
+
+      self.setKeyStoreDir(account.keyUid)
+      # This is moved from `status-lib` here
+      # TODO:
+      # If you added a new value in the nodeconfig in status-go, old accounts will not have this value, since the node config
+      # is stored in the database, and it's not easy to migrate using .sql
+      # While this is fixed, you can add here any missing attribute on the node config, and it will be merged with whatever
+      # the account has in the db
+      var nodeCfg = %* {
+        "KeyStoreDir": self.keyStoreDir.replace(main_constants.STATUSGODIR, ""),
+        "ShhextConfig": %* {
+          "BandwidthStatsEnabled": true
+        },
+        "Web3ProviderConfig": %* {
+          "Enabled": true
+        },
+        "EnsConfig": %* {
+          "Enabled": true
+        },
+        "WalletConfig": {
+          "Enabled": true,
+          "OpenseaAPIKey": OPENSEA_API_KEY_RESOLVED
+        },
+        "TorrentConfig": {
+          "Enabled": false,
+          "DataDir": DEFAULT_TORRENT_CONFIG_DATADIR,
+          "TorrentDir": DEFAULT_TORRENT_CONFIG_TORRENTDIR,
+          "Port": DEFAULT_TORRENT_CONFIG_PORT
+        },
+        "Networks": NETWORKS,
+        "OutputMessageCSVEnabled": output_csv
+      }
+
+      # Source the connection port from the environment for debugging or if default port not accessible
+      if existsEnv("STATUS_PORT"):
+        let wV1Port = $getEnv("STATUS_PORT")
+        # Waku V1 config
+        nodeCfg["ListenAddr"] = newJString("0.0.0.0:" & wV1Port)
+      if existsEnv("WAKUV2_PORT"):
+        let wV2Port = parseInt($getEnv("WAKUV2_PORT"))
+        # Waku V2 config
+        nodeCfg.add("WakuV2Config", %* {
+          "Port": wV2Port,
+          "UDPPort": wV2Port,
+        })
+
+      if TEST_PEER_ENR != "":
+        nodeCfg["Rendezvous"] = newJBool(false)
+        nodeCfg["ClusterConfig"] = %* {
+          "BootNodes": @[TEST_PEER_ENR],
+          "TrustedMailServers": @[TEST_PEER_ENR],
+          "StaticNodes": @[TEST_PEER_ENR],
+          "RendezvousNodes": @[],
+          "DiscV5BootstrapNodes": @[]
+        }
+
+      let response = status_account.login(account.name, account.keyUid, account.kdfIterations, hashedPassword, thumbnailImage,
+        largeImage, $nodeCfg)
+      var error = "response doesn't contain \"error\""
+      if(response.result.contains("error")):
+        error = response.result["error"].getStr
+        if error == "":
+          debug "Account logged in"
+          self.loggedInAccount = account
+          self.setLocalAccountSettingsFile()
+
+      return error
+
+    except Exception as e:
+      error "error: ", procName="login", errName = e.name, errDesription = e.msg
+      return e.msg
+
+  proc loginAccountKeycard*(self: Service, keycardData: KeycardEvent): string = 
+    try:
+      self.setKeyStoreDir(keycardData.keyUid)
+
+      let openedAccounts = self.openedAccounts()
+      var accToBeLoggedIn: AccountDto
+      for acc in openedAccounts:
+        if acc.keyUid == keycardData.keyUid:
+          accToBeLoggedIn = acc
+          break
+
+      var accountDataJson = %* {
+        "name": accToBeLoggedIn.name,
+        "address": keycardData.masterKey.address,
+        "key-uid": keycardData.keyUid
+      }
+      var settingsJson: JsonNode
+      self.addKeycardDetails(settingsJson, accountDataJson)
+
+      let response = status_account.loginWithKeycard(keycardData.whisperKey.privateKey, 
+        keycardData.encryptionKey.publicKey,
+        accountDataJson)
+
+      var error = "response doesn't contain \"error\""
+      if(response.result.contains("error")):
+        error = response.result["error"].getStr
+        if error == "":
+          debug "Account logged in succesfully"
+          # this should be fetched later from waku
+          self.loggedInAccount = accToBeLoggedIn
+          self.loggedInAccount.keycardPairing = accountDataJson{"keycard-pairing"}.getStr
+          return
+    except Exception as e:
+      error "error: ", procName="loginAccountKeycard", errName = e.name, errDesription = e.msg
+      return e.msg
+
+  proc verifyAccountPassword*(self: Service, account: string, password: string): bool =
+    try:
+      let response = status_account.verifyAccountPassword(account, password, self.keyStoreDir)
+      if(response.result.contains("error")):
+        let errMsg = response.result["error"].getStr
+        if(errMsg.len == 0):
+          return true
+        else:
+          error "error: ", procName="verifyAccountPassword", errDesription = errMsg
+      return false
+    except Exception as e:
+      error "error: ", procName="verifyAccountPassword", errName = e.name, errDesription = e.msg
+
+
+  proc convertToKeycardAccount*(self: Service, keyUid: string, currentPassword: string, newPassword: string): bool = 
+    try:
+      var accountDataJson = %* {
+        "name": self.getLoggedInAccount().name,
+        "key-uid": keyUid
+      }
+      var settingsJson = %* {
+        "display-name": self.getLoggedInAccount().name
+      }
+
+      self.addKeycardDetails(settingsJson, accountDataJson)
+      
+      if(accountDataJson.isNil or settingsJson.isNil):
+        let description = "at least one json object is not prepared well"
+        error "error: ", procName="convertToKeycardAccount", errDesription = description
+        return
+
+      let hashedCurrentPassword = hashString(currentPassword)
+      let response = status_account.convertToKeycardAccount(self.keyStoreDir, accountDataJson, settingsJson, 
+        hashedCurrentPassword, newPassword)
+
+      if(response.result.contains("error")):
+        let errMsg = response.result["error"].getStr
+        if(errMsg.len == 0):
+          return true
+        else:
+          error "error: ", procName="convertToKeycardAccount", errDesription = errMsg
+      return false
+    except Exception as e:
+      error "error: ", procName="convertToKeycardAccount", errName = e.name, errDesription = e.msg
+
+  proc verifyPassword*(self: Service, password: string): bool =
+    try:
+      let hashedPassword = hashString(password)
+      let response = status_account.verifyPassword(hashedPassword)
+      return response.result.getBool
+    except Exception as e:
+      error "error: ", procName="verifyPassword", errName = e.name, errDesription = e.msg
     return false
-  except Exception as e:
-    error "error: ", procName="convertToKeycardAccount", errName = e.name, errDesription = e.msg
-
-proc verifyPassword*(self: Service, password: string): bool =
-  try:
-    let hashedPassword = hashString(password)
-    let response = status_account.verifyPassword(hashedPassword)
-    return response.result.getBool
-  except Exception as e:
-    error "error: ", procName="verifyPassword", errName = e.name, errDesription = e.msg
-  return false

--- a/src/app_service/service/saved_address/dto.nim
+++ b/src/app_service/service/saved_address/dto.nim
@@ -1,4 +1,4 @@
-import json, sequtils, sugar
+import json
 
 include  ../../common/json_utils
 

--- a/src/app_service/service/wallet_account/async_tasks.nim
+++ b/src/app_service/service/wallet_account/async_tasks.nim
@@ -443,3 +443,26 @@ const prepareTokensTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
 
   arg.finish(builtTokensPerAccount)
 
+#################################################
+# Async add migrated keypair
+#################################################
+
+type
+  AddMigratedKeyPairTaskArg* = ref object of QObjectTaskArg
+    keyPair: KeyPairDto 
+    keyStoreDir: string
+
+const addMigratedKeyPairTask*: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+  let arg = decode[AddMigratedKeyPairTaskArg](argEncoded)
+  try:
+    let response = backend.addMigratedKeyPair(
+      arg.keyPair.keycardUid,
+      arg.keyPair.keycardName,
+      arg.keyPair.keyUid,
+      arg.keyPair.accountsAddresses,
+      arg.keyStoreDir
+      )
+    arg.finish(response)
+  except Exception as e:
+    error "error adding new keypair: ", message = e.msg  
+    arg.finish("")

--- a/src/backend/transactions.nim
+++ b/src/backend/transactions.nim
@@ -1,4 +1,4 @@
-import Tables, json, stint, chronicles, nimcrypto
+import json, stint, chronicles, nimcrypto
 
 import ../app_service/service/transaction/dto
 import ../app_service/service/eth/dto/transaction

--- a/ui/imports/shared/popups/keycard/KeycardPopup.qml
+++ b/ui/imports/shared/popups/keycard/KeycardPopup.qml
@@ -50,7 +50,7 @@ StatusModal {
     }
 
     onClosed: {
-        root.sharedKeycardModule.currentState.doTertiaryAction()
+        root.sharedKeycardModule.currentState.doCancelAction()
     }
 
     contentItem: StatusScrollView {

--- a/ui/imports/shared/popups/keycard/KeycardPopupDetails.qml
+++ b/ui/imports/shared/popups/keycard/KeycardPopupDetails.qml
@@ -36,16 +36,17 @@ QtObject {
             height: Constants.keycard.general.footerButtonsHeight
             width: height
             onClicked: {
-                root.sharedKeycardModule.currentState.backAction()
+                root.sharedKeycardModule.currentState.doBackAction()
             }
         }
     ]
 
     property list<StatusBaseButton> rightButtons: [
         StatusButton {
-            id: tertiaryButton
+            id: cancelButton
             height: Constants.keycard.general.footerButtonsHeight
-            text: {
+            text: qsTr("Cancel")
+            visible: {
                 switch (root.sharedKeycardModule.currentState.flowType) {
 
                 case Constants.keycardSharedFlow.setupNewKeycard:
@@ -64,7 +65,7 @@ QtObject {
                     case Constants.keycardSharedState.factoryResetSuccess:
                     case Constants.keycardSharedState.pinVerified:
                     case Constants.keycardSharedState.keycardMetadataDisplay:
-                        return qsTr("Cancel")
+                        return true
                     }
                     break
 
@@ -86,7 +87,7 @@ QtObject {
                     case Constants.keycardSharedState.keycardEmptyMetadata:
                     case Constants.keycardSharedState.factoryResetConfirmationDisplayMetadata:
                     case Constants.keycardSharedState.factoryResetConfirmation:
-                        return qsTr("Cancel")
+                        return true
                     }
                     break
 
@@ -112,7 +113,7 @@ QtObject {
                     case Constants.keycardSharedState.enterBiometricsPassword:
                     case Constants.keycardSharedState.wrongBiometricsPassword:
                     case Constants.keycardSharedState.enterPin:
-                        return qsTr("Cancel")
+                        return true
                     }
                     break
 
@@ -128,7 +129,7 @@ QtObject {
                     case Constants.keycardSharedState.notKeycard:
                     case Constants.keycardSharedState.unlockKeycardOptions:
                     case Constants.keycardSharedState.enterSeedPhrase:
-                        return qsTr("Cancel")
+                        return true
                     }
                     break
 
@@ -146,7 +147,7 @@ QtObject {
                     case Constants.keycardSharedState.maxPinRetriesReached:
                     case Constants.keycardSharedState.maxPukRetriesReached:
                     case Constants.keycardSharedState.maxPairingSlotsReached:
-                        return qsTr("Cancel")
+                        return true
                     }
                     break
 
@@ -165,7 +166,7 @@ QtObject {
                     case Constants.keycardSharedState.maxPinRetriesReached:
                     case Constants.keycardSharedState.maxPukRetriesReached:
                     case Constants.keycardSharedState.maxPairingSlotsReached:
-                        return qsTr("Cancel")
+                        return true
                     }
                     break
 
@@ -185,7 +186,7 @@ QtObject {
                     case Constants.keycardSharedState.maxPinRetriesReached:
                     case Constants.keycardSharedState.maxPukRetriesReached:
                     case Constants.keycardSharedState.maxPairingSlotsReached:
-                        return qsTr("Cancel")
+                        return true
                     }
                     break
 
@@ -205,7 +206,7 @@ QtObject {
                     case Constants.keycardSharedState.maxPinRetriesReached:
                     case Constants.keycardSharedState.maxPukRetriesReached:
                     case Constants.keycardSharedState.maxPairingSlotsReached:
-                        return qsTr("Cancel")
+                        return true
                     }
                     break
 
@@ -224,14 +225,13 @@ QtObject {
                     case Constants.keycardSharedState.maxPinRetriesReached:
                     case Constants.keycardSharedState.maxPukRetriesReached:
                     case Constants.keycardSharedState.maxPairingSlotsReached:
-                        return qsTr("Cancel")
+                        return true
                     }
                     break
                 }
 
-                return ""
+                return false
             }
-            visible: text !== ""
             enabled: {
                 switch (root.sharedKeycardModule.currentState.stateType) {
 
@@ -250,7 +250,7 @@ QtObject {
             }
 
             onClicked: {
-                root.sharedKeycardModule.currentState.doTertiaryAction()
+                root.sharedKeycardModule.currentState.doCancelAction()
             }
         },
 

--- a/ui/imports/shared/popups/keycard/states/KeycardInit.qml
+++ b/ui/imports/shared/popups/keycard/states/KeycardInit.qml
@@ -26,6 +26,7 @@ Item {
         id: d
 
         readonly property bool hideKeyPair: root.sharedKeycardModule.keycardData & Constants.predefinedKeycardData.hideKeyPair
+        readonly property bool continuousProcessingAnimation: root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.migratingKeyPair
     }
 
     Timer {
@@ -484,13 +485,25 @@ Item {
             }
             PropertyChanges {
                 target: image
-                pattern: Constants.keycardAnimations.warning.pattern
+                pattern: d.continuousProcessingAnimation?
+                             Constants.keycardAnimations.processing.pattern :
+                             Constants.keycardAnimations.warning.pattern
                 source: ""
-                startImgIndexForTheFirstLoop: Constants.keycardAnimations.warning.startImgIndexForTheFirstLoop
-                startImgIndexForOtherLoops: Constants.keycardAnimations.warning.startImgIndexForOtherLoops
-                endImgIndex: Constants.keycardAnimations.warning.endImgIndex
-                duration: Constants.keycardAnimations.warning.duration
-                loops: Constants.keycardAnimations.warning.loops
+                startImgIndexForTheFirstLoop: d.continuousProcessingAnimation?
+                                                  Constants.keycardAnimations.processing.startImgIndexForTheFirstLoop :
+                                                  Constants.keycardAnimations.warning.startImgIndexForTheFirstLoop
+                startImgIndexForOtherLoops: d.continuousProcessingAnimation?
+                                                Constants.keycardAnimations.processing.startImgIndexForOtherLoops :
+                                                Constants.keycardAnimations.warning.startImgIndexForOtherLoops
+                endImgIndex: d.continuousProcessingAnimation?
+                                 Constants.keycardAnimations.processing.endImgIndex :
+                                 Constants.keycardAnimations.warning.endImgIndex
+                duration: d.continuousProcessingAnimation?
+                              Constants.keycardAnimations.processing.duration :
+                              Constants.keycardAnimations.warning.duration
+                loops: d.continuousProcessingAnimation?
+                           Constants.keycardAnimations.processing.loops :
+                           Constants.keycardAnimations.warning.loops
             }
             PropertyChanges {
                 target: message

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -196,6 +196,15 @@ QtObject {
             readonly property int loops: 1
         }
 
+        readonly property QtObject processing: QtObject {
+            readonly property string pattern: "keycard/warning/img-%1"
+            readonly property int startImgIndexForTheFirstLoop: 0
+            readonly property int startImgIndexForOtherLoops: 18
+            readonly property int endImgIndex: 47
+            readonly property int duration: 1500
+            readonly property int loops: -1
+        }
+
         readonly property QtObject strongError: QtObject {
             readonly property string pattern: "keycard/strong_error/img-%1"
             readonly property int startImgIndexForTheFirstLoop: 0


### PR DESCRIPTION
All changes done in this PR were necessary in order to make migrating animation screen displayed for the whole time migration is being performed.

Changes are splitted in few commits that can be easier for review.

The most important thing is that add migration keypair and convert to a keycard account are now acyn actions which do not block UI.

Fixes: #8177