### PR TITLE
Change `:D` to `:smile:` alias

### DIFF
--- a/ui/StatusQ/src/StatusQ/Core/Utils/emojiList.js
+++ b/ui/StatusQ/src/StatusQ/Core/Utils/emojiList.js
@@ -63,7 +63,6 @@ var emoji_json = [
         "emoji_order": "5",
         "aliases": [],
         "aliases_ascii": [
-            ":D",
             ":-D",
             "=D"
         ]
@@ -76,7 +75,9 @@ var emoji_json = [
         "category": "people",
         "emoji_order": "6",
         "aliases": [],
-        "aliases_ascii": []
+        "aliases_ascii": [
+            ":D"
+	]
     },
     {
         "unicode": "1f605",


### PR DESCRIPTION
I'm sorry, this is probably the most silly thing of all time. But I like :smile:, and I find :smiley: creepy
Discords transforms :D to :smile:, so I'm happy. But status-desktop changes :D to :smiley:, so I can't sleep at night.

This PR changes :D to :smile: (:-D and =D still point to :smiley: for you creeps out here)