### PR TITLE
fix: Primary nav bar vertical alignment on Windows/Linux

### DIFF
--- a/ui/StatusQ/src/StatusQ/Layout/StatusAppNavBar.qml
+++ b/ui/StatusQ/src/StatusQ/Layout/StatusAppNavBar.qml
@@ -1,5 +1,6 @@
-import QtQuick 2.13
-import QtQuick.Layouts 1.14
+import QtQuick 2.15
+import QtQuick.Layouts 1.15
+import QtQuick.Window 2.15
 
 import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
@@ -42,7 +43,7 @@ Rectangle {
         id: layout
         anchors {
             fill: parent
-            topMargin: 48
+            topMargin: Qt.platform.os === "osx" && Window.visibility !== Window.FullScreen ? 48 : 12 // space reserved for Mac traffic lights (window icons)
             bottomMargin: 24
         }
 

--- a/ui/main.qml
+++ b/ui/main.qml
@@ -195,7 +195,7 @@ StatusWindow {
     Connections {
         target: applicationWindow
         function onClosing(close) {
-            if (Qt.platform.os === "osx") {
+            if (Qt.platform.os === Constants.mac) {
                 loader.sourceComponent = undefined
                 close.accepted = true
             } else {
@@ -261,12 +261,12 @@ StatusWindow {
         visible: true
         icon.source: {
             if (production) {
-                if (Qt.platform.os == "osx")
+                if (Qt.platform.os == Constants.mac)
                     return "imports/assets/icons/status-logo-round-rect.svg"
                 else
                     return "imports/assets/icons/status-logo-circle.svg"
             } else {
-                if (Qt.platform.os == "osx")
+                if (Qt.platform.os == Constants.mac)
                     return "imports/assets/icons/status-logo-dev-round-rect.svg"
                 else
                     return "imports/assets/icons/status-logo-dev-circle.svg"
@@ -345,13 +345,12 @@ StatusWindow {
         id: notificationWindow
     }
 
-    MacTrafficLights {
-//        parent: Overlay.overlay
+    MacTrafficLights { // FIXME should be a direct part of StatusAppNavBar
         anchors.left: parent.left
         anchors.top: parent.top
         anchors.margins: 13
 
-        visible: Qt.platform.os === "osx" && !applicationWindow.isFullScreen
+        visible: Qt.platform.os === Constants.mac && !applicationWindow.isFullScreen
 
         onClose: {
             if (loader.sourceComponent != app) {
@@ -375,9 +374,3 @@ StatusWindow {
         }
     }
 }
-
-/*##^##
-Designer {
-    D{i:0;formeditorZoom:0.5}
-}
-##^##*/


### PR DESCRIPTION
- reduce top margin for non-macOS builds

Fixes #9684

### What does the PR do

Fixes extra margin on top of the primary navbar when not running on macOS

### Affected areas

StatusAppNavBar, main

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![image](https://user-images.githubusercontent.com/5377645/222270992-0fc0fd29-b1a6-4dd8-99dd-c51db1d28c2f.png)
