### PR TITLE
ci: run e2e tests for release and master builds

### DIFF
--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -10,7 +10,7 @@ pipeline {
     timeout(time: 60, unit: 'MINUTES')
     /* Limit builds retained */
     buildDiscarder(logRotator(
-      numToKeepStr: '10',
+      numToKeepStr: '30',
       daysToKeepStr: '30',
       artifactNumToKeepStr: '10',
     ))
@@ -27,17 +27,20 @@ pipeline {
   stages {
     stage('Build') {
       parallel {
+        stage('Linux/E2E') { steps { script {
+          linux_e2e = jenkins.Build('status-desktop/systems/linux/x86_64/tests-e2e')
+        } } }
         stage('Linux/x86_64') { steps { script {
-          linux_x86_64 = jenkins.Build('status-desktop/platforms/linux/x86_64')
+          linux_x86_64 = jenkins.Build('status-desktop/systems/linux/x86_64/package')
         } } }
         stage('Windows/x86_64') { steps { script {
-          windows_x86_64 = jenkins.Build('status-desktop/platforms/windows/x86_64')
+          windows_x86_64 = jenkins.Build('status-desktop/systems/windows/x86_64/package')
         } } }
         stage('MacOS/x86_64') { steps { script {
-          macos_x86_64 = jenkins.Build('status-desktop/platforms/macos/x86_64')
+          macos_x86_64 = jenkins.Build('status-desktop/systems/macos/x86_64/package')
         } } }
         stage('MacOS/aarch64') { steps { script {
-          macos_aarch64 = jenkins.Build('status-desktop/platforms/macos/aarch64')
+          macos_aarch64 = jenkins.Build('status-desktop/systems/macos/aarch64/package')
         } } }
       }
     }

--- a/ci/Jenkinsfile.e2e
+++ b/ci/Jenkinsfile.e2e
@@ -1,1 +1,0 @@
-Jenkinsfile.tests-e2e

--- a/ci/Jenkinsfile.imports
+++ b/ci/Jenkinsfile.imports
@@ -1,1 +1,0 @@
-Jenkinsfile.tests-imports

--- a/ci/Jenkinsfile.tests-e2e
+++ b/ci/Jenkinsfile.tests-e2e
@@ -36,7 +36,7 @@ pipeline {
       throttleEnabled: true,
       throttleOption: 'category',
       maxConcurrentPerNode: 1,
-      maxConcurrentTotal: 10
+      maxConcurrentTotal: 9
     )
     /* Abort old PR builds. */
     disableConcurrentBuilds(


### PR DESCRIPTION
Useful for tracking down which commit introduced a breaking change.

I'm lowering `maxConcurrentTotal` limit for e2e parallel build since the release builds on `ci.infra.status.im` do not share the same throttling limits across Jenkins instances, so we can hit a licenses usage limit.

Also increasing number of builds to keep to 30.