### PR TITLE
fix(chat/messages): prevent multiple same cursor fetches

### DIFF
--- a/src/app_service/service/message/message_cursor.nim
+++ b/src/app_service/service/message/message_cursor.nim
@@ -1,0 +1,26 @@
+type
+  MessageCursor* = ref object
+    value: string
+    pending: bool
+    mostRecent: bool
+
+proc initMessageCursor*(value: string, pending: bool,
+    mostRecent: bool): MessageCursor =
+  MessageCursor(value: value, pending: pending, mostRecent: mostRecent)
+
+proc getValue*(self: MessageCursor): string =
+  self.value
+
+proc setValue*(self: MessageCursor, value: string) =
+  if value == "" or value == self.value:
+    self.mostRecent = true
+  else:
+    self.value = value
+
+  self.pending = false
+
+proc setPending*(self: MessageCursor) =
+  self.pending = true
+
+proc isFetchable*(self: MessageCursor): bool =
+  return not (self.pending or self.mostRecent)

--- a/src/app_service/service/message/service.nim
+++ b/src/app_service/service/message/service.nim
@@ -16,6 +16,7 @@ import ./dto/reaction as reaction_dto
 import ../chat/dto/chat as chat_dto
 import ./dto/pinned_message_update as pinned_msg_update_dto
 import ./dto/removed_message as removed_msg_dto
+import ./message_cursor
 
 import ../../common/message as message_common
 import ../../common/conversion as service_conversion
@@ -114,29 +115,6 @@ type
 
   ReloadMessagesArgs* = ref object of Args
     communityId*: string
-
-type
-  MessageCursor = ref object
-    value: string
-    pending: bool
-    mostRecent: bool
-
-proc getValue*(self: MessageCursor): string =
-    self.value
-
-proc setValue*(self: MessageCursor, value: string) =
-    if value == "" or value == self.value:
-      self.mostRecent = true
-    else:
-      self.value = value
-
-    self.pending = false
-
-proc setPending*(self: MessageCursor) =
-    self.pending = true
-
-proc isFetchable*(self: MessageCursor): bool =
-    return not (self.pending or self.mostRecent)
 
 QtObject:
   type Service* = ref object of QObject
@@ -324,12 +302,12 @@ QtObject:
 
   proc getMessageCursor(self: Service, chatId: string): MessageCursor =
     if(not self.msgCursor.hasKey(chatId)):
-      self.msgCursor[chatId] = MessageCursor(value: "", pending: false, mostRecent: false)
+      self.msgCursor[chatId] = initMessageCursor(value="", pending=false, mostRecent=false)
     return self.msgCursor[chatId]
 
   proc getPinnedMessageCursor(self: Service, chatId: string): MessageCursor =
     if(not self.pinnedMsgCursor.hasKey(chatId)):
-      self.pinnedMsgCursor[chatId] = MessageCursor(value: "", pending: false, mostRecent: false)
+      self.pinnedMsgCursor[chatId] = initMessageCursor(value="", pending=false, mostRecent=false)
 
     return self.pinnedMsgCursor[chatId]
 

--- a/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
@@ -145,10 +145,7 @@ Item {
 
         onContentYChanged: {
             scrollDownButton.visible = contentHeight - (scrollY + height) > 400
-            let loadMore = scrollDownButton.visible && scrollY < 500
-            if(loadMore){
-                messageStore.loadMoreMessages()
-            }
+            if(scrollY < 500) messageStore.loadMoreMessages()
         }
 
         ScrollBar.vertical: StatusScrollBar {


### PR DESCRIPTION
It may happen `asyncLoadMoreMessagesForChat` is called many times in a row. Previously it did not check whether there is any pending fetch for a given chat, which resulted in many same cursors fetches from status-go. Furthermore, in this case, `lastUsedMsgCursor` ended up with the same value as `msgCursor` resulting in wrong state where there are no more messages to fetch.

- Simplified message loading code by introducing MessageCursor helper type
- Ensured messages are not loaded twice for the same cursor

fixes: #8602

### Affected areas

- messages loading when scrolling
