### PR TITLE
hotfix(ActivityCenter): Fix warnings and text align with messageBadge

### DIFF
--- a/src/app/modules/main/activity_center/item.nim
+++ b/src/app/modules/main/activity_center/item.nim
@@ -130,15 +130,14 @@ proc messageItem*(self: Item): MessageItem =
 proc repliedMessageItem*(self: Item): MessageItem =
   return self.repliedMessageItem
 
-# TODO: this logic should be moved to status-go
+# TODO: this logic should be moved to status-go (https://github.com/status-im/status-desktop/issues/8074)
 proc isNotReadOrActiveCTA*(self: Item): bool =
   return ((self.notificationType == ActivityCenterNotificationType.CommunityMembershipRequest and
            self.membershipStatus == ActivityCenterMembershipStatus.Pending) or
           (self.notificationType == ActivityCenterNotificationType.ContactRequest and
            self.messageItem.contactRequestState == CONTACT_REQUEST_PENDING_STATE) or
           (self.notificationType == ActivityCenterNotificationType.ContactVerification and
-           (self.verificationStatus == VerificationStatus.Verifying or
-            self.verificationStatus == VerificationStatus.Verified)) or
+           self.verificationStatus == VerificationStatus.Verifying) or
           (self.notificationType == ActivityCenterNotificationType.Mention and
            not self.read) or
           (self.notificationType == ActivityCenterNotificationType.Reply and

--- a/ui/app/mainui/activitycenter/views/ActivityNotificationCommunityMembershipRequest.qml
+++ b/ui/app/mainui/activitycenter/views/ActivityNotificationCommunityMembershipRequest.qml
@@ -27,7 +27,7 @@ ActivityNotificationMessage {
     messageDetails.sender.profileImage.assetSettings.isImage: true
     messageDetails.sender.profileImage.pubkey: notification ? notification.author : ""
     messageDetails.sender.profileImage.colorId: Utils.colorIdForPubkey(notification ? notification.author : "")
-    messageDetails.sender.profileImage.colorHash: Utils.getColorHashAsJson(notification ? notification.author : "", contactDetails.ensVerified)
+    messageDetails.sender.profileImage.colorHash: Utils.getColorHashAsJson(notification ? notification.author : "", contactDetails && contactDetails.ensVerified)
 
     messageBadgeComponent: CommunityBadge {
         readonly property var community: notification ?

--- a/ui/app/mainui/activitycenter/views/ActivityNotificationMessage.qml
+++ b/ui/app/mainui/activitycenter/views/ActivityNotificationMessage.qml
@@ -34,7 +34,7 @@ ActivityNotificationBase {
             assetSettings.isImage: contactDetails && contactDetails.displayIcon.startsWith("data")
             pubkey: contactId
             colorId: Utils.colorIdForPubkey(contactId)
-            colorHash: Utils.getColorHashAsJson(contactId, contactDetails.ensVerified)
+            colorHash: Utils.getColorHashAsJson(contactId, contactDetails && contactDetails.ensVerified)
         }
     }
 

--- a/ui/imports/shared/views/chat/SimplifiedMessageView.qml
+++ b/ui/imports/shared/views/chat/SimplifiedMessageView.qml
@@ -85,13 +85,17 @@ RowLayout {
                 elide: Text.ElideRight
                 font.pixelSize: 15
                 Layout.alignment: Qt.AlignVCenter
-                Layout.fillWidth: true
+                Layout.fillWidth: !root.messageBadgeComponent
             }
 
             Loader {
                 sourceComponent: root.messageBadgeComponent
                 Layout.alignment: Qt.AlignVCenter
                 Layout.fillHeight: true
+            }
+
+            Item {
+                Layout.fillWidth: !!root.messageBadgeComponent
             }
         }
     }


### PR DESCRIPTION
### What does the PR do

1. Fix some qml warnings
2. Align text properly if SimplifiedMessageView has badge
3. Don't count verified verification notification as unread

### Affected areas

ActivityCenter

### Screenshot of functionality (including design for comparison)

<img width="552" alt="Screenshot 2023-01-18 at 16 07 07" src="https://user-images.githubusercontent.com/2522130/213167405-c4775823-8e19-4279-a3e1-fc1d1d1acab4.png">
