### PR TITLE
Adjust import tool front-end to latest refactor

### DIFF
--- a/src/app/core/signals/remote_signals/community.nim
+++ b/src/app/core/signals/remote_signals/community.nim
@@ -29,6 +29,8 @@ type DiscordCommunityImportProgressSignal* = ref object of Signal
   errorsCount*: int
   warningsCount*: int
   stopped*: bool
+  totalChunksCount*: int
+  currentChunk*: int
 
 type DiscordCommunityImportFinishedSignal* = ref object of Signal
   communityId*: string
@@ -74,6 +76,8 @@ proc fromEvent*(T: type DiscordCommunityImportProgressSignal, event: JsonNode): 
     result.errorsCount = importProgressObj{"errorsCount"}.getInt()
     result.warningsCount = importProgressObj{"warningsCount"}.getInt()
     result.stopped = importProgressObj{"stopped"}.getBool()
+    result.totalChunksCount = importProgressObj{"totalChunksCount"}.getInt()
+    result.currentChunk = importProgressObj{"currentChunk"}.getInt()
 
     if importProgressObj["communityImages"].kind == JObject:
       result.communityImages = chat.toImages(importProgressObj["communityImages"])

--- a/src/app/modules/main/communities/controller.nim
+++ b/src/app/modules/main/communities/controller.nim
@@ -76,7 +76,7 @@ proc init*(self: Controller) =
 
   self.events.on(SIGNAL_DISCORD_COMMUNITY_IMPORT_PROGRESS) do(e:Args):
     let args = DiscordImportProgressArgs(e)
-    self.delegate.discordImportProgressUpdated(args.communityId, args.communityName, args.communityImage, args.tasks, args.progress, args.errorsCount, args.warningsCount, args.stopped)
+    self.delegate.discordImportProgressUpdated(args.communityId, args.communityName, args.communityImage, args.tasks, args.progress, args.errorsCount, args.warningsCount, args.stopped, args.totalChunksCount, args.currentChunk)
 
   self.events.on(SIGNAL_COMMUNITY_HISTORY_ARCHIVES_DOWNLOAD_STARTED) do(e:Args):
     let args = CommunityIdArgs(e)

--- a/src/app/modules/main/communities/io_interface.nim
+++ b/src/app/modules/main/communities/io_interface.nim
@@ -134,7 +134,7 @@ method requestExtractDiscordChannelsAndCategories*(self: AccessInterface, filesT
 method discordCategoriesAndChannelsExtracted*(self: AccessInterface, categories: seq[DiscordCategoryDto], channels: seq[DiscordChannelDto], oldestMessageTimestamp: int, errors: Table[string, DiscordImportError], errorsCount: int) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method discordImportProgressUpdated*(self: AccessInterface, communityId: string, communityName: string, communityImage: string, tasks: seq[DiscordImportTaskProgress], progress: float, errorsCount: int, warningsCount: int, stopped: bool) {.base.} =
+method discordImportProgressUpdated*(self: AccessInterface, communityId: string, communityName: string, communityImage: string, tasks: seq[DiscordImportTaskProgress], progress: float, errorsCount: int, warningsCount: int, stopped: bool, totalChunksCount: int, currentChunk: int) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method requestCancelDiscordCommunityImport*(self: AccessInterface, id: string) {.base.} =

--- a/src/app/modules/main/communities/module.nim
+++ b/src/app/modules/main/communities/module.nim
@@ -335,7 +335,7 @@ method getDiscordImportTaskItem(self: Module, t: DiscordImportTaskProgress): Dis
       t.errorsCount,
       t.warningsCount)
 
-method discordImportProgressUpdated*(self: Module, communityId: string, communityName: string, communityImage: string, tasks: seq[DiscordImportTaskProgress], progress: float, errorsCount: int, warningsCount: int, stopped: bool) =
+method discordImportProgressUpdated*(self: Module, communityId: string, communityName: string, communityImage: string, tasks: seq[DiscordImportTaskProgress], progress: float, errorsCount: int, warningsCount: int, stopped: bool, totalChunksCount: int, currentChunk: int) =
 
   var taskItems: seq[DiscordImportTaskItem] = @[]
 
@@ -355,6 +355,8 @@ method discordImportProgressUpdated*(self: Module, communityId: string, communit
   # That's why we pass it as integer instead.
   self.view.setDiscordImportProgress((progress*100).int)
   self.view.setDiscordImportProgressStopped(stopped)
+  self.view.setDiscordImportProgressTotalChunksCount(totalChunksCount)
+  self.view.setDiscordImportProgressCurrentChunk(currentChunk)
   if stopped or progress.int >= 1:
     self.view.setDiscordImportInProgress(false)
 

--- a/src/app/modules/main/communities/view.nim
+++ b/src/app/modules/main/communities/view.nim
@@ -38,6 +38,8 @@ QtObject:
       discordImportInProgress: bool
       discordImportCancelled: bool
       discordImportProgressStopped: bool
+      discordImportProgressTotalChunksCount: int
+      discordImportProgressCurrentChunk: int
       discordImportTasksModel: DiscordImportTasksModel
       discordImportTasksModelVariant: QVariant
       discordDataExtractionInProgress: bool
@@ -225,6 +227,34 @@ QtObject:
   QtProperty[int] discordImportProgressStopped:
     read = getDiscordImportProgressStopped
     notify = discordImportProgressStoppedChanged
+
+  proc discordImportProgressTotalChunksCountChanged*(self: View) {.signal.}
+
+  proc setDiscordImportProgressTotalChunksCount*(self: View, count: int) {.slot.} =
+    if (self.discordImportProgressTotalChunksCount == count): return
+    self.discordImportProgressTotalChunksCount = count
+    self.discordImportProgressTotalChunksCountChanged()
+
+  proc getDiscordImportProgressTotalChunksCount*(self: View): int {.slot.} =
+    return self.discordImportProgressTotalChunksCount
+
+  QtProperty[int] discordImportProgressTotalChunksCount:
+    read = getDiscordImportProgressTotalChunksCount
+    notify = discordImportProgressTotalChunksCountChanged
+
+  proc discordImportProgressCurrentChunkChanged*(self: View) {.signal.}
+
+  proc setDiscordImportProgressCurrentChunk*(self: View, count: int) {.slot.} =
+    if (self.discordImportProgressCurrentChunk == count): return
+    self.discordImportProgressCurrentChunk = count
+    self.discordImportProgressCurrentChunkChanged()
+
+  proc getDiscordImportProgressCurrentChunk*(self: View): int {.slot.} =
+    return self.discordImportProgressCurrentChunk
+
+  QtProperty[int] discordImportProgressCurrentChunk:
+    read = getDiscordImportProgressCurrentChunk
+    notify = discordImportProgressCurrentChunkChanged
 
   proc addItem*(self: View, item: SectionItem) =
     self.model.addItem(item)

--- a/src/app_service/service/community/service.nim
+++ b/src/app_service/service/community/service.nim
@@ -91,6 +91,8 @@ type
     errorsCount*: int
     warningsCount*: int
     stopped*: bool
+    totalChunksCount*: int
+    currentChunk*: int
 
 # Signals which may be emitted by this service:
 const SIGNAL_COMMUNITY_JOINED* = "communityJoined"
@@ -257,7 +259,9 @@ QtObject:
         progress: receivedData.progress,
         errorsCount: receivedData.errorsCount,
         warningsCount: receivedData.warningsCount,
-        stopped: receivedData.stopped
+        stopped: receivedData.stopped,
+        totalChunksCount: receivedData.totalChunksCount,
+        currentChunk: receivedData.currentChunk,
       ))
 
     self.events.on(SignalType.ImportingHistoryArchiveMessages.event) do(e: Args):

--- a/ui/app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml
+++ b/ui/app/AppLayouts/CommunitiesPortal/popups/DiscordImportProgressContents.qml
@@ -110,6 +110,8 @@ StatusScrollView {
         readonly property bool importStopped: root.store.discordImportProgressStopped
         readonly property bool hasErrors: root.store.discordImportErrorsCount
         readonly property bool hasWarnings: root.store.discordImportWarningsCount
+        readonly property int totalChunksCount: root.store.discordImportProgressTotalChunksCount
+        readonly property int currentChunk: root.store.discordImportProgressCurrentChunk
 
         readonly property int status: {
             if (importStopped) {
@@ -137,9 +139,7 @@ StatusScrollView {
             if (progress <= 0.0)
               return qsTr("Pending...")
 
-            return state === "import.taskState.saving" ?
-              qsTr("Saving... This can take a moment, almost done!") :
-              qsTr("Working...")
+            return qsTr("Importing from file %1 of %2...").arg(currentChunk).arg(totalChunksCount)
         }
     }
 

--- a/ui/app/AppLayouts/CommunitiesPortal/stores/CommunitiesStore.qml
+++ b/ui/app/AppLayouts/CommunitiesPortal/stores/CommunitiesStore.qml
@@ -22,6 +22,8 @@ QtObject {
     property bool discordImportInProgress: root.communitiesModuleInst.discordImportInProgress
     property bool discordImportCancelled: root.communitiesModuleInst.discordImportCancelled
     property bool discordImportProgressStopped: root.communitiesModuleInst.discordImportProgressStopped
+    property int discordImportProgressTotalChunksCount: root.communitiesModuleInst.discordImportProgressTotalChunksCount
+    property int discordImportProgressCurrentChunk: root.communitiesModuleInst.discordImportProgressCurrentChunk
     property string discordImportCommunityId: root.communitiesModuleInst.discordImportCommunityId
     property string discordImportCommunityName: root.communitiesModuleInst.discordImportCommunityName
     property url discordImportCommunityImage: root.communitiesModuleInst.discordImportCommunityImage


### PR DESCRIPTION
This adjust the front-end for the import tool by handling new properties that have been added to the discord import progress signals.

Namely, the import is now done in chunks, so the progress signal contains information about how many chunks have been processed.

This needs: https://github.com/status-im/status-go/pull/3134

Closes #9262 #9261

