### PR TITLE
feat(@desktop/wallet): handle very small currency amounts

### DIFF
--- a/ui/StatusQ/src/StatusQ/Core/LocaleUtils.qml
+++ b/ui/StatusQ/src/StatusQ/Core/LocaleUtils.qml
@@ -44,13 +44,26 @@ QtObject {
             console.trace()
             return NaN
         }
-        var amountStr = numberToLocaleString(currencyAmount.amount, currencyAmount.displayDecimals, locale)
-        if (currencyAmount.stripTrailingZeroes) {
-            amountStr = stripTrailingZeroes(amountStr, locale)
+
+        var amountStr
+        let minAmount = 10**-currencyAmount.displayDecimals
+        if (currencyAmount.amount > 0 && currencyAmount.amount < minAmount && !(options && options.onlyAmount))
+        {
+            // Handle amounts smaller than resolution
+            amountStr = "<%1".arg(numberToLocaleString(minAmount, currencyAmount.displayDecimals, locale))
+        } else {
+            // Normal formatting
+            amountStr = numberToLocaleString(currencyAmount.amount, currencyAmount.displayDecimals, locale)
+            if (currencyAmount.stripTrailingZeroes) {
+                amountStr = stripTrailingZeroes(amountStr, locale)
+            }
         }
+
+        // Add symbol
         if (currencyAmount.symbol && !(options && options.onlyAmount)) {
             amountStr = "%1 %2".arg(amountStr).arg(currencyAmount.symbol)
         }
+
         return amountStr
     }
 


### PR DESCRIPTION
### What does the PR do
Fixes #9013

Currency amounts smaller than the resolution are now shown as "<(resolution) (unit)".

<img width="551" alt="Screenshot 2023-01-10 at 16 27 10" src="https://user-images.githubusercontent.com/11161531/211644554-b9e77c42-5be1-41d5-b620-ff9d24c802d0.png">
