### PR TITLE
Fix badge and category highlight

### DIFF
--- a/src/app_service/service/chat/service.nim
+++ b/src/app_service/service/chat/service.nim
@@ -282,6 +282,8 @@ QtObject:
       return false
 
     for chat in self.channelGroups[communityId].chats:
+      if chat.categoryId != categoryId:
+        continue
       if chat.unviewedMessagesCount > 0 or chat.unviewedMentionsCount > 0:
         return true
     return false


### PR DESCRIPTION
Fixes #10264

First commit fixes the category hightlight on new messages. We didn't correctly check the categoryId, so as soon as a channel has unread messages in the community, it would be bold.

Second commit ups status-go to fix the badge on the left side. The count was done only for personal chats by accident.

status-go PR https://github.com/status-im/status-go/pull/3389