### PR TITLE
fix(StatusTextMessage): Removed vertical text alignment leftover

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusTextMessage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusTextMessage.qml
@@ -78,7 +78,6 @@ Item {
         selectedTextColor: Theme.palette.directColor1
         selectionColor: Theme.palette.primaryColor3
         color: Theme.palette.directColor1
-        verticalAlignment: TextEdit.AlignVCenter
         font.family: Theme.palette.baseFont.name
         font.pixelSize: Theme.primaryTextFontSize
         textFormat: Text.RichText


### PR DESCRIPTION
Closes #8242

### What does the PR do
StatusTextMessage: Removed vertical text alignment leftover

### Affected areas
StatusTextMessage

### Screenshot of functionality (including design for comparison)

