### PR TITLE
fix: unbreak the image context menu

### DIFF
--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -200,8 +200,6 @@ Item {
                     contextMenu.hideEmojiPicker = true
                     contextMenu.isRightClickOnImage = true
                     contextMenu.parent = imagePopup.contentItem
-                    contextMenu.setXPosition = function() { return mouse.x + Style.current.smallPadding }
-                    contextMenu.setYPosition = function() { return mouse.y - Style.current.smallPadding }
                     contextMenu.show()
                 }
             }


### PR DESCRIPTION
- don't reference non-existent code
- positioning it manually is wrong anyway

Fixes: #8447

### What does the PR do

Fixes image context menu being not visible

### Affected areas

Chat

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![image](https://user-images.githubusercontent.com/5377645/203977926-2530b026-8758-44bf-876c-d14ed614f235.png)

