### PR TITLE
ci: show output from xcrun_altool on notarize error

### DIFF
--- a/scripts/notarize-macos-pkg.sh
+++ b/scripts/notarize-macos-pkg.sh
@@ -35,8 +35,10 @@ OUT=$(xcrun_altool --notarize-app -f "${BUNDLE_PATH}" --primary-bundle-id "${MAC
 # Necessary to track notarization request progress.
 REQUEST_UUID=$(echo "${OUT}" | jq -r '."notarization-upload".RequestUUID')
 
-if [[ -z "${REQUEST_UUID}" ]]; then
+if [[ -z "${REQUEST_UUID}" ]] || [[ "${REQUEST_UUID}" == "null" ]]; then
     echo "\n!!! FAILURE: No notarization request UUID found." >&1
+    echo "Full output:"
+    echo "${OUT}"
     exit 1
 fi
 echo -e "\n### Request ID: ${REQUEST_UUID}"


### PR DESCRIPTION
Right now we don't see what's actually happening:
```

!!! Notariztion Error
{"tool-version":"5.4211.13411","tool-path":"\/Applications\/Xcode.app\/Contents\/SharedFrameworks\/ContentDeliveryServices.framework\/Versions\/A\/Frameworks\/AppStoreService.framework","os-version":"12.3.1","product-errors":[{"message":"You supplied an invalid RequestUUID: null","userInfo":{"NSLocalizedFailureReason":"Apple Services operation failed.","NSLocalizedRecoverySuggestion":"You supplied an invalid RequestUUID: null","NSLocalizedDescription":"You supplied an invalid RequestUUID: null"},"code":1515}],"warnings":[{"message":"altool has been deprecated for notarization and starting in late 2023 will no longer be supported by the Apple notary service. You should start using notarytool to notarize your software.","userInfo":{"NSLocalizedDescription":"altool has been deprecated for notarization and starting in late 2023 will no longer be supported by the Apple notary service. You should start using notarytool to notarize your software."},"code":-1030}]}
make: *** [notarize-macos] Error 1
```