### PR TITLE
fix: changing password with wrong current one fails

### DIFF
--- a/ui/app/AppLayouts/Onboarding/views/ConfirmPasswordView.qml
+++ b/ui/app/AppLayouts/Onboarding/views/ConfirmPasswordView.qml
@@ -145,7 +145,6 @@ Item {
         function onPasswordChanged(success: bool, errorMsg: string) {
             if (success) {
                 submitBtn.loading = false
-                root.exit();
             }
         }
     }

--- a/ui/app/AppLayouts/Profile/popups/ChangePasswordModal.qml
+++ b/ui/app/AppLayouts/Profile/popups/ChangePasswordModal.qml
@@ -35,7 +35,7 @@ StatusModal {
             console.warn("TODO: Display error message when change password action failure! ")
         }
         d.passwordProcessing = "";
-        submitBtn.enabled = false;
+        submitBtn.loading = false;
     }
 
     QtObject {


### PR DESCRIPTION
do not break/overwrite the Submit button's `enabled` property binding; the button would stay in the "loading" state

Fixes #9465

### What does the PR do

Fixes "Change password" popup

### Affected areas

ChangePasswordModal

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

Before submitting:
![image](https://user-images.githubusercontent.com/5377645/217353889-d5e38cc2-a02a-4371-8607-cdbfcef4d428.png)

After submitting:
![image](https://user-images.githubusercontent.com/5377645/217354013-1070cddb-a400-462b-b20e-2f0611be3d24.png)
