### PR TITLE
fix: pasting a user's profile link in the ad-hoc chat search

### DIFF
--- a/ui/app/AppLayouts/Chat/ChatLayout.qml
+++ b/ui/app/AppLayouts/Chat/ChatLayout.qml
@@ -11,10 +11,8 @@ import "popups/community"
 StackLayout {
     id: root
 
-    property var contactsStore
-    property RootStore rootStore: RootStore {
-        contactsStore: root.contactsStore
-    }
+    property RootStore rootStore
+    readonly property var contactsStore: rootStore.contactsStore
 
     property alias chatView: chatView
     signal importCommunityClicked()

--- a/ui/app/AppLayouts/Chat/stores/qmldir
+++ b/ui/app/AppLayouts/Chat/stores/qmldir
@@ -2,3 +2,4 @@ StickerData 1.0 StickerData.qml
 StickerPackData 1.0 StickerPackData.qml
 StickersStore 1.0 StickersStore.qml
 CommunitiesStore 1.0 CommunitiesStore.qml
+RootStore 1.0 RootStore.qml

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -32,6 +32,7 @@ import StatusQ.Core 0.1
 
 import AppLayouts.Browser.stores 1.0 as BrowserStores
 import AppLayouts.stores 1.0
+import AppLayouts.Chat.stores 1.0 as ChatStores
 
 import SortFilterProxyModel 0.2
 
@@ -44,6 +45,11 @@ Item {
 
     property alias appLayout: appLayout
     property RootStore rootStore: RootStore {}
+    property var rootChatStore: ChatStores.RootStore {
+        contactsStore: appMain.rootStore.contactStore
+        emojiReactionsModel: appMain.rootStore.emojiReactionsModel
+        openCreateChat: createChatView.opened
+    }
     property ActivityCenterStore activityCenterStore: ActivityCenterStore {}
     // set from main.qml
     property var sysPalette
@@ -215,7 +221,7 @@ Item {
         active: appMain.rootStore.mainModuleInst.chatsLoaded
         sourceComponent: StatusStickersPopup {
             id: statusStickersPopup
-            store: personalChatLayoutLoader.item.rootStore
+            store: appMain.rootChatStore
         }
     }
 
@@ -755,12 +761,10 @@ Item {
                             ChatLayout {
                                 id: chatLayoutContainer
 
+                                rootStore: appMain.rootChatStore
+
                                 chatView.emojiPopup: statusEmojiPopup
                                 chatView.stickersPopup: statusStickersPopupLoader.item
-
-                                contactsStore: appMain.rootStore.contactStore
-                                rootStore.emojiReactionsModel: appMain.rootStore.emojiReactionsModel
-                                rootStore.openCreateChat: createChatView.opened
 
                                 chatView.onProfileButtonClicked: {
                                     Global.changeAppSectionBySectionType(Constants.appSection.profile);
@@ -857,9 +861,7 @@ Item {
                                         chatView.emojiPopup: statusEmojiPopup
                                         chatView.stickersPopup: statusStickersPopupLoader.item
 
-                                        contactsStore: appMain.rootStore.contactStore
-                                        rootStore.emojiReactionsModel: appMain.rootStore.emojiReactionsModel
-                                        rootStore.openCreateChat: createChatView.opened
+                                        rootStore: appMain.rootChatStore
 
                                         chatView.onProfileButtonClicked: {
                                             Global.changeAppSectionBySectionType(Constants.appSection.profile);
@@ -899,7 +901,7 @@ Item {
                             anchors.rightMargin - anchors.leftMargin : 0
 
                     sourceComponent: CreateChatView {
-                        rootStore: personalChatLayoutLoader.item.rootStore
+                        rootStore: appMain.rootChatStore
                         emojiPopup: statusEmojiPopup
                         stickersPopup: statusStickersPopupLoader.item
                     }
@@ -916,7 +918,7 @@ Item {
                 x: parent.width - width - Style.current.smallPadding
                 y: parent.y + _buttonSize
                 height: appView.height - _buttonSize * 2
-                store: personalChatLayoutLoader.item.rootStore
+                store: appMain.rootChatStore
                 activityCenterStore: appMain.activityCenterStore
             }
         }


### PR DESCRIPTION
... doesn't work in the community section

Extract the `Chat.RootStore` as a toplevel/shared property and pass it down to ChatLayouts, instead of cross referencing it between different components. This was also problematic since the ChatLayouts now live inside a Loader, so it's more appropriate to refer to the `Chat.RootStore` directly, instead of
`personalChatLayoutLoader.item.rootStore`, since the `personalChatLayoutLoader.item` might not be visible (due to it being inside a Loader and a StackLayout) or it might even be a different component (`loadingStateComponent` or `errorStateComponent`).

This also caused similar problems for other components, such as ActivityCenterPopup or StatusStickersPopup.

Fixes #9513

### Affected areas

AppMain, ChatLayout

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![image](https://user-images.githubusercontent.com/5377645/217948820-8ebdeeb1-5327-4a79-b2aa-981477dc1ca8.png)

