### PR TITLE
fix(StatusChatInput): fixed invisible text when pasting text with emoji

### DIFF
--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -131,7 +131,7 @@ Rectangle {
 
         property int leftOfMentionIndex: -1
         property int rightOfMentionIndex: -1
-
+        readonly property int nbEmojisInClipboard: StatusQUtils.Emoji.nbEmojis(QClipboardProxy.html)
         readonly property StateGroup emojiPopupTakeover: StateGroup {
             states: State {
                 when: control.emojiPopupOpened
@@ -474,13 +474,14 @@ Rectangle {
                             }
                         }
                     }
-
                     insertInTextInput(d.copyTextStart, d.copiedTextFormatted)
                 } else {
                     d.copiedTextPlain = ""
                     d.copiedTextFormatted = ""
                     d.copiedMentionsPos = []
-                    messageInputField.insert(d.copyTextStart, "<div style='white-space: pre-wrap'>" + Utils.escapeHtml(QClipboardProxy.text) + "</div>") // preserve formatting
+                    messageInputField.insert(d.copyTextStart, ((d.nbEmojisInClipboard === 0) ?
+                    ("<div style='white-space: pre-wrap'>" + Utils.escapeHtml(QClipboardProxy.text) + "</div>")
+                    : StatusQUtils.Emoji.deparse(QClipboardProxy.html)));
                 }
             }
         }
@@ -715,7 +716,7 @@ Rectangle {
 
         if (messageInputField.readOnly) {
             messageInputField.readOnly = false;
-            messageInputField.cursorPosition = d.copyTextStart + QClipboardProxy.text.length;
+            messageInputField.cursorPosition = (d.copyTextStart + QClipboardProxy.text.length + d.nbEmojisInClipboard);
         }
     }
 


### PR DESCRIPTION
Closes #3291

### What does the PR do
StatusChatInput): fixed invisible text when pasting text with emoji

### Affected areas
StatusChatInput

### Screenshot of functionality (including design for comparison)
https://user-images.githubusercontent.com/31625338/220933363-4e8129a3-37a1-4e88-97c9-ad8a56b1e87a.mov

