### PR TITLE
fix(Community): banners where overlapping

### DIFF
--- a/ui/app/AppLayouts/Chat/views/CommunityColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/CommunityColumnView.qml
@@ -437,12 +437,7 @@ Item {
                         (!localAccountSensitiveSettings.hiddenCommunityWelcomeBanners ||
                          !localAccountSensitiveSettings.hiddenCommunityWelcomeBanners.includes(communityData.id))
                 width: parent.width
-                height: {
-                    // I dont know why, the binding doesn't work well if this isn't here
-                    item && item.height
-                    return active ? item.height : 0
-                }
-
+                height: item.height
                 sourceComponent: Component {
                     CommunityWelcomeBannerPanel {
                         activeCommunity: communityData
@@ -459,11 +454,7 @@ Item {
                         (!localAccountSensitiveSettings.hiddenCommunityChannelAndCategoriesBanners ||
                          !localAccountSensitiveSettings.hiddenCommunityChannelAndCategoriesBanners.includes(communityData.id))
                 width: parent.width
-                height: {
-                    // I dont know why, the binding doesn't work well if this isn't here
-                    item && item.height
-                    return active ? item.height : 0
-                }
+                height: item.height
                 sourceComponent: Component {
                         CommunityChannelsAndCategoriesBannerPanel {
                             id: channelsAndCategoriesBanner
@@ -483,11 +474,7 @@ Item {
                         (!localAccountSensitiveSettings.hiddenCommunityBackUpBanners ||
                          !localAccountSensitiveSettings.hiddenCommunityBackUpBanners.includes(communityData.id))
                 width: parent.width
-                height: {
-                    // I dont know why, the binding doesn't work well if this isn't here
-                    item && item.height
-                    return active ? item.height : 0
-                }
+                height: item.height
                 sourceComponent: Component {
                         BackUpCommuntyBannerPanel {
                             id: backupBanner


### PR DESCRIPTION
Closes #8947 

### What does the PR do
Fixes Community left column banners where overlapping

### Affected areas
Community left column

### Screenshot of functionality (including design for comparison)
<img width="1004" alt="comm" src="https://user-images.githubusercontent.com/31625338/211552689-e7c1d82a-a9f0-41d3-96b3-4ab73b2f5453.png">
