### PR TITLE
fix(chat): wrap `contextMenu` and `chatInput` into Loader

### DIFF
--- a/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
@@ -138,7 +138,7 @@ Item {
         ChatContentView {
             width: parent.width
             height: parent.height
-            visible: model.active && !root.rootStore.openCreateChat && isActiveChannel
+            visible: !root.rootStore.openCreateChat && isActiveChannel
             chatId: model.itemId
             chatMessagesLoader.active: model.loaderActive
             rootStore: root.rootStore


### PR DESCRIPTION
### What does the PR do

fixes: #10378

wraps `contextMenu` and `chatInput` into Loader, see: https://github.com/status-im/status-desktop/pull/10343#issuecomment-1515103756

Please note that this solution serves as a temporary workaround and
comes with variety of limitations, particulary concerning the chat
input state. For instance, the reply area is not retained when switching
between chats.
Ideally the root cause, which is the high memory consumption of both
`StatusChatInput` and `MessageContextMenuView`, should be fixed. Once
this issue is addressed, the current workaround can be reverted.
