### PR TITLE
hotfix(ActivityCenter): Fix binding loop for previousMessageIndex

### DIFF
--- a/src/app/modules/main/activity_center/view.nim
+++ b/src/app/modules/main/activity_center/view.nim
@@ -113,12 +113,6 @@ QtObject:
     self.model.removeNotifications(notificationIds)
 
   proc addActivityCenterNotification*(self: View, activityCenterNotifications: seq[Item]) =
-      # TODO this should be handled by the chat or community module
-      # if self.channelView.activeChannel.id == activityCenterNotification.chatId:
-      #   activityCenterNotification.read = true
-      #   let communityId = self.status.chat.getCommunityIdForChat(activityCenterNotification.chatId)
-      #   if communityId != "":
-      #     self.communities.joinedCommunityList.decrementMentions(communityId, activityCenterNotification.chatId)
     self.model.addActivityNotificationItemsToList(activityCenterNotifications)
 
   proc switchTo*(self: View, sectionId: string, chatId: string, messageId: string) {.slot.} =

--- a/ui/StatusQ/src/StatusQ/Components/StatusDateGroupLabel.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusDateGroupLabel.qml
@@ -1,12 +1,12 @@
 import QtQuick 2.14
 
 import StatusQ.Core 0.1
+import StatusQ.Core.Utils 0.1
 import StatusQ.Core.Theme 0.1
 
 StatusBaseText {
     id: root
 
-    property int previousMessageIndex: -1
     property double previousMessageTimestamp
     property double messageTimestamp
 
@@ -15,13 +15,10 @@ StatusBaseText {
     horizontalAlignment: Text.AlignHCenter
 
     text: {
-        if (previousMessageIndex === -1)
-            return "";
+        const currentMsgDate = new Date(messageTimestamp)
+        const prevMsgDate = new Date(previousMessageTimestamp)
 
-        const currentMsgDate = new Date(messageTimestamp);
-        const prevMsgDate = new Date(previousMessageTimestamp);
-
-        if (!!prevMsgDate && currentMsgDate.getDay() === prevMsgDate.getDay())
+        if (prevMsgDate > 0 && currentMsgDate.getDay() === prevMsgDate.getDay())
             return "";
 
         const now = new Date();
@@ -29,7 +26,7 @@ StatusBaseText {
             return qsTr("Today");
 
         const yesterday = new Date();
-        yesterday.setDate(now.getDate()-1);
+        yesterday.setDate(now.getDate() - 1);
         if (yesterday.getFullYear() == currentMsgDate.getFullYear() && yesterday.getMonth() == currentMsgDate.getMonth() && yesterday.getDate() == currentMsgDate.getDate())
             return qsTr("Yesterday");
 

--- a/ui/app/mainui/activitycenter/popups/ActivityCenterPopup.qml
+++ b/ui/app/mainui/activitycenter/popups/ActivityCenterPopup.qml
@@ -187,10 +187,10 @@ Popup {
 
                 ActivityNotificationMention {
                     width: listView.availableWidth
+                    filteredIndex: index
                     store: root.store
                     activityCenterStore: root.activityCenterStore
                     notification: model
-                    previousNotificationIndex: Math.min(listView.count - 1, index + 1)
                     onCloseActivityCenter: root.close()
                 }
             }
@@ -199,10 +199,10 @@ Popup {
 
                 ActivityNotificationReply {
                     width: listView.availableWidth
+                    filteredIndex: index
                     store: root.store
                     activityCenterStore: root.activityCenterStore
                     notification: model
-                    previousNotificationIndex: Math.min(listView.count - 1, index + 1)
                     onCloseActivityCenter: root.close()
                 }
             }
@@ -211,10 +211,10 @@ Popup {
 
                 ActivityNotificationContactRequest {
                     width: listView.availableWidth
+                    filteredIndex: index
                     store: root.store
                     activityCenterStore: root.activityCenterStore
                     notification: model
-                    previousNotificationIndex: Math.min(listView.count - 1, index + 1)
                     onCloseActivityCenter: root.close()
                 }
             }
@@ -223,10 +223,10 @@ Popup {
 
                 ActivityNotificationCommunityInvitation {
                     width: listView.availableWidth
+                    filteredIndex: index
                     store: root.store
                     activityCenterStore: root.activityCenterStore
                     notification: model
-                    previousNotificationIndex: Math.min(listView.count - 1, index + 1)
                     onCloseActivityCenter: root.close()
                 }
             }
@@ -235,10 +235,10 @@ Popup {
 
                 ActivityNotificationCommunityMembershipRequest {
                     width: listView.availableWidth
+                    filteredIndex: index
                     store: root.store
                     activityCenterStore: root.activityCenterStore
                     notification: model
-                    previousNotificationIndex: Math.min(listView.count - 1, index + 1)
                     onCloseActivityCenter: root.close()
                 }
             }
@@ -247,10 +247,10 @@ Popup {
 
                 ActivityNotificationCommunityRequest {
                     width: listView.availableWidth
+                    filteredIndex: index
                     store: root.store
                     activityCenterStore: root.activityCenterStore
                     notification: model
-                    previousNotificationIndex: Math.min(listView.count - 1, index + 1)
                     onCloseActivityCenter: root.close()
                 }
             }
@@ -259,10 +259,10 @@ Popup {
 
                 ActivityNotificationCommunityKicked {
                     width: listView.availableWidth
+                    filteredIndex: index
                     store: root.store
                     activityCenterStore: root.activityCenterStore
                     notification: model
-                    previousNotificationIndex: Math.min(listView.count - 1, index + 1)
                     onCloseActivityCenter: root.close()
                 }
             }

--- a/ui/app/mainui/activitycenter/views/ActivityNotificationBase.qml
+++ b/ui/app/mainui/activitycenter/views/ActivityNotificationBase.qml
@@ -11,6 +11,7 @@ import utils 1.0
 Item {
     id: root
 
+    property int filteredIndex: 0
     property var notification
     property var store
     property var activityCenterStore
@@ -18,7 +19,6 @@ Item {
     property alias bodyComponent: bodyLoader.sourceComponent
     property alias badgeComponent: badgeLoader.sourceComponent
     property alias ctaComponent: ctaLoader.sourceComponent
-    property alias previousNotificationIndex: dateGroupLabel.previousMessageIndex
 
     signal closeActivityCenter()
 
@@ -32,8 +32,7 @@ Item {
         anchors.right: parent.right
         anchors.left: parent.left
         messageTimestamp: notification.timestamp
-        previousMessageTimestamp: root.activityCenterStore.activityCenterList.getNotificationData(
-                                    previousNotificationIndex, "timestamp")
+        previousMessageTimestamp: filteredIndex === 0 || !notification.previousTimestamp ? 0 : notification.previousTimestamp
         visible: text !== ""
     }
 

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -378,8 +378,7 @@ Loader {
                 Layout.topMargin: 16
                 Layout.bottomMargin: 16
                 messageTimestamp: root.messageTimestamp
-                previousMessageIndex: root.prevMessageIndex
-                previousMessageTimestamp: root.prevMsgTimestamp
+                previousMessageTimestamp: root.prevMessageIndex === -1 ? 0 : root.prevMsgTimestamp
                 visible: text !== ""
             }
 


### PR DESCRIPTION
Close #8434

### What does the PR do

Should help with binding loop with Qt 5.15

### Affected areas

ActivityCenter

### Screenshot of functionality (including design for comparison)

https://user-images.githubusercontent.com/2522130/203771797-f1943fdc-0303-4417-9f74-232fad5ab93f.mov
