### PR TITLE
ci(e2e): Updated squish version from 6.7.2 to 7.1-SNAPSHOT

### DIFF
--- a/ci/Jenkinsfile.e2e
+++ b/ci/Jenkinsfile.e2e
@@ -139,7 +139,7 @@ pipeline {
               '--config', 'addAUT', 'nim_status_client',
               "${WORKSPACE}/bin",
             ].join('\n'),
-            squishPackageName: 'squish-6.7.2-qt514x-linux64',
+            squishPackageName: 'squish-7.1-20230222-1555-qt515x-linux64',
             testSuite: "${WORKSPACE}/test/ui-test/testSuites/*",
           ])
           print("Squish run result: ${result}")

--- a/test/ui-test/README.md
+++ b/test/ui-test/README.md
@@ -28,7 +28,19 @@ Now you should be able to create new suites, test cases and run the existing one
 | 5.15.2 | 7.0.1 | 5.15 | KO | KO |
 | 5.15.2 | 7.1.0 | 5.14 | KO | KO |
 | 5.15.2 | 7.1.0 | 5.15 | KO | KO |
+| 5.15.2 | 7.1.-20230222-1555 (SNAPSHOT) | 5.15 | OK | OK (manual extension removal*) |
 
-NOTE: KO means the test execution hangs on `squish.waitForObject()` or `squish.findObject()`. Seen this behaviour particularly in `Onboarding / Create Password Screen`. 
+*NOTE 1*: KO means the test execution hangs on `squish.waitForObject()` or `squish.findObject()`. Seen this behaviour particularly in `Onboarding / Create Password Screen`. 
 
-Last status app tested: Master branch - Commit: `5f4000b7a57cd5c268c3ebf847e2b3ef1a8ff96a`
+*NOTE 2*: The `7.1-SNAPSHOT` version for `linux` needs a manual interaction (if not the app crashes when the test execution starts). It is needed to rename library in:
+
+SQUISHDIR\lib\extensions
+
+     squishqtwaylandcompositor.ext
+
+to
+
+     squishqtwaylandcompositor_off.ext
+
+
+Last status app tested: Master branch - Commit: `d31acbfb48fe7027657a08c648836d9a8f11240c`


### PR DESCRIPTION
### What does the PR do

- Updated squish version from `6.7.2` to `7.1-SNAPSHOT`. 

Related information: https://github.com/status-im/status-desktop/issues/9451#issuecomment-1453391615

### Affected areas

CI / e2e job
