### PR TITLE
fix(AppMain): Show banner on startup if diconnected

### DIFF
--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -566,6 +566,11 @@ Item {
                     processConnected()
                 }
 
+                Component.onCompleted: {
+                    if (!isConnected)
+                        processConnected()
+                }
+
                 Connections {
                     target: rootStore.aboutModuleInst
                     onAppVersionFetched: {


### PR DESCRIPTION
Fixes #9057

### What does the PR do

Show "Disconnected" banner, if there was no connection after startup.
If there was connection, no banner is required.

### Screenshot of functionality (including design for comparison)

https://user-images.githubusercontent.com/25482501/211826742-3ab5de76-2329-420d-a10f-9192fefcba53.mov


