### PR TITLE
macos: bump notarization retry limit from 20 to 40

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -644,7 +644,7 @@ ifdef MACOS_CODESIGN_IDENT
 endif
 
 notarize-macos: export CHECK_INTERVAL_SEC ?= 30
-notarize-macos: export CHECK_RETRY_LIMIT ?= 20
+notarize-macos: export CHECK_RETRY_LIMIT ?= 40
 notarize-macos: export MACOS_BUNDLE_ID ?= im.status.ethereum.desktop
 notarize-macos:
 	scripts/notarize-macos-pkg.sh $(STATUS_CLIENT_DMG)

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -25,7 +25,7 @@ pipeline {
   options {
     timestamps()
     /* Prevent Jenkins jobs from running forever */
-    timeout(time: 25, unit: 'MINUTES')
+    timeout(time: 30, unit: 'MINUTES')
     /* manage how many builds we keep */
     buildDiscarder(logRotator(
       numToKeepStr: '10',

--- a/scripts/notarize-macos-pkg.sh
+++ b/scripts/notarize-macos-pkg.sh
@@ -13,7 +13,7 @@ set -eof pipefail
 BUNDLE_PATH="${1}"
 # Notarization request check intervals/retries.
 CHECK_INTERVAL_SEC="${CHECK_INTERVAL_SEC:-30}"
-CHECK_RETRY_LIMIT="${CHECK_RETRY_LIMIT:-20}"
+CHECK_RETRY_LIMIT="${CHECK_RETRY_LIMIT:-40}"
 # Unique ID of MacOS application.
 MACOS_BUNDLE_ID="${MACOS_BUNDLE_ID:-im.status.ethereum.desktop}"
 # Xcode altool log file paths


### PR DESCRIPTION
Notarization has been taking longer recently and it times out.