### PR TITLE
fix(StatusPasswordInput): enable mouse interaction

### DIFF
--- a/ui/StatusQ/src/StatusQ/Controls/StatusPasswordInput.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusPasswordInput.qml
@@ -54,7 +54,7 @@ TextField {
     verticalAlignment: Text.AlignVCenter
     implicitWidth: 480
     implicitHeight: 44
-
+    selectByMouse: true
 
     placeholderTextColor: Theme.palette.baseColor1
     echoMode: TextInput.Password

--- a/ui/app/AppLayouts/Profile/popups/ChangePasswordModal.qml
+++ b/ui/app/AppLayouts/Profile/popups/ChangePasswordModal.qml
@@ -24,7 +24,7 @@ StatusModal {
 
     function onChangePasswordResponse(success, errorMsg) {
         if (success) {
-            if (Qt.platform.os === "osx" && localAccountSettings.storeToKeychainValue !== Constants.keychain.storedValue.never) {
+            if (Qt.platform.os === Constants.mac && localAccountSettings.storeToKeychainValue !== Constants.keychain.storedValue.never) {
                 localAccountSettings.storeToKeychainValue = Constants.keychain.storedValue.notNow;
             }
             passwordChanged()

--- a/ui/imports/shared/views/PasswordView.qml
+++ b/ui/imports/shared/views/PasswordView.qml
@@ -11,6 +11,7 @@ import StatusQ.Controls 0.1
 import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
 import StatusQ.Components 0.1
+
 ColumnLayout {
     id: root
 
@@ -169,7 +170,7 @@ ColumnLayout {
         echoMode: showPassword ? TextInput.Normal : TextInput.Password
         validator: d.validator
         rightPadding: showHideCurrentIcon.width + showHideCurrentIcon.anchors.rightMargin + Style.current.padding / 2
-        Keys.onReturnPressed: { root.returnPressed() }
+        onAccepted: root.returnPressed()
 
         StatusFlatRoundButton {
             id: showHideCurrentIcon
@@ -216,7 +217,7 @@ ColumnLayout {
                     root.checkPasswordMatches(false)
                 }
             }
-            Keys.onReturnPressed: { root.returnPressed() }
+            onAccepted: root.returnPressed()
 
             StatusFlatRoundButton {
                 id: showHideNewIcon
@@ -321,7 +322,7 @@ ColumnLayout {
                 root.checkPasswordMatches(false)
             }
         }
-        Keys.onReturnPressed: { root.returnPressed() }
+        onAccepted: root.returnPressed()
 
         StatusFlatRoundButton {
             id: showHideConfirmIcon


### PR DESCRIPTION
### What does the PR do

- enables selecting text with mouse in password input
- minor cleanups/fixes related to password modal

Fixes #9837

### Affected areas

password input related classes

