### PR TITLE
fix (ActivityCenter): Fix AC notification text formatting

### DIFF
--- a/ui/app/mainui/activitycenter/views/ActivityNotificationMessage.qml
+++ b/ui/app/mainui/activitycenter/views/ActivityNotificationMessage.qml
@@ -2,7 +2,6 @@ import QtQuick 2.14
 import QtQuick.Layouts 1.14
 
 import StatusQ.Core 0.1
-import StatusQ.Core.Utils 0.1 as CoreUtils
 import StatusQ.Core.Theme 0.1
 import StatusQ.Components 0.1
 
@@ -110,7 +109,7 @@ ActivityNotificationBase {
                     Layout.fillWidth: true
 
                     StatusBaseText {
-                        text: CoreUtils.Utils.stripHtmlTags(root.messageDetails.messageText)
+                        text: Utils.unescapeHtml(root.messageDetails.messageText)
                         maximumLineCount: root.maximumLineCount
                         wrapMode: Text.Wrap
                         elide: Text.ElideRight

--- a/ui/imports/utils/Utils.qml
+++ b/ui/imports/utils/Utils.qml
@@ -730,14 +730,21 @@ QtObject {
         return (str.length > maxLength) ? str.substr(0, maxLength-4) + '...' : str;
     }
 
-    function escapeHtml(unsafeStr)
-    {
+    function escapeHtml(unsafeStr) {
         return unsafeStr
             .replace(/&/g, "&amp;")
             .replace(/</g, "&lt;")
             .replace(/>/g, "&gt;")
             .replace(/"/g, "&quot;")
             .replace(/'/g, "&#039;");
+    }
+
+    function unescapeHtml(safeStr) {
+        return safeStr.replace(/&amp;/g, '&')
+            .replace(/&lt;/g, '<')
+            .replace(/&gt;/g, '>')
+            .replace(/&quot;/g, '"')
+            .replace(/&#039;/g, "'");
     }
 
     function isInvalidPasswordMessage(msg) {


### PR DESCRIPTION
Close #8387

### What does the PR do

Add unescapeHtml func to avoid amps in ac notifications

### Affected areas

ActivityCenter

### Screenshot of functionality (including design for comparison)

<img width="540" alt="Screenshot 2022-12-28 at 16 43 44" src="https://user-images.githubusercontent.com/2522130/209814774-ffd22b38-7094-4618-a239-dde342cbbfd0.png">
