### PR TITLE
Fix backup seed phrase test

### DIFF
--- a/test/ui-test/src/drivers/SquishDriver.py
+++ b/test/ui-test/src/drivers/SquishDriver.py
@@ -128,13 +128,8 @@ def hover_and_click_object_by_name(objName: str):
     squish.mouseClick(obj, squish.Qt.LeftButton)
 
 # It executes the left-click action into object with given object name:
-# If timeout is 0, it will use the default timeout (testSettings.waitForObjectTimeout)
-def click_obj_by_name(objName: str, timeout: int=0):
-    if timeout > 0:
-        obj = squish.waitForObject(getattr(names, objName), timeout)
-    else:
-        obj = squish.waitForObject(getattr(names, objName))
-    squish.mouseClick(obj, squish.Qt.LeftButton)
+def click_obj_by_name(objName: str, timeout: int = squish.testSettings.waitForObjectTimeout):
+    squish.mouseClick(squish.waitForObject(getattr(names, objName), timeout), squish.Qt.LeftButton)
 
 # It executes the click action into the given object at particular coordinates:
 def click_obj_by_name_at_coordinates(objName: str, x: int, y: int):

--- a/test/ui-test/src/screens/SettingsScreen.py
+++ b/test/ui-test/src/screens/SettingsScreen.py
@@ -129,6 +129,7 @@ class BackupSeedPhrasePopup(Enum):
     CONFIRM_SECOND_WORD_INPUT: str = "backup_seed_phrase_popup_BackupSeedStepBase_confirmSecondWord_inputText"
     CONFIRM_YOU_STORED_CHECKBOX: str = "backup_seed_phrase_popup_ConfirmStoringSeedPhrasePanel_storeCheck"
     CONFIRM_YOU_STORED_BUTTON: str = "backup_seed_phrase_popup_BackupSeedModal_completeAndDeleteSeedPhraseButton"
+    STEP_TITLE: str = "backup_seed_phrase_popup_step_StyledText"
 
 
 class SettingsScreen:
@@ -398,7 +399,7 @@ class SettingsScreen:
         obj = wait_and_get_obj(BackupSeedPhrasePopup.STORE_IT_CHECKBOX.value)
         obj.checked = True
         click_obj_by_name(BackupSeedPhrasePopup.NEXT_BUTTON.value)
-
+        assert wait_for_text_matching(BackupSeedPhrasePopup.STEP_TITLE.value, 'Step 1 of 4'), 'Step Title not found'        
         # Show seed phrase
         click_obj_by_name(BackupSeedPhrasePopup.REVEAL_SEED_PHRASE_BUTTON.value)
 

--- a/test/ui-test/testSuites/global_shared/scripts/settings_names.py
+++ b/test/ui-test/testSuites/global_shared/scripts/settings_names.py
@@ -1,3 +1,4 @@
+from objectmaphelper import *
 from scripts.global_names import *
 from enum import Enum
 
@@ -150,6 +151,7 @@ backup_seed_phrase_popup_BackupSeedStepBase_confirmSecondWord = {"container": st
 backup_seed_phrase_popup_BackupSeedStepBase_confirmSecondWord_inputText = {"container": backup_seed_phrase_popup_BackupSeedStepBase_confirmSecondWord, "objectName": "BackupSeedStepBase_inputText", "type": "TextEdit", "visible": True}
 backup_seed_phrase_popup_ConfirmStoringSeedPhrasePanel_storeCheck = {"container": statusDesktop_mainWindow_overlay, "objectName": "ConfirmStoringSeedPhrasePanel_storeCheck", "type": "StatusCheckBox", "checkable": True, "visible": True}
 backup_seed_phrase_popup_BackupSeedModal_completeAndDeleteSeedPhraseButton = {"container": statusDesktop_mainWindow_overlay, "objectName": "BackupSeedModal_completeAndDeleteSeedPhraseButton", "type": "StatusButton", "visible": True}
+backup_seed_phrase_popup_step_StyledText = {"container": statusDesktop_mainWindow_overlay, "type": "StyledText", "unnamed": 1, "visible": True}
 
 # User Status Profile Menu
 userContextmenu_AlwaysActiveButton= {"container": statusDesktop_mainWindow_overlay, "objectName": "userStatusMenuAlwaysOnlineAction", "type": "StatusMenuItem", "visible": True}

--- a/test/ui-test/testSuites/suite_settings/tst_mainSettingsSection/test.feature
+++ b/test/ui-test/testSuites/suite_settings/tst_mainSettingsSection/test.feature
@@ -12,8 +12,6 @@ Feature: Status Desktop Main Settings Section
 
 	# TODO: It must be reformulated or extracted to a different feature file bc preconditions of this feature file also include closing the backup seed phrase indicator at first instance
 	# so the validation is not providing relevant information
-	# TODO: It is also unstable. Needs to be checked.
-    @mayfail
     Scenario: The user can backup seed phrase
         Given the user opens the wallet settings
         When the user backs up the wallet seed phrase


### PR DESCRIPTION
### What does the PR do

- Added additional waiting for a UI element, before clicking on REVEAL_SEED_PHRASE_BUTTON
- Removed If/else from click_obj_by_name (minor improvement)

### Affected areas
- Scenario: The user can backup seed phrase
- All clicks on element in tests

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature) 
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [V] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

- [ ] I've checked the design and this PR matches it

<!-- screenshot (or gif/video) that demonstrates the functionality, specially important if it's a bug fix. -->

### Cool Spaceship Picture

<!-- optional but cool ->

! Test PR, any comments please how to improve?
! If the master is stable I will rebase it and change the target branch in PR
! The branch name also will be changed when the task created
! If it should be reviewed by the whole team, please assign you self.
