### PR TITLE
fix(@desktop/wallet): Wrong Password error should not be handled in the SendModal

### DIFF
--- a/src/app/modules/main/profile_section/ens_usernames/module.nim
+++ b/src/app/modules/main/profile_section/ens_usernames/module.nim
@@ -20,6 +20,8 @@ logScope:
 
 include ../../../../../app_service/common/json_utils
 
+const cancelledRequest* = "cancelled"
+
 # Shouldn't be public ever, user only within this module.
 type TmpSendEnsTransactionDetails = object
   ensUsername: string
@@ -359,10 +361,14 @@ method setPrefferedEnsUsername*(self: Module, ensUsername: string) =
   self.controller.setPreferredName(ensUsername)
 
 method onUserAuthenticated*(self: Module, password: string) =
-  if self.tmpSendEnsTransactionDetails.isRegistration:
-    self.registerEns(password)
-  elif self.tmpSendEnsTransactionDetails.isRelease:
-    self.releaseEns(password)
-  elif self.tmpSendEnsTransactionDetails.isSetPubKey:
-    self.setPubKey(password)
+  if password.len == 0:
+    let response = %* {"success": false, "result": cancelledRequest}
+    self.view.emitTransactionWasSentSignal($response)
+  else:
+    if self.tmpSendEnsTransactionDetails.isRegistration:
+      self.registerEns(password)
+    elif self.tmpSendEnsTransactionDetails.isRelease:
+      self.releaseEns(password)
+    elif self.tmpSendEnsTransactionDetails.isSetPubKey:
+     self.setPubKey(password)
 

--- a/src/app/modules/main/wallet_section/transactions/module.nim
+++ b/src/app/modules/main/wallet_section/transactions/module.nim
@@ -1,4 +1,4 @@
-import NimQml, stint
+import NimQml, stint, json
 
 import ./io_interface, ./view, ./controller
 import ../io_interface as delegate_interface
@@ -9,6 +9,8 @@ import ../../../../../app_service/service/wallet_account/service as wallet_accou
 import ../../../../../app_service/service/network/service as network_service
 
 export io_interface
+
+const cancelledRequest* = "cancelled"
 
 # Shouldn't be public ever, user only within this module.
 type TmpSendTransactionDetails = object
@@ -135,9 +137,13 @@ method authenticateAndTransfer*(self: Module, from_addr: string, to_addr: string
   ##################################
 
 method onUserAuthenticated*(self: Module, password: string) =
-  self.controller.transfer(self.tmpSendTransactionDetails.fromAddr, self.tmpSendTransactionDetails.toAddr,
-    self.tmpSendTransactionDetails.tokenSymbol, self.tmpSendTransactionDetails.value, self.tmpSendTransactionDetails.uuid,
-    self.tmpSendTransactionDetails.priority, self.tmpSendTransactionDetails.selectedRoutes, password)
+  if password.len == 0:
+    let response = %* {"uuid": self.tmpSendTransactionDetails.uuid, "success": false, "error": cancelledRequest}
+    self.view.transactionWasSent($response)
+  else:
+    self.controller.transfer(self.tmpSendTransactionDetails.fromAddr, self.tmpSendTransactionDetails.toAddr,
+      self.tmpSendTransactionDetails.tokenSymbol, self.tmpSendTransactionDetails.value, self.tmpSendTransactionDetails.uuid,
+      self.tmpSendTransactionDetails.priority, self.tmpSendTransactionDetails.selectedRoutes, password)
 
 method transactionWasSent*(self: Module, result: string) =
   self.view.transactionWasSent(result)

--- a/ui/app/AppLayouts/Profile/views/EnsDetailsView.qml
+++ b/ui/app/AppLayouts/Profile/views/EnsDetailsView.qml
@@ -150,8 +150,7 @@ Item {
                     try {
                         let response = JSON.parse(txResult)
                         if (!response.success) {
-                            if (Utils.isInvalidPasswordMessage(response.result)) {
-                                releaseEnsModal.setSendTxError()
+                            if (response.result.includes(Constants.walletSection.cancelledMessage)) {
                                 return
                             }
                             releaseEnsModal.sendingError.text = response.result

--- a/ui/app/AppLayouts/Profile/views/EnsSearchView.qml
+++ b/ui/app/AppLayouts/Profile/views/EnsSearchView.qml
@@ -101,8 +101,7 @@ Item {
                     try {
                         let response = JSON.parse(txResult)
                         if (!response.success) {
-                            if (Utils.isInvalidPasswordMessage(response.result)) {
-                                releaseEnsModal.setSendTxError()
+                            if (response.result.includes(Constants.walletSection.cancelledMessage)) {
                                 return
                             }
                             releaseEnsModal.sendingError.text = response.result

--- a/ui/app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml
+++ b/ui/app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml
@@ -90,8 +90,7 @@ Item {
                     try {
                         let response = JSON.parse(txResult)
                         if (!response.success) {
-                            if (Utils.isInvalidPasswordMessage(response.result)) {
-                                buyEnsModal.setSendTxError()
+                            if (response.result.includes(Constants.walletSection.cancelledMessage)) {
                                 return
                             }
                             buyEnsModal.sendingError.text = response.result

--- a/ui/imports/shared/status/StatusStickerMarket.qml
+++ b/ui/imports/shared/status/StatusStickerMarket.qml
@@ -193,8 +193,7 @@ Item {
                                 try {
                                     let response = JSON.parse(txResult)
                                     if (!response.success) {
-                                        if (Utils.isInvalidPasswordMessage(response.result)) {
-                                            buyStickersModal.setSendTxError()
+                                        if (response.result.includes(Constants.walletSection.cancelledMessage)) {
                                             return
                                         }
                                         buyStickersModal.sendingError.text = response.result

--- a/ui/imports/shared/status/StatusStickerPackClickPopup.qml
+++ b/ui/imports/shared/status/StatusStickerPackClickPopup.qml
@@ -106,8 +106,7 @@ ModalPopup {
                         try {
                             let response = JSON.parse(txResult)
                             if (!response.success) {
-                                if (Utils.isInvalidPasswordMessage(response.result)) {
-                                    buyStickersPackModal.setSendTxError()
+                                if (response.result.includes(Constants.walletSection.cancelledMessage)) {
                                     return
                                 }
                                 buyStickersPackModal.sendingError.text = response.result

--- a/ui/imports/shared/views/NetworkCardsComponent.qml
+++ b/ui/imports/shared/views/NetworkCardsComponent.qml
@@ -121,10 +121,10 @@ Item {
             spacing: 12
             StatusBaseText {
                 Layout.alignment: Qt.AlignRight
-                Layout.maximumWidth: 70
+                Layout.maximumWidth: 100
                 font.pixelSize: 10
                 color: Theme.palette.baseColor1
-                text: selectedAccount.address
+                text: StatusQUtils.Utils.elideText(selectedAccount.address, 6, 4).toUpperCase()
                 elide: Text.ElideMiddle
             }
             Repeater {

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -715,4 +715,8 @@ QtObject {
         StickersBuy,
         Bridge
     }
+
+    readonly property QtObject walletSection: QtObject {
+        readonly property string cancelledMessage: "cancelled"
+    }
 }


### PR DESCRIPTION
fix(@desktop/wallet): Wrong Password error should not be handled in the SendModal
fixes #8527

### What does the PR do

Handles the issues below:

- Wrong Password error should not be handled in the SendModal
- sender Address in advanced view should be capitalised
- While scrolling the gradient should show up on top of the content and not be added extra

### Affected areas

Wallet

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it
<img width="950" alt="image" src="https://user-images.githubusercontent.com/60327365/204912125-65bcfc5f-2f55-4252-acaf-69a7463a807a.png">

<img width="950" alt="image" src="https://user-images.githubusercontent.com/60327365/204912224-b08d0d48-a1ad-4e8b-a2bd-c7cfa9934a65.png">

