### PR TITLE
ci: clarify why we ignore UNSTABLE squish state

### DIFF
--- a/ci/Jenkinsfile.e2e
+++ b/ci/Jenkinsfile.e2e
@@ -139,6 +139,7 @@ pipeline {
             testSuite: "${WORKSPACE}/test/ui-test/testSuites/*",
           ])
           print("Squish run result: ${result}")
+          /* Ignore UNSTABLE caused by retried tests. */
           if (!['SUCCESS', 'UNSTABLE'].contains(result)) {
             throw new Exception('Squish run failed!')
           }


### PR DESCRIPTION
I tried using `--exitCodeOnFail` but it didn't work.
https://doc.qt.io/squish/cli-squishrunner.html#playback-option-op-op-op-op-exitcodeonfail