### PR TITLE
ci: update Apple dev team ID to update the org

### DIFF
--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -49,12 +49,12 @@ pipeline {
     /* Control output the filename */
     STATUS_CLIENT_DMG = "pkg/${utils.pkgFilename(ext: 'dmg')}"
     /* Apple Team ID for Notarization */
-    MACOS_NOTARIZE_TEAM_ID = "DTX7Z4U3YA"
+    MACOS_NOTARIZE_TEAM_ID = "8B5X2M6H2Y"
   }
 
   stages {
     stage('Deps') {
-      steps { 
+      steps {
         sh 'make update'
         withCredentials([
           usernamePassword( /* For fetching HomeBrew bottles. */


### PR DESCRIPTION
Otherwise we get failures when notarizing the app:
```json
{
  "message": "Unable to upload your app for notarization.",
  "userInfo": {
    "NSLocalizedDescription": "Unable to upload your app for notarization.",
    "NSLocalizedFailureReason": "--team-id DTX7Z4U3YA is not valid for the user name specified. Use --list-providers."
  },
  "code": -1027
}
```
Related: https://github.com/status-im/status-mobile/pull/14411b