### PR TITLE
fix(communities): handle removed community chats properly

### DIFF
--- a/src/app/core/signals/remote_signals/messages.nim
+++ b/src/app/core/signals/remote_signals/messages.nim
@@ -26,6 +26,7 @@ type MessageSignal* = ref object of Signal
   activityCenterNotifications*: seq[ActivityCenterNotificationDto]
   statusUpdates*: seq[StatusUpdateDto]
   deletedMessages*: seq[RemovedMessageDto]
+  removedChats*: seq[string]
   currentStatus*: seq[StatusUpdateDto]
   settings*: seq[SettingsFieldDto]
   clearedHistories*: seq[ClearedHistoryDto]
@@ -104,6 +105,10 @@ proc fromEvent*(T: type MessageSignal, event: JsonNode): MessageSignal =
   if event["event"]{"removedMessages"} != nil:
     for jsonRemovedMessage in event["event"]["removedMessages"]:
       signal.deletedMessages.add(jsonRemovedMessage.toRemovedMessageDto())
+
+  if event["event"]{"removedChats"} != nil:
+    for removedChatID in event["event"]["removedChats"]:
+      signal.removedChats.add(removedChatID.getStr())
 
   if event["event"]{"activityCenterNotifications"} != nil:
     for jsonNotification in event["event"]["activityCenterNotifications"]:


### PR DESCRIPTION
We were ignoring the `removedChats` in the messenger response and therefore never processed deleted community chats in the client.

This commit adds `removedChats` to `handleCommunityUpdates()` and ensures that the community channel's ID is used when emitting a signal to the app.

This needs: https://github.com/status-im/status-go/pull/2973

Closes #8000

