### PR TITLE
fix(@desktop/chat): Hide quick actions panel in non-joined chats

### DIFF
--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -126,7 +126,8 @@ Loader {
                                                isRightClickOnImage = false,
                                                imageSource = "") {
 
-        if (placeholderMessage || activityCenterMessage) {
+        if (placeholderMessage || activityCenterMessage ||
+                !(root.rootStore.mainModuleInst.activeSection.joined || isProfileClick)) {
             return
         }
 
@@ -476,7 +477,9 @@ Loader {
                                   root.placeholderMessage ||
                                   root.activityCenterMessage ||
                                   root.isInPinnedPopup ||
-                                  root.editModeOn
+                                  root.editModeOn ||
+                                  !root.rootStore.mainModuleInst.activeSection.joined
+
                 hideMessage: d.isSingleImage && d.unfurledLinksCount === 1
 
                 overrideBackground: root.activityCenterMessage || root.placeholderMessage


### PR DESCRIPTION
### What does the PR do

Hide quick actions panel in non-joined chats
Hide mouse context menu with actions
Fixed: #8301

### Affected areas

Quick actions panel visibility
Mouse context menu visibility

### Screenshot of functionality (including design for comparison)

https://user-images.githubusercontent.com/117639195/204486765-3cdaffee-b04c-433b-926d-216f464ac025.mov

