### PR TITLE
fix(@desktop/chat): Pending request disappear from the contacts list when blocked and unblocked

### DIFF
--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -679,9 +679,11 @@ method blockContact*(self: Module, publicKey: string) =
 method onContactBlocked*(self: Module, publicKey: string) =
   self.view.contactRequestsModel().removeItemById(publicKey)
   self.view.chatsModel().blockUnblockItemOrSubItemById(publicKey, blocked=true)
+  self.updateParentBadgeNotifications()
 
 method onContactUnblocked*(self: Module, publicKey: string) =
   self.view.chatsModel().blockUnblockItemOrSubItemById(publicKey, blocked=false)
+  self.onContactDetailsUpdated(publicKey)
 
 method onContactDetailsUpdated*(self: Module, publicKey: string) =
   if(self.controller.isCommunity()):


### PR DESCRIPTION
### What does the PR do

- restore contact request by pubkey in the model after removing from the model during the contact block
- fixes badge icon displaying after block/unblock

Fixed: #7520

### Affected areas

Displaying contact requests in chat after blocking/unblocking

### Screenshot of functionality (including design for comparison)

https://user-images.githubusercontent.com/117639195/204743254-270a0c89-838d-4dc2-a747-af0f834520e3.mov



