### PR TITLE
ci: add missing dependencies for Qts libqxcb.so

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -40,11 +40,17 @@ RUN apt update -yq && apt install -yq software-properties-common \
  && add-apt-repository -y ppa:git-core/ppa \
  && add-apt-repository -y ppa:ubuntu-toolchain-r/test \
  && apt update -yq && apt full-upgrade -yq && apt install -yq --no-install-recommends --fix-missing  \
-    git openssh-client ca-certificates locales sudo curl build-essential pkg-config libgl1-mesa-dev libsm6 libice6 libxext6 libxrender1 \
-    libfontconfig1 libdbus-1-3 libz-dev fuse file libxkbcommon-dev libxkbcommon-x11-dev wget make libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev llvm \
-    libncurses5-dev libncursesw5-dev xz-utils tk-dev libgstreamer-plugins-base1.0-0 libpcsclite-dev cmake extra-cmake-modules s3cmd libpcre3-dev libnss3 libxcomposite1 libxtst6 jq \
-    gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly gstreamer1.0-libav gstreamer1.0-tools gstreamer1.0-alsa libpulse-mainloop-glib0 \
-    gstreamer1.0-pulseaudio libxrandr2 libxcursor1 libxi6 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-render-util0 libxcb-render0 libxcb-xinerama0 gnupg2 gcc-9 g++-9 \
+    gnupg2 openssh-client ca-certificates locales sudo jq curl wget fuse s3cmdfile llvm tk-dev xz-utils \
+    git make build-essential pkg-config cmake extra-cmake-modules gcc-9 g++-9 \
+    libgl1-mesa-dev libsm6 libice6 libfontconfig1 libdbus-1-3 libssl-dev libz-dev \
+    zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev \
+    libncurses5-dev libncursesw5-dev libpcsclite-dev  libpcre3-dev libnss3 \
+    gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly \
+    gstreamer1.0-libav gstreamer1.0-tools gstreamer1.0-alsa libpulse-mainloop-glib0 \
+    gstreamer1.0-pulseaudio libgstreamer-plugins-base1.0-0 \
+    libxext6 libxrender1 libxkbcommon-dev libxkbcommon-x11-dev libxcomposite1 libxtst6 \
+    libxrandr2 libxcursor1 libxi6 libxcb-randr0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 \
+    libxcb-render-util0 libxcb-shape0 libxcb-render0 libxcb-xinerama0 \
  &&  update-alternatives \
     --install /usr/bin/gcc gcc /usr/bin/gcc-9 100 \
     --slave /usr/bin/g++ g++ /usr/bin/g++-9 \

--- a/ci/Jenkinsfile.imports
+++ b/ci/Jenkinsfile.imports
@@ -4,7 +4,9 @@ library 'status-jenkins-lib@v1.6.3'
 def isPRBuild = utils.isPRBuild()
 
 pipeline {
-  agent { label 'linux' }
+  agent {
+    label 'linux && x86_64 && qt-5.15.2'
+  }
 
   parameters {
     choice(
@@ -37,7 +39,8 @@ pipeline {
     /* Disable colors in Nim compiler logs */
     NIMFLAGS = '--colors:off'
     /* Makefile assumes the compiler folder is included */
-    QTDIR = "/opt/qt/5.14.2/gcc_64"
+    QTDIR = "/opt/qt/5.15.2/gcc_64"
+    PATH = "${env.QTDIR}/bin:${env.PATH}"
     /* Include library in order to compile the project */
     LD_LIBRARY_PATH = "$QTDIR/lib:$WORKSPACE/vendor/status-go/build/bin:$WORKSPACE/vendor/status-keycard-go/build/libkeycard/"
   }

--- a/scripts/ubuntu_build_setup.sh
+++ b/scripts/ubuntu_build_setup.sh
@@ -37,7 +37,9 @@ function install_release_dependencies {
 function install_runtime_dependencies {
   echo "Install runtime dependencies"
   # xvfb is needed in order run squish test into a headless server 
-  apt install -yq libxcomposite-dev xvfb libxft-dev
+  apt install -yq libxcomposite-dev xvfb libxft-dev \
+      libxcb-shape0 libxcb-randr0 libxcb-render0 libxcb-icccm4 libxcb-image0 \
+      libxcb-keysyms1 libxcb-render-util0 libxcb-xinerama0
 }
 
 function install_qt {


### PR DESCRIPTION
Without the following dependencies:
```
libxcb-shape0 libxcb-randr0 libxcb-icccm4 libxcb-image0
libxcb-keysyms1 libxcb-render-util0 libxcb-render0 libxcb-xinerama0
```
The `libqxcb.so` library is unusable:
```
 > ldd -v /opt/qt/5.15.2/gcc_64/plugins/platforms/libqxcb.so
 > echo $?
1
 >
 > LD_TRACE_LOADED_OBJECTS=1 /lib64/ld-linux-x86-64.so.2 /opt/qt/5.15.2/gcc_64/plugins/platforms/libqxcb.so
zsh: segmentation fault (core dumped)  LD_TRACE_LOADED_OBJECTS=1 /lib64/ld-linux-x86-64.so.2
```
Related to:
* https://github.com/status-im/status-desktop/pull/9398
* https://github.com/status-im/infra-ci/issues/70

Also arranged the deps in `ci/Dockerfile` a bit to create some order.