### PR TITLE
fix(chat-badge): don't count unread messages when restarting

### DIFF
--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -137,7 +137,7 @@ proc buildChatSectionUI(
       continue
 
     let hasNotification = not chatDto.muted and (chatDto.unviewedMessagesCount > 0 or chatDto.unviewedMentionsCount > 0)
-    let notificationsCount = if (chatDto.muted): 0 else: chatDto.unviewedMentionsCount
+    let notificationsCount = chatDto.unviewedMentionsCount
 
     var chatName = chatDto.name
     var chatImage = ""

--- a/src/app/modules/main/controller.nim
+++ b/src/app/modules/main/controller.nim
@@ -325,7 +325,8 @@ proc getNumOfNotificaitonsForChat*(self: Controller): tuple[unviewed:int, mentio
     if(chat.chatType == ChatType.CommunityChat):
       continue
 
-    result.unviewed += chat.unviewedMessagesCount
+    if not chat.muted:
+      result.unviewed += chat.unviewedMessagesCount
     result.mentions += chat.unviewedMentionsCount
 
 proc getNumOfNotificationsForCommunity*(self: Controller, communityId: string): tuple[unviewed:int, mentions:int] =
@@ -336,7 +337,8 @@ proc getNumOfNotificationsForCommunity*(self: Controller, communityId: string): 
     if(chat.communityId != communityId):
       continue
 
-    result.unviewed += chat.unviewedMessagesCount
+    if not chat.muted:
+      result.unviewed += chat.unviewedMessagesCount
     result.mentions += chat.unviewedMentionsCount
 
 proc setCurrentUserStatus*(self: Controller, status: StatusType) =

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -223,7 +223,7 @@ proc createChannelGroupItem[T](self: Module[T], c: ChannelGroupDto): SectionItem
     mentionsCount = mentionsCount + receivedContactRequests.len
 
   let hasNotification = unviewedCount > 0 or mentionsCount > 0
-  let notificationsCount = mentionsCount # we need to add here number of requests
+  let notificationsCount = mentionsCount
   let active = self.getActiveSectionId() == c.id # We must pass on if the current item section is currently active to keep that property as it is
   result = initItem(
     c.id,


### PR DESCRIPTION
Fixes #8943

If a channel is muted, don't increase `unviewedMessagesCount` for it. 
Only count mentions