### PR TITLE
fix(HoldingsDropdown): Add basic focus management and keyboard support

### DIFF
--- a/ui/StatusQ/src/StatusQ/Controls/StatusBaseInput.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusBaseInput.qml
@@ -268,6 +268,9 @@ Item {
     */
     signal editClicked()
 
+    onFocusChanged: {
+        if(focus) edit.forceActiveFocus()
+    }
 
     Rectangle {
         id: background
@@ -356,8 +359,14 @@ Item {
                         font.family: Theme.palette.baseFont.name
                         color: root.enabled ? Theme.palette.directColor1 : Theme.palette.baseColor1 
                         wrapMode: root.multiline ? Text.WrapAtWordBoundaryOrAnywhere : TextEdit.NoWrap
-                        Keys.onReturnPressed: event.accepted = !multiline && !acceptReturn
-                        Keys.onEnterPressed: event.accepted = !multiline && !acceptReturn
+                        Keys.onReturnPressed: {
+                            root.keyPressed(event)
+                            event.accepted = !multiline && !acceptReturn
+                        }
+                        Keys.onEnterPressed: {
+                            root.keyPressed(event)
+                            event.accepted = !multiline && !acceptReturn
+                        }
                         Keys.forwardTo: [root]
                         KeyNavigation.priority: !!root.tabNavItem ? KeyNavigation.BeforeItem : KeyNavigation.AfterItem
                         KeyNavigation.tab: root.tabNavItem

--- a/ui/StatusQ/src/StatusQ/Controls/StatusInput.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusInput.qml
@@ -377,6 +377,11 @@ Item {
         validate()
     }
 
+    onFocusChanged: {
+        if(focus)
+            statusBaseInput.forceActiveFocus()
+    }
+
     ColumnLayout {
         id: inputLayout
         anchors.fill: parent

--- a/ui/app/AppLayouts/Chat/controls/community/EnsPanel.qml
+++ b/ui/app/AppLayouts/Chat/controls/community/EnsPanel.qml
@@ -55,12 +55,23 @@ ColumnLayout {
                         && !alreadyUsed
             }
         }
+        onVisibleChanged: {
+            if(visible)
+                forceActiveFocus()
+        }
+        onKeyPressed: {
+            if(!addOrUpdateButton.enabled) return
+
+            if(event.key === Qt.Key_Enter || event.key === Qt.Key_Return)
+                addOrUpdateButton.clicked()
+        }
 
         Component.onCompleted: {
             if (text) {
                 input.dirty = true
                 validate()
             }
+            forceActiveFocus()
         }
     }
 

--- a/ui/app/AppLayouts/Chat/controls/community/ExtendedDropdownContent.qml
+++ b/ui/app/AppLayouts/Chat/controls/community/ExtendedDropdownContent.qml
@@ -51,6 +51,11 @@ Item {
                 ? d.depth2_ThumbnailsState : d.depth2_ListState
     }
 
+    onFocusChanged: {
+        if(focus)
+            searcher.forceActiveFocus()
+    }
+
     Settings {
         property alias useThumbnailsOnDepth2: d.useThumbnailsOnDepth2
     }
@@ -131,6 +136,8 @@ Item {
             root.state = d.depth1_ListState
         }
     }
+
+    onStateChanged: forceActiveFocus()
 
     state: d.depth1_ListState
     states: [
@@ -341,6 +348,14 @@ Item {
             Binding on placeholderText{
                 when: d.currentItemName !== ""
                 value: qsTr("Search %1").arg(d.currentItemName)
+            }
+            onVisibleChanged: {
+                if(visible)
+                    forceActiveFocus()
+            }
+            Component.onCompleted: {
+                if(visible)
+                    forceActiveFocus()
             }
         }
 

--- a/ui/app/AppLayouts/Chat/controls/community/HoldingsDropdown.qml
+++ b/ui/app/AppLayouts/Chat/controls/community/HoldingsDropdown.qml
@@ -244,6 +244,7 @@ StatusDropdown {
 
             checkedKeys: root.usedTokens.map(entry => entry.key)
             type: d.extendedDropdownType
+            onTypeChanged: forceActiveFocus()
 
             onItemClicked: {
                 d.assetAmountText = ""

--- a/ui/app/AppLayouts/Chat/controls/community/TokenPanel.qml
+++ b/ui/app/AppLayouts/Chat/controls/community/TokenPanel.qml
@@ -65,6 +65,20 @@ ColumnLayout {
         customHeight: d.defaultHeight
         allowDecimals: true
         keepHeight: true
+        onKeyPressed: {
+            if(!addOrUpdateButton.enabled) return
+
+            if(event.key === Qt.Key_Enter || event.key === Qt.Key_Return)
+                addOrUpdateButton.clicked()
+        }
+        onVisibleChanged: {
+            if(visible)
+                forceActiveFocus()
+        }
+        Component.onCompleted: {
+            if(visible)
+                forceActiveFocus()
+        }
     }
 
     StatusButton {

--- a/ui/imports/shared/controls/Input.qml
+++ b/ui/imports/shared/controls/Input.qml
@@ -60,6 +60,10 @@ Item {
         validationError = ""
     }
 
+    onFocusChanged: {
+        if(focus) inputField.forceActiveFocus()
+    }
+
     StyledText {
         id: inputLabel
         text: inputBox.label


### PR DESCRIPTION
### What does the PR do
Closing #9967 
<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->
1. When Holdings dropdown is open, activate focus to searcher in assets and collectibles. Changes focus to ENS input in case ENS tab is active.
 2. In Holdings dropdown, when ENS tab is active and Add button is enabled, pressing enter key should behave same than clicking on the button itself.
 3. In Holdings dropdown, when one asset or collectible has been selected, activate focus in the amount input, then when Add button is enabled, pressing enter key should behave same than clicking on the button itself.
### Affected areas

<!-- List the affected areas (e.g wallet, browser, etc..) -->
HoldingsDropdown
StatusQ/Input/BaseInput.qml - forward focus to the input component and send signals on Enter/Return pressed
StatusQ/Input/StatusInput.qml - forward focus to the input component

### Screenshot of functionality (including design for comparison)

https://user-images.githubusercontent.com/47811206/226682999-3d2d1bd0-49f6-4c7b-9844-4c94f44f5649.mov


<!-- screenshot (or gif/video) that demonstrates the functionality, specially important if it's a bug fix. -->
