### PR TITLE
fix(@desktop/statusq): Fix icons background square, but must be circle

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/StatusContactVerificationIcons.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusContactVerificationIcons.qml
@@ -18,6 +18,7 @@ Row {
         height: Math.min(bgHeight, dummyImage.height)
         bgWidth: root.tiny ? 10 : 16.5
         bgHeight: root.tiny ? 10 : 16.5
+        bgRadius: bgWidth / 2
         bgColor: Theme.palette.primaryColor1
         // Only used to get implicit width and height from the actual image
         property Image dummyImage: Image {
@@ -35,6 +36,7 @@ Row {
         height: Math.min(bgHeight, dummyImage.height)
         bgWidth: root.tiny ? 10 : 16
         bgHeight: root.tiny ? 10 : 16
+        bgRadius: bgWidth / 2
         bgColor: root.trustIndicator === StatusContactVerificationIcons.TrustedType.Verified ? Theme.palette.primaryColor1 : Theme.palette.dangerColor1
         // Only used to get implicit width and height from the actual image
         property Image dummyImage: Image {

--- a/ui/StatusQ/src/StatusQ/Components/StatusExpandableItem.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusExpandableItem.qml
@@ -25,6 +25,7 @@ Rectangle {
         color: Theme.palette.directColor1
         bgWidth: 32
         bgHeight: 32
+        bgRadius: bgWidth / 2
         bgColor: Theme.palette.primaryColor2
     }
 

--- a/ui/StatusQ/src/StatusQ/Components/StatusListItem.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusListItem.qml
@@ -46,6 +46,7 @@ Rectangle {
             Theme.palette.dangerColor1 : Theme.palette.primaryColor1
         bgWidth: 40
         bgHeight: 40
+        bgRadius: bgWidth / 2
         bgColor: {
             if (sensor.containsMouse) {
                 return type === StatusListItem.Type.Secondary ||

--- a/ui/StatusQ/src/StatusQ/Components/StatusListItemTag.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusListItemTag.qml
@@ -28,6 +28,7 @@ Control {
         bgWidth: 15
         bgHeight: 15
         bgColor: Theme.palette.primaryColor3
+        bgRadius: bgWidth / 2
         imgIsIdenticon: false
     }
 

--- a/ui/StatusQ/src/StatusQ/Components/StatusSmartIdenticon.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusSmartIdenticon.qml
@@ -15,6 +15,7 @@ Loader {
     property StatusAssetSettings asset: StatusAssetSettings {
         width: 40
         height: 40
+        bgRadius: bgWidth / 2
     }
 
     property StatusIdenticonRingSettings ringSettings: StatusIdenticonRingSettings {


### PR DESCRIPTION
Fixes: #9714

### What does the PR do

Changes to StatusRoundIcon in PR [9574](https://github.com/status-im/status-desktop/pull/9574) specifically lines:
https://github.com/IvanBelyakoff/status-desktop/blob/ae082b26ff245fac902491139b98f599187ae139/ui/StatusQ/src/StatusQ/Components/StatusRoundIcon.qml#L22
this:
`radius: bgWidth / 2`
was changed to:
```
bgRadius: bgWidth / 2
...
radius: asset.bgRadius
```
Does not work, when asset is entirely overwritten, but `bgRadius` is not specified:
_Somewhere in code:_
```
asset.bgWidth: 40
// asset.bgRadius: asset.bgWidth / 2 // This is not done!
...
asset: root.asset // `bgWidth` will be set, but `bgRadius` is now empty even if it defaulted to `bgWidth / 2` for StatusRoundIcon, icon background will be square, but meant to be circle
```

I still believe the fix was correct, because when `SmartIdentIcon` is used deep in component, like in `StatusListItem`, the only good option to pass parameters for it is via `asset`, because its `radius` is not reachable.
So the solution would be if one wants to entirely overwrite asset like `asset: root.asset`, they must provide `bgRadius` explicitly.

By default, I also set `bgRadius` to make the icon circle for `StatusListItem` as I believe this is the most common usecase.
I've scanned through the source code and made updates where:

- `asset.bgWidth` was explicitly set, but `bgRadius` was not set, and `asset: <item_id>.asset` was used for `SmartIdentIcon` or `StatusRoundIcon`

### Affected areas

All UI that uses icons

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?
