### PR TITLE
fix(StatusQ): Removed nonexisting/unused imports from Sandbox pages

### DIFF
--- a/ui/StatusQ/sandbox/controls/Controls.qml
+++ b/ui/StatusQ/sandbox/controls/Controls.qml
@@ -5,6 +5,7 @@ import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
 import StatusQ.Controls 0.1
 
+
 ColumnLayout {
     spacing: 5
 

--- a/ui/StatusQ/sandbox/pages/StatusAccountSelectorPage.qml
+++ b/ui/StatusQ/sandbox/pages/StatusAccountSelectorPage.qml
@@ -2,7 +2,6 @@ import QtQuick 2.14
 import QtQuick.Controls 2.14
 import QtQuick.Layouts 1.14
 
-import Sandbox 0.1
 import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
 import StatusQ.Controls 0.1

--- a/ui/StatusQ/sandbox/pages/StatusAddressPage.qml
+++ b/ui/StatusQ/sandbox/pages/StatusAddressPage.qml
@@ -5,8 +5,6 @@ import QtQuick.Layouts 1.14
 import StatusQ.Core 0.1
 import StatusQ.Components 0.1
 
-import Sandbox 0.1
-
 Item {
     id: root
 

--- a/ui/StatusQ/sandbox/pages/StatusCardPage.qml
+++ b/ui/StatusQ/sandbox/pages/StatusCardPage.qml
@@ -2,7 +2,6 @@ import QtQuick 2.14
 import QtQuick.Controls 2.14
 import QtQuick.Layouts 1.14
 
-import Sandbox 0.1
 import StatusQ.Core 0.1
 import StatusQ.Core.Utils 0.1
 import StatusQ.Core.Theme 0.1

--- a/ui/StatusQ/sandbox/pages/StatusChartPanelPage.qml
+++ b/ui/StatusQ/sandbox/pages/StatusChartPanelPage.qml
@@ -7,8 +7,6 @@ import StatusQ.Core.Theme 0.1
 import StatusQ.Controls 0.1
 import StatusQ.Components 0.1
 
-import Sandbox 0.1
-
 Item {
 
     QtObject {

--- a/ui/StatusQ/sandbox/pages/StatusChatCommandButtonPage.qml
+++ b/ui/StatusQ/sandbox/pages/StatusChatCommandButtonPage.qml
@@ -6,8 +6,6 @@ import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
 import StatusQ.Controls 0.1
 
-import Sandbox 0.1
-
 Column {
     spacing: 8
 

--- a/ui/StatusQ/sandbox/pages/StatusColorSelectorPage.qml
+++ b/ui/StatusQ/sandbox/pages/StatusColorSelectorPage.qml
@@ -6,8 +6,6 @@ import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
 import StatusQ.Controls 0.1
 
-import Sandbox 0.1
-
 Row {
     spacing: 8
 

--- a/ui/StatusQ/sandbox/pages/StatusColorSpacePage.qml
+++ b/ui/StatusQ/sandbox/pages/StatusColorSpacePage.qml
@@ -7,8 +7,6 @@ import StatusQ.Core.Theme 0.1
 import StatusQ.Controls 0.1
 import StatusQ.Components 0.1
 
-import Sandbox 0.1
-
 Item {
 
     ColumnLayout {

--- a/ui/StatusQ/sandbox/pages/StatusComboBoxPage.qml
+++ b/ui/StatusQ/sandbox/pages/StatusComboBoxPage.qml
@@ -7,8 +7,6 @@ import StatusQ.Core.Theme 0.1
 import StatusQ.Controls 0.1
 import StatusQ.Popups 0.1
 
-import Sandbox 0.1
-
 Column {
     spacing: 20
 

--- a/ui/StatusQ/sandbox/pages/StatusCommunityTagsPage.qml
+++ b/ui/StatusQ/sandbox/pages/StatusCommunityTagsPage.qml
@@ -7,8 +7,6 @@ import StatusQ.Core.Theme 0.1
 import StatusQ.Controls 0.1
 import StatusQ.Components 0.1
 
-import Sandbox 0.1
-
 import "../demoapp/data" 1.0
 
 Item {

--- a/ui/StatusQ/sandbox/pages/StatusInputPage.qml
+++ b/ui/StatusQ/sandbox/pages/StatusInputPage.qml
@@ -6,8 +6,6 @@ import StatusQ.Core.Theme 0.1
 import StatusQ.Controls 0.1
 import StatusQ.Controls.Validators 0.1
 
-import Sandbox 0.1
-
 Column {
     spacing: 8
 

--- a/ui/StatusQ/sandbox/pages/StatusMacNotificationPage.qml
+++ b/ui/StatusQ/sandbox/pages/StatusMacNotificationPage.qml
@@ -4,8 +4,6 @@ import QtQuick.Layouts 1.14
 
 import StatusQ.Platform 0.1
 
-import Sandbox 0.1
-
 Column {
     spacing: 8
 

--- a/ui/StatusQ/sandbox/pages/StatusSelectPage.qml
+++ b/ui/StatusQ/sandbox/pages/StatusSelectPage.qml
@@ -7,8 +7,6 @@ import StatusQ.Core.Theme 0.1
 import StatusQ.Controls 0.1
 import StatusQ.Popups 0.1
 
-import Sandbox 0.1
-
 Column {
     spacing: 20
 

--- a/ui/StatusQ/sandbox/pages/StatusTabBarButtonPage.qml
+++ b/ui/StatusQ/sandbox/pages/StatusTabBarButtonPage.qml
@@ -4,8 +4,6 @@ import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
 import StatusQ.Controls 0.1
 
-import Sandbox 0.1
-
 Column {
     spacing: 8
 

--- a/ui/StatusQ/sandbox/pages/StatusTabBarIconButtonPage.qml
+++ b/ui/StatusQ/sandbox/pages/StatusTabBarIconButtonPage.qml
@@ -6,8 +6,6 @@ import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
 import StatusQ.Controls 0.1
 
-import Sandbox 0.1
-
 Column {
     spacing: 8
 

--- a/ui/StatusQ/sandbox/pages/StatusWalletColorButtonPage.qml
+++ b/ui/StatusQ/sandbox/pages/StatusWalletColorButtonPage.qml
@@ -6,7 +6,6 @@ import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
 import StatusQ.Controls 0.1
 
-import Sandbox 0.1
 Column {
     spacing: 8
 

--- a/ui/StatusQ/sandbox/pages/StatusWalletColorSelectPage.qml
+++ b/ui/StatusQ/sandbox/pages/StatusWalletColorSelectPage.qml
@@ -6,8 +6,6 @@ import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
 import StatusQ.Controls 0.1
 
-import Sandbox 0.1
-
 Column {
     spacing: 8
 


### PR DESCRIPTION
### What does the PR do

Closes: #9594

Some sandbox pages had an unused import `import Sandbox`. That namespace had been removed at some point causing errors on pages where it was used.

The second part of the ticker (build script) has been covered here: https://github.com/status-im/status-desktop/pull/9595


<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas
`StatusQ`'s pages
