### PR TITLE
feat(@desktop/wallet): Wallet -> Send: polish Send/Bridge Modals

### DIFF
--- a/src/app/modules/main/wallet_section/transactions/view.nim
+++ b/src/app/modules/main/wallet_section/transactions/view.nim
@@ -17,6 +17,7 @@ QtObject:
       fetchingHistoryState: Table[string, bool]
       enabledChainIds: seq[int]
       isNonArchivalNode: bool
+      tempAddress: string
 
   proc delete*(self: View) =
     self.model.delete
@@ -197,3 +198,12 @@ QtObject:
       if not self.models.hasKey(fromAddress):
         self.models[fromAddress] = newModel()
       self.models[fromAddress].addNewTransactions(@[tx], wasFetchMore=false)
+
+  proc prepareTransactionsForAddress*(self: View, address: string) {.slot.} =
+    self.tempAddress = address
+
+  proc getTransactions*(self: View): QVariant {.slot.} =
+    if self.models.hasKey(self.tempAddress):
+      return newQVariant(self.models[self.tempAddress])
+    else:
+      return newQVariant()

--- a/src/app_service/service/contacts/async_tasks.nim
+++ b/src/app_service/service/contacts/async_tasks.nim
@@ -20,28 +20,38 @@ type
 
 const lookupContactTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[LookupContactTaskArg](argEncoded)
-  var pubkey = arg.value
-  var address = ""
-
-  if (pubkey.startsWith("0x") or isCompressedPubKey(pubkey)):
-    if pubkey.startsWith("0x"):
-      var num64: int64
-      let parsedChars = parseHex(pubkey, num64)
-      if(parsedChars != PK_LENGTH_0X_INCLUDED):
-        pubkey = ""
-        address = ""
-  else:
-    # TODO refactor those calls to use the new backend and also do it in a signle call
-    pubkey = ens_utils.publicKeyOf(arg.chainId, arg.value)
-    address = ens_utils.addressOf(arg.chainid, arg.value)
-  
-  let output = %*{
-    "id": pubkey,
-    "address": address,
+  var output = %*{
+    "id": "",
+    "address": "",
     "uuid": arg.uuid,
     "reason": arg.reason
   }
-  arg.finish(output)
+  try:
+    var pubkey = arg.value
+    var address = ""
+
+    if (pubkey.startsWith("0x") or isCompressedPubKey(pubkey)):
+      if pubkey.startsWith("0x"):
+        var num64: int64
+        let parsedChars = parseHex(pubkey, num64)
+        if(parsedChars != PK_LENGTH_0X_INCLUDED):
+          pubkey = ""
+          address = ""
+    else:
+      # TODO refactor those calls to use the new backend and also do it in a signle call
+      pubkey = ens_utils.publicKeyOf(arg.chainId, arg.value)
+      address = ens_utils.addressOf(arg.chainid, arg.value)
+
+    output = %*{
+      "id": pubkey,
+      "address": address,
+      "uuid": arg.uuid,
+      "reason": arg.reason
+    }
+    arg.finish(output)
+  except Exception as e:
+    error "error lookupContactTask: ", message = e.msg
+    arg.finish(output)
 
 #################################################
 # Async request contact info

--- a/ui/StatusQ/src/StatusQ/Core/Theme/StatusDarkTheme.qml
+++ b/ui/StatusQ/src/StatusQ/Core/Theme/StatusDarkTheme.qml
@@ -111,6 +111,7 @@ ThemePalette {
     statusListItem: QtObject {
         property color backgroundColor: baseColor3
         property color secondaryHoverBackgroundColor: primaryColor3
+        property color highlightColor: getColor('blue3', 0.05)
     }
 
     statusChatListItem: QtObject {

--- a/ui/StatusQ/src/StatusQ/Core/Theme/StatusLightTheme.qml
+++ b/ui/StatusQ/src/StatusQ/Core/Theme/StatusLightTheme.qml
@@ -109,6 +109,7 @@ ThemePalette {
     statusListItem: QtObject {
         property color backgroundColor: white
         property color secondaryHoverBackgroundColor: getColor('blue6')
+        property color highlightColor: getColor('blue', 0.05)
     }
 
     statusChatListItem: QtObject {

--- a/ui/StatusQ/src/StatusQ/Core/Theme/ThemePalette.qml
+++ b/ui/StatusQ/src/StatusQ/Core/Theme/ThemePalette.qml
@@ -196,6 +196,7 @@ QtObject {
     property QtObject statusListItem: QtObject {
         property color backgroundColor
         property color secondaryHoverBackgroundColor
+        property color highlightColor
     }
 
     property QtObject statusChatListItem: QtObject {

--- a/ui/app/AppLayouts/Profile/controls/WalletAccountDelegate.qml
+++ b/ui/app/AppLayouts/Profile/controls/WalletAccountDelegate.qml
@@ -22,7 +22,6 @@ StatusListItem {
     asset.bgColor: Theme.palette.primaryColor3
     asset.width: 40
     asset.height: 40
-    width: parent.width
     
     components: !showShevronIcon ? [] : [ shevronIcon ]
 

--- a/ui/app/AppLayouts/Profile/views/wallet/MainView.qml
+++ b/ui/app/AppLayouts/Profile/views/wallet/MainView.qml
@@ -86,6 +86,7 @@ Column {
         objectName: "generatedAccounts"
         model: walletStore.generatedAccounts
         delegate: WalletAccountDelegate {
+            width: ListView.view.width
             account: model
             onGoToAccountView: {
                 root.goToAccountView(model.address)
@@ -104,6 +105,7 @@ Column {
     Repeater {
         model: walletStore.importedAccounts
         delegate: WalletAccountDelegate {
+            width: ListView.view.width
             account: model
             onGoToAccountView: {
                 root.goToAccountView(model.address)
@@ -122,6 +124,7 @@ Column {
     Repeater {
         model: walletStore.watchOnlyAccounts
         delegate: WalletAccountDelegate {
+            width: ListView.view.width
             account: model
             onGoToAccountView: {
                 root.goToAccountView(model.address)

--- a/ui/app/AppLayouts/Wallet/views/LeftTabView.qml
+++ b/ui/app/AppLayouts/Wallet/views/LeftTabView.qml
@@ -273,17 +273,16 @@ Rectangle {
                 }
                 components: [
                     StatusIcon {
-                        icon: {
-                            if (model.walletType === Constants.watchWalletType)
-                                return "show"
-                            if (model.walletType === Constants.keyWalletType)
-                                return "keycard"
-
-                            return ""
-                        }
+                        width: !!icon ? 15: 0
+                        height: !!icon ? 15: 0
                         color: Theme.palette.directColor1
-                        width: 15
-                        height: 15
+                        icon: model.walletType === Constants.watchWalletType ? "show" : ""
+                    },
+                    StatusIcon {
+                        width: !!icon ? 15: 0
+                        height: !!icon ? 15: 0
+                        color: Theme.palette.directColor1
+                        icon: model.migratedToKeycard ? "keycard" : ""
                     }
                 ]
 

--- a/ui/imports/shared/controls/ClearButton.qml
+++ b/ui/imports/shared/controls/ClearButton.qml
@@ -1,0 +1,13 @@
+import QtQuick 2.14
+
+import StatusQ.Controls 0.1
+import StatusQ.Core.Theme 0.1
+
+StatusFlatRoundButton {
+    type: StatusFlatRoundButton.Type.Secondary
+    icon.name: "clear"
+    icon.width: 16
+    icon.height: 16
+    icon.color: Theme.palette.baseColor1
+    backgroundHoverColor: "transparent"
+}

--- a/ui/imports/shared/controls/SavedAddressListItem.qml
+++ b/ui/imports/shared/controls/SavedAddressListItem.qml
@@ -1,0 +1,44 @@
+import QtQuick 2.15
+
+import StatusQ.Components 0.1
+import StatusQ.Core.Theme 0.1
+import StatusQ.Controls 0.1
+import StatusQ.Core.Utils 0.1 as StatusQUtils
+
+import AppLayouts.Wallet 1.0
+
+import utils 1.0
+
+StatusListItem {
+    id: root
+    property var modelData
+    property bool clearVisible: false
+    signal cleared()
+
+    implicitHeight: visible ? 64 : 0
+    title: !!modelData ? modelData.name: ""
+    subTitle:  {
+        if(!!modelData) {
+            if (modelData.ens.length > 0) {
+                return sensor.containsMouse ? Utils.richColorText(modelData.ens, Theme.palette.directColor1) : modelData.ens
+            }
+            else {
+                let elidedAddress = StatusQUtils.Utils.elideText(modelData.address,6,4)
+                return sensor.containsMouse ? WalletUtils.colorizedChainPrefix(modelData.chainShortNames) + Utils.richColorText(elidedAddress, Theme.palette.directColor1): modelData.chainShortNames + elidedAddress
+            }
+        }
+        return ""
+    }
+    statusListItemSubTitle.elide: Text.ElideMiddle
+    statusListItemSubTitle.wrapMode: Text.NoWrap
+    radius: 0
+    color: sensor.containsMouse || highlighted ? Theme.palette.statusListItem.highlightColor : "transparent"
+    components: [
+        ClearButton {
+            width: 24
+            height: 24
+            visible: root.clearVisible
+            onClicked: root.cleared()
+        }
+    ]
+}

--- a/ui/imports/shared/controls/SearchBoxWithRightIcon.qml
+++ b/ui/imports/shared/controls/SearchBoxWithRightIcon.qml
@@ -1,0 +1,22 @@
+import QtQuick 2.14
+
+import StatusQ.Controls 0.1
+import StatusQ.Core.Theme 0.1
+
+StatusInput {
+    placeholderText: qsTr("Search")
+    input.implicitHeight: 56
+    input.background.color: Theme.palette.indirectColor1
+    input.background.border.width: 0
+    input.rightComponent: StatusFlatRoundButton {
+        icon.name: "search"
+        type: StatusFlatRoundButton.Type.Secondary
+        enabled: false
+    }
+    Rectangle {
+        anchors.bottom: parent.bottom
+        height: 1
+        width: parent.width
+        color: Theme.palette.baseColor2
+    }
+}

--- a/ui/imports/shared/controls/TokenBalancePerChainDelegate.qml
+++ b/ui/imports/shared/controls/TokenBalancePerChainDelegate.qml
@@ -13,19 +13,32 @@ StatusListItem {
         return ""
     }
     signal tokenSelected(var selectedToken)
+    signal tokenHovered(var selectedToken, bool hovered)
 
     title: name
+    titleAsideText: symbol
+    statusListItemTitleAside.font.pixelSize: 15
     label: LocaleUtils.currencyAmountToLocaleString(totalCurrencyBalance)
     asset.name: symbol ? Style.png("tokens/" + symbol) : ""
     asset.isImage: true
     asset.width: 32
     asset.height: 32
+    statusListItemLabel.anchors.verticalCenterOffset: -12
     statusListItemLabel.color: Theme.palette.directColor1
     statusListItemInlineTagsSlot.spacing: sensor.containsMouse ? 0 :  -8
     tagsModel: balances.count > 0 ? balances : []
     tagsDelegate: sensor.containsMouse ? expandedItem : compactItem
+    radius: sensor.containsMouse || root.highlighted ? 0 : 8
+    color: sensor.containsMouse || highlighted ? Theme.palette.statusListItem.highlightColor : "transparent"
 
     onClicked: d.selectToken()
+
+    Connections {
+        target: root.sensor
+        function onContainsMouseChanged() {
+            root.tokenHovered({name, symbol, totalBalance, totalCurrencyBalance, balances, decimals}, root.sensor.containsMouse)
+        }
+    }
 
     QtObject {
         id: d
@@ -42,7 +55,6 @@ StatusListItem {
             width: 16
             height: 16
             image.source: Style.svg("tiny/%1".arg(root.getNetworkIcon(chainId)))
-            visible: balance.amount > 0
         }
     }
     Component {
@@ -57,7 +69,6 @@ StatusListItem {
             asset.height: 16
             asset.isImage: true
             asset.name: Style.svg("tiny/%1".arg(root.getNetworkIcon(chainId)))
-            visible: balance.amount > 0
         }
     }
 }

--- a/ui/imports/shared/controls/WalletAccountListItem.qml
+++ b/ui/imports/shared/controls/WalletAccountListItem.qml
@@ -1,0 +1,76 @@
+import QtQuick 2.15
+
+import StatusQ.Components 0.1
+import StatusQ.Core.Theme 0.1
+import StatusQ.Core 0.1
+import StatusQ.Controls 0.1
+import StatusQ.Core.Utils 0.1 as StatusQUtils
+
+import AppLayouts.Wallet 1.0
+
+import utils 1.0
+
+StatusListItem {
+    id: root
+
+    property var modelData
+    property string chainShortNames
+    property bool clearVisible: false
+    signal cleared()
+
+    objectName: !!modelData  ? modelData.name: ""
+
+    height: visible ? 64 : 0
+    title: !!modelData && !!modelData.name ? modelData.name : ""
+    subTitle:{
+        if(!!modelData) {
+            let elidedAddress = StatusQUtils.Utils.elideText(modelData.address,6,4)
+            return sensor.containsMouse ? WalletUtils.colorizedChainPrefix(chainShortNames) + Utils.richColorText(elidedAddress, Theme.palette.directColor1): chainShortNames + elidedAddress
+        }
+        return ""
+    }
+    statusListItemSubTitle.wrapMode: Text.NoWrap
+    asset.emoji: !!modelData && !!modelData.emoji ? modelData.emoji: ""
+    asset.color: !!modelData ? modelData.color: ""
+    asset.name: !!modelData && !modelData.emoji ? "filled-account": ""
+    asset.letterSize: 14
+    asset.isLetterIdenticon: !!modelData && !!modelData.emoji ? true : false
+    asset.bgColor: Theme.palette.indirectColor1
+    asset.width: 40
+    asset.height: 40
+    radius: 0
+    color: sensor.containsMouse || highlighted ? Theme.palette.statusListItem.highlightColor : "transparent"
+    components: [
+        Column {
+            anchors.verticalCenter: parent.verticalCenter
+            StatusTextWithLoadingState   {
+                anchors.right: parent.right
+                font.pixelSize: 15
+                text: LocaleUtils.currencyAmountToLocaleString(!!modelData ? modelData.currencyBalance: "")
+            }
+            Row {
+                anchors.right: parent.right
+                spacing: 6
+                StatusIcon {
+                    width: !!icon ? 15: 0
+                    height: !!icon ? 15 : 0
+                    color: Theme.palette.directColor1
+                    icon: modelData.walletType === Constants.watchWalletType ? "show" : ""
+                }
+                StatusIcon {
+                    width: !!icon ? 15: 0
+                    height: !!icon ? 15 : 0
+                    color: Theme.palette.directColor1
+                    icon: modelData.migratedToKeycard ? "keycard" : ""
+                }
+            }
+        },
+        ClearButton {
+            anchors.verticalCenter: parent.verticalCenter
+            width: 24
+            height: 24
+            visible: root.clearVisible
+            onClicked: root.cleared()
+        }
+    ]
+}

--- a/ui/imports/shared/panels/StatusAssetSelector.qml
+++ b/ui/imports/shared/panels/StatusAssetSelector.qml
@@ -25,6 +25,7 @@ Item {
     property string userSelectedToken
     property string currentCurrencySymbol
     property string placeholderText
+    property var hoveredToken
 
     property var tokenAssetSourceFn: function (symbol) {
         return ""
@@ -51,12 +52,19 @@ Item {
         }
     }
 
+    onHoveredTokenChanged: {
+        if (hoveredToken && hoveredToken.symbol) {
+            d.iconSource = tokenAssetSourceFn(hoveredToken.symbol)
+            d.text = hoveredToken.symbol
+        }
+    }
+
     QtObject {
         id: d
         property string iconSource: ""
         property string text: ""
         property string searchString
-        property bool isTokenSelected: !!root.selectedAsset
+        readonly property bool isTokenSelected: !!root.selectedAsset || !!root.hoveredToken
 
         readonly property var updateSearchText: Backpressure.debounce(root, 1000, function(inputText) {
             d.searchString = inputText
@@ -70,8 +78,8 @@ Item {
 
         control.padding: 4
         control.popup.width: 492
-        control.popup.height: 416
         control.popup.x: -root.x
+        control.popup.verticalPadding: 0
 
         popupContentItemObjectName: "assetSelectorList"
 
@@ -171,11 +179,11 @@ Item {
             placeholderText: qsTr("Search for token or enter token address")
             onTextChanged: Qt.callLater(d.updateSearchText, text)
             input.clearable: true
-            input.rightComponent: StatusIcon {
-                width: 16
-                height: 16
-                color: Theme.palette.baseColor1
-                icon: "search"
+            input.implicitHeight: 56
+            input.rightComponent: StatusFlatRoundButton {
+                icon.name: "search"
+                type: StatusFlatRoundButton.Type.Secondary
+                enabled: false
             }
             Rectangle {
                 anchors.bottom: parent.bottom

--- a/ui/imports/shared/stores/TransactionStore.qml
+++ b/ui/imports/shared/stores/TransactionStore.qml
@@ -4,6 +4,7 @@ import utils 1.0
 
 import shared.stores 1.0
 import "../../../app/AppLayouts/Profile/stores"
+import SortFilterProxyModel 0.2
 
 QtObject {
     id: root
@@ -20,7 +21,15 @@ QtObject {
     property var accounts: walletSectionAccounts.model
     property var currentAccount: walletSectionCurrent
     property string signingPhrase: walletSection.signingPhrase
-    property var savedAddressesModel: walletSectionSavedAddresses.model
+    property var savedAddressesModel: SortFilterProxyModel {
+        sourceModel: walletSectionSavedAddresses.model
+        filters: [
+            ValueFilter {
+                roleName: "isTest"
+                value: networksModule.areTestNetworksEnabled
+            }
+        ]
+    }
     property var disabledChainIdsFromList: []
     property var disabledChainIdsToList: []
 
@@ -279,5 +288,22 @@ QtObject {
                 }
         }
         return {}
+    }
+
+    function prepareTransactionsForAddress(address) {
+        walletSectionTransactions.prepareTransactionsForAddress(address)
+    }
+
+    function getTransactions() {
+        return walletSectionTransactions.getTransactions()
+    }
+
+    function getAllNetworksSupportedString() {
+        let result = ""
+        for(var i = 0; i < allNetworks.count; i++) {
+            let shortName = allNetworks.rowData(i, "shortName")
+            result += shortName + ':'
+        }
+        return result
     }
 }

--- a/ui/imports/shared/views/RecipientView.qml
+++ b/ui/imports/shared/views/RecipientView.qml
@@ -1,0 +1,230 @@
+import QtQuick 2.13
+import QtQuick.Layouts 1.13
+
+import StatusQ.Controls 0.1
+import StatusQ.Core 0.1
+import StatusQ.Core.Theme 0.1
+import StatusQ.Core.Utils 0.1 as StatusQUtils
+
+import AppLayouts.Wallet 1.0
+
+import utils 1.0
+
+import "../controls"
+
+Loader {
+    id: root
+
+    property var store
+    property bool isBridgeTx: false
+    property bool interactive: true
+    property bool showUnpreferredNetworks: false
+    property var selectedAsset
+    property var selectedRecipient: null
+    property int selectedRecipientType
+
+    readonly property bool ready: (d.isAddressValid || root.isENSValid) && !d.isPending
+    property string addressText
+    property bool isENSValid: false
+    property string resolvedENSAddress
+
+    signal recalculateRoutesAndFees()
+    signal isLoading()
+
+    onAddressTextChanged: d.isPending = false
+
+    onSelectedRecipientChanged: {
+        root.isLoading()
+        d.waitTimer.restart()
+        if(!!root.selectedRecipient && root.selectedRecipientType !== TabAddressSelectorView.Type.None) {
+            switch(root.selectedRecipientType) {
+            case TabAddressSelectorView.Type.SavedAddress: {
+                if (root.selectedRecipient.ens.length > 0) {
+                    d.isPending = true
+                    return  store.resolveENS(root.selectedRecipient.ens)
+                }
+            }
+            case TabAddressSelectorView.Type.RecentsAddress: {
+                let isIncoming = root.selectedRecipient.to === root.selectedRecipient.address
+                root.addressText = isIncoming ? root.selectedRecipient.from : root.selectedRecipient.to
+                root.item.input.text = root.addressText
+                return
+            }
+            case TabAddressSelectorView.Type.Address: {
+                root.item.input.text = root.selectedRecipient.address
+            }
+            }
+            root.addressText = root.selectedRecipient.address
+        }
+    }
+
+    QtObject {
+        id: d
+        property bool isAddressValid: Utils.isValidAddress(root.addressText)
+        readonly property var resolveENS: Backpressure.debounce(root, 500, function (ensName) {
+            store.resolveENS(ensName)
+        })
+        property bool isPending: false
+        function clearValues() {
+            root.addressText = ""
+            root.isENSValid = false
+            root.resolvedENSAddress = ""
+            root.selectedRecipientType = TabAddressSelectorView.Type.None
+            root.selectedRecipient = null
+        }
+        property Timer waitTimer: Timer {
+            interval: 1500
+            onTriggered: {
+                if(!!root.item) {
+                    if (d.isPending) {
+                        return
+                    }
+                    if (root.isENSValid)  {
+                        if(!!root.item.input)
+                            root.item.input.text = root.resolvedENSAddress
+                        root.addressText = root.resolvedENSAddress
+                        store.splitAndFormatAddressPrefix(root.address, root.isBridgeTx, root.showUnpreferredNetworks)
+                    } else {
+                        let address = d.getAddress()
+                        let result = store.splitAndFormatAddressPrefix(address, root.isBridgeTx, root.showUnpreferredNetworks)
+                        if(!!result.address) {
+                            root.addressText = result.address
+                            if(!!root.item.input)
+                                root.item.input.text = result.formattedText
+                        }
+                    }
+                    root.recalculateRoutesAndFees()
+                }
+            }
+        }
+
+        function getAddress() {
+            if(root.selectedRecipientType === TabAddressSelectorView.Type.SavedAddress || root.selectedRecipientType === TabAddressSelectorView.Type.Account){
+                return root.item.chainShortNames + root.selectedRecipient.address
+            }
+            else {
+                return !!root.item.input && !!root.store.plainText(root.item.input.text) ? root.store.plainText(root.item.input.text): ""
+            }
+        }
+    }
+
+    sourceComponent: root.selectedRecipientType === TabAddressSelectorView.Type.SavedAddress ? savedAddressRecipient:
+                                                                                               root.selectedRecipientType === TabAddressSelectorView.Type.Account ? myAccountRecipient : addressRecipient
+
+    Component {
+        id: savedAddressRecipient
+        SavedAddressListItem {
+            property string chainShortNames: !!modelData ? modelData.chainShortNames: ""
+            implicitWidth: parent.width
+            modelData: root.selectedRecipient
+            radius: 8
+            clearVisible: true
+            color: Theme.palette.indirectColor1
+            sensor.enabled: false
+            subTitle:  {
+                if(!!modelData) {
+                    if (!!modelData && !!modelData.ens && modelData.ens.length > 0)
+                        return Utils.richColorText(modelData.ens, Theme.palette.directColor1)
+                    else
+                        return WalletUtils.colorizedChainPrefix(modelData.chainShortNames) + StatusQUtils.Utils.elideText(modelData.address,6,4)
+                }
+                return ""
+            }
+            onCleared: d.clearValues()
+        }
+    }
+
+    Component {
+        id: myAccountRecipient
+        WalletAccountListItem {
+            implicitWidth: parent.width
+            chainShortNames: store.getAllNetworksSupportedString()
+            modelData: root.selectedRecipient
+            radius: 8
+            clearVisible: true
+            color: Theme.palette.indirectColor1
+            sensor.enabled: false
+            subTitle: {
+                if(!!modelData) {
+                    let elidedAddress = StatusQUtils.Utils.elideText(modelData.address,6,4)
+                    return WalletUtils.colorizedChainPrefix(chainShortNames) + StatusQUtils.Utils.elideText(elidedAddress,6,4)
+                }
+                return ""
+            }
+            onCleared: d.clearValues()
+        }
+    }
+
+    Component {
+        id: addressRecipient
+        StatusInput {
+            id: recipientInput
+            width: parent.width
+            height: visible ? implicitHeight: 0
+            visible: !root.isBridgeTx && !!root.selectedAsset
+
+            placeholderText: qsTr("Enter an ENS name or address")
+            input.background.color: Theme.palette.indirectColor1
+            input.background.border.width: 0
+            input.implicitHeight: 56
+            input.clearable: root.interactive
+            input.edit.readOnly: !root.interactive
+            multiline: false
+            input.edit.textFormat: TextEdit.RichText
+
+            input.rightComponent: RowLayout {
+                StatusButton {
+                    font.weight: Font.Normal
+                    borderColor: Theme.palette.primaryColor1
+                    size: StatusBaseButton.Size.Tiny
+                    text: qsTr("Paste")
+                    visible: !store.plainText(recipientInput.text)
+                    onClicked: recipientInput.input.edit.paste()
+                }
+                StatusIcon {
+                    Layout.preferredWidth: 16
+                    Layout.preferredHeight: 16
+                    icon: "tiny/checkmark"
+                    color: Theme.palette.primaryColor1
+                    visible: !!store.plainText(recipientInput.text)
+                }
+                ClearButton {
+                    Layout.preferredWidth: 24
+                    Layout.preferredHeight: 24
+                    visible: !!store.plainText(recipientInput.text)
+                    onClicked: {
+                        recipientInput.input.edit.clear()
+                        d.clearValues()
+                    }
+                }
+            }
+            Keys.onReleased: {
+                let plainText =  store.plainText(input.edit.text)
+                if(!plainText) {
+                    d.clearValues()
+                }
+                else {
+                    root.isLoading()
+                    d.waitTimer.restart()
+                    if(!Utils.isValidAddress(plainText)) {
+                        d.isPending = true
+                        d.resolveENS(plainText)
+                    }
+                }
+            }
+        }
+    }
+
+    Connections {
+        target: store.mainModuleInst
+        function onResolvedENS(resolvedPubKey: string, resolvedAddress: string, uuid: string) {
+            d.isPending = false
+            if(Utils.isValidAddress(resolvedAddress)) {
+                root.resolvedENSAddress = resolvedAddress
+                root.isENSValid = true
+            }
+            d.waitTimer.restart()
+        }
+    }
+}
+

--- a/ui/imports/shared/views/TokenListView.qml
+++ b/ui/imports/shared/views/TokenListView.qml
@@ -17,6 +17,7 @@ Item {
 
     property var assets: null
     signal tokenSelected(var selectedToken)
+    signal tokenHovered(var selectedToken, bool hovered)
     property var searchTokenSymbolByAddressFn: function (address) {
         return ""
     }
@@ -37,66 +38,55 @@ Item {
         id: contentLayout
 
         anchors.fill: parent
+        spacing: 8
+
+        StatusBaseText {
+            id: label
+            elide: Text.ElideRight
+            text: qsTr("Token to send")
+            font.pixelSize: 13
+            color: Theme.palette.directColor1
+        }
 
         Rectangle {
             Layout.fillWidth: true
-            Layout.preferredHeight: headerColumn.height
+            Layout.preferredHeight: tokenList.height
 
             color: Theme.palette.indirectColor1
             radius: 8
 
-            Column {
-                id: headerColumn
+            StatusListView {
+                id: tokenList
 
                 width: parent.width
-                Item {
-                    height: 5
+                height: tokenList.contentHeight
+
+                header: SearchBoxWithRightIcon {
                     width: parent.width
-                }
-                StatusInput {
-                    height: 50
-                    width: parent.width
-                    input.showBackground: false
                     placeholderText: qsTr("Search for token or enter token address")
-                    input.rightComponent: StatusIcon {
-                        icon: "search"
-                        height: 17
-                        color: Theme.palette.baseColor1
-                    }
                     onTextChanged: Qt.callLater(d.updateSearchText, text)
                 }
-                Rectangle {
-                    height: 1
-                    width: parent.width
-                    color: Theme.palette.baseColor3
-                }
-            }
-        }
 
-        StatusListView {
-            id: tokenList
-
-            Layout.fillWidth: true
-            Layout.preferredHeight: 396
-
-            model: SortFilterProxyModel {
-                sourceModel: root.assets
-                filters: [
-                    ExpressionFilter {
-                        expression: {
-                            var tokenSymbolByAddress = searchTokenSymbolByAddressFn(d.searchString)
-                            tokenList.positionViewAtBeginning()
-                            return visibleForNetwork && (
-                                symbol.startsWith(d.searchString.toUpperCase()) || name.toUpperCase().startsWith(d.searchString.toUpperCase()) || (tokenSymbolByAddress!=="" && symbol.startsWith(tokenSymbolByAddress))
-                            )
+                model: SortFilterProxyModel {
+                    sourceModel: root.assets
+                    filters: [
+                        ExpressionFilter {
+                            expression: {
+                                var tokenSymbolByAddress = searchTokenSymbolByAddressFn(d.searchString)
+                                tokenList.positionViewAtBeginning()
+                                return visibleForNetwork && (
+                                            symbol.startsWith(d.searchString.toUpperCase()) || name.toUpperCase().startsWith(d.searchString.toUpperCase()) || (tokenSymbolByAddress!=="" && symbol.startsWith(tokenSymbolByAddress))
+                                            )
+                            }
                         }
-                    }
-                ]
-            }
-            delegate: TokenBalancePerChainDelegate {
-                width: ListView.view.width
-                getNetworkIcon: root.getNetworkIcon
-                onTokenSelected: root.tokenSelected(selectedToken)
+                    ]
+                }
+                delegate: TokenBalancePerChainDelegate {
+                    width: ListView.view.width
+                    getNetworkIcon: root.getNetworkIcon
+                    onTokenSelected: root.tokenSelected(selectedToken)
+                    onTokenHovered: root.tokenHovered(selectedToken, hovered)
+                }
             }
         }
     }


### PR DESCRIPTION
fixes #10344, #10321, #10320

### What does the PR do

IMplements brlow features/bugs:


- [x] 1. Circular highlight of the tokens list when send modal is launched  Magnify in search should be correct size and joint to  the list
- [x] NO token selected view
- [x] Hovering over token should update token and max on top of the modal
- [x] 0.00 with cursor is missing
- [x] clicking on max should update amount to send 
- [x] Recents account doesn’t correlated with selected account from header
- [x] On switching account the max amount should change
- [x] The my accounts list in the my accounts the list item is different and highlight I slighter
- [x] When own account is elected, the UI in to field is different and all networks are selected by default
- [x] For saved address, with and without prefix -> prefix should show in list in send Modal as well
- [x] Search list and magnify glass in saved addresses
- [x] Paste button missing inside the To field in send modal
- [x] Token selector  combbox, highlight, search icon and placement, and only as long as the tokens list
- [x] Rounded corners for all background rects
- [x] Have padding for list with modal so that no list overflows the modal
- [x] add loading state to recents in sendModal

### Affected areas

<!-- List the affected areas (e.g wallet, browser, etc..) -->
SendModal

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

https://user-images.githubusercontent.com/60327365/233621104-7a60e7f6-58d4-473b-ac6f-91adb33dc727.mov



