### PR TITLE
fix(QAbstractItemsModel): Fixing nim memory leaks

### DIFF
--- a/src/app/boot/app_controller.nim
+++ b/src/app/boot/app_controller.nim
@@ -281,6 +281,7 @@ proc delete*(self: AppController) =
   self.gifService.delete
   if not self.startupModule.isNil:
     self.startupModule.delete
+    self.startupModule = nil
   self.mainModule.delete
   self.languageService.delete
 
@@ -460,6 +461,7 @@ proc finishAppLoading*(self: AppController) =
 
   if not self.startupModule.isNil:
     self.startupModule.delete
+    self.startupModule = nil
 
 proc logout*(self: AppController) =
   self.generalService.logout()

--- a/src/app/modules/startup/module.nim
+++ b/src/app/modules/startup/module.nim
@@ -65,11 +65,16 @@ proc newModule*[T](delegate: T,
   profileService, keycardService)
 
 method delete*[T](self: Module[T]) =
+  singletonInstance.engine.setRootContextProperty("startupModule", newQVariant())
   self.view.delete
+  self.view = nil
   self.viewVariant.delete
+  self.viewVariant = nil
   self.controller.delete
+  self.controller = nil
   if not self.keycardSharedModule.isNil:
     self.keycardSharedModule.delete
+    self.keycardSharedModule = nil
 
 proc extractImages(self: Module, account: AccountDto, thumbnailImage: var string,
   largeImage: var string) =
@@ -394,10 +399,10 @@ method onNodeLogin*[T](self: Module[T], error: string) =
       if err.len > 0:
         self.logoutAndDisplayError(err, StartupErrorType.UnknownType)
         return
-      self.delegate.finishAppLoading()
       if currStateObj.flowType() != FlowType.AppLogin:
         discard self.controller.storeIdentityImage()
       self.controller.cleanTmpData()
+      self.delegate.finishAppLoading()
   else:
     self.moveToStartupState()
     if currStateObj.flowType() == FlowType.AppLogin:


### PR DESCRIPTION
### What does the PR do

1. Bump nimqml version to include fixes for qmodelindex, char* and qabstractlistmodel memory leaks
2. Fixing app crash after qabstractlistmodel leak is fixed in nimqml. The `startupModule` is exposed in qml and we need to reset the `rootContextProperty` after delete. Also, the `self.delegate.finishAppLoading` called from `startup/module.nim` is triggering the module delete on the same call stack. This is dangerous and this PR is fixing the symptoms by moving `self.delegate.finishAppLoading()` at the end of the method.

Part of #9558