### PR TITLE
hotfix(StatusMessage): restore timestamps

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
@@ -63,8 +63,8 @@ Control {
     property StatusMessageDetails messageDetails: StatusMessageDetails {}
     property StatusMessageDetails replyDetails: StatusMessageDetails {}
 
-    property string timestampString: Qt.formatTime(new Date(timestamp), Qt.locale(), Locale.ShortFormat)
-    property string timestampTooltipString: Qt.formatDateTime(new Date(timestamp), Qt.locale(), Locale.LongFormat)
+    property string timestampString: new Date(timestamp).toLocaleTimeString(Qt.locale(), Locale.ShortFormat)
+    property string timestampTooltipString: new Date(timestamp).toLocaleString()
 
     signal clicked(var sender, var mouse)
     signal profilePictureClicked(var sender, var mouse)


### PR DESCRIPTION
Revert to using Date functions; Qt broke the API between Qt 5.14 and Qt 5.15
(https://doc.qt.io/archives/qt-5.14/qml-qtqml-qt.html#formatDateTime-method vs https://doc.qt.io/qt-5/qml-qtqml-qt.html#formatDateTime-method)

We'll move this function to C++ in a followup PR to preserve the API compatibility while keeping it fast enough

Fixes #9037

### What does the PR do

Restore message timestamps under Qt 5.14

### Affected areas

StatusMessage

