### PR TITLE
[CHERRY_PICK] fix: make avatar info in replies of imported messages work again

### DIFF
--- a/src/app/modules/main/activity_center/module.nim
+++ b/src/app/modules/main/activity_center/module.nim
@@ -106,6 +106,7 @@ proc createMessageItemFromDto(self: Module, message: MessageDto, chatDetails: Ch
     self.controller.getRenderedText( message.quotedMessage.parsedText),
     message.quotedMessage.contentType,
     message.quotedMessage.deleted,
+    message.quotedMessage.discordMessage,
     ))
 
 method convertToItems*(

--- a/src/app/modules/main/chat_section/chat_content/messages/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/module.nim
@@ -110,6 +110,7 @@ proc createFetchMoreMessagesItem(self: Module): Item =
     quotedMessageParsedText = "",
     quotedMessageContentType = -1,
     quotedMessageDeleted = false,
+    quotedMessageDiscordMessage = DiscordMessage(),
   )
 
 proc createChatIdentifierItem(self: Module): Item =
@@ -159,6 +160,7 @@ proc createChatIdentifierItem(self: Module): Item =
     quotedMessageParsedText = "",
     quotedMessageContentType = -1,
     quotedMessageDeleted = false,
+    quotedMessageDiscordMessage = DiscordMessage(),
   )
 
 proc checkIfMessageLoadedAndScrollToItIfItIs(self: Module) =
@@ -247,6 +249,7 @@ method newMessagesLoaded*(self: Module, messages: seq[MessageDto], reactions: se
         self.controller.getRenderedText(message.quotedMessage.parsedText),
         message.quotedMessage.contentType,
         message.quotedMessage.deleted,
+        message.quotedMessage.discordMessage,
         )
 
       for r in reactions:
@@ -357,6 +360,7 @@ method messagesAdded*(self: Module, messages: seq[MessageDto]) =
       self.controller.getRenderedText(message.quotedMessage.parsedText),
       message.quotedMessage.contentType,
       message.quotedMessage.deleted,
+      message.quotedMessage.discordMessage,
     )
 
     items.add(item)
@@ -646,6 +650,7 @@ method getMessageById*(self: Module, messageId: string): message_item.Item =
       self.controller.getRenderedText(message.quotedMessage.parsedText),
       message.quotedMessage.contentType,
       message.quotedMessage.deleted,
+      message.quotedMessage.discordMessage
       )
     return item
   return nil
@@ -671,4 +676,3 @@ method scrollToNewMessagesMarker*(self: Module) =
 
 method markAllMessagesRead*(self: Module) =
   self.view.model().markAllAsSeen()
-

--- a/src/app/modules/main/chat_section/chat_content/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/module.nim
@@ -206,6 +206,7 @@ proc buildPinnedMessageItem(self: Module, messageId: string, actionInitiatedBy: 
     self.controller.getRenderedText(message.quotedMessage.parsedText),
     message.quotedMessage.contentType,
     message.quotedMessage.deleted,
+    message.quotedMessage.discordMessage,
   )
   item.pinned = true
   item.pinnedBy = actionInitiatedBy

--- a/src/app/modules/shared_models/message_item.nim
+++ b/src/app/modules/shared_models/message_item.nim
@@ -50,6 +50,8 @@ type
     quotedMessageParsedText: string
     quotedMessageContentType: int
     quotedMessageDeleted: bool
+    quotedMessageAuthorDisplayName: string
+    quotedMessageAuthorAvatar: string
     # This is only used to update the author's details when author's details change
     quotedMessageFromIterator: int
 
@@ -89,6 +91,7 @@ proc initItem*(
     quotedMessageParsedText: string,
     quotedMessageContentType: int,
     quotedMessageDeleted: bool,
+    quotedMessageDiscordMessage: DiscordMessage,
     ): Item =
   result = Item()
   result.id = id
@@ -134,7 +137,14 @@ proc initItem*(
   result.quotedMessageDeleted = quotedMessageDeleted
   result.quotedMessageFromIterator = 0
 
-  if contentType == ContentType.DiscordMessage :
+  if quotedMessageContentType == ContentType.DiscordMessage.int:
+    result.quotedMessageAuthorDisplayName = quotedMessageDiscordMessage.author.name
+    result.quotedMessageAuthorAvatar = quotedMessageDiscordMessage.author.localUrl
+    if result.quotedMessageAuthorAvatar == "":
+      result.quotedMessageAuthorAvatar = quotedMessageDiscordMessage.author.avatarUrl
+
+  if contentType == ContentType.DiscordMessage:
+
     if result.messageText == "":
       result.messageText = discordMessage.content
       result.unparsedText = discordMessage.content
@@ -190,6 +200,7 @@ proc initNewMessagesMarkerItem*(clock, timestamp: int64): Item =
     quotedMessageParsedText = "",
     quotedMessageContentType = -1,
     quotedMessageDeleted = false,
+    quotedMessageDiscordMessage = DiscordMessage(),
   )
 
 proc `$`*(self: Item): string =
@@ -421,6 +432,8 @@ proc toJsonNode*(self: Item): JsonNode =
     "quotedMessageParsedText": self.quotedMessageParsedText,
     "quotedMessageContentType": self.quotedMessageContentType,
     "quotedMessageDeleted": self.quotedMessageDeleted,
+    "quotedMessageAuthorDisplayName": self.quotedMessageAuthorDisplayName,
+    "quotedMessageAuthorAvatar": self.quotedMessageAuthorAvatar,
   }
 
 proc editMode*(self: Item): bool {.inline.} =
@@ -482,3 +495,15 @@ proc quotedMessageFromIterator*(self: Item): int {.inline.} =
   self.quotedMessageFromIterator
 proc `quotedMessageFromIterator=`*(self: Item, value: int) {.inline.} =
   self.quotedMessageFromIterator = value
+
+proc quotedMessageAuthorDisplayName*(self: Item): string {.inline.} =
+  self.quotedMessageAuthorDisplayName
+
+proc `quotedMessageAuthorDisplayName=`*(self: Item, value: string) {.inline.} =
+  self.quotedMessageAuthorDisplayName = value
+
+proc quotedMessageAuthorAvatar*(self: Item): string {.inline.} =
+  self.quotedMessageAuthorAvatar
+
+proc `quotedMessageAuthorAvatar=`*(self: Item, value: string) {.inline.} =
+  self.quotedMessageAuthorAvatar = value

--- a/src/app/modules/shared_models/message_item_qobject.nim
+++ b/src/app/modules/shared_models/message_item_qobject.nim
@@ -46,6 +46,14 @@ QtObject:
   QtProperty[bool] quotedMessageDeleted:
     read = quotedMessageDeleted
 
+  proc quotedMessageAuthorDisplayName*(self: MessageItem): string {.slot.} = result = ?.self.messageItem.quotedMessageAuthorDisplayName
+  QtProperty[string] quotedMessageAuthorDisplayName:
+    read = quotedMessageAuthorDisplayName
+
+  proc quotedMessageAuthorAvatar*(self: MessageItem): string {.slot.} = result = ?.self.messageItem.quotedMessageAuthorAvatar
+  QtProperty[string] quotedMessageAuthorAvatar:
+    read = quotedMessageAuthorAvatar
+
   proc senderId*(self: MessageItem): string {.slot.} = result = ?.self.messageItem.senderId
   QtProperty[string] senderId:
     read = senderId

--- a/src/app/modules/shared_models/message_model.nim
+++ b/src/app/modules/shared_models/message_model.nim
@@ -51,6 +51,8 @@ type
     QuotedMessageContentType
     QuotedMessageDeleted
     QuotedMessageFromIterator
+    QuotedMessageAuthorDisplayName
+    QuotedMessageAuthorAvatar
 
 QtObject:
   type
@@ -142,6 +144,8 @@ QtObject:
       ModelRole.QuotedMessageParsedText.int: "quotedMessageParsedText",
       ModelRole.QuotedMessageContentType.int: "quotedMessageContentType",
       ModelRole.QuotedMessageDeleted.int: "quotedMessageDeleted",
+      ModelRole.QuotedMessageAuthorDisplayName.int: "quotedMessageAuthorDisplayName",
+      ModelRole.QuotedMessageAuthorAvatar.int: "quotedMessageAuthorAvatar",
     }.toTable
 
   method data(self: Model, index: QModelIndex, role: int): QVariant =
@@ -205,6 +209,10 @@ QtObject:
       result = newQVariant(item.quotedMessageContentType)
     of ModelRole.QuotedMessageDeleted:
       result = newQVariant(item.quotedMessageDeleted)
+    of ModelRole.QuotedMessageAuthorDisplayName:
+      result = newQVariant(item.quotedMessageAuthorDisplayName)
+    of ModelRole.QuotedMessageAuthorAvatar:
+      result = newQVariant(item.quotedMessageAuthorAvatar)
     of ModelRole.MessageText:
       result = newQVariant(item.messageText)
     of ModelRole.UnparsedText:

--- a/src/app_service/service/message/dto/message.nim
+++ b/src/app_service/service/message/dto/message.nim
@@ -31,13 +31,6 @@ type ParsedText* = object
   destination*: string
   children*: seq[ParsedText]
 
-type QuotedMessage* = object
-  `from`*: string
-  text*: string
-  parsedText*: seq[ParsedText]
-  contentType*: int
-  deleted*: bool
-
 type DiscordMessageAttachment* = object
   id*: string
   fileUrl*: string
@@ -60,6 +53,15 @@ type DiscordMessage* = object
   content*: string
   author*: DiscordMessageAuthor
   attachments*: seq[DiscordMessageAttachment]
+
+
+type QuotedMessage* = object
+  `from`*: string
+  text*: string
+  parsedText*: seq[ParsedText]
+  contentType*: int
+  deleted*: bool
+  discordMessage*: DiscordMessage
 
 type Sticker* = object
   hash*: string
@@ -172,6 +174,10 @@ proc toQuotedMessage*(jsonObj: JsonNode): QuotedMessage =
   if(jsonObj.getProp("parsedText", parsedTextArr) and parsedTextArr.kind == JArray):
     for pTextObj in parsedTextArr:
       result.parsedText.add(toParsedText(pTextObj))
+
+  var discordMessageObj: JsonNode
+  if(jsonObj.getProp("discordMessage", discordMessageObj)):
+    result.discordMessage = toDiscordMessage(discordMessageObj)
 
 proc toSticker*(jsonObj: JsonNode): Sticker =
   result = Sticker()

--- a/test/nim/message_model_test.nim
+++ b/test/nim/message_model_test.nim
@@ -45,6 +45,7 @@ proc createTestMessageItem(id: string, clock: int64): Item =
     quotedMessageParsedText = "",
     quotedMessageContentType = -1,
     quotedMessageDeleted = false,
+    quotedMessageDiscordMessage = DiscordMessage(),
   )
 
 let message0_chatIdentifier = createTestMessageItem("chat-identifier", -2)

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -641,14 +641,14 @@ Loader {
                     amISender: root.quotedMessageFrom === userProfile.pubKey
                     sender.id: root.quotedMessageFrom
                     sender.isContact: quotedMessageAuthorDetails.isContact
-                    sender.displayName: quotedMessageAuthorDetails.displayName
+                    sender.displayName: root.quotedMessageContentType === Constants.messageContentType.discordMessageType ? quotedMessageAuthorDisplayName : quotedMessageAuthorDetails.displayName
                     sender.isEnsVerified: quotedMessageAuthorDetails.ensVerified
                     sender.secondaryName: quotedMessageAuthorDetails.name || ""
                     sender.profileImage {
                         width: 20
                         height: 20
-                        name: quotedMessageAuthorDetails.thumbnailImage
-                        assetSettings.isImage: quotedMessageAuthorDetails.thumbnailImage !== ""
+                        name: root.quotedMessageContentType === Constants.messageContentType.discordMessageType ? quotedMessageAuthorAvatar : quotedMessageAuthorDetails.thumbnailImage
+                        assetSettings.isImage: quotedMessageAuthorDetails.thumbnailImage !== "" || quotedMessageAuthorAvatar != ""
                         showRing: (root.quotedMessageContentType !== Constants.messageContentType.discordMessageType) && !sender.isEnsVerified
                         pubkey: sender.id
                         colorId: Utils.colorIdForPubkey(sender.id)


### PR DESCRIPTION
Because we've switched to `QuotedMessage` as an attached payload to messages to make message replies data more reliable, we lost some of the author information in imported messages, that was available prior to that move.

This commit introduces `quotedMessageAuthorDisplayName` and `quotedMessageAuthorAvatar` to our model so it can be set in case we can't retrieve contact details for a given message (which is always the case for imported messages)

