### PR TITLE
fix: Chat Input isn't focused after editing a message

### DIFF
--- a/ui/app/AppLayouts/Chat/views/ChatContentView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatContentView.qml
@@ -162,6 +162,7 @@ ColumnLayout {
             onOpenStickerPackPopup: {
                 root.openStickerPackPopup(stickerPackId);
             }
+            onEditModeChanged: if (!editModeOn) chatInput.forceInputActiveFocus()
         }
 
         Item {

--- a/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
@@ -44,6 +44,7 @@ Item {
 
     signal openStickerPackPopup(string stickerPackId)
     signal showReplyArea(string messageId, string author)
+    signal editModeChanged(bool editModeOn)
 
     QtObject {
         id: d
@@ -272,6 +273,7 @@ Item {
             sticker: model.sticker
             stickerPack: model.stickerPack
             editModeOn: model.editMode
+            onEditModeOnChanged: root.editModeChanged(editModeOn)
             isEdited: model.isEdited
             linkUrls: model.links
             messageAttachments: model.messageAttachments


### PR DESCRIPTION
Fixes #8966

### What does the PR do

Put focus back to chat input when the edit is done

### Affected areas

ChatContentView, ChatMessagesView

