### PR TITLE
fix(AppMain): Open only one popup per component

### DIFF
--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -52,6 +52,8 @@ Item {
     // set from main.qml
     property var sysPalette
 
+    property var activePopupComponents: []
+
     signal closeProfilePopup()
 
     Connections {
@@ -158,8 +160,21 @@ Item {
         onOpenEditDisplayNamePopup: Global.openPopup(displayNamePopupComponent)
 
         onOpenPopupRequested: {
+            if (activePopupComponents.includes(popupComponent)) {
+                return;
+            }
+
             const popup = popupComponent.createObject(appMain, params);
             popup.open();
+
+            activePopupComponents.push(popupComponent);
+
+            popup.closed.connect(() => {
+                const removeIndex = activePopupComponents.indexOf(popupComponent);
+                if (removeIndex !== -1) {
+                    activePopupComponents.splice(removeIndex, 1);
+                }
+            })
             return popup;
         }
 


### PR DESCRIPTION
Mentions #9131

### What does the PR do

This is partial fix for #9131 that limits opening more one one popup per component. I believe it can be helpful regardless of actual fix of mailserver

### Affected areas

AppMain

### Screenshot

<img width="666" alt="Screenshot 2023-01-17 at 16 26 02" src="https://user-images.githubusercontent.com/2522130/212898809-1ba67dd1-bba0-4c49-bda7-5de3a7b2bd14.png">
