### PR TITLE
fix(Community Permissions): Update `tokens` names to `assets`

### DIFF
--- a/storybook/pages/CommunityNewPermissionViewPage.qml
+++ b/storybook/pages/CommunityNewPermissionViewPage.qml
@@ -12,7 +12,7 @@ Pane {
     CommunityNewPermissionView {
 
         store: CommunitiesStore {
-            readonly property var tokensModel: TokensModel {}
+            readonly property var assetsModel: AssetsModel {}
             readonly property var collectiblesModel: CollectiblesModel {}
             readonly property var channelsModel: ChannelsModel {}
 

--- a/storybook/pages/CommunityPermissionsSettingsPanelEditor.qml
+++ b/storybook/pages/CommunityPermissionsSettingsPanelEditor.qml
@@ -61,7 +61,7 @@ Flickable {
                                 icon: model.imageSource
                                 amountText: model.amount
                                 isAmountVisible: true
-                                iconsModel: TokensCollectiblesIconsModel {}
+                                iconsModel: AssetsCollectiblesIconsModel {}
                                 onNameChanged: model.name = name
                                 onIconChanged: model.imageSource = icon
                                 onAmountTextChanged: model.amount = parseFloat(amountText)
@@ -75,7 +75,7 @@ Flickable {
                         icon: d.newImageSource
                         amountText: d.newAmount
                         isAmountVisible: true
-                        iconsModel: TokensCollectiblesIconsModel {}
+                        iconsModel: AssetsCollectiblesIconsModel {}
                         onNameChanged: d.newName = name
                         onIconChanged: d.newImageSource = icon
                         onAmountTextChanged: d.newAmount = parseFloat(amountText)
@@ -103,7 +103,7 @@ Flickable {
                                  panelText: "In [item " + model.index + "]"
                                  name: model.name
                                  icon: model.iconSource
-                                 iconsModel: TokensCollectiblesIconsModel {}
+                                 iconsModel: AssetsCollectiblesIconsModel {}
                                  onNameChanged: model.name = name
                                  onIconChanged: model.iconSource = icon
                              }
@@ -116,7 +116,7 @@ Flickable {
                         panelText: "New In item"
                         name: d.newChannelName
                         icon: d.newChannelIconSource
-                        iconsModel: TokensCollectiblesIconsModel {}
+                        iconsModel: AssetsCollectiblesIconsModel {}
                         onNameChanged: d.newChannelName = name
                         onIconChanged: d.newChannelIconSource = icon
                     }

--- a/storybook/pages/CommunityPermissionsSettingsPanelPage.qml
+++ b/storybook/pages/CommunityPermissionsSettingsPanelPage.qml
@@ -25,19 +25,19 @@ SplitView {
                     topMargin: 50
                 }
                 store: CommunitiesStore {
-                    tokensModel: TokensModel {}
+                    assetsModel: AssetsModel {}
                     collectiblesModel: CollectiblesModel {}
                     channelsModel: ListModel {
                         Component.onCompleted: {
                             append([
                                 {
                                     key: "welcome",
-                                    iconSource: ModelsData.tokens.inch,
+                                    iconSource: ModelsData.assets.inch,
                                     name: "#welcome"
                                 },
                                 {
                                     key: "general",
-                                    iconSource: ModelsData.tokens.inch,
+                                    iconSource: ModelsData.assets.inch,
                                     name: "#general"
                                 }
                             ])

--- a/storybook/pages/HoldingsDropdownPage.qml
+++ b/storybook/pages/HoldingsDropdownPage.qml
@@ -68,21 +68,21 @@ Pane {
                 }
             }
 
-            readonly property ListModel tokensModel: ListModel {
+            readonly property ListModel assetsModel: ListModel {
                 ListElement {
-                    key: "socks"; iconSource: ""; name: "Unisocks"; shortName: "SOCKS"; category: "Community tokens"
+                    key: "socks"; iconSource: ""; name: "Unisocks"; shortName: "SOCKS"; category: "Community assets"
                 }
                 ListElement {
-                    key: "zrx"; iconSource: ""; name: "Ox"; shortName: "ZRX"; category: "Listed tokens"
+                    key: "zrx"; iconSource: ""; name: "Ox"; shortName: "ZRX"; category: "Listed assets"
                 }
                 ListElement {
-                    key: "1inch"; iconSource: ""; name: "1inch"; shortName: "ZRX"; category: "Listed tokens"
+                    key: "1inch"; iconSource: ""; name: "1inch"; shortName: "ZRX"; category: "Listed assets"
                 }
                 ListElement {
-                    key: "Aave"; iconSource: ""; name: "Aave"; shortName: "AAVE"; category: "Listed tokens"}
+                    key: "Aave"; iconSource: ""; name: "Aave"; shortName: "AAVE"; category: "Listed assets"}
 
                 ListElement {
-                    key: "Amp"; iconSource: ""; name: "Amp"; shortName: "AMP"; category: "Listed tokens"
+                    key: "Amp"; iconSource: ""; name: "Amp"; shortName: "AMP"; category: "Listed assets"
                 }
             }
         }

--- a/storybook/src/Models/AssetsCollectiblesIconsModel.qml
+++ b/storybook/src/Models/AssetsCollectiblesIconsModel.qml
@@ -4,9 +4,9 @@ import QtQuick 2.14
 
 ListModel {
     Component.onCompleted: append([
-                                      {image: ModelsData.tokens.socks},
-                                      {image: ModelsData.tokens.zrx},
-                                      {image: ModelsData.tokens.inch},
+                                      {image: ModelsData.assets.socks},
+                                      {image: ModelsData.assets.zrx},
+                                      {image: ModelsData.assets.inch},
                                       {image: ModelsData.collectibles.anniversary},
                                       {image: ModelsData.collectibles.cryptoKitties},
                                       {image: ModelsData.collectibles.kitty1},

--- a/storybook/src/Models/AssetsModel.qml
+++ b/storybook/src/Models/AssetsModel.qml
@@ -5,38 +5,38 @@ ListModel {
         append([
                    {
                        key: "socks",
-                       iconSource: ModelsData.tokens.socks,
+                       iconSource: ModelsData.assets.socks,
                        name: "Unisocks",
                        shortName: "SOCKS",
-                       category: "Community tokens"
+                       category: "Community assets"
                    },
                    {
                        key: "zrx",
-                       iconSource: ModelsData.tokens.zrx,
+                       iconSource: ModelsData.assets.zrx,
                        name: "Ox",
                        shortName: "ZRX",
-                       category: "Listed tokens"
+                       category: "Listed assets"
                    },
                    {
                        key: "1inch",
-                       iconSource: ModelsData.tokens.inch,
+                       iconSource: ModelsData.assets.inch,
                        name: "1inch",
                        shortName: "ZRX",
-                       category: "Listed tokens"
+                       category: "Listed assets"
                    },
                    {
                        key: "Aave",
-                       iconSource: ModelsData.tokens.aave,
+                       iconSource: ModelsData.assets.aave,
                        name: "Aave",
                        shortName: "AAVE",
-                       category: "Listed tokens"
+                       category: "Listed assets"
                    },
                    {
                        key: "Amp",
-                       iconSource: ModelsData.tokens.amp,
+                       iconSource: ModelsData.assets.amp,
                        name: "Amp",
                        shortName: "AMP",
-                       category: "Listed tokens"
+                       category: "Listed assets"
                    }
                ])
 }

--- a/storybook/src/Models/ModelsData.qml
+++ b/storybook/src/Models/ModelsData.qml
@@ -33,7 +33,7 @@ QtObject {
                             "Software dev":"👩‍💻","Sports":"⚽️","Tech":"📱","Travel":"🗺","Vehicles":"🚕","Web3":"🌐"})
 
 
-    readonly property QtObject tokens: QtObject {
+    readonly property QtObject assets: QtObject {
         readonly property string socks: Style.png("tokens/SOCKS")
         readonly property string zrx: Style.png("tokens/ZRX")
         readonly property string inch: Style.png("tokens/CUSTOM-TOKEN")

--- a/storybook/src/Models/PermissionsModel.qml
+++ b/storybook/src/Models/PermissionsModel.qml
@@ -35,19 +35,19 @@ ListModel {
         var holdings = []
         holdings.push({
                           operator: OperatorsUtils.Operators.None,
-                          type: HoldingTypes.Type.Token,
+                          type: HoldingTypes.Type.Asset,
                           key: "SOCKS",
                           name: "SOCKS",
                           amount: 1.2,
-                          imageSource: ModelsData.tokens.socks
+                          imageSource: ModelsData.assets.socks
                       });
         holdings.push({
                           operator: OperatorsUtils.Operators.Or,
-                          type: HoldingTypes.Type.Token,
+                          type: HoldingTypes.Type.Asset,
                           key: "ZRX",
                           name: "ZRX",
                           amount: 15,
-                          imageSource: ModelsData.tokens.zrx
+                          imageSource: ModelsData.assets.zrx
                       });
         holdings.push({
                           operator: OperatorsUtils.Operators.And,
@@ -76,7 +76,7 @@ ListModel {
                           key: "AMP",
                           name: "AMP",
                           amount: 11,
-                          imageSource: ModelsData.tokens.amp
+                          imageSource: ModelsData.assets.amp
                       });
         return holdings
     }
@@ -85,12 +85,12 @@ ListModel {
         var channels = []
         channels.push({
                           key: "help",
-                          iconSource: ModelsData.tokens.zrx,
+                          iconSource: ModelsData.assets.zrx,
                           name: "#help"
                       });
         channels.push({
                           key: "faq",
-                          iconSource: ModelsData.tokens.zrx,
+                          iconSource: ModelsData.assets.zrx,
                           name: "#faq"
                       });
         return channels
@@ -100,12 +100,12 @@ ListModel {
         var channels = []
         channels.push({
                           key: "welcome",
-                          iconSource: ModelsData.tokens.inch,
+                          iconSource: ModelsData.assets.inch,
                           name: "#welcome"
                       });
         channels.push({
                           key: "general",
-                          iconSource: ModelsData.tokens.inch,
+                          iconSource: ModelsData.assets.inch,
                           name: "#general"
                       });
         return channels

--- a/storybook/src/Models/qmldir
+++ b/storybook/src/Models/qmldir
@@ -2,8 +2,8 @@ singleton ModelsData 1.0 ModelsData.qml
 IconModel 1.0 IconModel.qml
 BannerModel 1.0 BannerModel.qml
 UsersModel 1.0 UsersModel.qml
-TokensModel 1.0 TokensModel.qml
+AssetsModel 1.0 AssetsModel.qml
 CollectiblesModel 1.0 CollectiblesModel.qml
 ChannelsModel 1.0 ChannelsModel.qml
 PermissionsModel 1.0 PermissionsModel.qml
-TokensCollectiblesIconsModel 1.0 TokensCollectiblesIconsModel.qml
+AssetsCollectiblesIconsModel 1.0 AssetsCollectiblesIconsModel.qml

--- a/ui/app/AppLayouts/Chat/controls/community/AssetsPanel.qml
+++ b/ui/app/AppLayouts/Chat/controls/community/AssetsPanel.qml
@@ -10,8 +10,8 @@ import shared.controls 1.0
 ColumnLayout {
     id: root
 
-    property alias tokenName: pickerButton.text
-    property url tokenImage
+    property alias assetName: pickerButton.text
+    property url assetImage
     property alias amountText: amountInput.text
     property alias amount: amountInput.amount
     readonly property bool amountValid: amountInput.valid && amountInput.text.length > 0
@@ -33,7 +33,7 @@ ColumnLayout {
         bgColor: Theme.palette.baseColor5
         contentColor: Theme.palette.directColor1
         font.pixelSize: 13
-        asset.name: root.tokenImage
+        asset.name: root.assetImage
 
         onClicked: pickerClicked()
     }

--- a/ui/app/AppLayouts/Chat/controls/community/ExtendedDropdownContent.qml
+++ b/ui/app/AppLayouts/Chat/controls/community/ExtendedDropdownContent.qml
@@ -16,14 +16,14 @@ Item {
     id: root
 
     property var store
-    property int type: ExtendedDropdownContent.Type.Tokens
+    property int type: ExtendedDropdownContent.Type.Assets
 
     readonly property bool canGoBack: root.state !== d.listView_depth1_State
 
     signal itemClicked(string key, string name, url iconSource)
 
     enum Type{
-        Tokens,
+        Assets,
         Collectibles
     }
 
@@ -76,13 +76,13 @@ Item {
 
             PropertyChanges {
                 target: contentLoader
-                sourceComponent: root.type === ExtendedDropdownContent.Type.Tokens
-                                 ? tokensListView : collectiblesListView
+                sourceComponent: root.type === ExtendedDropdownContent.Type.Assets
+                                 ? assetsListView : collectiblesListView
             }
             PropertyChanges {
                 target: d
-                currentModel: root.type === ExtendedDropdownContent.Type.Tokens
-                              ? root.store.tokensModel : collectiblesFilteredModel//root.store.collectiblesModel
+                currentModel: root.type === ExtendedDropdownContent.Type.Assets
+                              ? root.store.assetsModel : collectiblesFilteredModel//root.store.collectiblesModel
                 isFilterOptionVisible: false
             }
             PropertyChanges {
@@ -257,18 +257,18 @@ Item {
     }
 
     Component {
-        id: tokensListView
+        id: assetsListView
 
         ListDropdownContent {
             headerModel: ListModel {
-                ListElement { key: "MINT"; icon: "add"; iconSize: 16; description: qsTr("Mint token"); rotation: 0; spacing: 8 }
-                ListElement { key: "IMPORT"; icon: "invite-users"; iconSize: 16; description: qsTr("Import existing token"); rotation: 180; spacing: 8 }
+                ListElement { key: "MINT"; icon: "add"; iconSize: 16; description: qsTr("Mint asset"); rotation: 0; spacing: 8 }
+                ListElement { key: "IMPORT"; icon: "invite-users"; iconSize: 16; description: qsTr("Import existing asset"); rotation: 180; spacing: 8 }
             }
             isHeaderVisible: false  // TEMPORARILY hidden. These 2 header options will be implemented after MVP.
             model: d.currentModel
             onHeaderItemClicked: {
-                if(key === "MINT") console.log("TODO: Mint token")
-                else if(key === "IMPORT") console.log("TODO: Import existing token")
+                if(key === "MINT") console.log("TODO: Mint asset")
+                else if(key === "IMPORT") console.log("TODO: Import existing asset")
             }
             onItemClicked: root.itemClicked(key, shortName, iconSource)
         }

--- a/ui/app/AppLayouts/Chat/controls/community/HoldingTypes.qml
+++ b/ui/app/AppLayouts/Chat/controls/community/HoldingTypes.qml
@@ -2,6 +2,6 @@ import QtQml 2.14
 
 QtObject {
     enum Type {
-        Token, Collectible, Ens
+        Asset, Collectible, Ens
     }
 }

--- a/ui/app/AppLayouts/Chat/controls/community/HoldingsDropdown.qml
+++ b/ui/app/AppLayouts/Chat/controls/community/HoldingsDropdown.qml
@@ -15,8 +15,8 @@ StatusDropdown {
 
     property var store
 
-    property string tokenKey: ""
-    property real tokenAmount: 0
+    property string assetKey: ""
+    property real assetAmount: 0
 
     property string collectibleKey: ""
     property real collectibleAmount: 1
@@ -25,24 +25,24 @@ StatusDropdown {
     property int ensType: EnsPanel.EnsType.Any
     property string ensDomainName: ""
 
-    signal addToken(string key, real amount)
+    signal addAsset(string key, real amount)
     signal addCollectible(string key, real amount)
     signal addEns(bool any, string customDomain)
 
-    signal updateToken(string key, real amount)
+    signal updateAsset(string key, real amount)
     signal updateCollectible(string key, real amount)
     signal updateEns(bool any, string customDomain)
 
     signal removeClicked
 
     function reset() {
-        d.currentHoldingType = HoldingTypes.Type.Token
-        d.tokenAmountText = ""
+        d.currentHoldingType = HoldingTypes.Type.Asset
+        d.assetAmountText = ""
         d.collectibleAmountText = ""
 
-        root.tokenKey = ""
+        root.assetKey = ""
         root.collectibleKey = ""
-        root.tokenAmount = 0
+        root.assetAmount = 0
         root.collectibleAmount = 1
         root.collectiblesSpecificAmount = false
         root.ensType = EnsPanel.EnsType.Any
@@ -87,7 +87,7 @@ StatusDropdown {
         id: d
 
         // Internal management properties and signals:
-        readonly property bool tokensReady: root.tokenAmount > 0 && root.tokenKey
+        readonly property bool assetsReady: root.assetAmount > 0 && root.assetKey
         readonly property bool collectiblesReady: root.collectibleAmount > 0 && root.collectibleKey
         readonly property bool ensReady: root.ensType === EnsPanel.EnsType.Any || d.ensDomainNameValid
 
@@ -96,12 +96,12 @@ StatusDropdown {
         readonly property string extendedState: "EXTENDED"
 
         property int holdingsTabMode: HoldingsTabs.Mode.Add
-        property int extendedDropdownType: ExtendedDropdownContent.Type.Tokens
+        property int extendedDropdownType: ExtendedDropdownContent.Type.Assets
 
-        property string tokenAmountText: ""
+        property string assetAmountText: ""
         property string collectibleAmountText: ""
 
-        property int currentHoldingType: HoldingTypes.Type.Token
+        property int currentHoldingType: HoldingTypes.Type.Asset
 
         property bool ensDomainNameValid: false
 
@@ -125,7 +125,7 @@ StatusDropdown {
         readonly property int backButtonHeight: 24
         readonly property int backButtonToContentSpace: 8
 
-        readonly property string defaultTokenNameText: qsTr("Choose token")
+        readonly property string defaultAssetNameText: qsTr("Choose asset")
         readonly property string defaultCollectibleNameText: qsTr("Choose collectible")
     }
 
@@ -209,9 +209,9 @@ StatusDropdown {
             id: holdingsTabs
 
             readonly property var holdingTypes: [
-                HoldingTypes.Type.Token, HoldingTypes.Type.Collectible, HoldingTypes.Type.Ens
+                HoldingTypes.Type.Asset, HoldingTypes.Type.Collectible, HoldingTypes.Type.Ens
             ]
-            readonly property var labels: [qsTr("Token"), qsTr("Collectible"), qsTr("ENS")]
+            readonly property var labels: [qsTr("Asset"), qsTr("Collectible"), qsTr("ENS")]
 
             readonly property bool extendedHeight:
                 d.currentHoldingType === HoldingTypes.Type.Collectible && collectiblesSpecificAmount ||
@@ -223,8 +223,8 @@ StatusDropdown {
 
             states: [
                 State {
-                    name: HoldingTypes.Type.Token
-                    PropertyChanges {target: holdingsTabs; sourceComponent: tokensLayout; addOrUpdateButtonEnabled: d.tokensReady}
+                    name: HoldingTypes.Type.Asset
+                    PropertyChanges {target: holdingsTabs; sourceComponent: assetsLayout; addOrUpdateButtonEnabled: d.assetsReady}
                 },
                 State {
                     name: HoldingTypes.Type.Collectible
@@ -258,52 +258,52 @@ StatusDropdown {
     }
 
     Component {
-        id: tokensLayout
+        id: assetsLayout
 
-        TokensPanel {
-            id: tokensPanel
+        AssetsPanel {
+            id: assetsPanel
 
-            tokenName: d.defaultTokenNameText
-            amountText: d.tokenAmountText
-            onAmountTextChanged: d.tokenAmountText = amountText
+            assetName: d.defaultAssetNameText
+            amountText: d.assetAmountText
+            onAmountTextChanged: d.assetAmountText = amountText
 
             readonly property real effectiveAmount: amountValid ? amount : 0
-            onEffectiveAmountChanged: root.tokenAmount = effectiveAmount
+            onEffectiveAmountChanged: root.assetAmount = effectiveAmount
 
             onPickerClicked: {
-                d.extendedDropdownType = ExtendedDropdownContent.Type.Tokens
+                d.extendedDropdownType = ExtendedDropdownContent.Type.Assets
                 statesStack.push(d.extendedState)
             }
 
-            readonly property string tokenKey: root.tokenKey
+            readonly property string assetKey: root.assetKey
 
-            onTokenKeyChanged: {
-                const modelItem = CommunityPermissionsHelpers.getTokenByKey(
-                                    store.tokensModel, tokenKey)
+            onAssetKeyChanged: {
+                const modelItem = CommunityPermissionsHelpers.getAssetByKey(
+                                    store.assetsModel, assetKey)
 
                 if (modelItem) {
-                    tokensPanel.tokenName = modelItem.shortName
-                    tokensPanel.tokenImage = modelItem.iconSource
+                    assetsPanel.assetName = modelItem.shortName
+                    assetsPanel.assetImage = modelItem.iconSource
                 } else {
-                    tokensPanel.tokenName = d.defaultTokenNameText
-                    tokensPanel.tokenImage = ""
+                    assetsPanel.assetName = d.defaultAssetNameText
+                    assetsPanel.assetImage = ""
                 }
             }
 
             Component.onCompleted: {
-                if (d.tokenAmountText.length === 0 && root.tokenAmount)
-                    tokensPanel.setAmount(root.tokenAmount)
+                if (d.assetAmountText.length === 0 && root.assetAmount)
+                    assetsPanel.setAmount(root.assetAmount)
             }
 
             Connections {
                 target: d
 
                 function onAddClicked() {
-                    root.addToken(root.tokenKey, root.tokenAmount)
+                    root.addAsset(root.assetKey, root.assetAmount)
                 }
 
                 function onUpdateClicked() {
-                    root.updateToken(root.tokenKey, root.tokenAmount)
+                    root.updateAsset(root.assetKey, root.assetAmount)
                 }
             }
         }
@@ -405,8 +405,8 @@ StatusDropdown {
             onItemClicked: {
                 statesStack.pop()
 
-                if(d.extendedDropdownType === ExtendedDropdownContent.Type.Tokens)
-                    root.tokenKey = key
+                if(d.extendedDropdownType === ExtendedDropdownContent.Type.Assets)
+                    root.assetKey = key
                 else
                     root.collectibleKey = key
             }

--- a/ui/app/AppLayouts/Chat/helpers/CommunityPermissionsHelpers.qml
+++ b/ui/app/AppLayouts/Chat/helpers/CommunityPermissionsHelpers.qml
@@ -17,8 +17,8 @@ QtObject {
         }
     }
 
-    function getTokenByKey(tokensModel, key) {
-        return d.getByKey(tokensModel, key)
+    function getAssetByKey(assetsModel, key) {
+        return d.getByKey(assetsModel, key)
     }
 
     function getCollectibleByKey(collectiblesModel, key) {

--- a/ui/app/AppLayouts/Chat/stores/CommunitiesStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/CommunitiesStore.qml
@@ -10,12 +10,12 @@ QtObject {
     property var permissionsModel: ListModel {} // Backend permissions list object model asignement. Please check the current expected data in qml defined in `createPermissions` method
 
     // TODO: Replace to real data, now dummy model
-    property var  tokensModel: ListModel {
-        ListElement {key: "socks"; iconSource: "qrc:imports/assets/png/tokens/SOCKS.png"; name: "Unisocks"; shortName: "SOCKS"; category: "Community tokens"}
-        ListElement {key: "zrx"; iconSource: "qrc:imports/assets/png/tokens/ZRX.png"; name: "Ox"; shortName: "ZRX"; category: "Listed tokens"}
-        ListElement {key: "1inch"; iconSource: "qrc:imports/assets/png/tokens/CUSTOM-TOKEN.png"; name: "1inch"; shortName: "ZRX"; category: "Listed tokens"}
-        ListElement {key: "Aave"; iconSource: "qrc:imports/assets/png/tokens/CUSTOM-TOKEN.png"; name: "Aave"; shortName: "AAVE"; category: "Listed tokens"}
-        ListElement {key: "Amp"; iconSource: "qrc:imports/assets/png/tokens/CUSTOM-TOKEN.png"; name: "Amp"; shortName: "AMP"; category: "Listed tokens"}
+    property var  assetsModel: ListModel {
+        ListElement {key: "socks"; iconSource: "qrc:imports/assets/png/tokens/SOCKS.png"; name: "Unisocks"; shortName: "SOCKS"; category: "Community assets"}
+        ListElement {key: "zrx"; iconSource: "qrc:imports/assets/png/tokens/ZRX.png"; name: "Ox"; shortName: "ZRX"; category: "Listed assets"}
+        ListElement {key: "1inch"; iconSource: "qrc:imports/assets/png/tokens/CUSTOM-TOKEN.png"; name: "1inch"; shortName: "ZRX"; category: "Listed assets"}
+        ListElement {key: "Aave"; iconSource: "qrc:imports/assets/png/tokens/CUSTOM-TOKEN.png"; name: "Aave"; shortName: "AAVE"; category: "Listed assets"}
+        ListElement {key: "Amp"; iconSource: "qrc:imports/assets/png/tokens/CUSTOM-TOKEN.png"; name: "Amp"; shortName: "AMP"; category: "Listed assets"}
     }
 
     // TODO: Replace to real data, now dummy model
@@ -135,7 +135,7 @@ QtObject {
 
     function setHoldingsTextFormat(type, name, amount) {
         switch (type) {
-            case HoldingTypes.Type.Token:
+            case HoldingTypes.Type.Asset:
             case HoldingTypes.Type.Collectible:
                 return `${LocaleUtils.numberToLocaleString(amount)} ${name}`
             case HoldingTypes.Type.Ens:

--- a/ui/app/AppLayouts/Chat/views/communities/CommunityNewPermissionView.qml
+++ b/ui/app/AppLayouts/Chat/views/communities/CommunityNewPermissionView.qml
@@ -216,10 +216,10 @@ StatusScrollView {
                     d.dirtyValues.holdingsModel.append({ type, key, name, amount, imageSource })
                 }
 
-                onAddToken: {
-                    const modelItem = CommunityPermissionsHelpers.getTokenByKey(
-                                        store.tokensModel, key)
-                    addItem(HoldingTypes.Type.Token, modelItem, amount)
+                onAddAsset: {
+                    const modelItem = CommunityPermissionsHelpers.getAssetByKey(
+                                        store.assetsModel, key)
+                    addItem(HoldingTypes.Type.Asset, modelItem, amount)
                     dropdown.close()
                 }
 
@@ -239,13 +239,13 @@ StatusScrollView {
                     dropdown.close()
                 }
 
-                onUpdateToken: {
-                    const modelItem = CommunityPermissionsHelpers.getTokenByKey(
-                                        store.tokensModel, key)
+                onUpdateAsset: {
+                    const modelItem = CommunityPermissionsHelpers.getAssetByKey(
+                                        store.assetsModel, key)
                     const name = modelItem.shortName ? modelItem.shortName : modelItem.name
                     const imageSource = modelItem.iconSource.toString()
 
-                    d.dirtyValues.holdingsModel.set(tokensSelector.editedIndex, { type: HoldingTypes.Type.Token, key, name, amount, imageSource })
+                    d.dirtyValues.holdingsModel.set(tokensSelector.editedIndex, { type: HoldingTypes.Type.Asset, key, name, amount, imageSource })
                     d.triggerDirtyTool = !d.triggerDirtyTool
                     dropdown.close()
                 }
@@ -295,9 +295,9 @@ StatusScrollView {
                 const modelItem = tokensSelector.itemsModel.get(index)
 
                 switch(modelItem.type) {
-                    case HoldingTypes.Type.Token:
-                        dropdown.tokenKey = modelItem.key
-                        dropdown.tokenAmount = modelItem.amount
+                    case HoldingTypes.Type.Asset:
+                        dropdown.assetKey = modelItem.key
+                        dropdown.assetAmount = modelItem.amount
                         break
                     case HoldingTypes.Type.Collectible:
                         dropdown.collectibleKey = modelItem.key


### PR DESCRIPTION
Fixes #8816

### What does the PR do
- It updates enumerators that were defining `tokens` instead of `assets`.
- It updates property names and labels.
- It updates signals and components names.
- It updates storybook.

### Affected areas

The only visual change is in  `Community Permissions/How holds dropdown`.
Internal changes - `Community Permissions` flow and related `storybook` pages.

### Screenshot of functionality 

![Screenshot 2023-01-12 at 15 10 14](https://user-images.githubusercontent.com/97019400/212088915-e6e51320-da60-4ac0-a2c4-99b118ce4380.png)

![Screenshot 2023-01-12 at 15 15 05](https://user-images.githubusercontent.com/97019400/212089669-e45a7524-ae3e-4979-95aa-363b805300b0.png)

