### PR TITLE
Fix/8955/chat logo in the middle

### DIFF
--- a/src/app/modules/main/chat_section/chat_content/messages/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/module.nim
@@ -21,7 +21,9 @@ logScope:
   topics = "messages-module"
 
 const CHAT_IDENTIFIER_MESSAGE_ID = "chat-identifier-message-id"
+const CHAT_IDENTIFIER_CLOCK = -2
 const FETCH_MORE_MESSAGES_MESSAGE_ID = "fetch-more_messages-message-id"
+const FETCH_MORE_MESSAGES_CLOCK = -1
 
 type
   Module* = ref object of io_interface.AccessInterface
@@ -61,8 +63,8 @@ method isLoaded*(self: Module): bool =
 
 method viewDidLoad*(self: Module) =
   if self.controller.getChatDetails().hasMoreMessagesToRequest():
-    self.view.model().appendItem(self.createFetchMoreMessagesItem())
-  self.view.model().appendItem(self.createChatIdentifierItem())
+    self.view.model().insertItemBasedOnClock(self.createFetchMoreMessagesItem())
+  self.view.model().insertItemBasedOnClock(self.createChatIdentifierItem())
 
   self.moduleLoaded = true
   self.delegate.messagesDidLoad()
@@ -88,7 +90,7 @@ proc createFetchMoreMessagesItem(self: Module): Item =
     messageContainsMentions = false,
     seen = true,
     timestamp = 0,
-    clock = 0,
+    clock = FETCH_MORE_MESSAGES_CLOCK,
     ContentType.FetchMoreMessagesButton,
     messageType = -1,
     contactRequestState = 0,
@@ -131,7 +133,7 @@ proc createChatIdentifierItem(self: Module): Item =
     messageContainsMentions = false,
     seen = true,
     timestamp = 0,
-    clock = 0,
+    clock = CHAT_IDENTIFIER_CLOCK,
     ContentType.ChatIdentifier,
     messageType = -1,
     contactRequestState = 0,
@@ -261,7 +263,7 @@ method newMessagesLoaded*(self: Module, messages: seq[MessageDto], reactions: se
     self.view.model().removeItem(FETCH_MORE_MESSAGES_MESSAGE_ID)
     self.view.model().removeItem(CHAT_IDENTIFIER_MESSAGE_ID)
     # Add new loaded messages
-    self.view.model().appendItems(viewItems)
+    self.view.model().insertItemsBasedOnClock(viewItems)
     self.view.model().resetNewMessagesMarker()
 
     # check if this loading was caused by the click on a messages from the app search result
@@ -508,13 +510,13 @@ method updateChatIdentifier*(self: Module) =
   # Delete the old ChatIdentifier message first
   self.view.model().removeItem(CHAT_IDENTIFIER_MESSAGE_ID)
   # Add new loaded messages
-  self.view.model().appendItem(self.createChatIdentifierItem())
+  self.view.model().insertItemBasedOnClock(self.createChatIdentifierItem())
 
 method updateChatFetchMoreMessages*(self: Module) =
   self.view.model().removeItem(FETCH_MORE_MESSAGES_MESSAGE_ID)
 
   if (self.controller.getChatDetails().hasMoreMessagesToRequest()):
-    self.view.model().appendItem(self.createFetchMoreMessagesItem())
+    self.view.model().insertItemBasedOnClock(self.createFetchMoreMessagesItem())
 
 method getLinkPreviewData*(self: Module, link: string, uuid: string): string =
   return self.controller.getLinkPreviewData(link, uuid)

--- a/src/app/modules/main/chat_section/chat_content/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/module.nim
@@ -228,7 +228,7 @@ method newPinnedMessagesLoaded*(self: Module, pinnedMessages: seq[PinnedMessageD
 
   if(viewItems.len == 0):
     return
-  self.view.pinnedModel().prependItems(viewItems)
+  self.view.pinnedModel().insertItemsBasedOnClock(viewItems)
 
 method unpinMessage*(self: Module, messageId: string) =
   self.controller.unpinMessage(messageId)
@@ -241,7 +241,7 @@ method onPinMessage*(self: Module, messageId: string, actionInitiatedBy: string)
   if(not self.buildPinnedMessageItem(messageId, actionInitiatedBy, item)):
     return
 
-  self.view.pinnedModel().appendItem(item)
+  self.view.pinnedModel().insertItemBasedOnClock(item)
 
 method getMyChatId*(self: Module): string =
   self.controller.getMyChatId()

--- a/src/app/modules/shared_models/message_item.nim
+++ b/src/app/modules/shared_models/message_item.nim
@@ -131,7 +131,7 @@ proc initItem*(
       if attachment.contentType.contains("image"):
         result.messageAttachments.add(attachment.localUrl)
 
-proc initNewMessagesMarkerItem*(timestamp: int64): Item =
+proc initNewMessagesMarkerItem*(clock, timestamp: int64): Item =
   return initItem(
     id = "",
     communityId = "",
@@ -148,7 +148,7 @@ proc initNewMessagesMarkerItem*(timestamp: int64): Item =
     messageContainsMentions = false,
     seen = true,
     timestamp = timestamp,
-    clock = 0,
+    clock = clock,
     ContentType.NewMessagesMarker,
     messageType = -1,
     contactRequestState = 0,

--- a/src/app/modules/shared_models/message_model.nim
+++ b/src/app/modules/shared_models/message_model.nim
@@ -569,7 +569,7 @@ QtObject:
     defer: parentModelIndex.delete
 
     self.beginInsertRows(parentModelIndex, position, position)
-    self.items.insert(initNewMessagesMarkerItem(self.items[index].timestamp), position)
+    self.items.insert(initNewMessagesMarkerItem(self.items[index].clock, self.items[index].timestamp), position)
     self.endInsertRows()
     self.countChanged()
 

--- a/src/app/modules/shared_models/message_model.nim
+++ b/src/app/modules/shared_models/message_model.nim
@@ -254,11 +254,6 @@ QtObject:
           return i
     return self.items.len
 
-  proc filterExistingItems(self: Model, items: seq[Item]): seq[Item] =
-    for item in items:
-      if(self.findIndexForMessageId(item.id) < 0):
-        result &= item
-
   proc insertItemBasedOnClock*(self: Model, item: Item) =
     if(self.findIndexForMessageId(item.id) != -1):
       return
@@ -278,53 +273,9 @@ QtObject:
       self.updateItemAtIndex(position + 1)
     self.countChanged()
 
-  proc prependItems*(self: Model, items: seq[Item]) =
-    let itemsToAppend = self.filterExistingItems(items)
-    if(itemsToAppend.len == 0):
-      return
-
+  proc insertItemsBasedOnClock*(self: Model, items: seq[Item]) =
     for item in items:
       self.insertItemBasedOnClock(item)
-
-  proc appendItems*(self: Model, items: seq[Item]) =
-    let itemsToAppend = self.filterExistingItems(items)
-    if(itemsToAppend.len == 0):
-      return
-
-    for item in items:
-      self.insertItemBasedOnClock(item)
-
-  proc appendItem*(self: Model, item: Item) =
-    if(self.findIndexForMessageId(item.id) != -1):
-      return
-
-    let parentModelIndex = newQModelIndex()
-    defer: parentModelIndex.delete
-
-    let position = self.items.len
-
-    self.beginInsertRows(parentModelIndex, position, position)
-    self.items.add(item)
-    self.endInsertRows()
-
-    if position > 0:
-      self.updateItemAtIndex(position - 1)
-    self.countChanged()
-
-  proc prependItem*(self: Model, item: Item) =
-    if(self.findIndexForMessageId(item.id) != -1):
-      return
-
-    let parentModelIndex = newQModelIndex()
-    defer: parentModelIndex.delete
-
-    self.beginInsertRows(parentModelIndex, 0, 0)
-    self.items.insert(item, 0)
-    self.endInsertRows()
-
-    if self.items.len > 1:
-      self.updateItemAtIndex(1)
-    self.countChanged()
 
   proc replyDeleted*(self: Model, messageIndex: int) {.signal.}
 

--- a/test/nim/message_model_test.nim
+++ b/test/nim/message_model_test.nim
@@ -37,7 +37,8 @@ proc createTestMessageItem(id: string, clock: int64): Item =
     senderTrustStatus = TrustStatus.Unknown,
     senderEnsVerified = false,
     discordMessage = DiscordMessage(),
-    resendError = ""
+    resendError = "",
+    mentioned = false
   )
 
 let message1 = createTestMessageItem("0xa", 1)

--- a/test/nim/message_model_test.nim
+++ b/test/nim/message_model_test.nim
@@ -26,7 +26,7 @@ proc createTestMessageItem(id: string, clock: int64): Item =
     seen = true,
     timestamp = 0,
     clock = clock,
-    ContentType.NewMessagesMarker,
+    ContentType.Unknown,
     messageType = -1,
     contactRequestState = 0,
     sticker = "",
@@ -41,6 +41,8 @@ proc createTestMessageItem(id: string, clock: int64): Item =
     mentioned = false
   )
 
+let message0_chatIdentifier = createTestMessageItem("chat-identifier", 0)
+let message0_fetchMoreMessages = createTestMessageItem("fetch-more-messages", 0)
 let message1 = createTestMessageItem("0xa", 1)
 let message2 = createTestMessageItem("0xb", 2)
 let message3 = createTestMessageItem("0xc", 3)
@@ -48,12 +50,14 @@ let message4 = createTestMessageItem("0xd", 3)
 let message5 = createTestMessageItem("0xe", 4)
 
 template checkOrder(model: Model) =
-  require(model.items.len == 5)
+  require(model.items.len == 7)
   check(model.items[0].id == message5.id)
   check(model.items[1].id == message4.id)
   check(model.items[2].id == message3.id)
   check(model.items[3].id == message2.id)
   check(model.items[4].id == message1.id)
+  check(model.items[5].id == message0_fetchMoreMessages.id)
+  check(model.items[6].id == message0_chatIdentifier.id)
 
 suite "empty model":
   let model = newModel()
@@ -65,56 +69,60 @@ suite "empty model":
 suite "inserting new messages":
   setup:
     let model = newModel()
+    model.appendItem(message0_fetchMoreMessages)
+    model.appendItem(message0_chatIdentifier)
 
   test "insert same message twice":
     model.insertItemBasedOnClock(message1)
-    check(model.rowCount() == 1)
+    check(model.rowCount() == 3)
     model.insertItemBasedOnClock(message1)
-    check(model.rowCount() == 1)
+    check(model.rowCount() == 3)
 
   test "insert in order":
     model.insertItemBasedOnClock(message1)
-    check(model.rowCount() == 1)
-    model.insertItemBasedOnClock(message2)
-    check(model.rowCount() == 2)
-    model.insertItemBasedOnClock(message3)
     check(model.rowCount() == 3)
-    model.insertItemBasedOnClock(message4)
+    model.insertItemBasedOnClock(message2)
     check(model.rowCount() == 4)
-    model.insertItemBasedOnClock(message5)
+    model.insertItemBasedOnClock(message3)
     check(model.rowCount() == 5)
+    model.insertItemBasedOnClock(message4)
+    check(model.rowCount() == 6)
+    model.insertItemBasedOnClock(message5)
+    check(model.rowCount() == 7)
     checkOrder(model)
 
   test "insert out of order":
     model.insertItemBasedOnClock(message5)
-    check(model.rowCount() == 1)
-    model.insertItemBasedOnClock(message4)
-    check(model.rowCount() == 2)
-    model.insertItemBasedOnClock(message3)
     check(model.rowCount() == 3)
-    model.insertItemBasedOnClock(message2)
+    model.insertItemBasedOnClock(message4)
     check(model.rowCount() == 4)
-    model.insertItemBasedOnClock(message1)
+    model.insertItemBasedOnClock(message3)
     check(model.rowCount() == 5)
+    model.insertItemBasedOnClock(message2)
+    check(model.rowCount() == 6)
+    model.insertItemBasedOnClock(message1)
+    check(model.rowCount() == 7)
     checkOrder(model)
 
   test "insert out of order (randomly)":
     model.insertItemBasedOnClock(message3)
-    check(model.rowCount() == 1)
-    model.insertItemBasedOnClock(message1)
-    check(model.rowCount() == 2)
-    model.insertItemBasedOnClock(message4)
     check(model.rowCount() == 3)
-    model.insertItemBasedOnClock(message2)
+    model.insertItemBasedOnClock(message1)
     check(model.rowCount() == 4)
-    model.insertItemBasedOnClock(message5)
+    model.insertItemBasedOnClock(message4)
     check(model.rowCount() == 5)
+    model.insertItemBasedOnClock(message2)
+    check(model.rowCount() == 6)
+    model.insertItemBasedOnClock(message5)
+    check(model.rowCount() == 7)
     checkOrder(model)
 
 # assumption: each append sequence is already sorted
 suite "appending new messages":
   setup:
     let model = newModel()
+    model.appendItem(message0_fetchMoreMessages)
+    model.appendItem(message0_chatIdentifier)
 
   test "append empty model":
     model.appendItems(@[message5,
@@ -147,3 +155,142 @@ suite "appending new messages":
     model.appendItems(@[message4,
                         message2])
     checkOrder(model)
+
+suite "new messages marker":
+  setup:
+    let model = newModel()
+    model.appendItem(message0_fetchMoreMessages)
+    model.appendItem(message0_chatIdentifier)
+
+  test "set new messages marker":
+    model.appendItems(@[message1,
+                        message2])
+    require(model.items.len == 4)
+
+    # add new messages marker
+    model.setFirstUnseenMessageId(message2.id)
+    model.resetNewMessagesMarker()
+
+    require(model.items.len == 5)
+    check(model.items[0].id == message2.id)
+    check(model.items[1].contentType == ContentType.NewMessagesMarker)
+    check(model.items[2].id == message1.id)
+    check(model.items[3].id == message0_fetchMoreMessages.id)
+    check(model.items[4].id == message0_chatIdentifier.id)
+
+  test "remove new messages marker":
+    model.appendItems(@[message1,
+                        message2])
+    require(model.items.len == 4)
+
+    # add new messages marker
+    model.setFirstUnseenMessageId(message2.id)
+    model.resetNewMessagesMarker()
+    require(model.items.len == 5)
+
+    # remove new messages marker
+    model.setFirstUnseenMessageId("")
+    model.resetNewMessagesMarker()
+    require(model.items.len == 4)
+    check(model.items[0].id == message2.id)
+    check(model.items[1].id == message1.id)
+    check(model.items[2].id == message0_fetchMoreMessages.id)
+    check(model.items[3].id == message0_chatIdentifier.id)
+
+suite "simulations":
+  setup:
+    let model = newModel()
+    model.appendItem(message0_fetchMoreMessages)
+    model.appendItem(message0_chatIdentifier)
+
+  test "simulate messages loading":
+    # load first two messages
+    var loadedMessages: seq[Item]
+    loadedMessages.add(message5)
+    loadedMessages.add(message4)
+    model.removeItem(message0_fetchMoreMessages.id)
+    model.removeItem(message0_chatIdentifier.id)
+    loadedMessages.add(message0_fetchMoreMessages)
+    loadedMessages.add(message0_chatIdentifier)
+    model.appendItems(loadedMessages)
+
+    require(model.items.len == 4)
+    check(model.items[0].id == message5.id)
+    check(model.items[1].id == message4.id)
+    check(model.items[2].id == message0_fetchMoreMessages.id)
+    check(model.items[3].id == message0_chatIdentifier.id)
+
+    # set new messages marker
+    model.setFirstUnseenMessageId(message5.id)
+    model.resetNewMessagesMarker()
+
+    require(model.items.len == 5)
+    check(model.items[0].id == message5.id)
+    check(model.items[1].contentType == ContentType.NewMessagesMarker)
+    check(model.items[2].id == message4.id)
+    check(model.items[3].id == message0_fetchMoreMessages.id)
+    check(model.items[4].id == message0_chatIdentifier.id)
+
+    # load next two messages
+    loadedMessages = @[]
+    loadedMessages.add(message3)
+    loadedMessages.add(message2)
+    model.removeItem(message0_fetchMoreMessages.id)
+    model.removeItem(message0_chatIdentifier.id)
+    loadedMessages.add(message0_fetchMoreMessages)
+    loadedMessages.add(message0_chatIdentifier)
+    model.appendItems(loadedMessages)
+
+    require(model.items.len == 7)
+    check(model.items[0].id == message5.id)
+    check(model.items[1].contentType == ContentType.NewMessagesMarker)
+    check(model.items[2].id == message4.id)
+    check(model.items[3].id == message3.id)
+    check(model.items[4].id == message2.id)
+    check(model.items[5].id == message0_fetchMoreMessages.id)
+    check(model.items[6].id == message0_chatIdentifier.id)
+
+    # load last message
+    loadedMessages = @[]
+    loadedMessages.add(message1)
+    model.removeItem(message0_fetchMoreMessages.id)
+    model.removeItem(message0_chatIdentifier.id)
+    loadedMessages.add(message0_fetchMoreMessages)
+    loadedMessages.add(message0_chatIdentifier)
+    model.appendItems(loadedMessages)
+
+    require(model.items.len == 8)
+    check(model.items[0].id == message5.id)
+    check(model.items[1].contentType == ContentType.NewMessagesMarker)
+    check(model.items[2].id == message4.id)
+    check(model.items[3].id == message3.id)
+    check(model.items[4].id == message2.id)
+    check(model.items[5].id == message1.id)
+    check(model.items[6].id == message0_fetchMoreMessages.id)
+    check(model.items[7].id == message0_chatIdentifier.id)
+
+  test "simulate chat identifier update":
+    model.appendItems(@[message5,
+                        message4,
+                        message3,
+                        message2,
+                        message1])
+    checkOrder(model)
+
+    # set new messages marker
+    model.setFirstUnseenMessageId(message4.id)
+    model.resetNewMessagesMarker()
+
+    # update chat identifier
+    model.removeItem(message0_chatIdentifier.id)
+    model.appendItem(message0_chatIdentifier)
+
+    require(model.items.len == 8)
+    check(model.items[0].id == message5.id)
+    check(model.items[1].id == message4.id)
+    check(model.items[2].contentType == ContentType.NewMessagesMarker)
+    check(model.items[3].id == message3.id)
+    check(model.items[4].id == message2.id)
+    check(model.items[5].id == message1.id)
+    check(model.items[6].id == message0_fetchMoreMessages.id)
+    check(model.items[7].id == message0_chatIdentifier.id)


### PR DESCRIPTION
### What does the PR do

- fixes: https://github.com/status-im/status-desktop/issues/8955

  New messages marker had a clock value of "0" before. Since all
  messages are inserted based on the clock value, new messages marker
  would cause other "0"-valued clock items to be inserted after it,
  effectively making chat header being displayed in the middle of the
  chat.
  
  Setting new messages marker clock value to the clock of the message it
  points to solves the issue.

- refactor: remove misleading APIs from message_model

**NOTE**: easier to review per commits

### Affected areas

messages ordering