### PR TITLE
feature(@desktop/keycard): import or restore a Keycard via a seed phrase

### DIFF
--- a/src/app/modules/main/profile_section/keycard/module.nim
+++ b/src/app/modules/main/profile_section/keycard/module.nim
@@ -122,7 +122,10 @@ method runCreateNewKeycardWithNewSeedPhrasePopup*(self: Module) =
   self.keycardSharedModule.runFlow(keycard_shared_module.FlowType.SetupNewKeycardNewSeedPhrase)
 
 method runImportOrRestoreViaSeedPhrasePopup*(self: Module) =
-  info "TODO: Import or restore via a seed phrase..."
+  self.createSharedKeycardModule()
+  if self.keycardSharedModule.isNil:
+    return
+  self.keycardSharedModule.runFlow(keycard_shared_module.FlowType.SetupNewKeycardOldSeedPhrase)
   
 method runImportFromKeycardToAppPopup*(self: Module) =
   info "TODO: Import from Keycard to Status Desktop..."

--- a/src/app/modules/shared_modules/keycard_popup/controller.nim
+++ b/src/app/modules/shared_modules/keycard_popup/controller.nim
@@ -1,4 +1,4 @@
-import chronicles, strutils, os
+import chronicles, strutils, os, sequtils, sugar
 import uuids
 import io_interface
 
@@ -176,6 +176,9 @@ proc setContainsMetadata*(self: Controller, value: bool) =
 
 proc setKeyPairForProcessing*(self: Controller, item: KeyPairItem) =
   self.delegate.setKeyPairForProcessing(item)
+
+proc prepareKeyPairForProcessing*(self: Controller, keyUid: string) =
+  self.delegate.prepareKeyPairForProcessing(keyUid)
 
 proc getKeyPairForProcessing*(self: Controller): KeyPairItem =
   return self.delegate.getKeyPairForProcessing()
@@ -516,6 +519,11 @@ proc getWalletAccounts*(self: Controller): seq[wallet_account_service.WalletAcco
     return
   return self.walletAccountService.fetchAccounts()
 
+proc isKeyPairAlreadyAdded*(self: Controller, keyUid: string): bool =
+  let walletAccounts = self.getWalletAccounts()
+  let accountsForKeyUid = walletAccounts.filter(a => a.keyUid == keyUid)
+  return accountsForKeyUid.len > 0
+
 proc getCurrencyBalanceForAddress*(self: Controller, address: string): float64 =
   if not serviceApplicable(self.walletAccountService):
     return
@@ -531,6 +539,11 @@ proc addMigratedKeyPair*(self: Controller, keyPair: KeyPairDto) =
 
 proc getAddingMigratedKeypairSuccess*(self: Controller): bool =
   return self.tmpAddingMigratedKeypairSuccess
+
+proc getMigratedKeyPairByKeyUid*(self: Controller, keyUid: string): seq[KeyPairDto] =
+  if not serviceApplicable(self.walletAccountService):
+    return
+  return self.walletAccountService.getMigratedKeyPairByKeyUid(keyUid)
 
 proc getAllMigratedKeyPairs*(self: Controller): seq[KeyPairDto] =
   if not serviceApplicable(self.walletAccountService):

--- a/src/app/modules/shared_modules/keycard_popup/internal/create_pin_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/create_pin_state.nim
@@ -18,6 +18,7 @@ method executePreBackStateCommand*(self: CreatePinState, controller: Controller)
 method executeCancelCommand*(self: CreatePinState, controller: Controller) =
   if self.flowType == FlowType.SetupNewKeycard or
     self.flowType == FlowType.SetupNewKeycardNewSeedPhrase or
+    self.flowType == FlowType.SetupNewKeycardOldSeedPhrase or
     self.flowType == FlowType.UnlockKeycard or
     self.flowType == FlowType.ChangeKeycardPin:
       controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)
@@ -25,6 +26,7 @@ method executeCancelCommand*(self: CreatePinState, controller: Controller) =
 method getNextSecondaryState*(self: CreatePinState, controller: Controller): State =
   if self.flowType == FlowType.SetupNewKeycard or
     self.flowType == FlowType.SetupNewKeycardNewSeedPhrase or
+    self.flowType == FlowType.SetupNewKeycardOldSeedPhrase or
     self.flowType == FlowType.UnlockKeycard or
     self.flowType == FlowType.ChangeKeycardPin:
       if controller.getPin().len == PINLengthForStatusApp:

--- a/src/app/modules/shared_modules/keycard_popup/internal/enter_keycard_name_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/enter_keycard_name_state.nim
@@ -13,10 +13,12 @@ proc delete*(self: EnterKeycardNameState) =
 method getNextPrimaryState*(self: EnterKeycardNameState, controller: Controller): State =
   if self.flowType == FlowType.RenameKeycard:
     return createState(StateType.RenamingKeycard, self.flowType, nil)
-  if self.flowType == FlowType.SetupNewKeycardNewSeedPhrase:
-    return createState(StateType.ManageKeycardAccounts, self.flowType, self)
+  if self.flowType == FlowType.SetupNewKeycardNewSeedPhrase or
+    self.flowType == FlowType.SetupNewKeycardOldSeedPhrase:
+      return createState(StateType.ManageKeycardAccounts, self.flowType, self)
 
 method executeCancelCommand*(self: EnterKeycardNameState, controller: Controller) =
   if self.flowType == FlowType.RenameKeycard or
-    self.flowType == FlowType.SetupNewKeycardNewSeedPhrase:
+    self.flowType == FlowType.SetupNewKeycardNewSeedPhrase or
+    self.flowType == FlowType.SetupNewKeycardOldSeedPhrase:
       controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)

--- a/src/app/modules/shared_modules/keycard_popup/internal/factory_reset_confirmation_displayed_metadata_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/factory_reset_confirmation_displayed_metadata_state.nim
@@ -13,6 +13,7 @@ method executePrePrimaryStateCommand*(self: FactoryResetConfirmationDisplayMetad
     controller.runGetAppInfoFlow(factoryReset = true)
   elif self.flowType == FlowType.SetupNewKeycard or
     self.flowType == FlowType.SetupNewKeycardNewSeedPhrase or
+    self.flowType == FlowType.SetupNewKeycardOldSeedPhrase or
     self.flowType == FlowType.CreateCopyOfAKeycard:
       controller.setKeycardData(updatePredefinedKeycardData(controller.getKeycardData(), PredefinedKeycardData.HideKeyPair, add = true))
       controller.runGetAppInfoFlow(factoryReset = true)
@@ -21,6 +22,7 @@ method executeCancelCommand*(self: FactoryResetConfirmationDisplayMetadataState,
   if self.flowType == FlowType.FactoryReset or
     self.flowType == FlowType.SetupNewKeycard or
     self.flowType == FlowType.SetupNewKeycardNewSeedPhrase or
+    self.flowType == FlowType.SetupNewKeycardOldSeedPhrase or
     self.flowType == FlowType.CreateCopyOfAKeycard:
       controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)
 

--- a/src/app/modules/shared_modules/keycard_popup/internal/factory_reset_confirmation_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/factory_reset_confirmation_state.nim
@@ -13,6 +13,7 @@ method executePrePrimaryStateCommand*(self: FactoryResetConfirmationState, contr
     controller.runGetAppInfoFlow(factoryReset = true)
   elif self.flowType == FlowType.SetupNewKeycard or
     self.flowType == FlowType.SetupNewKeycardNewSeedPhrase or
+    self.flowType == FlowType.SetupNewKeycardOldSeedPhrase or
     self.flowType == FlowType.CreateCopyOfAKeycard:
       controller.setKeycardData(updatePredefinedKeycardData(controller.getKeycardData(), PredefinedKeycardData.HideKeyPair, add = true))
       controller.runGetAppInfoFlow(factoryReset = true)
@@ -21,6 +22,7 @@ method executeCancelCommand*(self: FactoryResetConfirmationState, controller: Co
   if self.flowType == FlowType.FactoryReset or
     self.flowType == FlowType.SetupNewKeycard or
     self.flowType == FlowType.SetupNewKeycardNewSeedPhrase or
+    self.flowType == FlowType.SetupNewKeycardOldSeedPhrase or
     self.flowType == FlowType.CreateCopyOfAKeycard:
       controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)
 

--- a/src/app/modules/shared_modules/keycard_popup/internal/factory_reset_success_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/factory_reset_success_state.nim
@@ -14,8 +14,9 @@ method executePrePrimaryStateCommand*(self: FactoryResetSuccessState, controller
   elif self.flowType == FlowType.SetupNewKeycard:
     controller.setSelectedKeypairAsKeyPairForProcessing() # we need to update keypair for next state (e.g. if user run into factory reset for example)
     controller.runLoadAccountFlow()
-  elif self.flowType == FlowType.SetupNewKeycardNewSeedPhrase:
-    controller.runLoadAccountFlow()
+  elif self.flowType == FlowType.SetupNewKeycardNewSeedPhrase or
+    self.flowType == FlowType.SetupNewKeycardOldSeedPhrase:
+      controller.runLoadAccountFlow()
   elif self.flowType == FlowType.CreateCopyOfAKeycard:
     controller.setMetadataFromKeycard(controller.getMetadataForKeycardCopy()) # we need to update keypair for next state
     controller.runLoadAccountFlow(seedPhraseLength = 0, seedPhrase = "", pin = controller.getPinForKeycardCopy())
@@ -23,6 +24,7 @@ method executePrePrimaryStateCommand*(self: FactoryResetSuccessState, controller
 method executeCancelCommand*(self: FactoryResetSuccessState, controller: Controller) =
   if self.flowType == FlowType.SetupNewKeycard or
     self.flowType == FlowType.SetupNewKeycardNewSeedPhrase or
+    self.flowType == FlowType.SetupNewKeycardOldSeedPhrase or
     self.flowType == FlowType.CreateCopyOfAKeycard:
       controller.terminateCurrentFlow(lastStepInTheCurrentFlow = true)
 

--- a/src/app/modules/shared_modules/keycard_popup/internal/insert_keycard_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/insert_keycard_state.nim
@@ -17,6 +17,7 @@ method executeCancelCommand*(self: InsertKeycardState, controller: Controller) =
   if self.flowType == FlowType.FactoryReset or
     self.flowType == FlowType.SetupNewKeycard or
     self.flowType == FlowType.SetupNewKeycardNewSeedPhrase or
+    self.flowType == FlowType.SetupNewKeycardOldSeedPhrase or
     self.flowType == FlowType.Authentication or
     self.flowType == FlowType.UnlockKeycard or
     self.flowType == FlowType.DisplayKeycardContent or

--- a/src/app/modules/shared_modules/keycard_popup/internal/keycard_create_account_old_seed_phrase_failure_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/keycard_create_account_old_seed_phrase_failure_state.nim
@@ -1,0 +1,17 @@
+type
+  CreatingAccountOldSeedPhraseFailureState* = ref object of State
+
+proc newCreatingAccountOldSeedPhraseFailureState*(flowType: FlowType, backState: State): CreatingAccountOldSeedPhraseFailureState =
+  result = CreatingAccountOldSeedPhraseFailureState()
+  result.setup(flowType, StateType.CreatingAccountOldSeedPhraseFailure, backState)
+
+proc delete*(self: CreatingAccountOldSeedPhraseFailureState) =
+  self.State.delete
+
+method executePrePrimaryStateCommand*(self: CreatingAccountOldSeedPhraseFailureState, controller: Controller) =
+  if self.flowType == FlowType.SetupNewKeycardOldSeedPhrase:
+    controller.terminateCurrentFlow(lastStepInTheCurrentFlow = true)
+
+method executeCancelCommand*(self: CreatingAccountOldSeedPhraseFailureState, controller: Controller) =
+  if self.flowType == FlowType.SetupNewKeycardOldSeedPhrase:
+    controller.terminateCurrentFlow(lastStepInTheCurrentFlow = true)

--- a/src/app/modules/shared_modules/keycard_popup/internal/keycard_create_account_old_seed_phrase_success_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/keycard_create_account_old_seed_phrase_success_state.nim
@@ -1,0 +1,17 @@
+type
+  CreatingAccountOldSeedPhraseSuccessState* = ref object of State
+
+proc newCreatingAccountOldSeedPhraseSuccessState*(flowType: FlowType, backState: State): CreatingAccountOldSeedPhraseSuccessState =
+  result = CreatingAccountOldSeedPhraseSuccessState()
+  result.setup(flowType, StateType.CreatingAccountOldSeedPhraseSuccess, backState)
+
+proc delete*(self: CreatingAccountOldSeedPhraseSuccessState) =
+  self.State.delete
+
+method executePrePrimaryStateCommand*(self: CreatingAccountOldSeedPhraseSuccessState, controller: Controller) =
+  if self.flowType == FlowType.SetupNewKeycardOldSeedPhrase:
+    controller.terminateCurrentFlow(lastStepInTheCurrentFlow = true)
+
+method executeCancelCommand*(self: CreatingAccountOldSeedPhraseSuccessState, controller: Controller) =
+  if self.flowType == FlowType.SetupNewKeycardOldSeedPhrase:
+    controller.terminateCurrentFlow(lastStepInTheCurrentFlow = true)

--- a/src/app/modules/shared_modules/keycard_popup/internal/keycard_empty_metadata_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/keycard_empty_metadata_state.nim
@@ -12,6 +12,7 @@ method executeCancelCommand*(self: KeycardEmptyMetadataState, controller: Contro
   if self.flowType == FlowType.FactoryReset or
     self.flowType == FlowType.SetupNewKeycard or
     self.flowType == FlowType.SetupNewKeycardNewSeedPhrase or
+    self.flowType == FlowType.SetupNewKeycardOldSeedPhrase or
     self.flowType == FlowType.DisplayKeycardContent or
     self.flowType == FlowType.RenameKeycard or
     self.flowType == FlowType.CreateCopyOfAKeycard:
@@ -28,7 +29,8 @@ method executePrePrimaryStateCommand*(self: KeycardEmptyMetadataState, controlle
 method getNextPrimaryState*(self: KeycardEmptyMetadataState, controller: Controller): State =
   if self.flowType == FlowType.FactoryReset or
     self.flowType == FlowType.SetupNewKeycard or
-    self.flowType == FlowType.SetupNewKeycardNewSeedPhrase:
+    self.flowType == FlowType.SetupNewKeycardNewSeedPhrase or
+    self.flowType == FlowType.SetupNewKeycardOldSeedPhrase:
       return createState(StateType.FactoryResetConfirmation, self.flowType, self)
   if self.flowType == FlowType.CreateCopyOfAKeycard:
     if isPredefinedKeycardDataFlagSet(controller.getKeycardData(), PredefinedKeycardData.CopyFromAKeycardPartDone):

--- a/src/app/modules/shared_modules/keycard_popup/internal/keycard_inserted_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/keycard_inserted_state.nim
@@ -24,6 +24,7 @@ method executeCancelCommand*(self: KeycardInsertedState, controller: Controller)
   if self.flowType == FlowType.FactoryReset or
     self.flowType == FlowType.SetupNewKeycard or
     self.flowType == FlowType.SetupNewKeycardNewSeedPhrase or
+    self.flowType == FlowType.SetupNewKeycardOldSeedPhrase or
     self.flowType == FlowType.Authentication or
     self.flowType == FlowType.UnlockKeycard or
     self.flowType == FlowType.DisplayKeycardContent or

--- a/src/app/modules/shared_modules/keycard_popup/internal/keycard_metadata_display_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/keycard_metadata_display_state.nim
@@ -11,7 +11,8 @@ proc delete*(self: KeycardMetadataDisplayState) =
 method getNextPrimaryState*(self: KeycardMetadataDisplayState, controller: Controller): State =
   if self.flowType == FlowType.FactoryReset or
     self.flowType == FlowType.SetupNewKeycard or
-    self.flowType == FlowType.SetupNewKeycardNewSeedPhrase:
+    self.flowType == FlowType.SetupNewKeycardNewSeedPhrase or
+    self.flowType == FlowType.SetupNewKeycardOldSeedPhrase:
       return createState(StateType.FactoryResetConfirmationDisplayMetadata, self.flowType, self)
   if self.flowType == FlowType.DisplayKeycardContent:
     controller.terminateCurrentFlow(lastStepInTheCurrentFlow = true)
@@ -31,6 +32,7 @@ method executeCancelCommand*(self: KeycardMetadataDisplayState, controller: Cont
   if self.flowType == FlowType.FactoryReset or
     self.flowType == FlowType.SetupNewKeycard or
     self.flowType == FlowType.SetupNewKeycardNewSeedPhrase or
+    self.flowType == FlowType.SetupNewKeycardOldSeedPhrase or
     self.flowType == FlowType.DisplayKeycardContent or
     self.flowType == FlowType.RenameKeycard or
     self.flowType == FlowType.CreateCopyOfAKeycard:

--- a/src/app/modules/shared_modules/keycard_popup/internal/keycard_not_empty_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/keycard_not_empty_state.nim
@@ -10,7 +10,8 @@ proc delete*(self: KeycardNotEmptyState) =
 
 method executePrePrimaryStateCommand*(self: KeycardNotEmptyState, controller: Controller) =
   if self.flowType == FlowType.SetupNewKeycard or
-    self.flowType == FlowType.SetupNewKeycardNewSeedPhrase:
+    self.flowType == FlowType.SetupNewKeycardNewSeedPhrase or
+    self.flowType == FlowType.SetupNewKeycardOldSeedPhrase:
       controller.setKeycardData(updatePredefinedKeycardData(controller.getKeycardData(), PredefinedKeycardData.HideKeyPair, add = true))
       controller.runGetMetadataFlow(resolveAddress = true)
       return
@@ -22,6 +23,7 @@ method executePrePrimaryStateCommand*(self: KeycardNotEmptyState, controller: Co
 method executeCancelCommand*(self: KeycardNotEmptyState, controller: Controller) =
   if self.flowType == FlowType.SetupNewKeycard or
     self.flowType == FlowType.SetupNewKeycardNewSeedPhrase or
+    self.flowType == FlowType.SetupNewKeycardOldSeedPhrase or
     self.flowType == FlowType.CreateCopyOfAKeycard:
       controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)
 

--- a/src/app/modules/shared_modules/keycard_popup/internal/manage_keycard_accounts_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/manage_keycard_accounts_state.nim
@@ -13,11 +13,15 @@ proc delete*(self: ManageKeycardAccountsState) =
 method getNextPrimaryState*(self: ManageKeycardAccountsState, controller: Controller): State =
   if self.flowType == FlowType.SetupNewKeycardNewSeedPhrase:
     return createState(StateType.CreatingAccountNewSeedPhrase, self.flowType, nil)
+  if self.flowType == FlowType.SetupNewKeycardOldSeedPhrase:
+    return createState(StateType.CreatingAccountOldSeedPhrase, self.flowType, nil)
 
 method executePreSecondaryStateCommand*(self: ManageKeycardAccountsState, controller: Controller) =
-  if self.flowType == FlowType.SetupNewKeycardNewSeedPhrase:
-    controller.getKeyPairForProcessing().addAccount(newKeyPairAccountItem())
+  if self.flowType == FlowType.SetupNewKeycardNewSeedPhrase or
+    self.flowType == FlowType.SetupNewKeycardOldSeedPhrase:
+      controller.getKeyPairForProcessing().addAccount(newKeyPairAccountItem())
 
 method executeCancelCommand*(self: ManageKeycardAccountsState, controller: Controller) =
-  if self.flowType == FlowType.SetupNewKeycardNewSeedPhrase:
-    controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)
+  if self.flowType == FlowType.SetupNewKeycardNewSeedPhrase or
+    self.flowType == FlowType.SetupNewKeycardOldSeedPhrase:
+      controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)

--- a/src/app/modules/shared_modules/keycard_popup/internal/max_pairing_slots_reached_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/max_pairing_slots_reached_state.nim
@@ -11,7 +11,8 @@ proc delete*(self: MaxPairingSlotsReachedState) =
 method getNextPrimaryState*(self: MaxPairingSlotsReachedState, controller: Controller): State =
   if self.flowType == FlowType.FactoryReset or
     self.flowType == FlowType.SetupNewKeycard or
-    self.flowType == FlowType.SetupNewKeycardNewSeedPhrase:
+    self.flowType == FlowType.SetupNewKeycardNewSeedPhrase or
+    self.flowType == FlowType.SetupNewKeycardOldSeedPhrase:
       return createState(StateType.FactoryResetConfirmation, self.flowType, self)
   if self.flowType == FlowType.Authentication or
     self.flowType == FlowType.DisplayKeycardContent or
@@ -28,6 +29,7 @@ method executeCancelCommand*(self: MaxPairingSlotsReachedState, controller: Cont
   if self.flowType == FlowType.FactoryReset or
     self.flowType == FlowType.SetupNewKeycard or
     self.flowType == FlowType.SetupNewKeycardNewSeedPhrase or
+    self.flowType == FlowType.SetupNewKeycardOldSeedPhrase or
     self.flowType == FlowType.Authentication or
     self.flowType == FlowType.UnlockKeycard or
     self.flowType == FlowType.DisplayKeycardContent or

--- a/src/app/modules/shared_modules/keycard_popup/internal/max_pin_retries_reached_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/max_pin_retries_reached_state.nim
@@ -20,7 +20,8 @@ method getNextPrimaryState*(self: MaxPinRetriesReachedState, controller: Control
     controller.runSharedModuleFlow(FlowType.UnlockKeycard)
   if self.flowType == FlowType.FactoryReset or
     self.flowType == FlowType.SetupNewKeycard or
-    self.flowType == FlowType.SetupNewKeycardNewSeedPhrase:
+    self.flowType == FlowType.SetupNewKeycardNewSeedPhrase or
+    self.flowType == FlowType.SetupNewKeycardOldSeedPhrase:
       let currValue = extractPredefinedKeycardDataToNumber(controller.getKeycardData())
       if (currValue and PredefinedKeycardData.DisableSeedPhraseForUnlock.int) > 0:
         controller.runSharedModuleFlow(FlowType.UnlockKeycard)
@@ -40,6 +41,7 @@ method executeCancelCommand*(self: MaxPinRetriesReachedState, controller: Contro
   if self.flowType == FlowType.FactoryReset or
     self.flowType == FlowType.DisplayKeycardContent or
     self.flowType == FlowType.SetupNewKeycard or
-    self.flowType == FlowType.SetupNewKeycardNewSeedPhrase:
+    self.flowType == FlowType.SetupNewKeycardNewSeedPhrase or
+    self.flowType == FlowType.SetupNewKeycardOldSeedPhrase:
       controller.setKeycardData(updatePredefinedKeycardData(controller.getKeycardData(), PredefinedKeycardData.DisableSeedPhraseForUnlock, add = false))
       controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)

--- a/src/app/modules/shared_modules/keycard_popup/internal/max_puk_retries_reached_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/max_puk_retries_reached_state.nim
@@ -11,7 +11,8 @@ proc delete*(self: MaxPukRetriesReachedState) =
 method getNextPrimaryState*(self: MaxPukRetriesReachedState, controller: Controller): State =
   if self.flowType == FlowType.FactoryReset or
     self.flowType == FlowType.SetupNewKeycard or
-    self.flowType == FlowType.SetupNewKeycardNewSeedPhrase:
+    self.flowType == FlowType.SetupNewKeycardNewSeedPhrase or
+    self.flowType == FlowType.SetupNewKeycardOldSeedPhrase:
       return createState(StateType.FactoryResetConfirmation, self.flowType, self)
   if self.flowType == FlowType.Authentication or
     self.flowType == FlowType.DisplayKeycardContent or
@@ -28,6 +29,7 @@ method executeCancelCommand*(self: MaxPukRetriesReachedState, controller: Contro
   if self.flowType == FlowType.FactoryReset or
     self.flowType == FlowType.SetupNewKeycard or
     self.flowType == FlowType.SetupNewKeycardNewSeedPhrase or
+    self.flowType == FlowType.SetupNewKeycardOldSeedPhrase or
     self.flowType == FlowType.Authentication or
     self.flowType == FlowType.UnlockKeycard or
     self.flowType == FlowType.DisplayKeycardContent or

--- a/src/app/modules/shared_modules/keycard_popup/internal/not_keycard_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/not_keycard_state.nim
@@ -11,6 +11,8 @@ proc delete*(self: NotKeycardState) =
 method executeCancelCommand*(self: NotKeycardState, controller: Controller) =
   if self.flowType == FlowType.FactoryReset or
     self.flowType == FlowType.SetupNewKeycard or
+    self.flowType == FlowType.SetupNewKeycardNewSeedPhrase or
+    self.flowType == FlowType.SetupNewKeycardOldSeedPhrase or
     self.flowType == FlowType.Authentication or
     self.flowType == FlowType.UnlockKeycard or
     self.flowType == FlowType.DisplayKeycardContent or

--- a/src/app/modules/shared_modules/keycard_popup/internal/pin_set_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/pin_set_state.nim
@@ -16,6 +16,8 @@ method getNextPrimaryState*(self: PinSetState, controller: Controller): State =
       return createState(StateType.SeedPhraseDisplay, self.flowType, nil)
   if self.flowType == FlowType.SetupNewKeycardNewSeedPhrase:
     return createState(StateType.SeedPhraseDisplay, self.flowType, nil)
+  if self.flowType == FlowType.SetupNewKeycardOldSeedPhrase:
+    return createState(StateType.EnterKeycardName, self.flowType, nil)
   if self.flowType == FlowType.UnlockKeycard:
     if controller.getCurrentKeycardServiceFlow() == KCSFlowType.GetMetadata:
       if controller.getValidPuk():
@@ -27,5 +29,6 @@ method getNextPrimaryState*(self: PinSetState, controller: Controller): State =
 method executeCancelCommand*(self: PinSetState, controller: Controller) =
   if self.flowType == FlowType.SetupNewKeycard or
     self.flowType == FlowType.SetupNewKeycardNewSeedPhrase or
+    self.flowType == FlowType.SetupNewKeycardOldSeedPhrase or
     self.flowType == FlowType.UnlockKeycard:
       controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)

--- a/src/app/modules/shared_modules/keycard_popup/internal/pin_verified_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/pin_verified_state.nim
@@ -12,6 +12,7 @@ method getNextPrimaryState*(self: PinVerifiedState, controller: Controller): Sta
   if self.flowType == FlowType.FactoryReset or
     self.flowType == FlowType.SetupNewKeycard or
     self.flowType == FlowType.SetupNewKeycardNewSeedPhrase or
+    self.flowType == FlowType.SetupNewKeycardOldSeedPhrase or
     self.flowType == FlowType.DisplayKeycardContent or
     self.flowType == FlowType.RenameKeycard or
     self.flowType == FlowType.CreateCopyOfAKeycard:
@@ -27,6 +28,7 @@ method executeCancelCommand*(self: PinVerifiedState, controller: Controller) =
   if self.flowType == FlowType.FactoryReset or
     self.flowType == FlowType.SetupNewKeycard or
     self.flowType == FlowType.SetupNewKeycardNewSeedPhrase or
+    self.flowType == FlowType.SetupNewKeycardOldSeedPhrase or
     self.flowType == FlowType.DisplayKeycardContent or
     self.flowType == FlowType.RenameKeycard or
     self.flowType == FlowType.ChangeKeycardPin or

--- a/src/app/modules/shared_modules/keycard_popup/internal/plugin_reader_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/plugin_reader_state.nim
@@ -17,6 +17,7 @@ method executeCancelCommand*(self: PluginReaderState, controller: Controller) =
   if self.flowType == FlowType.FactoryReset or
     self.flowType == FlowType.SetupNewKeycard or
     self.flowType == FlowType.SetupNewKeycardNewSeedPhrase or
+    self.flowType == FlowType.SetupNewKeycardOldSeedPhrase or
     self.flowType == FlowType.Authentication or
     self.flowType == FlowType.UnlockKeycard or
     self.flowType == FlowType.DisplayKeycardContent or

--- a/src/app/modules/shared_modules/keycard_popup/internal/recognized_keycard_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/recognized_keycard_state.nim
@@ -22,7 +22,9 @@ method getNextSecondaryState*(self: RecognizedKeycardState, controller: Controll
   if self.flowType == FlowType.SetupNewKeycard:
     return createState(StateType.CreatePin, self.flowType, self.getBackState)
   if self.flowType == FlowType.SetupNewKeycardNewSeedPhrase:
-    return createState(StateType.CreatePin, self.flowType, nil)
+      return createState(StateType.CreatePin, self.flowType, nil)
+  if self.flowType == FlowType.SetupNewKeycardOldSeedPhrase:
+    return createState(StateType.EnterSeedPhrase, self.flowType, nil)
   if self.flowType == FlowType.UnlockKeycard:
     return createState(StateType.UnlockKeycardOptions, self.flowType, nil)
   if self.flowType == FlowType.DisplayKeycardContent or

--- a/src/app/modules/shared_modules/keycard_popup/internal/seed_phrase_already_in_use_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/seed_phrase_already_in_use_state.nim
@@ -1,0 +1,14 @@
+type
+  SeedPhraseAlreadyInUseState* = ref object of State
+    verifiedSeedPhrase: bool
+
+proc newSeedPhraseAlreadyInUseState*(flowType: FlowType, backState: State): SeedPhraseAlreadyInUseState =
+  result = SeedPhraseAlreadyInUseState()
+  result.setup(flowType, StateType.SeedPhraseAlreadyInUse, backState)
+
+proc delete*(self: SeedPhraseAlreadyInUseState) =
+  self.State.delete
+
+method executeCancelCommand*(self: SeedPhraseAlreadyInUseState, controller: Controller) =
+  if self.flowType == FlowType.SetupNewKeycardOldSeedPhrase:
+    controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)

--- a/src/app/modules/shared_modules/keycard_popup/internal/state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/state.nim
@@ -39,6 +39,7 @@ type StateType* {.pure.} = enum
   SelectExistingKeyPair = "SelectExistingKeyPair"
   EnterSeedPhrase = "EnterSeedPhrase"
   WrongSeedPhrase = "WrongSeedPhrase"
+  SeedPhraseAlreadyInUse = "SeedPhraseAlreadyInUse"
   SeedPhraseDisplay = "SeedPhraseDisplay"
   SeedPhraseEnterWords = "SeedPhraseEnterWords"
   KeyPairMigrateSuccess = "KeyPairMigrateSuccess"
@@ -78,6 +79,9 @@ type StateType* {.pure.} = enum
   CreatingAccountNewSeedPhrase = "CreatingAccountNewSeedPhrase"
   CreatingAccountNewSeedPhraseSuccess = "CreatingAccountNewSeedPhraseSuccess"
   CreatingAccountNewSeedPhraseFailure = "CreatingAccountNewSeedPhraseFailure"
+  CreatingAccountOldSeedPhrase = "CreatingAccountOldSeedPhrase"
+  CreatingAccountOldSeedPhraseSuccess = "CreatingAccountOldSeedPhraseSuccess"
+  CreatingAccountOldSeedPhraseFailure = "CreatingAccountOldSeedPhraseFailure"
 
 
 ## This is the base class for all state we may have in onboarding/login flow.

--- a/src/app/modules/shared_modules/keycard_popup/internal/state_factory.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/state_factory.nim
@@ -48,6 +48,7 @@ include create_pairing_code_state
 include create_pin_state
 include create_puk_state
 include creating_account_new_seed_phrase_state
+include creating_account_old_seed_phrase_state
 include enter_biometrics_password_state
 include enter_keycard_name_state
 include enter_password_state
@@ -70,6 +71,8 @@ include keycard_copy_failure_state
 include keycard_copy_success_state
 include keycard_create_account_new_seed_phrase_failure_state
 include keycard_create_account_new_seed_phrase_success_state
+include keycard_create_account_old_seed_phrase_failure_state
+include keycard_create_account_old_seed_phrase_success_state
 include keycard_empty_metadata_state
 include keycard_empty_state
 include keycard_inserted_state
@@ -94,6 +97,7 @@ include renaming_keycard_state
 include repeat_pin_state
 include repeat_puk_state
 include same_keycard_state
+include seed_phrase_already_in_use_state
 include seed_phrase_display_state
 include seed_phrase_enter_words_state
 include select_existing_key_pair_state

--- a/src/app/modules/shared_modules/keycard_popup/internal/state_factory_general_implementation.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/state_factory_general_implementation.nim
@@ -57,6 +57,8 @@ proc createState*(stateToBeCreated: StateType, flowType: FlowType, backState: St
     return newCreatePukState(flowType, backState)
   if stateToBeCreated == StateType.CreatingAccountNewSeedPhrase:
     return newCreatingAccountNewSeedPhraseState(flowType, backState)
+  if stateToBeCreated == StateType.CreatingAccountOldSeedPhrase:
+    return newCreatingAccountOldSeedPhraseState(flowType, backState)
   if stateToBeCreated == StateType.EnterBiometricsPassword:
     return newEnterBiometricsPasswordState(flowType, backState)
   if stateToBeCreated == StateType.EnterKeycardName:
@@ -101,6 +103,10 @@ proc createState*(stateToBeCreated: StateType, flowType: FlowType, backState: St
     return newCreatingAccountNewSeedPhraseFailureState(flowType, backState)
   if stateToBeCreated == StateType.CreatingAccountNewSeedPhraseSuccess:
     return newCreatingAccountNewSeedPhraseSuccessState(flowType, backState)
+  if stateToBeCreated == StateType.CreatingAccountOldSeedPhraseFailure:
+    return newCreatingAccountOldSeedPhraseFailureState(flowType, backState)
+  if stateToBeCreated == StateType.CreatingAccountOldSeedPhraseSuccess:
+    return newCreatingAccountOldSeedPhraseSuccessState(flowType, backState)
   if stateToBeCreated == StateType.KeycardInserted:
     return newKeycardInsertedState(flowType, backState)
   if stateToBeCreated == StateType.KeycardEmptyMetadata:
@@ -155,6 +161,8 @@ proc createState*(stateToBeCreated: StateType, flowType: FlowType, backState: St
     return newSameKeycardState(flowType, backState)
   if stateToBeCreated == StateType.SeedPhraseDisplay:
     return newSeedPhraseDisplayState(flowType, backState)
+  if stateToBeCreated == StateType.SeedPhraseAlreadyInUse:
+    return newSeedPhraseAlreadyInUseState(flowType, backState)
   if stateToBeCreated == StateType.SeedPhraseEnterWords:
     return newSeedPhraseEnterWordsState(flowType, backState)
   if stateToBeCreated == StateType.SelectExistingKeyPair:

--- a/src/app/modules/shared_modules/keycard_popup/io_interface.nim
+++ b/src/app/modules/shared_modules/keycard_popup/io_interface.nim
@@ -50,6 +50,7 @@ type FlowType* {.pure.} = enum
   FactoryReset = "FactoryReset"
   SetupNewKeycard = "SetupNewKeycard"
   SetupNewKeycardNewSeedPhrase = "SetupNewKeycardNewSeedPhrase"
+  SetupNewKeycardOldSeedPhrase = "SetupNewKeycardOldSeedPhrase"
   Authentication = "Authentication"
   UnlockKeycard = "UnlockKeycard"
   DisplayKeycardContent = "DisplayKeycardContent"
@@ -150,6 +151,9 @@ method updateKeyPairForProcessing*(self: AccessInterface, cardMetadata: CardMeta
   raise newException(ValueError, "No implementation available")
 
 method setKeyPairForProcessing*(self: AccessInterface, item: KeyPairItem) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method prepareKeyPairForProcessing*(self: AccessInterface, keyUid: string, keycardUid = "") {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method migratingProfileKeyPair*(self: AccessInterface): bool {.base.} =

--- a/ui/imports/shared/popups/keycard/KeycardPopup.qml
+++ b/ui/imports/shared/popups/keycard/KeycardPopup.qml
@@ -21,6 +21,8 @@ StatusModal {
             return qsTr("Set up a new Keycard with an existing account")
         case Constants.keycardSharedFlow.setupNewKeycardNewSeedPhrase:
             return qsTr("Create a new Keycard account with a new seed phrase")
+        case Constants.keycardSharedFlow.setupNewKeycardOldSeedPhrase:
+            return qsTr("Import or restore a Keycard via a seed phrase")
         case Constants.keycardSharedFlow.factoryReset:
             return qsTr("Factory reset a Keycard")
         case Constants.keycardSharedFlow.authentication:

--- a/ui/imports/shared/popups/keycard/KeycardPopupContent.qml
+++ b/ui/imports/shared/popups/keycard/KeycardPopupContent.qml
@@ -34,6 +34,9 @@ Item {
             case Constants.keycardSharedState.creatingAccountNewSeedPhraseSuccess:
             case Constants.keycardSharedState.creatingAccountNewSeedPhraseFailure:
             case Constants.keycardSharedState.creatingAccountNewSeedPhrase:
+            case Constants.keycardSharedState.creatingAccountOldSeedPhraseSuccess:
+            case Constants.keycardSharedState.creatingAccountOldSeedPhraseFailure:
+            case Constants.keycardSharedState.creatingAccountOldSeedPhrase:
             case Constants.keycardSharedState.keycardRenameSuccess:
             case Constants.keycardSharedState.keycardRenameFailure:
             case Constants.keycardSharedState.renamingKeycard:
@@ -68,6 +71,7 @@ Item {
             case Constants.keycardSharedState.copyingKeycard:
             case Constants.keycardSharedState.copyingKeycardSuccess:
             case Constants.keycardSharedState.copyingKeycardFailure:
+            case Constants.keycardSharedState.seedPhraseAlreadyInUse:
                 return initComponent
 
             case Constants.keycardSharedState.factoryResetConfirmation:

--- a/ui/imports/shared/popups/keycard/KeycardPopupDetails.qml
+++ b/ui/imports/shared/popups/keycard/KeycardPopupDetails.qml
@@ -22,6 +22,7 @@ QtObject {
         case Constants.keycardSharedState.changingKeycardPairingCode:
         case Constants.keycardSharedState.migratingKeyPair:
         case Constants.keycardSharedState.creatingAccountNewSeedPhrase:
+        case Constants.keycardSharedState.creatingAccountOldSeedPhrase:
         case Constants.keycardSharedState.copyingKeycard:
             return true
 
@@ -96,6 +97,34 @@ QtObject {
                     case Constants.keycardSharedState.factoryResetSuccess:
                     case Constants.keycardSharedState.pinVerified:
                     case Constants.keycardSharedState.keycardMetadataDisplay:
+                        return true
+                    }
+                    break
+
+                case Constants.keycardSharedFlow.setupNewKeycardOldSeedPhrase:
+                    switch (root.sharedKeycardModule.currentState.stateType) {
+                    case Constants.keycardSharedState.pluginReader:
+                    case Constants.keycardSharedState.readingKeycard:
+                    case Constants.keycardSharedState.insertKeycard:
+                    case Constants.keycardSharedState.keycardInserted:
+                    case Constants.keycardSharedState.recognizedKeycard:
+                    case Constants.keycardSharedState.keycardNotEmpty:
+                    case Constants.keycardSharedState.keycardEmptyMetadata:
+                    case Constants.keycardSharedState.notKeycard:
+                    case Constants.keycardSharedState.enterPin:
+                    case Constants.keycardSharedState.wrongPin:
+                    case Constants.keycardSharedState.createPin:
+                    case Constants.keycardSharedState.repeatPin:
+                    case Constants.keycardSharedState.maxPinRetriesReached:
+                    case Constants.keycardSharedState.maxPukRetriesReached:
+                    case Constants.keycardSharedState.maxPairingSlotsReached:
+                    case Constants.keycardSharedState.factoryResetConfirmation:
+                    case Constants.keycardSharedState.factoryResetConfirmationDisplayMetadata:
+                    case Constants.keycardSharedState.factoryResetSuccess:
+                    case Constants.keycardSharedState.pinVerified:
+                    case Constants.keycardSharedState.keycardMetadataDisplay:
+                    case Constants.keycardSharedState.enterSeedPhrase:
+                    case Constants.keycardSharedState.seedPhraseAlreadyInUse:
                         return true
                     }
                     break
@@ -305,6 +334,7 @@ QtObject {
                 case Constants.keycardSharedState.readingKeycard:
                 case Constants.keycardSharedState.migratingKeyPair:
                 case Constants.keycardSharedState.creatingAccountNewSeedPhrase:
+                case Constants.keycardSharedState.creatingAccountOldSeedPhrase:
                 case Constants.keycardSharedState.renamingKeycard:
                 case Constants.keycardSharedState.changingKeycardPin:
                 case Constants.keycardSharedState.changingKeycardPuk:
@@ -385,6 +415,13 @@ QtObject {
                         return qsTr("Add another account")
                     }
                     break
+
+                case Constants.keycardSharedFlow.setupNewKeycardOldSeedPhrase:
+                    switch (root.sharedKeycardModule.currentState.stateType) {
+                    case Constants.keycardSharedState.manageKeycardAccounts:
+                        return qsTr("Add another account")
+                    }
+                    break
                 }
 
                 return ""
@@ -397,6 +434,7 @@ QtObject {
                 case Constants.keycardSharedState.readingKeycard:
                 case Constants.keycardSharedState.migratingKeyPair:
                 case Constants.keycardSharedState.creatingAccountNewSeedPhrase:
+                case Constants.keycardSharedState.creatingAccountOldSeedPhrase:
                 case Constants.keycardSharedState.renamingKeycard:
                 case Constants.keycardSharedState.changingKeycardPin:
                 case Constants.keycardSharedState.changingKeycardPuk:
@@ -432,6 +470,14 @@ QtObject {
                     break
 
                 case Constants.keycardSharedFlow.setupNewKeycardNewSeedPhrase:
+                    switch (root.sharedKeycardModule.currentState.stateType) {
+
+                    case Constants.keycardSharedState.manageKeycardAccounts:
+                        return root.primaryButtonEnabled
+                    }
+                    break
+
+                case Constants.keycardSharedFlow.setupNewKeycardOldSeedPhrase:
                     switch (root.sharedKeycardModule.currentState.stateType) {
 
                     case Constants.keycardSharedState.manageKeycardAccounts:
@@ -550,6 +596,47 @@ QtObject {
                     case Constants.keycardSharedState.creatingAccountNewSeedPhrase:
                     case Constants.keycardSharedState.creatingAccountNewSeedPhraseSuccess:
                     case Constants.keycardSharedState.creatingAccountNewSeedPhraseFailure:
+                        return qsTr("Done")
+
+                    case Constants.keycardSharedState.manageKeycardAccounts:
+                        return qsTr("Finalise Keycard")
+                    }
+                    break
+
+                case Constants.keycardSharedFlow.setupNewKeycardOldSeedPhrase:
+                    switch (root.sharedKeycardModule.currentState.stateType) {
+                    case Constants.keycardSharedState.keycardNotEmpty:
+                        return qsTr("Check what is stored on this Keycard")
+
+                    case Constants.keycardSharedState.enterPin:
+                    case Constants.keycardSharedState.wrongPin:
+                        return qsTr("I don’t know the PIN")
+
+                    case Constants.keycardSharedState.factoryResetConfirmation:
+                    case Constants.keycardSharedState.factoryResetConfirmationDisplayMetadata:
+                        return qsTr("Factory reset this Keycard")
+
+                    case Constants.keycardSharedState.keycardEmptyMetadata:
+                    case Constants.keycardSharedState.keycardMetadataDisplay:
+                    case Constants.keycardSharedState.factoryResetSuccess:
+                    case Constants.keycardSharedState.createPin:
+                    case Constants.keycardSharedState.repeatPin:
+                    case Constants.keycardSharedState.pinVerified:
+                    case Constants.keycardSharedState.pinSet:
+                    case Constants.keycardSharedState.enterKeycardName:
+                    case Constants.keycardSharedState.enterSeedPhrase:
+                        return qsTr("Next")
+
+                    case Constants.keycardSharedState.maxPinRetriesReached:
+                    case Constants.keycardSharedState.maxPukRetriesReached:
+                    case Constants.keycardSharedState.maxPairingSlotsReached:
+                        if (root.sharedKeycardModule.keycardData & Constants.predefinedKeycardData.disableSeedPhraseForUnlock)
+                            return qsTr("Unlock Keycard")
+                        return qsTr("Next")
+
+                    case Constants.keycardSharedState.creatingAccountOldSeedPhrase:
+                    case Constants.keycardSharedState.creatingAccountOldSeedPhraseSuccess:
+                    case Constants.keycardSharedState.creatingAccountOldSeedPhraseFailure:
                         return qsTr("Done")
 
                     case Constants.keycardSharedState.manageKeycardAccounts:
@@ -848,6 +935,7 @@ QtObject {
                 case Constants.keycardSharedState.readingKeycard:
                 case Constants.keycardSharedState.migratingKeyPair:
                 case Constants.keycardSharedState.creatingAccountNewSeedPhrase:
+                case Constants.keycardSharedState.creatingAccountOldSeedPhrase:
                 case Constants.keycardSharedState.renamingKeycard:
                 case Constants.keycardSharedState.changingKeycardPin:
                 case Constants.keycardSharedState.changingKeycardPuk:
@@ -889,6 +977,22 @@ QtObject {
                     case Constants.keycardSharedState.seedPhraseEnterWords:
                     case Constants.keycardSharedState.enterKeycardName:
                     case Constants.keycardSharedState.manageKeycardAccounts:
+                        return root.primaryButtonEnabled
+
+                    case Constants.keycardSharedState.createPin:
+                    case Constants.keycardSharedState.repeatPin:
+                        return false
+                    }
+                    break
+
+                case Constants.keycardSharedFlow.setupNewKeycardOldSeedPhrase:
+                    switch (root.sharedKeycardModule.currentState.stateType) {
+
+                    case Constants.keycardSharedState.factoryResetConfirmation:
+                    case Constants.keycardSharedState.factoryResetConfirmationDisplayMetadata:
+                    case Constants.keycardSharedState.enterKeycardName:
+                    case Constants.keycardSharedState.manageKeycardAccounts:
+                    case Constants.keycardSharedState.enterSeedPhrase:
                         return root.primaryButtonEnabled
 
                     case Constants.keycardSharedState.createPin:

--- a/ui/imports/shared/popups/keycard/states/EnterName.qml
+++ b/ui/imports/shared/popups/keycard/states/EnterName.qml
@@ -32,7 +32,8 @@ Item {
     }
 
     Component.onCompleted: {
-        if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.setupNewKeycardNewSeedPhrase) {
+        if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.setupNewKeycardNewSeedPhrase ||
+                root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.setupNewKeycardOldSeedPhrase) {
             if(root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.enterKeycardName) {
                 if (root.sharedKeycardModule.keyPairForProcessing.name.trim() !== "") {
                     d.updateValidity()

--- a/ui/imports/shared/popups/keycard/states/KeycardConfirmation.qml
+++ b/ui/imports/shared/popups/keycard/states/KeycardConfirmation.qml
@@ -112,6 +112,11 @@ Item {
                         return true
                     }
                 }
+                if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.setupNewKeycardOldSeedPhrase) {
+                    if (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.factoryResetConfirmationDisplayMetadata) {
+                        return true
+                    }
+                }
                 if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.factoryReset) {
                     if (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.factoryResetConfirmationDisplayMetadata) {
                         return true
@@ -135,6 +140,14 @@ Item {
                     }
                 }
                 if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.setupNewKeycardNewSeedPhrase) {
+                    if (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.factoryResetConfirmationDisplayMetadata) {
+                        if (root.sharedKeycardModule.keyPairStoredOnKeycardIsKnown) {
+                            return keyPairForProcessingComponent
+                        }
+                        return unknownKeyPairCompontnt
+                    }
+                }
+                if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.setupNewKeycardOldSeedPhrase) {
                     if (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.factoryResetConfirmationDisplayMetadata) {
                         if (root.sharedKeycardModule.keyPairStoredOnKeycardIsKnown) {
                             return keyPairForProcessingComponent

--- a/ui/imports/shared/popups/keycard/states/KeycardInit.qml
+++ b/ui/imports/shared/popups/keycard/states/KeycardInit.qml
@@ -18,6 +18,7 @@ Item {
     Component.onCompleted: {
         if (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.migratingKeyPair ||
                 root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.creatingAccountNewSeedPhrase ||
+                root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.creatingAccountOldSeedPhrase ||
                 root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.renamingKeycard ||
                 root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.copyingKeycard) {
             root.sharedKeycardModule.currentState.doPrimaryAction()
@@ -31,6 +32,7 @@ Item {
         readonly property bool copyFromAKeycardPartDone: root.sharedKeycardModule.keycardData & Constants.predefinedKeycardData.copyFromAKeycardPartDone
         readonly property bool continuousProcessingAnimation: root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.migratingKeyPair ||
                                                               root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.creatingAccountNewSeedPhrase ||
+                                                              root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.creatingAccountOldSeedPhrase ||
                                                               root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.copyingKeycard
     }
 
@@ -127,6 +129,7 @@ Item {
                 visible: root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.readingKeycard ||
                          root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.migratingKeyPair ||
                          root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.creatingAccountNewSeedPhrase ||
+                         root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.creatingAccountOldSeedPhrase ||
                          root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.renamingKeycard ||
                          root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.changingKeycardPin ||
                          root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.changingKeycardPuk ||
@@ -144,6 +147,7 @@ Item {
             Layout.alignment: Qt.AlignCenter
             Layout.preferredWidth: parent.width
             Layout.preferredHeight: Constants.keycard.general.messageHeight
+            Layout.fillHeight: root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.seedPhraseAlreadyInUse
             horizontalAlignment: Text.AlignHCenter
             wrapMode: Text.WordWrap
         }
@@ -170,6 +174,15 @@ Item {
                             root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.creatingAccountNewSeedPhrase ||
                             root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.creatingAccountNewSeedPhraseSuccess ||
                             root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.creatingAccountNewSeedPhraseFailure) {
+                        return true
+                    }
+                }
+                if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.setupNewKeycardOldSeedPhrase) {
+                    if(root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardMetadataDisplay ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.creatingAccountOldSeedPhrase ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.creatingAccountOldSeedPhraseSuccess ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.creatingAccountOldSeedPhraseFailure ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.seedPhraseAlreadyInUse) {
                         return true
                     }
                 }
@@ -298,6 +311,21 @@ Item {
                     if(root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.creatingAccountNewSeedPhrase ||
                             root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.creatingAccountNewSeedPhraseSuccess ||
                             root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.creatingAccountNewSeedPhraseFailure) {
+                        return keyPairForProcessingComponent
+                    }
+                }
+                if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.setupNewKeycardOldSeedPhrase) {
+                    if(root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardMetadataDisplay) {
+                        if (root.sharedKeycardModule.keyPairStoredOnKeycardIsKnown) {
+                            return keyPairForProcessingComponent
+                        }
+                        return unknownKeyPairCompontnt
+                    }
+
+                    if(root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.creatingAccountOldSeedPhrase ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.creatingAccountOldSeedPhraseSuccess ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.creatingAccountOldSeedPhraseFailure ||
+                            root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.seedPhraseAlreadyInUse) {
                         return keyPairForProcessingComponent
                     }
                 }
@@ -500,6 +528,7 @@ Item {
             when: root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.readingKeycard ||
                   root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.migratingKeyPair ||
                   root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.creatingAccountNewSeedPhrase ||
+                  root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.creatingAccountOldSeedPhrase ||
                   root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.renamingKeycard ||
                   root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.changingKeycardPin ||
                   root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.changingKeycardPuk ||
@@ -516,6 +545,9 @@ Item {
                     }
                     if (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.creatingAccountNewSeedPhrase) {
                         return qsTr("Creating new account...")
+                    }
+                    if (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.creatingAccountOldSeedPhrase) {
+                        return qsTr("Setting a new Keycard...")
                     }
                     if (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.renamingKeycard) {
                         return qsTr("Renaming keycard...")
@@ -733,7 +765,8 @@ Item {
                         return qsTr("To migrate %1 on to this Keycard, you\nwill need to perform a factory reset first")
                         .arg(root.sharedKeycardModule.keyPairForProcessing.name)
                     }
-                    if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.setupNewKeycardNewSeedPhrase) {
+                    if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.setupNewKeycardNewSeedPhrase ||
+                            root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.setupNewKeycardOldSeedPhrase) {
                         return qsTr("To create a new account on to this Keycard, you\nwill need to perform a factory reset first")
                     }
                     if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.createCopyOfAKeycard) {
@@ -756,12 +789,14 @@ Item {
                 target: title
                 text: root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.setupNewKeycard ||
                       root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.setupNewKeycardNewSeedPhrase ||
+                      root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.setupNewKeycardOldSeedPhrase ||
                       root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.createCopyOfAKeycard?
                           qsTr("Keycard locked and already stores keys") : qsTr("Keycard locked")
                 font.pixelSize: Constants.keycard.general.fontSize1
                 font.weight: Font.Bold
                 color: root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.setupNewKeycard ||
                        root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.setupNewKeycardNewSeedPhrase ||
+                       root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.setupNewKeycardOldSeedPhrase ||
                        root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.createCopyOfAKeycard?
                            Theme.palette.directColor1 : Theme.palette.dangerColor1
             }
@@ -781,6 +816,7 @@ Item {
                     if (root.sharedKeycardModule.keycardData & Constants.predefinedKeycardData.useGeneralMessageForLockedState) {
                         if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.setupNewKeycard ||
                                 root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.setupNewKeycardNewSeedPhrase ||
+                                root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.setupNewKeycardOldSeedPhrase ||
                                 root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.createCopyOfAKeycard)
                             return qsTr("The Keycard you have inserted is locked,\nyou will need to factory reset it before proceeding")
                         return qsTr("You will need to unlock it before proceeding")
@@ -796,6 +832,7 @@ Item {
                 font.pixelSize: Constants.keycard.general.fontSize2
                 color: root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.setupNewKeycard ||
                        root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.setupNewKeycardNewSeedPhrase ||
+                       root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.setupNewKeycardOldSeedPhrase ||
                        root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.createCopyOfAKeycard?
                            Theme.palette.directColor1 : Theme.palette.dangerColor1
             }
@@ -854,6 +891,7 @@ Item {
             name: "processing-success"
             when: root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keyPairMigrateSuccess ||
                   root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.creatingAccountNewSeedPhraseSuccess ||
+                  root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.creatingAccountOldSeedPhraseSuccess ||
                   root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.factoryResetSuccess ||
                   root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.unlockKeycardSuccess ||
                   root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardRenameSuccess ||
@@ -869,9 +907,13 @@ Item {
                     if (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.creatingAccountNewSeedPhraseSuccess) {
                         return qsTr("New account successfully created")
                     }
+                    if (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.creatingAccountOldSeedPhraseSuccess) {
+                        return qsTr("Keycard is ready to use!")
+                    }
                     if (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.factoryResetSuccess) {
                         if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.setupNewKeycard ||
                                 root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.setupNewKeycardNewSeedPhrase ||
+                                root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.setupNewKeycardOldSeedPhrase ||
                                 root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.createCopyOfAKeycard)
                             return qsTr("Your Keycard has been reset")
                         return qsTr("Keycard successfully factory reset")
@@ -917,6 +959,7 @@ Item {
                     if (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.factoryResetSuccess) {
                         if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.setupNewKeycard ||
                                 root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.setupNewKeycardNewSeedPhrase ||
+                                root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.setupNewKeycardOldSeedPhrase ||
                                 root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.createCopyOfAKeycard)
                             return qsTr("You can now create a new key pair on this Keycard")
                         return qsTr("You can now use this Keycard as if it\nwas a brand new empty Keycard")
@@ -931,6 +974,7 @@ Item {
             name: "processing-failure"
             when: root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keyPairMigrateFailure ||
                   root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.creatingAccountNewSeedPhraseFailure ||
+                  root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.creatingAccountOldSeedPhraseFailure ||
                   root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardRenameFailure ||
                   root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.changingKeycardPukFailure ||
                   root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.changingKeycardPairingCodeFailure ||
@@ -943,6 +987,9 @@ Item {
                     }
                     if (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.creatingAccountNewSeedPhraseFailure) {
                         return qsTr("Creating new account failed")
+                    }
+                    if (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.creatingAccountOldSeedPhraseFailure) {
+                        return qsTr("Setting a Keycard failed")
                     }
                     if (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardRenameFailure) {
                         return qsTr("Keycard renaming failed")
@@ -1153,6 +1200,27 @@ Item {
             PropertyChanges {
                 target: message
                 text: ""
+            }
+        },
+        State {
+            name: Constants.keycardSharedState.seedPhraseAlreadyInUse
+            when: root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.seedPhraseAlreadyInUse
+            PropertyChanges {
+                target: title
+                text: ""
+            }
+            PropertyChanges {
+                target: image
+                source: ""
+                pattern: ""
+                visible: false
+            }
+            PropertyChanges {
+                target: message
+                text: qsTr("The seed phrase you entered is\ncurrently in use on this device")
+                font.pixelSize: Constants.keycard.general.fontSize1
+                font.weight: Font.Bold
+                color: Theme.palette.directColor1
             }
         }
     ]

--- a/ui/imports/shared/popups/keycard/states/ManageAccounts.qml
+++ b/ui/imports/shared/popups/keycard/states/ManageAccounts.qml
@@ -71,8 +71,8 @@ Item {
 
     Connections {
         target: root.emojiPopup
-        enabled: root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.setupNewKeycardNewSeedPhrase &&
-                 root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.manageKeycardAccounts
+        enabled: root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.setupNewKeycardNewSeedPhrase ||
+                 root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.setupNewKeycardOldSeedPhrase
 
         function onEmojiSelected (emojiText, atCursor) {
             d.observedAccount.emoji = emojiText

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -99,6 +99,7 @@ QtObject {
         readonly property string factoryReset: "FactoryReset"
         readonly property string setupNewKeycard: "SetupNewKeycard"
         readonly property string setupNewKeycardNewSeedPhrase: "SetupNewKeycardNewSeedPhrase"
+        readonly property string setupNewKeycardOldSeedPhrase: "SetupNewKeycardOldSeedPhrase"
         readonly property string authentication: "Authentication"
         readonly property string unlockKeycard: "UnlockKeycard"
         readonly property string displayKeycardContent: "DisplayKeycardContent"
@@ -143,6 +144,7 @@ QtObject {
         readonly property string selectExistingKeyPair: "SelectExistingKeyPair"
         readonly property string enterSeedPhrase: "EnterSeedPhrase"
         readonly property string wrongSeedPhrase: "WrongSeedPhrase"
+        readonly property string seedPhraseAlreadyInUse: "SeedPhraseAlreadyInUse"
         readonly property string seedPhraseDisplay: "SeedPhraseDisplay"
         readonly property string seedPhraseEnterWords: "SeedPhraseEnterWords"
         readonly property string keyPairMigrateSuccess: "KeyPairMigrateSuccess"
@@ -182,6 +184,9 @@ QtObject {
         readonly property string creatingAccountNewSeedPhrase: "CreatingAccountNewSeedPhrase"
         readonly property string creatingAccountNewSeedPhraseSuccess: "CreatingAccountNewSeedPhraseSuccess"
         readonly property string creatingAccountNewSeedPhraseFailure: "CreatingAccountNewSeedPhraseFailure"
+        readonly property string creatingAccountOldSeedPhrase: "CreatingAccountOldSeedPhrase"
+        readonly property string creatingAccountOldSeedPhraseSuccess: "CreatingAccountOldSeedPhraseSuccess"
+        readonly property string creatingAccountOldSeedPhraseFailure: "CreatingAccountOldSeedPhraseFailure"
     }
 
     readonly property QtObject keycardAnimations: QtObject {


### PR DESCRIPTION
This flow imports an account for a certain seed phrase (user needs to own that seed phrase in advance) if such account is not already added and adds custom number of wallet accounts. Accounts are added to the app (wallet part) and to a Keycard as well.

If user is trying to add a seed phrase which is already added in the app the screen we point him to differs from one user in figma. That's something we need to discuss with designers and if needed will be changed in another PR (minor thing, this PR is ready for review).

@glitchminer this PR is built on top of #8775 so checking this one you will check both.

Closes: #7029 