### PR TITLE
fix(main/module): don't signal a section switch if it's the same section

### DIFF
--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -750,6 +750,8 @@ proc notifySubModulesAboutChange[T](self: Module[T], sectionId: string) =
   # If there is a need other section may be notified the same way from here...
 
 method activeSectionSet*[T](self: Module[T], sectionId: string) =
+  if self.view.activeSection.getId() == sectionId:
+    return
   let item = self.view.model().getItemById(sectionId)
 
   if(item.isEmpty()):


### PR DESCRIPTION
Fixes #10428

The issue above happened when you double click on a chat section. It causes the fetch to happen twice, which is wasteful, but also causes the model to get reset while it's being processed, thus creating the crash.

The fix here is to not signal that we are changing section if we are trying to switch to the section which is already active (makes sense ofc)