### PR TITLE
feat(context-menu): add Copy message action in message context menu

### DIFF
--- a/src/app/modules/main/activity_center/module.nim
+++ b/src/app/modules/main/activity_center/module.nim
@@ -82,6 +82,7 @@ proc createMessageItemFromDto(self: Module, message: MessageDto, chatDetails: Ch
     contactDetails.details.added,
     message.outgoingStatus,
     self.controller.getRenderedText(message.parsedText),
+    message.text,
     message.image,
     message.containsContactMentions(),
     message.seen,

--- a/src/app/modules/shared_models/message_item.nim
+++ b/src/app/modules/shared_models/message_item.nim
@@ -20,6 +20,7 @@ type
     seen: bool
     outgoingStatus: string
     messageText: string
+    unparsedText: string
     messageImage: string
     messageContainsMentions: bool
     sticker: string
@@ -64,6 +65,7 @@ proc initItem*(
     senderIsAdded: bool,
     outgoingStatus,
     text,
+    unparsedText,
     image: string,
     messageContainsMentions,
     seen: bool,
@@ -100,7 +102,8 @@ proc initItem*(
   result.senderIcon = senderIcon
   result.seen = seen
   result.outgoingStatus = outgoingStatus
-  result.messageText = if ContentType.Image == contentType: "" else: text
+  result.messageText = if contentType == ContentType.Image : "" else: text
+  result.unparsedText = if contentType == ContentType.Image : "" else: unparsedText
   result.messageImage = image
   result.messageContainsMentions = messageContainsMentions
   result.timestamp = timestamp
@@ -131,9 +134,10 @@ proc initItem*(
   result.quotedMessageDeleted = quotedMessageDeleted
   result.quotedMessageFromIterator = 0
 
-  if ContentType.DiscordMessage == contentType:
+  if contentType == ContentType.DiscordMessage :
     if result.messageText == "":
       result.messageText = discordMessage.content
+      result.unparsedText = discordMessage.content
     result.senderId = discordMessage.author.id
     result.senderDisplayName = discordMessage.author.name
     result.senderIcon = discordMessage.author.localUrl
@@ -162,6 +166,7 @@ proc initNewMessagesMarkerItem*(clock, timestamp: int64): Item =
     senderIsAdded = false,
     outgoingStatus = "",
     text = "",
+    unparsedText = "",
     image = "",
     messageContainsMentions = false,
     seen = true,
@@ -201,6 +206,7 @@ proc `$`*(self: Item): string =
     outgoingStatus:{$self.outgoingStatus},
     resendError:{$self.resendError},
     messageText:{self.messageText},
+    unparsedText:{self.unparsedText},
     messageContainsMentions:{self.messageContainsMentions},
     timestamp:{$self.timestamp},
     contentType:{$self.contentType.int},
@@ -286,6 +292,12 @@ proc messageText*(self: Item): string {.inline.} =
 
 proc `messageText=`*(self: Item, value: string) {.inline.} =
   self.messageText = value
+
+proc unparsedText*(self: Item): string {.inline.} =
+  self.unparsedText
+
+proc `unparsedText=`*(self: Item, value: string) {.inline.} =
+  self.unparsedText = value
 
 proc messageImage*(self: Item): string {.inline.} =
   self.messageImage
@@ -383,6 +395,7 @@ proc toJsonNode*(self: Item): JsonNode =
     "seen": self.seen,
     "outgoingStatus": self.outgoingStatus,
     "messageText": self.messageText,
+    "unparsedText": self.unparsedText,
     "messageImage": self.messageImage,
     "messageContainsMentions": self.messageContainsMentions,
     "sticker": self.sticker,

--- a/src/app/modules/shared_models/message_item_qobject.nim
+++ b/src/app/modules/shared_models/message_item_qobject.nim
@@ -97,6 +97,10 @@ QtObject:
   QtProperty[string] messageText:
     read = messageText
 
+  proc unparsedText*(self: MessageItem): string {.slot.} = result = ?.self.messageItem.unparsedText
+  QtProperty[string] unparsedText:
+    read = unparsedText
+
   proc messageImage*(self: MessageItem): string {.slot.} = result = ?.self.messageItem.messageImage
   QtProperty[string] messageImage:
     read = messageImage

--- a/src/app/modules/shared_models/message_model.nim
+++ b/src/app/modules/shared_models/message_model.nim
@@ -21,6 +21,7 @@ type
     Seen
     OutgoingStatus
     MessageText
+    UnparsedText
     MessageImage
     MessageContainsMentions # Actually we don't need to exposed this to qml since we only used it as an improved way to
                             # check whether we need to update mentioned contact name or not.
@@ -114,6 +115,7 @@ QtObject:
       ModelRole.ResendError.int:"resendError",
       ModelRole.Mentioned.int:"mentioned",
       ModelRole.MessageText.int:"messageText",
+      ModelRole.UnparsedText.int:"unparsedText",
       ModelRole.MessageImage.int:"messageImage",
       ModelRole.MessageContainsMentions.int:"messageContainsMentions",
       ModelRole.Timestamp.int:"timestamp",
@@ -205,6 +207,8 @@ QtObject:
       result = newQVariant(item.quotedMessageDeleted)
     of ModelRole.MessageText:
       result = newQVariant(item.messageText)
+    of ModelRole.UnparsedText:
+      result = newQVariant(item.unparsedText)
     of ModelRole.MessageImage:
       result = newQVariant(item.messageImage)
     of ModelRole.MessageContainsMentions:
@@ -441,7 +445,7 @@ QtObject:
       if(self.items[i].pinnedBy == contactId):
         roles.add(ModelRole.PinnedBy.int)
       if(self.items[i].messageContainsMentions):
-        roles.add(@[ModelRole.MessageText.int, ModelRole.MessageContainsMentions.int])
+        roles.add(@[ModelRole.MessageText.int, ModelRole.UnparsedText.int, ModelRole.MessageContainsMentions.int])
 
       if (self.items[i].quotedMessageFrom == contactId):
         # If there is a quoted message whom the author changed, increase the iterator to force
@@ -496,6 +500,7 @@ QtObject:
     let index = self.createIndex(ind, 0, nil)
     self.dataChanged(index, index, @[
       ModelRole.MessageText.int,
+      ModelRole.UnparsedText.int,
       ModelRole.MessageContainsMentions.int,
       ModelRole.IsEdited.int,
       ModelRole.Links.int,

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -155,6 +155,8 @@ QtObject {
 
     property var stickersModuleInst: stickersModule
 
+    property bool isDebugEnabled: advancedModule ? advancedModule.isDebugEnabled : false
+
     property var stickersStore: StickersStore {
         stickersModule: stickersModuleInst
     }

--- a/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
@@ -250,6 +250,7 @@ Item {
             senderTrustStatus: model.senderTrustStatus
             amISender: model.amISender
             messageText: model.messageText
+            unparsedText: model.unparsedText
             messageImage: model.messageImage
             messageTimestamp: model.timestamp
             messageOutgoingStatus: model.outgoingStatus

--- a/ui/imports/shared/views/chat/MessageContextMenuView.qml
+++ b/ui/imports/shared/views/chat/MessageContextMenuView.qml
@@ -31,6 +31,7 @@ StatusMenu {
 
     property int chatType: Constants.chatType.publicChat
     property string messageId: ""
+    property string unparsedText: ""
     property string messageSenderId: ""
     property int messageContentType: Constants.messageContentType.unknownContentType
     property string imageSource: ""
@@ -39,7 +40,7 @@ StatusMenu {
     property bool isRightClickOnImage: false
     property bool pinnedPopup: false
     property bool pinMessageAllowedForMembers: false
-    property bool isDebugEnabled: false
+    property bool isDebugEnabled: store.isDebugEnabled
     property bool isEmoji: false
     property bool isSticker: false
     property bool hideEmojiPicker: true
@@ -127,11 +128,6 @@ StatusMenu {
         }
         root.emojiReactionsReactedByUser = newEmojiReactions;
 
-        /* // copy link feature not ready yet
-        const numLinkUrls = root.linkUrls.split(" ").length
-        copyLinkMenu.enabled = numLinkUrls > 1
-        copyLinkAction.enabled = !!root.linkUrls && numLinkUrls === 1 && !isEmoji && !root.isProfile
-        */
         popup()
     }
 
@@ -362,12 +358,23 @@ StatusMenu {
     }
 
     StatusAction {
+        id: copyMessageMenuItem
+        text: qsTr("Copy message")
+        icon.name: "copy"
+        onTriggered: {
+            root.store.copyToClipboard(root.unparsedText)
+            close()
+        }
+        enabled: root.messageContentType === Constants.messageContentType.messageType
+    }
+
+    StatusAction {
         id: copyMessageIdAction
         text: qsTr("Copy Message Id")
-        icon.name: "chat"
+        icon.name: "copy"
         enabled: root.isDebugEnabled && !pinnedPopup
         onTriggered: {
-            root.store.copyToClipboard(SelectedMessage.messageId)
+            root.store.copyToClipboard(root.messageId)
             close()
         }
     }
@@ -425,6 +432,7 @@ StatusMenu {
                  (viewProfileAction.enabled ||
                   sendMessageMenuItem.enabled ||
                   replyToMenuItem.enabled ||
+                  copyMessageMenuItem.enabled ||
                   editMessageAction.enabled ||
                   pinAction.enabled)
     }

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -48,6 +48,7 @@ Loader {
     property bool senderIsAdded: false
     property int senderTrustStatus: Constants.trustStatus.unknown
     property string messageText: ""
+    property string unparsedText: ""
     property string messageImage: ""
     property double messageTimestamp: 0 // We use double, because QML's int is too small
     property string messageOutgoingStatus: ""
@@ -141,6 +142,7 @@ Loader {
         messageContextMenu.chatType = messageStore.getChatType()
 
         messageContextMenu.messageId = root.messageId
+        messageContextMenu.unparsedText = root.unparsedText
         messageContextMenu.messageSenderId = root.senderId
         messageContextMenu.messageContentType = root.messageContentType
         messageContextMenu.pinnedMessage = root.pinnedMessage


### PR DESCRIPTION
Adds the action to copy the right-clicked message's text.

It copies the unparsed text (no html).
For that, I had to add it in the MessageItem and expose it in the model.

I also fixed the copy MessageId action that didn't show + didn't work even if it would have shown.

Plus some small cleanups.

![image](https://user-images.githubusercontent.com/11926403/211093062-208d74ad-4d14-4c09-98b6-e874de2fe36b.png)

The text copied in the screenshot above results in 
```
**bold** test
enter

emopty
*italic* ok ~~strik~~
```