### PR TITLE
refactor(communities): use ImportingHistoryArchiveMessages signal for

### DIFF
--- a/src/app/core/signals/remote_signals/community.nim
+++ b/src/app/core/signals/remote_signals/community.nim
@@ -130,6 +130,11 @@ proc downloadingHistoryArchivesStartedFromEvent*(T: type HistoryArchivesSignal, 
   result.communityId = event["event"]{"communityId"}.getStr()
   result.signalType = SignalType.DownloadingHistoryArchivesStarted
 
+proc importingHistoryArchiveMessagesFromEvent*(T: type HistoryArchivesSignal, event: JsonNode): HistoryArchivesSignal =
+  result = HistoryArchivesSignal()
+  result.communityId = event["event"]{"communityId"}.getStr()
+  result.signalType = SignalType.ImportingHistoryArchiveMessages
+
 proc downloadingHistoryArchivesFinishedFromEvent*(T: type HistoryArchivesSignal, event: JsonNode): HistoryArchivesSignal =
   result = HistoryArchivesSignal()
   result.communityId = event["event"]{"communityId"}.getStr()

--- a/src/app/core/signals/remote_signals/signal_type.nim
+++ b/src/app/core/signals/remote_signals/signal_type.nim
@@ -41,6 +41,7 @@ type SignalType* {.pure.} = enum
   HistoryArchiveDownloaded = "community.historyArchiveDownloaded"
   DownloadingHistoryArchivesStarted = "community.downloadingHistoryArchivesStarted"
   DownloadingHistoryArchivesFinished = "community.downloadingHistoryArchivesFinished"
+  ImportingHistoryArchiveMessages = "community.importingHistoryArchiveMessages"
   UpdateAvailable = "update.available"
   DiscordCategoriesAndChannelsExtracted = "community.discordCategoriesAndChannelsExtracted"
   StatusUpdatesTimedout = "status.updates.timedout"

--- a/src/app/core/signals/signals_manager.nim
+++ b/src/app/core/signals/signals_manager.nim
@@ -95,6 +95,7 @@ QtObject:
       of SignalType.HistoryArchiveDownloaded: HistoryArchivesSignal.historyArchiveDownloadedFromEvent(jsonSignal)
       of SignalType.DownloadingHistoryArchivesStarted: HistoryArchivesSignal.downloadingHistoryArchivesStartedFromEvent(jsonSignal)
       of SignalType.DownloadingHistoryArchivesFinished: HistoryArchivesSignal.downloadingHistoryArchivesFinishedFromEvent(jsonSignal)
+      of SignalType.ImportingHistoryArchiveMessages: HistoryArchivesSignal.importingHistoryArchiveMessagesFromEvent(jsonSignal)
       of SignalType.UpdateAvailable: UpdateAvailableSignal.fromEvent(jsonSignal)
       of SignalType.DiscordCategoriesAndChannelsExtracted: DiscordCategoriesAndChannelsExtractedSignal.fromEvent(jsonSignal)
       of SignalType.StatusUpdatesTimedout: StatusUpdatesTimedoutSignal.fromEvent(jsonSignal)

--- a/src/app_service/service/community/service.nim
+++ b/src/app_service/service/community/service.nim
@@ -254,7 +254,7 @@ QtObject:
         stopped: receivedData.stopped
       ))
 
-    self.events.on(SignalType.DownloadingHistoryArchivesStarted.event) do(e: Args):
+    self.events.on(SignalType.ImportingHistoryArchiveMessages.event) do(e: Args):
       var receivedData = HistoryArchivesSignal(e)
       if receivedData.communityId notin self.historyArchiveDownloadTaskCommunityIds:
         self.historyArchiveDownloadTaskCommunityIds.incl(receivedData.communityId)


### PR DESCRIPTION
banner

@John-44 requested that we show the banner only for when messages are indeed imported into the database, not necessarily already when the torrent data is being downloaded.

This commit ensures Desktop processes the newly introduced `ImportingHistoryArchiveMessages` signal to render the banner introduced in https://github.com/status-im/status-desktop/commit/d5db1e635653f1cabee72bcdf67e88157b7d558c

