### PR TITLE
fix(Settings): cant switch off sounds for notifications

### DIFF
--- a/ui/app/AppLayouts/stores/RootStore.qml
+++ b/ui/app/AppLayouts/stores/RootStore.qml
@@ -66,8 +66,8 @@ QtObject {
 
 //    property MessageStore messageStore: MessageStore { }
 
-    property real volume: !!localAccountSensitiveSettings ? localAccountSensitiveSettings.volume * 0.01 : 0.5
-    property bool notificationSoundsEnabled: !!localAccountSensitiveSettings ? localAccountSensitiveSettings.notificationSoundsEnabled : false
+    property real volume: !!appSettings ? appSettings.volume * 0.01 : 0.5
+    property bool notificationSoundsEnabled: !!appSettings ? appSettings.notificationSoundsEnabled : true
 
     property var walletSectionTransactionsInst: walletSectionTransactions
 

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -256,7 +256,7 @@ Item {
     Audio {
         id: sendMessageSound
         store: rootStore
-        track: Qt.resolvedUrl("../imports/assets/audio/send_message.wav")
+        source: "qrc:/imports/assets/audio/send_message.wav"
         Component.onCompleted: {
             Global.sendMessageSound = this;
         }
@@ -265,7 +265,7 @@ Item {
     Audio {
         id: notificationSound
         store: rootStore
-        track: Qt.resolvedUrl("../imports/assets/audio/notification.wav")
+        source: "qrc:/imports/assets/audio/notification.wav"
         Component.onCompleted: {
             Global.notificationSound = this;
         }
@@ -273,7 +273,7 @@ Item {
 
     Audio {
         id: errorSound
-        track: Qt.resolvedUrl("../imports/assets/audio/error.mp3")
+        source: "qrc:/imports/assets/audio/error.mp3"
         store: rootStore
         Component.onCompleted: {
             Global.errorSound = this;

--- a/ui/imports/shared/stores/RootStore.qml
+++ b/ui/imports/shared/stores/RootStore.qml
@@ -13,17 +13,17 @@ QtObject {
     property var privacyModule: profileSectionModuleInst.privacyModule
     property var userProfileInst: !!userProfile ? userProfile : null
     property var walletSectionInst: !!walletSection ? walletSection : null
-    property var appSettings: !!localAppSettings ? localAppSettings : null
+    property var appSettingsInst: !!appSettings ? appSettings : null
     property var accountSensitiveSettings: !!localAccountSensitiveSettings ? localAccountSensitiveSettings : null
-    property real volume: !!accountSensitiveSettings ? accountSensitiveSettings.volume * 0.1 : 0.2
+    property real volume: !!appSettingsInst ? appSettingsInst.volume * 0.01 : 0.5
     property bool isWalletEnabled: !!accountSensitiveSettings ? accountSensitiveSettings.isWalletEnabled : false
-    property bool notificationSoundsEnabled: !!accountSensitiveSettings ? accountSensitiveSettings.notificationSoundsEnabled : false
+    property bool notificationSoundsEnabled: !!appSettingsInst ? appSettingsInst.notificationSoundsEnabled : true
     property bool neverAskAboutUnfurlingAgain: !!accountSensitiveSettings ? accountSensitiveSettings.neverAskAboutUnfurlingAgain : false
     property bool isGifWidgetEnabled: !!accountSensitiveSettings ? accountSensitiveSettings.isGifWidgetEnabled : false
     property bool isTenorWarningAccepted: !!accountSensitiveSettings ? accountSensitiveSettings.isTenorWarningAccepted : false
     property bool displayChatImages: !!accountSensitiveSettings ? accountSensitiveSettings.displayChatImages : false
 
-    property string locale: !!appSettings ? appSettings.locale : ""
+    property string locale: Qt.locale().name
 //    property string signingPhrase: !!walletModelInst ? walletModelInst.utilsView.signingPhrase : ""
 //    property string gasPrice: !!walletModelInst ? walletModelInst.gasView.gasPrice : "0"
 //    property string gasEthValue: !!walletModelInst ? walletModelInst.gasView.getGasEthValue : "0"

--- a/ui/imports/utils/Audio.qml
+++ b/ui/imports/utils/Audio.qml
@@ -1,14 +1,13 @@
-import QtQuick 2.13
-import QtMultimedia 5.13
+import QtQuick 2.14
+import QtMultimedia 5.14 as T
 
-Audio {
+T.Audio {
     id: audio
 
     property var store
-    property string track: "error.mp3"
 
-    source: Qt.resolvedUrl("./../assets/audio" + track)
     audioRole: Audio.NotificationRole
     volume: store.volume
     muted: !store.notificationSoundsEnabled
+    onError: console.warn("Audio error:", errorString, "; code:", error)
 }


### PR DESCRIPTION
Fix a bunch of problems with handling sound/notifications related options coming from the backend:
- `volume` and `notificationSoundsEnabled` live in a different settings object; adjust the stores for that
- unbreak loading the actual wav/mp3 files (was never working on Linux outside of AppImage!) -> use "qrc:/", same as the NIM backend does
- fix the volume scaling (backend has [1,100], QML is [0, 1])
- simplify our Audio QML item interface; no need for an extra property and resolving the URL twice (which results in broken scenarios mentioned above); we know which sounds we want to load

Closes #8668

### What does the PR do

Fixes notification sounds mute/volume

### Affected areas

AppMain

### Screenshot of functionality (including design for comparison)

- [N/A] I've checked the design and this PR matches it

