### PR TITLE
fix: unbreak community options layout

### DIFF
--- a/ui/app/AppLayouts/Chat/controls/community/CommunityLogoPicker.qml
+++ b/ui/app/AppLayouts/Chat/controls/community/CommunityLogoPicker.qml
@@ -30,7 +30,7 @@ Item {
 
         implicitWidth: childrenRect.width
         implicitHeight: childrenRect.height
-
+        anchors.horizontalCenter: parent.horizontalCenter
         spacing: 8
 
         StatusBaseText {

--- a/ui/app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml
+++ b/ui/app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml
@@ -448,6 +448,7 @@ StatusStackModal {
 
                 CommunityOptions {
                     id: options
+                    Layout.fillWidth: true
                 }
 
                 Item {


### PR DESCRIPTION
got broken with the recent scroll view fixes

### Affected areas

CreateCommunityPopup

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

Before: 
![Snímek obrazovky z 2023-02-02 11-04-13](https://user-images.githubusercontent.com/5377645/216300093-2f0770fe-9a0b-472d-825d-0263c55ef530.png)

After:
![image](https://user-images.githubusercontent.com/5377645/216300234-6a0e1163-d37c-47f3-afad-676667517b76.png)

![image](https://user-images.githubusercontent.com/5377645/216300258-1904c40e-b430-4dd4-b213-28c67d1771f0.png)

