### PR TITLE
fix(StatusTooltip): long text goes out of bounds

### DIFF
--- a/ui/StatusQ/sandbox/controls/Controls.qml
+++ b/ui/StatusQ/sandbox/controls/Controls.qml
@@ -48,7 +48,7 @@ ColumnLayout {
         text: "Hover me!"
         StatusToolTip {
             visible: parent.hovered
-            text: "Top"
+            text: "http://thelongestlistofthelongeststuffatthelongestdomainnameatlonglast.com%2Fwearejustdoingthistobestupidnowsincethiscangoonforeverandeverandeverbutitstilllookskindaneatinthebrowsereventhoughitsabigwasteoftimeandenergyandhasnorealpointbutwehadtodoitanyways.html&ei=40egUo2MGI3xoATQtIKwDQ&usg=AFQjCNHbBa5Fk4YutdUOj_D8IwpJLu7hGw&sig2=8P4ew1Yie72Ps_OQ-L5cXw&bvm=bv.57155469%2Cd.cGU"
         }
         StatusToolTip {
             visible: parent.hovered

--- a/ui/StatusQ/src/StatusQ/Controls/StatusToolTip.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusToolTip.qml
@@ -65,11 +65,12 @@ ToolTip {
         text: statusToolTip.text
         color: Theme.palette.white
         linkColor: Theme.palette.white
-        wrapMode: Text.WordWrap
+        wrapMode: Text.Wrap
         font.pixelSize: 13
         font.weight: Font.Medium
         horizontalAlignment: Text.AlignHCenter
         bottomPadding: 8
         textFormat: Text.RichText
+        elide: Text.ElideRight
     }
 }


### PR DESCRIPTION
Fixes #9918

### What does the PR do

Fixes word wrap/elide for overly long text in the tooltip

### Affected areas

StatusTooltip

### StatusQ checklist

- [x] add documentation if necessary (new component, new feature)
- [x] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [x] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![Snímek obrazovky z 2023-03-16 11-37-05](https://user-images.githubusercontent.com/5377645/225691876-b0c8b0b3-9dc0-446d-9aa8-ce8ee5db501c.png)
