### PR TITLE
fix(SQ/StatusListItemTag):  Text is not horizontally centered

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/StatusListItemTag.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusListItemTag.qml
@@ -71,7 +71,6 @@ Control {
             Layout.fillWidth: true
             color: Theme.palette.primaryColor1
             text: root.title
-            Layout.rightMargin: closeButtonVisible ? 0 : d.commonMargin
             elide: Text.ElideRight
         }
 


### PR DESCRIPTION
Fixes #8876

### What does the PR do

It removes `Layout.rightMargin` on the text component. The text is now centered horizontally even though the close button is not visible.

### Affected areas

`StatusListItemTag`

### Screenshot of functionality (including design for comparison)

<img width="586" alt="Screenshot 2023-01-10 at 13 51 42" src="https://user-images.githubusercontent.com/97019400/211557668-13fd4068-d6f2-4b10-a8b8-ea7beb4ba5b5.png">

<img width="586" alt="Screenshot 2023-01-10 at 13 50 46" src="https://user-images.githubusercontent.com/97019400/211557683-e29e167e-6b8f-4bdb-a6a0-a19fc6452828.png">
