### PR TITLE
fix(Syncing): Update to newer version of status-go local pairing

### DIFF
--- a/src/app_service/service/accounts/service.nim
+++ b/src/app_service/service/accounts/service.nim
@@ -337,6 +337,7 @@ QtObject:
       result["Rendezvous"] = newJBool(false)
 
     result["KeyStoreDir"] = newJString(self.keyStoreDir.replace(main_constants.STATUSGODIR, ""))
+    result["RootDataDir"] = newJString(main_constants.STATUSGODIR)
 
   proc setLocalAccountSettingsFile(self: Service) =
     if(main_constants.IS_MACOS and self.getLoggedInAccount.isValid()):
@@ -747,3 +748,6 @@ QtObject:
     except Exception as e:
       error "error: ", procName="verifyPassword", errName = e.name, errDesription = e.msg
     return false
+
+  proc getKdfIterations*(self: Service): int =
+    return KDF_ITERATIONS

--- a/src/app_service/service/devices/service.nim
+++ b/src/app_service/service/devices/service.nim
@@ -165,11 +165,15 @@ QtObject:
 
   proc getConnectionStringForBootstrappingAnotherDevice*(self: Service, keyUid: string, password: string): string =
     let configJSON = %* {
-      "keyUID": keyUid,
-      "keystorePath": joinPath(main_constants.ROOTKEYSTOREDIR, keyUid),
-      "deviceType": hostOs,
-      "password": utils.hashPassword(password),
-      "timeout": 5 * 60 * 1000,
+      "senderConfig": %* {
+        "keystorePath": joinPath(main_constants.ROOTKEYSTOREDIR, keyUid),
+        "deviceType": hostOs,
+        "keyUID": keyUid,
+        "password": utils.hashPassword(password),
+      },
+      "serverConfig": %* {
+        "timeout": 5 * 60 * 1000,
+      }
     }
     self.localPairingStatus.mode = LocalPairingMode.BootstrapingOtherDevice
     return status_go.getConnectionStringForBootstrappingAnotherDevice($configJSON)
@@ -177,12 +181,15 @@ QtObject:
   proc inputConnectionStringForBootstrapping*(self: Service, connectionString: string): string =
     let installationId = $genUUID()
     let nodeConfigJson = self.accountsService.getDefaultNodeConfig(installationId)
-        
     let configJSON = %* {
-      "keystorePath": main_constants.ROOTKEYSTOREDIR,
-      "nodeConfig": nodeConfigJson,
-      "deviceType": hostOs,
-      "RootDataDir": main_constants.STATUSGODIR
+      "receiverConfig": %* {
+        "keystorePath": main_constants.ROOTKEYSTOREDIR,
+        "deviceType" : hostOs,
+        "nodeConfig": nodeConfigJson,
+        "kdfIterations": self.accountsService.getKdfIterations(),
+        "settingCurrentNetwork": ""
+      },
+      "clientConfig": %* {}
     }
     self.localPairingStatus.mode = LocalPairingMode.BootstrapingThisDevice
 


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/9982
Requires https://github.com/status-im/status-go/pull/3248

### What does the PR do

Update status-desktop to newer version of local pairing in status-go.
For user nothing should've changed, it's just internal update of structures.

Tested with https://github.com/status-im/status-mobile/pull/15412

I've tested all possible combinations:
* mobile -> desktop
* desktop -> mobil
* desktop -> desktop

### Affected areas

Syncing