### PR TITLE
feat(@desktop/wallet): implement unified currency formatting in Send/Bridge modal

### DIFF
--- a/src/app/modules/main/wallet_section/controller.nim
+++ b/src/app/modules/main/wallet_section/controller.nim
@@ -43,6 +43,9 @@ proc isMnemonicBackedUp*(self: Controller): bool =
 proc getCurrencyBalance*(self: Controller): CurrencyAmount =
   return currencyAmountToItem(self.walletAccountService.getTotalCurrencyBalance(), self.currencyService.getCurrencyFormat(self.getCurrency()))
 
+proc getCurrencyAmount*(self: Controller, amount: float64, symbol: string): CurrencyAmount =
+  return currencyAmountToItem(amount, self.currencyService.getCurrencyFormat(symbol))
+
 proc updateCurrency*(self: Controller, currency: string) =
   self.walletAccountService.updateCurrency(currency)
 

--- a/src/app/modules/main/wallet_section/io_interface.nim
+++ b/src/app/modules/main/wallet_section/io_interface.nim
@@ -1,3 +1,6 @@
+import ../../shared_models/currency_amount
+export CurrencyAmount
+
 type
   AccessInterface* {.pure inheritable.} = ref object of RootObj
   ## Abstract class for any input/interaction with this module.
@@ -21,6 +24,9 @@ method updateCurrency*(self: AccessInterface, currency: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method setTotalCurrencyBalance*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method getCurrencyAmount*(self: AccessInterface, amount: float64, symbol: string): CurrencyAmount {.base.} =
   raise newException(ValueError, "No implementation available")
 
 # View Delegate Interface

--- a/src/app/modules/main/wallet_section/module.nim
+++ b/src/app/modules/main/wallet_section/module.nim
@@ -100,6 +100,9 @@ method switchAccountByAddress*(self: Module, address: string) =
 method setTotalCurrencyBalance*(self: Module) =
   self.view.setTotalCurrencyBalance(self.controller.getCurrencyBalance())
 
+method getCurrencyAmount*(self: Module, amount: float64, symbol: string): CurrencyAmount =
+  return self.controller.getCurrencyAmount(amount, symbol)
+
 method load*(self: Module) =
   singletonInstance.engine.setRootContextProperty("walletSection", newQVariant(self.view))
 

--- a/src/app/modules/main/wallet_section/view.nim
+++ b/src/app/modules/main/wallet_section/view.nim
@@ -1,4 +1,4 @@
-import NimQml
+import NimQml, json
 
 import ./io_interface
 import ../../shared_models/currency_amount
@@ -74,6 +74,13 @@ QtObject:
   proc setCurrentCurrency*(self: View, currency: string) =
     self.currentCurrency = currency
     self.currentCurrencyChanged()
+
+# Returning a QVariant from a slot with parameters other than "self" won't compile
+#  proc getCurrencyAmount*(self: View, amount: float, symbol: string): QVariant {.slot.} =
+#    return newQVariant(self.delegate.getCurrencyAmount(amount, symbol))
+
+  proc getCurrencyAmountAsJson*(self: View, amount: float, symbol: string): string {.slot.} =
+    return $self.delegate.getCurrencyAmount(amount, symbol).toJsonNode()
 
   proc setData*(self: View, currency, signingPhrase: string, mnemonicBackedUp: bool) =
     self.currentCurrency = currency

--- a/ui/StatusQ/sandbox/demoapp/StatusAppCommunitiesPortalView.qml
+++ b/ui/StatusQ/sandbox/demoapp/StatusAppCommunitiesPortalView.qml
@@ -98,7 +98,7 @@ StatusSectionLayout {
                     Repeater {
                         model: d.featuredCommunitiesModel
                         delegate: StatusCommunityCard {
-                            locale: "es"
+                            locale: Qt.locale("es")
                             communityId: model.communityId
                             loaded: model.available
                             logo: model.logo
@@ -136,7 +136,7 @@ StatusSectionLayout {
                     Repeater {
                         model: d.popularCommunitiesModel
                         delegate: StatusCommunityCard {
-                            locale: "es"
+                            locale: Qt.locale("es")
                             communityId: model.communityId
                             loaded: model.available
                             logo: model.logo

--- a/ui/StatusQ/sandbox/pages/StatusCommunityCardPage.qml
+++ b/ui/StatusQ/sandbox/pages/StatusCommunityCardPage.qml
@@ -23,7 +23,7 @@ GridLayout {
     Repeater {
         model: Models.curatedCommunitiesModel
         delegate: StatusCommunityCard {
-            locale: "en"
+            locale: Qt.locale("en")
             communityId: model.communityId
             loaded: model.available
             logo: model.logo

--- a/ui/StatusQ/src/StatusQ/Components/StatusCommunityCard.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusCommunityCard.qml
@@ -96,9 +96,8 @@ Rectangle {
     /*!
        \qmlproperty var StatusCommunityCard::locale
        This property holds the application locale used to give format to members number representation.
-       If not provided, default value is "en".
     */
-    property var locale: Qt.locale("en")
+    property var locale: Qt.locale()
     /*!
        \qmlproperty url StatusCommunityCard::banner
        This property holds the community banner image url.

--- a/ui/StatusQ/src/StatusQ/Core/LocaleUtils.qml
+++ b/ui/StatusQ/src/StatusQ/Core/LocaleUtils.qml
@@ -40,7 +40,7 @@ QtObject {
             return "N/A"
         }
         if (typeof(currencyAmount) !== "object") {
-            console.log("Wrong type for currencyAmount: " + JSON.stringify(currencyAmount))
+            console.warn("Wrong type for currencyAmount: " + JSON.stringify(currencyAmount))
             console.trace()
             return NaN
         }

--- a/ui/StatusQ/src/StatusQ/Core/LocaleUtils.qml
+++ b/ui/StatusQ/src/StatusQ/Core/LocaleUtils.qml
@@ -27,20 +27,28 @@ QtObject {
         return num.toLocaleString(locale, 'f', precision)
     }
 
-    function currencyAmountToLocaleString(currencyAmount, locale) {
-        if (!locale) {
-            console.log("Unspecified locale for: " + JSON.stringify(currencyAmount))
-            locale = Qt.locale()
+    function numberFromLocaleString(num, locale = null) {
+        locale = locale || Qt.locale()
+
+        return Number.fromLocaleString(locale, num)
+    }
+
+    function currencyAmountToLocaleString(currencyAmount, options = null, locale = null) {
+        locale = locale || Qt.locale()
+
+        if (!currencyAmount) {
+            return "N/A"
         }
         if (typeof(currencyAmount) !== "object") {
             console.log("Wrong type for currencyAmount: " + JSON.stringify(currencyAmount))
+            console.trace()
             return NaN
         }
         var amountStr = numberToLocaleString(currencyAmount.amount, currencyAmount.displayDecimals, locale)
         if (currencyAmount.stripTrailingZeroes) {
             amountStr = stripTrailingZeroes(amountStr, locale)
         }
-        if (currencyAmount.symbol) {
+        if (currencyAmount.symbol && !(options && options.onlyAmount)) {
             amountStr = "%1 %2".arg(amountStr).arg(currencyAmount.symbol)
         }
         return amountStr

--- a/ui/app/AppLayouts/Browser/popups/BrowserWalletMenu.qml
+++ b/ui/app/AppLayouts/Browser/popups/BrowserWalletMenu.qml
@@ -204,12 +204,10 @@ Popup {
 
             AssetsView {
                 id: assetsTab
-                locale: RootStore.locale
                 account: WalletStore.dappBrowserAccount
             }
             HistoryView {
                 id: historyTab
-                locale: RootStore.locale
                 account: WalletStore.dappBrowserAccount
             }
         }

--- a/ui/app/AppLayouts/Browser/popups/BrowserWalletMenu.qml
+++ b/ui/app/AppLayouts/Browser/popups/BrowserWalletMenu.qml
@@ -204,10 +204,12 @@ Popup {
 
             AssetsView {
                 id: assetsTab
+                locale: RootStore.locale
                 account: WalletStore.dappBrowserAccount
             }
             HistoryView {
                 id: historyTab
+                locale: RootStore.locale
                 account: WalletStore.dappBrowserAccount
             }
         }

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -7,8 +7,6 @@ import shared.stores 1.0
 QtObject {
     id: root
 
-    property var locale: Qt.locale(localAppSettings.language)
-
     property var contactsStore
 
     property bool openCreateChat: false

--- a/ui/app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml
+++ b/ui/app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml
@@ -170,7 +170,6 @@ StatusSectionLayout {
                     padding: 0
                     bottomPadding: d.layoutBottomMargin
 
-                    locale: communitiesStore.locale
                     model: filteredCommunitiesModel
                     searchLayout: d.searchMode
 

--- a/ui/app/AppLayouts/CommunitiesPortal/stores/CommunitiesStore.qml
+++ b/ui/app/AppLayouts/CommunitiesPortal/stores/CommunitiesStore.qml
@@ -28,7 +28,6 @@ QtObject {
     property bool discordImportHasCommunityImage: root.communitiesModuleInst.discordImportHasCommunityImage
     property var discordImportTasks: root.communitiesModuleInst.discordImportTasks
     property bool downloadingCommunityHistoryArchives: root.communitiesModuleInst.downloadingCommunityHistoryArchives
-    property var locale: Qt.locale()
     property var advancedModule: profileSectionModule.advancedModule
 
     // TODO: Could the backend provide directly 2 filtered models??

--- a/ui/app/AppLayouts/CommunitiesPortal/views/CommunitiesGridView.qml
+++ b/ui/app/AppLayouts/CommunitiesPortal/views/CommunitiesGridView.qml
@@ -13,7 +13,6 @@ import SortFilterProxyModel 0.2
 StatusScrollView {
     id: root
 
-    property var locale
     property var model
     property bool searchLayout: false
 
@@ -64,7 +63,6 @@ StatusScrollView {
                 json: tags
             }
 
-            locale: root.locale
             communityId: model.id
             loaded: model.available
             logo: model.icon

--- a/ui/app/AppLayouts/Wallet/panels/WalletHeader.qml
+++ b/ui/app/AppLayouts/Wallet/panels/WalletHeader.qml
@@ -46,7 +46,7 @@ Item {
                 font.pixelSize: 28
                 font.bold: true
                 color: Theme.palette.baseColor1
-                text: LocaleUtils.currencyAmountToLocaleString(root.currentAccount.currencyBalance, root.locale)
+                text: LocaleUtils.currencyAmountToLocaleString(root.currentAccount.currencyBalance)
             }
         }
 

--- a/ui/app/AppLayouts/Wallet/panels/WalletHeader.qml
+++ b/ui/app/AppLayouts/Wallet/panels/WalletHeader.qml
@@ -18,7 +18,6 @@ import "../stores"
 Item {
     id: root
 
-    property var locale
     property string currency: ""
     property var currentAccount
     property var store

--- a/ui/app/AppLayouts/Wallet/popups/ReceiveModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/ReceiveModal.qml
@@ -59,7 +59,6 @@ StatusModal {
             root.selectedAccount = newAccount
         }
         showAllWalletTypes: true
-        locale: RootStore.locale
     }
 
     contentItem: Column {

--- a/ui/app/AppLayouts/Wallet/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Wallet/stores/RootStore.qml
@@ -22,7 +22,6 @@ QtObject {
     property var generatedAccounts: walletSectionAccounts.generated
     property var appSettings: localAppSettings
     property var accountSensitiveSettings: localAccountSensitiveSettings
-    property var locale: Qt.locale(appSettings.language)
     property bool hideSignPhraseModal: accountSensitiveSettings.hideSignPhraseModal
 
     property var currencyStore: SharedStore.RootStore.currencyStore

--- a/ui/app/AppLayouts/Wallet/views/LeftTabView.qml
+++ b/ui/app/AppLayouts/Wallet/views/LeftTabView.qml
@@ -82,7 +82,7 @@ Rectangle {
                 objectName: "walletLeftListAmountValue"
                 color: Style.current.textColor
                 text: {
-                    LocaleUtils.currencyAmountToLocaleString(RootStore.totalCurrencyBalance, RootStore.currencyStore.locale)
+                    LocaleUtils.currencyAmountToLocaleString(RootStore.totalCurrencyBalance)
                 }
                 selectByMouse: true
                 cursorVisible: true
@@ -117,7 +117,7 @@ Rectangle {
                 width: ListView.view.width
                 highlighted: RootStore.currentAccount.name === model.name
                 title: model.name
-                subTitle: LocaleUtils.currencyAmountToLocaleString(model.currencyBalance, RootStore.currencyStore.locale)
+                subTitle: LocaleUtils.currencyAmountToLocaleString(model.currencyBalance)
                 asset.emoji: !!model.emoji ? model.emoji: ""
                 asset.color: model.color
                 asset.name: !model.emoji ? "filled-account": ""

--- a/ui/app/AppLayouts/Wallet/views/RightTabView.qml
+++ b/ui/app/AppLayouts/Wallet/views/RightTabView.qml
@@ -104,6 +104,7 @@ Item {
                         }
                     }
                     HistoryView {
+                        locale: RootStore.locale
                         account: RootStore.currentAccount
                         onLaunchTransactionDetail: {
                             transactionDetailView.transaction = transaction
@@ -127,6 +128,7 @@ Item {
             }
             TransactionDetailView {
                 id: transactionDetailView
+                locale: RootStore.locale
                 Layout.fillWidth: true
                 Layout.fillHeight: true
                 sendModal: root.sendModal

--- a/ui/app/AppLayouts/Wallet/views/RightTabView.qml
+++ b/ui/app/AppLayouts/Wallet/views/RightTabView.qml
@@ -54,7 +54,6 @@ Item {
             ColumnLayout {
                 WalletHeader {
                     Layout.fillWidth: true
-                    locale: RootStore.locale
                     currency: RootStore.currentCurrency
                     currentAccount: RootStore.currentAccount
                     store: root.store
@@ -92,7 +91,6 @@ Item {
                     AssetsView {
                         account: RootStore.currentAccount
                         assetDetailsLaunched: stack.currentIndex === 2
-                        locale: RootStore.locale
                         onAssetClicked: {
                             assetDetailView.token = token
                             stack.currentIndex = 2
@@ -104,7 +102,6 @@ Item {
                         }
                     }
                     HistoryView {
-                        locale: RootStore.locale
                         account: RootStore.currentAccount
                         onLaunchTransactionDetail: {
                             transactionDetailView.transaction = transaction
@@ -128,7 +125,6 @@ Item {
             }
             TransactionDetailView {
                 id: transactionDetailView
-                locale: RootStore.locale
                 Layout.fillWidth: true
                 Layout.fillHeight: true
                 sendModal: root.sendModal

--- a/ui/app/AppLayouts/stores/RootStore.qml
+++ b/ui/app/AppLayouts/stores/RootStore.qml
@@ -7,8 +7,6 @@ import "../Profile/stores"
 QtObject {
     id: root
 
-    property var locale: Qt.locale()
-
     property var mainModuleInst: mainModule
     property var aboutModuleInst: aboutModule
     property var communitiesModuleInst: communitiesModule

--- a/ui/imports/shared/controls/AmountInput.qml
+++ b/ui/imports/shared/controls/AmountInput.qml
@@ -25,7 +25,7 @@ Input {
                             + textField.leftPadding
 
     function setAmount(amount) {
-        root.text = LocaleUtils.numberToLocaleString(amount, -1, root.locale)
+        root.text = LocaleUtils.numberToLocaleString(amount)
     }
 
     QtObject {
@@ -59,7 +59,7 @@ Input {
         }
 
         try {
-            d.amount = Number.fromLocaleString(root.locale, text) || 0
+            d.amount = LocaleUtils.numberFromLocaleString(text) || 0
             root.validationError = ""
         } catch (err) {
            root.validationError = qsTr("Invalid amount format")

--- a/ui/imports/shared/controls/AssetDelegate.qml
+++ b/ui/imports/shared/controls/AssetDelegate.qml
@@ -54,7 +54,7 @@ Item {
         anchors.leftMargin: Style.current.smallPadding
         font.pixelSize: 15
         color: Style.current.secondaryText
-        text: LocaleUtils.currencyAmountToLocaleString(enabledNetworkBalance, root.locale)
+        text: LocaleUtils.currencyAmountToLocaleString(enabledNetworkBalance)
     }
 
     StyledText {
@@ -65,6 +65,6 @@ Item {
         anchors.rightMargin: 0
         font.pixelSize: 15
         font.strikeout: false
-        text: LocaleUtils.currencyAmountToLocaleString(enabledNetworkCurrencyBalance, root.locale)
+        text: LocaleUtils.currencyAmountToLocaleString(enabledNetworkCurrencyBalance)
     }
 }

--- a/ui/imports/shared/controls/AssetDelegate.qml
+++ b/ui/imports/shared/controls/AssetDelegate.qml
@@ -12,7 +12,6 @@ Item {
     id: assetDelegate
     objectName: symbol
 
-    property var locale
     property string currency: ""
     property string currencySymbol: ""
 

--- a/ui/imports/shared/controls/GasSelector.qml
+++ b/ui/imports/shared/controls/GasSelector.qml
@@ -21,7 +21,6 @@ Item {
     property var getGasEthValue: function () {}
     property var getFiatValue: function () {}
     property var getCurrencyAmount: function () {}
-    property var locale
 
     width: parent.width
     height: visible ? advancedGasSelector.height + Style.current.halfPadding : 0

--- a/ui/imports/shared/controls/GasSelector.qml
+++ b/ui/imports/shared/controls/GasSelector.qml
@@ -16,11 +16,12 @@ Item {
 
     property string selectedTokenSymbol
     property string currentCurrency
-    property string currentCurrencySymbol
 
     property var bestRoutes: []
     property var getGasEthValue: function () {}
     property var getFiatValue: function () {}
+    property var getCurrencyAmount: function () {}
+    property var locale
 
     width: parent.width
     height: visible ? advancedGasSelector.height + Style.current.halfPadding : 0
@@ -48,19 +49,20 @@ Item {
                 statusListItemIcon.active: true
                 statusListItemIcon.opacity: modelData.isFirstSimpleTx
                 title: qsTr("%1 transaction fee").arg(modelData.fromNetwork.chainName)
-                subTitle: "%1 eth".arg(LocaleUtils.numberToLocaleString(parseFloat(totalGasAmount)))
-                property string totalGasAmount : {
+                subTitle: LocaleUtils.currencyAmountToLocaleString(totalGasAmountEth)
+                property var totalGasAmountEth: {
                     let maxFees = modelData.gasFees.maxFeePerGasM
                     let gasPrice = modelData.gasFees.eip1559Enabled ? maxFees : modelData.gasFees.gasPrice
                     return root.getGasEthValue(gasPrice , modelData.gasAmount)
                 }
+                property var totalGasAmountFiat: root.getFiatValue(totalGasAmountEth.amount, "ETH", root.currentCurrency)
                 statusListItemSubTitle.width: listItem.width/2 - Style.current.smallPadding
                 statusListItemSubTitle.elide: Text.ElideMiddle
                 statusListItemSubTitle.wrapMode: Text.NoWrap
                 components: [
                     StatusBaseText {
                         Layout.alignment: Qt.AlignRight
-                        text: "%1%2".arg(currentCurrencySymbol).arg(LocaleUtils.numberToLocaleString(parseFloat(root.getFiatValue(totalGasAmount, "ETH", root.currentCurrency))))
+                        text: LocaleUtils.currencyAmountToLocaleString(totalGasAmountFiat)
                         font.pixelSize: 15
                         color: Theme.palette.baseColor1
                         width: listItem.width/2 - Style.current.padding
@@ -82,7 +84,9 @@ Item {
                 statusListItemIcon.active: true
                 statusListItemIcon.opacity: modelData.isFirstSimpleTx
                 title: qsTr("Approve %1 %2 Bridge").arg(modelData.fromNetwork.chainName).arg(root.selectedTokenSymbol)
-                subTitle: "%1 eth".arg(LocaleUtils.numberToLocaleString(modelData.approvalGasFees))
+                property var approvalGasFees: root.getCurrencyAmount(modelData.approvalGasFees, "ETH")
+                property var approvalGasFeesFiat: root.getFiatValue(approvalGasFees.amount, "ETH", root.currentCurrency)
+                subTitle: LocaleUtils.currencyAmountToLocaleString(approvalGasFees)
                 statusListItemSubTitle.width: listItem.width/2 - Style.current.smallPadding
                 statusListItemSubTitle.elide: Text.ElideMiddle
                 statusListItemSubTitle.wrapMode: Text.NoWrap
@@ -90,7 +94,7 @@ Item {
                 components: [
                     StatusBaseText {
                         Layout.alignment: Qt.AlignRight
-                        text: "%1%2".arg(currentCurrencySymbol).arg(LocaleUtils.numberToLocaleString(parseFloat(root.getFiatValue(modelData.approvalGasFees, "ETH", root.currentCurrency))))
+                        text: LocaleUtils.currencyAmountToLocaleString(approvalGasFeesFiat)
                         font.pixelSize: 15
                         color: Theme.palette.baseColor1
                         width: listItem.width/2 - Style.current.padding
@@ -113,14 +117,16 @@ Item {
                 statusListItemIcon.active: true
                 statusListItemIcon.opacity: modelData.isFirstBridgeTx
                 title: qsTr("%1 -> %2 bridge").arg(modelData.fromNetwork.chainName).arg(modelData.toNetwork.chainName)
-                subTitle: "%1 %2".arg(LocaleUtils.numberToLocaleString(modelData.tokenFees)).arg(root.selectedTokenSymbol)
+                property var tokenFees: root.getCurrencyAmount(modelData.tokenFees, root.selectedTokenSymbol)
+                property var tokenFeesFiat: root.getFiatValue(tokenFees.amount, root.selectedTokenSymbol, root.currentCurrency)
+                subTitle: LocaleUtils.currencyAmountToLocaleString(tokenFees)
                 visible: modelData.bridgeName !== "Simple"
                 statusListItemSubTitle.width: 100
                 statusListItemSubTitle.elide: Text.ElideMiddle
                 components: [
                     StatusBaseText {
                         Layout.alignment: Qt.AlignRight
-                        text: "%1%2".arg(currentCurrencySymbol).arg(LocaleUtils.numberToLocaleString(parseFloat(root.getFiatValue(modelData.tokenFees, root.selectedTokenSymbol, root.currentCurrency))))
+                        text: LocaleUtils.currencyAmountToLocaleString(tokenFeesFiat)
                         font.pixelSize: 15
                         color: Theme.palette.baseColor1
                         width: listItem2.width/2 - Style.current.padding

--- a/ui/imports/shared/controls/TokenBalancePerChainDelegate.qml
+++ b/ui/imports/shared/controls/TokenBalancePerChainDelegate.qml
@@ -16,7 +16,7 @@ StatusListItem {
     signal tokenSelected(var selectedToken)
 
     title: name
-    label: LocaleUtils.currencyAmountToLocaleString(enabledNetworkCurrencyBalance, root.locale)
+    label: LocaleUtils.currencyAmountToLocaleString(enabledNetworkCurrencyBalance)
     asset.name: symbol ? Style.png("tokens/" + symbol) : ""
     asset.isImage: true
     asset.width: 32
@@ -42,7 +42,7 @@ StatusListItem {
         id: expandedItem
         StatusListItemTag {
             height: 16
-            title: LocaleUtils.currencyAmountToLocaleString(balance, root.locale)
+            title: LocaleUtils.currencyAmountToLocaleString(balance)
             titleText.font.pixelSize: 12
             closeButtonVisible: false
             bgColor: "transparent"

--- a/ui/imports/shared/controls/TokenBalancePerChainDelegate.qml
+++ b/ui/imports/shared/controls/TokenBalancePerChainDelegate.qml
@@ -9,7 +9,6 @@ import utils 1.0
 StatusListItem {
     id: root
 
-    property var locale
     property var getNetworkIcon: function(chainId){
         return ""
     }

--- a/ui/imports/shared/controls/TokenDelegate.qml
+++ b/ui/imports/shared/controls/TokenDelegate.qml
@@ -10,7 +10,6 @@ import utils 1.0
 
 StatusListItem {
     id: root
-    property var locale
     title: name
     subTitle: LocaleUtils.currencyAmountToLocaleString(enabledNetworkBalance)
     asset.name: symbol ? Style.png("tokens/" + symbol) : ""

--- a/ui/imports/shared/controls/TokenDelegate.qml
+++ b/ui/imports/shared/controls/TokenDelegate.qml
@@ -12,7 +12,7 @@ StatusListItem {
     id: root
     property var locale
     title: name
-    subTitle: LocaleUtils.currencyAmountToLocaleString(enabledNetworkBalance, root.locale)
+    subTitle: LocaleUtils.currencyAmountToLocaleString(enabledNetworkBalance)
     asset.name: symbol ? Style.png("tokens/" + symbol) : ""
     asset.isImage: true
     components: [
@@ -25,7 +25,7 @@ StatusListItem {
                 anchors.right: parent.right
                 font.pixelSize: 15
                 font.strikeout: false
-                text: LocaleUtils.currencyAmountToLocaleString(enabledNetworkCurrencyBalance, root.locale)
+                text: LocaleUtils.currencyAmountToLocaleString(enabledNetworkCurrencyBalance)
             }
             Row {
                 anchors.horizontalCenter: parent.horizontalCenter
@@ -35,7 +35,7 @@ StatusListItem {
                     font.pixelSize: 15
                     font.strikeout: false
                     color: valueColumn.textColor
-                    text: LocaleUtils.currencyAmountToLocaleString(currencyPrice, root.locale)
+                    text: LocaleUtils.currencyAmountToLocaleString(currencyPrice)
                 }
                 Rectangle {
                     width: 1

--- a/ui/imports/shared/controls/TransactionDelegate.qml
+++ b/ui/imports/shared/controls/TransactionDelegate.qml
@@ -11,7 +11,6 @@ import shared 1.0
 StatusListItem {
     id: root
 
-    property var locale
     property var modelData
     property string symbol
     property bool isIncoming

--- a/ui/imports/shared/controls/TransactionDelegate.qml
+++ b/ui/imports/shared/controls/TransactionDelegate.qml
@@ -11,13 +11,13 @@ import shared 1.0
 StatusListItem {
     id: root
 
+    property var locale
     property var modelData
     property string symbol
     property bool isIncoming
     property int transferStatus
-    property string currentCurrency
-    property string cryptoValue
-    property string fiatValue
+    property var cryptoValue
+    property var fiatValue
     property string networkIcon
     property string networkColor
     property string networkName
@@ -62,13 +62,13 @@ StatusListItem {
                 }
                 StatusBaseText {
                     id: cryptoValueText
-                    text: "%1 %2".arg(cryptoValue).arg(resolvedSymbol)
+                    text: LocaleUtils.currencyAmountToLocaleString(cryptoValue)
                     color: Theme.palette.directColor1
                 }
             }
             StatusBaseText {
                 Layout.alignment: Qt.AlignRight
-                text: "%1 %2".arg(fiatValue).arg(currentCurrency.toUpperCase())
+                text: LocaleUtils.currencyAmountToLocaleString(fiatValue)
                 font.pixelSize: 15
                 color: Theme.palette.baseColor1
             }

--- a/ui/imports/shared/panels/StatusAssetSelector.qml
+++ b/ui/imports/shared/panels/StatusAssetSelector.qml
@@ -27,7 +27,6 @@ Item {
     property string userSelectedToken
     property string currentCurrencySymbol
     property string placeholderText
-    property var locale
 
     property var tokenAssetSourceFn: function (symbol) {
         return ""
@@ -150,7 +149,6 @@ Item {
         delegate: TokenBalancePerChainDelegate {
             objectName: "AssetSelector_ItemDelegate_" + symbol
             width: comboBox.control.popup.width
-            locale: root.locale
             getNetworkIcon: root.getNetworkIcon
             onTokenSelected: {
                 userSelectedToken = selectedToken.symbol

--- a/ui/imports/shared/popups/AccountsModalHeader.qml
+++ b/ui/imports/shared/popups/AccountsModalHeader.qml
@@ -89,7 +89,7 @@ StatusFloatingButtonsSelector {
     popupMenuDelegate: StatusListItem {
         implicitWidth: 272
         title: name
-        subTitle: LocaleUtils.currencyAmountToLocaleString(currencyBalance, locale)
+        subTitle: LocaleUtils.currencyAmountToLocaleString(currencyBalance)
         asset.emoji: !!emoji ? emoji: ""
         asset.color: model.color
         asset.name: !emoji ? "filled-account": ""

--- a/ui/imports/shared/popups/AccountsModalHeader.qml
+++ b/ui/imports/shared/popups/AccountsModalHeader.qml
@@ -18,7 +18,6 @@ import "../views"
 StatusFloatingButtonsSelector {
     id: root
 
-    property var locale
     property var selectedAccount
     // Expected signature: function(newAccount, newIndex)
     property var changeSelectedAccount: function(){}

--- a/ui/imports/shared/popups/SendModal.qml
+++ b/ui/imports/shared/popups/SendModal.qml
@@ -157,7 +157,6 @@ StatusDialog {
     header: AccountsModalHeader {
         anchors.top: parent.top
         anchors.topMargin: -height - 18
-        locale: popup.store.locale
         model: popup.store.accounts
         selectedAccount: popup.selectedAccount
         changeSelectedAccount: function(newAccount, newIndex) {
@@ -241,7 +240,6 @@ StatusDialog {
                                 }
                                 popup.recalculateRoutesAndFees()
                             }
-                            locale: popup.store.locale
                         }
                         StatusListItemTag {
                             Layout.alignment: Qt.AlignVCenter | Qt.AlignRight
@@ -258,7 +256,6 @@ StatusDialog {
                         AmountToSend {
                             id: amountToSendInput
                             Layout.fillWidth:true
-                            locale: popup.store.locale
                             isBridgeTx: popup.isBridgeTx
                             interactive: popup.interactive
                             selectedAsset: assetSelector.selectedAsset
@@ -282,7 +279,6 @@ StatusDialog {
                             id: amountToReceive
                             Layout.alignment: Qt.AlignRight
                             Layout.fillWidth:true
-                            locale: popup.store.locale
                             visible: popup.bestRoutes !== undefined && popup.bestRoutes.length > 0
                             store: popup.store
                             isLoading: popup.isLoading
@@ -302,7 +298,6 @@ StatusDialog {
                         anchors.right: parent.right
                         visible: !assetSelector.selectedAsset
                         assets: popup.selectedAccount && popup.selectedAccount.assets ? popup.selectedAccount.assets : []
-                        locale: popup.store.locale
                         searchTokenSymbolByAddressFn: function (address) {
                             if(popup.selectedAccount) {
                                 return popup.selectedAccount.findTokenSymbolByAddress(address)
@@ -415,7 +410,6 @@ StatusDialog {
                             d.waitTimer.restart()
                         }
                         visible: !d.recipientReady && !isBridgeTx && !!assetSelector.selectedAsset
-                        locale: popup.store.locale
                     }
 
                     NetworkSelector {

--- a/ui/imports/shared/stores/CurrenciesStore.qml
+++ b/ui/imports/shared/stores/CurrenciesStore.qml
@@ -5,8 +5,6 @@ import "../../../app/AppLayouts/Profile/stores"
 QtObject {
     id: root
 
-    property var locale: Qt.locale(localAppSettings.language)
-
     // Some token+currency-related functions are implemented in the profileSectionModule.
     // We should probably refactor this and move those functions to some Wallet module.
     property ProfileSectionStore profileSectionStore: ProfileSectionStore {}

--- a/ui/imports/shared/stores/CurrenciesStore.qml
+++ b/ui/imports/shared/stores/CurrenciesStore.qml
@@ -1,10 +1,15 @@
 import QtQuick 2.13
 import utils 1.0
+import "../../../app/AppLayouts/Profile/stores"
 
 QtObject {
     id: root
 
     property var locale: Qt.locale(localAppSettings.language)
+
+    // Some token+currency-related functions are implemented in the profileSectionModule.
+    // We should probably refactor this and move those functions to some Wallet module.
+    property ProfileSectionStore profileSectionStore: ProfileSectionStore {}
 
     property string currentCurrency: walletSection.currentCurrency
     property int currentCurrencyModelIndex: {
@@ -951,5 +956,33 @@ QtObject {
 
     function updateCurrency(newCurrency) {
         walletSection.updateCurrency(newCurrency)
+    }
+
+    function getCurrencyAmount(amount, symbol) {
+        let obj = JSON.parse((walletSection.getCurrencyAmountAsJson(amount, symbol)))
+        if (obj.error) {
+            console.error("Error parsing currency amount json object, amount: ", amount, ", symbol ", symbol, " error: ", obj.error)
+            return {amount: nan, symbol: symbol}
+        }
+        return obj
+    }
+
+    function getFiatValue(balance, cryptoSymbol, fiatSymbol) {
+        var amount = profileSectionModule.ensUsernamesModule.getFiatValue(balance, cryptoSymbol, fiatSymbol)
+        return getCurrencyAmount(parseFloat(amount), fiatSymbol)
+    }
+
+    function getCryptoValue(balance, cryptoSymbol, fiatSymbol) {
+        var amount = profileSectionModule.ensUsernamesModule.getCryptoValue(balance, cryptoSymbol, fiatSymbol)
+        return getCurrencyAmount(parseFloat(amount), cryptoSymbol) 
+    }
+
+    function getGasEthValue(gweiValue, gasLimit) {
+        var amount = profileSectionModule.ensUsernamesModule.getGasEthValue(gweiValue, gasLimit)
+        return getCurrencyAmount(parseFloat(amount), "ETH") 
+    }
+
+    function formatCurrencyAmount(currencyAmount) {
+        return LocaleUtils.currencyAmountToLocaleString(currencyAmount)
     }
 }

--- a/ui/imports/shared/stores/RootStore.qml
+++ b/ui/imports/shared/stores/RootStore.qml
@@ -23,7 +23,6 @@ QtObject {
     property bool isTenorWarningAccepted: !!accountSensitiveSettings ? accountSensitiveSettings.isTenorWarningAccepted : false
     property bool displayChatImages: !!accountSensitiveSettings ? accountSensitiveSettings.displayChatImages : false
 
-    property var locale: Qt.locale(localAppSettings.language)
 //    property string signingPhrase: !!walletModelInst ? walletModelInst.utilsView.signingPhrase : ""
 //    property string gasPrice: !!walletModelInst ? walletModelInst.gasView.gasPrice : "0"
 //    property string gasEthValue: !!walletModelInst ? walletModelInst.gasView.getGasEthValue : "0"

--- a/ui/imports/shared/stores/RootStore.qml
+++ b/ui/imports/shared/stores/RootStore.qml
@@ -63,10 +63,6 @@ QtObject {
         return networksModule.all.getNetworkName(symbol)
     }
 
-    function getFiatValue(balance, cryptoSymbol, fiatSymbol) {
-        return profileSectionModule.ensUsernamesModule.getFiatValue(balance, cryptoSymbol, fiatSymbol)
-    }
-
     function hex2Dec(value) {
         return globalUtils.hex2Dec(value)
     }
@@ -207,8 +203,24 @@ QtObject {
         return walletSectionTransactions.getLastTxBlockNumber()
     }
 
+    function getCurrencyAmount(amount, symbol) {
+        return currencyStore.getCurrencyAmount(amount, symbol)
+    }
+
+    function getFiatValue(balance, cryptoSymbol, fiatSymbol) {
+        return currencyStore.getFiatValue(balance, cryptoSymbol, fiatSymbol)
+    }
+
+    function getCryptoValue(balance, cryptoSymbol, fiatSymbol) {
+        return currencyStore.getCryptoValue(balance, cryptoSymbol, fiatSymbol)
+    }
+
     function getGasEthValue(gweiValue, gasLimit) {
-        return profileSectionModule.ensUsernamesModule.getGasEthValue(gweiValue, gasLimit)
+        return currencyStore.getGasEthValue(gweiValue, gasLimit)
+    }
+
+    function formatCurrencyAmount(currencyAmount) {
+        return currencyStore.formatCurrencyAmount(currencyAmount)
     }
 
     function getHistoricalDataForToken(symbol, currency) {

--- a/ui/imports/shared/stores/TransactionStore.qml
+++ b/ui/imports/shared/stores/TransactionStore.qml
@@ -61,18 +61,6 @@ QtObject {
         globalUtils.copyToClipboard(text)
     }
 
-    function getFiatValue(balance, cryptoSymbol, fiatSymbol) {
-        return profileSectionStore.ensUsernamesStore.getFiatValue(balance, cryptoSymbol, fiatSymbol)
-    }
-
-    function getCryptoValue(balance, cryptoSymbol, fiatSymbol) {
-        return profileSectionStore.ensUsernamesStore.getCryptoValue(balance, cryptoSymbol, fiatSymbol)
-    }
-
-    function getGasEthValue(gweiValue, gasLimit) {
-        return profileSectionStore.ensUsernamesStore.getGasEthValue(gweiValue, gasLimit)
-    }
-
     function authenticateAndTransfer(from, to, tokenSymbol, amount, uuid, selectedRoutes) {
         walletSectionTransactions.authenticateAndTransfer(from, to, tokenSymbol, amount, uuid, selectedRoutes)
     }
@@ -233,7 +221,7 @@ QtObject {
     property var lockedInAmounts: []
 
     function addLockedInAmount(chainID, value, decimals, locked) {
-        let amount = Number.fromLocaleString(Qt.locale(), value) * Math.pow(10, decimals)
+        let amount = value * Math.pow(10, decimals)
         let index  = lockedInAmounts.findIndex(lockedItem => lockedItem !== undefined && lockedItem.chainID === chainID)
         if(index === -1) {
             lockedInAmounts.push({"chainID": chainID, "value": amount.toString(16)})
@@ -253,18 +241,6 @@ QtObject {
             return undefined
         }
 
-        const jsonObj = selectedAccount.getTokenBalanceOnChainAsJson(chainId, tokenSymbol)
-        if (jsonObj === "") {
-            console.warn("failed to get balance, returned json is empty")
-            return undefined
-        }
-
-        const obj = JSON.parse(jsonObj)
-        if (obj.error) {
-            console.warn("failed to get balance, json parse error: ", obj.error)
-            return undefined
-        }
-
-        return obj
+        return JSON.parse(selectedAccount.getTokenBalanceOnChainAsJson(chainId, tokenSymbol))
     }
 }

--- a/ui/imports/shared/stores/TransactionStore.qml
+++ b/ui/imports/shared/stores/TransactionStore.qml
@@ -15,7 +15,6 @@ QtObject {
     property var mainModuleInst: mainModule
     property var walletSectionTransactionsInst: walletSectionTransactions
 
-    property var locale: Qt.locale(localAppSettings.language)
     property string currentCurrency: walletSection.currentCurrency
     property var allNetworks: networksModule.all
     property var accounts: walletSectionAccounts.model

--- a/ui/imports/shared/views/AmountToReceive.qml
+++ b/ui/imports/shared/views/AmountToReceive.qml
@@ -10,7 +10,6 @@ import shared.stores 1.0
 ColumnLayout {
     id: root
 
-    property var locale
     property var store
     property var selectedAsset
     property bool isLoading: false

--- a/ui/imports/shared/views/AmountToSend.qml
+++ b/ui/imports/shared/views/AmountToSend.qml
@@ -14,7 +14,6 @@ ColumnLayout {
 
     property alias input: topAmountToSendInput
 
-    property var locale
     property var selectedAsset
     property bool isBridgeTx: false
     property bool interactive: false

--- a/ui/imports/shared/views/AssetsDetailView.qml
+++ b/ui/imports/shared/views/AssetsDetailView.qml
@@ -58,8 +58,8 @@ Item {
         asset.name: token && token.symbol ? Style.png("tokens/%1".arg(token.symbol)) : ""
         asset.isImage: true
         primaryText: token ? token.name : ""
-        secondaryText: token ? LocaleUtils.currencyAmountToLocaleString(token.enabledNetworkBalance, RootStore.locale) : ""
-        tertiaryText: token ? LocaleUtils.currencyAmountToLocaleString(token.enabledNetworkCurrencyBalance, RootStore.locale) : ""
+        secondaryText: token ? LocaleUtils.currencyAmountToLocaleString(token.enabledNetworkBalance) : ""
+        tertiaryText: token ? LocaleUtils.currencyAmountToLocaleString(token.enabledNetworkCurrencyBalance) : ""
         balances: token && token.balances ? token.balances : null
         getNetworkColor: function(chainId){
             return RootStore.getNetworkColor(chainId)
@@ -68,7 +68,7 @@ Item {
             return RootStore.getNetworkIcon(chainId)
         }
         formatBalance: function(balance){
-            return LocaleUtils.currencyAmountToLocaleString(balance, RootStore.locale)
+            return LocaleUtils.currencyAmountToLocaleString(balance)
         }
     }
 
@@ -228,7 +228,7 @@ Item {
                                     fontColor: (Theme.palette.name === "dark") ? '#909090' : '#939BA1',
                                     padding: 8,
                                     callback: function(value, index, ticks) {
-                                        return LocaleUtils.numberToLocaleString(value, -1, RootStore.locale)
+                                        return LocaleUtils.numberToLocaleString(value)
                                     },
                                 }
                             }]
@@ -267,17 +267,17 @@ Item {
             InformationTile {
                 maxWidth: parent.width
                 primaryText: qsTr("Market Cap")
-                secondaryText: token && token.marketCap ? LocaleUtils.currencyAmountToLocaleString(token.marketCap, RootStore.locale) : "---"
+                secondaryText: token && token.marketCap ? LocaleUtils.currencyAmountToLocaleString(token.marketCap) : "---"
             }
             InformationTile {
                 maxWidth: parent.width
                 primaryText: qsTr("Day Low")
-                secondaryText: token && token.lowDay ? LocaleUtils.currencyAmountToLocaleString(token.lowDay, RootStore.locale) : "---"
+                secondaryText: token && token.lowDay ? LocaleUtils.currencyAmountToLocaleString(token.lowDay) : "---"
             }
             InformationTile {
                 maxWidth: parent.width
                 primaryText: qsTr("Day High")
-                secondaryText: token && token.highDay ? LocaleUtils.currencyAmountToLocaleString(token.highDay, RootStore.locale) : "---"
+                secondaryText: token && token.highDay ? LocaleUtils.currencyAmountToLocaleString(token.highDay) : "---"
             }
             Item {
                 Layout.fillWidth: true

--- a/ui/imports/shared/views/AssetsView.qml
+++ b/ui/imports/shared/views/AssetsView.qml
@@ -18,7 +18,6 @@ Item {
 
     property var account
     property bool assetDetailsLaunched: false
-    property var locale
 
     signal assetClicked(var token)
 
@@ -44,7 +43,6 @@ Item {
 
         delegate: TokenDelegate {
             objectName: "AssetView_TokenListItem_" + symbol
-            locale: root.locale
             readonly property string balance: "%1".arg(enabledNetworkBalance.amount) // Needed for the tests
             width: ListView.view.width
             onClicked: {

--- a/ui/imports/shared/views/FeesView.qml
+++ b/ui/imports/shared/views/FeesView.qml
@@ -7,15 +7,18 @@ import StatusQ.Core.Theme 0.1
 
 import utils 1.0
 
+import shared.stores 1.0
+
 import "../controls"
 
 Rectangle {
     id: root
 
-    property string gasFiatAmount
+    property var gasFiatAmount
     property bool isLoading: false
     property var bestRoutes
     property var store
+    property var currencyStore: store.currencyStore
     property var selectedTokenSymbol
     property int errorType: Constants.NoError
 
@@ -56,7 +59,7 @@ Rectangle {
                     anchors.right: parent.right
                     anchors.rightMargin: Style.current.padding
                     id: totalFeesAdvanced
-                    text: root.isLoading ? "..." : root.gasFiatAmount
+                    text: root.isLoading ? "..." : LocaleUtils.currencyAmountToLocaleString(root.gasFiatAmount)
                     font.pixelSize: 15
                     color: Theme.palette.directColor1
                     visible: !!root.bestRoutes && root.bestRoutes !== undefined && root.bestRoutes.length > 0
@@ -64,11 +67,12 @@ Rectangle {
             }
             GasSelector {
                 id: gasSelector
+                locale: root.store.locale
                 width: parent.width
-                getGasEthValue: root.store.getGasEthValue
-                getFiatValue: root.store.getFiatValue
-                currentCurrency: root.store.currencyStore.currentCurrency
-                currentCurrencySymbol: root.store.currencyStore.currentCurrencySymbol
+                getGasEthValue: root.currencyStore.getGasEthValue
+                getFiatValue: root.currencyStore.getFiatValue
+                getCurrencyAmount: root.currencyStore.getCurrencyAmount
+                currentCurrency: root.currencyStore.currentCurrency
                 visible: root.errorType === Constants.NoError && !root.isLoading
                 bestRoutes: root.bestRoutes
                 selectedTokenSymbol: root.selectedTokenSymbol

--- a/ui/imports/shared/views/FeesView.qml
+++ b/ui/imports/shared/views/FeesView.qml
@@ -67,7 +67,6 @@ Rectangle {
             }
             GasSelector {
                 id: gasSelector
-                locale: root.store.locale
                 width: parent.width
                 getGasEthValue: root.currencyStore.getGasEthValue
                 getFiatValue: root.currencyStore.getFiatValue

--- a/ui/imports/shared/views/HistoryView.qml
+++ b/ui/imports/shared/views/HistoryView.qml
@@ -17,6 +17,7 @@ import "../controls"
 ColumnLayout {
     id: historyView
 
+    property var locale
     property var account
     property int pageSize: 20 // number of transactions per page
     property bool isLoading: false
@@ -113,17 +114,18 @@ ColumnLayout {
     Component {
         id: transactionDelegate
         TransactionDelegate {
-            isIncoming: modelData !== undefined && !!modelData ? modelData.to === account.address: false
-            currentCurrency: RootStore.currentCurrency
-            cryptoValue: modelData !== undefined && !!modelData ? RootStore.hex2Eth(modelData.value) : ""
+            locale: historyView.locale
+            property bool modelDataValid: modelData !== undefined && !!modelData
+            isIncoming: modelDataValid ? modelData.to === account.address: false
+            cryptoValue: modelDataValid ? RootStore.getCurrencyAmount(RootStore.hex2Eth(modelData.value), resolvedSymbol) : ""
             fiatValue: RootStore.getFiatValue(cryptoValue, resolvedSymbol, RootStore.currentCurrency)
-            networkIcon: modelData !== undefined && !!modelData ? RootStore.getNetworkIcon(modelData.chainId) : ""
-            networkColor: modelData !== undefined && !!modelData ? RootStore.getNetworkColor(modelData.chainId) : ""
-            networkName: modelData !== undefined && !!modelData ? RootStore.getNetworkShortName(modelData.chainId) : ""
-            symbol: modelData !== undefined && !!modelData ? !!modelData.symbol ? modelData.symbol : RootStore.findTokenSymbolByAddress(modelData.contract) : ""
-            transferStatus: modelData !== undefined && !!modelData ? RootStore.hex2Dec(modelData.txStatus) : ""
-            shortTimeStamp: modelData !== undefined && !!modelData ? LocaleUtils.formatTime(modelData.timestamp * 1000, Locale.ShortFormat) : ""
-            savedAddressName: modelData !== undefined && !!modelData ? RootStore.getNameForSavedWalletAddress(modelData.to) : ""
+            networkIcon: modelDataValid ? RootStore.getNetworkIcon(modelData.chainId) : ""
+            networkColor: modelDataValid ? RootStore.getNetworkColor(modelData.chainId) : ""
+            networkName: modelDataValid ? RootStore.getNetworkShortName(modelData.chainId) : ""
+            symbol: modelDataValid ? !!modelData.symbol ? modelData.symbol : RootStore.findTokenSymbolByAddress(modelData.contract) : ""
+            transferStatus: modelDataValid ? RootStore.hex2Dec(modelData.txStatus) : ""
+            shortTimeStamp: modelDataValid ? LocaleUtils.formatTime(modelData.timestamp * 1000, Locale.ShortFormat) : ""
+            savedAddressName: modelDataValid ? RootStore.getNameForSavedWalletAddress(modelData.to) : ""
             onClicked: launchTransactionDetail(modelData)
         }
     }

--- a/ui/imports/shared/views/HistoryView.qml
+++ b/ui/imports/shared/views/HistoryView.qml
@@ -17,7 +17,6 @@ import "../controls"
 ColumnLayout {
     id: historyView
 
-    property var locale
     property var account
     property int pageSize: 20 // number of transactions per page
     property bool isLoading: false
@@ -114,7 +113,6 @@ ColumnLayout {
     Component {
         id: transactionDelegate
         TransactionDelegate {
-            locale: historyView.locale
             property bool modelDataValid: modelData !== undefined && !!modelData
             isIncoming: modelDataValid ? modelData.to === account.address: false
             cryptoValue: modelDataValid ? RootStore.getCurrencyAmount(RootStore.hex2Eth(modelData.value), resolvedSymbol) : ""

--- a/ui/imports/shared/views/NetworkCardsComponent.qml
+++ b/ui/imports/shared/views/NetworkCardsComponent.qml
@@ -16,7 +16,6 @@ Item {
     id: root
 
     property var store
-    property var locale
     property var bestRoutes
     property var selectedAccount
     property var selectedAsset

--- a/ui/imports/shared/views/NetworkSelector.qml
+++ b/ui/imports/shared/views/NetworkSelector.qml
@@ -80,7 +80,6 @@ Item {
                 amountToSend: root.amountToSend
                 isLoading: root.isLoading
                 store: root.store
-                locale: root.store.locale
                 selectedAsset: root.selectedAsset
                 selectedAccount: root.selectedAccount
                 errorMode: root.errorMode

--- a/ui/imports/shared/views/NetworkSelector.qml
+++ b/ui/imports/shared/views/NetworkSelector.qml
@@ -2,6 +2,7 @@
 import QtQuick.Layouts 1.13
 
 import utils 1.0
+import shared.stores 1.0
 
 import StatusQ.Controls 0.1
 import StatusQ.Popups 0.1
@@ -17,10 +18,11 @@ Item {
     implicitHeight: visible ? tabBar.height + stackLayout.height + Style.current.xlPadding : 0
 
     property var store
+    property var currencyStore : store.currencyStore
     property var selectedAccount
     property var selectedAsset
-    property double amountToSend: 0
-    property double requiredGasInEth: 0
+    property var amountToSend
+    property var requiredGasInEth
     property var bestRoutes
     property bool isLoading: false
     property bool advancedOrCustomMode: (tabBar.currentIndex === 1) || (tabBar.currentIndex === 2)
@@ -78,13 +80,14 @@ Item {
                 amountToSend: root.amountToSend
                 isLoading: root.isLoading
                 store: root.store
+                locale: root.store.locale
                 selectedAsset: root.selectedAsset
                 selectedAccount: root.selectedAccount
                 errorMode: root.errorMode
                 errorType: root.errorType
                 toNetworksList: root.toNetworksList
                 weiToEth: function(wei) {
-                    return "%1 %2".arg(LocaleUtils.numberToLocaleString(parseFloat(store.getWei2Eth(wei, selectedAsset.decimals)))).arg(selectedAsset.symbol)
+                    return root.currencyStore.getCurrencyAmount(parseFloat(store.getWei2Eth(wei, selectedAsset.decimals)), selectedAsset.symbol)
                 }
                 reCalculateSuggestedRoute: function() {
                     root.reCalculateSuggestedRoute()
@@ -114,7 +117,10 @@ Item {
                 isBridgeTx: root.isBridgeTx
                 errorType: root.errorType
                 weiToEth: function(wei) {
-                    return parseFloat(store.getWei2Eth(wei, selectedAsset.decimals))
+                    return root.currencyStore.getCurrencyAmount(parseFloat(store.getWei2Eth(wei, selectedAsset.decimals)), selectedAsset.symbol)
+                }
+                getCryptoCurrencyAmount: function(cryptoValue) {
+                    return selectedAsset ? root.currencyStore.getCurrencyAmount(parseFloat(cryptoValue), selectedAsset.symbol) : undefined
                 }
             }
         }

--- a/ui/imports/shared/views/NetworksAdvancedCustomRoutingView.qml
+++ b/ui/imports/shared/views/NetworksAdvancedCustomRoutingView.qml
@@ -82,7 +82,6 @@ ColumnLayout {
                 visible: active
                 sourceComponent: NetworkCardsComponent {
                     store: root.store
-                    locale: root.store.locale
                     selectedAccount: root.selectedAccount
                     allNetworks: root.store.allNetworks
                     amountToSend: root.amountToSend

--- a/ui/imports/shared/views/NetworksAdvancedCustomRoutingView.qml
+++ b/ui/imports/shared/views/NetworksAdvancedCustomRoutingView.qml
@@ -16,14 +16,15 @@ ColumnLayout {
 
     property var store
     property var selectedAccount
-    property double amountToSend: 0
-    property double requiredGasInEth: 0
+    property var amountToSend
+    property var requiredGasInEth
     property bool customMode: false
     property var selectedAsset
     property var bestRoutes
     property bool isLoading: false
     property bool errorMode: networksLoader.item ? networksLoader.item.errorMode : false
     property var weiToEth: function(wei) {}
+    property var getCryptoCurrencyAmount: function(cryptoValue) {}
     property bool interactive: true
     property bool isBridgeTx: false
     property bool showUnpreferredNetworks: preferredToggleButton.checked
@@ -81,6 +82,7 @@ ColumnLayout {
                 visible: active
                 sourceComponent: NetworkCardsComponent {
                     store: root.store
+                    locale: root.store.locale
                     selectedAccount: root.selectedAccount
                     allNetworks: root.store.allNetworks
                     amountToSend: root.amountToSend
@@ -93,6 +95,7 @@ ColumnLayout {
                     showPreferredChains: preferredToggleButton.checked
                     bestRoutes: root.bestRoutes
                     weiToEth: root.weiToEth
+                    getCryptoCurrencyAmount: root.getCryptoCurrencyAmount
                     interactive: root.interactive
                     errorType: root.errorType
                     isLoading: root.isLoading

--- a/ui/imports/shared/views/NetworksSimpleRoutingView.qml
+++ b/ui/imports/shared/views/NetworksSimpleRoutingView.qml
@@ -16,8 +16,9 @@ RowLayout {
     id: root
 
     property var store
+    property var locale
     property var bestRoutes
-    property double amountToSend: 0
+    property var amountToSend
     property bool isLoading: false
     property bool isBridgeTx: false
     property var selectedAsset
@@ -79,7 +80,7 @@ RowLayout {
             Layout.fillWidth: true
             Layout.alignment: Qt.AlignHCenter
             Layout.topMargin: Style.current.bigPadding
-            amountToSend: root.amountToSend
+            amountToSend: root.amountToSend ? root.amountToSend.amount : 0.0
             isLoading: root.isLoading
             errorType: root.errorType
         }
@@ -98,12 +99,14 @@ RowLayout {
             implicitWidth: 410
             title: modelData.chainName
             subTitle: {
-                let index  = store.lockedInAmounts.findIndex(lockedItem => lockedItem !== undefined && lockedItem.chainID === modelData.chainId)
+                let index = store.lockedInAmounts.findIndex(lockedItem => lockedItem !== undefined && lockedItem.chainID === modelData.chainId)
+                var amountOut
                 if(!root.errorMode || index === -1)
-                    return root.weiToEth(modelData.amountOut)
+                    amountOut = root.weiToEth(modelData.amountOut)
                 else {
-                    return root.weiToEth(parseInt(store.lockedInAmounts[index].value, 16))
+                    amountOut = root.weiToEth(parseInt(store.lockedInAmounts[index].value, 16))
                 }
+                return LocaleUtils.currencyAmountToLocaleString(amountOut)
             }
             statusListItemSubTitle.color: root.errorMode ? Theme.palette.dangerColor1 : Theme.palette.primaryColor1
             asset.width: 32
@@ -128,7 +131,7 @@ RowLayout {
                 title: chainName
                 property bool tokenBalanceOnChainValid: selectedAccount && selectedAccount !== undefined && selectedAsset !== undefined
                 property var tokenBalanceOnChain: tokenBalanceOnChainValid ? root.store.getTokenBalanceOnChain(selectedAccount, chainId, selectedAsset.symbol) : undefined
-                subTitle: tokenBalanceOnChain ? LocaleUtils.currencyAmountToLocaleString(tokenBalanceOnChain, root.store.locale) : "N/A"
+                subTitle: tokenBalanceOnChain ? LocaleUtils.currencyAmountToLocaleString(tokenBalanceOnChain) : "N/A"
                 statusListItemSubTitle.color: Theme.palette.primaryColor1
                 asset.width: 32
                 asset.height: 32

--- a/ui/imports/shared/views/NetworksSimpleRoutingView.qml
+++ b/ui/imports/shared/views/NetworksSimpleRoutingView.qml
@@ -16,7 +16,6 @@ RowLayout {
     id: root
 
     property var store
-    property var locale
     property var bestRoutes
     property var amountToSend
     property bool isLoading: false

--- a/ui/imports/shared/views/TabAddressSelectorView.qml
+++ b/ui/imports/shared/views/TabAddressSelectorView.qml
@@ -22,7 +22,6 @@ Item {
     implicitHeight: visible ? accountSelectionTabBar.height + stackLayout.height + Style.current.bigPadding: 0
 
     property var store
-    property var locale
 
     signal contactSelected(string address, int type)
 

--- a/ui/imports/shared/views/TabAddressSelectorView.qml
+++ b/ui/imports/shared/views/TabAddressSelectorView.qml
@@ -153,7 +153,7 @@ Item {
                     objectName: model.name
                     height: visible ? 64 : 0
                     title: !!model.name ? model.name : ""
-                    subTitle: LocaleUtils.currencyAmountToLocaleString(model.currencyBalance, root.locale)
+                    subTitle: LocaleUtils.currencyAmountToLocaleString(model.currencyBalance)
                     asset.emoji: !!model.emoji ? model.emoji: ""
                     asset.color: model.color
                     asset.name: !model.emoji ? "filled-account": ""

--- a/ui/imports/shared/views/TokenListView.qml
+++ b/ui/imports/shared/views/TokenListView.qml
@@ -14,7 +14,6 @@ import "../controls"
 Rectangle {
     id: root
 
-    property var locale
     property var assets: []
     signal tokenSelected(var selectedToken)
     property var searchTokenSymbolByAddressFn: function (address) {
@@ -56,7 +55,6 @@ Rectangle {
         }
         delegate: TokenBalancePerChainDelegate {
             width: ListView.view.width
-            locale: root.locale
             getNetworkIcon: root.getNetworkIcon
             onTokenSelected: root.tokenSelected(selectedToken)
         }

--- a/ui/imports/shared/views/TransactionDetailView.qml
+++ b/ui/imports/shared/views/TransactionDetailView.qml
@@ -18,6 +18,7 @@ import "../controls"
 Item {
     id: root
 
+    property var locale
     property var currentAccount: RootStore.currentAccount
     property var contactsStore
     property var transaction
@@ -57,18 +58,19 @@ Item {
                 objectName: "transactionDetailHeader"
                 width: parent.width
 
+                locale: root.locale
                 modelData: transaction
                 isIncoming: d.isIncoming
-                currentCurrency: RootStore.currentCurrency
-                cryptoValue: root.transaction !== undefined && !!root.transaction ? RootStore.hex2Eth(transaction.value): ""
-                fiatValue: root.transaction !== undefined && !!root.transaction ? RootStore.getFiatValue(cryptoValue, resolvedSymbol, RootStore.currentCurrency): ""
-                networkIcon: root.transaction !== undefined && !!root.transaction ? RootStore.getNetworkIcon(transaction.chainId): ""
-                networkColor: root.transaction !== undefined && !!root.transaction ? RootStore.getNetworkColor(transaction.chainId): ""
-                networkName: root.transaction !== undefined && !!root.transaction ? RootStore.getNetworkShortName(transaction.chainId): ""
-                symbol: root.transaction !== undefined && !!root.transaction ? RootStore.findTokenSymbolByAddress(transaction.contract): ""
-                transferStatus: root.transaction !== undefined && !!root.transaction ? RootStore.hex2Dec(transaction.txStatus): ""
-                shortTimeStamp: root.transaction !== undefined && !!root.transaction ? LocaleUtils.formatTime(transaction.timestamp * 1000, Locale.ShortFormat): ""
-                savedAddressName: root.transaction !== undefined && !!root.transaction ? RootStore.getNameForSavedWalletAddress(transaction.to): ""
+                property bool transactionValid: root.transaction !== undefined && !!root.transaction
+                cryptoValue: transactionValid ? RootStore.getCurrencyAmount(RootStore.hex2Eth(transaction.value), resolvedSymbol): undefined
+                fiatValue: transactionValid ? RootStore.getFiatValue(cryptoValue, resolvedSymbol, RootStore.currentCurrency): ""
+                networkIcon: transactionValid ? RootStore.getNetworkIcon(transaction.chainId): ""
+                networkColor: transactionValid ? RootStore.getNetworkColor(transaction.chainId): ""
+                networkName: transactionValid ? RootStore.getNetworkShortName(transaction.chainId): ""
+                symbol: transactionValid ? RootStore.findTokenSymbolByAddress(transaction.contract): ""
+                transferStatus: transactionValid ? RootStore.hex2Dec(transaction.txStatus): ""
+                shortTimeStamp: transactionValid ? LocaleUtils.formatTime(transaction.timestamp * 1000, Locale.ShortFormat): ""
+                savedAddressName: transactionValid ? RootStore.getNameForSavedWalletAddress(transaction.to): ""
                 title: d.isIncoming ? qsTr("Received %1 %2 from %3").arg(cryptoValue).arg(resolvedSymbol).arg(d.from) :
                                     qsTr("Sent %1 %2 to %3").arg(cryptoValue).arg(resolvedSymbol).arg(d.to)
                 sensor.enabled: false
@@ -154,18 +156,19 @@ Item {
             spacing: 8
             TransactionDelegate {
                 width: parent.width
+                locale: root.locale
                 modelData: transaction
                 isIncoming: d.isIncoming
-                currentCurrency: RootStore.currentCurrency
-                cryptoValue: root.transaction !== undefined && !!root.transaction ? RootStore.hex2Eth(transaction.value): ""
+                property bool transactionValid: root.transaction !== undefined && !!root.transaction
+                cryptoValue: transactionValid ? RootStore.getCurrencyAmount(RootStore.hex2Eth(transaction.value), resolvedSymbol): ""
                 fiatValue: RootStore.getFiatValue(cryptoValue, resolvedSymbol, RootStore.currentCurrency)
-                networkIcon: root.transaction !== undefined && !!root.transaction ? RootStore.getNetworkIcon(transaction.chainId) : ""
-                networkColor: root.transaction !== undefined && !!root.transaction ? RootStore.getNetworkColor(transaction.chainId): ""
-                networkName: root.transaction !== undefined && !!root.transaction ? RootStore.getNetworkShortName(transaction.chainId): ""
-                symbol: root.transaction !== undefined && !!root.transaction ? RootStore.findTokenSymbolByAddress(transaction.contract): ""
-                transferStatus: root.transaction !== undefined && !!root.transaction ? RootStore.hex2Dec(transaction.txStatus): ""
-                shortTimeStamp: root.transaction !== undefined && !!root.transaction ? LocaleUtils.formatTime(transaction.timestamp * 1000, Locale.ShortFormat): ""
-                savedAddressName: root.transaction !== undefined && !!root.transaction ? RootStore.getNameForSavedWalletAddress(transaction.to): ""
+                networkIcon: transactionValid ? RootStore.getNetworkIcon(transaction.chainId) : ""
+                networkColor: transactionValid ? RootStore.getNetworkColor(transaction.chainId): ""
+                networkName: transactionValid ? RootStore.getNetworkShortName(transaction.chainId): ""
+                symbol: transactionValid ? RootStore.findTokenSymbolByAddress(transaction.contract): ""
+                transferStatus: transactionValid ? RootStore.hex2Dec(transaction.txStatus): ""
+                shortTimeStamp: transactionValid ? LocaleUtils.formatTime(transaction.timestamp * 1000, Locale.ShortFormat): ""
+                savedAddressName: transactionValid ? RootStore.getNameForSavedWalletAddress(transaction.to): ""
                 title: d.isIncoming ? qsTr("Received %1 %2 from %3").arg(cryptoValue).arg(resolvedSymbol).arg(d.from) :
                                       qsTr("Sent %1 %2 to %3").arg(cryptoValue).arg(resolvedSymbol).arg(d.to)
                 sensor.enabled: false

--- a/ui/imports/shared/views/TransactionDetailView.qml
+++ b/ui/imports/shared/views/TransactionDetailView.qml
@@ -18,7 +18,6 @@ import "../controls"
 Item {
     id: root
 
-    property var locale
     property var currentAccount: RootStore.currentAccount
     property var contactsStore
     property var transaction
@@ -58,7 +57,6 @@ Item {
                 objectName: "transactionDetailHeader"
                 width: parent.width
 
-                locale: root.locale
                 modelData: transaction
                 isIncoming: d.isIncoming
                 property bool transactionValid: root.transaction !== undefined && !!root.transaction
@@ -156,7 +154,6 @@ Item {
             spacing: 8
             TransactionDelegate {
                 width: parent.width
-                locale: root.locale
                 modelData: transaction
                 isIncoming: d.isIncoming
                 property bool transactionValid: root.transaction !== undefined && !!root.transaction


### PR DESCRIPTION
### What does the PR do

Fixes #8934 

Use new unified currency formatting mechanism in Send/Bridge modal

Removed passing around of locale object, not required anymore if `LocaleUtils` functions are used.

System locale is now used for all conversions Number<->String

### Affected areas

Wallet

### Screenshots

Before:

![image](https://user-images.githubusercontent.com/11161531/211222311-7d5285e5-b2f6-4f98-a3ab-25bc8947359c.png)
![image](https://user-images.githubusercontent.com/11161531/211222345-7ffed7d5-1339-40a4-80d8-3db696522432.png)
![image](https://user-images.githubusercontent.com/11161531/211222355-4623efed-53d1-490f-942c-27ed21aa056e.png)

After:

![image](https://user-images.githubusercontent.com/11161531/211222441-638477af-6cf1-4cd4-b308-fc3cac0a95f2.png)
![image](https://user-images.githubusercontent.com/11161531/211222711-46ca469e-872c-489c-8a08-39aacf65782b.png)
![image](https://user-images.githubusercontent.com/11161531/211222723-2bbe81f7-a2b8-4a31-9a0d-2c15beaa329a.png)



