### PR TITLE
feat(@desktop/activities): Updated no activity text style

### DIFF
--- a/ui/app/AppLayouts/Profile/panels/ProfileShowcasePanel.qml
+++ b/ui/app/AppLayouts/Profile/panels/ProfileShowcasePanel.qml
@@ -10,6 +10,8 @@ import StatusQ.Components 0.1
 import StatusQ.Core.Theme 0.1
 import StatusQ.Popups 0.1
 
+import shared.controls 1.0
+
 import utils 1.0
 
 import AppLayouts.Profile.controls 1.0

--- a/ui/app/AppLayouts/Profile/panels/ProfileSocialLinksPanel.qml
+++ b/ui/app/AppLayouts/Profile/panels/ProfileSocialLinksPanel.qml
@@ -7,6 +7,8 @@ import StatusQ.Controls 0.1
 import StatusQ.Components 0.1
 import StatusQ.Core.Theme 0.1
 
+import shared.controls 1.0
+
 import utils 1.0
 
 import AppLayouts.Profile.popups 1.0

--- a/ui/imports/shared/controls/ShapeRectangle.qml
+++ b/ui/imports/shared/controls/ShapeRectangle.qml
@@ -30,6 +30,8 @@ Shape {
     id: root
 
     property string text
+    property color textColor: Theme.palette.baseColor1
+    property alias font: description.font
 
     property int radius: Style.current.radius
     readonly property alias path: path
@@ -41,11 +43,12 @@ Shape {
     implicitHeight: 44
 
     StatusBaseText {
+        id: description
         anchors.centerIn: parent
-        color: Theme.palette.baseColor1
+        color: root.textColor
         text: root.text
         font.pixelSize: 13
-        visible: text
+        visible: (!!text)
     }
 
     ShapePath {

--- a/ui/imports/shared/controls/qmldir
+++ b/ui/imports/shared/controls/qmldir
@@ -13,6 +13,7 @@ Input 1.0 Input.qml
 RadioButtonSelector 1.0 RadioButtonSelector.qml
 RecipientSelector 1.0 RecipientSelector.qml
 SearchBox 1.0 SearchBox.qml
+ShapeRectangle 1.0 ShapeRectangle.qml
 SeedPhraseTextArea 1.0 SeedPhraseTextArea.qml
 SendToContractWarning 1.0 SendToContractWarning.qml
 SettingsRadioButton 1.0 SettingsRadioButton.qml

--- a/ui/imports/shared/views/HistoryView.qml
+++ b/ui/imports/shared/views/HistoryView.qml
@@ -56,11 +56,13 @@ ColumnLayout {
         color: Style.current.danger
     }
 
-    StyledText {
+    ShapeRectangle {
         id: noTxs
+        Layout.fillWidth: true
+        Layout.preferredHeight: 42
         visible: !d.isLoading && transactionListRoot.count === 0
-        text: qsTr("No transactions found")
         font.pixelSize: Style.current.primaryTextFontSize
+        text: qsTr("Activity for this account will appear here")
     }
 
     StatusListView {


### PR DESCRIPTION
Issue: #10443

### What does the PR do

* Updated no activity text according to new designs
* Moved ShapeRectangle.qml to shared directory to be used in multiple places

### Affected areas

Wallet activity view and Profile (usage of ShapeRectangle)

### Screenshot of functionality (including design for comparison)

Design: 
![image](https://user-images.githubusercontent.com/11396062/234863286-cc29112f-5210-4264-927b-289416ad049f.png)

App:
![image](https://user-images.githubusercontent.com/11396062/234863005-0ba96c27-0f74-47b7-bba7-5e12c300d0dd.png)
![image](https://user-images.githubusercontent.com/11396062/234862903-585ed37d-fe10-4c19-99aa-da4e78d999c3.png)
