### PR TITLE
fix(Contacts): Add Reverse Contact Rejection to profile actions

### DIFF
--- a/ui/imports/shared/views/ProfileDialogView.qml
+++ b/ui/imports/shared/views/ProfileDialogView.qml
@@ -183,6 +183,22 @@ Pane {
     }
 
     Component {
+        id: btnRevertContactRequestRejectionComponent
+
+        StatusButton {
+            size: StatusButton.Size.Small
+            text: qsTr("Reverse Contact Rejection")
+            icon.name: "refresh"
+            icon.width: 16
+            icon.height: 16
+            onClicked: {
+                root.contactsStore.removeContactRequestRejection(root.publicKey)
+                d.reload()
+            }
+        }
+    }
+
+    Component {
         id: btnSendContactRequestComponent
         StatusButton {
             objectName: "profileDialog_sendContactRequestButton"
@@ -352,13 +368,19 @@ Pane {
                     // contact request, outgoing, rejected
                     if (!d.isContact && d.isContactRequestSent && d.outgoingVerificationStatus === Constants.verificationStatus.declined)
                         return txtRejectedContactRequestComponent
+
                     // contact request, outgoing, pending
                     if (!d.isContact && d.isContactRequestSent)
                         return txtPendingContactRequestComponent
 
                     // contact request, incoming, pending
-                    if (!d.isContact && d.isContactRequestReceived && !d.contactDetails.removed)
-                        return btnAcceptContactRequestComponent
+                    if (!d.isContact && d.isContactRequestReceived) {
+                        if (d.contactDetails.removed) {
+                            return btnRevertContactRequestRejectionComponent
+                        } else {
+                            return btnAcceptContactRequestComponent
+                        }
+                    }
 
                     // contact request, incoming, rejected
                     if (d.isContactRequestSent && d.incomingVerificationStatus === Constants.verificationStatus.declined)

--- a/ui/imports/shared/views/ProfileDialogView.qml
+++ b/ui/imports/shared/views/ProfileDialogView.qml
@@ -469,16 +469,6 @@ Pane {
                         }
                     }
                     StatusAction {
-                        text: qsTr("Reverse Contact Rejection")
-                        icon.name: "refresh"
-                        enabled: d.contactDetails.removed
-                        onTriggered: {
-                            moreMenu.close()
-                            root.contactsStore.removeContactRequestRejection(root.publicKey)
-                            d.reload()
-                        }
-                    }
-                    StatusAction {
                         text: qsTr("Copy Link to Profile")
                         icon.name: "copy"
                         onTriggered: {


### PR DESCRIPTION
Close #9897

### What does the PR do

Add Reverse Contact Rejection action to profile

### Affected areas

Profile, Contacts

### Screenshot of functionality (including design for comparison)

https://user-images.githubusercontent.com/2522130/225340066-34741232-42c8-4b06-80bd-adb066ec32cb.mov

