### PR TITLE
fix(@desktop/wallet): fix add new saved address popup close button

### DIFF
--- a/ui/app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml
+++ b/ui/app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml
@@ -40,6 +40,7 @@ StatusDialog {
     header: StatusDialogHeader {
         headline.title: edit ? qsTr("Edit saved address") : qsTr("Add saved address")
         headline.subtitle: edit ? name : ""
+        actions.closeButton.onClicked: root.close()
     }
 
     onOpened: {

--- a/ui/imports/shared/popups/AddEditSavedAddressPopup.qml
+++ b/ui/imports/shared/popups/AddEditSavedAddressPopup.qml
@@ -41,6 +41,7 @@ StatusDialog {
     header: StatusDialogHeader {
         headline.title: edit ? qsTr("Edit saved address") : qsTr("Add saved address")
         headline.subtitle: edit ? name : ""
+        actions.closeButton.onClicked: root.close()
     }
 
     onOpened: {


### PR DESCRIPTION
### What does the PR do
This fixes #8214

The definition of `StatusDialogHeader` for `AddEditSavedAddressPopup.qml` was missing the action for the close button. This PR adds it.

### Affected areas

Wallet

### Testing

1. Enable wallet
2. Click "Saved addresses"
3. Click "Add new address¨
4. On the popup, click the close button (X)

The popup should close
