### PR TITLE
fix(community): ensure chats are reordered when cateories have changed

### DIFF
--- a/src/app/modules/main/chat_section/controller.nim
+++ b/src/app/modules/main/chat_section/controller.nim
@@ -172,12 +172,12 @@ proc init*(self: Controller) =
     self.events.on(SIGNAL_COMMUNITY_CHANNEL_REORDERED) do(e:Args):
       let args = CommunityChatOrderArgs(e)
       if (args.communityId == self.sectionId):
-        self.delegate.onReorderChat(args.chatId, args.position, args.categoryId)
+        self.delegate.onReorderChat(args.chatId, args.position, args.categoryId, args.prevCategoryId, false)
     
     self.events.on(SIGNAL_COMMUNITY_CHANNEL_CATEGORY_CHANGED) do(e:Args):
       let args = CommunityChatOrderArgs(e)
       if (args.communityId == self.sectionId):
-        self.delegate.onCommunityCategoryChannelChanged(args.chatId, args.categoryId)
+        self.delegate.onReorderChat(args.chatId, args.position, args.categoryId, args.prevCategoryId, args.prevCategoryDeleted)
 
     self.events.on(SIGNAL_RELOAD_MESSAGES) do(e: Args):
       let args = ReloadMessagesArgs(e)

--- a/src/app/modules/main/chat_section/io_interface.nim
+++ b/src/app/modules/main/chat_section/io_interface.nim
@@ -124,7 +124,7 @@ method onGroupChatDetailsUpdated*(self: AccessInterface, chatId: string, newName
 method onCommunityChannelEdited*(self: AccessInterface, chat: ChatDto) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method onReorderChat*(self: AccessInterface, chattId: string, position: int, newCategoryIdForChat: string) {.base.} =
+method onReorderChat*(self: AccessInterface, chattId: string, position: int, newCategoryIdForChat: string, prevCategoryId: string, prevCategoryDeleted: bool) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method onReorderCategory*(self: AccessInterface, catId: string, position: int) {.base.} =

--- a/src/app/modules/main/chat_section/model.nim
+++ b/src/app/modules/main/chat_section/model.nim
@@ -185,6 +185,12 @@ QtObject:
       idx.inc
     return -1
 
+  proc hasEmptyChatItem*(self: Model, categoryId: string): bool =
+    for it in self.items:
+      if it.id == categoryId:
+        return true
+    return false
+
   proc getCategoryNameForCategoryId*(self: Model, categoryId: string): string {.slot.} =
     let index = self.getItemIdxByCategory(categoryId)
     if index == -1:
@@ -391,7 +397,7 @@ QtObject:
         continue
       item.categoryName = newName
       let modelIndex = self.createIndex(i, 0, nil)
-      self.dataChanged(modelIndex, modelIndex, @[ModelRole.CategoryName.int])
+      self.dataChanged(modelIndex, modelIndex, @[ModelRole.CategoryId.int, ModelRole.CategoryName.int])
 
   proc renameItemById*(self: Model, id, name: string) =
     let index = self.getItemIdxById(id)


### PR DESCRIPTION
We were not reordering chats when their category IDs have changed, this resulted in missing updates in community member's UIs

Closes #9329

