### PR TITLE
feat(CommunitySettings): Implement UI for`edit`, `duplicate` and `remove` actions in community permissions page

### DIFF
--- a/storybook/pages/CommunityPermissionsSettingsPanelPage.qml
+++ b/storybook/pages/CommunityPermissionsSettingsPanelPage.qml
@@ -29,7 +29,7 @@ SplitView {
                     collectiblesModel: CollectiblesModel {}
                     channelsModel: ChannelsModel {}
 
-                    function editPermission(index) {
+                    function editPermission(index, holdings, permissions, channels, isPrivate) {
                         logs.logEvent("CommunitiesStore::editPermission - index: " + index)
                     }
 

--- a/storybook/pages/CommunityPermissionsViewPage.qml
+++ b/storybook/pages/CommunityPermissionsViewPage.qml
@@ -27,18 +27,13 @@ SplitView {
                 store: CommunitiesStore {
                     permissionsModel: PermissionsModel { id: mockedModel }
 
-                    function editPermission(index) {
-                        logs.logEvent("CommunitiesStore::editPermission - index: " + index)
-                    }
-
                     function duplicatePermission(index) {
                         logs.logEvent("CommunitiesStore::duplicatePermission - index: " + index)
                     }
-
-                    function removePermission(index) {
-                        logs.logEvent("CommunitiesStore::removePermission - index: " + index)
-                    }
                 }
+                onEditPermission: logs.logEvent("CommunitiesStore::editPermission - index: " + index)
+                onRemovePermission: logs.logEvent("CommunitiesStore::removePermission - index: " + index)
+
             }
         }
 

--- a/ui/app/AppLayouts/Chat/controls/community/PermissionItem.qml
+++ b/ui/app/AppLayouts/Chat/controls/community/PermissionItem.qml
@@ -235,7 +235,7 @@ Control{
                 }
                 StatusBaseText {
                     Layout.alignment: Qt.AlignHCenter
-                    text: qsTr("Remove")
+                    text: qsTr("Delete")
                     color: Theme.palette.dangerColor1
                     font.pixelSize: d.buttonTextPixelSize
                 }

--- a/ui/app/AppLayouts/Chat/layouts/SettingsPageLayout.qml
+++ b/ui/app/AppLayouts/Chat/layouts/SettingsPageLayout.qml
@@ -23,6 +23,7 @@ Item {
     property string headerButtonText: ""
     property int headerWidth: 0
     property string previousPageName: ""
+    property bool saveChangesButtonEnabled: !!root.contentItem && !!root.contentItem.saveChangesButtonEnabled
 
     readonly property Item contentItem: contentLoader.item
     readonly property size settingsDirtyToastMessageImplicitSize: 
@@ -96,7 +97,7 @@ Item {
         }
         active: root.dirty
         flickable: root.dirty ? root.contentItem : null
-        saveChangesButtonEnabled: !!root.contentItem && !!root.contentItem.saveChangesButtonEnabled
+        saveChangesButtonEnabled: root.saveChangesButtonEnabled
         onResetChangesClicked: root.resetChangesClicked()
         onSaveChangesClicked: root.saveChangesClicked()
     }

--- a/ui/app/AppLayouts/Chat/stores/CommunitiesStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/CommunitiesStore.qml
@@ -84,9 +84,8 @@ QtObject {
         ListElement { key: "general"; iconSource: "qrc:imports/assets/png/tokens/CUSTOM-TOKEN.png"; name: "#general"}
     }
 
-    function createPermissions(holdings, permissions, isPrivate) {
-        console.log("TODO: Create permissions - backend call - Now dummy data shown")
-        // TO BE REMOVED: It shold just be a call to the backend sharing `holdings`, `permissions`, `channels` and `isPrivate` properties.
+    function createPermission(holdings, permissions, isPrivate, channels, index = null) {
+        // TO BE REPLACED: It shold just be a call to the backend sharing `holdings`, `permissions`, `channels` and `isPrivate` properties.
         var permission = {
             isPrivate: true,
             holdingsListModel: [],
@@ -123,8 +122,16 @@ QtObject {
         // TODO: Set channels list. Now mocked data.
         permission.channelsListModel = root.channelsModel
 
-        // Add into permission model:
-        root.permissionsModel.append(permission)
+        if(index !== null) {
+            // Edit permission model:
+            console.log("TODO: Edit permissions - backend call")
+            root.permissionsModel.set(index, permission)
+        }
+        else {
+            // Add into permission model:
+            console.log("TODO: Create permissions - backend call - Now dummy data shown")
+            root.permissionsModel.append(permission)
+        }
     }
 
     function setHoldingsTextFormat(type, name, amount) {
@@ -142,15 +149,20 @@ QtObject {
         }
     }
 
-    function editPermission(index) {
-        console.log("TODO: Edit permissions - backend call")
+    function editPermission(index, holdings, permissions, channels, isPrivate) {
+        // TO BE REPLACED: Call to backend
+        createPermission(holdings, permissions, isPrivate, channels, index)
     }
 
     function duplicatePermission(index) {
+        // TO BE REPLACED: Call to backend
         console.log("TODO: Duplicate permissions - backend call")
+        const permission = root.permissionsModel.get(index)
+        createPermission(permission.holdingsListModel, permission.permissionsObjectModel, permission.isPrivate, permission.channelsListModel)
     }
 
     function removePermission(index) {
         console.log("TODO: Remove permissions - backend call")
+        root.permissionsModel.remove(index)
     }
 }

--- a/ui/app/AppLayouts/Chat/views/communities/CommunityPermissionsView.qml
+++ b/ui/app/AppLayouts/Chat/views/communities/CommunityPermissionsView.qml
@@ -7,6 +7,7 @@ import StatusQ.Controls 0.1
 
 import SortFilterProxyModel 0.2
 import utils 1.0
+import shared.popups 1.0
 
 import AppLayouts.Chat.controls.community 1.0
 
@@ -16,8 +17,21 @@ StatusScrollView {
     property var store
     property int viewWidth: 560 // by design
 
+    signal editPermission(int index, var holidings, var permission, var channels, bool isPrivate)
+    signal removePermission(int index)
+
+    QtObject {
+        id: d
+        property int permissionIndexToRemove
+    }
+
     contentWidth: mainLayout.width
     contentHeight: mainLayout.height + mainLayout.anchors.topMargin
+
+    onRemovePermission: {
+        d.permissionIndexToRemove = index
+        Global.openPopup(deletePopup)
+    }
 
     ColumnLayout {
         id: mainLayout
@@ -54,10 +68,24 @@ StatusScrollView {
                 }
                 isPrivate: model.isPrivate
 
-                onEditClicked: store.editPermission(model.index)
+                onEditClicked: root.editPermission(model.index, model.holdingsListModel, model.permissionsObjectModel, model.channelsListModel, model.isPrivate)
                 onDuplicateClicked: store.duplicatePermission(model.index)
-                onRemoveClicked: store.removePermission(model.index)
+                onRemoveClicked: root.removePermission(model.index)
             }
         }
     }
+
+    Component {
+        id: deletePopup
+        ConfirmationDialog {
+            id: declineAllDialog
+            header.title: qsTr("Sure you want to delete permission")
+            confirmationText: qsTr("If you delete this permission, any of your community members who rely on this permission will loose the access this permission gives them.")
+            onConfirmButtonClicked: {
+                store.removePermission(d.permissionIndexToRemove)
+                close()
+            }
+        }
+    }
+
 }


### PR DESCRIPTION
Closes [#8581](https://github.com/status-im/status-desktop/issues/8581)

### What does the PR do

- Enabled `duplicate` action (mocked).
- Enabled `delete` action (mocked) and added / updated navigations in case all permissions are removed. Added delete confirmation popup.
- Enabled `edit` action (mocked) where changes are detected and the `dirty changes toast` appears properly.

**COMMENTS:**

- All is mocked data!!!
- Edit / dirty changes managements first step done in js. Here a new task to improve it by creating a new C++ object type: https://github.com/status-im/status-desktop/issues/8830

### Affected areas

Community permissions

### Screenshot of functionality (including design for comparison)

https://user-images.githubusercontent.com/97019400/207913637-3b13f638-e274-4382-a3a1-de24b6fc8257.mov