### PR TITLE
refactor(devices): make loading devices lazy load and async

### DIFF
--- a/src/app/boot/app_controller.nim
+++ b/src/app/boot/app_controller.nim
@@ -205,7 +205,7 @@ proc newAppController*(statusFoundation: StatusFoundation): AppController =
   result.privacyService = privacy_service.newService(statusFoundation.events, result.settingsService,
   result.accountsService)
   result.savedAddressService = saved_address_service.newService(statusFoundation.events, result.networkService)
-  result.devicesService = devices_service.newService(statusFoundation.events, result.settingsService)
+  result.devicesService = devices_service.newService(statusFoundation.events, statusFoundation.threadpool, result.settingsService)
   result.mailserversService = mailservers_service.newService(statusFoundation.events, statusFoundation.threadpool,
     result.settingsService, result.nodeConfigurationService, statusFoundation.fleetConfiguration)
   result.nodeService = node_service.newService(statusFoundation.events, result.settingsService, result.nodeConfigurationService)

--- a/src/app/modules/main/profile_section/devices/controller.nim
+++ b/src/app/modules/main/profile_section/devices/controller.nim
@@ -29,6 +29,13 @@ proc delete*(self: Controller) =
   discard
 
 proc init*(self: Controller) =
+  self.events.on(SIGNAL_DEVICES_LOADED) do(e: Args):
+    var args = DevicesArg(e)
+    self.delegate.onDevicesLoaded(args.devices)
+
+  self.events.on(SIGNAL_ERROR_LOADING_DEVICES) do(e: Args):
+    self.delegate.onDevicesLoadingErrored()
+
   self.events.on(SIGNAL_UPDATE_DEVICE) do(e: Args):
     var args = UpdateDeviceArgs(e)
     self.delegate.updateOrAddDevice(args.deviceId, args.name, args.enabled)
@@ -36,11 +43,8 @@ proc init*(self: Controller) =
 proc getMyInstallationId*(self: Controller): string =
   return self.settingsService.getInstallationId()
 
-proc getAllDevices*(self: Controller): seq[DeviceDto] =
-  return self.devicesService.getAllDevices()
-
-proc isDeviceSetup*(self: Controller): bool =
-  return self.devicesService.isDeviceSetup()
+proc asyncLoadDevices*(self: Controller) =
+  self.devicesService.asyncLoadDevices()
 
 proc setDeviceName*(self: Controller, name: string) =
   self.devicesService.setDeviceName(name)

--- a/src/app/modules/main/profile_section/devices/io_interface.nim
+++ b/src/app/modules/main/profile_section/devices/io_interface.nim
@@ -1,4 +1,6 @@
 import NimQml
+import ../../../../../app_service/service/devices/service as devices_service
+
 
 type
   AccessInterface* {.pure inheritable.} = ref object of RootObj
@@ -21,7 +23,16 @@ method updateOrAddDevice*(self: AccessInterface, installationId: string, name: s
 method viewDidLoad*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method isDeviceSetup*(self: AccessInterface): bool {.base.} =
+method getMyInstallationId*(self: AccessInterface): string {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method onDevicesLoaded*(self: AccessInterface, allDevices: seq[DeviceDto]) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method onDevicesLoadingErrored*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method loadDevices*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method setDeviceName*(self: AccessInterface, name: string) {.base.} =

--- a/src/app/modules/main/profile_section/devices/model.nim
+++ b/src/app/modules/main/profile_section/devices/model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables
+import NimQml, Tables, sequtils
 import item
 
 type
@@ -101,3 +101,6 @@ QtObject:
     self.items[i].name = name
     self.items[i].enabled = enabled
     self.dataChanged(first, last, @[ModelRole.Name.int, ModelRole.Enabled.int])
+
+  proc getIsDeviceSetup*(self: Model, installationId: string): bool =
+    return anyIt(self.items, it.installationId == installationId and it.name != "")

--- a/src/app/modules/main/profile_section/devices/view.nim
+++ b/src/app/modules/main/profile_section/devices/view.nim
@@ -7,6 +7,8 @@ QtObject:
       delegate: io_interface.AccessInterface
       model: Model
       modelVariant: QVariant
+      devicesLoading: bool
+      devicesLoadingError: bool
 
   proc delete*(self: View) =
     self.model.delete
@@ -17,6 +19,8 @@ QtObject:
     new(result, delete)
     result.QObject.setup
     result.delegate = delegate
+    result.devicesLoading = false
+    result.devicesLoadingError = false
     result.model = newModel()
     result.modelVariant = newQVariant(result.model)
 
@@ -35,13 +39,37 @@ QtObject:
 
   proc deviceSetupChanged*(self: View) {.signal.}
   proc getIsDeviceSetup*(self: View): bool {.slot} =
-    return self.delegate.isDeviceSetup()
+    return self.model.getIsDeviceSetup(self.delegate.getMyInstallationId())
   QtProperty[bool] isDeviceSetup:
     read = getIsDeviceSetup
     notify = deviceSetupChanged
 
-  proc emitDeviceSetupChangedSignal*(self: View) =
-    self.deviceSetupChanged()
+  proc devicesLoadingChanged*(self: View) {.signal.}
+  proc setDevicesLoading*(self: View, value: bool) =
+    if self.devicesLoading == value:
+      return
+    self.devicesLoading = value
+    self.devicesLoadingChanged()
+  proc getDevicesLoading*(self: View): bool {.slot} =
+    return self.devicesLoading
+  QtProperty[bool] devicesLoading:
+    read = getDevicesLoading
+    notify = devicesLoadingChanged
+
+  proc devicesLoadingErrorChanged*(self: View) {.signal.}
+  proc setDevicesLoadingError*(self: View, value: bool) =
+    if self.devicesLoadingError == value:
+      return
+    self.devicesLoadingError = value
+    self.devicesLoadingErrorChanged()
+  proc getDevicesLoadingError*(self: View): bool {.slot} =
+    return self.devicesLoadingError
+  QtProperty[bool] devicesLoadingError:
+    read = getDevicesLoadingError
+    notify = devicesLoadingErrorChanged
+
+  proc loadDevices*(self: View) {.slot.} =
+    self.delegate.loadDevices()
 
   proc setName*(self: View, deviceName: string) {.slot.} =
     self.delegate.setDeviceName(deviceName)

--- a/src/app_service/service/devices/async_tasks.nim
+++ b/src/app_service/service/devices/async_tasks.nim
@@ -1,0 +1,8 @@
+type
+  AsyncLoadDevicesTaskArg = ref object of QObjectTaskArg
+
+const asyncLoadDevicesTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+  let arg = decode[AsyncLoadDevicesTaskArg](argEncoded)
+  let response = status_installations.getOurInstallations()
+
+  arg.finish(response)

--- a/src/app_service/service/devices/service.nim
+++ b/src/app_service/service/devices/service.nim
@@ -1,5 +1,7 @@
 import NimQml, json, sequtils, system, chronicles
 
+import ../../../app/core/[main]
+import ../../../app/core/tasks/[qt, threadpool]
 import ./dto/device as device_dto
 import ../settings/service as settings_service
 
@@ -8,6 +10,7 @@ import ../../../app/core/eventemitter
 import ../../../backend/installations as status_installations
 
 export device_dto
+include async_tasks
 
 logScope:
   topics = "devices-service"
@@ -18,25 +21,34 @@ type
     name*: string
     enabled*: bool
 
+type
+  DevicesArg* = ref object of Args
+    devices*: seq[DeviceDto]
+
 # Signals which may be emitted by this service:
 const SIGNAL_UPDATE_DEVICE* = "updateDevice"
+const SIGNAL_DEVICES_LOADED* = "devicesLoaded"
+const SIGNAL_ERROR_LOADING_DEVICES* = "devicesErrorLoading"
 
 QtObject:
   type Service* = ref object of QObject
     events: EventEmitter
+    threadpool: ThreadPool
     settingsService: settings_service.Service
-
-  ## Forward declaration
-  proc isNewDevice(self: Service, device: DeviceDto): bool
 
   proc delete*(self: Service) =
     self.QObject.delete
 
-  proc newService*(events: EventEmitter, settingsService: settings_service.Service): Service =
+  proc newService*(
+      events: EventEmitter,
+      threadpool: ThreadPool,
+      settingsService: settings_service.Service,
+    ): Service =
     new(result, delete)
     result.QObject.setup
     result.events = events
     result.settingsService = settingsService
+    result.threadpool = threadpool
 
   proc doConnect(self: Service) =
     self.events.on(SignalType.Message.event) do(e:Args):
@@ -52,6 +64,24 @@ QtObject:
   proc init*(self: Service) =
     self.doConnect()
 
+  proc asyncLoadDevices*(self: Service) =
+    let arg = AsyncLoadDevicesTaskArg(
+      tptr: cast[ByteAddress](asyncLoadDevicesTask),
+      vptr: cast[ByteAddress](self.vptr),
+      slot: "asyncDevicesLoaded",
+    )
+    self.threadpool.start(arg)
+
+  proc asyncDevicesLoaded*(self: Service, response: string) {.slot.} =
+    try:
+      let rpcResponse = Json.decode(response, RpcResponse[JsonNode])
+      let installations = map(rpcResponse.result.getElems(), proc(x: JsonNode): DeviceDto = x.toDeviceDto())
+      self.events.emit(SIGNAL_DEVICES_LOADED, DevicesArg(devices: installations))
+    except Exception as e:
+      let errDesription = e.msg
+      error "error loading devices: ", errDesription
+      self.events.emit(SIGNAL_ERROR_LOADING_DEVICES, Args())
+
   proc getAllDevices*(self: Service): seq[DeviceDto] =
     try:
       let response = status_installations.getOurInstallations()
@@ -60,25 +90,10 @@ QtObject:
       let errDesription = e.msg
       error "error: ", errDesription
 
-  proc isNewDevice(self: Service, device: DeviceDto): bool =
-    let allDevices = self.getAllDevices()
-    for d in allDevices:
-      if(d.id == device.id):
-        return false
-    return true
-
   proc setDeviceName*(self: Service, name: string) =
     let installationId = self.settingsService.getInstallationId()
     # Once we get more info from `status-go` we may emit success/failed signal from here.
     discard status_installations.setInstallationMetadata(installationId, name, hostOs)
-
-  proc isDeviceSetup*(self: Service): bool =
-    let allDevices = self.getAllDevices()
-    let installationId = self.settingsService.getInstallationId()
-    for d in allDevices:
-      if d.id == installationId:
-        return not d.metadata.isEmpty()
-    return false
 
   proc syncAllDevices*(self: Service) =
     let preferredName = self.settingsService.getPreferredName()

--- a/ui/app/AppLayouts/Profile/stores/DevicesStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/DevicesStore.qml
@@ -11,6 +11,10 @@ QtObject {
     // Module Properties
     property bool isDeviceSetup: devicesModule.isDeviceSetup
 
+    function loadDevices() {
+        return root.devicesModule.loadDevices()
+    }
+
     function setName(name) {
         return root.devicesModule.setName(name)
     }


### PR DESCRIPTION
Fixes #9439
#9525 Makes the getInstallations call load only when we enter the device screen and makes it async.

I added a very basic loading and error text as well.

The DeviceView was very old too, so there were stuff that I cleaned up, but there is more to clean there, that should be done later.