### PR TITLE
fix(message): removed extra markup when typing before mention

### DIFF
--- a/ui/app/AppLayouts/Chat/panels/SuggestionFilterPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/SuggestionFilterPanel.qml
@@ -54,7 +54,7 @@ Item {
             return
 
         this.lastAtPosition = -1
-        for (let c = cursorPosition; c >= 0; c--) {
+        for (let c = cursorPosition === 0 ? 0 : (cursorPosition-1); c >= 0; c--) {
             if (filter.charAt(c) === "@") {
                 this.lastAtPosition = c
                 break
@@ -119,12 +119,12 @@ Item {
         if (properties.length === 0) {
             return false
         }
-
         let filterWithoutAt = filter.substring(this.lastAtPosition + 1, this.cursorPosition)
         filterWithoutAt = filterWithoutAt.replace(/\*/g, "")
         suggestionsPanelRoot.formattedFilter = filterWithoutAt
 
         return !properties.every(p => item[p].toLowerCase().match(filterWithoutAt.toLowerCase()) === null)
+               && (lastAtPosition > -1)
     }
 
     function isFilteringPropertyOk() {

--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -367,7 +367,7 @@ Rectangle {
                             event.key !== Qt.Key_Backspace &&
                             event.key !== Qt.Key_Delete &&
                             event.key !== Qt.Key_Escape
-        if (mentionsPos.length > 0 && symbolPressed) {
+        if ((mentionsPos.length > 0) && symbolPressed && (messageInputField.selectedText.length === 0)) {
             for (var i = 0; i < mentionsPos.length; i++) {
                 if (messageInputField.cursorPosition === mentionsPos[i].leftIndex) {
                     d.leftOfMentionIndex = i
@@ -1223,6 +1223,7 @@ Rectangle {
 
                         TextArea {
                             id: messageInputField
+
                             objectName: "messageInputField"
 
                             property var lastClick: 0
@@ -1260,21 +1261,21 @@ Rectangle {
                             }
 
                             onCursorPositionChanged: {
-                                if(mentionsPos.length > 0) {
+                                if(mentionsPos.length > 0 && ((keyEvent.key === Qt.Key_Left) || (keyEvent.key === Qt.Key_Right)
+                                  || (selectedText.length>0))) {
                                     const mention = d.getMentionAtPosition(cursorPosition)
-                                    if(mention) {
-                                        const cursorMovingLeft = cursorPosition < previousCursorPosition
+                                    if (mention) {
+                                        const cursorMovingLeft = (cursorPosition < previousCursorPosition);
                                         const newCursorPosition = cursorMovingLeft ?
-                                                               mention.leftIndex :
-                                                               mention.rightIndex
-                                        const isSelection = selectionStart != selectionEnd
+                                                                    mention.leftIndex :
+                                                                    mention.rightIndex
+                                        const isSelection = (selectedText.length>0);
                                         isSelection ? moveCursorSelection(newCursorPosition, TextEdit.SelectCharacters) :
                                                       cursorPosition = newCursorPosition
                                     }
                                 }
 
                                 inputScrollView.ensureVisible(cursorRectangle)
-
                                 previousCursorPosition = cursorPosition
                             }
 


### PR DESCRIPTION
Closes #8495

### What does the PR do
removes extra markup when typing any text before mention

### Affected areas
status chat input & text message

https://user-images.githubusercontent.com/31625338/213291232-4bc50abd-198e-4d73-8efd-6729c480f9ae.mov



one more bug found related to @everyone mention, reported [here](https://github.com/status-im/status-desktop/issues/9186)