### PR TITLE
fix(messagesView): Increase spacing between chat messages

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
@@ -117,14 +117,6 @@ Control {
         })
     }
 
-    implicitWidth: messageLayout.implicitWidth
-                   + messageLayout.anchors.leftMargin
-                   + messageLayout.anchors.rightMargin
-
-    implicitHeight: messageLayout.implicitHeight
-                    + messageLayout.anchors.topMargin
-                    + messageLayout.anchors.bottomMargin
-
     hoverEnabled: (!root.isActiveMessage && !root.disableHover)
     background: Rectangle {
         color: {
@@ -151,6 +143,10 @@ Control {
     }
 
     contentItem: Item {
+
+        implicitWidth: messageLayout.implicitWidth
+        implicitHeight: messageLayout.implicitHeight
+
         Rectangle {
             anchors {
                 top: parent.top
@@ -212,8 +208,6 @@ Control {
         ColumnLayout {
             id: messageLayout
             anchors.fill: parent
-            anchors.topMargin: 2
-            anchors.bottomMargin: 2
             spacing: 2
 
             Loader {


### PR DESCRIPTION
### What does the PR do

Fix #8675

Added padding between messages as specified in Figma: 
topPadding - 8 if the current message has header, 2 otherwise 
bottomPadding - 8 if both current and next message have header, 2 otherwise

### Affected areas

MessageView
StatusMessage

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it
<img width="911" alt="Screenshot 2022-12-20 at 15 23 22" src="https://user-images.githubusercontent.com/47811206/208678017-83f1dd0a-8c7f-476c-82c4-da17ec22df86.png">
<img width="911" alt="Screenshot 2022-12-20 at 15 23 39" src="https://user-images.githubusercontent.com/47811206/208678038-8727913a-e39e-4ca8-b705-25cf276af5f4.png">


https://user-images.githubusercontent.com/47811206/208677808-c5198dc7-a944-4c01-9770-be4345ce290f.mov
