### PR TITLE
feat(ActivityCenter): Remove UI-side AC notifications filtering & sorting

### DIFF
--- a/src/app/modules/main/activity_center/controller.nim
+++ b/src/app/modules/main/activity_center/controller.nim
@@ -44,7 +44,7 @@ proc delete*(self: Controller) =
 proc init*(self: Controller) =
   self.events.on(activity_center_service.SIGNAL_ACTIVITY_CENTER_NOTIFICATIONS_LOADED) do(e: Args):
     let args = ActivityCenterNotificationsArgs(e)
-    self.delegate.addActivityCenterNotification(args.activityCenterNotifications)
+    self.delegate.addActivityCenterNotifications(args.activityCenterNotifications)
 
   self.events.on(activity_center_service.SIGNAL_MARK_NOTIFICATIONS_AS_ACCEPTED) do(e: Args):
     var evArgs = MarkAsAcceptedNotificationProperties(e)
@@ -143,6 +143,18 @@ proc getMessageById*(self: Controller, chatId, messageId: string): MessageDto =
 
 proc setActiveNotificationGroup*(self: Controller, group: int) =
   self.activityCenterService.setActiveNotificationGroup(ActivityCenterGroup(group))
+  self.activityCenterService.resetCursor()
+  let activityCenterNotifications = self.activityCenterService.getActivityCenterNotifications()
+  self.delegate.resetActivityCenterNotifications(activityCenterNotifications)
 
 proc getActiveNotificationGroup*(self: Controller): int =
   return self.activityCenterService.getActiveNotificationGroup().int
+
+proc setActivityCenterReadType*(self: Controller, readType: int) =
+  self.activityCenterService.setActivityCenterReadType(ActivityCenterReadType(readType))
+  self.activityCenterService.resetCursor()
+  let activityCenterNotifications = self.activityCenterService.getActivityCenterNotifications()
+  self.delegate.resetActivityCenterNotifications(activityCenterNotifications)
+
+proc getActivityCenterReadType*(self: Controller): int =
+  return self.activityCenterService.getActivityCenterReadType().int

--- a/src/app/modules/main/activity_center/controller.nim
+++ b/src/app/modules/main/activity_center/controller.nim
@@ -70,6 +70,7 @@ proc init*(self: Controller) =
   self.events.on(activity_center_service.SIGNAL_ACTIVITY_CENTER_NOTIFICATIONS_COUNT_MAY_HAVE_CHANGED) do(e: Args):
     self.delegate.unreadActivityCenterNotificationsCountChanged()
     self.delegate.hasUnseenActivityCenterNotificationsChanged()
+    self.delegate.groupCountersChanged()
 
 proc hasMoreToShow*(self: Controller): bool =
    return self.activityCenterService.hasMoreToShow()
@@ -158,3 +159,6 @@ proc setActivityCenterReadType*(self: Controller, readType: ActivityCenterReadTy
 
 proc getActivityCenterReadType*(self: Controller): ActivityCenterReadType =
   return self.activityCenterService.getActivityCenterReadType()
+
+proc getActivityGroupCounter*(self: Controller, group: ActivityCenterGroup): int =
+  return self.activityCenterService.getActivityGroupCounter(group)

--- a/src/app/modules/main/activity_center/controller.nim
+++ b/src/app/modules/main/activity_center/controller.nim
@@ -140,3 +140,9 @@ proc getMessageById*(self: Controller, chatId, messageId: string): MessageDto =
   if(err.len > 0):
     return MessageDto()
   return message
+
+proc setActiveNotificationGroup*(self: Controller, group: int) =
+  self.activityCenterService.setActiveNotificationGroup(ActivityCenterGroup(group))
+
+proc getActiveNotificationGroup*(self: Controller): int =
+  return self.activityCenterService.getActiveNotificationGroup().int

--- a/src/app/modules/main/activity_center/controller.nim
+++ b/src/app/modules/main/activity_center/controller.nim
@@ -141,20 +141,20 @@ proc getMessageById*(self: Controller, chatId, messageId: string): MessageDto =
     return MessageDto()
   return message
 
-proc setActiveNotificationGroup*(self: Controller, group: int) =
-  self.activityCenterService.setActiveNotificationGroup(ActivityCenterGroup(group))
+proc setActiveNotificationGroup*(self: Controller, group: ActivityCenterGroup) =
+  self.activityCenterService.setActiveNotificationGroup(group)
   self.activityCenterService.resetCursor()
   let activityCenterNotifications = self.activityCenterService.getActivityCenterNotifications()
   self.delegate.resetActivityCenterNotifications(activityCenterNotifications)
 
-proc getActiveNotificationGroup*(self: Controller): int =
-  return self.activityCenterService.getActiveNotificationGroup().int
+proc getActiveNotificationGroup*(self: Controller): ActivityCenterGroup =
+  return self.activityCenterService.getActiveNotificationGroup()
 
-proc setActivityCenterReadType*(self: Controller, readType: int) =
-  self.activityCenterService.setActivityCenterReadType(ActivityCenterReadType(readType))
+proc setActivityCenterReadType*(self: Controller, readType: ActivityCenterReadType) =
+  self.activityCenterService.setActivityCenterReadType(readType)
   self.activityCenterService.resetCursor()
   let activityCenterNotifications = self.activityCenterService.getActivityCenterNotifications()
   self.delegate.resetActivityCenterNotifications(activityCenterNotifications)
 
-proc getActivityCenterReadType*(self: Controller): int =
-  return self.activityCenterService.getActivityCenterReadType().int
+proc getActivityCenterReadType*(self: Controller): ActivityCenterReadType =
+  return self.activityCenterService.getActivityCenterReadType()

--- a/src/app/modules/main/activity_center/io_interface.nim
+++ b/src/app/modules/main/activity_center/io_interface.nim
@@ -66,10 +66,10 @@ method markActivityCenterNotificationUnread*(self: AccessInterface, notification
 method markAsSeenActivityCenterNotifications*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method pushActivityCenterNotifications*(self: AccessInterface, activityCenterNotifications: seq[ActivityCenterNotificationDto]) {.base.} =
+method addActivityCenterNotifications*(self: AccessInterface, activityCenterNotifications: seq[ActivityCenterNotificationDto]) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method addActivityCenterNotification*(self: AccessInterface, activityCenterNotifications: seq[ActivityCenterNotificationDto]) {.base.} =
+method resetActivityCenterNotifications*(self: AccessInterface, activityCenterNotifications: seq[ActivityCenterNotificationDto]) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method acceptActivityCenterNotifications*(self: AccessInterface, notificationIds: seq[string]): string {.base.} =
@@ -91,4 +91,10 @@ method setActiveNotificationGroup*(self: AccessInterface, group: int) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method getActiveNotificationGroup*(self: AccessInterface): int {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method setActivityCenterReadType*(self: AccessInterface, readType: int) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method getActivityCenterReadType*(self: AccessInterface): int {.base.} =
   raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/activity_center/io_interface.nim
+++ b/src/app/modules/main/activity_center/io_interface.nim
@@ -98,3 +98,24 @@ method setActivityCenterReadType*(self: AccessInterface, readType: int) {.base.}
 
 method getActivityCenterReadType*(self: AccessInterface): int {.base.} =
   raise newException(ValueError, "No implementation available")
+
+method groupCountersChanged*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method getAdminCount*(self: AccessInterface): int {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method getMentionsCount*(self: AccessInterface): int {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method getRepliesCount*(self: AccessInterface): int {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method getContactRequestsCount*(self: AccessInterface): int {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method getIdentityRequestsCount*(self: AccessInterface): int {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method getMembershipCount*(self: AccessInterface): int {.base.} =
+  raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/activity_center/io_interface.nim
+++ b/src/app/modules/main/activity_center/io_interface.nim
@@ -84,5 +84,11 @@ method switchTo*(self: AccessInterface, sectionId, chatId, messageId: string) {.
 method getDetails*(self: AccessInterface, sectionId: string, chatId: string): string {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method getChatDetailsAsJson*(self: AccessInterface, chatId: string): string {.base.} = 
+method getChatDetailsAsJson*(self: AccessInterface, chatId: string): string {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method setActiveNotificationGroup*(self: AccessInterface, group: int) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method getActiveNotificationGroup*(self: AccessInterface): int {.base.} =
   raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/activity_center/module.nim
+++ b/src/app/modules/main/activity_center/module.nim
@@ -292,13 +292,13 @@ method getChatDetailsAsJson*(self: Module, chatId: string): string =
   return $jsonObject
 
 method setActiveNotificationGroup*(self: Module, group: int) =
-  self.controller.setActiveNotificationGroup(group)
+  self.controller.setActiveNotificationGroup(ActivityCenterGroup(group))
 
 method getActiveNotificationGroup*(self: Module): int =
-  return self.controller.getActiveNotificationGroup()
+  return self.controller.getActiveNotificationGroup().int
 
 method setActivityCenterReadType*(self: Module, readType: int) =
-  self.controller.setActivityCenterReadType(readType)
+  self.controller.setActivityCenterReadType(ActivityCenterReadType(readType))
 
 method getActivityCenterReadType*(self: Module): int =
-  return self.controller.getActivityCenterReadType()
+  return self.controller.getActivityCenterReadType().int

--- a/src/app/modules/main/activity_center/module.nim
+++ b/src/app/modules/main/activity_center/module.nim
@@ -296,3 +296,9 @@ method getChatDetailsAsJson*(self: Module, chatId: string): string =
   jsonObject["color"] = %* chatDto.color
   jsonObject["emoji"] = %* chatDto.emoji
   return $jsonObject
+
+method setActiveNotificationGroup*(self: Module, group: int) =
+  self.controller.setActiveNotificationGroup(group)
+
+method getActiveNotificationGroup*(self: Module): int =
+  return self.controller.getActiveNotificationGroup()

--- a/src/app/modules/main/activity_center/module.nim
+++ b/src/app/modules/main/activity_center/module.nim
@@ -181,7 +181,7 @@ method convertToItems*(
 
 method fetchActivityCenterNotifications*(self: Module) =
   let activityCenterNotifications = self.controller.getActivityCenterNotifications()
-  self.view.pushActivityCenterNotifications(self.convertToItems(activityCenterNotifications))
+  self.view.addActivityCenterNotifications(self.convertToItems(activityCenterNotifications))
 
 method markAllActivityCenterNotificationsRead*(self: Module): string =
   self.controller.markAllActivityCenterNotificationsRead()
@@ -212,17 +212,11 @@ method markActivityCenterNotificationReadDone*(self: Module, notificationIds: se
 method markAsSeenActivityCenterNotifications*(self: Module) =
   self.controller.markAsSeenActivityCenterNotifications()
 
-method pushActivityCenterNotifications*(
-    self: Module,
-    activityCenterNotifications: seq[ActivityCenterNotificationDto]
-    ) =
-  self.view.pushActivityCenterNotifications(self.convertToItems(activityCenterNotifications))
+method addActivityCenterNotifications*(self: Module, activityCenterNotifications: seq[ActivityCenterNotificationDto]) =
+  self.view.addActivityCenterNotifications(self.convertToItems(activityCenterNotifications))
 
-method addActivityCenterNotification*(
-    self: Module,
-    activityCenterNotifications: seq[ActivityCenterNotificationDto]
-    ) =
-  self.view.addActivityCenterNotification(self.convertToItems(activityCenterNotifications))
+method resetActivityCenterNotifications*(self: Module, activityCenterNotifications: seq[ActivityCenterNotificationDto]) =
+  self.view.resetActivityCenterNotifications(self.convertToItems(activityCenterNotifications))
 
 method markActivityCenterNotificationUnread*(
     self: Module,
@@ -302,3 +296,9 @@ method setActiveNotificationGroup*(self: Module, group: int) =
 
 method getActiveNotificationGroup*(self: Module): int =
   return self.controller.getActiveNotificationGroup()
+
+method setActivityCenterReadType*(self: Module, readType: int) =
+  self.controller.setActivityCenterReadType(readType)
+
+method getActivityCenterReadType*(self: Module): int =
+  return self.controller.getActivityCenterReadType()

--- a/src/app/modules/main/activity_center/module.nim
+++ b/src/app/modules/main/activity_center/module.nim
@@ -302,3 +302,24 @@ method setActivityCenterReadType*(self: Module, readType: int) =
 
 method getActivityCenterReadType*(self: Module): int =
   return self.controller.getActivityCenterReadType().int
+
+method groupCountersChanged*(self: Module) =
+  self.view.groupCountersChanged()
+
+method getAdminCount*(self: Module): int =
+    return self.controller.getActivityGroupCounter(ActivityCenterGroup.Admin)
+
+method getMentionsCount*(self: Module): int =
+    return self.controller.getActivityGroupCounter(ActivityCenterGroup.Mentions)
+
+method getRepliesCount*(self: Module): int =
+    return self.controller.getActivityGroupCounter(ActivityCenterGroup.Replies)
+
+method getContactRequestsCount*(self: Module): int =
+    return self.controller.getActivityGroupCounter(ActivityCenterGroup.ContactRequests)
+
+method getIdentityRequestsCount*(self: Module): int =
+    return self.controller.getActivityGroupCounter(ActivityCenterGroup.IdentityVerification)
+
+method getMembershipCount*(self: Module): int =
+    return self.controller.getActivityGroupCounter(ActivityCenterGroup.Membership)

--- a/src/app/modules/main/activity_center/view.nim
+++ b/src/app/modules/main/activity_center/view.nim
@@ -172,3 +172,47 @@ QtObject:
     read = getActivityCenterReadType
     write = setActivityCenterReadType
     notify = activityCenterReadTypeChanged
+
+  proc groupCountersChanged*(self: View) {.signal.}
+
+  proc getAdminCount*(self: View): int {.slot.} =
+    return self.delegate.getAdminCount()
+
+  QtProperty[int] adminCount:
+    read = getAdminCount
+    notify = groupCountersChanged
+
+  proc getMentionsCount*(self: View): int {.slot.} =
+    return self.delegate.getMentionsCount()
+
+  QtProperty[int] mentionsCount:
+    read = getMentionsCount
+    notify = groupCountersChanged
+
+  proc getRepliesCount*(self: View): int {.slot.} =
+    return self.delegate.getRepliesCount()
+
+  QtProperty[int] repliesCount:
+    read = getRepliesCount
+    notify = groupCountersChanged
+
+  proc getContactRequestsCount*(self: View): int {.slot.} =
+    return self.delegate.getContactRequestsCount()
+
+  QtProperty[int] contactRequestsCount:
+    read = getContactRequestsCount
+    notify = groupCountersChanged
+
+  proc getIdentityRequestsCount*(self: View): int {.slot.} =
+    return self.delegate.getIdentityRequestsCount()
+
+  QtProperty[int] identityRequestsCount:
+    read = getIdentityRequestsCount
+    notify = groupCountersChanged
+
+  proc getMembershipCount*(self: View): int {.slot.} =
+    return self.delegate.getMembershipCount()
+
+  QtProperty[int] membershipCount:
+    read = getMembershipCount
+    notify = groupCountersChanged

--- a/src/app/modules/main/activity_center/view.nim
+++ b/src/app/modules/main/activity_center/view.nim
@@ -145,3 +145,17 @@ QtObject:
 
   proc getChatDetailsAsJson*(self: View, chatId: string): string {.slot.} =
     return self.delegate.getChatDetailsAsJson(chatId)
+
+  proc activeNotificationGroupChanged*(self: View) {.signal.}
+
+  proc setActiveNotificationGroup*(self: View, group: int) {.slot.} =
+    self.delegate.setActiveNotificationGroup(group)
+    self.activeNotificationGroupChanged()
+
+  proc getActiveNotificationGroup*(self: View): int {.slot.} =
+    return self.delegate.getActiveNotificationGroup()
+
+  QtProperty[int] activeNotificationGroup:
+    read = getActiveNotificationGroup
+    write = setActiveNotificationGroup
+    notify = activeNotificationGroupChanged

--- a/src/app/modules/main/activity_center/view.nim
+++ b/src/app/modules/main/activity_center/view.nim
@@ -60,10 +60,6 @@ QtObject:
     read = hasUnseenActivityCenterNotifications
     notify = hasUnseenActivityCenterNotificationsChanged
 
-  proc pushActivityCenterNotifications*(self:View, activityCenterNotifications: seq[Item]) =
-    self.model.addActivityNotificationItemsToList(activityCenterNotifications)
-    self.hasMoreToShowChanged()
-
   proc loadMoreNotifications(self: View) {.slot.} =
     self.delegate.fetchActivityCenterNotifications()
 
@@ -134,8 +130,11 @@ QtObject:
   proc dismissActivityCenterNotificationsDone*(self: View, notificationIds: seq[string]) =
     self.model.removeNotifications(notificationIds)
 
-  proc addActivityCenterNotification*(self: View, activityCenterNotifications: seq[Item]) =
+  proc addActivityCenterNotifications*(self: View, activityCenterNotifications: seq[Item]) =
     self.model.addActivityNotificationItemsToList(activityCenterNotifications)
+
+  proc resetActivityCenterNotifications*(self: View, activityCenterNotifications: seq[Item]) =
+    self.model.setNewData(activityCenterNotifications)
 
   proc switchTo*(self: View, sectionId: string, chatId: string, messageId: string) {.slot.} =
     self.delegate.switchTo(sectionId, chatId, messageId)
@@ -159,3 +158,17 @@ QtObject:
     read = getActiveNotificationGroup
     write = setActiveNotificationGroup
     notify = activeNotificationGroupChanged
+
+  proc activityCenterReadTypeChanged*(self: View) {.signal.}
+
+  proc setActivityCenterReadType*(self: View, readType: int) {.slot.} =
+    self.delegate.setActivityCenterReadType(readType)
+    self.activityCenterReadTypeChanged()
+
+  proc getActivityCenterReadType*(self: View): int {.slot.} =
+    return self.delegate.getActivityCenterReadType()
+
+  QtProperty[int] activityCenterReadType:
+    read = getActivityCenterReadType
+    write = setActivityCenterReadType
+    notify = activityCenterReadTypeChanged

--- a/src/app/modules/main/activity_center/view.nim
+++ b/src/app/modules/main/activity_center/view.nim
@@ -161,9 +161,12 @@ QtObject:
 
   proc activityCenterReadTypeChanged*(self: View) {.signal.}
 
+  proc groupCountersChanged*(self: View) {.signal.}
+
   proc setActivityCenterReadType*(self: View, readType: int) {.slot.} =
     self.delegate.setActivityCenterReadType(readType)
     self.activityCenterReadTypeChanged()
+    self.groupCountersChanged()
 
   proc getActivityCenterReadType*(self: View): int {.slot.} =
     return self.delegate.getActivityCenterReadType()
@@ -172,8 +175,6 @@ QtObject:
     read = getActivityCenterReadType
     write = setActivityCenterReadType
     notify = activityCenterReadTypeChanged
-
-  proc groupCountersChanged*(self: View) {.signal.}
 
   proc getAdminCount*(self: View): int {.slot.} =
     return self.delegate.getAdminCount()

--- a/src/app_service/service/activity_center/async_tasks.nim
+++ b/src/app_service/service/activity_center/async_tasks.nim
@@ -10,7 +10,8 @@ type
 
 const asyncActivityNotificationLoadTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AsyncActivityNotificationLoadTaskArg](argEncoded)
-  let activityNotificationsCallResult = backend.activityCenterNotificationsByGroup(newJString(arg.cursor), arg.limit, arg.group.int, arg.readType.int)
+  let groupTypes = activityCenterNotificationTypesByGroup(arg.group)
+  let activityNotificationsCallResult = backend.activityCenterNotificationsBy(newJString(arg.cursor), arg.limit, groupTypes, arg.readType.int, true)
 
   let responseJson = %*{
     "activityNotifications": activityNotificationsCallResult.result

--- a/src/app_service/service/activity_center/async_tasks.nim
+++ b/src/app_service/service/activity_center/async_tasks.nim
@@ -5,10 +5,12 @@ type
   AsyncActivityNotificationLoadTaskArg = ref object of QObjectTaskArg
     cursor: string
     limit: int
+    group: ActivityCenterGroup
+    readType: ActivityCenterReadType
 
 const asyncActivityNotificationLoadTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AsyncActivityNotificationLoadTaskArg](argEncoded)
-  let activityNotificationsCallResult = backend.activityCenterNotifications(newJString(arg.cursor), arg.limit)
+  let activityNotificationsCallResult = backend.activityCenterNotificationsByGroup(newJString(arg.cursor), arg.limit, arg.group.int, arg.readType.int)
 
   let responseJson = %*{
     "activityNotifications": activityNotificationsCallResult.result

--- a/src/app_service/service/activity_center/dto/notification.nim
+++ b/src/app_service/service/activity_center/dto/notification.nim
@@ -13,12 +13,23 @@ type ActivityCenterNotificationType* {.pure.}= enum
   NewPrivateGroupChat = 2,
   Mention = 3,
   Reply = 4,
-  ContactRequest = 5
-  CommunityInvitation = 6
-  CommunityRequest = 7
-  CommunityMembershipRequest = 8
-  CommunityKicked = 9
+  ContactRequest = 5,
+  CommunityInvitation = 6,
+  CommunityRequest = 7,
+  CommunityMembershipRequest = 8,
+  CommunityKicked = 9,
   ContactVerification = 10
+
+type ActivityCenterGroup* {.pure.}= enum
+  All = 0,
+  Mentions = 1,
+  Replies = 2,
+  Membership = 3,
+  Admin = 4,
+  ContactRequests = 5,
+  IdentityVerification = 6,
+  Transactions = 7,
+  System = 8
 
 type ActivityCenterMembershipStatus* {.pure.}= enum
   Idle = 0,
@@ -109,4 +120,3 @@ proc parseActivityCenterNotifications*(rpcResult: JsonNode): (string, seq[Activi
     for jsonMsg in rpcResult["notifications"]:
       notifs.add(jsonMsg.toActivityCenterNotificationDto())
   return (rpcResult{"cursor"}.getStr, notifs)
-

--- a/src/app_service/service/activity_center/dto/notification.nim
+++ b/src/app_service/service/activity_center/dto/notification.nim
@@ -125,11 +125,37 @@ proc parseActivityCenterNotifications*(rpcResult: JsonNode): (string, seq[Activi
       notifs.add(jsonMsg.toActivityCenterNotificationDto())
   return (rpcResult{"cursor"}.getStr, notifs)
 
-proc toActivityCenterNotificationTypeList*(rpcResult: JsonNode): seq[ActivityCenterNotificationType] =
-  var types: seq[ActivityCenterNotificationType] = @[]
-  for jsonObj in rpcResult:
-    var notificationTypeInt = jsonObj.getInt()
-    if notificationTypeInt >= ord(low(ActivityCenterNotificationType)) and
-       notificationTypeInt <= ord(high(ActivityCenterNotificationType)):
-      types.add(ActivityCenterNotificationType(notificationTypeInt))
-  return types
+proc activityCenterNotificationTypesByGroup*(group: ActivityCenterGroup) : seq[int] =
+  case group
+    of ActivityCenterGroup.All:
+      return @[
+        ActivityCenterNotificationType.NewPrivateGroupChat.int,
+        ActivityCenterNotificationType.Mention.int,
+        ActivityCenterNotificationType.Reply.int,
+        ActivityCenterNotificationType.ContactRequest.int,
+        ActivityCenterNotificationType.CommunityInvitation.int,
+        ActivityCenterNotificationType.CommunityRequest.int,
+        ActivityCenterNotificationType.CommunityMembershipRequest.int,
+        ActivityCenterNotificationType.CommunityKicked.int,
+        ActivityCenterNotificationType.ContactVerification.int
+      ]
+    of ActivityCenterGroup.Mentions:
+      return @[ActivityCenterNotificationType.Mention.int]
+    of ActivityCenterGroup.Replies:
+      return @[ActivityCenterNotificationType.Reply.int]
+    of ActivityCenterGroup.Membership:
+      return @[
+        ActivityCenterNotificationType.NewPrivateGroupChat.int,
+        ActivityCenterNotificationType.CommunityInvitation.int,
+        ActivityCenterNotificationType.CommunityRequest.int,
+        ActivityCenterNotificationType.CommunityMembershipRequest.int,
+        ActivityCenterNotificationType.CommunityKicked.int
+      ]
+    of ActivityCenterGroup.Admin:
+      return @[ActivityCenterNotificationType.CommunityMembershipRequest.int]
+    of ActivityCenterGroup.ContactRequests:
+      return @[ActivityCenterNotificationType.ContactRequest.int]
+    of ActivityCenterGroup.IdentityVerification:
+      return @[ActivityCenterNotificationType.ContactVerification.int]
+    else:
+      return @[]

--- a/src/app_service/service/activity_center/dto/notification.nim
+++ b/src/app_service/service/activity_center/dto/notification.nim
@@ -8,7 +8,7 @@ include ../../../common/json_utils
 include ../../../common/utils
 
 type ActivityCenterNotificationType* {.pure.}= enum
-  Unknown = 0,
+  NoType = 0,
   NewOneToOne = 1,
   NewPrivateGroupChat = 2,
   Mention = 3,
@@ -81,7 +81,7 @@ proc toActivityCenterNotificationDto*(jsonObj: JsonNode): ActivityCenterNotifica
 
   discard jsonObj.getProp("author", result.author)
 
-  result.notificationType = ActivityCenterNotificationType.Unknown
+  result.notificationType = ActivityCenterNotificationType.NoType
   var notificationTypeInt: int
   if (jsonObj.getProp("type", notificationTypeInt) and
     (notificationTypeInt >= ord(low(ActivityCenterNotificationType)) or

--- a/src/app_service/service/activity_center/service.nim
+++ b/src/app_service/service/activity_center/service.nim
@@ -91,7 +91,8 @@ QtObject:
         SIGNAL_ACTIVITY_CENTER_NOTIFICATIONS_LOADED,
         ActivityCenterNotificationsArgs(activityCenterNotifications: filteredNotifications)
       )
-      self.events.emit(SIGNAL_ACTIVITY_CENTER_NOTIFICATIONS_COUNT_MAY_HAVE_CHANGED, Args())
+    # NOTE: this signal must fire even we have no new notifications to show
+    self.events.emit(SIGNAL_ACTIVITY_CENTER_NOTIFICATIONS_COUNT_MAY_HAVE_CHANGED, Args())
 
   proc init*(self: Service) =
     self.asyncActivityNotificationLoad()
@@ -149,6 +150,16 @@ QtObject:
 
     self.cursor = activityCenterNotificationsTuple[0];
     result = activityCenterNotificationsTuple[1]
+
+  proc getActivityGroupCounter*(self: Service, group: ActivityCenterGroup): int =
+    try:
+      let response = backend.activityCenterNotificationsByGroupCount(group.int)
+
+      if response.result.kind != JNull:
+        return response.result.getInt
+    except Exception as e:
+      error "Error getting activity center notifications group count", msg = e.msg
+
 
   proc getUnreadActivityCenterNotificationsCount*(self: Service): int =
     try:

--- a/src/backend/backend.nim
+++ b/src/backend/backend.nim
@@ -164,17 +164,17 @@ rpc(activityCenterNotifications, "wakuext"):
   cursorVal: JsonNode
   limit: int
 
-rpc(activityCenterNotificationsByGroup, "wakuext"):
+rpc(activityCenterNotificationsBy, "wakuext"):
   cursorVal: JsonNode
   limit: int
-  group: int
+  activityTypes: seq[int]
   readType: int
+  accepted: bool
 
-rpc(activityCenterNotificationsByGroupCount, "wakuext"):
-  group: int
-
-rpc(activityCenterTypesByGroup, "wakuext"):
-  group: int
+rpc(activityCenterNotificationsCountBy, "wakuext"):
+  activityTypes: seq[int]
+  readType: int
+  accepted: bool
 
 rpc(markAllActivityCenterNotificationsRead, "wakuext"):
   discard

--- a/src/backend/backend.nim
+++ b/src/backend/backend.nim
@@ -164,6 +164,15 @@ rpc(activityCenterNotifications, "wakuext"):
   cursorVal: JsonNode
   limit: int
 
+rpc(activityCenterNotificationsByGroup, "wakuext"):
+  cursorVal: JsonNode
+  limit: int
+  group: int
+  readType: int
+
+rpc(activityCenterTypesByGroup, "wakuext"):
+  group: int
+
 rpc(markAllActivityCenterNotificationsRead, "wakuext"):
   discard
 

--- a/src/backend/backend.nim
+++ b/src/backend/backend.nim
@@ -170,6 +170,9 @@ rpc(activityCenterNotificationsByGroup, "wakuext"):
   group: int
   readType: int
 
+rpc(activityCenterNotificationsByGroupCount, "wakuext"):
+  group: int
+
 rpc(activityCenterTypesByGroup, "wakuext"):
   group: int
 

--- a/ui/app/mainui/activitycenter/panels/ActivityCenterPopupTopBarPanel.qml
+++ b/ui/app/mainui/activitycenter/panels/ActivityCenterPopupTopBarPanel.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.14
-import QtQuick.Controls 2.14
-import QtQuick.Layouts 1.14
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
 
 import utils 1.0
 
@@ -9,7 +9,7 @@ import StatusQ.Core.Theme 0.1
 import StatusQ.Controls 0.1
 import StatusQ.Popups 0.1
 
-import "../popups"
+import shared 1.0
 
 Item {
     id: root
@@ -24,11 +24,11 @@ Item {
     property bool hideReadNotifications: false
     property int unreadNotificationsCount: 0
 
-    property int currentActivityCategory: ActivityCenterPopup.ActivityCategory.All
+    property int activeGroup: Constants.ActivityCenterGroup.All
 
     property alias errorText: errorText.text
 
-    signal categoryTriggered(int category)
+    signal groupTriggered(int group)
     signal markAllReadClicked()
     signal showHideReadNotifications(bool hideReadNotifications)
 
@@ -49,24 +49,24 @@ Item {
 
                 Repeater {
                     // NOTE: some entries are hidden until implimentation
-                    model: [ { text: qsTr("All"), category: ActivityCenterPopup.ActivityCategory.All, visible: true, enabled: true },
-                             { text: qsTr("Admin"), category: ActivityCenterPopup.ActivityCategory.Admin, visible: root.hasAdmin, enabled: root.hasAdmin },
-                             { text: qsTr("Mentions"), category: ActivityCenterPopup.ActivityCategory.Mentions, visible: true, enabled: root.hasMentions },
-                             { text: qsTr("Replies"), category: ActivityCenterPopup.ActivityCategory.Replies, visible: true, enabled: root.hasReplies },
-                             { text: qsTr("Contact requests"), category: ActivityCenterPopup.ActivityCategory.ContactRequests, visible: true, enabled: root.hasContactRequests },
-                             { text: qsTr("Identity verification"), category: ActivityCenterPopup.ActivityCategory.IdentityVerification, visible: true, enabled: root.hasIdentityRequests },
-                             { text: qsTr("Transactions"), category: ActivityCenterPopup.ActivityCategory.Transactions, visible: false, enabled: true },
-                             { text: qsTr("Membership"), category: ActivityCenterPopup.ActivityCategory.Membership, visible: true, enabled: root.hasMembership },
-                             { text: qsTr("System"), category: ActivityCenterPopup.ActivityCategory.System, visible: false, enabled: true } ]
+                    model: [ { text: qsTr("All"), group: Constants.ActivityCenterGroup.All, visible: true, enabled: true },
+                             { text: qsTr("Admin"), group: Constants.ActivityCenterGroup.Admin, visible: root.hasAdmin, enabled: root.hasAdmin },
+                             { text: qsTr("Mentions"), group: Constants.ActivityCenterGroup.Mentions, visible: true, enabled: root.hasMentions },
+                             { text: qsTr("Replies"), group: Constants.ActivityCenterGroup.Replies, visible: true, enabled: root.hasReplies },
+                             { text: qsTr("Contact requests"), group: Constants.ActivityCenterGroup.ContactRequests, visible: true, enabled: root.hasContactRequests },
+                             { text: qsTr("Identity verification"), group: Constants.ActivityCenterGroup.IdentityVerification, visible: true, enabled: root.hasIdentityRequests },
+                             { text: qsTr("Transactions"), group: Constants.ActivityCenterGroup.Transactions, visible: false, enabled: true },
+                             { text: qsTr("Membership"), group: Constants.ActivityCenterGroup.Membership, visible: true, enabled: root.hasMembership },
+                             { text: qsTr("System"), group: Constants.ActivityCenterGroup.System, visible: false, enabled: true } ]
 
                     StatusFlatButton {
                         enabled: modelData.enabled
                         visible: modelData.visible
                         text: modelData.text
                         size: StatusBaseButton.Size.Small
-                        highlighted: modelData.category === root.currentActivityCategory
-                        onClicked: root.categoryTriggered(modelData.category)
-                        onEnabledChanged: if (!enabled && highlighted) root.categoryTriggered(ActivityCenterPopup.ActivityCategory.All)
+                        highlighted: modelData.group === root.activeGroup
+                        onClicked: root.groupTriggered(modelData.group)
+                        onEnabledChanged: if (!enabled && highlighted) root.groupTriggered(Constants.ActivityCenterGroup.All)
                         Layout.preferredWidth: visible ? implicitWidth : 0
                     }
                 }

--- a/ui/app/mainui/activitycenter/panels/ActivityCenterPopupTopBarPanel.qml
+++ b/ui/app/mainui/activitycenter/panels/ActivityCenterPopupTopBarPanel.qml
@@ -9,7 +9,7 @@ import StatusQ.Core.Theme 0.1
 import StatusQ.Controls 0.1
 import StatusQ.Popups 0.1
 
-import shared 1.0
+import "../stores"
 
 Item {
     id: root
@@ -24,7 +24,7 @@ Item {
     property bool hideReadNotifications: false
     property int unreadNotificationsCount: 0
 
-    property int activeGroup: Constants.ActivityCenterGroup.All
+    property int activeGroup: ActivityCenterStore.ActivityCenterGroup.All
 
     property alias errorText: errorText.text
 
@@ -49,15 +49,15 @@ Item {
 
                 Repeater {
                     // NOTE: some entries are hidden until implimentation
-                    model: [ { text: qsTr("All"), group: Constants.ActivityCenterGroup.All, visible: true, enabled: true },
-                             { text: qsTr("Admin"), group: Constants.ActivityCenterGroup.Admin, visible: root.hasAdmin, enabled: root.hasAdmin },
-                             { text: qsTr("Mentions"), group: Constants.ActivityCenterGroup.Mentions, visible: true, enabled: root.hasMentions },
-                             { text: qsTr("Replies"), group: Constants.ActivityCenterGroup.Replies, visible: true, enabled: root.hasReplies },
-                             { text: qsTr("Contact requests"), group: Constants.ActivityCenterGroup.ContactRequests, visible: true, enabled: root.hasContactRequests },
-                             { text: qsTr("Identity verification"), group: Constants.ActivityCenterGroup.IdentityVerification, visible: true, enabled: root.hasIdentityRequests },
-                             { text: qsTr("Transactions"), group: Constants.ActivityCenterGroup.Transactions, visible: false, enabled: true },
-                             { text: qsTr("Membership"), group: Constants.ActivityCenterGroup.Membership, visible: true, enabled: root.hasMembership },
-                             { text: qsTr("System"), group: Constants.ActivityCenterGroup.System, visible: false, enabled: true } ]
+                    model: [ { text: qsTr("All"), group: ActivityCenterStore.ActivityCenterGroup.All, visible: true, enabled: true },
+                             { text: qsTr("Admin"), group: ActivityCenterStore.ActivityCenterGroup.Admin, visible: root.hasAdmin, enabled: root.hasAdmin },
+                             { text: qsTr("Mentions"), group: ActivityCenterStore.ActivityCenterGroup.Mentions, visible: true, enabled: root.hasMentions },
+                             { text: qsTr("Replies"), group: ActivityCenterStore.ActivityCenterGroup.Replies, visible: true, enabled: root.hasReplies },
+                             { text: qsTr("Contact requests"), group: ActivityCenterStore.ActivityCenterGroup.ContactRequests, visible: true, enabled: root.hasContactRequests },
+                             { text: qsTr("Identity verification"), group: ActivityCenterStore.ActivityCenterGroup.IdentityVerification, visible: true, enabled: root.hasIdentityRequests },
+                             { text: qsTr("Transactions"), group: ActivityCenterStore.ActivityCenterGroup.Transactions, visible: false, enabled: true },
+                             { text: qsTr("Membership"), group: ActivityCenterStore.ActivityCenterGroup.Membership, visible: true, enabled: root.hasMembership },
+                             { text: qsTr("System"), group: ActivityCenterStore.ActivityCenterGroup.System, visible: false, enabled: true } ]
 
                     StatusFlatButton {
                         enabled: modelData.enabled
@@ -66,7 +66,7 @@ Item {
                         size: StatusBaseButton.Size.Small
                         highlighted: modelData.group === root.activeGroup
                         onClicked: root.groupTriggered(modelData.group)
-                        onEnabledChanged: if (!enabled && highlighted) root.groupTriggered(Constants.ActivityCenterGroup.All)
+                        onEnabledChanged: if (!enabled && highlighted) root.groupTriggered(ActivityCenterStore.ActivityCenterGroup.All)
                         Layout.preferredWidth: visible ? implicitWidth : 0
                     }
                 }

--- a/ui/app/mainui/activitycenter/popups/ActivityCenterPopup.qml
+++ b/ui/app/mainui/activitycenter/popups/ActivityCenterPopup.qml
@@ -70,13 +70,13 @@ Popup {
         hasContactRequests: root.contactRequestsCount > 0
         hasIdentityRequests: root.identityRequestsCount > 0
         hasMembership: root.membershipCount > 0
-        hideReadNotifications: activityCenterStore.activityCenterReadType === Constants.ActivityCenterReadType.Unread
+        hideReadNotifications: activityCenterStore.activityCenterReadType === ActivityCenterStore.ActivityCenterReadType.Unread
         activeGroup: activityCenterStore.activeNotificationGroup
         onGroupTriggered: activityCenterStore.setActiveNotificationGroup(group)
         onMarkAllReadClicked: root.activityCenterStore.markAllActivityCenterNotificationsRead()
         onShowHideReadNotifications: activityCenterStore.setActivityCenterReadType(hideReadNotifications ?
-                                                                                        Constants.ActivityCenterReadType.Unread :
-                                                                                        Constants.ActivityCenterReadType.All)
+                                                                                        ActivityCenterStore.ActivityCenterReadType.Unread :
+                                                                                        ActivityCenterStore.ActivityCenterReadType.All)
     }
 
     StatusListView {
@@ -98,21 +98,21 @@ Popup {
 
             sourceComponent: {
                 switch (model.notificationType) {
-                    case Constants.ActivityCenterNotificationType.Mention:
+                    case ActivityCenterStore.ActivityCenterNotificationType.Mention:
                         return mentionNotificationComponent
-                    case Constants.ActivityCenterNotificationType.Reply:
+                    case ActivityCenterStore.ActivityCenterNotificationType.Reply:
                         return replyNotificationComponent
-                    case Constants.ActivityCenterNotificationType.ContactRequest:
+                    case ActivityCenterStore.ActivityCenterNotificationType.ContactRequest:
                         return contactRequestNotificationComponent
-                    case Constants.ActivityCenterNotificationType.ContactVerification:
+                    case ActivityCenterStore.ActivityCenterNotificationType.ContactVerification:
                         return verificationRequestNotificationComponent
-                    case Constants.ActivityCenterNotificationType.CommunityInvitation:
+                    case ActivityCenterStore.ActivityCenterNotificationType.CommunityInvitation:
                         return communityInvitationNotificationComponent
-                    case Constants.ActivityCenterNotificationType.MembershipRequest:
+                    case ActivityCenterStore.ActivityCenterNotificationType.MembershipRequest:
                         return membershipRequestNotificationComponent
-                    case Constants.ActivityCenterNotificationType.CommunityRequest:
+                    case ActivityCenterStore.ActivityCenterNotificationType.CommunityRequest:
                         return communityRequestNotificationComponent
-                    case Constants.ActivityCenterNotificationType.CommunityKicked:
+                    case ActivityCenterStore.ActivityCenterNotificationType.CommunityKicked:
                         return communityKickedNotificationComponent
                     default:
                         return null

--- a/ui/app/mainui/activitycenter/popups/ActivityCenterPopup.qml
+++ b/ui/app/mainui/activitycenter/popups/ActivityCenterPopup.qml
@@ -18,14 +18,6 @@ import "../stores"
 Popup {
     id: root
 
-    // FIXME: counters from service
-    property int adminCount: 1
-    property int mentionsCount: 1
-    property int repliesCount: 1
-    property int contactRequestsCount: 1
-    property int identityRequestsCount: 1
-    property int membershipCount: 1
-
     property ActivityCenterStore activityCenterStore
     property var store
 
@@ -64,16 +56,16 @@ Popup {
         id: activityCenterTopBar
         width: parent.width
         unreadNotificationsCount: activityCenterStore.unreadNotificationsCount
-        hasAdmin: root.adminCount > 0
-        hasReplies: root.repliesCount > 0
-        hasMentions: root.mentionsCount > 0
-        hasContactRequests: root.contactRequestsCount > 0
-        hasIdentityRequests: root.identityRequestsCount > 0
-        hasMembership: root.membershipCount > 0
+        hasAdmin: activityCenterStore.adminCount > 0
+        hasReplies: activityCenterStore.repliesCount > 0
+        hasMentions: activityCenterStore.mentionsCount > 0
+        hasContactRequests: activityCenterStore.contactRequestsCount > 0
+        hasIdentityRequests: activityCenterStore.identityRequestsCount > 0
+        hasMembership: activityCenterStore.membershipCount > 0
         hideReadNotifications: activityCenterStore.activityCenterReadType === ActivityCenterStore.ActivityCenterReadType.Unread
         activeGroup: activityCenterStore.activeNotificationGroup
         onGroupTriggered: activityCenterStore.setActiveNotificationGroup(group)
-        onMarkAllReadClicked: root.activityCenterStore.markAllActivityCenterNotificationsRead()
+        onMarkAllReadClicked: activityCenterStore.markAllActivityCenterNotificationsRead()
         onShowHideReadNotifications: activityCenterStore.setActivityCenterReadType(hideReadNotifications ?
                                                                                         ActivityCenterStore.ActivityCenterReadType.Unread :
                                                                                         ActivityCenterStore.ActivityCenterReadType.All)

--- a/ui/app/mainui/activitycenter/popups/ActivityCenterPopup.qml
+++ b/ui/app/mainui/activitycenter/popups/ActivityCenterPopup.qml
@@ -1,7 +1,6 @@
-import QtQuick 2.14
-import QtQuick.Controls 2.14
-import QtGraphicalEffects 1.13
-import Qt.labs.qmlmodels 1.0
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtGraphicalEffects 1.15
 
 import StatusQ.Core 0.1
 import StatusQ.Controls 0.1
@@ -19,63 +18,18 @@ import "../stores"
 Popup {
     id: root
 
-   // NOTE: temporary enum until we have different categories on UI and status-go sides
-    enum ActivityCategory {
-        All,
-        Admin,
-        Mentions,
-        Replies,
-        ContactRequests,
-        IdentityVerification,
-        Transactions,
-        Membership,
-        System
-    }
-    property int currentActivityCategory: ActivityCenterPopup.ActivityCategory.All
-    property int adminCount: 0
-    property int mentionsCount: 0
-    property int repliesCount: 0
-    property int contactRequestsCount: 0
-    property int identityRequestsCount: 0
-    property int membershipCount: 0
+    // FIXME: counters from service
+    property int adminCount: 1
+    property int mentionsCount: 1
+    property int repliesCount: 1
+    property int contactRequestsCount: 1
+    property int identityRequestsCount: 1
+    property int membershipCount: 1
 
     property ActivityCenterStore activityCenterStore
     property var store
 
     readonly property int unreadNotificationsCount: root.activityCenterStore.unreadNotificationsCount
-
-    function calcNotificationType(notificationType, cnt) {
-        switch (notificationType) {
-        case Constants.activityCenterNotificationTypeMention:
-            root.mentionsCount += cnt;
-            break;
-        case Constants.activityCenterNotificationTypeReply:
-            root.repliesCount += cnt;
-            break;
-        case Constants.activityCenterNotificationTypeContactRequest:
-            root.contactRequestsCount += cnt;
-            break;
-        case Constants.activityCenterNotificationTypeContactVerification:
-            root.identityRequestsCount += cnt;
-            break;
-        case Constants.activityCenterNotificationTypeCommunityInvitation:
-            root.membershipCount += cnt;
-            break;
-        case Constants.activityCenterNotificationTypeCommunityMembershipRequest:
-            // NOTE: not a typo, membership requests are shown in both categories
-            root.membershipCount += cnt;
-            root.adminCount += cnt;
-            break;
-        case Constants.activityCenterNotificationTypeCommunityRequest:
-            root.membershipCount += cnt;
-            break;
-        case Constants.ActivityCenterNotificationTypeCommunityKicked:
-            root.membershipCount += cnt;
-            break;
-        default:
-            break;
-        }
-    }
 
     onOpened: {
         Global.popupOpened = true
@@ -108,16 +62,6 @@ Popup {
         }
     }
 
-    Repeater {
-        id: notificationTypeCounter
-        model: root.activityCenterStore.activityCenterNotifications
-
-        delegate: Item {
-            Component.onCompleted: calcNotificationType(model.notificationType, 1)
-            Component.onDestruction: calcNotificationType(model.notificationType, -1)
-        }
-    }
-
     ActivityCenterPopupTopBarPanel {
         id: activityCenterTopBar
         width: parent.width
@@ -129,8 +73,8 @@ Popup {
         hasIdentityRequests: root.identityRequestsCount > 0
         hasMembership: root.membershipCount > 0
         hideReadNotifications: activityCenterStore.hideReadNotifications
-        currentActivityCategory: root.currentActivityCategory
-        onCategoryTriggered: root.currentActivityCategory = category
+        activeGroup: activityCenterStore.activeNotificationGroup
+        onGroupTriggered: activityCenterStore.setActiveNotificationGroup(group)
         onMarkAllReadClicked: root.activityCenterStore.markAllActivityCenterNotificationsRead()
         onShowHideReadNotifications: activityCenterStore.hideReadNotifications = hideReadNotifications
     }
@@ -154,21 +98,21 @@ Popup {
 
             sourceComponent: {
                 switch (model.notificationType) {
-                    case Constants.activityCenterNotificationTypeMention:
+                    case Constants.ActivityCenterNotificationType.Mention:
                         return mentionNotificationComponent
-                    case Constants.activityCenterNotificationTypeReply:
+                    case Constants.ActivityCenterNotificationType.Reply:
                         return replyNotificationComponent
-                    case Constants.activityCenterNotificationTypeContactRequest:
+                    case Constants.ActivityCenterNotificationType.ContactRequest:
                         return contactRequestNotificationComponent
-                    case Constants.activityCenterNotificationTypeContactVerification:
+                    case Constants.ActivityCenterNotificationType.ContactVerification:
                         return verificationRequestNotificationComponent
-                    case Constants.activityCenterNotificationTypeCommunityInvitation:
+                    case Constants.ActivityCenterNotificationType.CommunityInvitation:
                         return communityInvitationNotificationComponent
-                    case Constants.activityCenterNotificationTypeCommunityMembershipRequest:
+                    case Constants.ActivityCenterNotificationType.MembershipRequest:
                         return membershipRequestNotificationComponent
-                    case Constants.activityCenterNotificationTypeCommunityRequest:
+                    case Constants.ActivityCenterNotificationType.CommunityRequest:
                         return communityRequestNotificationComponent
-                    case Constants.activityCenterNotificationTypeCommunityKicked:
+                    case Constants.ActivityCenterNotificationType.CommunityKicked:
                         return communityKickedNotificationComponent
                     default:
                         return null

--- a/ui/app/mainui/activitycenter/popups/ActivityCenterPopup.qml
+++ b/ui/app/mainui/activitycenter/popups/ActivityCenterPopup.qml
@@ -29,8 +29,6 @@ Popup {
     property ActivityCenterStore activityCenterStore
     property var store
 
-    readonly property int unreadNotificationsCount: root.activityCenterStore.unreadNotificationsCount
-
     onOpened: {
         Global.popupOpened = true
     }
@@ -65,18 +63,20 @@ Popup {
     ActivityCenterPopupTopBarPanel {
         id: activityCenterTopBar
         width: parent.width
-        unreadNotificationsCount: root.unreadNotificationsCount
+        unreadNotificationsCount: activityCenterStore.unreadNotificationsCount
         hasAdmin: root.adminCount > 0
         hasReplies: root.repliesCount > 0
         hasMentions: root.mentionsCount > 0
         hasContactRequests: root.contactRequestsCount > 0
         hasIdentityRequests: root.identityRequestsCount > 0
         hasMembership: root.membershipCount > 0
-        hideReadNotifications: activityCenterStore.hideReadNotifications
+        hideReadNotifications: activityCenterStore.activityCenterReadType === Constants.ActivityCenterReadType.Unread
         activeGroup: activityCenterStore.activeNotificationGroup
         onGroupTriggered: activityCenterStore.setActiveNotificationGroup(group)
         onMarkAllReadClicked: root.activityCenterStore.markAllActivityCenterNotificationsRead()
-        onShowHideReadNotifications: activityCenterStore.hideReadNotifications = hideReadNotifications
+        onShowHideReadNotifications: activityCenterStore.setActivityCenterReadType(hideReadNotifications ?
+                                                                                        Constants.ActivityCenterReadType.Unread :
+                                                                                        Constants.ActivityCenterReadType.All)
     }
 
     StatusListView {

--- a/ui/app/mainui/activitycenter/popups/ActivityCenterPopup.qml
+++ b/ui/app/mainui/activitycenter/popups/ActivityCenterPopup.qml
@@ -6,8 +6,6 @@ import Qt.labs.qmlmodels 1.0
 import StatusQ.Core 0.1
 import StatusQ.Controls 0.1
 
-import SortFilterProxyModel 0.2
-
 import shared 1.0
 import shared.popups 1.0
 import shared.views.chat 1.0
@@ -45,30 +43,6 @@ Popup {
     property var store
 
     readonly property int unreadNotificationsCount: root.activityCenterStore.unreadNotificationsCount
-
-    function filterActivityCategories(notificationType) {
-        switch (root.currentActivityCategory) {
-        case ActivityCenterPopup.ActivityCategory.All:
-            return true
-        case ActivityCenterPopup.ActivityCategory.Admin:
-            return notificationType === Constants.activityCenterNotificationTypeCommunityMembershipRequest
-        case ActivityCenterPopup.ActivityCategory.Mentions:
-            return notificationType === Constants.activityCenterNotificationTypeMention
-        case ActivityCenterPopup.ActivityCategory.Replies:
-            return notificationType === Constants.activityCenterNotificationTypeReply
-        case ActivityCenterPopup.ActivityCategory.ContactRequests:
-            return notificationType === Constants.activityCenterNotificationTypeContactRequest
-        case ActivityCenterPopup.ActivityCategory.IdentityVerification:
-            return notificationType === Constants.activityCenterNotificationTypeContactVerification
-        case ActivityCenterPopup.ActivityCategory.Membership:
-            return notificationType === Constants.activityCenterNotificationTypeCommunityInvitation ||
-                   notificationType === Constants.activityCenterNotificationTypeCommunityMembershipRequest ||
-                   notificationType === Constants.activityCenterNotificationTypeCommunityRequest ||
-                   notificationType === Constants.activityCenterNotificationTypeCommunityKicked
-        default:
-            return false
-        }
-    }
 
     function calcNotificationType(notificationType, cnt) {
         switch (notificationType) {
@@ -136,7 +110,7 @@ Popup {
 
     Repeater {
         id: notificationTypeCounter
-        model: root.activityCenterStore.activityCenterList
+        model: root.activityCenterStore.activityCenterNotifications
 
         delegate: Item {
             Component.onCompleted: calcNotificationType(model.notificationType, 1)
@@ -170,19 +144,7 @@ Popup {
         anchors.margins: Style.current.smallPadding
         spacing: 1
 
-        model: SortFilterProxyModel {
-            sourceModel: root.activityCenterStore.activityCenterList
-
-            filters: ExpressionFilter { expression: filterActivityCategories(model.notificationType) &&
-                                                    !(activityCenterStore.hideReadNotifications && model.read) }
-
-            sorters: [
-                RoleSorter {
-                    roleName: "timestamp"
-                    sortOrder: Qt.DescendingOrder
-                }
-            ]
-        }
+        model: root.activityCenterStore.activityCenterNotifications
 
         delegate: Loader {
             width: listView.availableWidth

--- a/ui/app/mainui/activitycenter/stores/ActivityCenterStore.qml
+++ b/ui/app/mainui/activitycenter/stores/ActivityCenterStore.qml
@@ -5,13 +5,12 @@ import shared 1.0
 QtObject {
     id: root
 
-    property bool hideReadNotifications: false
-
     readonly property var activityCenterModuleInst: activityCenterModule
     readonly property var activityCenterNotifications: activityCenterModuleInst.activityNotificationsModel
     readonly property int unreadNotificationsCount: activityCenterModuleInst.unreadActivityCenterNotificationsCount
     readonly property bool hasUnseenNotifications: activityCenterModuleInst.hasUnseenActivityCenterNotifications
     readonly property int activeNotificationGroup: activityCenterModuleInst.activeNotificationGroup
+    readonly property int activityCenterReadType: activityCenterModuleInst.activityCenterReadType
 
     function markAllActivityCenterNotificationsRead() {
         root.activityCenterModuleInst.markAllActivityCenterNotificationsRead()
@@ -39,5 +38,9 @@ QtObject {
 
     function setActiveNotificationGroup(group) {
         root.activityCenterModuleInst.setActiveNotificationGroup(group)
+    }
+
+    function setActivityCenterReadType(readType) {
+        root.activityCenterModuleInst.setActivityCenterReadType(readType)
     }
 }

--- a/ui/app/mainui/activitycenter/stores/ActivityCenterStore.qml
+++ b/ui/app/mainui/activitycenter/stores/ActivityCenterStore.qml
@@ -6,7 +6,7 @@ QtObject {
     property bool hideReadNotifications: false
 
     readonly property var activityCenterModuleInst: activityCenterModule
-    readonly property var activityCenterList: activityCenterModuleInst.activityNotificationsModel
+    readonly property var activityCenterNotifications: activityCenterModuleInst.activityNotificationsModel
     readonly property int unreadNotificationsCount: activityCenterModuleInst.unreadActivityCenterNotificationsCount
     readonly property bool hasUnseenNotifications: activityCenterModuleInst.hasUnseenActivityCenterNotifications
 

--- a/ui/app/mainui/activitycenter/stores/ActivityCenterStore.qml
+++ b/ui/app/mainui/activitycenter/stores/ActivityCenterStore.qml
@@ -45,10 +45,18 @@ QtObject {
 
     readonly property var activityCenterModuleInst: activityCenterModule
     readonly property var activityCenterNotifications: activityCenterModuleInst.activityNotificationsModel
+
     readonly property int unreadNotificationsCount: activityCenterModuleInst.unreadActivityCenterNotificationsCount
     readonly property bool hasUnseenNotifications: activityCenterModuleInst.hasUnseenActivityCenterNotifications
     readonly property int activeNotificationGroup: activityCenterModuleInst.activeNotificationGroup
     readonly property int activityCenterReadType: activityCenterModuleInst.activityCenterReadType
+
+    readonly property int adminCount: activityCenterModuleInst.adminCount
+    readonly property int mentionsCount: activityCenterModuleInst.mentionsCount
+    readonly property int repliesCount: activityCenterModuleInst.repliesCount
+    readonly property int contactRequestsCount: activityCenterModuleInst.contactRequestsCount
+    readonly property int identityRequestsCount: activityCenterModuleInst.identityRequestsCount
+    readonly property int membershipCount: activityCenterModuleInst.membershipCount
 
     function markAllActivityCenterNotificationsRead() {
         root.activityCenterModuleInst.markAllActivityCenterNotificationsRead()

--- a/ui/app/mainui/activitycenter/stores/ActivityCenterStore.qml
+++ b/ui/app/mainui/activitycenter/stores/ActivityCenterStore.qml
@@ -1,4 +1,6 @@
-import QtQuick 2.14
+import QtQuick 2.15
+
+import shared 1.0
 
 QtObject {
     id: root
@@ -9,6 +11,7 @@ QtObject {
     readonly property var activityCenterNotifications: activityCenterModuleInst.activityNotificationsModel
     readonly property int unreadNotificationsCount: activityCenterModuleInst.unreadActivityCenterNotificationsCount
     readonly property bool hasUnseenNotifications: activityCenterModuleInst.hasUnseenActivityCenterNotifications
+    readonly property int activeNotificationGroup: activityCenterModuleInst.activeNotificationGroup
 
     function markAllActivityCenterNotificationsRead() {
         root.activityCenterModuleInst.markAllActivityCenterNotificationsRead()
@@ -32,5 +35,9 @@ QtObject {
 
     function switchTo(notification) {
         root.activityCenterModuleInst.switchTo(notification.sectionId, notification.chatId, notification.id)
+    }
+
+    function setActiveNotificationGroup(group) {
+        root.activityCenterModuleInst.setActiveNotificationGroup(group)
     }
 }

--- a/ui/app/mainui/activitycenter/stores/ActivityCenterStore.qml
+++ b/ui/app/mainui/activitycenter/stores/ActivityCenterStore.qml
@@ -5,6 +5,44 @@ import shared 1.0
 QtObject {
     id: root
 
+    enum ActivityCenterGroup {
+        All = 0,
+        Mentions = 1,
+        Replies = 2,
+        Membership = 3,
+        Admin = 4,
+        ContactRequests = 5,
+        IdentityVerification = 6,
+        Transactions = 7,
+        System = 8
+    }
+
+    enum ActivityCenterNotificationType {
+        NoType = 0,
+        NewOneToOne = 1,
+        NewPrivateGroupChat = 2,
+        Mention = 3,
+        Reply = 4,
+        ContactRequest = 5,
+        CommunityInvitation = 6,
+        CommunityRequest = 7,
+        CommunityMembershipRequest = 8,
+        CommunityKicked = 9,
+        ContactVerification = 10
+    }
+
+    enum ActivityCenterReadType {
+        Read = 1,
+        Unread = 2,
+        All = 3
+    }
+
+    enum ActivityCenterMembershipStatus {
+        Pending = 1,
+        Accepted = 2,
+        Declined = 3
+    }
+
     readonly property var activityCenterModuleInst: activityCenterModule
     readonly property var activityCenterNotifications: activityCenterModuleInst.activityNotificationsModel
     readonly property int unreadNotificationsCount: activityCenterModuleInst.unreadActivityCenterNotificationsCount

--- a/ui/app/mainui/activitycenter/views/ActivityNotificationCommunityMembershipRequest.qml
+++ b/ui/app/mainui/activitycenter/views/ActivityNotificationCommunityMembershipRequest.qml
@@ -12,6 +12,7 @@ import shared.views.chat 1.0
 
 import "../controls"
 import "../panels"
+import "../stores"
 
 ActivityNotificationMessage {
     id: root
@@ -46,9 +47,9 @@ ActivityNotificationMessage {
     }
 
     ctaComponent: MembershipCta {
-        pending: notification && notification.membershipStatus === Constants.activityCenterMembershipStatusPending
-        accepted: notification && notification.membershipStatus === Constants.activityCenterMembershipStatusAccepted
-        declined: notification && notification.membershipStatus === Constants.activityCenterMembershipStatusDeclined
+        pending: notification && notification.membershipStatus === ActivityCenterStore.ActivityCenterMembershipStatus.Pending
+        accepted: notification && notification.membershipStatus === ActivityCenterStore.ActivityCenterMembershipStatus.Accepted
+        declined: notification && notification.membershipStatus === ActivityCenterStore.ActivityCenterMembershipStatus.Declined
         onAcceptRequestToJoinCommunity: root.store.acceptRequestToJoinCommunity(notification.id, notification.communityId)
         onDeclineRequestToJoinCommunity: root.store.declineRequestToJoinCommunity(notification.id, notification.communityId)
     }

--- a/ui/app/mainui/activitycenter/views/ActivityNotificationCommunityRequest.qml
+++ b/ui/app/mainui/activitycenter/views/ActivityNotificationCommunityRequest.qml
@@ -11,6 +11,7 @@ import shared.controls 1.0
 import utils 1.0
 
 import "../controls"
+import "../stores"
 
 ActivityNotificationBase {
     id: root
@@ -56,11 +57,11 @@ ActivityNotificationBase {
             text: {
                 if (!notification)
                     return ""
-                if (notification.membershipStatus === Constants.activityCenterMembershipStatusPending)
+                if (notification.membershipStatus === ActivityCenterStore.ActivityCenterMembershipStatus.Pending)
                     return qsTr("pending")
-                if (notification.membershipStatus === Constants.activityCenterMembershipStatusAccepted)
+                if (notification.membershipStatus === ActivityCenterStore.ActivityCenterMembershipStatus.Accepted)
                     return qsTr("accepted")
-                if (notification.membershipStatus === Constants.activityCenterMembershipStatusDeclined)
+                if (notification.membershipStatus === ActivityCenterStore.ActivityCenterMembershipStatus.Declined)
                     return qsTr("declined")
                 return ""
             }
@@ -72,7 +73,7 @@ ActivityNotificationBase {
         }
     }
 
-    ctaComponent: notification && notification.membershipStatus === Constants.activityCenterMembershipStatusAccepted ?
+    ctaComponent: notification && notification.membershipStatus === ActivityCenterStore.ActivityCenterMembershipStatus.Accepted ?
                         visitComponent : null
 
     Component {

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -613,17 +613,31 @@ QtObject {
     readonly property int communityChatInvitationOnlyAccess: 2
     readonly property int communityChatOnRequestAccess: 3
 
-    readonly property int activityCenterNotificationTypeNoType: 0
-    readonly property int activityCenterNotificationTypeOneToOne: 1
-    readonly property int activityCenterNotificationTypeGroupRequest: 2
-    readonly property int activityCenterNotificationTypeMention: 3
-    readonly property int activityCenterNotificationTypeReply: 4
-    readonly property int activityCenterNotificationTypeContactRequest: 5
-    readonly property int activityCenterNotificationTypeCommunityInvitation: 6
-    readonly property int activityCenterNotificationTypeCommunityRequest: 7
-    readonly property int activityCenterNotificationTypeCommunityMembershipRequest: 8
-    readonly property int activityCenterNotificationTypeCommunityKicked: 9
-    readonly property int activityCenterNotificationTypeContactVerification: 10
+    enum ActivityCenterGroup {
+        All = 0,
+        Mentions = 1,
+        Replies = 2,
+        Membership = 3,
+        Admin = 4,
+        ContactRequests = 5,
+        IdentityVerification = 6,
+        Transactions = 7,
+        System = 8
+    }
+
+    enum ActivityCenterNotificationType {
+        NoType = 0,
+        NewOneToOne = 1,
+        NewPrivateGroupChat = 2,
+        Mention = 3,
+        Reply = 4,
+        ContactRequest = 5,
+        CommunityInvitation = 6,
+        CommunityRequest = 7,
+        CommunityMembershipRequest = 8,
+        CommunityKicked = 9,
+        ContactVerification = 10
+    }
 
     readonly property int activityCenterMembershipStatusPending: 1
     readonly property int activityCenterMembershipStatusAccepted: 2

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -613,42 +613,6 @@ QtObject {
     readonly property int communityChatInvitationOnlyAccess: 2
     readonly property int communityChatOnRequestAccess: 3
 
-    enum ActivityCenterGroup {
-        All = 0,
-        Mentions = 1,
-        Replies = 2,
-        Membership = 3,
-        Admin = 4,
-        ContactRequests = 5,
-        IdentityVerification = 6,
-        Transactions = 7,
-        System = 8
-    }
-
-    enum ActivityCenterNotificationType {
-        NoType = 0,
-        NewOneToOne = 1,
-        NewPrivateGroupChat = 2,
-        Mention = 3,
-        Reply = 4,
-        ContactRequest = 5,
-        CommunityInvitation = 6,
-        CommunityRequest = 7,
-        CommunityMembershipRequest = 8,
-        CommunityKicked = 9,
-        ContactVerification = 10
-    }
-
-    enum ActivityCenterReadType {
-        Read = 1,
-        Unread = 2,
-        All = 3
-    }
-
-    readonly property int activityCenterMembershipStatusPending: 1
-    readonly property int activityCenterMembershipStatusAccepted: 2
-    readonly property int activityCenterMembershipStatusDeclined: 3
-
     readonly property int contactRequestStateNone: 0
     readonly property int contactRequestStatePending: 1
     readonly property int contactRequestStateAccepted: 2

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -639,6 +639,12 @@ QtObject {
         ContactVerification = 10
     }
 
+    enum ActivityCenterReadType {
+        Read = 1,
+        Unread = 2,
+        All = 3
+    }
+
     readonly property int activityCenterMembershipStatusPending: 1
     readonly property int activityCenterMembershipStatusAccepted: 2
     readonly property int activityCenterMembershipStatusDeclined: 3

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -613,6 +613,7 @@ QtObject {
     readonly property int communityChatInvitationOnlyAccess: 2
     readonly property int communityChatOnRequestAccess: 3
 
+    readonly property int activityCenterNotificationTypeNoType: 0
     readonly property int activityCenterNotificationTypeOneToOne: 1
     readonly property int activityCenterNotificationTypeGroupRequest: 2
     readonly property int activityCenterNotificationTypeMention: 3


### PR DESCRIPTION
Close #8510
Depends https://github.com/status-im/status-go/pull/3206


What should be fixed by this PR:
- [x] Show older notifications for categories that was not loaded before because of ui-side sorting
- [x] Fix overlapping notifications caused by SortFilterProxyModel
- [x] status-go endpoints calls optimisation

### What does the PR do

- [x] Remove ui-side filtering and sorting
- [x] Support fetching only visible for the ui notifications using cursor

### Affected areas

Activity Center

### Screenshot of functionality (including design for comparison)

<img width="1387" alt="Screenshot 2023-02-24 at 14 13 17" src="https://user-images.githubusercontent.com/2522130/221161370-ac41d146-b3d2-4577-99ad-4e9a1c2e0729.png">
