### PR TITLE
fix: unbreak chat categories height and highlight 

### DIFF
--- a/src/app/modules/main/chat_section/model.nim
+++ b/src/app/modules/main/chat_section/model.nim
@@ -202,8 +202,7 @@ QtObject:
       if self.items[i].categoryId == categoryId:
         self.items[i].categoryOpened = opened
         let index = self.createIndex(i, 0, nil)
-        # Also signal on CategoryId because the section header only knows the categoryId
-        self.dataChanged(index, index, @[ModelRole.CategoryId.int, ModelRole.CategoryOpened.int])
+        self.dataChanged(index, index, @[ModelRole.CategoryOpened.int])
 
   proc removeItemByIndex(self: Model, idx: int) =
     if idx == -1:
@@ -240,12 +239,13 @@ QtObject:
       if(it.id == id):
         return it
 
-  proc setCategoryHasUnreadMessages*(self: Model, id: string, value: bool) =
-    for i in 0 ..< self.items.len:
-      if(self.items[i].id == id):
-        let index = self.createIndex(i, 0, nil)
-        self.items[i].hasUnreadMessages = value
-        self.dataChanged(index, index, @[ModelRole.HasUnreadMessages.int])
+  proc categoryHasUnreadMessagesChanged*(self: Model, categoryId: string, hasUnread: bool) {.signal.}
+
+  proc getCategoryHasUnreadMessages*(self: Model, categoryId: string): bool {.slot.} =
+    return self.items.anyIt(it.categoryId == categoryId and it.hasUnreadMessages)
+
+  proc setCategoryHasUnreadMessages*(self: Model, categoryId: string, value: bool) =
+    self.categoryHasUnreadMessagesChanged(categoryId, value)
 
   proc getCategoryAndPosition*(self: Model, id: string): (string, int) =
     let item = self.getItemById(id)

--- a/src/app_service/service/chat/service.nim
+++ b/src/app_service/service/chat/service.nim
@@ -231,7 +231,7 @@ QtObject:
       return false
 
     for chat in self.channelGroups[communityId].chats:
-      if chat.unviewedMentionsCount > 0 or chat.unviewedMentionsCount > 0:
+      if chat.unviewedMessagesCount > 0 or chat.unviewedMentionsCount > 0:
         return true
     return false
 

--- a/ui/app/AppLayouts/Wallet/views/CollectiblesView.qml
+++ b/ui/app/AppLayouts/Wallet/views/CollectiblesView.qml
@@ -8,8 +8,6 @@ import StatusQ.Components 0.1
 import shared.panels 1.0
 import utils 1.0
 
-import utils 1.0
-
 import "collectibles"
 
 Item {


### PR DESCRIPTION
- fix chat category/section height not being (re)set to 0 properly and
  hidden
- restore the chat category header highlighting when it contains new
  messages/mentions after the new flattened chat model refactoring

Fixes #9493

### Affected areas

StatusChatList; chat model

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

Mobile category collapsed; alleged new msg in desktop:
![Snímek obrazovky z 2023-02-08 20-19-46](https://user-images.githubusercontent.com/5377645/217634502-2f8b9e9c-2e9e-4ab6-9ae5-1e85e0daf989.png)

Desktop channel activated, whole category unmarked:
![Snímek obrazovky z 2023-02-08 20-19-53](https://user-images.githubusercontent.com/5377645/217634510-2a2a9c33-de75-429d-b44a-b2fd6bee9957.png)

