### PR TITLE
fix(MyProfileSettingsView): Temporary image cropped properly

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/StatusSmartIdenticon.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusSmartIdenticon.qml
@@ -42,12 +42,7 @@ Loader {
                 color: root.asset.imgIsIdenticon ?
                            Theme.palette.statusRoundedImage.backgroundColor :
                            root.asset.bgColor
-                image.fillMode: root.asset.cropRect ? Image.PreserveAspectCrop
-                                                    : Image.PreserveAspectFit
-                image.x: root.asset.cropRectangle ? -root.asset.cropRectangle.x
-                                                  : 0
-                image.y: root.asset.cropRectangle ? -root.asset.cropRectangle.y
-                                                  : 0
+                image.fillMode: Image.PreserveAspectCrop
             }
             Loader {
                 anchors.centerIn: parent

--- a/ui/StatusQ/src/StatusQ/Core/StatusAssetSettings.qml
+++ b/ui/StatusQ/src/StatusQ/Core/StatusAssetSettings.qml
@@ -34,7 +34,4 @@ QtObject {
     property bool isImage: false
     property int imgStatus
     property bool imgIsIdenticon: false
-
-    // crop
-    property rect cropRect
 }

--- a/ui/app/AppLayouts/Profile/views/profile/MyProfileSettingsView.qml
+++ b/ui/app/AppLayouts/Profile/views/profile/MyProfileSettingsView.qml
@@ -32,7 +32,7 @@ ColumnLayout {
         property string displayName: descriptionPanel.displayName.text
         property string bio: descriptionPanel.bio.text
         property bool biomentricValue: biometricsSwitch.checked
-        property url profileLargeImage: profileHeader.icon
+        property url profileLargeImage: profileHeader.previewIcon
     }
 
     readonly property bool dirty: descriptionPanel.displayName.text !== profileStore.displayName ||

--- a/ui/imports/shared/controls/chat/ProfileHeader.qml
+++ b/ui/imports/shared/controls/chat/ProfileHeader.qml
@@ -23,6 +23,7 @@ Item {
     property string displayName
     property string pubkey
     property string icon
+    property url previewIcon: icon
     property int trustStatus
     property bool isContact: false
     property bool isCurrentUser
@@ -42,6 +43,10 @@ Item {
     signal clicked()
     signal editClicked()
 
+    Binding on previewIcon {
+        value: icon
+    }
+
     height: visible ? contentContainer.height : 0
     implicitHeight: contentContainer.implicitHeight
 
@@ -53,6 +58,34 @@ Item {
                 case ProfileHeader.ImageSize.Middle: return normal;
                 case ProfileHeader.ImageSize.Big: return big;
             }
+        }
+    }
+
+    Item {
+        id: tmpCroppedImageHelper
+
+        visible: false
+
+        Image {
+            id: tmpImage
+            mipmap: true
+        }
+
+        property var keepGrabResultAlive;
+
+        function setCroppedTmpIcon(source, x, y, width, height) {
+            tmpCroppedImageHelper.width = width
+            tmpCroppedImageHelper.height = height
+
+            tmpImage.x = -x
+            tmpImage.y = -y
+            tmpImage.source = source
+
+            tmpCroppedImageHelper.grabToImage(result => {
+                keepGrabResultAlive = result
+                root.previewIcon = result.url
+                tmpImage.source = ""
+            })
         }
     }
 
@@ -78,7 +111,7 @@ Item {
                 objectName: "ProfileHeader_userImage"
                 name: root.displayName
                 pubkey: root.pubkey
-                image: root.icon
+                image: root.previewIcon
                 interactive: false
                 imageWidth: d.getSize(36, 64, 160)
                 imageHeight: imageWidth
@@ -110,6 +143,9 @@ Item {
                 function tempIcon(image, aX, aY, bX, bY) {
                     root.icon = image
                     root.cropRect = Qt.rect(aX, aY, bX - aX, bY - aY)
+
+                    tmpCroppedImageHelper.setCroppedTmpIcon(
+                                image, aX, aY, bX - aX, bY - aY)
                 }
             }
         }

--- a/ui/imports/shared/controls/chat/ProfileHeader.qml
+++ b/ui/imports/shared/controls/chat/ProfileHeader.qml
@@ -27,7 +27,7 @@ Item {
     property bool isContact: false
     property bool isCurrentUser
     property bool userIsEnsVerified
-    property rect cropRect: undefined
+    property rect cropRect
 
     property int imageSize: ProfileHeader.ImageSize.Compact
     property bool displayNameVisible: true
@@ -83,7 +83,6 @@ Item {
                 imageWidth: d.getSize(36, 64, 160)
                 imageHeight: imageWidth
                 showRing: !root.userIsEnsVerified
-                cropRect: root.cropRect
             }
 
             StatusRoundButton {

--- a/ui/imports/shared/controls/chat/UserImage.qml
+++ b/ui/imports/shared/controls/chat/UserImage.qml
@@ -20,8 +20,6 @@ Loader {
     property bool interactive: true
     property bool disabled: false
 
-    property rect cropRect: undefined
-
     property int colorId: Utils.colorIdForPubkey(pubkey)
     property var colorHash: Utils.getColorHashAsJson(pubkey)
 
@@ -36,7 +34,6 @@ Loader {
             name: root.image
             charactersLen: 2
             isImage: true
-            cropRect: root.cropRect
         }
         ringSettings {
             ringSpecModel: root.showRing ? root.colorHash : undefined


### PR DESCRIPTION
### What does the PR do

Fixes cropping for temporary profile images.

Closes: #8520

### Affected areas
`MyProfileSettingsView`

### Screenshot of functionality (including design for comparison)

[Kazam_screencast_00090.webm](https://user-images.githubusercontent.com/20650004/205007620-48b46a97-5c8d-4955-93be-187b4d6c1797.webm)
