### PR TITLE
fix(images): Wrap text in image message

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
@@ -275,15 +275,20 @@ Control {
                     Loader {
                         active: root.messageDetails.contentType === StatusMessage.ContentType.Image && !editMode
                         visible: active
+                        Layout.fillWidth: true
 
                         sourceComponent: Column {
                             id: imagesColumn
                             spacing: 8
                             Loader {
                                 active: root.messageDetails.messageText !== ""
+                                anchors.left: parent.left
+                                anchors.right: parent.right
                                 visible: active
                                 sourceComponent: StatusTextMessage {
                                     messageDetails: root.messageDetails
+                                    allowShowMore: !root.isInPinnedPopup
+                                    textField.anchors.rightMargin: root.isInPinnedPopup ? /*Style.current.xlPadding*/ 32 : 0 // margin for the "Unpin" floating button
                                     onLinkActivated: {
                                         root.linkActivated(link);
                                     }


### PR DESCRIPTION
Fixes: #10044

### What does the PR do

Fix text component sizes for image messages

### Affected areas

StatusMessage

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)


![Снимок экрана 2023-03-31 в 12 52 22](https://user-images.githubusercontent.com/82511785/229089100-8c5b71cf-8b39-4667-ae51-611f8e3c469e.png)
