### PR TITLE
fix(@desktop/wallet): fix scrolling transactions list reset to top when

### DIFF
--- a/src/app/modules/main/wallet_section/transactions/item.nim
+++ b/src/app/modules/main/wallet_section/transactions/item.nim
@@ -155,19 +155,6 @@ proc initNFTItem*(
   result.nftName = nftName
   result.nftImageUrl = nftImageUrl
 
-proc initTimestampItem*(timestamp: int): Item =
-  result.timestamp = timestamp
-  result.gasPrice = newCurrencyAmount()
-  result.value = newCurrencyAmount()
-  result.chainId = 0
-  result.maxFeePerGas = newCurrencyAmount()
-  result.maxPriorityFeePerGas = newCurrencyAmount()
-  result.multiTransactionID = 0
-  result.isTimeStamp = true
-  result.baseGasFees = newCurrencyAmount()
-  result.totalFees = newCurrencyAmount()
-  result.maxTotalFees = newCurrencyAmount()
-
 proc initLoadingItem*(): Item =
   result.timestamp = 0
   result.gasPrice = newCurrencyAmount()

--- a/src/app/modules/main/wallet_section/transactions/model.nim
+++ b/src/app/modules/main/wallet_section/transactions/model.nim
@@ -255,7 +255,6 @@ QtObject:
       self.countChanged()
 
   proc removePageSizeBuffer*(self: Model) =
-    var removed = false
     for i in 0 ..< self.items.len:
       if self.items[i].getLoadingTransaction():
         self.beginRemoveRows(newQModelIndex(), i, self.items.len-1)

--- a/src/app/modules/main/wallet_section/transactions/view.nim
+++ b/src/app/modules/main/wallet_section/transactions/view.nim
@@ -76,6 +76,7 @@ QtObject:
     if not self.models.hasKey(address):
       self.models[address] = newModel()
 
+    self.models[address].removePageSizeBuffer()
     self.models[address].addNewTransactions(transactions, wasFetchMore)
     if self.fetchingHistoryState.hasKey(address) and self.fetchingHistoryState[address] and wasFetchMore:
       self.models[address].addPageSizeBuffer(transactions.len)

--- a/ui/imports/shared/controls/TransactionDelegate.qml
+++ b/ui/imports/shared/controls/TransactionDelegate.qml
@@ -1,5 +1,6 @@
-import QtQuick 2.13
-import QtQuick.Layouts 1.3
+import QtQuick 2.15
+import QtQuick.Layouts 1.15
+import QtQml 2.15
 
 import StatusQ.Components 0.1
 import StatusQ.Core.Theme 0.1
@@ -35,22 +36,22 @@ StatusListItem {
     readonly property bool isNFT: isModelDataValid && modelData.isNFT
     readonly property string name: isModelDataValid ?
                                         root.isNFT ?
-                                            modelData.nftName ? 
-                                                modelData.nftName : 
+                                            modelData.nftName ?
+                                                modelData.nftName :
                                                 "#" + modelData.tokenID :
                                             root.isSummary ? root.symbol : RootStore.formatCurrencyAmount(cryptoValue, symbol) :
                                         "N/A"
 
     readonly property string image: isModelDataValid ?
                                         root.isNFT ?
-                                            modelData.nftImageUrl ? 
-                                                modelData.nftImageUrl : 
+                                            modelData.nftImageUrl ?
+                                                modelData.nftImageUrl :
                                                 "" :
                                             root.symbol ?
                                                 Style.png("tokens/%1".arg(root.symbol)) :
                                                 "" :
                                         ""
-    
+
     readonly property string toAddress: !!savedAddressNameTo ?
                                             savedAddressNameTo :
                                             isModelDataValid ?
@@ -67,7 +68,7 @@ StatusListItem {
     asset.name: root.image
     asset.isLetterIdenticon: loading
     title: root.isModelDataValid ?
-                isIncoming ? 
+                isIncoming ?
                     isSummary ?
                         qsTr("Receive %1").arg(root.name) :
                         qsTr("Received %1 from %2").arg(root.name).arg(root.fromAddress):
@@ -115,7 +116,12 @@ StatusListItem {
                 StatusTextWithLoadingState {
                     id: cryptoValueText
                     text: RootStore.formatCurrencyAmount(cryptoValue, root.symbol)
-                    color: Theme.palette.directColor1
+                    Binding on width {
+                        when: root.loading
+                        value: 111
+                        restoreMode: Binding.RestoreBindingOrValue
+                    }
+                    customColor: Theme.palette.directColor1
                     loading: root.loading
                 }
 


### PR DESCRIPTION
new ones are fetched.

Fixes #9776

### What does the PR do

Transaction model reset is replaced with rows insertion.
Moves sorting transactions to QML side.
Added displaced animation to avoid confusing jerking of the list view when fetched transactions are inserted in the middle of the list.
Tries to preserve the last visible transaction in view visible area to avoid user confusion.
Fix balance in loading state to use loading component instead of 0
Fix width of some components in delegates of activities ListView when in loading state.
Remove property modelDataValid in favor of existing isModelDataValid for TransactionDelegate
Fix loading items not always properly removed before adding new transactions.

This PR also fixes #9012 

### Affected areas
Wallet->Activities

### Screenshots
This fix is quite hard to properly test, because of a  [this issue](https://github.com/status-im/status-desktop/issues/9814) that needs fixing as well.

This video demonstrates the fix, when a number of fetched items is reduced to 3 and fetching transactions from networks is disabled, so that transactions are loaded from database only:

https://user-images.githubusercontent.com/15627093/228787762-90b77f5a-7d32-4fe0-9aa7-2a730f32af71.mp4

### Other notes
Once https://github.com/status-im/status-desktop/issues/10233 is implemented, we can remove some complicated logic of preserving the list view scrolling position and displaced animations