### PR TITLE
chore: remove unused `loadingHistoryMessagesInProgress` property

### DIFF
--- a/src/app/modules/main/chat_section/chat_content/messages/view.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/view.nim
@@ -10,7 +10,6 @@ QtObject:
       model: Model
       modelVariant: QVariant
       initialMessagesLoaded: bool
-      loadingHistoryMessagesInProgress: bool
       messageSearchOngoing: bool
 
   proc delete*(self: View) =
@@ -110,21 +109,6 @@ QtObject:
       return
     self.initialMessagesLoaded = true
     self.initialMessagesLoadedChanged()
-
-  proc loadingHistoryMessagesInProgressChanged*(self: View) {.signal.}
-
-  proc getLoadingHistoryMessagesInProgress*(self: View): bool {.slot.} =
-    return self.loadingHistoryMessagesInProgress
-
-  QtProperty[bool] loadingHistoryMessagesInProgress:
-    read = getLoadingHistoryMessagesInProgress
-    notify = loadingHistoryMessagesInProgressChanged
-
-  proc setLoadingHistoryMessagesInProgress*(self: View, value: bool) = # this is not a slot
-    if (value == self.loadingHistoryMessagesInProgress):
-      return
-    self.loadingHistoryMessagesInProgress = value
-    self.loadingHistoryMessagesInProgressChanged()
 
   proc loadMoreMessages*(self: View) {.slot.} =
     self.delegate.loadMoreMessages()

--- a/src/app/modules/main/chat_section/controller.nim
+++ b/src/app/modules/main/chat_section/controller.nim
@@ -233,14 +233,11 @@ proc init*(self: Controller) =
     let args = ContactsStatusUpdatedArgs(e)
     self.delegate.contactsStatusUpdated(args.statusUpdates)
 
-  self.events.on(SignalType.HistoryRequestStarted.event) do(e: Args):
+  self.events.on(SIGNAL_MAILSERVER_HISTORY_REQUEST_STARTED) do(e: Args):
     self.delegate.setLoadingHistoryMessagesInProgress(true)
 
-  self.events.on(SignalType.HistoryRequestCompleted.event) do(e:Args):
+  self.events.on(SIGNAL_MAILSERVER_HISTORY_REQUEST_COMPLETED) do(e:Args):
     self.delegate.setLoadingHistoryMessagesInProgress(false)
-
-  self.events.on(SignalType.HistoryRequestFailed.event) do(e:Args):
-    discard
 
 proc getMySectionId*(self: Controller): string =
   return self.sectionId

--- a/src/app_service/service/mailservers/service.nim
+++ b/src/app_service/service/mailservers/service.nim
@@ -42,6 +42,8 @@ const SIGNAL_ACTIVE_MAILSERVER_CHANGED* = "activeMailserverChanged"
 const SIGNAL_MAILSERVER_AVAILABLE* = "mailserverAvailable"
 const SIGNAL_MAILSERVER_NOT_WORKING* = "mailserverNotWorking"
 const SIGNAL_MAILSERVER_SYNCED* = "mailserverSynced"
+const SIGNAL_MAILSERVER_HISTORY_REQUEST_STARTED* = "historyRequestStarted"
+const SIGNAL_MAILSERVER_HISTORY_REQUEST_COMPLETED* = "historyRequestCompleted"
 
 const requestMoreMessagesTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[RequestMoreMessagesTaskArg](argEncoded)
@@ -171,10 +173,12 @@ QtObject:
     self.events.on(SignalType.HistoryRequestStarted.event) do(e: Args):
       let h = HistoryRequestStartedSignal(e)
       info "history request started", numBatches=h.numBatches
+      self.events.emit(SIGNAL_MAILSERVER_HISTORY_REQUEST_STARTED, Args())
 
     self.events.on(SignalType.HistoryRequestCompleted.event) do(e: Args):
       let h = HistoryRequestCompletedSignal(e)
       info "history request completed"
+      self.events.emit(SIGNAL_MAILSERVER_HISTORY_REQUEST_COMPLETED, Args())
 
     self.events.on(SignalType.HistoryRequestFailed.event) do(e: Args):
       let h = HistoryRequestFailedSignal(e)


### PR DESCRIPTION
`loadingHistoryMessagesInProgress` was moved to content module but the property was never removed from the messages module view

see: fc24f16525e6f71b3a00848b4efd94543753ac0b