### PR TITLE
feat(CommunityPermissions): Switch to enable/disable 'Who holds' section 

### DIFF
--- a/storybook/pages/CommunityNewPermissionViewPage.qml
+++ b/storybook/pages/CommunityNewPermissionViewPage.qml
@@ -28,6 +28,8 @@ SplitView {
             permissionDuplicated: isPermissionDuplicatedCheckBox.checked
             permissionTypeLimitReached: isLimitReachedCheckBox.checked
 
+            showWhoHoldsSwitch: true
+
             assetsModel: AssetsModel {}
             collectiblesModel: CollectiblesModel {}
             channelsModel: ChannelsModel {}

--- a/storybook/pages/CommunityPermissionsSettingsPanelPage.qml
+++ b/storybook/pages/CommunityPermissionsSettingsPanelPage.qml
@@ -79,6 +79,8 @@ SplitView {
 
             isOwner: isOwnerCheckBox.checked
 
+            showWhoHoldsSwitch: true
+
             onCreatePermissionRequested: {
                 permissionsStoreMock.createPermission(holdings, permissionType,
                                                       isPrivate, channels)

--- a/storybook/pages/StatusGroupBoxPage.qml
+++ b/storybook/pages/StatusGroupBoxPage.qml
@@ -44,6 +44,8 @@ SplitView {
             icon: Style.png("tokens/SNT")
             iconSize: iconSizeSlider.value
 
+            label.enabled: labelEnabledCheckBox.checked
+
             width: undefinedSizeCheckBox.checked ? undefined
                                                  : widthSlider.value
             height: undefinedSizeCheckBox.checked ? undefined
@@ -110,10 +112,19 @@ SplitView {
                     text: "iconSize:"
                 }
 
-                TextField {
-                    id: titleTextEdit
+                RowLayout {
+                    TextField {
+                        id: titleTextEdit
 
-                    text: "Some title goes here"
+                        text: "Some title goes here"
+                    }
+
+                    CheckBox {
+                        id: labelEnabledCheckBox
+
+                        checked: true
+                        text: "label enabled"
+                    }
                 }
             }
         }

--- a/ui/StatusQ/src/StatusQ/Components/StatusGroupBox.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusGroupBox.qml
@@ -41,15 +41,15 @@ GroupBox {
         contentItem: RowLayout {
             spacing: 8
 
-            Image {
+            StatusIcon {
                 sourceSize.width: width || undefined
                 sourceSize.height: height || undefined
-                fillMode: Image.PreserveAspectFit
                 mipmap: true
                 antialiasing: true
                 width: root.iconSize
                 height: width
                 source: root.icon
+                color: enabled ? "transparent" : Theme.palette.baseColor1
             }
 
             StatusBaseText {
@@ -57,7 +57,7 @@ GroupBox {
                 Layout.fillWidth: true
 
                 text: root.title
-                color: Theme.palette.directColor1
+                color: enabled ? Theme.palette.directColor1 : Theme.palette.baseColor1
                 font.pixelSize: 17
 
                 elide: Text.ElideRight

--- a/ui/StatusQ/src/StatusQ/Components/StatusItemSelector.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusItemSelector.qml
@@ -105,6 +105,8 @@ StatusFlowSelector {
     */
     property bool itemsClickable: true
 
+    readonly property alias count: repeater.count
+
     /*!
        \qmlsignal StatusItemSelector::itemClicked
        This signal is emitted when the item is clicked.

--- a/ui/app/AppLayouts/Chat/controls/community/PermissionItem.qml
+++ b/ui/app/AppLayouts/Chat/controls/community/PermissionItem.qml
@@ -89,11 +89,14 @@ Control{
             StatusBaseText {
                 font.pixelSize: d.itemTextPixelSize
                 height: d.flowRowHeight
-                text: qsTr("Anyone who holds")
+                text: holdingsRepeater.count > 0 ? qsTr("Anyone who holds")
+                                                 : qsTr("Anyone")
                 verticalAlignment: Text.AlignVCenter
             }
 
             Repeater {
+                id: holdingsRepeater
+
                 model: root.holdingsListModel
 
                 StatusListItemTag {

--- a/ui/app/AppLayouts/Chat/panels/communities/CommunityPermissionsSettingsPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/CommunityPermissionsSettingsPanel.qml
@@ -23,6 +23,10 @@ SettingsPageLayout {
 
     property int viewWidth: 560 // by design
 
+    // TODO: temporary property, to be removed when no need to hide the switch
+    // in the app
+    property bool showWhoHoldsSwitch: false
+
     signal createPermissionRequested(
         int permissionType, var holdings, var channels, bool isPrivate)
 
@@ -182,6 +186,10 @@ SettingsPageLayout {
 
             permissionType: d.permissionTypeToEdit
             isPrivate: d.isPrivateToEditValue
+            holdingsRequired: selectedHoldingsModel ? selectedHoldingsModel.count > 0
+                                                    : false
+
+            showWhoHoldsSwitch: root.showWhoHoldsSwitch
 
             permissionDuplicated: {
                 // dependencies
@@ -204,6 +212,12 @@ SettingsPageLayout {
                     const permissionType = item.permissionType
 
                     const same = (a, b) => ModelUtils.checkEqualitySet(a, b, ["key"])
+
+                    if (holdings.rowCount() === 0 && dirtyValues.holdingsRequired)
+                        continue
+
+                    if (holdings.rowCount() !== 0 && !dirtyValues.holdingsRequired)
+                        continue
 
                     if (same(dirtyValues.selectedHoldingsModel, holdings)
                             && same(dirtyValues.selectedChannelsModel, channels)
@@ -233,9 +247,11 @@ SettingsPageLayout {
             }
 
             onCreatePermissionClicked: {
-                const holdings = ModelUtils.modelToArray(
-                                   dirtyValues.selectedHoldingsModel,
-                                   ["key", "type", "amount"])
+                const holdings = dirtyValues.holdingsRequired ?
+                                   ModelUtils.modelToArray(
+                                       dirtyValues.selectedHoldingsModel,
+                                       ["key", "type", "amount"])
+                                 : []
 
                 const channels = ModelUtils.modelToArray(
                                    dirtyValues.selectedChannelsModel, ["key"])


### PR DESCRIPTION
### What does the PR do

- adds visual representation of disabled StatusGroupBox's label
- adds switch to "Who holds" selector
- integrates the switch with duplicates detection
- updates dirty state checks
- allows defining permissions without holdings specified

### Affected areas
Community Permissions components

Note: full integration with the app will be done when per-channel permissions are implemented.

<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it


https://user-images.githubusercontent.com/20650004/229830161-ce797bf2-69b8-4a64-88df-f76f2f85294d.mp4


