### PR TITLE
fix(ActivityCenter): Update status-go ActivityCenterNotificationTypeCommunityKicked and fix accepting community requests from AC

### DIFF
--- a/src/app_service/service/activity_center/service.nim
+++ b/src/app_service/service/activity_center/service.nim
@@ -125,12 +125,15 @@ QtObject:
       if (receivedData.activityCenterNotifications.len > 0):
         self.handleNewNotificationsLoaded(receivedData.activityCenterNotifications)
 
-  proc parseActivityCenterResponse*(self: Service, response: RpcResponse[JsonNode]) =
+  proc parseActivityCenterNotifications*(self: Service, notificationsJson: JsonNode) =
     var activityCenterNotifications: seq[ActivityCenterNotificationDto] = @[]
+    for notificationJson in notificationsJson:
+      activityCenterNotifications.add(notificationJson.toActivityCenterNotificationDto)
+    self.handleNewNotificationsLoaded(activityCenterNotifications)
+
+  proc parseActivityCenterResponse*(self: Service, response: RpcResponse[JsonNode]) =
     if response.result{"activityCenterNotifications"} != nil:
-      for jsonMsg in response.result["activityCenterNotifications"]:
-        activityCenterNotifications.add(jsonMsg.toActivityCenterNotificationDto)
-      self.handleNewNotificationsLoaded(activityCenterNotifications)
+      self.parseActivityCenterNotifications(response.result["activityCenterNotifications"])
 
   proc setActiveNotificationGroup*(self: Service, group: ActivityCenterGroup) =
     self.activeGroup = group

--- a/src/app_service/service/community/service.nim
+++ b/src/app_service/service/community/service.nim
@@ -1367,6 +1367,7 @@ QtObject:
 
       self.events.emit(SIGNAL_COMMUNITY_EDITED, CommunityArgs(community: self.communities[communityId]))
       self.events.emit(SIGNAL_COMMUNITY_MEMBER_APPROVED, CommunityMemberArgs(communityId: communityId, pubKey: userKey, requestId: requestId))
+      self.activityCenterService.parseActivityCenterNotifications(rpcResponseObj["response"]["result"]["activityCenterNotifications"])
 
     except Exception as e:
       let errMsg = e.msg


### PR DESCRIPTION
Close #9811
Depends https://github.com/status-im/status-go/pull/3390

### What does the PR do

Right user gets the notification about kicking from community

### Affected areas

Activity Center, Communities

### Screenshot of functionality (including design for comparison)

<img width="586" alt="Screenshot 2023-04-13 at 14 06 32" src="https://user-images.githubusercontent.com/2522130/231726942-c711af39-9e2f-4ebe-b601-89f01bbbf719.png">

