### PR TITLE
Fix synced devices list UI bugs

### DIFF
--- a/src/app/modules/main/profile_section/devices/model.nim
+++ b/src/app/modules/main/profile_section/devices/model.nim
@@ -81,9 +81,6 @@ QtObject:
         result = newQVariant(item.isCurrentDevice)
 
   proc setItems*(self: Model, items: seq[Item]) =
-    if(items.len == 0):
-      return
-
     self.beginResetModel()
     self.items = items
     self.endResetModel()

--- a/src/app/modules/main/profile_section/devices/model.nim
+++ b/src/app/modules/main/profile_section/devices/model.nim
@@ -80,18 +80,13 @@ QtObject:
       of ModelRole.IsCurrentDevice:
         result = newQVariant(item.isCurrentDevice)
 
-  proc addItems*(self: Model, items: seq[Item]) =
+  proc setItems*(self: Model, items: seq[Item]) =
     if(items.len == 0):
       return
 
-    let parentModelIndex = newQModelIndex()
-    defer: parentModelIndex.delete
-
-    let first = self.items.len
-    let last = first + items.len - 1
-    self.beginInsertRows(parentModelIndex, first, last)
-    self.items.add(items)
-    self.endInsertRows()
+    self.beginResetModel()
+    self.items = items
+    self.endResetModel()
     self.countChanged()
 
   proc addItem*(self: Model, item: Item) =

--- a/src/app/modules/main/profile_section/devices/module.nim
+++ b/src/app/modules/main/profile_section/devices/module.nim
@@ -64,7 +64,7 @@ method onDevicesLoaded*(self: Module, allDevices: seq[InstallationDto]) =
   for d in allDevices:
     let item = initItem(d, self.isMyDevice(d.id))
     items.add(item)
-  self.view.model().addItems(items)
+  self.view.model().setItems(items)
   self.view.setDevicesLoading(false)
   self.view.deviceSetupChanged()
 

--- a/ui/StatusQ/sandbox/controls/ListItems.qml
+++ b/ui/StatusQ/sandbox/controls/ListItems.qml
@@ -544,34 +544,34 @@ ColumnLayout {
     StatusBaseText {
         Layout.fillWidth: true
         Layout.topMargin: 16
-        text: "Loading features:"
+        text: "Device delegate with online badge"
         font.pixelSize: 17
     }
 
-    StatusListItem {
+    component DeviceListItem: StatusListItem {
         title: "Nokia 3310"
-        subTitle: "Incoming device"
-        label: "loading: true"
-        asset.width: 40
-        asset.height: 40
-        asset.emoji: "😁"
-        asset.color: "hotpink"
-        asset.letterSize: 14
-        asset.isLetterIdenticon: true
-        loading: true
+        asset.name: "mobile"
+        asset.bgColor: Theme.palette.primaryColor3
+        asset.color: Theme.palette.primaryColor1
     }
 
-    StatusListItem {
-        title: "Nokia 3310"
-        subTitle: "Device"
-        label: "loadingFailed: true"
-        asset.width: 40
-        asset.height: 40
-        asset.emoji: "😁"
-        asset.color: "hotpink"
-        asset.letterSize: 14
-        asset.isLetterIdenticon: true
-        loadingFailed: true
+    DeviceListItem {
+        subTitle: "Online now"
+        subTitleBadgeComponent: StatusOnlineBadge {
+            online: true
+        }
+    }
+
+    DeviceListItem {
+        subTitle: "Online 47 minutes ago"
+        subTitleBadgeComponent: StatusOnlineBadge {
+            online: false
+        }
+    }
+
+    DeviceListItem {
+        subTitle: "This device"
+        subTitleBadgeComponent: null
     }
 
     StatusListItem {

--- a/ui/StatusQ/sandbox/controls/LoadingStates.qml
+++ b/ui/StatusQ/sandbox/controls/LoadingStates.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.14
+import QtQuick 2.15
 
 import StatusQ.Controls 0.1
 import StatusQ.Components 0.1
@@ -26,7 +26,7 @@ Column {
         width: 200
     }
 
-    StatusListItem {
+    component DeviceListItem: StatusListItem {
         title: "Nokia 3310"
         subTitle: "Incoming device"
         asset.width: 40
@@ -35,34 +35,20 @@ Column {
         asset.color: "hotpink"
         asset.letterSize: 14
         asset.isLetterIdenticon: true
+    }
+
+    DeviceListItem {
         statusListItemSubTitle.loading: loadingButton.checked
     }
 
-    StatusListItem {
-        title: "Nokia 3310"
-        subTitle: "Incoming device"
-        asset.width: 40
-        asset.height: 40
-        asset.emoji: "😁"
-        asset.color: "hotpink"
-        asset.letterSize: 14
-        asset.isLetterIdenticon: true
+    DeviceListItem {
         statusListItemSubTitle.loading: loadingButton.checked
         statusListItemIcon.loading: loadingButton.checked
     }
 
-    StatusListItem {
-        title: "Nokia 3310"
-        subTitle: "Incoming device"
-        asset.width: 40
-        asset.height: 40
-        asset.emoji: "😁"
-        asset.color: "hotpink"
-        asset.letterSize: 14
-        asset.isLetterIdenticon: true
+    DeviceListItem {
         statusListItemTitle.loading: loadingButton.checked
         statusListItemSubTitle.loading: loadingButton.checked
         statusListItemIcon.loading: loadingButton.checked
     }
-
 }

--- a/ui/StatusQ/src/StatusQ/Components/StatusListItem.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusListItem.qml
@@ -33,7 +33,6 @@ Rectangle {
     property var inlineTagModel: []
     property Component inlineTagDelegate
     property bool loading: false
-    property bool loadingFailed: false
 
     property StatusAssetSettings asset: StatusAssetSettings {
         height: isImage ? 40 : 20
@@ -78,6 +77,7 @@ Rectangle {
     property alias statusListItemTagsSlot: statusListItemTagsSlot
     property alias statusListItemInlineTagsSlot: statusListItemTagsSlotInline
     property alias statusListItemLabel: statusListItemLabel
+    property alias subTitleBadgeComponent: subTitleBadgeLoader.sourceComponent
 
     signal clicked(string itemId, var mouse)
     signal titleClicked(string titleId)
@@ -256,6 +256,12 @@ Rectangle {
                 anchors.top: statusListItemTitle.bottom
                 width: parent.width
                 spacing: 4
+
+                Loader {
+                    id: subTitleBadgeLoader
+                    Layout.alignment: Qt.AlignVCenter
+                    visible: sourceComponent
+                }
 
                 StatusTextWithLoadingState {
                     id: statusListItemSubTitle

--- a/ui/StatusQ/src/StatusQ/Components/StatusOnlineBadge.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusOnlineBadge.qml
@@ -1,0 +1,15 @@
+import QtQuick 2.15
+import StatusQ.Core.Theme 0.1
+
+StatusBadge {
+    id: root
+
+    property bool online: false
+
+    implicitHeight: 11
+    implicitWidth: 11
+    color: online ? Theme.palette.successColor1 : Theme.palette.baseColor1
+    border.width: 2
+    border.color: Theme.palette.baseColor4
+    radius: Math.ceil(width / 2)
+}

--- a/ui/StatusQ/src/StatusQ/Components/StatusSyncDeviceDelegate.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusSyncDeviceDelegate.qml
@@ -50,15 +50,8 @@ StatusListItem {
         return qsTr("Last online %1").arg(LocaleUtils.formatDate(lastSyncDate))
     }
 
-    QtObject {
-        id: d
 
-        readonly property var lastSyncDate: new Date(root.timestamp)
-        readonly property int millisecondsFromSync: lastSyncDate - Date.now()
-        readonly property int secondsFromSync: millisecondsFromSync / 1000
-        readonly property int minutesFromSync: secondsFromSync / 60
-        readonly property int daysFromSync: new Date().getDay() - lastSyncDate.getDay()
-    }
+    subTitleBadgeComponent: root.isCurrentDevice ? null : onlineBadgeComponent
 
     components: [
         StatusButton {
@@ -78,4 +71,23 @@ StatusListItem {
             color: Theme.palette.baseColor1
         }
     ]
+
+    QtObject {
+        id: d
+
+        readonly property var lastSyncDate: new Date(root.timestamp)
+        readonly property int millisecondsFromSync: lastSyncDate - Date.now()
+        readonly property int secondsFromSync: millisecondsFromSync / 1000
+        readonly property int minutesFromSync: secondsFromSync / 60
+        readonly property int daysFromSync: new Date().getDay() - lastSyncDate.getDay()
+        readonly property bool onlineNow: d.secondsFromSync <= 120
+    }
+
+    Component {
+        id: onlineBadgeComponent
+
+        StatusOnlineBadge {
+            online: d.onlineNow
+        }
+    }
 }

--- a/ui/StatusQ/src/StatusQ/Components/StatusSyncDeviceDelegate.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusSyncDeviceDelegate.qml
@@ -44,7 +44,7 @@ StatusListItem {
         if (d.daysFromSync == 1)
             return qsTr("Last online yesterday")
 
-        const date = new Date(root.timestamp)
+        const date = new Date(d.deviceLastTimestamp)
 
         if (d.daysFromSync <= 6)
             return qsTr("Last online [%1]").arg(LocaleUtils.getDayName(date))
@@ -77,7 +77,8 @@ StatusListItem {
         id: d
 
         property real now: 0
-        readonly property int secondsFromSync: (now - Math.max(0, root.timestamp)) / 1000
+        readonly property int deviceLastTimestamp: root.timestamp / 1000000
+        readonly property int secondsFromSync: (now - Math.max(0, d.deviceLastTimestamp)) / 1000
         readonly property int minutesFromSync: secondsFromSync / 60
         readonly property int hoursFromSync: minutesFromSync / 60
         readonly property int daysFromSync: hoursFromSync / 24

--- a/ui/StatusQ/src/StatusQ/Components/StatusSyncDeviceDelegate.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusSyncDeviceDelegate.qml
@@ -101,6 +101,4 @@ StatusListItem {
             online: d.onlineNow
         }
     }
-
-    tertiaryTitle: `${root.timestamp} ${d.now} --- ${d.secondsFromSync}`
 }

--- a/ui/StatusQ/src/StatusQ/Components/StatusSyncDeviceDelegate.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusSyncDeviceDelegate.qml
@@ -15,8 +15,9 @@ StatusListItem {
 
     property string deviceName: ""
     property string deviceType: ""
-    property bool isCurrentDevice: false
     property real timestamp: 0
+    property bool isCurrentDevice: false
+    property bool showOnlineBadge: !isCurrentDevice
 
     signal itemClicked
     signal setupSyncingButtonClicked
@@ -52,7 +53,7 @@ StatusListItem {
         return qsTr("Last online %1").arg(LocaleUtils.formatDate(date))
     }
 
-    subTitleBadgeComponent: root.isCurrentDevice ? null : onlineBadgeComponent
+    subTitleBadgeComponent: root.showOnlineBadge ? onlineBadgeComponent : null
 
     components: [
         StatusButton {
@@ -89,7 +90,7 @@ StatusListItem {
         interval: 1000
         repeat: true
         triggeredOnStart: true
-        running: !root.isCurrentDevice && root.visible
+        running: root.showOnlineBadge && root.visible
         onTriggered: {
             d.now = Date.now()
         }

--- a/ui/StatusQ/src/StatusQ/Components/qmldir
+++ b/ui/StatusQ/src/StatusQ/Components/qmldir
@@ -51,3 +51,4 @@ StatusStepper 0.1 StatusStepper.qml
 LoadingComponent 0.1 LoadingComponent.qml
 StatusQrCodeScanner 0.1 StatusQrCodeScanner.qml
 StatusSyncDeviceDelegate 0.1 StatusSyncDeviceDelegate.qml
+StatusOnlineBadge 0.1 StatusOnlineBadge.qml

--- a/ui/StatusQ/src/StatusQ/Core/LocaleUtils.qml
+++ b/ui/StatusQ/src/StatusQ/Core/LocaleUtils.qml
@@ -312,4 +312,8 @@ QtObject {
     function getMonthYear(value) {
         return formatDate(value, "MMM yyyy")
     }
+
+    function getDayName(value) {
+        return Qt.locale().dayName(value.getDay())
+    }
 }

--- a/ui/StatusQ/src/StatusQ/Core/LocaleUtils.qml
+++ b/ui/StatusQ/src/StatusQ/Core/LocaleUtils.qml
@@ -314,6 +314,6 @@ QtObject {
     }
 
     function getDayName(value) {
-        return Qt.locale().dayName(value.getDay())
+        return Qt.locale().standaloneDayName(value.getDay())
     }
 }

--- a/ui/StatusQ/src/statusq.qrc
+++ b/ui/StatusQ/src/statusq.qrc
@@ -197,5 +197,6 @@
         <file>StatusQ/Core/Utils/ModelsComparator.qml</file>
         <file>StatusQ/Core/Utils/ModelChangeTracker.qml</file>
         <file>StatusQ/Components/StatusQrCodeScanner.qml</file>
+        <file>StatusQ/Components/StatusOnlineBadge.qml</file>
     </qresource>
 </RCC>

--- a/ui/app/AppLayouts/Profile/views/SettingsContentBase.qml
+++ b/ui/app/AppLayouts/Profile/views/SettingsContentBase.qml
@@ -57,6 +57,7 @@ Item {
         id: titleRow
         width: root.contentWidth
         spacing: 0
+
         RowLayout {
             Layout.preferredWidth: (parent.width - Style.current.padding)
             Layout.preferredHeight: visible ? d.titleRowHeight : 0

--- a/ui/app/AppLayouts/Profile/views/SettingsContentBase.qml
+++ b/ui/app/AppLayouts/Profile/views/SettingsContentBase.qml
@@ -120,12 +120,6 @@ Item {
                         easing.type: Easing.InOutQuad
                     }
                 }
-
-                Rectangle {
-                    color: "red"
-                    opacity: 0.2
-                    anchors.fill: parent
-                }
             }
         }
     }

--- a/ui/app/AppLayouts/Profile/views/SettingsContentBase.qml
+++ b/ui/app/AppLayouts/Profile/views/SettingsContentBase.qml
@@ -14,7 +14,7 @@ Item {
 
     property string sectionTitle
     property int contentWidth
-    readonly property int contentHeight: (root.height - d.topHeaderHeight - d.titleRowHeight)
+    readonly property int contentHeight: root.height - titleRow.height - Style.current.padding
 
     property alias titleRowComponentLoader: loader
     property list<Item> headerComponents
@@ -35,7 +35,6 @@ Item {
     QtObject {
         id: d
 
-        readonly property int topHeaderHeight: 56
         readonly property int titleRowHeight: 56
     }
 
@@ -119,6 +118,12 @@ Item {
                         duration: 150
                         easing.type: Easing.InOutQuad
                     }
+                }
+
+                Rectangle {
+                    color: "red"
+                    opacity: 0.2
+                    anchors.fill: parent
                 }
             }
         }

--- a/ui/app/AppLayouts/Profile/views/SyncingView.qml
+++ b/ui/app/AppLayouts/Profile/views/SyncingView.qml
@@ -103,12 +103,15 @@ SettingsContentBase {
 
         StatusBaseText {
             Layout.fillWidth: true
+            visible: root.devicesStore.devicesModule.devicesLoading
             horizontalAlignment: Text.AlignHCenter
             text: qsTr("Loading devices...")
+
         }
 
         StatusBaseText {
             Layout.fillWidth: true
+            visible: root.devicesStore.devicesModule.devicesLoadingError
             horizontalAlignment: Text.AlignHCenter
             text: qsTr("Error loading devices. Please try again later.")
             color: Theme.palette.dangerColor1
@@ -133,7 +136,7 @@ SettingsContentBase {
                 width: ListView.view.width
                 deviceName: model.name
                 deviceType: model.deviceType
-                timestamp: model.timestamp
+                timestamp: model.timestamp / 1000000
                 isCurrentDevice: model.isCurrentDevice
                 onSetupSyncingButtonClicked: {
                     d.setupSyncing(SetupSyncingPopup.GenerateSyncCode)

--- a/ui/app/AppLayouts/Profile/views/SyncingView.qml
+++ b/ui/app/AppLayouts/Profile/views/SyncingView.qml
@@ -94,20 +94,24 @@ SettingsContentBase {
 
         StatusBaseText {
             Layout.fillWidth: true
+            Layout.leftMargin: Style.current.padding
+            Layout.rightMargin: Style.current.padding
             text: qsTr("Devices")
-            font.pixelSize: 15
+            font.pixelSize: Constants.settingsSection.subHeaderFontSize
+            color: Theme.palette.baseColor1
         }
 
         StatusBaseText {
             Layout.fillWidth: true
-            visible: root.devicesStore.devicesModule.devicesLoading
+            horizontalAlignment: Text.AlignHCenter
             text: qsTr("Loading devices...")
         }
 
         StatusBaseText {
             Layout.fillWidth: true
-            visible: root.devicesStore.devicesModule.devicesLoadingError
+            horizontalAlignment: Text.AlignHCenter
             text: qsTr("Error loading devices. Please try again later.")
+            color: Theme.palette.dangerColor1
         }
 
         ListView {

--- a/ui/app/AppLayouts/Profile/views/SyncingView.qml
+++ b/ui/app/AppLayouts/Profile/views/SyncingView.qml
@@ -38,7 +38,6 @@ SettingsContentBase {
     ColumnLayout {
         id: layout
         width: root.contentWidth
-//        height: root.contentHeight
         spacing: Style.current.padding
 
         QtObject {
@@ -107,9 +106,6 @@ SettingsContentBase {
 
         StatusListView {
             Layout.fillWidth: true
-//            Layout.fillHeight: true
-//            Layout.maximumHeight: implicitHeight
-
             implicitHeight: contentHeight
 
             interactive: false

--- a/ui/app/AppLayouts/Profile/views/SyncingView.qml
+++ b/ui/app/AppLayouts/Profile/views/SyncingView.qml
@@ -17,6 +17,8 @@ import shared.panels 1.0
 import shared.controls 1.0
 import shared.controls.chat 1.0
 
+import SortFilterProxyModel 0.2
+
 import "../stores"
 import "../popups"
 import "../controls"
@@ -37,6 +39,7 @@ SettingsContentBase {
 
     ColumnLayout {
         width: root.contentWidth
+        height: root.contentHeight
         spacing: Style.current.padding
 
         QtObject {
@@ -117,7 +120,7 @@ SettingsContentBase {
             color: Theme.palette.dangerColor1
         }
 
-        ListView {
+        StatusListView {
             id: listView
             Layout.fillWidth: true
             Layout.topMargin: 17
@@ -126,11 +129,17 @@ SettingsContentBase {
             implicitHeight: contentHeight
 
             spacing: Style.current.padding
-            model: root.devicesStore.devicesModel
-
             visible: !root.devicesStore.devicesModule.devicesLoading &&
                 !root.devicesStore.devicesModule.devicesLoadingError &&
                 root.devicesStore.isDeviceSetup
+
+            model: SortFilterProxyModel {
+                sourceModel: root.devicesStore.devicesModel
+                sorters: StringSorter {
+                    roleName: "isCurrentDevice"
+                    sortOrder: Qt.DescendingOrder
+                }
+            }
 
             delegate: StatusSyncDeviceDelegate {
                 width: ListView.view.width
@@ -225,7 +234,6 @@ SettingsContentBase {
                 }
 
                 StatusButton {
-//                    type: StatusRoundButton.Type.Secondary
                     Layout.alignment: Qt.AlignHCenter
                     normalColor: Theme.palette.primaryColor1
                     hoverColor: Theme.palette.miscColor1;

--- a/ui/app/AppLayouts/Profile/views/SyncingView.qml
+++ b/ui/app/AppLayouts/Profile/views/SyncingView.qml
@@ -240,15 +240,15 @@ SettingsContentBase {
             }
         }
 
-//        StatusButton {
-//            id: backupBtn
-//            Layout.alignment: Qt.AlignHCenter
-//            text: qsTr("Backup Data")
-//            onClicked : {
-//                let lastUpdate = root.privacyStore.backupData() * 1000
-//                console.log("Backup done at: ", LocaleUtils.formatDateTime(lastUpdate))
-//            }
-//        }
+        StatusButton {
+            id: backupBtn
+            Layout.alignment: Qt.AlignHCenter
+            text: qsTr("Backup Data")
+            onClicked : {
+                const lastUpdate = root.privacyStore.backupData() * 1000
+                console.log("Backup done at: ", LocaleUtils.formatDateTime(lastUpdate))
+            }
+        }
 
         Component {
             id: personalizeDevicePopup

--- a/ui/app/AppLayouts/Profile/views/SyncingView.qml
+++ b/ui/app/AppLayouts/Profile/views/SyncingView.qml
@@ -31,38 +31,24 @@ SettingsContentBase {
     property ProfileStore profileStore
     property PrivacyStore privacyStore
 
-    property bool isSyncing: false
-
     Component.onCompleted: {
         root.devicesStore.loadDevices()
     }
 
     ColumnLayout {
+        id: layout
         width: root.contentWidth
-        height: root.contentHeight
+//        height: root.contentHeight
         spacing: Style.current.padding
 
         QtObject {
             id: d
 
-            /*
-                Device INFO:
-                    id: "abcdabcd-1234-5678-9012-12a34b5cd678",
-                    identity: ""
-                    version: 1
-                    enabled: true
-                    timestamp: 0
-                    metadata:
-                        name: "MacBook-1"
-                        deviceType: "macosx"
-                        fcmToken: ""
-            */
-
             readonly property var instructionsModel: [
-                                        qsTr("Verify your login with password or KeyCard"),
-                                        qsTr("Reveal a temporary QR and Sync Code") + "*",
-                                        qsTr("Share that information with your new device"),
-                                    ]
+                qsTr("Verify your login with password or KeyCard"),
+                qsTr("Reveal a temporary QR and Sync Code") + "*",
+                qsTr("Share that information with your new device"),
+            ]
 
 
             function personalizeDevice(model) {
@@ -109,7 +95,6 @@ SettingsContentBase {
             visible: root.devicesStore.devicesModule.devicesLoading
             horizontalAlignment: Text.AlignHCenter
             text: qsTr("Loading devices...")
-
         }
 
         StatusBaseText {
@@ -121,17 +106,17 @@ SettingsContentBase {
         }
 
         StatusListView {
-            id: listView
             Layout.fillWidth: true
-            Layout.topMargin: 17
-            Layout.bottomMargin: 17
+//            Layout.fillHeight: true
+//            Layout.maximumHeight: implicitHeight
 
             implicitHeight: contentHeight
 
-            spacing: Style.current.padding
+            interactive: false
+            spacing: 0
             visible: !root.devicesStore.devicesModule.devicesLoading &&
-                !root.devicesStore.devicesModule.devicesLoadingError &&
-                root.devicesStore.isDeviceSetup
+                     !root.devicesStore.devicesModule.devicesLoadingError &&
+                     root.devicesStore.isDeviceSetup
 
             model: SortFilterProxyModel {
                 sourceModel: root.devicesStore.devicesModel
@@ -145,7 +130,7 @@ SettingsContentBase {
                 width: ListView.view.width
                 deviceName: model.name
                 deviceType: model.deviceType
-                timestamp: model.timestamp / 1000000
+                timestamp: model.timestamp
                 isCurrentDevice: model.isCurrentDevice
                 onSetupSyncingButtonClicked: {
                     d.setupSyncing(SetupSyncingPopup.GenerateSyncCode)
@@ -255,16 +240,15 @@ SettingsContentBase {
             }
         }
 
-        StatusButton {
-            id: backupBtn
-            Layout.alignment: Qt.AlignHCenter
-            Layout.topMargin: 17
-            text: qsTr("Backup Data")
-            onClicked : {
-                let lastUpdate = root.privacyStore.backupData() * 1000
-                console.log("Backup done at: ", LocaleUtils.formatDateTime(lastUpdate))
-            }
-        }
+//        StatusButton {
+//            id: backupBtn
+//            Layout.alignment: Qt.AlignHCenter
+//            text: qsTr("Backup Data")
+//            onClicked : {
+//                let lastUpdate = root.privacyStore.backupData() * 1000
+//                console.log("Backup done at: ", LocaleUtils.formatDateTime(lastUpdate))
+//            }
+//        }
 
         Component {
             id: personalizeDevicePopup
@@ -283,6 +267,11 @@ SettingsContentBase {
                 devicesStore: root.devicesStore
                 profileStore: root.profileStore
             }
+        }
+
+        Item {
+            Layout.fillHeight: true
+            Layout.fillWidth: true
         }
     }
 }

--- a/ui/imports/shared/views/DeviceSyncingView.qml
+++ b/ui/imports/shared/views/DeviceSyncingView.qml
@@ -179,7 +179,7 @@ Item {
                     enabled: false
                     deviceName: model.name
                     deviceType: model.deviceType
-                    timestamp: model.timestamp
+                    timestamp: model.timestamp / 1000000
                     isCurrentDevice: model.isCurrentDevice
                 }
             }

--- a/ui/imports/shared/views/DeviceSyncingView.qml
+++ b/ui/imports/shared/views/DeviceSyncingView.qml
@@ -179,7 +179,7 @@ Item {
                     enabled: false
                     deviceName: model.name
                     deviceType: model.deviceType
-                    timestamp: model.timestamp / 1000000
+                    timestamp: model.timestamp
                     isCurrentDevice: model.isCurrentDevice
                 }
             }

--- a/ui/imports/shared/views/DeviceSyncingView.qml
+++ b/ui/imports/shared/views/DeviceSyncingView.qml
@@ -130,6 +130,7 @@ Item {
             loading: d.pairingInProgress
             deviceName: qsTr("No device name")
             isCurrentDevice: false
+            showOnlineBadge: false
         }
 
         ErrorDetails {
@@ -166,14 +167,14 @@ Item {
             implicitWidth: contentWidth + leftPadding + rightPadding
             implicitHeight: contentHeight + topPadding + bottomPadding
 
-            ListView {
+            StatusListView {
                 id: listView
 
                 width: scrollView.availableWidth
                 height: scrollView.availableHeight
-
                 spacing: 4
                 clip: true
+
                 delegate: StatusSyncDeviceDelegate {
                     width: ListView.view.width
                     enabled: false


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/9916

### What does the PR do

1. Fixes calculation for "Last seen online" subtitle
Note: actual timestamps are currently invalid, but the calculation is tested to be correct.
I will fix the investigate invalid timestamp values as a separate issue.
2. Added online/offline badge
3. Fixed "Devices" title design
4. Fixed "Syncing" page scrolling
5. `This device` is now always first
6. Fixed duplication of Devices list

### Affected areas

Settings -> Syncing

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [x] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [x] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

<img width="1372" alt="image" src="https://user-images.githubusercontent.com/25482501/225823092-44072a97-8e70-4208-ac15-a9b15e4da2bb.png">
