### PR TITLE
fix: StatusComboBox doesn't react on click outside indicator

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/StatusEmojiAndColorComboBox.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusEmojiAndColorComboBox.qml
@@ -38,13 +38,13 @@ StatusComboBox {
     id: root
 
     /*!
-       \qmlproperty string StatusEmojiAndColorComboBox::v
+       \qmlproperty string StatusEmojiAndColorComboBox::defaultAssetName
        This property holds the default asset shown if no emoji provided.
     */
     property string defaultAssetName: "info"
 
     /*!
-       \qmlproperty string StatusEmojiAndColorComboBox::v
+       \qmlproperty int StatusEmojiAndColorComboBox::delegateHeight
        This property holds the delegate height value.
     */
     property int delegateHeight: 44
@@ -59,12 +59,11 @@ StatusComboBox {
     control.textRole: "name"
 
     contentItem: CustomComboItem {
-        anchors.top: parent.top
-        anchors.left: parent.left
-        anchors.verticalCenter: parent.verticalCenter
+        anchors.fill: parent
         text: root.control.displayText
         emoji: d.emoji
         color: d.color
+        onClicked: control.popup.opened ? control.popup.close() : control.popup.open()
     }
 
     delegate: CustomComboItem {


### PR DESCRIPTION
Redirect the click event and let the CustomComboItem fill the whole `contentItem` (otherwise a Button over another Button eats all the mouse events)

Fixes: #9977

### What does the PR do

Fixes opening/closing the combo box

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

[Záznam obrazovky z 2023-03-29 01-44-47.webm](https://user-images.githubusercontent.com/5377645/228391145-812d6b7f-b7ba-482a-b39c-58d0eaaff986.webm)
