### PR TITLE
refactor: reduce calls to getMessageById and remove calls for reactions

### DIFF
--- a/src/app/modules/main/activity_center/controller.nim
+++ b/src/app/modules/main/activity_center/controller.nim
@@ -146,7 +146,7 @@ proc getOneToOneChatNameAndImage*(self: Controller, chatId: string):
   return self.chatService.getOneToOneChatNameAndImage(chatId)
 
 proc getMessageById*(self: Controller, chatId, messageId: string): MessageDto =
-  let (message, _, err) = self.messageService.getDetailsForMessage(chatId, messageId)
+  let (message, err) = self.messageService.fetchMessageByMessageId(chatId, messageId)
   if(err.len > 0):
     return MessageDto()
   return message

--- a/src/app/modules/main/activity_center/controller.nim
+++ b/src/app/modules/main/activity_center/controller.nim
@@ -145,12 +145,6 @@ proc getOneToOneChatNameAndImage*(self: Controller, chatId: string):
     tuple[name: string, image: string, largeImage: string] =
   return self.chatService.getOneToOneChatNameAndImage(chatId)
 
-proc getMessageById*(self: Controller, chatId, messageId: string): MessageDto =
-  let (message, err) = self.messageService.fetchMessageByMessageId(chatId, messageId)
-  if(err.len > 0):
-    return MessageDto()
-  return message
-
 proc setActiveNotificationGroup*(self: Controller, group: ActivityCenterGroup) =
   self.activityCenterService.setActiveNotificationGroup(group)
   self.activityCenterService.resetCursor()

--- a/src/app/modules/main/activity_center/module.nim
+++ b/src/app/modules/main/activity_center/module.nim
@@ -105,6 +105,7 @@ proc createMessageItemFromDto(self: Module, message: MessageDto, chatDetails: Ch
     message.outgoingStatus,
     self.controller.getRenderedText(message.parsedText, communityChats),
     self.controller.replacePubKeysWithDisplayNames(message.text),
+    message.parsedText,
     message.image,
     message.containsContactMentions(),
     message.seen,

--- a/src/app/modules/main/activity_center/module.nim
+++ b/src/app/modules/main/activity_center/module.nim
@@ -133,46 +133,45 @@ proc createMessageItemFromDto(self: Module, message: MessageDto, chatDetails: Ch
     ))
 
 method convertToItems*(
-  self: Module,
-  activityCenterNotifications: seq[ActivityCenterNotificationDto]
-  ): seq[notification_item.Item] =
+    self: Module,
+    activityCenterNotifications: seq[ActivityCenterNotificationDto]
+    ): seq[notification_item.Item] =
   result = activityCenterNotifications.map(
-    proc(n: ActivityCenterNotificationDto): notification_item.Item =
+    proc(notification: ActivityCenterNotificationDto): notification_item.Item =
       var messageItem =  msg_item_qobj.newMessageItem(nil)
       var repliedMessageItem =  msg_item_qobj.newMessageItem(nil)
 
-      let chatDetails = self.controller.getChatDetails(n.chatId)
+      let chatDetails = self.controller.getChatDetails(notification.chatId)
       # default section id is `Chat` section
       let sectionId = if(chatDetails.communityId.len > 0):
           chatDetails.communityId
         else:
           singletonInstance.userProfile.getPubKey()
 
-      if (n.message.id != ""):
+      if (notification.message.id != ""):
         # If there is a message in the Notification, transfer it to a MessageItem (QObject)
-        messageItem = self.createMessageItemFromDto(n.message, chatDetails)
+        messageItem = self.createMessageItemFromDto(notification.message, chatDetails)
 
-        if (n.notificationType == ActivityCenterNotificationType.Reply and n.message.responseTo != ""):
-          let repliedMessage = self.controller.getMessageById(n.chatId, n.message.responseTo)
-          repliedMessageItem = self.createMessageItemFromDto(repliedMessage, chatDetails)
+        if (notification.notificationType == ActivityCenterNotificationType.Reply and notification.message.responseTo != ""):
+          repliedMessageItem = self.createMessageItemFromDto(notification.replyMessage, chatDetails)
 
-        if (n.notificationType == ActivityCenterNotificationType.ContactVerification):
-          repliedMessageItem = self.createMessageItemFromDto(n.replyMessage, chatDetails)
+        if (notification.notificationType == ActivityCenterNotificationType.ContactVerification):
+          repliedMessageItem = self.createMessageItemFromDto(notification.replyMessage, chatDetails)
 
       return notification_item.initItem(
-        n.id,
-        n.chatId,
-        n.communityId,
-        n.membershipStatus,
-        n.verificationStatus,
+        notification.id,
+        notification.chatId,
+        notification.communityId,
+        notification.membershipStatus,
+        notification.verificationStatus,
         sectionId,
-        n.name,
-        n.author,
-        n.notificationType,
-        n.timestamp,
-        n.read,
-        n.dismissed,
-        n.accepted,
+        notification.name,
+        notification.author,
+        notification.notificationType,
+        notification.timestamp,
+        notification.read,
+        notification.dismissed,
+        notification.accepted,
         messageItem,
         repliedMessageItem,
         chatDetails.chatType

--- a/src/app/modules/main/chat_section/chat_content/controller.nim
+++ b/src/app/modules/main/chat_section/chat_content/controller.nim
@@ -201,9 +201,9 @@ proc belongsToCommunity*(self: Controller): bool =
 proc unpinMessage*(self: Controller, messageId: string) =
   self.messageService.pinUnpinMessage(self.chatId, messageId, false)
 
-proc getMessageDetails*(self: Controller, messageId: string):
-  tuple[message: MessageDto, reactions: seq[ReactionDto], error: string] =
-  return self.messageService.getDetailsForMessage(self.chatId, messageId)
+proc getMessageById*(self: Controller, messageId: string):
+    tuple[message: MessageDto, error: string] =
+  return self.messageService.fetchMessageByMessageId(self.chatId, messageId)
 
 proc isUsersListAvailable*(self: Controller): bool =
   return self.isUsersListAvailable

--- a/src/app/modules/main/chat_section/chat_content/messages/controller.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/controller.nim
@@ -261,9 +261,9 @@ proc getRenderedText*(self: Controller, parsedTextArray: seq[ParsedText], commun
 proc replacePubKeysWithDisplayNames*(self: Controller, message: string): string =
   return self.messageService.replacePubKeysWithDisplayNames(message)
 
-proc getMessageDetails*(self: Controller, messageId: string):
-  tuple[message: MessageDto, reactions: seq[ReactionDto], error: string] =
-  return self.messageService.getDetailsForMessage(self.chatId, messageId)
+proc getMessageById*(self: Controller, messageId: string):
+    tuple[message: MessageDto, error: string] =
+  return self.messageService.fetchMessageByMessageId(self.chatId, messageId)
 
 proc deleteMessage*(self: Controller, messageId: string) =
   self.messageService.deleteMessage(messageId)

--- a/src/app/modules/main/chat_section/chat_content/messages/controller.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/controller.nim
@@ -261,10 +261,6 @@ proc getRenderedText*(self: Controller, parsedTextArray: seq[ParsedText], commun
 proc replacePubKeysWithDisplayNames*(self: Controller, message: string): string =
   return self.messageService.replacePubKeysWithDisplayNames(message)
 
-proc getMessageById*(self: Controller, messageId: string):
-    tuple[message: MessageDto, error: string] =
-  return self.messageService.fetchMessageByMessageId(self.chatId, messageId)
-
 proc deleteMessage*(self: Controller, messageId: string) =
   self.messageService.deleteMessage(messageId)
 

--- a/src/app/modules/main/chat_section/chat_content/messages/io_interface.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/io_interface.nim
@@ -144,9 +144,6 @@ method didIJoinedChat*(self: AccessInterface): bool {.base.} =
 method getMessages*(self: AccessInterface): seq[message_item.Item] =
   raise newException(ValueError, "No implementation available")
 
-method getMessageById*(self: AccessInterface, messageId: string): message_item.Item {.base.} =
-  raise newException(ValueError, "No implementation available")
-
 method onMailserverSynced*(self: AccessInterface, syncedFrom: int64) =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/chat_section/chat_content/messages/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/module.nim
@@ -92,6 +92,7 @@ proc createFetchMoreMessagesItem(self: Module): Item =
     outgoingStatus = "",
     text = "",
     unparsedText = "",
+    parsedText = @[],
     image = "",
     messageContainsMentions = false,
     seen = true,
@@ -146,6 +147,7 @@ proc createChatIdentifierItem(self: Module): Item =
     outgoingStatus = "",
     text = "",
     unparsedText = "",
+    parsedText = @[],
     image = "",
     messageContainsMentions = false,
     seen = true,
@@ -248,6 +250,7 @@ method newMessagesLoaded*(self: Module, messages: seq[MessageDto], reactions: se
         message.outgoingStatus,
         renderedMessageText,
         self.controller.replacePubKeysWithDisplayNames(message.text),
+        message.parsedText,
         message.image,
         message.containsContactMentions(),
         message.seen,
@@ -371,6 +374,7 @@ method messagesAdded*(self: Module, messages: seq[MessageDto]) =
       message.outgoingStatus,
       renderedMessageText,
       self.controller.replacePubKeysWithDisplayNames(message.text),
+      message.parsedText,
       message.image,
       message.containsContactMentions(),
       message.seen,
@@ -544,12 +548,9 @@ method updateContactDetails*(self: Module, contactId: string) =
       item.quotedMessageAuthorAvatar = updatedContact.icon
 
     if item.messageContainsMentions and item.mentionedUsersPks.anyIt(it == contactId):
-      let (message, err) = self.controller.getMessageById(item.id)
-      if err == "":
-        let chatDetails = self.controller.getChatDetails()
-        let communityChats = self.controller.getCommunityById(chatDetails.communityId).chats
-        item.messageText = self.controller.getRenderedText(message.parsedText, communityChats)
-        item.messageContainsMentions = message.containsContactMentions()
+      let chatDetails = self.controller.getChatDetails()
+      let communityChats = self.controller.getCommunityById(chatDetails.communityId).chats
+      item.messageText = self.controller.getRenderedText(item.parsedText, communityChats)
 
 method deleteMessage*(self: Module, messageId: string) =
   self.controller.deleteMessage(messageId)
@@ -573,6 +574,7 @@ method onMessageEdited*(self: Module, message: MessageDto) =
     message.id,
     self.controller.getRenderedText(message.parsedText, communityChats),
     self.controller.replacePubKeysWithDisplayNames(message.text),
+    message.parsedText,
     message.contentType,
     message.containsContactMentions(),
     message.links,

--- a/src/app/modules/main/chat_section/chat_content/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/module.nim
@@ -187,6 +187,7 @@ proc buildPinnedMessageItem(self: Module, messageId: string, actionInitiatedBy: 
     message.outgoingStatus,
     self.controller.getRenderedText(message.parsedText, communityChats),
     self.controller.replacePubKeysWithDisplayNames(message.text),
+    message.parsedText,
     message.image,
     message.containsContactMentions(),
     message.seen,
@@ -345,12 +346,9 @@ method onContactDetailsUpdated*(self: Module, contactId: string) =
       item.quotedMessageAuthorAvatar = updatedContact.icon
 
     if item.messageContainsMentions and item.mentionedUsersPks.anyIt(it == contactId):
-      let (message, err) = self.controller.getMessageById(item.id)
-      if err == "":
-        let chatDetails = self.controller.getChatDetails()
-        let communityChats = self.controller.getCommunityById(chatDetails.communityId).chats
-        item.messageText = self.controller.getRenderedText(message.parsedText, communityChats)
-        item.messageContainsMentions = message.containsContactMentions()
+      let chatDetails = self.controller.getChatDetails()
+      let communityChats = self.controller.getCommunityById(chatDetails.communityId).chats
+      item.messageText = self.controller.getRenderedText(item.parsedText, communityChats)
 
   if(self.controller.getMyChatId() == contactId):
     self.view.updateChatDetailsNameAndIcon(updatedContact.defaultDisplayName, updatedContact.icon)

--- a/src/app/modules/shared_models/message_item.nim
+++ b/src/app/modules/shared_models/message_item.nim
@@ -22,6 +22,8 @@ type
     outgoingStatus: string
     messageText: string
     unparsedText: string
+    # Saving the parsed text property because we need it to getRenderedText when mentions change
+    parsedText: seq[ParsedText]
     messageImage: string
     messageContainsMentions: bool
     sticker: string
@@ -68,7 +70,8 @@ proc initItem*(
     senderIsAdded: bool,
     outgoingStatus,
     text,
-    unparsedText,
+    unparsedText: string,
+    parsedText: seq[ParsedText],
     image: string,
     messageContainsMentions,
     seen: bool,
@@ -110,6 +113,7 @@ proc initItem*(
   result.outgoingStatus = outgoingStatus
   result.messageText = text
   result.unparsedText = unparsedText
+  result.parsedText = parsedText
   result.messageImage = image
   result.messageContainsMentions = messageContainsMentions
   result.timestamp = timestamp
@@ -184,6 +188,7 @@ proc initNewMessagesMarkerItem*(clock, timestamp: int64): Item =
     outgoingStatus = "",
     text = "",
     unparsedText = "",
+    parsedText = @[],
     image = "",
     messageContainsMentions = false,
     seen = true,
@@ -226,6 +231,7 @@ proc `$`*(self: Item): string =
     resendError:{$self.resendError},
     messageText:{self.messageText},
     unparsedText:{self.unparsedText},
+    parsedText:{$self.parsedText},
     messageContainsMentions:{self.messageContainsMentions},
     timestamp:{$self.timestamp},
     contentType:{$self.contentType.int},
@@ -323,6 +329,12 @@ proc unparsedText*(self: Item): string {.inline.} =
 
 proc `unparsedText=`*(self: Item, value: string) {.inline.} =
   self.unparsedText = value
+
+proc parsedText*(self: Item): seq[ParsedText] {.inline.} =
+  self.parsedText
+
+proc `parsedText=`*(self: Item, value: seq[ParsedText]) {.inline.} =
+  self.parsedText = value
 
 proc messageImage*(self: Item): string {.inline.} =
   self.messageImage

--- a/src/app/modules/shared_models/message_model.nim
+++ b/src/app/modules/shared_models/message_model.nim
@@ -588,6 +588,7 @@ QtObject:
       messageId: string,
       updatedMsg: string,
       updatedRawMsg: string,
+      updatedParsedText: seq[ParsedText],
       contentType: int,
       messageContainsMentions: bool,
       links: seq[string],
@@ -602,6 +603,7 @@ QtObject:
     self.items[ind].isEdited = true
     self.items[ind].links = links
     self.items[ind].mentionedUsersPks = mentionedUsersPks
+    self.items[ind].parsedText = updatedParsedText
 
     let index = self.createIndex(ind, 0, nil)
     self.dataChanged(index, index, @[

--- a/src/app_service/service/message/service.nim
+++ b/src/app_service/service/message/service.nim
@@ -499,8 +499,8 @@ QtObject:
     except Exception as e:
       error "error: ", procName="pinUnpinMessage", errName = e.name, errDesription = e.msg
 
-  proc getDetailsForMessage*(self: Service, chatId: string, messageId: string):
-    tuple[message: MessageDto, reactions: seq[ReactionDto], error: string] =
+  proc fetchMessageByMessageId*(self: Service, chatId: string, messageId: string):
+      tuple[message: MessageDto, error: string] =
     try:
       let msgResponse = status_go.fetchMessageByMessageId(messageId)
       if(msgResponse.error.isNil):
@@ -509,14 +509,9 @@ QtObject:
       if(result.message.id.len == 0):
         result.error = "message with id: " & messageId & " doesn't exist"
         return
-
-      let reactionsResponse = status_go.fetchReactionsForMessageWithId(chatId, messageId)
-      if(reactionsResponse.error.isNil):
-        result.reactions = map(reactionsResponse.result.getElems(), proc(x: JsonNode): ReactionDto = x.toReactionDto())
-
     except Exception as e:
       result.error = e.msg
-      error "error: ", procName="getDetailsForMessage", errName = e.name, errDesription = e.msg
+      error "error: ", procName="fetchMessageByMessageId", errName = e.name, errDesription = e.msg
 
   proc finishAsyncSearchMessagesWithError*(self: Service, chatId, errorMessage: string) =
     error "error: ", procName="onAsyncSearchMessages", errDescription = errorMessage

--- a/test/nim/message_model_test.nim
+++ b/test/nim/message_model_test.nim
@@ -23,6 +23,7 @@ proc createTestMessageItem(id: string, clock: int64): Item =
     outgoingStatus = "",
     text = "",
     unparsedText = "",
+    parsedText = @[],
     image = "",
     messageContainsMentions = false,
     seen = true,


### PR DESCRIPTION
Fixes #9859

getMessageById was called way too often, because each time a contact was updated, we called it on every message that contained a mention. Now we only call it on messages that contain a mention from that specific user.

Also, we called emojiReactionsByChatIDMessageID as part of that service call, but only the pinned message used it, so I removed it from the service function. This means that the pinned messages will no longer have the emoji reactions. I could add them back if we really want, but IMO, it's not really necessary. You can just click on the message and see it in the chat instead.

I removed the call to `getMessageById` in the activity center as well, since we can get the replied message info from the MessageDto directly now.

I also removed some dead code in the messages module.

~~I'm gonna try to improve it some more so that we don't need `getMessageById` at all when trying to update a mention, but it's a bit harder, because we don't keep the full message data in the item.~~
Done. The message now gets reparsed using the cached `parsedText`, instead of re-fetching the message

For QAs testing this, check that messages, user info in the messages, replies, mentions and activity center notifications still work well, especially in the context of a contact being updated (eg changing the name of a contact makes that person's messages, mentions, replies update)