### PR TITLE
refactor(@desktop/channel): refactor members list to only have one list per community

### DIFF
--- a/src/app/modules/main/chat_section/chat_content/users/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/users/module.nim
@@ -1,6 +1,5 @@
 import NimQml, strutils, sequtils, sugar
 import io_interface
-import ../io_interface as delegate_interface
 import view, controller
 import ../../../../shared_models/[member_model, member_item]
 import ../../../../../global/global_singleton
@@ -17,7 +16,6 @@ export io_interface
 
 type
   Module* = ref object of io_interface.AccessInterface
-    delegate: delegate_interface.AccessInterface
     view: View
     viewVariant: QVariant
     controller: Controller
@@ -27,13 +25,12 @@ type
 method addChatMember*(self: Module,  member: ChatMember)
 
 proc newModule*(
-  delegate: delegate_interface.AccessInterface, events: EventEmitter, sectionId: string, chatId: string,
+  events: EventEmitter, sectionId: string, chatId: string,
   belongsToCommunity: bool, isUsersListAvailable: bool, contactService: contact_service.Service,
   chatService: chat_service.Service, communityService: community_service.Service,
   messageService: message_service.Service,
 ): Module =
   result = Module()
-  result.delegate = delegate
   result.view = view.newView(result)
   result.viewVariant = newQVariant(result.view)
   result.controller = controller.newController(
@@ -48,8 +45,9 @@ method delete*(self: Module) =
   self.controller.delete
 
 method load*(self: Module) =
-  self.controller.init()
-  self.view.load()
+  if not self.moduleLoaded:
+    self.controller.init()
+    self.view.load()
 
 method isLoaded*(self: Module): bool =
   return self.moduleLoaded
@@ -60,7 +58,6 @@ method viewDidLoad*(self: Module) =
     self.addChatMember(member)
 
   self.moduleLoaded = true
-  self.delegate.usersDidLoad()
 
 method getModuleAsVariant*(self: Module): QVariant =
   return self.viewVariant
@@ -164,6 +161,9 @@ method addChatMember*(self: Module,  member: ChatMember) =
     ))
 
 method onChatMembersAdded*(self: Module,  ids: seq[string]) =
+  if ids.len() == 0:
+    return
+
   let members = self.controller.getChatMembers()
   for id in ids:
     for member in members:

--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -8,6 +8,7 @@ import ../../shared_models/user_item as user_item
 import ../../shared_models/user_model as user_model
 
 import chat_content/module as chat_content_module
+import chat_content/users/module as users_module
 
 import ../../../global/app_sections_config as conf
 import ../../../global/global_singleton
@@ -38,6 +39,7 @@ type
     controller: Controller
     chatContentModules: OrderedTable[string, chat_content_module.AccessInterface]
     moduleLoaded: bool
+    usersModule: users_module.AccessInterface
 
 # Forward declaration
 proc buildChatSectionUI(self: Module,
@@ -77,6 +79,12 @@ proc newModule*(
 
   result.chatContentModules = initOrderedTable[string, chat_content_module.AccessInterface]()
 
+  # Simple community channels uses comminity usersModule while chats uses their own usersModule
+  if isCommunity:
+    result.usersModule = users_module.newModule(
+      events, sectionId, chatId = "", belongsToCommunity = true, isUsersListAvailable = true,
+      contactService, chat_service, communityService, messageService)
+
 method delete*(self: Module) =
   for cModule in self.chatContentModules.values:
     cModule.delete
@@ -84,6 +92,8 @@ method delete*(self: Module) =
   self.view.delete
   self.viewVariant.delete
   self.controller.delete
+  if self.usersModule != nil:
+    self.usersModule.delete
 
 method isCommunity*(self: Module): bool =
   return self.controller.isCommunity()
@@ -108,7 +118,7 @@ proc addSubmodule(self: Module, chatId: string, belongToCommunity: bool, isUsers
   mailserversService: mailservers_service.Service) =
   self.chatContentModules[chatId] = chat_content_module.newModule(self, events, self.controller.getMySectionId(), chatId,
     belongToCommunity, isUsersListAvailable, settingsService, nodeConfigurationService, contactService, chatService, communityService,
-    messageService, gifService, mailserversService)
+    messageService, gifService, mailserversService, self.usersModule)
 
 proc removeSubmodule(self: Module, chatId: string) =
   if(not self.chatContentModules.contains(chatId)):
@@ -135,7 +145,6 @@ proc buildChatSectionUI(
   for chatDto in channelGroup.chats:
     if (chatDto.categoryId != ""):
       continue
-
     let hasNotification = not chatDto.muted and (chatDto.unviewedMessagesCount > 0 or chatDto.unviewedMentionsCount > 0)
     let notificationsCount = chatDto.unviewedMentionsCount
 
@@ -187,7 +196,6 @@ proc buildChatSectionUI(
 
     let categoryChats = channelGroup.chats.filter(c => c.categoryId == cat.id)
     for chatDto in categoryChats:
-
       let hasNotification = chatDto.unviewedMessagesCount > 0 or chatDto.unviewedMentionsCount > 0
       let notificationsCount = chatDto.unviewedMentionsCount
 
@@ -285,6 +293,8 @@ method load*(
   if(not self.controller.isCommunity()):
     # we do this only in case of chat section (not in case of communities)
     self.initContactRequestsModel()
+  else:
+    self.usersModule.load()
 
   let activeChatId = self.controller.getActiveChatId()
   for chatId, cModule in self.chatContentModules:


### PR DESCRIPTION
### What does the PR do

Community (chat_section) now has its own usersMembers and shares this data with chat_content. This allows us:
1. Decrease the amount of `chat_getMember` calls to DB
2. Reduce `usersMembers` duplicate data in memory for the communities
3. Speed up startup

Closes: #9090
status-go PR: https://github.com/status-im/status-go/pull/3122

### Affected areas

Chat members


