### PR TITLE
Fix/10275/loading state for chats in memory

### DIFF
--- a/src/app/modules/main/chat_section/chat_content/messages/io_interface.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/io_interface.nim
@@ -153,6 +153,9 @@ method resendChatMessage*(self: AccessInterface, messageId: string): string =
 method resetNewMessagesMarker*(self: AccessInterface) =
   raise newException(ValueError, "No implementation available")
 
+method removeNewMessagesMarker*(self: AccessInterface) =
+  raise newException(ValueError, "No implementation available")
+
 method resetAndScrollToNewMessagesMarker*(self: AccessInterface) =
   raise newException(ValueError, "No implementation available")
 
@@ -163,4 +166,10 @@ method updateCommunityDetails*(self: AccessInterface, community: CommunityDto) =
   raise newException(ValueError, "No implementation available")
 
 method onFirstUnseenMessageLoaded*(self: AccessInterface, messageId: string) =
+  raise newException(ValueError, "No implementation available")
+
+method isFirstUnseenMessageInitialized*(self: AccessInterface): bool =
+  raise newException(ValueError, "No implementation available")
+
+method reevaluateViewLoadingState*(self: AccessInterface) =
   raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/chat_section/chat_content/messages/view.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/view.nim
@@ -10,14 +10,13 @@ QtObject:
       delegate: io_interface.AccessInterface
       model: Model
       modelVariant: QVariant
-      initialMessagesLoaded: bool
       messageSearchOngoing: bool
       amIChatAdmin: bool
       isPinMessageAllowedForMembers: bool
       chatColor: string
       chatIcon: string
       chatType: int
-      firstUnseenMessageLoaded: bool
+      loading: bool
 
   proc delete*(self: View) =
     self.model.delete
@@ -30,14 +29,13 @@ QtObject:
     result.delegate = delegate
     result.model = newModel()
     result.modelVariant = newQVariant(result.model)
-    result.initialMessagesLoaded = false
     result.messageSearchOngoing = false
     result.amIChatAdmin = false
     result.isPinMessageAllowedForMembers = false
     result.chatColor = ""
     result.chatIcon = ""
     result.chatType = ChatType.Unknown.int
-
+    result.loading = false
 
   proc load*(self: View) =
     self.delegate.viewDidLoad()
@@ -79,21 +77,6 @@ QtObject:
 
   proc getNumberOfPinnedMessages*(self: View): int {.slot.} =
     return self.delegate.getNumberOfPinnedMessages()
-
-  proc initialMessagesLoadedChanged*(self: View) {.signal.}
-
-  proc getInitialMessagesLoaded(self: View): bool {.slot.} =
-    return self.initialMessagesLoaded
-
-  QtProperty[bool] initialMessagesLoaded:
-    read = getInitialMessagesLoaded
-    notify = initialMessagesLoadedChanged
-
-  proc initialMessagesAreLoaded*(self: View) = # this is not a slot
-    if (self.initialMessagesLoaded):
-      return
-    self.initialMessagesLoaded = true
-    self.initialMessagesLoadedChanged()
 
   proc loadMoreMessages*(self: View) {.slot.} =
     self.delegate.loadMoreMessages()
@@ -236,13 +219,13 @@ QtObject:
     self.chatType = value
     self.chatTypeChanged()
 
-  proc firstUnseenMessageLoadedChanged*(self: View) {.signal.}
-  proc getFirstUnseenMessageLoaded*(self: View): bool {.slot.} =
-    return self.firstUnseenMessageLoaded
-  proc setFirstUnseenMessageLoaded*(self: View, value: bool) =
-    self.firstUnseenMessageLoaded = value
-    self.firstUnseenMessageLoadedChanged()
+  proc loadingChanged*(self: View) {.signal.}
+  proc isLoading*(self: View): bool {.slot.} =
+    return self.loading
+  proc setLoading*(self: View, value: bool) =
+    self.loading = value
+    self.loadingChanged()
   
-  QtProperty[bool] firstUnseenMessageLoaded:
-    read = getFirstUnseenMessageLoaded
-    notify = firstUnseenMessageLoadedChanged
+  QtProperty[bool] loading:
+    read = isLoading
+    notify = loadingChanged

--- a/src/app/modules/main/chat_section/chat_content/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/module.nim
@@ -387,8 +387,16 @@ method contactTrustStatusChanged*(self: Module, publicKey: string, isUntrustwort
   self.view.updateTrustStatus(isUntrustworthy)
 
 method onMadeActive*(self: Module) =
-  self.messagesModule.resetAndScrollToNewMessagesMarker()
+  # The new messages marker is reset each time the chat is made active,
+  # as messages may arrive out of order and relying on the previous
+  # new messages marker could yield incorrect results.
+  if not self.messagesModule.isFirstUnseenMessageInitialized() or
+     self.controller.getChatDetails().unviewedMessagesCount > 0:
+    self.messagesModule.resetAndScrollToNewMessagesMarker()
+  self.messagesModule.reevaluateViewLoadingState()
   self.view.setActive()
 
 method onMadeInactive*(self: Module) =
+  if self.controller.getChatDetails().unviewedMessagesCount == 0:
+    self.messagesModule.removeNewMessagesMarker()
   self.view.setInactive()

--- a/ui/app/AppLayouts/Chat/stores/MessageStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/MessageStore.qml
@@ -11,8 +11,7 @@ QtObject {
     readonly property bool loadingHistoryMessagesInProgress: root.chatSectionModule? root.chatSectionModule.loadingHistoryMessagesInProgress : false
     readonly property int newMessagesCount: messagesModel ? messagesModel.newMessagesCount : 0
     readonly property bool messageSearchOngoing: messageModule ? messageModule.messageSearchOngoing : false
-    readonly property bool initialMessagesLoaded: messageModule ? messageModule.initialMessagesLoaded : false
-    readonly property bool firstUnseenMessageLoaded: messageModule ? messageModule.firstUnseenMessageLoaded : false
+    readonly property bool loading: messageModule ? messageModule.loading : false
 
     readonly property bool amIChatAdmin: messageModule ? messageModule.amIChatAdmin : false
     readonly property bool isPinMessageAllowedForMembers: messageModule ? messageModule.isPinMessageAllowedForMembers : false
@@ -31,7 +30,7 @@ QtObject {
         if(!messageModule)
             return
 
-        if(!messageModule.initialMessagesLoaded)
+        if(root.loading)
             return
 
         messageModule.loadMoreMessages()

--- a/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
@@ -59,8 +59,7 @@ Item {
                 return
             }
 
-            if (chatDetails && chatDetails.active && chatDetails.hasUnreadMessages &&
-                !messageStore.messageSearchOngoing && messageStore.firstUnseenMessageLoaded) {
+            if (chatDetails && chatDetails.active && chatDetails.hasUnreadMessages && !messageStore.loading) {
                 chatContentModule.markAllMessagesRead()
             }
         }
@@ -96,7 +95,7 @@ Item {
             d.markAllMessagesReadIfMostRecentMessageIsInViewport()
         }
 
-        function onFirstUnseenMessageLoadedChanged() {
+        function onLoadingChanged() {
             d.markAllMessagesReadIfMostRecentMessageIsInViewport()
         }
     }
@@ -116,11 +115,7 @@ Item {
 
             // HACK: we call `addNewMessagesMarker` later because messages model
             // may not be yet propagated with unread messages when this signal is emitted
-            if (chatLogView.visible) {
-                if (!d.isMostRecentMessageInViewport) {
-                    Qt.callLater(() => messageStore.addNewMessagesMarker())
-                }
-            } else {
+            if (chatLogView.visible && !d.isMostRecentMessageInViewport) {
                 Qt.callLater(() => messageStore.addNewMessagesMarker())
             }
         }
@@ -161,19 +156,17 @@ Item {
     Loader {
         id: loadingMessagesView
 
-        readonly property bool show: !messageStore.firstUnseenMessageLoaded ||
-                                     !messageStore.initialMessagesLoaded
-        active: show
-        visible: show
         anchors.top: loadingMessagesIndicator.bottom
         anchors.bottom: parent.bottom
         anchors.left: parent.left
         anchors.right: parent.right
-        sourceComponent:
-            MessagesLoadingView {
+
+        active: messageStore.loading
+        visible: active
+        sourceComponent: MessagesLoadingView {
             anchors.margins: 16
             anchors.fill: parent
-            }
+        }
     }
 
     StatusListView {
@@ -205,7 +198,7 @@ Item {
 
             // after inilial messages are loaded
             // load as much messages as the view requires
-            if (messageStore.initialMessagesLoaded) {
+            if (!messageStore.loading) {
                 d.loadMoreMessagesIfScrollBelowThreshold()
             }
         }


### PR DESCRIPTION
### What does the PR do

- [fix(chat): better integrate new messages marker with loading state](https://github.com/status-im/status-desktop/commit/611637932a2bbab80c292357ade5802554a176e6) 

  - new messages marker is reevaluated only if chat has unviewed messages
  - loading state is reevaluated only when chat is made active, this fixes
  case described here:
https://github.com/status-im/status-desktop/pull/10151#discussion_r1158702638

  fixes: https://github.com/status-im/status-desktop/issues/10275

- [simulate long first unseen message loading](https://github.com/status-im/status-desktop/commit/eb2b1d708c9aebb9d2749ae526613f8333d7bacd) 

  !TO BE REVERTED BEFORE MERGE!

### Affected areas

- loading messages state
- new messages marker

### Video of functionality

https://user-images.githubusercontent.com/33099791/232008391-bfd0a7e2-3023-481a-bd1c-d5bd87462914.mp4

### Notes
**It will still show a loading state when switching to chats with unread messages.** Justification: https://github.com/status-im/status-desktop/blob/eb2b1d708c9aebb9d2749ae526613f8333d7bacd/src/app/modules/main/chat_section/chat_content/module.nim#L390-L392