### PR TITLE
fix(os-notifications): Display image emoji for sticker in notification

### DIFF
--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -930,7 +930,7 @@ method onNewMessagesReceived*(self: Module, sectionIdMsgBelongsTo: string, chatI
   let communityChats = self.controller.getCommunityById(chatDetails.communityId).chats
   let renderedMessageText = self.controller.getRenderedText(message.parsedText, communityChats)
   var plainText = singletonInstance.utils.plainText(renderedMessageText)
-  if ContentType(message.contentType) == ContentType.Image and len(plainText) == 0:
+  if ContentType(message.contentType) == ContentType.Sticker or (ContentType(message.contentType) == ContentType.Image and len(plainText) == 0):
     plainText = "🖼️"
   var notificationTitle = contactDetails.defaultDisplayName
 


### PR DESCRIPTION
Fixes: #10294

### What does the PR do

Shows emoji for notifications with stickers instead of placeholder text

### Affected areas

OS Notifications

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

