### PR TITLE
Lazy load bookmarks for the browser + fix curated community loading in case of error

### DIFF
--- a/src/app/modules/main/browser_section/bookmark/io_interface.nim
+++ b/src/app/modules/main/browser_section/bookmark/io_interface.nim
@@ -9,6 +9,9 @@ method delete*(self: AccessInterface) {.base.} =
 method load*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method onActivated*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method isLoaded*(self: AccessInterface): bool {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/browser_section/bookmark/module.nim
+++ b/src/app/modules/main/browser_section/bookmark/module.nim
@@ -16,6 +16,7 @@ type
     view: View
     viewVariant: QVariant
     moduleLoaded: bool
+    bookmarksLoaded: bool
     controller: Controller
 
 proc newModule*(delegate: delegate_interface.AccessInterface, events: EventEmitter, bookmarkService: bookmark_service.Service): Module =
@@ -24,6 +25,7 @@ proc newModule*(delegate: delegate_interface.AccessInterface, events: EventEmitt
   result.view = view.newView(result)
   result.viewVariant = newQVariant(result.view)
   result.moduleLoaded = false
+  result.bookmarksLoaded = false
   result.controller = controller.newController(result, events, bookmarkService)
 
 method delete*(self: Module) =
@@ -36,14 +38,20 @@ method load*(self: Module) =
   self.controller.init()
   self.view.load()
 
-method isLoaded*(self: Module): bool =
-  return self.moduleLoaded
+method onActivated*(self: Module) =
+  if self.bookmarksLoaded:
+    return
 
-method viewDidLoad*(self: Module) =
   let bookmarks = self.controller.getBookmarks()
   for b in bookmarks:
     self.view.addItem(initItem(b.name, b.url, b.imageUrl))
 
+  self.bookmarksLoaded = true
+
+method isLoaded*(self: Module): bool =
+  return self.moduleLoaded
+
+method viewDidLoad*(self: Module) =
   self.moduleLoaded = true
   self.delegate.bookmarkDidLoad()
 

--- a/src/app/modules/main/browser_section/io_interface.nim
+++ b/src/app/modules/main/browser_section/io_interface.nim
@@ -7,6 +7,9 @@ method delete*(self: AccessInterface) {.base.} =
 method load*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method onActivated*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method isLoaded*(self: AccessInterface): bool {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/browser_section/module.nim
+++ b/src/app/modules/main/browser_section/module.nim
@@ -69,6 +69,9 @@ method load*(self: Module) =
   self.dappsModule.load()
   self.view.load()
 
+method onActivated*(self: Module) =
+  self.bookmarkModule.onActivated()
+
 method isLoaded*(self: Module): bool =
   return self.moduleLoaded
 

--- a/src/app/modules/main/communities/module.nim
+++ b/src/app/modules/main/communities/module.nim
@@ -40,6 +40,7 @@ type
     view: View
     viewVariant: QVariant
     moduleLoaded: bool
+    curatedCommunitiesLoaded: bool
     mintingModule: minting_module.AccessInterface
 
 # Forward declaration
@@ -66,6 +67,7 @@ proc newModule*(
   )
   result.mintingModule = minting_module.newMintingModule(result, events, communityTokensService)
   result.moduleLoaded = false
+  result.curatedCommunitiesLoaded = false
 
 method delete*(self: Module) =
   self.view.delete
@@ -92,9 +94,12 @@ method viewDidLoad*(self: Module) =
   self.delegate.communitiesModuleDidLoad()
 
 method onActivated*(self: Module) =
+  if self.curatedCommunitiesLoaded:
+    return
   self.controller.asyncLoadCuratedCommunities()
 
 method curatedCommunitiesLoaded*(self: Module, curatedCommunities: seq[CuratedCOmmunity]) =
+  self.curatedCommunitiesLoaded = true
   self.setCuratedCommunities(curatedCommunities)
   self.view.setCuratedCommunitiesLoading(false)
 
@@ -102,6 +107,8 @@ method curatedCommunitiesLoading*(self: Module) =
   self.view.setCuratedCommunitiesLoading(true)
 
 method curatedCommunitiesLoadingFailed*(self: Module) =
+  # TODO we probably want to show an error in the UI later
+  self.curatedCommunitiesLoaded = true
   self.view.setCuratedCommunitiesLoading(false)
 
 proc createMemberItem(self: Module, memberId, requestId: string): MemberItem =

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -669,8 +669,12 @@ method activeSectionSet*[T](self: Module[T], sectionId: string) =
     echo "main-module, incorrect section id: ", sectionId
     return
 
-  if sectionId == conf.COMMUNITIESPORTAL_SECTION_ID:
-    self.communitiesModule.onActivated()
+  case sectionId:
+    of conf.COMMUNITIESPORTAL_SECTION_ID:
+      self.communitiesModule.onActivated()
+    of conf.BROWSER_SECTION_ID:
+      self.browserSectionModule.onActivated()
+
   self.view.model().setActiveSection(sectionId)
   self.view.activeSectionSet(item)
 

--- a/src/app_service/service/bookmarks/service.nim
+++ b/src/app_service/service/bookmarks/service.nim
@@ -19,6 +19,7 @@ const SIGNAL_BOOKMARK_UPDATED* = "bookmarkUpdated"
 type
   Service* = ref object of RootObj
     bookmarks: Table[string, BookmarkDto] # [url, BookmarkDto]
+    bookmarksFetched: bool
     events: EventEmitter
 
 type R = Result[BookmarkDto, string]
@@ -38,18 +39,9 @@ proc newService*(events: EventEmitter): Service =
   result = Service()
   result.events = events
   result.bookmarks = initTable[string, BookmarkDto]()
+  result.bookmarksFetched = false
 
 proc init*(self: Service) =
-  try:
-    let response = backend.getBookmarks()
-    for bookmark in response.result.getElems().mapIt(it.toBookmarkDto()):
-      if not bookmark.removed:
-        self.bookmarks[bookmark.url] = bookmark
-
-  except Exception as e:
-    let errDescription = e.msg
-    error "error: ", errDescription
-
   self.events.on(SignalType.Message.event) do(e: Args):
     var receivedData = MessageSignal(e)
     if receivedData.bookmarks.len > 0:
@@ -77,7 +69,20 @@ proc init*(self: Service) =
 
         self.events.emit(SIGNAL_BOOKMARK_ADDED, BookmarkArgs(bookmark: self.bookmarks[url]))
 
+proc fetchBookmarks*(self: Service) =
+  # TODO later we can make this async, but it's not worth it for now
+  try:
+    let response = backend.getBookmarks()
+    for bookmark in response.result.getElems().mapIt(it.toBookmarkDto()):
+      if not bookmark.removed:
+        self.bookmarks[bookmark.url] = bookmark
+    self.bookmarksFetched = true
+  except Exception as e:
+    error "error fetching bookmarks: ", msg=e.msg
+
 proc getBookmarks*(self: Service): seq[BookmarkDto] =
+  if not self.bookmarksFetched:
+    self.fetchBookmarks()
   return toSeq(self.bookmarks.values)
 
 proc storeBookmark*(self: Service, url, name: string): R =

--- a/src/app_service/service/community/async_tasks.nim
+++ b/src/app_service/service/community/async_tasks.nim
@@ -17,6 +17,11 @@ type
 
 const asyncLoadCuratedCommunitiesTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AsyncLoadCuratedCommunitiesTaskArg](argEncoded)
-  let response = status_go.getCuratedCommunities()
-  arg.finish(response)
+  try:
+    let response = status_go.getCuratedCommunities()
+    arg.finish(response)
+  except Exception as e:
+    arg.finish(%* {
+      "error": RpcError(message: e.msg),
+    })
 

--- a/src/app_service/service/community/service.nim
+++ b/src/app_service/service/community/service.nim
@@ -1282,6 +1282,7 @@ QtObject:
       if (rpcResponseObj{"error"}.kind != JNull):
         let error = Json.decode($rpcResponseObj["error"], RpcError)
         error "Error requesting community info", msg = error.message
+        self.events.emit(SIGNAL_CURATED_COMMUNITIES_LOADING_FAILED, Args())
         return
 
       let curatedCommunities = parseCuratedCommunities(rpcResponseObj{"result"})
@@ -1290,8 +1291,8 @@ QtObject:
       self.events.emit(SIGNAL_CURATED_COMMUNITIES_LOADED, CuratedCommunitiesArgs(curatedCommunities: self.getCuratedCommunities()))
     except Exception as e:
       let errMsg = e.msg
-      error "error: ", errMsg
-      self.events.emit(SIGNAL_CURATEDCOMMUNITIES_LOADING_FAILED, Args())
+      error "error loading curated communities: ", errMsg
+      self.events.emit(SIGNAL_CURATED_COMMUNITIES_LOADING_FAILED, Args())
 
   proc requestCommunityInfo*(self: Service, communityId: string, importing = false) =
 


### PR DESCRIPTION
Fixes #9440

Lazy loads browser bookmarks so they only get fetched when we open the browser section.

I also fixed in the first commit an issue with the curated communities fetch. First, we didn't handle errors correctly. Second, I forgot to only load once, so if you leave the community portal and reopen, it would fetch again.