### PR TITLE
fix(@desktop/wallet): keypairs are displayed wrongly after account removal

### DIFF
--- a/src/app/modules/main/wallet_section/accounts/item.nim
+++ b/src/app/modules/main/wallet_section/accounts/item.nim
@@ -24,23 +24,23 @@ type
     ens: string
 
 proc initItem*(
-  name: string,
-  address: string,
-  mixedCaseAddress: string,
-  path: string,
-  color: string,
-  publicKey: string,
-  walletType: string,
-  isWallet: bool,
-  isChat: bool,
-  currencyBalance: CurrencyAmount,
-  assets: token_model.Model,
-  emoji: string,
-  derivedfrom: string,
-  relatedAccounts: compact_model.Model,
-  keyUid: string,
-  migratedToKeycard: bool,
-  ens: string
+  name: string = "",
+  address: string = "",
+  mixedCaseAddress: string = "",
+  path: string = "",
+  color: string = "",
+  publicKey: string = "",
+  walletType: string = "",
+  isWallet: bool = true,
+  isChat: bool = false,
+  currencyBalance: CurrencyAmount = nil,
+  assets: token_model.Model = nil,
+  emoji: string = "",
+  derivedfrom: string = "",
+  relatedAccounts: compact_model.Model = nil,
+  keyUid: string = "",
+  migratedToKeycard: bool = false,
+  ens: string = ""
 ): Item =
   result.name = name
   result.address = address

--- a/src/app/modules/main/wallet_section/accounts/utils.nim
+++ b/src/app/modules/main/wallet_section/accounts/utils.nim
@@ -38,16 +38,20 @@ proc walletAccountToItem*(
   tokenFormats: Table[string, CurrencyFormatDto],
   ) : item.Item =
   let assets = token_model.newModel()
+  let relatedAccounts = compact_model.newModel()
+
+  if w.isNil:
+    return item.initItem()
+
   assets.setItems(
     w.tokens.map(t => walletTokenToItem(t, chainIds, enabledChainIds, currency, currencyFormat, tokenFormats[t.symbol]))
   )
 
-  let relatedAccounts = compact_model.newModel()
   relatedAccounts.setItems(
     w.relatedAccounts.map(x => walletAccountToCompactItem(x, enabledChainIds, currency, currencyFormat))
   )
 
-  result = initItem(
+  return item.initItem(
     w.name,
     w.address,
     w.mixedCaseAddress,

--- a/src/app/modules/main/wallet_section/accounts/view.nim
+++ b/src/app/modules/main/wallet_section/accounts/view.nim
@@ -188,7 +188,7 @@ QtObject:
         watchOnly.add(item)
 
       # Accounts imported with Seed phrase
-      elif item.getWalletType() == SEED:
+      elif item.getWalletType() == SEED and imported.all(x => cmpIgnoreCase(x.getDerivedfrom(), item.getDerivedFrom()) != 0):
         var generatedAccs1: Model = newModel()
         var filterItems: seq[Item] = items.filter(x => cmpIgnoreCase(x.getDerivedFrom(), item.getDerivedFrom()) == 0)
         generatedAccs1.setItems(filterItems)

--- a/src/app/modules/main/wallet_section/current_account/module.nim
+++ b/src/app/modules/main/wallet_section/current_account/module.nim
@@ -30,6 +30,8 @@ type
 
 proc onTokensRebuilt(self: Module, accountsTokens: OrderedTable[string, seq[WalletTokenDto]])
 proc onCurrencyFormatsUpdated(self: Module)
+proc onAccountAdded(self: Module, account: WalletAccountDto)
+proc onAccountRemoved(self: Module, account: WalletAccountDto)
 
 proc newModule*(
   delegate: delegate_interface.AccessInterface,
@@ -54,6 +56,14 @@ method load*(self: Module) =
   singletonInstance.engine.setRootContextProperty("walletSectionCurrent", newQVariant(self.view))
 
   # these connections should be part of the controller's init method
+  self.events.on(SIGNAL_WALLET_ACCOUNT_SAVED) do(e:Args):
+    let args = AccountSaved(e)
+    self.onAccountAdded(args.account)
+
+  self.events.on(SIGNAL_WALLET_ACCOUNT_DELETED) do(e:Args):
+    let args = AccountDeleted(e)
+    self.onAccountRemoved(args.account)
+
   self.events.on(SIGNAL_WALLET_ACCOUNT_UPDATED) do(e:Args):
     self.switchAccount(self.currentAccountIndex)
 
@@ -107,46 +117,47 @@ method switchAccount*(self: Module, accountIndex: int) =
         return true
     return false
 
-  let defaultAccount = self.controller.getWalletAccount(0) # can safely do this as the account will always contain atleast one account
-  let walletAccount = self.controller.getWalletAccount(accountIndex)
-
   let migratedKeyPairs = self.controller.getAllMigratedKeyPairs()
   let currency = self.controller.getCurrentCurrency()
+  let currencyFormat = self.controller.getCurrencyFormat(currency)
 
   let chainIds = self.controller.getChainIds()
   let enabledChainIds = self.controller.getEnabledChainIds()
 
-  let defaultAccountTokenFormats = collect(initTable()):
-    for t in defaultAccount.tokens: {t.symbol: self.controller.getCurrencyFormat(t.symbol)}
-  
-  let accountTokenFormats = collect(initTable()):
-    for t in walletAccount.tokens: {t.symbol: self.controller.getCurrencyFormat(t.symbol)}
+  let defaultAccount = self.controller.getWalletAccount(0) # can safely do this as the account will always contain atleast one account
+  if not defaultAccount.isNil:
+    let defaultAccountTokenFormats = collect(initTable()):
+      for t in defaultAccount.tokens: {t.symbol: self.controller.getCurrencyFormat(t.symbol)}
+    
+    let defaultAccountItem = walletAccountToItem(
+      defaultAccount,
+      chainIds,
+      enabledChainIds,
+      currency,
+      keyPairMigrated(migratedKeyPairs, defaultAccount.keyUid),
+      currencyFormat,
+      defaultAccountTokenFormats
+      )
+    
+    self.view.setDefaultWalletAccount(defaultAccountItem)
 
-  let currencyFormat = self.controller.getCurrencyFormat(currency)
+  let walletAccount = self.controller.getWalletAccount(accountIndex)
+  if not walletAccount.isNil:
+    let accountTokenFormats = collect(initTable()):
+      for t in walletAccount.tokens: {t.symbol: self.controller.getCurrencyFormat(t.symbol)}
 
-  let defaultAccountItem = walletAccountToItem(
-    defaultAccount,
-    chainIds,
-    enabledChainIds,
-    currency,
-    keyPairMigrated(migratedKeyPairs, defaultAccount.keyUid),
-    currencyFormat,
-    defaultAccountTokenFormats
-    )
+    let accountItem = walletAccountToItem(
+      walletAccount,
+      chainIds,
+      enabledChainIds,
+      currency,
+      keyPairMigrated(migratedKeyPairs, walletAccount.keyUid),
+      currencyFormat,
+      accountTokenFormats
+      )
 
-  let accountItem = walletAccountToItem(
-    walletAccount,
-    chainIds,
-    enabledChainIds,
-    currency,
-    keyPairMigrated(migratedKeyPairs, walletAccount.keyUid),
-    currencyFormat,
-    accountTokenFormats
-    )
-
-  self.view.setDefaultWalletAccount(defaultAccountItem)
-  self.view.setData(accountItem)
-  self.setAssetsAndBalance(walletAccount.tokens)
+    self.view.setData(accountItem)
+    self.setAssetsAndBalance(walletAccount.tokens)
 
 method update*(self: Module, address: string, accountName: string, color: string, emoji: string) =
   self.controller.update(address, accountName, color, emoji)
@@ -165,3 +176,8 @@ proc onCurrencyFormatsUpdated(self: Module) =
 method findTokenSymbolByAddress*(self: Module, address: string): string =
   return self.controller.findTokenSymbolByAddress(address)
 
+proc onAccountAdded(self: Module, account: WalletAccountDto) =
+  self.switchAccount(self.currentAccountIndex)
+
+proc onAccountRemoved(self: Module, account: WalletAccountDto) =
+  self.switchAccount(self.currentAccountIndex)

--- a/src/app/modules/shared_modules/keycard_popup/module.nim
+++ b/src/app/modules/shared_modules/keycard_popup/module.nim
@@ -419,6 +419,9 @@ proc buildKeyPairsList[T](self: Module[T], excludeAlreadyMigratedPairs: bool): s
       if(items[i].getPairType() == keyPairType.int):
         result.inc
 
+  let containsItemWithDerivationPath = proc(items: seq[KeyPairItem], derivedFromAddress: string): bool =
+    return items.any(x => cmpIgnoreCase(x.getDerivedFrom(), derivedFromAddress) == 0)
+
   let accounts = self.controller.getWalletAccounts()
   var items: seq[KeyPairItem]
   for a in accounts:
@@ -442,7 +445,7 @@ proc buildKeyPairsList[T](self: Module[T], excludeAlreadyMigratedPairs: bool): s
         item.addAccount(newKeyPairAccountItem(ga.name, ga.path, ga.address, ga.publicKey, ga.emoji, ga.color, icon, balance = 0.0))
       items.insert(item, 0) # Status Account must be at first place
       continue
-    if a.walletType == WalletTypeSeed:
+    if a.walletType == WalletTypeSeed and not containsItemWithDerivationPath(items, a.derivedfrom):
       let diffImports = countOfKeyPairsForType(items, KeyPairType.SeedImport)
       var item = newKeyPairItem(keyUid = a.keyUid,
         pubKey = a.publicKey,
@@ -458,7 +461,7 @@ proc buildKeyPairsList[T](self: Module[T], excludeAlreadyMigratedPairs: bool): s
         item.addAccount(newKeyPairAccountItem(ga.name, ga.path, ga.address, ga.publicKey, ga.emoji, ga.color, icon = "", balance = 0.0))
       items.add(item)
       continue
-    if a.walletType == WalletTypeKey:
+    if a.walletType == WalletTypeKey and not containsItemWithDerivationPath(items, a.derivedfrom):
       let diffImports = countOfKeyPairsForType(items, KeyPairType.PrivateKeyImport)
       var item = newKeyPairItem(keyUid = a.keyUid,
         pubKey = a.publicKey,


### PR DESCRIPTION
What I noticed while was fixing this is that wallet account module for the settings part of the app is pretty weirdly developed. A lot of nested dependencies which may affect the performance of that part, actually that part is so light (like just reading and displaying data stored in the db) that it should be displayed instantly. I didn't refactor there anything just fixed the issue with as little as possible changes, but just wanted to warn about that part (we should keep that in mind).

Corresponding `status-go` PR:
- https://github.com/status-im/status-go/pull/3245

Closes: #9667