### PR TITLE
fix(desktop/chat): show the badge during receiving the new messages in inactive section

### DIFF
--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -286,8 +286,11 @@ method load*(
     # we do this only in case of chat section (not in case of communities)
     self.initContactRequestsModel()
 
-  for cModule in self.chatContentModules.values:
+  let activeChatId = self.controller.getActiveChatId()
+  for chatId, cModule in self.chatContentModules:
     cModule.load()
+    if chatId == activeChatId:
+      cModule.onMadeActive()
 
 proc checkIfModuleDidLoad(self: Module) =
   if self.moduleLoaded:
@@ -357,14 +360,14 @@ method activeItemSubItemSet*(self: Module, itemId: string, subItemId: string) =
   self.view.chatsModel().setActiveItemSubItem(itemId, subItemId)
   self.view.activeItemSubItemSet(item, subItem)
 
-  # update child modules
+  let activeChatId = self.controller.getActiveChatId()
+
+  # # update child modules
   for chatId, chatContentModule in self.chatContentModules:
-    if chatId == self.controller.getActiveChatId():
+    if chatId == activeChatId:
       chatContentModule.onMadeActive()
     else:
       chatContentModule.onMadeInactive()
-
-  let activeChatId = self.controller.getActiveChatId()
 
   # save last open chat in settings for restore on the next app launch
   singletonInstance.localAccountSensitiveSettings.setSectionLastOpenChat(mySectionId, activeChatId)

--- a/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
@@ -53,7 +53,7 @@ Item {
         readonly property var chatDetails: chatContentModule.chatDetails
 
         function markAllMessagesReadIfMostRecentMessageIsInViewport() {
-            if (!isMostRecentMessageInViewport) {
+            if (!isMostRecentMessageInViewport || !chatLogView.visible) {
                 return
             }
 
@@ -94,8 +94,17 @@ Item {
         }
 
         function onHasUnreadMessagesChanged() {
-            if (d.chatDetails.hasUnreadMessages && d.chatDetails.active && !d.isMostRecentMessageInViewport) {
-                // HACK: we call it later because messages model may not be yet propagated with unread messages when this signal is emitted
+            if (!d.chatDetails.hasUnreadMessages) {
+                return
+            }
+
+            // HACK: we call `addNewMessagesMarker` later because messages model
+            // may not be yet propagated with unread messages when this signal is emitted
+            if (chatLogView.visible) {
+                if (!d.isMostRecentMessageInViewport) {
+                    Qt.callLater(() => messageStore.addNewMessagesMarker())
+                }
+            } else {
                 Qt.callLater(() => messageStore.addNewMessagesMarker())
             }
         }
@@ -152,6 +161,8 @@ Item {
         }
 
         onCountChanged: d.markAllMessagesReadIfMostRecentMessageIsInViewport()
+
+        onVisibleChanged: d.markAllMessagesReadIfMostRecentMessageIsInViewport()
 
         ScrollBar.vertical: StatusScrollBar {
             visible: chatLogView.visibleArea.heightRatio < 1


### PR DESCRIPTION
### What does the PR do

Fixes
- show mention or unread msg badge for inactive section
- non-disappearing section and channel badge during app launch (when we restore on channel with unread msg)
- show unread msg marker for the channel which was active before switching to the settings section and then user return to this channel

Fixes: #8940

### Affected areas

- new messages marker display
- badge icon

### Screenshot of functionality (including design for comparison)

https://user-images.githubusercontent.com/117639195/210971549-32e346ed-62e4-4fcc-94b1-92e8f4b3e80f.mov

