### PR TITLE
ci(e2e): Changed UNSTABLE state to be considered as a failure

### DIFF
--- a/ci/Jenkinsfile.e2e
+++ b/ci/Jenkinsfile.e2e
@@ -143,8 +143,7 @@ pipeline {
             testSuite: "${WORKSPACE}/test/ui-test/testSuites/*",
           ])
           print("Squish run result: ${result}")
-          /* Ignore UNSTABLE caused by retried tests. */
-          if (!['SUCCESS', 'UNSTABLE'].contains(result)) {
+          if (!['SUCCESS'].contains(result)) {
             throw new Exception('Squish run failed!')
           }
         } }


### PR DESCRIPTION
### What does the PR do

Changed UNSTABLE state to be considered as a failure since UNSTABLE state means some tests have failed during the retries but also in the last retry so, it contemplates real failures too.

### Affected areas

jenkins file for e2e tests