### PR TITLE
fix(ChatHeaderContentView): reflect nickname changes in 1-1 chat

### DIFF
--- a/src/app/modules/main/chat_section/chat_content/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/module.nim
@@ -334,7 +334,7 @@ method onContactDetailsUpdated*(self: Module, contactId: string) =
         item.messageContainsMentions = m.containsContactMentions()
 
   if(self.controller.getMyChatId() == contactId):
-    self.view.updateChatDetailsNameAndIcon(updatedContact.details.displayName, updatedContact.icon)
+    self.view.updateChatDetailsNameAndIcon(updatedContact.defaultDisplayName, updatedContact.icon)
     self.view.updateTrustStatus(updatedContact.details.trustStatus == TrustStatus.Untrustworthy)
 
 method onNotificationsUpdated*(self: Module, hasUnreadMessages: bool, notificationCount: int) =

--- a/ui/app/AppLayouts/Chat/views/ChatHeaderContentView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatHeaderContentView.qml
@@ -267,18 +267,7 @@ Item {
             readonly property string emojiIcon: chatContentModule? chatContentModule.chatDetails.emoji : "" // Needed for test
 
             objectName: "chatInfoBtnInHeader"
-            title: {
-                const module = root.rootStore.currentChatContentModule()
-                if(!module)
-                    return ""
-
-                if (module.chatDetails.type === Constants.chatType.oneToOne) {
-                    const d = Utils.getContactDetailsAsJson(module.chatDetails.id)
-                    if (!!d.displayName)
-                        return d.displayName
-                }
-                return module.chatDetails.name
-            }
+            title: chatContentModule? chatContentModule.chatDetails.name : ""
 
             subTitle: {
                 if(!chatContentModule)


### PR DESCRIPTION
Fixes #8303

### What does the PR do

Fixes local nickname change not being reflected in 1-1 chat header

### Affected areas

ChatHeaderContentView

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

Before nickname change:
![image](https://user-images.githubusercontent.com/5377645/202416361-117996fb-f004-4d42-8c8c-9ce5e84f6dc9.png)

After nickname change:
![image](https://user-images.githubusercontent.com/5377645/202416445-abcd84af-6143-4caf-9014-ea81eb8c9a6b.png)

