### PR TITLE
fix(replies): update quoted message data when receiving new messages

### DIFF
--- a/src/app/modules/shared_models/message_model.nim
+++ b/src/app/modules/shared_models/message_model.nim
@@ -292,6 +292,31 @@ QtObject:
     let parentModelIndex = newQModelIndex()
     defer: parentModelIndex.delete
 
+    # Update replied to messages if there are
+    # We update replies before adding, since we do not need to update the new items, they should already be up to date
+    for i in 0 ..< self.items.len:
+      var oldItem = self.items[i]
+      if oldItem.responseToMessageWithId == "" or oldItem.quotedMessageFrom != "":
+        continue
+      for newItem in items:
+        if oldItem.responseToMessageWithId == newItem.id:
+          oldItem.quotedMessageFrom = newItem.senderId
+          oldItem.quotedMessageAuthorDisplayName = newItem.senderDisplayName
+          oldItem.quotedMessageAuthorAvatar = newItem.senderIcon
+          oldItem.quotedMessageParsedText = newItem.messageText
+          oldItem.quotedMessageText = newItem.unparsedText
+          oldItem.quotedMessageContentType = newItem.contentType.int
+          let index = self.createIndex(i, 0, nil)
+          self.dataChanged(index, index, @[
+            ModelRole.QuotedMessageFrom.int,
+            ModelRole.QuotedMessageAuthorDisplayName.int,
+            ModelRole.QuotedMessageAuthorAvatar.int,
+            ModelRole.QuotedMessageText.int,
+            ModelRole.QuotedMessageParsedText.int,
+            ModelRole.QuotedMessageContentType.int,
+          ])
+
+
     self.beginInsertRows(parentModelIndex, position, position + items.len - 1)
     self.items.insert(items, position)
     self.endInsertRows()


### PR DESCRIPTION
Fixes #9156

Fixes it by checking new messages added to the model and updating the quoted message if it's the right message ID and the quoted message was not already populated.

This is hard to manually reproduce without waiting a day for messages to go in the store node and then receive them out of order.

What I did was I modified the `chat_contact/module` and added this to `viewDidLoad`:

```nim
self.messagesAdded(@[
    MessageDto(
      id: "replyMessage",
      responseTo: "quotedMessage",
      `from`: "0x04b2a87e119964bf1b338a80f5aecf8f09aa6b246172c0951bdee0ca8ef1f402e5b90eeeb48d9539ec69886ecadb070cb1e81ccc7588a2b93968b172f832745ef5",
      alias: "Hospitable Frizzy Sealion",
      seen: true,
      outgoingStatus: "",
      rtl: false,
      parsedText: @[ParsedText(
        `type`: "paragraph",
        literal: "",
        destination: "",
        children: @[ParsedText(
          `type`: "",
          literal: "REPLY MESSAGE",
          destination: "",
          children: @[])])],
      lineCount: 0,
      text: "REPLY MESSAGE",
      chatId: "testjo",
      localChatId: "testjo",
      clock: 1673978250568,
      replace: "",
      ensName: "",
      image: "",
      timestamp: 1673978250568,
      contentType: 1,
      messageType: 2,
      contactRequestState: 0,
      editedAt: 0,
      deleted: false,
      deletedForMe: false,
      mentioned: false,
      replied: true
    )
  ])

  self.messagesAdded(@[
    MessageDto(
      id: "quotedMessage",
      responseTo: "",
      `from`: "0x04b2a87e119964bf1b338a80f5aecf8f09aa6b246172c0951bdee0ca8ef1f402e5b90eeeb48d9539ec69886ecadb070cb1e81ccc7588a2b93968b172f832745ef5",
      alias: "Hospitable Frizzy Sealion",
      seen: true,
      outgoingStatus: "",
      rtl: false,
      parsedText: @[ParsedText(
        `type`: "paragraph",
        literal: "",
        destination: "",
        children: @[ParsedText(
          `type`: "",
          literal: "QUOTED MESSAGE",
          destination: "",
          children: @[])])],
      lineCount: 0,
      text: "QUOTED MESSAGE",
      chatId: "testjo",
      localChatId: "testjo",
      clock: 1673977250568,
      replace: "",
      ensName: "",
      image: "",
      timestamp: 1673977250568,
      contentType: 1,
      messageType: 2,
      contactRequestState: 0,
      editedAt: 0,
      deleted: false,
      deletedForMe: false,
      mentioned: false,
      replied: true
    )
  ])
  ```

It adds a first message in the model which is the reply. So it comes out of order. Then it adds the quoted message. When running this, the message list should look ok since the model updates itself with the new message.

If you comment the second message, you would see the "Unknown message"