### PR TITLE
fix(re-encryption): make sure loading screen is shown when re-encrypting

### DIFF
--- a/src/app/modules/startup/controller.nim
+++ b/src/app/modules/startup/controller.nim
@@ -175,6 +175,11 @@ proc init*(self: Controller) =
     self.delegate.onReencryptionProcessStarted()
   self.connectionIds.add(handlerId)
 
+  handlerId = self.events.onWithUUID(SIGNAL_LOGIN_ERROR) do(e: Args):
+    let args = LoginErrorArgs(e)
+    self.delegate.emitAccountLoginError(args.error)
+  self.connectionIds.add(handlerId)
+
 proc shouldStartWithOnboardingScreen*(self: Controller): bool =
   return self.accountsService.openedAccounts().len == 0
 
@@ -440,9 +445,7 @@ proc isSelectedAccountAKeycardAccount*(self: Controller): bool =
 proc login*(self: Controller) =
   self.delegate.moveToLoadingAppState()
   let selectedAccount = self.getSelectedLoginAccount()
-  let error = self.accountsService.login(selectedAccount, self.tmpPassword)
-  if(error.len > 0):
-    self.delegate.emitAccountLoginError(error)
+  self.accountsService.login(selectedAccount, self.tmpPassword)
 
 proc loginAccountKeycard*(self: Controller, storeToKeychainValue: string, syncWalletAfterLogin = false) =
   if syncWalletAfterLogin:


### PR DESCRIPTION
Fixes #10352

Adds a 1 second timer before re-encrypting, to make sure the loading screen is shown before it starts, since it can freeze.

Do note that this is on top of the release branch. I'll cherry-pick on master once it is merged.

I have not tested with an actual big re-encryption yet, but I could reproduce the issue with a `sleep` and the timer fixed the freeze.

I'll test later on Windows.