### PR TITLE
refactor: make sure we only set active the active chat of active section

### DIFF
--- a/src/app/modules/main/chat_section/controller.nim
+++ b/src/app/modules/main/chat_section/controller.nim
@@ -23,6 +23,7 @@ type
     sectionId: string
     isCommunitySection: bool
     activeItemId: string
+    isCurrentSectionActive: bool
     events: EventEmitter
     settingsService: settings_service.Service
     nodeConfigurationService: node_configuration_service.Service
@@ -42,6 +43,7 @@ proc newController*(delegate: io_interface.AccessInterface, sectionId: string, i
   result.delegate = delegate
   result.sectionId = sectionId
   result.isCommunitySection = isCommunity
+  result.isCurrentSectionActive = false
   result.events = events
   result.settingsService = settingsService
   result.nodeConfigurationService = nodeConfigurationService
@@ -57,6 +59,12 @@ proc delete*(self: Controller) =
 
 proc getActiveChatId*(self: Controller): string =
   return self.activeItemId
+
+proc getIsCurrentSectionActive*(self: Controller): bool =
+  return self.isCurrentSectionActive
+
+proc setIsCurrentSectionActive*(self: Controller, active: bool) =
+  self.isCurrentSectionActive = active
 
 proc init*(self: Controller) =
   self.events.on(SIGNAL_SENDING_SUCCESS) do(e:Args):
@@ -282,6 +290,9 @@ proc getCommunityCategoryDetails*(self: Controller, communityId: string, categor
 
 proc setActiveItem*(self: Controller, itemId: string) =
   self.activeItemId = itemId
+  let isSectionActive = self.getIsCurrentSectionActive()
+  if not isSectionActive:
+    return
   if self.activeItemId != "":
     self.messageService.asyncLoadInitialMessagesForChat(self.activeItemId)
 

--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -348,9 +348,10 @@ method load*(
     self.usersModule.load()
 
   let activeChatId = self.controller.getActiveChatId()
+  let isCurrentSectionActive = self.controller.getIsCurrentSectionActive()
   for chatId, cModule in self.chatContentModules:
     cModule.load()
-    if chatId == activeChatId:
+    if isCurrentSectionActive and chatId == activeChatId:
       cModule.onMadeActive()
 
 proc checkIfModuleDidLoad(self: Module) =
@@ -445,8 +446,15 @@ method updateLastMessageTimestamp*(self: Module, chatId: string, lastMessageTime
 
 method onActiveSectionChange*(self: Module, sectionId: string) =
   if(sectionId != self.controller.getMySectionId()):
+    self.controller.setIsCurrentSectionActive(false)
     return
 
+  self.controller.setIsCurrentSectionActive(true)
+  let activeChatId = self.controller.getActiveChatId()
+  if activeChatId == "":
+    self.setFirstChannelAsActive()
+  else:
+    self.setActiveItem(activeChatId)
   self.delegate.onActiveChatChange(self.controller.getMySectionId(), self.controller.getActiveChatId())
 
 method chatsModel*(self: Module): chats_model.Model =


### PR DESCRIPTION
Fixes #9236 and #9438

Makes it so we activate only the active chat in the active section.

Before, one chat of each community would activate and trigger the message fetch, db get and `firstUnseenMessage` calls.