### PR TITLE
fix:(@desktop/keystone): Request saving password to keystone on a startup after changing the password through settings

### DIFF
--- a/src/app/boot/app_controller.nim
+++ b/src/app/boot/app_controller.nim
@@ -300,8 +300,7 @@ proc startupDidLoad*(self: AppController) =
 
 proc mainDidLoad*(self: AppController) =
   self.startupModule.moveToAppState()
-
-  self.mainModule.checkForStoringPassword()
+  self.startupModule.checkForStoringPasswordToKeychain()
 
 proc start*(self: AppController) =
   self.keycardService.init()

--- a/src/app/modules/main/controller.nim
+++ b/src/app/modules/main/controller.nim
@@ -299,22 +299,6 @@ proc isConnected*(self: Controller): bool =
 proc getChannelGroups*(self: Controller): seq[ChannelGroupDto] =
   return self.chatService.getChannelGroups()
 
-proc checkForStoringPassword*(self: Controller) =
-  # This proc is called once user is logged in irrespective he is logged in
-  # through the onboarding or login view.
-
-  # This is MacOS only feature
-  if(not defined(macosx)):
-    return
-
-  let value = singletonInstance.localAccountSettings.getStoreToKeychainValue()
-  if (value == LS_VALUE_STORE or value == LS_VALUE_NEVER):
-    return
-
-  # We are here if stored "storeToKeychain" property for the logged in user
-  # is either empty or set to "NotNow".
-  self.delegate.offerToStorePassword()
-
 proc storePassword*(self: Controller, password: string) =
   let account = self.accountsService.getLoggedInAccount()
 

--- a/src/app/modules/main/io_interface.nim
+++ b/src/app/modules/main/io_interface.nim
@@ -35,9 +35,6 @@ method load*(
   {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method checkForStoringPassword*(self: AccessInterface) {.base.} =
-  raise newException(ValueError, "No implementation available")
-
 method calculateProfileSectionHasNotification*(self: AccessInterface): bool {.base.} =
   raise newException(ValueError, "No implementation available")
 
@@ -82,9 +79,6 @@ method getActiveSectionId*(self: AccessInterface): string {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method communitiesModuleDidLoad*(self: AccessInterface) {.base.} =
-  raise newException(ValueError, "No implementation available")
-
-method offerToStorePassword*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method emitStoringPasswordError*(self: AccessInterface, errorDescription: string) {.base.} =

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -557,12 +557,6 @@ method networksModuleDidLoad*[T](self: Module[T]) =
 method viewDidLoad*[T](self: Module[T]) =
   self.checkIfModuleDidLoad()
 
-method checkForStoringPassword*[T](self: Module[T]) =
-  self.controller.checkForStoringPassword()
-
-method offerToStorePassword*[T](self: Module[T]) =
-  self.view.offerToStorePassword()
-
 method storePassword*[T](self: Module[T], password: string) =
   self.controller.storePassword(password)
 

--- a/src/app/modules/main/view.nim
+++ b/src/app/modules/main/view.nim
@@ -110,9 +110,6 @@ QtObject:
 
   proc openStoreToKeychainPopup*(self: View) {.signal.}
 
-  proc offerToStorePassword*(self: View) =
-    self.openStoreToKeychainPopup()
-
   proc storePassword*(self: View, password: string) {.slot.} =
     self.delegate.storePassword(password)
 

--- a/src/app/modules/startup/controller.nim
+++ b/src/app/modules/startup/controller.nim
@@ -468,3 +468,19 @@ proc storeMetadataForNewKeycardUser(self: Controller) =
   ## Stores metadata, default Status account only, to the keycard for a newly created keycard user.
   let paths = @[account_constants.PATH_DEFAULT_WALLET]
   self.runStoreMetadataFlow(self.getDisplayName(), self.getPin(), paths)
+
+proc checkForStoringPasswordToKeychain*(self: Controller) =
+  # This proc is called once user is logged in irrespective he is logged in
+  # through the onboarding or login view. 
+  # This is MacOS only feature
+  if not defined(macosx):
+    return
+
+  let value = singletonInstance.localAccountSettings.getStoreToKeychainValue()
+  if (value == LS_VALUE_STORE or value == LS_VALUE_NEVER):
+    return
+
+  # We are here if stored "storeToKeychain" property for the logged in user
+  # is either empty or set to "NotNow".
+  singletonInstance.localAccountSettings.setStoreToKeychainValue(LS_VALUE_STORE)
+  self.storePasswordToKeychain()

--- a/src/app/modules/startup/io_interface.nim
+++ b/src/app/modules/startup/io_interface.nim
@@ -142,6 +142,9 @@ method runFactoryResetPopup*(self: AccessInterface) {.base.} =
 method storeKeyPairForNewKeycardUser*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method checkForStoringPasswordToKeychain*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 # This way (using concepts) is used only for the modules managed by AppController
 type
   DelegateInterface* = concept c

--- a/src/app/modules/startup/module.nim
+++ b/src/app/modules/startup/module.nim
@@ -371,3 +371,6 @@ method onSharedKeycarModuleFlowTerminated*[T](self: Module[T], lastStepInTheCurr
 
 method storeKeyPairForNewKeycardUser*[T](self: Module[T]) =
   self.delegate.storeKeyPairForNewKeycardUser()
+
+method checkForStoringPasswordToKeychain*[T](self: Module[T]) =
+  self.controller.checkForStoringPasswordToKeychain()

--- a/ui/app/AppLayouts/Profile/popups/ChangePasswordModal.qml
+++ b/ui/app/AppLayouts/Profile/popups/ChangePasswordModal.qml
@@ -24,9 +24,8 @@ StatusModal {
 
     function onChangePasswordResponse(success, errorMsg) {
         if (success) {
-            if (Qt.platform.os === "osx" && localAccountSettings.storeToKeychainValue !== Constants.storeToKeychainValueNever) {
-                localAccountSettings.storeToKeychainValue = Constants.keychain.storedValue.store;
-                root.privacyStore.storeToKeyChain(d.passwordProcessing);
+            if (Qt.platform.os === "osx" && localAccountSettings.storeToKeychainValue !== Constants.keychain.storedValue.never) {
+                localAccountSettings.storeToKeychainValue = Constants.keychain.storedValue.notNow;
             }
             passwordChanged()
         }
@@ -86,7 +85,7 @@ StatusModal {
         StatusButton {
             id: submitBtn
             objectName: "changePasswordModalSubmitButton"
-            text: qsTr("Change Password")
+            text: qsTr("Change password and restart Status")
             enabled: !submitBtn.loading && view.ready
 
             property Timer sim: Timer {

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -686,10 +686,6 @@ QtObject {
     readonly property string ens_connected: "connected"
     readonly property string ens_connected_dkey: "connected-different-key"
 
-    readonly property string storeToKeychainValueStore: "store"
-    readonly property string storeToKeychainValueNotNow: "notNow"
-    readonly property string storeToKeychainValueNever: "never"
-
     // WARNING: Remove later. Moved to StatusQ.
     readonly property string editLabel: ` <span class="isEdited">` + qsTr("(edited)") + `</span>`
 


### PR DESCRIPTION
### What does the PR do

1. If the user has biometrics enabled and changes the password, we need to let the user enter a current password, check it and if it's valid we need to store it to the keychain and update the `storeToKeychain` prop to `store`
2. Button rename

Fixes: #7349

### Affected areas

- changing the password
- login via biometrics

### Screenshot of functionality (including design for comparison)

https://user-images.githubusercontent.com/117639195/208120591-91918053-5252-4982-a311-91582bbb8485.mov
