### PR TITLE
refactor(communities): refactor communities cache in service

### DIFF
--- a/src/app/modules/main/chat_section/controller.nim
+++ b/src/app/modules/main/chat_section/controller.nim
@@ -304,14 +304,11 @@ proc getMySectionId*(self: Controller): string =
 proc isCommunity*(self: Controller): bool =
   return self.isCommunitySection
 
-proc getCommunityByIdFromAllCommunities*(self: Controller, communityId: string): CommunityDto =
-  return self.communityService.getCommunityByIdFromAllCommunities(communityId)
-
-proc getMyCommunity*(self: Controller): CommunityDto =
-  return self.getCommunityByIdFromAllCommunities(self.sectionId)
-
 proc getCommunityById*(self: Controller, communityId: string): CommunityDto =
   return self.communityService.getCommunityById(communityId)
+
+proc getMyCommunity*(self: Controller): CommunityDto =
+  return self.getCommunityById(self.sectionId)
 
 proc getCategories*(self: Controller, communityId: string): seq[Category] =
   return self.communityService.getCategories(communityId)

--- a/src/backend/communities.nim
+++ b/src/backend/communities.nim
@@ -17,10 +17,6 @@ proc unmuteCategory*(communityId: string, categoryId: string): RpcResponse[JsonN
   let payload = %* [communityId, categoryId]
   result = callPrivateRPC("unmuteCommunityCategory".prefix, payload)
 
-proc getJoinedComunities*(): RpcResponse[JsonNode] {.raises: [Exception].} =
-  let payload = %* []
-  result = callPrivateRPC("joinedCommunities".prefix, payload)
-
 proc getCuratedCommunities*(): RpcResponse[JsonNode] {.raises: [Exception].} =
   let payload = %* []
   result = callPrivateRPC("curatedCommunities".prefix, payload)


### PR DESCRIPTION
Fixes #9570

Removes the `joinedCommunities` cache Table and uses `allCommunities` instead, which was renamed just `communities`.

It simplifies the code a lots, plus should be lighter and faster.

If we need just a table of `joined` communities, I added `getFilteredJoinedCommunities` which does a manual filter on `communities`. The function `getJoinedCommunities` that was used by some controllers uses that function.
