### PR TITLE
fix(StatusEmojiSuggestionPopup): emoji is blurry in the suggestions popup

### DIFF
--- a/ui/StatusQ/src/StatusQ/Core/Utils/Emoji.qml
+++ b/ui/StatusQ/src/StatusQ/Core/Utils/Emoji.qml
@@ -48,6 +48,9 @@ QtObject {
         const match = parsed.match('src="(.*\.svg).*"');
         return (match && match.length >= 2) ? match[1] : undefined;
     }
+    function svgImage(unicode) {
+        return `${base}/svg/${unicode}.svg`
+    }
     function iconId(text) {
         const parsed = parse(text);
         const match = parsed.match('src=".*\/(.+?).svg');

--- a/ui/imports/shared/status/StatusEmojiSuggestionPopup.qml
+++ b/ui/imports/shared/status/StatusEmojiSuggestionPopup.qml
@@ -1,10 +1,8 @@
-import QtQuick 2.13
-import QtQuick.Controls 2.13
-import QtGraphicalEffects 1.12
-import QtQuick.Dialogs 1.3
+import QtQuick 2.14
 
-import utils 1.0
 import shared 1.0
+
+import StatusQ.Core.Utils 0.1
 
 StatusInputListPopup {
     id: emojiSuggestions
@@ -19,7 +17,7 @@ StatusInputListPopup {
     }
 
     getImageSource: function (modelData) {
-        return `qrc:/StatusQ/src/assets/twemoji/72x72/${modelData.unicode}.png`
+        return Emoji.svgImage(modelData.unicode)
     }
     getText: function (modelData) {
         return modelData.shortname


### PR DESCRIPTION
use an SVG icon instead of a potentially lowres PNG

Fixes #8409

### What does the PR do

Fixes blurry emojis in the suggestion popup list

### Affected areas

StatusEmojiSuggestionPopup

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![image](https://user-images.githubusercontent.com/5377645/203596623-8cf72c21-86f5-4ee7-b212-8bfdcec07466.png)

