### PR TITLE
fix(StatusBaseInput): No padding for input fields

### DIFF
--- a/ui/StatusQ/src/StatusQ/Controls/StatusBaseInput.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusBaseInput.qml
@@ -157,12 +157,12 @@ Item {
         \qmlproperty real StatusBaseInput::leftPadding
         This property sets the leftComponentLoader's left padding.
     */
-    property real leftPadding: leftComponentLoader.item ? 6 : 16
+    property real leftPadding: leftComponentLoader.status === Loader.Ready && leftComponentLoader.item ? 6 : 16
     /*!
         \qmlproperty real StatusBaseInput::rightPadding
         This property sets the right padding.
     */
-    property real rightPadding: 16
+    property real rightPadding: rightComponentLoader.status === Loader.Ready && rightComponentLoader.item ? 6 : 16
     /*!
         \qmlproperty real StatusBaseInput::topPadding
         This property sets the top padding.
@@ -305,7 +305,7 @@ Item {
                 root.editClicked()
             }
             RowLayout {
-                spacing: 2
+                spacing: 8
                 anchors {
                     fill: parent
                     leftMargin: root.leftPadding
@@ -329,7 +329,6 @@ Item {
                     id: flick
                     Layout.fillWidth: true
                     Layout.fillHeight: true
-                    Layout.leftMargin: !!leftComponentLoader.item ? 8 : 0
                     Layout.topMargin: root.topPadding
                     Layout.bottomMargin: root.bottomPadding
                     contentWidth: edit.paintedWidth
@@ -412,13 +411,13 @@ Item {
                             font.pixelSize: 15
                             wrapMode: root.multiline ? Text.WordWrap : Text.NoWrap
                             elide: StatusBaseText.ElideRight
-                            font.family: Theme.palette.baseFont.name
                             color: root.enabled ? Theme.palette.baseColor1 : Theme.palette.directColor6
                         }
                     }
                 } // Flickable
 
                 Loader {
+                    id: rightComponentLoader
                     sourceComponent: {
                         if (root.rightComponent) return root.rightComponent
                         if (root.clearable) return clearButton

--- a/ui/app/AppLayouts/Chat/controls/community/CommunityDescriptionInput.qml
+++ b/ui/app/AppLayouts/Chat/controls/community/CommunityDescriptionInput.qml
@@ -10,8 +10,6 @@ import StatusQ.Controls.Validators 0.1
 StatusInput {
     id: root
 
-    leftPadding: 0
-    rightPadding: 0
     label: qsTr("Give it a short description")
     charLimit: 140
 

--- a/ui/app/AppLayouts/Chat/controls/community/CommunityIntroMessageInput.qml
+++ b/ui/app/AppLayouts/Chat/controls/community/CommunityIntroMessageInput.qml
@@ -10,8 +10,6 @@ import StatusQ.Controls.Validators 0.1
 StatusInput {
     id: root
 
-    leftPadding: 0
-    rightPadding: 0
     label: qsTr("Community introduction and rules")
     charLimit: 1400
 

--- a/ui/app/AppLayouts/Chat/controls/community/CommunityNameInput.qml
+++ b/ui/app/AppLayouts/Chat/controls/community/CommunityNameInput.qml
@@ -10,8 +10,6 @@ import StatusQ.Controls.Validators 0.1
 StatusInput {
     id: root
 
-    leftPadding: 0
-    rightPadding: 0
     label: qsTr("Name your community")
     charLimit: 30
     placeholderText: qsTr("A catchy name")

--- a/ui/app/AppLayouts/Chat/controls/community/CommunityOutroMessageInput.qml
+++ b/ui/app/AppLayouts/Chat/controls/community/CommunityOutroMessageInput.qml
@@ -10,8 +10,6 @@ import StatusQ.Controls.Validators 0.1
 StatusInput {
     id: root
 
-    leftPadding: 0
-    rightPadding: 0
     label: qsTr("Leaving community message")
     charLimit: 80
 

--- a/ui/app/AppLayouts/Chat/popups/community/CreateChannelPopup.qml
+++ b/ui/app/AppLayouts/Chat/popups/community/CreateChannelPopup.qml
@@ -115,7 +115,7 @@ StatusDialog {
                     }
                 }
                 input.asset.color: colorDialog.color.toString()
-                rightPadding: 6
+                leftPadding: 16
                 input.rightComponent: StatusRoundButton {
                     objectName: "StatusChannelPopup_emojiButton"
                     implicitWidth: 32
@@ -173,7 +173,7 @@ StatusDialog {
                     // contentColor: colorDialog.colorSelected ? Theme.palette.indirectColor1 : Theme.palette.baseColor1
                     text: colorDialog.colorSelected ?
                               colorDialog.color.toString().toUpperCase() :
-                              qsTr("Pick a color")
+                              qsTr("Pick a colour")
 
                     onClicked: colorDialog.open();
                     onTextChanged: {

--- a/ui/app/AppLayouts/Chat/popups/community/TransferOwnershipPopup.qml
+++ b/ui/app/AppLayouts/Chat/popups/community/TransferOwnershipPopup.qml
@@ -39,8 +39,6 @@ StatusDialog {
 
             readonly property string elidedPkey: Utils.getElidedCommunityPK(root.privateKey)
 
-            leftPadding: 0
-            rightPadding: 0
             label: qsTr("Community private key")
 
             input.text: elidedPkey

--- a/ui/imports/shared/controls/AmountInputWithCursor.qml
+++ b/ui/imports/shared/controls/AmountInputWithCursor.qml
@@ -14,16 +14,14 @@ StatusInput {
 
     leftPadding: 0
     rightPadding: 0
+    topPadding: 0
+    bottomPadding: 0
 
     placeholderText: ""
     input.edit.objectName: "amountInput"
     input.edit.cursorVisible: true
     input.edit.font.pixelSize: Utils.getFontSizeBasedOnLetterCount(text)
     input.placeholderFont.pixelSize: 34
-    input.leftPadding: 0
-    input.rightPadding: 0
-    input.topPadding: 0
-    input.bottomPadding: 0
     input.edit.padding: 0
     input.background.color: "transparent"
     input.background.border.width: 0

--- a/ui/imports/shared/controls/SearchBox.qml
+++ b/ui/imports/shared/controls/SearchBox.qml
@@ -6,6 +6,4 @@ StatusInput {
     placeholderText: qsTr("Search")
     input.asset.name: "search"
     input.clearable: true
-    leftPadding: 0
-    rightPadding: 4
 }


### PR DESCRIPTION
- make the left/right padding and internal spacing consistent with the Figma design

- the padding itself got broken by a behavior-incompatible change introduced in https://github.com/status-im/status-desktop/commit/17aaec2d536f496c9defa54f020afddc55cadd66#diff-451194c72ab50ea2586b6f1d6521b81d9a93206069788117326788be28b638fd; this change is however correct but we can no longer rely on the implementation detail that used to "reset" the left/right padding to its default value when we set  `leftPadding: 0`

Fixes #8910

### What does the PR do

Fixes left/right padding and spacing in StatusBaseInput derived components

### Affected areas

StatusBaseInput based components

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

New channel:
![image](https://user-images.githubusercontent.com/5377645/210675927-7484f4b1-1bec-43a0-aeb8-05e4030a36ba.png)

New category:
![image](https://user-images.githubusercontent.com/5377645/210675989-7f8a1e14-01ce-4a6a-9924-ba0e834dd17a.png)

Edit community:
![image](https://user-images.githubusercontent.com/5377645/210676056-acced801-bfa4-40ff-b612-b207a6a29240.png)

Wallet/send popup, search field and amount input:
![image](https://user-images.githubusercontent.com/5377645/210676335-3ed4193a-ea27-46aa-9110-fbb294ed9d3b.png)

Profile settings:
![image](https://user-images.githubusercontent.com/5377645/210676420-ca611727-0de0-40cb-ad3a-dfd946d71b7f.png)



