### PR TITLE
fix(chat_section_module): Don't force update icon and name for 1-1 chats

### DIFF
--- a/src/app/modules/main/chat_section/chat_content/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/module.nim
@@ -343,7 +343,7 @@ method onNotificationsUpdated*(self: Module, hasUnreadMessages: bool, notificati
   self.view.updateChatDetailsNotifications(hasUnreadMessages, notificationCount)
 
 method onChatEdited*(self: Module, chatDto: ChatDto) =
-  self.view.updateChatDetails(chatDto.name, chatDto.description, chatDto.emoji, chatDto.color, chatDto.icon, chatDto.chatType == ChatType.OneToOne)
+  self.view.updateChatDetails(chatDto)
   self.messagesModule.updateChatFetchMoreMessages()
   self.messagesModule.updateChatIdentifier()
 

--- a/src/app/modules/main/chat_section/chat_content/view.nim
+++ b/src/app/modules/main/chat_section/chat_content/view.nim
@@ -1,6 +1,6 @@
 import NimQml
 import ../../../shared_models/message_model as pinned_msg_model
-import ../../../../../app_service/service/contacts/dto/contacts as contacts_dto
+import ../../../../../app_service/service/chat/dto/chat as chat_dto
 
 import io_interface
 import chat_details
@@ -128,13 +128,13 @@ QtObject:
   proc amIChatAdmin*(self: View): bool {.slot.} =
     return self.delegate.amIChatAdmin()
 
-  proc updateChatDetails*(self: View, name, description, emoji, color, icon: string, ignoreName: bool) =
-    if not ignoreName:
-      self.chatDetails.setName(name)
-    self.chatDetails.setDescription(description)
-    self.chatDetails.setEmoji(emoji)
-    self.chatDetails.setColor(color)
-    self.chatDetails.setIcon(icon)
+  proc updateChatDetails*(self: View, chatDto: ChatDto) =
+    if chatDto.chatType != ChatType.OneToOne:
+      self.chatDetails.setName(chatDto.name)
+      self.chatDetails.setIcon(chatDto.icon)
+    self.chatDetails.setDescription(chatDto.description)
+    self.chatDetails.setEmoji(chatDto.emoji)
+    self.chatDetails.setColor(chatDto.color)
 
   proc updateChatDetailsName*(self: View, name: string) =
     self.chatDetails.setName(name)


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/8273

### What does the PR do

In ChatContentModule don't update name and icon for 1-1 chat. It will be updated with contact details change.

### Affected areas

chat

### Screenshot BEFORE

https://user-images.githubusercontent.com/25482501/208859316-161905ab-e99b-4a6c-9bbc-4387730b006d.mov

### Screenshot AFTER

https://user-images.githubusercontent.com/25482501/208859451-aa20892e-42ae-4b2d-a7e1-5b65972854ec.mov


