### PR TITLE
feat(ActivityCenter): Move AC notifications counting to status-go

### DIFF
--- a/src/app/modules/main/activity_center/controller.nim
+++ b/src/app/modules/main/activity_center/controller.nim
@@ -67,12 +67,14 @@ proc init*(self: Controller) =
     if (evArgs.notificationIds.len > 0):
       self.delegate.markActivityCenterNotificationUnreadDone(evArgs.notificationIds)
 
+  self.events.on(activity_center_service.SIGNAL_ACTIVITY_CENTER_NOTIFICATIONS_COUNT_MAY_HAVE_CHANGED) do(e: Args):
+    self.delegate.unreadActivityCenterNotificationsCountChanged()
 
 proc hasMoreToShow*(self: Controller): bool =
    return self.activityCenterService.hasMoreToShow()
 
 proc unreadActivityCenterNotificationsCount*(self: Controller): int =
-   return self.activityCenterService.unreadActivityCenterNotificationsCount()
+   return self.activityCenterService.getUnreadActivityCenterNotificationsCount()
 
 proc getContactDetails*(self: Controller, contactId: string): ContactDetails =
    return self.contactsService.getContactDetails(contactId)

--- a/src/app/modules/main/activity_center/io_interface.nim
+++ b/src/app/modules/main/activity_center/io_interface.nim
@@ -24,6 +24,9 @@ method hasMoreToShow*(self: AccessInterface): bool {.base.} =
 method unreadActivityCenterNotificationsCount*(self: AccessInterface): int {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method unreadActivityCenterNotificationsCountChanged*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method convertToItems*(self: AccessInterface, activityCenterNotifications: seq[ActivityCenterNotificationDto]): seq[Item] {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/activity_center/item.nim
+++ b/src/app/modules/main/activity_center/item.nim
@@ -129,16 +129,3 @@ proc messageItem*(self: Item): MessageItem =
 
 proc repliedMessageItem*(self: Item): MessageItem =
   return self.repliedMessageItem
-
-# TODO: this logic should be moved to status-go (https://github.com/status-im/status-desktop/issues/8074)
-proc isNotReadOrActiveCTA*(self: Item): bool =
-  return ((self.notificationType == ActivityCenterNotificationType.CommunityMembershipRequest and
-           self.membershipStatus == ActivityCenterMembershipStatus.Pending) or
-          (self.notificationType == ActivityCenterNotificationType.ContactRequest and
-           self.messageItem.contactRequestState == CONTACT_REQUEST_PENDING_STATE) or
-          (self.notificationType == ActivityCenterNotificationType.ContactVerification and
-           self.verificationStatus == VerificationStatus.Verifying) or
-          (self.notificationType == ActivityCenterNotificationType.Mention and
-           not self.read) or
-          (self.notificationType == ActivityCenterNotificationType.Reply and
-           not self.read))

--- a/src/app/modules/main/activity_center/model.nim
+++ b/src/app/modules/main/activity_center/model.nim
@@ -43,19 +43,6 @@ QtObject:
       if (notification.chatId == chatId and not notification.read):
         result.add(notification.id)
 
-  proc unreadCountChanged*(self: Model) {.signal.}
-
-  proc unreadCount*(self: Model): int {.slot.} =
-    result = 0
-    for notification in self.activityCenterNotifications:
-      if (notification.isNotReadOrActiveCTA()):
-          result += 1
-    return result
-
-  QtProperty[int] unreadCount:
-    read = unreadCount
-    notify = unreadCountChanged
-
   proc markAllAsRead*(self: Model)  =
     for activityCenterNotification in self.activityCenterNotifications:
       activityCenterNotification.read = true
@@ -63,7 +50,6 @@ QtObject:
     let topLeft = self.createIndex(0, 0, nil)
     let bottomRight = self.createIndex(self.activityCenterNotifications.len - 1, 0, nil)
     self.dataChanged(topLeft, bottomRight, @[NotifRoles.Read.int])
-    self.unreadCountChanged()
 
   method rowCount*(self: Model, index: QModelIndex = nil): int = self.activityCenterNotifications.len
 
@@ -127,7 +113,6 @@ QtObject:
         self.dataChanged(index, index, @[NotifRoles.Read.int])
         break
       i.inc
-    self.unreadCountChanged()
 
   proc markActivityCenterNotificationRead*(self: Model, notificationId: string) =
     var i = 0
@@ -138,7 +123,6 @@ QtObject:
         self.dataChanged(index, index, @[NotifRoles.Read.int])
         break
       i.inc
-    self.unreadCountChanged()
 
   proc removeNotifications*(self: Model, ids: seq[string]) =
     var i = 0
@@ -157,7 +141,6 @@ QtObject:
       self.activityCenterNotifications.delete(indexUpdated)
       self.endRemoveRows()
       i = i + 1
-    self.unreadCountChanged()
 
   proc setNewData*(self: Model, activityCenterNotifications: seq[Item]) =
     self.beginResetModel()
@@ -168,8 +151,6 @@ QtObject:
     self.beginInsertRows(newQModelIndex(), 0, 0)
     self.activityCenterNotifications.insert(activityCenterNotification, 0)
     self.endInsertRows()
-
-    self.unreadCountChanged()
 
     if self.activityCenterNotifications.len > 1:
       let topLeft = self.createIndex(0, 0, nil)
@@ -186,4 +167,3 @@ QtObject:
             self.removeNotifications(@[notif.id])
             break
         self.addActivityNotificationItemToList(activityCenterNotification, false)
-    self.unreadCountChanged()

--- a/src/app/modules/main/activity_center/module.nim
+++ b/src/app/modules/main/activity_center/module.nim
@@ -71,6 +71,9 @@ method hasMoreToShow*(self: Module): bool =
 method unreadActivityCenterNotificationsCount*(self: Module): int =
   self.controller.unreadActivityCenterNotificationsCount()
 
+method unreadActivityCenterNotificationsCountChanged*(self: Module) =
+  self.view.unreadActivityCenterNotificationsCountChanged()
+
 proc createMessageItemFromDto(self: Module, message: MessageDto, chatDetails: ChatDto): MessageItem =
   let contactDetails = self.controller.getContactDetails(message.`from`)
   let communityChats = self.controller.getCommunityById(chatDetails.communityId).chats

--- a/src/app/modules/main/activity_center/view.nim
+++ b/src/app/modules/main/activity_center/view.nim
@@ -42,6 +42,15 @@ QtObject:
     read = hasMoreToShow
     notify = hasMoreToShowChanged
 
+  proc unreadActivityCenterNotificationsCountChanged*(self: View) {.signal.}
+
+  proc unreadActivityCenterNotificationsCount*(self: View): int {.slot.}  =
+    self.delegate.unreadActivityCenterNotificationsCount()
+
+  QtProperty[int] unreadActivityCenterNotificationsCount:
+    read = unreadActivityCenterNotificationsCount
+    notify = unreadActivityCenterNotificationsCountChanged
+
   proc pushActivityCenterNotifications*(self:View, activityCenterNotifications: seq[Item]) =
     self.model.addActivityNotificationItemsToList(activityCenterNotifications)
     self.hasMoreToShowChanged()

--- a/src/backend/backend.nim
+++ b/src/backend/backend.nim
@@ -182,6 +182,9 @@ rpc(dismissActivityCenterNotifications, "wakuext"):
 rpc(unreadActivityCenterNotificationsCount, "wakuext"):
   discard
 
+rpc(unreadAndAcceptedActivityCenterNotificationsCount, "wakuext"):
+  discard
+
 rpc(getBookmarks, "browsers"):
   discard
 

--- a/ui/app/mainui/activitycenter/popups/ActivityCenterPopup.qml
+++ b/ui/app/mainui/activitycenter/popups/ActivityCenterPopup.qml
@@ -167,7 +167,7 @@ Popup {
         anchors.top: activityCenterTopBar.bottom
         anchors.bottom: parent.bottom
         anchors.margins: Style.current.smallPadding
-        spacing: Style.current.padding
+        spacing: 1
 
         model: SortFilterProxyModel {
             sourceModel: root.activityCenterStore.activityCenterList

--- a/ui/app/mainui/activitycenter/stores/ActivityCenterStore.qml
+++ b/ui/app/mainui/activitycenter/stores/ActivityCenterStore.qml
@@ -5,9 +5,9 @@ QtObject {
 
     property bool hideReadNotifications: false
 
-    property var activityCenterModuleInst: activityCenterModule
-    property var activityCenterList: activityCenterModuleInst.activityNotificationsModel
-    property int unreadNotificationsCount: activityCenterList.unreadCount
+    readonly property var activityCenterModuleInst: activityCenterModule
+    readonly property var activityCenterList: activityCenterModuleInst.activityNotificationsModel
+    readonly property int unreadNotificationsCount: activityCenterModuleInst.unreadActivityCenterNotificationsCount
 
     function markAllActivityCenterNotificationsRead() {
         root.activityCenterModuleInst.markAllActivityCenterNotificationsRead()

--- a/ui/app/mainui/activitycenter/views/ActivityNotificationBase.qml
+++ b/ui/app/mainui/activitycenter/views/ActivityNotificationBase.qml
@@ -22,7 +22,7 @@ Item {
 
     signal closeActivityCenter()
 
-    implicitHeight: Math.max(60, bodyLoader.height +
+    implicitHeight: Math.max(60, bodyLoader.height + bodyLoader.anchors.topMargin * 2 +
                                  (dateGroupLabel.visible ? dateGroupLabel.height : 0) +
                                  (badgeLoader.item ? badgeLoader.height + Style.current.smallPadding : 0))
 
@@ -37,9 +37,19 @@ Item {
         visible: text !== ""
     }
 
+    Rectangle {
+        id: backgroundRect
+        anchors.fill: parent
+        anchors.topMargin: dateGroupLabel.visible ? dateGroupLabel.height : 0
+        radius: 6
+        color: notification && !notification.read ? Theme.palette.primaryColor3 : "transparent"
+        Behavior on color { ColorAnimation { duration: 200 } }
+    }
+
     Loader {
         id: bodyLoader
         anchors.top: dateGroupLabel.visible ? dateGroupLabel.bottom : parent.top
+        anchors.topMargin: Style.current.smallPadding
         anchors.right: ctaLoader.left
         anchors.left: parent.left
     }
@@ -47,6 +57,7 @@ Item {
     Loader {
         id: badgeLoader
         anchors.bottom: parent.bottom
+        anchors.bottomMargin: Style.current.smallPadding
         anchors.left: parent.left
         anchors.leftMargin: 50 // TODO find a way to align with the text of the message
     }


### PR DESCRIPTION
Close #8074
Needs https://github.com/status-im/status-go/pull/3126

### What does the PR do

Replace custom AC notifications counting with `wakuext_unreadAndAcceptedActivityCenterNotificationsCount `

### Affected areas

ActivityCenter

### Screenshot of functionality (including design for comparison)

https://user-images.githubusercontent.com/2522130/214000836-33a865fc-069a-4607-85f6-e50178d35a9e.mov

<img width="573" alt="Screenshot 2023-01-24 at 19 25 55" src="https://user-images.githubusercontent.com/2522130/214510339-dcc989d0-0de3-42eb-a9f2-3c02a2cddbf5.png">
