### PR TITLE
perf(ChatLoadingTime): Separate get chat messages and get pinned messages in different tasks

### DIFF
--- a/src/app/modules/main/chat_section/chat_content/controller.nim
+++ b/src/app/modules/main/chat_section/chat_content/controller.nim
@@ -58,8 +58,8 @@ proc delete*(self: Controller) =
   self.events.disconnect()
 
 proc init*(self: Controller) =
-  self.events.on(SIGNAL_MESSAGES_LOADED) do(e:Args):
-    let args = MessagesLoadedArgs(e)
+  self.events.on(SIGNAL_PINNED_MESSAGES_LOADED) do(e:Args):
+    let args = PinnedMessagesLoadedArgs(e)
     if(self.chatId != args.chatId or args.pinnedMessages.len == 0):
       return
     self.delegate.newPinnedMessagesLoaded(args.pinnedMessages)

--- a/src/app/modules/main/chat_section/chat_content/messages/controller.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/controller.nim
@@ -58,7 +58,13 @@ proc init*(self: Controller) =
     let args = MessagesLoadedArgs(e)
     if(self.chatId != args.chatId):
       return
-    self.delegate.newMessagesLoaded(args.messages, args.reactions, args.pinnedMessages)
+    self.delegate.newMessagesLoaded(args.messages, args.reactions)
+
+  self.events.on(SIGNAL_PINNED_MESSAGES_LOADED) do(e:Args):
+    let args = PinnedMessagesLoadedArgs(e)
+    if(self.chatId != args.chatId):
+      return
+    self.delegate.newPinnedMessagesLoaded(args.pinnedMessages)
 
   self.events.on(SIGNAL_NEW_MESSAGE_RECEIVED) do(e: Args):
     var args = MessagesArgs(e)

--- a/src/app/modules/main/chat_section/chat_content/messages/io_interface.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/io_interface.nim
@@ -25,8 +25,10 @@ method updateChatIdentifier*(self: AccessInterface) {.base.} =
 method updateChatFetchMoreMessages*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method newMessagesLoaded*(self: AccessInterface, messages: seq[MessageDto], reactions: seq[ReactionDto],
-  pinnedMessages: seq[PinnedMessageDto]) {.base.} =
+method newMessagesLoaded*(self: AccessInterface, messages: seq[MessageDto], reactions: seq[ReactionDto]) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method newPinnedMessagesLoaded*(self: AccessInterface, pinnedMessages: seq[PinnedMessageDto]) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method onReactionAdded*(self: AccessInterface, messageId: string, emojiId: int, reactionId: string) {.base.} =

--- a/src/app/modules/main/chat_section/chat_content/messages/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/module.nim
@@ -221,8 +221,7 @@ method reevaluateViewLoadingState*(self: Module) =
                        not self.firstUnseenMessageState.initialized or
                        self.firstUnseenMessageState.fetching)
 
-method newMessagesLoaded*(self: Module, messages: seq[MessageDto], reactions: seq[ReactionDto],
-  pinnedMessages: seq[PinnedMessageDto]) =
+method newMessagesLoaded*(self: Module, messages: seq[MessageDto], reactions: seq[ReactionDto]) =
   var viewItems: seq[Item]
 
   if(messages.len > 0):
@@ -327,11 +326,6 @@ method newMessagesLoaded*(self: Module, messages: seq[MessageDto], reactions: se
           else:
             error "wrong emoji id found when loading messages", methodName="newMessagesLoaded"
 
-      for p in pinnedMessages:
-        if(p.message.id == message.id):
-          item.pinned = true
-          item.pinnedBy = p.pinnedBy
-
       if message.editedAt != 0:
         item.isEdited = true
 
@@ -356,6 +350,10 @@ method newMessagesLoaded*(self: Module, messages: seq[MessageDto], reactions: se
 
   self.initialMessagesLoaded = true
   self.reevaluateViewLoadingState()
+
+method newPinnedMessagesLoaded*(self: Module, pinnedMessages: seq[PinnedMessageDto]) =
+  for p in pinnedMessages:
+    self.onPinMessage(p.message.id, p.pinnedBy)
 
 method messagesAdded*(self: Module, messages: seq[MessageDto]) =
   var items: seq[Item]


### PR DESCRIPTION
### What does the PR do
Closing: #10231

The root cause of this issue is that the get chat messages and get pinned messages RPC are bundled in the same async task. Get pinned messages RPC is really heavy and it would delay the get chat messages response.

There are 3 main changes in this PR:
1. Separate get chat messages and get pinned messages calls in two async tasks.
2. Optimise the get pinned messages calls. Now it's called only once when the channel gets initialised.
3. Optimise the get first unseen message calls. Now it's called only once when the channel gets initialised.
<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas
Chat messages
Pinned messages
First unseen message
<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Screenshot of functionality (including design for comparison)

`master` - light theme
this branch - dark theme

1. General channels loading time

https://user-images.githubusercontent.com/47811206/231709228-aee6ee2a-0368-4e8f-b06e-87d121469fb1.mov

2. Fixing an issue where the channel is reloaded when clicking the Community button

https://user-images.githubusercontent.com/47811206/231709591-7da6971a-ef20-42fc-b47a-d1c7046c0b35.mov

<!-- screenshot (or gif/video) that demonstrates the functionality, specially important if it's a bug fix. -->
