### PR TITLE
fix(@desktop/chat): Hide 'no results found' when entering the chat key in start chat

### DIFF
--- a/ui/app/AppLayouts/Chat/panels/InlineSelectorPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/InlineSelectorPanel.qml
@@ -19,6 +19,7 @@ Item {
 
     property alias suggestionsModel: suggestionsListView.model
     property alias suggestionsDelegate: suggestionsListView.delegate
+    property alias suggestionsDialog: suggestionsDialog
     property size suggestionsDelegateSize: Qt.size(344, 64)
 
     readonly property alias label: label
@@ -118,6 +119,8 @@ Item {
                                     }
                                 }
 
+                                onTextEdited: if (suggestionsDialog.forceHide) suggestionsDialog.forceHide = false;
+
                                 Keys.onPressed: {
                                     if (event.matches(StandardKey.Paste)) {
                                         event.accepted = true
@@ -210,10 +213,13 @@ Item {
 
     Popup {
         id: suggestionsDialog
+
+        property bool forceHide: false
+
         parent: scrollView
         x: Math.min(parent.width, parent.contentWidth)
         y: parent.height + Style.current.halfPadding
-        visible: edit.text !== ""
+        visible: edit.text !== "" && !forceHide
         padding: Style.current.halfPadding
         background: StatusDialogBackground {
             id: bg

--- a/ui/app/AppLayouts/Chat/views/MembersSelectorView.qml
+++ b/ui/app/AppLayouts/Chat/views/MembersSelectorView.qml
@@ -108,6 +108,7 @@ MembersSelectorBase {
             }
 
             if (root.model.count === 0) {
+                root.suggestionsDialog.forceHide = true
                 Global.openContactRequestPopup(contactDetails.publicKey,
                                                popup => popup.closed.connect(root.rejected))
                 return


### PR DESCRIPTION
### What does the PR do

Subscribe on resolvedENS signal and if the chat key is valid - hide 'no results found' msg in the start chat

Fixed: #8541

### Affected areas

Start chat 'no results found' msg displaying

### Screenshot of functionality (including design for comparison)

![image](https://user-images.githubusercontent.com/117639195/205593770-6135318c-a1b6-4277-8992-6dee24273b1a.png)
