### PR TITLE
fix(ActivityCenter): Fix displaying mention as a tag in AC

### DIFF
--- a/ui/imports/shared/views/chat/SimplifiedMessageView.qml
+++ b/ui/imports/shared/views/chat/SimplifiedMessageView.qml
@@ -70,7 +70,7 @@ RowLayout {
             Layout.fillWidth: true
 
             StatusBaseText {
-                text: CoreUtils.Utils.stripHtmlTags(root.messageDetails.messageText)
+                text: root.messageDetails.messageText
                 maximumLineCount: root.maximumLineCount
                 wrapMode: Text.Wrap
                 elide: Text.ElideRight


### PR DESCRIPTION
Close #10297

### What does the PR do

Remove stripping html tags from base AC message

### Affected areas

Activity Center

### Screenshot of functionality (including design for comparison)

<img width="535" alt="Screenshot 2023-04-14 at 16 57 13" src="https://user-images.githubusercontent.com/2522130/232050030-10c76cc9-926e-42fa-ab66-90292c992b20.png">
