### PR TITLE
fix(Makefile): Move StatusQ to order-only-dependencies of the app

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -264,7 +264,7 @@ $(STATUSQ_CMAKE_CACHE): | deps
 		-DSTATUSQ_BUILD_TESTS=OFF \
 		$(STATUSQ_CMAKE_CONFIG_PARAMS) \
 		-B $(STATUSQ_BUILD_PATH) \
-		-S ui/StatusQ
+		-S ui/StatusQ \
 		$(HANDLE_OUTPUT)
 
 statusq-configure: | $(STATUSQ_CMAKE_CACHE) 
@@ -459,7 +459,7 @@ else
 endif
 
 $(NIM_STATUS_CLIENT): NIM_PARAMS += $(RESOURCES_LAYOUT)
-$(NIM_STATUS_CLIENT): $(NIM_SOURCES) statusq $(DOTHERSIDE) | check-qt-dir $(STATUSGO) $(STATUSKEYCARDGO) $(QRCODEGEN) $(FLEETS) rcc compile-translations deps
+$(NIM_STATUS_CLIENT): $(NIM_SOURCES) $(DOTHERSIDE) | statusq check-qt-dir $(STATUSGO) $(STATUSKEYCARDGO) $(QRCODEGEN) $(FLEETS) rcc compile-translations deps
 	echo -e $(BUILD_MSG) "$@" && \
 		$(ENV_SCRIPT) nim c $(NIM_PARAMS) --passL:"-L$(STATUSGO_LIBDIR)" --passL:"-lstatus" --passL:"-L$(STATUSKEYCARDGO_LIBDIR)" --passL:"-lkeycard" $(NIM_EXTRA_PARAMS) --passL:"$(QRCODEGEN)" --passL:"-lm" src/nim_status_client.nim && \
 		[[ $$? = 0 ]] && \


### PR DESCRIPTION
Fix #10349

- move StatusQ to order-only-dependencies of the app
- hide StatusQ build output