### PR TITLE
fix(Storybook): linking WebEngine causes errors on Linux

### DIFF
--- a/storybook/CMakeLists.txt
+++ b/storybook/CMakeLists.txt
@@ -17,7 +17,7 @@ endif()
 
 find_package(
   Qt5
-  COMPONENTS Core Quick QuickControls2 WebEngine Test
+  COMPONENTS Core Quick QuickControls2 Test
   REQUIRED)
 
 file(GLOB_RECURSE QML_FILES "stubs/*.qml" "mocks/*.qml" "pages/*.qml" "src/*.qml" "src/qmldir" "../ui/StatusQ/*.qml" "../ui/app/*.qml")
@@ -36,8 +36,7 @@ add_executable(
 target_compile_definitions(${PROJECT_NAME}
                            PRIVATE QML_IMPORT_ROOT="${CMAKE_CURRENT_LIST_DIR}")
 target_link_libraries(
-  ${PROJECT_NAME} PRIVATE Qt5::Core Qt5::Quick Qt5::QuickControls2 Qt5::WebEngine
-                          SortFilterProxyModel)
+  ${PROJECT_NAME} PRIVATE Qt5::Core Qt5::Quick Qt5::QuickControls2 SortFilterProxyModel)
 
 enable_testing()
 add_executable(SectionsDecoratorModelTest tests/tst_SectionsDecoratorModel.cpp sectionsdecoratormodel.cpp)

--- a/storybook/main.cpp
+++ b/storybook/main.cpp
@@ -1,10 +1,6 @@
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
 
-#ifdef QT_WEBENGINE_LIB
-#include <QtWebEngine>
-#endif
-
 #include "cachecleaner.h"
 #include "directorieswatcher.h"
 #include "sectionsdecoratormodel.h"
@@ -15,9 +11,7 @@ int main(int argc, char *argv[])
     QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
 #endif
     QCoreApplication::setAttribute(Qt::AA_ShareOpenGLContexts);
-#ifdef QT_WEBENGINE_LIB
-    QtWebEngine::initialize();
-#endif
+
     QGuiApplication app(argc, argv);
     QGuiApplication::setOrganizationName(QStringLiteral("Status"));
     QGuiApplication::setOrganizationDomain(QStringLiteral("status.im"));


### PR DESCRIPTION
### What does the PR do

For linux the linker is set to gold which fixes the problem with linking described in the ticket.

Closes: #8454

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas
`Storybook`