### PR TITLE
fix(StatusChatInput): various keyboard shortcut fixes

### DIFF
--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -303,6 +303,9 @@ Rectangle {
                 event.accepted = true
                 messageTooLongDialog.open()
             }
+        } else if (event.key === Qt.Key_Escape && control.isReply) {
+            control.isReply = false
+            event.accepted = true
         }
 
         const symbolPressed = event.text.length > 0 &&

--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -387,7 +387,7 @@ Rectangle {
 
         // ⌘⇧U
         if (isUploadFilePressed(event)) {
-            imageBtn.clicked()
+            imageBtn.clicked(null)
             event.accepted = true
         }
 


### PR DESCRIPTION
### What does the PR do

- unbreak upload image shortcut (Ctrl+U)
- add Esc key handler to close reply area

### Affected areas

StatusChatInput

### Screenshot of functionality (including design for comparison)

- [N/A] I've checked the design and this PR matches it

