### PR TITLE
fix: nothing happens after clicking on a pinned message

### DIFF
--- a/ui/app/AppLayouts/Chat/popups/PinnedMessagesPopup.qml
+++ b/ui/app/AppLayouts/Chat/popups/PinnedMessagesPopup.qml
@@ -111,12 +111,16 @@ StatusDialog {
 
                 MouseArea {
                     anchors.fill: parent
-                    enabled: !!root.messageToPin
                     cursorShape: Qt.PointingHandCursor
                     z: 55
                     onClicked: {
-                        if (!radio.checked)
-                            radio.checked = true
+                        if (!!root.messageToPin) {
+                            if (!radio.checked)
+                                radio.checked = true
+                        } else {
+                            root.close()
+                            root.messageStore.messageModule.jumpToMessage(model.id)
+                        }
                     }
                 }
 


### PR DESCRIPTION
implement jumping to a message on a simple click

Fixes #9365

### Affected areas

PinnedMessagesPopup

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

About to click on a pinned message:
![image](https://user-images.githubusercontent.com/5377645/216123146-b1716d6b-77af-4eaf-ade0-b598907df432.png)

Message jumped to and highlighted:
![image](https://user-images.githubusercontent.com/5377645/216123306-653c19a4-917e-4f9f-bec0-3f29315457e2.png)
