### PR TITLE
fix(@desktop/wallet): Disabled network still shows in valid path

### DIFF
--- a/ui/imports/shared/popups/SendModal.qml
+++ b/ui/imports/shared/popups/SendModal.qml
@@ -139,7 +139,7 @@ StatusDialog {
         }
 
         // add networks that are down to disabled list
-        if(!!d.networkConnectionStore.blockchainNetworksDown) {
+        if(d.networkConnectionStore.blockchainNetworksDown.length !== 0) {
             for(let i in d.networkConnectionStore.blockchainNetworksDown) {
                 store.addRemoveDisabledToChain(parseInt(d.networkConnectionStore.blockchainNetworksDown[i]), true)
             }

--- a/ui/imports/shared/stores/NetworkConnectionStore.qml
+++ b/ui/imports/shared/stores/NetworkConnectionStore.qml
@@ -15,7 +15,7 @@ QtObject {
     readonly property bool marketValuesCache: walletSectionCurrent.hasMarketValuesCache
     readonly property bool collectiblesCache: walletSectionCurrent.getHasCollectiblesCache()
 
-    readonly property var blockchainNetworksDown: networkConnectionModule.blockchainNetworkConnection.chainIds.split(";")
+    readonly property var blockchainNetworksDown: !!networkConnectionModule.blockchainNetworkConnection.chainIds ? networkConnectionModule.blockchainNetworkConnection.chainIds.split(";") : []
     readonly property bool atleastOneBlockchainNetworkAvailable: blockchainNetworksDown.length <  networksModule.all.count
 
     readonly property bool sendBuyBridgeEnabled: localAppSettings.testEnvironment || (isOnline &&


### PR DESCRIPTION
When a path is shown on goreli and I disable it , it still shows the path to Goreli on simple view

fixes #10393

### What does the PR do

Fixes the bug of disabled chain not added to list of disabled chains

### Affected areas

SendModal

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it


Uploading Screen Recording 2023-04-25 at 9.50.49 AM.mov…

