### PR TITLE
fix(Chat): Show message's text for community invitation

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
@@ -256,9 +256,10 @@ Control {
                     Loader {
                         Layout.fillWidth: true
                         active: (!root.editMode && !!root.messageDetails.messageText && !root.hideMessage
-                                 && ((root.messageDetails.contentType === StatusMessage.ContentType.Text)
-                                     || (root.messageDetails.contentType === StatusMessage.ContentType.Emoji) ||
-                                     (root.messageDetails.contentType === StatusMessage.ContentType.DiscordMessage)))
+                                 && ((root.messageDetails.contentType === StatusMessage.ContentType.Text) ||
+                                     (root.messageDetails.contentType === StatusMessage.ContentType.Emoji) ||
+                                     (root.messageDetails.contentType === StatusMessage.ContentType.DiscordMessage) ||
+                                     (root.messageDetails.contentType === StatusMessage.ContentType.Invitation)))
                         visible: active
                         sourceComponent: StatusTextMessage {
                             objectName: "StatusMessage_textMessage"


### PR DESCRIPTION
Close #9812

### What does the PR do

Show message's text for community invitation

### Affected areas

Chat

### Screenshot of functionality (including design for comparison)

<img width="571" alt="Screenshot 2023-03-13 at 14 06 15" src="https://user-images.githubusercontent.com/2522130/224648647-a494d6de-062f-4acf-a572-9064785ce5cc.png">
