### PR TITLE
fix(permissions): ensure permissions model is rebuilt when permission

### DIFF
--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -771,8 +771,7 @@ method onChatUnmuted*(self: Module, chatId: string) =
   self.view.chatsModel().changeMutedOnItemById(chatId, muted=false)
 
 method onCommunityTokenPermissionDeleted*(self: Module, communityId: string, permissionId: string) =
-  self.view.tokenPermissionsModel().removeItemWithId(permissionId)
-  self.view.setRequiresTokenPermissionToJoin(self.view.tokenPermissionsModel().getCount() > 0)
+  self.rebuildCommunityTokenPermissionsModel()
   singletonInstance.globalEvents.showCommunityTokenPermissionDeletedNotification(communityId, "Community permission deleted", "A token permission has been removed")
 
 method onCommunityTokenPermissionCreated*(self: Module, communityId: string, tokenPermission: CommunityTokenPermissionDto) =

--- a/src/app_service/service/community/service.nim
+++ b/src/app_service/service/community/service.nim
@@ -553,6 +553,7 @@ QtObject:
       elif community.tokenPermissions.len < prev_community.tokenPermissions.len:
         for id, prvTokenPermission in prev_community.tokenPermissions:
           if not community.tokenPermissions.hasKey(id):
+            self.communities[community.id].tokenPermissions.del(id)
             self.events.emit(SIGNAL_COMMUNITY_TOKEN_PERMISSION_DELETED,
             CommunityTokenPermissionRemovedArgs(communityId: community.id, permissionId: id))
 


### PR DESCRIPTION
was deleted

This is needed because there's cases where the deletion of a permission might cause the current user to no longer be eligible to join a community.

Community has the follwoing permissions:
- own 2 ETH and 1 FOO_NFT or
- own 1 FOO_NFT

User owns: 1 FOO_NFT

^ The above would make the user eligible to request access to join.

Now if the community removes the second permission, the user now no longer fulfills the requirements so we need to ensure the UI permits the user to request access.

Rebuilding the permissions model (including its token criteria) sets the necessary flags in the UI automatically.

