### PR TITLE
fix(tests): wallet tests

### DIFF
--- a/test/ui-test/src/screens/StatusWalletScreen.py
+++ b/test/ui-test/src/screens/StatusWalletScreen.py
@@ -70,6 +70,7 @@ class AddAccountPopup(Enum):
     PRIVATE_KEY_INPUT: str = "mainWallet_Add_Account_Popup_Private_Key"
     ADD_ACCOUNT_BUTTON: str = "mainWallet_Add_Account_Popup_Footer_Add_Account"
     SEED_PHRASE_INPUT_TEMPLATE: str = "mainWindow_Add_Account_Popup_Seed_Phrase_"
+    SEED_PHRASE_INPUT_LAST: str = "mainWindow_Add_Account_Popup_Seed_Phrase_12"
 
 class SharedPopup(Enum):
     POPUP_CONTENT: str = "sharedPopup_Popup_Content"
@@ -123,6 +124,7 @@ class StatusWalletScreen:
         time.sleep(1)
         click_obj_by_name(AddAccountPopup.TYPE_PRIVATE_KEY.value)
 
+        scroll_item_until_item_is_visible(AddAccountPopup.SCROLL_BAR.value, AddAccountPopup.PRIVATE_KEY_INPUT.value)
         type(AddAccountPopup.PRIVATE_KEY_INPUT.value, private_key)
 
         click_obj_by_name(AddAccountPopup.ADD_ACCOUNT_BUTTON.value)
@@ -143,16 +145,12 @@ class StatusWalletScreen:
         time.sleep(1)
         click_obj_by_name(AddAccountPopup.TYPE_SEED_PHRASE.value)
         time.sleep(1)
+
+        for i in range(1, 5):
+            scroll_obj_by_name(AddAccountPopup.SCROLL_BAR.value)
+            time.sleep(1)
+
         words = mnemonic.split()
-        scroll_obj_by_name(AddAccountPopup.SCROLL_BAR.value)
-        time.sleep(1)
-
-        scroll_obj_by_name(AddAccountPopup.SCROLL_BAR.value)
-        time.sleep(1)
-
-        scroll_obj_by_name(AddAccountPopup.SCROLL_BAR.value)
-        time.sleep(1)
-
         input_seed_phrase(AddAccountPopup.SEED_PHRASE_INPUT_TEMPLATE.value, words)
         time.sleep(1)
 

--- a/test/ui-test/src/screens/StatusWalletScreen.py
+++ b/test/ui-test/src/screens/StatusWalletScreen.py
@@ -109,6 +109,7 @@ class StatusWalletScreen:
         time.sleep(1)
         click_obj_by_name(AddAccountPopup.TYPE_WATCH_ONLY.value)
 
+        scroll_item_until_item_is_visible(AddAccountPopup.SCROLL_BAR.value, AddAccountPopup.ADDRESS_INPUT.value)
         type(AddAccountPopup.ADDRESS_INPUT.value, address)
         click_obj_by_name(AddAccountPopup.ADD_ACCOUNT_BUTTON.value)
 

--- a/test/ui-test/testSuites/suite_wallet/tst_wallet/test.feature
+++ b/test/ui-test/testSuites/suite_wallet/tst_wallet/test.feature
@@ -17,8 +17,6 @@ Feature: Status Desktop Wallet
         Given the user opens wallet screen
         And the user clicks on the first account
 
-    @mayfail
-    # FIXME all wallet tests are broken. Issue #9498
 	Scenario: The user can manage and observe a watch only account
         When the user adds watch only account "0xea123F7beFF45E3C9fdF54B324c29DBdA14a639A" named "AccountWatch"
         Then the new account "AccountWatch" is added

--- a/test/ui-test/testSuites/suite_wallet/tst_wallet/test.feature
+++ b/test/ui-test/testSuites/suite_wallet/tst_wallet/test.feature
@@ -25,28 +25,20 @@ Feature: Status Desktop Wallet
         # And the collectibles are listed for the on
         # And the transactions are listed for the added account
 
-    @mayfail
-    # FIXME all wallet tests are broken. Issue #9498
     Scenario: The user imports a private key
         When an account named "AccountPrivate" is added via private key "8da4ef21b864d2cc526dbdb2a120bd2874c36c9d0a1fb7f8c63d7f7a8b41de8f" and authenticated using password "TesTEr16843/!@00"
         Then the new account "AccountPrivate" is added
 
-    @mayfail
-    # FIXME all wallet tests are broken. Issue #9498
 	Scenario: The user generates a new account from wallet and deletes it
         When an account named "AccountGenerated" is generated and authenticated using password "TesTEr16843/!@00"
         Then the new account "AccountGenerated" is added
         When the user deletes the account "AccountGenerated" with password "TesTEr16843/!@00"
         Then the account "AccountGenerated" is not in the list of accounts
 
-    @mayfail
-    # FIXME all wallet tests are broken. Issue #9498
 	Scenario: The user can import seed phrase
         When an account named "AccountSeed" is added via imported seed phrase "pelican chief sudden oval media rare swamp elephant lawsuit wheat knife initial" and authenticated using password "TesTEr16843/!@00"
         Then the new account "AccountSeed" is added
 
-    @mayfail
-    # FIXME all wallet tests are broken. Issue #9498
     Scenario: The user edits the default account
         Given the user opens app settings screen
         And the user opens the wallet settings
@@ -54,8 +46,6 @@ Feature: Status Desktop Wallet
         And the user edits default account to "Default" name and "#FFCA0F" color
         Then the default account is updated to be named "DefaultStatus account" with color "#FFCA0F"
 
-    @mayfail
-    # FIXME all wallet tests are broken. Issue #9498
     Scenario Outline: The user can manage a saved address
         When the user adds a saved address named "<name>" and address "<address>"
         And the user toggles favourite for the saved address with name "<name>"

--- a/ui/imports/shared/popups/keycard/KeycardPopup.qml
+++ b/ui/imports/shared/popups/keycard/KeycardPopup.qml
@@ -63,6 +63,10 @@ StatusModal {
 
     contentItem: StatusScrollView {
         id: scrollView
+
+        implicitWidth: contentWidth + leftPadding + rightPadding
+        implicitHeight: contentHeight + topPadding + bottomPadding
+
         ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
         width: parent.width
         height: {


### PR DESCRIPTION
### What does the PR do

Fixes following the improvements brought with this change: https://github.com/status-im/status-desktop/pull/9469

- The user can manage and observe a watch-only account
  - I don't understand how it did work, given that the address was hidden. The `StatusScrollView` changes were probably optimized and made the invisible items not found. 
- The user imports a private key
- The user generates a new account from wallet and deletes it
- [x] The user can import seed phrase
  - The placeholder used to identify seed input might not work for scrolling!?
- [x] The user edits the default account
- [x] The user can manage a saved address
### Affected areas

Wallet