### PR TITLE
fix(Communities): Emit the signal about community tags changes

### DIFF
--- a/src/app/modules/main/communities/view.nim
+++ b/src/app/modules/main/communities/view.nim
@@ -105,8 +105,11 @@ QtObject:
   proc discordImportErrorsCountChanged*(self: View) {.signal.}
   proc communityAccessRequested*(self: View, communityId: string) {.signal.}
 
+  proc communityTagsChanged*(self: View) {.signal.}
+  
   proc setCommunityTags*(self: View, communityTags: string) =
     self.communityTags = newQVariant(communityTags)
+    self.communityTagsChanged()
 
   proc setDiscordOldestMessageTimestamp*(self: View, timestamp: int) {.slot.} =
     if (self.discordOldestMessageTimestamp == timestamp): return
@@ -270,6 +273,7 @@ QtObject:
 
   QtProperty[QVariant] tags:
     read = getTags
+    notify = communityTagsChanged
 
   proc getModel(self: View): QVariant {.slot.} =
     return self.modelVariant


### PR DESCRIPTION
Fixes: #10146

### What does the PR do

The problem was in `setCommunityTags` which change the tags but not notify UI about it. 

### Affected areas

Communities

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

<img width="1199" alt="Снимок экрана 2023-04-06 в 19 06 15" src="https://user-images.githubusercontent.com/82511785/230436699-4e694fa3-6988-4e29-98e0-7a63a8320d12.png">
