### PR TITLE
fix(wallet): SendModal layout

### DIFF
--- a/src/app_service/service/node_configuration/service.nim
+++ b/src/app_service/service/node_configuration/service.nim
@@ -57,7 +57,7 @@ proc adaptNodeSettingsForTheAppNeed(self: Service) =
   self.configuration.LogFile = "./geth.log"
   self.configuration.ShhextConfig.BackupDisabledDataDir = "./"
 
-  if (not self.isCommunityHistoryArchiveSupportEnabled):
+  if (not self.isCommunityHistoryArchiveSupportEnabled()):
     # Force community archive support true on Desktop
     # TODO those lines can be removed in the future once we are sure no one has used a legacy client where it is off
     if (self.enableCommunityHistoryArchiveSupport()):

--- a/ui/imports/shared/panels/StatusAssetSelector.qml
+++ b/ui/imports/shared/panels/StatusAssetSelector.qml
@@ -68,7 +68,6 @@ Item {
     StatusComboBox {
         id: comboBox
         objectName: "assetSelectorButton"
-        width: d.isTokenSelected ? rowLayout.implicitWidth : 116
         height: 34
 
         control.padding: 4
@@ -132,7 +131,6 @@ Item {
                 visible: d.isTokenSelected
             }
             StatusBaseText {
-                Layout.maximumWidth: comboBox.width - Style.current.padding
                 Layout.alignment: Qt.AlignCenter
                 visible: !d.isTokenSelected
                 font.pixelSize: 15

--- a/ui/imports/shared/popups/SendModal.qml
+++ b/ui/imports/shared/popups/SendModal.qml
@@ -328,8 +328,12 @@ StatusDialog {
             StatusScrollView {
                 id: scrollView
                 topPadding: 12
+
+                implicitWidth: contentWidth + leftPadding + rightPadding
+                implicitHeight: contentHeight + topPadding + bottomPadding
+                Layout.fillWidth: true
                 Layout.fillHeight: true
-                Layout.preferredWidth: parent.width
+
                 contentHeight: layout.height + Style.current.padding
                 contentWidth: parent.width
                 z: 0

--- a/ui/imports/shared/stores/CurrenciesStore.qml
+++ b/ui/imports/shared/stores/CurrenciesStore.qml
@@ -969,6 +969,9 @@ QtObject {
     }
 
     function getCurrencyAmount(amount, symbol) {
+        if (isNaN(amount)) {
+            amount = 0
+        }
         let obj = JSON.parse((walletSection.getCurrencyAmountAsJson(amount, symbol)))
         if (obj.error) {
             console.error("Error parsing currency amount json object, amount: ", amount, ", symbol ", symbol, " error: ", obj.error)


### PR DESCRIPTION
StatusScrollView was missing a height hint, so even though it was expanding, the parent layout didn't know how much to allow it.

Root cause change: https://github.com/status-im/status-desktop/pull/9469

### Affected areas

Wallet, SendModal