### PR TITLE
feat(chat): support copy & pasting images into chat input

### DIFF
--- a/src/app/modules/main/chat_section/chat_content/input_area/controller.nim
+++ b/src/app/modules/main/chat_section/chat_content/input_area/controller.nim
@@ -45,8 +45,8 @@ proc getChatId*(self: Controller): string =
 proc belongsToCommunity*(self: Controller): bool =
   return self.belongsToCommunity
 
-proc sendImages*(self: Controller, imagePathsJson: string): string =
-  self.chatService.sendImages(self.chatId, imagePathsJson)
+proc sendImages*(self: Controller, imagePathsAndDataJson: string): string =
+  self.chatService.sendImages(self.chatId, imagePathsAndDataJson)
 
 proc sendChatMessage*(
     self: Controller,

--- a/src/app/modules/main/chat_section/chat_content/input_area/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/input_area/module.nim
@@ -60,8 +60,8 @@ method getModuleAsVariant*(self: Module): QVariant =
 method getChatId*(self: Module): string =
   return self.controller.getChatId()
 
-method sendImages*(self: Module, imagePathsJson: string): string =
-  self.controller.sendImages(imagePathsJson)
+method sendImages*(self: Module, imagePathsAndDataJson: string): string =
+  self.controller.sendImages(imagePathsAndDataJson)
 
 method sendChatMessage*(
     self: Module,

--- a/src/app/modules/main/chat_section/chat_content/input_area/view.nim
+++ b/src/app/modules/main/chat_section/chat_content/input_area/view.nim
@@ -36,8 +36,8 @@ QtObject:
       contentType: int) {.slot.} =
     self.delegate.sendChatMessage(msg, replyTo, contentType)
 
-  proc sendImages*(self: View, sendImages: string): string {.slot.} =
-    self.delegate.sendImages(sendImages)
+  proc sendImages*(self: View, imagePathsAndDataJson: string): string {.slot.} =
+    self.delegate.sendImages(imagePathsAndDataJson)
 
   proc acceptAddressRequest*(self: View, messageId: string , address: string) {.slot.} =
     self.delegate.acceptRequestAddressForTransaction(messageId, address)

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -98,11 +98,12 @@ QtObject {
         return msg
     }
 
-    function sendMessage(event, text, replyMessageId, fileUrls) {
+    function sendMessage(event, text, replyMessageId, fileUrlsAndSources) {
         var chatContentModule = currentChatContentModule()
-        if (fileUrls.length > 0){
-            chatContentModule.inputAreaModule.sendImages(JSON.stringify(fileUrls));
+        if (fileUrlsAndSources.length > 0){
+            chatContentModule.inputAreaModule.sendImages(JSON.stringify(fileUrlsAndSources));
         }
+
         let msg = globalUtils.plainText(StatusQUtils.Emoji.deparse(text))
         if (msg.length > 0) {
             msg = interpretMessage(msg)

--- a/ui/app/AppLayouts/Chat/views/ChatContentView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatContentView.qml
@@ -234,7 +234,7 @@ ColumnLayout {
                     if(root.rootStore.sendMessage(event,
                                                   chatInput.getTextWithPublicKeys(),
                                                   chatInput.isReply? chatInput.replyMessageId : "",
-                                                  chatInput.fileUrls
+                                                  chatInput.fileUrlsAndSources
                                                   ))
                     {
                         Global.sendMessageSound.stop();


### PR DESCRIPTION
This adds support for receiving copied images from the clipboard and pasting it into the chat input.

After pasting, chat input will recognize the image and render a preview similar to how it would do it when selecting images via the file dialog.

**Also important to note**:

At the time of this PR, it seems that desktop only supports sending jpegs to status-go. I'm not sure if this was deliberately done this way because the protocol says it supports jpg, png, webp and gif.

Because of this, pasting for example pngs will work, however transparency will be lost (which is also most likely the cause of #8220 )

This PR operates on that assumption. So while it adds support for copy/pasting images, it does not address the lack of file type support.

Closes #3395

