### PR TITLE
fix(@desktop/chat): Do not allow sending empty message

### DIFF
--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -341,10 +341,16 @@ Rectangle {
 
     function onKeyPress(event) {
         if (event.modifiers === Qt.NoModifier && (event.key === Qt.Key_Enter || event.key === Qt.Key_Return)) {
+            if (getPlainText().trim() === "") {
+                event.accepted = true;
+                return
+            }
+
             if (checkTextInsert()) {
                 event.accepted = true;
                 return
             }
+
             if (messageInputField.length <= messageLimit) {
                 control.sendMessage(event)
                 control.hideExtendedArea();


### PR DESCRIPTION
### What does the PR do

Do not allow sending an empty message
Fixes: #8268

### Affected areas

StatusChatInput

### Screenshot of functionality (including design for comparison)

https://user-images.githubusercontent.com/117639195/209141808-570f1492-6bc2-41ba-9679-ccdd0422df0d.mov

