### PR TITLE
feat(@desktop/activity): Updated section delegate

### DIFF
--- a/ui/imports/shared/views/HistoryView.qml
+++ b/ui/imports/shared/views/HistoryView.qml
@@ -138,21 +138,32 @@ ColumnLayout {
         ScrollBar.vertical: StatusScrollBar {}
 
         section.property: "date"
-        section.delegate: Item {
+        section.delegate: ColumnLayout {
             id: sectionDelegate
 
             readonly property bool isFirstSection: ListView.view.firstSection === section
 
             width: ListView.view.width
-            height: isFirstSection || section.length > 1 ? 40 : 0 // 1 because we don't use empty for loading state
+            height: isFirstSection ? 38 : (section.length > 1 ? 58 : 0) // 1 because we don't use empty for loading state
             visible: height > 0 // display always first section. Other sections when more items are being fetched must not be visible
+            spacing: 0
 
             required property string section
+
+            Separator {
+                Layout.fillWidth: true
+                Layout.preferredHeight: 1
+                Layout.topMargin: sectionDelegate.isFirstSection ? 0 : 20
+            }
 
             StatusTextWithLoadingState {
                 id: sectionText
 
-                anchors.verticalCenter: parent.verticalCenter
+                Layout.fillWidth: true
+                Layout.leftMargin: 16
+                Layout.fillHeight: true
+                Layout.bottomMargin: 8
+
                 text: loading ? "dummy" : parent.section // dummy text because loading component height depends on text height, and not visible with height == 0
                 Binding on width {
                     when: sectionText.loading
@@ -160,7 +171,8 @@ ColumnLayout {
                     restoreMode: Binding.RestoreBindingOrValue
                 }
                 customColor: Theme.palette.baseColor1
-                font.pixelSize: 15
+                font.pixelSize: 13
+                verticalAlignment: Qt.AlignBottom
                 loading: { // First section must be loading when first item in the list is loading. Other sections are never visible until have date value
                     if (parent.ListView.view.count > 0) {
                         const firstItem = parent.ListView.view.itemAtIndex(0)

--- a/ui/imports/shared/views/HistoryView.qml
+++ b/ui/imports/shared/views/HistoryView.qml
@@ -144,26 +144,24 @@ ColumnLayout {
             readonly property bool isFirstSection: ListView.view.firstSection === section
 
             width: ListView.view.width
-            height: isFirstSection ? 38 : (section.length > 1 ? 58 : 0) // 1 because we don't use empty for loading state
-            visible: height > 0 // display always first section. Other sections when more items are being fetched must not be visible
+            // display always first section. Other sections when more items are being fetched must not be visible
+            visible: isFirstSection || section.length > 1
             spacing: 0
 
             required property string section
 
             Separator {
                 Layout.fillWidth: true
-                Layout.preferredHeight: 1
                 Layout.topMargin: sectionDelegate.isFirstSection ? 0 : 20
+                implicitHeight: 1
             }
 
             StatusTextWithLoadingState {
                 id: sectionText
 
-                Layout.fillWidth: true
-                Layout.leftMargin: 16
-                Layout.fillHeight: true
-                Layout.bottomMargin: 8
-
+                Layout.topMargin: 12
+                leftPadding: 16
+                bottomPadding: 8
                 text: loading ? "dummy" : parent.section // dummy text because loading component height depends on text height, and not visible with height == 0
                 Binding on width {
                     when: sectionText.loading


### PR DESCRIPTION
Closes #10432

### What does the PR do

Updated section delegate to new height and added divider line according to design

### Affected areas

Wallet activity list section delegate.

### Screenshot of functionality (including design for comparison)
**Design:**

![image](https://user-images.githubusercontent.com/11396062/235102715-47016e86-9419-49f1-bbe5-8874a38ceaad.png)

**App:**
![image](https://user-images.githubusercontent.com/11396062/235102863-c818d080-03e8-49cd-b641-7ae8b8d2cf06.png)
![image](https://user-images.githubusercontent.com/11396062/235102813-a137e8e5-d0f8-48da-90ea-2b895e5490a9.png)
