### PR TITLE
Fix/stickers test

### DIFF
--- a/src/app/modules/main/stickers/controller.nim
+++ b/src/app/modules/main/stickers/controller.nim
@@ -82,6 +82,9 @@ proc init*(self: Controller) =
   self.events.on(SIGNAL_ALL_STICKER_PACKS_LOADED) do(e: Args):
     self.delegate.allPacksLoaded()
 
+  self.events.on(SIGNAL_ALL_STICKER_PACKS_LOAD_FAILED) do(e: Args):
+    self.delegate.allPacksLoadFailed()
+
   self.events.on(SIGNAL_STICKER_GAS_ESTIMATED) do(e: Args):
     let args = StickerGasEstimatedArgs(e)
     self.delegate.gasEstimateReturned(args.estimate, args.uuid)

--- a/src/app/modules/main/stickers/io_interface.nim
+++ b/src/app/modules/main/stickers/io_interface.nim
@@ -40,6 +40,9 @@ method getNumInstalledStickerPacks*(self: AccessInterface): int {.base.} =
 method allPacksLoaded*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method allPacksLoadFailed*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method estimate*(self: AccessInterface, packId: string, address: string, price: string, uuid: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/stickers/module.nim
+++ b/src/app/modules/main/stickers/module.nim
@@ -158,6 +158,9 @@ method clearStickerPacks*(self: Module) =
 method allPacksLoaded*(self: Module) =
   self.view.allPacksLoaded()
 
+method allPacksLoadFailed*(self: Module) =
+  self.view.allPacksLoadFailed()
+
 method populateInstalledStickerPacks*(self: Module, stickers: Table[string, StickerPackDto]) =
   var stickerPackItems: seq[PackItem] = @[]
   for stickerPack in stickers.values:

--- a/src/app/modules/main/stickers/view.nim
+++ b/src/app/modules/main/stickers/view.nim
@@ -9,6 +9,7 @@ QtObject:
     View* = ref object of QObject
       delegate: io_interface.AccessInterface
       packsLoaded*: bool
+      packsLoadFailed*: bool
       stickerPacks*: StickerPackList
       recentStickers*: StickerList
       signingPhrase: string
@@ -66,6 +67,8 @@ QtObject:
 
   proc stickerPacksLoaded*(self: View) {.signal.}
 
+  proc packsLoadFailedChanged*(self: View) {.signal.}
+
   proc installedStickerPacksUpdated*(self: View) {.signal.}
 
   proc clearStickerPacks*(self: View) =
@@ -110,8 +113,22 @@ QtObject:
 
   proc allPacksLoaded*(self: View) =
     self.packsLoaded = true
+    self.packsLoadFailed = false
+
     self.stickerPacksLoaded()
+    self.packsLoadFailedChanged()
     self.installedStickerPacksUpdated()
+
+  proc allPacksLoadFailed*(self: View) =
+    self.packsLoadFailed = true
+    self.packsLoadFailedChanged()
+
+  proc getPacksLoadFailed(self: View): bool {.slot.} =
+    self.packsLoadFailed
+
+  QtProperty[bool] packsLoadFailed:
+    read = getPacksLoadFailed
+    notify = packsLoadFailedChanged
 
   proc send*(self: View, channelId: string, hash: string, replyTo: string, pack: string, url: string) {.slot.} =
     let sticker = initItem(hash, pack, url)

--- a/src/app/modules/main/stickers/view.nim
+++ b/src/app/modules/main/stickers/view.nim
@@ -130,6 +130,14 @@ QtObject:
     read = getPacksLoadFailed
     notify = packsLoadFailedChanged
 
+  proc loadStickers(self: View) {.slot.} =
+    self.packsLoaded = false
+    self.packsLoadFailed = false
+    self.stickerPacksLoaded()
+    self.packsLoadFailedChanged()
+
+    self.delegate.obtainMarketStickerPacks()
+
   proc send*(self: View, channelId: string, hash: string, replyTo: string, pack: string, url: string) {.slot.} =
     let sticker = initItem(hash, pack, url)
     self.addRecentStickerToList(sticker)

--- a/test/ui-test/src/screens/StatusChatScreen.py
+++ b/test/ui-test/src/screens/StatusChatScreen.py
@@ -76,6 +76,7 @@ class ChatComponents(Enum):
 
 class ChatStickerPopup(Enum):
     STICKERS_POPUP_GET_STICKERS_BUTTON = "chat_StickersPopup_GetStickers_Button"
+    STICKERS_POPUP_RETRY_BUTTON = "chat_StickersPopup_Retry_Button"
     STICKERS_POPUP_MARKET_GRID_VIEW = "chat_StickersPopup_StickerMarket_GridView"
     STICKERS_POPUP_MARKET_GRID_VIEW_DELEGATE_ITEM_1 = "chat_StickersPopup_StickerMarket_DelegateItem_1"
     STICKERS_POPUP_MARKET_INSTALL_BUTTON = "chat_StickersPopup_StickerMarket_Install_Button"
@@ -272,9 +273,25 @@ class StatusChatScreen:
         click_obj_by_name(ChatStickerPopup.STICKERS_POPUP_GET_STICKERS_BUTTON.value)
         
         # Wait for grid view to be loaded
-        loaded, grid_view = is_loaded_visible_and_enabled(ChatStickerPopup.STICKERS_POPUP_MARKET_GRID_VIEW.value)
-        if (not loaded):
-            verify_failure("Sticker market grid view is not loaded")
+        grid_view_displayed, grid_view = is_loaded_visible_and_enabled(ChatStickerPopup.STICKERS_POPUP_MARKET_GRID_VIEW.value)
+        verify(grid_view_displayed, "Sticker market grid view is not loaded")
+        
+        # Stickers may not be loaded, retry to load them
+        stickers_not_loaded = is_displayed(ChatStickerPopup.STICKERS_POPUP_RETRY_BUTTON.value)
+        if (stickers_not_loaded):
+            click_obj_by_name(ChatStickerPopup.STICKERS_POPUP_RETRY_BUTTON.value)
+        
+        # Wait for stickers to load
+        stickers_grid_displayed = is_displayed(ChatStickerPopup.STICKERS_POPUP_MARKET_GRID_VIEW_DELEGATE_ITEM_1.value)
+        
+        # In the meantime popup may be closed due to external (unknown?) reason, reopen it
+        if (not stickers_grid_displayed):
+            grid_view_displayed = is_displayed(ChatStickerPopup.STICKERS_POPUP_MARKET_GRID_VIEW.value)
+            if (not grid_view_displayed):
+                click_obj_by_name(ChatComponents.CHAT_INPUT_STICKER_BUTTON.value)
+                click_obj_by_name(ChatStickerPopup.STICKERS_POPUP_GET_STICKERS_BUTTON.value)
+                grid_view_displayed, grid_view = is_loaded_visible_and_enabled(ChatStickerPopup.STICKERS_POPUP_MARKET_GRID_VIEW.value)
+                verify(grid_view_displayed, "Sticker market grid view is not loaded")
           
         # Wait for the items in the GridView to be loaded
         verify(is_displayed(ChatStickerPopup.STICKERS_POPUP_MARKET_GRID_VIEW_DELEGATE_ITEM_1.value), "Sticker item 0 is not displayed")

--- a/test/ui-test/testSuites/suite_messaging/shared/scripts/chat_names.py
+++ b/test/ui-test/testSuites/suite_messaging/shared/scripts/chat_names.py
@@ -54,6 +54,7 @@ chatView_chatMembers_ListView = {"container": statusDesktop_mainWindow, "objectN
 
 # Stickers Popup
 chat_StickersPopup_GetStickers_Button = {"container": statusDesktop_mainWindow_overlay, "objectName": "stickersPopupGetStickersButton", "type": "StatusButton", "visible": True}
+chat_StickersPopup_Retry_Button = {"container": statusDesktop_mainWindow_overlay, "objectName": "stickersPopupRetryButton", "type": "StatusButton", "visible": True}
 chat_StickersPopup_StickerMarket_GridView = {"container": statusDesktop_mainWindow_overlay, "objectName": "stickerMarketStatusGridView", "type": "StatusGridView", "visible": True}
 chat_StickersPopup_StickerMarket_DelegateItem_1 = {"container": chat_StickersPopup_StickerMarket_GridView, "objectName": "stickerMarketDelegateItem1", "type": "Item", "visible": True}
 chat_StickersPopup_StickerMarket_Install_Button = {"container": statusDesktop_mainWindow_overlay, "objectName": "statusStickerMarketInstallButton", "type": "StatusStickerButton", "visible": True}

--- a/test/ui-test/testSuites/suite_messaging/tst_ChatFlow/test.feature
+++ b/test/ui-test/testSuites/suite_messaging/tst_ChatFlow/test.feature
@@ -160,8 +160,8 @@ Feature: Status Desktop Chat Basic Flows
     	Then the last chat message contains "🙂"
     	And the last chat message contains "Hello"
 
- 	@mayfail
-	# TODO: It works standalone but when it runs as part of the sequence and mostly in the CI, the action of verification doesn't work.
+	@mayfail
+	# NOTE: It may be flaky due to undeterministic network conditions and 3rd party infura response.
     Scenario: The user can send a sticker after installing a free pack
          Given the user installs the sticker pack at position 4
          When the user sends the sticker at position 2 in the list

--- a/ui/imports/shared/status/StatusStickersPopup.qml
+++ b/ui/imports/shared/status/StatusStickersPopup.qml
@@ -103,6 +103,26 @@ Popup {
                 active: d.stickerPacksLoading
                 sourceComponent: loadingImageComponent
             }
+
+            ColumnLayout {
+                id: failedToLoadStickersInfo
+
+                anchors.centerIn: parent
+                visible: d.stickerPacksLoadFailed
+
+                StatusBaseText {
+                    text: qsTr("Failed to load stickers")
+                    color: Theme.palette.dangerColor1
+                }
+
+                StatusButton {
+                    objectName: "stickersPopupRetryButton"
+                    Layout.alignment: Qt.AlignHCenter
+                    text: qsTr("Try again")
+
+                    onClicked: d.loadStickers()
+                }
+            }
         }
 
         Item {


### PR DESCRIPTION
### What does the PR do

fixes: https://github.com/status-im/status-desktop/issues/7995 ("The user can send a sticker after installing a free pack" squish scenario)

#### Problems:
1. For some reason stickers are not loaded for the first time under the Squish environment.
    Sometimes (but very rarely) it happens also in the non-Squish environment. It happens due to the failure of loading stickerpack data: `lvl=warn msg="Could not retrieve stickerpack data" packID=4 error="could not load ipfs data"`. 
3. Sometimes stickers popup is closed out of control due to some internal app event, see video at 0:25.

#### Solutions:

AD 1. Inform user about fetch failure and give user the ability to retry fetching sticker data. Make squish fetch the stickers if they are not available straight away.
Ad 2. Make squish ensure the popup is opened just before verifying stickers are loaded.

### Affected areas

stickers popup

### Video

https://user-images.githubusercontent.com/33099791/203574249-5363a44c-2a80-4486-ac82-0e2809d9a2f0.mp4


