### PR TITLE
fix(@desktop/wallet): Preferred network doesn't reflect in advanced view

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/StatusCard.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusCard.qml
@@ -373,7 +373,7 @@ Rectangle {
             name: "default"
             PropertyChanges {
                 target: root
-                color: disabled ? Theme.palette.baseColor4 : "transparent"
+                color: disabled ? Theme.palette.baseColor4 : Theme.palette.indirectColor1
             }
             PropertyChanges {
                 target: root
@@ -447,7 +447,7 @@ Rectangle {
             name: "error"
             PropertyChanges {
                 target: root
-                color: disabled ? Theme.palette.baseColor4 : "transparent"
+                color: disabled ? Theme.palette.baseColor4 : Theme.palette.indirectColor1
             }
             PropertyChanges {
                 target: root
@@ -520,7 +520,7 @@ Rectangle {
             name: "unpreferred"
             PropertyChanges {
                 target: root
-                color: disabled ? Theme.palette.baseColor4 : "transparent"
+                color: disabled ? Theme.palette.baseColor4 : Theme.palette.indirectColor1
             }
             PropertyChanges {
                 target: root

--- a/ui/imports/shared/stores/TransactionStore.qml
+++ b/ui/imports/shared/stores/TransactionStore.qml
@@ -140,10 +140,12 @@ QtObject {
         return networksModule.getMainnetChainId()
     }
 
+    // We should move all this over to nim
     function addPreferredChains(preferredchains, showUnpreferredNetworks) {
+        let tempPreferredChains = preferredChainIds
         for(const chain of preferredchains) {
-            if(!preferredChainIds.includes(chain)) {
-                preferredChainIds.push(chain)
+            if(!tempPreferredChains.includes(chain)) {
+                tempPreferredChains.push(chain)
                 // remove from disabled accounts as it was added as preferred
                 addRemoveDisabledToChain(chain, false)
             }
@@ -151,13 +153,15 @@ QtObject {
 
         // here we are trying to remove chains that are not preferred from the list and
         // also disable them incase the showUnpreferredNetworks toggle is turned off
-        for(var i = 0; i < preferredChainIds.length; i++) {
-            if(!preferredchains.includes(preferredChainIds[i])) {
+        for(var i = 0; i < tempPreferredChains.length; i++) {
+            if(!preferredchains.includes(tempPreferredChains[i])) {
                 if(!showUnpreferredNetworks)
-                    addRemoveDisabledToChain(preferredChainIds[i], true)
-                preferredChainIds.splice(i, 1)
+                    addRemoveDisabledToChain(tempPreferredChains[i], true)
+                tempPreferredChains.splice(i, 1)
             }
         }
+
+        preferredChainIds = tempPreferredChains
     }
 
     function addUnpreferredChainsToDisabledChains() {

--- a/ui/imports/shared/views/NetworkCardsComponent.qml
+++ b/ui/imports/shared/views/NetworkCardsComponent.qml
@@ -188,6 +188,7 @@ Item {
                     property int bentLine: 0
                     property double amountToReceive: 0
                     property var currencyAmountToReceive: root.getCryptoCurrencyAmount(amountToReceive)
+                    property var preferredChains: store.preferredChainIds
                     property bool preferred: store.preferredChainIds.includes(model.chainId)
                     primaryText: model.chainName
                     secondaryText: LocaleUtils.currencyAmountToLocaleString(currencyAmountToReceive)
@@ -221,6 +222,8 @@ Item {
                                 root.reCalculateSuggestedRoute()
                         }
                     }
+                    // Only needed until we move preferredChains to nim side
+                    onPreferredChainsChanged: preferred = store.preferredChainIds.includes(model.chainId)
                 }
             }
         }


### PR DESCRIPTION
fixes #9456

### What does the PR do

Adds background to the statuscard so that the highlight doesnt look white in dark mode
Fixes issue of preferredChains not updated after editing them

### Affected areas

Wallet, SendModal

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [x] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it


https://user-images.githubusercontent.com/60327365/217328179-639aff1f-d713-4971-a44f-a234e096ada1.mov


https://user-images.githubusercontent.com/60327365/217328224-26041ebd-9c75-4daf-8983-a1fba4ace5d4.mov

