### PR TITLE
fix(Community Permissions): Update `PermissionItem` according to the new design

### DIFF
--- a/ui/app/AppLayouts/Chat/controls/community/PermissionItem.qml
+++ b/ui/app/AppLayouts/Chat/controls/community/PermissionItem.qml
@@ -154,30 +154,16 @@ Control{
             Repeater {
                 model: root.channelsListModel
 
-                RowLayout {
-                    spacing: content.spacing
-
-                    StatusBaseText {
-                        id: operatorInText
-                        Layout.preferredHeight: d.flowRowHeight
-                        visible: model.index !== 0
-                        Layout.alignment: Qt.AlignVCenter
-                        text: qsTr("and")
-                        font.pixelSize: d.itemTextPixelSize
-                        verticalAlignment: Text.AlignVCenter
-
-                    }
-                    StatusListItemTag {
-                        Layout.preferredHeight: d.flowRowHeight
-                        Layout.maximumWidth: (model.index !== 0) ? (content.width - operatorInText.width - spacing) : content.width
-                        title: model.text
-                        asset.name: model.imageSource
-                        asset.isImage: true
-                        asset.bgColor: "transparent"
-                        closeButtonVisible: false
-                        titleText.color: Theme.palette.primaryColor1
-                        titleText.font.pixelSize: d.tagTextPixelSize
-                    }
+                StatusListItemTag {
+                    height: d.flowRowHeight
+                    width: (implicitWidth > content.width) ? content.width : implicitWidth
+                    title: model.text
+                    asset.name: model.imageSource
+                    asset.isImage: true
+                    asset.bgColor: "transparent"
+                    closeButtonVisible: false
+                    titleText.color: Theme.palette.primaryColor1
+                    titleText.font.pixelSize: d.tagTextPixelSize
                 }
             }
         }


### PR DESCRIPTION
Fixes #9049

### What does the PR do

It removes `and` text between items in `In` section.

### Affected areas

Community Permissions -- Permissions Item

### Screenshot of functionality 

<img width="648" alt="Screenshot 2023-01-11 at 15 47 05" src="https://user-images.githubusercontent.com/97019400/212026097-706b90f6-9fb1-430b-a2ad-210d7534dad3.png">

