### PR TITLE
Fix message view quick actions regression

### DIFF
--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -736,7 +736,7 @@ Loader {
                             tooltip.text: qsTr("Add reaction")
                             onClicked: {
                                 d.setMessageActive(root.messageId, true)
-                                root.messageClickHandler(this, Qt.point(mouse.x, mouse.y), false, false, false, null, true, false)
+                                root.messageClickHandler(delegate, mapToItem(delegate, mouse.x, mouse.y), false, false, false, null, true, false)
                             }
                         }
                     },


### PR DESCRIPTION
### What does the PR do

Fixing regression introduced by #9085
The Reactions popup was being destroyed because its parent was getting destroyed by the loader.

### Affected areas

Chat reactions
<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Screenshot of functionality (including design for comparison)

https://user-images.githubusercontent.com/47811206/212666101-f257a872-b71d-4a1b-a64a-1c0184891ace.mov
