### PR TITLE
feat(@desktop:communities): Minting module sketch with dummy data

### DIFF
--- a/src/app/modules/main/communities/minting/controller.nim
+++ b/src/app/modules/main/communities/minting/controller.nim
@@ -1,0 +1,24 @@
+import ./io_interface as minting_module_interface
+
+import ../../../../core/signals/types
+import ../../../../core/eventemitter
+
+type
+  Controller* = ref object of RootObj
+    mintingModule: minting_module_interface.AccessInterface
+    events: EventEmitter
+
+proc newMintingController*(
+    mintingModule: minting_module_interface.AccessInterface,
+    events: EventEmitter
+    ): Controller =
+  result = Controller()
+  result.mintingModule = mintingModule
+  result.events = events
+
+proc delete*(self: Controller) =
+  discard
+
+proc init*(self: Controller) =
+  discard
+

--- a/src/app/modules/main/communities/minting/io_interface.nim
+++ b/src/app/modules/main/communities/minting/io_interface.nim
@@ -1,0 +1,12 @@
+type
+  AccessInterface* {.pure inheritable.} = ref object of RootObj
+
+method delete*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method load*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method mintCollectible*(self: AccessInterface, name: string, description: string, supply: int, transferable: bool,
+                      selfDestruct: bool, network: string) {.base.} =
+  raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/communities/minting/models/token_item.nim
+++ b/src/app/modules/main/communities/minting/models/token_item.nim
@@ -1,0 +1,92 @@
+import strformat
+
+type
+  TokenType* {.pure.} = enum
+    #ERC20,
+    ERC721
+
+type
+  MintingState* {.pure.} = enum
+    InProgress,
+    Minted
+
+type
+  TokenItem* = ref object
+    tokenType: TokenType
+    tokenAddress: string
+    name: string
+    description: string
+    icon: string
+    supply: int
+    transferable: bool
+    remoteSelfDestruct: bool
+    networkId: string
+    mintingState: MintingState
+    # TODO holders
+
+proc initCollectibleTokenItem*(
+  tokenAddress: string,
+  name: string,
+  description: string,
+  icon: string,
+  supply: int,
+  transferable: bool,
+  remoteSelfDestruct: bool,
+  networkId: string,
+  mintingState: MintingState
+): TokenItem =
+  result = TokenItem()
+  result.tokenType = TokenType.ERC721
+  result.tokenAddress = description
+  result.name = name
+  result.description = description
+  result.icon = icon
+  result.supply = supply
+  result.transferable  = transferable
+  result.remoteSelfDestruct = remoteSelfDestruct
+  result.networkId = networkId
+  result.mintingState = mintingState
+
+proc `$`*(self: TokenItem): string =
+  result = fmt"""TokenItem(
+    tokenType: {$self.tokenType.int},
+    tokenAddress: {self.tokenAddress},
+    name: {self.name},
+    description: {self.description},
+    icon: {self.icon},
+    supply: {self.supply},
+    transferable: {self.transferable},
+    remoteSelfDestruct: {self.remoteSelfDestruct},
+    networkId: {self.networkId},
+    mintingState: {$self.mintingState.int}
+    ]"""
+
+proc getTokenType*(self: TokenItem): TokenType =
+  return self.tokenType
+
+proc getTokenAddress*(self: TokenItem): string =
+  return self.tokenAddress
+
+proc getName*(self: TokenItem): string =
+  return self.name
+
+proc getDescription*(self: TokenItem): string =
+  return self.description
+
+proc getIcon*(self: TokenItem): string =
+  return self.icon
+
+proc getSupply*(self: TokenItem): int =
+  return self.supply
+
+proc isTransferrable*(self: TokenItem): bool =
+  return self.transferable
+
+proc isRemoteSelfDestruct*(self: TokenItem): bool =
+  return self.remoteSelfDestruct
+
+proc getNetworkId*(self: TokenItem): string =
+  return self.networkId
+
+proc getMintingState*(self: TokenItem): MintingState =
+  return self.mintingState

--- a/src/app/modules/main/communities/minting/models/token_model.nim
+++ b/src/app/modules/main/communities/minting/models/token_model.nim
@@ -1,0 +1,92 @@
+import NimQml, Tables
+import token_item
+
+type
+  ModelRole {.pure.} = enum
+    TokenType = UserRole + 1
+    TokenAddress
+    Name
+    Description
+    Icon
+    Supply
+    Transferable
+    RemoteSelfDestruct
+    NetworkId
+    MintingState
+
+QtObject:
+  type TokenModel* = ref object of QAbstractListModel
+    items*: seq[TokenItem]
+
+  proc setup(self: TokenModel) =
+    self.QAbstractListModel.setup
+
+  proc delete(self: TokenModel) =
+    self.items = @[]
+    self.QAbstractListModel.delete
+
+  proc newTokenModel*(): TokenModel =
+    new(result, delete)
+    result.setup
+
+  proc countChanged(self: TokenModel) {.signal.}
+
+  proc setItems*(self: TokenModel, items: seq[TokenItem]) =
+    self.beginResetModel()
+    self.items = items
+    self.endResetModel()
+    self.countChanged()
+
+  proc getCount*(self: TokenModel): int {.slot.} =
+    self.items.len
+
+  QtProperty[int] count:
+    read = getCount
+    notify = countChanged
+
+  method rowCount(self: TokenModel, index: QModelIndex = nil): int =
+    return self.items.len
+
+  method roleNames(self: TokenModel): Table[int, string] =
+    {
+      ModelRole.TokenType.int:"tokenType",
+      ModelRole.TokenAddress.int:"tokenAddress",
+      ModelRole.Name.int:"name",
+      ModelRole.Description.int:"description",
+      ModelRole.Icon.int:"icon",
+      ModelRole.Supply.int:"supply",
+      ModelRole.Transferable.int:"transferable",
+      ModelRole.RemoteSelfDestruct.int:"remoteSelfDestruct",
+      ModelRole.NetworkId.int:"networkId",
+      ModelRole.MintingState.int:"mintingState",
+    }.toTable
+
+  method data(self: TokenModel, index: QModelIndex, role: int): QVariant =
+    if not index.isValid:
+      return
+    if index.row < 0 or index.row >= self.items.len:
+      return
+    let item = self.items[index.row]
+    let enumRole = role.ModelRole
+    case enumRole:
+      of ModelRole.TokenType:
+        result = newQVariant(item.getTokenType().int)
+      of ModelRole.TokenAddress:
+        result = newQVariant(item.getTokenAddress())
+      of ModelRole.Name:
+        result = newQVariant(item.getName())
+      of ModelRole.Description:
+        result = newQVariant(item.getDescription())
+      of ModelRole.Icon:
+        result = newQVariant(item.getIcon())
+      of ModelRole.Supply:
+        result = newQVariant(item.getSupply())
+      of ModelRole.Transferable:
+        result = newQVariant(item.isTransferrable())
+      of ModelRole.RemoteSelfDestruct:
+        result = newQVariant(item.isRemoteSelfDestruct())
+      of ModelRole.NetworkId:
+        result = newQVariant(item.getNetworkId())
+      of ModelRole.MintingState:
+        result = newQVariant(item.getMintingState().int)
+

--- a/src/app/modules/main/communities/minting/module.nim
+++ b/src/app/modules/main/communities/minting/module.nim
@@ -1,0 +1,52 @@
+import NimQml, json
+
+import ../../../../core/eventemitter
+import ../../../../global/global_singleton
+import ../io_interface as parent_interface
+import ./io_interface, ./view , ./controller
+import ./models/token_item
+
+export io_interface
+
+type
+  Module*  = ref object of io_interface.AccessInterface
+    parent: parent_interface.AccessInterface
+    controller: Controller
+    view: View
+    viewVariant: QVariant
+
+proc newMintingModule*(
+    parent: parent_interface.AccessInterface,
+    events: EventEmitter): Module =
+  result = Module()
+  result.parent = parent
+  result.view = newView(result)
+  result.viewVariant = newQVariant(result.view)
+  result.controller = controller.newMintingController(result, events)
+
+method delete*(self: Module) =
+  self.view.delete
+  self.viewVariant.delete
+  self.controller.delete
+
+method load*(self: Module) =
+  singletonInstance.engine.setRootContextProperty("mintingModule", self.viewVariant)
+  self.controller.init()
+  self.view.load()
+  # tested data
+  var items: seq[TokenItem] = @[]
+  let tok1 = token_item.initCollectibleTokenItem("", "Collect1", "Desc1", "", 100, true, true, "", MintingState.Minted)
+  let tok2 = token_item.initCollectibleTokenItem("", "Collect2", "Desc2", "", 200, false, false, "", MintingState.Minted)
+  items.add(tok1)
+  items.add(tok2)
+  self.view.setItems(items)
+
+method mintCollectible*(self: Module, name: string, description: string, supply: int, transferable: bool,
+                      selfDestruct: bool, network: string) =
+  echo "Minting pressed"
+  echo "Name ", name
+  echo "Desc ", description
+  echo "Supply ", supply
+  echo "Trans ", transferable
+  echo "Self-destruct ", selfDestruct
+  echo "Network ", network

--- a/src/app/modules/main/communities/minting/view.nim
+++ b/src/app/modules/main/communities/minting/view.nim
@@ -1,0 +1,43 @@
+import NimQml, json, strutils, sequtils
+
+import ./io_interface as minting_module_interface
+import models/token_model
+import models/token_item
+
+QtObject:
+  type
+    View* = ref object of QObject
+      mintingModule: minting_module_interface.AccessInterface
+      model: TokenModel
+      modelVariant: QVariant
+
+  proc load*(self: View) =
+    discard
+
+  proc delete*(self: View) =
+    self.model.delete
+    self.modelVariant.delete
+    self.QObject.delete
+
+  proc newView*(mintingModule: minting_module_interface.AccessInterface): View =
+    new(result, delete)
+    result.QObject.setup
+    result.mintingModule = mintingModule
+    result.model = newTokenModel()
+    result.modelVariant = newQVariant(result.model)
+
+  proc mintCollectible*(self: View, name: string, description: string, supply: int, transferable: bool, selfDestruct: bool, network: string) {.slot.} =
+    self.mintingModule.mintCollectible(name, description, supply, transferable, selfDestruct, network)
+
+  proc setItems*(self: View, items: seq[TokenItem]) =
+    self.model.setItems(items)
+
+  proc getModel(self: View): QVariant {.slot.} =
+    return self.modelVariant
+
+  QtProperty[QVariant] tokensModel:
+    read = getModel
+
+
+
+

--- a/src/app/modules/main/communities/module.nim
+++ b/src/app/modules/main/communities/module.nim
@@ -22,6 +22,7 @@ import ../../../../app_service/common/types
 import ../../../../app_service/service/community/service as community_service
 import ../../../../app_service/service/contacts/service as contacts_service
 import ../../../../app_service/service/chat/dto/chat
+import ./minting/module as minting_module
 
 export io_interface
 
@@ -38,6 +39,7 @@ type
     view: View
     viewVariant: QVariant
     moduleLoaded: bool
+    mintingModule: minting_module.AccessInterface
 
 # Forward declaration
 method setCommunityTags*(self: Module, communityTags: string)
@@ -59,16 +61,19 @@ proc newModule*(
     communityService,
     contactsService,
   )
+  result.mintingModule = minting_module.newMintingModule(result, events)
   result.moduleLoaded = false
 
 method delete*(self: Module) =
   self.view.delete
   self.viewVariant.delete
   self.controller.delete
+  self.mintingModule.delete
 
 method load*(self: Module) =
   singletonInstance.engine.setRootContextProperty("communitiesModule", self.viewVariant)
   self.controller.init()
+  self.mintingModule.load()
   self.view.load()
 
 method isLoaded*(self: Module): bool =

--- a/ui/app/AppLayouts/Chat/panels/communities/CommunityMintTokenPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/CommunityMintTokenPanel.qml
@@ -1,0 +1,89 @@
+import QtQuick 2.14
+import QtQuick.Layouts 1.14
+
+import StatusQ.Core 0.1
+import StatusQ.Controls 0.1
+
+Rectangle {
+    id: root
+
+    property var tokensModel
+
+    signal mintCollectible(string name, string description, int supply,
+                           bool transferable, bool selfDestruct, string network)
+
+    ColumnLayout {
+        id: layout
+        anchors.left: parent.left
+
+        spacing: Style.current.padding
+
+        StatusInput {
+            id: name
+            width: 200
+            label: qsTr("Name")
+        }
+
+        StatusInput {
+            id: description
+            width: 200
+            label: qsTr("Description")
+        }
+
+        StatusInput {
+            id: supply
+            width: 100
+            label: qsTr("Total finite supply")
+            text: "0"
+        }
+
+        StatusCheckBox {
+            id: transferable
+            text: qsTr("Transferable")
+        }
+
+        StatusCheckBox {
+            id: selfDestruct
+            text: qsTr("Remote self-destruct")
+        }
+
+        StatusComboBox {
+            id: network
+            Layout.alignment: Qt.AlignVCenter
+            Layout.maximumWidth: 200
+            label: qsTr("Select network")
+            model: ListModel {
+                ListElement {
+                    name: "Goerli"
+                }
+                ListElement {
+                    name: "Optimism Goerli"
+                }
+            }
+        }
+
+        StatusButton {
+            id: mintButton
+            text: "Mint"
+            onClicked: root.mintCollectible(name.text, description.text, parseInt(supply.text),
+                                            transferable.checked, selfDestruct.checked, network.currentValue)
+        }
+
+        StatusBaseText {
+            text: "Minted collectibles"
+        }
+
+        ListView {
+            id: collectibles
+
+            width: 200
+            height: 100
+
+            model: root.tokensModel
+
+            delegate: Text {
+                text: "name: " + name + ", descr: " + description + ", supply: " + supply
+            }
+        }
+    }
+}

--- a/ui/app/AppLayouts/Chat/panels/communities/CommunityTokensPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/CommunityTokensPanel.qml
@@ -1,0 +1,23 @@
+import QtQuick 2.14
+
+import AppLayouts.Chat.layouts 1.0
+import AppLayouts.Chat.views.communities 1.0
+import AppLayouts.Chat.stores 1.0
+
+SettingsPageLayout {
+    id: root
+
+    property var tokensModel
+
+    signal mintCollectible(string name, string description, int supply,
+                           bool transferable, bool selfDestruct, string network)
+
+    property int viewWidth: 560 // by design
+
+    CommunityMintTokenPanel {
+        anchors.fill: parent
+        tokensModel: root.tokensModel
+        onMintCollectible: root.mintCollectible(name, description, supply,
+                                                transferable, selfDestruct, network)
+    }
+}

--- a/ui/app/AppLayouts/Chat/stores/CommunitiesStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/CommunitiesStore.qml
@@ -7,6 +7,8 @@ import utils 1.0
 QtObject {
     id: root
 
+    property var mintingModuleInst: mintingModule
+
     property var permissionsModel: ListModel {} // Backend permissions list object model asignement. Please check the current expected data in qml defined in `createPermissions` method
 
     // TODO: Replace to real data, now dummy model
@@ -164,5 +166,16 @@ QtObject {
     function removePermission(index) {
         console.log("TODO: Remove permissions - backend call")
         root.permissionsModel.remove(index)
+    }
+
+    //MINTING
+
+    property var mintTokensModel: mintingModuleInst.tokensModel
+
+    function mintCollectible(name, description, supply,
+                             transferable, selfDestruct, network)
+    {
+        mintingModuleInst.mintCollectible(name, description, supply,
+                                          transferable, selfDestruct, network)
     }
 }

--- a/ui/app/AppLayouts/Chat/views/CommunitySettingsView.qml
+++ b/ui/app/AppLayouts/Chat/views/CommunitySettingsView.qml
@@ -16,6 +16,8 @@ import StatusQ.Components 0.1
 import StatusQ.Controls 0.1
 import StatusQ.Controls.Validators 0.1
 
+import AppLayouts.Chat.stores 1.0
+
 import "../panels/communities"
 import "../popups/community"
 import "../layouts"
@@ -28,7 +30,8 @@ StatusSectionLayout {
     // TODO: get this model from backend?
     property var settingsMenuModel: root.rootStore.communityPermissionsEnabled ? [{name: qsTr("Overview"), icon: "show"},
                                                                                  {name: qsTr("Members"), icon: "group-chat"},
-                                                                                 {name: qsTr("Permissions"), icon: "objects"}] :
+                                                                                 {name: qsTr("Permissions"), icon: "objects"},
+                                                                                 /*{name: qsTr("Tokens"), icon: "token"}*/] :
                                                                                    [{name: qsTr("Overview"), icon: "show"},
                                                                                  {name: qsTr("Members"), icon: "group-chat"}]
     // TODO: Next community settings options:
@@ -40,6 +43,7 @@ StatusSectionLayout {
     property var rootStore
     property var community
     property var chatCommunitySectionModule
+    property var communityStore: CommunitiesStore {}
     property bool hasAddedContacts: false
 
     readonly property string filteredSelectedTags: {
@@ -239,6 +243,14 @@ StatusSectionLayout {
             CommunityPermissionsSettingsPanel {
                 rootStore: root.rootStore
                 onPreviousPageNameChanged: root.backButtonName = previousPageName
+            }
+
+            CommunityTokensPanel {
+                tokensModel: root.communityStore.mintTokensModel
+                onMintCollectible: {
+                    root.communityStore.mintCollectible(name, description, supply,
+                                                        transferable, selfDestruct, network)
+                }
             }
 
             onCurrentIndexChanged: root.backButtonName = centerPanelContentLoader.item.children[d.currentIndex].previousPageName


### PR DESCRIPTION
Issue #8921

Preparing a simple minting module/view/controller with dummy data and some simple UI.
This pr will allow to divide a minting work to UI and backend.
UI is hidden by default.

### Screenshot of functionality (including design for comparison)

![image](https://user-images.githubusercontent.com/61889657/211313659-b71fcc39-503f-4610-979d-4e00af6f606e.png)

