### PR TITLE
refactor(gifs): lazy load tenor api key + make search async

### DIFF
--- a/src/app/modules/main/chat_section/chat_content/input_area/controller.nim
+++ b/src/app/modules/main/chat_section/chat_content/input_area/controller.nim
@@ -49,6 +49,26 @@ proc init*(self: Controller) =
     let args = GifsArgs(e)
     self.delegate.loadFavoriteGifsDone(args.gifs)
 
+  self.events.on(SIGNAL_LOAD_TRENDING_GIFS_STARTED) do(e:Args):
+    self.delegate.loadTrendingGifsStarted()
+
+  self.events.on(SIGNAL_LOAD_TRENDING_GIFS_DONE) do(e:Args):
+    let args = GifsArgs(e)
+    self.delegate.loadTrendingGifsDone(args.gifs)
+
+  self.events.on(SIGNAL_LOAD_TRENDING_GIFS_ERROR) do(e:Args):
+    self.delegate.loadTrendingGifsError()
+
+  self.events.on(SIGNAL_SEARCH_GIFS_STARTED) do(e:Args):
+    self.delegate.searchGifsStarted()
+
+  self.events.on(SIGNAL_SEARCH_GIFS_DONE) do(e:Args):
+    let args = GifsArgs(e)
+    self.delegate.serachGifsDone(args.gifs)
+
+  self.events.on(SIGNAL_SEARCH_GIFS_ERROR) do(e:Args):
+    self.delegate.searchGifsError()
+
 proc getChatId*(self: Controller): string =
   return self.chatId
 
@@ -85,11 +105,11 @@ proc acceptRequestAddressForTransaction*(self: Controller, messageId: string, ad
 proc acceptRequestTransaction*(self: Controller, transactionHash: string, messageId: string, signature: string) =
   self.chatService.acceptRequestTransaction(transactionHash, messageId, signature)
 
-proc searchGifs*(self: Controller, query: string): seq[GifDto] =
-  return self.gifService.search(query)
+proc searchGifs*(self: Controller, query: string) =
+  self.gifService.search(query)
 
-proc getTrendingsGifs*(self: Controller): seq[GifDto] =
-  return self.gifService.getTrendings()
+proc getTrendingsGifs*(self: Controller) =
+  self.gifService.getTrending()
 
 proc getRecentsGifs*(self: Controller): seq[GifDto] =
   return self.gifService.getRecents()

--- a/src/app/modules/main/chat_section/chat_content/input_area/io_interface.nim
+++ b/src/app/modules/main/chat_section/chat_content/input_area/io_interface.nim
@@ -41,10 +41,10 @@ method acceptRequestAddressForTransaction*(self: AccessInterface, messageId: str
 method acceptRequestTransaction*(self: AccessInterface, transactionHash: string, messageId: string, signature: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method searchGifs*(self: AccessInterface, query: string): seq[GifDto] {.base.} =
+method searchGifs*(self: AccessInterface, query: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method getTrendingsGifs*(self: AccessInterface): seq[GifDto] {.base.} =
+method getTrendingsGifs*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method getRecentsGifs*(self: AccessInterface): seq[GifDto] {.base.} =
@@ -54,6 +54,24 @@ method loadRecentGifs*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method loadRecentGifsDone*(self: AccessInterface, gifs: seq[GifDto]) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method loadTrendingGifsStarted*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method loadTrendingGifsError*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method loadTrendingGifsDone*(self: AccessInterface, gifs: seq[GifDto]) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method searchGifsStarted*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method searchGifsError*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method serachGifsDone*(self: AccessInterface, gifs: seq[GifDto]) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method getFavoritesGifs*(self: AccessInterface): seq[GifDto] {.base.} =

--- a/src/app/modules/main/chat_section/chat_content/input_area/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/input_area/module.nim
@@ -91,11 +91,11 @@ method acceptRequestAddressForTransaction*(self: Module, messageId: string, addr
 method acceptRequestTransaction*(self: Module, transactionHash: string, messageId: string, signature: string) =
   self.controller.acceptRequestTransaction(transactionHash, messageId, signature)
 
-method searchGifs*(self: Module, query: string): seq[GifDto] =
-  return self.controller.searchGifs(query)
+method searchGifs*(self: Module, query: string) =
+  self.controller.searchGifs(query)
 
-method getTrendingsGifs*(self: Module): seq[GifDto] =
-  return self.controller.getTrendingsGifs()
+method getTrendingsGifs*(self: Module) =
+  self.controller.getTrendingsGifs()
 
 method getRecentsGifs*(self: Module): seq[GifDto] =
   return self.controller.getRecentsGifs()
@@ -104,6 +104,30 @@ method loadRecentGifs*(self: Module) =
   self.controller.loadRecentGifs()
 
 method loadRecentGifsDone*(self: Module, gifs: seq[GifDto]) =
+  self.view.updateGifColumns(gifs)
+
+method loadTrendingGifsStarted*(self: Module) =
+  self.view.updateGifColumns(@[])
+  self.view.setGifLoading(true)
+
+method loadTrendingGifsError*(self: Module) =
+  # Just setting loading to false works because the UI shows an error when there are no gifs
+  self.view.setGifLoading(false)
+
+method loadTrendingGifsDone*(self: Module, gifs: seq[GifDto]) =
+  self.view.setGifLoading(false)
+  self.view.updateGifColumns(gifs)
+
+method searchGifsStarted*(self: Module) =
+  self.view.updateGifColumns(@[])
+  self.view.setGifLoading(true)
+
+method searchGifsError*(self: Module) =
+  # Just setting loading to false works because the UI shows an error when there are no gifs
+  self.view.setGifLoading(false)
+
+method serachGifsDone*(self: Module, gifs: seq[GifDto]) =
+  self.view.setGifLoading(false)
   self.view.updateGifColumns(gifs)
 
 method getFavoritesGifs*(self: Module): seq[GifDto] =

--- a/src/app/modules/main/chat_section/chat_content/input_area/view.nim
+++ b/src/app/modules/main/chat_section/chat_content/input_area/view.nim
@@ -12,6 +12,7 @@ QtObject:
       gifColumnAModel: GifColumnModel
       gifColumnBModel: GifColumnModel
       gifColumnCModel: GifColumnModel
+      gifLoading: bool
 
   proc delete*(self: View) =
     self.model.delete
@@ -25,6 +26,7 @@ QtObject:
     result.gifColumnAModel = newGifColumnModel()
     result.gifColumnBModel = newGifColumnModel()
     result.gifColumnCModel = newGifColumnModel()
+    result.gifLoading = false
 
   proc load*(self: View) =
     self.delegate.viewDidLoad()
@@ -105,13 +107,22 @@ QtObject:
     self.gifColumnCModel.setNewData(columnCData)
     self.gifLoaded()
 
+  proc gifLoadingChanged*(self: View) {.signal.}
+  proc setGifLoading*(self: View, value: bool) =
+    self.gifLoading = value
+    self.gifLoadingChanged()
+  proc getGifLoading*(self: View): bool {.slot.} =
+    result = self.gifLoading
+
+  QtProperty[bool] gifLoading:
+    read = getGifLoading
+    notify = gifLoadingChanged
+
   proc searchGifs*(self: View, query: string) {.slot.} =
-    let data = self.delegate.searchGifs(query)
-    self.updateGifColumns(data)
+    self.delegate.searchGifs(query)
 
   proc getTrendingsGifs*(self: View) {.slot.} =
-    let data = self.delegate.getTrendingsGifs()
-    self.updateGifColumns(data)
+    self.delegate.getTrendingsGifs()
 
   proc getRecentsGifs*(self: View) {.slot.} =
     let data = self.delegate.getRecentsGifs()

--- a/ui/imports/shared/status/StatusGifPopup.qml
+++ b/ui/imports/shared/status/StatusGifPopup.qml
@@ -39,6 +39,7 @@ Popup {
     property alias searchString: searchBox.text
     property int currentCategory: GifPopupDefinitions.Category.Trending
     property int previousCategory: GifPopupDefinitions.Category.Trending
+    property bool loading: RootStore.gifLoading
 
     modal: false
     width: 360
@@ -264,6 +265,7 @@ Popup {
 
         EmptyPlaceholder {
             currentCategory: root.currentCategory
+            loading: root.loading
             onDoRetry: searchBox.text === ""
                         ? RootStore.getTrendingsGifs()
                         : searchGif(searchBox.text)

--- a/ui/imports/shared/status/StatusGifPopup/EmptyPlaceholder.qml
+++ b/ui/imports/shared/status/StatusGifPopup/EmptyPlaceholder.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.13
-import QtQuick.Controls 2.13
+import QtQuick 2.15
+import QtQuick.Controls 2.15
 import QtGraphicalEffects 1.0
 
 import StatusQ.Core 0.1
@@ -10,7 +10,8 @@ import utils 1.0
 Rectangle {
     id: root
 
-    /*required*/ property int currentCategory: GifPopupDefinitions.Category.Trending
+    required property int currentCategory;
+    property bool loading: false
 
     signal doRetry()
 
@@ -20,9 +21,13 @@ Rectangle {
         id: emptyText
         anchors.centerIn: parent
         text: {
-            if(root.currentCategory === GifPopupDefinitions.Category.Favorite) {
+            if (root.loading) {
+                return qsTr("Loading gifs...")
+            }
+            if (root.currentCategory === GifPopupDefinitions.Category.Favorite) {
                 return qsTr("Favorite GIFs will appear here")
-            } else if(root.currentCategory === GifPopupDefinitions.Category.Recent) {
+            }
+            if (root.currentCategory === GifPopupDefinitions.Category.Recent) {
                 return qsTr("Recent GIFs will appear here")
             }
 
@@ -35,7 +40,9 @@ Rectangle {
     StatusButton {
         text: qsTr("Retry")
 
-        visible: root.currentCategory === GifPopupDefinitions.Category.Trending || root.currentCategory === GifPopupDefinitions.Category.Search
+        visible: !root.loading &&
+            (root.currentCategory === GifPopupDefinitions.Category.Trending ||
+            root.currentCategory === GifPopupDefinitions.Category.Search)
 
         anchors.top: emptyText.bottom
         anchors.topMargin: Style.current.padding

--- a/ui/imports/shared/stores/RootStore.qml
+++ b/ui/imports/shared/stores/RootStore.qml
@@ -111,6 +111,8 @@ QtObject {
                                                                  : null
     property var gifColumnC: chatSectionChatContentInputAreaInst ? chatSectionChatContentInputArea.gifColumnC
                                                                  : null
+    property bool gifLoading: chatSectionChatContentInputAreaInst ? chatSectionChatContentInputArea.gifLoading
+                                                                 : false
 
     function searchGifs(query) {
         if (chatSectionChatContentInputAreaInst)


### PR DESCRIPTION
Fixes #9949

Only calls `setTenorAPIKey` once we need it (when doing a search or getting trending).  Also caches the trending gifs so that they are only fetched once. Makes the search and trending calls async by create an async tenor query async task.

For QAs: test that the gif popup works as before. You'll see a (quick) loading indicator when searching and opening for the first time.