### PR TITLE
chore: consolidate & refactor popup handling

### DIFF
--- a/storybook/pages/AboutViewPage.qml
+++ b/storybook/pages/AboutViewPage.qml
@@ -21,6 +21,8 @@ SplitView {
             contentWidth: parent.width
 
             store: QtObject {
+                readonly property bool isProduction: false
+
                 function checkForUpdates() {
                     logs.logEvent("store::checkForUpdates")
                 }

--- a/storybook/pages/CommunitiesPortalLayoutPage.qml
+++ b/storybook/pages/CommunitiesPortalLayoutPage.qml
@@ -10,9 +10,16 @@ import Storybook 1.0
 import Models 1.0
 
 import utils 1.0
+import mainui 1.0
 
 SplitView {
+    id: root
     Logs { id: logs }
+
+    Popups {
+        popupParent: root
+        rootStore: QtObject {}
+    }
 
     SplitView {
         orientation: Qt.Vertical
@@ -38,16 +45,6 @@ SplitView {
                 function navigateToCommunity() {
                     logs.logEvent("CommunitiesStore::navigateToCommunity", ["communityId"], arguments)
                 }
-            }
-
-            // TODO: onCompleted handler and localAccountSensitiveSettings are here to allow opening
-            // "Import Community" and "Create New Community" popups. However those popups shouldn't
-            // be tightly coupled with `CommunitiesPortalLayout` so it should be refactored in the next step.
-            // Pressing buttons "Import using key" and "Create new community" should only request for opening
-            // dialogs, and in Storybook it should be logged in the same way as calls to stores.
-            // Mentioned popups should have their own pages in the Storybook.
-            Component.onCompleted: {
-                Global.appMain = this
             }
 
             QtObject {

--- a/storybook/pages/ProfileDialogViewPage.qml
+++ b/storybook/pages/ProfileDialogViewPage.qml
@@ -6,6 +6,9 @@ import Storybook 1.0
 
 import utils 1.0
 import shared.views 1.0
+import mainui 1.0
+
+import StatusQ 0.1
 
 SplitView {
     id: root
@@ -91,6 +94,11 @@ SplitView {
 
     Logs { id: logs }
 
+    Popups {
+        popupParent: root
+        rootStore: QtObject {}
+    }
+
     SplitView {
         orientation: Qt.Vertical
         SplitView.fillWidth: true
@@ -113,10 +121,6 @@ SplitView {
                         implicitWidth: 640
 
                         publicKey: switchOwnProfile.checked ? "0xdeadbeef" : "0xrandomguy"
-
-                        Component.onCompleted: {
-                            Global.appMain = root // FIXME this is here for the popups to work
-                        }
 
                         profileStore: QtObject {
                             readonly property string pubkey: "0xdeadbeef"
@@ -286,7 +290,11 @@ SplitView {
                     TextField {
                         Layout.fillWidth: true
                         id: bio
-                        text: "Hello from MockMainModule, I am a mock user and this is my bio."
+                        text: "Hi, I am Alex. I'm an indie developer who mainly works on web products.
+
+I worked for several different companies and created a couple of my own products from scratch. Currently building Telescope and Prepacked.
+
+Say hi, or find me on Twitter, GitHub, or Mastodon."
                     }
                 }
             }

--- a/test/ui-test/testSuites/suite_settings/tst_userIdentity/test.feature
+++ b/test/ui-test/testSuites/suite_settings/tst_userIdentity/test.feature
@@ -9,8 +9,6 @@ Feature: User Identity
         And the user signs up with username "tester123" and password "TesTEr16843/!@00"
         And the user lands on the signed in app
 
-    @mayfail
-    # FIXME test is broken on step `the user's social links are empty`. Issue #9499
     Scenario Outline: The user sets display name, bio and social links
         Given the user opens app settings screen
         And the user opens the profile settings

--- a/ui/StatusQ/src/StatusQ/Controls/Validators/StatusUrlValidator.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/Validators/StatusUrlValidator.qml
@@ -2,7 +2,6 @@ import StatusQ.Core.Utils 0.1
 import StatusQ.Controls 0.1
 
 StatusValidator {
-
     name: "url"
 
     errorMessage: qsTr("Please enter a valid URL")
@@ -11,5 +10,3 @@ StatusValidator {
         return Utils.isURL(value);
     }
 }
-
-

--- a/ui/StatusQ/src/StatusQ/Controls/Validators/StatusValidator.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/Validators/StatusValidator.qml
@@ -1,9 +1,6 @@
-import QtQuick 2.13
-import StatusQ.Controls 0.1
+import QtQuick 2.14
 
 QtObject {
-    id: statusValidator
-
     property string name: ""
     property string errorMessage: qsTr("invalid input")
     property var validatorObj

--- a/ui/StatusQ/src/typesregistration.cpp
+++ b/ui/StatusQ/src/typesregistration.cpp
@@ -3,6 +3,7 @@
 #include "StatusQ/QClipboardProxy.h"
 #include "StatusQ/statussyntaxhighlighter.h"
 #include "StatusQ/statuswindow.h"
+#include "StatusQ/rxvalidator.h"
 
 #include <QQmlEngine>
 
@@ -12,4 +13,5 @@ void registerStatusQTypes()
     qmlRegisterSingletonType<QClipboardProxy>("StatusQ", 0 , 1, "QClipboardProxy",
                                               &QClipboardProxy::qmlInstance);
     qmlRegisterType<StatusSyntaxHighlighter>("StatusQ", 0 , 1, "StatusSyntaxHighlighter");
+    qmlRegisterType<RXValidator>("StatusQ", 0 , 1, "RXValidator");
 }

--- a/ui/app/AppLayouts/Browser/popups/AddFavoriteModal.qml
+++ b/ui/app/AppLayouts/Browser/popups/AddFavoriteModal.qml
@@ -79,8 +79,6 @@ ModalPopup {
             id: urlInput
             anchors.left: parent.left
             anchors.right: parent.right
-            leftPadding: 0
-            rightPadding: 0
             label: qsTr("URL")
             input.text: ogUrl
             placeholderText: qsTr("Paste URL")

--- a/ui/app/AppLayouts/Chat/ChatLayout.qml
+++ b/ui/app/AppLayouts/Chat/ChatLayout.qml
@@ -61,16 +61,12 @@ StackLayout {
             hasAddedContacts: root.contactsStore.myContactsModel.count > 0
             chatCommunitySectionModule: root.rootStore.chatCommunitySectionModule
             community: root.rootStore.mainModuleInst ? root.rootStore.mainModuleInst.activeSection
-                                                       || {} : {}
+                                                       || ({}) : ({})
 
-        onBackToCommunityClicked: root.currentIndex = 0
+            onBackToCommunityClicked: root.currentIndex = 0
 
-        // TODO: remove me when migration to new settings is done
-        onOpenLegacyPopupClicked: Global.openPopup(Global.communityProfilePopup, {
-                                                       "store": root.rootStore,
-                                                       "community": community,
-                                                       "communitySectionModule": chatCommunitySectionModule
-                                                   })
+            // TODO: remove me when migration to new settings is done
+            onOpenLegacyPopupClicked: Global.openCommunityProfilePopupRequested(root.rootStore, community, chatCommunitySectionModule)
         }
     }
 }

--- a/ui/app/AppLayouts/Chat/popups/ChatCommandModal.qml
+++ b/ui/app/AppLayouts/Chat/popups/ChatCommandModal.qml
@@ -1,7 +1,6 @@
 import QtQuick 2.13
 import QtQuick.Controls 2.13
 import QtQuick.Layouts 1.13
-import QtQuick.Dialogs 1.3
 
 import utils 1.0
 import shared.controls 1.0
@@ -18,8 +17,8 @@ StatusModal {
     property var store
     property var contactsStore
 
-    property string commandTitle: "Send"
-    property string finalButtonLabel: "Request address"
+    property string commandTitle: qsTr("Send")
+    property string finalButtonLabel: qsTr("Request address")
     property var sendChatCommand: function () {}
     property bool isRequested: false
 

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -37,7 +37,7 @@ QtObject {
     // Contact requests related part
     property var contactRequestsModel: chatCommunitySectionModule.contactRequestsModel
 
-    property var loadingHistoryMessagesInProgress: chatCommunitySectionModule.loadingHistoryMessagesInProgress
+    property bool loadingHistoryMessagesInProgress: chatCommunitySectionModule.loadingHistoryMessagesInProgress
 
     property var advancedModule: profileSectionModule.advancedModule
 

--- a/ui/app/AppLayouts/Chat/views/ChatContentView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatContentView.qml
@@ -99,12 +99,7 @@ ColumnLayout {
                 console.warn("error on open pinned messages limit reached from message context menu - chat content module is not set")
                 return
             }
-            Global.openPopup(Global.pinnedMessagesPopup, {
-                                 store: rootStore,
-                                 messageStore: messageStore,
-                                 pinnedMessagesModel: chatContentModule.pinnedMessagesModel,
-                                 messageToPin: messageId
-                             })
+            Global.openPinnedMessagesPopupRequested(rootStore, messageStore, chatContentModule.pinnedMessagesModel, messageId)
         }
 
         onToggleReaction: {
@@ -243,8 +238,7 @@ ColumnLayout {
                                                   chatInput.fileUrlsAndSources
                                                   ))
                     {
-                        Global.sendMessageSound.stop();
-                        Qt.callLater(Global.sendMessageSound.play);
+                        Global.playSendMessageSound()
 
                         chatInput.textInput.clear();
                         chatInput.textInput.textFormat = TextEdit.PlainText;

--- a/ui/app/AppLayouts/Chat/views/ChatHeaderContentView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatHeaderContentView.qml
@@ -309,12 +309,7 @@ Item {
                     console.warn("error on open pinned messages - chat content module is not set")
                     return
                 }
-                Global.openPopup(Global.pinnedMessagesPopup, {
-                                     store: rootStore,
-                                     messageStore: messageStore,
-                                     pinnedMessagesModel: chatContentModule.pinnedMessagesModel,
-                                     messageToPin: ""
-                                 })
+                Global.openPinnedMessagesPopupRequested(rootStore, messageStore, chatContentModule.pinnedMessagesModel, "")
             }
             onUnmute: {
                 if(!chatContentModule) {

--- a/ui/app/AppLayouts/Profile/popups/SocialLinksModal.qml
+++ b/ui/app/AppLayouts/Profile/popups/SocialLinksModal.qml
@@ -66,6 +66,7 @@ StatusDialog {
     StatusScrollView {
         id: scrollView
 
+        implicitHeight: contentHeight + topPadding + bottomPadding
         anchors.fill: parent
         padding: 0
 

--- a/ui/app/AppLayouts/Profile/stores/AdvancedStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/AdvancedStore.qml
@@ -13,7 +13,6 @@ QtObject {
     property bool isTelemetryEnabled: advancedModule? advancedModule.isTelemetryEnabled : false
     property bool isAutoMessageEnabled: advancedModule? advancedModule.isAutoMessageEnabled : false
     property bool isDebugEnabled: advancedModule? advancedModule.isDebugEnabled : false
-    property bool isCommunityHistoryArchiveSupportEnabled: advancedModule? advancedModule.isCommunityHistoryArchiveSupportEnabled : false
     property bool isWakuV2StoreEnabled: advancedModule ? advancedModule.isWakuV2StoreEnabled : false
 
     property var customNetworksModel: advancedModule? advancedModule.customNetworksModel : []

--- a/ui/app/AppLayouts/Profile/views/NotificationsView.qml
+++ b/ui/app/AppLayouts/Profile/views/NotificationsView.qml
@@ -471,8 +471,7 @@ SettingsContentBase {
                     value = appSettings.volume
                     volumeSlider.valueChanged.connect(() => {
                                                           // play a sound preview, but not on startup
-                                                          Global.notificationSound.stop()
-                                                          Global.notificationSound.play()
+                                                          Global.playNotificationSound()
                                                       });
                 }
             }

--- a/ui/app/mainui/qmldir
+++ b/ui/app/mainui/qmldir
@@ -1,2 +1,3 @@
 AppMain 1.0 AppMain.qml
 SplashScreen 1.0 SplashScreen.qml
+Popups 1.0 Popups.qml

--- a/ui/imports/shared/popups/ImageCropWorkflow.qml
+++ b/ui/imports/shared/popups/ImageCropWorkflow.qml
@@ -23,6 +23,7 @@ Item {
     property bool roundedImage: true
 
     signal imageCropped(var image, var cropRect)
+    signal done()
 
     function chooseImageToCrop() {
         fileDialog.open()
@@ -87,6 +88,7 @@ Item {
                 }
             }
         ]
+        onClosed: root.done()
     } // StatusModal
 } // Item
 

--- a/ui/imports/shared/popups/NicknamePopup.qml
+++ b/ui/imports/shared/popups/NicknamePopup.qml
@@ -1,5 +1,4 @@
-import QtQuick 2.13
-import QtQuick.Controls 2.13
+import QtQuick 2.14
 
 import utils 1.0
 import shared.controls 1.0
@@ -61,11 +60,9 @@ StatusModal {
                 charLimit: maxNicknameLength
                 validationMode: StatusInput.ValidationMode.IgnoreInvalidInput
                 validators: [
-                    StatusRegularExpressionValidator {
+                    StatusValidator {
                         validatorObj: RXValidator { regularExpression: /^[\w\d_ -]*$/u }
-                        validate: function (value) {
-                            return validatorObj.test(value)
-                        }
+                        validate: (value) => validatorObj.test(value)
                     }
                 ]
                 Keys.onReleased: {

--- a/ui/imports/shared/popups/keycard/helpers/KeyPairUnknownItem.qml
+++ b/ui/imports/shared/popups/keycard/helpers/KeyPairUnknownItem.qml
@@ -129,12 +129,10 @@ Rectangle {
                     StatusBaseText {
                         Layout.alignment: Qt.AlignVCenter
                         text: {
-                            if (Global.appMain) {
-                                return "%1%2".arg(SharedStore.RootStore.currencyStore.currentCurrencySymbol)
-                                .arg(Utils.toLocaleString(parseFloat(model.account.balance.amount).toFixed(2), appSettings.locale, {"model.account.currency": true}))
-                            }
-                            // without language/model refactor no way to read currency symbol or `appSettings.locale` before user logs in
-                            return "$%1".arg(Utils.toLocaleString(parseFloat(model.account.balance.amount).toFixed(2), localAppSettings.language, {"model.account.currency": true}))
+                            return LocaleUtils.currencyAmountToLocaleString({
+                                        amount: parseFloat(model.account.balance.amount),
+                                        symbol: SharedStore.RootStore.currencyStore.currentCurrencySymbol,
+                                        displayDecimals: 2})
                         }
                         wrapMode: Text.WordWrap
                         font.pixelSize: Constants.keycard.general.fontSize2

--- a/ui/imports/shared/popups/keycard/states/ManageAccounts.qml
+++ b/ui/imports/shared/popups/keycard/states/ManageAccounts.qml
@@ -161,12 +161,10 @@ Item {
                 ColumnLayout {
                     StatusBaseText {
                         text: {
-                            if (Global.appMain) {
-                                return "Balance: %1%2".arg(SharedStore.RootStore.currencyStore.currentCurrencySymbol)
-                                .arg(Utils.toLocaleString(root.sharedKeycardModule.keyPairHelper.observedAccount.balance.toFixed(2), appSettings.locale, {"model.account.currency": true}))
-                            }
-                            // without language/model refactor no way to read currency symbol or `appSettings.locale` before user logs in
-                            return "Balance: $%1".arg(Utils.toLocaleString(root.sharedKeycardModule.keyPairHelper.observedAccount.balance.toFixed(2), localAppSettings.language, {"model.account.currency": true}))
+                            return qsTr("Balance: %1").arg(LocaleUtils.currencyAmountToLocaleString({
+                                        amount: parseFloat(root.sharedKeycardModule.keyPairHelper.observedAccount.balance),
+                                        symbol: SharedStore.RootStore.currencyStore.currentCurrencySymbol,
+                                        displayDecimals: 2}))
                         }
                         wrapMode: Text.WordWrap
                         font.pixelSize: Constants.keycard.general.fontSize2

--- a/ui/imports/shared/stores/qmldir
+++ b/ui/imports/shared/stores/qmldir
@@ -4,3 +4,4 @@ TransactionStore 1.0 TransactionStore.qml
 BIP39_en 1.0 BIP39_en.qml
 TokenBalanceHistoryStore 1.0 TokenBalanceHistoryStore.qml
 TokenMarketValuesStore 1.0 TokenMarketValuesStore.qml
+ChartStoreBase 1.0 ChartStoreBase.qml

--- a/ui/imports/shared/views/ProfileDialogView.qml
+++ b/ui/imports/shared/views/ProfileDialogView.qml
@@ -104,6 +104,15 @@ Pane {
             }
         }
 
+        readonly property var conns3: Connections {
+            target: root.contactsStore.sentContactRequestsModel
+
+            function onItemChanged(pubKey) {
+                if (pubKey === root.publicKey)
+                    d.reload()
+            }
+        }
+
         readonly property var timer: Timer {
             id: timer
         }
@@ -171,8 +180,7 @@ Pane {
             size: StatusButton.Size.Small
             text: qsTr("Send Contact Request")
             onClicked: {
-                Global.openContactRequestPopup(root.publicKey,
-                                               popup => popup.accepted.connect(d.reload))
+                Global.openContactRequestPopup(root.publicKey, null)
             }
         }
     }
@@ -395,8 +403,7 @@ Pane {
                                  d.contactDetails.trustStatus === Constants.trustStatus.untrustworthy // we have an action button otherwise
                         onTriggered: {
                             moreMenu.close()
-                            Global.openContactRequestPopup(root.publicKey,
-                                                           popup => popup.closed.connect(d.reload))
+                            Global.openContactRequestPopup(root.publicKey, null)
                         }
                     }
                     StatusAction {

--- a/ui/imports/shared/views/chat/MessageContextMenuView.qml
+++ b/ui/imports/shared/views/chat/MessageContextMenuView.qml
@@ -365,14 +365,14 @@ StatusMenu {
             root.store.copyToClipboard(root.unparsedText)
             close()
         }
-        enabled: root.messageContentType === Constants.messageContentType.messageType && !root.isProfile && !emojiContainer.visible
+        enabled: root.messageContentType === Constants.messageContentType.messageType && replyToMenuItem.enabled
     }
 
     StatusAction {
         id: copyMessageIdAction
         text: qsTr("Copy Message Id")
         icon.name: "copy"
-        enabled: root.isDebugEnabled && !root.isProfile && !root.pinnedPopup && !emojiContainer.visible
+        enabled: root.isDebugEnabled && replyToMenuItem.enabled
         onTriggered: {
             root.store.copyToClipboard(root.messageId)
             close()

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -467,7 +467,6 @@ Loader {
                 disableHover: root.disableHover ||
                               (root.chatLogView && root.chatLogView.moving) ||
                               (root.messageContextMenu && root.messageContextMenu.opened) ||
-                              Global.profilePopupOpened ||
                               Global.popupOpened
 
                 hideQuickActions: root.isChatBlocked ||
@@ -816,12 +815,7 @@ Loader {
                                     return;
                                 }
 
-                                Global.openPopup(Global.pinnedMessagesPopup, {
-                                                     store: root.rootStore,
-                                                     messageStore: messageStore,
-                                                     pinnedMessagesModel: chatContentModule.pinnedMessagesModel,
-                                                     messageToPin: root.messageId
-                                                 });
+                                Global.openPinnedMessagesPopupRequested(root.rootStore, messageStore, chatContentModule.pinnedMessagesModel, root.messageId)
                             }
                         }
                     },

--- a/ui/imports/utils/Global.qml
+++ b/ui/imports/utils/Global.qml
@@ -6,19 +6,14 @@ QtObject {
     id: root
 
     property var dragArea
-    property var appMain
     property var applicationWindow
     property bool popupOpened: false
     property int settingsSubsection: Constants.settingsSubsection.profile
 
     property var userProfile
-    property var pinnedMessagesPopup
-    property var communityProfilePopup
-    property bool profilePopupOpened: false
 
-    property var sendMessageSound
-    property var notificationSound
-    property var errorSound
+    signal openPinnedMessagesPopupRequested(var store, var messageStore, var pinnedMessagesModel, string messageToPin)
+    signal openCommunityProfilePopupRequested(var store, var community, var chatCommunitySectionModule)
 
     signal openLinkInBrowser(string link)
     signal openChooseBrowserPopup(string link)
@@ -31,7 +26,7 @@ QtObject {
 
     signal displayToastMessage(string title, string subTitle, string icon, bool loading, int ephNotifType, string url)
 
-    signal openPopupRequested(var popupComponent, var params);
+    signal openPopupRequested(var popupComponent, var params)
     signal openNicknamePopupRequested(string publicKey, string nickname, string subtitle)
     signal openDownloadModalRequested(bool available, string version, string url)
     signal openChangeProfilePicPopup(var cb)
@@ -51,6 +46,10 @@ QtObject {
     signal setNthEnabledSectionActive(int nthSection)
     signal appSectionBySectionTypeChanged(int sectionType, int subsection)
 
+    signal playSendMessageSound()
+    signal playNotificationSound()
+    signal playErrorSound()
+
     function openProfilePopup(publicKey, parentPopup) {
         root.openProfilePopupRequested(publicKey, parentPopup)
     }
@@ -69,10 +68,5 @@ QtObject {
 
     function changeAppSectionBySectionType(sectionType, subsection = 0) {
         root.appSectionBySectionTypeChanged(sectionType, subsection);
-    }
-
-    function playErrorSound() {
-        if (root.errorSound)
-            root.errorSound.play();
     }
 }


### PR DESCRIPTION
- all remaining global popup components moved into a separate Popups entity
- removed some static objects from the Global singleton (appMain, pinnedMessagesPopup, communityProfilePopup, sounds); rationale: singletons should not contain any state
- fixed support for popups in storybook
- fixed some warnings (most of them broke the popups in one way or the other)

Fixes #9311
Fixes #9499

### What does the PR do

Consolidates popup handling

### Affected areas

Global, AppMain

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

Profile Popup:
![image](https://user-images.githubusercontent.com/5377645/217312566-e81cc208-45fc-4f61-b027-24dd3b76b72b.png)

Mock profile in Storybook, including another popup on top:
![Snímek obrazovky z 2023-02-07 17-46-30](https://user-images.githubusercontent.com/5377645/217312718-bf4b6580-6f11-46c5-a567-93805a74de97.png)
