### PR TITLE
fix(Chat): Make new messages marker update on messages coming out of order

### DIFF
--- a/src/app/modules/main/chat_section/chat_content/messages/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/module.nim
@@ -343,7 +343,7 @@ method messagesAdded*(self: Module, messages: seq[MessageDto]) =
     # https://github.com/status-im/status-desktop/issues/7632 will introduce deleteFroMe feature.
     # Now we just skip deleted messages
     if message.deleted or message.deletedForMe:
-      return
+      continue
 
     var item = initItem(
       message.id,
@@ -648,7 +648,7 @@ method getMessageById*(self: Module, messageId: string): message_item.Item =
         quotedMessageAuthorDetails = sender
       else:
         quotedMessageAuthorDetails = self.controller.getContactDetails(message.quotedMessage.`from`)
-        
+
     var transactionContract = message.transactionParameters.contract
     var transactionValue = message.transactionParameters.value
     var isCurrentUser = sender.isCurrentUser


### PR DESCRIPTION
Close #9218
Needs https://github.com/status-im/status-go/pull/3167

### What does the PR do

Refactor new messages marker flow to handle messages coming out of order

### Affected areas

Chat

### Screenshot of functionality (including design for comparison)


<img width="507" alt="Screenshot 2023-02-03 at 18 41 49" src="https://user-images.githubusercontent.com/2522130/216631351-4e12f85a-6a62-4753-b712-8ffbeec40875.png">

https://user-images.githubusercontent.com/2522130/216631032-23455aeb-7a08-452c-b6e7-53f8dd809377.mov
