### PR TITLE
fix(Communities): ensure community chats exist in memory upon spectating

### DIFF
--- a/src/app_service/service/chat/service.nim
+++ b/src/app_service/service/chat/service.nim
@@ -129,6 +129,7 @@ QtObject:
 
   # Forward declarations
   proc updateOrAddChat*(self: Service, chat: ChatDto)
+  proc hydrateChats*(self: Service, data: JsonNode)
   proc updateOrAddChannelGroup*(self: Service, channelGroup: ChannelGroupDto)
 
   proc doConnect(self: Service) =
@@ -163,6 +164,14 @@ QtObject:
   proc getChannelGroups*(self: Service): seq[ChannelGroupDto] =
     return toSeq(self.channelGroups.values)
 
+  proc loadChats*(self: Service) =
+    try:
+      let response = status_chat.getChats()
+      self.hydrateChats(response.result)
+    except Exception as e:
+      let errDesription = e.msg
+      error "error: ", errDesription
+
   proc asyncGetChats*(self: Service) =
     let arg = AsyncGetChatsTaskArg(
       tptr: cast[ByteAddress](asyncGetChatsTask),
@@ -176,6 +185,26 @@ QtObject:
     if (y[1].channelGroupType == Personal): return 1
     return 0
 
+  proc hydrateChats(self: Service, data: JsonNode) =
+    var chats: seq[ChatDto] = @[]
+    for (sectionId, section) in data.pairs:
+      var channelGroup = section.toChannelGroupDto()
+      channelGroup.id = sectionId
+      self.channelGroups[sectionId] = channelGroup
+      for (chatId, chat) in section["chats"].pairs:
+        chats.add(chat.toChatDto())
+
+    # Make the personal channelGroup the first one
+    self.channelGroups.sort(sortPersonnalChatAsFirst[string, ChannelGroupDto], SortOrder.Ascending)
+
+    for chat in chats:
+      if chat.active and chat.chatType != chat_dto.ChatType.Unknown:
+        if chat.chatType == chat_dto.ChatType.Public:
+          # Deactivate old public chats
+          discard status_chat.deactivateChat(chat.id)
+        else:
+          self.chats[chat.id] = chat
+
   proc onAsyncGetChatsResponse*(self: Service, response: string) {.slot.} =
     try:
       let rpcResponseObj = response.parseJson
@@ -183,25 +212,7 @@ QtObject:
       if(rpcResponseObj["channelGroups"].kind == JNull):
         raise newException(RpcException, "No channel groups returned")
 
-      var chats: seq[ChatDto] = @[]
-      for (sectionId, section) in rpcResponseObj["channelGroups"].pairs:
-        var channelGroup = section.toChannelGroupDto()
-        channelGroup.id = sectionId
-        self.channelGroups[sectionId] = channelGroup
-        for (chatId, chat) in section["chats"].pairs:
-          chats.add(chat.toChatDto())
-
-      # Make the personal channelGroup the first one
-      self.channelGroups.sort(sortPersonnalChatAsFirst[string, ChannelGroupDto], SortOrder.Ascending)
-
-      for chat in chats:
-        if chat.active and chat.chatType != chat_dto.ChatType.Unknown:
-          if chat.chatType == chat_dto.ChatType.Public:
-            # Deactivate old public chats
-            discard status_chat.deactivateChat(chat.id)
-          else:
-            self.chats[chat.id] = chat
-
+      self.hydrateChats(rpcResponseObj["channelGroups"])
       self.events.emit(SIGNAL_CHATS_LOADED, ChannelGroupsArgs(channelGroups: self.getChannelGroups()))
     except Exception as e:
       let errDesription = e.msg

--- a/src/app_service/service/community/service.nim
+++ b/src/app_service/service/community/service.nim
@@ -688,6 +688,7 @@ QtObject:
 
       updatedCommunity.settings = communitySettings
       self.allCommunities[communityId] = updatedCommunity
+      self.chatService.loadChats()
 
       for k, chat in updatedCommunity.chats:
         let fullChatId = communityId & chat.id


### PR DESCRIPTION
When a community link is shared with a user and that user visits that community, it turns out that the chat objects for that community have not been created yet.

This results in chat data being malformed/non-existent until another message signal is processed that updates the chats in memory. This update can someimes occur earlier, sometimes later, which is why the issue isn't always reproducible.

This commit ensures we're loading chats from status-go again upon spectating, to ensure they exist in memory when we try to access the data in the UI.

Closes #8361


