### PR TITLE
ENS usernames depend on the network

### DIFF
--- a/src/app/boot/app_controller.nim
+++ b/src/app/boot/app_controller.nim
@@ -422,8 +422,6 @@ proc buildAndRegisterUserProfile(self: AppController) =
   let alias = self.settingsService.getName()
   var preferredName = self.settingsService.getPreferredName()
   let displayName = self.settingsService.getDisplayName()
-  let ensUsernames = self.settingsService.getEnsUsernames()
-  let firstEnsName = if (ensUsernames.len > 0): ensUsernames[0] else: ""
   let currentUserStatus = self.settingsService.getCurrentUserStatus()
 
   let loggedInAccount = self.accountsService.getLoggedInAccount()

--- a/src/app/modules/main/profile_section/ens_usernames/io_interface.nim
+++ b/src/app/modules/main/profile_section/ens_usernames/io_interface.nim
@@ -18,7 +18,7 @@ method getModuleAsVariant*(self: AccessInterface): QVariant {.base.} =
 method ensUsernameAvailabilityChecked*(self: AccessInterface, availabilityStatus: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method onDetailsForEnsUsername*(self: AccessInterface, ensUsername: string, address: string, pubkey: string,
+method onDetailsForEnsUsername*(self: AccessInterface, chainId: int, ensUsername: string, address: string, pubkey: string,
   isStatus: bool, expirationTime: int) {.base.} =
   raise newException(ValueError, "No implementation available")
 
@@ -39,23 +39,23 @@ method checkEnsUsernameAvailability*(self: AccessInterface, desiredEnsUsername: 
 method numOfPendingEnsUsernames*(self: AccessInterface): int {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method fetchDetailsForEnsUsername*(self: AccessInterface, ensUsername: string) {.base.} =
+method fetchDetailsForEnsUsername*(self: AccessInterface, chainId: int, ensUsername: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method setPubKeyGasEstimate*(self: AccessInterface, ensUsername: string, address: string): int {.base.} =
+method setPubKeyGasEstimate*(self: AccessInterface, chainId: int,  ensUsername: string, address: string): int {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method authenticateAndSetPubKey*(self: AccessInterface, ensUsername: string, address: string, gas: string, gasPrice: string,
+method authenticateAndSetPubKey*(self: AccessInterface, chainId: int, ensUsername: string, address: string, gas: string, gasPrice: string,
   maxPriorityFeePerGas: string, maxFeePerGas: string, eip1559Enabled: bool) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method removeEnsUsername*(self: AccessInterface, ensUsername: string): bool {.base.} =
+method removeEnsUsername*(self: AccessInterface, chainId: int, ensUsername: string): bool {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method releaseEnsEstimate*(self: AccessInterface, ensUsername: string, address: string): int {.base.} =
+method releaseEnsEstimate*(self: AccessInterface, chainId: int, ensUsername: string, address: string): int {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method authenticateAndReleaseEns*(self: AccessInterface, ensUsername: string, address: string, gas: string, gasPrice: string,
+method authenticateAndReleaseEns*(self: AccessInterface, chainId: int, ensUsername: string, address: string, gas: string, gasPrice: string,
   maxPriorityFeePerGas: string, maxFeePerGas: string, eip1559Enabled: bool) {.base.} =
   raise newException(ValueError, "No implementation available")
 
@@ -65,10 +65,10 @@ method connectOwnedUsername*(self: AccessInterface, ensUsername: string, isStatu
 method getEnsRegisteredAddress*(self: AccessInterface): string {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method registerEnsGasEstimate*(self: AccessInterface, ensUsername: string, address: string): int {.base.} =
+method registerEnsGasEstimate*(self: AccessInterface, chainId: int, ensUsername: string, address: string): int {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method authenticateAndRegisterEns*(self: AccessInterface, ensUsername: string, address: string, gas: string, gasPrice: string,
+method authenticateAndRegisterEns*(self: AccessInterface, chainId: int, ensUsername: string, address: string, gas: string, gasPrice: string,
   maxPriorityFeePerGas: string, maxFeePerGas: string, eip1559Enabled: bool) {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/profile_section/ens_usernames/view.nim
+++ b/src/app/modules/main/profile_section/ens_usernames/view.nim
@@ -39,6 +39,16 @@ QtObject:
     read = getModel
     notify = modelChanged
 
+  proc chainIdChanged*(self: View) {.signal.}
+  proc chainId(self: View): int {.slot.} =
+    return self.delegate.getChainIdForEns()
+  QtProperty[int] chainId:
+    read = chainId
+    notify = chainIdChanged
+
+  proc emitChainIdChanged*(self: View) =
+    self.chainIdChanged()
+
   proc getEnsRegistry(self: View): string {.slot.} =
     return ENS_REGISTRY
 
@@ -53,27 +63,27 @@ QtObject:
     return self.delegate.numOfPendingEnsUsernames()
 
   proc loading(self: View, isLoading: bool) {.signal.}
-  proc detailsObtained(self: View, ensName: string, address: string, pubkey: string, isStatus: bool, expirationTime: int) {.signal.}
+  proc detailsObtained(self: View, chainId: int, ensName: string, address: string, pubkey: string, isStatus: bool, expirationTime: int) {.signal.}
 
-  proc fetchDetailsForEnsUsername*(self: View, ensUsername: string) {.slot.} =
+  proc fetchDetailsForEnsUsername*(self: View, chainId: int, ensUsername: string) {.slot.} =
     self.loading(true)
-    self.delegate.fetchDetailsForEnsUsername(ensUsername)
+    self.delegate.fetchDetailsForEnsUsername(chainId, ensUsername)
 
-  proc setDetailsForEnsUsername*(self: View, ensUsername: string, address: string, pubkey: string, isStatus: bool,
+  proc processObtainedEnsUsermesDetails*(self: View, chainId: int, ensUsername: string, address: string, pubkey: string, isStatus: bool,
     expirationTime: int) =
     self.loading(false)
-    self.detailsObtained(ensUsername, address, pubkey, isStatus, expirationTime)
+    self.detailsObtained(chainId, ensUsername, address, pubkey, isStatus, expirationTime)
 
   proc transactionWasSent(self: View, txResult: string) {.signal.}
   proc emitTransactionWasSentSignal*(self: View, txResult: string) =
     self.transactionWasSent(txResult)
 
-  proc setPubKeyGasEstimate*(self: View, ensUsername: string, address: string): int {.slot.} =
-    return self.delegate.setPubKeyGasEstimate(ensUsername, address)
+  proc setPubKeyGasEstimate*(self: View, chainId: int, ensUsername: string, address: string): int {.slot.} =
+    return self.delegate.setPubKeyGasEstimate(chainId, ensUsername, address)
 
-  proc authenticateAndSetPubKey*(self: View, ensUsername: string, address: string, gas: string, gasPrice: string,
+  proc authenticateAndSetPubKey*(self: View, chainId: int, ensUsername: string, address: string, gas: string, gasPrice: string,
     maxPriorityFeePerGas: string, maxFeePerGas: string, eip1559Enabled: bool) {.slot.} =
-    self.delegate.authenticateAndSetPubKey(ensUsername, address, gas, gasPrice, maxPriorityFeePerGas, maxFeePerGas, eip1559Enabled)
+    self.delegate.authenticateAndSetPubKey(chainId, ensUsername, address, gas, gasPrice, maxPriorityFeePerGas, maxFeePerGas, eip1559Enabled)
 
   proc getEtherscanLink*(self: View): string {.slot.} =
     return self.etherscanLink
@@ -91,15 +101,15 @@ QtObject:
     revertReason: string) =
     self.transactionCompleted(success, txHash, username, trxType, revertReason)
 
-  proc removeEnsUsername*(self: View, ensUsername: string): bool {.slot.} =
-    return self.delegate.removeEnsUsername(ensUsername)
+  proc removeEnsUsername*(self: View, chainId: int, ensUsername: string): bool {.slot.} =
+    return self.delegate.removeEnsUsername(chainId, ensUsername)
 
-  proc releaseEnsEstimate*(self: View, ensUsername: string, address: string): int {.slot.} =
-    return self.delegate.releaseEnsEstimate(ensUsername, address)
+  proc releaseEnsEstimate*(self: View, chainId: int, ensUsername: string, address: string): int {.slot.} =
+    return self.delegate.releaseEnsEstimate(chainId, ensUsername, address)
 
-  proc authenticateAndReleaseEns*(self: View, ensUsername: string, address: string, gas: string, gasPrice: string,
+  proc authenticateAndReleaseEns*(self: View, chainId: int, ensUsername: string, address: string, gas: string, gasPrice: string,
     maxPriorityFeePerGas: string, maxFeePerGas: string, eip1559Enabled: bool) {.slot.} =
-    self.delegate.authenticateAndReleaseEns(ensUsername, address, gas, gasPrice, maxPriorityFeePerGas, maxFeePerGas, eip1559Enabled)
+    self.delegate.authenticateAndReleaseEns(chainId, ensUsername, address, gas, gasPrice, maxPriorityFeePerGas, maxFeePerGas, eip1559Enabled)
 
   proc connectOwnedUsername*(self: View, ensUsername: string, isStatus: bool) {.slot.} =
     self.delegate.connectOwnedUsername(ensUsername, isStatus)
@@ -107,12 +117,12 @@ QtObject:
   proc getEnsRegisteredAddress*(self: View): string {.slot.} =
     return self.delegate.getEnsRegisteredAddress()
 
-  proc registerEnsGasEstimate*(self: View, ensUsername: string, address: string): int {.slot.} =
-    return self.delegate.registerEnsGasEstimate(ensUsername, address)
+  proc registerEnsGasEstimate*(self: View, chainId: int, ensUsername: string, address: string): int {.slot.} =
+    return self.delegate.registerEnsGasEstimate(chainId, ensUsername, address)
 
-  proc authenticateAndRegisterEns*(self: View, ensUsername: string, address: string, gas: string, gasPrice: string,
+  proc authenticateAndRegisterEns*(self: View, chainId: int, ensUsername: string, address: string, gas: string, gasPrice: string,
     maxPriorityFeePerGas: string, maxFeePerGas: string, eip1559Enabled: bool) {.slot.} =
-    self.delegate.authenticateAndRegisterEns(ensUsername, address, gas, gasPrice, maxPriorityFeePerGas, maxFeePerGas, eip1559Enabled)
+    self.delegate.authenticateAndRegisterEns(chainId, ensUsername, address, gas, gasPrice, maxPriorityFeePerGas, maxFeePerGas, eip1559Enabled)
 
   proc getSNTBalance*(self: View): string {.slot.} =
     return self.delegate.getSNTBalance()

--- a/src/app_service/service/ens/async_tasks.nim
+++ b/src/app_service/service/ens/async_tasks.nim
@@ -59,6 +59,7 @@ const ensUsernameDetailsTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.
     expirationTime = ens_utils.getExpirationTime(arg.chainId, arg.ensUsername)
 
   let responseJson = %* {
+    "chainId": arg.chainId,
     "ensUsername": arg.ensUsername,
     "address": address,
     "pubkey": pubkey,

--- a/src/app_service/service/ens/dto/ens_username_dto.nim
+++ b/src/app_service/service/ens/dto/ens_username_dto.nim
@@ -1,0 +1,25 @@
+{.used.}
+
+import json, strformat, hashes
+include ../../../common/json_utils
+
+type EnsUsernameDto* = ref object
+  chainId*: int
+  username*: string
+
+proc `==`*(l, r: EnsUsernameDto): bool =
+    return l.chainId == r.chainid and l.username == r.username
+
+proc `$`*(self: EnsUsernameDto): string =
+  result = fmt"""ContactDto(
+    chainId: {self.chainId},
+    username: {self.username}
+    )"""
+
+proc hash*(dto: EnsUsernameDto): Hash =
+    return ($dto).hash
+
+proc toEnsUsernameDto*(jsonObj: JsonNode): EnsUsernameDto =
+  result = EnsUsernameDto()
+  discard jsonObj.getProp("chainId", result.chainId)
+  discard jsonObj.getProp("username", result.username)

--- a/src/app_service/service/network/service.nim
+++ b/src/app_service/service/network/service.nim
@@ -96,11 +96,14 @@ proc toggleNetwork*(self: Service, chainId: int) =
   network.enabled = not network.enabled
   self.upsertNetwork(network)
 
-proc getNetworkForEns*(self: Service): NetworkDto =
+proc getChainIdForEns*(self: Service): int =
   if self.settingsService.areTestNetworksEnabled():
-    return self.getNetwork(Goerli)
+    return Goerli
+  return Mainnet
 
-  return self.getNetwork(Mainnet)
+proc getNetworkForEns*(self: Service): NetworkDto =
+  let chainId = self.getChainIdForEns()
+  return self.getNetwork(chainId)
 
 proc getNetworkForStickers*(self: Service): NetworkDto =
   if self.settingsService.areTestNetworksEnabled():

--- a/src/app_service/service/settings/service.nim
+++ b/src/app_service/service/settings/service.nim
@@ -153,32 +153,6 @@ QtObject:
       return true
     return false
 
-  proc saveNewEnsUsername*(self: Service, username: string): bool =
-    var newEnsUsernames = self.settings.ensUsernames
-    newEnsUsernames.add(username)
-    let newEnsUsernamesAsJson = %* newEnsUsernames
-
-    if(self.saveSetting(KEY_ENS_USERNAMES, newEnsUsernamesAsJson)):
-      self.settings.ensUsernames = newEnsUsernames
-      return true
-    return false
-
-  proc removeEnsUsername*(self: Service, username: string): bool = 
-    var newEnsUsernames = self.settings.ensUsernames
-    let index = newEnsUsernames.find(username)
-    if (index < 0):
-        return false
-    newEnsUsernames.delete(index)
-    let newEnsUsernamesAsJson = %* newEnsUsernames
-
-    if(self.saveSetting(KEY_ENS_USERNAMES, newEnsUsernamesAsJson)):
-      self.settings.ensUsernames = newEnsUsernames
-      return true
-    return false
-
-  proc getEnsUsernames*(self: Service): seq[string] =
-    return self.settings.ensUsernames
-
   proc saveKeyUid*(self: Service, value: string): bool =
     if(self.saveSetting(KEY_KEY_UID, value)):
       self.settings.keyUid = value

--- a/src/backend/ens.nim
+++ b/src/backend/ens.nim
@@ -3,6 +3,18 @@ import ./core, ./response_type
 import ./utils
 export response_type
 
+proc getEnsUsernames*(): RpcResponse[JsonNode] {.raises: [Exception].} =
+  let payload = %* []
+  return core.callPrivateRPC("ens_getEnsUsernames", payload)
+
+proc add*(chainId: int, username: string): RpcResponse[JsonNode] {.raises: [Exception].} =
+  let payload = %* [chainId, username]
+  return core.callPrivateRPC("ens_add", payload)
+
+proc remove*(chainId: int, username: string): RpcResponse[JsonNode] {.raises: [Exception].} =
+  let payload = %* [chainId, username]
+  return core.callPrivateRPC("ens_remove", payload)
+
 proc getRegistrarAddress*(chainId: int): RpcResponse[JsonNode] {.raises: [Exception].} =
   let payload = %* [chainId]
 

--- a/ui/app/AppLayouts/Profile/popups/ENSPopup.qml
+++ b/ui/app/AppLayouts/Profile/popups/ENSPopup.qml
@@ -72,8 +72,7 @@ StatusDialog {
             Layout.fillWidth: true
             Layout.fillHeight: true
             implicitHeight: contentHeight
-
-            model: root.ensUsernamesStore.ensUsernamesModel
+            model: root.ensUsernamesStore.currentChainEnsUsernamesModel
 
             delegate: RadioDelegate {
                 id: radioDelegate

--- a/ui/app/AppLayouts/Profile/stores/EnsUsernamesStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/EnsUsernamesStore.qml
@@ -1,5 +1,6 @@
 import QtQuick 2.13
 import utils 1.0
+import SortFilterProxyModel 0.2
 
 QtObject {
     id: root
@@ -8,9 +9,18 @@ QtObject {
 
     property var ensUsernamesModel: root.ensUsernamesModule ? ensUsernamesModule.model : []
 
+    readonly property QtObject currentChainEnsUsernamesModel: SortFilterProxyModel {
+        sourceModel: root.ensUsernamesModel
+        filters: ValueFilter {
+            roleName: "chainId"
+            value: root.chainId
+        }
+    }
+
     property string pubkey: userProfile.pubKey
     property string icon: userProfile.icon
     property string preferredUsername: userProfile.preferredName
+    readonly property string chainId: ensUsernamesModule.chainId
 
     property string username: userProfile.username
 
@@ -34,22 +44,22 @@ QtObject {
         return ensUsernamesModule.numOfPendingEnsUsernames()
     }
 
-    function ensDetails(ensUsername) {
+    function ensDetails(chainId, ensUsername) {
         if(!root.ensUsernamesModule)
             return ""
-        ensUsernamesModule.fetchDetailsForEnsUsername(ensUsername)
+        ensUsernamesModule.fetchDetailsForEnsUsername(chainId, ensUsername)
     }
 
-    function setPubKeyGasEstimate(ensUsername, address) {
+    function setPubKeyGasEstimate(chainId, ensUsername, address) {
         if(!root.ensUsernamesModule)
             return 0
-        return ensUsernamesModule.setPubKeyGasEstimate(ensUsername, address)
+        return ensUsernamesModule.setPubKeyGasEstimate(chainId, ensUsername, address)
     }
 
-    function authenticateAndSetPubKey(ensUsername, address, gas, gasPrice, maxPriorityFeePerGas, maxFeePerGas, eip1559Enabled) {
+    function authenticateAndSetPubKey(chainId, ensUsername, address, gas, gasPrice, maxPriorityFeePerGas, maxFeePerGas, eip1559Enabled) {
         if(!root.ensUsernamesModule)
             return ""
-        return ensUsernamesModule.authenticateAndSetPubKey(ensUsername, address, gas, gasPrice, maxPriorityFeePerGas, maxFeePerGas, eip1559Enabled)
+        return ensUsernamesModule.authenticateAndSetPubKey(chainId, ensUsername, address, gas, gasPrice, maxPriorityFeePerGas, maxFeePerGas, eip1559Enabled)
     }
 
     function getEtherscanLink() {
@@ -68,10 +78,10 @@ QtObject {
         globalUtils.copyToClipboard(value)
     }
 
-    function authenticateAndReleaseEns(ensUsername, address, gas, gasPrice, maxPriorityFeePerGas, maxFeePerGas, eip1559Enabled) {
+    function authenticateAndReleaseEns(chainId, ensUsername, address, gas, gasPrice, maxPriorityFeePerGas, maxFeePerGas, eip1559Enabled) {
         if(!root.ensUsernamesModule)
             return ""
-        return ensUsernamesModule.authenticateAndReleaseEns(ensUsername, address, gas, gasPrice, maxPriorityFeePerGas, maxFeePerGas, eip1559Enabled)
+        return ensUsernamesModule.authenticateAndReleaseEns(chainId, ensUsername, address, gas, gasPrice, maxPriorityFeePerGas, maxFeePerGas, eip1559Enabled)
     }
 
     function ensConnectOwnedUsername(name, isStatus) {
@@ -86,10 +96,10 @@ QtObject {
         return ensUsernamesModule.getEnsRegisteredAddress()
     }
 
-    function authenticateAndRegisterEns(ensUsername, address, gasLimit, gasPrice, tipLimit, overallLimit, eip1559Enabled) {
+    function authenticateAndRegisterEns(chainId, ensUsername, address, gasLimit, gasPrice, tipLimit, overallLimit, eip1559Enabled) {
         if(!root.ensUsernamesModule)
             return
-        ensUsernamesModule.authenticateAndRegisterEns(ensUsername, address, gasLimit, gasPrice, tipLimit, overallLimit, eip1559Enabled)
+        ensUsernamesModule.authenticateAndRegisterEns(chainId, ensUsername, address, gasLimit, gasPrice, tipLimit, overallLimit, eip1559Enabled)
     }
 
     function getEnsRegistry() {
@@ -148,16 +158,10 @@ QtObject {
         return JSON.parse(walletSectionTransactions.suggestedFees(chainId))
     }
 
-    function getChainIdForEns() {
+    function removeEnsUsername(chainId, ensUsername) {
         if(!root.ensUsernamesModule)
             return ""
-        return ensUsernamesModule.getChainIdForEns()
-    }
-
-    function removeEnsUsername(ensUsername) {
-        if(!root.ensUsernamesModule)
-            return ""
-        return ensUsernamesModule.removeEnsUsername(ensUsername)
+        return ensUsernamesModule.removeEnsUsername(chainId, ensUsername)
     }
 }
 

--- a/ui/app/AppLayouts/Profile/views/EnsDetailsView.qml
+++ b/ui/app/AppLayouts/Profile/views/EnsDetailsView.qml
@@ -16,11 +16,12 @@ Item {
     property var ensUsernamesStore
     property var contactsStore
     property string username: ""
+    property string chainId: ""
     property string walletAddress: "-"
     property string key: "-"
 
     signal backBtnClicked();
-    signal usernameReleased(username: string);
+    signal usernameReleased()
 
     QtObject {
         id: d
@@ -140,6 +141,7 @@ Item {
                     let eip1559Enabled = path.gasFees.eip1559Enabled
                     let maxFeePerGas = path.gasFees.maxFeePerGasM
                     root.ensUsernamesStore.authenticateAndReleaseEns(
+                                root.chainId,
                                 root.username,
                                 selectedAccount.address,
                                 path.gasAmount,
@@ -163,7 +165,7 @@ Item {
                             return releaseEnsModal.sendingError.open()
                         }
                         for(var i=0; i<releaseEnsModal.bestRoutes.length; i++) {
-                            usernameReleased(username);
+                            usernameReleased()
                             let url =  "%1/%2".arg(releaseEnsModal.store.getEtherscanLink(releaseEnsModal.bestRoutes[i].fromNetwork.chainId)).arg(response.result)
                             Global.displayToastMessage(qsTr("Transaction pending..."),
                                                        qsTr("View on etherscan"),
@@ -195,7 +197,7 @@ Item {
             type: StatusQControls.StatusBaseButton.Type.Danger
             text: qsTr("Remove username")
             onClicked: {
-                root.ensUsernamesStore.removeEnsUsername(root.username)
+                root.ensUsernamesStore.removeEnsUsername(root.chainId, root.username)
                 root.backBtnClicked()
             }
         }

--- a/ui/app/AppLayouts/Profile/views/EnsListView.qml
+++ b/ui/app/AppLayouts/Profile/views/EnsListView.qml
@@ -23,7 +23,7 @@ Item {
     property int profileContentWidth
 
     signal addBtnClicked()
-    signal selectEns(string username)
+    signal selectEns(string username, string chainId)
 
     Component.onCompleted: {
         d.updateNumberOfPendingEnsUsernames()
@@ -121,7 +121,8 @@ Item {
             StatusListView {
                 id: lvEns
                 anchors.fill: parent
-                model: root.ensUsernamesStore.ensUsernamesModel
+                model: root.ensUsernamesStore.currentChainEnsUsernamesModel
+
                 spacing: 10
                 delegate: StatusListItem {
                     readonly property int indexOfDomainStart: model.ensUsername.indexOf(".")
@@ -149,7 +150,7 @@ Item {
                     ]
 
                     onClicked: {
-                        root.selectEns(model.ensUsername)
+                        root.selectEns(model.ensUsername, model.chainId)
                     }
                 }
 

--- a/ui/app/AppLayouts/Profile/views/EnsSearchView.qml
+++ b/ui/app/AppLayouts/Profile/views/EnsSearchView.qml
@@ -86,6 +86,7 @@ Item {
                     let path = bestRoutes[0]
                     let eip1559Enabled = path.gasFees.eip1559Enabled
                     root.ensUsernamesStore.authenticateAndSetPubKey(
+                                root.ensUsernamesStore.chainId,
                                 ensUsername.text + (isStatus ? ".stateofus.eth" : "" ),
                                 selectedAccount.address,
                                 path.gasAmount,

--- a/ui/app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml
+++ b/ui/app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml
@@ -73,6 +73,7 @@ Item {
                     let eip1559Enabled = path.gasFees.eip1559Enabled
                     let maxFeePerGas = path.gasFees.maxFeePerGasM
                     root.ensUsernamesStore.authenticateAndRegisterEns(
+                                root.ensUsernamesStore.chainId,
                                 username,
                                 selectedAccount.address,
                                 path.gasAmount,

--- a/ui/app/AppLayouts/Profile/views/EnsView.qml
+++ b/ui/app/AppLayouts/Profile/views/EnsView.qml
@@ -20,6 +20,7 @@ Item {
     property bool showSearchScreen: false
     property string addedUsername: ""
     property string selectedUsername: ""
+    property string selectedChainId: ""
 
     signal next(output: string)
     signal back()
@@ -292,8 +293,9 @@ Item {
             profileContentWidth: ensView.profileContentWidth
             onAddBtnClicked: next("search")
             onSelectEns: {
-                ensView.ensUsernamesStore.ensDetails(username)
-                selectedUsername = username;
+                ensView.ensUsernamesStore.ensDetails(chainId, username)
+                selectedUsername = username
+                selectedChainId = chainId
                 next("details")
             }
         }
@@ -305,10 +307,12 @@ Item {
             ensUsernamesStore: ensView.ensUsernamesStore
             contactsStore: ensView.contactsStore
             username: selectedUsername
-            onBackBtnClicked: back();
+            chainId: selectedChainId
+            onBackBtnClicked: back()
             onUsernameReleased: {
-                selectedUsername = username;
-                done(username);
+                selectedUsername = username
+                selectedChainId = chainId
+                done(username)
             }
         }
     }


### PR DESCRIPTION
Fixes #3234 
Corresponding status-go PR: https://github.com/status-im/status-go/pull/3066

### What does the PR do

* Support ENS usernames on different networks.
* Only current network ENS usernames are shown in settings.
* The new table is maintained fully in status-go, not from app (as it was before)
* Preferred username is temporarily dumb-fixed during network chain: https://github.com/status-im/status-desktop/issues/9035

### Affected areas

ENS usernames settings

### Screenshot of functionality (including design for comparison)

https://user-images.githubusercontent.com/25482501/211618608-3a0654fa-72c8-4fa9-a146-3fd88ad9640a.mov

