### PR TITLE
fix: delete `appController` before `statusFoundation`

### DIFF
--- a/src/nim_status_client.nim
+++ b/src/nim_status_client.nim
@@ -150,8 +150,8 @@ proc mainProc() =
     networkAccessFactory.delete()
     dockShowAppEvent.delete()
     osThemeEvent.delete()
-    statusFoundation.delete()
     appController.delete()
+    statusFoundation.delete()
     singleInstance.delete()
     app.delete()
 


### PR DESCRIPTION
AppController executes status-go Logout function when it's being deleted, and that will stop all status-go services and kill pending mailserver requests. If StatusFoundation is deleted before the AppController, it's possible for some tasks to freeze the app on logout
