### PR TITLE
Show identicon ring during onboarding

### DIFF
--- a/ui/imports/utils/Utils.qml
+++ b/ui/imports/utils/Utils.qml
@@ -511,37 +511,41 @@ QtObject {
     /* Validation section end */
 
     function getContactDetailsAsJson(publicKey, getVerificationRequest=true) {
-        let jsonObj = mainModuleInst.getContactDetailsAsJson(publicKey, getVerificationRequest)
+        const defaultValue = {
+            displayName: "",
+            displayIcon: "",
+            publicKey: publicKey,
+            name: "",
+            ensVerified: false,
+            alias: "",
+            lastUpdated: 0,
+            lastUpdatedLocally: 0,
+            localNickname: "",
+            thumbnailImage: "",
+            largeImage: "",
+            isContact: false,
+            isAdded: false,
+            isBlocked: false,
+            requestReceived: false,
+            isSyncing: false,
+            removed: false,
+            trustStatus: Constants.trustStatus.unknown,
+            verificationStatus: Constants.verificationStatus.unverified,
+            incomingVerificationStatus: Constants.verificationStatus.unverified
+        }
+
+        if (!mainModuleInst)
+            return defaultValue
+
+        const jsonObj = mainModuleInst.getContactDetailsAsJson(publicKey, getVerificationRequest)
+
         try {
-            let obj = JSON.parse(jsonObj)
-            return obj
+            return JSON.parse(jsonObj)
         }
         catch (e) {
             // This log is available only in debug mode, if it's annoying we can remove it
             console.warn("error parsing contact details for public key: ", publicKey, " error: ", e.message)
-
-            return {
-                displayName: "",
-                displayIcon: "",
-                publicKey: publicKey,
-                name: "",
-                ensVerified: false,
-                alias: "",
-                lastUpdated: 0,
-                lastUpdatedLocally: 0,
-                localNickname: "",
-                thumbnailImage: "",
-                largeImage: "",
-                isContact: false,
-                isAdded: false,
-                isBlocked: false,
-                requestReceived: false,
-                isSyncing: false,
-                removed: false,
-                trustStatus: Constants.trustStatus.unknown,
-                verificationStatus: Constants.verificationStatus.unverified,
-                incomingVerificationStatus: Constants.verificationStatus.unverified
-            }
+            return defaultValue
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/8551

### What does the PR do

The identicon ring wasn't show during onboarding.
This is because `getColorHashAsJson` uses `isEnsVerified`, which uses `Utils.getContactDetailsAsJson`. And the last one throws exception when `mainModuleInst` is not set. And it's not set during onboarding. 
Fixed that.

### Affected areas

Onboarding with new profile

### Screenshot of functionality (including design for comparison)

<img width="1512" alt="Снимок экрана 2022-12-14 в 23 54 49" src="https://user-images.githubusercontent.com/25482501/207713550-132569a5-4924-4d71-a0f0-3a513049a5cb.png">
<img width="1512" alt="Снимок экрана 2022-12-14 в 23 54 52" src="https://user-images.githubusercontent.com/25482501/207713571-6c568f33-8305-4a32-ac30-64ae8673aafa.png">
