### PR TITLE
fix(ChatMessagesView): Fixing scroll to message

### DIFF
--- a/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
@@ -65,6 +65,11 @@ Item {
             }
         }
 
+        function goToMessage(messageIndex) {
+            chatLogView.currentIndex = -1
+            chatLogView.currentIndex = messageIndex
+        }
+
         onIsMostRecentMessageInViewportChanged: markAllMessagesReadIfMostRecentMessageIsInViewport()
     }
 
@@ -80,13 +85,12 @@ Item {
         }
 
         function onScrollToMessage(messageIndex) {
-            chatLogView.positionViewAtIndex(messageIndex, ListView.Center)
-            chatLogView.itemAtIndex(messageIndex).startMessageFoundAnimation()
+            d.goToMessage(messageIndex)
         }
 
         function onScrollToFirstUnreadMessage(messageIndex) {
             if (d.isMostRecentMessageInViewport) {
-                onScrollToMessage(messageIndex)
+                d.goToMessage(messageIndex)
             }
         }
     }
@@ -188,8 +192,13 @@ Item {
         anchors.right: parent.right
         spacing: 0
         verticalLayoutDirection: ListView.BottomToTop
-        cacheBuffer: height * 2 // cache 2 screens worth of items
+        cacheBuffer: height > 0 ? height * 2 : 0 // cache 2 screens worth of items
 
+        highlightRangeMode: ListView.ApplyRange
+        highlightMoveDuration: 200
+        preferredHighlightBegin: 0
+        preferredHighlightEnd: chatLogView.height/2
+        
         model: messageStore.messagesModel
 
         onContentYChanged: {
@@ -200,6 +209,12 @@ Item {
         onCountChanged: d.markAllMessagesReadIfMostRecentMessageIsInViewport()
 
         onVisibleChanged: d.markAllMessagesReadIfMostRecentMessageIsInViewport()
+
+        onCurrentItemChanged: {
+            if(currentItem && currentIndex > 0) {
+                currentItem.startMessageFoundAnimation()
+            }
+        }
 
         ScrollBar.vertical: StatusScrollBar {
             visible: chatLogView.visibleArea.heightRatio < 1


### PR DESCRIPTION
### What does the PR do
Closing: https://github.com/status-im/status-desktop/issues/10131

Use Listview [currentIndex](https://doc.qt.io/qt-6/qml-qtquick-listview.html#currentIndex-prop) to scroll to message instead of positionViewAtIndex. The currentIndex implementation can be fine tuned to work with our async delegates with dynamic height.

### Screenshot of functionality (including design for comparison)

https://user-images.githubusercontent.com/47811206/229896629-9c9e5bd5-e292-42e2-af1b-d40caa1d6acc.mov


https://user-images.githubusercontent.com/47811206/229896701-f64ba3f1-1585-4da3-887f-d1d82ef4e802.mov


<!-- screenshot (or gif/video) that demonstrates the functionality, specially important if it's a bug fix. -->
