### PR TITLE
fix(BackupSeedModal): always show vertical scrollbar

### DIFF
--- a/ui/app/AppLayouts/Profile/popups/backupseed/Acknowledgements.qml
+++ b/ui/app/AppLayouts/Profile/popups/backupseed/Acknowledgements.qml
@@ -1,4 +1,5 @@
 import QtQuick 2.12
+import QtQuick.Controls 2.14
 import QtQuick.Layouts 1.12
 
 import shared.panels 1.0
@@ -32,6 +33,8 @@ ColumnLayout {
                 anchors.fill: parent
                 anchors.margins: -parent.anchors.margins
                 anchors.bottomMargin: -parent.anchors.bottomMargin
+
+                ScrollBar.vertical.policy: ScrollBar.AlwaysOn
 
                 clip: false
 


### PR DESCRIPTION
This is to ensure users don't get confused with the fact there's more checkboxes to check in the modal until they can continue.

Depending on viewport size, checkboxes can be hidden but it's not obvious that the area is scrollable.

See #8651

Closes #8651

