### PR TITLE
fix(@desktop/wallet) make collection expansion more responsive

### DIFF
--- a/src/app/modules/main/wallet_section/collectibles/collectibles/controller.nim
+++ b/src/app/modules/main/wallet_section/collectibles/collectibles/controller.nim
@@ -1,25 +1,31 @@
 import io_interface
 import ../../../../../../app_service/service/collectible/service as collectible_service
+import ../../../../../core/eventemitter
 
 
 type
   Controller* = ref object of RootObj
     delegate: io_interface.AccessInterface
+    events: EventEmitter
     collectibleService: collectible_service.Service
 
 proc newController*(
   delegate: io_interface.AccessInterface,
+  events: EventEmitter,
   collectibleService: collectible_service.Service
 ): Controller =
   result = Controller()
   result.delegate = delegate
+  result.events = events
   result.collectibleService = collectibleService
 
 proc delete*(self: Controller) =
   discard
 
 proc init*(self: Controller) =
-  discard
+  self.events.on(GetCollectibles) do(e:Args):
+    let args = GetCollectiblesArgs(e)
+    self.delegate.setCollectibles(args.collectionSlug, args.collectibles)
 
-proc fetch*(self: Controller, address: string, collectionSlug: string): seq[collectible_service.CollectibleDto] =
-  return self.collectibleService.getCollectibles(address, collectionSlug)
+proc fetch*(self: Controller, address: string, collectionSlug: string) =
+  self.collectibleService.getCollectiblesAsync(address, collectionSlug)

--- a/src/app/modules/main/wallet_section/collectibles/collectibles/io_interface.nim
+++ b/src/app/modules/main/wallet_section/collectibles/collectibles/io_interface.nim
@@ -1,3 +1,4 @@
+import ../../../../../../app_service/service/collectible/service as collectible_service
 import ./item
 
 type
@@ -13,10 +14,13 @@ method load*(self: AccessInterface) {.base.} =
 method isLoaded*(self: AccessInterface): bool {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method setCurrentAddress*(self: AccessInterface, address: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method fetch*(self: AccessInterface, collectionSlug: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method setCurrentAddress*(self: AccessInterface, address: string) {.base.} =
+method setCollectibles*(self: AccessInterface, collectionSlug: string, collectibles: seq[CollectibleDto]) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method getCollectible*(self: AccessInterface, collectionSlug: string, id: int) : Item {.base.} =

--- a/src/app/modules/main/wallet_section/collectibles/collectibles/module.nim
+++ b/src/app/modules/main/wallet_section/collectibles/collectibles/module.nim
@@ -4,6 +4,7 @@ import ../../../../../global/global_singleton
 import ./io_interface, ./view, ./controller, ./item
 import ../io_interface as delegate_interface
 import ../../../../../../app_service/service/collectible/service as collectible_service
+import ../../../../../core/eventemitter
 
 export io_interface
 
@@ -15,12 +16,12 @@ type
     moduleLoaded: bool
     currentAddress: string
 
-proc newModule*(delegate: delegate_interface.AccessInterface, collectibleService: collectible_service.Service):
+proc newModule*(delegate: delegate_interface.AccessInterface, events: EventEmitter, collectibleService: collectible_service.Service):
   Module =
   result = Module()
   result.delegate = delegate
   result.view = newView(result)
-  result.controller = controller.newController(result, collectibleService)
+  result.controller = controller.newController(result, events, collectibleService)
   result.moduleLoaded = false
 
 method delete*(self: Module) =
@@ -43,7 +44,9 @@ method setCurrentAddress*(self: Module, address: string) =
   self.currentAddress = address
 
 method fetch*(self: Module, collectionSlug: string) =
-  let collectibles = self.controller.fetch(self.currentAddress, collectionSlug)
+  self.controller.fetch(self.currentAddress, collectionSlug)
+
+method setCollectibles*(self: Module, collectionSlug: string, collectibles: seq[CollectibleDto]) =
   let items = collectibles.map(c => initItem(
     c.id,
     c.name,

--- a/src/app/modules/main/wallet_section/collectibles/module.nim
+++ b/src/app/modules/main/wallet_section/collectibles/module.nim
@@ -31,7 +31,7 @@ proc newModule*(
   result.controller = newController(result, walletAccountService)
   result.moduleLoaded = false
 
-  result.collectiblesModule = collectibles_module.newModule(result, collectibleService)
+  result.collectiblesModule = collectibles_module.newModule(result, events, collectibleService)
   result.collectionsModule = collectionsModule.newModule(result, events, collectibleService)
   result.currentCollectibleModule = currentCollectibleModule.newModule(result, collectibleService, result.collectionsModule, result.collectiblesModule)
 

--- a/src/app_service/service/collectible/async_tasks.nim
+++ b/src/app_service/service/collectible/async_tasks.nim
@@ -5,13 +5,38 @@ type
 
 const getCollectionsTaskArg: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[GetCollectionsTaskArg](argEncoded)
-
+  let output = %* {
+    "chainId": arg.chainId,
+    "address": arg.address,
+    "collections": ""
+  }
   try:
     let response = backend.getOpenseaCollectionsByOwner(arg.chainId, arg.address)
-    arg.finish(response.result)
+    output["collections"] = response.result
   except Exception as e:
     let errDesription = e.msg
-    error "error: ", errDesription
-    arg.finish("")
+    error "error getCollectionsTaskArg: ", errDesription
+  arg.finish(output)
 
-  
+type
+  GetCollectiblesTaskArg = ref object of QObjectTaskArg
+    chainId*: int
+    address*: string
+    collectionSlug: string
+    limit: int
+
+const getCollectiblesTaskArg: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+  let arg = decode[GetCollectiblesTaskArg](argEncoded)
+  let output = %* {
+    "chainId": arg.chainId,
+    "address": arg.address,
+    "collectionSlug": arg.collectionSlug,
+    "collectibles": ""
+  }
+  try:
+    let response = backend.getOpenseaAssetsByOwnerAndCollection(arg.chainId, arg.address, arg.collectionSlug, arg.limit)
+    output["collectibles"] = response.result
+  except Exception as e:
+    let errDesription = e.msg
+    error "error getCollectiblesTaskArg: ", errDesription
+  arg.finish(output)


### PR DESCRIPTION
### What does the PR do
Fixes #8406
Collection fetch is now non-blocking. This makes collection expansion more responsive.
Added a couple of changes to Collectibles service as preparation for future work.

Old:
[collection_expand_old-2022-11-29_15.42.29.webm](https://user-images.githubusercontent.com/11161531/204618274-1f0309df-47f0-4e20-a3bb-060a93f9e806.webm)

New:
[collection_expand_new-2022-11-29_15.37.38.webm](https://user-images.githubusercontent.com/11161531/204618300-9cf525a3-0f26-4d82-9729-6525f71a9143.webm)

Depends on https://github.com/status-im/status-desktop/pull/8487

### Affected areas
Wallet -> Collectibles

