### PR TITLE
fix(StatusChatList): Fixing StatusChatList scrolling

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/StatusChatList.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusChatList.qml
@@ -11,7 +11,7 @@ Item {
     id: root
 
     implicitWidth: statusChatListItems.width
-    height: statusChatListItems.height
+    implicitHeight: statusChatListItems.contentHeight
 
     property string categoryId: ""
     property var model: null
@@ -34,10 +34,11 @@ Item {
     StatusListView {
         id: statusChatListItems
         width: 288
-        height: contentHeight
+        height: root.height
         objectName: "chatListItems"
         model: root.model
         spacing: 0
+        interactive: height !== contentHeight
         section.property: "categoryId"
         section.criteria: ViewSection.FullString
 


### PR DESCRIPTION
### Enable StatusChatList sizing and disable scroll filtering when the listview.height == listview.contentHeight

The root-cause of this issue is that we use a Listview with height == contentHeight and delegate the scrolling to a ScrollView. The reasoning is that we can attach other items to the bottom of the listview and delegating the scroll to a ScrollView will enable us to scroll the listview+other items attached at the bottom at the same time. 
The fix is to set ListView.interactive to false when the listview cannot be scrolled. Also fixed the listview height so that it can be used as a scrollable listview.

### What does the PR do
Closing #9460
<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas

Community chat list
Contacts chat list
