### PR TITLE
fix(MessageView): Ignore message editing with no actual changes

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
@@ -370,7 +370,7 @@ Control {
                         Layout.rightMargin: 16
                         active: root.editMode
                         visible: active
-                        msgText: root.messageDetails.messageText
+                        messageText: root.messageDetails.messageText
                         saveButtonText: root.saveButtonText
                         cancelButtonText: root.cancelButtonText
                         onEditCancelled: root.editCancelled()

--- a/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusEditMessage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusEditMessage.qml
@@ -13,7 +13,7 @@ Item {
 
     property string cancelButtonText: ""
     property string saveButtonText: ""
-    property string msgText: ""
+    property string messageText: ""
 
     signal editCancelled()
     signal editCompleted(var newMsgText)
@@ -40,7 +40,7 @@ Item {
                 readonly property string messageText: input.text
                 width: parent.width
                 input.placeholderText: ""
-                input.text: msgText
+                input.text: root.messageText
                 maximumHeight: 40
             }
         }

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -432,8 +432,9 @@ Loader {
                 readonly property bool isReply: root.responseToMessageWithId !== ""
     
                 property var replyMessage: getReplyMessage()
-
                 readonly property string replySenderId: replyMessage ? replyMessage.senderId : ""
+
+                property string originalMessageText: ""
 
                 function getReplyMessage() {
                     return root.messageStore && isReply
@@ -441,8 +442,19 @@ Loader {
                             : null
                 }
 
+                function editCancelledHandler() {
+                    root.messageStore.setEditModeOff(root.messageId)
+                }
+
                 function editCompletedHandler(newMessageText) {
+
+                    if (delegate.originalMessageText === newMessageText) {
+                        delegate.editCancelledHandler()
+                        return
+                    }
+
                     const message = root.rootStore.plainText(StatusQUtils.Emoji.deparse(newMessageText))
+
                     if (message.length <= 0)
                         return;
 
@@ -515,7 +527,7 @@ Loader {
                 messageAttachments: root.messageAttachments
 
                 onEditCancelled: {
-                    root.messageStore.setEditModeOff(root.messageId)
+                    delegate.editCancelledHandler()
                 }
 
                 onEditCompleted: {
@@ -719,6 +731,7 @@ Loader {
 
                     Component.onCompleted: {
                         parseMessage(root.messageText);
+                        delegate.originalMessageText = editTextInput.textInput.text
                     }
                 }
 


### PR DESCRIPTION
Fixes #8261 

### What does the PR do

When a message is finished, but no actual changes was found, ignore the changes and simply close the edit field.
Works both for clicking `Enter` key and `Apply` button.

Also renamed property to `messageText` in `StatusMessage`.

### Affected areas

Message editing

### Screenshot of functionality (including design for comparison)

https://user-images.githubusercontent.com/25482501/208937177-eb6b43a7-b232-4672-af6a-6547af817c3f.mov


