### PR TITLE
feat(Mint Collectibles): Implement Remotely self-destruct footer option

### DIFF
--- a/storybook/PagesModel.qml
+++ b/storybook/PagesModel.qml
@@ -134,6 +134,10 @@ ListModel {
          section: "Popups"
     }
     ListElement {
+         title: "SelfDestructAlertPopup"
+         section: "Popups"
+    }
+    ListElement {
         title: "MembersSelector"
         section: "Components"
     }

--- a/storybook/PagesModel.qml
+++ b/storybook/PagesModel.qml
@@ -130,6 +130,10 @@ ListModel {
          section: "Popups"
     }
     ListElement {
+         title: "RemoteSelfDestructPopup"
+         section: "Popups"
+    }
+    ListElement {
         title: "MembersSelector"
         section: "Components"
     }

--- a/storybook/PagesModel.qml
+++ b/storybook/PagesModel.qml
@@ -98,6 +98,10 @@ ListModel {
          section: "Panels"
     }
     ListElement {
+         title: "TokenHoldersPanel"
+         section: "Panels"
+    }
+    ListElement {
         title: "InviteFriendsToCommunityPopup"
         section: "Popups"
     }

--- a/storybook/pages/RemoteSelfDestructPopupPage.qml
+++ b/storybook/pages/RemoteSelfDestructPopupPage.qml
@@ -1,0 +1,76 @@
+import QtQuick 2.14
+import QtQuick.Controls 2.14
+import QtQuick.Layouts 1.14
+
+import Storybook 1.0
+import Models 1.0
+
+import AppLayouts.Chat.popups.community 1.0
+
+SplitView {
+    Logs { id: logs }
+
+    SplitView {
+        orientation: Qt.Vertical
+        SplitView.fillWidth: true
+
+        Item {
+            SplitView.fillWidth: true
+            SplitView.fillHeight: true
+
+            PopupBackground {
+                anchors.fill: parent
+            }
+
+            Button {
+                anchors.centerIn: parent
+                text: "Reopen"
+
+                onClicked: dialog.open()
+            }
+
+            RemoteSelfDestructPopup {
+                id: dialog
+
+                anchors.centerIn: parent
+                collectibleName: editorCollectible.text
+                model: TokenHoldersModel {}
+
+                onSelfDestructClicked: logs.logEvent("RemoteSelfDestructPopup::onSelfDestructClicked")
+
+            }
+        }
+
+        LogsAndControlsPanel {
+            id: logsAndControlsPanel
+
+            SplitView.minimumHeight: 100
+            SplitView.preferredHeight: 150
+
+            logsView.logText: logs.logText
+        }
+    }
+
+    Pane {
+        SplitView.minimumWidth: 300
+        SplitView.preferredWidth: 300
+
+        ColumnLayout {
+
+            Label {
+                Layout.fillWidth: true
+                text: "Collectible name"
+            }
+
+            TextField {
+                id: editorCollectible
+                background: Rectangle { border.color: 'lightgrey' }
+                Layout.preferredWidth: 200
+                text: "Anniversary"
+            }
+
+        }
+    }
+}
+
+

--- a/storybook/pages/SelfDestructAlertPopupPage.qml
+++ b/storybook/pages/SelfDestructAlertPopupPage.qml
@@ -1,0 +1,60 @@
+import QtQuick 2.14
+import QtQuick.Controls 2.14
+import QtQuick.Layouts 1.14
+
+import Storybook 1.0
+import Models 1.0
+
+import AppLayouts.Chat.popups.community 1.0
+
+SplitView {
+    Logs { id: logs }
+
+    SplitView {
+        orientation: Qt.Vertical
+        SplitView.fillWidth: true
+
+        Item {
+            SplitView.fillWidth: true
+            SplitView.fillHeight: true
+
+            PopupBackground {
+                anchors.fill: parent
+            }
+
+            Button {
+                anchors.centerIn: parent
+                text: "Reopen"
+
+                onClicked: dialog.open()
+            }
+
+            SelfDestructAlertPopup {
+                id: dialog
+
+                anchors.centerIn: parent
+                tokenCount: 12
+
+                onSelfDestructClicked: logs.logEvent("SelfDestructAlertPopup::onSelfDestructClicked")
+                onCancelClicked: logs.logEvent("SelfDestructAlertPopup::onCancelClicked")
+
+            }
+        }
+
+        LogsAndControlsPanel {
+            id: logsAndControlsPanel
+
+            SplitView.minimumHeight: 100
+            SplitView.preferredHeight: 150
+
+            logsView.logText: logs.logText
+        }
+    }
+
+    Pane {
+        SplitView.minimumWidth: 300
+        SplitView.preferredWidth: 300
+    }
+}
+
+

--- a/storybook/pages/TokenHoldersPanelPage.qml
+++ b/storybook/pages/TokenHoldersPanelPage.qml
@@ -1,0 +1,48 @@
+import QtQuick 2.14
+import QtQuick.Controls 2.14
+
+import StatusQ.Core 0.1
+
+import mainui 1.0
+
+import AppLayouts.Chat.panels.communities 1.0
+
+import Storybook 1.0
+import Models 1.0
+
+SplitView {
+    id: root
+
+    Logs { id: logs }
+
+    orientation: Qt.Vertical
+
+    Item {
+        SplitView.fillWidth: true
+        SplitView.fillHeight: true
+
+        TokenHoldersPanel {
+            anchors.centerIn: parent
+            width: 568
+            tokenName: "Aniversary"
+            model: TokenHoldersModel {}
+            isSelectorMode: editorSelectorMode.checked
+        }
+    }
+
+    LogsAndControlsPanel {
+        id: logsAndControlsPanel
+
+        SplitView.minimumHeight: 100
+        SplitView.preferredHeight: 200
+
+        logsView.logText: logs.logText
+
+        CheckBox {
+            id: editorSelectorMode
+
+            text: "Is selector mode?"
+            checked: true
+        }
+    }
+}

--- a/storybook/src/Models/TokenHoldersModel.qml
+++ b/storybook/src/Models/TokenHoldersModel.qml
@@ -9,25 +9,34 @@ ListModel {
             ensName: "carmen.eth",
             walletAddress: "0xb794f5450ba39494ce839613fffba74279579268",
             imageSource: image,
-            amount: 3
+            amount: 15,
+            selfDestructAmount: 2,
+            selfDestruct: false
+
         },
         {
             ensName: "chris.eth",
             walletAddress: "0xb794f5ea0ba39494ce839613fffba74279579268",
             imageSource: image,
-            amount: 2
+            amount: 5,
+            selfDestructAmount: 4,
+            selfDestruct: false
         },
         {
             ensName: "emily.eth",
             walletAddress: "0xb794f5ea0ba39494ce839613fffba74279579268",
             imageSource: image,
-            amount: 2
+            amount: 2,
+            selfDestructAmount: 2,
+            selfDestruct: false
         },
         {
             ensName: "",
             walletAddress: "0xb794f5ea0ba39494ce839613fffba74279579268",
             imageSource: "",
-            amount: 1
+            amount: 1,
+            selfDestructAmount: 1,
+            selfDestruct: false
         }
     ]
 

--- a/ui/StatusQ/src/StatusQ/Controls/StatusItemDelegate.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusItemDelegate.qml
@@ -9,6 +9,8 @@ import StatusQ.Controls 0.1
 ItemDelegate {
     id: root
 
+    property alias textHorizontalAligment: textItem.horizontalAlignment
+
     padding: 8
     spacing: 8
 

--- a/ui/app/AppLayouts/Chat/panels/communities/MintTokensFooterPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/MintTokensFooterPanel.qml
@@ -48,6 +48,7 @@ Control {
                 id: retailButton
 
                 icon.name: "token-sale"
+                visible: false // TODO: Milestone 14
                 text: qsTr("Retail")
 
                 onClicked: root.retailClicked()
@@ -61,13 +62,14 @@ Control {
                 type: StatusBaseButton.Type.Danger
                 borderColor: "transparent"
 
-                onClicked: root.remoteSelfDestructClicked()
+                onClicked: root.remotelySelfDestructClicked()
             }
 
             StatusFlatButton {
                 id: burnButton
 
                 icon.name: "delete"
+                visible: false // Post MVP
                 text: qsTr("Burn")
                 type: StatusBaseButton.Type.Danger
                 borderColor: "transparent"

--- a/ui/app/AppLayouts/Chat/popups/community/RemoteSelfDestructPopup.qml
+++ b/ui/app/AppLayouts/Chat/popups/community/RemoteSelfDestructPopup.qml
@@ -1,0 +1,83 @@
+import QtQuick 2.14
+import QtQuick.Controls 2.14
+import QtQuick.Layouts 1.14
+import QtQml.Models 2.14
+
+import StatusQ.Core 0.1
+import StatusQ.Controls 0.1
+import StatusQ.Popups.Dialog 0.1
+import StatusQ.Core.Theme 0.1
+
+import AppLayouts.Chat.panels.communities 1.0
+
+import utils 1.0
+
+StatusDialog {
+    id: root
+
+    property alias model: tokenHoldersPanel.model
+
+    property string collectibleName
+
+    signal selfDestructClicked(int tokenCount)
+
+    QtObject {
+        id: d
+
+        readonly property int maxHeight: 560 // by design
+        property int tokenCount: 0
+
+        function getVerticalPadding() {
+            return root.topPadding + root.bottomPadding
+        }
+
+        function getHorizontalPadding() {
+            return root.leftPadding + root.rightPadding
+        }
+
+        function calculateTotalTokensToDestruct() {
+            tokenCount = 0
+            for(var i = 0; i < tokenHoldersPanel.model.count; i ++) {
+                var item = tokenHoldersPanel.model.get(i)
+                if(item.selfDestruct) {
+                    tokenCount += item.selfDestructAmount
+                }
+            }
+        }
+    }
+
+    title: qsTr("Remotely self-destruct %1 token").arg(root.collectibleName)
+    implicitWidth: 600 // by design
+    topPadding: Style.current.padding
+    bottomPadding: topPadding
+    implicitHeight: Math.min(tokenHoldersPanel.implicitHeight + d.getVerticalPadding() + root.header.height + root.footer.height, d.maxHeight)
+    contentItem: StatusScrollView {
+        id: scrollview
+
+        contentHeight: tokenHoldersPanel.implicitHeight
+        contentWidth: tokenHoldersPanel.implicitWidth
+        rightPadding: 20
+
+        TokenHoldersPanel {
+            id: tokenHoldersPanel
+
+            width: root.width - d.getHorizontalPadding() - scrollview.rightPadding
+            tokenName: root.collectibleName
+            isSelectorMode: true
+
+            onSelfDestructChanged: d.calculateTotalTokensToDestruct()
+        }
+    }
+
+    footer: StatusDialogFooter {
+        spacing: Style.current.padding
+        rightButtons: ObjectModel {
+            StatusButton {
+                enabled: d.tokenCount > 0
+                text: qsTr("Self-destruct %n token(s)", "", d.tokenCount)
+                type: StatusBaseButton.Type.Danger
+                onClicked: root.selfDestructClicked(d.tokenCount)
+            }
+        }
+    }
+}

--- a/ui/app/AppLayouts/Chat/popups/community/SelfDestructAlertPopup.qml
+++ b/ui/app/AppLayouts/Chat/popups/community/SelfDestructAlertPopup.qml
@@ -1,0 +1,59 @@
+import QtQuick 2.14
+import QtQuick.Controls 2.14
+import QtQuick.Layouts 1.14
+import QtQml.Models 2.14
+
+import StatusQ.Core 0.1
+import StatusQ.Controls 0.1
+import StatusQ.Popups.Dialog 0.1
+import StatusQ.Core.Theme 0.1
+
+import AppLayouts.Chat.panels.communities 1.0
+
+import utils 1.0
+
+StatusDialog {
+    id: root
+
+    property int tokenCount: 0
+
+    signal selfDestructClicked
+    signal cancelClicked
+
+    title: qsTr("Self-destruct %n token(s)", "", root.tokenCount)
+    implicitWidth: 400 // by design
+    topPadding: Style.current.padding
+    bottomPadding: topPadding
+    contentItem: StatusBaseText {
+        text: qsTr("Continuing will destroy tokens held by members and revoke any perissions they given. To undo you will have to issue them new tokens.")
+        font.pixelSize: Style.current.primaryTextFontSize
+        wrapMode: Text.WordWrap
+        lineHeight: 1.2
+    }
+
+    footer: StatusDialogFooter {
+        spacing: Style.current.padding
+        rightButtons: ObjectModel {
+
+            StatusButton {
+                text: qsTr("Cancel")
+                normalColor: "transparent"
+
+                onClicked: {
+                    root.cancelClicked()
+                    close()
+                }
+            }
+
+            StatusButton {
+                text: qsTr("Self-destruct")
+                type: StatusBaseButton.Type.Danger
+
+                onClicked: {
+                    root.selfDestructClicked()
+                    close()
+                }
+            }
+        }
+    }
+}

--- a/ui/app/AppLayouts/Chat/popups/community/qmldir
+++ b/ui/app/AppLayouts/Chat/popups/community/qmldir
@@ -1,3 +1,4 @@
 CreateChannelPopup 1.0 CreateChannelPopup.qml
 CommunityTokenPermissionsPopup 1.0 CommunityTokenPermissionsPopup.qml
 SignMintTokenTransactionPopup 1.0 SignMintTokenTransactionPopup.qml
+RemoteSelfDestructPopup 1.0 RemoteSelfDestructPopup.qml

--- a/ui/app/AppLayouts/Chat/popups/community/qmldir
+++ b/ui/app/AppLayouts/Chat/popups/community/qmldir
@@ -1,4 +1,5 @@
 CreateChannelPopup 1.0 CreateChannelPopup.qml
 CommunityTokenPermissionsPopup 1.0 CommunityTokenPermissionsPopup.qml
-SignMintTokenTransactionPopup 1.0 SignMintTokenTransactionPopup.qml
 RemoteSelfDestructPopup 1.0 RemoteSelfDestructPopup.qml
+SelfDestructAlertPopup 1.0 SelfDestructAlertPopup.qml
+SignMintTokenTransactionPopup 1.0 SignMintTokenTransactionPopup.qml

--- a/ui/app/AppLayouts/Chat/stores/CommunityTokensStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/CommunityTokensStore.qml
@@ -56,6 +56,9 @@ QtObject {
                    ])
     }
 
+    signal deployFeeUpdated(var ethCurrency, var fiatCurrency, int error)
+    signal selfDestructFeeUpdated(string value) // TO BE REMOVED
+
     // Minting tokens:
     function deployCollectible(communityId, accountAddress, name, symbol, description, supply,
                              infiniteSupply, transferable, selfDestruct, chainId, artworkSource, accountName)
@@ -64,8 +67,6 @@ QtObject {
         communityTokensModuleInst.deployCollectible(communityId, accountAddress, name, symbol, description, supply,
                                                     infiniteSupply, transferable, selfDestruct, chainId, artworkSource)
     }
-
-    signal deployFeeUpdated(var ethCurrency, var fiatCurrency, int error)
 
     readonly property Connections connections: Connections {
       target: communityTokensModuleInst
@@ -76,6 +77,17 @@ QtObject {
 
     function computeDeployFee(chainId, accountAddress) {
         communityTokensModuleInst.computeDeployFee(chainId, accountAddress)
+    }
+
+    function computeSelfDestructFee(chainId) {
+        // TODO BACKEND
+        root.selfDestructFeeUpdated("0,0005 ETH")
+        console.warn("TODO: Compute self-destruct fee backend")
+    }
+
+    function remoteSelfDestructCollectibles(holdersModel, chainId, accountName, accountAddress) {
+        // TODO BACKEND
+        console.warn("TODO: Remote self-destruct collectible backend")
     }
 
     // Airdrop tokens:

--- a/ui/app/AppLayouts/Chat/stores/CommunityTokensStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/CommunityTokensStore.qml
@@ -25,25 +25,33 @@ QtObject {
                            ensName: "carmen.eth",
                            walletAddress: "0xb794f5450ba39494ce839613fffba74279579268",
                            imageSource:image,
-                           amount: 3
+                           amount: 3,
+                           selfDestructAmount: 0,
+                           selfDestruct: false
                        },
                        {
                            ensName: "chris.eth",
                            walletAddress: "0xb794f5ea0ba39494ce839613fffba74279579268",
                            imageSource: image,
-                           amount: 2
+                           amount: 2,
+                           selfDestructAmount: 0,
+                           selfDestruct: false
                        },
                        {
                            ensName: "emily.eth",
                            walletAddress: "0xb794f5ea0ba39494ce839613fffba74279579268",
                            imageSource: image,
-                           amount: 2
+                           amount: 2,
+                           selfDestructAmount: 0,
+                           selfDestruct: false
                        },
                        {
                            ensName: "",
                            walletAddress: "0xb794f5ea0ba39494ce839613fffba74279579268",
                            imageSource: "",
-                           amount: 1
+                           amount: 1,
+                           selfDestructAmount: 0,
+                           selfDestruct: false
                        }
                    ])
     }

--- a/ui/app/AppLayouts/Chat/views/CommunitySettingsView.qml
+++ b/ui/app/AppLayouts/Chat/views/CommunitySettingsView.qml
@@ -323,6 +323,13 @@ StatusSectionLayout {
                                                            artworkSource,
                                                            accountName)
                 }
+                onSignSelfDestructTransactionOpened: communityTokensStore.computeSelfDestructFee(chainId)
+                onRemoteSelfDestructCollectibles: {
+                    communityTokensStore.remoteSelfDestructCollectibles(holdersModel,
+                                                                        chainId,
+                                                                        accountName,
+                                                                        accountAddress)
+                }
 
                 Connections {
                     target: rootStore.communityTokensStore
@@ -343,6 +350,17 @@ StatusSectionLayout {
 
                         mintPanel.errorText = qsTr("Unknown error")
                         mintPanel.isFeeLoading = true
+                    }
+
+                    // TODO: Self-destruct backend
+                    function onSelfDestructFeeUpdated(value) {
+                        // TODO better error handling
+                        if (value === "-") {
+                            mintPanel.isFeeLoading = true
+                        } else {
+                            mintPanel.isFeeLoading = false
+                            mintPanel.feeText = value
+                        }
                     }
                 }
             }
@@ -431,11 +449,11 @@ StatusSectionLayout {
         target: root.chatCommunitySectionModule
         function onOpenNoPermissionsToJoinPopup(communityName: string, userName: string, communityId: string, requestId: string) {
             Global.openPopup(noPermissionsPopupCmp, {
-                communityName: communityName,
-                userName: userName,
-                communityId: communityId,
-                requestId: requestId
-            })
+                                 communityName: communityName,
+                                 userName: userName,
+                                 communityId: communityId,
+                                 requestId: requestId
+                             })
         }
 
     }

--- a/ui/app/AppLayouts/Chat/views/communities/CommunityMintedTokensView.qml
+++ b/ui/app/AppLayouts/Chat/views/communities/CommunityMintedTokensView.qml
@@ -15,7 +15,11 @@ StatusScrollView {
     property int viewWidth: 560 // by design
     property var model
 
-    signal itemClicked(int index)
+    signal itemClicked(int index,
+                       int chainId,
+                       string chainName,
+                       string accountName,
+                       string accountAddress)
 
     enum DeployState {
           Failed,
@@ -72,7 +76,7 @@ StatusScrollView {
                 isLoading: false
                 navigationIconVisible: true
 
-                onClicked: root.itemClicked(model.index) // TODO: Replace to model.key when role exists in backend
+                onClicked: root.itemClicked(model.index, model.chainId, model.chainName, model.accountName, model.address) // TODO: Replace to model.key when role exists in backend
             }
         }
     }


### PR DESCRIPTION
Closes #10051

### What does the PR do
- Created needed popups and added storybook support.
- Extended token holders panel with selector mode.
- Integrated remote self-destruct flow in the app. **ONLY UI - BACKEND NEEDED**

### Affected areas

Community Settings / Mint tokens / Self-destruct option

### Screenshot of functionality 

https://user-images.githubusercontent.com/97019400/229211010-0783eca8-1c7e-43aa-91c5-6c368b79aa29.mov

https://user-images.githubusercontent.com/97019400/229211021-be47b4cb-d284-433f-af65-54c09a91e026.mov