### PR TITLE
fix(@desktop/keycard): update logic of enabling action buttons during the flow

### DIFF
--- a/ui/imports/shared/popups/keycard/KeycardPopup.qml
+++ b/ui/imports/shared/popups/keycard/KeycardPopup.qml
@@ -13,7 +13,8 @@ StatusModal {
     property var emojiPopup
 
     width: Constants.keycard.general.popupWidth
-    closePolicy: d.disablePopupClose? Popup.NoAutoClose : Popup.CloseOnEscape
+    closePolicy: d.disableActionPopupButtons? Popup.NoAutoClose : Popup.CloseOnEscape
+    hasCloseButton: !d.disableActionPopupButtons
 
     header.title: {
         switch (root.sharedKeycardModule.currentState.flowType) {
@@ -51,10 +52,6 @@ StatusModal {
     KeycardPopupDetails {
         id: d
         sharedKeycardModule: root.sharedKeycardModule
-
-        onDisablePopupCloseChanged: {
-            hasCloseButton = !disablePopupClose
-        }
     }
 
     onClosed: {

--- a/ui/imports/shared/popups/keycard/KeycardPopupDetails.qml
+++ b/ui/imports/shared/popups/keycard/KeycardPopupDetails.qml
@@ -13,15 +13,14 @@ QtObject {
     property bool primaryButtonEnabled: false
 
     // disables action buttons (back, cancel, primary, secondary) and close button (upper right "X" button) as well
-    readonly property bool disableActionPopupButtons: root.sharedKeycardModule.disablePopup
-
-    readonly property bool disablePopupClose: { // disables popup close button (upper right "X" button)
-        if (root.disableActionPopupButtons) {
+    readonly property bool disableActionPopupButtons: {
+        if (root.sharedKeycardModule.disablePopup) {
             return true
         }
 
         switch (root.sharedKeycardModule.currentState.stateType) {
 
+        case Constants.keycardSharedState.keycardInserted:
         case Constants.keycardSharedState.readingKeycard:
         case Constants.keycardSharedState.recognizedKeycard:
         case Constants.keycardSharedState.renamingKeycard:
@@ -464,8 +463,6 @@ QtObject {
                         switch (root.sharedKeycardModule.currentState.stateType) {
                         case Constants.keycardSharedState.pluginReader:
                         case Constants.keycardSharedState.insertKeycard:
-                        case Constants.keycardSharedState.keycardInserted:
-                        case Constants.keycardSharedState.readingKeycard:
                         case Constants.keycardSharedState.notKeycard:
                         case Constants.keycardSharedState.wrongKeycard:
                         case Constants.keycardSharedState.keycardEmpty:
@@ -999,7 +996,6 @@ QtObject {
 
                     case Constants.keycardSharedState.pluginReader:
                     case Constants.keycardSharedState.insertKeycard:
-                    case Constants.keycardSharedState.keycardInserted:
                     case Constants.keycardSharedState.recognizedKeycard:
                     case Constants.keycardSharedState.createPin:
                     case Constants.keycardSharedState.repeatPin:
@@ -1061,9 +1057,7 @@ QtObject {
                     switch (root.sharedKeycardModule.currentState.stateType) {
 
                     case Constants.keycardSharedState.pluginReader:
-                    case Constants.keycardSharedState.readingKeycard:
                     case Constants.keycardSharedState.insertKeycard:
-                    case Constants.keycardSharedState.keycardInserted:
                     case Constants.keycardSharedState.wrongPin:
                     case Constants.keycardSharedState.wrongKeychainPin:
                     case Constants.keycardSharedState.notKeycard:


### PR DESCRIPTION
During my work on other issue, I noticed that some buttons were enabled for some states (keycard inserted, reading...) when they should not be. Logic updated.