### PR TITLE
feat(ActivityCenter): Remove MessageView from the Activity Center

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
@@ -73,8 +73,8 @@ Control {
     property StatusMessageDetails messageDetails: StatusMessageDetails {}
     property StatusMessageDetails replyDetails: StatusMessageDetails {}
 
-    property string timestampString: Qt.formatTime(new Date(timestamp), "hh:mm");
-    property string timestampTooltipString: Qt.formatTime(new Date(timestamp), "dddd, MMMM d, yyyy hh:mm:ss t");
+    property string timestampString: new Date(notification.timestamp).toLocaleTimeString(Qt.locale(), Locale.ShortFormat)
+    property string timestampTooltipString: new Date(notification.timestamp).toLocaleString()
 
     signal clicked(var sender, var mouse)
     signal profilePictureClicked(var sender, var mouse)

--- a/ui/StatusQ/src/StatusQ/Components/StatusMessageHeader.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusMessageHeader.qml
@@ -7,6 +7,8 @@ import StatusQ.Core.Utils 0.1
 import StatusQ.Components 0.1
 import StatusQ.Controls 0.1
 
+import "./private/statusMessage"
+
 Item {
     id: root
 

--- a/ui/StatusQ/src/StatusQ/Components/StatusSmartIdenticon.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusSmartIdenticon.qml
@@ -44,7 +44,6 @@ Loader {
                            root.asset.bgColor
                 image.fillMode: root.asset.cropRect ? Image.PreserveAspectCrop
                                                     : Image.PreserveAspectFit
-                image.scale: root.asset.scale
                 image.x: root.asset.cropRectangle ? -root.asset.cropRectangle.x
                                                   : 0
                 image.y: root.asset.cropRectangle ? -root.asset.cropRectangle.y

--- a/ui/StatusQ/src/StatusQ/Components/qmldir
+++ b/ui/StatusQ/src/StatusQ/Components/qmldir
@@ -31,6 +31,7 @@ StatusListPicker 0.1 StatusListPicker.qml
 StatusExpandableItem 0.1 StatusExpandableItem.qml
 StatusSmartIdenticon 0.1 StatusSmartIdenticon.qml
 StatusMessage 0.1 StatusMessage.qml
+StatusMessageHeader 0.1 StatusMessageHeader.qml
 StatusMessageDetails 0.1 StatusMessageDetails.qml
 StatusMessageSenderDetails 0.1 StatusMessageSenderDetails.qml
 StatusTagSelector 0.1 StatusTagSelector.qml

--- a/ui/StatusQ/src/statusq.qrc
+++ b/ui/StatusQ/src/statusq.qrc
@@ -6,7 +6,6 @@
         <file>StatusQ/Components/private/statusMessage/StatusAudioMessage.qml</file>
         <file>StatusQ/Components/private/statusMessage/StatusEditMessage.qml</file>
         <file>StatusQ/Components/private/statusMessage/StatusImageMessage.qml</file>
-        <file>StatusQ/Components/private/statusMessage/StatusMessageHeader.qml</file>
         <file>StatusQ/Components/private/statusMessage/StatusMessageQuickActions.qml</file>
         <file>StatusQ/Components/private/statusMessage/StatusMessageReply.qml</file>
         <file>StatusQ/Components/private/statusMessage/StatusPinMessageDetails.qml</file>
@@ -46,6 +45,7 @@
         <file>StatusQ/Components/StatusMemberListItem.qml</file>
         <file>StatusQ/Components/StatusMessage.qml</file>
         <file>StatusQ/Components/StatusMessageDetails.qml</file>
+        <file>StatusQ/Components/StatusMessageHeader.qml</file>
         <file>StatusQ/Components/StatusNavigationListItem.qml</file>
         <file>StatusQ/Components/StatusNavigationPanelHeadline.qml</file>
         <file>StatusQ/Components/StatusRoundedImage.qml</file>

--- a/ui/app/mainui/activitycenter/controls/ReplyBadge.qml
+++ b/ui/app/mainui/activitycenter/controls/ReplyBadge.qml
@@ -1,7 +1,6 @@
-import QtQuick 2.3
-import QtQuick.Controls 2.3
-import QtQuick.Layouts 1.3
-import Qt.labs.platform 1.1
+import QtQuick 2.4
+
+import StatusQ.Core 0.1
 
 import utils 1.0
 import shared.controls 1.0
@@ -20,24 +19,20 @@ Badge {
         id: replyIcon
         anchors.left: parent.left
         anchors.leftMargin: Style.current.smallPadding
-        anchors.verticalCenter:parent.verticalCenter
+        anchors.verticalCenter: parent.verticalCenter
         width: 16
         height: width
         source: Style.svg("reply-small-arrow")
     }
 
-    StyledTextEdit {
-        id: communityNameText
-        width: implicitWidth > 300 ? 300 : implicitWidth
-        height: 18
+    StatusBaseText {
         anchors.left: replyIcon.right
         anchors.leftMargin: 4
         anchors.verticalCenter: parent.verticalCenter
-        text: Utils.getReplyMessageStyle(StatusQUtils.Emoji.parse(StatusQUtils.Utils.linkifyAndXSS(repliedMessageContent), 
-                                         StatusQUtils.Emoji.size.small), false)
-        readOnly: true
-        textFormat: Text.RichText
-        clip: true
+        width: Math.min(implicitWidth, 300)
+        text: repliedMessageContent
+        maximumLineCount: 1
+        elide: Text.ElideRight
         font.pixelSize: 13
 
         MouseArea {

--- a/ui/app/mainui/activitycenter/popups/ActivityCenterPopup.qml
+++ b/ui/app/mainui/activitycenter/popups/ActivityCenterPopup.qml
@@ -42,10 +42,6 @@ Popup {
 
     property ActivityCenterStore activityCenterStore
     property var store
-    property var messageContextMenu: MessageContextMenuView {
-        store: root.store
-        reactionModel: root.store.emojiReactionsModel
-    }
 
     readonly property int unreadNotificationsCount: root.activityCenterStore.unreadNotificationsCount
 
@@ -194,9 +190,8 @@ Popup {
                     store: root.store
                     activityCenterStore: root.activityCenterStore
                     notification: model
-                    messageContextMenu: root.messageContextMenu
                     previousNotificationIndex: Math.min(listView.count - 1, index + 1)
-                    onActivityCenterClose: root.close()
+                    onCloseActivityCenter: root.close()
                 }
             }
             DelegateChoice {
@@ -207,9 +202,8 @@ Popup {
                     store: root.store
                     activityCenterStore: root.activityCenterStore
                     notification: model
-                    messageContextMenu: root.messageContextMenu
                     previousNotificationIndex: Math.min(listView.count - 1, index + 1)
-                    onActivityCenterClose: root.close()
+                    onCloseActivityCenter: root.close()
                 }
             }
             DelegateChoice {
@@ -220,9 +214,8 @@ Popup {
                     store: root.store
                     activityCenterStore: root.activityCenterStore
                     notification: model
-                    messageContextMenu: root.messageContextMenu
                     previousNotificationIndex: Math.min(listView.count - 1, index + 1)
-                    onActivityCenterClose: root.close()
+                    onCloseActivityCenter: root.close()
                 }
             }
             DelegateChoice {
@@ -233,9 +226,8 @@ Popup {
                     store: root.store
                     activityCenterStore: root.activityCenterStore
                     notification: model
-                    messageContextMenu: root.messageContextMenu
                     previousNotificationIndex: Math.min(listView.count - 1, index + 1)
-                    onActivityCenterClose: root.close()
+                    onCloseActivityCenter: root.close()
                 }
             }
             DelegateChoice {
@@ -246,9 +238,8 @@ Popup {
                     store: root.store
                     activityCenterStore: root.activityCenterStore
                     notification: model
-                    messageContextMenu: root.messageContextMenu
                     previousNotificationIndex: Math.min(listView.count - 1, index + 1)
-                    onActivityCenterClose: root.close()
+                    onCloseActivityCenter: root.close()
                 }
             }
             DelegateChoice {
@@ -260,6 +251,7 @@ Popup {
                     activityCenterStore: root.activityCenterStore
                     notification: model
                     previousNotificationIndex: Math.min(listView.count - 1, index + 1)
+                    onCloseActivityCenter: root.close()
                 }
             }
             DelegateChoice {
@@ -271,6 +263,7 @@ Popup {
                     activityCenterStore: root.activityCenterStore
                     notification: model
                     previousNotificationIndex: Math.min(listView.count - 1, index + 1)
+                    onCloseActivityCenter: root.close()
                 }
             }
         }

--- a/ui/app/mainui/activitycenter/views/ActivityNotificationBase.qml
+++ b/ui/app/mainui/activitycenter/views/ActivityNotificationBase.qml
@@ -20,6 +20,8 @@ Item {
     property alias ctaComponent: ctaLoader.sourceComponent
     property alias previousNotificationIndex: dateGroupLabel.previousMessageIndex
 
+    signal closeActivityCenter()
+
     implicitHeight: Math.max(60, bodyLoader.height +
                                  (dateGroupLabel.visible ? dateGroupLabel.height : 0) +
                                  (badgeLoader.item ? badgeLoader.height + Style.current.smallPadding : 0))
@@ -47,7 +49,7 @@ Item {
         id: badgeLoader
         anchors.bottom: parent.bottom
         anchors.left: parent.left
-        anchors.leftMargin: 61 // TODO find a way to align with the text of the message
+        anchors.leftMargin: 50 // TODO find a way to align with the text of the message
     }
 
     Loader {

--- a/ui/app/mainui/activitycenter/views/ActivityNotificationCommunityInvitation.qml
+++ b/ui/app/mainui/activitycenter/views/ActivityNotificationCommunityInvitation.qml
@@ -25,11 +25,11 @@ ActivityNotificationMessage {
 
         onCommunityNameClicked: {
             root.store.setActiveCommunity(notification.message.communityId)
-            root.activityCenterClose()
+            root.closeActivityCenter()
         }
         onChannelNameClicked: {
             root.activityCenterStore.switchTo(notification)
-            root.activityCenterClose()
+            root.closeActivityCenter()
         }
     }
 }

--- a/ui/app/mainui/activitycenter/views/ActivityNotificationCommunityMembershipRequest.qml
+++ b/ui/app/mainui/activitycenter/views/ActivityNotificationCommunityMembershipRequest.qml
@@ -13,63 +13,30 @@ import shared.views.chat 1.0
 import "../controls"
 import "../panels"
 
-ActivityNotificationBase {
+ActivityNotificationMessage {
     id: root
 
-    property var messageContextMenu
+    readonly property var contactDetails: Utils.getContactDetailsAsJson(notification.author)
 
-    signal activityCenterClose()
+    messageDetails.messageText: qsTr("Wants to join")
+    messageDetails.sender.displayName: contactDetails.displayName
+    messageDetails.sender.secondaryName: contactDetails.localNickname
+    messageDetails.sender.profileImage.name: contactDetails.displayIcon
+    messageDetails.sender.profileImage.assetSettings.isImage: true
+    messageDetails.sender.profileImage.pubkey: notification.author
+    messageDetails.sender.profileImage.colorId: Utils.colorIdForPubkey(notification.author)
+    messageDetails.sender.profileImage.colorHash: Utils.getColorHashAsJson(notification.author, false, true)
 
-    bodyComponent: MessageView {
-        readonly property var contactDetails: Utils.getContactDetailsAsJson(notification.author)
+    messageBadgeComponent: CommunityBadge {
+        readonly property var community: root.store.getCommunityDetailsAsJson(notification.communityId)
 
-        rootStore: root.store
-        messageStore: root.store.messageStore
-        messageId: notification.id
-        messageText: qsTr("Wants to join")
-        messageTimestamp: notification.timestamp
-        senderId: notification.author
-        senderIcon: contactDetails.displayIcon
-        senderDisplayName: contactDetails.displayName
-        senderOptionalName: contactDetails.localNickname
-        messageContextMenu: root.messageContextMenu
-        activityCenterMessage: true
-        activityCenterMessageRead: false
-        onImageClicked: Global.openImagePopup(image, root.messageContextMenu)
-        messageClickHandler: (sender,
-                        point,
-                        isProfileClick,
-                        isSticker = false,
-                        isImage = false,
-                        image = null,
-                        isEmoji = false,
-                        ideEmojiPicker = false,
-                        isReply = false,
-                        isRightClickOnImage = false,
-                        imageSource = "") => {
-            if (isProfileClick) {
-                return Global.openProfilePopup(notification.author)
-            }
+        communityName: community.name
+        communityImage: community.image
+        communityColor: community.color
 
-            root.activityCenterStore.switchTo(notification)
-            root.activityCenterClose()
-        }
-
-        CommunityBadge {
-            readonly property var community: root.store.getCommunityDetailsAsJson(notification.communityId)
-
-            anchors.verticalCenter: parent.verticalCenter
-            anchors.verticalCenterOffset: 15
-            anchors.left: parent.left
-            anchors.leftMargin: 160 // TODO: get right text margin
-            communityName: community.name
-            communityImage: community.image
-            communityColor: community.color
-
-            onCommunityNameClicked: {
-                root.store.setActiveCommunity(notification.communityId)
-                root.activityCenterClose()
-            }
+        onCommunityNameClicked: {
+            root.store.setActiveCommunity(notification.communityId)
+            root.closeActivityCenter()
         }
     }
 

--- a/ui/app/mainui/activitycenter/views/ActivityNotificationCommunityRequest.qml
+++ b/ui/app/mainui/activitycenter/views/ActivityNotificationCommunityRequest.qml
@@ -79,7 +79,7 @@ ActivityNotificationBase {
             font.pixelSize: 13
             onLinkActivated: {
                 root.store.setActiveCommunity(notification.communityId)
-                root.activityCenterClose()
+                root.closeActivityCenter()
             }
         }
     }

--- a/ui/app/mainui/activitycenter/views/ActivityNotificationContactRequest.qml
+++ b/ui/app/mainui/activitycenter/views/ActivityNotificationContactRequest.qml
@@ -14,6 +14,8 @@ import "../panels"
 ActivityNotificationMessage {
     id: root
 
+    maximumLineCount: 5
+
     ctaComponent: ContactRequestCta {
         readonly property string senderId: notification.message.senderId
         readonly property var contactDetails: Utils.getContactDetailsAsJson(senderId)

--- a/ui/app/mainui/activitycenter/views/ActivityNotificationMention.qml
+++ b/ui/app/mainui/activitycenter/views/ActivityNotificationMention.qml
@@ -41,11 +41,11 @@ ActivityNotificationMessage {
 
             onCommunityNameClicked: {
                 root.store.setActiveCommunity(notification.message.communityId)
-                root.activityCenterClose()
+                root.closeActivityCenter()
             }
             onChannelNameClicked: {
                 root.activityCenterStore.switchTo(notification)
-                root.activityCenterClose()
+                root.closeActivityCenter()
             }
         }
     }
@@ -65,7 +65,7 @@ ActivityNotificationMessage {
 
             onChannelNameClicked: {
                 root.activityCenterStore.switchTo(notification)
-                root.activityCenterClose()
+                root.closeActivityCenter()
             }
         }
     }

--- a/ui/app/mainui/activitycenter/views/ActivityNotificationReply.qml
+++ b/ui/app/mainui/activitycenter/views/ActivityNotificationReply.qml
@@ -17,7 +17,7 @@ ActivityNotificationMessage {
         repliedMessageContent: notification.repliedMessage.messageText
         onReplyClicked: {
             root.activityCenterStore.switchTo(notification)
-            root.activityCenterClose()
+            root.closeActivityCenter()
         }
     }
 }


### PR DESCRIPTION
Close #8285

### What does the PR do

- Replace MessageView in the Activity Center with custom ActivityNotificationMessage
- Limit AC notifications msg height in lines: contact and identity verification requests - 5, others - 2 
- Make AC notifications message plain (without stickers, links and etc),

### Affected areas

Activity Center

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it
<img width="548" alt="Screenshot 2022-11-17 at 17 05 20" src="https://user-images.githubusercontent.com/2522130/202454196-30566d99-c76f-4c7a-96ae-8846414674f8.png">

