### PR TITLE
feat(Airdrop): Some `HoldingsDropdown` improvements / adjustments

### DIFF
--- a/storybook/pages/HoldingsDropdownPage.qml
+++ b/storybook/pages/HoldingsDropdownPage.qml
@@ -50,6 +50,7 @@ SplitView {
             collectiblesModel: CollectiblesModel {}
             assetsModel: AssetsModel {}
             isENSTab: isEnsTabChecker.checked
+            isCollectiblesOnly: isCollectiblesOnlyChecker.checked
 
             onOpened: contentItem.parent.parent = container
             Component.onCompleted: {
@@ -64,10 +65,18 @@ SplitView {
         SplitView.minimumHeight: 100
         SplitView.preferredHeight: 250
 
-        CheckBox {
-            id: isEnsTabChecker
-            text: "Is ENS tab visible?"
-            checked: true
+        RowLayout {
+            CheckBox {
+                id: isEnsTabChecker
+                text: "Is ENS tab visible?"
+                checked: true
+            }
+
+            CheckBox {
+                id: isCollectiblesOnlyChecker
+                text: "Is collectibles only visible?"
+                checked: false
+            }
         }
     }
 }

--- a/ui/app/AppLayouts/Chat/controls/community/ExtendedDropdownContent.qml
+++ b/ui/app/AppLayouts/Chat/controls/community/ExtendedDropdownContent.qml
@@ -23,6 +23,7 @@ Item {
 
     property var checkedKeys: []
     property int type: ExtendedDropdownContent.Type.Assets
+    property string noDataText: qsTr("No data found")
 
     readonly property bool canGoBack: root.state !== d.depth1_ListState
 
@@ -81,6 +82,13 @@ Item {
         property url currentItemSource: ""
 
         readonly property bool searchMode: searcher.text.length > 0
+        readonly property bool availableData: {
+            if(root.type === ExtendedDropdownContent.Type.Assets && root.assetsModel && root.assetsModel.count > 0)
+                return true
+            if(root.type === ExtendedDropdownContent.Type.Collectibles && root.collectiblesModel && root.collectiblesModel.count > 0)
+                return true
+            return false
+        }
 
         onCurrentModelChanged: {
             // Workaround for a bug in SortFilterProxyModel causing that model
@@ -337,6 +345,7 @@ Item {
             Layout.fillWidth: true
             Layout.topMargin: root.state === d.depth1_ListState ? 0 : 8
 
+            visible: d.availableData
             topPadding: 0
             bottomPadding: 0
             minimumHeight: 36
@@ -388,6 +397,8 @@ Item {
         id: assetsListView
 
         ListDropdownContent {
+            availableData: d.availableData
+            noDataText: root.noDataText
             headerModel: ListModel {
                 ListElement { key: "MINT"; icon: "add"; iconSize: 16; description: qsTr("Mint asset"); rotation: 0; spacing: 8 }
                 ListElement { key: "IMPORT"; icon: "invite-users"; iconSize: 16; description: qsTr("Import existing asset"); rotation: 180; spacing: 8 }
@@ -414,6 +425,8 @@ Item {
         id: collectiblesListView
 
         ListDropdownContent {
+            availableData: d.availableData
+            noDataText: root.noDataText
             areHeaderButtonsVisible: root.state === d.depth1_ListState
             headerModel: ListModel {
                ListElement { key: "MINT"; icon: "add"; iconSize: 16; description: qsTr("Mint collectible"); rotation: 0; spacing: 8 }

--- a/ui/app/AppLayouts/Chat/controls/community/ExtendedDropdownContent.qml
+++ b/ui/app/AppLayouts/Chat/controls/community/ExtendedDropdownContent.qml
@@ -30,6 +30,7 @@ Item {
     signal itemClicked(string key, string name, url iconSource)
     signal navigateDeep(string key, var subItems)
     signal layoutChanged()
+    signal navigateToMintTokenSettings
 
     implicitHeight: content.implicitHeight
     implicitWidth: content.implicitWidth
@@ -435,9 +436,7 @@ Item {
             checkedKeys: root.checkedKeys
             searchMode: d.searchMode
 
-            onHeaderItemClicked: {
-                if(key === "MINT") console.log("TODO: Mint collectible")
-            }
+            onHeaderItemClicked: root.navigateToMintTokenSettings()
             onItemClicked: {
                 if(subItems && root.state === d.depth1_ListState) {
                     // One deep navigation

--- a/ui/app/AppLayouts/Chat/controls/community/HoldingsDropdown.qml
+++ b/ui/app/AppLayouts/Chat/controls/community/HoldingsDropdown.qml
@@ -16,6 +16,7 @@ StatusDropdown {
     property var assetsModel
     property var collectiblesModel
     property bool isENSTab: true
+    property bool isCollectiblesOnly: false
 
     property var usedTokens: []
     property var usedEnsNames: []
@@ -54,11 +55,11 @@ StatusDropdown {
     }
 
     function setActiveTab(holdingType) {
-        d.currentHoldingType = holdingType
+        d.currentHoldingType = root.isCollectiblesOnly ? HoldingTypes.Type.Collectible : holdingType
     }
 
     function reset() {
-        d.currentHoldingType = HoldingTypes.Type.Asset
+        d.currentHoldingType = root.isCollectiblesOnly ? HoldingTypes.Type.Collectible : HoldingTypes.Type.Asset
         d.initialHoldingMode = HoldingTypes.Mode.Add
 
         root.assetKey = ""
@@ -83,7 +84,7 @@ StatusDropdown {
         readonly property bool ensReady: d.ensDomainNameValid
 
         property int extendedDropdownType: ExtendedDropdownContent.Type.Assets
-        property int currentHoldingType: HoldingTypes.Type.Asset
+        property int currentHoldingType: root.isCollectiblesOnly ? HoldingTypes.Type.Collectible : HoldingTypes.Type.Asset
 
         property bool updateSelected: false
 
@@ -165,7 +166,7 @@ StatusDropdown {
         StatusSwitchTabBar {
             id: tabBar
 
-            visible: !backButton.visible
+            visible: !root.isCollectiblesOnly && !backButton.visible
             Layout.preferredHeight: d.tabBarHeigh
             Layout.fillWidth: true
             currentIndex: d.holdingTypes.indexOf(d.currentHoldingType)
@@ -189,7 +190,7 @@ StatusDropdown {
 
             onCurrentIndexChanged: {
                 if(currentIndex >= 0) {
-                    d.currentHoldingType = d.holdingTypes[currentIndex]
+                    d.currentHoldingType = root.isCollectiblesOnly ? HoldingTypes.Type.Collectible : d.holdingTypes[currentIndex]
                     d.setInitialFlow()
                 }
             }
@@ -232,6 +233,8 @@ StatusDropdown {
     }
 
     onClosed: root.reset()
+    onIsCollectiblesOnlyChanged: root.reset()
+    onIsENSTabChanged: root.reset()
 
     Component {
         id: listLayout

--- a/ui/app/AppLayouts/Chat/controls/community/HoldingsDropdown.qml
+++ b/ui/app/AppLayouts/Chat/controls/community/HoldingsDropdown.qml
@@ -45,6 +45,7 @@ StatusDropdown {
     signal updateEns(string domain)
 
     signal removeClicked
+    signal navigateToMintTokenSettings
 
     enum FlowType {
         Selected, List_Deep1, List_Deep2
@@ -298,6 +299,8 @@ StatusDropdown {
                                         CommunityPermissionsHelpers.getTokenIconByKey(root.collectiblesModel, d.currentItemKey),
                                         d.currentSubItems)
             }
+
+            onNavigateToMintTokenSettings: root.navigateToMintTokenSettings()
 
             Connections {
                 target: backButton

--- a/ui/app/AppLayouts/Chat/controls/community/HoldingsDropdown.qml
+++ b/ui/app/AppLayouts/Chat/controls/community/HoldingsDropdown.qml
@@ -17,6 +17,13 @@ StatusDropdown {
     property var collectiblesModel
     property bool isENSTab: true
     property bool isCollectiblesOnly: false
+    property string noDataText: {
+        if(d.currentHoldingType  ===  HoldingTypes.Type.Asset)
+            return qsTr("No assets found")
+        if(d.currentHoldingType === HoldingTypes.Type.Collectible)
+            return qsTr("No collectibles found")
+        return qsTr("No data found")
+    }
 
     property var usedTokens: []
     property var usedEnsNames: []
@@ -244,6 +251,7 @@ StatusDropdown {
 
             assetsModel: root.assetsModel
             collectiblesModel: root.collectiblesModel
+            noDataText: root.noDataText
 
             checkedKeys: root.usedTokens.map(entry => entry.key)
             type: d.extendedDropdownType

--- a/ui/app/AppLayouts/Chat/controls/community/ListDropdownContent.qml
+++ b/ui/app/AppLayouts/Chat/controls/community/ListDropdownContent.qml
@@ -8,6 +8,7 @@ import StatusQ.Core.Theme 0.1
 import StatusQ.Controls 0.1
 import StatusQ.Components 0.1
 
+import utils 1.0
 
 StatusListView {
     id: root
@@ -17,6 +18,8 @@ StatusListView {
     property var headerModel
     property bool areHeaderButtonsVisible: true
     property bool searchMode: false
+    property bool availableData: false
+    property string noDataText: qsTr("No data found")
 
     property int maxHeight: 381 // default by design
 
@@ -72,7 +75,7 @@ StatusListView {
             Layout.preferredHeight: visible ? d.sectionHeight : 0
             Layout.fillWidth: true
 
-            visible: root.searchMode
+            visible: !root.availableData || root.searchMode
             sourceComponent: sectionComponent
         }
     }
@@ -122,18 +125,25 @@ StatusListView {
         Item {
             id: sectionDelegateRoot
 
-            property string section: root.count ?
-                                         qsTr("Search result") :
-                                         qsTr("No results")
+            property string section: {
+                if(!root.availableData)
+                    return root.noDataText
+                if(root.count)
+                    return qsTr("Search result")
+                return qsTr("No results")
+            }
 
             StatusBaseText {
-                anchors.leftMargin: 8
+                anchors.leftMargin: Style.current.halfPadding
                 anchors.left: parent.left
                 anchors.verticalCenter: parent.verticalCenter
+                width: parent.width
                 text: sectionDelegateRoot.section
                 color: Theme.palette.baseColor1
                 font.pixelSize: 12
                 elide: Text.ElideRight
+                wrapMode: Text.WordWrap
+                lineHeight: 1.2
             }
         }
     }

--- a/ui/app/AppLayouts/Chat/panels/communities/CommunityAirdropsSettingsPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/CommunityAirdropsSettingsPanel.qml
@@ -20,6 +20,7 @@ SettingsPageLayout {
     property int viewWidth: 560 // by design
 
     signal airdropClicked(var airdropTokens, string address)
+    signal navigateToMintTokenSettings
 
     // TODO: Update with stackmanager when #8736 is integrated
     function navigateBack() {
@@ -98,6 +99,7 @@ SettingsPageLayout {
                 root.airdropClicked(airdropTokens, address)
                 stackManager.clear(d.welcomeViewState, StackView.Immediate)
             }
+            onNavigateToMintTokenSettings: root.navigateToMintTokenSettings()
         }
     }
 }

--- a/ui/app/AppLayouts/Chat/panels/communities/CommunityPermissionsSettingsPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/CommunityPermissionsSettingsPanel.qml
@@ -31,6 +31,8 @@ SettingsPageLayout {
 
     signal removePermissionRequested(string key)
 
+    signal navigateToMintTokenSettings
+
     function navigateBack() {
         if (root.state === d.newPermissionViewState) {
             root.state = d.initialState
@@ -244,6 +246,8 @@ SettingsPageLayout {
 
                 root.state = d.permissionsViewState
             }
+
+            onNavigateToMintTokenSettings: root.navigateToMintTokenSettings()
 
             Connections {
                 target: d

--- a/ui/app/AppLayouts/Chat/views/CommunitySettingsView.qml
+++ b/ui/app/AppLayouts/Chat/views/CommunitySettingsView.qml
@@ -280,6 +280,8 @@ StatusSectionLayout {
                     permissionsStore.removePermission(key)
 
                 onPreviousPageNameChanged: root.backButtonName = previousPageName
+
+                onNavigateToMintTokenSettings: d.currentIndex = d.mintTokensSettingsIndex
             }
 
             CommunityMintTokensSettingsPanel {
@@ -313,6 +315,12 @@ StatusSectionLayout {
                                                            artworkSource,
                                                            accountName)
                 }
+                                
+                Binding {
+                   target: d
+                   property: "mintTokensSettingsIndex"
+                   value: communityMintTokensSettingsPanel.StackView.index
+                }
 
                 // TODO: Review once backend is done
                 Connections {
@@ -333,6 +341,7 @@ StatusSectionLayout {
 
                 onPreviousPageNameChanged: root.backButtonName = previousPageName
                 onAirdropClicked: communityTokensStore.airdrop(airdropTokens, chainId, address)
+                onNavigateToMintTokenSettings: d.currentIndex = d.mintTokensSettingsIndex
             }
 
             onCurrentIndexChanged: root.backButtonName = centerPanelContentLoader.item.children[d.currentIndex].previousPageName
@@ -343,7 +352,9 @@ StatusSectionLayout {
 
     QtObject {
         id: d
+
         property int currentIndex: 0
+        property int mintTokensSettingsIndex
     }
 
     MessageDialog {

--- a/ui/app/AppLayouts/Chat/views/communities/CommunityNewAirdropView.qml
+++ b/ui/app/AppLayouts/Chat/views/communities/CommunityNewAirdropView.qml
@@ -77,6 +77,7 @@ StatusScrollView {
                 assetsModel: root.assetsModel
                 collectiblesModel: root.collectiblesModel
                 isENSTab: false
+                isCollectiblesOnly: true
 
                 function addItem(type, item, amount) {
                     const key = item.key

--- a/ui/app/AppLayouts/Chat/views/communities/CommunityNewAirdropView.qml
+++ b/ui/app/AppLayouts/Chat/views/communities/CommunityNewAirdropView.qml
@@ -78,6 +78,7 @@ StatusScrollView {
                 collectiblesModel: root.collectiblesModel
                 isENSTab: false
                 isCollectiblesOnly: true
+                noDataText: qsTr("First you need to mint or import a collectible before you can perform an airdrop")
 
                 function addItem(type, item, amount) {
                     const key = item.key

--- a/ui/app/AppLayouts/Chat/views/communities/CommunityNewAirdropView.qml
+++ b/ui/app/AppLayouts/Chat/views/communities/CommunityNewAirdropView.qml
@@ -32,6 +32,7 @@ StatusScrollView {
                                           addressess.model.count > 0
 
     signal airdropClicked(var airdropTokens, string address)
+    signal navigateToMintTokenSettings
 
     QtObject {
         id: d
@@ -145,6 +146,11 @@ StatusScrollView {
                 onRemoveClicked: {
                     root.selectedHoldingsModel.remove(tokensSelector.editedIndex)
                     dropdown.close()
+                }
+
+                onNavigateToMintTokenSettings: {
+                    root.navigateToMintTokenSettings()
+                    close()
                 }
             }
 

--- a/ui/app/AppLayouts/Chat/views/communities/CommunityNewPermissionView.qml
+++ b/ui/app/AppLayouts/Chat/views/communities/CommunityNewPermissionView.qml
@@ -56,6 +56,7 @@ StatusScrollView {
     property bool permissionTypeLimitReached: false
 
     signal createPermissionClicked
+    signal navigateToMintTokenSettings
 
     function resetChanges() {
         d.loadInitValues()
@@ -285,6 +286,11 @@ StatusScrollView {
                 onRemoveClicked: {
                     d.dirtyValues.selectedHoldingsModel.remove(tokensSelector.editedIndex)
                     dropdown.close()
+                }
+
+                onNavigateToMintTokenSettings: {
+                    root.navigateToMintTokenSettings()
+                    close()
                 }
             }
 


### PR DESCRIPTION
Closes #9938

### What does the PR do

- Added `isCollectiblesOnly` option in `HoldingsDropdown`.
- Hidden assets tab in airdrop `HoldingsDropdown`.
- No data message added in `HoldingsDropdown`.
- Enabled navigation to mint tokens settings section from `HoldingsDropdown`.
- `storybook` updated accordingly.

### Affected areas

Community Settings / Airdrop / Permissions holdings dropdown

### Screenshot of functionality

https://user-images.githubusercontent.com/97019400/227328116-e61ca05a-dd09-45c8-bd99-4b529d29d78f.mov

https://user-images.githubusercontent.com/97019400/227328157-576ba7f3-79f3-4215-951f-60e8e4b142d1.mov





