### PR TITLE
fix(@desktop/chat): message box buttons do not work in group chat creation screen

### DIFF
--- a/ui/app/AppLayouts/Chat/views/CreateChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/CreateChatView.qml
@@ -18,6 +18,7 @@ Page {
 
     property var rootStore
     property var emojiPopup: null
+    property var stickersPopup: null
 
     QtObject {
         id: d
@@ -153,6 +154,7 @@ Page {
                 visible: membersSelector.model.count > 0
                 chatType: membersSelector.model.count === 1? Constants.chatType.oneToOne : Constants.chatType.privateGroupChat
                 emojiPopup: root.emojiPopup
+                stickersPopup: root.stickersPopup
                 closeGifPopupAfterSelection: true
                 onSendTransactionCommandButtonClicked: {
                     root.rootStore.createChatStartSendTransactionProcess = true;

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -1014,6 +1014,7 @@ Item {
                     sourceComponent: CreateChatView {
                         rootStore: chatLayoutContainer.rootStore
                         emojiPopup: statusEmojiPopup
+                        stickersPopup: statusStickersPopup
                     }
                 }
             }


### PR DESCRIPTION
### What does the PR do

`CreateChatView` didn't have a `statusStickersPopup` (was null), so when the user clicked the message box buttons, we had a qml error that the sticker popup is null and further code did not execute

Fixed: #8730 

### Affected areas

CreateChatView

### Screenshot of functionality (including design for comparison)

https://user-images.githubusercontent.com/117639195/211282497-2abacb78-e7cf-4fc4-9d7e-85fd57727fbb.mov

