### PR TITLE
fix(UnfurlingUrls): Fix community invitation when community cannot be fetched (or in progress)

### DIFF
--- a/ui/imports/shared/views/chat/InvitationBubbleView.qml
+++ b/ui/imports/shared/views/chat/InvitationBubbleView.qml
@@ -28,6 +28,15 @@ Control {
         id: d
 
         property var invitedCommunity
+    
+        readonly property string communityName:         !!d.invitedCommunity ? d.invitedCommunity.name : ""
+        readonly property string communityDescription:  !!d.invitedCommunity ? d.invitedCommunity.description : ""
+        readonly property string communityImage:        !!d.invitedCommunity ? d.invitedCommunity.image : ""
+        readonly property string communityColor:        !!d.invitedCommunity ? d.invitedCommunity.color : ""
+        readonly property int    communityNbMembers:    !!d.invitedCommunity ? d.invitedCommunity.nbMembers : 0
+        readonly property bool   communityVerified:     false //!!d.invitedCommunity ? d.invitedCommunity.verified : false TODO: add this to the community object if we should support verified communities
+        readonly property bool   communityJoined:       !!d.invitedCommunity ? d.invitedCommunity.joined : false
+        readonly property bool   communitySpectated:    !!d.invitedCommunity ? d.invitedCommunity.spectated : false
 
         readonly property int margin: 12
         readonly property int radius: 16
@@ -91,8 +100,8 @@ Control {
             Layout.topMargin: 8
             Layout.bottomMargin: 8
 
-            text: d.invitedCommunity.verifed ? qsTr("Verified community invitation") : qsTr("Community invitation")
-            color: d.invitedCommunity.verifed ? Theme.palette.primaryColor1 : Theme.palette.baseColor1
+            text: d.communityVerified ? qsTr("Verified community invitation") : qsTr("Community invitation")
+            color: d.communityVerified ? Theme.palette.primaryColor1 : Theme.palette.baseColor1
             font.weight: Font.Medium
             font.pixelSize: 13
         }
@@ -118,13 +127,13 @@ Control {
                 Layout.preferredWidth: 40
                 Layout.preferredHeight: 40
 
-                name: d.invitedCommunity.name
+                name: d.communityName
 
                 asset {
                     width: 40
                     height: 40
-                    name: d.invitedCommunity.image
-                    color: d.invitedCommunity.color
+                    name: d.communityImage
+                    color: d.communityColor
                     isImage: true
                 }
             }
@@ -135,7 +144,7 @@ Control {
                 StatusBaseText {
                     Layout.fillWidth: true
 
-                    text: d.invitedCommunity.name
+                    text: d.communityName
                     font.weight: Font.Bold
                     wrapMode: Text.WrapAtWordBoundaryOrAnywhere
                     font.pixelSize: 17
@@ -145,7 +154,7 @@ Control {
                 StatusBaseText {
                     Layout.fillWidth: true
 
-                    text: d.invitedCommunity.description
+                    text: d.communityDescription
                     wrapMode: Text.WrapAtWordBoundaryOrAnywhere
                     color: Theme.palette.directColor1
                 }
@@ -153,7 +162,7 @@ Control {
                 StatusBaseText {
                     Layout.fillWidth: true
 
-                    text: qsTr("%n member(s)", "", d.invitedCommunity.nbMembers)
+                    text: qsTr("%n member(s)", "", d.communityNbMembers)
                     font.pixelSize: 13
                     font.weight: Font.Medium
                     color: Theme.palette.baseColor1
@@ -177,7 +186,7 @@ Control {
             radius: d.radius - 1 // We do -1, otherwise there's a gap between border and button
 
             onClicked: {
-                if (d.invitedCommunity.joined || d.invitedCommunity.spectated) {
+                if (d.communityJoined || d.communitySpectated) {
                     root.store.setActiveCommunity(communityId)
                 } else {
                     root.store.spectateCommunity(communityId, userProfile.name)

--- a/ui/imports/shared/views/chat/LinksMessageView.qml
+++ b/ui/imports/shared/views/chat/LinksMessageView.qml
@@ -183,10 +183,10 @@ Column {
             store: root.store
             communityId: invitationData ? invitationData.communityId : ""
             anchors.left: parent.left
-            visible: invitationData && !invitationData.fetching
+            visible: !!invitationData && !invitationData.fetching
 
             Connections {
-                enabled: invitationData && invitationData.fetching
+                enabled: !!invitationData && invitationData.fetching
                 target: root.store.communitiesModuleInst
                 function onCommunityAdded(communityId:  string) {
                     if (communityId !== invitationData.communityId) return


### PR DESCRIPTION
### What does the PR do
Closing #9653

`visible: invitationData && !invitationData.fetching` This condition is failing when invitationData is null or undefined.
Also fixed warnings in [InvitationBubbleView.qml](https://github.com/status-im/status-desktop/compare/fix/issue-9653?expand=1#diff-08a51598e69bdd9997718cb97efe31d0fd4bd5f6132ddb88720dd402e7b21ad2) when the community data cannot be found by adding default values.

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas

Unfurling community urls
<!-- List the affected areas (e.g wallet, browser, etc..) -->

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [x] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)
<img width="756" alt="Screenshot 2023-02-27 at 19 35 00" src="https://user-images.githubusercontent.com/47811206/221639964-4445996e-4f79-4139-88d7-56384e6c4492.png">

- [ ] I've checked the design and this PR matches it

<!-- screenshot (or gif/video) that demonstrates the functionality, specially important if it's a bug fix. -->

### Cool Spaceship Picture

<!-- optional but cool ->
