### PR TITLE
fix(ENS): For an ENS name the wrong release date is shown

### DIFF
--- a/ui/app/AppLayouts/Profile/views/EnsDetailsView.qml
+++ b/ui/app/AppLayouts/Profile/views/EnsDetailsView.qml
@@ -26,7 +26,7 @@ Item {
     QtObject {
         id: d
 
-        property int expirationTimestamp: 0
+        property double expirationTimestamp: 0
     }
 
     StatusBaseText {


### PR DESCRIPTION
`int` is not enough for a timestamp

Fixes #9381

### What does the PR do

Fixes formatted ENS release date

### Affected areas

EnsDetailsView

