### PR TITLE
fix(@desktop/general): broken `StatusModal` popups fixed

### DIFF
--- a/ui/StatusQ/src/StatusQ/Core/StatusScrollView.qml
+++ b/ui/StatusQ/src/StatusQ/Core/StatusScrollView.qml
@@ -49,6 +49,8 @@ Flickable {
     rightMargin: rightPadding
     contentWidth: contentItem.childrenRect.width
     contentHeight: contentItem.childrenRect.height
+    implicitWidth: contentWidth + leftPadding + rightPadding
+    implicitHeight: contentHeight + topPadding + bottomPadding
     boundsBehavior: Flickable.StopAtBounds
     maximumFlickVelocity: 2000
     synchronousDrag: true


### PR DESCRIPTION
All `StatusModal` popups got broken because of these two lines removal.

They were removed in this commit: https://github.com/status-im/status-desktop/commit/9a2ffc0fc7e45675a2d38a9d7cb87a8ffebeff5a

I just brought them back.

Popups were without content, just header and footer:
![b](https://user-images.githubusercontent.com/86303051/216018458-863d4fe7-d684-40d3-b8a8-3dae08f51b05.png)
