### PR TITLE
fix: ci build

### DIFF
--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -58,6 +58,7 @@ pipeline {
   stages {
     stage('Deps') {
       steps {
+        sh 'make update'
         /* trigger fetching of git submodules */
         sh 'make check-pkg-target-linux'
         /* TODO: Re-add caching of Nim compiler. */


### PR DESCRIPTION
Since we change cleanWs by a clean git, the submodule are not fetch on checkout.
Running make update would hopefully update reference to latest