### PR TITLE
feat(general): Initial setup for app monitoring tool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,6 +147,12 @@ else
  DOTHERSIDE_BUILD_CMD := cmake --build . --config Release $(HANDLE_OUTPUT)
 endif
 
+MONITORING ?= false
+ifneq ($(MONITORING), false)
+ DOTHERSIDE_CMAKE_PARAMS := ${DOTHERSIDE_CMAKE_PARAMS} -DMONITORING:BOOL=ON -DMONITORING_QML_ENTRY_POINT:STRING="/../monitoring/Main.qml"
+endif
+
+
 # Qt5 dirs (we can't indent with tabs here)
 ifneq ($(detected_OS),Windows)
  QT5_LIBDIR := $(shell qmake -query QT_INSTALL_LIBS 2>/dev/null)

--- a/monitoring/HotComponentFromSource.qml
+++ b/monitoring/HotComponentFromSource.qml
@@ -1,0 +1,44 @@
+import QtQuick 2.14
+
+QtObject {
+    id: root
+
+    property string source
+    property bool rethrowErrors: true
+    readonly property alias component: d.component
+    readonly property alias errors: d.errors // QQmlError
+
+    onSourceChanged: d.createComponent()
+
+    readonly property QtObject _d: QtObject {
+        id: d
+
+        property Component component
+        property var errors: null
+
+        function createComponent() {
+            if (component) {
+                component.destroy()
+                component = null
+            }
+
+            try {
+                component = Qt.createQmlObject(root.source,
+                    this,
+                    "HotComponentFromSource_dynamicSnippet"
+                )
+                d.errors = null
+            } catch (e) {
+                d.errors = e
+
+                if (root.rethrowErrors)
+                    throw e
+            }
+        }
+    }
+
+    Component.onCompleted: {
+        if (root.source)
+            d.createComponent()
+    }
+}

--- a/monitoring/HotLoader.qml
+++ b/monitoring/HotLoader.qml
@@ -1,0 +1,13 @@
+import QtQuick 2.14
+
+Loader {
+    sourceComponent: hotComponent.component
+
+    property alias source: hotComponent.source
+    property alias rethrowErrors: hotComponent.rethrowErrors
+    readonly property alias errors: hotComponent.errors
+
+    HotComponentFromSource {
+        id: hotComponent
+    }
+}

--- a/monitoring/Main.qml
+++ b/monitoring/Main.qml
@@ -1,0 +1,35 @@
+import QtQuick 2.14
+import QtQuick.Controls 2.14
+
+ApplicationWindow {
+    id: monitorRoot
+
+    width: 800
+    height: 600
+
+    visible: true
+    title: "Status Monitor"
+
+    Timer {
+        interval: 1000
+        running: true
+        repeat: true
+
+        onTriggered: {
+            const xhr = new XMLHttpRequest()
+            xhr.open("GET", "MonitorEntryPoint.qml", false)
+            xhr.send()
+
+            const content = xhr.responseText
+
+            if (loader.source != content)
+                loader.source = content
+        }
+    }
+
+    HotLoader {
+        id: loader
+
+        anchors.fill: parent
+    }
+}

--- a/monitoring/MonitorEntryPoint.qml
+++ b/monitoring/MonitorEntryPoint.qml
@@ -1,0 +1,40 @@
+import QtQuick 2.14
+import QtQuick.Controls 2.14
+import QtQuick.Layouts 1.14
+
+import Monitoring 1.0
+
+
+Component {
+    ColumnLayout {
+        anchors.fill: parent
+        anchors.margins: 10
+
+        spacing: 15
+
+        Label {
+            Layout.fillWidth: true
+
+            text: "Context properties:"
+            font.bold: true
+        }
+
+        ListView {
+            id: lv
+
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+
+            clip: true
+
+
+            model: Monitor.contexPropertiesNames
+
+            spacing: 5
+
+            delegate: Text {
+                text: modelData
+            }
+        }
+    }
+}

--- a/ui/nim-status-client.pro
+++ b/ui/nim-status-client.pro
@@ -16,6 +16,7 @@ lupdate_only{
 SOURCES += $$files("$$PWD/*qmldir", true)
 SOURCES += $$files("$$PWD/*.qml", true)
 SOURCES += $$files("$$PWD/*.js", true)
+SOURCES += $$files("$$PWD/../monitoring/*.qml", true)
 }
 
 # Other *.ts files will be provided by Lokalise platform
@@ -28,6 +29,7 @@ OTHER_FILES += $$files("$$PWD/*qmldir", true)
 OTHER_FILES += $$files("$$PWD/*.qml", true)
 OTHER_FILES += $$files("$$PWD/*.js", true)
 OTHER_FILES += $$files("$$PWD/../src/*.nim", true)
+OTHER_FILES += $$files("$$PWD/../monitoring/*.qml", true)
 
 # Additional import path used to resolve QML modules in Qt Creator's code model
 QML_IMPORT_PATH = $$PWD/imports \


### PR DESCRIPTION
### What does the PR do

Allows building the app with support for live inspection. When enabled, the separate window is opened to present inspection results. The intention is to track raw data coming from the backend, what can be beneficial for both development and debugging/profiling.

To compile the app with the monitoring support, `MONITORING=true` should be passed to `make`.

When compiled with the monitoring support, the monitoring window can be disabled by defining `DISABLE_MONITORING_WINDOW` env variable.

This is the initial setup, further work is intended to be provided in separate prs.

Closes: #8786
Depends on: https://github.com/status-im/dotherside/pull/85

[Kazam_screencast_00098.webm](https://user-images.githubusercontent.com/20650004/210600259-a41fd2b9-98b2-44af-b253-85ba872a0801.webm)