### PR TITLE
refactor(chat-model): simplify chat model and put category as an Item

### DIFF
--- a/src/app/modules/main/chat_section/io_interface.nim
+++ b/src/app/modules/main/chat_section/io_interface.nim
@@ -130,9 +130,6 @@ method onReorderChat*(self: AccessInterface, chattId: string, position: int, new
 method onReorderCategory*(self: AccessInterface, catId: string, position: int) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method onCommunityCategoryChannelChanged*(self: AccessInterface, chatId: string, newCategoryIdForChat: string) {.base.} =
-  raise newException(ValueError, "No implementation available")
-
 method onCommunityCategoryCreated*(self: AccessInterface, category: Category, chats: seq[ChatDto]) {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/chat_section/item.nim
+++ b/src/app/modules/main/chat_section/item.nim
@@ -27,7 +27,6 @@ type
     active: bool
     position: int
     categoryId: string
-    categoryName: string
     categoryPosition: int
     categoryOpened: bool
     highlight: bool
@@ -51,7 +50,6 @@ proc initItem*(
     active: bool,
     position: int,
     categoryId: string = "",
-    categoryName: string = "",
     categoryPosition: int = -1,
     colorId: int = 0,
     colorHash: seq[ColorHashSegment] = @[],
@@ -80,7 +78,6 @@ proc initItem*(
   result.active = active
   result.position = position
   result.categoryId = categoryId
-  result.categoryName = categoryName
   result.categoryPosition = categoryPosition
   result.highlight = highlight
   result.categoryOpened = categoryOpened
@@ -106,7 +103,6 @@ proc `$`*(self: Item): string =
     active: {$self.active},
     position: {$self.position},
     categoryId: {$self.categoryId},
-    categoryName: {$self.categoryName},
     categoryPosition: {$self.categoryPosition},
     highlight: {$self.highlight},
     categoryOpened: {$self.categoryOpened},
@@ -132,7 +128,6 @@ proc toJsonNode*(self: Item): JsonNode =
     "active": self.active,
     "position": self.position,
     "categoryId": self.categoryId,
-    "categoryName": self.categoryName,
     "categoryPosition": self.categoryPosition,
     "highlight": self.highlight,
     "categoryOpened": self.categoryOpened,
@@ -235,12 +230,6 @@ proc categoryId*(self: Item): string =
 
 proc `categoryId=`*(self: var Item, value: string) =
   self.categoryId = value
-
-proc categoryName*(self: Item): string =
-  self.categoryName
-
-proc `categoryName=`*(self: var Item, value: string) =
-  self.categoryName = value
 
 proc categoryPosition*(self: Item): int =
   self.categoryPosition

--- a/src/app/modules/main/chat_section/view.nim
+++ b/src/app/modules/main/chat_section/view.nim
@@ -153,12 +153,6 @@ QtObject:
       return
     return $jsonObj
 
-  proc getItemPartOfCategoryAsJsonById*(self: View, categoryId: string): string {.slot.} =
-    let jsonObj = self.model.getItemPartOfCategoryAsJsonById(categoryId)
-    if jsonObj == nil or jsonObj.kind != JObject:
-      return
-    return $jsonObj
-
   proc muteChat*(self: View, chatId: string) {.slot.} =
     self.delegate.muteChat(chatId)
 

--- a/ui/StatusQ/src/StatusQ/Components/StatusChatList.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusChatList.qml
@@ -39,248 +39,240 @@ Item {
         model: root.model
         spacing: 0
         interactive: height !== contentHeight
-        section.property: "categoryId"
-        section.criteria: ViewSection.FullString
 
-        section.delegate: Loader {
-            id: statusChatListCategoryItemLoader
-            active: !!section
+        delegate: Loader {
+            id: chatLoader
 
-            required property string section
-
-            sourceComponent: StatusChatListCategoryItem {
-                id: statusChatListCategoryItem
-                
-                function setupPopup() {
-                    categoryPopupMenuSlot.item.categoryId = statusChatListCategoryItemLoader.section
+            sourceComponent: {
+                if (model.isCategory) {
+                     return categoryItemComponent
                 }
-
-                function toggleCategory() {
-                    root.model.sourceModel.changeCategoryOpened(statusChatListCategoryItemLoader.section, !opened)
-                    opened = root.model.sourceModel.getCategoryOpenedForCategoryId(statusChatListCategoryItemLoader.section)
-                }
-
-                Connections {
-                    enabled: categoryPopupMenuSlot.active && statusChatListCategoryItem.highlighted
-                    target: categoryPopupMenuSlot.item
-                    function onClosed() {
-                        statusChatListCategoryItem.highlighted = false
-                        statusChatListCategoryItem.menuButton.highlighted = false
+                return channelItemComponent
+            }
+            
+            Component {
+                id: categoryItemComponent
+                StatusChatListCategoryItem {
+                    id: statusChatListCategoryItem
+                    
+                    function setupPopup() {
+                        categoryPopupMenuSlot.item.categoryItem = model
                     }
-                }
 
-                title: root.model.sourceModel.getCategoryNameForCategoryId(statusChatListCategoryItemLoader.section)
-
-                opened: root.model.sourceModel.getCategoryOpenedForCategoryId(statusChatListCategoryItemLoader.section)
-
-                sensor.pressAndHoldInterval: 150
-                propagateTitleClicks: true // title click is handled as a normal click (fallthru)
-                showAddButton: showCategoryActionButtons
-                showMenuButton: !!root.popupMenu
-                highlighted: false//statusChatListCategory.dragged // FIXME DND
-
-                hasUnreadMessages: root.model.sourceModel.getCategoryHasUnreadMessages(statusChatListCategoryItemLoader.section)
-                Connections {
-                    target: root.model.sourceModel
-                    function onCategoryHasUnreadMessagesChanged(categoryId: string, hasUnread: bool) {
-                        if (categoryId === statusChatListCategoryItemLoader.section) {
-                            statusChatListCategoryItem.hasUnreadMessages = hasUnread
+                    Connections {
+                        enabled: categoryPopupMenuSlot.active && statusChatListCategoryItem.highlighted
+                        target: categoryPopupMenuSlot.item
+                        function onClosed() {
+                            statusChatListCategoryItem.highlighted = false
+                            statusChatListCategoryItem.menuButton.highlighted = false
                         }
                     }
-                }
 
-                onClicked: {
-                    if (sensor.enabled) {
+                    title: model.name
+
+                    opened: model.categoryOpened
+
+                    sensor.pressAndHoldInterval: 150
+                    propagateTitleClicks: true // title click is handled as a normal click (fallthru)
+                    showAddButton: showCategoryActionButtons
+                    showMenuButton: !!root.onPopupMenuChanged
+                    highlighted: false//statusChatListCategory.dragged // FIXME DND
+                    
+                    hasUnreadMessages: model.hasUnreadMessages
+                    
+                    onClicked: {
+                        if (!sensor.enabled) {
+                            return
+                        }
                         if (mouse.button === Qt.RightButton && showCategoryActionButtons && !!root.categoryPopupMenu) {
                             statusChatListCategoryItem.setupPopup()
                             highlighted = true;
                             categoryPopupMenuSlot.item.popup()
                         } else if (mouse.button === Qt.LeftButton) {
-                            toggleCategory()
+                            root.model.sourceModel.changeCategoryOpened(model.categoryId, !statusChatListCategoryItem.opened)
                         }
                     }
+                    onToggleButtonClicked: root.model.sourceModel.changeCategoryOpened(model.categoryId, !statusChatListCategoryItem.opened)
+                    onMenuButtonClicked: {
+                        statusChatListCategoryItem.setupPopup()
+                        highlighted = true
+                        menuButton.highlighted = true
+                        let p = menuButton.mapToItem(statusChatListCategoryItem, menuButton.x, menuButton.y)
+                        let menuWidth = categoryPopupMenuSlot.item.width
+                        categoryPopupMenuSlot.item.popup()
+                    }
+                    onAddButtonClicked: {
+                        root.categoryAddButtonClicked(categoryId)
+                    }
                 }
-                onToggleButtonClicked: toggleCategory()
-                onMenuButtonClicked: {
-                    statusChatListCategoryItem.setupPopup()
-                    highlighted = true
-                    menuButton.highlighted = true
-                    let p = menuButton.mapToItem(statusChatListCategoryItem, menuButton.x, menuButton.y)
-                    let menuWidth = categoryPopupMenuSlot.item.width
-                    categoryPopupMenuSlot.item.popup()
-                }
-                onAddButtonClicked: {
-                    root.categoryAddButtonClicked(categoryId)
-                }
+                
             }
-        }
+            
+            Component {
+                id: channelItemComponent
+                QC.Control {
+                    id: draggable
+                    objectName: model.name
+                    width: root.width
+                    height: model.categoryOpened ? statusChatListItem.height : 0
+                    visible: height
+                    verticalPadding: 2
 
-        delegate: Loader {
-            id: chatLoader
-            active: model.type !== d.chatTypeCategory
-            height: active && item ? item.height : 0
-            visible: height
+                    property alias chatListItem: statusChatListItem
 
-            sourceComponent: QC.Control {
-                id: draggable
-                objectName: model.name
-                width: root.width
-                height: model.categoryOpened ? statusChatListItem.height : 0
-                verticalPadding: 2
+                    contentItem: MouseArea {
+                        id: dragSensor
 
-                property alias chatListItem: statusChatListItem
+                        anchors.fill: parent
+                        cursorShape: active ? Qt.ClosedHandCursor : Qt.PointingHandCursor
+                        hoverEnabled: true
+                        enabled: root.draggableItems
 
-                contentItem: MouseArea {
-                    id: dragSensor
+                        property bool active: false
+                        property real startY: 0
+                        property real startX: 0
 
-                    anchors.fill: parent
-                    cursorShape: active ? Qt.ClosedHandCursor : Qt.PointingHandCursor
-                    hoverEnabled: true
-                    enabled: root.draggableItems
+                        drag.target: draggedListItemLoader.item
+                        drag.filterChildren: true
 
-                    property bool active: false
-                    property real startY: 0
-                    property real startX: 0
-
-                    drag.target: draggedListItemLoader.item
-                    drag.filterChildren: true
-
-                    onPressed: {
-                        startY = mouseY
-                        startX = mouseX
-                    }
-                    onPressAndHold: active = true
-                    onReleased: {
-                        if (active && d.destinationPosition !== -1 && statusChatListItem.originalOrder !== d.destinationPosition) {
-                            root.chatItemReordered(statusChatListItem.chatId, statusChatListItem.originalOrder, d.destinationPosition)
+                        onPressed: {
+                            startY = mouseY
+                            startX = mouseX
                         }
-                        active = false
-                    }
-                    onMouseYChanged: {
-                        if ((Math.abs(startY - mouseY) > 1) && pressed) {
-                            active = true
+                        onPressAndHold: active = true
+                        onReleased: {
+                            if (active && d.destinationPosition !== -1 && statusChatListItem.originalOrder !== d.destinationPosition) {
+                                root.chatItemReordered(statusChatListItem.chatId, statusChatListItem.originalOrder, d.destinationPosition)
+                            }
+                            active = false
                         }
-                    }
-                    onMouseXChanged: {
-                        if ((Math.abs(startX - mouseX) > 1) && pressed) {
-                            active = true
+                        onMouseYChanged: {
+                            if ((Math.abs(startY - mouseY) > 1) && pressed) {
+                                active = true
+                            }
                         }
-                    }
-                    onActiveChanged: d.destinationPosition = -1
+                        onMouseXChanged: {
+                            if ((Math.abs(startX - mouseX) > 1) && pressed) {
+                                active = true
+                            }
+                        }
+                        onActiveChanged: d.destinationPosition = -1
 
-                    StatusChatListItem {
-                        id: statusChatListItem
+                        StatusChatListItem {
+                            id: statusChatListItem
 
-                        width: parent.width
-                        opacity: dragSensor.active ? 0.0 : 1.0
-                        originalOrder: model.position
-                        chatId: model.itemId
-                        categoryId: model.categoryId
-                        name: model.name
-                        type: !!model.type ? model.type : StatusChatListItem.Type.CommunityChat
-                        muted: model.muted
-                        hasUnreadMessages: model.hasUnreadMessages
-                        notificationsCount: model.notificationsCount
-                        highlightWhenCreated: !!model.highlight
-                        selected: (model.active && root.highlightItem)
-                        asset.emoji: !!model.emoji ? model.emoji : ""
-                        asset.color: !!model.color ? model.color : Theme.palette.userCustomizationColors[model.colorId]
-                        asset.isImage: model.icon.includes("data")
-                        asset.name: model.icon
-                        ringSettings.ringSpecModel: type === StatusChatListItem.Type.OneToOneChat && root.isEnsVerified(chatId) ? undefined : model.colorHash
-                        onlineStatus: !!model.onlineStatus ? model.onlineStatus : StatusChatListItem.OnlineStatus.Inactive
+                            width: parent.width
+                            opacity: dragSensor.active ? 0.0 : 1.0
+                            originalOrder: model.position
+                            chatId: model.itemId
+                            categoryId: model.categoryId
+                            name: model.name
+                            type: model.type ?? StatusChatListItem.Type.CommunityChat
+                            muted: model.muted
+                            hasUnreadMessages: model.hasUnreadMessages
+                            notificationsCount: model.notificationsCount
+                            highlightWhenCreated: !!model.highlight
+                            selected: (model.active && root.highlightItem)
+                            asset.emoji: !!model.emoji ? model.emoji : ""
+                            asset.color: !!model.color ? model.color : Theme.palette.userCustomizationColors[model.colorId]
+                            asset.isImage: model.icon.includes("data")
+                            asset.name: model.icon
+                            ringSettings.ringSpecModel: type === StatusChatListItem.Type.OneToOneChat && root.isEnsVerified(chatId) ? undefined : model.colorHash
+                            onlineStatus: !!model.onlineStatus ? model.onlineStatus : StatusChatListItem.OnlineStatus.Inactive
 
-                        sensor.cursorShape: dragSensor.cursorShape
+                            sensor.cursorShape: dragSensor.cursorShape
 
-                        onClicked: {
-                            highlightWhenCreated = false
+                            onClicked: {
+                                highlightWhenCreated = false
 
-                            if (mouse.button === Qt.RightButton && !!root.popupMenu) {
-                                statusChatListItem.highlighted = true
+                                if (mouse.button === Qt.RightButton && !!root.popupMenu) {
+                                    statusChatListItem.highlighted = true
 
-                                let originalOpenHandler = popupMenuSlot.item.openHandler
-                                let originalCloseHandler = popupMenuSlot.item.closeHandler
+                                    const originalOpenHandler = popupMenuSlot.item.openHandler
+                                    const originalCloseHandler = popupMenuSlot.item.closeHandler
 
-                                popupMenuSlot.item.openHandler = function () {
-                                    if (!!originalOpenHandler) {
-                                        originalOpenHandler(statusChatListItem.chatId)
+                                    popupMenuSlot.item.openHandler = function () {
+                                        if (!!originalOpenHandler) {
+                                            originalOpenHandler(statusChatListItem.chatId)
+                                        }
                                     }
+
+                                    popupMenuSlot.item.closeHandler = function () {
+                                        if (statusChatListItem) {
+                                            statusChatListItem.highlighted = false
+                                        }
+                                        if (!!originalCloseHandler) {
+                                            originalCloseHandler()
+                                        }
+                                    }
+
+                                    const p = statusChatListItem.mapToItem(root, mouse.x, mouse.y)
+
+                                    popupMenuSlot.item.popup(p.x + 4, p.y + 6)
+                                    popupMenuSlot.item.openHandler = originalOpenHandler
+                                    return
                                 }
-
-                                popupMenuSlot.item.closeHandler = function () {
-                                    if (statusChatListItem) {
-                                        statusChatListItem.highlighted = false
-                                    }
-                                    if (!!originalCloseHandler) {
-                                        originalCloseHandler()
-                                    }
+                                if (!statusChatListItem.selected) {
+                                    root.chatItemSelected(statusChatListItem.categoryId, statusChatListItem.chatId)
                                 }
-
-                                let p = statusChatListItem.mapToItem(root, mouse.x, mouse.y)
-
-                                popupMenuSlot.item.popup(p.x + 4, p.y + 6)
-                                popupMenuSlot.item.openHandler = originalOpenHandler
-                                return
                             }
-                            if (!statusChatListItem.selected) {
-                                root.chatItemSelected(statusChatListItem.categoryId, statusChatListItem.chatId)
-                            }
+                            onUnmute: root.chatItemUnmuted(statusChatListItem.chatId)
                         }
-                        onUnmute: root.chatItemUnmuted(statusChatListItem.chatId)
                     }
-                }
 
-                DropArea {
-                    id: dropArea
-                    width: dragSensor.active ? 0 : parent.width
-                    height: dragSensor.active ? 0 : parent.height
-                    keys: ["chat-item-category-" + statusChatListItem.categoryId]
+                    DropArea {
+                        id: dropArea
+                        width: dragSensor.active ? 0 : parent.width
+                        height: dragSensor.active ? 0 : parent.height
+                        keys: ["chat-item-category-" + statusChatListItem.categoryId]
 
-                    onEntered: reorderDelay.start()
+                        onEntered: reorderDelay.start()
 
-                    Timer {
-                        id: reorderDelay
-                        interval: 100
-                        repeat: false
-                        onTriggered: {
-                            if (dropArea.containsDrag) {
-                                d.destinationPosition = root.model.get(draggable.DelegateModel.itemsIndex).position
-                                statusChatListItems.items.move(dropArea.drag.source.DelegateModel.itemsIndex, draggable.DelegateModel.itemsIndex)
+                        Timer {
+                            id: reorderDelay
+                            interval: 100
+                            repeat: false
+                            onTriggered: {
+                                if (dropArea.containsDrag) {
+                                    d.destinationPosition = root.model.get(draggable.DelegateModel.itemsIndex).position
+                                    statusChatListItems.items.move(dropArea.drag.source.DelegateModel.itemsIndex, draggable.DelegateModel.itemsIndex)
+                                }
                             }
                         }
                     }
-                }
 
-                Loader {
-                    id: draggedListItemLoader
-                    active: dragSensor.active
-                    sourceComponent: StatusChatListItem {
-                        property var globalPosition: Utils.getAbsolutePosition(draggable)
-                        parent: QC.Overlay.overlay
-                        sensor.cursorShape: dragSensor.cursorShape
-                        Drag.active: dragSensor.active
-                        Drag.hotSpot.x: width / 2
-                        Drag.hotSpot.y: height / 2
-                        Drag.keys: ["chat-item-category-" + categoryId]
-                        Drag.source: draggable
+                    Loader {
+                        id: draggedListItemLoader
+                        active: dragSensor.active
+                        sourceComponent: StatusChatListItem {
+                            property var globalPosition: Utils.getAbsolutePosition(draggable)
+                            parent: QC.Overlay.overlay
+                            sensor.cursorShape: dragSensor.cursorShape
+                            Drag.active: dragSensor.active
+                            Drag.hotSpot.x: width / 2
+                            Drag.hotSpot.y: height / 2
+                            Drag.keys: ["chat-item-category-" + categoryId]
+                            Drag.source: draggable
 
-                        Component.onCompleted: {
-                            x = globalPosition.x
-                            y = globalPosition.y
+                            chatId: draggable.chatListItem.chatId
+                            categoryId: draggable.chatListItem.categoryId
+                            name: draggable.chatListItem.name
+                            type: draggable.chatListItem.type
+                            muted: draggable.chatListItem.muted
+                            dragged: true
+                            hasUnreadMessages: model.hasUnreadMessages
+                            notificationsCount: model.notificationsCount
+                            selected: draggable.chatListItem.selected
+
+                            asset.color: draggable.chatListItem.asset.color
+                            asset.imgIsIdenticon: draggable.chatListItem.asset.imgIsIdenticon
+                            asset.name: draggable.chatListItem.asset.name
+
+                            Component.onCompleted: {
+                                x = globalPosition.x
+                                y = globalPosition.y
+                            }
                         }
-                        chatId: draggable.chatListItem.chatId
-                        categoryId: draggable.chatListItem.categoryId
-                        name: draggable.chatListItem.name
-                        type: draggable.chatListItem.type
-                        muted: draggable.chatListItem.muted
-                        dragged: true
-                        hasUnreadMessages: model.hasUnreadMessages
-                        notificationsCount: model.notificationsCount
-                        selected: draggable.chatListItem.selected
-
-                        asset.color: draggable.chatListItem.asset.color
-                        asset.imgIsIdenticon: draggable.chatListItem.asset.imgIsIdenticon
-                        asset.name: draggable.chatListItem.asset.name
                     }
                 }
             }
@@ -303,7 +295,6 @@ Item {
         id: d
 
         property int destinationPosition: -1
-        readonly property int chatTypeCategory: -1
     }
 
     Loader {

--- a/ui/app/AppLayouts/Chat/views/CommunityColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/CommunityColumnView.qml
@@ -254,35 +254,16 @@ Item {
 
             categoryPopupMenu: StatusMenu {
 
-                property var itemWithCategory
-                property string categoryId
-
-                openHandler: function () {
-                    let jsonObj = root.communitySectionModule.getItemPartOfCategoryAsJsonById(categoryId)
-                    try {
-                        let obj = JSON.parse(jsonObj)
-                        if (obj.error) {
-                            console.error("error parsing chat item json object, id: ", categoryId, " error: ", obj.error)
-                            close()
-                            return
-                        }
-                        itemWithCategory = obj
-                    } catch (e) {
-                        console.error("error parsing chat item json object, id: ", categoryId, " error: ", e)
-                        close()
-                        return
-                    }
-                }
+                property var categoryItem
 
                 StatusAction {
-                    // TODO pass categoryMuted to Item
-                    text: itemWithCategory.muted ? qsTr("Unmute category") : qsTr("Mute category")
+                    text: categoryItem.muted ? qsTr("Unmute category") : qsTr("Mute category")
                     icon.name: "notification"
                     onTriggered: {
-                        if (itemWithCategory.muted) {
-                            root.communitySectionModule.unmuteCategory(itemWithCategory.categoryId)
+                        if (categoryItem.muted) {
+                            root.communitySectionModule.unmuteCategory(categoryItem.itemId)
                         } else {
-                            root.communitySectionModule.muteCategory(itemWithCategory.categoryId)
+                            root.communitySectionModule.muteCategory(categoryItem.itemId)
                         }
                     }
                 }
@@ -296,8 +277,8 @@ Item {
                        Global.openPopup(createCategoryPopup, {
                            isEdit: true,
                            channels: [],
-                           categoryId: itemWithCategory.categoryId,
-                           categoryName: itemWithCategory.categoryName
+                           categoryId: categoryItem.itemId,
+                           categoryName: categoryItem.name
                        })
                     }
                 }
@@ -314,10 +295,10 @@ Item {
                     type: StatusAction.Type.Danger
                     onTriggered: {
                         Global.openPopup(deleteCategoryConfirmationDialogComponent, {
-                            title: qsTr("Delete %1 category").arg(itemWithCategory.categoryName),
+                            title: qsTr("Delete %1 category").arg(categoryItem.name),
                             confirmationText: qsTr("Are you sure you want to delete %1 category? Channels inside the category won't be deleted.")
-                                .arg(itemWithCategory.categoryName),
-                            categoryId: itemWithCategory.categoryId
+                                .arg(categoryItem.name),
+                            categoryId: categoryItem.itemId
                         })
                     }
                 }
@@ -327,6 +308,7 @@ Item {
                 id: chatContextMenuView
                 emojiPopup: root.emojiPopup
 
+                // TODO pass the chatModel in its entirety instead of fetching the JSOn using just the id
                 openHandler: function (id) {
                     try {
                         let jsonObj = root.communitySectionModule.getItemAsJson(id)


### PR DESCRIPTION
Fixes #9494

Simplifies the chat model by putting categories inside the model as an Item. We use the `type` to differentiate chats and categories, that way we can choose the right delegate.

To test: if everything with regards to chats, channels and categories work as expected