### PR TITLE
fix(activity_center): Remove notifications from activity center

### DIFF
--- a/src/app/modules/main/activity_center/controller.nim
+++ b/src/app/modules/main/activity_center/controller.nim
@@ -76,6 +76,11 @@ proc init*(self: Controller) =
     self.delegate.hasUnseenActivityCenterNotificationsChanged()
     self.updateActivityGroupCounters()
 
+  self.events.on(activity_center_service.SIGNAL_ACTIVITY_CENTER_NOTIFICATIONS_REMOVED) do(e: Args):
+    var evArgs = RemoveActivityCenterNotificationsArgs(e)
+    if (evArgs.notificationIds.len > 0):
+      self.delegate.removeActivityCenterNotifications(evArgs.notificationIds)
+
 proc hasMoreToShow*(self: Controller): bool =
    return self.activityCenterService.hasMoreToShow()
 

--- a/src/app/modules/main/activity_center/io_interface.nim
+++ b/src/app/modules/main/activity_center/io_interface.nim
@@ -54,6 +54,9 @@ method markActivityCenterNotificationReadDone*(self: AccessInterface, notificati
 method markActivityCenterNotificationUnreadDone*(self: AccessInterface, notificationIds: seq[string]) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method removeActivityCenterNotifications*(self: AccessInterface, notificationIds: seq[string]) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method acceptActivityCenterNotificationsDone*(self: AccessInterface, notificationIds: seq[string]) {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/activity_center/module.nim
+++ b/src/app/modules/main/activity_center/module.nim
@@ -239,6 +239,9 @@ method markActivityCenterNotificationUnreadDone*(self: Module, notificationIds: 
   for notificationId in notificationIds:
     self.view.markActivityCenterNotificationUnreadDone(notificationId)
 
+method removeActivityCenterNotifications*(self: Module, notificationIds: seq[string]) =
+  self.view.removeActivityCenterNotifications(notificationIds)
+
 method acceptActivityCenterNotificationsDone*(self: Module, notificationIds: seq[string]) =
   self.view.acceptActivityCenterNotificationsDone(notificationIds)
 

--- a/src/app/modules/main/activity_center/view.nim
+++ b/src/app/modules/main/activity_center/view.nim
@@ -86,6 +86,9 @@ QtObject:
   proc markActivityCenterNotificationUnreadDone*(self: View, notificationId: string) =
      self.model.markActivityCenterNotificationUnread(notificationId)
 
+  proc removeActivityCenterNotifications*(self: View, notificationIds: seq[string]) =
+     self.model.removeNotifications(notificationIds)
+
   proc markAllChatMentionsAsRead*(self: View, communityId: string, chatId: string) =
     let notifsIds = self.model.getUnreadNotificationsForChat(chatId)
     for notifId in notifsIds:

--- a/src/app_service/service/activity_center/dto/notification.nim
+++ b/src/app_service/service/activity_center/dto/notification.nim
@@ -56,6 +56,7 @@ type ActivityCenterNotificationDto* = ref object of RootObj
   timestamp*: int64
   read*: bool
   dismissed*: bool
+  deleted*: bool
   accepted*: bool
 
 proc `$`*(self: ActivityCenterNotificationDto): string =
@@ -70,6 +71,7 @@ proc `$`*(self: ActivityCenterNotificationDto): string =
     timestamp: {self.timestamp},
     read: {$self.read},
     dismissed: {$self.dismissed},
+    deleted: {$self.deleted},
     accepted: {$self.accepted},
     message: {self.message}
     replyMessage: {self.replyMessage}
@@ -107,6 +109,7 @@ proc toActivityCenterNotificationDto*(jsonObj: JsonNode): ActivityCenterNotifica
   discard jsonObj.getProp("timestamp", result.timestamp)
   discard jsonObj.getProp("read", result.read)
   discard jsonObj.getProp("dismissed", result.dismissed)
+  discard jsonObj.getProp("deleted", result.deleted)
   discard jsonObj.getProp("accepted", result.accepted)
 
   if jsonObj.contains("message") and jsonObj{"message"}.kind != JNull:


### PR DESCRIPTION
Fixes: #9751

[STATUS-GO PR](https://github.com/status-im/status-go/pull/3277)

### What does the PR do

Remove notifications from activity center model when source was deleted.

### Affected areas

Activity Center

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

- [ ] I've checked the design and this PR matches it

