### PR TITLE
fix(windows): fix app not showing when monitor setup changed

### DIFF
--- a/ui/main.qml
+++ b/ui/main.qml
@@ -50,7 +50,14 @@ StatusWindow {
             visibility = Window.Windowed;
         }
 
-        if (geometry === undefined) {
+        if (geometry === undefined ||
+            // If the monitor setup of the user changed, it's possible that the old geometry now falls out of the monitor range
+            // In this case, we reset to the basic geometry
+            geometry.x > Screen.desktopAvailableWidth ||
+            geometry.y > Screen.desktopAvailableHeight ||
+            geometry.width > Screen.desktopAvailableWidth ||
+            geometry.height > Screen.desktopAvailableHeight)
+        {
             let screen = Qt.application.screens[0];
 
             geometry = Qt.rect(0,


### PR DESCRIPTION
Fixes #8726

This took me longer than I dare to admit to fix.
Turns out it's a simple call in QML that made it fails on open. I fixed by checking if the wanted position is within the possible screen layout. If not, I reset to the default position and size.

I think the bug only appeared on Windows BTW