### PR TITLE
feat(Community Permissions): Hide `Who holds - Add` button when there are 5 items already added

### DIFF
--- a/ui/app/AppLayouts/Chat/views/communities/CommunityNewPermissionView.qml
+++ b/ui/app/AppLayouts/Chat/views/communities/CommunityNewPermissionView.qml
@@ -70,6 +70,8 @@ StatusScrollView {
     QtObject {
         id: d
 
+        readonly property int maxHoldingsItems: 5
+
         readonly property int dropdownHorizontalOffset: 4
         readonly property int dropdownVerticalOffset: 1
 
@@ -195,6 +197,7 @@ StatusScrollView {
             tagLeftPadding: 2
             asset.height: 28
             asset.width: asset.height
+            addButton.visible: itemsModel.count < d.maxHoldingsItems
 
             property int editedIndex
             itemsModel: SortFilterProxyModel {


### PR DESCRIPTION
Closes #9195

### What does the PR do

It adds logic to hidden  `Add` button when the number of items 5 is reached.

### Affected areas

Community Permissions / Create new permission

### Screenshot of functionality

https://user-images.githubusercontent.com/97019400/213519016-b99c6f00-5cd9-4222-b834-5f8d26be46d9.mov

