### PR TITLE
fix: Edit Community / Community Color selector dialogue does not need the back button

### DIFF
--- a/ui/StatusQ/src/StatusQ/Popups/StatusStackModal.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/StatusStackModal.qml
@@ -19,6 +19,21 @@ StatusModal {
     readonly property int itemsCount: stackLayout.count
     readonly property var currentItem: stackLayout.currentItem
 
+    property Item backButton: StatusBackButton {
+        visible: replaceItem || stackLayout.currentIndex > 0
+        onClicked: {
+            if (replaceItem) {
+                replaceItem = null;
+            } else {
+                let prevAction = stackLayout.currentItem.prevAction
+                stackLayout.currentIndex--;
+                if (typeof(prevAction) == "function") {
+                    prevAction()
+                }
+            }
+        }
+    }
+
     property Item nextButton: StatusButton {
         text: qsTr("Next")
         onClicked: root.currentIndex++
@@ -52,21 +67,7 @@ StatusModal {
                                                 ? replaceLoader.item.title : stackTitle
     padding: 16
 
-    leftButtons: StatusBackButton {
-        id: backButton
-        visible: replaceItem || stackLayout.currentIndex > 0
-        onClicked: {
-            if (replaceItem) {
-              replaceItem = null;
-            } else {
-              let prevAction = stackLayout.currentItem.prevAction
-              stackLayout.currentIndex--;
-              if (typeof(prevAction) == "function") {
-                prevAction()
-              }
-            }
-        }
-    }
+    leftButtons: [ backButton ]
 
     rightButtons: [ nextButton, finishButton ]
 

--- a/ui/app/AppLayouts/Chat/panels/communities/CommunityEditSettingsPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/CommunityEditSettingsPanel.qml
@@ -93,8 +93,8 @@ StatusScrollView {
 
                 StatusStackModal {
                     width: 640
-                    height: root.height
                     anchors.centerIn: parent
+                    leftButtons: []
                     replaceItem: CommunityColorPanel {
                         clip: true
                         Component.onCompleted: color = colorPicker.color
@@ -119,6 +119,7 @@ StatusScrollView {
 
                 StatusStackModal {
                     anchors.centerIn: parent
+                    leftButtons: []
                     width: 640
                     replaceItem: CommunityTagsPanel {
                         Component.onCompleted: {


### PR DESCRIPTION
### What does the PR do

Remove the the back button here in a separate color dialog popup (same for Tags dialog as well)

Fixes #9790

### Affected areas

CommunityEditSettingsPanel

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

Back button gone from the community color dialog:
![image](https://user-images.githubusercontent.com/5377645/229597333-fad2390b-50d7-49f0-840c-114d2e45d3a1.png)

