### PR TITLE
tests(wallet) disable add watch only account failing test

### DIFF
--- a/test/ui-test/testSuites/suite_wallet/tst_wallet/test.feature
+++ b/test/ui-test/testSuites/suite_wallet/tst_wallet/test.feature
@@ -17,6 +17,7 @@ Feature: Status Desktop Wallet
         Given the user opens wallet screen
         And the user clicks on the first account
 
+    @mayfail
     Scenario: The user can manage and observe a watch only account
         When the user adds watch only account "0xea123F7beFF45E3C9fdF54B324c29DBdA14a639A" named "AccountWatch" and authenticated using password "TesTEr16843/!@00"
         Then the new account "AccountWatch" is added


### PR DESCRIPTION
Disable the test case "The user can manage and observe a watch-only account" from running in CI.

The manual run also fails to show the real SNT balance in the ganache server. Requesting using `curl` works, so it seems to be something on the wallet side or ganache test integration.

On a second restart of the app, the `SNT` balance is displayed as expected.

Issue to fix and enable it: https://github.com/status-im/status-desktop/issues/9927