### PR TITLE
fix(@desktop/notifications): sent contact request accepted notification fix

### DIFF
--- a/src/app/core/notifications/notifications_manager.nim
+++ b/src/app/core/notifications/notifications_manager.nim
@@ -83,6 +83,8 @@ QtObject:
       self, "onMyRequestToJoinCommunityRejected(QString, QString, QString)", 2)
     signalConnect(singletonInstance.globalEvents, "meMentionedIconBadgeNotification(int)",
       self, "onMeMentionedIconBadgeNotification(int)", 2)
+    signalConnect(singletonInstance.globalEvents, "showAcceptedContactRequest(QString, QString, QString)", 
+      self, "onShowAcceptedContactRequest(QString, QString, QString)", 2)
 
     self.notificationSetUp = true
 
@@ -141,6 +143,11 @@ QtObject:
   proc onShowNewContactRequestNotification*(self: NotificationsManager, title: string, message: string, 
     sectionId: string) {.slot.} =
     let details = NotificationDetails(notificationType: NotificationType.NewContactRequest, sectionId: sectionId)
+    self.processNotification(title, message, details)
+
+  proc onShowAcceptedContactRequest*(self: NotificationsManager, title: string, message: string, 
+    sectionId: string) {.slot.} =
+    let details = NotificationDetails(notificationType: NotificationType.AcceptedContactRequest, sectionId: sectionId)
     self.processNotification(title, message, details)
 
   proc onNewCommunityMembershipRequestNotification*(self: NotificationsManager, title: string, message: string, 
@@ -202,6 +209,7 @@ QtObject:
         data.message = "You have a new message"
       elif(self.settingsService.getNotificationMessagePreview() == PREVIEW_NAME_ONLY):
         data.message = "You have a new message"
+
       let identifier = $(details.toJsonNode())
       debug "Add OS notification", title=data.title, message=data.message, identifier=identifier
       self.showOSNotification(data.title, data.message, identifier)  

--- a/src/app/global/global_events.nim
+++ b/src/app/global/global_events.nim
@@ -31,4 +31,7 @@ QtObject:
   proc myRequestToJoinCommunityRejected*(self: GlobalEvents, title: string, message: string, 
     sectionId: string) {.signal.}
 
+  proc showAcceptedContactRequest*(self: GlobalEvents, title: string, message: string, 
+    sectionId: string) {.signal.}
+
   proc meMentionedIconBadgeNotification*(self: GlobalEvents, allMentions: int) {.signal.}

--- a/src/app_service/service/contacts/service.nim
+++ b/src/app_service/service/contacts/service.nim
@@ -168,8 +168,16 @@ QtObject:
         for c in receivedData.contacts:
           let localContact = self.getContactById(c.id)
           var receivedContact = c
+
           receivedContact.localNickname = localContact.localNickname
           self.saveContact(receivedContact)
+
+          # Check if the contact request was sent by us and if it was approved by the recipient
+          if localContact.added and not localContact.hasAddedUs and receivedContact.hasAddedUs:
+            singletonInstance.globalEvents.showAcceptedContactRequest(
+              "Contact request accepted",
+              fmt "{receivedContact.displayName} accepted your contact request",
+              receivedContact.id)
 
           let data = ContactArgs(contactId: c.id)
           self.events.emit(SIGNAL_CONTACT_UPDATED, data)


### PR DESCRIPTION
### What does the PR do

1. Block sending messages from us as notifications. This can happen when we send a contact request. After the recipient accepts a contact request, a chat is created and we receive our "send request" message as a new msg in the chat.
2. Notify the sender of the contact request about accepting the contact request by the recipient

Closed: #8488 #8381

### Affected areas

- Contact service
- Sending chat notifications

### Screenshot of functionality (including design for comparison)

https://user-images.githubusercontent.com/117639195/207837108-2fab49d1-67d0-4b72-8577-fd84b6b0b13b.mov


