### PR TITLE
fix(CommunityPermissionsSettingsPanel): Fix height and width for permission views

### DIFF
--- a/ui/app/AppLayouts/Chat/panels/communities/CommunityPermissionsSettingsPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/CommunityPermissionsSettingsPanel.qml
@@ -286,7 +286,6 @@ SettingsPageLayout {
             communityDetails: root.communityDetails
 
             viewWidth: root.viewWidth
-            height: root.height
 
             function setInitialValuesFromIndex(index) {
                 const item = ModelUtils.get(root.permissionsModel, index)


### PR DESCRIPTION
### What does the PR do
Fixing: https://github.com/status-im/status-desktop/issues/9765

The height and width is set by [SettingsPageLayout](https://github.com/status-im/status-desktop/blob/33d38a408124ba63243bd8af12874a9d4e817104/ui/app/AppLayouts/Chat/layouts/SettingsPageLayout.qml#L84). Overriding it breaks the layout.
<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas
Community Permissions
<!-- List the affected areas (e.g wallet, browser, etc..) -->

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [x] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

https://user-images.githubusercontent.com/47811206/225901737-76c21a60-b13f-4d28-a400-73d0b670530d.mov


- [x] I've checked the design and this PR matches it

<!-- screenshot (or gif/video) that demonstrates the functionality, specially important if it's a bug fix. -->

### Cool Spaceship Picture

<!-- optional but cool ->
