### PR TITLE
ci: separate buckets for mobile and desktop builds

### DIFF
--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.5.6'
+library 'status-jenkins-lib@v1.6.2'
 
 pipeline {
   agent { label 'linux' }

--- a/ci/Jenkinsfile.imports
+++ b/ci/Jenkinsfile.imports
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.5.1'
+library 'status-jenkins-lib@v1.6.2'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.5.6'
+library 'status-jenkins-lib@v1.6.2'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/Jenkinsfile.linux-cpp
+++ b/ci/Jenkinsfile.linux-cpp
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.5.6'
+library 'status-jenkins-lib@v1.6.2'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.5.6'
+library 'status-jenkins-lib@v1.6.2'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/Jenkinsfile.macos-cpp.todo
+++ b/ci/Jenkinsfile.macos-cpp.todo
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.5.6'
+library 'status-jenkins-lib@v1.6.2'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/Jenkinsfile.uitests
+++ b/ci/Jenkinsfile.uitests
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.5.1'
+library 'status-jenkins-lib@v1.6.2'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/Jenkinsfile.windows
+++ b/ci/Jenkinsfile.windows
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.5.6'
+library 'status-jenkins-lib@v1.6.2'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/Jenkinsfile.windows-cpp.todo
+++ b/ci/Jenkinsfile.windows-cpp.todo
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.5.6'
+library 'status-jenkins-lib@v1.6.2'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()


### PR DESCRIPTION
Possible fix for slow upload speeds and failures caused by most probably hitting per-bucket rate limits of DigitalOcean:

>- 500 total operations per second to any individual bucket.
>- 300 combined PUT, POST, COPY, DELETE, and LIST operations per second
>  to any individual Space. We may further limit LIST operations if
>  necessary under periods of high load.

https://docs.digitalocean.com/products/spaces/details/limits/#rate-limits

Depends on: https://github.com/status-im/status-jenkins-lib/pull/52