### PR TITLE
chore/fix: various StatusChatInput fixes and spedups

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/StatusCursorDelegate.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusCursorDelegate.qml
@@ -1,0 +1,22 @@
+import QtQuick 2.15
+
+import StatusQ.Core.Theme 0.1
+
+Rectangle {
+    id: root
+
+    required property bool cursorVisible
+
+    color: Theme.palette.primaryColor1
+    implicitWidth: 2
+    implicitHeight: 22
+    radius: 1
+    visible: cursorVisible
+
+    SequentialAnimation on visible {
+        loops: Animation.Infinite
+        running: root.cursorVisible
+        PropertyAnimation { to: false; duration: Qt.styleHints.cursorFlashTime / 2 }
+        PropertyAnimation { to: true; duration: Qt.styleHints.cursorFlashTime / 2 }
+    }
+}

--- a/ui/StatusQ/src/StatusQ/Components/qmldir
+++ b/ui/StatusQ/src/StatusQ/Components/qmldir
@@ -9,6 +9,7 @@ StatusChatListItem 0.1 StatusChatListItem.qml
 StatusChatListCategory 0.1 StatusChatListCategory.qml
 StatusChatListCategoryItem 0.1 StatusChatListCategoryItem.qml
 StatusChatListAndCategories 0.1 StatusChatListAndCategories.qml
+StatusCursorDelegate 0.1 StatusCursorDelegate.qml
 StatusToolBar 0.1 StatusToolBar.qml
 StatusContactRequestsIndicatorListItem 0.1 StatusContactRequestsIndicatorListItem.qml
 StatusEmoji 0.1 StatusEmoji.qml

--- a/ui/StatusQ/src/StatusQ/Controls/StatusBaseInput.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusBaseInput.qml
@@ -411,19 +411,8 @@ Item {
                             }
                         }
 
-                        cursorDelegate: Rectangle {
-                            color: Theme.palette.primaryColor1
-                            implicitWidth: 2
-                            implicitHeight: 22
-                            radius: 1
-                            visible: edit.cursorVisible
-
-                            SequentialAnimation on visible {
-                                loops: Animation.Infinite
-                                running: edit.cursorVisible
-                                PropertyAnimation { to: false; duration: 600; }
-                                PropertyAnimation { to: true; duration: 600; }
-                            }
+                        cursorDelegate: StatusCursorDelegate {
+                            cursorVisible: edit.cursorVisible
                         }
 
                         StatusBaseText {

--- a/ui/StatusQ/src/StatusQ/Controls/StatusTextArea.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusTextArea.qml
@@ -2,6 +2,7 @@ import QtQuick 2.14
 import QtQuick.Controls 2.14
 
 import StatusQ.Core.Theme 0.1
+import StatusQ.Components 0.1
 
 /*!
       \qmltype StatusTextArea
@@ -74,6 +75,7 @@ TextArea {
     }
 
     selectByMouse: true
+    persistentSelection: true
     wrapMode: TextEdit.WordWrap
 
     activeFocusOnTab: enabled
@@ -94,18 +96,7 @@ TextArea {
         }
     }
 
-    cursorDelegate: Rectangle {
-        color: Theme.palette.primaryColor1
-        implicitWidth: 2
-        implicitHeight: 22
-        radius: 1
-        visible: root.cursorVisible
-
-        SequentialAnimation on visible {
-            loops: Animation.Infinite
-            running: root.cursorVisible
-            PropertyAnimation { to: false; duration: 600 }
-            PropertyAnimation { to: true; duration: 600 }
-        }
+    cursorDelegate: StatusCursorDelegate {
+        cursorVisible: root.cursorVisible
     }
 }

--- a/ui/StatusQ/src/statusq.qrc
+++ b/ui/StatusQ/src/statusq.qrc
@@ -25,6 +25,7 @@
         <file>StatusQ/Components/StatusCommunityTags.qml</file>
         <file>StatusQ/Components/StatusContactRequestsIndicatorListItem.qml</file>
         <file>StatusQ/Components/StatusContactVerificationIcons.qml</file>
+        <file>StatusQ/Components/StatusCursorDelegate.qml</file>
         <file>StatusQ/Components/StatusDatePicker.qml</file>
         <file>StatusQ/Components/StatusDescriptionListItem.qml</file>
         <file>StatusQ/Components/StatusEmoji.qml</file>

--- a/ui/app/AppLayouts/Chat/panels/InlineSelectorPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/InlineSelectorPanel.qml
@@ -5,6 +5,7 @@ import QtGraphicalEffects 1.0
 
 import StatusQ.Core 0.1
 import StatusQ.Controls 0.1
+import StatusQ.Components 0.1
 import StatusQ.Core.Theme 0.1
 import StatusQ.Core.Utils 0.1
 import StatusQ.Popups.Dialog 0.1
@@ -107,17 +108,8 @@ Item {
                                 selectionColor: Theme.palette.primaryColor2
                                 selectedTextColor: color
 
-                                cursorDelegate: Rectangle {
-                                    color: Theme.palette.primaryColor1
-                                    implicitWidth: 2
-                                    radius: 1
-                                    visible: edit.cursorVisible
-                                    SequentialAnimation on visible {
-                                        loops: Animation.Infinite
-                                        running: edit.cursorVisible
-                                        PropertyAnimation { to: false; duration: 600; }
-                                        PropertyAnimation { to: true; duration: 600; }
-                                    }
+                                cursorDelegate: StatusCursorDelegate {
+                                    cursorVisible: edit.cursorVisible
                                 }
 
                                 onTextEdited: if (suggestionsDialog.forceHide && !pasteOperation)

--- a/ui/imports/shared/controls/AmountInputWithCursor.qml
+++ b/ui/imports/shared/controls/AmountInputWithCursor.qml
@@ -10,8 +10,6 @@ import utils 1.0
 StatusInput {
     id: cursorInput
 
-    property string cursorColor: Theme.palette.primaryColor1
-
     leftPadding: 0
     rightPadding: 0
     topPadding: 0
@@ -25,40 +23,4 @@ StatusInput {
     input.edit.padding: 0
     input.background.color: "transparent"
     input.background.border.width: 0
-    // To-do this needs to be removed once https://github.com/status-im/StatusQ/issues/578 is implemented and cursor is moved to StatusInput
-    input.edit.cursorDelegate: Rectangle {
-        id: cursor
-        visible: input.edit.cursorVisible
-        color: cursorColor
-        width: 2
-
-        SequentialAnimation {
-            loops: Animation.Infinite
-            running: input.edit.cursorVisible
-
-            PropertyAction {
-                target: cursor
-                property: 'visible'
-                value: true
-            }
-
-            PauseAnimation {
-                duration: 600
-            }
-
-            PropertyAction {
-                target: cursor
-                property: 'visible'
-                value: false
-            }
-
-            PauseAnimation {
-                duration: 600
-            }
-
-            onStopped: {
-                cursor.visible = false
-            }
-        }
-    }
 }

--- a/ui/imports/shared/panels/ModuleWarning.qml
+++ b/ui/imports/shared/panels/ModuleWarning.qml
@@ -149,6 +149,7 @@ Item {
             Button {
                 id: button
                 visible: text != ""
+                focusPolicy: Qt.NoFocus
                 padding: 5
                 onClicked: {
                     root.clicked()

--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -1493,9 +1493,7 @@ Rectangle {
             visible: control.isContactBlocked
             text: qsTr("Unblock")
             type: StatusQ.StatusBaseButton.Type.Danger
-            onClicked: function (event) {
-                control.unblockChat()
-            }
+            onClicked: control.unblockChat()
         }
     }
 }

--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -1292,14 +1292,16 @@ Rectangle {
 
                             onTextChanged: {
                                 if (length <= control.messageLimit) {
-                                    var symbols = ":='xX><0O;*dB8-D#%\\";
-                                    var symbolIdx = ((cursorPosition > 2) && (symbols.indexOf(getText((cursorPosition - 2), (cursorPosition - 1)))!==-1))
+                                    const symbols = ":='xX><0O;*dB8-D#%\\";
+                                    const symbolIdx = ((cursorPosition > 2) && (symbols.indexOf(getText((cursorPosition - 2), (cursorPosition - 1)))!==-1))
                                                     ? (cursorPosition -1) : (symbols.indexOf(getText(0, 1))!==-1) ? 2 : -1;
                                     if ((getText(symbolIdx-2, (symbolIdx-1)) === " ") || (symbolIdx === 2)) {
+                                        const textBefore1 = getText((symbolIdx-1), (symbolIdx+1))
+                                        const textBefore2 = getText((symbolIdx-2), (symbolIdx+1))
+                                        const has2CharsText = getText((symbolIdx-4), (symbolIdx-2))
                                         const emojis = StatusQUtils.Emoji.emojiJSON.emoji_json.filter(function (emoji) {
-                                            if (emoji.aliases_ascii.includes(getText((symbolIdx-1), (symbolIdx+1))) ||
-                                                emoji.aliases_ascii.includes(getText((symbolIdx-2), (symbolIdx+1)))) {
-                                                var has2Chars = emoji.aliases_ascii.includes(getText((symbolIdx-4), (symbolIdx-2)));
+                                            if (emoji.aliases_ascii.includes(textBefore1) || emoji.aliases_ascii.includes(textBefore2)) {
+                                                const has2Chars = emoji.aliases_ascii.includes(has2CharsText)
                                                 replaceWithEmoji("", getText((symbolIdx - (has2Chars ? 3 : 2)), symbolIdx), emoji.unicode);
                                             }
                                         })
@@ -1308,7 +1310,7 @@ Rectangle {
                                         mentionsPos = [];
                                     }
                                 } else {
-                                    var removeFrom = (cursorPosition < messageLimit) ? cursorWhenPressed : messageLimit;
+                                    const removeFrom = (cursorPosition < messageLimit) ? cursorWhenPressed : messageLimit;
                                     remove(removeFrom, cursorPosition);
                                 }
 

--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -1342,7 +1342,7 @@ Rectangle {
 
                             onEnabledChanged: {
                                 if (!enabled) {
-                                    text = ""
+                                    clear()
                                     control.hideExtendedArea()
                                 }
                             }

--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -1350,19 +1350,8 @@ Rectangle {
                                 }
                             }
 
-                            cursorDelegate: Rectangle {
-                                color: Theme.palette.primaryColor1
-                                implicitWidth: 2
-                                implicitHeight: 22
-                                radius: 1
-                                visible: messageInputField.cursorVisible
-
-                                SequentialAnimation on visible {
-                                    loops: Animation.Infinite
-                                    running: messageInputField.cursorVisible
-                                    PropertyAnimation { to: false; duration: 600; }
-                                    PropertyAnimation { to: true; duration: 600; }
-                                }
+                            cursorDelegate: StatusCursorDelegate {
+                                cursorVisible: messageInputField.cursorVisible
                             }
 
                             StatusSyntaxHighlighter {

--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -1244,7 +1244,7 @@ Rectangle {
                             leftPadding: 0
                             padding: 0
                             Keys.onUpPressed: {
-                                if (isEdit) {
+                                if (isEdit && !activeFocus) {
                                     forceActiveFocus();
                                 } else {
                                     if (messageInputField.length === 0) {
@@ -1254,6 +1254,7 @@ Rectangle {
                                 if (emojiSuggestions.visible) {
                                     emojiSuggestions.listView.decrementCurrentIndex();
                                 }
+                                event.accepted = false
                             }
                             Keys.onPressed: {
                                 keyEvent = event;


### PR DESCRIPTION
### What does the PR do

Fixes several smaller UI and perf issues; see individual commits for explanation, namely:
- fix "Unblock" chat button
- speedup channel switching
- speed up emoji parsing and replacements
- fix handling "up" key event in multiline text
- fix stealing input focus
- extract cursor delegate into StatusCursorDelegate 
- fix inline emoji replacements behavior

### Affected areas

StatusChatInput

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![image](https://user-images.githubusercontent.com/5377645/230113980-6f59eb8f-bc29-4631-b8af-70272bebb46b.png)


