### PR TITLE
fix: unbreak ModuleWarning banners

### DIFF
--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -111,7 +111,7 @@ Item {
                 {
                     newVersionAvailable: available,
                     downloadURL: url,
-                    currentVersion: rootStore.profileSectionStore.getCurrentVersion(),
+                    currentVersion: appMain.rootStore.profileSectionStore.getCurrentVersion(),
                     newVersion: version
                 })
             return downloadPage
@@ -566,6 +566,9 @@ Item {
             ColumnLayout {
                 id: bannersLayout
 
+                enabled: !localAppSettings.testEnvironment
+                visible: enabled
+
                 property var updateBanner: null
                 property var connectedBanner: null
                 readonly property bool isConnected: appMain.rootStore.mainModuleInst.isOnline
@@ -762,11 +765,9 @@ Item {
                         onCloseClicked: {
                             hide();
                         }
-                        onHideStarted: {
-                            bannersLayout.connectedBanner = null
-                        }
                         onHideFinished: {
                             destroy()
+                            bannersLayout.connectedBanner = null
                         }
                     }
                 }
@@ -813,11 +814,9 @@ Item {
                                 appMain.rootStore.resetLastVersion();
                             hide()
                         }
-                        onHideStarted: {
-                            bannersLayout.updateBanner = null
-                        }
                         onHideFinished: {
                             destroy()
+                            bannersLayout.updateBanner = null
                         }
                     }
                 }

--- a/ui/imports/shared/panels/ModuleWarning.qml
+++ b/ui/imports/shared/panels/ModuleWarning.qml
@@ -17,7 +17,7 @@ Item {
         Success
     }
 
-    property bool active: false
+    property bool active
     property int type: ModuleWarning.Danger
     property int progressValue: -1 // 0..100, -1 not visible
     property string text: ""
@@ -31,18 +31,9 @@ Item {
     signal hideStarted()
     signal hideFinished()
 
-    QtObject {
-        id: d 
-        property bool active: false
-    }
-
     function show() {
-        if (localAppSettings.testEnvironment) {
-            // Never show the banner while in a test enviornment
-            return
-        }
         hideTimer.stop()
-        d.active = true;
+        active = true;
     }
 
     function showFor(duration = 5000) {
@@ -61,15 +52,10 @@ Item {
 
     signal linkActivated(string link)
 
-    implicitHeight: d.active ? content.implicitHeight : 0
+    implicitHeight: active ? content.implicitHeight : 0
     visible: implicitHeight > 0
 
     onActiveChanged: {
-         if (localAppSettings.testEnvironment) {
-            // Never show the banner while in a test enviornment
-            return
-        }
-        d.active = active
         active ? showAnimation.start() : hideAnimation.start()
     }
 
@@ -110,7 +96,7 @@ Item {
         repeat: false
         running: false
         onTriggered: {
-            d.active = false
+            root.active = false
         }
     }
 


### PR DESCRIPTION
they stopped appearing after the introduction of `localAppSettings.testEnvironment`

Fixes https://github.com/status-im/status-desktop/issues/9354

### What does the PR do

Fixes app banners

### Affected areas

AppMain, ModuleWarning

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

Before (update check banner):
![image](https://user-images.githubusercontent.com/5377645/215456672-e9e79563-14d3-42ba-83ea-362089bfba18.png)

After:
![image](https://user-images.githubusercontent.com/5377645/215457677-d7425f16-c333-4caf-9df1-75256e56361a.png)



