### PR TITLE
fix: suggestions list displayed when mentioning, still searches by alias

### DIFF
--- a/ui/app/AppLayouts/Chat/panels/SuggestionFilterPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/SuggestionFilterPanel.qml
@@ -73,7 +73,6 @@ Item {
                 publicKey: listItem.publicKey,
                 name: listItem.name || listItem.alias,
                 nickname: listItem.nickname,
-                alias: listItem.alias,
                 ensName: listItem.ensName,
                 icon: listItem.icon
             }
@@ -88,7 +87,7 @@ Item {
             icon: ""
         }
         if (suggestionsPanelRoot.addSystemSuggestions && (all || isAcceptedItem(filter, everyoneItem))) {
-          filterModel.append(everyoneItem)
+            filterModel.append(everyoneItem)
         }
     }
 

--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -1010,7 +1010,7 @@ Rectangle {
         width: messageInput.width
         filter: messageInputField.text
         cursorPosition: messageInputField.cursorPosition
-        property: ["nickname", "ensName", "name", "alias"]
+        property: ["nickname", "ensName", "name"]
         inputField: messageInputField
         onItemSelected: function (item, lastAtPosition, lastCursorPosition) {
             messageInputField.forceActiveFocus();


### PR DESCRIPTION
explicitly leave out searching by the `alias` (3-word name); it's already enabled as a fallback to `name`

Fixes #9738

### What does the PR do

Fixes searching for erroneously by the 3-word name (alias) when mentioning a user

### Affected areas

StatusChatInput

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![image](https://user-images.githubusercontent.com/5377645/232768526-3fc7ca28-ce17-48e1-8bc1-480bbc23a080.png)

