### PR TITLE
test(onboarding): Select specific account was broken

### DIFF
--- a/test/ui-test/src/screens/StatusAccountsScreen.py
+++ b/test/ui-test/src/screens/StatusAccountsScreen.py
@@ -38,9 +38,10 @@ class StatusAccountsScreen():
         account_obj = None
         [is_loaded, accountsList] = is_loaded_visible_and_enabled(SAccountsComponents.ACCOUNTS_POPUP.value)
         if is_loaded:
-            for child in get_children_of_type(accountsList, "AccountMenuItemPanel"):
-                if(child.label == account):
-                    account_obj = child
+            for index in range(accountsList.count):
+                a = accountsList.itemAt(index)
+                if(a.label == account):
+                    account_obj = a
                     found = True
-                    break
+                    break 
         return found, account_obj


### PR DESCRIPTION
### What does the PR do

Updated `findAccount` method since statement `When the user "xxx" logs in with password "xxx"` was broken due to `accountsList` iteration was wrong.

### Affected areas

Tests that call the following statement: `When the user "xxx" logs in with password "xxx"`
I.e: `tst_groupChat`