### PR TITLE
fix: device sync timestamp is wrong

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/StatusContactRequestsIndicatorListItem.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusContactRequestsIndicatorListItem.qml
@@ -21,11 +21,8 @@ StatusListItem {
             border.color: color
         },
         StatusIcon {
-            icon: "chevron-down"
-            rotation: 270
+            icon: "next"
             color: Theme.palette.baseColor1
         }
     ]
 }
-
-

--- a/ui/StatusQ/src/StatusQ/Components/StatusSyncDeviceDelegate.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusSyncDeviceDelegate.qml
@@ -45,12 +45,10 @@ StatusListItem {
         if (d.daysFromSync == 1)
             return qsTr("Last online yesterday")
 
-        const date = new Date(d.deviceLastTimestamp)
-
         if (d.daysFromSync <= 6)
-            return qsTr("Last online [%1]").arg(LocaleUtils.getDayName(date))
+            return qsTr("Last online: %1").arg(LocaleUtils.formatRelativeTimestamp(d.deviceLastTimestamp))
 
-        return qsTr("Last online %1").arg(LocaleUtils.formatDate(date))
+        return qsTr("Last online: %1").arg(LocaleUtils.formatDate(d.deviceLastTimestamp))
     }
 
     subTitleBadgeComponent: root.showOnlineBadge ? onlineBadgeComponent : null
@@ -77,11 +75,10 @@ StatusListItem {
         id: d
 
         property real now: 0
-        readonly property int deviceLastTimestamp: root.timestamp / 1000000
+        readonly property real deviceLastTimestamp: root.timestamp / 1000000
         readonly property int secondsFromSync: (now - Math.max(0, d.deviceLastTimestamp)) / 1000
         readonly property int minutesFromSync: secondsFromSync / 60
-        readonly property int hoursFromSync: minutesFromSync / 60
-        readonly property int daysFromSync: hoursFromSync / 24
+        readonly property int daysFromSync: LocaleUtils.daysBetween(new Date(now), new Date(d.deviceLastTimestamp))
         readonly property bool onlineNow: secondsFromSync <= 120
     }
 

--- a/ui/StatusQ/src/StatusQ/Components/StatusSyncDeviceDelegate.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusSyncDeviceDelegate.qml
@@ -68,8 +68,7 @@ StatusListItem {
         StatusIcon {
             anchors.verticalCenter: parent.verticalCenter
             visible: root.enabled
-            icon: "chevron-down"
-            rotation: 270
+            icon: "next"
             color: Theme.palette.baseColor1
         }
     ]

--- a/ui/StatusQ/src/StatusQ/Core/LocaleUtils.qml
+++ b/ui/StatusQ/src/StatusQ/Core/LocaleUtils.qml
@@ -206,13 +206,6 @@ QtObject {
             }
         }
 
-        // return full days between 2 dates
-        function daysBetween(firstDate, secondDate) {
-            firstDate.setHours(0, 0, 0) // discard time
-            secondDate.setHours(0, 0, 0)
-            return Math.round(Math.abs((firstDate - secondDate) / d.msInADay)) // Math.round: not all days are 24 hours long!
-        }
-
         property var nonDigitCharacterRegExpLocale
 
         readonly property var nonDigitCharacterRegExp: {
@@ -232,6 +225,13 @@ QtObject {
     function is24hTimeFormatDefault() {
         const timeFormatString = Qt.locale().timeFormat(Locale.LongFormat)
         return !d.amPmFormatChars.some(ampm => timeFormatString.includes(ampm))
+    }
+
+    // return full days between 2 dates
+    function daysBetween(firstDate, secondDate) {
+        firstDate.setHours(0, 0, 0) // discard time
+        secondDate.setHours(0, 0, 0)
+        return Math.round(Math.abs((firstDate - secondDate) / d.msInADay)) // Math.round: not all days are 24 hours long!
     }
 
     /**
@@ -287,7 +287,7 @@ QtObject {
         const value = d.readDate(timestamp)
         const loc = Qt.locale()
         const formatString = d.fixupTimeFormatString(loc.timeFormat(Locale.ShortFormat)) // format string for the time part
-        const dayDifference = d.daysBetween(d.readDate(timestamp), now)
+        const dayDifference = daysBetween(d.readDate(timestamp), now)
 
         // within last day, 2 or 7 days
         if (dayDifference < 1) // today -> "Today 14:23"

--- a/ui/app/AppLayouts/Profile/controls/WalletNetworkDelegate.qml
+++ b/ui/app/AppLayouts/Profile/controls/WalletNetworkDelegate.qml
@@ -14,8 +14,7 @@ StatusListItem {
     rightPadding: Style.current.padding
     components: [
         StatusIcon {
-            icon: "chevron-down"
-            rotation: 270
+            icon: "next"
             color: Theme.palette.baseColor1
         }
     ]

--- a/ui/app/AppLayouts/Profile/views/EnsListView.qml
+++ b/ui/app/AppLayouts/Profile/views/EnsListView.qml
@@ -143,8 +143,7 @@ Item {
 
                     components: [
                         StatusIcon {
-                            icon: "chevron-down"
-                            rotation: 270
+                            icon: "next"
                             color: Theme.palette.baseColor1
                         }
                     ]

--- a/ui/app/AppLayouts/Profile/views/MessagingView.qml
+++ b/ui/app/AppLayouts/Profile/views/MessagingView.qml
@@ -341,8 +341,7 @@ SettingsContentBase {
             label: root.messagingStore.getMailserverNameForNodeAddress(root.messagingStore.activeMailserver)
             components: [
                 StatusIcon {
-                    icon: "chevron-down"
-                    rotation: 270
+                    icon: "next"
                     color: Theme.palette.baseColor1
                 }
             ]
@@ -363,8 +362,7 @@ SettingsContentBase {
             visible: root.advancedStore.isWakuV2
             components: [
                 StatusIcon {
-                    icon: "chevron-down"
-                    rotation: 270
+                    icon: "next"
                     color: Theme.palette.baseColor1
                 }
             ]

--- a/ui/app/AppLayouts/Profile/views/keycard/MainView.qml
+++ b/ui/app/AppLayouts/Profile/views/keycard/MainView.qml
@@ -99,7 +99,7 @@ ColumnLayout {
                               : qsTr("Migrate an existing account from Status Desktop to Keycard")
         components: [
             StatusIcon {
-                icon: "tiny/chevron-right"
+                icon: "next"
                 color: Theme.palette.baseColor1
             }
         ]
@@ -120,7 +120,7 @@ ColumnLayout {
         title: qsTr("Create a new Keycard account with a new seed phrase")
         components: [
             StatusIcon {
-                icon: "tiny/chevron-right"
+                icon: "next"
                 color: Theme.palette.baseColor1
             }
         ]
@@ -134,7 +134,7 @@ ColumnLayout {
         title: qsTr("Import or restore via a seed phrase")
         components: [
             StatusIcon {
-                icon: "tiny/chevron-right"
+                icon: "next"
                 color: Theme.palette.baseColor1
             }
         ]
@@ -148,7 +148,7 @@ ColumnLayout {
         title: qsTr("Import from Keycard to Status Desktop")
         components: [
             StatusIcon {
-                icon: "tiny/chevron-right"
+                icon: "next"
                 color: Theme.palette.baseColor1
             }
         ]
@@ -169,7 +169,7 @@ ColumnLayout {
         title: qsTr("Check what’s on a Keycard")
         components: [
             StatusIcon {
-                icon: "tiny/chevron-right"
+                icon: "next"
                 color: Theme.palette.baseColor1
             }
         ]
@@ -183,7 +183,7 @@ ColumnLayout {
         title: qsTr("Factory reset a Keycard")
         components: [
             StatusIcon {
-                icon: "tiny/chevron-right"
+                icon: "next"
                 color: Theme.palette.baseColor1
             }
         ]

--- a/ui/app/AppLayouts/Profile/views/wallet/MainView.qml
+++ b/ui/app/AppLayouts/Profile/views/wallet/MainView.qml
@@ -39,8 +39,7 @@ Column {
         label: qsTr("%n DApp(s) connected", "", root.walletStore.dappList.count)
         components: [
             StatusIcon {
-                icon: "chevron-down"
-                rotation: 270
+                icon: "next"
                 color: Theme.palette.baseColor1
             }
         ]
@@ -58,8 +57,7 @@ Column {
         onClicked: goToNetworksView()
         components: [
             StatusIcon {
-                icon: "chevron-down"
-                rotation: 270
+                icon: "next"
                 color: Theme.palette.baseColor1
             }
         ]
@@ -121,9 +119,10 @@ Column {
     }
 
     Repeater {
+        width: parent.width
         model: importedAccounts
         delegate: WalletAccountDelegate {
-            width: ListView.view.width
+            width: parent.width
             account: model
             onGoToAccountView: {
                 root.goToAccountView(model)
@@ -149,9 +148,10 @@ Column {
     }
 
     Repeater {
+        width: parent.width
         model: watchOnlyAccounts
         delegate: WalletAccountDelegate {
-            width: ListView.view.width
+            width: parent.width
             account: model
             onGoToAccountView: {
                 root.goToAccountView(model)

--- a/ui/app/AppLayouts/Wallet/popups/CryptoServicesModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/CryptoServicesModal.qml
@@ -60,8 +60,7 @@ StatusModal {
                         statusListItemSubTitle.maximumLineCount: 1
                         components: [
                             StatusIcon {
-                                icon: "chevron-down"
-                                rotation: 270
+                                icon: "next"
                                 color: Theme.palette.baseColor1
                             }
                         ]

--- a/ui/imports/shared/status/StatusSettingsLineButton.qml
+++ b/ui/imports/shared/status/StatusSettingsLineButton.qml
@@ -6,6 +6,7 @@ import ".."
 import "../panels"
 
 import StatusQ.Controls 0.1 as StatusQControls
+import StatusQ.Core 0.1 as StatusQCore
 
 Rectangle {
     property string text
@@ -100,21 +101,14 @@ Rectangle {
         }
     }
 
-    SVGImage {
+    StatusQCore.StatusIcon {
         id: caret
         visible: !root.isSwitch
         anchors.right: parent.right
         anchors.rightMargin: Style.current.padding
         anchors.verticalCenter: textItem.verticalCenter
-        source: Style.svg("caret")
-        width: 13
-        height: 7
-        rotation: -90
-        ColorOverlay {
-            anchors.fill: caret
-            source: caret
-            color: Style.current.secondaryText
-        }
+        icon: "next"
+        color: Style.current.secondaryText
     }
 
     MouseArea {


### PR DESCRIPTION
- prevent QML `int` overflow
- use `LocaleUtils.formatRelativeTimestamp()` to perform the timestamp
formatting
- separate commit for the next/chevron icons

Fixes https://github.com/status-im/status-desktop/issues/10412

### Affected areas

Settings/Syncing

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![image](https://user-images.githubusercontent.com/5377645/234252411-0028e49d-c4bc-475e-ae20-29295966cb43.png)

