### PR TITLE
chore: reduce the number of (verification) RPC calls

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
@@ -60,6 +60,7 @@ Control {
     property bool hasExpired: false
     property double timestamp: 0
     property var reactionsModel: []
+    property bool hasLinks
 
     property bool showHeader: true
     property bool isActiveMessage: false
@@ -346,7 +347,7 @@ Control {
                     }
                     Loader {
                         id: linksLoader
-                        active: !root.editMode
+                        active: !root.editMode && root.hasLinks
                         visible: active
                     }
                     Loader {

--- a/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusMessageReply.qml
+++ b/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusMessageReply.qml
@@ -1,6 +1,5 @@
 import QtQuick 2.14
 import QtQuick.Shapes 1.13
-import QtGraphicalEffects 1.13
 import QtQuick.Layouts 1.14
 
 import StatusQ.Core 0.1

--- a/ui/app/AppLayouts/Chat/panels/SuggestionBoxPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/SuggestionBoxPanel.qml
@@ -198,7 +198,7 @@ Rectangle {
                 objectName: model.name
                 color: ListView.isCurrentItem ? Style.current.backgroundHover : Style.current.transparent
                 border.width: 0
-                width: parent.width
+                width: ListView.view.width
                 height: 42
                 radius: Style.current.radius
 

--- a/ui/app/AppLayouts/Chat/panels/UserListPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/UserListPanel.qml
@@ -77,7 +77,7 @@ Item {
                 readonly property bool ensVerified: Utils.isEnsVerified(model.pubKey)
                 width: ListView.view.width
                 nickName: model.localNickname
-                userName: ensVerified ? model.ensName : model.displayName !== "" ? model.displayName : model.alias
+                userName: ensVerified ? model.ensName : model.displayName || model.alias
                 pubKey: ensVerified ? "" : Utils.getCompressedPk(model.pubKey)
                 isContact: model.isContact
                 isVerified: model.isVerified
@@ -88,7 +88,7 @@ Item {
                 asset.isLetterIdenticon: (asset.name === "")
                 asset.color: Utils.colorForColorId(model.colorId)
                 status: model.onlineStatus
-                ringSettings.ringSpecModel: ensVerified ? undefined : Utils.getColorHashAsJson(model.pubKey, true) // FIXME: use model.colorHash
+                ringSettings.ringSpecModel: Utils.getColorHashAsJson(model.pubKey, ensVerified) // FIXME: use model.colorHash
                 onClicked: {
                     if (mouse.button === Qt.RightButton) {
                         // Set parent, X & Y positions for the messageContextMenu

--- a/ui/app/AppLayouts/Chat/panels/communities/CommunityMembersTabPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/CommunityMembersTabPanel.qml
@@ -138,7 +138,7 @@ Item {
                 asset.isLetterIdenticon: !model.icon
                 asset.width: 40
                 asset.height: 40
-                ringSettings.ringSpecModel: !!model.ensName ? undefined : Utils.getColorHashAsJson(model.pubKey, true)
+                ringSettings.ringSpecModel: Utils.getColorHashAsJson(model.pubKey, !!model.ensName)
                 statusListItemIcon.badge.visible: (root.panelType === CommunityMembersTabPanel.TabType.AllMembers)
 
                 onClicked: root.userProfileClicked(model.pubKey)

--- a/ui/app/AppLayouts/Chat/popups/community/MembershipRequestsPopup.qml
+++ b/ui/app/AppLayouts/Chat/popups/community/MembershipRequestsPopup.qml
@@ -57,9 +57,9 @@ StatusModal {
 
                 delegate: StatusListItem {
                     anchors.horizontalCenter: parent.horizontalCenter
-                    property var contactDetails: Utils.getContactDetailsAsJson(model.pubKey)
+                    readonly property var contactDetails: Utils.getContactDetailsAsJson(model.pubKey, false)
 
-                    property string displayName: contactDetails.displayName || popup.store.generateAlias(model.pubKey)
+                    readonly property string displayName: contactDetails.displayName || popup.store.generateAlias(model.pubKey)
                     asset.name: contactDetails.thumbnailImage
                     asset.isImage: true
                     title: displayName

--- a/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
@@ -52,9 +52,8 @@ Item {
     property bool stickersLoaded: false
     property Timer timer: Timer { }
     property var userList
-    property var contactDetails: Utils.getContactDetailsAsJson(root.activeChatId)
+    property var contactDetails: Utils.getContactDetailsAsJson(root.activeChatId, false)
     property bool isUserAdded: root.contactDetails.isAdded
-    property bool contactRequestReceived: root.contactDetails.requestReceived
 
     signal openAppSearch()
     signal openStickerPackPopup(string stickerPackId)
@@ -106,7 +105,7 @@ Item {
     // This function is called once `1:1` or `group` chat is created.
     function checkForCreateChatOptions(chatId) {
         if(root.rootStore.createChatStartSendTransactionProcess) {
-            if (Utils.getContactDetailsAsJson(chatId).ensVerified) {
+            if (root.contactDetails.ensVerified) {
                 Global.openPopup(cmpSendTransactionWithEns);
             } else {
                 Global.openPopup(cmpSendTransactionNoEns);

--- a/ui/app/AppLayouts/Chat/views/ChatContentView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatContentView.qml
@@ -207,7 +207,7 @@ ColumnLayout {
                         return
                     }
 
-                    if (Utils.getContactDetailsAsJson(chatContentModule.getMyChatId()).ensVerified) {
+                    if (Utils.isEnsVerified(chatContentModule.getMyChatId())) {
                         Global.openPopup(root.sendTransactionWithEnsModal)
                     } else {
                         Global.openPopup(root.sendTransactionNoEnsModal)

--- a/ui/app/AppLayouts/Chat/views/MembersSelectorView.qml
+++ b/ui/app/AppLayouts/Chat/views/MembersSelectorView.qml
@@ -93,7 +93,7 @@ MembersSelectorBase {
             if (resolvedPubKey === "")
                 return
 
-            const contactDetails = Utils.getContactDetailsAsJson(resolvedPubKey)
+            const contactDetails = Utils.getContactDetailsAsJson(resolvedPubKey, false)
 
             if (contactDetails.publicKey === root.rootStore.contactsStore.myPublicKey)
                 return;

--- a/ui/app/AppLayouts/Onboarding/views/InsertDetailsView.qml
+++ b/ui/app/AppLayouts/Onboarding/views/InsertDetailsView.qml
@@ -97,7 +97,7 @@ Item {
                 asset.isImage: !!asset.name
                 asset.imgIsIdenticon: false
                 ringSettings {
-                    ringSpecModel: Utils.getColorHashAsJson(root.pubKey, true)
+                    ringSpecModel: Utils.getColorHashAsJson(root.pubKey)
                 }
             }
             StatusRoundButton {
@@ -198,7 +198,7 @@ Item {
                 asset.width: 44
                 asset.height: 44
                 asset.color: "transparent"
-                ringSettings { ringSpecModel: Utils.getColorHashAsJson(root.pubKey, true) }
+                ringSettings { ringSpecModel: Utils.getColorHashAsJson(root.pubKey) }
             }
         }
 

--- a/ui/app/AppLayouts/Profile/panels/ContactPanel.qml
+++ b/ui/app/AppLayouts/Profile/panels/ContactPanel.qml
@@ -71,7 +71,7 @@ StatusListItem {
     asset.isImage: asset.name.includes("data")
     asset.isLetterIdenticon: root.iconSource.toString() === ""
     ringSettings {
-        ringSpecModel: d.ensVerified ? undefined : Utils.getColorHashAsJson(root.publicKey, true)
+        ringSpecModel: Utils.getColorHashAsJson(root.publicKey, d.ensVerified)
         ringPxSize: Math.max(asset.width / 24.0)
     }
 

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -442,7 +442,8 @@ Item {
                 identicon.asset.height: height
                 identicon.asset.charactersLen: 2
                 identicon.asset.color: Utils.colorForPubkey(appMain.rootStore.userProfileInst.pubKey)
-                identicon.ringSettings.ringSpecModel: appMain.rootStore.userProfileInst.ensName ? undefined : Utils.getColorHashAsJson(appMain.rootStore.userProfileInst.pubKey, true)
+                identicon.ringSettings.ringSpecModel: Utils.getColorHashAsJson(appMain.rootStore.userProfileInst.pubKey,
+                                                                               appMain.rootStore.userProfileInst.ensName)
 
                 badge.visible: true
                 badge.anchors {

--- a/ui/app/mainui/Popups.qml
+++ b/ui/app/mainui/Popups.qml
@@ -11,7 +11,7 @@ QtObject {
     /* required */ property var rootStore
 
     function openSendIDRequestPopup(publicKey, cb) {
-        const contactDetails = Utils.getContactDetailsAsJson(publicKey)
+        const contactDetails = Utils.getContactDetailsAsJson(publicKey, false)
         const popup = Global.openPopup(sendIDRequestPopupComponent, {
             userPublicKey: publicKey,
             userDisplayName: contactDetails.displayName,
@@ -74,7 +74,7 @@ QtObject {
     }
 
     function openContactRequestPopup(publicKey, cb) {
-        const contactDetails = Utils.getContactDetailsAsJson(publicKey)
+        const contactDetails = Utils.getContactDetailsAsJson(publicKey, false)
         const popupProperties = {
             userPublicKey: publicKey,
             userDisplayName: contactDetails.displayName,

--- a/ui/app/mainui/activitycenter/views/ActivityNotificationCommunityMembershipRequest.qml
+++ b/ui/app/mainui/activitycenter/views/ActivityNotificationCommunityMembershipRequest.qml
@@ -17,7 +17,7 @@ ActivityNotificationMessage {
     id: root
 
     readonly property var contactDetails: notification ?
-                                            Utils.getContactDetailsAsJson(notification.author) : 
+                                            Utils.getContactDetailsAsJson(notification.author, false) :
                                             null
 
     messageDetails.messageText: qsTr("Wants to join")
@@ -27,7 +27,7 @@ ActivityNotificationMessage {
     messageDetails.sender.profileImage.assetSettings.isImage: true
     messageDetails.sender.profileImage.pubkey: notification ? notification.author : ""
     messageDetails.sender.profileImage.colorId: Utils.colorIdForPubkey(notification ? notification.author : "")
-    messageDetails.sender.profileImage.colorHash: Utils.getColorHashAsJson(notification ? notification.author : "", false, true)
+    messageDetails.sender.profileImage.colorHash: Utils.getColorHashAsJson(notification ? notification.author : "", contactDetails.ensVerified)
 
     messageBadgeComponent: CommunityBadge {
         readonly property var community: notification ?

--- a/ui/app/mainui/activitycenter/views/ActivityNotificationContactRequest.qml
+++ b/ui/app/mainui/activitycenter/views/ActivityNotificationContactRequest.qml
@@ -19,12 +19,12 @@ ActivityNotificationMessage {
     ctaComponent: ContactRequestCta {
         readonly property string senderId: notification ? notification.message.senderId : ""
         readonly property var contactDetails: notification ?
-                        Utils.getContactDetailsAsJson(notification.message.senderId) :
+                        Utils.getContactDetailsAsJson(notification.message.senderId, false) :
                         null
 
-        pending: notification && notification.message.contactRequestState == Constants.contactRequestStatePending
-        accepted: notification && notification.message.contactRequestState == Constants.contactRequestStateAccepted
-        dismissed: notification && notification.message.contactRequestState == Constants.contactRequestStateDismissed
+        pending: notification && notification.message.contactRequestState === Constants.contactRequestStatePending
+        accepted: notification && notification.message.contactRequestState === Constants.contactRequestStateAccepted
+        dismissed: notification && notification.message.contactRequestState === Constants.contactRequestStateDismissed
         blocked: contactDetails && contactDetails.isBlocked
         onAcceptClicked: root.store.contactsStore.acceptContactRequest(senderId)
         onDeclineClicked: root.store.contactsStore.dismissContactRequest(senderId)

--- a/ui/app/mainui/activitycenter/views/ActivityNotificationMessage.qml
+++ b/ui/app/mainui/activitycenter/views/ActivityNotificationMessage.qml
@@ -53,7 +53,10 @@ ActivityNotificationBase {
         height: messageRow.implicitHeight
         hoverEnabled: root.messageBadgeComponent
         cursorShape: Qt.PointingHandCursor
-        onClicked: root.messageClicked()
+        onClicked: {
+            root.activityCenterStore.switchTo(notification)
+            root.closeActivityCenter()
+        }
 
         RowLayout {
             id: messageRow

--- a/ui/imports/shared/controls/chat/ProfileHeader.qml
+++ b/ui/imports/shared/controls/chat/ProfileHeader.qml
@@ -82,7 +82,7 @@ Item {
                 interactive: false
                 imageWidth: d.getSize(36, 64, 160)
                 imageHeight: imageWidth
-                showRing: !root.userIsEnsVerified
+                ensVerified: root.userIsEnsVerified
             }
 
             StatusRoundButton {

--- a/ui/imports/shared/controls/chat/UserImage.qml
+++ b/ui/imports/shared/controls/chat/UserImage.qml
@@ -16,12 +16,13 @@ Loader {
     property string name
     property string pubkey
     property string image
-    property bool showRing: true
+    property bool showRing: !ensVerified
     property bool interactive: true
     property bool disabled: false
+    property bool ensVerified: false
 
     property int colorId: Utils.colorIdForPubkey(pubkey)
-    property var colorHash: Utils.getColorHashAsJson(pubkey)
+    property var colorHash: Utils.getColorHashAsJson(pubkey, ensVerified)
 
     signal clicked()
 
@@ -30,7 +31,7 @@ Loader {
         asset {
             width: root.imageWidth
             height: root.imageHeight
-            color: Theme.palette.userCustomizationColors[root.colorId]
+            color: Utils.colorForColorId(root.colorId)
             name: root.image
             charactersLen: 2
             isImage: true

--- a/ui/imports/shared/controls/delegates/ContactListItemDelegate.qml
+++ b/ui/imports/shared/controls/delegates/ContactListItemDelegate.qml
@@ -28,6 +28,6 @@ StatusMemberListItem {
     asset.isLetterIdenticon: (asset.name === "")
     status: model.onlineStatus
     statusListItemIcon.badge.border.color: sensor.containsMouse ? Theme.palette.baseColor2 : Theme.palette.baseColor4
-    ringSettings.ringSpecModel: hasEnsName ? undefined : Utils.getColorHashAsJson(model.pubKey, true)
+    ringSettings.ringSpecModel: Utils.getColorHashAsJson(model.pubKey, hasEnsName)
     color: (sensor.containsMouse || highlighted) ? Theme.palette.baseColor2 : "transparent"
 }

--- a/ui/imports/shared/status/StatusInputListPopup.qml
+++ b/ui/imports/shared/status/StatusInputListPopup.qml
@@ -142,12 +142,12 @@ Popup {
         delegate: Rectangle {
             id: rectangle
             objectName: "inputListRectangle_" + index
-            property variant myData: typeof modelData === "undefined" ? model : modelData
+            property var myData: typeof modelData === "undefined" ? model : modelData
             property string myText: popup.getText(myData)
             visible: searchBox.text === "" || myText.includes(searchBox.text)
             color: listView.currentIndex === index ? Style.current.backgroundHover : Style.current.transparent
             border.width: 0
-            width: parent.width
+            width: ListView.view.width
             height: visible ? 42 : 0
             radius: Style.current.radius
 

--- a/ui/imports/shared/status/StatusStickersPopup.qml
+++ b/ui/imports/shared/status/StatusStickersPopup.qml
@@ -89,7 +89,7 @@ Popup {
             onUninstallClicked: {
                 stickersModule.uninstall(packId)
                 stickerGrid.model = d.recentStickers
-                btnHistory.clicked()
+                btnHistory.clicked(null)
             }
             onBackClicked: {
                 stickerMarket.visible = false

--- a/ui/imports/shared/views/ExistingContacts.qml
+++ b/ui/imports/shared/views/ExistingContacts.qml
@@ -61,7 +61,7 @@ Item {
             asset.width: 40
             asset.height: 40
             asset.color: Utils.colorForColorId(model.colorId)
-            ringSettings.ringSpecModel: model.ensName ? undefined : Utils.getColorHashAsJson(model.pubKey, true)
+            ringSettings.ringSpecModel: Utils.getColorHashAsJson(model.pubKey, model.ensName)
             statusListItemIcon.badge.border.color: Theme.palette.baseColor4
             statusListItemIcon.badge.implicitHeight: 14 // 10 px + 2 px * 2 borders
             statusListItemIcon.badge.implicitWidth: 14 // 10 px + 2 px * 2 borders

--- a/ui/imports/shared/views/ProfileDialogView.qml
+++ b/ui/imports/shared/views/ProfileDialogView.qml
@@ -264,7 +264,7 @@ Pane {
                 interactive: false
                 imageWidth: 80
                 imageHeight: imageWidth
-                showRing: !d.contactDetails.ensVerified
+                ensVerified: d.contactDetails.ensVerified
             }
 
             ColumnLayout {

--- a/ui/imports/shared/views/TransactionPreview.qml
+++ b/ui/imports/shared/views/TransactionPreview.qml
@@ -263,6 +263,7 @@ Item {
                 name: root.toAccount.name
                 pubkey: root.toAccount.pubKey
                 image: root.toAccount.icon
+                ensVerified: root.toAccount.ensVerified
             }
             SVGImage {
                 id: toInvalid

--- a/ui/imports/shared/views/chat/MessageContextMenuView.qml
+++ b/ui/imports/shared/views/chat/MessageContextMenuView.qml
@@ -61,7 +61,7 @@ StatusPopupMenu {
     readonly property bool isContact: {
         return root.selectedUserPublicKey !== "" && !!contactDetails.isContact
     }
-    readonly property bool isBlockedContact: (!!d.contactDetails && d.contactDetails.isBlocked) || false
+    readonly property bool isBlockedContact: (!!contactDetails && contactDetails.isBlocked) || false
 
     readonly property int outgoingVerificationStatus: {
         if (root.selectedUserPublicKey === "" || root.isMe || !root.isContact) {
@@ -97,12 +97,12 @@ StatusPopupMenu {
         if (!root.selectedUserPublicKey || root.isMe || !root.isContact) {
             return false
         }
-        return root.verificationStatus === Constants.verificationStatus.trusted ||
-            root.incomingVerificationStatus === Constants.verificationStatus.trusted
+        return root.outgoingVerificationStatus === Constants.verificationStatus.trusted ||
+                root.incomingVerificationStatus === Constants.verificationStatus.trusted
     }
 
-    readonly property bool userTrustIsUnknown: d.contactDetails && d.contactDetails.trustStatus === Constants.trustStatus.unknown
-    readonly property bool userIsUntrustworthy: d.contactDetails && d.contactDetails.trustStatus === Constants.trustStatus.untrustworthy
+    readonly property bool userTrustIsUnknown: contactDetails && contactDetails.trustStatus === Constants.trustStatus.unknown
+    readonly property bool userIsUntrustworthy: contactDetails && contactDetails.trustStatus === Constants.trustStatus.untrustworthy
 
     property var emojiReactionsReactedByUser: []
 
@@ -138,24 +138,10 @@ StatusPopupMenu {
     onClosed: {
         // Reset selectedUserPublicKey so that associated properties get recalculated on re-open
         selectedUserPublicKey = ""
-        d.contactDetails = {}
     }
 
     width: Math.max(emojiContainer.visible ? emojiContainer.width : 0,
                     (root.isRightClickOnImage && !root.pinnedPopup) ? 176 : 230)
-
-    onAboutToShow: {
-        if (root.isProfile && root.selectedUserPublicKey !== "") {
-            d.contactDetails = Utils.getContactDetailsAsJson(root.selectedUserPublicKey)
-        } else {
-            d.contactDetails = {}
-        }
-    }
-
-    QtObject {
-        id: d
-        property var contactDetails: ({})
-    }
 
     Item {
         id: emojiContainer
@@ -193,11 +179,11 @@ StatusPopupMenu {
         displayName: root.selectedUserDisplayName
         pubkey: root.selectedUserPublicKey
         icon: root.selectedUserIcon
-        trustStatus: d.contactDetails && d.contactDetails.trustStatus ? d.contactDetails.trustStatus
-                                                                      : Constants.trustStatus.unknown
+        trustStatus: contactDetails && contactDetails.trustStatus ? contactDetails.trustStatus
+                                                                  : Constants.trustStatus.unknown
         isContact: root.isContact
         isCurrentUser: root.isMe
-        userIsEnsVerified: (!!d.contactDetails && d.contactDetails.ensVerified) || false
+        userIsEnsVerified: (!!contactDetails && contactDetails.ensVerified) || false
     }
 
     Item {
@@ -300,7 +286,7 @@ StatusPopupMenu {
         icon.name: "edit_pencil"
         enabled: root.isProfile && !root.isMe
         onTriggered: {
-            Global.openNicknamePopupRequested(root.selectedUserPublicKey, d.contactDetails.localNickname,
+            Global.openNicknamePopupRequested(root.selectedUserPublicKey, contactDetails.localNickname,
                                               "%1 (%2)".arg(root.selectedUserDisplayName).arg(Utils.getElidedCompressedPk(root.selectedUserPublicKey)))
             root.close()
         }

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -466,7 +466,7 @@ Loader {
                 isEdited: root.isEdited
                 hasMention: root.hasMention
                 isPinned: root.pinnedMessage
-                pinnedBy: root.pinnedMessage && !root.isDiscordMessage ? Utils.getContactDetailsAsJson(root.messagePinnedBy).displayName : ""
+                pinnedBy: root.pinnedMessage && !root.isDiscordMessage ? Utils.getContactDetailsAsJson(root.messagePinnedBy, false).displayName : ""
                 hasExpired: root.isExpired
                 reactionsModel: root.reactionsModel
 
@@ -621,15 +621,15 @@ Loader {
                         assetSettings.isImage: root.isDiscordMessage || root.senderIcon.startsWith("data")
                         pubkey: root.senderId
                         colorId: Utils.colorIdForPubkey(root.senderId)
-                        colorHash: Utils.getColorHashAsJson(root.senderId, false, !root.isDiscordMessage)
-                        showRing: !root.isDiscordMessage
+                        colorHash: Utils.getColorHashAsJson(root.senderId, root.senderIsEnsVerified)
+                        showRing: !root.isDiscordMessage && !root.senderIsEnsVerified
                     }
                 }
 
                 replyDetails: StatusMessageDetails {
-                    messageText:  delegate.replyMessage ? delegate.replyMessage.messageText
-                                                          //: deleted message
-                                                        : qsTr("&lt;deleted&gt;")
+                    messageText: delegate.replyMessage ? delegate.replyMessage.messageText
+                                                         //: deleted message
+                                                       : qsTr("&lt;deleted&gt;")
                     contentType: delegate.replyMessage ? delegate.convertContentType(delegate.replyMessage.contentType) : 0
                     messageContent: {
                         if (!delegate.replyMessage)
@@ -646,7 +646,7 @@ Loader {
                     amISender: delegate.replyMessage && delegate.replyMessage.amISender
                     sender.id: delegate.replyMessage ? delegate.replyMessage.senderId : ""
                     sender.isContact: delegate.replyMessage && delegate.replyMessage.senderIsAdded
-                    sender.displayName:  delegate.replyMessage ? delegate.replyMessage.senderDisplayName: ""
+                    sender.displayName: delegate.replyMessage ? delegate.replyMessage.senderDisplayName: ""
                     sender.isEnsVerified: delegate.replyMessage && delegate.replyMessage.senderEnsVerified
                     sender.secondaryName: delegate.replyMessage ? delegate.replyMessage.senderOptionalName : ""
                     sender.profileImage {
@@ -654,10 +654,10 @@ Loader {
                         height: 20
                         name: delegate.replyMessage ? delegate.replyMessage.senderIcon : ""
                         assetSettings.isImage: delegate.replyMessage && (delegate.replyMessage.contentType === Constants.messageContentType.discordMessageType || delegate.replyMessage.senderIcon.startsWith("data"))
-                        showRing: delegate.replyMessage && delegate.replyMessage.contentType !== Constants.messageContentType.discordMessageType
+                        showRing: (delegate.replyMessage && delegate.replyMessage.contentType !== Constants.messageContentType.discordMessageType) && !sender.isEnsVerified
                         pubkey: delegate.replySenderId
                         colorId: Utils.colorIdForPubkey(delegate.replySenderId)
-                        colorHash: Utils.getColorHashAsJson(delegate.replySenderId, false, !root.isDiscordMessage)
+                        colorHash: Utils.getColorHashAsJson(delegate.replySenderId, sender.isEnsVerified)
                     }
                 }
 
@@ -703,6 +703,7 @@ Loader {
                     }
                 }
 
+                hasLinks: linkUrlsModel.count
                 linksComponent: Component {
                     LinksMessageView {
                         linksModel: linkUrlsModel

--- a/ui/imports/utils/Utils.qml
+++ b/ui/imports/utils/Utils.qml
@@ -535,15 +535,16 @@ QtObject {
                 isSyncing: false,
                 removed: false,
                 trustStatus: Constants.trustStatus.unknown,
-                verificationStatus: Constants.verificationStatus.unverified
+                verificationStatus: Constants.verificationStatus.unverified,
+                incomingVerificationStatus: Constants.verificationStatus.unverified
             }
         }
     }
 
-    function isEnsVerified(publicKey, getVerificationRequest=true) {
+    function isEnsVerified(publicKey) {
         if (publicKey === "" || !isChatKey(publicKey) )
             return
-        return getContactDetailsAsJson(publicKey, getVerificationRequest).ensVerified
+        return getContactDetailsAsJson(publicKey, false).ensVerified
     }
 
     function getEmojiHashAsJson(publicKey) {
@@ -554,10 +555,12 @@ QtObject {
         return JSON.parse(jsonObj)
     }
 
-    function getColorHashAsJson(publicKey, force=false, getVerificationRequest=true) {
-        if (publicKey === "" || !isChatKey(publicKey) )
+    function getColorHashAsJson(publicKey, skipEnsVerification=false) {
+        if (publicKey === "" || !isChatKey(publicKey))
             return
-        if (!force && isEnsVerified(publicKey, getVerificationRequest))
+        if (skipEnsVerification) // we know already the user is ENS verified -> no color ring
+            return
+        if (isEnsVerified(publicKey)) // ENS verified -> no color ring
             return
         let jsonObj = globalUtilsInst.getColorHashAsJson(publicKey)
         return JSON.parse(jsonObj)
@@ -571,7 +574,7 @@ QtObject {
     }
 
     function colorForColorId(colorId)  {
-        if (colorId < 0 || colorId >=  Theme.palette.userCustomizationColors.length) {
+        if (colorId < 0 || colorId >= Theme.palette.userCustomizationColors.length) {
             console.warn("Utils.colorForColorId : colorId is out of bounds")
             return StatusColors.colors['blue']
         }


### PR DESCRIPTION
- when calling `Utils.getColorHashAsJson()` we don't actually need to issue ID verification requests at all and there might be situations when we know beforehand that we don't need the ENS verification either
- change these helper functions' syntax and do early returns in that case
- in MessageContextMenuView, the "contact details" were duplicated, so remove one
- remove dead code, fix some warnings

### What does the PR do

Reduces the number of verification related RPC calls

### Affected areas

A lot (mostly messaging)

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

Community, chat, user list, user profile:
![image](https://user-images.githubusercontent.com/5377645/205034595-8c0fb28c-91c5-4618-b433-3fa27f4d110e.png)

Addressbook:
![image](https://user-images.githubusercontent.com/5377645/205034722-75093d1b-5904-4eba-baf1-c24c9c349179.png)


