### PR TITLE
fix: unbreak StatusAppNavBar margins

### DIFF
--- a/ui/StatusQ/src/StatusQ/Layout/StatusAppNavBar.qml
+++ b/ui/StatusQ/src/StatusQ/Layout/StatusAppNavBar.qml
@@ -24,11 +24,6 @@ Rectangle {
     property alias profileComponent: profileItemLoader.sourceComponent
 
     implicitWidth: 78
-    anchors {
-        fill: parent
-        topMargin: 48
-        bottomMargin: 24
-    }
 
     color: Theme.palette.statusAppNavBar.backgroundColor
 
@@ -45,7 +40,11 @@ Rectangle {
 
     ColumnLayout {
         id: layout
-        anchors.fill: parent
+        anchors {
+            fill: parent
+            topMargin: 48
+            bottomMargin: 24
+        }
 
         spacing: d.spacing
 


### PR DESCRIPTION
partially revert ba811acc27eb27f73a4259e318f9e0d9c0f5f6fa and silence the warning

### What does the PR do

Fixes white margins on top/bottom of the nav bar

### Affected areas

StatusAppNavBar

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

Before:
![image_05-01-2023_12-23-35](https://user-images.githubusercontent.com/5377645/210769128-448c1e15-2816-4772-879d-94f9048811b2.png)

After:
![image](https://user-images.githubusercontent.com/5377645/210769212-6844f05a-8fb3-49a8-b2ea-7f21f8afc139.png)
