### PR TITLE
fix(StatusChatList): Missing space between channels in StatusChatList

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/StatusChatList.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusChatList.qml
@@ -97,15 +97,12 @@ Item {
                         statusChatListCategoryItem.setupPopup()
                         highlighted = true
                         menuButton.highlighted = true
-                        let p = menuButton.mapToItem(statusChatListCategoryItem, menuButton.x, menuButton.y)
-                        let menuWidth = categoryPopupMenuSlot.item.width
                         categoryPopupMenuSlot.item.popup()
                     }
                     onAddButtonClicked: {
                         root.categoryAddButtonClicked(categoryId)
                     }
                 }
-                
             }
             
             Component {
@@ -114,7 +111,7 @@ Item {
                     id: draggable
                     objectName: model.name
                     width: root.width
-                    height: model.categoryOpened ? statusChatListItem.height : 0
+                    height: model.categoryOpened ? statusChatListItem.height + 4 /*spacing between non-collapsed items*/ : 0
                     visible: height
                     verticalPadding: 2
 


### PR DESCRIPTION
- add an extra space for the item height to fix spacing; can't do this using regular `spacing` due to height of collapsed categories
- remove dead code

Fixes #9657

### Affected areas

StatusChatList

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![image](https://user-images.githubusercontent.com/5377645/221916567-7974e34c-2400-49f7-bf16-9a0f5627ef76.png)

![image](https://user-images.githubusercontent.com/5377645/221916618-048da1ab-e821-4c33-acc6-0a2ce774a75f.png)
