### PR TITLE
fix(@desktop/communities): empty chat view during adding/removing active channel to the category

### DIFF
--- a/src/app/modules/main/chat_section/controller.nim
+++ b/src/app/modules/main/chat_section/controller.nim
@@ -173,6 +173,11 @@ proc init*(self: Controller) =
       let args = CommunityChatOrderArgs(e)
       if (args.communityId == self.sectionId):
         self.delegate.onReorderChatOrCategory(args.chatId, args.position, args.categoryId)
+    
+    self.events.on(SIGNAL_COMMUNITY_CHANNEL_CATEGORY_CHANGED) do(e:Args):
+      let args = CommunityChatOrderArgs(e)
+      if (args.communityId == self.sectionId):
+        self.delegate.onCommunityCategoryChannelChanged(args.chatId, args.categoryId)
 
     self.events.on(SIGNAL_RELOAD_MESSAGES) do(e: Args):
       let args = ReloadMessagesArgs(e)
@@ -272,13 +277,11 @@ proc getCommunityCategoryDetails*(self: Controller, communityId: string, categor
 proc setActiveItemSubItem*(self: Controller, itemId: string, subItemId: string) =
   self.activeItemId = itemId
   self.activeSubItemId = subItemId
-
   let chatId = self.getActiveChatId()
   if chatId != "":
     self.messageService.asyncLoadInitialMessagesForChat(chatId)
 
   # We need to take other actions here like notify status go that unviewed mentions count is updated and so...
-
   self.delegate.activeItemSubItemSet(self.activeItemId, self.activeSubItemId)
 
 proc removeCommunityChat*(self: Controller, itemId: string) =

--- a/src/app/modules/main/chat_section/io_interface.nim
+++ b/src/app/modules/main/chat_section/io_interface.nim
@@ -127,6 +127,9 @@ method onCommunityChannelEdited*(self: AccessInterface, chat: ChatDto) {.base.} 
 method onReorderChatOrCategory*(self: AccessInterface, chatOrCatId: string, position: int, newCategoryIdForChat: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method onCommunityCategoryChannelChanged*(self: AccessInterface, chatId: string, newCategoryIdForChat: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method onCommunityCategoryCreated*(self: AccessInterface, category: Category, chats: seq[ChatDto]) {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -552,6 +552,13 @@ method setFirstChannelAsActive*(self: Module) =
     let subItem = item.subItems.getItemAtIndex(0)
     self.setActiveItemSubItem(item.id, subItem.id)
 
+method onCommunityCategoryChannelChanged*(self: Module, channelId: string, newCategoryIdForChat: string) =
+  if channelId == self.controller.getActiveChatId():
+    if newCategoryIdForChat.len > 0:
+      self.setActiveItemSubItem(newCategoryIdForChat, channelId)
+    else:
+      self.setActiveItemSubItem(channelId, "")
+
 method onReorderChatOrCategory*(self: Module, chatOrCatId: string, position: int, newCategoryIdForChat: string) =
   self.view.chatsModel().reorder(chatOrCatId, position, newCategoryIdForChat)
 
@@ -571,16 +578,18 @@ method onCommunityCategoryEdited*(self: Module, cat: Category, chats: seq[ChatDt
     self.view.chatsModel().removeItemById(chatDto.id)
     categoryItem.subItems().removeItemById(chatDto.id)
 
+    let isActive = chatDto.id == self.controller.getActiveChatId()
+
     if chatDto.categoryId == cat.id:
       let channelItem = initSubItem(chatDto.id, cat.id, chatDto.name, chatDto.icon,
         chatDto.color, chatDto.emoji, chatDto.description, chatDto.chatType.int,
         amIChatAdmin=true, chatDto.timestamp.int, hasNotification, notificationsCount, chatDto.muted, blocked=false,
-        active=false, chatDto.position)
+        active=isActive, chatDto.position)
       categoryItem.appendSubItem(channelItem)
     else:
       let channelItem = initItem(chatDto.id, chatDto.name, chatDto.icon,
         chatDto.color, chatDto.emoji, chatDto.description, chatDto.chatType.int, amIChatAdmin,
-        chatDto.timestamp.int, hasNotification, notificationsCount, chatDto.muted, blocked=false, active = false,
+        chatDto.timestamp.int, hasNotification, notificationsCount, chatDto.muted, blocked=false, active = isActive,
         chatDto.position, categoryId="")
       self.view.chatsModel().appendItem(channelItem)
 

--- a/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
@@ -166,16 +166,6 @@ Item {
         model: parentModule && parentModule.model
         delegate: delegateChooser
 
-        function isChatActive(myChatId) {
-            if(!myChatId || !root.isSectionActive)
-                return false
-
-            if(myChatId === root.activeChatId || myChatId === root.activeSubItemId)
-                return true
-
-            return false
-        }
-
         DelegateChooser {
             id: delegateChooser
             role: "type"
@@ -189,25 +179,15 @@ Item {
                         return subItems
                     }
                     delegate: Loader {
-                        property bool isActiveChannel: chatRepeater.isChatActive(model.itemId)
-
                         id: categoryChatLoader
                         // Channels are not loaded by default and only load when first put active
-                        active: false
+                        active: model.active
+                        visible: model.active
                         width: parent.width
-                        height: isActiveChannel ? parent.height : 0
+                        height: parent.height
 
-                        Connections {
-                            id: loaderConnections
-                            target: categoryChatLoader
-                            // First time this channel turns active, activate the Loader
-                            onIsActiveChannelChanged: {
-                                if (categoryChatLoader.isActiveChannel) {
-                                    categoryChatLoader.active = true
-                                    loaderConnections.enabled = false
-                                }
-                            }
-                        }
+                        // Removing the binding in order not to unload the content
+                        onStatusChanged: if (status == Loader.Ready) active = true
 
                         sourceComponent: ChatContentView {
                             visible: !root.rootStore.openCreateChat && isActiveChannel
@@ -221,7 +201,7 @@ Item {
                             sendTransactionWithEnsModal: cmpSendTransactionWithEns
                             stickersLoaded: root.stickersLoaded
                             isBlocked: model.blocked
-                            isActiveChannel: categoryChatLoader.isActiveChannel
+                            isActiveChannel: categoryChatLoader.visible
                             onOpenStickerPackPopup: {
                                 root.openStickerPackPopup(stickerPackId)
                             }
@@ -239,24 +219,15 @@ Item {
             }
             DelegateChoice { // In all other cases
                 delegate: Loader {
-                    property bool isActiveChannel: chatRepeater.isChatActive(model.itemId)
-
                     id: chatLoader
                     // Channels are not loaded by default and only load when first put active
-                    active: false
+                    active: model.active
+                    visible: model.active
                     width: parent.width
-                    height: isActiveChannel ? parent.height : 0
-                    Connections {
-                        id: defaultLoaderConnections
-                        target: chatLoader
-                        // First time this channel turns active, activate the Loader
-                        onIsActiveChannelChanged: {
-                            if (chatLoader.isActiveChannel) {
-                                chatLoader.active = true
-                                defaultLoaderConnections.enabled = false
-                            }
-                        }
-                    }
+                    height: parent.height
+
+                    // Removing the binding in order not to unload the content
+                    onStatusChanged: if (status == Loader.Ready) active = true
 
                     sourceComponent: ChatContentView {
                         visible: !root.rootStore.openCreateChat && isActiveChannel
@@ -270,7 +241,7 @@ Item {
                         sendTransactionWithEnsModal: cmpSendTransactionWithEns
                         stickersLoaded: root.stickersLoaded
                         isBlocked: model.blocked
-                        isActiveChannel: chatLoader.isActiveChannel
+                        isActiveChannel: chatLoader.visible
                         onOpenStickerPackPopup: {
                             root.openStickerPackPopup(stickerPackId)
                         }


### PR DESCRIPTION
### What does the PR do

Fixes: #8297

- Fixes empty chat view after:
- - creating a new category with an active channel
- - adding/removing an active channel to the category
- - changing active channels inside the category and removing any channel from the category
- Keep the correct active state for the model when the community was edited
- Refactored chat selection based on the active state of the chat model
- Tiny optimization in community service during searching for changes

### Affected areas

- Chat view in the community
- Correct chat selection in the community

### Screenshot of functionality (including design for comparison)

https://user-images.githubusercontent.com/117639195/208879197-32b775dd-edf1-41fe-b065-d18e833d6217.mov
