### PR TITLE
fix(community): fix messages being gone when we re-join a community

### DIFF
--- a/src/app/boot/app_controller.nim
+++ b/src/app/boot/app_controller.nim
@@ -147,8 +147,6 @@ proc newAppController*(statusFoundation: StatusFoundation): AppController =
     result.activityCenterService
   )
   result.chatService = chat_service.newService(statusFoundation.events, result.contactsService)
-  result.communityService = community_service.newService(statusFoundation.events,
-    statusFoundation.threadpool, result.chatService, result.activityCenterService)
   result.tokenService = token_service.newService(
     statusFoundation.events, statusFoundation.threadpool, result.networkService
   )
@@ -160,6 +158,8 @@ proc newAppController*(statusFoundation: StatusFoundation): AppController =
   result.messageService = message_service.newService(
     statusFoundation.events, statusFoundation.threadpool, result.contactsService, result.tokenService, result.walletAccountService, result.networkService
   )
+  result.communityService = community_service.newService(statusFoundation.events,
+    statusFoundation.threadpool, result.chatService, result.activityCenterService, result.messageService)
   result.transactionService = transaction_service.newService(statusFoundation.events, statusFoundation.threadpool, result.networkService, result.settingsService, result.tokenService)
   result.bookmarkService = bookmark_service.newService(statusFoundation.events)
   result.profileService = profile_service.newService(result.contactsService, result.settingsService)

--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -719,17 +719,17 @@ method onNewMessagesReceived*(self: Module, sectionIdMsgBelongsTo: string, chatI
 
   let chatDetails = self.controller.getChatDetails(chatIdMsgBelongsTo)
 
-  if (chatDetails.muted):
-    # No need to update the badge nor send a notification
-    return
-
   # Badge notification
   let messageBelongsToActiveSection = sectionIdMsgBelongsTo == self.controller.getMySectionId() and 
     self.controller.getMySectionId() == self.delegate.getActiveSectionId()
   let messageBelongsToActiveChat = self.controller.getActiveChatId() == chatIdMsgBelongsTo
   if(not messageBelongsToActiveSection or not messageBelongsToActiveChat):
-    let hasUnreadMessages = unviewedMessagesCount > 0
+    let hasUnreadMessages = (not chatDetails.muted and unviewedMessagesCount > 0) or unviewedMentionsCount > 0
     self.updateBadgeNotifications(chatIdMsgBelongsTo, hasUnreadMessages, unviewedMentionsCount)
+
+  if (chatDetails.muted):
+    # No need to update the badge nor send a notification
+    return
 
   # Prepare notification
   let myPK = singletonInstance.userProfile.getPubKey()

--- a/src/app_service/service/message/service.nim
+++ b/src/app_service/service/message/service.nim
@@ -300,6 +300,11 @@ QtObject:
   proc initialMessagesFetched(self: Service, chatId: string): bool =
     return self.msgCursor.hasKey(chatId)
 
+  proc resetMessageCursor*(self: Service, chatId: string) =
+    if(not self.msgCursor.hasKey(chatId)):
+      return
+    self.msgCursor.del(chatId)
+
   proc getMessageCursor(self: Service, chatId: string): MessageCursor =
     if(not self.msgCursor.hasKey(chatId)):
       self.msgCursor[chatId] = initMessageCursor(value="", pending=false, mostRecent=false)


### PR DESCRIPTION
Fixes #7512

The problem was twofold.
1. We didn't try to fetch the messages when we re-joined, since the cursor was not reseted
2. The messages are not longer in the DB since they get deleted on joining.

I fixed 1. by reseting the cursor on leave and calling fetch on spectate I fixed 2. in the status-go PR so that we no longer delete the messages when leaving.

~~Based on top of https://github.com/status-im/status-desktop/pull/8664 to not conflict with the cursor and to be able to test the fetching~~

Status-go PR: https://github.com/status-im/status-go/pull/3006