### PR TITLE
6567 stickers hang when disconnected

### DIFF
--- a/src/app/modules/main/stickers/controller.nim
+++ b/src/app/modules/main/stickers/controller.nim
@@ -107,6 +107,10 @@ proc init*(self: Controller) =
       return
     self.delegate.onUserAuthenticated(args.password)
 
+  self.events.on(SIGNAL_STICKER_PACK_INSTALLED) do(e: Args):
+    let args = StickerPackInstalledArgs(e)
+    self.delegate.onStickerPackInstalled(args.packId)
+
 proc buy*(self: Controller, packId: string, address: string, gas: string, gasPrice: string, maxPriorityFeePerGas: string, maxFeePerGas: string, password: string, eip1559Enabled: bool): tuple[response: string, success: bool] =
   self.stickerService.buy(packId, address, gas, gasPrice, maxPriorityFeePerGas, maxFeePerGas, password, eip1559Enabled)
 

--- a/src/app/modules/main/stickers/io_interface.nim
+++ b/src/app/modules/main/stickers/io_interface.nim
@@ -49,6 +49,9 @@ method estimate*(self: AccessInterface, packId: string, address: string, price: 
 method installStickerPack*(self: AccessInterface, packId: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method onStickerPackInstalled*(self: AccessInterface, packId: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method uninstallStickerPack*(self: AccessInterface, packId: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/stickers/models/sticker_pack_list.nim
+++ b/src/app/modules/main/stickers/models/sticker_pack_list.nim
@@ -26,6 +26,7 @@ QtObject:
       delegate: io_interface.AccessInterface
       packs*: seq[StickerPackView]
       packIdToRetrieve*: int
+      foundStickers*: QVariant
 
   proc setup(self: StickerPackList) = self.QAbstractListModel.setup
 
@@ -122,6 +123,18 @@ QtObject:
   proc getStickers*(self: StickerPackList): QVariant {.slot.} =
     let packInfo = self.packs[self.packIdToRetrieve]
     result = newQVariant(packInfo.stickers)
+
+  # We cannot return QVariant from the proc which has arguments.
+  # First findStickersById has to be called, then getFoundStickers
+  proc findStickersById*(self: StickerPackList, packId: string) {.slot.} =
+    self.foundStickers = newQVariant()
+    for item in self.packs:
+      if(item.pack.id == packId):
+        self.foundStickers = newQVariant(item.stickers)
+        break
+
+  proc getFoundStickers*(self: StickerPackList): QVariant {.slot.} =
+    return self.foundStickers
 
   proc rowData*(self: StickerPackList, row: int, data: string): string {.slot.} =
     if row < 0 or (row > self.packs.len - 1):

--- a/src/app/modules/main/stickers/module.nim
+++ b/src/app/modules/main/stickers/module.nim
@@ -137,6 +137,9 @@ method getNumInstalledStickerPacks*(self: Module): int =
 method installStickerPack*(self: Module, packId: string) =
   self.controller.installStickerPack(packId)
 
+method onStickerPackInstalled*(self: Module, packId: string) =
+  self.view.onStickerPackInstalled(packId)
+
 method uninstallStickerPack*(self: Module, packId: string) =
   self.controller.uninstallStickerPack(packId)
 

--- a/src/app/modules/main/stickers/view.nim
+++ b/src/app/modules/main/stickers/view.nim
@@ -67,6 +67,8 @@ QtObject:
 
   proc stickerPacksLoaded*(self: View) {.signal.}
 
+  proc stickerPackInstalled*(self: View, packId: string) {.signal.}
+
   proc packsLoadFailedChanged*(self: View) {.signal.}
 
   proc installedStickerPacksUpdated*(self: View) {.signal.}
@@ -87,8 +89,11 @@ QtObject:
 
   proc install*(self: View, packId: string) {.slot.} =
     self.delegate.installStickerPack(packId)
+
+  proc onStickerPackInstalled*(self:View, packId: string) =
     self.stickerPacks.updateStickerPackInList(packId, true, false)
     self.installedStickerPacksUpdated()
+    self.stickerPackInstalled(packId)
 
   proc resetBuyAttempt*(self: View, packId: string) {.slot.} =
     self.stickerPacks.updateStickerPackInList(packId, false, false)

--- a/ui/imports/shared/status/StatusStickersPopup.qml
+++ b/ui/imports/shared/status/StatusStickersPopup.qml
@@ -82,9 +82,8 @@ Popup {
             stickerPacks: d.stickerPackList
             packId: stickerPackListView.selectedPackId
             onInstallClicked: {
+                //starts async task
                 stickersModule.install(packId)
-                stickerGrid.model = stickers
-                stickerPackListView.itemAt(index).clicked()
             }
             onUninstallClicked: {
                 stickersModule.uninstall(packId)
@@ -95,6 +94,19 @@ Popup {
                 stickerMarket.visible = false
                 footerContent.visible = true
                 stickersContainer.visible = true
+            }
+
+            Connections {
+                target: root.store.stickersModuleInst
+                function onStickerPackInstalled(packId) {
+                    const idx = stickersModule.stickerPacks.findIndexById(packId, false);
+                    if (idx === -1) {
+                        return
+                    }
+                    stickersModule.stickerPacks.findStickersById(packId)
+                    stickerGrid.model = stickersModule.stickerPacks.getFoundStickers()
+                    stickerPackListView.itemAt(idx).clicked()
+                }
             }
 
             Loader {


### PR DESCRIPTION
### What does the PR do

Fixes #6567 

Improve installing stickers code so it does not hang when there is no internet connection.
The solution contains 2 fixes:
- [status-go](https://github.com/status-im/status-go/pull/3043) fix - using timeout context - the operation times out after 5 seconds
- executing status-go request in thread in order not to block UI

### Affected areas

Chat / installing stickers

### Screenshot of functionality (including design for comparison)

https://user-images.githubusercontent.com/61889657/210208304-dc3e8a37-e14a-490f-9b32-9621d386ca2a.mov



