### PR TITLE
chore(InDropdown): Adapt to flattened model for channels

### DIFF
--- a/storybook/pages/CommunityPermissionsViewPage.qml
+++ b/storybook/pages/CommunityPermissionsViewPage.qml
@@ -31,14 +31,15 @@ SplitView {
                 store: CommunitiesStore {
                     id: mockedCommunity
 
-                    readonly property var permissionsModel:
-                        PermissionsModel.permissionsModel
+                    readonly property ListModel permissionsModel: ListModel {
+                        Component.onCompleted: append(PermissionsModel.permissionsModelData)
+                    }
 
-                    readonly property var assetsModel: AssetsModel {
+                    readonly property AssetsModel assetsModel: AssetsModel {
                         id: assetsModel
                     }
 
-                    readonly property var collectiblesModel: CollectiblesModel {
+                    readonly property CollectiblesModel collectiblesModel: CollectiblesModel {
                         id: collectiblesModel
                     }
                 }

--- a/storybook/src/Models/ChannelsModel.qml
+++ b/storybook/src/Models/ChannelsModel.qml
@@ -2,66 +2,84 @@ import QtQuick 2.14
 
 ListModel {
     ListElement {
-        itemId: 0
+        itemId: "1"
+        isCategory: false
+        categoryId: ""
         name: "welcome"
-        isCategory: false
+        emoji: ""
         color: ""
         colorId: 1
-        icon: ""
     }
     ListElement {
-        itemId: 1
+        itemId: "2"
+        isCategory: false
+        categoryId: ""
         name: "announcements"
-        isCategory: false
+        emoji: ""
         color: ""
         colorId: 1
-        icon: ""
     }
     ListElement {
-        name: "Discussion"
+        itemId: "0"
         isCategory: true
-
-        subItems: [
-            ListElement {
-                itemId: 2
-                name: "general"
-                icon: ""
-                emoji: "👋"
-            },
-            ListElement {
-                itemId: 3
-                name: "help"
-                icon: ""
-                color: ""
-                colorId: 1
-                emoji: "⚽"
-            }
-        ]
+        categoryId: "1"
+        name: "discussion"
+        emoji: ""
+        color: ""
+        colorId: 1
     }
     ListElement {
-        name: "Support"
-        isCategory: true
-
-        subItems: [
-            ListElement {
-                itemId: 4
-                name: "faq"
-                icon: ""
-                color: ""
-                colorId: 5
-            },
-            ListElement {
-                itemId: 5
-                name: "report-scam"
-                icon: ""
-                color: ""
-                colorId: 4
-            }
-        ]
+        itemId: "3"
+        isCategory: false
+        categoryId: "1"
+        name: "general"
+        emoji: "👋"
+        color: ""
+        colorId: 1
     }
     ListElement {
-        name: "Empty"
+        itemId: "4"
+        isCategory: false
+        categoryId: "1"
+        name: "help"
+        emoji: "⚽"
+        color: ""
+        colorId: 1
+    }
+    ListElement {
+        itemId: "0"
         isCategory: true
-        subItems: []
+        categoryId: "2"
+        name: "support"
+        emoji: ""
+        color: ""
+        colorId: 1
+    }
+    ListElement {
+        itemId: "5"
+        isCategory: false
+        categoryId: "2"
+        name: "faq"
+        emoji: ""
+        color: ""
+        colorId: 5
+    }
+    ListElement {
+        itemId: "6"
+        isCategory: false
+        categoryId: "2"
+        name: "report-scam"
+        emoji: ""
+        color: ""
+        colorId: 4
+    }
+    ListElement {
+        itemId: "0"
+        isCategory: true
+        categoryId: "3"
+        name: "faq"
+        emoji: ""
+        color: ""
+        colorId: 5
     }
 }

--- a/storybook/src/Models/PermissionsModel.qml
+++ b/storybook/src/Models/PermissionsModel.qml
@@ -61,15 +61,36 @@ QtObject {
     ]
 
     readonly property ListModel permissionsModel: ListModel {
-        Component.onCompleted: append(permissionsModelData)
+        readonly property ModelChangeGuard guard: ModelChangeGuard {
+            model: root.permissionsModel
+        }
+
+        Component.onCompleted: {
+            append(permissionsModelData)
+            guard.enabled = true
+        }
     }
 
     readonly property var shortPermissionsModel: ListModel {
-        Component.onCompleted: append(shortPermissionsModelData)
+        readonly property ModelChangeGuard guard: ModelChangeGuard {
+            model: root.shortPermissionsModel
+        }
+
+        Component.onCompleted: {
+            append(shortPermissionsModelData)
+            guard.enabled = true
+        }
     }
 
     readonly property var longPermissionsModel: ListModel {
-        Component.onCompleted: append(longPermissionsModelData)
+        readonly property ModelChangeGuard guard: ModelChangeGuard {
+            model: root.longPermissionsModel
+        }
+
+        Component.onCompleted: {
+            append(longPermissionsModelData)
+            guard.enabled = true
+        }
     }
 
     function createHoldingsModel1() {

--- a/storybook/src/Models/PermissionsModel.qml
+++ b/storybook/src/Models/PermissionsModel.qml
@@ -9,64 +9,67 @@ import AppLayouts.Chat.controls.community 1.0
 QtObject {
     id: root
 
-    readonly property var permissionsModel: ListModel {
-        Component.onCompleted:
-        append([
-                   {
-                       holdingsListModel: root.createHoldingsModel1(),
-                       channelsListModel: root.createChannelsModel1(),
-                       permissionType: PermissionTypes.Type.Admin,
-                       isPrivate: true
-                   },
-                   {
-                       holdingsListModel: root.createHoldingsModel2(),
-                       channelsListModel: root.createChannelsModel2(),
-                       permissionType: PermissionTypes.Type.Member,
-                       isPrivate: false
-                   }
-               ])
+    readonly property var permissionsModelData: [
+        {
+            holdingsListModel: root.createHoldingsModel1(),
+            channelsListModel: root.createChannelsModel1(),
+            permissionType: PermissionTypes.Type.Admin,
+            isPrivate: true
+        },
+        {
+            holdingsListModel: root.createHoldingsModel2(),
+            channelsListModel: root.createChannelsModel2(),
+            permissionType: PermissionTypes.Type.Member,
+            isPrivate: false
+        }
+    ]
+
+    readonly property var shortPermissionsModelData: [
+        {
+            holdingsListModel: root.createHoldingsModel3(),
+            channelsListModel: root.createChannelsModel1(),
+            permissionType: PermissionTypes.Type.Admin,
+            isPrivate: true,
+        }
+    ]
+
+    readonly property var longPermissionsModelData: [
+        {
+            holdingsListModel: root.createHoldingsModel4(),
+            channelsListModel: root.createChannelsModel1(),
+            permissionType: PermissionTypes.Type.Admin,
+            isPrivate: true
+        },
+        {
+            holdingsListModel: root.createHoldingsModel3(),
+            channelsListModel: root.createChannelsModel2(),
+            permissionType: PermissionTypes.Type.Member,
+            isPrivate: false
+        },
+        {
+            holdingsListModel: root.createHoldingsModel2(),
+            channelsListModel: root.createChannelsModel2(),
+            permissionType: PermissionTypes.Type.Member,
+            isPrivate: false
+        },
+        {
+            channelsListModel: root.createChannelsModel2(),
+            holdingsListModel: root.createHoldingsModel1(),
+            permissionType: PermissionTypes.Type.Member,
+            isPrivate: false
+        }
+    ]
+
+    readonly property ListModel permissionsModel: ListModel {
+        Component.onCompleted: append(permissionsModelData)
     }
 
     readonly property var shortPermissionsModel: ListModel {
-        Component.onCompleted:
-        append([
-                   {
-                       holdingsListModel: root.createHoldingsModel3(),
-                       channelsListModel: root.createChannelsModel1(),
-                       permissionType: PermissionTypes.Type.Admin,
-                       isPrivate: true,
-                   }
-               ])
+        Component.onCompleted: append(shortPermissionsModelData)
     }
 
     readonly property var longPermissionsModel: ListModel {
-        Component.onCompleted:
-        append([
-                   {
-                       holdingsListModel: root.createHoldingsModel4(),
-                       channelsListModel: root.createChannelsModel1(),
-                       permissionType: PermissionTypes.Type.Admin,
-                       isPrivate: true
-                   },
-                   {
-                       holdingsListModel: root.createHoldingsModel3(),
-                       channelsListModel: root.createChannelsModel2(),
-                       permissionType: PermissionTypes.Type.Member,
-                       isPrivate: false
-                   },
-                   {
-                       holdingsListModel: root.createHoldingsModel2(),
-                       channelsListModel: root.createChannelsModel2(),
-                       permissionType: PermissionTypes.Type.Member,
-                       isPrivate: false
-                   },
-                   {
-                       channelsListModel: root.createChannelsModel2(),
-                       holdingsListModel: root.createHoldingsModel1(),
-                       permissionType: PermissionTypes.Type.Member,
-                       isPrivate: false
-                   }
-               ])
+        Component.onCompleted: append(longPermissionsModelData)
     }
 
     function createHoldingsModel1() {

--- a/ui/StatusQ/src/StatusQ/Core/Utils/ModelChangeGuard.qml
+++ b/ui/StatusQ/src/StatusQ/Core/Utils/ModelChangeGuard.qml
@@ -1,0 +1,9 @@
+import QtQml 2.15
+
+ModelChangeTracker {
+    enabled: false
+
+    onRevisionChanged: {
+        throw new Error("The model is assumed to be immutable.")
+    }
+}

--- a/ui/StatusQ/src/StatusQ/Core/Utils/ModelChangeTracker.qml
+++ b/ui/StatusQ/src/StatusQ/Core/Utils/ModelChangeTracker.qml
@@ -1,9 +1,10 @@
-import QtQml 2.14
+import QtQml 2.15
 
 QtObject {
     property var model
 
     readonly property alias revision: d.revision
+    property alias enabled: d.enabled
 
     function reset() {
         d.revision = 0

--- a/ui/StatusQ/src/StatusQ/Core/Utils/qmldir
+++ b/ui/StatusQ/src/StatusQ/Core/Utils/qmldir
@@ -2,6 +2,7 @@ module StatusQ.Core.Utils
 
 EmojiJSON 1.0 emojiList.js
 JSONListModel 0.1 JSONListModel.qml
+ModelChangeGuard 0.1 ModelChangeGuard.qml
 ModelChangeTracker 0.1 ModelChangeTracker.qml
 ModelsComparator 0.1 ModelsComparator.qml
 XSS 1.0 xss.js

--- a/ui/app/AppLayouts/Chat/controls/community/CommunityListItem.qml
+++ b/ui/app/AppLayouts/Chat/controls/community/CommunityListItem.qml
@@ -20,7 +20,7 @@ StatusListItem {
 
     asset.isLetterIdenticon: true
     asset.letterSize: 12
-    asset.isImage: model.icon.includes("data")
+    asset.isImage: asset.name.includes("data")
     asset.width: 32
     asset.height: 32
 


### PR DESCRIPTION
### What does the PR do

So far channel models was 2-level. The first level for channels/categories, the second one for channels in category. Now it's simplified and the model is flattened. The `InDropdown` component has been updated for that.

Moreover: 
- fixed `CommunityPermissionsViewPage` which was altering singleton's data making it impossible to reset state of the page

Requires: https://github.com/status-im/status-desktop/pull/9518 (needs to be integrated first)

Closes: https://github.com/status-im/status-desktop/issues/9591

### Affected areas
`InDropdown`
