### PR TITLE
fix(ActivityCenterPopup): close the AC popup a second time the button is clicked

### DIFF
--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -36,11 +36,12 @@ import AppLayouts.Browser.stores 1.0 as BrowserStores
 import AppLayouts.stores 1.0
 import AppLayouts.Chat.stores 1.0 as ChatStores
 
+import mainui.activitycenter.stores 1.0
+import mainui.activitycenter.popups 1.0
+
 import SortFilterProxyModel 0.2
 
 import "panels"
-import "activitycenter/popups"
-import "activitycenter/stores"
 
 Item {
     id: appMain
@@ -86,7 +87,25 @@ Item {
         }
 
         function onOpenActivityCenter() {
-            popups.openPopup(activityCenterPopupComponent)
+            d.openActivityCenterPopup()
+        }
+    }
+
+    QtObject {
+        id: d
+
+        property var activityCenterPopupObj: null
+
+        function openActivityCenterPopup() {
+            if (!activityCenterPopupObj) {
+                activityCenterPopupObj = activityCenterPopupComponent.createObject(appMain)
+            }
+
+            if (activityCenterPopupObj.opened) {
+                activityCenterPopupObj.close()
+            } else {
+                activityCenterPopupObj.open()
+            }
         }
     }
 
@@ -114,7 +133,7 @@ Item {
         }
 
         function onOpenActivityCenterPopupRequested() {
-            popups.openPopup(activityCenterPopupComponent)
+            d.openActivityCenterPopup()
         }
 
         function onDisplayToastMessage(title: string, subTitle: string, icon: string, loading: bool, ephNotifType: int, url: string) {
@@ -1057,7 +1076,7 @@ Item {
             id: activityCenterPopupComponent
             ActivityCenterPopup {
                 // TODO get screen size // Taken from old code top bar height was fixed there to 56
-                property int _buttonSize: 56
+                readonly property int _buttonSize: 56
 
                 x: parent.width - width - Style.current.smallPadding
                 y: parent.y + _buttonSize

--- a/ui/app/mainui/activitycenter/popups/ActivityCenterPopup.qml
+++ b/ui/app/mainui/activitycenter/popups/ActivityCenterPopup.qml
@@ -29,14 +29,19 @@ Popup {
         activityCenterStore.markAsSeenActivityCenterNotifications()
     }
 
-    x: Global.applicationWindow.width - root.width - Style.current.halfPadding
     width: 560
     padding: 0
-    modal: false
-    closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
+    modal: true
     parent: Overlay.overlay
 
-    Overlay.modeless: null
+    Overlay.modal: MouseArea { // eat every event behind the popup
+        hoverEnabled: true
+        onPressed: (event) => {
+                       event.accept()
+                       root.close()
+                   }
+        onWheel: (event) => event.accept()
+    }
 
     background: Rectangle {
         color: Style.current.background

--- a/ui/app/mainui/activitycenter/popups/ActivityCenterPopup.qml
+++ b/ui/app/mainui/activitycenter/popups/ActivityCenterPopup.qml
@@ -26,7 +26,7 @@ Popup {
     }
     onClosed: {
         Global.popupOpened = false
-        activityCenterStore.markAsSeenActivityCenterNotifications()
+        Qt.callLater(activityCenterStore.markAsSeenActivityCenterNotifications)
     }
 
     width: 560


### PR DESCRIPTION
### What does the PR do

Fixes 2 issues in the AC popup (see individual commits for explanation):
- clicking the bell icon a second time should close the popup
- memleak/slow operation on every popup open

Fixes #9838

### Affected areas

AppMain, ActivityCenterPopup

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

[Záznam obrazovky z 2023-04-17 11-08-17.webm](https://user-images.githubusercontent.com/5377645/232438945-a29b9b09-a10f-4fb2-9151-0e2a9607bc82.webm)


