### PR TITLE
refactor(ChatLayout): expose emoji and sticker popup properties and s…

### DIFF
--- a/ui/app/AppLayouts/Chat/ChatLayout.qml
+++ b/ui/app/AppLayouts/Chat/ChatLayout.qml
@@ -14,9 +14,12 @@ StackLayout {
     property RootStore rootStore
     readonly property var contactsStore: rootStore.contactsStore
 
-    property alias chatView: chatView
+    property var emojiPopup
+    property var stickersPopup
     signal importCommunityClicked()
     signal createCommunityClicked()
+    signal profileButtonClicked()
+    signal openAppSearch()
 
     onCurrentIndexChanged: {
         Global.closeCreateChatView()
@@ -36,6 +39,8 @@ StackLayout {
 
     ChatView {
         id: chatView
+        emojiPopup: root.emojiPopup
+        stickersPopup: root.stickersPopup
         contactsStore: root.contactsStore
         rootStore: root.rootStore
         membershipRequestPopup: membershipRequestPopupComponent
@@ -48,6 +53,12 @@ StackLayout {
         }
         onCreateCommunityClicked: {
             root.createCommunityClicked();
+        }
+        onProfileButtonClicked: {
+            root.profileButtonClicked()
+        }
+        onOpenAppSearch: {
+            root.openAppSearch()
         }
     }
 

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -771,14 +771,14 @@ Item {
                                 }
 
                                 rootStore: appMain.rootChatStore
-                                chatView.emojiPopup: statusEmojiPopup
-                                chatView.stickersPopup: statusStickersPopupLoader.item
+                                emojiPopup: statusEmojiPopup
+                                stickersPopup: statusStickersPopupLoader.item
 
-                                chatView.onProfileButtonClicked: {
+                                onProfileButtonClicked: {
                                     Global.changeAppSectionBySectionType(Constants.appSection.profile);
                                 }
 
-                                chatView.onOpenAppSearch: {
+                                onOpenAppSearch: {
                                     appSearch.openSearchPopup()
                                 }
 
@@ -876,16 +876,16 @@ Item {
                                             restoreMode: Binding.RestoreBindingOrValue
                                         }
 
-                                        chatView.emojiPopup: statusEmojiPopup
-                                        chatView.stickersPopup: statusStickersPopupLoader.item
+                                        emojiPopup: statusEmojiPopup
+                                        stickersPopup: statusStickersPopupLoader.item
 
                                         rootStore: appMain.rootChatStore
 
-                                        chatView.onProfileButtonClicked: {
+                                        onProfileButtonClicked: {
                                             Global.changeAppSectionBySectionType(Constants.appSection.profile);
                                         }
 
-                                        chatView.onOpenAppSearch: {
+                                        onOpenAppSearch: {
                                             appSearch.openSearchPopup()
                                         }
 


### PR DESCRIPTION
…ignals

Prior to this change `ChatLayout` exposed `chatView` which let other components access it, its properties and signals.

This is problematic as we need to be able to swap out the `ChatView` with the `JoinCommunityView` for token gated communities, in which case there won't be an instance of `chatView`.

This commit ensures that we rely purely on inputs and outputs of the component, without exposing the component instance itself.
