### PR TITLE
[onboarding]: forbid display name whitespaces on beggining and end

### DIFF
--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -442,13 +442,23 @@ QtObject {
 
     readonly property QtObject validators: QtObject {
         readonly property list<StatusValidator> displayName: [
-            StatusMinLengthValidator {
-                minLength: 5
-                errorMessage: qsTr("Username must be at least 5 characters")
+            StatusValidator {
+                name: "startsWithSpaceValidator"
+                validate: function (t) { return !t.startsWith(" ") }
+                errorMessage: qsTr("Usernames starting with whitespace are not allowed")
             },
             StatusRegularExpressionValidator {
                 regularExpression: /^[a-zA-Z0-9\-_ ]+$/
                 errorMessage: qsTr("Only letters, numbers, underscores, whitespaces and hyphens allowed")
+            },
+            StatusMinLengthValidator {
+                minLength: 5
+                errorMessage: qsTr("Username must be at least 5 characters")
+            },
+            StatusValidator {
+                name: "endsWithSpaceValidator"
+                validate: function (t) { return !t.endsWith(" ") }
+                errorMessage: qsTr("Usernames ending with whitespace are not allowed")
             },
             // TODO: Create `StatusMaxLengthValidator` in StatusQ
             StatusValidator {


### PR DESCRIPTION
Closes #10120 

### What does the PR do
Onboarding: prevent user to create display names with whitespaces in the beginning or end

### Affected areas
Onboarding

### Screenshot of functionality (including design for comparison)
https://user-images.githubusercontent.com/31625338/234036903-9b118bb4-a028-4d43-a46f-b00b096236fe.mov

