### PR TITLE
refactor(StatusItemSelector): Decompose into smaller components

### DIFF
--- a/storybook/PagesModel.qml
+++ b/storybook/PagesModel.qml
@@ -150,6 +150,10 @@ ListModel {
         section: "Components"
     }
     ListElement {
+        title: "StatusItemSelector"
+        section: "Components"
+    }
+    ListElement {
          title: "BrowserSettings"
          section: "Settings"
     }

--- a/storybook/PagesModel.qml
+++ b/storybook/PagesModel.qml
@@ -154,6 +154,10 @@ ListModel {
         section: "Components"
     }
     ListElement {
+        title: "StatusGroupBox"
+        section: "Components"
+    }
+    ListElement {
          title: "BrowserSettings"
          section: "Settings"
     }

--- a/storybook/PagesModel.qml
+++ b/storybook/PagesModel.qml
@@ -150,6 +150,10 @@ ListModel {
         section: "Components"
     }
     ListElement {
+        title: "StatusFlowSelector"
+        section: "Components"
+    }
+    ListElement {
         title: "StatusItemSelector"
         section: "Components"
     }

--- a/storybook/pages/StatusDotsLoadingIndicatorPage.qml
+++ b/storybook/pages/StatusDotsLoadingIndicatorPage.qml
@@ -1,46 +1,37 @@
-import QtQuick 2.14
-import QtQuick.Controls 2.14
-import QtQuick.Layouts 1.14
+import QtQuick 2.15
+import QtQuick.Layouts 1.15
 
 import StatusQ.Components 0.1
-import StatusQ.Core.Theme 0.1
 
+Item {
+    ColumnLayout {
+        anchors.centerIn: parent
+        spacing: 100
 
-SplitView {
-    id: root
+        StatusDotsLoadingIndicator {
+            Layout.alignment: Qt.AlignHCenter
 
-    SplitView {
-        orientation: Qt.Vertical
-        SplitView.fillWidth: true
-        ColumnLayout {
-            anchors.margins: 100
-            anchors.fill: parent
-            spacing: 100
+            dotsDiameter: 5
+            duration: 500
+            dotsColor: "blue"
+        }
 
-            StatusDotsLoadingIndicator {
-                dotsDiameter: 5
-                duration: 500
-                dotsColor: "blue"
-            }
+        StatusDotsLoadingIndicator {
+            Layout.alignment: Qt.AlignHCenter
 
-            StatusDotsLoadingIndicator {
-                dotsDiameter: 15
-                duration: 1000
-                dotsColor: "orange"
-                spacing: 16
-            }
+            dotsDiameter: 15
+            duration: 1000
+            dotsColor: "orange"
+            spacing: 16
+        }
 
-            StatusDotsLoadingIndicator {
-                dotsDiameter: 30
-                duration: 1500
-                dotsColor: "green"
-                spacing: 30
-            }
+        StatusDotsLoadingIndicator {
+            Layout.alignment: Qt.AlignHCenter
 
-            // filler
-            Item {
-                Layout.fillHeight: true
-            }
+            dotsDiameter: 30
+            duration: 1500
+            dotsColor: "green"
+            spacing: 30
         }
     }
 }

--- a/storybook/pages/StatusFlowSelectorPage.qml
+++ b/storybook/pages/StatusFlowSelectorPage.qml
@@ -1,0 +1,53 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+import StatusQ.Components 0.1
+import utils 1.0
+
+
+ColumnLayout {
+    Item {
+        Layout.fillHeight: true
+        Layout.fillWidth: true
+
+        StatusFlowSelector {
+            anchors.centerIn: parent
+
+            icon: Style.png("tokens/SNT")
+            title: "Item Selector Title"
+
+            placeholderText: "Example: Empty items"
+
+            Repeater {
+                id: repeater
+
+                model: ListModel {
+                    id: listModel
+                }
+
+                property int counter: 0
+
+                delegate: StatusListItemTag {
+                    title: `tag ${model.name}`
+
+                    onClicked: listModel.remove(index)
+                }
+            }
+
+            placeholderItem.visible: listModel.count === 0
+
+            addButton.onClicked: {
+                listModel.append({ name: `item ${repeater.counter++}` })
+            }
+        }
+    }
+
+    Button {
+        Layout.bottomMargin: 10
+        Layout.alignment: Qt.AlignHCenter
+
+        text: "Clear list"
+        onClicked: listModel.clear()
+    }
+}

--- a/storybook/pages/StatusGroupBoxPage.qml
+++ b/storybook/pages/StatusGroupBoxPage.qml
@@ -1,0 +1,121 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+import StatusQ.Components 0.1
+import utils 1.0
+
+
+SplitView {
+    orientation: Qt.Vertical
+
+    component LabeledSlider: Row {
+        property alias text: label.text
+        property alias value: slider.value
+        property alias from: slider.from
+        property alias to: slider.to
+
+        Label {
+            id: label
+
+            anchors.verticalCenter: parent.verticalCenter
+        }
+
+        Slider {
+            id: slider
+
+            value: (from + to) / 2
+            from: 10
+            to: 500
+        }
+    }
+
+    Item {
+        SplitView.fillWidth: true
+        SplitView.fillHeight: true
+        clip: true
+
+        StatusGroupBox {
+            id: group
+
+            anchors.centerIn: parent
+
+            title: titleTextEdit.text
+            icon: Style.png("tokens/SNT")
+            iconSize: iconSizeSlider.value
+
+            width: undefinedSizeCheckBox.checked ? undefined
+                                                 : widthSlider.value
+            height: undefinedSizeCheckBox.checked ? undefined
+                                                  : heightSlider.value
+
+            Button {
+                width: group.availableWidth
+                height: group.availableHeight
+
+                text: "Content button with some text"
+
+                implicitWidth: contentImplicitWidthSlider.value
+                implicitHeight: contentImplicitHeightSlider.value
+            }
+        }
+    }
+
+    ScrollView {
+        clip: true
+
+        Pane {
+            SplitView.minimumHeight: 100
+            SplitView.preferredHeight: 200
+
+            ColumnLayout {
+                LabeledSlider {
+                    id: widthSlider
+
+                    enabled: !undefinedSizeCheckBox.checked
+                    text: "width:"
+                }
+
+                LabeledSlider {
+                    id: heightSlider
+
+                    enabled: !undefinedSizeCheckBox.checked
+                    text: "height:"
+                }
+
+                CheckBox {
+                    id: undefinedSizeCheckBox
+                    text: "Undefined size"
+                    checked: true
+                }
+
+                LabeledSlider {
+                    id: contentImplicitWidthSlider
+
+                    text: "content implicit width:"
+                }
+
+                LabeledSlider {
+                    id: contentImplicitHeightSlider
+
+                    text: "content implicit height:"
+                }
+
+                LabeledSlider {
+                    id: iconSizeSlider
+
+                    from: 10
+                    to: 40
+                    value: 18
+                    text: "iconSize:"
+                }
+
+                TextField {
+                    id: titleTextEdit
+
+                    text: "Some title goes here"
+                }
+            }
+        }
+    }
+}

--- a/storybook/pages/StatusItemSelectorPage.qml
+++ b/storybook/pages/StatusItemSelectorPage.qml
@@ -1,15 +1,19 @@
-import QtQuick 2.14
-import QtQuick.Layouts 1.14
+import QtQuick 2.15
+import QtQuick.Layouts 1.15
 
 import StatusQ.Components 0.1
 import StatusQ.Controls 0.1
 import StatusQ.Core.Utils 0.1
 
+import utils 1.0
+
 ColumnLayout {
     spacing: 20
+
     StatusItemSelector {
         id: selector
-        icon: "qrc:/images/SNT.png"
+
+        icon: Style.png("tokens/SNT")
         iconSize: 24
         title: "Item Selector Title"
         defaultItemText: "Example: Empty items"
@@ -25,19 +29,23 @@ ColumnLayout {
             width: 200
             contentItem: ColumnLayout {
                 spacing: 10
+
                 StatusInput {
                     id: input
                     text: "Sample"
                     Layout.fillWidth: true
                 }
+
                 StatusButton {
                     Layout.alignment: Qt.AlignHCenter
+
                     text: "Add element"
                     onClicked: {
                         model.append({
                             text: input.text,
-                            imageSource: "qrc:/images/SNT.png",
-                            operator: model.count > 0 ? OperatorsUtils.Operators.Or : OperatorsUtils.Operators.None
+                            imageSource: Style.png("tokens/SNT"),
+                            operator: model.count > 0 ? OperatorsUtils.Operators.Or
+                                                      : OperatorsUtils.Operators.None
                         })
 
                         dropdown.close()
@@ -55,6 +63,7 @@ ColumnLayout {
 
     StatusButton {
         Layout.alignment: Qt.AlignHCenter
+
         text: "Clear list"
         onClicked: { selector.itemsModel.clear() }
     }

--- a/storybook/pages/StatusItemSelectorPage.qml
+++ b/storybook/pages/StatusItemSelectorPage.qml
@@ -14,11 +14,11 @@ ColumnLayout {
         id: selector
 
         icon: Style.png("tokens/SNT")
-        iconSize: 24
         title: "Item Selector Title"
-        defaultItemText: "Example: Empty items"
 
-        itemsModel: ListModel {
+        placeholderText: "Example: Empty items"
+
+        model: ListModel {
             id: model
         }
 
@@ -65,6 +65,6 @@ ColumnLayout {
         Layout.alignment: Qt.AlignHCenter
 
         text: "Clear list"
-        onClicked: { selector.itemsModel.clear() }
+        onClicked: model.clear()
     }
 }

--- a/ui/StatusQ/doc/src/statusqcomponents.qdoc
+++ b/ui/StatusQ/doc/src/statusqcomponents.qdoc
@@ -11,32 +11,33 @@
        \li \l{StatusAddress}
        \li \l{StatusBadge}
        \li \l{StatusChatInfoToolBar}
-       \li \l{StatusChatList}
-       \li \l{StatusChatListItem}
-       \li \l{StatusImageSettings}
-       \li \l{StatusChatListCategory}
-       \li \l{StatusChatListCategoryItem}
        \li \l{StatusChatListAndCategories}
+       \li \l{StatusChatListCategoryItem}
+       \li \l{StatusChatListCategory}
+       \li \l{StatusChatListItem}
+       \li \l{StatusChatList}
        \li \l{StatusChatToolBar}
        \li \l{StatusContactRequestsIndicatorListItem}
        \li \l{StatusDescriptionListItem}
+       \li \l{StatusExpandableItem}
+       \li \l{StatusGroupBox}
+       \li \l{StatusImageSettings}
        \li \l{StatusItemSelector}
        \li \l{StatusLetterIdenticon}
+       \li \l{StatusListItemBadge}
        \li \l{StatusListItem}
        \li \l{StatusListPicker}
        \li \l{StatusListSectionHeadline}
        \li \l{StatusLoadingIndicator}
+       \li \l{StatusMacWindowButtons}
        \li \l{StatusMemberListItem}
+       \li \l{StatusMessageDetails}
+       \li \l{StatusMessage}
        \li \l{StatusNavigationListItem}
        \li \l{StatusNavigationPanelHeadline}
        \li \l{StatusRoundIcon}
        \li \l{StatusRoundedImage}
-       \li \l{StatusMacWindowButtons}
-       \li \l{StatusListItemBadge}
-       \li \l{StatusExpandableItem}
        \li \l{StatusSmartIdenticon}
-       \li \l{StatusMessage}
-       \li \l{StatusMessageDetails}
        \li \l{StatusTagSelector}
        \li \l{StatusToastMessage}
        \li \l{StatusWizardStepper}

--- a/ui/StatusQ/doc/src/statusqcomponents.qdoc
+++ b/ui/StatusQ/doc/src/statusqcomponents.qdoc
@@ -20,6 +20,7 @@
        \li \l{StatusContactRequestsIndicatorListItem}
        \li \l{StatusDescriptionListItem}
        \li \l{StatusExpandableItem}
+       \li \l{StatusFlowSelector}
        \li \l{StatusGroupBox}
        \li \l{StatusImageSettings}
        \li \l{StatusItemSelector}

--- a/ui/StatusQ/sandbox/main.qml
+++ b/ui/StatusQ/sandbox/main.qml
@@ -307,11 +307,6 @@ StatusWindow {
                         onClicked: mainPageView.page(title);
                     }
                     StatusNavigationListItem {
-                        title: "StatusItemSelector"
-                        selected: viewLoader.source.toString().includes(title)
-                        onClicked: mainPageView.page(title, true);
-                    }
-                    StatusNavigationListItem {
                         title: "StatusChartPanel"
                         selected: viewLoader.source.toString().includes(title)
                         onClicked: mainPageView.page(title, true);

--- a/ui/StatusQ/sandbox/qml.qrc
+++ b/ui/StatusQ/sandbox/qml.qrc
@@ -56,7 +56,6 @@
         <file>pages/StatusExpandableSettingsItemPage.qml</file>
         <file>pages/StatusImageCropPanelPage.qml</file>
         <file>pages/StatusInputPage.qml</file>
-        <file>pages/StatusItemSelectorPage.qml</file>
         <file>pages/StatusListPickerPage.qml</file>
         <file>pages/StatusMacNotificationPage.qml</file>
         <file>pages/StatusPasswordStrengthIndicatorPage.qml</file>

--- a/ui/StatusQ/src/StatusQ/Components/StatusFlowSelector.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusFlowSelector.qml
@@ -1,0 +1,124 @@
+import QtQuick 2.15
+
+import StatusQ.Core.Theme 0.1
+import StatusQ.Controls 0.1
+
+/*!
+   \qmltype StatusFlowSelector
+   \inherits StatusGroupBox
+   \inqmlmodule StatusQ.Components
+   \since StatusQ.Components 0.1
+   \brief It allows to add items and display them as a list within a Flow
+   component.
+
+   The \c StatusFlowSelector can be populated with a repeater.
+
+   Example of how the component looks like:
+   \image status_item_selector.png
+
+   Example of how to use it:
+   \qml
+        StatusFlowSelector {
+            icon: Style.svg("contact_verified")
+            title: qsTr("Who holds")
+            placeholderItem.visible: listModel.count === 0
+
+            Repeater {
+                id: repeater
+
+                model: ListModel {
+                    id: listModel
+                }
+
+                property int counter: 0
+
+                delegate: StatusListItemTag {
+                    title: `tag ${model.name}`
+
+                    onClicked: listModel.remove(index)
+                }
+            }
+
+            addButton.onClicked: {
+                listModel.append({ name: `item ${repeater.counter++}` })
+            }
+        }
+   \endqml
+   For a list of components available see StatusQ.
+*/
+StatusGroupBox {
+    id: root
+
+    default property alias content: flow.data
+
+    /*!
+       \qmlproperty string StatusFlowSelector::placeholderText
+       This property holds the placeholder item text which can be shown when the
+       list of items is empty.
+    */
+    property string placeholderText
+
+    /*!
+       \qmlproperty url StatusFlowSelector::placeholderImageSource
+       This property holds the default item icon shown when the list of items is empty.
+    */
+    property url placeholderImageSource
+
+    /*!
+       \qmlproperty StatusListItemTag StatusFlowSelector::placeholder
+       This property holds an alias to the placeholder item.
+    */
+    readonly property alias placeholderItem: placeholderListItemTag
+
+    /*!
+       \qmlproperty StatusRoundButton StatusFlowSelector::addButton
+       This property holds an alias to the `add` button.
+    */
+    readonly property alias addButton: addItemButton
+
+    /*!
+       \qmlproperty int StatusFlowSelector::flowSpacing
+       This property specifies spacing between items in the selector.
+    */
+    property alias flowSpacing: flow.spacing
+
+    implicitWidth: 560
+
+    Flow {
+        id: flow
+
+        width: root.availableWidth
+        spacing: 6
+
+        StatusListItemTag {
+            id: placeholderListItemTag
+
+            bgColor: Theme.palette.baseColor2
+            title: root.placeholderText
+            asset.name: root.placeholderImageSource
+            asset.isImage: true
+            closeButtonVisible: false
+            titleText.color: Theme.palette.baseColor1
+            titleText.font.pixelSize: 15
+        }
+
+        onPositioningComplete: {
+            // the "add" button is intended to be the last item in the flow
+            if (addItemButton.Positioner.isLastItem || !addItemButton.visible)
+                return
+
+            addItemButton.parent = null
+            addItemButton.parent = flow
+        }
+
+        StatusRoundButton {
+            id: addItemButton
+
+            implicitHeight: 32
+            implicitWidth: implicitHeight
+            height: width
+            type: StatusRoundButton.Type.Secondary
+            icon.name: "add"
+        }
+    }
+}

--- a/ui/StatusQ/src/StatusQ/Components/StatusGroupBox.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusGroupBox.qml
@@ -1,0 +1,67 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+import StatusQ.Components 0.1
+import StatusQ.Core.Theme 0.1
+import StatusQ.Core 0.1
+
+
+GroupBox {
+    id: root
+
+    topPadding: label.implicitHeight
+    leftPadding: 16
+
+    /*!
+       \qmlproperty string StatusGroupBox::icon
+       This property holds the icon name for the icon represented on top of the
+       component as a title icon.
+    */
+    property string icon
+
+    /*!
+       \qmlproperty int StatusItemSelector::iconSize
+       This property holds the icon size for the icon represented on top of the
+       component as a title icon.
+    */
+    property int iconSize: 24
+
+    background: Rectangle {
+        color: Theme.palette.baseColor4
+        radius: 16
+    }
+
+    label: Control {
+        x: root.leftPadding
+        width: root.availableWidth
+        topPadding: 12
+        bottomPadding: 12
+
+        contentItem: RowLayout {
+            spacing: 8
+
+            Image {
+                sourceSize.width: width || undefined
+                sourceSize.height: height || undefined
+                fillMode: Image.PreserveAspectFit
+                mipmap: true
+                antialiasing: true
+                width: root.iconSize
+                height: width
+                source: root.icon
+            }
+
+            StatusBaseText {
+                Layout.alignment: Qt.AlignVCenter
+                Layout.fillWidth: true
+
+                text: root.title
+                color: Theme.palette.directColor1
+                font.pixelSize: 17
+
+                elide: Text.ElideRight
+            }
+        }
+    }
+}

--- a/ui/StatusQ/src/StatusQ/Components/StatusItemSelector.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusItemSelector.qml
@@ -3,17 +3,19 @@ import QtQuick.Layouts 1.14
 
 import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
-import StatusQ.Controls 0.1
 import StatusQ.Core.Utils 0.1
 
 /*!
    \qmltype StatusItemSelector
-   \inherits Rectangle
+   \inherits StatusFlowSelector
    \inqmlmodule StatusQ.Components
    \since StatusQ.Components 0.1
-   \brief It allows to add items and display them as a tag item with an image and text. It also allows to store and display logical `and` / `or` operators into the list. Inherits \l{https://doc.qt.io/qt-6/qml-qtquick-rectangle.html}{Item}.
+   \brief It allows to add items and display them as a tag item with an image
+   and text. It also allows to store and display logical `and` / `or` operators
+   into the list.
 
-   The \c StatusItemSelector is populated with a data model. The data model is commonly a JavaScript array or a ListModel object with specific expected roles.
+   The \c StatusItemSelector is populated with a data model. The data model is
+   commonly a JavaScript array or a ListModel object with specific expected roles.
 
    Example of how the component looks like:
    \image status_item_selector.png
@@ -40,45 +42,41 @@ import StatusQ.Core.Utils 0.1
    \endqml
    For a list of components available see StatusQ.
 */
-StatusGroupBox {
+StatusFlowSelector {
     id: root
 
     /*!
-       \qmlproperty string StatusItemSelector::defaultItemText
-       This property holds the default item text shown when the list of items is empty.
-    */
-    property string defaultItemText
-    /*!
-       \qmlproperty url StatusItemSelector::defaultItemImageSource
-       This property holds the default item icon shown when the list of items is empty.
-    */
-    property url defaultItemImageSource: ""
-    /*!
-       \qmlproperty StatusRoundButton StatusItemSelector::addButton
-       This property holds an alias to the `add` button.
-    */
-    readonly property alias addButton: addItemButton
-    /*!
-       \qmlproperty ListModel StatusItemSelector::itemsModel
+       \qmlproperty ListModel StatusItemSelector::model
        This property holds the data that will be populated in the items selector.
 
        Here an example of the model roles expected:
        \qml
-            itemsModel: ListModel {
+        model: ListModel {
             ListElement {
                 text: "Socks"
                 imageSource: "qrc:imports/assets/png/tokens/SOCKS.png"
+                color: ""
+                emoji: ""
                 operator: Utils.Operator.None
             }
             ListElement {
                 text: "ZRX"
                 imageSource: "qrc:imports/assets/png/tokens/ZRX.png"
+                color: ""
+                emoji: ""
+                operator: Utils.Operator.Or
+            }
+            ListElement {
+                text: "Custom Token"
+                imageSource: ""
+                color: "red"
+                emoji: "⚽"
                 operator: Utils.Operator.Or
             }
         }
        \endqml
     */
-    property var itemsModel: ListModel { }
+    property alias model: repeater.model
     /*!
        \qmlproperty bool StatusItemSelector::useIcons
        This property determines if the imageSource role from the model will be handled as
@@ -115,84 +113,58 @@ StatusGroupBox {
     */
     signal itemClicked(var item, int index, var mouse)
 
+    placeholderItem.visible: repeater.count === 0
+
     implicitWidth: 560
-    clip: true
 
-    Flow {
-        id: flow
+    Repeater {
+        id: repeater
 
-        clip: true
-        width: root.availableWidth
-        spacing: 6
+        RowLayout {
+            spacing: flowSpacing
 
-        StatusListItemTag {
-            bgColor: Theme.palette.baseColor2
-            visible: !itemsModel || itemsModel.count === 0
-            title: root.defaultItemText
-            asset.name: root.defaultItemImageSource
-            asset.isImage: true
-            closeButtonVisible: false
-            titleText.color: Theme.palette.baseColor1
-            titleText.font.pixelSize: 15
-        }
-        Repeater {
-            model: itemsModel
-
-            RowLayout {
-                spacing: flow.spacing
-
-                StatusBaseText {
-                    visible: model.operator !== OperatorsUtils.Operators.None
-                    Layout.alignment: Qt.AlignVCenter
-                    text: OperatorsUtils.setOperatorTextFormat(model.operator)
-                    color: Theme.palette.primaryColor1
-                    font.pixelSize: 17
-                    MouseArea {
-                        anchors.fill: parent
-                        cursorShape: Qt.PointingHandCursor
-                        onClicked: {
-                            // Switch operator
-                            if(model.operator === OperatorsUtils.Operators.And)
-                                model.operator = OperatorsUtils.Operators.Or
-                            else
-                                model.operator = OperatorsUtils.Operators.And
-                        }
-                    }
-                }
-                StatusListItemTag {
-                    title: model.text
-
-                    asset.height: root.asset.height
-                    asset.width: root.asset.width
-                    asset.name: root.useLetterIdenticons ? model.text : (model.imageSource ?? "")
-                    asset.isImage: root.asset.isImage
-                    asset.bgColor: root.asset.bgColor
-                    asset.emoji: model.emoji ? model.emoji : ""
-                    asset.color: model.color ? model.color : ""
-                    asset.isLetterIdenticon: root.useLetterIdenticons
-                    //color: Theme.palette.primaryColor3
-                    closeButtonVisible: false
-                    titleText.color: Theme.palette.primaryColor1
-                    titleText.font.pixelSize: 15
-                    leftPadding: root.tagLeftPadding
-
-                    MouseArea {
-                        anchors.fill: parent
-                        enabled: root.itemsClickable
-                        cursorShape: enabled ? Qt.PointingHandCursor : Qt.ArrowCursor
-                        acceptedButtons: Qt.LeftButton | Qt.RightButton
-                        onClicked: root.itemClicked(parent, model.index, mouse)
+            StatusBaseText {
+                visible: model.operator !== OperatorsUtils.Operators.None
+                Layout.alignment: Qt.AlignVCenter
+                text: OperatorsUtils.setOperatorTextFormat(model.operator)
+                color: Theme.palette.primaryColor1
+                font.pixelSize: 17
+                MouseArea {
+                    anchors.fill: parent
+                    cursorShape: Qt.PointingHandCursor
+                    onClicked: {
+                        // Switch operator
+                        if(model.operator === OperatorsUtils.Operators.And)
+                            model.operator = OperatorsUtils.Operators.Or
+                        else
+                            model.operator = OperatorsUtils.Operators.And
                     }
                 }
             }
-        }
-        StatusRoundButton {
-            id: addItemButton
-            implicitHeight: 32
-            implicitWidth: implicitHeight
-            height: width
-            type: StatusRoundButton.Type.Secondary
-            icon.name: "add"
+            StatusListItemTag {
+                title: model.text
+
+                asset.height: root.asset.height
+                asset.width: root.asset.width
+                asset.name: root.useLetterIdenticons ? model.text : (model.imageSource ?? "")
+                asset.isImage: root.asset.isImage
+                asset.bgColor: root.asset.bgColor
+                asset.emoji: model.emoji ? model.emoji : ""
+                asset.color: model.color ? model.color : ""
+                asset.isLetterIdenticon: root.useLetterIdenticons
+                closeButtonVisible: false
+                titleText.color: Theme.palette.primaryColor1
+                titleText.font.pixelSize: 15
+                leftPadding: root.tagLeftPadding
+
+                MouseArea {
+                    anchors.fill: parent
+                    enabled: root.itemsClickable
+                    cursorShape: enabled ? Qt.PointingHandCursor : Qt.ArrowCursor
+                    acceptedButtons: Qt.LeftButton | Qt.RightButton
+                    onClicked: root.itemClicked(parent, model.index, mouse)
+                }
+            }
         }
     }
 }

--- a/ui/StatusQ/src/StatusQ/Components/StatusItemSelector.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusItemSelector.qml
@@ -1,6 +1,5 @@
 import QtQuick 2.14
 import QtQuick.Layouts 1.14
-import QtQuick.Controls 2.14 as QC
 
 import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
@@ -41,23 +40,9 @@ import StatusQ.Core.Utils 0.1
    \endqml
    For a list of components available see StatusQ.
 */
-Rectangle {
+StatusGroupBox {
     id: root
-    /*!
-       \qmlproperty string StatusItemSelector::icon
-       This property holds the icon name for the icon represented on top of the component as a title icon.
-    */
-    property string icon
-    /*!
-       \qmlproperty int StatusItemSelector::iconSize
-       This property holds the icon size for the icon represented on top of the component as a title icon.
-    */
-    property int iconSize: 18
-    /*!
-       \qmlproperty string StatusItemSelector::title
-       This property holds the titel shown on top of the component.
-    */
-    property string title
+
     /*!
        \qmlproperty string StatusItemSelector::defaultItemText
        This property holds the default item text shown when the list of items is empty.
@@ -130,116 +115,84 @@ Rectangle {
     */
     signal itemClicked(var item, int index, var mouse)
 
-    color: Theme.palette.baseColor4
-    implicitHeight: columnLayout.implicitHeight + columnLayout.anchors.topMargin + columnLayout.anchors.bottomMargin
     implicitWidth: 560
-    radius: 16
     clip: true
 
-    ColumnLayout {
-        id: columnLayout
-        anchors.top: parent.top
-        anchors.topMargin: 12
-        anchors.bottomMargin: anchors.topMargin
-        anchors.left: parent.left
-        anchors.leftMargin: 16
-        anchors.right: parent.right
-        anchors.rightMargin: 16
-        spacing: 12
+    Flow {
+        id: flow
+
         clip: true
-        RowLayout {
-            id: headerRow
-            spacing: 8
-            Image {
-                sourceSize.width: width || undefined
-                sourceSize.height: height || undefined
-                fillMode: Image.PreserveAspectFit
-                mipmap: true
-                antialiasing: true
-                width: root.iconSize
-                height: width
-                source: root.icon
-            }
-            StatusBaseText {
-                Layout.alignment: Qt.AlignVCenter
-                text: root.title
-                color: Theme.palette.directColor1
-                font.pixelSize: 17
-            }
-        }        
-        Flow {
-            id: flow
-            Layout.fillWidth: true
-            spacing: 6
-            StatusListItemTag {
-                bgColor: Theme.palette.baseColor2
-                visible: !itemsModel || itemsModel.count === 0
-                title: root.defaultItemText
-                asset.name: root.defaultItemImageSource
-                asset.isImage: true
-                closeButtonVisible: false
-                titleText.color: Theme.palette.baseColor1
-                titleText.font.pixelSize: 15
-            }
-            Repeater {
-                model: itemsModel
+        width: root.availableWidth
+        spacing: 6
 
-                RowLayout {
-                    spacing: flow.spacing
+        StatusListItemTag {
+            bgColor: Theme.palette.baseColor2
+            visible: !itemsModel || itemsModel.count === 0
+            title: root.defaultItemText
+            asset.name: root.defaultItemImageSource
+            asset.isImage: true
+            closeButtonVisible: false
+            titleText.color: Theme.palette.baseColor1
+            titleText.font.pixelSize: 15
+        }
+        Repeater {
+            model: itemsModel
 
-                    StatusBaseText {                        
-                        visible: model.operator !== OperatorsUtils.Operators.None
-                        Layout.alignment: Qt.AlignVCenter
-                        text: OperatorsUtils.setOperatorTextFormat(model.operator)
-                        color: Theme.palette.primaryColor1
-                        font.pixelSize: 17
-                        MouseArea {
-                            anchors.fill: parent
-                            cursorShape: Qt.PointingHandCursor
-                            onClicked: {
-                                // Switch operator
-                                if(model.operator === OperatorsUtils.Operators.And)
-                                    model.operator = OperatorsUtils.Operators.Or
-                                else
-                                    model.operator = OperatorsUtils.Operators.And
-                            }
-                        }
-                    }
-                    StatusListItemTag {
-                        title: model.text
+            RowLayout {
+                spacing: flow.spacing
 
-                        asset.height: root.asset.height
-                        asset.width: root.asset.width
-                        asset.name: root.useLetterIdenticons ? model.text : (model.imageSource ?? "")
-                        asset.isImage: root.asset.isImage
-                        asset.bgColor: root.asset.bgColor
-                        asset.emoji: model.emoji ? model.emoji : ""
-                        asset.color: model.color ? model.color : ""
-                        asset.isLetterIdenticon: root.useLetterIdenticons
-                        //color: Theme.palette.primaryColor3
-                        closeButtonVisible: false
-                        titleText.color: Theme.palette.primaryColor1
-                        titleText.font.pixelSize: 15
-                        leftPadding: root.tagLeftPadding
-
-                        MouseArea {
-                            anchors.fill: parent
-                            enabled: root.itemsClickable
-                            cursorShape: enabled ? Qt.PointingHandCursor : Qt.ArrowCursor
-                            acceptedButtons: Qt.LeftButton | Qt.RightButton
-                            onClicked: root.itemClicked(parent, model.index, mouse)
+                StatusBaseText {
+                    visible: model.operator !== OperatorsUtils.Operators.None
+                    Layout.alignment: Qt.AlignVCenter
+                    text: OperatorsUtils.setOperatorTextFormat(model.operator)
+                    color: Theme.palette.primaryColor1
+                    font.pixelSize: 17
+                    MouseArea {
+                        anchors.fill: parent
+                        cursorShape: Qt.PointingHandCursor
+                        onClicked: {
+                            // Switch operator
+                            if(model.operator === OperatorsUtils.Operators.And)
+                                model.operator = OperatorsUtils.Operators.Or
+                            else
+                                model.operator = OperatorsUtils.Operators.And
                         }
                     }
                 }
+                StatusListItemTag {
+                    title: model.text
+
+                    asset.height: root.asset.height
+                    asset.width: root.asset.width
+                    asset.name: root.useLetterIdenticons ? model.text : (model.imageSource ?? "")
+                    asset.isImage: root.asset.isImage
+                    asset.bgColor: root.asset.bgColor
+                    asset.emoji: model.emoji ? model.emoji : ""
+                    asset.color: model.color ? model.color : ""
+                    asset.isLetterIdenticon: root.useLetterIdenticons
+                    //color: Theme.palette.primaryColor3
+                    closeButtonVisible: false
+                    titleText.color: Theme.palette.primaryColor1
+                    titleText.font.pixelSize: 15
+                    leftPadding: root.tagLeftPadding
+
+                    MouseArea {
+                        anchors.fill: parent
+                        enabled: root.itemsClickable
+                        cursorShape: enabled ? Qt.PointingHandCursor : Qt.ArrowCursor
+                        acceptedButtons: Qt.LeftButton | Qt.RightButton
+                        onClicked: root.itemClicked(parent, model.index, mouse)
+                    }
+                }
             }
-            StatusRoundButton {
-                id: addItemButton
-                implicitHeight: 32
-                implicitWidth: implicitHeight
-                height: width
-                type: StatusRoundButton.Type.Secondary
-                icon.name: "add"
-            }
+        }
+        StatusRoundButton {
+            id: addItemButton
+            implicitHeight: 32
+            implicitWidth: implicitHeight
+            height: width
+            type: StatusRoundButton.Type.Secondary
+            icon.name: "add"
         }
     }
 }

--- a/ui/StatusQ/src/StatusQ/Components/qmldir
+++ b/ui/StatusQ/src/StatusQ/Components/qmldir
@@ -43,6 +43,7 @@ StatusImageCropPanel 0.1 StatusImageCropPanel.qml
 StatusColorSpace 0.0 StatusColorSpace.qml
 StatusCommunityCard 0.1 StatusCommunityCard.qml
 StatusCommunityTags 0.1 StatusCommunityTags.qml
+StatusFlowSelector 0.1 StatusFlowSelector.qml
 StatusItemSelector 0.1 StatusItemSelector.qml
 StatusCard 0.1 StatusCard.qml
 StatusDatePicker 0.1 StatusDatePicker.qml

--- a/ui/StatusQ/src/StatusQ/Components/qmldir
+++ b/ui/StatusQ/src/StatusQ/Components/qmldir
@@ -53,3 +53,4 @@ LoadingComponent 0.1 LoadingComponent.qml
 StatusQrCodeScanner 0.1 StatusQrCodeScanner.qml
 StatusSyncDeviceDelegate 0.1 StatusSyncDeviceDelegate.qml
 StatusOnlineBadge 0.1 StatusOnlineBadge.qml
+StatusGroupBox 0.1 StatusGroupBox.qml

--- a/ui/StatusQ/src/statusq.qrc
+++ b/ui/StatusQ/src/statusq.qrc
@@ -30,6 +30,7 @@
         <file>StatusQ/Components/StatusEmoji.qml</file>
         <file>StatusQ/Components/StatusExpandableItem.qml</file>
         <file>StatusQ/Components/StatusImageCropPanel.qml</file>
+        <file>StatusQ/Components/StatusFlowSelector.qml</file>
         <file>StatusQ/Components/StatusItemSelector.qml</file>
         <file>StatusQ/Components/StatusLetterIdenticon.qml</file>
         <file>StatusQ/Components/StatusListItem.qml</file>

--- a/ui/StatusQ/src/statusq.qrc
+++ b/ui/StatusQ/src/statusq.qrc
@@ -198,5 +198,6 @@
         <file>StatusQ/Core/Utils/ModelChangeTracker.qml</file>
         <file>StatusQ/Components/StatusQrCodeScanner.qml</file>
         <file>StatusQ/Components/StatusOnlineBadge.qml</file>
+        <file>StatusQ/Components/StatusGroupBox.qml</file>
     </qresource>
 </RCC>

--- a/ui/app/AppLayouts/Chat/views/communities/CommunityNewAirdropView.qml
+++ b/ui/app/AppLayouts/Chat/views/communities/CommunityNewAirdropView.qml
@@ -29,7 +29,7 @@ StatusScrollView {
     property var selectedHoldingsModel: ListModel {}
 
     readonly property bool isFullyFilled: selectedHoldingsModel.count > 0 &&
-                                          addressess.itemsModel.count > 0
+                                          addressess.model.count > 0
 
     signal airdropClicked(var airdropTokens, string address)
 
@@ -57,13 +57,13 @@ StatusScrollView {
             Layout.fillWidth: true
             icon: Style.svg("token")
             title: qsTr("What")
-            defaultItemText: qsTr("Example: 1 SOCK")
+            placeholderText: qsTr("Example: 1 SOCK")
             tagLeftPadding: 2
             asset.height: 28
             asset.width: asset.height
-            addButton.visible: itemsModel.count < d.maxAirdropTokens
+            addButton.visible: model.count < d.maxAirdropTokens
 
-            itemsModel: HoldingsSelectionModel {
+            model: HoldingsSelectionModel {
                 sourceModel: root.selectedHoldingsModel
 
                 assetsModel: root.assetsModel
@@ -163,7 +163,7 @@ StatusScrollView {
                 dropdown.x = mouse.x + d.dropdownHorizontalOffset
                 dropdown.y = d.dropdownVerticalOffset
 
-                const modelItem = tokensSelector.itemsModel.get(index)
+                const modelItem = tokensSelector.model.get(index)
 
                 switch(modelItem.type) {
                 case HoldingTypes.Type.Asset:
@@ -213,17 +213,19 @@ StatusScrollView {
             Layout.fillWidth: true
             icon: Style.svg("member")
             title: qsTr("To")
-            defaultItemText: qsTr("Example: 12 addresses and 3 members")
+            placeholderText: qsTr("Example: 12 addresses and 3 members")
             tagLeftPadding: 2
             asset.height: 28
             asset.width: asset.height
 
+            model: ListModel {}
+
             addButton.onClicked: {
                 if(addressInput.text.length > 0)
-                    itemsModel.append({text: addressInput.text})
+                    model.append({text: addressInput.text})
             }
 
-            onItemClicked: addressess.itemsModel.remove(index)
+            onItemClicked: addressess.model.remove(index)
         }
 
         StatusButton {
@@ -239,7 +241,7 @@ StatusScrollView {
                                         root.selectedHoldingsModel,
                                         ["key", "type", "amount"])
 
-                root.airdropClicked(airdropTokens, addressess.itemsModel)
+                root.airdropClicked(airdropTokens, addressess.model)
             }
         }
     }

--- a/ui/app/AppLayouts/Chat/views/communities/CommunityNewPermissionView.qml
+++ b/ui/app/AppLayouts/Chat/views/communities/CommunityNewPermissionView.qml
@@ -96,11 +96,11 @@ StatusScrollView {
             if (isCommunityPermission) {
                 d.dirtyValues.selectedChannelsModel.clear()
                 inSelector.wholeCommunitySelected = true
-                inSelector.itemsModel = inModelCommunity
+                inSelector.model = inModelCommunity
             } else {
-                inSelector.itemsModel = 0
+                inSelector.model = 0
                 inSelector.wholeCommunitySelected = false
-                inSelector.itemsModel = channelsSelectionModel
+                inSelector.model = channelsSelectionModel
             }
         }
 
@@ -152,10 +152,10 @@ StatusScrollView {
                     (root.selectedChannelsModel.rowCount()
                      || d.dirtyValues.permissionType === PermissionTypes.Type.None)) {
                 inSelector.wholeCommunitySelected = false
-                inSelector.itemsModel = channelsSelectionModel
+                inSelector.model = channelsSelectionModel
             } else {
                 inSelector.wholeCommunitySelected = true
-                inSelector.itemsModel = inModelCommunity
+                inSelector.model = inModelCommunity
             }
 
             // Is private permission
@@ -187,13 +187,13 @@ StatusScrollView {
             Layout.fillWidth: true
             icon: Style.svg("contact_verified")
             title: qsTr("Who holds")
-            defaultItemText: qsTr("Example: 10 SNT")
+            placeholderText: qsTr("Example: 10 SNT")
             tagLeftPadding: 2
             asset.height: 28
             asset.width: asset.height
-            addButton.visible: itemsModel.count < d.maxHoldingsItems
+            addButton.visible: model.count < d.maxHoldingsItems
 
-            itemsModel: HoldingsSelectionModel {
+            model: HoldingsSelectionModel {
                 sourceModel: d.dirtyValues.selectedHoldingsModel
 
                 assetsModel: root.assetsModel
@@ -305,7 +305,7 @@ StatusScrollView {
                 dropdown.x = mouse.x + d.dropdownHorizontalOffset
                 dropdown.y = d.dropdownVerticalOffset
 
-                const modelItem = tokensSelector.itemsModel.get(index)
+                const modelItem = tokensSelector.model.get(index)
 
                 switch(modelItem.type) {
                     case HoldingTypes.Type.Asset:
@@ -343,7 +343,7 @@ StatusScrollView {
             iconSize: 24
             useIcons: true
             title: qsTr("Is allowed to")
-            defaultItemText: qsTr("Example: View and post")
+            placeholderText: qsTr("Example: View and post")
 
             QtObject {
                 id: permissionItemModelData
@@ -353,8 +353,8 @@ StatusScrollView {
                 readonly property string imageSource: PermissionTypes.getIcon(key)
             }
 
-            itemsModel: d.dirtyValues.permissionType !== PermissionTypes.Type.None
-                        ? permissionItemModelData : null
+            model: d.dirtyValues.permissionType !== PermissionTypes.Type.None
+                   ? permissionItemModelData : null
 
             addButton.visible: d.dirtyValues.permissionType === PermissionTypes.Type.None
 
@@ -413,7 +413,7 @@ StatusScrollView {
             icon: d.isCommunityPermission ? Style.svg("communities") : Style.svg("create-category")
             iconSize: 24
             title: qsTr("In")
-            defaultItemText: qsTr("Example: `#general` channel")
+            placeholderText: qsTr("Example: `#general` channel")
 
             useLetterIdenticons: !wholeCommunitySelected || !inDropdown.communityImage
 
@@ -474,20 +474,20 @@ StatusScrollView {
 
                 onChannelsSelected: {
                     d.dirtyValues.selectedChannelsModel.clear()
-                    inSelector.itemsModel = 0
+                    inSelector.model = 0
                     inSelector.wholeCommunitySelected = false
 
                     const modelData = channels.map(key => ({ key }))
                     d.dirtyValues.selectedChannelsModel.append(modelData)
 
-                    inSelector.itemsModel = channelsSelectionModel
+                    inSelector.model = channelsSelectionModel
                     close()
                 }
 
                 onCommunitySelected: {
                     d.dirtyValues.selectedChannelsModel.clear()
                     inSelector.wholeCommunitySelected = true
-                    inSelector.itemsModel = inModelCommunity
+                    inSelector.model = inModelCommunity
                     close()
                 }
             }


### PR DESCRIPTION
### What does the PR do

Decomposes `StatusItemSelector` into smaller components that can be used as a building blocks in other scenarios:
- `StatusGroupBox` - styled box with a background, title and icon, based on `GroupBox`
- `StatusFlowSelector` - base component for components implementing flow-based selection - implements placeholder item, "add" button and flow layout
- `StatusItemSelector` - based on `StatusFlowSelector` (instead of `Rectangle), the functionality as before.

Closes: https://github.com/status-im/status-desktop/issues/9851

### Affected areas
`StatusItemSelector`

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![Screenshot from 2023-03-13 11-38-31](https://user-images.githubusercontent.com/20650004/224678383-507fafe9-986f-4666-97a6-bce40b612d5e.png)
![Screenshot from 2023-03-13 11-38-58](https://user-images.githubusercontent.com/20650004/224678406-7c95e078-ef47-49b6-be37-58d9bd8f88ad.png)

