### PR TITLE
fix(@desktop/chat): Pasting the chat key of someone you're already mutual with open the 1-1 chat

### DIFF
--- a/ui/app/AppLayouts/Chat/panels/InlineSelectorPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/InlineSelectorPanel.qml
@@ -96,6 +96,7 @@ Item {
 
                             TextInput {
                                 id: edit
+                                property bool pasteOperation: false
                                 Layout.minimumWidth: 4
                                 Layout.fillHeight: true
                                 verticalAlignment: Text.AlignVCenter
@@ -119,17 +120,13 @@ Item {
                                     }
                                 }
 
-                                onTextEdited: if (suggestionsDialog.forceHide) suggestionsDialog.forceHide = false;
+                                onTextEdited: if (suggestionsDialog.forceHide && !pasteOperation)
+                                                  suggestionsDialog.forceHide = false
 
                                 Keys.onPressed: {
                                     if (event.matches(StandardKey.Paste)) {
-                                        event.accepted = true
-                                        const previousText = text;
-                                        const previousSelectedText = selectedText;
-                                        paste()
-                                        if (previousText === "" || previousSelectedText.length === previousText.length)
-                                            root.textPasted(text)
-                                        return;
+                                        pasteOperation = true
+                                        root.suggestionsDialog.forceHide = true
                                     }
 
                                     if (suggestionsDialog.visible) {
@@ -152,6 +149,17 @@ Item {
                                         } else if (event.key === Qt.Key_Down) {
                                             root.downKeyPressed()
                                         }
+                                    }
+                                }
+
+                                Keys.onReleased: {
+                                    if (event.matches(StandardKey.Paste)) {
+                                        event.accepted = true
+                                        pasteOperation = false
+                                        if (text) {
+                                            root.textPasted(text)
+                                        }
+
                                     }
                                 }
                             }

--- a/ui/app/AppLayouts/Chat/views/MembersSelectorView.qml
+++ b/ui/app/AppLayouts/Chat/views/MembersSelectorView.qml
@@ -89,30 +89,31 @@ MembersSelectorBase {
         enabled: root.visible
         target: root.rootStore.contactsStore.mainModuleInst
         onResolvedENS: {
-
-            if (resolvedPubKey === "")
+            if (resolvedPubKey === "") {
+                root.suggestionsDialog.forceHide = false
                 return
+            }
 
             const contactDetails = Utils.getContactDetailsAsJson(resolvedPubKey, false)
 
-            if (contactDetails.publicKey === root.rootStore.contactsStore.myPublicKey)
-                return;
-
-            if (contactDetails.isBlocked)
-                return;
+            if (contactDetails.publicKey === root.rootStore.contactsStore.myPublicKey ||
+                contactDetails.isBlocked) {
+                root.suggestionsDialog.forceHide = false
+                return
+            };
 
             if (contactDetails.isContact) {
-                if (d.addMember(contactDetails.publicKey, contactDetails.displayName))
-                    root.cleanup()
+                root.rootStore.mainModuleInst.switchTo(root.rootStore.getMySectionId(), contactDetails.publicKey)
                 return
             }
 
             if (root.model.count === 0) {
-                root.suggestionsDialog.forceHide = true
                 Global.openContactRequestPopup(contactDetails.publicKey,
                                                popup => popup.closed.connect(root.rejected))
                 return
             }
+
+            root.suggestionsDialog.forceHide = false
         }
     }
 }


### PR DESCRIPTION
### What does the PR do

1. Pasting the chat key of someone you're already mutual with opens the 1-1 chat
2. Removes "no results found" flickering
3. Shows "no results found" after the paste of contact only after verification, that result does not exist

Fixed: #8591

### Affected areas

"No results found" display in the Start chat

### Screenshot of functionality (including design for comparison)

https://user-images.githubusercontent.com/117639195/205906141-3af41954-417a-4c1f-8a8c-4e3b46f705e8.mov


