### PR TITLE
feat(CommunityPermissions): prevent adding tokens and ens names that are already chosen

### DIFF
--- a/storybook/pages/HoldingsDropdownPage.qml
+++ b/storybook/pages/HoldingsDropdownPage.qml
@@ -3,6 +3,7 @@ import QtQuick.Controls 2.14
 import QtQuick.Layouts 1.14
 
 import Storybook 1.0
+import Models 1.0
 
 import AppLayouts.Chat.controls.community 1.0
 
@@ -39,54 +40,8 @@ Pane {
         anchors.centerIn: root
 
         store: QtObject {
-            readonly property ListModel collectiblesModel: ListModel {
-
-                Component.onCompleted: {
-                    const collectibles = []
-
-                    for (let i = 0; i < 20; i++) {
-                        collectibles.push({
-                            key: "key " + (i + 1),
-                            iconSource: "",
-                            name: "Collectible " + (i + 1),
-                            category: "Community collectibles, cat "
-                                      + (Math.floor(i / 4) + 1)
-                        })
-                    }
-
-                    const subitems = []
-                    for (let j = 0; j < 20; j++) {
-
-                        subitems.push({
-                            key: "subkey " + (j + 1),
-                            iconSource: "",
-                            name: "Collectible (sub) " + (j + 1)//,
-                        })
-                    }
-
-                    collectibles[1].subItems = subitems;
-
-                    append(collectibles)
-                }
-            }
-
-            readonly property ListModel assetsModel: ListModel {
-                ListElement {
-                    key: "socks"; iconSource: ""; name: "Unisocks"; shortName: "SOCKS"; category: "Community assets"
-                }
-                ListElement {
-                    key: "zrx"; iconSource: ""; name: "Ox"; shortName: "ZRX"; category: "Listed assets"
-                }
-                ListElement {
-                    key: "1inch"; iconSource: ""; name: "1inch"; shortName: "ZRX"; category: "Listed assets"
-                }
-                ListElement {
-                    key: "Aave"; iconSource: ""; name: "Aave"; shortName: "AAVE"; category: "Listed assets"}
-
-                ListElement {
-                    key: "Amp"; iconSource: ""; name: "Amp"; shortName: "AMP"; category: "Listed assets"
-                }
-            }
+            readonly property var collectiblesModel: CollectiblesModel {}
+            readonly property var assetsModel: AssetsModel {}
         }
 
         onOpened: contentItem.parent.parent = root

--- a/storybook/src/Models/AssetsModel.qml
+++ b/storybook/src/Models/AssetsModel.qml
@@ -21,7 +21,7 @@ ListModel {
                        key: "1inch",
                        iconSource: ModelsData.assets.inch,
                        name: "1inch",
-                       shortName: "ZRX",
+                       shortName: "1INCH",
                        category: "Listed assets"
                    },
                    {

--- a/ui/app/AppLayouts/Chat/controls/community/ExtendedDropdownContent.qml
+++ b/ui/app/AppLayouts/Chat/controls/community/ExtendedDropdownContent.qml
@@ -16,6 +16,7 @@ Item {
     id: root
 
     property var store
+    property var checkedKeys: []
     property int type: ExtendedDropdownContent.Type.Assets
 
     readonly property bool canGoBack: root.state !== d.listView_depth1_State
@@ -272,10 +273,14 @@ Item {
 
         TokenItem {
            id: tokenGroupItem
+
            Layout.fillWidth: true
+
            key: d.currentItemKey
            name: d.currentItemName
            iconSource: d.currentItemSource
+
+           selected: root.checkedKeys.includes(key)
            enabled: true
            onItemClicked: root.itemClicked(d.currentItemKey,
                                            d.currentItemName,
@@ -301,6 +306,8 @@ Item {
             }
             isHeaderVisible: false  // TEMPORARILY hidden. These 2 header options will be implemented after MVP.
             model: d.currentModel
+            checkedKeys: root.checkedKeys
+
             onHeaderItemClicked: {
                 if(key === "MINT") console.log("TODO: Mint asset")
                 else if(key === "IMPORT") console.log("TODO: Import existing asset")
@@ -319,6 +326,7 @@ Item {
             }
 
             model: d.currentModel
+            checkedKeys: root.checkedKeys
 
             onHeaderItemClicked: {
                 if(key === "MINT") console.log("TODO: Mint collectible")
@@ -351,6 +359,8 @@ Item {
             padding: 0
 
             model: d.currentModel
+            checkedKeys: root.checkedKeys
+
             onItemClicked: {
                 d.reset()
                 root.itemClicked(key, name, iconSource)

--- a/ui/app/AppLayouts/Chat/controls/community/HoldingTypes.qml
+++ b/ui/app/AppLayouts/Chat/controls/community/HoldingTypes.qml
@@ -6,6 +6,6 @@ QtObject {
     }
 
     enum Mode {
-        Add, Update
+        Add, Update, UpdateOrRemove
     }
 }

--- a/ui/app/AppLayouts/Chat/controls/community/ListDropdownContent.qml
+++ b/ui/app/AppLayouts/Chat/controls/community/ListDropdownContent.qml
@@ -12,6 +12,8 @@ import StatusQ.Components 0.1
 StatusListView {
     id: root
 
+    property var checkedKeys: []
+
     property var headerModel
     property bool isHeaderVisible: true
     property int maxHeight: 381 // default by design
@@ -60,7 +62,8 @@ StatusListView {
         shortName: !!model.shortName ? model.shortName : ""
         iconSource: model.iconSource
         subItems: model.subItems
-        enabled: true
+        selected: root.checkedKeys.includes(model.key)
+
         onItemClicked: root.itemClicked(model.key,
                                         model.name,
                                         model.shortName,

--- a/ui/app/AppLayouts/Chat/controls/community/ThumbnailsDropdownContent.qml
+++ b/ui/app/AppLayouts/Chat/controls/community/ThumbnailsDropdownContent.qml
@@ -13,6 +13,8 @@ StatusScrollView {
     property url titleImage: ""
     property string subtitle: ""
     property ListModel model
+    property var checkedKeys: []
+
     property int maxHeight: 381 // default by design
 
     signal itemClicked(var key, string name, url iconSource)
@@ -47,6 +49,29 @@ StatusScrollView {
                     Image {
                         source: model.imageSource ?  model.imageSource :  ""
                         anchors.fill: parent
+
+                        Rectangle {
+                            width: 32
+                            height: 32
+
+                            anchors.bottom: parent.bottom
+                            anchors.right: parent.right
+                            anchors.margins: 8
+
+                            radius: width / 2
+                            visible: root.checkedKeys.includes(model.key)
+                            // TODO: use color from theme when defined properly in the design
+                            color: "#F5F6F8"
+
+                            StatusIcon {
+                                anchors.centerIn: parent
+                                icon: "checkmark"
+
+                                color: Theme.palette.baseColor1
+                                width: 16
+                                height: 16
+                            }
+                        }
                     }
                     MouseArea {
                         anchors.fill: parent

--- a/ui/app/AppLayouts/Chat/controls/community/TokenItem.qml
+++ b/ui/app/AppLayouts/Chat/controls/community/TokenItem.qml
@@ -15,6 +15,7 @@ Control {
     property string shortName
     property url iconSource
     property var subItems
+    property bool selected: false
 
     signal itemClicked(string key, string name, string shortName,  url iconSource, var subItems)
 
@@ -71,8 +72,10 @@ Control {
         }
 
         StatusIcon {
-            icon: "tiny/chevron-right"
-            visible: !!root.subItems && root.subItems.count > 0
+            readonly property bool hasSubItems: !!root.subItems && root.subItems.count > 0
+
+            icon: root.selected && !hasSubItems ? "checkmark" : "tiny/chevron-right"
+            visible: root.selected || hasSubItems
             Layout.alignment: Qt.AlignVCenter
             Layout.rightMargin: 16
             color: Theme.palette.baseColor1

--- a/ui/app/AppLayouts/Chat/controls/community/TokenPanel.qml
+++ b/ui/app/AppLayouts/Chat/controls/community/TokenPanel.qml
@@ -83,7 +83,7 @@ ColumnLayout {
         Layout.preferredHeight: d.defaultHeight
         Layout.fillWidth: true
         Layout.topMargin: d.defaultSpacing
-        visible: root.mode === HoldingTypes.Mode.Update
+        visible: root.mode === HoldingTypes.Mode.UpdateOrRemove
         type: StatusBaseButton.Type.Danger
 
         onClicked: root.removeClicked()


### PR DESCRIPTION
### What does the PR do

Implements logic preventing from duplicating tokens and ens names in `Who holds` section when creating/editing community permissions.

Closes: #8817 

### Affected areas
Components related to `Community Permissions` functionality.


### Screenshot of functionality (including design for comparison)
- [x] I've checked the design and this PR matches it

[Kazam_screencast_00107.webm](https://user-images.githubusercontent.com/20650004/214429305-538ab21b-cbb9-4b80-85cd-8c92188cd7e5.webm)


