### PR TITLE
Use binaries from qt installation when building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -295,7 +295,7 @@ $(UI_RESOURCES): $(UI_SOURCES) | check-qt-dir
 	rm -f ./resources.rcc
 	rm -f ./ui/resources.qrc
 	go run ui/generate-rcc.go -source=ui -output=ui/resources.qrc
-	rcc -binary $(RCC_PARAMS) ui/resources.qrc -o ./resources.rcc
+	$(QTDIR)/bin/rcc -binary $(RCC_PARAMS) ui/resources.qrc -o ./resources.rcc
 
 rcc: $(UI_RESOURCES)
 
@@ -305,7 +305,7 @@ QM_BINARIES := $(shell find ui/i18n -iname "*.ts" | sed 's/\.ts/\.qm/' | sed 's/
 $(QM_BINARIES): TS_FILE = $(shell echo $@ | sed 's/\.qm/\.ts/' | sed 's/bin/ui/')
 $(QM_BINARIES): $(TS_SOURCES) | check-qt-dir
 	mkdir -p bin/i18n
-	lrelease -removeidentical $(TS_FILE) -qm $@
+	$(QTDIR)/bin/lrelease -removeidentical $(TS_FILE) -qm $@
 
 compile-translations: $(QM_BINARIES)
 


### PR DESCRIPTION
Since there may be multiple QT versions installed, the compilation process should use the binaries from the given QTDIR, same as the rest of it.

In particular, this allows compiling on Fedora with the right devel packages installed (of which there are many).

### What does the PR do

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas

<!-- List the affected areas (e.g wallet, browser, etc..) -->

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

- [ ] I've checked the design and this PR matches it

<!-- screenshot (or gif/video) that demonstrates the functionality, specially important if it's a bug fix. -->

### Cool Spaceship Picture

<!-- optional but cool ->
