### PR TITLE
Fix(DOtherSide): Exclude threaded renderer all darwin architectures

### DIFF
--- a/vendor/DOtherSide/lib/src/DOtherSide.cpp
+++ b/vendor/DOtherSide/lib/src/DOtherSide.cpp
@@ -175,7 +175,7 @@ void dos_qguiapplication_initialize_opengl()
 
 void dos_qguiapplication_try_enable_threaded_renderer()
 {
-    if(QSysInfo::buildCpuArchitecture() == "arm64" && QSysInfo::kernelType() == "darwin" && QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
+    if(QSysInfo::kernelType() == "darwin" && QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
     {
         //Threaded renderer is crashing on M1 Macs
         return;


### PR DESCRIPTION
Close #10332

Solution found by @alexjbam, discussion [here](https://github.com/status-im/status-desktop/issues/10332#issuecomment-1519850306)

### Affected areas

DOtherSide
