### PR TITLE
Fix Mentions in statusChatInput - don't allow unintended mention invalidation

### DIFF
--- a/storybook/pages/StatusChatInputPage.qml
+++ b/storybook/pages/StatusChatInputPage.qml
@@ -12,6 +12,8 @@ import shared.stores 1.0
 SplitView {
     id: root
 
+    Logs { id: logs }
+
     QtObject {
         id: globalUtilsMock
 
@@ -90,7 +92,21 @@ SplitView {
                 usersStore: QtObject {
                     readonly property var usersModel: fakeUsersModel
                 }
+                onSendMessage: {
+                    logs.logEvent("StatusChatInput::sendMessage", ["MessageWithPk"], [chatInput.getTextWithPublicKeys()])
+                    logs.logEvent("StatusChatInput::sendMessage", ["PlainText"], [globalUtilsMock.globalUtils.plainText(chatInput.getTextWithPublicKeys())])
+                    logs.logEvent("StatusChatInput::sendMessage", ["RawText"], [chatInput.textInput.text])
+                }
             }
+        }
+
+        LogsAndControlsPanel {
+            id: logsAndControlsPanel
+
+            SplitView.minimumHeight: 100
+            SplitView.preferredHeight: 200
+
+            logsView.logText: logs.logText
         }
     }
 


### PR DESCRIPTION
### What does the PR do

Fixes #8740, #8742, #8731, #7686
1. Don't allow mention invalidation by altering mention with mouse or keyboard
3. Don't allow mention duplication on the same position in mentionsPos
4. Clean mentions after text with mentions changes
5. Fix mention selection
6. Make sure mention is separated by text with valid separators (by default we're using only space)
7. Cursor will consider the mention as an object and will jump over it as it would be a single character (placing cursor inside leaves room for mention invalidation)

### Affected areas

StatusChatInput.qml
tst_statusChatInput.qml
StatusChatInputPage.qml

### Screenshot of functionality (including design for comparison)


https://user-images.githubusercontent.com/47811206/208405944-adc76aeb-9615-47a1-aff4-0b4861f3d85f.mov


