### PR TITLE
fix(windows): use QML's OS notification for Windows

### DIFF
--- a/src/app/core/notifications/notifications_manager.nim
+++ b/src/app/core/notifications/notifications_manager.nim
@@ -16,6 +16,7 @@ const NOTIFICATION_SOUND = "qrc:/imports/assets/audio/notification.wav"
 # Signals which may be emitted by this class:
 const SIGNAL_ADD_NOTIFICATION_TO_ACTIVITY_CENTER* = "addNotificationToActivityCenter"
 const SIGNAL_DISPLAY_APP_NOTIFICATION* = "displayAppNotification"
+const SIGNAL_DISPLAY_WINDOWS_OS_NOTIFICATION* = "displayWindowsOsNotification"
 const SIGNAL_OS_NOTIFICATION_CLICKED* = "osNotificationClicked"
 
 # Notification preferences
@@ -32,6 +33,7 @@ type
   NotificationArgs* = ref object of Args
     title*: string
     message*: string
+    identifier*: string
     details*: NotificationDetails
 
   ClickedNotificationArgs* = ref object of Args
@@ -85,9 +87,13 @@ QtObject:
     self.notificationSetUp = true
 
   proc showOSNotification(self: NotificationsManager, title: string, message: string, identifier: string) =
-    ## This method will add new notification to the OS Notification center. Param
-    ## "identifier" is used to uniquely define notification bubble.    
-    self.osNotification.showNotification(title, message, identifier)
+    if defined(windows):
+      let data = NotificationArgs(title: title, message: message)
+      self.events.emit(SIGNAL_DISPLAY_WINDOWS_OS_NOTIFICATION, data)
+    else:
+      ## This method will add new notification to the OS Notification center. Param
+      ## "identifier" is used to uniquely define notification bubble.
+      self.osNotification.showNotification(title, message, identifier)
 
   proc onOSNotificationClicked(self: NotificationsManager, identifier: string) {.slot.} =
     ## This slot is called once user clicks OS notificaiton bubble, "identifier"

--- a/src/app/modules/main/controller.nim
+++ b/src/app/modules/main/controller.nim
@@ -230,6 +230,11 @@ proc init*(self: Controller) =
     var args = ClickedNotificationArgs(e)
     self.delegate.osNotificationClicked(args.details)
 
+  if defined(windows):
+    self.events.on(SIGNAL_DISPLAY_WINDOWS_OS_NOTIFICATION) do(e: Args):
+      var args = NotificationArgs(e)
+      self.delegate.displayWindowsOsNotification(args.title, args.message)
+
   self.events.on(SIGNAL_DISPLAY_APP_NOTIFICATION) do(e: Args):
     var args = NotificationArgs(e)
     self.delegate.displayEphemeralNotification(args.title, args.message, args.details)

--- a/src/app/modules/main/io_interface.nim
+++ b/src/app/modules/main/io_interface.nim
@@ -132,6 +132,9 @@ method mnemonicBackedUp*(self: AccessInterface) {.base.} =
 method osNotificationClicked*(self: AccessInterface, details: NotificationDetails) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method displayWindowsOsNotification*(self: AccessInterface, title: string, message: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method displayEphemeralNotification*(self: AccessInterface, title: string, subTitle: string, details: NotificationDetails) 
   {.base.} =
   raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -846,6 +846,10 @@ method mnemonicBackedUp*[T](self: Module[T]) =
     self.calculateProfileSectionHasNotification(),
     notificationsCount = 0)
 
+method displayWindowsOsNotification*[T](self: Module[T], title: string,
+    message: string) =
+  self.view.displayWindowsOsNotification(title, message)
+
 method osNotificationClicked*[T](self: Module[T], details: NotificationDetails) =
   if(details.notificationType == NotificationType.NewContactRequest):
     self.controller.switchTo(details.sectionId, "", "")

--- a/src/app/modules/main/view.nim
+++ b/src/app/modules/main/view.nim
@@ -128,6 +128,8 @@ QtObject:
 
   proc mailserverNotWorking*(self:View) {.signal.}
 
+  proc displayWindowsOsNotification*(self:View, title: string, message: string) {.signal.}
+
   proc emitMailservernotWorking*(self: View) =
     self.mailserverNotWorking()
 

--- a/ui/main.qml
+++ b/ui/main.qml
@@ -123,6 +123,15 @@ StatusWindow {
     }
 
     Connections {
+        id: windowsOsNotificationsConnection
+        enabled: false
+        target: Global.mainModuleInst
+        function onDisplayWindowsOsNotification(title, message) {
+            systemTray.showMessage(title, message)
+        }
+    }
+
+    Connections {
         target: startupModule
 
         function onStartUpUIRaised() {
@@ -143,6 +152,10 @@ StatusWindow {
             else if(state === Constants.appState.main) {
                 // We set main module to the Global singleton once user is logged in and we move to the main app.
                 Global.mainModuleInst = mainModule
+                if (Qt.platform.os === Constants.windows) {
+                    windowsOsNotificationsConnection.enabled = true
+                }
+
                 loader.sourceComponent = app
 
                 if(localAccountSensitiveSettings.recentEmojis === "") {
@@ -243,6 +256,12 @@ StatusWindow {
                     return "imports/assets/icons/status-logo-dev-round-rect.svg"
                 else
                     return "imports/assets/icons/status-logo-dev-circle.svg"
+            }
+        }
+
+        onMessageClicked: {
+            if (Qt.platform.os === Constants.windows) {
+                applicationWindow.makeStatusAppActive()
             }
         }
 


### PR DESCRIPTION
Fixes #4943

The custom OS notifications we have in place make it possible to click the notification and go to the right place in the app, but it causes a big issue in Windows; it breaks the tray icon, it becomes no longer clickable.
The easy fix I did here is the go back to using the QML `sendMessage` function. It works fine to send the notif and the tray icon keeps working. The only downside is we lose context when clicking on the notification, so it doesn't navigate to the chat.
IMO, this is a good tradeoff.

When we end up using QT6, doing a patch of `showMessage` should be more manageable. 