### PR TITLE
fix(Albums): Fix extra count of messages for image albums

### DIFF
--- a/src/app/modules/shared_models/message_model.nim
+++ b/src/app/modules/shared_models/message_model.nim
@@ -319,9 +319,15 @@ QtObject:
     if messageId.len == 0:
       return
     for i in 0 ..< self.items.len:
-      if(self.items[i].id == messageId):
+      let item = self.items[i]
+      if(item.id == messageId):
         result = i
         return
+      elif item.albumId != "":
+        for j in 0 ..< item.albumMessageIds.len:
+          if(item.albumMessageIds[j] == messageId):
+            result = i
+            return
 
   proc findIdsOfTheMessagesWhichRespondedToMessageWithId*(self: Model, messageId: string): seq[string] =
     for i in 0 ..< self.items.len:


### PR DESCRIPTION
Fixes: #9958

[status-go pr](https://github.com/status-im/status-go/pull/3345)

### What does the PR do

Skip extra count of new messages for image albums

### Affected areas

Chat

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

![Снимок экрана 2023-03-24 в 20 41 36](https://user-images.githubusercontent.com/82511785/227600589-84ce5f5f-7aec-42f8-8d5c-b18814d25654.png)

