### PR TITLE
fix(message-service): fix receiving messages from channels not loaded

### DIFF
--- a/src/app_service/service/message/service.nim
+++ b/src/app_service/service/message/service.nim
@@ -240,19 +240,13 @@ QtObject:
       if(chats[i].chatType == ChatType.OneToOne and not self.contactService.getContactById(chatId).isContact):
         continue
 
-      let currentChatCursor = self.initOrGetMessageCursor(chatId)
-      # Ignore messages update if chat haven't loaded any messages and try to load them from database instead
-      if(currentChatCursor.isEmpty()):
-        currentChatCursor.makeObsolete()
-        self.asyncLoadMoreMessagesForChat(chatId)
-        continue
-
       var chatMessages: seq[MessageDto]
       for msg in messages:
         if(msg.localChatId != chatId):
           continue
 
         # Ignore messages older than current chat cursor
+        let currentChatCursor = self.initOrGetMessageCursor(chatId)
         let msgCursorValue = initCursorValue(msg.id, msg.clock)
         if(not currentChatCursor.isLessThan(msgCursorValue)):
           currentChatCursor.makeObsolete()

--- a/test/ui-test/testSuites/suite_messaging/tst_OneToOneChatFlow/test.feature
+++ b/test/ui-test/testSuites/suite_messaging/tst_OneToOneChatFlow/test.feature
@@ -15,6 +15,8 @@ Feature: Status Desktop One to One Chat Flows
     [Cleanup] Also each scenario ends with:
     ** when the user leaves the current chat
 
+    @mayfail
+    # Fails on CI. Issue #9335
     Scenario: The user can create a one to chat
         When the user creates a one to one chat with "Athletic"
         Then the chat title is "Athletic"


### PR DESCRIPTION
Fixes #9297

This was caused by the fact we skip new message signals when we don't have the cursor for it.

This might undo some of @osmaczko 's performance improvement, but that improvement caused a huge regression.