### PR TITLE
fix(AmountInput): Skip non-digits for max input length limit validation

### DIFF
--- a/ui/StatusQ/src/StatusQ/Core/LocaleUtils.qml
+++ b/ui/StatusQ/src/StatusQ/Core/LocaleUtils.qml
@@ -38,6 +38,18 @@ QtObject {
         }
     }
 
+    function getLocalizedDigitsCount(str, locale = null) {
+        if (!str)
+            return 0
+
+        locale = locale || Qt.locale()
+
+        if (d.nonDigitCharacterRegExpLocale !== locale)
+            d.nonDigitCharacterRegExpLocale = locale
+
+        return str.replace(d.nonDigitCharacterRegExp, "").length
+    }
+
     function currencyAmountToLocaleString(currencyAmount, options = null, locale = null) {
         locale = locale || Qt.locale()
 
@@ -126,6 +138,15 @@ QtObject {
             firstDate.setHours(0, 0, 0) // discard time
             secondDate.setHours(0, 0, 0)
             return Math.round(Math.abs((firstDate - secondDate) / d.msInADay)) // Math.round: not all days are 24 hours long!
+        }
+
+        property var nonDigitCharacterRegExpLocale
+
+        readonly property var nonDigitCharacterRegExp: {
+            const localizedNumbers = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9].map(
+                    n => LocaleUtils.numberToLocaleString(n, 0, nonDigitCharacterRegExpLocale))
+
+            return new RegExp(`[^${localizedNumbers.join("")}]`, "g")
         }
     }
 

--- a/ui/imports/shared/controls/AmountInput.qml
+++ b/ui/imports/shared/controls/AmountInput.qml
@@ -32,6 +32,11 @@ Input {
         id: d
 
         property real amount: 0
+
+        function getEffectiveDigitsCount(str) {
+            const digits = LocaleUtils.getLocalizedDigitsCount(text, root.locale)
+            return str.startsWith(locale.decimalPoint) ? digits + 1 : digits
+        }
     }
 
     validator: DoubleValidator {
@@ -53,7 +58,7 @@ Input {
             return
         }
 
-        if (text.length > root.maximumLength) {
+        if (d.getEffectiveDigitsCount(text) > root.maximumLength) {
             root.validationError = qsTr("The maximum number of characters is %1").arg(root.maximumLength)
             return
         }


### PR DESCRIPTION
### What does the PR do

Only number of digits is taken into consideration when calculating input length for comparison with the limit. Possibility of using non-standard digits is taken into account.

Closes: #9718

### Affected areas
`AmountInput`

### Screenshot of functionality (including design for comparison)

[Kazam_screencast_00124.webm](https://user-images.githubusercontent.com/20650004/222418850-8df1a116-8bc2-4167-bd99-68ec239bb3f0.webm)
