### PR TITLE
feat(Storybook): Add button for copying component name to clipboard

### DIFF
--- a/storybook/main.qml
+++ b/storybook/main.qml
@@ -136,7 +136,7 @@ ApplicationWindow {
             footer: PageToolBar {
                 id: pageToolBar
 
-                title: `pages/${root.currentPage}Page.qml`
+                componentName: root.currentPage
                 figmaPagesCount: currentPageModelItem.object
                                  ? currentPageModelItem.object.figma.count : 0
 

--- a/storybook/src/Storybook/PageToolBar.qml
+++ b/storybook/src/Storybook/PageToolBar.qml
@@ -5,7 +5,8 @@ import QtQuick.Layouts 1.14
 ToolBar {
     id: root
 
-    property string title
+    property string componentName
+
     property int figmaPagesCount: 0
 
     signal figmaPreviewClicked
@@ -13,16 +14,41 @@ ToolBar {
     RowLayout {
         anchors.fill: parent
 
-        TextField {
+        Item {
             Layout.fillWidth: true
+        }
 
-            text: root.title
+        TextField {
+            text: `pages/${root.componentName}Page.qml`
             horizontalAlignment: Qt.AlignHCenter
             verticalAlignment: Qt.AlignVCenter
 
             selectByMouse: true
             readOnly: true
             background: null
+        }
+
+        ToolButton {
+            text: "📋"
+
+            ToolTip.timeout: 2000
+            ToolTip.text: "Component name copied to the clipboard"
+
+            TextInput {
+                id: hiddenTextInput
+                text: root.componentName
+                visible: false
+            }
+
+            onClicked: {
+                hiddenTextInput.selectAll()
+                hiddenTextInput.copy()
+                ToolTip.visible = true
+            }
+        }
+
+        Item {
+            Layout.fillWidth: true
         }
 
         ToolSeparator {}


### PR DESCRIPTION
### What does the PR do

Adds small convenience button to storybook allowing to copy component name to clipboard in order to find it quickly in QtCreator via Ctrl+K, Ctrl+V sequence.

Closes: #9673

### Affected areas
Storybook (PageToolBar)

### Screenshot of functionality (including design for comparison)

[Kazam_screencast_00125.webm](https://user-images.githubusercontent.com/20650004/221978849-60531e7a-2c3d-4140-b87f-c20696041749.webm)
