### PR TITLE
fix(windows): remove extra -m option from aqt install

### DIFF
--- a/scripts/windows_build_setup.ps1
+++ b/scripts/windows_build_setup.ps1
@@ -26,7 +26,7 @@ function Install-Dependencies {
 function Install-Qt-SDK {
     Write-Host "Installing Qt $QtVersion SDK..."
     pip install aqtinstall
-    aqt install --output "C:\Qt" $QtVersion windows desktop win64_msvc2017_64 -m qtwebengine -m qtlottie
+    aqt install --output "C:\Qt" $QtVersion windows desktop win64_msvc2017_64 -m qtwebengine qtlottie
 }
 
 # Install Microsoft Visual C++ Build Tools 15.8.9


### PR DESCRIPTION
As per the documentation of aqt, we just need one `-m` and list the modules after. It seems like the first -m is ignored otherwise.

https://aqtinstall.readthedocs.io/en/latest/cli.html#cmdoption-list-tool-modules