### PR TITLE
chore(PermissionsDropdown): Temporarily hide channel-level permissions from the dropdown

### DIFF
--- a/ui/app/AppLayouts/Chat/controls/community/PermissionsDropdown.qml
+++ b/ui/app/AppLayouts/Chat/controls/community/PermissionsDropdown.qml
@@ -112,6 +112,9 @@ StatusDropdown {
             Layout.fillWidth: true
         }
 
+        // TODO: Channel-level permissions are temporarily hidden until they are
+        // supported by the backend. Uncomment when backend functionality is ready.
+        /*
         CustomSeparator {
             Layout.fillWidth: true
             Layout.preferredHeight: d.sectionHeight
@@ -136,6 +139,7 @@ StatusDropdown {
 
             Layout.fillWidth: true
         }
+        */
 
         Separator {
             visible: !!group.checkedButton


### PR DESCRIPTION
### What does the PR do

Simply comments-out part responsible for displaying channel-level permissions. It's intended to be restored to the previous version when that functionality is implemented in the backend.

Closes: https://github.com/status-im/status-desktop/issues/9537

### Affected areas
`PermissionsDropdown.qml`

### Screenshot of functionality (including design for comparison)
![Screenshot from 2023-03-20 13-51-52](https://user-images.githubusercontent.com/20650004/226344204-0a1c5c12-377b-4a78-a22d-25c7e992eb81.png)

