### PR TITLE
fix(@desktop/wallet): Wallet: user can click on dummy loading items from activity-history and open an empty transaction view

### DIFF
--- a/src/app/modules/main/wallet_section/accounts/model.nim
+++ b/src/app/modules/main/wallet_section/accounts/model.nim
@@ -152,7 +152,7 @@ QtObject:
         return newQVariant(account.getAssets())
     return nil
 
-  proc getTokenBalanceOnChain1*(self: Model, address: string, chainId: int, tokenSymbol: string): CurrencyAmount =
+  proc getTokenBalanceOnChain*(self: Model, address: string, chainId: int, tokenSymbol: string): CurrencyAmount =
     for account in self.items:
       if(account.getAddress() == address):
         return account.getAssets().getTokenBalanceOnChain(chainId, tokenSymbol)

--- a/src/app/modules/main/wallet_section/accounts/view.nim
+++ b/src/app/modules/main/wallet_section/accounts/view.nim
@@ -187,7 +187,7 @@ QtObject:
     self.tmpSymbol = tokenSymbol
 
   proc getPreparedTokenBalanceOnChain*(self: View): QVariant {.slot.} =
-    let currencyAmount = self.model.getTokenBalanceOnChain1(self.tmpAddress, self.tmpChainId, self.tmpSymbol)
+    let currencyAmount = self.model.getTokenBalanceOnChain(self.tmpAddress, self.tmpChainId, self.tmpSymbol)
     self.tmpAddress = ""
     self.tmpChainId = 0
     self.tmpSymbol = "ERROR"

--- a/ui/imports/shared/controls/LoadingTokenDelegate.qml
+++ b/ui/imports/shared/controls/LoadingTokenDelegate.qml
@@ -25,4 +25,5 @@ TokenDelegate {
     change24Hour.loading: true
     localeCurrencyBalance.loading: true
     textColor: Theme.palette.baseColor1
+    enabled: false
 }

--- a/ui/imports/shared/controls/TransactionDelegate.qml
+++ b/ui/imports/shared/controls/TransactionDelegate.qml
@@ -64,6 +64,7 @@ StatusListItem {
                                                 Utils.compactAddress(modelData.from, 4) :
                                                 ""
     state: "normal"
+    enabled: !loading
     asset.isImage: !loading
     asset.name: root.image
     asset.isLetterIdenticon: loading


### PR DESCRIPTION
fix(@desktop/wallet): Wallet: user can click on dummy loading items from activity-history and open an empty transaction view
fixes #10083

### What does the PR do

Make List items non interactive when loading,for 
1. Assets List
2. Transactions list

### Affected areas

Assets and Transactions view

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it


https://user-images.githubusercontent.com/60327365/230599408-30475912-95b9-4c11-ba55-968a08a44a46.mov


https://user-images.githubusercontent.com/60327365/230599434-79f4e458-0bad-4e5c-bbcc-767a76ebe6ed.mov

