### PR TITLE
feat(Contacts): Remove ability to cancel outgoing CR

### DIFF
--- a/ui/imports/shared/views/ProfileDialogView.qml
+++ b/ui/imports/shared/views/ProfileDialogView.qml
@@ -531,17 +531,6 @@ Pane {
                         }
                     }
                     StatusAction {
-                        text: qsTr("Cancel Contact Request")
-                        icon.name: "cancel"
-                        type: StatusAction.Type.Danger
-                        enabled: !d.isContact && d.isContactRequestSent && !d.contactDetails.removed
-                        onTriggered: {
-                            moreMenu.close()
-                            root.contactsStore.removeContact(root.publicKey)
-                            d.reload()
-                        }
-                    }
-                    StatusAction {
                         text: qsTr("Block User")
                         icon.name: "cancel"
                         type: StatusAction.Type.Danger


### PR DESCRIPTION
Close #9901 and #9898

### What does the PR do

Remove ability to cancel outgoing contact request

### Affected areas

Contacts, Profile

### Screenshot of functionality (including design for comparison)

<img width="653" alt="Screenshot 2023-03-22 at 16 14 36" src="https://user-images.githubusercontent.com/2522130/226855752-6dbeaf29-7b67-42ae-94df-2dece0ceb95d.png">
