### PR TITLE
Fix: import join/community flow

### DIFF
--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -488,7 +488,7 @@ QtObject {
         const communityName = getSectionNameById(result.communityId)
         if (!communityName) {
             // Unknown community, fetch the info if possible
-            root.requestCommunityInfo(communityId)
+            root.requestCommunityInfo(result.communityId)
             return result
         }
 

--- a/ui/app/AppLayouts/Profile/stores/ProfileSectionStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/ProfileSectionStore.qml
@@ -9,7 +9,7 @@ QtObject {
     property string backButtonName
 
     property var aboutModuleInst: aboutModule
-
+    property var mainModuleInst: mainModule
     property var profileSectionModuleInst: profileSectionModule
 
     readonly property bool fetchingUpdate: aboutModuleInst.fetching
@@ -141,6 +141,14 @@ QtObject {
 
     function importCommunity(communityKey) {
         root.communitiesModuleInst.importCommunity(communityKey);
+    }
+
+    function requestCommunityInfo(communityKey, importing = false) {
+        const publicKey = Utils.isCompressedPubKey(communityKey)
+                            ? Utils.changeCommunityKeyCompression(communityKey)
+                            : communityKey
+        root.mainModuleInst.setCommunityIdToSpectate(publicKey)
+        root.communitiesModuleInst.requestCommunityInfo(publicKey, importing)
     }
 
     function getCurrentVersion() {


### PR DESCRIPTION
- the community invitation bubble would never show up when pasting a link into a chat
- the import community popup in settings was missing some required store methods

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![image](https://user-images.githubusercontent.com/5377645/227533485-3885191c-8ed7-4bc0-833e-39ea2e00501e.png)

