### PR TITLE
tests(suite_messaging): properly check if reply message has reply

### DIFF
--- a/test/ui-test/src/screens/StatusChatScreen.py
+++ b/test/ui-test/src/screens/StatusChatScreen.py
@@ -84,6 +84,8 @@ class ChatStickerPopup(Enum):
 
 class ChatItems(Enum):
     STATUS_MESSAGE_TEXT_MESSAGE = "StatusMessage_textMessage"
+    STATUS_MESSAGE_REPLY_DETAILS = "StatusMessage_replyDetails"
+    STATUS_MESSAGE_REPLY_DETAILS_TEXT_MESSAGE = "StatusMessage_replyDetails_textMessage"
     STATUS_TEXT_MESSAGE_CHAT_TEXT = "StatusTextMessage_chatText"
 
 class ChatMessagesHistory(Enum):
@@ -318,7 +320,26 @@ class StatusChatScreen:
     def verify_last_message_is_not_loaded(self):
         [loaded, _] = is_loaded_visible_and_enabled(ChatComponents.LAST_MESSAGE_TEXT.value)
         verify_false(loaded, "Success: No message was found")
-                
+
+    def verify_last_message_is_reply(self, message: str):
+        last_message_obj = self.get_message_at_index(0)
+        last_message_reply_details_obj = getChildrenWithObjectName(last_message_obj, ChatItems.STATUS_MESSAGE_REPLY_DETAILS.value)[0]
+        verify(not is_null(last_message_reply_details_obj), "Checking last message is a reply: " + message)
+
+    def verify_last_message_is_reply_to(self, reply: str, message: str):
+        last_message_obj = self.get_message_at_index(0)
+        last_message_reply_details_obj = getChildrenWithObjectName(last_message_obj, ChatItems.STATUS_MESSAGE_REPLY_DETAILS.value)[0]
+        text_message_obj = getChildrenWithObjectName(last_message_reply_details_obj, ChatItems.STATUS_MESSAGE_REPLY_DETAILS_TEXT_MESSAGE.value)[0]
+        verify_text_contains(str(text_message_obj.messageDetails.messageText), str(message))
+
+    def verify_last_message_is_reply_to_loggedin_user_message(self, reply: str, message: str):
+        last_message_obj = self.get_message_at_index(0)
+        last_message_reply_details_obj = getChildrenWithObjectName(last_message_obj, ChatItems.STATUS_MESSAGE_REPLY_DETAILS.value)[0]
+        text_message_obj = getChildrenWithObjectName(last_message_reply_details_obj, ChatItems.STATUS_MESSAGE_REPLY_DETAILS_TEXT_MESSAGE.value)[0]
+        verify_text_contains(str(text_message_obj.messageDetails.messageText), str(message))
+        verify_values_equal(str(last_message_reply_details_obj.replyDetails.sender.id), str(last_message_obj.senderId), "Message sender ID doesn't match reply message sender ID")
+
+
     def verify_last_message_sent(self, message: str):
         # Get the message text
         # We don't search for StatusTextMessage_chatText directly, because there're 2 instances of it in a reply message

--- a/test/ui-test/testSuites/suite_messaging/shared/steps/chatSteps.py
+++ b/test/ui-test/testSuites/suite_messaging/shared/steps/chatSteps.py
@@ -182,8 +182,15 @@ def step(context, message):
     
 @Then("the chat message \"|any|\" is displayed as a reply")
 def step(context, message):
-    # TODO: Check the last message is really a reply.
-    _statusChat.verify_last_message_sent(message) 
+    _statusChat.verify_last_message_is_reply(message) 
+
+@Then("the chat message \"|any|\" is displayed as a reply of \"|any|\"")
+def step(context, reply, message):
+    _statusChat.verify_last_message_is_reply_to(reply, message) 
+
+@Then("the chat message \"|any|\" is displayed as a reply of this user's \"|any|\"")
+def step(context, reply, message):
+    _statusChat.verify_last_message_is_reply_to_loggedin_user_message(reply, message) 
     
 @Then("the chat message \"|any|\" is displayed as an edited one")
 def step(context, message):

--- a/test/ui-test/testSuites/suite_messaging/tst_ChatFlow/test.feature
+++ b/test/ui-test/testSuites/suite_messaging/tst_ChatFlow/test.feature
@@ -24,17 +24,15 @@ Feature: Status Desktop Chat Basic Flows
 		 | I am from status   	 |
 		 | tell me how you do?   |
 
-    # TODO: Scenario: The user can reply to their OWN message
     @mayfail
     # TODO: It works standalone but when it runs as part of the sequence, the action of reply is not done always. The popup option does not appear.
-    Scenario Outline: The user can reply to the last message
-         Given the user sends a chat message "random chat message"
+    Scenario Outline: The user can reply to own message
+         Given the user sends a chat message "<message>"
          When the user replies to the message at index 0 with "<reply>"
-         # TODO: Check the last message is really a reply, now just checking the last message is the expected one but could not be a reply. The popup option does not appear.
-         Then the chat message "<reply>" is displayed as a reply
+         Then the chat message "<reply>" is displayed as a reply of this user's "<message>"
          Examples:
-		 | reply		   |
-		 | This is a reply |
+     | message             | reply           |
+     | random chat message | This is a reply |
 
 	@mayfail
 	# TODO: It works standalone but when it runs as part of the sequence, the action of edit is not done always. The popup option does not appear.

--- a/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
@@ -215,6 +215,7 @@ Control {
                 active: isAReply
                 visible: active
                 sourceComponent: StatusMessageReply {
+                    objectName: "StatusMessage_replyDetails"
                     replyDetails: root.replyDetails
                     profileClickable: root.profileClickable
                     audioMessageInfoText: root.audioMessageInfoText

--- a/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusMessageReply.qml
+++ b/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusMessageReply.qml
@@ -97,6 +97,7 @@ Item {
                     }
                 }
                 StatusTextMessage {
+                    objectName: "StatusMessage_replyDetails_textMessage"
                     Layout.fillWidth: true
                     textField.font.pixelSize: Theme.secondaryTextFontSize
                     textField.color: Theme.palette.baseColor1


### PR DESCRIPTION
Prior to this commit we were merely checking if the message in question was the last one.

With this commit we now check whether there's a reply in the first place and whether the reply-to-message is the correct one.

Closes #7909

