### PR TITLE
fix(MembersSelectorView): Change paste event to parsing text for lookup contacts

### DIFF
--- a/ui/app/AppLayouts/Chat/views/MembersSelectorView.qml
+++ b/ui/app/AppLayouts/Chat/views/MembersSelectorView.qml
@@ -32,8 +32,8 @@ MembersSelectorBase {
         d.removeMember(delegate._pubKey)
     }
 
-    onTextPasted: {
-        d.lookupContact(text);
+    edit.onTextChanged: {
+        d.lookupContact(edit.text)
     }
 
     model: SortFilterProxyModel {
@@ -57,7 +57,9 @@ MembersSelectorBase {
         function lookupContact(value) {
             if (value.startsWith(Constants.userLinkPrefix))
                 value = value.slice(Constants.userLinkPrefix.length)
-            root.rootStore.contactsStore.resolveENS(value)
+
+            if (Utils.isCompressedPubKey(value))
+                root.rootStore.contactsStore.resolveENS(value)
         }
 
         function addMember(pubKey, displayName, localNickname) {
@@ -95,6 +97,7 @@ MembersSelectorBase {
             }
 
             const contactDetails = Utils.getContactDetailsAsJson(resolvedPubKey, false)
+
 
             if (contactDetails.publicKey === root.rootStore.contactsStore.myPublicKey ||
                 contactDetails.isBlocked) {


### PR DESCRIPTION
Fixes: #9881

### What does the PR do

`Paste` event not working perfect. I change it to parsing text which works 100%.
Just one suggestion: Checking the length of `CompressedPubkey` cos  `zQ3` is valid for method `isCompressedPubKey`

### Affected areas

MembersSelectorView

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

