### PR TITLE
fix: disable quick actions when editting a message

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
@@ -209,6 +209,9 @@ Control {
         ColumnLayout {
             id: messageLayout
             anchors.fill: parent
+            anchors.topMargin: 2
+            anchors.bottomMargin: 2
+            spacing: 2
 
             Loader {
                 Layout.fillWidth: true
@@ -234,7 +237,6 @@ Control {
                     implicitWidth: root.messageDetails.sender.profileImage.assetSettings.width
                     implicitHeight: profileImage.visible ? profileImage.height : 0
                     Layout.alignment: Qt.AlignTop
-                    Layout.topMargin: 2
                     StatusSmartIdenticon {
                         id: profileImage
                         active: root.showHeader

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -386,8 +386,6 @@ Loader {
             StatusMessage {
                 id: delegate
                 Layout.fillWidth: true
-                Layout.topMargin: 2
-                Layout.bottomMargin: 2
                 function convertContentType(value) {
                     switch (value) {
                     case Constants.messageContentType.messageType:
@@ -477,7 +475,8 @@ Loader {
                 hideQuickActions: root.isChatBlocked ||
                                   root.placeholderMessage ||
                                   root.activityCenterMessage ||
-                                  root.isInPinnedPopup
+                                  root.isInPinnedPopup ||
+                                  root.editModeOn
                 hideMessage: d.isSingleImage && d.unfurledLinksCount === 1
 
                 overrideBackground: root.activityCenterMessage || root.placeholderMessage


### PR DESCRIPTION
also move the top/bottom margins one level up so that the message editor gets the same margins as well

Fixes: #8185

### What does the PR do

Removed quick action when editing a message

### Affected areas

StatusMessage/MessageView

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![image](https://user-images.githubusercontent.com/5377645/203103441-43b78a9c-dfaf-4734-b8b6-dfbcad6b0b27.png)


