### PR TITLE
feat(ActivityCenter): Update ActivityNotificationMessage's text maximum width

### DIFF
--- a/ui/app/mainui/activitycenter/views/ActivityNotificationMessage.qml
+++ b/ui/app/mainui/activitycenter/views/ActivityNotificationMessage.qml
@@ -132,7 +132,7 @@ ActivityNotificationBase {
                         elide: Text.ElideRight
                         font.pixelSize: 15
                         Layout.alignment: Qt.AlignVCenter
-                        Layout.maximumWidth: 400 // From designs, fixed value to align all possible CTAs
+                        Layout.maximumWidth: 350 // From designs, fixed value to align all possible CTAs
                     }
 
                     Loader {


### PR DESCRIPTION
Close #8915, close #8950

### What does the PR do

Limit ActivityNotificationMessage's text to 350 chars (That should be fixed value  tom make all notifications look similar)

### Affected areas

ActivityCenter

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

<img width="565" alt="Screenshot 2023-01-09 at 15 02 00" src="https://user-images.githubusercontent.com/2522130/211295720-d1b67938-6d28-4a0c-9845-b04f716c3b1c.png">
