### PR TITLE
Adding StatusChatInput to storybook.

### DIFF
--- a/storybook/CMakeLists.txt
+++ b/storybook/CMakeLists.txt
@@ -21,7 +21,7 @@ find_package(
   REQUIRED)
 
 file(GLOB_RECURSE QML_FILES "stubs/*.qml" "mocks/*.qml" "pages/*.qml"
-    "src/*.qml" "src/qmldir" "../ui/StatusQ/*.qml" "../ui/app/*.qml")
+    "src/*.qml" "src/qmldir" "../ui/StatusQ/*.qml" "../ui/app/*.qml" "../ui/imports/*.qml")
 file(GLOB_RECURSE JS_FILES "../ui/StatusQ/*.js" "../ui/app/*.js")
 
 set(PROJECT_LIB "${PROJECT_NAME}Lib")

--- a/storybook/PagesModel.qml
+++ b/storybook/PagesModel.qml
@@ -58,6 +58,10 @@ ListModel {
         section: "Components"
     }
     ListElement {
+        title: "StatusChatInput"
+        section: "Components"
+    }
+    ListElement {
          title: "BrowserSettings"
          section: "Settings"
     }

--- a/storybook/pages/CommunityProfilePopupInviteFriendsPanelPage.qml
+++ b/storybook/pages/CommunityProfilePopupInviteFriendsPanelPage.qml
@@ -3,85 +3,53 @@ import QtQuick.Controls 2.14
 
 import AppLayouts.Chat.panels.communities 1.0
 import utils 1.0
+import StubDecorators 1.0
 
 Item {
-    property bool globalUtilsReady: false
-    property bool mainModuleReady: false
-
-    QtObject {
-        function isCompressedPubKey(publicKey) {
-            return true
-        }
-
-        function getCompressedPk(publicKey) { return "zx3sh" + publicKey }
-
-        function getColorHashAsJson(publicKey) {
+    UtilsDecorator {
+        globalUtils.isCompressedPubKey: function(publicKey) { return true }
+        globalUtils.getCompressedPk: function(publicKey) { return "zx3sh" + publicKey }
+        globalUtils.getColorHashAsJson: function(publicKey) {
             return JSON.stringify([{colorId: 0, segmentLength: 1},
                                    {colorId: 19, segmentLength: 2}])
         }
-
-        Component.onCompleted: {
-            Utils.globalUtilsInst = this
-            globalUtilsReady = true
-
-        }
-        Component.onDestruction: {
-            globalUtilsReady = false
-            Utils.globalUtilsInst = {}
-        }
     }
 
-    QtObject {
-        function getContactDetailsAsJson() {
-            return JSON.stringify({})
-        }
-
-        Component.onCompleted: {
-            mainModuleReady = true
-            Utils.mainModuleInst = this
-        }
-        Component.onDestruction: {
-            mainModuleReady = false
-            Utils.mainModuleInst = {}
-        }
-    }
+    SharedRootStoreDecorator {}
 
     Frame {
         anchors.centerIn: parent
 
-        Loader {
-            active: globalUtilsReady && mainModuleReady
-            sourceComponent: CommunityProfilePopupInviteFriendsPanel {
-                id: panel
+        CommunityProfilePopupInviteFriendsPanel {
+            id: panel
 
-                community: ({ id: "communityId" })
+            community: ({ id: "communityId" })
 
-                rootStore: QtObject {
-                    function communityHasMember(communityId, pubKey) {
-                        return false
-                    }
+            rootStore: QtObject {
+                function communityHasMember(communityId, pubKey) {
+                    return false
                 }
+            }
 
-                contactsStore: QtObject {
-                    readonly property ListModel myContactsModel: ListModel {
-                        Component.onCompleted: {
-                            const keys = []
+            contactsStore: QtObject {
+                readonly property ListModel myContactsModel: ListModel {
+                    Component.onCompleted: {
+                        const keys = []
 
-                            for (let i = 0; i < 20; i++) {
-                                const key = `pub_key_${i}`
+                        for (let i = 0; i < 20; i++) {
+                            const key = `pub_key_${i}`
 
-                                append({
-                                    alias: "",
-                                    colorId: "1",
-                                    displayName: `contact ${i}`,
-                                    ensName: "",
-                                    icon: "",
-                                    isContact: true,
-                                    localNickname: "",
-                                    onlineStatus: 1,
-                                    pubKey: key
-                                })
-                            }
+                            append({
+                                alias: "",
+                                colorId: "1",
+                                displayName: `contact ${i}`,
+                                ensName: "",
+                                icon: "",
+                                isContact: true,
+                                localNickname: "",
+                                onlineStatus: 1,
+                                pubKey: key
+                            })
                         }
                     }
                 }

--- a/storybook/pages/CommunityProfilePopupInviteMessagePanelPage.qml
+++ b/storybook/pages/CommunityProfilePopupInviteMessagePanelPage.qml
@@ -3,49 +3,15 @@ import QtQuick.Controls 2.14
 
 import AppLayouts.Chat.panels.communities 1.0
 import utils 1.0
+import StubDecorators 1.0
 
 Item {
-    property bool globalUtilsReady: false
-    property bool mainModuleReady: false
-
-    QtObject {
-        function getCompressedPk(publicKey) {
-            return "compressed"
-        }
-
-        function isCompressedPubKey() {
-            return true
-        }
-
-        function getColorHashAsJson(publicKey) {
+    UtilsDecorator {
+        globalUtils.getCompressedPk: function(publicKey) { return "compressed" }
+        globalUtils.isCompressedPubKey: function() { return true }
+        globalUtils.getColorHashAsJson: function(publicKey) {
             return JSON.stringify([{colorId: 0, segmentLength: 1},
                                    {colorId: 19, segmentLength: 2}])
-        }
-
-        Component.onCompleted: {
-            Utils.globalUtilsInst = this
-            globalUtilsReady = true
-        }
-
-        Component.onDestruction: {
-            globalUtilsReady = false
-            Utils.globalUtilsInst = {}
-        }
-    }
-
-    QtObject {
-        function getContactDetailsAsJson() {
-            return JSON.stringify({})
-        }
-
-        Component.onCompleted: {
-            Utils.mainModuleInst = this
-            mainModuleReady = true
-        }
-
-        Component.onDestruction: {
-            mainModuleReady = false
-            Utils.mainModuleInst = {}
         }
     }
 
@@ -55,36 +21,31 @@ Item {
         height: parent.height * 0.8
         width: parent.width * 0.8
 
-        Loader {
-            active: globalUtilsReady && mainModuleReady
+        CommunityProfilePopupInviteMessagePanel {
+            id: panel
 
             anchors.fill: parent
+            contactsStore: QtObject {
+                readonly property ListModel myContactsModel: ListModel {
+                    Component.onCompleted: {
+                        const keys = []
 
-            sourceComponent: CommunityProfilePopupInviteMessagePanel {
-                id: panel
+                        for (let i = 0; i < 20; i++) {
+                            const key = `pub_key_${i}`
 
-                contactsStore: QtObject {
-                    readonly property ListModel myContactsModel: ListModel {
-                        Component.onCompleted: {
-                            const keys = []
+                            append({
+                                isContact: true,
+                                onlineStatus: 1,
+                                displayName: `contact ${i}`,
+                                icon: "",
+                                colorId: "1",
+                                pubKey: key
+                            })
 
-                            for (let i = 0; i < 20; i++) {
-                                const key = `pub_key_${i}`
-
-                                append({
-                                    isContact: true,
-                                    onlineStatus: 1,
-                                    displayName: `contact ${i}`,
-                                    icon: "",
-                                    colorId: "1",
-                                    pubKey: key
-                                })
-
-                                keys.push(key)
-                            }
-
-                            panel.pubKeys = keys
+                            keys.push(key)
                         }
+
+                        panel.pubKeys = keys
                     }
                 }
             }

--- a/storybook/pages/ContactsListAndSearchPage.qml
+++ b/storybook/pages/ContactsListAndSearchPage.qml
@@ -2,59 +2,16 @@ import QtQuick 2.14
 import QtQuick.Controls 2.14
 
 import shared.controls 1.0
-import shared.stores 1.0
 
-import utils 1.0
+import StubDecorators 1.0
 
 Pane {
-    QtObject {
-        id: userProfileInst
-
-        Component.onCompleted: RootStore.userProfileInst = userProfileInst
-    }
-
-    QtObject {
-        id: chatSectionChatContentInputArea
-    }
-
-    QtObject {
-        id: mainModule
-
-        signal resolvedENS
-    }
-
-    QtObject {
-        id: globalUtilsInst
-
-        function isCompressedPubKey() {
-            return true
-        }
-
-        function getCompressedPk(publicKey) {
-            return "zx3sh" + publicKey
-        }
-
-        Component.onCompleted: Utils.globalUtilsInst = globalUtilsInst
-    }
-
-    QtObject {
-        id: mainModuleInst
-
-        function isCompressedPubKey() {
-            return true
-        }
-
-        function getContactDetailsAsJson() {
-            return JSON.stringify({
-                alias: "alias",
-                isAdded: false
-            })
-        }
-
-        Component.onCompleted: Utils.mainModuleInst = mainModuleInst
-    }
+    SharedRootStoreDecorator {}
+    UtilsDecorator { id: utilsDecorator }
 
     ContactsListAndSearch {
+        //inject mainModule (expected as context property)
+        property var mainModule: utilsDecorator.mainModule
         anchors.fill: parent
 
         community: ({ id: "communityId" })

--- a/storybook/pages/InviteFriendsToCommunityPopupPage.qml
+++ b/storybook/pages/InviteFriendsToCommunityPopupPage.qml
@@ -5,14 +5,12 @@ import AppLayouts.Chat.popups 1.0
 import utils 1.0
 
 import Storybook 1.0
+import StubDecorators 1.0
 
 SplitView {
     orientation: Qt.Vertical
 
     Logs { id: logs }
-
-    property bool globalUtilsReady: false
-    property bool mainModuleReady: false
 
     Item {
 
@@ -27,101 +25,61 @@ SplitView {
             anchors.centerIn: parent
             text: "Reopen"
 
-            onClicked: loader.item.open()
+            onClicked: invideFriendsPopup.open()
         }
 
-        QtObject {
-            function getCompressedPk(publicKey) {
-                return "compressed"
-            }
-
-            function isCompressedPubKey() {
-                return true
-            }
-
-            function getColorHashAsJson(publicKey) {
-                return JSON.stringify([{colorId: 0, segmentLength: 1},
-                                       {colorId: 19, segmentLength: 2}])
-            }
-
-            Component.onCompleted: {
-                Utils.globalUtilsInst = this
-                globalUtilsReady = true
-
-            }
-            Component.onDestruction: {
-                globalUtilsReady = false
-                Utils.globalUtilsInst = {}
-            }
+        UtilsDecorator {
+            id: utilsStub
         }
 
-        QtObject {
-            function getContactDetailsAsJson() {
-                return JSON.stringify({})
-            }
 
-            Component.onCompleted: {
-                mainModuleReady = true
-                Utils.mainModuleInst = this
-            }
-            Component.onDestruction: {
-                mainModuleReady = false
-                Utils.mainModuleInst = {}
-            }
-        }
+        InviteFriendsToCommunityPopup {
+            id: invideFriendsPopup
+            parent: parent
+            modal: false
+            anchors.centerIn: parent
 
-        Loader {
-            id: loader
-            active: globalUtilsReady && mainModuleReady
-            anchors.fill: parent
+            community: ({
+                id: "communityId",
+                name: "community-name"
+            })
 
-            sourceComponent: InviteFriendsToCommunityPopup {
-                parent: parent
-                modal: false
-                anchors.centerIn: parent
-
-                community: ({
-                    id: "communityId",
-                    name: "community-name"
-                })
-
-                rootStore: QtObject {
-                    function communityHasMember(communityId, pubKey) {
-                        return false
-                    }
+            rootStore: QtObject {
+                function communityHasMember(communityId, pubKey) {
+                    return false
                 }
+            }
 
-                communitySectionModule: QtObject {
-                    function inviteUsersToCommunity(keys, message) {
-                        logs.logEvent("communitySectionModule::inviteUsersToCommunity",
-                                      ["keys", "message"], arguments)
-                    }
+            communitySectionModule: QtObject {
+                function inviteUsersToCommunity(keys, message) {
+                    logs.logEvent("communitySectionModule::inviteUsersToCommunity",
+                                  ["keys", "message"], arguments)
                 }
+            }
 
-                contactsStore: QtObject {
-                    readonly property ListModel myContactsModel: ListModel {
-                        Component.onCompleted: {
-                            for (let i = 0; i < 20; i++) {
-                                const key = `pub_key_${i}`
+            contactsStore: QtObject {
+                readonly property ListModel myContactsModel: ListModel {
+                    Component.onCompleted: {
+                        for (let i = 0; i < 20; i++) {
+                            const key = `pub_key_${i}`
 
-                                append({
-                                    alias: "",
-                                    colorId: "1",
-                                    displayName: `contact ${i}`,
-                                    ensName: "",
-                                    icon: "",
-                                    isContact: true,
-                                    localNickname: "",
-                                    onlineStatus: 1,
-                                    pubKey: key
-                                })
-                            }
+                            append({
+                                alias: "",
+                                colorId: "1",
+                                displayName: `contact ${i}`,
+                                ensName: "",
+                                icon: "",
+                                isContact: true,
+                                localNickname: "",
+                                onlineStatus: 1,
+                                pubKey: key
+                            })
                         }
                     }
                 }
-
-                Component.onCompleted: open()
             }
+
+            Component.onCompleted: open()
         }
     }
 

--- a/storybook/pages/StatusChatInputPage.qml
+++ b/storybook/pages/StatusChatInputPage.qml
@@ -1,0 +1,55 @@
+import QtQuick 2.14
+import QtQuick.Controls 2.14
+import QtQuick.Layouts 1.14
+
+import Storybook 1.0
+import Models 1.0
+import StubDecorators 1.0
+
+import utils 1.0
+import shared.status 1.0
+
+SplitView {
+    Logs { id: logs }
+    SharedRootStoreDecorator { id: rootStoreDecorator }
+    UtilsDecorator {id: utilsDecorator }
+
+    SplitView {
+        orientation: Qt.Vertical
+        SplitView.fillWidth: true
+        //dummy item to position chatInput at the bottom
+        Item {
+            SplitView.fillHeight: true
+            SplitView.fillWidth: true
+        }
+
+        StatusChatInput {
+            id: chatInput
+            property var globalUtils: rootStoreDecorator.globalUtils
+            usersStore: QtObject {
+                readonly property var usersModel: UsersModel {
+                    id: usersModel
+                }
+            }
+        }
+    }
+
+    Pane {
+        SplitView.minimumWidth: 300
+        SplitView.preferredWidth: 300
+
+        UsersModelEditor {
+            id: modelEditor
+            anchors.fill: parent
+            model: usersModel
+
+            onRemoveClicked: usersModel.remove(index, 1)
+            onRemoveAllClicked: usersModel.clear()
+            onAddClicked: usersModel.append(modelEditor.getNewUser(usersModel.count))
+        }
+    }
+
+    Component.onCompleted: {
+        Global.dragArea = this
+    }
+}

--- a/storybook/pages/UserListPanelPage.qml
+++ b/storybook/pages/UserListPanelPage.qml
@@ -5,127 +5,31 @@ import AppLayouts.Chat.panels 1.0
 import utils 1.0
 
 import Storybook 1.0
+import Models 1.0
+import StubDecorators 1.0
 
 SplitView {
     id: root
 
     Logs { id: logs }
+    UsersModel { id: model }
+    UtilsDecorator {
+        mainModule.getContactDetailsAsJson: function(publicKey, getVerificationRequest) {
+            return JSON.stringify({ ensVerified: false })
+        }
+    }
 
     orientation: Qt.Vertical
 
-    property bool globalUtilsReady: false
-    property bool mainModuleReady: false
-
-    ListModel {
-        id: model
-
-        ListElement {
-            pubKey: "0x043a7ed0e8d1012cf04"
-            onlineStatus: 1
-            isContact: true
-            isVerified: true
-            isAdmin: false
-            isUntrustworthy: false
-            displayName: "Mike"
-            alias: ""
-            localNickname: ""
-            ensName: ""
-            icon: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADIAAAAyCAYAAAAeP4ixAAAAlklEQVR4nOzW0QmDQBAG4SSkl7SUQlJGCrElq9F3QdjjVhh/5nv3cFhY9vUIYQiNITSG0BhCExPynn1gWf9bx498P7/
-                  nzPcxEzGExhBdJGYihtAYQlO+tUZvqrPbqeudo5iJGEJjCE15a3VtodH3q2ImYgiNITTlTdG1nUZ5a92VITQxITFiJmIIjSE0htAYQrMHAAD//+wwFVpz+yqXAAAAAElFTkSuQmCC"
-            colorId: 7
-        }
-        ListElement {
-            pubKey: "0x04df12f12f12f12f1234"
-            onlineStatus: 0
-            isContact: true
-            isVerified: true
-            isAdmin: false
-            isUntrustworthy: false
-            displayName: "Jane"
-            alias: ""
-            localNickname: ""
-            ensName: ""
-            icon: ""
-            colorId: 7
-        }
-        ListElement {
-            pubKey: "0x04d1b7cc0ef3f470f1238"
-            onlineStatus: 0
-            isContact: true
-            isVerified: false
-            isAdmin: false
-            isUntrustworthy: true
-            displayName: "John"
-            alias: ""
-            localNickname: "Johny Johny"
-            ensName: ""
-            icon: ""
-            colorId: 7
-        }
-        ListElement {
-            pubKey: "0x04d1bed192343f470f1255"
-            onlineStatus: 1
-            isContact: true
-            isVerified: true
-            isAdmin: false
-            isUntrustworthy: true
-            displayName: ""
-            alias: "meth"
-            localNickname: ""
-            ensName: "maria.eth"
-            icon: ""
-            colorId: 7
-        }
-    }
-
-    // globalUtilsInst mock
-    QtObject {
-        function getCompressedPk(publicKey) { return "zx3sh" + publicKey }
-
-        function getColorHashAsJson(publicKey) {
-            return JSON.stringify([{colorId: 0, segmentLength: 1},
-                                   {colorId: 19, segmentLength: 2}])
-        }
-
-        function isCompressedPubKey(publicKey) { return true }
-
-        Component.onCompleted: {
-            Utils.globalUtilsInst = this
-            root.globalUtilsReady = true
-        }
-        Component.onDestruction: {
-            root.globalUtilsReady = false
-            Utils.globalUtilsInst = {}
-        }
-    }
-
-    // mainModuleInst mock
-    QtObject {
-        function getContactDetailsAsJson(publicKey, getVerificationRequest) {
-            return JSON.stringify({ ensVerified: false })
-        }
-        Component.onCompleted: {
-            Utils.mainModuleInst = this
-            root.mainModuleReady = true
-        }
-        Component.onDestruction: {
-            root.mainModuleReady = false
-            Utils.mainModuleInst = {}
-        }
-    }
     Item {
         SplitView.fillWidth: true
         SplitView.fillHeight: true
 
-        Loader {
+        UserListPanel {
             anchors.fill: parent
-            active: globalUtilsReady && mainModuleReady
-
-            sourceComponent: UserListPanel {
-                usersModel: model
-                messageContextMenu: null
-                label: "Some label"
-            }
+            usersModel: model
+            messageContextMenu: null
+            label: "Some label"
         }
     }
 

--- a/storybook/pages/UsersModelEditor.qml
+++ b/storybook/pages/UsersModelEditor.qml
@@ -14,6 +14,25 @@ Item {
     signal removeAllClicked
     signal addClicked
 
+    function getNewUser(seed: int) {
+        const pubKey = "0x%1".arg(seed)
+        return {
+            pubKey: pubKey,
+            displayName: seed%8 ? "user%1".arg(seed) : "",
+            localNickname: seed%3 ? "" : "nickname%1".arg(seed),
+            alias: "three word name(%1)".arg(pubKey),
+            isVerified: seed%3 ? false : true,
+            isUntrustworthy: seed%5 ? false : true,
+            isContact: true,
+            icon: "",
+            color: seed%2 ? "white" : "red",
+            onlineStatus: seed%2,
+            isAdmin: seed%2 ? true : false,
+            ensName: "",
+            colorId: 7
+        }
+    }
+
     ColumnLayout {
         id: layout
 

--- a/storybook/src/Models/UsersModel.qml
+++ b/storybook/src/Models/UsersModel.qml
@@ -1,0 +1,63 @@
+import QtQuick 2.14
+
+ListModel {
+    id: root
+
+    ListElement {
+        pubKey: "0x043a7ed0e8d1012cf04"
+        onlineStatus: 1
+        isContact: true
+        isVerified: true
+        isAdmin: false
+        isUntrustworthy: false
+        displayName: "Mike"
+        alias: ""
+        localNickname: ""
+        ensName: ""
+        icon: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADIAAAAyCAYAAAAeP4ixAAAAlklEQVR4nOzW0QmDQBAG4SSkl7SUQlJGCrElq9F3QdjjVhh/5nv3cFhY9vUIYQiNITSG0BhCExPynn1gWf9bx498P7/
+              nzPcxEzGExhBdJGYihtAYQlO+tUZvqrPbqeudo5iJGEJjCE15a3VtodH3q2ImYgiNITTlTdG1nUZ5a92VITQxITFiJmIIjSE0htAYQrMHAAD//+wwFVpz+yqXAAAAAElFTkSuQmCC"
+        colorId: 7
+    }
+    ListElement {
+        pubKey: "0x04df12f12f12f12f1234"
+        onlineStatus: 0
+        isContact: true
+        isVerified: true
+        isAdmin: false
+        isUntrustworthy: false
+        displayName: "Jane"
+        alias: ""
+        localNickname: ""
+        ensName: ""
+        icon: ""
+        colorId: 7
+    }
+    ListElement {
+        pubKey: "0x04d1b7cc0ef3f470f1238"
+        onlineStatus: 0
+        isContact: true
+        isVerified: false
+        isAdmin: false
+        isUntrustworthy: true
+        displayName: "John"
+        alias: ""
+        localNickname: "Johny Johny"
+        ensName: ""
+        icon: ""
+        colorId: 7
+    }
+    ListElement {
+        pubKey: "0x04d1bed192343f470f1255"
+        onlineStatus: 1
+        isContact: true
+        isVerified: true
+        isAdmin: false
+        isUntrustworthy: true
+        displayName: ""
+        alias: "meth"
+        localNickname: ""
+        ensName: "maria.eth"
+        icon: ""
+        colorId: 7
+    }
+}

--- a/storybook/src/Models/qmldir
+++ b/storybook/src/Models/qmldir
@@ -1,3 +1,4 @@
 singleton ModelsData 1.0 ModelsData.qml
 IconModel 1.0 IconModel.qml
 BannerModel 1.0 BannerModel.qml
+UsersModel 1.0 UsersModel.qml

--- a/storybook/stubs/NimModules/ChatSectionChatContentInputArea.qml
+++ b/storybook/stubs/NimModules/ChatSectionChatContentInputArea.qml
@@ -1,0 +1,34 @@
+import QtQuick 2.14
+
+QtObject {
+    property ListModel gifColumnA: ListModel{}
+    property ListModel gifColumnB: ListModel{}
+    property ListModel gifColumnC: ListModel{}
+    property var searchGifs: function(query) {
+        console.log("searchGifs")
+    }
+
+    property var getTrendingsGifs: function() {
+        console.log("getTrendingsGifs")
+    }
+
+    property var getRecentsGifs: function() {
+        console.log("getRecentsGifs")
+    }
+
+    property var getFavoritesGifs: function() {
+        console.log("getRecentsGifs")
+    }
+
+    property var isFavorite: function(id) {
+        console.log("getRecentsGifs")
+    }
+
+    property var toggleFavoriteGif: function(id, reload) {
+        console.log("getRecentsGifs")
+    }
+
+    property var addToRecentsGif: function(id) {
+        console.log("getRecentsGifs")
+    }
+}

--- a/storybook/stubs/NimModules/GlobalUtils.qml
+++ b/storybook/stubs/NimModules/GlobalUtils.qml
@@ -1,0 +1,33 @@
+import QtQuick 2.14
+
+QtObject {
+    property var plainText: function (htmlText) {
+        return htmlText.replace(/(?:<style[^]+?>[^]+?<\/style>|[\n]|<script[^]+?>[^]+?<\/script>|<(?:!|\/?[a-zA-Z]+).*?\/?>)/g,'')
+    }
+
+    property var isCompressedPubKey: function (publicKey) {
+        return true
+    }
+
+    property var getCompressedPk: function (publicKey) {
+        return "123456789"
+    }
+
+    property var getColorHashAsJson: function (publicKey) {
+        return JSON.stringify([{colorId: 0, segmentLength: 1},
+                               {colorId: 19, segmentLength: 2}])
+    }
+
+    property var getColorId: function (publicKey) {
+        return Math.floor(Math.random() * 10)
+    }
+
+    property var isEnsVerified: function (publicKey)  {
+        return false
+    }
+
+
+    property var getEmojiHashAsJson: function(publicKey) {
+        return JSON.stringify(["👨🏻‍🍼", "🏃🏿‍♂️", "🌇", "🤶🏿", "🏮","🤷🏻‍♂️", "🤦🏻", "📣", "🤎", "👷🏽", "😺", "🥞", "🔃", "🧝🏽‍♂️"])
+    }
+}

--- a/storybook/stubs/NimModules/LocalAccountSensitiveSettings.qml
+++ b/storybook/stubs/NimModules/LocalAccountSensitiveSettings.qml
@@ -1,0 +1,11 @@
+import QtQuick 2.14
+
+QtObject {
+    property bool displayChatImages: true
+    property real volume: 0.2
+    property bool isWalletEnabled: false
+    property bool notificationSoundsEnabled: false
+    property bool neverAskAboutUnfurlingAgain: false
+    property bool isGifWidgetEnabled: false
+    property bool isTenorWarningAccepted: false
+}

--- a/storybook/stubs/NimModules/LocalAppSettings.qml
+++ b/storybook/stubs/NimModules/LocalAppSettings.qml
@@ -1,0 +1,5 @@
+import QtQuick 2.14
+
+QtObject {
+    property string locale: ""
+}

--- a/storybook/stubs/NimModules/MainModule.qml
+++ b/storybook/stubs/NimModules/MainModule.qml
@@ -1,0 +1,14 @@
+import QtQuick 2.14
+
+QtObject {
+    id: root
+
+    signal resolvedENS
+
+    property var getContactDetailsAsJson: function() {
+        return JSON.stringify({
+            alias: "alias",
+            isAdded: false
+        })
+    }
+}

--- a/storybook/stubs/NimModules/NetworksModule.qml
+++ b/storybook/stubs/NimModules/NetworksModule.qml
@@ -1,0 +1,3 @@
+import QtQuick 2.14
+
+QtObject {}

--- a/storybook/stubs/NimModules/ProfileSectionModule.qml
+++ b/storybook/stubs/NimModules/ProfileSectionModule.qml
@@ -1,0 +1,3 @@
+import QtQuick 2.14
+
+QtObject {}

--- a/storybook/stubs/NimModules/UserProfile.qml
+++ b/storybook/stubs/NimModules/UserProfile.qml
@@ -1,0 +1,3 @@
+import QtQuick 2.14
+
+QtObject {}

--- a/storybook/stubs/NimModules/WalletSection.qml
+++ b/storybook/stubs/NimModules/WalletSection.qml
@@ -1,0 +1,5 @@
+import QtQuick 2.14
+
+QtObject {
+    property string currentCurrency: ""
+}

--- a/storybook/stubs/NimModules/WalletSectionAccounts.qml
+++ b/storybook/stubs/NimModules/WalletSectionAccounts.qml
@@ -1,0 +1,3 @@
+import QtQuick 2.14
+
+QtObject {}

--- a/storybook/stubs/NimModules/WalletSectionAllTokens.qml
+++ b/storybook/stubs/NimModules/WalletSectionAllTokens.qml
@@ -1,0 +1,3 @@
+import QtQuick 2.14
+
+QtObject {}

--- a/storybook/stubs/NimModules/WalletSectionCurrent.qml
+++ b/storybook/stubs/NimModules/WalletSectionCurrent.qml
@@ -1,0 +1,3 @@
+import QtQuick 2.14
+
+QtObject {}

--- a/storybook/stubs/NimModules/WalletSectionSavedAddresses.qml
+++ b/storybook/stubs/NimModules/WalletSectionSavedAddresses.qml
@@ -1,0 +1,3 @@
+import QtQuick 2.14
+
+QtObject {}

--- a/storybook/stubs/NimModules/WalletSectionTransactions.qml
+++ b/storybook/stubs/NimModules/WalletSectionTransactions.qml
@@ -1,0 +1,6 @@
+import QtQuick 2.14
+
+QtObject {
+    property ListModel model: ListModel{}
+    property bool isNonArchivalNode: true
+}

--- a/storybook/stubs/NimModules/qmldir
+++ b/storybook/stubs/NimModules/qmldir
@@ -1,0 +1,15 @@
+AccountSensitiveSettings 1.0 AccountSensitiveSettings.qml
+ChatSectionChatContentInputArea 1.0 ChatSectionChatContentInputArea.qml
+GlobalUtils 1.0 GlobalUtils.qml
+LocalAccountSensitiveSettings 1.0 LocalAccountSensitiveSettings.qml
+LocalAppSettings 1.0 LocalAppSettings.qml
+MainModule 1.0 MainModule.qml
+NetworksModule 1.0 NetworksModule.qml
+ProfileSectionModule 1.0 ProfileSectionModule.qml
+UserProfile 1.0 UserProfile.qml
+WalletSection 1.0 WalletSection.qml
+WalletSectionAccounts 1.0 WalletSectionAccounts.qml
+WalletSectionAllTokens 1.0 WalletSectionAllTokens.qml
+WalletSectionCurrent 1.0 WalletSectionCurrent.qml
+WalletSectionSavedAddresses 1.0 WalletSectionSavedAddresses.qml
+WalletSectionTransactions 1.0 WalletSectionTransactions.qml

--- a/storybook/stubs/StubDecorators/SharedRootStoreDecorator.qml
+++ b/storybook/stubs/StubDecorators/SharedRootStoreDecorator.qml
@@ -1,0 +1,58 @@
+import QtQuick 2.14
+
+import shared.stores 1.0
+
+import NimModules 1.0
+
+QtObject {
+    id: root
+    property ChatSectionChatContentInputArea gifProviderMock: ChatSectionChatContentInputArea { }
+    property WalletSectionAccounts walletSectionAccountsMock: WalletSectionAccounts {}
+    property WalletSectionCurrent walletSectionCurrent: WalletSectionCurrent {}
+    property WalletSectionAllTokens walletSectionAllTokens: WalletSectionAllTokens {}
+    property WalletSectionTransactions walletSectionTransactions: WalletSectionTransactions {}
+    property ProfileSectionModule profileSectionModule: ProfileSectionModule {}
+    property WalletSection walletSection: WalletSection {}
+    property UserProfile userProfile: UserProfile {}
+    property LocalAppSettings localAppSettings: LocalAppSettings {}
+    property LocalAccountSensitiveSettings localAccountSensitiveSettings: LocalAccountSensitiveSettings {}
+    property NetworksModule networksModule: NetworksModule {}
+    property GlobalUtils globalUtils: GlobalUtils {}
+    property WalletSectionSavedAddresses walletSectionSavedAddresses: WalletSectionSavedAddresses {}
+    property CurrenciesStore currencyStore: CurrenciesStore {
+        currentCurrency: root.walletSection.currentCurrency
+    }
+
+    Component.onCompleted: {
+        RootStore.gifProvider =                      root.gifProviderMock
+        RootStore.walletSectionAccountsProvider=     root.walletSectionAccountsMock
+        RootStore.currentAccount=                    root.walletSectionCurrent
+        RootStore.walletTokensModule=                root.walletSectionAllTokens
+        RootStore.history=                           root.walletSectionTransactions
+        RootStore.profileSectionModuleInst=          root.profileSectionModule
+        RootStore.walletSectionInst=                 root.walletSection
+        RootStore.userProfileInst=                   root.userProfile
+        RootStore.appSettings=                       root.localAppSettings
+        RootStore.accountSensitiveSettings=          root.localAccountSensitiveSettings
+        RootStore.networksModuleInst=                root.networksModule
+        RootStore.globalUtilsInst=                   root.globalUtils
+        RootStore.walletSectionSavedAddressesInst=   root.walletSectionSavedAddresses
+        RootStore.currencyStore=                     root.currencyStore
+    }
+
+    Component.onDestruction: {
+        RootStore.gifProvider =                      {}
+        RootStore.walletSectionAccountsProvider=     {}
+        RootStore.currentAccount=                    {}
+        RootStore.walletTokensModule=                {}
+        RootStore.history=                           {}
+        RootStore.profileSectionModuleInst=          {}
+        RootStore.walletSectionInst=                 {}
+        RootStore.userProfileInst=                   {}
+        RootStore.appSettings=                       {}
+        RootStore.accountSensitiveSettings=          {}
+        RootStore.networksModuleInst=                {}
+        RootStore.globalUtilsInst=                   {}
+        RootStore.walletSectionSavedAddressesInst=   {}
+    }
+}

--- a/storybook/stubs/StubDecorators/UtilsDecorator.qml
+++ b/storybook/stubs/StubDecorators/UtilsDecorator.qml
@@ -1,0 +1,16 @@
+import QtQuick 2.14
+
+import utils 1.0
+
+import NimModules 1.0
+
+QtObject {
+    id: root
+    property GlobalUtils globalUtils: GlobalUtils {}
+    property MainModule mainModule: MainModule {}
+
+    Component.onCompleted: {
+        Utils.globalUtilsInst = root.globalUtils
+        Utils.mainModuleInst = root.mainModule
+    }
+}

--- a/storybook/stubs/StubDecorators/qmldir
+++ b/storybook/stubs/StubDecorators/qmldir
@@ -1,0 +1,2 @@
+SharedRootStoreDecorator 1.0 SharedRootStoreDecorator.qml
+UtilsDecorator 1.0 UtilsDecorator.qml

--- a/storybook/stubs/shared/stores/RootStore.qml
+++ b/storybook/stubs/shared/stores/RootStore.qml
@@ -1,7 +1,0 @@
-pragma Singleton
-
-import QtQuick 2.14
-
-QtObject {
-    property var userProfileInst
-}

--- a/storybook/stubs/shared/stores/qmldir
+++ b/storybook/stubs/shared/stores/qmldir
@@ -1,1 +1,0 @@
-singleton RootStore 1.0 RootStore.qml

--- a/ui/imports/shared/stores/RootStore.qml
+++ b/ui/imports/shared/stores/RootStore.qml
@@ -9,12 +9,23 @@ QtObject {
 //    property var walletModelInst: !!walletModel ? walletModel : null
 //    property var profileModelInst: !!profileModel ? profileModel : null
 
-    property var profileSectionModuleInst: profileSectionModule
+    /// Contex properties wrappers ///
+    property var gifProvider:                       !!chatSectionChatContentInputArea ? chatSectionChatContentInputArea : null
+    property var walletSectionAccountsProvider:     !!walletSectionAccounts ? walletSectionAccounts : null
+    property var currentAccount:                    !!walletSectionCurrent ? walletSectionCurrent : null
+    property var walletTokensModule:                !!walletSectionAllTokens ? walletSectionAllTokens : null
+    property var history:                           !!walletSectionTransactions ? walletSectionTransactions : null
+    property var profileSectionModuleInst:          !!profileSectionModule ? profileSectionModule : null
+    property var walletSectionInst:                 !!walletSection ? walletSection : null
+    property var userProfileInst:                   !!userProfile ? userProfile : null
+    property var appSettings:                       !!localAppSettings ? localAppSettings : null
+    property var accountSensitiveSettings:          !!localAccountSensitiveSettings ? localAccountSensitiveSettings : null
+    property var networksModuleInst:                !!networksModule ? networksModule : null
+    property var globalUtilsInst:                   !!globalUtils ? globalUtils : null
+    property var walletSectionSavedAddressesInst:   !!walletSectionSavedAddresses ? walletSectionSavedAddresses : null
+    /// end of context propertyies wrappers ///
+
     property var privacyModule: profileSectionModuleInst.privacyModule
-    property var userProfileInst: !!userProfile ? userProfile : null
-    property var walletSectionInst: !!walletSection ? walletSection : null
-    property var appSettings: !!localAppSettings ? localAppSettings : null
-    property var accountSensitiveSettings: !!localAccountSensitiveSettings ? localAccountSensitiveSettings : null
     property real volume: !!accountSensitiveSettings ? accountSensitiveSettings.volume * 0.1 : 0.2
     property bool isWalletEnabled: !!accountSensitiveSettings ? accountSensitiveSettings.isWalletEnabled : false
     property bool notificationSoundsEnabled: !!accountSensitiveSettings ? accountSensitiveSettings.notificationSoundsEnabled : false
@@ -29,44 +40,42 @@ QtObject {
 //    property string gasEthValue: !!walletModelInst ? walletModelInst.gasView.getGasEthValue : "0"
 
     property CurrenciesStore currencyStore: CurrenciesStore { }
-    property string currentCurrency: walletSection.currentCurrency
+    property string currentCurrency: walletSectionInst.currentCurrency
 //    property string defaultCurrency: !!walletModelInst ? walletModelInst.balanceView.defaultCurrency : "0"
 //    property string fiatValue: !!walletModelInst ? walletModelInst.balanceView.getFiatValue : "0"
 //    property string cryptoValue: !!walletModelInst ? walletModelInst.balanceView.getCryptoValue : "0"
 
-    property var history: walletSectionTransactions
-    property var historyTransactions: walletSectionTransactions.model
+    property var historyTransactions: history.model
     property bool isNonArchivalNode:  history.isNonArchivalNode
 
-    property var currentAccount: walletSectionCurrent
     property var marketValueStore: TokenMarketValuesStore{}
 
     function getNetworkColor(chainId) {
-        return networksModule.all.getChainColor(chainId)
+        return networksModuleInst.all.getChainColor(chainId)
     }
 
     function getNetworkIcon(chainId) {
-        return networksModule.all.getIconUrl(chainId)
+        return networksModuleInst.all.getIconUrl(chainId)
     }
 
     function getNetworkShortName(chainId) {
-        return networksModule.all.getNetworkShortName(chainId)
+        return networksModuleInst.all.getNetworkShortName(chainId)
     }
 
     function getNetworkIconUrl(symbol) {
-        return networksModule.all.getNetworkIconUrl(symbol)
+        return networksModuleInst.all.getNetworkIconUrl(symbol)
     }
 
     function getNetworkName(symbol) {
-        return networksModule.all.getNetworkName(symbol)
+        return networksModuleInst.all.getNetworkName(symbol)
     }
 
     function getFiatValue(balance, cryptoSymbol, fiatSymbol) {
-        return profileSectionModule.ensUsernamesModule.getFiatValue(balance, cryptoSymbol, fiatSymbol)
+        return profileSectionModuleInst.ensUsernamesModule.getFiatValue(balance, cryptoSymbol, fiatSymbol)
     }
 
     function hex2Dec(value) {
-        return globalUtils.hex2Dec(value)
+        return globalUtilsInst.hex2Dec(value)
     }
 
     readonly property var formationChars: (["*", "`", "~"])
@@ -90,36 +99,36 @@ QtObject {
     }
 
     function setNeverAskAboutUnfurlingAgain(value) {
-        localAccountSensitiveSettings.neverAskAboutUnfurlingAgain = value;
+        accountSensitiveSettings.neverAskAboutUnfurlingAgain = value;
     }
 
     function enableWallet() {
-        localAccountSensitiveSettings.isWalletEnabled = true;
+        accountSensitiveSettings.isWalletEnabled = true;
     }
 
     function setIsTenorWarningAccepted(value) {
-        localAccountSensitiveSettings.isTenorWarningAccepted = value;
+        accountSensitiveSettings.isTenorWarningAccepted = value;
     }
 
     function copyToClipboard(text) {
-        globalUtils.copyToClipboard(text)
+        globalUtilsInst.copyToClipboard(text)
     }
 
-    property var gifColumnA: chatSectionChatContentInputArea.gifColumnA
-    property var gifColumnB: chatSectionChatContentInputArea.gifColumnB
-    property var gifColumnC: chatSectionChatContentInputArea.gifColumnC
+    property var gifColumnA: gifProvider.gifColumnA
+    property var gifColumnB: gifProvider.gifColumnB
+    property var gifColumnC: gifProvider.gifColumnC
 
     function searchGifs(query) {
-        chatSectionChatContentInputArea.searchGifs(query)
+        gifProvider.searchGifs(query)
     }
 
     function getTrendingsGifs() {
-        chatSectionChatContentInputArea.getTrendingsGifs()
+        gifProvider.getTrendingsGifs()
     }
 
     function updateWhitelistedUnfurlingSites(hostname, whitelisted) {
         // no way to send update notification for individual array entries
-        let settings = localAccountSensitiveSettings.whitelistedUnfurlingSites
+        let settings = accountSensitiveSettings.whitelistedUnfurlingSites
 
         if (!settings)
             settings = {}
@@ -128,29 +137,29 @@ QtObject {
             return
 
         settings[hostname] = whitelisted
-        localAccountSensitiveSettings.whitelistedUnfurlingSites = settings
+        accountSensitiveSettings.whitelistedUnfurlingSites = settings
         if(hostname === "media.tenor.com" && whitelisted === false)
             RootStore.setIsTenorWarningAccepted(false)
     }
 
     function getRecentsGifs() {
-        chatSectionChatContentInputArea.getRecentsGifs()
+        gifProvider.getRecentsGifs()
     }
 
     function getFavoritesGifs() {
-        return chatSectionChatContentInputArea.getFavoritesGifs()
+        return gifProvider.getFavoritesGifs()
     }
 
     function isFavorite(id) {
-        return chatSectionChatContentInputArea.isFavorite(id)
+        return gifProvider.isFavorite(id)
     }
 
     function toggleFavoriteGif(id, reload) {
-        chatSectionChatContentInputArea.toggleFavoriteGif(id, reload)
+        gifProvider.toggleFavoriteGif(id, reload)
     }
 
     function addToRecentsGif(id) {
-        chatSectionChatContentInputArea.addToRecentsGif(id)
+        gifProvider.addToRecentsGif(id)
     }
 
     function getPasswordStrengthScore(password) {
@@ -166,43 +175,43 @@ QtObject {
     }
 
     function hex2Eth(value) {
-        return globalUtils.hex2Eth(value)
+        return globalUtilsInst.hex2Eth(value)
     }
 
     function hex2Gwei(value) {
-        return globalUtils.hex2Gwei(value)
+        return globalUtilsInst.hex2Gwei(value)
     }
 
     function findTokenSymbolByAddress(address) {
-        return  walletSectionAllTokens.findTokenSymbolByAddress(address)
+        return  walletTokensModule.findTokenSymbolByAddress(address)
     }
 
     function getNameForSavedWalletAddress(address) {
-        return walletSectionSavedAddresses.getNameByAddress(address)
+        return walletSectionSavedAddressesInst.getNameByAddress(address)
     }
 
     function createOrUpdateSavedAddress(name, address, favourite) {
-        return walletSectionSavedAddresses.createOrUpdateSavedAddress(name, address, favourite)
+        return walletSectionSavedAddressesInst.createOrUpdateSavedAddress(name, address, favourite)
     }
 
     function deleteSavedAddress(address) {
-        return walletSectionSavedAddresses.deleteSavedAddress(address)
+        return walletSectionSavedAddressesInst.deleteSavedAddress(address)
     }
 
     function getLatestBlockNumber() {
-        return walletSectionTransactions.getLastTxBlockNumber()
+        return history.getLastTxBlockNumber()
     }
 
     function getGasEthValue(gweiValue, gasLimit) {
-        return profileSectionModule.ensUsernamesModule.getGasEthValue(gweiValue, gasLimit)
+        return profileSectionModuleInst.ensUsernamesModule.getGasEthValue(gweiValue, gasLimit)
     }
 
     function getHistoricalDataForToken(symbol, currency) {
-        walletSectionAllTokens.getHistoricalDataForToken(symbol,currency)
+        walletTokensModule.getHistoricalDataForToken(symbol,currency)
     }
 
     // TODO: range until we optimize to cache the data and abuse the requests
     function fetchHistoricalBalanceForTokenAsJson(address, symbol, timeIntervalEnum) {
-        walletSectionAllTokens.fetchHistoricalBalanceForTokenAsJson(address, symbol, timeIntervalEnum)
+        walletTokensModule.fetchHistoricalBalanceForTokenAsJson(address, symbol, timeIntervalEnum)
     }
 }


### PR DESCRIPTION
### What does the PR do

Update RootStore to allow dependency injection.
Added stub decorators for RootStore and Utils singletons. These decorators will inject stub nim modules in singletons and allow function override. Updated storybook pages using stub decorators.
Extract UsersModel and UsersModelEditor to be used by multiple pages.

This is a preparation step for StatusChatInput Qt Quick tests (see #8471). The stubs, decorators and models will be shared by storybook and UT.
<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas
shared/RootStore.qml
Storybook pages
<!-- List the affected areas (e.g wallet, browser, etc..) -->
### Screenshot of functionality (including design for comparison)

https://user-images.githubusercontent.com/47811206/205515426-d7063c62-0c4f-4a8e-8694-7be6c7cdd274.mov

<!-- screenshot (or gif/video) that demonstrates the functionality, specially important if it's a bug fix. -->
