### PR TITLE
fix: figma links pasted in channel are not clickable

### DIFF
--- a/ui/StatusQ/src/StatusQ/Core/Utils/Utils.qml
+++ b/ui/StatusQ/src/StatusQ/Core/Utils/Utils.qml
@@ -154,8 +154,8 @@ QtObject {
     }
 
     function linkifyAndXSS(inputText) {
-        //URLs starting with http://, https://, or ftp://
-        var replacePattern1 = /(\b(https?|ftp|statusim):\/\/[-A-Z0-9+&@#\/%?=~_|!:,.;]*[-A-Z0-9+&@#\/%=~_|])/gim;
+        //URLs starting with http://, https://, ftp:// or status-im://
+        var replacePattern1 = /(\b(https?|ftp|status-im):\/\/[-A-Z0-9+&@#\/%?=~_|!:,.;\(\)]*[-A-Z0-9+&@#\/%=~_|])/gim;
         var replacedText = inputText.replace(replacePattern1, "<a href='$1'>$1</a>");
 
         //URLs starting with "www." (without // before it, or it'd re-link the ones done above).


### PR DESCRIPTION
- recognize parentheses, `(` and `)` respectively, as part of a URL when linkifying the hyperlink; these are valid URL characters
- also correct the "status-im" deep link prefix to the new form

Fixes: #8512

### What does the PR do

Fixes highlighting URLs containing `(` or `)`

### Affected areas

Utils.linkifyAndXSS()

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![image](https://user-images.githubusercontent.com/5377645/204802040-3a3128f6-83a9-4eac-9b7c-7161796e9bb8.png)

