### PR TITLE
chore(CommunitySettings): Remove old legacy community popup

### DIFF
--- a/ui/app/AppLayouts/Chat/ChatLayout.qml
+++ b/ui/app/AppLayouts/Chat/ChatLayout.qml
@@ -136,8 +136,6 @@ StackLayout {
 
             onBackToCommunityClicked: root.currentIndex = 0
 
-            // TODO: remove me when migration to new settings is done
-            onOpenLegacyPopupClicked: Global.openCommunityProfilePopupRequested(root.rootStore, community, chatCommunitySectionModule)
             Connections {
                 target: root.rootStore
                 function onGoToMembershipRequestsPage() {

--- a/ui/app/AppLayouts/Chat/views/CommunitySettingsView.qml
+++ b/ui/app/AppLayouts/Chat/views/CommunitySettingsView.qml
@@ -67,7 +67,6 @@ StatusSectionLayout {
     }
 
     signal backToCommunityClicked
-    signal openLegacyPopupClicked // TODO: remove me when migration to new settings is done
 
     //navigate to a specific section and subsection
     function goTo(section: int, subSection: int) {
@@ -133,46 +132,23 @@ StatusSectionLayout {
             }
         }
 
-        // TODO: remove me when migration to new settings is done. Only keep back button and anchor to it.
-        ColumnLayout {
-            id: footer
-
+        StatusBaseText {
+            objectName: "communitySettingsBackToCommunityButton"
             anchors {
                 bottom: parent.bottom
                 bottomMargin: 16
+                horizontalCenter: parent.horizontalCenter
             }
-            width: parent.width
-            spacing: 16
+            text: "<- " + qsTr("Back to community")
+            color: Theme.palette.baseColor1
+            font.pixelSize: 15
+            font.underline: true
 
-            // TODO: remove me when migration to new settings is done
-            StatusBaseText {
-                Layout.alignment: Qt.AlignHCenter
-                text: qsTr("Open legacy popup (to be removed)")
-                color: Theme.palette.baseColor1
-                font.pixelSize: 10
-                font.underline: true
-
-                MouseArea {
-                    anchors.fill: parent
-                    cursorShape: Qt.PointingHandCursor
-                    onClicked: root.openLegacyPopupClicked()
-                }
-            }
-
-            StatusBaseText {
-                objectName: "communitySettingsBackToCommunityButton"
-                Layout.alignment: Qt.AlignHCenter
-                text: "<- " + qsTr("Back to community")
-                color: Theme.palette.baseColor1
-                font.pixelSize: 15
-                font.underline: true
-
-                MouseArea {
-                    anchors.fill: parent
-                    cursorShape: Qt.PointingHandCursor
-                    onClicked: root.backToCommunityClicked()
-                    hoverEnabled: true
-                }
+            MouseArea {
+                anchors.fill: parent
+                cursorShape: Qt.PointingHandCursor
+                onClicked: root.backToCommunityClicked()
+                hoverEnabled: true
             }
         }
     }


### PR DESCRIPTION
Fixes: #9913

### What does the PR do

Remove legacy community popup call from settings.

PS: Don't know the popup should be removed as well cos it used in another place.  

### Affected areas

Community Settings

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?
