### PR TITLE
feat(wallet) propagate multi-transaction ID to Nim

### DIFF
--- a/src/app/modules/main/wallet_section/transactions/controller.nim
+++ b/src/app/modules/main/wallet_section/transactions/controller.nim
@@ -62,7 +62,7 @@ proc init*(self: Controller) =
     let accounts = self.getWalletAccounts()
     let addresses = accounts.map(account => account.address)
     self.delegate.setHistoryFetchState(addresses, isFetching = false)
-    
+
   self.events.on(SIGNAL_TRANSACTIONS_LOADED) do(e:Args):
     let args = TransactionsLoadedArgs(e)
     self.delegate.setHistoryFetchState(@[args.address], isFetching = false)

--- a/src/app_service/service/transaction/dto.nim
+++ b/src/app_service/service/transaction/dto.nim
@@ -51,7 +51,7 @@ type
     value*: string
     fromAddress*: string
     to*: string
-    chainId*: int    
+    chainId*: int
     maxFeePerGas*: string
     maxPriorityFeePerGas*: string
     input*: string

--- a/src/app_service/service/transaction/service.nim
+++ b/src/app_service/service/transaction/service.nim
@@ -88,7 +88,6 @@ type
 type
   CryptoServicesArgs* = ref object of Args
     data*: seq[CryptoRampDto]
-  
 
 QtObject:
   type Service* = ref object of QObject
@@ -109,7 +108,7 @@ QtObject:
   proc newService*(
       events: EventEmitter,
       threadpool: ThreadPool,
-      networkService: network_service.Service,  
+      networkService: network_service.Service,
       settingsService: settings_service.Service,
       tokenService: token_service.Service,
   ): Service =
@@ -162,7 +161,7 @@ QtObject:
       let address = watchTxResult["address"].getStr
       let transactionReceipt = transactions.getTransactionReceipt(chainId, hash).result
       if transactionReceipt != nil and transactionReceipt.kind != JNull:
-        discard transactions.deletePendingTransaction(chainId, hash)
+        # Pending transaction will be deleted by backend after transfering multi-transaction info to history
         echo watchTxResult["data"].getStr
         let ev = TransactionMinedArgs(
           data: watchTxResult["data"].getStr,

--- a/ui/app/AppLayouts/Wallet/views/LeftTabView.qml
+++ b/ui/app/AppLayouts/Wallet/views/LeftTabView.qml
@@ -148,7 +148,7 @@ Rectangle {
                 width: ListView.view.width - Style.current.padding * 2
                 highlighted: !ListView.view.footerItem.button.highlighted &&
                              RootStore.currentAccount.name === model.name
-                anchors.horizontalCenter: parent.horizontalCenter
+                anchors.horizontalCenter: !!parent ? parent.horizontalCenter : undefined
                 title: model.name
                 subTitle: LocaleUtils.currencyAmountToLocaleString(model.currencyBalance)
                 asset.emoji: !!model.emoji ? model.emoji: ""

--- a/ui/imports/shared/popups/SendModal.qml
+++ b/ui/imports/shared/popups/SendModal.qml
@@ -341,7 +341,7 @@ StatusDialog {
                 Layout.fillHeight: true
 
                 contentHeight: layout.height + Style.current.padding
-                contentWidth: parent.width
+
                 z: 0
                 objectName: "sendModalScroll"
 


### PR DESCRIPTION
Bump status-go to include the propagation of transaction ID for status-go APIs
Remove deletion of pending from Nim, it is done in status-go on first transaction status change

Also

- Add leftover fixes from SendModal layout :(

Updates: #7663