### PR TITLE
fix(SplashScreen): Enable threaded renderer

### DIFF
--- a/src/nim_status_client.nim
+++ b/src/nim_status_client.nim
@@ -93,6 +93,7 @@ proc mainProc() =
   let statusFoundation = newStatusFoundation(fleetConfig)
   let uiScaleFilePath = joinPath(DATADIR, "ui-scale")
   enableHDPI(uiScaleFilePath)
+  tryEnableThreadedRenderer()
   initializeOpenGL()
 
   let imageCert = imageServerTLSCert()

--- a/vendor/DOtherSide/lib/include/DOtherSide/DOtherSide.h
+++ b/vendor/DOtherSide/lib/include/DOtherSide/DOtherSide.h
@@ -60,6 +60,8 @@ DOS_API void DOS_CALL dos_qguiapplication_enable_hdpi(const char *uiScaleFilePat
 
 DOS_API void DOS_CALL dos_qguiapplication_initialize_opengl(void);
 
+DOS_API void DOS_CALL dos_qguiapplication_try_enable_threaded_renderer();
+
 /// \brief Create a QGuiApplication
 /// \note The created QGuiApplication should be freed by calling dos_qguiapplication_delete()
 DOS_API void DOS_CALL dos_qguiapplication_create();

--- a/vendor/DOtherSide/lib/src/DOtherSide.cpp
+++ b/vendor/DOtherSide/lib/src/DOtherSide.cpp
@@ -50,6 +50,7 @@
 #include <QTranslator>
 #include <QSettings>
 #include <QTimer>
+#include <QSysInfo>
 #ifdef QT_QUICKCONTROLS2_LIB
 #include <QtQuickControls2/QQuickStyle>
 #endif
@@ -186,6 +187,16 @@ void dos_qguiapplication_enable_hdpi(const char *uiScaleFilePath)
 void dos_qguiapplication_initialize_opengl()
 {
     QGuiApplication::setAttribute(Qt::AA_ShareOpenGLContexts);
+}
+
+void dos_qguiapplication_try_enable_threaded_renderer()
+{
+    if(QSysInfo::buildCpuArchitecture() == "arm64" && QSysInfo::kernelType() == "darwin" && QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
+    {
+        //Threaded renderer is crashing on M1 Macs
+        return;
+    }
+    qputenv("QSG_RENDER_LOOP", "threaded");
 }
 
 // This catches the QT and QML logs and outputs them.


### PR DESCRIPTION
### What does the PR do
Part of #9558

Motivation: The splash screen is freezing when the main thread is blocked even with the new animator introduced here #9524.

Enable threaded renderer except when using Qt5 for `arm64` on Macs.

I'm adding the nimqml changes to be reviewed here first. Will add nimqml PR and bump the version when this PR is reviewed.

### Affected areas
Qt renderer
