### PR TITLE
fix(notifications): The sound of notifications is harsh and annoying

### DIFF
--- a/ui/app/AppLayouts/Profile/views/NotificationsView.qml
+++ b/ui/app/AppLayouts/Profile/views/NotificationsView.qml
@@ -468,6 +468,11 @@ SettingsContentBase {
 
                             Component.onCompleted: {
                                 value = appSettings.volume
+                                volumeSlider.valueChanged.connect(() => {
+                                                                      // play a sound preview, but not on startup
+                                                                      Global.notificationSound.stop()
+                                                                      Global.notificationSound.play()
+                                                                  });
                             }
                         }
 

--- a/ui/imports/utils/Audio.qml
+++ b/ui/imports/utils/Audio.qml
@@ -7,7 +7,9 @@ T.Audio {
     property var store
 
     audioRole: Audio.NotificationRole
-    volume: store.volume
+    volume: T.QtMultimedia.convertVolume(store.volume,
+                                         T.QtMultimedia.LogarithmicVolumeScale,
+                                         T.QtMultimedia.LinearVolumeScale)
     muted: !store.notificationSoundsEnabled
     onError: console.warn("Audio error:", errorString, "; code:", error)
 }


### PR DESCRIPTION
Use logarithmic scale instead of linear when interpreting the sound volume value

TLDR; we were literally overblowing the speakers with absolute sound volume levels; for the whole story I recommend reading: https://www.dr-lex.be/info-stuff/volumecontrols.html

Also play a sound preview when changing the volume in Settings

Needs https://github.com/status-im/dotherside/pull/83

Fixes #8426

### What does the PR do

Fixes sound volume for notifications

### Affected areas

Audio component; Settings/Notifications&Sound

### Screenshot of functionality (including design for comparison)

- [N/A] I've checked the design and this PR matches it
