### PR TITLE
fix(general): removed not working code for cropping tmp profile image

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/StatusSmartIdenticon.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusSmartIdenticon.qml
@@ -42,12 +42,7 @@ Loader {
                 color: root.asset.imgIsIdenticon ?
                            Theme.palette.statusRoundedImage.backgroundColor :
                            root.asset.bgColor
-                image.fillMode: root.asset.cropRect ? Image.PreserveAspectCrop
-                                                    : Image.PreserveAspectFit
-                image.x: root.asset.cropRectangle ? -root.asset.cropRectangle.x
-                                                  : 0
-                image.y: root.asset.cropRectangle ? -root.asset.cropRectangle.y
-                                                  : 0
+                image.fillMode: Image.PreserveAspectCrop
             }
             Loader {
                 anchors.centerIn: parent

--- a/ui/StatusQ/src/StatusQ/Core/StatusAssetSettings.qml
+++ b/ui/StatusQ/src/StatusQ/Core/StatusAssetSettings.qml
@@ -34,7 +34,4 @@ QtObject {
     property bool isImage: false
     property int imgStatus
     property bool imgIsIdenticon: false
-
-    // crop
-    property rect cropRect
 }

--- a/ui/imports/shared/controls/chat/ProfileHeader.qml
+++ b/ui/imports/shared/controls/chat/ProfileHeader.qml
@@ -27,7 +27,7 @@ Item {
     property bool isContact: false
     property bool isCurrentUser
     property bool userIsEnsVerified
-    property rect cropRect: undefined
+    property rect cropRect
 
     property int imageSize: ProfileHeader.ImageSize.Compact
     property bool displayNameVisible: true
@@ -83,7 +83,6 @@ Item {
                 imageWidth: d.getSize(36, 64, 160)
                 imageHeight: imageWidth
                 showRing: !root.userIsEnsVerified
-                cropRect: root.cropRect
             }
 
             StatusRoundButton {

--- a/ui/imports/shared/controls/chat/UserImage.qml
+++ b/ui/imports/shared/controls/chat/UserImage.qml
@@ -20,8 +20,6 @@ Loader {
     property bool interactive: true
     property bool disabled: false
 
-    property rect cropRect: undefined
-
     property int colorId: Utils.colorIdForPubkey(pubkey)
     property var colorHash: Utils.getColorHashAsJson(pubkey)
 
@@ -36,7 +34,6 @@ Loader {
             name: root.image
             charactersLen: 2
             isImage: true
-            cropRect: root.cropRect
         }
         ringSettings {
             ringSpecModel: root.showRing ? root.colorHash : undefined


### PR DESCRIPTION
### What does the PR do

Removes not working code for cropping tmp profile image.

It was a source of warnings in the app and storybook.

Qml `rect` type cannot be set to `undefined` like that:
```
property rect cropRect: undefined
```

Closes: #8519