### PR TITLE
fix(Communities): only render category toggle buttons if it has items

### DIFF
--- a/src/app/modules/main/chat_section/item.nim
+++ b/src/app/modules/main/chat_section/item.nim
@@ -30,6 +30,7 @@ type
     categoryName: string
     categoryPosition: int
     categoryOpened: bool
+    categoryHasItems: bool
     highlight: bool
     trustStatus: TrustStatus
     onlineStatus: OnlineStatus
@@ -58,7 +59,8 @@ proc initItem*(
     highlight: bool = false,
     categoryOpened: bool = true,
     trustStatus: TrustStatus = TrustStatus.Unknown,
-    onlineStatus = OnlineStatus.Inactive
+    onlineStatus = OnlineStatus.Inactive,
+    categoryHasItems = false
     ): Item =
   result = Item()
   result.id = id
@@ -86,6 +88,7 @@ proc initItem*(
   result.categoryOpened = categoryOpened
   result.trustStatus = trustStatus
   result.onlineStatus = onlineStatus
+  result.categoryHasItems = categoryHasItems
 
 proc `$`*(self: Item): string =
   result = fmt"""chat_section/Item(
@@ -112,6 +115,7 @@ proc `$`*(self: Item): string =
     categoryOpened: {$self.categoryOpened},
     trustStatus: {$self.trustStatus},
     onlineStatus: {$self.onlineStatus},
+    categoryHasItems: {$self.categoryHasItems},
     ]"""
 
 proc toJsonNode*(self: Item): JsonNode =
@@ -137,7 +141,8 @@ proc toJsonNode*(self: Item): JsonNode =
     "highlight": self.highlight,
     "categoryOpened": self.categoryOpened,
     "trustStatus": self.trustStatus,
-    "onlineStatus": self.onlineStatus
+    "onlineStatus": self.onlineStatus,
+    "categoryHasItems": self.categoryHasItems
   }
 
 proc delete*(self: Item) =
@@ -247,6 +252,12 @@ proc categoryPosition*(self: Item): int =
 
 proc `categoryPosition=`*(self: var Item, value: int) =
   self.categoryPosition = value
+
+proc categoryHasItems*(self: Item): bool =
+  self.categoryHasItems
+
+proc `categoryHasItems=`*(self: var Item, value: bool) =
+  self.categoryHasItems = value
 
 proc highlight*(self: Item): bool =
   self.highlight

--- a/src/app/modules/main/chat_section/model.nim
+++ b/src/app/modules/main/chat_section/model.nim
@@ -26,6 +26,7 @@ type
     CategoryId
     CategoryName
     CategoryPosition
+    CategoryHasChatItems
     Highlight
     CategoryOpened
     TrustStatus
@@ -93,6 +94,7 @@ QtObject:
       ModelRole.CategoryId.int:"categoryId",
       ModelRole.CategoryName.int:"categoryName",
       ModelRole.CategoryPosition.int:"categoryPosition",
+      ModelRole.CategoryHasChatItems.int:"categoryHasItems",
       ModelRole.Highlight.int:"highlight",
       ModelRole.CategoryOpened.int:"categoryOpened",
       ModelRole.TrustStatus.int:"trustStatus",
@@ -150,6 +152,8 @@ QtObject:
       result = newQVariant(item.categoryName)
     of ModelRole.CategoryPosition:
       result = newQVariant(item.categoryPosition)
+    of ModelRole.CategoryHasChatItems:
+      result = newQVariant(item.categoryHasItems)
     of ModelRole.Highlight:
       result = newQVariant(item.highlight)
     of ModelRole.CategoryOpened:
@@ -196,6 +200,12 @@ QtObject:
     if index == -1:
       return true # Default to true just in case
     return self.items[index].categoryOpened
+
+  proc getCategoryHasItemsForCategoryId*(self: Model, categoryId: string): bool {.slot.} =
+    let index = self.getItemIdxByCategory(categoryId)
+    if index == -1:
+      return true # Default to true just in case
+    return self.items[index].categoryHasItems
 
   proc changeCategoryOpened*(self: Model, categoryId: string, opened: bool) {.slot.} =
     for i in 0 ..< self.items.len:
@@ -339,6 +349,7 @@ QtObject:
       categoryId,
       newCategoryName: string,
       newCategoryPosition: int,
+      categoryHasItems: bool,
     ) =
     var indexesToDelete: seq[int] = @[]
     for i in 0 ..< self.items.len:
@@ -352,12 +363,14 @@ QtObject:
         item.categoryId = categoryId
         item.categoryName = newCategoryName
         item.categoryPosition = newCategoryPosition
+        item.categoryHasItems = categoryHasItems
         let modelIndex = self.createIndex(i, 0, nil)
         # Also signal on CategoryId because the section header only knows the categoryId
         self.dataChanged(modelIndex, modelIndex, @[
           ModelRole.CategoryId.int,
           ModelRole.CategoryName.int,
           ModelRole.CategoryPosition.int,
+          ModelRole.CategoryHasChatItems.int,
         ])
         break
       if hasCategory and not found:
@@ -370,11 +383,13 @@ QtObject:
         item.categoryId = ""
         item.categoryName = ""
         item.categoryPosition = -1
+        item.categoryHasItems = false
         let modelIndex = self.createIndex(i, 0, nil)
         self.dataChanged(modelIndex, modelIndex, @[
           ModelRole.CategoryId.int,
           ModelRole.CategoryName.int,
           ModelRole.CategoryPosition.int,
+          ModelRole.CategoryHasChatItems.int,
         ])
 
     # Go through indexesToDelete from the highest to the bottom, that way the indexes stay correct
@@ -460,6 +475,7 @@ QtObject:
         ModelRole.CategoryId.int,
         ModelRole.CategoryName.int,
         ModelRole.CategoryPosition.int,
+        ModelRole.CategoryHasChatItems.int,
       ])
     self.items[index].position = position
     let modelIndex = self.createIndex(index, 0, nil)

--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -145,9 +145,10 @@ proc addEmptyChatItemForCategory(self: Module, category: Category) =
         blocked = false,
         active = false,
         position = 99,
-        category.id,
-        category.name,
-        category.position,
+        categoryId = category.id,
+        categoryName = category.name,
+        categoryPosition = category.position,
+        categoryHasItems = false
       )
   self.view.chatsModel().appendItem(emptyChatItem)
 
@@ -565,17 +566,18 @@ method removeCommunityChat*(self: Module, chatId: string) =
 method onCommunityCategoryEdited*(self: Module, cat: Category, chats: seq[ChatDto]) =
   # Update chat items that have that category
   let chatIds = chats.filterIt(it.categoryId == cat.id).mapIt(it.id)
+  let hasChatItems = chatIds.len > 0
   self.view.chatsModel().updateItemsWithCategoryDetailById(
     chatIds,
     cat.id,
     cat.name,
     cat.position,
+    hasChatItems
   )
-  
-  if chatIds.len == 0:
+
+  if not hasChatItems:
     # New category with no chats associated, we created an empty chatItem with the category info
     self.addEmptyChatItemForCategory(cat)
-    return
 
 method onCommunityCategoryCreated*(self: Module, cat: Category, chats: seq[ChatDto]) =
   if (self.doesCatOrChatExist(cat.id)):

--- a/ui/StatusQ/src/StatusQ/Components/StatusChatList.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusChatList.qml
@@ -51,10 +51,12 @@ Item {
             }
             property string categoryName: ""
             property bool categoryOpened: true
+            property bool categoryHasItems: false
 
             function updateCategoryData(catId) {
                 categoryName = root.model.sourceModel.getCategoryNameForCategoryId(catId)
                 categoryOpened = root.model.sourceModel.getCategoryOpenedForCategoryId(catId)
+                categoryHasItems = root.model.sourceModel.getCategoryHasItemsForCategoryId(catId)
             }
 
             id: statusChatListCategoryItemLoader
@@ -84,6 +86,7 @@ Item {
                 propagateTitleClicks: true // title click is handled as a normal click (fallthru)
                 showAddButton: showCategoryActionButtons
                 showMenuButton: !!root.popupMenu
+                showToggleButton: categoryHasItems
                 // TODO uncomment this when drag and drop is reimplemented
                 highlighted: false//statusChatListCategory.dragged
                 onClicked: {

--- a/ui/StatusQ/src/StatusQ/Components/StatusChatListCategoryItem.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusChatListCategoryItem.qml
@@ -19,6 +19,7 @@ StatusListItem {
     property bool showActionButtons: false
     property bool showMenuButton: showActionButtons
     property bool showAddButton: showActionButtons
+    property bool showToggleButton: showActionButtons
     property bool hasUnreadMessages: false
     property alias addButton: addButton
     property alias menuButton: menuButton
@@ -61,6 +62,7 @@ StatusListItem {
             icon.name: "chevron-down"
             icon.width: 18
             icon.rotation: statusChatListCategoryItem.opened ? 0 : 270
+            visible: statusChatListCategoryItem.showToggleButton
             onClicked: statusChatListCategoryItem.toggleButtonClicked(mouse)
         }
     ]


### PR DESCRIPTION
This introduces a new `categoryHasItems` flag that is used to decide whether or not to render the toggle button the category item in the community view.

Categories with no chat items should not have that action button as there's nothing to toggle.

Closes #9300
