### PR TITLE
fix(StatusChatInput): don't insert control characters

### DIFF
--- a/storybook/mocks/DotherSide/StatusSyntaxHighlighter.qml
+++ b/storybook/mocks/DotherSide/StatusSyntaxHighlighter.qml
@@ -2,4 +2,6 @@ import QtQuick 2.14
 
 QtObject {
     property var quickTextDocument
+    property color codeBackgroundColor
+    property color codeForegroundColor
 }

--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -222,7 +222,7 @@ Rectangle {
             if(mentionsPos.length == 0) return
 
             const unformattedText = messageInputField.getText(0, messageInputField.length)
-            mentionsPos = mentionsPos.filter( mention => unformattedText.charAt(mention.leftIndex) === "@")
+            mentionsPos = mentionsPos.filter(mention => unformattedText.charAt(mention.leftIndex) === "@")
         }
 
         function insertMention(aliasName, publicKey, lastAtPosition, lastCursorPosition) {
@@ -411,7 +411,7 @@ Rectangle {
                 anticipatedCursorPosition += event.key === Qt.Key_Backspace ?
                                                -1 : 1
 
-               const mention = d.getMentionAtPosition(anticipatedCursorPosition)
+                const mention = d.getMentionAtPosition(anticipatedCursorPosition)
                 if(mention) {
                     d.removeMention(mention)
                     event.accepted = true
@@ -909,15 +909,15 @@ Rectangle {
         target: Global.dragArea
         ignoreUnknownSignals: true
         function onDroppedOnValidScreen(drop) {
-                                    let validImages = validateImages(drop.urls)
-                                    if (validImages.length > 0) {
-                                        showImageArea(validImages)
-                                        drop.acceptProposedAction()
-                                    }
-                                }
+            let validImages = validateImages(drop.urls)
+            if (validImages.length > 0) {
+                showImageArea(validImages)
+                drop.acceptProposedAction()
+            }
+        }
     }
 
-     // This is used by Squish tests to not have to access the file dialog
+    // This is used by Squish tests to not have to access the file dialog
     function selectImageString(filePath) {
         let validImages = validateImages([filePath])
         if (validImages.length > 0) {
@@ -1479,5 +1479,4 @@ Rectangle {
             }
         }
     }
-
 }

--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -678,6 +678,9 @@ Rectangle {
     }
 
     function onRelease(event) {
+        if ((event.modifiers & Qt.ControlModifier) || (event.modifiers & Qt.MetaModifier)) // these are likely shortcuts with no meaningful text
+            return
+
         if (event.key === Qt.Key_Backspace && textFormatMenu.opened) {
             textFormatMenu.close()
         }


### PR DESCRIPTION
@mentions have a special `onRelease()` key handler that makes sure a space is inserted around the mention when needed. 

Fix the `onRelease()` handler to prevent control or otherwise unprintable characters being inserted as text. This happened when pressing a keyboard shortcut involving the `Ctrl` modifier

(2 separate commits to fixup other minor issues)

Fixes: https://github.com/status-im/status-desktop/issues/7685

### What does the PR do

Fixes unprintable characters appearing when pressing a keyboard shortcut

### Affected areas

StatusChatInput

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

