### PR TITLE
fix: Highlight color of jump-to-message has too little contrast

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
@@ -136,8 +136,8 @@ Control {
             }
             width: 2
             visible: root.isPinned || root.hasMention
-            color: root.isPinned ? Theme.palette.pinColor1 : root.hasMention ? Theme.palette.mentionColor1
-                                                                             : "transparent" // not visible really
+            color: root.hasMention ? Theme.palette.mentionColor1 : root.isPinned ? Theme.palette.pinColor1
+                                                                                 : "transparent" // not visible really
         }
     }
 
@@ -175,7 +175,7 @@ Control {
             anchors.fill: parent
             opacity: 0
             visible: opacity > 0.001
-            color: Theme.palette.baseColor2
+            color: Theme.palette.messageHighlightColor
         }
 
         MouseArea {

--- a/ui/StatusQ/src/StatusQ/Core/Theme/StatusColors.qml
+++ b/ui/StatusQ/src/StatusQ/Core/Theme/StatusColors.qml
@@ -1,10 +1,10 @@
 pragma Singleton
-import QtQuick 2.13
+
+import QtQml 2.14
 
 QtObject {
 
-    property var colors: {
-
+    readonly property var colors: {
         'black': '#000000',
         'white': '#FFFFFF',
 
@@ -69,4 +69,3 @@ QtObject {
         'lightPattensBlue': '#D7DEE4',
     }
 }
-

--- a/ui/StatusQ/src/StatusQ/Core/Theme/StatusDarkTheme.qml
+++ b/ui/StatusQ/src/StatusQ/Core/Theme/StatusDarkTheme.qml
@@ -65,6 +65,8 @@ ThemePalette {
     statusLoadingHighlight: getColor('white', 0.03)
     statusLoadingHighlight2: getColor('white', 0.07)
 
+    messageHighlightColor: getColor('blue4', 0.2)
+
     userCustomizationColors: [
         "#AAC6FF",
         "#887AF9",

--- a/ui/StatusQ/src/StatusQ/Core/Theme/StatusDarkTheme.qml
+++ b/ui/StatusQ/src/StatusQ/Core/Theme/StatusDarkTheme.qml
@@ -87,83 +87,82 @@ ThemePalette {
                           "#000086", "#9B81FF", "#3FAEF9", "#9A6600", "#00FFFF", "#008694",
                           "#C2FFFF", "#00F0B6"]
 
-    property QtObject statusAppLayout: QtObject {
+    statusAppLayout: QtObject {
         property color backgroundColor: baseColor3
         property color rightPanelBackgroundColor: baseColor3
     }
 
-    property QtObject statusAppNavBar: QtObject {
+    statusAppNavBar: QtObject {
         property color backgroundColor: baseColor5
     }
 
-    property QtObject statusToastMessage: QtObject {
+    statusToastMessage: QtObject {
         property color backgroundColor: baseColor3
     }
 
-    property QtObject statusListItem: QtObject {
+    statusListItem: QtObject {
         property color backgroundColor: baseColor3
         property color secondaryHoverBackgroundColor: primaryColor3
     }
 
-    property QtObject statusChatListItem: QtObject {
+    statusChatListItem: QtObject {
         property color hoverBackgroundColor: directColor8
         property color selectedBackgroundColor: directColor7
     }
 
-    property QtObject statusChatListCategoryItem: QtObject {
+    statusChatListCategoryItem: QtObject {
         property color buttonHoverBackgroundColor: directColor7
     }
 
-    property QtObject statusNavigationListItem: QtObject {
+    statusNavigationListItem: QtObject {
         property color hoverBackgroundColor: directColor8
         property color selectedBackgroundColor: directColor7
     }
 
-    property QtObject statusBadge: QtObject {
+    statusBadge: QtObject {
         property color foregroundColor: baseColor3
         property color borderColor: baseColor5
         property color hoverBorderColor: "#353A4D"
     }
 
-    property QtObject statusChatInfoButton: QtObject {
+    statusChatInfoButton: QtObject {
         property color backgroundColor: baseColor3
     }
 
-    property QtObject statusMenu: QtObject {
+    statusMenu: QtObject {
         property color backgroundColor: baseColor2
         property color hoverBackgroundColor: directColor7
         property color separatorColor: directColor7
     }
 
-    property QtObject statusModal: QtObject {
+    statusModal: QtObject {
         property color backgroundColor: baseColor3
     }
 
-    property QtObject statusRoundedImage: QtObject {
+    statusRoundedImage: QtObject {
         property color backgroundColor: baseColor3
     }
 
-    property QtObject statusChatInput: QtObject {
+    statusChatInput: QtObject {
         property color secondaryBackgroundColor: "#414141"
     }
 
-    property QtObject statusSwitchTab: QtObject {
+    statusSwitchTab: QtObject {
         property color buttonBackgroundColor: primaryColor1
         property color barBackgroundColor: primaryColor3
         property color selectedTextColor: white
         property color textColor: primaryColor1
     }
 
-    property QtObject statusSelect: QtObject {
+    statusSelect: QtObject {
         property color menuItemBackgroundColor: baseColor2
         property color menuItemHoverBackgroundColor: directColor7
     }
 
-    property QtObject statusMessage: QtObject {
+    statusMessage: QtObject {
         property color emojiReactionBackground: "#2d2823"
         property color emojiReactionBackgroundHovered: "#3a3632"
         property color emojiReactionActiveBackground: getColor('blue')
         property color emojiReactionActiveBackgroundHovered: Qt.darker(emojiReactionActiveBackground, 1.1)
     }
 }
-

--- a/ui/StatusQ/src/StatusQ/Core/Theme/StatusLightTheme.qml
+++ b/ui/StatusQ/src/StatusQ/Core/Theme/StatusLightTheme.qml
@@ -85,83 +85,82 @@ ThemePalette {
                           "#000086", "#9B81FF", "#3FAEF9", "#9A6600", "#00FFFF", "#008694",
                           "#C2FFFF", "#00F0B6"]
 
-    property QtObject statusAppLayout: QtObject {
+    statusAppLayout: QtObject {
         property color backgroundColor: white
         property color rightPanelBackgroundColor: white
     }
 
-    property QtObject statusAppNavBar: QtObject {
+    statusAppNavBar: QtObject {
         property color backgroundColor: baseColor2
     }
 
-    property QtObject statusToastMessage: QtObject {
+    statusToastMessage: QtObject {
         property color backgroundColor: white
     }
 
-    property QtObject statusListItem: QtObject {
+    statusListItem: QtObject {
         property color backgroundColor: white
         property color secondaryHoverBackgroundColor: getColor('blue6')
     }
 
-    property QtObject statusChatListItem: QtObject {
+    statusChatListItem: QtObject {
         property color hoverBackgroundColor: baseColor2
         property color selectedBackgroundColor: baseColor3
     }
 
-    property QtObject statusChatListCategoryItem: QtObject {
+    statusChatListCategoryItem: QtObject {
         property color buttonHoverBackgroundColor: directColor8
     }
 
-    property QtObject statusNavigationListItem: QtObject {
+    statusNavigationListItem: QtObject {
         property color hoverBackgroundColor: baseColor2
         property color selectedBackgroundColor: baseColor3
     }
 
-    property QtObject statusBadge: QtObject {
+    statusBadge: QtObject {
         property color foregroundColor: white
         property color borderColor: baseColor4
         property color hoverBorderColor: "#DDE3F3"
     }
 
-    property QtObject statusChatInfoButton: QtObject {
+    statusChatInfoButton: QtObject {
         property color backgroundColor: white
     }
 
-    property QtObject statusMenu: QtObject {
+    statusMenu: QtObject {
         property color backgroundColor: white
         property color hoverBackgroundColor: baseColor2
         property color separatorColor: baseColor2
     }
 
-    property QtObject statusModal: QtObject {
+    statusModal: QtObject {
         property color backgroundColor: white
     }
 
-    property QtObject statusRoundedImage: QtObject {
+    statusRoundedImage: QtObject {
         property color backgroundColor: white
     }
 
-    property QtObject statusChatInput: QtObject {
+    statusChatInput: QtObject {
         property color secondaryBackgroundColor: "#E2E6E8"
     }
 
-    property QtObject statusSwitchTab: QtObject {
+    statusSwitchTab: QtObject {
         property color buttonBackgroundColor: primaryColor1
         property color barBackgroundColor: primaryColor3
         property color selectedTextColor: white
         property color textColor: primaryColor1
     }
 
-    property QtObject statusSelect: QtObject {
+    statusSelect: QtObject {
         property color menuItemBackgroundColor: white
         property color menuItemHoverBackgroundColor: baseColor2
     }
 
-    property QtObject statusMessage: QtObject {
+    statusMessage: QtObject {
         property color emojiReactionBackground: "#e2e6e9"
         property color emojiReactionBackgroundHovered: "#d7dadd"
         property color emojiReactionActiveBackground: getColor('blue')
         property color emojiReactionActiveBackgroundHovered: Qt.darker(emojiReactionActiveBackground, 1.1)
     }
 }
-

--- a/ui/StatusQ/src/StatusQ/Core/Theme/StatusLightTheme.qml
+++ b/ui/StatusQ/src/StatusQ/Core/Theme/StatusLightTheme.qml
@@ -63,6 +63,8 @@ ThemePalette {
     statusLoadingHighlight: getColor('lightPattensBlue', 0.5)
     statusLoadingHighlight2: indirectColor3
 
+    messageHighlightColor: getColor('blue', 0.2)
+
     userCustomizationColors: [
         "#2946C4",
         "#887AF9",

--- a/ui/StatusQ/src/StatusQ/Core/Theme/ThemePalette.qml
+++ b/ui/StatusQ/src/StatusQ/Core/Theme/ThemePalette.qml
@@ -246,6 +246,13 @@ QtObject {
         property color menuItemHoeverBackgroundColor
     }
 
+    property QtObject statusMessage: QtObject {
+        property color emojiReactionBackground
+        property color emojiReactionBackgroundHovered
+        property color emojiReactionActiveBackground
+        property color emojiReactionActiveBackgroundHovered
+    }
+
     function alphaColor(color, alpha) {
         let actualColor = Qt.darker(color, 1)
         actualColor.a = alpha
@@ -257,4 +264,3 @@ QtObject {
                        : StatusColors.colors[name]
     }
 }
-

--- a/ui/StatusQ/src/StatusQ/Core/Theme/ThemePalette.qml
+++ b/ui/StatusQ/src/StatusQ/Core/Theme/ThemePalette.qml
@@ -169,6 +169,8 @@ QtObject {
     property color statusLoadingHighlight
     property color statusLoadingHighlight2
 
+    property color messageHighlightColor
+
     property var userCustomizationColors: []
 
     property var identiconRingColors: []


### PR DESCRIPTION
Use the colors defined by design:
```
Light theme: Light Desktop / Blue 20% (4360DF 20%)
Dark theme: Dark Desktop / Blue 20% (869EFF 20%)
```

Separate commit to fixup palette color groups handling

Fixes https://github.com/status-im/status-desktop/issues/8271

### What does the PR do

Fixes highlight colors for message found

### Affected areas

StatusMessage, Theme

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

Light theme:
![image](https://user-images.githubusercontent.com/5377645/213135808-5f97ef97-53f1-48e3-ae87-1eeb857f4d19.png)

Dark theme:
![image](https://user-images.githubusercontent.com/5377645/213135903-65ed6a53-94b0-482c-bf5a-aaf34b4338e7.png)

