### PR TITLE
fix(os-notifications): Add `Image` text to notifications with image without a text

### DIFF
--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -929,7 +929,9 @@ method onNewMessagesReceived*(self: Module, sectionIdMsgBelongsTo: string, chatI
   let contactDetails = self.controller.getContactDetails(message.`from`)
   let communityChats = self.controller.getCommunityById(chatDetails.communityId).chats
   let renderedMessageText = self.controller.getRenderedText(message.parsedText, communityChats)
-  let plainText = singletonInstance.utils.plainText(renderedMessageText)
+  var plainText = singletonInstance.utils.plainText(renderedMessageText)
+  if ContentType(message.contentType) == ContentType.Image and len(plainText) == 0:
+    plainText = "🖼️"
   var notificationTitle = contactDetails.defaultDisplayName
 
   case chatDetails.chatType:


### PR DESCRIPTION
Fixes: #10162

### What does the PR do

Adds `Image` text to notifications with images when its needed

### Affected areas

OS Notifications

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

![Снимок экрана 2023-04-11 в 15 18 23](https://user-images.githubusercontent.com/82511785/231160908-6c7515c0-1c73-4309-8bb8-bfa2c3c41453.png)

