### PR TITLE
fix(warnings): Avoid flickable manipulations in SettingsPageLayout when dirty toast message isn't active

### DIFF
--- a/ui/app/AppLayouts/Chat/layouts/SettingsPageLayout.qml
+++ b/ui/app/AppLayouts/Chat/layouts/SettingsPageLayout.qml
@@ -79,7 +79,7 @@ Item {
             bottomMargin: 16
         }
         active: root.dirty
-        flickable: root.contentItem
+        flickable: root.dirty ? root.contentItem : null
         saveChangesButtonEnabled: !!root.contentItem && !!root.contentItem.saveChangesButtonEnabled
         onResetChangesClicked: root.resetChangesClicked()
         onSaveChangesClicked: root.saveChangesClicked()


### PR DESCRIPTION
Fixes: #8293

### What does the PR do

`SettingsPageLayout` was used as base component for `CommunityOverview`, but content type isn't `Flickable`.
I think that solution when `SettingsDirtyToastMessage` unexpectedly got a control for `contentItem` was wrong.
In fact of PR type I won't rectaforing this component, I will fix just warning. But I think, we should change it.

### Affected areas

Settings