### PR TITLE
fix: '@everyone' in the pinned messages leads to 'qrc:/app/mainui/1'

### DIFF
--- a/src/app_service/service/message/service.nim
+++ b/src/app_service/service/message/service.nim
@@ -709,12 +709,12 @@ proc renderInline(self: Service, parsedText: ParsedText, communityChats: seq[Cha
           if pair[1] == "@" & id:
             tag = pair[0]
             break
-        result = fmt("<a href=\"\" class=\"mention\">{tag}</a>")
+        result = fmt("<a href=\"#\" class=\"mention\">{tag}</a>")
       else:
         if isCompressedPubKey(id):
           id = status_accounts.decompressPk(id).result
         let contactDto = self.contactService.getContactById(id)
-        result = fmt("<a href=\"//{id}\" class=\"mention\">{contactDto.userDefaultDisplayName()}</a>")
+        result = fmt("<a href=\"//{id}\" class=\"mention\">@{contactDto.userDefaultDisplayName()}</a>")
     of PARSED_TEXT_CHILD_TYPE_STATUS_TAG:
       result = fmt("<span>#{value}</span>")
       for chat in communityChats:


### PR DESCRIPTION
- make the `href` point to `#` to prevent Qt from resolving the empty URL as if it were a relative link
- prepend the at sign (`@`) to the mention tag, just like Discord and `@everyone` else :)

Fixes #9364

### What does the PR do

Fixes `@everyone` link leading to bogus destination

### Affected areas

Chat

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

Pinned messages popup:
![image](https://user-images.githubusercontent.com/5377645/216039212-5dfdda4a-8aa8-4063-a59b-fa6414a72444.png)

Chat:
![image](https://user-images.githubusercontent.com/5377645/216038834-01abe7ca-2dca-423e-8708-90ea2704b0d9.png)
