### PR TITLE
fix(chat/groups): do not propagate empty members sequence

### DIFF
--- a/src/app/modules/main/chat_section/chat_content/users/view.nim
+++ b/src/app/modules/main/chat_section/chat_content/users/view.nim
@@ -77,5 +77,7 @@ QtObject:
     let temporaryModelIDs = self.temporaryModel.getItemIds()
     let membersAdded = filter(temporaryModelIDs, id => not modelIDs.contains(id))
     let membersRemoved = filter(modelIDs, id => not temporaryModelIDs.contains(id))
-    self.delegate.addGroupMembers(membersAdded)
-    self.delegate.removeGroupMembers(membersRemoved)
+    if (membersAdded.len > 0):
+      self.delegate.addGroupMembers(membersAdded)
+    if (membersRemoved.len > 0):
+      self.delegate.removeGroupMembers(membersRemoved)


### PR DESCRIPTION
fixes: #8832

![image](https://user-images.githubusercontent.com/33099791/208094284-6ad71960-ed32-4e6b-b0c8-179894569db5.png)


### Affected areas
group chat members addition/removal