### PR TITLE
fix(MessageView): Fix calculating `isExpired` value

### DIFF
--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -107,7 +107,7 @@ Loader {
     property bool isMessage: isEmoji || isImage || isSticker || isText || isAudio
                              || messageContentType === Constants.messageContentType.communityInviteType || messageContentType === Constants.messageContentType.transactionType
 
-    readonly property bool isExpired: d.getIsExpired(messageOutgoingStatus, messageTimestamp)
+    readonly property bool isExpired: d.getIsExpired(messageTimestamp, messageOutgoingStatus)
     readonly property bool isSending: messageOutgoingStatus === Constants.sending && !isExpired
 
     signal imageClicked(var image)


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/9066

1. Fixed arguments order in "Resend" button was never shown, because of a typo in arguments order
2. Also restored `now` variable for in `StatusDateGroupLabel` (there was a warning about it in log)

<img width="210" alt="image" src="https://user-images.githubusercontent.com/25482501/211839426-18ea9701-6165-4072-b2d4-4a3bbb4fcd68.png">