### PR TITLE
fix(@desktop/wallet): fix wallet account item balances

### DIFF
--- a/src/app/modules/main/wallet_section/accounts/module.nim
+++ b/src/app/modules/main/wallet_section/accounts/module.nim
@@ -113,7 +113,7 @@ method refreshWalletAccounts*(self: Module) =
           x.walletType,
           x.isWallet,
           x.isChat,
-          x.getBalance(enabledChainIds),
+          x.getCurrencyBalance(enabledChainIds),
           x.emoji,
           x.derivedfrom,
         ))
@@ -128,7 +128,7 @@ method refreshWalletAccounts*(self: Module) =
       w.walletType,
       w.isWallet,
       w.isChat,
-      w.getBalance(enabledChainIds),
+      w.getCurrencyBalance(enabledChainIds),
       assets,
       w.emoji,
       w.derivedfrom,

--- a/src/app_service/service/wallet_account/dto.nim
+++ b/src/app_service/service/wallet_account/dto.nim
@@ -114,6 +114,14 @@ proc getBalances*(self: WalletTokenDto, chainIds: seq[int]): seq[BalanceDto] =
     if self.balancesPerChain.hasKey(chainId):
       result.add(self.balancesPerChain[chainId])
 
+proc getBalance*(self: WalletTokenDto, chainIds: seq[int]): float64 =
+  var sum = 0.0
+  for chainId in chainIds:
+    if self.balancesPerChain.hasKey(chainId):
+      sum += self.balancesPerChain[chainId].balance
+  
+  return sum
+
 proc getCurrencyBalance*(self: WalletTokenDto, chainIds: seq[int]): float64 =
   var sum = 0.0
   for chainId in chainIds:
@@ -134,17 +142,6 @@ proc getVisible*(self: WalletTokenDto, chainIds: seq[int]): bool =
 
 proc getCurrencyBalance*(self: WalletAccountDto, chainIds: seq[int]): float64 =
   return self.tokens.map(t => t.getCurrencyBalance(chainIds)).foldl(a + b, 0.0)
-
-proc getBalance*(self: WalletTokenDto, chainIds: seq[int]): float64 =
-  var sum = 0.0
-  for chainId in chainIds:
-    if self.balancesPerChain.hasKey(chainId):
-      sum += self.balancesPerChain[chainId].balance
-  
-  return sum
-
-proc getBalance*(self: WalletAccountDto, chainIds: seq[int]): float64 =
-  return self.tokens.map(t => t.getBalance(chainIds)).foldl(a + b, 0.0)
 
 proc toBalanceDto*(jsonObj: JsonNode): BalanceDto =
   result = BalanceDto()


### PR DESCRIPTION
Fixes: #8582

### What does the PR do

The following function makes no sense:
```
proc getBalance*(self: WalletAccountDto, chainIds: seq[int]): float64 =
  return self.tokens.map(t => t.getBalance(chainIds)).foldl(a + b, 0.0)
```
It's adding the balances of different tokens (for example, 10ETH + 5 USDC + 0.1BTC = 15.1USD).
The proper function is `WalletAccountDto::getCurrencyBalance`, since it first converts each token's balance to a common currency before adding them.

- Function `WalletAccountDto::getBalance` was removed
- Usages of `WalletAccountDto::getBalance`were replaced with `WalletAccountDto::getCurrencyBalance`

This fixes the balances shown for each acount on the wallet's LeftTabView, which now match the balances in the corresponding Account header.

Before:
![image](https://user-images.githubusercontent.com/11161531/205360269-22194f9a-ff52-4bb0-b6a5-c97c5ff5a7df.png)

After:
![image](https://user-images.githubusercontent.com/11161531/205359809-63d93b4f-04d6-450c-b670-dddec7ade156.png)

### Affected areas

Wallet
