### PR TITLE
Fix `WakuConfig` enabled

### DIFF
--- a/src/app_service/common/network_constants.nim
+++ b/src/app_service/common/network_constants.nim
@@ -321,7 +321,6 @@ var NODE_CONFIG* = %* {
   "WakuConfig": {
     "Enabled": false,
     "BloomFilterMode": true,
-    "Enabled": true,
     "LightClient": true,
     "MinimumPoW": 0.001
   },


### PR DESCRIPTION
Required for https://github.com/status-im/status-desktop/pull/9981

### What does the PR do

This doesn't make any sense 🙂 
Waku2Config is default now, afaik.

![image](https://user-images.githubusercontent.com/25482501/228832924-5efc7b69-fc48-4833-898d-eea0e4560a69.png)

