### PR TITLE
fix(@desktop/wallet): Wallet -> Activity tab: transaction history issues

### DIFF
--- a/src/app/modules/main/wallet_section/transactions/io_interface.nim
+++ b/src/app/modules/main/wallet_section/transactions/io_interface.nim
@@ -34,6 +34,9 @@ method setTrxHistoryResult*(self: AccessInterface, transactions: seq[Transaction
 method setHistoryFetchState*(self: AccessInterface, addresses: seq[string], isFetching: bool) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method setHistoryFetchState*(self: AccessInterface, address: string, isFetching: bool) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method setIsNonArchivalNode*(self: AccessInterface, isNonArchivalNode: bool) {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/wallet_section/transactions/model.nim
+++ b/src/app/modules/main/wallet_section/transactions/model.nim
@@ -248,5 +248,3 @@ QtObject:
       self.items = allTxs
       self.setItems(itemsWithDateHeaders)
       self.setHasMore(true)
-    else:
-      self.setHasMore(false)

--- a/src/app/modules/main/wallet_section/transactions/module.nim
+++ b/src/app/modules/main/wallet_section/transactions/module.nim
@@ -91,6 +91,9 @@ method setTrxHistoryResult*(self: Module, transactions: seq[TransactionDto], add
 method setHistoryFetchState*(self: Module, addresses: seq[string], isFetching: bool) =
   self.view.setHistoryFetchStateForAccounts(addresses, isFetching)
 
+method setHistoryFetchState*(self: Module, address: string, isFetching: bool) =
+  self.view.setHistoryFetchState(address, isFetching)
+
 method setIsNonArchivalNode*(self: Module, isNonArchivalNode: bool) =
   self.view.setIsNonArchivalNode(isNonArchivalNode)
 

--- a/src/app/modules/main/wallet_section/transactions/view.nim
+++ b/src/app/modules/main/wallet_section/transactions/view.nim
@@ -75,8 +75,6 @@ QtObject:
 
     self.models[address].addNewTransactions(transactions, wasFetchMore)
 
-    self.setHistoryFetchState(address, false)
-
   proc setHistoryFetchStateForAccounts*(self: View, addresses: seq[string], isFetching: bool) =
     for address in addresses:
       self.setHistoryFetchState(address, isFetching)

--- a/src/app_service/service/transaction/async_tasks.nim
+++ b/src/app_service/service/transaction/async_tasks.nim
@@ -26,7 +26,7 @@ const loadTransactionsTask*: Task = proc(argEncoded: string) {.gcsafe, nimcall.}
       "address": arg.address,
       "chainId": arg.chainId,
       "history": transactions.getTransfersByAddress(arg.chainId, arg.address, arg.toBlock, limitAsHex, arg.loadMore),
-      "loadMore": arg.loadMore
+      "loadMore": arg.loadMore,
     }
   arg.finish(output)
 

--- a/ui/imports/shared/views/HistoryView.qml
+++ b/ui/imports/shared/views/HistoryView.qml
@@ -44,7 +44,7 @@ ColumnLayout {
         id: loadingImg
         active: isLoading
         sourceComponent: loadingImageComponent
-        Layout.alignment: Qt.AlignRight | Qt.AlignTop
+        Layout.alignment: Qt.AlignHCenter | Qt.AlignTop
         Layout.rightMargin: Style.current.padding
     }
 
@@ -94,6 +94,7 @@ ColumnLayout {
             // is currently no way to know that there are no more results
             enabled: !isLoading && RootStore.historyTransactions.hasMore 
             onClicked: fetchHistory()
+            loading: isLoading
         }
     }
 


### PR DESCRIPTION
fixes #7278

### What does the PR do

The a load more button was greyed out even before the entire Tx list was presented , not allowing users to load more transaction

Added loading icon to the load more button so its clear a request is ongoing

Each time we request transaction they are made for all the networks enabled by the user, the issue was that we were showing that loading is completed before all the requests were completed and we wouldnt see the loader on the UI at all.

### Affected areas

Wallet

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it



https://user-images.githubusercontent.com/60327365/210331311-058262e9-8ad0-4892-a0cf-210610bb44e7.mov

