### PR TITLE
fix(blockChat): Disable chat input when minimal conditions are not met

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
@@ -55,7 +55,6 @@ Control {
     property bool showHeader: true
     property bool isActiveMessage: false
     property bool disableHover: false
-    property bool hideQuickActions: false
     property bool disableEmojis: false
     property color overrideBackgroundColor: "transparent"
     property bool overrideBackground: false
@@ -393,7 +392,7 @@ Control {
         }
 
         Loader {
-            active: root.hovered && !root.hideQuickActions
+            active: root.hovered && root.quickActions.length > 0
             anchors.right: parent.right
             anchors.rightMargin: 20
             anchors.top: parent.top

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -1,4 +1,5 @@
-import QtQuick 2.13
+import QtQuick 2.15
+import QtQml 2.15
 
 import utils 1.0
 import SortFilterProxyModel 0.2
@@ -60,6 +61,10 @@ QtObject {
             expression: icon(model.icon)
         }
     }
+
+    readonly property bool isUserAllowedToSendMessage: _d.isUserAllowedToSendMessage
+    readonly property string chatInputPlaceHolderText: _d.chatInputPlaceHolderText
+    readonly property var oneToOneChatContact: _d.oneToOneChatContact
     // Since qml component doesn't follow encaptulation from the backend side, we're introducing
     // a method which will return appropriate chat content module for selected chat/channel
     function currentChatContentModule(){
@@ -661,6 +666,78 @@ QtObject {
                 readonly property bool amIBanned: model.amIBanned
                 // add others when needed..
             }
+        }
+
+        readonly property string activeChatId: chatCommunitySectionModule && chatCommunitySectionModule.activeItem ? chatCommunitySectionModule.activeItem.id : ""
+        readonly property int activeChatType: chatCommunitySectionModule && chatCommunitySectionModule.activeItem ? chatCommunitySectionModule.activeItem.type : -1
+        readonly property bool amIMember: chatCommunitySectionModule ? chatCommunitySectionModule.amIMember : false
+
+        property var oneToOneChatContact: undefined
+        readonly property string oneToOneChatContactName: !!_d.oneToOneChatContact ? ProfileUtils.displayName(_d.oneToOneChatContact.localNickname, 
+                                                                                                    _d.oneToOneChatContact.name, 
+                                                                                                    _d.oneToOneChatContact.displayName, 
+                                                                                                    _d.oneToOneChatContact.alias) : ""
+
+        //Update oneToOneChatContact when the contact is updated
+        readonly property var myContactsModelConnection: Connections {
+            target: root.contactsStore.myContactsModel ?? null
+            enabled: _d.activeChatType === Constants.chatType.oneToOne
+
+            function onItemChanged(pubKey) {
+                if (pubKey === _d.activeChatId) {
+                    _d.oneToOneChatContact = Utils.getContactDetailsAsJson(pubKey, false)
+                }
+            }
+        }
+
+        readonly property var receivedContactsReqModelConnection: Connections {
+            target: root.contactsStore.receivedContactRequestsModel ?? null
+            enabled: _d.activeChatType === Constants.chatType.oneToOne
+
+            function onItemChanged(pubKey) {
+                if (pubKey === _d.activeChatId) {
+                    _d.oneToOneChatContact = Utils.getContactDetailsAsJson(pubKey, false)
+                }
+            }
+        }
+
+        readonly property var sentContactReqModelConnection: Connections {
+            target: root.contactsStore.sentContactRequestsModel ?? null
+            enabled: _d.activeChatType === Constants.chatType.oneToOne
+
+            function onItemChanged(pubKey) {
+                if (pubKey === _d.activeChatId) {
+                    _d.oneToOneChatContact = Utils.getContactDetailsAsJson(pubKey, false)
+                }
+            }
+        }
+
+        readonly property bool isUserAllowedToSendMessage: {
+            if (_d.activeChatType === Constants.chatType.oneToOne && _d.oneToOneChatContact) {
+                return _d.oneToOneChatContact.contactRequestState == Constants.ContactRequestState.Mutual
+            }
+            else if(_d.activeChatType === Constants.chatType.privateGroupChat) {
+                return _d.amIMember
+            }
+
+            return true
+        }
+
+        readonly property string chatInputPlaceHolderText: {
+            if(!_d.isUserAllowedToSendMessage && _d.activeChatType === Constants.chatType.privateGroupChat) {
+                return qsTr("You need to be a member of this group to send messages")
+            } else if(!_d.isUserAllowedToSendMessage && _d.activeChatType === Constants.chatType.oneToOne) {
+                return qsTr("Add %1 as a contact to send a message").arg(_d.oneToOneChatContactName)
+            }
+
+            return qsTr("Message")
+        }
+
+        //Update oneToOneChatContact when activeChat id changes
+        Binding on oneToOneChatContact {
+            when: _d.activeChatId && _d.activeChatType === Constants.chatType.oneToOne 
+            value: Utils.getContactDetailsAsJson(_d.activeChatId, false)
+            restoreMode: Binding.RestoreBindingOrValue
         }
     }
 }

--- a/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
@@ -39,7 +39,6 @@ Item {
     property bool isChatBlocked: false
     property bool isOneToOne: false
     property bool isActiveChannel: false
-    property int contactRequestState: Constants.ContactRequestState.None
 
     property var messageContextMenu
 
@@ -253,7 +252,7 @@ Item {
             chatLogView: ListView.view
 
             isActiveChannel: root.isActiveChannel
-            isChatBlocked: root.isChatBlocked || (root.isOneToOne && root.contactRequestState !== Constants.ContactRequestState.Mutual)
+            isChatBlocked: root.isChatBlocked
             messageContextMenu: root.messageContextMenu
 
             messageId: model.id
@@ -333,8 +332,8 @@ Item {
             }
         }
         header: {
-            if (root.isOneToOne) {
-                switch (root.contactRequestState) {
+            if (root.isOneToOne && root.rootStore.oneToOneChatContact) {
+                switch (root.rootStore.oneToOneChatContact.contactRequestState) {
                 case Constants.ContactRequestState.None: // no break
                 case Constants.ContactRequestState.Dismissed:
                     return sendContactRequestComponent

--- a/ui/app/AppLayouts/Profile/views/EnsListView.qml
+++ b/ui/app/AppLayouts/Profile/views/EnsListView.qml
@@ -221,7 +221,6 @@ Item {
 
             timestamp: new Date().getTime()
             disableHover: true
-            hideQuickActions: true
             profileClickable: false
 
             messageDetails: StatusMessageDetails {

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -432,6 +432,11 @@ Loader {
 
                 readonly property int contentType: d.convertContentType(root.messageContentType)
                 property string originalMessageText: ""
+                readonly property bool hideQuickActions: root.isChatBlocked ||
+                                  root.placeholderMessage ||
+                                  root.isInPinnedPopup ||
+                                  root.editModeOn ||
+                                  !root.rootStore.mainModuleInst.activeSection.joined
 
                 function editCancelledHandler() {
                     root.messageStore.setEditModeOff(root.messageId)
@@ -492,12 +497,6 @@ Loader {
                               (root.chatLogView && root.chatLogView.moving) ||
                               (root.messageContextMenu && root.messageContextMenu.opened) ||
                               Global.popupOpened
-
-                hideQuickActions: root.isChatBlocked ||
-                                  root.placeholderMessage ||
-                                  root.isInPinnedPopup ||
-                                  root.editModeOn ||
-                                  !root.rootStore.mainModuleInst.activeSection.joined
 
                 disableEmojis: root.isChatBlocked
                 hideMessage: d.hideMessage
@@ -762,7 +761,7 @@ Loader {
 
                 quickActions: [
                     Loader {
-                        active: !root.isInPinnedPopup && delegate.hovered
+                        active: !root.isInPinnedPopup && delegate.hovered && !delegate.hideQuickActions
                         visible: active
                         sourceComponent: StatusFlatRoundButton {
                             width: d.chatButtonSize
@@ -777,7 +776,7 @@ Loader {
                         }
                     },
                     Loader {
-                        active: !root.isInPinnedPopup && delegate.hovered
+                        active: !root.isInPinnedPopup && delegate.hovered && !delegate.hideQuickActions
                         visible: active
                         sourceComponent: StatusFlatRoundButton {
                             objectName: "replyToMessageButton"
@@ -795,7 +794,7 @@ Loader {
                         }
                     },
                     Loader {
-                        active: !root.isInPinnedPopup && root.isText && !root.editModeOn && root.amISender && delegate.hovered
+                        active: !root.isInPinnedPopup && root.isText && !root.editModeOn && root.amISender && delegate.hovered && !delegate.hideQuickActions
                         visible: active
                         sourceComponent: StatusFlatRoundButton {
                             objectName: "editMessageButton"
@@ -816,6 +815,9 @@ Loader {
                                 
                             if (!root.messageStore)
                                 return false
+                            
+                            if(delegate.hideQuickActions)
+                                return false;
 
                             const chatType = root.messageStore.chatType;
                             const pinMessageAllowedForMembers = root.messageStore.isPinMessageAllowedForMembers


### PR DESCRIPTION
### What does the PR do

Closing #10183 

1. Disable the group chat when the user is kicked
    Here we need to detect the kick happens and update the UI accordingly. To do this I've used the same `amIMember` boolean from `chatCommunitySectionModule` that it is used for communities. This boolean is updated from 2 additional flows: When the chat becomes active; When the chat is added or updated.
2. Move 1to1 chat disabling logic to RootStore and extend it with the group chat logic

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas
StatusChatInput
Message history
Group chat
1to1 chat

<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Screenshot of functionality (including design for comparison)

Group chats:

https://user-images.githubusercontent.com/47811206/236434822-1665afb6-b4f8-4543-87c5-7e9d3b5ef881.mov


1to1 chats:

https://user-images.githubusercontent.com/47811206/236434876-5994bf3f-49bd-4dda-b65a-427a069aa400.mov


<!-- screenshot (or gif/video) that demonstrates the functionality, specially important if it's a bug fix. -->

