### PR TITLE
fix: Community importing notification fixes and improvements

### DIFF
--- a/src/app/modules/main/communities/controller.nim
+++ b/src/app/modules/main/communities/controller.nim
@@ -35,12 +35,11 @@ proc init*(self: Controller) =
 
   self.events.on(SIGNAL_COMMUNITY_DATA_IMPORTED) do(e:Args):
     let args = CommunityArgs(e)
-    self.delegate.communityImported(args.community)
+    self.delegate.communityDataImported(args.community)
 
   self.events.on(SIGNAL_COMMUNITY_LOAD_DATA_FAILED) do(e: Args):
     let args = CommunityArgs(e)
     self.delegate.onImportCommunityErrorOccured(args.community.id, args.error)
-
 
   self.events.on(SIGNAL_CURATED_COMMUNITY_FOUND) do(e:Args):
     let args = CuratedCommunityArgs(e)
@@ -191,8 +190,8 @@ proc deleteCommunityCategory*(
     categoryId: string) =
   self.communityService.deleteCommunityCategory(communityId, categoryId)
 
-proc requestCommunityInfo*(self: Controller, communityId: string) =
-  self.communityService.requestCommunityInfo(communityId)
+proc requestCommunityInfo*(self: Controller, communityId: string, importing: bool) =
+  self.communityService.requestCommunityInfo(communityId, importing)
 
 proc importCommunity*(self: Controller, communityKey: string) =
   self.communityService.importCommunity(communityKey)

--- a/src/app/modules/main/communities/io_interface.nim
+++ b/src/app/modules/main/communities/io_interface.nim
@@ -68,7 +68,7 @@ method cancelRequestToJoinCommunity*(self: AccessInterface, communityId: string)
 method requestToJoinCommunity*(self: AccessInterface, communityId: string, ensName: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method requestCommunityInfo*(self: AccessInterface, communityId: string) {.base.} =
+method requestCommunityInfo*(self: AccessInterface, communityId: string, importing: bool) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method deleteCommunityChat*(self: AccessInterface, communityId: string, channelId: string) {.base.} =
@@ -111,6 +111,9 @@ method curatedCommunityEdited*(self: AccessInterface, community: CuratedCommunit
   raise newException(ValueError, "No implementation available")
 
 method communityImported*(self: AccessInterface, community: CommunityDto) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method communityDataImported*(self: AccessInterface, community: CommunityDto) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method onImportCommunityErrorOccured*(self: AccessInterface, communityId: string, error: string) {.base.} =

--- a/src/app/modules/main/communities/module.nim
+++ b/src/app/modules/main/communities/module.nim
@@ -284,8 +284,8 @@ method cancelRequestToJoinCommunity*(self: Module, communityId: string) =
 method requestToJoinCommunity*(self: Module, communityId: string, ensName: string) =
   self.controller.requestToJoinCommunity(communityId, ensName)
 
-method requestCommunityInfo*(self: Module, communityId: string) =
-  self.controller.requestCommunityInfo(communityId)
+method requestCommunityInfo*(self: Module, communityId: string, importing: bool) =
+  self.controller.requestCommunityInfo(communityId, importing)
 
 method isUserMemberOfCommunity*(self: Module, communityId: string): bool =
   self.controller.isUserMemberOfCommunity(communityId)
@@ -303,9 +303,12 @@ method communityImported*(self: Module, community: CommunityDto) =
   self.view.addItem(self.getCommunityItem(community))
   self.view.emitImportingCommunityStateChangedSignal(community.id, ImportCommunityState.Imported.int, "")
 
-method importCommunity*(self: Module, communityKey: string) =
-  self.view.emitImportingCommunityStateChangedSignal(communityKey, ImportCommunityState.ImportingInProgress.int, "")
-  self.controller.importCommunity(communityKey)
+method communityDataImported*(self: Module, community: CommunityDto) = 
+  self.view.addItem(self.getCommunityItem(community))
+
+method importCommunity*(self: Module, communityId: string) =
+  self.view.emitImportingCommunityStateChangedSignal(communityId, ImportCommunityState.ImportingInProgress.int, "")
+  self.controller.importCommunity(communityId)
 
 method onImportCommunityErrorOccured*(self: Module, communityId: string, error: string) =
   self.view.emitImportingCommunityStateChangedSignal(communityId, ImportCommunityState.ImportingError.int, error)

--- a/src/app/modules/main/communities/view.nim
+++ b/src/app/modules/main/communities/view.nim
@@ -440,8 +440,8 @@ QtObject:
   proc requestToJoinCommunity*(self: View, communityId: string, ensName: string) {.slot.} =
     self.delegate.requestToJoinCommunity(communityId, ensName)
 
-  proc requestCommunityInfo*(self: View, communityId: string) {.slot.} =
-    self.delegate.requestCommunityInfo(communityId)
+  proc requestCommunityInfo*(self: View, communityId: string, importing: bool) {.slot.} =
+    self.delegate.requestCommunityInfo(communityId, importing)
 
   proc getCommunityDetails*(self: View, communityId: string): string {.slot.} =
     let communityItem = self.model.getItemById(communityId)

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -935,7 +935,7 @@ method onStatusUrlRequested*[T](self: Module[T], action: StatusUrlAction, commun
     if item.isEmpty():
       # request community info and then spectate
       self.statusUrlCommunityToSpectate = communityId
-      self.communitiesModule.requestCommunityInfo(communityId)
+      self.communitiesModule.requestCommunityInfo(communityId, false)
     else:
       self.setActiveSection(item)
 
@@ -954,7 +954,7 @@ method onStatusUrlRequested*[T](self: Module[T], action: StatusUrlAction, commun
       let communityIdToSpectate = getCommunityIdFromFullChatId(chatId)
       # request community info and then spectate
       self.statusUrlCommunityToSpectate = communityIdToSpectate
-      self.communitiesModule.requestCommunityInfo(communityIdToSpectate)
+      self.communitiesModule.requestCommunityInfo(communityIdToSpectate, false)
 
   # enable after MVP
   #else(action == StatusUrlAction.OpenLinkInBrowser and singletonInstance.localAccountSensitiveSettings.getIsBrowserEnabled()):

--- a/src/app_service/service/community/async_tasks.nim
+++ b/src/app_service/service/community/async_tasks.nim
@@ -4,9 +4,10 @@ include ../../../app/core/tasks/common
 type
   AsyncRequestCommunityInfoTaskArg = ref object of QObjectTaskArg
     communityId: string
+    importing: bool
 
 const asyncRequestCommunityInfoTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AsyncRequestCommunityInfoTaskArg](argEncoded)
   let response = status_go.requestCommunityInfo(arg.communityId)
-  let tpl: tuple[communityId: string, response: RpcResponse[JsonNode]] = (arg.communityId, response)
+  let tpl: tuple[communityId: string, response: RpcResponse[JsonNode], importing: bool] = (arg.communityId, response, arg.importing)
   arg.finish(tpl)

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -356,8 +356,8 @@ QtObject {
         return communitiesList.getSectionByIdJson(id)
     }
 
-    function requestCommunityInfo(id) {
-        communitiesModuleInst.requestCommunityInfo(id)
+    function requestCommunityInfo(id, importing = false) {
+        communitiesModuleInst.requestCommunityInfo(id, importing)
     }
 
     function getCommunityDetailsAsJson(id) {

--- a/ui/app/AppLayouts/Chat/views/ContactsColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ContactsColumnView.qml
@@ -296,32 +296,34 @@ Item {
 
     Connections {
         target: root.store
+
         function onImportingCommunityStateChanged(communityId, state, errorMsg) {
+
+            const community = root.store.getCommunityDetailsAsJson(communityId)
             let title = ""
+            let subTitle = ""
             let loading = false
 
-            if (state === Constants.communityImported)
+            switch (state)
             {
-                title = qsTr("Community imported")
-            }
-            else if (state === Constants.communityImportingInProgress)
-            {
+            case Constants.communityImported:
+                title = qsTr("%1 community imported").arg(community.name);
+                break
+            case Constants.communityImportingInProgress:
                 title = qsTr("Importing community is in progress")
                 loading = true
-            }
-            else if (state === Constants.communityImportingError)
-            {
-                title = errorMsg
-            }
-
-            if(title == "")
-            {
-                console.error("unknown state while importing community: ", state)
+                break
+            case Constants.communityImportingError:
+                title = qsTr("%1 community importing error").arg(community.name)
+                subTitle = errorMsg
+                break
+            default:
+                console.error("unknown state while importing community: %1").arg(state)
                 return
             }
 
             Global.displayToastMessage(title,
-                                       "",
+                                       subTitle,
                                        "",
                                        loading,
                                        Constants.ephemeralNotificationType.normal,

--- a/ui/app/AppLayouts/CommunitiesPortal/stores/CommunitiesStore.qml
+++ b/ui/app/AppLayouts/CommunitiesPortal/stores/CommunitiesStore.qml
@@ -89,14 +89,12 @@ QtObject {
         root.communitiesModuleInst.importCommunity(communityKey);
     }
 
-    function requestCommunityInfo(communityKey) {
-        let publicKey = communityKey
-        if (Utils.isCompressedPubKey(communityKey)) {
-            publicKey = Utils.changeCommunityKeyCompression(communityKey)
-        }
-
+    function requestCommunityInfo(communityKey, importing = false) {
+        const publicKey = Utils.isCompressedPubKey(communityKey)
+                            ? Utils.changeCommunityKeyCompression(communityKey)
+                            : communityKey
         root.mainModuleInst.setCommunityIdToSpectate(publicKey)
-        root.communitiesModuleInst.requestCommunityInfo(publicKey);
+        root.communitiesModuleInst.requestCommunityInfo(publicKey, importing)
     }
 
     function setActiveCommunity(communityId) {

--- a/ui/imports/shared/popups/ImportCommunityPopup.qml
+++ b/ui/imports/shared/popups/ImportCommunityPopup.qml
@@ -50,7 +50,8 @@ StatusDialog {
                   }
                   if (d.isPublicKey) {
                     importButton.loading = true
-                    root.store.requestCommunityInfo(communityKey)
+                    root.store.requestCommunityInfo(communityKey, true)
+                    root.close();
                   }
               }
             }


### PR DESCRIPTION
Fixes #8970
(including @John-44 [comment](https://github.com/status-im/status-desktop/issues/8970#issuecomment-1372653309) about imrpovements)

### What does the PR do

1. Remove "Community imported" notification when automatically loading information in background.
(e.g. when seeing a community invitation bubble in chat)
2. Show "Community imported" when community was imported with public key
3. Added community name to "Community imported" notification
4. Close import community popup after information requested with public key

### Screenshot of functionality (including design for comparison)

https://user-images.githubusercontent.com/25482501/213178283-9d59b26d-9571-4858-9415-d55319a4abe2.mov

### For those who's interested in calls order:

**BEFORE:**

<img width="997" alt="image" src="https://user-images.githubusercontent.com/25482501/213177630-80c282be-7861-4b03-9556-0260bbc7aab4.png">

**AFTER:**

<img width="972" alt="image" src="https://user-images.githubusercontent.com/25482501/213177677-f4113122-ac40-4eef-b5f3-fd9a3a01681a.png">

