### PR TITLE
fix(@desktop/communities): enforce alphanumerical characters in community name/description, channel name

### DIFF
--- a/ui/app/AppLayouts/Chat/controls/community/CommunityDescriptionInput.qml
+++ b/ui/app/AppLayouts/Chat/controls/community/CommunityDescriptionInput.qml
@@ -26,6 +26,10 @@ StatusInput {
             minLength: 1
             errorMessage: Utils.getErrorMessage(root.errors,
                                                 qsTr("community description"))
+        },
+        StatusRegularExpressionValidator {
+            regularExpression: Constants.regularExpressions.alphanumericalExpanded
+            errorMessage: Constants.errorMessages.alphanumericalExpandedRegExp
         }
     ]
 }

--- a/ui/app/AppLayouts/Chat/controls/community/CommunityNameInput.qml
+++ b/ui/app/AppLayouts/Chat/controls/community/CommunityNameInput.qml
@@ -13,11 +13,16 @@ StatusInput {
     label: qsTr("Name your community")
     charLimit: 30
     placeholderText: qsTr("A catchy name")
+
     validators: [
         StatusMinLengthValidator {
             minLength: 1
             errorMessage: Utils.getErrorMessage(root.errors,
                                                 qsTr("community name"))
+        },
+        StatusRegularExpressionValidator {
+            regularExpression: Constants.regularExpressions.alphanumericalExpanded
+            errorMessage: Constants.errorMessages.alphanumericalExpandedRegExp
         }
     ]
 }

--- a/ui/app/AppLayouts/Chat/panels/communities/CommunityEditSettingsPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/CommunityEditSettingsPanel.qml
@@ -46,7 +46,8 @@ StatusScrollView {
     property size bottomReservedSpace: Qt.size(0, 0)
     property bool bottomReservedSpaceActive: false
 
-    readonly property bool saveChangesButtonEnabled: true
+    readonly property bool saveChangesButtonEnabled: !((nameInput.input.dirty && !nameInput.valid) ||
+                                                       (descriptionTextInput.input.dirty && !descriptionTextInput.valid))
 
     ColumnLayout {
         id: layout

--- a/ui/app/AppLayouts/Chat/popups/community/CreateChannelPopup.qml
+++ b/ui/app/AppLayouts/Chat/popups/community/CreateChannelPopup.qml
@@ -135,6 +135,10 @@ StatusDialog {
                     StatusMinLengthValidator {
                         minLength: 1
                         errorMessage: Utils.getErrorMessage(nameInput.errors, qsTr("channel name"))
+                    },
+                    StatusRegularExpressionValidator {
+                        regularExpression: Constants.regularExpressions.alphanumericalExpanded
+                        errorMessage: Constants.errorMessages.alphanumericalExpandedRegExp
                     }
                 ]
             }

--- a/ui/app/AppLayouts/CommunitiesPortal/panels/CommunityColorPanel.qml
+++ b/ui/app/AppLayouts/CommunitiesPortal/panels/CommunityColorPanel.qml
@@ -18,6 +18,7 @@ StatusScrollView {
         objectName: "communityColorPanelSelectColorButton"
         text: qsTr("Select Community Colour")
         onClicked: root.accepted()
+        enabled: hexInput.valid
     }
 
     property alias color: colorSpace.color

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -578,6 +578,14 @@ QtObject {
         readonly property int telegram: 6
     }
 
+    readonly property QtObject regularExpressions: QtObject {
+        readonly property var alphanumericalExpanded: /^$|^[a-zA-Z0-9\-_ ]+$/
+    }
+
+    readonly property QtObject errorMessages: QtObject {
+        readonly property string alphanumericalExpandedRegExp: qsTr("Only letters, numbers, underscores, whitespaces and hyphens allowed")
+    }
+
     readonly property var socialLinkPrefixesByType: [ // NB order must match the "socialLinkType" enum above
         "",
         "https://twitter.com/",


### PR DESCRIPTION
### What does the PR do

- Allow in community name/description and channel name only numbers, ANSII letters, underscores whitespaces, and hyphens (taken from Profile name restrictions)
- Block saving the data if an input error is showing
- Disable the "Select community color" button during setting community color if an invalid color hex was set

Fixes: #9180

### Affected areas

Community name/description, channel name creation
Saving community changes
Saving community color changes

### Screenshot of functionality (including design for comparison)

https://user-images.githubusercontent.com/117639195/215474448-2a102c67-f9a8-472f-902e-c01d4e6c819a.mov
