### PR TITLE
fix: random crash when joining a channel for the first time

### DIFF
--- a/ui/main.qml
+++ b/ui/main.qml
@@ -128,7 +128,7 @@ StatusWindow {
     Connections {
         id: windowsOsNotificationsConnection
         enabled: Qt.platform.os === Constants.windows
-        target: typeof mainModule !== "undefined" ? mainModule : null
+        target: Qt.platform.os === Constants.windows && typeof mainModule !== "undefined" ? mainModule : null
         function onDisplayWindowsOsNotification(title, message) {
             systemTray.showMessage(title, message)
         }


### PR DESCRIPTION
Fixes #8848

I'm not 100% sure why the issue is fixed by this, but I was able to pin point the source with a bisect and by running the Squish test for public chats over and over.