### PR TITLE
fix(StatusEmojiReactions): Text in own reactions has wrong color in dark mode

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusMessageEmojiReactions.qml
+++ b/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusMessageEmojiReactions.qml
@@ -123,7 +123,7 @@ Item {
                         anchors.verticalCenter: parent.verticalCenter
                         text: model.numberOfReactions
                         font.pixelSize: 12
-                        color: model.didIReactWithThisEmoji ? Theme.palette.indirectColor1 : Theme.palette.directColor1
+                        color: model.didIReactWithThisEmoji ? Theme.palette.white : Theme.palette.directColor1
                     }
 
                 }


### PR DESCRIPTION
always use "white on blue"

Fixes #9944

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

Light mode:
![image](https://user-images.githubusercontent.com/5377645/226861130-d5b012dd-1bb0-41dd-9148-ad1ea35c7efb.png)

Dark mode:
![image](https://user-images.githubusercontent.com/5377645/226861218-0f5487a8-020e-4820-80b3-78bb8a9039b4.png)
