### PR TITLE
feat(Community Permissions): Add conflicts waring in `New permission` page

### DIFF
--- a/storybook/PagesModel.qml
+++ b/storybook/PagesModel.qml
@@ -54,6 +54,10 @@ ListModel {
          section: "Panels"
     }
     ListElement {
+         title: "PermissionConflictWarningPanel"
+         section: "Panels"
+    }
+    ListElement {
         title: "InviteFriendsToCommunityPopup"
         section: "Popups"
     }

--- a/storybook/figma.json
+++ b/storybook/figma.json
@@ -75,5 +75,11 @@
     "PermissionQualificationPanel": [
         "https://www.figma.com/file/17fc13UBFvInrLgNUKJJg5/Kuba%E2%8E%9CDesktop?node-id=2934%3A480089",
         "https://www.figma.com/file/17fc13UBFvInrLgNUKJJg5/Kuba%E2%8E%9CDesktop?node-id=22734%3A502803"
+    ],
+    "PermissionConflictWarningPanel": [
+        "https://www.figma.com/file/17fc13UBFvInrLgNUKJJg5/Kuba%E2%8E%9CDesktop?node-id=22253%3A486103&t=JrCIfks1zVzsk3vn-0"
+    ],
+    "CommunityNewPermissionView": [
+        "https://www.figma.com/file/17fc13UBFvInrLgNUKJJg5/Kuba%E2%8E%9CDesktop?node-id=22253%3A486103&t=JrCIfks1zVzsk3vn-0"
     ]
 }

--- a/storybook/pages/CommunityNewPermissionViewPage.qml
+++ b/storybook/pages/CommunityNewPermissionViewPage.qml
@@ -15,6 +15,13 @@ Pane {
             readonly property var assetsModel: AssetsModel {}
             readonly property var collectiblesModel: CollectiblesModel {}
             readonly property var channelsModel: ChannelsModel {}
+            readonly property var permissionConflict: QtObject {
+                property bool exists: true
+                property string holdings: "1 ETH"
+                property string permissions: "View and Post"
+                property string channels: "#general"
+
+            }
 
             function editPermission(index, holdings, permissions, channels, isPrivate) {
                 logs.logEvent("CommunitiesStore::editPermission - index: " + index)

--- a/storybook/pages/PermissionConflictWarningPanelPage.qml
+++ b/storybook/pages/PermissionConflictWarningPanelPage.qml
@@ -1,0 +1,90 @@
+import QtQuick 2.14
+import QtQuick.Controls 2.14
+import QtQuick.Layouts 1.14
+
+import Storybook 1.0
+
+import AppLayouts.Chat.panels.communities 1.0
+
+SplitView {
+    orientation: Qt.Vertical
+
+    Item {
+        SplitView.fillWidth: true
+        SplitView.fillHeight: true
+
+        Item {
+            id: container
+            width: widthSlider.value
+            height: conflictPanel.implicitHeight
+            anchors.centerIn: parent
+
+            PermissionConflictWarningPanel{
+                id: conflictPanel
+                anchors.left: parent.left
+                anchors.right: parent.right
+                holdings: holdingsField.text
+                permissions: permissionsField.text
+                channels: channelsField.text
+            }
+        }
+    }
+
+    LogsAndControlsPanel {
+        SplitView.minimumHeight: 100
+        SplitView.preferredHeight: 250
+
+        ColumnLayout {
+            spacing: 10
+            Row {
+                Label {
+                    anchors.verticalCenter: parent.verticalCenter
+                    text: "Width:"
+                }
+
+                Slider {
+                    id: widthSlider
+                    value: 400
+                    from: 200
+                    to: 600
+                }
+            }
+            Row {
+                Label {
+                    anchors.verticalCenter: parent.verticalCenter
+                    text: "Holdings:"
+                }
+
+                TextField {
+                    id: holdingsField
+                    text: "1 ETH"
+                }
+            }
+
+            Row {
+                Label {
+                    anchors.verticalCenter: parent.verticalCenter
+                    text: "Permissions:"
+                }
+
+                TextField {
+                    id: permissionsField
+                    text: "View and Post"
+                }
+            }
+
+            Row {
+                Label {
+                    anchors.verticalCenter: parent.verticalCenter
+                    text: "Channels:"
+                }
+
+                TextField {
+                    id: channelsField
+                    text: "#general"
+                }
+            }
+
+        }
+    }
+}

--- a/ui/app/AppLayouts/Chat/panels/communities/PermissionConflictWarningPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/PermissionConflictWarningPanel.qml
@@ -1,0 +1,65 @@
+import QtQuick 2.14
+import QtQuick.Controls 2.14
+import QtQuick.Layouts 1.14
+
+import StatusQ.Core 0.1
+import StatusQ.Core.Theme 0.1
+
+import utils 1.0
+
+Control {
+    id: root
+
+    property string holdings
+    property string permissions
+    property string channels
+
+    spacing: 8
+
+    QtObject {
+        id: d
+
+        property int iconSize: 20
+    }
+
+    contentItem: ColumnLayout {
+        spacing: 4
+
+        RowLayout {
+            spacing: root.spacing
+
+            StatusIcon {
+                Layout.preferredWidth: d.iconSize
+                Layout.preferredHeight: d.iconSize
+                Layout.alignment: Qt.AlignTop
+                color: Theme.palette.dangerColor1
+                icon: "warning"
+            }
+            StatusBaseText {
+                Layout.fillWidth: true
+                wrapMode: Text.Wrap
+                font.pixelSize: Style.current.primaryTextFontSize
+                color: Theme.palette.dangerColor1
+                font.bold: true
+                text: qsTr("Conflicts with existing permission:")
+            }
+        }
+
+        StatusBaseText {
+            Layout.leftMargin: root.spacing + d.iconSize
+            Layout.fillWidth: true
+            wrapMode: Text.Wrap
+            font.pixelSize: Style.current.primaryTextFontSize
+            font.bold: true
+            text: qsTr("\"Anyone who holds %1 can %2 in %3\"").arg(root.holdings).arg(root.permissions).arg(root.channels)
+        }
+
+        StatusBaseText {
+            Layout.leftMargin: root.spacing + d.iconSize
+            Layout.fillWidth: true
+            wrapMode: Text.Wrap
+            font.pixelSize: Style.current.primaryTextFontSize
+            text: qsTr("Edit permissions to resolve a conflict.")
+        }
+    }
+}

--- a/ui/app/AppLayouts/Chat/panels/communities/qmldir
+++ b/ui/app/AppLayouts/Chat/panels/communities/qmldir
@@ -2,3 +2,4 @@ CommunityPermissionsSettingsPanel 1.0 CommunityPermissionsSettingsPanel.qml
 CommunityProfilePopupInviteFriendsPanel 1.0 CommunityProfilePopupInviteFriendsPanel.qml
 CommunityProfilePopupInviteMessagePanel 1.0 CommunityProfilePopupInviteMessagePanel.qml
 PermissionQualificationPanel 1.0 PermissionQualificationPanel.qml
+PermissionConflictWarningPanel 1.0 PermissionConflictWarningPanel.qml

--- a/ui/app/AppLayouts/Chat/stores/CommunitiesStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/CommunitiesStore.qml
@@ -8,7 +8,14 @@ import utils 1.0
 QtObject {
     id: root
 
-    property var permissionsModel: ListModel {} // Backend permissions list object model asignement. Please check the current expected data in qml defined in `createPermissions` method
+    property var permissionsModel: ListModel {} // Backend permissions list object model assignment. Please check the current expected data in qml defined in `createPermissions` method
+    property var permissionConflict: QtObject { // Backend conflicts object model assignment. Now mocked data.
+        property bool exists: false
+        property string holdings: qsTr("1 ETH")
+        property string permissions: qsTr("View and Post")
+        property string channels: qsTr("#general")
+
+    }
 
     // TODO: Replace to real data, now dummy model
     property var  assetsModel: ListModel {

--- a/ui/app/AppLayouts/Chat/views/communities/CommunityNewPermissionView.qml
+++ b/ui/app/AppLayouts/Chat/views/communities/CommunityNewPermissionView.qml
@@ -514,9 +514,19 @@ StatusScrollView {
             }
         }
 
+        PermissionConflictWarningPanel{
+            id: conflictPanel
+            visible: store.permissionConflict.exists
+            Layout.fillWidth: true
+            Layout.topMargin: 50 // by desing
+            holdings: store.permissionConflict.holdings
+            permissions: store.permissionConflict.permissions
+            channels: store.permissionConflict.channels
+        }
+
         StatusButton {
             visible: !root.isEditState
-            Layout.topMargin: 24
+            Layout.topMargin: conflictPanel.visible ? conflictPanel.Layout.topMargin : 24 // by design
             text: qsTr("Create permission")
             enabled: d.dirtyValues.holdingsModel && d.dirtyValues.holdingsModel.count > 0 && d.dirtyValues.permissionObject.key !== null
             Layout.preferredHeight: 44


### PR DESCRIPTION
Closes [#8738](https://github.com/status-im/status-desktop/issues/8738)

### What does the PR do

- It adds conflicts warning in `New permission` page. Mocked data.
- It adds new pages and updates figma files in storybook.

### Affected areas

`Community Permission / Create new permission`

### Screenshot of functionality (including design for comparison)

https://user-images.githubusercontent.com/97019400/214085887-ffb10816-2088-44b3-b6d7-c2e361d31acc.mov
