### PR TITLE
fix(edit): don't send new message event on edits

### DIFF
--- a/src/app_service/service/message/service.nim
+++ b/src/app_service/service/message/service.nim
@@ -248,18 +248,18 @@ QtObject:
           continue
 
         # Ignore messages older than current chat cursor
-        if(self.isChatCursorInitialized(chatId)):
+        if self.isChatCursorInitialized(chatId):
           let currentChatCursor = self.initOrGetMessageCursor(chatId)
           let msgCursorValue = initCursorValue(msg.id, msg.clock)
           if(not currentChatCursor.isLessThan(msgCursorValue)):
             currentChatCursor.makeObsolete()
             continue
 
-        if(msg.editedAt > 0):
+        if msg.editedAt > 0:
           let data = MessageEditedArgs(chatId: msg.localChatId, message: msg)
           self.events.emit(SIGNAL_MESSAGE_EDITED, data)
-
-        chatMessages.add(msg)
+        else:
+          chatMessages.add(msg)
 
       let data = MessagesArgs(
         sectionId: if chats[i].communityId.len != 0: chats[i].communityId else: singletonInstance.userProfile.getPubKey(),


### PR DESCRIPTION
Fixes #10108

We were sending SIGNAL_NEW_MESSAGE_RECEIVED and SIGNAL_MESSAGE_EDITED, but the former is not needed, because the message editing is all done with the latter. The new message signal was sending the OS notification, which is not wanted, plus it did some useless processing, like trying to re-edit the message model, when it was already done.

The badge does get updated anyway, but that seems like an issue in status-go. It was telling me I had 3 unread messages, and I'm not sure why.