### PR TITLE
fix(@desktop): only allow dot as decimal separator for user input

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/StatusCard.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusCard.qml
@@ -40,6 +40,12 @@ Rectangle {
     id: root
 
     /*!
+       \qmlproperty var StatusCard::locale
+       This property holds the locale used to interpret the number.
+    */
+    property var locale: Qt.locale()
+
+    /*!
        \qmlproperty string StatusCard::disabledText
        This property is the text to be shown when the card is disabled
     */
@@ -318,6 +324,7 @@ Rectangle {
                     bottom: 0
                     top: root.maxAdvancedValue
                     errorMessage: ""
+                    locale: root.locale
                 }
             ]
             text: root.preCalculatedAdvancedText

--- a/ui/StatusQ/src/StatusQ/Core/LocaleUtils.qml
+++ b/ui/StatusQ/src/StatusQ/Core/LocaleUtils.qml
@@ -6,6 +6,8 @@ import Qt.labs.settings 1.0
 QtObject {
     id: root
 
+    readonly property var userInputLocale: Qt.locale("en_US")
+
     function fractionalPartLength(num) {
         if (Number.isInteger(num))
             return 0

--- a/ui/app/AppLayouts/Chat/controls/community/TokenPanel.qml
+++ b/ui/app/AppLayouts/Chat/controls/community/TokenPanel.qml
@@ -60,6 +60,8 @@ ColumnLayout {
     AmountInput {
         id: amountInput
 
+        locale: LocaleUtils.userInputLocale
+
         Layout.fillWidth: true
         Layout.bottomMargin: (validationError !== "") ? root.spacing : 0
         customHeight: d.defaultHeight

--- a/ui/imports/shared/controls/AmountInput.qml
+++ b/ui/imports/shared/controls/AmountInput.qml
@@ -25,7 +25,7 @@ Input {
                             + textField.leftPadding
 
     function setAmount(amount) {
-        root.text = LocaleUtils.numberToLocaleString(amount)
+        root.text = LocaleUtils.numberToLocaleString(amount, -1, root.locale)
     }
 
     QtObject {
@@ -63,7 +63,7 @@ Input {
             return
         }
 
-        let amount = LocaleUtils.numberFromLocaleString(text)
+        let amount = LocaleUtils.numberFromLocaleString(text, root.locale)
         if (isNaN(amount)) {
             d.amount = 0
             root.validationError = qsTr("Invalid amount format")

--- a/ui/imports/shared/views/AmountToSend.qml
+++ b/ui/imports/shared/views/AmountToSend.qml
@@ -54,8 +54,8 @@ ColumnLayout {
 
     QtObject {
         id: d
-        readonly property string zeroString: LocaleUtils.numberToLocaleString(0, 2)
-        readonly property double inputNumber: LocaleUtils.numberFromLocaleString(topAmountToSendInput.text)
+        readonly property string zeroString: LocaleUtils.numberToLocaleString(0, 2, LocaleUtils.userInputLocale)
+        readonly property double inputNumber: LocaleUtils.numberFromLocaleString(topAmountToSendInput.text, LocaleUtils.userInputLocale)
         property Timer waitTimer: Timer {
             interval: 1000
             onTriggered: reCalculateSuggestedRoute()
@@ -94,6 +94,7 @@ ColumnLayout {
                     bottom: 0
                     top: root.maxInputBalance
                     errorMessage: ""
+                    locale: LocaleUtils.userInputLocale
                 }
             ]
             TextMetrics {
@@ -102,7 +103,7 @@ ColumnLayout {
                 font: topAmountToSendInput.input.placeholder.font
             }
             Keys.onReleased: {
-                const amount = LocaleUtils.numberFromLocaleString(topAmountToSendInput.text)
+                const amount = LocaleUtils.numberFromLocaleString(topAmountToSendInput.text, LocaleUtils.userInputLocale)
                 if (isNaN(amount)) {
                     return
                 }
@@ -131,7 +132,7 @@ ColumnLayout {
             onClicked: {
                 topAmountToSendInput.validate()
                 if(!!topAmountToSendInput.text) {
-                    topAmountToSendInput.text = root.formatCurrencyAmount(bottomItem.bottomAmountToSend, bottomItem.bottomAmountSymbol, {onlyAmount: true})
+                    topAmountToSendInput.text = root.formatCurrencyAmount(bottomItem.bottomAmountToSend, bottomItem.bottomAmountSymbol, {onlyAmount: true}, LocaleUtils.userInputLocale)
                 }
                 inputIsFiat = !inputIsFiat
                 d.waitTimer.restart()

--- a/ui/imports/shared/views/NetworkCardsComponent.qml
+++ b/ui/imports/shared/views/NetworkCardsComponent.qml
@@ -93,13 +93,14 @@ Item {
                 model: root.allNetworks
                 StatusCard {
                     id: fromNetwork
+                    locale: LocaleUtils.userInputLocale
                     objectName: model.chainId
                     property double amountToSend: 0
                     property int routeOnNetwork: 0
                     property bool selectedAssetValid: selectedAccount && selectedAccount !== undefined && selectedAsset !== undefined
                     property double tokenBalanceOnChain: selectedAssetValid ? root.store.getTokenBalanceOnChain(selectedAccount, model.chainId, root.selectedSymbol).amount : 0.0
                     property bool hasGas: selectedAssetValid && requiredGasInEth !== undefined ? selectedAccount.hasGas(model.chainId, model.nativeCurrencySymbol, requiredGasInEth) : false
-                    property double advancedInputCurrencyAmount: selectedAssetValid && advancedInput.valid ? LocaleUtils.numberFromLocaleString(advancedInputText) : 0.0
+                    property double advancedInputCurrencyAmount: selectedAssetValid && advancedInput.valid ? LocaleUtils.numberFromLocaleString(advancedInputText, LocaleUtils.userInputLocale) : 0.0
 
                     primaryText: model.chainName
                     secondaryText: (tokenBalanceOnChain == 0 && root.amountToSend > 0) ?
@@ -110,9 +111,9 @@ Item {
                         let index  = store.lockedInAmounts.findIndex(lockedItem => lockedItem!== undefined && lockedItem.chainID === model.chainId)
                         if(locked && index !== -1) {
                             let amount = root.weiToEth(parseInt(store.lockedInAmounts[index].value, 16))
-                            return LocaleUtils.numberToLocaleString(amount)
+                            return LocaleUtils.numberToLocaleString(amount, -1, LocaleUtils.userInputLocale)
                         }
-                        else return LocaleUtils.numberToLocaleString(fromNetwork.amountToSend)
+                        else return LocaleUtils.numberToLocaleString(fromNetwork.amountToSend, -1, LocaleUtils.userInputLocale)
                     }
                     maxAdvancedValue: tokenBalanceOnChain
                     state: tokenBalanceOnChain === 0 || !hasGas ?
@@ -186,6 +187,7 @@ Item {
                 model: root.allNetworks
                 StatusCard {
                     id: toCard
+                    locale: LocaleUtils.userInputLocale
                     objectName: model.chainId
                     property int routeOnNetwork: 0
                     property int bentLine: 0


### PR DESCRIPTION
Cherrypicks #10169
Fixes #10125

### What does the PR do

Regardless of system locale, use `en_US` locale for user input. That means that `.` is the only accepter decimal separator.


https://user-images.githubusercontent.com/11161531/229835309-1dc9e3ef-6288-4899-bfec-0f78998d1d63.mov
