### PR TITLE
fix(HoldingsDropdown): Implement dynamic height for holdings dropdown

### DIFF
--- a/ui/app/AppLayouts/Chat/controls/community/ExtendedDropdownContent.qml
+++ b/ui/app/AppLayouts/Chat/controls/community/ExtendedDropdownContent.qml
@@ -28,6 +28,10 @@ Item {
 
     signal itemClicked(string key, string name, url iconSource)
     signal navigateDeep(string key, var subItems)
+    signal layoutChanged()
+
+    implicitHeight: content.implicitHeight
+    implicitWidth: content.implicitWidth
 
     enum Type{
         Assets,
@@ -317,6 +321,7 @@ Item {
     // List elements content
 
     ColumnLayout {
+        id: content
         anchors.fill: parent
 
         SearchBox {
@@ -360,6 +365,7 @@ Item {
 
             Layout.fillWidth: true
             Layout.fillHeight: true
+            onItemChanged: root.layoutChanged()
         }
     }
 
@@ -380,6 +386,12 @@ Item {
                 else if(key === "IMPORT") console.log("TODO: Import existing asset")
             }
             onItemClicked: root.itemClicked(key, shortName, iconSource)
+            onImplicitHeightChanged: root.layoutChanged()
+            Binding on implicitHeight {
+                value: contentHeight
+                //avoid too many changes of the implicit height
+                delayed: true
+            }
         }
     }
 
@@ -414,6 +426,12 @@ Item {
                     root.itemClicked(key, name, iconSource)
                 }
             }
+            onImplicitHeightChanged: root.layoutChanged()
+            Binding on implicitHeight {
+                value: contentHeight
+                //avoid too many changes of the implicit height
+                delayed: true
+            }
         }
     }
 
@@ -430,6 +448,12 @@ Item {
             onItemClicked: {
                 d.reset()
                 root.itemClicked(key, name, iconSource)
+            }
+            onImplicitHeightChanged: root.layoutChanged()
+            Binding on implicitHeight {
+                value: contentHeight
+                //avoid too many changes of the implicit height
+                delayed: true
             }
         }
     }


### PR DESCRIPTION
### What does the PR do
Closing #9385
Implement dynamic height for `HoldingsDropdown`.
There is one workaround in place in order for the Popup to be able to properly compute the height when the content implicit height changes from a value higher than available height to something smaller. The workaround is to temporarily set the popup height to 0 before setting the height to undefined and let it compute the proper height.
<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas
HoldingsDropdown
ExtendedDropdownContent
<!-- List the affected areas (e.g wallet, browser, etc..) -->

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [x] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

<!-- screenshot (or gif/video) that demonstrates the functionality, specially important if it's a bug fix. -->

https://user-images.githubusercontent.com/47811206/226444716-e702fde8-a428-4419-b052-85fd2dee3f43.mov


https://user-images.githubusercontent.com/47811206/226444819-0083f8be-54ca-4054-80c4-16e99b17d400.mov


### Cool Spaceship Picture

<!-- optional but cool ->
