### PR TITLE
fix: Fix and rework "start chat" text field input

### DIFF
--- a/src/app_service/common/conversion.nim
+++ b/src/app_service/common/conversion.nim
@@ -8,7 +8,10 @@ const SystemMentionChars* = {'0'..'9', 'x'}
 const SystemTagMapping* = [("@everyone", "@0x00001")]
 
 proc isCompressedPubKey*(strPubKey: string): bool =
-  return strPubKey.startsWith("zQ3") and allCharsInSet(strPubKey, CompressedKeyChars)
+  let length = len(strPubKey)
+  return length >= 48 and length <= 50 and
+         strPubKey.startsWith("zQ3sh") and
+         allCharsInSet(strPubKey, CompressedKeyChars)
 
 proc isSystemMention*(mention: string) : bool =
   mention.startsWith("0x") and allCharsInSet(mention, SystemMentionChars)

--- a/src/app_service/service/contacts/async_tasks.nim
+++ b/src/app_service/service/contacts/async_tasks.nim
@@ -67,9 +67,11 @@ const asyncRequestContactInfoTask: Task = proc(argEncoded: string) {.gcsafe, nim
     let response = status_go.requestContactInfo(arg.pubkey)
     arg.finish(%* {
       "publicKey": arg.pubkey,
-      "response":  response,
+      "response": response,
+      "error": nil,
     })
   except Exception as e:
     arg.finish(%* {
+      "publicKey": arg.pubkey,
       "error": e.msg,
     })

--- a/ui/app/AppLayouts/Chat/panels/InlineSelectorPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/InlineSelectorPanel.qml
@@ -41,6 +41,18 @@ Item {
     implicitWidth: mainLayout.implicitWidth
     implicitHeight: mainLayout.implicitHeight
 
+    QtObject {
+        id: d
+
+        function paste() {
+            root.suggestionsDialog.forceHide = true
+            edit.pasteOperation = true
+            edit.paste()
+            root.textPasted(edit.text)
+            edit.pasteOperation = false
+        }
+    }
+
     RowLayout {
         id: mainLayout
         anchors.fill: parent
@@ -118,13 +130,17 @@ Item {
                                     cursorVisible: edit.cursorVisible
                                 }
 
-                                onTextEdited: if (suggestionsDialog.forceHide && !pasteOperation)
-                                                  suggestionsDialog.forceHide = false
+                                onTextEdited: {
+                                    if (suggestionsDialog.forceHide && !pasteOperation)
+                                        suggestionsDialog.forceHide = false
+                                }
 
-                                Keys.onPressed: {
+                                Keys.onPressed: (event) => {
+
                                     if (event.matches(StandardKey.Paste)) {
-                                        pasteOperation = true
-                                        root.suggestionsDialog.forceHide = true
+                                        event.accepted = true
+                                        d.paste()
+                                        return
                                     }
 
                                     if (suggestionsDialog.visible) {
@@ -147,17 +163,6 @@ Item {
                                         } else if (event.key === Qt.Key_Down) {
                                             root.downKeyPressed()
                                         }
-                                    }
-                                }
-
-                                Keys.onReleased: {
-                                    if (event.matches(StandardKey.Paste)) {
-                                        event.accepted = true
-                                        pasteOperation = false
-                                        if (text) {
-                                            root.textPasted(text)
-                                        }
-
                                     }
                                 }
                             }


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/10318

Relates to:
- https://github.com/status-im/status-desktop/pull/7420
- https://github.com/status-im/status-desktop/pull/9996
- https://github.com/status-im/status-desktop/pull/8659

### What does the PR do

I've consolidated all the work we've done here and here's the solution.

1. We agreed with @John-44 to support "editing", not just "pasting"
2. What's supported:
    - ENS name
    - compressed keys
    - uncompressed key
    - link with one of above
3. Any leading and ending spaces are trimmed
4. Pasting processed immediately, editing has a heuristic delay of 500ms
5. Compressed key length is checked
6. Compressed key is checked to start with `zQ3sh`
7. Fixed `asyncRequestContactInfoTask` which led to a crush
8. `getContactById` checks the decompressed key for validness

### Affected areas

"Start chat" screen

### Screenshot of functionality (including design for comparison)

https://user-images.githubusercontent.com/25482501/234667922-a77d36f8-eafc-44f1-a5b4-ab495e6eb07f.mov
