### PR TITLE
fix(Chats): Drag/drop image files is only available for community channels

### DIFF
--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -5,6 +5,7 @@ import QtMultimedia 5.13
 import Qt.labs.qmlmodels 1.0
 import Qt.labs.platform 1.1
 import QtQml.Models 2.14
+import QtQml 2.15
 
 import AppLayouts.Wallet 1.0
 import AppLayouts.Node 1.0
@@ -761,8 +762,15 @@ Item {
                             ChatLayout {
                                 id: chatLayoutContainer
 
-                                rootStore: appMain.rootChatStore
+                                Binding {
+                                    target: rootDropAreaPanel
+                                    property: "enabled"
+                                    value: chatLayoutContainer.currentIndex === 0 // Meaning: Chats / channels view
+                                    when: visible
+                                    restoreMode: Binding.RestoreBindingOrValue
+                                }
 
+                                rootStore: appMain.rootChatStore
                                 chatView.emojiPopup: statusEmojiPopup
                                 chatView.stickersPopup: statusStickersPopupLoader.item
 
@@ -858,6 +866,16 @@ Item {
                                     Layout.fillHeight: true
 
                                     sourceComponent: ChatLayout {
+                                        id: chatLayoutComponent
+
+                                        Binding {
+                                            target: rootDropAreaPanel
+                                            property: "enabled"
+                                            value: chatLayoutComponent.currentIndex === 0 // Meaning: Chats / channels view
+                                            when: visible
+                                            restoreMode: Binding.RestoreBindingOrValue
+                                        }
+
                                         chatView.emojiPopup: statusEmojiPopup
                                         chatView.stickersPopup: statusStickersPopupLoader.item
 
@@ -1172,32 +1190,10 @@ Item {
         }
     }
 
-    Connections {
-        target: appMain.rootStore.mainModuleInst
-        function onActiveSectionChanged() {
-            let communitySectionModule = appMain.rootStore.mainModuleInst.getCommunitySectionModule()
-            if (communitySectionModule)
-                rootDropAreaPanel.activeChatType = communitySectionModule.activeItem.type
-        }
-    }
-
     DropAreaPanel {
         id: rootDropAreaPanel
+
         width: appMain.width
         height: appMain.height
-        activeChatType: appMain.rootStore.mainModuleInst.getCommunitySectionModule() ? appMain.rootStore.mainModuleInst.getCommunitySectionModule().activeItem.type
-                                                                                     : 0
-        enabled: !drag.source && (
-                                // in chat view
-                                (appMain.rootStore.mainModuleInst.activeSection.sectionType === Constants.appSection.chat &&
-                                (
-                                    // in a one-to-one chat
-                                    activeChatType === Constants.chatType.oneToOne ||
-                                    // in a private group chat
-                                    activeChatType === Constants.chatType.privateGroupChat
-                                    )
-                                ) ||
-                                // In community section
-                                appMain.rootStore.mainModuleInst.activeSection.sectionType === Constants.appSection.community)
     }
 }

--- a/ui/app/mainui/panels/DropAreaPanel.qml
+++ b/ui/app/mainui/panels/DropAreaPanel.qml
@@ -6,7 +6,6 @@ DropArea {
 
     property bool enabled: false
     property alias droppedUrls: rptDraggedPreviews.model
-    property int activeChatType
 
     signal droppedOnValidScreen(var drop)
 


### PR DESCRIPTION
Fixes #9630

### What does the PR do

- Drag/drop images are available from all chat types (1:1 , group chats and community channels).
- In case of community settings views, it is disabled.

### Affected areas

Chats / Channels
Community Settings Views

### Screenshot of functionality

https://user-images.githubusercontent.com/97019400/221190842-53f12741-098c-43dc-83bc-b7bbec6a9f3b.mov


