### PR TITLE
fix: Chat input: can't send html text from the clipboard

### DIFF
--- a/src/app/global/utils.nim
+++ b/src/app/global/utils.nim
@@ -140,6 +140,9 @@ QtObject:
   proc plainText*(self: Utils, text: string): string {.slot.} =
     result = plain_text(text)
 
+  proc escapeHtml*(self: Utils, text: string): string {.slot.} =
+    result = escape_html(text)
+
   proc getEmojiHashAsJson*(self: Utils, publicKey: string): string {.slot.} =
     procs_from_visual_identity_service.getEmojiHashAsJson(publicKey)
 

--- a/ui/imports/shared/popups/ContactVerificationRequestPopup.qml
+++ b/ui/imports/shared/popups/ContactVerificationRequestPopup.qml
@@ -28,7 +28,7 @@ StatusModal {
                 root.close()
             }
 
-            d.senderPublicKey = request.from,
+            d.senderPublicKey = request.from
             d.senderDisplayName = request.displayName
             d.senderIcon = request.icon
             d.challengeText = request.challenge

--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -365,10 +365,10 @@ Rectangle {
         } else if (event.key === Qt.Key_Escape && control.isReply) {
             control.isReply = false
             event.accepted = true
-        } else if (event.key === Qt.Key_Up && getPlainText() == "") {
+        } else if (event.key === Qt.Key_Up && messageInputField.length === 0) {
             event.accepted = true
             control.keyUpPress()
-            return 
+            return
         }
 
         const symbolPressed = event.text.length > 0 &&
@@ -458,8 +458,8 @@ Rectangle {
                 d.copyTextStart = messageInputField.cursorPosition
                 messageInputField.readOnly = true
 
-                const clipboardText = globalUtils.plainText(QClipboardProxy.text)
-                const copiedText = globalUtils.plainText(d.copiedTextPlain)
+                const clipboardText = Utils.plainText(QClipboardProxy.text)
+                const copiedText = Utils.plainText(d.copiedTextPlain)
                 if (copiedText === clipboardText) {
                     d.internalPaste = true
                 } else {
@@ -574,7 +574,7 @@ Rectangle {
 
         const deparsedEmoji = StatusQUtils.Emoji.deparse(textWithoutMention);
 
-        return globalUtils.plainText(deparsedEmoji)
+        return Utils.plainText(deparsedEmoji)
     }
 
     function removeMentions(currentText) {
@@ -717,9 +717,8 @@ Rectangle {
             insertInTextInput(d.copyTextStart, d.copiedTextFormatted)
             messageInputField.cursorPosition = d.copyTextStart + messageInputField.length - prevLength
             d.internalPaste = false
-        } else if (event.matches(StandardKey.Paste)) {
-            insertInTextInput(d.copyTextStart, QClipboardProxy.text)
-            messageInputField.cursorPosition = d.copyTextStart + QClipboardProxy.text.length
+        } else if (event.matches(StandardKey.Paste) && QClipboardProxy.hasText) {
+            messageInputField.insert(d.copyTextStart, "<div style='white-space: pre-wrap'>" + Utils.escapeHtml(QClipboardProxy.text) + "</div>") // preserve formatting
         }
 
         if (event.key !== Qt.Key_Escape) {

--- a/ui/imports/utils/Utils.qml
+++ b/ui/imports/utils/Utils.qml
@@ -731,12 +731,11 @@ QtObject {
     }
 
     function escapeHtml(unsafeStr) {
-        return unsafeStr
-            .replace(/&/g, "&amp;")
-            .replace(/</g, "&lt;")
-            .replace(/>/g, "&gt;")
-            .replace(/"/g, "&quot;")
-            .replace(/'/g, "&#039;");
+        return globalUtilsInst.escapeHtml(unsafeStr)
+    }
+
+    function plainText(text) {
+        return globalUtilsInst.plainText(text)
     }
 
     function isInvalidPasswordMessage(msg) {


### PR DESCRIPTION
We always take the plain text from the clipboard but even the plaintext can contain HTML tags, so escape those and wrap the result in a `<div style='white-space: pre-wrap'>foo</div>` container. That way we preserve not only the linebreaks but also any whitespace or tags. This also improves code snippet pasting a _lot_ (see 2nd screenshot).

The problem was that TextEdit was interpreting the HTML tags as if we were pasting HTML text (in fact we don't want this, we always meant to support plaintext only)

Remove manipulating the `messageInputField.cursorPosition`, it's done automatically by `messageInputField.insert` and we'd get it wrong most of the time anyways :)

Fixes #8919
Fixes #8538

### What does the PR do

Fix pasting of plain text to preserve formatting

### Affected areas

StatusChatInput

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

Text:
![image](https://user-images.githubusercontent.com/5377645/210460904-fa773ddd-c687-4434-a82a-0899c83f75bf.png)

Inside a codeblock:
![image](https://user-images.githubusercontent.com/5377645/210461314-3d784933-9604-40f7-9f3b-0bb07548220a.png)

