### PR TITLE
refactor(community-service): merge curatedCommunities in communities

### DIFF
--- a/src/app/modules/main/communities/controller.nim
+++ b/src/app/modules/main/communities/controller.nim
@@ -46,8 +46,8 @@ proc init*(self: Controller) =
     self.delegate.onImportCommunityErrorOccured(args.community.id, args.error)
 
   self.events.on(SIGNAL_CURATED_COMMUNITY_FOUND) do(e:Args):
-    let args = CuratedCommunityArgs(e)
-    self.delegate.curatedCommunityAdded(args.curatedCommunity)
+    let args = CommunityArgs(e)
+    self.delegate.curatedCommunityAdded(args.community)
 
   self.events.on(SIGNAL_COMMUNITY_ADDED) do(e:Args):
     let args = CommunityArgs(e)
@@ -64,7 +64,7 @@ proc init*(self: Controller) =
     let args = CommunitiesArgs(e)
     for community in args.communities:
       self.delegate.communityEdited(community)
-      self.delegate.curatedCommunityEdited(CuratedCommunity(communityId: community.id, available: true, community:community))
+      self.delegate.curatedCommunityEdited(community)
 
   self.events.on(SIGNAL_COMMUNITY_MUTED) do(e:Args):
     let args = CommunityMutedArgs(e)
@@ -97,8 +97,8 @@ proc init*(self: Controller) =
     self.delegate.curatedCommunitiesLoadingFailed()
 
   self.events.on(SIGNAL_CURATED_COMMUNITIES_LOADED) do(e:Args):
-    let args = CuratedCommunitiesArgs(e)
-    self.delegate.curatedCommunitiesLoaded(args.curatedCommunities)
+    let args = CommunitiesArgs(e)
+    self.delegate.curatedCommunitiesLoaded(args.communities)
 
 proc getCommunityTags*(self: Controller): string =
   result = self.communityService.getCommunityTags()
@@ -106,7 +106,7 @@ proc getCommunityTags*(self: Controller): string =
 proc getAllCommunities*(self: Controller): seq[CommunityDto] =
   result = self.communityService.getAllCommunities()
 
-proc getCuratedCommunities*(self: Controller): seq[CuratedCommunity] =
+proc getCuratedCommunities*(self: Controller): seq[CommunityDto] =
   result = self.communityService.getCuratedCommunities()
 
 proc spectateCommunity*(self: Controller, communityId: string): string =

--- a/src/app/modules/main/communities/io_interface.nim
+++ b/src/app/modules/main/communities/io_interface.nim
@@ -107,10 +107,10 @@ method communityEdited*(self: AccessInterface, community: CommunityDto) {.base.}
 method communityAdded*(self: AccessInterface, community: CommunityDto) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method curatedCommunityAdded*(self: AccessInterface, community: CuratedCommunity) {.base.} =
+method curatedCommunityAdded*(self: AccessInterface, community: CommunityDto) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method curatedCommunityEdited*(self: AccessInterface, community: CuratedCommunity) {.base.} =
+method curatedCommunityEdited*(self: AccessInterface, community: CommunityDto) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method communityImported*(self: AccessInterface, community: CommunityDto) {.base.} =
@@ -155,5 +155,5 @@ method curatedCommunitiesLoading*(self: AccessInterface) {.base.} =
 method curatedCommunitiesLoadingFailed*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method curatedCommunitiesLoaded*(self: AccessInterface, curatedCommunities: seq[CuratedCOmmunity]) {.base.} =
+method curatedCommunitiesLoaded*(self: AccessInterface, curatedCommunities: seq[CommunityDto]) {.base.} =
   raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/communities/module.nim
+++ b/src/app/modules/main/communities/module.nim
@@ -46,7 +46,7 @@ type
 # Forward declaration
 method setCommunityTags*(self: Module, communityTags: string)
 method setAllCommunities*(self: Module, communities: seq[CommunityDto])
-method setCuratedCommunities*(self: Module, curatedCommunities: seq[CuratedCommunity])
+method setCuratedCommunities*(self: Module, curatedCommunities: seq[CommunityDto])
 
 proc newModule*(
     delegate: delegate_interface.AccessInterface,
@@ -89,7 +89,6 @@ method viewDidLoad*(self: Module) =
 
   self.setCommunityTags(self.controller.getCommunityTags())
   self.setAllCommunities(self.controller.getAllCommunities())
-  self.setCuratedCommunities(self.controller.getCuratedCommunities())
 
   self.delegate.communitiesModuleDidLoad()
 
@@ -98,7 +97,7 @@ method onActivated*(self: Module) =
     return
   self.controller.asyncLoadCuratedCommunities()
 
-method curatedCommunitiesLoaded*(self: Module, curatedCommunities: seq[CuratedCOmmunity]) =
+method curatedCommunitiesLoaded*(self: Module, curatedCommunities: seq[CommunityDto]) =
   self.curatedCommunitiesLoaded = true
   self.setCuratedCommunities(curatedCommunities)
   self.view.setCuratedCommunitiesLoading(false)
@@ -167,17 +166,17 @@ method getCommunityItem(self: Module, c: CommunityDto): SectionItem =
       communityTokens = self.controller.getCommunityTokens(c.id)
     )
 
-method getCuratedCommunityItem(self: Module, c: CuratedCommunity): CuratedCommunityItem =
+method getCuratedCommunityItem(self: Module, c: CommunityDto): CuratedCommunityItem =
   return initCuratedCommunityItem(
-      c.communityId,
-      c.community.name,
-      c.community.description,
-      c.available,
-      c.community.images.thumbnail,
-      c.community.images.banner,
-      c.community.color,
-      c.community.tags,
-      len(c.community.members))
+      c.id,
+      c.name,
+      c.description,
+      c.isAvailable,
+      c.images.thumbnail,
+      c.images.banner,
+      c.color,
+      c.tags,
+      len(c.members))
 
 method getDiscordCategoryItem(self: Module, c: DiscordCategoryDto): DiscordCategoryItem =
   return initDiscordCategoryItem(
@@ -218,14 +217,14 @@ method communityEdited*(self: Module, community: CommunityDto) =
   self.view.model().editItem(self.getCommunityItem(community))
   self.view.communityChanged(community.id)
 
-method setCuratedCommunities*(self: Module, curatedCommunities: seq[CuratedCommunity]) =
+method setCuratedCommunities*(self: Module, curatedCommunities: seq[CommunityDto]) =
   for community in curatedCommunities:
     self.view.curatedCommunitiesModel().addItem(self.getCuratedCommunityItem(community))
 
-method curatedCommunityAdded*(self: Module, community: CuratedCommunity) =
+method curatedCommunityAdded*(self: Module, community: CommunityDto) =
   self.view.curatedCommunitiesModel().addItem(self.getCuratedCommunityItem(community))
 
-method curatedCommunityEdited*(self: Module, community: CuratedCommunity) =
+method curatedCommunityEdited*(self: Module, community: CommunityDto) =
   self.view.curatedCommunitiesModel().addItem(self.getCuratedCommunityItem(community))
 
 method requestAdded*(self: Module) =

--- a/src/app_service/service/community/async_tasks.nim
+++ b/src/app_service/service/community/async_tasks.nim
@@ -19,9 +19,12 @@ const asyncLoadCuratedCommunitiesTask: Task = proc(argEncoded: string) {.gcsafe,
   let arg = decode[AsyncLoadCuratedCommunitiesTaskArg](argEncoded)
   try:
     let response = status_go.getCuratedCommunities()
-    arg.finish(response)
+    arg.finish(%* {
+      "response": response,
+      "error": "",
+    })
   except Exception as e:
     arg.finish(%* {
-      "error": RpcError(message: e.msg),
+      "error": e.msg,
     })
 

--- a/ui/app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml
+++ b/ui/app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml
@@ -57,6 +57,9 @@ StatusSectionLayout {
         id: filteredCommunitiesModel
 
         function selectedTagsPredicate(selectedTagsNames, tagsJSON) {
+            if (!tagsJSON) {
+                return true
+            }
             const tags = JSON.parse(tagsJSON)
             for (const i in tags) {
                 selectedTagsNames = selectedTagsNames.filter(name => name !== tags[i].name)


### PR DESCRIPTION
Fixes #9752

Adds properties to `CommunityDto` so that `curatedCommunities` can be removed and we only need `communities`.

For testers, make sure curated communities work as before in the community portal (TBH, it was pretty messed up before, so just having communities show up there is a good thing lol)

Normal communities should also work as expected, but I didn't actually touch that.
