### PR TITLE
ci: force default Squish params for PR jobs

### DIFF
--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -5,6 +5,7 @@ def isPRBuild = utils.isPRBuild()
 
 pipeline {
   agent {
+    /* Necessary image with Ubuntu 18.04 for older Glibc. */
     docker {
       label 'linux'
       image 'statusteam/nim-status-client-build:1.2.1-qt5.15.2'
@@ -36,6 +37,8 @@ pipeline {
       daysToKeepStr: '30',
       artifactNumToKeepStr: '3',
     ))
+    /* Allows combined build to copy */
+    copyArtifactPermission('/status-desktop/*')
     /* Abort old PR builds. */
     disableConcurrentBuilds(
       abortPrevious: isPRBuild

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -32,6 +32,8 @@ pipeline {
       daysToKeepStr: '30',
       artifactNumToKeepStr: '3',
     ))
+    /* Allows combined build to copy */
+    copyArtifactPermission('/status-desktop/*')
     /* Abort old PR builds. */
     disableConcurrentBuilds(
       abortPrevious: isPRBuild

--- a/ci/Jenkinsfile.tests-e2e
+++ b/ci/Jenkinsfile.tests-e2e
@@ -17,12 +17,12 @@ pipeline {
     string(
       name: 'SQUISH_SUITE',
       description: 'Name of test suite to run in Squish. Defaults to all.',
-      defaultValue: '*'
+      defaultValue: forcePRDefaults(params.SQUISH_SUITE, '*')
     )
     string(
       name: 'SQUISH_TAGS',
       description: 'List of tags to use for Squish tests separated by spaces.',
-      defaultValue: '~mayfail ~merge ~relyon-mailserver'
+      defaultValue: forcePRDefaults(params.SQUISH_TAGS, '~mayfail ~merge ~relyon-mailserver')
     )
     choice(
       name: 'VERBOSE',
@@ -194,4 +194,10 @@ def getPeerAddress() {
     ).trim()
     assert rpcResp : 'Could not get node address from RPC API!'
     return readJSON(text: rpcResp)['result']['listenAddresses'][0]
+}
+
+/* Helper that prevents saving of parameters in PR jobs. */
+def String forcePRDefaults(String previousValue, String defaultValue) {
+  if (utils.isPRBuild()) { return defaultValue }
+  return previousValue ?: defaultValue
 }

--- a/ci/Jenkinsfile.windows
+++ b/ci/Jenkinsfile.windows
@@ -29,6 +29,8 @@ pipeline {
       daysToKeepStr: '30',
       artifactNumToKeepStr: '3',
     ))
+    /* Allows combined build to copy */
+    copyArtifactPermission('/status-desktop/*')
     /* Abort old PR builds. */
     disableConcurrentBuilds(
       abortPrevious: isPRBuild


### PR DESCRIPTION
This way we prevent situation in which a developer or QA engineer runs a custom job with adjusted parameters, and then all following jobs use those modified parameters implicitly. The more sane behavior is to always revert to defaults for PR builds, but remember last used parameters for non-PR builds.

Also added some missing options and comments for other jobs.