### PR TITLE
feat: add authentication modal to join commmunity view

### DIFF
--- a/src/app/core/unique_event_emitter.nim
+++ b/src/app/core/unique_event_emitter.nim
@@ -13,6 +13,9 @@ proc initUniqueUUIDEventEmitter*(events: EventEmitter): UniqueUUIDEventEmitter =
   result.events = events
   result.handlerId = genUUID()
 
+proc emit*(self: UniqueUUIDEventEmitter, name: string, args: Args): void =
+  self.events.emit(name, args)
+
 proc on*(self: UniqueUUIDEventEmitter, name: string, handler: Handler): void =
   self.events.onUsingUUID(self.handlerId, name, handler)
 

--- a/src/app/modules/main/chat_section/io_interface.nim
+++ b/src/app/modules/main/chat_section/io_interface.nim
@@ -368,3 +368,9 @@ method onJoinedCommunity*(self: AccessInterface) =
 
 method onAcceptRequestToJoinFailedNoPermission*(self: AccessInterface, communityId: string, memberKey: string, requestId: string) {.base.} =
   raise newException(ValueError, "No implementation available")
+
+method onUserAuthenticated*(self: AccessInterface, pin: string, password: string, keyUid: string) =
+  raise newException(ValueError, "No implementation available")
+
+method requestToJoinCommunity*(self: AccessInterface, communityId: string, ensName: string) =
+  raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -815,6 +815,9 @@ method onKickedFromCommunity*(self: Module) =
 method onJoinedCommunity*(self: Module) =
   self.view.setAmIMember(true)
 
+method onUserAuthenticated*(self: Module, pin: string, password: string, keyUid: string) =
+  self.controller.requestToJoinCommunityAuthenticated(password)
+
 method onMarkAllMessagesRead*(self: Module, chatId: string) =
   self.updateBadgeNotifications(chatId, hasUnreadMessages=false, unviewedMentionsCount=0)
   let chatDetails = self.controller.getChatDetails(chatId)
@@ -1182,6 +1185,9 @@ method createOrEditCommunityTokenPermission*(self: Module, communityId: string, 
 
 method deleteCommunityTokenPermission*(self: Module, communityId: string, permissionId: string) =
   self.controller.deleteCommunityTokenPermission(communityId, permissionId)
+
+method requestToJoinCommunity*(self: Module, communityId: string, ensName: string) =
+  self.controller.authenticateToRequestToJoinCommunity(communityId, ensName)
 
 proc buildTokenPermissionItem*(self: Module, tokenPermission: CommunityTokenPermissionDto): TokenPermissionItem =
   var tokenCriteriaItems: seq[TokenCriteriaItem] = @[]

--- a/src/app/modules/main/chat_section/view.nim
+++ b/src/app/modules/main/chat_section/view.nim
@@ -242,6 +242,9 @@ QtObject:
   proc createGroupChat*(self: View, communityID: string, groupName: string, pubKeys: string) {.slot.} =
     self.delegate.createGroupChat(communityID, groupName, pubKeys)
 
+  proc requestToJoinCommunity*(self: View, communityId: string, ensName: string) {.slot.} =
+    self.delegate.requestToJoinCommunity(communityId, ensName)
+
   proc joinGroupChatFromInvitation*(self: View, groupName: string, chatId: string, adminPK: string) {.slot.} =
     self.delegate.joinGroupChatFromInvitation(groupName, chatId, adminPK)
 

--- a/src/app/modules/main/communities/controller.nim
+++ b/src/app/modules/main/communities/controller.nim
@@ -123,7 +123,7 @@ proc cancelRequestToJoinCommunity*(self: Controller, communityId: string) =
   self.communityService.cancelRequestToJoinCommunity(communityId)
 
 proc requestToJoinCommunity*(self: Controller, communityId: string, ensName: string) =
-  self.communityService.requestToJoinCommunity(communityId, ensName)
+  self.communityService.requestToJoinCommunity(communityId, ensName, password="")
 
 proc createCommunity*(
     self: Controller,

--- a/src/app_service/service/community/service.nim
+++ b/src/app_service/service/community/service.nim
@@ -813,9 +813,9 @@ QtObject:
       error "Error joining the community", msg = e.msg
       result = fmt"Error joining the community: {e.msg}"
 
-  proc requestToJoinCommunity*(self: Service, communityId: string, ensName: string) =
+  proc requestToJoinCommunity*(self: Service, communityId: string, ensName: string, password: string) =
     try:
-      let response = status_go.requestToJoinCommunity(communityId, ensName)
+      let response = status_go.requestToJoinCommunity(communityId, ensName, password)
       self.activityCenterService.parseActivityCenterResponse(response)
 
       if not self.processRequestsToJoinCommunity(response.result):

--- a/src/backend/communities.nim
+++ b/src/backend/communities.nim
@@ -27,10 +27,12 @@ proc getAllCommunities*(): RpcResponse[JsonNode] {.raises: [Exception].} =
 proc spectateCommunity*(communityId: string): RpcResponse[JsonNode] {.raises: [Exception].} =
   result = callPrivateRPC("spectateCommunity".prefix, %*[communityId])
 
-proc requestToJoinCommunity*(communityId: string, ensName: string): RpcResponse[JsonNode] {.raises: [Exception].} =
+proc requestToJoinCommunity*(communityId: string, ensName: string, password: string): RpcResponse[JsonNode] {.raises: [Exception].} =
+  var passwordToSend = password
   result = callPrivateRPC("requestToJoinCommunity".prefix, %*[{
     "communityId": communityId,
-    "ensName": ensName
+    "ensName": ensName,
+    "password": if passwordToSend != "": utils.hashPassword(password) else: ""
   }])
 
 proc myPendingRequestsToJoin*(): RpcResponse[JsonNode] {.raises: [Exception].} =

--- a/ui/app/AppLayouts/Chat/ChatLayout.qml
+++ b/ui/app/AppLayouts/Chat/ChatLayout.qml
@@ -3,6 +3,7 @@ import QtQuick.Controls 2.14
 import QtQuick.Layouts 1.14
 
 import utils 1.0
+import shared.popups 1.0
 
 import "views"
 import "views/communities"
@@ -69,7 +70,7 @@ StackLayout {
             collectiblesModel: root.rootStore.collectiblesModel
             isInvitationPending: root.rootStore.isCommunityRequestPending(communityData.id)
             onRevealAddressClicked: {
-                root.rootStore.requestToJoinCommunity(communityData.id, root.rootStore.userProfileInst.name)
+                communityIntroDialog.open()
             }
             onInvitationPendingClicked: {
                 root.rootStore.cancelPendingRequest(communityData.id)
@@ -84,7 +85,27 @@ StackLayout {
                     }
                 }
             }
+
+            CommunityIntroDialog {
+                id: communityIntroDialog
+
+                isInvitationPending: joinCommunityView.isInvitationPending
+                name: communityData.name
+                introMessage: communityData.introMessage
+                imageSrc: communityData.image
+                accessType: communityData.access
+
+                onJoined: {
+                    root.rootStore.requestToJoinCommunity(communityData.id, root.rootStore.userProfileInst.name)
+                }
+
+                onCancelMembershipRequest: {
+                    root.rootStore.cancelPendingRequest(communityData.id)
+                    joinCommunityView.isInvitationPending = root.rootStore.isCommunityRequestPending(communityData.id)
+                }
+            }
         }
+
 
     }
 

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -403,7 +403,7 @@ QtObject {
     }
 
     function requestToJoinCommunity(id, ensName) {
-        return communitiesModuleInst.requestToJoinCommunity(id, ensName)
+        chatCommunitySectionModule.requestToJoinCommunity(id, ensName)
     }
 
     function userCanJoin(id) {


### PR DESCRIPTION
Users that request access to community that are token permissioned need to authenticate and enter their password, so they can reveal their wallet addresses
