### PR TITLE
fix(CommunityPermissions): Change `Flickable` to `StatusScrollView`

### DIFF
--- a/ui/app/AppLayouts/Chat/views/communities/CommunityNewPermissionView.qml
+++ b/ui/app/AppLayouts/Chat/views/communities/CommunityNewPermissionView.qml
@@ -14,7 +14,7 @@ import SortFilterProxyModel 0.2
 
 import "../../../Chat/controls/community"
 
-Flickable {
+StatusScrollView {
     id: root
 
     property var store
@@ -30,8 +30,6 @@ Flickable {
 
     contentWidth: mainLayout.width
     contentHeight: mainLayout.height
-    clip: true
-    flickableDirection: Flickable.AutoFlickIfNeeded
 
     ColumnLayout {
         id: mainLayout

--- a/ui/app/AppLayouts/Chat/views/communities/CommunityPermissionsView.qml
+++ b/ui/app/AppLayouts/Chat/views/communities/CommunityPermissionsView.qml
@@ -10,7 +10,7 @@ import utils 1.0
 
 import AppLayouts.Chat.controls.community 1.0
 
-Flickable {
+StatusScrollView {
     id: root
 
     property var store
@@ -18,8 +18,6 @@ Flickable {
 
     contentWidth: mainLayout.width
     contentHeight: mainLayout.height + mainLayout.anchors.topMargin
-    clip: true
-    flickableDirection: Flickable.AutoFlickIfNeeded
 
     ColumnLayout {
         id: mainLayout

--- a/ui/app/AppLayouts/Chat/views/communities/CommunityWelcomePermissionsView.qml
+++ b/ui/app/AppLayouts/Chat/views/communities/CommunityWelcomePermissionsView.qml
@@ -7,15 +7,13 @@ import StatusQ.Controls 0.1
 
 import utils 1.0
 
-Flickable {
+StatusScrollView {
     id: root
 
     property int viewWidth: 560 // by design
 
     contentWidth: mainLayout.width
     contentHeight: mainLayout.height + mainLayout.anchors.topMargin
-    clip: true
-    flickableDirection: Flickable.AutoFlickIfNeeded
 
     ColumnLayout {
         id: mainLayout


### PR DESCRIPTION
Fixes #8584

### What does the PR do
Modified `Flickable` in `CommunityNewPermissionView`, `CommunityWelcomePermissionsView` and `CommunityPermissionView` to `StatusScrollView`

### Affected areas
`CommunityXXXPermissionsView`

### Screenshot of functionality

https://user-images.githubusercontent.com/97019400/207327162-4dd3fe9d-973f-481d-becd-7568e91be5cb.mov



