### PR TITLE
fix: reduce Image cache

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/StatusCommunityCard.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusCommunityCard.qml
@@ -203,6 +203,7 @@ Rectangle {
             fillMode: Image.PreserveAspectCrop
             smooth: true
             visible: false
+            cache: false
         }
 
         OpacityMask {

--- a/ui/StatusQ/src/StatusQ/Components/StatusContactVerificationIcons.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusContactVerificationIcons.qml
@@ -24,6 +24,7 @@ Row {
         property Image dummyImage: Image {
             source: mutualConnectionIcon.name ? "../../assets/img/icons/" + mutualConnectionIcon.name + ".svg": ""
             visible: false
+            cache: false
         }
     }
 
@@ -42,6 +43,7 @@ Row {
         property Image dummyImage: Image {
             source: trustContactIcon.name ? "../../assets/img/icons/" + trustContactIcon.name + ".svg": ""
             visible: false
+            cache: false
         }
     }
 

--- a/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusImageMessage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusImageMessage.qml
@@ -32,7 +32,7 @@ Item {
 
     QtObject {
         id: _internal
-        property bool isAnimated: !!source && source.toString().endsWith('.gif')
+        readonly property bool isAnimated: !!source && source.toString().endsWith('.gif')
         property bool pausePlaying: false
     }
 
@@ -43,6 +43,7 @@ Item {
         fillMode: Image.PreserveAspectFit
         source: imageContainer.source
         playing: _internal.isAnimated && isAppWindowActive && !_internal.pausePlaying
+        cache: false
 
         layer.enabled: true
         layer.effect: OpacityMask {

--- a/ui/StatusQ/src/StatusQ/Controls/StatusImageCrop.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusImageCrop.qml
@@ -366,5 +366,6 @@ Item {
         // Align window center to window rect
         x: windowRect.x + windowRect.width/2
         y: windowRect.y + windowRect.height/2
+        cache: false
     }
 }

--- a/ui/StatusQ/src/StatusQ/Controls/StatusImageSelector.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusImageSelector.qml
@@ -220,6 +220,7 @@ Control {
 
                 anchors.fill: parent
                 fillMode: Image.PreserveAspectFit
+                cache: false
             }
         }
     }

--- a/ui/app/AppLayouts/Browser/views/BrowserWebEngineView.qml
+++ b/ui/app/AppLayouts/Browser/views/BrowserWebEngineView.qml
@@ -133,6 +133,7 @@ WebEngineView {
                 anchors.horizontalCenter: parent.horizontalCenter
                 anchors.top: parent.top
                 anchors.topMargin: 60
+                cache: false
             }
 
             FavoritesList {

--- a/ui/app/AppLayouts/Chat/panels/ChatRequestMessagePanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/ChatRequestMessagePanel.qml
@@ -21,6 +21,7 @@ Item {
         width: 80
         height: 80
         anchors.horizontalCenter: parent.horizontalCenter
+        cache: false
     }
 
     StatusBaseText {

--- a/ui/app/AppLayouts/Chat/popups/ChooseBrowserPopup.qml
+++ b/ui/app/AppLayouts/Chat/popups/ChooseBrowserPopup.qml
@@ -24,6 +24,7 @@ StatusDialog {
             Layout.preferredWidth: 240
             Layout.preferredHeight: 148
             Layout.alignment: Qt.AlignHCenter
+            cache: false
         }
 
         StatusButton {

--- a/ui/app/AppLayouts/Chat/views/communities/CommunityWelcomeSettingsView.qml
+++ b/ui/app/AppLayouts/Chat/views/communities/CommunityWelcomeSettingsView.qml
@@ -52,6 +52,7 @@ StatusScrollView {
                     Layout.alignment: Qt.AlignHCenter
                     fillMode: Image.PreserveAspectFit
                     mipmap: true
+                    cache: false
                 }
 
                 StatusBaseText {

--- a/ui/app/AppLayouts/Onboarding/views/AllowNotificationsView.qml
+++ b/ui/app/AppLayouts/Onboarding/views/AllowNotificationsView.qml
@@ -33,6 +33,7 @@ Item {
         anchors.bottomMargin: Style.current.padding
         fillMode: Image.PreserveAspectFit
         source: Style.png("onboarding/notifications@2x")
+        cache: false
     }
 
     StyledText {

--- a/ui/app/AppLayouts/Onboarding/views/InsertDetailsView.qml
+++ b/ui/app/AppLayouts/Onboarding/views/InsertDetailsView.qml
@@ -199,6 +199,7 @@ Item {
                 id: imgChains
                 anchors.horizontalCenter: parent.horizontalCenter
                 source: Style.svg("onboarding/chains")
+                cache: false
             }
             EmojiHash {
                 anchors {

--- a/ui/app/AppLayouts/Onboarding/views/KeysMainView.qml
+++ b/ui/app/AppLayouts/Onboarding/views/KeysMainView.qml
@@ -45,6 +45,7 @@ Item {
             id: keysImg
             Layout.alignment: Qt.AlignHCenter
             mipmap: true
+            cache: false
         }
 
         StyledText {

--- a/ui/app/AppLayouts/Onboarding/views/TouchIDAuthView.qml
+++ b/ui/app/AppLayouts/Onboarding/views/TouchIDAuthView.qml
@@ -47,6 +47,7 @@ Item {
             antialiasing: true
             source: Style.png("onboarding/fingerprint@2x")
             mipmap: true
+            cache: false
         }
 
         StyledText {

--- a/ui/app/AppLayouts/Onboarding/views/WelcomeView.qml
+++ b/ui/app/AppLayouts/Onboarding/views/WelcomeView.qml
@@ -46,6 +46,7 @@ Item {
             fillMode: Image.PreserveAspectFit
             source: Style.png("onboarding/welcome")
             mipmap: true
+            cache: false
         }
 
         StyledText {

--- a/ui/app/AppLayouts/Profile/popups/backupseed/Acknowledgements.qml
+++ b/ui/app/AppLayouts/Profile/popups/backupseed/Acknowledgements.qml
@@ -51,6 +51,7 @@ ColumnLayout {
                         Layout.alignment: Qt.AlignHCenter
                         Layout.preferredWidth: 120
                         Layout.preferredHeight: width
+                        cache: false
                     }
 
                     StyledText {

--- a/ui/app/AppLayouts/Profile/popups/setupsyncing/DisplaySyncCode.qml
+++ b/ui/app/AppLayouts/Profile/popups/setupsyncing/DisplaySyncCode.qml
@@ -73,6 +73,7 @@ ColumnLayout {
             mipmap: true
             smooth: false
             source: globalUtils.qrCode(root.connectionString)
+            cache: false
         }
 
         FastBlur {

--- a/ui/app/AppLayouts/Profile/views/AboutView.qml
+++ b/ui/app/AppLayouts/Profile/views/AboutView.qml
@@ -38,6 +38,7 @@ SettingsContentBase {
                 fillMode: Image.PreserveAspectFit
                 source: Style.png("status-logo")
                 anchors.horizontalCenter: parent.horizontalCenter
+                cache: false
             }
 
             Item { width: 1; height: 8}

--- a/ui/app/AppLayouts/Profile/views/CommunitiesView.qml
+++ b/ui/app/AppLayouts/Profile/views/CommunitiesView.qml
@@ -53,6 +53,7 @@ SettingsContentBase {
                 Layout.preferredWidth: 434
                 Layout.preferredHeight: 213
                 Layout.topMargin: 18
+                cache: false
             }
 
             StatusBaseText {

--- a/ui/app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml
+++ b/ui/app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml
@@ -364,6 +364,7 @@ Item {
             width: height
             source: Style.png("tokens/SNT")
             sourceSize: Qt.size(width, height)
+            cache: false
         }
 
         StatusBaseText {

--- a/ui/app/AppLayouts/Profile/views/EnsWelcomeView.qml
+++ b/ui/app/AppLayouts/Profile/views/EnsWelcomeView.qml
@@ -41,6 +41,7 @@ Item {
                 anchors.horizontalCenter: parent.horizontalCenter
                 fillMode: Image.PreserveAspectFit
                 source: Style.png("ens-header-" + Style.current.name + "@2x")
+                cache: false
             }
 
             StatusBaseText {

--- a/ui/app/AppLayouts/Profile/views/keycard/MainView.qml
+++ b/ui/app/AppLayouts/Profile/views/keycard/MainView.qml
@@ -40,6 +40,7 @@ ColumnLayout {
         antialiasing: true
         source: Style.png("keycard/keycard-security")
         mipmap: true
+        cache: false
     }
 
     Item {

--- a/ui/app/AppLayouts/Wallet/addaccount/states/ConfirmAddingNewMasterKey.qml
+++ b/ui/app/AppLayouts/Wallet/addaccount/states/ConfirmAddingNewMasterKey.qml
@@ -52,6 +52,7 @@ Item {
             fillMode: Image.PreserveAspectFit
             source: Style.png("onboarding/keys")
             mipmap: true
+            cache: false
         }
 
         StatusBaseText {

--- a/ui/app/AppLayouts/Wallet/controls/CollectiblesHeader.qml
+++ b/ui/app/AppLayouts/Wallet/controls/CollectiblesHeader.qml
@@ -29,6 +29,7 @@ Rectangle {
         anchors.left: parent.left
         anchors.leftMargin: Style.current.padding
         anchors.verticalCenter: parent.verticalCenter
+        cache: false
     }
 
     StyledText {

--- a/ui/app/AppLayouts/Wallet/views/LoadingGraphView.qml
+++ b/ui/app/AppLayouts/Wallet/views/LoadingGraphView.qml
@@ -31,6 +31,7 @@ Loader {
             sourceSize: Qt.size(parent.width, parent.height)
             smooth: true
             visible: false
+            cache: false
         }
 
         OpacityMask {

--- a/ui/app/mainui/panels/DropAreaPanel.qml
+++ b/ui/app/mainui/panels/DropAreaPanel.qml
@@ -64,6 +64,7 @@ DropArea {
             x: index * 10 + rptDraggedPreviews.x
             y: index * 10 + rptDraggedPreviews.y
             z: 1
+            cache: false
         }
     }
 }

--- a/ui/imports/shared/controls/chat/ProfileHeader.qml
+++ b/ui/imports/shared/controls/chat/ProfileHeader.qml
@@ -70,6 +70,7 @@ Item {
         Image {
             id: tmpImage
             mipmap: true
+            cache: false
         }
 
         property var keepGrabResultAlive;

--- a/ui/imports/shared/status/StatusChatImageLoader.qml
+++ b/ui/imports/shared/status/StatusChatImageLoader.qml
@@ -56,6 +56,7 @@ Item {
         source: root.source
         playing: root.isAnimated && root.playing
         mipmap: true
+        cache: false
 
         onStatusChanged: {
             if (imageMessage.status === Image.Error && !retryTimer.running) {

--- a/ui/imports/shared/status/StatusChatInputImageArea.qml
+++ b/ui/imports/shared/status/StatusChatInputImageArea.qml
@@ -31,6 +31,7 @@ Row {
                 mipmap: true
                 smooth: false
                 antialiasing: true
+                cache: false
                 source: modelData
                 layer.enabled: true
                 layer.effect: OpacityMask {

--- a/ui/imports/shared/views/chat/LinksMessageView.qml
+++ b/ui/imports/shared/views/chat/LinksMessageView.qml
@@ -139,6 +139,7 @@ Column {
                 asynchronous: true
                 isAnimated: result.contentType ? result.contentType.toLowerCase().endsWith("gif") : false
                 onClicked: isAnimated && !playing ? localAnimationEnabled = true : root.imageClicked(linkImage.imageAlias)
+                imageAlias.cache: localAnimationEnabled // GIFs can only loop/play properly with cache enabled
                 Loader {
                     width: 45
                     height: 38


### PR DESCRIPTION
for everything that's not a user interface element, esp. for static/big images or chat/message elements which get served locally anyway from status-go

Iterates #10339

### What does the PR do

Reduce RAM usage by _not_ caching non-UI interface elements