### PR TITLE
feat: relative or absolute timestamping depending on time/date proximity

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusTimeStampLabel.qml
+++ b/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusTimeStampLabel.qml
@@ -12,7 +12,7 @@ StatusBaseText {
     color: Theme.palette.baseColor1
     font.pixelSize: 10
     visible: !!text
-    text: showFullTimestamp ? LocaleUtils.formatDateTime(timestamp) : LocaleUtils.formatTime(timestamp, Locale.ShortFormat)
+    text: showFullTimestamp ? LocaleUtils.formatDateTime(timestamp) : LocaleUtils.formatRelativeTimestamp(timestamp)
     StatusToolTip {
         id: tooltip
         visible: hhandler.hovered && !!text


### PR DESCRIPTION
- implement LocaleUtils.formatRelativeTimestamp() that does all the heavy lifting
- use it in StatusTimeStampLabel -> propagates to all message timestamps (chat, activity center, settings, etc)

Closes #9397

### What does the PR do

Implements relative timestamps based on proximity

### Affected areas

StatusTimeStampLabel

### StatusQ checklist

- [x] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

Today == Tuesday, 21st February

Today/Yesterday:
![image](https://user-images.githubusercontent.com/5377645/220415071-371ba469-9466-40de-91d9-8a3bd147b7eb.png)

Earlier this week (<7 days); last Wednesday -> relative, day before that -> absolute:
![image](https://user-images.githubusercontent.com/5377645/220415403-59ad3f04-7535-40c9-b022-aa57c73b9275.png)

Year turnover (current one displayed w/o year number):
![image](https://user-images.githubusercontent.com/5377645/220416676-1c03fd2f-8b53-4311-a870-4b8bf98e012c.png)

