### PR TITLE
cleanup(squish): remove redundant definition of `mouse_over_object` api

### DIFF
--- a/test/ui-test/src/drivers/SquishDriver.py
+++ b/test/ui-test/src/drivers/SquishDriver.py
@@ -286,15 +286,6 @@ def _find_link(objName: str, link: str):
     return [-1, -1]
 
 
-def move_mouse_over_object(obj):
-    # Start moving the cursor:
-    end_x = obj.x + (obj.width / 2)
-    y = round(int(obj.height) / 2)
-    x = 0
-    while x < end_x:
-        squish.mouseMove(obj, x, y)
-        x += 10
-
 def expect_true(assertionValue: bool, message: str):
     return test.verify(assertionValue, message)
 


### PR DESCRIPTION
Probably a mistake. This was defined twice in our package.

