### PR TITLE
fix(chat-input): Colon detection for foreign keyboard layout

### DIFF
--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -437,7 +437,7 @@ Rectangle {
             return emojiSuggestions.listView.decrementCurrentIndex()
         }
 
-        isColonPressed = (event.key === Qt.Key_Colon) && (event.modifiers & Qt.ShiftModifier);
+        isColonPressed = event.key === Qt.Key_Colon;
 
         if (suggestionsBox.visible) {
             let aliasName = suggestionsBox.formattedPlainTextFilter;


### PR DESCRIPTION
### What does the PR do

Fix https://github.com/status-im/status-desktop/issues/8822
On foreign layouts where Shift isn't needed for `:`, emoji completion is a bit broken
(example azerty layout)

### Affected areas

chat-input

### Screenshot of fix
This branch with AZERTY:
![Peek 2022-12-15 19-23](https://user-images.githubusercontent.com/13471753/207938109-3a740291-fd16-41df-a658-bb10a26dd923.gif)

Master:
![Peek 2022-12-15 16-08](https://user-images.githubusercontent.com/13471753/207895838-cc305954-5e96-48a8-988e-2c6ed40700df.gif)

### Cool Spaceship Picture

![image](https://user-images.githubusercontent.com/13471753/207938303-13606e9c-15e4-4103-88a7-82de018f3266.png)
