### PR TITLE
fix(category): fix category highlight calculation

### DIFF
--- a/src/app/modules/main/chat_section/controller.nim
+++ b/src/app/modules/main/chat_section/controller.nim
@@ -152,7 +152,7 @@ proc init*(self: Controller) =
         (not self.isCommunitySection and chat.communityId != "")):
       return
     self.chatService.updateUnreadMessagesAndMentions(args.chatId, args.allMessagesMarked, args.messagesCount, args.messagesWithMentionsCount)
-    self.delegate.updateUnreadMessagesAndMentions(args.chatId)
+    self.delegate.onMarkAllMessagesRead(chat)
 
   self.events.on(chat_service.SIGNAL_CHAT_LEFT) do(e: Args):
     let args = chat_service.ChatArgs(e)
@@ -217,7 +217,7 @@ proc init*(self: Controller) =
     self.events.on(SIGNAL_COMMUNITY_CATEGORY_CREATED) do(e:Args):
       let args = CommunityCategoryArgs(e)
       if (args.communityId == self.sectionId):
-        self.delegate.onCommunityCategoryCreated(args.category, args.chats)
+        self.delegate.onCommunityCategoryCreated(args.category, args.chats, args.communityId)
 
     self.events.on(SIGNAL_COMMUNITY_CATEGORY_DELETED) do(e:Args):
       let args = CommunityCategoryArgs(e)

--- a/src/app/modules/main/chat_section/io_interface.nim
+++ b/src/app/modules/main/chat_section/io_interface.nim
@@ -111,7 +111,7 @@ method onChatMuted*(self: AccessInterface, chatId: string) {.base.} =
 method onChatUnmuted*(self: AccessInterface, chatId: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method updateUnreadMessagesAndMentions*(self: AccessInterface, chatId: string) {.base.} =
+method onMarkAllMessagesRead*(self: AccessInterface, chat: ChatDto) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method onContactAdded*(self: AccessInterface, publicKey: string) {.base.} =
@@ -147,7 +147,7 @@ method onReorderChat*(self: AccessInterface, chattId: string, position: int, new
 method onReorderCategory*(self: AccessInterface, catId: string, position: int) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method onCommunityCategoryCreated*(self: AccessInterface, category: Category, chats: seq[ChatDto]) {.base.} =
+method onCommunityCategoryCreated*(self: AccessInterface, category: Category, chats: seq[ChatDto], communityId: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method onCommunityCategoryDeleted*(self: AccessInterface, category: Category, chats: seq[ChatDto]) {.base.} =

--- a/src/app_service/service/chat/service.nim
+++ b/src/app_service/service/chat/service.nim
@@ -306,6 +306,8 @@ QtObject:
     # status-go doesn't seem to preserve categoryIDs from chat
     # objects received via new messages. So we rely on what we
     # have in memory.
+    if chat.id == "":
+      return
     var categoryId = ""
     if self.chats.hasKey(chat.id):
       categoryId = self.chats[chat.id].categoryId
@@ -322,9 +324,9 @@ QtObject:
 
     let index = self.getChatIndex(channelGroupId, chat.id)
     if (index == -1):
-      self.channelGroups[channelGroupId].chats.add(chat)
+      self.channelGroups[channelGroupId].chats.add(self.chats[chat.id])
     else:
-      self.channelGroups[channelGroupId].chats[index] = chat
+      self.channelGroups[channelGroupId].chats[index] = self.chats[chat.id]
 
   proc updateOrAddChannelGroup*(self: Service, channelGroup: ChannelGroupDto) =
     self.channelGroups[channelGroup.id] = channelGroup


### PR DESCRIPTION
Fixes #10313

There were a couple of small issues.
First, we didn't call the function to calculate the highlight on new messages. Secondly, the calculation was bugged because the category wasn't saved correctly in the channelGroup update.