### PR TITLE
fix(Settings/LanguageView): do not change language on the fly

### DIFF
--- a/src/app_service/service/language/service.nim
+++ b/src/app_service/service/language/service.nim
@@ -28,7 +28,7 @@ proc delete*(self: Service) =
 proc newService*(events: EventEmitter): Service =
   result = Service()
   result.events = events
-  result.shouldRetranslate = false #not defined(linux)
+  result.shouldRetranslate = false
 
 proc obtainLanguages(dir: string): seq[string] =
   let localeRe = re".*qml_(.*).qm"

--- a/vendor/DOtherSide/lib/src/DOtherSide.cpp
+++ b/vendor/DOtherSide/lib/src/DOtherSide.cpp
@@ -439,7 +439,8 @@ void dos_qguiapplication_load_translation(::DosQQmlApplicationEngine *vptr, cons
     if (g_translator.load(translationPackage)) {
         bool success = QGuiApplication::installTranslator(&g_translator);
         auto engine = static_cast<QQmlApplicationEngine *>(vptr);
-        if (shouldRetranslate) engine->retranslate();
+        if (engine && success && shouldRetranslate)
+            engine->retranslate();
     } else {
         printf("Failed to load translation file %s\n", translationPackage);
     }


### PR DESCRIPTION
disable retranslation, display a confirmation dialog and apply the language change after app restart

rationale: the way the retranslation works internally is that it forces reevaluation of _all_ QML bindings which:
- might lead to crashes (immediately or later)
- lots of warnings printed to console, some bindings can get broken as a result
- not all UI is correctly retranslated on the fly (we have lots of places where we assign the text imperatively via JS code), so these wouldn't appear translated before app restart anyway

Fixes #7823

### Affected areas

Settings/Language

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![image](https://user-images.githubusercontent.com/5377645/234850375-7eb43471-17a8-4d92-9649-b001cd51ab46.png)

For comparison, this is when changing the language on-the-fly, before and after restart (parts of the app don't get retranslated correctly)

![Snímek obrazovky z 2023-04-27 12-27-03](https://user-images.githubusercontent.com/5377645/234850669-89d5ef32-f077-4d5c-887e-c60778bd71d8.png)
![Snímek obrazovky z 2023-04-27 12-28-50](https://user-images.githubusercontent.com/5377645/234850684-e4a7b7e1-9a52-4636-8050-04a2d3cacec2.png)
