### PR TITLE
feat(ActivityCenter): Add indication for visited/unvisited AC state

### DIFF
--- a/src/app/modules/main/activity_center/controller.nim
+++ b/src/app/modules/main/activity_center/controller.nim
@@ -69,12 +69,16 @@ proc init*(self: Controller) =
 
   self.events.on(activity_center_service.SIGNAL_ACTIVITY_CENTER_NOTIFICATIONS_COUNT_MAY_HAVE_CHANGED) do(e: Args):
     self.delegate.unreadActivityCenterNotificationsCountChanged()
+    self.delegate.hasUnseenActivityCenterNotificationsChanged()
 
 proc hasMoreToShow*(self: Controller): bool =
    return self.activityCenterService.hasMoreToShow()
 
 proc unreadActivityCenterNotificationsCount*(self: Controller): int =
    return self.activityCenterService.getUnreadActivityCenterNotificationsCount()
+
+proc hasUnseenActivityCenterNotifications*(self: Controller): bool =
+   return self.activityCenterService.getHasUnseenActivityCenterNotifications()
 
 proc getContactDetails*(self: Controller, contactId: string): ContactDetails =
    return self.contactsService.getContactDetails(contactId)
@@ -101,6 +105,9 @@ proc markActivityCenterNotificationUnread*(
     markAsUnreadProps: MarkAsUnreadNotificationProperties
     ): string =
    return self.activityCenterService.markActivityCenterNotificationUnread(notificationId, markAsUnreadProps)
+
+proc markAsSeenActivityCenterNotifications*(self: Controller) =
+   self.activityCenterService.markAsSeenActivityCenterNotifications()
 
 proc acceptActivityCenterNotifications*(self: Controller, notificationIds: seq[string]): string =
    return self.activityCenterService.acceptActivityCenterNotifications(notificationIds)

--- a/src/app/modules/main/activity_center/io_interface.nim
+++ b/src/app/modules/main/activity_center/io_interface.nim
@@ -24,7 +24,13 @@ method hasMoreToShow*(self: AccessInterface): bool {.base.} =
 method unreadActivityCenterNotificationsCount*(self: AccessInterface): int {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method hasUnseenActivityCenterNotifications*(self: AccessInterface): bool {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method unreadActivityCenterNotificationsCountChanged*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method hasUnseenActivityCenterNotificationsChanged*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method convertToItems*(self: AccessInterface, activityCenterNotifications: seq[ActivityCenterNotificationDto]): seq[Item] {.base.} =
@@ -55,6 +61,9 @@ method markActivityCenterNotificationRead*(self: AccessInterface, notificationId
   raise newException(ValueError, "No implementation available")
 
 method markActivityCenterNotificationUnread*(self: AccessInterface, notificationId: string, communityId: string, channelId: string, nType: int): string {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method markAsSeenActivityCenterNotifications*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method pushActivityCenterNotifications*(self: AccessInterface, activityCenterNotifications: seq[ActivityCenterNotificationDto]) {.base.} =

--- a/src/app/modules/main/activity_center/module.nim
+++ b/src/app/modules/main/activity_center/module.nim
@@ -71,8 +71,14 @@ method hasMoreToShow*(self: Module): bool =
 method unreadActivityCenterNotificationsCount*(self: Module): int =
   self.controller.unreadActivityCenterNotificationsCount()
 
+method hasUnseenActivityCenterNotifications*(self: Module): bool =
+  self.controller.hasUnseenActivityCenterNotifications()
+
 method unreadActivityCenterNotificationsCountChanged*(self: Module) =
   self.view.unreadActivityCenterNotificationsCountChanged()
+
+method hasUnseenActivityCenterNotificationsChanged*(self: Module) =
+  self.view.hasUnseenActivityCenterNotificationsChanged()
 
 proc createMessageItemFromDto(self: Module, message: MessageDto, chatDetails: ChatDto): MessageItem =
   let contactDetails = self.controller.getContactDetails(message.`from`)
@@ -202,6 +208,9 @@ method markActivityCenterNotificationRead*(
 method markActivityCenterNotificationReadDone*(self: Module, notificationIds: seq[string]) =
   for notificationId in notificationIds:
     self.view.markActivityCenterNotificationReadDone(notificationId)
+
+method markAsSeenActivityCenterNotifications*(self: Module) =
+  self.controller.markAsSeenActivityCenterNotifications()
 
 method pushActivityCenterNotifications*(
     self: Module,

--- a/src/app/modules/main/activity_center/view.nim
+++ b/src/app/modules/main/activity_center/view.nim
@@ -51,6 +51,15 @@ QtObject:
     read = unreadActivityCenterNotificationsCount
     notify = unreadActivityCenterNotificationsCountChanged
 
+  proc hasUnseenActivityCenterNotificationsChanged*(self: View) {.signal.}
+
+  proc hasUnseenActivityCenterNotifications*(self: View): bool {.slot.}  =
+    self.delegate.hasUnseenActivityCenterNotifications()
+
+  QtProperty[bool] hasUnseenActivityCenterNotifications:
+    read = hasUnseenActivityCenterNotifications
+    notify = hasUnseenActivityCenterNotificationsChanged
+
   proc pushActivityCenterNotifications*(self:View, activityCenterNotifications: seq[Item]) =
     self.model.addActivityNotificationItemsToList(activityCenterNotifications)
     self.hasMoreToShowChanged()
@@ -98,6 +107,10 @@ QtObject:
       channelId,
       nType
     )
+
+  proc markAsSeenActivityCenterNotifications(self: View): void {.slot.} =
+    self.delegate.markAsSeenActivityCenterNotifications()
+    self.hasUnseenActivityCenterNotificationsChanged()
 
   proc acceptActivityCenterNotifications(self: View, idsJson: string): string {.slot.} =
     let ids = map(parseJson(idsJson).getElems(), proc(x:JsonNode):string = x.getStr())

--- a/src/app_service/service/community/service.nim
+++ b/src/app_service/service/community/service.nim
@@ -726,7 +726,7 @@ QtObject:
   proc requestToJoinCommunity*(self: Service, communityId: string, ensName: string) =
     try:
       let response = status_go.requestToJoinCommunity(communityId, ensName)
-      self.activityCenterService.parseACNotificationResponse(response)
+      self.activityCenterService.parseActivityCenterResponse(response)
 
       if not self.processRequestsToJoinCommunity(response.result):
         error "error: ", procName="requestToJoinCommunity", errDesription = "no 'requestsToJoinCommunity' key in response"
@@ -794,7 +794,7 @@ QtObject:
   proc leaveCommunity*(self: Service, communityId: string) =
     try:
       let response = status_go.leaveCommunity(communityId)
-      self.activityCenterService.parseACNotificationResponse(response)
+      self.activityCenterService.parseActivityCenterResponse(response)
 
       if response.error != nil:
         let error = Json.decode($response.error, RpcError)
@@ -1382,7 +1382,7 @@ QtObject:
             error "error while cancel membership request ", msg
             return
           self.myCommunityRequests.delete(i)
-          self.activityCenterService.parseACNotificationResponse(response)
+          self.activityCenterService.parseActivityCenterResponse(response)
           self.events.emit(SIGNAL_REQUEST_TO_JOIN_COMMUNITY_CANCELED, Args())
           return
 
@@ -1394,7 +1394,7 @@ QtObject:
   proc acceptRequestToJoinCommunity*(self: Service, communityId: string, requestId: string) =
     try:
       let response = status_go.acceptRequestToJoinCommunity(requestId)
-      self.activityCenterService.parseACNotificationResponse(response)
+      self.activityCenterService.parseActivityCenterResponse(response)
 
       let newMemberPubkey = self.removeMembershipRequestFromCommunityAndGetMemberPubkey(communityId, requestId)
 
@@ -1409,7 +1409,7 @@ QtObject:
   proc declineRequestToJoinCommunity*(self: Service, communityId: string, requestId: string) =
     try:
       let response = status_go.declineRequestToJoinCommunity(requestId)
-      self.activityCenterService.parseACNotificationResponse(response)
+      self.activityCenterService.parseActivityCenterResponse(response)
 
       self.moveRequestToDeclined(communityId, requestId)
 

--- a/src/app_service/service/contacts/service.nim
+++ b/src/app_service/service/contacts/service.nim
@@ -436,7 +436,7 @@ QtObject:
       contact.removed = false
       self.saveContact(contact)
       self.events.emit(SIGNAL_CONTACT_ADDED, ContactArgs(contactId: contact.id))
-      self.activityCenterService.parseACNotificationResponse(response)
+      self.activityCenterService.parseActivityCenterResponse(response)
 
     except Exception as e:
       error "an error occurred while accepting contact request", msg=e.msg
@@ -453,7 +453,7 @@ QtObject:
       contact.removed = true
       self.saveContact(contact)
       self.events.emit(SIGNAL_CONTACT_REMOVED, ContactArgs(contactId: contact.id))
-      self.activityCenterService.parseACNotificationResponse(response)
+      self.activityCenterService.parseActivityCenterResponse(response)
     except Exception as e:
       error "an error occurred while dismissing contact request", msg=e.msg
 
@@ -593,7 +593,7 @@ QtObject:
       if not response.error.isNil:
         let msg = response.error.message
         raise newException(RpcException, msg)
-      self.activityCenterService.parseACNotificationResponse(response)
+      self.activityCenterService.parseActivityCenterResponse(response)
 
       if self.contacts.hasKey(publicKey):
         self.contacts[publicKey].trustStatus = TrustStatus.Trusted
@@ -618,7 +618,7 @@ QtObject:
       if not response.error.isNil:
         let msg = response.error.message
         raise newException(RpcException, msg)
-      self.activityCenterService.parseACNotificationResponse(response)
+      self.activityCenterService.parseActivityCenterResponse(response)
 
       if self.contacts.hasKey(publicKey):
         self.contacts[publicKey].trustStatus = TrustStatus.Untrustworthy
@@ -693,7 +693,7 @@ QtObject:
       self.saveContact(contact)
 
       self.events.emit(SIGNAL_CONTACT_VERIFICATION_SENT, ContactArgs(contactId: publicKey))
-      self.activityCenterService.parseACNotificationResponse(response)
+      self.activityCenterService.parseActivityCenterResponse(response)
     except Exception as e:
       error "Error sending verification request", msg = e.msg
 
@@ -717,7 +717,7 @@ QtObject:
       self.saveContact(contact)
 
       self.events.emit(SIGNAL_CONTACT_VERIFICATION_CANCELLED, ContactArgs(contactId: publicKey))
-      self.activityCenterService.parseACNotificationResponse(response)
+      self.activityCenterService.parseActivityCenterResponse(response)
     except Exception as e:
       error "Error canceling verification request", msg = e.msg
 
@@ -739,7 +739,7 @@ QtObject:
 
       self.events.emit(SIGNAL_CONTACT_VERIFICATION_ACCEPTED,
         VerificationRequestArgs(verificationRequest: request))
-      self.activityCenterService.parseACNotificationResponse(response)
+      self.activityCenterService.parseActivityCenterResponse(response)
     except Exception as e:
       error "error accepting contact verification request", msg=e.msg
 
@@ -758,6 +758,6 @@ QtObject:
       self.receivedIdentityRequests[publicKey] = request
 
       self.events.emit(SIGNAL_CONTACT_VERIFICATION_DECLINED, ContactArgs(contactId: publicKey))
-      self.activityCenterService.parseACNotificationResponse(response)
+      self.activityCenterService.parseActivityCenterResponse(response)
     except Exception as e:
       error "error declining contact verification request", msg=e.msg

--- a/src/backend/backend.nim
+++ b/src/backend/backend.nim
@@ -185,6 +185,12 @@ rpc(dismissActivityCenterNotifications, "wakuext"):
 rpc(unreadActivityCenterNotificationsCount, "wakuext"):
   discard
 
+rpc(hasUnseenActivityCenterNotifications, "wakuext"):
+  discard
+
+rpc(markAsSeenActivityCenterNotifications, "wakuext"):
+  discard
+
 rpc(unreadAndAcceptedActivityCenterNotificationsCount, "wakuext"):
   discard
 

--- a/ui/StatusQ/sandbox/controls/Layout.qml
+++ b/ui/StatusQ/sandbox/controls/Layout.qml
@@ -40,6 +40,7 @@ Column {
 
     StatusToolBar {
         notificationCount: 1
+        hasUnseenNotifications: true
         width: 518
 
         headerContent: StatusChatInfoButton {
@@ -75,6 +76,7 @@ Column {
 
     StatusToolBar {
         notificationCount: 1
+        hasUnseenNotifications: true
         width: 518
 
         StatusTagSelector {

--- a/ui/StatusQ/sandbox/demoapp/CreateChatView.qml
+++ b/ui/StatusQ/sandbox/demoapp/CreateChatView.qml
@@ -90,6 +90,7 @@ Page {
                 id: notificationButton
                 anchors.right: parent.right
                 unreadNotificationsCount: 3
+                hasUnseenNotifications: true
             }
         }
     }

--- a/ui/StatusQ/sandbox/demoapp/StatusAppChatView.qml
+++ b/ui/StatusQ/sandbox/demoapp/StatusAppChatView.qml
@@ -15,6 +15,7 @@ StatusSectionLayout {
     property bool createChat: false
 
     notificationCount: 1
+    hasUnseenNotifications: true
     onNotificationButtonClicked: { notificationCount = 0; }
     showHeader: !root.createChat
 

--- a/ui/StatusQ/src/StatusQ/Components/StatusToolBar.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusToolBar.qml
@@ -11,6 +11,7 @@ ToolBar {
 
     property string backButtonName: ""
     property int notificationCount: 0
+    property bool hasUnseenNotifications: false
     property Item headerContent
     property alias notificationButton: notificationButton
 
@@ -56,6 +57,7 @@ ToolBar {
         StatusActivityCenterButton {
             id: notificationButton
             unreadNotificationsCount: root.notificationCount
+            hasUnseenNotifications: root.hasUnseenNotifications
             onClicked: root.notificationButtonClicked()
         }
     }

--- a/ui/StatusQ/src/StatusQ/Controls/StatusActivityCenterButton.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusActivityCenterButton.qml
@@ -23,7 +23,13 @@ import StatusQ.Components 0.1
 */
 
 StatusFlatRoundButton {
-    id: notificationButton
+    id: root
+
+    /*!
+       \qmlproperty bool StatusActivityCenterButton::hasUnseenNotifications
+       This property indicates whether there are unseen notifications
+    */
+    property bool hasUnseenNotifications: false
 
     /*!
        \qmlproperty int StatusActivityCenterButton::unreadNotificationsCount
@@ -44,8 +50,9 @@ StatusFlatRoundButton {
         id: statusBadge
         visible: value > 0
         anchors.centerIn: parent
-        anchors.verticalCenterOffset: -(icon.height/2.5)
-        anchors.horizontalCenterOffset: (width/2.5)
+        anchors.verticalCenterOffset: -(icon.height / 2.5)
+        anchors.horizontalCenterOffset: (width / 2.5)
+        color: root.hasUnseenNotifications ? Theme.palette.primaryColor1 : Theme.palette.baseColor1
         border.width: 2
         border.color: parent.hovered ? Theme.palette.baseColor2 : Theme.palette.statusAppLayout.backgroundColor
     }

--- a/ui/StatusQ/src/StatusQ/Layout/StatusSectionLayout.qml
+++ b/ui/StatusQ/src/StatusQ/Layout/StatusSectionLayout.qml
@@ -88,6 +88,13 @@ SplitView {
     property alias notificationCount: statusToolBar.notificationCount
 
     /*!
+        \qmlproperty alias StatusAppLayout::hasUnseenNotifications
+        This property holds a reference to the hasUnseenNotifications property of the
+        header component.
+    */
+    property alias hasUnseenNotifications: statusToolBar.hasUnseenNotifications
+
+    /*!
         \qmlproperty alias StatusAppLayout::backButtonName
         This property holds a reference to the backButtonName property of the
         header component.

--- a/ui/app/AppLayouts/Browser/BrowserLayout.qml
+++ b/ui/app/AppLayouts/Browser/BrowserLayout.qml
@@ -37,6 +37,7 @@ StatusSectionLayout {
     }
 
     notificationCount: activityCenterStore.unreadNotificationsCount
+    hasUnseenNotifications: activityCenterStore.hasUnseenNotifications
     onNotificationButtonClicked: Global.openActivityCenterPopup()
 
     QtObject {

--- a/ui/app/AppLayouts/Chat/views/ChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatView.qml
@@ -61,6 +61,7 @@ StatusSectionLayout {
     notificationButton.tooltip.offset: localAccountSensitiveSettings.expandUsersList && headerContent.membersButton.visible ? 0 : 14
     onNotificationButtonClicked: Global.openActivityCenterPopup()
     notificationCount: activityCenterStore.unreadNotificationsCount
+    hasUnseenNotifications: activityCenterStore.hasUnseenNotifications
 
     headerContent: ChatHeaderContentView {
         id: headerContent

--- a/ui/app/AppLayouts/Chat/views/CommunitySettingsView.qml
+++ b/ui/app/AppLayouts/Chat/views/CommunitySettingsView.qml
@@ -26,6 +26,7 @@ StatusSectionLayout {
     id: root
 
     notificationCount: activityCenterStore.unreadNotificationsCount
+    hasUnseenNotifications: activityCenterStore.hasUnseenNotifications
     onNotificationButtonClicked: Global.openActivityCenterPopup()
     // TODO: get this model from backend?
     property var settingsMenuModel: [{name: qsTr("Overview"), icon: "show", enabled: true},

--- a/ui/app/AppLayouts/Chat/views/CreateChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/CreateChatView.qml
@@ -107,6 +107,7 @@ Page {
             StatusActivityCenterButton {
                 Layout.alignment: Qt.AlignVCenter
                 unreadNotificationsCount: activityCenterStore.unreadNotificationsCount
+                hasUnseenNotifications: activityCenterStore.hasUnseenNotifications
                 onClicked: Global.openActivityCenterPopup()
             }
         }

--- a/ui/app/AppLayouts/Node/NodeLayout.qml
+++ b/ui/app/AppLayouts/Node/NodeLayout.qml
@@ -21,7 +21,10 @@ StatusSectionLayout {
     property RootStore store: RootStore {}
 
     notificationCount: activityCenterStore.unreadNotificationsCount
+    hasUnseenNotifications: activityCenterStore.hasUnseenNotifications
+
     onNotificationButtonClicked: Global.openActivityCenterPopup()
+
     centerPanel: ColumnLayout {
         id: rpcColumn
         spacing: 0

--- a/ui/app/AppLayouts/Profile/ProfileLayout.qml
+++ b/ui/app/AppLayouts/Profile/ProfileLayout.qml
@@ -24,6 +24,7 @@ StatusSectionLayout {
 
     backButtonName: root.store.backButtonName
     notificationCount: activityCenterStore.unreadNotificationsCount
+    hasUnseenNotifications: activityCenterStore.hasUnseenNotifications
 
     onNotificationButtonClicked: Global.openActivityCenterPopup()
     onBackButtonClicked: {

--- a/ui/app/AppLayouts/Wallet/WalletLayout.qml
+++ b/ui/app/AppLayouts/Wallet/WalletLayout.qml
@@ -65,6 +65,7 @@ Item {
         width: root.width
         backButtonName: RootStore.backButtonName
         notificationCount: activityCenterStore.unreadNotificationsCount
+        
         onNotificationButtonClicked: Global.openActivityCenterPopup()
         onBackButtonClicked: {
             rightPanelStackView.currentItem.resetStack();

--- a/ui/app/mainui/activitycenter/popups/ActivityCenterPopup.qml
+++ b/ui/app/mainui/activitycenter/popups/ActivityCenterPopup.qml
@@ -108,6 +108,7 @@ Popup {
     }
     onClosed: {
         Global.popupOpened = false
+        activityCenterStore.markAsSeenActivityCenterNotifications()
     }
 
     x: Global.applicationWindow.width - root.width - Style.current.halfPadding

--- a/ui/app/mainui/activitycenter/stores/ActivityCenterStore.qml
+++ b/ui/app/mainui/activitycenter/stores/ActivityCenterStore.qml
@@ -8,6 +8,7 @@ QtObject {
     readonly property var activityCenterModuleInst: activityCenterModule
     readonly property var activityCenterList: activityCenterModuleInst.activityNotificationsModel
     readonly property int unreadNotificationsCount: activityCenterModuleInst.unreadActivityCenterNotificationsCount
+    readonly property bool hasUnseenNotifications: activityCenterModuleInst.hasUnseenActivityCenterNotifications
 
     function markAllActivityCenterNotificationsRead() {
         root.activityCenterModuleInst.markAllActivityCenterNotificationsRead()
@@ -23,6 +24,10 @@ QtObject {
         root.activityCenterModuleInst.markActivityCenterNotificationUnread(
             notification.id, notification.message.communityId,
             notification.message.chatId, notification.notificationType)
+    }
+
+    function markAsSeenActivityCenterNotifications() {
+        root.activityCenterModuleInst.markAsSeenActivityCenterNotifications()
     }
 
     function switchTo(notification) {


### PR DESCRIPTION
Close #9347
Depends https://github.com/status-im/status-go/pull/3148

Add indication for visited/unvisited ActivityCenter state

### Affected areas

ActivityCenter

### Screenshot of functionality (including design for comparison)


https://user-images.githubusercontent.com/2522130/217846552-615831db-6e11-43ea-8b6c-b90c5b8c62c8.mov

