### PR TITLE
(settings): removed community permissions,tokens,airdrop and discord options

### DIFF
--- a/src/app/global/local_account_sensitive_settings.nim
+++ b/src/app/global/local_account_sensitive_settings.nim
@@ -91,7 +91,6 @@ const LSS_KEY_STICKERS_ENS_ROPSTEN* = "stickersEnsRopsten"
 const DEFAULT_STICKERS_ENS_ROPSTEN = false
 const LSS_KEY_USER_DECLINED_BACKUP_BANNER* = "userDeclinedBackupBanner"
 const DEFAULT_USER_DECLINED_BACKUP_BANNER = false
-const LSS_KEY_IS_DISCORD_IMPORT_TOOL_ENABLED* = "isDiscordImportToolEnabled"
 const DEFAULT_IS_DISCORD_IMPORT_TOOL_ENABLED = false
 
 
@@ -227,30 +226,6 @@ QtObject:
     write = setProfileSplitView
     notify = profileSplitViewChanged
 
-  proc isCommunityPermissionsEnabledChanged*(self: LocalAccountSensitiveSettings) {.signal.}
-  proc getIsCommunityPermissionsEnabled*(self: LocalAccountSensitiveSettings): bool {.slot.} =
-    getSettingsProp[bool](self, LSS_KEY_IS_COMMUNITY_PERMISSIONS_ENABLED, newQVariant(DEFAULT_IS_COMMUNITY_PERMISSIONS_ENABLED))
-  proc setIsCommunityPermissionsEnabled*(self: LocalAccountSensitiveSettings, value: bool) {.slot.} =
-    setSettingsProp(self, LSS_KEY_IS_COMMUNITY_PERMISSIONS_ENABLED, newQVariant(value)):
-      self.isCommunityPermissionsEnabledChanged()
-
-  QtProperty[bool] isCommunityPermissionsEnabled:
-    read = getIsCommunityPermissionsEnabled
-    write = setIsCommunityPermissionsEnabled
-    notify = isCommunityPermissionsEnabledChanged
-
-  proc isCommunityTokensEnabledChanged*(self: LocalAccountSensitiveSettings) {.signal.}
-  proc getIsCommunityTokensEnabled*(self: LocalAccountSensitiveSettings): bool {.slot.} =
-    getSettingsProp[bool](self, LSS_KEY_IS_COMMUNITY_TOKENS_ENABLED, newQVariant(DEFAULT_IS_COMMUNITY_TOKENS_ENABLED))
-  proc setIsCommunityTokensEnabled*(self: LocalAccountSensitiveSettings, value: bool) {.slot.} =
-    setSettingsProp(self, LSS_KEY_IS_COMMUNITY_TOKENS_ENABLED, newQVariant(value)):
-      self.isCommunityTokensEnabledChanged()
-
-  QtProperty[bool] isCommunityTokensEnabled:
-    read = getIsCommunityTokensEnabled
-    write = setIsCommunityTokensEnabled
-    notify = isCommunityTokensEnabledChanged
-
   proc nodeManagementEnabledChanged*(self: LocalAccountSensitiveSettings) {.signal.}
   proc getNodeManagementEnabled*(self: LocalAccountSensitiveSettings): bool {.slot.} =
     getSettingsProp[bool](self, LSS_KEY_NODE_MANAGEMENT_ENABLED, newQVariant(DEFAULT_NODE_MANAGEMENT_ENABLED))
@@ -262,18 +237,6 @@ QtObject:
     read = getNodeManagementEnabled
     write = setNodeManagementEnabled
     notify = nodeManagementEnabledChanged
-
-  proc isDiscordImportToolEnabledChanged*(self: LocalAccountSensitiveSettings) {.signal.}
-  proc getIsDiscordImportToolEnabled*(self: LocalAccountSensitiveSettings): bool {.slot.} =
-    getSettingsProp[bool](self, LSS_KEY_IS_DISCORD_IMPORT_TOOL_ENABLED, newQVariant(DEFAULT_IS_DISCORD_IMPORT_TOOL_ENABLED))
-  proc setIsDiscordImportToolEnabled*(self: LocalAccountSensitiveSettings, value: bool) {.slot.} =
-    setSettingsProp(self, LSS_KEY_IS_DISCORD_IMPORT_TOOL_ENABLED, newQVariant(value)):
-      self.isDiscordImportToolEnabledChanged()
-
-  QtProperty[bool] isDiscordImportToolEnabled:
-    read = getIsDiscordImportToolEnabled
-    write = setIsDiscordImportToolEnabled
-    notify = isDiscordImportToolEnabledChanged
 
   proc isBrowserEnabledChanged*(self: LocalAccountSensitiveSettings) {.signal.}
   proc getIsBrowserEnabled*(self: LocalAccountSensitiveSettings): bool {.slot.} =
@@ -774,7 +737,6 @@ QtObject:
       of LSS_KEY_CHAT_SPLIT_VIEW: self.chatSplitViewChanged()
       of LSS_KEY_WALLET_SPLIT_VIEW: self.walletSplitViewChanged()
       of LSS_KEY_PROFILE_SPLIT_VIEW: self.profileSplitViewChanged()
-      of LSS_KEY_IS_COMMUNITY_PERMISSIONS_ENABLED: self.isCommunityPermissionsEnabledChanged()
       of LSS_KEY_NODE_MANAGEMENT_ENABLED: self.nodeManagementEnabledChanged()
       of LSS_KEY_IS_BROWSER_ENABLED: self.isBrowserEnabledChanged()
       of LSS_KEY_SHOW_ONLINE_USERS: self.showOnlineUsersChanged()

--- a/test/ui-test/src/drivers/SquishDriverVerification.py
+++ b/test/ui-test/src/drivers/SquishDriverVerification.py
@@ -104,6 +104,9 @@ def verify_equals(val1, val2):
 def log(text: str):
     test.log(text)
     
+def warning(text: str):
+    test.warning(text)
+    
     
 def verify_or_create_screenshot(vp: str, obj: Dict[str, Any]):
     try:

--- a/test/ui-test/src/screens/SettingsScreen.py
+++ b/test/ui-test/src/screens/SettingsScreen.py
@@ -137,10 +137,6 @@ class SettingsScreen:
     def open_advanced_settings(self):
         click_obj_by_name(SidebarComponents.ADVANCED_OPTION.value)
 
-    def activate_community_permission_settings(self):
-        click_obj_by_name(AdvancedOptionScreen.ACTIVATE_OR_DEACTIVATE_COMMUNITY_PERMISSIONS.value)
-        click_obj_by_name(AdvancedOptionScreen.I_UNDERSTAND_POP_UP.value)
-
     def open_wallet_settings(self):
         click_obj_by_name(SidebarComponents.WALLET_OPTION.value)
 
@@ -378,6 +374,9 @@ class SettingsScreen:
                 click_obj(delegate)
                 return
         verify(False, "Community not found")
+        
+    def toggle_experimental_feature(self, settings_type: str):
+        warning("TODO: Implement toggle_experimental_feature method foreach settings type")
 
 
 class ProfileSettingsView(BaseElement):

--- a/test/ui-test/src/screens/StatusCommunityPortalScreen.py
+++ b/test/ui-test/src/screens/StatusCommunityPortalScreen.py
@@ -4,9 +4,9 @@ import sys
 from drivers.SquishDriver import *
 from drivers.SquishDriverVerification import *
 
-
 class MainCommunityPortalScreen(Enum):
     CREATE_COMMUNITY_BUTTON: str = "communitiesPortalLayoutContainer_createCommunityButton_StatusButton"
+    CREATE_COMMUNITY_BANNER_BUTTON: str = "createCommunity_bannerButton"
 
     
 class CreateCommunityPopup(Enum):
@@ -25,6 +25,8 @@ class StatusCommunityPortalScreen:
     
     def create_community(self, communityName: str, communityDescription: str, introMessage: str, outroMessage: str):
         click_obj_by_name(MainCommunityPortalScreen.CREATE_COMMUNITY_BUTTON.value)
+        
+        click_obj_by_name(MainCommunityPortalScreen.CREATE_COMMUNITY_BANNER_BUTTON.value)
         
         type_text(CreateCommunityPopup.COMMUNITY_NAME_INPUT.value, communityName)
         type_text(CreateCommunityPopup.COMMUNITY_DESCRIPTION_INPUT.value, communityDescription)

--- a/test/ui-test/testSuites/global_shared/steps/settingsSteps.py
+++ b/test/ui-test/testSuites/global_shared/steps/settingsSteps.py
@@ -61,8 +61,7 @@ def step(context: any, settings_type:str):
 
 @Given("\"|any|\" is toggled on under Experimental features")
 def step(context: any, settings_type:str):
-    #TODO: Implement parameters for settings
-    _settingsScreen.activate_community_permission_settings()
+    _settingsScreen.toggle_experimental_feature(settings_type)
 
 #########################
 ### ACTIONS region:

--- a/test/ui-test/testSuites/suite_communities/shared/scripts/community_portal_names.py
+++ b/test/ui-test/testSuites/suite_communities/shared/scripts/community_portal_names.py
@@ -6,6 +6,10 @@ mainWindow_communitiesPortalLayoutContainer_CommunitiesPortalLayout = {"containe
 communitiesPortalLayoutContainer_createCommunityButton_StatusButton = {"container": mainWindow_communitiesPortalLayoutContainer_CommunitiesPortalLayout, "objectName": "createCommunityButton", "type": "StatusButton", "visible": True}
 navBarListView_All_Community_Buttons = {"checkable": True, "container": mainWindow_communityNavBarListView_ListView, "objectName": "CommunityNavBarButton", "type": "StatusNavBarTabButton"}
 
+# Create community intermediate popup:
+createCommunity_banner = {"container": statusDesktop_mainWindow_overlay, "objectName": "createCommunityBanner", "type": "CommunityBanner", "visible": True}
+createCommunity_bannerButton = {"container": createCommunity_banner, "objectName": "communityBannerButton", "type": "StatusButton", "visible": True}
+
 # Create community popup:
 createCommunityNameInput_TextEdit = {"container": statusDesktop_mainWindow_overlay, "objectName": "createCommunityNameInput", "type": "TextEdit", "visible": True}
 createCommunityDescriptionInput_TextEdit = {"container": statusDesktop_mainWindow_overlay, "objectName": "createCommunityDescriptionInput", "type": "TextEdit", "visible": True}

--- a/test/ui-test/testSuites/suite_communities/shared/steps/communitySteps.py
+++ b/test/ui-test/testSuites/suite_communities/shared/steps/communitySteps.py
@@ -48,8 +48,7 @@ def step(context, category_name, channel_names):
 
 @Given("\"|any|\" is toggled on under Experimental features")
 def step(context: any, settings_type:str):
-    #TODO: Implement parameters for settings
-    _settingsScreen.activate_community_permission_settings()
+    _settingsScreen.toggle_experimental_feature(settings_type)
 
 #########################
 ### ACTIONS region:

--- a/test/ui-test/testSuites/suite_communities/tst_communityPermissions/test.feature
+++ b/test/ui-test/testSuites/suite_communities/tst_communityPermissions/test.feature
@@ -10,12 +10,6 @@ Background:
     And the user lands on the community named "Test-Community"
 
 
- Scenario: Enable community permissions feature
-   Given the user opens app settings screen
-   And Application Settings "Advanced" is open
-   And "Community Permissions Settings" is toggled on under Experimental features
-   And the user opens the communities settings
-   Then the user opens the community named "Test-Community"
-   And the user lands on the community named "Test-Community"
+ Scenario: Community permissions is an available option is Community Settings
    When "Manage Community" is clicked in the community sidebar
    Then "Permissions" should be an available option in Community Settings

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -182,8 +182,6 @@ QtObject {
 
     property var communitiesModuleInst: communitiesModule
     property var communitiesList: communitiesModuleInst.model
-    property bool communityPermissionsEnabled: localAccountSensitiveSettings.isCommunityPermissionsEnabled
-    property bool communityTokensEnabled: localAccountSensitiveSettings.isCommunityTokensEnabled
 
     property var userProfileInst: userProfile
 

--- a/ui/app/AppLayouts/Chat/views/CommunitySettingsView.qml
+++ b/ui/app/AppLayouts/Chat/views/CommunitySettingsView.qml
@@ -36,9 +36,9 @@ StatusSectionLayout {
     // TODO: get this model from backend?
     property var settingsMenuModel: [{id: Constants.CommunitySettingsSections.Overview, name: qsTr("Overview"), icon: "show", enabled: true},
         {id: Constants.CommunitySettingsSections.Members, name: qsTr("Members"), icon: "group-chat", enabled: true, },
-        {id: Constants.CommunitySettingsSections.Permissions, name: qsTr("Permissions"), icon: "objects", enabled: root.rootStore.communityPermissionsEnabled},
-        {id: Constants.CommunitySettingsSections.MintTokens, name: qsTr("Mint Tokens"), icon: "token", enabled: root.rootStore.communityTokensEnabled},
-        {id: Constants.CommunitySettingsSections.Airdrops, name: qsTr("Airdrops"), icon: "airdrop", enabled: root.rootStore.communityTokensEnabled}]
+        {id: Constants.CommunitySettingsSections.Permissions, name: qsTr("Permissions"), icon: "objects", enabled: true},
+        {id: Constants.CommunitySettingsSections.MintTokens, name: qsTr("Mint Tokens"), icon: "token", enabled: true},
+        {id: Constants.CommunitySettingsSections.Airdrops, name: qsTr("Airdrops"), icon: "airdrop", enabled: true}]
     // TODO: Next community settings options:
     //                        {name: qsTr("Token sales"), icon: "token-sale"},
     //                        {name: qsTr("Subscriptions"), icon: "subscription"},

--- a/ui/app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml
+++ b/ui/app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml
@@ -143,11 +143,7 @@ StatusSectionLayout {
                     verticalPadding: 0
                     text: qsTr("Create New Community")
                     onClicked: {
-                        if (localAccountSensitiveSettings.isDiscordImportToolEnabled) {
-                            Global.openPopup(chooseCommunityCreationTypePopupComponent)
-                        } else {
-                            Global.openPopup(createCommunitiesPopupComponent)
-                        }
+                        Global.openPopup(chooseCommunityCreationTypePopupComponent)
                     }
                 }
             }
@@ -234,6 +230,7 @@ StatusSectionLayout {
             contentItem: RowLayout {
                 spacing: 20
                 CommunityBanner {
+                    objectName: "createCommunityBanner"
                     text: qsTr("Create a new Status community")
                     buttonText: qsTr("Create new")
                     icon.name: "favourite"

--- a/ui/app/AppLayouts/Profile/stores/AdvancedStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/AdvancedStore.qml
@@ -129,15 +129,6 @@ QtObject {
         else if (feature === experimentalFeatures.gifWidget) {
             localAccountSensitiveSettings.isGifWidgetEnabled = !localAccountSensitiveSettings.isGifWidgetEnabled
         }
-        else if (feature === experimentalFeatures.communityPermissions) {
-            localAccountSensitiveSettings.isCommunityPermissionsEnabled = !localAccountSensitiveSettings.isCommunityPermissionsEnabled
-        }
-        else if (feature === experimentalFeatures.discordImportTool) {
-            localAccountSensitiveSettings.isDiscordImportToolEnabled = !localAccountSensitiveSettings.isDiscordImportToolEnabled
-        }
-        else if (feature === experimentalFeatures.communityTokens) {
-            localAccountSensitiveSettings.isCommunityTokensEnabled = !localAccountSensitiveSettings.isCommunityTokensEnabled
-        }
     }
 
     function toggleFakeLoadingScreen() {

--- a/ui/app/AppLayouts/Profile/views/AdvancedView.qml
+++ b/ui/app/AppLayouts/Profile/views/AdvancedView.qml
@@ -133,58 +133,6 @@ SettingsContentBase {
             }
 
             // TODO: replace with StatusQ component
-            StatusSettingsLineButton {
-                objectName: "CommunitySettingsLineButton"
-                anchors.leftMargin: 0
-                anchors.rightMargin: 0
-                text: qsTr("Community Permissions Settings")
-                isSwitch: true
-                switchChecked: localAccountSensitiveSettings.isCommunityPermissionsEnabled
-                onClicked: {
-                    if (!localAccountSensitiveSettings.isCommunityPermissionsEnabled) {
-                        confirmationPopup.experimentalFeature = root.advancedStore.experimentalFeatures.communityPermissions
-                        confirmationPopup.open()
-                    } else {
-                        root.advancedStore.toggleExperimentalFeature(root.advancedStore.experimentalFeatures.communityPermissions)
-                    }
-                }
-            }
-
-            // TODO: replace with StatusQ component
-            StatusSettingsLineButton {
-                anchors.leftMargin: 0
-                anchors.rightMargin: 0
-                text: qsTr("Community Tokens")
-                isSwitch: true
-                switchChecked: localAccountSensitiveSettings.isCommunityTokensEnabled
-                onClicked: {
-                    if (!localAccountSensitiveSettings.isCommunityTokensEnabled) {
-                        confirmationPopup.experimentalFeature = root.advancedStore.experimentalFeatures.communityTokens
-                        confirmationPopup.open()
-                    } else {
-                        root.advancedStore.toggleExperimentalFeature(root.advancedStore.experimentalFeatures.communityTokens)
-                    }
-                }
-            }
-
-            StatusSettingsLineButton {
-                anchors.leftMargin: 0
-                anchors.rightMargin: 0
-                text: qsTr("Discord Import Tool")
-                objectName: "DiscordImportToolSettingsLineButton"
-                isSwitch: true
-                switchChecked: localAccountSensitiveSettings.isDiscordImportToolEnabled
-                onClicked: {
-                    if (!localAccountSensitiveSettings.isDiscordImportToolEnabled) {
-                        confirmationPopup.experimentalFeature = root.advancedStore.experimentalFeatures.discordImportTool
-                        confirmationPopup.open()
-                    } else {
-                        root.advancedStore.toggleExperimentalFeature(root.advancedStore.experimentalFeatures.discordImportTool)
-                    }
-                }
-            }
-
-            // TODO: replace with StatusQ component
              StatusSettingsLineButton {
                 anchors.leftMargin: 0
                 anchors.rightMargin: 0

--- a/ui/imports/shared/panels/CommunityBanner.qml
+++ b/ui/imports/shared/panels/CommunityBanner.qml
@@ -72,6 +72,7 @@ Rectangle {
 
     StatusQControls.StatusButton {
         id: bannerButton
+        objectName: "communityBannerButton"
         anchors.horizontalCenter: parent.horizontalCenter
         anchors.bottom: parent.bottom
         anchors.bottomMargin: 16


### PR DESCRIPTION
Closes #10115

### What does the PR do
Settings removed community permissions, tokens, airdrop and discord import options - should be enabled by default

Also:
    test(suite_communities): Fixed community related tests

    - A new intermediate popup is now displayed when user clicks on `Create New Community` button from `Community Portal`.
    - Reformulated `tst_communityPermissions` since now it is a default option without the need of activating it from experimental feature's section.

### Affected areas
Settings

### Screenshot of functionality (including design for comparison)
https://user-images.githubusercontent.com/31625338/234640392-1fdfc26e-8b14-4ccc-9c6a-0e9a2e2f08fc.mov

