### PR TITLE
fix(@desktop/wallet): Fix send modal to display all balances in

### DIFF
--- a/src/app/modules/shared_models/token_model.nim
+++ b/src/app/modules/shared_models/token_model.nim
@@ -200,6 +200,10 @@ QtObject:
         if(balance.balance.getAmount() >= requiredGas):
           return true
 
+        break
+
+      break
+
     return false
 
   proc getTokenBalanceOnChain*(self: Model, chainId: int, tokenSymbol: string): CurrencyAmount =
@@ -212,6 +216,8 @@ QtObject:
           continue
 
         return balance.balance
+
+      break
 
     return newCurrencyAmount(
       0.0,

--- a/src/app/modules/shared_models/token_utils.nim
+++ b/src/app/modules/shared_models/token_utils.nim
@@ -24,7 +24,7 @@ proc walletTokenToItem*(
     currencyAmountToItem(t.getCurrencyBalance(enabledChainIds, currency), currencyFormat),
     t.getVisibleForNetwork(enabledChainIds),
     t.getVisibleForNetworkWithPositiveBalance(enabledChainIds),
-    t.getBalances(enabledChainIds).map(b => balanceToItem(b, tokenFormat)),
+    t.getBalances(chainIds).map(b => balanceToItem(b, tokenFormat)),
     t.description,
     t.assetWebsiteUrl,
     t.builtOn,

--- a/ui/imports/shared/controls/TokenBalancePerChainDelegate.qml
+++ b/ui/imports/shared/controls/TokenBalancePerChainDelegate.qml
@@ -15,7 +15,7 @@ StatusListItem {
     signal tokenSelected(var selectedToken)
 
     title: name
-    label: LocaleUtils.currencyAmountToLocaleString(enabledNetworkCurrencyBalance)
+    label: LocaleUtils.currencyAmountToLocaleString(totalCurrencyBalance)
     asset.name: symbol ? Style.png("tokens/" + symbol) : ""
     asset.isImage: true
     asset.width: 32


### PR DESCRIPTION
advanced mode, independent of network selection.
Fix missing break in for loop in token model

Fixes #8858

### What does the PR do

Fixes send modal to display all balances in advanced mode, independent of network selection.

### Affected areas

Wallet SendModal dialog

### Screenshot of functionality (including design for comparison)

Before:
![optimism_disabled_in_advanced_send](https://user-images.githubusercontent.com/15627093/221904763-9d1d6ccf-86ee-4d97-b947-0172fed3f9fb.png)
![send_modal_1_before](https://user-images.githubusercontent.com/15627093/221904795-a98b21d8-f837-4a79-89e8-cfaa938ae2b1.png)


After:
![send_modal_1](https://user-images.githubusercontent.com/15627093/221904863-67c54242-1f2b-4e13-aa5d-1e2eaaa3b51b.png)
![send_modal_1_network_selected_two_active](https://user-images.githubusercontent.com/15627093/221904963-7c109194-ac54-4cdc-af7d-4899ad58b531.png)

https://user-images.githubusercontent.com/15627093/221906236-1875e06f-5794-4307-aa0c-6054ecdeae3e.mp4



