### PR TITLE
fix(SettingsDirtyToastMessage): Avoid scrolling when content height is 0

### DIFF
--- a/ui/app/AppLayouts/Profile/views/profile/MyProfileSettingsView.qml
+++ b/ui/app/AppLayouts/Profile/views/profile/MyProfileSettingsView.qml
@@ -38,7 +38,7 @@ ColumnLayout {
     readonly property bool dirty: descriptionPanel.displayName.text !== profileStore.displayName ||
                                   descriptionPanel.bio.text !== profileStore.bio ||
                                   profileStore.socialLinksDirty ||
-                                  biometricsSwitch.checked != biometricsSwitch.currentStoredValue ||
+                                  biometricsSwitch.checked !== biometricsSwitch.currentStoredValue ||
                                   profileHeader.icon !== profileStore.profileLargeImage
 
     readonly property bool valid: !!descriptionPanel.displayName.text && descriptionPanel.displayName.valid

--- a/ui/imports/shared/popups/SettingsDirtyToastMessage.qml
+++ b/ui/imports/shared/popups/SettingsDirtyToastMessage.qml
@@ -55,7 +55,7 @@ Rectangle {
         const margin = 20;
         const offset = h2 - (y1 - y2);
 
-        if (offset <= 0)
+        if (offset <= 0 || flickable.contentHeight <= 0)
             return;
 
         toastFlickAnimation.from = flickable.contentY;


### PR DESCRIPTION
Fixes: #8247

### What does the PR do

If view isn't ready and `dirty` flag is true in initial state, toast message trying to scroll ui, but contentHeight is 0. This PR may be just a workaround, but hidden scrolling shouldn't exist. 

### Affected areas

SettingsDirtyToastMessage
