### PR TITLE
Fix QML warnings after Qt5.15 migration

### DIFF
--- a/ui/StatusQ/src/StatusQ/Controls/StatusSeedPhraseInput.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusSeedPhraseInput.qml
@@ -176,7 +176,7 @@ Item {
         // Consider word inserted if input looses focus while a valid word is present ("user" clicks outside)
         Connections {
             target: seedWordInput.input.edit
-            onActiveFocusChanged: {
+            function onActiveFocusChanged() {
                 if (!seedWordInput.input.edit.activeFocus && d.isInputValidWord) {
                     // There are so many side effects regarding focus and doneInsertingWord that we need to reset this flag not to be processed again.
                     d.isInputValidWord = false

--- a/ui/app/AppLayouts/Browser/BrowserLayout.qml
+++ b/ui/app/AppLayouts/Browser/BrowserLayout.qml
@@ -596,7 +596,7 @@ StatusSectionLayout {
 
     Connections {
         target: _internal.currentWebView
-        onUrlChanged: {
+        function onUrlChanged() {
             browserHeader.addressBar.text = Web3ProviderStore.obtainAddress(_internal.currentWebView.url)
             RootStore.currentTabConnected = Web3ProviderStore.hasWalletConnected(Utils.getHostname(_internal.currentWebView.url))
         }
@@ -604,14 +604,14 @@ StatusSectionLayout {
 
     Connections {
         target: BookmarksStore.bookmarksModel
-        onModelChanged: {
+        function onModelChanged() {
             browserHeader.currentFavorite = Qt.binding(function () {return BookmarksStore.getCurrentFavorite(_internal.currentWebView.url)})
         }
     }
 
     Connections {
         target: browserSection
-        onOpenUrl: {
+        function onOpenUrl(url: string) {
             root.openUrlInNewTab(url);
         }
     }

--- a/ui/app/AppLayouts/Browser/panels/DownloadBar.qml
+++ b/ui/app/AppLayouts/Browser/panels/DownloadBar.qml
@@ -85,7 +85,7 @@ Rectangle {
                 }
                 Connections {
                     target: downloadsMenu
-                    onCancelClicked: {
+                    function onCancelClicked() {
                         isCanceled = true
                     }
                 }

--- a/ui/app/AppLayouts/Browser/panels/DownloadView.qml
+++ b/ui/app/AppLayouts/Browser/panels/DownloadView.qml
@@ -61,7 +61,7 @@ import "../controls"
             }
             Connections {
                 target: downloadsMenu
-                onCancelClicked: {
+                function onCancelClicked() {
                     isCanceled = true
                 }
             }

--- a/ui/app/AppLayouts/Browser/popups/BrowserWalletMenu.qml
+++ b/ui/app/AppLayouts/Browser/popups/BrowserWalletMenu.qml
@@ -102,7 +102,7 @@ Popup {
 
     Connections {
         target: WalletStore.dappBrowserAccount
-        onConnectedAccountDeleted: {
+        function onConnectedAccountDeleted() {
             popup.reload()
             // This is done because when an account is deleted and the account is updated to default one,
             // only the properties are updated and we need to listen to those events and update the selected account

--- a/ui/app/AppLayouts/Browser/views/WebProviderObj.qml
+++ b/ui/app/AppLayouts/Browser/views/WebProviderObj.qml
@@ -30,7 +30,7 @@ QtObject {
     property Connections conn: Connections {
         target: Web3ProviderStore.web3ProviderInst
 
-        onPostMessageResult: {
+        function onPostMessageResult(payloadMethod: string, result: string, chainId: string) {
             web3Response(result)
             const isSign = ["eth_sign", "personal_sign", "eth_signTypedData", "eth_signTypedData_v3"].indexOf(payloadMethod) > -1
             const isTx = payloadMethod === "eth_sendTransaction"

--- a/ui/app/AppLayouts/Chat/popups/community/CreateChannelPopup.qml
+++ b/ui/app/AppLayouts/Chat/popups/community/CreateChannelPopup.qml
@@ -65,11 +65,11 @@ StatusDialog {
         enabled: root.opened && root.emojiPopupOpened
         target: emojiPopup
 
-        onEmojiSelected: function (emojiText, atCursor) {
+        function onEmojiSelected(emojiText: string, atCursor: bool) {
             nameInput.input.asset.isLetterIdenticon = false;
             nameInput.input.asset.emoji = emojiText
         }
-        onClosed: {
+        function onClosed() {
             root.emojiPopupOpened = false
         }
     }

--- a/ui/app/AppLayouts/Chat/views/CommunityColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/CommunityColumnView.qml
@@ -124,7 +124,7 @@ Item {
 
         Connections {
             target: root.store.communitiesModuleInst
-            onCommunityAccessRequested: function (communityId) {
+            function onCommunityAccessRequested(communityId: string) {
                 if (communityId === communityData.id) {
                     joinCommunityButton.invitationPending = root.store.isCommunityRequestPending(communityData.id)
                 }
@@ -608,7 +608,7 @@ Item {
     Connections {
         target: root.store.mainModuleInst
 
-        onOpenCommunityMembershipRequestsPopup:{
+        function onOpenCommunityMembershipRequestsPopup(sectionId: string) {
             if(root.store.getMySectionId() != sectionId)
                 return
 

--- a/ui/app/AppLayouts/Chat/views/MembersSelectorView.qml
+++ b/ui/app/AppLayouts/Chat/views/MembersSelectorView.qml
@@ -88,7 +88,7 @@ MembersSelectorBase {
     Connections {
         enabled: root.visible
         target: root.rootStore.contactsStore.mainModuleInst
-        onResolvedENS: {
+        function onResolvedENS(resolvedPubKey: string, resolvedAddress: string, uuid: string) {
             if (resolvedPubKey === "") {
                 root.suggestionsDialog.forceHide = false
                 return

--- a/ui/app/AppLayouts/Onboarding/OnboardingLayout.qml
+++ b/ui/app/AppLayouts/Onboarding/OnboardingLayout.qml
@@ -138,7 +138,7 @@ OnboardingBasePage {
 
     Connections {
         target: root.startupStore.startupModuleInst
-        onStartupError: {
+        function onStartupError(error: string, errType: int) {
             msgDialog.errType = errType
             if (errType === Constants.startupErrorType.setupAccError) {
                 if (error === Constants.existingAccountError) {
@@ -172,10 +172,10 @@ following the \"Add existing Status user\" flow, using your seed phrase.")
             msgDialog.open()
         }
 
-        onDisplayKeycardSharedModuleFlow: {
+        function onDisplayKeycardSharedModuleFlow() {
             keycardPopup.active = true
         }
-        onDestroyKeycardSharedModuleFlow: {
+        function onDestroyKeycardSharedModuleFlow() {
             keycardPopup.active = false
         }
     }

--- a/ui/app/AppLayouts/Onboarding/views/ConfirmPasswordView.qml
+++ b/ui/app/AppLayouts/Onboarding/views/ConfirmPasswordView.qml
@@ -142,7 +142,7 @@ Item {
 
     Connections {
         target: RootStore.privacyModule
-        onPasswordChanged: {
+        function onPasswordChanged(success: bool, errorMsg: string) {
             if (success) {
                 submitBtn.loading = false
                 root.exit();

--- a/ui/app/AppLayouts/Onboarding/views/LoginView.qml
+++ b/ui/app/AppLayouts/Onboarding/views/LoginView.qml
@@ -105,7 +105,7 @@ Item {
     Connections{
         target: root.startupStore.startupModuleInst
 
-        onObtainingPasswordError: {
+        function onObtainingPasswordError(errorDescription: string, errorType: string) {
             if (errorType === Constants.keychain.errorType.authentication) {
                 // We are notifying user only about keychain errors.
                 return
@@ -120,7 +120,7 @@ Item {
             obtainingPasswordErrorNotification.open()
         }
 
-        onObtainingPasswordSuccess: {
+        function onObtainingPasswordSuccess(password: string) {
             if(localAccountSettings.storeToKeychainValue !== Constants.keychain.storedValue.store)
                 return
 
@@ -132,7 +132,7 @@ Item {
             }
         }
 
-        onAccountLoginError: {
+        function onAccountLoginError(error: string) {
             if (error) {
                 if (!root.startupStore.selectedLoginAccount.keycardCreatedAccount) {
                     // SQLITE_NOTADB: "file is not a database"

--- a/ui/app/AppLayouts/Profile/ProfileLayout.qml
+++ b/ui/app/AppLayouts/Profile/ProfileLayout.qml
@@ -5,6 +5,7 @@ import QtQuick.Layouts 1.13
 import utils 1.0
 import shared 1.0
 import shared.panels 1.0
+import shared.stores 1.0 as SharedStores
 
 import "stores"
 import "popups"
@@ -193,7 +194,7 @@ StatusSectionLayout {
                 implicitHeight: parent.height
 
                 languageStore: root.store.languageStore
-                currencyStore: root.store.walletStore.currencyStore
+                currencyStore: SharedStores.RootStore.currencyStore
                 sectionTitle: root.store.getNameForSubsection(Constants.settingsSubsection.language)
                 contentWidth: d.contentWidth
             }

--- a/ui/app/AppLayouts/Profile/popups/ChangePasswordModal.qml
+++ b/ui/app/AppLayouts/Profile/popups/ChangePasswordModal.qml
@@ -55,7 +55,9 @@ StatusModal {
 
     Connections {
         target: root.privacyStore.privacyModule
-        onPasswordChanged: onChangePasswordResponse(success, errorMsg)
+        function onPasswordChanged(success: bool, errorMsg: string) {
+            onChangePasswordResponse(success, errorMsg)
+        }
     }
 
     width: 480

--- a/ui/app/AppLayouts/Profile/popups/RenameAccontModal.qml
+++ b/ui/app/AppLayouts/Profile/popups/RenameAccontModal.qml
@@ -34,7 +34,7 @@ StatusModal {
     Connections {
         enabled: popup.opened
         target: emojiPopup
-        onEmojiSelected: function (emojiText, atCursor) {
+        function onEmojiSelected(emojiText: string, atCursor: bool) {
             popup.contentItem.accountNameInput.input.asset.emoji = emojiText
         }
     }

--- a/ui/app/AppLayouts/Profile/popups/SendContactRequestModal.qml
+++ b/ui/app/AppLayouts/Profile/popups/SendContactRequestModal.qml
@@ -65,7 +65,7 @@ StatusModal {
 
     Connections {
         target: contactsStore.mainModuleInst
-        onResolvedENS: {
+        function onResolvedENS(resolvedPubKey: string, resolvedAddress: string, uuid: string) {
             if(!d.showChatKeyValidationIndicator){
                 d.showPasteButton = false
                 d.showChatKeyValidationIndicator = true

--- a/ui/app/AppLayouts/Profile/stores/WalletStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/WalletStore.qml
@@ -1,6 +1,5 @@
 import QtQuick 2.13
 
-import shared.stores 1.0 as SharedStore
 import "../../Wallet/stores"
 
 QtObject {
@@ -21,9 +20,7 @@ QtObject {
     property var importedAccounts: walletSectionAccounts.imported
     property var generatedAccounts: walletSectionAccounts.generated
     property var watchOnlyAccounts: walletSectionAccounts.watchOnly
-
-    property var currencyStore: SharedStore.RootStore.currencyStore
-
+    
     property var currentAccount: walletSectionCurrent
 
     function switchAccountByAddress(address) {

--- a/ui/app/AppLayouts/Profile/views/EnsDetailsView.qml
+++ b/ui/app/AppLayouts/Profile/views/EnsDetailsView.qml
@@ -57,7 +57,7 @@ Item {
 
     Connections {
         target: root.ensUsernamesStore.ensUsernamesModule
-        onDetailsObtained: {
+        function onDetailsObtained(ensName: string, address: string, pubkey: string, isStatus: bool, expirationTime: int) {
             if(username != (isStatus ? ensName + ".stateofus.eth" : ensName))
                 return;
             walletAddressLbl.subTitle = address;
@@ -71,7 +71,7 @@ Item {
                                  && root.ensUsernamesStore.preferredUsername !== username
             d.expirationTimestamp = expirationTime * 1000
         }
-        onLoading: {
+        function onLoading(isLoading: bool) {
             loadingImg.active = isLoading
             if (!isLoading)
                 return;
@@ -152,7 +152,7 @@ Item {
             }
             Connections {
                 target: root.ensUsernamesStore.ensUsernamesModule
-                onTransactionWasSent: {
+                function onTransactionWasSent(txResult: string) {
                     try {
                         let response = JSON.parse(txResult)
                         if (!response.success) {

--- a/ui/app/AppLayouts/Profile/views/EnsListView.qml
+++ b/ui/app/AppLayouts/Profile/views/EnsListView.qml
@@ -43,7 +43,7 @@ Item {
 
     Connections {
         target: root.ensUsernamesStore.ensUsernamesModule
-        onUsernameConfirmed: {
+        function onUsernameConfirmed(username: string) {
             d.updateNumberOfPendingEnsUsernames()
             chatSettingsLabel.visible = true
         }

--- a/ui/app/AppLayouts/Profile/views/EnsSearchView.qml
+++ b/ui/app/AppLayouts/Profile/views/EnsSearchView.qml
@@ -98,7 +98,7 @@ Item {
             }
             Connections {
                 target: root.ensUsernamesStore.ensUsernamesModule
-                onTransactionWasSent: {
+                function onTransactionWasSent(txResult: string) {
                     try {
                         let response = JSON.parse(txResult)
                         if (!response.success) {
@@ -189,7 +189,7 @@ Item {
 
             Connections {
                 target: root.ensUsernamesStore.ensUsernamesModule
-                onUsernameAvailabilityChecked: {
+                function onUsernameAvailabilityChecked(availabilityStatus: string) {
                     if(!validate(ensUsername.text)) return;
                     valid = false;
                     loading = false;

--- a/ui/app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml
+++ b/ui/app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml
@@ -85,7 +85,7 @@ Item {
             }
             Connections {
                 target: root.ensUsernamesStore.ensUsernamesModule
-                onTransactionWasSent: {
+                function onTransactionWasSent(txResult: string) {
                     try {
                         let response = JSON.parse(txResult)
                         if (!response.success) {

--- a/ui/app/AppLayouts/Profile/views/EnsView.qml
+++ b/ui/app/AppLayouts/Profile/views/EnsView.qml
@@ -315,14 +315,14 @@ Item {
 
     Connections {
         target: ensView
-        onConnect: {
+        function onConnect(ensUsername: string) {
             addedUsername = ensUsername;
         }
     }
 
     Connections {
         target: ensView.ensUsernamesStore.ensUsernamesModule
-        onTransactionCompleted: {
+        function onTransactionCompleted(success: bool, txHash: string, username: string, trxType: string, revertReason: string) {
             let title = ""
             switch(trxType){
             case "RegisterENS":

--- a/ui/app/AppLayouts/Profile/views/KeycardView.qml
+++ b/ui/app/AppLayouts/Profile/views/KeycardView.qml
@@ -89,10 +89,10 @@ SettingsContentBase {
         Connections {
             target: root.keycardStore.keycardModule
 
-            onDisplayKeycardSharedModuleFlow: {
+            function onDisplayKeycardSharedModuleFlow() {
                 keycardPopup.active = true
             }
-            onDestroyKeycardSharedModuleFlow: {
+            function onDestroyKeycardSharedModuleFlow() {
                 keycardPopup.active = false
             }
             onSharedModuleBusy: {

--- a/ui/app/AppLayouts/Profile/views/MessagingView.qml
+++ b/ui/app/AppLayouts/Profile/views/MessagingView.qml
@@ -238,7 +238,9 @@ SettingsContentBase {
 
             Connections {
                 target: localAccountSensitiveSettings
-                onWhitelistedUnfurlingSitesChanged: generalColumn.populatePreviewableSites()
+                function onWhitelistedUnfurlingSitesChanged() {
+                    generalColumn.populatePreviewableSites()
+                }
             }
 
             // Manually add switch for the image unfurling

--- a/ui/app/AppLayouts/Wallet/panels/DerivedAddressesPanel.qml
+++ b/ui/app/AppLayouts/Wallet/panels/DerivedAddressesPanel.qml
@@ -15,7 +15,7 @@ import "../stores"
 Item {
     id: derivedAddresses
 
-    property int selectedAccountType: RootStore.defaultSelectedType
+    property int selectedAccountType: Constants.AddAccountType.GenerateNew
     property string selectedKeyUid: RootStore.defaultSelectedKeyUid
     property bool selectedKeyUidMigratedToKeycard: RootStore.defaultSelectedKeyUidMigratedToKeycard
     property string selectedPath: ""
@@ -52,8 +52,8 @@ Item {
         id: _internal
 
         readonly property bool showEnterPinPassButton: !RootStore.loggedInUserAuthenticated &&
-                                                       derivedAddresses.selectedAccountType !== SelectGeneratedAccount.AddAccountType.ImportSeedPhrase &&
-                                                       derivedAddresses.selectedAccountType !== SelectGeneratedAccount.AddAccountType.ImportPrivateKey
+                                                       derivedAddresses.selectedAccountType !== Constants.AddAccountType.ImportSeedPhrase &&
+                                                       derivedAddresses.selectedAccountType !== Constants.AddAccountType.ImportPrivateKey
         property int pageSize: 6
         property int noOfPages: Math.ceil(RootStore.derivedAddressesList.count/pageSize)
         property int lastPageSize: RootStore.derivedAddressesList.count - ((noOfPages -1) * pageSize)
@@ -85,7 +85,7 @@ Item {
 
     Connections {
         target: RootStore.derivedAddressesList
-        onModelReset: {
+        function onModelReset() {
             _internal.pageSize = 0
             _internal.pageSize = 6
             _internal.nextSelectableAddressIndex = -1

--- a/ui/app/AppLayouts/Wallet/panels/SelectGeneratedAccount.qml
+++ b/ui/app/AppLayouts/Wallet/panels/SelectGeneratedAccount.qml
@@ -17,24 +17,16 @@ StatusSelect {
     property string selectedKeyUid: userProfile.keyUid
     property bool selectedKeyUidMigratedToKeycard: userProfile.isKeycardUser
 
-
-    enum AddAccountType {
-        GenerateNew,
-        ImportSeedPhrase,
-        ImportPrivateKey,
-        WatchOnly
-    }
-
     function resetMe() {
         _internal.getGeneratedAccountsModel()
-        selectAccountType.addAccountType = SelectGeneratedAccount.AddAccountType.GenerateNew
+        selectAccountType.addAccountType = Constants.AddAccountType.GenerateNew
         selectAccountType.selectedKeyUid = userProfile.keyUid
         selectAccountType.selectedKeyUidMigratedToKeycard = userProfile.isKeycardUser
     }
 
     Connections {
         target: RootStore.generatedAccountsViewModel
-        onModelReset: {
+        function onModelReset() {
             _internal.delegateModel.model = RootStore.generatedAccountsViewModel
             _internal.getGeneratedAccountsModel()
         }
@@ -116,10 +108,10 @@ StatusSelect {
             titleText.color: Theme.palette.indirectColor1
         }
         onClicked: {
-            selectAccountType.addAccountType = (model.name === _internal.importSeedPhraseString) ? SelectGeneratedAccount.AddAccountType.ImportSeedPhrase :
-                                             (model.name === _internal.importPrivateKeyString) ? SelectGeneratedAccount.AddAccountType.ImportPrivateKey :
-                                             (model.name === _internal.addWatchOnlyAccountString) ? SelectGeneratedAccount.AddAccountType.WatchOnly :
-                                             SelectGeneratedAccount.AddAccountType.GenerateNew
+            selectAccountType.addAccountType = (model.name === _internal.importSeedPhraseString) ? Constants.AddAccountType.ImportSeedPhrase :
+                                             (model.name === _internal.importPrivateKeyString) ? Constants.AddAccountType.ImportPrivateKey :
+                                             (model.name === _internal.addWatchOnlyAccountString) ? Constants.AddAccountType.WatchOnly :
+                                             Constants.AddAccountType.GenerateNew
             selectedItem.title = model.name
             selectedItem.asset.name = model.iconName
             selectedItem.tagsModel = model.generatedModel

--- a/ui/app/AppLayouts/Wallet/popups/AddAccountModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/AddAccountModal.qml
@@ -42,11 +42,11 @@ StatusModal {
 
     Connections {
         target: walletSectionAccounts
-        onUserAuthenticationSuccess: {
+        function onUserAuthenticationSuccess(password: string) {
             validationError.text = ""
             d.password = password
             RootStore.loggedInUserAuthenticated = true
-            if (d.selectedAccountType === SelectGeneratedAccount.AddAccountType.ImportPrivateKey) {
+            if (d.selectedAccountType === Constants.AddAccountType.ImportPrivateKey) {
                 d.generateNewAccount()
             }
             else {
@@ -55,7 +55,7 @@ StatusModal {
                 }
             }
         }
-        onUserAuthentiactionFail: {
+        function onUserAuthentiactionFail() {
             d.password = ""
             RootStore.loggedInUserAuthenticated = false
             validationError.text = qsTr("An authentication failed")
@@ -70,7 +70,7 @@ StatusModal {
         readonly property int pageNumber: 1
 
         property string password: ""
-        property int selectedAccountType: RootStore.defaultSelectedType
+        property int selectedAccountType: Constants.AddAccountType.GenerateNew
         property string selectedAccountDerivedFromAddress: ""
         property string selectedKeyUid: RootStore.defaultSelectedKeyUid
         property bool selectedKeyUidMigratedToKeycard: RootStore.defaultSelectedKeyUidMigratedToKeycard
@@ -78,7 +78,7 @@ StatusModal {
         property string selectedAddress: ""
         property bool selectedAddressAvailable: true
 
-        readonly property bool authenticationNeeded: d.selectedAccountType !== SelectGeneratedAccount.AddAccountType.WatchOnly &&
+        readonly property bool authenticationNeeded: d.selectedAccountType !== Constants.AddAccountType.WatchOnly &&
                                                      d.password === ""
         property string addAccountIcon: ""
 
@@ -90,7 +90,7 @@ StatusModal {
         }
 
         function getDerivedAddressList() {
-            if(d.selectedAccountType === SelectGeneratedAccount.AddAccountType.ImportSeedPhrase
+            if(d.selectedAccountType === Constants.AddAccountType.ImportSeedPhrase
                     && !!advancedSelection.expandableItem.path
                     && !!advancedSelection.expandableItem.mnemonicText) {
                 RootStore.getDerivedAddressListForMnemonic(advancedSelection.expandableItem.mnemonicText,
@@ -113,7 +113,7 @@ StatusModal {
             let errMessage = ""
 
             switch(d.selectedAccountType) {
-            case SelectGeneratedAccount.AddAccountType.GenerateNew:
+            case Constants.AddAccountType.GenerateNew:
                 if (d.selectedKeyUidMigratedToKeycard) {
                     errMessage = RootStore.addNewWalletAccountGeneratedFromKeycard(Constants.generatedWalletType,
                                                                                    accountNameInput.text,
@@ -126,16 +126,16 @@ StatusModal {
                                                           advancedSelection.expandableItem.derivedFromAddress)
                 }
                 break
-            case SelectGeneratedAccount.AddAccountType.ImportSeedPhrase:
+            case Constants.AddAccountType.ImportSeedPhrase:
                 errMessage = RootStore.addAccountsFromSeed(advancedSelection.expandableItem.mnemonicText, d.password,
                                                            accountNameInput.text, colorSelectionGrid.selectedColor, accountNameInput.input.asset.emoji,
                                                            advancedSelection.expandableItem.completePath)
                 break
-            case SelectGeneratedAccount.AddAccountType.ImportPrivateKey:
+            case Constants.AddAccountType.ImportPrivateKey:
                 errMessage = RootStore.addAccountsFromPrivateKey(advancedSelection.expandableItem.privateKey, d.password,
                                                                  accountNameInput.text, colorSelectionGrid.selectedColor, accountNameInput.input.asset.emoji)
                 break
-            case SelectGeneratedAccount.AddAccountType.WatchOnly:
+            case Constants.AddAccountType.WatchOnly:
                 errMessage = RootStore.addWatchOnlyAccount(advancedSelection.expandableItem.watchAddress, accountNameInput.text,
                                                            colorSelectionGrid.selectedColor, accountNameInput.input.asset.emoji)
                 break
@@ -156,7 +156,7 @@ StatusModal {
             if (d.authenticationNeeded) {
                 d.password = ""
                 if (d.selectedKeyUidMigratedToKeycard &&
-                        d.selectedAccountType === SelectGeneratedAccount.AddAccountType.GenerateNew) {
+                        d.selectedAccountType === Constants.AddAccountType.GenerateNew) {
                     RootStore.authenticateUserAndDeriveAddressOnKeycardForPath(d.selectedKeyUid, d.selectedPath)
                 }
                 else {

--- a/ui/app/AppLayouts/Wallet/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Wallet/stores/RootStore.qml
@@ -3,14 +3,11 @@ pragma Singleton
 import QtQuick 2.13
 
 import utils 1.0
-import shared.stores 1.0 as SharedStore
-
 import "../panels"
 
 QtObject {
     id: root
 
-    readonly property int defaultSelectedType: SelectGeneratedAccount.AddAccountType.GenerateNew
     readonly property string defaultSelectedKeyUid: userProfile.keyUid
     readonly property bool defaultSelectedKeyUidMigratedToKeycard: userProfile.isKeycardUser
 
@@ -24,8 +21,6 @@ QtObject {
     property var accountSensitiveSettings: localAccountSensitiveSettings
     property bool hideSignPhraseModal: accountSensitiveSettings.hideSignPhraseModal
 
-    property var currencyStore: SharedStore.RootStore.currencyStore
-    property string currentCurrency: currencyStore.currentCurrency
     property var totalCurrencyBalance: walletSection.totalCurrencyBalance
     property bool tokensLoading: walletSection.tokensLoading
     property string signingPhrase: walletSection.signingPhrase

--- a/ui/app/AppLayouts/Wallet/views/AssetsDetailView.qml
+++ b/ui/app/AppLayouts/Wallet/views/AssetsDetailView.qml
@@ -36,7 +36,7 @@ Item {
 
     Connections {
         target: walletSectionAllTokens
-        onTokenHistoricalDataReady: {
+        function onTokenHistoricalDataReady(tokenDetails: string) {
             let response = JSON.parse(tokenDetails)
             if (response === null) {
                 console.debug("error parsing json message for tokenHistoricalDataReady")

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -58,29 +58,31 @@ Item {
     Connections {
         target: rootStore.mainModuleInst
 
-        onDisplayUserProfile: Global.openProfilePopup(publicKey)
+        function onDisplayUserProfile(publicKey: string) {
+            Global.openProfilePopup(publicKey)
+        }
 
-        onDisplayKeycardSharedModuleFlow: {
+        function onDisplayKeycardSharedModuleFlow() {
             keycardPopup.active = true
         }
 
-        onDestroyKeycardSharedModuleFlow: {
+        function onDestroyKeycardSharedModuleFlow() {
             keycardPopup.active = false
         }
 
-        onMailserverWorking: {
+        function onMailserverWorking() {
             mailserverConnectionBanner.hide()
         }
 
-        onMailserverNotWorking: {
+        function onMailserverNotWorking() {
             mailserverConnectionBanner.show()
         }
 
-        onActiveSectionChanged: {
+        function onActiveSectionChanged() {
             createChatView.opened = false
         }
 
-        onOpenActivityCenter: {
+        function onOpenActivityCenter() {
             Global.openPopup(activityCenterPopupComponent)
         }
     }
@@ -99,14 +101,14 @@ Item {
 
     Connections {
         target: Global
-        onOpenLinkInBrowser: {
+        function onOpenLinkInBrowser(link: string) {
             changeAppSectionBySectionId(Constants.appSection.browser)
             Qt.callLater(() => browserLayoutContainer.item.openUrlInNewTab(link));
         }
-        onOpenChooseBrowserPopup: {
+        function onOpenChooseBrowserPopup(link: string) {
             Global.openPopup(chooseBrowserPopupComponent, {link: link});
         }
-        onOpenDownloadModalRequested: {
+        function onOpenDownloadModalRequested(available: bool, version: string, url: string) {
             const downloadPage = downloadPageComponent.createObject(appMain,
                 {
                     newVersionAvailable: available,
@@ -117,52 +119,57 @@ Item {
             return downloadPage
         }
 
-        onOpenImagePopup: {
+        function onOpenImagePopup(image, contextMenu) {
             var popup = imagePopupComponent.createObject(appMain)
             popup.contextMenu = contextMenu
             popup.openPopup(image)
         }
 
-        onOpenCreateChatView: {
+        function onOpenCreateChatView() {
             createChatView.opened = true
         }
 
-        onCloseCreateChatView: {
+        function onCloseCreateChatView() {
             createChatView.opened = false
         }
 
-        onOpenProfilePopupRequested: {
+        function onOpenProfilePopupRequested(publicKey: string, parentPopup) {
             if (Global.profilePopupOpened) {
                 appMain.closeProfilePopup()
             }
             Global.openPopup(profilePopupComponent, {publicKey: publicKey, parentPopup: parentPopup})
             Global.profilePopupOpened = true
         }
-        onOpenNicknamePopupRequested: {
+        function onOpenNicknamePopupRequested(publicKey: string,nickname: string, subtitle: string) {
             Global.openPopup(nicknamePopupComponent, {publicKey: publicKey, nickname: nickname, "header.subTitle": subtitle})
         }
-        onBlockContactRequested: {
+        function onBlockContactRequested(publicKey: string, contactName: string) {
             Global.openPopup(blockContactConfirmationComponent, {contactName: contactName, contactAddress: publicKey})
         }
-        onUnblockContactRequested: {
+        function onUnblockContactRequested(publicKey: string, contactName: string) {
             Global.openPopup(unblockContactConfirmationComponent, {contactName: contactName, contactAddress: publicKey})
         }
 
-        onOpenActivityCenterPopupRequested: {
+        function onOpenActivityCenterPopupRequested(publicKey: string, contactName: string) {
             Global.openPopup(activityCenterPopupComponent)
         }
 
-        onOpenChangeProfilePicPopup: {
+        function onOpenChangeProfilePicPopup(cb) {
             var popup = changeProfilePicComponent.createObject(appMain, {callback: cb});
             popup.chooseImageToCrop();
         }
-        onOpenBackUpSeedPopup: Global.openPopup(backupSeedModalComponent)
-        onDisplayToastMessage: {
+        function onOpenBackUpSeedPopup() {
+            Global.openPopup(backupSeedModalComponent)
+        }
+        function onDisplayToastMessage(title: string, subTitle: string, icon: string, loading: bool, ephNotifType: int, url: string) {
             appMain.rootStore.mainModuleInst.displayEphemeralNotification(title, subTitle, icon, loading, ephNotifType, url);
         }
-        onOpenEditDisplayNamePopup: Global.openPopup(displayNamePopupComponent)
+        function onOpenEditDisplayNamePopup() {
+            Global.openPopup(displayNamePopupComponent)
+        }
 
-        onOpenPopupRequested: {
+        function onOpenPopupRequested(popupComponent, params) {
+
             if (activePopupComponents.includes(popupComponent)) {
                 return;
             }
@@ -181,7 +188,7 @@ Item {
             return popup;
         }
 
-        onOpenLink: {
+        function onOpenLink(link: string) {
             // Qt sometimes inserts random HTML tags; and this will break on invalid URL inside QDesktopServices::openUrl(link)
             link = appMain.rootStore.plainText(link);
             if (appMain.rootStore.showBrowserSelector) {
@@ -196,13 +203,13 @@ Item {
             }
         }
 
-        onSetNthEnabledSectionActive: {
+        function onSetNthEnabledSectionActive(nthSection: int) {
             if(!appMain.rootStore.mainModuleInst)
                 return
             appMain.rootStore.mainModuleInst.setNthEnabledSectionActive(nthSection)
         }
 
-        onAppSectionBySectionTypeChanged: {
+        function onAppSectionBySectionTypeChanged(sectionType: int, subsection: int) {
             if(!appMain.rootStore.mainModuleInst)
                 return
 
@@ -598,7 +605,7 @@ Item {
 
                 Connections {
                     target: rootStore.aboutModuleInst
-                    onAppVersionFetched: {
+                    function onAppVersionFetched(available: bool, version: string, url: string) {
                         rootStore.setLatestVersionInfo(available, version, url);
                         bannersLayout.processUpdateAvailable()
                     }

--- a/ui/app/mainui/AppSearch.qml
+++ b/ui/app/mainui/AppSearch.qml
@@ -28,7 +28,7 @@ Item {
 
     Connections {
         target: appSearch.store.locationMenuModel
-        onModelAboutToBeReset: {
+        function onModelAboutToBeReset() {
              while (searchPopupMenu.takeItem(searchPopupMenu.numDefaultItems)) {
                 // Delete the item right after the default items
                 // If takeItem returns null, it means there was nothing to remove
@@ -38,7 +38,9 @@ Item {
 
     Connections {
         target: appSearch.store.appSearchModule
-        onAppSearchCompleted: searchPopup.loading = false
+        function onAppSearchCompleted() {
+            searchPopup.loading = false
+        } 
     }
 
     StatusSearchLocationMenu {

--- a/ui/imports/shared/PolyfillNumberToLocaleString.js
+++ b/ui/imports/shared/PolyfillNumberToLocaleString.js
@@ -1,3 +1,4 @@
+.pragma library
 // polyfill.number.toLocaleDateString
 // Copied from: https://github.com/willsp/polyfill-Number.toLocaleString-with-Locales
 // Got this from MDN: 

--- a/ui/imports/shared/controls/ContactsListAndSearch.qml
+++ b/ui/imports/shared/controls/ContactsListAndSearch.qml
@@ -115,7 +115,7 @@ Item {
 
             Connections {
                 target: mainModule
-                onResolvedENS: {
+                function onResolvedENS(resolvedPubKey: string, resolvedAddress: string, uuid: string) {
                     chatKey.hasValidSearchResult = false
                     if (chatKey.text == "") {
                         ensUsername.text = "";

--- a/ui/imports/shared/popups/SendModal.qml
+++ b/ui/imports/shared/popups/SendModal.qml
@@ -48,7 +48,7 @@ StatusDialog {
 
     Connections {
         target: store.currentAccount.assets
-        onModelReset: {
+        function onModelReset() {
             popup.selectedAccount =  null
             popup.selectedAccount = store.currentAccount
         }
@@ -393,7 +393,7 @@ StatusDialog {
 
                     Connections {
                         target: store.mainModuleInst
-                        onResolvedENS: {
+                        function onResolvedENS(resolvedPubKey: string, resolvedAddress: string, uuid: string) {
                             recipientSelector.isPending = false
                             if(Utils.isValidAddress(resolvedAddress)) {
                                 d.resolvedENSAddress = resolvedAddress
@@ -474,7 +474,7 @@ StatusDialog {
 
     Connections {
         target: popup.store.walletSectionTransactionsInst
-        onSuggestedRoutesReady: {
+        function onSuggestedRoutesReady(suggestedRoutes: string) {
             let response = JSON.parse(suggestedRoutes)
             if(!!response.error) {
                 popup.isLoading = false
@@ -495,7 +495,7 @@ StatusDialog {
 
     Connections {
         target: popup.store.walletSectionTransactionsInst
-        onTransactionSent: {
+        function onTransactionSent(txResult: string) {
             d.isPendingTx = false
             try {
                 let response = JSON.parse(txResult)

--- a/ui/imports/shared/qmldir
+++ b/ui/imports/shared/qmldir
@@ -3,4 +3,4 @@ module shared
 DelegateModelGeneralized 1.0 DelegateModelGeneralized.qml
 LoadingAnimation 1.0 LoadingAnimation.qml
 MacTrafficLights 1.0 MacTrafficLights.qml
-NumberPolyFill 1.0 polyfill.number.toLocaleString.js
+NumberPolyFill 1.0 PolyfillNumberToLocaleString.js

--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -293,7 +293,7 @@ Rectangle {
         enabled: control.emojiPopupOpened
         target: emojiPopup
 
-        function onEmojiSelected(text, atCursor) {
+        function onEmojiSelected(text: string, atCursor: bool) {
             insertInTextInput(atCursor ? messageInputField.cursorPosition : messageInputField.length, text)
             emojiBtn.highlighted = false
             messageInputField.forceActiveFocus();
@@ -308,7 +308,7 @@ Rectangle {
         enabled: control.stickersPopupOpened
         target: control.stickersPopup
 
-        function onStickerSelected(hashId, packId, url) {
+        function onStickerSelected(hashId: string, packId: string, url: string ) {
             control.stickerSelected(hashId, packId, url)
             control.hideExtendedArea();
             messageInputField.forceActiveFocus();

--- a/ui/imports/shared/status/StatusStickerMarket.qml
+++ b/ui/imports/shared/status/StatusStickerMarket.qml
@@ -187,7 +187,7 @@ Item {
                         }
                         Connections {
                             target: root.store.stickersStore.stickersModule
-                            onTransactionWasSent: {
+                            function onTransactionWasSent(txResult: string) {
                                 try {
                                     let response = JSON.parse(txResult)
                                     if (!response.success) {

--- a/ui/imports/shared/status/StatusStickerPackClickPopup.qml
+++ b/ui/imports/shared/status/StatusStickerPackClickPopup.qml
@@ -102,7 +102,7 @@ ModalPopup {
                 }
                 Connections {
                     target: stickerPackDetailsPopup.store.stickersStore.stickersModule
-                    onTransactionWasSent: {
+                    function onTransactionWasSent(txResult: string) {
                         try {
                             let response = JSON.parse(txResult)
                             if (!response.success) {

--- a/ui/imports/shared/stores/TokenBalanceHistoryStore.qml
+++ b/ui/imports/shared/stores/TokenBalanceHistoryStore.qml
@@ -51,7 +51,7 @@ ChartStoreBase {
 
     Connections {
         target: walletSectionAllTokens
-        onTokenBalanceHistoryDataReady: (balanceHistory) => {
+        function onTokenBalanceHistoryDataReady(balanceHistory: string) {
            // chainId, address, symbol, timeInterval
             let response = JSON.parse(balanceHistory)
             if (response === null) {

--- a/ui/imports/shared/views/EnsResolver.qml
+++ b/ui/imports/shared/views/EnsResolver.qml
@@ -44,7 +44,7 @@ Item {
 
     Connections {
         target: mainModule
-        onResolvedENS: {
+        function onResolvedENS(resolvedPubKey: string, resolvedAddress: string, uuid: string) {
             if (uuid !== root.uuid) {
                 return
             }

--- a/ui/imports/shared/views/HistoryView.qml
+++ b/ui/imports/shared/views/HistoryView.qml
@@ -33,7 +33,7 @@ ColumnLayout {
 
     Connections {
         target: RootStore.history
-        onLoadingTrxHistoryChanged: function(isLoading, address) {
+        function onLoadingTrxHistoryChanged(isLoading: bool, address: string) {
             if (historyView.account.address.toLowerCase() === address.toLowerCase()) {
                 historyView.isLoading = isLoading
             }

--- a/ui/imports/shared/views/chat/LinksMessageView.qml
+++ b/ui/imports/shared/views/chat/LinksMessageView.qml
@@ -70,7 +70,7 @@ Column {
                 id: linkFetchConnections
                 enabled: false
                 target: root.messageStore.messageModule
-                onLinkPreviewDataWasReceived: {
+                function onLinkPreviewDataWasReceived(previewData: string) {
                     let response = {}
                     try {
                         response = JSON.parse(previewData)
@@ -106,7 +106,7 @@ Column {
                 id: linkCommunityFetchConnections
                 enabled: false
                 target: root.store.communitiesModuleInst
-                function onCommunityAdded(communityId) {
+                function onCommunityAdded(communityId: string) {
                     if (communityId !== linkData.communityId) {
                         return
                     }

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -779,6 +779,13 @@ QtObject {
         NoError
     }
 
+    enum AddAccountType {
+        GenerateNew,
+        ImportSeedPhrase,
+        ImportPrivateKey,
+        WatchOnly
+    }
+
     readonly property QtObject walletSection: QtObject {
         readonly property string cancelledMessage: "cancelled"
     }


### PR DESCRIPTION
### What does the PR do
Part of #8642

There are 3 commits in this PR:
1. Fixing QML Connections warnings due to deprecated `onFoo` handlers. Now we're using `function onFoo(params)`.
2. Fixing QML compilation error due to js filename format.
3. Fixing cyclic dependencies between qml components.