### PR TITLE
fix(messaging): Fix processing successfully sent messages and remove @mayfail from relevant ui test

### DIFF
--- a/src/app_service/service/chat/service.nim
+++ b/src/app_service/service/chat/service.nim
@@ -233,9 +233,12 @@ QtObject:
     for chat in chats:
       if (chat.active):
         self.events.emit(SIGNAL_CHAT_CREATED, CreatedChatArgs(chat: chat))
-
-    for i, msg in messages:
-      self.events.emit(SIGNAL_SENDING_SUCCESS, MessageSendingSuccess(message: msg, chat: chats[i]))
+      
+    for msg in messages:
+      for chat in chats:
+        if chat.id == msg.chatId:
+          self.events.emit(SIGNAL_SENDING_SUCCESS, MessageSendingSuccess(message: msg, chat: chat))
+          break
 
   proc processUpdateForTransaction*(self: Service, messageId: string, response: RpcResponse[JsonNode]) =
     var (chats, messages) = self.processMessageUpdateAfterSend(response)

--- a/test/ui-test/testSuites/suite_communities/tst_communityMessageFlows/test.feature
+++ b/test/ui-test/testSuites/suite_communities/tst_communityMessageFlows/test.feature
@@ -33,8 +33,6 @@ Feature: Status Desktop community messages
         Then the test image is displayed just before the last message
         And the last chat message contains "Message"
 
-	@mayfail
-	# TODO: The action of sending multiple images doesn't work. It is only sent one.
     Scenario: The user sends multiple test images with a message
         When the user sends multiple test images in the current channel with message "Message" with an image again
         Then the test images are displayed just before the last message


### PR DESCRIPTION
Fixes: #7961

### What does the PR do

The problem was in processing several messages after send. Images were sent, but displaying several messages was impossible (was expected several messages from different chats).

Fix image validation in ui-test

### Affected areas

Messaging

edit: this also fixes showing your own replies