### PR TITLE
fix(@desktop/communities): show members in spectate mode for open communities and hide for closed communities

### DIFF
--- a/src/app_service/service/community/dto/community.nim
+++ b/src/app_service/service/community/dto/community.nim
@@ -290,9 +290,10 @@ proc toCommunityDto*(jsonObj: JsonNode): CommunityDto =
 
   var membersObj: JsonNode
   if(jsonObj.getProp("members", membersObj) and membersObj.kind == JObject):
+    # Do not show members list in closed communities
+    let joined = result.isMember or result.tokenPermissions.len == 0
     for memberId, memberObj in membersObj:
-      # Do not display members list until the user became a community member
-      result.members.add(toChannelMember(memberObj, memberId, joined = result.isMember))
+      result.members.add(toChannelMember(memberObj, memberId, joined))
 
   var tagsObj: JsonNode
   if(jsonObj.getProp("tags", tagsObj)):

--- a/src/app_service/service/community/service.nim
+++ b/src/app_service/service/community/service.nim
@@ -517,7 +517,7 @@ QtObject:
             self.events.emit(SIGNAL_COMMUNITY_CHANNEL_EDITED, data)
 
       # members list was changed
-      if community.isMember and community.members != prev_community.members:
+      if (community.isMember or community.tokenPermissions.len == 0) and community.members != prev_community.members:
         self.events.emit(SIGNAL_COMMUNITY_MEMBERS_CHANGED, 
         CommunityMembersArgs(communityId: community.id, members: community.members))
 


### PR DESCRIPTION
### What does the PR do

Show members in spectate mode (non-joined communities) for open communities and hide for closed communities

Fixes: #9697

### Affected areas

Members list displaying

