### PR TITLE
fix(StatusPopupMenu): Refactoring

### DIFF
--- a/ui/StatusQ/sandbox/pages/StatusPopupMenuPage.qml
+++ b/ui/StatusQ/sandbox/pages/StatusPopupMenuPage.qml
@@ -22,8 +22,8 @@ GridLayout {
         onClicked: complexMenu.popup()
     }
 
-
     StatusButton {
+        id: customPopupButton
         text: "Menu with custom images and icons"
         onClicked: customMenu.popup()
     }
@@ -51,7 +51,6 @@ GridLayout {
 
     StatusPopupMenu {
         id: complexMenu
-        subMenuItemIcons: [{ icon: 'info' }]
 
         StatusMenuItem { 
             text: "One" 
@@ -65,13 +64,10 @@ GridLayout {
             assetSettings.name: "info"
         }
 
-        StatusMenuItem { 
-            text: "Three"
-            assetSettings.name: "info"
-        }
-
         StatusPopupMenu {
-            title: "Four"
+            title: "Two"
+            assetSettings.name: "info"
+
             StatusMenuItem { 
                 text: "One"
                 assetSettings.name: "info"
@@ -81,21 +77,21 @@ GridLayout {
                 assetSettings.name: "info"
             }
         }
+
+        StatusMenuItem {
+            text: "Disabled"
+            assetSettings.name: "info"
+            enabled: false
+        }
+
+        StatusMenuItem {
+            text: "Danger"
+            type: StatusMenuItem.Type.Danger
+        }
     }
 
     StatusPopupMenu {
         id: customMenu
-
-        subMenuItemIcons: [
-            { icon: "chat" },
-            { 
-                source: "qrc:/demoapp/data/profile-image-1.jpeg"
-            },
-            { 
-                isLetterIdenticon: true, 
-                color: "red" 
-            }
-        ]
 
         StatusMenuItem {
             text: "Anywhere"
@@ -104,14 +100,15 @@ GridLayout {
         StatusMenuSeparator {}
 
         StatusPopupMenu {
-            title: "Chat" 
+            title: "Chat"
+            assetSettings.name: "chat"
 
             StatusMenuItem { 
                 text: "vitalik.eth"
                 assetSettings.isImage: true
+                assetSettings.imgIsIdenticon: true
                 assetSettings.name: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADIAAAAyCAYAAAAeP4ixAAAAlklEQVR4nOzW0QmDQBAG4SSkl7SUQlJGCrElq9F3QdjjVhh/5nv3cFhY9vUIYQiNITSG0Bh
 CExPynn1gWf9bx498P7/nzPcxEzGExhBdJGYihtAYQlO+tUZvqrPbqeudo5iJGEJjCE15a3VtodH3q2ImYgiNITTlTdG1nUZ5a92VITQxITFiJmIIjSE0htAYQrMHAAD//+wwFVpz+yqXAAAAAElFTkSuQmCC"
-                assetSettings.imgIsIdenticon: true
             }
 
             StatusMenuItem { 
@@ -123,6 +120,8 @@ CExPynn1gWf9bx498P7/nzPcxEzGExhBdJGYihtAYQlO+tUZvqrPbqeudo5iJGEJjCE15a3VtodH3q2I
 
         StatusPopupMenu {
             title: "Cryptokitties"
+            assetSettings.isImage: true
+            assetSettings.name: "qrc:/demoapp/data/profile-image-1.jpeg"
 
             StatusMenuItem { 
                 text: "welcome" 
@@ -146,6 +145,8 @@ CExPynn1gWf9bx498P7/nzPcxEzGExhBdJGYihtAYQlO+tUZvqrPbqeudo5iJGEJjCE15a3VtodH3q2I
 
         StatusPopupMenu {
             title: "Another community"
+            assetSettings.isLetterIdenticon: true
+            assetSettings.bgColor: "red"
 
             StatusMenuItem { 
                 text: "welcome" 

--- a/ui/StatusQ/sandbox/pages/StatusSelectPage.qml
+++ b/ui/StatusQ/sandbox/pages/StatusSelectPage.qml
@@ -41,7 +41,6 @@ Column {
         model: commmonModel
 
         selectMenu.delegate: StatusMenuItemDelegate {
-            statusPopupMenu: select
             action: StatusMenuItem {
                 assetSettings.name: "filled-account"
                 text: name

--- a/ui/StatusQ/src/StatusQ/Popups/StatusMenuItem.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/StatusMenuItem.qml
@@ -9,17 +9,20 @@ Action {
         Normal,
         Danger
     }
-    icon.color: "transparent"
+
     property int type: StatusMenuItem.Type.Normal
-    property real iconRotation: 0
+
     property StatusAssetSettings assetSettings: StatusAssetSettings {
-        width: 16
-        height: 16
-        color: "transparent"
+        width: 18
+        height: 18
+        rotation: 0
         isLetterIdenticon: false
         imgIsIdenticon: false
+        color: "transparent"
         name: statusMenuItem.icon.name
     }
 
     property StatusFontSettings fontSettings: StatusFontSettings {}
+
+    icon.color: "transparent"
 }

--- a/ui/StatusQ/src/StatusQ/Popups/StatusPopupMenu.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/StatusPopupMenu.qml
@@ -10,20 +10,31 @@ import StatusQ.Popups 0.1
 
 Menu {
     id: root
+
     closePolicy: Popup.CloseOnPressOutside | Popup.CloseOnEscape
     topPadding: 8
     bottomPadding: 8
     bottomMargin: 16
 
-    property int menuItemCount: 0
-    property var subMenuItemIcons: []
+    property StatusAssetSettings assetSettings: StatusAssetSettings {
+        width: 18
+        height: 18
+        rotation: 0
+        isLetterIdenticon: false
+        isImage: false
+        color: "transparent"
+    }
+
+    property StatusFontSettings fontSettings: StatusFontSettings {}
+
+    property bool hideDisabledItems: false
 
     property var openHandler
     property var closeHandler
 
-    dim: false
-
     signal menuItemClicked(int menuIndex)
+
+    dim: false
 
     onOpened: {
         if (typeof openHandler === "function") {
@@ -37,9 +48,7 @@ Menu {
         }
     }
 
-    delegate: StatusMenuItemDelegate {
-        statusPopupMenu: root
-    }
+    delegate: StatusMenuItemDelegate { }
 
     contentItem: StatusListView {
         currentIndex: root.currentIndex

--- a/ui/StatusQ/src/StatusQ/Popups/StatusSearchLocationMenu.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/StatusSearchLocationMenu.qml
@@ -29,6 +29,8 @@ StatusPopupMenu {
     MenuItem { implicitHeight: 0.00001 }
     Instantiator {
         model: root.locationModel
+
+        // NOTE: Use DelegateChooser here
         delegate: Loader {
             sourceComponent: (!!model.subItems && model.subItems.count > 0) ? subMenus : subMenuItemComponent
             onLoaded: {
@@ -39,13 +41,13 @@ StatusPopupMenu {
                     item.parentIconName = model.iconName;
                     item.parentImageSource = model.imageSource;
                     item.parentIdenticonColor = !!model.iconColor ? model.iconColor : Theme.palette.primaryColor1;
-                    root.subMenuItemIcons.push({
-                                    source: model.imageSource,
-                                    icon: model.iconName,
-                                    isIdenticon: model.isIdenticon,
-                                    color: model.iconColor,
-                                    isLetterIdenticon: !model.imageSource && !model.iconName
-                                   });
+
+                    item.assetSettings.source = model.imageSource;
+                    item.assetSettings.isIdenticon = model.isIdenticon;
+                    item.assetSettings.name = model.iconName;
+                    item.assetSettings.color = model.iconColor;
+                    item.assetSettings.isLetterIdenticon = !model.imageSource && !model.iconName;
+
                     root.insertMenu(index + numDefaultItems, item);
                 } else {
                     item.value = model.value


### PR DESCRIPTION
Part of https://github.com/status-im/status-desktop/issues/7232
As continuation of https://github.com/status-im/StatusQ/pull/894.

⚠️  **NOTE:**
This is a PR to a temporary branch `fix/status-menu`
After this PR is merged, I will update and test the main application. And create a PR to `master`.

1. All Menu components are refactored.
2. Some UI improvements made:
    - Highlight menu when submenu opened
    - Proper colors for disabled menu items
3. I'm also planning to rename the components as following in a separate PR after testing with status-desktop

| Old name | New name |
| ---------- | ----------- |
| StatusPopupMenu | StatusMenu |
| StatusMenuItem | StatusAction |
| StatusMenuItemDelegate | StatusMenuItem |

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [x] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [x] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

https://user-images.githubusercontent.com/25482501/203008348-e0a7e043-8168-41b3-97a6-2efea8d02269.mov
