### PR TITLE
fix: scrolling speed and inertia

### DIFF
--- a/ui/StatusQ/src/StatusQ/Core/StatusGridView.qml
+++ b/ui/StatusQ/src/StatusQ/Core/StatusGridView.qml
@@ -33,6 +33,7 @@ GridView {
 
     clip: true
     boundsBehavior: Flickable.StopAtBounds
-    maximumFlickVelocity: 2000
+    maximumFlickVelocity: 1000000
+    flickDeceleration: 1000000
     synchronousDrag: true
 }

--- a/ui/StatusQ/src/StatusQ/Core/StatusListView.qml
+++ b/ui/StatusQ/src/StatusQ/Core/StatusListView.qml
@@ -38,7 +38,8 @@ ListView {
 
     clip: true
     boundsBehavior: Flickable.StopAtBounds
-    maximumFlickVelocity: 2000
+    maximumFlickVelocity: 1000000
+    flickDeceleration: 1000000
     synchronousDrag: true
 
     ScrollBar.horizontal: StatusScrollBar {

--- a/ui/StatusQ/src/StatusQ/Core/StatusScrollView.qml
+++ b/ui/StatusQ/src/StatusQ/Core/StatusScrollView.qml
@@ -52,7 +52,8 @@ Flickable {
     implicitWidth: contentWidth + leftPadding + rightPadding
     implicitHeight: contentHeight + topPadding + bottomPadding
     boundsBehavior: Flickable.StopAtBounds
-    maximumFlickVelocity: 2000
+    maximumFlickVelocity: 1000000
+    flickDeceleration: 1000000
     synchronousDrag: true
 
     ScrollBar.horizontal: StatusScrollBar {


### PR DESCRIPTION
### What does the PR do

This PR practically uncap the scrolling speed, and makes it very sticky.
This fixes #8646 on my setup

### Affected areas

Every Flickable thing I found

### Screenshot of fix

Quickly scrolling and stopping through the channel list, after this PR, nice and snappy:
![Peek 2022-12-16 10-55](https://user-images.githubusercontent.com/13471753/208072715-c5f42c95-238c-47e8-a4c9-74fe86938421.gif)

Before this PR, sluggish and slow:
![Peek 2022-12-16 10-57](https://user-images.githubusercontent.com/13471753/208073079-0f45493f-a789-432a-9f2c-f023c606bee4.gif)


### Cool Spaceship Picture
Since
![image](https://user-images.githubusercontent.com/13471753/207938303-13606e9c-15e4-4103-88a7-82de018f3266.png)
Please, test this on your setup to see if it causes any issues, and double check that I'm not doing anything stupid :)