### PR TITLE
fix: Cannot open the link in the channel's description

### DIFF
--- a/ui/app/AppLayouts/Chat/views/ChatHeaderContentView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatHeaderContentView.qml
@@ -337,6 +337,7 @@ Item {
                     break;
                 }
             }
+            onLinkActivated: Global.openLink(link)
         }
     }
 


### PR DESCRIPTION
Hook up the `linkActivated` signal to open a hyper link

Fixes #8939

### What does the PR do

Fixes opening URLs which a channel description might contain 

### Affected areas

ChatHeaderContentView

### Screenshot of functionality (including design for comparison)

- [N/A] I've checked the design and this PR matches it

