### PR TITLE
fix(@desktop/wallet): Fix for market values not displayed on Asset details view

### DIFF
--- a/src/app/modules/shared_models/token_item.nim
+++ b/src/app/modules/shared_models/token_item.nim
@@ -18,13 +18,13 @@ type
     assetWebsiteUrl: string
     builtOn: string
     address: string
-    marketCap: string
-    highDay: string
-    lowDay: string
-    changePctHour: string
-    changePctDay: string
-    changePct24hour: string
-    change24hour: string
+    marketCap: float64
+    highDay: float64
+    lowDay: float64
+    changePctHour: float64
+    changePctDay: float64
+    changePct24hour: float64
+    change24hour: float64
     currencyPrice: float
     decimals: int
 
@@ -41,13 +41,13 @@ proc initItem*(
   assetWebsiteUrl: string,
   builtOn: string,
   address: string,
-  marketCap: string,
-  highDay: string,
-  lowDay: string,
-  changePctHour: string,
-  changePctDay: string,
-  changePct24hour: string,
-  change24hour: string,
+  marketCap: float64,
+  highDay: float64,
+  lowDay: float64,
+  changePctHour: float64,
+  changePctDay: float64,
+  changePct24hour: float64,
+  change24hour: float64,
   currencyPrice: float,
   decimals: int,
 ): Item =
@@ -139,25 +139,25 @@ proc getBuiltOn*(self: Item): string =
 proc getAddress*(self: Item): string =
   return self.address
 
-proc getMarketCap*(self: Item): string =
+proc getMarketCap*(self: Item): float64 =
   return self.marketCap
 
-proc getHighDay*(self: Item): string =
+proc getHighDay*(self: Item): float64 =
   return self.highDay
 
-proc getLowDay*(self: Item): string =
+proc getLowDay*(self: Item): float64 =
   return self.lowDay
 
-proc getChangePctHour*(self: Item): string =
+proc getChangePctHour*(self: Item): float64 =
   return self.changePctHour
 
-proc getChangePctDay*(self: Item): string =
+proc getChangePctDay*(self: Item): float64 =
   return self.changePctDay
 
-proc getChangePct24hour*(self: Item): string =
+proc getChangePct24hour*(self: Item): float64 =
   return self.changePct24hour
 
-proc getChange24hour*(self: Item): string =
+proc getChange24hour*(self: Item): float64 =
   return self.change24hour
 
 proc getCurrencyPrice*(self: Item): float =

--- a/src/app_service/service/wallet_account/dto.nim
+++ b/src/app_service/service/wallet_account/dto.nim
@@ -32,13 +32,13 @@ type
     description*: string
     assetWebsiteUrl*: string
     builtOn*: string
-    marketCap*: string
-    highDay*: string
-    lowDay*: string
-    changePctHour*: string
-    changePctDay*: string
-    changePct24hour*: string
-    change24hour*: string
+    marketCap*: float64
+    highDay*: float64
+    lowDay*: float64
+    changePctHour*: float64
+    changePctDay*: float64
+    changePct24hour*: float64
+    change24hour*: float64
     currencyPrice*: float64
 
 type
@@ -157,7 +157,7 @@ proc toBalanceDto*(jsonObj: JsonNode): BalanceDto =
   discard jsonObj.getProp("address", result.address)
   discard jsonObj.getProp("chainId", result.chainId)
 
-proc toWalletTokenDto*(jsonObj: JsonNode): WalletTokenDto =
+proc toWalletTokenDto*(jsonObj: JsonNode, currentCurrency: string): WalletTokenDto =
   result = WalletTokenDto()
   discard jsonObj.getProp("name", result.name)
   discard jsonObj.getProp("symbol", result.symbol)
@@ -166,14 +166,16 @@ proc toWalletTokenDto*(jsonObj: JsonNode): WalletTokenDto =
   discard jsonObj.getProp("description", result.description)
   discard jsonObj.getProp("assetWebsiteUrl", result.assetWebsiteUrl)
   discard jsonObj.getProp("builtOn", result.builtOn)
-  discard jsonObj.getProp("marketCap", result.marketCap)
-  discard jsonObj.getProp("highDay", result.highDay)
-  discard jsonObj.getProp("lowDay", result.lowDay)
-  discard jsonObj.getProp("changePctHour", result.changePctHour)
-  discard jsonObj.getProp("changePctDay", result.changePctDay)
-  discard jsonObj.getProp("changePct24hour", result.changePct24hour)
-  discard jsonObj.getProp("change24hour", result.change24hour)
   discard jsonObj.getProp("currencyPrice", result.currencyPrice)
+
+  let marketValuesPerCurrency = jsonObj{"marketValuesPerCurrency"}{currentCurrency}
+  result.marketCap = marketValuesPerCurrency{"marketCap"}.getFloat
+  result.highDay = marketValuesPerCurrency{"highDay"}.getFloat
+  result.lowDay = marketValuesPerCurrency{"lowDay"}.getFloat
+  result.changePctHour = marketValuesPerCurrency{"changePctHour"}.getFloat
+  result.changePctDay = marketValuesPerCurrency{"changePctDay"}.getFloat
+  result.changePct24hour = marketValuesPerCurrency{"changePct24hour"}.getFloat
+  result.change24hour = marketValuesPerCurrency{"change24hour"}.getFloat
 
   var balancesPerChainObj: JsonNode
   if(jsonObj.getProp("balancesPerChain", balancesPerChainObj)):

--- a/src/app_service/service/wallet_account/service.nim
+++ b/src/app_service/service/wallet_account/service.nim
@@ -467,7 +467,7 @@ QtObject:
         var tokensArr: JsonNode
         var tokens: seq[WalletTokenDto]
         if(responseObj.getProp(wAddress, tokensArr)):
-          tokens = map(tokensArr.getElems(), proc(x: JsonNode): WalletTokenDto = x.toWalletTokenDto())
+          tokens = map(tokensArr.getElems(), proc(x: JsonNode): WalletTokenDto = x.toWalletTokenDto(self.settingsService.getCurrency()))
         
           tokens.sort(priorityTokenCmp)
           self.walletAccounts[wAddress].tokens = tokens

--- a/ui/imports/shared/views/AssetsDetailView.qml
+++ b/ui/imports/shared/views/AssetsDetailView.qml
@@ -264,47 +264,47 @@ Item {
             InformationTile {
                 maxWidth: parent.width
                 primaryText: qsTr("Market Cap")
-                secondaryText: token && token.marketCap !== "" ? token.marketCap : "---"
+                secondaryText: token && token.marketCap !== "" ? LocaleUtils.numberToLocaleString(token.marketCap, 4) : "---"
             }
             InformationTile {
                 maxWidth: parent.width
                 primaryText: qsTr("Day Low")
-                secondaryText: token && token.lowDay !== "" ? token.lowDay : "---"
+                secondaryText: token && token.lowDay !== "" ? LocaleUtils.numberToLocaleString(token.lowDay, 4) : "---"
             }
             InformationTile {
                 maxWidth: parent.width
                 primaryText: qsTr("Day High")
-                secondaryText: token && token.highDay ? token.highDay : "---"
+                secondaryText: token && token.highDay ? LocaleUtils.numberToLocaleString(token.highDay, 4)  : "---"
             }
             Item {
                 Layout.fillWidth: true
             }
             InformationTile {
-                readonly property string changePctHour: token ? token.changePctHour : ""
+                readonly property string changePctHour: token ? LocaleUtils.numberToLocaleString(token.changePctHour, 2) : ""
                 maxWidth: parent.width
                 primaryText: qsTr("Hour")
                 secondaryText: changePctHour ? "%1%".arg(changePctHour) : "---"
-                secondaryLabel.color: Math.sign(Number(changePctHour)) === 0 ? Theme.palette.directColor1 :
-                                                                               Math.sign(Number(changePctHour)) === -1 ? Theme.palette.dangerColor1 :
-                                                                                                                         Theme.palette.successColor1
+                secondaryLabel.color: Math.sign(changePctHour) === 0 ? Theme.palette.directColor1 :
+                                      Math.sign(changePctHour) === -1 ? Theme.palette.dangerColor1 :
+                                                                        Theme.palette.successColor1
             }
             InformationTile {
-                readonly property string changePctDay: token ? token.changePctDay : ""
+                readonly property string changePctDay: token ? LocaleUtils.numberToLocaleString(token.changePctDay, 2) : ""
                 maxWidth: parent.width
                 primaryText: qsTr("Day")
                 secondaryText: changePctDay ? "%1%".arg(changePctDay) : "---"
-                secondaryLabel.color: Math.sign(Number(changePctDay)) === 0 ? Theme.palette.directColor1 :
-                                                                              Math.sign(Number(changePctDay)) === -1 ? Theme.palette.dangerColor1 :
-                                                                                                                       Theme.palette.successColor1
+                secondaryLabel.color: Math.sign(changePctDay) === 0 ? Theme.palette.directColor1 :
+                                      Math.sign(changePctDay) === -1 ? Theme.palette.dangerColor1 :
+                                                                       Theme.palette.successColor1
             }
             InformationTile {
-                readonly property string changePct24hour: token ? token.changePct24hour : ""
+                readonly property string changePct24hour: token ? LocaleUtils.numberToLocaleString(token.changePct24hour, 2) : ""
                 maxWidth: parent.width
                 primaryText: qsTr("24 Hours")
                 secondaryText: changePct24hour ? "%1%".arg(changePct24hour) : "---"
-                secondaryLabel.color: Math.sign(Number(changePct24hour)) === 0 ? Theme.palette.directColor1 :
-                                                                                 Math.sign(Number(changePct24hour)) === -1 ? Theme.palette.dangerColor1 :
-                                                                                                                             Theme.palette.successColor1
+                secondaryLabel.color: Math.sign(changePct24hour) === 0 ? Theme.palette.directColor1 :
+                                      Math.sign(changePct24hour) === -1 ? Theme.palette.dangerColor1 :
+                                                                          Theme.palette.successColor1
             }
         }
 
@@ -357,6 +357,7 @@ Item {
                         InformationTag {
                             id: website
                             Layout.alignment: detailsFlow.isOverflowing ? Qt.AlignLeft : Qt.AlignRight
+                            Layout.preferredWidth: tagPrimaryLabel.width + iconAsset.width + Style.current.bigPadding
                             iconAsset.icon: "browser"
                             tagPrimaryLabel.text: qsTr("Website")
                             controlBackground.color: Theme.palette.baseColor2
@@ -371,6 +372,7 @@ Item {
                         InformationTag {
                             id: smartContractAddress
                             Layout.alignment: detailsFlow.isOverflowing ? Qt.AlignLeft : Qt.AlignRight
+                            Layout.preferredWidth: tagPrimaryLabel.width + tagSecondaryLabel.width + image.width + Style.current.bigPadding
 
                             image.source: token  && token.builtOn !== "" ? Style.svg("tiny/" + RootStore.getNetworkIconUrl(token.builtOn)) : ""
                             tagPrimaryLabel.text: token && token.builtOn !== "" ? RootStore.getNetworkName(token.builtOn) : "---"


### PR DESCRIPTION
closes #9055 

### What does the PR do

Market values not displayed on wallets asset view

the statusgo structure has changes but the nim side update was missing

### Affected areas

<!-- List the affected areas (e.g wallet, browser, etc..) -->

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

<img width="1718" alt="Screenshot 2023-01-11 at 4 04 30 PM" src="https://user-images.githubusercontent.com/60327365/211841091-7507e8e4-f9a3-429c-9ab7-244c8a9d9a3b.png">

