### PR TITLE
perf(chatScroll): Create message quick context items only when message row is hovered

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
@@ -23,7 +23,7 @@ Control {
         Invitation = 7
     }
 
-    property alias quickActions: quickActionsPanel.items
+    property list<Item> quickActions
     property var statusChatInput
     property alias linksComponent: linksLoader.sourceComponent
     property alias transcationComponent: transactionBubbleLoader.sourceComponent
@@ -365,13 +365,18 @@ Control {
             }
         }
 
-        StatusMessageQuickActions {
-            id: quickActionsPanel
+        Loader {
+            active: root.hovered && !root.hideQuickActions
             anchors.right: parent.right
             anchors.rightMargin: 20
             anchors.top: parent.top
             anchors.topMargin: -8
-            visible: root.hovered && !root.hideQuickActions
+            sourceComponent: Component {
+                StatusMessageQuickActions {
+                    id: quickActionsPanel
+                    items: root.quickActions
+                }
+            }
         }
     }
 

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -743,7 +743,7 @@ Loader {
 
                 quickActions: [
                     Loader {
-                        active: !root.isInPinnedPopup
+                        active: !root.isInPinnedPopup && delegate.hovered
                         sourceComponent: StatusFlatRoundButton {
                             width: d.chatButtonSize
                             height: d.chatButtonSize
@@ -757,7 +757,7 @@ Loader {
                         }
                     },
                     Loader {
-                        active: !root.isInPinnedPopup
+                        active: !root.isInPinnedPopup && delegate.hovered
                         sourceComponent: StatusFlatRoundButton {
                             objectName: "replyToMessageButton"
                             width: d.chatButtonSize
@@ -774,7 +774,7 @@ Loader {
                         }
                     },
                     Loader {
-                        active: !root.isInPinnedPopup && root.isText && !root.editModeOn && root.amISender
+                        active: !root.isInPinnedPopup && root.isText && !root.editModeOn && root.amISender && delegate.hovered
                         visible: active
                         sourceComponent: StatusFlatRoundButton {
                             objectName: "editMessageButton"
@@ -790,6 +790,9 @@ Loader {
                     },
                     Loader {
                         active: {
+                            if(!delegate.hovered)
+                                return false;
+                                
                             if (!root.messageStore)
                                 return false
 
@@ -835,6 +838,8 @@ Loader {
                     },
                     Loader {
                         active: {
+                            if(!delegate.hovered)
+                                return false;
                             if (root.isInPinnedPopup)
                                 return false;
                             if (!root.messageStore)


### PR DESCRIPTION
### What does the PR do

Part of #3067 
Depends on #9031. In #9031 the hover is disabled while scrolling. This means the quick action Items will not be created at all while scrolling.

Create quick action Items only when needed.

### Affected areas

Chat history quick actions
