### PR TITLE
Cherrypick Fix/10063 various collectibles bugs

### DIFF
--- a/src/app/boot/app_controller.nim
+++ b/src/app/boot/app_controller.nim
@@ -180,7 +180,7 @@ proc newAppController*(statusFoundation: StatusFoundation): AppController =
   result.collectibleService = collectible_service.newService(statusFoundation.events, statusFoundation.threadpool, result.networkService)
   result.walletAccountService = wallet_account_service.newService(
     statusFoundation.events, statusFoundation.threadpool, result.settingsService, result.accountsService,
-    result.tokenService, result.networkService, result.collectibleService
+    result.tokenService, result.networkService
   )
   result.messageService = message_service.newService(
     statusFoundation.events, statusFoundation.threadpool, result.contactsService, result.tokenService, result.walletAccountService, result.networkService

--- a/src/app/modules/main/wallet_section/collectibles/io_interface.nim
+++ b/src/app/modules/main/wallet_section/collectibles/io_interface.nim
@@ -37,6 +37,3 @@ method collectiblesModuleDidLoad*(self: AccessInterface) {.base.} =
 
 method currentCollectibleModuleDidLoad*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
-
-method connectionToOpenSea*(self: AccessInterface, connected: bool) {.base.} =
-  raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/wallet_section/collectibles/module.nim
+++ b/src/app/modules/main/wallet_section/collectibles/module.nim
@@ -109,6 +109,8 @@ method onFetchStarted*(self: Module, chainId: int, address: string) =
 method setCollectibles*(self: Module, chainId: int, address: string, data: CollectiblesData) =
   if self.chainId == chainId and self.address == address:
     self.view.setIsFetching(data.isFetching)
+    self.view.setIsError(data.isError)
+
     var newCollectibles = data.collectibles.map(oc => self.ownedCollectibleToItem(oc))
     self.view.setCollectibles(newCollectibles)
     self.view.setAllLoaded(data.allLoaded)
@@ -116,15 +118,17 @@ method setCollectibles*(self: Module, chainId: int, address: string, data: Colle
 method appendCollectibles*(self: Module, chainId: int, address: string, data: CollectiblesData) =
   if self.chainId == chainId and self.address == address:
     self.view.setIsFetching(data.isFetching)
+    self.view.setIsError(data.isError)
 
-    var ownedCollectiblesToAdd = newSeq[OwnedCollectible]()
-    for i in data.collectibles.len - data.lastLoadCount ..< data.collectibles.len:
-      ownedCollectiblesToAdd.add(data.collectibles[i])
+    if not data.isError:
+      var ownedCollectiblesToAdd = newSeq[OwnedCollectible]()
+      for i in data.collectibles.len - data.lastLoadCount ..< data.collectibles.len:
+        ownedCollectiblesToAdd.add(data.collectibles[i])
 
-    let newCollectibles = ownedCollectiblesToAdd.map(oc => self.ownedCollectibleToItem(oc))
+      let newCollectibles = ownedCollectiblesToAdd.map(oc => self.ownedCollectibleToItem(oc))
 
-    self.view.appendCollectibles(newCollectibles)
-    self.view.setAllLoaded(data.allLoaded)
+      self.view.appendCollectibles(newCollectibles)
+      self.view.setAllLoaded(data.allLoaded)
 
 method connectionToOpenSea*(self: Module, connected: bool) =
    self.view.connectionToOpenSea(connected)

--- a/src/app/modules/main/wallet_section/collectibles/module.nim
+++ b/src/app/modules/main/wallet_section/collectibles/module.nim
@@ -108,8 +108,14 @@ method onFetchStarted*(self: Module, chainId: int, address: string) =
 
 method setCollectibles*(self: Module, chainId: int, address: string, data: CollectiblesData) =
   if self.chainId == chainId and self.address == address:
-    self.view.setIsFetching(data.isFetching)
     self.view.setIsError(data.isError)
+
+    if data.isError and not data.anyLoaded:
+      # If fetching failed before being able to get any collectibles info,
+      # show loading animation
+      self.view.setIsFetching(true)
+    else:
+      self.view.setIsFetching(data.isFetching)
 
     var newCollectibles = data.collectibles.map(oc => self.ownedCollectibleToItem(oc))
     self.view.setCollectibles(newCollectibles)
@@ -117,10 +123,16 @@ method setCollectibles*(self: Module, chainId: int, address: string, data: Colle
 
 method appendCollectibles*(self: Module, chainId: int, address: string, data: CollectiblesData) =
   if self.chainId == chainId and self.address == address:
-    self.view.setIsFetching(data.isFetching)
     self.view.setIsError(data.isError)
 
-    if not data.isError:
+    if data.isError and not data.anyLoaded:
+      # If fetching failed before being able to get any collectibles info,
+      # show loading animation
+      self.view.setIsFetching(true)
+    else:
+      self.view.setIsFetching(data.isFetching)
+
+    if data.lastLoadCount > 0:
       var ownedCollectiblesToAdd = newSeq[OwnedCollectible]()
       for i in data.collectibles.len - data.lastLoadCount ..< data.collectibles.len:
         ownedCollectiblesToAdd.add(data.collectibles[i])
@@ -128,7 +140,5 @@ method appendCollectibles*(self: Module, chainId: int, address: string, data: Co
       let newCollectibles = ownedCollectiblesToAdd.map(oc => self.ownedCollectibleToItem(oc))
 
       self.view.appendCollectibles(newCollectibles)
-      self.view.setAllLoaded(data.allLoaded)
 
-method connectionToOpenSea*(self: Module, connected: bool) =
-   self.view.connectionToOpenSea(connected)
+    self.view.setAllLoaded(data.allLoaded)

--- a/src/app/modules/main/wallet_section/collectibles/view.nim
+++ b/src/app/modules/main/wallet_section/collectibles/view.nim
@@ -49,5 +49,3 @@ QtObject:
   proc appendCollectibles*(self: View, collectibles: seq[Item]) =
     self.model.appendItems(collectibles)
 
-  proc connectionToOpenSea*(self: View, connected: bool) =
-    self.model.connectionToOpenSea(connected)

--- a/src/app/modules/main/wallet_section/collectibles/view.nim
+++ b/src/app/modules/main/wallet_section/collectibles/view.nim
@@ -34,6 +34,9 @@ QtObject:
   proc fetchMoreOwnedCollectibles*(self: View) {.slot.} =
     self.delegate.fetchOwnedCollectibles()
 
+  proc setIsError*(self: View, isError: bool) =
+    self.model.setIsError(isError)
+
   proc setIsFetching*(self: View, isFetching: bool) =
     self.model.setIsFetching(isFetching)
 

--- a/src/app/modules/main/wallet_section/current_account/controller.nim
+++ b/src/app/modules/main/wallet_section/current_account/controller.nim
@@ -4,6 +4,7 @@ import ../../../../../app_service/service/wallet_account/service as wallet_accou
 import ../../../../../app_service/service/network/service as network_service
 import ../../../../../app_service/service/token/service as token_service
 import ../../../../../app_service/service/currency/service as currency_service
+import ../../../../../app_service/service/collectible/service as collectible_service
 
 type
   Controller* = ref object of RootObj
@@ -12,6 +13,7 @@ type
     networkService: network_service.Service
     tokenService: token_service.Service
     currencyService: currency_service.Service
+    collectibleService: collectible_service.Service
  
 proc newController*(
   delegate: io_interface.AccessInterface,
@@ -19,6 +21,7 @@ proc newController*(
   networkService: network_service.Service,
   tokenService: token_service.Service,
   currencyService: currency_service.Service,
+  collectibleService: collectible_service.Service,
 ): Controller =
   result = Controller()
   result.delegate = delegate
@@ -26,6 +29,7 @@ proc newController*(
   result.networkService = networkService
   result.tokenService = tokenService
   result.currencyService = currencyService
+  result.collectibleService = collectibleService
 
 proc delete*(self: Controller) =
   discard
@@ -58,4 +62,4 @@ proc getAllMigratedKeyPairs*(self: Controller): seq[KeyPairDto] =
   return self.walletAccountService.getAllMigratedKeyPairs()
 
 proc getHasCollectiblesCache*(self: Controller, address: string): bool  =
-  return self.walletAccountService.getHasCollectiblesCache(address)
+  return self.collectibleService.areCollectionsLoaded(address)

--- a/src/app/modules/main/wallet_section/current_account/module.nim
+++ b/src/app/modules/main/wallet_section/current_account/module.nim
@@ -8,6 +8,7 @@ import ../../../../../app_service/service/wallet_account/service as wallet_accou
 import ../../../../../app_service/service/network/service as network_service
 import ../../../../../app_service/service/node/service as node_service
 import ../../../../../app_service/service/network_connection/service as network_connection
+import ../../../../../app_service/service/collectible/service as collectible_service
 import ../../../shared_models/currency_amount_utils
 import ../../../shared_models/currency_amount
 import ../../../shared_models/token_model as token_model
@@ -43,13 +44,14 @@ proc newModule*(
   networkService: network_service.Service,
   tokenService: token_service.Service,
   currencyService: currency_service.Service,
+  collectibleService: collectible_service.Service,
 ): Module =
   result = Module()
   result.delegate = delegate
   result.events = events
   result.currentAccountIndex = 0
   result.view = newView(result)
-  result.controller = newController(result, walletAccountService, networkService, tokenService, currencyService)
+  result.controller = newController(result, walletAccountService, networkService, tokenService, currencyService, collectibleService)
   result.moduleLoaded = false
 
 method delete*(self: Module) =

--- a/src/app/modules/main/wallet_section/module.nim
+++ b/src/app/modules/main/wallet_section/module.nim
@@ -83,7 +83,7 @@ proc newModule*(
   result.accountsModule = accounts_module.newModule(result, events, walletAccountService, networkService, currencyService)
   result.allTokensModule = all_tokens_module.newModule(result, events, tokenService, walletAccountService)
   result.collectiblesModule = collectibles_module.newModule(result, events, collectibleService, walletAccountService, networkService, nodeService, networkConnectionService)
-  result.currentAccountModule = current_account_module.newModule(result, events, walletAccountService, networkService, tokenService, currencyService)
+  result.currentAccountModule = current_account_module.newModule(result, events, walletAccountService, networkService, tokenService, currencyService, collectibleService)
   result.transactionsModule = transactions_module.newModule(result, events, transactionService, walletAccountService, networkService, currencyService)
   result.savedAddressesModule = saved_addresses_module.newModule(result, events, savedAddressService)
   result.buySellCryptoModule = buy_sell_crypto_module.newModule(result, events, transactionService)

--- a/src/app/modules/startup/controller.nim
+++ b/src/app/modules/startup/controller.nim
@@ -306,8 +306,6 @@ proc getRecoverUsingSeedPhraseWhileLogin*(self: Controller): bool =
   return self.tmpRecoverUsingSeedPhraseWhileLogin
 
 proc cleanTmpData(self: Controller) =
-  self.tmpSelectedLoginAccountKeyUid = ""
-  self.tmpSelectedLoginAccountIsKeycardAccount = false
   self.tmpProfileImageDetails = ProfileImageDetails()
   self.tmpKeychainErrorOccurred = false
   self.setDisplayName("")

--- a/src/app_service/service/collectible/async_tasks.nim
+++ b/src/app_service/service/collectible/async_tasks.nim
@@ -7,19 +7,25 @@ type
 
 const fetchOwnedCollectiblesTaskArg: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[FetchOwnedCollectiblesTaskArg](argEncoded)
-  let output = %* {
-    "chainId": arg.chainId,
-    "address": arg.address,
-    "cursor": arg.cursor,
-    "collectibles": {"assets":nil,"next":"","previous":""}
-  }
   try:
     let response = collectibles.getOpenseaAssetsByOwnerWithCursor(arg.chainId, arg.address, arg.cursor, arg.limit)
-    output["collectibles"] = response.result
+    let output = %* {
+      "chainId": arg.chainId,
+      "address": arg.address,
+      "cursor": arg.cursor,
+      "collectibles": response.result,
+      "error": ""
+    }
+    arg.finish(output)
   except Exception as e:
-    let errDesription = e.msg
-    error "error fetchOwnedCollectiblesTaskArg: ", errDesription
-  arg.finish(output)
+    let output = %* {
+      "chainId": arg.chainId,
+      "address": arg.address,
+      "cursor": arg.cursor,
+      "collectibles": "",
+      "error": e.msg
+    }
+    arg.finish(output)
 
 type
   FetchOwnedCollectiblesFromContractAddressesTaskArg = ref object of QObjectTaskArg
@@ -31,19 +37,25 @@ type
 
 const fetchOwnedCollectiblesFromContractAddressesTaskArg: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[FetchOwnedCollectiblesFromContractAddressesTaskArg](argEncoded)
-  let output = %* {
-    "chainId": arg.chainId,
-    "address": arg.address,
-    "cursor": arg.cursor,
-    "collectibles": ""
-  }
   try:
     let response = collectibles.getOpenseaAssetsByOwnerAndContractAddressWithCursor(arg.chainId, arg.address, arg.contractAddresses, arg.cursor, arg.limit)
-    output["collectibles"] = response.result
+    let output = %* {
+      "chainId": arg.chainId,
+      "address": arg.address,
+      "cursor": arg.cursor,
+      "collectibles": response.result,
+      "error": ""
+    }
+    arg.finish(output)
   except Exception as e:
-    let errDesription = e.msg
-    error "error fetchOwnedCollectiblesFromContractAddressesTaskArg: ", errDesription
-  arg.finish(output)
+    let output = %* {
+      "chainId": arg.chainId,
+      "address": arg.address,
+      "cursor": arg.cursor,
+      "collectibles": "",
+      "error": e.msg
+    }
+    arg.finish(output)
 
 type
   FetchCollectiblesTaskArg = ref object of QObjectTaskArg
@@ -53,14 +65,18 @@ type
 
 const fetchCollectiblesTaskArg: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[FetchCollectiblesTaskArg](argEncoded)
-  let output = %* {
-    "chainId": arg.chainId,
-    "collectibles": ""
-  }
   try:
     let response = collectibles.getOpenseaAssetsByNFTUniqueID(arg.chainId, arg.ids, arg.limit)
-    output["collectibles"] = response.result
+    let output = %* {
+      "chainId": arg.chainId,
+      "collectibles": response.result,
+      "error": ""
+    }
+    arg.finish(output)
   except Exception as e:
-    let errDesription = e.msg
-    error "error fetchCollectiblesTaskArg: ", errDesription
-  arg.finish(output)
+    let output = %* {
+      "chainId": arg.chainId,
+      "collectibles": "",
+      "error": e.msg
+    }
+    arg.finish(output)

--- a/src/app_service/service/collectible/service.nim
+++ b/src/app_service/service/collectible/service.nim
@@ -27,7 +27,7 @@ const SIGNAL_COLLECTIBLES_UPDATED* = "collectiblesUpdated"
 const INVALID_TIMESTAMP* = fromUnix(0)
 
 # Maximum number of owned collectibles to be fetched at a time
-const ownedCollectiblesFetchLimit = 200
+const ownedCollectiblesFetchLimit = 100
 
 type
   OwnedCollectiblesUpdateArgs* = ref object of Args

--- a/src/app_service/service/network_connection/service.nim
+++ b/src/app_service/service/network_connection/service.nim
@@ -108,7 +108,7 @@ QtObject:
         let connectionStatus = self.connectionStatus[BLOCKCHAINS]
         self.updateBlockchainsStatus(connectionStatus.completelyDown, connectionStatus.chainIds, connectionStatus.lastCheckedAt)
 
-    self.events.on(SIGNAL_OWNED_COLLECTIBLES_RESET) do(e:Args):
+    self.events.on(SIGNAL_OWNED_COLLECTIBLES_UPDATE_ERROR) do(e:Args):
       if self.connectionStatus.hasKey(COLLECTIBLES):
         let connectionStatus = self.connectionStatus[COLLECTIBLES]
         self.updateMarketOrCollectibleStatus(COLLECTIBLES, connectionStatus.completelyDown, connectionStatus.lastCheckedAt)

--- a/src/app_service/service/wallet_account/service.nim
+++ b/src/app_service/service/wallet_account/service.nim
@@ -6,7 +6,6 @@ import ../settings/service as settings_service
 import ../accounts/service as accounts_service
 import ../token/service as token_service
 import ../network/service as network_service
-import ../collectible/service as collectible_service
 import ../../common/[account_constants, utils]
 import ../../../app/global/global_singleton
 
@@ -123,7 +122,6 @@ QtObject:
     accountsService: accounts_service.Service
     tokenService: token_service.Service
     networkService: network_service.Service
-    collectibleService: collectible_service.Service
     processedKeyPair: KeyPairDto
     walletAccountsLock: Lock
     walletAccounts {.guard: walletAccountsLock.}: OrderedTable[string, WalletAccountDto]
@@ -146,7 +144,6 @@ QtObject:
     accountsService: accounts_service.Service,
     tokenService: token_service.Service,
     networkService: network_service.Service,
-    collectibleService: collectible_service.Service,
   ): Service =
     new(result, delete)
     result.QObject.setup
@@ -157,7 +154,6 @@ QtObject:
     result.accountsService = accountsService
     result.tokenService = tokenService
     result.networkService = networkService
-    result.collectibleService = collectibleService
     initLock(result.walletAccountsLock)
     withLock result.walletAccountsLock:
       result.walletAccounts = initOrderedTable[string, WalletAccountDto]()
@@ -877,6 +873,3 @@ QtObject:
             totalTokenBalance += token.getTotalBalanceOfSupportedChains()
 
     return totalTokenBalance   
-
-  proc getHasCollectiblesCache*(self: Service, address: string): bool =
-    return self.collectibleService.areCollectionsLoaded(address)


### PR DESCRIPTION
fixes https://github.com/status-im/status-desktop/issues/10063
cherrypicks https://github.com/status-im/status-desktop/pull/10073

### What does the PR do

Fix several issues related to collectibles:

- Properly handle errors when fetching collectibles. There's now an `Error` state, which prevents further fetching until a reset occurs.
- Added missing init, fixing periodic re-fetches
- Reduced chunk size to improve responsiveness
- Fixed loading items on initial fetch
- Made collectibles screen match the design when an error occurs