### PR TITLE
fix: Rename "Chat" tooltip to "Messages"

### DIFF
--- a/src/app/global/app_sections_config.nim
+++ b/src/app/global/app_sections_config.nim
@@ -1,4 +1,4 @@
-const CHAT_SECTION_NAME* = "Chat"
+const CHAT_SECTION_NAME* = "Messages"
 const CHAT_SECTION_ICON* = "chat"
 
 const COMMUNITIESPORTAL_SECTION_ID* = "communitiesPortal"

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -228,7 +228,7 @@ proc createChannelGroupItem[T](self: Module[T], c: ChannelGroupDto): SectionItem
   result = initItem(
     c.id,
     if isCommunity: SectionType.Community else: SectionType.Chat,
-    if isCommunity: c.name else: "Chat",
+    if isCommunity: c.name else: conf.CHAT_SECTION_NAME,
     c.admin,
     c.description,
     c.introMessage,

--- a/test/ui-test/testSuites/global_shared/scripts/global_names.py
+++ b/test/ui-test/testSuites/global_shared/scripts/global_names.py
@@ -34,7 +34,7 @@ delete_Channel_ConfirmationDialog_DeleteButton = {"container": statusDesktop_mai
 
 # Main Window - chat related:
 mainWindow_statusChatNavBarListView_ListView = {"container": statusDesktop_mainWindow, "objectName": "statusChatNavBarListView", "type": "ListView", "visible": True}
-navBarListView_Chat_navbar_StatusNavBarTabButton = {"checkable": True, "container": mainWindow_statusChatNavBarListView_ListView, "objectName": "Chat-navbar", "type": "StatusNavBarTabButton", "visible": True}
+navBarListView_Chat_navbar_StatusNavBarTabButton = {"checkable": True, "container": mainWindow_statusChatNavBarListView_ListView, "objectName": "Messages-navbar", "type": "StatusNavBarTabButton", "visible": True}
 mainWindow_public_chat_icon_StatusIcon = {"container": statusDesktop_mainWindow, "objectName": "public-chat-icon", "source": "qrc:/StatusQ/src/assets/img/icons/public-chat.svg", "type": "StatusIcon", "visible": True}
 chatList_Repeater = {"container": statusDesktop_mainWindow, "objectName": "chatListItems", "type": "Repeater"}
 chatList = {"container": statusDesktop_mainWindow, "objectName": "ContactsColumnView_chatList", "type": "StatusChatList"}

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -488,7 +488,7 @@ Item {
                     name: model.icon.length > 0? "" : model.name
                     icon.name: model.icon
                     icon.source: model.image
-                    tooltip.text: model.name
+                    tooltip.text: Utils.translatedSectionName(model.sectionType, model.name)
                     checked: model.active
                     badge.value: model.notificationsCount
                     badge.visible: model.hasNotification

--- a/ui/i18n/qml_base.ts
+++ b/ui/i18n/qml_base.ts
@@ -1,4 +1,4 @@
-<TS version="2.1" sourcelanguage="en">
+<TS version="2.1" language="en_GB" sourcelanguage="en">
 <context>
     <name>AboutView</name>
     <message>
@@ -83,8 +83,14 @@
 <context>
     <name>AcceptRejectOptionsButtonsPanel</name>
     <message>
-        <location filename="../imports/shared/panels/AcceptRejectOptionsButtonsPanel.qml" line="71" />
-        <location filename="../imports/shared/panels/AcceptRejectOptionsButtonsPanel.qml" line="71" />
+        <location filename="../imports/shared/panels/AcceptRejectOptionsButtonsPanel.qml" line="70" />
+        <location filename="../imports/shared/panels/AcceptRejectOptionsButtonsPanel.qml" line="70" />
+        <source>Details</source>
+        <translation>Details</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/panels/AcceptRejectOptionsButtonsPanel.qml" line="78" />
+        <location filename="../imports/shared/panels/AcceptRejectOptionsButtonsPanel.qml" line="78" />
         <source>Decline and block</source>
         <translation>Decline and block</translation>
     </message>
@@ -235,74 +241,74 @@
 <context>
     <name>ActivityCenterPopupTopBarPanel</name>
     <message>
-        <location filename="../app/mainui/activitycenter/panels/ActivityCenterPopupTopBarPanel.qml" line="44" />
-        <location filename="../app/mainui/activitycenter/panels/ActivityCenterPopupTopBarPanel.qml" line="44" />
+        <location filename="../app/mainui/activitycenter/panels/ActivityCenterPopupTopBarPanel.qml" line="51" />
+        <location filename="../app/mainui/activitycenter/panels/ActivityCenterPopupTopBarPanel.qml" line="51" />
         <source>All</source>
         <translation>All</translation>
     </message>
     <message>
-        <location filename="../app/mainui/activitycenter/panels/ActivityCenterPopupTopBarPanel.qml" line="45" />
-        <location filename="../app/mainui/activitycenter/panels/ActivityCenterPopupTopBarPanel.qml" line="45" />
+        <location filename="../app/mainui/activitycenter/panels/ActivityCenterPopupTopBarPanel.qml" line="52" />
+        <location filename="../app/mainui/activitycenter/panels/ActivityCenterPopupTopBarPanel.qml" line="52" />
         <source>Admin</source>
         <translation>Admin</translation>
     </message>
     <message>
-        <location filename="../app/mainui/activitycenter/panels/ActivityCenterPopupTopBarPanel.qml" line="46" />
-        <location filename="../app/mainui/activitycenter/panels/ActivityCenterPopupTopBarPanel.qml" line="46" />
+        <location filename="../app/mainui/activitycenter/panels/ActivityCenterPopupTopBarPanel.qml" line="53" />
+        <location filename="../app/mainui/activitycenter/panels/ActivityCenterPopupTopBarPanel.qml" line="53" />
         <source>Mentions</source>
         <translation>Mentions</translation>
     </message>
     <message>
-        <location filename="../app/mainui/activitycenter/panels/ActivityCenterPopupTopBarPanel.qml" line="47" />
-        <location filename="../app/mainui/activitycenter/panels/ActivityCenterPopupTopBarPanel.qml" line="47" />
+        <location filename="../app/mainui/activitycenter/panels/ActivityCenterPopupTopBarPanel.qml" line="54" />
+        <location filename="../app/mainui/activitycenter/panels/ActivityCenterPopupTopBarPanel.qml" line="54" />
         <source>Replies</source>
         <translation>Replies</translation>
     </message>
     <message>
-        <location filename="../app/mainui/activitycenter/panels/ActivityCenterPopupTopBarPanel.qml" line="48" />
-        <location filename="../app/mainui/activitycenter/panels/ActivityCenterPopupTopBarPanel.qml" line="48" />
+        <location filename="../app/mainui/activitycenter/panels/ActivityCenterPopupTopBarPanel.qml" line="55" />
+        <location filename="../app/mainui/activitycenter/panels/ActivityCenterPopupTopBarPanel.qml" line="55" />
         <source>Contact requests</source>
         <translation>Contact requests</translation>
     </message>
     <message>
-        <location filename="../app/mainui/activitycenter/panels/ActivityCenterPopupTopBarPanel.qml" line="49" />
-        <location filename="../app/mainui/activitycenter/panels/ActivityCenterPopupTopBarPanel.qml" line="49" />
+        <location filename="../app/mainui/activitycenter/panels/ActivityCenterPopupTopBarPanel.qml" line="56" />
+        <location filename="../app/mainui/activitycenter/panels/ActivityCenterPopupTopBarPanel.qml" line="56" />
         <source>Identity verification</source>
         <translation>Identity verification</translation>
     </message>
     <message>
-        <location filename="../app/mainui/activitycenter/panels/ActivityCenterPopupTopBarPanel.qml" line="50" />
-        <location filename="../app/mainui/activitycenter/panels/ActivityCenterPopupTopBarPanel.qml" line="50" />
+        <location filename="../app/mainui/activitycenter/panels/ActivityCenterPopupTopBarPanel.qml" line="57" />
+        <location filename="../app/mainui/activitycenter/panels/ActivityCenterPopupTopBarPanel.qml" line="57" />
         <source>Transactions</source>
         <translation>Transactions</translation>
     </message>
     <message>
-        <location filename="../app/mainui/activitycenter/panels/ActivityCenterPopupTopBarPanel.qml" line="51" />
-        <location filename="../app/mainui/activitycenter/panels/ActivityCenterPopupTopBarPanel.qml" line="51" />
+        <location filename="../app/mainui/activitycenter/panels/ActivityCenterPopupTopBarPanel.qml" line="58" />
+        <location filename="../app/mainui/activitycenter/panels/ActivityCenterPopupTopBarPanel.qml" line="58" />
         <source>Membership</source>
         <translation>Membership</translation>
     </message>
     <message>
-        <location filename="../app/mainui/activitycenter/panels/ActivityCenterPopupTopBarPanel.qml" line="52" />
-        <location filename="../app/mainui/activitycenter/panels/ActivityCenterPopupTopBarPanel.qml" line="52" />
+        <location filename="../app/mainui/activitycenter/panels/ActivityCenterPopupTopBarPanel.qml" line="59" />
+        <location filename="../app/mainui/activitycenter/panels/ActivityCenterPopupTopBarPanel.qml" line="59" />
         <source>System</source>
         <translation>System</translation>
     </message>
     <message>
-        <location filename="../app/mainui/activitycenter/panels/ActivityCenterPopupTopBarPanel.qml" line="80" />
-        <location filename="../app/mainui/activitycenter/panels/ActivityCenterPopupTopBarPanel.qml" line="80" />
+        <location filename="../app/mainui/activitycenter/panels/ActivityCenterPopupTopBarPanel.qml" line="83" />
+        <location filename="../app/mainui/activitycenter/panels/ActivityCenterPopupTopBarPanel.qml" line="83" />
         <source>Mark all as Read</source>
         <translation>Mark all as Read</translation>
     </message>
     <message>
-        <location filename="../app/mainui/activitycenter/panels/ActivityCenterPopupTopBarPanel.qml" line="92" />
-        <location filename="../app/mainui/activitycenter/panels/ActivityCenterPopupTopBarPanel.qml" line="92" />
+        <location filename="../app/mainui/activitycenter/panels/ActivityCenterPopupTopBarPanel.qml" line="95" />
+        <location filename="../app/mainui/activitycenter/panels/ActivityCenterPopupTopBarPanel.qml" line="95" />
         <source>Show read notifications</source>
         <translation>Show read notifications</translation>
     </message>
     <message>
-        <location filename="../app/mainui/activitycenter/panels/ActivityCenterPopupTopBarPanel.qml" line="92" />
-        <location filename="../app/mainui/activitycenter/panels/ActivityCenterPopupTopBarPanel.qml" line="92" />
+        <location filename="../app/mainui/activitycenter/panels/ActivityCenterPopupTopBarPanel.qml" line="95" />
+        <location filename="../app/mainui/activitycenter/panels/ActivityCenterPopupTopBarPanel.qml" line="95" />
         <source>Hide read notifications</source>
         <translation>Hide read notifications</translation>
     </message>
@@ -310,77 +316,122 @@
 <context>
     <name>ActivityNotificationBase</name>
     <message>
-        <location filename="../app/mainui/activitycenter/views/ActivityNotificationBase.qml" line="48" />
-        <location filename="../app/mainui/activitycenter/views/ActivityNotificationBase.qml" line="48" />
+        <location filename="../app/mainui/activitycenter/views/ActivityNotificationBase.qml" line="65" />
+        <location filename="../app/mainui/activitycenter/views/ActivityNotificationBase.qml" line="65" />
+        <source>Mark as Unread</source>
+        <translation>Mark as Unread</translation>
+    </message>
+    <message>
+        <location filename="../app/mainui/activitycenter/views/ActivityNotificationBase.qml" line="65" />
+        <location filename="../app/mainui/activitycenter/views/ActivityNotificationBase.qml" line="65" />
         <source>Mark as Read</source>
         <translation>Mark as Read</translation>
     </message>
+</context>
+<context>
+    <name>ActivityNotificationCommunityKicked</name>
     <message>
-        <location filename="../app/mainui/activitycenter/views/ActivityNotificationBase.qml" line="48" />
-        <location filename="../app/mainui/activitycenter/views/ActivityNotificationBase.qml" line="48" />
-        <source>Mark as Unread</source>
-        <translation>Mark as Unread</translation>
+        <location filename="../app/mainui/activitycenter/views/ActivityNotificationCommunityKicked.qml" line="38" />
+        <location filename="../app/mainui/activitycenter/views/ActivityNotificationCommunityKicked.qml" line="38" />
+        <source>You were kicked from</source>
+        <translation>You were kicked from</translation>
+    </message>
+</context>
+<context>
+    <name>ActivityNotificationCommunityMembershipRequest</name>
+    <message>
+        <location filename="../app/mainui/activitycenter/views/ActivityNotificationCommunityMembershipRequest.qml" line="23" />
+        <location filename="../app/mainui/activitycenter/views/ActivityNotificationCommunityMembershipRequest.qml" line="23" />
+        <source>Wants to join</source>
+        <translation>Wants to join</translation>
+    </message>
+</context>
+<context>
+    <name>ActivityNotificationCommunityRequest</name>
+    <message>
+        <location filename="../app/mainui/activitycenter/views/ActivityNotificationCommunityRequest.qml" line="38" />
+        <location filename="../app/mainui/activitycenter/views/ActivityNotificationCommunityRequest.qml" line="38" />
+        <source>Request to join</source>
+        <translation>Request to join</translation>
+    </message>
+    <message>
+        <location filename="../app/mainui/activitycenter/views/ActivityNotificationCommunityRequest.qml" line="58" />
+        <location filename="../app/mainui/activitycenter/views/ActivityNotificationCommunityRequest.qml" line="58" />
+        <source>pending</source>
+        <translation>pending</translation>
+    </message>
+    <message>
+        <location filename="../app/mainui/activitycenter/views/ActivityNotificationCommunityRequest.qml" line="60" />
+        <location filename="../app/mainui/activitycenter/views/ActivityNotificationCommunityRequest.qml" line="60" />
+        <source>accepted</source>
+        <translation>accepted</translation>
+    </message>
+    <message>
+        <location filename="../app/mainui/activitycenter/views/ActivityNotificationCommunityRequest.qml" line="62" />
+        <location filename="../app/mainui/activitycenter/views/ActivityNotificationCommunityRequest.qml" line="62" />
+        <source>declined</source>
+        <translation>declined</translation>
+    </message>
+    <message>
+        <location filename="../app/mainui/activitycenter/views/ActivityNotificationCommunityRequest.qml" line="80" />
+        <location filename="../app/mainui/activitycenter/views/ActivityNotificationCommunityRequest.qml" line="80" />
+        <source>Visit Community</source>
+        <translation>Visit Community</translation>
     </message>
 </context>
 <context>
     <name>AddAccountModal</name>
     <message>
-        <location filename="../app/AppLayouts/Wallet/popups/AddAccountModal.qml" line="29" />
-        <location filename="../app/AppLayouts/Wallet/popups/AddAccountModal.qml" line="29" />
+        <location filename="../app/AppLayouts/Wallet/popups/AddAccountModal.qml" line="28" />
+        <location filename="../app/AppLayouts/Wallet/popups/AddAccountModal.qml" line="28" />
         <source>Generate an account</source>
         <translation>Generate an account</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/popups/AddAccountModal.qml" line="52" />
-        <location filename="../app/AppLayouts/Wallet/popups/AddAccountModal.qml" line="52" />
+        <location filename="../app/AppLayouts/Wallet/popups/AddAccountModal.qml" line="61" />
+        <location filename="../app/AppLayouts/Wallet/popups/AddAccountModal.qml" line="61" />
         <source>An authentication failed</source>
         <translation>An authentication failed</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/popups/AddAccountModal.qml" line="187" />
-        <location filename="../app/AppLayouts/Wallet/popups/AddAccountModal.qml" line="187" />
+        <location filename="../app/AppLayouts/Wallet/popups/AddAccountModal.qml" line="225" />
+        <location filename="../app/AppLayouts/Wallet/popups/AddAccountModal.qml" line="225" />
         <source>Enter an account name...</source>
         <translation>Enter an account name...</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/popups/AddAccountModal.qml" line="188" />
-        <location filename="../app/AppLayouts/Wallet/popups/AddAccountModal.qml" line="188" />
+        <location filename="../app/AppLayouts/Wallet/popups/AddAccountModal.qml" line="226" />
+        <location filename="../app/AppLayouts/Wallet/popups/AddAccountModal.qml" line="226" />
         <source>Account name</source>
         <translation>Account name</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/popups/AddAccountModal.qml" line="200" />
-        <location filename="../app/AppLayouts/Wallet/popups/AddAccountModal.qml" line="200" />
+        <location filename="../app/AppLayouts/Wallet/popups/AddAccountModal.qml" line="238" />
+        <location filename="../app/AppLayouts/Wallet/popups/AddAccountModal.qml" line="238" />
         <source>You need to enter an account name</source>
         <translation>You need to enter an account name</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/popups/AddAccountModal.qml" line="217" />
-        <location filename="../app/AppLayouts/Wallet/popups/AddAccountModal.qml" line="217" />
+        <location filename="../app/AppLayouts/Wallet/popups/AddAccountModal.qml" line="256" />
+        <location filename="../app/AppLayouts/Wallet/popups/AddAccountModal.qml" line="256" />
         <source>color</source>
         <translation>color</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/popups/AddAccountModal.qml" line="236" />
-        <location filename="../app/AppLayouts/Wallet/popups/AddAccountModal.qml" line="236" />
+        <location filename="../app/AppLayouts/Wallet/popups/AddAccountModal.qml" line="276" />
+        <location filename="../app/AppLayouts/Wallet/popups/AddAccountModal.qml" line="276" />
         <source>Advanced</source>
         <translation>Advanced</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/popups/AddAccountModal.qml" line="268" />
-        <location filename="../app/AppLayouts/Wallet/popups/AddAccountModal.qml" line="268" />
-        <source>Authenticate</source>
-        <translation>Authenticate</translation>
-    </message>
-    <message>
-        <location filename="../app/AppLayouts/Wallet/popups/AddAccountModal.qml" line="271" />
-        <location filename="../app/AppLayouts/Wallet/popups/AddAccountModal.qml" line="271" />
+        <location filename="../app/AppLayouts/Wallet/popups/AddAccountModal.qml" line="320" />
+        <location filename="../app/AppLayouts/Wallet/popups/AddAccountModal.qml" line="320" />
         <source>Loading...</source>
         <translation>Loading...</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/popups/AddAccountModal.qml" line="273" />
-        <location filename="../app/AppLayouts/Wallet/popups/AddAccountModal.qml" line="273" />
+        <location filename="../app/AppLayouts/Wallet/popups/AddAccountModal.qml" line="322" />
+        <location filename="../app/AppLayouts/Wallet/popups/AddAccountModal.qml" line="322" />
         <source>Add account</source>
         <translation>Add account</translation>
     </message>
@@ -404,74 +455,82 @@
         <translation>Add saved address</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml" line="65" />
-        <location filename="../imports/shared/popups/AddEditSavedAddressPopup.qml" line="66" />
-        <location filename="../app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml" line="65" />
-        <location filename="../imports/shared/popups/AddEditSavedAddressPopup.qml" line="66" />
+        <location filename="../app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml" line="66" />
+        <location filename="../imports/shared/popups/AddEditSavedAddressPopup.qml" line="67" />
+        <location filename="../app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml" line="66" />
+        <location filename="../imports/shared/popups/AddEditSavedAddressPopup.qml" line="67" />
         <source>Enter a name</source>
         <translation>Enter a name</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml" line="66" />
-        <location filename="../imports/shared/popups/AddEditSavedAddressPopup.qml" line="67" />
-        <location filename="../app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml" line="66" />
-        <location filename="../imports/shared/popups/AddEditSavedAddressPopup.qml" line="67" />
+        <location filename="../app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml" line="67" />
+        <location filename="../imports/shared/popups/AddEditSavedAddressPopup.qml" line="68" />
+        <location filename="../app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml" line="67" />
+        <location filename="../imports/shared/popups/AddEditSavedAddressPopup.qml" line="68" />
         <source>Name</source>
         <translation>Name</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml" line="70" />
-        <location filename="../imports/shared/popups/AddEditSavedAddressPopup.qml" line="71" />
-        <location filename="../app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml" line="70" />
-        <location filename="../imports/shared/popups/AddEditSavedAddressPopup.qml" line="71" />
+        <location filename="../app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml" line="71" />
+        <location filename="../imports/shared/popups/AddEditSavedAddressPopup.qml" line="72" />
+        <location filename="../app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml" line="71" />
+        <location filename="../imports/shared/popups/AddEditSavedAddressPopup.qml" line="72" />
         <source>Name must not be blank</source>
         <translation>Name must not be blank</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml" line="74" />
-        <location filename="../imports/shared/popups/AddEditSavedAddressPopup.qml" line="75" />
-        <location filename="../app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml" line="74" />
-        <location filename="../imports/shared/popups/AddEditSavedAddressPopup.qml" line="75" />
+        <location filename="../app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml" line="75" />
+        <location filename="../imports/shared/popups/AddEditSavedAddressPopup.qml" line="76" />
+        <location filename="../app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml" line="75" />
+        <location filename="../imports/shared/popups/AddEditSavedAddressPopup.qml" line="76" />
         <source>This is not a valid account name</source>
         <translation>This is not a valid account name</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml" line="88" />
-        <location filename="../imports/shared/popups/AddEditSavedAddressPopup.qml" line="89" />
-        <location filename="../app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml" line="88" />
-        <location filename="../imports/shared/popups/AddEditSavedAddressPopup.qml" line="89" />
+        <location filename="../app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml" line="89" />
+        <location filename="../imports/shared/popups/AddEditSavedAddressPopup.qml" line="90" />
+        <location filename="../app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml" line="89" />
+        <location filename="../imports/shared/popups/AddEditSavedAddressPopup.qml" line="90" />
         <source>Address</source>
         <translation>Address</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml" line="90" />
-        <location filename="../imports/shared/popups/AddEditSavedAddressPopup.qml" line="91" />
-        <location filename="../app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml" line="90" />
-        <location filename="../imports/shared/popups/AddEditSavedAddressPopup.qml" line="91" />
+        <location filename="../app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml" line="91" />
+        <location filename="../imports/shared/popups/AddEditSavedAddressPopup.qml" line="92" />
+        <location filename="../app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml" line="91" />
+        <location filename="../imports/shared/popups/AddEditSavedAddressPopup.qml" line="92" />
         <source>Enter ENS Name or Ethereum Address</source>
         <translation>Enter ENS Name or Ethereum Address</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml" line="101" />
-        <location filename="../imports/shared/popups/AddEditSavedAddressPopup.qml" line="102" />
-        <location filename="../app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml" line="101" />
-        <location filename="../imports/shared/popups/AddEditSavedAddressPopup.qml" line="102" />
+        <location filename="../app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml" line="102" />
+        <location filename="../imports/shared/popups/AddEditSavedAddressPopup.qml" line="103" />
+        <location filename="../app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml" line="102" />
+        <location filename="../imports/shared/popups/AddEditSavedAddressPopup.qml" line="103" />
         <source>Please enter a valid ENS name OR Ethereum Address</source>
         <translation>Please enter a valid ENS name OR Ethereum Address</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml" line="108" />
-        <location filename="../imports/shared/popups/AddEditSavedAddressPopup.qml" line="109" />
-        <location filename="../app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml" line="108" />
-        <location filename="../imports/shared/popups/AddEditSavedAddressPopup.qml" line="109" />
+        <location filename="../app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml" line="103" />
+        <location filename="../imports/shared/popups/AddEditSavedAddressPopup.qml" line="104" />
+        <location filename="../app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml" line="103" />
+        <location filename="../imports/shared/popups/AddEditSavedAddressPopup.qml" line="104" />
+        <source>Can't add yourself as a saved address</source>
+        <translation>Can't add yourself as a saved address</translation>
+    </message>
+    <message>
+        <location filename="../app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml" line="110" />
+        <location filename="../imports/shared/popups/AddEditSavedAddressPopup.qml" line="111" />
+        <location filename="../app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml" line="110" />
+        <location filename="../imports/shared/popups/AddEditSavedAddressPopup.qml" line="111" />
         <source>Save</source>
         <translation>Save</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml" line="108" />
-        <location filename="../imports/shared/popups/AddEditSavedAddressPopup.qml" line="109" />
-        <location filename="../app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml" line="108" />
-        <location filename="../imports/shared/popups/AddEditSavedAddressPopup.qml" line="109" />
+        <location filename="../app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml" line="110" />
+        <location filename="../imports/shared/popups/AddEditSavedAddressPopup.qml" line="111" />
+        <location filename="../app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml" line="110" />
+        <location filename="../imports/shared/popups/AddEditSavedAddressPopup.qml" line="111" />
         <source>Add address</source>
         <translation>Add address</translation>
     </message>
@@ -570,81 +629,6 @@
     </message>
 </context>
 <context>
-    <name>AddShowTokenModal</name>
-    <message>
-        <location filename="../app/AppLayouts/Profile/popups/AddShowTokenModal.qml" line="22" />
-        <location filename="../app/AppLayouts/Profile/popups/AddShowTokenModal.qml" line="22" />
-        <source>Add custom token</source>
-        <translation>Add custom token</translation>
-    </message>
-    <message>
-        <location filename="../app/AppLayouts/Profile/popups/AddShowTokenModal.qml" line="55" />
-        <location filename="../app/AppLayouts/Profile/popups/AddShowTokenModal.qml" line="55" />
-        <source>This needs to be a valid address</source>
-        <translation>This needs to be a valid address</translation>
-    </message>
-    <message>
-        <location filename="../app/AppLayouts/Profile/popups/AddShowTokenModal.qml" line="81" />
-        <location filename="../app/AppLayouts/Profile/popups/AddShowTokenModal.qml" line="81" />
-        <source>Invalid ERC20 address</source>
-        <translation>Invalid ERC20 address</translation>
-    </message>
-    <message>
-        <location filename="../app/AppLayouts/Profile/popups/AddShowTokenModal.qml" line="104" />
-        <location filename="../app/AppLayouts/Profile/popups/AddShowTokenModal.qml" line="104" />
-        <source>Enter contract address...</source>
-        <translation>Enter contract address...</translation>
-    </message>
-    <message>
-        <location filename="../app/AppLayouts/Profile/popups/AddShowTokenModal.qml" line="105" />
-        <location filename="../app/AppLayouts/Profile/popups/AddShowTokenModal.qml" line="105" />
-        <source>Contract address</source>
-        <translation>Contract address</translation>
-    </message>
-    <message>
-        <location filename="../app/AppLayouts/Profile/popups/AddShowTokenModal.qml" line="117" />
-        <location filename="../app/AppLayouts/Profile/popups/AddShowTokenModal.qml" line="117" />
-        <source>The name of your token...</source>
-        <translation>The name of your token...</translation>
-    </message>
-    <message>
-        <location filename="../app/AppLayouts/Profile/popups/AddShowTokenModal.qml" line="118" />
-        <location filename="../app/AppLayouts/Profile/popups/AddShowTokenModal.qml" line="118" />
-        <source>Name</source>
-        <translation>Name</translation>
-    </message>
-    <message>
-        <location filename="../app/AppLayouts/Profile/popups/AddShowTokenModal.qml" line="124" />
-        <location filename="../app/AppLayouts/Profile/popups/AddShowTokenModal.qml" line="124" />
-        <source>ABC</source>
-        <translation>ABC</translation>
-    </message>
-    <message>
-        <location filename="../app/AppLayouts/Profile/popups/AddShowTokenModal.qml" line="125" />
-        <location filename="../app/AppLayouts/Profile/popups/AddShowTokenModal.qml" line="125" />
-        <source>Symbol</source>
-        <translation>Symbol</translation>
-    </message>
-    <message>
-        <location filename="../app/AppLayouts/Profile/popups/AddShowTokenModal.qml" line="137" />
-        <location filename="../app/AppLayouts/Profile/popups/AddShowTokenModal.qml" line="137" />
-        <source>Decimals</source>
-        <translation>Decimals</translation>
-    </message>
-    <message>
-        <location filename="../app/AppLayouts/Profile/popups/AddShowTokenModal.qml" line="149" />
-        <location filename="../app/AppLayouts/Profile/popups/AddShowTokenModal.qml" line="149" />
-        <source>Changing settings failed</source>
-        <translation>Changing settings failed</translation>
-    </message>
-    <message>
-        <location filename="../app/AppLayouts/Profile/popups/AddShowTokenModal.qml" line="156" />
-        <location filename="../app/AppLayouts/Profile/popups/AddShowTokenModal.qml" line="156" />
-        <source>Add</source>
-        <translation>Add</translation>
-    </message>
-</context>
-<context>
     <name>AddWakuNodeModal</name>
     <message>
         <location filename="../app/AppLayouts/Profile/popups/AddWakuNodeModal.qml" line="19" />
@@ -736,26 +720,26 @@ Assets won&#8217;t be sent yet.</translation>
 <context>
     <name>AdvancedAddAccountView</name>
     <message>
-        <location filename="../app/AppLayouts/Wallet/views/AdvancedAddAccountView.qml" line="129" />
-        <location filename="../app/AppLayouts/Wallet/views/AdvancedAddAccountView.qml" line="129" />
+        <location filename="../app/AppLayouts/Wallet/views/AdvancedAddAccountView.qml" line="136" />
+        <location filename="../app/AppLayouts/Wallet/views/AdvancedAddAccountView.qml" line="136" />
         <source>Enter address...</source>
         <translation>Enter address...</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/views/AdvancedAddAccountView.qml" line="130" />
-        <location filename="../app/AppLayouts/Wallet/views/AdvancedAddAccountView.qml" line="130" />
+        <location filename="../app/AppLayouts/Wallet/views/AdvancedAddAccountView.qml" line="137" />
+        <location filename="../app/AppLayouts/Wallet/views/AdvancedAddAccountView.qml" line="137" />
         <source>Account address</source>
         <translation>Account address</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/views/AdvancedAddAccountView.qml" line="133" />
-        <location filename="../app/AppLayouts/Wallet/views/AdvancedAddAccountView.qml" line="133" />
+        <location filename="../app/AppLayouts/Wallet/views/AdvancedAddAccountView.qml" line="140" />
+        <location filename="../app/AppLayouts/Wallet/views/AdvancedAddAccountView.qml" line="140" />
         <source>This needs to be a valid address (starting with 0x)</source>
         <translation>This needs to be a valid address (starting with 0x)</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/views/AdvancedAddAccountView.qml" line="136" />
-        <location filename="../app/AppLayouts/Wallet/views/AdvancedAddAccountView.qml" line="136" />
+        <location filename="../app/AppLayouts/Wallet/views/AdvancedAddAccountView.qml" line="143" />
+        <location filename="../app/AppLayouts/Wallet/views/AdvancedAddAccountView.qml" line="143" />
         <source>You need to enter an address</source>
         <translation>You need to enter an address</translation>
     </message>
@@ -763,196 +747,202 @@ Assets won&#8217;t be sent yet.</translation>
 <context>
     <name>AdvancedView</name>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="39" />
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="39" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="42" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="42" />
         <source>Fleet</source>
         <translation>Fleet</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="48" />
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="48" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="51" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="51" />
         <source>Minimize on close</source>
         <translation>Minimize on close</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="61" />
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="61" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="64" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="64" />
         <source>Application Logs</source>
         <translation>Application Logs</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="93" />
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="93" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="96" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="96" />
         <source>Experimental features</source>
         <translation>Experimental features</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="103" />
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="103" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="106" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="106" />
         <source>Wallet</source>
         <translation>Wallet</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="121" />
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="121" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="124" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="124" />
         <source>Dapp Browser</source>
         <translation>Dapp Browser</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="137" />
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="137" />
-        <source>Community History Archive Protocol</source>
-        <translation>Community History Archive Protocol</translation>
-    </message>
-    <message>
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="154" />
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="154" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="141" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="141" />
         <source>Node Management</source>
         <translation>Node Management</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="171" />
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="171" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="158" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="158" />
         <source>Community Permissions Settings</source>
         <translation>Community Permissions Settings</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="187" />
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="187" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="174" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="174" />
         <source>Discord Import Tool</source>
         <translation>Discord Import Tool</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="207" />
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="207" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="194" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="194" />
         <source>Bloom filter level</source>
         <translation>Bloom filter level</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="226" />
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="226" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="213" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="213" />
         <source>Warning!</source>
         <translation>Warning!</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="227" />
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="313" />
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="227" />
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="313" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="214" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="300" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="214" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="300" />
         <source>The account will be logged out. When you login again, the selected mode will be enabled</source>
         <translation>The account will be logged out. When you login again, the selected mode will be enabled</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="250" />
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="336" />
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="250" />
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="336" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="237" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="323" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="237" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="323" />
         <source>Light Node</source>
         <translation>Light Node</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="264" />
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="264" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="251" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="251" />
         <source>Normal</source>
         <translation>Normal</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="278" />
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="350" />
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="278" />
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="350" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="265" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="337" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="265" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="337" />
         <source>Full Node</source>
         <translation>Full Node</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="295" />
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="295" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="282" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="282" />
         <source>WakuV2 mode</source>
         <translation>WakuV2 mode</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="366" />
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="366" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="353" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="353" />
         <source>Developer features</source>
         <translation>Developer features</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="378" />
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="378" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="365" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="365" />
         <source>Full developer mode</source>
         <translation>Full developer mode</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="398" />
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="398" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="385" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="385" />
         <source>Download messages</source>
         <translation>Download messages</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="410" />
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="410" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="397" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="397" />
         <source>Telemetry</source>
         <translation>Telemetry</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="422" />
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="422" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="409" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="409" />
         <source>Debug</source>
         <translation>Debug</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="434" />
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="434" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="421" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="421" />
         <source>Auto message</source>
         <translation>Auto message</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="455" />
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="455" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="442" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="442" />
         <source>Are you sure you want to enable all the develoer features? The app will be restarted.</source>
         <translation>Are you sure you want to enable all the develoer features? The app will be restarted.</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="474" />
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="474" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="461" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="461" />
         <source>Are you sure you want to enable telemetry? This will reduce your privacy level while using Status. You need to restart the app for this change to take effect.</source>
         <translation>Are you sure you want to enable telemetry? This will reduce your privacy level while using Status. You need to restart the app for this change to take effect.</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="492" />
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="492" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="479" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="479" />
         <source>Are you sure you want to enable auto message? You need to restart the app for this change to take effect.</source>
         <translation>Are you sure you want to enable auto message? You need to restart the app for this change to take effect.</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="510" />
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="510" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="497" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="497" />
         <source>Are you sure you want to %1 debug mode? You need to restart the app for this change to take effect.</source>
         <translation>Are you sure you want to %1 debug mode? You need to restart the app for this change to take effect.</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="511" />
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="511" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="498" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="498" />
         <source>disable</source>
         <translation>disable</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="512" />
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="512" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="499" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="499" />
         <source>enable</source>
         <translation>enable</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="527" />
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="527" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="514" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="514" />
         <source>This feature is experimental and is meant for testing purposes by core contributors and the community. It's not meant for real use and makes no claims of security or integrity of funds or data. Use at your own risk.</source>
         <translation>This feature is experimental and is meant for testing purposes by core contributors and the community. It's not meant for real use and makes no claims of security or integrity of funds or data. Use at your own risk.</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="528" />
-        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="528" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="515" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="515" />
         <source>I understand</source>
         <translation>I understand</translation>
+    </message>
+    <message>
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="532" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="532" />
+        <source>An error occoured</source>
+        <translation>An error occoured</translation>
+    </message>
+    <message>
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="538" />
+        <location filename="../app/AppLayouts/Profile/views/AdvancedView.qml" line="538" />
+        <source>The specified torrent client port is already in use.</source>
+        <translation>The specified torrent client port is already in use.</translation>
     </message>
 </context>
 <context>
@@ -1002,176 +992,183 @@ edit your notification preferences later in settings.</translation>
 <context>
     <name>AppMain</name>
     <message>
-        <location filename="../app/mainui/AppMain.qml" line="214" />
-        <location filename="../app/mainui/AppMain.qml" line="214" />
+        <location filename="../app/mainui/AppMain.qml" line="235" />
+        <location filename="../app/mainui/AppMain.qml" line="235" />
         <source>Profile Picture</source>
         <translation>Profile Picture</translation>
     </message>
     <message>
-        <location filename="../app/mainui/AppMain.qml" line="215" />
-        <location filename="../app/mainui/AppMain.qml" line="215" />
+        <location filename="../app/mainui/AppMain.qml" line="236" />
+        <location filename="../app/mainui/AppMain.qml" line="236" />
         <source>Make this my Profile Pic</source>
         <translation>Make this my Profile Pic</translation>
     </message>
     <message>
-        <location filename="../app/mainui/AppMain.qml" line="369" />
-        <location filename="../app/mainui/AppMain.qml" line="369" />
+        <location filename="../app/mainui/AppMain.qml" line="383" />
+        <location filename="../app/mainui/AppMain.qml" line="383" />
         <source>Invite People</source>
         <translation>Invite People</translation>
     </message>
     <message>
-        <location filename="../app/mainui/AppMain.qml" line="379" />
-        <location filename="../app/mainui/AppMain.qml" line="379" />
+        <location filename="../app/mainui/AppMain.qml" line="394" />
+        <location filename="../app/mainui/AppMain.qml" line="394" />
         <source>View Community</source>
         <translation>View Community</translation>
     </message>
     <message>
-        <location filename="../app/mainui/AppMain.qml" line="391" />
-        <location filename="../app/mainui/AppMain.qml" line="391" />
+        <location filename="../app/mainui/AppMain.qml" line="406" />
+        <location filename="../app/mainui/AppMain.qml" line="406" />
         <source>Leave Community</source>
         <translation>Leave Community</translation>
     </message>
     <message>
-        <location filename="../app/mainui/AppMain.qml" line="490" />
-        <location filename="../app/mainui/AppMain.qml" line="490" />
+        <location filename="../app/mainui/AppMain.qml" line="545" />
+        <location filename="../app/mainui/AppMain.qml" line="545" />
         <source>Testnet mode is enabled. All balances, transactions and dApp interactions will be on testnets.</source>
         <translation>Testnet mode is enabled. All balances, transactions and dApp interactions will be on testnets.</translation>
     </message>
     <message>
-        <location filename="../app/mainui/AppMain.qml" line="491" />
-        <location filename="../app/mainui/AppMain.qml" line="491" />
+        <location filename="../app/mainui/AppMain.qml" line="546" />
+        <location filename="../app/mainui/AppMain.qml" line="546" />
         <source>Turn off</source>
         <translation>Turn off</translation>
     </message>
     <message>
-        <location filename="../app/mainui/AppMain.qml" line="507" />
-        <location filename="../app/mainui/AppMain.qml" line="507" />
+        <location filename="../app/mainui/AppMain.qml" line="562" />
+        <location filename="../app/mainui/AppMain.qml" line="562" />
         <source>Turn off Testnet mode</source>
         <translation>Turn off Testnet mode</translation>
     </message>
     <message>
-        <location filename="../app/mainui/AppMain.qml" line="511" />
-        <location filename="../app/mainui/AppMain.qml" line="511" />
+        <location filename="../app/mainui/AppMain.qml" line="566" />
+        <location filename="../app/mainui/AppMain.qml" line="566" />
         <source>Closing this banner will turn off Testnet mode.
 All future transactions will be on mainnet or other active networks.</source>
         <translation>Closing this banner will turn off Testnet mode.
 All future transactions will be on mainnet or other active networks.</translation>
     </message>
     <message>
-        <location filename="../app/mainui/AppMain.qml" line="520" />
-        <location filename="../app/mainui/AppMain.qml" line="520" />
+        <location filename="../app/mainui/AppMain.qml" line="575" />
+        <location filename="../app/mainui/AppMain.qml" line="575" />
         <source>Turn off Testnet</source>
         <translation>Turn off Testnet</translation>
     </message>
     <message>
-        <location filename="../app/mainui/AppMain.qml" line="538" />
-        <location filename="../app/mainui/AppMain.qml" line="538" />
+        <location filename="../app/mainui/AppMain.qml" line="593" />
+        <location filename="../app/mainui/AppMain.qml" line="593" />
         <source>Secure your seed phrase</source>
         <translation>Secure your seed phrase</translation>
     </message>
     <message>
-        <location filename="../app/mainui/AppMain.qml" line="539" />
-        <location filename="../app/mainui/AppMain.qml" line="539" />
+        <location filename="../app/mainui/AppMain.qml" line="594" />
+        <location filename="../app/mainui/AppMain.qml" line="594" />
         <source>Back up now</source>
         <translation>Back up now</translation>
     </message>
     <message>
-        <location filename="../app/mainui/AppMain.qml" line="568" />
-        <location filename="../app/mainui/AppMain.qml" line="568" />
+        <location filename="../app/mainui/AppMain.qml" line="623" />
+        <location filename="../app/mainui/AppMain.qml" line="623" />
         <source>The import of &#8216;%1&#8217; from Discord to Status was stopped: &lt;a href='#'&gt;Critical issues found&lt;/a&gt;</source>
         <translation>The import of &#8216;%1&#8217; from Discord to Status was stopped: &lt;a href='#'&gt;Critical issues found&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../app/mainui/AppMain.qml" line="570" />
-        <location filename="../app/mainui/AppMain.qml" line="570" />
+        <location filename="../app/mainui/AppMain.qml" line="625" />
+        <location filename="../app/mainui/AppMain.qml" line="625" />
         <source>&#8216;%1&#8217; was successfully imported from Discord to Status</source>
         <translation>&#8216;%1&#8217; was successfully imported from Discord to Status</translation>
     </message>
     <message>
-        <location filename="../app/mainui/AppMain.qml" line="572" />
-        <location filename="../app/mainui/AppMain.qml" line="572" />
+        <location filename="../app/mainui/AppMain.qml" line="627" />
+        <location filename="../app/mainui/AppMain.qml" line="627" />
         <source>Details (%1)</source>
         <translation>Details (%1)</translation>
     </message>
     <message numerus="yes">
-        <location filename="../app/mainui/AppMain.qml" line="572" />
-        <location filename="../app/mainui/AppMain.qml" line="581" />
-        <location filename="../app/mainui/AppMain.qml" line="572" />
-        <location filename="../app/mainui/AppMain.qml" line="581" />
+        <location filename="../app/mainui/AppMain.qml" line="627" />
+        <location filename="../app/mainui/AppMain.qml" line="636" />
+        <location filename="../app/mainui/AppMain.qml" line="627" />
+        <location filename="../app/mainui/AppMain.qml" line="636" />
         <source>%n issue(s)</source>
         <translation type="unfinished">
+            <numerusform />
             <numerusform />
         </translation>
     </message>
     <message>
-        <location filename="../app/mainui/AppMain.qml" line="574" />
-        <location filename="../app/mainui/AppMain.qml" line="574" />
+        <location filename="../app/mainui/AppMain.qml" line="629" />
+        <location filename="../app/mainui/AppMain.qml" line="629" />
         <source>Details</source>
         <translation>Details</translation>
     </message>
     <message>
-        <location filename="../app/mainui/AppMain.qml" line="579" />
-        <location filename="../app/mainui/AppMain.qml" line="579" />
+        <location filename="../app/mainui/AppMain.qml" line="634" />
+        <location filename="../app/mainui/AppMain.qml" line="634" />
         <source>Importing &#8216;%1&#8217; from Discord to Status</source>
         <translation>Importing &#8216;%1&#8217; from Discord to Status</translation>
     </message>
     <message>
-        <location filename="../app/mainui/AppMain.qml" line="581" />
-        <location filename="../app/mainui/AppMain.qml" line="581" />
+        <location filename="../app/mainui/AppMain.qml" line="636" />
+        <location filename="../app/mainui/AppMain.qml" line="636" />
         <source>Check progress (%1)</source>
         <translation>Check progress (%1)</translation>
     </message>
     <message>
-        <location filename="../app/mainui/AppMain.qml" line="583" />
-        <location filename="../app/mainui/AppMain.qml" line="583" />
+        <location filename="../app/mainui/AppMain.qml" line="638" />
+        <location filename="../app/mainui/AppMain.qml" line="638" />
         <source>Check progress</source>
         <translation>Check progress</translation>
     </message>
     <message>
-        <location filename="../app/mainui/AppMain.qml" line="591" />
-        <location filename="../app/mainui/AppMain.qml" line="591" />
+        <location filename="../app/mainui/AppMain.qml" line="646" />
+        <location filename="../app/mainui/AppMain.qml" line="646" />
         <source>Visit your Community</source>
         <translation>Visit your Community</translation>
     </message>
     <message>
-        <location filename="../app/mainui/AppMain.qml" line="609" />
-        <location filename="../app/mainui/AppMain.qml" line="609" />
+        <location filename="../app/mainui/AppMain.qml" line="661" />
+        <location filename="../app/mainui/AppMain.qml" line="661" />
+        <source>Downloading message history archives, DO NOT CLOSE THE APP until this banner disappears.</source>
+        <translation>Downloading message history archives, DO NOT CLOSE THE APP until this banner disappears.</translation>
+    </message>
+    <message>
+        <location filename="../app/mainui/AppMain.qml" line="674" />
+        <location filename="../app/mainui/AppMain.qml" line="674" />
         <source>Connected</source>
         <translation>Connected</translation>
     </message>
     <message>
-        <location filename="../app/mainui/AppMain.qml" line="609" />
-        <location filename="../app/mainui/AppMain.qml" line="609" />
+        <location filename="../app/mainui/AppMain.qml" line="674" />
+        <location filename="../app/mainui/AppMain.qml" line="674" />
         <source>Disconnected</source>
         <translation>Disconnected</translation>
     </message>
     <message>
-        <location filename="../app/mainui/AppMain.qml" line="647" />
-        <location filename="../app/mainui/AppMain.qml" line="647" />
+        <location filename="../app/mainui/AppMain.qml" line="712" />
+        <location filename="../app/mainui/AppMain.qml" line="712" />
         <source>A new version of Status (%1) is available</source>
         <translation>A new version of Status (%1) is available</translation>
     </message>
     <message>
-        <location filename="../app/mainui/AppMain.qml" line="648" />
-        <location filename="../app/mainui/AppMain.qml" line="648" />
+        <location filename="../app/mainui/AppMain.qml" line="713" />
+        <location filename="../app/mainui/AppMain.qml" line="713" />
         <source>Your version is up to date</source>
         <translation>Your version is up to date</translation>
     </message>
     <message>
-        <location filename="../app/mainui/AppMain.qml" line="650" />
-        <location filename="../app/mainui/AppMain.qml" line="650" />
+        <location filename="../app/mainui/AppMain.qml" line="715" />
+        <location filename="../app/mainui/AppMain.qml" line="715" />
         <source>Update</source>
         <translation>Update</translation>
     </message>
     <message>
-        <location filename="../app/mainui/AppMain.qml" line="651" />
-        <location filename="../app/mainui/AppMain.qml" line="651" />
+        <location filename="../app/mainui/AppMain.qml" line="716" />
+        <location filename="../app/mainui/AppMain.qml" line="716" />
         <source>Close</source>
         <translation>Close</translation>
     </message>
     <message>
-        <location filename="../app/mainui/AppMain.qml" line="1135" />
-        <location filename="../app/mainui/AppMain.qml" line="1135" />
+        <location filename="../app/mainui/AppMain.qml" line="1208" />
+        <location filename="../app/mainui/AppMain.qml" line="1208" />
         <source>Where do you want to go?</source>
         <translation>Where do you want to go?</translation>
     </message>
@@ -1179,14 +1176,14 @@ All future transactions will be on mainnet or other active networks.</translatio
 <context>
     <name>AppSearch</name>
     <message>
-        <location filename="../app/mainui/AppSearch.qml" line="55" />
-        <location filename="../app/mainui/AppSearch.qml" line="55" />
+        <location filename="../app/mainui/AppSearch.qml" line="73" />
+        <location filename="../app/mainui/AppSearch.qml" line="73" />
         <source>No results</source>
         <translation>No results</translation>
     </message>
     <message>
-        <location filename="../app/mainui/AppSearch.qml" line="56" />
-        <location filename="../app/mainui/AppSearch.qml" line="56" />
+        <location filename="../app/mainui/AppSearch.qml" line="74" />
+        <location filename="../app/mainui/AppSearch.qml" line="74" />
         <source>Anywhere</source>
         <translation>Anywhere</translation>
     </message>
@@ -1344,8 +1341,8 @@ All future transactions will be on mainnet or other active networks.</translatio
 <context>
     <name>AssetDelegate</name>
     <message>
-        <location filename="../imports/shared/controls/AssetDelegate.qml" line="60" />
-        <location filename="../imports/shared/controls/AssetDelegate.qml" line="60" />
+        <location filename="../imports/shared/controls/AssetDelegate.qml" line="55" />
+        <location filename="../imports/shared/controls/AssetDelegate.qml" line="55" />
         <source>%1 %2</source>
         <translation>%1 %2</translation>
     </message>
@@ -1353,50 +1350,62 @@ All future transactions will be on mainnet or other active networks.</translatio
 <context>
     <name>AssetsDetailView</name>
     <message>
-        <location filename="../imports/shared/views/AssetsDetailView.qml" line="182" />
-        <location filename="../imports/shared/views/AssetsDetailView.qml" line="182" />
+        <location filename="../imports/shared/views/AssetsDetailView.qml" line="114" />
+        <location filename="../imports/shared/views/AssetsDetailView.qml" line="114" />
+        <source>Price</source>
+        <translation>Price</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/views/AssetsDetailView.qml" line="116" />
+        <location filename="../imports/shared/views/AssetsDetailView.qml" line="116" />
+        <source>Balance</source>
+        <translation>Balance</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/views/AssetsDetailView.qml" line="266" />
+        <location filename="../imports/shared/views/AssetsDetailView.qml" line="266" />
         <source>Market Cap</source>
         <translation>Market Cap</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/AssetsDetailView.qml" line="187" />
-        <location filename="../imports/shared/views/AssetsDetailView.qml" line="187" />
+        <location filename="../imports/shared/views/AssetsDetailView.qml" line="271" />
+        <location filename="../imports/shared/views/AssetsDetailView.qml" line="271" />
         <source>Day Low</source>
         <translation>Day Low</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/AssetsDetailView.qml" line="192" />
-        <location filename="../imports/shared/views/AssetsDetailView.qml" line="192" />
+        <location filename="../imports/shared/views/AssetsDetailView.qml" line="276" />
+        <location filename="../imports/shared/views/AssetsDetailView.qml" line="276" />
         <source>Day High</source>
         <translation>Day High</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/AssetsDetailView.qml" line="201" />
-        <location filename="../imports/shared/views/AssetsDetailView.qml" line="201" />
+        <location filename="../imports/shared/views/AssetsDetailView.qml" line="285" />
+        <location filename="../imports/shared/views/AssetsDetailView.qml" line="285" />
         <source>Hour</source>
         <translation>Hour</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/AssetsDetailView.qml" line="210" />
-        <location filename="../imports/shared/views/AssetsDetailView.qml" line="210" />
+        <location filename="../imports/shared/views/AssetsDetailView.qml" line="294" />
+        <location filename="../imports/shared/views/AssetsDetailView.qml" line="294" />
         <source>Day</source>
         <translation>Day</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/AssetsDetailView.qml" line="219" />
-        <location filename="../imports/shared/views/AssetsDetailView.qml" line="219" />
+        <location filename="../imports/shared/views/AssetsDetailView.qml" line="303" />
+        <location filename="../imports/shared/views/AssetsDetailView.qml" line="303" />
         <source>24 Hours</source>
         <translation>24 Hours</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/AssetsDetailView.qml" line="234" />
-        <location filename="../imports/shared/views/AssetsDetailView.qml" line="234" />
+        <location filename="../imports/shared/views/AssetsDetailView.qml" line="318" />
+        <location filename="../imports/shared/views/AssetsDetailView.qml" line="318" />
         <source>Overview</source>
         <translation>Overview</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/AssetsDetailView.qml" line="277" />
-        <location filename="../imports/shared/views/AssetsDetailView.qml" line="277" />
+        <location filename="../imports/shared/views/AssetsDetailView.qml" line="361" />
+        <location filename="../imports/shared/views/AssetsDetailView.qml" line="361" />
         <source>Website</source>
         <translation>Website</translation>
     </message>
@@ -1419,40 +1428,40 @@ All future transactions will be on mainnet or other active networks.</translatio
 <context>
     <name>BackupSeedModal</name>
     <message>
-        <location filename="../app/AppLayouts/Profile/popups/BackupSeedModal.qml" line="44" />
-        <location filename="../app/AppLayouts/Profile/popups/BackupSeedModal.qml" line="44" />
+        <location filename="../app/AppLayouts/Profile/popups/BackupSeedModal.qml" line="54" />
+        <location filename="../app/AppLayouts/Profile/popups/BackupSeedModal.qml" line="54" />
         <source>Not Now</source>
         <translation>Not Now</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/popups/BackupSeedModal.qml" line="55" />
-        <location filename="../app/AppLayouts/Profile/popups/BackupSeedModal.qml" line="55" />
+        <location filename="../app/AppLayouts/Profile/popups/BackupSeedModal.qml" line="65" />
+        <location filename="../app/AppLayouts/Profile/popups/BackupSeedModal.qml" line="65" />
         <source>Back up your seed phrase</source>
         <translation>Back up your seed phrase</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/popups/BackupSeedModal.qml" line="78" />
-        <location filename="../app/AppLayouts/Profile/popups/BackupSeedModal.qml" line="78" />
+        <location filename="../app/AppLayouts/Profile/popups/BackupSeedModal.qml" line="88" />
+        <location filename="../app/AppLayouts/Profile/popups/BackupSeedModal.qml" line="88" />
         <source>Confirm Seed Phrase</source>
         <translation>Confirm Seed Phrase</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/popups/BackupSeedModal.qml" line="81" />
-        <location filename="../app/AppLayouts/Profile/popups/BackupSeedModal.qml" line="81" />
+        <location filename="../app/AppLayouts/Profile/popups/BackupSeedModal.qml" line="91" />
+        <location filename="../app/AppLayouts/Profile/popups/BackupSeedModal.qml" line="91" />
         <source>Continue</source>
         <translation>Continue</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/popups/BackupSeedModal.qml" line="90" />
-        <location filename="../app/AppLayouts/Profile/popups/BackupSeedModal.qml" line="90" />
+        <location filename="../app/AppLayouts/Profile/popups/BackupSeedModal.qml" line="100" />
+        <location filename="../app/AppLayouts/Profile/popups/BackupSeedModal.qml" line="100" />
         <source>Complete &amp; Delete My Seed Phrase</source>
         <translation>Complete &amp; Delete My Seed Phrase</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/popups/BackupSeedModal.qml" line="126" />
-        <location filename="../app/AppLayouts/Profile/popups/BackupSeedModal.qml" line="133" />
-        <location filename="../app/AppLayouts/Profile/popups/BackupSeedModal.qml" line="126" />
-        <location filename="../app/AppLayouts/Profile/popups/BackupSeedModal.qml" line="133" />
+        <location filename="../app/AppLayouts/Profile/popups/BackupSeedModal.qml" line="136" />
+        <location filename="../app/AppLayouts/Profile/popups/BackupSeedModal.qml" line="143" />
+        <location filename="../app/AppLayouts/Profile/popups/BackupSeedModal.qml" line="136" />
+        <location filename="../app/AppLayouts/Profile/popups/BackupSeedModal.qml" line="143" />
         <source>Confirm word #%1 of your seed phrase</source>
         <translation>Confirm word #%1 of your seed phrase</translation>
     </message>
@@ -1460,20 +1469,20 @@ All future transactions will be on mainnet or other active networks.</translatio
 <context>
     <name>BackupSeedStepBase</name>
     <message>
-        <location filename="../app/AppLayouts/Profile/popups/backupseed/BackupSeedStepBase.qml" line="44" />
-        <location filename="../app/AppLayouts/Profile/popups/backupseed/BackupSeedStepBase.qml" line="44" />
+        <location filename="../app/AppLayouts/Profile/popups/backupseed/BackupSeedStepBase.qml" line="48" />
+        <location filename="../app/AppLayouts/Profile/popups/backupseed/BackupSeedStepBase.qml" line="48" />
         <source>Word #%1</source>
         <translation>Word #%1</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/popups/backupseed/BackupSeedStepBase.qml" line="45" />
-        <location filename="../app/AppLayouts/Profile/popups/backupseed/BackupSeedStepBase.qml" line="45" />
+        <location filename="../app/AppLayouts/Profile/popups/backupseed/BackupSeedStepBase.qml" line="49" />
+        <location filename="../app/AppLayouts/Profile/popups/backupseed/BackupSeedStepBase.qml" line="49" />
         <source>Enter word</source>
         <translation>Enter word</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/popups/backupseed/BackupSeedStepBase.qml" line="49" />
-        <location filename="../app/AppLayouts/Profile/popups/backupseed/BackupSeedStepBase.qml" line="49" />
+        <location filename="../app/AppLayouts/Profile/popups/backupseed/BackupSeedStepBase.qml" line="53" />
+        <location filename="../app/AppLayouts/Profile/popups/backupseed/BackupSeedStepBase.qml" line="53" />
         <source>Wrong word</source>
         <translation>Wrong word</translation>
     </message>
@@ -1481,14 +1490,20 @@ All future transactions will be on mainnet or other active networks.</translatio
 <context>
     <name>BalanceExceeded</name>
     <message>
-        <location filename="../imports/shared/controls/BalanceExceeded.qml" line="34" />
-        <location filename="../imports/shared/controls/BalanceExceeded.qml" line="34" />
+        <location filename="../imports/shared/controls/BalanceExceeded.qml" line="43" />
+        <location filename="../imports/shared/controls/BalanceExceeded.qml" line="43" />
+        <source>Calculating fees</source>
+        <translation>Calculating fees</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/controls/BalanceExceeded.qml" line="43" />
+        <location filename="../imports/shared/controls/BalanceExceeded.qml" line="43" />
         <source>Balance exceeded</source>
         <translation>Balance exceeded</translation>
     </message>
     <message>
-        <location filename="../imports/shared/controls/BalanceExceeded.qml" line="34" />
-        <location filename="../imports/shared/controls/BalanceExceeded.qml" line="34" />
+        <location filename="../imports/shared/controls/BalanceExceeded.qml" line="43" />
+        <location filename="../imports/shared/controls/BalanceExceeded.qml" line="43" />
         <source>No networks available</source>
         <translation>No networks available</translation>
     </message>
@@ -1505,38 +1520,38 @@ All future transactions will be on mainnet or other active networks.</translatio
 <context>
     <name>BeforeGetStartedModal</name>
     <message>
-        <location filename="../app/AppLayouts/Onboarding/popups/BeforeGetStartedModal.qml" line="20" />
-        <location filename="../app/AppLayouts/Onboarding/popups/BeforeGetStartedModal.qml" line="20" />
+        <location filename="../app/AppLayouts/Onboarding/popups/BeforeGetStartedModal.qml" line="22" />
+        <location filename="../app/AppLayouts/Onboarding/popups/BeforeGetStartedModal.qml" line="22" />
         <source>Before you get started...</source>
         <translation>Before you get started...</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Onboarding/popups/BeforeGetStartedModal.qml" line="31" />
-        <location filename="../app/AppLayouts/Onboarding/popups/BeforeGetStartedModal.qml" line="31" />
+        <location filename="../app/AppLayouts/Onboarding/popups/BeforeGetStartedModal.qml" line="33" />
+        <location filename="../app/AppLayouts/Onboarding/popups/BeforeGetStartedModal.qml" line="33" />
         <source>Get Started</source>
         <translation>Get Started</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Onboarding/popups/BeforeGetStartedModal.qml" line="49" />
-        <location filename="../app/AppLayouts/Onboarding/popups/BeforeGetStartedModal.qml" line="49" />
+        <location filename="../app/AppLayouts/Onboarding/popups/BeforeGetStartedModal.qml" line="51" />
+        <location filename="../app/AppLayouts/Onboarding/popups/BeforeGetStartedModal.qml" line="51" />
         <source>I acknowledge that Status Desktop is in Beta and by using it I take the full responsibility for all risks concerning my data and funds.</source>
         <translation>I acknowledge that Status Desktop is in Beta and by using it I take the full responsibility for all risks concerning my data and funds.</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Onboarding/popups/BeforeGetStartedModal.qml" line="63" />
-        <location filename="../app/AppLayouts/Onboarding/popups/BeforeGetStartedModal.qml" line="63" />
+        <location filename="../app/AppLayouts/Onboarding/popups/BeforeGetStartedModal.qml" line="65" />
+        <location filename="../app/AppLayouts/Onboarding/popups/BeforeGetStartedModal.qml" line="65" />
         <source>I accept Status</source>
         <translation>I accept Status</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Onboarding/popups/BeforeGetStartedModal.qml" line="69" />
-        <location filename="../app/AppLayouts/Onboarding/popups/BeforeGetStartedModal.qml" line="69" />
+        <location filename="../app/AppLayouts/Onboarding/popups/BeforeGetStartedModal.qml" line="71" />
+        <location filename="../app/AppLayouts/Onboarding/popups/BeforeGetStartedModal.qml" line="71" />
         <source>Terms of Use</source>
         <translation>Terms of Use</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Onboarding/popups/BeforeGetStartedModal.qml" line="97" />
-        <location filename="../app/AppLayouts/Onboarding/popups/BeforeGetStartedModal.qml" line="97" />
+        <location filename="../app/AppLayouts/Onboarding/popups/BeforeGetStartedModal.qml" line="99" />
+        <location filename="../app/AppLayouts/Onboarding/popups/BeforeGetStartedModal.qml" line="99" />
         <source>Privacy Policy</source>
         <translation>Privacy Policy</translation>
     </message>
@@ -1612,44 +1627,44 @@ All future transactions will be on mainnet or other active networks.</translatio
 <context>
     <name>BrowserLayout</name>
     <message>
-        <location filename="../app/AppLayouts/Browser/BrowserLayout.qml" line="73" />
-        <location filename="../app/AppLayouts/Browser/BrowserLayout.qml" line="73" />
+        <location filename="../app/AppLayouts/Browser/BrowserLayout.qml" line="71" />
+        <location filename="../app/AppLayouts/Browser/BrowserLayout.qml" line="71" />
         <source>Error sending the transaction</source>
         <translation>Error sending the transaction</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Browser/BrowserLayout.qml" line="79" />
-        <location filename="../app/AppLayouts/Browser/BrowserLayout.qml" line="79" />
+        <location filename="../app/AppLayouts/Browser/BrowserLayout.qml" line="77" />
+        <location filename="../app/AppLayouts/Browser/BrowserLayout.qml" line="77" />
         <source>Error signing message</source>
         <translation>Error signing message</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Browser/BrowserLayout.qml" line="201" />
-        <location filename="../app/AppLayouts/Browser/BrowserLayout.qml" line="201" />
+        <location filename="../app/AppLayouts/Browser/BrowserLayout.qml" line="197" />
+        <location filename="../app/AppLayouts/Browser/BrowserLayout.qml" line="197" />
         <source>Transaction pending...</source>
         <translation>Transaction pending...</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Browser/BrowserLayout.qml" line="202" />
-        <location filename="../app/AppLayouts/Browser/BrowserLayout.qml" line="202" />
+        <location filename="../app/AppLayouts/Browser/BrowserLayout.qml" line="198" />
+        <location filename="../app/AppLayouts/Browser/BrowserLayout.qml" line="198" />
         <source>View on etherscan</source>
         <translation>View on etherscan</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Browser/BrowserLayout.qml" line="479" />
-        <location filename="../app/AppLayouts/Browser/BrowserLayout.qml" line="479" />
+        <location filename="../app/AppLayouts/Browser/BrowserLayout.qml" line="475" />
+        <location filename="../app/AppLayouts/Browser/BrowserLayout.qml" line="475" />
         <source>Server's certificate not trusted</source>
         <translation>Server's certificate not trusted</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Browser/BrowserLayout.qml" line="480" />
-        <location filename="../app/AppLayouts/Browser/BrowserLayout.qml" line="480" />
+        <location filename="../app/AppLayouts/Browser/BrowserLayout.qml" line="476" />
+        <location filename="../app/AppLayouts/Browser/BrowserLayout.qml" line="476" />
         <source>Do you wish to continue?</source>
         <translation>Do you wish to continue?</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Browser/BrowserLayout.qml" line="481" />
-        <location filename="../app/AppLayouts/Browser/BrowserLayout.qml" line="481" />
+        <location filename="../app/AppLayouts/Browser/BrowserLayout.qml" line="477" />
+        <location filename="../app/AppLayouts/Browser/BrowserLayout.qml" line="477" />
         <source>If you wish so, you may continue with an unverified certificate. Accepting an unverified certificate means you may not be connected with the host you tried to connect to.
 Do you wish to override the security check and continue?</source>
         <translation>If you wish so, you may continue with an unverified certificate. Accepting an unverified certificate means you may not be connected with the host you tried to connect to.
@@ -1746,38 +1761,38 @@ Do you wish to override the security check and continue?</translation>
 <context>
     <name>BrowserView</name>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/BrowserView.qml" line="52" />
-        <location filename="../app/AppLayouts/Profile/views/BrowserView.qml" line="52" />
+        <location filename="../app/AppLayouts/Profile/views/BrowserView.qml" line="56" />
+        <location filename="../app/AppLayouts/Profile/views/BrowserView.qml" line="56" />
         <source>Search engine used in the address bar</source>
         <translation>Search engine used in the address bar</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/BrowserView.qml" line="59" />
-        <location filename="../app/AppLayouts/Profile/views/BrowserView.qml" line="59" />
+        <location filename="../app/AppLayouts/Profile/views/BrowserView.qml" line="63" />
+        <location filename="../app/AppLayouts/Profile/views/BrowserView.qml" line="63" />
         <source>None</source>
         <translation>None</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/BrowserView.qml" line="76" />
-        <location filename="../app/AppLayouts/Profile/views/BrowserView.qml" line="76" />
+        <location filename="../app/AppLayouts/Profile/views/BrowserView.qml" line="81" />
+        <location filename="../app/AppLayouts/Profile/views/BrowserView.qml" line="81" />
         <source>Show Favorites Bar</source>
         <translation>Show Favorites Bar</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/BrowserView.qml" line="95" />
-        <location filename="../app/AppLayouts/Profile/views/BrowserView.qml" line="95" />
+        <location filename="../app/AppLayouts/Profile/views/BrowserView.qml" line="96" />
+        <location filename="../app/AppLayouts/Profile/views/BrowserView.qml" line="96" />
         <source>Connected DApps</source>
         <translation>Connected DApps</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/BrowserView.qml" line="121" />
-        <location filename="../app/AppLayouts/Profile/views/BrowserView.qml" line="121" />
+        <location filename="../app/AppLayouts/Profile/views/BrowserView.qml" line="122" />
+        <location filename="../app/AppLayouts/Profile/views/BrowserView.qml" line="122" />
         <source>No connected dApps</source>
         <translation>No connected dApps</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/BrowserView.qml" line="131" />
-        <location filename="../app/AppLayouts/Profile/views/BrowserView.qml" line="131" />
+        <location filename="../app/AppLayouts/Profile/views/BrowserView.qml" line="132" />
+        <location filename="../app/AppLayouts/Profile/views/BrowserView.qml" line="132" />
         <source>Connecting a dApp grants it permission to view your address and balances, and to send you transaction requests</source>
         <translation>Connecting a dApp grants it permission to view your address and balances, and to send you transaction requests</translation>
     </message>
@@ -1894,24 +1909,57 @@ Do you wish to override the security check and continue?</translation>
     </message>
 </context>
 <context>
+    <name>ChartStoreBase</name>
+    <message>
+        <location filename="../imports/shared/stores/ChartStoreBase.qml" line="18" />
+        <location filename="../imports/shared/stores/ChartStoreBase.qml" line="18" />
+        <source>7D</source>
+        <translation>7D</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/stores/ChartStoreBase.qml" line="19" />
+        <location filename="../imports/shared/stores/ChartStoreBase.qml" line="19" />
+        <source>1M</source>
+        <translation>1M</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/stores/ChartStoreBase.qml" line="20" />
+        <location filename="../imports/shared/stores/ChartStoreBase.qml" line="20" />
+        <source>6M</source>
+        <translation>6M</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/stores/ChartStoreBase.qml" line="21" />
+        <location filename="../imports/shared/stores/ChartStoreBase.qml" line="21" />
+        <source>1Y</source>
+        <translation>1Y</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/stores/ChartStoreBase.qml" line="22" />
+        <location filename="../imports/shared/stores/ChartStoreBase.qml" line="22" />
+        <source>ALL</source>
+        <translation>ALL</translation>
+    </message>
+</context>
+<context>
     <name>ChatColumnView</name>
     <message>
-        <location filename="../app/AppLayouts/Chat/views/ChatColumnView.qml" line="312" />
-        <location filename="../app/AppLayouts/Chat/views/ChatColumnView.qml" line="312" />
+        <location filename="../app/AppLayouts/Chat/views/ChatColumnView.qml" line="291" />
+        <location filename="../app/AppLayouts/Chat/views/ChatColumnView.qml" line="291" />
         <source>Send</source>
         <translation>Send</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/views/ChatColumnView.qml" line="314" />
-        <location filename="../app/AppLayouts/Chat/views/ChatColumnView.qml" line="314" />
+        <location filename="../app/AppLayouts/Chat/views/ChatColumnView.qml" line="293" />
+        <location filename="../app/AppLayouts/Chat/views/ChatColumnView.qml" line="293" />
         <source>Request Address</source>
         <translation>Request Address</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/views/ChatColumnView.qml" line="344" />
-        <location filename="../app/AppLayouts/Chat/views/ChatColumnView.qml" line="346" />
-        <location filename="../app/AppLayouts/Chat/views/ChatColumnView.qml" line="344" />
-        <location filename="../app/AppLayouts/Chat/views/ChatColumnView.qml" line="346" />
+        <location filename="../app/AppLayouts/Chat/views/ChatColumnView.qml" line="323" />
+        <location filename="../app/AppLayouts/Chat/views/ChatColumnView.qml" line="325" />
+        <location filename="../app/AppLayouts/Chat/views/ChatColumnView.qml" line="323" />
+        <location filename="../app/AppLayouts/Chat/views/ChatColumnView.qml" line="325" />
         <source>Request</source>
         <translation>Request</translation>
     </message>
@@ -1984,8 +2032,8 @@ Do you wish to override the security check and continue?</translation>
         <translation>Send transaction</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/ChatCommandsPopup.qml" line="55" />
-        <location filename="../imports/shared/popups/ChatCommandsPopup.qml" line="55" />
+        <location filename="../imports/shared/popups/ChatCommandsPopup.qml" line="56" />
+        <location filename="../imports/shared/popups/ChatCommandsPopup.qml" line="56" />
         <source>Request transaction</source>
         <translation>Request transaction</translation>
     </message>
@@ -1993,20 +2041,20 @@ Do you wish to override the security check and continue?</translation>
 <context>
     <name>ChatContentView</name>
     <message>
-        <location filename="../app/AppLayouts/Chat/views/ChatContentView.qml" line="72" />
-        <location filename="../app/AppLayouts/Chat/views/ChatContentView.qml" line="72" />
+        <location filename="../app/AppLayouts/Chat/views/ChatContentView.qml" line="73" />
+        <location filename="../app/AppLayouts/Chat/views/ChatContentView.qml" line="73" />
         <source>Blocked</source>
         <translation>Blocked</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/views/ChatContentView.qml" line="195" />
-        <location filename="../app/AppLayouts/Chat/views/ChatContentView.qml" line="195" />
+        <location filename="../app/AppLayouts/Chat/views/ChatContentView.qml" line="196" />
+        <location filename="../app/AppLayouts/Chat/views/ChatContentView.qml" line="196" />
         <source>This user has been blocked.</source>
         <translation>This user has been blocked.</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/views/ChatContentView.qml" line="200" />
-        <location filename="../app/AppLayouts/Chat/views/ChatContentView.qml" line="200" />
+        <location filename="../app/AppLayouts/Chat/views/ChatContentView.qml" line="201" />
+        <location filename="../app/AppLayouts/Chat/views/ChatContentView.qml" line="201" />
         <source>You need to join this community to send messages</source>
         <translation>You need to join this community to send messages</translation>
     </message>
@@ -2155,16 +2203,17 @@ Do you wish to override the security check and continue?</translation>
         <translation>More</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/views/ChatHeaderContentView.qml" line="289" />
-        <location filename="../app/AppLayouts/Chat/views/ChatHeaderContentView.qml" line="289" />
+        <location filename="../app/AppLayouts/Chat/views/ChatHeaderContentView.qml" line="280" />
+        <location filename="../app/AppLayouts/Chat/views/ChatHeaderContentView.qml" line="280" />
         <source>Public chat</source>
         <translation>Public chat</translation>
     </message>
     <message numerus="yes">
-        <location filename="../app/AppLayouts/Chat/views/ChatHeaderContentView.qml" line="291" />
-        <location filename="../app/AppLayouts/Chat/views/ChatHeaderContentView.qml" line="291" />
+        <location filename="../app/AppLayouts/Chat/views/ChatHeaderContentView.qml" line="282" />
+        <location filename="../app/AppLayouts/Chat/views/ChatHeaderContentView.qml" line="282" />
         <source>%n member(s)</source>
         <translation type="unfinished">
+            <numerusform />
             <numerusform />
         </translation>
     </message>
@@ -2172,8 +2221,8 @@ Do you wish to override the security check and continue?</translation>
 <context>
     <name>ChatMessagesView</name>
     <message>
-        <location filename="../app/AppLayouts/Chat/views/ChatMessagesView.qml" line="339" />
-        <location filename="../app/AppLayouts/Chat/views/ChatMessagesView.qml" line="339" />
+        <location filename="../app/AppLayouts/Chat/views/ChatMessagesView.qml" line="343" />
+        <location filename="../app/AppLayouts/Chat/views/ChatMessagesView.qml" line="343" />
         <source>Failed to send message.</source>
         <translation>Failed to send message.</translation>
     </message>
@@ -2202,8 +2251,8 @@ Do you wish to override the security check and continue?</translation>
 <context>
     <name>ChatView</name>
     <message>
-        <location filename="../app/AppLayouts/Chat/views/ChatView.qml" line="117" />
-        <location filename="../app/AppLayouts/Chat/views/ChatView.qml" line="117" />
+        <location filename="../app/AppLayouts/Chat/views/ChatView.qml" line="118" />
+        <location filename="../app/AppLayouts/Chat/views/ChatView.qml" line="118" />
         <source>Members</source>
         <translation>Members</translation>
     </message>
@@ -2256,8 +2305,8 @@ Do you wish to override the security check and continue?</translation>
 <context>
     <name>CollectibleDetailView</name>
     <message>
-        <location filename="../app/AppLayouts/Wallet/views/collectibles/CollectibleDetailView.qml" line="77" />
-        <location filename="../app/AppLayouts/Wallet/views/collectibles/CollectibleDetailView.qml" line="77" />
+        <location filename="../app/AppLayouts/Wallet/views/collectibles/CollectibleDetailView.qml" line="79" />
+        <location filename="../app/AppLayouts/Wallet/views/collectibles/CollectibleDetailView.qml" line="79" />
         <source>Properties</source>
         <translation>Properties</translation>
     </message>
@@ -2353,15 +2402,6 @@ Do you wish to override the security check and continue?</translation>
     </message>
 </context>
 <context>
-    <name>CollectiblesStore</name>
-    <message>
-        <location filename="../app/AppLayouts/Wallet/stores/CollectiblesStore.qml" line="11" />
-        <location filename="../app/AppLayouts/Wallet/stores/CollectiblesStore.qml" line="11" />
-        <source>Collectibles</source>
-        <translation>Collectibles</translation>
-    </message>
-</context>
-<context>
     <name>CollectiblesView</name>
     <message>
         <location filename="../app/AppLayouts/Wallet/views/CollectiblesView.qml" line="41" />
@@ -2373,14 +2413,14 @@ Do you wish to override the security check and continue?</translation>
 <context>
     <name>CommunitiesGridView</name>
     <message>
-        <location filename="../app/AppLayouts/CommunitiesPortal/views/CommunitiesGridView.qml" line="79" />
-        <location filename="../app/AppLayouts/CommunitiesPortal/views/CommunitiesGridView.qml" line="79" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/views/CommunitiesGridView.qml" line="91" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/views/CommunitiesGridView.qml" line="91" />
         <source>Featured</source>
         <translation>Featured</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/CommunitiesPortal/views/CommunitiesGridView.qml" line="102" />
-        <location filename="../app/AppLayouts/CommunitiesPortal/views/CommunitiesGridView.qml" line="102" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/views/CommunitiesGridView.qml" line="116" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/views/CommunitiesGridView.qml" line="116" />
         <source>Popular</source>
         <translation>Popular</translation>
     </message>
@@ -2392,6 +2432,7 @@ Do you wish to override the security check and continue?</translation>
         <location filename="../app/AppLayouts/Profile/panels/CommunitiesListPanel.qml" line="33" />
         <source>%n member(s)</source>
         <translation type="unfinished">
+            <numerusform />
             <numerusform />
         </translation>
     </message>
@@ -2452,6 +2493,7 @@ Do you wish to override the security check and continue?</translation>
         <source>%n member(s)</source>
         <translation type="unfinished">
             <numerusform />
+            <numerusform />
         </translation>
     </message>
     <message>
@@ -2464,83 +2506,116 @@ Do you wish to override the security check and continue?</translation>
 <context>
     <name>CommunitiesPortalLayout</name>
     <message>
-        <location filename="../app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml" line="91" />
-        <location filename="../app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml" line="91" />
-        <source>Find community</source>
-        <translation>Find community</translation>
+        <location filename="../app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml" line="101" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml" line="101" />
+        <source>Discover Communities</source>
+        <translation>Discover Communities</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml" line="118" />
-        <location filename="../app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml" line="118" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml" line="128" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml" line="128" />
         <source>Import using key</source>
         <translation>Import using key</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml" line="128" />
-        <location filename="../app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml" line="128" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml" line="138" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml" line="138" />
         <source>Create New Community</source>
         <translation>Create New Community</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml" line="172" />
-        <location filename="../app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml" line="172" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml" line="185" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml" line="185" />
         <source>No communities found</source>
         <translation>No communities found</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml" line="206" />
-        <location filename="../app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml" line="206" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml" line="219" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml" line="219" />
         <source>Create new community</source>
         <translation>Create new community</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml" line="215" />
-        <location filename="../app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml" line="215" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml" line="228" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml" line="228" />
         <source>Create a new Status community</source>
         <translation>Create a new Status community</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml" line="216" />
-        <location filename="../app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml" line="216" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml" line="229" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml" line="229" />
         <source>Create new</source>
         <translation>Create new</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml" line="226" />
-        <location filename="../app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml" line="226" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml" line="239" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml" line="239" />
         <source>'%1' import in progress...</source>
         <translation>'%1' import in progress...</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml" line="227" />
-        <location filename="../app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml" line="227" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml" line="240" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml" line="240" />
         <source>Import existing Discord community into Status</source>
         <translation>Import existing Discord community into Status</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml" line="228" />
-        <location filename="../app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml" line="228" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml" line="241" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml" line="241" />
         <source>Import existing</source>
         <translation>Import existing</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml" line="230" />
-        <location filename="../app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml" line="230" />
-        <source>Your current import must finished or be cancelled before a new import can be started.</source>
-        <translation>Your current import must finished or be cancelled before a new import can be started.</translation>
+        <location filename="../app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml" line="243" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml" line="243" />
+        <source>Your current import must be finished or cancelled before a new import can be started.</source>
+        <translation>Your current import must be finished or cancelled before a new import can be started.</translation>
+    </message>
+</context>
+<context>
+    <name>CommunitiesStore</name>
+    <message>
+        <location filename="../app/AppLayouts/Chat/stores/CommunitiesStore.qml" line="171" />
+        <location filename="../app/AppLayouts/Chat/stores/CommunitiesStore.qml" line="171" />
+        <source>ENS username on '%1' domain</source>
+        <translation>ENS username on '%1' domain</translation>
+    </message>
+    <message>
+        <location filename="../app/AppLayouts/Chat/stores/CommunitiesStore.qml" line="173" />
+        <location filename="../app/AppLayouts/Chat/stores/CommunitiesStore.qml" line="173" />
+        <source>Any ENS username</source>
+        <translation>Any ENS username</translation>
     </message>
 </context>
 <context>
     <name>CommunitiesView</name>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/CommunitiesView.qml" line="29" />
-        <location filename="../app/AppLayouts/Profile/views/CommunitiesView.qml" line="29" />
+        <location filename="../app/AppLayouts/Profile/views/CommunitiesView.qml" line="31" />
+        <location filename="../app/AppLayouts/Profile/views/CommunitiesView.qml" line="31" />
         <source>Import community</source>
         <translation>Import community</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/CommunitiesView.qml" line="51" />
-        <location filename="../app/AppLayouts/Profile/views/CommunitiesView.qml" line="51" />
+        <location filename="../app/AppLayouts/Profile/views/CommunitiesView.qml" line="59" />
+        <location filename="../app/AppLayouts/Profile/views/CommunitiesView.qml" line="59" />
+        <source>Discover your Communities</source>
+        <translation>Discover your Communities</translation>
+    </message>
+    <message>
+        <location filename="../app/AppLayouts/Profile/views/CommunitiesView.qml" line="70" />
+        <location filename="../app/AppLayouts/Profile/views/CommunitiesView.qml" line="70" />
+        <source>Explore and see what communities are trending</source>
+        <translation>Explore and see what communities are trending</translation>
+    </message>
+    <message>
+        <location filename="../app/AppLayouts/Profile/views/CommunitiesView.qml" line="79" />
+        <location filename="../app/AppLayouts/Profile/views/CommunitiesView.qml" line="79" />
+        <source>Discover</source>
+        <translation>Discover</translation>
+    </message>
+    <message>
+        <location filename="../app/AppLayouts/Profile/views/CommunitiesView.qml" line="98" />
+        <location filename="../app/AppLayouts/Profile/views/CommunitiesView.qml" line="98" />
         <source>Communities you've joined</source>
         <translation>Communities you've joined</translation>
     </message>
@@ -2640,24 +2715,25 @@ Do you wish to override the security check and continue?</translation>
 <context>
     <name>CommunityColumnView</name>
     <message numerus="yes">
-        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="58" />
-        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="58" />
+        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="59" />
+        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="59" />
         <source>%n member(s)</source>
         <translation type="unfinished">
+            <numerusform />
             <numerusform />
         </translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="92" />
-        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="92" />
+        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="93" />
+        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="93" />
         <source>Start chat</source>
         <translation>Start chat</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="113" />
         <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="113" />
-        <source>Pending</source>
-        <translation>Pending</translation>
+        <source>Membership request pending...</source>
+        <translation>Membership request pending...</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="115" />
@@ -2672,80 +2748,80 @@ Do you wish to override the security check and continue?</translation>
         <translation>Join Community</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="153" />
-        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="153" />
+        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="161" />
+        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="161" />
         <source>Membership requests</source>
         <translation>Membership requests</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="172" />
-        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="249" />
-        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="172" />
-        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="249" />
+        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="180" />
+        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="258" />
+        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="180" />
+        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="258" />
         <source>Create channel</source>
         <translation>Create channel</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="179" />
-        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="256" />
-        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="179" />
-        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="256" />
+        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="187" />
+        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="265" />
+        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="187" />
+        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="265" />
         <source>Create category</source>
         <translation>Create category</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="190" />
-        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="265" />
-        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="190" />
-        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="265" />
+        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="198" />
+        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="274" />
+        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="198" />
+        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="274" />
         <source>Invite people</source>
         <translation>Invite people</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="291" />
-        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="291" />
+        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="301" />
+        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="301" />
         <source>Unmute category</source>
         <translation>Unmute category</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="291" />
-        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="291" />
+        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="301" />
+        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="301" />
         <source>Mute category</source>
         <translation>Mute category</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="305" />
-        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="305" />
+        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="315" />
+        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="315" />
         <source>Edit Category</source>
         <translation>Edit Category</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="324" />
-        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="324" />
+        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="334" />
+        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="334" />
         <source>Delete Category</source>
         <translation>Delete Category</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="329" />
-        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="329" />
+        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="339" />
+        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="339" />
         <source>Delete %1 category</source>
         <translation>Delete %1 category</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="330" />
-        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="330" />
+        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="340" />
+        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="340" />
         <source>Are you sure you want to delete %1 category? Channels inside the category won&#8217;t be deleted.</source>
         <translation>Are you sure you want to delete %1 category? Channels inside the category won&#8217;t be deleted.</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="505" />
-        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="505" />
+        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="515" />
+        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="515" />
         <source>Create channel or category</source>
         <translation>Create channel or category</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="577" />
-        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="577" />
+        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="587" />
+        <location filename="../app/AppLayouts/Chat/views/CommunityColumnView.qml" line="587" />
         <source>Error deleting the category</source>
         <translation>Error deleting the category</translation>
     </message>
@@ -2826,6 +2902,7 @@ Do you wish to override the security check and continue?</translation>
         <source>%n member(s)</source>
         <translation type="unfinished">
             <numerusform />
+            <numerusform />
         </translation>
     </message>
     <message>
@@ -2870,26 +2947,38 @@ Do you wish to override the security check and continue?</translation>
 <context>
     <name>CommunityIntroDialog</name>
     <message>
-        <location filename="../imports/shared/popups/CommunityIntroDialog.qml" line="21" />
-        <location filename="../imports/shared/popups/CommunityIntroDialog.qml" line="21" />
+        <location filename="../imports/shared/popups/CommunityIntroDialog.qml" line="26" />
+        <location filename="../imports/shared/popups/CommunityIntroDialog.qml" line="26" />
         <source>Welcome to %1</source>
         <translation>Welcome to %1</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/CommunityIntroDialog.qml" line="26" />
-        <location filename="../imports/shared/popups/CommunityIntroDialog.qml" line="26" />
+        <location filename="../imports/shared/popups/CommunityIntroDialog.qml" line="31" />
+        <location filename="../imports/shared/popups/CommunityIntroDialog.qml" line="31" />
+        <source>Cancel Membership Request</source>
+        <translation>Cancel Membership Request</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/popups/CommunityIntroDialog.qml" line="33" />
+        <location filename="../imports/shared/popups/CommunityIntroDialog.qml" line="33" />
+        <source>Request to join %1</source>
+        <translation>Request to join %1</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/popups/CommunityIntroDialog.qml" line="34" />
+        <location filename="../imports/shared/popups/CommunityIntroDialog.qml" line="34" />
         <source>Join %1</source>
         <translation>Join %1</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/CommunityIntroDialog.qml" line="60" />
-        <location filename="../imports/shared/popups/CommunityIntroDialog.qml" line="60" />
+        <location filename="../imports/shared/popups/CommunityIntroDialog.qml" line="76" />
+        <location filename="../imports/shared/popups/CommunityIntroDialog.qml" line="76" />
         <source>Community &lt;b&gt;%1&lt;/b&gt; has no intro message...</source>
         <translation>Community &lt;b&gt;%1&lt;/b&gt; has no intro message...</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/CommunityIntroDialog.qml" line="69" />
-        <location filename="../imports/shared/popups/CommunityIntroDialog.qml" line="69" />
+        <location filename="../imports/shared/popups/CommunityIntroDialog.qml" line="86" />
+        <location filename="../imports/shared/popups/CommunityIntroDialog.qml" line="86" />
         <source>I agree with the above</source>
         <translation>I agree with the above</translation>
     </message>
@@ -2982,6 +3071,7 @@ Do you wish to override the security check and continue?</translation>
         <source>Search %1's %n member(s)</source>
         <translation type="unfinished">
             <numerusform />
+            <numerusform />
         </translation>
     </message>
     <message>
@@ -3059,8 +3149,8 @@ Do you wish to override the security check and continue?</translation>
         <translation>Kick %1</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityMembersSettingsPanel.qml" line="239" />
-        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityMembersSettingsPanel.qml" line="239" />
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityMembersSettingsPanel.qml" line="240" />
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityMembersSettingsPanel.qml" line="240" />
         <source>Kick</source>
         <translation>Kick</translation>
     </message>
@@ -3068,32 +3158,32 @@ Do you wish to override the security check and continue?</translation>
 <context>
     <name>CommunityMembersTabPanel</name>
     <message>
-        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityMembersTabPanel.qml" line="82" />
-        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityMembersTabPanel.qml" line="82" />
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityMembersTabPanel.qml" line="84" />
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityMembersTabPanel.qml" line="84" />
         <source>Kick</source>
         <translation>Kick</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityMembersTabPanel.qml" line="90" />
-        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityMembersTabPanel.qml" line="90" />
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityMembersTabPanel.qml" line="92" />
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityMembersTabPanel.qml" line="92" />
         <source>Ban</source>
         <translation>Ban</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityMembersTabPanel.qml" line="98" />
-        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityMembersTabPanel.qml" line="98" />
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityMembersTabPanel.qml" line="100" />
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityMembersTabPanel.qml" line="100" />
         <source>Unban</source>
         <translation>Unban</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityMembersTabPanel.qml" line="105" />
-        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityMembersTabPanel.qml" line="105" />
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityMembersTabPanel.qml" line="107" />
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityMembersTabPanel.qml" line="107" />
         <source>Accept</source>
         <translation>Accept</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityMembersTabPanel.qml" line="116" />
-        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityMembersTabPanel.qml" line="116" />
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityMembersTabPanel.qml" line="118" />
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityMembersTabPanel.qml" line="118" />
         <source>Reject</source>
         <translation>Reject</translation>
     </message>
@@ -3122,86 +3212,62 @@ Do you wish to override the security check and continue?</translation>
 <context>
     <name>CommunityNewPermissionView</name>
     <message>
-        <location filename="../app/AppLayouts/Chat/views/communities/CommunityNewPermissionView.qml" line="50" />
-        <location filename="../app/AppLayouts/Chat/views/communities/CommunityNewPermissionView.qml" line="50" />
+        <location filename="../app/AppLayouts/Chat/views/communities/CommunityNewPermissionView.qml" line="43" />
+        <location filename="../app/AppLayouts/Chat/views/communities/CommunityNewPermissionView.qml" line="43" />
         <source>Anyone</source>
         <translation>Anyone</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/views/communities/CommunityNewPermissionView.qml" line="56" />
-        <location filename="../app/AppLayouts/Chat/views/communities/CommunityNewPermissionView.qml" line="56" />
+        <location filename="../app/AppLayouts/Chat/views/communities/CommunityNewPermissionView.qml" line="49" />
+        <location filename="../app/AppLayouts/Chat/views/communities/CommunityNewPermissionView.qml" line="49" />
         <source>Who holds</source>
         <translation>Who holds</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/views/communities/CommunityNewPermissionView.qml" line="57" />
-        <location filename="../app/AppLayouts/Chat/views/communities/CommunityNewPermissionView.qml" line="57" />
+        <location filename="../app/AppLayouts/Chat/views/communities/CommunityNewPermissionView.qml" line="50" />
+        <location filename="../app/AppLayouts/Chat/views/communities/CommunityNewPermissionView.qml" line="50" />
         <source>Example: 10 SNT</source>
         <translation>Example: 10 SNT</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/views/communities/CommunityNewPermissionView.qml" line="58" />
-        <location filename="../app/AppLayouts/Chat/views/communities/CommunityNewPermissionView.qml" line="58" />
-        <source>and</source>
-        <translation>and</translation>
-    </message>
-    <message>
-        <location filename="../app/AppLayouts/Chat/views/communities/CommunityNewPermissionView.qml" line="59" />
-        <location filename="../app/AppLayouts/Chat/views/communities/CommunityNewPermissionView.qml" line="59" />
-        <source>or</source>
-        <translation>or</translation>
-    </message>
-    <message>
-        <location filename="../app/AppLayouts/Chat/views/communities/CommunityNewPermissionView.qml" line="75" />
-        <location filename="../app/AppLayouts/Chat/views/communities/CommunityNewPermissionView.qml" line="75" />
-        <source>ENS username on '%1' domain</source>
-        <translation>ENS username on '%1' domain</translation>
-    </message>
-    <message>
-        <location filename="../app/AppLayouts/Chat/views/communities/CommunityNewPermissionView.qml" line="77" />
-        <location filename="../app/AppLayouts/Chat/views/communities/CommunityNewPermissionView.qml" line="77" />
-        <source>Any ENS username</source>
-        <translation>Any ENS username</translation>
-    </message>
-    <message>
-        <location filename="../app/AppLayouts/Chat/views/communities/CommunityNewPermissionView.qml" line="224" />
-        <location filename="../app/AppLayouts/Chat/views/communities/CommunityNewPermissionView.qml" line="224" />
+        <location filename="../app/AppLayouts/Chat/views/communities/CommunityNewPermissionView.qml" line="197" />
+        <location filename="../app/AppLayouts/Chat/views/communities/CommunityNewPermissionView.qml" line="197" />
         <source>Is allowed to</source>
         <translation>Is allowed to</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/views/communities/CommunityNewPermissionView.qml" line="225" />
-        <location filename="../app/AppLayouts/Chat/views/communities/CommunityNewPermissionView.qml" line="225" />
+        <location filename="../app/AppLayouts/Chat/views/communities/CommunityNewPermissionView.qml" line="198" />
+        <location filename="../app/AppLayouts/Chat/views/communities/CommunityNewPermissionView.qml" line="198" />
         <source>Example: View and post</source>
         <translation>Example: View and post</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/views/communities/CommunityNewPermissionView.qml" line="282" />
-        <location filename="../app/AppLayouts/Chat/views/communities/CommunityNewPermissionView.qml" line="282" />
+        <location filename="../app/AppLayouts/Chat/views/communities/CommunityNewPermissionView.qml" line="257" />
+        <location filename="../app/AppLayouts/Chat/views/communities/CommunityNewPermissionView.qml" line="257" />
         <source>In</source>
         <translation>In</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/views/communities/CommunityNewPermissionView.qml" line="283" />
-        <location filename="../app/AppLayouts/Chat/views/communities/CommunityNewPermissionView.qml" line="283" />
+        <location filename="../app/AppLayouts/Chat/views/communities/CommunityNewPermissionView.qml" line="258" />
+        <location filename="../app/AppLayouts/Chat/views/communities/CommunityNewPermissionView.qml" line="258" />
         <source>Example: `#general` channel</source>
         <translation>Example: `#general` channel</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/views/communities/CommunityNewPermissionView.qml" line="300" />
-        <location filename="../app/AppLayouts/Chat/views/communities/CommunityNewPermissionView.qml" line="300" />
+        <location filename="../app/AppLayouts/Chat/views/communities/CommunityNewPermissionView.qml" line="275" />
+        <location filename="../app/AppLayouts/Chat/views/communities/CommunityNewPermissionView.qml" line="275" />
         <source>Private</source>
         <translation>Private</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/views/communities/CommunityNewPermissionView.qml" line="307" />
-        <location filename="../app/AppLayouts/Chat/views/communities/CommunityNewPermissionView.qml" line="307" />
+        <location filename="../app/AppLayouts/Chat/views/communities/CommunityNewPermissionView.qml" line="282" />
+        <location filename="../app/AppLayouts/Chat/views/communities/CommunityNewPermissionView.qml" line="282" />
         <source>Make this permission private to hide it from members who don&#8217;t meet it&#8217;s requirements</source>
         <translation>Make this permission private to hide it from members who don&#8217;t meet it&#8217;s requirements</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/views/communities/CommunityNewPermissionView.qml" line="323" />
-        <location filename="../app/AppLayouts/Chat/views/communities/CommunityNewPermissionView.qml" line="323" />
+        <location filename="../app/AppLayouts/Chat/views/communities/CommunityNewPermissionView.qml" line="298" />
+        <location filename="../app/AppLayouts/Chat/views/communities/CommunityNewPermissionView.qml" line="298" />
         <source>Create permission</source>
         <translation>Create permission</translation>
     </message>
@@ -3209,22 +3275,28 @@ Do you wish to override the security check and continue?</translation>
 <context>
     <name>CommunityOptions</name>
     <message>
-        <location filename="../app/AppLayouts/Chat/controls/community/CommunityOptions.qml" line="33" />
-        <location filename="../app/AppLayouts/Chat/controls/community/CommunityOptions.qml" line="33" />
+        <location filename="../app/AppLayouts/Chat/controls/community/CommunityOptions.qml" line="34" />
+        <location filename="../app/AppLayouts/Chat/controls/community/CommunityOptions.qml" line="34" />
         <source>Community history service</source>
         <translation>Community history service</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/controls/community/CommunityOptions.qml" line="50" />
-        <location filename="../app/AppLayouts/Chat/controls/community/CommunityOptions.qml" line="50" />
+        <location filename="../app/AppLayouts/Chat/controls/community/CommunityOptions.qml" line="52" />
+        <location filename="../app/AppLayouts/Chat/controls/community/CommunityOptions.qml" line="52" />
         <source>Request to join required</source>
         <translation>Request to join required</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/controls/community/CommunityOptions.qml" line="67" />
-        <location filename="../app/AppLayouts/Chat/controls/community/CommunityOptions.qml" line="67" />
+        <location filename="../app/AppLayouts/Chat/controls/community/CommunityOptions.qml" line="69" />
+        <location filename="../app/AppLayouts/Chat/controls/community/CommunityOptions.qml" line="69" />
         <source>Any member can pin a message</source>
         <translation>Any member can pin a message</translation>
+    </message>
+    <message>
+        <location filename="../app/AppLayouts/Chat/controls/community/CommunityOptions.qml" line="87" />
+        <location filename="../app/AppLayouts/Chat/controls/community/CommunityOptions.qml" line="87" />
+        <source>Encrypted</source>
+        <translation>Encrypted</translation>
     </message>
 </context>
 <context>
@@ -3251,58 +3323,60 @@ Do you wish to override the security check and continue?</translation>
 <context>
     <name>CommunityOverviewSettingsPanel</name>
     <message>
-        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityOverviewSettingsPanel.qml" line="54" />
-        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityOverviewSettingsPanel.qml" line="54" />
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityOverviewSettingsPanel.qml" line="33" />
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityOverviewSettingsPanel.qml" line="55" />
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityOverviewSettingsPanel.qml" line="33" />
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityOverviewSettingsPanel.qml" line="55" />
         <source>Overview</source>
         <translation>Overview</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityOverviewSettingsPanel.qml" line="102" />
-        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityOverviewSettingsPanel.qml" line="171" />
-        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityOverviewSettingsPanel.qml" line="102" />
-        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityOverviewSettingsPanel.qml" line="171" />
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityOverviewSettingsPanel.qml" line="103" />
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityOverviewSettingsPanel.qml" line="172" />
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityOverviewSettingsPanel.qml" line="103" />
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityOverviewSettingsPanel.qml" line="172" />
         <source>Edit Community</source>
         <translation>Edit Community</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityOverviewSettingsPanel.qml" line="126" />
-        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityOverviewSettingsPanel.qml" line="126" />
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityOverviewSettingsPanel.qml" line="127" />
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityOverviewSettingsPanel.qml" line="127" />
         <source>This node is the Community Owner Node. For your Community to function correctly try to keep this computer with Status running and onlinie as much as possible.</source>
         <translation>This node is the Community Owner Node. For your Community to function correctly try to keep this computer with Status running and onlinie as much as possible.</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityOverviewSettingsPanel.qml" line="139" />
-        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityOverviewSettingsPanel.qml" line="139" />
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityOverviewSettingsPanel.qml" line="140" />
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityOverviewSettingsPanel.qml" line="140" />
         <source>Welcome to your community!</source>
         <translation>Welcome to your community!</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityOverviewSettingsPanel.qml" line="140" />
-        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityOverviewSettingsPanel.qml" line="140" />
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityOverviewSettingsPanel.qml" line="141" />
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityOverviewSettingsPanel.qml" line="141" />
         <source>Invite new people</source>
         <translation>Invite new people</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityOverviewSettingsPanel.qml" line="148" />
-        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityOverviewSettingsPanel.qml" line="148" />
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityOverviewSettingsPanel.qml" line="149" />
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityOverviewSettingsPanel.qml" line="149" />
         <source>Try an airdrop to reward your community for engagement!</source>
         <translation>Try an airdrop to reward your community for engagement!</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityOverviewSettingsPanel.qml" line="149" />
-        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityOverviewSettingsPanel.qml" line="149" />
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityOverviewSettingsPanel.qml" line="150" />
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityOverviewSettingsPanel.qml" line="150" />
         <source>Airdrop Tokens</source>
         <translation>Airdrop Tokens</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityOverviewSettingsPanel.qml" line="159" />
-        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityOverviewSettingsPanel.qml" line="159" />
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityOverviewSettingsPanel.qml" line="160" />
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityOverviewSettingsPanel.qml" line="160" />
         <source>Back up community key</source>
         <translation>Back up community key</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityOverviewSettingsPanel.qml" line="160" />
-        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityOverviewSettingsPanel.qml" line="160" />
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityOverviewSettingsPanel.qml" line="161" />
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityOverviewSettingsPanel.qml" line="161" />
         <source>Back up</source>
         <translation>Back up</translation>
     </message>
@@ -3310,16 +3384,26 @@ Do you wish to override the security check and continue?</translation>
 <context>
     <name>CommunityPermissionsSettingsPanel</name>
     <message>
-        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityPermissionsSettingsPanel.qml" line="27" />
-        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityPermissionsSettingsPanel.qml" line="34" />
-        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityPermissionsSettingsPanel.qml" line="27" />
-        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityPermissionsSettingsPanel.qml" line="34" />
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityPermissionsSettingsPanel.qml" line="38" />
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityPermissionsSettingsPanel.qml" line="48" />
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityPermissionsSettingsPanel.qml" line="55" />
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityPermissionsSettingsPanel.qml" line="38" />
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityPermissionsSettingsPanel.qml" line="48" />
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityPermissionsSettingsPanel.qml" line="55" />
         <source>Permissions</source>
         <translation>Permissions</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityPermissionsSettingsPanel.qml" line="33" />
-        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityPermissionsSettingsPanel.qml" line="33" />
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityPermissionsSettingsPanel.qml" line="42" />
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityPermissionsSettingsPanel.qml" line="59" />
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityPermissionsSettingsPanel.qml" line="42" />
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityPermissionsSettingsPanel.qml" line="59" />
+        <source>Add new permission</source>
+        <translation>Add new permission</translation>
+    </message>
+    <message>
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityPermissionsSettingsPanel.qml" line="47" />
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityPermissionsSettingsPanel.qml" line="47" />
         <source>New permission</source>
         <translation>New permission</translation>
     </message>
@@ -3366,26 +3450,26 @@ Do you wish to override the security check and continue?</translation>
 <context>
     <name>CommunityProfilePopupInviteFriendsPanel</name>
     <message>
-        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityProfilePopupInviteFriendsPanel.qml" line="30" />
-        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityProfilePopupInviteFriendsPanel.qml" line="30" />
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityProfilePopupInviteFriendsPanel.qml" line="31" />
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityProfilePopupInviteFriendsPanel.qml" line="31" />
         <source>Contacts</source>
         <translation>Contacts</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityProfilePopupInviteFriendsPanel.qml" line="39" />
-        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityProfilePopupInviteFriendsPanel.qml" line="39" />
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityProfilePopupInviteFriendsPanel.qml" line="40" />
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityProfilePopupInviteFriendsPanel.qml" line="40" />
         <source>Search contacts</source>
         <translation>Search contacts</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityProfilePopupInviteFriendsPanel.qml" line="87" />
-        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityProfilePopupInviteFriendsPanel.qml" line="87" />
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityProfilePopupInviteFriendsPanel.qml" line="88" />
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityProfilePopupInviteFriendsPanel.qml" line="88" />
         <source>Share community</source>
         <translation>Share community</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityProfilePopupInviteFriendsPanel.qml" line="89" />
-        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityProfilePopupInviteFriendsPanel.qml" line="89" />
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityProfilePopupInviteFriendsPanel.qml" line="90" />
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityProfilePopupInviteFriendsPanel.qml" line="90" />
         <source>Copied!</source>
         <translation>Copied!</translation>
     </message>
@@ -3393,20 +3477,20 @@ Do you wish to override the security check and continue?</translation>
 <context>
     <name>CommunityProfilePopupInviteMessagePanel</name>
     <message>
-        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityProfilePopupInviteMessagePanel.qml" line="36" />
-        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityProfilePopupInviteMessagePanel.qml" line="36" />
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityProfilePopupInviteMessagePanel.qml" line="38" />
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityProfilePopupInviteMessagePanel.qml" line="38" />
         <source>Invitation Message</source>
         <translation>Invitation Message</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityProfilePopupInviteMessagePanel.qml" line="38" />
-        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityProfilePopupInviteMessagePanel.qml" line="38" />
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityProfilePopupInviteMessagePanel.qml" line="40" />
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityProfilePopupInviteMessagePanel.qml" line="40" />
         <source>The message a contact will get with community invitation</source>
         <translation>The message a contact will get with community invitation</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityProfilePopupInviteMessagePanel.qml" line="53" />
-        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityProfilePopupInviteMessagePanel.qml" line="53" />
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityProfilePopupInviteMessagePanel.qml" line="55" />
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityProfilePopupInviteMessagePanel.qml" line="55" />
         <source>Invites will be sent to:</source>
         <translation>Invites will be sent to:</translation>
     </message>
@@ -3443,10 +3527,8 @@ Do you wish to override the security check and continue?</translation>
     <message>
         <location filename="../app/AppLayouts/Chat/views/CommunitySettingsView.qml" line="29" />
         <location filename="../app/AppLayouts/Chat/views/CommunitySettingsView.qml" line="32" />
-        <location filename="../app/AppLayouts/Chat/views/CommunitySettingsView.qml" line="184" />
         <location filename="../app/AppLayouts/Chat/views/CommunitySettingsView.qml" line="29" />
         <location filename="../app/AppLayouts/Chat/views/CommunitySettingsView.qml" line="32" />
-        <location filename="../app/AppLayouts/Chat/views/CommunitySettingsView.qml" line="184" />
         <source>Overview</source>
         <translation>Overview</translation>
     </message>
@@ -3470,23 +3552,24 @@ Do you wish to override the security check and continue?</translation>
         <source>%n member(s)</source>
         <translation type="unfinished">
             <numerusform />
+            <numerusform />
         </translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/views/CommunitySettingsView.qml" line="127" />
-        <location filename="../app/AppLayouts/Chat/views/CommunitySettingsView.qml" line="127" />
+        <location filename="../app/AppLayouts/Chat/views/CommunitySettingsView.qml" line="128" />
+        <location filename="../app/AppLayouts/Chat/views/CommunitySettingsView.qml" line="128" />
         <source>Open legacy popup (to be removed)</source>
         <translation>Open legacy popup (to be removed)</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/views/CommunitySettingsView.qml" line="142" />
-        <location filename="../app/AppLayouts/Chat/views/CommunitySettingsView.qml" line="142" />
+        <location filename="../app/AppLayouts/Chat/views/CommunitySettingsView.qml" line="143" />
+        <location filename="../app/AppLayouts/Chat/views/CommunitySettingsView.qml" line="143" />
         <source>Back to community</source>
         <translation>Back to community</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/views/CommunitySettingsView.qml" line="255" />
-        <location filename="../app/AppLayouts/Chat/views/CommunitySettingsView.qml" line="255" />
+        <location filename="../app/AppLayouts/Chat/views/CommunitySettingsView.qml" line="251" />
+        <location filename="../app/AppLayouts/Chat/views/CommunitySettingsView.qml" line="251" />
         <source>Error editing the community</source>
         <translation>Error editing the community</translation>
     </message>
@@ -3554,14 +3637,14 @@ Do you wish to override the security check and continue?</translation>
         <translation>Welcome to your community!</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityWelcomeBannerPanel.qml" line="86" />
-        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityWelcomeBannerPanel.qml" line="86" />
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityWelcomeBannerPanel.qml" line="87" />
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityWelcomeBannerPanel.qml" line="87" />
         <source>Add members</source>
         <translation>Add members</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityWelcomeBannerPanel.qml" line="98" />
-        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityWelcomeBannerPanel.qml" line="98" />
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityWelcomeBannerPanel.qml" line="100" />
+        <location filename="../app/AppLayouts/Chat/panels/communities/CommunityWelcomeBannerPanel.qml" line="100" />
         <source>Manage community</source>
         <translation>Manage community</translation>
     </message>
@@ -3597,12 +3680,6 @@ Do you wish to override the security check and continue?</translation>
         <location filename="../app/AppLayouts/Chat/views/communities/CommunityWelcomePermissionsView.qml" line="120" />
         <source>Require holding a token or NFT to obtain exclusive membership rights</source>
         <translation>Require holding a token or NFT to obtain exclusive membership rights</translation>
-    </message>
-    <message>
-        <location filename="../app/AppLayouts/Chat/views/communities/CommunityWelcomePermissionsView.qml" line="132" />
-        <location filename="../app/AppLayouts/Chat/views/communities/CommunityWelcomePermissionsView.qml" line="132" />
-        <source>Add permission</source>
-        <translation>Add permission</translation>
     </message>
 </context>
 <context>
@@ -3811,92 +3888,136 @@ Do you wish to override the security check and continue?</translation>
 <context>
     <name>Constants</name>
     <message>
-        <location filename="../imports/utils/Constants.qml" line="287" />
-        <location filename="../imports/utils/Constants.qml" line="287" />
+        <location filename="../imports/utils/Constants.qml" line="322" />
+        <location filename="../imports/utils/Constants.qml" line="322" />
+        <source>Profile successfully fetched</source>
+        <translation>Profile successfully fetched</translation>
+    </message>
+    <message>
+        <location filename="../imports/utils/Constants.qml" line="323" />
+        <location filename="../imports/utils/Constants.qml" line="323" />
+        <source>Unable to fetch your profile</source>
+        <translation>Unable to fetch your profile</translation>
+    </message>
+    <message>
+        <location filename="../imports/utils/Constants.qml" line="325" />
+        <location filename="../imports/utils/Constants.qml" line="325" />
+        <source>Sorry, we were unable to fetch your Status profile. If you are using Status on 
+another device, make sure Status is running and it is online and try again. </source>
+        <translation>Sorry, we were unable to fetch your Status profile. If you are using Status on 
+another device, make sure Status is running and it is online and try again. </translation>
+    </message>
+    <message>
+        <location filename="../imports/utils/Constants.qml" line="326" />
+        <location filename="../imports/utils/Constants.qml" line="326" />
+        <source>Securely transferring data...</source>
+        <translation>Securely transferring data...</translation>
+    </message>
+    <message>
+        <location filename="../imports/utils/Constants.qml" line="327" />
+        <location filename="../imports/utils/Constants.qml" line="327" />
+        <source>This might take a while...</source>
+        <translation>This might take a while...</translation>
+    </message>
+    <message>
+        <location filename="../imports/utils/Constants.qml" line="331" />
+        <location filename="../imports/utils/Constants.qml" line="331" />
+        <source>Try again</source>
+        <translation>Try again</translation>
+    </message>
+    <message>
+        <location filename="../imports/utils/Constants.qml" line="332" />
+        <location filename="../imports/utils/Constants.qml" line="332" />
+        <source>Create new Status profile</source>
+        <translation>Create new Status profile</translation>
+    </message>
+    <message>
+        <location filename="../imports/utils/Constants.qml" line="402" />
+        <location filename="../imports/utils/Constants.qml" line="402" />
         <source>Username must be at least 5 characters</source>
         <translation>Username must be at least 5 characters</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Constants.qml" line="291" />
-        <location filename="../imports/utils/Constants.qml" line="291" />
-        <source>Only letters, numbers, underscores and hyphens allowed</source>
-        <translation>Only letters, numbers, underscores and hyphens allowed</translation>
+        <location filename="../imports/utils/Constants.qml" line="406" />
+        <location filename="../imports/utils/Constants.qml" line="406" />
+        <source>Only letters, numbers, underscores, whitespaces and hyphens allowed</source>
+        <translation>Only letters, numbers, underscores, whitespaces and hyphens allowed</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Constants.qml" line="297" />
-        <location filename="../imports/utils/Constants.qml" line="297" />
+        <location filename="../imports/utils/Constants.qml" line="412" />
+        <location filename="../imports/utils/Constants.qml" line="412" />
         <source>24 character username limit</source>
         <translation>24 character username limit</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Constants.qml" line="302" />
-        <location filename="../imports/utils/Constants.qml" line="302" />
+        <location filename="../imports/utils/Constants.qml" line="417" />
+        <location filename="../imports/utils/Constants.qml" line="417" />
         <source>Usernames ending with '-eth' are not allowed</source>
         <translation>Usernames ending with '-eth' are not allowed</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Constants.qml" line="307" />
-        <location filename="../imports/utils/Constants.qml" line="307" />
+        <location filename="../imports/utils/Constants.qml" line="422" />
+        <location filename="../imports/utils/Constants.qml" line="422" />
         <source>Usernames ending with '_eth' are not allowed</source>
         <translation>Usernames ending with '_eth' are not allowed</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Constants.qml" line="312" />
-        <location filename="../imports/utils/Constants.qml" line="312" />
+        <location filename="../imports/utils/Constants.qml" line="427" />
+        <location filename="../imports/utils/Constants.qml" line="427" />
         <source>Usernames ending with '.eth' are not allowed</source>
         <translation>Usernames ending with '.eth' are not allowed</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Constants.qml" line="317" />
-        <location filename="../imports/utils/Constants.qml" line="317" />
+        <location filename="../imports/utils/Constants.qml" line="432" />
+        <location filename="../imports/utils/Constants.qml" line="432" />
         <source>Sorry, the name you have chosen is not allowed, try picking another username</source>
         <translation>Sorry, the name you have chosen is not allowed, try picking another username</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Constants.qml" line="577" />
-        <location filename="../imports/utils/Constants.qml" line="577" />
+        <location filename="../imports/utils/Constants.qml" line="694" />
+        <location filename="../imports/utils/Constants.qml" line="694" />
         <source>(edited)</source>
         <translation>(edited)</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Constants.qml" line="582" />
-        <location filename="../imports/utils/Constants.qml" line="582" />
+        <location filename="../imports/utils/Constants.qml" line="699" />
+        <location filename="../imports/utils/Constants.qml" line="699" />
         <source>Username already taken :(</source>
         <translation>Username already taken :(</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Constants.qml" line="583" />
-        <location filename="../imports/utils/Constants.qml" line="583" />
+        <location filename="../imports/utils/Constants.qml" line="700" />
+        <location filename="../imports/utils/Constants.qml" line="700" />
         <source>Username doesn&#8217;t belong to you :(</source>
         <translation>Username doesn&#8217;t belong to you :(</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Constants.qml" line="584" />
-        <location filename="../imports/utils/Constants.qml" line="584" />
+        <location filename="../imports/utils/Constants.qml" line="701" />
+        <location filename="../imports/utils/Constants.qml" line="701" />
         <source>Continuing will connect this username with your chat key.</source>
         <translation>Continuing will connect this username with your chat key.</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Constants.qml" line="585" />
-        <location filename="../imports/utils/Constants.qml" line="585" />
+        <location filename="../imports/utils/Constants.qml" line="702" />
+        <location filename="../imports/utils/Constants.qml" line="702" />
         <source>&#10003; Username available!</source>
         <translation>&#10003; Username available!</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Constants.qml" line="586" />
-        <location filename="../imports/utils/Constants.qml" line="586" />
+        <location filename="../imports/utils/Constants.qml" line="703" />
+        <location filename="../imports/utils/Constants.qml" line="703" />
         <source>Username is already connected with your chat key and can be used inside Status.</source>
         <translation>Username is already connected with your chat key and can be used inside Status.</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Constants.qml" line="587" />
-        <location filename="../imports/utils/Constants.qml" line="587" />
+        <location filename="../imports/utils/Constants.qml" line="704" />
+        <location filename="../imports/utils/Constants.qml" line="704" />
         <source>This user name is owned by you and connected with your chat key. Continue to set `Show my ENS username in chats`.</source>
         <translation>This user name is owned by you and connected with your chat key. Continue to set `Show my ENS username in chats`.</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Constants.qml" line="588" />
-        <location filename="../imports/utils/Constants.qml" line="588" />
+        <location filename="../imports/utils/Constants.qml" line="705" />
+        <location filename="../imports/utils/Constants.qml" line="705" />
         <source>Continuing will require a transaction to connect the username with your current chat key.</source>
         <translation>Continuing will require a transaction to connect the username with your current chat key.</translation>
     </message>
@@ -3913,14 +4034,14 @@ Do you wish to override the security check and continue?</translation>
 <context>
     <name>ContactPanel</name>
     <message>
-        <location filename="../app/AppLayouts/Profile/panels/ContactPanel.qml" line="84" />
-        <location filename="../app/AppLayouts/Profile/panels/ContactPanel.qml" line="84" />
+        <location filename="../app/AppLayouts/Profile/panels/ContactPanel.qml" line="85" />
+        <location filename="../app/AppLayouts/Profile/panels/ContactPanel.qml" line="85" />
         <source>Respond to ID Request</source>
         <translation>Respond to ID Request</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/panels/ContactPanel.qml" line="85" />
-        <location filename="../app/AppLayouts/Profile/panels/ContactPanel.qml" line="85" />
+        <location filename="../app/AppLayouts/Profile/panels/ContactPanel.qml" line="86" />
+        <location filename="../app/AppLayouts/Profile/panels/ContactPanel.qml" line="86" />
         <source>See ID Request</source>
         <translation>See ID Request</translation>
     </message>
@@ -3928,20 +4049,20 @@ Do you wish to override the security check and continue?</translation>
 <context>
     <name>ContactRequestCta</name>
     <message>
-        <location filename="../app/mainui/activitycenter/panels/ContactRequestCta.qml" line="31" />
-        <location filename="../app/mainui/activitycenter/panels/ContactRequestCta.qml" line="31" />
+        <location filename="../app/mainui/activitycenter/panels/ContactRequestCta.qml" line="33" />
+        <location filename="../app/mainui/activitycenter/panels/ContactRequestCta.qml" line="33" />
         <source>Accepted</source>
         <translation>Accepted</translation>
     </message>
     <message>
-        <location filename="../app/mainui/activitycenter/panels/ContactRequestCta.qml" line="33" />
-        <location filename="../app/mainui/activitycenter/panels/ContactRequestCta.qml" line="33" />
+        <location filename="../app/mainui/activitycenter/panels/ContactRequestCta.qml" line="35" />
+        <location filename="../app/mainui/activitycenter/panels/ContactRequestCta.qml" line="35" />
         <source>Declined &amp; Blocked</source>
         <translation>Declined &amp; Blocked</translation>
     </message>
     <message>
-        <location filename="../app/mainui/activitycenter/panels/ContactRequestCta.qml" line="33" />
-        <location filename="../app/mainui/activitycenter/panels/ContactRequestCta.qml" line="33" />
+        <location filename="../app/mainui/activitycenter/panels/ContactRequestCta.qml" line="35" />
+        <location filename="../app/mainui/activitycenter/panels/ContactRequestCta.qml" line="35" />
         <source>Declined</source>
         <translation>Declined</translation>
     </message>
@@ -4080,8 +4201,8 @@ Do you wish to override the security check and continue?</translation>
     <message>
         <location filename="../app/AppLayouts/Chat/views/ContactsColumnView.qml" line="58" />
         <location filename="../app/AppLayouts/Chat/views/ContactsColumnView.qml" line="58" />
-        <source>Chat</source>
-        <translation>Chat</translation>
+        <source>Messages</source>
+        <translation>Messages</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Chat/views/ContactsColumnView.qml" line="78" />
@@ -4108,14 +4229,14 @@ Do you wish to override the security check and continue?</translation>
         <translation>Contact requests</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/views/ContactsColumnView.qml" line="346" />
-        <location filename="../app/AppLayouts/Chat/views/ContactsColumnView.qml" line="346" />
+        <location filename="../app/AppLayouts/Chat/views/ContactsColumnView.qml" line="329" />
+        <location filename="../app/AppLayouts/Chat/views/ContactsColumnView.qml" line="329" />
         <source>Community imported</source>
         <translation>Community imported</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/views/ContactsColumnView.qml" line="350" />
-        <location filename="../app/AppLayouts/Chat/views/ContactsColumnView.qml" line="350" />
+        <location filename="../app/AppLayouts/Chat/views/ContactsColumnView.qml" line="333" />
+        <location filename="../app/AppLayouts/Chat/views/ContactsColumnView.qml" line="333" />
         <source>Importing community is in progress</source>
         <translation>Importing community is in progress</translation>
     </message>
@@ -4129,16 +4250,14 @@ Do you wish to override the security check and continue?</translation>
         <translation>Enter a valid chat key or ENS username</translation>
     </message>
     <message>
-        <location filename="../imports/shared/controls/ContactsListAndSearch.qml" line="54" />
-        <location filename="../imports/shared/controls/ContactsListAndSearch.qml" line="129" />
-        <location filename="../imports/shared/controls/ContactsListAndSearch.qml" line="54" />
-        <location filename="../imports/shared/controls/ContactsListAndSearch.qml" line="129" />
+        <location filename="../imports/shared/controls/ContactsListAndSearch.qml" line="40" />
+        <location filename="../imports/shared/controls/ContactsListAndSearch.qml" line="40" />
         <source>Can't chat with yourself</source>
         <translation>Can't chat with yourself</translation>
     </message>
     <message>
-        <location filename="../imports/shared/controls/ContactsListAndSearch.qml" line="77" />
-        <location filename="../imports/shared/controls/ContactsListAndSearch.qml" line="77" />
+        <location filename="../imports/shared/controls/ContactsListAndSearch.qml" line="78" />
+        <location filename="../imports/shared/controls/ContactsListAndSearch.qml" line="78" />
         <source>Enter ENS username or chat key</source>
         <translation>Enter ENS username or chat key</translation>
     </message>
@@ -4146,14 +4265,14 @@ Do you wish to override the security check and continue?</translation>
 <context>
     <name>ContactsListPanel</name>
     <message>
-        <location filename="../app/AppLayouts/Profile/panels/ContactsListPanel.qml" line="133" />
-        <location filename="../app/AppLayouts/Profile/panels/ContactsListPanel.qml" line="133" />
+        <location filename="../app/AppLayouts/Profile/panels/ContactsListPanel.qml" line="135" />
+        <location filename="../app/AppLayouts/Profile/panels/ContactsListPanel.qml" line="135" />
         <source>Contact Request Sent</source>
         <translation>Contact Request Sent</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/panels/ContactsListPanel.qml" line="136" />
-        <location filename="../app/AppLayouts/Profile/panels/ContactsListPanel.qml" line="136" />
+        <location filename="../app/AppLayouts/Profile/panels/ContactsListPanel.qml" line="138" />
+        <location filename="../app/AppLayouts/Profile/panels/ContactsListPanel.qml" line="138" />
         <source>Contact Request Rejected</source>
         <translation>Contact Request Rejected</translation>
     </message>
@@ -4167,16 +4286,16 @@ Do you wish to override the security check and continue?</translation>
         <translation>Send contact request to chat key</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/ContactsView.qml" line="68" />
-        <location filename="../app/AppLayouts/Profile/views/ContactsView.qml" line="68" />
+        <location filename="../app/AppLayouts/Profile/views/ContactsView.qml" line="67" />
+        <location filename="../app/AppLayouts/Profile/views/ContactsView.qml" line="67" />
         <source>Search by a display name or chat key</source>
         <translation>Search by a display name or chat key</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/ContactsView.qml" line="82" />
-        <location filename="../app/AppLayouts/Profile/views/ContactsView.qml" line="147" />
-        <location filename="../app/AppLayouts/Profile/views/ContactsView.qml" line="82" />
-        <location filename="../app/AppLayouts/Profile/views/ContactsView.qml" line="147" />
+        <location filename="../app/AppLayouts/Profile/views/ContactsView.qml" line="81" />
+        <location filename="../app/AppLayouts/Profile/views/ContactsView.qml" line="148" />
+        <location filename="../app/AppLayouts/Profile/views/ContactsView.qml" line="81" />
+        <location filename="../app/AppLayouts/Profile/views/ContactsView.qml" line="148" />
         <source>Contacts</source>
         <translation>Contacts</translation>
     </message>
@@ -4193,26 +4312,26 @@ Do you wish to override the security check and continue?</translation>
         <translation>Blocked</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/ContactsView.qml" line="129" />
-        <location filename="../app/AppLayouts/Profile/views/ContactsView.qml" line="129" />
+        <location filename="../app/AppLayouts/Profile/views/ContactsView.qml" line="130" />
+        <location filename="../app/AppLayouts/Profile/views/ContactsView.qml" line="130" />
         <source>Identity Verified Contacts</source>
         <translation>Identity Verified Contacts</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/ContactsView.qml" line="168" />
-        <location filename="../app/AppLayouts/Profile/views/ContactsView.qml" line="168" />
+        <location filename="../app/AppLayouts/Profile/views/ContactsView.qml" line="169" />
+        <location filename="../app/AppLayouts/Profile/views/ContactsView.qml" line="169" />
         <source>You don&#8217;t have any contacts yet</source>
         <translation>You don&#8217;t have any contacts yet</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/ContactsView.qml" line="188" />
-        <location filename="../app/AppLayouts/Profile/views/ContactsView.qml" line="188" />
+        <location filename="../app/AppLayouts/Profile/views/ContactsView.qml" line="189" />
+        <location filename="../app/AppLayouts/Profile/views/ContactsView.qml" line="189" />
         <source>Received</source>
         <translation>Received</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/ContactsView.qml" line="217" />
-        <location filename="../app/AppLayouts/Profile/views/ContactsView.qml" line="217" />
+        <location filename="../app/AppLayouts/Profile/views/ContactsView.qml" line="220" />
+        <location filename="../app/AppLayouts/Profile/views/ContactsView.qml" line="220" />
         <source>Sent</source>
         <translation>Sent</translation>
     </message>
@@ -4385,14 +4504,14 @@ Do you wish to override the security check and continue?</translation>
         <translation>Edit #%1</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/popups/community/CreateChannelPopup.qml" line="106" />
-        <location filename="../app/AppLayouts/Chat/popups/community/CreateChannelPopup.qml" line="106" />
+        <location filename="../app/AppLayouts/Chat/popups/community/CreateChannelPopup.qml" line="105" />
+        <location filename="../app/AppLayouts/Chat/popups/community/CreateChannelPopup.qml" line="105" />
         <source>Channel name</source>
         <translation>Channel name</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/popups/community/CreateChannelPopup.qml" line="108" />
-        <location filename="../app/AppLayouts/Chat/popups/community/CreateChannelPopup.qml" line="108" />
+        <location filename="../app/AppLayouts/Chat/popups/community/CreateChannelPopup.qml" line="107" />
+        <location filename="../app/AppLayouts/Chat/popups/community/CreateChannelPopup.qml" line="107" />
         <source># Name the channel</source>
         <translation># Name the channel</translation>
     </message>
@@ -4473,17 +4592,17 @@ Do you wish to override the security check and continue?</translation>
     </message>
     <message>
         <location filename="../StatusQ/sandbox/demoapp/CreateChatView.qml" line="33" />
-        <location filename="../app/AppLayouts/Chat/views/CreateChatView.qml" line="108" />
+        <location filename="../app/AppLayouts/Chat/views/CreateChatView.qml" line="128" />
         <location filename="../StatusQ/sandbox/demoapp/CreateChatView.qml" line="33" />
-        <location filename="../app/AppLayouts/Chat/views/CreateChatView.qml" line="108" />
+        <location filename="../app/AppLayouts/Chat/views/CreateChatView.qml" line="128" />
         <source>Contacts</source>
         <translation>Contacts</translation>
     </message>
     <message>
         <location filename="../StatusQ/sandbox/demoapp/CreateChatView.qml" line="111" />
-        <location filename="../app/AppLayouts/Chat/views/CreateChatView.qml" line="170" />
+        <location filename="../app/AppLayouts/Chat/views/CreateChatView.qml" line="185" />
         <location filename="../StatusQ/sandbox/demoapp/CreateChatView.qml" line="111" />
-        <location filename="../app/AppLayouts/Chat/views/CreateChatView.qml" line="170" />
+        <location filename="../app/AppLayouts/Chat/views/CreateChatView.qml" line="185" />
         <source>You can only send direct messages to your Contacts.
 
 Send a contact request to the person you would like to chat with, you will be able to chat with them once they have accepted your contact request.</source>
@@ -4531,98 +4650,98 @@ Send a contact request to the person you would like to chat with, you will be ab
         <translation>Clear all</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml" line="101" />
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml" line="101" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml" line="98" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml" line="98" />
         <source>Proceed with (%1/%2) files</source>
         <translation>Proceed with (%1/%2) files</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml" line="102" />
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml" line="102" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml" line="99" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml" line="99" />
         <source>Validate (%1/%2) files</source>
         <translation>Validate (%1/%2) files</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml" line="103" />
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml" line="103" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml" line="100" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml" line="100" />
         <source>Import files</source>
         <translation>Import files</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml" line="116" />
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml" line="116" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml" line="113" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml" line="113" />
         <source>Select Discord JSON files to import</source>
         <translation>Select Discord JSON files to import</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml" line="117" />
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml" line="117" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml" line="114" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml" line="114" />
         <source>Some of your community files cannot be used</source>
         <translation>Some of your community files cannot be used</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml" line="118" />
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml" line="118" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml" line="115" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml" line="115" />
         <source>Uncheck any files you would like to exclude from the import</source>
         <translation>Uncheck any files you would like to exclude from the import</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml" line="124" />
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml" line="124" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml" line="121" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml" line="121" />
         <source>(JSON file format only)</source>
         <translation>(JSON file format only)</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml" line="141" />
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml" line="141" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml" line="138" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml" line="138" />
         <source>Browse files</source>
         <translation>Browse files</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml" line="169" />
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml" line="169" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml" line="165" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml" line="165" />
         <source>Export your Discord JSON data using %1</source>
         <translation>Export your Discord JSON data using %1</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml" line="185" />
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml" line="185" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml" line="180" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml" line="180" />
         <source>Refer to this &lt;a href='https://github.com/Tyrrrz/DiscordChatExporter/wiki'&gt;wiki&lt;/a&gt; if you have any queries</source>
         <translation>Refer to this &lt;a href='https://github.com/Tyrrrz/DiscordChatExporter/wiki'&gt;wiki&lt;/a&gt; if you have any queries</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml" line="233" />
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml" line="233" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml" line="245" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml" line="245" />
         <source>Choose files to import</source>
         <translation>Choose files to import</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml" line="235" />
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml" line="235" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml" line="247" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml" line="247" />
         <source>JSON files (%1)</source>
         <translation>JSON files (%1)</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml" line="289" />
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml" line="289" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml" line="301" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml" line="301" />
         <source>Please select the categories and channels you would like to import</source>
         <translation>Please select the categories and channels you would like to import</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml" line="297" />
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml" line="297" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml" line="309" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml" line="309" />
         <source>Import all history</source>
         <translation>Import all history</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml" line="302" />
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml" line="302" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml" line="314" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml" line="314" />
         <source>Start date</source>
         <translation>Start date</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml" line="525" />
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml" line="525" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml" line="535" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml" line="535" />
         <source>Error creating the community</source>
         <translation>Error creating the community</translation>
     </message>
@@ -4725,66 +4844,46 @@ Send a contact request to the person you would like to chat with, you will be ab
 <context>
     <name>CurrenciesStore</name>
     <message>
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="20" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="20" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="20" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="20" />
         <source>US Dollars</source>
         <translation>US Dollars</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="30" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="30" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="30" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="30" />
         <source>British Pound</source>
         <translation>British Pound</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="40" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="40" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="40" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="40" />
         <source>Euros</source>
         <translation>Euros</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="50" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="50" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="50" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="50" />
         <source>Russian ruble</source>
         <translation>Russian ruble</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="60" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="60" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="60" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="60" />
         <source>South Korean won</source>
         <translation>South Korean won</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="70" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="70" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="70" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="70" />
         <source>Ethereum</source>
         <translation>Ethereum</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="72" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="82" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="92" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="102" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="72" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="82" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="92" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="102" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="72" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="82" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="92" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="102" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="72" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="82" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="92" />
@@ -4793,112 +4892,30 @@ Send a contact request to the person you would like to chat with, you will be ab
         <translation>Tokens</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="80" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="80" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="80" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="80" />
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="90" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="90" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="90" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="90" />
         <source>Status Network Token</source>
         <translation>Status Network Token</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="100" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="100" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="100" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="100" />
         <source>Dai</source>
         <translation>Dai</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="110" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="110" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="110" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="110" />
         <source>United Arab Emirates dirham</source>
         <translation>United Arab Emirates dirham</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="112" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="122" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="132" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="142" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="152" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="162" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="172" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="182" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="192" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="202" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="212" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="222" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="232" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="242" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="252" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="262" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="272" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="282" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="292" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="302" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="312" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="322" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="332" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="342" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="352" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="362" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="372" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="382" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="392" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="402" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="412" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="422" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="432" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="442" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="452" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="462" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="472" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="482" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="492" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="502" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="512" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="522" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="532" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="542" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="552" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="562" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="572" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="582" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="592" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="602" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="612" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="622" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="632" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="642" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="652" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="662" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="672" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="682" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="692" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="702" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="712" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="722" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="732" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="742" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="752" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="762" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="772" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="782" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="792" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="802" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="812" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="822" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="832" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="842" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="112" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="122" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="132" />
@@ -4973,80 +4990,6 @@ Send a contact request to the person you would like to chat with, you will be ab
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="822" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="832" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="842" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="112" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="122" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="132" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="142" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="152" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="162" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="172" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="182" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="192" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="202" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="212" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="222" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="232" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="242" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="252" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="262" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="272" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="282" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="292" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="302" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="312" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="322" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="332" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="342" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="352" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="362" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="372" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="382" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="392" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="402" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="412" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="422" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="432" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="442" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="452" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="462" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="472" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="482" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="492" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="502" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="512" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="522" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="532" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="542" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="552" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="562" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="572" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="582" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="592" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="602" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="612" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="622" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="632" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="642" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="652" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="662" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="672" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="682" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="692" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="702" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="712" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="722" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="732" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="742" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="752" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="762" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="772" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="782" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="792" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="802" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="812" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="822" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="832" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="842" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="112" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="122" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="132" />
@@ -5125,585 +5068,439 @@ Send a contact request to the person you would like to chat with, you will be ab
         <translation>Other Fiat</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="120" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="120" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="120" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="120" />
         <source>Afghan afghani</source>
         <translation>Afghan afghani</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="130" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="130" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="130" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="130" />
         <source>Argentine peso</source>
         <translation>Argentine peso</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="140" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="140" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="140" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="140" />
         <source>Australian dollar</source>
         <translation>Australian dollar</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="150" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="150" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="150" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="150" />
         <source>Barbadian dollar</source>
         <translation>Barbadian dollar</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="160" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="160" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="160" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="160" />
         <source>Bangladeshi taka</source>
         <translation>Bangladeshi taka</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="170" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="170" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="170" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="170" />
         <source>Bulgarian lev</source>
         <translation>Bulgarian lev</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="180" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="180" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="180" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="180" />
         <source>Bahraini dinar</source>
         <translation>Bahraini dinar</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="190" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="190" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="190" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="190" />
         <source>Brunei dollar</source>
         <translation>Brunei dollar</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="200" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="200" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="200" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="200" />
         <source>Bolivian boliviano</source>
         <translation>Bolivian boliviano</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="210" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="210" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="210" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="210" />
         <source>Brazillian real</source>
         <translation>Brazillian real</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="220" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="220" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="220" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="220" />
         <source>Bhutanese ngultrum</source>
         <translation>Bhutanese ngultrum</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="230" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="230" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="230" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="230" />
         <source>Canadian dollar</source>
         <translation>Canadian dollar</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="240" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="240" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="240" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="240" />
         <source>Swiss franc</source>
         <translation>Swiss franc</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="250" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="250" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="250" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="250" />
         <source>Chilean peso</source>
         <translation>Chilean peso</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="260" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="260" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="260" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="260" />
         <source>Chinese yuan</source>
         <translation>Chinese yuan</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="270" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="270" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="270" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="270" />
         <source>Colombian peso</source>
         <translation>Colombian peso</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="280" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="280" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="280" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="280" />
         <source>Costa Rican col&#243;n</source>
         <translation>Costa Rican col&#243;n</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="290" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="290" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="290" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="290" />
         <source>Czech koruna</source>
         <translation>Czech koruna</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="300" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="300" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="300" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="300" />
         <source>Danish krone</source>
         <translation>Danish krone</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="310" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="310" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="310" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="310" />
         <source>Dominican peso</source>
         <translation>Dominican peso</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="320" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="320" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="320" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="320" />
         <source>Egyptian pound</source>
         <translation>Egyptian pound</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="330" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="330" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="330" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="330" />
         <source>Ethiopian birr</source>
         <translation>Ethiopian birr</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="340" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="340" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="340" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="340" />
         <source>Georgian lari</source>
         <translation>Georgian lari</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="350" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="350" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="350" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="350" />
         <source>Ghanaian cedi</source>
         <translation>Ghanaian cedi</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="360" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="360" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="360" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="360" />
         <source>Hong Kong dollar</source>
         <translation>Hong Kong dollar</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="370" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="370" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="370" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="370" />
         <source>Croatian kuna</source>
         <translation>Croatian kuna</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="380" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="380" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="380" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="380" />
         <source>Hungarian forint</source>
         <translation>Hungarian forint</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="390" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="390" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="390" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="390" />
         <source>Indonesian rupiah</source>
         <translation>Indonesian rupiah</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="400" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="400" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="400" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="400" />
         <source>Israeli new shekel</source>
         <translation>Israeli new shekel</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="410" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="410" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="410" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="410" />
         <source>Indian rupee</source>
         <translation>Indian rupee</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="420" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="420" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="420" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="420" />
         <source>Icelandic kr&#243;na</source>
         <translation>Icelandic kr&#243;na</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="430" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="430" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="430" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="430" />
         <source>Jamaican dollar</source>
         <translation>Jamaican dollar</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="440" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="440" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="440" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="440" />
         <source>Japanese yen</source>
         <translation>Japanese yen</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="450" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="450" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="450" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="450" />
         <source>Kenyan shilling</source>
         <translation>Kenyan shilling</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="460" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="460" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="460" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="460" />
         <source>Kuwaiti dinar</source>
         <translation>Kuwaiti dinar</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="470" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="470" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="470" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="470" />
         <source>Kazakhstani tenge</source>
         <translation>Kazakhstani tenge</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="480" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="480" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="480" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="480" />
         <source>Sri Lankan rupee</source>
         <translation>Sri Lankan rupee</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="490" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="490" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="490" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="490" />
         <source>Moroccan dirham</source>
         <translation>Moroccan dirham</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="500" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="500" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="500" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="500" />
         <source>Moldovan leu</source>
         <translation>Moldovan leu</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="510" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="510" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="510" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="510" />
         <source>Mauritian rupee</source>
         <translation>Mauritian rupee</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="520" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="520" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="520" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="520" />
         <source>Malawian kwacha</source>
         <translation>Malawian kwacha</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="530" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="530" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="530" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="530" />
         <source>Mexican peso</source>
         <translation>Mexican peso</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="540" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="540" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="540" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="540" />
         <source>Malaysian ringgit</source>
         <translation>Malaysian ringgit</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="550" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="550" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="550" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="550" />
         <source>Mozambican metical</source>
         <translation>Mozambican metical</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="560" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="560" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="560" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="560" />
         <source>Namibian dollar</source>
         <translation>Namibian dollar</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="570" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="570" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="570" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="570" />
         <source>Nigerian naira</source>
         <translation>Nigerian naira</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="580" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="580" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="580" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="580" />
         <source>Norwegian krone</source>
         <translation>Norwegian krone</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="590" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="590" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="590" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="590" />
         <source>Nepalese rupee</source>
         <translation>Nepalese rupee</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="600" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="600" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="600" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="600" />
         <source>New Zealand dollar</source>
         <translation>New Zealand dollar</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="610" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="610" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="610" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="610" />
         <source>Omani rial</source>
         <translation>Omani rial</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="620" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="620" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="620" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="620" />
         <source>Peruvian sol</source>
         <translation>Peruvian sol</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="630" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="630" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="630" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="630" />
         <source>Papua New Guinean kina</source>
         <translation>Papua New Guinean kina</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="640" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="640" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="640" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="640" />
         <source>Philippine peso</source>
         <translation>Philippine peso</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="650" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="650" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="650" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="650" />
         <source>Pakistani rupee</source>
         <translation>Pakistani rupee</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="660" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="660" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="660" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="660" />
         <source>Polish z&#322;oty</source>
         <translation>Polish z&#322;oty</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="670" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="670" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="670" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="670" />
         <source>Paraguayan guaran&#237;</source>
         <translation>Paraguayan guaran&#237;</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="680" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="680" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="680" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="680" />
         <source>Qatari riyal</source>
         <translation>Qatari riyal</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="690" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="690" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="690" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="690" />
         <source>Romanian leu</source>
         <translation>Romanian leu</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="700" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="700" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="700" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="700" />
         <source>Serbian dinar</source>
         <translation>Serbian dinar</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="710" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="710" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="710" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="710" />
         <source>Saudi riyal</source>
         <translation>Saudi riyal</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="720" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="720" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="720" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="720" />
         <source>Swedish krona</source>
         <translation>Swedish krona</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="730" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="730" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="730" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="730" />
         <source>Singapore dollar</source>
         <translation>Singapore dollar</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="740" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="740" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="740" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="740" />
         <source>Thai baht</source>
         <translation>Thai baht</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="750" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="750" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="750" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="750" />
         <source>Trinidad and Tobago dollar</source>
         <translation>Trinidad and Tobago dollar</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="760" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="760" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="760" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="760" />
         <source>New Taiwan dollar</source>
         <translation>New Taiwan dollar</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="770" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="770" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="770" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="770" />
         <source>Tanzanian shilling</source>
         <translation>Tanzanian shilling</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="780" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="780" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="780" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="780" />
         <source>Turkish lira</source>
         <translation>Turkish lira</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="790" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="790" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="790" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="790" />
         <source>Ukrainian hryvnia</source>
         <translation>Ukrainian hryvnia</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="800" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="800" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="800" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="800" />
         <source>Ugandan shilling</source>
         <translation>Ugandan shilling</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="810" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="810" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="810" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="810" />
         <source>Uruguayan peso</source>
         <translation>Uruguayan peso</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="820" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="820" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="820" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="820" />
         <source>Venezuelan bol&#237;var</source>
         <translation>Venezuelan bol&#237;var</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="830" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="830" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="830" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="830" />
         <source>Vietnamese &#273;&#7891;ng</source>
         <translation>Vietnamese &#273;&#7891;ng</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="840" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="840" />
-        <location filename="../app/AppLayouts/Wallet/stores/CurrenciesStore.qml" line="840" />
         <location filename="../imports/shared/stores/CurrenciesStore.qml" line="840" />
         <source>South African rand</source>
         <translation>South African rand</translation>
@@ -5757,41 +5554,41 @@ Send a contact request to the person you would like to chat with, you will be ab
 <context>
     <name>DefaultDAppExplorerView</name>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/browser/DefaultDAppExplorerView.qml" line="16" />
-        <location filename="../app/AppLayouts/Profile/views/browser/DefaultDAppExplorerView.qml" line="16" />
+        <location filename="../app/AppLayouts/Profile/views/browser/DefaultDAppExplorerView.qml" line="18" />
+        <location filename="../app/AppLayouts/Profile/views/browser/DefaultDAppExplorerView.qml" line="18" />
         <source>Default DApp explorer</source>
         <translation>Default DApp explorer</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/browser/DefaultDAppExplorerView.qml" line="37" />
-        <location filename="../app/AppLayouts/Profile/views/browser/DefaultDAppExplorerView.qml" line="37" />
-        <source>none</source>
-        <translation>none</translation>
+        <location filename="../app/AppLayouts/Profile/views/browser/DefaultDAppExplorerView.qml" line="39" />
+        <location filename="../app/AppLayouts/Profile/views/browser/DefaultDAppExplorerView.qml" line="39" />
+        <source>None</source>
+        <translation>None</translation>
     </message>
 </context>
 <context>
     <name>DemoApp</name>
     <message>
-        <location filename="../StatusQ/sandbox/DemoApp.qml" line="158" />
-        <location filename="../StatusQ/sandbox/DemoApp.qml" line="158" />
+        <location filename="../StatusQ/sandbox/DemoApp.qml" line="122" />
+        <location filename="../StatusQ/sandbox/DemoApp.qml" line="122" />
         <source>Invite People</source>
         <translation>Invite People</translation>
     </message>
     <message>
-        <location filename="../StatusQ/sandbox/DemoApp.qml" line="163" />
-        <location filename="../StatusQ/sandbox/DemoApp.qml" line="163" />
+        <location filename="../StatusQ/sandbox/DemoApp.qml" line="127" />
+        <location filename="../StatusQ/sandbox/DemoApp.qml" line="127" />
         <source>View Community</source>
         <translation>View Community</translation>
     </message>
     <message>
-        <location filename="../StatusQ/sandbox/DemoApp.qml" line="168" />
-        <location filename="../StatusQ/sandbox/DemoApp.qml" line="168" />
+        <location filename="../StatusQ/sandbox/DemoApp.qml" line="132" />
+        <location filename="../StatusQ/sandbox/DemoApp.qml" line="132" />
         <source>Edit Community</source>
         <translation>Edit Community</translation>
     </message>
     <message>
-        <location filename="../StatusQ/sandbox/DemoApp.qml" line="176" />
-        <location filename="../StatusQ/sandbox/DemoApp.qml" line="176" />
+        <location filename="../StatusQ/sandbox/DemoApp.qml" line="140" />
+        <location filename="../StatusQ/sandbox/DemoApp.qml" line="140" />
         <source>Leave Community</source>
         <translation>Leave Community</translation>
     </message>
@@ -5814,48 +5611,60 @@ Send a contact request to the person you would like to chat with, you will be ab
 <context>
     <name>DerivedAddressesPanel</name>
     <message>
-        <location filename="../app/AppLayouts/Wallet/panels/DerivedAddressesPanel.qml" line="26" />
-        <location filename="../app/AppLayouts/Wallet/panels/DerivedAddressesPanel.qml" line="26" />
+        <location filename="../app/AppLayouts/Wallet/panels/DerivedAddressesPanel.qml" line="35" />
+        <location filename="../app/AppLayouts/Wallet/panels/DerivedAddressesPanel.qml" line="35" />
         <source>No activity</source>
         <translation>No activity</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/panels/DerivedAddressesPanel.qml" line="31" />
-        <location filename="../app/AppLayouts/Wallet/panels/DerivedAddressesPanel.qml" line="31" />
+        <location filename="../app/AppLayouts/Wallet/panels/DerivedAddressesPanel.qml" line="40" />
+        <location filename="../app/AppLayouts/Wallet/panels/DerivedAddressesPanel.qml" line="40" />
         <source>Pending</source>
         <translation>Pending</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/panels/DerivedAddressesPanel.qml" line="38" />
-        <location filename="../app/AppLayouts/Wallet/panels/DerivedAddressesPanel.qml" line="38" />
+        <location filename="../app/AppLayouts/Wallet/panels/DerivedAddressesPanel.qml" line="47" />
+        <location filename="../app/AppLayouts/Wallet/panels/DerivedAddressesPanel.qml" line="47" />
         <source>Invalid path</source>
         <translation>Invalid path</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/panels/DerivedAddressesPanel.qml" line="56" />
-        <location filename="../app/AppLayouts/Wallet/panels/DerivedAddressesPanel.qml" line="97" />
-        <location filename="../app/AppLayouts/Wallet/panels/DerivedAddressesPanel.qml" line="160" />
-        <location filename="../app/AppLayouts/Wallet/panels/DerivedAddressesPanel.qml" line="56" />
-        <location filename="../app/AppLayouts/Wallet/panels/DerivedAddressesPanel.qml" line="97" />
-        <location filename="../app/AppLayouts/Wallet/panels/DerivedAddressesPanel.qml" line="160" />
+        <location filename="../app/AppLayouts/Wallet/panels/DerivedAddressesPanel.qml" line="69" />
+        <location filename="../app/AppLayouts/Wallet/panels/DerivedAddressesPanel.qml" line="118" />
+        <location filename="../app/AppLayouts/Wallet/panels/DerivedAddressesPanel.qml" line="192" />
+        <location filename="../app/AppLayouts/Wallet/panels/DerivedAddressesPanel.qml" line="69" />
+        <location filename="../app/AppLayouts/Wallet/panels/DerivedAddressesPanel.qml" line="118" />
+        <location filename="../app/AppLayouts/Wallet/panels/DerivedAddressesPanel.qml" line="192" />
         <source>Has Activity</source>
         <translation>Has Activity</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/panels/DerivedAddressesPanel.qml" line="56" />
-        <location filename="../app/AppLayouts/Wallet/panels/DerivedAddressesPanel.qml" line="97" />
-        <location filename="../app/AppLayouts/Wallet/panels/DerivedAddressesPanel.qml" line="160" />
-        <location filename="../app/AppLayouts/Wallet/panels/DerivedAddressesPanel.qml" line="56" />
-        <location filename="../app/AppLayouts/Wallet/panels/DerivedAddressesPanel.qml" line="97" />
-        <location filename="../app/AppLayouts/Wallet/panels/DerivedAddressesPanel.qml" line="160" />
+        <location filename="../app/AppLayouts/Wallet/panels/DerivedAddressesPanel.qml" line="69" />
+        <location filename="../app/AppLayouts/Wallet/panels/DerivedAddressesPanel.qml" line="118" />
+        <location filename="../app/AppLayouts/Wallet/panels/DerivedAddressesPanel.qml" line="192" />
+        <location filename="../app/AppLayouts/Wallet/panels/DerivedAddressesPanel.qml" line="69" />
+        <location filename="../app/AppLayouts/Wallet/panels/DerivedAddressesPanel.qml" line="118" />
+        <location filename="../app/AppLayouts/Wallet/panels/DerivedAddressesPanel.qml" line="192" />
         <source>No Activity</source>
         <translation>No Activity</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/panels/DerivedAddressesPanel.qml" line="84" />
-        <location filename="../app/AppLayouts/Wallet/panels/DerivedAddressesPanel.qml" line="84" />
+        <location filename="../app/AppLayouts/Wallet/panels/DerivedAddressesPanel.qml" line="104" />
+        <location filename="../app/AppLayouts/Wallet/panels/DerivedAddressesPanel.qml" line="104" />
         <source>Account</source>
         <translation>Account</translation>
+    </message>
+    <message>
+        <location filename="../app/AppLayouts/Wallet/panels/DerivedAddressesPanel.qml" line="145" />
+        <location filename="../app/AppLayouts/Wallet/panels/DerivedAddressesPanel.qml" line="145" />
+        <source>Enter PIN</source>
+        <translation>Enter PIN</translation>
+    </message>
+    <message>
+        <location filename="../app/AppLayouts/Wallet/panels/DerivedAddressesPanel.qml" line="146" />
+        <location filename="../app/AppLayouts/Wallet/panels/DerivedAddressesPanel.qml" line="146" />
+        <source>Enter password</source>
+        <translation>Enter password</translation>
     </message>
 </context>
 <context>
@@ -5969,178 +5778,182 @@ Send a contact request to the person you would like to chat with, you will be ab
 <context>
     <name>DiscordImportProgressContents</name>
     <message>
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="43" />
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="43" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="42" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="42" />
         <source>Delete community &amp; restart import</source>
         <translation>Delete community &amp; restart import</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="53" />
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="53" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="51" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="51" />
         <source>Cancel import</source>
         <translation>Cancel import</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="62" />
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="62" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="59" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="59" />
         <source>Restart import</source>
         <translation>Restart import</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="72" />
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="72" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="68" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="68" />
         <source>Hide window</source>
         <translation>Hide window</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="79" />
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="79" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="74" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="74" />
         <source>Visit your new community</source>
         <translation>Visit your new community</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="93" />
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="93" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="88" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="88" />
         <source>Setting up your community</source>
         <translation>Setting up your community</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="97" />
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="97" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="92" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="92" />
         <source>Importing channels</source>
         <translation>Importing channels</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="101" />
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="101" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="96" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="96" />
         <source>Importing messages</source>
         <translation>Importing messages</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="105" />
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="105" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="100" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="100" />
         <source>Downloading assets</source>
         <translation>Downloading assets</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="109" />
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="109" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="104" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="104" />
         <source>Initializing community</source>
         <translation>Initializing community</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="136" />
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="136" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="132" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="132" />
         <source>&#10003; Complete</source>
         <translation>&#10003; Complete</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="138" />
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="138" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="134" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="134" />
         <source>Import stopped...</source>
         <translation>Import stopped...</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="142" />
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="142" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="138" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="138" />
         <source>Pending...</source>
         <translation>Pending...</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="145" />
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="145" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="141" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="141" />
         <source>Saving... This can take a moment, almost done!</source>
         <translation>Saving... This can take a moment, almost done!</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="146" />
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="146" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="142" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="142" />
         <source>Working...</source>
         <translation>Working...</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="201" />
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="201" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="197" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="197" />
         <source>%1%</source>
         <translation>%1%</translation>
     </message>
-    <message>
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="245" />
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="245" />
-        <source>%1 more issue(s) downloading assets</source>
-        <translation>%1 more issue(s) downloading assets</translation>
-    </message>
-    <message>
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="278" />
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="278" />
-        <source>Importing &#8216;%1&#8217; from Discord...</source>
-        <translation>Importing &#8216;%1&#8217; from Discord...</translation>
-    </message>
-    <message>
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="280" />
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="280" />
-        <source>Importing &#8216;%1&#8217; from Discord stopped...</source>
-        <translation>Importing &#8216;%1&#8217; from Discord stopped...</translation>
-    </message>
-    <message>
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="282" />
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="282" />
-        <source>Importing &#8216;%1&#8217; stopped due to a critical issue...</source>
-        <translation>Importing &#8216;%1&#8217; stopped due to a critical issue...</translation>
-    </message>
     <message numerus="yes">
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="284" />
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="284" />
-        <source>&#8216;%1&#8217; was imported with %n issue(s).</source>
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="241" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="241" />
+        <source>%n more issue(s) downloading assets</source>
         <translation type="unfinished">
+            <numerusform />
             <numerusform />
         </translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="286" />
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="286" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="281" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="281" />
+        <source>Importing &#8216;%1&#8217; from Discord...</source>
+        <translation>Importing &#8216;%1&#8217; from Discord...</translation>
+    </message>
+    <message>
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="283" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="283" />
+        <source>Importing &#8216;%1&#8217; from Discord stopped...</source>
+        <translation>Importing &#8216;%1&#8217; from Discord stopped...</translation>
+    </message>
+    <message>
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="285" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="285" />
+        <source>Importing &#8216;%1&#8217; stopped due to a critical issue...</source>
+        <translation>Importing &#8216;%1&#8217; stopped due to a critical issue...</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="287" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="287" />
+        <source>&#8216;%1&#8217; was imported with %n issue(s).</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
+    </message>
+    <message>
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="289" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="289" />
         <source>&#8216;%1&#8217; was successfully imported from Discord.</source>
         <translation>&#8216;%1&#8217; was successfully imported from Discord.</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="288" />
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="288" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="291" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="291" />
         <source>Your Discord community import is in progress...</source>
         <translation>Your Discord community import is in progress...</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="328" />
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="328" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="331" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="331" />
         <source>This process can take a while. Feel free to hide this window and use Status normally in the meantime. We&#8217;ll notify you when the Community is ready for you.</source>
         <translation>This process can take a while. Feel free to hide this window and use Status normally in the meantime. We&#8217;ll notify you when the Community is ready for you.</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="329" />
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="329" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="332" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="332" />
         <source>If there were any issues with your import you can upload new JSON files via the community page at any time.</source>
         <translation>If there were any issues with your import you can upload new JSON files via the community page at any time.</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="337" />
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="337" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="340" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="340" />
         <source>Are you sure you want to cancel the import?</source>
         <translation>Are you sure you want to cancel the import?</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="338" />
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="338" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="341" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="341" />
         <source>Your new Status community will be deleted and all information entered will be lost.</source>
         <translation>Your new Status community will be deleted and all information entered will be lost.</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="341" />
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="341" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="344" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="344" />
         <source>Delete community</source>
         <translation>Delete community</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="342" />
-        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="342" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="345" />
+        <location filename="../app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml" line="345" />
         <source>Continue importing</source>
         <translation>Continue importing</translation>
     </message>
@@ -6280,20 +6093,20 @@ Send a contact request to the person you would like to chat with, you will be ab
 <context>
     <name>ENSPopup</name>
     <message>
-        <location filename="../app/AppLayouts/Profile/popups/ENSPopup.qml" line="17" />
-        <location filename="../app/AppLayouts/Profile/popups/ENSPopup.qml" line="17" />
+        <location filename="../app/AppLayouts/Profile/popups/ENSPopup.qml" line="21" />
+        <location filename="../app/AppLayouts/Profile/popups/ENSPopup.qml" line="21" />
         <source>Primary username</source>
         <translation>Primary username</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/popups/ENSPopup.qml" line="31" />
-        <location filename="../app/AppLayouts/Profile/popups/ENSPopup.qml" line="31" />
+        <location filename="../app/AppLayouts/Profile/popups/ENSPopup.qml" line="43" />
+        <location filename="../app/AppLayouts/Profile/popups/ENSPopup.qml" line="43" />
         <source>Your messages are displayed to others with this username:</source>
         <translation>Your messages are displayed to others with this username:</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/popups/ENSPopup.qml" line="33" />
-        <location filename="../app/AppLayouts/Profile/popups/ENSPopup.qml" line="33" />
+        <location filename="../app/AppLayouts/Profile/popups/ENSPopup.qml" line="45" />
+        <location filename="../app/AppLayouts/Profile/popups/ENSPopup.qml" line="45" />
         <source>Once you select a username, you won&#8217;t be able to disable it afterwards. You will only be able choose a different username to display.</source>
         <translation>Once you select a username, you won&#8217;t be able to disable it afterwards. You will only be able choose a different username to display.</translation>
     </message>
@@ -6301,26 +6114,26 @@ Send a contact request to the person you would like to chat with, you will be ab
 <context>
     <name>EmptyChatPanel</name>
     <message>
-        <location filename="../app/AppLayouts/Chat/panels/EmptyChatPanel.qml" line="35" />
-        <location filename="../app/AppLayouts/Chat/panels/EmptyChatPanel.qml" line="35" />
+        <location filename="../app/AppLayouts/Chat/panels/EmptyChatPanel.qml" line="36" />
+        <location filename="../app/AppLayouts/Chat/panels/EmptyChatPanel.qml" line="36" />
         <source>Share your chat key</source>
         <translation>Share your chat key</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/panels/EmptyChatPanel.qml" line="55" />
-        <location filename="../app/AppLayouts/Chat/panels/EmptyChatPanel.qml" line="55" />
+        <location filename="../app/AppLayouts/Chat/panels/EmptyChatPanel.qml" line="56" />
+        <location filename="../app/AppLayouts/Chat/panels/EmptyChatPanel.qml" line="56" />
         <source>or</source>
         <translation>or</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/panels/EmptyChatPanel.qml" line="65" />
-        <location filename="../app/AppLayouts/Chat/panels/EmptyChatPanel.qml" line="65" />
+        <location filename="../app/AppLayouts/Chat/panels/EmptyChatPanel.qml" line="66" />
+        <location filename="../app/AppLayouts/Chat/panels/EmptyChatPanel.qml" line="66" />
         <source>invite</source>
         <translation>invite</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/panels/EmptyChatPanel.qml" line="90" />
-        <location filename="../app/AppLayouts/Chat/panels/EmptyChatPanel.qml" line="90" />
+        <location filename="../app/AppLayouts/Chat/panels/EmptyChatPanel.qml" line="91" />
+        <location filename="../app/AppLayouts/Chat/panels/EmptyChatPanel.qml" line="91" />
         <source>friends to start messaging in Status</source>
         <translation>friends to start messaging in Status</translation>
     </message>
@@ -6415,46 +6228,64 @@ Send a contact request to the person you would like to chat with, you will be ab
 <context>
     <name>EnsDetailsView</name>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/EnsDetailsView.qml" line="79" />
-        <location filename="../app/AppLayouts/Profile/views/EnsDetailsView.qml" line="79" />
+        <location filename="../app/AppLayouts/Profile/views/EnsDetailsView.qml" line="88" />
+        <location filename="../app/AppLayouts/Profile/views/EnsDetailsView.qml" line="88" />
         <source>Wallet address</source>
         <translation>Wallet address</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/EnsDetailsView.qml" line="84" />
-        <location filename="../app/AppLayouts/Profile/views/EnsDetailsView.qml" line="97" />
-        <location filename="../app/AppLayouts/Profile/views/EnsDetailsView.qml" line="84" />
-        <location filename="../app/AppLayouts/Profile/views/EnsDetailsView.qml" line="97" />
+        <location filename="../app/AppLayouts/Profile/views/EnsDetailsView.qml" line="93" />
+        <location filename="../app/AppLayouts/Profile/views/EnsDetailsView.qml" line="106" />
+        <location filename="../app/AppLayouts/Profile/views/EnsDetailsView.qml" line="93" />
+        <location filename="../app/AppLayouts/Profile/views/EnsDetailsView.qml" line="106" />
         <source>Copied to clipboard!</source>
         <translation>Copied to clipboard!</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/EnsDetailsView.qml" line="92" />
-        <location filename="../app/AppLayouts/Profile/views/EnsDetailsView.qml" line="92" />
+        <location filename="../app/AppLayouts/Profile/views/EnsDetailsView.qml" line="101" />
+        <location filename="../app/AppLayouts/Profile/views/EnsDetailsView.qml" line="101" />
         <source>Key</source>
         <translation>Key</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/EnsDetailsView.qml" line="111" />
-        <location filename="../app/AppLayouts/Profile/views/EnsDetailsView.qml" line="111" />
+        <location filename="../app/AppLayouts/Profile/views/EnsDetailsView.qml" line="117" />
+        <location filename="../app/AppLayouts/Profile/views/EnsDetailsView.qml" line="117" />
         <source>Release your username</source>
         <translation>Release your username</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/EnsDetailsView.qml" line="146" />
-        <location filename="../app/AppLayouts/Profile/views/EnsDetailsView.qml" line="146" />
+        <location filename="../app/AppLayouts/Profile/views/EnsDetailsView.qml" line="167" />
+        <location filename="../app/AppLayouts/Profile/views/EnsDetailsView.qml" line="167" />
+        <source>Transaction pending...</source>
+        <translation>Transaction pending...</translation>
+    </message>
+    <message>
+        <location filename="../app/AppLayouts/Profile/views/EnsDetailsView.qml" line="168" />
+        <location filename="../app/AppLayouts/Profile/views/EnsDetailsView.qml" line="168" />
+        <source>View on etherscan</source>
+        <translation>View on etherscan</translation>
+    </message>
+    <message>
+        <location filename="../app/AppLayouts/Profile/views/EnsDetailsView.qml" line="194" />
+        <location filename="../app/AppLayouts/Profile/views/EnsDetailsView.qml" line="194" />
+        <source>Remove username</source>
+        <translation>Remove username</translation>
+    </message>
+    <message>
+        <location filename="../app/AppLayouts/Profile/views/EnsDetailsView.qml" line="205" />
+        <location filename="../app/AppLayouts/Profile/views/EnsDetailsView.qml" line="205" />
         <source>Release username</source>
         <translation>Release username</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/EnsDetailsView.qml" line="158" />
-        <location filename="../app/AppLayouts/Profile/views/EnsDetailsView.qml" line="158" />
+        <location filename="../app/AppLayouts/Profile/views/EnsDetailsView.qml" line="220" />
+        <location filename="../app/AppLayouts/Profile/views/EnsDetailsView.qml" line="220" />
         <source>Username locked. You won't be able to release it until %1</source>
         <translation>Username locked. You won't be able to release it until %1</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/EnsDetailsView.qml" line="167" />
-        <location filename="../app/AppLayouts/Profile/views/EnsDetailsView.qml" line="167" />
+        <location filename="../app/AppLayouts/Profile/views/EnsDetailsView.qml" line="229" />
+        <location filename="../app/AppLayouts/Profile/views/EnsDetailsView.qml" line="229" />
         <source>Back</source>
         <translation>Back</translation>
     </message>
@@ -6462,58 +6293,56 @@ Send a contact request to the person you would like to chat with, you will be ab
 <context>
     <name>EnsListView</name>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/EnsListView.qml" line="32" />
-        <location filename="../app/AppLayouts/Profile/views/EnsListView.qml" line="32" />
-        <source>Hey</source>
-        <translation>Hey</translation>
-    </message>
-    <message>
-        <location filename="../app/AppLayouts/Profile/views/EnsListView.qml" line="55" />
-        <location filename="../app/AppLayouts/Profile/views/EnsListView.qml" line="74" />
-        <location filename="../app/AppLayouts/Profile/views/EnsListView.qml" line="55" />
-        <location filename="../app/AppLayouts/Profile/views/EnsListView.qml" line="74" />
-        <source>(pending)</source>
-        <translation>(pending)</translation>
-    </message>
-    <message>
-        <location filename="../app/AppLayouts/Profile/views/EnsListView.qml" line="134" />
-        <location filename="../app/AppLayouts/Profile/views/EnsListView.qml" line="134" />
+        <location filename="../app/AppLayouts/Profile/views/EnsListView.qml" line="60" />
+        <location filename="../app/AppLayouts/Profile/views/EnsListView.qml" line="60" />
         <source>ENS usernames</source>
         <translation>ENS usernames</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/EnsListView.qml" line="162" />
-        <location filename="../app/AppLayouts/Profile/views/EnsListView.qml" line="162" />
+        <location filename="../app/AppLayouts/Profile/views/EnsListView.qml" line="88" />
+        <location filename="../app/AppLayouts/Profile/views/EnsListView.qml" line="88" />
         <source>Add username</source>
         <translation>Add username</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/EnsListView.qml" line="180" />
-        <location filename="../app/AppLayouts/Profile/views/EnsListView.qml" line="180" />
+        <location filename="../app/AppLayouts/Profile/views/EnsListView.qml" line="106" />
+        <location filename="../app/AppLayouts/Profile/views/EnsListView.qml" line="106" />
         <source>Your usernames</source>
         <translation>Your usernames</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/EnsListView.qml" line="217" />
-        <location filename="../app/AppLayouts/Profile/views/EnsListView.qml" line="217" />
+        <location filename="../app/AppLayouts/Profile/views/EnsListView.qml" line="133" />
+        <location filename="../app/AppLayouts/Profile/views/EnsListView.qml" line="133" />
+        <source>(pending)</source>
+        <translation>(pending)</translation>
+    </message>
+    <message>
+        <location filename="../app/AppLayouts/Profile/views/EnsListView.qml" line="169" />
+        <location filename="../app/AppLayouts/Profile/views/EnsListView.qml" line="169" />
         <source>Chat settings</source>
         <translation>Chat settings</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/EnsListView.qml" line="237" />
-        <location filename="../app/AppLayouts/Profile/views/EnsListView.qml" line="237" />
+        <location filename="../app/AppLayouts/Profile/views/EnsListView.qml" line="189" />
+        <location filename="../app/AppLayouts/Profile/views/EnsListView.qml" line="189" />
         <source>Primary Username</source>
         <translation>Primary Username</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/EnsListView.qml" line="246" />
-        <location filename="../app/AppLayouts/Profile/views/EnsListView.qml" line="246" />
+        <location filename="../app/AppLayouts/Profile/views/EnsListView.qml" line="198" />
+        <location filename="../app/AppLayouts/Profile/views/EnsListView.qml" line="198" />
         <source>None selected</source>
         <translation>None selected</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/EnsListView.qml" line="332" />
-        <location filename="../app/AppLayouts/Profile/views/EnsListView.qml" line="332" />
+        <location filename="../app/AppLayouts/Profile/views/EnsListView.qml" line="230" />
+        <location filename="../app/AppLayouts/Profile/views/EnsListView.qml" line="230" />
+        <source>Hey!</source>
+        <translation>Hey!</translation>
+    </message>
+    <message>
+        <location filename="../app/AppLayouts/Profile/views/EnsListView.qml" line="242" />
+        <location filename="../app/AppLayouts/Profile/views/EnsListView.qml" line="242" />
         <source>You&#8217;re displaying your ENS username in chats</source>
         <translation>You&#8217;re displaying your ENS username in chats</translation>
     </message>
@@ -6608,20 +6437,20 @@ Send a contact request to the person you would like to chat with, you will be ab
 <context>
     <name>EnsSearchView</name>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/EnsSearchView.qml" line="41" />
-        <location filename="../app/AppLayouts/Profile/views/EnsSearchView.qml" line="41" />
+        <location filename="../app/AppLayouts/Profile/views/EnsSearchView.qml" line="43" />
+        <location filename="../app/AppLayouts/Profile/views/EnsSearchView.qml" line="43" />
         <source>At least 4 characters. Latin letters, numbers, and lowercase only.</source>
         <translation>At least 4 characters. Latin letters, numbers, and lowercase only.</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/EnsSearchView.qml" line="43" />
-        <location filename="../app/AppLayouts/Profile/views/EnsSearchView.qml" line="43" />
+        <location filename="../app/AppLayouts/Profile/views/EnsSearchView.qml" line="45" />
+        <location filename="../app/AppLayouts/Profile/views/EnsSearchView.qml" line="45" />
         <source>Letters and numbers only.</source>
         <translation>Letters and numbers only.</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/EnsSearchView.qml" line="45" />
-        <location filename="../app/AppLayouts/Profile/views/EnsSearchView.qml" line="45" />
+        <location filename="../app/AppLayouts/Profile/views/EnsSearchView.qml" line="47" />
+        <location filename="../app/AppLayouts/Profile/views/EnsSearchView.qml" line="47" />
         <source>Type the entire username including the custom domain like username.domain.eth</source>
         <translation>Type the entire username including the custom domain like username.domain.eth</translation>
     </message>
@@ -6632,20 +6461,32 @@ Send a contact request to the person you would like to chat with, you will be ab
         <translation>Connect username with your pubkey</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/EnsSearchView.qml" line="232" />
-        <location filename="../app/AppLayouts/Profile/views/EnsSearchView.qml" line="232" />
+        <location filename="../app/AppLayouts/Profile/views/EnsSearchView.qml" line="113" />
+        <location filename="../app/AppLayouts/Profile/views/EnsSearchView.qml" line="113" />
+        <source>Transaction pending...</source>
+        <translation>Transaction pending...</translation>
+    </message>
+    <message>
+        <location filename="../app/AppLayouts/Profile/views/EnsSearchView.qml" line="114" />
+        <location filename="../app/AppLayouts/Profile/views/EnsSearchView.qml" line="114" />
+        <source>View on etherscan</source>
+        <translation>View on etherscan</translation>
+    </message>
+    <message>
+        <location filename="../app/AppLayouts/Profile/views/EnsSearchView.qml" line="267" />
+        <location filename="../app/AppLayouts/Profile/views/EnsSearchView.qml" line="267" />
         <source>Custom domain</source>
         <translation>Custom domain</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/EnsSearchView.qml" line="243" />
-        <location filename="../app/AppLayouts/Profile/views/EnsSearchView.qml" line="243" />
+        <location filename="../app/AppLayouts/Profile/views/EnsSearchView.qml" line="278" />
+        <location filename="../app/AppLayouts/Profile/views/EnsSearchView.qml" line="278" />
         <source>I want a stateofus.eth domain</source>
         <translation>I want a stateofus.eth domain</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/EnsSearchView.qml" line="245" />
-        <location filename="../app/AppLayouts/Profile/views/EnsSearchView.qml" line="245" />
+        <location filename="../app/AppLayouts/Profile/views/EnsSearchView.qml" line="280" />
+        <location filename="../app/AppLayouts/Profile/views/EnsSearchView.qml" line="280" />
         <source>I own a name on another domain</source>
         <translation>I own a name on another domain</translation>
     </message>
@@ -6659,132 +6500,144 @@ Send a contact request to the person you would like to chat with, you will be ab
         <translation>ENS usernames</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="83" />
-        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="83" />
+        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="99" />
+        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="99" />
+        <source>Transaction pending...</source>
+        <translation>Transaction pending...</translation>
+    </message>
+    <message>
+        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="100" />
+        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="100" />
+        <source>View on etherscan</source>
+        <translation>View on etherscan</translation>
+    </message>
+    <message>
+        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="116" />
+        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="116" />
         <source>Terms of name registration</source>
         <translation>Terms of name registration</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="99" />
-        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="99" />
+        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="132" />
+        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="132" />
         <source>Funds are deposited for 1 year. Your SNT will be locked, but not spent.</source>
         <translation>Funds are deposited for 1 year. Your SNT will be locked, but not spent.</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="107" />
-        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="107" />
+        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="140" />
+        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="140" />
         <source>After 1 year, you can release the name and get your deposit back, or take no action to keep the name.</source>
         <translation>After 1 year, you can release the name and get your deposit back, or take no action to keep the name.</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="115" />
-        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="115" />
+        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="148" />
+        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="148" />
         <source>If terms of the contract change &#8212; e.g. Status makes contract upgrades &#8212; user has the right to release the username regardless of time held.</source>
         <translation>If terms of the contract change &#8212; e.g. Status makes contract upgrades &#8212; user has the right to release the username regardless of time held.</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="123" />
-        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="123" />
+        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="156" />
+        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="156" />
         <source>The contract controller cannot access your deposited funds. They can only be moved back to the address that sent them.</source>
         <translation>The contract controller cannot access your deposited funds. They can only be moved back to the address that sent them.</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="131" />
-        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="131" />
+        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="164" />
+        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="164" />
         <source>Your address(es) will be publicly associated with your ENS name.</source>
         <translation>Your address(es) will be publicly associated with your ENS name.</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="139" />
-        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="139" />
+        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="172" />
+        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="172" />
         <source>Usernames are created as subdomain nodes of stateofus.eth and are subject to the ENS smart contract terms.</source>
         <translation>Usernames are created as subdomain nodes of stateofus.eth and are subject to the ENS smart contract terms.</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="147" />
-        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="147" />
+        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="180" />
+        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="180" />
         <source>You authorize the contract to transfer SNT on your behalf. This can only occur when you approve a transaction to authorize the transfer.</source>
         <translation>You authorize the contract to transfer SNT on your behalf. This can only occur when you approve a transaction to authorize the transfer.</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="155" />
-        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="155" />
+        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="188" />
+        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="188" />
         <source>These terms are guaranteed by the smart contract logic at addresses:</source>
         <translation>These terms are guaranteed by the smart contract logic at addresses:</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="164" />
-        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="164" />
+        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="197" />
+        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="197" />
         <source>%1 (Status UsernameRegistrar).</source>
         <translation>%1 (Status UsernameRegistrar).</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="173" />
-        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="197" />
-        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="173" />
-        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="197" />
+        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="206" />
+        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="230" />
+        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="206" />
+        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="230" />
         <source>&lt;a href='%1%2'&gt;Look up on Etherscan&lt;/a&gt;</source>
         <translation>&lt;a href='%1%2'&gt;Look up on Etherscan&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="188" />
-        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="188" />
+        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="221" />
+        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="221" />
         <source>%1 (ENS Registry).</source>
         <translation>%1 (ENS Registry).</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="265" />
-        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="265" />
+        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="298" />
+        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="298" />
         <source>Wallet address</source>
         <translation>Wallet address</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="267" />
-        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="284" />
-        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="267" />
-        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="284" />
+        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="300" />
+        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="317" />
+        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="300" />
+        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="317" />
         <source>Copied to clipboard!</source>
         <translation>Copied to clipboard!</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="279" />
-        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="279" />
+        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="312" />
+        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="312" />
         <source>Key</source>
         <translation>Key</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="304" />
-        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="304" />
+        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="337" />
+        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="337" />
         <source>Agree to &lt;a href="#"&gt;Terms of name registration.&lt;/a&gt; I understand that my wallet address will be publicly connected to my username.</source>
         <translation>Agree to &lt;a href="#"&gt;Terms of name registration.&lt;/a&gt; I understand that my wallet address will be publicly connected to my username.</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="330" />
-        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="330" />
+        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="363" />
+        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="363" />
         <source>Back</source>
         <translation>Back</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="350" />
-        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="350" />
+        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="383" />
+        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="383" />
         <source>10 SNT</source>
         <translation>10 SNT</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="359" />
-        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="359" />
+        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="392" />
+        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="392" />
         <source>Deposit</source>
         <translation>Deposit</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="377" />
-        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="377" />
+        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="410" />
+        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="410" />
         <source>Not enough SNT</source>
         <translation>Not enough SNT</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="378" />
-        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="378" />
+        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="411" />
+        <location filename="../app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml" line="411" />
         <source>Register</source>
         <translation>Register</translation>
     </message>
@@ -6792,44 +6645,40 @@ Send a contact request to the person you would like to chat with, you will be ab
 <context>
     <name>EnsView</name>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/EnsView.qml" line="327" />
-        <location filename="../app/AppLayouts/Profile/views/EnsView.qml" line="362" />
-        <location filename="../app/AppLayouts/Profile/views/EnsView.qml" line="327" />
-        <location filename="../app/AppLayouts/Profile/views/EnsView.qml" line="362" />
-        <source>Transaction pending...</source>
-        <translation>Transaction pending...</translation>
-    </message>
-    <message>
-        <location filename="../app/AppLayouts/Profile/views/EnsView.qml" line="328" />
-        <location filename="../app/AppLayouts/Profile/views/EnsView.qml" line="363" />
-        <location filename="../app/AppLayouts/Profile/views/EnsView.qml" line="328" />
-        <location filename="../app/AppLayouts/Profile/views/EnsView.qml" line="363" />
-        <source>View on etherscan</source>
-        <translation>View on etherscan</translation>
-    </message>
-    <message>
-        <location filename="../app/AppLayouts/Profile/views/EnsView.qml" line="339" />
-        <location filename="../app/AppLayouts/Profile/views/EnsView.qml" line="339" />
+        <location filename="../app/AppLayouts/Profile/views/EnsView.qml" line="330" />
+        <location filename="../app/AppLayouts/Profile/views/EnsView.qml" line="330" />
         <source>ENS Registration failed</source>
         <translation>ENS Registration failed</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/EnsView.qml" line="341" />
-        <location filename="../app/AppLayouts/Profile/views/EnsView.qml" line="341" />
+        <location filename="../app/AppLayouts/Profile/views/EnsView.qml" line="332" />
+        <location filename="../app/AppLayouts/Profile/views/EnsView.qml" line="332" />
         <source>ENS Registration completed</source>
         <translation>ENS Registration completed</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/EnsView.qml" line="345" />
-        <location filename="../app/AppLayouts/Profile/views/EnsView.qml" line="345" />
+        <location filename="../app/AppLayouts/Profile/views/EnsView.qml" line="336" />
+        <location filename="../app/AppLayouts/Profile/views/EnsView.qml" line="336" />
         <source>Updating ENS pubkey failed</source>
         <translation>Updating ENS pubkey failed</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/EnsView.qml" line="347" />
-        <location filename="../app/AppLayouts/Profile/views/EnsView.qml" line="347" />
+        <location filename="../app/AppLayouts/Profile/views/EnsView.qml" line="338" />
+        <location filename="../app/AppLayouts/Profile/views/EnsView.qml" line="338" />
         <source>Updating ENS pubkey completed</source>
         <translation>Updating ENS pubkey completed</translation>
+    </message>
+    <message>
+        <location filename="../app/AppLayouts/Profile/views/EnsView.qml" line="353" />
+        <location filename="../app/AppLayouts/Profile/views/EnsView.qml" line="353" />
+        <source>Transaction pending...</source>
+        <translation>Transaction pending...</translation>
+    </message>
+    <message>
+        <location filename="../app/AppLayouts/Profile/views/EnsView.qml" line="354" />
+        <location filename="../app/AppLayouts/Profile/views/EnsView.qml" line="354" />
+        <source>View on etherscan</source>
+        <translation>View on etherscan</translation>
     </message>
 </context>
 <context>
@@ -6947,6 +6796,45 @@ Send a contact request to the person you would like to chat with, you will be ab
     </message>
 </context>
 <context>
+    <name>EnterPairingCode</name>
+    <message>
+        <location filename="../imports/shared/popups/keycard/states/EnterPairingCode.qml" line="38" />
+        <location filename="../imports/shared/popups/keycard/states/EnterPairingCode.qml" line="38" />
+        <source>The codes don&#8217;t match</source>
+        <translation>The codes don&#8217;t match</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/popups/keycard/states/EnterPairingCode.qml" line="68" />
+        <location filename="../imports/shared/popups/keycard/states/EnterPairingCode.qml" line="68" />
+        <source>Enter a new pairing code</source>
+        <translation>Enter a new pairing code</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/popups/keycard/states/EnterPairingCode.qml" line="77" />
+        <location filename="../imports/shared/popups/keycard/states/EnterPairingCode.qml" line="77" />
+        <source>Pairing code</source>
+        <translation>Pairing code</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/popups/keycard/states/EnterPairingCode.qml" line="89" />
+        <location filename="../imports/shared/popups/keycard/states/EnterPairingCode.qml" line="89" />
+        <source>Enter code</source>
+        <translation>Enter code</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/popups/keycard/states/EnterPairingCode.qml" line="130" />
+        <location filename="../imports/shared/popups/keycard/states/EnterPairingCode.qml" line="130" />
+        <source>Confirm pairing code</source>
+        <translation>Confirm pairing code</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/popups/keycard/states/EnterPairingCode.qml" line="142" />
+        <location filename="../imports/shared/popups/keycard/states/EnterPairingCode.qml" line="142" />
+        <source>Confirm code</source>
+        <translation>Confirm code</translation>
+    </message>
+</context>
+<context>
     <name>EnterPassword</name>
     <message>
         <location filename="../imports/shared/popups/keycard/states/EnterPassword.qml" line="85" />
@@ -7020,6 +6908,7 @@ Send a contact request to the person you would like to chat with, you will be ab
         <location filename="../imports/shared/popups/keycard/states/EnterSeedPhrase.qml" line="142" />
         <source>%n word(s)</source>
         <translation type="unfinished">
+            <numerusform />
             <numerusform />
         </translation>
     </message>
@@ -7181,6 +7070,15 @@ Send a contact request to the person you would like to chat with, you will be ab
     </message>
 </context>
 <context>
+    <name>FeesView</name>
+    <message>
+        <location filename="../imports/shared/views/FeesView.qml" line="52" />
+        <location filename="../imports/shared/views/FeesView.qml" line="52" />
+        <source>Fees</source>
+        <translation>Fees</translation>
+    </message>
+</context>
+<context>
     <name>FetchMoreMessagesButton</name>
     <message>
         <location filename="../imports/shared/controls/chat/FetchMoreMessagesButton.qml" line="58" />
@@ -7237,171 +7135,31 @@ Send a contact request to the person you would like to chat with, you will be ab
 <context>
     <name>GasSelector</name>
     <message>
-        <location filename="../imports/shared/controls/GasSelector.qml" line="38" />
-        <location filename="../imports/shared/controls/GasSelector.qml" line="38" />
-        <source>Must be greater than 0</source>
-        <translation>Must be greater than 0</translation>
+        <location filename="../imports/shared/controls/GasSelector.qml" line="47" />
+        <location filename="../imports/shared/controls/GasSelector.qml" line="47" />
+        <source>%1 transaction fee</source>
+        <translation>%1 transaction fee</translation>
     </message>
     <message>
-        <location filename="../imports/shared/controls/GasSelector.qml" line="39" />
-        <location filename="../imports/shared/controls/GasSelector.qml" line="39" />
-        <source>This needs to be a number</source>
-        <translation>This needs to be a number</translation>
-    </message>
-    <message>
-        <location filename="../imports/shared/controls/GasSelector.qml" line="40" />
-        <location filename="../imports/shared/controls/GasSelector.qml" line="40" />
-        <source>Please enter an amount</source>
-        <translation>Please enter an amount</translation>
-    </message>
-    <message>
-        <location filename="../imports/shared/controls/GasSelector.qml" line="93" />
-        <location filename="../imports/shared/controls/GasSelector.qml" line="93" />
-        <source>Min 21000 units</source>
-        <translation>Min 21000 units</translation>
-    </message>
-    <message>
-        <location filename="../imports/shared/controls/GasSelector.qml" line="95" />
-        <location filename="../imports/shared/controls/GasSelector.qml" line="95" />
-        <source>Not enough gas</source>
-        <translation>Not enough gas</translation>
-    </message>
-    <message>
-        <location filename="../imports/shared/controls/GasSelector.qml" line="100" />
-        <location filename="../imports/shared/controls/GasSelector.qml" line="100" />
-        <source>Miners will currently not process transactions with a tip below %1 Gwei, the average is %2 Gwei</source>
-        <translation>Miners will currently not process transactions with a tip below %1 Gwei, the average is %2 Gwei</translation>
-    </message>
-    <message>
-        <location filename="../imports/shared/controls/GasSelector.qml" line="103" />
-        <location filename="../imports/shared/controls/GasSelector.qml" line="103" />
-        <source>The average miner tip is %1 Gwei</source>
-        <translation>The average miner tip is %1 Gwei</translation>
-    </message>
-    <message>
-        <location filename="../imports/shared/controls/GasSelector.qml" line="175" />
-        <location filename="../imports/shared/controls/GasSelector.qml" line="175" />
-        <source>Priority</source>
-        <translation>Priority</translation>
-    </message>
-    <message>
-        <location filename="../imports/shared/controls/GasSelector.qml" line="175" />
-        <location filename="../imports/shared/controls/GasSelector.qml" line="175" />
-        <source>Gas Price</source>
-        <translation>Gas Price</translation>
-    </message>
-    <message>
-        <location filename="../imports/shared/controls/GasSelector.qml" line="188" />
-        <location filename="../imports/shared/controls/GasSelector.qml" line="188" />
-        <source>Current base fee: %1 %2</source>
-        <translation>Current base fee: %1 %2</translation>
-    </message>
-    <message>
-        <location filename="../imports/shared/controls/GasSelector.qml" line="203" />
-        <location filename="../imports/shared/controls/GasSelector.qml" line="203" />
-        <source>Use suggestions</source>
-        <translation>Use suggestions</translation>
-    </message>
-    <message>
-        <location filename="../imports/shared/controls/GasSelector.qml" line="204" />
-        <location filename="../imports/shared/controls/GasSelector.qml" line="204" />
-        <source>Use custom</source>
-        <translation>Use custom</translation>
-    </message>
-    <message>
-        <location filename="../imports/shared/controls/GasSelector.qml" line="219" />
-        <location filename="../imports/shared/controls/GasSelector.qml" line="219" />
-        <source>Low</source>
-        <translation>Low</translation>
-    </message>
-    <message>
-        <location filename="../imports/shared/controls/GasSelector.qml" line="245" />
-        <location filename="../imports/shared/controls/GasSelector.qml" line="245" />
-        <source>Optimal</source>
-        <translation>Optimal</translation>
-    </message>
-    <message>
-        <location filename="../imports/shared/controls/GasSelector.qml" line="276" />
-        <location filename="../imports/shared/controls/GasSelector.qml" line="276" />
-        <source>High</source>
-        <translation>High</translation>
-    </message>
-    <message>
-        <location filename="../imports/shared/controls/GasSelector.qml" line="310" />
-        <location filename="../imports/shared/controls/GasSelector.qml" line="310" />
-        <source>Gas amount limit</source>
-        <translation>Gas amount limit</translation>
-    </message>
-    <message>
-        <location filename="../imports/shared/controls/GasSelector.qml" line="334" />
-        <location filename="../imports/shared/controls/GasSelector.qml" line="334" />
-        <source>Per-gas tip limit</source>
-        <translation>Per-gas tip limit</translation>
-    </message>
-    <message>
-        <location filename="../imports/shared/controls/GasSelector.qml" line="354" />
-        <location filename="../imports/shared/controls/GasSelector.qml" line="383" />
-        <location filename="../imports/shared/controls/GasSelector.qml" line="354" />
-        <location filename="../imports/shared/controls/GasSelector.qml" line="383" />
-        <source>Gwei</source>
-        <translation>Gwei</translation>
-    </message>
-    <message>
-        <location filename="../imports/shared/controls/GasSelector.qml" line="366" />
-        <location filename="../imports/shared/controls/GasSelector.qml" line="366" />
-        <source>Per-gas overall limit</source>
-        <translation>Per-gas overall limit</translation>
-    </message>
-    <message>
-        <location filename="../imports/shared/controls/GasSelector.qml" line="412" />
-        <location filename="../imports/shared/controls/GasSelector.qml" line="412" />
-        <source>Maximum priority fee: %1 ETH</source>
-        <translation>Maximum priority fee: %1 ETH</translation>
-    </message>
-    <message>
-        <location filename="../imports/shared/controls/GasSelector.qml" line="434" />
-        <location filename="../imports/shared/controls/GasSelector.qml" line="434" />
-        <source>Maximum overall price for the transaction. If the block base fee exceeds this, it will be included in a following block with a lower base fee.</source>
-        <translation>Maximum overall price for the transaction. If the block base fee exceeds this, it will be included in a following block with a lower base fee.</translation>
-    </message>
-</context>
-<context>
-    <name>GasSelectorButton</name>
-    <message>
-        <location filename="../imports/shared/controls/chat/GasSelectorButton.qml" line="14" />
-        <location filename="../imports/shared/controls/chat/GasSelectorButton.qml" line="14" />
-        <source>Low</source>
-        <translation>Low</translation>
+        <location filename="../imports/shared/controls/GasSelector.qml" line="78" />
+        <location filename="../imports/shared/controls/GasSelector.qml" line="78" />
+        <source>%1 -&gt; %2 bridge</source>
+        <translation>%1 -&gt; %2 bridge</translation>
     </message>
 </context>
 <context>
     <name>GasValidator</name>
     <message>
-        <location filename="../imports/shared/controls/GasValidator.qml" line="62" />
-        <location filename="../imports/shared/controls/GasValidator.qml" line="62" />
-        <source>Not enough ETH for gas</source>
-        <translation>Not enough ETH for gas</translation>
-    </message>
-</context>
-<context>
-    <name>Global</name>
-    <message>
-        <location filename="../imports/utils/Global.qml" line="78" />
-        <location filename="../imports/utils/Global.qml" line="78" />
-        <source>Verify %1's Identity</source>
-        <translation>Verify %1's Identity</translation>
+        <location filename="../imports/shared/controls/GasValidator.qml" line="41" />
+        <location filename="../imports/shared/controls/GasValidator.qml" line="41" />
+        <source>Calculating fees</source>
+        <translation>Calculating fees</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Global.qml" line="79" />
-        <location filename="../imports/utils/Global.qml" line="79" />
-        <source>Ask a question that only the real %1 will be able to answer e.g. a question about a shared experience, or ask %1 to enter a code or phrase you have sent to them via a different communication channel (phone, post, etc...).</source>
-        <translation>Ask a question that only the real %1 will be able to answer e.g. a question about a shared experience, or ask %1 to enter a code or phrase you have sent to them via a different communication channel (phone, post, etc...).</translation>
-    </message>
-    <message>
-        <location filename="../imports/utils/Global.qml" line="80" />
-        <location filename="../imports/utils/Global.qml" line="80" />
-        <source>Send verification request</source>
-        <translation>Send verification request</translation>
+        <location filename="../imports/shared/controls/GasValidator.qml" line="41" />
+        <location filename="../imports/shared/controls/GasValidator.qml" line="41" />
+        <source>Balance exceeded</source>
+        <translation>Balance exceeded</translation>
     </message>
 </context>
 <context>
@@ -7490,8 +7248,8 @@ Send a contact request to the person you would like to chat with, you will be ab
     <message>
         <location filename="../app/AppLayouts/Profile/views/browser/HomePageView.qml" line="18" />
         <location filename="../app/AppLayouts/Profile/views/browser/HomePageView.qml" line="18" />
-        <source>homepage</source>
-        <translation>homepage</translation>
+        <source>Homepage</source>
+        <translation>Homepage</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/browser/HomePageView.qml" line="34" />
@@ -7515,8 +7273,8 @@ Send a contact request to the person you would like to chat with, you will be ab
 <context>
     <name>ImageCropWorkflow</name>
     <message>
-        <location filename="../imports/shared/popups/ImageCropWorkflow.qml" line="40" />
-        <location filename="../imports/shared/popups/ImageCropWorkflow.qml" line="40" />
+        <location filename="../imports/shared/popups/ImageCropWorkflow.qml" line="41" />
+        <location filename="../imports/shared/popups/ImageCropWorkflow.qml" line="41" />
         <source>Supported image formats (%1)</source>
         <translation>Supported image formats (%1)</translation>
     </message>
@@ -7524,28 +7282,58 @@ Send a contact request to the person you would like to chat with, you will be ab
 <context>
     <name>ImportCommunityPopup</name>
     <message>
-        <location filename="../imports/shared/popups/ImportCommunityPopup.qml" line="25" />
-        <location filename="../imports/shared/popups/ImportCommunityPopup.qml" line="25" />
+        <location filename="../imports/shared/popups/ImportCommunityPopup.qml" line="20" />
+        <location filename="../imports/shared/popups/ImportCommunityPopup.qml" line="20" />
         <source>Import Community</source>
         <translation>Import Community</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/ImportCommunityPopup.qml" line="43" />
-        <location filename="../imports/shared/popups/ImportCommunityPopup.qml" line="43" />
-        <source>Entering a community key will grant you the ownership of that community. Please be responsible with it and don&#8217;t share the key with people you don&#8217;t trust.</source>
-        <translation>Entering a community key will grant you the ownership of that community. Please be responsible with it and don&#8217;t share the key with people you don&#8217;t trust.</translation>
+        <location filename="../imports/shared/popups/ImportCommunityPopup.qml" line="25" />
+        <location filename="../imports/shared/popups/ImportCommunityPopup.qml" line="25" />
+        <source>Invalid key</source>
+        <translation>Invalid key</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/ImportCommunityPopup.qml" line="52" />
-        <location filename="../imports/shared/popups/ImportCommunityPopup.qml" line="52" />
-        <source>Community private key</source>
-        <translation>Community private key</translation>
+        <location filename="../imports/shared/popups/ImportCommunityPopup.qml" line="35" />
+        <location filename="../imports/shared/popups/ImportCommunityPopup.qml" line="35" />
+        <source>Cancel</source>
+        <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/ImportCommunityPopup.qml" line="70" />
-        <location filename="../imports/shared/popups/ImportCommunityPopup.qml" line="70" />
+        <location filename="../imports/shared/popups/ImportCommunityPopup.qml" line="41" />
+        <location filename="../imports/shared/popups/ImportCommunityPopup.qml" line="41" />
+        <source>Make this an Owner Node</source>
+        <translation>Make this an Owner Node</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/popups/ImportCommunityPopup.qml" line="41" />
+        <location filename="../imports/shared/popups/ImportCommunityPopup.qml" line="41" />
         <source>Import</source>
         <translation>Import</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/popups/ImportCommunityPopup.qml" line="67" />
+        <location filename="../imports/shared/popups/ImportCommunityPopup.qml" line="67" />
+        <source>Enter the public key of the community you wish to access, or enter the private key of a community you own. Remember to always keep any private key safe and never share a private key with anyone else.</source>
+        <translation>Enter the public key of the community you wish to access, or enter the private key of a community you own. Remember to always keep any private key safe and never share a private key with anyone else.</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/popups/ImportCommunityPopup.qml" line="75" />
+        <location filename="../imports/shared/popups/ImportCommunityPopup.qml" line="75" />
+        <source>Community key</source>
+        <translation>Community key</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/popups/ImportCommunityPopup.qml" line="100" />
+        <location filename="../imports/shared/popups/ImportCommunityPopup.qml" line="100" />
+        <source>Private key detected</source>
+        <translation>Private key detected</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/popups/ImportCommunityPopup.qml" line="103" />
+        <location filename="../imports/shared/popups/ImportCommunityPopup.qml" line="103" />
+        <source>Public key detected</source>
+        <translation>Public key detected</translation>
     </message>
 </context>
 <context>
@@ -7632,10 +7420,11 @@ Send a contact request to the person you would like to chat with, you will be ab
         <translation>This seed phrase doesn't match our supported dictionary. Check for misspelled words.</translation>
     </message>
     <message numerus="yes">
-        <location filename="../app/AppLayouts/Wallet/panels/ImportSeedPhrasePanel.qml" line="263" />
-        <location filename="../app/AppLayouts/Wallet/panels/ImportSeedPhrasePanel.qml" line="263" />
+        <location filename="../app/AppLayouts/Wallet/panels/ImportSeedPhrasePanel.qml" line="258" />
+        <location filename="../app/AppLayouts/Wallet/panels/ImportSeedPhrasePanel.qml" line="258" />
         <source>%n word(s)</source>
         <translation type="unfinished">
+            <numerusform />
             <numerusform />
         </translation>
     </message>
@@ -7643,16 +7432,22 @@ Send a contact request to the person you would like to chat with, you will be ab
 <context>
     <name>InlineSelectorPanel</name>
     <message>
-        <location filename="../app/AppLayouts/Chat/panels/InlineSelectorPanel.qml" line="185" />
-        <location filename="../app/AppLayouts/Chat/panels/InlineSelectorPanel.qml" line="185" />
+        <location filename="../app/AppLayouts/Chat/panels/InlineSelectorPanel.qml" line="210" />
+        <location filename="../app/AppLayouts/Chat/panels/InlineSelectorPanel.qml" line="210" />
         <source>Confirm</source>
         <translation>Confirm</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/panels/InlineSelectorPanel.qml" line="191" />
-        <location filename="../app/AppLayouts/Chat/panels/InlineSelectorPanel.qml" line="191" />
-        <source>Reject</source>
-        <translation>Reject</translation>
+        <location filename="../app/AppLayouts/Chat/panels/InlineSelectorPanel.qml" line="216" />
+        <location filename="../app/AppLayouts/Chat/panels/InlineSelectorPanel.qml" line="216" />
+        <source>Cancel</source>
+        <translation>Cancel</translation>
+    </message>
+    <message>
+        <location filename="../app/AppLayouts/Chat/panels/InlineSelectorPanel.qml" line="260" />
+        <location filename="../app/AppLayouts/Chat/panels/InlineSelectorPanel.qml" line="260" />
+        <source>No results found</source>
+        <translation>No results found</translation>
     </message>
 </context>
 <context>
@@ -7752,28 +7547,29 @@ Send a contact request to the person you would like to chat with, you will be ab
 <context>
     <name>InvitationBubbleView</name>
     <message>
-        <location filename="../imports/shared/views/chat/InvitationBubbleView.qml" line="113" />
-        <location filename="../imports/shared/views/chat/InvitationBubbleView.qml" line="113" />
+        <location filename="../imports/shared/views/chat/InvitationBubbleView.qml" line="94" />
+        <location filename="../imports/shared/views/chat/InvitationBubbleView.qml" line="94" />
         <source>Verified community invitation</source>
         <translation>Verified community invitation</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/chat/InvitationBubbleView.qml" line="113" />
-        <location filename="../imports/shared/views/chat/InvitationBubbleView.qml" line="113" />
+        <location filename="../imports/shared/views/chat/InvitationBubbleView.qml" line="94" />
+        <location filename="../imports/shared/views/chat/InvitationBubbleView.qml" line="94" />
         <source>Community invitation</source>
         <translation>Community invitation</translation>
     </message>
     <message numerus="yes">
-        <location filename="../imports/shared/views/chat/InvitationBubbleView.qml" line="200" />
-        <location filename="../imports/shared/views/chat/InvitationBubbleView.qml" line="200" />
+        <location filename="../imports/shared/views/chat/InvitationBubbleView.qml" line="156" />
+        <location filename="../imports/shared/views/chat/InvitationBubbleView.qml" line="156" />
         <source>%n member(s)</source>
         <translation type="unfinished">
+            <numerusform />
             <numerusform />
         </translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/chat/InvitationBubbleView.qml" line="220" />
-        <location filename="../imports/shared/views/chat/InvitationBubbleView.qml" line="220" />
+        <location filename="../imports/shared/views/chat/InvitationBubbleView.qml" line="176" />
+        <location filename="../imports/shared/views/chat/InvitationBubbleView.qml" line="176" />
         <source>Go to Community</source>
         <translation>Go to Community</translation>
     </message>
@@ -7802,26 +7598,26 @@ Send a contact request to the person you would like to chat with, you will be ab
 <context>
     <name>InviteFriendsToCommunityPopup</name>
     <message>
-        <location filename="../app/AppLayouts/Chat/popups/community/InviteFriendsToCommunityPopup.qml" line="41" />
-        <location filename="../app/AppLayouts/Chat/popups/community/InviteFriendsToCommunityPopup.qml" line="41" />
+        <location filename="../app/AppLayouts/Chat/popups/community/InviteFriendsToCommunityPopup.qml" line="45" />
+        <location filename="../app/AppLayouts/Chat/popups/community/InviteFriendsToCommunityPopup.qml" line="45" />
         <source>Invite successfully sent</source>
         <translation>Invite successfully sent</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/popups/community/InviteFriendsToCommunityPopup.qml" line="52" />
-        <location filename="../app/AppLayouts/Chat/popups/community/InviteFriendsToCommunityPopup.qml" line="52" />
+        <location filename="../app/AppLayouts/Chat/popups/community/InviteFriendsToCommunityPopup.qml" line="56" />
+        <location filename="../app/AppLayouts/Chat/popups/community/InviteFriendsToCommunityPopup.qml" line="56" />
         <source>Invite Contacts to %1</source>
         <translation>Invite Contacts to %1</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/popups/community/InviteFriendsToCommunityPopup.qml" line="59" />
-        <location filename="../app/AppLayouts/Chat/popups/community/InviteFriendsToCommunityPopup.qml" line="59" />
+        <location filename="../app/AppLayouts/Chat/popups/community/InviteFriendsToCommunityPopup.qml" line="66" />
+        <location filename="../app/AppLayouts/Chat/popups/community/InviteFriendsToCommunityPopup.qml" line="66" />
         <source>Next</source>
         <translation>Next</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/popups/community/InviteFriendsToCommunityPopup.qml" line="68" />
-        <location filename="../app/AppLayouts/Chat/popups/community/InviteFriendsToCommunityPopup.qml" line="68" />
+        <location filename="../app/AppLayouts/Chat/popups/community/InviteFriendsToCommunityPopup.qml" line="77" />
+        <location filename="../app/AppLayouts/Chat/popups/community/InviteFriendsToCommunityPopup.qml" line="77" />
         <source>Send Invites</source>
         <translation>Send Invites</translation>
     </message>
@@ -7834,6 +7630,7 @@ Send a contact request to the person you would like to chat with, you will be ab
         <source>%n warning(s)</source>
         <translation type="unfinished">
             <numerusform />
+            <numerusform />
         </translation>
     </message>
     <message numerus="yes">
@@ -7841,6 +7638,7 @@ Send a contact request to the person you would like to chat with, you will be ab
         <location filename="../app/AppLayouts/CommunitiesPortal/controls/IssuePill.qml" line="19" />
         <source>%n error(s)</source>
         <translation type="unfinished">
+            <numerusform />
             <numerusform />
         </translation>
     </message>
@@ -7881,16 +7679,24 @@ Send a contact request to the person you would like to chat with, you will be ab
 <context>
     <name>KeycardConfirmation</name>
     <message>
-        <location filename="../imports/shared/popups/keycard/states/KeycardConfirmation.qml" line="74" />
-        <location filename="../imports/shared/popups/keycard/states/KeycardConfirmation.qml" line="74" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardConfirmation.qml" line="75" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardConfirmation.qml" line="75" />
+        <source>Warning, this Keycard stores your main Status profile and
+accounts. A factory reset will permanently delete it.</source>
+        <translation>Warning, this Keycard stores your main Status profile and
+accounts. A factory reset will permanently delete it.</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/popups/keycard/states/KeycardConfirmation.qml" line="77" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardConfirmation.qml" line="77" />
         <source>A factory reset will delete the key on this Keycard.
 Are you sure you want to do this?</source>
         <translation>A factory reset will delete the key on this Keycard.
 Are you sure you want to do this?</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/keycard/states/KeycardConfirmation.qml" line="86" />
-        <location filename="../imports/shared/popups/keycard/states/KeycardConfirmation.qml" line="86" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardConfirmation.qml" line="90" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardConfirmation.qml" line="90" />
         <source>I understand the key pair on this Keycard will be deleted</source>
         <translation>I understand the key pair on this Keycard will be deleted</translation>
     </message>
@@ -7927,282 +7733,382 @@ Are you sure you want to do this?</translation>
 <context>
     <name>KeycardInit</name>
     <message>
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="308" />
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="308" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="427" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="427" />
         <source>Plug in Keycard reader...</source>
         <translation>Plug in Keycard reader...</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="328" />
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="328" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="449" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="449" />
+        <source>Insert empty Keycard...</source>
+        <translation>Insert empty Keycard...</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="451" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="451" />
         <source>Insert Keycard...</source>
         <translation>Insert Keycard...</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="346" />
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="346" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="470" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="470" />
         <source>Check the card, it might be wrongly inserted</source>
         <translation>Check the card, it might be wrongly inserted</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="357" />
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="357" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="481" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="481" />
         <source>Keycard inserted...</source>
         <translation>Keycard inserted...</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="386" />
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="386" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="514" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="514" />
         <source>Reading Keycard...</source>
         <translation>Reading Keycard...</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="389" />
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="389" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="517" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="517" />
         <source>Migrating key pair to Keycard</source>
         <translation>Migrating key pair to Keycard</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="392" />
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="392" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="520" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="520" />
         <source>Renaming keycard...</source>
         <translation>Renaming keycard...</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="420" />
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="420" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="523" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="523" />
+        <source>Updating PIN</source>
+        <translation>Updating PIN</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="526" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="526" />
+        <source>Setting your Keycard PUK...</source>
+        <translation>Setting your Keycard PUK...</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="529" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="529" />
+        <source>Setting your pairing code...</source>
+        <translation>Setting your pairing code...</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="532" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="532" />
+        <source>Copying Keycard...</source>
+        <translation>Copying Keycard...</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="572" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="572" />
         <source>This is not a Keycard</source>
         <translation>This is not a Keycard</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="442" />
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="442" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="596" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="596" />
         <source>The card inserted is not a recognised Keycard,
 please remove and try and again</source>
         <translation>The card inserted is not a recognised Keycard,
 please remove and try and again</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="452" />
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="452" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="606" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="606" />
         <source>Unlock this Keycard</source>
         <translation>Unlock this Keycard</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="477" />
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="477" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="631" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="631" />
         <source>Wrong Keycard inserted</source>
         <translation>Wrong Keycard inserted</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="492" />
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="492" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="650" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="650" />
         <source>Keycard inserted does not match the Keycard below</source>
         <translation>Keycard inserted does not match the Keycard below</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="495" />
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="495" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="653" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="653" />
         <source>Keycard inserted does not match the Keycard you're trying to unlock</source>
         <translation>Keycard inserted does not match the Keycard you're trying to unlock</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="508" />
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="508" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="666" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="666" />
         <source>This Keycard has empty metadata</source>
         <translation>This Keycard has empty metadata</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="520" />
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="520" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="678" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="678" />
         <source>This Keycard already stores keys
 but doesn't store any metadata</source>
         <translation>This Keycard already stores keys
 but doesn't store any metadata</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="530" />
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="530" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="688" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="688" />
         <source>Keycard is empty</source>
         <translation>Keycard is empty</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="542" />
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="542" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="700" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="700" />
         <source>There is no key pair on this Keycard</source>
         <translation>There is no key pair on this Keycard</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="552" />
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="552" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="710" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="710" />
         <source>This Keycard already stores keys</source>
         <translation>This Keycard already stores keys</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="565" />
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="565" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="724" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="724" />
         <source>To migrate %1 on to this Keycard, you
 will need to perform a factory reset first</source>
         <translation>To migrate %1 on to this Keycard, you
 will need to perform a factory reset first</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="580" />
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="580" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="728" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="728" />
+        <source>To copy %1 on to this Keycard, you
+will need to perform a factory reset first</source>
+        <translation>To copy %1 on to this Keycard, you
+will need to perform a factory reset first</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="747" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="747" />
         <source>Keycard locked and already stores keys</source>
         <translation>Keycard locked and already stores keys</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="580" />
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="580" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="747" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="747" />
         <source>Keycard locked</source>
         <translation>Keycard locked</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="601" />
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="601" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="770" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="770" />
         <source>The Keycard you have inserted is locked,
 you will need to factory reset it before proceeding</source>
         <translation>The Keycard you have inserted is locked,
 you will need to factory reset it before proceeding</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="602" />
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="602" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="771" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="771" />
         <source>You will need to unlock it before proceeding</source>
         <translation>You will need to unlock it before proceeding</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="605" />
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="605" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="774" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="774" />
         <source>Pin entered incorrectly too many times</source>
         <translation>Pin entered incorrectly too many times</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="607" />
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="607" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="776" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="776" />
         <source>Puk entered incorrectly too many times</source>
         <translation>Puk entered incorrectly too many times</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="609" />
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="609" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="778" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="778" />
         <source>Max pairing slots reached for the entered keycard</source>
         <translation>Max pairing slots reached for the entered keycard</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="622" />
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="622" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="792" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="792" />
         <source>Your Keycard is already unlocked!</source>
         <translation>Your Keycard is already unlocked!</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="647" />
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="647" />
-        <source>Unlock successful</source>
-        <translation>Unlock successful</translation>
-    </message>
-    <message>
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="672" />
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="672" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="817" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="817" />
         <source>Keycard recognized</source>
         <translation>Keycard recognized</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="698" />
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="698" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="850" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="850" />
+        <source>Key pair successfully migrated</source>
+        <translation>Key pair successfully migrated</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="855" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="855" />
         <source>Your Keycard has been reset</source>
         <translation>Your Keycard has been reset</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="699" />
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="699" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="856" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="856" />
         <source>Keycard successfully factory reset</source>
         <translation>Keycard successfully factory reset</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="717" />
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="717" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="859" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="859" />
+        <source>Unlock successful</source>
+        <translation>Unlock successful</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="862" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="862" />
+        <source>Keycard successfully renamed</source>
+        <translation>Keycard successfully renamed</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="865" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="865" />
+        <source>Keycard&#8217;s PUK successfully set</source>
+        <translation>Keycard&#8217;s PUK successfully set</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="868" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="868" />
+        <source>Pairing code successfully set</source>
+        <translation>Pairing code successfully set</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="871" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="871" />
+        <source>This Keycard is now a copy of %1</source>
+        <translation>This Keycard is now a copy of %1</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="894" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="894" />
+        <source>To complete migration close Status and log in with your new Keycard</source>
+        <translation>To complete migration close Status and log in with your new Keycard</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="899" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="899" />
         <source>You can now create a new key pair on this Keycard</source>
         <translation>You can now create a new key pair on this Keycard</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="718" />
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="718" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="900" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="900" />
         <source>You can now use this Keycard as if it
 was a brand new empty Keycard</source>
         <translation>You can now use this Keycard as if it
 was a brand new empty Keycard</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="731" />
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="731" />
-        <source>Key pair successfully migrated</source>
-        <translation>Key pair successfully migrated</translation>
-    </message>
-    <message>
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="734" />
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="734" />
-        <source>Keycard successfully renamed</source>
-        <translation>Keycard successfully renamed</translation>
-    </message>
-    <message>
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="756" />
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="756" />
-        <source>To complete migration close Status and log in with your new Keycard</source>
-        <translation>To complete migration close Status and log in with your new Keycard</translation>
-    </message>
-    <message>
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="772" />
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="772" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="919" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="919" />
         <source>Key pair failed to migrated</source>
         <translation>Key pair failed to migrated</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="775" />
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="775" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="922" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="922" />
         <source>Keycard renaming failed</source>
         <translation>Keycard renaming failed</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="803" />
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="803" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="925" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="925" />
+        <source>Setting Keycard&#8217;s PUK failed</source>
+        <translation>Setting Keycard&#8217;s PUK failed</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="928" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="928" />
+        <source>Setting pairing code failed</source>
+        <translation>Setting pairing code failed</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="931" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="931" />
+        <source>Copying %1 Keycard failed</source>
+        <translation>Copying %1 Keycard failed</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="960" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="960" />
         <source>Accounts on this Keycard</source>
         <translation>Accounts on this Keycard</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="823" />
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="823" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="980" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="980" />
         <source>Ready to authenticate...</source>
         <translation>Ready to authenticate...</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="848" />
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="869" />
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="848" />
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="869" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="1005" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="1026" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="1005" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="1026" />
         <source>Biometric scan failed</source>
         <translation>Biometric scan failed</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="855" />
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="876" />
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="855" />
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="876" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="1012" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="1033" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="1012" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="1033" />
         <source>Biometrics incorrect</source>
         <translation>Biometrics incorrect</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="890" />
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="890" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="1047" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="1047" />
         <source>Biometric pin invalid</source>
         <translation>Biometric pin invalid</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="897" />
-        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="897" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="1054" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="1054" />
         <source>The PIN length doesn't match Keycard's PIN length</source>
         <translation>The PIN length doesn't match Keycard's PIN length</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="1064" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="1064" />
+        <source>Remove Keycard</source>
+        <translation>Remove Keycard</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="1089" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="1089" />
+        <source>Oops this is the same Keycard!</source>
+        <translation>Oops this is the same Keycard!</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="1106" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="1106" />
+        <source>You need to remove this Keycard and insert
+an empty new or factory reset Keycard</source>
+        <translation>You need to remove this Keycard and insert
+an empty new or factory reset Keycard</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="1116" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardInit.qml" line="1116" />
+        <source>Copy &#8220;%1&#8221; to inserted keycard</source>
+        <translation>Copy &#8220;%1&#8221; to inserted keycard</translation>
     </message>
 </context>
 <context>
@@ -8256,86 +8162,121 @@ was a brand new empty Keycard</translation>
 <context>
     <name>KeycardPin</name>
     <message>
-        <location filename="../imports/shared/popups/keycard/states/KeycardPin.qml" line="138" />
-        <location filename="../imports/shared/popups/keycard/states/KeycardPin.qml" line="328" />
-        <location filename="../imports/shared/popups/keycard/states/KeycardPin.qml" line="357" />
-        <location filename="../imports/shared/popups/keycard/states/KeycardPin.qml" line="138" />
-        <location filename="../imports/shared/popups/keycard/states/KeycardPin.qml" line="328" />
-        <location filename="../imports/shared/popups/keycard/states/KeycardPin.qml" line="357" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardPin.qml" line="62" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardPin.qml" line="62" />
         <source>It is very important that you do not lose this PIN</source>
         <translation>It is very important that you do not lose this PIN</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/keycard/states/KeycardPin.qml" line="141" />
-        <location filename="../imports/shared/popups/keycard/states/KeycardPin.qml" line="141" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardPin.qml" line="63" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardPin.qml" line="63" />
+        <source>Don&#8217;t lose your PIN! If you do, you may lose
+access to your funds.</source>
+        <translation>Don&#8217;t lose your PIN! If you do, you may lose
+access to your funds.</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/popups/keycard/states/KeycardPin.qml" line="155" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardPin.qml" line="155" />
         <source>PINs don't match</source>
         <translation>PINs don't match</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/keycard/states/KeycardPin.qml" line="223" />
-        <location filename="../imports/shared/popups/keycard/states/KeycardPin.qml" line="223" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardPin.qml" line="241" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardPin.qml" line="241" />
+        <source>Enter the Keycard PIN</source>
+        <translation>Enter the Keycard PIN</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/popups/keycard/states/KeycardPin.qml" line="243" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardPin.qml" line="243" />
         <source>Enter this Keycard&#8217;s PIN</source>
         <translation>Enter this Keycard&#8217;s PIN</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/keycard/states/KeycardPin.qml" line="250" />
-        <location filename="../imports/shared/popups/keycard/states/KeycardPin.qml" line="250" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardPin.qml" line="271" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardPin.qml" line="271" />
         <source>Enter Keycard PIN</source>
         <translation>Enter Keycard PIN</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/keycard/states/KeycardPin.qml" line="260" />
-        <location filename="../imports/shared/popups/keycard/states/KeycardPin.qml" line="295" />
-        <location filename="../imports/shared/popups/keycard/states/KeycardPin.qml" line="260" />
-        <location filename="../imports/shared/popups/keycard/states/KeycardPin.qml" line="295" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardPin.qml" line="281" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardPin.qml" line="316" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardPin.qml" line="281" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardPin.qml" line="316" />
         <source>PIN incorrect</source>
         <translation>PIN incorrect</translation>
     </message>
     <message numerus="yes">
-        <location filename="../imports/shared/popups/keycard/states/KeycardPin.qml" line="266" />
-        <location filename="../imports/shared/popups/keycard/states/KeycardPin.qml" line="301" />
-        <location filename="../imports/shared/popups/keycard/states/KeycardPin.qml" line="266" />
-        <location filename="../imports/shared/popups/keycard/states/KeycardPin.qml" line="301" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardPin.qml" line="287" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardPin.qml" line="322" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardPin.qml" line="287" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardPin.qml" line="322" />
         <source>%n attempt(s) remaining</source>
         <translation type="unfinished">
+            <numerusform />
             <numerusform />
         </translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/keycard/states/KeycardPin.qml" line="283" />
-        <location filename="../imports/shared/popups/keycard/states/KeycardPin.qml" line="283" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardPin.qml" line="304" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardPin.qml" line="304" />
         <source>Your saved PIN is out of date</source>
         <translation>Your saved PIN is out of date</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/keycard/states/KeycardPin.qml" line="289" />
-        <location filename="../imports/shared/popups/keycard/states/KeycardPin.qml" line="289" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardPin.qml" line="310" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardPin.qml" line="310" />
         <source>Enter your new PIN to proceed</source>
         <translation>Enter your new PIN to proceed</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/keycard/states/KeycardPin.qml" line="318" />
-        <location filename="../imports/shared/popups/keycard/states/KeycardPin.qml" line="318" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardPin.qml" line="341" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardPin.qml" line="341" />
+        <source>Enter new Keycard PIN</source>
+        <translation>Enter new Keycard PIN</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/popups/keycard/states/KeycardPin.qml" line="343" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardPin.qml" line="343" />
         <source>Choose a Keycard PIN</source>
         <translation>Choose a Keycard PIN</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/keycard/states/KeycardPin.qml" line="347" />
-        <location filename="../imports/shared/popups/keycard/states/KeycardPin.qml" line="347" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardPin.qml" line="380" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardPin.qml" line="380" />
+        <source>Repeat new Keycard PIN</source>
+        <translation>Repeat new Keycard PIN</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/popups/keycard/states/KeycardPin.qml" line="382" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardPin.qml" line="382" />
         <source>Repeat Keycard PIN</source>
         <translation>Repeat Keycard PIN</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/keycard/states/KeycardPin.qml" line="381" />
-        <location filename="../imports/shared/popups/keycard/states/KeycardPin.qml" line="381" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardPin.qml" line="426" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardPin.qml" line="426" />
         <source>Keycard PIN set</source>
         <translation>Keycard PIN set</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/keycard/states/KeycardPin.qml" line="413" />
-        <location filename="../imports/shared/popups/keycard/states/KeycardPin.qml" line="413" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardPin.qml" line="429" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardPin.qml" line="429" />
         <source>Keycard PIN verified!</source>
         <translation>Keycard PIN verified!</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/popups/keycard/states/KeycardPin.qml" line="432" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardPin.qml" line="432" />
+        <source>PIN successfully changed</source>
+        <translation>PIN successfully changed</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/popups/keycard/states/KeycardPin.qml" line="469" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardPin.qml" line="469" />
+        <source>Changing PIN failed</source>
+        <translation>Changing PIN failed</translation>
     </message>
 </context>
 <context>
@@ -8394,259 +8335,360 @@ was a brand new empty Keycard</translation>
         <source>%n attempt(s) remaining</source>
         <translation type="unfinished">
             <numerusform />
+            <numerusform />
         </translation>
     </message>
 </context>
 <context>
     <name>KeycardPopup</name>
     <message>
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="47" />
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="47" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="21" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="21" />
         <source>Set up a new Keycard with an existing account</source>
         <translation>Set up a new Keycard with an existing account</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="50" />
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="50" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="23" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="23" />
         <source>Factory reset a Keycard</source>
         <translation>Factory reset a Keycard</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="53" />
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="628" />
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="53" />
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="628" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="25" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="25" />
         <source>Authenticate</source>
         <translation>Authenticate</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="56" />
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="579" />
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="609" />
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="648" />
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="670" />
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="688" />
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="708" />
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="56" />
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="579" />
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="609" />
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="648" />
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="670" />
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="688" />
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="708" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="27" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="27" />
         <source>Unlock Keycard</source>
         <translation>Unlock Keycard</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="59" />
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="59" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="29" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="29" />
         <source>Check what&#8217;s on a Keycard</source>
         <translation>Check what&#8217;s on a Keycard</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="62" />
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="62" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="31" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="31" />
         <source>Rename Keycard</source>
         <translation>Rename Keycard</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="356" />
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="376" />
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="400" />
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="413" />
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="428" />
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="444" />
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="356" />
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="376" />
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="400" />
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="413" />
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="428" />
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="444" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="33" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="33" />
+        <source>Change pin</source>
+        <translation>Change pin</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="35" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="35" />
+        <source>Create a 12-digit personal unblocking key (PUK)</source>
+        <translation>Create a 12-digit personal unblocking key (PUK)</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="37" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="37" />
+        <source>Create a new pairing code</source>
+        <translation>Create a new pairing code</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="39" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="39" />
+        <source>Create a backup copy of this Keycard</source>
+        <translation>Create a backup copy of this Keycard</translation>
+    </message>
+</context>
+<context>
+    <name>KeycardPopupDetails</name>
+    <message>
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="49" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="49" />
         <source>Cancel</source>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="473" />
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="473" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="304" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="304" />
         <source>Use biometrics instead</source>
         <translation>Use biometrics instead</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="475" />
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="475" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="307" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="307" />
         <source>Use password instead</source>
         <translation>Use password instead</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="478" />
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="478" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="311" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="311" />
         <source>Use biometrics</source>
         <translation>Use biometrics</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="488" />
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="488" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="322" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="322" />
         <source>Use PIN</source>
         <translation>Use PIN</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="490" />
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="490" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="325" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="325" />
         <source>Update PIN</source>
         <translation>Update PIN</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="495" />
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="495" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="334" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="334" />
         <source>Unlock using PUK</source>
         <translation>Unlock using PUK</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="545" />
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="545" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="409" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="409" />
         <source>Input seed phrase</source>
         <translation>Input seed phrase</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="548" />
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="548" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="412" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="412" />
         <source>Yes, migrate key pair to this Keycard</source>
         <translation>Yes, migrate key pair to this Keycard</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="551" />
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="551" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="415" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="415" />
         <source>Yes, migrate key pair to Keycard</source>
         <translation>Yes, migrate key pair to Keycard</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="554" />
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="667" />
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="554" />
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="667" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="418" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="545" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="704" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="418" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="545" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="704" />
         <source>Try entering seed phrase again</source>
         <translation>Try entering seed phrase again</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="557" />
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="557" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="421" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="721" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="421" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="721" />
         <source>Check what is stored on this Keycard</source>
         <translation>Check what is stored on this Keycard</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="561" />
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="595" />
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="680" />
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="699" />
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="561" />
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="595" />
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="680" />
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="699" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="425" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="463" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="562" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="586" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="612" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="634" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="656" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="678" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="425" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="463" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="562" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="586" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="612" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="634" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="656" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="678" />
         <source>I don&#8217;t know the PIN</source>
         <translation>I don&#8217;t know the PIN</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="565" />
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="599" />
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="565" />
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="599" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="429" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="467" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="725" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="429" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="467" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="725" />
         <source>Factory reset this Keycard</source>
         <translation>Factory reset this Keycard</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="573" />
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="580" />
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="604" />
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="665" />
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="683" />
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="703" />
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="573" />
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="580" />
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="604" />
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="665" />
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="683" />
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="703" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="437" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="444" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="472" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="542" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="565" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="590" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="615" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="637" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="659" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="695" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="699" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="437" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="444" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="472" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="542" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="565" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="590" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="615" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="637" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="659" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="695" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="699" />
         <source>Next</source>
         <translation>Next</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="584" />
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="589" />
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="613" />
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="631" />
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="656" />
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="677" />
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="697" />
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="584" />
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="589" />
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="613" />
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="631" />
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="656" />
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="677" />
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="697" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="443" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="477" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="519" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="548" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="570" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="595" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="620" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="642" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="664" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="709" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="443" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="477" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="519" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="548" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="570" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="595" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="620" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="642" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="664" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="709" />
+        <source>Unlock Keycard</source>
+        <translation>Unlock Keycard</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="448" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="453" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="481" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="502" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="531" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="559" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="583" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="609" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="631" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="653" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="687" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="701" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="448" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="453" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="481" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="502" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="531" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="559" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="583" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="609" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="631" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="653" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="687" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="701" />
         <source>Done</source>
         <translation>Done</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="588" />
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="588" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="452" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="452" />
         <source>Restart app &amp; sign in using your new Keycard</source>
         <translation>Restart app &amp; sign in using your new Keycard</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="635" />
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="635" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="499" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="499" />
+        <source>Authenticate</source>
+        <translation>Authenticate</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="506" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="506" />
         <source>Update password &amp; authenticate</source>
         <translation>Update password &amp; authenticate</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="638" />
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="638" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="509" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="509" />
         <source>Update PIN &amp; authenticate</source>
         <translation>Update PIN &amp; authenticate</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="643" />
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="643" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="514" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="514" />
         <source>Try biometrics again</source>
         <translation>Try biometrics again</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="658" />
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="658" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="534" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="534" />
         <source>Unlock using seed phrase</source>
         <translation>Unlock using seed phrase</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="711" />
-        <location filename="../imports/shared/popups/keycard/KeycardPopup.qml" line="711" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="598" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="598" />
         <source>Rename this Keycard</source>
         <translation>Rename this Keycard</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="667" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="667" />
+        <source>Set paring code</source>
+        <translation>Set paring code</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="712" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="716" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="712" />
+        <location filename="../imports/shared/popups/keycard/KeycardPopupDetails.qml" line="716" />
+        <source>Try inserting a different Keycard</source>
+        <translation>Try inserting a different Keycard</translation>
     </message>
 </context>
 <context>
     <name>KeycardPuk</name>
     <message>
-        <location filename="../imports/shared/popups/keycard/states/KeycardPuk.qml" line="110" />
-        <location filename="../imports/shared/popups/keycard/states/KeycardPuk.qml" line="133" />
-        <location filename="../imports/shared/popups/keycard/states/KeycardPuk.qml" line="110" />
-        <location filename="../imports/shared/popups/keycard/states/KeycardPuk.qml" line="133" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardPuk.qml" line="86" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardPuk.qml" line="86" />
+        <source>The PUK doesn&#8217;t match</source>
+        <translation>The PUK doesn&#8217;t match</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/popups/keycard/states/KeycardPuk.qml" line="125" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardPuk.qml" line="148" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardPuk.qml" line="125" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardPuk.qml" line="148" />
         <source>Enter PUK</source>
         <translation>Enter PUK</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/keycard/states/KeycardPuk.qml" line="139" />
-        <location filename="../imports/shared/popups/keycard/states/KeycardPuk.qml" line="139" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardPuk.qml" line="154" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardPuk.qml" line="154" />
         <source>The PUK is incorrect, try entering it again</source>
         <translation>The PUK is incorrect, try entering it again</translation>
     </message>
     <message numerus="yes">
-        <location filename="../imports/shared/popups/keycard/states/KeycardPuk.qml" line="145" />
-        <location filename="../imports/shared/popups/keycard/states/KeycardPuk.qml" line="145" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardPuk.qml" line="160" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardPuk.qml" line="160" />
         <source>%n attempt(s) remaining</source>
         <translation type="unfinished">
             <numerusform />
+            <numerusform />
         </translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/popups/keycard/states/KeycardPuk.qml" line="177" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardPuk.qml" line="177" />
+        <source>Choose a Keycard PUK</source>
+        <translation>Choose a Keycard PUK</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/popups/keycard/states/KeycardPuk.qml" line="200" />
+        <location filename="../imports/shared/popups/keycard/states/KeycardPuk.qml" line="200" />
+        <source>Repeat your Keycard PUK</source>
+        <translation>Repeat your Keycard PUK</translation>
     </message>
 </context>
 <context>
@@ -8668,6 +8710,7 @@ was a brand new empty Keycard</translation>
         <location filename="../app/AppLayouts/Onboarding/views/KeycardPukView.qml" line="182" />
         <source>Invalid PUK code, %n attempt(s) remaining</source>
         <translation type="unfinished">
+            <numerusform />
             <numerusform />
         </translation>
     </message>
@@ -8859,56 +8902,62 @@ Max pairing slots reached for this keycard</translation>
         <translation>Use your existing Status keys to login to this device.</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Onboarding/views/KeysMainView.qml" line="159" />
-        <location filename="../app/AppLayouts/Onboarding/views/KeysMainView.qml" line="159" />
+        <location filename="../app/AppLayouts/Onboarding/views/KeysMainView.qml" line="154" />
+        <location filename="../app/AppLayouts/Onboarding/views/KeysMainView.qml" line="154" />
+        <source>Login with Keycard</source>
+        <translation>Login with Keycard</translation>
+    </message>
+    <message>
+        <location filename="../app/AppLayouts/Onboarding/views/KeysMainView.qml" line="158" />
+        <location filename="../app/AppLayouts/Onboarding/views/KeysMainView.qml" line="158" />
         <source>Enter a seed phrase</source>
         <translation>Enter a seed phrase</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Onboarding/views/KeysMainView.qml" line="172" />
-        <location filename="../app/AppLayouts/Onboarding/views/KeysMainView.qml" line="172" />
+        <location filename="../app/AppLayouts/Onboarding/views/KeysMainView.qml" line="171" />
+        <location filename="../app/AppLayouts/Onboarding/views/KeysMainView.qml" line="171" />
         <source>Get your keys</source>
         <translation>Get your keys</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Onboarding/views/KeysMainView.qml" line="176" />
-        <location filename="../app/AppLayouts/Onboarding/views/KeysMainView.qml" line="176" />
+        <location filename="../app/AppLayouts/Onboarding/views/KeysMainView.qml" line="175" />
+        <location filename="../app/AppLayouts/Onboarding/views/KeysMainView.qml" line="175" />
         <source>A set of keys controls your account. Your keys live on your
 device, so only you can use them.</source>
         <translation>A set of keys controls your account. Your keys live on your
 device, so only you can use them.</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Onboarding/views/KeysMainView.qml" line="180" />
-        <location filename="../app/AppLayouts/Onboarding/views/KeysMainView.qml" line="180" />
+        <location filename="../app/AppLayouts/Onboarding/views/KeysMainView.qml" line="179" />
+        <location filename="../app/AppLayouts/Onboarding/views/KeysMainView.qml" line="179" />
         <source>Generate new keys</source>
         <translation>Generate new keys</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Onboarding/views/KeysMainView.qml" line="186" />
-        <location filename="../app/AppLayouts/Onboarding/views/KeysMainView.qml" line="186" />
+        <location filename="../app/AppLayouts/Onboarding/views/KeysMainView.qml" line="185" />
+        <location filename="../app/AppLayouts/Onboarding/views/KeysMainView.qml" line="185" />
         <source>Generate keys for a new Keycard</source>
         <translation>Generate keys for a new Keycard</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Onboarding/views/KeysMainView.qml" line="190" />
-        <location filename="../app/AppLayouts/Onboarding/views/KeysMainView.qml" line="203" />
-        <location filename="../app/AppLayouts/Onboarding/views/KeysMainView.qml" line="218" />
-        <location filename="../app/AppLayouts/Onboarding/views/KeysMainView.qml" line="190" />
-        <location filename="../app/AppLayouts/Onboarding/views/KeysMainView.qml" line="203" />
-        <location filename="../app/AppLayouts/Onboarding/views/KeysMainView.qml" line="218" />
+        <location filename="../app/AppLayouts/Onboarding/views/KeysMainView.qml" line="189" />
+        <location filename="../app/AppLayouts/Onboarding/views/KeysMainView.qml" line="202" />
+        <location filename="../app/AppLayouts/Onboarding/views/KeysMainView.qml" line="217" />
+        <location filename="../app/AppLayouts/Onboarding/views/KeysMainView.qml" line="189" />
+        <location filename="../app/AppLayouts/Onboarding/views/KeysMainView.qml" line="202" />
+        <location filename="../app/AppLayouts/Onboarding/views/KeysMainView.qml" line="217" />
         <source>Import a seed phrase</source>
         <translation>Import a seed phrase</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Onboarding/views/KeysMainView.qml" line="213" />
-        <location filename="../app/AppLayouts/Onboarding/views/KeysMainView.qml" line="213" />
+        <location filename="../app/AppLayouts/Onboarding/views/KeysMainView.qml" line="212" />
+        <location filename="../app/AppLayouts/Onboarding/views/KeysMainView.qml" line="212" />
         <source>Seed phrases are used to back up and restore your keys. Only use this option if you already have a seed phrase.</source>
         <translation>Seed phrases are used to back up and restore your keys. Only use this option if you already have a seed phrase.</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Onboarding/views/KeysMainView.qml" line="224" />
-        <location filename="../app/AppLayouts/Onboarding/views/KeysMainView.qml" line="224" />
+        <location filename="../app/AppLayouts/Onboarding/views/KeysMainView.qml" line="223" />
+        <location filename="../app/AppLayouts/Onboarding/views/KeysMainView.qml" line="223" />
         <source>Import a seed phrase into a new Keycard</source>
         <translation>Import a seed phrase into a new Keycard</translation>
     </message>
@@ -8916,92 +8965,92 @@ device, so only you can use them.</translation>
 <context>
     <name>LanguageView</name>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/LanguageView.qml" line="57" />
-        <location filename="../app/AppLayouts/Profile/views/LanguageView.qml" line="57" />
+        <location filename="../app/AppLayouts/Profile/views/LanguageView.qml" line="58" />
+        <location filename="../app/AppLayouts/Profile/views/LanguageView.qml" line="58" />
         <source>Set Display Currency</source>
         <translation>Set Display Currency</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/LanguageView.qml" line="82" />
-        <location filename="../app/AppLayouts/Profile/views/LanguageView.qml" line="82" />
+        <location filename="../app/AppLayouts/Profile/views/LanguageView.qml" line="83" />
+        <location filename="../app/AppLayouts/Profile/views/LanguageView.qml" line="83" />
         <source>Search Currencies</source>
         <translation>Search Currencies</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/LanguageView.qml" line="103" />
-        <location filename="../app/AppLayouts/Profile/views/LanguageView.qml" line="103" />
+        <location filename="../app/AppLayouts/Profile/views/LanguageView.qml" line="104" />
+        <location filename="../app/AppLayouts/Profile/views/LanguageView.qml" line="104" />
         <source>Language</source>
         <translation>Language</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/LanguageView.qml" line="114" />
-        <location filename="../app/AppLayouts/Profile/views/LanguageView.qml" line="114" />
+        <location filename="../app/AppLayouts/Profile/views/LanguageView.qml" line="115" />
+        <location filename="../app/AppLayouts/Profile/views/LanguageView.qml" line="115" />
         <source>Alpha languages</source>
         <translation>Alpha languages</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/LanguageView.qml" line="115" />
-        <location filename="../app/AppLayouts/Profile/views/LanguageView.qml" line="115" />
+        <location filename="../app/AppLayouts/Profile/views/LanguageView.qml" line="116" />
+        <location filename="../app/AppLayouts/Profile/views/LanguageView.qml" line="116" />
         <source>Beta languages</source>
         <translation>Beta languages</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/LanguageView.qml" line="166" />
-        <location filename="../app/AppLayouts/Profile/views/LanguageView.qml" line="166" />
+        <location filename="../app/AppLayouts/Profile/views/LanguageView.qml" line="167" />
+        <location filename="../app/AppLayouts/Profile/views/LanguageView.qml" line="167" />
         <source>Search Languages</source>
         <translation>Search Languages</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/LanguageView.qml" line="201" />
-        <location filename="../app/AppLayouts/Profile/views/LanguageView.qml" line="201" />
+        <location filename="../app/AppLayouts/Profile/views/LanguageView.qml" line="202" />
+        <location filename="../app/AppLayouts/Profile/views/LanguageView.qml" line="202" />
         <source>Date Format</source>
         <translation>Date Format</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/LanguageView.qml" line="208" />
-        <location filename="../app/AppLayouts/Profile/views/LanguageView.qml" line="208" />
+        <location filename="../app/AppLayouts/Profile/views/LanguageView.qml" line="209" />
+        <location filename="../app/AppLayouts/Profile/views/LanguageView.qml" line="209" />
         <source>DD/MM/YY</source>
         <translation>DD/MM/YY</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/LanguageView.qml" line="215" />
-        <location filename="../app/AppLayouts/Profile/views/LanguageView.qml" line="215" />
+        <location filename="../app/AppLayouts/Profile/views/LanguageView.qml" line="216" />
+        <location filename="../app/AppLayouts/Profile/views/LanguageView.qml" line="216" />
         <source>MM/DD/YY</source>
         <translation>MM/DD/YY</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/LanguageView.qml" line="230" />
-        <location filename="../app/AppLayouts/Profile/views/LanguageView.qml" line="230" />
+        <location filename="../app/AppLayouts/Profile/views/LanguageView.qml" line="231" />
+        <location filename="../app/AppLayouts/Profile/views/LanguageView.qml" line="231" />
         <source>Time Format</source>
         <translation>Time Format</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/LanguageView.qml" line="237" />
-        <location filename="../app/AppLayouts/Profile/views/LanguageView.qml" line="237" />
+        <location filename="../app/AppLayouts/Profile/views/LanguageView.qml" line="238" />
+        <location filename="../app/AppLayouts/Profile/views/LanguageView.qml" line="238" />
         <source>24-Hour Time</source>
         <translation>24-Hour Time</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/LanguageView.qml" line="244" />
-        <location filename="../app/AppLayouts/Profile/views/LanguageView.qml" line="244" />
+        <location filename="../app/AppLayouts/Profile/views/LanguageView.qml" line="245" />
+        <location filename="../app/AppLayouts/Profile/views/LanguageView.qml" line="245" />
         <source>12-Hour Time</source>
         <translation>12-Hour Time</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/LanguageView.qml" line="258" />
-        <location filename="../app/AppLayouts/Profile/views/LanguageView.qml" line="258" />
+        <location filename="../app/AppLayouts/Profile/views/LanguageView.qml" line="259" />
+        <location filename="../app/AppLayouts/Profile/views/LanguageView.qml" line="259" />
         <source>Change language</source>
         <translation>Change language</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/LanguageView.qml" line="259" />
-        <location filename="../app/AppLayouts/Profile/views/LanguageView.qml" line="259" />
+        <location filename="../app/AppLayouts/Profile/views/LanguageView.qml" line="260" />
+        <location filename="../app/AppLayouts/Profile/views/LanguageView.qml" line="260" />
         <source>Display language has been changed. You must restart the application for changes to take effect.</source>
         <translation>Display language has been changed. You must restart the application for changes to take effect.</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/LanguageView.qml" line="260" />
-        <location filename="../app/AppLayouts/Profile/views/LanguageView.qml" line="260" />
+        <location filename="../app/AppLayouts/Profile/views/LanguageView.qml" line="261" />
+        <location filename="../app/AppLayouts/Profile/views/LanguageView.qml" line="261" />
         <source>Close the app now</source>
         <translation>Close the app now</translation>
     </message>
@@ -9021,50 +9070,26 @@ device, so only you can use them.</translation>
         <translation>USER LIMIT REACHED</translation>
     </message>
     <message>
-        <location filename="../StatusQ/sandbox/controls/Layout.qml" line="208" />
-        <location filename="../StatusQ/sandbox/controls/Layout.qml" line="291" />
-        <location filename="../StatusQ/sandbox/controls/Layout.qml" line="379" />
-        <location filename="../StatusQ/sandbox/controls/Layout.qml" line="472" />
-        <location filename="../StatusQ/sandbox/controls/Layout.qml" line="208" />
-        <location filename="../StatusQ/sandbox/controls/Layout.qml" line="291" />
-        <location filename="../StatusQ/sandbox/controls/Layout.qml" line="379" />
-        <location filename="../StatusQ/sandbox/controls/Layout.qml" line="472" />
+        <location filename="../StatusQ/sandbox/controls/Layout.qml" line="401" />
+        <location filename="../StatusQ/sandbox/controls/Layout.qml" line="401" />
         <source>Invite People</source>
         <translation>Invite People</translation>
     </message>
     <message>
-        <location filename="../StatusQ/sandbox/controls/Layout.qml" line="213" />
-        <location filename="../StatusQ/sandbox/controls/Layout.qml" line="296" />
-        <location filename="../StatusQ/sandbox/controls/Layout.qml" line="384" />
-        <location filename="../StatusQ/sandbox/controls/Layout.qml" line="477" />
-        <location filename="../StatusQ/sandbox/controls/Layout.qml" line="213" />
-        <location filename="../StatusQ/sandbox/controls/Layout.qml" line="296" />
-        <location filename="../StatusQ/sandbox/controls/Layout.qml" line="384" />
-        <location filename="../StatusQ/sandbox/controls/Layout.qml" line="477" />
+        <location filename="../StatusQ/sandbox/controls/Layout.qml" line="406" />
+        <location filename="../StatusQ/sandbox/controls/Layout.qml" line="406" />
         <source>View Community</source>
         <translation>View Community</translation>
     </message>
     <message>
-        <location filename="../StatusQ/sandbox/controls/Layout.qml" line="218" />
-        <location filename="../StatusQ/sandbox/controls/Layout.qml" line="301" />
-        <location filename="../StatusQ/sandbox/controls/Layout.qml" line="389" />
-        <location filename="../StatusQ/sandbox/controls/Layout.qml" line="482" />
-        <location filename="../StatusQ/sandbox/controls/Layout.qml" line="218" />
-        <location filename="../StatusQ/sandbox/controls/Layout.qml" line="301" />
-        <location filename="../StatusQ/sandbox/controls/Layout.qml" line="389" />
-        <location filename="../StatusQ/sandbox/controls/Layout.qml" line="482" />
+        <location filename="../StatusQ/sandbox/controls/Layout.qml" line="411" />
+        <location filename="../StatusQ/sandbox/controls/Layout.qml" line="411" />
         <source>Edit Community</source>
         <translation>Edit Community</translation>
     </message>
     <message>
-        <location filename="../StatusQ/sandbox/controls/Layout.qml" line="226" />
-        <location filename="../StatusQ/sandbox/controls/Layout.qml" line="309" />
-        <location filename="../StatusQ/sandbox/controls/Layout.qml" line="397" />
-        <location filename="../StatusQ/sandbox/controls/Layout.qml" line="490" />
-        <location filename="../StatusQ/sandbox/controls/Layout.qml" line="226" />
-        <location filename="../StatusQ/sandbox/controls/Layout.qml" line="309" />
-        <location filename="../StatusQ/sandbox/controls/Layout.qml" line="397" />
-        <location filename="../StatusQ/sandbox/controls/Layout.qml" line="490" />
+        <location filename="../StatusQ/sandbox/controls/Layout.qml" line="419" />
+        <location filename="../StatusQ/sandbox/controls/Layout.qml" line="419" />
         <source>Leave Community</source>
         <translation>Leave Community</translation>
     </message>
@@ -9096,26 +9121,26 @@ device, so only you can use them.</translation>
         <translation>Sign out &amp; Quit</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/views/LeftTabView.qml" line="48" />
-        <location filename="../app/AppLayouts/Wallet/views/LeftTabView.qml" line="48" />
+        <location filename="../app/AppLayouts/Wallet/views/LeftTabView.qml" line="71" />
+        <location filename="../app/AppLayouts/Wallet/views/LeftTabView.qml" line="71" />
         <source>Wallet</source>
         <translation>Wallet</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/views/LeftTabView.qml" line="74" />
-        <location filename="../app/AppLayouts/Wallet/views/LeftTabView.qml" line="74" />
+        <location filename="../app/AppLayouts/Wallet/views/LeftTabView.qml" line="98" />
+        <location filename="../app/AppLayouts/Wallet/views/LeftTabView.qml" line="98" />
         <source>Total value</source>
         <translation>Total value</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/views/LeftTabView.qml" line="120" />
-        <location filename="../app/AppLayouts/Wallet/views/LeftTabView.qml" line="120" />
+        <location filename="../app/AppLayouts/Wallet/views/LeftTabView.qml" line="146" />
+        <location filename="../app/AppLayouts/Wallet/views/LeftTabView.qml" line="146" />
         <source>Add account</source>
         <translation>Add account</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/views/LeftTabView.qml" line="137" />
-        <location filename="../app/AppLayouts/Wallet/views/LeftTabView.qml" line="137" />
+        <location filename="../app/AppLayouts/Wallet/views/LeftTabView.qml" line="163" />
+        <location filename="../app/AppLayouts/Wallet/views/LeftTabView.qml" line="163" />
         <source>Saved addresses</source>
         <translation>Saved addresses</translation>
     </message>
@@ -9123,32 +9148,32 @@ device, so only you can use them.</translation>
 <context>
     <name>LinksMessageView</name>
     <message>
-        <location filename="../imports/shared/views/chat/LinksMessageView.qml" line="366" />
-        <location filename="../imports/shared/views/chat/LinksMessageView.qml" line="366" />
+        <location filename="../imports/shared/views/chat/LinksMessageView.qml" line="362" />
+        <location filename="../imports/shared/views/chat/LinksMessageView.qml" line="362" />
         <source>Enable automatic image unfurling</source>
         <translation>Enable automatic image unfurling</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/chat/LinksMessageView.qml" line="367" />
-        <location filename="../imports/shared/views/chat/LinksMessageView.qml" line="367" />
+        <location filename="../imports/shared/views/chat/LinksMessageView.qml" line="363" />
+        <location filename="../imports/shared/views/chat/LinksMessageView.qml" line="363" />
         <source>Enable link previews in chat?</source>
         <translation>Enable link previews in chat?</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/chat/LinksMessageView.qml" line="379" />
-        <location filename="../imports/shared/views/chat/LinksMessageView.qml" line="379" />
+        <location filename="../imports/shared/views/chat/LinksMessageView.qml" line="374" />
+        <location filename="../imports/shared/views/chat/LinksMessageView.qml" line="374" />
         <source>Once enabled, links posted in the chat may share your metadata with their owners</source>
         <translation>Once enabled, links posted in the chat may share your metadata with their owners</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/chat/LinksMessageView.qml" line="397" />
-        <location filename="../imports/shared/views/chat/LinksMessageView.qml" line="397" />
+        <location filename="../imports/shared/views/chat/LinksMessageView.qml" line="392" />
+        <location filename="../imports/shared/views/chat/LinksMessageView.qml" line="392" />
         <source>Enable in Settings</source>
         <translation>Enable in Settings</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/chat/LinksMessageView.qml" line="431" />
-        <location filename="../imports/shared/views/chat/LinksMessageView.qml" line="431" />
+        <location filename="../imports/shared/views/chat/LinksMessageView.qml" line="426" />
+        <location filename="../imports/shared/views/chat/LinksMessageView.qml" line="426" />
         <source>Don't ask me again</source>
         <translation>Don't ask me again</translation>
     </message>
@@ -9180,170 +9205,171 @@ device, so only you can use them.</translation>
         <translation>Ok</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="310" />
-        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="310" />
+        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="306" />
+        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="306" />
         <source>Add new user</source>
         <translation>Add new user</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="319" />
-        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="319" />
+        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="315" />
+        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="315" />
         <source>Add existing Status user</source>
         <translation>Add existing Status user</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="346" />
-        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="346" />
+        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="341" />
+        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="341" />
         <source>Connecting...</source>
         <translation>Connecting...</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="347" />
-        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="347" />
+        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="342" />
+        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="342" />
         <source>Password</source>
         <translation>Password</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="400" />
-        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="916" />
-        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="1059" />
-        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="400" />
-        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="916" />
-        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="1059" />
+        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="395" />
+        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="911" />
+        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="1054" />
+        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="395" />
+        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="911" />
+        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="1054" />
         <source>Enter Keycard PIN</source>
         <translation>Enter Keycard PIN</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="516" />
-        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="864" />
-        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="516" />
-        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="864" />
+        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="511" />
+        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="859" />
+        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="511" />
+        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="859" />
         <source>Welcome back</source>
         <translation>Welcome back</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="529" />
-        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="576" />
-        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="529" />
-        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="576" />
+        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="524" />
+        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="571" />
+        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="524" />
+        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="571" />
         <source>Waiting for TouchID...</source>
         <translation>Waiting for TouchID...</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="548" />
-        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="548" />
+        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="543" />
+        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="543" />
         <source>Use password instead</source>
         <translation>Use password instead</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="595" />
-        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="595" />
+        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="590" />
+        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="590" />
         <source>Use PIN instead</source>
         <translation>Use PIN instead</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="623" />
-        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="623" />
+        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="618" />
+        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="618" />
         <source>Plug in Keycard reader...</source>
         <translation>Plug in Keycard reader...</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="674" />
-        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="674" />
+        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="669" />
+        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="669" />
         <source>Insert your Keycard...</source>
         <translation>Insert your Keycard...</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="684" />
-        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="684" />
+        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="679" />
+        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="679" />
         <source>Check the card, it might be wrongly inserted</source>
         <translation>Check the card, it might be wrongly inserted</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="727" />
-        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="727" />
+        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="722" />
+        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="722" />
         <source>Keycard inserted...</source>
         <translation>Keycard inserted...</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="778" />
-        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="778" />
+        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="773" />
+        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="773" />
         <source>Reading Keycard...</source>
         <translation>Reading Keycard...</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="829" />
-        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="829" />
+        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="824" />
+        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="824" />
         <source>Keycard recognized</source>
         <translation>Keycard recognized</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="964" />
-        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="964" />
+        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="959" />
+        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="959" />
         <source>PIN Verified</source>
         <translation>PIN Verified</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="1014" />
-        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="1014" />
+        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="1009" />
+        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="1009" />
         <source>Wrong Keycard!
 The card inserted is not linked to your profile.</source>
         <translation>Wrong Keycard!
 The card inserted is not linked to your profile.</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="1023" />
-        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="1023" />
+        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="1018" />
+        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="1018" />
         <source>Insert proper Keycard</source>
         <translation>Insert proper Keycard</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="1063" />
-        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="1063" />
+        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="1058" />
+        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="1058" />
         <source>PIN incorrect</source>
         <translation>PIN incorrect</translation>
     </message>
     <message numerus="yes">
-        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="1074" />
-        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="1074" />
+        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="1069" />
+        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="1069" />
         <source>%n attempt(s) remaining</source>
         <translation type="unfinished">
+            <numerusform />
             <numerusform />
         </translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="1120" />
-        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="1120" />
+        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="1115" />
+        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="1115" />
         <source>Keycard locked</source>
         <translation>Keycard locked</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="1134" />
-        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="1134" />
+        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="1129" />
+        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="1129" />
         <source>Unlock Keycard</source>
         <translation>Unlock Keycard</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="1166" />
-        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="1166" />
+        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="1161" />
+        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="1161" />
         <source>The card inserted is empty (has no profile linked).</source>
         <translation>The card inserted is empty (has no profile linked).</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="1185" />
-        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="1185" />
+        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="1180" />
+        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="1180" />
         <source>Generate keys for a new Keycard</source>
         <translation>Generate keys for a new Keycard</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="1217" />
-        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="1217" />
+        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="1212" />
+        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="1212" />
         <source>This is not a Keycard</source>
         <translation>This is not a Keycard</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="1226" />
-        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="1226" />
+        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="1221" />
+        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="1221" />
         <source>The card inserted is not a recognised Keycard,
 please remove and try and again</source>
         <translation>The card inserted is not a recognised Keycard,
@@ -9412,8 +9438,8 @@ please remove and try and again</translation>
     <message>
         <location filename="../app/AppLayouts/Profile/views/keycard/MainView.qml" line="120" />
         <location filename="../app/AppLayouts/Profile/views/keycard/MainView.qml" line="120" />
-        <source>Generate a seed phrase</source>
-        <translation>Generate a seed phrase</translation>
+        <source>Generate a new seed phrase</source>
+        <translation>Generate a new seed phrase</translation>
     </message>
     <message>
         <location filename="../app/AppLayouts/Profile/views/keycard/MainView.qml" line="134" />
@@ -9446,46 +9472,47 @@ please remove and try and again</translation>
         <translation>Factory reset a Keycard</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/wallet/MainView.qml" line="55" />
-        <location filename="../app/AppLayouts/Profile/views/wallet/MainView.qml" line="55" />
+        <location filename="../app/AppLayouts/Profile/views/wallet/MainView.qml" line="28" />
+        <location filename="../app/AppLayouts/Profile/views/wallet/MainView.qml" line="28" />
         <source>DApp Permissions</source>
         <translation>DApp Permissions</translation>
     </message>
     <message numerus="yes">
-        <location filename="../app/AppLayouts/Profile/views/wallet/MainView.qml" line="59" />
-        <location filename="../app/AppLayouts/Profile/views/wallet/MainView.qml" line="59" />
+        <location filename="../app/AppLayouts/Profile/views/wallet/MainView.qml" line="32" />
+        <location filename="../app/AppLayouts/Profile/views/wallet/MainView.qml" line="32" />
         <source>%n DApp(s) connected</source>
         <translation type="unfinished">
+            <numerusform />
             <numerusform />
         </translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/wallet/MainView.qml" line="75" />
-        <location filename="../app/AppLayouts/Profile/views/wallet/MainView.qml" line="75" />
+        <location filename="../app/AppLayouts/Profile/views/wallet/MainView.qml" line="48" />
+        <location filename="../app/AppLayouts/Profile/views/wallet/MainView.qml" line="48" />
         <source>Networks</source>
         <translation>Networks</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/wallet/MainView.qml" line="94" />
-        <location filename="../app/AppLayouts/Profile/views/wallet/MainView.qml" line="94" />
+        <location filename="../app/AppLayouts/Profile/views/wallet/MainView.qml" line="67" />
+        <location filename="../app/AppLayouts/Profile/views/wallet/MainView.qml" line="67" />
         <source>Accounts</source>
         <translation>Accounts</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/wallet/MainView.qml" line="98" />
-        <location filename="../app/AppLayouts/Profile/views/wallet/MainView.qml" line="98" />
+        <location filename="../app/AppLayouts/Profile/views/wallet/MainView.qml" line="71" />
+        <location filename="../app/AppLayouts/Profile/views/wallet/MainView.qml" line="71" />
         <source>Generated from Your Seed Phrase</source>
         <translation>Generated from Your Seed Phrase</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/wallet/MainView.qml" line="118" />
-        <location filename="../app/AppLayouts/Profile/views/wallet/MainView.qml" line="118" />
+        <location filename="../app/AppLayouts/Profile/views/wallet/MainView.qml" line="91" />
+        <location filename="../app/AppLayouts/Profile/views/wallet/MainView.qml" line="91" />
         <source>Imported</source>
         <translation>Imported</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/wallet/MainView.qml" line="135" />
-        <location filename="../app/AppLayouts/Profile/views/wallet/MainView.qml" line="135" />
+        <location filename="../app/AppLayouts/Profile/views/wallet/MainView.qml" line="108" />
+        <location filename="../app/AppLayouts/Profile/views/wallet/MainView.qml" line="108" />
         <source>Watch-Only</source>
         <translation>Watch-Only</translation>
     </message>
@@ -9493,16 +9520,31 @@ please remove and try and again</translation>
 <context>
     <name>MembersSelectorBase</name>
     <message>
-        <location filename="../app/AppLayouts/Chat/views/private/MembersSelectorBase.qml" line="26" />
-        <location filename="../app/AppLayouts/Chat/views/private/MembersSelectorBase.qml" line="26" />
+        <location filename="../app/AppLayouts/Chat/views/private/MembersSelectorBase.qml" line="30" />
+        <location filename="../app/AppLayouts/Chat/views/private/MembersSelectorBase.qml" line="30" />
         <source>To:</source>
         <translation>To:</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/views/private/MembersSelectorBase.qml" line="27" />
-        <location filename="../app/AppLayouts/Chat/views/private/MembersSelectorBase.qml" line="27" />
+        <location filename="../app/AppLayouts/Chat/views/private/MembersSelectorBase.qml" line="31" />
+        <location filename="../app/AppLayouts/Chat/views/private/MembersSelectorBase.qml" line="31" />
         <source>%1 USER LIMIT REACHED</source>
         <translation>%1 USER LIMIT REACHED</translation>
+    </message>
+</context>
+<context>
+    <name>MembershipCta</name>
+    <message>
+        <location filename="../app/mainui/activitycenter/panels/MembershipCta.qml" line="31" />
+        <location filename="../app/mainui/activitycenter/panels/MembershipCta.qml" line="31" />
+        <source>Accepted</source>
+        <translation>Accepted</translation>
+    </message>
+    <message>
+        <location filename="../app/mainui/activitycenter/panels/MembershipCta.qml" line="34" />
+        <location filename="../app/mainui/activitycenter/panels/MembershipCta.qml" line="34" />
+        <source>Declined</source>
+        <translation>Declined</translation>
     </message>
 </context>
 <context>
@@ -9538,243 +9580,234 @@ please remove and try and again</translation>
 <context>
     <name>MessageContextMenuView</name>
     <message>
-        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="215" />
-        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="215" />
+        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="202" />
+        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="202" />
         <source>Copy image</source>
         <translation>Copy image</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="228" />
-        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="228" />
+        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="215" />
+        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="215" />
         <source>Download image</source>
         <translation>Download image</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="265" />
-        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="265" />
+        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="252" />
+        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="252" />
         <source>Verify Identity</source>
         <translation>Verify Identity</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="280" />
-        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="280" />
+        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="267" />
+        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="267" />
         <source>ID Request Pending....</source>
         <translation>ID Request Pending....</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="281" />
-        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="281" />
+        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="268" />
+        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="268" />
         <source>Respond to ID Request...</source>
         <translation>Respond to ID Request...</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="299" />
-        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="299" />
+        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="286" />
+        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="286" />
         <source>Rename</source>
         <translation>Rename</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="310" />
-        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="310" />
+        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="297" />
+        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="297" />
         <source>Unblock User</source>
         <translation>Unblock User</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="322" />
-        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="322" />
+        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="309" />
+        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="309" />
         <source>Mark as Untrustworthy</source>
         <translation>Mark as Untrustworthy</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="331" />
-        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="331" />
+        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="318" />
+        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="318" />
         <source>Remove Untrustworthy Mark</source>
         <translation>Remove Untrustworthy Mark</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="339" />
-        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="339" />
+        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="326" />
+        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="326" />
         <source>Block User</source>
         <translation>Block User</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="348" />
-        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="348" />
+        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="335" />
+        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="335" />
         <source>Reply to</source>
         <translation>Reply to</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="363" />
-        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="363" />
+        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="350" />
+        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="350" />
         <source>Edit message</source>
         <translation>Edit message</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="379" />
-        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="379" />
+        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="366" />
+        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="366" />
         <source>Copy Message Id</source>
         <translation>Copy Message Id</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="392" />
-        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="392" />
+        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="379" />
+        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="379" />
         <source>Unpin</source>
         <translation>Unpin</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="394" />
-        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="394" />
+        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="381" />
+        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="381" />
         <source>Pin</source>
         <translation>Pin</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="457" />
-        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="457" />
+        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="444" />
+        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="444" />
         <source>Delete message</source>
         <translation>Delete message</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="473" />
-        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="473" />
+        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="460" />
+        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="460" />
         <source>Jump to</source>
         <translation>Jump to</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="484" />
-        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="484" />
+        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="471" />
+        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="471" />
         <source>Please choose a directory</source>
         <translation>Please choose a directory</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="501" />
-        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="501" />
+        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="488" />
+        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="488" />
         <source>Confirm deleting this message</source>
         <translation>Confirm deleting this message</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="502" />
-        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="502" />
+        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="489" />
+        <location filename="../imports/shared/views/chat/MessageContextMenuView.qml" line="489" />
         <source>Are you sure you want to delete this message? Be aware that other clients are not guaranteed to delete the message as well.</source>
         <translation>Are you sure you want to delete this message? Be aware that other clients are not guaranteed to delete the message as well.</translation>
     </message>
 </context>
 <context>
-    <name>MessageStore</name>
-    <message>
-        <location filename="../app/AppLayouts/stores/MessageStore.qml" line="46" />
-        <location filename="../app/AppLayouts/stores/MessageStore.qml" line="46" />
-        <source>You</source>
-        <translation>You</translation>
-    </message>
-</context>
-<context>
     <name>MessageView</name>
     <message>
-        <location filename="../imports/shared/views/chat/MessageView.qml" line="422" />
-        <location filename="../imports/shared/views/chat/MessageView.qml" line="422" />
+        <location filename="../imports/shared/views/chat/MessageView.qml" line="447" />
+        <location filename="../imports/shared/views/chat/MessageView.qml" line="447" />
         <source>Audio Message</source>
         <translation>Audio Message</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/chat/MessageView.qml" line="423" />
-        <location filename="../imports/shared/views/chat/MessageView.qml" line="423" />
+        <location filename="../imports/shared/views/chat/MessageView.qml" line="448" />
+        <location filename="../imports/shared/views/chat/MessageView.qml" line="448" />
         <source>Cancel</source>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/chat/MessageView.qml" line="424" />
-        <location filename="../imports/shared/views/chat/MessageView.qml" line="424" />
+        <location filename="../imports/shared/views/chat/MessageView.qml" line="449" />
+        <location filename="../imports/shared/views/chat/MessageView.qml" line="449" />
         <source>Save</source>
         <translation>Save</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/chat/MessageView.qml" line="425" />
-        <location filename="../imports/shared/views/chat/MessageView.qml" line="425" />
+        <location filename="../imports/shared/views/chat/MessageView.qml" line="450" />
+        <location filename="../imports/shared/views/chat/MessageView.qml" line="450" />
         <source>Loading image...</source>
         <translation>Loading image...</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/chat/MessageView.qml" line="426" />
-        <location filename="../imports/shared/views/chat/MessageView.qml" line="426" />
+        <location filename="../imports/shared/views/chat/MessageView.qml" line="451" />
+        <location filename="../imports/shared/views/chat/MessageView.qml" line="451" />
         <source>Error loading the image</source>
         <translation>Error loading the image</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/chat/MessageView.qml" line="427" />
-        <location filename="../imports/shared/views/chat/MessageView.qml" line="427" />
+        <location filename="../imports/shared/views/chat/MessageView.qml" line="452" />
+        <location filename="../imports/shared/views/chat/MessageView.qml" line="452" />
         <source>Resend</source>
         <translation>Resend</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/chat/MessageView.qml" line="428" />
-        <location filename="../imports/shared/views/chat/MessageView.qml" line="428" />
+        <location filename="../imports/shared/views/chat/MessageView.qml" line="453" />
+        <location filename="../imports/shared/views/chat/MessageView.qml" line="453" />
         <source>Pinned</source>
         <translation>Pinned</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/chat/MessageView.qml" line="428" />
-        <location filename="../imports/shared/views/chat/MessageView.qml" line="428" />
+        <location filename="../imports/shared/views/chat/MessageView.qml" line="453" />
+        <location filename="../imports/shared/views/chat/MessageView.qml" line="453" />
         <source>Pinned by</source>
         <translation>Pinned by</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/chat/MessageView.qml" line="569" />
-        <location filename="../imports/shared/views/chat/MessageView.qml" line="569" />
+        <location filename="../imports/shared/views/chat/MessageView.qml" line="594" />
+        <location filename="../imports/shared/views/chat/MessageView.qml" line="594" />
         <source>Imported from discord</source>
         <translation>Imported from discord</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/chat/MessageView.qml" line="607" />
-        <location filename="../imports/shared/views/chat/MessageView.qml" line="607" />
+        <location filename="../imports/shared/views/chat/MessageView.qml" line="632" />
+        <location filename="../imports/shared/views/chat/MessageView.qml" line="632" />
         <source>&amp;lt;deleted&amp;gt;</source>
-        <extracomment>There is should be a message for reply which source message was deleted</extracomment>
+        <extracomment>deleted message</extracomment>
         <translation>&amp;lt;deleted&amp;gt;</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/chat/MessageView.qml" line="719" />
-        <location filename="../imports/shared/views/chat/MessageView.qml" line="719" />
+        <location filename="../imports/shared/views/chat/MessageView.qml" line="746" />
+        <location filename="../imports/shared/views/chat/MessageView.qml" line="746" />
         <source>Add reaction</source>
         <translation>Add reaction</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/chat/MessageView.qml" line="734" />
-        <location filename="../imports/shared/views/chat/MessageView.qml" line="734" />
+        <location filename="../imports/shared/views/chat/MessageView.qml" line="761" />
+        <location filename="../imports/shared/views/chat/MessageView.qml" line="761" />
         <source>Reply</source>
         <translation>Reply</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/chat/MessageView.qml" line="752" />
-        <location filename="../imports/shared/views/chat/MessageView.qml" line="752" />
+        <location filename="../imports/shared/views/chat/MessageView.qml" line="779" />
+        <location filename="../imports/shared/views/chat/MessageView.qml" line="779" />
         <source>Edit</source>
         <translation>Edit</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/chat/MessageView.qml" line="778" />
-        <location filename="../imports/shared/views/chat/MessageView.qml" line="778" />
+        <location filename="../imports/shared/views/chat/MessageView.qml" line="805" />
+        <location filename="../imports/shared/views/chat/MessageView.qml" line="805" />
         <source>Unpin</source>
         <translation>Unpin</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/chat/MessageView.qml" line="778" />
-        <location filename="../imports/shared/views/chat/MessageView.qml" line="778" />
+        <location filename="../imports/shared/views/chat/MessageView.qml" line="805" />
+        <location filename="../imports/shared/views/chat/MessageView.qml" line="805" />
         <source>Pin</source>
         <translation>Pin</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/chat/MessageView.qml" line="825" />
-        <location filename="../imports/shared/views/chat/MessageView.qml" line="825" />
+        <location filename="../imports/shared/views/chat/MessageView.qml" line="852" />
+        <location filename="../imports/shared/views/chat/MessageView.qml" line="852" />
         <source>Delete</source>
         <translation>Delete</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/chat/MessageView.qml" line="845" />
-        <location filename="../imports/shared/views/chat/MessageView.qml" line="845" />
+        <location filename="../imports/shared/views/chat/MessageView.qml" line="873" />
+        <location filename="../imports/shared/views/chat/MessageView.qml" line="873" />
         <source>Confirm deleting this message</source>
         <translation>Confirm deleting this message</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/chat/MessageView.qml" line="846" />
-        <location filename="../imports/shared/views/chat/MessageView.qml" line="846" />
+        <location filename="../imports/shared/views/chat/MessageView.qml" line="874" />
+        <location filename="../imports/shared/views/chat/MessageView.qml" line="874" />
         <source>Are you sure you want to delete this message? Be aware that other clients are not guaranteed to delete the message as well.</source>
         <translation>Are you sure you want to delete this message? Be aware that other clients are not guaranteed to delete the message as well.</translation>
     </message>
@@ -9782,74 +9815,74 @@ please remove and try and again</translation>
 <context>
     <name>MessagingView</name>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="54" />
-        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="54" />
+        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="87" />
+        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="87" />
         <source>Allow new contact requests</source>
         <translation>Allow new contact requests</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="80" />
-        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="80" />
+        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="113" />
+        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="113" />
         <source>Open Message Links With</source>
         <translation>Open Message Links With</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="89" />
-        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="89" />
+        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="122" />
+        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="122" />
         <source>Status Browser</source>
         <translation>Status Browser</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="102" />
-        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="102" />
+        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="135" />
+        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="135" />
         <source>System Default Browser</source>
         <translation>System Default Browser</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="119" />
-        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="119" />
+        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="153" />
+        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="153" />
         <source>Contacts, Requests, and Blocked Users</source>
         <translation>Contacts, Requests, and Blocked Users</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="134" />
-        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="134" />
+        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="168" />
+        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="168" />
         <source>Display Message Link Previews</source>
         <translation>Display Message Link Previews</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="189" />
-        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="189" />
+        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="199" />
+        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="199" />
         <source>Fine tune which sites to allow link previews</source>
         <translation>Fine tune which sites to allow link previews</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="218" />
-        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="218" />
+        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="248" />
+        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="248" />
         <source>Image unfurling</source>
         <translation>Image unfurling</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="219" />
-        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="219" />
+        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="249" />
+        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="249" />
         <source>All images (links that contain an image extension) will be downloaded and displayed</source>
         <translation>All images (links that contain an image extension) will be downloaded and displayed</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="308" />
-        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="308" />
+        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="332" />
+        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="332" />
         <source>Message syncing</source>
         <translation>Message syncing</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="313" />
-        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="313" />
+        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="337" />
+        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="337" />
         <source>Waku nodes</source>
         <translation>Waku nodes</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="337" />
-        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="337" />
+        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="361" />
+        <location filename="../app/AppLayouts/Profile/views/MessagingView.qml" line="361" />
         <source>For security reasons, private chat history won't be synced.</source>
         <translation>For security reasons, private chat history won't be synced.</translation>
     </message>
@@ -9896,32 +9929,32 @@ please remove and try and again</translation>
 <context>
     <name>MyProfileSettingsView</name>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/profile/MyProfileSettingsView.qml" line="130" />
-        <location filename="../app/AppLayouts/Profile/views/profile/MyProfileSettingsView.qml" line="130" />
+        <location filename="../app/AppLayouts/Profile/views/profile/MyProfileSettingsView.qml" line="157" />
+        <location filename="../app/AppLayouts/Profile/views/profile/MyProfileSettingsView.qml" line="157" />
         <source>Biometric login and transaction authentication</source>
         <translation>Biometric login and transaction authentication</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/profile/MyProfileSettingsView.qml" line="161" />
-        <location filename="../app/AppLayouts/Profile/views/profile/MyProfileSettingsView.qml" line="161" />
+        <location filename="../app/AppLayouts/Profile/views/profile/MyProfileSettingsView.qml" line="188" />
+        <location filename="../app/AppLayouts/Profile/views/profile/MyProfileSettingsView.qml" line="188" />
         <source>Communities</source>
         <translation>Communities</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/profile/MyProfileSettingsView.qml" line="168" />
-        <location filename="../app/AppLayouts/Profile/views/profile/MyProfileSettingsView.qml" line="168" />
+        <location filename="../app/AppLayouts/Profile/views/profile/MyProfileSettingsView.qml" line="195" />
+        <location filename="../app/AppLayouts/Profile/views/profile/MyProfileSettingsView.qml" line="195" />
         <source>Accounts</source>
         <translation>Accounts</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/profile/MyProfileSettingsView.qml" line="185" />
-        <location filename="../app/AppLayouts/Profile/views/profile/MyProfileSettingsView.qml" line="185" />
+        <location filename="../app/AppLayouts/Profile/views/profile/MyProfileSettingsView.qml" line="212" />
+        <location filename="../app/AppLayouts/Profile/views/profile/MyProfileSettingsView.qml" line="212" />
         <source>You haven't joined any communities yet</source>
         <translation>You haven't joined any communities yet</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/profile/MyProfileSettingsView.qml" line="207" />
-        <location filename="../app/AppLayouts/Profile/views/profile/MyProfileSettingsView.qml" line="207" />
+        <location filename="../app/AppLayouts/Profile/views/profile/MyProfileSettingsView.qml" line="234" />
+        <location filename="../app/AppLayouts/Profile/views/profile/MyProfileSettingsView.qml" line="234" />
         <source>You don't have any wallet accounts yet</source>
         <translation>You don't have any wallet accounts yet</translation>
     </message>
@@ -9935,14 +9968,14 @@ please remove and try and again</translation>
         <translation>Change Password</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/MyProfileView.qml" line="59" />
-        <location filename="../app/AppLayouts/Profile/views/MyProfileView.qml" line="59" />
+        <location filename="../app/AppLayouts/Profile/views/MyProfileView.qml" line="52" />
+        <location filename="../app/AppLayouts/Profile/views/MyProfileView.qml" line="52" />
         <source>Edit</source>
         <translation>Edit</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/MyProfileView.qml" line="63" />
-        <location filename="../app/AppLayouts/Profile/views/MyProfileView.qml" line="63" />
+        <location filename="../app/AppLayouts/Profile/views/MyProfileView.qml" line="56" />
+        <location filename="../app/AppLayouts/Profile/views/MyProfileView.qml" line="56" />
         <source>Preview</source>
         <translation>Preview</translation>
     </message>
@@ -9950,36 +9983,42 @@ please remove and try and again</translation>
 <context>
     <name>NetworkCardsComponent</name>
     <message>
-        <location filename="../imports/shared/views/NetworkCardsComponent.qml" line="73" />
-        <location filename="../imports/shared/views/NetworkCardsComponent.qml" line="73" />
+        <location filename="../imports/shared/views/NetworkCardsComponent.qml" line="76" />
+        <location filename="../imports/shared/views/NetworkCardsComponent.qml" line="76" />
         <source>Your Balances</source>
         <translation>Your Balances</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/NetworkCardsComponent.qml" line="83" />
-        <location filename="../imports/shared/views/NetworkCardsComponent.qml" line="83" />
+        <location filename="../imports/shared/views/NetworkCardsComponent.qml" line="90" />
+        <location filename="../imports/shared/views/NetworkCardsComponent.qml" line="90" />
         <source>No Balance</source>
         <translation>No Balance</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/NetworkCardsComponent.qml" line="83" />
-        <location filename="../imports/shared/views/NetworkCardsComponent.qml" line="83" />
+        <location filename="../imports/shared/views/NetworkCardsComponent.qml" line="90" />
+        <location filename="../imports/shared/views/NetworkCardsComponent.qml" line="90" />
         <source>No Gas</source>
         <translation>No Gas</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/NetworkCardsComponent.qml" line="86" />
-        <location filename="../imports/shared/views/NetworkCardsComponent.qml" line="86" />
+        <location filename="../imports/shared/views/NetworkCardsComponent.qml" line="91" />
+        <location filename="../imports/shared/views/NetworkCardsComponent.qml" line="91" />
         <source>BALANCE: </source>
         <translation>BALANCE: </translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/NetworkCardsComponent.qml" line="89" />
-        <location filename="../imports/shared/views/NetworkCardsComponent.qml" line="140" />
-        <location filename="../imports/shared/views/NetworkCardsComponent.qml" line="89" />
-        <location filename="../imports/shared/views/NetworkCardsComponent.qml" line="140" />
+        <location filename="../imports/shared/views/NetworkCardsComponent.qml" line="94" />
+        <location filename="../imports/shared/views/NetworkCardsComponent.qml" line="145" />
+        <location filename="../imports/shared/views/NetworkCardsComponent.qml" line="94" />
+        <location filename="../imports/shared/views/NetworkCardsComponent.qml" line="145" />
         <source>Disabled</source>
         <translation>Disabled</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/views/NetworkCardsComponent.qml" line="141" />
+        <location filename="../imports/shared/views/NetworkCardsComponent.qml" line="141" />
+        <source>UNPREFERRED</source>
+        <translation>UNPREFERRED</translation>
     </message>
 </context>
 <context>
@@ -9996,14 +10035,15 @@ please remove and try and again</translation>
         <source>%n network(s)</source>
         <translation type="unfinished">
             <numerusform />
+            <numerusform />
         </translation>
     </message>
 </context>
 <context>
     <name>NetworkSelectPopup</name>
     <message>
-        <location filename="../app/AppLayouts/Wallet/popups/NetworkSelectPopup.qml" line="72" />
-        <location filename="../app/AppLayouts/Wallet/popups/NetworkSelectPopup.qml" line="72" />
+        <location filename="../app/AppLayouts/Wallet/popups/NetworkSelectPopup.qml" line="75" />
+        <location filename="../app/AppLayouts/Wallet/popups/NetworkSelectPopup.qml" line="75" />
         <source>Layer 2</source>
         <translation>Layer 2</translation>
     </message>
@@ -10011,31 +10051,31 @@ please remove and try and again</translation>
 <context>
     <name>NetworkSelector</name>
     <message>
-        <location filename="../imports/shared/views/NetworkSelector.qml" line="44" />
-        <location filename="../imports/shared/views/NetworkSelector.qml" line="44" />
+        <location filename="../imports/shared/views/NetworkSelector.qml" line="47" />
+        <location filename="../imports/shared/views/NetworkSelector.qml" line="47" />
         <source>Simple</source>
         <translation>Simple</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/NetworkSelector.qml" line="47" />
-        <location filename="../imports/shared/views/NetworkSelector.qml" line="47" />
+        <location filename="../imports/shared/views/NetworkSelector.qml" line="50" />
+        <location filename="../imports/shared/views/NetworkSelector.qml" line="50" />
         <source>Advanced</source>
         <translation>Advanced</translation>
-    </message>
-    <message>
-        <location filename="../imports/shared/views/NetworkSelector.qml" line="50" />
-        <location filename="../imports/shared/views/NetworkSelector.qml" line="50" />
-        <source>Custom</source>
-        <translation>Custom</translation>
     </message>
 </context>
 <context>
     <name>NetworksAdvancedCustomRoutingView</name>
     <message>
-        <location filename="../imports/shared/views/NetworksAdvancedCustomRoutingView.qml" line="53" />
-        <location filename="../imports/shared/views/NetworksAdvancedCustomRoutingView.qml" line="53" />
+        <location filename="../imports/shared/views/NetworksAdvancedCustomRoutingView.qml" line="49" />
+        <location filename="../imports/shared/views/NetworksAdvancedCustomRoutingView.qml" line="49" />
         <source>Networks</source>
         <translation>Networks</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/views/NetworksAdvancedCustomRoutingView.qml" line="62" />
+        <location filename="../imports/shared/views/NetworksAdvancedCustomRoutingView.qml" line="62" />
+        <source>Hide Unpreferred Networks</source>
+        <translation>Hide Unpreferred Networks</translation>
     </message>
     <message>
         <location filename="../imports/shared/views/NetworksAdvancedCustomRoutingView.qml" line="62" />
@@ -10044,8 +10084,8 @@ please remove and try and again</translation>
         <translation>Show Unpreferred Networks</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/NetworksAdvancedCustomRoutingView.qml" line="69" />
-        <location filename="../imports/shared/views/NetworksAdvancedCustomRoutingView.qml" line="69" />
+        <location filename="../imports/shared/views/NetworksAdvancedCustomRoutingView.qml" line="70" />
+        <location filename="../imports/shared/views/NetworksAdvancedCustomRoutingView.qml" line="70" />
         <source>The networks where the receipient will receive tokens. Amounts calculated automatically for the lowest cost.</source>
         <translation>The networks where the receipient will receive tokens. Amounts calculated automatically for the lowest cost.</translation>
     </message>
@@ -10053,16 +10093,22 @@ please remove and try and again</translation>
 <context>
     <name>NetworksSimpleRoutingView</name>
     <message>
-        <location filename="../imports/shared/views/NetworksSimpleRoutingView.qml" line="39" />
-        <location filename="../imports/shared/views/NetworksSimpleRoutingView.qml" line="39" />
+        <location filename="../imports/shared/views/NetworksSimpleRoutingView.qml" line="41" />
+        <location filename="../imports/shared/views/NetworksSimpleRoutingView.qml" line="41" />
         <source>Networks</source>
         <translation>Networks</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/NetworksSimpleRoutingView.qml" line="46" />
-        <location filename="../imports/shared/views/NetworksSimpleRoutingView.qml" line="46" />
-        <source>Choose a network to use for the transaction</source>
-        <translation>Choose a network to use for the transaction</translation>
+        <location filename="../imports/shared/views/NetworksSimpleRoutingView.qml" line="48" />
+        <location filename="../imports/shared/views/NetworksSimpleRoutingView.qml" line="48" />
+        <source>Choose the network to bridge token to</source>
+        <translation>Choose the network to bridge token to</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/views/NetworksSimpleRoutingView.qml" line="49" />
+        <location filename="../imports/shared/views/NetworksSimpleRoutingView.qml" line="49" />
+        <source>The networks where the receipient will receive tokens. Amounts calculated automatically for the lowest cost.</source>
+        <translation>The networks where the receipient will receive tokens. Amounts calculated automatically for the lowest cost.</translation>
     </message>
 </context>
 <context>
@@ -10083,22 +10129,22 @@ please remove and try and again</translation>
 <context>
     <name>NicknamePopup</name>
     <message>
-        <location filename="../imports/shared/popups/NicknamePopup.qml" line="20" />
-        <location filename="../imports/shared/popups/NicknamePopup.qml" line="56" />
-        <location filename="../imports/shared/popups/NicknamePopup.qml" line="20" />
-        <location filename="../imports/shared/popups/NicknamePopup.qml" line="56" />
+        <location filename="../imports/shared/popups/NicknamePopup.qml" line="21" />
+        <location filename="../imports/shared/popups/NicknamePopup.qml" line="57" />
+        <location filename="../imports/shared/popups/NicknamePopup.qml" line="21" />
+        <location filename="../imports/shared/popups/NicknamePopup.qml" line="57" />
         <source>Nickname</source>
         <translation>Nickname</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/NicknamePopup.qml" line="48" />
-        <location filename="../imports/shared/popups/NicknamePopup.qml" line="48" />
+        <location filename="../imports/shared/popups/NicknamePopup.qml" line="49" />
+        <location filename="../imports/shared/popups/NicknamePopup.qml" line="49" />
         <source>Nicknames help you identify others in Status. Only you can see the nicknames you&#8217;ve added</source>
         <translation>Nicknames help you identify others in Status. Only you can see the nicknames you&#8217;ve added</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/NicknamePopup.qml" line="79" />
-        <location filename="../imports/shared/popups/NicknamePopup.qml" line="79" />
+        <location filename="../imports/shared/popups/NicknamePopup.qml" line="81" />
+        <location filename="../imports/shared/popups/NicknamePopup.qml" line="81" />
         <source>Done</source>
         <translation>Done</translation>
     </message>
@@ -10136,14 +10182,14 @@ please remove and try and again</translation>
 <context>
     <name>NodeLayout</name>
     <message>
-        <location filename="../app/AppLayouts/Node/NodeLayout.qml" line="64" />
-        <location filename="../app/AppLayouts/Node/NodeLayout.qml" line="64" />
+        <location filename="../app/AppLayouts/Node/NodeLayout.qml" line="65" />
+        <location filename="../app/AppLayouts/Node/NodeLayout.qml" line="65" />
         <source>Bloom Filter Usage</source>
         <translation>Bloom Filter Usage</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Node/NodeLayout.qml" line="240" />
-        <location filename="../app/AppLayouts/Node/NodeLayout.qml" line="240" />
+        <location filename="../app/AppLayouts/Node/NodeLayout.qml" line="245" />
+        <location filename="../app/AppLayouts/Node/NodeLayout.qml" line="245" />
         <source>Type json-rpc message... e.g {"method": "eth_accounts"}</source>
         <translation>Type json-rpc message... e.g {"method": "eth_accounts"}</translation>
     </message>
@@ -10399,26 +10445,26 @@ please remove and try and again</translation>
         <translation>Volume</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="498" />
-        <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="498" />
+        <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="503" />
+        <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="503" />
         <source>Send a Test Notification</source>
         <translation>Send a Test Notification</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="513" />
-        <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="513" />
+        <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="518" />
+        <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="518" />
         <source>Exemptions</source>
         <translation>Exemptions</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="523" />
-        <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="523" />
+        <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="528" />
+        <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="528" />
         <source>Search Communities, Group Chats and 1:1 Chats</source>
         <translation>Search Communities, Group Chats and 1:1 Chats</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="529" />
-        <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="529" />
+        <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="534" />
+        <location filename="../app/AppLayouts/Profile/views/NotificationsView.qml" line="534" />
         <source>Most recent</source>
         <translation>Most recent</translation>
     </message>
@@ -10484,6 +10530,21 @@ please remove and try and again</translation>
     </message>
 </context>
 <context>
+    <name>OperatorsUtils</name>
+    <message>
+        <location filename="../StatusQ/src/StatusQ/Core/Utils/OperatorsUtils.qml" line="12" />
+        <location filename="../StatusQ/src/StatusQ/Core/Utils/OperatorsUtils.qml" line="12" />
+        <source>and</source>
+        <translation>and</translation>
+    </message>
+    <message>
+        <location filename="../StatusQ/src/StatusQ/Core/Utils/OperatorsUtils.qml" line="17" />
+        <location filename="../StatusQ/src/StatusQ/Core/Utils/OperatorsUtils.qml" line="17" />
+        <source>or</source>
+        <translation>or</translation>
+    </message>
+</context>
+<context>
     <name>OutgoingContactVerificationRequestPopup</name>
     <message>
         <location filename="../imports/shared/popups/OutgoingContactVerificationRequestPopup.qml" line="31" />
@@ -10519,124 +10580,181 @@ please remove and try and again</translation>
 <context>
     <name>PasswordView</name>
     <message>
-        <location filename="../imports/shared/views/PasswordView.qml" line="20" />
-        <location filename="../imports/shared/views/PasswordView.qml" line="20" />
+        <location filename="../imports/shared/views/PasswordView.qml" line="19" />
+        <location filename="../imports/shared/views/PasswordView.qml" line="19" />
         <source>Create a password</source>
         <translation>Create a password</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/PasswordView.qml" line="22" />
-        <location filename="../imports/shared/views/PasswordView.qml" line="22" />
+        <location filename="../imports/shared/views/PasswordView.qml" line="21" />
+        <location filename="../imports/shared/views/PasswordView.qml" line="21" />
         <source>Create a password to unlock Status on this device &amp; sign transactions.</source>
         <translation>Create a password to unlock Status on this device &amp; sign transactions.</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/PasswordView.qml" line="23" />
-        <location filename="../imports/shared/views/PasswordView.qml" line="23" />
+        <location filename="../imports/shared/views/PasswordView.qml" line="22" />
+        <location filename="../imports/shared/views/PasswordView.qml" line="22" />
         <source>You will not be able to recover this password if it is lost.</source>
         <translation>You will not be able to recover this password if it is lost.</translation>
     </message>
-    <message>
-        <location filename="../imports/shared/views/PasswordView.qml" line="24" />
-        <location filename="../imports/shared/views/PasswordView.qml" line="24" />
-        <source>Minimum %1 characters. To strengthen your password consider including:</source>
-        <translation>Minimum %1 characters. To strengthen your password consider including:</translation>
+    <message numerus="yes">
+        <location filename="../imports/shared/views/PasswordView.qml" line="23" />
+        <location filename="../imports/shared/views/PasswordView.qml" line="23" />
+        <source>Minimum %n character(s). To strengthen your password consider including:</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/PasswordView.qml" line="68" />
-        <location filename="../imports/shared/views/PasswordView.qml" line="68" />
+        <location filename="../imports/shared/views/PasswordView.qml" line="67" />
+        <location filename="../imports/shared/views/PasswordView.qml" line="67" />
         <source>Passwords don't match</source>
         <translation>Passwords don't match</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/PasswordView.qml" line="112" />
-        <location filename="../imports/shared/views/PasswordView.qml" line="112" />
+        <location filename="../imports/shared/views/PasswordView.qml" line="111" />
+        <location filename="../imports/shared/views/PasswordView.qml" line="111" />
         <source>This password has been pwned and shouldn't be used</source>
         <translation>This password has been pwned and shouldn't be used</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/PasswordView.qml" line="116" />
-        <location filename="../imports/shared/views/PasswordView.qml" line="116" />
+        <location filename="../imports/shared/views/PasswordView.qml" line="115" />
+        <location filename="../imports/shared/views/PasswordView.qml" line="115" />
         <source>This password is a common word and shouldn't be used</source>
         <translation>This password is a common word and shouldn't be used</translation>
     </message>
-    <message>
-        <location filename="../imports/shared/views/PasswordView.qml" line="120" />
-        <location filename="../imports/shared/views/PasswordView.qml" line="120" />
-        <source>Password must be at least %1 characters long</source>
-        <translation>Password must be at least %1 characters long</translation>
+    <message numerus="yes">
+        <location filename="../imports/shared/views/PasswordView.qml" line="119" />
+        <location filename="../imports/shared/views/PasswordView.qml" line="119" />
+        <source>Password must be at least %n character(s) long</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/PasswordView.qml" line="169" />
-        <location filename="../imports/shared/views/PasswordView.qml" line="169" />
+        <location filename="../imports/shared/views/PasswordView.qml" line="168" />
+        <location filename="../imports/shared/views/PasswordView.qml" line="168" />
         <source>Current password</source>
         <translation>Current password</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/PasswordView.qml" line="202" />
-        <location filename="../imports/shared/views/PasswordView.qml" line="202" />
+        <location filename="../imports/shared/views/PasswordView.qml" line="201" />
+        <location filename="../imports/shared/views/PasswordView.qml" line="201" />
         <source>New password</source>
         <translation>New password</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/PasswordView.qml" line="243" />
-        <location filename="../imports/shared/views/PasswordView.qml" line="243" />
+        <location filename="../imports/shared/views/PasswordView.qml" line="242" />
+        <location filename="../imports/shared/views/PasswordView.qml" line="242" />
         <source>Very weak</source>
         <translation>Very weak</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/PasswordView.qml" line="244" />
-        <location filename="../imports/shared/views/PasswordView.qml" line="244" />
+        <location filename="../imports/shared/views/PasswordView.qml" line="243" />
+        <location filename="../imports/shared/views/PasswordView.qml" line="243" />
         <source>Weak</source>
         <translation>Weak</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/PasswordView.qml" line="245" />
-        <location filename="../imports/shared/views/PasswordView.qml" line="245" />
+        <location filename="../imports/shared/views/PasswordView.qml" line="244" />
+        <location filename="../imports/shared/views/PasswordView.qml" line="244" />
         <source>So-so</source>
         <translation>So-so</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/PasswordView.qml" line="246" />
-        <location filename="../imports/shared/views/PasswordView.qml" line="246" />
+        <location filename="../imports/shared/views/PasswordView.qml" line="245" />
+        <location filename="../imports/shared/views/PasswordView.qml" line="245" />
         <source>Good</source>
         <translation>Good</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/PasswordView.qml" line="247" />
-        <location filename="../imports/shared/views/PasswordView.qml" line="247" />
+        <location filename="../imports/shared/views/PasswordView.qml" line="246" />
+        <location filename="../imports/shared/views/PasswordView.qml" line="246" />
         <source>Great</source>
         <translation>Great</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/PasswordView.qml" line="268" />
-        <location filename="../imports/shared/views/PasswordView.qml" line="268" />
+        <location filename="../imports/shared/views/PasswordView.qml" line="267" />
+        <location filename="../imports/shared/views/PasswordView.qml" line="267" />
         <source>Lower case</source>
         <translation>Lower case</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/PasswordView.qml" line="275" />
-        <location filename="../imports/shared/views/PasswordView.qml" line="275" />
+        <location filename="../imports/shared/views/PasswordView.qml" line="274" />
+        <location filename="../imports/shared/views/PasswordView.qml" line="274" />
         <source>Upper case</source>
         <translation>Upper case</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/PasswordView.qml" line="282" />
-        <location filename="../imports/shared/views/PasswordView.qml" line="282" />
+        <location filename="../imports/shared/views/PasswordView.qml" line="281" />
+        <location filename="../imports/shared/views/PasswordView.qml" line="281" />
         <source>Numbers</source>
         <translation>Numbers</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/PasswordView.qml" line="289" />
-        <location filename="../imports/shared/views/PasswordView.qml" line="289" />
+        <location filename="../imports/shared/views/PasswordView.qml" line="288" />
+        <location filename="../imports/shared/views/PasswordView.qml" line="288" />
         <source>Symbols</source>
         <translation>Symbols</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/PasswordView.qml" line="303" />
-        <location filename="../imports/shared/views/PasswordView.qml" line="303" />
+        <location filename="../imports/shared/views/PasswordView.qml" line="302" />
+        <location filename="../imports/shared/views/PasswordView.qml" line="302" />
         <source>Confirm password</source>
         <translation>Confirm password</translation>
+    </message>
+</context>
+<context>
+    <name>PermissionItem</name>
+    <message>
+        <location filename="../app/AppLayouts/Chat/controls/community/PermissionItem.qml" line="66" />
+        <location filename="../app/AppLayouts/Chat/controls/community/PermissionItem.qml" line="66" />
+        <source>Active</source>
+        <translation>Active</translation>
+    </message>
+    <message>
+        <location filename="../app/AppLayouts/Chat/controls/community/PermissionItem.qml" line="92" />
+        <location filename="../app/AppLayouts/Chat/controls/community/PermissionItem.qml" line="92" />
+        <source>Anyone who holds</source>
+        <translation>Anyone who holds</translation>
+    </message>
+    <message>
+        <location filename="../app/AppLayouts/Chat/controls/community/PermissionItem.qml" line="130" />
+        <location filename="../app/AppLayouts/Chat/controls/community/PermissionItem.qml" line="130" />
+        <source>is allowed to</source>
+        <translation>is allowed to</translation>
+    </message>
+    <message>
+        <location filename="../app/AppLayouts/Chat/controls/community/PermissionItem.qml" line="149" />
+        <location filename="../app/AppLayouts/Chat/controls/community/PermissionItem.qml" line="149" />
+        <source>in</source>
+        <translation>in</translation>
+    </message>
+    <message>
+        <location filename="../app/AppLayouts/Chat/controls/community/PermissionItem.qml" line="163" />
+        <location filename="../app/AppLayouts/Chat/controls/community/PermissionItem.qml" line="163" />
+        <source>and</source>
+        <translation>and</translation>
+    </message>
+    <message>
+        <location filename="../app/AppLayouts/Chat/controls/community/PermissionItem.qml" line="202" />
+        <location filename="../app/AppLayouts/Chat/controls/community/PermissionItem.qml" line="202" />
+        <source>Edit</source>
+        <translation>Edit</translation>
+    </message>
+    <message>
+        <location filename="../app/AppLayouts/Chat/controls/community/PermissionItem.qml" line="220" />
+        <location filename="../app/AppLayouts/Chat/controls/community/PermissionItem.qml" line="220" />
+        <source>Duplicate</source>
+        <translation>Duplicate</translation>
+    </message>
+    <message>
+        <location filename="../app/AppLayouts/Chat/controls/community/PermissionItem.qml" line="238" />
+        <location filename="../app/AppLayouts/Chat/controls/community/PermissionItem.qml" line="238" />
+        <source>Remove</source>
+        <translation>Remove</translation>
     </message>
 </context>
 <context>
@@ -10741,14 +10859,14 @@ please remove and try and again</translation>
 <context>
     <name>PermissionsListView</name>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/wallet/PermissionsListView.qml" line="39" />
-        <location filename="../app/AppLayouts/Profile/views/wallet/PermissionsListView.qml" line="39" />
+        <location filename="../app/AppLayouts/Profile/views/wallet/PermissionsListView.qml" line="40" />
+        <location filename="../app/AppLayouts/Profile/views/wallet/PermissionsListView.qml" line="40" />
         <source>Disconnect All</source>
         <translation>Disconnect All</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/views/wallet/PermissionsListView.qml" line="39" />
-        <location filename="../app/AppLayouts/Profile/views/wallet/PermissionsListView.qml" line="39" />
+        <location filename="../app/AppLayouts/Profile/views/wallet/PermissionsListView.qml" line="40" />
+        <location filename="../app/AppLayouts/Profile/views/wallet/PermissionsListView.qml" line="40" />
         <source>Disconnect</source>
         <translation>Disconnect</translation>
     </message>
@@ -10756,57 +10874,64 @@ please remove and try and again</translation>
 <context>
     <name>PinnedMessagesPopup</name>
     <message>
-        <location filename="../app/AppLayouts/Chat/popups/PinnedMessagesPopup.qml" line="27" />
-        <location filename="../app/AppLayouts/Chat/popups/PinnedMessagesPopup.qml" line="27" />
+        <location filename="../app/AppLayouts/Chat/popups/PinnedMessagesPopup.qml" line="28" />
+        <location filename="../app/AppLayouts/Chat/popups/PinnedMessagesPopup.qml" line="28" />
         <source>Pin limit reached</source>
         <translation>Pin limit reached</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/popups/PinnedMessagesPopup.qml" line="27" />
-        <location filename="../app/AppLayouts/Chat/popups/PinnedMessagesPopup.qml" line="27" />
+        <location filename="../app/AppLayouts/Chat/popups/PinnedMessagesPopup.qml" line="28" />
+        <location filename="../app/AppLayouts/Chat/popups/PinnedMessagesPopup.qml" line="28" />
         <source>Pinned messages</source>
         <translation>Pinned messages</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/popups/PinnedMessagesPopup.qml" line="32" />
-        <location filename="../app/AppLayouts/Chat/popups/PinnedMessagesPopup.qml" line="32" />
+        <location filename="../app/AppLayouts/Chat/popups/PinnedMessagesPopup.qml" line="29" />
+        <location filename="../app/AppLayouts/Chat/popups/PinnedMessagesPopup.qml" line="29" />
         <source>Unpin a previous message first</source>
         <translation>Unpin a previous message first</translation>
     </message>
     <message numerus="yes">
-        <location filename="../app/AppLayouts/Chat/popups/PinnedMessagesPopup.qml" line="33" />
-        <location filename="../app/AppLayouts/Chat/popups/PinnedMessagesPopup.qml" line="33" />
+        <location filename="../app/AppLayouts/Chat/popups/PinnedMessagesPopup.qml" line="30" />
+        <location filename="../app/AppLayouts/Chat/popups/PinnedMessagesPopup.qml" line="30" />
         <source>%n message(s)</source>
         <translation type="unfinished">
+            <numerusform />
             <numerusform />
         </translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/popups/PinnedMessagesPopup.qml" line="40" />
-        <location filename="../app/AppLayouts/Chat/popups/PinnedMessagesPopup.qml" line="40" />
+        <location filename="../app/AppLayouts/Chat/popups/PinnedMessagesPopup.qml" line="37" />
+        <location filename="../app/AppLayouts/Chat/popups/PinnedMessagesPopup.qml" line="37" />
         <source>Pinned messages will appear here.</source>
         <translation>Pinned messages will appear here.</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/popups/PinnedMessagesPopup.qml" line="155" />
-        <location filename="../app/AppLayouts/Chat/popups/PinnedMessagesPopup.qml" line="155" />
+        <location filename="../app/AppLayouts/Chat/popups/PinnedMessagesPopup.qml" line="167" />
+        <location filename="../app/AppLayouts/Chat/popups/PinnedMessagesPopup.qml" line="167" />
         <source>Unpin selected message and pin new message</source>
         <translation>Unpin selected message and pin new message</translation>
     </message>
 </context>
 <context>
-    <name>PrivateChatPopup</name>
+    <name>Popups</name>
     <message>
-        <location filename="../app/AppLayouts/Chat/popups/PrivateChatPopup.qml" line="16" />
-        <location filename="../app/AppLayouts/Chat/popups/PrivateChatPopup.qml" line="16" />
-        <source>New chat</source>
-        <translation>New chat</translation>
+        <location filename="../app/mainui/Popups.qml" line="20" />
+        <location filename="../app/mainui/Popups.qml" line="20" />
+        <source>Verify %1's Identity</source>
+        <translation>Verify %1's Identity</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/popups/PrivateChatPopup.qml" line="79" />
-        <location filename="../app/AppLayouts/Chat/popups/PrivateChatPopup.qml" line="79" />
-        <source>My Profile</source>
-        <translation>My Profile</translation>
+        <location filename="../app/mainui/Popups.qml" line="21" />
+        <location filename="../app/mainui/Popups.qml" line="21" />
+        <source>Ask a question that only the real %1 will be able to answer e.g. a question about a shared experience, or ask %1 to enter a code or phrase you have sent to them via a different communication channel (phone, post, etc...).</source>
+        <translation>Ask a question that only the real %1 will be able to answer e.g. a question about a shared experience, or ask %1 to enter a code or phrase you have sent to them via a different communication channel (phone, post, etc...).</translation>
+    </message>
+    <message>
+        <location filename="../app/mainui/Popups.qml" line="22" />
+        <location filename="../app/mainui/Popups.qml" line="22" />
+        <source>Send verification request</source>
+        <translation>Send verification request</translation>
     </message>
 </context>
 <context>
@@ -10836,8 +10961,8 @@ please remove and try and again</translation>
         <translation>Tell us about yourself</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/panels/ProfileDescriptionPanel.qml" line="92" />
-        <location filename="../app/AppLayouts/Profile/panels/ProfileDescriptionPanel.qml" line="92" />
+        <location filename="../app/AppLayouts/Profile/panels/ProfileDescriptionPanel.qml" line="93" />
+        <location filename="../app/AppLayouts/Profile/panels/ProfileDescriptionPanel.qml" line="93" />
         <source>Add more social links</source>
         <translation>Add more social links</translation>
     </message>
@@ -10845,202 +10970,206 @@ please remove and try and again</translation>
 <context>
     <name>ProfileDialogView</name>
     <message>
-        <location filename="../imports/shared/views/ProfileDialogView.qml" line="104" />
-        <location filename="../imports/shared/views/ProfileDialogView.qml" line="104" />
+        <location filename="../imports/shared/views/ProfileDialogView.qml" line="110" />
+        <location filename="../imports/shared/views/ProfileDialogView.qml" line="110" />
         <source>Edit Profile</source>
         <translation>Edit Profile</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/ProfileDialogView.qml" line="117" />
-        <location filename="../imports/shared/views/ProfileDialogView.qml" line="117" />
+        <location filename="../imports/shared/views/ProfileDialogView.qml" line="123" />
+        <location filename="../imports/shared/views/ProfileDialogView.qml" line="123" />
         <source>Send Message</source>
         <translation>Send Message</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/ProfileDialogView.qml" line="133" />
-        <location filename="../imports/shared/views/ProfileDialogView.qml" line="133" />
+        <location filename="../imports/shared/views/ProfileDialogView.qml" line="139" />
+        <location filename="../imports/shared/views/ProfileDialogView.qml" line="139" />
         <source>Respond to contact request</source>
         <translation>Respond to contact request</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/ProfileDialogView.qml" line="154" />
-        <location filename="../imports/shared/views/ProfileDialogView.qml" line="154" />
+        <location filename="../imports/shared/views/ProfileDialogView.qml" line="160" />
+        <location filename="../imports/shared/views/ProfileDialogView.qml" line="160" />
         <source>Send Contact Request</source>
         <translation>Send Contact Request</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/ProfileDialogView.qml" line="167" />
-        <location filename="../imports/shared/views/ProfileDialogView.qml" line="507" />
-        <location filename="../imports/shared/views/ProfileDialogView.qml" line="167" />
-        <location filename="../imports/shared/views/ProfileDialogView.qml" line="507" />
+        <location filename="../imports/shared/views/ProfileDialogView.qml" line="173" />
+        <location filename="../imports/shared/views/ProfileDialogView.qml" line="514" />
+        <location filename="../imports/shared/views/ProfileDialogView.qml" line="173" />
+        <location filename="../imports/shared/views/ProfileDialogView.qml" line="514" />
         <source>Block User</source>
         <translation>Block User</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/ProfileDialogView.qml" line="176" />
-        <location filename="../imports/shared/views/ProfileDialogView.qml" line="442" />
-        <location filename="../imports/shared/views/ProfileDialogView.qml" line="176" />
-        <location filename="../imports/shared/views/ProfileDialogView.qml" line="442" />
+        <location filename="../imports/shared/views/ProfileDialogView.qml" line="182" />
+        <location filename="../imports/shared/views/ProfileDialogView.qml" line="449" />
+        <location filename="../imports/shared/views/ProfileDialogView.qml" line="182" />
+        <location filename="../imports/shared/views/ProfileDialogView.qml" line="449" />
         <source>Unblock User</source>
         <translation>Unblock User</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/ProfileDialogView.qml" line="188" />
-        <location filename="../imports/shared/views/ProfileDialogView.qml" line="188" />
+        <location filename="../imports/shared/views/ProfileDialogView.qml" line="194" />
+        <location filename="../imports/shared/views/ProfileDialogView.qml" line="194" />
         <source>Contact Request Pending...</source>
         <translation>Contact Request Pending...</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/ProfileDialogView.qml" line="199" />
-        <location filename="../imports/shared/views/ProfileDialogView.qml" line="199" />
+        <location filename="../imports/shared/views/ProfileDialogView.qml" line="205" />
+        <location filename="../imports/shared/views/ProfileDialogView.qml" line="205" />
         <source>Contact Request Rejected</source>
         <translation>Contact Request Rejected</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/ProfileDialogView.qml" line="207" />
-        <location filename="../imports/shared/views/ProfileDialogView.qml" line="207" />
+        <location filename="../imports/shared/views/ProfileDialogView.qml" line="213" />
+        <location filename="../imports/shared/views/ProfileDialogView.qml" line="213" />
         <source>Respond to ID Request</source>
         <translation>Respond to ID Request</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/ProfileDialogView.qml" line="217" />
-        <location filename="../imports/shared/views/ProfileDialogView.qml" line="217" />
+        <location filename="../imports/shared/views/ProfileDialogView.qml" line="223" />
+        <location filename="../imports/shared/views/ProfileDialogView.qml" line="223" />
         <source>Remove contact '%1'</source>
         <translation>Remove contact '%1'</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/ProfileDialogView.qml" line="218" />
-        <location filename="../imports/shared/views/ProfileDialogView.qml" line="218" />
+        <location filename="../imports/shared/views/ProfileDialogView.qml" line="224" />
+        <location filename="../imports/shared/views/ProfileDialogView.qml" line="224" />
         <source>This will remove the user as a contact. Please confirm.</source>
         <translation>This will remove the user as a contact. Please confirm.</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/ProfileDialogView.qml" line="228" />
-        <location filename="../imports/shared/views/ProfileDialogView.qml" line="228" />
+        <location filename="../imports/shared/views/ProfileDialogView.qml" line="234" />
+        <location filename="../imports/shared/views/ProfileDialogView.qml" line="234" />
         <source>Remove contact verification</source>
         <translation>Remove contact verification</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/ProfileDialogView.qml" line="229" />
-        <location filename="../imports/shared/views/ProfileDialogView.qml" line="229" />
+        <location filename="../imports/shared/views/ProfileDialogView.qml" line="235" />
+        <location filename="../imports/shared/views/ProfileDialogView.qml" line="235" />
         <source>This will remove the contact's verified status. Please confirm.</source>
         <translation>This will remove the contact's verified status. Please confirm.</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/ProfileDialogView.qml" line="393" />
-        <location filename="../imports/shared/views/ProfileDialogView.qml" line="393" />
+        <location filename="../imports/shared/views/ProfileDialogView.qml" line="400" />
+        <location filename="../imports/shared/views/ProfileDialogView.qml" line="400" />
         <source>Verify Identity</source>
         <translation>Verify Identity</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/ProfileDialogView.qml" line="405" />
-        <location filename="../imports/shared/views/ProfileDialogView.qml" line="405" />
+        <location filename="../imports/shared/views/ProfileDialogView.qml" line="412" />
+        <location filename="../imports/shared/views/ProfileDialogView.qml" line="412" />
         <source>ID Request Pending...</source>
         <translation>ID Request Pending...</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/ProfileDialogView.qml" line="415" />
-        <location filename="../imports/shared/views/ProfileDialogView.qml" line="415" />
+        <location filename="../imports/shared/views/ProfileDialogView.qml" line="422" />
+        <location filename="../imports/shared/views/ProfileDialogView.qml" line="422" />
         <source>Rename</source>
         <translation>Rename</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/ProfileDialogView.qml" line="424" />
-        <location filename="../imports/shared/views/ProfileDialogView.qml" line="424" />
+        <location filename="../imports/shared/views/ProfileDialogView.qml" line="431" />
+        <location filename="../imports/shared/views/ProfileDialogView.qml" line="431" />
         <source>Reverse Contact Rejection</source>
         <translation>Reverse Contact Rejection</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/ProfileDialogView.qml" line="434" />
-        <location filename="../imports/shared/views/ProfileDialogView.qml" line="434" />
+        <location filename="../imports/shared/views/ProfileDialogView.qml" line="441" />
+        <location filename="../imports/shared/views/ProfileDialogView.qml" line="441" />
         <source>Copy Link to Profile</source>
         <translation>Copy Link to Profile</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/ProfileDialogView.qml" line="452" />
-        <location filename="../imports/shared/views/ProfileDialogView.qml" line="452" />
+        <location filename="../imports/shared/views/ProfileDialogView.qml" line="459" />
+        <location filename="../imports/shared/views/ProfileDialogView.qml" line="459" />
         <source>Mark as Untrustworthy</source>
         <translation>Mark as Untrustworthy</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/ProfileDialogView.qml" line="466" />
-        <location filename="../imports/shared/views/ProfileDialogView.qml" line="466" />
+        <location filename="../imports/shared/views/ProfileDialogView.qml" line="473" />
+        <location filename="../imports/shared/views/ProfileDialogView.qml" line="473" />
         <source>Remove Untrustworthy Mark</source>
         <translation>Remove Untrustworthy Mark</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/ProfileDialogView.qml" line="476" />
-        <location filename="../imports/shared/views/ProfileDialogView.qml" line="476" />
+        <location filename="../imports/shared/views/ProfileDialogView.qml" line="483" />
+        <location filename="../imports/shared/views/ProfileDialogView.qml" line="483" />
         <source>Remove Identity Verification</source>
         <translation>Remove Identity Verification</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/ProfileDialogView.qml" line="486" />
-        <location filename="../imports/shared/views/ProfileDialogView.qml" line="486" />
+        <location filename="../imports/shared/views/ProfileDialogView.qml" line="493" />
+        <location filename="../imports/shared/views/ProfileDialogView.qml" line="493" />
         <source>Remove Contact</source>
         <translation>Remove Contact</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/ProfileDialogView.qml" line="496" />
-        <location filename="../imports/shared/views/ProfileDialogView.qml" line="496" />
+        <location filename="../imports/shared/views/ProfileDialogView.qml" line="503" />
+        <location filename="../imports/shared/views/ProfileDialogView.qml" line="503" />
         <source>Cancel Contact Request</source>
         <translation>Cancel Contact Request</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/ProfileDialogView.qml" line="565" />
-        <location filename="../imports/shared/views/ProfileDialogView.qml" line="565" />
+        <location filename="../imports/shared/views/ProfileDialogView.qml" line="574" />
+        <location filename="../imports/shared/views/ProfileDialogView.qml" line="574" />
         <source>Link to Profile</source>
         <translation>Link to Profile</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/ProfileDialogView.qml" line="584" />
-        <location filename="../imports/shared/views/ProfileDialogView.qml" line="615" />
-        <location filename="../imports/shared/views/ProfileDialogView.qml" line="584" />
-        <location filename="../imports/shared/views/ProfileDialogView.qml" line="615" />
+        <location filename="../imports/shared/views/ProfileDialogView.qml" line="594" />
+        <location filename="../imports/shared/views/ProfileDialogView.qml" line="599" />
+        <location filename="../imports/shared/views/ProfileDialogView.qml" line="629" />
+        <location filename="../imports/shared/views/ProfileDialogView.qml" line="634" />
+        <location filename="../imports/shared/views/ProfileDialogView.qml" line="594" />
+        <location filename="../imports/shared/views/ProfileDialogView.qml" line="599" />
+        <location filename="../imports/shared/views/ProfileDialogView.qml" line="629" />
+        <location filename="../imports/shared/views/ProfileDialogView.qml" line="634" />
         <source>Copy</source>
         <translation>Copy</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/ProfileDialogView.qml" line="586" />
-        <location filename="../imports/shared/views/ProfileDialogView.qml" line="618" />
-        <location filename="../imports/shared/views/ProfileDialogView.qml" line="586" />
-        <location filename="../imports/shared/views/ProfileDialogView.qml" line="618" />
+        <location filename="../imports/shared/views/ProfileDialogView.qml" line="596" />
+        <location filename="../imports/shared/views/ProfileDialogView.qml" line="632" />
+        <location filename="../imports/shared/views/ProfileDialogView.qml" line="596" />
+        <location filename="../imports/shared/views/ProfileDialogView.qml" line="632" />
         <source>Copied</source>
         <translation>Copied</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/ProfileDialogView.qml" line="595" />
-        <location filename="../imports/shared/views/ProfileDialogView.qml" line="595" />
+        <location filename="../imports/shared/views/ProfileDialogView.qml" line="608" />
+        <location filename="../imports/shared/views/ProfileDialogView.qml" line="608" />
         <source>Emoji Hash</source>
         <translation>Emoji Hash</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/ProfileDialogView.qml" line="655" />
-        <location filename="../imports/shared/views/ProfileDialogView.qml" line="655" />
+        <location filename="../imports/shared/views/ProfileDialogView.qml" line="672" />
+        <location filename="../imports/shared/views/ProfileDialogView.qml" line="672" />
         <source>Tokens</source>
         <translation>Tokens</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/ProfileDialogView.qml" line="659" />
-        <location filename="../imports/shared/views/ProfileDialogView.qml" line="659" />
+        <location filename="../imports/shared/views/ProfileDialogView.qml" line="676" />
+        <location filename="../imports/shared/views/ProfileDialogView.qml" line="676" />
         <source>NFTs</source>
         <translation>NFTs</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/ProfileDialogView.qml" line="663" />
-        <location filename="../imports/shared/views/ProfileDialogView.qml" line="663" />
+        <location filename="../imports/shared/views/ProfileDialogView.qml" line="680" />
+        <location filename="../imports/shared/views/ProfileDialogView.qml" line="680" />
         <source>Communities</source>
         <translation>Communities</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/ProfileDialogView.qml" line="667" />
-        <location filename="../imports/shared/views/ProfileDialogView.qml" line="667" />
+        <location filename="../imports/shared/views/ProfileDialogView.qml" line="684" />
+        <location filename="../imports/shared/views/ProfileDialogView.qml" line="684" />
         <source>Accounts</source>
         <translation>Accounts</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/ProfileDialogView.qml" line="688" />
-        <location filename="../imports/shared/views/ProfileDialogView.qml" line="688" />
+        <location filename="../imports/shared/views/ProfileDialogView.qml" line="705" />
+        <location filename="../imports/shared/views/ProfileDialogView.qml" line="705" />
         <source>More content to appear here soon...</source>
         <translation>More content to appear here soon...</translation>
     </message>
@@ -11048,20 +11177,20 @@ please remove and try and again</translation>
 <context>
     <name>ProfileHeader</name>
     <message>
-        <location filename="../imports/shared/controls/chat/ProfileHeader.qml" line="187" />
-        <location filename="../imports/shared/controls/chat/ProfileHeader.qml" line="187" />
+        <location filename="../imports/shared/controls/chat/ProfileHeader.qml" line="225" />
+        <location filename="../imports/shared/controls/chat/ProfileHeader.qml" line="225" />
         <source>Chatkey:%1...</source>
         <translation>Chatkey:%1...</translation>
     </message>
     <message>
-        <location filename="../imports/shared/controls/chat/ProfileHeader.qml" line="216" />
-        <location filename="../imports/shared/controls/chat/ProfileHeader.qml" line="216" />
+        <location filename="../imports/shared/controls/chat/ProfileHeader.qml" line="254" />
+        <location filename="../imports/shared/controls/chat/ProfileHeader.qml" line="254" />
         <source>Upload a file</source>
         <translation>Upload a file</translation>
     </message>
     <message>
-        <location filename="../imports/shared/controls/chat/ProfileHeader.qml" line="223" />
-        <location filename="../imports/shared/controls/chat/ProfileHeader.qml" line="223" />
+        <location filename="../imports/shared/controls/chat/ProfileHeader.qml" line="261" />
+        <location filename="../imports/shared/controls/chat/ProfileHeader.qml" line="261" />
         <source>Remove image</source>
         <translation>Remove image</translation>
     </message>
@@ -11069,8 +11198,8 @@ please remove and try and again</translation>
 <context>
     <name>ProfileLayout</name>
     <message>
-        <location filename="../app/AppLayouts/Profile/ProfileLayout.qml" line="109" />
-        <location filename="../app/AppLayouts/Profile/ProfileLayout.qml" line="109" />
+        <location filename="../app/AppLayouts/Profile/ProfileLayout.qml" line="115" />
+        <location filename="../app/AppLayouts/Profile/ProfileLayout.qml" line="115" />
         <source>Contacts</source>
         <translation>Contacts</translation>
     </message>
@@ -11078,92 +11207,92 @@ please remove and try and again</translation>
 <context>
     <name>ProfileSectionStore</name>
     <message>
-        <location filename="../app/AppLayouts/Profile/stores/ProfileSectionStore.qml" line="83" />
-        <location filename="../app/AppLayouts/Profile/stores/ProfileSectionStore.qml" line="83" />
+        <location filename="../app/AppLayouts/Profile/stores/ProfileSectionStore.qml" line="79" />
+        <location filename="../app/AppLayouts/Profile/stores/ProfileSectionStore.qml" line="79" />
         <source>Back up seed phrase</source>
         <translation>Back up seed phrase</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/stores/ProfileSectionStore.qml" line="86" />
-        <location filename="../app/AppLayouts/Profile/stores/ProfileSectionStore.qml" line="86" />
+        <location filename="../app/AppLayouts/Profile/stores/ProfileSectionStore.qml" line="82" />
+        <location filename="../app/AppLayouts/Profile/stores/ProfileSectionStore.qml" line="82" />
         <source>Profile</source>
         <translation>Profile</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/stores/ProfileSectionStore.qml" line="89" />
-        <location filename="../app/AppLayouts/Profile/stores/ProfileSectionStore.qml" line="89" />
+        <location filename="../app/AppLayouts/Profile/stores/ProfileSectionStore.qml" line="85" />
+        <location filename="../app/AppLayouts/Profile/stores/ProfileSectionStore.qml" line="85" />
         <source>Keycard</source>
         <translation>Keycard</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/stores/ProfileSectionStore.qml" line="92" />
-        <location filename="../app/AppLayouts/Profile/stores/ProfileSectionStore.qml" line="92" />
+        <location filename="../app/AppLayouts/Profile/stores/ProfileSectionStore.qml" line="88" />
+        <location filename="../app/AppLayouts/Profile/stores/ProfileSectionStore.qml" line="88" />
         <source>ENS usernames</source>
         <translation>ENS usernames</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/stores/ProfileSectionStore.qml" line="100" />
-        <location filename="../app/AppLayouts/Profile/stores/ProfileSectionStore.qml" line="100" />
+        <location filename="../app/AppLayouts/Profile/stores/ProfileSectionStore.qml" line="96" />
+        <location filename="../app/AppLayouts/Profile/stores/ProfileSectionStore.qml" line="96" />
         <source>Messaging</source>
         <translation>Messaging</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/stores/ProfileSectionStore.qml" line="103" />
-        <location filename="../app/AppLayouts/Profile/stores/ProfileSectionStore.qml" line="103" />
+        <location filename="../app/AppLayouts/Profile/stores/ProfileSectionStore.qml" line="99" />
+        <location filename="../app/AppLayouts/Profile/stores/ProfileSectionStore.qml" line="99" />
         <source>Wallet</source>
         <translation>Wallet</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/stores/ProfileSectionStore.qml" line="106" />
-        <location filename="../app/AppLayouts/Profile/stores/ProfileSectionStore.qml" line="106" />
+        <location filename="../app/AppLayouts/Profile/stores/ProfileSectionStore.qml" line="102" />
+        <location filename="../app/AppLayouts/Profile/stores/ProfileSectionStore.qml" line="102" />
         <source>Browser</source>
         <translation>Browser</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/stores/ProfileSectionStore.qml" line="109" />
-        <location filename="../app/AppLayouts/Profile/stores/ProfileSectionStore.qml" line="109" />
+        <location filename="../app/AppLayouts/Profile/stores/ProfileSectionStore.qml" line="105" />
+        <location filename="../app/AppLayouts/Profile/stores/ProfileSectionStore.qml" line="105" />
         <source>Communities</source>
         <translation>Communities</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/stores/ProfileSectionStore.qml" line="117" />
-        <location filename="../app/AppLayouts/Profile/stores/ProfileSectionStore.qml" line="117" />
+        <location filename="../app/AppLayouts/Profile/stores/ProfileSectionStore.qml" line="113" />
+        <location filename="../app/AppLayouts/Profile/stores/ProfileSectionStore.qml" line="113" />
         <source>Appearance</source>
         <translation>Appearance</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/stores/ProfileSectionStore.qml" line="120" />
-        <location filename="../app/AppLayouts/Profile/stores/ProfileSectionStore.qml" line="120" />
+        <location filename="../app/AppLayouts/Profile/stores/ProfileSectionStore.qml" line="116" />
+        <location filename="../app/AppLayouts/Profile/stores/ProfileSectionStore.qml" line="116" />
         <source>Notifications &amp; Sounds</source>
         <translation>Notifications &amp; Sounds</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/stores/ProfileSectionStore.qml" line="123" />
-        <location filename="../app/AppLayouts/Profile/stores/ProfileSectionStore.qml" line="123" />
+        <location filename="../app/AppLayouts/Profile/stores/ProfileSectionStore.qml" line="119" />
+        <location filename="../app/AppLayouts/Profile/stores/ProfileSectionStore.qml" line="119" />
         <source>Language &amp; Currency</source>
         <translation>Language &amp; Currency</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/stores/ProfileSectionStore.qml" line="126" />
-        <location filename="../app/AppLayouts/Profile/stores/ProfileSectionStore.qml" line="126" />
+        <location filename="../app/AppLayouts/Profile/stores/ProfileSectionStore.qml" line="122" />
+        <location filename="../app/AppLayouts/Profile/stores/ProfileSectionStore.qml" line="122" />
         <source>Devices settings</source>
         <translation>Devices settings</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/stores/ProfileSectionStore.qml" line="129" />
-        <location filename="../app/AppLayouts/Profile/stores/ProfileSectionStore.qml" line="129" />
+        <location filename="../app/AppLayouts/Profile/stores/ProfileSectionStore.qml" line="125" />
+        <location filename="../app/AppLayouts/Profile/stores/ProfileSectionStore.qml" line="125" />
         <source>Advanced</source>
         <translation>Advanced</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/stores/ProfileSectionStore.qml" line="137" />
-        <location filename="../app/AppLayouts/Profile/stores/ProfileSectionStore.qml" line="137" />
+        <location filename="../app/AppLayouts/Profile/stores/ProfileSectionStore.qml" line="133" />
+        <location filename="../app/AppLayouts/Profile/stores/ProfileSectionStore.qml" line="133" />
         <source>About</source>
         <translation>About</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/stores/ProfileSectionStore.qml" line="140" />
-        <location filename="../app/AppLayouts/Profile/stores/ProfileSectionStore.qml" line="140" />
+        <location filename="../app/AppLayouts/Profile/stores/ProfileSectionStore.qml" line="136" />
+        <location filename="../app/AppLayouts/Profile/stores/ProfileSectionStore.qml" line="136" />
         <source>Sign out &amp; Quit</source>
         <translation>Sign out &amp; Quit</translation>
     </message>
@@ -11189,20 +11318,20 @@ please remove and try and again</translation>
         <translation>chat-name</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/popups/PublicChatPopup.qml" line="70" />
-        <location filename="../app/AppLayouts/Chat/popups/PublicChatPopup.qml" line="70" />
+        <location filename="../app/AppLayouts/Chat/popups/PublicChatPopup.qml" line="71" />
+        <location filename="../app/AppLayouts/Chat/popups/PublicChatPopup.qml" line="71" />
         <source>You need to enter a channel name</source>
         <translation>You need to enter a channel name</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/popups/PublicChatPopup.qml" line="75" />
-        <location filename="../app/AppLayouts/Chat/popups/PublicChatPopup.qml" line="75" />
+        <location filename="../app/AppLayouts/Chat/popups/PublicChatPopup.qml" line="76" />
+        <location filename="../app/AppLayouts/Chat/popups/PublicChatPopup.qml" line="76" />
         <source>The channel name can only contain lowercase letters, numbers and dashes</source>
         <translation>The channel name can only contain lowercase letters, numbers and dashes</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/popups/PublicChatPopup.qml" line="112" />
-        <location filename="../app/AppLayouts/Chat/popups/PublicChatPopup.qml" line="112" />
+        <location filename="../app/AppLayouts/Chat/popups/PublicChatPopup.qml" line="113" />
+        <location filename="../app/AppLayouts/Chat/popups/PublicChatPopup.qml" line="113" />
         <source>Start chat</source>
         <translation>Start chat</translation>
     </message>
@@ -11239,32 +11368,32 @@ please remove and try and again</translation>
 <context>
     <name>ReceiveModal</name>
     <message>
-        <location filename="../app/AppLayouts/Wallet/popups/ReceiveModal.qml" line="36" />
-        <location filename="../app/AppLayouts/Wallet/popups/ReceiveModal.qml" line="36" />
+        <location filename="../app/AppLayouts/Wallet/popups/ReceiveModal.qml" line="38" />
+        <location filename="../app/AppLayouts/Wallet/popups/ReceiveModal.qml" line="38" />
         <source>Receive</source>
         <translation>Receive</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/popups/ReceiveModal.qml" line="113" />
-        <location filename="../app/AppLayouts/Wallet/popups/ReceiveModal.qml" line="113" />
+        <location filename="../app/AppLayouts/Wallet/popups/ReceiveModal.qml" line="75" />
+        <location filename="../app/AppLayouts/Wallet/popups/ReceiveModal.qml" line="75" />
         <source>Legacy</source>
         <translation>Legacy</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/popups/ReceiveModal.qml" line="116" />
-        <location filename="../app/AppLayouts/Wallet/popups/ReceiveModal.qml" line="116" />
+        <location filename="../app/AppLayouts/Wallet/popups/ReceiveModal.qml" line="78" />
+        <location filename="../app/AppLayouts/Wallet/popups/ReceiveModal.qml" line="78" />
         <source>Multichain</source>
         <translation>Multichain</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/popups/ReceiveModal.qml" line="235" />
-        <location filename="../app/AppLayouts/Wallet/popups/ReceiveModal.qml" line="235" />
+        <location filename="../app/AppLayouts/Wallet/popups/ReceiveModal.qml" line="202" />
+        <location filename="../app/AppLayouts/Wallet/popups/ReceiveModal.qml" line="202" />
         <source>Your Address</source>
         <translation>Your Address</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/popups/ReceiveModal.qml" line="275" />
-        <location filename="../app/AppLayouts/Wallet/popups/ReceiveModal.qml" line="275" />
+        <location filename="../app/AppLayouts/Wallet/popups/ReceiveModal.qml" line="248" />
+        <location filename="../app/AppLayouts/Wallet/popups/ReceiveModal.qml" line="248" />
         <source>Copy</source>
         <translation>Copy</translation>
     </message>
@@ -11278,26 +11407,26 @@ please remove and try and again</translation>
         <translation>Invalid ethereum address</translation>
     </message>
     <message>
-        <location filename="../imports/shared/controls/RecipientSelector.qml" line="46" />
-        <location filename="../imports/shared/controls/RecipientSelector.qml" line="46" />
+        <location filename="../imports/shared/controls/RecipientSelector.qml" line="47" />
+        <location filename="../imports/shared/controls/RecipientSelector.qml" line="47" />
         <source>Address</source>
         <translation>Address</translation>
     </message>
     <message>
-        <location filename="../imports/shared/controls/RecipientSelector.qml" line="47" />
-        <location filename="../imports/shared/controls/RecipientSelector.qml" line="47" />
+        <location filename="../imports/shared/controls/RecipientSelector.qml" line="48" />
+        <location filename="../imports/shared/controls/RecipientSelector.qml" line="48" />
         <source>My account</source>
         <translation>My account</translation>
     </message>
     <message>
-        <location filename="../imports/shared/controls/RecipientSelector.qml" line="48" />
-        <location filename="../imports/shared/controls/RecipientSelector.qml" line="48" />
+        <location filename="../imports/shared/controls/RecipientSelector.qml" line="49" />
+        <location filename="../imports/shared/controls/RecipientSelector.qml" line="49" />
         <source>Contact</source>
         <translation>Contact</translation>
     </message>
     <message>
-        <location filename="../imports/shared/controls/RecipientSelector.qml" line="121" />
-        <location filename="../imports/shared/controls/RecipientSelector.qml" line="121" />
+        <location filename="../imports/shared/controls/RecipientSelector.qml" line="122" />
+        <location filename="../imports/shared/controls/RecipientSelector.qml" line="122" />
         <source>Recipient</source>
         <translation>Recipient</translation>
     </message>
@@ -11395,6 +11524,27 @@ please remove and try and again</translation>
     </message>
 </context>
 <context>
+    <name>ReviewContactRequestPopup</name>
+    <message>
+        <location filename="../app/mainui/activitycenter/popups/ReviewContactRequestPopup.qml" line="30" />
+        <location filename="../app/mainui/activitycenter/popups/ReviewContactRequestPopup.qml" line="30" />
+        <source>Review Contact Request</source>
+        <translation>Review Contact Request</translation>
+    </message>
+    <message>
+        <location filename="../app/mainui/activitycenter/popups/ReviewContactRequestPopup.qml" line="83" />
+        <location filename="../app/mainui/activitycenter/popups/ReviewContactRequestPopup.qml" line="83" />
+        <source>Accept Contact Request</source>
+        <translation>Accept Contact Request</translation>
+    </message>
+    <message>
+        <location filename="../app/mainui/activitycenter/popups/ReviewContactRequestPopup.qml" line="91" />
+        <location filename="../app/mainui/activitycenter/popups/ReviewContactRequestPopup.qml" line="91" />
+        <source>Reject Contact Request</source>
+        <translation>Reject Contact Request</translation>
+    </message>
+</context>
+<context>
     <name>RightTabView</name>
     <message>
         <location filename="../app/AppLayouts/Wallet/views/RightTabView.qml" line="32" />
@@ -11424,61 +11574,49 @@ please remove and try and again</translation>
 <context>
     <name>RootStore</name>
     <message>
-        <location filename="../app/AppLayouts/Chat/stores/RootStore.qml" line="203" />
-        <location filename="../app/AppLayouts/Chat/stores/RootStore.qml" line="203" />
+        <location filename="../app/AppLayouts/Chat/stores/RootStore.qml" line="179" />
+        <location filename="../app/AppLayouts/Chat/stores/RootStore.qml" line="179" />
         <source>You</source>
         <translation>You</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/stores/RootStore.qml" line="403" />
-        <location filename="../app/AppLayouts/Chat/stores/RootStore.qml" line="403" />
-        <source>Start a 1-on-1 chat with %1</source>
-        <translation>Start a 1-on-1 chat with %1</translation>
-    </message>
-    <message>
-        <location filename="../app/AppLayouts/Chat/stores/RootStore.qml" line="431" />
-        <location filename="../app/AppLayouts/Chat/stores/RootStore.qml" line="431" />
+        <location filename="../app/AppLayouts/Chat/stores/RootStore.qml" line="412" />
+        <location filename="../app/AppLayouts/Chat/stores/RootStore.qml" line="412" />
         <source>Join the %1 community</source>
         <translation>Join the %1 community</translation>
-    </message>
-    <message>
-        <location filename="../app/AppLayouts/Chat/stores/RootStore.qml" line="458" />
-        <location filename="../app/AppLayouts/Chat/stores/RootStore.qml" line="458" />
-        <source>Join the %1 group chat</source>
-        <translation>Join the %1 group chat</translation>
     </message>
 </context>
 <context>
     <name>SavedAddressesDelegate</name>
     <message>
-        <location filename="../imports/shared/controls/SavedAddressesDelegate.qml" line="109" />
-        <location filename="../imports/shared/controls/SavedAddressesDelegate.qml" line="109" />
+        <location filename="../imports/shared/controls/SavedAddressesDelegate.qml" line="108" />
+        <location filename="../imports/shared/controls/SavedAddressesDelegate.qml" line="108" />
         <source>Edit</source>
         <translation>Edit</translation>
     </message>
     <message>
-        <location filename="../imports/shared/controls/SavedAddressesDelegate.qml" line="124" />
-        <location filename="../imports/shared/controls/SavedAddressesDelegate.qml" line="179" />
-        <location filename="../imports/shared/controls/SavedAddressesDelegate.qml" line="124" />
-        <location filename="../imports/shared/controls/SavedAddressesDelegate.qml" line="179" />
+        <location filename="../imports/shared/controls/SavedAddressesDelegate.qml" line="123" />
+        <location filename="../imports/shared/controls/SavedAddressesDelegate.qml" line="178" />
+        <location filename="../imports/shared/controls/SavedAddressesDelegate.qml" line="123" />
+        <location filename="../imports/shared/controls/SavedAddressesDelegate.qml" line="178" />
         <source>Delete</source>
         <translation>Delete</translation>
     </message>
     <message>
-        <location filename="../imports/shared/controls/SavedAddressesDelegate.qml" line="157" />
-        <location filename="../imports/shared/controls/SavedAddressesDelegate.qml" line="157" />
+        <location filename="../imports/shared/controls/SavedAddressesDelegate.qml" line="156" />
+        <location filename="../imports/shared/controls/SavedAddressesDelegate.qml" line="156" />
         <source>Are you sure?</source>
         <translation>Are you sure?</translation>
     </message>
     <message>
-        <location filename="../imports/shared/controls/SavedAddressesDelegate.qml" line="162" />
-        <location filename="../imports/shared/controls/SavedAddressesDelegate.qml" line="162" />
+        <location filename="../imports/shared/controls/SavedAddressesDelegate.qml" line="161" />
+        <location filename="../imports/shared/controls/SavedAddressesDelegate.qml" line="161" />
         <source>Are you sure you want to remove '%1' from your saved addresses?</source>
         <translation>Are you sure you want to remove '%1' from your saved addresses?</translation>
     </message>
     <message>
-        <location filename="../imports/shared/controls/SavedAddressesDelegate.qml" line="173" />
-        <location filename="../imports/shared/controls/SavedAddressesDelegate.qml" line="173" />
+        <location filename="../imports/shared/controls/SavedAddressesDelegate.qml" line="172" />
+        <location filename="../imports/shared/controls/SavedAddressesDelegate.qml" line="172" />
         <source>Cancel</source>
         <translation>Cancel</translation>
     </message>
@@ -11516,14 +11654,14 @@ please remove and try and again</translation>
 <context>
     <name>SearchEngineModal</name>
     <message>
-        <location filename="../app/AppLayouts/Profile/popups/SearchEngineModal.qml" line="12" />
-        <location filename="../app/AppLayouts/Profile/popups/SearchEngineModal.qml" line="12" />
+        <location filename="../app/AppLayouts/Profile/popups/SearchEngineModal.qml" line="14" />
+        <location filename="../app/AppLayouts/Profile/popups/SearchEngineModal.qml" line="14" />
         <source>Search engine</source>
         <translation>Search engine</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/popups/SearchEngineModal.qml" line="31" />
-        <location filename="../app/AppLayouts/Profile/popups/SearchEngineModal.qml" line="31" />
+        <location filename="../app/AppLayouts/Profile/popups/SearchEngineModal.qml" line="33" />
+        <location filename="../app/AppLayouts/Profile/popups/SearchEngineModal.qml" line="33" />
         <source>None</source>
         <translation>None</translation>
     </message>
@@ -11592,6 +11730,7 @@ please remove and try and again</translation>
         <location filename="../app/AppLayouts/Onboarding/views/SeedPhraseInputView.qml" line="99" />
         <source>%n word(s)</source>
         <translation type="unfinished">
+            <numerusform />
             <numerusform />
         </translation>
     </message>
@@ -11709,38 +11848,38 @@ your PIN or if the wrong PIN is entered five times in a row.</translation>
 <context>
     <name>SelectGeneratedAccount</name>
     <message>
-        <location filename="../app/AppLayouts/Wallet/panels/SelectGeneratedAccount.qml" line="40" />
-        <location filename="../app/AppLayouts/Wallet/panels/SelectGeneratedAccount.qml" line="40" />
+        <location filename="../app/AppLayouts/Wallet/panels/SelectGeneratedAccount.qml" line="45" />
+        <location filename="../app/AppLayouts/Wallet/panels/SelectGeneratedAccount.qml" line="45" />
         <source>Import new Seed Phrase</source>
         <translation>Import new Seed Phrase</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/panels/SelectGeneratedAccount.qml" line="41" />
-        <location filename="../app/AppLayouts/Wallet/panels/SelectGeneratedAccount.qml" line="41" />
+        <location filename="../app/AppLayouts/Wallet/panels/SelectGeneratedAccount.qml" line="46" />
+        <location filename="../app/AppLayouts/Wallet/panels/SelectGeneratedAccount.qml" line="46" />
         <source>Generate from Private key</source>
         <translation>Generate from Private key</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/panels/SelectGeneratedAccount.qml" line="42" />
-        <location filename="../app/AppLayouts/Wallet/panels/SelectGeneratedAccount.qml" line="42" />
+        <location filename="../app/AppLayouts/Wallet/panels/SelectGeneratedAccount.qml" line="47" />
+        <location filename="../app/AppLayouts/Wallet/panels/SelectGeneratedAccount.qml" line="47" />
         <source>Add a watch-only address</source>
         <translation>Add a watch-only address</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/panels/SelectGeneratedAccount.qml" line="60" />
-        <location filename="../app/AppLayouts/Wallet/panels/SelectGeneratedAccount.qml" line="60" />
+        <location filename="../app/AppLayouts/Wallet/panels/SelectGeneratedAccount.qml" line="66" />
+        <location filename="../app/AppLayouts/Wallet/panels/SelectGeneratedAccount.qml" line="66" />
         <source>Imported</source>
         <translation>Imported</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/panels/SelectGeneratedAccount.qml" line="64" />
-        <location filename="../app/AppLayouts/Wallet/panels/SelectGeneratedAccount.qml" line="64" />
+        <location filename="../app/AppLayouts/Wallet/panels/SelectGeneratedAccount.qml" line="70" />
+        <location filename="../app/AppLayouts/Wallet/panels/SelectGeneratedAccount.qml" line="70" />
         <source>Add new</source>
         <translation>Add new</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Wallet/panels/SelectGeneratedAccount.qml" line="72" />
-        <location filename="../app/AppLayouts/Wallet/panels/SelectGeneratedAccount.qml" line="72" />
+        <location filename="../app/AppLayouts/Wallet/panels/SelectGeneratedAccount.qml" line="78" />
+        <location filename="../app/AppLayouts/Wallet/panels/SelectGeneratedAccount.qml" line="78" />
         <source>Origin</source>
         <translation>Origin</translation>
     </message>
@@ -11790,44 +11929,44 @@ your PIN or if the wrong PIN is entered five times in a row.</translation>
         <translation>Send Contact Request to chat key</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/popups/SendContactRequestModal.qml" line="95" />
-        <location filename="../app/AppLayouts/Profile/popups/SendContactRequestModal.qml" line="95" />
+        <location filename="../app/AppLayouts/Profile/popups/SendContactRequestModal.qml" line="98" />
+        <location filename="../app/AppLayouts/Profile/popups/SendContactRequestModal.qml" line="98" />
         <source>Paste</source>
         <translation>Paste</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/popups/SendContactRequestModal.qml" line="115" />
-        <location filename="../app/AppLayouts/Profile/popups/SendContactRequestModal.qml" line="115" />
+        <location filename="../app/AppLayouts/Profile/popups/SendContactRequestModal.qml" line="119" />
+        <location filename="../app/AppLayouts/Profile/popups/SendContactRequestModal.qml" line="119" />
         <source>Enter chat key here</source>
         <translation>Enter chat key here</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/popups/SendContactRequestModal.qml" line="137" />
+        <location filename="../app/AppLayouts/Profile/popups/SendContactRequestModal.qml" line="142" />
         <location filename="../imports/shared/popups/SendContactRequestModal.qml" line="22" />
-        <location filename="../app/AppLayouts/Profile/popups/SendContactRequestModal.qml" line="137" />
+        <location filename="../app/AppLayouts/Profile/popups/SendContactRequestModal.qml" line="142" />
         <location filename="../imports/shared/popups/SendContactRequestModal.qml" line="22" />
         <source>Say who you are / why you want to become a contact...</source>
         <translation>Say who you are / why you want to become a contact...</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/popups/SendContactRequestModal.qml" line="145" />
-        <location filename="../imports/shared/popups/SendContactRequestModal.qml" line="73" />
-        <location filename="../app/AppLayouts/Profile/popups/SendContactRequestModal.qml" line="145" />
-        <location filename="../imports/shared/popups/SendContactRequestModal.qml" line="73" />
+        <location filename="../app/AppLayouts/Profile/popups/SendContactRequestModal.qml" line="150" />
+        <location filename="../imports/shared/popups/SendContactRequestModal.qml" line="77" />
+        <location filename="../app/AppLayouts/Profile/popups/SendContactRequestModal.qml" line="150" />
+        <location filename="../imports/shared/popups/SendContactRequestModal.qml" line="77" />
         <source>who are you</source>
         <translation>who are you</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/popups/SendContactRequestModal.qml" line="155" />
+        <location filename="../app/AppLayouts/Profile/popups/SendContactRequestModal.qml" line="161" />
         <location filename="../imports/shared/popups/SendContactRequestModal.qml" line="23" />
-        <location filename="../app/AppLayouts/Profile/popups/SendContactRequestModal.qml" line="155" />
+        <location filename="../app/AppLayouts/Profile/popups/SendContactRequestModal.qml" line="161" />
         <location filename="../imports/shared/popups/SendContactRequestModal.qml" line="23" />
         <source>Send Contact Request</source>
         <translation>Send Contact Request</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/SendContactRequestModal.qml" line="28" />
-        <location filename="../imports/shared/popups/SendContactRequestModal.qml" line="28" />
+        <location filename="../imports/shared/popups/SendContactRequestModal.qml" line="30" />
+        <location filename="../imports/shared/popups/SendContactRequestModal.qml" line="30" />
         <source>Send Contact Request to %1</source>
         <translation>Send Contact Request to %1</translation>
     </message>
@@ -11844,62 +11983,78 @@ your PIN or if the wrong PIN is entered five times in a row.</translation>
 <context>
     <name>SendModal</name>
     <message>
-        <location filename="../imports/shared/popups/SendModal.qml" line="34" />
-        <location filename="../imports/shared/popups/SendModal.qml" line="34" />
+        <location filename="../imports/shared/popups/SendModal.qml" line="43" />
+        <location filename="../imports/shared/popups/SendModal.qml" line="43" />
         <source>Error sending the transaction</source>
         <translation>Error sending the transaction</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/SendModal.qml" line="168" />
-        <location filename="../imports/shared/popups/SendModal.qml" line="168" />
+        <location filename="../imports/shared/popups/SendModal.qml" line="217" />
+        <location filename="../imports/shared/popups/SendModal.qml" line="493" />
+        <location filename="../imports/shared/popups/SendModal.qml" line="217" />
+        <location filename="../imports/shared/popups/SendModal.qml" line="493" />
+        <source>Bridge</source>
+        <translation>Bridge</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/popups/SendModal.qml" line="217" />
+        <location filename="../imports/shared/popups/SendModal.qml" line="493" />
+        <location filename="../imports/shared/popups/SendModal.qml" line="217" />
+        <location filename="../imports/shared/popups/SendModal.qml" line="493" />
         <source>Send</source>
         <translation>Send</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/SendModal.qml" line="175" />
-        <location filename="../imports/shared/popups/SendModal.qml" line="175" />
+        <location filename="../imports/shared/popups/SendModal.qml" line="224" />
+        <location filename="../imports/shared/popups/SendModal.qml" line="224" />
         <source>Max: %1</source>
         <translation>Max: %1</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/SendModal.qml" line="175" />
-        <location filename="../imports/shared/popups/SendModal.qml" line="175" />
+        <location filename="../imports/shared/popups/SendModal.qml" line="224" />
+        <location filename="../imports/shared/popups/SendModal.qml" line="224" />
         <source>No balances active</source>
         <translation>No balances active</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/SendModal.qml" line="311" />
-        <location filename="../imports/shared/popups/SendModal.qml" line="311" />
+        <location filename="../imports/shared/popups/SendModal.qml" line="267" />
+        <location filename="../imports/shared/popups/SendModal.qml" line="267" />
+        <source>Select token to bridge</source>
+        <translation>Select token to bridge</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/popups/SendModal.qml" line="267" />
+        <location filename="../imports/shared/popups/SendModal.qml" line="267" />
+        <source>Select token to send</source>
+        <translation>Select token to send</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/popups/SendModal.qml" line="384" />
+        <location filename="../imports/shared/popups/SendModal.qml" line="384" />
         <source>To</source>
         <translation>To</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/SendModal.qml" line="312" />
-        <location filename="../imports/shared/popups/SendModal.qml" line="312" />
+        <location filename="../imports/shared/popups/SendModal.qml" line="385" />
+        <location filename="../imports/shared/popups/SendModal.qml" line="385" />
         <source>Enter an ENS name or address</source>
         <translation>Enter an ENS name or address</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/SendModal.qml" line="323" />
-        <location filename="../imports/shared/popups/SendModal.qml" line="323" />
+        <location filename="../imports/shared/popups/SendModal.qml" line="398" />
+        <location filename="../imports/shared/popups/SendModal.qml" line="398" />
         <source>Paste</source>
         <translation>Paste</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/SendModal.qml" line="427" />
-        <location filename="../imports/shared/popups/SendModal.qml" line="427" />
-        <source>Fees</source>
-        <translation>Fees</translation>
-    </message>
-    <message>
-        <location filename="../imports/shared/popups/SendModal.qml" line="540" />
-        <location filename="../imports/shared/popups/SendModal.qml" line="540" />
+        <location filename="../imports/shared/popups/SendModal.qml" line="542" />
+        <location filename="../imports/shared/popups/SendModal.qml" line="542" />
         <source>Transaction pending...</source>
         <translation>Transaction pending...</translation>
     </message>
     <message>
-        <location filename="../imports/shared/popups/SendModal.qml" line="541" />
-        <location filename="../imports/shared/popups/SendModal.qml" line="541" />
+        <location filename="../imports/shared/popups/SendModal.qml" line="543" />
+        <location filename="../imports/shared/popups/SendModal.qml" line="543" />
         <source>View on etherscan</source>
         <translation>View on etherscan</translation>
     </message>
@@ -11907,20 +12062,20 @@ your PIN or if the wrong PIN is entered five times in a row.</translation>
 <context>
     <name>SendModalFooter</name>
     <message>
-        <location filename="../imports/shared/views/SendModalFooter.qml" line="51" />
-        <location filename="../imports/shared/views/SendModalFooter.qml" line="51" />
+        <location filename="../imports/shared/views/SendModalFooter.qml" line="47" />
+        <location filename="../imports/shared/views/SendModalFooter.qml" line="47" />
         <source>Estimated Time:</source>
         <translation>Estimated Time:</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/SendModalFooter.qml" line="75" />
-        <location filename="../imports/shared/views/SendModalFooter.qml" line="75" />
+        <location filename="../imports/shared/views/SendModalFooter.qml" line="71" />
+        <location filename="../imports/shared/views/SendModalFooter.qml" line="71" />
         <source>Max Fees:</source>
         <translation>Max Fees:</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/SendModalFooter.qml" line="89" />
-        <location filename="../imports/shared/views/SendModalFooter.qml" line="89" />
+        <location filename="../imports/shared/views/SendModalFooter.qml" line="85" />
+        <location filename="../imports/shared/views/SendModalFooter.qml" line="85" />
         <source>Send</source>
         <translation>Send</translation>
     </message>
@@ -12052,9 +12207,7 @@ your PIN or if the wrong PIN is entered five times in a row.</translation>
     <name>SignTransactionModal</name>
     <message>
         <location filename="../imports/shared/popups/SignTransactionModal.qml" line="19" />
-        <location filename="../imports/shared/popups/SignTransactionModal.qml" line="104" />
         <location filename="../imports/shared/popups/SignTransactionModal.qml" line="19" />
-        <location filename="../imports/shared/popups/SignTransactionModal.qml" line="104" />
         <source>Send</source>
         <translation>Send</translation>
     </message>
@@ -12063,76 +12216,6 @@ your PIN or if the wrong PIN is entered five times in a row.</translation>
         <location filename="../imports/shared/popups/SignTransactionModal.qml" line="66" />
         <source>Error sending the transaction</source>
         <translation>Error sending the transaction</translation>
-    </message>
-    <message>
-        <location filename="../imports/shared/popups/SignTransactionModal.qml" line="106" />
-        <location filename="../imports/shared/popups/SignTransactionModal.qml" line="138" />
-        <location filename="../imports/shared/popups/SignTransactionModal.qml" line="106" />
-        <location filename="../imports/shared/popups/SignTransactionModal.qml" line="138" />
-        <source>Continue</source>
-        <translation>Continue</translation>
-    </message>
-    <message>
-        <location filename="../imports/shared/popups/SignTransactionModal.qml" line="119" />
-        <location filename="../imports/shared/popups/SignTransactionModal.qml" line="119" />
-        <source>Choose account</source>
-        <translation>Choose account</translation>
-    </message>
-    <message>
-        <location filename="../imports/shared/popups/SignTransactionModal.qml" line="137" />
-        <location filename="../imports/shared/popups/SignTransactionModal.qml" line="137" />
-        <source>Network fee</source>
-        <translation>Network fee</translation>
-    </message>
-    <message>
-        <location filename="../imports/shared/popups/SignTransactionModal.qml" line="171" />
-        <location filename="../imports/shared/popups/SignTransactionModal.qml" line="171" />
-        <source>Error estimating gas: %1</source>
-        <translation>Error estimating gas: %1</translation>
-    </message>
-    <message>
-        <location filename="../imports/shared/popups/SignTransactionModal.qml" line="192" />
-        <location filename="../imports/shared/popups/SignTransactionModal.qml" line="192" />
-        <source>Transaction preview</source>
-        <translation>Transaction preview</translation>
-    </message>
-    <message>
-        <location filename="../imports/shared/popups/SignTransactionModal.qml" line="193" />
-        <location filename="../imports/shared/popups/SignTransactionModal.qml" line="243" />
-        <location filename="../imports/shared/popups/SignTransactionModal.qml" line="193" />
-        <location filename="../imports/shared/popups/SignTransactionModal.qml" line="243" />
-        <source>Sign with password</source>
-        <translation>Sign with password</translation>
-    </message>
-    <message>
-        <location filename="../imports/shared/popups/SignTransactionModal.qml" line="244" />
-        <location filename="../imports/shared/popups/SignTransactionModal.qml" line="244" />
-        <source>Send %1 %2</source>
-        <translation>Send %1 %2</translation>
-    </message>
-    <message>
-        <location filename="../imports/shared/popups/SignTransactionModal.qml" line="275" />
-        <location filename="../imports/shared/popups/SignTransactionModal.qml" line="275" />
-        <source>Next</source>
-        <translation>Next</translation>
-    </message>
-    <message>
-        <location filename="../imports/shared/popups/SignTransactionModal.qml" line="338" />
-        <location filename="../imports/shared/popups/SignTransactionModal.qml" line="338" />
-        <source>Wrong password</source>
-        <translation>Wrong password</translation>
-    </message>
-    <message>
-        <location filename="../imports/shared/popups/SignTransactionModal.qml" line="350" />
-        <location filename="../imports/shared/popups/SignTransactionModal.qml" line="350" />
-        <source>Transaction pending...</source>
-        <translation>Transaction pending...</translation>
-    </message>
-    <message>
-        <location filename="../imports/shared/popups/SignTransactionModal.qml" line="351" />
-        <location filename="../imports/shared/popups/SignTransactionModal.qml" line="351" />
-        <source>View on etherscan</source>
-        <translation>View on etherscan</translation>
     </message>
 </context>
 <context>
@@ -12144,14 +12227,14 @@ your PIN or if the wrong PIN is entered five times in a row.</translation>
         <translation>Social Links</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/popups/SocialLinksModal.qml" line="102" />
-        <location filename="../app/AppLayouts/Profile/popups/SocialLinksModal.qml" line="102" />
+        <location filename="../app/AppLayouts/Profile/popups/SocialLinksModal.qml" line="103" />
+        <location filename="../app/AppLayouts/Profile/popups/SocialLinksModal.qml" line="103" />
         <source>Custom links</source>
         <translation>Custom links</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/popups/SocialLinksModal.qml" line="150" />
-        <location filename="../app/AppLayouts/Profile/popups/SocialLinksModal.qml" line="150" />
+        <location filename="../app/AppLayouts/Profile/popups/SocialLinksModal.qml" line="151" />
+        <location filename="../app/AppLayouts/Profile/popups/SocialLinksModal.qml" line="151" />
         <source>Add another custom link</source>
         <translation>Add another custom link</translation>
     </message>
@@ -12222,38 +12305,38 @@ your PIN or if the wrong PIN is entered five times in a row.</translation>
 <context>
     <name>StaticSocialLinkInput</name>
     <message>
-        <location filename="../app/AppLayouts/Profile/controls/StaticSocialLinkInput.qml" line="16" />
-        <location filename="../app/AppLayouts/Profile/controls/StaticSocialLinkInput.qml" line="16" />
+        <location filename="../app/AppLayouts/Profile/controls/StaticSocialLinkInput.qml" line="17" />
+        <location filename="../app/AppLayouts/Profile/controls/StaticSocialLinkInput.qml" line="17" />
         <source>Twitter Handle</source>
         <translation>Twitter Handle</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/controls/StaticSocialLinkInput.qml" line="17" />
-        <location filename="../app/AppLayouts/Profile/controls/StaticSocialLinkInput.qml" line="17" />
+        <location filename="../app/AppLayouts/Profile/controls/StaticSocialLinkInput.qml" line="18" />
+        <location filename="../app/AppLayouts/Profile/controls/StaticSocialLinkInput.qml" line="18" />
         <source>Personal Site</source>
         <translation>Personal Site</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/controls/StaticSocialLinkInput.qml" line="18" />
-        <location filename="../app/AppLayouts/Profile/controls/StaticSocialLinkInput.qml" line="18" />
+        <location filename="../app/AppLayouts/Profile/controls/StaticSocialLinkInput.qml" line="19" />
+        <location filename="../app/AppLayouts/Profile/controls/StaticSocialLinkInput.qml" line="19" />
         <source>Github</source>
         <translation>Github</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/controls/StaticSocialLinkInput.qml" line="19" />
-        <location filename="../app/AppLayouts/Profile/controls/StaticSocialLinkInput.qml" line="19" />
+        <location filename="../app/AppLayouts/Profile/controls/StaticSocialLinkInput.qml" line="20" />
+        <location filename="../app/AppLayouts/Profile/controls/StaticSocialLinkInput.qml" line="20" />
         <source>YouTube Channel</source>
         <translation>YouTube Channel</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/controls/StaticSocialLinkInput.qml" line="20" />
-        <location filename="../app/AppLayouts/Profile/controls/StaticSocialLinkInput.qml" line="20" />
+        <location filename="../app/AppLayouts/Profile/controls/StaticSocialLinkInput.qml" line="21" />
+        <location filename="../app/AppLayouts/Profile/controls/StaticSocialLinkInput.qml" line="21" />
         <source>Discord Handle</source>
         <translation>Discord Handle</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Profile/controls/StaticSocialLinkInput.qml" line="21" />
-        <location filename="../app/AppLayouts/Profile/controls/StaticSocialLinkInput.qml" line="21" />
+        <location filename="../app/AppLayouts/Profile/controls/StaticSocialLinkInput.qml" line="22" />
+        <location filename="../app/AppLayouts/Profile/controls/StaticSocialLinkInput.qml" line="22" />
         <source>Telegram Handle</source>
         <translation>Telegram Handle</translation>
     </message>
@@ -12263,8 +12346,8 @@ your PIN or if the wrong PIN is entered five times in a row.</translation>
     <message>
         <location filename="../StatusQ/src/StatusQ/Controls/StatusActivityCenterButton.qml" line="39" />
         <location filename="../StatusQ/src/StatusQ/Controls/StatusActivityCenterButton.qml" line="39" />
-        <source>Activity</source>
-        <translation>Activity</translation>
+        <source>Notifications</source>
+        <translation>Notifications</translation>
     </message>
 </context>
 <context>
@@ -12346,15 +12429,15 @@ your PIN or if the wrong PIN is entered five times in a row.</translation>
     </message>
     <message>
         <location filename="../StatusQ/sandbox/demoapp/StatusAppCommunityView.qml" line="67" />
-        <location filename="../StatusQ/sandbox/demoapp/StatusAppCommunityView.qml" line="283" />
+        <location filename="../StatusQ/sandbox/demoapp/StatusAppCommunityView.qml" line="298" />
         <location filename="../StatusQ/sandbox/demoapp/StatusAppCommunityView.qml" line="67" />
-        <location filename="../StatusQ/sandbox/demoapp/StatusAppCommunityView.qml" line="283" />
+        <location filename="../StatusQ/sandbox/demoapp/StatusAppCommunityView.qml" line="298" />
         <source>Members</source>
         <translation>Members</translation>
     </message>
     <message>
-        <location filename="../StatusQ/sandbox/demoapp/StatusAppCommunityView.qml" line="268" />
-        <location filename="../StatusQ/sandbox/demoapp/StatusAppCommunityView.qml" line="268" />
+        <location filename="../StatusQ/sandbox/demoapp/StatusAppCommunityView.qml" line="283" />
+        <location filename="../StatusQ/sandbox/demoapp/StatusAppCommunityView.qml" line="283" />
         <source>Community content here</source>
         <translation>Community content here</translation>
     </message>
@@ -12362,8 +12445,8 @@ your PIN or if the wrong PIN is entered five times in a row.</translation>
 <context>
     <name>StatusAssetSelector</name>
     <message>
-        <location filename="../imports/shared/panels/StatusAssetSelector.qml" line="207" />
-        <location filename="../imports/shared/panels/StatusAssetSelector.qml" line="207" />
+        <location filename="../imports/shared/panels/StatusAssetSelector.qml" line="215" />
+        <location filename="../imports/shared/panels/StatusAssetSelector.qml" line="215" />
         <source>Search for token or enter token address</source>
         <translation>Search for token or enter token address</translation>
     </message>
@@ -12433,6 +12516,7 @@ your PIN or if the wrong PIN is entered five times in a row.</translation>
         <source>You can only upload %n image(s) at a time</source>
         <translation type="unfinished">
             <numerusform />
+            <numerusform />
         </translation>
     </message>
 </context>
@@ -12459,74 +12543,75 @@ your PIN or if the wrong PIN is entered five times in a row.</translation>
         <source>%Ln pinned message(s)</source>
         <translation type="unfinished">
             <numerusform />
+            <numerusform />
         </translation>
     </message>
 </context>
 <context>
     <name>StatusChatInput</name>
     <message>
-        <location filename="../imports/shared/status/StatusChatInput.qml" line="58" />
-        <location filename="../imports/shared/status/StatusChatInput.qml" line="58" />
+        <location filename="../imports/shared/status/StatusChatInput.qml" line="57" />
+        <location filename="../imports/shared/status/StatusChatInput.qml" line="57" />
         <source>Message</source>
         <translation>Message</translation>
     </message>
     <message>
-        <location filename="../imports/shared/status/StatusChatInput.qml" line="852" />
-        <location filename="../imports/shared/status/StatusChatInput.qml" line="852" />
+        <location filename="../imports/shared/status/StatusChatInput.qml" line="892" />
+        <location filename="../imports/shared/status/StatusChatInput.qml" line="892" />
         <source>Please choose an image</source>
         <translation>Please choose an image</translation>
     </message>
     <message>
-        <location filename="../imports/shared/status/StatusChatInput.qml" line="856" />
-        <location filename="../imports/shared/status/StatusChatInput.qml" line="856" />
+        <location filename="../imports/shared/status/StatusChatInput.qml" line="896" />
+        <location filename="../imports/shared/status/StatusChatInput.qml" line="896" />
         <source>Image files (%1)</source>
         <translation>Image files (%1)</translation>
     </message>
     <message>
-        <location filename="../imports/shared/status/StatusChatInput.qml" line="873" />
-        <location filename="../imports/shared/status/StatusChatInput.qml" line="873" />
+        <location filename="../imports/shared/status/StatusChatInput.qml" line="913" />
+        <location filename="../imports/shared/status/StatusChatInput.qml" line="913" />
         <source>Your message is too long.</source>
         <translation>Your message is too long.</translation>
     </message>
     <message>
-        <location filename="../imports/shared/status/StatusChatInput.qml" line="875" />
-        <location filename="../imports/shared/status/StatusChatInput.qml" line="875" />
+        <location filename="../imports/shared/status/StatusChatInput.qml" line="915" />
+        <location filename="../imports/shared/status/StatusChatInput.qml" line="915" />
         <source>Please make your message shorter. We have set the limit to 2000 characters to be courteous of others.</source>
         <translation>Please make your message shorter. We have set the limit to 2000 characters to be courteous of others.</translation>
     </message>
     <message>
-        <location filename="../imports/shared/status/StatusChatInput.qml" line="1032" />
-        <location filename="../imports/shared/status/StatusChatInput.qml" line="1032" />
+        <location filename="../imports/shared/status/StatusChatInput.qml" line="1054" />
+        <location filename="../imports/shared/status/StatusChatInput.qml" line="1054" />
         <source>Bold</source>
         <translation>Bold</translation>
     </message>
     <message>
-        <location filename="../imports/shared/status/StatusChatInput.qml" line="1041" />
-        <location filename="../imports/shared/status/StatusChatInput.qml" line="1041" />
+        <location filename="../imports/shared/status/StatusChatInput.qml" line="1063" />
+        <location filename="../imports/shared/status/StatusChatInput.qml" line="1063" />
         <source>Italic</source>
         <translation>Italic</translation>
     </message>
     <message>
-        <location filename="../imports/shared/status/StatusChatInput.qml" line="1051" />
-        <location filename="../imports/shared/status/StatusChatInput.qml" line="1051" />
+        <location filename="../imports/shared/status/StatusChatInput.qml" line="1073" />
+        <location filename="../imports/shared/status/StatusChatInput.qml" line="1073" />
         <source>Strikethrough</source>
         <translation>Strikethrough</translation>
     </message>
     <message>
-        <location filename="../imports/shared/status/StatusChatInput.qml" line="1060" />
-        <location filename="../imports/shared/status/StatusChatInput.qml" line="1060" />
+        <location filename="../imports/shared/status/StatusChatInput.qml" line="1082" />
+        <location filename="../imports/shared/status/StatusChatInput.qml" line="1082" />
         <source>Code</source>
         <translation>Code</translation>
     </message>
     <message>
-        <location filename="../imports/shared/status/StatusChatInput.qml" line="1069" />
-        <location filename="../imports/shared/status/StatusChatInput.qml" line="1069" />
+        <location filename="../imports/shared/status/StatusChatInput.qml" line="1091" />
+        <location filename="../imports/shared/status/StatusChatInput.qml" line="1091" />
         <source>Quote</source>
         <translation>Quote</translation>
     </message>
     <message>
-        <location filename="../imports/shared/status/StatusChatInput.qml" line="1420" />
-        <location filename="../imports/shared/status/StatusChatInput.qml" line="1420" />
+        <location filename="../imports/shared/status/StatusChatInput.qml" line="1446" />
+        <location filename="../imports/shared/status/StatusChatInput.qml" line="1446" />
         <source>Unblock</source>
         <translation>Unblock</translation>
     </message>
@@ -12564,8 +12649,8 @@ your PIN or if the wrong PIN is entered five times in a row.</translation>
 <context>
     <name>StatusChatListItem</name>
     <message>
-        <location filename="../StatusQ/src/StatusQ/Components/StatusChatListItem.qml" line="187" />
-        <location filename="../StatusQ/src/StatusQ/Components/StatusChatListItem.qml" line="187" />
+        <location filename="../StatusQ/src/StatusQ/Components/StatusChatListItem.qml" line="191" />
+        <location filename="../StatusQ/src/StatusQ/Components/StatusChatListItem.qml" line="191" />
         <source>Unmute</source>
         <translation>Unmute</translation>
     </message>
@@ -12696,14 +12781,14 @@ your PIN or if the wrong PIN is entered five times in a row.</translation>
 <context>
     <name>StatusDateGroupLabel</name>
     <message>
-        <location filename="../StatusQ/src/StatusQ/Components/StatusDateGroupLabel.qml" line="29" />
-        <location filename="../StatusQ/src/StatusQ/Components/StatusDateGroupLabel.qml" line="29" />
+        <location filename="../StatusQ/src/StatusQ/Components/StatusDateGroupLabel.qml" line="26" />
+        <location filename="../StatusQ/src/StatusQ/Components/StatusDateGroupLabel.qml" line="26" />
         <source>Today</source>
         <translation>Today</translation>
     </message>
     <message>
-        <location filename="../StatusQ/src/StatusQ/Components/StatusDateGroupLabel.qml" line="34" />
-        <location filename="../StatusQ/src/StatusQ/Components/StatusDateGroupLabel.qml" line="34" />
+        <location filename="../StatusQ/src/StatusQ/Components/StatusDateGroupLabel.qml" line="31" />
+        <location filename="../StatusQ/src/StatusQ/Components/StatusDateGroupLabel.qml" line="31" />
         <source>Yesterday</source>
         <translation>Yesterday</translation>
     </message>
@@ -12829,63 +12914,10 @@ your PIN or if the wrong PIN is entered five times in a row.</translation>
     </message>
 </context>
 <context>
-    <name>StatusETHTransactionModal</name>
-    <message>
-        <location filename="../imports/shared/status/StatusETHTransactionModal.qml" line="26" />
-        <location filename="../imports/shared/status/StatusETHTransactionModal.qml" line="26" />
-        <source>Contract interaction</source>
-        <translation>Contract interaction</translation>
-    </message>
-    <message>
-        <location filename="../imports/shared/status/StatusETHTransactionModal.qml" line="49" />
-        <location filename="../imports/shared/status/StatusETHTransactionModal.qml" line="49" />
-        <source>Wrong password</source>
-        <translation>Wrong password</translation>
-    </message>
-    <message>
-        <location filename="../imports/shared/status/StatusETHTransactionModal.qml" line="60" />
-        <location filename="../imports/shared/status/StatusETHTransactionModal.qml" line="60" />
-        <source>Error sending the transaction: %1</source>
-        <translation>Error sending the transaction: %1</translation>
-    </message>
-    <message>
-        <location filename="../imports/shared/status/StatusETHTransactionModal.qml" line="72" />
-        <location filename="../imports/shared/status/StatusETHTransactionModal.qml" line="72" />
-        <source>Error sending the transaction</source>
-        <translation>Error sending the transaction</translation>
-    </message>
-    <message>
-        <location filename="../imports/shared/status/StatusETHTransactionModal.qml" line="90" />
-        <location filename="../imports/shared/status/StatusETHTransactionModal.qml" line="90" />
-        <source>Continue</source>
-        <translation>Continue</translation>
-    </message>
-    <message>
-        <location filename="../imports/shared/status/StatusETHTransactionModal.qml" line="105" />
-        <location filename="../imports/shared/status/StatusETHTransactionModal.qml" line="105" />
-        <source>Choose account</source>
-        <translation>Choose account</translation>
-    </message>
-    <message>
-        <location filename="../imports/shared/status/StatusETHTransactionModal.qml" line="142" />
-        <location filename="../imports/shared/status/StatusETHTransactionModal.qml" line="165" />
-        <location filename="../imports/shared/status/StatusETHTransactionModal.qml" line="142" />
-        <location filename="../imports/shared/status/StatusETHTransactionModal.qml" line="165" />
-        <source>Sign with password</source>
-        <translation>Sign with password</translation>
-    </message>
-    <message>
-        <location filename="../imports/shared/status/StatusETHTransactionModal.qml" line="202" />
-        <location filename="../imports/shared/status/StatusETHTransactionModal.qml" line="202" />
-        <source>Next</source>
-        <translation>Next</translation>
-    </message>
-</context>
-<context>
     <name>StatusEmojiSection</name>
     <message>
-        <location filename="../imports/shared/status/StatusEmojiSection.qml" line="39" />
-        <location filename="../imports/shared/status/StatusEmojiSection.qml" line="39" />
+        <location filename="../imports/shared/status/StatusEmojiSection.qml" line="38" />
+        <location filename="../imports/shared/status/StatusEmojiSection.qml" line="38" />
         <source>No recent emojis</source>
         <translation>No recent emojis</translation>
     </message>
@@ -12959,38 +12991,38 @@ your PIN or if the wrong PIN is entered five times in a row.</translation>
 <context>
     <name>StatusImageCropPanelPage</name>
     <message>
-        <location filename="../StatusQ/sandbox/pages/StatusImageCropPanelPage.qml" line="91" />
-        <location filename="../StatusQ/sandbox/pages/StatusImageCropPanelPage.qml" line="91" />
+        <location filename="../StatusQ/sandbox/pages/StatusImageCropPanelPage.qml" line="95" />
+        <location filename="../StatusQ/sandbox/pages/StatusImageCropPanelPage.qml" line="95" />
         <source>Cycle image</source>
         <translation>Cycle image</translation>
     </message>
     <message>
-        <location filename="../StatusQ/sandbox/pages/StatusImageCropPanelPage.qml" line="101" />
-        <location filename="../StatusQ/sandbox/pages/StatusImageCropPanelPage.qml" line="101" />
+        <location filename="../StatusQ/sandbox/pages/StatusImageCropPanelPage.qml" line="105" />
+        <location filename="../StatusQ/sandbox/pages/StatusImageCropPanelPage.qml" line="105" />
         <source>Cycle spacing</source>
         <translation>Cycle spacing</translation>
     </message>
     <message>
-        <location filename="../StatusQ/sandbox/pages/StatusImageCropPanelPage.qml" line="109" />
-        <location filename="../StatusQ/sandbox/pages/StatusImageCropPanelPage.qml" line="109" />
+        <location filename="../StatusQ/sandbox/pages/StatusImageCropPanelPage.qml" line="113" />
+        <location filename="../StatusQ/sandbox/pages/StatusImageCropPanelPage.qml" line="113" />
         <source>Cycle frame margins</source>
         <translation>Cycle frame margins</translation>
     </message>
     <message>
-        <location filename="../StatusQ/sandbox/pages/StatusImageCropPanelPage.qml" line="117" />
-        <location filename="../StatusQ/sandbox/pages/StatusImageCropPanelPage.qml" line="117" />
+        <location filename="../StatusQ/sandbox/pages/StatusImageCropPanelPage.qml" line="121" />
+        <location filename="../StatusQ/sandbox/pages/StatusImageCropPanelPage.qml" line="121" />
         <source>Load external image</source>
         <translation>Load external image</translation>
     </message>
     <message>
-        <location filename="../StatusQ/sandbox/pages/StatusImageCropPanelPage.qml" line="130" />
-        <location filename="../StatusQ/sandbox/pages/StatusImageCropPanelPage.qml" line="130" />
+        <location filename="../StatusQ/sandbox/pages/StatusImageCropPanelPage.qml" line="134" />
+        <location filename="../StatusQ/sandbox/pages/StatusImageCropPanelPage.qml" line="134" />
         <source>Test Title</source>
         <translation>Test Title</translation>
     </message>
     <message>
-        <location filename="../StatusQ/sandbox/pages/StatusImageCropPanelPage.qml" line="175" />
-        <location filename="../StatusQ/sandbox/pages/StatusImageCropPanelPage.qml" line="175" />
+        <location filename="../StatusQ/sandbox/pages/StatusImageCropPanelPage.qml" line="179" />
+        <location filename="../StatusQ/sandbox/pages/StatusImageCropPanelPage.qml" line="179" />
         <source>Supported image formats (%1)</source>
         <translation>Supported image formats (%1)</translation>
     </message>
@@ -13002,21 +13034,6 @@ your PIN or if the wrong PIN is entered five times in a row.</translation>
         <location filename="../StatusQ/src/StatusQ/Controls/Validators/StatusIntValidator.qml" line="50" />
         <source>Please enter a valid numeric value.</source>
         <translation>Please enter a valid numeric value.</translation>
-    </message>
-</context>
-<context>
-    <name>StatusItemSelector</name>
-    <message>
-        <location filename="../StatusQ/src/StatusQ/Components/StatusItemSelector.qml" line="107" />
-        <location filename="../StatusQ/src/StatusQ/Components/StatusItemSelector.qml" line="107" />
-        <source>and</source>
-        <translation>and</translation>
-    </message>
-    <message>
-        <location filename="../StatusQ/src/StatusQ/Components/StatusItemSelector.qml" line="112" />
-        <location filename="../StatusQ/src/StatusQ/Components/StatusItemSelector.qml" line="112" />
-        <source>or</source>
-        <translation>or</translation>
     </message>
 </context>
 <context>
@@ -13065,37 +13082,28 @@ your PIN or if the wrong PIN is entered five times in a row.</translation>
     </message>
 </context>
 <context>
-    <name>StatusMessage</name>
-    <message>
-        <location filename="../StatusQ/src/StatusQ/Components/StatusMessage.qml" line="313" />
-        <location filename="../StatusQ/src/StatusQ/Components/StatusMessage.qml" line="313" />
-        <source>(edited)</source>
-        <translation>(edited)</translation>
-    </message>
-</context>
-<context>
     <name>StatusMessageEmojiReactions</name>
     <message>
-        <location filename="../StatusQ/src/StatusQ/Components/private/statusMessage/StatusMessageEmojiReactions.qml" line="33" />
-        <location filename="../StatusQ/src/StatusQ/Components/private/statusMessage/StatusMessageEmojiReactions.qml" line="33" />
+        <location filename="../StatusQ/src/StatusQ/Components/private/statusMessage/StatusMessageEmojiReactions.qml" line="32" />
+        <location filename="../StatusQ/src/StatusQ/Components/private/statusMessage/StatusMessageEmojiReactions.qml" line="32" />
         <source> and </source>
         <translation> and </translation>
     </message>
     <message>
-        <location filename="../StatusQ/src/StatusQ/Components/private/statusMessage/StatusMessageEmojiReactions.qml" line="59" />
-        <location filename="../StatusQ/src/StatusQ/Components/private/statusMessage/StatusMessageEmojiReactions.qml" line="59" />
+        <location filename="../StatusQ/src/StatusQ/Components/private/statusMessage/StatusMessageEmojiReactions.qml" line="58" />
+        <location filename="../StatusQ/src/StatusQ/Components/private/statusMessage/StatusMessageEmojiReactions.qml" line="58" />
         <source>%1 more</source>
         <translation>%1 more</translation>
     </message>
     <message>
-        <location filename="../StatusQ/src/StatusQ/Components/private/statusMessage/StatusMessageEmojiReactions.qml" line="66" />
-        <location filename="../StatusQ/src/StatusQ/Components/private/statusMessage/StatusMessageEmojiReactions.qml" line="66" />
+        <location filename="../StatusQ/src/StatusQ/Components/private/statusMessage/StatusMessageEmojiReactions.qml" line="65" />
+        <location filename="../StatusQ/src/StatusQ/Components/private/statusMessage/StatusMessageEmojiReactions.qml" line="65" />
         <source>%1 reacted with %2</source>
         <translation>%1 reacted with %2</translation>
     </message>
     <message>
-        <location filename="../StatusQ/src/StatusQ/Components/private/statusMessage/StatusMessageEmojiReactions.qml" line="187" />
-        <location filename="../StatusQ/src/StatusQ/Components/private/statusMessage/StatusMessageEmojiReactions.qml" line="187" />
+        <location filename="../StatusQ/src/StatusQ/Components/private/statusMessage/StatusMessageEmojiReactions.qml" line="186" />
+        <location filename="../StatusQ/src/StatusQ/Components/private/statusMessage/StatusMessageEmojiReactions.qml" line="186" />
         <source>Add reaction</source>
         <translation>Add reaction</translation>
     </message>
@@ -13103,8 +13111,8 @@ your PIN or if the wrong PIN is entered five times in a row.</translation>
 <context>
     <name>StatusMessageHeader</name>
     <message>
-        <location filename="../StatusQ/src/StatusQ/Components/private/statusMessage/StatusMessageHeader.qml" line="47" />
-        <location filename="../StatusQ/src/StatusQ/Components/private/statusMessage/StatusMessageHeader.qml" line="47" />
+        <location filename="../StatusQ/src/StatusQ/Components/StatusMessageHeader.qml" line="49" />
+        <location filename="../StatusQ/src/StatusQ/Components/StatusMessageHeader.qml" line="49" />
         <source>You</source>
         <translation>You</translation>
     </message>
@@ -13112,8 +13120,8 @@ your PIN or if the wrong PIN is entered five times in a row.</translation>
 <context>
     <name>StatusMessageReply</name>
     <message>
-        <location filename="../StatusQ/src/StatusQ/Components/private/statusMessage/StatusMessageReply.qml" line="81" />
-        <location filename="../StatusQ/src/StatusQ/Components/private/statusMessage/StatusMessageReply.qml" line="81" />
+        <location filename="../StatusQ/src/StatusQ/Components/private/statusMessage/StatusMessageReply.qml" line="97" />
+        <location filename="../StatusQ/src/StatusQ/Components/private/statusMessage/StatusMessageReply.qml" line="97" />
         <source>You</source>
         <translation>You</translation>
     </message>
@@ -13161,63 +13169,6 @@ your PIN or if the wrong PIN is entered five times in a row.</translation>
     </message>
 </context>
 <context>
-    <name>StatusSNTTransactionModal</name>
-    <message>
-        <location filename="../imports/shared/status/StatusSNTTransactionModal.qml" line="37" />
-        <location filename="../imports/shared/status/StatusSNTTransactionModal.qml" line="96" />
-        <location filename="../imports/shared/status/StatusSNTTransactionModal.qml" line="167" />
-        <location filename="../imports/shared/status/StatusSNTTransactionModal.qml" line="37" />
-        <location filename="../imports/shared/status/StatusSNTTransactionModal.qml" line="96" />
-        <location filename="../imports/shared/status/StatusSNTTransactionModal.qml" line="167" />
-        <source>Authorize %1 %2</source>
-        <translation>Authorize %1 %2</translation>
-    </message>
-    <message>
-        <location filename="../imports/shared/status/StatusSNTTransactionModal.qml" line="41" />
-        <location filename="../imports/shared/status/StatusSNTTransactionModal.qml" line="41" />
-        <source>Error sending the transaction</source>
-        <translation>Error sending the transaction</translation>
-    </message>
-    <message>
-        <location filename="../imports/shared/status/StatusSNTTransactionModal.qml" line="66" />
-        <location filename="../imports/shared/status/StatusSNTTransactionModal.qml" line="66" />
-        <source>Wrong password</source>
-        <translation>Wrong password</translation>
-    </message>
-    <message>
-        <location filename="../imports/shared/status/StatusSNTTransactionModal.qml" line="97" />
-        <location filename="../imports/shared/status/StatusSNTTransactionModal.qml" line="97" />
-        <source>Continue</source>
-        <translation>Continue</translation>
-    </message>
-    <message>
-        <location filename="../imports/shared/status/StatusSNTTransactionModal.qml" line="111" />
-        <location filename="../imports/shared/status/StatusSNTTransactionModal.qml" line="111" />
-        <source>Choose account</source>
-        <translation>Choose account</translation>
-    </message>
-    <message>
-        <location filename="../imports/shared/status/StatusSNTTransactionModal.qml" line="168" />
-        <location filename="../imports/shared/status/StatusSNTTransactionModal.qml" line="191" />
-        <location filename="../imports/shared/status/StatusSNTTransactionModal.qml" line="168" />
-        <location filename="../imports/shared/status/StatusSNTTransactionModal.qml" line="191" />
-        <source>Sign with password</source>
-        <translation>Sign with password</translation>
-    </message>
-    <message>
-        <location filename="../imports/shared/status/StatusSNTTransactionModal.qml" line="190" />
-        <location filename="../imports/shared/status/StatusSNTTransactionModal.qml" line="190" />
-        <source>Send %1 %2</source>
-        <translation>Send %1 %2</translation>
-    </message>
-    <message>
-        <location filename="../imports/shared/status/StatusSNTTransactionModal.qml" line="230" />
-        <location filename="../imports/shared/status/StatusSNTTransactionModal.qml" line="230" />
-        <source>Next</source>
-        <translation>Next</translation>
-    </message>
-</context>
-<context>
     <name>StatusSearchListPopup</name>
     <message>
         <location filename="../imports/shared/status/StatusSearchListPopup.qml" line="31" />
@@ -13229,8 +13180,8 @@ your PIN or if the wrong PIN is entered five times in a row.</translation>
 <context>
     <name>StatusSearchLocationMenu</name>
     <message>
-        <location filename="../StatusQ/src/StatusQ/Popups/StatusSearchLocationMenu.qml" line="21" />
-        <location filename="../StatusQ/src/StatusQ/Popups/StatusSearchLocationMenu.qml" line="21" />
+        <location filename="../StatusQ/src/StatusQ/Popups/StatusSearchLocationMenu.qml" line="52" />
+        <location filename="../StatusQ/src/StatusQ/Popups/StatusSearchLocationMenu.qml" line="52" />
         <source>Anywhere</source>
         <translation>Anywhere</translation>
     </message>
@@ -13260,21 +13211,6 @@ your PIN or if the wrong PIN is entered five times in a row.</translation>
         <location filename="../StatusQ/src/StatusQ/Popups/StatusSearchPopup.qml" line="174" />
         <source>In: </source>
         <translation>In: </translation>
-    </message>
-</context>
-<context>
-    <name>StatusSpellcheckingMenuItems</name>
-    <message>
-        <location filename="../StatusQ/src/StatusQ/Popups/StatusSpellcheckingMenuItems.qml" line="62" />
-        <location filename="../StatusQ/src/StatusQ/Popups/StatusSpellcheckingMenuItems.qml" line="62" />
-        <source>Add to dictionary</source>
-        <translation>Add to dictionary</translation>
-    </message>
-    <message>
-        <location filename="../StatusQ/src/StatusQ/Popups/StatusSpellcheckingMenuItems.qml" line="89" />
-        <location filename="../StatusQ/src/StatusQ/Popups/StatusSpellcheckingMenuItems.qml" line="89" />
-        <source>Disable Spellchecking</source>
-        <translation>Disable Spellchecking</translation>
     </message>
 </context>
 <context>
@@ -13346,35 +13282,74 @@ your PIN or if the wrong PIN is entered five times in a row.</translation>
 <context>
     <name>StatusStickerMarket</name>
     <message>
-        <location filename="../imports/shared/status/StatusStickerMarket.qml" line="220" />
-        <location filename="../imports/shared/status/StatusStickerMarket.qml" line="220" />
+        <location filename="../imports/shared/status/StatusStickerMarket.qml" line="201" />
+        <location filename="../imports/shared/status/StatusStickerMarket.qml" line="201" />
+        <source>Transaction pending...</source>
+        <translation>Transaction pending...</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/status/StatusStickerMarket.qml" line="202" />
+        <location filename="../imports/shared/status/StatusStickerMarket.qml" line="202" />
+        <source>View on etherscan</source>
+        <translation>View on etherscan</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/status/StatusStickerMarket.qml" line="254" />
+        <location filename="../imports/shared/status/StatusStickerMarket.qml" line="254" />
         <source>This feature is experimental and is meant for testing purposes by core contributors and the community. It's not meant for real use and makes no claims of security or integrity of funds or data. Use at your own risk.</source>
         <translation>This feature is experimental and is meant for testing purposes by core contributors and the community. It's not meant for real use and makes no claims of security or integrity of funds or data. Use at your own risk.</translation>
     </message>
     <message>
-        <location filename="../imports/shared/status/StatusStickerMarket.qml" line="221" />
-        <location filename="../imports/shared/status/StatusStickerMarket.qml" line="221" />
+        <location filename="../imports/shared/status/StatusStickerMarket.qml" line="255" />
+        <location filename="../imports/shared/status/StatusStickerMarket.qml" line="255" />
         <source>I understand</source>
         <translation>I understand</translation>
     </message>
 </context>
 <context>
+    <name>StatusStickerPackClickPopup</name>
+    <message>
+        <location filename="../imports/shared/status/StatusStickerPackClickPopup.qml" line="114" />
+        <location filename="../imports/shared/status/StatusStickerPackClickPopup.qml" line="114" />
+        <source>Transaction pending...</source>
+        <translation>Transaction pending...</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/status/StatusStickerPackClickPopup.qml" line="115" />
+        <location filename="../imports/shared/status/StatusStickerPackClickPopup.qml" line="115" />
+        <source>View on etherscan</source>
+        <translation>View on etherscan</translation>
+    </message>
+</context>
+<context>
     <name>StatusStickersPopup</name>
     <message>
-        <location filename="../imports/shared/status/StatusStickersPopup.qml" line="141" />
-        <location filename="../imports/shared/status/StatusStickersPopup.qml" line="141" />
+        <location filename="../imports/shared/status/StatusStickersPopup.qml" line="114" />
+        <location filename="../imports/shared/status/StatusStickersPopup.qml" line="114" />
+        <source>Failed to load stickers</source>
+        <translation>Failed to load stickers</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/status/StatusStickersPopup.qml" line="121" />
+        <location filename="../imports/shared/status/StatusStickersPopup.qml" line="121" />
+        <source>Try again</source>
+        <translation>Try again</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/status/StatusStickersPopup.qml" line="166" />
+        <location filename="../imports/shared/status/StatusStickersPopup.qml" line="166" />
         <source>You don't have any stickers yet</source>
         <translation>You don't have any stickers yet</translation>
     </message>
     <message>
-        <location filename="../imports/shared/status/StatusStickersPopup.qml" line="151" />
-        <location filename="../imports/shared/status/StatusStickersPopup.qml" line="151" />
+        <location filename="../imports/shared/status/StatusStickersPopup.qml" line="176" />
+        <location filename="../imports/shared/status/StatusStickersPopup.qml" line="176" />
         <source>Recently used stickers will appear here</source>
         <translation>Recently used stickers will appear here</translation>
     </message>
     <message>
-        <location filename="../imports/shared/status/StatusStickersPopup.qml" line="160" />
-        <location filename="../imports/shared/status/StatusStickersPopup.qml" line="160" />
+        <location filename="../imports/shared/status/StatusStickersPopup.qml" line="185" />
+        <location filename="../imports/shared/status/StatusStickersPopup.qml" line="185" />
         <source>Get Stickers</source>
         <translation>Get Stickers</translation>
     </message>
@@ -13392,6 +13367,15 @@ your PIN or if the wrong PIN is entered five times in a row.</translation>
         <location filename="../StatusQ/sandbox/pages/StatusTagSelectorPage.qml" line="64" />
         <source>USER LIMIT REACHED</source>
         <translation>USER LIMIT REACHED</translation>
+    </message>
+</context>
+<context>
+    <name>StatusTextMessage</name>
+    <message>
+        <location filename="../StatusQ/src/StatusQ/Components/private/statusMessage/StatusTextMessage.qml" line="43" />
+        <location filename="../StatusQ/src/StatusQ/Components/private/statusMessage/StatusTextMessage.qml" line="43" />
+        <source>(edited)</source>
+        <translation>(edited)</translation>
     </message>
 </context>
 <context>
@@ -13427,8 +13411,8 @@ your PIN or if the wrong PIN is entered five times in a row.</translation>
 <context>
     <name>StatusValidator</name>
     <message>
-        <location filename="../StatusQ/src/StatusQ/Controls/Validators/StatusValidator.qml" line="8" />
-        <location filename="../StatusQ/src/StatusQ/Controls/Validators/StatusValidator.qml" line="8" />
+        <location filename="../StatusQ/src/StatusQ/Controls/Validators/StatusValidator.qml" line="5" />
+        <location filename="../StatusQ/src/StatusQ/Controls/Validators/StatusValidator.qml" line="5" />
         <source>invalid input</source>
         <translation>invalid input</translation>
     </message>
@@ -13463,38 +13447,38 @@ your PIN or if the wrong PIN is entered five times in a row.</translation>
 <context>
     <name>TabAddressSelectorView</name>
     <message>
-        <location filename="../imports/shared/views/TabAddressSelectorView.qml" line="43" />
-        <location filename="../imports/shared/views/TabAddressSelectorView.qml" line="43" />
+        <location filename="../imports/shared/views/TabAddressSelectorView.qml" line="42" />
+        <location filename="../imports/shared/views/TabAddressSelectorView.qml" line="42" />
         <source>Saved</source>
         <translation>Saved</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/TabAddressSelectorView.qml" line="49" />
-        <location filename="../imports/shared/views/TabAddressSelectorView.qml" line="49" />
+        <location filename="../imports/shared/views/TabAddressSelectorView.qml" line="48" />
+        <location filename="../imports/shared/views/TabAddressSelectorView.qml" line="48" />
         <source>My Accounts</source>
         <translation>My Accounts</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/TabAddressSelectorView.qml" line="54" />
-        <location filename="../imports/shared/views/TabAddressSelectorView.qml" line="54" />
+        <location filename="../imports/shared/views/TabAddressSelectorView.qml" line="53" />
+        <location filename="../imports/shared/views/TabAddressSelectorView.qml" line="53" />
         <source>Recent</source>
         <translation>Recent</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/TabAddressSelectorView.qml" line="108" />
-        <location filename="../imports/shared/views/TabAddressSelectorView.qml" line="108" />
+        <location filename="../imports/shared/views/TabAddressSelectorView.qml" line="107" />
+        <location filename="../imports/shared/views/TabAddressSelectorView.qml" line="107" />
         <source>Search for saved address</source>
         <translation>Search for saved address</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/TabAddressSelectorView.qml" line="129" />
-        <location filename="../imports/shared/views/TabAddressSelectorView.qml" line="129" />
+        <location filename="../imports/shared/views/TabAddressSelectorView.qml" line="128" />
+        <location filename="../imports/shared/views/TabAddressSelectorView.qml" line="128" />
         <source>No Saved Address</source>
         <translation>No Saved Address</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/TabAddressSelectorView.qml" line="190" />
-        <location filename="../imports/shared/views/TabAddressSelectorView.qml" line="190" />
+        <location filename="../imports/shared/views/TabAddressSelectorView.qml" line="189" />
+        <location filename="../imports/shared/views/TabAddressSelectorView.qml" line="189" />
         <source>No Recents</source>
         <translation>No Recents</translation>
     </message>
@@ -13517,63 +13501,12 @@ your PIN or if the wrong PIN is entered five times in a row.</translation>
     </message>
 </context>
 <context>
-    <name>TokenMarketValuesStore</name>
+    <name>TokenListView</name>
     <message>
-        <location filename="../imports/shared/stores/TokenMarketValuesStore.qml" line="20" />
-        <location filename="../imports/shared/stores/TokenMarketValuesStore.qml" line="20" />
-        <source>Price</source>
-        <translation>Price</translation>
-    </message>
-    <message>
-        <location filename="../imports/shared/stores/TokenMarketValuesStore.qml" line="20" />
-        <location filename="../imports/shared/stores/TokenMarketValuesStore.qml" line="20" />
-        <source>Balance</source>
-        <translation>Balance</translation>
-    </message>
-    <message>
-        <location filename="../imports/shared/stores/TokenMarketValuesStore.qml" line="21" />
-        <location filename="../imports/shared/stores/TokenMarketValuesStore.qml" line="21" />
-        <source>7D</source>
-        <translation>7D</translation>
-    </message>
-    <message>
-        <location filename="../imports/shared/stores/TokenMarketValuesStore.qml" line="22" />
-        <location filename="../imports/shared/stores/TokenMarketValuesStore.qml" line="22" />
-        <source>1M</source>
-        <translation>1M</translation>
-    </message>
-    <message>
-        <location filename="../imports/shared/stores/TokenMarketValuesStore.qml" line="22" />
-        <location filename="../imports/shared/stores/TokenMarketValuesStore.qml" line="22" />
-        <source>6M</source>
-        <translation>6M</translation>
-    </message>
-    <message>
-        <location filename="../imports/shared/stores/TokenMarketValuesStore.qml" line="23" />
-        <location filename="../imports/shared/stores/TokenMarketValuesStore.qml" line="23" />
-        <source>1Y</source>
-        <translation>1Y</translation>
-    </message>
-    <message>
-        <location filename="../imports/shared/stores/TokenMarketValuesStore.qml" line="23" />
-        <location filename="../imports/shared/stores/TokenMarketValuesStore.qml" line="23" />
-        <source>ALL</source>
-        <translation>ALL</translation>
-    </message>
-</context>
-<context>
-    <name>TokenSettingsModal</name>
-    <message>
-        <location filename="../app/AppLayouts/Profile/popups/TokenSettingsModal.qml" line="18" />
-        <location filename="../app/AppLayouts/Profile/popups/TokenSettingsModal.qml" line="18" />
-        <source>Manage Assets</source>
-        <translation>Manage Assets</translation>
-    </message>
-    <message>
-        <location filename="../app/AppLayouts/Profile/popups/TokenSettingsModal.qml" line="22" />
-        <location filename="../app/AppLayouts/Profile/popups/TokenSettingsModal.qml" line="22" />
-        <source>Add custom token</source>
-        <translation>Add custom token</translation>
+        <location filename="../imports/shared/views/TokenListView.qml" line="82" />
+        <location filename="../imports/shared/views/TokenListView.qml" line="82" />
+        <source>Search for token or enter token address</source>
+        <translation>Search for token or enter token address</translation>
     </message>
 </context>
 <context>
@@ -13873,32 +13806,32 @@ to login to Status?</translation>
         <translation>Unknown</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/TransactionPreview.qml" line="282" />
-        <location filename="../imports/shared/views/TransactionPreview.qml" line="282" />
+        <location filename="../imports/shared/views/TransactionPreview.qml" line="283" />
+        <location filename="../imports/shared/views/TransactionPreview.qml" line="283" />
         <source>Asset</source>
         <translation>Asset</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/TransactionPreview.qml" line="328" />
-        <location filename="../imports/shared/views/TransactionPreview.qml" line="328" />
+        <location filename="../imports/shared/views/TransactionPreview.qml" line="329" />
+        <location filename="../imports/shared/views/TransactionPreview.qml" line="329" />
         <source>Amount</source>
         <translation>Amount</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/TransactionPreview.qml" line="384" />
-        <location filename="../imports/shared/views/TransactionPreview.qml" line="384" />
+        <location filename="../imports/shared/views/TransactionPreview.qml" line="385" />
+        <location filename="../imports/shared/views/TransactionPreview.qml" line="385" />
         <source>Network fee</source>
         <translation>Network fee</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/TransactionPreview.qml" line="490" />
-        <location filename="../imports/shared/views/TransactionPreview.qml" line="490" />
+        <location filename="../imports/shared/views/TransactionPreview.qml" line="491" />
+        <location filename="../imports/shared/views/TransactionPreview.qml" line="491" />
         <source>Data</source>
         <translation>Data</translation>
     </message>
     <message>
-        <location filename="../imports/shared/views/TransactionPreview.qml" line="532" />
-        <location filename="../imports/shared/views/TransactionPreview.qml" line="532" />
+        <location filename="../imports/shared/views/TransactionPreview.qml" line="533" />
+        <location filename="../imports/shared/views/TransactionPreview.qml" line="533" />
         <source>Data field</source>
         <translation>Data field</translation>
     </message>
@@ -14036,6 +13969,39 @@ to login to Status?</translation>
     </message>
 </context>
 <context>
+    <name>TransactionStore</name>
+    <message>
+        <location filename="../imports/shared/stores/TransactionStore.qml" line="162" />
+        <location filename="../imports/shared/stores/TransactionStore.qml" line="162" />
+        <source>~ Unknown</source>
+        <translation>~ Unknown</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/stores/TransactionStore.qml" line="164" />
+        <location filename="../imports/shared/stores/TransactionStore.qml" line="164" />
+        <source>&lt; 1 minute</source>
+        <translation>&lt; 1 minute</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/stores/TransactionStore.qml" line="166" />
+        <location filename="../imports/shared/stores/TransactionStore.qml" line="166" />
+        <source>&lt; 3 minutes</source>
+        <translation>&lt; 3 minutes</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/stores/TransactionStore.qml" line="168" />
+        <location filename="../imports/shared/stores/TransactionStore.qml" line="168" />
+        <source>&lt; 5 minutes</source>
+        <translation>&lt; 5 minutes</translation>
+    </message>
+    <message>
+        <location filename="../imports/shared/stores/TransactionStore.qml" line="170" />
+        <location filename="../imports/shared/stores/TransactionStore.qml" line="170" />
+        <source>&gt; 5 minutes</source>
+        <translation>&gt; 5 minutes</translation>
+    </message>
+</context>
+<context>
     <name>TransferOwnershipPopup</name>
     <message>
         <location filename="../app/AppLayouts/Chat/popups/community/TransferOwnershipPopup.qml" line="21" />
@@ -14094,14 +14060,14 @@ to login to Status?</translation>
 <context>
     <name>UserListPanel</name>
     <message>
-        <location filename="../app/AppLayouts/Chat/panels/UserListPanel.qml" line="128" />
-        <location filename="../app/AppLayouts/Chat/panels/UserListPanel.qml" line="128" />
+        <location filename="../app/AppLayouts/Chat/panels/UserListPanel.qml" line="167" />
+        <location filename="../app/AppLayouts/Chat/panels/UserListPanel.qml" line="167" />
         <source>Online</source>
         <translation>Online</translation>
     </message>
     <message>
-        <location filename="../app/AppLayouts/Chat/panels/UserListPanel.qml" line="130" />
-        <location filename="../app/AppLayouts/Chat/panels/UserListPanel.qml" line="130" />
+        <location filename="../app/AppLayouts/Chat/panels/UserListPanel.qml" line="169" />
+        <location filename="../app/AppLayouts/Chat/panels/UserListPanel.qml" line="169" />
         <source>Inactive</source>
         <translation>Inactive</translation>
     </message>
@@ -14145,402 +14111,411 @@ to login to Status?</translation>
 <context>
     <name>Utils</name>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="196" />
-        <location filename="../imports/utils/Utils.qml" line="196" />
+        <location filename="../imports/utils/Utils.qml" line="176" />
+        <location filename="../imports/utils/Utils.qml" line="176" />
         <source>Sun</source>
         <translation>Sun</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="197" />
-        <location filename="../imports/utils/Utils.qml" line="197" />
+        <location filename="../imports/utils/Utils.qml" line="177" />
+        <location filename="../imports/utils/Utils.qml" line="177" />
         <source>Mon</source>
         <translation>Mon</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="198" />
-        <location filename="../imports/utils/Utils.qml" line="198" />
+        <location filename="../imports/utils/Utils.qml" line="178" />
+        <location filename="../imports/utils/Utils.qml" line="178" />
         <source>Tue</source>
         <translation>Tue</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="199" />
-        <location filename="../imports/utils/Utils.qml" line="199" />
+        <location filename="../imports/utils/Utils.qml" line="179" />
+        <location filename="../imports/utils/Utils.qml" line="179" />
         <source>Wed</source>
         <translation>Wed</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="200" />
-        <location filename="../imports/utils/Utils.qml" line="200" />
+        <location filename="../imports/utils/Utils.qml" line="180" />
+        <location filename="../imports/utils/Utils.qml" line="180" />
         <source>Thu</source>
         <translation>Thu</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="201" />
-        <location filename="../imports/utils/Utils.qml" line="201" />
+        <location filename="../imports/utils/Utils.qml" line="181" />
+        <location filename="../imports/utils/Utils.qml" line="181" />
         <source>Fri</source>
         <translation>Fri</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="202" />
-        <location filename="../imports/utils/Utils.qml" line="202" />
+        <location filename="../imports/utils/Utils.qml" line="182" />
+        <location filename="../imports/utils/Utils.qml" line="182" />
         <source>Sat</source>
         <translation>Sat</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="204" />
-        <location filename="../imports/utils/Utils.qml" line="204" />
+        <location filename="../imports/utils/Utils.qml" line="184" />
+        <location filename="../imports/utils/Utils.qml" line="184" />
         <source>Jan</source>
         <translation>Jan</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="205" />
-        <location filename="../imports/utils/Utils.qml" line="205" />
+        <location filename="../imports/utils/Utils.qml" line="185" />
+        <location filename="../imports/utils/Utils.qml" line="185" />
         <source>Feb</source>
         <translation>Feb</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="206" />
-        <location filename="../imports/utils/Utils.qml" line="206" />
+        <location filename="../imports/utils/Utils.qml" line="186" />
+        <location filename="../imports/utils/Utils.qml" line="186" />
         <source>Mar</source>
         <translation>Mar</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="207" />
-        <location filename="../imports/utils/Utils.qml" line="207" />
+        <location filename="../imports/utils/Utils.qml" line="187" />
+        <location filename="../imports/utils/Utils.qml" line="187" />
         <source>Apr</source>
         <translation>Apr</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="208" />
-        <location filename="../imports/utils/Utils.qml" line="208" />
+        <location filename="../imports/utils/Utils.qml" line="188" />
+        <location filename="../imports/utils/Utils.qml" line="188" />
         <source>May</source>
         <translation>May</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="209" />
-        <location filename="../imports/utils/Utils.qml" line="209" />
+        <location filename="../imports/utils/Utils.qml" line="189" />
+        <location filename="../imports/utils/Utils.qml" line="189" />
         <source>Jun</source>
         <translation>Jun</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="210" />
-        <location filename="../imports/utils/Utils.qml" line="210" />
+        <location filename="../imports/utils/Utils.qml" line="190" />
+        <location filename="../imports/utils/Utils.qml" line="190" />
         <source>Jul</source>
         <translation>Jul</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="211" />
-        <location filename="../imports/utils/Utils.qml" line="211" />
+        <location filename="../imports/utils/Utils.qml" line="191" />
+        <location filename="../imports/utils/Utils.qml" line="191" />
         <source>Aug</source>
         <translation>Aug</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="212" />
-        <location filename="../imports/utils/Utils.qml" line="212" />
+        <location filename="../imports/utils/Utils.qml" line="192" />
+        <location filename="../imports/utils/Utils.qml" line="192" />
         <source>Sep</source>
         <translation>Sep</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="213" />
-        <location filename="../imports/utils/Utils.qml" line="213" />
+        <location filename="../imports/utils/Utils.qml" line="193" />
+        <location filename="../imports/utils/Utils.qml" line="193" />
         <source>Oct</source>
         <translation>Oct</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="214" />
-        <location filename="../imports/utils/Utils.qml" line="214" />
+        <location filename="../imports/utils/Utils.qml" line="194" />
+        <location filename="../imports/utils/Utils.qml" line="194" />
         <source>Nov</source>
         <translation>Nov</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="215" />
-        <location filename="../imports/utils/Utils.qml" line="215" />
+        <location filename="../imports/utils/Utils.qml" line="195" />
+        <location filename="../imports/utils/Utils.qml" line="195" />
         <source>Dec</source>
         <translation>Dec</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="262" />
-        <location filename="../imports/utils/Utils.qml" line="262" />
+        <location filename="../imports/utils/Utils.qml" line="242" />
+        <location filename="../imports/utils/Utils.qml" line="242" />
         <source>Yesterday</source>
         <translation>Yesterday</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="264" />
-        <location filename="../imports/utils/Utils.qml" line="264" />
+        <location filename="../imports/utils/Utils.qml" line="244" />
+        <location filename="../imports/utils/Utils.qml" line="244" />
         <source>Sunday</source>
         <translation>Sunday</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="265" />
-        <location filename="../imports/utils/Utils.qml" line="265" />
+        <location filename="../imports/utils/Utils.qml" line="245" />
+        <location filename="../imports/utils/Utils.qml" line="245" />
         <source>Monday</source>
         <translation>Monday</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="266" />
-        <location filename="../imports/utils/Utils.qml" line="266" />
+        <location filename="../imports/utils/Utils.qml" line="246" />
+        <location filename="../imports/utils/Utils.qml" line="246" />
         <source>Tuesday</source>
         <translation>Tuesday</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="267" />
-        <location filename="../imports/utils/Utils.qml" line="267" />
+        <location filename="../imports/utils/Utils.qml" line="247" />
+        <location filename="../imports/utils/Utils.qml" line="247" />
         <source>Wednesday</source>
         <translation>Wednesday</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="268" />
-        <location filename="../imports/utils/Utils.qml" line="268" />
+        <location filename="../imports/utils/Utils.qml" line="248" />
+        <location filename="../imports/utils/Utils.qml" line="248" />
         <source>Thursday</source>
         <translation>Thursday</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="269" />
-        <location filename="../imports/utils/Utils.qml" line="269" />
+        <location filename="../imports/utils/Utils.qml" line="249" />
+        <location filename="../imports/utils/Utils.qml" line="249" />
         <source>Friday</source>
         <translation>Friday</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="270" />
-        <location filename="../imports/utils/Utils.qml" line="270" />
+        <location filename="../imports/utils/Utils.qml" line="250" />
+        <location filename="../imports/utils/Utils.qml" line="250" />
         <source>Saturday</source>
         <translation>Saturday</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="285" />
-        <location filename="../imports/utils/Utils.qml" line="285" />
+        <location filename="../imports/utils/Utils.qml" line="265" />
+        <location filename="../imports/utils/Utils.qml" line="265" />
         <source>NOW</source>
         <translation>NOW</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="289" />
-        <location filename="../imports/utils/Utils.qml" line="289" />
+        <location filename="../imports/utils/Utils.qml" line="269" />
+        <location filename="../imports/utils/Utils.qml" line="269" />
         <source>%1M</source>
         <translation>%1M</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="293" />
-        <location filename="../imports/utils/Utils.qml" line="293" />
+        <location filename="../imports/utils/Utils.qml" line="273" />
+        <location filename="../imports/utils/Utils.qml" line="273" />
         <source>%1H</source>
         <translation>%1H</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="295" />
-        <location filename="../imports/utils/Utils.qml" line="295" />
+        <location filename="../imports/utils/Utils.qml" line="275" />
+        <location filename="../imports/utils/Utils.qml" line="275" />
         <source>%1D</source>
         <translation>%1D</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="385" />
-        <location filename="../imports/utils/Utils.qml" line="385" />
+        <location filename="../imports/utils/Utils.qml" line="365" />
+        <location filename="../imports/utils/Utils.qml" line="365" />
         <source>words</source>
         <translation>words</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="397" />
-        <location filename="../imports/utils/Utils.qml" line="397" />
+        <location filename="../imports/utils/Utils.qml" line="377" />
+        <location filename="../imports/utils/Utils.qml" line="377" />
         <source>You need to enter a password</source>
         <translation>You need to enter a password</translation>
     </message>
-    <message>
-        <location filename="../imports/utils/Utils.qml" line="399" />
-        <location filename="../imports/utils/Utils.qml" line="399" />
-        <source>Password needs to be 6 characters or more</source>
-        <translation>Password needs to be 6 characters or more</translation>
+    <message numerus="yes">
+        <location filename="../imports/utils/Utils.qml" line="379" />
+        <location filename="../imports/utils/Utils.qml" line="379" />
+        <source>Password needs to be %n character(s) or more</source>
+        <translation type="unfinished">
+            <numerusform />
+            <numerusform />
+        </translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="405" />
-        <location filename="../imports/utils/Utils.qml" line="405" />
+        <location filename="../imports/utils/Utils.qml" line="385" />
+        <location filename="../imports/utils/Utils.qml" line="385" />
         <source>You need to repeat your password</source>
         <translation>You need to repeat your password</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="407" />
-        <location filename="../imports/utils/Utils.qml" line="407" />
+        <location filename="../imports/utils/Utils.qml" line="387" />
+        <location filename="../imports/utils/Utils.qml" line="387" />
         <source>Passwords don't match</source>
         <translation>Passwords don't match</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="420" />
-        <location filename="../imports/utils/Utils.qml" line="420" />
+        <location filename="../imports/utils/Utils.qml" line="400" />
+        <location filename="../imports/utils/Utils.qml" line="400" />
         <source>You need to enter a PIN</source>
         <translation>You need to enter a PIN</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="422" />
-        <location filename="../imports/utils/Utils.qml" line="422" />
+        <location filename="../imports/utils/Utils.qml" line="402" />
+        <location filename="../imports/utils/Utils.qml" line="402" />
         <source>The PIN must contain only digits</source>
         <translation>The PIN must contain only digits</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="424" />
-        <location filename="../imports/utils/Utils.qml" line="424" />
+        <location filename="../imports/utils/Utils.qml" line="404" />
+        <location filename="../imports/utils/Utils.qml" line="404" />
         <source>The PIN must be exactly %1 digits</source>
         <translation>The PIN must be exactly %1 digits</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="430" />
-        <location filename="../imports/utils/Utils.qml" line="430" />
+        <location filename="../imports/utils/Utils.qml" line="410" />
+        <location filename="../imports/utils/Utils.qml" line="410" />
         <source>You need to repeat your PIN</source>
         <translation>You need to repeat your PIN</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="432" />
-        <location filename="../imports/utils/Utils.qml" line="432" />
+        <location filename="../imports/utils/Utils.qml" line="412" />
+        <location filename="../imports/utils/Utils.qml" line="412" />
         <source>PIN don't match</source>
         <translation>PIN don't match</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="498" />
-        <location filename="../imports/utils/Utils.qml" line="520" />
-        <location filename="../imports/utils/Utils.qml" line="498" />
-        <location filename="../imports/utils/Utils.qml" line="520" />
+        <location filename="../imports/utils/Utils.qml" line="482" />
+        <location filename="../imports/utils/Utils.qml" line="504" />
+        <location filename="../imports/utils/Utils.qml" line="482" />
+        <location filename="../imports/utils/Utils.qml" line="504" />
         <source>You need to enter a %1</source>
         <translation>You need to enter a %1</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="502" />
-        <location filename="../imports/utils/Utils.qml" line="502" />
+        <location filename="../imports/utils/Utils.qml" line="486" />
+        <location filename="../imports/utils/Utils.qml" line="486" />
         <source>The %1 cannot exceed %2 characters</source>
         <translation>The %1 cannot exceed %2 characters</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="506" />
-        <location filename="../imports/utils/Utils.qml" line="506" />
+        <location filename="../imports/utils/Utils.qml" line="490" />
+        <location filename="../imports/utils/Utils.qml" line="490" />
         <source>Must be an hexadecimal color (eg: #4360DF)</source>
         <translation>Must be an hexadecimal color (eg: #4360DF)</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="510" />
-        <location filename="../imports/utils/Utils.qml" line="510" />
+        <location filename="../imports/utils/Utils.qml" line="494" />
+        <location filename="../imports/utils/Utils.qml" line="494" />
         <source>Use only lowercase letters (a to z), numbers &amp; dashes (-). Do not use chat keys.</source>
         <translation>Use only lowercase letters (a to z), numbers &amp; dashes (-). Do not use chat keys.</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="521" />
-        <location filename="../imports/utils/Utils.qml" line="521" />
+        <location filename="../imports/utils/Utils.qml" line="505" />
+        <location filename="../imports/utils/Utils.qml" line="505" />
         <source>Value has to be at least %1 characters long</source>
         <translation>Value has to be at least %1 characters long</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="531" />
-        <location filename="../imports/utils/Utils.qml" line="531" />
-        <source>Unknown</source>
-        <translation>Unknown</translation>
-    </message>
-    <message>
-        <location filename="../imports/utils/Utils.qml" line="535" />
-        <location filename="../imports/utils/Utils.qml" line="535" />
-        <source>&lt; 1 min</source>
-        <translation>&lt; 1 min</translation>
-    </message>
-    <message>
-        <location filename="../imports/utils/Utils.qml" line="538" />
-        <location filename="../imports/utils/Utils.qml" line="538" />
-        <source>&lt; 3 mins</source>
-        <translation>&lt; 3 mins</translation>
-    </message>
-    <message>
-        <location filename="../imports/utils/Utils.qml" line="541" />
-        <location filename="../imports/utils/Utils.qml" line="541" />
-        <source>&lt; 5 mins</source>
-        <translation>&lt; 5 mins</translation>
-    </message>
-    <message>
-        <location filename="../imports/utils/Utils.qml" line="544" />
-        <location filename="../imports/utils/Utils.qml" line="544" />
-        <source>&gt; 5 mins</source>
-        <translation>&gt; 5 mins</translation>
-    </message>
-    <message>
-        <location filename="../imports/utils/Utils.qml" line="666" />
-        <location filename="../imports/utils/Utils.qml" line="666" />
+        <location filename="../imports/utils/Utils.qml" line="676" />
+        <location filename="../imports/utils/Utils.qml" line="676" />
         <source>years ago</source>
         <translation>years ago</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="666" />
-        <location filename="../imports/utils/Utils.qml" line="666" />
+        <location filename="../imports/utils/Utils.qml" line="676" />
+        <location filename="../imports/utils/Utils.qml" line="676" />
         <source>year ago</source>
         <translation>year ago</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="673" />
-        <location filename="../imports/utils/Utils.qml" line="673" />
+        <location filename="../imports/utils/Utils.qml" line="683" />
+        <location filename="../imports/utils/Utils.qml" line="683" />
         <source>months ago</source>
         <translation>months ago</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="673" />
-        <location filename="../imports/utils/Utils.qml" line="673" />
+        <location filename="../imports/utils/Utils.qml" line="683" />
+        <location filename="../imports/utils/Utils.qml" line="683" />
         <source>month ago</source>
         <translation>month ago</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="680" />
-        <location filename="../imports/utils/Utils.qml" line="680" />
+        <location filename="../imports/utils/Utils.qml" line="690" />
+        <location filename="../imports/utils/Utils.qml" line="690" />
         <source>weeks ago</source>
         <translation>weeks ago</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="680" />
-        <location filename="../imports/utils/Utils.qml" line="680" />
+        <location filename="../imports/utils/Utils.qml" line="690" />
+        <location filename="../imports/utils/Utils.qml" line="690" />
         <source>week ago</source>
         <translation>week ago</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="687" />
-        <location filename="../imports/utils/Utils.qml" line="687" />
+        <location filename="../imports/utils/Utils.qml" line="697" />
+        <location filename="../imports/utils/Utils.qml" line="697" />
         <source>days ago</source>
         <translation>days ago</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="687" />
-        <location filename="../imports/utils/Utils.qml" line="687" />
+        <location filename="../imports/utils/Utils.qml" line="697" />
+        <location filename="../imports/utils/Utils.qml" line="697" />
         <source>day ago</source>
         <translation>day ago</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="694" />
-        <location filename="../imports/utils/Utils.qml" line="694" />
+        <location filename="../imports/utils/Utils.qml" line="704" />
+        <location filename="../imports/utils/Utils.qml" line="704" />
         <source>hours ago</source>
         <translation>hours ago</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="694" />
-        <location filename="../imports/utils/Utils.qml" line="694" />
+        <location filename="../imports/utils/Utils.qml" line="704" />
+        <location filename="../imports/utils/Utils.qml" line="704" />
         <source>hour ago</source>
         <translation>hour ago</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="701" />
-        <location filename="../imports/utils/Utils.qml" line="701" />
+        <location filename="../imports/utils/Utils.qml" line="711" />
+        <location filename="../imports/utils/Utils.qml" line="711" />
         <source>mins ago</source>
         <translation>mins ago</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="701" />
-        <location filename="../imports/utils/Utils.qml" line="701" />
+        <location filename="../imports/utils/Utils.qml" line="711" />
+        <location filename="../imports/utils/Utils.qml" line="711" />
         <source>min ago</source>
         <translation>min ago</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="708" />
-        <location filename="../imports/utils/Utils.qml" line="708" />
+        <location filename="../imports/utils/Utils.qml" line="718" />
+        <location filename="../imports/utils/Utils.qml" line="718" />
         <source>secs ago</source>
         <translation>secs ago</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="708" />
-        <location filename="../imports/utils/Utils.qml" line="708" />
+        <location filename="../imports/utils/Utils.qml" line="718" />
+        <location filename="../imports/utils/Utils.qml" line="718" />
         <source>sec ago</source>
         <translation>sec ago</translation>
     </message>
     <message>
-        <location filename="../imports/utils/Utils.qml" line="712" />
-        <location filename="../imports/utils/Utils.qml" line="712" />
+        <location filename="../imports/utils/Utils.qml" line="722" />
+        <location filename="../imports/utils/Utils.qml" line="722" />
         <source>now</source>
         <translation>now</translation>
+    </message>
+    <message>
+        <location filename="../imports/utils/Utils.qml" line="783" />
+        <location filename="../imports/utils/Utils.qml" line="783" />
+        <source>Messages</source>
+        <translation>Messages</translation>
+    </message>
+    <message>
+        <location filename="../imports/utils/Utils.qml" line="785" />
+        <location filename="../imports/utils/Utils.qml" line="785" />
+        <source>Wallet</source>
+        <translation>Wallet</translation>
+    </message>
+    <message>
+        <location filename="../imports/utils/Utils.qml" line="787" />
+        <location filename="../imports/utils/Utils.qml" line="787" />
+        <source>Browser</source>
+        <translation>Browser</translation>
+    </message>
+    <message>
+        <location filename="../imports/utils/Utils.qml" line="789" />
+        <location filename="../imports/utils/Utils.qml" line="789" />
+        <source>Settings</source>
+        <translation>Settings</translation>
+    </message>
+    <message>
+        <location filename="../imports/utils/Utils.qml" line="791" />
+        <location filename="../imports/utils/Utils.qml" line="791" />
+        <source>Node Management</source>
+        <translation>Node Management</translation>
+    </message>
+    <message>
+        <location filename="../imports/utils/Utils.qml" line="793" />
+        <location filename="../imports/utils/Utils.qml" line="793" />
+        <source>Communities Portal</source>
+        <translation>Communities Portal</translation>
     </message>
 </context>
 <context>
@@ -14610,6 +14585,12 @@ to login to Status?</translation>
         <location filename="../app/AppLayouts/Wallet/panels/WalletFooter.qml" line="52" />
         <source>Buy / Sell</source>
         <translation>Buy / Sell</translation>
+    </message>
+    <message>
+        <location filename="../app/AppLayouts/Wallet/panels/WalletFooter.qml" line="61" />
+        <location filename="../app/AppLayouts/Wallet/panels/WalletFooter.qml" line="61" />
+        <source>Bridge</source>
+        <translation>Bridge</translation>
     </message>
 </context>
 <context>
@@ -14687,14 +14668,14 @@ to login to Status?</translation>
         <translation>Status Desktop</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="244" />
-        <location filename="../main.qml" line="244" />
+        <location filename="../main.qml" line="270" />
+        <location filename="../main.qml" line="270" />
         <source>Open Status</source>
         <translation>Open Status</translation>
     </message>
     <message>
-        <location filename="../main.qml" line="254" />
-        <location filename="../main.qml" line="254" />
+        <location filename="../main.qml" line="280" />
+        <location filename="../main.qml" line="280" />
         <source>Quit</source>
         <translation>Quit</translation>
     </message>

--- a/ui/i18n/qml_en.ts
+++ b/ui/i18n/qml_en.ts
@@ -4,10 +4,10 @@
 <context>
     <name>AppMain</name>
     <message numerus="yes">
-        <location filename="../app/mainui/AppMain.qml" line="611"/>
-        <location filename="../app/mainui/AppMain.qml" line="620"/>
-        <location filename="../app/mainui/AppMain.qml" line="611"/>
-        <location filename="../app/mainui/AppMain.qml" line="620"/>
+        <location filename="../app/mainui/AppMain.qml" line="627"/>
+        <location filename="../app/mainui/AppMain.qml" line="636"/>
+        <location filename="../app/mainui/AppMain.qml" line="627"/>
+        <location filename="../app/mainui/AppMain.qml" line="636"/>
         <source>%n issue(s)</source>
         <translation>
             <numerusform>%n issue</numerusform>
@@ -147,8 +147,8 @@
 <context>
     <name>InvitationBubbleView</name>
     <message numerus="yes">
-        <location filename="../imports/shared/views/chat/InvitationBubbleView.qml" line="200"/>
-        <location filename="../imports/shared/views/chat/InvitationBubbleView.qml" line="200"/>
+        <location filename="../imports/shared/views/chat/InvitationBubbleView.qml" line="156"/>
+        <location filename="../imports/shared/views/chat/InvitationBubbleView.qml" line="156"/>
         <source>%n member(s)</source>
         <translation>
             <numerusform>%n member</numerusform>
@@ -230,8 +230,8 @@
 <context>
     <name>LoginView</name>
     <message numerus="yes">
-        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="1077"/>
-        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="1077"/>
+        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="1069"/>
+        <location filename="../app/AppLayouts/Onboarding/views/LoginView.qml" line="1069"/>
         <source>%n attempt(s) remaining</source>
         <translation>
             <numerusform>%n attempt remaining</numerusform>
@@ -242,8 +242,8 @@
 <context>
     <name>MainView</name>
     <message numerus="yes">
-        <location filename="../app/AppLayouts/Profile/views/wallet/MainView.qml" line="59"/>
-        <location filename="../app/AppLayouts/Profile/views/wallet/MainView.qml" line="59"/>
+        <location filename="../app/AppLayouts/Profile/views/wallet/MainView.qml" line="32"/>
+        <location filename="../app/AppLayouts/Profile/views/wallet/MainView.qml" line="32"/>
         <source>%n DApp(s) connected</source>
         <translation>
             <numerusform>%n DApp connected</numerusform>
@@ -287,8 +287,8 @@
 <context>
     <name>PinnedMessagesPopup</name>
     <message numerus="yes">
-        <location filename="../app/AppLayouts/Chat/popups/PinnedMessagesPopup.qml" line="33"/>
-        <location filename="../app/AppLayouts/Chat/popups/PinnedMessagesPopup.qml" line="33"/>
+        <location filename="../app/AppLayouts/Chat/popups/PinnedMessagesPopup.qml" line="30"/>
+        <location filename="../app/AppLayouts/Chat/popups/PinnedMessagesPopup.qml" line="30"/>
         <source>%n message(s)</source>
         <translation>
             <numerusform>%n message</numerusform>
@@ -335,8 +335,8 @@
 <context>
     <name>Utils</name>
     <message numerus="yes">
-        <location filename="../imports/utils/Utils.qml" line="375"/>
-        <location filename="../imports/utils/Utils.qml" line="375"/>
+        <location filename="../imports/utils/Utils.qml" line="379"/>
+        <location filename="../imports/utils/Utils.qml" line="379"/>
         <source>Password needs to be %n character(s) or more</source>
         <translation>
             <numerusform>Password needs to be %n character or more</numerusform>

--- a/ui/imports/utils/Utils.qml
+++ b/ui/imports/utils/Utils.qml
@@ -776,6 +776,26 @@ QtObject {
         return link.replace(Constants.socialLinkPrefixesByType[type], "")
     }
 
+    // handle translations for section names coming from app_sections_config.nim
+    function translatedSectionName(sectionType, fallback) {
+        switch(sectionType) {
+        case Constants.appSection.chat:
+            return qsTr("Messages")
+        case Constants.appSection.wallet:
+            return qsTr("Wallet")
+        case Constants.appSection.browser:
+            return qsTr("Browser")
+        case Constants.appSection.profile:
+            return qsTr("Settings")
+        case Constants.appSection.node:
+            return qsTr("Node Management")
+        case Constants.appSection.communitiesPortal:
+            return qsTr("Communities Portal")
+        default:
+            return fallback
+        }
+    }
+
     // Leave this function at the bottom of the file as QT Creator messes up the code color after this
     function isPunct(c) {
         return /(!|\@|#|\$|%|\^|&|\*|\(|\)|\+|\||-|=|\\|{|}|[|]|"|;|'|<|>|\?|,|\.|\/)/.test(c)


### PR DESCRIPTION
... and do it the proper way, ie. make the string translatable as we
can't handle translations coming from NIM files at the moment

(separate commit to update/extract the messages)

Closes #8418

### What does the PR do

Changes Chat->Messages in the navbar tooltip

### Affected areas

AppMain/NavBar

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![image](https://user-images.githubusercontent.com/5377645/207047973-a78f74fe-1a12-4a84-863b-506158d59e0b.png)

