### PR TITLE
fix(Settings): better error handling for toggling archive protocol

### DIFF
--- a/src/app/boot/app_controller.nim
+++ b/src/app/boot/app_controller.nim
@@ -136,7 +136,7 @@ proc newAppController*(statusFoundation: StatusFoundation): AppController =
   result.activityCenterService = activity_center_service.newService(statusFoundation.events, statusFoundation.threadpool)
   result.keycardService = keycard_service.newService(statusFoundation.events, statusFoundation.threadpool)
   result.nodeConfigurationService = node_configuration_service.newService(statusFoundation.fleetConfiguration,
-  result.settingsService)
+  result.settingsService, statusFoundation.events)
   result.keychainService = keychain_service.newService(statusFoundation.events)
   result.accountsService = accounts_service.newService(statusFoundation.events, statusFoundation.threadpool, 
     statusFoundation.fleetConfiguration)

--- a/src/app/modules/main/profile_section/advanced/controller.nim
+++ b/src/app/modules/main/profile_section/advanced/controller.nim
@@ -4,6 +4,7 @@ import io_interface
 import ../../../../global/app_signals
 import ../../../../core/eventemitter
 import ../../../../core/fleets/fleet_configuration
+import ../../../../../app_service/service/community/service
 import ../../../../../app_service/service/settings/service as settings_service
 import ../../../../../app_service/service/stickers/service as stickers_service
 import ../../../../../app_service/service/node_configuration/service as node_configuration_service
@@ -33,6 +34,9 @@ proc delete*(self: Controller) =
   discard
 
 proc init*(self: Controller) =
+  self.events.on(SIGNAL_ENABLE_COMMUNITY_ARCHIVE_FAILED) do(e:Args):
+    let args = ErrorArgs(e)
+    self.delegate.enableCommunityHistoryArchiveSupportFailed(args.msg)
   discard
 
 proc getFleet*(self: Controller): string =

--- a/src/app/modules/main/profile_section/advanced/io_interface.nim
+++ b/src/app/modules/main/profile_section/advanced/io_interface.nim
@@ -101,3 +101,6 @@ method isCommunityHistoryArchiveSupportEnabled*(self: AccessInterface): bool {.b
 
 method toggleCommunityHistoryArchiveSupport*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
+
+method enableCommunityHistoryArchiveSupportFailed*(self: AccessInterface, msg: string) {.base.} =
+  raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/profile_section/advanced/module.nim
+++ b/src/app/modules/main/profile_section/advanced/module.nim
@@ -139,3 +139,7 @@ method toggleCommunityHistoryArchiveSupport*(self: Module) =
 
 method isCommunityHistoryArchiveSupportEnabled*(self: Module): bool =
   self.controller.isCommunityHistoryArchiveSupportEnabled()
+
+method enableCommunityHistoryArchiveSupportFailed*(self: Module, msg: string) =
+  self.view.setEnableCommunityHistoryArchiveSupportFailedMsg(msg)
+  self.view.enableCommunityHistoryArchiveSupportFailed()

--- a/src/app/modules/main/profile_section/advanced/view.nim
+++ b/src/app/modules/main/profile_section/advanced/view.nim
@@ -5,6 +5,7 @@ QtObject:
   type
     View* = ref object of QObject
       delegate: io_interface.AccessInterface
+      enableCommunityHistoryArchiveSupportFailedMsg*: string
 
   proc delete*(self: View) =
     self.QObject.delete
@@ -16,6 +17,19 @@ QtObject:
 
   proc load*(self: View) =
     self.delegate.viewDidLoad()
+
+  proc enableCommunityHistoryArchiveSupportFailedMsgChanged*(self: View) {.signal.}
+  proc getEnableCommunityHistoryArchiveSupportFailedMsg*(self: View): string {.slot.} =
+    return self.enableCommunityHistoryArchiveSupportFailedMsg
+  QtProperty[string] enableCommunityHistoryArchiveSupportFailedMsg:
+    read = getEnableCommunityHistoryArchiveSupportFailedMsg
+    notify = enableCommunityHistoryArchiveSupportFailedMsgChanged
+
+  proc setEnableCommunityHistoryArchiveSupportFailedMsg*(self: View, msg: string) {.slot.} =
+    self.enableCommunityHistoryArchiveSupportFailedMsg = msg
+    self.enableCommunityHistoryArchiveSupportFailedMsgChanged()
+
+  proc enableCommunityHistoryArchiveSupportFailed*(self: View) {.signal.}
 
   proc fleetChanged*(self: View) {.signal.}
   proc getFleet*(self: View): string {.slot.} =

--- a/src/app_service/service/community/service.nim
+++ b/src/app_service/service/community/service.nim
@@ -119,6 +119,8 @@ const SIGNAL_CURATED_COMMUNITY_FOUND* = "curatedCommunityFound"
 const SIGNAL_COMMUNITY_MUTED* = "communityMuted"
 const SIGNAL_CATEGORY_MUTED* = "categoryMuted"
 const SIGNAL_CATEGORY_UNMUTED* = "categoryUnmuted"
+
+const SIGNAL_ENABLE_COMMUNITY_ARCHIVE_FAILED* = "enableCommunityHistoryArchiveSupportFailed"
 const SIGNAL_DISCORD_CATEGORIES_AND_CHANNELS_EXTRACTED* = "discordCategoriesAndChannelsExtracted"
 const SIGNAL_DISCORD_COMMUNITY_IMPORT_FINISHED* = "discordCommunityImportFinished"
 const SIGNAL_DISCORD_COMMUNITY_IMPORT_PROGRESS* = "discordCommunityImportProgress"

--- a/ui/app/AppLayouts/Profile/stores/AdvancedStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/AdvancedStore.qml
@@ -14,6 +14,7 @@ QtObject {
     property bool isAutoMessageEnabled: advancedModule? advancedModule.isAutoMessageEnabled : false
     property bool isDebugEnabled: advancedModule? advancedModule.isDebugEnabled : false
     property bool isCommunityHistoryArchiveSupportEnabled: advancedModule? advancedModule.isCommunityHistoryArchiveSupportEnabled : false
+    property string enableCommunityHistoryArchiveSupportFailedMsg: advancedModule ? advancedModule.enableCommunityHistoryArchiveSupportFailedMsg : ""
 
     property var customNetworksModel: advancedModule? advancedModule.customNetworksModel : []
 
@@ -35,6 +36,17 @@ QtObject {
         readonly property string communityPermissions: "communityPermissions"
         readonly property string discordImportTool: "discordImportTool"
     }
+
+    readonly property Connections connections: Connections {
+        target: advancedModule
+        function onEnableCommunityHistoryArchiveSupportFailed() {
+            root.enableCommunityHistoryArchiveSupportFailed()
+        }
+    }
+
+
+    signal enableCommunityHistoryArchiveSupportFailed()
+
 
     function logDir() {
         if(!root.advancedModule)

--- a/ui/app/AppLayouts/Profile/views/AdvancedView.qml
+++ b/ui/app/AppLayouts/Profile/views/AdvancedView.qml
@@ -1,5 +1,6 @@
 import QtQuick 2.13
 import QtQuick.Controls 2.13
+import QtQml.Models 2.14
 import QtQuick.Layouts 1.13
 import QtGraphicalEffects 1.13
 
@@ -10,6 +11,8 @@ import shared.popups 1.0
 import shared.status 1.0
 
 import StatusQ.Core 0.1
+import StatusQ.Popups.Dialog 0.1
+import StatusQ.Controls 0.1
 
 import "../stores"
 import "../controls"
@@ -534,6 +537,39 @@ SettingsContentBase {
 
             onCancelButtonClicked: {
                 close()
+            }
+        }
+
+        Connections {
+            target: advancedStore
+            function onEnableCommunityHistoryArchiveSupportFailed() {
+              if (root.advancedStore.enableCommunityHistoryArchiveSupportFailedMsg !== "") {
+                Global.openPopup(errorMessageDialogCmp, {
+                  errorMessage: root.advancedStore.enableCommunityHistoryArchiveSupportFailedMsg
+                })
+              }
+            }
+        }
+
+        Component {
+            id: errorMessageDialogCmp
+            StatusDialog {
+                id: errorMessageDialog
+                property string errorMessage: ""
+                title: qsTr("An error occoured")
+
+                StatusBaseText {
+                    anchors.fill: parent
+                    text: {
+                      if (errorMessageDialog.errorMessage.indexOf("address already in use") > -1) {
+                        return qsTr("The specified torrent client port is already in use.")
+                      }
+                      return errorMessageDialog.errorMessage
+                    }
+                }
+
+                standardButtons: Dialog.Ok
+                onAccepted: errorMessageDialog.close()
             }
         }
     }


### PR DESCRIPTION
Enabling the community archive protocol could fail when another app is using the same port that is specified as torrent client port.

This would cause the app to crash.

With these changes we:

1. No longer crash the app but output an error in the logs
2. We popup a dialog telling the user that the specified pord is in use

Closes #7328


