### PR TITLE
[Community permissions]: Align UI to work with real backend, remove warnings

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/StatusItemSelector.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusItemSelector.qml
@@ -210,7 +210,7 @@ Rectangle {
 
                         asset.height: root.asset.height
                         asset.width: root.asset.width
-                        asset.name: root.useLetterIdenticons ? model.text : model.imageSource
+                        asset.name: root.useLetterIdenticons ? model.text : (model.imageSource ?? "")
                         asset.isImage: root.asset.isImage
                         asset.bgColor: root.asset.bgColor
                         asset.emoji: model.emoji ? model.emoji : ""

--- a/ui/StatusQ/src/StatusQ/Core/Utils/ModelChangeTracker.qml
+++ b/ui/StatusQ/src/StatusQ/Core/Utils/ModelChangeTracker.qml
@@ -1,7 +1,7 @@
 import QtQml 2.14
 
 QtObject {
-    property alias model: d.target
+    property var model
 
     readonly property alias revision: d.revision
 
@@ -11,6 +11,8 @@ QtObject {
 
     readonly property Connections _d: Connections {
         id: d
+
+        target: model ?? null
 
         property int revision: 0
 

--- a/ui/StatusQ/src/StatusQ/Core/Utils/ModelUtils.qml
+++ b/ui/StatusQ/src/StatusQ/Core/Utils/ModelUtils.qml
@@ -54,8 +54,8 @@ QtObject {
         if (modelA === modelB)
             return true
 
-        const countA = modelA === null ? 0 : modelA.rowCount()
-        const countB = modelB === null ? 0 : modelB.rowCount()
+        const countA = !!modelA ? modelA.rowCount() : 0
+        const countB = !!modelB ? modelB.rowCount() : 0
 
         if (countA !== countB)
             return false
@@ -78,8 +78,8 @@ QtObject {
         if (modelA === modelB)
             return true
 
-        const countA = modelA === null ? 0 : modelA.rowCount()
-        const countB = modelB === null ? 0 : modelB.rowCount()
+        const countA = !!modelA ? modelA.rowCount() : 0
+        const countB = !!modelB ? modelB.rowCount() : 0
 
         if (countA !== countB)
             return false

--- a/ui/app/AppLayouts/Chat/controls/community/ListDropdownContent.qml
+++ b/ui/app/AppLayouts/Chat/controls/community/ListDropdownContent.qml
@@ -81,16 +81,13 @@ StatusListView {
         width: ListView.view.width
         key: model.key
         name: model.name
-        shortName: !!model.shortName ? model.shortName : ""
-        iconSource: model.iconSource
+        shortName: model.shortName ?? ""
+        iconSource: model.iconSource ?? ""
         subItems: model.subItems
         selected: root.checkedKeys.includes(model.key)
 
-        onItemClicked: root.itemClicked(model.key,
-                                        model.name,
-                                        model.shortName,
-                                        model.iconSource,
-                                        model.subItems)
+        onItemClicked: root.itemClicked(
+                           key, name, shortName, iconSource, subItems)
     }
 
     section.property: root.searchMode ? "" : "categoryLabel"

--- a/ui/app/AppLayouts/Chat/helpers/CommunityPermissionsHelpers.qml
+++ b/ui/app/AppLayouts/Chat/helpers/CommunityPermissionsHelpers.qml
@@ -41,14 +41,14 @@ QtObject {
     function getTokenShortNameByKey(model, key) {
         const item = getTokenByKey(model, key)
         if (item)
-            return item.shortName
+            return item.shortName ?? ""
         return ""
     }
 
     function getTokenIconByKey(model, key) {
         const item = getTokenByKey(model, key)
         if (item)
-            return item.iconSource
+            return item.iconSource ?? ""
         return ""
     }
 

--- a/ui/app/AppLayouts/Chat/views/communities/CommunityNewPermissionView.qml
+++ b/ui/app/AppLayouts/Chat/views/communities/CommunityNewPermissionView.qml
@@ -61,7 +61,7 @@ StatusScrollView {
         modelA: root.dirtyValues.holdingsModel
         modelB: root.holdingsModel
 
-        roles: ["key", "name", "shortName", "amount"]
+        roles: ["key", "amount"]
         mode: ModelsComparator.CompareMode.Set
     }
 
@@ -130,7 +130,6 @@ StatusScrollView {
         function loadInitValues() {
             // Holdings:
             d.dirtyValues.holdingsModel.clear()
-
             d.dirtyValues.holdingsModel.append(
                         ModelUtils.modelToArray(root.holdingsModel, ["type", "key", "amount"]))
 

--- a/ui/app/AppLayouts/Chat/views/communities/CommunityPermissionsView.qml
+++ b/ui/app/AppLayouts/Chat/views/communities/CommunityPermissionsView.qml
@@ -69,7 +69,6 @@ StatusScrollView {
 
                     sourceModel: model.channelsListModel
 
-
                     proxyRoles: [
                         ExpressionRole {
                             name: "imageSource"


### PR DESCRIPTION
### What does the PR do

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

- Fix `ModelChangeTracker` and `ModelUtils` to handle properly - assigning `undefined` caused many warning from Connection component
- Use only key/amount to compare holdings when tracking duplicates - only those values are significant and identify given holding
- clean warnings by preventing assigning when some roles doesn't exist - backend may skip some roles, especially in early phases of development, ui should handle such cases seamlessly

Closes: #9608

### Affected areas
CommunityPermission's components, StatusQ utils - `ModelChangeTracker`, `ModelUtils`

### Screenshot of functionality (including design for comparison)

[Kazam_screencast_00120.webm](https://user-images.githubusercontent.com/20650004/220450923-520cf163-35ab-4cfa-b03f-7b93032b784a.webm)

