### PR TITLE
Fix/10285/10286/messages input not persisted

### DIFF
--- a/src/app/global/loader_deactivator.nim
+++ b/src/app/global/loader_deactivator.nim
@@ -27,14 +27,6 @@ QtObject:
   proc newChatInMemory(sectionId, chatId: string): ChatInMemory =
     (sectionId, chatId)
 
-  proc unloadSection*(self: LoaderDeactivator, searchSectionId: string): bool = 
-    if searchSectionId.len == 0:
-      return false
-    for (sectionId, _) in self.keepInMemory.items:
-      if sectionId == searchSectionId:
-        return false
-    return true
-
   proc addChatInMemory*(self: LoaderDeactivator, sectionId, chatId: string): ChatInMemory =
     if self.keepInMemory.contains(newChatInMemory(sectionId, chatId)):
       return

--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -460,7 +460,7 @@ method activeItemSet*(self: Module, itemId: string) =
 
   # notify parent module about active chat/channel
   self.delegate.onActiveChatChange(mySectionId, activeChatId)
-  self.delegate.onDeactivateSectionAndChatLoader(deactivateSectionId, deactivateChatId)
+  self.delegate.onDeactivateChatLoader(deactivateSectionId, deactivateChatId)
 
 method getModuleAsVariant*(self: Module): QVariant =
   return self.viewVariant

--- a/src/app/modules/main/communities/view.nim
+++ b/src/app/modules/main/communities/view.nim
@@ -3,7 +3,7 @@ import NimQml, json, strutils, json_serialization, sequtils
 import ./io_interface
 import ../../shared_models/section_model
 import ../../shared_models/section_item
-import ../../shared_models/active_section
+import ../../shared_models/section_details
 import ./models/curated_community_model
 import ./models/curated_community_item
 import ./models/discord_file_list_model
@@ -22,7 +22,7 @@ QtObject:
       delegate: io_interface.AccessInterface
       model: SectionModel
       modelVariant: QVariant
-      observedItem: ActiveSection
+      observedItem: SectionDetails
       curatedCommunitiesModel: CuratedCommunityModel
       curatedCommunitiesModelVariant: QVariant
       curatedCommunitiesLoading: bool

--- a/src/app/modules/main/io_interface.nim
+++ b/src/app/modules/main/io_interface.nim
@@ -306,7 +306,7 @@ method onAcceptRequestToJoinLoading*(self: AccessInterface, communityId: string,
 method onAcceptRequestToJoinSuccess*(self: AccessInterface, communityId: string, memberKey: string, requestId: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method onDeactivateSectionAndChatLoader*(self: AccessInterface, sectionId: string, chatId: string) {.base.} =
+method onDeactivateChatLoader*(self: AccessInterface, sectionId: string, chatId: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 # This way (using concepts) is used only for the modules managed by AppController

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -3,7 +3,7 @@ import NimQml, tables, json, sugar, sequtils, strformat, marshal, times, chronic
 import io_interface, view, controller, chat_search_item, chat_search_model
 import ephemeral_notification_item, ephemeral_notification_model
 import ./communities/models/[pending_request_item, pending_request_model]
-import ../shared_models/[user_item, member_item, member_model, section_item, section_model, active_section]
+import ../shared_models/[user_item, member_item, member_model, section_item, section_model, section_details]
 import ../shared_modules/keycard_popup/module as keycard_shared_module
 import ../../global/app_sections_config as conf
 import ../../global/app_signals

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -369,7 +369,6 @@ proc createChannelGroupItem[T](self: Module[T], channelGroup: ChannelGroupDto): 
     ) else: @[],
     channelGroup.encrypted,
     communityTokensItems,
-    loaderActive = active,
   )
 
 method load*[T](
@@ -1194,8 +1193,6 @@ method activateStatusDeepLink*[T](self: Module[T], statusDeepLink: string) =
   let linkToActivate = self.urlsManager.convertExternalLinkToInternal(statusDeepLink)
   self.urlsManager.onUrlActivated(linkToActivate)
 
-method onDeactivateSectionAndChatLoader*[T](self: Module[T], sectionId: string, chatId: string) =
+method onDeactivateChatLoader*[T](self: Module[T], sectionId: string, chatId: string) =
   if (sectionId.len > 0 and self.channelGroupModules.contains(sectionId)):
     self.channelGroupModules[sectionId].onDeactivateChatLoader(chatId)
-    if (singletonInstance.loaderDeactivator.unloadSection(sectionId)):
-      self.view.model().disableSectionLoader(sectionId)

--- a/src/app/modules/main/view.nim
+++ b/src/app/modules/main/view.nim
@@ -1,7 +1,7 @@
 import NimQml, strutils
 import ../shared_models/section_model
 import ../shared_models/section_item
-import ../shared_models/active_section
+import ../shared_models/section_details
 import io_interface
 import chat_search_model
 import ephemeral_notification_model
@@ -16,7 +16,7 @@ QtObject:
       modelVariant: QVariant
       sectionsLoaded: bool
       chatsLoadingFailed: bool
-      activeSection: ActiveSection
+      activeSection: SectionDetails
       activeSectionVariant: QVariant
       chatSearchModel: chat_search_model.Model
       chatSearchModelVariant: QVariant
@@ -126,7 +126,7 @@ QtObject:
   proc emitMailserverNotWorking*(self: View) =
     self.mailserverNotWorking()
 
-  proc activeSection*(self: View): ActiveSection =
+  proc activeSection*(self: View): SectionDetails =
     return self.activeSection
 
   proc getActiveSection(self: View): QVariant {.slot.} =

--- a/src/app/modules/shared_models/section_details.nim
+++ b/src/app/modules/shared_models/section_details.nim
@@ -5,27 +5,27 @@ import ../../../app_service/service/contacts/dto/contacts
 import ../../../app_service/common/types
 
 QtObject:
-  type ActiveSection* = ref object of QObject
+  type SectionDetails* = ref object of QObject
     item: SectionItem
 
-  proc setup(self: ActiveSection) =
+  proc setup(self: SectionDetails) =
     self.QObject.setup
 
-  proc delete*(self: ActiveSection) =
+  proc delete*(self: SectionDetails) =
     self.QObject.delete
 
-  proc newActiveSection*(): ActiveSection =
+  proc newActiveSection*(): SectionDetails =
     new(result, delete)
     result.setup
 
-  proc membersChanged*(self: ActiveSection) {.signal.}
-  proc bannedMembersChanged*(self: ActiveSection) {.signal.}
-  proc pendingRequestsToJoinChanged*(self: ActiveSection) {.signal.}
-  proc pendingMemberRequestsChanged*(self: ActiveSection) {.signal.}
-  proc declinedMemberRequestsChanged*(self: ActiveSection) {.signal.}
-  proc communityTokensChanged*(self: ActiveSection) {.signal.}
+  proc membersChanged*(self: SectionDetails) {.signal.}
+  proc bannedMembersChanged*(self: SectionDetails) {.signal.}
+  proc pendingRequestsToJoinChanged*(self: SectionDetails) {.signal.}
+  proc pendingMemberRequestsChanged*(self: SectionDetails) {.signal.}
+  proc declinedMemberRequestsChanged*(self: SectionDetails) {.signal.}
+  proc communityTokensChanged*(self: SectionDetails) {.signal.}
 
-  proc setActiveSectionData*(self: ActiveSection, item: SectionItem) =
+  proc setActiveSectionData*(self: SectionDetails, item: SectionItem) =
     self.item = item
     self.membersChanged()
     self.bannedMembersChanged()
@@ -34,151 +34,151 @@ QtObject:
     self.pendingRequestsToJoinChanged()
     self.communityTokensChanged()
 
-  proc getId*(self: ActiveSection): string {.slot.} =
+  proc getId*(self: SectionDetails): string {.slot.} =
     return self.item.id
 
   QtProperty[string] id:
     read = getId
 
-  proc getSectionType(self: ActiveSection): int {.slot.} =
+  proc getSectionType(self: SectionDetails): int {.slot.} =
     return self.item.sectionType.int
 
   QtProperty[int] sectionType:
     read = getSectionType
 
-  proc getName(self: ActiveSection): string {.slot.} =
+  proc getName(self: SectionDetails): string {.slot.} =
     return self.item.name
 
   QtProperty[string] name:
     read = getName
 
-  proc getAmISectionAdmin(self: ActiveSection): bool {.slot.} =
+  proc getAmISectionAdmin(self: SectionDetails): bool {.slot.} =
     return self.item.amISectionAdmin
 
   QtProperty[bool] amISectionAdmin:
     read = getAmISectionAdmin
 
-  proc description(self: ActiveSection): string {.slot.} =
+  proc description(self: SectionDetails): string {.slot.} =
     return self.item.description
 
   QtProperty[string] description:
     read = description
 
-  proc introMessage(self: ActiveSection): string {.slot.} =
+  proc introMessage(self: SectionDetails): string {.slot.} =
     return self.item.introMessage
 
   QtProperty[string] introMessage:
     read = introMessage
 
-  proc outroMessage(self: ActiveSection): string {.slot.} =
+  proc outroMessage(self: SectionDetails): string {.slot.} =
     return self.item.outroMessage
 
   QtProperty[string] outroMessage:
     read = outroMessage
 
-  proc getImage(self: ActiveSection): string {.slot.} =
+  proc getImage(self: SectionDetails): string {.slot.} =
     return self.item.image
 
   QtProperty[string] image:
     read = getImage
 
-  proc getBannerImageData(self: ActiveSection): string {.slot.} =
+  proc getBannerImageData(self: SectionDetails): string {.slot.} =
     return self.item.bannerImageData
 
   QtProperty[string] bannerImageData:
     read = getBannerImageData
 
-  proc getIcon(self: ActiveSection): string {.slot.} =
+  proc getIcon(self: SectionDetails): string {.slot.} =
     return self.item.icon
 
   QtProperty[string] icon:
     read = getIcon
 
-  proc getColor(self: ActiveSection): string {.slot.} =
+  proc getColor(self: SectionDetails): string {.slot.} =
     return self.item.color
 
   QtProperty[string] color:
     read = getColor
 
-  proc getTags(self: ActiveSection): string {.slot.} =
+  proc getTags(self: SectionDetails): string {.slot.} =
     return self.item.tags
 
   QtProperty[string] tags:
     read = getTags
 
-  proc getHasNotification(self: ActiveSection): bool {.slot.} =
+  proc getHasNotification(self: SectionDetails): bool {.slot.} =
     return self.item.hasNotification
 
   QtProperty[bool] hasNotification:
     read = getHasNotification
 
-  proc getNotificationCount(self: ActiveSection): int {.slot.} =
+  proc getNotificationCount(self: SectionDetails): int {.slot.} =
     return self.item.notificationsCount
 
   QtProperty[int] notificationCount:
     read = getNotificationCount
 
-  proc canJoin(self: ActiveSection): bool {.slot.} =
+  proc canJoin(self: SectionDetails): bool {.slot.} =
     return self.item.canJoin
 
   QtProperty[bool] canJoin:
     read = canJoin
 
-  proc canRequestAccess(self: ActiveSection): bool {.slot.} =
+  proc canRequestAccess(self: SectionDetails): bool {.slot.} =
     return self.item.canRequestAccess
 
   QtProperty[bool] canRequestAccess:
     read = canRequestAccess
 
-  proc canManageUsers(self: ActiveSection): bool {.slot.} =
+  proc canManageUsers(self: SectionDetails): bool {.slot.} =
     return self.item.canManageUsers
 
   QtProperty[bool] canManageUsers:
     read = canManageUsers
 
-  proc getJoined(self: ActiveSection): bool {.slot.} =
+  proc getJoined(self: SectionDetails): bool {.slot.} =
     return self.item.joined
 
   QtProperty[bool] joined:
     read = getJoined
 
-  proc getIsMember(self: ActiveSection): bool {.slot.} =
+  proc getIsMember(self: SectionDetails): bool {.slot.} =
     return self.item.isMember
 
   QtProperty[bool] isMember:
     read = getIsMember
 
-  proc access(self: ActiveSection): int {.slot.} =
+  proc access(self: SectionDetails): int {.slot.} =
     return self.item.access
 
   QtProperty[int] access:
     read = access
 
-  proc ensOnly(self: ActiveSection): bool {.slot.} =
+  proc ensOnly(self: SectionDetails): bool {.slot.} =
     return self.item.ensOnly
 
   QtProperty[bool] ensOnly:
     read = ensOnly
 
-  proc historyArchiveSupportEnabled(self: ActiveSection): bool {.slot.} =
+  proc historyArchiveSupportEnabled(self: SectionDetails): bool {.slot.} =
     return self.item.historyArchiveSupportEnabled
 
   QtProperty[bool] historyArchiveSupportEnabled:
     read = historyArchiveSupportEnabled
 
-  proc pinMessageAllMembersEnabled(self: ActiveSection): bool {.slot.} =
+  proc pinMessageAllMembersEnabled(self: SectionDetails): bool {.slot.} =
     return self.item.pinMessageAllMembersEnabled
 
   QtProperty[bool] pinMessageAllMembersEnabled:
     read = pinMessageAllMembersEnabled
 
-  proc encrypted(self: ActiveSection): bool {.slot.} =
+  proc encrypted(self: SectionDetails): bool {.slot.} =
     return self.item.encrypted
 
   QtProperty[bool] encrypted:
     read = encrypted
 
-  proc members(self: ActiveSection): QVariant {.slot.} =
+  proc members(self: SectionDetails): QVariant {.slot.} =
     if (self.item.id == ""):
       # FIXME (Jo) I don't know why but the Item is sometimes empty and doing anything here crashes the app
       return newQVariant("")
@@ -189,7 +189,7 @@ QtObject:
     notify = membersChanged
 
 
-  proc bannedMembers(self: ActiveSection): QVariant {.slot.} =
+  proc bannedMembers(self: SectionDetails): QVariant {.slot.} =
     if (self.item.id == ""):
       # FIXME (Jo) I don't know why but the Item is sometimes empty and doing anything here crashes the app
       return newQVariant("")
@@ -199,7 +199,7 @@ QtObject:
     read = bannedMembers
     notify = bannedMembersChanged
 
-  proc communityTokens(self: ActiveSection): QVariant {.slot.} =
+  proc communityTokens(self: SectionDetails): QVariant {.slot.} =
     if (self.item.id == ""):
       # FIXME (Jo) I don't know why but the Item is sometimes empty and doing anything here crashes the app
       return newQVariant("")
@@ -209,14 +209,14 @@ QtObject:
     read = communityTokens
     notify = communityTokensChanged
 
-  proc amIBanned(self: ActiveSection): bool {.slot.} =
+  proc amIBanned(self: SectionDetails): bool {.slot.} =
     return self.item.amIBanned
 
   QtProperty[bool] amIBanned:
     read = amIBanned
     notify = bannedMembersChanged
 
-  proc pendingMemberRequests(self: ActiveSection): QVariant {.slot.} =
+  proc pendingMemberRequests(self: SectionDetails): QVariant {.slot.} =
     if (self.item.id == ""):
       # FIXME (Jo) I don't know why but the Item is sometimes empty and doing anything here crashes the app
       return newQVariant("")
@@ -227,7 +227,7 @@ QtObject:
     notify = pendingMemberRequestsChanged
 
 
-  proc declinedMemberRequests(self: ActiveSection): QVariant {.slot.} =
+  proc declinedMemberRequests(self: SectionDetails): QVariant {.slot.} =
     if (self.item.id == ""):
       # FIXME (Jo) I don't know why but the Item is sometimes empty and doing anything here crashes the app
       return newQVariant("")
@@ -237,15 +237,15 @@ QtObject:
     read = declinedMemberRequests
     notify = declinedMemberRequestsChanged
 
-  proc hasMember(self: ActiveSection, pubkey: string): bool {.slot.} =
+  proc hasMember(self: SectionDetails, pubkey: string): bool {.slot.} =
     return self.item.hasMember(pubkey)
 
-  proc setOnlineStatusForMember*(self: ActiveSection, pubKey: string,
+  proc setOnlineStatusForMember*(self: SectionDetails, pubKey: string,
       onlineStatus: OnlineStatus) =
     self.item.setOnlineStatusForMember(pubKey, onlineStatus)
-    
+
   proc updateMember*(
-      self: ActiveSection,
+      self: SectionDetails,
       pubkey: string,
       name: string,
       ensName: string,
@@ -258,7 +258,7 @@ QtObject:
     self.item.updateMember(pubkey, name, ensName, localNickname, alias, image, isContact,
       isVerified, isUntrustworthy)
 
-  proc pendingRequestsToJoin(self: ActiveSection): QVariant {.slot.} =
+  proc pendingRequestsToJoin(self: SectionDetails): QVariant {.slot.} =
     if (self.item.id == ""):
       # FIXME (Jo) I don't know why but the Item is sometimes empty and doing anything here crashes the app
       return newQVariant("")

--- a/src/app/modules/shared_models/section_item.nim
+++ b/src/app/modules/shared_models/section_item.nim
@@ -55,7 +55,6 @@ type
     declinedMemberRequestsModel: member_model.Model
     encrypted: bool
     communityTokensModel: community_tokens_model.TokenModel
-    loaderActive: bool
 
 proc initItem*(
     id: string,
@@ -92,7 +91,6 @@ proc initItem*(
     declinedMemberRequests: seq[MemberItem] = @[],
     encrypted: bool = false,
     communityTokens: seq[TokenItem] = @[],
-    loaderActive = false,
     ): SectionItem =
   result.id = id
   result.sectionType = sectionType
@@ -134,7 +132,6 @@ proc initItem*(
   result.encrypted = encrypted
   result.communityTokensModel = newTokenModel()
   result.communityTokensModel.setItems(communityTokens)
-  result.loaderActive = loaderActive
 
 proc isEmpty*(self: SectionItem): bool =
   return self.id.len == 0
@@ -174,7 +171,6 @@ proc `$`*(self: SectionItem): string =
     declinedMemberRequests:{self.declinedMemberRequestsModel},
     encrypted:{self.encrypted},
     communityTokensModel:{self.communityTokensModel},
-    loaderActive:{self.loaderActive},
     ]"""
 
 proc id*(self: SectionItem): string {.inline.} =
@@ -326,9 +322,3 @@ proc communityTokens*(self: SectionItem): community_tokens_model.TokenModel {.in
 
 proc updatePendingRequestLoadingState*(self: SectionItem, memberKey: string, loading: bool) {.inline.} =
   self.pendingMemberRequestsModel.updateLoadingState(memberKey, loading)
-
-proc loaderActive*(self: SectionItem): bool {.inline.} = 
-  self.loaderActive
-
-proc `loaderActive=`*(self: var SectionItem, value: bool) {.inline.} = 
-  self.loaderActive = value

--- a/src/app/modules/shared_models/section_model.nim
+++ b/src/app/modules/shared_models/section_model.nim
@@ -42,7 +42,6 @@ type
     PendingMemberRequestsModel
     DeclinedMemberRequestsModel
     AmIBanned
-    LoaderActive
 
 QtObject:
   type
@@ -115,7 +114,6 @@ QtObject:
       ModelRole.PendingMemberRequestsModel.int:"pendingMemberRequests",
       ModelRole.DeclinedMemberRequestsModel.int:"declinedMemberRequests",
       ModelRole.AmIBanned.int:"amIBanned",
-      ModelRole.LoaderActive.int:"loaderActive"
     }.toTable
 
   method data(self: SectionModel, index: QModelIndex, role: int): QVariant =
@@ -199,8 +197,6 @@ QtObject:
       result = newQVariant(item.declinedMemberRequests)
     of ModelRole.AmIBanned:
       result = newQVariant(item.amIBanned)
-    of ModelRole.LoaderActive:
-      result = newQVariant(item.loaderActive)
 
   proc isItemExist(self: SectionModel, id: string): bool =
     for it in self.items:
@@ -299,7 +295,6 @@ QtObject:
       ModelRole.PendingMemberRequestsModel.int,
       ModelRole.DeclinedMemberRequestsModel.int,
       ModelRole.AmIBanned.int,
-      ModelRole.LoaderActive.int
       ])
 
   proc getNthEnabledItem*(self: SectionModel, nth: int): SectionItem =
@@ -339,9 +334,8 @@ QtObject:
         let index = self.createIndex(i, 0, nil)
         defer: index.delete
         self.items[i].active = true
-        self.items[i].loaderActive = true
 
-        self.dataChanged(index, index, @[ModelRole.Active.int, ModelRole.LoaderActive.int])
+        self.dataChanged(index, index, @[ModelRole.Active.int])
 
   proc sectionVisibilityUpdated*(self: SectionModel) {.signal.}
 
@@ -441,14 +435,5 @@ QtObject:
           "ensOnly": item.ensOnly,
           "nbMembers": item.members.getCount(),
           "encrypted": item.encrypted,
-          "loaderActive": item.loaderActive,
         }
         return $jsonObj
-
-  proc disableSectionLoader*(self: SectionModel, sectionId: string) =
-    for i in 0 ..< self.items.len:
-        if(self.items[i].id == sectionId):
-          let index = self.createIndex(i, 0, nil)
-          defer: index.delete
-          self.items[i].loaderActive = false
-          self.dataChanged(index, index, @[ModelRole.LoaderActive.int])

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -33,9 +33,10 @@ QtObject {
     // Each `ChatLayout` has its own chatCommunitySectionModule
     // (on the backend chat and community sections share the same module since they are actually the same)
     property var chatCommunitySectionModule
+    readonly property var sectionDetails: _d.sectionDetailsInstantiator.count ? _d.sectionDetailsInstantiator.objectAt(0) : null
 
     property var communityItemsModel: chatCommunitySectionModule.model
-    
+
     property var assetsModel: SortFilterProxyModel {
         sourceModel: chatCommunitySectionModule.tokenList
 
@@ -656,6 +657,26 @@ QtObject {
                 return
 
             root.goToMembershipRequestsPage()
+        }
+    }
+
+    readonly property QtObject _d: QtObject {
+        readonly property var sectionDetailsInstantiator: Instantiator {
+            model: SortFilterProxyModel {
+                sourceModel: mainModuleInst.sectionsModel
+                filters: ValueFilter {
+                    roleName: "id"
+                    value: chatCommunitySectionModule.getMySectionId()
+                }
+            }
+            delegate: QtObject {
+                readonly property string id: model.id
+                readonly property int sectionType: model.sectionType
+                readonly property string name: model.name
+                readonly property bool joined: model.joined
+                readonly property bool amIBanned: model.amIBanned
+                // add others when needed..
+            }
         }
     }
 }

--- a/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
@@ -139,6 +139,7 @@ Item {
             width: parent.width
             height: parent.height
             visible: model.active && !root.rootStore.openCreateChat && isActiveChannel
+            chatId: model.itemId
             chatMessagesLoader.active: model.loaderActive
             rootStore: root.rootStore
             contactsStore: root.contactsStore
@@ -149,7 +150,6 @@ Item {
             sendTransactionWithEnsModal: cmpSendTransactionWithEns
             stickersLoaded: root.stickersLoaded
             isBlocked: model.blocked
-            isUserAdded: root.isUserAdded
             isActiveChannel: model.active
             onOpenStickerPackPopup: {
                 root.openStickerPackPopup(stickerPackId)

--- a/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
@@ -135,40 +135,33 @@ Item {
         id: chatRepeater
         model: parentModule && parentModule.model
 
-        delegate: Loader {
-            id: chatLoader
-
-            // Channels/chats are not loaded by default and only load when first put active
-            active: model.loaderActive
+        ChatContentView {
             width: parent.width
             height: parent.height
-            visible: model.active
-
-            sourceComponent: ChatContentView {
-                visible: !root.rootStore.openCreateChat && isActiveChannel
-                rootStore: root.rootStore
-                contactsStore: root.contactsStore
-                emojiPopup: root.emojiPopup
-                stickersPopup: root.stickersPopup
-                sendTransactionNoEnsModal: cmpSendTransactionNoEns
-                receiveTransactionModal: cmpReceiveTransaction
-                sendTransactionWithEnsModal: cmpSendTransactionWithEns
-                stickersLoaded: root.stickersLoaded
-                isBlocked: model.blocked
-                isUserAdded: root.isUserAdded
-                isActiveChannel: chatLoader.visible
-                onOpenStickerPackPopup: {
-                    root.openStickerPackPopup(stickerPackId)
-                }
-                onOpenAppSearch: {
-                    root.openAppSearch();
-                }
-                Component.onCompleted: {
-                    parentModule.prepareChatContentModuleForChatId(model.itemId)
-                    chatContentModule = parentModule.getChatContentModule()
-                    chatSectionModule = root.parentModule
-                    root.checkForCreateChatOptions(model.itemId)
-                }
+            visible: model.active && !root.rootStore.openCreateChat && isActiveChannel
+            chatMessagesLoader.active: model.loaderActive
+            rootStore: root.rootStore
+            contactsStore: root.contactsStore
+            emojiPopup: root.emojiPopup
+            stickersPopup: root.stickersPopup
+            sendTransactionNoEnsModal: cmpSendTransactionNoEns
+            receiveTransactionModal: cmpReceiveTransaction
+            sendTransactionWithEnsModal: cmpSendTransactionWithEns
+            stickersLoaded: root.stickersLoaded
+            isBlocked: model.blocked
+            isUserAdded: root.isUserAdded
+            isActiveChannel: model.active
+            onOpenStickerPackPopup: {
+                root.openStickerPackPopup(stickerPackId)
+            }
+            onOpenAppSearch: {
+                root.openAppSearch();
+            }
+            Component.onCompleted: {
+                parentModule.prepareChatContentModuleForChatId(model.itemId)
+                chatContentModule = parentModule.getChatContentModule()
+                chatSectionModule = root.parentModule
+                root.checkForCreateChatOptions(model.itemId)
             }
         }
     }

--- a/ui/app/AppLayouts/Chat/views/ChatContentView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatContentView.qml
@@ -36,9 +36,10 @@ ColumnLayout {
     property var contactsStore
     property bool isActiveChannel: false
 
+    readonly property alias chatMessagesLoader: chatMessagesLoader
+
     property var emojiPopup
     property var stickersPopup
-    property alias textInputField: chatInput
     property UsersStore usersStore: UsersStore {}
 
     onChatContentModuleChanged: {
@@ -76,8 +77,7 @@ ColumnLayout {
         }
     }
 
-    MessageStore {
-        id: messageStore
+    readonly property var messageStore: MessageStore {
         messageModule: chatContentModule ? chatContentModule.messagesModule : null
         chatSectionModule: root.rootStore.chatCommunitySectionModule
     }
@@ -137,33 +137,36 @@ ColumnLayout {
         Layout.fillHeight: true
         clip: true
 
-        ChatMessagesView {
-            id: chatMessages
+        Loader {
+            id: chatMessagesLoader
             Layout.fillWidth: true
             Layout.fillHeight: true
-            chatContentModule: root.chatContentModule
-            rootStore: root.rootStore
-            contactsStore: root.contactsStore
-            messageContextMenu: contextmenu
-            messageStore: messageStore
-            emojiPopup: root.emojiPopup
-            stickersPopup: root.stickersPopup
-            usersStore: root.usersStore
-            stickersLoaded: root.stickersLoaded
-            isChatBlocked: root.isBlocked || (chatContentModule && chatContentModule.chatDetails.type === Constants.chatType.oneToOne && !root.isUserAdded)
-            channelEmoji: !chatContentModule ? "" : (chatContentModule.chatDetails.emoji || "")
-            isActiveChannel: root.isActiveChannel
-            onShowReplyArea: {
-                let obj = messageStore.getMessageByIdAsJson(messageId)
-                if (!obj) {
-                    return
+
+            sourceComponent: ChatMessagesView {
+                chatContentModule: root.chatContentModule
+                rootStore: root.rootStore
+                contactsStore: root.contactsStore
+                messageContextMenu: contextmenu
+                messageStore: root.messageStore
+                emojiPopup: root.emojiPopup
+                stickersPopup: root.stickersPopup
+                usersStore: root.usersStore
+                stickersLoaded: root.stickersLoaded
+                isChatBlocked: root.isBlocked || (chatContentModule && chatContentModule.chatDetails.type === Constants.chatType.oneToOne && !root.isUserAdded)
+                channelEmoji: !chatContentModule ? "" : (chatContentModule.chatDetails.emoji || "")
+                isActiveChannel: root.isActiveChannel
+                onShowReplyArea: {
+                    let obj = messageStore.getMessageByIdAsJson(messageId)
+                    if (!obj) {
+                        return
+                    }
+                    chatInput.showReplyArea(messageId, obj.senderDisplayName, obj.messageText, obj.contentType, obj.messageImage, obj.sticker)
                 }
-                chatInput.showReplyArea(messageId, obj.senderDisplayName, obj.messageText, obj.contentType, obj.messageImage, obj.sticker)
+                onOpenStickerPackPopup: {
+                    root.openStickerPackPopup(stickerPackId);
+                }
+                onEditModeChanged: if (!editModeOn) chatInput.forceInputActiveFocus()
             }
-            onOpenStickerPackPopup: {
-                root.openStickerPackPopup(stickerPackId);
-            }
-            onEditModeChanged: if (!editModeOn) chatInput.forceInputActiveFocus()
         }
 
         Item {

--- a/ui/app/AppLayouts/Chat/views/ChatContentView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatContentView.qml
@@ -58,9 +58,6 @@ ColumnLayout {
 
     property bool stickersLoaded: false
 
-    // FIXME: this should be section data related only to that view, not the active one
-    readonly property var activeSectionData: rootStore.mainModuleInst ? rootStore.mainModuleInst.activeSection || {} : {}
-
     onIsActiveChannelChanged: {
         if (isActiveChannel) {
             chatInput.forceInputActiveFocus();
@@ -183,7 +180,7 @@ ColumnLayout {
                 anchors.fill: parent
                 anchors.margins: Style.current.smallPadding
 
-                enabled: root.activeSectionData.joined && !root.activeSectionData.amIBanned &&
+                enabled: root.rootStore.sectionDetails.joined && !root.rootStore.sectionDetails.amIBanned &&
                          !(chatType === Constants.chatType.oneToOne && !root.isUserAdded)
 
                 store: root.rootStore
@@ -204,7 +201,7 @@ ColumnLayout {
                 }
 
                 Binding on chatInputPlaceholder {
-                    when: !root.activeSectionData.joined || root.activeSectionData.amIBanned
+                    when: !root.rootStore.sectionDetails.joined || root.rootStore.sectionDetails.amIBanned
                     value: qsTr("You need to join this community to send messages")
                 }
 


### PR DESCRIPTION
### What does the PR do

fixes: #10285 
fixes: #10286 

#### Notes

- review commit by commit
- [refactor(chat): rename ActiveSection to SectionDetails](https://github.com/status-im/status-desktop/commit/f48e779295205fe3ac0e1db25edc0f421d903ff0) is not related to the issue but still a good refactor

### Affected areas

- chat switching
- section switching
- chat input permissions ("You need to join this community to send messages", etc.)
- chats memory optimization (up to 5 chats in memory)

https://user-images.githubusercontent.com/33099791/232735686-35b3e376-b1e6-4692-8652-8467f3a27e81.mp4


