### PR TITLE
[RFC] fix: make the wallet warning banners less obtrusive

### DIFF
--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -480,7 +480,6 @@ Item {
                 }
 
                 Layout.fillWidth: true
-                Layout.maximumHeight: implicitHeight
                 spacing: 1
 
                 onIsConnectedChanged: {
@@ -561,7 +560,6 @@ Item {
                         appMain.rootStore.profileSectionStore.profileStore.userDeclinedBackupBanner = true
                     }
                 }
-
 
                 ModuleWarning {
                     Layout.fillWidth: true
@@ -736,7 +734,7 @@ Item {
                             }
                             else if(chainIdsDown.length > 0) {
                                 if(chainIdsDown.length > 2) {
-                                    return qsTr("POKT & Infura down for <a href='#'>multiple chains </a>. Token balances for those chains cannot be retrieved.")
+                                    return qsTr("POKT & Infura down for <a href='#'>multiple chains</a>. Token balances for those chains cannot be retrieved.")
                                 }
                                 else if(chainIdsDown.length === 1) {
                                     return qsTr("POKT & Infura down for %1. %1 token balances are as of %2.").arg(jointChainIdString).arg(lastCheckedAt)


### PR DESCRIPTION
### What does the PR do

- show the wallet connection warning/error banners only when the active
app section is actually "Wallet"
- fix some out-of-context variable access in NetworkConnectionStore

### Affected areas

AppMain/Wallet banners

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

Banners still visible in Wallet:
![image](https://user-images.githubusercontent.com/5377645/234300409-1ab2d957-6c22-4377-a102-9b75f8d782a7.png)


Nothing to see elsewhere (once you hide them):
![image](https://user-images.githubusercontent.com/5377645/234288255-5cca0fd2-cde0-49a3-bd21-4622214151f1.png)

