### PR TITLE
Feat/9459 change currency formatting for sendbridge modal

### DIFF
--- a/ui/StatusQ/src/StatusQ/Core/LocaleUtils.qml
+++ b/ui/StatusQ/src/StatusQ/Core/LocaleUtils.qml
@@ -50,22 +50,38 @@ QtObject {
             return NaN
         }
 
+        // Parse options
+        var optShowOnlyAmount = false
+        var optDisplayDecimals = currencyAmount.displayDecimals
+        var optStripTrailingZeroes = currencyAmount.stripTrailingZeroes
+        if (options) {
+            if (options.onlyAmount !== undefined) {
+                optShowOnlyAmount = true
+            }
+            if (options.minDecimals !== undefined && options.minDecimals > optDisplayDecimals) {
+                optDisplayDecimals = options.minDecimals
+            }
+            if (options.stripTrailingZeroes !== undefined) {
+                optStripTrailingZeroes = options.stripTrailingZeroes
+            }
+        }
+
         var amountStr
-        let minAmount = 10**-currencyAmount.displayDecimals
-        if (currencyAmount.amount > 0 && currencyAmount.amount < minAmount && !(options && options.onlyAmount))
+        let minAmount = 10**-optDisplayDecimals
+        if (currencyAmount.amount > 0 && currencyAmount.amount < minAmount && !optShowOnlyAmount)
         {
             // Handle amounts smaller than resolution
-            amountStr = "<%1".arg(numberToLocaleString(minAmount, currencyAmount.displayDecimals, locale))
+            amountStr = "<%1".arg(numberToLocaleString(minAmount, optDisplayDecimals, locale))
         } else {
             // Normal formatting
-            amountStr = numberToLocaleString(currencyAmount.amount, currencyAmount.displayDecimals, locale)
-            if (currencyAmount.stripTrailingZeroes) {
+            amountStr = numberToLocaleString(currencyAmount.amount, optDisplayDecimals, locale)
+            if (optStripTrailingZeroes) {
                 amountStr = stripTrailingZeroes(amountStr, locale)
             }
         }
 
         // Add symbol
-        if (currencyAmount.symbol && !(options && options.onlyAmount)) {
+        if (currencyAmount.symbol && !optShowOnlyAmount) {
             amountStr = "%1 %2".arg(amountStr).arg(currencyAmount.symbol)
         }
 

--- a/ui/app/AppLayouts/Wallet/views/TransactionDetailView.qml
+++ b/ui/app/AppLayouts/Wallet/views/TransactionDetailView.qml
@@ -59,8 +59,9 @@ Item {
 
                 modelData: transaction
                 isIncoming: d.isIncoming
-                cryptoValue: root.isTransactionValid ? transaction.value : undefined
-                fiatValue: root.isTransactionValid ? RootStore.getFiatValue(cryptoValue.amount, symbol, RootStore.currentCurrency): undefined
+                currentCurrency: RootStore.currentCurrency
+                cryptoValue: root.isTransactionValid ? transaction.value.amount: 0.0
+                fiatValue: root.isTransactionValid ? RootStore.getFiatValue(cryptoValue, symbol, currentCurrency): 0.0
                 networkIcon: root.isTransactionValid ? RootStore.getNetworkIcon(transaction.chainId): ""
                 networkColor: root.isTransactionValid ? RootStore.getNetworkColor(transaction.chainId): ""
                 networkName: root.isTransactionValid ? RootStore.getNetworkShortName(transaction.chainId): ""
@@ -68,8 +69,8 @@ Item {
                 transferStatus: root.isTransactionValid ? RootStore.hex2Dec(transaction.txStatus): ""
                 shortTimeStamp: root.isTransactionValid ? LocaleUtils.formatTime(transaction.timestamp * 1000, Locale.ShortFormat): ""
                 savedAddressName: root.isTransactionValid ? RootStore.getNameForSavedWalletAddress(transaction.to): ""
-                title: d.isIncoming ? qsTr("Received %1 from %2").arg(LocaleUtils.currencyAmountToLocaleString(cryptoValue)).arg(d.from) :
-                                    qsTr("Sent %1 to %2").arg(LocaleUtils.currencyAmountToLocaleString(cryptoValue)).arg(d.to)
+                title: d.isIncoming ? qsTr("Received %1 from %2").arg(RootStore.formatCurrencyAmount(cryptoValue, symbol)).arg(d.from) :
+                                    qsTr("Sent %1 to %2").arg(RootStore.formatCurrencyAmount(cryptoValue, symbol)).arg(d.to)
                 sensor.enabled: false
                 color: Theme.palette.statusListItem.backgroundColor
                 state: "big"
@@ -137,8 +138,9 @@ Item {
                 width: parent.width
                 modelData: transaction
                 isIncoming: d.isIncoming
-                cryptoValue: root.isTransactionValid ? transaction.value: undefined
-                fiatValue: root.isTransactionValid ? RootStore.getFiatValue(cryptoValue.amount, symbol, RootStore.currentCurrency): undefined
+                currentCurrency: RootStore.currentCurrency
+                cryptoValue: root.isTransactionValid ? transaction.value.amount: 0.0
+                fiatValue: root.isTransactionValid ? RootStore.getFiatValue(cryptoValue, symbol, currentCurrency): 0.0
                 networkIcon: root.isTransactionValid ? RootStore.getNetworkIcon(transaction.chainId) : ""
                 networkColor: root.isTransactionValid ? RootStore.getNetworkColor(transaction.chainId): ""
                 networkName: root.isTransactionValid ? RootStore.getNetworkShortName(transaction.chainId): ""
@@ -146,8 +148,8 @@ Item {
                 transferStatus: root.isTransactionValid ? RootStore.hex2Dec(transaction.txStatus): ""
                 shortTimeStamp: root.isTransactionValid ? LocaleUtils.formatTime(transaction.timestamp * 1000, Locale.ShortFormat): ""
                 savedAddressName: root.isTransactionValid ? RootStore.getNameForSavedWalletAddress(transaction.to): ""
-                title: d.isIncoming ? qsTr("Received %1 from %2").arg(LocaleUtils.currencyAmountToLocaleString(cryptoValue)).arg(d.from) :
-                                    qsTr("Sent %1 to %2").arg(LocaleUtils.currencyAmountToLocaleString(cryptoValue)).arg(d.to)
+                title: d.isIncoming ? qsTr("Received %1 from %2").arg(RootStore.formatCurrencyAmount(cryptoValue, symbol)).arg(d.from) :
+                                    qsTr("Sent %1 to %2").arg(RootStore.formatCurrencyAmount(cryptoValue, symbol)).arg(d.to)
                 sensor.enabled: false
                 color: Theme.palette.statusListItem.backgroundColor
                 border.width: 1

--- a/ui/imports/shared/controls/GasSelector.qml
+++ b/ui/imports/shared/controls/GasSelector.qml
@@ -20,7 +20,7 @@ Item {
     property var bestRoutes: []
     property var getGasEthValue: function () {}
     property var getFiatValue: function () {}
-    property var getCurrencyAmount: function () {}
+    property var formatCurrencyAmount: function () {}
 
     width: parent.width
     height: visible ? advancedGasSelector.height + Style.current.halfPadding : 0
@@ -48,20 +48,20 @@ Item {
                 statusListItemIcon.active: true
                 statusListItemIcon.opacity: modelData.isFirstSimpleTx
                 title: qsTr("%1 transaction fee").arg(modelData.fromNetwork.chainName)
-                subTitle: LocaleUtils.currencyAmountToLocaleString(totalGasAmountEth)
-                property var totalGasAmountEth: {
+                subTitle: root.formatCurrencyAmount(totalGasAmountEth, "ETH")
+                property double totalGasAmountEth: {
                     let maxFees = modelData.gasFees.maxFeePerGasM
                     let gasPrice = modelData.gasFees.eip1559Enabled ? maxFees : modelData.gasFees.gasPrice
                     return root.getGasEthValue(gasPrice , modelData.gasAmount)
                 }
-                property var totalGasAmountFiat: root.getFiatValue(totalGasAmountEth.amount, "ETH", root.currentCurrency)
+                property double totalGasAmountFiat: root.getFiatValue(totalGasAmountEth, "ETH", root.currentCurrency)
                 statusListItemSubTitle.width: listItem.width/2 - Style.current.smallPadding
                 statusListItemSubTitle.elide: Text.ElideMiddle
                 statusListItemSubTitle.wrapMode: Text.NoWrap
                 components: [
                     StatusBaseText {
                         Layout.alignment: Qt.AlignRight
-                        text: LocaleUtils.currencyAmountToLocaleString(totalGasAmountFiat)
+                        text: root.formatCurrencyAmount(totalGasAmountFiat, root.currentCurrency)
                         font.pixelSize: 15
                         color: Theme.palette.baseColor1
                         width: listItem.width/2 - Style.current.padding
@@ -83,9 +83,10 @@ Item {
                 statusListItemIcon.active: true
                 statusListItemIcon.opacity: modelData.isFirstSimpleTx
                 title: qsTr("Approve %1 %2 Bridge").arg(modelData.fromNetwork.chainName).arg(root.selectedTokenSymbol)
-                property var approvalGasFees: root.getCurrencyAmount(modelData.approvalGasFees, "ETH")
-                property var approvalGasFeesFiat: root.getFiatValue(approvalGasFees.amount, "ETH", root.currentCurrency)
-                subTitle: LocaleUtils.currencyAmountToLocaleString(approvalGasFees)
+                property double approvalGasFees: modelData.approvalGasFees
+                property string approvalGasFeesSymbol: "ETH"
+                property double approvalGasFeesFiat: root.getFiatValue(approvalGasFees, approvalGasFeesSymbol, root.currentCurrency)
+                subTitle: root.formatCurrencyAmount(approvalGasFees, approvalGasFeesSymbol)
                 statusListItemSubTitle.width: listItem.width/2 - Style.current.smallPadding
                 statusListItemSubTitle.elide: Text.ElideMiddle
                 statusListItemSubTitle.wrapMode: Text.NoWrap
@@ -93,7 +94,7 @@ Item {
                 components: [
                     StatusBaseText {
                         Layout.alignment: Qt.AlignRight
-                        text: LocaleUtils.currencyAmountToLocaleString(approvalGasFeesFiat)
+                        text:  root.formatCurrencyAmount(approvalGasFeesFiat, root.currentCurrency)
                         font.pixelSize: 15
                         color: Theme.palette.baseColor1
                         width: listItem.width/2 - Style.current.padding
@@ -116,16 +117,16 @@ Item {
                 statusListItemIcon.active: true
                 statusListItemIcon.opacity: modelData.isFirstBridgeTx
                 title: qsTr("%1 -> %2 bridge").arg(modelData.fromNetwork.chainName).arg(modelData.toNetwork.chainName)
-                property var tokenFees: root.getCurrencyAmount(modelData.tokenFees, root.selectedTokenSymbol)
-                property var tokenFeesFiat: root.getFiatValue(tokenFees.amount, root.selectedTokenSymbol, root.currentCurrency)
-                subTitle: LocaleUtils.currencyAmountToLocaleString(tokenFees)
+                property double tokenFees: modelData.tokenFees
+                property double tokenFeesFiat: root.getFiatValue(tokenFees, root.selectedTokenSymbol, root.currentCurrency)
+                subTitle: root.formatCurrencyAmount(tokenFees, root.selectedTokenSymbol)
                 visible: modelData.bridgeName !== "Simple"
                 statusListItemSubTitle.width: 100
                 statusListItemSubTitle.elide: Text.ElideMiddle
                 components: [
                     StatusBaseText {
                         Layout.alignment: Qt.AlignRight
-                        text: LocaleUtils.currencyAmountToLocaleString(tokenFeesFiat)
+                        text: root.formatCurrencyAmount(tokenFeesFiat, root.currentCurrency)
                         font.pixelSize: 15
                         color: Theme.palette.baseColor1
                         width: listItem2.width/2 - Style.current.padding

--- a/ui/imports/shared/controls/TransactionDelegate.qml
+++ b/ui/imports/shared/controls/TransactionDelegate.qml
@@ -8,6 +8,7 @@ import StatusQ.Controls 0.1
 
 import utils 1.0
 import shared 1.0
+import shared.stores 1.0
 
 StatusListItem {
     id: root
@@ -18,9 +19,10 @@ StatusListItem {
     property var modelData
     property string symbol
     property bool isIncoming
+    property string currentCurrency
     property int transferStatus
-    property var cryptoValue
-    property var fiatValue
+    property double cryptoValue
+    property double fiatValue
     property string networkIcon
     property string networkColor
     property string networkName
@@ -73,8 +75,8 @@ StatusListItem {
                 }
                 StatusTextWithLoadingState {
                     id: cryptoValueText
-                    text: LocaleUtils.currencyAmountToLocaleString(cryptoValue)
-                    customColor: Theme.palette.directColor1
+                    text: RootStore.formatCurrencyAmount(cryptoValue, root.symbol)
+                    color: Theme.palette.directColor1
                     loading: root.loading
                 }
 
@@ -82,7 +84,7 @@ StatusListItem {
             StatusTextWithLoadingState {
                 id: fiatValueText
                 Layout.alignment: Qt.AlignRight
-                text: LocaleUtils.currencyAmountToLocaleString(fiatValue)
+                text: RootStore.formatCurrencyAmount(fiatValue, root.currentCurrency)
                 font.pixelSize: 15
                 customColor: Theme.palette.baseColor1
                 loading: root.loading

--- a/ui/imports/shared/popups/SendModal.qml
+++ b/ui/imports/shared/popups/SendModal.qml
@@ -298,6 +298,8 @@ StatusDialog {
                             isBridgeTx: popup.isBridgeTx
                             cryptoValueToReceive: d.totalAmountToReceive
                             inputIsFiat: amountToSendInput.inputIsFiat
+                            minCryptoDecimals: amountToSendInput.minReceiveCryptoDecimals
+                            minFiatDecimals: amountToSendInput.minReceiveFiatDecimals
                             currentCurrency: popup.store.currentCurrency
                             getFiatValue: function(cryptoValue) {
                                 return popup.currencyStore.getFiatValue(cryptoValue, selectedSymbol, currentCurrency)
@@ -445,6 +447,8 @@ StatusDialog {
                         selectedAccount: popup.selectedAccount
                         ensAddressOrEmpty: d.isENSValid ? d.resolvedENSAddress : ""
                         amountToSend: amountToSendInput.cryptoValueToSend
+                        minSendCryptoDecimals: amountToSendInput.minSendCryptoDecimals
+                        minReceiveCryptoDecimals: amountToSendInput.minReceiveCryptoDecimals
                         requiredGasInEth: d.totalFeesInEth
                         selectedAsset: assetSelector.selectedAsset
                         onReCalculateSuggestedRoute: popup.recalculateRoutesAndFees()

--- a/ui/imports/shared/stores/CurrenciesStore.qml
+++ b/ui/imports/shared/stores/CurrenciesStore.qml
@@ -972,34 +972,31 @@ QtObject {
         walletSection.updateCurrency(shortName)
     }
 
+    // The object returned by this sometimes becomes null when used as part of a binding expression.
+    // Will probably be solved when moving to C++, for now avoid storing the result of this function and use
+    // formatCurrencyAmount at the visualization point instead, or move functionality over to the NIM side.
     function getCurrencyAmount(amount, symbol) {
-        if (isNaN(amount)) {
-            amount = 0
-        }
-        let obj = JSON.parse((walletSection.getCurrencyAmountAsJson(amount, symbol)))
-        if (obj.error) {
-            console.error("Error parsing currency amount json object, amount: ", amount, ", symbol ", symbol, " error: ", obj.error)
-            return {amount: nan, symbol: symbol}
-        }
-        return obj
+        walletSection.prepareCurrencyAmount(amount, symbol)
+        return walletSection.getPreparedCurrencyAmount()
     }
 
-    function getFiatValue(balance, cryptoSymbol, fiatSymbol) {
-        var amount = profileSectionStore.profileSectionModuleInst.ensUsernamesModule.getFiatValue(balance, cryptoSymbol, fiatSymbol)
-        return getCurrencyAmount(parseFloat(amount), fiatSymbol)
+    function formatCurrencyAmount(amount, symbol, options = null, locale = null) {
+        var currencyAmount = getCurrencyAmount(amount, symbol)
+        return LocaleUtils.currencyAmountToLocaleString(currencyAmount, options, locale)
     }
 
-    function getCryptoValue(balance, cryptoSymbol, fiatSymbol) {
-        var amount = profileSectionStore.profileSectionModuleInst.ensUsernamesModule.getCryptoValue(balance, cryptoSymbol, fiatSymbol)
-        return getCurrencyAmount(parseFloat(amount), cryptoSymbol) 
+    function getFiatValue(cryptoAmount, cryptoSymbol, fiatSymbol) {
+        var amount = profileSectionStore.profileSectionModuleInst.ensUsernamesModule.getFiatValue(cryptoAmount, cryptoSymbol, fiatSymbol)
+        return parseFloat(amount)
+    }
+
+    function getCryptoValue(fiatAmount, cryptoSymbol, fiatSymbol) {
+        var amount = profileSectionStore.profileSectionModuleInst.ensUsernamesModule.getCryptoValue(fiatAmount, cryptoSymbol, fiatSymbol)
+        return parseFloat(amount)
     }
 
     function getGasEthValue(gweiValue, gasLimit) {
         var amount = profileSectionStore.profileSectionModuleInst.ensUsernamesModule.getGasEthValue(gweiValue, gasLimit)
-        return getCurrencyAmount(parseFloat(amount), "ETH") 
-    }
-
-    function formatCurrencyAmount(currencyAmount) {
-        return LocaleUtils.currencyAmountToLocaleString(currencyAmount)
+        return parseFloat(amount)
     }
 }

--- a/ui/imports/shared/stores/RootStore.qml
+++ b/ui/imports/shared/stores/RootStore.qml
@@ -221,8 +221,8 @@ QtObject {
         return currencyStore.getGasEthValue(gweiValue, gasLimit)
     }
 
-    function formatCurrencyAmount(currencyAmount) {
-        return currencyStore.formatCurrencyAmount(currencyAmount)
+    function formatCurrencyAmount(amount, symbol, options = null, locale = null) {
+        return currencyStore.formatCurrencyAmount(amount, symbol, options, locale)
     }
 
     function getHistoricalDataForToken(symbol, currency) {

--- a/ui/imports/shared/stores/TransactionStore.qml
+++ b/ui/imports/shared/stores/TransactionStore.qml
@@ -256,6 +256,7 @@ QtObject {
             return undefined
         }
 
-        return JSON.parse(selectedAccount.getTokenBalanceOnChainAsJson(chainId, tokenSymbol))
+        selectedAccount.prepareTokenBalanceOnChain(chainId, tokenSymbol)
+        return selectedAccount.getPreparedTokenBalanceOnChain()
     }
 }

--- a/ui/imports/shared/views/AmountToReceive.qml
+++ b/ui/imports/shared/views/AmountToReceive.qml
@@ -11,26 +11,27 @@ ColumnLayout {
     id: root
 
     property var store
-    property var selectedAsset
+    property string selectedSymbol
     property bool isLoading: false
-    property var cryptoValueToReceive
+    property double cryptoValueToReceive
     property bool isBridgeTx: false
     property bool inputIsFiat: false
     property string currentCurrency
     property var getFiatValue: function(cryptoValue) {}
+    property var formatCurrencyAmount: function() {}
 
     QtObject {
         id: d
         readonly property string fiatValue: {
-            if(!root.selectedAsset || !cryptoValueToReceive)
+            if(!root.selectedSymbol || !cryptoValueToReceive)
                 return LocaleUtils.numberToLocaleString(0, 2)
-            let fiatValue = root.getFiatValue(cryptoValueToReceive.amount, root.selectedAsset.symbol, RootStore.currentCurrency)
-            return LocaleUtils.currencyAmountToLocaleString(fiatValue)
+            let fiatValue = root.getFiatValue(cryptoValueToReceive, root.selectedSymbol, root.currentCurrency)
+            return root.formatCurrencyAmount(fiatValue, root.currentCurrency)
         }
         readonly property string cryptoValue: {
-            if(!root.selectedAsset || !cryptoValueToReceive)
+            if(!root.selectedSymbol || !cryptoValueToReceive)
                 return LocaleUtils.numberToLocaleString(0, 2)
-            return LocaleUtils.currencyAmountToLocaleString(cryptoValueToReceive)
+            return root.formatCurrencyAmount(cryptoValueToReceive, root.selectedSymbol)
         }
     }
 

--- a/ui/imports/shared/views/AmountToReceive.qml
+++ b/ui/imports/shared/views/AmountToReceive.qml
@@ -17,6 +17,8 @@ ColumnLayout {
     property bool isBridgeTx: false
     property bool inputIsFiat: false
     property string currentCurrency
+    property int minCryptoDecimals: 0
+    property int minFiatDecimals: 0
     property var getFiatValue: function(cryptoValue) {}
     property var formatCurrencyAmount: function() {}
 
@@ -26,12 +28,12 @@ ColumnLayout {
             if(!root.selectedSymbol || !cryptoValueToReceive)
                 return LocaleUtils.numberToLocaleString(0, 2)
             let fiatValue = root.getFiatValue(cryptoValueToReceive, root.selectedSymbol, root.currentCurrency)
-            return root.formatCurrencyAmount(fiatValue, root.currentCurrency)
+            return root.formatCurrencyAmount(fiatValue, root.currentCurrency, inputIsFiat ? {"minDecimals": root.minFiatDecimals, "stripTrailingZeroes": true} : {})
         }
         readonly property string cryptoValue: {
             if(!root.selectedSymbol || !cryptoValueToReceive)
                 return LocaleUtils.numberToLocaleString(0, 2)
-            return root.formatCurrencyAmount(cryptoValueToReceive, root.selectedSymbol)
+            return root.formatCurrencyAmount(cryptoValueToReceive, root.selectedSymbol, !inputIsFiat ? {"minDecimals": root.minCryptoDecimals, "stripTrailingZeroes": true} : {})
         }
     }
 

--- a/ui/imports/shared/views/AmountToSend.qml
+++ b/ui/imports/shared/views/AmountToSend.qml
@@ -14,6 +14,10 @@ ColumnLayout {
 
     property alias input: topAmountToSendInput
     readonly property double inputNumber: topAmountToSendInput.text ? LocaleUtils.numberFromLocaleString(topAmountToSendInput.text) : 0
+    readonly property int minSendCryptoDecimals: !inputIsFiat ? LocaleUtils.fractionalPartLength(inputNumber) : 0 
+    readonly property int minReceiveCryptoDecimals: !inputIsFiat ? minSendCryptoDecimals + 1 : 0 
+    readonly property int minSendFiatDecimals: inputIsFiat ? LocaleUtils.fractionalPartLength(inputNumber) : 0 
+    readonly property int minReceiveFiatDecimals: inputIsFiat ? minSendFiatDecimals + 1 : 0 
 
     property string selectedSymbol
     property bool isBridgeTx: false

--- a/ui/imports/shared/views/FeesView.qml
+++ b/ui/imports/shared/views/FeesView.qml
@@ -19,7 +19,7 @@ Rectangle {
     property var bestRoutes
     property var store
     property var currencyStore: store.currencyStore
-    property var selectedTokenSymbol
+    property string selectedTokenSymbol
     property int errorType: Constants.NoError
 
     radius: 13
@@ -60,7 +60,7 @@ Rectangle {
                     anchors.right: parent.right
                     anchors.rightMargin: Style.current.padding
                     id: totalFeesAdvanced
-                    text: root.isLoading ? "..." : LocaleUtils.currencyAmountToLocaleString(root.gasFiatAmount)
+                    text: root.isLoading ? "..." : root.currencyStore.formatCurrencyAmount(root.gasFiatAmount, root.currencyStore.currentCurrency)
                     font.pixelSize: 15
                     color: Theme.palette.directColor1
                     visible: !!root.bestRoutes && root.bestRoutes !== undefined && root.bestRoutes.length > 0
@@ -71,7 +71,7 @@ Rectangle {
                 width: parent.width
                 getGasEthValue: root.currencyStore.getGasEthValue
                 getFiatValue: root.currencyStore.getFiatValue
-                getCurrencyAmount: root.currencyStore.getCurrencyAmount
+                formatCurrencyAmount: root.currencyStore.formatCurrencyAmount
                 currentCurrency: root.currencyStore.currentCurrency
                 visible: root.errorType === Constants.NoError && !root.isLoading
                 bestRoutes: root.bestRoutes

--- a/ui/imports/shared/views/HistoryView.qml
+++ b/ui/imports/shared/views/HistoryView.qml
@@ -101,8 +101,9 @@ ColumnLayout {
         TransactionDelegate {
             property bool modelDataValid: !!modelData
             isIncoming: modelDataValid ? modelData.to === account.address: false
-            cryptoValue: modelDataValid ? modelData.value : undefined
-            fiatValue: modelDataValid  && !!cryptoValue ? RootStore.getFiatValue(cryptoValue.amount, symbol, RootStore.currentCurrency) : undefined
+            currentCurrency: RootStore.currentCurrency
+            cryptoValue: modelDataValid ? modelData.value.amount : 0.0
+            fiatValue: modelDataValid ? RootStore.getFiatValue(cryptoValue, symbol, currentCurrency): 0.0
             networkIcon: modelDataValid ? RootStore.getNetworkIcon(modelData.chainId) : ""
             networkColor: modelDataValid ? RootStore.getNetworkColor(modelData.chainId) : ""
             networkName: modelDataValid ? RootStore.getNetworkShortName(modelData.chainId) : ""

--- a/ui/imports/shared/views/NetworkCardsComponent.qml
+++ b/ui/imports/shared/views/NetworkCardsComponent.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.13
+﻿import QtQuick 2.13
 import QtQuick.Layouts 1.13
 
 import utils 1.0
@@ -25,6 +25,8 @@ Item {
     property var allNetworks
     property bool customMode: false
     property double amountToSend
+    property int minSendCryptoDecimals: 0
+    property int minReceiveCryptoDecimals: 0
     property double requiredGasInEth
     property bool errorMode: d.customAmountToSend > root.amountToSend
     property bool interactive: true
@@ -101,7 +103,7 @@ Item {
 
                     primaryText: model.chainName
                     secondaryText: (tokenBalanceOnChain == 0 && root.amountToSend > 0) ?
-                                        qsTr("No Balance") : !hasGas ? qsTr("No Gas") : root.currencyStore.formatCurrencyAmount(advancedInputCurrencyAmount, root.selectedSymbol)
+                                        qsTr("No Balance") : !hasGas ? qsTr("No Gas") : root.currencyStore.formatCurrencyAmount(advancedInputCurrencyAmount, root.selectedSymbol, {"minDecimals": root.minSendCryptoDecimals})
                     tertiaryText: root.errorMode && advancedInputCurrencyAmount > 0 ? qsTr("EXCEEDS SEND AMOUNT"): qsTr("BALANCE: ") + root.currencyStore.formatCurrencyAmount(tokenBalanceOnChain, root.selectedSymbol)
                     locked: store.lockedInAmounts.findIndex(lockedItem => lockedItem !== undefined && lockedItem.chainID ===  model.chainId) !== -1
                     preCalculatedAdvancedText: {
@@ -191,7 +193,7 @@ Item {
                     property var preferredChains: store.preferredChainIds
                     property bool preferred: store.preferredChainIds.includes(model.chainId)
                     primaryText: model.chainName
-                    secondaryText: root.currencyStore.formatCurrencyAmount(amountToReceive, root.selectedSymbol)
+                    secondaryText: root.currencyStore.formatCurrencyAmount(amountToReceive, root.selectedSymbol, {"minDecimals": root.minReceiveCryptoDecimals})
                     tertiaryText: state === "unpreferred"  ? qsTr("UNPREFERRED") : ""
                     state: !preferred ? "unpreferred" : "default"
                     opacity: preferred || showPreferredChains ? 1 : 0

--- a/ui/imports/shared/views/NetworkCardsComponent.qml
+++ b/ui/imports/shared/views/NetworkCardsComponent.qml
@@ -1,4 +1,4 @@
-﻿import QtQuick 2.13
+import QtQuick 2.13
 import QtQuick.Layouts 1.13
 
 import utils 1.0
@@ -16,20 +16,21 @@ Item {
     id: root
 
     property var store
+    readonly property var currencyStore: store.currencyStore
     property var bestRoutes
     property var selectedAccount
     property string ensAddressOrEmpty: ""
     property var selectedAsset
+    readonly property string selectedSymbol: !!selectedAsset ? selectedAsset.symbol : ""
     property var allNetworks
     property bool customMode: false
-    property var amountToSend
-    property var requiredGasInEth
-    property bool errorMode: !root.amountToSend || d.customAmountToSend > root.amountToSend.amount
+    property double amountToSend
+    property double requiredGasInEth
+    property bool errorMode: d.customAmountToSend > root.amountToSend
     property bool interactive: true
     property bool showPreferredChains: false
     property var weiToEth: function(wei) {}
     property var reCalculateSuggestedRoute: function() {}
-    property var getCryptoCurrencyAmount: function(cryptoValue) {}
     property int errorType: Constants.NoError
     property bool isLoading
 
@@ -52,7 +53,7 @@ Item {
             d.customAmountToSend = 0
             for(var i = 0; i<fromNetworksRepeater.count; i++) {
                 if(fromNetworksRepeater.itemAt(i).locked) {
-                    let amountEntered = fromNetworksRepeater.itemAt(i).advancedInputCurrencyAmount.amount
+                    let amountEntered = fromNetworksRepeater.itemAt(i).advancedInputCurrencyAmount
                     d.customAmountToSend += isNaN(amountEntered) ? 0 : amountEntered
                 }
             }
@@ -94,27 +95,27 @@ Item {
                     property double amountToSend: 0
                     property int routeOnNetwork: 0
                     property bool selectedAssetValid: selectedAccount && selectedAccount !== undefined && selectedAsset !== undefined
-                    property var tokenBalanceOnChain: selectedAssetValid ? root.store.getTokenBalanceOnChain(selectedAccount, model.chainId, selectedAsset.symbol) : undefined
-                    property bool hasGas: selectedAssetValid && requiredGasInEth ? selectedAccount.hasGas(model.chainId, model.nativeCurrencySymbol, requiredGasInEth.amount) : false
-                    property var advancedInputCurrencyAmount: selectedAssetValid ? root.getCryptoCurrencyAmount(LocaleUtils.numberFromLocaleString(advancedInputText)) : undefined
+                    property double tokenBalanceOnChain: selectedAssetValid ? root.store.getTokenBalanceOnChain(selectedAccount, model.chainId, root.selectedSymbol).amount : 0.0
+                    property bool hasGas: selectedAssetValid && requiredGasInEth !== undefined ? selectedAccount.hasGas(model.chainId, model.nativeCurrencySymbol, requiredGasInEth) : false
+                    property double advancedInputCurrencyAmount: selectedAssetValid && advancedInput.valid ? LocaleUtils.numberFromLocaleString(advancedInputText) : 0.0
 
                     primaryText: model.chainName
-                    secondaryText: !tokenBalanceOnChain || (tokenBalanceOnChain.amount === 0 && root.amountToSend && root.amountToSend.amount !== 0) ?
-                                       qsTr("No Balance") : !hasGas ? qsTr("No Gas") : advancedInputCurrencyAmount ? LocaleUtils.currencyAmountToLocaleString(advancedInputCurrencyAmount) : "N/A"
-                    tertiaryText: root.errorMode && advancedInputCurrencyAmount && advancedInputCurrencyAmount.amount !== 0 && advancedInput.valid ? qsTr("EXCEEDS SEND AMOUNT"): qsTr("BALANCE: ") + LocaleUtils.currencyAmountToLocaleString(tokenBalanceOnChain)
+                    secondaryText: (tokenBalanceOnChain == 0 && root.amountToSend > 0) ?
+                                        qsTr("No Balance") : !hasGas ? qsTr("No Gas") : root.currencyStore.formatCurrencyAmount(advancedInputCurrencyAmount, root.selectedSymbol)
+                    tertiaryText: root.errorMode && advancedInputCurrencyAmount > 0 ? qsTr("EXCEEDS SEND AMOUNT"): qsTr("BALANCE: ") + root.currencyStore.formatCurrencyAmount(tokenBalanceOnChain, root.selectedSymbol)
                     locked: store.lockedInAmounts.findIndex(lockedItem => lockedItem !== undefined && lockedItem.chainID ===  model.chainId) !== -1
                     preCalculatedAdvancedText: {
                         let index  = store.lockedInAmounts.findIndex(lockedItem => lockedItem!== undefined && lockedItem.chainID === model.chainId)
                         if(locked && index !== -1) {
                             let amount = root.weiToEth(parseInt(store.lockedInAmounts[index].value, 16))
-                            return LocaleUtils.numberToLocaleString(amount.amount)
+                            return LocaleUtils.numberToLocaleString(amount)
                         }
                         else return LocaleUtils.numberToLocaleString(fromNetwork.amountToSend)
                     }
-                    maxAdvancedValue: tokenBalanceOnChain ? tokenBalanceOnChain.amount : 0.0
-                    state: !tokenBalanceOnChain || tokenBalanceOnChain.amount === 0 || !hasGas ?
+                    maxAdvancedValue: tokenBalanceOnChain
+                    state: tokenBalanceOnChain === 0 || !hasGas ?
                                "unavailable" :
-                               (root.errorMode || !advancedInput.valid) && (advancedInputCurrencyAmount.amount !== 0) ? "error" : "default"
+                               (root.errorMode || !advancedInput.valid) && advancedInputCurrencyAmount > 0 ? "error" : "default"
                     cardIcon.source: Style.svg(model.iconUrl)
                     disabledText: qsTr("Disabled")
                     disableText:  qsTr("Disable")
@@ -134,9 +135,9 @@ Item {
                     }
                     onCardLocked: {
 
-                        store.addLockedInAmount(model.chainId, advancedInputCurrencyAmount.amount, root.selectedAsset.decimals, isLocked)
+                        store.addLockedInAmount(model.chainId, advancedInputCurrencyAmount, root.selectedAsset.decimals, isLocked)
                         d.calculateCustomAmounts()
-                        if(!locked || (d.customAmountToSend <= root.amountToSend.amount && advancedInput.valid))
+                        if(!locked || (d.customAmountToSend <= root.amountToSend && advancedInput.valid))
                             root.reCalculateSuggestedRoute()
                     }
                 }
@@ -145,7 +146,7 @@ Item {
         BalanceExceeded {
             Layout.fillWidth: true
             Layout.alignment: Qt.AlignVCenter
-            amountToSend: root.amountToSend ? root.amountToSend.amount : 0.0
+            amountToSend: root.amountToSend
             errorType: root.errorType
             visible: root.errorType === Constants.NoRoute
         }
@@ -187,11 +188,10 @@ Item {
                     property int routeOnNetwork: 0
                     property int bentLine: 0
                     property double amountToReceive: 0
-                    property var currencyAmountToReceive: root.getCryptoCurrencyAmount(amountToReceive)
                     property var preferredChains: store.preferredChainIds
                     property bool preferred: store.preferredChainIds.includes(model.chainId)
                     primaryText: model.chainName
-                    secondaryText: LocaleUtils.currencyAmountToLocaleString(currencyAmountToReceive)
+                    secondaryText: root.currencyStore.formatCurrencyAmount(amountToReceive, root.selectedSymbol)
                     tertiaryText: state === "unpreferred"  ? qsTr("UNPREFERRED") : ""
                     state: !preferred ? "unpreferred" : "default"
                     opacity: preferred || showPreferredChains ? 1 : 0
@@ -276,10 +276,10 @@ Item {
                     yOffsetFrom = toN.objectName === fromN.objectName  && toN.routeOnNetwork !== 0 ? toN.routeOnNetwork * 16 : 0
                     yOffsetTo = toN.routeOnNetwork * 16
                     xOffset = (fromN.y - toN.y > 0 ? -1 : 1) * toN.bentLine * 16
-                    let amountToSend = weiToEth(bestRoutes[i].amountIn)
-                    let amountToReceive = weiToEth(bestRoutes[i].amountOut)
-                    fromN.amountToSend = amountToSend.amount
-                    toN.amountToReceive += amountToReceive.amount
+                    let amountToSend = root.weiToEth(bestRoutes[i].amountIn)
+                    let amountToReceive = root.weiToEth(bestRoutes[i].amountOut)
+                    fromN.amountToSend = amountToSend
+                    toN.amountToReceive += amountToReceive
                     fromN.routeOnNetwork += 1
                     toN.routeOnNetwork += 1
                     toN.bentLine = toN.objectName !== fromN.objectName

--- a/ui/imports/shared/views/NetworkSelector.qml
+++ b/ui/imports/shared/views/NetworkSelector.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.13
+﻿import QtQuick 2.13
 import QtQuick.Layouts 1.13
 
 import utils 1.0
@@ -23,6 +23,8 @@ Item {
     property string ensAddressOrEmpty: ""
     property var selectedAsset
     property var amountToSend
+    property int minSendCryptoDecimals: 0
+    property int minReceiveCryptoDecimals: 0
     property var requiredGasInEth
     property var bestRoutes
     property bool isLoading: false
@@ -79,6 +81,7 @@ Item {
                 bestRoutes: root.bestRoutes
                 isBridgeTx: root.isBridgeTx
                 amountToSend: root.amountToSend
+                minReceiveCryptoDecimals: root.minReceiveCryptoDecimals
                 isLoading: root.isLoading
                 store: root.store
                 selectedAsset: root.selectedAsset
@@ -111,6 +114,8 @@ Item {
                 ensAddressOrEmpty: root.ensAddressOrEmpty
                 amountToSend: root.amountToSend
                 requiredGasInEth: root.requiredGasInEth
+                minSendCryptoDecimals: root.minSendCryptoDecimals
+                minReceiveCryptoDecimals: root.minReceiveCryptoDecimals
                 selectedAsset: root.selectedAsset
                 onReCalculateSuggestedRoute: root.reCalculateSuggestedRoute()
                 bestRoutes: root.bestRoutes

--- a/ui/imports/shared/views/NetworkSelector.qml
+++ b/ui/imports/shared/views/NetworkSelector.qml
@@ -1,4 +1,4 @@
-﻿import QtQuick 2.13
+import QtQuick 2.13
 import QtQuick.Layouts 1.13
 
 import utils 1.0
@@ -87,8 +87,9 @@ Item {
                 errorType: root.errorType
                 toNetworksList: root.toNetworksList
                 weiToEth: function(wei) {
-                    return root.currencyStore.getCurrencyAmount(parseFloat(store.getWei2Eth(wei, selectedAsset.decimals)), selectedAsset.symbol)
+                    return parseFloat(store.getWei2Eth(wei, selectedAsset.decimals))
                 }
+                formatCurrencyAmount: root.currencyStore.formatCurrencyAmount
                 reCalculateSuggestedRoute: function() {
                     root.reCalculateSuggestedRoute()
                 }
@@ -118,10 +119,7 @@ Item {
                 isBridgeTx: root.isBridgeTx
                 errorType: root.errorType
                 weiToEth: function(wei) {
-                    return root.currencyStore.getCurrencyAmount(parseFloat(store.getWei2Eth(wei, selectedAsset.decimals)), selectedAsset.symbol)
-                }
-                getCryptoCurrencyAmount: function(cryptoValue) {
-                    return selectedAsset ? root.currencyStore.getCurrencyAmount(parseFloat(cryptoValue), selectedAsset.symbol) : undefined
+                    return parseFloat(store.getWei2Eth(wei, selectedAsset.decimals))
                 }
             }
         }

--- a/ui/imports/shared/views/NetworksAdvancedCustomRoutingView.qml
+++ b/ui/imports/shared/views/NetworksAdvancedCustomRoutingView.qml
@@ -1,4 +1,4 @@
-﻿import QtQuick 2.13
+import QtQuick 2.13
 import QtQuick.Layouts 1.13
 
 import utils 1.0
@@ -17,15 +17,14 @@ ColumnLayout {
     property var store
     property var selectedAccount
     property string ensAddressOrEmpty: ""
-    property var amountToSend
-    property var requiredGasInEth
+    property double amountToSend
+    property double requiredGasInEth
     property bool customMode: false
     property var selectedAsset
     property var bestRoutes
     property bool isLoading: false
     property bool errorMode: networksLoader.item ? networksLoader.item.errorMode : false
     property var weiToEth: function(wei) {}
-    property var getCryptoCurrencyAmount: function(cryptoValue) {}
     property bool interactive: true
     property bool isBridgeTx: false
     property bool showUnpreferredNetworks: preferredToggleButton.checked
@@ -96,7 +95,6 @@ ColumnLayout {
                     showPreferredChains: preferredToggleButton.checked
                     bestRoutes: root.bestRoutes
                     weiToEth: root.weiToEth
-                    getCryptoCurrencyAmount: root.getCryptoCurrencyAmount
                     interactive: root.interactive
                     errorType: root.errorType
                     isLoading: root.isLoading

--- a/ui/imports/shared/views/NetworksAdvancedCustomRoutingView.qml
+++ b/ui/imports/shared/views/NetworksAdvancedCustomRoutingView.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.13
+﻿import QtQuick 2.13
 import QtQuick.Layouts 1.13
 
 import utils 1.0
@@ -18,6 +18,8 @@ ColumnLayout {
     property var selectedAccount
     property string ensAddressOrEmpty: ""
     property double amountToSend
+    property int minSendCryptoDecimals: 0
+    property int minReceiveCryptoDecimals: 0
     property double requiredGasInEth
     property bool customMode: false
     property var selectedAsset
@@ -86,6 +88,8 @@ ColumnLayout {
                     ensAddressOrEmpty: root.ensAddressOrEmpty
                     allNetworks: root.store.allNetworks
                     amountToSend: root.amountToSend
+                    minSendCryptoDecimals: root.minSendCryptoDecimals
+                    minReceiveCryptoDecimals: root.minReceiveCryptoDecimals
                     customMode: root.customMode
                     requiredGasInEth: root.requiredGasInEth
                     selectedAsset: root.selectedAsset

--- a/ui/imports/shared/views/NetworksSimpleRoutingView.qml
+++ b/ui/imports/shared/views/NetworksSimpleRoutingView.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.13
+﻿import QtQuick 2.13
 import QtQuick.Controls 2.13
 import QtQuick.Layouts 1.13
 
@@ -18,6 +18,7 @@ RowLayout {
     property var store
     property var bestRoutes
     property double amountToSend
+    property int minReceiveCryptoDecimals: 0
     property bool isLoading: false
     property bool isBridgeTx: false
     property var selectedAsset
@@ -107,7 +108,7 @@ RowLayout {
                 else {
                     amountOut = root.weiToEth(parseInt(store.lockedInAmounts[index].value, 16))
                 }
-                return root.formatCurrencyAmount(amountOut, selectedAsset.symbol)
+                return root.formatCurrencyAmount(amountOut, selectedAsset.symbol, {"minDecimals": root.minReceiveCryptoDecimals})
             }
             statusListItemSubTitle.color: root.errorMode ? Theme.palette.dangerColor1 : Theme.palette.primaryColor1
             asset.width: 32

--- a/ui/imports/shared/views/NetworksSimpleRoutingView.qml
+++ b/ui/imports/shared/views/NetworksSimpleRoutingView.qml
@@ -1,4 +1,4 @@
-﻿import QtQuick 2.13
+import QtQuick 2.13
 import QtQuick.Controls 2.13
 import QtQuick.Layouts 1.13
 
@@ -17,13 +17,14 @@ RowLayout {
 
     property var store
     property var bestRoutes
-    property var amountToSend
+    property double amountToSend
     property bool isLoading: false
     property bool isBridgeTx: false
     property var selectedAsset
     property var selectedAccount
     property var toNetworksList: []
     property var weiToEth: function(wei) {}
+    property var formatCurrencyAmount: function () {}
     property var reCalculateSuggestedRoute: function() {}
     property bool errorMode: false
     property int errorType: Constants.NoError
@@ -80,7 +81,7 @@ RowLayout {
             Layout.fillWidth: true
             Layout.alignment: Qt.AlignHCenter
             Layout.topMargin: Style.current.smallPadding
-            amountToSend: root.amountToSend ? root.amountToSend.amount : 0.0
+            amountToSend: root.amountToSend
             errorType: root.errorType
             isLoading: root.isLoading && !root.isBridgeTx
         }
@@ -106,7 +107,7 @@ RowLayout {
                 else {
                     amountOut = root.weiToEth(parseInt(store.lockedInAmounts[index].value, 16))
                 }
-                return LocaleUtils.currencyAmountToLocaleString(amountOut)
+                return root.formatCurrencyAmount(amountOut, selectedAsset.symbol)
             }
             statusListItemSubTitle.color: root.errorMode ? Theme.palette.dangerColor1 : Theme.palette.primaryColor1
             asset.width: 32
@@ -130,8 +131,8 @@ RowLayout {
                 implicitWidth: 410
                 title: chainName
                 property bool tokenBalanceOnChainValid: selectedAccount && selectedAccount !== undefined && selectedAsset !== undefined
-                property var tokenBalanceOnChain: tokenBalanceOnChainValid ? root.store.getTokenBalanceOnChain(selectedAccount, chainId, selectedAsset.symbol) : undefined
-                subTitle: tokenBalanceOnChain ? LocaleUtils.currencyAmountToLocaleString(tokenBalanceOnChain) : "N/A"
+                property double tokenBalanceOnChain: tokenBalanceOnChainValid ? root.store.getTokenBalanceOnChain(selectedAccount, chainId, selectedAsset.symbol).amount : 0.0
+                subTitle: tokenBalanceOnChainValid ? root.formatCurrencyAmount(tokenBalanceOnChain, selectedAsset.symbol) : "N/A"
                 statusListItemSubTitle.color: Theme.palette.primaryColor1
                 asset.width: 32
                 asset.height: 32


### PR DESCRIPTION
### What does the PR do

Fixes #9459 

The Send/Bridge modal now respects the amount of decimals entered by the user for displaying Send/Receive currency amounts. On the Send side we should get at least as many significant decimal places as entered by the user, while the Receive side should get one more (since we're expecting some small fee to be deducted while bridging).

The task itself required few changes, but for it to work properly I needed to fix some issues with storing CurrencyAmount objects in QML, as discovered by @Khushboo-dev-cpp in https://github.com/status-im/status-desktop/pull/9484. The first commit of this PR is a generalized version of her fix, so that issue will be closed as well.

Before:
![image](https://user-images.githubusercontent.com/11161531/219680611-edd89d32-a83d-4308-a5d8-9446e1beb3a5.png)

After:


![Screenshot 2023-02-17 at 11 23 34 AM](https://user-images.githubusercontent.com/11161531/219681689-5ef20e92-695d-4149-808d-bc79b15aff63.png)
![Screenshot 2023-02-17 at 11 23 50 AM](https://user-images.githubusercontent.com/11161531/219681695-b7768348-b3c2-4469-a77b-84ac8c0375b8.png)
![Screenshot 2023-02-17 at 11 24 04 AM](https://user-images.githubusercontent.com/11161531/219681698-40c6c0a1-532b-40c1-b970-17873995221d.png)
![Screenshot 2023-02-17 at 11 24 33 AM](https://user-images.githubusercontent.com/11161531/219681700-e3267154-acbb-4609-9f6b-97d6b49cb76c.png)
![Screenshot 2023-02-17 at 11 25 35 AM](https://user-images.githubusercontent.com/11161531/219681704-a56ba438-5eea-4993-b7f3-95df76443bc7.png)
![Screenshot 2023-02-17 at 11 25 49 AM](https://user-images.githubusercontent.com/11161531/219681706-ffd9e7cf-d50b-41ba-8b53-350d75ea701c.png)
![Screenshot 2023-02-17 at 11 26 52 AM](https://user-images.githubusercontent.com/11161531/219681709-fc00b995-0e3b-4d0c-9f78-e5790ca23018.png)


