### PR TITLE
refactor(chat): make getChats async to speed up start time

### DIFF
--- a/src/app/boot/app_controller.nim
+++ b/src/app/boot/app_controller.nim
@@ -166,7 +166,7 @@ proc newAppController*(statusFoundation: StatusFoundation): AppController =
     statusFoundation.events, statusFoundation.threadpool, result.networkService, result.settingsService, 
     result.activityCenterService
   )
-  result.chatService = chat_service.newService(statusFoundation.events, result.contactsService)
+  result.chatService = chat_service.newService(statusFoundation.events, statusFoundation.threadpool, result.contactsService)
   result.tokenService = token_service.newService(
     statusFoundation.events, statusFoundation.threadpool, result.networkService
   )

--- a/src/app/modules/main/controller.nim
+++ b/src/app/modules/main/controller.nim
@@ -86,6 +86,24 @@ proc init*(self: Controller) =
     let d9 = 9*86400 # 9 days
     discard self.settingsService.setDefaultSyncPeriod(d9)
 
+  self.events.on(SIGNAL_CHATS_LOADED) do(e:Args):
+    let args = ChannelGroupsArgs(e)
+    self.delegate.onChatsLoaded(
+      args.channelGroups,
+      self.events,
+      self.settingsService,
+      self.nodeConfigurationService,
+      self.contactsService,
+      self.chatService,
+      self.communityService,
+      self.messageService,
+      self.gifService,
+      self.mailserversService,
+    )
+
+  self.events.on(SIGNAL_CHATS_LOADING_FAILED) do(e:Args):
+    self.delegate.onChatsLoadingFailed()
+
   self.events.on(SIGNAL_ACTIVE_MAILSERVER_CHANGED) do(e:Args):
     let args = ActiveMailserverChangedArgs(e)
     if args.nodeAddress == "":

--- a/src/app/modules/main/io_interface.nim
+++ b/src/app/modules/main/io_interface.nim
@@ -68,6 +68,24 @@ method chatSectionDidLoad*(self: AccessInterface) {.base.} =
 method communitySectionDidLoad*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method onChatsLoaded*(
+  self: AccessInterface,
+  channelGroups: seq[ChannelGroupDto],
+  events: EventEmitter,
+  settingsService: settings_service.Service,
+  nodeConfigurationService: node_configuration_service.Service,
+  contactsService: contacts_service.Service,
+  chatService: chat_service.Service,
+  communityService: community_service.Service,
+  messageService: message_service.Service,
+  gifService: gif_service.Service,
+  mailserversService: mailservers_service.Service)
+  {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method onChatsLoadingFailed*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method onActiveChatChange*(self: AccessInterface, sectionId: string, chatId: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/view.nim
+++ b/src/app/modules/main/view.nim
@@ -14,6 +14,8 @@ QtObject:
       delegate: io_interface.AccessInterface
       model: section_model.SectionModel
       modelVariant: QVariant
+      chatsLoaded: bool
+      chatsLoadingFailed: bool
       activeSection: ActiveSection
       activeSectionVariant: QVariant
       chatSearchModel: chat_search_model.Model
@@ -40,6 +42,8 @@ QtObject:
     result.QObject.setup
     result.delegate = delegate
     result.model = section_model.newModel()
+    result.chatsLoaded = false
+    result.chatsLoadingFailed = false
     result.modelVariant = newQVariant(result.model)
     result.activeSection = newActiveSection()
     result.activeSectionVariant = newQVariant(result.activeSection)
@@ -154,6 +158,30 @@ QtObject:
 
   proc setCurrentUserStatus*(self: View, status: int) {.slot.} =
     self.delegate.setCurrentUserStatus(intToEnum(status, StatusType.Unknown))
+
+  proc chatsLoadedChanged(self: View) {.signal.}
+
+  proc chatsLoaded*(self: View) =
+    self.chatsLoaded = true
+    self.chatsLoadedChanged()
+
+  proc getChatsLoaded(self: View): bool {.slot.} =
+    return self.chatsLoaded
+  QtProperty[bool] chatsLoaded:
+    read = getChatsLoaded
+    notify = chatsLoadedChanged
+
+  proc chatsLoadingFailedChanged(self: View) {.signal.}
+
+  proc chatsLoadingFailed*(self: View) =
+    self.chatsLoadingFailed = true
+    self.chatsLoadingFailedChanged()
+
+  proc getChatsLoadingFailed(self: View): bool {.slot.} =
+    return self.chatsLoadingFailed
+  QtProperty[bool] chatsLoadingFailed:
+    read = getChatsLoadingFailed
+    notify = chatsLoadingFailedChanged
 
   # Since we cannot return QVariant from the proc which has arguments, so cannot have proc like this:
   # prepareCommunitySectionModuleForCommunityId(self: View, communityId: string): QVariant {.slot.}

--- a/src/app_service/service/chat/async_tasks.nim
+++ b/src/app_service/service/chat/async_tasks.nim
@@ -1,0 +1,15 @@
+#################################################
+# Async get chats (channel groups)
+#################################################
+type
+  AsyncGetChatsTaskArg = ref object of QObjectTaskArg
+
+const asyncGetChatsTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+  let arg = decode[AsyncGetChatsTaskArg](argEncoded)
+
+  let response = status_chat.getChats()
+
+  let responseJson = %*{
+    "channelGroups": response.result
+  }
+  arg.finish(responseJson)

--- a/ui/app/AppLayouts/Chat/views/ContactsColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ContactsColumnView.qml
@@ -20,7 +20,7 @@ import "../popups/community"
 
 Item {
     id: root
-    width: 304
+    width: Constants.chatSectionLeftColumnWidth
     height: parent.height
 
     // Important:

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -291,6 +291,8 @@ QtObject {
         }
     }
 
+    readonly property int chatSectionLeftColumnWidth: 304
+
     readonly property QtObject appSection: QtObject {
         readonly property int chat: 0
         readonly property int community: 1


### PR DESCRIPTION
Fixes #9340

Makes the getChats call async, so opening the app will be faster. You might see a (placeholder) loader when opening the app until chats and communities appear.

For QAs testing this, make sure the community section, chat section, stickers, activity center, ad-hoc chat thingy all still work as before