### PR TITLE
feat(CommunityPermissions): Handle update/remove by permission's key instead of index

### DIFF
--- a/storybook/pages/CommunityNewPermissionViewPage.qml
+++ b/storybook/pages/CommunityNewPermissionViewPage.qml
@@ -47,12 +47,12 @@ SplitView {
                     logs.logEvent("CommunitiesStore::creatPermission")
                 }
 
-                function editPermission(index, holdings, permissions, channels, isPrivate) {
-                    logs.logEvent("CommunitiesStore::editPermission - index: " + index)
+                function editPermission(key, holdings, permissions, channels, isPrivate) {
+                    logs.logEvent("CommunitiesStore::editPermission - key: " + key)
                 }
 
-                function removePermission(index) {
-                    logs.logEvent("CommunitiesStore::removePermission - index: " + index)
+                function removePermission(key) {
+                    logs.logEvent("CommunitiesStore::removePermission - key: " + key)
                 }
             }
 

--- a/storybook/pages/CommunityPermissionsViewPage.qml
+++ b/storybook/pages/CommunityPermissionsViewPage.qml
@@ -57,12 +57,11 @@ SplitView {
                 }
 
                 onEditPermissionRequested:
-                    logs.logEvent("CommunitiesStore::editPermission - index: " + index)
+                    logs.logEvent("CommunityPermissionsView::editPermissionRequested - index: " + index)
                 onRemovePermissionRequested:
-                    logs.logEvent("CommunitiesStore::removePermission - index: " + index)
+                    logs.logEvent("CommunityPermissionsView::removePermissionRequested - index: " + index)
                 onDuplicatePermissionRequested:
-                    logs.logEvent("CommunitiesStore::duplicatePermission - index: " + index)
-
+                    logs.logEvent("CommunityPermissionsView::duplicatePermissionRequested - index: " + index)
             }
         }
 

--- a/ui/app/AppLayouts/Chat/panels/communities/CommunityPermissionsSettingsPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/CommunityPermissionsSettingsPanel.qml
@@ -18,9 +18,9 @@ SettingsPageLayout {
     function navigateBack() {
         if (root.state === d.newPermissionViewState) {
             root.state = d.initialState
-        } else if(root.state === d.permissionsViewState) {
+        } else if (root.state === d.permissionsViewState) {
             root.state = d.newPermissionViewState
-        } else if(root.state === d.editPermissionViewState) {
+        } else if (root.state === d.editPermissionViewState) {
             if (root.dirty) {
                 root.notifyDirty()
             } else {
@@ -41,7 +41,8 @@ SettingsPageLayout {
         signal saveChanges
         signal resetChanges
 
-        property int permissionIndexToEdit
+        property string permissionKeyToEdit
+
         property ListModel holdingsToEditModel: ListModel {}
         property int permissionTypeToEdit: PermissionTypes.Type.None
         property ListModel channelsToEditModel: ListModel {}
@@ -50,7 +51,7 @@ SettingsPageLayout {
         onPermissionsExistChanged: {
             // Navigate back to welcome permissions view if all existing permissions are removed.
             if(root.state === d.permissionsViewState && !permissionsExist) {
-                root.state =  d.welcomeViewState;
+                root.state = d.welcomeViewState;
             }
         }
 
@@ -173,11 +174,11 @@ SettingsPageLayout {
                 const count = model.rowCount()
 
                 for (let i = 0; i < count; i++) {
-                    if (root.state === d.editPermissionViewState
-                            && d.permissionIndexToEdit === i)
-                        continue
-
                     const item = ModelUtils.get(model, i)
+
+                    if (root.state === d.editPermissionViewState
+                            && d.permissionKeyToEdit === item.key)
+                        continue
 
                     const holdings = item.holdingsListModel
                     const channels = item.channelsListModel
@@ -208,7 +209,7 @@ SettingsPageLayout {
 
                 function onSaveChanges() {
                     root.store.editPermission(
-                                d.permissionIndexToEdit,
+                                d.permissionKeyToEdit,
                                 dirtyValues.holdingsModel,
                                 dirtyValues.permissionType,
                                 dirtyValues.channelsModel,
@@ -266,7 +267,8 @@ SettingsPageLayout {
 
             onEditPermissionRequested: {
                 setInitialValuesFromIndex(index)
-                d.permissionIndexToEdit = index
+                d.permissionKeyToEdit = ModelUtils.get(
+                            root.store.permissionsModel, index, "key")
                 root.state = d.editPermissionViewState
             }
 
@@ -276,7 +278,8 @@ SettingsPageLayout {
             }
 
             onRemovePermissionRequested: {
-                root.store.removePermission(index)
+                const key = ModelUtils.get(root.store.permissionsModel, index, "key")
+                root.store.removePermission(key)
             }
         }
     }

--- a/ui/app/AppLayouts/Chat/stores/CommunitiesStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/CommunitiesStore.qml
@@ -2,6 +2,8 @@ import QtQuick 2.15
 
 import AppLayouts.Chat.controls.community 1.0
 
+import StatusQ.Core.Utils 0.1
+
 QtObject {
     id: root
 
@@ -131,56 +133,69 @@ QtObject {
         ListElement { key: "general"; iconSource: "qrc:imports/assets/png/tokens/CUSTOM-TOKEN.png"; name: "#general"}
     }
 
+    readonly property QtObject _d: QtObject {
+        id: d
+
+        property int keyCounter: 0
+
+        function createPermissionEntry(holdings, permissionType, isPrivate, channels) {
+            const permission = {
+                holdingsListModel: [],
+                channelsListModel: [],
+                permissionType,
+                isPrivate
+            }
+
+            // Setting HOLDINGS:
+            for (let i = 0; i < holdings.count; i++ ) {
+                const entry = holdings.get(i)
+
+                permission.holdingsListModel.push({
+                    type: entry.type,
+                    key: entry.key,
+                    amount: entry.amount
+                })
+            }
+
+            // Setting CHANNELS:
+            for (let c = 0; c < channels.count; c++) {
+                const entry = channels.get(c)
+
+                permission.channelsListModel.push({
+                    itemId: entry.itemId,
+                    text: entry.text,
+                    emoji: entry.emoji,
+                    color: entry.color
+                })
+            }
+
+            return permission
+        }
+    }
+
     function createPermission(holdings, permissionType, isPrivate, channels, index = null) {
-        // TO BE REPLACED: It shold just be a call to the backend sharing `holdings`, `permissions`, `channels` and `isPrivate` properties.
-        const permission = {
-            holdingsListModel: [],
-            channelsListModel: [],
-            permissionType,
-            isPrivate
-        }
+        // TO BE REPLACED: It shold just be a call to the backend sharing
+        // `holdings`, `permissions`, `channels` and `isPrivate` properties.
 
-        // Setting HOLDINGS:
-        for (let i = 0; i < holdings.count; i++ ) {
-            const entry = holdings.get(i)
+        const permissionEntry = d.createPermissionEntry(
+                                  holdings, permissionType, isPrivate, channels)
 
-            permission.holdingsListModel.push({
-                type: entry.type,
-                key: entry.key,
-                amount: entry.amount
-            })
-        }
-
-        // Setting CHANNELS:
-        for (let c = 0; c < channels.count; c++) {
-            const entry = channels.get(c)
-
-            permission.channelsListModel.push({
-                itemId: entry.itemId,
-                text: entry.text,
-                emoji: entry.emoji,
-                color: entry.color
-            })
-        }
-
-        if (index !== null) {
-            // Edit permission model:
-            console.log("TODO: Edit permissions - backend call")
-            root.permissionsModel.set(index, permission)
-        } else {
-            // Add into permission model:
-            console.log("TODO: Create permissions - backend call - Now dummy data shown")
-            root.permissionsModel.append(permission)
-        }
+        permissionEntry.key = "" + d.keyCounter++
+        root.permissionsModel.append(permissionEntry)
     }
 
-    function editPermission(index, holdings, permissionType, channels, isPrivate) {
+    function editPermission(key, holdings, permissionType, channels, isPrivate) {
         // TO BE REPLACED: Call to backend
-        createPermission(holdings, permissionType, isPrivate, channels, index)
+
+        const permissionEntry = d.createPermissionEntry(
+                                  holdings, permissionType, isPrivate, channels)
+
+        const index = ModelUtils.indexOf(root.permissionsModel, "key", key)
+        root.permissionsModel.set(index, permissionEntry)
     }
 
-    function removePermission(index) {
-        console.log("TODO: Remove permissions - backend call")
+    function removePermission(key) {
+        const index = ModelUtils.indexOf(root.permissionsModel, "key", key)
         root.permissionsModel.remove(index)
     }
 


### PR DESCRIPTION
### What does the PR do

So far store had methods for update/remove taking index of the permission in the model. Now those ops are based on unique identifier representing permission, independent from position in the input model.

Closes: #9577

### Affected areas
`CommunityPermissionsSettingsPanel`