### PR TITLE
feat(Community Permissions): Integrate In section with permission creation/editing

### DIFF
--- a/storybook/pages/CommunityPermissionsSettingItemEditor.qml
+++ b/storybook/pages/CommunityPermissionsSettingItemEditor.qml
@@ -12,8 +12,10 @@ ColumnLayout {
     property string name
     property string icon
     property string amountText
+    property string emoji
     property bool isAmountVisible: false
     property bool isImageSelectorVisible: true
+    property bool isEmojiSelectorVisible: false
     property var iconsModel
 
     Label {
@@ -63,7 +65,7 @@ ColumnLayout {
         ColumnLayout {
             Label {
                 Layout.fillWidth: true
-                text: "Type"
+                text: "Name"
             }
             TextField {
                 background: Rectangle {
@@ -90,6 +92,23 @@ ColumnLayout {
                 Layout.fillWidth: true
                 text: root.amountText
                 onTextChanged: root.amountText = text
+            }
+        }
+
+        ColumnLayout {
+            visible: root.isEmojiSelectorVisible
+            Label {
+                Layout.fillWidth: true
+                text: "Emoji"
+            }
+            TextField {
+                background: Rectangle {
+                    radius: 16
+                    border.color: 'lightgrey'
+                }
+                Layout.fillWidth: true
+                text: root.emoji
+                onTextChanged: root.emoji = text
             }
         }
     }

--- a/storybook/pages/CommunityPermissionsSettingsPanelEditor.qml
+++ b/storybook/pages/CommunityPermissionsSettingsPanelEditor.qml
@@ -100,12 +100,16 @@ Flickable {
                         Repeater {
                              model: channelsListModel
                              CommunityPermissionsSettingItemEditor {
+                                 isEmojiSelectorVisible: true
+
                                  panelText: "In [item " + model.index + "]"
-                                 name: model.name
-                                 icon: model.iconSource
+                                 name: model.text
+                                 icon: model.iconSource ? model.iconSource : ""
+                                 emoji: model.emoji ? model.emoji : ""
                                  iconsModel: AssetsCollectiblesIconsModel {}
                                  onNameChanged: model.name = name
                                  onIconChanged: model.iconSource = icon
+                                 onEmojiChanged: model.emoji = emoji
                              }
                         }
                     }

--- a/storybook/pages/CommunityPermissionsSettingsPanelPage.qml
+++ b/storybook/pages/CommunityPermissionsSettingsPanelPage.qml
@@ -45,18 +45,6 @@ SplitView {
                         ])
                     }
                 }
-
-                function editPermission(index, holdings, permissions, channels, isPrivate) {
-                    logs.logEvent("CommunitiesStore::editPermission - index: " + index)
-                }
-
-                function duplicatePermission(index) {
-                    logs.logEvent("CommunitiesStore::duplicatePermission - index: " + index)
-                }
-
-                function removePermission(index) {
-                    logs.logEvent("CommunitiesStore::removePermission - index: " + index)
-                }
             }
 
             rootStore: QtObject {

--- a/storybook/pages/CommunityPermissionsViewPage.qml
+++ b/storybook/pages/CommunityPermissionsViewPage.qml
@@ -31,6 +31,21 @@ SplitView {
                         logs.logEvent("CommunitiesStore::duplicatePermission - index: " + index)
                     }
                 }
+
+                rootStore: QtObject {
+                    readonly property QtObject chatCommunitySectionModule: QtObject {
+                        readonly property var model: ChannelsModel {}
+                    }
+
+                    readonly property QtObject mainModuleInst: QtObject {
+                        readonly property QtObject activeSection: QtObject {
+                            readonly property string name: "Socks"
+                            readonly property string image: ModelsData.icons.socks
+                            readonly property color color: "red"
+                        }
+                    }
+                }
+
                 onEditPermission: logs.logEvent("CommunitiesStore::editPermission - index: " + index)
                 onRemovePermission: logs.logEvent("CommunitiesStore::removePermission - index: " + index)
 

--- a/storybook/src/Models/ChannelsModel.qml
+++ b/storybook/src/Models/ChannelsModel.qml
@@ -48,14 +48,14 @@ ListModel {
                 name: "faq"
                 icon: ""
                 color: ""
-                colorId: 1
+                colorId: 5
             },
             ListElement {
                 itemId: 5
                 name: "report-scam"
                 icon: ""
                 color: ""
-                colorId: 1
+                colorId: 4
             }
         ]
     }

--- a/storybook/src/Models/PermissionsModel.qml
+++ b/storybook/src/Models/PermissionsModel.qml
@@ -32,82 +32,79 @@ ListModel {
                ])
 
     function createHoldingsModel1() {
-        var holdings = []
-        holdings.push({
-                          operator: OperatorsUtils.Operators.None,
-                          type: HoldingTypes.Type.Asset,
-                          key: "SOCKS",
-                          name: "SOCKS",
-                          amount: 1.2,
-                          imageSource: ModelsData.assets.socks
-                      });
-        holdings.push({
-                          operator: OperatorsUtils.Operators.Or,
-                          type: HoldingTypes.Type.Asset,
-                          key: "ZRX",
-                          name: "ZRX",
-                          amount: 15,
-                          imageSource: ModelsData.assets.zrx
-                      });
-        holdings.push({
-                          operator: OperatorsUtils.Operators.And,
-                          type: HoldingTypes.Type.Collectible,
-                          key: "Furbeard",
-                          name: "Furbeard",
-                          amount: 12,
-                          imageSource: ModelsData.collectibles.kitty1
-                      });
-        return holdings
+        return [
+            {
+                operator: OperatorsUtils.Operators.None,
+                type: HoldingTypes.Type.Asset,
+                key: "SOCKS",
+                name: "SOCKS",
+                amount: 1.2,
+                imageSource: ModelsData.assets.socks
+            },
+            {
+                operator: OperatorsUtils.Operators.Or,
+                type: HoldingTypes.Type.Asset,
+                key: "ZRX",
+                name: "ZRX",
+                amount: 15,
+                imageSource: ModelsData.assets.zrx
+            },
+            {
+                operator: OperatorsUtils.Operators.And,
+                type: HoldingTypes.Type.Collectible,
+                key: "Furbeard",
+                name: "Furbeard",
+                amount: 12,
+                imageSource: ModelsData.collectibles.kitty1
+            }
+        ]
     }
 
     function createHoldingsModel2() {
-        var holdings = []
-        holdings.push({
-                          operator: OperatorsUtils.Operators.None,
-                          type: HoldingTypes.Type.Collectible,
-                          key: "Happy Meow",
-                          name: "Happy Meow",
-                          amount: 50.25,
-                          imageSource: ModelsData.collectibles.kitty3
-                      });
-        holdings.push({
-                          operator: OperatorsUtils.Operators.And,
-                          type: HoldingTypes.Type.Collectible,
-                          key: "AMP",
-                          name: "AMP",
-                          amount: 11,
-                          imageSource: ModelsData.assets.amp
-                      });
-        return holdings
+        return [
+            {
+                operator: OperatorsUtils.Operators.None,
+                type: HoldingTypes.Type.Collectible,
+                key: "Happy Meow",
+                name: "Happy Meow",
+                amount: 50.25,
+                imageSource: ModelsData.collectibles.kitty3
+            },
+            {
+                operator: OperatorsUtils.Operators.And,
+                type: HoldingTypes.Type.Collectible,
+                key: "AMP",
+                name: "AMP",
+                amount: 11,
+                imageSource: ModelsData.assets.amp
+            }
+        ]
     }
 
     function createChannelsModel1() {
-        var channels = []
-        channels.push({
-                          key: "help",
-                          iconSource: ModelsData.assets.zrx,
-                          name: "#help"
-                      });
-        channels.push({
-                          key: "faq",
-                          iconSource: ModelsData.assets.zrx,
-                          name: "#faq"
-                      });
-        return channels
+        return [
+            {
+                key: "general",
+                text: "#general",
+                color: "lightgreen",
+                emoji: "👋"
+            },
+            {
+                key: "faq",
+                text: "#faq",
+                color: "lightblue",
+                emoji: "⚽"
+            }
+        ]
     }
 
     function createChannelsModel2() {
-        var channels = []
-        channels.push({
-                          key: "welcome",
-                          iconSource: ModelsData.assets.inch,
-                          name: "#welcome"
-                      });
-        channels.push({
-                          key: "general",
-                          iconSource: ModelsData.assets.inch,
-                          name: "#general"
-                      });
-        return channels
+        return [
+            {
+                key: "socks",
+                iconSource: ModelsData.icons.socks,
+                text: "Socks"
+            }
+        ]
     }
 }

--- a/ui/app/AppLayouts/Chat/controls/community/PermissionItem.qml
+++ b/ui/app/AppLayouts/Chat/controls/community/PermissionItem.qml
@@ -141,10 +141,22 @@ Control{
                 model: root.channelsListModel
 
                 StatusListItemTag {
+                    readonly property bool isLetterIdenticon: !model.imageSource
+
+                    asset.isLetterIdenticon: isLetterIdenticon
+                    asset.emoji: model.emoji ? model.emoji : ""
+                    asset.color: model.color ? model.color : ""
+                    asset.width: isLetterIdenticon ? 20 : 28
+                    asset.height: asset.width
+
+                    leftPadding: isLetterIdenticon ? 6 : 2
+
                     height: d.flowRowHeight
-                    width: (implicitWidth > content.width) ? content.width : implicitWidth
+                    width: (implicitWidth > content.width)
+                           ? content.width : implicitWidth
+
                     title: model.text
-                    asset.name: model.imageSource
+                    asset.name: model.imageSource ? model.imageSource : ""
                     asset.isImage: true
                     asset.bgColor: "transparent"
                     closeButtonVisible: false

--- a/ui/app/AppLayouts/Chat/panels/communities/CommunityPermissionsSettingsPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/CommunityPermissionsSettingsPanel.qml
@@ -156,6 +156,7 @@ SettingsPageLayout {
         id: permissionsView
         CommunityPermissionsView {
             viewWidth: root.viewWidth
+            rootStore: root.rootStore
             store: root.store
             onEditPermission: {
                 d.permissionIndexToEdit = index

--- a/ui/app/AppLayouts/Chat/stores/CommunitiesStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/CommunitiesStore.qml
@@ -91,7 +91,7 @@ QtObject {
 
     function createPermission(holdings, permissions, isPrivate, channels, index = null) {
         // TO BE REPLACED: It shold just be a call to the backend sharing `holdings`, `permissions`, `channels` and `isPrivate` properties.
-        var permission = {
+        const permission = {
             isPrivate: true,
             holdingsListModel: [],
             permissionsObjectModel: {
@@ -99,20 +99,20 @@ QtObject {
                 text: "",
                 imageSource: ""
             },
-            channelsListModel: []
-        };
+            channelsListModel: [],
+        }
 
         // Setting HOLDINGS:
-        for (var i = 0; i < holdings.count; i++ ) {
-            var entry = holdings.get(i);
-             // roles: type, key, name, amount, imageSource
+        for (let i = 0; i < holdings.count; i++ ) {
+            const entry = holdings.get(i)
+
             permission.holdingsListModel.push({
-                                                  type: entry.type,
-                                                  key: entry.key,
-                                                  name: entry.name,
-                                                  amount: entry.amount,
-                                                  imageSource: entry.imageSource
-                                          });
+                type: entry.type,
+                key: entry.key,
+                name: entry.name,
+                amount: entry.amount,
+                imageSource: entry.imageSource
+            })
         }
 
         // Setting PERMISSIONS:
@@ -120,18 +120,27 @@ QtObject {
         permission.permissionsObjectModel.text = permissions.text
         permission.permissionsObjectModel.imageSource = permissions.imageSource
 
+        // Setting CHANNELS
+        for (let c = 0; c < channels.count; c++) {
+            const entry = channels.get(c)
+
+            permission.channelsListModel.push({
+                itemId: entry.itemId,
+                text: entry.text,
+                emoji: entry.emoji,
+                color: entry.color
+            })
+        }
+
         // Setting PRIVATE permission property:
         permission.isPrivate = isPrivate
 
-        // TODO: Set channels list. Now mocked data.
-        permission.channelsListModel = root.channelsModel
 
-        if(index !== null) {
+        if (index !== null) {
             // Edit permission model:
             console.log("TODO: Edit permissions - backend call")
             root.permissionsModel.set(index, permission)
-        }
-        else {
+        } else {
             // Add into permission model:
             console.log("TODO: Create permissions - backend call - Now dummy data shown")
             root.permissionsModel.append(permission)
@@ -147,7 +156,8 @@ QtObject {
         // TO BE REPLACED: Call to backend
         console.log("TODO: Duplicate permissions - backend call")
         const permission = root.permissionsModel.get(index)
-        createPermission(permission.holdingsListModel, permission.permissionsObjectModel, permission.isPrivate, permission.channelsListModel)
+        createPermission(permission.holdingsListModel, permission.permissionsObjectModel,
+                         permission.isPrivate, permission.channelsListModel)
     }
 
     function removePermission(index) {


### PR DESCRIPTION
### What does the PR do

Adds tracking of dirty values and storing state for `In` section of community permission.

Closes: #8855 

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas
`CommunityPermissionsSettingsPanel`, `CommunityNewPermissionView`, `CommunityPermissionsView`

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

[Kazam_screencast_00112.webm](https://user-images.githubusercontent.com/20650004/215483417-611988a5-2236-4794-8ae0-163e4d69e183.webm)
