### PR TITLE
fix(wallet): improve send modal advanced recipient text

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/StatusAddressPanel.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusAddressPanel.qml
@@ -20,7 +20,7 @@ import StatusQ.Controls 0.1
 
     \qmlproperty string address address to show
     \qmlproperty bool showCopy if \c true shows the copy action which triggers \c doCopy signal
-    \qmlproperty bool autHideCopyIcon if \c true shows the copy action when hovered. \see showCopy
+    \qmlproperty bool autHideCopyIcon if \c true and \c showCopy is \c true shows the copy action only when hovered. \see showCopy
     \qmlproperty alias showFrame if \c true displays frame and \c 0x prefix
     \qmlproperty bool expandable if \c true user can toggle between expanded and compact version; \see expanded
     \qmlproperty bool expanded if \c true show address in full; if \c false show the address in compact mode eliding in the middle
@@ -124,8 +124,7 @@ Item {
             StatusIcon {
                 icon: "copy"
 
-                visible: root.autHideCopyIcon ? (mainMouseArea.containsMouse || copyMouseArea.containsMouse )
-                                              : root.showCopy
+                visible: root.showCopy && (!root.autHideCopyIcon || (mainMouseArea.containsMouse || copyMouseArea.containsMouse ))
 
                 Layout.alignment: Qt.AlignVCenter
                 Layout.preferredWidth: (statusAddress.font.pixelSize * 1.2).toFixed()

--- a/ui/imports/shared/popups/SendModal.qml
+++ b/ui/imports/shared/popups/SendModal.qml
@@ -445,6 +445,7 @@ StatusDialog {
                         store: popup.store
                         interactive: popup.interactive
                         selectedAccount: popup.selectedAccount
+                        ensAddressOrEmpty: d.isENSValid ? d.resolvedENSAddress : ""
                         amountToSend: amountToSendInput.cryptoValueToSend
                         requiredGasInEth: d.totalFeesInEth
                         selectedAsset: assetSelector.selectedAsset

--- a/ui/imports/shared/views/NetworkCardsComponent.qml
+++ b/ui/imports/shared/views/NetworkCardsComponent.qml
@@ -18,6 +18,7 @@ Item {
     property var store
     property var bestRoutes
     property var selectedAccount
+    property string ensAddressOrEmpty: ""
     property var selectedAsset
     property var allNetworks
     property bool customMode: false
@@ -152,14 +153,31 @@ Item {
             id: toNetworksLayout
             Layout.alignment: Qt.AlignRight | Qt.AlignTop
             spacing: 12
-            StatusBaseText {
+
+            RowLayout {
                 Layout.alignment: Qt.AlignRight | Qt.AlignTop
-                Layout.maximumWidth: 100
-                font.pixelSize: 10
-                color: Theme.palette.baseColor1
-                text: !!selectedAccount ? StatusQUtils.Utils.elideText(selectedAccount.address, 6, 4).toUpperCase() :  ""
-                elide: Text.ElideMiddle
+                Layout.maximumWidth: 160
+
+                StatusBaseText {
+                    id: receiverIdentityText
+
+                    text: root.ensAddressOrEmpty.length > 0
+                            ? root.ensAddressOrEmpty
+                            : !!selectedAccount ? StatusQUtils.Utils.elideText(selectedAccount.address, 6, 4).toUpperCase() :  ""
+                    Layout.fillWidth: true
+
+                    font.pixelSize: 10
+                    color: Theme.palette.baseColor1
+                    elide: Text.ElideMiddle
+                    horizontalAlignment: Text.AlignRight
+                }
+                StatusBaseText {
+                    font.pixelSize: receiverIdentityText.font.pixelSize
+                    color: receiverIdentityText.color
+                    text: qsTr("WILL RECEIVE")
+                }
             }
+
             Repeater {
                 id: toNetworksRepeater
                 model: root.allNetworks

--- a/ui/imports/shared/views/NetworkSelector.qml
+++ b/ui/imports/shared/views/NetworkSelector.qml
@@ -20,6 +20,7 @@ Item {
     property var store
     property var currencyStore : store.currencyStore
     property var selectedAccount
+    property string ensAddressOrEmpty: ""
     property var selectedAsset
     property var amountToSend
     property var requiredGasInEth
@@ -106,6 +107,7 @@ Item {
                 store: root.store
                 customMode: tabBar.currentIndex === 2
                 selectedAccount: root.selectedAccount
+                ensAddressOrEmpty: root.ensAddressOrEmpty
                 amountToSend: root.amountToSend
                 requiredGasInEth: root.requiredGasInEth
                 selectedAsset: root.selectedAsset

--- a/ui/imports/shared/views/NetworksAdvancedCustomRoutingView.qml
+++ b/ui/imports/shared/views/NetworksAdvancedCustomRoutingView.qml
@@ -16,6 +16,7 @@ ColumnLayout {
 
     property var store
     property var selectedAccount
+    property string ensAddressOrEmpty: ""
     property var amountToSend
     property var requiredGasInEth
     property bool customMode: false
@@ -83,6 +84,7 @@ ColumnLayout {
                 sourceComponent: NetworkCardsComponent {
                     store: root.store
                     selectedAccount: root.selectedAccount
+                    ensAddressOrEmpty: root.ensAddressOrEmpty
                     allNetworks: root.store.allNetworks
                     amountToSend: root.amountToSend
                     customMode: root.customMode


### PR DESCRIPTION
### Closes https://github.com/status-im/status-desktop/issues/9331

Changes:

- Add "WILL RECEIVE" after identity
- Allow ENS name if resolved
  - Elide the middle if doesn't fit (the main is displayed above and can be checked)

Also, fix `autHideCopyIcon` of `StatusAddressPanel` property  working independently behaviour of `showCopy` property

### Affected areas

- Wallet Send Modal
- Copy address changes behaviour when `showCopy` is `false`, and `autHideCopyIcon` is `true`. I've checked and none of our usages has this corner case 

Considerations

- Tried to fix `NetworksSimpleRoutingView` scrolling is blocked found issue but it seems complicated and will take some time, so I gave up.

### StatusQ checklist

- [x] add documentation if necessary (new component, new feature)
- [x] ~~update sandbox app~~
- [x] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design ~~and this PR matches it~~
  - The new design is partially described in the corresponding ticket

| Dark | Light |
| -- | -- |
| ![image](https://user-images.githubusercontent.com/47554641/216108763-82510835-c6af-41e5-ab9a-d6d15f243f89.png) | ![image](https://user-images.githubusercontent.com/47554641/216108626-6995eb30-1631-46da-a490-0980e3341c25.png) |

ENS name that doesn't fit elided middle (`very_long_long_name.stateofus.eth`)

![image](https://user-images.githubusercontent.com/47554641/216108047-46010660-d068-4fb7-b103-1e7781c1d16e.png)
