### PR TITLE
fix(@desktop/onboarding): Clear tempPassword before sending login error

### DIFF
--- a/src/app/modules/startup/module.nim
+++ b/src/app/modules/startup/module.nim
@@ -268,6 +268,7 @@ method setSelectedLoginAccount*[T](self: Module[T], item: login_acc_item.Item) =
   self.controller.connectKeychain()
 
 method emitAccountLoginError*[T](self: Module[T], error: string) =
+  self.controller.setPassword("")
   self.view.emitAccountLoginError(error)
 
 method emitObtainingPasswordError*[T](self: Module[T], errorDescription: string, errorType: string) =


### PR DESCRIPTION
Fix #8082

### What does the PR do

Clears internal variable with password when there is a login error

### Affected areas

Onboarding

### Screenshot of functionality (including design for comparison)

https://user-images.githubusercontent.com/61889657/201668590-2989990a-bc95-4e16-9218-b1e52d2d0edf.mov


