### PR TITLE
fix(PinnedMessagesPopup): Pinned messages cover rounded corners of modal

### DIFF
--- a/ui/app/AppLayouts/Chat/popups/PinnedMessagesPopup.qml
+++ b/ui/app/AppLayouts/Chat/popups/PinnedMessagesPopup.qml
@@ -2,6 +2,7 @@ import QtQuick 2.14
 import QtQuick.Controls 2.14
 import QtQuick.Layouts 1.14
 import QtQml.Models 2.14
+import QtGraphicalEffects 1.14
 
 import StatusQ.Core 0.1
 import StatusQ.Controls 0.1
@@ -25,16 +26,12 @@ StatusDialog {
     padding: 0
 
     title: root.messageToPin ? qsTr("Pin limit reached") : qsTr("Pinned messages")
-
-    header: StatusDialogHeader {
-        visible: root.title
-        headline.title: root.title
-        headline.subtitle: root.messageToPin ? qsTr("Unpin a previous message first")
-                                              : qsTr("%n message(s)", "", pinnedMessageListView.count)
-        actions.closeButton.onClicked: root.close()
-    }
+    subtitle: root.messageToPin ? qsTr("Unpin a previous message first")
+                                : qsTr("%n message(s)", "", pinnedMessageListView.count)
 
     contentItem: ColumnLayout {
+        id: column
+
         StatusBaseText {
             visible: pinnedMessageListView.count === 0
             text: qsTr("Pinned messages will appear here.")
@@ -141,6 +138,21 @@ StatusDialog {
 
             onJumpToMessage: {
                 root.messageStore.messageModule.jumpToMessage(messageId)
+            }
+        }
+
+        layer.enabled: root.visible
+        layer.effect: OpacityMask {
+            maskSource: Rectangle {
+                width: column.width
+                height: column.height
+                radius: background.radius
+
+                Rectangle {
+                    width: parent.width
+                    height: parent.radius
+                    anchors.top: parent.top
+                }
             }
         }
     }


### PR DESCRIPTION
similar to the profile dialog, we need to add an opacity mask in front of the contentItem to ensure the rounded corners at the bottom are preserved when we have no margins/padding inside the popup

Fixes #7759

### What does the PR do

Fixes rounded corners at the bottom 

### Affected areas

PinnedMessagesPopup

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![Snímek obrazovky z 2022-11-22 12-22-42](https://user-images.githubusercontent.com/5377645/203302977-00292110-359c-489a-9c00-b164d464e1de.png)

