### PR TITLE
ci: add suite and tags parameters to e2e CI job

### DIFF
--- a/ci/Jenkinsfile.tests-e2e
+++ b/ci/Jenkinsfile.tests-e2e
@@ -14,6 +14,16 @@ pipeline {
       description: 'Decides whether binaries are built with debug symbols.',
       defaultValue: params.RELEASE ?: false
     )
+    string(
+      name: 'SQUISH_SUITE',
+      description: 'Name of test suite to run in Squish. Defaults to all.',
+      defaultValue: '*'
+    )
+    string(
+      name: 'SQUISH_TAGS',
+      description: 'List of tags to use for Squish tests separated by spaces.',
+      defaultValue: '~mayfail ~merge ~relyon-mailserver'
+    )
     choice(
       name: 'VERBOSE',
       description: 'Level of verbosity based on nimbus-build-system setup.',
@@ -124,6 +134,11 @@ pipeline {
         throttle(categories: ['status-desktop-e2e-tests'])
       }
       steps { script {
+        /* Combine specified tags with --tags flag for each. */
+        def tags = params.SQUISH_TAGS.split(' ')
+        def flags = Collections.nCopies(tags.size(), "--tags")
+        def tagsFlags = [flags, tags].transpose().flatten()
+
         wrap([
           $class: 'Xvfb',
           autoDisplayName: true,
@@ -131,16 +146,13 @@ pipeline {
           screen: '2560x1440x24',
         ]) { script {
           def result = squish([
-            extraOptions: [
+            extraOptions: (tagsFlags + [
               '--retry', '2',
-              '--tags', '~mayfail',
-              '--tags', '~merge',
-              '--tags', '~relyon-mailserver',
               '--config', 'addAUT', 'nim_status_client',
               "${WORKSPACE}/bin",
-            ].join('\n'),
+            ]).join('\n'),
             squishPackageName: 'squish-7.1-20230222-1555-qt515x-linux64',
-            testSuite: "${WORKSPACE}/test/ui-test/testSuites/*",
+            testSuite: "${WORKSPACE}/test/ui-test/testSuites/${params.SQUISH_SUITE}",
           ])
           print("Squish run result: ${result}")
           if (!['SUCCESS'].contains(result)) {


### PR DESCRIPTION
Allows for easier running of individual test suites and selecting tags.

![image](https://user-images.githubusercontent.com/2212681/232039280-7269add0-c7e3-4dfb-99dc-b1e1d36fbd14.png)