### PR TITLE
fix(ProfileDialogView): Wrong name "Tokens" in Profile preview

### DIFF
--- a/ui/imports/shared/views/ProfileDialogView.qml
+++ b/ui/imports/shared/views/ProfileDialogView.qml
@@ -669,11 +669,11 @@ Pane {
                     StatusTabButton {
                         leftPadding: 0
                         width: implicitWidth
-                        text: qsTr("Tokens")
+                        text: qsTr("Assets")
                     }
                     StatusTabButton {
                         width: implicitWidth
-                        text: qsTr("NFTs")
+                        text: qsTr("Collectibles")
                     }
                     StatusTabButton {
                         width: implicitWidth


### PR DESCRIPTION
Tokens -> Assets
NFTs -> Collectibles

(to be consistent with the rest of the app)

Fixes #8716

### What does the PR do

Fixes wording in the Profile Dialog

### Affected areas

ProfileDialogView

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![image](https://user-images.githubusercontent.com/5377645/207284057-f49e6daa-e1d1-4d94-9fb5-03a937d5727a.png)

