### PR TITLE
Nim 1.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,4 @@ build/
 *.exe
 *.out
 *.app
+nimbus-build-system.paths

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "vendor/nimbus-build-system"]
 	path = vendor/nimbus-build-system
 	url = https://github.com/status-im/nimbus-build-system.git
-	branch = status-desktop-1-2
+	branch = status-desktop
 [submodule "vendor/nimqml"]
 	path = vendor/nimqml
 	url = https://github.com/status-im/nimqml.git

--- a/config.nims
+++ b/config.nims
@@ -45,3 +45,6 @@ switch("warning", "ObservableStores:off")
 
 # Too many false positives for "Warning: method has lock level <unknown>, but another method has 0 [LockLevel]"
 switch("warning", "LockLevel:off")
+
+# No clean workaround for this warning in certain cases, waiting for better upstream support
+switch("warning", "BareExcept:off")

--- a/src/app/core/main.nim
+++ b/src/app/core/main.nim
@@ -7,7 +7,7 @@ import
   ./custom_urls/urls_manager
 
 export eventemitter
-export signals_manager, fleet_configuration
+export threadpool, signals_manager, fleet_configuration
 
 type StatusFoundation* = ref object
   events*: EventEmitter

--- a/src/app/core/tasks/threadpool.nim
+++ b/src/app/core/tasks/threadpool.nim
@@ -7,7 +7,7 @@ import # vendor libs
 import # status-desktop libs
   ./common 
 
-export common, json_serialization
+export common, json_serialization, taskpools
 
 logScope:
   topics = "task-threadpool"

--- a/src/app/modules/main/wallet_section/accounts/view.nim
+++ b/src/app/modules/main/wallet_section/accounts/view.nim
@@ -123,6 +123,7 @@ QtObject:
     var generatedAccounts: seq[GeneratedWalletItem] = @[]
 
     for item in items:
+      let item = item # TODO https://github.com/nim-lang/Nim/issues/16740
       #  Default Account
       if item.getWalletType() == "":
         statusDefaultAccountDerivedFrom = item.getDerivedFrom()

--- a/src/app_service/common/message.nim
+++ b/src/app_service/common/message.nim
@@ -12,6 +12,7 @@ proc replacePubKeysWithDisplayNames*(allKnownContacts: seq[ContactsDto], message
     updatedMessage = updatedMessage.replaceWord(pair[1], pair[0])
 
   for pk in pubKeys:
+    let pk = pk # TODO https://github.com/nim-lang/Nim/issues/16740
     let listOfMatched = allKnownContacts.filter(x => "@" & x.id == pk)
     if(listOfMatched.len > 0):
       updatedMessage = updatedMessage.replaceWord(pk, "@" & listOfMatched[0].userDefaultDisplayName())
@@ -35,16 +36,19 @@ proc replaceMentionsWithPubKeys*(allKnownContacts: seq[ContactsDto], message: st
   # In the following lines we're free to compare to `x.userDefaultDisplayName()` cause that's actually what we're displaying
   # in the mentions suggestion list.
   for mention in aliasMentions:
+    let mention = mention # TODO https://github.com/nim-lang/Nim/issues/16740
     let listOfMatched = allKnownContacts.filter(x => "@" & x.userDefaultDisplayName().toLowerAscii == mention.toLowerAscii)
     if(listOfMatched.len > 0):
       updatedMessage = updatedMessage.replaceWord(mention, '@' & listOfMatched[0].id)
 
   for mention in ensMentions:
+    let mention = mention # TODO https://github.com/nim-lang/Nim/issues/16740
     let listOfMatched = allKnownContacts.filter(x => "@" & x.name.toLowerAscii == mention.toLowerAscii)
     if(listOfMatched.len > 0):
       updatedMessage = updatedMessage.replaceWord(mention, '@' & listOfMatched[0].id)
 
   for mention in nameMentions:
+    let mention = mention # TODO https://github.com/nim-lang/Nim/issues/16740
     let listOfMatched = allKnownContacts.filter(x => x.userDefaultDisplayName().toLowerAscii == mention.toLowerAscii or
       "@" & x.userDefaultDisplayName().toLowerAscii == mention.toLowerAscii)
     if(listOfMatched.len > 0):

--- a/src/app_service/service/token/service.nim
+++ b/src/app_service/service/token/service.nim
@@ -86,6 +86,7 @@ QtObject:
       let networks = self.networkService.getNetworks()
     
       for network in networks:
+        let network = network # TODO https://github.com/nim-lang/Nim/issues/16740
         var found = false
         for chainId in self.tokens.keys:
           if chainId == network.chainId:

--- a/src/app_service/service/wallet_account/service.nim
+++ b/src/app_service/service/wallet_account/service.nim
@@ -266,6 +266,7 @@ QtObject:
     try:
       let accounts = self.fetchAccounts()
       for account in accounts:
+        let account = account # TODO https://github.com/nim-lang/Nim/issues/16740
         self.setEnsName(account)
         self.setRelatedAccountsToAccount(account)
         self.storeAccount(account)
@@ -335,6 +336,7 @@ QtObject:
     var newAccount: WalletAccountDto
     var found = false
     for account in accounts:
+      let account = account # TODO https://github.com/nim-lang/Nim/issues/16740
       if not self.walletAccountsContainsAddress(account.address):
         found = true
         newAccount = account


### PR DESCRIPTION
closes https://github.com/status-im/status-desktop/issues/9603

Upgrade Nim compiler to 1.6.

The necessary changes are related to how `for` loops now implicitly create a `lent` type, which is Nim's way of creating a "temporary" reference to an item inside a collection - this helps performance by avoiding a copy of the data, but it also means that the copy that previously was implicit in the for loop must be made explicit in the code, where memory safety requirements dictate it's needed.
