### PR TITLE
Fix ENS names inconsistency across app

### DIFF
--- a/src/app/boot/app_controller.nim
+++ b/src/app/boot/app_controller.nim
@@ -382,8 +382,8 @@ proc buildAndRegisterLocalAccountSensitiveSettings(self: AppController) =
 proc buildAndRegisterUserProfile(self: AppController) =
   let pubKey = self.settingsService.getPublicKey()
   let alias = self.settingsService.getName()
-  let preferredName = self.settingsService.getPreferredName()
-  var displayName = self.settingsService.getDisplayName()
+  var preferredName = self.settingsService.getPreferredName()
+  let displayName = self.settingsService.getDisplayName()
   let ensUsernames = self.settingsService.getEnsUsernames()
   let firstEnsName = if (ensUsernames.len > 0): ensUsernames[0] else: ""
   let currentUserStatus = self.settingsService.getCurrentUserStatus()
@@ -399,7 +399,6 @@ proc buildAndRegisterUserProfile(self: AppController) =
   singletonInstance.userProfile.setFixedData(alias, loggedInAccount.keyUid, pubKey, loggedInAccount.keycardPairing.len > 0)
   singletonInstance.userProfile.setDisplayName(displayName)
   singletonInstance.userProfile.setPreferredName(preferredName)
-  singletonInstance.userProfile.setEnsName(firstEnsName)
   singletonInstance.userProfile.setThumbnailImage(thumbnail)
   singletonInstance.userProfile.setLargeImage(large)
   singletonInstance.userProfile.setCurrentUserStatus(currentUserStatus.statusType.int)

--- a/src/app/global/user_profile.nim
+++ b/src/app/global/user_profile.nim
@@ -11,7 +11,6 @@ QtObject:
     pubKey: string
     isKeycardUser: bool
     # fields which may change during runtime
-    ensName: string
     displayName: string
     preferredName: string
     thumbnailImage: string
@@ -69,20 +68,6 @@ QtObject:
     notify = nameChanged
 
   # this is not a slot
-  proc setEnsName*(self: UserProfile, name: string) =
-    if(self.ensName == name):
-      return
-    self.ensName = name
-    self.nameChanged()
-
-  proc getEnsName*(self: UserProfile): string {.slot.} =
-    self.ensName
-  QtProperty[string] ensName:
-    read = getEnsName
-    notify = nameChanged
-
-
-  # this is not a slot
   proc setPreferredName*(self: UserProfile, name: string) =
     if(self.preferredName == name):
       return
@@ -91,14 +76,9 @@ QtObject:
 
   proc getPreferredName*(self: UserProfile): string {.slot.} =
     self.preferredName
+
   QtProperty[string] preferredName:
     read = getPreferredName
-    notify = nameChanged
-
-  proc getPrettyPreferredName*(self: UserProfile): string {.slot.} =
-    self.preferredName
-  QtProperty[string] prettyPreferredName:
-    read = getPrettyPreferredName
     notify = nameChanged
 
   proc setDisplayName*(self: UserProfile, displayName: string) = # Not a slot
@@ -116,9 +96,7 @@ QtObject:
 
   proc getName*(self: UserProfile): string {.slot.} =
     if(self.preferredName.len > 0):
-      return self.getPrettyPreferredName()
-    elif(self.ensName.len > 0):
-      return self.ensName
+      return self.getPreferredName()
     elif(self.displayName.len > 0):
       return self.getDisplayName()
     return self.username

--- a/src/app/modules/main/chat_section/chat_content/input_area/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/input_area/module.nim
@@ -69,7 +69,7 @@ method sendChatMessage*(
     replyTo: string,
     contentType: int) =
   self.controller.sendChatMessage(msg, replyTo, contentType,
-    singletonInstance.userProfile.getEnsName())
+    singletonInstance.userProfile.getPreferredName())
 
 method requestAddressForTransaction*(self: Module, fromAddress: string, amount: string, tokenAddress: string) =
   self.controller.requestAddressForTransaction(fromAddress, amount, tokenAddress)

--- a/src/app/modules/main/chat_section/chat_content/messages/controller.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/controller.nim
@@ -153,6 +153,9 @@ proc init*(self: Controller) =
     var args = ContactArgs(e)
     self.delegate.updateContactDetails(args.contactId)
 
+  self.events.on(SIGNAL_LOGGEDIN_USER_NAME_CHANGED) do(e: Args):
+    self.delegate.updateContactDetails(singletonInstance.userProfile.getPubKey())
+
   self.events.on(SIGNAL_LOGGEDIN_USER_IMAGE_CHANGED) do(e: Args):
     self.delegate.updateContactDetails(singletonInstance.userProfile.getPubKey())
 

--- a/src/app/modules/main/chat_section/chat_content/messages/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/module.nim
@@ -452,6 +452,7 @@ method updateContactDetails*(self: Module, contactId: string) =
       item.senderIcon = updatedContact.icon
       item.senderIsAdded = updatedContact.details.added
       item.senderTrustStatus = updatedContact.details.trustStatus
+      item.senderEnsVerified = updatedContact.details.ensVerified
     if(item.messageContainsMentions):
       let (m, _, err) = self.controller.getMessageDetails(item.id)
       if(err.len == 0):

--- a/src/app/modules/main/chat_section/chat_content/users/controller.nim
+++ b/src/app/modules/main/chat_section/chat_content/users/controller.nim
@@ -75,6 +75,9 @@ proc init*(self: Controller) =
     let args = ContactArgs(e)
     self.delegate.contactUpdated(args.contactId)
 
+  self.events.on(SIGNAL_LOGGEDIN_USER_NAME_CHANGED) do(e: Args):
+    self.delegate.userProfileUpdated()
+
   self.events.on(SIGNAL_LOGGEDIN_USER_IMAGE_CHANGED) do(e: Args):
     self.delegate.loggedInUserImageChanged()
 

--- a/src/app/modules/main/chat_section/chat_content/users/io_interface.nim
+++ b/src/app/modules/main/chat_section/chat_content/users/io_interface.nim
@@ -31,6 +31,9 @@ method contactsStatusUpdated*(self: AccessInterface, statusUpdates: seq[StatusUp
 method contactUpdated*(self: AccessInterface, publicKey: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method userProfileUpdated*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method loggedInUserImageChanged*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/chat_section/chat_content/users/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/users/module.nim
@@ -116,6 +116,9 @@ method contactUpdated*(self: Module, publicKey: string) =
     isUntrustworthy = contactDetails.details.trustStatus == TrustStatus.Untrustworthy,
   )
 
+method userProfileUpdated*(self: Module) =
+  self.contactUpdated(singletonInstance.userProfile.getPubKey())
+
 method loggedInUserImageChanged*(self: Module) =
   self.view.model().setIcon(singletonInstance.userProfile.getPubKey(), singletonInstance.userProfile.getIcon())
 

--- a/src/app/modules/main/profile_section/ens_usernames/controller.nim
+++ b/src/app/modules/main/profile_section/ens_usernames/controller.nim
@@ -108,6 +108,13 @@ proc setPreferredName*(self: Controller, preferredName: string) =
   else:
     info "an error occurred saving prefered ens username", methodName="setPreferredName"
 
+proc fixPreferredName*(self: Controller, ignoreCurrentValue: bool = false) =
+  if (not ignoreCurrentValue and singletonInstance.userProfile.getPreferredName().len > 0):
+    return
+  let ensUsernames = self.settingsService.getEnsUsernames()
+  let firstEnsName = if (ensUsernames.len > 0): ensUsernames[0] else: ""
+  self.setPreferredName(firstEnsName)
+
 proc getEnsRegisteredAddress*(self: Controller): string =
   return self.ensService.getEnsRegisteredAddress()
 

--- a/src/app/modules/main/profile_section/ens_usernames/module.nim
+++ b/src/app/modules/main/profile_section/ens_usernames/module.nim
@@ -182,7 +182,7 @@ method removeEnsUsername*(self: Module, ensUsername: string): bool =
     info "an error occurred removing ens username", methodName="removeEnsUsername"
     return false
   if (self.controller.getPreferredEnsUsername() == ensUsername):
-    self.controller.setPreferredName("")
+    self.controller.fixPreferredName(true)
   self.view.model().removeItemByEnsUsername(ensUsername)
   return true
 
@@ -228,14 +228,14 @@ method connectOwnedUsername*(self: Module, ensUsername: string, isStatus: bool) 
     info "an error occurred saving ens username", methodName="connectOwnedUsername"
     return
 
-  self.controller.setPreferredName(ensUsername)
+  self.controller.fixPreferredName()
   self.view.model().addItem(Item(ensUsername: ensUsername, isPending: false))
 
 method ensTransactionConfirmed*(self: Module, trxType: string, ensUsername: string, transactionHash: string) =
   if(not self.controller.saveNewEnsUsername(ensUsername)):
     info "an error occurred saving ens username", methodName="ensTransactionConfirmed"
     return
-
+  self.controller.fixPreferredName()
   if(self.view.model().containsEnsUsername(ensUsername)):
     self.view.model().updatePendingStatus(ensUsername, false)
   else:
@@ -312,6 +312,7 @@ method registerEns(self: Module, password: string) =
 
   var respResult: string
   if(responseObj.getProp("result", respResult) and responseObj{"success"}.getBool == true):
+    self.controller.fixPreferredName()
     self.view.model().addItem(Item(ensUsername: self.formatUsername(self.tmpSendEnsTransactionDetails.ensUsername, true), isPending: true))
   self.view.emitTransactionWasSentSignal(response)
 

--- a/src/app/modules/main/stickers/module.nim
+++ b/src/app/modules/main/stickers/module.nim
@@ -150,7 +150,7 @@ method sendSticker*(self: Module, channelId: string, replyTo: string, sticker: I
     channelId,
     replyTo,
     stickerDto,
-    singletonInstance.userProfile.getEnsName())
+    singletonInstance.userProfile.getPreferredName())
 
 method estimate*(self: Module, packId: string, address: string, price: string, uuid: string) =
   self.controller.estimate(packId, address, price, uuid)

--- a/ui/StatusQ/src/StatusQ/Controls/StatusInput.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusInput.qml
@@ -258,7 +258,7 @@ Item {
         This function validates the text input's text.
     */
 
-    function validate(force) {
+    function validate(force = false) {
         if (!force && !statusBaseInput.dirty && validationMode === StatusInput.ValidationMode.OnlyWhenDirty) {
             return
         }
@@ -364,6 +364,14 @@ Item {
     implicitHeight: inputLayout.implicitHeight
 
     Component.onCompleted: {
+        validate()
+    }
+
+    onValidatorsChanged: {
+        validate()
+    }
+
+    onValidationModeChanged: {
         validate()
     }
 

--- a/ui/app/AppLayouts/Chat/popups/community/CommunityDetailPopup.qml
+++ b/ui/app/AppLayouts/Chat/popups/community/CommunityDetailPopup.qml
@@ -194,7 +194,7 @@ StatusModal {
                 //        text = qsTr("Pending")
                 //    }
                } else {
-                   error = root.store.communitiesModuleInst.requestToJoinCommunity(root.communityId, root.store.userProfileInst.ensName)
+                   error = root.store.communitiesModuleInst.requestToJoinCommunity(root.communityId, root.store.userProfileInst.preferredName)
                }
 
                if (error) {

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -421,7 +421,7 @@ QtObject {
                 const userCanJoin = userCanJoin(communityId)
                 // TODO find what to do when you can't join
                 if (userCanJoin) {
-                    requestToJoinCommunity(communityId, userProfileInst.ensName)
+                    requestToJoinCommunity(communityId, userProfileInst.preferredName)
                 }
             }
             return result

--- a/ui/app/AppLayouts/Profile/popups/ENSPopup.qml
+++ b/ui/app/AppLayouts/Profile/popups/ENSPopup.qml
@@ -27,10 +27,22 @@ StatusDialog {
         close();
     }
 
+    footer: StatusDialogFooter {
+        rightButtons: ObjectModel {
+            StatusButton {
+                enabled: d.newUsername !== root.ensUsernamesStore.preferredUsername
+                text: qsTr("Apply")
+                onClicked: {
+                    root.applied()
+                }
+            }
+        }
+    }
+
     QtObject {
         id: d
 
-        property string newUsername: ""
+        property string newUsername: root.ensUsernamesStore.preferredUsername
     }
 
     ColumnLayout {

--- a/ui/app/AppLayouts/Profile/stores/ProfileStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/ProfileStore.qml
@@ -7,10 +7,10 @@ QtObject {
     property var profileModule
 
     property string pubkey: userProfile.pubKey
-    property string name: userProfile.name // in case of ens returns pretty ens form
+    property string name: userProfile.name
     property string username: userProfile.username
     property string displayName: userProfile.displayName
-    property string ensName: userProfile.preferredName || userProfile.ensName
+    property string preferredName: userProfile.preferredName
     property string profileLargeImage: userProfile.largeImage
     property string icon: userProfile.icon
     property bool userDeclinedBackupBanner: localAccountSensitiveSettings.userDeclinedBackupBanner

--- a/ui/app/AppLayouts/Profile/views/profile/MyProfileSettingsView.qml
+++ b/ui/app/AppLayouts/Profile/views/profile/MyProfileSettingsView.qml
@@ -123,7 +123,7 @@ ColumnLayout {
     ProfileDescriptionPanel {
         id: descriptionPanel
 
-        readonly property bool isEnsName: profileStore.ensName
+        readonly property bool isEnsName: profileStore.preferredName
 
         function reevaluateSocialLinkInputs()  {
             socialLinksModel = null
@@ -134,8 +134,8 @@ ColumnLayout {
 
         displayName.focus: !isEnsName
         displayName.input.edit.readOnly: isEnsName
-        displayName.text: profileStore.ensName || profileStore.displayName
-        displayName.validationMode: isEnsName ? StatusInput.ValidationMode.None : StatusInput.ValidationMode.Always
+        displayName.text: profileStore.name
+        displayName.validationMode: StatusInput.ValidationMode.Always
         displayName.validators: isEnsName ? [] : Constants.validators.displayName
         bio.text: profileStore.bio
         socialLinksModel: staticSocialLinksSubsetModel

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -443,7 +443,7 @@ Item {
                 identicon.asset.charactersLen: 2
                 identicon.asset.color: Utils.colorForPubkey(appMain.rootStore.userProfileInst.pubKey)
                 identicon.ringSettings.ringSpecModel: Utils.getColorHashAsJson(appMain.rootStore.userProfileInst.pubKey,
-                                                                               appMain.rootStore.userProfileInst.ensName)
+                                                                               appMain.rootStore.userProfileInst.preferredName)
 
                 badge.visible: true
                 badge.anchors {

--- a/ui/imports/shared/popups/ContactVerificationRequestPopup.qml
+++ b/ui/imports/shared/popups/ContactVerificationRequestPopup.qml
@@ -98,7 +98,7 @@ StatusModal {
             messageTimestamp: root.responseTimestamp
             senderId: userProfile.pubKey
             senderDisplayName: userProfile.displayName
-            senderIsEnsVerified: !!userProfile.ensName
+            senderIsEnsVerified: !!userProfile.preferredName
             senderIcon: userProfile.icon
             messageText: root.responseText
             messageContentType: Constants.messageContentType.messageType

--- a/ui/imports/shared/popups/OutgoingContactVerificationRequestPopup.qml
+++ b/ui/imports/shared/popups/OutgoingContactVerificationRequestPopup.qml
@@ -75,7 +75,7 @@ StatusDialog {
             senderId: userProfile.pubKey
             senderDisplayName: userProfile.name
             senderIcon: userProfile.icon
-            senderIsEnsVerified: !!userProfile.ensName
+            senderIsEnsVerified: !!userProfile.preferredName
             messageText: root.verificationChallenge
             messageContentType: Constants.messageContentType.messageType
             placeholderMessage: true

--- a/ui/imports/shared/popups/UserStatusContextMenu.qml
+++ b/ui/imports/shared/popups/UserStatusContextMenu.qml
@@ -23,7 +23,7 @@ StatusMenu {
         displayName: root.store.userProfileInst.name
         pubkey: root.store.userProfileInst.pubKey
         icon: root.store.userProfileInst.icon
-        userIsEnsVerified: !!root.store.userProfileInst.ensName
+        userIsEnsVerified: !!root.store.userProfileInst.preferredName
     }
 
     StatusMenuSeparator {

--- a/ui/imports/shared/views/ProfileDialogView.qml
+++ b/ui/imports/shared/views/ProfileDialogView.qml
@@ -77,7 +77,7 @@ Pane {
         readonly property string linkToProfile: {
             let user = ""
             if (d.isCurrentUser)
-                user = root.profileStore.ensName
+                user = root.profileStore.preferredName
             else
                 user = contactDetails.name
             if (!user)

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -395,6 +395,7 @@ Loader {
             StatusMessage {
                 id: delegate
                 Layout.fillWidth: true
+
                 function convertContentType(value) {
                     switch (value) {
                     case Constants.messageContentType.messageType:
@@ -468,7 +469,13 @@ Loader {
                 isEdited: root.isEdited
                 hasMention: root.hasMention
                 isPinned: root.pinnedMessage
-                pinnedBy: root.pinnedMessage && !root.isDiscordMessage ? Utils.getContactDetailsAsJson(root.messagePinnedBy, false).displayName : ""
+                pinnedBy: {
+                    if (!root.pinnedMessage || root.isDiscordMessage)
+                        return ""
+                    const contact = Utils.getContactDetailsAsJson(root.messagePinnedBy, false)
+                    const ensName = contact.ensVerified ? contact.name : ""
+                    return ProfileUtils.displayName(contact.localNickname, ensName, contact.displayName, contact.alias)
+                }
                 hasExpired: root.isExpired
                 isSending: root.isSending
                 resendError: root.resendError


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/7598

### What does the PR do

1. Used `preferredName` for current user profile
2. Removed redundant `ensName` property from `user_profile`
It was really the same as `preferredName`
3. Added and connected signals for `preferredName` property changes
4. Reduced number of calls (from 5 to 1) to `getContactById` in `getContactDetails` function
5. Automatically select another `preferredName` when:
    - a new ENS was added while no preferred name chosen
    - ENS name that is currently preferred is removed/released
6. Fixed update for `ensVerified` property in contacts for. current user profile
7. Validate `StatusInput` when `validators` or `validationMode` changed
8. Apply button in `ENSPopup` is only enabled when changes detected
There was a bug: if you open the popup, change nothing and click "Apply", the preferredName would set to empty string `""`.

### Affected areas

Everywhere where you can see ENS names

### Screenshot of functionality (including design for comparison)

Before having ENS name (and buying an ENS)

https://user-images.githubusercontent.com/25482501/207291877-bef0c79d-52a8-4460-b4fd-2b6cc9e93bde.mov

After the transaction is confirmed, restart the app.
Note that a new ENS name automatically selected as preferred (because no preferred name was set previously).
And we see the new ENS name everywhere.
And then let's add another ENS

https://user-images.githubusercontent.com/25482501/207292033-48bf9406-2fc6-4274-9fb2-5d9355f45296.mov

After the transaction is confirmed, restart the app.
Note that the preferred name didn't change automatically.
When we change the preferred name now, we can see that the changes reflect immediately everywhere.
Now try to remove an ENS that is currently selected as "preferred", the name will auto-update to another ENS that we have.

https://user-images.githubusercontent.com/25482501/207292118-2c600e49-0ec6-430e-a563-ea712d1b24da.mov

Now when we don't have any ENS names locally, we still have one in the network, because we didn't release them.
When we restore our own ENS, it's applied immediately everywhere.

https://user-images.githubusercontent.com/25482501/207294721-a3fe2d52-4b5a-4a48-8285-cc9a44e24251.mov
