### PR TITLE
fix: Excessive vertical spacing between subtitle and standard colour selector in all colour selectors

### DIFF
--- a/ui/StatusQ/src/StatusQ/Controls/StatusColorRadioButton.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusColorRadioButton.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.13
-import QtQuick.Controls 2.14
+import QtQuick 2.15
+import QtQuick.Controls 2.15
 
 import StatusQ.Core.Theme 0.1
 
@@ -30,15 +30,13 @@ RadioButton {
             radius: width/2
             color: selectionColor
             border.color: StatusColors.colors['grey3']
+            border.width: 1
         }
     }
 
-    MouseArea {
-        id: mouseArea
-        anchors.fill: parent
-        hoverEnabled: true
+    HoverHandler {
+        enabled: control.enabled
         cursorShape: Qt.PointingHandCursor
-        onPressed: mouse.accepted = false
     }
 }
 

--- a/ui/StatusQ/src/StatusQ/Controls/StatusColorSelectorGrid.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusColorSelectorGrid.qml
@@ -47,6 +47,7 @@ Column {
         columns: 6
         rowSpacing: 16
         columnSpacing: 32
+        anchors.horizontalCenter: parent.horizontalCenter
 
         Repeater {
             objectName: "statusColorRepeater"

--- a/ui/StatusQ/src/StatusQ/Controls/StatusPickerButton.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusPickerButton.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.14
-import QtQuick.Controls 2.12
-import QtQuick.Layouts 1.14
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
 
 import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
@@ -76,11 +76,8 @@ Button {
         }
     }
 
-    // TODO: To remove when switch to Qt 5.15
-    MouseArea {
-        anchors.fill: parent
-        hoverEnabled: true
+    HoverHandler {
+        enabled: root.enabled
         cursorShape: Qt.PointingHandCursor
-        onClicked: { root.clicked() }
     }
 }

--- a/ui/StatusQ/src/StatusQ/Popups/StatusColorDialog.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/StatusColorDialog.qml
@@ -51,7 +51,7 @@ StatusModal {
         ColumnLayout {
             id: column
             width: scroll.width - scroll.leftPadding - scroll.rightPadding
-            spacing: 12
+            spacing: 16
 
             StatusColorSpace {
                 id: colorSpace
@@ -115,20 +115,18 @@ StatusModal {
                 }
             }
 
-            StatusBaseText {
-                text: qsTr("Standard colours")
-                font.pixelSize: 15
-            }
-
             StatusColorSelectorGrid {
                 id: colorSelectionGrid
+                titleText: qsTr("Standard colours")
+                title.color: Theme.palette.directColor1
+                title.font.pixelSize: 15
                 columns: 8
                 model: ["#4360df", "#887af9", "#d37ef4", "#51d0f0", "#26a69a", "#7cda00", "#eab700", "#fa6565"]
                 selectedColorIndex: -1
                 onColorSelected: {
                     root.color = selectedColor;
                 }
-                Layout.alignment: Qt.AlignHCenter
+                Layout.fillWidth: true
             }
         }
     }

--- a/ui/app/AppLayouts/Chat/popups/community/CreateChannelPopup.qml
+++ b/ui/app/AppLayouts/Chat/popups/community/CreateChannelPopup.qml
@@ -171,10 +171,8 @@ StatusDialog {
 
                     property string validationError: ""
 
-                    bgColor: colorDialog.colorSelected ?
-                                 colorDialog.color : Theme.palette.baseColor2
-                    // TODO adjust text color depending on the background color to make it readable
-                    // contentColor: colorDialog.colorSelected ? Theme.palette.indirectColor1 : Theme.palette.baseColor1
+                    bgColor: colorDialog.colorSelected ? colorDialog.color : Theme.palette.baseColor2
+                    contentColor: colorDialog.colorSelected ? Theme.palette.white : Theme.palette.baseColor1
                     text: colorDialog.colorSelected ?
                               colorDialog.color.toString().toUpperCase() :
                               qsTr("Pick a colour")
@@ -191,8 +189,9 @@ StatusDialog {
                     id: colorDialog
                     anchors.centerIn: parent
                     property bool colorSelected: root.isEdit && root.channelColor
+                    header.title: qsTr("Channel Colour")
                     color: root.isEdit && root.channelColor ? root.channelColor :
-                                                                Theme.palette.primaryColor1
+                                                              Theme.palette.primaryColor1
                     onAccepted: colorSelected = true
                 }
 

--- a/ui/app/AppLayouts/CommunitiesPortal/controls/CommunityColorPicker.qml
+++ b/ui/app/AppLayouts/CommunitiesPortal/controls/CommunityColorPicker.qml
@@ -20,9 +20,8 @@ ColumnLayout {
 
     implicitHeight: childrenRect.height
     StatusBaseText {
-        text: qsTr("Community color")
+        text: qsTr("Community colour")
         font.pixelSize: 15
-        color: Theme.palette.directColor1
     }
 
     StatusPickerButton {
@@ -31,7 +30,7 @@ ColumnLayout {
         property string validationError: ""
 
         bgColor: root.color
-        contentColor: Theme.palette.indirectColor1
+        contentColor: Theme.palette.white
         text: root.color.toString()
         onClicked: root.pick()
 

--- a/ui/app/AppLayouts/CommunitiesPortal/panels/CommunityColorPanel.qml
+++ b/ui/app/AppLayouts/CommunitiesPortal/panels/CommunityColorPanel.qml
@@ -45,7 +45,7 @@ StatusScrollView {
     ColumnLayout {
         id: column
         width: root.availableWidth
-        spacing: 12
+        spacing: 16
 
         StatusColorSpace {
             id: colorSpace
@@ -73,7 +73,7 @@ StatusScrollView {
             validators: [
                 StatusRegularExpressionValidator {
                     regularExpression: /^#(?:[0-9a-fA-F]{3}){1,2}$/
-                    errorMessage: qsTr("This is not a valid color")
+                    errorMessage: qsTr("This is not a valid colour")
                 }
             ]
             validationMode: StatusInput.ValidationMode.Always
@@ -104,26 +104,24 @@ StatusScrollView {
                 id: preview
                 x: 16
                 y: 16
-                text: qsTr("White text should be legible on top of this color")
+                text: qsTr("White text should be legible on top of this colour")
                 color: Theme.palette.white
                 font.pixelSize: 15
             }
         }
 
-        StatusBaseText {
-            text: qsTr("Standard colors")
-            font.pixelSize: 15
-        }
-
         StatusColorSelectorGrid {
             id: colorSelectionGrid
+            titleText: qsTr("Standard colours")
+            title.color: Theme.palette.directColor1
+            title.font.pixelSize: 15
             columns: 8
             model: ["#4360df", "#887af9", "#d37ef4", "#51d0f0", "#26a69a", "#7cda00", "#eab700", "#fa6565"]
             selectedColorIndex: -1
             onColorSelected: {
                 root.color = selectedColor;
             }
-            Layout.alignment: Qt.AlignHCenter
+            Layout.fillWidth: true
         }
     }
 }


### PR DESCRIPTION
### What does the PR do

- use spacing as designed in Figma
- re-use StatusColorSelectorGrid title label component (not leaving extra
space behind when empty)
- always use white text for the color previews (our color palette/picker
are designed for this)
- give Channel color dialog a title (as designed)
- use BE spelling (as designed, and to be consistent with the rest of the app)

Fixes: #9841

### Affected areas

Color selector/picker related components

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

Edit community panel:
![image](https://user-images.githubusercontent.com/5377645/229593200-00610bac-3a24-4185-a9dc-09e9ffc39676.png)

Community color dialog:
![image](https://user-images.githubusercontent.com/5377645/229593256-e58984c5-624e-46db-8088-ab0f68b3af31.png)

Create new community wizard:
![image](https://user-images.githubusercontent.com/5377645/229593431-f74e6bdf-5333-4bf1-bed4-0eb81f5b6afc.png)

Create new community wizard (color selection sub-popup):
![image](https://user-images.githubusercontent.com/5377645/229593579-672157c7-823c-4e6b-8bcf-356fca8ab1cc.png)

Edit channel preview:
![image](https://user-images.githubusercontent.com/5377645/229593620-0723543d-5e86-4ec6-8487-3eead2fecef4.png)

Channel Color dialog:
![image](https://user-images.githubusercontent.com/5377645/229593859-64d80bf6-ceee-46eb-85ca-575c0b511a3a.png)

