### PR TITLE
fix(AC): fix store so that community request buttons work in the AC

### DIFF
--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -970,7 +970,12 @@ Item {
                 x: parent.width - width - Style.current.smallPadding
                 y: parent.y + _buttonSize
                 height: appView.height - _buttonSize * 2
-                store: appMain.rootChatStore
+                store: ChatStores.RootStore {
+                    contactsStore: appMain.rootStore.contactStore
+                    emojiReactionsModel: appMain.rootStore.emojiReactionsModel
+                    openCreateChat: createChatView.opened
+                    chatCommunitySectionModule: appMain.rootStore.mainModuleInst.getChatSectionModule()
+                }
                 activityCenterStore: appMain.activityCenterStore
             }
         }


### PR DESCRIPTION
Fixes #9988

The store was not valid, since the chat can be not loaded on start. Instead, we just generate a new store using the chat module.