### PR TITLE
fix: prevent spam of "requested community doesn't exists"

### DIFF
--- a/src/app/modules/main/chat_section/chat_content/messages/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/module.nim
@@ -206,7 +206,6 @@ method newMessagesLoaded*(self: Module, messages: seq[MessageDto], reactions: se
       if message.deleted or message.deletedForMe:
         continue
       let chatDetails = self.controller.getChatDetails()
-      let communityChats = self.controller.getCommunityById(chatDetails.communityId).chats
 
       let sender = self.controller.getContactDetails(message.`from`)
       var quotedMessageAuthorDetails = ContactDetails()
@@ -215,6 +214,10 @@ method newMessagesLoaded*(self: Module, messages: seq[MessageDto], reactions: se
           quotedMessageAuthorDetails = sender
         else:
           quotedMessageAuthorDetails = self.controller.getContactDetails(message.quotedMessage.`from`)
+
+      var communityChats: seq[ChatDto]
+      if chatDetails.communityId != "":
+        communityChats = self.controller.getCommunityById(chatDetails.communityId).chats
 
       let renderedMessageText = self.controller.getRenderedText(message.parsedText, communityChats)
       var transactionContract = message.transactionParameters.contract


### PR DESCRIPTION
### What does the PR do

prevent spam of "requested community doesn't exists"

The spam was caused by calling `getCommunityById` with empty id.