### PR TITLE
fix(Onboarding): Image is visible after first onboard. Other minor fixes

### DIFF
--- a/src/app/modules/startup/module.nim
+++ b/src/app/modules/startup/module.nim
@@ -407,7 +407,8 @@ method onNodeLogin*[T](self: Module[T], error: string) =
         self.logoutAndDisplayError(err, StartupErrorType.UnknownType)
         return
       if currStateObj.flowType() != FlowType.AppLogin:
-        discard self.controller.storeIdentityImage()
+        let images = self.controller.storeIdentityImage()
+        self.accountsService.updateLoggedInAccount(self.getDisplayName, images)
       self.delegate.finishAppLoading()
   else:
     self.moveToStartupState()

--- a/ui/app/AppLayouts/Onboarding/views/InsertDetailsView.qml
+++ b/ui/app/AppLayouts/Onboarding/views/InsertDetailsView.qml
@@ -148,18 +148,7 @@ Item {
                 input.edit.objectName: "onboardingDisplayNameInput"
                 width: parent.width
                 placeholderText: qsTr("Display name")
-                input.rightComponent: RoundedIcon {
-                    width: 14
-                    height: 14
-                    iconWidth: 14
-                    iconHeight: 14
-                    visible: (nameInput.input.text.length > 0)
-                    color: "transparent"
-                    source: Style.svg("close-filled")
-                    onClicked: {
-                        nameInput.input.edit.clear();
-                    }
-                }
+                input.clearable: true
                 errorMessageCmp.wrapMode: Text.NoWrap
                 errorMessageCmp.horizontalAlignment: Text.AlignHCenter
                 validators: Constants.validators.displayName

--- a/ui/app/AppLayouts/Profile/stores/ProfileStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/ProfileStore.qml
@@ -15,8 +15,8 @@ QtObject {
     property string icon: !!Global.userProfile? Global.userProfile.icon : ""
     property bool userDeclinedBackupBanner: Global.appIsReady? localAccountSensitiveSettings.userDeclinedBackupBanner : false
     property var privacyStore: profileSectionModule.privacyModule
-    readonly property string keyUid: userProfile.keyUid
-    readonly property bool isKeycardUser: userProfile.isKeycardUser
+    readonly property string keyUid: !!Global.userProfile ? Global.userProfile.keyUid : ""
+    readonly property bool isKeycardUser: !!Global.userProfile ? Global.userProfile.isKeycardUser : false
 
     readonly property string bio: profileModule.bio
     readonly property string socialLinksJson: profileModule.socialLinksJson

--- a/ui/imports/utils/Utils.qml
+++ b/ui/imports/utils/Utils.qml
@@ -435,7 +435,9 @@ QtObject {
 
     function isEnsVerified(publicKey) {
         if (publicKey === "" || !isChatKey(publicKey) )
-            return
+            return false
+        if (!mainModuleInst)
+            return false
         return mainModuleInst.isEnsVerified(publicKey)
     }
 


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/10099

### What does the PR do

1. The profile image is visible when login after first onboarding
2. The identicon ring is visible during onboarding
3. Minor cleanup

### Affected areas

Onboarding

### Screenshot of functionality (including design for comparison)

https://user-images.githubusercontent.com/25482501/235351769-490f937f-4d0a-46fa-b93e-c8e532bcce51.mov
