### PR TITLE
fix(messaging): Sync with status-go content type enum

### DIFF
--- a/src/app_service/common/types.nim
+++ b/src/app_service/common/types.nim
@@ -14,7 +14,7 @@ type
     Audio = 8
     Community = 9
     Gap = 10
-    Edit = 11
+    ContactRequest = 11
     DiscordMessage = 12
     ContactIdentityVerification = 13
 

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -109,7 +109,7 @@ Loader {
     property bool isStatusMessage: messageContentType === Constants.messageContentType.systemMessagePrivateGroupType
     property bool isSticker: messageContentType === Constants.messageContentType.stickerType
     property bool isDiscordMessage: messageContentType === Constants.messageContentType.discordMessageType
-    property bool isText: messageContentType === Constants.messageContentType.messageType || messageContentType === Constants.messageContentType.editType || isDiscordMessage
+    property bool isText: messageContentType === Constants.messageContentType.messageType || messageContentType === Constants.messageContentType.contactRequestType || isDiscordMessage
     property bool isMessage: isEmoji || isImage || isSticker || isText || isAudio
                              || messageContentType === Constants.messageContentType.communityInviteType || messageContentType === Constants.messageContentType.transactionType
 
@@ -249,6 +249,7 @@ Loader {
 
         function convertContentType(value) {
             switch (value) {
+            case Constants.messageContentType.contactRequestType:
             case Constants.messageContentType.messageType:
                 return StatusMessage.ContentType.Text;
             case Constants.messageContentType.stickerType:
@@ -271,7 +272,6 @@ Loader {
             case Constants.messageContentType.statusType:
             case Constants.messageContentType.systemMessagePrivateGroupType:
             case Constants.messageContentType.gapType:
-            case Constants.messageContentType.editType:
             default:
                 return StatusMessage.ContentType.Unknown;
             }

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -404,7 +404,7 @@ QtObject {
         readonly property int audioType: 8
         readonly property int communityInviteType: 9
         readonly property int gapType: 10
-        readonly property int editType: 11
+        readonly property int contactRequestType: 11
         readonly property int discordMessageType: 12
     }
 


### PR DESCRIPTION
Fixes: #9655

### What does the PR do

Rename `Edit` type to `ContactRequest` and use it type as Text message

### Affected areas

Chat

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

- [ ] I've checked the design and this PR matches it

<img width="1054" alt="Снимок экрана 2023-03-07 в 18 15 51" src="https://user-images.githubusercontent.com/82511785/223419509-a8d03f21-5a6f-4c6f-9151-128650c4d69e.png">

