### PR TITLE
ci: add make update to for other platforms

### DIFF
--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -59,9 +59,6 @@ pipeline {
     stage('Deps') {
       steps {
         sh 'make update'
-        /* trigger fetching of git submodules */
-        sh 'make check-pkg-target-linux'
-        /* TODO: Re-add caching of Nim compiler. */
         sh 'make deps'
       }
     }

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -55,9 +55,7 @@ pipeline {
   stages {
     stage('Deps') {
       steps { 
-        /* trigger fetching of git submodules */
-        sh 'make check-pkg-target-macos'
-        /* TODO: Re-add caching of Nim compiler. */
+        sh 'make update'
         withCredentials([
           usernamePassword( /* For fetching HomeBrew bottles. */
             credentialsId: "status-im-auto-pkgs",

--- a/ci/Jenkinsfile.windows
+++ b/ci/Jenkinsfile.windows
@@ -52,9 +52,7 @@ pipeline {
   stages {
     stage('Deps') {
       steps {
-        /* trigger fetching of git submodules */
-        sh 'make check-pkg-target-windows'
-        /* TODO: Re-add caching of Nim compiler. */
+        sh 'make update'
         sh 'make deps'
       }
     }


### PR DESCRIPTION
This was added to fix some build issues to Linux:

* https://github.com/status-im/status-desktop/pull/8233

But other 2 platforms also have had the cleanup stage change which could have cause these submodules update issues.