### PR TITLE
fix(ActivitiCenterTooltip): Position tooltip arrow in the middle of the button

### DIFF
--- a/ui/StatusQ/src/StatusQ/Controls/StatusActivityCenterButton.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusActivityCenterButton.qml
@@ -45,6 +45,7 @@ StatusFlatRoundButton {
     tooltip.text: qsTr("Notifications")
     tooltip.orientation: StatusToolTip.Orientation.Bottom
     tooltip.y: parent.height + 12
+    tooltip.offset: -(tooltip.x + tooltip.width/2 - root.width/2) //position arrow center in root center
 
     StatusBadge {
         id: statusBadge

--- a/ui/app/AppLayouts/Chat/views/ChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatView.qml
@@ -59,7 +59,6 @@ StatusSectionLayout {
         }
     }
 
-    notificationButton.tooltip.offset: localAccountSensitiveSettings.expandUsersList && headerContent.membersButton.visible ? 0 : 14
     onNotificationButtonClicked: Global.openActivityCenterPopup()
     notificationCount: activityCenterStore.unreadNotificationsCount
     hasUnseenNotifications: activityCenterStore.hasUnseenNotifications


### PR DESCRIPTION
### What does the PR do
Fixing #9615

Position tooltip arrow in the middle of the button
<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas
App toolbar
<!-- List the affected areas (e.g wallet, browser, etc..) -->

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [x] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

<!-- screenshot (or gif/video) that demonstrates the functionality, specially important if it's a bug fix. -->

<img width="1492" alt="Screenshot 2023-03-27 at 12 45 02" src="https://user-images.githubusercontent.com/47811206/227905672-3af9357a-77e6-4f23-a765-103df0190d79.png">
