### PR TITLE
chore: optimize StatusMessageReply/StatusDateGroupLabel

### DIFF
--- a/src/app/modules/main/chat_section/chat_content/messages/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/module.nim
@@ -527,6 +527,8 @@ method updateContactDetails*(self: Module, contactId: string) =
       item.senderEnsVerified = updatedContact.details.ensVerified
     if(item.quotedMessageAuthorDetails.details.id == contactId):
       item.quotedMessageAuthorDetails = updatedContact
+      item.quotedMessageAuthorDisplayName = updatedContact.defaultDisplayName
+      item.quotedMessageAuthorAvatar = updatedContact.icon
     if(item.messageContainsMentions):
       let (message, _, err) = self.controller.getMessageDetails(item.id)
       if(err.len == 0):

--- a/src/app/modules/shared_models/message_item.nim
+++ b/src/app/modules/shared_models/message_item.nim
@@ -146,7 +146,8 @@ proc initItem*(
     if result.quotedMessageAuthorAvatar == "":
       result.quotedMessageAuthorAvatar = quotedMessageDiscordMessage.author.avatarUrl
   else:
-    result.quotedMessageAuthorDisplayName = quotedMessageAuthorDetails.details.displayName
+    result.quotedMessageAuthorDisplayName = if quotedMessageAuthorDetails.details.localNickname != "": quotedMessageAuthorDetails.details.localNickname
+                                            else: quotedMessageAuthorDetails.details.displayName
     result.quotedMessageAuthorAvatar = quotedMessageAuthorDetails.details.image.thumbnail
 
   if contentType == ContentType.DiscordMessage:

--- a/src/app/modules/shared_models/message_item.nim
+++ b/src/app/modules/shared_models/message_item.nim
@@ -146,8 +146,7 @@ proc initItem*(
     if result.quotedMessageAuthorAvatar == "":
       result.quotedMessageAuthorAvatar = quotedMessageDiscordMessage.author.avatarUrl
   else:
-    result.quotedMessageAuthorDisplayName = if quotedMessageAuthorDetails.details.localNickname != "": quotedMessageAuthorDetails.details.localNickname
-                                            else: quotedMessageAuthorDetails.details.displayName
+    result.quotedMessageAuthorDisplayName = quotedMessageAuthorDetails.details.userDefaultDisplayName()
     result.quotedMessageAuthorAvatar = quotedMessageAuthorDetails.details.image.thumbnail
 
   if contentType == ContentType.DiscordMessage:

--- a/ui/StatusQ/src/StatusQ/Components/StatusDateGroupLabel.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusDateGroupLabel.qml
@@ -10,8 +10,8 @@ StatusBaseText {
     property double messageTimestamp
 
     readonly property int msInADay: 86400000
-    readonly property int lastMessageInDays:  Math.floor(previousMessageTimestamp / msInADay)
-    readonly property int currentMessageInDays: Math.floor(messageTimestamp / msInADay)
+    readonly property int lastMessageInDays: previousMessageTimestamp / msInADay
+    readonly property int currentMessageInDays: messageTimestamp / msInADay
 
     font.pixelSize: 13
     color: Theme.palette.baseColor1

--- a/ui/StatusQ/src/StatusQ/Components/StatusDateGroupLabel.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusDateGroupLabel.qml
@@ -1,7 +1,6 @@
 import QtQuick 2.14
 
 import StatusQ.Core 0.1
-import StatusQ.Core.Utils 0.1
 import StatusQ.Core.Theme 0.1
 
 StatusBaseText {
@@ -9,6 +8,10 @@ StatusBaseText {
 
     property double previousMessageTimestamp
     property double messageTimestamp
+
+    readonly property int msInADay: 86400000
+    readonly property int lastMessageInDays:  Math.floor(previousMessageTimestamp / msInADay)
+    readonly property int currentMessageInDays: Math.floor(messageTimestamp / msInADay)
 
     font.pixelSize: 13
     color: Theme.palette.baseColor1
@@ -18,20 +21,9 @@ StatusBaseText {
         if (messageTimestamp === 0)
             return ""
 
-        const msInADay = 86400000
-        const lastMessageInDays = Math.floor(previousMessageTimestamp / msInADay)
-        const currentMessageInDays = Math.floor(messageTimestamp / msInADay)
         if(previousMessageTimestamp > 0 && currentMessageInDays <= lastMessageInDays)
             return ""
 
-        let date = new Date()
-        const currentYear = date.getFullYear()
-        date.setTime(messageTimestamp)
-
-        // FIXME Qt6: replace with Intl.DateTimeFormat
-        const monthName = Qt.locale().standaloneMonthName(date.getMonth(), Locale.LongFormat)
-        if (currentYear > date.getFullYear())
-            return "%1 %2, %3".arg(monthName).arg(date.getDate()).arg(date.getFullYear())
-        return "%1, %2".arg(monthName).arg(date.getDate())
+        return LocaleUtils.formatDate(messageTimestamp)
     }
 }

--- a/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusMessageReply.qml
+++ b/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusMessageReply.qml
@@ -67,6 +67,8 @@ Item {
                 anchors.fill: parent
 
                 RowLayout {
+                    Layout.fillWidth: true
+
                     StatusSmartIdenticon {
                         id: profileImage
                         Layout.alignment: Qt.AlignTop
@@ -78,7 +80,7 @@ Item {
                             acceptedButtons: Qt.LeftButton | Qt.RightButton
                             anchors.fill: parent
                             enabled: root.profileClickable
-                            onClicked: replyProfileClicked(this, mouse)
+                            onClicked: root.replyProfileClicked(this, mouse)
                         }
                     }
                     StatusBaseText {
@@ -89,44 +91,50 @@ Item {
                         text: replyDetails.amISender ? qsTr("You") : replyDetails.sender.displayName
                     }
                 }
-                // FIXME OPTIMIZE by using Loaders
-                StatusTextMessage {
-                    objectName: "StatusMessage_replyDetails_textMessage"
+                Loader {
                     Layout.fillWidth: true
-                    textField.font.pixelSize: Theme.secondaryTextFontSize
-                    textField.color: Theme.palette.baseColor1
-                    visible: !!replyDetails.messageText && replyDetails.contentType !== StatusMessage.ContentType.Sticker
-                    allowShowMore: false
-                    stripHtmlTags: true
-                    convertToSingleLine: true
-                    messageDetails: root.replyDetails
-                }
-                StatusImageMessage {
-                    Layout.fillWidth: true
-                    Layout.preferredHeight: imageAlias.paintedHeight
-                    imageWidth: 56
-                    source: replyDetails.contentType === StatusMessage.ContentType.Image ? replyDetails.messageContent : ""
-                    visible: source
-                    shapeType: StatusImageMessage.ShapeType.ROUNDED
-                }
-                Item {
-                    Layout.fillWidth: true
-                    Layout.preferredHeight: 48
-                    Layout.alignment: Qt.AlignLeft
-                    visible: replyDetails.contentType === StatusMessage.ContentType.Sticker
-                    StatusSticker {
-                        asset.width: 48
-                        asset.height: 48
-                        asset.name: replyDetails.messageContent
-                        asset.isImage: true
+                    asynchronous: true
+                    active: !!replyDetails.messageText && replyDetails.contentType !== StatusMessage.ContentType.Sticker
+                    visible: active
+                    sourceComponent: StatusTextMessage {
+                        objectName: "StatusMessage_replyDetails_textMessage"
+                        textField.font.pixelSize: Theme.secondaryTextFontSize
+                        textField.color: Theme.palette.baseColor1
+                        allowShowMore: false
+                        stripHtmlTags: true
+                        convertToSingleLine: true
+                        messageDetails: root.replyDetails
                     }
                 }
-                Item {
+                Loader {
+                    Layout.fillWidth: true
+                    asynchronous: true
+                    active: replyDetails.contentType === StatusMessage.ContentType.Image
+                    visible: active
+                    sourceComponent: StatusImageMessage {
+                        Layout.fillWidth: true
+                        Layout.preferredHeight: imageAlias.paintedHeight
+                        imageWidth: 56
+                        source: replyDetails.messageContent
+                        shapeType: StatusImageMessage.ShapeType.ROUNDED
+                    }
+                }
+                StatusSticker {
+                    asynchronous: true
+                    active: replyDetails.contentType === StatusMessage.ContentType.Sticker
+                    visible: active
+                    asset.width: 48
+                    asset.height: 48
+                    asset.name: replyDetails.messageContent
+                    asset.isImage: true
+                }
+                Loader {
                     Layout.fillWidth: true
                     Layout.preferredHeight: 22
-                    visible: replyDetails.contentType === StatusMessage.ContentType.Audio
-                    StatusAudioMessage {
-                        id: audioMessage
+                    asynchronous: true
+                    active: replyDetails.contentType === StatusMessage.ContentType.Audio
+                    visible: active
+                    sourceComponent: StatusAudioMessage {
                         anchors.left: parent.left
                         width: 125
                         height: 22

--- a/ui/app/AppLayouts/Chat/panels/UserListPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/UserListPanel.qml
@@ -96,7 +96,7 @@ Item {
                         messageContextMenu.isProfile = true
                         messageContextMenu.myPublicKey = userProfile.pubKey
                         messageContextMenu.selectedUserPublicKey = model.pubKey
-                        messageContextMenu.selectedUserDisplayName = model.displayName
+                        messageContextMenu.selectedUserDisplayName = nickName || userName
                         messageContextMenu.selectedUserIcon = model.icon
                         messageContextMenu.popup(4, 4)
                     } else if (mouse.button === Qt.LeftButton && !!messageContextMenu) {

--- a/ui/app/AppLayouts/Chat/panels/UserListPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/UserListPanel.qml
@@ -96,7 +96,7 @@ Item {
                         messageContextMenu.isProfile = true
                         messageContextMenu.myPublicKey = userProfile.pubKey
                         messageContextMenu.selectedUserPublicKey = model.pubKey
-                        messageContextMenu.selectedUserDisplayName = nickName || userName
+                        messageContextMenu.selectedUserDisplayName = title
                         messageContextMenu.selectedUserIcon = model.icon
                         messageContextMenu.popup(4, 4)
                     } else if (mouse.button === Qt.LeftButton && !!messageContextMenu) {

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -89,7 +89,7 @@ Loader {
     property string prevMessageSenderId: prevMessageAsJsonObj ? prevMessageAsJsonObj.senderId : ""
     property var prevMessageAsJsonObj
     property int nextMessageIndex: -1
-    property int nextMessageTimestamp: nextMessageAsJsonObj ? nextMessageAsJsonObj.timestamp : 0
+    property double nextMessageTimestamp: nextMessageAsJsonObj ? nextMessageAsJsonObj.timestamp : 0
     property var nextMessageAsJsonObj
 
     property bool editModeOn: false

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -639,7 +639,7 @@ Loader {
                     sender.isContact: quotedMessageAuthorDetailsIsContact
                     sender.displayName: quotedMessageAuthorDetailsDisplayName
                     sender.isEnsVerified: quotedMessageAuthorDetailsEnsVerified
-                    sender.secondaryName: quotedMessageAuthorDetailsName || ""
+                    sender.secondaryName: quotedMessageAuthorDetailsName
                     sender.profileImage {
                         width: 20
                         height: 20


### PR DESCRIPTION
### What does the PR do

- optimizes StatusMessageReply and StatusDateGroupLabel 
- fixes a couple of issues with displayName being wrong in various places

Fixes: https://github.com/status-im/status-desktop/issues/9016

### Affected areas

StatusMessageReply, StatusDateGroupLabel

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

Contact with a local nickname (Alexxx/Alex99), original msg and reply:
![image](https://user-images.githubusercontent.com/5377645/213741871-48acc6ef-a54b-49eb-be44-e12838a417cc.png)

Correct (repeated) date group labels, same correct date formatting as in the msg tooltips:
![image](https://user-images.githubusercontent.com/5377645/213742864-c3d60d86-92a5-4f68-ac93-8305ff6e4527.png)


