### PR TITLE
fix(image): fix image download on Windows

### DIFF
--- a/src/app/global/utils.nim
+++ b/src/app/global/utils.nim
@@ -115,7 +115,8 @@ QtObject:
     downloadImage(content, path)
 
   proc downloadImageByUrl*(self: Utils, url: string, path: string) {.slot.} =
-    downloadImageByUrl(url, path)
+    let pathFormatted = self.formatImagePath(path)
+    downloadImageByUrl(url, pathFormatted)
 
   proc generateQRCodeSVG*(self: Utils, text: string, border: int = 0): string =
     var qr0: array[0..qrcodegen_BUFFER_LEN_MAX, uint8]

--- a/ui/imports/shared/views/chat/MessageContextMenuView.qml
+++ b/ui/imports/shared/views/chat/MessageContextMenuView.qml
@@ -470,10 +470,12 @@ StatusMenu {
         id: fileDialog
         title: qsTr("Please choose a directory")
         selectFolder: true
+        selectExisting : true
+        selectMultiple: false
         modality: Qt.NonModal
         onAccepted: {
             if (root.imageSource) {
-                root.store.downloadImageByUrl(root.imageSource, fileDialog.fileUrls)
+                root.store.downloadImageByUrl(root.imageSource, fileDialog.fileUrl)
             }
             fileDialog.close()
         }


### PR DESCRIPTION
Fixes #8755

Paths are not formatted correctly on Windows. There were three `/`s and also the path cannot start with `/`

edit: I tested on both Windows and Linux