### PR TITLE
perf(AppMain): wrap CommunitiesPortalLayout in a Loader

### DIFF
--- a/ui/app/AppLayouts/Chat/ChatLayout.qml
+++ b/ui/app/AppLayouts/Chat/ChatLayout.qml
@@ -23,8 +23,6 @@ StackLayout {
 
     property var emojiPopup
     property var stickersPopup
-    signal importCommunityClicked()
-    signal createCommunityClicked()
     signal profileButtonClicked()
     signal openAppSearch()
 
@@ -33,7 +31,6 @@ StackLayout {
     }
 
     Loader {
-
         readonly property var chatItem: root.rootStore.chatCommunitySectionModule
         sourceComponent: chatItem.isCommunity() && chatItem.requiresTokenPermissionToJoin && !chatItem.amIMember ? joinCommunityViewComponent : chatViewComponent
     }
@@ -116,12 +113,6 @@ StackLayout {
             onCommunityInfoButtonClicked: root.currentIndex = 1
             onCommunityManageButtonClicked: root.currentIndex = 1
 
-            onImportCommunityClicked: {
-                root.importCommunityClicked();
-            }
-            onCreateCommunityClicked: {
-                root.createCommunityClicked();
-            }
             onProfileButtonClicked: {
                 root.profileButtonClicked()
             }

--- a/ui/app/AppLayouts/Chat/views/ChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatView.qml
@@ -38,8 +38,6 @@ StatusSectionLayout {
     signal communityManageButtonClicked()
     signal profileButtonClicked()
     signal openAppSearch()
-    signal importCommunityClicked()
-    signal createCommunityClicked()
 
     Connections {
         target: root.rootStore.stickersStore.stickersModule
@@ -138,12 +136,6 @@ StatusSectionLayout {
 
             onOpenAppSearch: {
                 root.openAppSearch()
-            }
-            onImportCommunityClicked: {
-                root.importCommunityClicked();
-            }
-            onCreateCommunityClicked: {
-                root.createCommunityClicked();
             }
             onAddRemoveGroupMemberClicked: {
                 headerContent.addRemoveGroupMember()

--- a/ui/app/AppLayouts/Chat/views/ContactsColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ContactsColumnView.qml
@@ -32,12 +32,8 @@ Item {
     property var contactsStore
     property var emojiPopup
 
-    // Not Refactored Yet
-    //property int chatGroupsListViewCount: channelList.model.count
     signal openProfileClicked()
     signal openAppSearch()
-    signal importCommunityClicked()
-    signal createCommunityClicked()
     signal addRemoveGroupMemberClicked()
 
     // main layout

--- a/ui/app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml
+++ b/ui/app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml
@@ -16,8 +16,6 @@ import shared.panels 1.0
 
 import SortFilterProxyModel 0.2
 
-import AppLayouts.CommunitiesPortal.stores 1.0
-
 import "controls"
 import "popups"
 import "views"
@@ -25,16 +23,12 @@ import "views"
 StatusSectionLayout {
     id: root
 
-    property CommunitiesStore communitiesStore: CommunitiesStore {}
-    property var importCommunitiesPopup: importCommunitiesPopupComponent
-    property var createCommunitiesPopup: createCommunitiesPopupComponent
-    property var discordImportProgressPopup: discordImportProgressDialog
+    property var communitiesStore
 
     property alias assetsModel: communitiesGrid.assetsModel
     property alias collectiblesModel: communitiesGrid.collectiblesModel
 
     objectName: "communitiesPortalLayout"
-    notificationCount: activityCenterStore.unreadNotificationsCount
     onNotificationButtonClicked: Global.openActivityCenterPopup()
 
     onVisibleChanged: {
@@ -133,7 +127,7 @@ StatusSectionLayout {
                     Layout.preferredHeight: 38
                     text: qsTr("Import using key")
                     verticalPadding: 0
-                    onClicked: Global.openPopup(importCommunitiesPopupComponent)
+                    onClicked: Global.importCommunityPopupRequested()
                 }
 
                 StatusButton {
@@ -196,28 +190,6 @@ StatusSectionLayout {
     }
 
     Component {
-        id: importCommunitiesPopupComponent
-        ImportCommunityPopup {
-            anchors.centerIn: parent
-            store: root.communitiesStore
-            onClosed: {
-                destroy()
-            }
-        }
-    }
-
-    Component {
-        id: createCommunitiesPopupComponent
-        CreateCommunityPopup {
-            anchors.centerIn: parent
-            store: root.communitiesStore
-            onClosed: {
-                destroy()
-            }
-        }
-    }
-
-    Component {
         id: chooseCommunityCreationTypePopupComponent
         StatusDialog {
             id: chooseCommunityCreationTypePopup
@@ -236,7 +208,7 @@ StatusSectionLayout {
                     icon.name: "favourite"
                     onButtonClicked: {
                         chooseCommunityCreationTypePopup.close()
-                        Global.openPopup(createCommunitiesPopupComponent)
+                        Global.createCommunityPopupRequested(false /*isDiscordImport*/)
                     }
                 }
                 CommunityBanner {
@@ -250,17 +222,10 @@ StatusSectionLayout {
                     buttonLoading: importInProgress
                     onButtonClicked: {
                         chooseCommunityCreationTypePopup.close()
-                        Global.openPopup(createCommunitiesPopupComponent, {isDiscordImport: true})
+                        Global.createCommunityPopupRequested(true /*isDiscordImport*/)
                     }
                 }
             }
-        }
-    }
-
-    Component {
-        id: discordImportProgressDialog
-        DiscordImportProgressDialog {
-            store: root.communitiesStore
         }
     }
 }

--- a/ui/app/AppLayouts/CommunitiesPortal/popups/qmldir
+++ b/ui/app/AppLayouts/CommunitiesPortal/popups/qmldir
@@ -1,0 +1,2 @@
+CreateCommunityPopup 1.0 CreateCommunityPopup.qml
+DiscordImportProgressDialog 1.0 DiscordImportProgressDialog.qml

--- a/ui/app/AppLayouts/Profile/views/AdvancedView.qml
+++ b/ui/app/AppLayouts/Profile/views/AdvancedView.qml
@@ -133,7 +133,7 @@ SettingsContentBase {
             }
 
             // TODO: replace with StatusQ component
-             StatusSettingsLineButton {
+            StatusSettingsLineButton {
                 anchors.leftMargin: 0
                 anchors.rightMargin: 0
                 text: qsTr("WakuV2 Store")
@@ -513,28 +513,6 @@ SettingsContentBase {
 
             onCancelButtonClicked: {
                 close()
-            }
-        }
-
-        Component {
-            id: errorMessageDialogCmp
-            StatusDialog {
-                id: errorMessageDialog
-                property string errorMessage: ""
-                title: qsTr("An error occoured")
-
-                StatusBaseText {
-                    anchors.fill: parent
-                    text: {
-                      if (errorMessageDialog.errorMessage.indexOf("address already in use") > -1) {
-                        return qsTr("The specified torrent client port is already in use.")
-                      }
-                      return errorMessageDialog.errorMessage
-                    }
-                }
-
-                standardButtons: Dialog.Ok
-                onAccepted: errorMessageDialog.close()
             }
         }
     }

--- a/ui/app/AppLayouts/Wallet/WalletLayout.qml
+++ b/ui/app/AppLayouts/Wallet/WalletLayout.qml
@@ -67,6 +67,7 @@ Item {
         width: root.width
         backButtonName: RootStore.backButtonName
         notificationCount: activityCenterStore.unreadNotificationsCount
+        hasUnseenNotifications: activityCenterStore.hasUnseenNotifications
         
         onNotificationButtonClicked: Global.openActivityCenterPopup()
         onBackButtonClicked: {

--- a/ui/app/AppLayouts/Wallet/views/LeftTabView.qml
+++ b/ui/app/AppLayouts/Wallet/views/LeftTabView.qml
@@ -198,7 +198,7 @@ Rectangle {
                 width: parent.width
                 font.weight: Font.Medium
                 font.pixelSize: 22
-                loading: RootStore.currentAccount.assetsLoading
+                loading: RootStore.assetsLoading
                 visible: !networkConnectionStore.accountBalanceNotAvailable
             }
 

--- a/ui/app/mainui/Popups.qml
+++ b/ui/app/mainui/Popups.qml
@@ -2,6 +2,7 @@ import QtQuick 2.15
 
 import AppLayouts.Chat.popups 1.0
 import AppLayouts.Profile.popups 1.0
+import AppLayouts.CommunitiesPortal.popups 1.0
 
 import shared.popups 1.0
 import shared.status 1.0
@@ -13,6 +14,7 @@ QtObject {
 
     required property var popupParent
     required property var rootStore
+    property var communitiesStore
 
     property var activePopupComponents: []
 
@@ -34,6 +36,8 @@ QtObject {
         Global.openEditDisplayNamePopup.connect(openEditDisplayNamePopup)
         Global.openPinnedMessagesPopupRequested.connect(openPinnedMessagesPopup)
         Global.openCommunityProfilePopupRequested.connect(openCommunityProfilePopup)
+        Global.createCommunityPopupRequested.connect(openCreateCommunityPopup)
+        Global.importCommunityPopupRequested.connect(openImportCommunityPopup)
         Global.openPopupRequested.connect(openPopup)
     }
 
@@ -180,6 +184,18 @@ QtObject {
 
     function openCommunityPopup(store, community, chatCommunitySectionModule) {
         openPopup(communityProfilePopup, {store: store, community: community, chatCommunitySectionModule: chatCommunitySectionModule})
+    }
+
+    function openCreateCommunityPopup(isDiscordImport) {
+        openPopup(createCommunitiesPopupComponent, {isDiscordImport: isDiscordImport})
+    }
+
+    function openImportCommunityPopup() {
+        openPopup(importCommunitiesPopupComponent)
+    }
+
+    function openDiscordImportProgressPopup() {
+        openPopup(discordImportProgressDialog)
     }
 
     readonly property list<Component> _components: [
@@ -389,6 +405,34 @@ QtObject {
                     close()
                 }
                 onClosed: destroy()
+            }
+        },
+
+        Component {
+            id: importCommunitiesPopupComponent
+            ImportCommunityPopup {
+                store: root.communitiesStore
+                onClosed: {
+                    destroy()
+                }
+            }
+        },
+
+        Component {
+            id: createCommunitiesPopupComponent
+            CreateCommunityPopup {
+                anchors.centerIn: parent
+                store: root.communitiesStore
+                onClosed: {
+                    destroy()
+                }
+            }
+        },
+
+        Component {
+            id: discordImportProgressDialog
+            DiscordImportProgressDialog {
+                store: root.communitiesStore
             }
         }
     ]

--- a/ui/imports/utils/Global.qml
+++ b/ui/imports/utils/Global.qml
@@ -50,6 +50,8 @@ QtObject {
 
     signal openSendModal(string address)
     signal switchToCommunity(string communityId)
+    signal createCommunityPopupRequested(bool isDiscordImport)
+    signal importCommunityPopupRequested()
 
     signal playSendMessageSound()
     signal playNotificationSound()


### PR DESCRIPTION
- CommunitiesPortalLayout was the last piece still unconditionally loaded on startup -> fixed (this will further improve the startup speed)
- extract the `communitiesStore` into `AppMain` to be able to reuse it from other components
- move the import/create community dialogs to `Popups` (reusability)
- wrapped `EmojiPopup` in a loader too
- cleanup and remove some dead code, fix warnings

Iterates #6204

### Affected areas

AppMain/Popups/CommunitiesPortalLayout

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

Portal + create community popup:
![image](https://user-images.githubusercontent.com/5377645/235126927-e8b97ccc-3aa3-4983-bc52-5b0a99a0f4ba.png)

Portal + import community:
![image](https://user-images.githubusercontent.com/5377645/235126977-8a940e91-1f67-48ac-a6e1-22d54c85a7cd.png)

