### PR TITLE
fix(@desktop/chat): Limit chat name length #6938

### DIFF
--- a/ui/app/AppLayouts/Chat/popups/PublicChatPopup.qml
+++ b/ui/app/AppLayouts/Chat/popups/PublicChatPopup.qml
@@ -62,6 +62,7 @@ ModalPopup {
         anchors.top: description.bottom
         anchors.topMargin: Style.current.padding
         placeholderText: qsTr("chat-name")
+        charLimit: 24
         Keys.onEnterPressed: doJoin()
         Keys.onReturnPressed: doJoin()
         input.asset.name: "channel"


### PR DESCRIPTION
### What does the PR do

Limit chat name length to 24 symbols 
Closes: #6938

### Affected areas

Chat name length

### Screenshot of functionality (including design for comparison)

![image](https://user-images.githubusercontent.com/117639195/201724763-81f677ba-18bd-4641-b266-11d2610e8298.png)
