### PR TITLE
fix(ActivityCenter): Workaround for nil message

### DIFF
--- a/src/app/modules/main/activity_center/model.nim
+++ b/src/app/modules/main/activity_center/model.nim
@@ -71,7 +71,7 @@ QtObject:
       of NotifRoles.Name: result = newQVariant(activityNotificationItem.name)
       of NotifRoles.Author: result = newQVariant(activityNotificationItem.author)
       of NotifRoles.NotificationType: result = newQVariant(activityNotificationItem.notificationType.int)
-      of NotifRoles.Message: result = if activityNotificationItem.messageItem != nil:
+      of NotifRoles.Message: result = if not activityNotificationItem.messageItem.isNil:
                                         newQVariant(activityNotificationItem.messageItem)
                                       else:
                                         newQVariant()

--- a/src/app/modules/main/activity_center/model.nim
+++ b/src/app/modules/main/activity_center/model.nim
@@ -71,7 +71,10 @@ QtObject:
       of NotifRoles.Name: result = newQVariant(activityNotificationItem.name)
       of NotifRoles.Author: result = newQVariant(activityNotificationItem.author)
       of NotifRoles.NotificationType: result = newQVariant(activityNotificationItem.notificationType.int)
-      of NotifRoles.Message: result = newQVariant(activityNotificationItem.messageItem)
+      of NotifRoles.Message: result = if activityNotificationItem.messageItem != nil:
+                                        newQVariant(activityNotificationItem.messageItem)
+                                      else:
+                                        newQVariant()
       of NotifRoles.Timestamp: result = newQVariant(activityNotificationItem.timestamp)
       of NotifRoles.PreviousTimestamp: result = newQVariant(if index.row > 0:
                                                               self.activityCenterNotifications[index.row - 1].timestamp

--- a/src/app/modules/main/activity_center/module.nim
+++ b/src/app/modules/main/activity_center/module.nim
@@ -143,8 +143,8 @@ method convertToItems*(
     ): seq[notification_item.Item] =
   result = activityCenterNotifications.map(
     proc(notification: ActivityCenterNotificationDto): notification_item.Item =
-      var messageItem =  msg_item_qobj.newMessageItem(nil)
-      var repliedMessageItem =  msg_item_qobj.newMessageItem(nil)
+      var messageItem: MessageItem
+      var repliedMessageItem: MessageItem
       # default section id is `Chat` section
       let sectionId = if notification.communityId.len > 0:
           notification.communityId


### PR DESCRIPTION
Close #10455

### What does the PR do

AC notification can have nil message, but with recent changes this caused segfault 

### Affected areas

ActivityCenter

### Screenshot of functionality (including design for comparison)

<img width="543" alt="Screenshot 2023-04-27 at 16 25 39" src="https://user-images.githubusercontent.com/2522130/234862015-6a58b741-2599-4ec0-8cc7-1adf1c6a6048.png">

