### PR TITLE
chore(Storybook): Update Readme to point CMakeLists.txt as the main way to build instead of WebAssembly

### DIFF
--- a/storybook/CMakeLists.txt
+++ b/storybook/CMakeLists.txt
@@ -59,6 +59,7 @@ add_executable(
   ${CORE_JS_FILES}
   ${STORYBOOK_QML_FILES}
   figma.json
+  README.md
 )
 
 target_compile_definitions(${PROJECT_NAME}

--- a/storybook/README.md
+++ b/storybook/README.md
@@ -1,6 +1,8 @@
+# Building Storybook
+
+For regular usage of **Storybook** it's enough to open `status-desktop/storybook/CMakeLists.txt` in QtCreator. Please **`do not use StoryBook.pro`** which is intended for WebAssembly builds. Please make sure that selected run target is `Storybook`.
+
 # Building Storybook with Webassembly and Qt 5.14
-
-
 
 ## Configuring the environment
 ### Install Emscripten v1.38.27


### PR DESCRIPTION
### What does the PR do

So far README.md had only description for WASM builds what was misleading, suggesting that's the only proper way of building Storybook.

Additionally, `README.md` added to `storybook/CMakeLists.txt` in order to show readme file in QtCreator.

Closes: #9679

### Affected areas
Storybook's readme