### PR TITLE
fix: unbreak suggestions for emojis containing an underscore

### DIFF
--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -796,7 +796,7 @@ Rectangle {
     function validSubstr(substr) {
         for(var i = 0; i < substr.length; i++) {
             var c = substr.charAt(i);
-            if (Utils.isSpace(c) === true || Utils.isPunct(c) === true)
+            if (Utils.isSpace(c) || Utils.isPunct(c))
                 return false;
         }
         return true;

--- a/ui/imports/utils/Utils.qml
+++ b/ui/imports/utils/Utils.qml
@@ -755,7 +755,6 @@ QtObject {
 
     // Leave this function at the bottom of the file as QT Creator messes up the code color after this
     function isPunct(c) {
-        return /(!|\@|#|\$|%|\^|&|\*|\(|\)|_|\+|\||-|=|\\|{|}|[|]|"|;|'|<|>|\?|,|\.|\/)/.test(c)
+        return /(!|\@|#|\$|%|\^|&|\*|\(|\)|\+|\||-|=|\\|{|}|[|]|"|;|'|<|>|\?|,|\.|\/)/.test(c)
     }
-
 }


### PR DESCRIPTION
- don't consider `_` as a "punct" or invalid character, some emojis like flags do contain it in their name

Fixes: #8446

### What does the PR do

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas

StatusChatInput

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![image](https://user-images.githubusercontent.com/5377645/203996103-3e12db7d-0543-446e-8de3-b9d447c0ad95.png)

