### PR TITLE
fix(NicknamePopup): add support for Unicode nicknames

### DIFF
--- a/ui/StatusQ/src/StatusQ/Controls/Validators/StatusRegularExpressionValidator.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/Validators/StatusRegularExpressionValidator.qml
@@ -28,7 +28,7 @@ StatusValidator {
     id: root
 
     /*!
-       \qmlproperty string StatusRegularExpressionValidator::regularExpression
+       \qmlproperty var StatusRegularExpressionValidator::regularExpression
         This property holds the regular expression used for validation.
 
         Note that this property should be a regular expression in JS syntax, e.g /a/ for the regular expression matching "a".
@@ -50,11 +50,11 @@ StatusValidator {
     property var regularExpression
 
     name: "regex"
-    errorMessage: `Must match regex(${validatorObj.regularExpression.toString()})`
+    errorMessage: `Must match regex(${regularExpression.toString()})`
     validatorObj: RegularExpressionValidator { regularExpression: root.regularExpression }
 
     validate: function (value) {
         // Basic validation management
-        return root.validatorObj.regularExpression.test(value)
+        return root.regularExpression.test(value)
     }
 }

--- a/ui/imports/shared/popups/NicknamePopup.qml
+++ b/ui/imports/shared/popups/NicknamePopup.qml
@@ -1,6 +1,8 @@
 import QtQuick 2.13
 import QtQuick.Controls 2.13
 
+import DotherSide 0.1
+
 import utils 1.0
 import shared.controls 1.0
 
@@ -61,7 +63,10 @@ StatusModal {
                 validationMode: StatusInput.ValidationMode.IgnoreInvalidInput
                 validators: [
                     StatusRegularExpressionValidator {
-                        regularExpression: /^[0-9A-Za-z_-]*$/
+                        validatorObj: RXValidator { regularExpression: /^[\w\d_-]*$/u }
+                        validate: function (value) {
+                            return validatorObj.test(value)
+                        }
                     }
                 ]
                 Keys.onReleased: {


### PR DESCRIPTION
- do not restrict NicknamePopup's regexp to ASCII characters
- a similar thing could be done to the user's DisplayName but currently that's blocked on status-go side
- uses RXValidator from dotherside

Needs status-im/dotherside/pull/74
Fixes #8115

### What does the PR do

Fixes Unicode support for local nicknames

### Affected areas

NicknamePopup

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![image](https://user-images.githubusercontent.com/5377645/201855202-c60be18c-aa5a-418b-906d-227aa7d59fbe.png)
