### PR TITLE
fix(CreateCategoryPopup): move the delete button into footer

### DIFF
--- a/ui/app/AppLayouts/Chat/popups/community/CreateCategoryPopup.qml
+++ b/ui/app/AppLayouts/Chat/popups/community/CreateCategoryPopup.qml
@@ -123,10 +123,11 @@ StatusModal {
                             readonly property bool checked: channelItemCheckbox.checked
                             objectName: "category_item_name_" + model.name
                             anchors.horizontalCenter: parent.horizontalCenter
+                            anchors.horizontalCenterOffset: 16
                             height: visible ? implicitHeight : 0
                             title: "#" + model.name
-                            asset.width: 30
-                            asset.height: 30
+                            asset.width: 40
+                            asset.height: 40
                             asset.emoji: model.emoji
                             asset.color: model.color
                             asset.imgIsIdenticon: false
@@ -156,29 +157,6 @@ StatusModal {
                         }
                     }
                 }
-            }
-        }
-
-        StatusModalDivider {
-            visible: deleteCategoryButton.visible
-            topPadding: 8
-            bottomPadding: 8
-        }
-
-        StatusListItem {
-            id: deleteCategoryButton
-            anchors.horizontalCenter: parent.horizontalCenter
-            visible: isEdit
-
-            title: qsTr("Delete category")
-            asset.name: "delete"
-            type: StatusListItem.Type.Danger
-            onClicked: {
-                Global.openPopup(deleteCategoryConfirmationDialogComponent, {
-                    title: qsTr("Delete %1 category").arg(root.contentItem.categoryName.input.text),
-                    confirmationText: qsTr("Are you sure you want to delete %1 category? Channels inside the category won’t be deleted.").arg(root.contentItem.categoryName.input.text)
-
-                })
             }
         }
 
@@ -212,6 +190,17 @@ StatusModal {
     }
 
     rightButtons: [
+        StatusButton {
+            visible: isEdit
+            type: StatusBaseButton.Type.Danger
+            text: qsTr("Delete Category")
+            onClicked: {
+                Global.openPopup(deleteCategoryConfirmationDialogComponent, {
+                    "header.title": qsTr("Delete '%1' category").arg(nameInput.text),
+                    confirmationText: qsTr("Are you sure you want to delete '%1' category? Channels inside the category won’t be deleted.").arg(nameInput.text)
+                })
+            }
+        },
         StatusButton {
             objectName: "createOrEditCommunityCategoryBtn"
             enabled: isFormValid()

--- a/ui/app/AppLayouts/Chat/views/CommunityColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/CommunityColumnView.qml
@@ -303,8 +303,8 @@ Item {
                     type: StatusAction.Type.Danger
                     onTriggered: {
                         Global.openPopup(deleteCategoryConfirmationDialogComponent, {
-                            title: qsTr("Delete %1 category").arg(categoryItem.name),
-                            confirmationText: qsTr("Are you sure you want to delete %1 category? Channels inside the category won't be deleted.")
+                            "header.title": qsTr("Delete '%1' category").arg(categoryItem.name),
+                            confirmationText: qsTr("Are you sure you want to delete '%1' category? Channels inside the category won't be deleted.")
                                 .arg(categoryItem.name),
                             categoryId: categoryItem.itemId
                         })


### PR DESCRIPTION
Adjust according to Figma design
- the "Delete Category" button should be inside the footer
- the asset size should be 40x40
- fix the listview's horizontal alignment
- fix the confirmation dialog(s!) title

Fixes #9887

### What does the PR do

Aligns the popup with Figma design

### Affected areas

CreateCategoryPopup

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![image](https://user-images.githubusercontent.com/5377645/229619384-18c2392e-55be-4e9b-99fa-6b4960e12ae9.png)

Delete confirmation:
![image](https://user-images.githubusercontent.com/5377645/229624105-f35bf122-2cdf-4a7d-a5f3-b7144ebfc532.png)

