### PR TITLE
refactor: load recent stickers asynchronously

### DIFF
--- a/src/app/modules/main/stickers/controller.nim
+++ b/src/app/modules/main/stickers/controller.nim
@@ -53,9 +53,6 @@ proc delete*(self: Controller) =
   discard
 
 proc init*(self: Controller) =
-  let recentStickers = self.stickerService.getRecentStickers()
-  for sticker in recentStickers:
-    self.delegate.addRecentStickerToList(sticker)
 
   let installedStickers = self.stickerService.getInstalledStickerPacks()
   self.delegate.populateInstalledStickerPacks(installedStickers)
@@ -73,6 +70,11 @@ proc init*(self: Controller) =
       self.delegate.clearStickerPacks()
       self.obtainMarketStickerPacks()
       self.disconnected = false
+
+  self.events.on(SIGNAL_LOAD_RECENT_STICKERS_DONE) do(e: Args):
+    let args = StickersArgs(e)
+    for sticker in args.stickers:
+      self.delegate.addRecentStickerToList(sticker)
 
   self.events.on(SIGNAL_STICKER_PACK_LOADED) do(e: Args):
     let args = StickerPackLoadedArgs(e)
@@ -113,6 +115,12 @@ proc init*(self: Controller) =
 
 proc buy*(self: Controller, packId: string, address: string, gas: string, gasPrice: string, maxPriorityFeePerGas: string, maxFeePerGas: string, password: string, eip1559Enabled: bool): tuple[response: string, success: bool] =
   self.stickerService.buy(packId, address, gas, gasPrice, maxPriorityFeePerGas, maxFeePerGas, password, eip1559Enabled)
+
+proc getRecentStickers*(self: Controller): seq[StickerDto] = 
+  return self.stickerService.getRecentStickers()
+
+proc loadRecentStickers*(self: Controller) =
+  self.stickerService.asyncLoadRecentStickers()
 
 proc estimate*(self: Controller, packId: string, address: string, price: string, uuid: string) =
   self.stickerService.estimate(packId, address, price, uuid)

--- a/src/app/modules/main/stickers/controller.nim
+++ b/src/app/modules/main/stickers/controller.nim
@@ -54,9 +54,6 @@ proc delete*(self: Controller) =
 
 proc init*(self: Controller) =
 
-  let installedStickers = self.stickerService.getInstalledStickerPacks()
-  self.delegate.populateInstalledStickerPacks(installedStickers)
-
   self.events.on(SIGNAL_NETWORK_DISCONNECTED) do(e: Args):
     self.disconnected = true
     self.delegate.clearStickerPacks()
@@ -84,6 +81,11 @@ proc init*(self: Controller) =
       args.isBought,
       args.isPending
     )
+
+  self.events.on(SIGNAL_LOAD_INSTALLED_STICKER_PACKS_DONE) do(e: Args):
+    let args = StickerPacksArgs(e)
+    self.delegate.installedStickerPacksLoaded()
+    self.delegate.populateInstalledStickerPacks(args.packs)
 
   self.events.on(SIGNAL_ALL_STICKER_PACKS_LOADED) do(e: Args):
     self.delegate.allPacksLoaded()
@@ -121,6 +123,9 @@ proc getRecentStickers*(self: Controller): seq[StickerDto] =
 
 proc loadRecentStickers*(self: Controller) =
   self.stickerService.asyncLoadRecentStickers()
+
+proc loadInstalledStickerPacks*(self: Controller) =
+  self.stickerService.asyncLoadInstalledStickerPacks()
 
 proc estimate*(self: Controller, packId: string, address: string, price: string, uuid: string) =
   self.stickerService.estimate(packId, address, price, uuid)

--- a/src/app/modules/main/stickers/io_interface.nim
+++ b/src/app/modules/main/stickers/io_interface.nim
@@ -22,6 +22,12 @@ method viewDidLoad*(self: AccessInterface) {.base.} =
 method authenticateAndBuy*(self: AccessInterface, packId: string, address: string, gas: string, gasPrice: string, maxPriorityFeePerGas: string, maxFeePerGas: string, eip1559Enabled: bool){.base.} =
   raise newException(ValueError, "No implementation available")
 
+method getRecentStickers*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method loadRecentStickers*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method getInstalledStickerPacks*(self: AccessInterface): Table[string, StickerPackDto] {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/stickers/io_interface.nim
+++ b/src/app/modules/main/stickers/io_interface.nim
@@ -28,7 +28,10 @@ method getRecentStickers*(self: AccessInterface) {.base.} =
 method loadRecentStickers*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method getInstalledStickerPacks*(self: AccessInterface): Table[string, StickerPackDto] {.base.} =
+method getInstalledStickerPacks*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method installedStickerPacksLoaded*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method obtainMarketStickerPacks*(self: AccessInterface) {.base.} =

--- a/src/app/modules/main/stickers/module.nim
+++ b/src/app/modules/main/stickers/module.nim
@@ -125,9 +125,6 @@ method onUserAuthenticated*(self: Module, password: string) =
       self.view.stickerPacks.updateStickerPackInList(self.tmpBuyStickersTransactionDetails.packId, false, true)
     self.view.transactionWasSent($(%*{"success": success, "result": response}))
 
-method getInstalledStickerPacks*(self: Module): Table[string, StickerPackDto] =
-  self.controller.getInstalledStickerPacks()
-
 method obtainMarketStickerPacks*(self: Module) =
   self.controller.obtainMarketStickerPacks()
 
@@ -139,6 +136,9 @@ method installStickerPack*(self: Module, packId: string) =
 
 method onStickerPackInstalled*(self: Module, packId: string) =
   self.view.onStickerPackInstalled(packId)
+
+method installedStickerPacksLoaded*(self: Module) =
+  self.view.setInstalledStickerPacksLoaded(true)
 
 method uninstallStickerPack*(self: Module, packId: string) =
   self.controller.uninstallStickerPack(packId)
@@ -164,13 +164,10 @@ method addRecentStickerToList*(self: Module, sticker: StickerDto) =
   self.view.addRecentStickerToList(initItem(sticker.hash, sticker.packId, sticker.url))
 
 method getRecentStickers*(self: Module) =
-  let data = self.controller.getRecentStickers()
-  if data.len > 0:
-    for sticker in data:
-      self.addRecentStickerToList(sticker)
-      return
   self.controller.loadRecentStickers()
 
+method getInstalledStickerPacks*(self: Module) =
+  self.controller.loadInstalledStickerPacks()
 
 method clearStickerPacks*(self: Module) =
   self.view.clearStickerPacks()

--- a/src/app/modules/main/stickers/module.nim
+++ b/src/app/modules/main/stickers/module.nim
@@ -163,6 +163,15 @@ method estimate*(self: Module, packId: string, address: string, price: string, u
 method addRecentStickerToList*(self: Module, sticker: StickerDto) =
   self.view.addRecentStickerToList(initItem(sticker.hash, sticker.packId, sticker.url))
 
+method getRecentStickers*(self: Module) =
+  let data = self.controller.getRecentStickers()
+  if data.len > 0:
+    for sticker in data:
+      self.addRecentStickerToList(sticker)
+      return
+  self.controller.loadRecentStickers()
+
+
 method clearStickerPacks*(self: Module) =
   self.view.clearStickerPacks()
 

--- a/src/app/modules/main/stickers/view.nim
+++ b/src/app/modules/main/stickers/view.nim
@@ -108,6 +108,7 @@ QtObject:
 
   proc addRecentStickerToList*(self: View, sticker: Item) =
     self.recentStickers.addStickerToList(sticker)
+    self.recentStickersUpdated()
 
   proc getAllPacksLoaded(self: View): bool {.slot.} =
     self.packsLoaded
@@ -142,6 +143,9 @@ QtObject:
     self.packsLoadFailedChanged()
 
     self.delegate.obtainMarketStickerPacks()
+
+  proc getRecentStickers(self: View) {.slot.} =
+    self.delegate.getRecentStickers()
 
   proc send*(self: View, channelId: string, hash: string, replyTo: string, pack: string, url: string) {.slot.} =
     let sticker = initItem(hash, pack, url)

--- a/src/app_service/service/stickers/async_tasks.nim
+++ b/src/app_service/service/stickers/async_tasks.nim
@@ -14,10 +14,16 @@ type
     chainId*: int
     hasKey*: bool
   AsyncGetRecentStickersTaskArg* = ref object of QObjectTaskArg
+  AsyncGetInstalledStickerPacksTaskArg* = ref object of QObjectTaskArg
 
 const asyncGetRecentStickersTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AsyncGetRecentStickersTaskArg](argEncoded)
   let response = status_stickers.recent()
+  arg.finish(response)
+
+const asyncGetInstalledStickerPacksTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+  let arg = decode[AsyncGetInstalledStickerPacksTaskArg](argEncoded)
+  let response = status_stickers.installed()
   arg.finish(response)
 
 proc getMarketStickerPacks*(chainId: int): 

--- a/src/app_service/service/stickers/async_tasks.nim
+++ b/src/app_service/service/stickers/async_tasks.nim
@@ -13,6 +13,12 @@ type
     packId*: string
     chainId*: int
     hasKey*: bool
+  AsyncGetRecentStickersTaskArg* = ref object of QObjectTaskArg
+
+const asyncGetRecentStickersTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+  let arg = decode[AsyncGetRecentStickersTaskArg](argEncoded)
+  let response = status_stickers.recent()
+  arg.finish(response)
 
 proc getMarketStickerPacks*(chainId: int): 
     tuple[stickers: Table[string, StickerPackDto], error: string] =

--- a/ui/imports/shared/status/StatusStickersPopup.qml
+++ b/ui/imports/shared/status/StatusStickersPopup.qml
@@ -34,6 +34,10 @@ Popup {
         function loadStickers() {
             store.stickersModuleInst.loadStickers()
         }
+
+        function getRecentStickers() {
+            store.stickersModuleInst.getRecentStickers()
+        }
     }
 
     enabled: !!d.recentStickers && !!d.stickerPackList
@@ -53,6 +57,12 @@ Popup {
             fast: true
             cached: true
             color: "#22000000"
+        }
+    }
+
+    onAboutToShow: {
+        if (stickerGrid.packId == -1) {
+            d.getRecentStickers()
         }
     }
 
@@ -261,6 +271,7 @@ Popup {
                 onClicked: {
                     highlighted = true
                     stickerPackListView.selectedPackId = -1
+                    d.getRecentStickers()
                     stickerGrid.model = d.recentStickers
                 }
             }

--- a/ui/imports/shared/status/StatusStickersPopup.qml
+++ b/ui/imports/shared/status/StatusStickersPopup.qml
@@ -38,6 +38,10 @@ Popup {
         function getRecentStickers() {
             store.stickersModuleInst.getRecentStickers()
         }
+
+        function getInstalledStickerPacks() {
+            store.stickersModuleInst.getInstalledStickerPacks()
+        }
     }
 
     enabled: !!d.recentStickers && !!d.stickerPackList
@@ -61,6 +65,7 @@ Popup {
     }
 
     onAboutToShow: {
+        d.getInstalledStickerPacks()
         if (stickerGrid.packId == -1) {
             d.getRecentStickers()
         }


### PR DESCRIPTION
This postpones the loading of recently used stickers to the point when a) the stickers popup is opened and the recent stickers tab was the last visited one or b) when the sticker popup is open and one switches to the recent stickers tab.

Partially closes #9435
