### PR TITLE
fix(AboutView): Version text is still black on dark mode

### DIFF
--- a/ui/app/AppLayouts/Profile/views/AboutView.qml
+++ b/ui/app/AppLayouts/Profile/views/AboutView.qml
@@ -43,7 +43,6 @@ SettingsContentBase {
 
             StatusBaseText {
                 anchors.horizontalCenter: parent.horizontalCenter
-                color: Theme.palette.textColor
                 font.pixelSize: 22
                 font.bold: true
                 text: root.store.getCurrentVersion()
@@ -51,7 +50,6 @@ SettingsContentBase {
 
             StatusBaseText {
                 anchors.horizontalCenter: parent.horizontalCenter
-                color: Theme.palette.textColor
                 font.pixelSize: 15
                 text: qsTr("Current Version")
             }


### PR DESCRIPTION
use the default (existing) color for the text

Fixes #8374

### What does the PR do

fixes text color in dark mode

### Affected areas

AboutView

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![image](https://user-images.githubusercontent.com/5377645/203280305-8071c684-0ee0-4497-b46e-ed4f6d4d376d.png)
