### PR TITLE
fix(@desktop/wallet): checkConnected API doesnt return correct values

### DIFF
--- a/src/app/boot/app_controller.nim
+++ b/src/app/boot/app_controller.nim
@@ -180,7 +180,7 @@ proc newAppController*(statusFoundation: StatusFoundation): AppController =
   result.collectibleService = collectible_service.newService(statusFoundation.events, statusFoundation.threadpool, result.networkService)
   result.walletAccountService = wallet_account_service.newService(
     statusFoundation.events, statusFoundation.threadpool, result.settingsService, result.accountsService,
-    result.tokenService, result.networkService,
+    result.tokenService, result.networkService, result.collectibleService
   )
   result.messageService = message_service.newService(
     statusFoundation.events, statusFoundation.threadpool, result.contactsService, result.tokenService, result.walletAccountService, result.networkService
@@ -218,7 +218,7 @@ proc newAppController*(statusFoundation: StatusFoundation): AppController =
   result.tokensService = tokens_service.newService(statusFoundation.events, statusFoundation.threadpool,
     result.transactionService, result.tokenService, result.settingsService)
   result.providerService = provider_service.newService(statusFoundation.events, statusFoundation.threadpool, result.ensService)
-  result.networkConnectionService = network_connection_service.newService(statusFoundation.events, result.walletAccountService, result.networkService, result.collectibleService, result.nodeService)
+  result.networkConnectionService = network_connection_service.newService(statusFoundation.events, result.walletAccountService, result.networkService, result.nodeService)
 
   # Modules
   result.startupModule = startup_module.newModule[AppController](
@@ -428,6 +428,7 @@ proc load(self: AppController) =
   self.tokenService.init()
   self.currencyService.init()
   self.walletAccountService.init()
+  self.collectibleService.init()
 
   # Apply runtime log level settings
   if not existsEnv("LOG_LEVEL"):

--- a/src/app/core/signals/remote_signals/wallet.nim
+++ b/src/app/core/signals/remote_signals/wallet.nim
@@ -10,6 +10,9 @@ type WalletSignal* = ref object of Signal
   accounts*: seq[string]
   # newTransactions*: ???
   erc20*: bool
+  at*: int
+  chainID*: int
+  message*: string
 
 proc fromEvent*(T: type WalletSignal, jsonSignal: JsonNode): WalletSignal =
   result = WalletSignal()
@@ -23,3 +26,6 @@ proc fromEvent*(T: type WalletSignal, jsonSignal: JsonNode): WalletSignal =
     if jsonSignal["event"]["accounts"].kind != JNull:
       for account in jsonSignal["event"]["accounts"]:
         result.accounts.add(account.getStr)
+    result.at = jsonSignal["event"]{"at"}.getInt
+    result.chainID = jsonSignal["event"]{"chainID"}.getInt
+    result.message = jsonSignal["event"]{"message"}.getStr

--- a/src/app/modules/main/network_connection/controller.nim
+++ b/src/app/modules/main/network_connection/controller.nim
@@ -27,10 +27,13 @@ proc delete*(self: Controller) =
 proc init*(self: Controller) =
   self.events.on(SIGNAL_CONNECTION_UPDATE) do(e:Args):
     let args = NetworkConnectionsArgs(e)
-    self.delegate.networkConnectionStatusUpdate(args.website, args.completelyDown, ord(args.connectionState), args.chainIds, args.lastCheckedAt, args.timeToAutoRetryInSecs, args.withCache)
+    self.delegate.networkConnectionStatusUpdate(args.website, args.completelyDown, ord(args.connectionState), args.chainIds, args.lastCheckedAt, args.timeToAutoRetryInSecs)
 
   self.events.on(SIGNAL_NETWORK_CONNECTED) do(e: Args):
-    self.networkConnectionService.networkConnected()
+    self.networkConnectionService.networkConnected(true)
+
+  self.events.on(SIGNAL_NETWORK_DISCONNECTED) do(e: Args):
+    self.networkConnectionService.networkConnected(false)
 
 proc refreshBlockchainValues*(self: Controller) =
   self.networkConnectionService.blockchainsRetry()

--- a/src/app/modules/main/network_connection/io_interface.nim
+++ b/src/app/modules/main/network_connection/io_interface.nim
@@ -19,7 +19,7 @@ method isLoaded*(self: AccessInterface): bool {.base.} =
 method viewDidLoad*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method networkConnectionStatusUpdate*(self: AccessInterface, website: string, completelyDown: bool, connectionState: int, chainIds: string, lastCheckedAt: int, timeToAutoRetryInSecs: int, withCache: bool) {.base.} =
+method networkConnectionStatusUpdate*(self: AccessInterface, website: string, completelyDown: bool, connectionState: int, chainIds: string, lastCheckedAt: int, timeToAutoRetryInSecs: int) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method refreshBlockchainValues*(self: AccessInterface)  {.base.} =
@@ -30,3 +30,4 @@ method refreshMarketValues*(self: AccessInterface)  {.base.} =
 
 method refreshCollectiblesValues*(self: AccessInterface)  {.base.} =
   raise newException(ValueError, "No implementation available")
+

--- a/src/app/modules/main/network_connection/module.nim
+++ b/src/app/modules/main/network_connection/module.nim
@@ -49,8 +49,8 @@ proc checkIfModuleDidLoad(self: Module) =
 method viewDidLoad*(self: Module) =
   self.checkIfModuleDidLoad()
 
-method networkConnectionStatusUpdate*(self: Module, website: string, completelyDown: bool, connectionState: int, chainIds: string, lastCheckedAt: int, timeToAutoRetryInSecs: int, withCache: bool) =
-  self.view.updateNetworkConnectionStatus(website, completelyDown, connectionState, chainIds, lastCheckedAt, timeToAutoRetryInSecs, withCache)
+method networkConnectionStatusUpdate*(self: Module, website: string, completelyDown: bool, connectionState: int, chainIds: string, lastCheckedAt: int, timeToAutoRetryInSecs: int) =
+  self.view.updateNetworkConnectionStatus(website, completelyDown, connectionState, chainIds, lastCheckedAt, timeToAutoRetryInSecs)
 
 method refreshBlockchainValues*(self: Module) =
   self.controller.refreshBlockchainValues()

--- a/src/app/modules/main/network_connection/network_connection_item.nim
+++ b/src/app/modules/main/network_connection/network_connection_item.nim
@@ -7,12 +7,11 @@ QtObject:
     chainIds: string
     lastCheckedAt: int
     timeToAutoRetryInSecs: int
-    withCache: bool
 
   proc delete*(self: NetworkConnectionItem) =
     self.QObject.delete
 
-  proc newNetworkConnectionItem*(completelyDown = false, connectionState = 0, chainIds = "", lastCheckedAt = 0, timeToAutoRetryInSecs = 0, withCache = false,): NetworkConnectionItem =
+  proc newNetworkConnectionItem*(completelyDown = false, connectionState = 0, chainIds = "", lastCheckedAt = 0, timeToAutoRetryInSecs = 0): NetworkConnectionItem =
     new(result, delete)
     result.QObject.setup
     result.completelyDown = completelyDown
@@ -20,7 +19,6 @@ QtObject:
     result.chainIds = chainIds
     result.lastCheckedAt = lastCheckedAt
     result.timeToAutoRetryInSecs = timeToAutoRetryInSecs
-    result.withCache = withCache
 
   proc `$`*(self: NetworkConnectionItem): string =
     result = fmt"""NetworkConnectionItem[
@@ -28,8 +26,7 @@ QtObject:
       connectionState: {self.connectionState},
       chainIds: {self.chainIds},
       lastCheckedAt: {self.lastCheckedAt},
-      timeToAutoRetryInSecs: {self.timeToAutoRetryInSecs},
-      withCache: {self.withCache}
+      timeToAutoRetryInSecs: {self.timeToAutoRetryInSecs}
       ]"""
 
   proc completelyDownChanged*(self: NetworkConnectionItem) {.signal.}
@@ -67,15 +64,8 @@ QtObject:
     read = getTimeToAutoRetryInSecs
     notify = timeToAutoRetryInSecsChanged
 
-  proc withCacheChanged*(self: NetworkConnectionItem) {.signal.}
-  proc getWithCache*(self: NetworkConnectionItem): bool {.slot.} =
-    return self.withCache
-  QtProperty[bool] withCache:
-    read = getWithCache
-    notify = withCacheChanged
-
   proc updateValues*(self: NetworkConnectionItem, completelyDown: bool, connectionState: int,
-    chainIds: string, lastCheckedAt: int, timeToAutoRetryInSecs: int, withCache: bool) =
+    chainIds: string, lastCheckedAt: int, timeToAutoRetryInSecs: int) =
       if self.completelyDown != completelyDown :
         self.completelyDown = completelyDown
         self.completelyDownChanged()
@@ -95,7 +85,3 @@ QtObject:
       if self.timeToAutoRetryInSecs != timeToAutoRetryInSecs :
         self.timeToAutoRetryInSecs = timeToAutoRetryInSecs
         self.timeToAutoRetryInSecsChanged()
-
-      if self.withCache != withCache :
-        self.withCache = withCache
-        self.withCacheChanged()

--- a/src/app/modules/main/network_connection/view.nim
+++ b/src/app/modules/main/network_connection/view.nim
@@ -62,19 +62,18 @@ QtObject:
   proc refreshCollectiblesValues*(self: View) {.slot.} =
     self.delegate.refreshCollectiblesValues()
 
-  proc networkConnectionStatusUpdate*(self: View, website: string, completelyDown: bool, connectionState: int, chainIds: string, lastCheckedAt: int, timeToAutoRetryInSecs: int, withCache: bool) {.signal.}
+  proc networkConnectionStatusUpdate*(self: View, website: string, completelyDown: bool, connectionState: int, chainIds: string, lastCheckedAt: int, timeToAutoRetryInSecs: int) {.signal.}
 
-  proc updateNetworkConnectionStatus*(self: View, website: string, completelyDown: bool, connectionState: int, chainIds: string, lastCheckedAt: int, timeToAutoRetryInSecs: int, withCache: bool) =
+  proc updateNetworkConnectionStatus*(self: View, website: string, completelyDown: bool, connectionState: int, chainIds: string, lastCheckedAt: int, timeToAutoRetryInSecs: int) =
     case website:
       of BLOCKCHAINS:
-        self.blockchainNetworkConnection.updateValues(completelyDown, connectionState, chainIds, lastCheckedAt, timeToAutoRetryInSecs, withCache)
+        self.blockchainNetworkConnection.updateValues(completelyDown, connectionState, chainIds, lastCheckedAt, timeToAutoRetryInSecs)
         self.blockchainNetworkConnectionChanged()
       of COLLECTIBLES:
-        self.collectiblesNetworkConnection.updateValues(completelyDown, connectionState, chainIds, lastCheckedAt, timeToAutoRetryInSecs, withCache)
+        self.collectiblesNetworkConnection.updateValues(completelyDown, connectionState, chainIds, lastCheckedAt, timeToAutoRetryInSecs)
         self.collectiblesNetworkConnectionChanged()
       of MARKET:
-        self.marketValuesNetworkConnection.updateValues(completelyDown, connectionState, chainIds, lastCheckedAt, timeToAutoRetryInSecs, withCache)
+        self.marketValuesNetworkConnection.updateValues(completelyDown, connectionState, chainIds, lastCheckedAt, timeToAutoRetryInSecs)
         self.marketValuesNetworkConnectionChanged()
-    self.networkConnectionStatusUpdate(website, completelyDown, connectionState, chainIds, lastCheckedAt, timeToAutoRetryInSecs, withCache)
-
+    self.networkConnectionStatusUpdate(website, completelyDown, connectionState, chainIds, lastCheckedAt, timeToAutoRetryInSecs)
 

--- a/src/app/modules/main/wallet_section/accounts/item.nim
+++ b/src/app/modules/main/wallet_section/accounts/item.nim
@@ -23,6 +23,8 @@ type
     migratedToKeycard: bool
     ens: string
     assetsLoading: bool
+    hasBalanceCache: bool
+    hasMarketValuesCache: bool
 
 proc initItem*(
   name: string = "",
@@ -42,7 +44,9 @@ proc initItem*(
   keyUid: string = "",
   migratedToKeycard: bool = false,
   ens: string = "",
-  assetsLoading: bool  = true
+  assetsLoading: bool  = true,
+  hasBalanceCache: bool = false,
+  hasMarketValuesCache: bool = false
 ): Item =
   result.name = name
   result.address = address
@@ -62,6 +66,8 @@ proc initItem*(
   result.migratedToKeycard = migratedToKeycard
   result.ens = ens
   result.assetsLoading = assetsLoading
+  result.hasBalanceCache = hasBalanceCache
+  result.hasMarketValuesCache = hasMarketValuesCache
 
 proc `$`*(self: Item): string =
   result = fmt"""WalletAccountItem(
@@ -82,7 +88,9 @@ proc `$`*(self: Item): string =
     keyUid: {self.keyUid},
     migratedToKeycard: {self.migratedToKeycard},
     ens: {self.ens},
-    assetsLoading: {self.assetsLoading}
+    assetsLoading: {self.assetsLoading},
+    hasBalanceCache: {self.hasBalanceCache},
+    hasMarketValuesCache: {self.hasMarketValuesCache},
     ]"""
 
 proc getName*(self: Item): string =
@@ -138,3 +146,9 @@ proc getEns*(self: Item): string =
 
 proc getAssetsLoading*(self: Item): bool =
   return self.assetsLoading
+
+proc getHasBalanceCache*(self: Item): bool =
+  return self.hasBalanceCache
+
+proc getHasMarketValuesCache*(self: Item): bool =
+  return self.hasMarketValuesCache

--- a/src/app/modules/main/wallet_section/accounts/model.nim
+++ b/src/app/modules/main/wallet_section/accounts/model.nim
@@ -19,7 +19,9 @@ type
     RelatedAccounts,
     KeyUid,
     MigratedToKeycard,
-    AssetsLoading
+    AssetsLoading,
+    HasBalanceCache,
+    HasMarketValuesCache
 
 QtObject:
   type
@@ -70,7 +72,9 @@ QtObject:
       ModelRole.RelatedAccounts.int: "relatedAccounts",
       ModelRole.KeyUid.int: "keyUid",
       ModelRole.MigratedToKeycard.int: "migratedToKeycard",
-      ModelRole.AssetsLoading.int: "assetsLoading"
+      ModelRole.AssetsLoading.int: "assetsLoading",
+      ModelRole.HasBalanceCache.int: "hasBalanceCache",
+      ModelRole.HasMarketValuesCache.int: "hasMarketValuesCache"
     }.toTable
 
 
@@ -123,6 +127,10 @@ QtObject:
       result = newQVariant(item.getMigratedToKeycard())
     of ModelRole.AssetsLoading:
       result = newQVariant(item.getAssetsLoading())
+    of ModelRole.HasBalanceCache:
+      result = newQVariant(item.getHasBalanceCache())
+    of ModelRole.HasMarketValuesCache:
+      result = newQVariant(item.getHasMarketValuesCache())
 
   proc getAccountNameByAddress*(self: Model, address: string): string =
     for account in self.items:

--- a/src/app/modules/main/wallet_section/accounts/utils.nim
+++ b/src/app/modules/main/wallet_section/accounts/utils.nim
@@ -69,5 +69,7 @@ proc walletAccountToItem*(
     w.keyUid,
     keyPairMigrated,
     w.ens,
-    w.assetsLoading
+    w.assetsLoading,
+    w.hasBalanceCache,
+    w.hasMarketValuesCache
   )

--- a/src/app/modules/main/wallet_section/collectibles/io_interface.nim
+++ b/src/app/modules/main/wallet_section/collectibles/io_interface.nim
@@ -38,5 +38,5 @@ method collectiblesModuleDidLoad*(self: AccessInterface) {.base.} =
 method currentCollectibleModuleDidLoad*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method noConnectionToOpenSea*(self: AccessInterface) {.base.} =
+method connectionToOpenSea*(self: AccessInterface, connected: bool) {.base.} =
   raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/wallet_section/collectibles/models/collectibles_model.nim
+++ b/src/app/modules/main/wallet_section/collectibles/models/collectibles_model.nim
@@ -205,6 +205,6 @@ QtObject:
     self.countChanged()
 
   # in case loading is still going on and no items are present, show loading items when there is no connection to opensea possible
-  proc noConnectionToOpenSea*(self: Model) =
+  proc connectionToOpenSea*(self: Model, connected: bool) =
     if self.items.len == 0:
-      self.setIsFetching(true)
+      self.setIsFetching(not connected)

--- a/src/app/modules/main/wallet_section/collectibles/module.nim
+++ b/src/app/modules/main/wallet_section/collectibles/module.nim
@@ -126,5 +126,5 @@ method appendCollectibles*(self: Module, chainId: int, address: string, data: Co
     self.view.appendCollectibles(newCollectibles)
     self.view.setAllLoaded(data.allLoaded)
 
-method noConnectionToOpenSea*(self: Module) =
-   self.view.noConnectionToOpenSea()
+method connectionToOpenSea*(self: Module, connected: bool) =
+   self.view.connectionToOpenSea(connected)

--- a/src/app/modules/main/wallet_section/collectibles/view.nim
+++ b/src/app/modules/main/wallet_section/collectibles/view.nim
@@ -46,5 +46,5 @@ QtObject:
   proc appendCollectibles*(self: View, collectibles: seq[Item]) =
     self.model.appendItems(collectibles)
 
-  proc noConnectionToOpenSea*(self: View) =
-    self.model.noConnectionToOpenSea()
+  proc connectionToOpenSea*(self: View, connected: bool) =
+    self.model.connectionToOpenSea(connected)

--- a/src/app/modules/main/wallet_section/current_account/controller.nim
+++ b/src/app/modules/main/wallet_section/current_account/controller.nim
@@ -56,3 +56,6 @@ proc getCurrencyFormat*(self: Controller, symbol: string): CurrencyFormatDto =
 
 proc getAllMigratedKeyPairs*(self: Controller): seq[KeyPairDto] =
   return self.walletAccountService.getAllMigratedKeyPairs()
+
+proc getHasCollectiblesCache*(self: Controller, address: string): bool  =
+  return self.walletAccountService.getHasCollectiblesCache(address)

--- a/src/app/modules/main/wallet_section/current_account/io_interface.nim
+++ b/src/app/modules/main/wallet_section/current_account/io_interface.nim
@@ -20,6 +20,9 @@ method update*(self: AccessInterface, address: string, accountName: string, colo
 method findTokenSymbolByAddress*(self: AccessInterface, address: string): string {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method getHasCollectiblesCache*(self: AccessInterface, address: string): bool  {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 # View Delegate Interface
 # Delegate for the view must be declared here due to use of QtObject and multi
 # inheritance, which is not well supported in Nim.

--- a/src/app/modules/main/wallet_section/current_account/view.nim
+++ b/src/app/modules/main/wallet_section/current_account/view.nim
@@ -35,6 +35,8 @@ QtObject:
       tmpChainID: int  # shouldn't be used anywhere except in prepareCurrencyAmount/getPreparedCurrencyAmount procs
       tmpSymbol: string # shouldn't be used anywhere except in prepareCurrencyAmount/getPreparedCurrencyAmount procs
       assetsLoading: bool
+      hasBalanceCache: bool
+      hasMarketValuesCache: bool
 
   proc setup(self: View) =
     self.QObject.setup
@@ -195,6 +197,20 @@ QtObject:
       self.assetsLoading = assetLoading
       self.assetsLoadingChanged()
 
+  proc getHasBalanceCache(self: View): QVariant {.slot.} =
+    return newQVariant(self.hasBalanceCache)
+  proc hasBalanceCacheChanged(self: View) {.signal.}
+  QtProperty[QVariant] hasBalanceCache:
+    read = getHasBalanceCache
+    notify = hasBalanceCacheChanged
+
+  proc getHasMarketValuesCache(self: View): QVariant {.slot.} =
+    return newQVariant(self.hasMarketValuesCache)
+  proc hasMarketValuesCacheChanged(self: View) {.signal.}
+  QtProperty[QVariant] hasMarketValuesCache:
+    read = getHasMarketValuesCache
+    notify = hasMarketValuesCacheChanged
+
   proc update(self: View, address: string, accountName: string, color: string, emoji: string) {.slot.} =
     self.delegate.update(address, accountName, color, emoji)
 
@@ -243,7 +259,11 @@ QtObject:
     if(self.ens != item.getEns()):
       self.ens = item.getEns()
       self.ensChanged()
-    self.setAssetsLoading(item.getAssetsLoading())
+    self.setAssetsLoading(item.getAssetsLoading())  
+    self.hasBalanceCache = item.getHasBalanceCache()
+    self.hasBalanceCacheChanged()
+    self.hasMarketValuesCache = item.getHasMarketValuesCache()
+    self.hasMarketValuesCacheChanged()
     # Set related accounts
     self.relatedAccounts = item.getRelatedAccounts()
     self.relatedAccountsChanged()
@@ -268,3 +288,12 @@ QtObject:
     self.tmpChainId = 0
     self.tmpSymbol = "ERROR"
     return newQVariant(currencyAmount)
+
+  proc setCacheValues*(self: View, hasBalanceCache: bool, hasMarketValuesCache: bool) =
+    self.hasBalanceCache = hasBalanceCache
+    self.hasBalanceCacheChanged()
+    self.hasMarketValuesCache = hasMarketValuesCache
+    self.hasMarketValuesCacheChanged()   
+
+  proc getHasCollectiblesCache(self: View): bool {.slot.} =
+    return self.delegate.getHasCollectiblesCache(self.address)

--- a/src/app_service/service/collectible/service.nim
+++ b/src/app_service/service/collectible/service.nim
@@ -156,10 +156,10 @@ QtObject:
           self.resetAllOwnedCollectibles()
 
   # needs to be re-written once cache for colletibles works
-  proc areCollectionsLoaded*(self: Service): bool =
+  proc areCollectionsLoaded*(self: Service, address: string): bool =
     for chainId, adressesData in self.accountsOwnershipData:
-      for address, ownershipData in adressesData:
-        if ownershipData.data.anyLoaded:
+      for addressData, ownershipData in adressesData:
+        if addressData == address and ownershipData.data.anyLoaded:
           return true
     return false
 

--- a/src/app_service/service/network_connection/service.nim
+++ b/src/app_service/service/network_connection/service.nim
@@ -4,10 +4,10 @@ import ../../../app/global/global_singleton
 import ../../../app/core/eventemitter
 import ../../../app/core/signals/types
 
-import ../collectible/service as collectible_service
 import ../wallet_account/service as wallet_service
 import ../network/service as network_service
 import ../node/service as node_service
+import ../collectible/service as collectible_service
 import ../../../backend/backend as backend
 
 logScope:
@@ -25,7 +25,6 @@ type ConnectionStatus* = ref object of RootObj
     lastCheckedAt*: int
     timeToAutoRetryInSecs*: int
     timer*: QTimer
-    withCache*: bool
 
 const SIGNAL_CONNECTION_UPDATE* = "signalConnectionUpdate"
 const SIGNAL_REFRESH_COLLECTIBLES* = "signalRefreshCollectibles"
@@ -37,10 +36,6 @@ type NetworkConnectionsArgs* = ref object of Args
   chainIds*: string
   lastCheckedAt*: int
   timeToAutoRetryInSecs*: int
-  withCache*: bool
-
-type RetryCollectibleArgs* = ref object of Args
-   addresses*: seq[string]
 
 const BLOCKCHAINS* = "blockchains"
 const MARKET* = "market"
@@ -56,8 +51,7 @@ proc newConnectionStatus(): ConnectionStatus =
     chainIds: @[],
     lastCheckedAt: 0,
     timeToAutoRetryInSecs: BACKOFF_TIMERS[0],
-    timer: newQTimer(),
-    withCache: false
+    timer: newQTimer()
   )
 
 QtObject:
@@ -66,12 +60,14 @@ QtObject:
     events: EventEmitter
     walletService: wallet_service.Service
     networkService: network_service.Service
-    collectibleService: collectible_service.Service
     nodeService: node_service.Service
     connectionStatus: Table[string, ConnectionStatus]
 
   # Forward declaration
-  proc checkConnected(self: Service)
+  proc updateBlockchainsStatus(self: Service, completelyDown: bool, chaindIdsDown: seq[int], at: int)
+  proc updateMarketOrCollectibleStatus(self: Service, website: string, isDown: bool, at: int)
+  proc getChainIdsDown(self: Service, message: string): (bool, seq[int])
+  proc getIsDown(self: Service,message: string): bool
 
   proc delete*(self: Service) =
     self.closingApp = true
@@ -81,7 +77,6 @@ QtObject:
     events: EventEmitter,
     walletService: wallet_service.Service,
     networkService: network_service.Service,
-    collectibleService: collectible_service.Service,
     nodeService: node_service.Service,
   ): Service =
     new(result, delete)
@@ -90,7 +85,6 @@ QtObject:
     result.events = events
     result.walletService = walletService
     result.networkService = networkService
-    result.collectibleService = collectibleService
     result.nodeService = nodeService
     result.connectionStatus = {BLOCKCHAINS: newConnectionStatus(),
                                 MARKET: newConnectionStatus(),
@@ -100,8 +94,53 @@ QtObject:
     self.events.on(SignalType.Wallet.event) do(e:Args):
       var data = WalletSignal(e)
       case data.eventType:
-        of "wallet-tick-check-connected":
-          self.checkConnected()
+        of "wallet-blockchain-status-changed":
+          if self.nodeService.isConnected():
+            let (allDown, chainsDown) =  self.getChainIdsDown(data.message)
+            self.updateBlockchainsStatus(allDown, chainsDown, data.at)
+        of "wallet-market-status-changed":
+          if self.nodeService.isConnected():
+            self.updateMarketOrCollectibleStatus(MARKET, self.getIsDown(data.message), data.at)
+        of "wallet-collectible-status-changed":
+          if self.nodeService.isConnected():
+            self.updateMarketOrCollectibleStatus(COLLECTIBLES, self.getIsDown(data.message), data.at)
+
+    self.events.on(SIGNAL_WALLET_ACCOUNT_TOKENS_REBUILT) do(e:Args):
+      if self.connectionStatus.hasKey(MARKET):
+        let connectionStatus = self.connectionStatus[MARKET]
+        self.updateMarketOrCollectibleStatus(MARKET, connectionStatus.completelyDown, connectionStatus.lastCheckedAt)
+
+      if self.connectionStatus.hasKey(BLOCKCHAINS):
+        let connectionStatus = self.connectionStatus[BLOCKCHAINS]
+        self.updateBlockchainsStatus(connectionStatus.completelyDown, connectionStatus.chainIds, connectionStatus.lastCheckedAt)
+
+    self.events.on(SIGNAL_OWNED_COLLECTIBLES_RESET) do(e:Args):
+      if self.connectionStatus.hasKey(COLLECTIBLES):
+        let connectionStatus = self.connectionStatus[COLLECTIBLES]
+        self.updateMarketOrCollectibleStatus(COLLECTIBLES, connectionStatus.completelyDown, connectionStatus.lastCheckedAt)
+
+  proc getIsDown(self: Service, message: string): bool =
+    result = message == "down"
+
+  proc getChainIdsDown(self: Service, message: string): (bool, seq[int]) =
+    let chainStatusTable =  parseJson(message)
+    var allDown: bool = true
+    var chaindIdsDown: seq[int] = @[]
+
+    # checking all down we check all networks and for chainIds to be displayed as down
+    # we only check for networks currently active (for test net only testnet networks etc...)
+    let currentChainIds = self.networkService.getNetworks().map(a => a.chainId)
+    let allChainIds = self.networkService.fetchNetworks().map(a => a.chainId)
+    if chainStatusTable.kind != JNull:
+      for id in allChainIds:
+        if chainStatusTable[$id].kind != JNull:
+          let isDown = self.getIsDown(chainStatusTable[$id].getStr)
+          if not isDown:
+            allDown = false
+          if currentChainIds.contains(id):
+            if isDown:
+              chaindIdsDown.add(id)
+    return (allDown, chaindIdsDown)
 
   proc getFormattedStringForChainIds(self: Service, chainIds: seq[int]): string =
     var result: string = ""
@@ -119,9 +158,85 @@ QtObject:
       connectionState: connectionStatus.connectionState,
       chainIds: self.getFormattedStringForChainIds(connectionStatus.chainIds),
       lastCheckedAt: connectionStatus.lastCheckedAt,
-      timeToAutoRetryInSecs: connectionStatus.timeToAutoRetryInSecs,
-      withCache: connectionStatus.withCache
+      timeToAutoRetryInSecs: connectionStatus.timeToAutoRetryInSecs
       )
+
+  proc updateConnectionStatus(self: Service,
+    website: string,
+    connectionState: ConnectionState,
+    completelyDown: bool,
+    chainIds: seq[int],
+    lastCheckedAt: int,
+    timeToAutoRetryInSecs: int
+    ) =
+      if self.connectionStatus.hasKey(website):
+        self.connectionStatus[website].connectionState = connectionState
+        self.connectionStatus[website].completelyDown = completelyDown
+        self.connectionStatus[website].chainIds = chainIds
+        self.connectionStatus[website].lastCheckedAt = lastCheckedAt
+        self.connectionStatus[website].timeToAutoRetryInSecs = timeToAutoRetryInSecs
+
+  proc increaseTimer(self: Service, connectionStatus: ConnectionStatus): int  =
+    var backOffTimer: int = connectionStatus.timeToAutoRetryInSecs
+     # Is down even after retry we need to increase the timer duration
+    if connectionStatus.connectionState == ConnectionState.Retrying:
+      let index = BACKOFF_TIMERS.find(backOffTimer)
+      if index != -1 and index < BACKOFF_TIMERS.len:
+        backOffTimer = BACKOFF_TIMERS[index + 1]
+    return backOffTimer
+
+  proc updateMarketOrCollectibleStatus(self: Service, website: string, isDown: bool, at: int) =
+    if self.connectionStatus.hasKey(website):
+      if isDown:
+        self.updateConnectionStatus(website, ConnectionState.Failed, true, @[], at, self.increaseTimer(self.connectionStatus[website]))
+        # restart timer
+        signalConnect(self.connectionStatus[website].timer, "timeout()", self, website&"Retry()", 2)
+        self.connectionStatus[website].timer.setInterval(self.connectionStatus[website].timeToAutoRetryInSecs*1000)
+        self.connectionStatus[website].timer.start()
+
+        # trigger event
+        self.events.emit(SIGNAL_CONNECTION_UPDATE, self.convertConnectionStatusToNetworkConnectionsArgs(website, self.connectionStatus[website]))
+      else:
+        # site was completely down and is back up now
+        if self.connectionStatus[website].completelyDown:
+          self.connectionStatus[website] = newConnectionStatus()
+          # trigger event
+          self.events.emit(SIGNAL_CONNECTION_UPDATE, self.convertConnectionStatusToNetworkConnectionsArgs(website, self.connectionStatus[website]))
+
+
+  proc updateBlockchainsStatus(self: Service, completelyDown: bool, chaindIdsDown: seq[int], at: int) =
+    if self.connectionStatus.hasKey(BLOCKCHAINS):
+      # if all the networks are down for the BLOCKCHAINS
+      if completelyDown:
+        var backOffTimer: int = self.connectionStatus[BLOCKCHAINS].timeToAutoRetryInSecs
+        if self.connectionStatus[BLOCKCHAINS].completelyDown:
+          backOffTimer = self.increaseTimer(self.connectionStatus[BLOCKCHAINS])
+        self.updateConnectionStatus(BLOCKCHAINS, ConnectionState.Failed, true, chaindIdsDown, at, backOffTimer)
+        # restart timer
+        signalConnect(self.connectionStatus[BLOCKCHAINS].timer, "timeout()", self, BLOCKCHAINS&"Retry()", 2)
+        self.connectionStatus[BLOCKCHAINS].timer.setInterval(self.connectionStatus[BLOCKCHAINS].timeToAutoRetryInSecs*1000)
+        self.connectionStatus[BLOCKCHAINS].timer.start()
+
+        # trigger event
+        self.events.emit(SIGNAL_CONNECTION_UPDATE, self.convertConnectionStatusToNetworkConnectionsArgs(BLOCKCHAINS, self.connectionStatus[BLOCKCHAINS]))
+
+      # if all the networks are not down for the website
+      else:
+        # case where a down website is back up
+        if self.connectionStatus[BLOCKCHAINS].completelyDown or (chaindIdsDown.len == 0 and self.connectionStatus[BLOCKCHAINS].chainIds.len != 0):
+          self.connectionStatus[BLOCKCHAINS] = newConnectionStatus()
+          self.events.emit(SIGNAL_CONNECTION_UPDATE, self.convertConnectionStatusToNetworkConnectionsArgs(BLOCKCHAINS, self.connectionStatus[BLOCKCHAINS]))
+
+        # case where a some of networks on the website are down
+        if chaindIdsDown.len > 0:
+          self.updateConnectionStatus(BLOCKCHAINS, ConnectionState.Failed, false, chaindIdsDown, at, self.increaseTimer(self.connectionStatus[BLOCKCHAINS]))
+          # restart timer
+          signalConnect(self.connectionStatus[BLOCKCHAINS].timer, "timeout()", self, BLOCKCHAINS&"Retry()", 2)
+          self.connectionStatus[BLOCKCHAINS].timer.setInterval(self.connectionStatus[BLOCKCHAINS].timeToAutoRetryInSecs*1000)
+          self.connectionStatus[BLOCKCHAINS].timer.start()
+
+          # trigger event
+          self.events.emit(SIGNAL_CONNECTION_UPDATE, self.convertConnectionStatusToNetworkConnectionsArgs(BLOCKCHAINS, self.connectionStatus[BLOCKCHAINS]))
 
   proc blockchainsRetry*(self: Service) {.slot.} =
     if(self.connectionStatus.hasKey(BLOCKCHAINS)):
@@ -142,124 +257,22 @@ QtObject:
       self.connectionStatus[COLLECTIBLES].timer.stop()
       self.connectionStatus[COLLECTIBLES].connectionState = ConnectionState.Retrying
       self.events.emit(SIGNAL_CONNECTION_UPDATE, self.convertConnectionStatusToNetworkConnectionsArgs(COLLECTIBLES, self.connectionStatus[COLLECTIBLES]))
-      self.events.emit(SIGNAL_REFRESH_COLLECTIBLES, RetryCollectibleArgs(addresses: self.walletService.getAddresses()))
+      self.events.emit(SIGNAL_REFRESH_COLLECTIBLES, Args())
 
-  # needs to be re-written once cache for market, blockchain and collectibles is implemented
-  proc hasCache(self: Service,  website: string): bool =
-      case website:
-        of BLOCKCHAINS:
-          return self.walletService.hasCache()
-        of MARKET:
-          return self.walletService.hasMarketCache()
-        of COLLECTIBLES:
-          return self.collectibleService.areCollectionsLoaded()
-
-  proc checkStatus(self: Service, status: JsonNode, website: string) =
-    var allDown: bool = true
-    var lastCheckedAt: int = 0
-    var chaindIdsDown: seq[int] = @[]
-
-    # checking only for networks currently active (for test net only testnet networks etc...)
-    let currentChainIds = self.networkService.getNetworks().map(a => a.chainId)
-    for chainId, state in status:
-      if state["up"].getBool:
-        allDown = false
-      # only add chains that belong to the test node or not based on current user setting
-      if currentChainIds.contains(chainId.parseInt):
-        lastCheckedAt = state["lastCheckedAt"].getInt
-        if not state["up"].getBool:
-          chaindIdsDown.add(chainId.parseInt)
-
-    if self.connectionStatus.hasKey(website):
-      self.connectionStatus[website].withCache = self.hasCache(website)
-      # if all the networks are down for the website
-      if allDown:
-        if not self.connectionStatus[website].timer.isActive():
-          var backOffTimer: int = self.connectionStatus[website].timeToAutoRetryInSecs
-
-          # if all the networks are down for the website after a retry increment the backoff timer
-          if self.connectionStatus[website].completelyDown and self.connectionStatus[website].connectionState == ConnectionState.Retrying:
-            let index = BACKOFF_TIMERS.find(self.connectionStatus[website].timeToAutoRetryInSecs)
-            if index != -1 and index < BACKOFF_TIMERS.len:
-              backOffTimer = BACKOFF_TIMERS[index + 1]
-
-          self.connectionStatus[website].connectionState = ConnectionState.Failed
-          self.connectionStatus[website].completelyDown = true
-          self.connectionStatus[website].lastCheckedAt = lastCheckedAt
-          self.connectionStatus[website].timeToAutoRetryInSecs = backOffTimer
-          self.connectionStatus[website].chainIds = chaindIdsDown
-          signalConnect(self.connectionStatus[website].timer, "timeout()", self, website&"Retry()", 2)
-          self.connectionStatus[website].timer.setInterval(backOffTimer*1000)
-          self.connectionStatus[website].timer.start()
-
-          self.events.emit(SIGNAL_CONNECTION_UPDATE, self.convertConnectionStatusToNetworkConnectionsArgs(website, self.connectionStatus[website]))
-
-      # if all the networks are not down for the website
-      else:
-        # case where a down website is back up
-        if self.connectionStatus[website].completelyDown or (chaindIdsDown.len == 0 and self.connectionStatus[website].chainIds.len != 0):
-          self.connectionStatus[website] = newConnectionStatus()
-          self.events.emit(SIGNAL_CONNECTION_UPDATE, self.convertConnectionStatusToNetworkConnectionsArgs(website, self.connectionStatus[website]))
-
-        # case where a some of networks on the website are down
-        if chaindIdsDown.len > 0:
-          var backOffTimer: int = self.connectionStatus[website].timeToAutoRetryInSecs
-          if self.connectionStatus[website].connectionState == ConnectionState.Retrying:
-            let index = BACKOFF_TIMERS.find(self.connectionStatus[website].timeToAutoRetryInSecs)
-            if index != -1 and index < BACKOFF_TIMERS.len:
-              backOffTimer = BACKOFF_TIMERS[index + 1]
-
-          self.connectionStatus[website].completelyDown = false
-          self.connectionStatus[website].chainIds = chaindIdsDown
-          self.connectionStatus[website].timeToAutoRetryInSecs = backOffTimer
-          self.connectionStatus[website].connectionState = ConnectionState.Failed
-          self.connectionStatus[website].lastCheckedAt = lastCheckedAt
-          signalConnect(self.connectionStatus[website].timer, "timeout()", self, website&"Retry()", 2)
-          self.connectionStatus[website].timer.setInterval(self.connectionStatus[website].timeToAutoRetryInSecs*1000)
-          self.connectionStatus[website].timer.start()
-
-          self.events.emit(SIGNAL_CONNECTION_UPDATE, self.convertConnectionStatusToNetworkConnectionsArgs(website, self.connectionStatus[website]))
-
-  proc checkMarketStatus(self: Service, status: JsonNode, website: string) =
-    if self.connectionStatus.hasKey(website):
-      self.connectionStatus[website].withCache = self.hasCache(website)
-      if not status["up"].getBool:
-        if not self.connectionStatus[website].timer.isActive():
-          var backOffTimer: int = self.connectionStatus[website].timeToAutoRetryInSecs
-          if self.connectionStatus[website].connectionState == ConnectionState.Retrying:
-            let index = BACKOFF_TIMERS.find(self.connectionStatus[website].timeToAutoRetryInSecs)
-            if index != -1 and index < BACKOFF_TIMERS.len:
-              backOffTimer = BACKOFF_TIMERS[index + 1]
-
-          self.connectionStatus[website].completelyDown = true
-          self.connectionStatus[website].connectionState = ConnectionState.Failed
-          self.connectionStatus[website].timeToAutoRetryInSecs = backOffTimer
-          self.connectionStatus[website].lastCheckedAt = status["lastCheckedAt"].getInt
-          signalConnect(self.connectionStatus[website].timer, "timeout()", self, website&"Retry()", 2)
-          self.connectionStatus[website].timer.setInterval(self.connectionStatus[website].timeToAutoRetryInSecs*1000)
-          self.connectionStatus[website].timer.start()
-          self.events.emit(SIGNAL_CONNECTION_UPDATE,self.convertConnectionStatusToNetworkConnectionsArgs(website, self.connectionStatus[website]))
-      else:
-        # site was completely down and is back up now
-        if self.connectionStatus[website].completelyDown:
-          self.connectionStatus[website] = newConnectionStatus()
-          self.events.emit(SIGNAL_CONNECTION_UPDATE, self.convertConnectionStatusToNetworkConnectionsArgs(website, self.connectionStatus[website]))
-
-  proc checkConnected(self: Service) =
-    try:
-      if self.nodeService.isConnected():
-        let response = backend.checkConnected()
-        self.checkStatus(response.result[BLOCKCHAINS], BLOCKCHAINS)
-        self.checkStatus(response.result[COLLECTIBLES], COLLECTIBLES)
-        self.checkMarketStatus(response.result[MARKET], MARKET)
-    except Exception as e:
-      let errDescription = e.msg
-      error "error: ", errDescription
-      return
-
-  proc networkConnected*(self: Service) =
-    self.walletService.reloadAccountTokens()
-    self.events.emit(SIGNAL_REFRESH_COLLECTIBLES, RetryCollectibleArgs(addresses: self.walletService.getAddresses()))
+  proc networkConnected*(self: Service, connected: bool) =
+    if connected:
+      self.walletService.reloadAccountTokens()
+      self.events.emit(SIGNAL_REFRESH_COLLECTIBLES, Args())
+    else:
+      if(self.connectionStatus.hasKey(BLOCKCHAINS)):
+        self.connectionStatus[BLOCKCHAINS].timer.stop()
+        self.connectionStatus[BLOCKCHAINS] = newConnectionStatus()
+      if(self.connectionStatus.hasKey(MARKET)):
+        self.connectionStatus[MARKET].timer.stop()
+        self.connectionStatus[MARKET] = newConnectionStatus()
+      if(self.connectionStatus.hasKey(COLLECTIBLES)):
+        self.connectionStatus[COLLECTIBLES].timer.stop()
+        self.connectionStatus[COLLECTIBLES] = newConnectionStatus()
 
   proc checkIfConnected*(self: Service, website: string): bool =
     if self.connectionStatus.hasKey(website) and self.connectionStatus[website].completelyDown:

--- a/src/app_service/service/wallet_account/dto.nim
+++ b/src/app_service/service/wallet_account/dto.nim
@@ -21,6 +21,7 @@ type BalanceDto* = object
   balance*: float64
   address*: string
   chainId*: int
+  hasError*: bool
 
 type
   TokenMarketValuesDto* = object
@@ -32,6 +33,7 @@ type
     changePct24hour*: float64
     change24hour*: float64
     price*: float64
+    hasError*: bool
 
 proc newTokenMarketValuesDto*(
   marketCap: float64,
@@ -41,7 +43,8 @@ proc newTokenMarketValuesDto*(
   changePctDay: float64,
   changePct24hour: float64,
   change24hour: float64,
-  price: float64
+  price: float64,
+  hasError: bool
 ): TokenMarketValuesDto =
   return TokenMarketValuesDto(
     marketCap: marketCap,
@@ -52,6 +55,7 @@ proc newTokenMarketValuesDto*(
     changePct24hour: changePct24hour,
     change24hour: change24hour,
     price: price,
+    hasError: hasError,
   )
 
 proc toTokenMarketValuesDto*(jsonObj: JsonNode): TokenMarketValuesDto =
@@ -64,6 +68,7 @@ proc toTokenMarketValuesDto*(jsonObj: JsonNode): TokenMarketValuesDto =
   discard jsonObj.getProp("changePct24hour", result.changePct24hour)
   discard jsonObj.getProp("change24hour", result.change24hour)
   discard jsonObj.getProp("price", result.price)
+  discard jsonObj.getProp("hasError", result.hasError)
 
 type
   WalletTokenDto* = object
@@ -97,6 +102,8 @@ type
     assetsLoading*: bool
     keypairName*: string
     lastUsedDerivationIndex*: int
+    hasBalanceCache*: bool
+    hasMarketValuesCache*: bool
 
 proc newDto*(
   name: string,
@@ -142,6 +149,8 @@ proc toWalletAccountDto*(jsonObj: JsonNode): WalletAccountDto =
   discard jsonObj.getProp("keypair-name", result.keypairName)
   discard jsonObj.getProp("last-used-derivation-index", result.lastUsedDerivationIndex)
   result.assetsLoading = true
+  result.hasBalanceCache = false
+  result.hasMarketValuesCache = false
 
 proc getCurrencyBalance*(self: BalanceDto, currencyPrice: float64): float64 =
   return self.balance * currencyPrice
@@ -206,6 +215,7 @@ proc toBalanceDto*(jsonObj: JsonNode): BalanceDto =
   result.balance = jsonObj{"balance"}.getStr.parseFloat()
   discard jsonObj.getProp("address", result.address)
   discard jsonObj.getProp("chainId", result.chainId)
+  discard jsonObj.getProp("hasError", result.hasError)
 
 proc toWalletTokenDto*(jsonObj: JsonNode): WalletTokenDto =
   result = WalletTokenDto()

--- a/ui/app/AppLayouts/Wallet/panels/WalletHeader.qml
+++ b/ui/app/AppLayouts/Wallet/panels/WalletHeader.qml
@@ -48,7 +48,7 @@ Item {
                 customColor: Theme.palette.baseColor1
                 text: loading ? Constants.dummyText : LocaleUtils.currencyAmountToLocaleString(root.currentAccount.currencyBalance)
                 loading: root.currentAccount.assetsLoading
-                visible: !networkConnectionStore.tokenBalanceNotAvailable
+                visible: !networkConnectionStore.accountBalanceNotAvailable
             }
         }
 

--- a/ui/app/AppLayouts/Wallet/views/LeftTabView.qml
+++ b/ui/app/AppLayouts/Wallet/views/LeftTabView.qml
@@ -114,7 +114,7 @@ Rectangle {
                 font.weight: Font.Medium
                 font.pixelSize: 22
                 loading: RootStore.currentAccount.assetsLoading
-                visible: !networkConnectionStore.tokenBalanceNotAvailable
+                visible: !networkConnectionStore.accountBalanceNotAvailable
             }
 
             StatusFlatRoundButton {
@@ -125,9 +125,9 @@ Rectangle {
                 icon.height: 14
                 icon.name: "tiny/warning"
                 icon.color: Theme.palette.dangerColor1
-                tooltip.text: networkConnectionStore.tokenBalanceNotAvailableText
+                tooltip.text: networkConnectionStore.accountBalanceNotAvailableText
                 tooltip.maxWidth: 200
-                visible: networkConnectionStore.tokenBalanceNotAvailable
+                visible: networkConnectionStore.accountBalanceNotAvailable
             }
 
             StatusBaseText {
@@ -173,9 +173,9 @@ Rectangle {
                 statusListItemTitle.font.weight: Font.Medium
                 color: sensor.containsMouse || highlighted ? Theme.palette.baseColor3 : "transparent"
                 statusListItemSubTitle.loading: model.assetsLoading
-                errorMode: networkConnectionStore.tokenBalanceNotAvailable
+                errorMode: networkConnectionStore.accountBalanceNotAvailable
                 errorIcon.tooltip.maxWidth: 300
-                errorIcon.tooltip.text: networkConnectionStore.tokenBalanceNotAvailableText
+                errorIcon.tooltip.text: networkConnectionStore.accountBalanceNotAvailableText
                 onClicked: {
                     changeSelectedAccount(index)
                     showSavedAddresses = false

--- a/ui/app/AppLayouts/Wallet/views/collectibles/CollectibleView.qml
+++ b/ui/app/AppLayouts/Wallet/views/collectibles/CollectibleView.qml
@@ -47,7 +47,7 @@ Control {
             border.color: Theme.palette.baseColor2
             border.width: 1
             showLoadingIndicator: true
-            color: root.backgroundColor
+            color: root.isLoading ? "transparent": root.backgroundColor
 
             Loader {
                 anchors.fill: parent

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -682,6 +682,7 @@ Item {
                     objectName: "walletBlockchainConnectionBanner"
                     Layout.fillWidth: true
                     websiteDown: Constants.walletConnections.blockchains
+                    withCache: networkConnectionStore.balanceCache
                     text: {
                         switch(connectionState) {
                         case Constants.ConnectionStatus.Success:
@@ -731,6 +732,7 @@ Item {
                     objectName: "walletCollectiblesConnectionBanner"
                     Layout.fillWidth: true
                     websiteDown: Constants.walletConnections.collectibles
+                    withCache: networkConnectionStore.collectiblesCache
                     text: {
                         switch(connectionState) {
                         case Constants.ConnectionStatus.Success:
@@ -757,6 +759,7 @@ Item {
                     objectName: "walletMarketConnectionBanner"
                     Layout.fillWidth: true
                     websiteDown: Constants.walletConnections.market
+                    withCache: networkConnectionStore.marketValuesCache
                     text: {
                         switch(connectionState) {
                         case Constants.ConnectionStatus.Success:

--- a/ui/imports/shared/controls/TokenDelegate.qml
+++ b/ui/imports/shared/controls/TokenDelegate.qml
@@ -31,6 +31,7 @@ StatusListItem {
     subTitle: LocaleUtils.currencyAmountToLocaleString(modelData.enabledNetworkBalance)
     asset.name: modelData.symbol ? Style.png("tokens/" + modelData.symbol) : ""
     asset.isImage: true
+    errorIcon.tooltip.maxWidth: 300
 
     statusListItemTitleIcons.sourceComponent: StatusFlatRoundButton {
         width: 14

--- a/ui/imports/shared/panels/ConnectionWarnings.qml
+++ b/ui/imports/shared/panels/ConnectionWarnings.qml
@@ -37,6 +37,12 @@ ModuleWarning {
             showFor(3000)
     }
 
+    QtObject {
+        id: d
+        property bool isOnline: networkConnectionStore.isOnline
+        onIsOnlineChanged: if(!isOnline) root.hide()
+    }
+
     type: connectionState === Constants.ConnectionStatus.Success ? ModuleWarning.Success : ModuleWarning.Danger
     buttonText: connectionState === Constants.ConnectionStatus.Failure ? qsTr("Retry now") : ""
 
@@ -45,13 +51,12 @@ ModuleWarning {
 
     Connections {
         target: networkConnectionStore.networkConnectionModuleInst
-        function onNetworkConnectionStatusUpdate(website: string, completelyDown: bool, connectionState: int, chainIds: string, lastCheckedAt: int, timeToAutoRetryInSecs: int, withCache: bool)  {
+        function onNetworkConnectionStatusUpdate(website: string, completelyDown: bool, connectionState: int, chainIds: string, lastCheckedAt: int, timeToAutoRetryInSecs: int)  {
             if (website === websiteDown) {
                 root.connectionState = connectionState
                 root.autoTryTimerInSecs = timeToAutoRetryInSecs
                 root.chainIdsDown = chainIds.split(";")
                 root.completelyDown = completelyDown
-                root.withCache = withCache
                 root.lastCheckedAt = LocaleUtils.formatDateTime(new Date(lastCheckedAt*1000))
                 root.updateBanner()
             }

--- a/ui/imports/shared/views/AssetsView.qml
+++ b/ui/imports/shared/views/AssetsView.qml
@@ -71,6 +71,9 @@ Item {
             readonly property string balance: "%1".arg(modelData.enabledNetworkBalance.amount) // Needed for the tests
             errorTooltipText_1: networkConnectionStore.getBlockchainNetworkDownTextForToken(modelData.balances)
             errorTooltipText_2: networkConnectionStore.getMarketNetworkDownText()
+            subTitle: networkConnectionStore.noTokenBalanceAvailable ? "" :  LocaleUtils.currencyAmountToLocaleString(modelData.enabledNetworkBalance)
+            errorMode: networkConnectionStore.noBlockchainConnectionAndNoCache && !networkConnectionStore.noMarketConnectionAndNoCache
+            errorIcon.tooltip.text: networkConnectionStore.noBlockchainConnectionAndNoCacheText
             onClicked: {
                 RootStore.getHistoricalDataForToken(modelData.symbol, RootStore.currencyStore.currentCurrency)
                 d.selectedAssetIndex = index

--- a/ui/imports/utils/Utils.qml
+++ b/ui/imports/utils/Utils.qml
@@ -618,7 +618,7 @@ QtObject {
     function getTimerString(timeInSecs) {
         let result = ""
         const hour = Math.floor(timeInSecs/60/60)
-        const mins = Math.floor(timeInSecs/60)
+        const mins = Math.floor(timeInSecs/60%60)
         const secs = Math.floor(timeInSecs%60)
         if(hour > 0 )
             result += qsTr(" %n hour(s) ", "", hour)


### PR DESCRIPTION
fixes #9833
cherry-pick - https://github.com/status-im/status-desktop/pull/9994

### What does the PR do

The UI now acts on events rather than "check-connected" tick every one min to check status of the blockchain, market, collectibles being up/down,
The user should see error states for instantly now and also if the error is gone more instantly
Ive fixed the timer issue in UI for toast where you would see "2 mins 168 secs"
Fixed the collectibles loading background
Implemented a sort of cache on client side for market values and balances, such that if due to an error in connections to the sites we get a list with empty values we do not update them on the UI.

Note that: Caching for collectibles is being worked on by Dario
also the error we see first time saying opensea is down

### Affected areas

AssetsView, Accounts list and Error toasts

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it


Uploading Screen Recording 2023-03-31 at 11.34.06 AM.mov…