### PR TITLE
Embed QR code scanner for syncing devices on onboarding

### DIFF
--- a/ci/Jenkinsfile.e2e
+++ b/ci/Jenkinsfile.e2e
@@ -54,7 +54,7 @@ pipeline {
     QTDIR = '/opt/qt/5.15.2/gcc_64'
     PATH = "${env.QTDIR}/bin:${env.PATH}"
     /* Include library in order to compile the project */
-    LD_LIBRARY_PATH = "$QTDIR/lib:$WORKSPACE/vendor/status-go/build/bin:$WORKSPACE/vendor/status-keycard-go/build/libkeycard/"
+    LD_LIBRARY_PATH = "$QTDIR/lib:$WORKSPACE/vendor/DOtherSide/build/qzxing:$WORKSPACE/vendor/status-go/build/bin:$WORKSPACE/vendor/status-keycard-go/build/libkeycard/"
     /* Container ports */
     RPC_PORT = "${8545 + env.EXECUTOR_NUMBER.toInteger()}"
     P2P_PORT = "${6010 + env.EXECUTOR_NUMBER.toInteger()}"

--- a/config.nims
+++ b/config.nims
@@ -17,6 +17,7 @@ if defined(macosx):
   switch("passL", "-rpath" & " " & getEnv("QT5_LIBDIR"))
   switch("passL", "-rpath" & " " & getEnv("STATUSGO_LIBDIR"))
   switch("passL", "-rpath" & " " & getEnv("STATUSKEYCARDGO_LIBDIR"))
+  switch("passL", "-rpath" & " " & getEnv("QZXING_LIBDIR"))
   # statically link these libs
   switch("passL", "bottles/openssl@1.1/lib/libcrypto.a")
   switch("passL", "bottles/openssl@1.1/lib/libssl.a")

--- a/src/app_service/service/devices/service.nim
+++ b/src/app_service/service/devices/service.nim
@@ -157,8 +157,11 @@ QtObject:
   # Local Pairing
   #
 
-  proc inputConnectionStringForBootstrappingFinished(self: Service, result: string) =
-    discard
+  proc inputConnectionStringForBootstrappingFinished*(self: Service, responseJson: string) {.slot.} =
+    let response = responseJson.parseJson
+    let errorDescription = response["error"].getStr
+    if len(errorDescription) > 0:
+      error "failed to start bootstrapping device", errorDescription
 
   proc validateConnectionString*(self: Service, connectionString: string): string =
     return status_go.validateConnectionString(connectionString)

--- a/src/app_service/service/devices/service.nim
+++ b/src/app_service/service/devices/service.nim
@@ -74,6 +74,11 @@ QtObject:
     result.accountsService = accountsService
     result.localPairingStatus = newLocalPairingStatus()
 
+  proc updateLocalPairingStatus(self: Service, data: LocalPairingEventArgs) =
+    self.events.emit(SIGNAL_LOCAL_PAIRING_EVENT, data)
+    self.localPairingStatus.update(data.eventType, data.action, data.account, data.error)
+    self.events.emit(SIGNAL_LOCAL_PAIRING_STATUS_UPDATE, self.localPairingStatus)
+
   proc doConnect(self: Service) =
     self.events.on(SignalType.Message.event) do(e:Args):
       let receivedData = MessageSignal(e)
@@ -89,10 +94,7 @@ QtObject:
         action: signalData.action.parse(),
         account: signalData.account,
         error: signalData.error)
-      self.events.emit(SIGNAL_LOCAL_PAIRING_EVENT, data)
-
-      self.localPairingStatus.update(data.eventType, data.action, data.account, data.error)
-      self.events.emit(SIGNAL_LOCAL_PAIRING_STATUS_UPDATE, self.localPairingStatus)
+      self.updateLocalPairingStatus(data)
 
   proc init*(self: Service) =
     self.doConnect()
@@ -160,8 +162,15 @@ QtObject:
   proc inputConnectionStringForBootstrappingFinished*(self: Service, responseJson: string) {.slot.} =
     let response = responseJson.parseJson
     let errorDescription = response["error"].getStr
-    if len(errorDescription) > 0:
-      error "failed to start bootstrapping device", errorDescription
+    if len(errorDescription) == 0:
+      return
+    error "failed to start bootstrapping device", errorDescription
+    let data = LocalPairingEventArgs(
+      eventType: EventConnectionError,
+      action: ActionUnknown,
+      account: AccountDto(),
+      error: errorDescription)
+    self.updateLocalPairingStatus(data)
 
   proc validateConnectionString*(self: Service, connectionString: string): string =
     return status_go.validateConnectionString(connectionString)
@@ -190,7 +199,7 @@ QtObject:
         "deviceType" : hostOs,
         "nodeConfig": nodeConfigJson,
         "kdfIterations": self.accountsService.getKdfIterations(),
-        "settingCurrentNetwork": ""
+        "settingCurrentNetwork": "mainnet_rpc"
       },
       "clientConfig": %* {}
     }

--- a/ui/StatusQ/sandbox/QrCodeScannerPage.qml
+++ b/ui/StatusQ/sandbox/QrCodeScannerPage.qml
@@ -1,0 +1,157 @@
+import QtQuick 2.15
+import QtQuick.Layouts 1.15
+
+import StatusQ.Core 0.1
+import StatusQ.Core.Theme 0.1
+import StatusQ.Controls 0.1
+import StatusQ.Components 0.1
+
+import QtMultimedia 5.15
+
+Rectangle {
+    id: root
+
+    component ValueIndicator: RowLayout {
+
+        property string title
+        property alias value: lastTagText.text
+        property bool readOnly: true
+
+        spacing: 10
+
+        StatusBaseText {
+            text: parent.title
+        }
+
+        StatusInput {
+            id: lastTagText
+            Layout.fillWidth: true
+            input.edit.readOnly: parent.readOnly
+            input.edit.selectByKeyboard: true
+            input.edit.selectByMouse: true
+            input.rightPadding: 10
+        }
+    }
+
+    color: Theme.palette.baseColor3
+
+    QtObject {
+        id: d
+
+        function sizeToString(size) {
+            return whToString(size.width, size.height)
+        }
+
+        function whToString(width, height) {
+            return `${width.toFixed(0)}*${height.toFixed(0)}`
+        }
+
+        function rectToString(rect) {
+            return `${rect.width.toFixed(2)}*${rect.height.toFixed(2)} (${rect.x.toFixed(2)}, ${rect.y.toFixed(2)})`
+        }
+
+        function cameraStateString(state) {
+            switch (state) {
+                case Camera.UnloadedState: return "Unloaded"
+                case Camera.LoadedState: return "Loaded"
+                case Camera.ActiveState: return "Active"
+                default: return "unknown"
+            }
+        }
+
+        function cameraStatusString(status) {
+            switch (status) {
+                case Camera.ActiveStatus: return "Active"
+                case Camera.StartingStatus: return "Starting"
+                case Camera.StoppingStatus: return "Stopping"
+                case Camera.StandbyStatus: return "Standby"
+                case Camera.LoadedStatus: return "Loaded"
+                case Camera.LoadingStatus: return "Loading"
+                case Camera.UnloadingStatus: return "Unloading"
+                case Camera.UnloadedStatus: return "Unloaded"
+                case Camera.UnavailableStatus: return "Unavailable"
+                default: return "unknown"
+            }
+        }
+    }
+
+    ColumnLayout {
+        anchors.fill: parent
+        anchors.margins: 20
+        spacing: 10
+
+        StatusQrCodeScanner {
+            id: qrScanner
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            Layout.preferredHeight: width / sourceRatio
+        }
+
+        ValueIndicator {
+            Layout.fillWidth: true
+            title: qsTr("Last tag:")
+            value: qrScanner.lastTag
+        }
+
+        RowLayout {
+            Layout.fillWidth: true
+
+            ValueIndicator {
+                Layout.fillWidth: true
+                title: qsTr("Current tag:")
+                value: qrScanner.currentTag
+            }
+
+            ValueIndicator {
+                title: qsTr("Last decode time, ms:")
+                value: qrScanner.decodeTime
+            }
+        }
+
+        RowLayout {
+            Layout.fillWidth: true
+            spacing: 10
+
+            ValueIndicator {
+                Layout.fillWidth: true
+                title: qsTr("Source size:")
+                value: d.sizeToString(qrScanner.sourceSize)
+            }
+
+            ValueIndicator {
+                Layout.fillWidth: true
+                title: qsTr("Source size:")
+                value: d.sizeToString(qrScanner.contentSize)
+            }
+
+            ValueIndicator {
+                Layout.fillWidth: true
+                title: qsTr("View size:")
+                value: d.whToString(qrScanner.width, qrScanner.height)
+            }
+
+            ValueIndicator {
+                Layout.fillWidth: true
+                title: qsTr("Capture rect:")
+                value: d.rectToString(qrScanner.captureRectangle)
+            }
+        }
+
+        RowLayout {
+            Layout.fillWidth: true
+            spacing: 10
+
+            ValueIndicator {
+                Layout.fillWidth: true
+                title: qsTr("Camera state:")
+                value: qrScanner.camera ? d.cameraStateString(qrScanner.camera.cameraState) : ""
+            }
+
+            ValueIndicator {
+                Layout.fillWidth: true
+                title: qsTr("Camera status:")
+                value: qrScanner.camera ? d.cameraStatusString(qrScanner.camera.cameraStatus) : ""
+            }
+        }
+    }
+}

--- a/ui/StatusQ/sandbox/QrCodeScannerPage.qml
+++ b/ui/StatusQ/sandbox/QrCodeScannerPage.qml
@@ -89,7 +89,7 @@ Rectangle {
 
         ValueIndicator {
             Layout.fillWidth: true
-            title: qsTr("Last tag:")
+            title: "Last tag:"
             value: qrScanner.lastTag
         }
 
@@ -98,12 +98,12 @@ Rectangle {
 
             ValueIndicator {
                 Layout.fillWidth: true
-                title: qsTr("Current tag:")
+                title: "Current tag:"
                 value: qrScanner.currentTag
             }
 
             ValueIndicator {
-                title: qsTr("Last decode time, ms:")
+                title: "Last decode time, ms:"
                 value: qrScanner.decodeTime
             }
         }
@@ -114,25 +114,25 @@ Rectangle {
 
             ValueIndicator {
                 Layout.fillWidth: true
-                title: qsTr("Source size:")
+                title: "Source size:"
                 value: d.sizeToString(qrScanner.sourceSize)
             }
 
             ValueIndicator {
                 Layout.fillWidth: true
-                title: qsTr("Source size:")
+                title: "Source size:"
                 value: d.sizeToString(qrScanner.contentSize)
             }
 
             ValueIndicator {
                 Layout.fillWidth: true
-                title: qsTr("View size:")
+                title: "View size:"
                 value: d.whToString(qrScanner.width, qrScanner.height)
             }
 
             ValueIndicator {
                 Layout.fillWidth: true
-                title: qsTr("Capture rect:")
+                title: "Capture rect:"
                 value: d.rectToString(qrScanner.captureRectangle)
             }
         }
@@ -143,13 +143,13 @@ Rectangle {
 
             ValueIndicator {
                 Layout.fillWidth: true
-                title: qsTr("Camera state:")
+                title: "Camera state:"
                 value: qrScanner.camera ? d.cameraStateString(qrScanner.camera.cameraState) : ""
             }
 
             ValueIndicator {
                 Layout.fillWidth: true
-                title: qsTr("Camera status:")
+                title: "Camera status:"
                 value: qrScanner.camera ? d.cameraStatusString(qrScanner.camera.cameraStatus) : ""
             }
         }

--- a/ui/StatusQ/sandbox/main.qml
+++ b/ui/StatusQ/sandbox/main.qml
@@ -546,44 +546,8 @@ StatusWindow {
     Component {
         id: qrScannerComponent
 
-        Rectangle {
+        QrCodeScannerPage {
             anchors.fill: parent
-            color: Theme.palette.baseColor3
-
-            ColumnLayout {
-                anchors.fill: parent
-                anchors.margins: 20
-                spacing: 10
-
-                StatusQrCodeScanner {
-                    id: qrScanner
-                    Layout.fillWidth: true
-                    Layout.preferredHeight: width / sourceRatio
-                }
-
-                RowLayout {
-                    Layout.fillWidth: true
-                    spacing: 10
-
-                    StatusBaseText {
-                        text: qsTr("Last tag: ")
-                    }
-
-                    StatusInput {
-                        id: lastTagText
-                        Layout.fillWidth: true
-                        input.enabled: false
-                        text: qrScanner.lastTag
-                        input.rightPadding: 10
-                    }
-
-                }
-
-                Item {
-                    Layout.fillWidth: true
-                    Layout.fillHeight: true
-                }
-            }
         }
     }
 

--- a/ui/StatusQ/sandbox/qml.qrc
+++ b/ui/StatusQ/sandbox/qml.qrc
@@ -79,5 +79,6 @@
         <file>pages/StatusComboBoxPage.qml</file>
         <file>pages/StatusChartPanelPage.qml</file>
         <file>pages/StatusTextAreaPage.qml</file>
+        <file>QrCodeScannerPage.qml</file>
     </qresource>
 </RCC>

--- a/ui/StatusQ/src/StatusQ/Components/StatusQrCodeScanner.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusQrCodeScanner.qml
@@ -192,11 +192,8 @@ Item {
 
             decoder {
                 enabledDecoders: QZXing.DecoderFormat_QR_CODE
-                tryHarder: true
                 onTagFound: {
                     d.currentTag = tag
-                    if (tag === d.lastTag)
-                        return
                     d.lastTag = tag
                     root.tagFound(tag)
                 }

--- a/ui/StatusQ/src/StatusQ/Components/StatusQrCodeScanner.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusQrCodeScanner.qml
@@ -7,42 +7,112 @@ import QtGraphicalEffects 1.0
 
 import StatusQ.Controls 0.1
 import StatusQ.Core 0.1
+import StatusQ.Core.Backpressure 1.0
 import StatusQ.Core.Theme 0.1
 
 import QZXing 3.3
 
+/*
+    NOTE:   I'm doing some crazy workarounds here. Tested on MacOS.
+            What I wanted to achieve:
+
+            1. User only gets a OS "allow camera access" popup
+               when a page with QR code scanner is opened.
+            2. Mimize UI freezes, or at least make it obvious
+               that something is going on.
+
+    Camera component uses main UI thread to request OS for available devices.
+    Therefore, we can't simply use Loader with `asyncronous` flag.
+    Neiter we can set `loading: loader.status === Loader.Loading` to this button.
+
+    To achieve desired points, I manually set `loading` property of the button
+    and delay the camera loading for 250ms. UI quickly shows loading indicator,
+    then it will freeze until the camera is loaded.
+
+    I think this can only be improved by moving the OS requests to another thread from C++.
+
+    We also don't yet have ability to auto-detect if the camera access was already enabled.
+    So we show `Enable camera` button everytime.
+*/
+
 Item {
     id: root
 
-    readonly property alias camera: camera
+    property rect captureRectangle: Qt.rect(0, 0, 1, 1)
 
+    // Use this property to clip capture rectangle to biggest possible square
+    readonly property rect squareCaptureRectangle: {
+        const size = Math.min(contentSize.width, contentSize.height)
+        const w = size / contentSize.width
+        const h = size / contentSize.height
+        const x = (1 - w) / 2
+        const y = (1 - h) / 2
+        return Qt.rect(x, y, w, h)
+    }
+
+    property bool highlightContentZone: false
+    property bool highlightCaptureZone: false
+
+    readonly property alias camera: d.camera
     readonly property size sourceSize: Qt.size(videoOutput.sourceRect.width, videoOutput.sourceRect.height)
     readonly property size contentSize: Qt.size(videoOutput.contentRect.width, videoOutput.contentRect.height)
     readonly property real sourceRatio: videoOutput.sourceRect.width / videoOutput.sourceRect.height
 
-    property int failsCount: 0
-    property int tagsCount: 0
-    property int decodeTime: 0
+    readonly property int failsCount: d.failsCount
+    readonly property int tagsCount: d.tagsCount
+    readonly property int decodeTime: d.decodeTime
+    readonly property string lastTag: d.lastTag
+    readonly property string currentTag: d.currentTag
 
-    property string lastTag
+    signal tagFound(string tag)
 
     implicitWidth: sourceSize.width
     implicitHeight: sourceSize.height
-
-    signal tagFound(string tag)
 
     QtObject {
         id: d
 
         readonly property int radius: 16
+
+        function setCameraDevice(deviceId) {
+            if (!d.camera)
+                return
+            d.camera.deviceId = "" // Workaround for Qt bug. Without this the device changes only first time.
+            d.camera.deviceId = deviceId
+        }
+
+        property QtObject camera: null
+
+        //  NOTE:   QtMultimedia.availableCameras also makes a request to OS, if not made previously.
+        //          So we postpone this call until the `Camera` component is loaded
+        property var availableCameras: []
+
+        function onCameraLoaded() {
+            d.camera = loader.item
+            d.availableCameras = QtMultimedia.availableCameras
+            button.loading = false
+        }
+
+        property int failsCount: 0
+        property int tagsCount: 0
+        property int decodeTime: 0
+        property string lastTag
+        property string currentTag
+
     }
 
-    Camera {
-        id: camera
-        captureMode: Camera.CaptureVideo
-        focus {
-            focusMode: CameraFocus.FocusContinuous
-            focusPointMode: CameraFocus.FocusPointAuto
+    Loader {
+        id: loader
+        active: false
+        visible: status == Loader.Ready
+        sourceComponent: Camera {
+            focus {
+                focusMode: CameraFocus.FocusContinuous
+                focusPointMode: CameraFocus.FocusPointAuto
+            }
+        }
+        onLoaded: {
+            d.onCameraLoaded()
         }
     }
 
@@ -56,15 +126,16 @@ Item {
         anchors.fill: parent
         implicitWidth: videoOutput.contentRect.width
         implicitHeight: videoOutput.contentRect.height
-        visible: camera.availability === Camera.Available
+        visible: d.camera && d.camera.availability === Camera.Available
+        clip: true
 
         VideoOutput {
             id: videoOutput
             anchors.fill: parent
             visible: false
-            source: camera
+            source: d.camera
             filters: [ qzxingFilter ]
-            fillMode: VideoOutput.PreserveAspectFit
+            fillMode: VideoOutput.PreserveAspectCrop
         }
 
         Rectangle {
@@ -81,12 +152,40 @@ Item {
             maskSource: mask
         }
 
+        Loader {
+            active: root.highlightContentZone
+            sourceComponent: Rectangle {
+                color: "blue"
+                opacity: 0.2
+                border.width: 3
+                border.color: "blue"
+                x: videoOutput.contentRect.x
+                y: videoOutput.contentRect.y
+                width: videoOutput.contentRect.width
+                height: videoOutput.contentRect.height
+            }
+        }
+
+        Loader {
+            active: root.highlightCaptureZone
+            sourceComponent:  Rectangle {
+                color: "hotpink"
+                opacity: 0.2
+                border.width: 3
+                border.color: "hotpink"
+                x: videoOutput.contentRect.x + root.captureRectangle.x * videoOutput.contentRect.width
+                y: videoOutput.contentRect.y + root.captureRectangle.y * videoOutput.contentRect.height
+                width: videoOutput.contentRect.width * root.captureRectangle.width
+                height: videoOutput.contentRect.height * root.captureRectangle.height
+            }
+        }
+
         QZXingFilter {
             id: qzxingFilter
             orientation: videoOutput.orientation
             captureRect: {
-                videoOutput.contentRect; videoOutput.sourceRect; // bindings
-                const normalizedRectangle = Qt.rect(0, 0, 1, 1)
+                videoOutput.contentRect; videoOutput.sourceRect // bindings
+                const normalizedRectangle = root.captureRectangle
                 const rectangle = videoOutput.mapNormalizedRectToItem(normalizedRectangle)
                 return videoOutput.mapRectToSource(rectangle);
             }
@@ -95,69 +194,99 @@ Item {
                 enabledDecoders: QZXing.DecoderFormat_QR_CODE
                 tryHarder: true
                 onTagFound: {
-                    root.lastTag = tag
+                    d.currentTag = tag
+                    if (tag === d.lastTag)
+                        return
+                    d.lastTag = tag
                     root.tagFound(tag)
                 }
             }
 
             onDecodingFinished: {
-                if (succeeded)
-                    ++root.tagsCount
-                else
-                    ++root.failsCount
-                root.decodeTime = decodeTime
+                if (succeeded) {
+                    ++d.tagsCount
+                } else {
+                    ++d.failsCount
+                    d.currentTag = ""
+                }
+                d.decodeTime = decodeTime
             }
         }
     }
 
-    // TODO: Implement camera selector
-    //       For me it works once. The first switch between 2 cameras is ok.
-    //       The second switch doesn't work and behaves different with 2 approaches:
-    //       With standard `ComboBox` it throws an exception.
-    //       Width `StatusComboBox` it just kinda unbinds from the Camera.
-    //
-    //    ComboBox {
-    //        id: cameraComboBox
+    ColumnLayout {
+        anchors.fill: parent
+        visible: loader.status !== Loader.Ready || loader.status === Loader.Error
+        spacing: 20
 
-    //        anchors {
-    //            right: parent.right
-    //            bottom: parent.bottom
-    //            margins: 10
-    //        }
+        Item {
+            Layout.fillHeight: true
+            Layout.fillWidth: true
+        }
 
-    //        width: implicitWidth
-    //        opacity: 0.7
-    //        model: QtMultimedia.availableCameras
-    //        textRole: "displayName"
-    //        valueRole: "deviceId"
-    //        onCurrentValueChanged: {
-    //            camera.deviceId = currentValue
-    //        }
-    //    }
+        StatusBaseText {
+            Layout.fillWidth: true
+            text: qsTr('Enable access to your camera')
+            leftPadding: 48
+            rightPadding: 48
+            font.pixelSize: 15
+            wrapMode: Text.WordWrap
+            horizontalAlignment: Text.AlignHCenter
+        }
 
-    //    StatusComboBox {
-    //        id: cameraComboBox
-    //        anchors {
-    //            right: parent.right
-    //            bottom: parent.bottom
-    //            margins: 10
-    //        }
+        StatusBaseText {
+            Layout.fillWidth: true
+            text: qsTr("To scan a QR, Status needs\naccess to your webcam")
+            leftPadding: 48
+            rightPadding: 48
+            font.pixelSize: 15
+            wrapMode: Text.WordWrap
+            horizontalAlignment: Text.AlignHCenter
+            color: Theme.palette.directColor4
+        }
 
-    //        width: implicitWidth
-    //        opacity: 0.7
-    //        model: QtMultimedia.availableCameras
-    //        control.textRole: "displayName"
-    //        control.valueRole: "deviceId"
-    //        onCurrentValueChanged: {
-    //            console.log("setting deviceId to", currentValue)
-    //            camera.deviceId = currentValue
-    //        }
-    //    }
+        StatusButton {
+            id: button
+            Layout.alignment: Qt.AlignHCenter
+            text: qsTr("Enable camera access")
+            onClicked: {
+                loading = true
+                Backpressure.debounce(this, 250, () => { loader.active = true })()
+            }
+        }
+
+        Item {
+            Layout.fillHeight: true
+            Layout.fillWidth: true
+        }
+    }
+
+    StatusComboBox {
+        id: cameraComboBox
+
+        anchors {
+            right: parent.right
+            bottom: parent.bottom
+            margins: 10
+        }
+
+        width: Math.min(implicitWidth, parent.width / 2)
+        visible: Array.isArray(d.availableCameras) && d.availableCameras.length > 0
+        opacity: 0.7
+        model: d.availableCameras
+        control.textRole: "displayName"
+        control.valueRole: "deviceId"
+        control.padding: 8
+        control.spacing: 8
+        onCurrentValueChanged: {
+            // Debounce to close combobox first
+            Backpressure.debounce(this, 50, () => { d.setCameraDevice(currentValue) })()
+        }
+    }
 
     ColumnLayout {
         anchors.verticalCenter: parent.verticalCenter
         width: parent.width
-
         spacing: 10
 
         StatusBaseText {
@@ -165,7 +294,7 @@ Item {
             horizontalAlignment: Text.AlignHCenter
             verticalAlignment: Text.AlignVCenter
             color: Theme.palette.dangerColor1
-            visible: camera.availability !== Camera.Available
+            visible: d.camera && d.camera.availability !== Camera.Available
             text: qsTr("Camera is not available")
         }
 
@@ -174,8 +303,8 @@ Item {
             horizontalAlignment: Text.AlignHCenter
             verticalAlignment: Text.AlignVCenter
             color: Theme.palette.directColor5
-            visible: camera.errorCode !== Camera.NoError
-            text: "Error comes here" // camera.errorString
+            visible: d.camera && d.camera.errorCode !== Camera.NoError
+            text: d.camera ? d.camera.errorString : ""
         }
     }
 }

--- a/ui/StatusQ/src/StatusQ/Controls/StatusComboBox.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusComboBox.qml
@@ -61,9 +61,6 @@ Item {
         ComboBox {
             id: comboBox
 
-            property color bgColor: Theme.palette.baseColor2
-            property color bgColorHover: bgColor
-
             Layout.fillWidth: true
             Layout.fillHeight: true
             Layout.topMargin: labelItem.visible ? 7 : 0
@@ -77,7 +74,7 @@ Item {
             spacing: 16
 
             background: Rectangle {
-                implicitHeight: 56
+                implicitHeight: 24 + comboBox.topPadding + comboBox.bottomPadding
                 implicitWidth: 448
                 color: root.type === StatusComboBox.Type.Secondary ? "transparent" : Theme.palette.baseColor2
                 radius: 8

--- a/ui/app/AppLayouts/Onboarding/views/SyncCodeView.qml
+++ b/ui/app/AppLayouts/Onboarding/views/SyncCodeView.qml
@@ -56,7 +56,7 @@ Item {
         id: layout
 
         anchors.centerIn: parent
-        width: 400
+        width: 330
         spacing: 24
 
         StatusBaseText {
@@ -84,13 +84,10 @@ Item {
         }
 
         StackLayout {
-            width: parent.width
             anchors.horizontalCenter: parent.horizontalCenter
-
-            implicitWidth: Math.max(mobileSync.implicitWidth, desktopSync.implicitWidth)
-            implicitHeight: Math.max(mobileSync.implicitHeight, desktopSync.implicitHeight)
+            width: parent.width
+            height: Math.max(mobileSync.implicitHeight, desktopSync.implicitHeight)
             currentIndex: switchTabBar.currentIndex
-            clip: true
 
             // StackLayout doesn't support alignment, so we create an `Item` wrappers
 
@@ -98,17 +95,21 @@ Item {
                 Layout.fillWidth: true
                 Layout.fillHeight: true
 
-                implicitWidth: mobileSync.implicitWidth
-                implicitHeight: mobileSync.implicitHeight
-
                 SyncDeviceFromMobile {
                     id: mobileSync
-                    anchors {
-                        verticalCenter: parent.verticalCenter
-                        horizontalCenter: parent.horizontalCenter
-                    }
-                    onConnectionStringFound: {
-                        d.processConnectionString(connectionString)
+                    anchors.fill: parent
+                    validators: [
+                        StatusValidator {
+                            name: "isConnectionString"
+                            errorMessage: qsTr("Oops! This is not a sync QR code")
+                            validate: (value) => {
+                                          return d.validateConnectionString(value)
+                                      }
+                        }
+                    ]
+                    onQrCodeScanned: {
+                        d.connectionString = desktopSync.input.text
+                        nextStateDelay.start()
                     }
                 }
             }
@@ -116,9 +117,6 @@ Item {
             Item {
                 Layout.fillWidth: true
                 Layout.fillHeight: true
-
-                implicitWidth: desktopSync.implicitWidth
-                implicitHeight: desktopSync.implicitHeight
 
                 SyncDeviceFromDesktop {
                     id: desktopSync

--- a/ui/app/AppLayouts/Onboarding/views/SyncCodeView.qml
+++ b/ui/app/AppLayouts/Onboarding/views/SyncCodeView.qml
@@ -34,16 +34,6 @@ Item {
     QtObject {
         id: d
 
-        readonly property list<StatusValidator> syncCodeValidators: [
-            StatusValidator {
-                name: "isConnectionString"
-                errorMessage: qsTr("This does not look like a sync code")
-                validate: (value) => {
-                              return d.validateConnectionString(value)
-                          }
-            }
-        ]
-
         function validateConnectionString(connectionString) {
             const result = root.startupStore.validateLocalPairingConnectionString(connectionString)
             return result === ""
@@ -117,7 +107,13 @@ Item {
                         right: parent.right
                         verticalCenter: parent.verticalCenter
                     }
-                    validators: d.syncCodeValidators
+                    validators: [
+                        StatusValidator {
+                            name: "isSyncQrCode"
+                            errorMessage: qsTr("This does not look like a sync QR code")
+                            validate: d.validateConnectionString
+                        }
+                    ]
                     onConnectionStringFound: {
                         d.onConnectionStringFound(connectionString)
                     }
@@ -136,7 +132,13 @@ Item {
                         verticalCenter: parent.verticalCenter
                     }
                     input.readOnly: nextStateDelay.running
-                    input.validators: d.syncCodeValidators
+                    input.validators: [
+                        StatusValidator {
+                            name: "isSyncCode"
+                            errorMessage: qsTr("This does not look like a sync code")
+                            validate: d.validateConnectionString
+                        }
+                    ]
                     input.onValidChanged: {
                         if (!input.valid)
                             return

--- a/ui/app/AppLayouts/Onboarding/views/sync/SyncDeviceFromDesktop.qml
+++ b/ui/app/AppLayouts/Onboarding/views/sync/SyncDeviceFromDesktop.qml
@@ -10,7 +10,7 @@ Column {
 
     StatusSyncCodeInput {
         id: codeInput
-        implicitWidth: 400
+        width: parent.width
         mode: StatusSyncCodeInput.WriteMode
     }
 }

--- a/ui/app/AppLayouts/Onboarding/views/sync/SyncDeviceFromMobile.qml
+++ b/ui/app/AppLayouts/Onboarding/views/sync/SyncDeviceFromMobile.qml
@@ -3,29 +3,74 @@ import QtQuick.Layouts 1.12
 import QtQuick.Controls 2.13
 
 import StatusQ.Controls 0.1
+import StatusQ.Controls.Validators 0.1
 import StatusQ.Components 0.1
 import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
 
-Rectangle {
+Column {
     id: root
 
-    signal connectionStringFound(connectionString: string)
+    property list<StatusValidator> validators
 
-    implicitWidth: 330
-    implicitHeight: 330
+    signal qrCodeScanned(value: string)
 
-    radius: 16
-    color: Theme.palette.baseColor4
+    spacing: 12
 
+    QtObject {
+        id: d
+
+        property string errorMessage
+        property string lastTag
+        property int counter: 0
+    }
+
+    StatusQrCodeScanner {
+        id: scanner
+
+        width: parent.width
+        implicitHeight: 330
+
+        onTagFound: {
+//            if (tag === d.lastTag) {
+//                console.log("<<< equals to last tag", tag, counter++)
+//                return
+//            }
+
+            console.log("<<< validating", tag)
+
+            d.lastTag = tag
+
+            for (let i in validators) {
+                const validator = validators[i]
+                if (!validator.validate(tag)) {
+                    d.errorMessage = validator.errorMessage
+                    return
+                }
+                d.errorMessage = ""
+                root.qrCodeScanned(value)
+            }
+        }
+    }
+
+    Item {
+        width: parent.width
+        height: 16
+    }
 
     StatusBaseText {
-        id: text
-        anchors.fill: parent
-        horizontalAlignment: Text.AlignHCenter
-        verticalAlignment: Text.AlignVCenter
-        font.pixelSize: 15
+        width: parent.width
+        wrapMode: Text.WordWrap
         color: Theme.palette.dangerColor1
-        text: qsTr("QR code scanning is not available yet")
+        horizontalAlignment: Text.AlignHCenter
+        text: d.errorMessage
+    }
+
+    StatusBaseText {
+        width: parent.width
+        wrapMode: Text.WordWrap
+        color: Theme.palette.baseColor1
+        horizontalAlignment: Text.AlignHCenter
+        text: qsTr("Ensure that the QR code is in focus to scan")
     }
 }

--- a/ui/app/AppLayouts/Onboarding/views/sync/SyncDeviceFromMobile.qml
+++ b/ui/app/AppLayouts/Onboarding/views/sync/SyncDeviceFromMobile.qml
@@ -13,7 +13,7 @@ Column {
 
     property list<StatusValidator> validators
 
-    signal qrCodeScanned(value: string)
+    signal connectionStringFound(connectionString: string)
 
     spacing: 12
 
@@ -23,33 +23,27 @@ Column {
         property string errorMessage
         property string lastTag
         property int counter: 0
-    }
 
-    StatusQrCodeScanner {
-        id: scanner
-
-        width: parent.width
-        implicitHeight: 330
-
-        onTagFound: {
-//            if (tag === d.lastTag) {
-//                console.log("<<< equals to last tag", tag, counter++)
-//                return
-//            }
-
-            console.log("<<< validating", tag)
-
-            d.lastTag = tag
-
-            for (let i in validators) {
-                const validator = validators[i]
-                if (!validator.validate(tag)) {
+        function validateConnectionString(connectionString) {
+            for (let i in root.validators) {
+                const validator = root.validators[i]
+                if (!validator.validate(connectionString)) {
                     d.errorMessage = validator.errorMessage
                     return
                 }
                 d.errorMessage = ""
-                root.qrCodeScanned(value)
+                root.connectionStringFound(connectionString)
             }
+        }
+    }
+
+    StatusQrCodeScanner {
+        id: scanner
+        anchors.horizontalCenter: parent.horizontalCenter
+        width: 330
+        height: 330
+        onLastTagChanged: {
+            d.validateConnectionString(lastTag)
         }
     }
 
@@ -60,6 +54,7 @@ Column {
 
     StatusBaseText {
         width: parent.width
+        opacity: scanner.currentTag ? 1 : 0
         wrapMode: Text.WordWrap
         color: Theme.palette.dangerColor1
         horizontalAlignment: Text.AlignHCenter
@@ -68,6 +63,7 @@ Column {
 
     StatusBaseText {
         width: parent.width
+        opacity: scanner.camera ? 1 : 0
         wrapMode: Text.WordWrap
         color: Theme.palette.baseColor1
         horizontalAlignment: Text.AlignHCenter

--- a/ui/imports/shared/views/DeviceSyncingView.qml
+++ b/ui/imports/shared/views/DeviceSyncingView.qml
@@ -66,6 +66,7 @@ Item {
             active: root.userPublicKey == ""
             Layout.alignment: Qt.AlignHCenter
             sourceComponent: UserImage {
+                opacity: name ? 1 : 0
                 name: root.userDisplayName
                 colorId: root.userColorId
                 colorHash: root.userColorHash
@@ -73,6 +74,10 @@ Item {
                 interactive: false
                 imageWidth: 80
                 imageHeight: 80
+
+                Behavior on opacity {
+                    NumberAnimation { duration: 250 }
+                }
             }
         }
 


### PR DESCRIPTION
FIxes https://github.com/status-im/status-desktop/issues/9865

Requires:
- https://github.com/status-im/status-desktop/pull/10088
- https://github.com/status-im/status-go/pull/3358


# What does the PR do

1. Embed `StatusQrCodeScanner` for "Setup with sync code" onboarding
1. Link `qzxing` as shared library
`qzxing` is built with many exceptions and `try/catch` blocks.
Currently catching doesn't work in the desktop app (though it works in sandbox).
When the library is build as shared one, it works. 
https://github.com/status-im/status-desktop/issues/9863 should fix this, for example.
1. Log error on `inputConnectionStringForBootstrappingFinished`
This should not happen, so I didn't implement any UI here
1. Hide user profile image until it's received from other device.

## Scanning different QR codes

https://user-images.githubusercontent.com/25482501/226880717-eb09126e-0754-4432-a765-bd17f610b93e.mov

## Scanning real QR code from mobile

https://user-images.githubusercontent.com/25482501/226881198-598b88b6-ca1c-469c-8d4d-b4164b63b636.mov

# `StatusQrCodeScanner`:
1. Added combo box for selecting a camera
3. Added "almost async" loading
Note [this comment in the code](https://github.com/status-im/status-desktop/blob/7eff03ec30670c799cf07d25ae006ad7acfb1f9c/ui/StatusQ/src/StatusQ/Components/StatusQrCodeScanner.qml#L15-L36) for more info.
4. Improved sandbox page

<img width="1325" alt="image" src="https://user-images.githubusercontent.com/25482501/226879596-f1c3731d-efe6-476e-b975-fd3744fab071.png">

# Important notes:

1. Asking for camera access on MacOS.
There're no such default handles in QML do detect if camera access was already gained.
This should be implemented in C++. I decided to postpone this feature and always show `Enable camera access` button.
This gratefully simplifies work for me and doesn't make much harm on UX.
Will implement it later.
1. There were some UI freezes in MacOS 13. 
Those are fixed in 13.1, as noted [here](https://bugreports.qt.io/browse/QTBUG-108530). I updated and tested with 13.2.
1. There's a [known Qt bug](https://bugreports.qt.io/browse/QTBUG-108018) on using [MacOS Continuity Camera feature](https://support.apple.com/guide/mac-help/use-iphone-as-a-webcam-mchl77879b8a/mac).
Currently we can't really do anything about it. The app will crash when choosing the iPhone camera in the combobox.

# Affected areas

Onboarding with sync code
