### PR TITLE
fix(network_constants): fix torrent port clash by adding PORT_SHIFT

### DIFF
--- a/src/app_service/common/network_constants.nim
+++ b/src/app_service/common/network_constants.nim
@@ -1,4 +1,4 @@
-import json, os, chronicles
+import json, os, chronicles, strutils
 import ../../constants as main_constants
 
 # set via `nim c` param `-d:INFURA_TOKEN:[token]`; should be set in CI/release builds
@@ -24,7 +24,18 @@ let OPENSEA_API_KEY_RESOLVED* =
   else:
     OPENSEA_API_KEY
 
-let DEFAULT_TORRENT_CONFIG_PORT* = 9025
+const DEFAULT_TORRENT_CONFIG_PORT = 9025
+let TORRENT_CONFIG_PORT* = if (existsEnv("PORT_SHIFT")):
+              DEFAULT_TORRENT_CONFIG_PORT + parseInt($getEnv("PORT_SHIFT"))
+            else:
+              DEFAULT_TORRENT_CONFIG_PORT
+
+const DEFAUL_WAKU_V2_PORT = 60000
+let WAKU_V2_PORT* = if (existsEnv("PORT_SHIFT")):
+              DEFAUL_WAKU_V2_PORT + parseInt($getEnv("PORT_SHIFT"))
+            else:
+              DEFAUL_WAKU_V2_PORT
+
 let DEFAULT_TORRENT_CONFIG_DATADIR* = joinPath(main_constants.defaultDataDir(), "data", "archivedata")
 let DEFAULT_TORRENT_CONFIG_TORRENTDIR* = joinPath(main_constants.defaultDataDir(), "data", "torrents")
 
@@ -293,11 +304,11 @@ var NODE_CONFIG* = %* {
   "WakuV2Config": {
     "Enabled": false,
     "Host": "0.0.0.0",
-    "Port": 0,
+    "Port": WAKU_V2_PORT,
     "LightClient": false,
     "PersistPeers": true,
     "EnableDiscV5": true,
-    "UDPPort": 0,
+    "UDPPort": WAKU_V2_PORT,
     "PeerExchange": true,
     "AutoUpdate": true,
   },
@@ -311,7 +322,7 @@ var NODE_CONFIG* = %* {
   "Networks": NETWORKS,
   "TorrentConfig": {
     "Enabled": true,
-    "Port": DEFAULT_TORRENT_CONFIG_PORT,
+    "Port": TORRENT_CONFIG_PORT,
     "DataDir": DEFAULT_TORRENT_CONFIG_DATADIR,
     "TorrentDir": DEFAULT_TORRENT_CONFIG_TORRENTDIR
   }

--- a/src/app_service/service/accounts/service.nim
+++ b/src/app_service/service/accounts/service.nim
@@ -317,12 +317,6 @@ QtObject:
 
     result["WakuConfig"]["Enabled"] = false.newJBool()
 
-    if existsEnv("WAKUV2_PORT"):
-      let wV2Port = parseInt($getEnv("WAKUV2_PORT"))
-      # Waku V2 config
-      result["WakuV2Config"]["Port"] = wV2Port.newJInt()
-      result["WakuV2Config"]["UDPPort"] = wV2Port.newJInt()
-
     if TEST_PEER_ENR != "":
       let testPeerENRArr = %* @[TEST_PEER_ENR]
       result["ClusterConfig"]["WakuNodes"] = %* testPeerENRArr
@@ -588,7 +582,7 @@ QtObject:
           "Enabled": false,
           "DataDir": DEFAULT_TORRENT_CONFIG_DATADIR,
           "TorrentDir": DEFAULT_TORRENT_CONFIG_TORRENTDIR,
-          "Port": DEFAULT_TORRENT_CONFIG_PORT
+          "Port": TORRENT_CONFIG_PORT
         },
         "Networks": NETWORKS,
         "OutputMessageCSVEnabled": output_csv
@@ -599,13 +593,6 @@ QtObject:
         let wV1Port = $getEnv("STATUS_PORT")
         # Waku V1 config
         nodeCfg["ListenAddr"] = newJString("0.0.0.0:" & wV1Port)
-      if existsEnv("WAKUV2_PORT"):
-        let wV2Port = parseInt($getEnv("WAKUV2_PORT"))
-        # Waku V2 config
-        nodeCfg.add("WakuV2Config", %* {
-          "Port": wV2Port,
-          "UDPPort": wV2Port,
-        })
 
       if TEST_PEER_ENR != "":
         nodeCfg["Rendezvous"] = newJBool(false)


### PR DESCRIPTION
Fixes #8553

The torrent port was clashing with the release app since both of them have it on by default now. That was causing the messenger to fail on start. This new PORT_SHIFT env var can be used to shift the port of the torrent service and wakuV2. No more need to use WAKUV2_PORT. we can also add more ports that need shifting.
This enables opening multiple instances of the app very easily. Just increase PORT_SHIFT by one