### PR TITLE
fix(PinnedMessagesPopup): Force show repeat header

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
@@ -140,12 +140,6 @@ Control {
                 return Theme.palette.pinColor3;
             return "transparent";
         }
-    }
-
-    contentItem: Item {
-
-        implicitWidth: messageLayout.implicitWidth
-        implicitHeight: messageLayout.implicitHeight
 
         Rectangle {
             anchors {
@@ -168,6 +162,13 @@ Control {
             visible: root.hasMention
             color: Theme.palette.mentionColor1
         }
+    }
+
+    contentItem: Item {
+
+        implicitWidth: messageLayout.implicitWidth
+        implicitHeight: messageLayout.implicitHeight
+
 
         SequentialAnimation {
             id: messageFoundAnimation

--- a/ui/app/AppLayouts/Chat/popups/PinnedMessagesPopup.qml
+++ b/ui/app/AppLayouts/Chat/popups/PinnedMessagesPopup.qml
@@ -95,6 +95,7 @@ StatusDialog {
                     // Additional params
                     isInPinnedPopup: true
                     disableHover: !!root.messageToPin
+                    shouldRepeatHeader: true
                 }
 
                 MouseArea {


### PR DESCRIPTION
Fixes #7128

### What does the PR do

- Always show message header with user icon and name in `PinnedMessagesPopup`
- Fixed height of message' left colored rectangle (used for mentions and pinned

### Affected areas

Chat, Pinned messages popup

### Screenshot of functionality (including design for comparison)

<img width="1115" alt="Снимок экрана 2022-12-26 в 19 32 42" src="https://user-images.githubusercontent.com/25482501/209568236-104515fd-2faa-4642-ae20-0bd298cb1d01.png">
