### PR TITLE
feature(@desktop/keycard): sync a Keycard state on every usage

### DIFF
--- a/src/app/modules/main/io_interface.nim
+++ b/src/app/modules/main/io_interface.nim
@@ -232,6 +232,12 @@ method activateStatusDeepLink*(self: AccessInterface, statusDeepLink: string) {.
 method setCommunityIdToSpectate*(self: AccessInterface, commnityId: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method tryKeycardSync*(self: AccessInterface, keyUid: string, pin: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method onSharedKeycarModuleKeycardSyncPurposeTerminated*(self: AccessInterface, lastStepInTheCurrentFlow: bool) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 # This way (using concepts) is used only for the modules managed by AppController
 type
   DelegateInterface* = concept c

--- a/src/app/modules/main/profile_section/keycard/controller.nim
+++ b/src/app/modules/main/profile_section/keycard/controller.nim
@@ -55,19 +55,29 @@ proc init*(self: Controller) =
 
   self.events.on(SIGNAL_KEYCARD_LOCKED) do(e: Args):
     let args = KeycardActivityArgs(e)
-    self.delegate.onKeycardLocked(args.keycardUid)
+    self.delegate.onKeycardLocked(args.keyPair.keyUid, args.keyPair.keycardUid)
 
   self.events.on(SIGNAL_KEYCARD_UNLOCKED) do(e: Args):
     let args = KeycardActivityArgs(e)
-    self.delegate.onKeycardUnlocked(args.keycardUid)
+    self.delegate.onKeycardUnlocked(args.keyPair.keyUid, args.keyPair.keycardUid)
 
   self.events.on(SIGNAL_KEYCARD_NAME_CHANGED) do(e: Args):
     let args = KeycardActivityArgs(e)
-    self.delegate.onKeycardNameChanged(args.keycardUid, args.keycardNewName)
+    self.delegate.onKeycardNameChanged(args.keyPair.keycardUid, args.keyPair.keycardName)
 
   self.events.on(SIGNAL_KEYCARD_UID_UPDATED) do(e: Args):
     let args = KeycardActivityArgs(e)
-    self.delegate.onKeycardUidUpdated(args.keycardUid, args.keycardNewUid)
+    self.delegate.onKeycardUidUpdated(args.oldKeycardUid, args.keyPair.keycardUid)
+
+  self.events.on(SIGNAL_KEYCARD_ACCOUNTS_REMOVED) do(e: Args):
+    let args = KeycardActivityArgs(e)
+    if not args.success:
+      return
+    self.delegate.onKeycardAccountsRemoved(args.keyPair.keyUid, args.keyPair.keycardUid, args.keyPair.accountsAddresses)
+
+  self.events.on(SIGNAL_WALLET_ACCOUNT_UPDATED) do(e: Args):
+    let args = WalletAccountUpdated(e)
+    self.delegate.onWalletAccountUpdated(args.account)
 
 proc getAllMigratedKeyPairs*(self: Controller): seq[KeyPairDto] =
   return self.walletAccountService.getAllMigratedKeyPairs()

--- a/src/app/modules/main/profile_section/keycard/io_interface.nim
+++ b/src/app/modules/main/profile_section/keycard/io_interface.nim
@@ -1,5 +1,6 @@
 import NimQml
 from ../../../../../app_service/service/wallet_account/service import KeyPairDto
+from ../../../../../app_service/service/wallet_account/service import WalletAccountDto
 
 type
   AccessInterface* {.pure inheritable.} = ref object of RootObj
@@ -68,16 +69,22 @@ method onLoggedInUserImageChanged*(self: AccessInterface) {.base.} =
 method onNewKeycardSet*(self: AccessInterface, keyPair: KeyPairDto) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method onKeycardLocked*(self: AccessInterface, keycardUid: string) {.base.} =
+method onKeycardLocked*(self: AccessInterface, keyUid: string, keycardUid: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method onKeycardUnlocked*(self: AccessInterface, keycardUid: string) {.base.} =
+method onKeycardUnlocked*(self: AccessInterface, keyUid: string, keycardUid: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method onKeycardNameChanged*(self: AccessInterface, keycardUid: string, keycardNewName: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method onKeycardUidUpdated*(self: AccessInterface, keycardUid: string, keycardNewUid: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method onKeycardAccountsRemoved*(self: AccessInterface, keyUid: string, keycardUid: string, accountsToRemove: seq[string]) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method onWalletAccountUpdated*(self: AccessInterface, account: WalletAccountDto) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method prepareKeycardDetailsModel*(self: AccessInterface, keyUid: string) {.base.} =

--- a/src/app/modules/main/profile_section/keycard/view.nim
+++ b/src/app/modules/main/profile_section/keycard/view.nim
@@ -37,7 +37,10 @@ QtObject:
     self.delegate.viewDidLoad()
 
   proc getKeycardSharedModule(self: View): QVariant {.slot.} =
-    return self.delegate.getKeycardSharedModule()
+    let module = self.delegate.getKeycardSharedModule()
+    if not module.isNil:
+      return module
+    return newQVariant()
   QtProperty[QVariant] keycardSharedModule:
     read = getKeycardSharedModule
     

--- a/src/app/modules/main/view.nim
+++ b/src/app/modules/main/view.nim
@@ -222,7 +222,10 @@ QtObject:
     self.displayUserProfile(publicKey)
 
   proc getKeycardSharedModule(self: View): QVariant {.slot.} =
-    return self.delegate.getKeycardSharedModule()
+    let module = self.delegate.getKeycardSharedModule()
+    if not module.isNil:
+      return module
+    return newQVariant()
   QtProperty[QVariant] keycardSharedModule:
     read = getKeycardSharedModule
 

--- a/src/app/modules/main/wallet_section/accounts/io_interface.nim
+++ b/src/app/modules/main/wallet_section/accounts/io_interface.nim
@@ -13,6 +13,9 @@ method load*(self: AccessInterface) {.base.} =
 method isLoaded*(self: AccessInterface): bool {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method syncKeycard*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method generateNewAccount*(self: AccessInterface, password: string, accountName: string, color: string, emoji: string, path: string, derivedFrom: string): string {.base.} =
   raise newException(ValueError, "No implementation available")
 
@@ -29,7 +32,7 @@ method addAccountsFromSeed*(self: AccessInterface, seedPhrase: string, password:
 method addWatchOnlyAccount*(self: AccessInterface, address: string, accountName: string, color: string, emoji: string): string {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method deleteAccount*(self: AccessInterface, address: string) {.base.} =
+method deleteAccount*(self: AccessInterface, keyUid: string, address: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method refreshWalletAccounts*(self: AccessInterface) {.base.} =
@@ -56,7 +59,7 @@ method validSeedPhrase*(self: AccessInterface, value: string): bool {.base.} =
 method authenticateUser*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method onUserAuthenticated*(self: AccessInterface, password: string) {.base.} =
+method onUserAuthenticated*(self: AccessInterface, pin: string, password: string, keyUid: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method authenticateUserAndDeriveAddressOnKeycardForPath*(self: AccessInterface, keyUid: string, derivationPath: string) {.base.} =
@@ -73,4 +76,7 @@ method onUserAuthenticatedAndWalletAddressGenerated*(self: AccessInterface, addr
   raise newException(ValueError, "No implementation available")
 
 method addressDetailsFetched*(self: AccessInterface, derivedAddress: DerivedAddressDto, error: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method onSharedKeycarModuleFlowTerminated*(self: AccessInterface, lastStepInTheCurrentFlow: bool) {.base.} =
   raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/wallet_section/accounts/view.nim
+++ b/src/app/modules/main/wallet_section/accounts/view.nim
@@ -222,8 +222,8 @@ QtObject:
   proc addWatchOnlyAccount*(self: View, address: string, accountName: string, color: string, emoji: string): string {.slot.} =
     return self.delegate.addWatchOnlyAccount(address, accountName, color, emoji)
 
-  proc deleteAccount*(self: View, address: string) {.slot.} =
-    self.delegate.deleteAccount(address)
+  proc deleteAccount*(self: View, keyUid: string, address: string) {.slot.} =
+    self.delegate.deleteAccount(keyUid, address)
 
   proc getAccountNameByAddress*(self: View, address: string): string {.slot.} =
     return self.model.getAccountNameByAddress(address)

--- a/src/app/modules/main/wallet_section/current_account/view.nim
+++ b/src/app/modules/main/wallet_section/current_account/view.nim
@@ -18,6 +18,7 @@ QtObject:
       delegate: io_interface.AccessInterface
       defaultAccount: account_item.Item
       name: string
+      keyUid: string
       address: string
       mixedcaseAddress: string
       path: string
@@ -56,6 +57,13 @@ QtObject:
   QtProperty[QVariant] name:
     read = getName
     notify = nameChanged
+
+  proc getKeyUid(self: View): QVariant {.slot.} =
+    return newQVariant(self.keyUid)
+  proc keyUidChanged(self: View) {.signal.}
+  QtProperty[QVariant] keyUid:
+    read = getKeyUid
+    notify = keyUidChanged
 
   proc getAddress(self: View): QVariant {.slot.} =
     return newQVariant(self.address)
@@ -182,6 +190,9 @@ QtObject:
     if(self.name != item.getName()):
       self.name = item.getName()
       self.nameChanged()
+    if(self.keyUid != item.getKeyUid()):
+      self.keyUid = item.getKeyUid()
+      self.keyUidChanged()
     if(self.address != item.getAddress()):
       self.address = item.getAddress()
       self.addressChanged()

--- a/src/app/modules/shared_modules/keycard_popup/internal/keycard_empty_metadata_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/keycard_empty_metadata_state.nim
@@ -14,13 +14,15 @@ method executeCancelCommand*(self: KeycardEmptyMetadataState, controller: Contro
     self.flowType == FlowType.SetupNewKeycardNewSeedPhrase or
     self.flowType == FlowType.SetupNewKeycardOldSeedPhrase or
     self.flowType == FlowType.ImportFromKeycard or
+    self.flowType == FlowType.UnlockKeycard or
     self.flowType == FlowType.DisplayKeycardContent or
     self.flowType == FlowType.RenameKeycard or
     self.flowType == FlowType.CreateCopyOfAKeycard:
       controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)
 
 method executePrePrimaryStateCommand*(self: KeycardEmptyMetadataState, controller: Controller) =
-  if self.flowType == FlowType.DisplayKeycardContent or
+  if self.flowType == FlowType.UnlockKeycard or 
+    self.flowType == FlowType.DisplayKeycardContent or
     self.flowType == FlowType.ImportFromKeycard or
     self.flowType == FlowType.RenameKeycard:
       controller.terminateCurrentFlow(lastStepInTheCurrentFlow = true)

--- a/src/app/modules/shared_modules/keycard_popup/internal/renaming_keycard_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/renaming_keycard_state.nim
@@ -15,7 +15,7 @@ method executePrePrimaryStateCommand*(self: RenamingKeycardState, controller: Co
     let md = controller.getMetadataFromKeycard()
     let paths = md.walletAccounts.map(a => a.path)
     let name = controller.getKeyPairForProcessing().getName()
-    self.success = controller.updateKeycardName(controller.getKeycardUid(), name)
+    self.success = controller.updateKeycardName(controller.getKeyPairForProcessing().getKeyUid(), controller.getKeycardUid(), name)
     if self.success:
       controller.runStoreMetadataFlow(name, controller.getPin(), paths)
     else:

--- a/src/app/modules/shared_modules/keycard_popup/internal/repeat_pin_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/repeat_pin_state.nim
@@ -75,7 +75,7 @@ method resolveKeycardNextState*(self: RepeatPinState, keycardFlowType: string, k
           return createState(StateType.MaxPukRetriesReached, self.flowType, nil)
       if keycardFlowType == ResponseTypeValueKeycardFlowResult:
         controller.setPukValid(true)
-        controller.updateKeycardUid(keycardEvent.instanceUID)
+        controller.updateKeycardUid(keycardEvent.keyUid, keycardEvent.instanceUID)
         return createState(StateType.PinSet, self.flowType, nil)
     if controller.getCurrentKeycardServiceFlow() == KCSFlowType.LoadAccount:
       if keycardFlowType == ResponseTypeValueKeycardFlowResult:
@@ -89,5 +89,5 @@ method resolveKeycardNextState*(self: RepeatPinState, keycardFlowType: string, k
     if controller.getCurrentKeycardServiceFlow() == KCSFlowType.StoreMetadata:
       if keycardFlowType == ResponseTypeValueKeycardFlowResult and
         keycardEvent.instanceUID.len > 0:
-          controller.updateKeycardUid(keycardEvent.instanceUID)
+          controller.updateKeycardUid(keycardEvent.keyUid, keycardEvent.instanceUID)
           return createState(StateType.PinSet, self.flowType, nil)    

--- a/src/app/modules/shared_modules/keycard_popup/internal/state_factory_state_implementation.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/state_factory_state_implementation.nim
@@ -307,6 +307,8 @@ proc ensureReaderAndCardPresenceAndResolveNextState*(state: State, keycardFlowTy
         keycardEvent.error.len > 0:
           if keycardEvent.error == ErrorNoKeys:
             return createState(StateType.KeycardEmpty, state.flowType, nil)
+          if keycardEvent.error == ErrorNoData:
+            return createState(StateType.KeycardEmptyMetadata, state.flowType, nil)
 
   if state.flowType == FlowType.DisplayKeycardContent:
     controller.setKeyPairForProcessing(newKeyPairItem(keyUid = keycardEvent.keyUid)) # must set keypair in case of running some other flow which needs e.g. keyuid. like unlock flow

--- a/src/app/modules/shared_modules/keycard_popup/internal/wrong_puk_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/wrong_puk_state.nim
@@ -38,5 +38,5 @@ method resolveKeycardNextState*(self: WrongPukState, keycardFlowType: string, ke
     if keycardFlowType == ResponseTypeValueKeycardFlowResult:
       if keycardEvent.error.len == 0:
         controller.setPukValid(true)
-        controller.updateKeycardUid(keycardEvent.instanceUID)
+        controller.updateKeycardUid(keycardEvent.keyUid, keycardEvent.instanceUID)
         return createState(StateType.UnlockKeycardSuccess, self.flowType, nil)

--- a/src/app/modules/shared_modules/keycard_popup/internal/wrong_seed_phrase_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/wrong_seed_phrase_state.nim
@@ -15,31 +15,30 @@ proc delete*(self: WrongSeedPhraseState) =
 method executePrePrimaryStateCommand*(self: WrongSeedPhraseState, controller: Controller) =
   if self.flowType == FlowType.SetupNewKeycard:
     controller.setKeycardData(updatePredefinedKeycardData(controller.getKeycardData(), PredefinedKeycardData.WrongSeedPhrase, add = false))
-    sleep(500) # just to shortly remove text on the UI side
     self.verifiedSeedPhrase = controller.validSeedPhrase(controller.getSeedPhrase()) and
       controller.getKeyUidForSeedPhrase(controller.getSeedPhrase()) == controller.getSelectedKeyPairDto().keyUid
     if self.verifiedSeedPhrase:
       controller.storeSeedPhraseToKeycard(controller.getSeedPhraseLength(), controller.getSeedPhrase())
-    else:
-      controller.setKeycardData(updatePredefinedKeycardData(controller.getKeycardData(), PredefinedKeycardData.WrongSeedPhrase, add = true))
   if self.flowType == FlowType.CreateCopyOfAKeycard:
     controller.setKeycardData(updatePredefinedKeycardData(controller.getKeycardData(), PredefinedKeycardData.WrongSeedPhrase, add = false))
-    sleep(500) # just to shortly remove text on the UI side
     self.verifiedSeedPhrase = controller.validSeedPhrase(controller.getSeedPhrase()) and
       controller.getKeyUidForSeedPhrase(controller.getSeedPhrase()) == controller.getKeyPairForProcessing().getKeyUid()
     if self.verifiedSeedPhrase:
       controller.storeSeedPhraseToKeycard(controller.getSeedPhraseLength(), controller.getSeedPhrase())
-    else:
-      controller.setKeycardData(updatePredefinedKeycardData(controller.getKeycardData(), PredefinedKeycardData.WrongSeedPhrase, add = true))
   if self.flowType == FlowType.UnlockKeycard:
     controller.setKeycardData(updatePredefinedKeycardData(controller.getKeycardData(), PredefinedKeycardData.WrongSeedPhrase, add = false))
-    sleep(500) # just to shortly remove text on the UI side
     self.verifiedSeedPhrase = controller.validSeedPhrase(controller.getSeedPhrase()) and
       controller.getKeyUidForSeedPhrase(controller.getSeedPhrase()) == controller.getKeyPairForProcessing().getKeyUid()
     if self.verifiedSeedPhrase:
       controller.runGetMetadataFlow()
-    else:
-      controller.setKeycardData(updatePredefinedKeycardData(controller.getKeycardData(), PredefinedKeycardData.WrongSeedPhrase, add = true))
+
+method getNextPrimaryState*(self: WrongSeedPhraseState, controller: Controller): State =
+  if self.flowType == FlowType.SetupNewKeycard or
+    self.flowType == FlowType.CreateCopyOfAKeycard or
+    self.flowType == FlowType.UnlockKeycard:
+      if not self.verifiedSeedPhrase:
+        controller.setKeycardData(updatePredefinedKeycardData(controller.getKeycardData(), PredefinedKeycardData.WrongSeedPhrase, add = true))
+        return self
 
 method executeCancelCommand*(self: WrongSeedPhraseState, controller: Controller) =
   if self.flowType == FlowType.SetupNewKeycard or

--- a/src/app/modules/shared_modules/keycard_popup/io_interface.nim
+++ b/src/app/modules/shared_modules/keycard_popup/io_interface.nim
@@ -9,6 +9,8 @@ const SIGNAL_SHARED_KEYCARD_MODULE_DISPLAY_POPUP* = "sharedKeycarModuleDisplayPo
 const SIGNAL_SHARED_KEYCARD_MODULE_FLOW_TERMINATED* = "sharedKeycarModuleFlowTerminated"
 const SIGNAL_SHARED_KEYCARD_MODULE_AUTHENTICATE_USER* = "sharedKeycarModuleAuthenticateUser"
 const SIGNAL_SHARED_KEYCARD_MODULE_USER_AUTHENTICATED* = "sharedKeycarModuleUserAuthenticated"
+const SIGNAL_SHARED_KEYCARD_MODULE_TRY_KEYCARD_SYNC* = "sharedKeycarModuleTryKeycardSync"
+const SIGNAL_SHARED_KEYCARD_MODULE_KEYCARD_SYNC_TERMINATED* = "sharedKeycarModuleKeycardSyncTerminated"
 
 ## Authentication in the app is a global thing and may be used from any part of the app. How to achieve that... it's enough just to send 
 ## `SIGNAL_SHARED_KEYCARD_MODULE_AUTHENTICATE_USER` signal with properly set `SharedKeycarModuleAuthenticationArgs` and props there:
@@ -45,6 +47,14 @@ type
   SharedKeycarModuleAuthenticationArgs* = ref object of SharedKeycarModuleBaseArgs
     keyUid*: string
 
+type
+  SharedKeycarModuleUserAuthenticatedAndWalletAddressGeneratedArgs* = ref object of Args
+    uniqueIdentifier*: string
+    address*: string
+    publicKey*: string
+    derivedFrom*: string
+    password*: string
+
 type FlowType* {.pure.} = enum
   General = "General"
   FactoryReset = "FactoryReset"
@@ -62,13 +72,17 @@ type FlowType* {.pure.} = enum
   AuthenticateAndDeriveAccountAddress = "AuthenticateAndDeriveAccountAddress"
   CreateCopyOfAKeycard = "CreateCopyOfAKeycard"
 
-type
-  SharedKeycarModuleUserAuthenticatedAndWalletAddressGeneratedArgs* = ref object of Args
-    uniqueIdentifier*: string
-    address*: string
-    publicKey*: string
-    derivedFrom*: string
-    password*: string
+# For the following flows we don't run card syncing.
+const FlowsWeShouldNotTryAKeycardSyncFor* = @[
+  FlowType.General, 
+  FlowType.FactoryReset,
+  FlowType.SetupNewKeycard, 
+  FlowType.SetupNewKeycardNewSeedPhrase,
+  FlowType.SetupNewKeycardOldSeedPhrase, 
+  FlowType.ImportFromKeycard, 
+  FlowType.Authentication,
+  FlowType.AuthenticateAndDeriveAccountAddress
+]
 
 type
   AccessInterface* {.pure inheritable.} = ref object of RootObj
@@ -77,6 +91,9 @@ method delete*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method getModuleAsVariant*(self: AccessInterface): QVariant {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method getCurrentFlowType*(self: AccessInterface): FlowType {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method getKeycardData*(self: AccessInterface): string {.base.} =
@@ -176,6 +193,12 @@ method keychainObtainedDataFailure*(self: AccessInterface, errorDescription: str
   raise newException(ValueError, "No implementation available")
 
 method keychainObtainedDataSuccess*(self: AccessInterface, data: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method syncKeycardBasedOnAppState*(self: AccessInterface, keyUid: string, pin: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method getPin*(self: AccessInterface): string {.base.} =
   raise newException(ValueError, "No implementation available")
 
 type

--- a/src/app/modules/shared_modules/keycard_popup/models/key_pair_account_model.nim
+++ b/src/app/modules/shared_modules/keycard_popup/models/key_pair_account_model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, strformat
+import NimQml, Tables, strformat, strutils
 import key_pair_account_item
 
 export key_pair_account_item
@@ -72,6 +72,12 @@ QtObject:
     self.endInsertRows()
     self.countChanged()
 
+  proc containsAccountAddress*(self: KeyPairAccountModel, address: string): bool =
+    for it in self.items:
+      if cmpIgnoreCase(it.getAddress(), address) == 0:
+        return true
+    return false
+
   proc getItemAtIndex*(self: KeyPairAccountModel, index: int): KeyPairAccountItem =
     if index < 0 or index >= self.items.len:
       return newKeyPairAccountItem()
@@ -86,3 +92,20 @@ QtObject:
     self.items.delete(index)
     self.endRemoveRows()
     self.countChanged()
+
+  proc removeItemByAddress*(self: KeyPairAccountModel, address: string) =
+    for i in 0 ..< self.items.len:
+      if cmpIgnoreCase(self.items[i].getAddress(), address) == 0:
+        self.removeItemAtIndex(i)
+        return
+
+  proc updateDetailsForAddressIfTheyAreSet*(self: KeyPairAccountModel, address, name, color, emoji: string) =
+    for i in 0 ..< self.items.len:
+      if cmpIgnoreCase(self.items[i].getAddress(), address) == 0:
+        if name.len > 0:
+          self.items[i].setName(name)
+        if color.len > 0:
+          self.items[i].setColor(color)
+        if emoji.len > 0:
+          self.items[i].setEmoji(emoji)
+        return

--- a/src/app/modules/shared_modules/keycard_popup/models/key_pair_item.nim
+++ b/src/app/modules/shared_modules/keycard_popup/models/key_pair_item.nim
@@ -181,12 +181,19 @@ QtObject:
   proc removeAccountAtIndex*(self: KeyPairItem, index: int) {.slot.} =
     self.accounts.removeItemAtIndex(index)
     self.setLastAccountAsObservedAccount()
+  proc removeAccountByAddress*(self: KeyPairItem, address: string) {.slot.} =
+    self.accounts.removeItemByAddress(address)
+    self.setLastAccountAsObservedAccount()
   proc addAccount*(self: KeyPairItem, item: KeyPairAccountItem) =
     self.accounts.addItem(item)
     self.setLastAccountAsObservedAccount()
   proc setAccounts*(self: KeyPairItem, items: seq[KeyPairAccountItem]) =
     self.accounts.setItems(items)
     self.setLastAccountAsObservedAccount()
+  proc containsAccountAddress*(self: KeyPairItem, address: string): bool =
+    return self.accounts.containsAccountAddress(address)
+  proc updateDetailsForAccountWithAddressIfTheyAreSet*(self: KeyPairItem, address, name, color, emoji: string) =
+    self.accounts.updateDetailsForAddressIfTheyAreSet(address, name, color, emoji)
 
   proc setItem*(self: KeyPairItem, item: KeyPairItem) =
     self.setKeyUid(item.getKeyUid())

--- a/src/app/modules/shared_modules/keycard_popup/view.nim
+++ b/src/app/modules/shared_modules/keycard_popup/view.nim
@@ -7,6 +7,7 @@ QtObject:
   type
     View* = ref object of QObject
       delegate: io_interface.AccessInterface
+      disablePopup: bool # used to disable popup after each action, to block users do multiple clikcs which the action is ongoing
       currentState: StateWrapper
       currentStateVariant: QVariant
       keyPairModel: KeyPairModel
@@ -43,16 +44,28 @@ QtObject:
     result.currentState = newStateWrapper()
     result.currentStateVariant = newQVariant(result.currentState)
     result.remainingAttempts = -1
+    result.disablePopup = false
 
     signalConnect(result.currentState, "backActionClicked()", result, "onBackActionClicked()", 2)
     signalConnect(result.currentState, "cancelActionClicked()", result, "onCancelActionClicked()", 2)
     signalConnect(result.currentState, "primaryActionClicked()", result, "onPrimaryActionClicked()", 2)
     signalConnect(result.currentState, "secondaryActionClicked()", result, "onSecondaryActionClicked()", 2)
 
+  proc diablePopupChanged*(self: View) {.signal.}
+  proc getDisablePopup*(self: View): bool {.slot.} =
+    return self.disablePopup
+  QtProperty[bool] disablePopup:
+    read = getDisablePopup
+    notify = diablePopupChanged
+  proc setDisablePopup*(self: View, value: bool) =
+    self.disablePopup = value
+    self.diablePopupChanged()
+
   proc currentStateObj*(self: View): State =
     return self.currentState.getStateObj()
 
   proc setCurrentState*(self: View, state: State) =
+    self.setDisablePopup(false)
     self.currentState.setStateObj(state)
   proc getCurrentState(self: View): QVariant {.slot.} =
     return self.currentStateVariant

--- a/src/app/modules/startup/controller.nim
+++ b/src/app/modules/startup/controller.nim
@@ -17,8 +17,6 @@ import ../shared_modules/keycard_popup/io_interface as keycard_shared_module
 logScope:
   topics = "startup-controller"
 
-const UNIQUE_STARTUP_MODULE_IDENTIFIER* = "SartupModule"
-
 type ProfileImageDetails = object
   url*: string
   croppedImage*: string

--- a/src/app/modules/startup/io_interface.nim
+++ b/src/app/modules/startup/io_interface.nim
@@ -3,6 +3,7 @@ import ../../../app_service/service/accounts/service as accounts_service
 import models/login_account_item as login_acc_item
 from ../../../app_service/service/keycard/service import KeycardEvent, KeyDetails
 
+const UNIQUE_STARTUP_MODULE_IDENTIFIER* = "SartupModule"
 
 type
   AccessInterface* {.pure inheritable.} = ref object of RootObj

--- a/src/app/modules/startup/module.nim
+++ b/src/app/modules/startup/module.nim
@@ -111,16 +111,17 @@ method load*[T](self: Module[T]) =
     self.setSelectedLoginAccount(items[0])
   self.delegate.startupDidLoad()
 
+proc isSharedKeycardModuleFlowRunning[T](self: Module[T]): bool =
+  return not self.keycardSharedModule.isNil
+
 method getKeycardSharedModule*[T](self: Module[T]): QVariant =
-  return self.keycardSharedModule.getModuleAsVariant()
+  if self.isSharedKeycardModuleFlowRunning():
+    return self.keycardSharedModule.getModuleAsVariant()
 
 proc createSharedKeycardModule[T](self: Module[T]) =
   self.keycardSharedModule = keycard_shared_module.newModule[Module[T]](self, UNIQUE_STARTUP_MODULE_IDENTIFIER, 
     self.events, self.keycardService, settingsService = nil, privacyService = nil, self.accountsService, 
     walletAccountService = nil, self.keychainService)
-
-proc isSharedKeycardModuleFlowRunning[T](self: Module[T]): bool =
-  return not self.keycardSharedModule.isNil
 
 method moveToLoadingAppState*[T](self: Module[T]) =
   self.view.setAppState(AppState.AppLoadingState)

--- a/src/app/modules/startup/view.nim
+++ b/src/app/modules/startup/view.nim
@@ -82,7 +82,10 @@ QtObject:
     read = getCurrentStartupState
 
   proc getKeycardSharedModule(self: View): QVariant {.slot.} =
-    return self.delegate.getKeycardSharedModule()
+    let module = self.delegate.getKeycardSharedModule()
+    if not module.isNil:
+      return module
+    return newQVariant()
   QtProperty[QVariant] keycardSharedModule:
     read = getKeycardSharedModule
 

--- a/src/app_service/common/utils.nim
+++ b/src/app_service/common/utils.nim
@@ -1,9 +1,12 @@
-import json, random, times, strutils, os, re, chronicles
+import json, random, times, strutils, sugar, os, re, chronicles
 import nimcrypto
 import signing_phrases
 
 const STATUS_DOMAIN* = ".stateofus.eth"
 const ETH_DOMAIN* = ".eth"
+
+proc arrayContains*[T](arr: seq[T], value: T): bool = 
+  return arr.any(x => x == value)
 
 proc hashPassword*(password: string): string =
   result = "0x" & $keccak_256.digest(password)

--- a/src/app_service/service/keycard/service.nim
+++ b/src/app_service/service/keycard/service.nim
@@ -219,12 +219,14 @@ QtObject:
     self.currentFlow = KCSFlowType.GetAppInfo
     self.startFlow(payload)
 
-  proc startGetMetadataFlow*(self: Service, resolveAddress: bool, exportMasterAddr = false) =
+  proc startGetMetadataFlow*(self: Service, resolveAddress: bool, exportMasterAddr = false, pin = "") =
     var payload = %* { }
     if resolveAddress:
       payload[RequestParamResolveAddr] = %* resolveAddress
     if exportMasterAddr:
       payload[RequestParamExportMasterAddress] = %* exportMasterAddr
+    if pin.len > 0:
+      payload[RequestParamPIN] = %* pin
     self.currentFlow = KCSFlowType.GetMetadata
     self.startFlow(payload)
 

--- a/src/app_service/service/wallet_account/async_tasks.nim
+++ b/src/app_service/service/wallet_account/async_tasks.nim
@@ -122,7 +122,37 @@ const addMigratedKeyPairTask*: Task = proc(argEncoded: string) {.gcsafe, nimcall
       arg.keyPair.accountsAddresses,
       arg.keyStoreDir
       )
-    arg.finish(response)
+    let success = responseHasNoErrors("addMigratedKeyPair", response)
+    let responseJson = %*{
+      "success": success,
+      "keyPair": arg.keyPair.toJsonNode()
+    }
+    arg.finish(responseJson)
   except Exception as e:
     error "error adding new keypair: ", message = e.msg  
+    arg.finish("")
+
+#################################################
+# Async add migrated keypair
+#################################################
+
+type
+  RemoveMigratedAccountsForKeycardTaskArg* = ref object of QObjectTaskArg
+    keyPair: KeyPairDto
+
+const removeMigratedAccountsForKeycardTask*: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+  let arg = decode[RemoveMigratedAccountsForKeycardTaskArg](argEncoded)
+  try:
+    let response = backend.removeMigratedAccountsForKeycard(
+      arg.keyPair.keycardUid,
+      arg.keyPair.accountsAddresses
+      )
+    let success = responseHasNoErrors("removeMigratedAccountsForKeycard", response)
+    let responseJson = %*{
+      "success": success,
+      "keyPair": arg.keyPair.toJsonNode()
+    }
+    arg.finish(responseJson)
+  except Exception as e:
+    error "error remove accounts from keycard: ", message = e.msg  
     arg.finish("")

--- a/src/app_service/service/wallet_account/key_pair_dto.nim
+++ b/src/app_service/service/wallet_account/key_pair_dto.nim
@@ -2,6 +2,13 @@ import json
 
 include  ../../common/json_utils
 
+const KeycardUid = "keycard-uid"
+const KeycardName = "keycard-name"
+const KeycardLocked = "keycard-locked"
+const KeyUid = "key-uid"
+const AccountAddresses = "accounts-addresses"
+
+
 type KeyPairDto* = object
   keycardUid*: string
   keycardName*: string
@@ -11,12 +18,21 @@ type KeyPairDto* = object
 
 proc toKeyPairDto*(jsonObj: JsonNode): KeyPairDto =
   result = KeyPairDto()
-  discard jsonObj.getProp("keycard-uid", result.keycardUid)
-  discard jsonObj.getProp("keycard-name", result.keycardName)
-  discard jsonObj.getProp("keycard-locked", result.keycardLocked)
-  discard jsonObj.getProp("key-uid", result.keyUid)
+  discard jsonObj.getProp(KeycardUid, result.keycardUid)
+  discard jsonObj.getProp(KeycardName, result.keycardName)
+  discard jsonObj.getProp(KeycardLocked, result.keycardLocked)
+  discard jsonObj.getProp(KeyUid, result.keyUid)
   
   var jArr: JsonNode
-  if(jsonObj.getProp("accounts-addresses", jArr) and jArr.kind == JArray):
+  if(jsonObj.getProp(AccountAddresses, jArr) and jArr.kind == JArray):
     for addrObj in jArr:
       result.accountsAddresses.add(addrObj.getStr)
+
+proc toJsonNode*(self: KeyPairDto): JsonNode =
+  result = %* {
+    KeycardUid: self.keycardUid,
+    KeycardName: self.keycardName,
+    KeycardLocked: self.keycardLocked,
+    KeyUid: self.keyUid,
+    AccountAddresses: self.accountsAddresses
+  }

--- a/src/backend/accounts.nim
+++ b/src/backend/accounts.nim
@@ -24,6 +24,9 @@ proc getAccounts*(): RpcResponse[JsonNode] {.raises: [Exception].} =
 proc deleteAccount*(address: string): RpcResponse[JsonNode] {.raises: [Exception].} =
   return core.callPrivateRPC("accounts_deleteAccount", %* [address])
 
+proc deleteAccountForMigratedKeypair*(address: string): RpcResponse[JsonNode] {.raises: [Exception].} =
+  return core.callPrivateRPC("accounts_deleteAccountForMigratedKeypair", %* [address])
+
 proc saveAccount*(name, address, path, addressAccountIsDerivedFrom, publicKey, keyUid, accountType, color, emoji: string,
   walletDefaultAccount: bool, chatDefaultAccount: bool): 
   RpcResponse[JsonNode] {.raises: [Exception].} =
@@ -43,19 +46,6 @@ proc saveAccount*(name, address, path, addressAccountIsDerivedFrom, publicKey, k
     }]
   ]
   return core.callPrivateRPC("accounts_saveAccounts", payload)
-
-proc updateAccount*(name, address, publicKey, walletType, color, emoji: string) {.raises: [Exception].} =
-  discard core.callPrivateRPC("accounts_saveAccounts", %* [
-    [{
-      "emoji": emoji,
-      "color": color,
-      "name": name,
-      "address": address,
-      "public-key": publicKey,
-      "type": walletType,
-      "path": "m/44'/60'/0'/0/1" # <--- TODO: fix this. Derivation path is not supposed to change
-    }]
-  ])
 
 proc generateAddresses*(paths: seq[string]): RpcResponse[JsonNode] {.raises: [Exception].} =
   let payload = %* {

--- a/src/backend/backend.nim
+++ b/src/backend/backend.nim
@@ -231,6 +231,10 @@ rpc(addMigratedKeyPair, "accounts"):
   accountAddresses: seq[string]
   keyStoreDir: string
 
+rpc(removeMigratedAccountsForKeycard, "accounts"):
+  keycardUid: string
+  accountsToRemove: seq[string]
+
 rpc(getAllKnownKeycards, "accounts"):
   discard
 

--- a/ui/app/AppLayouts/Profile/stores/WalletStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/WalletStore.qml
@@ -30,8 +30,8 @@ QtObject {
         walletSection.switchAccountByAddress(address)
     }
 
-    function deleteAccount(address) {
-        return walletSectionAccounts.deleteAccount(address)
+    function deleteAccount(keyUid, address) {
+        return walletSectionAccounts.deleteAccount(keyUid, address)
     }
 
     function updateCurrentAccount(address, accountName, color, emoji) {

--- a/ui/app/AppLayouts/Profile/views/wallet/AccountView.qml
+++ b/ui/app/AppLayouts/Profile/views/wallet/AccountView.qml
@@ -157,7 +157,7 @@ Item {
                 onConfirmButtonClicked: {
                     confirmationPopup.close();
                     root.goBack();
-                    root.walletStore.deleteAccount(walletStore.currentAccount.address);
+                    root.walletStore.deleteAccount(walletStore.currentAccount.keyUid, walletStore.currentAccount.address);
                 }
 
             }

--- a/ui/app/AppLayouts/Wallet/panels/DerivationPathsPanel.qml
+++ b/ui/app/AppLayouts/Wallet/panels/DerivationPathsPanel.qml
@@ -30,7 +30,7 @@ ColumnLayout {
         }
         property bool pathError: Utils.isInvalidPath(RootStore.derivedAddressesError)
         property bool derivationAddressLoading: RootStore.derivedAddressesLoading
-        property string defaultDerivationPath: "m/44'/60'/0'/0"
+        property string defaultDerivationPath: "m/44'/60'/0'/0/0"
     }
 
     spacing: 7

--- a/ui/imports/shared/popups/keycard/KeycardPopupDetails.qml
+++ b/ui/imports/shared/popups/keycard/KeycardPopupDetails.qml
@@ -11,7 +11,15 @@ QtObject {
     property var sharedKeycardModule
 
     property bool primaryButtonEnabled: false
-    readonly property bool disablePopupClose: {
+
+    // disables action buttons (back, cancel, primary, secondary) and close button (upper right "X" button) as well
+    readonly property bool disableActionPopupButtons: root.sharedKeycardModule.disablePopup
+
+    readonly property bool disablePopupClose: { // disables popup close button (upper right "X" button)
+        if (root.disableActionPopupButtons) {
+            return true
+        }
+
         switch (root.sharedKeycardModule.currentState.stateType) {
 
         case Constants.keycardSharedState.readingKeycard:
@@ -38,6 +46,7 @@ QtObject {
         StatusBackButton {
             id: backButton
             visible: root.sharedKeycardModule.currentState.displayBackButton
+            enabled: !root.disableActionPopupButtons
             height: Constants.keycard.general.footerButtonsHeight
             width: height
             onClicked: {
@@ -347,26 +356,7 @@ QtObject {
 
                 return false
             }
-            enabled: {
-                switch (root.sharedKeycardModule.currentState.stateType) {
-
-                case Constants.keycardSharedState.readingKeycard:
-                case Constants.keycardSharedState.migratingKeyPair:
-                case Constants.keycardSharedState.creatingAccountNewSeedPhrase:
-                case Constants.keycardSharedState.creatingAccountOldSeedPhrase:
-                case Constants.keycardSharedState.importingFromKeycard:
-                case Constants.keycardSharedState.renamingKeycard:
-                case Constants.keycardSharedState.changingKeycardPin:
-                case Constants.keycardSharedState.changingKeycardPuk:
-                case Constants.keycardSharedState.changingKeycardPairingCode:
-                case Constants.keycardSharedState.copyingKeycard:
-                    if (root.disablePopupClose) {
-                        return false
-                    }
-                }
-
-                return true
-            }
+            enabled: !root.disableActionPopupButtons
 
             onClicked: {
                 root.sharedKeycardModule.currentState.doCancelAction()
@@ -462,21 +452,8 @@ QtObject {
 
             visible: text !== ""
             enabled: {
-                switch (root.sharedKeycardModule.currentState.stateType) {
-
-                case Constants.keycardSharedState.readingKeycard:
-                case Constants.keycardSharedState.migratingKeyPair:
-                case Constants.keycardSharedState.creatingAccountNewSeedPhrase:
-                case Constants.keycardSharedState.creatingAccountOldSeedPhrase:
-                case Constants.keycardSharedState.importingFromKeycard:
-                case Constants.keycardSharedState.renamingKeycard:
-                case Constants.keycardSharedState.changingKeycardPin:
-                case Constants.keycardSharedState.changingKeycardPuk:
-                case Constants.keycardSharedState.changingKeycardPairingCode:
-                case Constants.keycardSharedState.copyingKeycard:
-                    if (root.disablePopupClose) {
-                        return false
-                    }
+                if (root.disableActionPopupButtons) {
+                    return false
                 }
 
                 switch (root.sharedKeycardModule.currentState.flowType) {
@@ -784,6 +761,7 @@ QtObject {
                     switch (root.sharedKeycardModule.currentState.stateType) {
 
                     case Constants.keycardSharedState.keycardEmpty:
+                    case Constants.keycardSharedState.keycardEmptyMetadata:
                     case Constants.keycardSharedState.keycardAlreadyUnlocked:
                     case Constants.keycardSharedState.wrongKeycard:
                     case Constants.keycardSharedState.unlockKeycardSuccess:
@@ -1000,21 +978,8 @@ QtObject {
             }
             visible: text !== ""
             enabled: {
-                switch (root.sharedKeycardModule.currentState.stateType) {
-
-                case Constants.keycardSharedState.readingKeycard:
-                case Constants.keycardSharedState.migratingKeyPair:
-                case Constants.keycardSharedState.creatingAccountNewSeedPhrase:
-                case Constants.keycardSharedState.creatingAccountOldSeedPhrase:
-                case Constants.keycardSharedState.importingFromKeycard:
-                case Constants.keycardSharedState.renamingKeycard:
-                case Constants.keycardSharedState.changingKeycardPin:
-                case Constants.keycardSharedState.changingKeycardPuk:
-                case Constants.keycardSharedState.changingKeycardPairingCode:
-                case Constants.keycardSharedState.copyingKeycard:
-                    if (root.disablePopupClose) {
-                        return false
-                    }
+                if (root.disableActionPopupButtons) {
+                    return false
                 }
 
                 switch (root.sharedKeycardModule.currentState.flowType) {

--- a/ui/imports/shared/popups/keycard/states/EnterSeedPhrase.qml
+++ b/ui/imports/shared/popups/keycard/states/EnterSeedPhrase.qml
@@ -280,7 +280,7 @@ Item {
                     if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
                         event.accepted = true
                         if (d.allEntriesValid) {
-                            d.sharedKeycardModule.currentState.doPrimaryAction()
+                            root.sharedKeycardModule.currentState.doPrimaryAction()
                             return
                         }
                     }


### PR DESCRIPTION
This PR introduces a keycard syncing with the app state for a keypair which is stored on a keycard. Syncing is done when user is closing a flow if the correct pin was entered during that flow. 

For the following flows sync is not done cause it's pointless:
- FlowType.FactoryReset
- FlowType.SetupNewKeycard
- FlowType.SetupNewKeycardNewSeedPhrase
- FlowType.SetupNewKeycardOldSeedPhrase
- FlowType.ImportFromKeycard
- FlowType.Authentication

This PR also introduces a fix for 2 crashes:
- when user was deleting a wallet account which belong to a keypair which is already migrated to a keycard
- when multiple wallet accounts were added in a row (creating new keycard (new/old seed phrase) or importing a keypair from a keycard), which is fixed in separed commit of this PR

Corresponding `status-go` PR:
- https://github.com/status-im/status-go/pull/3062

Closes: #8759 
Fixes: #9065