### PR TITLE
fix: prevent crash by ensuring there is active section on app start

### DIFF
--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -472,7 +472,7 @@ method load*[T](
 
   # Set active section on app start
   # If section is profile then open chat by default
-  if activeSection.sectionType == SectionType.ProfileSettings:
+  if activeSection.isEmpty() or activeSection.sectionType == SectionType.ProfileSettings:
     self.setActiveSection(self.view.model().getItemBySectionType(SectionType.Chat))
   else:
     self.setActiveSection(activeSection)


### PR DESCRIPTION
If `activeSectionId` does point to section that is not restored correctly (by any reason), then the app will crash. That's becasue code assumes there is always an active section set and it will try to reference null item in this case.

fixes: #8785

#### NOTE: 
The above happened because (most likely) joining a community that was removed previously does not restore it after app restart.

It should be cherry-picked to 0.8.x branch