### PR TITLE
chore(CommunityPermissions): Dissect real and mocked CommunitiesStore, adapt Storybook's pages

### DIFF
--- a/storybook/pages/CommunityPermissionsViewPage.qml
+++ b/storybook/pages/CommunityPermissionsViewPage.qml
@@ -31,7 +31,8 @@ SplitView {
                 store: CommunitiesStore {
                     id: mockedCommunity
 
-                    permissionsModel: PermissionsModel.permissionsModel
+                    readonly property var permissionsModel:
+                        PermissionsModel.permissionsModel
 
                     readonly property var assetsModel: AssetsModel {
                         id: assetsModel

--- a/storybook/pages/CommunityTokenPermissionsPopupPage.qml
+++ b/storybook/pages/CommunityTokenPermissionsPopupPage.qml
@@ -35,6 +35,9 @@ SplitView {
                 viewOnlyHoldingsModel: editor.viewOnlyHoldingsModel
                 viewAndPostHoldingsModel: editor.viewAndPostHoldingsModel
                 moderateHoldingsModel: editor.moderateHoldingsModel
+
+                assetsModel: AssetsModel {}
+                collectiblesModel: CollectiblesModel {}
             }
         }
     }

--- a/storybook/pages/HoldingsDropdownPage.qml
+++ b/storybook/pages/HoldingsDropdownPage.qml
@@ -39,10 +39,8 @@ Pane {
         parent: root
         anchors.centerIn: root
 
-        store: QtObject {
-            readonly property var collectiblesModel: CollectiblesModel {}
-            readonly property var assetsModel: AssetsModel {}
-        }
+        collectiblesModel: CollectiblesModel {}
+        assetsModel: AssetsModel {}
 
         onOpened: contentItem.parent.parent = root
         Component.onCompleted: {

--- a/storybook/stubs/AppLayouts/Chat/stores/CommunitiesStore.qml
+++ b/storybook/stubs/AppLayouts/Chat/stores/CommunitiesStore.qml
@@ -1,0 +1,3 @@
+import QtQuick 2.15
+
+QtObject {}

--- a/storybook/stubs/AppLayouts/Chat/stores/RootStore.qml
+++ b/storybook/stubs/AppLayouts/Chat/stores/RootStore.qml
@@ -1,0 +1,3 @@
+import QtQuick 2.15
+
+QtObject {}

--- a/storybook/stubs/AppLayouts/Chat/stores/StickersStore.qml
+++ b/storybook/stubs/AppLayouts/Chat/stores/StickersStore.qml
@@ -1,0 +1,3 @@
+import QtQuick 2.15
+
+QtObject {}

--- a/storybook/stubs/AppLayouts/Chat/stores/qmldir
+++ b/storybook/stubs/AppLayouts/Chat/stores/qmldir
@@ -1,0 +1,3 @@
+CommunitiesStore 1.0 CommunitiesStore.qml
+RootStore 1.0 RootStore.qml
+StickersStore 1.0 StickersStore.qml

--- a/ui/app/AppLayouts/Chat/ChatLayout.qml
+++ b/ui/app/AppLayouts/Chat/ChatLayout.qml
@@ -56,6 +56,8 @@ StackLayout {
 
         sourceComponent: CommunitySettingsView {
             rootStore: root.rootStore
+            communityStore: CommunitiesStore {}
+
             hasAddedContacts: root.contactsStore.myContactsModel.count > 0
             chatCommunitySectionModule: root.rootStore.chatCommunitySectionModule
             community: root.rootStore.mainModuleInst ? root.rootStore.mainModuleInst.activeSection

--- a/ui/app/AppLayouts/Chat/controls/community/ExtendedDropdownContent.qml
+++ b/ui/app/AppLayouts/Chat/controls/community/ExtendedDropdownContent.qml
@@ -18,7 +18,9 @@ import SortFilterProxyModel 0.2
 Item {
     id: root
 
-    property var store
+    property var assetsModel
+    property var collectiblesModel
+
     property var checkedKeys: []
     property int type: ExtendedDropdownContent.Type.Assets
 
@@ -139,7 +141,7 @@ Item {
             PropertyChanges {
                 target: d
                 currentModel: root.type === ExtendedDropdownContent.Type.Assets
-                              ? root.store.assetsModel : root.store.collectiblesModel
+                              ? root.assetsModel : root.collectiblesModel
                 isFilterOptionVisible: false
             }
 

--- a/ui/app/AppLayouts/Chat/controls/community/HoldingsDropdown.qml
+++ b/ui/app/AppLayouts/Chat/controls/community/HoldingsDropdown.qml
@@ -12,7 +12,9 @@ import AppLayouts.Chat.helpers 1.0
 StatusDropdown {
     id: root
 
-    property var store
+    property var assetsModel
+    property var collectiblesModel
+
     property var usedTokens: []
     property var usedEnsNames: []
 
@@ -248,7 +250,9 @@ StatusDropdown {
         ExtendedDropdownContent {
             id: listPanel
 
-            store: root.store
+            assetsModel: root.assetsModel
+            collectiblesModel: root.collectiblesModel
+
             checkedKeys: root.usedTokens.map(entry => entry.key)
             type: d.extendedDropdownType
 
@@ -287,8 +291,8 @@ StatusDropdown {
             Component.onCompleted: {
                 if(d.extendedDeepNavigation)
                     listPanel.goForward(d.currentItemKey,
-                                        CommunityPermissionsHelpers.getTokenNameByKey(store.collectiblesModel, d.currentItemKey),
-                                        CommunityPermissionsHelpers.getTokenIconByKey(store.collectiblesModel, d.currentItemKey),
+                                        CommunityPermissionsHelpers.getTokenNameByKey(root.collectiblesModel, d.currentItemKey),
+                                        CommunityPermissionsHelpers.getTokenIconByKey(root.collectiblesModel, d.currentItemKey),
                                         d.currentSubItems)
             }
 
@@ -318,9 +322,9 @@ StatusDropdown {
 
             readonly property real effectiveAmount: amountValid ? amount : 0
 
-            tokenName: CommunityPermissionsHelpers.getTokenNameByKey(store.assetsModel, root.assetKey)
-            tokenShortName: CommunityPermissionsHelpers.getTokenShortNameByKey(store.assetsModel, root.assetKey)
-            tokenImage: CommunityPermissionsHelpers.getTokenIconByKey(store.assetsModel, root.assetKey)
+            tokenName: CommunityPermissionsHelpers.getTokenNameByKey(root.assetsModel, root.assetKey)
+            tokenShortName: CommunityPermissionsHelpers.getTokenShortNameByKey(root.assetsModel, root.assetKey)
+            tokenImage: CommunityPermissionsHelpers.getTokenIconByKey(root.assetsModel, root.assetKey)
             amountText: d.assetAmountText
             tokenCategoryText: qsTr("Asset")
             addOrUpdateButtonEnabled: d.assetsReady
@@ -353,9 +357,9 @@ StatusDropdown {
 
             readonly property real effectiveAmount: amountValid ? amount : 0
 
-            tokenName: CommunityPermissionsHelpers.getTokenNameByKey(store.collectiblesModel, root.collectibleKey)
+            tokenName: CommunityPermissionsHelpers.getTokenNameByKey(root.collectiblesModel, root.collectibleKey)
             tokenShortName: ""
-            tokenImage: CommunityPermissionsHelpers.getTokenIconByKey(store.collectiblesModel, root.collectibleKey)
+            tokenImage: CommunityPermissionsHelpers.getTokenIconByKey(root.collectiblesModel, root.collectibleKey)
             amountText: d.collectibleAmountText
             tokenCategoryText: qsTr("Collectible")
             addOrUpdateButtonEnabled: d.collectiblesReady

--- a/ui/app/AppLayouts/Chat/panels/communities/CommunityPermissionsSettingsPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/CommunityPermissionsSettingsPanel.qml
@@ -12,7 +12,7 @@ SettingsPageLayout {
     id: root
 
     property var rootStore
-    property var store: CommunitiesStore {}
+    required property CommunitiesStore store
     property int viewWidth: 560 // by design
 
     function navigateBack() {

--- a/ui/app/AppLayouts/Chat/popups/community/CommunityTokenPermissionsPopup.qml
+++ b/ui/app/AppLayouts/Chat/popups/community/CommunityTokenPermissionsPopup.qml
@@ -14,6 +14,9 @@ StatusDialog {
     property alias viewAndPostHoldingsModel: overlayPanel.viewAndPostHoldingsModel
     property alias moderateHoldingsModel: overlayPanel.moderateHoldingsModel
 
+    property alias assetsModel: overlayPanel.assetsModel
+    property alias collectiblesModel: overlayPanel.collectiblesModel
+
     QtObject {
         id: d
 

--- a/ui/app/AppLayouts/Chat/views/CommunitySettingsView.qml
+++ b/ui/app/AppLayouts/Chat/views/CommunitySettingsView.qml
@@ -44,7 +44,7 @@ StatusSectionLayout {
     property var rootStore
     property var community
     property var chatCommunitySectionModule
-    property var communityStore: CommunitiesStore {}
+    required property CommunitiesStore communityStore
     property bool hasAddedContacts: false
     property var transactionStore: TransactionStore {}
 
@@ -248,6 +248,8 @@ StatusSectionLayout {
 
             CommunityPermissionsSettingsPanel {
                 rootStore: root.rootStore
+                store: root.communityStore
+
                 onPreviousPageNameChanged: root.backButtonName = previousPageName
             }
 

--- a/ui/app/AppLayouts/Chat/views/communities/CommunityNewPermissionView.qml
+++ b/ui/app/AppLayouts/Chat/views/communities/CommunityNewPermissionView.qml
@@ -13,6 +13,7 @@ import shared.panels 1.0
 
 import AppLayouts.Chat.helpers 1.0
 import AppLayouts.Chat.panels.communities 1.0
+import AppLayouts.Chat.stores 1.0
 
 import "../../../Chat/controls/community"
 
@@ -20,7 +21,7 @@ StatusScrollView {
     id: root
 
     property var rootStore
-    property var store
+    required property CommunitiesStore store
 
     property int viewWidth: 560 // by design
     property bool isEditState: false
@@ -196,7 +197,8 @@ StatusScrollView {
             HoldingsDropdown {
                 id: dropdown
 
-                store: root.store
+                assetsModel: store.assetsModel
+                collectiblesModel: store.collectiblesModel
 
                 function addItem(type, item, amount) {
                     const key = item.key

--- a/ui/app/AppLayouts/Chat/views/communities/CommunityPermissionsView.qml
+++ b/ui/app/AppLayouts/Chat/views/communities/CommunityPermissionsView.qml
@@ -10,12 +10,14 @@ import shared.popups 1.0
 
 import AppLayouts.Chat.controls.community 1.0
 import AppLayouts.Chat.helpers 1.0
+import AppLayouts.Chat.stores 1.0
 
 StatusScrollView {
     id: root
 
     property var rootStore
-    property var store
+    required property CommunitiesStore store
+
     property int viewWidth: 560 // by design
 
     signal editPermissionRequested(int index)

--- a/ui/imports/shared/stores/CurrenciesStore.qml
+++ b/ui/imports/shared/stores/CurrenciesStore.qml
@@ -3,7 +3,7 @@ import QtQuick 2.15
 import StatusQ.Core 0.1
 
 import utils 1.0
-import "../../../app/AppLayouts/Profile/stores"
+import AppLayouts.Profile.stores 1.0
 
 QtObject {
     id: root


### PR DESCRIPTION
### What does the PR do

So far single implementation of `CommunitiesStore`, serving mocked data was used in both the app and storybook. In order to integrate the backend, the mock version is separated and moved to storybook. The app still serves mocks but replacing by integrating with backend won't affect storybook's pages.

Moreover:
- usages of `CommunitiesStore` are refactored to be strongly typed
- `CommunityTokenPermissionsPopup` and corresponding storybook's page fixed (displaying tokens)

Closes: #9612

### Affected areas
Community Permission components
