### PR TITLE
fix(StatusMessage): add spacing between individual subcomponents

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
@@ -253,8 +253,7 @@ Control {
                 }
 
                 ColumnLayout {
-
-                    spacing: 0
+                    spacing: 2
                     Layout.alignment: Qt.AlignTop
                     Layout.fillWidth: true
 
@@ -292,7 +291,6 @@ Control {
                                 root.linkActivated(link);
                             }
                         }
-
                     }
 
                     Loader {


### PR DESCRIPTION
Fixes #8267

### What does the PR do

Fixes the individual StatusMessage subcomponents being too squashed together by adding a 2px spacing

### Affected areas

StatusMessage

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![image](https://user-images.githubusercontent.com/5377645/202136998-48df594e-437c-443d-a569-929523e70cd2.png)

