### PR TITLE
fix(Community Permissions): Update change detected buttons labels according to the new design

### DIFF
--- a/ui/app/AppLayouts/Chat/layouts/SettingsPageLayout.qml
+++ b/ui/app/AppLayouts/Chat/layouts/SettingsPageLayout.qml
@@ -24,6 +24,9 @@ Item {
     property int headerWidth: 0
     property string previousPageName: ""
     property bool saveChangesButtonEnabled: !!root.contentItem && !!root.contentItem.saveChangesButtonEnabled
+    property alias saveChangesText: settingsDirtyToastMessage.saveChangesText
+    property alias cancelChangesText: settingsDirtyToastMessage.cancelChangesText
+    property alias changesDetectedText: settingsDirtyToastMessage.changesDetectedText
 
     readonly property Item contentItem: contentLoader.item
     readonly property size settingsDirtyToastMessageImplicitSize: 

--- a/ui/app/AppLayouts/Chat/panels/communities/CommunityPermissionsSettingsPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/CommunityPermissionsSettingsPanel.qml
@@ -65,6 +65,8 @@ SettingsPageLayout {
     }
 
     saveChangesButtonEnabled: true
+    saveChangesText: qsTr("Update permission")
+    cancelChangesText: qsTr("Revert changes")
     state: d.getInitialState()
     states: [
         State {

--- a/ui/imports/shared/popups/SettingsDirtyToastMessage.qml
+++ b/ui/imports/shared/popups/SettingsDirtyToastMessage.qml
@@ -13,6 +13,9 @@ Rectangle {
 
     property bool active: false
     property bool saveChangesButtonEnabled: false
+    property alias saveChangesText: saveChangesButton.text
+    property alias cancelChangesText: cancelChangesButton.text
+    property alias changesDetectedText: changesDetectedTextItem.text
 
     property Flickable flickable: null
 
@@ -100,6 +103,7 @@ Rectangle {
         }
 
         StatusBaseText {
+            id: changesDetectedTextItem
             Layout.columnSpan: 2
             Layout.fillWidth: true
             padding: 8
@@ -109,6 +113,7 @@ Rectangle {
         }
 
         StatusButton {
+            id: cancelChangesButton
             text: qsTr("Cancel")
             enabled: root.active
             type: StatusBaseButton.Type.Danger


### PR DESCRIPTION
Fixes #9046

### What does the PR do

- It exposes new properties in `SettingsDirtyToastMessage` to customise buttons texts. 
- It exposes new properties in `SettingsPageLayout` to customise dirty toast buttons texts.

### Affected areas

`SettingsDirtyToastMessage` button texts.

### Screenshot of functionality
This is how the issue looks like:

<img width="718" alt="Screenshot 2023-01-11 at 15 00 38" src="https://user-images.githubusercontent.com/97019400/211826684-f1074113-2295-4b43-8ae6-ec3d15290dd3.png">

These are some other pages where the toast was already used so, we can see in the following images that nothing it's being broken by this change:

<img width="718" alt="Screenshot 2023-01-11 at 15 01 52" src="https://user-images.githubusercontent.com/97019400/211826802-f18737d0-8b1d-48d6-a9b0-5a9abda2bc7c.png">

<img width="718" alt="Screenshot 2023-01-11 at 15 02 06" src="https://user-images.githubusercontent.com/97019400/211826815-18ee46e1-ecae-4de0-b13d-e5903a46a749.png">