### PR TITLE
chore: use random ports for waku and torrents

### DIFF
--- a/src/app_service/common/network_constants.nim
+++ b/src/app_service/common/network_constants.nim
@@ -35,17 +35,17 @@ let OPENSEA_API_KEY_RESOLVED* =
   else:
     OPENSEA_API_KEY
 
-const DEFAULT_TORRENT_CONFIG_PORT = 9025
-let TORRENT_CONFIG_PORT* = if (existsEnv("PORT_SHIFT")):
-              DEFAULT_TORRENT_CONFIG_PORT + parseInt($getEnv("PORT_SHIFT"))
+const DEFAULT_TORRENT_CONFIG_PORT = 0 # Random
+let TORRENT_CONFIG_PORT* = if (existsEnv("TORRENT_PORT")):
+              parseInt($getEnv("TORRENT_PORT"))
             else:
               DEFAULT_TORRENT_CONFIG_PORT
 
-const DEFAUL_WAKU_V2_PORT = 60000
-let WAKU_V2_PORT* = if (existsEnv("PORT_SHIFT")):
-              DEFAUL_WAKU_V2_PORT + parseInt($getEnv("PORT_SHIFT"))
+const DEFAULT_WAKU_V2_PORT = 0 # Random
+let WAKU_V2_PORT* = if (existsEnv("WAKU_PORT")):
+              parseInt($getEnv("WAKU_PORT"))
             else:
-              DEFAUL_WAKU_V2_PORT
+              DEFAULT_WAKU_V2_PORT
 
 let DEFAULT_TORRENT_CONFIG_DATADIR* = joinPath(main_constants.defaultDataDir(), "data", "archivedata")
 let DEFAULT_TORRENT_CONFIG_TORRENTDIR* = joinPath(main_constants.defaultDataDir(), "data", "torrents")


### PR DESCRIPTION
Requires:
- https://github.com/status-im/status-go/pull/3247

Sets the default port for new accounts to 0 for both WakuV2 and Torrent.
It also replaces the PORT_SHIFT variable for TORRENT_PORT and WAKU_PORT which can be used in case someone wants to use an specific port number, otherwise, it will automagically find a new port.

(Currently this only applies to new accounts, maybe we should create a migration so existing users find a random port too?)