### PR TITLE
perf(chatScroll): Enable reuseItems on ChatMessagesView listview

### DIFF
--- a/ui/StatusQ/src/StatusQ/Core/StatusListView.qml
+++ b/ui/StatusQ/src/StatusQ/Core/StatusListView.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.14
-import QtQuick.Controls 2.14
+import QtQuick 2.15
+import QtQuick.Controls 2.15
 
 import StatusQ.Controls 0.1
 

--- a/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
@@ -1,4 +1,5 @@
-import QtQuick 2.13
+import QtQuick 2.15
+import QtQml 2.15
 import QtQuick.Controls 2.13
 import QtQuick.Layouts 1.13
 import QtQuick.Dialogs 1.3
@@ -218,6 +219,7 @@ Item {
             }
         }
 
+        reuseItems: true
         delegate: MessageView {
             id: msgDelegate
 


### PR DESCRIPTION
### What does the PR do

Fixing #3067 

Enabling reuseItems on chat history list view.

### Affected areas

<!-- List the affected areas (e.g wallet, browser, etc..) -->

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

- [ ] I've checked the design and this PR matches it

<!-- screenshot (or gif/video) that demonstrates the functionality, specially important if it's a bug fix. -->

### Cool Spaceship Picture

<!-- optional but cool ->
