### PR TITLE
chore(CommunityPermissions): Use enum for token category, keep string labels in UI only

### DIFF
--- a/storybook/src/Models/AssetsModel.qml
+++ b/storybook/src/Models/AssetsModel.qml
@@ -1,5 +1,7 @@
 import QtQuick 2.0
 
+import AppLayouts.Chat.controls.community 1.0
+
 ListModel {
     Component.onCompleted:
         append([
@@ -8,35 +10,35 @@ ListModel {
                        iconSource: ModelsData.assets.socks,
                        name: "Unisocks",
                        shortName: "SOCKS",
-                       category: "Community assets"
+                       category: TokenCategories.Category.Community
                    },
                    {
                        key: "zrx",
                        iconSource: ModelsData.assets.zrx,
                        name: "Ox",
                        shortName: "ZRX",
-                       category: "Listed assets"
+                       category: TokenCategories.Category.Own
                    },
                    {
                        key: "1inch",
                        iconSource: ModelsData.assets.inch,
                        name: "1inch",
                        shortName: "1INCH",
-                       category: "Listed assets"
+                       category: TokenCategories.Category.Own
                    },
                    {
                        key: "Aave",
                        iconSource: ModelsData.assets.aave,
                        name: "Aave",
                        shortName: "AAVE",
-                       category: "Listed assets"
+                       category: TokenCategories.Category.Own
                    },
                    {
                        key: "Amp",
                        iconSource: ModelsData.assets.amp,
                        name: "Amp",
                        shortName: "AMP",
-                       category: "Listed assets"
+                       category: TokenCategories.Category.Own
                    }
                ])
 }

--- a/storybook/src/Models/CollectiblesModel.qml
+++ b/storybook/src/Models/CollectiblesModel.qml
@@ -1,4 +1,6 @@
-import QtQuick 2.0
+import QtQuick 2.15
+
+import AppLayouts.Chat.controls.community 1.0
 
 ListModel {
     Component.onCompleted:
@@ -7,13 +9,13 @@ ListModel {
                        key: "Anniversary",
                        iconSource: ModelsData.collectibles.anniversary,
                        name: "Anniversary",
-                       category: "Community collectibles"
+                       category: TokenCategories.Category.Community
                    },
                    {
                        key: "CryptoKitties",
                        iconSource: ModelsData.collectibles.cryptoKitties,
                        name: "CryptoKitties",
-                       category: "Your collectibles",
+                       category: TokenCategories.Category.Own,
                        subItems: [
                            {
                                key: "Kitty1",
@@ -63,13 +65,13 @@ ListModel {
                        key: "SuperRare",
                        iconSource: ModelsData.collectibles.superRare,
                        name: "SuperRare",
-                       category: "Your collectibles"
+                       category: TokenCategories.Category.Own
                    },
                    {
                        key: "Custom",
                        iconSource: ModelsData.collectibles.custom,
                        name: "Custom Collectible",
-                       category: "All collectibles"
+                       category: TokenCategories.Category.General
                    }
                ])
 }

--- a/ui/app/AppLayouts/Chat/controls/community/ExtendedDropdownContent.qml
+++ b/ui/app/AppLayouts/Chat/controls/community/ExtendedDropdownContent.qml
@@ -99,6 +99,20 @@ Item {
                                     searcher.text.toLowerCase())
                     }
                 }
+
+                proxyRoles: ExpressionRole {
+                    name: "categoryLabel"
+
+                    function getCategoryLabelForType(category, type) {
+                        if (type === ExtendedDropdownContent.Type.Assets)
+                            return TokenCategories.getCategoryLabelForAsset(category)
+
+                        return TokenCategories.getCategoryLabelForCollectible(category)
+                    }
+
+                    expression: getCategoryLabelForType(model.category, root.type)
+
+               }
             }
         }
 

--- a/ui/app/AppLayouts/Chat/controls/community/ListDropdownContent.qml
+++ b/ui/app/AppLayouts/Chat/controls/community/ListDropdownContent.qml
@@ -93,7 +93,7 @@ StatusListView {
                                         model.subItems)
     }
 
-    section.property: root.searchMode ? "" : "category"
+    section.property: root.searchMode ? "" : "categoryLabel"
     section.criteria: ViewSection.FullString
 
     section.delegate: Item {

--- a/ui/app/AppLayouts/Chat/controls/community/TokenCategories.qml
+++ b/ui/app/AppLayouts/Chat/controls/community/TokenCategories.qml
@@ -1,0 +1,35 @@
+pragma Singleton
+
+import QtQml 2.15
+
+QtObject {
+    enum Category {
+        Community, Own, General
+    }
+
+    function getCategoryLabelForAsset(category) {
+        switch (category) {
+            case TokenCategories.Category.Community:
+                return qsTr("Community assets")
+            case TokenCategories.Category.Own:
+                return qsTr("Your assets")
+            case TokenCategories.Category.General:
+                return qsTr("All assets")
+        }
+
+        return ""
+    }
+
+    function getCategoryLabelForCollectible(category) {
+        switch (category) {
+            case TokenCategories.Category.Community:
+                return qsTr("Community collectibles")
+            case TokenCategories.Category.Own:
+                return qsTr("Your collectibles")
+            case TokenCategories.Category.General:
+                return qsTr("All collectibles")
+        }
+
+        return ""
+    }
+}

--- a/ui/app/AppLayouts/Chat/controls/community/qmldir
+++ b/ui/app/AppLayouts/Chat/controls/community/qmldir
@@ -4,3 +4,4 @@ HoldingTypes 1.0 HoldingTypes.qml
 HoldingsDropdown 1.0 HoldingsDropdown.qml
 InDropdown 1.0 InDropdown.qml
 PermissionItem 1.0 PermissionItem.qml
+singleton TokenCategories 1.0 TokenCategories.qml

--- a/ui/app/AppLayouts/Chat/stores/CommunitiesStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/CommunitiesStore.qml
@@ -1,5 +1,7 @@
 import QtQuick 2.0
 
+import AppLayouts.Chat.controls.community 1.0
+
 QtObject {
     id: root
 
@@ -18,70 +20,108 @@ QtObject {
 
     // TODO: Replace to real data, now dummy model
     property var  assetsModel: ListModel {
-        ListElement {key: "socks"; iconSource: "qrc:imports/assets/png/tokens/SOCKS.png"; name: "Unisocks"; shortName: "SOCKS"; category: "Community assets"}
-        ListElement {key: "zrx"; iconSource: "qrc:imports/assets/png/tokens/ZRX.png"; name: "Ox"; shortName: "ZRX"; category: "Listed assets"}
-        ListElement {key: "1inch"; iconSource: "qrc:imports/assets/png/tokens/CUSTOM-TOKEN.png"; name: "1inch"; shortName: "ZRX"; category: "Listed assets"}
-        ListElement {key: "Aave"; iconSource: "qrc:imports/assets/png/tokens/CUSTOM-TOKEN.png"; name: "Aave"; shortName: "AAVE"; category: "Listed assets"}
-        ListElement {key: "Amp"; iconSource: "qrc:imports/assets/png/tokens/CUSTOM-TOKEN.png"; name: "Amp"; shortName: "AMP"; category: "Listed assets"}
+        Component.onCompleted: {
+            append([
+                       {
+                           key: "socks",
+                           iconSource: "qrc:imports/assets/png/tokens/SOCKS.png",
+                           name: "Unisocks",
+                           shortName: "SOCKS",
+                           category: TokenCategories.Category.Community
+                       },
+                       {
+                           key: "zrx",
+                           iconSource: "qrc:imports/assets/png/tokens/ZRX.png",
+                           name: "Ox",
+                           shortName: "ZRX",
+                           category: TokenCategories.Category.Own
+                       },
+                       {
+                           key: "1inch",
+                           iconSource: "qrc:imports/assets/png/tokens/CUSTOM-TOKEN.png",
+                           name: "1inch",
+                           shortName: "ZRX",
+                           category: TokenCategories.Category.Own
+                       },
+                       {
+                           key: "Aave",
+                           iconSource: "qrc:imports/assets/png/tokens/CUSTOM-TOKEN.png",
+                           name: "Aave",
+                           shortName: "AAVE",
+                           category: TokenCategories.Category.Own
+                       },
+                       {
+                           key: "Amp",
+                           iconSource: "qrc:imports/assets/png/tokens/CUSTOM-TOKEN.png",
+                           name: "Amp",
+                           shortName: "AMP",
+                           category: TokenCategories.Category.Own
+                       }
+                   ])
+        }
     }
 
     // TODO: Replace to real data, now dummy model
     property var collectiblesModel: ListModel {
-        ListElement {
-            key: "Anniversary"
-            iconSource: "qrc:imports/assets/png/collectibles/Anniversary.png"
-            name: "Anniversary"
-            category: "Community collectibles"
-        }
-        ListElement {
-            key: "CryptoKitties"
-            iconSource: "qrc:imports/assets/png/collectibles/CryptoKitties.png"
-            name: "CryptoKitties"
-            category: "Your collectibles"
-            subItems: [
-                ListElement {
-                    key: "Kitty1"
-                    iconSource: "qrc:imports/assets/png/collectibles/Furbeard.png"
-                    imageSource: "qrc:imports/assets/png/collectibles/FurbeardBig.png"
-                    name: "Furbeard"
-                },
-                ListElement {
-                    key: "Kitty2"
-                    iconSource: "qrc:imports/assets/png/collectibles/Magicat.png"
-                    imageSource: "qrc:imports/assets/png/collectibles/MagicatBig.png"
-                    name: "Magicat"
-                },
-                ListElement {
-                    key: "Kitty3"
-                    iconSource: "qrc:imports/assets/png/collectibles/HappyMeow.png"
-                    imageSource: "qrc:imports/assets/png/collectibles/HappyMeowBig.png"
-                    name: "Happy Meow"
-                },
-                ListElement {
-                    key: "Kitty4"
-                    iconSource: "qrc:imports/assets/png/collectibles/Furbeard.png"
-                    imageSource: "qrc:imports/assets/png/collectibles/FurbeardBig.png"
-                    name: "Furbeard-2"
-                },
-                ListElement {
-                    key: "Kitty5"
-                    iconSource: "qrc:imports/assets/png/collectibles/Magicat.png"
-                    imageSource: "qrc:imports/assets/png/collectibles/MagicatBig.png"
-                    name: "Magicat-3"
-                }
-            ]
-        }
-        ListElement {
-            key: "SuperRare"
-            iconSource: "qrc:imports/assets/png/collectibles/SuperRare.png";
-            name: "SuperRare"
-            category: "Your collectibles"
-        }
-        ListElement {
-            key: "Custom"
-            iconSource: "qrc:imports/assets/png/collectibles/SNT.png"
-            name: "Custom Collectible"
-            category: "All collectibles"
+        Component.onCompleted: {
+            append([
+                       {
+                           key: "Anniversary",
+                           iconSource: "qrc:imports/assets/png/collectibles/Anniversary.png",
+                           name: "Anniversary",
+                           category: TokenCategories.Category.Community
+                       },
+                       {
+                           key: "CryptoKitties",
+                           iconSource: "qrc:imports/assets/png/collectibles/CryptoKitties.png",
+                           name: "CryptoKitties",
+                           category: TokenCategories.Category.Own,
+                           subItems: [
+                               {
+                                   key: "Kitty1",
+                                   iconSource: "qrc:imports/assets/png/collectibles/Furbeard.png",
+                                   imageSource: "qrc:imports/assets/png/collectibles/FurbeardBig.png",
+                                   name: "Furbeard"
+                               },
+                               {
+                                   key: "Kitty2",
+                                   iconSource: "qrc:imports/assets/png/collectibles/Magicat.png",
+                                   imageSource: "qrc:imports/assets/png/collectibles/MagicatBig.png",
+                                   name: "Magicat"
+                               },
+                               {
+                                   key: "Kitty3",
+                                   iconSource: "qrc:imports/assets/png/collectibles/HappyMeow.png",
+                                   imageSource: "qrc:imports/assets/png/collectibles/HappyMeowBig.png",
+                                   name: "Happy Meow"
+                               },
+                               {
+                                   key: "Kitty4",
+                                   iconSource: "qrc:imports/assets/png/collectibles/Furbeard.png",
+                                   imageSource: "qrc:imports/assets/png/collectibles/FurbeardBig.png",
+                                   name: "Furbeard-2"
+                               },
+                               {
+                                   key: "Kitty5",
+                                   iconSource: "qrc:imports/assets/png/collectibles/Magicat.png",
+                                   imageSource: "qrc:imports/assets/png/collectibles/MagicatBig.png",
+                                   name: "Magicat-3"
+                               }
+                           ]
+                       },
+                       {
+                           key: "SuperRare",
+                           iconSource: "qrc:imports/assets/png/collectibles/SuperRare.png",
+                           name: "SuperRare",
+                           category: TokenCategories.Category.Own
+                       },
+                       {
+                           key: "Custom",
+                           iconSource: "qrc:imports/assets/png/collectibles/SNT.png",
+                           name: "Custom Collectible",
+                           category: TokenCategories.Category.General
+                       }
+                   ])
         }
     }
 


### PR DESCRIPTION
### What does the PR do

Currently community permissions UI uses mocked store. Tokens models (assets, collectibles) had "category" name containing string presented in UI. It's changed to provide from backend only enum representing some predefined categories. UI is responsible for displaying proper textual representation to the user.

Closes: #9556

### Affected areas
`Community Permissions` components: `ExtendedDropdownContent`, `ListDropdownContent`

### Screenshot of functionality (including design for comparison)

UI hasn't changed.
