### PR TITLE
fix(i18n/wallet): properly format floating point numbers

### DIFF
--- a/ui/app/AppLayouts/Wallet/views/AssetsDetailView.qml
+++ b/ui/app/AppLayouts/Wallet/views/AssetsDetailView.qml
@@ -20,7 +20,7 @@ import shared.stores 1.0
 Item {
     id: root
 
-    property var token: {}
+    property var token: ({})
     /*required*/ property string address: ""
 
     QtObject {
@@ -290,31 +290,31 @@ Item {
                 Layout.fillWidth: true
             }
             InformationTile {
-                readonly property string changePctHour: token ? token.changePctHour.toFixed(2) : ""
+                readonly property double changePctHour: token ? token.changePctHour : 0
                 maxWidth: parent.width
                 primaryText: qsTr("Hour")
-                secondaryText: changePctHour ? "%1%".arg(changePctHour) : "---"
-                secondaryLabel.color: Math.sign(Number(changePctHour)) === 0 ? Theme.palette.directColor1 :
-                                                                               Math.sign(Number(changePctHour)) === -1 ? Theme.palette.dangerColor1 :
-                                                                                                                         Theme.palette.successColor1
+                secondaryText: changePctHour ? "%1%".arg(LocaleUtils.numberToLocaleString(changePctHour, 2)) : "---"
+                secondaryLabel.color: Math.sign(changePctHour) === 0 ? Theme.palette.directColor1 :
+                                                                       Math.sign(changePctHour) === -1 ? Theme.palette.dangerColor1 :
+                                                                                                         Theme.palette.successColor1
             }
             InformationTile {
-                readonly property string changePctDay: token ? token.changePctDay.toFixed(2) : ""
+                readonly property double changePctDay: token ? token.changePctDay : 0
                 maxWidth: parent.width
                 primaryText: qsTr("Day")
-                secondaryText: changePctDay ? "%1%".arg(changePctDay) : "---"
-                secondaryLabel.color: Math.sign(Number(changePctDay)) === 0 ? Theme.palette.directColor1 :
-                                                                              Math.sign(Number(changePctDay)) === -1 ? Theme.palette.dangerColor1 :
-                                                                                                                       Theme.palette.successColor1
+                secondaryText: changePctDay ? "%1%".arg(LocaleUtils.numberToLocaleString(changePctDay, 2)) : "---"
+                secondaryLabel.color: Math.sign(changePctDay) === 0 ? Theme.palette.directColor1 :
+                                                                      Math.sign(changePctDay) === -1 ? Theme.palette.dangerColor1 :
+                                                                                                       Theme.palette.successColor1
             }
             InformationTile {
-                readonly property string changePct24hour: token ? token.changePct24hour.toFixed(2) : ""
+                readonly property double changePct24hour: token ? token.changePct24hour : 0
                 maxWidth: parent.width
                 primaryText: qsTr("24 Hours")
-                secondaryText: changePct24hour ? "%1%".arg(changePct24hour) : "---"
-                secondaryLabel.color: Math.sign(Number(changePct24hour)) === 0 ? Theme.palette.directColor1 :
-                                                                                 Math.sign(Number(changePct24hour)) === -1 ? Theme.palette.dangerColor1 :
-                                                                                                                             Theme.palette.successColor1
+                secondaryText: changePct24hour ? "%1%".arg(LocaleUtils.numberToLocaleString(changePct24hour, 2)) : "---"
+                secondaryLabel.color: Math.sign(changePct24hour) === 0 ? Theme.palette.directColor1 :
+                                                                         Math.sign(changePct24hour) === -1 ? Theme.palette.dangerColor1 :
+                                                                                                             Theme.palette.successColor1
             }
         }
 

--- a/ui/imports/shared/controls/InformationTag.qml
+++ b/ui/imports/shared/controls/InformationTag.qml
@@ -15,8 +15,6 @@ Control {
     property alias controlBackground: controlBackground
     property alias rightComponent: rightComponent.sourceComponent
 
-    implicitWidth: 66
-    implicitHeight: 26
     horizontalPadding: Style.current.halfPadding
     verticalPadding: 5
 

--- a/ui/imports/shared/controls/TokenDelegate.qml
+++ b/ui/imports/shared/controls/TokenDelegate.qml
@@ -34,7 +34,6 @@ StatusListItem {
                 id: localeCurrencyBalance
                 anchors.right: parent.right
                 font.pixelSize: 15
-                font.strikeout: false
                 text: LocaleUtils.currencyAmountToLocaleString(enabledNetworkCurrencyBalance)
             }
             Row {
@@ -43,7 +42,6 @@ StatusListItem {
                 StatusTextWithLoadingState {
                     id: change24HourText
                     font.pixelSize: 15
-                    font.strikeout: false
                     customColor: root.textColor
                     text: LocaleUtils.currencyAmountToLocaleString(currencyPrice)
                 }
@@ -55,9 +53,8 @@ StatusListItem {
                 StatusTextWithLoadingState {
                     id: change24HourPercentageText
                     font.pixelSize: 15
-                    font.strikeout: false
                     customColor: root.textColor
-                    text: changePct24hour !== "" ? changePct24hour.toFixed(2) + "%" : "---"
+                    text: changePct24hour !== "" ? "%1%".arg(LocaleUtils.numberToLocaleString(changePct24hour, 2)) : "---"
                 }
             }
         }

--- a/ui/imports/shared/stores/CurrenciesStore.qml
+++ b/ui/imports/shared/stores/CurrenciesStore.qml
@@ -1,4 +1,7 @@
-import QtQuick 2.13
+import QtQuick 2.15
+
+import StatusQ.Core 0.1
+
 import utils 1.0
 import "../../../app/AppLayouts/Profile/stores"
 
@@ -27,9 +30,9 @@ QtObject {
         return 0;
     }
 
-    property string currentCurrency: Global.appIsReady? walletSection.currentCurrency : ""
-    property int currentCurrencyModelIndex: getModelIndexForShortName(currentCurrency)
-    property string currentCurrencySymbol: currenciesModel.get(currentCurrencyModelIndex).symbol
+    readonly property string currentCurrency: Global.appIsReady ? walletSection.currentCurrency : ""
+    readonly property int currentCurrencyModelIndex: getModelIndexForShortName(currentCurrency)
+    readonly property string currentCurrencySymbol: currenciesModel.get(currentCurrencyModelIndex).symbol ?? Qt.locale().currencySymbol(Locale.CurrencySymbol)
 
     property ListModel currenciesModel: ListModel {
        ListElement {
@@ -315,6 +318,7 @@ QtObject {
            category: qsTr("Other Fiat")
            imageSource: "../../assets/twemoji/svg/1f1e8-1f1f4.svg"
            selected: false
+           isToken: false
        }
 
        ListElement {
@@ -962,8 +966,8 @@ QtObject {
             root.currenciesModel.get(0).selected = true
     }
 
-    function updateCurrency(newCurrenyKey) {
-        let index = getModelIndexForKey(newCurrenyKey)
+    function updateCurrency(newCurrencyKey) {
+        let index = getModelIndexForKey(newCurrencyKey)
         let shortName = root.currenciesModel.get(index).shortName
         walletSection.updateCurrency(shortName)
     }
@@ -981,17 +985,17 @@ QtObject {
     }
 
     function getFiatValue(balance, cryptoSymbol, fiatSymbol) {
-        var amount = profileSectionModule.ensUsernamesModule.getFiatValue(balance, cryptoSymbol, fiatSymbol)
+        var amount = profileSectionStore.profileSectionModuleInst.ensUsernamesModule.getFiatValue(balance, cryptoSymbol, fiatSymbol)
         return getCurrencyAmount(parseFloat(amount), fiatSymbol)
     }
 
     function getCryptoValue(balance, cryptoSymbol, fiatSymbol) {
-        var amount = profileSectionModule.ensUsernamesModule.getCryptoValue(balance, cryptoSymbol, fiatSymbol)
+        var amount = profileSectionStore.profileSectionModuleInst.ensUsernamesModule.getCryptoValue(balance, cryptoSymbol, fiatSymbol)
         return getCurrencyAmount(parseFloat(amount), cryptoSymbol) 
     }
 
     function getGasEthValue(gweiValue, gasLimit) {
-        var amount = profileSectionModule.ensUsernamesModule.getGasEthValue(gweiValue, gasLimit)
+        var amount = profileSectionStore.profileSectionModuleInst.ensUsernamesModule.getGasEthValue(gweiValue, gasLimit)
         return getCurrencyAmount(parseFloat(amount), "ETH") 
     }
 


### PR DESCRIPTION
(in separate commits)
- fix formatting floating point numbers (asset percentage/changes)
- CurrenciesStore fixes
- Information tag fixes (text overflowing)

### Affected areas

Wallet/Asset view

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

Asset overview (percentage change using correct decimal separator):
![image](https://user-images.githubusercontent.com/5377645/219715945-a186b8d6-30ae-44b9-b63b-619e6280927c.png)

Asset detail (percentage changes using correct decimal separator, correct info tag text, not overflowing):
![image](https://user-images.githubusercontent.com/5377645/219716418-6c917835-5c8c-4a1a-9f35-477c1f578291.png)


