### PR TITLE
fix(MessageContextMenuView): "Copy message" action visible in emoji reactions and profile clicks

### DIFF
--- a/ui/imports/shared/views/chat/MessageContextMenuView.qml
+++ b/ui/imports/shared/views/chat/MessageContextMenuView.qml
@@ -365,14 +365,14 @@ StatusMenu {
             root.store.copyToClipboard(root.unparsedText)
             close()
         }
-        enabled: root.messageContentType === Constants.messageContentType.messageType
+        enabled: root.messageContentType === Constants.messageContentType.messageType && !root.isProfile && !emojiContainer.visible
     }
 
     StatusAction {
         id: copyMessageIdAction
         text: qsTr("Copy Message Id")
         icon.name: "copy"
-        enabled: root.isDebugEnabled && !pinnedPopup
+        enabled: root.isDebugEnabled && !root.isProfile && !root.pinnedPopup && !emojiContainer.visible
         onTriggered: {
             root.store.copyToClipboard(root.messageId)
             close()


### PR DESCRIPTION
Fixes #9295

### What does the PR do

hide the "Copy message (ID)" actions when in profile or emoji reactions mode 

### Affected areas

MessageContextMenuView

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![image](https://user-images.githubusercontent.com/5377645/214676639-f8aa8a11-f25d-449b-8dff-4cf9d602eaed.png)

