### PR TITLE
chore(badge): stop counting contact request in chat section badge

### DIFF
--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -388,7 +388,6 @@ method getChatContentModule*(self: Module, chatId: string): QVariant =
 proc updateParentBadgeNotifications(self: Module) =
   var (sectionHasUnreadMessages, sectionNotificationCount) = self.view.chatsModel().getAllNotifications()
   if(not self.controller.isCommunity()):
-    sectionNotificationCount += self.view.contactRequestsModel().getCount()
     sectionHasUnreadMessages = sectionHasUnreadMessages or sectionNotificationCount > 0
   self.delegate.onNotificationsUpdated(self.controller.getMySectionId(), sectionHasUnreadMessages, sectionNotificationCount)
 


### PR DESCRIPTION
Fixes #9152

I had forgotten that we did that when I removed the contact request button  and popup