### PR TITLE
feat(@desktop/wallet): implement unified currency formatting

### DIFF
--- a/src/app/boot/app_controller.nim
+++ b/src/app/boot/app_controller.nim
@@ -10,6 +10,7 @@ import ../../app_service/service/chat/service as chat_service
 import ../../app_service/service/community/service as community_service
 import ../../app_service/service/message/service as message_service
 import ../../app_service/service/token/service as token_service
+import ../../app_service/service/currency/service as currency_service
 import ../../app_service/service/transaction/service as transaction_service
 import ../../app_service/service/collectible/service as collectible_service
 import ../../app_service/service/wallet_account/service as wallet_account_service
@@ -67,6 +68,7 @@ type
     communityService: community_service.Service
     messageService: message_service.Service
     tokenService: token_service.Service
+    currencyService: currency_service.Service
     transactionService: transaction_service.Service
     collectibleService: collectible_service.Service
     walletAccountService: wallet_account_service.Service
@@ -160,6 +162,7 @@ proc newAppController*(statusFoundation: StatusFoundation): AppController =
   result.tokenService = token_service.newService(
     statusFoundation.events, statusFoundation.threadpool, result.networkService
   )
+  result.currencyService = currency_service.newService(result.tokenService, result.settingsService)
   result.collectibleService = collectible_service.newService(statusFoundation.events, statusFoundation.threadpool, result.networkService)
   result.walletAccountService = wallet_account_service.newService(
     statusFoundation.events, statusFoundation.threadpool, result.settingsService, result.accountsService,
@@ -221,6 +224,7 @@ proc newAppController*(statusFoundation: StatusFoundation): AppController =
     result.communityService,
     result.messageService,
     result.tokenService,
+    result.currencyService,
     result.transactionService,
     result.collectibleService,
     result.walletAccountService,
@@ -273,6 +277,7 @@ proc delete*(self: AppController) =
   self.accountsService.delete
   self.chatService.delete
   self.communityService.delete
+  self.currencyService.delete
   self.tokenService.delete
   self.transactionService.delete
   self.collectibleService.delete
@@ -352,6 +357,7 @@ proc load(self: AppController) =
 
   self.networkService.init()
   self.tokenService.init()
+  self.currencyService.init()
   self.walletAccountService.init()
 
   # Apply runtime log level settings

--- a/src/app/modules/main/browser_section/current_account/controller.nim
+++ b/src/app/modules/main/browser_section/current_account/controller.nim
@@ -1,23 +1,31 @@
-import sugar, sequtils
+import sugar, sequtils, Tables
 import io_interface
 import ../../../../../app_service/service/wallet_account/service as wallet_account_service
 import ../../../../../app_service/service/network/service as network_service
+import ../../../../../app_service/service/token/service as token_service
+import ../../../../../app_service/service/currency/service as currency_service
 
 type
   Controller* = ref object of RootObj
     delegate: io_interface.AccessInterface
     walletAccountService: wallet_account_service.Service
     networkService: network_service.Service
+    tokenService: token_service.Service
+    currencyService: currency_service.Service
 
 proc newController*(
   delegate: io_interface.AccessInterface,
   walletAccountService: wallet_account_service.Service,
   networkService: network_service.Service,
+  tokenService: token_service.Service,
+  currencyService: currency_service.Service,
 ): Controller =
   result = Controller()
   result.delegate = delegate
   result.walletAccountService = walletAccountService
   result.networkService = networkService
+  result.tokenService = tokenService
+  result.currencyService = currencyService
 
 proc delete*(self: Controller) =
   discard
@@ -39,3 +47,12 @@ proc getChainIds*(self: Controller): seq[int] =
 
 proc getEnabledChainIds*(self: Controller): seq[int] = 
   return self.networkService.getNetworks().filter(n => n.enabled).map(n => n.chainId)
+
+proc getCurrentCurrency*(self: Controller): string =
+  return self.walletAccountService.getCurrency()
+
+proc getCurrencyFormat*(self: Controller, symbol: string): CurrencyFormatDto =
+  return self.currencyService.getCurrencyFormat(symbol)
+
+proc getAllMigratedKeyPairs*(self: Controller): seq[KeyPairDto] =
+  return self.walletAccountService.getAllMigratedKeyPairs()

--- a/src/app/modules/main/browser_section/current_account/module.nim
+++ b/src/app/modules/main/browser_section/current_account/module.nim
@@ -1,11 +1,16 @@
-import NimQml, Tables, sequtils
+import NimQml, Tables, sequtils, sugar
 
 import ../../../../global/global_singleton
 import ../../../../core/eventemitter
 import ../../../../../app_service/service/wallet_account/service as wallet_account_service
 import ../../../../../app_service/service/network/service as network_service
+import ../../../../../app_service/service/token/service as token_service
+import ../../../../../app_service/service/currency/service as currency_service
 import ../../../shared_models/token_model as token_model
 import ../../../shared_models/token_item as token_item
+import ../../../shared_models/token_utils
+
+import ../../wallet_section/accounts/utils
 
 import ./io_interface, ./view, ./controller
 import ../io_interface as delegate_interface
@@ -28,57 +33,64 @@ proc newModule*(
   events: EventEmitter,
   walletAccountService: wallet_account_service.Service,
   networkService: network_service.Service,
+  tokenService: token_service.Service,
+  currencyService: currency_service.Service,
 ): Module =
   result = Module()
   result.delegate = delegate
   result.events = events
   result.currentAccountIndex = 0
   result.view = newView(result)
-  result.controller = newController(result, walletAccountService, networkService)
+  result.controller = newController(result, walletAccountService, networkService, tokenService, currencyService)
   result.moduleLoaded = false
 
 method delete*(self: Module) =
   self.view.delete
 
 proc setAssets(self: Module, tokens: seq[WalletTokenDto]) =
-  var items: seq[Item]
   let chainIds = self.controller.getChainIds()
   let enabledChainIds = self.controller.getEnabledChainIds()
 
-  for t in tokens:
-    let item = token_item.initItem(
-      t.name,
-      t.symbol,
-      t.getBalance(chainIds),
-      t.getCurrencyBalance(chainIds),
-      t.getBalance(enabledChainIds),
-      t.getCurrencyBalance(enabledChainIds),
-      t.getVisibleForNetwork(enabledChainIds),
-      t.getVisibleForNetworkWithPositiveBalance(enabledChainIds),
-      t.getBalances(enabledChainIds),
-      t.description,
-      t.assetWebsiteUrl,
-      t.builtOn,
-      t.getAddress(),
-      t.marketCap,
-      t.highDay,
-      t.lowDay,
-      t.changePctHour,
-      t.changePctDay,
-      t.changePct24hour,
-      t.change24hour,
-      t.currencyPrice,
-      t.decimals,
-    )
-    items.add(item)
+  let currency = self.controller.getCurrentCurrency()
+
+  let currencyFormat = self.controller.getCurrencyFormat(currency)
+
+  let items = tokens.map(t => walletTokenToItem(t, chainIds, enabledChainIds, currency, currencyFormat, self.controller.getCurrencyFormat(t.symbol)))
     
   self.view.getAssetsModel().setItems(items)
 
 method switchAccount*(self: Module, accountIndex: int) =
   self.currentAccountIndex = accountIndex
+
+  let keyPairMigrated = proc(migratedKeyPairs: seq[KeyPairDto], keyUid: string): bool =
+    for kp in migratedKeyPairs:
+      if kp.keyUid == keyUid:
+        return true
+    return false
+
   let walletAccount = self.controller.getWalletAccount(accountIndex)
+  let migratedKeyPairs = self.controller.getAllMigratedKeyPairs()
+  let currency = self.controller.getCurrentCurrency()
+
+  let chainIds = self.controller.getChainIds()
   let enabledChainIds = self.controller.getEnabledChainIds()
-  self.view.setData(walletAccount, enabledChainIds)
+
+  let tokenFormats = collect(initTable()):
+    for t in walletAccount.tokens: {t.symbol: self.controller.getCurrencyFormat(t.symbol)}
+  
+  let currencyFormat = self.controller.getCurrencyFormat(currency)
+
+  let accountItem = walletAccountToItem(
+    walletAccount,
+    chainIds,
+    enabledChainIds,
+    currency,
+    keyPairMigrated(migratedKeyPairs, walletAccount.keyUid),
+    currencyFormat,
+    tokenFormats
+    )
+
+  self.view.setData(accountItem)
   self.setAssets(walletAccount.tokens)
 
 method load*(self: Module) =

--- a/src/app/modules/main/browser_section/current_account/view.nim
+++ b/src/app/modules/main/browser_section/current_account/view.nim
@@ -1,10 +1,11 @@
 import NimQml, sequtils, sugar
 
-import ../../../../../app_service/service/wallet_account/service as wallet_account_service
 import ./io_interface
 import ../../../shared_models/token_model as token_model
 import ../../../shared_models/token_item as token_item
+import ../../../shared_models/currency_amount
 
+import ../../wallet_section/accounts/item as account_item
 
 QtObject:
   type
@@ -17,7 +18,7 @@ QtObject:
       publicKey: string
       walletType: string
       isChat: bool
-      currencyBalance: float64
+      currencyBalance: CurrencyAmount
       assets: token_model.Model
       emoji: string
 
@@ -140,27 +141,27 @@ QtObject:
   proc hasGas*(self: View, chainId: int, nativeGasSymbol: string, requiredGas: float): bool {.slot.} =
     return self.assets.hasGas(chainId, nativeGasSymbol, requiredGas)
 
-  proc getTokenBalanceOnChain*(self: View, chainId: int, tokenSymbol: string): string {.slot.} =
-    return self.assets.getTokenBalanceOnChain(chainId, tokenSymbol)
+#  proc getTokenBalanceOnChain*(self: View, chainId: int, tokenSymbol: string): QVariant {.slot.} =
+#    return newQVariant(self.assets.getTokenBalanceOnChain(chainId, tokenSymbol))
 
-proc setData*(self: View, dto: wallet_account_service.WalletAccountDto, chainIds: seq[int]) =
-    self.name = dto.name
+proc setData*(self: View, item: account_item.Item) =
+    self.name = item.getName()
     self.nameChanged()
-    self.address = dto.address
+    self.address = item.getAddress()
     self.addressChanged()
-    self.path = dto.path
+    self.path = item.getPath()
     self.pathChanged()
-    self.color = dto.color
+    self.color = item.getColor()
     self.colorChanged()
-    self.publicKey = dto.publicKey
+    self.publicKey = item.getPublicKey()
     self.publicKeyChanged()
-    self.walletType = dto.walletType
+    self.walletType = item.getWalletType()
     self.walletTypeChanged()
-    self.isChat = dto.isChat
+    self.isChat = item.getIsChat()
     self.isChatChanged()
-    self.currencyBalance = dto.getCurrencyBalance(chainIds)
+    self.currencyBalance = item.getCurrencyBalance()
     self.currencyBalanceChanged()
-    self.emoji = dto.emoji
+    self.emoji = item.getEmoji()
     self.emojiChanged()
 
 proc isAddressCurrentAccount*(self: View, address: string): bool =

--- a/src/app/modules/main/browser_section/module.nim
+++ b/src/app/modules/main/browser_section/module.nim
@@ -14,6 +14,8 @@ import ../../../../app_service/service/network/service as network_service
 import ../../../../app_service/service/dapp_permissions/service as dapp_permissions_service
 import ../../../../app_service/service/provider/service as provider_service
 import ../../../../app_service/service/wallet_account/service as wallet_account_service
+import ../../../../app_service/service/token/service as token_service
+import ../../../../app_service/service/currency/service as currency_service
 
 export io_interface
 
@@ -36,7 +38,10 @@ proc newModule*(delegate: delegate_interface.AccessInterface,
     networkService: network_service.Service,
     dappPermissionsService: dapp_permissions_service.Service,
     providerService: provider_service.Service,
-    walletAccountService: wallet_account_service.Service): Module =
+    walletAccountService: wallet_account_service.Service,
+    tokenService: token_service.Service,
+    currencyService: currency_service.Service
+): Module =
   result = Module()
   result.delegate = delegate
   result.events = events
@@ -46,7 +51,7 @@ proc newModule*(delegate: delegate_interface.AccessInterface,
   result.providerModule = provider_module.newModule(result, events, settingsService, networkService, providerService)
   result.bookmarkModule = bookmark_module.newModule(result, events, bookmarkService)
   result.dappsModule = dapps_module.newModule(result, dappPermissionsService, walletAccountService)
-  result.currentAccountModule = current_account_module.newModule(result, events, walletAccountService, networkService)
+  result.currentAccountModule = current_account_module.newModule(result, events, walletAccountService, networkService, tokenService, currencyService)
 
 method delete*(self: Module) =
   self.view.delete

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -29,6 +29,7 @@ import ../../../app_service/service/chat/service as chat_service
 import ../../../app_service/service/community/service as community_service
 import ../../../app_service/service/message/service as message_service
 import ../../../app_service/service/token/service as token_service
+import ../../../app_service/service/currency/service as currency_service
 import ../../../app_service/service/transaction/service as transaction_service
 import ../../../app_service/service/collectible/service as collectible_service
 import ../../../app_service/service/wallet_account/service as wallet_account_service
@@ -109,6 +110,7 @@ proc newModule*[T](
   communityService: community_service.Service,
   messageService: message_service.Service,
   tokenService: token_service.Service,
+  currencyService: currency_service.Service,
   transactionService: transaction_service.Service,
   collectibleService: collectible_service.Service,
   walletAccountService: wallet_account_service.Service,
@@ -168,21 +170,22 @@ proc newModule*[T](
   # Submodules
   result.channelGroupModules = initOrderedTable[string, chat_section_module.AccessInterface]()
   result.walletSectionModule = wallet_section_module.newModule(
-    result, events, tokenService,
+    result, events, tokenService, currencyService,
     transactionService, collectible_service, walletAccountService,
     settingsService, savedAddressService, networkService, accountsService, keycardService
   )
   result.browserSectionModule = browser_section_module.newModule(
     result, events, bookmarkService, settingsService, networkService,
-    dappPermissionsService, providerService, walletAccountService
+    dappPermissionsService, providerService, walletAccountService,
+    tokenService, currencyService
   )
   result.profileSectionModule = profile_section_module.newModule(
     result, events, accountsService, settingsService, stickersService,
     profileService, contactsService, aboutService, languageService, privacyService, nodeConfigurationService,
     devicesService, mailserversService, chatService, ensService, walletAccountService, generalService, communityService,
-    networkService, keycardService, keychainService
+    networkService, keycardService, keychainService, tokenService
   )
-  result.stickersModule = stickers_module.newModule(result, events, stickersService, settingsService, walletAccountService, networkService)
+  result.stickersModule = stickers_module.newModule(result, events, stickersService, settingsService, walletAccountService, networkService, tokenService)
   result.activityCenterModule = activity_center_module.newModule(result, events, activityCenterService, contactsService,
   messageService, chatService)
   result.communitiesModule = communities_module.newModule(result, events, communityService, contactsService)

--- a/src/app/modules/main/profile_section/ens_usernames/controller.nim
+++ b/src/app/modules/main/profile_section/ens_usernames/controller.nim
@@ -7,7 +7,7 @@ import ../../../../../app_service/service/settings/service as settings_service
 import ../../../../../app_service/service/ens/service as ens_service
 import ../../../../../app_service/service/network/service as network_service
 import ../../../../../app_service/service/wallet_account/service as wallet_account_service
-import ../../../../../app_service/service/token/dto
+import ../../../../../app_service/service/token/service as token_service
 import ../../../shared_modules/keycard_popup/io_interface as keycard_shared_module
 
 logScope:
@@ -23,11 +23,13 @@ type
     ensService: ens_service.Service
     networkService: network_service.Service
     walletAccountService: wallet_account_service.Service
+    tokenService: token_service.Service
 
 proc newController*(
   delegate: io_interface.AccessInterface, events: EventEmitter,
   settingsService: settings_service.Service, ensService: ens_service.Service,
   walletAccountService: wallet_account_service.Service, networkService: network_service.Service,
+  tokenService: token_service.Service
 ): Controller =
   result = Controller()
   result.delegate = delegate
@@ -36,6 +38,7 @@ proc newController*(
   result.ensService = ensService
   result.walletAccountService = walletAccountService
   result.networkService = networkService
+  result.tokenService = tokenService
 
 proc delete*(self: Controller) =
   discard
@@ -135,7 +138,7 @@ proc getCurrentCurrency*(self: Controller): string =
   return self.settingsService.getCurrency()
 
 proc getPrice*(self: Controller, crypto: string, fiat: string): float64 =
-  return self.walletAccountService.getPrice(crypto, fiat)
+  return self.tokenService.getTokenPrice(crypto, fiat)
 
 proc getStatusToken*(self: Controller): string =
   let token = self.ensService.getStatusToken()

--- a/src/app/modules/main/profile_section/ens_usernames/module.nim
+++ b/src/app/modules/main/profile_section/ens_usernames/module.nim
@@ -12,6 +12,7 @@ import ../../../../../app_service/service/ens/service as ens_service
 import ../../../../../app_service/service/network/service as network_service
 import ../../../../../app_service/service/ens/utils as ens_utils
 import ../../../../../app_service/service/wallet_account/service as wallet_account_service
+import ../../../../../app_service/service/token/service as token_service
 
 export io_interface
 
@@ -49,12 +50,13 @@ proc newModule*(
   settingsService: settings_service.Service, ensService: ens_service.Service,
   walletAccountService: wallet_account_service.Service,
   networkService: network_service.Service,
+  tokenService: token_service.Service,
 ): Module =
   result = Module()
   result.delegate = delegate
   result.view = view.newView(result)
   result.viewVariant = newQVariant(result.view)
-  result.controller = controller.newController(result, events, settingsService, ensService, walletAccountService, networkService)
+  result.controller = controller.newController(result, events, settingsService, ensService, walletAccountService, networkService, tokenService)
   result.moduleLoaded = false
 
 method delete*(self: Module) =

--- a/src/app/modules/main/profile_section/module.nim
+++ b/src/app/modules/main/profile_section/module.nim
@@ -22,6 +22,7 @@ import ../../../../app_service/service/general/service as general_service
 import ../../../../app_service/service/community/service as community_service
 import ../../../../app_service/service/keycard/service as keycard_service
 import ../../../../app_service/service/keychain/service as keychain_service
+import ../../../../app_service/service/token/service as token_service
 
 import ./profile/module as profile_module
 import ./contacts/module as contacts_module
@@ -79,7 +80,8 @@ proc newModule*(delegate: delegate_interface.AccessInterface,
   communityService: community_service.Service,
   networkService: network_service.Service,
   keycardService: keycard_service.Service,
-  keychainService: keychain_service.Service
+  keychainService: keychain_service.Service,
+  tokenService: token_service.Service
 ): Module =
   result = Module()
   result.delegate = delegate
@@ -98,7 +100,7 @@ proc newModule*(delegate: delegate_interface.AccessInterface,
   result.syncModule = sync_module.newModule(result, events, settingsService, nodeConfigurationService, mailserversService)
   result.notificationsModule = notifications_module.newModule(result, events, settingsService, chatService, contactsService)
   result.ensUsernamesModule = ens_usernames_module.newModule(
-    result, events, settingsService, ensService, walletAccountService, networkService
+    result, events, settingsService, ensService, walletAccountService, networkService, tokenService
   )
   result.communitiesModule = communities_module.newModule(result, communityService)
   result.keycardModule = keycard_module.newModule(result, events, keycardService, settingsService, privacyService, 

--- a/src/app/modules/main/stickers/controller.nim
+++ b/src/app/modules/main/stickers/controller.nim
@@ -10,6 +10,7 @@ import ../../../../app_service/service/settings/service as settings_service
 import ../../../../app_service/service/network/service as network_service
 import ../../../../app_service/service/eth/utils as eth_utils
 import ../../../../app_service/service/wallet_account/service as wallet_account_service
+import ../../../../app_service/service/token/service as token_service
 import ../../shared_modules/keycard_popup/io_interface as keycard_shared_module
 
 const UNIQUE_BUY_STICKER_TRANSACTION_MODULE_IDENTIFIER* = "StickersSection-TransactionModule"
@@ -22,6 +23,7 @@ type
     settingsService: settings_service.Service
     networkService: network_service.Service
     walletAccountService: wallet_account_service.Service
+    tokenService: token_service.Service
     disconnected: bool
 
 # Forward declaration
@@ -35,6 +37,7 @@ proc newController*(
     settingsService: settings_service.Service,
     walletAccountService: wallet_account_service.Service,
     networkService: network_service.Service,
+    tokenService: token_service.Service,
     ): Controller =
   result = Controller()
   result.delegate = delegate
@@ -43,6 +46,7 @@ proc newController*(
   result.settingsService = settingsService
   result.networkService = networkService
   result.walletAccountService = walletAccountService
+  result.tokenService = tokenService
   result.disconnected = false
 
 proc delete*(self: Controller) =
@@ -154,7 +158,7 @@ proc getCurrentCurrency*(self: Controller): string =
   return self.settingsService.getCurrency()
 
 proc getPrice*(self: Controller, crypto: string, fiat: string): float64 =
-  return self.walletAccountService.getPrice(crypto, fiat)
+  return self.tokenService.getTokenPrice(crypto, fiat)
 
 proc getChainIdForStickers*(self: Controller): int =
   return self.networkService.getNetworkForStickers().chainId

--- a/src/app/modules/main/stickers/module.nim
+++ b/src/app/modules/main/stickers/module.nim
@@ -8,6 +8,7 @@ import ../../../../app_service/service/settings/service as settings_service
 import ../../../../app_service/service/network/service as network_service
 import ../../../../app_service/common/conversion as service_conversion
 import ../../../../app_service/service/wallet_account/service as wallet_account_service
+import ../../../../app_service/service/token/service as token_service
 
 export io_interface
 
@@ -40,12 +41,13 @@ proc newModule*(
   settingsService: settings_Service.Service,
   walletAccountService: wallet_account_service.Service,
   networkService: network_service.Service,
+  tokenService: token_service.Service,
 ): Module =
   result = Module()
   result.delegate = delegate
   result.view = newView(result)
   result.viewVariant = newQVariant(result.view)
-  result.controller = controller.newController(result, events, stickersService, settingsService, walletAccountService, networkService)
+  result.controller = controller.newController(result, events, stickersService, settingsService, walletAccountService, networkService, tokenService)
   result.moduleLoaded = false
 
   singletonInstance.engine.setRootContextProperty("stickersModule", result.viewVariant)

--- a/src/app/modules/main/wallet_section/accounts/compact_item.nim
+++ b/src/app/modules/main/wallet_section/accounts/compact_item.nim
@@ -1,5 +1,7 @@
 import strformat
 
+import ../../../shared_models/currency_amount
+
 type
   Item* = object
     name: string
@@ -10,7 +12,7 @@ type
     walletType: string
     isWallet: bool
     isChat: bool
-    currencyBalance: float64
+    currencyBalance: CurrencyAmount
     emoji: string
     derivedfrom: string
 
@@ -23,7 +25,7 @@ proc initItem*(
   walletType: string,
   isWallet: bool,
   isChat: bool,
-  currencyBalance: float64,
+  currencyBalance: CurrencyAmount,
   emoji: string,
   derivedfrom: string
 ): Item =
@@ -81,7 +83,7 @@ proc getIsWallet*(self: Item): bool =
 proc getIsChat*(self: Item): bool =
   return self.isChat
 
-proc getCurrencyBalance*(self: Item): float64 =
+proc getCurrencyBalance*(self: Item): CurrencyAmount =
   return self.currencyBalance
 
 proc getDerivedFrom*(self: Item): string =

--- a/src/app/modules/main/wallet_section/accounts/controller.nim
+++ b/src/app/modules/main/wallet_section/accounts/controller.nim
@@ -1,8 +1,11 @@
-import sugar, sequtils
+import sugar, sequtils, tables
 import io_interface
 import ../../../../../app_service/service/wallet_account/service as wallet_account_service
 import ../../../../../app_service/service/accounts/service as accounts_service
 import ../../../../../app_service/service/network/service as network_service
+import ../../../../../app_service/service/token/service as token_service
+import ../../../../../app_service/service/currency/service as currency_service
+import ../../../../../app_service/service/currency/dto as currency_dto
 
 import ../../../../global/global_singleton
 import ../../../shared_modules/keycard_popup/io_interface as keycard_shared_module
@@ -19,6 +22,8 @@ type
     walletAccountService: wallet_account_service.Service
     accountsService: accounts_service.Service
     networkService: network_service.Service
+    tokenService: token_service.Service
+    currencyService: currency_service.Service
 
 proc newController*(
   delegate: io_interface.AccessInterface,
@@ -26,6 +31,8 @@ proc newController*(
   walletAccountService: wallet_account_service.Service,
   accountsService: accounts_service.Service,
   networkService: network_service.Service,
+  tokenService: token_service.Service,
+  currencyService: currency_service.Service,
 ): Controller =
   result = Controller()
   result.delegate = delegate
@@ -33,6 +40,8 @@ proc newController*(
   result.walletAccountService = walletAccountService
   result.accountsService = accountsService
   result.networkService = networkService
+  result.tokenService = tokenService
+  result.currencyService = currencyService
 
 proc delete*(self: Controller) =
   discard
@@ -112,3 +121,9 @@ proc getChainIds*(self: Controller): seq[int] =
 
 proc getEnabledChainIds*(self: Controller): seq[int] = 
   return self.networkService.getNetworks().filter(n => n.enabled).map(n => n.chainId)
+
+proc getCurrentCurrency*(self: Controller): string =
+  return self.walletAccountService.getCurrency()
+
+proc getCurrencyFormat*(self: Controller, symbol: string): CurrencyFormatDto =
+  return self.currencyService.getCurrencyFormat(symbol)

--- a/src/app/modules/main/wallet_section/accounts/item.nim
+++ b/src/app/modules/main/wallet_section/accounts/item.nim
@@ -1,44 +1,50 @@
 import strformat
 import ../../../shared_models/token_model as token_model
+import ../../../shared_models/currency_amount
 import ./compact_model as compact_model
 
 type
   Item* = object
     name: string
     address: string
+    mixedCaseAddress: string
     path: string
     color: string
     publicKey: string
     walletType: string
     isWallet: bool
     isChat: bool
-    currencyBalance: float64
+    currencyBalance: CurrencyAmount
     assets: token_model.Model
     emoji: string
     derivedfrom: string
     relatedAccounts: compact_model.Model
     keyUid: string
     migratedToKeycard: bool
+    ens: string
 
 proc initItem*(
   name: string,
   address: string,
+  mixedCaseAddress: string,
   path: string,
   color: string,
   publicKey: string,
   walletType: string,
   isWallet: bool,
   isChat: bool,
-  currencyBalance: float64,
+  currencyBalance: CurrencyAmount,
   assets: token_model.Model,
   emoji: string,
   derivedfrom: string,
   relatedAccounts: compact_model.Model,
   keyUid: string,
-  migratedToKeycard: bool
+  migratedToKeycard: bool,
+  ens: string
 ): Item =
   result.name = name
   result.address = address
+  result.mixedCaseAddress = mixedCaseAddress
   result.path = path
   result.color = color
   result.publicKey = publicKey
@@ -52,11 +58,13 @@ proc initItem*(
   result.relatedAccounts = relatedAccounts
   result.keyUid = keyUid
   result.migratedToKeycard = migratedToKeycard
+  result.ens = ens
 
 proc `$`*(self: Item): string =
   result = fmt"""WalletAccountItem(
     name: {self.name},
     address: {self.address},
+    mixedCaseAddress: {self.mixedCaseAddress},
     path: {self.path},
     color: {self.color},
     publicKey: {self.publicKey},
@@ -69,7 +77,8 @@ proc `$`*(self: Item): string =
     derivedfrom: {self.derivedfrom},
     relatedAccounts: {self.relatedAccounts}
     keyUid: {self.keyUid},
-    migratedToKeycard: {self.migratedToKeycard}
+    migratedToKeycard: {self.migratedToKeycard},
+    ens: {self.ens}
     ]"""
 
 proc getName*(self: Item): string =
@@ -77,6 +86,9 @@ proc getName*(self: Item): string =
 
 proc getAddress*(self: Item): string =
   return self.address
+
+proc getMixedCaseAddress*(self: Item): string =
+  return self.mixedCaseAddress
 
 proc getPath*(self: Item): string =
   return self.path
@@ -99,7 +111,7 @@ proc getIsWallet*(self: Item): bool =
 proc getIsChat*(self: Item): bool =
   return self.isChat
 
-proc getCurrencyBalance*(self: Item): float64 =
+proc getCurrencyBalance*(self: Item): CurrencyAmount =
   return self.currencyBalance
 
 proc getAssets*(self: Item): token_model.Model =
@@ -116,3 +128,6 @@ proc getKeyUid*(self: Item): string =
 
 proc getMigratedToKeycard*(self: Item): bool =
   return self.migratedToKeycard
+
+proc getEns*(self: Item): string =
+  return self.ens

--- a/src/app/modules/main/wallet_section/accounts/utils.nim
+++ b/src/app/modules/main/wallet_section/accounts/utils.nim
@@ -1,0 +1,68 @@
+import tables, sequtils, sugar
+
+import ./item
+
+import ../../../../../app_service/service/wallet_account/dto
+import ../../../../../app_service/service/token/dto as token_dto
+import ../../../../../app_service/service/currency/dto as currency_dto
+import ../../../shared_models/token_model as token_model
+import ../../../shared_models/token_item as token_item
+import ../../../shared_models/token_utils
+import ../../../shared_models/currency_amount
+import ../../../shared_models/currency_amount_utils
+
+import ./compact_item as compact_item
+import ./compact_model as compact_model
+
+proc walletAccountToCompactItem*(w: WalletAccountDto, enabledChainIds: seq[int], currency: string, currencyFormat: CurrencyFormatDto) : compact_item.Item =
+  return compact_item.initItem(
+    w.name,
+    w.address,
+    w.path,
+    w.color,
+    w.publicKey,
+    w.walletType,
+    w.isWallet,
+    w.isChat,
+    currencyAmountToItem(w.getCurrencyBalance(enabledChainIds, currency), currencyFormat),
+    w.emoji,
+    w.derivedfrom)
+
+proc walletAccountToItem*(
+  w: WalletAccountDto,
+  chainIds: seq[int],
+  enabledChainIds: seq[int],
+  currency: string,
+  keyPairMigrated: bool,
+  currencyFormat: CurrencyFormatDto,
+  tokenFormats: Table[string, CurrencyFormatDto],
+  ) : item.Item =
+  let assets = token_model.newModel()
+  assets.setItems(
+    w.tokens.map(t => walletTokenToItem(t, chainIds, enabledChainIds, currency, currencyFormat, tokenFormats[t.symbol]))
+  )
+
+  let relatedAccounts = compact_model.newModel()
+  relatedAccounts.setItems(
+    w.relatedAccounts.map(x => walletAccountToCompactItem(x, enabledChainIds, currency, currencyFormat))
+  )
+
+  result = initItem(
+    w.name,
+    w.address,
+    w.mixedCaseAddress,
+    w.path,
+    w.color,
+    w.publicKey,
+    w.walletType,
+    w.isWallet,
+    w.isChat,
+    currencyAmountToItem(w.getCurrencyBalance(enabledChainIds, currency), currencyFormat),
+    assets,
+    w.emoji,
+    w.derivedfrom,
+    relatedAccounts,
+    w.keyUid,
+    keyPairMigrated,
+    w.ens
+  )

--- a/src/app/modules/main/wallet_section/controller.nim
+++ b/src/app/modules/main/wallet_section/controller.nim
@@ -1,22 +1,29 @@
 import io_interface
 import ../../../../app_service/service/settings/service as settings_service
 import ../../../../app_service/service/wallet_account/service as wallet_account_service
+import ../../../../app_service/service/currency/service as currency_service
+
+import ../../shared_models/currency_amount
+import ../../shared_models/currency_amount_utils
 
 type
   Controller* = ref object of RootObj
     delegate: io_interface.AccessInterface
     settingsService: settings_service.Service
     walletAccountService: wallet_account_service.Service
+    currencyService: currency_service.Service
  
 proc newController*(
   delegate: io_interface.AccessInterface,
   settingsService: settings_service.Service,
   walletAccountService: wallet_account_service.Service,
+  currencyService: currency_service.Service,
 ): Controller =
   result = Controller()
   result.delegate = delegate
   result.settingsService = settingsService
   result.walletAccountService = walletAccountService
+  result.currencyService = currencyService
 
 proc delete*(self: Controller) =
   discard
@@ -33,8 +40,8 @@ proc getSigningPhrase*(self: Controller): string =
 proc isMnemonicBackedUp*(self: Controller): bool =
   return self.settingsService.getMnemonic().len > 0
 
-proc getCurrencyBalance*(self: Controller): float64 =
-  return self.walletAccountService.getTotalCurrencyBalance()
+proc getCurrencyBalance*(self: Controller): CurrencyAmount =
+  return currencyAmountToItem(self.walletAccountService.getTotalCurrencyBalance(), self.currencyService.getCurrencyFormat(self.getCurrency()))
 
 proc updateCurrency*(self: Controller, currency: string) =
   self.walletAccountService.updateCurrency(currency)

--- a/src/app/modules/main/wallet_section/current_account/controller.nim
+++ b/src/app/modules/main/wallet_section/current_account/controller.nim
@@ -1,24 +1,31 @@
-import sugar, sequtils
+import sugar, sequtils, Tables
 import io_interface
 import ../../../../../app_service/service/wallet_account/service as wallet_account_service
 import ../../../../../app_service/service/network/service as network_service
-
+import ../../../../../app_service/service/token/service as token_service
+import ../../../../../app_service/service/currency/service as currency_service
 
 type
   Controller* = ref object of RootObj
     delegate: io_interface.AccessInterface
     walletAccountService: wallet_account_service.Service
     networkService: network_service.Service
+    tokenService: token_service.Service
+    currencyService: currency_service.Service
  
 proc newController*(
   delegate: io_interface.AccessInterface,
   walletAccountService: wallet_account_service.Service,
   networkService: network_service.Service,
+  tokenService: token_service.Service,
+  currencyService: currency_service.Service,
 ): Controller =
   result = Controller()
   result.delegate = delegate
   result.walletAccountService = walletAccountService
   result.networkService = networkService
+  result.tokenService = tokenService
+  result.currencyService = currencyService
 
 proc delete*(self: Controller) =
   discard
@@ -40,3 +47,12 @@ proc getChainIds*(self: Controller): seq[int] =
 
 proc getEnabledChainIds*(self: Controller): seq[int] = 
   return self.networkService.getNetworks().filter(n => n.enabled).map(n => n.chainId)
+
+proc getCurrentCurrency*(self: Controller): string =
+  return self.walletAccountService.getCurrency()
+
+proc getCurrencyFormat*(self: Controller, symbol: string): CurrencyFormatDto =
+  return self.currencyService.getCurrencyFormat(symbol)
+
+proc getAllMigratedKeyPairs*(self: Controller): seq[KeyPairDto] =
+  return self.walletAccountService.getAllMigratedKeyPairs()

--- a/src/app/modules/main/wallet_section/module.nim
+++ b/src/app/modules/main/wallet_section/module.nim
@@ -16,6 +16,7 @@ import ../../../global/global_singleton
 import ../../../core/eventemitter
 import ../../../../app_service/service/keycard/service as keycard_service
 import ../../../../app_service/service/token/service as token_service
+import ../../../../app_service/service/currency/service as currency_service
 import ../../../../app_service/service/transaction/service as transaction_service
 import ../../../../app_service/service/collectible/service as collectible_service
 import ../../../../app_service/service/wallet_account/service as wallet_account_service
@@ -48,6 +49,7 @@ proc newModule*(
   delegate: delegate_interface.AccessInterface,
   events: EventEmitter,
   tokenService: token_service.Service,
+  currencyService: currency_service.Service,
   transactionService: transaction_service.Service,
   collectibleService: collectible_service.Service,
   walletAccountService: wallet_account_service.Service,
@@ -61,13 +63,13 @@ proc newModule*(
   result.delegate = delegate
   result.events = events
   result.moduleLoaded = false
-  result.controller = newController(result, settingsService, walletAccountService)
+  result.controller = newController(result, settingsService, walletAccountService, currencyService)
   result.view = newView(result)
 
-  result.accountsModule = accounts_module.newModule(result, events, keycardService, walletAccountService, accountsService, networkService)
+  result.accountsModule = accounts_module.newModule(result, events, keycardService, walletAccountService, accountsService, networkService, tokenService, currencyService)
   result.allTokensModule = all_tokens_module.newModule(result, events, tokenService, walletAccountService)
   result.collectiblesModule = collectibles_module.newModule(result, events, collectibleService, walletAccountService, networkService)
-  result.currentAccountModule = current_account_module.newModule(result, events, walletAccountService, networkService)
+  result.currentAccountModule = current_account_module.newModule(result, events, walletAccountService, networkService, tokenService, currencyService)
   result.transactionsModule = transactions_module.newModule(result, events, transactionService, walletAccountService, networkService)
   result.savedAddressesModule = saved_addresses_module.newModule(result, events, savedAddressService)
   result.buySellCryptoModule = buy_sell_crypto_module.newModule(result, events, transactionService)

--- a/src/app/modules/main/wallet_section/view.nim
+++ b/src/app/modules/main/wallet_section/view.nim
@@ -1,13 +1,14 @@
 import NimQml
 
 import ./io_interface
+import ../../shared_models/currency_amount
 
 QtObject:
   type
     View* = ref object of QObject
       delegate: io_interface.AccessInterface
       currentCurrency: string
-      totalCurrencyBalance: float64
+      totalCurrencyBalance: CurrencyAmount
       signingPhrase: string
       isMnemonicBackedUp: bool
 
@@ -66,7 +67,7 @@ QtObject:
   proc switchAccountByAddress(self: View, address: string) {.slot.} =
     self.delegate.switchAccountByAddress(address)
 
-  proc setTotalCurrencyBalance*(self: View, totalCurrencyBalance: float64) =
+  proc setTotalCurrencyBalance*(self: View, totalCurrencyBalance: CurrencyAmount) =
     self.totalCurrencyBalance = totalCurrencyBalance
     self.totalCurrencyBalanceChanged()
 

--- a/src/app/modules/shared_models/balance_item.nim
+++ b/src/app/modules/shared_models/balance_item.nim
@@ -1,0 +1,42 @@
+import strformat
+
+import ./currency_amount
+
+type
+  Item* = object
+    balance*: CurrencyAmount
+    address*: string
+    chainId*: int
+
+proc initItem*(
+  balance: CurrencyAmount,
+  address: string,
+  chainId: int,
+): Item =
+  result.balance = balance
+  result.address = address
+  result.chainId = chainId
+
+proc `$`*(self: Item): string =
+  result = fmt"""BalanceItem(
+    name: {self.balance},
+    address: {self.address},
+    chainId: {self.chainId},
+    ]"""
+
+proc getBalance*(self: Item): CurrencyAmount =
+  return self.balance
+
+proc getAddress*(self: Item): string =
+  return self.address
+
+proc getChainId*(self: Item): int =
+  return self.chainId
+
+proc getCurrencyBalance*(self: Item, currencyPrice: CurrencyAmount): CurrencyAmount =
+  return newCurrencyAmount(
+    self.balance.getAmount() * currencyPrice.getAmount(),
+    currencyPrice.getSymbol(),
+    currencyPrice.getDisplayDecimals(),
+    currencyPrice.isStripTrailingZeroesActive()
+  )

--- a/src/app/modules/shared_models/balance_model.nim
+++ b/src/app/modules/shared_models/balance_model.nim
@@ -1,6 +1,7 @@
 import NimQml, Tables, strutils, strformat
 
-import ../../../app_service/service/wallet_account/dto
+import balance_item
+import ./currency_amount
 
 type
   ModelRole {.pure.} = enum
@@ -11,7 +12,7 @@ type
 QtObject:
   type
     BalanceModel* = ref object of QAbstractListModel
-      items*: seq[BalanceDto]
+      items*: seq[Item]
 
   proc delete(self: BalanceModel) =
     self.items = @[]
@@ -63,7 +64,7 @@ QtObject:
     of ModelRole.Address:
       result = newQVariant(item.address)
     of ModelRole.Balance:
-      result = newQVariant($item.balance)
+      result = newQVariant(item.balance)
 
   proc rowData(self: BalanceModel, index: int, column: string): string {.slot.} =
     if (index >= self.items.len):
@@ -74,7 +75,7 @@ QtObject:
       of "address": result = $item.address
       of "balance": result = $item.balance
 
-  proc setItems*(self: BalanceModel, items: seq[BalanceDto]) =
+  proc setItems*(self: BalanceModel, items: seq[Item]) =
     self.beginResetModel()
     self.items = items
     self.endResetModel()

--- a/src/app/modules/shared_models/balance_utils.nim
+++ b/src/app/modules/shared_models/balance_utils.nim
@@ -1,0 +1,11 @@
+import ../../../app_service/service/wallet_account/dto
+import ../../../app_service/service/currency/dto as currency_dto
+import ./currency_amount_utils
+import ./balance_item
+
+proc balanceToItem*(b: BalanceDto, format: CurrencyFormatDto) : Item =
+  return initItem(
+    currencyAmountToItem(b.balance, format),
+    b.address,
+    b.chainId
+  )

--- a/src/app/modules/shared_models/currency_amount.nim
+++ b/src/app/modules/shared_models/currency_amount.nim
@@ -1,0 +1,67 @@
+import NimQml, strformat, json
+
+QtObject:
+  type CurrencyAmount* = ref object of QObject
+    amount: float64
+    symbol: string
+    displayDecimals: int
+    stripTrailingZeroes: bool
+
+  proc setup(self: CurrencyAmount) =
+    self.QObject.setup
+
+  proc delete*(self: CurrencyAmount) =
+    self.QObject.delete
+
+  proc newCurrencyAmount*(
+    amount: float64,
+    symbol: string,
+    displayDecimals: int,
+    stripTrailingZeroes: bool,
+  ): CurrencyAmount =
+    new(result, delete)
+    result.setup
+    result.amount = amount
+    result.symbol = symbol
+    result.displayDecimals = displayDecimals
+    result.stripTrailingZeroes = stripTrailingZeroes
+
+  proc `$`*(self: CurrencyAmount): string =
+    result = fmt"""CurrencyAmount(
+      amount: {self.amount},
+      symbol: {self.symbol},
+      displayDecimals: {self.displayDecimals},
+      stripTrailingZeroes: {self.stripTrailingZeroes}
+      )"""
+
+  proc getAmount*(self: CurrencyAmount): float64 =
+    return self.amount
+
+  proc getAmountFloat*(self: CurrencyAmount): float {.slot.}  =
+    return self.amount
+  QtProperty[float] amount:
+    read = getAmountFloat
+
+  proc getSymbol*(self: CurrencyAmount): string {.slot.} =
+    return self.symbol
+  QtProperty[string] symbol:
+    read = getSymbol
+
+  proc getDisplayDecimals*(self: CurrencyAmount): int {.slot.} =
+    return self.displayDecimals
+  QtProperty[int] displayDecimals:
+    read = getDisplayDecimals
+
+  proc isStripTrailingZeroesActive*(self: CurrencyAmount): bool {.slot.} =
+    return self.stripTrailingZeroes
+  QtProperty[bool] stripTrailingZeroes:
+    read = isStripTrailingZeroesActive
+
+  # Needed to expose object to QML, see issue #8913
+  proc toJsonNode*(self: CurrencyAmount): JsonNode =
+    result = %* {
+      "amount": self.amount,
+      "symbol": self.symbol,
+      "displayDecimals": self.displayDecimals,
+      "stripTrailingZeroes": self.stripTrailingZeroes
+    }

--- a/src/app/modules/shared_models/currency_amount_utils.nim
+++ b/src/app/modules/shared_models/currency_amount_utils.nim
@@ -1,0 +1,10 @@
+import ../../../app_service/service/currency/dto
+import ./currency_amount
+
+proc currencyAmountToItem*(amount: float64, format: CurrencyFormatDto) : CurrencyAmount =
+  return newCurrencyAmount(
+      amount,
+      format.symbol,
+      format.displayDecimals,
+      format.stripTrailingZeroes
+    )

--- a/src/app/modules/shared_models/token_item.nim
+++ b/src/app/modules/shared_models/token_item.nim
@@ -1,16 +1,18 @@
 import strformat
 
 import ../../../app_service/service/wallet_account/dto
+import ./balance_item as balance_item
 import ./balance_model as balance_model
+import ./currency_amount
 
 type
   Item* = object
     name: string
     symbol: string
-    totalBalance: float
-    totalCurrencyBalance: float
-    enabledNetworkCurrencyBalance: float
-    enabledNetworkBalance: float
+    totalBalance: CurrencyAmount
+    totalCurrencyBalance: CurrencyAmount
+    enabledNetworkCurrencyBalance: CurrencyAmount
+    enabledNetworkBalance: CurrencyAmount
     visibleForNetwork: bool
     visibleForNetworkWithPositiveBalance: bool
     balances: balance_model.BalanceModel
@@ -18,38 +20,40 @@ type
     assetWebsiteUrl: string
     builtOn: string
     address: string
-    marketCap: string
-    highDay: string
-    lowDay: string
-    changePctHour: string
-    changePctDay: string
-    changePct24hour: string
-    change24hour: string
-    currencyPrice: float
+    marketCap: CurrencyAmount
+    highDay: CurrencyAmount
+    lowDay: CurrencyAmount
+    changePctHour: float64
+    changePctDay: float64
+    changePct24hour: float64
+    change24hour: float64
+    currencyPrice: CurrencyAmount
     decimals: int
+    pegSymbol: string
 
 proc initItem*(
   name, symbol: string,
-  totalBalance: float,
-  totalCurrencyBalance: float,
-  enabledNetworkBalance: float,
-  enabledNetworkCurrencyBalance: float,
+  totalBalance: CurrencyAmount,
+  totalCurrencyBalance: CurrencyAmount,
+  enabledNetworkBalance: CurrencyAmount,
+  enabledNetworkCurrencyBalance: CurrencyAmount,
   visibleForNetwork: bool,
   visibleForNetworkWithPositiveBalance: bool,
-  balances: seq[BalanceDto],
+  balances: seq[balance_item.Item],
   description: string,
   assetWebsiteUrl: string,
   builtOn: string,
   address: string,
-  marketCap: string,
-  highDay: string,
-  lowDay: string,
-  changePctHour: string,
-  changePctDay: string,
-  changePct24hour: string,
-  change24hour: string,
-  currencyPrice: float,
+  marketCap: CurrencyAmount,
+  highDay: CurrencyAmount,
+  lowDay: CurrencyAmount,
+  changePctHour: float64,
+  changePctDay: float64,
+  changePct24hour: float64,
+  change24hour: float64,
+  currencyPrice: CurrencyAmount,
   decimals: int,
+  pegSymbol: string,
 ): Item =
   result.name = name
   result.symbol = symbol
@@ -74,6 +78,7 @@ proc initItem*(
   result.change24hour = change24hour
   result.currencyPrice = currencyPrice
   result.decimals = decimals
+  result.pegSymbol = pegSymbol
 
 proc `$`*(self: Item): string =
   result = fmt"""AllTokensItem(
@@ -98,6 +103,7 @@ proc `$`*(self: Item): string =
     change24hour: {self.change24hour},
     currencyPrice: {self.currencyPrice},
     decimals: {self.decimals},
+    pegSymbol: {self.pegSymbol},
     ]"""
 
 proc getName*(self: Item): string =
@@ -106,16 +112,16 @@ proc getName*(self: Item): string =
 proc getSymbol*(self: Item): string =
   return self.symbol
 
-proc getTotalBalance*(self: Item): float =
+proc getTotalBalance*(self: Item): CurrencyAmount =
   return self.totalBalance
 
-proc getTotalCurrencyBalance*(self: Item): float =
+proc getTotalCurrencyBalance*(self: Item): CurrencyAmount =
   return self.totalCurrencyBalance
 
-proc getEnabledNetworkBalance*(self: Item): float =
+proc getEnabledNetworkBalance*(self: Item): CurrencyAmount =
   return self.enabledNetworkBalance
 
-proc getEnabledNetworkCurrencyBalance*(self: Item): float =
+proc getEnabledNetworkCurrencyBalance*(self: Item): CurrencyAmount =
   return self.enabledNetworkCurrencyBalance
 
 proc getVisibleForNetwork*(self: Item): bool =
@@ -139,29 +145,32 @@ proc getBuiltOn*(self: Item): string =
 proc getAddress*(self: Item): string =
   return self.address
 
-proc getMarketCap*(self: Item): string =
+proc getMarketCap*(self: Item): CurrencyAmount =
   return self.marketCap
 
-proc getHighDay*(self: Item): string =
+proc getHighDay*(self: Item): CurrencyAmount =
   return self.highDay
 
-proc getLowDay*(self: Item): string =
+proc getLowDay*(self: Item): CurrencyAmount =
   return self.lowDay
 
-proc getChangePctHour*(self: Item): string =
+proc getChangePctHour*(self: Item): float64 =
   return self.changePctHour
 
-proc getChangePctDay*(self: Item): string =
+proc getChangePctDay*(self: Item): float64 =
   return self.changePctDay
 
-proc getChangePct24hour*(self: Item): string =
+proc getChangePct24hour*(self: Item): float64 =
   return self.changePct24hour
 
-proc getChange24hour*(self: Item): string =
+proc getChange24hour*(self: Item): float64 =
   return self.change24hour
 
-proc getCurrencyPrice*(self: Item): float =
+proc getCurrencyPrice*(self: Item): CurrencyAmount =
   return self.currencyPrice
 
 proc getDecimals*(self: Item): int =
   return self.decimals
+
+proc getPegSymbol*(self: Item): string =
+  return self.pegSymbol

--- a/src/app/modules/shared_models/token_utils.nim
+++ b/src/app/modules/shared_models/token_utils.nim
@@ -1,0 +1,42 @@
+import tables, sequtils, sugar
+import ../../../app_service/service/wallet_account/dto
+import ../../../app_service/service/currency/dto as currency_dto
+import ./currency_amount_utils
+import ./balance_utils
+import ./token_item
+
+proc walletTokenToItem*(
+  t: WalletTokenDto,
+  chainIds: seq[int],
+  enabledChainIds: seq[int],
+  currency: string,
+  currencyFormat: CurrencyFormatDto,
+  tokenFormat: CurrencyFormatDto,
+  ) : token_item.Item =
+  let marketValues = t.marketValuesPerCurrency.getOrDefault(currency)
+
+  return token_item.initItem(
+    t.name,
+    t.symbol,
+    currencyAmountToItem(t.getBalance(chainIds), tokenFormat),
+    currencyAmountToItem(t.getCurrencyBalance(chainIds, currency), currencyFormat),
+    currencyAmountToItem(t.getBalance(enabledChainIds), tokenFormat),
+    currencyAmountToItem(t.getCurrencyBalance(enabledChainIds, currency), currencyFormat),
+    t.getVisibleForNetwork(enabledChainIds),
+    t.getVisibleForNetworkWithPositiveBalance(enabledChainIds),
+    t.getBalances(enabledChainIds).map(b => balanceToItem(b, tokenFormat)),
+    t.description,
+    t.assetWebsiteUrl,
+    t.builtOn,
+    t.getAddress(),
+    currencyAmountToItem(marketValues.marketCap, currencyFormat),
+    currencyAmountToItem(marketValues.highDay, currencyFormat),
+    currencyAmountToItem(marketValues.lowDay, currencyFormat),
+    marketValues.changePctHour,
+    marketValues.changePctDay,
+    marketValues.changePct24hour,
+    marketValues.change24hour,
+    currencyAmountToItem(marketValues.price, currencyFormat),
+    t.decimals,
+    t.pegSymbol
+    )

--- a/src/app_service/service/currency/dto.nim
+++ b/src/app_service/service/currency/dto.nim
@@ -1,0 +1,6 @@
+
+type
+  CurrencyFormatDto* = ref object
+    symbol*: string
+    displayDecimals*: int
+    stripTrailingZeroes*: bool

--- a/src/app_service/service/currency/service.nim
+++ b/src/app_service/service/currency/service.nim
@@ -1,0 +1,55 @@
+import NimQml, strformat, strutils
+import ../settings/service as settings_service
+import ../token/service as token_service
+import ./dto, ./utils
+
+export dto
+
+const DECIMALS_CALCULATION_CURRENCY = "USD"
+
+QtObject:
+  type Service* = ref object of QObject
+    tokenService: token_service.Service
+    settingsService: settings_service.Service
+
+  proc delete*(self: Service) =
+    self.QObject.delete
+
+  proc newService*(
+    tokenService: token_service.Service,
+    settingsService: settings_service.Service,
+  ): Service =
+    new(result, delete)
+    result.QObject.setup
+    result.tokenService = tokenService
+    result.settingsService = settingsService
+  
+  proc init*(self: Service) =
+    discard
+
+  proc getFiatCurrencyFormat(self: Service, symbol: string): CurrencyFormatDto =
+    return CurrencyFormatDto(
+      symbol: toUpperAscii(symbol),
+      displayDecimals: getFiatDisplayDecimals(symbol),
+      stripTrailingZeroes: false
+    )
+
+  proc getTokenCurrencyFormat(self: Service, symbol: string): CurrencyFormatDto =
+    let pegSymbol = self.tokenService.getTokenPegSymbol(symbol)
+    if pegSymbol != "":
+      var currencyFormat = self.getFiatCurrencyFormat(pegSymbol)
+      currencyFormat.symbol = symbol
+      return currencyFormat
+    else:
+      let price = self.tokenService.getTokenPrice(symbol, DECIMALS_CALCULATION_CURRENCY, false)
+      return CurrencyFormatDto(
+        symbol: symbol,
+        displayDecimals: getTokenDisplayDecimals(price),
+        stripTrailingZeroes: true
+      )
+
+  proc getCurrencyFormat*(self: Service, symbol: string): CurrencyFormatDto =
+    if isCurrencyFiat(symbol):
+      return self.getFiatCurrencyFormat(symbol)
+    else:
+      return self.getTokenCurrencyFormat(symbol)

--- a/src/app_service/service/currency/utils.nim
+++ b/src/app_service/service/currency/utils.nim
@@ -1,0 +1,33 @@
+import math, chronicles, json, strutils
+import ../../../backend/backend as backend
+
+logScope:
+  topics = "currency-utils"
+
+proc isCurrencyFiat*(symbol: string): bool =
+    let response = backend.isCurrencyFiat(symbol)
+    return response.result.getBool
+
+proc getFiatDisplayDecimals*(symbol: string): int =
+    result = 0
+    try: 
+        let response = backend.getFiatCurrencyMinorUnit(symbol)
+        result = response.result.getInt
+    except Exception as e:
+        let errDesription = e.msg
+        error "error getFiatDisplayDecimals: ", errDesription
+
+proc getTokenDisplayDecimals*(currencyPrice: float): int =
+    var decimals = 0.0
+    if currencyPrice > 0:
+        const lowerCurrencyResolution = 0.1
+        const higherCurrencyResolution = 0.01
+        let lowerDecimalsBound = max(0.0, log10(currencyPrice) - log10(lowerCurrencyResolution))
+        let upperDecimalsBound = max(0.0, log10(currencyPrice) - log10(higherCurrencyResolution))
+
+        # Use as few decimals as needed to ensure lower precision
+        decimals = ceil(lowerDecimalsBound)
+        if (decimals + 1 < upperDecimalsBound):
+            # If allowed by upper bound, ensure resolution changes as soon as currency hits multiple of 10
+            decimals += 1
+    return decimals.int

--- a/src/app_service/service/message/service.nim
+++ b/src/app_service/service/message/service.nim
@@ -318,7 +318,7 @@ QtObject:
 
   proc getTransactionDetails*(self: Service, message: MessageDto): (string, string) =
     let networksDto = self.networkService.getNetworks()
-    var token = newTokenDto(networksDto[0].nativeCurrencyName, networksDto[0].chainId, parseAddress(ZERO_ADDRESS), networksDto[0].nativeCurrencySymbol, networksDto[0].nativeCurrencyDecimals, true)
+    var token = newTokenDto(networksDto[0].nativeCurrencyName, networksDto[0].chainId, parseAddress(ZERO_ADDRESS), networksDto[0].nativeCurrencySymbol, networksDto[0].nativeCurrencyDecimals, true, "")
 
     if message.transactionParameters.contract != "":
       for networkDto in networksDto:

--- a/src/app_service/service/token/dto.nim
+++ b/src/app_service/service/token/dto.nim
@@ -23,17 +23,7 @@ type
     color*: string
     isCustom* {.dontSerialize.}: bool
     isVisible* {.dontSerialize.}: bool
-    description* :string
-    assetWebsiteUrl*: string
-    builtOn*: string
-    smartContractAddress*: string
-    marketCap*: string
-    highDay*: string
-    lowDay*: string
-    changePctHour*: string
-    changePctDay*: string
-    changePct24hour*: string
-    change24hour*: string
+    pegSymbol*: string
 
 proc newTokenDto*(
   name: string,
@@ -42,18 +32,8 @@ proc newTokenDto*(
   symbol: string,
   decimals: int,
   hasIcon: bool,
+  pegSymbol: string,
   isCustom: bool = false,
-  description: string = "",
-  assetWebsiteUrl: string = "",
-  builtOn: string = "",
-  smartContractAddress: string = "",
-  marketCap: string = "",
-  highDay: string = "",
-  lowDay: string = "",
-  changePctHour: string = "",
-  changePctDay: string = "",
-  changePct24hour: string = "",
-  change24hour: string = "",
 ): TokenDto =
   return TokenDto(
     name: name,
@@ -62,6 +42,7 @@ proc newTokenDto*(
     symbol: symbol,
     decimals: decimals,
     hasIcon: hasIcon,
+    pegSymbol: pegSymbol,
     isCustom: isCustom
   )
 
@@ -76,6 +57,7 @@ proc toTokenDto*(jsonObj: JsonNode, isVisible: bool, hasIcon: bool = false, isCu
   discard jsonObj.getProp("symbol", result.symbol)
   discard jsonObj.getProp("decimals", result.decimals)
   discard jsonObj.getProp("color", result.color)
+  discard jsonObj.getProp("pegSymbol", result.pegSymbol)
   result.isVisible = isVisible
 
 proc addressAsString*(self: TokenDto): string =

--- a/src/backend/backend.nim
+++ b/src/backend/backend.nim
@@ -100,7 +100,7 @@ rpc(getTransactionEstimatedTime, "wallet"):
 
 rpc(fetchPrices, "wallet"):
   symbols: seq[string]
-  currency: string
+  currencies: seq[string]
 
 rpc(generateAccountWithDerivedPath, "accounts"):
   password: string
@@ -219,7 +219,7 @@ rpc(deleteDappPermissionsByNameAndAddress, "permissions"):
 
 rpc(fetchMarketValues, "wallet"):
   symbols: seq[string]
-  currency: string
+  currencies: seq[string]
 
 rpc(fetchTokenDetails, "wallet"):
   symbols: seq[string]
@@ -278,3 +278,9 @@ rpc(getBalanceHistory, "wallet"):
   chainId: int
   address: string
   timeInterval: int
+
+rpc(isCurrencyFiat, "wallet"):
+  code: string
+
+rpc(getFiatCurrencyMinorUnit, "wallet"):
+  code: string

--- a/storybook/pages/CommunitiesPortalLayoutPage.qml
+++ b/storybook/pages/CommunitiesPortalLayoutPage.qml
@@ -23,7 +23,6 @@ SplitView {
             SplitView.fillHeight: true
 
             communitiesStore: CommunitiesStore {
-                readonly property string locale: ""
                 readonly property int unreadNotificationsCount: 42
                 readonly property string communityTags: ModelsData.communityTags
                 readonly property var curatedCommunitiesModel: SortFilterProxyModel {

--- a/ui/StatusQ/src/StatusQ/Components/StatusCommunityCard.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusCommunityCard.qml
@@ -94,11 +94,11 @@ Rectangle {
     */
     property ListModel categories: ListModel {}
     /*!
-       \qmlproperty string StatusCommunityCard::locale
+       \qmlproperty var StatusCommunityCard::locale
        This property holds the application locale used to give format to members number representation.
        If not provided, default value is "en".
     */
-    property string locale: "en"
+    property var locale: Qt.locale("en")
     /*!
        \qmlproperty url StatusCommunityCard::banner
        This property holds the community banner image url.
@@ -148,14 +148,14 @@ Rectangle {
             const ks = 1000
             if(number > million) {
                 res = number / million
-                res = Number(number / million).toLocaleString(Qt.locale(root.locale), 'f', 1) + 'M'
+                res = Number(number / million).toLocaleString(root.locale, 'f', 1) + 'M'
             }
             else if(number > ks) {
                 res = number / ks
-                res = Number(number / ks).toLocaleString(Qt.locale(root.locale), 'f', 1) + 'K'
+                res = Number(number / ks).toLocaleString(root.locale, 'f', 1) + 'K'
             }
             else
-                res = Number(number).toLocaleString(Qt.locale(root.locale), 'f', 0)
+                res = Number(number).toLocaleString(root.locale, 'f', 0)
             return res
         }
     }

--- a/ui/StatusQ/src/StatusQ/Controls/StatusAccountSelector.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusAccountSelector.qml
@@ -47,7 +47,7 @@ Item {
         if (showBalanceForAssetSymbol == "" || minRequiredAssetBalance == 0 || !assetFound) {
             return root.isValid
         }
-        root.isValid = assetFound.totalBalance >= minRequiredAssetBalance
+        root.isValid = assetFound.totalBalance.amount >= minRequiredAssetBalance
         return root.isValid
     }
 
@@ -88,7 +88,7 @@ Item {
         if (!assetFound) {
             return
         }
-        txtAssetBalance.text = root.assetBalanceTextFn(assetFound.totalBalance)
+        txtAssetBalance.text = root.assetBalanceTextFn(assetFound.totalBalance.amount)
         txtAssetSymbol.text = " " + assetFound.symbol
     }
 

--- a/ui/StatusQ/src/StatusQ/Controls/Validators/StatusFloatValidator.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/Validators/StatusFloatValidator.qml
@@ -33,10 +33,10 @@ StatusValidator {
     property real bottom: qmlDoubleValidator.bottom
 
     /*!
-       \qmlproperty string StatusFloatValidator::locale
-       This property holds the name of the locale used to interpret the number.
+       \qmlproperty var StatusFloatValidator::locale
+       This property holds the locale used to interpret the number.
     */
-    property string locale
+    property var locale: Qt.locale()
 
     /*!
        \qmlproperty real StatusFloatValidator::top

--- a/ui/StatusQ/src/StatusQ/Controls/Validators/StatusIntValidator.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/Validators/StatusIntValidator.qml
@@ -35,10 +35,10 @@ StatusValidator {
     property int bottom
 
     /*!
-       \qmlproperty string StatusIntValidator::locale
-       This property holds the name of the locale used to interpret the number.
+       \qmlproperty var StatusIntValidator::locale
+       This property holds the locale used to interpret the number.
     */
-    property string locale
+    property var locale: Qt.locale()
 
     /*!
        \qmlproperty string StatusIntValidator::top
@@ -48,7 +48,7 @@ StatusValidator {
 
     name: "intValidator"
     errorMessage: qsTr("Please enter a valid numeric value.")
-    validatorObj: IntValidator { bottom: root.bottom; locale: root.locale; top: root.top }
+    validatorObj: IntValidator { bottom: root.bottom; locale: root.locale.name; top: root.top }
 
     validate: function (t) {
         // Basic validation management

--- a/ui/app/AppLayouts/Chat/controls/community/CollectiblesPanel.qml
+++ b/ui/app/AppLayouts/Chat/controls/community/CollectiblesPanel.qml
@@ -17,6 +17,7 @@ ColumnLayout {
     property alias amountText: amountInput.text
     property alias amount: amountInput.amount
     readonly property bool amountValid: amountInput.valid && amountInput.text.length > 0
+    property var locale
 
     signal pickerClicked
 
@@ -66,5 +67,7 @@ ColumnLayout {
         Layout.topMargin: 8
 
         allowDecimals: false
+
+        locale: root.locale
     }
 }

--- a/ui/app/AppLayouts/Chat/controls/community/HoldingsDropdown.qml
+++ b/ui/app/AppLayouts/Chat/controls/community/HoldingsDropdown.qml
@@ -291,6 +291,7 @@ StatusDropdown {
             tokenName: d.defaultTokenNameText
             amountText: d.tokenAmountText
             onAmountTextChanged: d.tokenAmountText = amountText
+            locale: root.store.locale
 
             readonly property real effectiveAmount: amountValid ? amount : 0
             onEffectiveAmountChanged: root.tokenAmount = effectiveAmount
@@ -343,6 +344,7 @@ StatusDropdown {
             collectibleName: d.defaultCollectibleNameText
             amountText: d.collectibleAmountText
             onAmountTextChanged: d.collectibleAmountText = amountText
+            locale: root.store.locale
 
             readonly property real effectiveAmount: amountValid ? amount : 0
             onEffectiveAmountChanged: root.collectibleAmount = effectiveAmount

--- a/ui/app/AppLayouts/Chat/controls/community/TokensPanel.qml
+++ b/ui/app/AppLayouts/Chat/controls/community/TokensPanel.qml
@@ -15,6 +15,7 @@ ColumnLayout {
     property alias amountText: amountInput.text
     property alias amount: amountInput.amount
     readonly property bool amountValid: amountInput.valid && amountInput.text.length > 0
+    property var locale
 
     signal pickerClicked
 
@@ -43,5 +44,7 @@ ColumnLayout {
 
         Layout.fillWidth: true
         Layout.topMargin: 8
+
+        locale: root.locale
     }
 }

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -7,7 +7,7 @@ import shared.stores 1.0
 QtObject {
     id: root
 
-    property string locale: localAppSettings.language
+    property var locale: Qt.locale(localAppSettings.language)
 
     property var contactsStore
 
@@ -464,7 +464,7 @@ QtObject {
     property var accounts: walletSectionAccounts.model
     property var currentAccount: walletSectionCurrent
     property string currentCurrency: walletSection.currentCurrency
-    property CurrenciesStore currencyStore: CurrenciesStore { }
+    property CurrenciesStore currencyStore: CurrenciesStore {}
     property var allNetworks: networksModule.all
     property var savedAddressesModel: walletSectionSavedAddresses.model
 

--- a/ui/app/AppLayouts/CommunitiesPortal/stores/CommunitiesStore.qml
+++ b/ui/app/AppLayouts/CommunitiesPortal/stores/CommunitiesStore.qml
@@ -28,7 +28,7 @@ QtObject {
     property bool discordImportHasCommunityImage: root.communitiesModuleInst.discordImportHasCommunityImage
     property var discordImportTasks: root.communitiesModuleInst.discordImportTasks
     property bool downloadingCommunityHistoryArchives: root.communitiesModuleInst.downloadingCommunityHistoryArchives
-    property string locale: localAppSettings.language
+    property var locale: Qt.locale(localAppSettings.language)
     property var advancedModule: profileSectionModule.advancedModule
 
     // TODO: Could the backend provide directly 2 filtered models??

--- a/ui/app/AppLayouts/Wallet/panels/WalletHeader.qml
+++ b/ui/app/AppLayouts/Wallet/panels/WalletHeader.qml
@@ -18,7 +18,7 @@ import "../stores"
 Item {
     id: root
 
-    property string locale: ""
+    property var locale
     property string currency: ""
     property var currentAccount
     property var store
@@ -46,7 +46,7 @@ Item {
                 font.pixelSize: 28
                 font.bold: true
                 color: Theme.palette.baseColor1
-                text: "%1 %2".arg(Utils.toLocaleString(root.currentAccount.currencyBalance.toFixed(2), root.locale, {"currency": true})).arg(root.currency.toUpperCase())
+                text: LocaleUtils.currencyAmountToLocaleString(root.currentAccount.currencyBalance, root.locale)
             }
         }
 

--- a/ui/app/AppLayouts/Wallet/popups/ReceiveModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/ReceiveModal.qml
@@ -59,6 +59,7 @@ StatusModal {
             root.selectedAccount = newAccount
         }
         showAllWalletTypes: true
+        locale: RootStore.locale
     }
 
     contentItem: Column {

--- a/ui/app/AppLayouts/Wallet/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Wallet/stores/RootStore.qml
@@ -22,12 +22,12 @@ QtObject {
     property var generatedAccounts: walletSectionAccounts.generated
     property var appSettings: localAppSettings
     property var accountSensitiveSettings: localAccountSensitiveSettings
-    property string locale: Qt.locale().name
+    property var locale: Qt.locale(appSettings.language)
     property bool hideSignPhraseModal: accountSensitiveSettings.hideSignPhraseModal
 
     property var currencyStore: SharedStore.RootStore.currencyStore
     property string currentCurrency: currencyStore.currentCurrency
-    property string totalCurrencyBalance: walletSection.totalCurrencyBalance
+    property var totalCurrencyBalance: walletSection.totalCurrencyBalance
     property string signingPhrase: walletSection.signingPhrase
     property string mnemonicBackedUp: walletSection.isMnemonicBackedUp
 

--- a/ui/app/AppLayouts/Wallet/views/LeftTabView.qml
+++ b/ui/app/AppLayouts/Wallet/views/LeftTabView.qml
@@ -82,7 +82,7 @@ Rectangle {
                 objectName: "walletLeftListAmountValue"
                 color: Style.current.textColor
                 text: {
-                    Utils.toLocaleString(parseFloat(RootStore.totalCurrencyBalance).toFixed(2), localAppSettings.language, {"currency": true}) + " " + RootStore.currentCurrency.toUpperCase()
+                    LocaleUtils.currencyAmountToLocaleString(RootStore.totalCurrencyBalance, RootStore.currencyStore.locale)
                 }
                 selectByMouse: true
                 cursorVisible: true
@@ -117,7 +117,7 @@ Rectangle {
                 width: ListView.view.width
                 highlighted: RootStore.currentAccount.name === model.name
                 title: model.name
-                subTitle: Utils.toLocaleString(model.currencyBalance.toFixed(2), RootStore.locale, {"model.currency": true}) + " " + RootStore.currentCurrency.toUpperCase()
+                subTitle: LocaleUtils.currencyAmountToLocaleString(model.currencyBalance, RootStore.currencyStore.locale)
                 asset.emoji: !!model.emoji ? model.emoji: ""
                 asset.color: model.color
                 asset.name: !model.emoji ? "filled-account": ""

--- a/ui/app/AppLayouts/Wallet/views/RightTabView.qml
+++ b/ui/app/AppLayouts/Wallet/views/RightTabView.qml
@@ -92,6 +92,7 @@ Item {
                     AssetsView {
                         account: RootStore.currentAccount
                         assetDetailsLaunched: stack.currentIndex === 2
+                        locale: RootStore.locale
                         onAssetClicked: {
                             assetDetailView.token = token
                             stack.currentIndex = 2

--- a/ui/app/AppLayouts/stores/RootStore.qml
+++ b/ui/app/AppLayouts/stores/RootStore.qml
@@ -7,7 +7,7 @@ import "../Profile/stores"
 QtObject {
     id: root
 
-    property string locale: localAppSettings.language
+    property var locale: Qt.locale(localAppSettings.language)
 
     property var mainModuleInst: mainModule
     property var aboutModuleInst: aboutModule

--- a/ui/imports/shared/controls/AmountInput.qml
+++ b/ui/imports/shared/controls/AmountInput.qml
@@ -10,7 +10,7 @@ Input {
     id: root
 
     property int maximumLength: 10
-    property var locale: Qt.locale()
+    property var locale
 
     readonly property alias amount: d.amount
     readonly property bool valid: validationError.length === 0
@@ -40,7 +40,7 @@ Input {
         decimals: root.allowDecimals ? 100 : 0
         bottom: 0
         notation: DoubleValidator.StandardNotation
-        locale: root.locale.name
+        locale: root.locale
     }
 
     onTextChanged: {

--- a/ui/imports/shared/controls/AssetAndAmountInput.qml
+++ b/ui/imports/shared/controls/AssetAndAmountInput.qml
@@ -181,7 +181,7 @@ Item {
              if (!selectAsset.selectedAsset) {
                  return
              }
-             txtBalance.text = Utils.stripTrailingZeros(parseFloat(selectAsset.selectedAsset.balance).toFixed(4))
+             txtBalance.text = Utils.stripTrailingZeros(selectAsset.selectedAsset.balance.amount.toFixed(4))
              if (inputAmount.text === "" || isNaN(inputAmount.text)) {
                  return
              }

--- a/ui/imports/shared/controls/AssetDelegate.qml
+++ b/ui/imports/shared/controls/AssetDelegate.qml
@@ -10,7 +10,7 @@ Item {
     id: assetDelegate
     objectName: symbol
 
-    property string locale: ""
+    property var locale
     property string currency: ""
     property string currencySymbol: ""
 
@@ -52,7 +52,7 @@ Item {
         anchors.leftMargin: Style.current.smallPadding
         font.pixelSize: 15
         color: Style.current.secondaryText
-        text: qsTr("%1 %2").arg(enabledNetworkBalance.toString()).arg(symbol)
+        text: LocaleUtils.currencyAmountToLocaleString(enabledNetworkBalance, root.locale)
     }
 
     StyledText {
@@ -63,6 +63,6 @@ Item {
         anchors.rightMargin: 0
         font.pixelSize: 15
         font.strikeout: false
-        text: enabledNetworkCurrencyBalance.toLocaleCurrencyString(Qt.locale(), assetDelegate.currencySymbol)
+        text: LocaleUtils.currencyAmountToLocaleString(enabledNetworkCurrencyBalance, root.locale)
     }
 }

--- a/ui/imports/shared/controls/AssetsDetailsHeader.qml
+++ b/ui/imports/shared/controls/AssetsDetailsHeader.qml
@@ -22,6 +22,7 @@ Control {
     }
     property var getNetworkColor: function(chainId){}
     property var getNetworkIcon: function(chainId){}
+    property var formatBalance: function(balance){}
 
     topPadding: Style.current.padding
 
@@ -77,7 +78,7 @@ Control {
                 id: chainRepeater
                 model: balances ? balances : null
                 delegate: InformationTag {
-                    tagPrimaryLabel.text: model.balance
+                    tagPrimaryLabel.text: root.formatBalance(model.balance)
                     tagPrimaryLabel.color: root.getNetworkColor(model.chainId)
                     image.source: Style.svg("tiny/%1".arg(root.getNetworkIcon(model.chainId)))
                 }

--- a/ui/imports/shared/controls/TokenBalancePerChainDelegate.qml
+++ b/ui/imports/shared/controls/TokenBalancePerChainDelegate.qml
@@ -8,14 +8,14 @@ import utils 1.0
 StatusListItem {
     id: root
 
-    property string currentCurrencySymbol
+    property var locale
     property var getNetworkIcon: function(chainId){
         return ""
     }
     signal tokenSelected(var selectedToken)
 
     title: name
-    label: enabledNetworkCurrencyBalance.toLocaleCurrencyString(Qt.locale(), root.currentCurrencySymbol)
+    label: LocaleUtils.currencyAmountToLocaleString(enabledNetworkCurrencyBalance, root.locale)
     asset.name: symbol ? Style.png("tokens/" + symbol) : ""
     asset.isImage: true
     asset.width: 32
@@ -34,14 +34,14 @@ StatusListItem {
             width: 16
             height: 16
             image.source: Style.svg("tiny/%1".arg(root.getNetworkIcon(chainId)))
-            visible: balance > 0
+            visible: balance.amount > 0
         }
     }
     Component {
         id: expandedItem
         StatusListItemTag {
             height: 16
-            title: balance
+            title: LocaleUtils.currencyAmountToLocaleString(balance, root.locale)
             titleText.font.pixelSize: 12
             closeButtonVisible: false
             bgColor: "transparent"
@@ -49,7 +49,7 @@ StatusListItem {
             asset.height: 16
             asset.isImage: true
             asset.name: Style.svg("tiny/%1".arg(root.getNetworkIcon(chainId)))
-            visible: balance > 0
+            visible: balance.amount > 0
         }
     }
 }

--- a/ui/imports/shared/controls/TokenDelegate.qml
+++ b/ui/imports/shared/controls/TokenDelegate.qml
@@ -9,10 +9,10 @@ import StatusQ.Core 0.1
 import utils 1.0
 
 StatusListItem {
-    property string currentCurrencySymbol
-
+    id: root
+    property var locale
     title: name
-    subTitle: `${enabledNetworkBalance} ${symbol}`
+    subTitle: LocaleUtils.currencyAmountToLocaleString(enabledNetworkBalance, root.locale)
     asset.name: symbol ? Style.png("tokens/" + symbol) : ""
     asset.isImage: true
     components: [
@@ -25,7 +25,7 @@ StatusListItem {
                 anchors.right: parent.right
                 font.pixelSize: 15
                 font.strikeout: false
-                text: enabledNetworkCurrencyBalance.toLocaleCurrencyString(Qt.locale(), currentCurrencySymbol)
+                text: LocaleUtils.currencyAmountToLocaleString(enabledNetworkCurrencyBalance, root.locale)
             }
             Row {
                 anchors.horizontalCenter: parent.horizontalCenter
@@ -35,7 +35,7 @@ StatusListItem {
                     font.pixelSize: 15
                     font.strikeout: false
                     color: valueColumn.textColor
-                    text: currencyPrice.toLocaleCurrencyString(Qt.locale(), currentCurrencySymbol)
+                    text: LocaleUtils.currencyAmountToLocaleString(currencyPrice, root.locale)
                 }
                 Rectangle {
                     width: 1
@@ -46,7 +46,7 @@ StatusListItem {
                     font.pixelSize: 15
                     font.strikeout: false
                     color: valueColumn.textColor
-                    text: changePct24hour !== "" ? "%1%".arg(changePct24hour) : "---"
+                    text: changePct24hour !== "" ? changePct24hour.toFixed(2) + "%" : "---"
                 }
             }
         }

--- a/ui/imports/shared/panels/StatusAssetSelector.qml
+++ b/ui/imports/shared/panels/StatusAssetSelector.qml
@@ -27,6 +27,7 @@ Item {
     property string userSelectedToken
     property string currentCurrencySymbol
     property string placeholderText
+    property var locale
 
     property var tokenAssetSourceFn: function (symbol) {
         return ""
@@ -149,7 +150,7 @@ Item {
         delegate: TokenBalancePerChainDelegate {
             objectName: "AssetSelector_ItemDelegate_" + symbol
             width: comboBox.control.popup.width
-            currentCurrencySymbol: root.currentCurrencySymbol
+            locale: root.locale
             getNetworkIcon: root.getNetworkIcon
             onTokenSelected: {
                 userSelectedToken = selectedToken.symbol

--- a/ui/imports/shared/popups/AccountsModalHeader.qml
+++ b/ui/imports/shared/popups/AccountsModalHeader.qml
@@ -18,6 +18,7 @@ import "../views"
 StatusFloatingButtonsSelector {
     id: root
 
+    property var locale
     property var selectedAccount
     // Expected signature: function(newAccount, newIndex)
     property var changeSelectedAccount: function(){}
@@ -88,7 +89,7 @@ StatusFloatingButtonsSelector {
     popupMenuDelegate: StatusListItem {
         implicitWidth: 272
         title: name
-        subTitle: currencyBalance
+        subTitle: LocaleUtils.currencyAmountToLocaleString(currencyBalance, locale)
         asset.emoji: !!emoji ? emoji: ""
         asset.color: model.color
         asset.name: !emoji ? "filled-account": ""

--- a/ui/imports/shared/popups/keycard/helpers/KeyPairUnknownItem.qml
+++ b/ui/imports/shared/popups/keycard/helpers/KeyPairUnknownItem.qml
@@ -131,10 +131,10 @@ Rectangle {
                         text: {
                             if (Global.appMain) {
                                 return "%1%2".arg(SharedStore.RootStore.currencyStore.currentCurrencySymbol)
-                                .arg(Utils.toLocaleString(model.account.balance.toFixed(2), appSettings.locale, {"model.account.currency": true}))
+                                .arg(Utils.toLocaleString(parseFloat(model.account.balance.amount).toFixed(2), appSettings.locale, {"model.account.currency": true}))
                             }
                             // without language/model refactor no way to read currency symbol or `appSettings.locale` before user logs in
-                            return "$%1".arg(Utils.toLocaleString(model.account.balance.toFixed(2), localAppSettings.language, {"model.account.currency": true}))
+                            return "$%1".arg(Utils.toLocaleString(parseFloat(model.account.balance.amount).toFixed(2), localAppSettings.language, {"model.account.currency": true}))
                         }
                         wrapMode: Text.WordWrap
                         font.pixelSize: Constants.keycard.general.fontSize2

--- a/ui/imports/shared/stores/CurrenciesStore.qml
+++ b/ui/imports/shared/stores/CurrenciesStore.qml
@@ -4,15 +4,20 @@ import utils 1.0
 QtObject {
     id: root
 
+    property var locale: Qt.locale(localAppSettings.language)
+
     property string currentCurrency: walletSection.currentCurrency
-    property string currentCurrencySymbol: {
+    property int currentCurrencyModelIndex: {
         for (var i=0; i<currenciesModel.count; i++) {
             if (currenciesModel.get(i).key === currentCurrency) {
-                return currenciesModel.get(i).symbol;
+                return i;
             }
         }
-        return "";
+        return 0;
     }
+
+    property string currentCurrencySymbol: currenciesModel.get(currentCurrencyModelIndex).symbol
+
     property ListModel currenciesModel: ListModel {
        ListElement {
            key: "usd"
@@ -22,6 +27,7 @@ QtObject {
            category: ""
            imageSource: "../../assets/twemoji/svg/1f1fa-1f1f8.svg"
            selected: false
+           isToken: false
        }
 
        ListElement {
@@ -32,6 +38,7 @@ QtObject {
            category: ""
            imageSource: "../../assets/twemoji/svg/1f1ec-1f1e7.svg"
            selected: false
+           isToken: false
        }
 
        ListElement {
@@ -42,6 +49,7 @@ QtObject {
            category: ""
            imageSource: "../../assets/twemoji/svg/1f1ea-1f1fa.svg"
            selected: false
+           isToken: false
        }
 
        ListElement {
@@ -52,6 +60,7 @@ QtObject {
            category: ""
            imageSource: "../../assets/twemoji/svg/1f1f7-1f1fa.svg"
            selected: false
+           isToken: false
        }
 
        ListElement {
@@ -62,6 +71,7 @@ QtObject {
            category: ""
            imageSource: "../../assets/twemoji/svg/1f1f0-1f1f7.svg"
            selected: false
+           isToken: false
        }
 
        ListElement {
@@ -72,6 +82,7 @@ QtObject {
            category: qsTr("Tokens")
            imageSource: "../../../../imports/assets/png/tokens/ETH.png"
            selected: false
+           isToken: true
        }
 
        ListElement {
@@ -82,6 +93,7 @@ QtObject {
            category: qsTr("Tokens")
            imageSource: "../../../../imports/assets/png/tokens/WBTC.png"
            selected: false
+           isToken: true
        }
 
        ListElement {
@@ -92,6 +104,7 @@ QtObject {
            category: qsTr("Tokens")
            imageSource: "../../../../imports/assets/png/tokens/SNT.png"
            selected: false
+           isToken: true
        }
 
        ListElement {
@@ -102,6 +115,7 @@ QtObject {
            category: qsTr("Tokens")
            imageSource: "../../../../imports/assets/png/tokens/DAI.png"
            selected: false
+           isToken: true
        }
 
        ListElement {
@@ -112,6 +126,7 @@ QtObject {
            category: qsTr("Other Fiat")
            imageSource: "../../assets/twemoji/svg/1f1e6-1f1ea.svg"
            selected: false
+           isToken: false
        }
 
        ListElement {
@@ -122,6 +137,7 @@ QtObject {
            category: qsTr("Other Fiat")
            imageSource: "../../assets/twemoji/svg/1f1e6-1f1eb.svg"
            selected: false
+           isToken: false
        }
 
        ListElement {
@@ -132,6 +148,7 @@ QtObject {
            category: qsTr("Other Fiat")
            imageSource: "../../assets/twemoji/svg/1f1e6-1f1f7.svg"
            selected: false
+           isToken: false
        }
 
        ListElement {
@@ -142,6 +159,7 @@ QtObject {
            category: qsTr("Other Fiat")
            imageSource: "../../assets/twemoji/svg/1f1e6-1f1fa.svg"
            selected: false
+           isToken: false
        }
 
        ListElement {
@@ -152,6 +170,7 @@ QtObject {
            category: qsTr("Other Fiat")
            imageSource: "../../assets/twemoji/svg/1f1e7-1f1e7.svg"
            selected: false
+           isToken: false
        }
 
        ListElement {
@@ -162,6 +181,7 @@ QtObject {
            category: qsTr("Other Fiat")
            imageSource: "../../assets/twemoji/svg/1f1e7-1f1e9.svg"
            selected: false
+           isToken: false
        }
 
        ListElement {
@@ -172,6 +192,7 @@ QtObject {
            category: qsTr("Other Fiat")
            imageSource: "../../assets/twemoji/svg/1f1e7-1f1ec.svg"
            selected: false
+           isToken: false
        }
 
        ListElement {
@@ -182,6 +203,7 @@ QtObject {
            category: qsTr("Other Fiat")
            imageSource: "../../assets/twemoji/svg/1f1e7-1f1ed.svg"
            selected: false
+           isToken: false
        }
 
        ListElement {
@@ -192,6 +214,7 @@ QtObject {
            category: qsTr("Other Fiat")
            imageSource: "../../assets/twemoji/svg/1f1e7-1f1f3.svg"
            selected: false
+           isToken: false
        }
 
        ListElement {
@@ -202,6 +225,7 @@ QtObject {
            category: qsTr("Other Fiat")
            imageSource: "../../assets/twemoji/svg/1f1e7-1f1f4.svg"
            selected: false
+           isToken: false
        }
 
        ListElement {
@@ -212,6 +236,7 @@ QtObject {
            category: qsTr("Other Fiat")
            imageSource: "../../assets/twemoji/svg/1f1e7-1f1f7.svg"
            selected: false
+           isToken: false
        }
 
        ListElement {
@@ -222,6 +247,7 @@ QtObject {
            category: qsTr("Other Fiat")
            imageSource: "../../assets/twemoji/svg/1f1e7-1f1f9.svg"
            selected: false
+           isToken: false
        }
 
        ListElement {
@@ -232,6 +258,7 @@ QtObject {
            category: qsTr("Other Fiat")
            imageSource: "../../assets/twemoji/svg/1f1e8-1f1e6.svg"
            selected: false
+           isToken: false
        }
 
        ListElement {
@@ -242,6 +269,7 @@ QtObject {
            category: qsTr("Other Fiat")
            imageSource: "../../assets/twemoji/svg/1f1e8-1f1ed.svg"
            selected: false
+           isToken: false
        }
 
        ListElement {
@@ -252,6 +280,7 @@ QtObject {
            category: qsTr("Other Fiat")
            imageSource: "../../assets/twemoji/svg/1f1e8-1f1f1.svg"
            selected: false
+           isToken: false
        }
 
        ListElement {
@@ -262,6 +291,7 @@ QtObject {
            category: qsTr("Other Fiat")
            imageSource: "../../assets/twemoji/svg/1f1e8-1f1f3.svg"
            selected: false
+           isToken: false
        }
 
        ListElement {
@@ -282,6 +312,7 @@ QtObject {
            category: qsTr("Other Fiat")
            imageSource: "../../assets/twemoji/svg/1f1e8-1f1f7.svg"
            selected: false
+           isToken: false
        }
 
        ListElement {
@@ -292,6 +323,7 @@ QtObject {
            category: qsTr("Other Fiat")
            imageSource: "../../assets/twemoji/svg/1f1e8-1f1ff.svg"
            selected: false
+           isToken: false
        }
 
        ListElement {
@@ -302,6 +334,7 @@ QtObject {
            category: qsTr("Other Fiat")
            imageSource: "../../assets/twemoji/svg/1f1e9-1f1f0.svg"
            selected: false
+           isToken: false
        }
 
        ListElement {
@@ -312,6 +345,7 @@ QtObject {
            category: qsTr("Other Fiat")
            imageSource: "../../assets/twemoji/svg/1f1e9-1f1f4.svg"
            selected: false
+           isToken: false
        }
 
        ListElement {
@@ -322,6 +356,7 @@ QtObject {
            category: qsTr("Other Fiat")
            imageSource: "../../assets/twemoji/svg/1f1ea-1f1ec.svg"
            selected: false
+           isToken: false
        }
 
        ListElement {
@@ -332,6 +367,7 @@ QtObject {
            category: qsTr("Other Fiat")
            imageSource: "../../assets/twemoji/svg/1f1ea-1f1f9.svg"
            selected: false
+           isToken: false
        }
 
        ListElement {
@@ -342,6 +378,7 @@ QtObject {
            category: qsTr("Other Fiat")
            imageSource: "../../assets/twemoji/svg/1f1ec-1f1ea.svg"
            selected: false
+           isToken: false
        }
 
        ListElement {
@@ -352,6 +389,7 @@ QtObject {
            category: qsTr("Other Fiat")
            imageSource: "../../assets/twemoji/svg/1f1ec-1f1ed.svg"
            selected: false
+           isToken: false
        }
 
        ListElement {
@@ -362,6 +400,7 @@ QtObject {
            category: qsTr("Other Fiat")
            imageSource: "../../assets/twemoji/svg/1f1ed-1f1f0.svg"
            selected: false
+           isToken: false
        }
 
        ListElement {
@@ -372,6 +411,7 @@ QtObject {
            category: qsTr("Other Fiat")
            imageSource: "../../assets/twemoji/svg/1f1ed-1f1f7.svg"
            selected: false
+           isToken: false
        }
 
        ListElement {
@@ -382,6 +422,7 @@ QtObject {
            category: qsTr("Other Fiat")
            imageSource: "../../assets/twemoji/svg/1f1ed-1f1fa.svg"
            selected: false
+           isToken: false
        }
 
        ListElement {
@@ -392,6 +433,7 @@ QtObject {
            category: qsTr("Other Fiat")
            imageSource: "../../assets/twemoji/svg/1f1ee-1f1e9.svg"
            selected: false
+           isToken: false
        }
 
        ListElement {
@@ -402,6 +444,7 @@ QtObject {
            category: qsTr("Other Fiat")
            imageSource: "../../assets/twemoji/svg/1f1ee-1f1f1.svg"
            selected: false
+           isToken: false
        }
 
        ListElement {
@@ -412,6 +455,7 @@ QtObject {
            category: qsTr("Other Fiat")
            imageSource: "../../assets/twemoji/svg/1f1ee-1f1f3.svg"
            selected: false
+           isToken: false
        }
 
        ListElement {
@@ -422,6 +466,7 @@ QtObject {
            category: qsTr("Other Fiat")
            imageSource: "../../assets/twemoji/svg/1f1ee-1f1f8.svg"
            selected: false
+           isToken: false
        }
 
        ListElement {
@@ -432,6 +477,7 @@ QtObject {
            category: qsTr("Other Fiat")
            imageSource: "../../assets/twemoji/svg/1f1ef-1f1f2.svg"
            selected: false
+           isToken: false
        }
 
        ListElement {
@@ -442,6 +488,7 @@ QtObject {
            category: qsTr("Other Fiat")
            imageSource: "../../assets/twemoji/svg/1f1ef-1f1f5.svg"
            selected: false
+           isToken: false
        }
 
        ListElement {
@@ -452,6 +499,7 @@ QtObject {
            category: qsTr("Other Fiat")
            imageSource: "../../assets/twemoji/svg/1f1f0-1f1ea.svg"
            selected: false
+           isToken: false
        }
 
        ListElement {
@@ -462,6 +510,7 @@ QtObject {
            category: qsTr("Other Fiat")
            imageSource: "../../assets/twemoji/svg/1f1f0-1f1fc.svg"
            selected: false
+           isToken: false
        }
 
        ListElement {
@@ -472,6 +521,7 @@ QtObject {
            category: qsTr("Other Fiat")
            imageSource: "../../assets/twemoji/svg/1f1f0-1f1ff.svg"
            selected: false
+           isToken: false
        }
 
        ListElement {
@@ -482,6 +532,7 @@ QtObject {
            category: qsTr("Other Fiat")
            imageSource: "../../assets/twemoji/svg/1f1f1-1f1f0.svg"
            selected: false
+           isToken: false
        }
 
        ListElement {
@@ -492,6 +543,7 @@ QtObject {
            category: qsTr("Other Fiat")
            imageSource: "../../assets/twemoji/svg/1f1f2-1f1e6.svg"
            selected: false
+           isToken: false
        }
 
        ListElement {
@@ -502,6 +554,7 @@ QtObject {
            category: qsTr("Other Fiat")
            imageSource: "../../assets/twemoji/svg/1f1f2-1f1e9.svg"
            selected: false
+           isToken: false
        }
 
        ListElement {
@@ -512,6 +565,7 @@ QtObject {
            category: qsTr("Other Fiat")
            imageSource: "../../assets/twemoji/svg/1f1f2-1f1f7.svg"
            selected: false
+           isToken: false
        }
 
        ListElement {
@@ -522,6 +576,7 @@ QtObject {
            category: qsTr("Other Fiat")
            imageSource: "../../assets/twemoji/svg/1f1f2-1f1fc.svg"
            selected: false
+           isToken: false
        }
 
        ListElement {
@@ -532,6 +587,7 @@ QtObject {
            category: qsTr("Other Fiat")
            imageSource: "../../assets/twemoji/svg/1f1f2-1f1fd.svg"
            selected: false
+           isToken: false
        }
 
        ListElement {
@@ -542,6 +598,7 @@ QtObject {
            category: qsTr("Other Fiat")
            imageSource: "../../assets/twemoji/svg/1f1f2-1f1fe.svg"
            selected: false
+           isToken: false
        }
 
        ListElement {
@@ -552,6 +609,7 @@ QtObject {
            category: qsTr("Other Fiat")
            imageSource: "../../assets/twemoji/svg/1f1f2-1f1ff.svg"
            selected: false
+           isToken: false
        }
 
        ListElement {
@@ -562,6 +620,7 @@ QtObject {
            category: qsTr("Other Fiat")
            imageSource: "../../assets/twemoji/svg/1f1f3-1f1e6.svg"
            selected: false
+           isToken: false
        }
 
        ListElement {
@@ -572,6 +631,7 @@ QtObject {
            category: qsTr("Other Fiat")
            imageSource: "../../assets/twemoji/svg/1f1f3-1f1ec.svg"
            selected: false
+           isToken: false
        }
 
        ListElement {
@@ -582,6 +642,7 @@ QtObject {
            category: qsTr("Other Fiat")
            imageSource: "../../assets/twemoji/svg/1f1f3-1f1f4.svg"
            selected: false
+           isToken: false
        }
 
        ListElement {
@@ -592,6 +653,7 @@ QtObject {
            category: qsTr("Other Fiat")
            imageSource: "../../assets/twemoji/svg/1f1f3-1f1f5.svg"
            selected: false
+           isToken: false
        }
 
        ListElement {
@@ -602,6 +664,7 @@ QtObject {
            category: qsTr("Other Fiat")
            imageSource: "../../assets/twemoji/svg/1f1f3-1f1ff.svg"
            selected: false
+           isToken: false
        }
 
        ListElement {
@@ -622,6 +685,7 @@ QtObject {
            category: qsTr("Other Fiat")
            imageSource: "../../assets/twemoji/svg/1f1f5-1f1ea.svg"
            selected: false
+           isToken: false
        }
 
        ListElement {
@@ -632,6 +696,7 @@ QtObject {
            category: qsTr("Other Fiat")
            imageSource: "../../assets/twemoji/svg/1f1f5-1f1ec.svg"
            selected: false
+           isToken: false
        }
 
        ListElement {
@@ -642,6 +707,7 @@ QtObject {
            category: qsTr("Other Fiat")
            imageSource: "../../assets/twemoji/svg/1f1f5-1f1ed.svg"
            selected: false
+           isToken: false
        }
 
        ListElement {
@@ -652,6 +718,7 @@ QtObject {
            category: qsTr("Other Fiat")
            imageSource: "../../assets/twemoji/svg/1f1f5-1f1f0.svg"
            selected: false
+           isToken: false
        }
 
        ListElement {
@@ -662,6 +729,7 @@ QtObject {
            category: qsTr("Other Fiat")
            imageSource: "../../assets/twemoji/svg/1f1f5-1f1f1.svg"
            selected: false
+           isToken: false
        }
 
        ListElement {
@@ -672,6 +740,7 @@ QtObject {
            category: qsTr("Other Fiat")
            imageSource: "../../assets/twemoji/svg/1f1f5-1f1fe.svg"
            selected: false
+           isToken: false
        }
 
        ListElement {
@@ -682,6 +751,7 @@ QtObject {
            category: qsTr("Other Fiat")
            imageSource: "../../assets/twemoji/svg/1f1f6-1f1e6.svg"
            selected: false
+           isToken: false
        }
 
        ListElement {
@@ -692,6 +762,7 @@ QtObject {
            category: qsTr("Other Fiat")
            imageSource: "../../assets/twemoji/svg/1f1f7-1f1f4.svg"
            selected: false
+           isToken: false
        }
 
        ListElement {
@@ -702,6 +773,7 @@ QtObject {
            category: qsTr("Other Fiat")
            imageSource: "../../assets/twemoji/svg/1f1f7-1f1f8.svg"
            selected: false
+           isToken: false
        }
 
        ListElement {
@@ -712,6 +784,7 @@ QtObject {
            category: qsTr("Other Fiat")
            imageSource: "../../assets/twemoji/svg/1f1f8-1f1e6.svg"
            selected: false
+           isToken: false
        }
 
        ListElement {
@@ -722,6 +795,7 @@ QtObject {
            category: qsTr("Other Fiat")
            imageSource: "../../assets/twemoji/svg/1f1f8-1f1ea.svg"
            selected: false
+           isToken: false
        }
 
        ListElement {
@@ -732,6 +806,7 @@ QtObject {
            category: qsTr("Other Fiat")
            imageSource: "../../assets/twemoji/svg/1f1f8-1f1ec.svg"
            selected: false
+           isToken: false
        }
 
        ListElement {
@@ -742,6 +817,7 @@ QtObject {
            category: qsTr("Other Fiat")
            imageSource: "../../assets/twemoji/svg/1f1f9-1f1ed.svg"
            selected: false
+           isToken: false
        }
 
        ListElement {
@@ -752,6 +828,7 @@ QtObject {
            category: qsTr("Other Fiat")
            imageSource: "../../assets/twemoji/svg/1f1f9-1f1f9.svg"
            selected: false
+           isToken: false
        }
 
        ListElement {
@@ -762,6 +839,7 @@ QtObject {
            category: qsTr("Other Fiat")
            imageSource: "../../assets/twemoji/svg/1f1f9-1f1fc.svg"
            selected: false
+           isToken: false
        }
 
        ListElement {
@@ -772,6 +850,7 @@ QtObject {
            category: qsTr("Other Fiat")
            imageSource: "../../assets/twemoji/svg/1f1f9-1f1ff.svg"
            selected: false
+           isToken: false
        }
 
        ListElement {
@@ -782,6 +861,7 @@ QtObject {
            category: qsTr("Other Fiat")
            imageSource: "../../assets/twemoji/svg/1f1f9-1f1f7.svg"
            selected: false
+           isToken: false
        }
 
        ListElement {
@@ -792,6 +872,7 @@ QtObject {
            category: qsTr("Other Fiat")
            imageSource: "../../assets/twemoji/svg/1f1fa-1f1e6.svg"
            selected: false
+           isToken: false
        }
 
        ListElement {
@@ -802,6 +883,7 @@ QtObject {
            category: qsTr("Other Fiat")
            imageSource: "../../assets/twemoji/svg/1f1fa-1f1ec.svg"
            selected: false
+           isToken: false
        }
 
        ListElement {
@@ -812,6 +894,7 @@ QtObject {
            category: qsTr("Other Fiat")
            imageSource: "../../assets/twemoji/svg/1f1fa-1f1fe.svg"
            selected: false
+           isToken: false
        }
 
        ListElement {
@@ -822,6 +905,7 @@ QtObject {
            category: qsTr("Other Fiat")
            imageSource: "../../assets/twemoji/svg/1f1fb-1f1ea.svg"
            selected: false
+           isToken: false
        }
 
        ListElement {
@@ -832,6 +916,7 @@ QtObject {
            category: qsTr("Other Fiat")
            imageSource: "../../assets/twemoji/svg/1f1fb-1f1f3.svg"
            selected: false
+           isToken: false
        }
 
        ListElement {
@@ -842,6 +927,7 @@ QtObject {
            category: qsTr("Other Fiat")
            imageSource: "../../assets/twemoji/svg/1f1ff-1f1e6.svg"
            selected: false
+           isToken: false
        }
     }
 

--- a/ui/imports/shared/stores/RootStore.qml
+++ b/ui/imports/shared/stores/RootStore.qml
@@ -23,12 +23,12 @@ QtObject {
     property bool isTenorWarningAccepted: !!accountSensitiveSettings ? accountSensitiveSettings.isTenorWarningAccepted : false
     property bool displayChatImages: !!accountSensitiveSettings ? accountSensitiveSettings.displayChatImages : false
 
-    property string locale: Qt.locale().name
+    property var locale: Qt.locale(localAppSettings.language)
 //    property string signingPhrase: !!walletModelInst ? walletModelInst.utilsView.signingPhrase : ""
 //    property string gasPrice: !!walletModelInst ? walletModelInst.gasView.gasPrice : "0"
 //    property string gasEthValue: !!walletModelInst ? walletModelInst.gasView.getGasEthValue : "0"
 
-    property CurrenciesStore currencyStore: CurrenciesStore { }
+    property CurrenciesStore currencyStore: CurrenciesStore {}
     property string currentCurrency: walletSection.currentCurrency
 //    property string defaultCurrency: !!walletModelInst ? walletModelInst.balanceView.defaultCurrency : "0"
 //    property string fiatValue: !!walletModelInst ? walletModelInst.balanceView.getFiatValue : "0"

--- a/ui/imports/shared/stores/TransactionStore.qml
+++ b/ui/imports/shared/stores/TransactionStore.qml
@@ -8,14 +8,14 @@ import "../../../app/AppLayouts/Profile/stores"
 QtObject {
     id: root
 
-    property CurrenciesStore currencyStore: CurrenciesStore { }
+    property CurrenciesStore currencyStore: CurrenciesStore {}
     property ProfileSectionStore profileSectionStore: ProfileSectionStore {}
     property var contactStore: profileSectionStore.contactsStore
 
     property var mainModuleInst: mainModule
     property var walletSectionTransactionsInst: walletSectionTransactions
 
-    property string locale: localAppSettings.language
+    property var locale: Qt.locale(localAppSettings.language)
     property string currentCurrency: walletSection.currentCurrency
     property var allNetworks: networksModule.all
     property var accounts: walletSectionAccounts.model
@@ -245,5 +245,26 @@ QtObject {
                 lockedInAmounts.splice(index,1)
             }
         }
+    }
+
+    function getTokenBalanceOnChain(selectedAccount, chainId: int, tokenSymbol: string) {
+        if (!selectedAccount) {
+            console.warn("selectedAccount invalid")
+            return undefined
+        }
+
+        const jsonObj = selectedAccount.getTokenBalanceOnChainAsJson(chainId, tokenSymbol)
+        if (jsonObj === "") {
+            console.warn("failed to get balance, returned json is empty")
+            return undefined
+        }
+
+        const obj = JSON.parse(jsonObj)
+        if (obj.error) {
+            console.warn("failed to get balance, json parse error: ", obj.error)
+            return undefined
+        }
+
+        return obj
     }
 }

--- a/ui/imports/shared/views/AmountToReceive.qml
+++ b/ui/imports/shared/views/AmountToReceive.qml
@@ -9,6 +9,7 @@ import utils 1.0
 ColumnLayout {
     id: root
 
+    property var locale
     property var store
     property var selectedAsset
     property bool isLoading: false
@@ -20,7 +21,7 @@ ColumnLayout {
         id: d
         function formatValue(value) {
             const precision = (value === 0 ? 2 : 0)
-            return LocaleUtils.numberToLocaleString(value, precision)
+            return LocaleUtils.numberToLocaleString(value, precision, root.locale)
         }
         readonly property string fiatValue: {
             if(!root.selectedAsset || !amountToReceive)

--- a/ui/imports/shared/views/AmountToSend.qml
+++ b/ui/imports/shared/views/AmountToSend.qml
@@ -14,10 +14,11 @@ ColumnLayout {
 
     property alias input: amountToSendInput
 
+    property var locale
     property var selectedAsset
     property bool isBridgeTx: false
     property bool interactive: false
-    property double maxFiatBalance: -1
+    property var maxFiatBalance
     property bool cryptoFiatFlipped: false
     property string cryptoValueToSend: !cryptoFiatFlipped ? amountToSendInput.text : txtFiatBalance.text
     property string currentCurrency
@@ -35,7 +36,7 @@ ColumnLayout {
         }
         function formatValue(value, precision) {
             const precisionVal = !!precision ? precision : (value === 0 ? 2 : 0)
-            return LocaleUtils.numberToLocaleString(value, precisionVal)
+            return LocaleUtils.numberToLocaleString(value, precisionVal, root.locale)
         }
         function getFiatValue(value) {
             if(!root.selectedAsset || !value)
@@ -58,7 +59,7 @@ ColumnLayout {
     }
 
     onMaxFiatBalanceChanged: {
-        floatValidator.top = maxFiatBalance
+        floatValidator.top = maxFiatBalance.amount
         input.validate()
     }
 
@@ -84,7 +85,7 @@ ColumnLayout {
                 StatusFloatValidator {
                     id: floatValidator
                     bottom: 0
-                    top: root.maxFiatBalance
+                    top: root.maxFiatBalance.amount
                     errorMessage: ""
                 }
             ]

--- a/ui/imports/shared/views/AssetsDetailView.qml
+++ b/ui/imports/shared/views/AssetsDetailView.qml
@@ -58,14 +58,17 @@ Item {
         asset.name: token && token.symbol ? Style.png("tokens/%1".arg(token.symbol)) : ""
         asset.isImage: true
         primaryText: token ? token.name : ""
-        secondaryText: token ? `${token.enabledNetworkBalance} ${token.symbol}` : ""
-        tertiaryText: token ? "%1 %2".arg(Utils.toLocaleString(token.enabledNetworkCurrencyBalance.toFixed(2), RootStore.locale, {"currency": true})).arg(RootStore.currencyStore.currentCurrency.toUpperCase()) : ""
-        balances: token && token.balances ? token.balances :  null
+        secondaryText: token ? LocaleUtils.currencyAmountToLocaleString(token.enabledNetworkBalance, RootStore.locale) : ""
+        tertiaryText: token ? LocaleUtils.currencyAmountToLocaleString(token.enabledNetworkCurrencyBalance, RootStore.locale) : ""
+        balances: token && token.balances ? token.balances : null
         getNetworkColor: function(chainId){
             return RootStore.getNetworkColor(chainId)
         }
         getNetworkIcon: function(chainId){
             return RootStore.getNetworkIcon(chainId)
+        }
+        formatBalance: function(balance){
+            return LocaleUtils.currencyAmountToLocaleString(balance, RootStore.locale)
         }
     }
 
@@ -225,7 +228,7 @@ Item {
                                     fontColor: (Theme.palette.name === "dark") ? '#909090' : '#939BA1',
                                     padding: 8,
                                     callback: function(value, index, ticks) {
-                                        return LocaleUtils.numberToLocaleString(value)
+                                        return LocaleUtils.numberToLocaleString(value, -1, RootStore.locale)
                                     },
                                 }
                             }]
@@ -264,23 +267,23 @@ Item {
             InformationTile {
                 maxWidth: parent.width
                 primaryText: qsTr("Market Cap")
-                secondaryText: token && token.marketCap !== "" ? token.marketCap : "---"
+                secondaryText: token && token.marketCap ? LocaleUtils.currencyAmountToLocaleString(token.marketCap, RootStore.locale) : "---"
             }
             InformationTile {
                 maxWidth: parent.width
                 primaryText: qsTr("Day Low")
-                secondaryText: token && token.lowDay !== "" ? token.lowDay : "---"
+                secondaryText: token && token.lowDay ? LocaleUtils.currencyAmountToLocaleString(token.lowDay, RootStore.locale) : "---"
             }
             InformationTile {
                 maxWidth: parent.width
                 primaryText: qsTr("Day High")
-                secondaryText: token && token.highDay ? token.highDay : "---"
+                secondaryText: token && token.highDay ? LocaleUtils.currencyAmountToLocaleString(token.highDay, RootStore.locale) : "---"
             }
             Item {
                 Layout.fillWidth: true
             }
             InformationTile {
-                readonly property string changePctHour: token ? token.changePctHour : ""
+                readonly property string changePctHour: token ? token.changePctHour.toFixed(2) : ""
                 maxWidth: parent.width
                 primaryText: qsTr("Hour")
                 secondaryText: changePctHour ? "%1%".arg(changePctHour) : "---"
@@ -289,7 +292,7 @@ Item {
                                                                                                                          Theme.palette.successColor1
             }
             InformationTile {
-                readonly property string changePctDay: token ? token.changePctDay : ""
+                readonly property string changePctDay: token ? token.changePctDay.toFixed(2) : ""
                 maxWidth: parent.width
                 primaryText: qsTr("Day")
                 secondaryText: changePctDay ? "%1%".arg(changePctDay) : "---"
@@ -298,7 +301,7 @@ Item {
                                                                                                                        Theme.palette.successColor1
             }
             InformationTile {
-                readonly property string changePct24hour: token ? token.changePct24hour : ""
+                readonly property string changePct24hour: token ? token.changePct24hour.toFixed(2) : ""
                 maxWidth: parent.width
                 primaryText: qsTr("24 Hours")
                 secondaryText: changePct24hour ? "%1%".arg(changePct24hour) : "---"

--- a/ui/imports/shared/views/AssetsView.qml
+++ b/ui/imports/shared/views/AssetsView.qml
@@ -18,6 +18,7 @@ Item {
 
     property var account
     property bool assetDetailsLaunched: false
+    property var locale
 
     signal assetClicked(var token)
 
@@ -43,8 +44,8 @@ Item {
 
         delegate: TokenDelegate {
             objectName: "AssetView_TokenListItem_" + symbol
-            readonly property string balance: enabledNetworkBalance // Needed for the tests
-            currentCurrencySymbol: RootStore.currencyStore.currentCurrencySymbol
+            locale: root.locale
+            readonly property string balance: "%1".arg(enabledNetworkBalance.amount) // Needed for the tests
             width: ListView.view.width
             onClicked: {
                 RootStore.getHistoricalDataForToken(symbol, RootStore.currencyStore.currentCurrency)

--- a/ui/imports/shared/views/NetworkCardsComponent.qml
+++ b/ui/imports/shared/views/NetworkCardsComponent.qml
@@ -91,13 +91,14 @@ Item {
                     objectName: model.chainId
                     property double amountToSend: 0
                     property int routeOnNetwork: 0
-                    property string tokenBalanceOnChain: selectedAccount && selectedAccount!== undefined && selectedAsset!== undefined ? selectedAccount.getTokenBalanceOnChain(model.chainId, selectedAsset.symbol) : ""
+                    property bool tokenBalanceOnChainValid: selectedAccount && selectedAccount !== undefined && selectedAsset !== undefined
+                    property var tokenBalanceOnChain: tokenBalanceOnChainValid ? root.store.getTokenBalanceOnChain(selectedAccount, model.chainId, selectedAsset.symbol) : undefined
                     property var hasGas: selectedAccount.hasGas(model.chainId, model.nativeCurrencySymbol, requiredGasInEth)
 
                     primaryText: model.chainName
-                    secondaryText: (parseFloat(tokenBalanceOnChain) === 0 && root.amountToSend !== 0) ?
+                    secondaryText: (tokenBalanceOnChain.amount === 0) && root.amountToSend !== 0 ?
                                        qsTr("No Balance") : !hasGas ? qsTr("No Gas") : advancedInputText
-                    tertiaryText: root.errorMode && parseFloat(advancedInputText) !== 0 && advancedInput.valid ? qsTr("EXCEEDS SEND AMOUNT"): qsTr("BALANCE: ") + LocaleUtils.numberToLocaleString(parseFloat(tokenBalanceOnChain))
+                    tertiaryText: root.errorMode && parseFloat(advancedInputText) !== 0 && advancedInput.valid ? qsTr("EXCEEDS SEND AMOUNT"): qsTr("BALANCE: ") + LocaleUtils.currencyAmountToLocaleString(tokenBalanceOnChain, root.store.locale)
                     locked: store.lockedInAmounts.findIndex(lockedItem => lockedItem !== undefined && lockedItem.chainID ===  model.chainId) !== -1
                     preCalculatedAdvancedText: {
                         let index  = store.lockedInAmounts.findIndex(lockedItem => lockedItem!== undefined && lockedItem.chainID === model.chainId)
@@ -106,8 +107,8 @@ Item {
                         }
                         else return LocaleUtils.numberToLocaleString(fromNetwork.amountToSend)
                     }
-                    maxAdvancedValue: parseFloat(tokenBalanceOnChain)
-                    state: tokenBalanceOnChain === 0 || !hasGas ?
+                    maxAdvancedValue: tokenBalanceOnChain.amount
+                    state: tokenBalanceOnChain.amount === 0 || !hasGas ?
                                "unavailable" :
                                (root.errorMode || !advancedInput.valid) && (parseFloat(advancedInputText) !== 0) ? "error" : "default"
                     cardIcon.source: Style.svg(model.iconUrl)

--- a/ui/imports/shared/views/NetworksSimpleRoutingView.qml
+++ b/ui/imports/shared/views/NetworksSimpleRoutingView.qml
@@ -126,8 +126,9 @@ RowLayout {
                 rightPadding: 5
                 implicitWidth: 150
                 title: chainName
-                subTitle: selectedAccount && selectedAccount!== undefined && selectedAsset!== undefined ?
-                              selectedAccount.getTokenBalanceOnChain(chainId, selectedAsset.symbol) : ""
+                property bool tokenBalanceOnChainValid: selectedAccount && selectedAccount !== undefined && selectedAsset !== undefined
+                property var tokenBalanceOnChain: tokenBalanceOnChainValid ? root.store.getTokenBalanceOnChain(selectedAccount, chainId, selectedAsset.symbol) : undefined
+                subTitle: tokenBalanceOnChain ? LocaleUtils.currencyAmountToLocaleString(tokenBalanceOnChain, root.store.locale) : "N/A"
                 statusListItemSubTitle.color: Theme.palette.primaryColor1
                 asset.width: 32
                 asset.height: 32

--- a/ui/imports/shared/views/TabAddressSelectorView.qml
+++ b/ui/imports/shared/views/TabAddressSelectorView.qml
@@ -22,6 +22,7 @@ Item {
     implicitHeight: visible ? accountSelectionTabBar.height + stackLayout.height + Style.current.bigPadding: 0
 
     property var store
+    property var locale
 
     signal contactSelected(string address, int type)
 
@@ -152,7 +153,7 @@ Item {
                     objectName: model.name
                     height: visible ? 64 : 0
                     title: !!model.name ? model.name : ""
-                    subTitle: "%1 %2".arg(LocaleUtils.numberToLocaleString(model.currencyBalance)).arg(store.currentCurrency.toUpperCase())
+                    subTitle: LocaleUtils.currencyAmountToLocaleString(model.currencyBalance, root.locale)
                     asset.emoji: !!model.emoji ? model.emoji: ""
                     asset.color: model.color
                     asset.name: !model.emoji ? "filled-account": ""

--- a/ui/imports/shared/views/TokenListView.qml
+++ b/ui/imports/shared/views/TokenListView.qml
@@ -14,8 +14,8 @@ import "../controls"
 Rectangle {
     id: root
 
+    property var locale
     property var assets: []
-    property string currentCurrencySymbol
     signal tokenSelected(var selectedToken)
     property var searchTokenSymbolByAddressFn: function (address) {
         return ""
@@ -56,7 +56,7 @@ Rectangle {
         }
         delegate: TokenBalancePerChainDelegate {
             width: ListView.view.width
-            currentCurrencySymbol: root.currentCurrencySymbol
+            locale: root.locale
             getNetworkIcon: root.getNetworkIcon
             onTokenSelected: root.tokenSelected(selectedToken)
         }

--- a/ui/imports/utils/LocaleUtils.qml
+++ b/ui/imports/utils/LocaleUtils.qml
@@ -11,6 +11,11 @@ QtObject {
         return num.toString().split('.')[1].length
     }
 
+    function stripTrailingZeroes(numStr, locale) {
+        let regEx = locale.decimalPoint == "." ? /(\.[0-9]*[1-9])0+$|\.0*$/ : /(\,[0-9]*[1-9])0+$|\,0*$/
+        return numStr.replace(regEx, '$1')
+    }
+
     function numberToLocaleString(num, precision = -1, locale = null) {
         locale = locale || Qt.locale()
 
@@ -18,5 +23,24 @@ QtObject {
             precision = fractionalPartLength(num)
 
         return num.toLocaleString(locale, 'f', precision)
+    }
+
+    function currencyAmountToLocaleString(currencyAmount, locale) {
+        if (!locale) {
+            console.log("Unspecified locale for: " + JSON.stringify(currencyAmount))
+            locale = Qt.locale()
+        }
+        if (typeof(currencyAmount) !== "object") {
+            console.log("Wrong type for currencyAmount: " + JSON.stringify(currencyAmount))
+            return NaN
+        }
+        var amountStr = numberToLocaleString(currencyAmount.amount, currencyAmount.displayDecimals, locale)
+        if (currencyAmount.stripTrailingZeroes) {
+            amountStr = stripTrailingZeroes(amountStr, locale)
+        }
+        if (currencyAmount.symbol) {
+            amountStr = "%1 %2".arg(amountStr).arg(currencyAmount.symbol)
+        }
+        return amountStr
     }
 }

--- a/ui/imports/utils/Utils.qml
+++ b/ui/imports/utils/Utils.qml
@@ -88,7 +88,11 @@ QtObject {
     }
 
     function toLocaleString(val, locale, options) {
-      return NumberPolyFill.toLocaleString(val, locale, options)
+        if (typeof(val) === "object") {
+            console.log("Wrong type for val: " + JSON.stringify(val))
+            return NaN
+        }
+        return NumberPolyFill.toLocaleString(val, locale, options)
     }
 
     function isOnlyEmoji(inputText) {


### PR DESCRIPTION
Fixes #8640

Depends on https://github.com/status-im/status-go/pull/3041

### What does the PR do

In this PR, a unified way of formatting currency is implemented. This includes
- How many decimals are displayed
- How the currency symbol is shown

The specification can be found in #8640

This is a broad list of changes:
- Introduced CurrencyService. It is used to determine the formatting for each currency
- Make use of the new Peg and ISO4217 features of status-go
- (Chore) Moved token price cache to TokenService. TODO: Split WalletTokenDto (WalletAccountService) into WalletBalanceDto (WalletAccountService) + TokenInfoDto (TokenService) (https://github.com/status-im/status-desktop/issues/8912)
- Introduced CurrencyAmount item, used to hold all currency amounts + formatting details
- (Chore). Moved conversions from Dto to Items that were repeated across the code to corresponding utils files
- Implemented QML utils for formatting currencies. Replaced all "manual" formatting of currency amounts scattered across the code with use of the new utils.

Weird things I found out when implementing this:
- For some reason, you cannot return a QVariant in a proc exposed to QML if the proc takes parameters (other than `self`). A compilation error occurs. This prevented me from passing the CurrencyAmount item to `[NetworkCardsComponent.qml](https://github.com/status-im/status-desktop/pull/8911/files#diff-2e942cade3306afbdf634f1872a19f214ebec38983d2caafa2cd589277619b9c) and [NetworksSimpleRoutingView.qml](https://github.com/status-im/status-desktop/pull/8911/files#diff-e9b9caee0b5901cce7d121099d6d7ca6cf2dc106999fccafd8f1ae692d6c8842). Will need to investigate the root cause in https://github.com/status-im/status-desktop/issues/8913
- (FIXED) For some reason, you cannot have a `QtProperty[float]`. The data received on the QML side will be wrong. Using  `QtProperty[string]` and parsing where needed. 

I left handling of very large numbers (> Billions) as a separate task, this one's large enough as it is. https://github.com/status-im/status-desktop/issues/8917

I also left the Send and Bridge modals for a different PR, since they have a bunch of logic implemented in QML and require a bit of rework.

### Affected areas
Mainly the wallet, but there's some other parts of the app where currencies are shown (browser, ens name).

### Screenshots

Before:

<img width="1238" alt="Screenshot 2022-12-29 at 11 52 58" src="https://user-images.githubusercontent.com/11161531/209983964-79d4052b-5c57-494c-a4de-6e5a7ac061e2.png">
<img width="1234" alt="Screenshot 2022-12-29 at 11 53 11" src="https://user-images.githubusercontent.com/11161531/209983971-f8ef8789-5dad-4073-bba4-6a2e8e6fd12b.png">
<img width="1235" alt="Screenshot 2022-12-29 at 11 53 22" src="https://user-images.githubusercontent.com/11161531/209983975-ee6fb165-1f63-4b08-885c-2b871dcc231d.png">

After:
<img width="1072" alt="Screenshot 2022-12-29 at 13 39 13" src="https://user-images.githubusercontent.com/11161531/209983999-53125f36-8162-4330-81ec-7b7d161b2cd7.png">
<img width="1271" alt="Screenshot 2022-12-29 at 13 39 28" src="https://user-images.githubusercontent.com/11161531/209984005-bfbc5639-8a5c-40f5-b923-de8decf5cbc9.png">
<img width="1269" alt="Screenshot 2022-12-29 at 13 39 41" src="https://user-images.githubusercontent.com/11161531/209984006-6812cafd-98ce-433b-910b-fc1945746402.png">
<img width="1276" alt="Screenshot 2022-12-29 at 16 07 31" src="https://user-images.githubusercontent.com/11161531/209997875-253e07a7-bf69-4012-b960-50f7053519b1.png">
