### PR TITLE
fix(@desktop/profile): do not show store password to keychain dialog during saving Bio with enabled biometrics

### DIFF
--- a/ui/app/AppLayouts/Profile/views/profile/MyProfileSettingsView.qml
+++ b/ui/app/AppLayouts/Profile/views/profile/MyProfileSettingsView.qml
@@ -67,9 +67,10 @@ ColumnLayout {
                                      (profileHeader.cropRect.x + profileHeader.cropRect.width).toFixed(),
                                      (profileHeader.cropRect.y + profileHeader.cropRect.height).toFixed());
         }
-        if (biometricsSwitch.checked)
+
+        if (biometricsSwitch.checked && !biometricsSwitch.currentStoredValue)
             Global.openPopup(storePasswordModal)
-        else
+        else if (!biometricsSwitch.checked)
             localAccountSettings.storeToKeychainValue = Constants.keychain.storedValue.never;
 
         reset()


### PR DESCRIPTION
### What does the PR do

Fixed saving Profile changes with enabled Biometrics. Do not show store password popup if biometrics toggle was not enabled

Fixes: #8843

### Affected areas

Saving biometrics profile settings

### Cool Spaceship Picture

![download](https://user-images.githubusercontent.com/117639195/209358410-0ce72152-e94e-4aff-999b-4eeb80eb6700.jpeg)

