### PR TITLE
fix: profile preview doesn't show entire profile

### DIFF
--- a/ui/imports/shared/views/ProfileDialogView.qml
+++ b/ui/imports/shared/views/ProfileDialogView.qml
@@ -547,7 +547,7 @@ Pane {
         StatusScrollView {
             id: scrollView
             Layout.fillWidth: true
-            Layout.fillHeight: true
+            Layout.preferredHeight: contentHeight + topPadding + bottomPadding
             Layout.leftMargin: -column.anchors.leftMargin
             Layout.rightMargin: -column.anchors.rightMargin
             Layout.topMargin: -column.spacing


### PR DESCRIPTION
rectifies one of the StatusScrollView behavior changes done recently

Fixes #9519

### Affected areas

ProfileDialogView

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![image](https://user-images.githubusercontent.com/5377645/218070835-45c99da5-f79d-4372-a667-dc6fdbca7006.png)
