### PR TITLE
test(tst_mainSettingsSection): remove hover action

### DIFF
--- a/test/ui-test/src/screens/SettingsScreen.py
+++ b/test/ui-test/src/screens/SettingsScreen.py
@@ -417,9 +417,8 @@ class SettingsScreen:
         started_at = time.monotonic()
         while wait_for_is_visible(BackupSeedPhrasePopup.REVEAL_SEED_PHRASE_BUTTON.value, verify=False):
             try:
-                hover(BackupSeedPhrasePopup.REVEAL_SEED_PHRASE_BUTTON.value)
                 click_obj_by_name(BackupSeedPhrasePopup.REVEAL_SEED_PHRASE_BUTTON.value)
-            except (LookupError, RuntimeError):
+            except (LookupError, RuntimeError) as error:           
                 pass
             if time.monotonic() - started_at > 10:
                 raise RuntimeError('Reveal seed phrase button not clicked')


### PR DESCRIPTION
### What does the PR do

Fixes https://github.com/status-im/status-desktop/issues/10350

Remove hover action from back up seed phrase test because it was failing to me. The test itself passed without this hovering thing so i decided to remove it for now
