### PR TITLE
Fix Windows' chat being empty because of some kind of popup overflow

### DIFF
--- a/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
@@ -32,6 +32,7 @@ Item {
     property var rootStore
     property var contactsStore
     property var emojiPopup
+    property var stickersPopup
 
     // Not Refactored Yet
     //property int chatGroupsListViewCount: 0
@@ -215,6 +216,7 @@ Item {
                             rootStore: root.rootStore
                             contactsStore: root.contactsStore
                             emojiPopup: root.emojiPopup
+                            stickersPopup: root.stickersPopup
                             sendTransactionNoEnsModal: cmpSendTransactionNoEns
                             receiveTransactionModal: cmpReceiveTransaction
                             sendTransactionWithEnsModal: cmpSendTransactionWithEns
@@ -263,6 +265,7 @@ Item {
                         rootStore: root.rootStore
                         contactsStore: root.contactsStore
                         emojiPopup: root.emojiPopup
+                        stickersPopup: root.stickersPopup
                         sendTransactionNoEnsModal: cmpSendTransactionNoEns
                         receiveTransactionModal: cmpReceiveTransaction
                         sendTransactionWithEnsModal: cmpSendTransactionWithEns

--- a/ui/app/AppLayouts/Chat/views/ChatContentView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatContentView.qml
@@ -36,6 +36,7 @@ ColumnLayout {
     property var contactsStore
     property bool isActiveChannel: false
     property var emojiPopup
+    property var stickersPopup
     property alias textInputField: chatInput
     property UsersStore usersStore: UsersStore {}
 
@@ -145,6 +146,7 @@ ColumnLayout {
             messageContextMenu: contextmenu
             messageStore: messageStore
             emojiPopup: root.emojiPopup
+            stickersPopup: root.stickersPopup
             usersStore: root.usersStore
             stickersLoaded: root.stickersLoaded
             isChatBlocked: root.isBlocked
@@ -183,11 +185,10 @@ ColumnLayout {
 
                 messageContextMenu: contextmenu
                 emojiPopup: root.emojiPopup
+                stickersPopup: root.stickersPopup
                 isContactBlocked: root.isBlocked
                 isActiveChannel: root.isActiveChannel
                 anchors.bottom: parent.bottom
-                recentStickers: root.rootStore.stickersModuleInst.recent
-                stickerPackList: root.rootStore.stickersModuleInst.stickerPacks
                 chatType: chatContentModule? chatContentModule.chatDetails.type : Constants.chatType.unknown
 
                 Binding on chatInputPlaceholder {

--- a/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
@@ -33,6 +33,7 @@ Item {
     property string channelEmoji
 
     property var emojiPopup
+    property var stickersPopup
 
     property bool stickersLoaded: false
     property alias chatLogView: chatLogView
@@ -265,6 +266,7 @@ Item {
             contactsStore: root.contactsStore
             channelEmoji: root.channelEmoji
             emojiPopup: root.emojiPopup
+            stickersPopup: root.stickersPopup
             chatLogView: ListView.view
 
             isActiveChannel: root.isActiveChannel

--- a/ui/app/AppLayouts/Chat/views/ChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatView.qml
@@ -31,6 +31,7 @@ StatusSectionLayout {
 
     property Component membershipRequestPopup
     property var emojiPopup
+    property var stickersPopup
     property bool stickersLoaded: false
 
     signal communityInfoButtonClicked()
@@ -84,6 +85,7 @@ StatusSectionLayout {
         contactsStore: root.contactsStore
         stickersLoaded: root.stickersLoaded
         emojiPopup: root.emojiPopup
+        stickersPopup: root.stickersPopup
         onOpenStickerPackPopup: {
             Global.openPopup(statusStickerPackClickPopup, {packId: stickerPackId} )
         }

--- a/ui/app/AppLayouts/Chat/views/CreateChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/CreateChatView.qml
@@ -146,8 +146,6 @@ Page {
                 visible: membersSelector.model.count > 0
                 chatType: membersSelector.model.count === 1? Constants.chatType.oneToOne : Constants.chatType.privateGroupChat
                 emojiPopup: root.emojiPopup
-                recentStickers: root.rootStore.stickersModuleInst.recent
-                stickerPackList: root.rootStore.stickersModuleInst.stickerPacks
                 closeGifPopupAfterSelection: true
                 onSendTransactionCommandButtonClicked: {
                     root.rootStore.createChatStartSendTransactionProcess = true;

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -311,6 +311,11 @@ Item {
         height: 440
     }
 
+    StatusStickersPopup {
+        id: statusStickersPopup
+        store: chatLayoutContainer.rootStore
+    }
+
     StatusMainLayout {
         id: appLayout
 
@@ -801,6 +806,7 @@ Item {
                         id: chatLayoutContainer
 
                         chatView.emojiPopup: statusEmojiPopup
+                        chatView.stickersPopup: statusStickersPopup
 
                         contactsStore: appMain.rootStore.contactStore
                         rootStore.emojiReactionsModel: appMain.rootStore.emojiReactionsModel
@@ -899,6 +905,7 @@ Item {
 
                                     sourceComponent: ChatLayout {
                                         chatView.emojiPopup: statusEmojiPopup
+                                        chatView.stickersPopup: statusStickersPopup
 
                                         contactsStore: appMain.rootStore.contactStore
                                         rootStore.emojiReactionsModel: appMain.rootStore.emojiReactionsModel

--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -33,8 +33,10 @@ Rectangle {
     property var store
 
     property var emojiPopup: null
+    property var stickersPopup: null
     // Use this to only enable the Connections only when this Input opens the Emoji popup
     property bool emojiPopupOpened: false
+    property bool stickersPopupOpened: false
     property bool closeGifPopupAfterSelection: true
 
     property bool emojiEvent: false
@@ -46,9 +48,6 @@ Rectangle {
     property bool isEdit: false
     property bool isContactBlocked: false
     property bool isActiveChannel: false
-
-    property var recentStickers
-    property var stickerPackList
 
     property int messageLimit: 2000
     property int messageLimitVisible: 200
@@ -149,6 +148,20 @@ Rectangle {
                 }
             }
         }
+        readonly property StateGroup stickersPopupTakeover: StateGroup {
+            states: State {
+                when: control.stickersPopupOpened
+
+                PropertyChanges {
+                    target: stickersPopup
+
+                    parent: control
+                    closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutsideParent
+                    x: control.width - stickersPopup.width - Style.current.halfPadding
+                    y: -stickersPopup.height
+                }
+            }
+        }
 
         function copyMentions(start, end) {
             copiedMentionsPos = []
@@ -212,8 +225,8 @@ Rectangle {
     }
 
     function togglePopup(popup, btn) {
-        if (popup !== stickersPopup) {
-            stickersPopup.close()
+        if (popup !== control.stickersPopup) {
+            control.stickersPopup.close()
         }
 
         if (popup !== gifPopup) {
@@ -245,6 +258,21 @@ Rectangle {
         onClosed: {
             emojiBtn.highlighted = false
             control.emojiPopupOpened = false
+        }
+    }
+
+    Connections {
+        enabled: control.stickersPopupOpened
+        target: control.stickersPopup
+
+        onStickerSelected: {
+            control.stickerSelected(hashId, packId, url)
+            control.hideExtendedArea();
+            messageInputField.forceActiveFocus();
+        }
+        onClosed: {
+            stickersBtn.highlighted = false
+            control.stickersPopupOpened = false
         }
     }
 
@@ -952,24 +980,6 @@ Rectangle {
         }
     }
 
-    StatusStickersPopup {
-        id: stickersPopup
-        x: control.width - width - Style.current.halfPadding
-        y: -height
-        store: control.store
-        enabled: !!control.recentStickers && !!control.stickerPackList
-        recentStickers: control.recentStickers
-        stickerPackList: control.stickerPackList
-        onStickerSelected: {
-            control.stickerSelected(hashId, packId, url)
-            control.hideExtendedArea();
-            messageInputField.forceActiveFocus();
-        }
-        onClosed: {
-            stickersBtn.highlighted = false
-        }
-    }
-
     RowLayout {
         id: layout
         anchors.fill: parent
@@ -1404,7 +1414,11 @@ Rectangle {
                                 type: StatusQ.StatusFlatRoundButton.Type.Tertiary
                                 visible: !isEdit && emojiBtn.visible
                                 color: "transparent"
-                                onClicked: togglePopup(stickersPopup, stickersBtn)
+                                onClicked: {
+                                    control.stickersPopupOpened = true
+                                    
+                                    togglePopup(control.stickersPopup, stickersBtn)
+                                }
                             }
                         }
                     }

--- a/ui/imports/shared/status/StatusStickersPopup.qml
+++ b/ui/imports/shared/status/StatusStickersPopup.qml
@@ -15,11 +15,12 @@ import AppLayouts.Chat.stores 1.0
 Popup {
     id: root
     property var store
-    property var recentStickers: StickerData {}
-    property var stickerPackList: StickerPackData {}
+    property var recentStickers: store.stickersModuleInst.recent
+    property var stickerPackList: store.stickersModuleInst.stickerPacks
     signal stickerSelected(string hashId, string packId, string url)
     property int installedPacksCount: stickersModule.numInstalledStickerPacks
     property bool stickerPacksLoaded: false
+    enabled: !!recentStickers && !!stickerPackList
     width: 360
     height: 440
     modal: false

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -29,6 +29,7 @@ Loader {
 
     property var chatLogView
     property var emojiPopup
+    property var stickersPopup
 
     // Once we redo qml we will know all section/chat related details in each message form the parent components
     // without an explicit need to fetch those details via message store/module.
@@ -678,6 +679,7 @@ Loader {
                     store: root.rootStore
                     usersStore: root.usersStore
                     emojiPopup: root.emojiPopup
+                    stickersPopup: root.stickersPopup
                     messageContextMenu: root.messageContextMenu
 
                     chatType: root.messageStore.getChatType()


### PR DESCRIPTION
Fixes #7906 

The original problem was that the Windows build wasn't opening. Technically, this PR doesn't fix that, because for me, on Windows 10, master already opened fine. So something in 0.8 already fixed that.

However, the chat view was completely empty. No message, no input, nothing, just the top bar. Even the community portal was empty.

It seems like it was caused by some sort of memory overflow, though increasing the max stack didn't do the trick.

Anyway, the thing is that our StatusChatInput is used A LOT. Each channel has one, and even worst, each **Message** has one, for the edit feature.

Then each ChatInput has a couple of Popups. Last time, Igor found that we have some sort of problem with those popups. He's working on a fix, but in the meantime, Windows is fully broke, so here's a fix.

I identified the StickersPopup as the current culprit. If I comment it, it works, if it's there, no go.
So what I did is, like the EmojiPopup, I moved it to the AppMain and just passed a reference to the ChatInputs. That way, we only have that Popup once. Since it's a possibly heavy popup and it doesn't actually need to be different for each chat, it makes sense. Plus, it's not even used in the Edit mode, so it was completely useless there.

Hopefully, we have the popup fix soon, but we should also try to improve the StatusChatInput, because it's very BIG and has a lot of subcomponents (mostly popups) that can probably be extracted as well.
Also, maybe we can find a way to NOT have a StatusChatInput in every Message.
