### PR TITLE
ci: add missing qt labels for build hosts

### DIFF
--- a/ci/Jenkinsfile.e2e
+++ b/ci/Jenkinsfile.e2e
@@ -4,7 +4,9 @@ library 'status-jenkins-lib@v1.6.3'
 def isPRBuild = utils.isPRBuild()
 
 pipeline {
-  agent { label 'linux' }
+  agent {
+    label 'linux && x86_64 && qt-5.14.2'
+  }
 
   parameters {
     booleanParam(

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -5,7 +5,7 @@ def isPRBuild = utils.isPRBuild()
 
 pipeline {
   agent {
-    label 'macos && x86_64'
+    label 'macos && x86_64 && qt-5.14.2'
   }
 
   parameters {


### PR DESCRIPTION
To avoid mixing builds on upgraded and unupgraded hosts.