### PR TITLE
chore(StatusQ): move c++ files that are integral part of `StatusQ` from `DOtherSide` to `StatusQ` dir

### DIFF
--- a/storybook/CMakeLists.txt
+++ b/storybook/CMakeLists.txt
@@ -20,6 +20,8 @@ find_package(
   COMPONENTS Core Quick QuickControls2 Test QuickTest Qml
   REQUIRED)
 
+include (../ui/StatusQ/StatusQSources.cmake)
+
 file(GLOB_RECURSE CORE_QML_FILES "../ui/StatusQ/*.qml" "../ui/app/*.qml" "../ui/imports/*.qml")
 file(GLOB_RECURSE CORE_JS_FILES "../ui/StatusQ/*.js" "../ui/app/*.js")
 
@@ -29,33 +31,6 @@ file(GLOB_RECURSE STORYBOOK_QML_FILES "stubs/*.qml" "mocks/*.qml" "pages/*.qml"
 file(GLOB_RECURSE TEST_QML_FILES "qmlTests/*.qml")
 
 set(PROJECT_LIB "${PROJECT_NAME}Lib")
-
-set(STATUSQ_DIR ../ui/StatusQ)
-set(STATUSQ_HEADERS
-    ${STATUSQ_DIR}/include/StatusQ/statuswindow.h
-    ${STATUSQ_DIR}/include/StatusQ/typesregistration.h
-    ${STATUSQ_DIR}/include/StatusQ/QClipboardProxy.h
-    ${STATUSQ_DIR}/include/StatusQ/statussyntaxhighlighter.h
-    ${STATUSQ_DIR}/include/StatusQ/rxvalidator.h
-)
-
-set(STATUSQ_SOURCES
-    ${STATUSQ_DIR}/src/statuswindow.cpp
-    ${STATUSQ_DIR}/src/typesregistration.cpp
-    ${STATUSQ_DIR}/src/QClipboardProxy.cpp
-    ${STATUSQ_DIR}/src/statussyntaxhighlighter.cpp
-    ${STATUSQ_DIR}/src/rxvalidator.cpp
-)
-
-if(APPLE)
-    list(APPEND STATUSQ_SOURCES
-        ${STATUSQ_DIR}/src/statuswindow_osx.mm
-    )
-else()
-    list(APPEND STATUSQ_SOURCES
-        ${STATUSQ_DIR}/src/statuswindow_other.cpp
-    )
-endif()
 
 add_library(${PROJECT_LIB}
     cachecleaner.cpp cachecleaner.h

--- a/ui/StatusQ/StatusQSources.cmake
+++ b/ui/StatusQ/StatusQSources.cmake
@@ -1,0 +1,27 @@
+set(STATUSQ_DIR ${CMAKE_CURRENT_LIST_DIR})
+
+set(STATUSQ_HEADERS
+    ${STATUSQ_DIR}/include/StatusQ/statuswindow.h
+    ${STATUSQ_DIR}/include/StatusQ/typesregistration.h
+    ${STATUSQ_DIR}/include/StatusQ/QClipboardProxy.h
+    ${STATUSQ_DIR}/include/StatusQ/statussyntaxhighlighter.h
+    ${STATUSQ_DIR}/include/StatusQ/rxvalidator.h
+)
+
+set(STATUSQ_SOURCES
+    ${STATUSQ_DIR}/src/statuswindow.cpp
+    ${STATUSQ_DIR}/src/typesregistration.cpp
+    ${STATUSQ_DIR}/src/QClipboardProxy.cpp
+    ${STATUSQ_DIR}/src/statussyntaxhighlighter.cpp
+    ${STATUSQ_DIR}/src/rxvalidator.cpp
+)
+
+if(APPLE)
+    list(APPEND STATUSQ_SOURCES
+        ${STATUSQ_DIR}/src/statuswindow_osx.mm
+    )
+else()
+    list(APPEND STATUSQ_SOURCES
+        ${STATUSQ_DIR}/src/statuswindow_other.cpp
+    )
+endif()

--- a/ui/StatusQ/sandbox/CMakeLists.txt
+++ b/ui/StatusQ/sandbox/CMakeLists.txt
@@ -5,38 +5,13 @@ find_package(
   COMPONENTS Core Quick QuickControls2
   REQUIRED)
 
+include (../StatusQSources.cmake)
+
 file(GLOB_RECURSE QML_FILES "../*.qml" "../qmldir")
 file(GLOB_RECURSE JS_FILES "../*.js")
 
 set(HEADERS sandboxapp.h)
 set(SOURCES main.cpp sandboxapp.cpp)
-
-set(STATUSQ_DIR ..)
-set(STATUSQ_HEADERS
-    ${STATUSQ_DIR}/include/StatusQ/statuswindow.h
-    ${STATUSQ_DIR}/include/StatusQ/typesregistration.h
-    ${STATUSQ_DIR}/include/StatusQ/QClipboardProxy.h
-    ${STATUSQ_DIR}/include/StatusQ/statussyntaxhighlighter.h
-    ${STATUSQ_DIR}/include/StatusQ/rxvalidator.h
-)
-
-set(STATUSQ_SOURCES
-    ${STATUSQ_DIR}/src/statuswindow.cpp
-    ${STATUSQ_DIR}/src/typesregistration.cpp
-    ${STATUSQ_DIR}/src/QClipboardProxy.cpp
-    ${STATUSQ_DIR}/src/statussyntaxhighlighter.cpp
-    ${STATUSQ_DIR}/src/rxvalidator.cpp
-)
-
-if(APPLE)
-    list(APPEND STATUSQ_SOURCES
-        ${STATUSQ_DIR}/src/statuswindow_osx.mm
-    )
-else()
-    list(APPEND STATUSQ_SOURCES
-        ${STATUSQ_DIR}/src/statuswindow_other.cpp
-    )
-endif()
 
 set(QRC_FILES qml.qrc ../src/statusq.qrc ../src/assets.qrc)
 qt5_add_big_resources(QRC_COMPILED ${QRC_FILES})

--- a/vendor/DOtherSide/lib/CMakeLists.txt
+++ b/vendor/DOtherSide/lib/CMakeLists.txt
@@ -5,6 +5,8 @@ include(GNUInstallDirs)
 option(MONITORING "Tools for real-time inspection of the application." OFF)
 set(MONITORING_QML_ENTRY_POINT "" CACHE STRING "QML file intended to start the monitoring tool UI.")
 
+include(../../../ui/StatusQ/StatusQSources.cmake)
+
 # Macro for merging common code between static and shared
 macro(add_target name type)
     find_package(Qt5 COMPONENTS Core Qml Gui Quick QuickControls2 Widgets Network Multimedia REQUIRED)
@@ -16,33 +18,6 @@ macro(add_target name type)
     if(MONITORING)
         file(GLOB MONITORING_HEADERS include/DOtherSide/Status/Monitoring/*.h)
         file(GLOB MONITORING_SOURCES src/Status/Monitoring/*.cpp)
-    endif()
-
-    set(STATUSQ_DIR ../../../ui/StatusQ)
-    set(STATUSQ_HEADERS
-        ${STATUSQ_DIR}/include/StatusQ/statuswindow.h
-        ${STATUSQ_DIR}/include/StatusQ/typesregistration.h
-        ${STATUSQ_DIR}/include/StatusQ/QClipboardProxy.h
-        ${STATUSQ_DIR}/include/StatusQ/statussyntaxhighlighter.h
-        ${STATUSQ_DIR}/include/StatusQ/rxvalidator.h
-    )
-
-    set(STATUSQ_SOURCES
-        ${STATUSQ_DIR}/src/statuswindow.cpp
-        ${STATUSQ_DIR}/src/typesregistration.cpp
-        ${STATUSQ_DIR}/src/QClipboardProxy.cpp
-        ${STATUSQ_DIR}/src/statussyntaxhighlighter.cpp
-        ${STATUSQ_DIR}/src/rxvalidator.cpp
-    )
-
-    if(APPLE)
-        list(APPEND STATUSQ_SOURCES
-            ${STATUSQ_DIR}/src/statuswindow_osx.mm
-        )
-    else()
-        list(APPEND STATUSQ_SOURCES
-            ${STATUSQ_DIR}/src/statuswindow_other.cpp
-        )
     endif()
 
     if(APPLE)


### PR DESCRIPTION
### What does the PR do

This PR relocates components, that are integral part of `StatusQ` but so far were located under `DOtherSide` directory, to their proper location (`StatusQ` dir):

1. `StatusWindow` 
    - fixed duplication in `sandbox` app
3. `QClipboardProxy`
    - now `QClipboardProxy` works in `Storybook`
4. `StatusSyntaxHighlighter`
   - mock in Storybook no longer need, now Storybook uses the real component
5. `RxValidator`

In general, now there is possibility to define c++ components in StatusQ lib.

Note: The next step is to create full cmake config for StatusQ as a standalone library.

Closes: https://github.com/status-im/status-desktop/issues/9426

### Affected areas
`DOtherSide`, `StatusQ`
