### PR TITLE
fix(@desktop/wallet): disable 'favourite' functionality for saved

### DIFF
--- a/ui/app/AppLayouts/Wallet/controls/SavedAddressesDelegate.qml
+++ b/ui/app/AppLayouts/Wallet/controls/SavedAddressesDelegate.qml
@@ -40,7 +40,7 @@ StatusListItem {
             return WalletUtils.colorizedChainPrefix(chainShortNames) + address
     }
     border.color: Theme.palette.baseColor5
-    asset.name: root.favourite ? "star-icon" : "favourite"
+    asset.name: d.favouriteEnabled ? (root.favourite ? "star-icon" : "favourite") : ""
     asset.color: root.favourite ? Theme.palette.pinColor1 : (showButtons ? Theme.palette.directColor1 : Theme.palette.baseColor1) // star icon color default
     asset.hoverColor: root.favourite ? "transparent": Theme.palette.directColor1 // star icon color on hover
     asset.bgColor: statusListItemIcon.hovered ? Theme.palette.primaryColor3 : "transparent" // icon outer background color
@@ -61,6 +61,7 @@ StatusListItem {
         id: d
 
         readonly property string visibleAddress: root.address == Constants.zeroAddress ? root.ens : root.address
+        readonly property bool favouriteEnabled: false // Disabling favourite functionality until good times
     }
 
     components: [


### PR DESCRIPTION
addresses

Fixes #9774

### What does the PR do

It was decided to drop the feature for now, because adding address to saved addresses makes it somewhat favourite.
Quoting @benjthayer "We can always add back in if we see a need later or if it is upvoted as an enhancement."
So I just hid the button without removing all the functionality.

### Affected areas

Wallet/Saved Addresses

### Screenshot of functionality (including design for comparison)

- [x ] I've checked the design and this PR matches it
![saved_addresses_no_favourite_button](https://user-images.githubusercontent.com/15627093/224947383-44487dec-934e-4f46-9c56-a0559aa865d5.png)

