### PR TITLE
Fix empty reply message

### DIFF
--- a/src/app/modules/main/activity_center/module.nim
+++ b/src/app/modules/main/activity_center/module.nim
@@ -99,7 +99,11 @@ proc createMessageItemFromDto(self: Module, message: MessageDto, chatDetails: Ch
     contactDetails.details.ensVerified,
     message.discordMessage,
     resendError = "",
-    message.mentioned
+    message.mentioned,
+    message.quotedMessage.`from`,
+    message.quotedMessage.text,
+    self.controller.getRenderedText( message.quotedMessage.parsedText),
+    message.quotedMessage.contentType
     ))
 
 method convertToItems*(

--- a/src/app/modules/main/activity_center/module.nim
+++ b/src/app/modules/main/activity_center/module.nim
@@ -103,7 +103,8 @@ proc createMessageItemFromDto(self: Module, message: MessageDto, chatDetails: Ch
     message.quotedMessage.`from`,
     message.quotedMessage.text,
     self.controller.getRenderedText( message.quotedMessage.parsedText),
-    message.quotedMessage.contentType
+    message.quotedMessage.contentType,
+    message.quotedMessage.deleted,
     ))
 
 method convertToItems*(

--- a/src/app/modules/main/chat_section/chat_content/messages/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/module.nim
@@ -107,7 +107,8 @@ proc createFetchMoreMessagesItem(self: Module): Item =
     quotedMessageFrom = "",
     quotedMessageText = "",
     quotedMessageParsedText = "",
-    quotedMessageContentType = -1
+    quotedMessageContentType = -1,
+    quotedMessageDeleted = false,
   )
 
 proc createChatIdentifierItem(self: Module): Item =
@@ -154,7 +155,8 @@ proc createChatIdentifierItem(self: Module): Item =
     quotedMessageFrom = "",
     quotedMessageText = "",
     quotedMessageParsedText = "",
-    quotedMessageContentType = -1
+    quotedMessageContentType = -1,
+    quotedMessageDeleted = false,
   )
 
 proc checkIfMessageLoadedAndScrollToItIfItIs(self: Module) =
@@ -240,7 +242,8 @@ method newMessagesLoaded*(self: Module, messages: seq[MessageDto], reactions: se
         m.quotedMessage.`from`,
         m.quotedMessage.text,
         self.controller.getRenderedText(m.quotedMessage.parsedText),
-        m.quotedMessage.contentType
+        m.quotedMessage.contentType,
+        m.quotedMessage.deleted,
         )
 
       for r in reactions:
@@ -345,7 +348,8 @@ method messageAdded*(self: Module, message: MessageDto) =
     message.quotedMessage.`from`,
     message.quotedMessage.text,
     self.controller.getRenderedText(message.quotedMessage.parsedText),
-    message.quotedMessage.contentType
+    message.quotedMessage.contentType,
+    message.quotedMessage.deleted,
   )
 
   self.view.model().insertItemBasedOnClock(item)
@@ -630,7 +634,8 @@ method getMessageById*(self: Module, messageId: string): message_item.Item =
       m.quotedMessage.`from`,
       m.quotedMessage.text,
       self.controller.getRenderedText(m.quotedMessage.parsedText),
-      m.quotedMessage.contentType
+      m.quotedMessage.contentType,
+      m.quotedMessage.deleted,
       )
     return item
   return nil

--- a/src/app/modules/main/chat_section/chat_content/messages/view.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/view.nim
@@ -58,19 +58,6 @@ QtObject:
       return ""
     return $jsonObj
 
-  proc getReplyMessageByIdAsJson*(self: View, messageId: string): string {.slot.} =
-    var jsonObj = self.model.getMessageByIdAsJson(messageId)
-    if(jsonObj.isNil):
-      # trying to get message from status-go
-      let messageItem = self.delegate.getMessageById(messageId)
-      if messageItem == nil:
-        return ""
-
-      jsonObj = messageItem.toJsonNode();
-      if(jsonObj.isNil):
-        return ""
-    return $jsonObj
-
   proc getSectionId*(self: View): string {.slot.} =
     return self.delegate.getSectionId()
 
@@ -158,10 +145,6 @@ QtObject:
 
   proc leaveChat*(self: View) {.slot.} =
     self.delegate.leaveChat()
-
-  proc refreshAMessageUserRespondedTo(self: View, msgId: string) {.signal.}
-  proc emitRefreshAMessageUserRespondedToSignal*(self: View, msgId: string) =
-    self.refreshAMessageUserRespondedTo(msgId)
 
   proc jumpToMessage*(self: View, messageId: string) {.slot.} =
     self.delegate.scrollToMessage(messageId)

--- a/src/app/modules/main/chat_section/chat_content/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/module.nim
@@ -203,7 +203,8 @@ proc buildPinnedMessageItem(self: Module, messageId: string, actionInitiatedBy: 
     m.quotedMessage.`from`,
     m.quotedMessage.text,
     self.controller.getRenderedText(m.quotedMessage.parsedText),
-    m.quotedMessage.contentType
+    m.quotedMessage.contentType,
+    m.quotedMessage.deleted,
   )
   item.pinned = true
   item.pinnedBy = actionInitiatedBy

--- a/src/app/modules/main/chat_section/chat_content/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/module.nim
@@ -199,7 +199,11 @@ proc buildPinnedMessageItem(self: Module, messageId: string, actionInitiatedBy: 
     contactDetails.details.ensVerified,
     m.discordMessage,
     resendError = "",
-    m.mentioned
+    m.mentioned,
+    m.quotedMessage.`from`,
+    m.quotedMessage.text,
+    self.controller.getRenderedText(m.quotedMessage.parsedText),
+    m.quotedMessage.contentType
   )
   item.pinned = true
   item.pinnedBy = actionInitiatedBy

--- a/src/app/modules/shared_models/message_item.nim
+++ b/src/app/modules/shared_models/message_item.nim
@@ -44,6 +44,12 @@ type
     messageAttachments: seq[string]
     resendError: string
     mentioned: bool
+    quotedMessageFrom: string
+    quotedMessageText: string
+    quotedMessageParsedText: string
+    quotedMessageContentType: int
+    # This is only used to update the author's details when author's details change
+    quotedMessageFromIterator: int
 
 proc initItem*(
     id,
@@ -74,7 +80,11 @@ proc initItem*(
     senderEnsVerified: bool,
     discordMessage: DiscordMessage,
     resendError: string,
-    mentioned: bool
+    mentioned: bool,
+    quotedMessageFrom: string,
+    quotedMessageText: string,
+    quotedMessageParsedText: string,
+    quotedMessageContentType: int
     ): Item =
   result = Item()
   result.id = id
@@ -112,6 +122,11 @@ proc initItem*(
   result.messageAttachments = @[]
   result.resendError = resendError
   result.mentioned = mentioned
+  result.quotedMessageFrom = quotedMessageFrom
+  result.quotedMessageText = quotedMessageText
+  result.quotedMessageParsedText = quotedMessageParsedText
+  result.quotedMessageContentType = quotedMessageContentType
+  result.quotedMessageFromIterator = 0
 
   if ContentType.DiscordMessage == contentType:
     if result.messageText == "":
@@ -161,7 +176,11 @@ proc initNewMessagesMarkerItem*(clock, timestamp: int64): Item =
     senderEnsVerified = false,
     discordMessage = DiscordMessage(),
     resendError = "",
-    mentioned = false
+    mentioned = false,
+    quotedMessageFrom = "",
+    quotedMessageText = "",
+    quotedMessageParsedText = "",
+    quotedMessageContentType = -1
   )
 
 proc `$`*(self: Item): string =
@@ -378,7 +397,12 @@ proc toJsonNode*(self: Item): JsonNode =
     "links": self.links,
     "mentionedUsersPks": self.mentionedUsersPks,
     "senderEnsVerified": self.senderEnsVerified,
-    "resendError": self.resendError
+    "resendError": self.resendError,
+    "mentioned": self.mentioned,
+    "quotedMessageFrom": self.quotedMessageFrom,
+    "quotedMessageText": self.quotedMessageText,
+    "quotedMessageParsedText": self.quotedMessageParsedText,
+    "quotedMessageContentType": self.quotedMessageContentType,
   }
 
 proc editMode*(self: Item): bool {.inline.} =
@@ -410,3 +434,28 @@ proc mentioned*(self: Item): bool {.inline.} =
 
 proc `mentioned=`*(self: Item, value: bool) {.inline.} =
   self.mentioned = value
+
+proc quotedMessageFrom*(self: Item): string {.inline.} =
+  self.quotedMessageFrom
+proc `quotedMessageFrom=`*(self: Item, value: string) {.inline.} =
+  self.quotedMessageFrom = value
+
+proc quotedMessageText*(self: Item): string {.inline.} =
+  self.quotedMessageText
+proc `quotedMessageText=`*(self: Item, value: string) {.inline.} =
+  self.quotedMessageText = value
+
+proc quotedMessageParsedText*(self: Item): string {.inline.} =
+  self.quotedMessageParsedText
+proc `quotedMessageParsedText=`*(self: Item, value: string) {.inline.} =
+  self.quotedMessageParsedText = value
+
+proc quotedMessageContentType*(self: Item): int {.inline.} =
+  self.quotedMessageContentType
+proc `quotedMessageContentType=`*(self: Item, value: int) {.inline.} =
+  self.quotedMessageContentType = value
+
+proc quotedMessageFromIterator*(self: Item): int {.inline.} =
+  self.quotedMessageFromIterator
+proc `quotedMessageFromIterator=`*(self: Item, value: int) {.inline.} =
+  self.quotedMessageFromIterator = value

--- a/src/app/modules/shared_models/message_item.nim
+++ b/src/app/modules/shared_models/message_item.nim
@@ -48,6 +48,7 @@ type
     quotedMessageText: string
     quotedMessageParsedText: string
     quotedMessageContentType: int
+    quotedMessageDeleted: bool
     # This is only used to update the author's details when author's details change
     quotedMessageFromIterator: int
 
@@ -84,7 +85,8 @@ proc initItem*(
     quotedMessageFrom: string,
     quotedMessageText: string,
     quotedMessageParsedText: string,
-    quotedMessageContentType: int
+    quotedMessageContentType: int,
+    quotedMessageDeleted: bool,
     ): Item =
   result = Item()
   result.id = id
@@ -126,6 +128,7 @@ proc initItem*(
   result.quotedMessageText = quotedMessageText
   result.quotedMessageParsedText = quotedMessageParsedText
   result.quotedMessageContentType = quotedMessageContentType
+  result.quotedMessageDeleted = quotedMessageDeleted
   result.quotedMessageFromIterator = 0
 
   if ContentType.DiscordMessage == contentType:
@@ -180,7 +183,8 @@ proc initNewMessagesMarkerItem*(clock, timestamp: int64): Item =
     quotedMessageFrom = "",
     quotedMessageText = "",
     quotedMessageParsedText = "",
-    quotedMessageContentType = -1
+    quotedMessageContentType = -1,
+    quotedMessageDeleted = false,
   )
 
 proc `$`*(self: Item): string =
@@ -403,6 +407,7 @@ proc toJsonNode*(self: Item): JsonNode =
     "quotedMessageText": self.quotedMessageText,
     "quotedMessageParsedText": self.quotedMessageParsedText,
     "quotedMessageContentType": self.quotedMessageContentType,
+    "quotedMessageDeleted": self.quotedMessageDeleted,
   }
 
 proc editMode*(self: Item): bool {.inline.} =
@@ -454,6 +459,11 @@ proc quotedMessageContentType*(self: Item): int {.inline.} =
   self.quotedMessageContentType
 proc `quotedMessageContentType=`*(self: Item, value: int) {.inline.} =
   self.quotedMessageContentType = value
+
+proc quotedMessageDeleted*(self: Item): bool {.inline.} =
+  self.quotedMessageDeleted
+proc `quotedMessageDeleted=`*(self: Item, value: bool) {.inline.} =
+  self.quotedMessageDeleted = value
 
 proc quotedMessageFromIterator*(self: Item): int {.inline.} =
   self.quotedMessageFromIterator

--- a/src/app/modules/shared_models/message_item_qobject.nim
+++ b/src/app/modules/shared_models/message_item_qobject.nim
@@ -26,6 +26,22 @@ QtObject:
   QtProperty[string] responseToMessageWithId:
     read = responseToMessageWithId
 
+  proc quotedMessageFrom*(self: MessageItem): string {.slot.} = result = ?.self.messageItem.quotedMessageFrom
+  QtProperty[string] quotedMessageFrom:
+    read = quotedMessageFrom
+
+  proc quotedMessageText*(self: MessageItem): string {.slot.} = result = ?.self.messageItem.quotedMessageText
+  QtProperty[string] quotedMessageText:
+    read = quotedMessageText
+
+  proc quotedMessageParsedText*(self: MessageItem): string {.slot.} = result = ?.self.messageItem.quotedMessageParsedText
+  QtProperty[string] quotedMessageParsedText:
+    read = quotedMessageParsedText
+
+  proc quotedMessageContentType*(self: MessageItem): int {.slot.} = result = ?.self.messageItem.quotedMessageContentType
+  QtProperty[int] quotedMessageContentType:
+    read = quotedMessageContentType
+
   proc senderId*(self: MessageItem): string {.slot.} = result = ?.self.messageItem.senderId
   QtProperty[string] senderId:
     read = senderId

--- a/src/app/modules/shared_models/message_item_qobject.nim
+++ b/src/app/modules/shared_models/message_item_qobject.nim
@@ -42,6 +42,10 @@ QtObject:
   QtProperty[int] quotedMessageContentType:
     read = quotedMessageContentType
 
+  proc quotedMessageDeleted*(self: MessageItem): bool {.slot.} = result = ?.self.messageItem.quotedMessageDeleted
+  QtProperty[bool] quotedMessageDeleted:
+    read = quotedMessageDeleted
+
   proc senderId*(self: MessageItem): string {.slot.} = result = ?.self.messageItem.senderId
   QtProperty[string] senderId:
     read = senderId

--- a/src/app/modules/shared_models/message_model.nim
+++ b/src/app/modules/shared_models/message_model.nim
@@ -48,6 +48,7 @@ type
     QuotedMessageText
     QuotedMessageParsedText
     QuotedMessageContentType
+    QuotedMessageDeleted
     QuotedMessageFromIterator
 
 QtObject:
@@ -135,7 +136,8 @@ QtObject:
       ModelRole.QuotedMessageFromIterator.int: "quotedMessageFromIterator",
       ModelRole.QuotedMessageText.int: "quotedMessageText",
       ModelRole.QuotedMessageParsedText.int: "quotedMessageParsedText",
-      ModelRole.QuotedMessageContentType.int: "quotedMessageContentType"
+      ModelRole.QuotedMessageContentType.int: "quotedMessageContentType",
+      ModelRole.QuotedMessageDeleted.int: "quotedMessageDeleted",
     }.toTable
 
   method data(self: Model, index: QModelIndex, role: int): QVariant =
@@ -197,6 +199,8 @@ QtObject:
       result = newQVariant(item.quotedMessageParsedText)
     of ModelRole.QuotedMessageContentType:
       result = newQVariant(item.quotedMessageContentType)
+    of ModelRole.QuotedMessageDeleted:
+      result = newQVariant(item.quotedMessageDeleted)
     of ModelRole.MessageText:
       result = newQVariant(item.messageText)
     of ModelRole.MessageImage:
@@ -297,7 +301,7 @@ QtObject:
     for item in items:
       self.insertItemBasedOnClock(item)
 
-
+  # Replied message was deleted
   proc updateMessagesWithResponseTo(self: Model, messageId: string) =
     for i in 0 ..< self.items.len:
       if(self.items[i].responseToMessageWithId == messageId):
@@ -306,7 +310,13 @@ QtObject:
         item.quotedMessageText = ""
         item.quotedMessageParsedText = ""
         item.quotedMessageFrom = ""
-        self.dataChanged(ind, ind, @[ModelRole.QuotedMessageFrom.int, ModelRole.QuotedMessageParsedText.int, ModelRole.QuotedMessageContentType.int])
+        item.quotedMessageDeleted = true
+        self.dataChanged(ind, ind, @[
+          ModelRole.QuotedMessageFrom.int,
+          ModelRole.QuotedMessageParsedText.int,
+          ModelRole.QuotedMessageContentType.int,
+          ModelRole.QuotedMessageDeleted.int,
+        ])
 
   proc removeItem*(self: Model, messageId: string) =
     let ind = self.findIndexForMessageId(messageId)

--- a/src/app/modules/shared_models/message_model.nim
+++ b/src/app/modules/shared_models/message_model.nim
@@ -44,6 +44,11 @@ type
     MessageAttachments
     ResendError
     Mentioned
+    QuotedMessageFrom
+    QuotedMessageText
+    QuotedMessageParsedText
+    QuotedMessageContentType
+    QuotedMessageFromIterator
 
 QtObject:
   type
@@ -125,7 +130,12 @@ QtObject:
       ModelRole.MentionedUsersPks.int: "mentionedUsersPks",
       ModelRole.SenderTrustStatus.int: "senderTrustStatus",
       ModelRole.SenderEnsVerified.int: "senderEnsVerified",
-      ModelRole.MessageAttachments.int: "messageAttachments"
+      ModelRole.MessageAttachments.int: "messageAttachments",
+      ModelRole.QuotedMessageFrom.int: "quotedMessageFrom",
+      ModelRole.QuotedMessageFromIterator.int: "quotedMessageFromIterator",
+      ModelRole.QuotedMessageText.int: "quotedMessageText",
+      ModelRole.QuotedMessageParsedText.int: "quotedMessageParsedText",
+      ModelRole.QuotedMessageContentType.int: "quotedMessageContentType"
     }.toTable
 
   method data(self: Model, index: QModelIndex, role: int): QVariant =
@@ -177,6 +187,16 @@ QtObject:
       result = newQVariant(item.resendError)
     of ModelRole.Mentioned:
       result = newQVariant(item.mentioned)
+    of ModelRole.QuotedMessageFrom:
+      result = newQVariant(item.quotedMessageFrom)
+    of ModelRole.QuotedMessageFromIterator:
+      result = newQVariant(item.quotedMessageFromIterator)
+    of ModelRole.QuotedMessageText:
+      result = newQVariant(item.quotedMessageText)
+    of ModelRole.QuotedMessageParsedText:
+      result = newQVariant(item.quotedMessageParsedText)
+    of ModelRole.QuotedMessageContentType:
+      result = newQVariant(item.quotedMessageContentType)
     of ModelRole.MessageText:
       result = newQVariant(item.messageText)
     of ModelRole.MessageImage:
@@ -277,13 +297,16 @@ QtObject:
     for item in items:
       self.insertItemBasedOnClock(item)
 
-  proc replyDeleted*(self: Model, messageIndex: int) {.signal.}
 
   proc updateMessagesWithResponseTo(self: Model, messageId: string) =
     for i in 0 ..< self.items.len:
       if(self.items[i].responseToMessageWithId == messageId):
         let ind = self.createIndex(i, 0, nil)
-        self.replyDeleted(i)
+        var item = self.items[i]
+        item.quotedMessageText = ""
+        item.quotedMessageParsedText = ""
+        item.quotedMessageFrom = ""
+        self.dataChanged(ind, ind, @[ModelRole.QuotedMessageFrom.int, ModelRole.QuotedMessageParsedText.int, ModelRole.QuotedMessageContentType.int])
 
   proc removeItem*(self: Model, messageId: string) =
     let ind = self.findIndexForMessageId(messageId)
@@ -389,12 +412,6 @@ QtObject:
       return
     self.items[index].toJsonNode()
 
-  proc updateContactInReplies(self: Model, messageId: string) =
-    for i in 0 ..< self.items.len:
-      if (self.items[i].responseToMessageWithId == messageId):
-        let index = self.createIndex(i, 0, nil)
-        self.dataChanged(index, index, @[ModelRole.ResponseToMessageWithId.int])
-
   iterator modelContactUpdateIterator*(self: Model, contactId: string): Item =
     for i in 0 ..< self.items.len:
       yield self.items[i]
@@ -412,10 +429,15 @@ QtObject:
       if(self.items[i].messageContainsMentions):
         roles.add(@[ModelRole.MessageText.int, ModelRole.MessageContainsMentions.int])
 
+      if (self.items[i].quotedMessageFrom == contactId):
+        # If there is a quoted message whom the author changed, increase the iterator to force
+        # the view to re-fetch the author's details
+        self.items[i].quotedMessageFromIterator = self.items[i].quotedMessageFromIterator + 1
+        roles.add(ModelRole.QuotedMessageFromIterator.int)
+
       if(roles.len > 0):
         let index = self.createIndex(i, 0, nil)
         self.dataChanged(index, index, roles)
-        self.updateContactInReplies(self.items[i].id)
 
   proc setEditModeOn*(self: Model, messageId: string)  =
     let ind = self.findIndexForMessageId(messageId)
@@ -441,6 +463,8 @@ QtObject:
       self: Model,
       messageId: string,
       updatedMsg: string,
+      updatedRawMsg: string,
+      contentType: int,
       messageContainsMentions: bool,
       links: seq[string],
       mentionedUsersPks: seq[string]
@@ -464,7 +488,18 @@ QtObject:
       ModelRole.MentionedUsersPks.int
       ])
 
-    self.updateContactInReplies(messageId)
+    # Update replied to messages if there are
+    for i in 0 ..< self.items.len:
+      if(self.items[i].responseToMessageWithId == messageId):
+        self.items[i].quotedMessageParsedText = updatedMsg
+        self.items[i].quotedMessageText = updatedRawMsg
+        self.items[i].quotedMessageContentType = contentType
+        let index = self.createIndex(i, 0, nil)
+        self.dataChanged(index, index, @[
+          ModelRole.QuotedMessageText.int,
+          ModelRole.QuotedMessageParsedText.int,
+          ModelRole.QuotedMessageContentType.int,
+        ])  
 
   proc clear*(self: Model) =
     self.beginResetModel()

--- a/src/app_service/service/message/dto/message.nim
+++ b/src/app_service/service/message/dto/message.nim
@@ -36,6 +36,7 @@ type QuotedMessage* = object
   text*: string
   parsedText*: seq[ParsedText]
   contentType*: int
+  deleted*: bool
 
 type DiscordMessageAttachment* = object
   id*: string
@@ -164,6 +165,7 @@ proc toQuotedMessage*(jsonObj: JsonNode): QuotedMessage =
   discard jsonObj.getProp("from", result.`from`)
   discard jsonObj.getProp("text", result.text)
   discard jsonObj.getProp("contentType", result.contentType)
+  discard jsonObj.getProp("deleted", result.deleted)
 
   var parsedTextArr: JsonNode
   if(jsonObj.getProp("parsedText", parsedTextArr) and parsedTextArr.kind == JArray):

--- a/src/app_service/service/message/dto/message.nim
+++ b/src/app_service/service/message/dto/message.nim
@@ -35,6 +35,7 @@ type QuotedMessage* = object
   `from`*: string
   text*: string
   parsedText*: seq[ParsedText]
+  contentType*: int
 
 type DiscordMessageAttachment* = object
   id*: string
@@ -160,8 +161,9 @@ proc toDiscordMessage*(jsonObj: JsonNode): DiscordMessage =
 
 proc toQuotedMessage*(jsonObj: JsonNode): QuotedMessage =
   result = QuotedMessage()
-  discard jsonObj.getProp("from", result.from)
+  discard jsonObj.getProp("from", result.`from`)
   discard jsonObj.getProp("text", result.text)
+  discard jsonObj.getProp("contentType", result.contentType)
 
   var parsedTextArr: JsonNode
   if(jsonObj.getProp("parsedText", parsedTextArr) and parsedTextArr.kind == JArray):

--- a/test/nim/message_model_test.nim
+++ b/test/nim/message_model_test.nim
@@ -38,7 +38,11 @@ proc createTestMessageItem(id: string, clock: int64): Item =
     senderEnsVerified = false,
     discordMessage = DiscordMessage(),
     resendError = "",
-    mentioned = false
+    mentioned = false,
+    quotedMessageFrom = "",
+    quotedMessageText = "",
+    quotedMessageParsedText = "",
+    quotedMessageContentType = -1
   )
 
 let message0_chatIdentifier = createTestMessageItem("chat-identifier", -2)

--- a/test/ui-test/testSuites/suite_wallet/tst_wallet/test.feature
+++ b/test/ui-test/testSuites/suite_wallet/tst_wallet/test.feature
@@ -17,6 +17,7 @@ Feature: Status Desktop Wallet
         Given the user opens wallet screen
         And the user clicks on the first account
 
+    @mayfail
 	Scenario: The user can manage and observe a watch only account
         When the user adds watch only account "0xea123F7beFF45E3C9fdF54B324c29DBdA14a639A" named "AccountWatch"
         Then the new account "AccountWatch" is added

--- a/ui/app/AppLayouts/Chat/stores/MessageStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/MessageStore.qml
@@ -50,28 +50,6 @@ QtObject {
         return obj
     }
 
-    function getReplyMessageByIdAsJson(messageId: string) {
-        if (!messageModule) {
-            console.warn("getReplyMessageByIdAsJson: Failed to parse message, because messageModule is not set")
-            return false
-        }
-
-        const jsonObj = messageModule.getReplyMessageByIdAsJson(messageId)
-        if (jsonObj === "") {
-            console.warn("getReplyMessageByIdAsJson: Failed to get message, returned json is empty")
-            return undefined
-        }
-
-        const obj = JSON.parse(jsonObj)
-        if (obj.error) {
-            // This log is available only in debug mode, if it's annoying we can remove it
-            console.debug("getReplyMessageByIdAsJson: Failed to parse message for index: ", messageId, " error: ", obj.error)
-            return false
-        }
-
-        return obj
-    }
-
     function getMessageByIndexAsJson (index) {
         if(!messageModule)
             return false

--- a/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
@@ -271,6 +271,7 @@ Item {
             quotedMessageFrom: model.quotedMessageFrom
             quotedMessageContentType: model.quotedMessageContentType
             quotedMessageFromIterator: model.quotedMessageFromIterator
+            quotedMessageDeleted: model.quotedMessageDeleted
 
             gapFrom: model.gapFrom
             gapTo: model.gapTo

--- a/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
@@ -218,25 +218,6 @@ Item {
             }
         }
 
-        Connections {
-            target: chatLogView.model || null
-            function onDataChanged(topLeft, bottomRight, roles) {
-                if (roles.indexOf(Constants.messageModelRoles.responseToMessageWithId) !== -1) {
-                    let item = chatLogView.itemAtIndex(topLeft.row)
-                    if (item) {
-                        item.updateReplyInfo()
-                    }
-                }
-            }
-
-            function onReplyDeleted(messageIndex) {
-                let item = chatLogView.itemAtIndex(messageIndex)
-                if (item) {
-                    item.replyDeleted()
-                }
-            }
-        }
-
         delegate: MessageView {
             id: msgDelegate
 
@@ -286,6 +267,10 @@ Item {
             messageAttachments: model.messageAttachments
             transactionParams: model.transactionParameters
             hasMention: model.mentioned
+            quotedMessageText: model.quotedMessageParsedText
+            quotedMessageFrom: model.quotedMessageFrom
+            quotedMessageContentType: model.quotedMessageContentType
+            quotedMessageFromIterator: model.quotedMessageFromIterator
 
             gapFrom: model.gapFrom
             gapTo: model.gapTo

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -65,6 +65,7 @@ Loader {
     property string quotedMessageFrom: ""
     property int quotedMessageContentType: Constants.messageContentType.messageType
     property int quotedMessageFromIterator: -1
+    property bool quotedMessageDeleted: false
     property var quotedMessageAuthorDetails: quotedMessageFromIterator >= 0 && Utils.getContactDetailsAsJson(quotedMessageFrom, false)
 
     // External behavior changers
@@ -609,8 +610,15 @@ Loader {
                 }
 
                 replyDetails: StatusMessageDetails {
-                    messageText: root.quotedMessageText ? root.quotedMessageText
-                                                       : qsTr("Message deleted")
+                    messageText: {
+                        if (root.quotedMessageDeleted) {
+                            return qsTr("Message deleted")
+                        }
+                        if (!root.quotedMessageText) {
+                            return qsTr("Unknown message. Try fetching more messages")
+                        }
+                        return root.quotedMessageText
+                    }
                     contentType: delegate.convertContentType(root.quotedMessageContentType)
                     messageContent: {
                         if (contentType !== StatusMessage.ContentType.Sticker && contentType !== StatusMessage.ContentType.Image) {

--- a/ui/imports/utils/Utils.qml
+++ b/ui/imports/utils/Utils.qml
@@ -538,7 +538,7 @@ QtObject {
             incomingVerificationStatus: Constants.verificationStatus.unverified
         }
 
-        if (!mainModuleInst)
+        if (!mainModuleInst || !publicKey)
             return defaultValue
 
         const jsonObj = mainModuleInst.getContactDetailsAsJson(publicKey, getVerificationRequest)


### PR DESCRIPTION
Fixes [#7754](https://github.com/status-im/status-desktop/issues/7754)

Uses the already available QuotedMessage data that comes with the Message to show the replied message instead of fetching it using JSON. It's cleaner, less error prone (fixes the issue above) and is way faster.

~~I put this as a Draft because I still need to figure out what to do with deletions of original messages. I can set it as `deleted` when we receive the signal, but if I restart, the message is back, because status-go doesn't handle the og message deletion in the QuotedMessage section.
I need to figure out if that's a bug or if it's intended.~~

The bug has been fixed in status-go. Here is the PR: https://github.com/status-im/status-go/pull/3054