### PR TITLE
feat(SplashScreen): Display recommendation do not close the app on re-encryption process

### DIFF
--- a/src/app/modules/startup/controller.nim
+++ b/src/app/modules/startup/controller.nim
@@ -170,6 +170,10 @@ proc init*(self: Controller) =
     self.delegate.onLocalPairingStatusUpdate(args)
   self.connectionIds.add(handlerId)
 
+  handlerId = self.events.onWithUUID(SIGNAL_REENCRYPTION_PROCESS_STARTED) do(e: Args):
+    self.delegate.onReencryptionProcessStarted()
+  self.connectionIds.add(handlerId)
+
 proc shouldStartWithOnboardingScreen*(self: Controller): bool =
   return self.accountsService.openedAccounts().len == 0
 

--- a/src/app/modules/startup/io_interface.nim
+++ b/src/app/modules/startup/io_interface.nim
@@ -181,6 +181,9 @@ method validateLocalPairingConnectionString*(self: AccessInterface, connectionSt
 method onLocalPairingStatusUpdate*(self: AccessInterface, status: LocalPairingStatus) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method onReencryptionProcessStarted*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 # This way (using concepts) is used only for the modules managed by AppController
 type
   DelegateInterface* = concept c

--- a/src/app/modules/startup/module.nim
+++ b/src/app/modules/startup/module.nim
@@ -514,3 +514,6 @@ method validateLocalPairingConnectionString*[T](self: Module[T], connectionStrin
 
 method onLocalPairingStatusUpdate*[T](self: Module[T], status: LocalPairingStatus) =
   self.view.onLocalPairingStatusUpdate(status)
+
+method onReencryptionProcessStarted*[T](self: Module[T]) =
+  self.view.onReencryptionProcessStarted()

--- a/src/app/modules/startup/view.nim
+++ b/src/app/modules/startup/view.nim
@@ -16,6 +16,7 @@ type
     StartupState = 0
     AppLoadingState
     MainAppState
+    AppEncryptionProcessState
 
 QtObject:
   type
@@ -354,3 +355,6 @@ QtObject:
 
   proc validateLocalPairingConnectionString*(self: View, connectionString: string): string {.slot.} =
     return self.delegate.validateLocalPairingConnectionString(connectionString)
+
+  proc onReencryptionProcessStarted*(self: View) =
+    self.setAppState(AppState.AppEncryptionProcessState)

--- a/src/app_service/service/accounts/service.nim
+++ b/src/app_service/service/accounts/service.nim
@@ -36,6 +36,7 @@ let TEST_PEER_ENR = getEnv("TEST_PEER_ENR").string
 
 const SIGNAL_CONVERTING_PROFILE_KEYPAIR* = "convertingProfileKeypair"
 const SIGNAL_DERIVED_ADDRESSES_FROM_NOT_IMPORTED_MNEMONIC_FETCHED* = "derivedAddressesFromNotImportedMnemonicFetched"
+const SIGNAL_REENCRYPTION_PROCESS_STARTED* = "reencryptionProcessStarted"
 
 type ResultArgs* = ref object of Args
   success*: bool
@@ -669,6 +670,7 @@ QtObject:
 
       let isOldHashPassword = self.verifyDatabasePassword(account.keyUid, hashPassword(password, lower=false))
       if isOldHashPassword:
+        self.events.emit(SIGNAL_REENCRYPTION_PROCESS_STARTED, Args())
         discard status_privacy.lowerDatabasePassword(account.keyUid, password)
       
       let response = status_account.login(

--- a/ui/app/mainui/SplashScreen.qml
+++ b/ui/app/mainui/SplashScreen.qml
@@ -7,6 +7,7 @@ import utils 1.0
 import shared 1.0
 
 Item {
+    property alias text: loadingText.text
     ColumnLayout {
         anchors.centerIn: parent
         LoadingAnimation {
@@ -16,7 +17,9 @@ Item {
             source: Style.svg("status-logo-circle")
         }
         StatusBaseText {
+            id: loadingText
             Layout.alignment: Qt.AlignHCenter
+            horizontalAlignment: Qt.AlignHCenter
             text: qsTr("Loading Status...")
         }
     }

--- a/ui/imports/shared/panels/DidYouKnowSplashScreen.qml
+++ b/ui/imports/shared/panels/DidYouKnowSplashScreen.qml
@@ -14,6 +14,7 @@ import shared.panels.private 1.0
 Pane {
     id: root
     property alias progress: progressBar.value
+    property alias splashScreenText: splashScreen.text
 
     contentItem: Item {
             SplashScreen {

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -11,6 +11,7 @@ QtObject {
         readonly property int startup: 0
         readonly property int appLoading: 1
         readonly property int main: 2
+        readonly property int appEncryptionProcess: 3
     }
 
     readonly property QtObject startupFlow: QtObject {

--- a/ui/main.qml
+++ b/ui/main.qml
@@ -187,6 +187,11 @@ StatusWindow {
                 Style.changeTheme(localAppSettings.theme, systemPalette.isCurrentSystemThemeDark())
                 Style.changeFontSize(localAccountSensitiveSettings.fontSize)
                 Theme.updateFontSize(localAccountSensitiveSettings.fontSize)
+            } else if(state === Constansts.appState.appEncryptionProcess) {
+                loader.sourceComponent = undefined
+                appLoadingAnimation.active = true
+                appLoadingAnimation.item.splashScreenText = qsTr("Database re-encryption in progress. Please do NOT close the app.\nThis may take up to 30 minutes. Sorry for the inconvenience.\n\n This process is a one time thing and is necessary for the proper functioning of the application.")
+                startupOnboarding.visible = false
             }
         }
     }


### PR DESCRIPTION
Fixes: #10039

### What does the PR do

Adds the recommendation to not close the app

### Affected areas

Startup

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

<img width="1200" alt="Снимок экрана 2023-03-29 в 16 31 46" src="https://user-images.githubusercontent.com/82511785/228555169-a46c4076-dc77-4a6e-9236-2120f5fea568.png">
