### PR TITLE
fix(MessageView): Show message when there is one img preview and extra text

### DIFF
--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -693,7 +693,8 @@ Loader {
                         onLinksLoaded: {
                             // If there is only one image and no links, hide the message
                             // Handled in linksLoaded signal to evaulate it only once
-                            d.hideMessage = linksMessageView.unfurledImagesCount === 1 && linksMessageView.unfurledLinksCount === 0
+                            d.hideMessage = linksMessageView.unfurledImagesCount === 1 && linksMessageView.unfurledLinksCount === 0 
+                                            && `<p>${root.linkUrls}</p>` === root.messageText
                         }
                     }
                 }


### PR DESCRIPTION
### What does the PR do
Fixing regression from LinksMessagePreview refactoring where if the message contains text + image url, the message will be hidden.

Issue found here: https://github.com/status-im/status-mobile/issues/15065

### Affected areas
MessageView

### Screenshot of functionality (including design for comparison)

<img width="1399" alt="Screenshot 2023-02-15 at 15 52 18" src="https://user-images.githubusercontent.com/47811206/219046012-589e9384-cb41-40c6-a150-b92308f33903.png">
