### PR TITLE
Fix(ActivityCenter): Fix reply badge text eliding

### DIFF
--- a/ui/app/mainui/activitycenter/controls/ReplyBadge.qml
+++ b/ui/app/mainui/activitycenter/controls/ReplyBadge.qml
@@ -1,12 +1,12 @@
 import QtQuick 2.4
+import QtQuick.Layouts 1.4
 
 import StatusQ.Core 0.1
+import StatusQ.Core.Utils 0.1 as StatusQUtils
 
 import utils 1.0
 import shared.controls 1.0
 import shared.panels 1.0
-
-import StatusQ.Core.Utils 0.1 as StatusQUtils
 
 Badge {
     id: root
@@ -15,32 +15,43 @@ Badge {
 
     signal replyClicked()
 
-    SVGImage {
-        id: replyIcon
-        anchors.left: parent.left
-        anchors.leftMargin: Style.current.smallPadding
-        anchors.verticalCenter: parent.verticalCenter
-        width: 16
-        height: width
-        source: Style.svg("reply-small-arrow")
+    implicitWidth: layout.implicitWidth + layout.anchors.leftMargin + layout.anchors.rightMargin
+    implicitHeight: layout.implicitHeight + layout.anchors.topMargin + layout.anchors.bottomMargin
+
+    RowLayout {
+        id: layout
+
+        anchors {
+            fill: parent
+            leftMargin: 8
+            rightMargin: 8
+            topMargin: 3
+            bottomMargin: 3
+        }
+
+        spacing: 4
+
+        StatusIcon {
+            source: Style.svg("reply-small-arrow")
+            Layout.preferredWidth: 16
+            Layout.preferredHeight: 16
+        }
+
+        StatusBaseText {
+            text: repliedMessageContent
+            maximumLineCount: 1
+            wrapMode: Text.Wrap
+            elide: Text.ElideRight
+            font.pixelSize: 13
+            Layout.maximumWidth: 300
+            Layout.alignment: Qt.AlignVCenter
+        }
     }
 
-    StatusBaseText {
-        anchors.left: replyIcon.right
-        anchors.leftMargin: 4
-        anchors.verticalCenter: parent.verticalCenter
-        width: Math.min(implicitWidth, 300)
-        text: repliedMessageContent
-        maximumLineCount: 1
-        elide: Text.ElideRight
-        font.pixelSize: 13
-
-        MouseArea {
-            id: replyArea
-            hoverEnabled: true
-            anchors.fill: parent
-            cursorShape: Qt.PointingHandCursor
-            onClicked: root.replyClicked()
-        }
+    MouseArea {
+        hoverEnabled: true
+        anchors.fill: layout
+        cursorShape: Qt.PointingHandCursor
+        onClicked: root.replyClicked()
     }
 }


### PR DESCRIPTION
Close #8526

### What does the PR do

Re-layout and fix eliding reply badge 

### Affected areas

Activity Center

### Screenshot of functionality (including design for comparison)

<img width="546" alt="Screenshot 2022-12-01 at 14 29 02" src="https://user-images.githubusercontent.com/2522130/205030677-5faa7f13-75ac-4512-b526-375bd0571323.png">
