### PR TITLE
feat(communities): Process ban state for community

### DIFF
--- a/src/app/modules/shared_models/active_section.nim
+++ b/src/app/modules/shared_models/active_section.nim
@@ -197,6 +197,13 @@ QtObject:
     read = bannedMembers
     notify = bannedMembersChanged
 
+  proc amIBanned(self: ActiveSection): bool {.slot.} =
+    return self.item.amIBanned
+
+  QtProperty[bool] amIBanned:
+    read = amIBanned
+    notify = bannedMembersChanged
+
   proc pendingMemberRequests(self: ActiveSection): QVariant {.slot.} =
     if (self.item.id == ""):
       # FIXME (Jo) I don't know why but the Item is sometimes empty and doing anything here crashes the app

--- a/src/app/modules/shared_models/section_item.nim
+++ b/src/app/modules/shared_models/section_item.nim
@@ -1,6 +1,7 @@
 import strformat
 import ./member_model, ./member_item
 import ../main/communities/models/[pending_request_item, pending_request_model]
+import ../../global/global_singleton
 
 import ../../../app_service/common/types
 
@@ -279,6 +280,9 @@ proc updateMember*(
 
 proc bannedMembers*(self: SectionItem): member_model.Model {.inline.} =
   self.bannedMembersModel
+
+proc amIBanned*(self: SectionItem): bool {.inline.} =
+  self.bannedMembersModel.isContactWithIdAdded(singletonInstance.userProfile.getPubKey())
 
 proc pendingMemberRequests*(self: SectionItem): member_model.Model {.inline.} =
   self.pendingMemberRequestsModel

--- a/src/app/modules/shared_models/section_model.nim
+++ b/src/app/modules/shared_models/section_model.nim
@@ -239,23 +239,7 @@ QtObject:
 
     self.items[index].muted = muted 
     let dataIndex = self.createIndex(index, 0, nil)
-    self.dataChanged(dataIndex, dataIndex, @[
-      ModelRole.Name.int,
-      ModelRole.Description.int,
-      ModelRole.Image.int,
-      ModelRole.Icon.int,
-      ModelRole.Color.int,
-      ModelRole.HasNotification.int,
-      ModelRole.NotificationsCount.int,
-      ModelRole.IsMember.int,
-      ModelRole.CanJoin.int,
-      ModelRole.Joined.int,
-      ModelRole.Muted.int, 
-      ModelRole.MembersModel.int,
-      ModelRole.PendingRequestsToJoinModel.int,
-      ModelRole.HistoryArchiveSupportEnabled.int,
-      ModelRole.BannedMembersModel.int
-      ])
+    self.dataChanged(dataIndex, dataIndex, @[ModelRole.Muted.int])
 
 
   proc editItem*(self: SectionModel, item: SectionItem) =
@@ -405,6 +389,7 @@ QtObject:
           "canManageUsers": item.canManageUsers,
           "canRequestAccess": item.canRequestAccess,
           "isMember": item.isMember,
+          "amIBanned": item.amIBanned,
           "access": item.access,
           "ensOnly": item.ensOnly,
           "nbMembers": item.members.getCount(),

--- a/ui/app/AppLayouts/Chat/views/ChatContentView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatContentView.qml
@@ -179,7 +179,7 @@ ColumnLayout {
                 anchors.fill: parent
                 anchors.margins: Style.current.smallPadding
 
-                enabled: root.activeSectionData.joined
+                enabled: root.activeSectionData.joined && !root.activeSectionData.amIBanned
 
                 store: root.rootStore
                 usersStore: root.usersStore
@@ -199,7 +199,7 @@ ColumnLayout {
                 }
 
                 Binding on chatInputPlaceholder {
-                    when: !root.activeSectionData.joined
+                    when: !root.activeSectionData.joined || root.activeSectionData.amIBanned
                     value: qsTr("You need to join this community to send messages")
                 }
 

--- a/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
@@ -51,7 +51,7 @@ Item {
 
         readonly property real scrollY: chatLogView.visibleArea.yPosition * chatLogView.contentHeight
         readonly property bool isMostRecentMessageInViewport: chatLogView.visibleArea.yPosition >= 0.999 - chatLogView.visibleArea.heightRatio
-        readonly property var chatDetails: chatContentModule.chatDetails
+        readonly property var chatDetails: chatContentModule.chatDetails || null
 
         function markAllMessagesReadIfMostRecentMessageIsInViewport() {
             if (!isMostRecentMessageInViewport) {

--- a/ui/app/AppLayouts/Chat/views/CommunityColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/CommunityColumnView.qml
@@ -106,11 +106,14 @@ Item {
         anchors.topMargin: 8
         anchors.bottomMargin: Style.current.halfPadding
         anchors.horizontalCenter: parent.horizontalCenter
+        enabled: !root.communityData.amIBanned
 
-        visible: !communityData.joined
+        visible: !communityData.joined || root.communityData.amIBanned
 
         text: {
+            if (root.communityData.amIBanned) return qsTr("You were banned from community")
             if (invitationPending) return qsTr("Membership request pending...")
+
             return root.communityData.access === Constants.communityChatOnRequestAccess ?
                     qsTr("Request to join") : qsTr("Join Community")
         }

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -1375,8 +1375,9 @@ Item {
     Connections {
         target: appMain.rootStore.mainModuleInst
         function onActiveSectionChanged() {
-            if (!!appMain.rootStore.mainModuleInst.getCommunitySectionModule())
-                rootDropAreaPanel.activeChatType = appMain.rootStore.mainModuleInst.getCommunitySectionModule().activeItem.type
+            let communitySectionModule = appMain.rootStore.mainModuleInst.getCommunitySectionModule()
+            if (communitySectionModule)
+                rootDropAreaPanel.activeChatType = communitySectionModule.activeItem.type
         }
     }
 


### PR DESCRIPTION
Fixes: #8761

### What does the PR do

Add ban community state. Also fix some warnings.

### Affected areas

Communities 

### Screenshot of functionality (including design for comparison)

- [ ] I've checked the design and this PR matches it

<img width="1385" alt="Снимок экрана 2022-12-18 в 23 21 13" src="https://user-images.githubusercontent.com/82511785/208317993-c994ace6-baab-424b-8e3d-484589b72736.png">

