### PR TITLE
chore: fix qrc resource bloat

### DIFF
--- a/ui/generate-rcc.go
+++ b/ui/generate-rcc.go
@@ -24,7 +24,7 @@ var qrcExtensions = map[string]bool{
 	".qm":   true,
 	".txt":  true,
 	".gif":  true,
-	".json":  true,
+	".json": true,
 }
 
 func main() {
@@ -51,6 +51,9 @@ func main() {
 		func(path string, info os.FileInfo, err error) error {
 			if err != nil {
 				return err
+			}
+			if info.IsDir() && (info.Name() == "vendor" || info.Name() == "tests") {
+				return filepath.SkipDir
 			}
 			if !info.IsDir() {
 				ext := filepath.Ext(path)


### PR DESCRIPTION
let the `generate-rcc.go` skip files under `vendor` and `tests` subdirs; decreases the binary size and thus RAM usage by ~130 MB!

It became more pronounced recently with the import of `ui/StatusQ/vendor/qzxing` git submodule
```
$ ls -al resources.*
-rw-r--r--. 1 ltinkl ltinkl  81950109 Mar  8 14:47 resources.rcc
-rw-r--r--. 1 ltinkl ltinkl 215385428 Mar  8 12:35 resources.rcc.bloat
```

### What does the PR do

Reduces binary resources/app size

### Screenshot of functionality (including design for comparison)

- [N/A] I've checked the design and this PR matches it

