### PR TITLE
perf(chatScroll): Adding signals for chat settings in MessageStore

### DIFF
--- a/src/app/modules/main/chat_section/chat_content/messages/controller.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/controller.nim
@@ -205,6 +205,12 @@ proc init*(self: Controller) =
       return
     self.delegate.onMailserverSynced(args.syncedFrom)
 
+  self.events.on(SIGNAL_COMMUNITIES_UPDATE) do(e: Args):
+    let args = CommunitiesArgs(e)
+    for community in args.communities:
+      if (community.id == self.sectionId):
+        self.delegate.updateCommunityDetails(community)
+
 proc getMySectionId*(self: Controller): string =
   return self.sectionId
 

--- a/src/app/modules/main/chat_section/chat_content/messages/io_interface.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/io_interface.nim
@@ -1,6 +1,7 @@
 import NimQml
 
 import ../../../../../../app_service/service/message/dto/[message, reaction, pinned_message]
+import ../../../../../../app_service/service/community/dto/community
 import ../../../../shared_models/message_item
 
 type
@@ -161,3 +162,5 @@ method scrollToNewMessagesMarker*(self: AccessInterface) =
 method markAllMessagesRead*(self: AccessInterface) =
   raise newException(ValueError, "No implementation available")
 
+method updateCommunityDetails*(self: AccessInterface, community: CommunityDto) =
+  raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/chat_section/chat_content/messages/view.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/view.nim
@@ -1,6 +1,7 @@
 import NimQml, json
 import ../../../../shared_models/message_model
 import ../../../../shared_models/message_item
+import ../../../../../../app_service/service/chat/dto/chat
 import io_interface
 
 QtObject:
@@ -11,6 +12,11 @@ QtObject:
       modelVariant: QVariant
       initialMessagesLoaded: bool
       messageSearchOngoing: bool
+      amIChatAdmin: bool
+      isPinMessageAllowedForMembers: bool
+      chatColor: string
+      chatIcon: string
+      chatType: int
 
   proc delete*(self: View) =
     self.model.delete
@@ -25,6 +31,12 @@ QtObject:
     result.modelVariant = newQVariant(result.model)
     result.initialMessagesLoaded = false
     result.messageSearchOngoing = false
+    result.amIChatAdmin = false
+    result.isPinMessageAllowedForMembers = false
+    result.chatColor = ""
+    result.chatIcon = ""
+    result.chatType = ChatType.Unknown.int
+
 
   proc load*(self: View) =
     self.delegate.viewDidLoad()
@@ -63,21 +75,6 @@ QtObject:
 
   proc getChatId*(self: View): string {.slot.} =
     return self.delegate.getChatId()
-
-  proc getChatType*(self: View): int {.slot.} =
-    return self.delegate.getChatType()
-
-  proc getChatColor*(self: View): string {.slot.} =
-    return self.delegate.getChatColor()
-
-  proc getChatIcon*(self: View): string {.slot.} =
-    return self.delegate.getChatIcon()
-
-  proc amIChatAdmin*(self: View): bool {.slot.} =
-    return self.delegate.amIChatAdmin()
-
-  proc pinMessageAllowedForMembers*(self: View): bool {.slot.} =
-    return self.delegate.pinMessageAllowedForMembers()
 
   proc getNumberOfPinnedMessages*(self: View): int {.slot.} =
     return self.delegate.getNumberOfPinnedMessages()
@@ -178,3 +175,62 @@ QtObject:
     if self.model.newMessagesMarkerIndex() == -1:
       self.delegate.resetNewMessagesMarker()
 
+  proc amIChatAdminChanged*(self: View) {.signal.}
+  proc getAmIChatAdmin*(self: View): bool {.slot.} =
+    return self.amIChatAdmin
+  
+  QtProperty[bool] amIChatAdmin:
+    read = getAmIChatAdmin
+    notify = amIChatAdminChanged
+  
+  proc setAmIChatAdmin*(self: View, value: bool) =
+    self.amIChatAdmin = value
+    self.amIChatAdminChanged()
+
+  proc isPinMessageAllowedForMembersChanged*(self: View) {.signal.}
+  proc getIsPinMessageAllowedForMembers*(self: View): bool {.slot.} =
+    return self.isPinMessageAllowedForMembers
+  
+  QtProperty[bool] isPinMessageAllowedForMembers:
+    read = getIsPinMessageAllowedForMembers
+    notify = isPinMessageAllowedForMembersChanged
+  
+  proc setIsPinMessageAllowedForMembers*(self: View, value: bool) =
+    self.isPinMessageAllowedForMembers = value
+    self.isPinMessageAllowedForMembersChanged()
+
+  proc chatColorChanged*(self: View) {.signal.}
+  proc getChatColor*(self: View): string {.slot.} =
+    return self.chatColor
+
+  QtProperty[string] chatColor:
+    read = getChatColor
+    notify = chatColorChanged
+  
+  proc setChatColor*(self: View, value: string) =
+    self.chatColor = value
+    self.chatColorChanged()
+
+  proc chatIconChanged*(self: View) {.signal.}
+  proc getChatIcon*(self: View): string {.slot.} =
+    return self.chatIcon
+
+  QtProperty[string] chatIcon:
+    read = getChatIcon
+    notify = chatIconChanged
+  
+  proc setChatIcon*(self: View, value: string) =
+    self.chatIcon = value
+    self.chatIconChanged()
+  
+  proc chatTypeChanged*(self: View) {.signal.}
+  proc getChatType*(self: View): int {.slot.} =
+    return self.chatType
+
+  QtProperty[int] chatType:
+    read = getChatType
+    notify = chatTypeChanged
+  
+  proc setChatType*(self: View, value: int) =
+    self.chatType = value
+    self.chatTypeChanged()

--- a/ui/app/AppLayouts/Chat/stores/MessageStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/MessageStore.qml
@@ -12,6 +12,13 @@ QtObject {
     readonly property int newMessagesCount: messagesModel ? messagesModel.newMessagesCount : 0
     readonly property bool messageSearchOngoing: messageModule ? messageModule.messageSearchOngoing : false
 
+    readonly property bool amIChatAdmin: messageModule ? messageModule.amIChatAdmin : false
+    readonly property bool isPinMessageAllowedForMembers: messageModule ? messageModule.isPinMessageAllowedForMembers : false
+    readonly property string chatId: messageModule ? messageModule.getChatId() : ""
+    readonly property int chatType: messageModule ? messageModule.chatType : Constants.chatType.unknown
+    readonly property string chatColor: messageModule ? messageModule.chatColor : Style.current.blue
+    readonly property string chatIcon: messageModule ? messageModule.chatIcon : ""
+
     onMessageModuleChanged: {
         if(!messageModule)
             return
@@ -80,41 +87,6 @@ QtObject {
             return ""
 
         return messageModule.getChatId()
-    }
-
-    function getChatType () {
-        if(!messageModule)
-            return Constants.chatType.unknown
-
-        return messageModule.getChatType()
-    }
-
-    function getChatColor () {
-        if(!messageModule)
-            return Style.current.blue
-
-        return messageModule.getChatColor()
-    }
-
-    function getChatIcon () {
-        if(!messageModule)
-            return ""
-
-        return messageModule.getChatIcon()
-    }
-
-    function amIChatAdmin () {
-        if(!messageModule)
-            return false
-
-        return messageModule.amIChatAdmin()
-    }
-
-    function pinMessageAllowedForMembers() {
-        if(!messageModule)
-            return false
-
-        return messageModule.pinMessageAllowedForMembers()
     }
 
     function getNumberOfPinnedMessages () {

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -44,7 +44,7 @@ Loader {
     property bool senderIsEnsVerified: false
     property string senderIcon: ""
     property bool amISender: false
-    property bool amIChatAdmin: messageStore && messageStore.amIChatAdmin()
+    property bool amIChatAdmin: messageStore && messageStore.amIChatAdmin
     property bool senderIsAdded: false
     property int senderTrustStatus: Constants.trustStatus.unknown
     property string messageText: ""
@@ -138,8 +138,8 @@ Loader {
 
         messageContextMenu.myPublicKey = userProfile.pubKey
         messageContextMenu.amIChatAdmin = root.amIChatAdmin
-        messageContextMenu.pinMessageAllowedForMembers = messageStore.pinMessageAllowedForMembers()
-        messageContextMenu.chatType = messageStore.getChatType()
+        messageContextMenu.pinMessageAllowedForMembers = messageStore.isPinMessageAllowedForMembers
+        messageContextMenu.chatType = messageStore.chatType
 
         messageContextMenu.messageId = root.messageId
         messageContextMenu.unparsedText = root.unparsedText
@@ -296,14 +296,14 @@ Loader {
         ChannelIdentifierView {
             chatName: root.senderDisplayName
             chatId: root.messageStore.getChatId()
-            chatType: root.messageStore.getChatType()
-            chatColor: root.messageStore.getChatColor()
+            chatType: root.messageStore.chatType
+            chatColor: root.messageStore.chatColor
             chatEmoji: root.channelEmoji
             amIChatAdmin: root.amIChatAdmin
             chatIcon: {
-                if (root.messageStore.getChatType() === Constants.chatType.privateGroupChat &&
-                        root.messageStore.getChatIcon() !== "") {
-                    return root.messageStore.getChatIcon()
+                if (root.messageStore.chatType === Constants.chatType.privateGroupChat &&
+                        root.messageStore.chatIcon !== "") {
+                    return root.messageStore.chatIcon
                 }
                 return root.senderIcon
             }
@@ -679,7 +679,7 @@ Loader {
                         stickersPopup: root.stickersPopup
                         messageContextMenu: root.messageContextMenu
 
-                        chatType: root.messageStore.getChatType()
+                        chatType: root.messageStore.chatType
                         isEdit: true
 
                         onSendMessage: {
@@ -728,6 +728,7 @@ Loader {
                 quickActions: [
                     Loader {
                         active: !root.isInPinnedPopup && delegate.hovered
+                        visible: active
                         sourceComponent: StatusFlatRoundButton {
                             width: d.chatButtonSize
                             height: d.chatButtonSize
@@ -742,6 +743,7 @@ Loader {
                     },
                     Loader {
                         active: !root.isInPinnedPopup && delegate.hovered
+                        visible: active
                         sourceComponent: StatusFlatRoundButton {
                             objectName: "replyToMessageButton"
                             width: d.chatButtonSize
@@ -780,14 +782,15 @@ Loader {
                             if (!root.messageStore)
                                 return false
 
-                            const chatType = root.messageStore.getChatType();
-                            const pinMessageAllowedForMembers = root.messageStore.pinMessageAllowedForMembers()
+                            const chatType = root.messageStore.chatType;
+                            const pinMessageAllowedForMembers = root.messageStore.isPinMessageAllowedForMembers
 
                             return chatType === Constants.chatType.oneToOne ||
                                     chatType === Constants.chatType.privateGroupChat && root.amIChatAdmin ||
                                     chatType === Constants.chatType.communityChat && (root.amIChatAdmin || pinMessageAllowedForMembers);
 
                         }
+                        visible: active
                         sourceComponent: StatusFlatRoundButton {
                             objectName: "MessageView_toggleMessagePin"
                             width: d.chatButtonSize
@@ -835,6 +838,7 @@ Loader {
                                      messageContentType === Constants.messageContentType.imageType ||
                                      messageContentType === Constants.messageContentType.audioType);
                         }
+                        visible: active
                         sourceComponent: StatusFlatRoundButton {
                             objectName: "chatDeleteMessageButton"
                             width: d.chatButtonSize


### PR DESCRIPTION
### What does the PR do
Part of #3067
Adding signals for chat color, icon, type and channel settings in MessageStore in order to use property bindings in MessageView instead of backend calls on delegate creation.

Related to PR #9031

### Affected areas
Community settings representation in chat history (admin settings and members are allowed to pin message)
Chat settings representation in chat history (chat color, icon, type)

https://user-images.githubusercontent.com/47811206/212032123-c2fec5ea-67cf-4350-b44d-b2acea892b45.mov

