### PR TITLE
fix(@desktop/community): Decrease amount of chat_getMembers calls

### DIFF
--- a/src/app/modules/main/chat_section/chat_content/users/controller.nim
+++ b/src/app/modules/main/chat_section/chat_content/users/controller.nim
@@ -57,8 +57,11 @@ proc handleCommunityOnlyConnections(self: Controller) =
     for community in args.communities:
       if (community.id != self.sectionId):
         continue
-      let membersPubKeys = community.members.map(x => x.id)
-      self.delegate.onChatMembersAddedOrRemoved(membersPubKeys)
+      # If we didn't join the community, all members in the list will have status
+      # joined=false. No need to try add them to the model
+      if community.isMember:
+        let membersPubKeys = community.members.map(x => x.id)
+        self.delegate.onChatMembersAddedOrRemoved(membersPubKeys)
 
   self.events.on(SIGNAL_COMMUNITY_MEMBER_REMOVED) do(e: Args):
     let args = CommunityMemberArgs(e)
@@ -160,12 +163,6 @@ proc getChatMembers*(self: Controller): seq[ChatMember] =
   if (self.belongsToCommunity):
     communityId = self.sectionId
   return self.chatService.getMembers(communityId, self.chatId)
-
-proc getChatMember*(self: Controller, id: string): ChatMember =
-  let members = self.getChatMembers()
-  for member in members:
-    if (member.id == id):
-      return member
 
 proc getMembersPublicKeys*(self: Controller): seq[string] =
   if(self.belongsToCommunity):

--- a/src/app/modules/main/chat_section/chat_content/users/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/users/module.nim
@@ -162,12 +162,18 @@ method addChatMember*(self: Module,  member: ChatMember) =
     ))
 
 method onChatMembersAdded*(self: Module,  ids: seq[string]) =
+  let members = self.controller.getChatMembers()
   for id in ids:
-    self.addChatMember(self.controller.getChatMember(id))
+    for member in members:
+      if (member.id == id):
+        self.addChatMember(member)
 
 method onChatUpdated*(self: Module,  chat: ChatDto) =
+  let members = self.controller.getChatMembers()
   for member in chat.members:
-    self.addChatMember(self.controller.getChatMember(member.id))
+    for existingMember in members:
+      if existingMember.id == member.id:
+        self.addChatMember(member)
 
   if chat.members.len > 0:
     let ids = self.view.model.getItemIds()


### PR DESCRIPTION
### What does the PR do

1. Decrease amount of chat_getMembers calls
2. Do not try to add members to the model if we are not a member of the community. Members won't be added anyway as they will have joined=false status

Fixes: #8801

### Affected areas

Community members list display after the join

### Cool Spaceship Picture

![63ac7cb1c1e8e5c6364b44b8aa430ffc--cute-minions-minion-stuff](https://user-images.githubusercontent.com/117639195/209668438-a92ef507-122d-468e-8e35-a60efdbe340c.jpg)

