### PR TITLE
hotfix(wallet): comment out history timer to fix app hanging on close

### DIFF
--- a/src/app_service/service/wallet_account/service.nim
+++ b/src/app_service/service/wallet_account/service.nim
@@ -695,17 +695,17 @@ QtObject:
     self.checkRecentHistory(true)
 
   proc startFetchingHistoryTimer(self: Service, resetTimeToNow = true) =
-    if(self.closingApp):
+    if(self.closingApp or
+        not singletonInstance.localAccountSensitiveSettings.getIsWalletEnabled() or
+        self.isHistoryFetchTimerAlreadyRunning):
       return
 
-    if(self.isHistoryFetchTimerAlreadyRunning):
-      return
-
-    self.isHistoryFetchTimerAlreadyRunning = true
-    let arg = TimerTaskArg(
-      tptr: cast[ByteAddress](timerTask),
-      vptr: cast[ByteAddress](self.vptr),
-      slot: "onStartHistoryFetchingTimer",
-      timeoutInMilliseconds: CheckHistoryIntervalInMilliseconds
-    )
-    self.threadpool.start(arg)
+    # TODO move this to status-go, because the 20 minutes timer leaves the app hanging when trying to leave
+    # self.isHistoryFetchTimerAlreadyRunning = true
+    # let arg = TimerTaskArg(
+    #   tptr: cast[ByteAddress](timerTask),
+    #   vptr: cast[ByteAddress](self.vptr),
+    #   slot: "onStartHistoryFetchingTimer",
+    #   timeoutInMilliseconds: CheckHistoryIntervalInMilliseconds
+    # )
+    # self.threadpool.start(arg)


### PR DESCRIPTION
Fixes #8401

Threads in Nim are very bad and when the app closes, the thread doesn't close until it is done. That means that the 20 minute timer needs to finish before it can be closed.

This partially breaks the history fetching. I want @alaibe 's and @Khushboo-dev-cpp 's eyes on this before merging. We'll need to move that timer to status-go. If possible, one from the wallet cohort should do it.

edit: @alaibe gave me the thumbs up to merge, so feel free to review