### PR TITLE
fix(@desktop/chat): show message which was sent during group chat creation

### DIFF
--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -100,8 +100,9 @@ QtObject {
         return msg
     }
 
-    function sendMessage(event, text, replyMessageId, fileUrlsAndSources) {
-        var chatContentModule = currentChatContentModule()
+    function sendMessage(chatId, event, text, replyMessageId, fileUrlsAndSources) {
+        chatCommunitySectionModule.prepareChatContentModuleForChatId(chatId)
+        const chatContentModule = chatCommunitySectionModule.getChatContentModule()
         if (fileUrlsAndSources.length > 0){
             chatContentModule.inputAreaModule.sendImages(JSON.stringify(fileUrlsAndSources));
         }

--- a/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
@@ -90,7 +90,8 @@ Item {
         else if (root.rootStore.createChatInitMessage !== "" ||
                  root.rootStore.createChatFileUrls.length > 0) {
 
-            root.rootStore.sendMessage(Qt.Key_Enter,
+            root.rootStore.sendMessage(chatId,
+                                       Qt.Key_Enter,
                                        root.rootStore.createChatInitMessage,
                                        "",
                                        root.rootStore.createChatFileUrls

--- a/ui/app/AppLayouts/Chat/views/ChatContentView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatContentView.qml
@@ -236,7 +236,8 @@ ColumnLayout {
                         return
                     }
 
-                    if(root.rootStore.sendMessage(event,
+                    if(root.rootStore.sendMessage(chatContentModule.getMyChatId(),
+                                                  event,
                                                   chatInput.getTextWithPublicKeys(),
                                                   chatInput.isReply? chatInput.replyMessageId : "",
                                                   chatInput.fileUrlsAndSources

--- a/ui/app/AppLayouts/Chat/views/CreateChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/CreateChatView.qml
@@ -25,7 +25,7 @@ Page {
 
         function createChat() {
             root.rootStore.createChatInitMessage = chatInput.textInput.text
-            root.rootStore.createChatFileUrls = chatInput.fileUrls
+            root.rootStore.createChatFileUrls = chatInput.fileUrlsAndSources
             membersSelector.createChat()
 
             membersSelector.cleanup()


### PR DESCRIPTION
### What does the PR do

Allow sending an initial message during group chat creation.

The problem is that we send a message for the new chat during `ChatContentView` component is completed (onCompleted. slot), and at this moment new chat item is not set as Active due to View is constructing, so we send the initial message during group chat creation to the previously opened chat

Fixes: #8991 

### Affected areas

Send chat messages

### Screenshot of functionality (including design for comparison)

https://user-images.githubusercontent.com/117639195/211526529-3012765e-43f6-4b81-b603-a568be50488e.mov

