### PR TITLE
fix(JoinCommunityView): Change Reveal Address button icon based on auth type

### DIFF
--- a/storybook/pages/JoinCommunityViewPage.qml
+++ b/storybook/pages/JoinCommunityViewPage.qml
@@ -41,6 +41,7 @@ Nemo enim 😋 ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit,
         property bool isInvitationPending: true
         property bool isJoinRequestRejected: false
         property bool requiresRequest: false
+        property int loginType: Constants.LoginType.Biometrics
 
         property var communityHoldingsModel: PermissionsModel.shortPermissionsModel
         property var viewOnlyHoldingsModel: PermissionsModel.shortPermissionsModel
@@ -116,6 +117,7 @@ Nemo enim 😋 ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit,
                 joinCommunity: d.joinCommunity
                 accessType: d.accessType
                 isInvitationPending: d.isInvitationPending
+                loginType: d.loginType
 
                 // Blur background properties:
                 membersCount: d.membersCount
@@ -279,6 +281,21 @@ Nemo enim 😋 ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit,
                     onViewOnlyHoldingsModelChanged: d.viewOnlyHoldingsModel = viewOnlyHoldingsModel
                     onViewAndPostHoldingsModelChanged: d.viewAndPostHoldingsModel = viewAndPostHoldingsModel
                     onModerateHoldingsModelChanged: d.moderateHoldingsModel = moderateHoldingsModel
+                }
+
+                ColumnLayout {
+                    Label {
+                        Layout.fillWidth: true
+                        text: "Login type"
+                    }
+
+                    ComboBox {
+                        id: loginTypeComboBox
+                        Layout.fillWidth: true
+                        model: ["Password","Biometrics","Keycard"]
+                        onActivated: d.loginType = currentIndex
+                        Component.onCompleted: currentIndex = d.loginType
+                    }
                 }
             }
         }

--- a/ui/app/AppLayouts/Chat/ChatLayout.qml
+++ b/ui/app/AppLayouts/Chat/ChatLayout.qml
@@ -72,6 +72,7 @@ StackLayout {
             notificationCount: activityCenterStore.unreadNotificationsCount
             hasUnseenNotifications: activityCenterStore.hasUnseenNotifications
             openCreateChat: rootStore.openCreateChat
+            loginType: root.rootStore.loginType
             onNotificationButtonClicked: Global.openActivityCenterPopup()
             onAdHocChatButtonClicked: rootStore.openCloseCreateChatView()
             onRevealAddressClicked: {

--- a/ui/app/AppLayouts/Chat/panels/communities/JoinPermissionsOverlayPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/JoinPermissionsOverlayPanel.qml
@@ -11,6 +11,7 @@ import AppLayouts.Chat.helpers 1.0
 import AppLayouts.Chat.controls.community 1.0
 
 import SortFilterProxyModel 0.2
+import utils 1.0
 
 
 Control {
@@ -28,6 +29,7 @@ Control {
     property var viewAndPostHoldingsModel
     property var moderateHoldingsModel
     property bool showOnlyPanels: false
+    property int loginType: Constants.LoginType.Password
 
     property var assetsModel
     property var collectiblesModel
@@ -57,6 +59,11 @@ Control {
 
         function getRevealAddressText() {
             return root.joinCommunity ? (root.requiresRequest ? d.communityRevealAddressWithRequestText : d.communityRevealAddressText) : d.channelRevealAddressText
+        }
+
+        function getRevealAddressIcon() {
+            if(root.loginType == Constants.LoginType.Password) return "password"
+            return root.loginType == Constants.LoginType.Biometrics ? "touch-id" : "keycard"
         }
     }
 
@@ -106,6 +113,7 @@ Control {
             Layout.alignment: Qt.AlignHCenter
             visible: !root.showOnlyPanels && !root.isJoinRequestRejected
             text: root.isInvitationPending ? d.getInvitationPendingText() : d.getRevealAddressText()
+            icon.name: root.isInvitationPending ? "" : d.getRevealAddressIcon()
             font.pixelSize: 13
             enabled: root.requirementsMet
             onClicked: root.isInvitationPending ? root.invitationPendingClicked() : root.revealAddressClicked()

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -234,6 +234,8 @@ QtObject {
 
     property bool isDebugEnabled: advancedModule ? advancedModule.isDebugEnabled : false
 
+    readonly property int loginType: getLoginType()
+
     property var stickersStore: StickersStore {
         stickersModule: stickersModuleInst
     }
@@ -654,6 +656,17 @@ QtObject {
 
     function hex2Eth(value) {
         return globalUtilsInst.hex2Eth(value)
+    }
+
+    function getLoginType() {
+        if(!userProfileInst)
+            return Constants.LoginType.Password
+
+        if(userProfileInst.usingBiometricLogin)
+            return Constants.LoginType.Biometrics
+        else if(userProfileInst.isKeycardUser)
+            return Constants.LoginType.Keycard
+        else return Constants.LoginType.Password
     }
 
     readonly property Connections communitiesModuleConnections: Connections {

--- a/ui/app/AppLayouts/Chat/views/communities/JoinCommunityView.qml
+++ b/ui/app/AppLayouts/Chat/views/communities/JoinCommunityView.qml
@@ -36,6 +36,7 @@ StatusSectionLayout {
     property bool requirementsMet: true
     property bool isJoinRequestRejected: false
     property bool requiresRequest: false
+    property alias loginType: overlayPannel.loginType
 
     property var communityHoldingsModel
     property var viewOnlyHoldingsModel

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -857,6 +857,12 @@ QtObject {
         NoError
     }
 
+    enum LoginType {
+        Password,
+        Biometrics,
+        Keycard
+    }
+
 
     readonly property QtObject walletSection: QtObject {
         readonly property string cancelledMessage: "cancelled"


### PR DESCRIPTION
### What does the PR do
Fixes: #9857 
1. Add login type enum
2. Pass the user login type from `JoinCommunityView` to `Reveal your address` button and configure the icon based on this value
<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas
JoinCommunityView
<!-- List the affected areas (e.g wallet, browser, etc..) -->


### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

<!-- screenshot (or gif/video) that demonstrates the functionality, specially important if it's a bug fix. -->

https://user-images.githubusercontent.com/47811206/228797764-e7956d42-7761-45b4-8caf-509976df2496.mov

KeyCard user using biometrics:

<img width="1526" alt="Screenshot 2023-03-30 at 12 43 00" src="https://user-images.githubusercontent.com/47811206/228797988-e0498089-2829-423f-8a64-0983158abc73.png">

Keycard user without biometrics:

<img width="1526" alt="Screenshot 2023-03-30 at 12 53 03" src="https://user-images.githubusercontent.com/47811206/228799353-d974f107-c654-4025-a47b-356ae0b09c84.png">
