### PR TITLE
fix(permissions): check ownership of collectibles in permissions view

### DIFF
--- a/src/app/modules/main/chat_section/io_interface.nim
+++ b/src/app/modules/main/chat_section/io_interface.nim
@@ -393,3 +393,6 @@ method onDeactivateChatLoader*(self: AccessInterface, chatId: string) =
 
 method requestToJoinCommunityWithAuthentication*(self: AccessInterface, communityId: string, ensName: string) =
   raise newException(ValueError, "No implementation available")
+
+method onOwnedcollectiblesUpdated*(self: AccessInterface) =
+  raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/controller.nim
+++ b/src/app/modules/main/controller.nim
@@ -21,6 +21,7 @@ import ../../../app_service/service/community_tokens/service as community_tokens
 import ../../../app_service/service/wallet_account/service as wallet_account_service
 import ../../../app_service/service/token/service as token_service
 import ../../../app_service/service/network/service as networks_service
+import ../../../app_service/service/collectible/service as collectible_service
 
 import ../shared_models/section_item, io_interface
 import ../shared_modules/keycard_popup/io_interface as keycard_shared_module
@@ -52,6 +53,7 @@ type
     walletAccountService: wallet_account_service.Service
     tokenService: token_service.Service
     networksService: networks_service.Service
+    collectibleService: collectible_service.Service
 
 # Forward declaration
 proc setActiveSection*(self: Controller, sectionId: string, skipSavingInSettings: bool = false)
@@ -72,7 +74,8 @@ proc newController*(delegate: io_interface.AccessInterface,
   communityTokensService: community_tokens_service.Service,
   walletAccountService: wallet_account_service.Service,
   tokenService: token_service.Service,
-  networksService: networks_service.Service
+  networksService: networks_service.Service,
+  collectibleService: collectible_service.Service
 ):
   Controller =
   result = Controller()
@@ -93,6 +96,7 @@ proc newController*(delegate: io_interface.AccessInterface,
   result.walletAccountService = walletAccountService
   result.tokenService = tokenService
   result.networksService = networksService
+  result.collectibleService = collectibleService
 
 proc delete*(self: Controller) =
   discard
@@ -117,6 +121,7 @@ proc init*(self: Controller) =
       self.mailserversService,
       self.walletAccountService,
       self.tokenService,
+      self.collectibleService,
       self.communityTokensService
     )
 
@@ -133,6 +138,7 @@ proc init*(self: Controller) =
       self.mailserversService,
       self.walletAccountService,
       self.tokenService,
+      self.collectibleService,
       self.communityTokensService
     )
 
@@ -168,6 +174,7 @@ proc init*(self: Controller) =
       self.mailserversService,
       self.walletAccountService,
       self.tokenService,
+      self.collectibleService,
       self.communityTokensService,
       setActive = args.fromUserAction
     )
@@ -187,6 +194,7 @@ proc init*(self: Controller) =
       self.mailserversService,
       self.walletAccountService,
       self.tokenService,
+      self.collectibleService,
       self.communityTokensService,
       setActive = args.fromUserAction
     )
@@ -210,6 +218,7 @@ proc init*(self: Controller) =
       self.mailserversService,
       self.walletAccountService,
       self.tokenService,
+      self.collectibleService,
       self.communityTokensService,
       setActive = true
     )
@@ -231,6 +240,7 @@ proc init*(self: Controller) =
       self.mailserversService,
       self.walletAccountService,
       self.tokenService,
+      self.collectibleService,
       self.communityTokensService,
       setActive = false
     )

--- a/src/app/modules/main/io_interface.nim
+++ b/src/app/modules/main/io_interface.nim
@@ -11,6 +11,7 @@ import ../../../app_service/service/mailservers/service as mailservers_service
 import ../../../app_service/service/community_tokens/service as community_token_service
 import ../../../app_service/service/wallet_account/service as wallet_account_service
 import ../../../app_service/service/token/service as token_service
+import ../../../app_service/service/collectible/service as collectible_service
 import ../../../app_service/service/community_tokens/service as community_tokens_service
 from ../../../app_service/common/types import StatusType
 
@@ -89,6 +90,7 @@ method onChannelGroupsLoaded*(
   mailserversService: mailservers_service.Service,
   walletAccountService: wallet_account_service.Service,
   tokenService: token_service.Service,
+  collectibleService: collectible_service.Service,
   communityTokensService: community_tokens_service.Service)
   {.base.} =
   raise newException(ValueError, "No implementation available")
@@ -106,6 +108,7 @@ method onCommunityDataLoaded*(
   mailserversService: mailservers_service.Service,
   walletAccountService: wallet_account_service.Service,
   tokenService: token_service.Service,
+  collectibleService: collectible_service.Service,
   communityTokensService: community_tokens_service.Service)
   {.base.} =
   raise newException(ValueError, "No implementation available")
@@ -153,6 +156,7 @@ method communityJoined*(self: AccessInterface, community: CommunityDto, events: 
   mailserversService: mailservers_service.Service,
   walletAccountService: wallet_account_service.Service,
   tokenService: token_service.Service,
+  collectibleService: collectible_service.Service,
   communityTokensService: community_tokens_service.Service,
   setActive: bool = false,) {.base.} =
   raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -169,7 +169,8 @@ proc newModule*[T](
     communityTokensService,
     walletAccountService,
     tokenService,
-    networkService
+    networkService,
+    collectibleService
   )
   result.moduleLoaded = false
   result.chatsLoaded = false
@@ -546,6 +547,7 @@ method onChannelGroupsLoaded*[T](
   mailserversService: mailservers_service.Service,
   walletAccountService: wallet_account_service.Service,
   tokenService: token_service.Service,
+  collectibleService: collectible_service.Service,
   communityTokensService: community_tokens_service.Service
 ) =
   self.chatsLoaded = true
@@ -572,6 +574,7 @@ method onChannelGroupsLoaded*[T](
       mailserversService,
       walletAccountService,
       tokenService,
+      collectibleService,
       communityTokensService
     )
     let channelGroupItem = self.createChannelGroupItem(channelGroup)
@@ -604,6 +607,7 @@ method onCommunityDataLoaded*[T](
   mailserversService: mailservers_service.Service,
   walletAccountService: wallet_account_service.Service,
   tokenService: token_service.Service,
+  collectibleService: collectible_service.Service,
   communityTokensService: community_tokens_service.Service
 ) =
   self.communityDataLoaded = true
@@ -623,6 +627,7 @@ method onCommunityDataLoaded*[T](
     mailserversService,
     walletAccountService,
     tokenService,
+    collectibleService,
     communityTokensService
   )
 
@@ -848,6 +853,7 @@ method communityJoined*[T](
   mailserversService: mailservers_service.Service,
   walletAccountService: wallet_account_service.Service,
   tokenService: token_service.Service,
+  collectibleService: collectible_service.Service,
   communityTokensService: community_tokens_service.Service,
   setActive: bool = false,
 ) =
@@ -869,6 +875,7 @@ method communityJoined*[T](
       mailserversService,
       walletAccountService,
       tokenService,
+      collectibleService,
       communityTokensService
     )
   let channelGroup = community.toChannelGroupDto()

--- a/src/app_service/service/community/dto/community.nim
+++ b/src/app_service/service/community/dto/community.nim
@@ -202,7 +202,7 @@ proc toTokenCriteriaDto*(jsonObj: JsonNode): TokenCriteriaDto =
       result.`type` = TokenType(typeInt)
 
   var contractAddressesObj: JsonNode
-  if(jsonObj.getProp("contractAddresses", contractAddressesObj) and contractAddressesObj.kind == JObject):
+  if(jsonObj.getProp("contract_addresses", contractAddressesObj) and contractAddressesObj.kind == JObject):
     result.contractAddresses = initTable[int, string]()
     for chainId, contractAddress in contractAddressesObj:
       result.contractAddresses[parseInt(chainId)] = contractAddress.getStr


### PR DESCRIPTION
Marks collectible token criteria items in JoinCommunityView as we owned if the account owns wallets that match the criteria
![Screenshot from 2023-03-28 12-43-22](https://user-images.githubusercontent.com/445106/228222515-0e2fa1d8-1d69-46cb-a9f5-2d7111fba00a.png)

Ideally, this PR lands first: https://github.com/status-im/status-go/pull/3348