### PR TITLE
fix(@desktop/general): clicking anywhere outside a modal dialog should close it

### DIFF
--- a/ui/app/AppLayouts/Profile/popups/ChangePasswordModal.qml
+++ b/ui/app/AppLayouts/Profile/popups/ChangePasswordModal.qml
@@ -62,7 +62,8 @@ StatusModal {
 
     width: 480
     height: 546
-    closePolicy: Popup.NoAutoClose
+    closePolicy: submitBtn.loading? Popup.NoAutoClose : Popup.CloseOnEscape | Popup.CloseOnPressOutside
+    hasCloseButton: !submitBtn.loading
     header.title: qsTr("Change password")
 
     onOpened: view.reset()

--- a/ui/app/AppLayouts/Profile/popups/ChangePasswordSuccessModal.qml
+++ b/ui/app/AppLayouts/Profile/popups/ChangePasswordSuccessModal.qml
@@ -15,6 +15,7 @@ StatusModal {
     height: 248
 
     closePolicy: Popup.NoAutoClose
+    hasCloseButton: false
 
     showHeader: false
     contentItem: ColumnLayout {

--- a/ui/imports/shared/popups/keycard/KeycardPopup.qml
+++ b/ui/imports/shared/popups/keycard/KeycardPopup.qml
@@ -13,7 +13,7 @@ StatusModal {
     property var emojiPopup
 
     width: Constants.keycard.general.popupWidth
-    closePolicy: d.disableActionPopupButtons || d.disableCloseButton? Popup.NoAutoClose : Popup.CloseOnEscape
+    closePolicy: d.disableActionPopupButtons || d.disableCloseButton? Popup.NoAutoClose : Popup.CloseOnEscape | Popup.CloseOnPressOutside
     hasCloseButton: !d.disableActionPopupButtons && !d.disableCloseButton
 
     header.title: {


### PR DESCRIPTION
Fixed popups:
- password change
- all keycard flows

Closing on click outside the popup for add account popup, since it's completely redone, is already implemented in #9820 

Fixes: #9702