### PR TITLE
fix(@desktop): fix AmountInput locale

### DIFF
--- a/ui/app/AppLayouts/Chat/controls/community/CollectiblesPanel.qml
+++ b/ui/app/AppLayouts/Chat/controls/community/CollectiblesPanel.qml
@@ -17,7 +17,6 @@ ColumnLayout {
     property alias amountText: amountInput.text
     property alias amount: amountInput.amount
     readonly property bool amountValid: amountInput.valid && amountInput.text.length > 0
-    property var locale
 
     signal pickerClicked
 
@@ -67,7 +66,5 @@ ColumnLayout {
         Layout.topMargin: 8
 
         allowDecimals: false
-
-        locale: root.locale
     }
 }

--- a/ui/app/AppLayouts/Chat/controls/community/HoldingsDropdown.qml
+++ b/ui/app/AppLayouts/Chat/controls/community/HoldingsDropdown.qml
@@ -266,7 +266,6 @@ StatusDropdown {
             tokenName: d.defaultTokenNameText
             amountText: d.tokenAmountText
             onAmountTextChanged: d.tokenAmountText = amountText
-            locale: root.store.locale
 
             readonly property real effectiveAmount: amountValid ? amount : 0
             onEffectiveAmountChanged: root.tokenAmount = effectiveAmount
@@ -319,7 +318,6 @@ StatusDropdown {
             collectibleName: d.defaultCollectibleNameText
             amountText: d.collectibleAmountText
             onAmountTextChanged: d.collectibleAmountText = amountText
-            locale: root.store.locale
 
             readonly property real effectiveAmount: amountValid ? amount : 0
             onEffectiveAmountChanged: root.collectibleAmount = effectiveAmount

--- a/ui/app/AppLayouts/Chat/controls/community/TokensPanel.qml
+++ b/ui/app/AppLayouts/Chat/controls/community/TokensPanel.qml
@@ -15,7 +15,6 @@ ColumnLayout {
     property alias amountText: amountInput.text
     property alias amount: amountInput.amount
     readonly property bool amountValid: amountInput.valid && amountInput.text.length > 0
-    property var locale
 
     signal pickerClicked
 
@@ -44,7 +43,5 @@ ColumnLayout {
 
         Layout.fillWidth: true
         Layout.topMargin: 8
-
-        locale: root.locale
     }
 }

--- a/ui/imports/shared/controls/AmountInput.qml
+++ b/ui/imports/shared/controls/AmountInput.qml
@@ -10,7 +10,7 @@ Input {
     id: root
 
     property int maximumLength: 10
-    property var locale
+    property var locale: Qt.locale()
 
     readonly property alias amount: d.amount
     readonly property bool valid: validationError.length === 0


### PR DESCRIPTION
Fixes #9103

### What does the PR do

There was a missing locale setting introduced here https://github.com/status-im/status-go/pull/3079 for one component containing `AmountInput`, causing the input to be improperly validated.

It was fixed in https://github.com/status-im/status-desktop/pull/8995, but since that will take longer to  get merged I'm doing a hotfix here.

![Screenshot 2023-01-13 at 8 54 52 AM](https://user-images.githubusercontent.com/11161531/212314929-58319487-80c4-4c93-90be-91a5adc44105.png)
