### PR TITLE
fix(chat): Sent images with text correctly

### DIFF
--- a/src/app/modules/main/activity_center/module.nim
+++ b/src/app/modules/main/activity_center/module.nim
@@ -130,7 +130,10 @@ proc createMessageItemFromDto(self: Module, message: MessageDto, chatDetails: Ch
     message.quotedMessage.contentType,
     message.quotedMessage.deleted,
     message.quotedMessage.discordMessage,
-    quotedMessageAuthorDetails
+    quotedMessageAuthorDetails,
+    message.albumId,
+    if (len(message.albumId) == 0): @[] else: @[message.image],
+    if (len(message.albumId) == 0): @[] else: @[message.id],
     ))
 
 method convertToItems*(

--- a/src/app/modules/main/chat_section/chat_content/input_area/controller.nim
+++ b/src/app/modules/main/chat_section/chat_content/input_area/controller.nim
@@ -76,8 +76,8 @@ proc getChatId*(self: Controller): string =
 proc belongsToCommunity*(self: Controller): bool =
   return self.belongsToCommunity
 
-proc sendImages*(self: Controller, imagePathsAndDataJson: string): string =
-  self.chatService.sendImages(self.chatId, imagePathsAndDataJson)
+proc sendImages*(self: Controller, imagePathsAndDataJson: string, msg: string): string =
+  self.chatService.sendImages(self.chatId, imagePathsAndDataJson, msg)
 
 proc sendChatMessage*(
     self: Controller,

--- a/src/app/modules/main/chat_section/chat_content/input_area/io_interface.nim
+++ b/src/app/modules/main/chat_section/chat_content/input_area/io_interface.nim
@@ -20,7 +20,7 @@ method getModuleAsVariant*(self: AccessInterface): QVariant {.base.} =
 method sendChatMessage*(self: AccessInterface, msg: string, replyTo: string, contentType: int) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method sendImages*(self: AccessInterface, imagePathsJson: string): string {.base.} =
+method sendImages*(self: AccessInterface, imagePathsJson: string, msg: string): string {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method requestAddressForTransaction*(self: AccessInterface, fromAddress: string, amount: string, tokenAddress: string) {.base.} =

--- a/src/app/modules/main/chat_section/chat_content/input_area/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/input_area/module.nim
@@ -62,8 +62,8 @@ method getModuleAsVariant*(self: Module): QVariant =
 method getChatId*(self: Module): string =
   return self.controller.getChatId()
 
-method sendImages*(self: Module, imagePathsAndDataJson: string): string =
-  self.controller.sendImages(imagePathsAndDataJson)
+method sendImages*(self: Module, imagePathsAndDataJson: string, msg: string): string =
+  self.controller.sendImages(imagePathsAndDataJson, msg)
 
 method sendChatMessage*(
     self: Module,

--- a/src/app/modules/main/chat_section/chat_content/input_area/view.nim
+++ b/src/app/modules/main/chat_section/chat_content/input_area/view.nim
@@ -38,8 +38,8 @@ QtObject:
       contentType: int) {.slot.} =
     self.delegate.sendChatMessage(msg, replyTo, contentType)
 
-  proc sendImages*(self: View, imagePathsAndDataJson: string): string {.slot.} =
-    self.delegate.sendImages(imagePathsAndDataJson)
+  proc sendImages*(self: View, imagePathsAndDataJson: string, msg: string): string {.slot.} =
+    self.delegate.sendImages(imagePathsAndDataJson, msg)
 
   proc acceptAddressRequest*(self: View, messageId: string , address: string) {.slot.} =
     self.delegate.acceptRequestAddressForTransaction(messageId, address)

--- a/src/app/modules/main/chat_section/chat_content/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/module.nim
@@ -220,7 +220,10 @@ proc buildPinnedMessageItem(self: Module, messageId: string, actionInitiatedBy: 
     message.quotedMessage.contentType,
     message.quotedMessage.deleted,
     message.quotedMessage.discordMessage,
-    quotedMessageAuthorDetails
+    quotedMessageAuthorDetails,
+    message.albumId,
+    if (len(message.albumId) == 0): @[] else: @[message.image],
+    if (len(message.albumId) == 0): @[] else: @[message.id],
   )
   item.pinned = true
   item.pinnedBy = actionInitiatedBy

--- a/src/app/modules/shared_models/message_item.nim
+++ b/src/app/modules/shared_models/message_item.nim
@@ -56,6 +56,9 @@ type
     quotedMessageAuthorDisplayName: string
     quotedMessageAuthorAvatar: string
     quotedMessageAuthorDetails: ContactDetails
+    albumId: string
+    albumMessageImages: seq[string]
+    albumMessageIds: seq[string]
 
 proc initItem*(
     id,
@@ -97,6 +100,9 @@ proc initItem*(
     quotedMessageDeleted: bool,
     quotedMessageDiscordMessage: DiscordMessage,
     quotedMessageAuthorDetails: ContactDetails,
+    albumId: string,
+    albumMessageImages: seq[string],
+    albumMessageIds: seq[string],
     ): Item =
   result = Item()
   result.id = id
@@ -143,6 +149,9 @@ proc initItem*(
   result.quotedMessageContentType = quotedMessageContentType
   result.quotedMessageDeleted = quotedMessageDeleted
   result.quotedMessageAuthorDetails = quotedMessageAuthorDetails
+  result.albumId = albumId
+  result.albumMessageImages = albumMessageImages
+  result.albumMessageIds = albumMessageIds
 
   if quotedMessageContentType == ContentType.DiscordMessage.int:
     result.quotedMessageAuthorDisplayName = quotedMessageDiscordMessage.author.name
@@ -214,6 +223,9 @@ proc initNewMessagesMarkerItem*(clock, timestamp: int64): Item =
     quotedMessageDeleted = false,
     quotedMessageDiscordMessage = DiscordMessage(),
     quotedMessageAuthorDetails = ContactDetails(),
+    albumId = "",
+    albumMessageImages = @[],
+    albumMessageIds = @[],
   )
 
 proc `$`*(self: Item): string =
@@ -339,6 +351,21 @@ proc `parsedText=`*(self: Item, value: seq[ParsedText]) {.inline.} =
 proc messageImage*(self: Item): string {.inline.} =
   self.messageImage
 
+proc albumId*(self: Item): string {.inline.} =
+  self.albumId
+
+proc albumMessageImages*(self: Item): seq[string] {.inline.} =
+  self.albumMessageImages
+
+proc `albumMessageImages=`*(self: Item, value: seq[string]) {.inline.} =
+  self.albumMessageImages = value
+
+proc albumMessageIds*(self: Item): seq[string] {.inline.} =
+  self.albumMessageIds
+
+proc `albumMessageIds=`*(self: Item, value: seq[string]) {.inline.} =
+  self.albumMessageIds = value
+
 proc messageContainsMentions*(self: Item): bool {.inline.} =
   self.messageContainsMentions
 
@@ -461,6 +488,9 @@ proc toJsonNode*(self: Item): JsonNode =
     "quotedMessageDeleted": self.quotedMessageDeleted,
     "quotedMessageAuthorDisplayName": self.quotedMessageAuthorDisplayName,
     "quotedMessageAuthorAvatar": self.quotedMessageAuthorAvatar,
+    "albumId": self.albumId,
+    "albumMessageImages": self.albumMessageImages,
+    "albumMessageIds": self.albumMessageIds,
   }
 
 proc editMode*(self: Item): bool {.inline.} =

--- a/src/app_service/service/chat/service.nim
+++ b/src/app_service/service/chat/service.nim
@@ -394,7 +394,7 @@ QtObject:
       error "Error deleting channel", chatId, msg = e.msg
       return
 
-  proc sendImages*(self: Service, chatId: string, imagePathsAndDataJson: string): string =
+  proc sendImages*(self: Service, chatId: string, imagePathsAndDataJson: string, msg: string): string =
     result = ""
     try:
       var images = Json.decode(imagePathsAndDataJson, seq[string])
@@ -430,7 +430,7 @@ QtObject:
 
         imagePaths.add(imagePath)
 
-      let response = status_chat.sendImages(chatId, imagePaths)
+      let response = status_chat.sendImages(chatId, imagePaths, msg)
 
       for imagePath in imagePaths:
         removeFile(imagePath)

--- a/src/app_service/service/message/dto/message.nim
+++ b/src/app_service/service/message/dto/message.nim
@@ -103,6 +103,7 @@ type MessageDto* = object
   ensName*: string
   sticker*: Sticker
   image*: string
+  albumId*: string
   gapParameters*: GapParameters
   timestamp*: int64
   contentType*: int
@@ -222,6 +223,7 @@ proc toMessageDto*(jsonObj: JsonNode): MessageDto =
   discard jsonObj.getProp("messageType", result.messageType)
   discard jsonObj.getProp("contactRequestState", result.contactRequestState)
   discard jsonObj.getProp("image", result.image)
+  discard jsonObj.getProp("albumId", result.albumId)
   discard jsonObj.getProp("editedAt", result.editedAt)
   discard jsonObj.getProp("deleted", result.deleted)
   discard jsonObj.getProp("deletedForMe", result.deletedForMe)

--- a/src/backend/chat.nim
+++ b/src/backend/chat.nim
@@ -75,7 +75,7 @@ proc sendChatMessage*(
     }
   ])
 
-proc sendImages*(chatId: string, images: var seq[string]): RpcResponse[JsonNode] {.raises: [Exception].} =
+proc sendImages*(chatId: string, images: var seq[string], msg: string): RpcResponse[JsonNode] {.raises: [Exception].} =
   let imagesJson = %* images.map(image => %*
       {
         "chatId": chatId,
@@ -83,7 +83,7 @@ proc sendImages*(chatId: string, images: var seq[string]): RpcResponse[JsonNode]
         "imagePath": image,
         # TODO is this still needed
         # "ensName": preferredUsername,
-        "text": "🖼️"
+        "text": msg
       }
     )
   callPrivateRPC("sendChatMessages".prefix, %* [imagesJson])

--- a/test/nim/message_model_test.nim
+++ b/test/nim/message_model_test.nim
@@ -49,6 +49,9 @@ proc createTestMessageItem(id: string, clock: int64): Item =
     quotedMessageDeleted = false,
     quotedMessageDiscordMessage = DiscordMessage(),
     quotedMessageAuthorDetails = ContactDetails(),
+    albumId = "",
+    albumMessageImages = @[],
+    albumMessageIds = @[],
   )
 
 let message0_chatIdentifier = createTestMessageItem("chat-identifier", -2)

--- a/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
@@ -275,7 +275,9 @@ Control {
                     Loader {
                         active: root.messageDetails.contentType === StatusMessage.ContentType.Image && !editMode
                         visible: active
+
                         sourceComponent: Column {
+                            id: imagesColumn
                             spacing: 8
                             Loader {
                                 active: root.messageDetails.messageText !== ""
@@ -288,13 +290,46 @@ Control {
                                 }
                             }
 
+                            Loader {
+                                active: true
+                                sourceComponent: messageDetails.album.length > 1 ? albumComp : imageComp
+                            }
+
+                        }
+
+                        Component {
+                            id: imageComp
                             StatusImageMessage {
                                 source: root.messageDetails.messageContent
                                 onClicked: root.imageClicked(image, mouse, imageSource)
                                 shapeType: root.messageDetails.amISender ? StatusImageMessage.ShapeType.RIGHT_ROUNDED : StatusImageMessage.ShapeType.LEFT_ROUNDED
                             }
                         }
+
+                        Component {
+                            id: albumComp
+                            RowLayout {
+                                width: messageLayout.width
+                                spacing: 9
+                                Repeater {
+                                    model: root.messageDetails.album
+                                    StatusImageMessage {
+                                        Layout.alignment: Qt.AlignLeft
+                                        imageWidth: Math.min(parent.width / root.messageDetails.album.length - 9 * (root.messageDetails.album.length - 1), 144)
+                                        source: modelData
+                                        onClicked: root.imageClicked(image, mouse, imageSource)
+                                        shapeType: root.messageDetails.amISender ? StatusImageMessage.ShapeType.RIGHT_ROUNDED : StatusImageMessage.ShapeType.LEFT_ROUNDED
+                                    }
+                                }
+
+                                Item {
+                                    Layout.fillWidth: true
+                                    Layout.fillHeight: true
+                                }
+                            }
+                        }
                     }
+
                     Loader {
                         active: root.messageAttachments && !editMode
                         visible: active

--- a/ui/StatusQ/src/StatusQ/Components/StatusMessageDetails.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusMessageDetails.qml
@@ -12,4 +12,5 @@ QtObject {
     property string messageText: ""
     property string messageContent: ""
     property string messageOriginInfo: ""
+    property var album: []
 }

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -167,26 +167,31 @@ QtObject {
         const chatContentModule = chatCommunitySectionModule.getChatContentModule()
         var result = false
 
-        if (fileUrlsAndSources.length > 0){
-            chatContentModule.inputAreaModule.sendImages(JSON.stringify(fileUrlsAndSources))
-            result = true
-        }
+        let textMsg = globalUtils.plainText(StatusQUtils.Emoji.deparse(text))
+        if (textMsg.trim() !== "") {
+            textMsg = interpretMessage(textMsg)
 
-        let msg = globalUtils.plainText(StatusQUtils.Emoji.deparse(text))
-        if (msg.trim() !== "") {
-            msg = interpretMessage(msg)
-
-            chatContentModule.inputAreaModule.sendMessage(
-                        msg,
-                        replyMessageId,
-                        Utils.isOnlyEmoji(msg) ? Constants.messageContentType.emojiType : Constants.messageContentType.messageType,
-                        false)
-
-            if (event)
+            if (event) {
                 event.accepted = true
-
-            result = true
+            }
         }
+
+        if (fileUrlsAndSources.length > 0) {
+            chatContentModule.inputAreaModule.sendImages(JSON.stringify(fileUrlsAndSources), textMsg.trim())
+            result = true
+
+        } else {
+            if (textMsg.trim() !== "") {
+                chatContentModule.inputAreaModule.sendMessage(
+                            textMsg,
+                            replyMessageId,
+                            Utils.isOnlyEmoji(textMsg) ? Constants.messageContentType.emojiType : Constants.messageContentType.messageType,
+                            false)
+
+                result = true
+            }
+        }
+
         return result
     }
 

--- a/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
@@ -243,6 +243,7 @@ Item {
             messageText: model.messageText
             unparsedText: model.unparsedText
             messageImage: model.messageImage
+            album: model.albumMessageImages.split(" ")
             messageTimestamp: model.timestamp
             messageOutgoingStatus: model.outgoingStatus
             resendError: model.resendError

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -76,6 +76,8 @@ Loader {
     property bool quotedMessageAuthorDetailsIsContact: false
     property var quotedMessageAuthorDetailsColorHash
 
+    property var album: []
+
     // External behavior changers
     property bool isInPinnedPopup: false // The pinned popup limits the number of buttons shown
     property bool disableHover: false // Used to force the HoverHandler to be active (useful for messages in popups)
@@ -570,6 +572,7 @@ Loader {
                         case StatusMessage.ContentType.Sticker:
                             return root.sticker;
                         case StatusMessage.ContentType.Image:
+
                             return root.messageImage;
                         }
                         if (root.isDiscordMessage && root.messageImage != "") {
@@ -577,6 +580,7 @@ Loader {
                         }
                         return "";
                     }
+                    album: root.album
 
                     amISender: root.amISender
                     sender.id: root.senderIsEnsVerified ? "" :  Utils.getCompressedPk(root.senderId)


### PR DESCRIPTION
Fixes: #9564 #6374

### What does the PR do

Changes:
- User may send images without any text
- Display images album
- User may send images in one message

Relevant [status-go pr](https://github.com/status-im/status-go/pull/3287)

### Affected areas

Chat

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![Снимок экрана 2023-03-13 в 15 45 31](https://user-images.githubusercontent.com/82511785/224706213-f0b47075-73cc-4a9d-bed8-29538a79c9c7.png)

