### PR TITLE
fix(communities): only require auth for token gated communities

### DIFF
--- a/src/app/modules/main/chat_section/io_interface.nim
+++ b/src/app/modules/main/chat_section/io_interface.nim
@@ -377,3 +377,6 @@ method requestToJoinCommunity*(self: AccessInterface, communityId: string, ensNa
 
 method onDeactivateChatLoader*(self: AccessInterface, chatId: string) =
   raise newException(ValueError, "No implementation available")
+
+method requestToJoinCommunityWithAuthentication*(self: AccessInterface, communityId: string, ensName: string) =
+  raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -1199,6 +1199,9 @@ method deleteCommunityTokenPermission*(self: Module, communityId: string, permis
   self.controller.deleteCommunityTokenPermission(communityId, permissionId)
 
 method requestToJoinCommunity*(self: Module, communityId: string, ensName: string) =
+  self.controller.requestToJoinCommunity(communityId, ensName)
+
+method requestToJoinCommunityWithAuthentication*(self: Module, communityId: string, ensName: string) =
   self.controller.authenticateToRequestToJoinCommunity(communityId, ensName)
 
 proc buildTokenPermissionItem*(self: Module, tokenPermission: CommunityTokenPermissionDto): TokenPermissionItem =

--- a/src/app/modules/main/chat_section/view.nim
+++ b/src/app/modules/main/chat_section/view.nim
@@ -245,6 +245,9 @@ QtObject:
   proc requestToJoinCommunity*(self: View, communityId: string, ensName: string) {.slot.} =
     self.delegate.requestToJoinCommunity(communityId, ensName)
 
+  proc requestToJoinCommunityWithAuthentication*(self: View, communityId: string, ensName: string) {.slot.} =
+    self.delegate.requestToJoinCommunityWithAuthentication(communityId, ensName)
+
   proc joinGroupChatFromInvitation*(self: View, groupName: string, chatId: string, adminPK: string) {.slot.} =
     self.delegate.joinGroupChatFromInvitation(groupName, chatId, adminPK)
 

--- a/ui/app/AppLayouts/Chat/ChatLayout.qml
+++ b/ui/app/AppLayouts/Chat/ChatLayout.qml
@@ -101,7 +101,7 @@ StackLayout {
                 accessType: communityData.access
 
                 onJoined: {
-                    root.rootStore.requestToJoinCommunity(communityData.id, root.rootStore.userProfileInst.name)
+                    root.rootStore.requestToJoinCommunityWithAuthentication(communityData.id, root.rootStore.userProfileInst.name)
                 }
 
                 onCancelMembershipRequest: {

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -411,6 +411,10 @@ QtObject {
         chatCommunitySectionModule.requestToJoinCommunity(id, ensName)
     }
 
+    function requestToJoinCommunityWithAuthentication(id, ensName) {
+        chatCommunitySectionModule.requestToJoinCommunityWithAuthentication(id, ensName)
+    }
+
     function userCanJoin(id) {
         return communitiesModuleInst.userCanJoin(id)
     }


### PR DESCRIPTION

There's a bug that all requests to join a community require the user to
authenticate themselves. This should only be needed for community that
are token permissioned.

This commit fixes it by only performing auth when requesting from the
tokengated community view.

Fixes #10010

