### PR TITLE
fix(ActivityCenter): Get rid of DelegateChooser in ActivityCenterPopop

### DIFF
--- a/ui/app/mainui/activitycenter/popups/ActivityCenterPopup.qml
+++ b/ui/app/mainui/activitycenter/popups/ActivityCenterPopup.qml
@@ -176,93 +176,110 @@ Popup {
             ]
         }
 
-        delegate: DelegateChooser {
-            role: "notificationType"
+        delegate: Loader {
+            width: listView.availableWidth
 
-            DelegateChoice {
-                roleValue: Constants.activityCenterNotificationTypeMention
+            property int filteredIndex: index
+            property var notification: model
 
-                ActivityNotificationMention {
-                    width: listView.availableWidth
-                    filteredIndex: index
-                    store: root.store
-                    activityCenterStore: root.activityCenterStore
-                    notification: model
-                    onCloseActivityCenter: root.close()
+            sourceComponent: {
+                switch (model.notificationType) {
+                    case Constants.activityCenterNotificationTypeMention:
+                        return mentionNotificationComponent
+                    case Constants.activityCenterNotificationTypeReply:
+                        return replyNotificationComponent
+                    case Constants.activityCenterNotificationTypeContactRequest:
+                        return contactRequestNotificationComponent
+                    case Constants.activityCenterNotificationTypeCommunityInvitation:
+                        return communityInvitationNotificationComponent
+                    case Constants.activityCenterNotificationTypeCommunityMembershipRequest:
+                        return membershipRequestNotificationComponent
+                    case Constants.activityCenterNotificationTypeCommunityRequest:
+                        return communityRequestNotificationComponent
+                    case Constants.activityCenterNotificationTypeCommunityKicked:
+                        return communityKickedNotificationComponent
+                    default:
+                        return null
                 }
             }
-            DelegateChoice {
-                roleValue: Constants.activityCenterNotificationTypeReply
+        }
+    }
 
-                ActivityNotificationReply {
-                    width: listView.availableWidth
-                    filteredIndex: index
-                    store: root.store
-                    activityCenterStore: root.activityCenterStore
-                    notification: model
-                    onCloseActivityCenter: root.close()
-                }
-            }
-            DelegateChoice {
-                roleValue: Constants.activityCenterNotificationTypeContactRequest
+    Component {
+        id: mentionNotificationComponent
 
-                ActivityNotificationContactRequest {
-                    width: listView.availableWidth
-                    filteredIndex: index
-                    store: root.store
-                    activityCenterStore: root.activityCenterStore
-                    notification: model
-                    onCloseActivityCenter: root.close()
-                }
-            }
-            DelegateChoice {
-                roleValue: Constants.activityCenterNotificationTypeCommunityInvitation
+        ActivityNotificationMention {
+            filteredIndex: parent.filteredIndex
+            notification: parent.notification
+            store: root.store
+            activityCenterStore: root.activityCenterStore
+            onCloseActivityCenter: root.close()
+        }
+    }
+    Component {
+        id: replyNotificationComponent
 
-                ActivityNotificationCommunityInvitation {
-                    width: listView.availableWidth
-                    filteredIndex: index
-                    store: root.store
-                    activityCenterStore: root.activityCenterStore
-                    notification: model
-                    onCloseActivityCenter: root.close()
-                }
-            }
-            DelegateChoice {
-                roleValue: Constants.activityCenterNotificationTypeCommunityMembershipRequest
+        ActivityNotificationReply {
+            filteredIndex: parent.filteredIndex
+            notification: parent.notification
+            store: root.store
+            activityCenterStore: root.activityCenterStore
+            onCloseActivityCenter: root.close()
+        }
+    }
+    Component {
+        id: contactRequestNotificationComponent
 
-                ActivityNotificationCommunityMembershipRequest {
-                    width: listView.availableWidth
-                    filteredIndex: index
-                    store: root.store
-                    activityCenterStore: root.activityCenterStore
-                    notification: model
-                    onCloseActivityCenter: root.close()
-                }
-            }
-            DelegateChoice {
-                roleValue: Constants.activityCenterNotificationTypeCommunityRequest
+        ActivityNotificationContactRequest {
+            filteredIndex: parent.filteredIndex
+            notification: parent.notification
+            store: root.store
+            activityCenterStore: root.activityCenterStore
+            onCloseActivityCenter: root.close()
+        }
+    }
+    Component {
+        id: communityInvitationNotificationComponent
 
-                ActivityNotificationCommunityRequest {
-                    width: listView.availableWidth
-                    filteredIndex: index
-                    store: root.store
-                    activityCenterStore: root.activityCenterStore
-                    notification: model
-                    onCloseActivityCenter: root.close()
-                }
-            }
-            DelegateChoice {
-                roleValue: Constants.activityCenterNotificationTypeCommunityKicked
+        ActivityNotificationCommunityInvitation {
+            filteredIndex: parent.filteredIndex
+            notification: parent.notification
+            store: root.store
+            activityCenterStore: root.activityCenterStore
+            onCloseActivityCenter: root.close()
+        }
+    }
+    Component {
+        id: membershipRequestNotificationComponent
 
-                ActivityNotificationCommunityKicked {
-                    width: listView.availableWidth
-                    filteredIndex: index
-                    store: root.store
-                    activityCenterStore: root.activityCenterStore
-                    notification: model
-                    onCloseActivityCenter: root.close()
-                }
-            }
+        ActivityNotificationCommunityMembershipRequest {
+            filteredIndex: parent.filteredIndex
+            notification: parent.notification
+            store: root.store
+            activityCenterStore: root.activityCenterStore
+            onCloseActivityCenter: root.close()
+        }
+    }
+    Component {
+        id: communityRequestNotificationComponent
+
+        ActivityNotificationCommunityRequest {
+            filteredIndex: parent.filteredIndex
+            notification: parent.notification
+            store: root.store
+            activityCenterStore: root.activityCenterStore
+            onCloseActivityCenter: root.close()
+        }
+    }
+    Component {
+        id: communityKickedNotificationComponent
+
+        ActivityNotificationCommunityKicked {
+            filteredIndex: parent.filteredIndex
+            notification: parent.notification
+            store: root.store
+            activityCenterStore: root.activityCenterStore
+            onCloseActivityCenter: root.close()
         }
     }
 }

--- a/ui/app/mainui/activitycenter/views/ActivityNotificationBase.qml
+++ b/ui/app/mainui/activitycenter/views/ActivityNotificationBase.qml
@@ -11,10 +11,10 @@ import utils 1.0
 Item {
     id: root
 
-    property int filteredIndex: 0
-    property var notification
-    property var store
-    property var activityCenterStore
+    /* required */ property int filteredIndex
+    /* required */ property var notification
+    /* required */ property var store
+    /* required */ property var activityCenterStore
 
     property alias bodyComponent: bodyLoader.sourceComponent
     property alias badgeComponent: badgeLoader.sourceComponent
@@ -31,8 +31,9 @@ Item {
         anchors.top: parent.top
         anchors.right: parent.right
         anchors.left: parent.left
-        messageTimestamp: notification.timestamp
-        previousMessageTimestamp: filteredIndex === 0 || !notification.previousTimestamp ? 0 : notification.previousTimestamp
+        messageTimestamp: notification ? notification.timestamp : 0
+        previousMessageTimestamp: !notification || filteredIndex === 0 || !notification.previousTimestamp ?
+                                        0 : notification.previousTimestamp
         visible: text !== ""
     }
 
@@ -60,8 +61,8 @@ Item {
             icon.width: 20
             icon.height: 20
             icon.name: "checkmark"
-            icon.color: root.notification.read ? icon.disabledColor : Theme.palette.primaryColor1
-            tooltip.text: !root.notification.read ? qsTr("Mark as Read") : qsTr("Mark as Unread")
+            icon.color: notification && notification.read ? icon.disabledColor : Theme.palette.primaryColor1
+            tooltip.text: notification && notification.read ? qsTr("Mark as Unread") : qsTr("Mark as Read")
             tooltip.orientation: StatusToolTip.Orientation.Left
             tooltip.x: -tooltip.width - Style.current.padding
             tooltip.y: 4

--- a/ui/app/mainui/activitycenter/views/ActivityNotificationCommunityInvitation.qml
+++ b/ui/app/mainui/activitycenter/views/ActivityNotificationCommunityInvitation.qml
@@ -17,11 +17,13 @@ ActivityNotificationMessage {
     badgeComponent: CommunityBadge {
         id: communityBadge
 
-        readonly property var community: root.store.getCommunityDetailsAsJson(notification.message.communityId)
+        readonly property var community: notification ?
+                                    root.store.getCommunityDetailsAsJson(notification.message.communityId) :
+                                    null
 
-        communityName: community.name
-        communityImage: community.image
-        communityColor: community.color
+        communityName: community ? community.name : ""
+        communityImage: community ? community.image : ""
+        communityColor: community ? community.color : "black"
 
         onCommunityNameClicked: {
             root.store.setActiveCommunity(notification.message.communityId)

--- a/ui/app/mainui/activitycenter/views/ActivityNotificationCommunityKicked.qml
+++ b/ui/app/mainui/activitycenter/views/ActivityNotificationCommunityKicked.qml
@@ -17,16 +17,18 @@ ActivityNotificationBase {
 
     bodyComponent: RowLayout {
         height: 50
-        readonly property var community: root.store.getCommunityDetailsAsJson(notification.communityId)
+        readonly property var community: notification ?
+                                root.store.getCommunityDetailsAsJson(notification.communityId) :
+                                null
 
         StatusSmartIdenticon {
             id: identicon
-            name: community.name
+            name: community ? community.name : ""
+            asset.name: community ? community.image : ""
+            asset.color: community ? community.color : "black"
             asset.width: 40
             asset.height: 40
-            asset.color: community.color
             asset.letterSize: width / 2.4
-            asset.name: community.image
             asset.isImage: true
             Layout.alignment: Qt.AlignVCenter
             Layout.leftMargin: Style.current.padding
@@ -39,9 +41,9 @@ ActivityNotificationBase {
         }
 
         CommunityBadge {
-            communityName: community.name
-            communityImage: community.image
-            communityColor: community.color
+            communityName: community ? community.name : ""
+            communityImage: community ? community.image : ""
+            communityColor: community ? community.color : "black"
             onCommunityNameClicked: root.store.setActiveCommunity(notification.communityId)
             Layout.alignment: Qt.AlignVCenter
         }

--- a/ui/app/mainui/activitycenter/views/ActivityNotificationCommunityMembershipRequest.qml
+++ b/ui/app/mainui/activitycenter/views/ActivityNotificationCommunityMembershipRequest.qml
@@ -16,23 +16,27 @@ import "../panels"
 ActivityNotificationMessage {
     id: root
 
-    readonly property var contactDetails: Utils.getContactDetailsAsJson(notification.author)
+    readonly property var contactDetails: notification ?
+                                            Utils.getContactDetailsAsJson(notification.author) : 
+                                            null
 
     messageDetails.messageText: qsTr("Wants to join")
-    messageDetails.sender.displayName: contactDetails.displayName
-    messageDetails.sender.secondaryName: contactDetails.localNickname
-    messageDetails.sender.profileImage.name: contactDetails.displayIcon
+    messageDetails.sender.displayName: contactDetails ? contactDetails.displayName : ""
+    messageDetails.sender.secondaryName: contactDetails ? contactDetails.localNickname : ""
+    messageDetails.sender.profileImage.name: contactDetails ? contactDetails.displayIcon : ""
     messageDetails.sender.profileImage.assetSettings.isImage: true
-    messageDetails.sender.profileImage.pubkey: notification.author
-    messageDetails.sender.profileImage.colorId: Utils.colorIdForPubkey(notification.author)
-    messageDetails.sender.profileImage.colorHash: Utils.getColorHashAsJson(notification.author, false, true)
+    messageDetails.sender.profileImage.pubkey: notification ? notification.author : ""
+    messageDetails.sender.profileImage.colorId: Utils.colorIdForPubkey(notification ? notification.author : "")
+    messageDetails.sender.profileImage.colorHash: Utils.getColorHashAsJson(notification ? notification.author : "", false, true)
 
     messageBadgeComponent: CommunityBadge {
-        readonly property var community: root.store.getCommunityDetailsAsJson(notification.communityId)
+        readonly property var community: notification ?
+                            root.store.getCommunityDetailsAsJson(notification.communityId) :
+                            null
 
-        communityName: community.name
-        communityImage: community.image
-        communityColor: community.color
+        communityName: community ? community.name : ""
+        communityImage: community ? community.image : ""
+        communityColor: community ? community.color : "black"
 
         onCommunityNameClicked: {
             root.store.setActiveCommunity(notification.communityId)
@@ -41,9 +45,9 @@ ActivityNotificationMessage {
     }
 
     ctaComponent: MembershipCta {
-        pending: notification.membershipStatus === Constants.activityCenterMembershipStatusPending
-        accepted: notification.membershipStatus === Constants.activityCenterMembershipStatusAccepted
-        declined: notification.membershipStatus === Constants.activityCenterMembershipStatusDeclined
+        pending: notification && notification.membershipStatus === Constants.activityCenterMembershipStatusPending
+        accepted: notification && notification.membershipStatus === Constants.activityCenterMembershipStatusAccepted
+        declined: notification && notification.membershipStatus === Constants.activityCenterMembershipStatusDeclined
         onAcceptRequestToJoinCommunity: root.store.acceptRequestToJoinCommunity(notification.id, notification.communityId)
         onDeclineRequestToJoinCommunity: root.store.declineRequestToJoinCommunity(notification.id, notification.communityId)
     }

--- a/ui/app/mainui/activitycenter/views/ActivityNotificationCommunityRequest.qml
+++ b/ui/app/mainui/activitycenter/views/ActivityNotificationCommunityRequest.qml
@@ -17,16 +17,18 @@ ActivityNotificationBase {
 
     bodyComponent: RowLayout {
         height: 50
-        readonly property var community: root.store.getCommunityDetailsAsJson(notification.communityId)
+        readonly property var community: notification ? 
+                                root.store.getCommunityDetailsAsJson(notification.communityId) :
+                                null
 
         StatusSmartIdenticon {
             id: identicon
-            name: community.name
+            name: community ? community.name : ""
+            asset.color: community ? community.color : "black"
+            asset.name: community ? community.image : ""
             asset.width: 40
             asset.height: 40
-            asset.color: community.color
             asset.letterSize: width / 2.4
-            asset.name: community.image
             asset.isImage: true
             Layout.alignment: Qt.AlignVCenter
             Layout.leftMargin: Style.current.padding
@@ -41,15 +43,17 @@ ActivityNotificationBase {
         }
 
         CommunityBadge {
-            communityName: community.name
-            communityImage: community.image
-            communityColor: community.color
+            communityName: community ? community.name : ""
+            communityImage: community ? community.image : ""
+            communityColor: community ? community.color : "black"
             onCommunityNameClicked: root.store.setActiveCommunity(notification.communityId)
             Layout.alignment: Qt.AlignVCenter
         }
 
         StatusBaseText {
             text: {
+                if (!notification)
+                    return ""
                 if (notification.membershipStatus === Constants.activityCenterMembershipStatusPending)
                     return qsTr("pending")
                 if (notification.membershipStatus === Constants.activityCenterMembershipStatusAccepted)
@@ -66,7 +70,8 @@ ActivityNotificationBase {
         }
     }
 
-    ctaComponent: notification.membershipStatus === Constants.activityCenterMembershipStatusAccepted ? visitComponent : null
+    ctaComponent: notification && notification.membershipStatus === Constants.activityCenterMembershipStatusAccepted ?
+                        visitComponent : null
 
     Component {
         id: visitComponent

--- a/ui/app/mainui/activitycenter/views/ActivityNotificationContactRequest.qml
+++ b/ui/app/mainui/activitycenter/views/ActivityNotificationContactRequest.qml
@@ -17,13 +17,15 @@ ActivityNotificationMessage {
     maximumLineCount: 5
 
     ctaComponent: ContactRequestCta {
-        readonly property string senderId: notification.message.senderId
-        readonly property var contactDetails: Utils.getContactDetailsAsJson(senderId)
+        readonly property string senderId: notification ? notification.message.senderId : ""
+        readonly property var contactDetails: notification ?
+                        Utils.getContactDetailsAsJson(notification.message.senderId) :
+                        null
 
-        pending: notification.message.contactRequestState == Constants.contactRequestStatePending
-        accepted: notification.message.contactRequestState == Constants.contactRequestStateAccepted
-        dismissed: notification.message.contactRequestState == Constants.contactRequestStateDismissed
-        blocked: contactDetails.isBlocked
+        pending: notification && notification.message.contactRequestState == Constants.contactRequestStatePending
+        accepted: notification && notification.message.contactRequestState == Constants.contactRequestStateAccepted
+        dismissed: notification && notification.message.contactRequestState == Constants.contactRequestStateDismissed
+        blocked: contactDetails && contactDetails.isBlocked
         onAcceptClicked: root.store.contactsStore.acceptContactRequest(senderId)
         onDeclineClicked: root.store.contactsStore.dismissContactRequest(senderId)
         onProfileClicked: Global.openProfilePopup(senderId)

--- a/ui/app/mainui/activitycenter/views/ActivityNotificationMention.qml
+++ b/ui/app/mainui/activitycenter/views/ActivityNotificationMention.qml
@@ -14,6 +14,9 @@ ActivityNotificationMessage {
     id: root
 
     badgeComponent: {
+        if (!notification)
+            return null
+
         switch (notification.chatType)
         {
         case Constants.chatType.communityChat:

--- a/ui/app/mainui/activitycenter/views/ActivityNotificationMessage.qml
+++ b/ui/app/mainui/activitycenter/views/ActivityNotificationMessage.qml
@@ -12,28 +12,32 @@ import utils 1.0
 ActivityNotificationBase {
     id: root
 
-    readonly property string timestampString: new Date(notification.timestamp).toLocaleTimeString(Qt.locale(), Locale.ShortFormat)
-    readonly property string timestampTooltipString: new Date(notification.timestamp).toLocaleString()
+    readonly property string timestampString: notification ?
+                new Date(notification.timestamp).toLocaleTimeString(Qt.locale(), Locale.ShortFormat) :
+                ""
+    readonly property string timestampTooltipString: notification ?
+                new Date(notification.timestamp).toLocaleString() :
+                ""
 
     property int maximumLineCount: 2
 
     signal messageClicked()
 
     property StatusMessageDetails messageDetails: StatusMessageDetails {
-        messageText: notification.message.messageText
-        amISender: notification.message.amISender
-        sender.id: notification.message.senderId
-        sender.displayName: notification.message.senderDisplayName
-        sender.secondaryName: notification.message.senderOptionalName
-        sender.trustIndicator: notification.message.senderTrustStatus
+        messageText: notification ? notification.message.messageText : ""
+        amISender: notification ? notification.message.amISender : false
+        sender.id: notification ? notification.message.senderId : ""
+        sender.displayName: notification ? notification.message.senderDisplayName : ""
+        sender.secondaryName: notification ? notification.message.senderOptionalName : ""
+        sender.trustIndicator: notification ? notification.message.senderTrustStatus : Constants.trustStatus.unknown
         sender.profileImage {
             width: 40
             height: 40
-            name: notification.message.senderIcon || ""
-            assetSettings.isImage: notification.message.senderIcon.startsWith("data")
-            pubkey: notification.message.senderId
-            colorId: Utils.colorIdForPubkey(notification.message.senderId)
-            colorHash: Utils.getColorHashAsJson(notification.message.senderId)
+            name: notification ? notification.message.senderIcon || "" : ""
+            assetSettings.isImage: notification ? notification.message.senderIcon.startsWith("data") : false
+            pubkey: notification ? notification.message.senderId : ""
+            colorId: Utils.colorIdForPubkey(notification ? notification.message.senderId : "")
+            colorHash: Utils.getColorHashAsJson(notification ? notification.message.senderId : "")
         }
     }
 
@@ -44,11 +48,13 @@ ActivityNotificationBase {
         closeActivityCenter()
         Global.openProfilePopup(notification.message.senderId)
     }
+
     bodyComponent: MouseArea {
+        height: messageRow.implicitHeight
         hoverEnabled: root.messageBadgeComponent
         cursorShape: Qt.PointingHandCursor
         onClicked: root.messageClicked()
-        height: messageRow.implicitHeight
+
         RowLayout {
             id: messageRow
             spacing: 8

--- a/ui/app/mainui/activitycenter/views/ActivityNotificationReply.qml
+++ b/ui/app/mainui/activitycenter/views/ActivityNotificationReply.qml
@@ -14,7 +14,7 @@ ActivityNotificationMessage {
     id: root
 
     badgeComponent: ReplyBadge {
-        repliedMessageContent: notification.repliedMessage.messageText
+        repliedMessageContent: notification ? notification.repliedMessage.messageText : ""
         onReplyClicked: {
             root.activityCenterStore.switchTo(notification)
             root.closeActivityCenter()


### PR DESCRIPTION
Close #8499

### What does the PR do

Replace DelegateChooser with Loader

### Affected areas

Activity Center

### Screenshot of functionality (including design for comparison)

<img width="566" alt="Screenshot 2022-11-30 at 15 13 52" src="https://user-images.githubusercontent.com/2522130/204782395-cd0890d6-52a3-4744-a7d8-16f4311b8430.png">
