### PR TITLE
fix: truncation of channel description and pinned message text

### DIFF
--- a/ui/StatusQ/sandbox/controls/Controls.qml
+++ b/ui/StatusQ/sandbox/controls/Controls.qml
@@ -5,12 +5,8 @@ import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
 import StatusQ.Controls 0.1
 
-import Sandbox 0.1
-
-GridLayout {
-    columns: 1
-    columnSpacing: 5
-    rowSpacing: 5
+ColumnLayout {
+    spacing: 5
 
     StatusSelectableText {
         color: Theme.palette.baseColor1
@@ -146,7 +142,7 @@ GridLayout {
     }
 
     Item {
-        implicitWidth: 100
+        implicitWidth: 140
         implicitHeight: 48
         StatusChatInfoButton {
             title: "Iuri Matias elided"
@@ -157,7 +153,7 @@ GridLayout {
             type: StatusChatInfoButton.Type.OneToOneChat
             muted: true
             pinnedMessagesCount: 10
-            width: 100
+            width: parent.width
         }
     }
 
@@ -183,6 +179,7 @@ GridLayout {
         pinnedMessagesCount: 1
         asset.color: Theme.palette.miscColor7
         type: StatusChatInfoButton.Type.GroupChat
+        muted: true
     }
 
     StatusChatInfoButton {
@@ -193,11 +190,17 @@ GridLayout {
     }
 
     StatusChatInfoButton {
-        title: "community-channel"
-        subTitle: "Some very long description text to see how the whole item wraps or elides"
+        title: "public-chat-type"
+        subTitle: "Some very long description text with hover disabled to see how the whole item wraps or elides"
         asset.color: Theme.palette.miscColor7
-        type: StatusChatInfoButton.Type.CommunityChat
+        type: StatusChatInfoButton.Type.PublicChat
         pinnedMessagesCount: 3
+        hoverEnabled: false
+    }
+
+    StatusChatInfoButton {
+        title: "No subtitle and no type"
+        asset.color: Theme.palette.miscColor7
     }
 
     StatusSlider {

--- a/ui/StatusQ/src/StatusQ/Components/StatusChatInfoToolBar.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusChatInfoToolBar.qml
@@ -73,19 +73,17 @@ Item {
                     duration: 150
                     direction: RotationAnimation.Clockwise
                     easing.type: Easing.InCubic
-                    running: visible
                 }
             },
             Transition {
-								from: "pressed"
-								to: "default"
-								RotationAnimation {
-										duration: 150
-										direction: RotationAnimation.Counterclockwise
-										easing.type: Easing.OutCubic
-										running: visible
-								}
-        		}
+                from: "pressed"
+                to: "default"
+                RotationAnimation {
+                    duration: 150
+                    direction: RotationAnimation.Counterclockwise
+                    easing.type: Easing.OutCubic
+                }
+            }
         ]
 
         onClicked: {

--- a/ui/StatusQ/src/StatusQ/Components/StatusToolBar.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusToolBar.qml
@@ -56,6 +56,7 @@ ToolBar {
 
         StatusActivityCenterButton {
             id: notificationButton
+            Layout.leftMargin: 8
             unreadNotificationsCount: root.notificationCount
             hasUnseenNotifications: root.hasUnseenNotifications
             onClicked: root.notificationButtonClicked()

--- a/ui/StatusQ/src/StatusQ/Controls/StatusLinkText.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusLinkText.qml
@@ -1,23 +1,21 @@
 import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
 
-import QtQuick 2.0
-import QtQuick.Layouts 1.0
+import QtQuick 2.14
 
-import StatusQ.Core 0.1
 /*!
    \qmltype StatusLinkText
    \inherits StatusBaseText
    \inqmlmodule StatusQ.Controls
    \since StatusQ.Controls 0.1
-   \brief Displays text abailable for mouse interaction and styled as link.
+   \brief Displays text available for mouse interaction and styled as link.
 
    Example of how to use it:
 
    \qml
         StatusLinkText {
             text: qsTr("Click me")
-            onClicked: console,log("link clicked")
+            onClicked: console.log("link clicked")
         }
    \endqml
 
@@ -31,7 +29,7 @@ StatusBaseText {
        \qmlproperty StatusLinkText StatusLinkText::linkColor
        This property holds text color while it's hovered by mouse cursor
     */
-    property color linkColor: Theme.palette.primaryColor1
+    linkColor: Theme.palette.primaryColor1
 
     /*!
        \qmlproperty StatusLinkText StatusLinkText::normalColor
@@ -41,7 +39,7 @@ StatusBaseText {
 
     /*!
        \qmlproperty StatusLinkText StatusLinkText::containsMouse
-       This property true whenever text is hoverd by mouse cursor
+       This property true whenever text is hovered by mouse cursor
     */
     readonly property alias containsMouse: textMouseArea.containsMouse
 

--- a/ui/StatusQ/src/StatusQ/Controls/StatusToolTip.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusToolTip.qml
@@ -67,6 +67,7 @@ ToolTip {
     contentItem: StatusBaseText {
         text: statusToolTip.text
         color: Theme.palette.white
+        linkColor: Theme.palette.white
         wrapMode: Text.WordWrap
         font.pixelSize: 13
         font.weight: Font.Medium

--- a/ui/app/AppLayouts/Chat/views/ChatHeaderContentView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatHeaderContentView.qml
@@ -51,16 +51,9 @@ Item {
         anchors.top: parent.top
         anchors.bottom: parent.bottom
         anchors.left: parent.left
-        anchors.right: d.selectingMembers ? parent.right : undefined
+        anchors.right: d.selectingMembers ? parent.right : actionButtons.left
 
         sourceComponent: d.selectingMembers ? membersSelector : statusChatInfoButton
-    }
-
-    Rectangle {
-        anchors.fill: actionButtons
-        visible: actionButtons.visible
-        opacity: 0.8
-        color: Style.current.background
     }
 
     RowLayout {


### PR DESCRIPTION
### What does the PR do

The chat title/subtitle no longer bleeds into the action buttons

- handle long texts in chat description, elide them and show the whole
text in a tooltip
- minor UI fixes in ChatHeaderContentView and StatusToolBar
- adjust Sandbox' Controls page

Fixes #9583
Fixes #9056

### Affected areas

StatusChatInfoButton, StatusToolBar, ChatHeaderContentView

### StatusQ checklist

- [x] add documentation if necessary (new component, new feature)
- [x] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

[Záznam obrazovky z 2023-02-21 12-22-13.webm](https://user-images.githubusercontent.com/5377645/220332034-9080541e-daf8-4cb0-9506-6b7fd2d482e5.webm)

![Snímek obrazovky z 2023-02-21 11-09-32](https://user-images.githubusercontent.com/5377645/220328149-5568b050-7f9e-47ab-a608-6120e83ea773.png)

