### PR TITLE
fix(@desktop/wallet): fix wrong symbol for pegged tokens

### DIFF
--- a/src/app_service/service/currency/service.nim
+++ b/src/app_service/service/currency/service.nim
@@ -53,9 +53,12 @@ QtObject:
     var updateCache = true
     let pegSymbol = self.tokenService.getTokenPegSymbol(symbol)
     if pegSymbol != "":
-      var currencyFormat = self.getFiatCurrencyFormat(pegSymbol)
-      currencyFormat.symbol = symbol
-      result = currencyFormat
+      let currencyFormat = self.getFiatCurrencyFormat(pegSymbol)
+      result = CurrencyFormatDto(
+        symbol: symbol,
+        displayDecimals: currencyFormat.displayDecimals,
+        stripTrailingZeroes: currencyFormat.stripTrailingZeroes
+      )
       updateCache = true
     else:
       let price = self.tokenService.getCachedTokenPrice(symbol, DECIMALS_CALCULATION_CURRENCY)


### PR DESCRIPTION
### What does the PR do

When implementing the Cache for CurrencyAmount format, a single object was shared between all tokens with the same peg, resulting in a wrong symbol. This PR fixes that.
