### PR TITLE
fix(CommunitySettings): Previous page navigations are broken in community settings sections

### DIFF
--- a/ui/app/AppLayouts/Chat/layouts/SettingsPageLayout.qml
+++ b/ui/app/AppLayouts/Chat/layouts/SettingsPageLayout.qml
@@ -22,6 +22,7 @@ Item {
     property bool headerButtonVisible: false
     property string headerButtonText: ""
     property int headerWidth: 0
+    property string previousPageName: ""
 
     readonly property Item contentItem: contentLoader.item
     readonly property size settingsDirtyToastMessageImplicitSize: 

--- a/ui/app/AppLayouts/Chat/panels/communities/CommunityOverviewSettingsPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/CommunityOverviewSettingsPanel.qml
@@ -30,11 +30,12 @@ StackLayout {
     property bool requestToJoinEnabled
     property bool pinMessagesEnabled
     property bool encrypted
+    property string previousPageName: (currentIndex === 1) ? qsTr("Overview") : ""
 
     property bool editable: false
     property bool owned: false
 
-    function updateState() {
+    function navigateBack() {
         if (editCommunityPage.dirty) {
             editCommunityPage.notifyDirty();
         } else {

--- a/ui/app/AppLayouts/Chat/panels/communities/CommunityPermissionsSettingsPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/CommunityPermissionsSettingsPanel.qml
@@ -10,10 +10,12 @@ SettingsPageLayout {
     property var store: CommunitiesStore {}
     property int viewWidth: 560 // by design
 
-    property string previousPageName
-    function updateState() {
+    function navigateBack() {
         if (root.state === d.newPermissionViewState) {
-            root.state = d.welcomeViewState;
+            root.state = d.getInitialState()
+        }
+        else if(root.state === d.permissionsViewState) {
+            root.state = d.newPermissionViewState;
         }
     }
 
@@ -23,9 +25,13 @@ SettingsPageLayout {
         readonly property string welcomeViewState: "WELCOME"
         readonly property string newPermissionViewState: "NEWPERMISSION"
         readonly property string permissionsViewState: "PERMISSIONS"
+
+        function getInitialState() {
+            return root.store.permissionsModel.count > 0 ? d.permissionsViewState : d.welcomeViewState
+        }
     }
 
-    state: root.store.permissionsModel.count > 0 ? d.permissionsViewState : d.welcomeViewState
+    state: d.getInitialState()
     states: [
         State {
             name: d.welcomeViewState

--- a/ui/app/AppLayouts/Chat/views/CommunitySettingsView.qml
+++ b/ui/app/AppLayouts/Chat/views/CommunitySettingsView.qml
@@ -57,7 +57,7 @@ StatusSectionLayout {
     signal openLegacyPopupClicked // TODO: remove me when migration to new settings is done
 
     onBackButtonClicked: {
-        centerPanelContentLoader.item.children[d.currentIndex].updateState();
+        centerPanelContentLoader.item.children[d.currentIndex].navigateBack()
     }
 
     leftPanel: Item {
@@ -178,9 +178,6 @@ StatusSectionLayout {
                 encrypted: root.community.encrypted
                 requestToJoinEnabled: root.community.access === Constants.communityChatOnRequestAccess
                 pinMessagesEnabled: root.community.pinMessageAllMembersEnabled
-                onCurrentIndexChanged: {
-                    root.backButtonName = (currentIndex === 1) ? qsTr("Overview") : "";
-                }
                 editable: root.community.amISectionAdmin
 
                 onEdited: {
@@ -215,6 +212,7 @@ StatusSectionLayout {
                         privateKey: root.chatCommunitySectionModule.exportCommunity(root.communityId),
                     })
                 }
+                onPreviousPageNameChanged: root.backButtonName = previousPageName
             }
 
             CommunityMembersSettingsPanel {
@@ -234,10 +232,10 @@ StatusSectionLayout {
             }
 
             CommunityPermissionsSettingsPanel {
-                onStateChanged: {
-                    root.backButtonName = previousPageName;
-                }
+                onPreviousPageNameChanged: root.backButtonName = previousPageName
             }
+
+            onCurrentIndexChanged: root.backButtonName = centerPanelContentLoader.item.children[d.currentIndex].previousPageName
         }
     }
 


### PR DESCRIPTION
Fixes #8455

### What does the PR do

- Added property `previousPageName` into `SettingsPageLayout`.
- Added needed slots in `CommunitySettingsView` to get - `previousPageName` property changes and display the correct string. 
- Renamed `updateState` method to `navigateBack` to have a better accurate name.

### Affected areas

`Community Settings`

### Screenshot of functionality

https://user-images.githubusercontent.com/97019400/206232810-1b995ce0-568e-4534-a8ba-31c91a42466c.mov

