### PR TITLE
test: Skip broken/unstable tests

### DIFF
--- a/test/ui-test/testSuites/suite_communities/tst_communityFlows/test.feature
+++ b/test/ui-test/testSuites/suite_communities/tst_communityFlows/test.feature
@@ -36,6 +36,7 @@ Feature: Status Desktop community
             | test-channel    | Community channel description tested 1      | bottom_menu      |
             | test-channel2   | Community channel description tested 2      | right_click_menu |
 
+	@mayfail
     Scenario Outline: The admin edits a community channel
         Given the admin creates a community channel named "<community_channel_name>", with description "<community_channel_description>", with the method "bottom_menu"
         And the channel named "<community_channel_name>" is open

--- a/test/ui-test/testSuites/suite_onboarding/tst_signUpSeedPhraseNegativeCases/test.feature
+++ b/test/ui-test/testSuites/suite_onboarding/tst_signUpSeedPhraseNegativeCases/test.feature
@@ -6,6 +6,7 @@ Feature: Status Desktop Sign Up with seed phrase, negative cases
 
   The feature start sequence follows the global one (setup on global `bdd_hooks`): No additional steps
 
+  @mayfail
   Scenario: User signs up with wrong imported seed phrase
 
     Given A first time user lands on the status desktop and navigates to import seed phrase

--- a/test/ui-test/testSuites/suite_onboarding/tst_statusLoginPassword/test.feature
+++ b/test/ui-test/testSuites/suite_onboarding/tst_statusLoginPassword/test.feature
@@ -29,6 +29,7 @@ Feature: Status Desktop login
             | username 		   | password          |
             | Athletic_Prime   | TesTEr16843/!@00  |
 
+	@mayfail
     Scenario Outline: User tries to login with an invalid password
         Given A first time user lands on the status desktop and generates new key
         And the user signs up with username "<username>" and password "<password>"

--- a/test/ui-test/testSuites/suite_onboarding/tst_statusSignUp/test.feature
+++ b/test/ui-test/testSuites/suite_onboarding/tst_statusSignUp/test.feature
@@ -23,6 +23,7 @@ Feature: Status Desktop Sign Up
     Then the user lands on the signed in app
     And the user is online
 
+  @mayfail
   Scenario Outline: The user signs up with imported seed phrase and and its state is online
     Given A first time user lands on the status desktop and navigates to import seed phrase
     When the user inputs the seed phrase "<seed>"

--- a/test/ui-test/testSuites/suite_settings/tst_contactsFlow/test.feature
+++ b/test/ui-test/testSuites/suite_settings/tst_contactsFlow/test.feature
@@ -9,6 +9,7 @@ Feature: Status Desktop Contacts Flows
         And the user opens app settings screen
 
 
+	@mayfail
     Scenario: The user can add a contact with a chat key
     	When the user opens the messaging settings
     	And the user opens the contacts settings

--- a/test/ui-test/testSuites/suite_settings/tst_mainSettingsSection/test.feature
+++ b/test/ui-test/testSuites/suite_settings/tst_mainSettingsSection/test.feature
@@ -20,6 +20,7 @@ Feature: Status Desktop Main Settings Section
         When the user backs up the wallet seed phrase
         Then the backup seed phrase indicator is not displayed
 
+	@mayfail
     Scenario: The user can switch state to offline
     	When the users switches state to offline
     	Then the user appears offline
@@ -28,6 +29,7 @@ Feature: Status Desktop Main Settings Section
     	And the user "tester123" logs in with password "TesTEr16843/!@00"
     	Then the user appears offline
 
+	@mayfail
     Scenario: The user can switch state to online
         When the users switches state to offline
     	And the user restarts the app
@@ -41,6 +43,7 @@ Feature: Status Desktop Main Settings Section
     	And the user "tester123" logs in with password "TesTEr16843/!@00"
     	Then the user appears online
 
+	@mayfail
 	Scenario: The user can switch state to automatic
         When the users switches state to automatic
     	Then the user status is automatic
@@ -49,6 +52,7 @@ Feature: Status Desktop Main Settings Section
     	And the user "tester123" logs in with password "TesTEr16843/!@00"
     	Then the user status is automatic
 
+	@mayfail
 	Scenario: The user can change the password and login with new password
     	When the user changes the password from TesTEr16843/!@00 to NewPassword@12345
     	And the user restarts the app

--- a/test/ui-test/testSuites/suite_wallet/tst_transaction/test.feature
+++ b/test/ui-test/testSuites/suite_wallet/tst_transaction/test.feature
@@ -16,6 +16,7 @@ Feature: Status Desktop Transaction
 	** and the user opens wallet screen
 	** and the user accepts the signing phrase
 
+	@mayfail
     Scenario Outline: The user sends a transaction
  		When the user sends a transaction to himself from account "Status account" of "<amount>" "<token>" on "<chain_name>" with password "qqqqqqqqqq"
 		Then the transaction is in progress


### PR DESCRIPTION
### What does the PR do

Tagged with `@mayfail` some scenarios that seem to be unstable / broken on CI and also locally.

### Affected areas
`SETTINGS:`

1. tst_contactsFlow --> The user can add a contact with a chat key
2. tst_mainSettingsSection --> The user can switch state to online 
3. tst_mainSettingsSection --> The user can switch state to offline 
4. tst_mainSettingsSection --> The user can switch state to automatic
5. tst_mainSettingsSection --> The user can change the password and login with new password

`ONBOARDING:`

1. tst_statusSignUp --> The user signs up with imported seed phrase and and its state is online
2. tst_statusLoginpassword -- > User tries to login with an invalid password
3. tst_signUpSeedPhraseNegativeCases -->  User signs up with wrong imported seed phrase

`COMMUNITIES:`

1. tst_communityFlows --> The admin edits a community channel

`WALLET:`

1. tst_transaction --> The user sends a transaction
