### PR TITLE
fix(ContactsColumnView): Open add/remove group member on context menu

### DIFF
--- a/ui/app/AppLayouts/Chat/views/ChatHeaderContentView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatHeaderContentView.qml
@@ -26,6 +26,10 @@ Item {
 
     signal searchButtonClicked()
 
+    function addRemoveGroupMember() {
+        root.state = d.stateMembersSelectorContent
+    }
+
     QtObject {
         id: d
 
@@ -231,7 +235,7 @@ Item {
                                 )
                 }
                 onAddRemoveGroupMember: {
-                    root.state = d.stateMembersSelectorContent
+                    root.addRemoveGroupMember()
                 }
                 onFetchMoreMessages: {
                     messageStore.requestMoreMessages();

--- a/ui/app/AppLayouts/Chat/views/ChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatView.qml
@@ -148,6 +148,9 @@ StatusSectionLayout {
             onCreateCommunityClicked: {
                 root.createCommunityClicked();
             }
+            onAddRemoveGroupMemberClicked: {
+                headerContent.addRemoveGroupMember()
+            }
         }
     }
 

--- a/ui/app/AppLayouts/Chat/views/ContactsColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ContactsColumnView.qml
@@ -38,6 +38,7 @@ Item {
     signal openAppSearch()
     signal importCommunityClicked()
     signal createCommunityClicked()
+    signal addRemoveGroupMemberClicked()
 
     // main layout
     ColumnLayout {
@@ -232,6 +233,9 @@ Item {
                                 groupColor,
                                 groupImage
                             )
+                        }
+                        onAddRemoveGroupMember: {
+                            root.addRemoveGroupMemberClicked()
                         }
                     }
                 }


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/9145

### What does the PR do

Open add/remove member text field via context menu to the group chat.

### Screenshot of functionality (including design for comparison)

https://user-images.githubusercontent.com/25482501/212966387-0120c2fe-d069-4bc0-b329-e04815422fb3.mov

