### PR TITLE
feat(CommunityPermission): Create main UI page for joining a community that requires permissions

### DIFF
--- a/storybook/PagesModel.qml
+++ b/storybook/PagesModel.qml
@@ -110,6 +110,10 @@ ListModel {
         section: "Components"
     }
     ListElement {
+        title: "StatusMessage"
+        section: "Components"
+    }
+    ListElement {
          title: "BrowserSettings"
          section: "Settings"
     }

--- a/storybook/PagesModel.qml
+++ b/storybook/PagesModel.qml
@@ -66,6 +66,10 @@ ListModel {
          section: "Panels"
     }
     ListElement {
+         title: "JoinPermissionsOverlayPanel"
+         section: "Panels"
+    }
+    ListElement {
         title: "InviteFriendsToCommunityPopup"
         section: "Popups"
     }

--- a/storybook/PagesModel.qml
+++ b/storybook/PagesModel.qml
@@ -30,6 +30,10 @@ ListModel {
          section: "Views"
     }
     ListElement {
+         title: "JoinCommunityView"
+         section: "Views"
+    }
+    ListElement {
          title: "StatusCommunityCard"
          section: "Panels"
     }

--- a/storybook/PagesModel.qml
+++ b/storybook/PagesModel.qml
@@ -58,6 +58,10 @@ ListModel {
          section: "Panels"
     }
     ListElement {
+         title: "CommunityColumnHeaderPanel"
+         section: "Panels"
+    }
+    ListElement {
         title: "InviteFriendsToCommunityPopup"
         section: "Popups"
     }

--- a/storybook/figma.json
+++ b/storybook/figma.json
@@ -93,5 +93,10 @@
     ],
     "JoinPermissionsOverlayPanel": [
         "https://www.figma.com/file/17fc13UBFvInrLgNUKJJg5/Kuba%E2%8E%9CDesktop?node-id=2365%3A291788&t=UOvsb3QLi26KmVrk-0"
+    ],
+    "JoinCommunityView": [
+        "https://www.figma.com/file/17fc13UBFvInrLgNUKJJg5/Kuba%E2%8E%9CDesktop?node-id=2365%3A317901&t=05yQWHWBWOs2DUTp-0",
+        "https://www.figma.com/file/17fc13UBFvInrLgNUKJJg5/Kuba%E2%8E%9CDesktop?node-id=2698%3A380426&t=UOvsb3QLi26KmVrk-0",
+        "https://www.figma.com/file/17fc13UBFvInrLgNUKJJg5/Kuba%E2%8E%9CDesktop?node-id=2365%3A291788&t=UOvsb3QLi26KmVrk-0"
     ]
 }

--- a/storybook/figma.json
+++ b/storybook/figma.json
@@ -90,5 +90,8 @@
     ],
     "CommunityNewPermissionView": [
         "https://www.figma.com/file/17fc13UBFvInrLgNUKJJg5/Kuba%E2%8E%9CDesktop?node-id=22253%3A486103&t=JrCIfks1zVzsk3vn-0"
+    ],
+    "JoinPermissionsOverlayPanel": [
+        "https://www.figma.com/file/17fc13UBFvInrLgNUKJJg5/Kuba%E2%8E%9CDesktop?node-id=2365%3A291788&t=UOvsb3QLi26KmVrk-0"
     ]
 }

--- a/storybook/pages/CommunityColumnHeaderPanelPage.qml
+++ b/storybook/pages/CommunityColumnHeaderPanelPage.qml
@@ -1,0 +1,100 @@
+import QtQuick 2.14
+import QtQuick.Controls 2.14
+import QtQuick.Layouts 1.14
+
+import Storybook 1.0
+
+import AppLayouts.Chat.panels.communities 1.0
+import StatusQ.Core.Theme 0.1
+
+import utils 1.0
+
+SplitView {
+
+    QtObject {
+        id: d
+
+        property string name: "Uniswap"
+        property int membersCount: 184
+        property bool amISectionAdmin: false
+        property color color: "orchid"
+        property url image: Style.png("tokens/UNI")
+        property bool openCreateChat: false
+    }
+
+    Logs { id: logs }
+
+    SplitView {
+        orientation: Qt.Vertical
+        SplitView.fillWidth: true
+
+        Item {
+            SplitView.fillWidth: true
+            SplitView.fillHeight: true
+
+            Rectangle {
+                width: widthSlider.value
+                height: communityColumnHeader.implicitHeight
+                anchors.centerIn: parent
+                color: Theme.palette.baseColor4
+
+                CommunityColumnHeaderPanel {
+                    id: communityColumnHeader
+
+                    width: widthSlider.value
+                     anchors.centerIn: parent
+                    name: d.name
+                    membersCount: d.membersCount
+                    image: d.image
+                    color: d.color
+                    amISectionAdmin: d.amISectionAdmin
+                    openCreateChat: false
+                    onInfoButtonClicked: logs.logEvent("CommunityColumnHeaderPanel::onInfoButtonClicked()")
+                    onAdHocChatButtonClicked: {
+                        logs.logEvent("CommunityColumnHeaderPanel::onAdHocChatButtonClicked(): " + openCreateChat.toString())
+                        openCreateChat = !openCreateChat
+                    }
+                }
+            }
+        }
+
+        LogsAndControlsPanel {
+            SplitView.minimumHeight: 100
+            SplitView.preferredHeight: 250
+            logsView.logText: logs.logText
+
+            Row {
+                Label {
+                    anchors.verticalCenter: parent.verticalCenter
+                    text: "Width:"
+                }
+
+                Slider {
+                    id: widthSlider
+                    value: 400
+                    from: 250
+                    to: 600
+                }
+            }
+        }
+    }
+
+    Pane {
+        SplitView.minimumWidth: 300
+        SplitView.preferredWidth: 300
+
+        CommunityInfoEditor {
+            name: d.name
+            membersCount: d.membersCount
+            amISectionAdmin: d.amISectionAdmin
+            color: d.color
+            image: d.image
+
+            onNameChanged: d.name = name
+            onMembersCountChanged: d.membersCount = membersCount
+            onAmISectionAdminChanged: d.amISectionAdmin = amISectionAdmin
+            onColorChanged: d.color = color
+            onImageChanged: d.image = image
+        }
+    }
+}

--- a/storybook/pages/CommunityInfoEditor.qml
+++ b/storybook/pages/CommunityInfoEditor.qml
@@ -1,0 +1,99 @@
+import QtQuick 2.14
+import QtQuick.Controls 2.14
+import QtQuick.Layouts 1.14
+
+import utils 1.0
+
+ColumnLayout {
+    id: root
+
+    property string name: "Uniswap"
+    property int membersCount: 184
+    property bool amISectionAdmin: false
+    property color color: "orchid"
+    property url image: Style.png("tokens/UNI")
+    property bool colorVisible: false
+
+    spacing: 24
+
+    ColumnLayout {
+        Label {
+            Layout.fillWidth: true
+            text: "Name"
+        }
+        TextField {
+            background: Rectangle { border.color: 'lightgrey' }
+            Layout.preferredWidth: 200
+            text: root.name
+            onTextChanged: root.name = text
+        }
+    }
+
+    ColumnLayout {
+        Label {
+            Layout.fillWidth: true
+            text: "Community members:"
+        }
+
+        Slider {
+            value: root.membersCount
+            from: 0
+            to: 1000
+            onValueChanged: root.membersCount = value
+        }
+    }
+
+    ColumnLayout {
+        visible: root.colorVisible
+        Label {
+            Layout.fillWidth: true
+            text: "Community color:"
+        }
+
+        RadioButton {
+            checked: true
+            text: "Orchid"
+            onCheckedChanged: if(checked) root.color = "orchid"
+        }
+        RadioButton {
+            text: "Blue"
+            onCheckedChanged: if(checked) root.color = "blue"
+        }
+        RadioButton {
+            text: "Orange"
+            onCheckedChanged: if(checked) root.color = "orange"
+        }
+    }
+
+    ColumnLayout {
+        Label {
+            Layout.fillWidth: true
+            text: "Community image:"
+        }
+
+        RadioButton {
+            checked: true
+            text: qsTr("UNI")
+            onCheckedChanged: if(checked) root.image = Style.png("tokens/UNI")
+        }
+        RadioButton {
+            text: qsTr("SOCKS")
+            onCheckedChanged: if(checked) root.image = Style.png("tokens/SOCKS")
+        }
+        RadioButton {
+            text: qsTr("Status")
+            onCheckedChanged: if(checked) root.image = Style.png("tokens/SNT")
+        }
+    }
+
+    RowLayout {
+        Label {
+            text: "Is community admin:"
+        }
+
+        CheckBox {
+            checked: root.amISectionAdmin
+            onCheckedChanged: root.amISectionAdmin = checked
+        }
+    }
+}

--- a/storybook/pages/CommunityPermissionsViewPage.qml
+++ b/storybook/pages/CommunityPermissionsViewPage.qml
@@ -25,7 +25,8 @@ SplitView {
                     margins: 50
                 }
                 store: CommunitiesStore {
-                    permissionsModel: PermissionsModel { id: mockedModel }
+                    id: mockedCommunity
+                    permissionsModel: PermissionsModel.permissionsModel
 
                     function duplicatePermission(index) {
                         logs.logEvent("CommunitiesStore::duplicatePermission - index: " + index)
@@ -68,7 +69,7 @@ SplitView {
 
         CommunityPermissionsSettingsPanelEditor {
             anchors.fill: parent
-            model: mockedModel
+            model: mockedCommunity.permissionsModel
         }
     }
 }

--- a/storybook/pages/JoinCommunityPermissionsEditor.qml
+++ b/storybook/pages/JoinCommunityPermissionsEditor.qml
@@ -1,0 +1,200 @@
+import QtQuick 2.14
+import QtQuick.Controls 2.14
+import QtQuick.Layouts 1.14
+
+import Models 1.0
+
+import utils 1.0
+
+ColumnLayout {
+    id: root
+
+    property string channelName: "#vip"
+    property bool joinCommunity: true // Otherwise, enter channel
+    property bool requirementsMet: true
+    property bool isInvitationPending: false
+    property bool isJoinRequestRejected: false
+    property bool requiresRequest: false
+    property var communityHoldings: PermissionsModel.shortPermissionsModel
+    property var viewOnlyHoldings: PermissionsModel.shortPermissionsModel
+    property var viewAndPostHoldings: PermissionsModel.shortPermissionsModel
+    property var moderateHoldings: PermissionsModel.shortPermissionsModel
+
+    spacing: 16
+
+    ColumnLayout {
+        Label {
+            Layout.fillWidth: true
+            text: "View type:"
+        }
+
+        RadioButton {
+            checked: true
+            text: "Join community"
+            onCheckedChanged: if(checked) d.joinCommunity =  true
+        }
+        RadioButton {
+            text: "Enter channel"
+            onCheckedChanged: if(checked) d.joinCommunity = false
+        }
+    }
+
+    ColumnLayout {
+        Label {
+            Layout.fillWidth: true
+            text: "Requirements met:"
+        }
+
+        CheckBox {
+            checked: root.requirementsMet
+            onCheckedChanged: root.requirementsMet = checked
+        }
+    }
+
+    ColumnLayout {
+        Label {
+            Layout.fillWidth: true
+            text: "Request pending:"
+        }
+
+        CheckBox {
+            checked: root.isInvitationPending
+            onCheckedChanged: root.isInvitationPending = checked
+        }
+    }
+
+    ColumnLayout {
+        Label {
+            Layout.fillWidth: true
+            text: "Request rejected:"
+        }
+
+        CheckBox {
+            checked: root.isJoinRequestRejected
+            onCheckedChanged: root.isJoinRequestRejected = checked
+        }
+    }
+
+    ColumnLayout {
+        visible: root.joinCommunity
+        Label {
+            Layout.fillWidth: true
+            text: "Requires request:"
+        }
+
+        CheckBox {
+            checked: root.requiresRequest
+            onCheckedChanged: root.requiresRequest = checked
+        }
+    }
+
+    ColumnLayout {
+        visible: root.joinCommunity
+        Label {
+            Layout.fillWidth: true
+            text: "Holdings model type:"
+        }
+
+        RadioButton {
+            checked: true
+            text: "Short model"
+            onCheckedChanged: if(checked) root.communityHoldings = PermissionsModel.shortPermissionsModel
+        }
+
+        RadioButton {
+            text: "Long model"
+            onCheckedChanged: if(checked) root.communityHoldings = PermissionsModel.longPermissionsModel
+        }
+    }
+
+    ColumnLayout {
+        visible: !root.joinCommunity
+
+        Label {
+            Layout.fillWidth: true
+            text: "Channel name"
+        }
+
+        TextField {
+            background: Rectangle { border.color: 'lightgrey' }
+            Layout.preferredWidth: 200
+            text: root.channelName
+            onTextChanged: root.channelName = text
+        }
+    }
+
+    ColumnLayout {
+        visible: !root.joinCommunity
+
+        Label {
+            Layout.fillWidth: true
+            text: "Only view holdings model type:"
+        }
+
+        RadioButton {
+            checked: true
+            text: "Short model"
+            onCheckedChanged: if(checked) root.viewOnlyHoldings = PermissionsModel.shortPermissionsModel
+        }
+
+        RadioButton {
+            text: "Long model"
+            onCheckedChanged: if(checked) root.viewOnlyHoldings = PermissionsModel.longPermissionsModel
+        }
+
+        RadioButton {
+            text: "None"
+            onCheckedChanged: if(checked) root.viewOnlyHoldings = undefined
+        }
+    }
+
+    ColumnLayout {
+        visible: !root.joinCommunity
+
+        Label {
+            Layout.fillWidth: true
+            text: "View and post holdings model type:"
+        }
+
+        RadioButton {
+            checked: true
+            text: "Short model"
+            onCheckedChanged: if(checked) root.viewAndPostHoldings = PermissionsModel.shortPermissionsModel
+        }
+
+        RadioButton {
+            text: "Long model"
+            onCheckedChanged: if(checked) root.viewAndPostHoldings = PermissionsModel.longPermissionsModel
+        }
+
+        RadioButton {
+            text: "None"
+            onCheckedChanged: if(checked) root.viewAndPostHoldings = undefined
+        }
+    }
+
+    ColumnLayout {
+        visible: !root.joinCommunity
+
+        Label {
+            Layout.fillWidth: true
+            text: "Moderate holdings model type:"
+        }
+
+        RadioButton {
+            checked: true
+            text: "Short model"
+            onCheckedChanged: if(checked) root.moderateHoldings = PermissionsModel.shortPermissionsModel
+        }
+
+        RadioButton {
+            text: "Long model"
+            onCheckedChanged: if(checked) root.moderateHoldings = PermissionsModel.longPermissionsModel
+        }
+
+        RadioButton {
+            text: "None"
+            onCheckedChanged: if(checked) root.moderateHoldings = undefined
+        }
+    }
+}

--- a/storybook/pages/JoinCommunityViewPage.qml
+++ b/storybook/pages/JoinCommunityViewPage.qml
@@ -1,0 +1,224 @@
+import QtQuick 2.14
+import QtQuick.Controls 2.14
+import QtQuick.Layouts 1.14
+
+import StatusQ.Core.Theme 0.1
+import StatusQ.Components 0.1
+
+import AppLayouts.Chat.views.communities 1.0
+
+import Storybook 1.0
+import Models 1.0
+
+import utils 1.0
+
+SplitView {
+
+    QtObject {
+        id: d
+
+        // General properties:
+        property string name: "Uniswap"
+        property string communityDesc: "General channel for the community"
+        property color color: "orchid"
+        property string channelName: joinCommunity ? "general" : "#vip"
+        property string channelDesc: "VIP members only"
+        property bool joinCommunity: true // Otherwise it means join channel action
+
+        // Overlay component:
+        property bool requirementsMet: true
+        property bool isInvitationPending: false
+        property bool isJoinRequestRejected: false
+        property bool requiresRequest: false
+        property var communityHoldings: PermissionsModel.shortPermissionsModel
+        property var viewOnlyHoldings: PermissionsModel.shortPermissionsModel
+        property var viewAndPostHoldings: PermissionsModel.shortPermissionsModel
+        property var moderateHoldings: PermissionsModel.shortPermissionsModel
+
+        // Blur background:
+        property int membersCount: 184
+        property bool amISectionAdmin: false
+        property url image: Style.png("tokens/UNI")
+        property var communityItemsModel: model1
+        property string chatDateTimeText: "Dec 31, 2020"
+        property string  listUsersText: "simon, Mark Cuban "
+        readonly property ListModel model1:  ListModel {
+            ListElement { name: "welcome"; selected: false; notificationsCount: 0; hasUnreadMessages: false}
+            ListElement { name: "general"; selected: false; notificationsCount: 0; hasUnreadMessages: true}
+            ListElement { name: "design"; selected: true; notificationsCount: 3; hasUnreadMessages: true}
+            ListElement { name: "random"; selected: false; notificationsCount: 0; hasUnreadMessages: false}
+            ListElement { name: "vip"; selected: false; notificationsCount: 0; hasUnreadMessages: true}
+        }
+        readonly property ListModel model2:  ListModel {
+            ListElement { name: "general"; selected: false; notificationsCount: 3; hasUnreadMessages: false}
+            ListElement { name: "blockchain"; selected: true; notificationsCount: 3; hasUnreadMessages: true}
+            ListElement { name: "faq"; selected: false; notificationsCount: 0; hasUnreadMessages: false}
+        }
+        readonly property var messagesModel: ListModel {
+            ListElement {
+                timestamp: 1656937930
+                senderDisplayName: "simon"
+                contentType: StatusMessage.ContentType.Text
+                message:  "Hello, this is awesome! Feels like decentralized Discord!"
+                isContact: true
+                trustIndicator: StatusContactVerificationIcons.TrustedType.Verified
+                colorId: 4
+            }
+            ListElement {
+                timestamp: 1657937930
+                senderDisplayName: "Mark Cuban"
+                contentType: StatusMessage.ContentType.Text
+                message: "I know a lot of you really seem to get off or be validated by arguing with strangers online but please know it's a complete waste of your time and energy"
+                isContact: false
+                trustIndicator: StatusContactVerificationIcons.TrustedType.Untrustworthy
+                colorId: 2
+            }
+        }        
+    }
+
+    Logs { id: logs }
+
+    SplitView {
+        orientation: Qt.Vertical
+        SplitView.fillWidth: true
+
+        Rectangle {
+            SplitView.fillWidth: true
+            SplitView.fillHeight: true
+            color: Theme.palette.statusAppLayout.rightPanelBackgroundColor
+            clip: true
+
+            JoinCommunityView {
+                anchors.fill: parent
+                anchors.margins: 50
+
+                // General properties:
+                name: d.name
+                communityDesc: d.communityDesc
+                color: d.color
+                channelName: d.channelName
+                channelDesc: d.channelDesc
+                joinCommunity: d.joinCommunity
+
+                // Blur background properties:
+                membersCount: d.membersCount
+                image: d.image                
+                amISectionAdmin: d.amISectionAdmin
+                openCreateChat: false
+                communityItemsModel: d.communityItemsModel
+                chatDateTimeText: d.chatDateTimeText
+                listUsersText: d.listUsersText
+                messagesModel: d.messagesModel
+
+                // Permissions properties
+                requirementsMet: d.requirementsMet
+                isInvitationPending: d.isInvitationPending
+                isJoinRequestRejected: d.isJoinRequestRejected
+                requiresRequest: d.requiresRequest
+                communityHoldings: d.communityHoldings
+                viewOnlyHoldings: d.viewOnlyHoldings
+                viewAndPostHoldings: d.viewAndPostHoldings
+                moderateHoldings: d.moderateHoldings
+
+                onInfoButtonClicked: logs.logEvent("JoinCommunityView::onInfoButtonClicked()")
+                onAdHocChatButtonClicked: {
+                    logs.logEvent("JoinCommunityView::store.openCloseCreateChatView(): " + openCreateChat.toString())
+                    openCreateChat = !openCreateChat
+                }
+                onNotificationButtonClicked: logs.logEvent("JoinCommunityView::onNotificationButtonClicked()")
+                onRevealAddressClicked: logs.logEvent("JoinCommunityView::onRevealAddressClicked()")
+                onInvitationPendingClicked: logs.logEvent("JoinCommunityView::onInvitationPendingClicked()")
+            }
+        }
+
+        LogsAndControlsPanel {
+            id: logsAndControlsPanel
+
+            SplitView.minimumHeight: 100
+            SplitView.preferredHeight: 150
+
+            logsView.logText: logs.logText
+        }
+    }
+
+    Pane {
+        SplitView.minimumWidth: 300
+        SplitView.preferredWidth: 300
+
+        ScrollView {
+            anchors.fill: parent
+
+            ColumnLayout {
+                spacing: 16
+
+                // Blur info editor:
+                Label {
+                    Layout.fillWidth: true
+                    text: "BLUR INFO EDITOR"
+                    font.bold: true
+                    font.pixelSize: 18
+                }
+
+                CommunityInfoEditor {
+                    name: d.name
+                    membersCount: d.membersCount
+                    amISectionAdmin: d.amISectionAdmin
+                    color: d.color
+                    image: d.image
+                    colorVisible: true
+
+                    onNameChanged: d.name = name
+                    onMembersCountChanged: d.membersCount = membersCount
+                    onAmISectionAdminChanged: d.amISectionAdmin = amISectionAdmin
+                    onColorChanged: d.color = color
+                    onImageChanged: d.image = image
+                }
+
+                ColumnLayout {
+                    Label {
+                        Layout.fillWidth: true
+                        text: "Community items model:"
+                    }
+
+                    RadioButton {
+                           checked: true
+                           text: qsTr("Model 1")
+                           onCheckedChanged: if(checked) d.communityItemsModel =  d.model1
+                       }
+                       RadioButton {
+                           text: qsTr("Model 2")
+                            onCheckedChanged: if(checked) d.communityItemsModel = d.model2
+                       }
+                }
+
+                // Join community overlay editor:
+                Label {
+                    Layout.fillWidth: true
+                    text: "JOIN HOLDINGS EDITOR"
+                    font.bold: true
+                    font.pixelSize: 18
+                }
+
+                JoinCommunityPermissionsEditor {
+                    channelName: d.chanelName
+                    joinCommunity: d.joinCommunity
+                    requirementsMet: d.requirementsMet
+                    isInvitationPending: d.isInvitationPending
+                    isJoinRequestRejected: d.isJoinRequestRejected
+                    requiresRequest: d.requiresRequest
+
+                    onChannelNameChanged: d.channelName = channelName
+                    onJoinCommunityChanged: d.joinCommunity = joinCommunity
+                    onRequirementsMetChanged: d.requirementsMet = requirementsMet
+                    onIsInvitationPendingChanged: d.isInvitationPending = isInvitationPending
+                    onIsJoinRequestRejectedChanged: d.isJoinRequestRejected = isJoinRequestRejected
+                    onRequiresRequestChanged: d.requiresRequest = requiresRequest
+                    onCommunityHoldingsChanged: d.communityHoldings = communityHoldings
+                    onViewOnlyHoldingsChanged: d.viewOnlyHoldings = viewOnlyHoldings
+                    onViewAndPostHoldingsChanged: d.viewAndPostHoldings = viewAndPostHoldings
+                    onModerateHoldingsChanged: d.moderateHoldings = moderateHoldings
+                }
+            }
+        }
+    }
+}

--- a/storybook/pages/JoinPermissionsOverlayPanelPage.qml
+++ b/storybook/pages/JoinPermissionsOverlayPanelPage.qml
@@ -1,0 +1,167 @@
+import QtQuick 2.14
+import QtQuick.Controls 2.14
+import QtQuick.Layouts 1.14
+
+import StatusQ.Core.Theme 0.1
+import StatusQ.Core 0.1
+
+import Storybook 1.0
+import Models 1.0
+
+import AppLayouts.Chat.panels.communities 1.0
+
+
+import utils 1.0
+
+SplitView {
+
+    QtObject {
+        id: d
+
+        property string name: "Uniswap"
+        property string channelName: "#vip"
+        property bool joinCommunity: true // Otherwise, enter channel
+        property bool requirementsMet: true
+        property bool isInvitationPending: false
+        property bool isJoinRequestRejected: false
+        property bool requiresRequest: false
+        property var communityHoldings: PermissionsModel.shortPermissionsModel
+        property var viewOnlyHoldings: PermissionsModel.shortPermissionsModel
+        property var viewAndPostHoldings: PermissionsModel.shortPermissionsModel
+        property var moderateHoldings: PermissionsModel.shortPermissionsModel
+    }
+
+    Logs { id: logs }
+
+    SplitView {
+        orientation: Qt.Vertical
+        SplitView.fillWidth: true
+
+
+
+        Item {
+            SplitView.fillWidth: true
+            SplitView.fillHeight: true
+
+            Rectangle {
+                id: rect
+                width: widthSlider.value
+                height: heightSlider.value
+                anchors.centerIn: parent
+                color: Theme.palette.baseColor4
+
+                StatusScrollView {
+                    id: scroll
+                    anchors.fill: parent
+                    ScrollBar.vertical.policy: ScrollBar.AsNeeded
+                    ScrollBar.horizontal.policy: ScrollBar.AsNeeded
+                    contentHeight: content.height
+                    contentWidth: content.width
+                    padding: 0
+
+                    Item {
+                        id: content
+                        height: Math.max(overlayPannel.implicitHeight, rect.height)
+                        width: Math.max(overlayPannel.implicitWidth, rect.width)
+
+                        JoinPermissionsOverlayPanel {
+                            id: overlayPannel
+
+                            anchors.centerIn: parent
+                            joinCommunity: d.joinCommunity
+                            requirementsMet: d.requirementsMet
+                            isInvitationPending: d.isInvitationPending
+                            isJoinRequestRejected: d.isJoinRequestRejected
+                            requiresRequest: d.requiresRequest
+                            communityName: d.name
+                            communityHoldings: d.communityHoldings
+                            channelName: d.channelName
+                            viewOnlyHoldings: d.viewOnlyHoldings
+                            viewAndPostHoldings: d.viewAndPostHoldings
+                            moderateHoldings: d.moderateHoldings
+
+                            onRevealAddressClicked: logs.logEvent("JoinPermissionsOverlayPanel::onRevealAddressClicked()")
+                            onInvitationPendingClicked: logs.logEvent("JoinPermissionsOverlayPanel::onInvitationPendingClicked()")
+                        }
+                    }
+                }
+            }
+        }
+
+        LogsAndControlsPanel {
+            SplitView.minimumHeight: 100
+            SplitView.preferredHeight: 250
+            logsView.logText: logs.logText
+
+            ColumnLayout {
+                Row {
+                    Label {
+                        anchors.verticalCenter: parent.verticalCenter
+                        text: "Width:"
+                    }
+
+                    Slider {
+                        id: widthSlider
+                        value: 800
+                        from: 350
+                        to: 1000
+                    }
+                }
+
+                Row {
+                    Label {
+                        anchors.verticalCenter: parent.verticalCenter
+                        text: "Height:"
+                    }
+
+                    Slider {
+                        id: heightSlider
+                        value: 500
+                        from: 100
+                        to: 1000
+                    }
+                }
+            }
+        }
+    }
+
+    Pane {
+        SplitView.minimumWidth: 300
+        SplitView.preferredWidth: 300
+
+        ColumnLayout {
+            ColumnLayout {
+                Label {
+                    Layout.fillWidth: true
+                    text: "Name"
+                }
+                TextField {
+                    background: Rectangle { border.color: 'lightgrey' }
+                    Layout.preferredWidth: 200
+                    text: d.name
+                    onTextChanged: d.name = text
+                }
+            }
+
+            JoinCommunityPermissionsEditor {
+                channelName: d.chanelName
+                joinCommunity: d.joinCommunity
+                requirementsMet: d.requirementsMet
+                isInvitationPending: d.isInvitationPending
+                isJoinRequestRejected: d.isJoinRequestRejected
+                requiresRequest: d.requiresRequest
+
+                onChannelNameChanged: d.channelName = channelName
+                onJoinCommunityChanged: d.joinCommunity = joinCommunity
+                onRequirementsMetChanged: d.requirementsMet = requirementsMet
+                onIsInvitationPendingChanged: d.isInvitationPending = isInvitationPending
+                onIsJoinRequestRejectedChanged: d.isJoinRequestRejected = isJoinRequestRejected
+                onRequiresRequestChanged: d.requiresRequest = requiresRequest
+                onCommunityHoldingsChanged: d.communityHoldings = communityHoldings
+                onViewOnlyHoldingsChanged: d.viewOnlyHoldings = viewOnlyHoldings
+                onViewAndPostHoldingsChanged: d.viewAndPostHoldings = viewAndPostHoldings
+                onModerateHoldingsChanged: d.moderateHoldings = moderateHoldings
+            }
+        }
+    }
+}

--- a/storybook/pages/StatusMessagePage.qml
+++ b/storybook/pages/StatusMessagePage.qml
@@ -1,0 +1,103 @@
+import QtQuick 2.14
+import QtQuick.Controls 2.14
+import QtQuick.Layouts 1.14
+
+import StatusQ.Core 0.1
+import StatusQ.Components 0.1
+import StatusQ.Core.Theme 0.1
+
+import Storybook 1.0
+import Models 1.0
+
+SplitView {
+    id: root
+
+    Logs { id: logs }
+
+    QtObject {
+        id: d
+
+        property var messagesModel: ListModel {
+            ListElement {
+                timestamp: 1656937930
+                senderDisplayName: "simon"
+                profileImage: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADIAAAAyCAYAAAAeP4ixAAAAlklEQVR4nOzW0QmDQBAG4SSkl7SUQlJGCrElq9F3QdjjVhh/5nv3cFhY9vUIYQiNITSG0BhCExPynn1gWf9bx498P7/
+                              nzPcxEzGExhBdJGYihtAYQlO+tUZvqrPbqeudo5iJGEJjCE15a3VtodH3q2ImYgiNITTlTdG1nUZ5a92VITQxITFiJmIIjSE0htAYQrMHAAD//+wwFVpz+yqXAAAAAElFTkSuQmCC"
+                contentType: StatusMessage.ContentType.Text
+                message:  "Hello, this is awesome! Feels like decentralized Discord!"
+                isContact: true
+                trustIndicator: StatusContactVerificationIcons.TrustedType.Verified
+            }
+            ListElement {
+                timestamp: 1657937930
+                senderDisplayName: "Mark Cuban"
+                contentType: StatusMessage.ContentType.Text
+                message: "I know a lot of you really seem to get off or be validated by arguing with strangers online but please know it's a complete waste of your time and energy"
+                isContact: false
+                trustIndicator: StatusContactVerificationIcons.TrustedType.Untrustworthy
+            }
+        }
+        property var colorHash: ListModel {
+            ListElement { colorId: 13; segmentLength: 5 }
+            ListElement { colorId: 31; segmentLength: 5 }
+            ListElement { colorId: 10; segmentLength: 1 }
+            ListElement { colorId: 2; segmentLength: 5 }
+            ListElement { colorId: 26; segmentLength: 2 }
+            ListElement { colorId: 19; segmentLength: 4 }
+            ListElement { colorId: 28; segmentLength: 3 }
+        }
+    }
+
+    SplitView {
+        orientation: Qt.Vertical
+        SplitView.fillWidth: true
+
+
+        Rectangle {
+            SplitView.fillWidth: true
+            SplitView.fillHeight: true
+            color: Theme.palette.statusAppLayout.rightPanelBackgroundColor
+
+            ListView {
+                anchors.margins: 50
+                anchors.fill: parent
+                spacing: 16
+                model: d.messagesModel
+                delegate: StatusMessage {
+                    width: ListView.view.width
+                    timestamp: model.timestamp
+                    messageDetails: StatusMessageDetails {
+                        messageText: model.message
+                        contentType: model.contentType
+                        sender.displayName: model.senderDisplayName
+                        sender.isContact: model.isContact
+                        sender.trustIndicator: model.trustIndicator
+                        sender.profileImage: StatusProfileImageSettings {
+                            width: 40
+                            height: 40
+                            name: model.profileImage || ""
+                            colorId: 1
+                            colorHash: d.colorHash
+                        }
+                    }
+                    onSenderNameClicked: logs.logEvent("StatusMessage::onSenderNameClicked(): ")
+                    onProfilePictureClicked: logs.logEvent("StatusMessage::profilePictureClicked(): ")
+                }
+            }
+        }
+
+        LogsAndControlsPanel {
+            id: logsAndControlsPanel
+
+            SplitView.minimumHeight: 100
+            SplitView.preferredHeight: 200
+
+            logsView.logText: logs.logText
+        }
+    }
+
+    Pane {
+        SplitView.minimumWidth: 300
+        SplitView.preferredWidth: 300
+    }
+}

--- a/storybook/src/Models/ModelsData.qml
+++ b/storybook/src/Models/ModelsData.qml
@@ -39,6 +39,11 @@ QtObject {
         readonly property string inch: Style.png("tokens/CUSTOM-TOKEN")
         readonly property string aave: Style.png("tokens/CUSTOM-TOKEN")
         readonly property string amp: Style.png("tokens/CUSTOM-TOKEN")
+        readonly property string uni: Style.png("tokens/UNI")
+        readonly property string eth: Style.png("tokens/ETH")
+        readonly property string dai: Style.png("tokens/DAI")
+        readonly property string snt: Style.png("tokens/SNT")
+        readonly property string mana: Style.png("tokens/aMANA")
     }
 
     readonly property QtObject collectibles: QtObject {

--- a/storybook/src/Models/PermissionsModel.qml
+++ b/storybook/src/Models/PermissionsModel.qml
@@ -1,13 +1,16 @@
-import QtQuick 2.0
+pragma Singleton
+
+import QtQuick 2.14
 
 import Models 1.0
 import StatusQ.Core.Utils 0.1
 import AppLayouts.Chat.controls.community 1.0
 
-ListModel {
+QtObject {
     id: root
 
-    Component.onCompleted:
+    readonly property var permissionsModel: ListModel {
+        Component.onCompleted:
         append([
                    {
                        isPrivate: true,
@@ -30,81 +33,222 @@ ListModel {
                        channelsListModel: root.createChannelsModel2()
                    }
                ])
+    }
+
+    readonly property var shortPermissionsModel: ListModel {
+        Component.onCompleted:
+        append([
+                   {
+                       isPrivate: true,
+                       holdingsListModel: root.createHoldingsModel3(),
+                       permissionsObjectModel: {
+                           key: 1,
+                           text: "Become member",
+                           imageSource: "in-contacts"
+                       },
+                       channelsListModel: root.createChannelsModel1()
+                   }
+               ])
+    }
+
+    readonly property var longPermissionsModel: ListModel {
+        Component.onCompleted:
+        append([
+                   {
+                       isPrivate: true,
+                       holdingsListModel: root.createHoldingsModel4(),
+                       permissionsObjectModel: {
+                           key: 1,
+                           text: "Become member",
+                           imageSource: "in-contacts"
+                       },
+                       channelsListModel: root.createChannelsModel1()
+                   },
+                   {
+                       isPrivate: false,
+                       holdingsListModel: root.createHoldingsModel3(),
+                       permissionsObjectModel: {
+                           key: 2,
+                           text: "View and post",
+                           imageSource: "edit"
+                       },
+                       channelsListModel: root.createChannelsModel2()
+                   },
+                   {
+                       isPrivate: false,
+                       holdingsListModel: root.createHoldingsModel2(),
+                       permissionsObjectModel: {
+                           key: 2,
+                           text: "View and post",
+                           imageSource: "edit"
+                       },
+                       channelsListModel: root.createChannelsModel2()
+                   },
+                   {
+                       isPrivate: false,
+                       holdingsListModel: root.createHoldingsModel1(),
+                       permissionsObjectModel: {
+                           key: 2,
+                           text: "View and post",
+                           imageSource: "edit"
+                       },
+                       channelsListModel: root.createChannelsModel2()
+                   }
+               ])
+    }
 
     function createHoldingsModel1() {
         return [
-            {
-                operator: OperatorsUtils.Operators.None,
-                type: HoldingTypes.Type.Asset,
-                key: "SOCKS",
-                name: "SOCKS",
-                amount: 1.2,
-                imageSource: ModelsData.assets.socks
-            },
-            {
-                operator: OperatorsUtils.Operators.Or,
-                type: HoldingTypes.Type.Asset,
-                key: "ZRX",
-                name: "ZRX",
-                amount: 15,
-                imageSource: ModelsData.assets.zrx
-            },
-            {
-                operator: OperatorsUtils.Operators.And,
-                type: HoldingTypes.Type.Collectible,
-                key: "Furbeard",
-                name: "Furbeard",
-                amount: 12,
-                imageSource: ModelsData.collectibles.kitty1
-            }
-        ]
+                    {
+                        operator: OperatorsUtils.Operators.None,
+                        type: HoldingTypes.Type.Asset,
+                        key: "SOCKS",
+                        name: "SOCKS",
+                        amount: 1.2,
+                        imageSource: ModelsData.assets.socks,
+                        available: true
+                    },
+                    {
+                        operator: OperatorsUtils.Operators.Or,
+                        type: HoldingTypes.Type.Asset,
+                        key: "ZRX",
+                        name: "ZRX",
+                        amount: 15,
+                        imageSource: ModelsData.assets.zrx,
+                        available: false
+                    },
+                    {
+                        operator: OperatorsUtils.Operators.And,
+                        type: HoldingTypes.Type.Collectible,
+                        key: "Furbeard",
+                        name: "Furbeard",
+                        amount: 12,
+                        imageSource: ModelsData.collectibles.kitty1,
+                        available: true
+                    }
+                ]
     }
 
     function createHoldingsModel2() {
         return [
-            {
-                operator: OperatorsUtils.Operators.None,
-                type: HoldingTypes.Type.Collectible,
-                key: "Happy Meow",
-                name: "Happy Meow",
-                amount: 50.25,
-                imageSource: ModelsData.collectibles.kitty3
-            },
-            {
-                operator: OperatorsUtils.Operators.And,
-                type: HoldingTypes.Type.Collectible,
-                key: "AMP",
-                name: "AMP",
-                amount: 11,
-                imageSource: ModelsData.assets.amp
-            }
-        ]
+                    {
+                        operator: OperatorsUtils.Operators.None,
+                        type: HoldingTypes.Type.Collectible,
+                        key: "Happy Meow",
+                        name: "Happy Meow",
+                        amount: 50.25,
+                        imageSource: ModelsData.collectibles.kitty3,
+                        available: true
+                    },
+                    {
+                        operator: OperatorsUtils.Operators.And,
+                        type: HoldingTypes.Type.Collectible,
+                        key: "AMP",
+                        name: "AMP",
+                        amount: 11,
+                        imageSource: ModelsData.assets.amp,
+                        available: false
+                    }
+                ]
+    }
+
+    function createHoldingsModel3() {
+        return [
+                    {
+                        operator: OperatorsUtils.Operators.None,
+                        type: HoldingTypes.Type.Asset,
+                        key: "uni",
+                        imageSource: ModelsData.assets.uni,
+                        name: "UNI",
+                        amount: 15,
+                        available: true
+                    },
+                    {
+                        operator: OperatorsUtils.Operators.None,
+                        type: HoldingTypes.Type.Asset,
+                        key: "eth",
+                        imageSource: ModelsData.assets.eth,
+                        name: "ETH",
+                        amount: 1,
+                        available: false
+                    }
+                ]
+    }
+
+    function createHoldingsModel4() {
+        return [
+                    {
+                        operator: OperatorsUtils.Operators.None,
+                        type: HoldingTypes.Type.Asset,
+                        key: "uni",
+                        imageSource: ModelsData.assets.uni,
+                        name: "UNI",
+                        amount: 15,
+                        available: true
+                    },
+                    {
+                        operator: OperatorsUtils.Operators.None,
+                        type: HoldingTypes.Type.Asset,
+                        key: "eth",
+                        imageSource: ModelsData.assets.eth,
+                        name: "ETH",
+                        amount: 1,
+                        available: false
+                    },
+                    {
+                        operator: OperatorsUtils.Operators.None,
+                        type: HoldingTypes.Type.Asset,
+                        key: "snt",
+                        imageSource: ModelsData.assets.snt,
+                        name: "SNT",
+                        amount: 25000,
+                        available: true
+                    },
+                    {
+                        operator: OperatorsUtils.Operators.None,
+                        type: HoldingTypes.Type.Asset,
+                        key: "uni",
+                        imageSource: ModelsData.assets.dai,
+                        name: "DAI",
+                        amount: 100,
+                        available: true
+                    },
+                    {
+                        operator: OperatorsUtils.Operators.None,
+                        type: HoldingTypes.Type.Asset,
+                        key: "mana",
+                        imageSource: ModelsData.assets.mana,
+                        name: "MANA",
+                        amount: 2,
+                        available: true
+                    }
+                ]
     }
 
     function createChannelsModel1() {
         return [
-            {
-                key: "general",
-                text: "#general",
-                color: "lightgreen",
-                emoji: "👋"
-            },
-            {
-                key: "faq",
-                text: "#faq",
-                color: "lightblue",
-                emoji: "⚽"
-            }
-        ]
+                    {
+                        key: "general",
+                        text: "#general",
+                        color: "lightgreen",
+                        emoji: "👋"
+                    },
+                    {
+                        key: "faq",
+                        text: "#faq",
+                        color: "lightblue",
+                        emoji: "⚽"
+                    }
+                ]
     }
 
     function createChannelsModel2() {
         return [
-            {
-                key: "socks",
-                iconSource: ModelsData.icons.socks,
-                text: "Socks"
-            }
-        ]
+                    {
+                        key: "socks",
+                        iconSource: ModelsData.icons.socks,
+                        text: "Socks"
+                    }
+                ]
     }
 }

--- a/storybook/src/Models/qmldir
+++ b/storybook/src/Models/qmldir
@@ -1,9 +1,9 @@
 singleton ModelsData 1.0 ModelsData.qml
+singleton PermissionsModel 1.0 PermissionsModel.qml
 IconModel 1.0 IconModel.qml
 BannerModel 1.0 BannerModel.qml
 UsersModel 1.0 UsersModel.qml
 AssetsModel 1.0 AssetsModel.qml
 CollectiblesModel 1.0 CollectiblesModel.qml
 ChannelsModel 1.0 ChannelsModel.qml
-PermissionsModel 1.0 PermissionsModel.qml
 AssetsCollectiblesIconsModel 1.0 AssetsCollectiblesIconsModel.qml

--- a/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
@@ -226,7 +226,7 @@ Control {
                     spacing: 2
                     Layout.alignment: Qt.AlignTop
                     Layout.fillWidth: true
-                    Layout.leftMargin: profileImage.visible ? 0 : root.messageDetails.sender.profileImage.assetSettings.width + parent.spacing
+                    Layout.leftMargin: profileImage.active ? 0 : root.messageDetails.sender.profileImage.assetSettings.width + parent.spacing
 
                     StatusPinMessageDetails {
                         active: root.isPinned && !editMode

--- a/ui/app/AppLayouts/Chat/panels/communities/CommunityColumnHeaderPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/CommunityColumnHeaderPanel.qml
@@ -1,0 +1,59 @@
+import QtQuick 2.0
+import QtQuick.Controls 2.14
+import QtQuick.Layouts 1.14
+
+import StatusQ.Core 0.1
+import StatusQ.Core.Theme 0.1
+import StatusQ.Controls 0.1
+
+import utils 1.0
+
+Control {
+    id: root
+
+    property string name
+    property int membersCount
+    property url image
+    property color color
+    property bool amISectionAdmin
+    property bool openCreateChat
+
+    signal infoButtonClicked
+    signal adHocChatButtonClicked
+
+    padding: Style.current.halfPadding
+    rightPadding: Style.current.padding
+    topPadding: Style.current.smallPadding
+
+    contentItem: RowLayout {
+        StatusChatInfoButton {
+            objectName: "communityHeaderButton"
+            Layout.fillWidth: true
+            title: root.name
+            subTitle: qsTr("%n member(s)", "", root.membersCount)
+            asset.name: root.image
+            asset.color: root.color
+            asset.isImage: true
+            type: StatusChatInfoButton.Type.OneToOneChat
+            hoverEnabled: root.amISectionAdmin
+            onClicked: if(root.amISectionAdmin) root.infoButtonClicked()
+        }
+
+        StatusIconTabButton {
+            objectName: "startChatButton"
+            icon.name: "edit"
+            icon.color: Theme.palette.directColor1
+            Layout.alignment: Qt.AlignVCenter
+            checked: root.openCreateChat
+            highlighted: root.openCreateChat
+            onClicked: root.adHocChatButtonClicked()
+
+            StatusToolTip {
+                text: qsTr("Start chat")
+                visible: parent.hovered
+                orientation: StatusToolTip.Orientation.Bottom
+                y: parent.height + 12
+            }
+        }
+    }
+}

--- a/ui/app/AppLayouts/Chat/panels/communities/HoldingsListPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/HoldingsListPanel.qml
@@ -1,0 +1,96 @@
+import QtQuick 2.14
+import QtQuick.Controls 2.14
+import QtQuick.Layouts 1.14
+
+import StatusQ.Core 0.1
+import StatusQ.Core.Theme 0.1
+import StatusQ.Components 0.1
+import StatusQ.Controls 0.1
+
+import AppLayouts.Chat.helpers 1.0
+import AppLayouts.Chat.controls.community 1.0
+
+import SortFilterProxyModel 0.2
+
+import utils 1.0
+
+Control {
+    id: root
+
+    property var model
+    property string introText
+
+    QtObject {
+        id: d
+
+        // By design values:
+        readonly property int defaultHoldingsSpacing: 8
+
+        function holdingsTextFormat(name, amount) {
+            return CommunityPermissionsHelpers.setHoldingsTextFormat(HoldingTypes.Type.Asset, name, amount)
+        }
+    }
+
+    contentItem: ColumnLayout {
+        spacing: root.spacing
+
+        StatusBaseText {
+            Layout.fillWidth: true
+            horizontalAlignment: Text.AlignHCenter
+            wrapMode: Text.WordWrap
+            text: root.introText
+            textFormat: Text.StyledText
+        }
+
+        ColumnLayout {
+            Layout.alignment: Qt.AlignHCenter
+            spacing: d.defaultHoldingsSpacing
+
+            Repeater {
+                model: root.model
+
+                ColumnLayout {
+                    Layout.alignment: Qt.AlignHCenter
+                    spacing: d.defaultHoldingsSpacing
+
+                    RowLayout {
+                        spacing: 18 // by design
+
+                        Repeater {
+                            model: SortFilterProxyModel {
+                                sourceModel: holdingsListModel
+                                proxyRoles: ExpressionRole {
+                                    name: "text"
+                                    // Direct call for singleton function is not handled properly by SortFilterProxyModel that's why `holdingsTextFormat` is used instead.
+                                    expression: d.holdingsTextFormat(model.name, model.amount)
+                                }
+                            }
+
+                            StatusListItemTag {
+                                enabled: false
+                                leftPadding: 2
+                                title: text
+                                asset.name: model.imageSource
+                                asset.isImage: true
+                                asset.bgColor: "transparent"
+                                asset.height: 28
+                                asset.width: asset.height
+                                closeButtonVisible: false
+                                titleText.color: model.available ? Theme.palette.primaryColor1 : Theme.palette.dangerColor1
+                                bgColor: model.available ? Theme.palette.primaryColor2 :Theme.palette.dangerColor2
+                                titleText.font.pixelSize: 15
+                            }
+                        }
+                    }
+
+                    StatusBaseText {
+                        Layout.alignment: Qt.AlignHCenter
+                        text: qsTr("or")
+                        textFormat: Text.StyledText
+                        visible: (index !== root.model.count - 1)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/ui/app/AppLayouts/Chat/panels/communities/JoinPermissionsOverlayPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/JoinPermissionsOverlayPanel.qml
@@ -1,0 +1,115 @@
+import QtQuick 2.14
+import QtQuick.Controls 2.14
+import QtQuick.Layouts 1.14
+
+import StatusQ.Core 0.1
+import StatusQ.Core.Theme 0.1
+import StatusQ.Components 0.1
+import StatusQ.Controls 0.1
+
+import AppLayouts.Chat.helpers 1.0
+import AppLayouts.Chat.controls.community 1.0
+
+import SortFilterProxyModel 0.2
+
+
+Control {
+    id: root
+
+    property bool joinCommunity: true // Otherwise it means join channel action
+    property bool requirementsMet: false
+    property bool requiresRequest: false
+    property bool isInvitationPending: false
+    property bool isJoinRequestRejected: false
+    property string communityName
+    property var communityHoldings
+    property string channelName
+    property var viewOnlyHoldings
+    property var viewAndPostHoldings
+    property var moderateHoldings
+
+    signal revealAddressClicked
+    signal invitationPendingClicked
+
+    QtObject {
+        id: d
+
+        readonly property string communityRequirementsNotMetText: qsTr("Membership requirements not met")
+        readonly property string communityRevealAddressText: qsTr("Reveal your address to join")
+        readonly property string communityRevealAddressWithRequestText: qsTr("Reveal your address and request to join")
+        readonly property string communityMembershipRequestPendingText: qsTr("Membership Request Pending...")
+        readonly property string channelRequirementsNotMetText: qsTr("Channel requirements not met")
+        readonly property string channelRevealAddressText: qsTr("Reveal your address to enter")
+        readonly property string channelMembershipRequestPendingText: qsTr("Channel Membership Request Pending...")
+        readonly property string memberchipRequestRejectedText: qsTr("Membership Request Rejected")
+
+        function holdingsTextFormat(name, amount) {
+            return CommunityPermissionsHelpers.setHoldingsTextFormat(HoldingTypes.Type.Asset, name, amount)
+        }
+
+        function getInvitationPendingText() {
+            return root.joinCommunity ? d.communityMembershipRequestPendingText : d.channelMembershipRequestPendingText
+        }
+
+        function getRevealAddressText() {
+            return root.joinCommunity ? (root.requiresRequest ? d.communityRevealAddressWithRequestText : d.communityRevealAddressText) : d.channelRevealAddressText
+        }
+    }
+
+    padding: 35 // default by design
+    spacing: 32 // default by design
+    contentItem: ColumnLayout {
+        id: column
+        spacing: root.spacing
+
+        HoldingsListPanel {
+            Layout.fillWidth: true
+            spacing: root.spacing
+            visible: root.joinCommunity && root.communityHoldings
+            introText: qsTr("To join <b>%1</b> you need to prove that you hold").arg(root.communityName)
+            model: root.communityHoldings
+        }
+
+        HoldingsListPanel {
+            Layout.fillWidth: true
+            spacing: root.spacing
+            visible: !root.joinCommunity && !!root.viewOnlyHoldings
+            introText: qsTr("To only view the <b>%1</b> channel you need to hold").arg(root.channelName)
+            model: root.viewOnlyHoldings
+        }
+
+        HoldingsListPanel {
+            Layout.fillWidth: true
+            spacing: root.spacing
+            visible: !root.joinCommunity && !!root.viewAndPostHoldings
+            introText: qsTr("To view and post in the <b>%1</b> channel you need to hold").arg(root.channelName)
+            model: root.viewAndPostHoldings
+        }
+
+        HoldingsListPanel {
+            Layout.fillWidth: true
+            spacing: root.spacing
+            visible: !root.joinCommunity && !!root.moderateHoldings
+            introText: qsTr("To moderate in the <b>%1</b> channel you need to hold").arg(root.channelName)
+            model: root.moderateHoldings
+        }
+
+        StatusButton {
+            Layout.alignment: Qt.AlignHCenter
+            visible: !root.isJoinRequestRejected
+            text: root.isInvitationPending ? d.getInvitationPendingText() : d.getRevealAddressText()
+            font.pixelSize: 13
+            enabled: root.requirementsMet
+            onClicked: root.isInvitationPending ? root.invitationPendingClicked() : root.revealAddressClicked()
+        }
+
+        StatusBaseText {
+            Layout.alignment: Qt.AlignHCenter
+            visible: root.isJoinRequestRejected || !root.requirementsMet
+            text: root.isJoinRequestRejected ? d.memberchipRequestRejectedText :
+                                          (root.joinCommunity ? d.communityRequirementsNotMetText : d.channelRequirementsNotMetText)
+            color: Theme.palette.dangerColor1
+        }
+    }
+}
+

--- a/ui/app/AppLayouts/Chat/panels/communities/qmldir
+++ b/ui/app/AppLayouts/Chat/panels/communities/qmldir
@@ -4,3 +4,4 @@ CommunityProfilePopupInviteMessagePanel 1.0 CommunityProfilePopupInviteMessagePa
 PermissionQualificationPanel 1.0 PermissionQualificationPanel.qml
 PermissionConflictWarningPanel 1.0 PermissionConflictWarningPanel.qml
 CommunityColumnHeaderPanel 1.0 CommunityColumnHeaderPanel.qml
+JoinPermissionsOverlayPanel 1.0 JoinPermissionsOverlayPanel.qml

--- a/ui/app/AppLayouts/Chat/panels/communities/qmldir
+++ b/ui/app/AppLayouts/Chat/panels/communities/qmldir
@@ -3,3 +3,4 @@ CommunityProfilePopupInviteFriendsPanel 1.0 CommunityProfilePopupInviteFriendsPa
 CommunityProfilePopupInviteMessagePanel 1.0 CommunityProfilePopupInviteMessagePanel.qml
 PermissionQualificationPanel 1.0 PermissionQualificationPanel.qml
 PermissionConflictWarningPanel 1.0 PermissionConflictWarningPanel.qml
+CommunityColumnHeaderPanel 1.0 CommunityColumnHeaderPanel.qml

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -122,6 +122,13 @@ QtObject {
         return result
     }
 
+    function openCloseCreateChatView() {
+        if (root.openCreateChat) {
+             Global.closeCreateChatView()
+        } else {
+            Global.openCreateChatView()
+        }
+    }
 
     property var messageStore: MessageStore { }
 

--- a/ui/app/AppLayouts/Chat/views/CommunityColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/CommunityColumnView.qml
@@ -51,50 +51,20 @@ Item {
         }
     }
 
-    StatusChatInfoButton {
+    CommunityColumnHeaderPanel {
         id: communityHeader
-        objectName: "communityHeaderButton"
-        readonly property int nbMembers: communityData.members.count
-        title: communityData.name
-        subTitle: qsTr("%n member(s)", "", nbMembers)
-        asset.name: communityData.image
-        asset.color: communityData.color
-        asset.isImage: true
-        onClicked: if (communityData.amISectionAdmin) { root.infoButtonClicked() }
+
         anchors.top: parent.top
-        anchors.topMargin: Style.current.smallPadding
         anchors.left: parent.left
-        anchors.leftMargin: Style.current.halfPadding
-        anchors.right: (implicitWidth > parent.width - 50) ? adHocChatButton.left : undefined
-        anchors.rightMargin: Style.current.halfPadding
-        type: StatusChatInfoButton.Type.OneToOneChat
-        hoverEnabled: communityData.amISectionAdmin
-    }
-
-    StatusIconTabButton {
-        id: adHocChatButton
-        icon.name: "edit"
-        objectName: "startChatButton"
-        icon.color: Theme.palette.directColor1
-        anchors.verticalCenter: communityHeader.verticalCenter
         anchors.right: parent.right
-        anchors.rightMargin: Style.current.padding
-        checked: root.store.openCreateChat
-        highlighted: root.store.openCreateChat
-        onClicked: {
-            if (root.store.openCreateChat) {
-                Global.closeCreateChatView()
-            } else {
-                Global.openCreateChatView()
-            }
-        }
-
-        StatusToolTip {
-            text: qsTr("Start chat")
-            visible: parent.hovered
-            orientation: StatusToolTip.Orientation.Bottom
-            y: parent.height + 12
-        }
+        name: communityData.name
+        membersCount: communityData.members.count
+        image: communityData.image
+        color: communityData.color
+        amISectionAdmin: communityData.amISectionAdmin
+        openCreateChat: root.store.openCreateChat
+        onInfoButtonClicked: root.infoButtonClicked()
+        onAdHocChatButtonClicked: root.store.openCloseCreateChatView()
     }
 
     StatusButton {

--- a/ui/app/AppLayouts/Chat/views/communities/JoinCommunityView.qml
+++ b/ui/app/AppLayouts/Chat/views/communities/JoinCommunityView.qml
@@ -1,0 +1,286 @@
+import QtQuick 2.14
+import QtQuick.Controls 2.14
+import QtQuick.Layouts 1.14
+import QtGraphicalEffects 1.0
+
+import StatusQ.Core 0.1
+import StatusQ.Core.Theme 0.1
+import StatusQ.Components 0.1
+import StatusQ.Controls 0.1
+
+import AppLayouts.Chat.panels.communities 1.0
+import AppLayouts.Chat.views 1.0
+
+import StatusQ.Layout 0.1
+
+import utils 1.0
+
+StatusSectionLayout {
+    id: root
+
+    // General properties:
+    property bool amISectionAdmin: false
+    property bool openCreateChat: false
+    property string name
+    property string communityDesc
+    property color color
+    property string channelName
+    property string channelDesc
+    property bool joinCommunity: true // Otherwise it means join channel action
+
+    // Permission overlay view properties:
+    property bool requirementsMet: true
+    property bool isInvitationPending: false
+    property bool isJoinRequestRejected: false
+    property bool requiresRequest: false
+    property var communityHoldings
+    property var viewOnlyHoldings
+    property var viewAndPostHoldings
+    property var moderateHoldings
+
+    // Blur view properties:
+    property int membersCount
+    property url image
+    property var communityItemsModel
+    property string chatDateTimeText
+    property string listUsersText
+    property var messagesModel
+
+    signal infoButtonClicked
+    signal adHocChatButtonClicked
+    signal revealAddressClicked
+    signal invitationPendingClicked
+
+    QtObject {
+        id: d
+
+        readonly property int blurryRadius: 32
+    }
+
+    // Blur background:
+    headerContent: RowLayout {
+        anchors.fill: parent
+        spacing: 30
+
+        StatusChatInfoButton {
+            id: headerInfoButton
+            Layout.preferredHeight: parent.height
+            Layout.minimumWidth: 100
+            Layout.fillWidth: true
+            title: root.joinCommunity ? root.name : root.channelName
+            subTitle: root.joinCommunity ? root.communityDesc : root.channelDesc
+            asset.color: root.color
+            enabled: false
+            type: StatusChatInfoButton.Type.CommunityChat
+            layer.enabled: root.joinCommunity // Blured when joining community but not when entering channel
+            layer.effect: fastBlur
+        }
+
+        RowLayout {
+            Layout.preferredHeight: parent.height
+            spacing: 10
+            layer.enabled: true
+            layer.effect: fastBlur
+
+            StatusFlatRoundButton {
+                id: search
+                icon.name: "search"
+                type: StatusFlatRoundButton.Type.Secondary
+                enabled: false
+            }
+
+            StatusFlatRoundButton {
+                icon.name: "group-chat"
+                type: StatusFlatRoundButton.Type.Secondary
+                enabled: false
+            }
+
+            StatusFlatRoundButton {
+                icon.name: "more"
+                type: StatusFlatRoundButton.Type.Secondary
+                enabled: false
+            }
+        }
+    }
+
+    // Blur background:
+    leftPanel: ColumnLayout {
+        anchors.fill: parent
+
+        CommunityColumnHeaderPanel {
+            Layout.fillWidth: true
+            name: root.name
+            membersCount: root.membersCount
+            image: root.image
+            color: root.color
+            amISectionAdmin: root.amISectionAdmin
+            openCreateChat: root.openCreateChat
+            onInfoButtonClicked: if(root.amISectionAdmin) root.infoButtonClicked()
+            onAdHocChatButtonClicked: root.adHocChatButtonClicked()
+        }
+
+        ColumnLayout {
+            Layout.fillWidth: true
+            Layout.margins: Style.current.halfPadding
+            layer.enabled: true
+            layer.effect: fastBlur
+
+            Repeater {
+                model: root.communityItemsModel
+                delegate: StatusChatListItem {
+                    enabled: false
+                    name: model.name
+                    asset.color: root.color
+                    selected: model.selected
+                    type: StatusChatListItem.Type.CommunityChat
+                    notificationsCount: model.notificationsCount
+                    hasUnreadMessages: model.hasUnreadMessages
+                }
+            }
+        }
+
+        Item {
+            // filler
+            Layout.fillHeight: true
+            Layout.fillWidth: true
+        }
+    }
+
+    // Blur background + Permissions base information content:
+    centerPanel: ColumnLayout {
+        anchors.fill: parent
+        spacing: 0
+
+        // Blur background:
+        Item {
+            Layout.fillWidth: true
+            Layout.preferredHeight: Math.min(centralPanelData.implicitHeight, parent.height - overlayPannel.implicitHeight)
+
+            ColumnLayout {
+                id: centralPanelData
+                width: parent.width
+                layer.enabled: true
+                layer.effect: fastBlur
+
+                StatusBaseText {
+                    Layout.alignment: Qt.AlignHCenter
+                    Layout.topMargin: 30
+                    Layout.bottomMargin: 30
+                    text: root.chatDateTimeText
+                    font.pixelSize: 13
+                    color: Theme.palette.baseColor1
+                }
+
+                RowLayout {
+                    Layout.alignment: Qt.AlignHCenter
+
+                    StatusBaseText {
+                        text: root.listUsersText
+                        font.pixelSize: 13
+                    }
+
+                    StatusBaseText {
+                        text: qsTr("joined the channel")
+                        font.pixelSize: 13
+                        color: Theme.palette.baseColor1
+                    }
+                }
+
+                ListView {
+                    Layout.fillWidth: true
+                    Layout.preferredHeight: childrenRect.height + spacing
+                    Layout.topMargin: 16
+                    spacing: 16
+                    model: root.messagesModel
+                    delegate: StatusMessage {
+                        width: ListView.view.width
+                        timestamp: model.timestamp
+                        enabled: false
+                        messageDetails: StatusMessageDetails {
+                            messageText: model.message
+                            contentType: model.contentType
+                            sender.displayName: model.senderDisplayName
+                            sender.isContact: model.isContact
+                            sender.trustIndicator: model.trustIndicator
+                            sender.profileImage: StatusProfileImageSettings {
+                                width: 40
+                                height: 40
+                                name: model.profileImage || ""
+                                colorId: model.colorId
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // Permissions base information content:
+        Rectangle {
+            id: panelBase
+
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            color: Theme.palette.statusAppLayout.rightPanelBackgroundColor
+            gradient: Gradient {
+                GradientStop {
+                    position: 0.000
+                    color: "transparent"
+                }
+                GradientStop {
+                    position: 0.180
+                    color: panelBase.color
+                }
+            }
+
+            StatusScrollView {
+                id: scroll
+
+                anchors.fill: parent
+                ScrollBar.vertical.policy: ScrollBar.AsNeeded
+                ScrollBar.horizontal.policy: ScrollBar.AsNeeded
+                contentHeight: content.height
+                contentWidth: content.width
+                padding: 0
+
+                Item {
+                    id: content
+
+                    height: Math.max(overlayPannel.implicitHeight, panelBase.height)
+                    width: Math.max(overlayPannel.implicitWidth, panelBase.width)
+
+                    JoinPermissionsOverlayPanel {
+                        id: overlayPannel
+
+                        anchors.centerIn: parent
+                        Layout.maximumHeight: parent.height
+                        topPadding: 2 * bottomPadding
+                        joinCommunity: root.joinCommunity
+                        requirementsMet: root.requirementsMet
+                        isInvitationPending: root.isInvitationPending
+                        isJoinRequestRejected: root.isJoinRequestRejected
+                        requiresRequest: root.requiresRequest
+                        communityName: root.name
+                        communityHoldings: root.communityHoldings
+                        channelName: root.channelName
+                        viewOnlyHoldings: root.viewOnlyHoldings
+                        viewAndPostHoldings: root.viewAndPostHoldings
+                        moderateHoldings: root.moderateHoldings
+
+                        onRevealAddressClicked: root.revealAddressClicked()
+                        onInvitationPendingClicked: root.invitationPendingClicked()
+                    }
+                }
+            }
+        }
+    }
+    showRightPanel: false
+
+    Component {
+        id: fastBlur
+
+        FastBlur {
+            radius: d.blurryRadius
+            transparentBorder: true
+        }
+    }
+}

--- a/ui/app/AppLayouts/Chat/views/communities/qmldir
+++ b/ui/app/AppLayouts/Chat/views/communities/qmldir
@@ -1,3 +1,4 @@
 CommunityWelcomePermissionsView 1.0 CommunityWelcomePermissionsView.qml
 CommunityNewPermissionView 1.0 CommunityNewPermissionView.qml
 CommunityPermissionsView 1.0 CommunityPermissionsView.qml
+JoinCommunityView 1.0 JoinCommunityView.qml


### PR DESCRIPTION
Closes https://github.com/status-im/status-desktop/issues/9267

### What does the PR do
Separated in different commits:
- It creates `CommunityColumnHeaderPanel` component and updates `CommunityColumnView` to use it. Storybook new page added for that.
- It creates join permission overlay panel. Storybook new page added for that.
- It creates `JoinCommunityView` page containing blur custom background layout. It will allow to create different fake data that can be completely fake or we can get some information real from the specific community.  Storybook new page added for that.
- It adds `StatusMessage` component in storybook but just with 2 basic validations.

**NOTE:** `JoinCommunityView` is still not integrated in the app (waiting for backend). This pr only contemplates the UI part.

### Affected areas

- Left panel - **Community header** component
- New UI pages / components, not affecting the existing app behavior.

### Screenshot of functionality

1. `CommunityColumnHeaderPanel` component in storybook:

https://user-images.githubusercontent.com/97019400/216307790-f85cdac3-323e-42d1-8fb8-c9bddb1b5921.mov

2. `StatusMessage` component in storybook:

https://user-images.githubusercontent.com/97019400/216308897-7a8aece8-2baf-44c7-a578-2046d3f96794.mov

3. `JoinPermissionsOverlayPanel` component in storybook:

https://user-images.githubusercontent.com/97019400/216308218-72b1acc8-596d-4093-a18f-d9d6d39ecb0b.mov

4.  `JoinCommunityView` component in storybook:

https://user-images.githubusercontent.com/97019400/216309005-69d2062f-e4f1-425d-a946-7480f5305ccf.mov