### PR TITLE
feat(CommunityPermissions): UI support to show the % of members fulfilling permission

### DIFF
--- a/storybook/PagesModel.qml
+++ b/storybook/PagesModel.qml
@@ -50,6 +50,10 @@ ListModel {
          section: "Panels"
     }
     ListElement {
+         title: "PermissionQualificationPanel"
+         section: "Panels"
+    }
+    ListElement {
         title: "InviteFriendsToCommunityPopup"
         section: "Popups"
     }

--- a/storybook/figma.json
+++ b/storybook/figma.json
@@ -71,5 +71,9 @@
     ],
     "CommunityPermissionsView": [
         "https://www.figma.com/file/17fc13UBFvInrLgNUKJJg5/Kuba%E2%8E%9CDesktop?node-id=2934%3A484715&t=IfHHp5GSPo1j9m5j-0"
+    ],
+    "PermissionQualificationPanel": [
+        "https://www.figma.com/file/17fc13UBFvInrLgNUKJJg5/Kuba%E2%8E%9CDesktop?node-id=2934%3A480089",
+        "https://www.figma.com/file/17fc13UBFvInrLgNUKJJg5/Kuba%E2%8E%9CDesktop?node-id=22734%3A502803"
     ]
 }

--- a/storybook/pages/PermissionQualificationPanelPage.qml
+++ b/storybook/pages/PermissionQualificationPanelPage.qml
@@ -1,0 +1,99 @@
+import QtQuick 2.14
+import QtQuick.Controls 2.14
+import QtQuick.Layouts 1.14
+
+import Storybook 1.0
+
+import AppLayouts.Chat.panels.communities 1.0
+
+SplitView {
+    orientation: Qt.Vertical
+
+    Item {
+        SplitView.fillWidth: true
+        SplitView.fillHeight: true
+
+        Item {
+            id: container
+
+            width: widthSlider.value
+            height: qualificationPanel.implicitHeight
+
+            anchors.centerIn: parent
+
+            PermissionQualificationPanel {
+                id: qualificationPanel
+
+                anchors.left: parent.left
+                anchors.right: parent.right
+
+                qualifyingAddresses: qualifyingAddressesSlider.value
+                knownAddresses: knownAddressesSlider.value
+                unknownAddresses: unknownAddressesSlider.value
+            }
+        }
+    }
+
+    LogsAndControlsPanel {
+        SplitView.minimumHeight: 100
+        SplitView.preferredHeight: 250
+
+        ColumnLayout {
+            Row {
+                Label {
+                    anchors.verticalCenter: parent.verticalCenter
+                    text: "width:"
+                }
+
+                Slider {
+                    id: widthSlider
+                    value: 400
+                    from: 200
+                    to: 600
+                }
+            }
+
+            Row {
+                Label {
+                    anchors.verticalCenter: parent.verticalCenter
+                    text: "number of qualifying addresses:"
+                }
+
+                Slider {
+                    id: qualifyingAddressesSlider
+                    value: 200234
+                    from: 0
+                    to: 500000
+                }
+            }
+
+            Row {
+                Label {
+                    anchors.verticalCenter: parent.verticalCenter
+                    text: "number of known addresses:"
+                }
+
+                Slider {
+                    id: knownAddressesSlider
+                    value: 663026
+                    from: 1
+                    to: 1000000
+                }
+            }
+
+            Row {
+                Label {
+                    anchors.verticalCenter: parent.verticalCenter
+                    text: "number of unknown addresses:"
+                }
+
+                Slider {
+                    id: unknownAddressesSlider
+                    value: 396720
+                    from: 1
+                    to: 1000000
+                }
+            }
+        }
+    }
+}

--- a/ui/app/AppLayouts/Chat/panels/communities/PermissionQualificationPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/PermissionQualificationPanel.qml
@@ -1,0 +1,61 @@
+import QtQuick 2.14
+import QtQuick.Controls 2.14
+import QtQuick.Layouts 1.14
+
+import StatusQ.Core 0.1
+import StatusQ.Core.Theme 0.1
+
+import utils 1.0
+
+Control {
+    property int qualifyingAddresses: 1
+    property int knownAddresses: 1
+    property int unknownAddresses: 1
+
+    verticalPadding: 16
+    horizontalPadding: 18
+
+    background: Rectangle {
+        border.color: Style.current.border
+        radius: Style.current.radius
+        color: Style.current.transparent
+    }
+
+    contentItem: RowLayout {
+        spacing: 4
+
+        StatusIcon {
+            Layout.preferredWidth: 22
+            Layout.preferredHeight: 22
+
+            Layout.alignment: Qt.AlignTop
+
+            color: Theme.palette.baseColor1
+            icon: "communities"
+        }
+
+        StatusBaseText {
+            Layout.fillWidth: true
+
+            wrapMode: Text.Wrap
+
+            font.pixelSize: Style.current.primaryTextFontSize
+            lineHeight: 22
+            lineHeightMode: Text.FixedHeight
+
+            Binding on color {
+                when: qualifyingAddresses === 0
+                value: Theme.palette.dangerColor1
+            }
+
+            readonly property real ratio: 100 * qualifyingAddresses / knownAddresses
+            readonly property string ratioAligned: Number(ratio.toFixed(1))
+
+            readonly property string part1: qsTr("%L1% of the %Ln community member(s) with known addresses will qualify for this permission.",
+                                                 "", knownAddresses).arg(ratioAligned)
+            readonly property string part2: qsTr("The addresses of %Ln community member(s) are unknown.", "", unknownAddresses)
+
+            text: `${part1} ${part2}`
+        }
+    }
+}

--- a/ui/app/AppLayouts/Chat/panels/communities/qmldir
+++ b/ui/app/AppLayouts/Chat/panels/communities/qmldir
@@ -1,3 +1,4 @@
+CommunityPermissionsSettingsPanel 1.0 CommunityPermissionsSettingsPanel.qml
 CommunityProfilePopupInviteFriendsPanel 1.0 CommunityProfilePopupInviteFriendsPanel.qml
 CommunityProfilePopupInviteMessagePanel 1.0 CommunityProfilePopupInviteMessagePanel.qml
-CommunityPermissionsSettingsPanel 1.0 CommunityPermissionsSettingsPanel.qml
+PermissionQualificationPanel 1.0 PermissionQualificationPanel.qml

--- a/ui/app/AppLayouts/Chat/views/communities/CommunityNewPermissionView.qml
+++ b/ui/app/AppLayouts/Chat/views/communities/CommunityNewPermissionView.qml
@@ -1,4 +1,5 @@
 import QtQuick 2.14
+import QtQuick.Controls 2.14
 import QtQuick.Layouts 1.14
 
 import StatusQ.Core 0.1
@@ -13,6 +14,7 @@ import shared.panels 1.0
 
 import SortFilterProxyModel 0.2
 
+import AppLayouts.Chat.panels.communities 1.0
 
 import "../../../Chat/controls/community"
 
@@ -515,6 +517,18 @@ StatusScrollView {
                 onToggled: d.dirtyValues.isPrivateDirty = (root.isPrivate !== checked)
             }
         }
+
+        PermissionQualificationPanel {
+            Layout.fillWidth: true
+            Layout.topMargin: 24
+
+            visible: d.dirtyValues.holdingsModel.count > 0
+
+            qualifyingAddresses: 200234
+            knownAddresses: 663026
+            unknownAddresses: 396720
+        }
+
         StatusButton {
             visible: !root.isEditState
             Layout.topMargin: 24

--- a/ui/app/AppLayouts/Chat/views/communities/CommunityNewPermissionView.qml
+++ b/ui/app/AppLayouts/Chat/views/communities/CommunityNewPermissionView.qml
@@ -518,17 +518,6 @@ StatusScrollView {
             }
         }
 
-        PermissionQualificationPanel {
-            Layout.fillWidth: true
-            Layout.topMargin: 24
-
-            visible: d.dirtyValues.holdingsModel.count > 0
-
-            qualifyingAddresses: 200234
-            knownAddresses: 663026
-            unknownAddresses: 396720
-        }
-
         StatusButton {
             visible: !root.isEditState
             Layout.topMargin: 24


### PR DESCRIPTION
### What does the PR do

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

Shows some details regarding members fulfilling permission and counts of members with known/uknown addresses.

Closes: #9044

### Affected areas
`CommunityNewPermissionView`

### Screenshot of functionality (including design for comparison)

- [ ] I've checked the design and this PR matches it

![Screenshot from 2023-01-17 13-51-22](https://user-images.githubusercontent.com/20650004/212903634-910d3e5c-1b38-4d99-aec6-692effcabacd.png)
![Screenshot from 2023-01-17 13-43-24](https://user-images.githubusercontent.com/20650004/212903646-a91ee9f1-9764-4517-a336-b7ed40f911d0.png)
![Screenshot from 2023-01-17 13-43-14](https://user-images.githubusercontent.com/20650004/212903656-70e3ac74-a0c8-4074-baf4-2d162c6fe5f3.png)
