### PR TITLE
[Community Permissions] Update `Is allowed`, `In` and `Hide permission` logic according to the new design

### DIFF
--- a/storybook/pages/CommunityNewPermissionViewPage.qml
+++ b/storybook/pages/CommunityNewPermissionViewPage.qml
@@ -4,51 +4,76 @@ import QtQuick.Controls 2.14
 import AppLayouts.Chat.views.communities 1.0
 import AppLayouts.Chat.stores 1.0
 
+import Storybook 1.0
 import Models 1.0
 
-Pane {
-    id: root
+SplitView {
+    orientation: Qt.Vertical
+    SplitView.fillWidth: true
 
-    CommunityNewPermissionView {
+    Logs { id: logs }
 
-        store: CommunitiesStore {
-            readonly property var assetsModel: AssetsModel {}
-            readonly property var collectiblesModel: CollectiblesModel {}
-            readonly property var channelsModel: ChannelsModel {}
-            readonly property var permissionConflict: QtObject {
-                property bool exists: true
-                property string holdings: "1 ETH"
-                property string permissions: "View and Post"
-                property string channels: "#general"
+    Pane {
+        id: root
 
-            }
+        CommunityNewPermissionView {
 
-            function editPermission(index, holdings, permissions, channels, isPrivate) {
-                logs.logEvent("CommunitiesStore::editPermission - index: " + index)
-            }
+            store: CommunitiesStore {
+                readonly property var assetsModel: AssetsModel {}
+                readonly property var collectiblesModel: CollectiblesModel {}
+                readonly property var channelsModel: ChannelsModel {}
+                readonly property var permissionConflict: QtObject {
+                    property bool exists: true
+                    property string holdings: "1 ETH"
+                    property string permissions: "View and Post"
+                    property string channels: "#general"
 
-            function duplicatePermission(index) {
-                logs.logEvent("CommunitiesStore::duplicatePermission - index: " + index)
-            }
+                }
 
-            function removePermission(index) {
-                logs.logEvent("CommunitiesStore::removePermission - index: " + index)
-            }
-        }
+                readonly property bool isOwner: isOwnerCheckBox.checked
 
-        rootStore: QtObject {
-            readonly property QtObject chatCommunitySectionModule: QtObject {
-                readonly property var model: ChannelsModel {}
-            }
+                function editPermission(index, holdings, permissions, channels, isPrivate) {
+                    logs.logEvent("CommunitiesStore::editPermission - index: " + index)
+                }
 
-            readonly property QtObject mainModuleInst: QtObject {
+                function duplicatePermission(index) {
+                    logs.logEvent("CommunitiesStore::duplicatePermission - index: " + index)
+                }
 
-                readonly property QtObject activeSection: QtObject {
-                    readonly property string name: "Socks"
-                    readonly property string image: ModelsData.icons.socks
-                    readonly property color color: "red"
+                function removePermission(index) {
+                    logs.logEvent("CommunitiesStore::removePermission - index: " + index)
                 }
             }
+
+            rootStore: QtObject {
+                readonly property QtObject chatCommunitySectionModule: QtObject {
+                    readonly property var model: ChannelsModel {}
+                }
+
+                readonly property QtObject mainModuleInst: QtObject {
+
+                    readonly property QtObject activeSection: QtObject {
+                        readonly property string name: "Socks"
+                        readonly property string image: ModelsData.icons.socks
+                        readonly property color color: "red"
+                    }
+                }
+            }
+        }
+    }
+
+    LogsAndControlsPanel {
+        id: logsAndControlsPanel
+
+        SplitView.minimumHeight: 100
+        SplitView.preferredHeight: 150
+
+        logsView.logText: logs.logText
+
+        CheckBox {
+            id: isOwnerCheckBox
+
+            text: "Is owner"
         }
     }
 }

--- a/storybook/pages/CommunityPermissionsSettingsPanelPage.qml
+++ b/storybook/pages/CommunityPermissionsSettingsPanelPage.qml
@@ -8,86 +8,85 @@ import StatusQ.Core.Theme 0.1
 import Storybook 1.0
 import Models 1.0
 
+
 SplitView {
+    orientation: Qt.Vertical
+    SplitView.fillWidth: true
+
     Logs { id: logs }
 
-    SplitView {
-        orientation: Qt.Vertical
+    Rectangle {
         SplitView.fillWidth: true
+        SplitView.fillHeight: true
+        color: Theme.palette.statusAppLayout.rightPanelBackgroundColor
+        CommunityPermissionsSettingsPanel {
+            anchors {
+                fill: parent
+                topMargin: 50
+            }
+            store: CommunitiesStore {
+                readonly property bool isOwner: isOwnerCheckBox.checked
 
-        Rectangle {
-            SplitView.fillWidth: true
-            SplitView.fillHeight: true
-            color: Theme.palette.statusAppLayout.rightPanelBackgroundColor
-            CommunityPermissionsSettingsPanel {
-                anchors {
-                    fill: parent
-                    topMargin: 50
-                }
-                store: CommunitiesStore {
-                    readonly property bool isOwner: isOwnerCheckBox.checked
-
-                    assetsModel: AssetsModel {}
-                    collectiblesModel: CollectiblesModel {}
-                    channelsModel: ListModel {
-                        Component.onCompleted: {
-                            append([
-                                {
-                                    key: "welcome",
-                                    iconSource: ModelsData.assets.inch,
-                                    name: "#welcome"
-                                },
-                                {
-                                    key: "general",
-                                    iconSource: ModelsData.assets.inch,
-                                    name: "#general"
-                                }
-                            ])
-                        }
-                    }
-
-                    function editPermission(index, holdings, permissions, channels, isPrivate) {
-                        logs.logEvent("CommunitiesStore::editPermission - index: " + index)
-                    }
-
-                    function duplicatePermission(index) {
-                        logs.logEvent("CommunitiesStore::duplicatePermission - index: " + index)
-                    }
-
-                    function removePermission(index) {
-                        logs.logEvent("CommunitiesStore::removePermission - index: " + index)
+                assetsModel: AssetsModel {}
+                collectiblesModel: CollectiblesModel {}
+                channelsModel: ListModel {
+                    Component.onCompleted: {
+                        append([
+                            {
+                                key: "welcome",
+                                iconSource: ModelsData.assets.inch,
+                                name: "#welcome"
+                            },
+                            {
+                                key: "general",
+                                iconSource: ModelsData.assets.inch,
+                                name: "#general"
+                            }
+                        ])
                     }
                 }
 
-                rootStore: QtObject {
-                    readonly property QtObject chatCommunitySectionModule: QtObject {
-                        readonly property var model: ChannelsModel {}
-                    }
+                function editPermission(index, holdings, permissions, channels, isPrivate) {
+                    logs.logEvent("CommunitiesStore::editPermission - index: " + index)
+                }
 
-                    readonly property QtObject mainModuleInst: QtObject {
-                        readonly property QtObject activeSection: QtObject {
-                            readonly property string name: "Socks"
-                            readonly property string image: ModelsData.icons.socks
-                            readonly property color color: "red"
-                        }
+                function duplicatePermission(index) {
+                    logs.logEvent("CommunitiesStore::duplicatePermission - index: " + index)
+                }
+
+                function removePermission(index) {
+                    logs.logEvent("CommunitiesStore::removePermission - index: " + index)
+                }
+            }
+
+            rootStore: QtObject {
+                readonly property QtObject chatCommunitySectionModule: QtObject {
+                    readonly property var model: ChannelsModel {}
+                }
+
+                readonly property QtObject mainModuleInst: QtObject {
+                    readonly property QtObject activeSection: QtObject {
+                        readonly property string name: "Socks"
+                        readonly property string image: ModelsData.icons.socks
+                        readonly property color color: "red"
                     }
                 }
             }
         }
+    }
 
-        LogsAndControlsPanel {
-            id: logsAndControlsPanel
+    LogsAndControlsPanel {
+        id: logsAndControlsPanel
 
-            SplitView.minimumHeight: 100
-            SplitView.preferredHeight: 150
+        SplitView.minimumHeight: 100
+        SplitView.preferredHeight: 150
 
-            logsView.logText: logs.logText
+        logsView.logText: logs.logText
 
-            CheckBox {
-                id: isOwnerCheckBox
+        CheckBox {
+            id: isOwnerCheckBox
 
-                text: "Is owner"
-            }
+            text: "Is owner"
         }
     }
 }

--- a/storybook/pages/CommunityPermissionsSettingsPanelPage.qml
+++ b/storybook/pages/CommunityPermissionsSettingsPanelPage.qml
@@ -25,6 +25,8 @@ SplitView {
                     topMargin: 50
                 }
                 store: CommunitiesStore {
+                    readonly property bool isOwner: isOwnerCheckBox.checked
+
                     assetsModel: AssetsModel {}
                     collectiblesModel: CollectiblesModel {}
                     channelsModel: ListModel {
@@ -80,6 +82,12 @@ SplitView {
             SplitView.preferredHeight: 150
 
             logsView.logText: logs.logText
+
+            CheckBox {
+                id: isOwnerCheckBox
+
+                text: "Is owner"
+            }
         }
     }
 }

--- a/storybook/pages/InDropdownPage.qml
+++ b/storybook/pages/InDropdownPage.qml
@@ -1,5 +1,6 @@
 import QtQuick 2.14
 import QtQuick.Controls 2.14
+import QtQuick.Layouts 1.14
 
 import AppLayouts.Chat.controls.community 1.0
 
@@ -22,6 +23,9 @@ SplitView {
         InDropdown {
             parent: pane
             anchors.centerIn: parent
+
+            allowChoosingEntireCommunity: allowChoosingEntireCommunityCheckBox.checked
+            showAddChannelButton: showAddChannelButtonCheckBox.checked
 
             communityName: "Socks"
             communityImage: ModelsData.icons.socks
@@ -53,5 +57,18 @@ SplitView {
         SplitView.preferredHeight: 200
 
         logsView.logText: logs.logText
+
+        ColumnLayout {
+            CheckBox {
+                id: allowChoosingEntireCommunityCheckBox
+
+                text: "Allow choosing entire community"
+            }
+            CheckBox {
+                id: showAddChannelButtonCheckBox
+
+                text: "Show \"Add channel\" button"
+            }
+        }
     }
 }

--- a/ui/StatusQ/src/StatusQ/Components/StatusItemSelector.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusItemSelector.qml
@@ -118,6 +118,13 @@ Rectangle {
     property bool useLetterIdenticons: false
 
     /*!
+       \qmlproperty bool StatusItemSelector::itemsClickable
+       This property determines if items in the selector are clickable (cursor
+       is changed on hover and itemClicked emitted when clicked)
+    */
+    property bool itemsClickable: true
+
+    /*!
        \qmlsignal StatusItemSelector::itemClicked
        This signal is emitted when the item is clicked.
     */
@@ -217,7 +224,8 @@ Rectangle {
 
                         MouseArea {
                             anchors.fill: parent
-                            cursorShape: Qt.PointingHandCursor
+                            enabled: root.itemsClickable
+                            cursorShape: enabled ? Qt.PointingHandCursor : Qt.ArrowCursor
                             acceptedButtons: Qt.LeftButton | Qt.RightButton
                             onClicked: root.itemClicked(parent, model.index, mouse)
                         }

--- a/ui/app/AppLayouts/Chat/controls/community/InDropdown.qml
+++ b/ui/app/AppLayouts/Chat/controls/community/InDropdown.qml
@@ -14,6 +14,9 @@ import SortFilterProxyModel 0.2
 StatusDropdown {
     id: root
 
+    property bool allowChoosingEntireCommunity: false
+    property bool showAddChannelButton: false
+
     property string communityName
     property string communityImage
     property color communityColor
@@ -100,6 +103,7 @@ StatusDropdown {
             Layout.topMargin: 9
             Layout.preferredHeight: 44
 
+            visible: root.allowChoosingEntireCommunity
 
             title: root.communityName
             subTitle: qsTr("Community")
@@ -147,6 +151,8 @@ StatusDropdown {
             Layout.fillWidth: true
             Layout.topMargin: 4 - implicitHeight / 2
             Layout.bottomMargin: 4 - implicitHeight / 2
+
+            visible: root.allowChoosingEntireCommunity
         }
 
         StatusScrollView {
@@ -154,6 +160,8 @@ StatusDropdown {
 
             Layout.fillWidth: true
             Layout.bottomMargin: 9
+            Layout.topMargin:
+                !root.allowChoosingEntireCommunity && !root.allowChoosingEntireCommunity ? 9 : 0
 
             padding: 0
 
@@ -165,6 +173,8 @@ StatusDropdown {
 
                 StatusIconTextButton {
                     Layout.preferredHeight: 36
+
+                    visible: root.showAddChannelButton
 
                     leftPadding: 8
                     spacing: 8

--- a/ui/app/AppLayouts/Chat/controls/community/PermissionListItem.qml
+++ b/ui/app/AppLayouts/Chat/controls/community/PermissionListItem.qml
@@ -5,6 +5,8 @@ import StatusQ.Controls 0.1
 import QtQuick 2.14
 import QtQuick.Controls 2.14
 
+import utils 1.0
+
 StatusListItem {
     id: root
 
@@ -22,9 +24,16 @@ StatusListItem {
     asset.bgWidth: 32
     asset.bgHeight: 32
 
+    Binding on asset.color {
+        when: !root.enabled
+        value: Style.current.darkGrey
+    }
+
     components: [
         StatusRadioButton {
             id: radioButton
+
+            visible: root.enabled
 
             // reference to root for better integration with ButtonGroup
             // by accessing main component via ButtonGroup::checkedButton.item

--- a/ui/app/AppLayouts/Chat/controls/community/PermissionsDropdown.qml
+++ b/ui/app/AppLayouts/Chat/controls/community/PermissionsDropdown.qml
@@ -15,7 +15,7 @@ StatusDropdown {
     property int mode: PermissionsDropdown.Mode.Add
     property int initialPermissionType: PermissionTypes.Type.None
 
-    property bool disableAdminPermission: false
+    property bool enableAdminPermission: true
 
     enum Mode {
         Add, Update
@@ -95,7 +95,7 @@ StatusDropdown {
             checked: d.initialPermissionType === permissionType
             buttonGroup: group
 
-            enabled: !root.disableAdminPermission
+            enabled: root.enableAdminPermission
 
             Layout.fillWidth: true
         }
@@ -160,7 +160,7 @@ StatusDropdown {
             readonly property string description:
                 qsTr("Members who meet the requirements will be allowed to read the selected channels")
 
-            title: qsTr("Read")
+            title: qsTr("View only")
             asset.name: "show"
             checked: d.initialPermissionType === permissionType
             buttonGroup: group

--- a/ui/app/AppLayouts/Chat/controls/community/PermissionsDropdown.qml
+++ b/ui/app/AppLayouts/Chat/controls/community/PermissionsDropdown.qml
@@ -15,6 +15,8 @@ StatusDropdown {
     property int mode: PermissionsDropdown.Mode.Add
     property int initialPermissionType: PermissionTypes.Type.None
 
+    property bool disableAdminPermission: false
+
     enum Mode {
         Add, Update
     }
@@ -92,6 +94,8 @@ StatusDropdown {
             asset.name: "admin"
             checked: d.initialPermissionType === permissionType
             buttonGroup: group
+
+            enabled: !root.disableAdminPermission
 
             Layout.fillWidth: true
         }

--- a/ui/app/AppLayouts/Chat/stores/CommunitiesStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/CommunitiesStore.qml
@@ -3,6 +3,8 @@ import QtQuick 2.0
 QtObject {
     id: root
 
+    readonly property bool isOwner: false
+
     property var permissionsModel: ListModel {} // Backend permissions list object model assignment. Please check the current expected data in qml defined in `createPermissions` method
     property var permissionConflict: QtObject { // Backend conflicts object model assignment. Now mocked data.
         property bool exists: false

--- a/ui/app/AppLayouts/Chat/views/communities/CommunityNewPermissionView.qml
+++ b/ui/app/AppLayouts/Chat/views/communities/CommunityNewPermissionView.qml
@@ -81,6 +81,18 @@ StatusScrollView {
             permissionType === PermissionTypes.Type.Admin ||
             permissionType === PermissionTypes.Type.Member
 
+        onPermissionTypeChanged: {
+            if (permissionType === PermissionTypes.Type.Admin) {
+                d.dirtyValues.isPrivateDirty = (root.isPrivate === false)
+            } else {
+                if (permissionType === PermissionTypes.Type.Moderator) {
+                    d.dirtyValues.isPrivateDirty = (root.isPrivate === false)
+                } else {
+                    d.dirtyValues.isPrivateDirty = (root.isPrivate === true)
+                }
+            }
+        }
+
         onIsCommunityPermissionChanged: {
             if (isCommunityPermission) {
                 inModelChannels.clear()
@@ -431,7 +443,7 @@ StatusScrollView {
                 id: permissionsDropdown
 
                 initialPermissionType: d.permissionType
-                disableAdminPermission: !root.store.isOwner
+                enableAdminPermission: root.store.isOwner
 
                 onDone: {
                     if (d.permissionType === permissionType) {
@@ -594,14 +606,14 @@ StatusScrollView {
             ColumnLayout {
                 Layout.fillWidth: true
                 StatusBaseText {
-                    text: qsTr("Private")
+                    text: qsTr("Hide permission")
                     color: Theme.palette.directColor1
                     font.pixelSize: 15
                 }
                 StatusBaseText {
                     Layout.fillWidth: true
                     Layout.fillHeight: true
-                    text: qsTr("Make this permission private to hide it from members who don’t meet it’s requirements")
+                    text: qsTr("Make this permission hidden from members who don’t meet it’s requirements")
                     color: Theme.palette.baseColor1
                     font.pixelSize: 15
                     lineHeight: 1.2
@@ -611,6 +623,7 @@ StatusScrollView {
                 }
             }
             StatusSwitch {
+                enabled: d.permissionType !== PermissionTypes.Type.Admin
                 checked: d.dirtyValues.isPrivateDirty ? !root.isPrivate : root.isPrivate
                 onToggled: d.dirtyValues.isPrivateDirty = (root.isPrivate !== checked)
             }

--- a/ui/app/AppLayouts/Chat/views/communities/CommunityNewPermissionView.qml
+++ b/ui/app/AppLayouts/Chat/views/communities/CommunityNewPermissionView.qml
@@ -414,6 +414,7 @@ StatusScrollView {
                 id: permissionsDropdown
 
                 initialPermissionType: d.permissionType
+                disableAdminPermission: !root.store.isOwner
 
                 onDone: {
                     d.permissionType = permissionType


### PR DESCRIPTION
### What does the PR do

- Disable granting admin permission for non-owners
- Simplify InDropdown popup (selecting only channels, no add channel button)
- Setting icon/default values for 'In' section depending on chosen permission
- Adjust behavior of 'Hide permission' switch depending on selected permission

Closes #9050 

Needed alignments for `StatusSwitch` are excluded to a separate ticket: https://github.com/status-im/status-desktop/issues/9212

### Affected areas
`CommunityNewPermissionView` and releted components

<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

<!-- screenshot (or gif/video) that demonstrates the functionality, specially important if it's a bug fix. -->

[Kazam_screencast_00104.webm](https://user-images.githubusercontent.com/20650004/213686907-e33edeea-ddeb-48a1-9261-631a59ac1442.webm)

