### PR TITLE
test(@desktop/community): edit community tests - verify results only when the element is visible

### DIFF
--- a/test/ui-test/src/screens/StatusCommunityScreen.py
+++ b/test/ui-test/src/screens/StatusCommunityScreen.py
@@ -241,7 +241,6 @@ class StatusCommunityScreen:
     
     def open_edit_community_by_community_header(self):
         click_obj_by_name(CommunityScreenComponents.COMMUNITY_HEADER_BUTTON.value)
-        time.sleep(0.5) # wait for UI to load
         click_obj_by_name(CommunitySettingsComponents.EDIT_COMMUNITY_BUTTON.value)
         
     def change_community_name(self, new_community_name: str):
@@ -265,7 +264,6 @@ class StatusCommunityScreen:
     
     def save_community_changes(self):
         click_obj_by_name(CommunitySettingsComponents.SAVE_BUTTON.value)
-        time.sleep(0.5)
     
     def edit_community(self, new_community_name: str, new_community_description: str, new_community_color: str):
         self.open_edit_community_by_community_header()

--- a/test/ui-test/testSuites/suite_communities/shared/scripts/community_names.py
+++ b/test/ui-test/testSuites/suite_communities/shared/scripts/community_names.py
@@ -55,10 +55,10 @@ communitySettings_Community_LetterIdenticon = {"container": communitySettings_Co
 
 # Community Edit:
 communitySettings_EditCommunity_ScrollView = {"container": statusDesktop_mainWindow, "objectName": "communityEditPanelScrollView", "type": "StatusScrollView", "visible": True}
-communitySettings_EditCommunity_Name_Input = {"container": communitySettings_EditCommunity_ScrollView, "objectName": "editCommunityNameInput", "type": "TextEdit"}
-communitySettings_EditCommunity_Description_Input = {"container": communitySettings_EditCommunity_ScrollView, "objectName": "editCommunityDescriptionInput", "type": "TextEdit"}
+communitySettings_EditCommunity_Name_Input = {"container": communitySettings_EditCommunity_ScrollView, "objectName": "editCommunityNameInput", "type": "TextEdit",  "visible": True}
+communitySettings_EditCommunity_Description_Input = {"container": communitySettings_EditCommunity_ScrollView, "objectName": "editCommunityDescriptionInput", "type": "TextEdit",  "visible": True}
 communitySettings_EditCommunity_ColorPicker_Button = {"container": communitySettings_EditCommunity_ScrollView, "objectName": "editCommunityColorPicker", "type": "CommunityColorPicker", "visible": True}
 
 # Community color popup:
-communitySettings_ColorPanel_HexColor_Input = {"container": statusDesktop_mainWindow_overlay, "objectName": "communityColorPanelHexInput", "type": "TextEdit"}
+communitySettings_ColorPanel_HexColor_Input = {"container": statusDesktop_mainWindow_overlay, "objectName": "communityColorPanelHexInput", "type": "TextEdit",  "visible": True}
 communitySettings_SaveColor_Button = {"container": statusDesktop_mainWindow_overlay, "objectName": "communityColorPanelSelectColorButton", "type": "StatusButton", "visible": True}

--- a/test/ui-test/testSuites/suite_communities/tst_communityFlows/test.feature
+++ b/test/ui-test/testSuites/suite_communities/tst_communityFlows/test.feature
@@ -84,7 +84,6 @@ Feature: Status Desktop community
         When the admin deletes category named "test-category"
         Then the category named "test-category" is missing
 
-    @mayfail
     Scenario Outline: The admin edits a community name, description and color separately
         When the admin changes the community name to "<new_community_name>"
         Then the community overview name is "<new_community_name>"
@@ -98,7 +97,6 @@ Feature: Status Desktop community
             | new_community_name       | new_community_description  | new_community_color |
             | myCommunityNamedChanged  | Cool new description 123   | #ff0000             |
 
-    @mayfail
     Scenario Outline: The admin edits a community name, description and color
         When the admin renames the community to "<new_community_name>" and description to "<new_community_description>" and color to "<new_community_color>"
         Then the community overview name is "<new_community_name>"


### PR DESCRIPTION
### What does the PR do

Verify results of edit community tests only when the element is visible

The only assumption why they can fail is that after clicking `save changes`, we requested the `name` before it was updated and displayed

P.S. Locally tests are not failing

Potential fix for #8977

### Affected areas

Squish community test