### PR TITLE
fix(@desktop/chats): Always show the message header in the private group chats after system message

### DIFF
--- a/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
@@ -213,7 +213,6 @@ Item {
             id: msgDelegate
 
             width: ListView.view.width
-            height: implicitHeight
 
             objectName: "chatMessageViewDelegate"
             rootStore: root.rootStore

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -55,6 +55,7 @@ Loader {
     property string messageOutgoingStatus: ""
     property string resendError: ""
     property int messageContentType: Constants.messageContentType.messageType
+
     property bool pinnedMessage: false
     property string messagePinnedBy: ""
     property var reactionsModel: []
@@ -443,7 +444,8 @@ Loader {
                 reactionsModel: root.reactionsModel
 
                 showHeader: root.shouldRepeatHeader || dateGroupLabel.visible || isAReply ||
-                            (root.prevMessageContentType !== Constants.messageContentType.systemMessagePrivateGroupType && root.senderId !== root.prevMessageSenderId)
+                            root.prevMessageContentType === Constants.messageContentType.systemMessagePrivateGroupType ||
+                            root.senderId !== root.prevMessageSenderId
                 isActiveMessage: d.isMessageActive
                 topPadding: showHeader ? Style.current.halfPadding : 0
                 bottomPadding: showHeader && d.nextMessageHasHeader() ? Style.current.halfPadding : 2


### PR DESCRIPTION
### What does the PR do

Always show the message header in the private group chats after the system message

Fixes: #9827 

### Affected areas

Private group chat message headers

### Screenshot of functionality (including design for comparison)

https://user-images.githubusercontent.com/117639195/224989750-9808d46c-0dc6-4b97-8fde-b69cb73a35fd.mov

