### PR TITLE
fix(NotificationsView): fixup global @everyone text

### DIFF
--- a/ui/app/AppLayouts/Profile/views/NotificationsView.qml
+++ b/ui/app/AppLayouts/Profile/views/NotificationsView.qml
@@ -305,7 +305,7 @@ SettingsContentBase {
         StatusListItem {
             Layout.preferredWidth: root.contentWidth
             title: qsTr("Global @ Mentions")
-            tertiaryTitle: qsTr("Messages containing @here and @channel")
+            tertiaryTitle: qsTr("Messages containing @everyone")
             components: [
                 NotificationSelect {
                     selected: appSettings.notifSettingGlobalMentions


### PR DESCRIPTION
Fixes #9708

### What does the PR do

Use `@everyone` instead of `@here` and `@channel` for the description

### Affected areas

Settings/NotificationsView

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![image](https://user-images.githubusercontent.com/5377645/224979476-f39e5c88-411d-4c7a-80fc-a6b30580e098.png)

