### PR TITLE
ci: remove submodule vendor folders to save space

### DIFF
--- a/scripts/clean-git.sh
+++ b/scripts/clean-git.sh
@@ -3,3 +3,4 @@
 git clean -qfdx
 git submodule foreach --recursive git reset -q --hard
 git submodule foreach --recursive git clean -qfdx
+git submodule foreach --recursive rm -fr vendor


### PR DESCRIPTION
Currently the `nimbus-build-system` exists twice in each checked out `status-desktop` reposity, and each contains the `Nim-csources-v1` submodule, which weights close to 900MB each:
https://github.com/nim-lang/csources_v1

Because of this each `status-destop` clone takes up 4 GB of disk space after the cleanup has run, which is not okay.

![image](https://user-images.githubusercontent.com/2212681/222122572-39610841-6d2a-40cd-8aa5-8fe81874339d.png)

This might slow down CI job startup, but the disk space we reclaim is worth it.