### PR TITLE
fix(CommunityMembersSettings): Add member context menu + fix user click handler

### DIFF
--- a/ui/app/AppLayouts/Chat/panels/communities/CommunityMembersSettingsPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/CommunityMembersSettingsPanel.qml
@@ -21,6 +21,7 @@ SettingsPageLayout {
     property var pendingMemberRequestsModel
     property var declinedMemberRequestsModel
     property string communityName
+    property var communityMemberContextMenu
 
     property bool editable: true
 
@@ -78,6 +79,7 @@ SettingsPageLayout {
 
             CommunityMembersTabPanel {
                 model: root.membersModel
+                communityMemberContextMenu: root.communityMemberContextMenu
                 placeholderText: {
                     if (root.membersModel.count === 0) {
                         return qsTr("No members to search")
@@ -106,6 +108,7 @@ SettingsPageLayout {
 
             CommunityMembersTabPanel {
                 model: root.pendingMemberRequestsModel
+                communityMemberContextMenu: root.communityMemberContextMenu
                 placeholderText: {
                     if (root.pendingMemberRequestsModel.count === 0) {
                         return qsTr("No pending requests to search")
@@ -120,12 +123,14 @@ SettingsPageLayout {
                 Layout.fillWidth: true
                 Layout.fillHeight: true
 
+                onUserProfileClicked: root.userProfileClicked(id)
                 onAcceptRequestToJoin: root.acceptRequestToJoin(id)
                 onDeclineRequestToJoin: root.declineRequestToJoin(id)
             }
 
             CommunityMembersTabPanel {
                 model: root.declinedMemberRequestsModel
+                communityMemberContextMenu: root.communityMemberContextMenu
                 placeholderText: {
                     if (root.declinedMemberRequestsModel.count === 0) {
                         return qsTr("No rejected members to search")
@@ -140,11 +145,13 @@ SettingsPageLayout {
                 Layout.fillWidth: true
                 Layout.fillHeight: true
 
+                onUserProfileClicked: root.userProfileClicked(id)
                 onAcceptRequestToJoin: root.acceptRequestToJoin(id)
             }
 
             CommunityMembersTabPanel {
                 model: root.bannedMembersModel
+                communityMemberContextMenu: root.communityMemberContextMenu
                 placeholderText: {
                     if (root.bannedMembersModel.count === 0) {
                         return qsTr("No banned members to search")

--- a/ui/app/AppLayouts/Chat/panels/communities/CommunityMembersTabPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/CommunityMembersTabPanel.qml
@@ -18,6 +18,7 @@ Item {
 
     property string placeholderText
     property var model
+    property var communityMemberContextMenu
 
     signal userProfileClicked(string id)
     signal kickUserClicked(string id, string name)
@@ -143,7 +144,19 @@ Item {
                 ringSettings.ringSpecModel: model.colorHash
                 statusListItemIcon.badge.visible: (root.panelType === CommunityMembersTabPanel.TabType.AllMembers)
 
-                onClicked: root.userProfileClicked(model.pubKey)
+                onClicked: {
+                    if(mouse.button === Qt.RightButton) {
+                        // Set parent, X & Y positions for the messageContextMenu
+                        root.communityMemberContextMenu.parent = this
+                        root.communityMemberContextMenu.isProfile = true
+                        root.communityMemberContextMenu.selectedUserPublicKey = model.pubKey
+                        root.communityMemberContextMenu.selectedUserDisplayName = userName
+                        root.communityMemberContextMenu.selectedUserIcon = asset.name
+                        root.communityMemberContextMenu.popup()
+                    } else {
+                        root.userProfileClicked(model.pubKey)
+                    }
+                }
             }
         }
     }

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -266,6 +266,10 @@ QtObject {
         return isCurrentUser(pubkey) ? qsTr("You") : name
     }
 
+    function myPubKey() {
+        return userProfileInst.pubKey
+    }
+
     function getCommunity(communityId) {
         // Not Refactored Yet
 //        try {

--- a/ui/app/AppLayouts/Chat/views/CommunitySettingsView.qml
+++ b/ui/app/AppLayouts/Chat/views/CommunitySettingsView.qml
@@ -21,6 +21,7 @@ import StatusQ.Controls.Validators 0.1
 import AppLayouts.Chat.stores 1.0
 
 import shared.stores 1.0
+import shared.views.chat 1.0
 
 import "../panels/communities"
 import "../popups/community"
@@ -235,6 +236,7 @@ StatusSectionLayout {
                 declinedMemberRequestsModel: root.community.declinedMemberRequests
                 editable: root.community.amISectionAdmin
                 communityName: root.community.name
+                communityMemberContextMenu: memberContextMenuView
 
                 onUserProfileClicked: Global.openProfilePopup(id)
                 onKickUserClicked: root.rootStore.removeUserFromCommunity(id)
@@ -393,6 +395,21 @@ StatusSectionLayout {
                 close()
             }
             onClosed: destroy()
+        }
+    }
+
+    MessageContextMenuView {
+        id: memberContextMenuView
+        store: root.rootStore
+        amIChatAdmin: root.rootStore.amIChatAdmin()
+        myPublicKey: root.rootStore.myPublicKey()
+
+        onOpenProfileClicked: {
+            Global.openProfilePopup(publicKey, null)
+        }
+        onCreateOneToOneChat: {
+            Global.changeAppSectionBySectionType(Constants.appSection.chat)
+            root.rootStore.chatCommunitySectionModule.createOneToOneChat(communityId, chatId, ensName)
         }
     }
 


### PR DESCRIPTION
### What does the PR do
Part of https://github.com/status-im/status-desktop/issues/9912

This PR is unifying the user click handling between members list and community members settings:
Left click will open the user profile
Right click will open the context menu

1. Fix left click handler - Open user profile
2. Add context menu on right click (reusing the same one from Members list)
<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas
Community members settings
<!-- List the affected areas (e.g wallet, browser, etc..) -->
### Screenshot of functionality (including design for comparison)

https://user-images.githubusercontent.com/47811206/230408955-76ea5492-819f-49a5-b83f-b222882a6b34.mov

<!-- screenshot (or gif/video) that demonstrates the functionality, specially important if it's a bug fix. -->

