### PR TITLE
feat: Add scrolling velocity and deceleration settings to advanced

### DIFF
--- a/src/app/global/local_app_settings.nim
+++ b/src/app/global/local_app_settings.nim
@@ -9,6 +9,12 @@ const LAS_KEY_THEME* = "global/theme"
 const DEFAULT_THEME = 2 #system theme, from qml
 const LAS_KEY_GEOMETRY = "global/app_geometry"
 const LAS_KEY_VISIBILITY = "global/app_visibility"
+const LAS_KEY_SCROLL_VELOCITY = "global/scroll_velocity"
+const LAS_KEY_SCROLL_DECELERATION = "global/scroll_deceleration"
+const DEFAULT_SCROLL_VELOCITY = 0 # unset
+const DEFAULT_SCROLL_DECELERATION = 0 # unset
+const LAS_KEY_CUSTOM_MOUSE_SCROLLING_ENABLED = "global/custom_mouse_scroll_enabled"
+const DEFAULT_CUSTOM_MOUSE_SCROLLING_ENABLED = false
 const DEFAULT_VISIBILITY = 2 #windowed visibility, from qml
 const LAS_KEY_FAKE_LOADING_SCREEN_ENABLED = "global/fake_loading_screen"
 const DEFAULT_FAKE_LOADING_SCREEN_ENABLED = defined(production) and (not existsEnv(TEST_ENVIRONMENT_VAR)) #enabled in production, disabled in development and e2e tests
@@ -83,6 +89,41 @@ QtObject:
     write = setVisibility
     notify = visibilityChanged
 
+  proc isCustomMouseScrollingEnabledChanged*(self: LocalAppSettings) {.signal.}
+  proc getCustomMouseScrollingEnabled*(self: LocalAppSettings): bool {.slot.} =
+    self.settings.value(LAS_KEY_CUSTOM_MOUSE_SCROLLING_ENABLED, newQVariant(DEFAULT_CUSTOM_MOUSE_SCROLLING_ENABLED)).boolVal
+  proc setCustomMouseScrollingEnabled*(self: LocalAppSettings, value: bool) {.slot.} =
+    self.settings.setValue(LAS_KEY_CUSTOM_MOUSE_SCROLLING_ENABLED, newQVariant(value))
+    self.isCustomMouseScrollingEnabledChanged()
+
+  QtProperty[bool] isCustomMouseScrollingEnabled:
+    read = getCustomMouseScrollingEnabled
+    write = setCustomMouseScrollingEnabled
+    notify = isCustomMouseScrollingEnabledChanged
+
+  proc scrollVelocityChanged*(self: LocalAppSettings) {.signal.}
+  proc getScrollVelocity*(self: LocalAppSettings): int {.slot.} =
+    self.settings.value(LAS_KEY_SCROLL_VELOCITY, newQVariant(DEFAULT_SCROLL_VELOCITY)).intVal
+  proc setScrollVelocity*(self: LocalAppSettings, value: int) {.slot.} =
+    self.settings.setValue(LAS_KEY_SCROLL_VELOCITY, newQVariant(value))
+    self.scrollVelocityChanged()
+
+  QtProperty[int] scrollVelocity:
+    read = getScrollVelocity
+    write = setScrollVelocity
+    notify = scrollVelocityChanged
+
+  proc scrollDecelerationChanged*(self: LocalAppSettings) {.signal.}
+  proc getScrollDeceleration*(self: LocalAppSettings): int {.slot.} =
+    self.settings.value(LAS_KEY_SCROLL_DECELERATION, newQVariant(DEFAULT_SCROLL_DECELERATION)).intVal
+  proc setScrollDeceleration*(self: LocalAppSettings, value: int) {.slot.} =
+    self.settings.setValue(LAS_KEY_SCROLL_DECELERATION, newQVariant(value))
+    self.scrollDecelerationChanged()
+
+  QtProperty[int] scrollDeceleration:
+    read = getScrollDeceleration
+    write = setScrollDeceleration
+    notify = scrollDecelerationChanged
 
   proc removeKey*(self: LocalAppSettings, key: string) =
     if(self.settings.isNil):
@@ -95,6 +136,9 @@ QtObject:
       of LAS_KEY_THEME: self.themeChanged()
       of LAS_KEY_GEOMETRY: self.geometryChanged()
       of LAS_KEY_VISIBILITY: self.visibilityChanged()
+      of LAS_KEY_SCROLL_VELOCITY: self.scrollVelocityChanged()
+      of LAS_KEY_SCROLL_DECELERATION: self.scrollDecelerationChanged()
+      of LAS_KEY_CUSTOM_MOUSE_SCROLLING_ENABLED: self.isCustomMouseScrollingEnabledChanged()
 
 
   proc getTestEnvironment*(self: LocalAppSettings): bool {.slot.} =

--- a/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
@@ -1,4 +1,5 @@
-import QtQuick 2.13
+import QtQuick 2.15
+import QtQml 2.15
 import QtQuick.Controls 2.13
 import QtQuick.Layouts 1.13
 import QtQuick.Dialogs 1.3
@@ -187,6 +188,18 @@ Item {
         highlightMoveDuration: 200
         preferredHighlightBegin: 0
         preferredHighlightEnd: chatLogView.height / 2
+
+        Binding on flickDeceleration {
+            when: localAppSettings.isCustomMouseScrollingEnabled
+            value: localAppSettings.scrollDeceleration
+            restoreMode: Binding.RestoreBindingOrValue
+        }
+
+        Binding on maximumFlickVelocity {
+            when: localAppSettings.isCustomMouseScrollingEnabled
+            value: localAppSettings.scrollVelocity
+            restoreMode: Binding.RestoreBindingOrValue
+        }
 
         model: messageStore.messagesModel
 

--- a/ui/app/AppLayouts/Profile/popups/FleetsModal.qml
+++ b/ui/app/AppLayouts/Profile/popups/FleetsModal.qml
@@ -24,8 +24,6 @@ ModalPopup {
         anchors.bottom: parent.bottom
         anchors.left: parent.left
         anchors.right: parent.right
-        anchors.rightMargin: Style.current.padding
-        anchors.leftMargin: Style.current.padding
 
         spacing: 0
 

--- a/ui/app/AppLayouts/Profile/popups/SearchEngineModal.qml
+++ b/ui/app/AppLayouts/Profile/popups/SearchEngineModal.qml
@@ -20,8 +20,6 @@ ModalPopup {
     Column {
         anchors.left: parent.left
         anchors.right: parent.right
-        anchors.rightMargin: Style.current.padding
-        anchors.leftMargin: Style.current.padding
 
         spacing: 0
 

--- a/ui/app/AppLayouts/Profile/stores/AdvancedStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/AdvancedStore.qml
@@ -38,6 +38,10 @@ QtObject {
         readonly property string communityTokens: "communityTokens"
     }
 
+    readonly property bool isCustomScrollingEnabled: localAppSettings.isCustomMouseScrollingEnabled ?? false
+    readonly property real scrollVelocity: localAppSettings.scrollVelocity
+    readonly property real scrollDeceleration: localAppSettings.scrollDeceleration
+
     function logDir() {
         if(!root.advancedModule)
             return ""
@@ -144,5 +148,26 @@ QtObject {
             return
 
         localAppSettings.fakeLoadingScreenEnabled = !localAppSettings.fakeLoadingScreenEnabled
+    }
+
+    function setCustomScrollingEnabled(value) {
+        if(!localAppSettings)
+            return
+
+        localAppSettings.isCustomMouseScrollingEnabled = value
+    }
+
+    function setScrollVelocity(value) {
+        if(!localAppSettings)
+            return
+
+        localAppSettings.scrollVelocity = value
+    }
+
+    function setScrollDeceleration(value) {
+        if(!localAppSettings)
+            return
+
+        localAppSettings.scrollDeceleration = value
     }
 }

--- a/ui/app/AppLayouts/Profile/views/AdvancedView.qml
+++ b/ui/app/AppLayouts/Profile/views/AdvancedView.qml
@@ -9,6 +9,7 @@ import shared 1.0
 import shared.panels 1.0
 import shared.popups 1.0
 import shared.status 1.0
+import shared.controls 1.0
 
 import StatusQ.Core 0.1
 import StatusQ.Popups 0.1
@@ -47,6 +48,15 @@ SettingsContentBase {
                 text: qsTr("Fleet")
                 currentValue: root.advancedStore.fleet
                 onClicked: fleetModal.open()
+            }
+
+            StatusSettingsLineButton {
+                id: labelScrolling
+                anchors.leftMargin: 0
+                anchors.rightMargin: 0
+                text: qsTr("Chat scrolling")
+                currentValue: root.advancedStore.isCustomScrollingEnabled ? qsTr("Custom") : qsTr("System")
+                onClicked: scrollingModal.open()
             }
 
             // TODO: replace with StatusQ component
@@ -626,6 +636,18 @@ SettingsContentBase {
             onCancelButtonClicked: {
                 close()
             }
+        }
+
+        ScrollingModal {
+            id: scrollingModal
+
+            title: labelScrolling.text
+            initialVelocity: root.advancedStore.scrollVelocity
+            initialDeceleration: root.advancedStore.scrollDeceleration
+            isCustomScrollingEnabled: root.advancedStore.isCustomScrollingEnabled
+            onVelocityChanged: root.advancedStore.setScrollVelocity(value)
+            onDecelerationChanged: root.advancedStore.setScrollDeceleration(value)
+            onCustomScrollingChanged: root.advancedStore.setCustomScrollingEnabled(enabled)
         }
     }
 }

--- a/ui/app/AppLayouts/Profile/views/ScrollingModal.qml
+++ b/ui/app/AppLayouts/Profile/views/ScrollingModal.qml
@@ -1,0 +1,149 @@
+import QtQuick 2.15
+import QtQml 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+import StatusQ.Core 0.1
+import StatusQ.Controls 0.1
+import StatusQ.Components 0.1
+import StatusQ.Popups.Dialog 0.1
+
+import shared.popups 1.0
+import shared.controls 1.0
+
+import utils 1.0
+
+StatusDialog {
+    id: root
+
+    destroyOnClose: false
+
+    property bool isCustomScrollingEnabled: false
+    property real initialVelocity
+    property real initialDeceleration
+
+    signal velocityChanged(real value)
+    signal decelerationChanged(real value)
+    signal customScrollingChanged(bool enabled)
+
+    footer.visible: false
+
+    implicitHeight: 610 // see contentColumn.height's comment
+
+    ColumnLayout {
+        id: contentColumn
+
+        // contentColumn will spread radio buttons evenly across all height if their height
+        // is less than contentColumn's. And we want to maintain dialog's constant height, so
+        // binding it to root's height when custom scrolling
+        height: root.isCustomScrollingEnabled ? parent.implicitHeight : implicitHeight
+        width: parent.width
+
+        spacing: Style.current.padding
+
+        ButtonGroup { id: scrollSettingsGroup }
+
+        RadioButtonSelector {
+            Layout.fillWidth: true
+            title: qsTr("System")
+            buttonGroup: scrollSettingsGroup
+            checked: !root.isCustomScrollingEnabled
+            onClicked: {
+                root.customScrollingChanged(false)
+            }
+        }
+
+        RadioButtonSelector {
+            Layout.fillWidth: true
+            title: qsTr("Custom")
+            buttonGroup: scrollSettingsGroup
+            checked: root.isCustomScrollingEnabled
+            onClicked: {
+                root.customScrollingChanged(true)
+            }
+        }
+
+        ColumnLayout {
+            visible: root.isCustomScrollingEnabled
+
+            spacing: Style.current.padding
+
+            Rectangle {
+                id: scrollSeparator
+
+                Layout.fillWidth: true
+                height: 1
+                color: Style.current.separator
+            }
+
+            StatusBaseText {
+                color: Style.current.secondaryText
+                font.pixelSize: Style.current.secondaryTextFontSize
+                text: qsTr("Velocity")
+            }
+
+            StatusSlider {
+                id: scrollVelocitySlider
+
+                Layout.fillWidth: true
+                from: 0
+                to: 1000
+                stepSize: 1
+                readonly property int scaleFactor: 10
+                value: root.initialVelocity / scaleFactor
+                onMoved: {
+                    root.velocityChanged(value * scaleFactor)
+                }
+            }
+
+            StatusBaseText {
+                color: Style.current.secondaryText
+                font.pixelSize: Style.current.secondaryTextFontSize
+                text: qsTr("Deceleration")
+            }
+
+            StatusSlider {
+                id: scrollDecelerationSlider
+
+                Layout.fillWidth: true
+                from: 0
+                to: 2000
+                stepSize: 1
+                readonly property int scaleFactor: 10
+                value: initialDeceleration / scaleFactor
+                onMoved: {
+                    root.decelerationChanged(value * scaleFactor)
+                }
+            }
+
+            StatusBaseText {
+                color: Style.current.secondaryText
+                font.pixelSize: Style.current.secondaryTextFontSize
+                text: qsTr("Test scrolling")
+            }
+
+            StatusListView {
+                model: 100
+
+                Layout.fillWidth: true
+                Layout.preferredHeight: 170 // Bad, but setting fillHeight instead causes height being 0
+
+                delegate: StatusListItem {
+                    title: modelData
+                }
+
+                Binding on flickDeceleration {
+                    when: root.isCustomScrollingEnabled
+                    value: scrollDecelerationSlider.value * scrollDecelerationSlider.scaleFactor
+                    restoreMode: Binding.RestoreBindingOrValue
+                }
+
+                Binding on maximumFlickVelocity {
+                    when: root.isCustomScrollingEnabled
+                    value: scrollVelocitySlider.value * scrollVelocitySlider.scaleFactor
+                    restoreMode: Binding.RestoreBindingOrValue
+                }
+            }
+        }
+    }
+}

--- a/ui/imports/shared/controls/RadioButtonSelector.qml
+++ b/ui/imports/shared/controls/RadioButtonSelector.qml
@@ -16,13 +16,9 @@ StatusListItem {
     property alias checked: radioButton.checked
 
     implicitHeight: 52
-    anchors.left: parent.left
-    anchors.leftMargin: -Style.current.padding
-    anchors.right: parent.right
-    anchors.rightMargin: -Style.current.padding
 
     onClicked: {
-        radioButton.checked = !radioButton.checked
+        radioButton.checked = true
     }
 
     components: [


### PR DESCRIPTION
settings.

### What does the PR do

- Adds settings to change scrolling velocity and deceleration for (currently only) chat view, because on some devices scrolling is either too slow or too fast.

- Fixed RadioButtonSelector - it was possible to unselect radio button by second click on it, then nothing is selected
- Fixed FleetModal - it was destroyed on close, so it was not possible to open it twice

### Affected areas

- Chat view scrolling speed
- Settings->Advanced->Chat scrolling
- Settings->Advanced->FleetModal (alignment)

https://github.com/status-im/status-desktop/assets/15627093/50aa3ab5-5740-4c3f-b563-45ae0edba0bf

Related to https://github.com/status-im/status-desktop/issues/3353 but fixes only Chat view
