### PR TITLE
chore(CommunityPermissions): refactor access to stores in CP components 

### DIFF
--- a/storybook/pages/CommunityNewPermissionViewPage.qml
+++ b/storybook/pages/CommunityNewPermissionViewPage.qml
@@ -3,7 +3,6 @@ import QtQuick.Controls 2.14
 import QtQuick.Layouts 1.14
 
 import AppLayouts.Chat.views.communities 1.0
-import AppLayouts.Chat.stores 1.0
 
 import Storybook 1.0
 import Models 1.0
@@ -15,8 +14,6 @@ SplitView {
     Logs { id: logs }
 
     Pane {
-        id: root
-
         SplitView.fillWidth: true
         SplitView.fillHeight: true
 
@@ -27,48 +24,21 @@ SplitView {
 
             isEditState: isEditStateCheckBox.checked
             isPrivate: isPrivateCheckBox.checked
+            isOwner: isOwnerCheckBox.checked
             duplicationWarningVisible: isDuplicationWarningVisibleCheckBox.checked
 
-            store: CommunitiesStore {
-                readonly property var assetsModel: AssetsModel {}
-                readonly property var collectiblesModel: CollectiblesModel {}
-                readonly property var channelsModel: ChannelsModel {}
-                readonly property var permissionConflict: QtObject {
-                    property bool exists: true
-                    property string holdings: "1 ETH"
-                    property string permissions: "View and Post"
-                    property string channels: "#general"
+            assetsModel: AssetsModel {}
+            collectiblesModel: CollectiblesModel {}
+            channelsModel: ChannelsModel {}
 
-                }
-
-                readonly property bool isOwner: isOwnerCheckBox.checked
-
-                function createPermission(holdings, permissions, isPrivate, channels) {
-                    logs.logEvent("CommunitiesStore::creatPermission")
-                }
-
-                function editPermission(key, holdings, permissions, channels, isPrivate) {
-                    logs.logEvent("CommunitiesStore::editPermission - key: " + key)
-                }
-
-                function removePermission(key) {
-                    logs.logEvent("CommunitiesStore::removePermission - key: " + key)
-                }
+            communityDetails: QtObject {
+                readonly property string name: "Socks"
+                readonly property string image: ModelsData.icons.socks
+                readonly property string color: "red"
             }
 
-            rootStore: QtObject {
-                readonly property QtObject chatCommunitySectionModule: QtObject {
-                    readonly property var model: ChannelsModel {}
-                }
-
-                readonly property QtObject mainModuleInst: QtObject {
-
-                    readonly property QtObject activeSection: QtObject {
-                        readonly property string name: "Socks"
-                        readonly property string image: ModelsData.icons.socks
-                        readonly property string color: "red"
-                    }
-                }
+            onCreatePermissionClicked: {
+                logs.logEvent("CommunityNewPermissionView::onCreatePermissionClicked")
             }
         }
     }
@@ -81,9 +51,7 @@ SplitView {
 
         logsView.logText: logs.logText
 
-
         ColumnLayout {
-
             anchors.top: parent.top
             anchors.left: parent.left
             anchors.right: parent.right

--- a/storybook/pages/CommunityPermissionsSettingsPanelPage.qml
+++ b/storybook/pages/CommunityPermissionsSettingsPanelPage.qml
@@ -3,7 +3,6 @@ import QtQuick.Controls 2.14
 import QtQuick.Layouts 1.14
 
 import AppLayouts.Chat.panels.communities 1.0
-import AppLayouts.Chat.stores 1.0
 import StatusQ.Core.Theme 0.1
 import StatusQ.Core.Utils 0.1
 
@@ -17,6 +16,51 @@ SplitView {
 
     Logs { id: logs }
 
+    QtObject {
+        id: permissionsStoreMock
+
+        readonly property ListModel permissionsModel: ListModel {}
+
+        readonly property QtObject _d: QtObject {
+            id: d
+
+            property int keyCounter: 0
+
+            function createPermissionEntry(holdings, permissionType, isPrivate,
+                                           channels) {
+                const permission = {
+                    holdingsListModel: holdings,
+                    channelsListModel: channels,
+                    permissionType,
+                    isPrivate
+                }
+
+                return permission
+            }
+        }
+
+        function createPermission(holdings, permissionType, isPrivate, channels) {
+            const permissionEntry = d.createPermissionEntry(
+                                      holdings, permissionType, isPrivate, channels)
+
+            permissionEntry.key = "" + d.keyCounter++
+            permissionsModel.append(permissionEntry)
+        }
+
+        function editPermission(key, holdings, permissionType, channels, isPrivate) {
+            const permissionEntry = d.createPermissionEntry(
+                                      holdings, permissionType, isPrivate, channels)
+
+            const index = ModelUtils.indexOf(permissionsModel, "key", key)
+            permissionsModel.set(index, permissionEntry)
+        }
+
+        function removePermission(key) {
+            const index = ModelUtils.indexOf(permissionsModel, "key", key)
+            permissionsModel.remove(index)
+        }
+    }
+
     Rectangle {
         SplitView.fillWidth: true
         SplitView.fillHeight: true
@@ -25,92 +69,32 @@ SplitView {
         CommunityPermissionsSettingsPanel {
             id: communityPermissionsSettingsPanel
 
-            anchors {
-                fill: parent
-                topMargin: 50
-            }
-            store: CommunitiesStore {
-                readonly property bool isOwner: isOwnerCheckBox.checked
+            anchors.fill: parent
+            anchors.topMargin: 50
 
-                property var permissionConflict: QtObject { // Backend conflicts object model assignment. Now mocked data.
-                    property bool exists: false
-                    property string holdings: qsTr("1 ETH")
-                    property string permissions: qsTr("View and Post")
-                    property string channels: qsTr("#general")
+            permissionsModel: permissionsStoreMock.permissionsModel
+            assetsModel: AssetsModel {}
+            collectiblesModel: CollectiblesModel {}
+            channelsModel: ChannelsModel {}
 
-                }
+            isOwner: isOwnerCheckBox.checked
 
-                readonly property var permissionsModel: ListModel {}
-                readonly property var assetsModel: AssetsModel {}
-                readonly property var collectiblesModel: CollectiblesModel {}
-                readonly property var channelsModel: ListModel {
-                    Component.onCompleted: {
-                        append([
-                            {
-                                key: "welcome",
-                                iconSource: ModelsData.assets.inch,
-                                name: "#welcome"
-                            },
-                            {
-                                key: "general",
-                                iconSource: ModelsData.assets.inch,
-                                name: "#general"
-                            }
-                        ])
-                    }
-                }
-
-                readonly property QtObject _d: QtObject {
-                    id: d
-
-                    property int keyCounter: 0
-
-                    function createPermissionEntry(holdings, permissionType, isPrivate, channels) {
-                        const permission = {
-                            holdingsListModel: holdings,
-                            channelsListModel: channels,
-                            permissionType,
-                            isPrivate
-                        }
-
-                        return permission
-                    }
-                }
-
-                function createPermission(holdings, permissionType, isPrivate, channels, index = null) {
-                    const permissionEntry = d.createPermissionEntry(
-                                              holdings, permissionType, isPrivate, channels)
-
-                    permissionEntry.key = "" + d.keyCounter++
-                    permissionsModel.append(permissionEntry)
-                }
-
-                function editPermission(key, holdings, permissionType, channels, isPrivate) {
-                    const permissionEntry = d.createPermissionEntry(
-                                              holdings, permissionType, isPrivate, channels)
-
-                    const index = ModelUtils.indexOf(permissionsModel, "key", key)
-                    permissionsModel.set(index, permissionEntry)
-                }
-
-                function removePermission(key) {
-                    const index = ModelUtils.indexOf(permissionsModel, "key", key)
-                    permissionsModel.remove(index)
-                }
+            onCreatePermissionRequested: {
+                permissionsStoreMock.createPermission(holdings, permissionType,
+                                                      isPrivate, channels)
             }
 
-            rootStore: QtObject {
-                readonly property QtObject chatCommunitySectionModule: QtObject {
-                    readonly property var model: ChannelsModel {}
-                }
+            onUpdatePermissionRequested:
+                permissionsStoreMock.editPermission(key, holdings, permissionType,
+                                                    channels, isPrivate)
 
-                readonly property QtObject mainModuleInst: QtObject {
-                    readonly property QtObject activeSection: QtObject {
-                        readonly property string name: "Socks"
-                        readonly property string image: ModelsData.icons.socks
-                        readonly property string color: "red"
-                    }
-                }
+            onRemovePermissionRequested:
+                permissionsStoreMock.removePermission(key)
+
+            communityDetails: QtObject {
+                readonly property string name: "Socks"
+                readonly property string image: ModelsData.icons.socks
+                readonly property string color: "red"
             }
         }
     }

--- a/storybook/pages/CommunityPermissionsViewPage.qml
+++ b/storybook/pages/CommunityPermissionsViewPage.qml
@@ -1,13 +1,13 @@
-import QtQuick 2.14
-import QtQuick.Controls 2.14
+import QtQuick 2.15
+import QtQuick.Controls 2.15
 
-import AppLayouts.Chat.views.communities 1.0
-import AppLayouts.Chat.stores 1.0
-
-import Storybook 1.0
-import Models 1.0
 import StatusQ.Core.Theme 0.1
 import StatusQ.Core.Utils 0.1
+
+import AppLayouts.Chat.views.communities 1.0
+
+import Models 1.0
+import Storybook 1.0
 
 
 SplitView {
@@ -28,44 +28,37 @@ SplitView {
                     margins: 50
                 }
 
-                store: CommunitiesStore {
-                    id: mockedCommunity
+                permissionsModel: ListModel {
+                    id: permissionsModel
 
-                    readonly property ListModel permissionsModel: ListModel {
-                        Component.onCompleted: append(PermissionsModel.permissionsModelData)
-                    }
-
-                    readonly property AssetsModel assetsModel: AssetsModel {
-                        id: assetsModel
-                    }
-
-                    readonly property CollectiblesModel collectiblesModel: CollectiblesModel {
-                        id: collectiblesModel
-                    }
+                    Component.onCompleted: append(PermissionsModel.permissionsModelData)
                 }
 
-                rootStore: QtObject {
-                    readonly property QtObject chatCommunitySectionModule: QtObject {
-                        readonly property var model: ChannelsModel {
-                            id: channelsModel
-                        }
-                    }
-
-                    readonly property QtObject mainModuleInst: QtObject {
-                        readonly property QtObject activeSection: QtObject {
-                            readonly property string name: "Socks"
-                            readonly property string image: ModelsData.icons.socks
-                            readonly property string color: "red"
-                        }
-                    }
+                assetsModel: AssetsModel {
+                    id: assetsModel
                 }
 
-                onEditPermissionRequested:
-                    logs.logEvent("CommunityPermissionsView::editPermissionRequested - index: " + index)
-                onRemovePermissionRequested:
-                    logs.logEvent("CommunityPermissionsView::removePermissionRequested - index: " + index)
-                onDuplicatePermissionRequested:
-                    logs.logEvent("CommunityPermissionsView::duplicatePermissionRequested - index: " + index)
+                collectiblesModel: CollectiblesModel {
+                    id: collectiblesModel
+                }
+
+                channelsModel: ChannelsModel {
+                    id: channelsModel
+                }
+
+                communityDetails: QtObject {
+                    readonly property string name: "Socks"
+                    readonly property string image: ModelsData.icons.socks
+                    readonly property string color: "red"
+                }
+
+                function log(method, index) {
+                    logs.logEvent(`CommunityPermissionsView::${method} - index: ${index}`)
+                }
+
+                onEditPermissionRequested: log("editPermissionRequested", index)
+                onRemovePermissionRequested: log("removePermissionRequested", index)
+                onDuplicatePermissionRequested: log("duplicatePermissionRequested", index)
             }
         }
 
@@ -85,7 +78,7 @@ SplitView {
 
         CommunityPermissionsSettingsPanelEditor {
             anchors.fill: parent
-            model: mockedCommunity.permissionsModel
+            model: permissionsModel
 
             assetKeys: assetsModel.data.map(asset => asset.key)
             collectibleKeys: collectiblesModel.data.map(collectible => collectible.key)

--- a/ui/app/AppLayouts/Chat/controls/community/InDropdown.qml
+++ b/ui/app/AppLayouts/Chat/controls/community/InDropdown.qml
@@ -18,7 +18,7 @@ StatusDropdown {
 
     property string communityName
     property string communityImage
-    property color communityColor
+    property string communityColor
 
     property var model
 

--- a/ui/app/AppLayouts/Chat/panels/communities/CommunityPermissionsSettingsPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/CommunityPermissionsSettingsPanel.qml
@@ -52,7 +52,7 @@ SettingsPageLayout {
         readonly property string newPermissionViewState: "NEW_PERMISSION"
         readonly property string permissionsViewState: "PERMISSIONS"
         readonly property string editPermissionViewState: "EDIT_PERMISSION"
-        readonly property bool permissionsExist: permissionsModel.count > 0
+        readonly property bool permissionsExist: root.permissionsModel.count > 0
 
         signal saveChanges
         signal resetChanges

--- a/ui/app/AppLayouts/Chat/stores/CommunitiesStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/CommunitiesStore.qml
@@ -1,67 +1,10 @@
 import QtQuick 2.15
 
-import AppLayouts.Chat.controls.community 1.0
-
-import StatusQ.Core.Utils 0.1
 
 QtObject {
     id: root
 
-    property var mainModuleInst: mainModule
-    property var communitiesModuleInst: communitiesModule
-    readonly property bool isOwner: false
-
     property var mintingModuleInst: mintingModule ?? null
-
-    property var permissionConflict: QtObject { // Backend conflicts object model assignment. Now mocked data.
-        property bool exists: false
-        property string holdings: qsTr("1 ETH")
-        property string permissions: qsTr("View and Post")
-        property string channels: qsTr("#general")
-    }
-
-    property var assetsModel: chatCommunitySectionModule.tokenList
-    property var collectiblesModel: chatCommunitySectionModule.collectiblesModel
-
-    // TODO: Replace to real data, now dummy model
-    property var  channelsModel: ListModel {
-        ListElement { key: "welcome"; iconSource: "qrc:imports/assets/png/tokens/CUSTOM-TOKEN.png"; name: "#welcome"}
-        ListElement { key: "general"; iconSource: "qrc:imports/assets/png/tokens/CUSTOM-TOKEN.png"; name: "#general"}
-    }
-
-    readonly property QtObject _d: QtObject {
-        id: d
-
-        property int keyCounter: 0
-
-        function createPermissionEntry(holdings, permissionType, isPrivate, channels) {
-            const permission = {
-                holdingsListModel: holdings,
-                channelsListModel: channels,
-                permissionType,
-                isPrivate
-            }
-
-            return permission
-        }
-    }
-
-    function createPermission(holdings, permissionType, isPrivate, channels, index = null) {
-        const permissionEntry = d.createPermissionEntry(
-                                  holdings, permissionType, isPrivate, channels)
-        chatCommunitySectionModule.createOrEditCommunityTokenPermission(root.mainModuleInst.activeSection.id, "", permissionEntry.permissionType, JSON.stringify(permissionEntry.holdingsListModel), permissionEntry.isPrivate)
-    }
-
-    function editPermission(key, holdings, permissionType, channels, isPrivate) {
-        const permissionEntry = d.createPermissionEntry(
-                                  holdings, permissionType, isPrivate, channels)
-
-        chatCommunitySectionModule.createOrEditCommunityTokenPermission(root.mainModuleInst.activeSection.id, key, permissionEntry.permissionType, JSON.stringify(permissionEntry.holdingsListModel), permissionEntry.isPrivate)
-    }
-
-    function removePermission(key) {
-        chatCommunitySectionModule.deleteCommunityTokenPermission(root.mainModuleInst.activeSection.id, key)
-    }
 
     // Minting tokens:
     function mintCollectible(communityId, address, artworkSource, name, symbol, description, supply,

--- a/ui/app/AppLayouts/Chat/stores/PermissionsStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/PermissionsStore.qml
@@ -1,0 +1,50 @@
+import QtQml 2.15
+
+QtObject {
+    id: root
+
+    required property string activeSectionId
+    required property var chatCommunitySectionModuleInst
+
+    readonly property var permissionsModel:
+        chatCommunitySectionModuleInst.permissionsModel
+
+    readonly property bool isOwner: false
+
+    readonly property QtObject _d: QtObject {
+        id: d
+
+        function createPermissionEntry(holdings, permissionType, isPrivate,
+                                       channels) {
+            return {
+                holdingsListModel: holdings,
+                channelsListModel: channels,
+                permissionType,
+                isPrivate
+            }
+        }
+
+        function createOrEdit(key, holdings, permissionType, isPrivate,
+                              channels) {
+
+            root.chatCommunitySectionModuleInst.createOrEditCommunityTokenPermission(
+                        root.activeSectionId, key,
+                        permissionType,
+                        JSON.stringify(holdings),
+                        isPrivate)
+        }
+    }
+
+    function createPermission(holdings, permissionType, isPrivate, channels) {
+        d.createOrEdit("", holdings, permissionType, isPrivate, channels)
+    }
+
+    function editPermission(key, holdings, permissionType, channels, isPrivate) {
+        d.createOrEdit(key, holdings, permissionType, isPrivate, channels)
+    }
+
+    function removePermission(key) {
+        root.chatCommunitySectionModuleInst.deleteCommunityTokenPermission(
+                    root.activeSectionId, key)
+    }
+}

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -9,6 +9,11 @@ QtObject {
 
     property var contactsStore
 
+    readonly property PermissionsStore permissionsStore: PermissionsStore {
+        activeSectionId: mainModuleInst.activeSection.id
+        chatCommunitySectionModuleInst: chatCommunitySectionModule
+    }
+
     property bool openCreateChat: false
     property string createChatInitMessage: ""
     property var createChatFileUrls: []
@@ -165,7 +170,6 @@ QtObject {
         stickersModule: stickersModuleInst
     }
 
-    property var permissionsModel: chatCommunitySectionModule.permissionsModel
     property var assetsModel: chatCommunitySectionModule.tokenList
     property var collectiblesModel: chatCommunitySectionModule.collectiblesModel
 

--- a/ui/app/AppLayouts/Chat/stores/qmldir
+++ b/ui/app/AppLayouts/Chat/stores/qmldir
@@ -1,5 +1,6 @@
+CommunitiesStore 1.0 CommunitiesStore.qml
+PermissionsStore 1.0 PermissionsStore.qml
+RootStore 1.0 RootStore.qml
 StickerData 1.0 StickerData.qml
 StickerPackData 1.0 StickerPackData.qml
 StickersStore 1.0 StickersStore.qml
-CommunitiesStore 1.0 CommunitiesStore.qml
-RootStore 1.0 RootStore.qml

--- a/ui/app/AppLayouts/Chat/views/CommunitySettingsView.qml
+++ b/ui/app/AppLayouts/Chat/views/CommunitySettingsView.qml
@@ -247,8 +247,33 @@ StatusSectionLayout {
             }
 
             CommunityPermissionsSettingsPanel {
-                rootStore: root.rootStore
-                store: root.communityStore
+                readonly property PermissionsStore permissionsStore:
+                    rootStore.permissionsStore
+
+                permissionsModel: permissionsStore.permissionsModel
+                assetsModel: rootStore.assetsModel
+                collectiblesModel: rootStore.collectiblesModel
+                channelsModel: rootStore.chatCommunitySectionModule.model
+
+                communityDetails: QtObject {
+                    readonly property var _activeSection:
+                        rootStore.mainModuleInst.activeSection
+
+                    readonly property string name: _activeSection.name
+                    readonly property string image: _activeSection.image
+                    readonly property string color: _activeSection.color
+                }
+
+                onCreatePermissionRequested:
+                    permissionsStore.createPermission(holdings, permissionType,
+                                                      isPrivate, channels)
+
+                onUpdatePermissionRequested:
+                    permissionsStore.editPermission(
+                        key, holdings, permissionType, channels, isPrivate)
+
+                onRemovePermissionRequested:
+                    permissionsStore.removePermission(key)
 
                 onPreviousPageNameChanged: root.backButtonName = previousPageName
             }

--- a/ui/app/AppLayouts/Chat/views/communities/CommunityPermissionsView.qml
+++ b/ui/app/AppLayouts/Chat/views/communities/CommunityPermissionsView.qml
@@ -68,7 +68,7 @@ StatusScrollView {
                 ChannelsSelectionModel {
                     id: channelsSelectionModel
 
-                    sourceModel: model.channelsListModel
+                    sourceModel: model.channelsListModel ?? null
                     channelsModel: root.channelsModel
                 }
 

--- a/ui/app/AppLayouts/Chat/views/communities/CommunityPermissionsView.qml
+++ b/ui/app/AppLayouts/Chat/views/communities/CommunityPermissionsView.qml
@@ -2,21 +2,22 @@ import QtQuick 2.14
 import QtQuick.Layouts 1.14
 
 import StatusQ.Core 0.1
-import StatusQ.Core.Theme 0.1
-import StatusQ.Controls 0.1
 
 import SortFilterProxyModel 0.2
 import shared.popups 1.0
 
 import AppLayouts.Chat.controls.community 1.0
-import AppLayouts.Chat.helpers 1.0
-import AppLayouts.Chat.stores 1.0
 
 StatusScrollView {
     id: root
 
-    property var rootStore
-    required property CommunitiesStore store
+    required property var permissionsModel
+    required property var assetsModel
+    required property var collectiblesModel
+    required property var channelsModel
+
+    // name, image, color properties expected
+    required property var communityDetails
 
     property int viewWidth: 560 // by design
 
@@ -41,27 +42,25 @@ StatusScrollView {
         ListModel {
             id: communityItemModel
 
-            readonly property var communityData: rootStore.mainModuleInst.activeSection
-
             Component.onCompleted: {
                 append({
-                    text: communityData.name,
-                    imageSource: communityData.image,
-                    color: communityData.color
+                    text: root.communityDetails.name,
+                    imageSource: root.communityDetails.image,
+                    color: root.communityDetails.color
                 })
             }
         }
 
         Repeater {
-            model: root.rootStore.permissionsModel
+            model: root.permissionsModel
 
             delegate: PermissionItem {
                 Layout.preferredWidth: root.viewWidth
 
                 holdingsListModel: HoldingsSelectionModel {
                     sourceModel: model.holdingsListModel
-                    assetsModel: store.assetsModel
-                    collectiblesModel: store.collectiblesModel
+                    assetsModel: root.assetsModel
+                    collectiblesModel: root.collectiblesModel
                 }
 
                 permissionType: model.permissionType
@@ -70,7 +69,7 @@ StatusScrollView {
                     id: channelsSelectionModel
 
                     sourceModel: model.channelsListModel
-                    channelsModel: rootStore.chatCommunitySectionModule.model
+                    channelsModel: root.channelsModel
                 }
 
                 channelsListModel: channelsSelectionModel.count


### PR DESCRIPTION
### What does the PR do

So far CP components (views, panels) were accessing stores directly. Now `CommunitySettingsView` is a single place where stores are accessed. Other components no longer depend on stores.

Moreover:
- dedicated store `PermissionsStore` created for handling permissions in a single, separated place
- storybook pages fixed
- some warnings fixed

Closes: #9784
Iterates: https://github.com/status-im/status-desktop/issues/9663

Note: in the next step naming should be aligned for both community permissions and minting components.

### Affected areas
CommunityPermissions components
