### PR TITLE
fix(ChatColumnView): unbreak 1-1 chats

### DIFF
--- a/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
@@ -1,10 +1,6 @@
 import QtQuick 2.14
-import Qt.labs.platform 1.1
 import QtQuick.Controls 2.14
-import QtQuick.Layouts 1.14
-import QtGraphicalEffects 1.0
 import QtQml 2.14
-import Qt.labs.qmlmodels 1.0
 
 import StatusQ.Core.Theme 0.1
 import StatusQ.Components 0.1
@@ -35,7 +31,6 @@ Item {
     property var emojiPopup
     property var stickersPopup
 
-    property bool isSectionActive: mainModule.activeSection.id === parentModule.getMySectionId()
     property string activeChatId: parentModule && parentModule.activeItem.id
     property int chatsCount: parentModule && parentModule.model ? parentModule.model.count : 0
     property int activeChatType: parentModule && parentModule.activeItem.type
@@ -140,7 +135,7 @@ Item {
             height: parent.height
             visible: !root.rootStore.openCreateChat && isActiveChannel
             chatId: model.itemId
-            activeChatType: root.activeChatType
+            chatType: model.type
             chatMessagesLoader.active: model.loaderActive
             rootStore: root.rootStore
             contactsStore: root.contactsStore
@@ -262,34 +257,4 @@ Item {
             }
         }
     }
-
-        // Not Refactored Yet
-//        Connections {
-//            target: root.rootStore.chatsModelInst.stickers
-//            onTransactionWasSent: {
-//                //% "Transaction pending..."
-//                toastMessage.title = qsTr("Transaction pending...")
-//                toastMessage.source = Style.svg("loading")
-//                toastMessage.iconColor = Style.current.primary
-//                toastMessage.iconRotates = true
-//                toastMessage.link = `${walletModel.utilsView.etherscanLink}/${txResult}`
-//                toastMessage.open()
-//            }
-//            onTransactionCompleted: {
-//                toastMessage.title = !success ?
-//                                     qsTr("Could not buy Stickerpack")
-//                                     :
-//                                     qsTr("Stickerpack bought successfully");
-//                if (success) {
-//                    toastMessage.source = Style.svg("check-circle")
-//                    toastMessage.iconColor = Style.current.success
-//                } else {
-//                    toastMessage.source = Style.svg("block-icon")
-//                    toastMessage.iconColor = Style.current.danger
-//                }
-
-//                toastMessage.link = `${walletModel.utilsView.etherscanLink}/${txHash}`
-//                toastMessage.open()
-//            }
-//        }
 }

--- a/ui/app/AppLayouts/Chat/views/ChatContentView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatContentView.qml
@@ -37,7 +37,7 @@ ColumnLayout {
     property var contactsStore
     property bool isActiveChannel: false
     property string chatId
-    property int activeChatType
+    property int chatType: Constants.chatType.unknown
 
     readonly property alias chatMessagesLoader: chatMessagesLoader
 
@@ -66,7 +66,7 @@ ColumnLayout {
         property bool isUserAdded
 
         function updateIsUserAdded() {
-            if (activeChatType !== Constants.chatType.oneToOne) {
+            if (root.chatType !== Constants.chatType.oneToOne) {
                 return false
             }
             isUserAdded = Qt.binding(() => {isActiveChannel; return Utils.getContactDetailsAsJson(root.chatId, false).isAdded})
@@ -178,7 +178,7 @@ ColumnLayout {
                 stickersPopup: root.stickersPopup
                 usersStore: root.usersStore
                 stickersLoaded: root.stickersLoaded
-                isChatBlocked: root.isBlocked || (chatContentModule && chatContentModule.chatDetails.type === Constants.chatType.oneToOne && !d.isUserAdded)
+                isChatBlocked: root.isBlocked || (root.chatType === Constants.chatType.oneToOne && !d.isUserAdded)
                 channelEmoji: !chatContentModule ? "" : (chatContentModule.chatDetails.emoji || "")
                 isActiveChannel: root.isActiveChannel
                 onShowReplyArea: {
@@ -243,8 +243,8 @@ ColumnLayout {
                     isContactBlocked: root.isBlocked
                     isActiveChannel: root.isActiveChannel
                     anchors.bottom: parent.bottom
-                    chatType: chatContentModule ? chatContentModule.chatDetails.type : Constants.chatType.unknown
-                    suggestions.suggestionFilter.addSystemSuggestions: chatType == Constants.chatType.communityChat
+                    chatType: root.chatType
+                    suggestions.suggestionFilter.addSystemSuggestions: chatType === Constants.chatType.communityChat
 
                     Binding on chatInputPlaceholder {
                         when: root.isBlocked


### PR DESCRIPTION
the StatusChatInput (among other things) was disabled due to wrong `activeChatType` being passed down to `ChatContentView` which does all sorts of checks whether we are allowed to chat with that contact

The `root.activeChatType` no longer reflects the chat that we are going to activate (probably due to the extensive use of `Loader`s)

(plus remove some dead code)

Fixes: #10463

### What does the PR do

Unbreaks 1-1 chats

### Affected areas

ChatColumnView/ChatContentView

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![image](https://user-images.githubusercontent.com/5377645/234893855-da350413-7cc5-4c29-8445-973b2bda822c.png)


