### PR TITLE
fix(@desktop/test): [suite_communities / tst_communityFlows] - 'The a…

### DIFF
--- a/src/app_service/service/community/service.nim
+++ b/src/app_service/service/community/service.nim
@@ -841,6 +841,10 @@ QtObject:
         community.settings = communitySettings
         # add this to the joinedCommunities list and communitiesSettings
         self.joinedCommunities[community.id] = community
+        # add new community channel group and chats to chat service
+        self.chatService.updateOrAddChannelGroup(community.toChannelGroupDto())
+        for chat in community.chats: 
+          self.chatService.updateOrAddChat(chat)
 
         self.events.emit(SIGNAL_COMMUNITY_CREATED, CommunityArgs(community: community))
     except Exception as e:

--- a/test/ui-test/testSuites/suite_communities/tst_communityFlows/test.feature
+++ b/test/ui-test/testSuites/suite_communities/tst_communityFlows/test.feature
@@ -95,8 +95,6 @@ Feature: Status Desktop community
             | new_community_name       | new_community_description  | new_community_color |
             | myCommunityNamedChanged  | Cool new description 123   | #ff0000             |
 
-	@mayfail
-	# TODO: Test broken. Validation doesn't work (No attribute ` emoji`found error).
     Scenario Outline: The admin changes the emoji of a channel
         When the admin changes the current community channel emoji to "<new_emoji_description>"
         Then the community channel has emoji "<new_emoji>"


### PR DESCRIPTION
…dmin changes the emoji of a channel'

### What does the PR do

After creating a new Community, save the default new Community chat and group to the chat service.

Fixes the issue, when after creating the Community and during loading the chat content module, the chat content controller did not find chat details and returned default chat details without chatId

Close: #8006

### Affected areas

Community creation in community service
