### PR TITLE
fix: cancel mailserver requests on shutdown

### DIFF
--- a/src/app/boot/app_controller.nim
+++ b/src/app/boot/app_controller.nim
@@ -259,6 +259,9 @@ proc newAppController*(statusFoundation: StatusFoundation): AppController =
   result.connect()
 
 proc delete*(self: AppController) =
+  info "logging out..."
+  self.generalService.logout()
+
   singletonInstance.delete
   self.notificationsManager.delete
   self.keychainService.delete

--- a/src/app_service/service/mailservers/service.nim
+++ b/src/app_service/service/mailservers/service.nim
@@ -157,7 +157,10 @@ QtObject:
       let receivedData = MailserverChangedSignal(e)
       let address = receivedData.address
 
-      info "active mailserver changed", node=address
+      if address == "":
+        info "removing active mailserver"
+      else:
+        info "active mailserver changed", node=address
       let data = ActiveMailserverChangedArgs(nodeAddress: address)
       self.events.emit(SIGNAL_ACTIVE_MAILSERVER_CHANGED, data)
 


### PR DESCRIPTION
This should allow doing individual storenode requests that can take up to 30s, and when logging out, it should not stop the app from closing.

Requires
- https://github.com/status-im/status-go/pull/3129