### PR TITLE
fix: CTRL+K (jump to) modal is case sensitive

### DIFF
--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -1211,7 +1211,8 @@ Item {
                     property var modelData
                     property bool isCurrentItem: true
                     function filterAccepts(searchText) {
-                        return title.includes(searchText)
+                        const lowerCaseSearchText = searchText.toLowerCase()
+                        return title.toLowerCase().includes(lowerCaseSearchText) || label.toLowerCase().includes(lowerCaseSearchText)
                     }
 
                     title: modelData ? modelData.name : ""


### PR DESCRIPTION
make the ChannelPicker/StatusSearchListPopup search case insensitive

Fixes #8460

### Affected areas

AppMain/StatusSearchListPopup

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![image](https://user-images.githubusercontent.com/5377645/206217601-6e886e0b-1205-40ff-811b-fcb3876ff3e2.png)


