### PR TITLE
fix(chat): Download image is saving to wrong folder

### DIFF
--- a/ui/imports/shared/views/chat/MessageContextMenuView.qml
+++ b/ui/imports/shared/views/chat/MessageContextMenuView.qml
@@ -476,17 +476,13 @@ StatusMenu {
         id: fileDialog
         title: qsTr("Please choose a directory")
         selectFolder: true
-        selectExisting : true
+        selectExisting: true
         selectMultiple: false
         modality: Qt.NonModal
         onAccepted: {
             if (root.imageSource) {
                 root.store.downloadImageByUrl(root.imageSource, fileDialog.fileUrl)
             }
-            fileDialog.close()
-        }
-        onRejected: {
-            fileDialog.close()
         }
     }
 


### PR DESCRIPTION
- fetch latest dotherside for the fix
- minor cleanup

Fixes #9307

### What does the PR do

Fix saving image to the correct folder

### Affected areas

MessageContextMenuView

### Screenshot of functionality (including design for comparison)

- [N/A] I've checked the design and this PR matches it
