### PR TITLE
fix(@desktop/keycard): Keycard -> Factory reset: $NaN amount is shown in factory reset flow when account has no funds

### DIFF
--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -80,6 +80,7 @@ type
     urlsManager: UrlsManager
     keycardService: keycard_service.Service
     settingsService: settings_service.Service
+    networkService: network_service.Service
     privacyService: privacy_service.Service
     accountsService: accounts_service.Service
     walletAccountService: wallet_account_service.Service
@@ -163,6 +164,7 @@ proc newModule*[T](
   result.urlsManager = urlsManager
   result.keycardService = keycardService
   result.settingsService = settingsService
+  result.networkService = networkService
   result.privacyService = privacyService
   result.accountsService = accountsService
   result.walletAccountService = walletAccountService
@@ -981,7 +983,7 @@ method getKeycardSharedModule*[T](self: Module[T]): QVariant =
 
 proc createSharedKeycardModule[T](self: Module[T]) =
   self.keycardSharedModule = keycard_shared_module.newModule[Module[T]](self, UNIQUE_MAIN_MODULE_IDENTIFIER, 
-    self.events, self.keycardService, self.settingsService, self.privacyService, self.accountsService, 
+    self.events, self.keycardService, self.settingsService, self.networkService, self.privacyService, self.accountsService, 
     self.walletAccountService, self.keychainService)
 
 method onSharedKeycarModuleFlowTerminated*[T](self: Module[T], lastStepInTheCurrentFlow: bool) =
@@ -1003,7 +1005,7 @@ method onSharedKeycarModuleKeycardSyncPurposeTerminated*[T](self: Module[T], las
 
 method tryKeycardSync*[T](self: Module[T], keyUid: string, pin: string) =
   self.keycardSharedModuleKeycardSyncPurpose = keycard_shared_module.newModule[Module[T]](self, UNIQUE_MAIN_MODULE_KEYCARD_SYNC_IDENTIFIER, 
-    self.events, self.keycardService, self.settingsService, self.privacyService, self.accountsService, 
+    self.events, self.keycardService, self.settingsService, self.networkService, self.privacyService, self.accountsService, 
     self.walletAccountService, self.keychainService)
   if self.keycardSharedModuleKeycardSyncPurpose.isNil:
     return

--- a/src/app/modules/main/profile_section/keycard/module.nim
+++ b/src/app/modules/main/profile_section/keycard/module.nim
@@ -8,6 +8,7 @@ import ../../../../core/eventemitter
 
 import ../../../../../app_service/service/keycard/service as keycard_service
 import ../../../../../app_service/service/settings/service as settings_service
+import ../../../../../app_service/service/network/service as network_service
 import ../../../../../app_service/service/privacy/service as privacy_service
 import ../../../../../app_service/service/accounts/service as accounts_service
 import ../../../../../app_service/service/wallet_account/service as wallet_account_service
@@ -36,6 +37,7 @@ type
     events: EventEmitter
     keycardService: keycard_service.Service
     settingsService: settings_service.Service
+    networkService: network_service.Service
     privacyService: privacy_service.Service
     accountsService: accounts_service.Service
     walletAccountService: wallet_account_service.Service
@@ -49,6 +51,7 @@ proc newModule*(delegate: delegate_interface.AccessInterface,
   events: EventEmitter,
   keycardService: keycard_service.Service,
   settingsService: settings_service.Service,
+  networkService: network_service.Service,
   privacyService: privacy_service.Service,
   accountsService: accounts_service.Service,
   walletAccountService: wallet_account_service.Service,
@@ -58,6 +61,7 @@ proc newModule*(delegate: delegate_interface.AccessInterface,
   result.events = events
   result.keycardService = keycardService
   result.settingsService = settingsService
+  result.networkService = networkService
   result.privacyService = privacyService
   result.accountsService = accountsService
   result.walletAccountService = walletAccountService
@@ -102,7 +106,7 @@ proc createSharedKeycardModule(self: Module) =
     self.view.emitSharedModuleBusy()
     return
   self.keycardSharedModule = keycard_shared_module.newModule[Module](self, UNIQUE_SETTING_KEYCARD_MODULE_IDENTIFIER, 
-    self.events, self.keycardService, self.settingsService, self.privacyService, self.accountsService, 
+    self.events, self.keycardService, self.settingsService, self.networkService, self.privacyService, self.accountsService, 
     self.walletAccountService, self.keychainService)
 
 method onSharedKeycarModuleFlowTerminated*(self: Module, lastStepInTheCurrentFlow: bool) =

--- a/src/app/modules/main/profile_section/module.nim
+++ b/src/app/modules/main/profile_section/module.nim
@@ -106,8 +106,8 @@ proc newModule*(delegate: delegate_interface.AccessInterface,
     result, events, settingsService, ensService, walletAccountService, networkService, tokenService
   )
   result.communitiesModule = communities_module.newModule(result, communityService)
-  result.keycardModule = keycard_module.newModule(result, events, keycardService, settingsService, privacyService, 
-    accountsService, walletAccountService, keychainService)
+  result.keycardModule = keycard_module.newModule(result, events, keycardService, settingsService, networkService, 
+    privacyService, accountsService, walletAccountService, keychainService)
 
   singletonInstance.engine.setRootContextProperty("profileSectionModule", result.viewVariant)
 

--- a/src/app/modules/main/wallet_section/accounts/module.nim
+++ b/src/app/modules/main/wallet_section/accounts/module.nim
@@ -237,7 +237,7 @@ method onUserAuthenticated*(self: Module, pin: string, password: string, keyUid:
 method createSharedKeycardModule*(self: Module) =
   if self.keycardSharedModule.isNil:
     self.keycardSharedModule = keycard_shared_module.newModule[Module](self, UNIQUE_WALLET_SECTION_ACCOUNTS_MODULE_IDENTIFIER, 
-      self.events, self.keycardService, settingsService = nil, privacyService = nil, self.accountsService, 
+      self.events, self.keycardService, settingsService = nil, networkService = nil, privacyService = nil, self.accountsService, 
       self.walletAccountService, keychainService = nil)
 
 method destroySharedKeycarModule*(self: Module) =

--- a/src/app/modules/shared_modules/keycard_popup/io_interface.nim
+++ b/src/app/modules/shared_modules/keycard_popup/io_interface.nim
@@ -1,6 +1,7 @@
-import NimQml
+import NimQml, tables
 import ../../../../app/core/eventemitter
 from ../../../../app_service/service/keycard/service import KeycardEvent, CardMetadata, KeyDetails
+from ../../../../app_service/service/wallet_account/service as wallet_account_service import WalletTokenDto
 import models/key_pair_item
 
 const SIGNAL_SHARED_KEYCARD_MODULE_USER_AUTHENTICATED_AND_WALLET_ADDRESS_GENERATED* = "sharedKeycarModuleUserAuthenticatedAndWalletAddressGenerated"
@@ -200,6 +201,9 @@ method syncKeycardBasedOnAppState*(self: AccessInterface, keyUid: string, pin: s
   raise newException(ValueError, "No implementation available")
 
 method getPin*(self: AccessInterface): string {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method onTokensRebuilt*(self: AccessInterface, accountsTokens: OrderedTable[string, seq[WalletTokenDto]]) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 type

--- a/src/app/modules/shared_modules/keycard_popup/models/key_pair_account_item.nim
+++ b/src/app/modules/shared_modules/keycard_popup/models/key_pair_account_item.nim
@@ -10,12 +10,13 @@ QtObject:
     color: string
     icon: string
     balance: float
+    balanceFetched: bool
 
   proc delete*(self: KeyPairAccountItem) =
     self.QObject.delete
 
   proc newKeyPairAccountItem*(name = "", path = "", address = "", pubKey = "", emoji = "", color = "", icon = "", 
-    balance = 0.0): KeyPairAccountItem =
+    balance = 0.0, balanceFetched = true): KeyPairAccountItem =
     new(result, delete)
     result.QObject.setup
     result.name = name
@@ -26,6 +27,7 @@ QtObject:
     result.color = color
     result.icon = icon
     result.balance = balance
+    result.balanceFetched = balanceFetched
 
   proc `$`*(self: KeyPairAccountItem): string =
     result = fmt"""KeyPairAccountItem[
@@ -37,7 +39,8 @@ QtObject:
       color: {self.color},
       icon: {self.icon},
       icon: {$self.icon},
-      balance: {self.balance}
+      balance: {self.balance},
+      balanceFetched: {self.balanceFetched}
       ]"""
 
   proc nameChanged*(self: KeyPairAccountItem) {.signal.}
@@ -122,8 +125,15 @@ QtObject:
     return self.balance
   proc setBalance*(self: KeyPairAccountItem, value: float) {.slot.} =
     self.balance = value
+    self.balanceFetched = true
     self.balanceChanged()
   QtProperty[float] balance:
     read = getBalance
     write = setBalance
+    notify = balanceChanged
+
+  proc getBalanceFetched*(self: KeyPairAccountItem): bool {.slot.} =
+    return self.balanceFetched
+  QtProperty[bool] balanceFetched:
+    read = getBalanceFetched
     notify = balanceChanged

--- a/src/app/modules/shared_modules/keycard_popup/models/key_pair_account_model.nim
+++ b/src/app/modules/shared_modules/keycard_popup/models/key_pair_account_model.nim
@@ -119,4 +119,9 @@ QtObject:
         if emoji.len > 0:
           self.items[i].setEmoji(emoji)
         return
+
+  proc setBalanceForAddress*(self: KeyPairAccountModel, address: string, balance: float) =
+    for i in 0 ..< self.items.len:
+      if cmpIgnoreCase(self.items[i].getAddress(), address) == 0:
+        self.items[i].setBalance(balance)
       

--- a/src/app/modules/shared_modules/keycard_popup/models/key_pair_item.nim
+++ b/src/app/modules/shared_modules/keycard_popup/models/key_pair_item.nim
@@ -196,6 +196,8 @@ QtObject:
     return self.accounts.containsPathOutOfTheDefaultStatusDerivationTree()
   proc updateDetailsForAccountWithAddressIfTheyAreSet*(self: KeyPairItem, address, name, color, emoji: string) =
     self.accounts.updateDetailsForAddressIfTheyAreSet(address, name, color, emoji)
+  proc setBalanceForAddress*(self: KeyPairItem, address: string, balance: float) =
+    self.accounts.setBalanceForAddress(address, balance)
 
   proc setItem*(self: KeyPairItem, item: KeyPairItem) =
     self.setKeyUid(item.getKeyUid())

--- a/src/app/modules/startup/module.nim
+++ b/src/app/modules/startup/module.nim
@@ -129,7 +129,7 @@ method getKeycardSharedModule*[T](self: Module[T]): QVariant =
 
 proc createSharedKeycardModule[T](self: Module[T]) =
   self.keycardSharedModule = keycard_shared_module.newModule[Module[T]](self, UNIQUE_STARTUP_MODULE_IDENTIFIER, 
-    self.events, self.keycardService, settingsService = nil, privacyService = nil, self.accountsService, 
+    self.events, self.keycardService, settingsService = nil, networkService = nil, privacyService = nil, self.accountsService, 
     walletAccountService = nil, self.keychainService)
 
 method moveToLoadingAppState*[T](self: Module[T]) =

--- a/src/app_service/service/wallet_account/async_tasks.nim
+++ b/src/app_service/service/wallet_account/async_tasks.nim
@@ -112,11 +112,21 @@ const fetchDerivedAddressDetailsTask*: Task = proc(argEncoded: string) {.gcsafe,
 type
   BuildTokensTaskArg = ref object of QObjectTaskArg
     accounts: seq[string]
+    storeResult: bool
 
 const prepareTokensTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[BuildTokensTaskArg](argEncoded)
-  let response = backend.getWalletToken(arg.accounts)
-  arg.finish(response.result)
+  var output = %*{
+    "result": "",
+    "storeResult": false
+  }
+  try:
+    let response = backend.getWalletToken(arg.accounts)
+    output["result"] = response.result
+    output["storeResult"] = %* arg.storeResult
+  except Exception as e:
+    let err = fmt"Error getting wallet tokens"
+  arg.finish(output)
 
 #################################################
 # Async add migrated keypair

--- a/ui/app/AppLayouts/Chat/stores/StickersStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/StickersStore.qml
@@ -6,7 +6,7 @@ QtObject {
 
     property var stickersModule
 
-    property var walletAccounts: walletSectionAccounts.model
+    property var walletAccounts: Global.appIsReady? walletSectionAccounts.model : null
 
     function getSigningPhrase() {
         if(!root.stickersModule)

--- a/ui/app/AppLayouts/Profile/stores/ContactsStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/ContactsStore.qml
@@ -7,9 +7,9 @@ QtObject {
     property var contactsModule
 
     property var globalUtilsInst: globalUtils
-    property var mainModuleInst: mainModule
+    property var mainModuleInst: Global.appIsReady? mainModule : null
 
-    property string myPublicKey: userProfile.pubKey
+    property string myPublicKey: !!Global.userProfile? Global.userProfile.pubKey : ""
 
     property var myContactsModel: contactsModule.myMutualContactsModel
     property var blockedContactsModel: contactsModule.blockedContactsModel

--- a/ui/app/AppLayouts/Profile/stores/EnsUsernamesStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/EnsUsernamesStore.qml
@@ -17,14 +17,14 @@ QtObject {
         }
     }
 
-    property string pubkey: userProfile.pubKey
-    property string icon: userProfile.icon
-    property string preferredUsername: userProfile.preferredName
+    property string pubkey: !!Global.userProfile? Global.userProfile.pubKey : ""
+    property string icon: !!Global.userProfile? Global.userProfile.icon : ""
+    property string preferredUsername: !!Global.userProfile? Global.userProfile.preferredName : ""
     readonly property string chainId: ensUsernamesModule.chainId
 
-    property string username: userProfile.username
+    property string username: !!Global.userProfile? Global.userProfile.username : ""
 
-    property var walletAccounts: walletSectionAccounts.model
+    property var walletAccounts: Global.appIsReady? walletSectionAccounts.model : null
 
     function setPrefferedEnsUsername(ensName) {
         if(!root.ensUsernamesModule)

--- a/ui/app/AppLayouts/Profile/stores/ProfileSectionStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/ProfileSectionStore.qml
@@ -67,11 +67,11 @@ QtObject {
         stickersModule: stickersModuleInst
     }
 
-    property bool browserMenuItemEnabled: localAccountSensitiveSettings.isBrowserEnabled
-    property bool walletMenuItemEnabled: localAccountSensitiveSettings.isWalletEnabled
+    property bool browserMenuItemEnabled: Global.appIsReady? localAccountSensitiveSettings.isBrowserEnabled : false
+    property bool walletMenuItemEnabled: Global.appIsReady? localAccountSensitiveSettings.isWalletEnabled : false
 
-    property var communitiesModuleInst: communitiesModule
-    property var communitiesList: communitiesModuleInst.model
+    property var communitiesModuleInst: Global.appIsReady? communitiesModule : null
+    property var communitiesList: !!communitiesModuleInst? communitiesModuleInst.model : null
     property var communitiesProfileModule: profileSectionModuleInst.communitiesModule
 
     property ListModel mainMenuItems: ListModel {

--- a/ui/app/AppLayouts/Profile/stores/ProfileStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/ProfileStore.qml
@@ -6,14 +6,14 @@ QtObject {
 
     property var profileModule
 
-    property string pubkey: userProfile.pubKey
-    property string name: userProfile.name
-    property string username: userProfile.username
-    property string displayName: userProfile.displayName
-    property string preferredName: userProfile.preferredName
-    property string profileLargeImage: userProfile.largeImage
-    property string icon: userProfile.icon
-    property bool userDeclinedBackupBanner: localAccountSensitiveSettings.userDeclinedBackupBanner
+    property string pubkey: !!Global.userProfile? Global.userProfile.pubKey : ""
+    property string name: !!Global.userProfile? Global.userProfile.name : ""
+    property string username: !!Global.userProfile? Global.userProfile.username : ""
+    property string displayName: !!Global.userProfile? Global.userProfile.displayName : ""
+    property string preferredName: !!Global.userProfile? Global.userProfile.preferredName : ""
+    property string profileLargeImage: !!Global.userProfile? Global.userProfile.largeImage : ""
+    property string icon: !!Global.userProfile? Global.userProfile.icon : ""
+    property bool userDeclinedBackupBanner: Global.appIsReady? localAccountSensitiveSettings.userDeclinedBackupBanner : false
     property var privacyStore: profileSectionModule.privacyModule
 
     readonly property string bio: profileModule.bio

--- a/ui/app/AppLayouts/Profile/stores/WalletStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/WalletStore.qml
@@ -1,11 +1,12 @@
 import QtQuick 2.13
 
 import "../../Wallet/stores"
+import utils 1.0
 
 QtObject {
     id: root
 
-    property var accountSensitiveSettings: localAccountSensitiveSettings
+    property var accountSensitiveSettings: Global.appIsReady? localAccountSensitiveSettings : null
 
     property var areTestNetworksEnabled: networksModule.areTestNetworksEnabled
     property var layer1Networks: networksModule.layer1
@@ -16,12 +17,12 @@ QtObject {
         networksModule.toggleTestNetworksEnabled()
     }
 
-    property var accounts: walletSectionAccounts.model
-    property var importedAccounts: walletSectionAccounts.imported
-    property var generatedAccounts: walletSectionAccounts.generated
-    property var watchOnlyAccounts: walletSectionAccounts.watchOnly
+    property var accounts: Global.appIsReady? walletSectionAccounts.model : null
+    property var importedAccounts: Global.appIsReady? walletSectionAccounts.imported : null
+    property var generatedAccounts: Global.appIsReady? walletSectionAccounts.generated : null
+    property var watchOnlyAccounts: Global.appIsReady? walletSectionAccounts.watchOnly : null
     
-    property var currentAccount: walletSectionCurrent
+    property var currentAccount: Global.appIsReady? walletSectionCurrent : null
 
     function switchAccountByAddress(address) {
         walletSection.switchAccountByAddress(address)
@@ -35,7 +36,7 @@ QtObject {
         return walletSectionCurrent.update(address, accountName, color, emoji)
     }
 
-    property var dappList: dappPermissionsModule.dapps
+    property var dappList: Global.appIsReady? dappPermissionsModule.dapps : null
 
     function disconnect(dappName) {
         dappPermissionsModule.disconnect(dappName)

--- a/ui/imports/shared/popups/keycard/helpers/KeyPairUnknownItem.qml
+++ b/ui/imports/shared/popups/keycard/helpers/KeyPairUnknownItem.qml
@@ -126,17 +126,34 @@ Rectangle {
                         Layout.preferredHeight: parent.height
                     }
 
-                    StatusBaseText {
-                        Layout.alignment: Qt.AlignVCenter
-                        text: {
-                            return LocaleUtils.currencyAmountToLocaleString({
-                                        amount: parseFloat(model.account.balance.amount),
-                                        symbol: SharedStore.RootStore.currencyStore.currentCurrencySymbol,
-                                        displayDecimals: 2})
+                    Component {
+                        id: balance
+                        StatusBaseText {
+
+                            text: {
+                                return LocaleUtils.currencyAmountToLocaleString({
+                                                                                    amount: parseFloat(model.account.balance),
+                                                                                    symbol: SharedStore.RootStore.currencyStore.currentCurrencySymbol,
+                                                                                    displayDecimals: 2})
+                            }
+                            wrapMode: Text.WordWrap
+                            font.pixelSize: Constants.keycard.general.fontSize2
+                            color: Theme.palette.baseColor1
                         }
-                        wrapMode: Text.WordWrap
-                        font.pixelSize: Constants.keycard.general.fontSize2
-                        color: Theme.palette.baseColor1
+                    }
+
+                    Component {
+                        id: fetchingBalance
+                        StatusLoadingIndicator {
+                            width: 12
+                            height: 12
+                        }
+                    }
+
+                    Loader {
+                        id: fetchLoaderIndicator
+                        Layout.alignment: Qt.AlignVCenter
+                        sourceComponent: model.account.balanceFetched? balance : fetchingBalance
                     }
                 }
             }

--- a/ui/imports/shared/stores/CurrenciesStore.qml
+++ b/ui/imports/shared/stores/CurrenciesStore.qml
@@ -27,7 +27,7 @@ QtObject {
         return 0;
     }
 
-    property string currentCurrency: walletSection.currentCurrency
+    property string currentCurrency: Global.appIsReady? walletSection.currentCurrency : ""
     property int currentCurrencyModelIndex: getModelIndexForShortName(currentCurrency)
     property string currentCurrencySymbol: currenciesModel.get(currentCurrencyModelIndex).symbol
 

--- a/ui/imports/shared/stores/RootStore.qml
+++ b/ui/imports/shared/stores/RootStore.qml
@@ -1,6 +1,7 @@
 pragma Singleton
 
 import QtQuick 2.12
+import utils 1.0
 
 QtObject {
     id: root
@@ -11,10 +12,10 @@ QtObject {
 
     property var profileSectionModuleInst: profileSectionModule
     property var privacyModule: profileSectionModuleInst.privacyModule
-    property var userProfileInst: !!userProfile ? userProfile : null
-    property var walletSectionInst: !!walletSection ? walletSection : null
-    property var appSettingsInst: !!appSettings ? appSettings : null
-    property var accountSensitiveSettings: !!localAccountSensitiveSettings ? localAccountSensitiveSettings : null
+    property var userProfileInst: !!Global.userProfile? Global.userProfile : null
+    property var walletSectionInst: Global.appIsReady && !!walletSection? walletSection : null
+    property var appSettingsInst: Global.appIsReady && !!appSettings? appSettings : null
+    property var accountSensitiveSettings: Global.appIsReady && !!localAccountSensitiveSettings? localAccountSensitiveSettings : null
     property real volume: !!appSettingsInst ? appSettingsInst.volume * 0.01 : 0.5
     property bool isWalletEnabled: !!accountSensitiveSettings ? accountSensitiveSettings.isWalletEnabled : false
     property bool notificationSoundsEnabled: !!appSettingsInst ? appSettingsInst.notificationSoundsEnabled : true
@@ -28,18 +29,18 @@ QtObject {
 //    property string gasEthValue: !!walletModelInst ? walletModelInst.gasView.getGasEthValue : "0"
 
     property CurrenciesStore currencyStore: CurrenciesStore {}
-    property string currentCurrency: walletSection.currentCurrency
+    property string currentCurrency: Global.appIsReady? walletSection.currentCurrency : ""
 //    property string defaultCurrency: !!walletModelInst ? walletModelInst.balanceView.defaultCurrency : "0"
 //    property string fiatValue: !!walletModelInst ? walletModelInst.balanceView.getFiatValue : "0"
 //    property string cryptoValue: !!walletModelInst ? walletModelInst.balanceView.getCryptoValue : "0"
 
     property var history: typeof walletSectionTransactions !== "undefined" ? walletSectionTransactions
                                                                           : null
-    property var historyTransactions: walletSectionTransactions.model
+    property var historyTransactions: Global.appIsReady? walletSectionTransactions.model : null
     property bool isNonArchivalNode: history ? history.isNonArchivalNode
                                              : false
-    property bool tokensLoading: walletSection.tokensLoading
-    property var currentAccount: walletSectionCurrent
+    property bool tokensLoading: Global.appIsReady? walletSection.tokensLoading : false
+    property var currentAccount: Global.appIsReady? walletSectionCurrent : null
     property var marketValueStore: TokenMarketValuesStore{}
 
     function getNetworkColor(chainId) {
@@ -183,7 +184,9 @@ QtObject {
     }
 
     function findTokenSymbolByAddress(address) {
-        return  walletSectionAllTokens.findTokenSymbolByAddress(address)
+        if (Global.appIsReady)
+            return walletSectionAllTokens.findTokenSymbolByAddress(address)
+        return ""
     }
 
     function getNameForSavedWalletAddress(address) {
@@ -223,16 +226,18 @@ QtObject {
     }
 
     function getHistoricalDataForToken(symbol, currency) {
-        walletSectionAllTokens.getHistoricalDataForToken(symbol,currency)
+        if (Global.appIsReady)
+            walletSectionAllTokens.getHistoricalDataForToken(symbol,currency)
     }
 
-    property bool marketHistoryIsLoading: walletSectionAllTokens.marketHistoryIsLoading
+    property bool marketHistoryIsLoading: Global.appIsReady? walletSectionAllTokens.marketHistoryIsLoading : false
 
     // TODO: range until we optimize to cache the data and abuse the requests
     function fetchHistoricalBalanceForTokenAsJson(address, tokenSymbol, currencySymbol, timeIntervalEnum) {
-        walletSectionAllTokens.fetchHistoricalBalanceForTokenAsJson(address, tokenSymbol, currencySymbol, timeIntervalEnum)
+        if (Global.appIsReady)
+            walletSectionAllTokens.fetchHistoricalBalanceForTokenAsJson(address, tokenSymbol, currencySymbol, timeIntervalEnum)
     }
 
-    property bool balanceHistoryIsLoading: walletSectionAllTokens.balanceHistoryIsLoading
+    property bool balanceHistoryIsLoading: Global.appIsReady? walletSectionAllTokens.balanceHistoryIsLoading : false
 
 }

--- a/ui/imports/utils/Global.qml
+++ b/ui/imports/utils/Global.qml
@@ -11,6 +11,7 @@ QtObject {
     property int settingsSubsection: Constants.settingsSubsection.profile
 
     property var userProfile
+    property bool appIsReady: false
 
     signal openPinnedMessagesPopupRequested(var store, var messageStore, var pinnedMessagesModel, string messageToPin)
     signal openCommunityProfilePopupRequested(var store, var community, var chatCommunitySectionModule)

--- a/ui/main.qml
+++ b/ui/main.qml
@@ -165,6 +165,7 @@ StatusWindow {
                 appLoadingAnimation.active = localAppSettings && localAppSettings.fakeLoadingScreenEnabled
                 appLoadingAnimation.runningProgressAnimation = localAppSettings && localAppSettings.fakeLoadingScreenEnabled
                 Global.userProfile = userProfile
+                Global.appIsReady = true
 
                 loader.sourceComponent = app
 


### PR DESCRIPTION
There are 2 logically different contexts where we can run factory reset flow:
- before user logs in
- after user logs in

For the first case, because of the current limitations (fixing this entails many other things) cause `getWalletToken` call is a json rpc endpoint on the status-go side, therefore it is unavailable before user logs in, we display always 0$ for balance. 

Maybe we can check with the design team and remove that info in that context or invest more time and try to make `getWalletToken` call available even user is not logged in. @alaibe what do you think?

For the second case loading indicator will be shown till the balance is fetched and calculated.

The second commit, cleans the log from warnings caused by undefined context props mostly.

Fixes: #9418