### PR TITLE
fix: App crashes on uploading an image containing "+" in its name

### DIFF
--- a/src/app/global/utils.nim
+++ b/src/app/global/utils.nim
@@ -22,7 +22,7 @@ QtObject:
     result.setup
 
   proc formatImagePath*(self: Utils, imagePath: string): string =
-    result = uri.decodeUrl(replace(imagePath, "file://", ""))
+    result = uri.decodeUrl(replace(imagePath, "file://", ""), decodePlus=false)
     if defined(windows):
       # Windows doesn't work with paths starting with a slash
       result.removePrefix('/')

--- a/ui/imports/shared/status/StatusChatImageSizeValidator.qml
+++ b/ui/imports/shared/status/StatusChatImageSizeValidator.qml
@@ -1,10 +1,6 @@
 import QtQuick 2.13
-import QtQuick.Controls 2.13
-import QtQuick.Layouts 1.13
-import QtGraphicalEffects 1.0
 
 import utils 1.0
-import ".."
 
 StatusChatImageValidator {
     id: root


### PR DESCRIPTION
as we're dealing with local file URLs only here, we don't want to turn the plus signs (`+`) into spaces (leads to failing to open the file, emits an exception, crashes later on in our JS code)

Fixes #9538

### What does the PR do

Fixes a crash trying to open/upload an image

### Affected areas

globalUtils

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

Opening an image with a `+` in its filename:
![Snímek obrazovky z 2023-02-15 16-34-51](https://user-images.githubusercontent.com/5377645/219082762-256ff26f-1e6c-448c-b2e6-e73952f592e6.png)

Image uploaded with no crash:
![Snímek obrazovky z 2023-02-15 16-37-13](https://user-images.githubusercontent.com/5377645/219082770-0ee32eeb-aece-4691-a4d5-f66841f6bd25.png)

