### PR TITLE
Feat(Contacts): Fixes contact removal side effects

### DIFF
--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -959,6 +959,7 @@ method getContactDetailsAsJson*[T](self: Module[T], publicKey: string, getVerifi
     "removed": contact.removed,
     "trustStatus": contact.trustStatus.int,
     # TODO rename verificationStatus to outgoingVerificationStatus
+    "contactRequestState": contact.contactRequestState.int,
     "verificationStatus": contact.verificationStatus.int,
     "incomingVerificationStatus": requestStatus,
     "hasAddedUs": contact.hasAddedUs,

--- a/src/app/modules/main/profile_section/contacts/controller.nim
+++ b/src/app/modules/main/profile_section/contacts/controller.nim
@@ -41,10 +41,6 @@ proc init*(self: Controller) =
     var args = ContactArgs(e)
     self.delegate.contactRemoved(args.contactId)
 
-  self.events.on(SIGNAL_CONTACT_REJECTION_REMOVED) do(e: Args):
-    var args = ContactArgs(e)
-    self.delegate.contactRequestRejectionRemoved(args.contactId)
-
   self.events.on(SIGNAL_CONTACT_NICKNAME_CHANGED) do(e: Args):
     var args = ContactArgs(e)
     self.delegate.contactNicknameChanged(args.contactId)
@@ -126,9 +122,6 @@ proc acceptContactRequest*(self: Controller, publicKey: string, contactRequestId
 
 proc dismissContactRequest*(self: Controller, publicKey: string, contactRequestId: string) =
   self.contactsService.dismissContactRequest(publicKey, contactRequestId)
-
-proc removeContactRequestRejection*(self: Controller, publicKey: string) =
-  self.contactsService.removeContactRequestRejection(publicKey)
 
 proc switchToOrCreateOneToOneChat*(self: Controller, chatId: string) =
   self.chatService.switchToOrCreateOneToOneChat(chatId, "")

--- a/src/app/modules/main/profile_section/contacts/io_interface.nim
+++ b/src/app/modules/main/profile_section/contacts/io_interface.nim
@@ -51,9 +51,6 @@ method blockContact*(self: AccessInterface, publicKey: string) {.base.} =
 method removeContact*(self: AccessInterface, publicKey: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method removeContactRequestRejection*(self: AccessInterface, publicKey: string) {.base.} =
-  raise newException(ValueError, "No implementation available")
-
 # Controller Delegate Interface
 
 method contactAdded*(self: AccessInterface, publicKey: string) {.base.} =
@@ -108,9 +105,6 @@ method declineVerificationRequest*(self: AccessInterface, publicKey: string): vo
   raise newException(ValueError, "No implementation available")
 
 method acceptVerificationRequest*(self: AccessInterface, publicKey: string, response: string): void {.base.} =
-  raise newException(ValueError, "No implementation available")
-
-method contactRequestRejectionRemoved*(self: AccessInterface, publicKey: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method getReceivedVerificationRequests*(self: AccessInterface): seq[VerificationRequest] {.base.} =

--- a/src/app/modules/main/profile_section/contacts/module.nim
+++ b/src/app/modules/main/profile_section/contacts/module.nim
@@ -134,7 +134,7 @@ proc addItemToAppropriateModel(self: Module, item: UserItem) =
     self.view.blockedContactsModel().addItem(item)
     return
 
-  case contact.requestState:
+  case contact.contactRequestState:
     of ContactRequestState.Received:
       self.view.receivedContactRequestsModel().addItem(item)
     of ContactRequestState.Sent:

--- a/src/app/modules/main/profile_section/contacts/module.nim
+++ b/src/app/modules/main/profile_section/contacts/module.nim
@@ -129,22 +129,20 @@ proc addItemToAppropriateModel(self: Module, item: UserItem) =
   if(singletonInstance.userProfile.getPubKey() == item.pubKey):
     return
   let contact = self.controller.getContact(item.pubKey())
-  if(contact.isContactRemoved()):
-    return
-  elif(contact.isBlocked()):
+
+  if contact.isBlocked():
     self.view.blockedContactsModel().addItem(item)
-  elif(contact.isContact()):
-    self.view.myMutualContactsModel().addItem(item)
-  else:
-    if(contact.isContactRequestReceived() and not contact.isContactRequestSent()):
+    return
+
+  case contact.requestState:
+    of ContactRequestState.Received:
       self.view.receivedContactRequestsModel().addItem(item)
-    elif(contact.isContactRequestSent() and not contact.isContactRequestReceived()):
+    of ContactRequestState.Sent:
       self.view.sentContactRequestsModel().addItem(item)
-    # Temporary commented until we provide appropriate flags on the `status-go` side to cover all sections.
-    # elif(contact.isContactRequestReceived() and contact.isReceivedContactRequestRejected()):
-    #   self.view.receivedButRejectedContactRequestsModel().addItem(item)
-    # elif(contact.isContactRequestSent() and contact.isSentContactRequestRejected()):
-    #   self.view.sentButRejectedContactRequestsModel().addItem(item)
+    of ContactRequestState.Mutual:
+      self.view.myMutualContactsModel().addItem(item)
+    else:
+      return
 
 proc removeItemWithPubKeyFromAllModels(self: Module, publicKey: string) =
   self.view.myMutualContactsModel().removeItemById(publicKey)
@@ -170,9 +168,6 @@ method contactUnblocked*(self: Module, publicKey: string) =
   self.removeIfExistsAndAddToAppropriateModel(publicKey)
 
 method contactRemoved*(self: Module, publicKey: string) =
-  self.removeIfExistsAndAddToAppropriateModel(publicKey)
-
-method contactRequestRejectionRemoved*(self: Module, publicKey: string) =
   self.removeIfExistsAndAddToAppropriateModel(publicKey)
 
 method contactUpdated*(self: Module, publicKey: string) =

--- a/src/app/modules/main/profile_section/contacts/module.nim
+++ b/src/app/modules/main/profile_section/contacts/module.nim
@@ -125,9 +125,6 @@ method removeContact*(self: Module, publicKey: string) =
 method changeContactNickname*(self: Module, publicKey: string, nickname: string) =
   self.controller.changeContactNickname(publicKey, nickname)
 
-method removeContactRequestRejection*(self: Module, publicKey: string) =
-  self.controller.removeContactRequestRejection(publicKey)
-
 proc addItemToAppropriateModel(self: Module, item: UserItem) =
   if(singletonInstance.userProfile.getPubKey() == item.pubKey):
     return

--- a/src/app/modules/main/profile_section/contacts/view.nim
+++ b/src/app/modules/main/profile_section/contacts/view.nim
@@ -161,9 +161,6 @@ QtObject:
   proc removeTrustStatus*(self: View, publicKey: string) {.slot.} =
     self.delegate.removeTrustStatus(publicKey)
 
-  proc removeContactRequestRejection*(self: View, publicKey: string) {.slot.} =
-    self.delegate.removeContactRequestRejection(publicKey)
-    
   proc getSentVerificationDetailsAsJson(self: View, publicKey: string): string {.slot.} =
     return self.delegate.getSentVerificationDetailsAsJson(publicKey)
 

--- a/src/app/modules/shared_models/user_model.nim
+++ b/src/app/modules/shared_models/user_model.nim
@@ -48,6 +48,9 @@ QtObject:
     self.endResetModel()
     self.countChanged()
 
+    for item in items:
+      self.itemChanged(item.pubKey)
+
   proc `$`*(self: Model): string =
     for i in 0 ..< self.items.len:
       result &= fmt"""User Model:

--- a/src/app_service/service/contacts/dto/contacts.nim
+++ b/src/app_service/service/contacts/dto/contacts.nim
@@ -60,7 +60,7 @@ type ContactsDto* = object
   isSyncing*: bool
   removed*: bool
   trustStatus*: TrustStatus
-  requestState*: ContactRequestState
+  contactRequestState*: ContactRequestState
   verificationStatus*: VerificationStatus
 
 proc `$`(self: Images): string =
@@ -144,10 +144,10 @@ proc toContactsDto*(jsonObj: JsonNode): ContactsDto =
   discard jsonObj.getProp("localNickname", result.localNickname)
   discard jsonObj.getProp("bio", result.bio)
 
-  result.requestState = ContactRequestState.None
-  var requestState: int
-  discard jsonObj.getProp("contactRequestState", requestState)
-  result.requestState = requestState.toContactRequestState()
+  result.contactRequestState = ContactRequestState.None
+  var contactRequestState: int
+  discard jsonObj.getProp("contactRequestState", contactRequestState)
+  result.contactRequestState = contactRequestState.toContactRequestState()
 
   result.trustStatus = TrustStatus.Unknown
   var trustStatusInt: int
@@ -194,7 +194,7 @@ proc isContactRequestReceived*(self: ContactsDto): bool =
   return self.hasAddedUs
 
 proc isReceivedContactRequestRejected*(self: ContactsDto): bool =
-  return self.requestState == ContactRequestState.Dismissed
+  return self.contactRequestState == ContactRequestState.Dismissed
 
 proc isContactRequestSent*(self: ContactsDto): bool =
   return self.added

--- a/src/app_service/service/contacts/service.nim
+++ b/src/app_service/service/contacts/service.nim
@@ -57,7 +57,6 @@ const SIGNAL_CONTACT_ADDED* = "contactAdded"
 const SIGNAL_CONTACT_BLOCKED* = "contactBlocked"
 const SIGNAL_CONTACT_UNBLOCKED* = "contactUnblocked"
 const SIGNAL_CONTACT_REMOVED* = "contactRemoved"
-const SIGNAL_CONTACT_REJECTION_REMOVED* = "contactRejectionRemoved"
 const SIGNAL_CONTACT_NICKNAME_CHANGED* = "contactNicknameChanged"
 const SIGNAL_CONTACTS_STATUS_UPDATED* = "contactsStatusUpdated"
 const SIGNAL_CONTACT_UPDATED* = "contactUpdated"
@@ -78,7 +77,7 @@ const SIGNAL_CONTACT_INFO_REQUEST_FINISHED* = "contactInfoRequestFinished"
 type
   ContactsGroup* {.pure.} = enum
     AllKnownContacts
-    MyMutualContacts    
+    MyMutualContacts
     IncomingPendingContactRequests
     OutgoingPendingContactRequests
     IncomingRejectedContactRequests
@@ -474,16 +473,6 @@ QtObject:
     except Exception as e:
       error "an error occurred while dismissing contact request", msg=e.msg
 
-  proc removeContactRequestRejection*(self: Service, publicKey: string) =
-    var contact = self.getContactById(publicKey)
-    contact.removed = false
-
-    # When we know what flags or what `status-go` end point we need to call, we should add
-    # that call here.
-
-    self.saveContact(contact)
-    self.events.emit(SIGNAL_CONTACT_REJECTION_REMOVED, ContactArgs(contactId: contact.id))
-
   proc changeContactNickname*(self: Service, publicKey: string, nickname: string) =
     var contact = self.getContactById(publicKey)
     contact.localNickname = nickname
@@ -533,6 +522,7 @@ QtObject:
     var contact = self.getContactById(publicKey)
     contact.removed = true
     contact.added = false
+    contact.hasAddedUs = false
 
     self.saveContact(contact)
     self.events.emit(SIGNAL_CONTACT_REMOVED, ContactArgs(contactId: contact.id))

--- a/src/app_service/service/contacts/service.nim
+++ b/src/app_service/service/contacts/service.nim
@@ -421,6 +421,8 @@ QtObject:
       contact.added = true
       contact.blocked = false
       contact.removed = false
+      contact.contactRequestState = ContactRequestState.Sent
+
       self.saveContact(contact)
       self.events.emit(SIGNAL_CONTACT_ADDED, ContactArgs(contactId: contact.id))
       self.activityCenterService.parseActivityCenterResponse(response)
@@ -445,6 +447,8 @@ QtObject:
       var contact = self.getContactById(publicKey)
       contact.added = true
       contact.removed = false
+      contact.contactRequestState = ContactRequestState.Mutual
+
       self.saveContact(contact)
       self.events.emit(SIGNAL_CONTACT_ADDED, ContactArgs(contactId: contact.id))
       self.activityCenterService.parseActivityCenterResponse(response)
@@ -467,6 +471,8 @@ QtObject:
         return
       var contact = self.getContactById(publicKey)
       contact.removed = true
+      contact.contactRequestState = ContactRequestState.Dismissed
+
       self.saveContact(contact)
       self.events.emit(SIGNAL_CONTACT_REMOVED, ContactArgs(contactId: contact.id))
       self.activityCenterService.parseActivityCenterResponse(response)
@@ -523,6 +529,7 @@ QtObject:
     contact.removed = true
     contact.added = false
     contact.hasAddedUs = false
+    contact.contactRequestState = ContactRequestState.None
 
     self.saveContact(contact)
     self.events.emit(SIGNAL_CONTACT_REMOVED, ContactArgs(contactId: contact.id))

--- a/storybook/pages/ProfileDialogViewPage.qml
+++ b/storybook/pages/ProfileDialogViewPage.qml
@@ -165,10 +165,6 @@ SplitView {
                                 logs.logEvent("contactsStore::removeTrustStatus", ["publicKey"], arguments)
                             }
 
-                            function removeContactRequestRejection(publicKey) {
-                                logs.logEvent("contactsStore::removeContactRequestRejection", ["publicKey"], arguments)
-                            }
-
                             function verifiedUntrustworthy(publicKey) {
                                 logs.logEvent("contactsStore::verifiedUntrustworthy", ["publicKey"], arguments)
                             }

--- a/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
@@ -162,16 +162,6 @@ Item {
         }
     }
 
-    ChatRequestMessagePanel {
-        anchors.fill: parent
-        anchors.bottomMargin: Style.current.bigPadding
-        isUserAdded: root.isUserAdded
-        visible: root.activeChatType === Constants.chatType.oneToOne && !root.isUserAdded
-        onAddContactClicked: {
-            root.rootStore.addContact(root.activeChatId);
-        }
-    }
-
     Component {
         id: cmpSendTransactionNoEns
         ChatCommandModal {

--- a/ui/app/AppLayouts/Chat/views/ChatContentView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatContentView.qml
@@ -1,6 +1,7 @@
 import QtQuick 2.15
 import QtQml 2.15
 import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
 
 import StatusQ.Core.Theme 0.1
 import StatusQ.Core.Utils 0.1 as StatusQUtils
@@ -124,7 +125,7 @@ ColumnLayout {
         sourceComponent: MessageContextMenuView {
             store: root.rootStore
             reactionModel: root.rootStore.emojiReactionsModel
-            disabledForChat: chatType === Constants.chatType.oneToOne && d.contactRequestState !== Constants.ContactRequestState.Mutual
+            disabledForChat: root.chatType === Constants.chatType.oneToOne && root.contactRequestState !== Constants.ContactRequestState.Mutual
 
             onPinMessage: {
                 messageStore.pinMessage(messageId)
@@ -248,7 +249,7 @@ ColumnLayout {
                     anchors.margins: Style.current.smallPadding
 
                     enabled: root.rootStore.sectionDetails.joined && !root.rootStore.sectionDetails.amIBanned &&
-                             !(chatType === Constants.chatType.oneToOne && d.contactRequestState !== Constants.ContactRequestState.Mutual)
+                             !(chatType === Constants.chatType.oneToOne && root.contactRequestState !== Constants.ContactRequestState.Mutual)
 
                     store: root.rootStore
                     usersStore: root.usersStore

--- a/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
@@ -253,7 +253,7 @@ Item {
             chatLogView: ListView.view
 
             isActiveChannel: root.isActiveChannel
-            isChatBlocked: root.isChatBlocked || (root.isOneToOne && d.contactRequestState !== Constants.ContactRequestState.Mutual)
+            isChatBlocked: root.isChatBlocked || (root.isOneToOne && root.contactRequestState !== Constants.ContactRequestState.Mutual)
             messageContextMenu: root.messageContextMenu
 
             messageId: model.id
@@ -339,7 +339,7 @@ Item {
                 case Constants.ContactRequestState.Dismissed:
                     return sendContactRequestComponent
                 case Constants.ContactRequestState.Received:
-                    return acceptContactRequestComponent
+                    return acceptOrDeclineContactRequestComponent
                 case Constants.ContactRequestState.Sent:
                     return pendingContactRequestComponent
                 default:
@@ -371,13 +371,24 @@ Item {
     }
 
     Component {
-        id: acceptContactRequestComponent
+        id: acceptOrDeclineContactRequestComponent
 
-        StatusButton {
+        RowLayout {
             anchors.horizontalCenter: parent.horizontalCenter
-            text: qsTr("Accept Contact Request")
-            onClicked: {
-                root.contactsStore.acceptContactRequest(root.publicKey, "")
+
+            StatusButton {
+                text: qsTr("Reject Contact Request")
+                type: StatusBaseButton.Type.Danger
+                onClicked: {
+                    root.contactsStore.dismissContactRequest(root.publicKey, "")
+                }
+            }
+
+            StatusButton {
+                text: qsTr("Accept Contact Request")
+                onClicked: {
+                    root.contactsStore.acceptContactRequest(root.publicKey, "")
+                }
             }
         }
     }

--- a/ui/app/AppLayouts/Profile/stores/ContactsStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/ContactsStore.qml
@@ -77,10 +77,6 @@ QtObject {
         root.contactsModule.dismissContactRequest(pubKey, contactRequestId)
     }
 
-    function removeContactRequestRejection(pubKey) {
-        root.contactsModule.removeContactRequestRejection(pubKey)
-    }
-
     function markUntrustworthy(pubKey) {
         root.contactsModule.markUntrustworthy(pubKey)
     }

--- a/ui/app/mainui/activitycenter/stores/ActivityCenterStore.qml
+++ b/ui/app/mainui/activitycenter/stores/ActivityCenterStore.qml
@@ -43,6 +43,12 @@ QtObject {
         Declined = 3
     }
 
+    enum ActivityCenterContactRequestState {
+        Pending = 1,
+        Accepted = 2,
+        Dismissed = 3
+    }
+
     readonly property var activityCenterModuleInst: activityCenterModule
     readonly property var activityCenterNotifications: activityCenterModuleInst.activityNotificationsModel
 

--- a/ui/app/mainui/activitycenter/views/ActivityNotificationContactRequest.qml
+++ b/ui/app/mainui/activitycenter/views/ActivityNotificationContactRequest.qml
@@ -11,13 +11,14 @@ import utils 1.0
 
 import "../panels"
 import "../popups"
+import "../stores"
 
 ActivityNotificationMessage {
     id: root
 
-    readonly property bool pending: notification && notification.message.contactRequestState === Constants.contactRequestStatePending
-    readonly property bool accepted: notification && notification.message.contactRequestState === Constants.contactRequestStateAccepted
-    readonly property bool dismissed: notification && notification.message.contactRequestState === Constants.contactRequestStateDismissed
+    readonly property bool pending: notification && notification.message.contactRequestState === ActivityCenterStore.ActivityCenterContactRequestState.Pending
+    readonly property bool accepted: notification && notification.message.contactRequestState === ActivityCenterStore.ActivityCenterContactRequestState.Accepted
+    readonly property bool dismissed: notification && notification.message.contactRequestState === ActivityCenterStore.ActivityCenterContactRequestState.Dismissed
 
     readonly property string contactRequestId: notification && notification.message ? notification.message.id : ""
 

--- a/ui/imports/shared/views/ProfileDialogView.qml
+++ b/ui/imports/shared/views/ProfileDialogView.qml
@@ -358,6 +358,10 @@ Pane {
                     if (d.isCurrentUser)
                         return btnEditProfileComponent
 
+                    // blocked contact
+                    if (d.isBlocked)
+                        return btnUnblockUserComponent
+
                     // contact request, outgoing, rejected
                     if (!d.isContact && d.isContactRequestSent && d.outgoingVerificationStatus === Constants.verificationStatus.declined)
                         return txtRejectedContactRequestComponent
@@ -387,10 +391,6 @@ Pane {
                     // send contact request
                     if (!d.isContact && !d.isBlocked && !d.isContactRequestSent)
                         return btnSendContactRequestComponent
-
-                    // blocked contact
-                    if (d.isBlocked)
-                        return btnUnblockUserComponent
 
                     // send message
                     if (d.isContact && !d.isBlocked)

--- a/ui/imports/shared/views/ProfileDialogView.qml
+++ b/ui/imports/shared/views/ProfileDialogView.qml
@@ -407,7 +407,7 @@ Pane {
                     id: moreMenu
                     width: 230
                     SendContactRequestMenuItem {
-                        enabled: !d.isContact && !d.isBlocked && !d.contactRequestState === Constants.ContactRequestState.Sent &&
+                        enabled: !d.isContact && !d.isBlocked && d.contactRequestState !== Constants.ContactRequestState.Sent &&
                                  d.contactDetails.trustStatus === Constants.trustStatus.untrustworthy // we have an action button otherwise
                         onTriggered: {
                             moreMenu.close()

--- a/ui/imports/shared/views/ProfileDialogView.qml
+++ b/ui/imports/shared/views/ProfileDialogView.qml
@@ -406,7 +406,6 @@ Pane {
                 StatusMenu {
                     id: moreMenu
                     width: 230
-                    // FIXME: raly on contactRequestState !!!
                     SendContactRequestMenuItem {
                         enabled: !d.isContact && !d.isBlocked && !d.contactRequestState === Constants.ContactRequestState.Sent &&
                                  d.contactDetails.trustStatus === Constants.trustStatus.untrustworthy // we have an action button otherwise

--- a/ui/imports/shared/views/ProfileDialogView.qml
+++ b/ui/imports/shared/views/ProfileDialogView.qml
@@ -192,22 +192,6 @@ Pane {
     }
 
     Component {
-        id: btnRevertContactRequestRejectionComponent
-
-        StatusButton {
-            size: StatusButton.Size.Small
-            text: qsTr("Reverse Contact Rejection")
-            icon.name: "refresh"
-            icon.width: 16
-            icon.height: 16
-            onClicked: {
-                root.contactsStore.removeContactRequestRejection(root.publicKey)
-                d.reload()
-            }
-        }
-    }
-
-    Component {
         id: btnSendContactRequestComponent
         StatusButton {
             objectName: "profileDialog_sendContactRequestButton"
@@ -384,11 +368,7 @@ Pane {
 
                     // contact request, incoming, pending
                     if (!d.isContact && d.isContactRequestReceived) {
-                        if (d.contactDetails.removed) {
-                            return btnRevertContactRequestRejectionComponent
-                        } else {
-                            return btnAcceptContactRequestComponent
-                        }
+                        return btnAcceptContactRequestComponent
                     }
 
                     // contact request, incoming, rejected

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -705,11 +705,6 @@ QtObject {
     readonly property int communityChatInvitationOnlyAccess: 2
     readonly property int communityChatOnRequestAccess: 3
 
-    readonly property int contactRequestStateNone: 0
-    readonly property int contactRequestStatePending: 1
-    readonly property int contactRequestStateAccepted: 2
-    readonly property int contactRequestStateDismissed: 3
-
     readonly property int maxNbDaysToFetch: 30
     readonly property int fetchRangeLast24Hours: 86400
     readonly property int fetchRangeLast2Days: 172800
@@ -896,6 +891,14 @@ QtObject {
           Failed,
           InProgress,
           Deployed
+    }
+
+    enum ContactRequestState {
+        None = 0,
+        Mutual = 1,
+        Sent = 2,
+        Received = 3,
+        Dismissed = 4
     }
 
     readonly property QtObject walletSection: QtObject {


### PR DESCRIPTION
Close #10268
Close #9935
Waits https://github.com/status-im/status-desktop/pull/9871

### What does the PR do

- [x] Replace `contact request rejection` with `remove contact` 
- [x] Fix live updating when we receive a CR
- [x] Fix contact tabs behaviour in some edge cases
- [x] Rely on actual CR state instead of artificial flags for [profile](https://www.figma.com/file/ibJOTPlNtIxESwS96vJb06/%F0%9F%91%A4-Profile-%7C-Desktop?node-id=2-10&t=FYHYb3q0bTrGy3Ic-0)
- [x] Update 1-to-1 chat UI for removed contact
- [x] Add add/remove contact events to the 1-to-1 chat (moved [here](https://github.com/status-im/status-desktop/issues/10395))

### Affected areas

Contacts, Profile, Chat

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it (check comments in #9935)

https://user-images.githubusercontent.com/2522130/233578352-7e8b0070-a758-4dd5-9c54-466381393bd3.mov

