### PR TITLE
fix(Community Permissions): Remove (hide) minting and import option in assets dropdown

### DIFF
--- a/ui/app/AppLayouts/Chat/controls/community/ExtendedDropdownContent.qml
+++ b/ui/app/AppLayouts/Chat/controls/community/ExtendedDropdownContent.qml
@@ -264,6 +264,7 @@ Item {
                 ListElement { key: "MINT"; icon: "add"; iconSize: 16; description: qsTr("Mint token"); rotation: 0; spacing: 8 }
                 ListElement { key: "IMPORT"; icon: "invite-users"; iconSize: 16; description: qsTr("Import existing token"); rotation: 180; spacing: 8 }
             }
+            isHeaderVisible: false  // TEMPORARILY hidden. These 2 header options will be implemented after MVP.
             model: d.currentModel
             onHeaderItemClicked: {
                 if(key === "MINT") console.log("TODO: Mint token")


### PR DESCRIPTION
Fixes #8827

### What does the PR do

Removed (hidden) minting and import option in assets dropdown

### Affected areas

Assets (still named as tokens) dropdown

### Screenshot of functionality 

<img width="718" alt="Screenshot 2023-01-11 at 15 34 10" src="https://user-images.githubusercontent.com/97019400/211833071-62557612-06cf-443d-bd17-7a077deec4b6.png">
