### PR TITLE
fix(chat): Display text from image message

### DIFF
--- a/src/app/modules/shared_models/message_item.nim
+++ b/src/app/modules/shared_models/message_item.nim
@@ -108,8 +108,8 @@ proc initItem*(
   result.senderColorHash = senderColorHash
   result.seen = seen
   result.outgoingStatus = outgoingStatus
-  result.messageText = if contentType == ContentType.Image : "" else: text
-  result.unparsedText = if contentType == ContentType.Image : "" else: unparsedText
+  result.messageText = text
+  result.unparsedText = unparsedText
   result.messageImage = image
   result.messageContainsMentions = messageContainsMentions
   result.timestamp = timestamp

--- a/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
@@ -274,10 +274,24 @@ Control {
                     Loader {
                         active: root.messageDetails.contentType === StatusMessage.ContentType.Image && !editMode
                         visible: active
-                        sourceComponent: StatusImageMessage {
-                            source: root.messageDetails.messageContent
-                            onClicked: root.imageClicked(image, mouse, imageSource)
-                            shapeType: root.messageDetails.amISender ? StatusImageMessage.ShapeType.RIGHT_ROUNDED : StatusImageMessage.ShapeType.LEFT_ROUNDED
+                        sourceComponent: Column {
+                            spacing: 8
+                            Loader {
+                                active: root.messageDetails.messageText !== ""
+                                visible: active
+                                sourceComponent: StatusTextMessage {
+                                    messageDetails: root.messageDetails
+                                    onLinkActivated: {
+                                        root.linkActivated(link);
+                                    }
+                                }
+                            }
+
+                            StatusImageMessage {
+                                source: root.messageDetails.messageContent
+                                onClicked: root.imageClicked(image, mouse, imageSource)
+                                shapeType: root.messageDetails.amISender ? StatusImageMessage.ShapeType.RIGHT_ROUNDED : StatusImageMessage.ShapeType.LEFT_ROUNDED
+                            }
                         }
                     }
                     Loader {


### PR DESCRIPTION
Fixes: #9564

### What does the PR do

Mobile app sending images with text in one message. This PR adds filtering images in messages and displaying text from message.

P.S.: Don't know how to fix out placeholder in image messages which already sent.

### Affected areas

Chat

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

- [ ] I've checked the design and this PR matches it

<!-- screenshot (or gif/video) that demonstrates the functionality, specially important if it's a bug fix. -->

