### PR TITLE
fix(StatusChatListItem): fix mute icon overlapping badges

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/StatusChatListItem.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusChatListItem.qml
@@ -138,7 +138,7 @@ Rectangle {
             anchors.left: statusIcon.visible ? statusIcon.right : identicon.right
             anchors.leftMargin: statusIcon.visible ? 1 : 8
             anchors.right: mutedIcon.visible ? mutedIcon.left :
-                                               statusBadge.visible ? statusBadge.left : parent.right
+                                               statusBadge.visible ? statusBadgeContainer.left : parent.right
             anchors.rightMargin: 6
             anchors.verticalCenter: parent.verticalCenter
 
@@ -166,7 +166,7 @@ Rectangle {
 
         StatusIcon {
             id: mutedIcon
-            anchors.right: statusBadge.visible ? statusBadge.left : parent.right
+            anchors.right: statusBadge.visible ? statusBadgeContainer.left : parent.right
             anchors.rightMargin: 8
             anchors.verticalCenter: parent.verticalCenter
             width: 14
@@ -188,6 +188,7 @@ Rectangle {
             }
         }
         Item {
+            id: statusBadgeContainer
             width: 32
             height: parent.height
             anchors.right: parent.right


### PR DESCRIPTION
### What does the PR do

Fixes the mute icon overlapping the badges

Partly fixes (the UI issue): #10345

### Affected areas

StatusChatListItem

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![image](https://user-images.githubusercontent.com/5377645/233611683-7285cf24-7640-45b6-aa02-ded211bcc12f.png)

