### PR TITLE
fix(StatusMessage): don't render message text of image message

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusMessageReply.qml
+++ b/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusMessageReply.qml
@@ -94,7 +94,7 @@ Item {
                 Loader {
                     Layout.fillWidth: true
                     asynchronous: true
-                    active: !!replyDetails.messageText && replyDetails.contentType !== StatusMessage.ContentType.Sticker
+                    active: !!replyDetails.messageText && replyDetails.contentType !== StatusMessage.ContentType.Sticker && replyDetails.contentType !== StatusMessage.ContentType.Image
                     visible: active
                     sourceComponent: StatusTextMessage {
                         objectName: "StatusMessage_replyDetails_textMessage"


### PR DESCRIPTION
Image messages have a text attached to them that is typically rendered in app notifications (as the actual image won't fit in there).

That text was accidentally rendered as part of the reply.

This commit adds a check such that we don't render the message text for messages of contact type image.

Closes #9383


