### PR TITLE
Test/8279 fix backup seed phrase validation

### DIFF
--- a/test/ui-test/src/drivers/SquishDriver.py
+++ b/test/ui-test/src/drivers/SquishDriver.py
@@ -7,20 +7,17 @@
 # * \date    February 2022
 # * \brief   It contains generic Status view components definitions and Squish driver API.
 # *****************************************************************************/
-from enum import Enum
+import copy
 import sys
+import test
 import time
 
-# IMPORTANT: It is necessary to import manually the Squish drivers module by module. 
+import names
+import object
+# IMPORTANT: It is necessary to import manually the Squish drivers module by module.
 # More info in: https://kb.froglogic.com/display/KB/Article+-+Using+Squish+functions+in+your+own+Python+modules+or+packages
 import squish
-import object
-import names
-import test
-
 from objectmaphelper import Wildcard
-
-import copy
 
 # The default maximum timeout to find ui object
 _MAX_WAIT_OBJ_TIMEOUT = 5000
@@ -30,12 +27,14 @@ _MIN_WAIT_OBJ_TIMEOUT = 500
 
 _SEARCH_IMAGES_PATH = "../shared/searchImages/"
 
+
 def start_application(app_name: str):
     squish.startApplication(app_name)
 
+
 # Waits for the given object is loaded, visible and enabled.
 # It returns a tuple: True in case it is found. Otherwise, false. And the object itself.
-def is_loaded_visible_and_enabled(objName: str, timeout: int=_MAX_WAIT_OBJ_TIMEOUT):
+def is_loaded_visible_and_enabled(objName: str, timeout: int = _MAX_WAIT_OBJ_TIMEOUT):
     obj = None
     try:
         obj = squish.waitForObject(getattr(names, objName), timeout)
@@ -43,14 +42,16 @@ def is_loaded_visible_and_enabled(objName: str, timeout: int=_MAX_WAIT_OBJ_TIMEO
     except LookupError:
         return False, obj
 
+
 # Waits for the given object is loaded, visible and enabled.
 # It returns a tuple: True in case it is found. Otherwise, false. And the object itself.
-def is_object_loaded_visible_and_enabled(obj: object, timeout: int=_MAX_WAIT_OBJ_TIMEOUT):
+def is_object_loaded_visible_and_enabled(obj: object, timeout: int = _MAX_WAIT_OBJ_TIMEOUT):
     try:
         squish.waitForObject(obj, timeout)
         return True
     except LookupError:
         return False
+
 
 # Waits for the given object is loaded and might be not visible and/or not enabled:
 # It returns a tuple: True in case it is found. Otherwise, false. And the object itself.
@@ -62,6 +63,7 @@ def is_loaded(objName: str):
     except LookupError:
         return False, obj
 
+
 # It tries to find if the object with given objectName is currently displayed (visible and enabled):
 # It returns True in case it is found. Otherwise, false.
 def is_found(objName: str):
@@ -70,40 +72,44 @@ def is_found(objName: str):
         return True
     except LookupError:
         return False
-    
+
+
 # It waits for the object with given objectName to appear in the UI (visible and enabled):
 # It returns True in case it appears without exceeding a specific timeout. Otherwise, false.
-def is_displayed(objName: str, timeout: int=_MAX_WAIT_OBJ_TIMEOUT):
+def is_displayed(objName: str, timeout: int = _MAX_WAIT_OBJ_TIMEOUT):
     try:
         squish.waitForObject(getattr(names, objName), timeout)
         return True
     except LookupError:
         return False
 
+
 # It checks if the given object is visible and enabled.
 def is_visible_and_enabled(obj):
     return obj.visible and obj.enabled
 
+
 def wait_for_is_visible(
-        objName: str, 
-        visible: bool = True, 
-        verify: bool = True, 
-        timeout: int=_MAX_WAIT_OBJ_TIMEOUT
-        ) -> bool:
-    
+        objName: str,
+        visible: bool = True,
+        verify: bool = True,
+        timeout: int = _MAX_WAIT_OBJ_TIMEOUT
+) -> bool:
     def _is_visible(value: bool):
         try:
             return squish.findObject(getattr(names, objName)).visible is value
         except LookupError:
             return False
-        
+
     result = squish.waitFor(lambda: _is_visible(visible), timeout)
     if verify:
         assert result, f'Visible property is not {visible}'
     return result
-    
+
+
 def is_null(obj):
     return squish.isNull(obj)
+
 
 # Given a specific object, get a specific child.
 def get_child(obj, child_index=None):
@@ -117,6 +123,7 @@ def get_child(obj, child_index=None):
 def click_obj(obj):
     squish.mouseClick(obj, squish.Qt.LeftButton)
 
+
 # It executes the right-click action into the given object:
 def right_click_obj(obj):
     try:
@@ -125,43 +132,52 @@ def right_click_obj(obj):
     except LookupError:
         return False
 
+
 def get_obj(objName: str):
     obj = squish.findObject(getattr(names, objName))
     return obj
 
-def wait_and_get_obj(objName: str, timeout: int=_MAX_WAIT_OBJ_TIMEOUT):
+
+def wait_and_get_obj(objName: str, timeout: int = _MAX_WAIT_OBJ_TIMEOUT):
     obj = squish.waitForObject(getattr(names, objName), timeout)
     return obj
+
 
 def get_and_click_obj(obj_name: str):
     click_obj(get_obj(obj_name))
 
+
 def get_objects(objName: str):
     objs = squish.findAllObjects(getattr(names, objName))
     return objs
+
 
 def hover_and_click_object_by_name(objName: str):
     obj = squish.waitForObject(getattr(names, objName))
     hover_obj(obj)
     squish.mouseClick(obj, squish.Qt.LeftButton)
 
+
 # It executes the left-click action into object with given object name:
 # If timeout is 0, it will use the default timeout (testSettings.waitForObjectTimeout)
-def click_obj_by_name(objName: str, timeout: int=0):
+def click_obj_by_name(objName: str, timeout: int = 0):
     if timeout > 0:
         obj = squish.waitForObject(getattr(names, objName), timeout)
     else:
         obj = squish.waitForObject(getattr(names, objName))
     squish.mouseClick(obj, squish.Qt.LeftButton)
 
+
 # It executes the click action into the given object at particular coordinates:
 def click_obj_by_name_at_coordinates(objName: str, x: int, y: int):
     obj = squish.waitForObject(getattr(names, objName))
     squish.mouseClick(obj, x, y, squish.Qt.LeftButton)
 
+
 def click_obj_by_attr(attr: str):
     obj = squish.waitForObject(attr)
     squish.mouseClick(obj, squish.Qt.LeftButton)
+
 
 def click_obj_by_wildcards_name(objName: str, wildcardString: str):
     wildcardRealName = copy.deepcopy(getattr(names, objName))
@@ -170,15 +186,18 @@ def click_obj_by_wildcards_name(objName: str, wildcardString: str):
     obj = squish.waitForObject(wildcardRealName)
     squish.mouseClick(obj, squish.Qt.LeftButton)
 
+
 # Replaces all occurrences of objectNamePlaceholder with newValue in the objectName from the realName
 # Then use the new objectName as a wildcard search pattern, waiting for the object with the new Real Name
 # and return it if found. Raise an exception if not found.
-def wait_by_wildcards(realNameVarName: str, objectNamePlaceholder: str, newValue: str, timeoutMSec: int = _MAX_WAIT_OBJ_TIMEOUT):
+def wait_by_wildcards(realNameVarName: str, objectNamePlaceholder: str, newValue: str,
+                      timeoutMSec: int = _MAX_WAIT_OBJ_TIMEOUT):
     wildcardRealName = copy.deepcopy(getattr(names, realNameVarName))
     newObjectName = wildcardRealName["objectName"].replace(objectNamePlaceholder, newValue)
     wildcardRealName["objectName"] = Wildcard(newObjectName)
 
     return squish.waitForObject(wildcardRealName, timeoutMSec)
+
 
 # It executes the right-click action into object with given object name:
 def right_click_obj_by_name(objName: str):
@@ -190,24 +209,27 @@ def right_click_obj_by_name(objName: str):
 def hover_obj(obj):
     squish.mouseMove(obj)
 
-def hover(objName: str, timeout_sec: int = 5):
-    def _hover(objName: str,):
-        obj = squish.waitForObject(getattr(names, objName), 1000)
+
+def hover(obj_name: str, timeout_sec: int = 5):
+    def _hover(_obj_name: str):
+        obj = squish.waitForObject(getattr(names, _obj_name), 1000)
         try:
             squish.mouseMove(obj)
-            obj = squish.waitForObject(getattr(names, objName), 1000)
+            obj = squish.waitForObject(getattr(names, _obj_name), 1000)
             assert getattr(obj, 'hovered', True)
             return True
         except (RuntimeError, AssertionError) as err:
             # Object does not have a valid geometry
             squish.snooze(1)
             return False
-    
-    assert squish.waitFor(lambda: _hover(objName), timeout_sec * 1000)
+
+    assert squish.waitFor(lambda: _hover(obj_name), timeout_sec * 1000)
+
 
 def move_mouse_over_object_by_name(objName: str):
     obj = squish.waitForObject(getattr(names, objName))
     move_mouse_over_object(obj)
+
 
 def move_mouse_over_object(obj):
     # Start moving the cursor:
@@ -218,16 +240,19 @@ def move_mouse_over_object(obj):
         squish.mouseMove(obj, x, y)
         x += 10
 
+
 def scroll_obj_by_name(objName: str):
     obj = squish.waitForObject(getattr(names, objName))
     squish.mouseWheel(obj, 206, 35, 0, -1, squish.Qt.ControlModifier)
+
 
 def reset_scroll_obj_by_name(objName: str):
     obj = squish.waitForObject(getattr(names, objName))
     obj.contentY = 0
 
+
 # execute do_fn until validation_fn returns True or timeout is reached
-def do_until_validation_with_timeout(do_fn, validation_fn, message: str, timeout_ms: int=_MAX_WAIT_OBJ_TIMEOUT * 2):
+def do_until_validation_with_timeout(do_fn, validation_fn, message: str, timeout_ms: int = _MAX_WAIT_OBJ_TIMEOUT * 2):
     start_time = time.time()
     while True:
         do_fn()
@@ -236,22 +261,29 @@ def do_until_validation_with_timeout(do_fn, validation_fn, message: str, timeout
         if ((time.time() - start_time) * 1000) > timeout_ms:
             raise Exception("Timeout reached while validating: " + message)
 
-def scroll_item_until_item_is_visible(itemToScrollObjName: str, itemToBeVisibleObjName: str, timeout_ms: int=_MAX_WAIT_OBJ_TIMEOUT * 2):
+
+def scroll_item_until_item_is_visible(itemToScrollObjName: str, itemToBeVisibleObjName: str,
+                                      timeout_ms: int = _MAX_WAIT_OBJ_TIMEOUT * 2):
     # It seems the underlying squish.waitForObject sometimes takes more than 300 ms to validate the object is visible
     is_item_visible_fn = lambda: is_loaded_visible_and_enabled(itemToBeVisibleObjName, 500)[0]
     scroll_item_fn = lambda: scroll_obj_by_name(itemToScrollObjName)
-    do_until_validation_with_timeout(scroll_item_fn, is_item_visible_fn, f'Scrolling {itemToScrollObjName} until {itemToBeVisibleObjName} is visible', timeout_ms)
+    do_until_validation_with_timeout(scroll_item_fn, is_item_visible_fn,
+                                     f'Scrolling {itemToScrollObjName} until {itemToBeVisibleObjName} is visible',
+                                     timeout_ms)
 
-def wait_until_item_not_visible_and_enabled(itemObjName: str, timeout_ms: int=2000):
+
+def wait_until_item_not_visible_and_enabled(itemObjName: str, timeout_ms: int = 2000):
     is_item_invisible_fn = lambda: not is_loaded_visible_and_enabled(itemObjName, 100)[0]
-    do_until_validation_with_timeout(lambda: time.sleep(0.05), is_item_invisible_fn, f'Waiting until {itemObjName} is not visible', timeout_ms)
+    do_until_validation_with_timeout(lambda: time.sleep(0.05), is_item_invisible_fn,
+                                     f'Waiting until {itemObjName} is not visible', timeout_ms)
+
 
 def check_obj_by_name(objName: str):
     obj = squish.waitForObject(getattr(names, objName))
     obj.checked = True
 
 
-def is_text_matching(objName: str, text: str, timeout: int=0):
+def is_text_matching(objName: str, text: str, timeout: int = 0):
     try:
         obj = squish.waitForObject(getattr(names, objName))
         test.compare(obj.text, text, "Found the following text " + str(obj.text) + " Wanted: " + text)
@@ -260,7 +292,8 @@ def is_text_matching(objName: str, text: str, timeout: int=0):
         print(objName + " is not found, please check app for correct object and update object mapper")
         return False
 
-def wait_for_text_matching(objName: str, text: str, timeout: int=0):
+
+def wait_for_text_matching(objName: str, text: str, timeout: int = 0):
     try:
         start_time = time.time()
         time_run_out = False
@@ -271,7 +304,8 @@ def wait_for_text_matching(objName: str, text: str, timeout: int=0):
             if timeout > 0:
                 time_run_out = ((time.time() - start_time) * 1000) > timeout
 
-        test.compare(obj.text, text, f'Found the following text {str(obj.text)} + Wanted: {text} {("; Aborted after " + str(int(time.time() - start_time)) + "s") if time_run_out else ""}')
+        test.compare(obj.text, text,
+                     f'Found the following text {str(obj.text)} + Wanted: {text} {("; Aborted after " + str(int(time.time() - start_time)) + "s") if time_run_out else ""}')
         return True
     except LookupError:
         print(objName + " is not found, please check app for correct object and update object mapper")
@@ -296,14 +330,16 @@ def type_text(objName: str, text: str):
     except LookupError:
         return False
 
+
 # It types the specified text in the currently focus input (like if the keyboard was typed on)
 def native_type(text: str):
     squish.nativeType(text)
 
+
 # Wait for the object to appears and
 # It types the specified text into the given object (as if the user had used the keyboard):
 # If timeout is 0, it will use the default timeout (testSettings.waitForObjectTimeout)
-def wait_for_object_and_type(objName: str, text: str, timeout: int=0):
+def wait_for_object_and_type(objName: str, text: str, timeout: int = 0):
     try:
         if timeout > 0:
             obj = squish.waitForObject(getattr(names, objName), timeout)
@@ -313,6 +349,7 @@ def wait_for_object_and_type(objName: str, text: str, timeout: int=0):
         return True
     except LookupError:
         return False
+
 
 # It sets the specified text into the given object (first erase, then type)
 def setText(objName: str, text: str):
@@ -324,22 +361,26 @@ def setText(objName: str, text: str):
     except LookupError:
         return False
 
+
 # Clicking link in label / textedit
 def click_link(objName: str, link: str):
     point = _find_link(getattr(names, objName), link)
     if point[0] != -1 and point[1] != -1:
         squish.mouseClick(getattr(names, objName), point[0], point[1], 0, squish.Qt.LeftButton)
-        
+
+
 # Global properties for getting link / hovered handler management:
-_expected_link = None 
+_expected_link = None
 _link_found = False
+
 
 def _handle_link_hovered(obj, link):
     global _link_found
     if link == _expected_link:
         _link_found = True
 
-# It registers to hovered handler and moves mouse around a specific object. 
+
+# It registers to hovered handler and moves mouse around a specific object.
 # Return: If handler is executed, link has been found and the position of the link is returned. Otherwise, it returns position [-1, -1] 
 def _find_link(objName: str, link: str):
     global _expected_link
@@ -350,7 +391,7 @@ def _find_link(objName: str, link: str):
 
     # Inject desired function into main module:
     sys.modules['__main__']._handle_link_hovered = _handle_link_hovered
-    squish.installSignalHandler(obj, "linkHovered(QString)", "_handle_link_hovered")  
+    squish.installSignalHandler(obj, "linkHovered(QString)", "_handle_link_hovered")
 
     # Start moving the cursor:
     squish.mouseMove(obj, int(obj.x), int(obj.y))
@@ -366,13 +407,14 @@ def _find_link(objName: str, link: str):
                 return [x - obj.x, y - obj.y]
             x += 10
         y += 10
-        
+
     squish.uninstallSignalHandler(obj, "linkHovered(QString)", "_handle_link_hovered")
     return [-1, -1]
 
 
 def expect_true(assertionValue: bool, message: str):
     return test.verify(assertionValue, message)
+
 
 # Wait for the object to appear and, assuming it is already focused
 # it types the specified text into the given object (as if the user had used the keyboard):
@@ -385,23 +427,26 @@ def wait_for_object_focused_and_type(obj_name: str, text: str):
     except LookupError:
         return False
 
+
 # NOTE: It is a specific method for ListView components.
 # It positions the mouse in the middle of the list_obj and scrolls until reaching the item at specific index is visible.
 # Return True if it has been possible to scroll until item index, False if timeout or index not found.     
-def scroll_list_view_at_index(list_obj, index: int, timeout: int=_MAX_WAIT_OBJ_TIMEOUT):
+def scroll_list_view_at_index(list_obj, index: int, timeout: int = _MAX_WAIT_OBJ_TIMEOUT):
     start_time = time.time() * 1000
     current_time = start_time
     end_scroll = False
     if not squish.isNull(list_obj):
         while not end_scroll and current_time - start_time <= timeout:
-            item_obj = list_obj.itemAtIndex(index)              
+            item_obj = list_obj.itemAtIndex(index)
             if not squish.isNull(item_obj) and item_obj.visible:
                 end_scroll = True
                 return True
-            squish.mouseWheel(list_obj, int(list_obj.x + list_obj.width/2), int(list_obj.y + list_obj.height/2), 0, -1, squish.Qt.ControlModifier)
-            squish.snooze(1) 
+            squish.mouseWheel(list_obj, int(list_obj.x + list_obj.width / 2), int(list_obj.y + list_obj.height / 2), 0,
+                              -1, squish.Qt.ControlModifier)
+            squish.snooze(1)
             current_time = time.time() * 1000
     return False
+
 
 # Fail if the object is found and pass if not found
 def verify_not_found(realNameVarName: str, message: str, timeoutMSec: int = 500):
@@ -411,13 +456,15 @@ def verify_not_found(realNameVarName: str, message: str, timeoutMSec: int = 500)
     except LookupError as err:
         test.passes(message, f'Expected: the object "{realNameVarName}" was not found. Exception: {str(err)}.')
 
-def grabScreenshot_and_save(obj, imageName:str, delay:int = 0):
+
+def grabScreenshot_and_save(obj, imageName: str, delay: int = 0):
     img = object.grabScreenshot(obj, {"delay": delay})
     img.save(_SEARCH_IMAGES_PATH + imageName + ".png")
 
+
 def wait_for_prop_value(object, propertyName, value, timeoutMSec: int = 2000):
     start = time.time()
-    while(start + timeoutMSec / 1000 > time.time()):
+    while (start + timeoutMSec / 1000 > time.time()):
         propertyNames = propertyName.split('.')
         objThenVal = object
         for name in propertyNames:
@@ -425,7 +472,9 @@ def wait_for_prop_value(object, propertyName, value, timeoutMSec: int = 2000):
         if objThenVal == value:
             return
         squish.snooze(0.1)
-    raise Exception(f'Failed to match value "{value}" for property "{propertyName}" before timeout {timeoutMSec}ms; actual value: "{objThenVal}"')
+    raise Exception(
+        f'Failed to match value "{value}" for property "{propertyName}" before timeout {timeoutMSec}ms; actual value: "{objThenVal}"')
+
 
 def get_child_item_with_object_name(item, objectName: str):
     for index in range(item.components.count()):
@@ -433,8 +482,14 @@ def get_child_item_with_object_name(item, objectName: str):
             return item.components.at(index)
     raise Exception("Could not find child component with object name '{}'".format(objectName))
 
+
 def sleep_test(seconds: float):
     squish.snooze(seconds)
 
+
 def wait_for(py_condition_to_check: str, timeout_msec: int = 500):
     squish.waitFor(py_condition_to_check, timeout_msec)
+
+
+def wait_util_hidden(object_name: str, timeout_msec: int = _MAX_WAIT_OBJ_TIMEOUT) -> bool:
+    return squish.waitFor(lambda: not is_displayed(object_name), timeout_msec)

--- a/test/ui-test/src/screens/SettingsScreen.py
+++ b/test/ui-test/src/screens/SettingsScreen.py
@@ -9,20 +9,21 @@
 # *****************************************************************************/
 
 
-from enum import Enum
 import random
-import time
 import string
-from wsgiref import validate
+from enum import Enum
+
 from drivers.SquishDriver import *
 from drivers.SquishDriverVerification import *
 from utils.ObjectAccess import *
+
 from .StatusMainScreen import MainScreenComponents
-from .StatusMainScreen import StatusMainScreen
 from .StatusMainScreen import authenticate_popup_enter_password
+
 
 class SettingsScreenComponents(Enum):
     SAVE_BUTTON: str = "settingsSave_StatusButton"
+
 
 class SidebarComponents(Enum):
     ADVANCED_OPTION: str = "advanced_StatusNavigationListItem"
@@ -40,14 +41,16 @@ class AdvancedOptionScreen(Enum):
     ACTIVATE_OR_DEACTIVATE_COMMUNITY_PERMISSIONS: str = "communitySettingsLineButton"
     I_UNDERSTAND_POP_UP: str = "i_understand_StatusBaseText"
 
+
 class ENSScreen(Enum):
-    START_BUTTON :str = "settings_ENS_Start_Button"
+    START_BUTTON: str = "settings_ENS_Start_Button"
     ENS_SEARCH_INPUT: str = "settings_ENS_Search_Input"
     NEXT_BUTTON: str = "settings_ENS_Search_Next_Button"
     AGREE_TERMS: str = "settings_ENS_Terms_Agree"
     OPEN_TRANSACTION: str = "settings_ENS_Terms_Open_Transaction"
     TRANSACTION_NEXT_BUTTON: str = "settings_ENS_Terms_Transaction_Next_Button"
     PASSWORD_INPUT: str = "settings_ENS_Terms_Transaction_Password_Input"
+
 
 class MessagingOptionScreen(Enum):
     ACTIVATE_OR_DEACTIVATE_LINK_PREVIEW: str = "displayMessageLinkPreviewItem"
@@ -56,6 +59,7 @@ class MessagingOptionScreen(Enum):
     TENOR_GIFS_PREVIEW_SWITCH_ITEM: str = "tenorGifsPreviewSwitchItem"
     SCROLLVIEW: str = "settingsContentBase_ScrollView"
     CONTACTS_BTN: str = "contacts_listItem_btn"
+
 
 class ContactsViewScreen(Enum):
     CONTACT_REQUEST_CHAT_KEY_BTN: str = "contact_request_to_chat_key_btn"
@@ -66,10 +70,12 @@ class ContactsViewScreen(Enum):
     SENT_REQUESTS_CONTACT_PANEL_LIST_VIEW: str = "sentRequests_contactListPanel_ListView"
     RECEIVED_REQUESTS_CONTACT_PANEL_LIST_VIEW: str = "receivedRequests_contactListPanel_ListView"
 
+
 class ProfilePopupScreen(Enum):
     PROFILE_POPUP_SEND_CONTACT_REQUEST_BUTTON = "ProfilePopup_SendContactRequestButton"
     SAY_WHO_YOU_ARE_INPUT: str = "ProfilePopup_SayWhoYouAre_TextEdit"
     SEND_CONTACT_REQUEST_BUTTON: str = "ProfilePopup_SendContactRequest_Button"
+
 
 class WalletSettingsScreen(Enum):
     GENERATED_ACCOUNTS: str = "settings_Wallet_MainView_GeneratedAccounts"
@@ -84,6 +90,7 @@ class WalletSettingsScreen(Enum):
     ACCOUNT_VIEW_ACCOUNT_NAME: str = "settings_Wallet_AccountView_AccountName"
     ACCOUNT_VIEW_ICON_SETTINGS: str = "settings_Wallet_AccountView_IconSettings"
     BACKUP_SEED_PHRASE_BUTTON: str = "settings_Wallet_MainView_BackupSeedPhrase"
+
 
 class ProfileSettingsScreen(Enum):
     DISPLAY_NAME: str = "displayName_TextEdit"
@@ -102,6 +109,7 @@ class ProfileSettingsScreen(Enum):
     CUSTOM_URL_IN_DIALOG: str = "customUrl_popup_TextEdit"
     CHANGE_PASSWORD_BUTTON: str = "change_password_button"
 
+
 class ChangePasswordMenu(Enum):
     CHANGE_PASSWORD_CURRENT_PASSWORD_INPUT: str = "change_password_menu_current_password"
     CHANGE_PASSWORD_NEW_PASSWORD_INPUT: str = "change_password_menu_new_password"
@@ -109,13 +117,16 @@ class ChangePasswordMenu(Enum):
     CHANGE_PASSWORD_SUBMIT_BUTTON: str = "change_password_menu_submit_button"
     CHANGE_PASSWORD_SUCCESS_MENU_SIGN_OUT_QUIT_BUTTON: str = "change_password_success_menu_sign_out_quit_button"
 
+
 class ConfirmationDialog(Enum):
     SIGN_OUT_CONFIRMATION: str = "signOutConfirmation_StatusButton"
+
 
 class CommunitiesSettingsScreen(Enum):
     LIST_PANEL: str = "settings_Communities_CommunitiesListPanel"
     LEAVE_COMMUNITY_BUTTONS: str = "settings_Communities_MainView_LeaveCommunityButtons"
     LEAVE_COMMUNITY_POPUP_LEAVE_BUTTON: str = "settings_Communities_MainView_LeavePopup_LeaveCommunityButton"
+
 
 class BackupSeedPhrasePopup(Enum):
     HAVE_PEN_CHECKBOX: str = "backup_seed_phrase_popup_Acknowledgements_havePen_checkbox"
@@ -130,6 +141,7 @@ class BackupSeedPhrasePopup(Enum):
     CONFIRM_SECOND_WORD_INPUT: str = "backup_seed_phrase_popup_BackupSeedStepBase_confirmSecondWord_inputText"
     CONFIRM_YOU_STORED_CHECKBOX: str = "backup_seed_phrase_popup_ConfirmStoringSeedPhrasePanel_storeCheck"
     CONFIRM_YOU_STORED_BUTTON: str = "backup_seed_phrase_popup_BackupSeedModal_completeAndDeleteSeedPhraseButton"
+
 
 class SettingsScreen:
     __pid = 0
@@ -185,20 +197,23 @@ class SettingsScreen:
         click_obj_by_name(SidebarComponents.MESSAGING_ITEM.value)
         # view can be scrolled down, we need to reset scroll
         reset_scroll_obj_by_name(MessagingOptionScreen.SCROLLVIEW.value)
-        scroll_item_until_item_is_visible(MessagingOptionScreen.SCROLLVIEW.value, MessagingOptionScreen.LINK_PREVIEW_SWITCH.value)
+        scroll_item_until_item_is_visible(MessagingOptionScreen.SCROLLVIEW.value,
+                                          MessagingOptionScreen.LINK_PREVIEW_SWITCH.value)
         switch = wait_and_get_obj(MessagingOptionScreen.LINK_PREVIEW_SWITCH.value)
         if not switch.checked:
             click_obj_by_name(MessagingOptionScreen.LINK_PREVIEW_SWITCH.value)
 
     # Post condition: Messaging Settings is active and Link Preview is activated (@see open_messaging_settings and activate_link_preview_if_dectivated)
     def activate_image_unfurling(self):
-        scroll_item_until_item_is_visible(MessagingOptionScreen.SCROLLVIEW.value, MessagingOptionScreen.ACTIVATE_OR_DECTIVATE_IMAGE_UNFURLING.value)
+        scroll_item_until_item_is_visible(MessagingOptionScreen.SCROLLVIEW.value,
+                                          MessagingOptionScreen.ACTIVATE_OR_DECTIVATE_IMAGE_UNFURLING.value)
         click_obj_by_name(MessagingOptionScreen.ACTIVATE_OR_DECTIVATE_IMAGE_UNFURLING.value)
 
     # Post condition: Messaging Settings is active and Link Preview is activated (@see open_messaging_settings and activate_link_preview_if_dectivated)
     def the_user_activates_tenor_gif_preview(self):
         click_obj_by_name(SidebarComponents.MESSAGING_ITEM.value)
-        scroll_item_until_item_is_visible(MessagingOptionScreen.SCROLLVIEW.value, MessagingOptionScreen.TENOR_GIFS_PREVIEW_SWITCH_ITEM.value)
+        scroll_item_until_item_is_visible(MessagingOptionScreen.SCROLLVIEW.value,
+                                          MessagingOptionScreen.TENOR_GIFS_PREVIEW_SWITCH_ITEM.value)
         click_obj_by_name(MessagingOptionScreen.TENOR_GIFS_PREVIEW_SWITCH_ITEM.value)
 
     def toggle_test_networks(self):
@@ -233,7 +248,7 @@ class SettingsScreen:
     def _find_account_index(self, account_name: str) -> int:
         accounts = get_obj(WalletSettingsScreen.GENERATED_ACCOUNTS.value)
         for index in range(accounts.count):
-            if(accounts.itemAtIndex(index).objectName == account_name):
+            if (accounts.itemAtIndex(index).objectName == account_name):
                 return index
         return -1
 
@@ -255,7 +270,7 @@ class SettingsScreen:
         colorList = get_obj(WalletSettingsScreen.EDIT_ACCOUNT_COLOR_REPEATER.value)
         for index in range(colorList.count):
             color = colorList.itemAt(index)
-            if(color.radioButtonColor == account_color):
+            if (color.radioButtonColor == account_color):
                 click_obj(colorList.itemAt(index))
 
         click_obj_by_name(WalletSettingsScreen.EDIT_ACCOUNT_SAVE_BUTTON.value)
@@ -264,7 +279,8 @@ class SettingsScreen:
         accountName = get_obj(WalletSettingsScreen.ACCOUNT_VIEW_ACCOUNT_NAME.value)
         iconSettings = get_obj(WalletSettingsScreen.ACCOUNT_VIEW_ICON_SETTINGS.value)
         verify_values_equal(str(accountName.text), str(new_name), "Edited account name not updated")
-        verify_values_equal(str(iconSettings.asset.color.name), str(new_color.lower()), "Edited account color not updated")
+        verify_values_equal(str(iconSettings.asset.color.name), str(new_color.lower()),
+                            "Edited account color not updated")
 
     def open_communities_section(self):
         click_obj_by_name(SidebarComponents.COMMUNITIES_OPTION.value)
@@ -317,7 +333,7 @@ class SettingsScreen:
         custom_link = ""
 
         if table is not None:
-            verify_equals(8, len(table)) # Expecting 8 as social media link fields to verify
+            verify_equals(8, len(table))  # Expecting 8 as social media link fields to verify
             twitter = table[0][0]
             personal_site = table[1][0]
             github = table[2][0]
@@ -361,7 +377,7 @@ class SettingsScreen:
         custom_link = ""
 
         if table is not None:
-            verify_equals(8, len(table)) # Expecting 8 as social media link fields to verify
+            verify_equals(8, len(table))  # Expecting 8 as social media link fields to verify
             twitter = table[0][0]
             personal_site = table[1][0]
             github = table[2][0]
@@ -409,7 +425,8 @@ class SettingsScreen:
                 raise RuntimeError('Reveal seed phrase button not clicked')
 
         # Collect word phrases for the next random confirmation steps
-        seed_phrase = [wait_by_wildcards(BackupSeedPhrasePopup.SEED_PHRASE_WORD_PLACEHOLDER.value, "%WORD_NO%", str(i + 1)).textEdit.input.edit.text for i in range(12)]
+        seed_phrase = [wait_by_wildcards(BackupSeedPhrasePopup.SEED_PHRASE_WORD_PLACEHOLDER.value, "%WORD_NO%",
+                                         str(i + 1)).textEdit.input.edit.text for i in range(12)]
         click_obj_by_name(BackupSeedPhrasePopup.NEXT_BUTTON.value)
 
         # Confirm first random word of the seed phrase
@@ -431,7 +448,9 @@ class SettingsScreen:
         click_obj_by_name(BackupSeedPhrasePopup.CONFIRM_YOU_STORED_BUTTON.value)
 
     def verify_seed_phrase_indicator_not_visible(self):
-        verify_not_found(WalletSettingsScreen.BACKUP_SEED_PHRASE_BUTTON.value, "Check that backup seed phrase settings button is visible")
+        assert wait_util_hidden(
+            WalletSettingsScreen.BACKUP_SEED_PHRASE_BUTTON.value,
+        ), "Backup seed phrase settings button is visible"
 
     def change_user_password(self, oldPassword: str, newPassword: str):
         get_and_click_obj(ProfileSettingsScreen.CHANGE_PASSWORD_BUTTON.value)

--- a/test/ui-test/src/screens/StatusAccountsScreen.py
+++ b/test/ui-test/src/screens/StatusAccountsScreen.py
@@ -7,6 +7,7 @@
 # * \date    February 2022
 # * \brief   It defines the status accounts popup behavior and properties.
 # *****************************************************************************/
+from enum import Enum
 
 from drivers.SquishDriver import *
 from drivers.SquishDriverVerification import *


### PR DESCRIPTION
### What does the PR do

<!-- The test verification is fixed. -->
When the phase is back upped, the banner is not hiding, we need to wait for 1 or more seconds. Wait for the banner hidden added with a timeout limit of 5 seconds.

Issue found on @glitchminer machine.
If you can also start testing locally we can handle as many possible issues as possible, so please run it on your machine.

### Affected areas

<!-- List the affected areas: Test scenario: The user can backup seed phrase -->

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

- [ ] I've checked the design and this PR matches it

<!-- screenshot (or gif/video) that demonstrates the functionality, specially important if it's a bug fix. -->

### Cool Spaceship Picture

<!-- optional but cool ->
![image](https://user-images.githubusercontent.com/128374224/232410003-ba4d50d8-fbe5-4d1d-b4fb-5e40f9e62eda.png)
