### PR TITLE
feat(CommunityPermissions): New permision - InDropdown added and integrated

### DIFF
--- a/storybook/PagesModel.qml
+++ b/storybook/PagesModel.qml
@@ -10,6 +10,10 @@ ListModel {
          section: "Views"
     }
     ListElement {
+         title: "CommunityNewPermissionView"
+         section: "Views"
+    }
+    ListElement {
          title: "ProfileFetchingView"
          section: "Views"
     }

--- a/storybook/PagesModel.qml
+++ b/storybook/PagesModel.qml
@@ -74,6 +74,10 @@ ListModel {
         section: "Components"
     }
     ListElement {
+        title: "StatusChatListAndCategories"
+        section: "Components"
+    }
+    ListElement {
          title: "BrowserSettings"
          section: "Settings"
     }

--- a/storybook/PagesModel.qml
+++ b/storybook/PagesModel.qml
@@ -58,6 +58,10 @@ ListModel {
          section: "Popups"
     }
     ListElement {
+         title: "InDropdown"
+         section: "Popups"
+    }
+    ListElement {
         title: "MembersSelector"
         section: "Components"
     }

--- a/storybook/figma.json
+++ b/storybook/figma.json
@@ -29,6 +29,14 @@
         "https://www.figma.com/file/17fc13UBFvInrLgNUKJJg5/Kuba%E2%8E%9CDesktop?node-id=2975%3A489607",
         "https://www.figma.com/file/17fc13UBFvInrLgNUKJJg5/Kuba%E2%8E%9CDesktop?node-id=2975%3A492910"
     ],
+    "InDropdown": [
+        "https://www.figma.com/file/17fc13UBFvInrLgNUKJJg5/Kuba%E2%8E%9CDesktop?node-id=2934%3A482182",
+        "https://www.figma.com/file/17fc13UBFvInrLgNUKJJg5/Kuba%E2%8E%9CDesktop?node-id=2934%3A482231",
+        "https://www.figma.com/file/17fc13UBFvInrLgNUKJJg5/Kuba%E2%8E%9CDesktop?node-id=2934%3A482280",
+        "https://www.figma.com/file/17fc13UBFvInrLgNUKJJg5/Kuba%E2%8E%9CDesktop?node-id=2934%3A481935",
+        "https://www.figma.com/file/17fc13UBFvInrLgNUKJJg5/Kuba%E2%8E%9CDesktop?node-id=2934%3A482006",
+        "https://www.figma.com/file/17fc13UBFvInrLgNUKJJg5/Kuba%E2%8E%9CDesktop?node-id=2934%3A482016"
+    ],
     "InviteFriendsToCommunityPopup": [
         "https://www.figma.com/file/17fc13UBFvInrLgNUKJJg5/Kuba%E2%8E%9CDesktop?node-id=2927%3A343592",
         "https://www.figma.com/file/17fc13UBFvInrLgNUKJJg5/Kuba%E2%8E%9CDesktop?node-id=2990%3A353179",

--- a/storybook/pages/CommunityNewPermissionViewPage.qml
+++ b/storybook/pages/CommunityNewPermissionViewPage.qml
@@ -1,0 +1,47 @@
+import QtQuick 2.14
+import QtQuick.Controls 2.14
+
+import AppLayouts.Chat.views.communities 1.0
+import AppLayouts.Chat.stores 1.0
+
+import Models 1.0
+
+Pane {
+    id: root
+
+    CommunityNewPermissionView {
+
+        store: CommunitiesStore {
+            readonly property var tokensModel: TokensModel {}
+            readonly property var collectiblesModel: CollectiblesModel {}
+            readonly property var channelsModel: ChannelsModel {}
+
+            function editPermission(index, holdings, permissions, channels, isPrivate) {
+                logs.logEvent("CommunitiesStore::editPermission - index: " + index)
+            }
+
+            function duplicatePermission(index) {
+                logs.logEvent("CommunitiesStore::duplicatePermission - index: " + index)
+            }
+
+            function removePermission(index) {
+                logs.logEvent("CommunitiesStore::removePermission - index: " + index)
+            }
+        }
+
+        rootStore: QtObject {
+            readonly property QtObject chatCommunitySectionModule: QtObject {
+                readonly property var model: ChannelsModel {}
+            }
+
+            readonly property QtObject mainModuleInst: QtObject {
+
+                readonly property QtObject activeSection: QtObject {
+                    readonly property string name: "Socks"
+                    readonly property string image: ModelsData.icons.socks
+                    readonly property color color: "red"
+                }
+            }
+        }
+    }
+}

--- a/storybook/pages/CommunityPermissionsSettingsPanelPage.qml
+++ b/storybook/pages/CommunityPermissionsSettingsPanelPage.qml
@@ -27,7 +27,22 @@ SplitView {
                 store: CommunitiesStore {
                     tokensModel: TokensModel {}
                     collectiblesModel: CollectiblesModel {}
-                    channelsModel: ChannelsModel {}
+                    channelsModel: ListModel {
+                        Component.onCompleted: {
+                            append([
+                                {
+                                    key: "welcome",
+                                    iconSource: ModelsData.tokens.inch,
+                                    name: "#welcome"
+                                },
+                                {
+                                    key: "general",
+                                    iconSource: ModelsData.tokens.inch,
+                                    name: "#general"
+                                }
+                            ])
+                        }
+                    }
 
                     function editPermission(index, holdings, permissions, channels, isPrivate) {
                         logs.logEvent("CommunitiesStore::editPermission - index: " + index)
@@ -39,6 +54,20 @@ SplitView {
 
                     function removePermission(index) {
                         logs.logEvent("CommunitiesStore::removePermission - index: " + index)
+                    }
+                }
+
+                rootStore: QtObject {
+                    readonly property QtObject chatCommunitySectionModule: QtObject {
+                        readonly property var model: ChannelsModel {}
+                    }
+
+                    readonly property QtObject mainModuleInst: QtObject {
+                        readonly property QtObject activeSection: QtObject {
+                            readonly property string name: "Socks"
+                            readonly property string image: ModelsData.icons.socks
+                            readonly property color color: "red"
+                        }
                     }
                 }
             }

--- a/storybook/pages/InDropdownPage.qml
+++ b/storybook/pages/InDropdownPage.qml
@@ -1,0 +1,127 @@
+import QtQuick 2.14
+import QtQuick.Controls 2.14
+
+import AppLayouts.Chat.controls.community 1.0
+
+import Models 1.0
+
+import Storybook 1.0
+
+SplitView {
+    id: root
+
+    orientation: Qt.Vertical
+
+    Logs { id: logs }
+
+    Pane {
+        id: pane
+
+        SplitView.fillWidth: true
+        SplitView.fillHeight: true
+
+        ListModel {
+            id: chatsModel
+
+            ListElement {
+                itemId: 0
+                name: "welcome"
+                isCategory: false
+                color: ""
+                colorId: 1
+                icon: ""
+            }
+            ListElement {
+                itemId: 1
+                name: "announcements"
+                isCategory: false
+                color: ""
+                colorId: 1
+                icon: ""
+            }
+            ListElement {
+                name: "Discussion"
+                isCategory: true
+
+                subItems: [
+                    ListElement {
+                        itemId: 2
+                        name: "general"
+                        icon: ""
+                        emoji: "👋"
+                    },
+                    ListElement {
+                        itemId: 3
+                        name: "help"
+                        icon: ""
+                        color: ""
+                        colorId: 1
+                        emoji: "⚽"
+                    }
+                ]
+            }
+            ListElement {
+                name: "Support"
+                isCategory: true
+
+                subItems: [
+                    ListElement {
+                        itemId: 4
+                        name: "faq"
+                        icon: ""
+                        color: ""
+                        colorId: 1
+                    },
+                    ListElement {
+                        itemId: 5
+                        name: "report-scam"
+                        icon: ""
+                        color: ""
+                        colorId: 1
+                    }
+                ]
+            }
+            ListElement {
+                name: "Empty"
+                isCategory: true
+
+                subItems: []
+            }
+        }
+
+        InDropdown {
+            parent: pane
+            anchors.centerIn: parent
+
+            communityName: "Socks"
+            communityImage: ModelsData.icons.socks
+            communityColor: "red"
+
+            model: chatsModel
+
+            onAddChannelClicked: {
+                logs.logEvent("InDropdown::addChannelClicked")
+            }
+
+            onCommunitySelected: {
+                logs.logEvent("InDropdown::communitySelected")
+            }
+
+            onChannelsSelected: {
+                logs.logEvent("InDropdown::channelSelected", ["channels"], arguments)
+            }
+
+            onOpened: contentItem.parent.parent = pane
+            Component.onCompleted: open()
+        }
+    }
+
+    LogsAndControlsPanel {
+        id: logsAndControlsPanel
+
+        SplitView.minimumHeight: 100
+        SplitView.preferredHeight: 200
+
+        logsView.logText: logs.logText
+    }
+}

--- a/storybook/pages/InDropdownPage.qml
+++ b/storybook/pages/InDropdownPage.qml
@@ -3,9 +3,8 @@ import QtQuick.Controls 2.14
 
 import AppLayouts.Chat.controls.community 1.0
 
-import Models 1.0
-
 import Storybook 1.0
+import Models 1.0
 
 SplitView {
     id: root
@@ -20,75 +19,6 @@ SplitView {
         SplitView.fillWidth: true
         SplitView.fillHeight: true
 
-        ListModel {
-            id: chatsModel
-
-            ListElement {
-                itemId: 0
-                name: "welcome"
-                isCategory: false
-                color: ""
-                colorId: 1
-                icon: ""
-            }
-            ListElement {
-                itemId: 1
-                name: "announcements"
-                isCategory: false
-                color: ""
-                colorId: 1
-                icon: ""
-            }
-            ListElement {
-                name: "Discussion"
-                isCategory: true
-
-                subItems: [
-                    ListElement {
-                        itemId: 2
-                        name: "general"
-                        icon: ""
-                        emoji: "👋"
-                    },
-                    ListElement {
-                        itemId: 3
-                        name: "help"
-                        icon: ""
-                        color: ""
-                        colorId: 1
-                        emoji: "⚽"
-                    }
-                ]
-            }
-            ListElement {
-                name: "Support"
-                isCategory: true
-
-                subItems: [
-                    ListElement {
-                        itemId: 4
-                        name: "faq"
-                        icon: ""
-                        color: ""
-                        colorId: 1
-                    },
-                    ListElement {
-                        itemId: 5
-                        name: "report-scam"
-                        icon: ""
-                        color: ""
-                        colorId: 1
-                    }
-                ]
-            }
-            ListElement {
-                name: "Empty"
-                isCategory: true
-
-                subItems: []
-            }
-        }
-
         InDropdown {
             parent: pane
             anchors.centerIn: parent
@@ -97,7 +27,7 @@ SplitView {
             communityImage: ModelsData.icons.socks
             communityColor: "red"
 
-            model: chatsModel
+            model: ChannelsModel {}
 
             onAddChannelClicked: {
                 logs.logEvent("InDropdown::addChannelClicked")

--- a/storybook/pages/StatusChatListAndCategoriesPage.qml
+++ b/storybook/pages/StatusChatListAndCategoriesPage.qml
@@ -1,0 +1,96 @@
+import QtQuick 2.14
+import QtQuick.Controls 2.14
+
+import StatusQ.Components 0.1
+
+import Storybook 1.0
+
+SplitView {
+    id: root
+
+    orientation: Qt.Vertical
+
+    Logs { id: logs }
+
+    Pane {
+        SplitView.fillWidth: true
+        SplitView.fillHeight: true
+
+        StatusChatListAndCategories {
+
+            anchors.fill: parent
+
+            model: ListModel {
+                ListElement {
+                    itemId: "id1"
+                    position: 0
+                    name: "X"
+                    subItems: []
+                    isCategory: false
+                    active: true
+                    notificationsCount: 12
+                    hasUnreadMessages: false
+                    color: ""
+                    colorId: 1
+                    icon: ""
+                    muted: false
+                    type: StatusChatListItem.Type.CommunityChat
+                }
+                ListElement {
+                    itemId: "id2"
+                    position: 0
+                    name: "Y"
+                    isCategory: true
+                    subItems: [
+                        ListElement {
+                            itemId: "id3"
+                            position: 0
+                            name: "Y_1"
+                            subItems: []
+                            active: true
+                            notificationsCount: 0
+                            hasUnreadMessages: false
+                            color: ""
+                            colorId: 1
+                            icon: ""
+                            muted: false
+                        },
+                        ListElement {
+                            itemId: "id4"
+                            position: 1
+                            name: "Y_2"
+                            active: true
+                            notificationsCount: 1
+                            hasUnreadMessages: true
+                            color: ""
+                            colorId: 2
+                            icon: ""
+                            muted: false
+                        },
+                        ListElement {
+                            itemId: "id5"
+                            position: 1
+                            name: "Y_3"
+                            active: true
+                            notificationsCount: 1
+                            hasUnreadMessages: false
+                            color: ""
+                            colorId: 2
+                            icon: ""
+                            muted: true
+                        }
+                    ]
+                }
+            }
+        }
+    }
+
+    LogsAndControlsPanel {
+        id: logsAndControlsPanel
+
+        SplitView.minimumHeight: 100
+        SplitView.preferredHeight: 200
+
+        logsView.logText: logs.logText
+    }
+}

--- a/storybook/src/Models/ChannelsModel.qml
+++ b/storybook/src/Models/ChannelsModel.qml
@@ -1,17 +1,67 @@
-import QtQuick 2.0
+import QtQuick 2.14
 
 ListModel {
-    Component.onCompleted:
-        append([
-                   {
-                       key: "welcome",
-                       iconSource: ModelsData.tokens.inch,
-                       name: "#welcome"
-                   },
-                   {
-                       key: "general",
-                       iconSource: ModelsData.tokens.inch,
-                       name: "#general"
-                   }
-               ])
+    ListElement {
+        itemId: 0
+        name: "welcome"
+        isCategory: false
+        color: ""
+        colorId: 1
+        icon: ""
+    }
+    ListElement {
+        itemId: 1
+        name: "announcements"
+        isCategory: false
+        color: ""
+        colorId: 1
+        icon: ""
+    }
+    ListElement {
+        name: "Discussion"
+        isCategory: true
+
+        subItems: [
+            ListElement {
+                itemId: 2
+                name: "general"
+                icon: ""
+                emoji: "👋"
+            },
+            ListElement {
+                itemId: 3
+                name: "help"
+                icon: ""
+                color: ""
+                colorId: 1
+                emoji: "⚽"
+            }
+        ]
+    }
+    ListElement {
+        name: "Support"
+        isCategory: true
+
+        subItems: [
+            ListElement {
+                itemId: 4
+                name: "faq"
+                icon: ""
+                color: ""
+                colorId: 1
+            },
+            ListElement {
+                itemId: 5
+                name: "report-scam"
+                icon: ""
+                color: ""
+                colorId: 1
+            }
+        ]
+    }
+    ListElement {
+        name: "Empty"
+        isCategory: true
+        subItems: []
+    }
 }

--- a/ui/StatusQ/src/StatusQ/Components/StatusItemSelector.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusItemSelector.qml
@@ -100,13 +100,23 @@ Rectangle {
        an image or an icon.
     */
     property bool useIcons: false
+
     property StatusAssetSettings asset: StatusAssetSettings {
         height: 20
         width: 20
         bgColor: "transparent"
         isImage: !root.useIcons
+        isLetterIdenticon: root.useLetterIdenticons
     }
     property int tagLeftPadding: 6
+
+    /*!
+       \qmlproperty bool StatusItemSelector::useLetterIdenticons
+       This property determines if letter identicons should be used. If set to
+       true, the model is expected to contain roles "color" and "emoji".
+    */
+    property bool useLetterIdenticons: false
+
     /*!
        \qmlsignal StatusItemSelector::itemClicked
        This signal is emitted when the item is clicked.
@@ -190,15 +200,20 @@ Rectangle {
                     }
                     StatusListItemTag {
                         title: model.text
-                        asset.name: model.imageSource
-                        asset.isImage: root.asset.isImage
-                        asset.bgColor: root.asset.bgColor
+
                         asset.height: root.asset.height
                         asset.width: root.asset.width
-                        leftPadding: root.tagLeftPadding
+                        asset.name: root.useLetterIdenticons ? model.text : model.imageSource
+                        asset.isImage: root.asset.isImage
+                        asset.bgColor: root.asset.bgColor
+                        asset.emoji: model.emoji ? model.emoji : ""
+                        asset.color: model.color ? model.color : ""
+                        asset.isLetterIdenticon: root.useLetterIdenticons
+                        //color: Theme.palette.primaryColor3
                         closeButtonVisible: false
                         titleText.color: Theme.palette.primaryColor1
                         titleText.font.pixelSize: 15
+                        leftPadding: root.tagLeftPadding
 
                         MouseArea {
                             anchors.fill: parent

--- a/ui/StatusQ/src/StatusQ/Controls/StatusChatInfoButton.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusChatInfoButton.qml
@@ -16,6 +16,8 @@ Button {
     property bool muted
     property int pinnedMessagesCount
 
+    property bool forceHideTypeIcon: false
+
     property StatusAssetSettings asset: StatusAssetSettings {
         width: 36
         height: 36
@@ -77,7 +79,7 @@ Button {
                 spacing: 1
 
                 StatusIcon {
-                    visible: root.type !== StatusChatInfoButton.Type.OneToOneChat
+                    visible: root.type !== StatusChatInfoButton.Type.OneToOneChat && !forceHideTypeIcon
                     Layout.preferredWidth: 14
                     Layout.preferredHeight: 14
                     color: root.muted ? Theme.palette.baseColor1 : Theme.palette.directColor1

--- a/ui/StatusQ/src/StatusQ/Controls/StatusCheckBox.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusCheckBox.qml
@@ -7,15 +7,43 @@ import StatusQ.Core.Theme 0.1
 CheckBox {
     id: root
 
+    /*!
+       \qmlproperty int StatusCheckBox::size
+       This property holds size type of the radio button.
+       Possible values are:
+       - Small
+       - Regular (default size)
+    */
+    property int size: StatusCheckBox.Size.Regular
+
+    enum Size {
+        Small,
+        Regular
+    }
+
     property bool leftSide: true
+
+    QtObject {
+        id: d
+
+        readonly property int indicatorSizeRegular: 18
+        readonly property int indicatorSizeSmall: 12
+
+        readonly property int indicatorIconWidthRegular: 11
+        readonly property int indicatorIconWidthSmall: 7
+
+        readonly property int indicatorIconHeightRegular: 8
+        readonly property int indicatorIconHeightSmall: 5
+    }
 
     font.family: Theme.palette.baseFont.name
 
     indicator: Rectangle {
         anchors.left: root.leftSide? parent.left : undefined
         anchors.right: !root.leftSide? parent.right : undefined
-        implicitWidth: 18
-        implicitHeight: 18
+        implicitWidth: size === StatusCheckBox.Size.Regular
+                       ? d.indicatorSizeRegular : d.indicatorSizeSmall
+        implicitHeight: implicitWidth
         x: !root.leftSide? root.rightPadding : root.leftPadding
         y: parent.height / 2 - height / 2
         radius: 2
@@ -24,8 +52,10 @@ CheckBox {
 
         StatusIcon {
             icon: "checkbox"
-            width: 11
-            height: 8
+            width: size === StatusCheckBox.Size.Regular
+                   ? d.indicatorIconWidthRegular : d.indicatorIconWidthSmall
+            height: size === StatusCheckBox.Size.Regular
+                    ? d.indicatorIconHeightRegular : d.indicatorIconHeightSmall
             anchors.centerIn: parent
             anchors.horizontalCenterOffset: 1
             color: Theme.palette.white

--- a/ui/app/AppLayouts/Chat/controls/community/CommunityCategoryListItem.qml
+++ b/ui/app/AppLayouts/Chat/controls/community/CommunityCategoryListItem.qml
@@ -1,0 +1,13 @@
+import StatusQ.Core.Theme 0.1
+
+CommunityListItem {
+    implicitHeight: 34
+
+    statusListItemTitle.font.pixelSize: 12
+    statusListItemTitle.color: Theme.palette.baseColor1
+
+    checkBox.visible: false
+
+    asset.isLetterIdenticon: false
+    asset.isImage: false
+}

--- a/ui/app/AppLayouts/Chat/controls/community/CommunityListItem.qml
+++ b/ui/app/AppLayouts/Chat/controls/community/CommunityListItem.qml
@@ -1,0 +1,46 @@
+import QtQuick 2.14
+
+import StatusQ.Components 0.1
+import StatusQ.Controls 0.1
+
+StatusListItem {
+    property alias checked: checkBox.checked
+    property alias checkState: checkBox.checkState
+    readonly property alias checkBox: checkBox
+
+    implicitHeight: 44
+    leftPadding: 8
+    rightPadding: 3
+    statusListItemTitle.font.pixelSize: 13
+
+    statusListItemTitleArea.anchors.leftMargin: 8
+
+    asset.bgWidth: 32
+    asset.bgHeight: 32
+
+    asset.isLetterIdenticon: true
+    asset.letterSize: 12
+    asset.isImage: model.icon.includes("data")
+    asset.width: 32
+    asset.height: 32
+
+    components: [
+        StatusCheckBox {
+            id: checkBox
+
+            size: StatusCheckBox.Size.Small
+            rightPadding: 0
+        }
+    ]
+
+    // using MouseArea instead of build-in 'clicked' signal to avoid
+    // intercepting event by the StatusCheckBox
+    MouseArea {
+        anchors.fill: parent
+        onClicked: {
+            checkBox.toggle()
+            checkBox.toggled()
+        }
+        cursorShape: Qt.PointingHandCursor
+    }
+}

--- a/ui/app/AppLayouts/Chat/controls/community/InDropdown.qml
+++ b/ui/app/AppLayouts/Chat/controls/community/InDropdown.qml
@@ -1,0 +1,376 @@
+import QtQuick 2.14
+import QtQuick.Layouts 1.14
+
+import StatusQ.Core 0.1
+import StatusQ.Core.Theme 0.1
+import StatusQ.Components 0.1
+import StatusQ.Controls 0.1
+import StatusQ.Popups 0.1
+
+import shared.controls 1.0
+
+import SortFilterProxyModel 0.2
+
+StatusDropdown {
+    id: root
+
+    property string communityName
+    property string communityImage
+    property color communityColor
+
+    property var model
+
+    property int acceptMode: InDropdown.AcceptMode.Add
+
+    enum AcceptMode {
+        Add, Update
+    }
+
+    width: 289
+    padding: 8
+
+    // force keeping within the bounds of the enclosing window
+    margins: 0
+
+    signal addChannelClicked
+    signal communitySelected
+    signal channelsSelected(var channels)
+
+    function setSelectedChannels(channels) {
+        d.setSelectedChannels(channels)
+    }
+
+    onAboutToHide: searcher.text = ""
+    onAboutToShow: scrollView.Layout.preferredHeight = Math.min(
+                       scrollView.implicitHeight, 420)
+
+    QtObject {
+        id: d
+
+        readonly property var selectedChannels: new Map()
+
+        signal setSelectedChannels(var channels)
+
+        function search(text, searcherText) {
+            return text.toLowerCase().includes(searcherText.toLowerCase())
+        }
+
+        function resolveEmoji(emoji) {
+            return !!emoji ? emoji : ""
+        }
+
+        function resolveColor(color, colorId) {
+            return !!color ? color : Theme.palette.userCustomizationColors[colorId]
+        }
+
+        function addToSelectedChannels(model) {
+            selectedChannels.set(model.itemId, {
+                itemId: model.itemId,
+                name: model.name,
+                color: d.resolveColor(model.color, model.colorId),
+                emoji: d.resolveEmoji(model.emoji)
+            })
+        }
+
+        function removeFromSelectedChannels(model) {
+            selectedChannels.delete(model.itemId)
+        }
+    }
+
+    ColumnLayout {
+        anchors.top: parent.top
+        anchors.right: parent.right
+        anchors.left: parent.left
+
+        spacing: 0
+
+        SearchBox {
+            id: searcher
+
+            Layout.fillWidth: true
+
+            topPadding: 0
+            bottomPadding: 0
+            minimumHeight: 36
+            maximumHeight: 36
+        }
+
+        StatusListItem {
+            Layout.fillWidth: true
+            Layout.topMargin: 9
+            Layout.preferredHeight: 44
+
+
+            title: root.communityName
+            subTitle: qsTr("Community")
+
+            asset.name:  root.communityImage
+            asset.color: root.communityColor
+            asset.isImage: true
+            asset.width: 32
+            asset.height: 32
+            asset.isLetterIdenticon: !asset.name
+            asset.charactersLen: 2
+            asset.letterSize: 15
+
+            leftPadding: 8
+            rightPadding: 6
+
+            statusListItemTitleArea.anchors.leftMargin: 8
+            statusListItemTitle.font.pixelSize: 13
+            statusListItemTitle.font.weight: Font.Medium
+
+            statusListItemSubTitle.font.pixelSize: 12
+
+            components: [
+                StatusRadioButton {
+                    id: radioButton
+
+                    size: StatusRadioButton.Size.Small
+                    rightPadding: 0
+                }
+            ]
+
+            // using MouseArea instead of build-in 'clicked' signal to avoid
+            // intercepting event by the StatusRadioButton
+            MouseArea {
+                anchors.fill: parent
+                onClicked: {
+                    radioButton.toggle()
+                    radioButton.toggled()
+                }
+                cursorShape: Qt.PointingHandCursor
+            }
+        }
+
+        StatusMenuSeparator {
+            Layout.fillWidth: true
+            Layout.topMargin: 4 - implicitHeight / 2
+            Layout.bottomMargin: 4 - implicitHeight / 2
+        }
+
+        StatusScrollView {
+            id: scrollView
+
+            Layout.fillWidth: true
+            Layout.bottomMargin: 9
+
+            padding: 0
+
+            ColumnLayout {
+                id: scollableColumn
+
+                spacing: 0
+                width: scrollView.width
+
+                StatusIconTextButton {
+                    Layout.preferredHeight: 36
+
+                    leftPadding: 8
+                    spacing: 8
+                    statusIcon: "add"
+                    icon.width: 16
+                    icon.height: 16
+                    iconRotation: 0
+                    text: qsTr("Add channel")
+                    onClicked: root.addChannelClicked()
+                }
+
+                Repeater {
+                    id: topRepeater
+
+                    model: SortFilterProxyModel {
+                        id: topLevelModel
+
+                        sourceModel: root.model
+
+                        sorters: [
+                            RoleSorter { roleName: "isCategory" },
+                            RoleSorter { roleName: "position" }
+                        ]
+                    }
+
+                    ColumnLayout {
+                        id: column
+
+                        Layout.fillWidth: true
+                        spacing: 0
+
+                        readonly property var topModel: model
+                        readonly property alias checkBox: loader.item
+                        property int checkedCount: 0
+
+                        visible: {
+                            if (!model.isCategory)
+                                return d.search(model.name, searcher.text)
+                                        || checkBox.checked
+
+                            if (checkedCount > 0)
+                                return true
+
+                            const subItemsCount = subItemsRepeater.count
+
+                            for (let i = 0; i < subItemsCount; i++)
+                                if (subItemsRepeater.itemAt(i).show)
+                                    return true
+
+                            return false
+                        }
+
+                        Loader {
+                            id: loader
+
+                            Layout.fillWidth: true
+                            Layout.topMargin: model.isCategory ? 9 : 0
+
+                            sourceComponent: model.isCategory
+                                             ? communityCategoryDelegate
+                                             : communityDelegate
+
+                            Connections {
+                                target: radioButton
+
+                                function onToggled() {
+                                    const checkBox = loader.item.checkBox
+                                    checkBox.checked = false
+                                    checkBox.onToggled()
+
+                                }
+                            }
+
+                            Component {
+                                id: communityDelegate
+
+                                CommunityListItem {
+                                    id: communityItem
+
+                                    title: "#" + model.name
+
+                                    asset.name: model.icon
+                                    asset.emoji: d.resolveEmoji(model.emoji)
+                                    asset.color: d.resolveColor(model.color,
+                                                                model.colorId)
+
+                                    checkBox.onToggled: {
+                                        if (checked)
+                                            radioButton.checked = false
+                                    }
+
+                                    checkBox.onCheckedChanged: {
+                                        if (checkBox.checked)
+                                            d.addToSelectedChannels(model)
+                                        else
+                                            d.removeFromSelectedChannels(model)
+                                    }
+
+                                    Connections {
+                                        target: d
+
+                                        function onSetSelectedChannels(channels) {
+                                            communityItem.checked = channels.includes(
+                                                        model.itemId)
+                                        }
+                                    }
+                                }
+                            }
+
+                            Component {
+                                id: communityCategoryDelegate
+
+                                CommunityCategoryListItem {
+                                    title: model.name
+
+                                    checkState: {
+                                        if (checkedCount === model.subItems.count)
+                                            return Qt.Checked
+                                        else if (checkedCount === 0)
+                                            return Qt.Unchecked
+
+                                        return Qt.PartiallyChecked
+                                    }
+
+                                    checkBox.onToggled: {
+                                        if (checked)
+                                            radioButton.checked = false
+
+                                        subItemsRepeater.setAll(checkState)
+                                    }
+                                }
+                            }
+                        }
+
+                        Repeater {
+                            id: subItemsRepeater
+
+                            model: SortFilterProxyModel {
+                                sourceModel: topModel.isCategory ? topModel.subItems : null
+                                sorters: RoleSorter { roleName: "position" }
+                            }
+
+                            function setAll(checkState) {
+                                const subItemsCount = count
+
+                                for (let i = 0; i < subItemsCount; i++) {
+                                    itemAt(i).checkState = checkState
+                                }
+                            }
+
+                            CommunityListItem {
+                                id: communitySubItem
+
+                                Layout.fillWidth: true
+
+                                readonly property bool show: d.search(model.name, searcher.text)
+                                                             || checked
+
+                                visible: show
+
+                                title: "#" + model.name
+
+                                asset.name: model.icon
+                                asset.emoji: d.resolveEmoji(model.emoji)
+                                asset.color: d.resolveColor(model.color,
+                                                            model.colorId)
+
+                                onCheckedChanged: {
+                                    if (checked) {
+                                        radioButton.checked = false
+                                        d.addToSelectedChannels(model)
+                                    } else {
+                                        d.removeFromSelectedChannels(model)
+                                    }
+
+                                    Qt.callLater(() => checkedCount += checked ? 1 : -1)
+                                }
+
+                                Connections {
+                                    target: d
+
+                                    function onSetSelectedChannels(channels) {
+                                        communitySubItem.checked = channels.includes(
+                                                    model.itemId)
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        StatusButton {
+            Layout.fillWidth: true
+            text: root.acceptMode === InDropdown.AcceptMode.Add
+                  ? qsTr("Add") : qsTr("Update")
+
+            onClicked: {
+                if (radioButton.checked) {
+                    root.communitySelected()
+                    return
+                }
+
+                root.channelsSelected(Array.from(d.selectedChannels.values()))
+            }
+        }
+    }
+}

--- a/ui/app/AppLayouts/Chat/controls/community/qmldir
+++ b/ui/app/AppLayouts/Chat/controls/community/qmldir
@@ -1,3 +1,6 @@
-HoldingsDropdown 1.0 HoldingsDropdown.qml
+CommunityCategoryListItem 1.0 CommunityCategoryListItem.qml
+CommunityListItem 1.0 CommunityListItem.qml
 HoldingTypes 1.0 HoldingTypes.qml
+HoldingsDropdown 1.0 HoldingsDropdown.qml
+InDropdown 1.0 InDropdown.qml
 PermissionItem 1.0 PermissionItem.qml

--- a/ui/app/AppLayouts/Chat/panels/communities/CommunityPermissionsSettingsPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/CommunityPermissionsSettingsPanel.qml
@@ -7,6 +7,7 @@ import AppLayouts.Chat.stores 1.0
 SettingsPageLayout {
     id: root
 
+    property var rootStore
     property var store: CommunitiesStore {}
     property int viewWidth: 560 // by design
 
@@ -133,6 +134,7 @@ SettingsPageLayout {
         CommunityNewPermissionView {
             id: newPermissionViewItem
             viewWidth: root.viewWidth
+            rootStore: root.rootStore
             store: root.store
             onPermissionCreated: root.state = d.permissionsViewState
             isEditState: root.state === d.editPermissionViewState

--- a/ui/app/AppLayouts/Chat/views/CommunitySettingsView.qml
+++ b/ui/app/AppLayouts/Chat/views/CommunitySettingsView.qml
@@ -237,6 +237,7 @@ StatusSectionLayout {
             }
 
             CommunityPermissionsSettingsPanel {
+                rootStore: root.rootStore
                 onPreviousPageNameChanged: root.backButtonName = previousPageName
             }
 

--- a/ui/nim-status-client.pro
+++ b/ui/nim-status-client.pro
@@ -13,6 +13,7 @@ DEFINES += QT_DEPRECATED_WARNINGS
 #DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0x060000    # disables all the APIs deprecated before Qt 6.0.0
 
 lupdate_only{
+SOURCES += $$files("$$PWD/*qmldir", true)
 SOURCES += $$files("$$PWD/*.qml", true)
 SOURCES += $$files("$$PWD/*.js", true)
 }
@@ -22,6 +23,8 @@ TRANSLATIONS += \
     i18n/qml_base.ts \
     i18n/qml_en.ts \
 
+
+OTHER_FILES += $$files("$$PWD/*qmldir", true)
 OTHER_FILES += $$files("$$PWD/*.qml", true)
 OTHER_FILES += $$files("$$PWD/*.js", true)
 OTHER_FILES += $$files("$$PWD/../src/*.nim", true)


### PR DESCRIPTION
### What does the PR do

1. Adds `InDropdown` popup for selecting whole community or particular channels
2. Integrates `InDropdown` with `CommunityNewPermissionsView` component
3. Add some extensions to used components (`StatusItemSelector`, `StatusCheckBox`, `StatusChatInfoButton`)
4. Adds minor fix to `nim-status-client.pro` to display `qmldir` files in QtCreator
5. Adds several new pages to Storybook

Closes: #6041 

### Affected areas
`CommunityNewPermissionsView`, `StatusItemSelector`, `StatusCheckBox`, `StatusChatInfoButton`

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

[Kazam_screencast_00097.webm](https://user-images.githubusercontent.com/20650004/208645062-8ccf29d8-e4ab-4623-82e5-4f6404dece20.webm)

