### PR TITLE
fix(unread): fix badge disappearing because of wrong calculation

### DIFF
--- a/src/app/modules/main/chat_section/io_interface.nim
+++ b/src/app/modules/main/chat_section/io_interface.nim
@@ -86,7 +86,7 @@ method doesCatOrChatExist*(self: AccessInterface, chatId: string): bool {.base.}
 method doesTopLevelChatExist*(self: AccessInterface, chatId: string): bool {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method addChatIfDontExist*(self: AccessInterface,
+method addOrUpdateChat*(self: AccessInterface,
     chat: ChatDto,
     belongsToCommunity: bool,
     events: UniqueUUIDEventEmitter,

--- a/src/app/modules/main/chat_section/model.nim
+++ b/src/app/modules/main/chat_section/model.nim
@@ -444,6 +444,13 @@ QtObject:
     let modelIndex = self.createIndex(index, 0, nil)
     self.dataChanged(modelIndex, modelIndex, @[ModelRole.HasUnreadMessages.int, ModelRole.NotificationsCount.int])
 
+  proc incrementNotificationsForItemByIdAndGetNotificationCount*(self: Model, id: string): int =
+    let index = self.getItemIdxById(id)
+    if index == -1:
+      return 0
+    self.updateNotificationsForItemById(id, hasUnreadMessages = true, self.items[index].notificationsCount + 1)
+    return self.items[index].notificationsCount
+
   proc updateLastMessageTimestampOnItemById*(self: Model, id: string, lastMessageTimestamp: int) =
     let index = self.getItemIdxById(id)
     if index == -1:
@@ -453,13 +460,6 @@ QtObject:
     self.items[index].lastMessageTimestamp = lastMessageTimestamp
     let modelIndex = self.createIndex(index, 0, nil)
     self.dataChanged(modelIndex, modelIndex, @[ModelRole.LastMessageTimestamp.int])
-
-  proc getAllNotifications*(self: Model): tuple[hasNotifications: bool, notificationsCount: int] =
-    result.hasNotifications = false
-    result.notificationsCount = 0
-    for i in 0 ..< self.items.len:
-      result.hasNotifications = result.hasNotifications or self.items[i].hasUnreadMessages
-      result.notificationsCount = result.notificationsCount + self.items[i].notificationsCount
 
   proc reorderChatById*(
       self: Model,

--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -67,7 +67,7 @@ proc buildChatSectionUI(self: Module,
   gifService: gif_service.Service,
   mailserversService: mailservers_service.Service)
 
-proc addChatIfDontExist(self: Module,
+proc addOrUpdateChat(self: Module,
     chat: ChatDto,
     channelGroup: ChannelGroupDto,
     belongsToCommunity: bool,
@@ -219,7 +219,7 @@ proc buildChatSectionUI(
           categoryPosition = category.position
           break
 
-    self.addChatIfDontExist(
+    self.addOrUpdateChat(
       chatDto,
       channelGroup,
       belongsToCommunity = chatDto.communityId.len > 0,
@@ -467,12 +467,18 @@ method getChatContentModule*(self: Module, chatId: string): QVariant =
 
   return self.chatContentModules[chatId].getModuleAsVariant()
 
-proc updateParentBadgeNotifications(self: Module, sectionHasUnreadMessagesArg: bool = false, unviewedMentionsCountArg: int = 0) =
+proc updateParentBadgeNotifications(self: Module) =
+  let (unviewedMessagesCount, unviewedMentionsCount) = self.controller.sectionUnreadMessagesAndMentionsCount(
+    self.controller.getMySectionId()
+  )
   self.delegate.onNotificationsUpdated(
     self.controller.getMySectionId(),
-    sectionHasUnreadMessagesArg,
-    unviewedMentionsCountArg
+    unviewedMessagesCount > 0,
+    unviewedMentionsCount
   )
+
+proc incrementParentBadgeNotifications(self: Module) =
+  self.delegate.onNotificationsIncremented(self.controller.getMySectionId())
 
 proc updateBadgeNotifications(self: Module, chatId: string, hasUnreadMessages: bool, unviewedMentionsCount: int) =
   # update model of this module (appropriate chat from the chats list (chats model))
@@ -481,7 +487,16 @@ proc updateBadgeNotifications(self: Module, chatId: string, hasUnreadMessages: b
   if (self.chatContentModules.contains(chatId)):
     self.chatContentModules[chatId].onNotificationsUpdated(hasUnreadMessages, unviewedMentionsCount)
   # update parent module
-  self.updateParentBadgeNotifications(hasUnreadMessages, unviewedMentionsCount)
+  self.updateParentBadgeNotifications()
+
+proc incrementBadgeNotifications(self: Module, chatId: string) =
+  if self.chatsLoaded:
+    let notificationCount = self.view.chatsModel().incrementNotificationsForItemByIdAndGetNotificationCount(chatId)
+    # update child module
+    if (self.chatContentModules.contains(chatId)):
+      self.chatContentModules[chatId].onNotificationsUpdated(hasUnreadMessages = true, notificationCount)
+  # update parent module
+  self.incrementParentBadgeNotifications()
 
 method updateLastMessageTimestamp*(self: Module, chatId: string, lastMessageTimestamp: int) =
   self.view.chatsModel().updateLastMessageTimestampOnItemById(chatId, lastMessageTimestamp)
@@ -845,8 +860,6 @@ method onContactAdded*(self: Module, publicKey: string) =
   if (contact.isContact):
     self.switchToOrCreateOneToOneChat(publicKey)
 
-  self.updateParentBadgeNotifications()
-
 method acceptAllContactRequests*(self: Module) =
   let pubKeys = self.view.contactRequestsModel().getItemIds()
   for pk in pubKeys:
@@ -857,7 +870,6 @@ method dismissContactRequest*(self: Module, publicKey: string) =
 
 method onContactRejected*(self: Module, publicKey: string) =
   self.view.contactRequestsModel().removeItemById(publicKey)
-  self.updateParentBadgeNotifications()
 
 method dismissAllContactRequests*(self: Module) =
   let pubKeys = self.view.contactRequestsModel().getItemIds()
@@ -870,7 +882,6 @@ method blockContact*(self: Module, publicKey: string) =
 method onContactBlocked*(self: Module, publicKey: string) =
   self.view.contactRequestsModel().removeItemById(publicKey)
   self.view.chatsModel().changeBlockedOnItemById(publicKey, blocked=true)
-  self.updateParentBadgeNotifications()
 
 method onContactUnblocked*(self: Module, publicKey: string) =
   self.view.chatsModel().changeBlockedOnItemById(publicKey, blocked=false)
@@ -886,7 +897,6 @@ method onContactDetailsUpdated*(self: Module, publicKey: string) =
     not self.view.contactRequestsModel().isContactWithIdAdded(publicKey)):
       let item = self.createItemFromPublicKey(publicKey)
       self.view.contactRequestsModel().addItem(item)
-      self.updateParentBadgeNotifications()
       singletonInstance.globalEvents.showNewContactRequestNotification("New Contact Request",
       fmt "{contactDetails.defaultDisplayName} added you as contact",
         singletonInstance.userProfile.getPubKey())
@@ -908,10 +918,6 @@ method onNewMessagesReceived*(self: Module, sectionIdMsgBelongsTo: string, chatI
     return
 
   let chatDetails = self.controller.getChatDetails(chatIdMsgBelongsTo)
-
-  # Badge notification
-  let showBadge = (not chatDetails.muted and unviewedMessagesCount > 0) or unviewedMentionsCount > 0
-  self.updateBadgeNotifications(chatIdMsgBelongsTo, showBadge, unviewedMentionsCount)
 
   if (chatDetails.muted):
     # No need to send a notification
@@ -960,8 +966,8 @@ method onMeMentionedInEditedMessage*(self: Module, chatId: string, editedMessage
     (editedMessage.communityId.len > 0 and
     self.controller.getMySectionId() != editedMessage.communityId)):
     return
-  var (sectionHasUnreadMessages, sectionNotificationCount) = self.view.chatsModel().getAllNotifications()
-  self.updateBadgeNotifications(chatId, sectionHasUnreadMessages, sectionNotificationCount + 1)
+
+  self.incrementBadgeNotifications(chatId)
 
 method addGroupMembers*(self: Module, chatId: string, pubKeys: string) =
   self.controller.addGroupMembers(chatId, self.convertPubKeysToJson(pubKeys))
@@ -1112,7 +1118,7 @@ method reorderCommunityChat*(self: Module, categoryId: string, chatId: string, p
 method setLoadingHistoryMessagesInProgress*(self: Module, isLoading: bool) =
   self.view.setLoadingHistoryMessagesInProgress(isLoading)
 
-proc addChatIfDontExist(self: Module,
+proc addOrUpdateChat(self: Module,
     chat: ChatDto,
     channelGroup: ChannelGroupDto,
     belongsToCommunity: bool,
@@ -1126,15 +1132,25 @@ proc addChatIfDontExist(self: Module,
     gifService: gif_service.Service,
     mailserversService: mailservers_service.Service,
     setChatAsActive: bool = true) =
-  if not self.chatsLoaded:
-    return
 
   let sectionId = self.controller.getMySectionId()
   if(belongsToCommunity and sectionId != chat.communityId or
     not belongsToCommunity and sectionId != singletonInstance.userProfile.getPubKey()):
     return
 
-  if self.doesCatOrChatExist(chat.id):
+  let chatExists = self.doesCatOrChatExist(chat.id)
+
+  if not self.chatsLoaded or chatExists:
+    # Update badges
+    var hasUnreadMessages = false
+    if not chat.muted:
+      hasUnreadMessages = chat.unviewedMessagesCount > 0
+    self.updateBadgeNotifications(chat.id, hasUnreadMessages, chat.unviewedMentionsCount)
+
+  if not self.chatsLoaded:
+    return
+
+  if chatExists:
     if (chat.chatType == ChatType.PrivateGroupChat):
       self.onGroupChatDetailsUpdated(chat.id, chat.name, chat.color, chat.icon)
     elif (chat.chatType != ChatType.OneToOne):
@@ -1157,7 +1173,7 @@ proc addChatIfDontExist(self: Module,
       setChatAsActive,
     )
 
-method addChatIfDontExist*(self: Module,
+method addOrUpdateChat*(self: Module,
     chat: ChatDto,
     belongsToCommunity: bool,
     events: UniqueUUIDEventEmitter,
@@ -1170,7 +1186,7 @@ method addChatIfDontExist*(self: Module,
     gifService: gif_service.Service,
     mailserversService: mailservers_service.Service,
     setChatAsActive: bool = true) =
- self.addChatIfDontExist(
+ self.addOrUpdateChat(
     chat,
     ChannelGroupDto(),
     belongsToCommunity,

--- a/src/app/modules/main/io_interface.nim
+++ b/src/app/modules/main/io_interface.nim
@@ -120,6 +120,9 @@ method onNotificationsUpdated*(self: AccessInterface, sectionId: string, section
   sectionNotificationCount: int) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method onNotificationsIncremented*(self: AccessInterface, sectionId: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method onNotificationsIncreased*(self: AccessInterface, sectionId: string, addedSectionNotificationCount: bool,
   sectionNotificationCount: int) {.base.} =
   raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -822,6 +822,9 @@ method onNotificationsUpdated[T](self: Module[T], sectionId: string, sectionHasU
     sectionNotificationCount: int) =
   self.view.model().updateNotifications(sectionId, sectionHasUnreadMessages, sectionNotificationCount)
 
+method onNotificationsIncremented[T](self: Module[T], sectionId: string) =
+  self.view.model().incrementNotifications(sectionId)
+
 method onNetworkConnected[T](self: Module[T]) =
   self.view.setConnected(true)
 

--- a/src/app_service/service/chat/service.nim
+++ b/src/app_service/service/chat/service.nim
@@ -277,7 +277,6 @@ QtObject:
       i.inc()
     return -1
       
-
   proc chatsWithCategoryHaveUnreadMessages*(self: Service, communityId: string, categoryId: string): bool =
     if communityId == "" or categoryId == "":
       return false
@@ -286,6 +285,20 @@ QtObject:
       if chat.unviewedMessagesCount > 0 or chat.unviewedMentionsCount > 0:
         return true
     return false
+
+  proc sectionUnreadMessagesAndMentionsCount*(self: Service, communityId: string):
+      tuple[unviewedMessagesCount: int, unviewedMentionsCount: int] =
+    if communityId == "":
+      return
+
+    result.unviewedMentionsCount = 0
+    result.unviewedMessagesCount = 0
+    for chat in self.channelGroups[communityId].chats:
+      result.unviewedMentionsCount += chat.unviewedMentionsCount
+      if chat.muted:
+        continue
+      if chat.unviewedMessagesCount > 0:
+        result.unviewedMessagesCount = result.unviewedMessagesCount + chat.unviewedMessagesCount
 
   proc updateOrAddChat*(self: Service, chat: ChatDto) =
     # status-go doesn't seem to preserve categoryIDs from chat

--- a/src/app_service/service/community/service.nim
+++ b/src/app_service/service/community/service.nim
@@ -727,7 +727,7 @@ QtObject:
     ## Returns all chats belonging to the community with passed `communityId`, sorted by position.
     ## Returned chats are sorted by position following set `order` parameter.
     if(not self.communities.contains(communityId)):
-      error "trying to get all community chats for an unexisting community id"
+      error "trying to get all community chats for an unexisting community id", communityId
       return
 
     result = self.communities[communityId].chats

--- a/src/app_service/service/message/async_tasks.nim
+++ b/src/app_service/service/message/async_tasks.nim
@@ -110,11 +110,10 @@ type
 const asyncMarkAllMessagesReadTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AsyncMarkAllMessagesReadTaskArg](argEncoded)
 
-  discard status_go.markAllMessagesFromChatWithIdAsRead(arg.chatId)
-
+  let response =  status_go.markAllMessagesFromChatWithIdAsRead(arg.chatId)
   let responseJson = %*{
     "chatId": arg.chatId,
-    "error": ""
+    "error": response.error
   }
   arg.finish(responseJson)
 #################################################


### PR DESCRIPTION
Fixes #10058

We were calling `updateParentBadgeNotifications` with wrong values, so we basically removed the badge all the time by accident.

Now, we calculate the unread messages and messages from the service's cache. 

Also, we still called `updateParentBadgeNotifications` when a contact is updated, as if the contact requests still went in the old contact request popup.

