### PR TITLE
fix(@desktop/keycard): modal title edits and migrate flow

### DIFF
--- a/src/app/modules/shared_modules/keycard_popup/models/key_pair_selected_item.nim
+++ b/src/app/modules/shared_modules/keycard_popup/models/key_pair_selected_item.nim
@@ -34,6 +34,14 @@ QtObject:
     self.keyPairSelectedItemLockedChanged()
     self.keyPairSelectedItemIconChanged()
 
+  proc getKeyUid*(self: KeyPairSelectedItem): string {.slot.} =
+    if(self.item.isNil):
+      return ""
+    return self.item.keyUid()
+  QtProperty[string] keyUid:
+    read = getKeyUid
+    notify = keyPairSelectedItemChanged
+
   proc getPubKey*(self: KeyPairSelectedItem): string {.slot.} =
     if(self.item.isNil):
       return ""

--- a/src/app/modules/shared_modules/keycard_popup/module.nim
+++ b/src/app/modules/shared_modules/keycard_popup/module.nim
@@ -453,6 +453,7 @@ proc updateKeyPairItemIfDataAreKnown[T](self: Module[T], address: string, item: 
     var icon = ""
     if a.walletType == WalletTypeDefaultStatusAccount:
       icon = "wallet"
+    item.setKeyUid(a.keyUid)
     item.addAccount(a.name, a.path, a.address, a.emoji, a.color, icon, balance = 0.0)
     return true
   return false

--- a/ui/app/AppLayouts/Profile/views/keycard/MainView.qml
+++ b/ui/app/AppLayouts/Profile/views/keycard/MainView.qml
@@ -117,7 +117,7 @@ ColumnLayout {
 
     StatusListItem {
         Layout.fillWidth: true
-        title: qsTr("Generate a seed phrase")
+        title: qsTr("Generate a new seed phrase")
         components: [
             StatusIcon {
                 icon: "tiny/chevron-right"

--- a/ui/imports/shared/popups/keycard/states/KeycardConfirmation.qml
+++ b/ui/imports/shared/popups/keycard/states/KeycardConfirmation.qml
@@ -70,8 +70,12 @@ Item {
             Layout.alignment: Qt.AlignHCenter
             horizontalAlignment: Text.AlignHCenter
             Layout.preferredHeight: Constants.keycard.general.titleHeight
-            wrapMode: Text.WordWrap
-            text: qsTr("A factory reset will delete the key on this Keycard.\nAre you sure you want to do this?")
+            text: {
+                if (root.sharedKeycardModule.keyPairStoredOnKeycard.keyUid === userProfile.keyUid)
+                    return qsTr("Warning, this Keycard stores your main Status profile and\naccounts. A factory reset will permanently delete it.")
+
+                return qsTr("A factory reset will delete the key on this Keycard.\nAre you sure you want to do this?")
+            }
             font.pixelSize: Constants.keycard.general.fontSize2
             color: Theme.palette.dangerColor1
         }


### PR DESCRIPTION
Addressed all points from the issue:

- 01: Keycard settings menu labelling - fixed in this commit
- 02: Modal title renaming - not developed yet
- 03: Additional decision diamond and flow - not developed yet
- 04: Modal title renaming - not developed yet
- 05: Modal title renaming - done in issue #7035
- 06: Copy change - fixed in this commit

Fixes: #8458