### PR TITLE
fix(StatusChatInput): return correct mention suggestions

### DIFF
--- a/ui/app/AppLayouts/Chat/panels/SuggestionBoxPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/SuggestionBoxPanel.qml
@@ -47,10 +47,6 @@ Rectangle {
     property var inputField
     property bool shouldHide: false
 
-    Timer {
-        id: timer
-    }
-
     onFormattedPlainTextFilterChanged: {
         // We need to callLater because the sort needs to happen before setting the index
         Qt.callLater(function () {
@@ -138,9 +134,6 @@ Rectangle {
                 event.accepted = false;
             }
         }
-        property int selectedIndex
-        property var selectedItem: selectedIndex == -1 ? null : model[selectedIndex]
-        signal suggestionClicked(var item)
 
         DelegateModelGeneralized {
             id: mentionsListDelegate

--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -990,11 +990,11 @@ Rectangle {
         width: messageInput.width
         filter: messageInputField.text
         cursorPosition: messageInputField.cursorPosition
-        property: ["name", "nickname", "ensName", "alias"]
+        property: ["nickname", "ensName", "name", "alias"]
         inputField: messageInputField
         onItemSelected: function (item, lastAtPosition, lastCursorPosition) {
             messageInputField.forceActiveFocus();
-            let name = item.name.replace("@", "")
+            const name = item[suggestionsBox.property.find(p => !!item[p])].replace("@", "")
             d.insertMention(name, item.publicKey, lastAtPosition, lastCursorPosition)
             suggestionsBox.suggestionsModel.clear()
         }


### PR DESCRIPTION
- follow the order of properties that `ProfileUtils.displayName()` uses
elsewhere in the application
- prefer nickname or ensName over displayName if the user has those

Fixes: #8691

### What does the PR do

Fixes wrong suggestions for mentioned users

### Affected areas

StatusChatInput

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

Multiple users with the nickname of "alex":
![image](https://user-images.githubusercontent.com/5377645/211019800-88da447c-d938-4e74-92c9-bc5193440461.png)

Selecting a user with nickname:
![image_06-01-2023_14-15-40](https://user-images.githubusercontent.com/5377645/211019441-429a4d8c-4fd9-4709-8f8e-f58c627ff891.png)

Suggestion activated and pasted correctly into chat input:
![image_06-01-2023_14-16-33](https://user-images.githubusercontent.com/5377645/211019579-96204375-24d8-4062-bac6-84270ca4e4c0.png)



