### PR TITLE
Fix/8466/messages not in order

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ BUILD_SYSTEM_DIR := vendor/nimbus-build-system
 	run-linux \
 	run-macos \
 	run-windows \
+	tests-nim-linux \
 	status-go \
 	status-keycard-go \
 	statusq-sanity-checker \
@@ -641,6 +642,10 @@ run-windows: nim_status_client $(NIM_WINDOWS_PREBUILT_DLLS)
 	echo -e "\e[92mRunning:\e[39m bin/nim_status_client.exe"
 	PATH="$(shell pwd)"/"$(shell dirname "$(DOTHERSIDE)")":"$(STATUSGO_LIBDIR)":"$(STATUSKEYCARDGO_LIBDIR)":"$(shell pwd)"/"$(shell dirname "$(NIM_WINDOWS_PREBUILT_DLLS)")":"$(PATH)" \
 	./bin/nim_status_client.exe
+
+tests-nim-linux: | check-qt-dir
+	LD_LIBRARY_PATH="$(QT5_LIBDIR)" \
+	$(ENV_SCRIPT) nim c $(NIM_PARAMS) $(NIM_EXTRA_PARAMS) -r test/nim/message_model_test.nim
 
 statusq-sanity-checker:
 	cmake -Bui/StatusQ/build -Sui/StatusQ && cmake --build ui/StatusQ/build --target SanityChecker

--- a/ci/Jenkinsfile.tests-nim
+++ b/ci/Jenkinsfile.tests-nim
@@ -1,0 +1,62 @@
+library 'status-jenkins-lib@v1.6.3'
+
+/* Options section can't access functions in objects. */
+def isPRBuild = utils.isPRBuild()
+
+pipeline {
+  agent { label 'linux' }
+
+  parameters {
+    choice(
+      name: 'VERBOSE',
+      description: 'Level of verbosity based on nimbus-build-system setup.',
+      choices: ['0', '1', '2']
+    )
+  }
+  
+  options {
+    timestamps()
+    /* Prevent Jenkins jobs from running forever */
+    timeout(time: 20, unit: 'MINUTES')
+    /* manage how many builds we keep */
+    buildDiscarder(logRotator(
+      numToKeepStr: '10',
+      daysToKeepStr: '30',
+      artifactNumToKeepStr: '3',
+    ))
+    /* Abort old PR builds. */
+    disableConcurrentBuilds(
+      abortPrevious: isPRBuild
+    )
+  }
+
+  environment {
+    TARGET = 'tests-nim'
+    /* Improve make performance */
+    MAKEFLAGS = "-j4 V=${params.VERBOSE}"
+    /* Disable colors in Nim compiler logs */
+    NIMFLAGS = '--colors:off'
+    /* Makefile assumes the compiler folder is included */
+    QTDIR = "/opt/qt/5.14.2/gcc_64"
+    /* Include library in order to compile the project */
+    LD_LIBRARY_PATH = "$QTDIR/lib"
+  }
+
+  stages {
+    stage('Check') {
+      steps { sh 'make tests-nim-linux' }
+    }
+
+    stage('Upload') {
+      steps { script {
+        env.PKG_URL = "${currentBuild.absoluteUrl}/consoleText"
+      } }
+    }
+  }
+
+  post {
+    success { script { github.notifyPR(true) } }
+    failure { script { github.notifyPR(false) } }
+    cleanup { cleanWs() }
+  }
+}

--- a/src/app_service/service/message/service.nim
+++ b/src/app_service/service/message/service.nim
@@ -424,12 +424,8 @@ QtObject:
     if(self.initialMessagesFetched(chatId)):
       return
 
-    if(self.getMessageCursor(chatId).getValue().len > 0):
-      return
-
     # we're here if initial messages are not loaded yet
     self.asyncLoadMoreMessagesForChat(chatId)
-
 
   proc addReaction*(self: Service, chatId: string, messageId: string, emojiId: int) =
     try:

--- a/test/nim/message_model_test.nim
+++ b/test/nim/message_model_test.nim
@@ -1,0 +1,148 @@
+import unittest
+
+import ../../../src/app_service/common/types
+import ../../../src/app_service/service/contacts/dto/contacts
+import ../../../src/app_service/service/message/dto/message
+
+import ../../../src/app/modules/shared_models/message_model
+import ../../../src/app/modules/shared_models/message_item
+import ../../../src/app/modules/shared_models/message_transaction_parameters_item
+
+proc createTestMessageItem(id: string, clock: int64): Item =
+  return initItem(
+    id = id,
+    communityId = "",
+    responseToMessageWithId = "",
+    senderId = "",
+    senderDisplayName = "",
+    senderOptionalName = "",
+    senderIcon = "",
+    amISender = false,
+    senderIsAdded = false,
+    outgoingStatus = "",
+    text = "",
+    image = "",
+    messageContainsMentions = false,
+    seen = true,
+    timestamp = 0,
+    clock = clock,
+    ContentType.NewMessagesMarker,
+    messageType = -1,
+    contactRequestState = 0,
+    sticker = "",
+    stickerPack = -1,
+    links = @[],
+    transactionParameters = newTransactionParametersItem("","","","","","",-1,""),
+    mentionedUsersPks = @[],
+    senderTrustStatus = TrustStatus.Unknown,
+    senderEnsVerified = false,
+    discordMessage = DiscordMessage(),
+    resendError = ""
+  )
+
+let message1 = createTestMessageItem("0xa", 1)
+let message2 = createTestMessageItem("0xb", 2)
+let message3 = createTestMessageItem("0xc", 3)
+let message4 = createTestMessageItem("0xd", 3)
+let message5 = createTestMessageItem("0xe", 4)
+
+template checkOrder(model: Model) =
+  require(model.items.len == 5)
+  check(model.items[0].id == message5.id)
+  check(model.items[1].id == message4.id)
+  check(model.items[2].id == message3.id)
+  check(model.items[3].id == message2.id)
+  check(model.items[4].id == message1.id)
+
+suite "empty model":
+  let model = newModel()
+
+  test "initial size":
+    require(model.rowCount() == 0)
+
+# newest messages should be first, break ties by message id
+suite "inserting new messages":
+  setup:
+    let model = newModel()
+
+  test "insert same message twice":
+    model.insertItemBasedOnClock(message1)
+    check(model.rowCount() == 1)
+    model.insertItemBasedOnClock(message1)
+    check(model.rowCount() == 1)
+
+  test "insert in order":
+    model.insertItemBasedOnClock(message1)
+    check(model.rowCount() == 1)
+    model.insertItemBasedOnClock(message2)
+    check(model.rowCount() == 2)
+    model.insertItemBasedOnClock(message3)
+    check(model.rowCount() == 3)
+    model.insertItemBasedOnClock(message4)
+    check(model.rowCount() == 4)
+    model.insertItemBasedOnClock(message5)
+    check(model.rowCount() == 5)
+    checkOrder(model)
+
+  test "insert out of order":
+    model.insertItemBasedOnClock(message5)
+    check(model.rowCount() == 1)
+    model.insertItemBasedOnClock(message4)
+    check(model.rowCount() == 2)
+    model.insertItemBasedOnClock(message3)
+    check(model.rowCount() == 3)
+    model.insertItemBasedOnClock(message2)
+    check(model.rowCount() == 4)
+    model.insertItemBasedOnClock(message1)
+    check(model.rowCount() == 5)
+    checkOrder(model)
+
+  test "insert out of order (randomly)":
+    model.insertItemBasedOnClock(message3)
+    check(model.rowCount() == 1)
+    model.insertItemBasedOnClock(message1)
+    check(model.rowCount() == 2)
+    model.insertItemBasedOnClock(message4)
+    check(model.rowCount() == 3)
+    model.insertItemBasedOnClock(message2)
+    check(model.rowCount() == 4)
+    model.insertItemBasedOnClock(message5)
+    check(model.rowCount() == 5)
+    checkOrder(model)
+
+# assumption: each append sequence is already sorted
+suite "appending new messages":
+  setup:
+    let model = newModel()
+
+  test "append empty model":
+    model.appendItems(@[message5,
+                        message4,
+                        message3,
+                        message2,
+                        message1])
+    checkOrder(model)
+
+  test "append to model with only newer messages":
+    model.insertItemBasedOnClock(message5)
+    model.insertItemBasedOnClock(message4)
+    model.appendItems(@[message3,
+                        message2,
+                        message1])
+    checkOrder(model)
+
+  test "append to model with newer and older messages":
+    model.insertItemBasedOnClock(message5)
+    model.insertItemBasedOnClock(message1)
+    model.appendItems(@[message4,
+                        message3,
+                        message2])
+    checkOrder(model)
+
+  test "append to model with newer and older messages and some in between":
+    model.insertItemBasedOnClock(message5)
+    model.insertItemBasedOnClock(message1)
+    model.insertItemBasedOnClock(message3) # in between
+    model.appendItems(@[message4,
+                        message2])
+    checkOrder(model)


### PR DESCRIPTION
### What does the PR do

most likely fixes: https://github.com/status-im/status-desktop/issues/8466

- fix(chat): ensure messages ordering on model append/prepend
- feat: introduce nim tests
```bash
$ make tests-nim-linux

[Suite] empty model
  [OK] initial size

[Suite] inserting new messages
  [OK] insert same message twice
  [OK] insert in order
  [OK] insert out of order
  [OK] insert out of order (randomly)

[Suite] appending new messages
  [OK] append empty model
  [OK] append to model with only newer messages
  [OK] append to model with newer and older messages
  [OK] append to model with newer and older messages and some in between
```