### PR TITLE
fix(Storybook): Register StatusQ types for Storybook/qmlTests

### DIFF
--- a/storybook/CMakeLists.txt
+++ b/storybook/CMakeLists.txt
@@ -86,7 +86,7 @@ add_executable(QmlTests
 target_compile_definitions(QmlTests
                            PRIVATE QML_IMPORT_ROOT="${CMAKE_CURRENT_LIST_DIR}"
                            PRIVATE -DQUICK_TEST_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}/qmlTests")
-target_link_libraries(QmlTests PRIVATE Qt5::QuickTest Qt5::Qml)
+target_link_libraries(QmlTests PRIVATE Qt5::QuickTest Qt5::Qml ${PROJECT_LIB})
 add_test(NAME QmlTests COMMAND QmlTests)
 
 list(APPEND QML_DIRS "${CMAKE_SOURCE_DIR}/../ui/StatusQ/src")

--- a/storybook/qmlTests/main.cpp
+++ b/storybook/qmlTests/main.cpp
@@ -2,6 +2,8 @@
 #include <QQmlEngine>
 #include "src/TextUtils.h"
 
+#include "StatusQ/typesregistration.h"
+
 class Setup : public QObject
 {
     Q_OBJECT
@@ -21,6 +23,8 @@ public slots:
             engine->addImportPath(path);
 
         qmlRegisterSingletonType<TextUtils>("TextUtils", 1, 0, "TextUtils", &TextUtils::qmlInstance);
+
+        registerStatusQTypes();
     }
 };
 


### PR DESCRIPTION
### What does the PR do

`StatusQ` types are registered properly for `Storybook/qmlTests` now in order to make that target functional again.

Closes: #9690

### Affected areas
Storybook/qmlTests
