### PR TITLE
feat(@desktop/wallet) reduce number of digits shown for large currenc…

### DIFF
--- a/storybook/PagesModel.qml
+++ b/storybook/PagesModel.qml
@@ -46,6 +46,10 @@ ListModel {
          section: "Views"
     }
     ListElement {
+        title: "AmountToSendView"
+        section: "Views"
+    }
+    ListElement {
          title: "StatusCommunityCard"
          section: "Panels"
     }

--- a/storybook/pages/AmountToSendViewPage.qml
+++ b/storybook/pages/AmountToSendViewPage.qml
@@ -1,0 +1,113 @@
+import QtQuick 2.14
+import QtQuick.Controls 2.14
+import QtQuick.Layouts 1.14
+
+import AppLayouts.Profile.views 1.0
+
+import Storybook 1.0
+
+import StatusQ.Core 0.1
+
+import utils 1.0
+import shared.views 1.0
+
+SplitView {
+    id: root
+
+    readonly property double maxCryptoBalance: parseFloat(maxCryptoBalanceText.text)
+    readonly property double rate: parseFloat(rateText.text)
+    readonly property int decimals: parseInt(decimalsText.text)
+
+    Logs { id: logs }
+    
+    SplitView {
+        orientation: Qt.Vertical
+        SplitView.fillWidth: true
+
+        Item {
+            SplitView.fillWidth: true
+            SplitView.fillHeight: true
+
+            AmountToSend {
+                id: amountToSendInput
+                isBridgeTx: false
+                interactive: true
+                selectedSymbol: "Crypto"
+                maxInputBalance: inputIsFiat ? getFiatValue(root.maxCryptoBalance) : root.maxCryptoBalance
+                currentCurrency: "Fiat"
+                getFiatValue: function(cryptoValue) {
+                    return cryptoValue * root.rate
+                }
+                getCryptoValue: function(fiatValue) {
+                    return fiatValue / root.rate
+                }
+                formatCurrencyAmount: function(amount, symbol, options = null, locale = null) {
+                    const currencyAmount = {
+                      amount: amount,
+                      symbol: symbol,
+                      displayDecimals: root.decimals,
+                      stripTrailingZeroes: true
+                    }
+                    return LocaleUtils.currencyAmountToLocaleString(currencyAmount, options)
+                }
+                onReCalculateSuggestedRoute: function() {
+                    logs.logEvent("onReCalculateSuggestedRoute")
+                }
+            }
+        }
+
+        LogsAndControlsPanel {
+            id: logsAndControlsPanel
+
+            SplitView.minimumHeight: 100
+
+            logsView.logText: logs.logText
+        }
+    }
+
+    Pane {
+        SplitView.minimumWidth: 300
+        SplitView.preferredWidth: 300
+
+        ColumnLayout {
+            Label {
+                Layout.topMargin: 10
+                Layout.fillWidth: true
+                text: "Max Crypto Balance"
+            }
+
+            TextField {
+                id: maxCryptoBalanceText
+                background: Rectangle { border.color: 'lightgrey' }
+                Layout.preferredWidth: 200
+                text: "1000000"
+            }
+
+            Label {
+                Layout.topMargin: 10
+                Layout.fillWidth: true
+                text: "Fiat/Crypto rate"
+            }
+
+            TextField {
+                id: rateText
+                background: Rectangle { border.color: 'lightgrey' }
+                Layout.preferredWidth: 200
+                text: "10"
+            }
+
+            Label {
+                Layout.topMargin: 10
+                Layout.fillWidth: true
+                text: "Decimals"
+            }
+
+            TextField {
+                id: decimalsText
+                background: Rectangle { border.color: 'lightgrey' }
+                Layout.preferredWidth: 200
+                text: "6"
+            }
+        }
+    }
+}

--- a/ui/StatusQ/src/StatusQ/Controls/StatusAccountSelector.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusAccountSelector.qml
@@ -239,7 +239,7 @@ Item {
                     id: txtFiatBalance
                     Layout.rightMargin: 4
                     font.pixelSize: 15
-                    text: LocaleUtils.currencyAmountToLocaleString(currencyBalance, {onlyAmount: true})
+                    text: LocaleUtils.currencyAmountToLocaleString(currencyBalance, {noSymbol: true})
                     color: Theme.palette.directColor1
                 }
                 StatusBaseText {

--- a/ui/imports/shared/views/AmountToSend.qml
+++ b/ui/imports/shared/views/AmountToSend.qml
@@ -132,7 +132,7 @@ ColumnLayout {
             onClicked: {
                 topAmountToSendInput.validate()
                 if(!!topAmountToSendInput.text) {
-                    topAmountToSendInput.text = root.formatCurrencyAmount(bottomItem.bottomAmountToSend, bottomItem.bottomAmountSymbol, {onlyAmount: true}, LocaleUtils.userInputLocale)
+                    topAmountToSendInput.text = root.formatCurrencyAmount(bottomItem.bottomAmountToSend, bottomItem.bottomAmountSymbol, {noSymbol: true, rawAmount: true}, LocaleUtils.userInputLocale)
                 }
                 inputIsFiat = !inputIsFiat
                 d.waitTimer.restart()

--- a/ui/imports/shared/views/qmldir
+++ b/ui/imports/shared/views/qmldir
@@ -11,3 +11,4 @@ ProfileDialogView 1.0 ProfileDialogView.qml
 AssetsView 1.0 AssetsView.qml
 HistoryView 1.0 HistoryView.qml
 DeviceSyncingView 1.0 DeviceSyncingView.qml
+AmountToSend 1.0 AmountToSend.qml


### PR DESCRIPTION
…y amounts

Fixes #8917

### What does the PR do

This tries to reduce the number of digits shown for large currency amounts. If the total number of digits between the decimal and integer part is greater than 10, we start removing decimal places one by one. If the integral part takes more than 10 digits (>9.99... billion), we show the number of Billions with 2 decimal places.

https://user-images.githubusercontent.com/11161531/230477687-40db1fc1-b9b7-487c-b6c9-60a9ddbeb1a6.mov


https://user-images.githubusercontent.com/11161531/230483131-14c41e4d-d32e-4ffa-afc6-642c5aadc53e.mov



