### PR TITLE
Removing and releasing ENS usernames

### DIFF
--- a/src/app/boot/app_controller.nim
+++ b/src/app/boot/app_controller.nim
@@ -405,7 +405,6 @@ proc buildAndRegisterUserProfile(self: AppController) =
   singletonInstance.userProfile.setDisplayName(displayName)
   singletonInstance.userProfile.setPreferredName(preferredName)
   singletonInstance.userProfile.setEnsName(firstEnsName)
-  singletonInstance.userProfile.setFirstEnsName(firstEnsName)
   singletonInstance.userProfile.setThumbnailImage(thumbnail)
   singletonInstance.userProfile.setLargeImage(large)
   singletonInstance.userProfile.setCurrentUserStatus(currentUserStatus.statusType.int)

--- a/src/app/global/user_profile.nim
+++ b/src/app/global/user_profile.nim
@@ -13,7 +13,6 @@ QtObject:
     # fields which may change during runtime
     ensName: string
     displayName: string
-    firstEnsName: string
     preferredName: string
     thumbnailImage: string
     largeImage: string
@@ -82,25 +81,6 @@ QtObject:
     read = getEnsName
     notify = nameChanged
 
-  # this is not a slot
-  proc setFirstEnsName*(self: UserProfile, name: string) =
-    if(self.firstEnsName == name):
-      return
-    self.firstEnsName = name
-    self.nameChanged()
-
-  proc getFirstEnsName*(self: UserProfile): string {.slot.} =
-    self.firstEnsName
-  QtProperty[string] firstEnsName:
-    read = getFirstEnsName
-    notify = nameChanged
-
-  proc getPrettyFirstEnsName*(self: UserProfile): string {.slot.} =
-    self.firstEnsName
-  QtProperty[string] prettyFirstEnsName:
-    read = getPrettyFirstEnsName
-    notify = nameChanged
-
 
   # this is not a slot
   proc setPreferredName*(self: UserProfile, name: string) =
@@ -137,8 +117,6 @@ QtObject:
   proc getName*(self: UserProfile): string {.slot.} =
     if(self.preferredName.len > 0):
       return self.getPrettyPreferredName()
-    elif(self.firstEnsName.len > 0):
-      return self.getPrettyFirstEnsName()
     elif(self.ensName.len > 0):
       return self.ensName
     elif(self.displayName.len > 0):

--- a/src/app/modules/main/profile_section/ens_usernames/controller.nim
+++ b/src/app/modules/main/profile_section/ens_usernames/controller.nim
@@ -88,6 +88,9 @@ proc getSigningPhrase*(self: Controller): string =
 proc saveNewEnsUsername*(self: Controller, ensUsername: string): bool =
   return self.settingsService.saveNewEnsUsername(ensUsername)
 
+proc removeEnsUsername*(self: Controller, ensUsername: string): bool =
+  return self.settingsService.removeEnsUsername(ensUsername)
+
 proc getPreferredEnsUsername*(self: Controller): string =
   return self.settingsService.getPreferredName()
 

--- a/src/app/modules/main/profile_section/ens_usernames/io_interface.nim
+++ b/src/app/modules/main/profile_section/ens_usernames/io_interface.nim
@@ -49,6 +49,9 @@ method authenticateAndSetPubKey*(self: AccessInterface, ensUsername: string, add
   maxPriorityFeePerGas: string, maxFeePerGas: string, eip1559Enabled: bool) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method removeEnsUsername*(self: AccessInterface, ensUsername: string): bool {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method releaseEnsEstimate*(self: AccessInterface, ensUsername: string, address: string): int {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/profile_section/ens_usernames/module.nim
+++ b/src/app/modules/main/profile_section/ens_usernames/module.nim
@@ -177,6 +177,15 @@ method authenticateAndReleaseEns*(self: Module, ensUsername: string, address: st
   else:
     self.controller.authenticateUser()
 
+method removeEnsUsername*(self: Module, ensUsername: string): bool = 
+  if (not self.controller.removeEnsUsername(ensUsername)):
+    info "an error occurred removing ens username", methodName="removeEnsUsername"
+    return false
+  if (self.controller.getPreferredEnsUsername() == ensUsername):
+    self.controller.setPreferredName("")
+  self.view.model().removeItemByEnsUsername(ensUsername)
+  return true
+
 method releaseEns*(self: Module, password: string) =
   let response = self.controller.release(
     self.tmpSendEnsTransactionDetails.ensUsername,
@@ -205,8 +214,7 @@ method releaseEns*(self: Module, password: string) =
 
   var result: string
   if(responseObj.getProp("result", result)):
-    self.controller.setPreferredName("")
-    self.view.model().removeItemByEnsUsername(self.tmpSendEnsTransactionDetails.ensUsername)
+    let removed = self.removeEnsUsername(self.tmpSendEnsTransactionDetails.ensUsername)
     self.view.emitTransactionWasSentSignal(response)
 
 proc formatUsername(self: Module, ensUsername: string, isStatus: bool): string =

--- a/src/app/modules/main/profile_section/ens_usernames/view.nim
+++ b/src/app/modules/main/profile_section/ens_usernames/view.nim
@@ -91,6 +91,9 @@ QtObject:
     revertReason: string) =
     self.transactionCompleted(success, txHash, username, trxType, revertReason)
 
+  proc removeEnsUsername*(self: View, ensUsername: string): bool {.slot.} =
+    return self.delegate.removeEnsUsername(ensUsername)
+
   proc releaseEnsEstimate*(self: View, ensUsername: string, address: string): int {.slot.} =
     return self.delegate.releaseEnsEstimate(ensUsername, address)
 

--- a/src/app_service/service/settings/service.nim
+++ b/src/app_service/service/settings/service.nim
@@ -163,6 +163,19 @@ QtObject:
       return true
     return false
 
+  proc removeEnsUsername*(self: Service, username: string): bool = 
+    var newEnsUsernames = self.settings.ensUsernames
+    let index = newEnsUsernames.find(username)
+    if (index < 0):
+        return false
+    newEnsUsernames.delete(index)
+    let newEnsUsernamesAsJson = %* newEnsUsernames
+
+    if(self.saveSetting(KEY_ENS_USERNAMES, newEnsUsernamesAsJson)):
+      self.settings.ensUsernames = newEnsUsernames
+      return true
+    return false
+
   proc getEnsUsernames*(self: Service): seq[string] =
     return self.settings.ensUsernames
 

--- a/ui/app/AppLayouts/Profile/stores/EnsUsernamesStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/EnsUsernamesStore.qml
@@ -147,5 +147,11 @@ QtObject {
             return ""
         return ensUsernamesModule.getChainIdForEns()
     }
+
+    function removeEnsUsername(ensUsername) {
+        if(!root.ensUsernamesModule)
+            return ""
+        return ensUsernamesModule.removeEnsUsername(ensUsername)
+    }
 }
 

--- a/ui/app/AppLayouts/Profile/stores/ProfileStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/ProfileStore.qml
@@ -10,7 +10,7 @@ QtObject {
     property string name: userProfile.name // in case of ens returns pretty ens form
     property string username: userProfile.username
     property string displayName: userProfile.displayName
-    property string ensName: userProfile.preferredName || userProfile.firstEnsName || userProfile.ensName
+    property string ensName: userProfile.preferredName || userProfile.ensName
     property string profileLargeImage: userProfile.largeImage
     property string icon: userProfile.icon
     property bool userDeclinedBackupBanner: localAccountSensitiveSettings.userDeclinedBackupBanner

--- a/ui/app/AppLayouts/Profile/views/EnsListView.qml
+++ b/ui/app/AppLayouts/Profile/views/EnsListView.qml
@@ -55,83 +55,6 @@ Item {
         width: profileContentWidth
         anchors.horizontalCenter: parent.horizontalCenter
 
-        Component {
-            id: statusENS
-            Item {
-                Text {
-                    id: usernameTxt
-                    text: username.substr(0, username.indexOf(".")) + " " + (isPending ? qsTr("(pending)") : "")
-                    color: Style.current.textColor
-                }
-
-                Text {
-
-                    anchors.top: usernameTxt.bottom
-                    anchors.topMargin: 2
-                    text: username.substr(username.indexOf("."))
-                    color: Theme.palette.baseColor1
-                }
-            }
-        }
-
-        Component {
-            id: normalENS
-            Item {
-                Text {
-                    id: usernameTxt
-                    text: username  + " " + (isPending ? qsTr("(pending)") : "")
-                    font.pixelSize: 16
-                    color: Theme.palette.directColor1
-                    anchors.top: parent.top
-                    anchors.topMargin: 5
-                }
-            }
-        }
-
-        Component {
-            id: ensDelegate
-            Item {
-                height: 45
-                anchors.left: parent.left
-                anchors.right: parent.right
-
-                MouseArea {
-                    enabled: !model.isPending
-                    anchors.fill: parent
-                    cursorShape:enabled ?  Qt.PointingHandCursor : Qt.ArrowCursor
-                    onClicked: selectEns(model.ensUsername)
-                }
-
-                Rectangle {
-                    id: circle
-                    width: 35
-                    height: 35
-                    radius: 35
-                    color: Theme.palette.primaryColor1
-
-                    StatusBaseText {
-                        text: "@"
-                        opacity: 0.7
-                        font.weight: Font.Bold
-                        font.pixelSize: 16
-                        color: Theme.palette.indirectColor1
-                        anchors.centerIn: parent
-                        verticalAlignment: Text.AlignVCenter
-                        anchors.verticalCenter: parent.verticalCenter
-                    }
-                }
-
-                Loader {
-                    sourceComponent: model.ensUsername.endsWith(".stateofus.eth") ? statusENS : normalENS
-                    property string username: model.ensUsername
-                    property bool isPending: model.isPending
-                    active: true
-                    anchors.left: circle.right
-                    anchors.leftMargin: Style.current.smallPadding
-                }
-            }
-        }
-
         StatusBaseText {
             id: sectionTitle
             text: qsTr("ENS usernames")
@@ -201,9 +124,36 @@ Item {
                 anchors.fill: parent
                 model: root.ensUsernamesStore.ensUsernamesModel
                 spacing: 10
-                delegate: ensDelegate
+                delegate: StatusListItem {
+                    readonly property int indexOfDomainStart: model.ensUsername.indexOf(".")
 
-                ScrollBar.vertical: ScrollBar { policy: ScrollBar.AsNeeded }
+                    width: ListView.view.width
+                    title: model.ensUsername.substr(0, indexOfDomainStart)
+                    subTitle: model.ensUsername.substr(indexOfDomainStart)
+                    titleAsideText: model.isPending ? qsTr("(pending)") : ""
+
+                    statusListItemTitle.font.pixelSize: 17
+                    statusListItemTitle.font.bold: true
+
+                    asset.isImage: false
+                    asset.isLetterIdenticon: true
+                    asset.bgColor: Theme.palette.primaryColor1
+                    asset.width: 40
+                    asset.height: 40
+
+                    components: [
+                        StatusIcon {
+                            icon: "chevron-down"
+                            rotation: 270
+                            color: Theme.palette.baseColor1
+                        }
+                    ]
+
+                    onClicked: {
+                        root.selectEns(model.ensUsername)
+                    }
+                }
+
             }
         }
 
@@ -306,4 +256,3 @@ Item {
         }
     }
 }
-


### PR DESCRIPTION
Fixes #6846 
Fixes #3261 

⚠️  This is a draft PR. Will be converted after https://github.com/status-im/status-desktop/pull/8645 is merged.

### What does the PR do

1. Add ability to remove ENS username.
It's removed from local settings, but still owned by user. Can be restored and connected back.
2. When releasing ENS, also remove it.
3. Redesign ENS username delegate in `EnsListView`. 
We don't really have any designs. I'm in contact with @benjthayer, also added him as a reviewer.
This is a working solution, we can redesign it later in a separate PR if needed.
4. Remove redundant `firstEnsName` property

### Affected areas

Profile Settings -> ENS Username

### StatusQ checklist

- [x] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

Buying ENS:

https://user-images.githubusercontent.com/25482501/206027043-df275d36-948a-44b8-bf66-8dfd1a427c21.mov

(I've changed the `pending` label design, as discussed with @benjthayer):

<img width="1240" alt="Снимок экрана 2022-12-07 в 19 09 24" src="https://user-images.githubusercontent.com/25482501/206230934-05d14f12-8acf-4484-8dd6-401710088c93.png">

Removing, restoring and releasing ENS:

https://user-images.githubusercontent.com/25482501/206027103-2052b6cc-20ff-4e93-a907-444219b6433b.mov

Check that ENS was removed after ens released:

https://user-images.githubusercontent.com/25482501/206027169-daf6bde9-4b33-437a-a45f-671a39500b8b.mov

