### PR TITLE
feat(Storybook): Prevent building for desktop using Storybook.pro

### DIFF
--- a/storybook/StoryBook.pro
+++ b/storybook/StoryBook.pro
@@ -1,3 +1,7 @@
+if(!wasm-emscripten) {
+    error("Use CMake configuration for platforms other then wasm!")
+}
+
 QT += core \
     quick \
     quickcontrols2 \


### PR DESCRIPTION
### What does the PR do

Simple check preventing building for other platforms than wasm using `Storybook.pro` config file.

Closes https://github.com/status-im/status-desktop/issues/8451

### Affected areas
`Storybook`
