### PR TITLE
chore(keycard): sync keycard with the current app state updated

### DIFF
--- a/src/app/boot/app_controller.nim
+++ b/src/app/boot/app_controller.nim
@@ -1,4 +1,4 @@
-import NimQml, sequtils, sugar, chronicles, os, uuids
+import NimQml, sequtils, chronicles, os, uuids
 
 import ../../app_service/service/general/service as general_service
 import ../../app_service/service/keychain/service as keychain_service
@@ -32,12 +32,11 @@ import ../../app_service/service/mailservers/service as mailservers_service
 import ../../app_service/service/gif/service as gif_service
 import ../../app_service/service/ens/service as ens_service
 import ../../app_service/service/community_tokens/service as tokens_service
-import ../../app_service/common/account_constants
 
+import ../modules/shared_modules/keycard_popup/module as keycard_shared_module
 import ../modules/startup/module as startup_module
 import ../modules/main/module as main_module
 import ../core/notifications/notifications_manager
-
 import ../../constants as main_constants
 import ../global/global_singleton
 
@@ -107,6 +106,7 @@ type
 proc load(self: AppController)
 proc buildAndRegisterLocalAccountSensitiveSettings(self: AppController)
 proc buildAndRegisterUserProfile(self: AppController)
+proc tryKeycardSyncWithTheAppState(self: AppController)
 
 # Startup Module Delegate Interface
 proc startupDidLoad*(self: AppController)
@@ -373,6 +373,7 @@ proc startupDidLoad*(self: AppController) =
   self.startupModule.startUpUIRaised()
 
 proc mainDidLoad*(self: AppController) =
+  self.tryKeycardSyncWithTheAppState()
   self.startupModule.moveToAppState()
   self.checkForStoringPasswordToKeychain()
 
@@ -492,6 +493,7 @@ proc buildAndRegisterUserProfile(self: AppController) =
 
   singletonInstance.engine.setRootContextProperty("userProfile", self.userProfileVariant)
 
+proc tryKeycardSyncWithTheAppState(self: AppController) =
   ##############################################################################                                             store def   kc sync with app    kc uid
   ## Onboarding flows sync keycard state after login                                                                          keypair  | (inc. kp store)  |  update
   ## `I’m new to Status` -> `Generate new keys`                                                                          ->     na     |       na         |    na
@@ -513,56 +515,19 @@ proc buildAndRegisterUserProfile(self: AppController) =
   ## `Login` -> if card was unlocked via seed phrase                                                                     ->     no     |       no         |   yes  
   ## `Login` -> `Create replacement Keycard with seed phrase`                                                            ->     no     |      yes         |    no (we don't know which kc is replaced if user has more kc for the same kp)
   ##############################################################################
-  if singletonInstance.userProfile.getIsKeycardUser():
-    if self.storeDefaultKeyPair:
-      let allAccounts = self.walletAccountService.fetchAccounts()
-      let defaultWalletAccounts = allAccounts.filter(a => 
-        a.walletType == WalletTypeDefaultStatusAccount and 
-        a.path == account_constants.PATH_DEFAULT_WALLET and
-        not a.isChat and 
-        a.isWallet
+  if singletonInstance.userProfile.getIsKeycardUser() or 
+    self.syncKeycardBasedOnAppWalletState:
+      let data = SharedKeycarModuleArgs(
+        pin: self.startupModule.getPin(), 
+        keyUid: singletonInstance.userProfile.getKeyUid()
       )
-      if defaultWalletAccounts.len == 0:
-        error "default wallet account was not generated"
-        return
-      let defaultWalletAddress = defaultWalletAccounts[0].address
-      let keyPair = KeyPairDto(keycardUid: self.keycardService.getLastReceivedKeycardData().flowEvent.instanceUID,
-        keycardName: displayName,
-        keycardLocked: false,
-        accountsAddresses: @[defaultWalletAddress],
-        keyUid: loggedInAccount.keyUid)
-      discard self.walletAccountService.addMigratedKeyPair(keyPair)
-    if self.syncKeycardBasedOnAppWalletState:
-      let allAccounts = self.walletAccountService.fetchAccounts()
-      let accountsForLoggedInUser = allAccounts.filter(a => a.keyUid == loggedInAccount.keyUid)
-      var keyPair = KeyPairDto(keycardUid: "",
-        keycardName: displayName,
-        keycardLocked: false,
-        accountsAddresses: @[],
-        keyUid: loggedInAccount.keyUid)
-      var activeValidPathsToStoreToAKeycard: seq[string]
-      for acc in accountsForLoggedInUser:
-        activeValidPathsToStoreToAKeycard.add(acc.path)
-        keyPair.accountsAddresses.add(acc.address)
-      self.keycardService.startStoreMetadataFlow(displayName, self.startupModule.getPin(), activeValidPathsToStoreToAKeycard)
-      ## sleep for 3 seconds, since that is more than enough to store metadata to a keycard, if the reader is still plugged in
-      ## and the card is still inserted, otherwise we just skip that.
-      ## At the moment we're not able to sync later keycard without metadata, cause such card doesn't return instance uid for 
-      ## loaded seed phrase, that's in the notes I am taking for discussion with keycard team. If they are able to provide
-      ## instance uid for GetMetadata flow we will be able to use SIGNAL_SHARED_KEYCARD_MODULE_TRY_KEYCARD_SYNC signal for syncing
-      ## otherwise we need to handle that way separatelly in `handleKeycardSyncing` of shared module 
-      sleep(3000)
-      self.keycardService.cancelCurrentFlow()
-      let (_, kcEvent) = self.keycardService.getLastReceivedKeycardData()
-      if kcEvent.instanceUID.len > 0:
-        keyPair.keycardUid = kcEvent.instanceUID
-        discard self.walletAccountService.addMigratedKeyPair(keyPair)
+      self.statusFoundation.events.emit(SIGNAL_SHARED_KEYCARD_MODULE_TRY_KEYCARD_SYNC, data)
 
-    if self.changedKeycardUids.len > 0:
-      let oldUid = self.changedKeycardUids[0].oldKcUid
-      let newUid = self.changedKeycardUids[^1].newKcUid
-      discard self.walletAccountService.updateKeycardUid(oldUid, newUid)
-      discard self.walletAccountService.setKeycardUnlocked(loggedInAccount.keyUid, newUid)
+  if self.changedKeycardUids.len > 0:
+    let oldUid = self.changedKeycardUids[0].oldKcUid
+    let newUid = self.changedKeycardUids[^1].newKcUid
+    discard self.walletAccountService.updateKeycardUid(oldUid, newUid)
+    discard self.walletAccountService.setKeycardUnlocked(singletonInstance.userProfile.getKeyUid(), newUid)
 
 proc storeDefaultKeyPairForNewKeycardUser*(self: AppController) = 
   self.storeDefaultKeyPair = true

--- a/src/app/core/signals/remote_signals/messages.nim
+++ b/src/app/core/signals/remote_signals/messages.nim
@@ -11,6 +11,7 @@ import ../../../../app_service/service/contacts/dto/[contacts, status_update]
 import ../../../../app_service/service/devices/dto/[device]
 import ../../../../app_service/service/settings/dto/[settings]
 import ../../../../app_service/service/saved_address/[dto]
+import ../../../../app_service/service/wallet_account/[key_pair_dto]
 
 type MessageSignal* = ref object of Signal
   bookmarks*: seq[BookmarkDto]
@@ -32,6 +33,8 @@ type MessageSignal* = ref object of Signal
   clearedHistories*: seq[ClearedHistoryDto]
   verificationRequests*: seq[VerificationRequest]
   savedAddresses*: seq[SavedAddressDto]
+  keycards*: seq[KeyPairDto]
+  keycardActions*: seq[KeycardActionDto]
 
 type MessageDeliveredSignal* = ref object of Signal
   chatId*: string
@@ -129,6 +132,14 @@ proc fromEvent*(T: type MessageSignal, event: JsonNode): MessageSignal =
   if event["event"]{"savedAddresses"} != nil:
     for jsonSavedAddress in event["event"]["savedAddresses"]:
       signal.savedAddresses.add(jsonSavedAddress.toSavedAddressDto())
+
+  if event["event"]{"keycards"} != nil:
+    for jsonKc in event["event"]["keycards"]:
+      signal.keycards.add(jsonKc.toKeyPairDto())
+
+  if event["event"]{"keycardActions"} != nil:
+    for jsonKc in event["event"]["keycardActions"]:
+      signal.keycardActions.add(jsonKc.toKeycardActionDto())
 
   result = signal
 

--- a/src/app/modules/main/profile_section/keycard/controller.nim
+++ b/src/app/modules/main/profile_section/keycard/controller.nim
@@ -53,6 +53,12 @@ proc init*(self: Controller) =
       return
     self.delegate.onNewKeycardSet(args.keyPair)
 
+  self.events.on(SIGNAL_KEYCARDS_SYNCHRONIZED) do(e: Args):
+    let args = KeycardActivityArgs(e)
+    if not args.success:
+      return
+    self.delegate.onKeycardsSynchronized()
+
   self.events.on(SIGNAL_KEYCARD_LOCKED) do(e: Args):
     let args = KeycardActivityArgs(e)
     self.delegate.onKeycardLocked(args.keyPair.keyUid, args.keyPair.keycardUid)

--- a/src/app/modules/main/profile_section/keycard/io_interface.nim
+++ b/src/app/modules/main/profile_section/keycard/io_interface.nim
@@ -66,6 +66,9 @@ method runCreateNewPairingCodePopup*(self: AccessInterface, keyUid: string) {.ba
 method onLoggedInUserImageChanged*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method onKeycardsSynchronized*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method onNewKeycardSet*(self: AccessInterface, keyPair: KeyPairDto) {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/profile_section/keycard/module.nim
+++ b/src/app/modules/main/profile_section/keycard/module.nim
@@ -276,6 +276,9 @@ method onLoggedInUserImageChanged*(self: Module) =
     return
   self.view.keycardDetailsModel().setImage(singletonInstance.userProfile.getPubKey(), singletonInstance.userProfile.getIcon())
 
+method onKeycardsSynchronized*(self: Module) =
+  self.buildKeycardList()
+
 method onNewKeycardSet*(self: Module, keyPair: KeyPairDto) =
   let walletAccounts = self.controller.getWalletAccounts()
   var mainViewItem = self.view.keycardModel().getItemForKeyUid(keyPair.keyUid)

--- a/src/app/modules/main/wallet_section/accounts/module.nim
+++ b/src/app/modules/main/wallet_section/accounts/module.nim
@@ -150,6 +150,12 @@ method load*(self: Module) =
       return
     self.refreshWalletAccounts()
 
+  self.events.on(SIGNAL_KEYCARDS_SYNCHRONIZED) do(e: Args):
+    let args = KeycardActivityArgs(e)
+    if not args.success:
+      return
+    self.refreshWalletAccounts()
+
   self.controller.init()
   self.view.load()
 

--- a/src/app/modules/shared_modules/keycard_popup/internal/renaming_keycard_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/renaming_keycard_state.nim
@@ -15,7 +15,7 @@ method executePrePrimaryStateCommand*(self: RenamingKeycardState, controller: Co
     let md = controller.getMetadataFromKeycard()
     let paths = md.walletAccounts.map(a => a.path)
     let name = controller.getKeyPairForProcessing().getName()
-    self.success = controller.updateKeycardName(controller.getKeyPairForProcessing().getKeyUid(), controller.getKeycardUid(), name)
+    self.success = controller.updateKeycardName(controller.getKeycardUid(), name)
     if self.success:
       controller.runStoreMetadataFlow(name, controller.getPin(), paths)
     else:

--- a/src/app/modules/shared_modules/keycard_popup/internal/wrong_seed_phrase_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/wrong_seed_phrase_state.nim
@@ -1,5 +1,3 @@
-import os
-
 type
   WrongSeedPhraseState* = ref object of State
     verifiedSeedPhrase: bool

--- a/src/app/modules/shared_modules/keycard_popup/models/key_pair_account_model.nim
+++ b/src/app/modules/shared_modules/keycard_popup/models/key_pair_account_model.nim
@@ -1,7 +1,7 @@
 import NimQml, Tables, strformat, strutils
 import key_pair_account_item
 
-import ../../../../../app_service/common/account_constants
+import ../../../../../app_service/common/utils
 
 export key_pair_account_item
 
@@ -82,10 +82,8 @@ QtObject:
 
   proc containsPathOutOfTheDefaultStatusDerivationTree*(self: KeyPairAccountModel): bool =
     for it in self.items:
-      if not it.getPath().startsWith(account_constants.PATH_WALLET_ROOT&"/") or
-        it.getPath().count("'") != 3 or
-        it.getPath().count("/") != 5: 
-          return true
+      if utils.isPathOutOfTheDefaultStatusDerivationTree(it.getPath()):
+        return true
     return false
 
   proc getItemAtIndex*(self: KeyPairAccountModel, index: int): KeyPairAccountItem =

--- a/src/app/modules/startup/module.nim
+++ b/src/app/modules/startup/module.nim
@@ -342,7 +342,7 @@ proc delayStartingApp[T](self: Module[T]) =
   ## - FlowType.FirstRunOldUserImportSeedPhrase
   ## - FlowType.FirstRunOldUserKeycardImport
   ## we want to delay app start just to be sure that messages from waku will be received
-  self.controller.connectToTimeoutEventAndStratTimer(timeoutInMilliseconds = 10000) # delay for 30 seconds
+  self.controller.connectToTimeoutEventAndStratTimer(timeoutInMilliseconds = 30000) # delay for 30 seconds
 
 method startAppAfterDelay*[T](self: Module[T]) =
   if not self.view.fetchingDataModel().allMessagesLoaded():

--- a/src/app_service/common/utils.nim
+++ b/src/app_service/common/utils.nim
@@ -1,6 +1,6 @@
 import json, random, times, strutils, sugar, os, re, chronicles
 import nimcrypto
-import signing_phrases
+import signing_phrases, account_constants
 
 import ../../constants as main_constants
 
@@ -74,3 +74,10 @@ proc validateLink*(link: string): bool =
         link, re"[(http(s)?):\/\/(www\.)?a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)", 0):
       error "Invalid social link", errDescription = link
       result = false
+
+proc isPathOutOfTheDefaultStatusDerivationTree*(path: string): bool =
+  if not path.startsWith(account_constants.PATH_WALLET_ROOT&"/") or
+    path.count("'") != 3 or
+    path.count("/") != 5: 
+      return true
+  return false

--- a/src/app_service/service/wallet_account/async_tasks.nim
+++ b/src/app_service/service/wallet_account/async_tasks.nim
@@ -140,14 +140,14 @@ type
 const addMigratedKeyPairTask*: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AddMigratedKeyPairTaskArg](argEncoded)
   try:
-    let response = backend.addMigratedKeyPair(
+    let response = backend.addMigratedKeyPairOrAddAccountsIfKeyPairIsAdded(
       arg.keyPair.keycardUid,
       arg.keyPair.keycardName,
       arg.keyPair.keyUid,
       arg.keyPair.accountsAddresses,
       arg.password
       )
-    let success = responseHasNoErrors("addMigratedKeyPair", response)
+    let success = responseHasNoErrors("addMigratedKeyPairOrAddAccountsIfKeyPairIsAdded", response)
     let responseJson = %*{
       "success": success,
       "keyPair": arg.keyPair.toJsonNode()

--- a/src/app_service/service/wallet_account/key_pair_dto.nim
+++ b/src/app_service/service/wallet_account/key_pair_dto.nim
@@ -2,12 +2,23 @@ import json
 
 include  ../../common/json_utils
 
-const KeycardUid = "keycard-uid"
-const KeycardName = "keycard-name"
-const KeycardLocked = "keycard-locked"
-const KeyUid = "key-uid"
-const AccountAddresses = "accounts-addresses"
+const ParamKeycardUid = "keycard-uid"
+const ParamKeycardName = "keycard-name"
+const ParamKeycardLocked = "keycard-locked"
+const ParamKeyUid = "key-uid"
+const ParamAccountAddresses = "accounts-addresses"
+const ParamAction = "action"
+const ParamOldKeycardUid = "old-keycard-uid"
+const ParamKeycard = "keycard"
 
+const KeycardActionKeycardAdded* = "KEYCARD_ADDED"
+const KeycardActionAccountsAdded* = "ACCOUNTS_ADDED"
+const KeycardActionKeycardDeleted* = "KEYCARD_DELETED"
+const KeycardActionAccountsRemoved* = "ACCOUNTS_REMOVED"
+const KeycardActionLocked* = "LOCKED"
+const KeycardActionUnlocked* = "UNLOCKED"
+const KeycardActionUidUpdated* = "UID_UPDATED"
+const KeycardActionNameChanged* = "NAME_CHANGED"
 
 type KeyPairDto* = object
   keycardUid*: string
@@ -16,23 +27,37 @@ type KeyPairDto* = object
   accountsAddresses*: seq[string]
   keyUid*: string
 
+type KeycardActionDto* = object
+  action*: string
+  oldKeycardUid*: string
+  keycard*: KeyPairDto
+
 proc toKeyPairDto*(jsonObj: JsonNode): KeyPairDto =
   result = KeyPairDto()
-  discard jsonObj.getProp(KeycardUid, result.keycardUid)
-  discard jsonObj.getProp(KeycardName, result.keycardName)
-  discard jsonObj.getProp(KeycardLocked, result.keycardLocked)
-  discard jsonObj.getProp(KeyUid, result.keyUid)
+  discard jsonObj.getProp(ParamKeycardUid, result.keycardUid)
+  discard jsonObj.getProp(ParamKeycardName, result.keycardName)
+  discard jsonObj.getProp(ParamKeycardLocked, result.keycardLocked)
+  discard jsonObj.getProp(ParamKeyUid, result.keyUid)
   
   var jArr: JsonNode
-  if(jsonObj.getProp(AccountAddresses, jArr) and jArr.kind == JArray):
+  if(jsonObj.getProp(ParamAccountAddresses, jArr) and jArr.kind == JArray):
     for addrObj in jArr:
       result.accountsAddresses.add(addrObj.getStr)
 
+proc toKeycardActionDto*(jsonObj: JsonNode): KeycardActionDto =
+  result = KeycardActionDto()
+  discard jsonObj.getProp(ParamAction, result.action)
+  discard jsonObj.getProp(ParamOldKeycardUid, result.oldKeycardUid)
+  
+  var keycardObj: JsonNode
+  if(jsonObj.getProp("keycard", keycardObj)):
+    result.keycard = toKeyPairDto(keycardObj)
+
 proc toJsonNode*(self: KeyPairDto): JsonNode =
   result = %* {
-    KeycardUid: self.keycardUid,
-    KeycardName: self.keycardName,
-    KeycardLocked: self.keycardLocked,
-    KeyUid: self.keyUid,
-    AccountAddresses: self.accountsAddresses
+    ParamKeycardUid: self.keycardUid,
+    ParamKeycardName: self.keycardName,
+    ParamKeycardLocked: self.keycardLocked,
+    ParamKeyUid: self.keyUid,
+    ParamAccountAddresses: self.accountsAddresses
   }

--- a/src/backend/backend.nim
+++ b/src/backend/backend.nim
@@ -239,12 +239,12 @@ rpc(fetchMarketValues, "wallet"):
 rpc(fetchTokenDetails, "wallet"):
   symbols: seq[string]
 
-rpc(addMigratedKeyPair, "accounts"):
+rpc(addMigratedKeyPairOrAddAccountsIfKeyPairIsAdded, "accounts"):
   keycardUid: string
   keyPairName: string
   keyUid: string
   accountAddresses: seq[string]
-  keyStoreDir: string
+  password: string
 
 rpc(removeMigratedAccountsForKeycard, "accounts"):
   keycardUid: string

--- a/ui/app/AppLayouts/Profile/views/KeycardView.qml
+++ b/ui/app/AppLayouts/Profile/views/KeycardView.qml
@@ -84,6 +84,10 @@ SettingsContentBase {
             Layout.preferredWidth: root.contentWidth
             keycardStore: root.keycardStore
             keyUid: d.observedKeyUid
+
+            onChangeSectionTitle: {
+                root.sectionTitle = title
+            }
         }
 
         Connections {

--- a/ui/app/AppLayouts/Profile/views/keycard/DetailsView.qml
+++ b/ui/app/AppLayouts/Profile/views/keycard/DetailsView.qml
@@ -18,11 +18,20 @@ ColumnLayout {
     property KeycardStore keycardStore
     property string keyUid: ""
 
+    signal changeSectionTitle(string title)
+
     spacing: Constants.settingsSection.itemSpacing
 
     QtObject {
         id: d
         property bool collapsed: true
+
+        function checkAndCheckTitleIfNeeded(newKeycardName) {
+            // We change title if there is only a single keycard for a keypair in keycard details view
+            if (root.keycardStore.keycardModule.keycardDetailsModel.count === 1) {
+                root.changeSectionTitle(newKeycardName)
+            }
+        }
     }
 
     StatusListView {
@@ -42,6 +51,10 @@ ColumnLayout {
             keyPairIcon: model.keycard.icon
             keyPairImage: model.keycard.image
             keyPairAccounts: model.keycard.accounts
+
+            onKeycardNameChanged: {
+                d.checkAndCheckTitleIfNeeded(keycardName)
+            }
         }
     }
 


### PR DESCRIPTION
This commit resolves a crash happened due to connection to `SIGNAL_WALLET_ACCOUNT_TOKENS_REBUILT` when keycard sync flow was run in the background.

Also updated the keycard synchronization process with the current state of the application and is the first step of many which leads towards completion of entire syncing feature.

The first commit syncs a Keycard with the current app state, second commit introduces syncing keycard details among devices.

Corresponding `status-go` PR:
- https://github.com/status-im/status-go/pull/3211

Here is the demo how keycard syncing among devices work:


https://user-images.githubusercontent.com/86303051/221022963-e9154baf-e694-49e5-a9c5-aea5fe8cdda3.mov


