### PR TITLE
fix(@desktop/communities): Chain details (name, icon) are taken from …

### DIFF
--- a/src/app/modules/main/communities/controller.nim
+++ b/src/app/modules/main/communities/controller.nim
@@ -5,6 +5,7 @@ import ../../../core/signals/types
 import ../../../core/eventemitter
 import ../../../../app_service/service/community/service as community_service
 import ../../../../app_service/service/contacts/service as contacts_service
+import ../../../../app_service/service/network/service as networks_service
 import ../../../../app_service/service/community_tokens/service as community_tokens_service
 
 type
@@ -14,6 +15,7 @@ type
     communityService: community_service.Service
     contactsService: contacts_service.Service
     communityTokensService: community_tokens_service.Service
+    networksService: networks_service.Service
 
 proc newController*(
     delegate: io_interface.AccessInterface,
@@ -21,6 +23,7 @@ proc newController*(
     communityService: community_service.Service,
     contactsService: contacts_service.Service,
     communityTokensService: community_tokens_service.Service,
+    networksService: networks_service.Service,
     ): Controller =
   result = Controller()
   result.delegate = delegate
@@ -28,6 +31,7 @@ proc newController*(
   result.communityService = communityService
   result.contactsService = contactsService
   result.communityTokensService = communityTokensService
+  result.networksService = networksService
 
 proc delete*(self: Controller) =
   discard
@@ -243,3 +247,6 @@ proc requestCancelDiscordCommunityImport*(self: Controller, id: string) =
 
 proc getCommunityTokens*(self: Controller, communityId: string): seq[CommunityTokenDto] =
   self.communityTokensService.getCommunityTokens(communityId)
+
+proc getNetworks*(self:Controller): seq[NetworkDto] =
+  self.networksService.getNetworks()

--- a/src/app/modules/main/communities/tokens/models/token_item.nim
+++ b/src/app/modules/main/communities/tokens/models/token_item.nim
@@ -1,0 +1,27 @@
+import strformat
+import ../../../../../../app_service/service/community_tokens/dto/community_token
+
+export community_token
+
+type
+  TokenItem* = object
+    tokenDto*: CommunityTokenDto
+    chainName*: string
+    chainIcon*: string
+
+proc initTokenItem*(
+  tokenDto: CommunityTokenDto,
+  chainName: string,
+  chainIcon: string,
+): TokenItem =
+  result.tokenDto = tokenDto
+  result.chainName = chainName
+  result.chainIcon = chainIcon
+
+proc `$`*(self: TokenItem): string =
+  result = fmt"""TokenItem(
+    tokenDto: {self.tokenDto},
+    chainName: {self.chainName},
+    chainIcon: {self.chainIcon}
+    ]"""
+

--- a/src/app/modules/main/communities/tokens/models/token_model.nim
+++ b/src/app/modules/main/communities/tokens/models/token_model.nim
@@ -1,4 +1,5 @@
 import NimQml, Tables, strformat
+import token_item
 import ../../../../../../app_service/service/community_tokens/dto/community_token
 
 type
@@ -15,10 +16,12 @@ type
     ChainId
     DeployState
     Image
+    ChainName
+    ChainIcon
 
 QtObject:
   type TokenModel* = ref object of QAbstractListModel
-    items*: seq[CommunityTokenDto]
+    items*: seq[TokenItem]
 
   proc setup(self: TokenModel) =
     self.QAbstractListModel.setup
@@ -33,21 +36,21 @@ QtObject:
 
   proc updateDeployState*(self: TokenModel, contractAddress: string, deployState: DeployState) =
     for i in 0 ..< self.items.len:
-      if(self.items[i].address == contractAddress):
-        self.items[i].deployState = deployState
+      if(self.items[i].tokenDto.address == contractAddress):
+        self.items[i].tokenDto.deployState = deployState
         let index = self.createIndex(i, 0, nil)
         self.dataChanged(index, index, @[ModelRole.DeployState.int])
         return
 
   proc countChanged(self: TokenModel) {.signal.}
 
-  proc setItems*(self: TokenModel, items: seq[CommunityTokenDto]) =
+  proc setItems*(self: TokenModel, items: seq[TokenItem]) =
     self.beginResetModel()
     self.items = items
     self.endResetModel()
     self.countChanged()
 
-  proc appendItem*(self: TokenModel, item: CommunityTokenDto) =
+  proc appendItem*(self: TokenModel, item: TokenItem) =
     let parentModelIndex = newQModelIndex()
     defer: parentModelIndex.delete
 
@@ -80,6 +83,8 @@ QtObject:
       ModelRole.ChainId.int:"chainId",
       ModelRole.DeployState.int:"deployState",
       ModelRole.Image.int:"image",
+      ModelRole.ChainName.int:"chainName",
+      ModelRole.ChainIcon.int:"chainIcon",
     }.toTable
 
   method data(self: TokenModel, index: QModelIndex, role: int): QVariant =
@@ -91,29 +96,33 @@ QtObject:
     let enumRole = role.ModelRole
     case enumRole:
       of ModelRole.TokenType:
-        result = newQVariant(item.tokenType.int)
+        result = newQVariant(item.tokenDto.tokenType.int)
       of ModelRole.TokenAddress:
-        result = newQVariant(item.address)
+        result = newQVariant(item.tokenDto.address)
       of ModelRole.Name:
-        result = newQVariant(item.name)
+        result = newQVariant(item.tokenDto.name)
       of ModelRole.Symbol:
-        result = newQVariant(item.symbol)
+        result = newQVariant(item.tokenDto.symbol)
       of ModelRole.Description:
-        result = newQVariant(item.description)
+        result = newQVariant(item.tokenDto.description)
       of ModelRole.Supply:
-        result = newQVariant(item.supply)
+        result = newQVariant(item.tokenDto.supply)
       of ModelRole.InfiniteSupply:
-        result = newQVariant(item.infiniteSupply)
+        result = newQVariant(item.tokenDto.infiniteSupply)
       of ModelRole.Transferable:
-        result = newQVariant(item.transferable)
+        result = newQVariant(item.tokenDto.transferable)
       of ModelRole.RemoteSelfDestruct:
-        result = newQVariant(item.remoteSelfDestruct)
+        result = newQVariant(item.tokenDto.remoteSelfDestruct)
       of ModelRole.ChainId:
-        result = newQVariant(item.chainId)
+        result = newQVariant(item.tokenDto.chainId)
       of ModelRole.DeployState:
-        result = newQVariant(item.deployState.int)
+        result = newQVariant(item.tokenDto.deployState.int)
       of ModelRole.Image:
-        result = newQVariant(item.image)
+        result = newQVariant(item.tokenDto.image)
+      of ModelRole.ChainName:
+        result = newQVariant(item.chainName)
+      of ModelRole.ChainIcon:
+        result = newQVariant(item.chainIcon)
 
   proc `$`*(self: TokenModel): string =
       for i in 0 ..< self.items.len:

--- a/src/app/modules/main/controller.nim
+++ b/src/app/modules/main/controller.nim
@@ -20,6 +20,7 @@ import ../../../app_service/service/node/service as node_service
 import ../../../app_service/service/community_tokens/service as community_tokens_service
 import ../../../app_service/service/wallet_account/service as wallet_account_service
 import ../../../app_service/service/token/service as token_service
+import ../../../app_service/service/network/service as networks_service
 
 import ../shared_models/section_item, io_interface
 import ../shared_modules/keycard_popup/io_interface as keycard_shared_module
@@ -50,6 +51,7 @@ type
     authenticateUserFlowRequestedBy: string
     walletAccountService: wallet_account_service.Service
     tokenService: token_service.Service
+    networksService: networks_service.Service
 
 # Forward declaration
 proc setActiveSection*(self: Controller, sectionId: string, skipSavingInSettings: bool = false)
@@ -69,7 +71,8 @@ proc newController*(delegate: io_interface.AccessInterface,
   nodeService: node_service.Service,
   communityTokensService: community_tokens_service.Service,
   walletAccountService: wallet_account_service.Service,
-  tokenService: token_service.Service
+  tokenService: token_service.Service,
+  networksService: networks_service.Service
 ):
   Controller =
   result = Controller()
@@ -89,6 +92,7 @@ proc newController*(delegate: io_interface.AccessInterface,
   result.communityTokensService = communityTokensService
   result.walletAccountService = walletAccountService
   result.tokenService = tokenService
+  result.networksService = networksService
 
 proc delete*(self: Controller) =
   discard
@@ -427,3 +431,6 @@ proc getVerificationRequestFrom*(self: Controller, publicKey: string): Verificat
 
 proc getCommunityTokens*(self: Controller, communityId: string): seq[CommunityTokenDto] =
   self.communityTokensService.getCommunityTokens(communityId)
+
+proc getNetworks*(self:Controller): seq[NetworkDto] =
+  self.networksService.getNetworks()

--- a/src/app/modules/shared_models/section_item.nim
+++ b/src/app/modules/shared_models/section_item.nim
@@ -2,10 +2,11 @@ import strformat
 import ./member_model, ./member_item
 import ../main/communities/models/[pending_request_item, pending_request_model]
 import ../main/communities/tokens/models/token_model as community_tokens_model
+import ../main/communities/tokens/models/token_item
+
 import ../../global/global_singleton
 
 import ../../../app_service/common/types
-import ../../../app_service/service/community_tokens/dto/community_token
 
 type
   SectionType* {.pure.} = enum
@@ -89,7 +90,7 @@ proc initItem*(
     pendingMemberRequests: seq[MemberItem] = @[],
     declinedMemberRequests: seq[MemberItem] = @[],
     encrypted: bool = false,
-    communityTokens: seq[CommunityTokenDto] = @[],
+    communityTokens: seq[TokenItem] = @[],
     ): SectionItem =
   result.id = id
   result.sectionType = sectionType
@@ -310,7 +311,7 @@ proc pinMessageAllMembersEnabled*(self: SectionItem): bool {.inline.} =
 proc encrypted*(self: SectionItem): bool {.inline.} =
   self.encrypted
 
-proc appendCommunityToken*(self: SectionItem, item: CommunityTokenDto) {.inline.} =
+proc appendCommunityToken*(self: SectionItem, item: TokenItem) {.inline.} =
   self.communityTokensModel.appendItem(item)
 
 proc updateCommunityTokenDeployState*(self: SectionItem, contractAddress: string, deployState: DeployState) {.inline.} =

--- a/src/app/modules/shared_models/section_model.nim
+++ b/src/app/modules/shared_models/section_model.nim
@@ -3,7 +3,7 @@ import NimQml, Tables, strutils, strformat
 import json, json_serialization
 
 import section_item, member_model
-import ../../../app_service/service/community_tokens/dto/community_token
+import ../main/communities/tokens/models/token_item
 
 
 type
@@ -366,7 +366,7 @@ QtObject:
         self.notificationsCountChanged()
         return
 
-  proc appendCommunityToken*(self: SectionModel, id: string, item: CommunityTokenDto) =
+  proc appendCommunityToken*(self: SectionModel, id: string, item: TokenItem) =
     for i in 0 ..< self.items.len:
       if(self.items[i].id == id):
         let index = self.createIndex(i, 0, nil)

--- a/ui/app/AppLayouts/Chat/views/communities/CommunityMintedTokensView.qml
+++ b/ui/app/AppLayouts/Chat/views/communities/CommunityMintedTokensView.qml
@@ -94,8 +94,9 @@ StatusScrollView {
                                             model.transferable,
                                             model.remoteSelfDestruct,
                                             model.chainId,
-                                            "Goerli", //model.chainName, TODO BACKEND
-                                            "network/Network=Custom")//model.chainIcon) TODO BACKEND
+                                            model.chainName,
+                                            model.chainIcon)
+
 
             }
         }


### PR DESCRIPTION
Chain details (name, icon) are taken from model.

Introduce TokenItem struct.
TokenModel keeps TokenItems.
TokenItem keeps CommunityTokenDto and chain details. Chain details are taken from networks service.

Fix #9867

### Screenshot of functionality (including design for comparison)

![image](https://user-images.githubusercontent.com/61889657/225288054-1bb878ca-0356-4dde-97bd-40fdaf24e56f.png)
