### PR TITLE
fix(messages): fix Resend btn not working and add Sending visual state

### DIFF
--- a/src/app/modules/main/activity_center/module.nim
+++ b/src/app/modules/main/activity_center/module.nim
@@ -97,7 +97,8 @@ proc createMessageItemFromDto(self: Module, message: MessageDto, chatDetails: Ch
     message.mentionedUsersPks,
     contactDetails.details.trustStatus,
     contactDetails.details.ensVerified,
-    message.discordMessage
+    message.discordMessage,
+    resendError = ""
     ))
 
 method convertToItems*(

--- a/src/app/modules/main/chat_section/chat_content/messages/controller.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/controller.nim
@@ -289,3 +289,6 @@ proc leaveChat*(self: Controller) =
 method checkEditedMessageForMentions*(self: Controller, chatId: string,
   editedMessage: MessageDto, oldMentions: seq[string]) =
   self.messageService.checkEditedMessageForMentions(chatId, editedMessage, oldMentions)
+
+method resendChatMessage*(self: Controller, messageId: string): string =
+  return self.messageService.resendChatMessage(messageId)

--- a/src/app/modules/main/chat_section/chat_content/messages/io_interface.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/io_interface.nim
@@ -148,3 +148,6 @@ method getMessageById*(self: AccessInterface, messageId: string): message_item.I
 
 method onMailserverSynced*(self: AccessInterface, syncedFrom: int64) =
   raise newException(ValueError, "No implementation available")
+
+method resendChatMessage*(self: AccessInterface, messageId: string): string =
+  raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/chat_section/chat_content/messages/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/module.nim
@@ -99,7 +99,8 @@ proc createFetchMoreMessagesItem(self: Module): Item =
     mentionedUsersPks = @[],
     senderTrustStatus = TrustStatus.Unknown,
     senderEnsVerified = false,
-    DiscordMessage()
+    DiscordMessage(),
+    resendError = ""
   )
 
 proc createChatIdentifierItem(self: Module): Item =
@@ -140,7 +141,8 @@ proc createChatIdentifierItem(self: Module): Item =
     mentionedUsersPks = @[],
     senderTrustStatus = TrustStatus.Unknown,
     senderEnsVerified = false,
-    DiscordMessage()
+    DiscordMessage(),
+    resendError = ""
   )
 
 proc checkIfMessageLoadedAndScrollToItIfItIs(self: Module): bool =
@@ -220,7 +222,8 @@ method newMessagesLoaded*(self: Module, messages: seq[MessageDto], reactions: se
         m.mentionedUsersPks(),
         sender.details.trustStatus,
         sender.details.ensVerified,
-        m.discordMessage
+        m.discordMessage,
+        resendError = ""
         )
 
       for r in reactions:
@@ -319,7 +322,8 @@ method messageAdded*(self: Module, message: MessageDto) =
     message.mentionedUsersPks,
     sender.details.trustStatus,
     sender.details.ensVerified,
-    message.discordMessage
+    message.discordMessage,
+    resendError = ""
   )
 
   self.view.model().insertItemBasedOnClock(item)
@@ -593,7 +597,8 @@ method getMessageById*(self: Module, messageId: string): message_item.Item =
       m.mentionedUsersPks(),
       sender.details.trustStatus,
       sender.details.ensVerified,
-      m.discordMessage
+      m.discordMessage,
+      resendError = ""
       )
     return item
   return nil
@@ -602,3 +607,6 @@ method onMailserverSynced*(self: Module, syncedFrom: int64) =
   let chatDto = self.controller.getChatDetails()
   if (not chatDto.hasMoreMessagesToRequest(syncedFrom)):
     self.view.model().removeItem(FETCH_MORE_MESSAGES_MESSAGE_ID)
+
+method resendChatMessage*(self: Module, messageId: string): string =
+  return self.controller.resendChatMessage(messageId)

--- a/src/app/modules/main/chat_section/chat_content/messages/view.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/view.nim
@@ -183,3 +183,11 @@ QtObject:
 
   proc jumpToMessage*(self: View, messageId: string) {.slot.} =
     self.delegate.scrollToMessage(messageId)
+
+  proc resendMessage*(self: View, messageId: string) {.slot.} =
+    let error = self.delegate.resendChatMessage(messageId)
+    if (error != ""):
+      self.model.itemFailedResending(messageId, error)
+      return
+    self.model.itemSending(messageId)
+     

--- a/src/app/modules/main/chat_section/chat_content/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/module.nim
@@ -197,7 +197,8 @@ proc buildPinnedMessageItem(self: Module, messageId: string, actionInitiatedBy: 
     m.mentionedUsersPks,
     contactDetails.details.trustStatus,
     contactDetails.details.ensVerified,
-    m.discordMessage
+    m.discordMessage,
+    resendError = ""
   )
   item.pinned = true
   item.pinnedBy = actionInitiatedBy

--- a/src/app/modules/shared_models/message_item.nim
+++ b/src/app/modules/shared_models/message_item.nim
@@ -42,6 +42,7 @@ type
     senderTrustStatus: TrustStatus
     senderEnsVerified: bool
     messageAttachments: seq[string]
+    resendError: string
 
 proc initItem*(
     id,
@@ -70,7 +71,8 @@ proc initItem*(
     mentionedUsersPks: seq[string],
     senderTrustStatus: TrustStatus,
     senderEnsVerified: bool,
-    discordMessage: DiscordMessage
+    discordMessage: DiscordMessage,
+    resendError: string
     ): Item =
   result = Item()
   result.id = id
@@ -106,6 +108,7 @@ proc initItem*(
   result.senderTrustStatus = senderTrustStatus
   result.senderEnsVerified = senderEnsVerified
   result.messageAttachments = @[]
+  result.resendError = resendError
 
   if ContentType.DiscordMessage == contentType:
     if result.messageText == "":
@@ -137,6 +140,7 @@ proc `$`*(self: Item): string =
     senderIsAdded: {$self.senderIsAdded},
     seen: {$self.seen},
     outgoingStatus:{$self.outgoingStatus},
+    resendError:{$self.resendError},
     messageText:{self.messageText},
     messageContainsMentions:{self.messageContainsMentions},
     timestamp:{$self.timestamp},
@@ -211,6 +215,12 @@ proc outgoingStatus*(self: Item): string {.inline.} =
 
 proc `outgoingStatus=`*(self: Item, value: string) {.inline.} =
   self.outgoingStatus = value
+
+proc resendError*(self: Item): string {.inline.} =
+  self.resendError
+
+proc `resendError=`*(self: Item, value: string) {.inline.} =
+  self.resendError = value
 
 proc messageText*(self: Item): string {.inline.} =
   self.messageText
@@ -328,7 +338,8 @@ proc toJsonNode*(self: Item): JsonNode =
     "isEdited": self.isEdited,
     "links": self.links,
     "mentionedUsersPks": self.mentionedUsersPks,
-    "senderEnsVerified": self.senderEnsVerified
+    "senderEnsVerified": self.senderEnsVerified,
+    "resendError": self.resendError
   }
 
 proc editMode*(self: Item): bool {.inline.} =

--- a/src/app/modules/shared_models/message_model.nim
+++ b/src/app/modules/shared_models/message_model.nim
@@ -42,6 +42,7 @@ type
     SenderTrustStatus
     SenderEnsVerified
     MessageAttachments
+    ResendError
 
 QtObject:
   type
@@ -98,6 +99,7 @@ QtObject:
       ModelRole.SenderIsAdded.int:"senderIsAdded",
       ModelRole.Seen.int:"seen",
       ModelRole.OutgoingStatus.int:"outgoingStatus",
+      ModelRole.ResendError.int:"resendError",
       ModelRole.MessageText.int:"messageText",
       ModelRole.MessageImage.int:"messageImage",
       ModelRole.MessageContainsMentions.int:"messageContainsMentions",
@@ -166,6 +168,8 @@ QtObject:
       result = newQVariant(item.seen)
     of ModelRole.OutgoingStatus:
       result = newQVariant(item.outgoingStatus)
+    of ModelRole.ResendError:
+      result = newQVariant(item.resendError)
     of ModelRole.MessageText:
       result = newQVariant(item.messageText)
     of ModelRole.MessageImage:
@@ -375,6 +379,9 @@ QtObject:
     let index = self.createIndex(ind, 0, nil)
     self.dataChanged(index, index, @[ModelRole.OutgoingStatus.int])
 
+  proc itemSending*(self: Model, messageId: string) =
+    self.setOutgoingStatus(messageId, PARSED_TEXT_OUTGOING_STATUS_SENDING)
+
   proc itemSent*(self: Model, messageId: string) =
     self.setOutgoingStatus(messageId, PARSED_TEXT_OUTGOING_STATUS_SENT)
 
@@ -383,6 +390,14 @@ QtObject:
 
   proc itemExpired*(self: Model, messageId: string) =
     self.setOutgoingStatus(messageId, PARSED_TEXT_OUTGOING_STATUS_EXPIRED)
+
+  proc itemFailedResending*(self: Model, messageId: string, error: string) =
+    let ind = self.findIndexForMessageId(messageId)
+    if(ind == -1):
+      return
+    self.items[ind].resendError = error
+    let index = self.createIndex(ind, 0, nil)
+    self.dataChanged(index, index, @[ModelRole.ResendError.int])
 
   proc addReaction*(self: Model, messageId: string, emojiId: EmojiId, didIReactWithThisEmoji: bool,
     userPublicKey: string, userDisplayName: string, reactionId: string) =

--- a/src/app_service/service/message/dto/message.nim
+++ b/src/app_service/service/message/dto/message.nim
@@ -21,6 +21,7 @@ const PARSED_TEXT_OUTGOING_STATUS_SENDING*   = "sending"
 const PARSED_TEXT_OUTGOING_STATUS_SENT*      = "sent"
 const PARSED_TEXT_OUTGOING_STATUS_DELIVERED* = "delivered"
 const PARSED_TEXT_OUTGOING_STATUS_EXPIRED* = "expired"
+const PARSED_TEXT_OUTGOING_STATUS_FAILED_RESENDING* = "failedResending"
 
 type ParsedText* = object
   `type`*: string

--- a/src/app_service/service/message/service.nim
+++ b/src/app_service/service/message/service.nim
@@ -788,3 +788,16 @@ proc checkEditedMessageForMentions*(self: Service, chatId: string, editedMessage
   if not oldMentions.contains(myPubKey) and editedMessage.mentionedUsersPks().contains(myPubKey):
     let data = MessageEditedArgs(chatId: chatId, message: editedMessage)
     self.events.emit(SIGNAL_MENTIONED_IN_EDITED_MESSAGE, data)
+
+proc resendChatMessage*(self: Service, messageId: string): string =
+  try:
+    let response = status_go.resendChatMessage(messageId)
+
+    if response.error != nil:
+        let error = Json.decode($response.error, RpcError)
+        raise newException(RpcException, "Error resending chat message: " & error.message)
+
+    return
+  except Exception as e:
+    error "error: ", procName="resendChatMessage", errName = e.name, errDesription = e.msg
+    return fmt"{e.name}: {e.msg}"

--- a/src/backend/messages.nim
+++ b/src/backend/messages.nim
@@ -64,3 +64,6 @@ proc deleteMessageAndSend*(messageID: string): RpcResponse[JsonNode] {.raises: [
 
 proc editMessage*(messageId: string, contentType: int, msg: string): RpcResponse[JsonNode] {.raises: [Exception].} =
   result = callPrivateRPC("editMessage".prefix, %* [{"id": messageId, "text": msg, "content-type": contentType}])
+
+proc resendChatMessage*(messageId: string): RpcResponse[JsonNode] {.raises: [Exception].} =
+  result = callPrivateRPC("reSendChatMessage".prefix, %* [messageId])

--- a/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
@@ -58,6 +58,8 @@ Control {
     property bool isPinned: false
     property string pinnedBy: ""
     property bool hasExpired: false
+    property bool isSending: false
+    property string resendError: ""
     property double timestamp: 0
     property var reactionsModel: []
     property bool hasLinks
@@ -275,7 +277,9 @@ Control {
                         amISender: root.messageDetails.amISender
                         messageOriginInfo: root.messageDetails.messageOriginInfo
                         resendText: root.resendText
-                        showResendButton: root.hasExpired && root.messageDetails.amISender
+                        showResendButton: root.hasExpired && root.messageDetails.amISender && !editMode
+                        showSendingLoader: root.isSending && root.messageDetails.amISender && !editMode
+                        resendError: root.messageDetails.amISender && !editMode ? root.resendError : ""
                         onClicked: root.senderNameClicked(sender, mouse)
                         onResendClicked: root.resendClicked()
                         visible: root.showHeader && !editMode
@@ -371,17 +375,6 @@ Control {
                         cancelButtonText: root.cancelButtonText
                         onEditCancelled: root.editCancelled()
                         onEditCompleted: root.editCompleted(newMsgText)
-                    }
-                    StatusBaseText {
-                        color: Theme.palette.dangerColor1
-                        text: root.resendText
-                        font.pixelSize: 12
-                        visible: root.hasExpired && root.messageDetails.amISender && !root.timestamp && !editMode
-                        MouseArea {
-                            cursorShape: Qt.PointingHandCursor
-                            anchors.fill: parent
-                            onClicked: root.resendClicked()
-                        }
                     }
                     Loader {
                         active: root.reactionsModel.count > 0

--- a/ui/StatusQ/src/StatusQ/Components/StatusMessageHeader.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusMessageHeader.qml
@@ -22,6 +22,8 @@ Item {
     property string tertiaryDetail: sender.id
     property string resendText: ""
     property bool showResendButton: false
+    property bool showSendingLoader: false
+    property string resendError: ""
     property bool isContact: sender.isContact
     property int trustIndicator: sender.trustIndicator
     property bool amISender: false
@@ -119,6 +121,20 @@ Item {
                 anchors.fill: parent
                 onClicked: root.resendClicked()
             }
+        }
+        StatusBaseText {
+            verticalAlignment: Text.AlignVCenter
+            color: Theme.palette.baseColor1
+            font.pixelSize: Theme.tertiaryTextFontSize
+            text: qsTr("Failed to resend: %1").arg(resendError) // TODO replace this with the required design
+            visible: resendError && !!timestampText.text
+        }
+        StatusBaseText {
+            verticalAlignment: Text.AlignVCenter
+            color: Theme.palette.baseColor1
+            font.pixelSize: Theme.tertiaryTextFontSize
+            text: qsTr("Sending...") // TODO replace this with the required design
+            visible: showSendingLoader && !!timestampText.text
         }
     }
 }

--- a/ui/app/AppLayouts/Chat/stores/MessageStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/MessageStore.qml
@@ -210,19 +210,19 @@ QtObject {
     function requestMoreMessages() {
         if(!messageModule)
             return
-        return messageModule.requestMoreMessages();
+        return messageModule.requestMoreMessages()
     }
 
     function fillGaps(messageId) {
-         if(!messageModule)
+        if(!messageModule)
             return
-        return messageModule.fillGaps(messageId);
+        return messageModule.fillGaps(messageId)
     }
 
     function leaveChat() {
-         if(!messageModule)
+        if(!messageModule)
             return
-        messageModule.leaveChat();
+        messageModule.leaveChat()
     }
 
     property bool playAnimation: {
@@ -242,5 +242,11 @@ QtObject {
             return false
 
         return true
+    }
+
+    function resendMessage(messageId) {
+        if(!messageModule)
+            return
+        messageModule.resendMessage(messageId)
     }
 }

--- a/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
@@ -293,6 +293,7 @@ Item {
             messageImage: model.messageImage
             messageTimestamp: model.timestamp
             messageOutgoingStatus: model.outgoingStatus
+            resendError: model.resendError
             messageContentType: model.contentType
             pinnedMessage: model.pinned
             messagePinnedBy: model.pinnedBy

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -729,4 +729,11 @@ QtObject {
     readonly property QtObject walletSection: QtObject {
         readonly property string cancelledMessage: "cancelled"
     }
+
+    // Message outgoing status
+    readonly property string sending: "sending"
+    readonly property string sent: "sent"
+    readonly property string delivered: "delivered"
+    readonly property string expired: "expired"
+    readonly property string failedResending: "failedResending"
 }


### PR DESCRIPTION
Fixes #7643

This adds the backend to resend. It then hooks the button to it. This also adds a visual state for when we are sending. This gives a good indication that a message was sent.

I don' think there is a design for the `sending` state, so for now, I just put a `Sending...` label.

In the video, you can see the `Sending..` label real quick. In a public channel, the encryption is faster, so I don't even see the label.

[Screencast 2022-12-08 16:08:36-sending.webm](https://user-images.githubusercontent.com/11926403/206567875-b953a494-033c-402f-8265-4fa75ef7447d.webm)

FYI, I couldn't actually test the Resend with a message that failed to send, since I couldn't repro. So I faked it, and I did get the right signals for `sent`. So if someone still has the `Resend` shown, please test this.

Also, I'm pretty sure the button itself was showing wrongly because of some timestamp shenanigans. Patryk is working on that.