### PR TITLE
test(wallet): fix user can manage and observe a watch only account

### DIFF
--- a/test/ui-test/testSuites/suite_wallet/dev/.env
+++ b/test/ui-test/testSuites/suite_wallet/dev/.env
@@ -1,0 +1,3 @@
+GANACHE_RPC_PORT=9545
+GANACHE_MNEMONIC='pelican chief sudden oval media rare swamp elephant lawsuit wheat knife initial'
+GANACHE_DB_FOLDER="./../../../../../test/ui-test/fixtures/ganache-dbs/goerli"

--- a/test/ui-test/testSuites/suite_wallet/dev/docker-compose.yml
+++ b/test/ui-test/testSuites/suite_wallet/dev/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '2.1'
+services:
+  uitestganache:
+    image: trufflesuite/ganache:v7.4.1
+    ports:
+      - 127.0.0.1:${GANACHE_RPC_PORT}:8545
+    volumes:
+      - ${GANACHE_DB_FOLDER}:/test_data/goerli-db
+    command: ["-m='${GANACHE_MNEMONIC}'", "-e=10", "--chain.chainId=5", "--database.dbPath=/test_data/goerli-db"]

--- a/test/ui-test/testSuites/suite_wallet/dev/readme.md
+++ b/test/ui-test/testSuites/suite_wallet/dev/readme.md
@@ -1,0 +1,21 @@
+# Developer helpers to run ganache dependent test cases locally
+
+Ganache is used in tests to avoid depending on RPC internet calls
+
+In CI ganache is started as a docker container directly from the [test suite](../../../../../ci/Jenkinsfile.e2e) (see stage `Containers`). In order to run locally you need to start ganache manually with the same options as Jenkins environment.
+
+## How to run e2e tests locally
+
+Optionally edit [`.env`](./.env) file to match your personal setup if the defaults don't work for you. The file is loaded by `desktop-compose` from the run step.
+
+Running
+
+- Compile to include the squish specific configuration like this `GANACHE_NETWORK_RPC_URL="http://localhost:9545" make -j10`
+  - This is required because `GANACHE_NETWORK_RPC_URL` is a `const` Nim variable and cannot be changed at runtime (`make clean` if binary is already built without the `GANACHE_NETWORK_RPC_URL`)
+  - Upon this step the production `NETWORKS` configuration in `status-desktop/src/app_service/common/network_constants.nim` is overridden with the second pair that includes the `GANACHE_NETWORK_RPC_URL` variable for all nodes along with specific token contract override for `SNT` and `STT`
+- Start ganache docker environment `docker-compose up uitestganache`
+- Run squish desired tests (if all is setup correctly, you should see RPC output calls in the `docker-compose up` output)
+
+**Beware** that the default `.env` will alter the in sources test data. Using the in-sources test data folder makes it is easy to add changes to the git index.
+
+- Solution: a copy of the `<status-desktop>/test/ui-test/fixtures/ganache-dbs/goerli` can be made outside sources and docker-compose redirected to use a personal `.env` file (using the `--env-file` option) pointing to the personal clone of the test data folder.

--- a/test/ui-test/testSuites/suite_wallet/tst_wallet/test.feature
+++ b/test/ui-test/testSuites/suite_wallet/tst_wallet/test.feature
@@ -17,7 +17,6 @@ Feature: Status Desktop Wallet
         Given the user opens wallet screen
         And the user clicks on the first account
 
-    @mayfail
 	Scenario: The user can manage and observe a watch only account
         When the user adds watch only account "0xea123F7beFF45E3C9fdF54B324c29DBdA14a639A" named "AccountWatch"
         Then the new account "AccountWatch" is added


### PR DESCRIPTION
## Closes #9091

Bumps status-go to include the fix for not fetching balance for overridden tokens: [PR #3168](https://github.com/status-im/status-go/pull/3168)

Add documentation on how to run wallet tests locally using ganache