### PR TITLE
fix(wallet): some of SendModal's broken windows

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/StatusListItem.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusListItem.qml
@@ -326,15 +326,14 @@ Rectangle {
                 implicitHeight: visible ? 22 : 0
             }
 
-            ScrollView {
+            Flickable {
                 visible: tagsRepeater.count > 0
                 anchors.top: statusListItemTertiaryTitle.bottom
                 anchors.topMargin: visible ? 8 : 0
-                width: parent.width
-                height: visible ? contentHeight : 0
+                width: Math.min(statusListItemTagsSlotInline.width, parent.width)
+                height: visible ? statusListItemTagsSlotInline.height : 0
                 clip: true
-
-                ScrollBar.vertical.policy: ScrollBar.AlwaysOff
+                interactive: contentWidth > width
 
                 Row {
                     id: statusListItemTagsSlotInline

--- a/ui/imports/shared/controls/TokenBalancePerChainDelegate.qml
+++ b/ui/imports/shared/controls/TokenBalancePerChainDelegate.qml
@@ -25,7 +25,15 @@ StatusListItem {
     tagsModel: balances.count > 0 ? balances : []
     tagsDelegate: sensor.containsMouse ? expandedItem : compactItem
 
-    onClicked: tokenSelected({name, symbol, totalBalance, totalCurrencyBalance, balances, decimals})
+    onClicked: d.selectToken()
+
+    QtObject {
+        id: d
+
+        function selectToken() {
+            root.tokenSelected({name, symbol, totalBalance, totalCurrencyBalance, balances, decimals})
+        }
+    }
 
     Component {
         id: compactItem

--- a/ui/imports/shared/panels/StatusAssetSelector.qml
+++ b/ui/imports/shared/panels/StatusAssetSelector.qml
@@ -75,7 +75,7 @@ Item {
         control.popup.width: 492
         control.popup.height: 416
         control.popup.x: -root.x
-        
+
         popupContentItemObjectName: "assetSelectorList"
 
         model : SortFilterProxyModel {

--- a/ui/imports/shared/popups/SendModal.qml
+++ b/ui/imports/shared/popups/SendModal.qml
@@ -179,11 +179,13 @@ StatusDialog {
         clip: true
         ColumnLayout {
             id: group1
-            Layout.preferredWidth: parent.width
+            Layout.fillWidth: true
+            Layout.fillHeight: true
 
             Rectangle {
-                Layout.preferredWidth: parent.width
-                Layout.preferredHeight: assetAndAmmountSelector.height + Style.current.halfPadding
+                Layout.fillWidth: true
+                Layout.preferredHeight: assetAndAmountSelector.implicitHeight + Style.current.halfPadding
+
                 color: Theme.palette.baseColor3
                 z: 100
 
@@ -195,17 +197,17 @@ StatusDialog {
                     color: Theme.palette.dropShadow
                 }
 
-                Column {
-                    id: assetAndAmmountSelector
-                    anchors.left: parent.left
-                    anchors.right: parent.right
+                ColumnLayout {
+                    id: assetAndAmountSelector
+
+                    anchors.fill: parent
                     anchors.leftMargin: Style.current.xlPadding
                     anchors.rightMargin: Style.current.xlPadding
+
                     z: 1
                     spacing: 16
 
                     RowLayout {
-                        width: parent.width
                         spacing: 8
                         StatusBaseText {
                             id: modalHeader
@@ -262,7 +264,6 @@ StatusDialog {
                         }
                     }
                     RowLayout {
-                        width: parent.width
                         AmountToSend {
                             id: amountToSendInput
                             Layout.fillWidth:true
@@ -285,6 +286,10 @@ StatusDialog {
                             }
                             onReCalculateSuggestedRoute: popup.recalculateRoutesAndFees()
                         }
+
+                        // Horizontal spacer
+                        RowLayout {}
+
                         AmountToReceive {
                             id: amountToReceive
                             Layout.alignment: Qt.AlignRight
@@ -304,8 +309,9 @@ StatusDialog {
                     }
                     TokenListView {
                         id: tokenListRect
-                        anchors.left: parent.left
-                        anchors.right: parent.right
+
+                        Layout.fillWidth: true
+
                         visible: !assetSelector.selectedAsset
                         assets: popup.selectedAccount && popup.selectedAccount.assets ? popup.selectedAccount.assets : []
                         searchTokenSymbolByAddressFn: function (address) {

--- a/ui/imports/shared/views/TokenListView.qml
+++ b/ui/imports/shared/views/TokenListView.qml
@@ -1,4 +1,5 @@
 import QtQuick 2.13
+import QtQuick.Layouts 1.14
 
 import SortFilterProxyModel 0.2
 
@@ -11,7 +12,7 @@ import utils 1.0
 
 import "../controls"
 
-Rectangle {
+Item {
     id: root
 
     property var assets: []
@@ -29,43 +30,24 @@ Rectangle {
         })
     }
 
-    height: visible ? tokenList.height: 0
-    color: Theme.palette.indirectColor1
-    radius: 8
+    implicitWidth: contentLayout.implicitWidth
+    implicitHeight: contentLayout.implicitHeight
 
-    StatusListView {
-        id: tokenList
-        anchors.horizontalCenter: parent.horizontalCenter
-        anchors.top: parent.top
-        width: parent.width
-        height: Math.min(433, tokenList.contentHeight)
+    ColumnLayout {
+        id: contentLayout
 
-        model: SortFilterProxyModel {
-            sourceModel: root.assets
-            filters: [
-                ExpressionFilter {
-                    expression: {
-                        var tokenSymbolByAddress = searchTokenSymbolByAddressFn(d.searchString)
-                        return visibleForNetwork && (
-                            symbol.startsWith(d.searchString.toUpperCase()) || name.toUpperCase().startsWith(d.searchString.toUpperCase()) || (tokenSymbolByAddress!=="" && symbol.startsWith(tokenSymbolByAddress))
-                        )
-                    }
-                }
-            ]
-        }
-        delegate: TokenBalancePerChainDelegate {
-            width: ListView.view.width
-            getNetworkIcon: root.getNetworkIcon
-            onTokenSelected: root.tokenSelected(selectedToken)
-        }
-        headerPositioning: ListView.OverlayHeader
-        header: Rectangle {
-            width: parent.width
-            height: childrenRect.height
+        anchors.fill: parent
+
+        Rectangle {
+            Layout.fillWidth: true
+            Layout.preferredHeight: headerColumn.height
+
             color: Theme.palette.indirectColor1
             radius: 8
-            z: 2
+
             Column {
+                id: headerColumn
+
                 width: parent.width
                 Item {
                     height: 5
@@ -88,6 +70,33 @@ Rectangle {
                     width: parent.width
                     color: Theme.palette.baseColor3
                 }
+            }
+        }
+
+        StatusListView {
+            id: tokenList
+
+            Layout.fillWidth: true
+            Layout.preferredHeight: 396
+
+            model: SortFilterProxyModel {
+                sourceModel: root.assets
+                filters: [
+                    ExpressionFilter {
+                        expression: {
+                            var tokenSymbolByAddress = searchTokenSymbolByAddressFn(d.searchString)
+                            tokenList.positionViewAtBeginning()
+                            return visibleForNetwork && (
+                                symbol.startsWith(d.searchString.toUpperCase()) || name.toUpperCase().startsWith(d.searchString.toUpperCase()) || (tokenSymbolByAddress!=="" && symbol.startsWith(tokenSymbolByAddress))
+                            )
+                        }
+                    }
+                ]
+            }
+            delegate: TokenBalancePerChainDelegate {
+                width: ListView.view.width
+                getNetworkIcon: root.getNetworkIcon
+                onTokenSelected: root.tokenSelected(selectedToken)
             }
         }
     }


### PR DESCRIPTION
## Closes #9282

- fix high-level mixed and broken sizing due to missing a consistent layouting strategy
- fix the first selection. The floating header covered the first entry in the list. I tried to force `StatusListView` to account for the floating header but nothing worked
    - moved header outside the StatisListView (a good example of control
    want to be doing too many things)
- fixed background colour of the TokenListView
- fixes the impossibility of clicking on chain balance tag
  - fixes `StatusListItem`, which is a base on `StatusListItemTag`, from `TokenBalancePerChainDelegate`

### Affected areas

- Send Modal
- StatusListItem tags ignore mouse if not scrollable, not an expected behaviour

### StatusQ checklist

- [x] add documentation if necessary: updated StatusQ changes
- [x] update sandbox app - not necessary
- [x] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

| Scope | Dark | Light |
| -- | -- | -- |
| Tokens list | ![image](https://user-images.githubusercontent.com/47554641/216395700-9527c53f-67cc-4441-ac78-01774a118c46.png) | ![image](https://user-images.githubusercontent.com/47554641/216396003-e2f9aa95-d2e5-43db-9369-417ac0c4385f.png) |
| Waiting for tokens list |  | ![image](https://user-images.githubusercontent.com/47554641/216453036-58c89f2e-586d-4367-93e5-2c15660c6e97.png) |


- [ ] ~~I've checked the design, and this PR matches it~~
  - Only worked to fix the reported issues