### PR TITLE
fix(CommunityPermissions): Adjust store API to not take models as parameters, move conversion to the caller

### DIFF
--- a/ui/app/AppLayouts/Chat/panels/communities/CommunityPermissionsSettingsPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/CommunityPermissionsSettingsPanel.qml
@@ -196,10 +196,18 @@ SettingsPageLayout {
             }
 
             onCreatePermissionClicked: {
-                root.store.createPermission(dirtyValues.holdingsModel,
+                const holdings = ModelUtils.modelToArray(
+                                   dirtyValues.holdingsModel,
+                                   ["key", "type", "amount"])
+
+                const channels = ModelUtils.modelToArray(
+                                   dirtyValues.channelsModel,
+                                   ["itemId", "text", "emoji", "color"])
+
+                root.store.createPermission(holdings,
                                             dirtyValues.permissionType,
                                             dirtyValues.isPrivate,
-                                            dirtyValues.channelsModel)
+                                            channels)
 
                 root.state = d.permissionsViewState
             }
@@ -208,11 +216,19 @@ SettingsPageLayout {
                 target: d
 
                 function onSaveChanges() {
+                    const holdings = ModelUtils.modelToArray(
+                                       dirtyValues.holdingsModel,
+                                       ["key", "type", "amount"])
+
+                    const channels = ModelUtils.modelToArray(
+                                       dirtyValues.channelsModel,
+                                       ["itemId", "text", "emoji", "color"])
+
                     root.store.editPermission(
                                 d.permissionKeyToEdit,
-                                dirtyValues.holdingsModel,
+                                holdings,
                                 dirtyValues.permissionType,
-                                dirtyValues.channelsModel,
+                                channels,
                                 dirtyValues.isPrivate)
                 }
 

--- a/ui/app/AppLayouts/Chat/stores/CommunitiesStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/CommunitiesStore.qml
@@ -140,33 +140,10 @@ QtObject {
 
         function createPermissionEntry(holdings, permissionType, isPrivate, channels) {
             const permission = {
-                holdingsListModel: [],
-                channelsListModel: [],
+                holdingsListModel: holdings,
+                channelsListModel: channels,
                 permissionType,
                 isPrivate
-            }
-
-            // Setting HOLDINGS:
-            for (let i = 0; i < holdings.count; i++ ) {
-                const entry = holdings.get(i)
-
-                permission.holdingsListModel.push({
-                    type: entry.type,
-                    key: entry.key,
-                    amount: entry.amount
-                })
-            }
-
-            // Setting CHANNELS:
-            for (let c = 0; c < channels.count; c++) {
-                const entry = channels.get(c)
-
-                permission.channelsListModel.push({
-                    itemId: entry.itemId,
-                    text: entry.text,
-                    emoji: entry.emoji,
-                    color: entry.color
-                })
             }
 
             return permission


### PR DESCRIPTION



### What does the PR do

So far `CommunitiesStore`'s methods like `createPermission` were assuming that e.g. holdings are provided as a model. For generality it's changed to take just plain JS array instead. Side-effect benefit is the fact that real impl and mock won't have to repeat the same conversion.

Closes: #9611

### Affected areas
`CommunityPermissionsSettingsPanel`, `CommunitiesStore`
<!-- List the affected areas (e.g wallet, browser, etc..) -->
