### PR TITLE
fix(@desktop/wallet): Remove the 'Load More' button from the Activity view

### DIFF
--- a/src/app/modules/main/wallet_section/transactions/controller.nim
+++ b/src/app/modules/main/wallet_section/transactions/controller.nim
@@ -82,7 +82,7 @@ proc init*(self: Controller) =
 
   self.events.on(SIGNAL_TRANSACTION_LOADING_COMPLETED_FOR_ALL_NETWORKS) do(e:Args):
     let args = TransactionsLoadedArgs(e)
-    self.delegate.setHistoryFetchState(args.address, isFetching = false)
+    self.delegate.setHistoryFetchState(args.address, args.allTxLoaded, isFetching = false)
 
   self.events.on(SIGNAL_CURRENCY_FORMATS_UPDATED) do(e:Args):
     # TODO: Rebuild Transaction items

--- a/src/app/modules/main/wallet_section/transactions/io_interface.nim
+++ b/src/app/modules/main/wallet_section/transactions/io_interface.nim
@@ -34,7 +34,7 @@ method setTrxHistoryResult*(self: AccessInterface, transactions: seq[Transaction
 method setHistoryFetchState*(self: AccessInterface, addresses: seq[string], isFetching: bool) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method setHistoryFetchState*(self: AccessInterface, address: string, isFetching: bool) {.base.} =
+method setHistoryFetchState*(self: AccessInterface, address: string, allTxLoaded: bool, isFetching: bool) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method setIsNonArchivalNode*(self: AccessInterface, isNonArchivalNode: bool) {.base.} =

--- a/src/app/modules/main/wallet_section/transactions/item.nim
+++ b/src/app/modules/main/wallet_section/transactions/item.nim
@@ -29,6 +29,7 @@ type
     totalFees: CurrencyAmount
     maxTotalFees: CurrencyAmount
     symbol: string
+    loadingTransaction: bool
 
 proc initItem*(
   id: string,
@@ -56,7 +57,8 @@ proc initItem*(
   baseGasFees: CurrencyAmount,
   totalFees: CurrencyAmount,
   maxTotalFees: CurrencyAmount,
-  symbol: string
+  symbol: string,
+  loadingTransaction: bool = false
 ): Item =
   result.id = id
   result.typ = typ
@@ -84,6 +86,7 @@ proc initItem*(
   result.totalFees = totalFees
   result.maxTotalFees = maxTotalFees
   result.symbol = symbol
+  result.loadingTransaction = loadingTransaction
 
 proc initTimestampItem*(timestamp: int): Item =
   result.timestamp = timestamp
@@ -97,6 +100,20 @@ proc initTimestampItem*(timestamp: int): Item =
   result.baseGasFees = newCurrencyAmount()
   result.totalFees = newCurrencyAmount()
   result.maxTotalFees = newCurrencyAmount()
+
+proc initLoadingItem*(): Item =
+  result.timestamp = 0
+  result.gasPrice = newCurrencyAmount()
+  result.value = newCurrencyAmount()
+  result.chainId = 0
+  result.maxFeePerGas = newCurrencyAmount()
+  result.maxPriorityFeePerGas = newCurrencyAmount()
+  result.multiTransactionID = 0
+  result.isTimeStamp = false
+  result.baseGasFees = newCurrencyAmount()
+  result.totalFees = newCurrencyAmount()
+  result.maxTotalFees = newCurrencyAmount()
+  result.loadingTransaction = true
 
 proc `$`*(self: Item): string =
   result = fmt"""AllTokensItem(
@@ -126,6 +143,7 @@ proc `$`*(self: Item): string =
     totalFees: {self.totalFees},
     maxTotalFees: {self.maxTotalFees},
     symbol: {self.symbol},
+    loadingTransaction: {self.loadingTransaction},
     ]"""
 
 proc getId*(self: Item): string =
@@ -205,3 +223,6 @@ proc  getMaxTotalFees*(self: Item): CurrencyAmount =
 
 proc  getSymbol*(self: Item): string =
   return self.symbol
+
+proc  getLoadingTransaction*(self: Item): bool =
+  return self.loadingTransaction

--- a/src/app/modules/main/wallet_section/transactions/module.nim
+++ b/src/app/modules/main/wallet_section/transactions/module.nim
@@ -115,8 +115,8 @@ method setTrxHistoryResult*(self: Module, transactions: seq[TransactionDto], add
 method setHistoryFetchState*(self: Module, addresses: seq[string], isFetching: bool) =
   self.view.setHistoryFetchStateForAccounts(addresses, isFetching)
 
-method setHistoryFetchState*(self: Module, address: string, isFetching: bool) =
-  self.view.setHistoryFetchState(address, isFetching)
+method setHistoryFetchState*(self: Module, address: string, allTxLoaded: bool, isFetching: bool) =
+  self.view.setHistoryFetchState(address, allTxLoaded, isFetching)
 
 method setIsNonArchivalNode*(self: Module, isNonArchivalNode: bool) =
   self.view.setIsNonArchivalNode(isNonArchivalNode)

--- a/src/app/modules/main/wallet_section/transactions/view.nim
+++ b/src/app/modules/main/wallet_section/transactions/view.nim
@@ -48,14 +48,15 @@ QtObject:
 
   proc loadingTrxHistoryChanged*(self: View, isLoading: bool, address: string) {.signal.}
 
-  proc setHistoryFetchState*(self: View, address: string, isFetching: bool) =
+  proc setHistoryFetchState*(self: View, address: string, allTxLoaded: bool, isFetching: bool) =
+    if self.models.hasKey(address):
+      if not isFetching:
+        self.models[address].removePageSizeBuffer()
+      elif isFetching and self.models[address].getCount() == 0:
+        self.models[address].addPageSizeBuffer(20)
+      self.models[address].setHasMore(not allTxLoaded)
     self.fetchingHistoryState[address] = isFetching
     self.loadingTrxHistoryChanged(isFetching, address)
-
-  proc setHistoryFetchState*(self: View, accounts: seq[string], isFetching: bool) =
-    for acc in accounts:
-      self.fetchingHistoryState[acc] = isFetching
-      self.loadingTrxHistoryChanged(isFetching, acc)
 
   proc isFetchingHistory*(self: View, address: string): bool {.slot.} =
     if self.fetchingHistoryState.hasKey(address):
@@ -66,7 +67,9 @@ QtObject:
     return self.model.getCount() > 0
 
   proc loadTransactionsForAccount*(self: View, address: string, toBlock: string = "0x0", limit: int = 20, loadMore: bool = false) {.slot.} =
-    self.setHistoryFetchState(address, true)
+    if self.models.hasKey(address):
+      self.setHistoryFetchState(address, allTxLoaded=not self.models[address].getHasMore(), isFetching=true)
+      self.models[address].addPageSizeBuffer(limit)
     self.delegate.loadTransactions(address, toBlock, limit, loadMore)
 
   proc setTrxHistoryResult*(self: View, transactions: seq[Item], address: string, wasFetchMore: bool) =
@@ -74,10 +77,15 @@ QtObject:
       self.models[address] = newModel()
 
     self.models[address].addNewTransactions(transactions, wasFetchMore)
+    if self.fetchingHistoryState.hasKey(address) and self.fetchingHistoryState[address] and wasFetchMore:
+      self.models[address].addPageSizeBuffer(transactions.len)
 
   proc setHistoryFetchStateForAccounts*(self: View, addresses: seq[string], isFetching: bool) =
     for address in addresses:
-      self.setHistoryFetchState(address, isFetching)
+      if self.models.hasKey(address):
+        self.setHistoryFetchState(address, allTxLoaded = not self.models[address].getHasMore(), isFetching)
+      else:
+        self.setHistoryFetchState(address, allTxLoaded = false, isFetching)
 
   proc setModel*(self: View, address: string) {.slot.} =
     if not self.models.hasKey(address):
@@ -165,4 +173,4 @@ QtObject:
       let fromAddress = tx.getfrom()
       if not self.models.hasKey(fromAddress):
         self.models[fromAddress] = newModel()
-      self.models[fromAddress].addNewTransactions(@[tx], false)
+      self.models[fromAddress].addNewTransactions(@[tx], wasFetchMore=false)

--- a/src/app_service/service/transaction/async_tasks.nim
+++ b/src/app_service/service/transaction/async_tasks.nim
@@ -17,16 +17,19 @@ type
     toBlock: Uint256
     limit: int
     loadMore: bool
+    allTxLoaded: bool
 
 const loadTransactionsTask*: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
   let
     arg = decode[LoadTransactionsTaskArg](argEncoded)
     limitAsHex = "0x" & eth_utils.stripLeadingZeros(arg.limit.toHex)
+    response = transactions.getTransfersByAddress(arg.chainId, arg.address, arg.toBlock, limitAsHex, arg.loadMore).result
     output = %*{
       "address": arg.address,
       "chainId": arg.chainId,
-      "history": transactions.getTransfersByAddress(arg.chainId, arg.address, arg.toBlock, limitAsHex, arg.loadMore),
+      "history": response,
       "loadMore": arg.loadMore,
+      "allTxLoaded": response.getElems().len < arg.limit
     }
   arg.finish(output)
 

--- a/ui/StatusQ/src/StatusQ/Components/StatusListItem.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusListItem.qml
@@ -281,7 +281,6 @@ Rectangle {
                     lineHeight: 24
 
                     visible: inlineTagModelRepeater.count > 0
-                    loading: statusListItem.loading
                 }
 
                 StatusScrollView {

--- a/ui/app/AppLayouts/Wallet/views/AssetsDetailView.qml
+++ b/ui/app/AppLayouts/Wallet/views/AssetsDetailView.qml
@@ -369,9 +369,15 @@ Item {
                             Layout.alignment: detailsFlow.isOverflowing ? Qt.AlignLeft : Qt.AlignRight
                             iconAsset.icon: "browser"
                             tagPrimaryLabel.text: qsTr("Website")
-                            controlBackground.color: Theme.palette.baseColor2
-                            controlBackground.border.color: "transparent"
                             visible: typeof token != "undefined" && token && token.assetWebsiteUrl !== ""
+                            customBackground: Component {
+                                Rectangle {
+                                    color: Theme.palette.baseColor2
+                                    border.width: 1
+                                    border.color: "transparent"
+                                    radius: 36
+                                }
+                            }
                             MouseArea {
                                 anchors.fill: parent
                                 cursorShape: Qt.PointingHandCursor
@@ -385,9 +391,15 @@ Item {
                             image.source: token  && token.builtOn !== "" ? Style.svg("tiny/" + RootStore.getNetworkIconUrl(token.builtOn)) : ""
                             tagPrimaryLabel.text: token && token.builtOn !== "" ? RootStore.getNetworkName(token.builtOn) : "---"
                             tagSecondaryLabel.text: token && token.address !== "" ? token.address : "---"
-                            controlBackground.color: Theme.palette.baseColor2
-                            controlBackground.border.color: "transparent"
                             visible: typeof token != "undefined" && token && token.builtOn !== "" && token.address !== ""
+                            customBackground: Component {
+                                Rectangle {
+                                    color: Theme.palette.baseColor2
+                                    border.width: 1
+                                    border.color: "transparent"
+                                    radius: 36
+                                }
+                            }
                         }
                     }
                 }

--- a/ui/imports/shared/controls/InformationTag.qml
+++ b/ui/imports/shared/controls/InformationTag.qml
@@ -4,30 +4,44 @@ import QtQuick.Controls 2.14
 
 import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
+import StatusQ.Components 0.1
 
 import utils 1.0
 
 Control {
+    id: root
+
     property alias image : image
     property alias iconAsset : iconAsset
     property alias tagPrimaryLabel: tagPrimaryLabel
     property alias tagSecondaryLabel: tagSecondaryLabel
-    property alias controlBackground: controlBackground
     property alias rightComponent: rightComponent.sourceComponent
+    property bool loading: false
+
+    property Component customBackground: Component {
+        Rectangle {
+            color: "transparent"
+            border.width: 1
+            border.color: Theme.palette.baseColor2
+            radius: 36
+        }
+    }
+
+    QtObject {
+        id: d
+        property var loadingComponent: Component { LoadingComponent {}}
+    }
 
     horizontalPadding: Style.current.halfPadding
     verticalPadding: 5
 
-    background: Rectangle {
-        id: controlBackground
-        color: "transparent"
-        border.width: 1
-        border.color: Theme.palette.baseColor2
-        radius: 36
+    background: Loader {
+        sourceComponent: root.loading ? d.loadingComponent : root.customBackground
     }
 
     contentItem: RowLayout {
         spacing: 4
+        visible: !root.loading
         // FIXME this could be StatusIcon but it can't load images from an arbitrary URL
         Image {
             id: image

--- a/ui/imports/shared/controls/TransactionDelegate.qml
+++ b/ui/imports/shared/controls/TransactionDelegate.qml
@@ -4,12 +4,16 @@ import QtQuick.Layouts 1.3
 import StatusQ.Components 0.1
 import StatusQ.Core.Theme 0.1
 import StatusQ.Core 0.1
+import StatusQ.Controls 0.1
 
 import utils 1.0
 import shared 1.0
 
 StatusListItem {
     id: root
+
+    property alias cryptoValueText: cryptoValueText
+    property alias fiatValueText: fiatValueText
 
     property var modelData
     property string symbol
@@ -24,8 +28,9 @@ StatusListItem {
     property string savedAddressName
 
     state: "normal"
-    asset.isImage: true
+    asset.isImage: !loading
     asset.name: root.symbol ? Style.png("tokens/%1".arg(root.symbol)) : ""
+    asset.isLetterIdenticon: loading
     title: modelData !== undefined && !!modelData ?
                isIncoming ? qsTr("Receive %1").arg(root.symbol) : !!savedAddressName ?
                             qsTr("Send %1 to %2").arg(root.symbol).arg(savedAddressName) :
@@ -36,16 +41,23 @@ StatusListItem {
         tagPrimaryLabel.text: networkName
         tagPrimaryLabel.color: networkColor
         image.source: !!networkIcon ? Style.svg("tiny/%1".arg(networkIcon)) : ""
-        background: Rectangle {
-            id: controlBackground
-            implicitWidth: 51
-            implicitHeight: 24
-            color: "transparent"
-            border.width: 1
-            border.color: Theme.palette.baseColor2
-            radius: 36
+        customBackground: Component {
+            Rectangle {
+                color: "transparent"
+                border.width: 1
+                border.color: Theme.palette.baseColor2
+                radius: 36
+            }
         }
+        width: 51
+        height: root.loading ? textMetrics.tightBoundingRect.height : 24
         rightComponent: transferStatus === Constants.TransactionStatus.Success ? completedIcon : loadingIndicator
+        loading: root.loading
+    }
+    TextMetrics {
+        id: textMetrics
+        font: statusListItemSubTitle.font
+        text: statusListItemSubTitle.text
     }
     components: [
         ColumnLayout {
@@ -57,18 +69,23 @@ StatusListItem {
                     icon: "arrow-up"
                     rotation: isIncoming ? 135 : 45
                     height: 18
+                    visible: !root.loading
                 }
-                StatusBaseText {
+                StatusTextWithLoadingState {
                     id: cryptoValueText
                     text: LocaleUtils.currencyAmountToLocaleString(cryptoValue)
-                    color: Theme.palette.directColor1
+                    customColor: Theme.palette.directColor1
+                    loading: root.loading
                 }
+
             }
-            StatusBaseText {
+            StatusTextWithLoadingState {
+                id: fiatValueText
                 Layout.alignment: Qt.AlignRight
                 text: LocaleUtils.currencyAmountToLocaleString(fiatValue)
                 font.pixelSize: 15
-                color: Theme.palette.baseColor1
+                customColor: Theme.palette.baseColor1
+                loading: root.loading
             }
         }
     ]


### PR DESCRIPTION
… view and replace with automatic loading when the user scrolls down using a skeleton loading state

fixes #8987

raised a follow up for a glitchy behaviour seen https://github.com/status-im/status-desktop/issues/9320

### What does the PR do

Implements loading state + load more behavior for the transaction view as defined in design https://www.figma.com/file/FkFClTCYKf83RJWoifWgoX/Wallet-v2?node-id=10401%3A122250&t=k58Oy9eh3MsUsFer-4

When the transactions are loading we should see loading item and then on scrolling if the user drags the list, it should fetch more transaction
 
### Affected areas

Wallet

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it



https://user-images.githubusercontent.com/60327365/214768818-edb499e6-4a74-4cd9-8f0b-872db68ecdb1.mov


