### PR TITLE
fix: prevent app from crash due to missing type variants

### DIFF
--- a/src/app_service/common/types.nim
+++ b/src/app_service/common/types.nim
@@ -15,6 +15,7 @@ type
     Gap = 10
     Edit = 11
     DiscordMessage = 12
+    ContactIdentityVerification = 13
 
 type
   StatusType* {.pure.} = enum

--- a/src/app_service/service/activity_center/dto/notification.nim
+++ b/src/app_service/service/activity_center/dto/notification.nim
@@ -17,6 +17,7 @@ type ActivityCenterNotificationType* {.pure.}= enum
   CommunityRequest = 7
   CommunityMembershipRequest = 8
   CommunityKicked = 9
+  ContactVerification = 10
 
 type ActivityCenterMembershipStatus* {.pure.}= enum
   Idle = 0,


### PR DESCRIPTION
Alright this was very painful to figure out.

Because desktop didn't know about the notification type for `ContactVerification`, the signal processing for incoming contact verifications would fail.

At the same time, the new message content type was missing a type variant for content verification as well, which would cause the app to crash at runtime for both, sender and receiver of verification requests.

Fixes #8205
