### PR TITLE
fix(StatusTextMessage): Add elide to TextEdit

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusTextMessage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusTextMessage.qml
@@ -69,12 +69,16 @@ Item {
         readonly property int effectiveHeight: d.veryLongChatText && !d.readMore
                                                ? Math.min(chatText.implicitHeight, 200)
                                                : chatText.implicitHeight
+        property FontMetrics metrics: FontMetrics {
+            font: chatText.font
+        }
 
         width: parent.width
         height: effectiveHeight + d.showMoreHeight / 2
         opacity: !showMoreOpacityMask.active && !horizontalOpacityMask.active ? 1 : 0
         clip: true
-        text: d.text
+        text: root.convertToSingleLine ? metrics.elidedText(d.text, Text.ElideRight, chatText.width)
+                                       : d.text
         selectedTextColor: Theme.palette.directColor1
         selectionColor: Theme.palette.primaryColor3
         color: Theme.palette.directColor1


### PR DESCRIPTION
Fixes: #7504

### What does the PR do

When `convertToSingleLine` is true, I add `elidedText` usage from `FontMetrics`

### Affected areas

Replies


### Screenshot of functionality (including design for comparison)

- [ ] I've checked the design and this PR matches it


<img width="756" alt="Снимок экрана 2022-11-21 в 12 54 08" src="https://user-images.githubusercontent.com/82511785/203021091-4d680047-3594-4398-9dbd-bf1b555538dd.png">
