### PR TITLE
fix(CommunityTagsPanel): unbreak the tags panel

### DIFF
--- a/ui/app/AppLayouts/CommunitiesPortal/panels/CommunityColorPanel.qml
+++ b/ui/app/AppLayouts/CommunitiesPortal/panels/CommunityColorPanel.qml
@@ -12,8 +12,6 @@ import StatusQ.Popups 0.1
 StatusScrollView {
     id: root
 
-    contentWidth: column.implicitWidth
-    contentHeight: column.implicitHeight
     property string title: qsTr("Community Colour")
 
     property var rightButtons: StatusButton {
@@ -39,6 +37,10 @@ StatusScrollView {
         hexInput.text = color.toString();
     }
 
+    contentWidth: implicitWidth
+    contentHeight: implicitHeight
+    implicitWidth: column.childrenRect.width
+    implicitHeight: column.childrenRect.height
     padding: 0
     clip: false
 

--- a/ui/app/AppLayouts/CommunitiesPortal/panels/CommunityTagsPanel.qml
+++ b/ui/app/AppLayouts/CommunitiesPortal/panels/CommunityTagsPanel.qml
@@ -63,7 +63,10 @@ StatusScrollView {
     onSelectedTagsChanged: updateSelectedTags()
 
     padding: 0
-    contentWidth: column.width
+    contentWidth: implicitWidth
+    contentHeight: implicitHeight
+    implicitWidth: column.childrenRect.width
+    implicitHeight: column.childrenRect.height
     clip: false
 
     QtObject {
@@ -80,8 +83,6 @@ StatusScrollView {
 
         StatusInput {
             id: tagsFilter
-            leftPadding: 0
-            rightPadding: 0
             label: qsTr("Select tags that will fit your Community")
             labelPadding: Style.current.bigPadding
             font.pixelSize: 15


### PR DESCRIPTION
yet another little victim of the StatusScrollView regression; same (similar) thing for the color panel

Fixes #9971

### What does the PR do

Makes it possible to edit community tags again

### Affected areas

CommunityTagsPanel/CommunityColorPanel

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

Tags preview:
![image](https://user-images.githubusercontent.com/5377645/229601882-26c4bb4a-f64d-4e9a-9d2a-d574f23f1eb8.png)

Tags editing:
![image](https://user-images.githubusercontent.com/5377645/229601926-3b4558f9-4b8a-413c-8fb6-9cca243e18b5.png)
