### PR TITLE
fix(settings): open links in external browser

### DIFF
--- a/src/app/global/local_account_sensitive_settings.nim
+++ b/src/app/global/local_account_sensitive_settings.nim
@@ -501,7 +501,8 @@ QtObject:
 
   proc showBrowserSelectorChanged*(self: LocalAccountSensitiveSettings) {.signal.}
   proc getShowBrowserSelector*(self: LocalAccountSensitiveSettings): bool {.slot.} =
-    getSettingsProp[bool](self, LSS_KEY_SHOW_BROWSER_SELECTOR, newQVariant(DEFAULT_SHOW_BROWSER_SELECTOR))
+    # getSettingsProp[bool](self, LSS_KEY_SHOW_BROWSER_SELECTOR, newQVariant(DEFAULT_SHOW_BROWSER_SELECTOR)) # https://github.com/status-im/status-desktop/issues/8568
+    return false
   proc setShowBrowserSelector*(self: LocalAccountSensitiveSettings, value: bool) {.slot.} =
     setSettingsProp(self, LSS_KEY_SHOW_BROWSER_SELECTOR, newQVariant(value)):
       self.showBrowserSelectorChanged()
@@ -514,7 +515,8 @@ QtObject:
 
   proc openLinksInStatusChanged*(self: LocalAccountSensitiveSettings) {.signal.}
   proc getOpenLinksInStatus*(self: LocalAccountSensitiveSettings): bool {.slot.} =
-    getSettingsProp[bool](self, LSS_KEY_OPEN_LINKS_IN_STATUS, newQVariant(DEFAULT_OPEN_LINKS_IN_STATUS))
+    # getSettingsProp[bool](self, LSS_KEY_OPEN_LINKS_IN_STATUS, newQVariant(DEFAULT_OPEN_LINKS_IN_STATUS)) # https://github.com/status-im/status-desktop/issues/8568
+    return false
   proc setOpenLinksInStatus*(self: LocalAccountSensitiveSettings, value: bool) {.slot.} =
     setSettingsProp(self, LSS_KEY_OPEN_LINKS_IN_STATUS, newQVariant(value)):
       self.openLinksInStatusChanged()


### PR DESCRIPTION
remove the dialog that asks users if they would like to open a link in Status Desktop's browser and always open them in the user's external browser

(merely changing defaults here wouldn't help for existing users)

Fixes #8568

### What does the PR do

Hardcodes opening links in an external browser

### Affected areas

settings

### Screenshot of functionality (including design for comparison)

- [N/A] I've checked the design and this PR matches it
