### PR TITLE
fix(wallet) remove all pending transactions upon downloaded update

### DIFF
--- a/src/app_service/service/transaction/service.nim
+++ b/src/app_service/service/transaction/service.nim
@@ -173,7 +173,7 @@ QtObject:
       return @[]
 
     return toSeq(self.allTransactions[address].values)
-  
+
   proc watchTransactionResult*(self: Service, watchTxResult: string) {.slot.} =
     let watchTxResult = parseJson(watchTxResult)
     let success = watchTxResult["isSuccessfull"].getBool
@@ -183,7 +183,7 @@ QtObject:
       let address = watchTxResult["address"].getStr
       let transactionReceipt = transactions.getTransactionReceipt(chainId, hash).result
       if transactionReceipt != nil and transactionReceipt.kind != JNull:
-        # Pending transaction will be deleted by backend after transfering multi-transaction info to history
+        # Pending transaction are deleted by backend on new state downloading
         echo watchTxResult["data"].getStr
         let ev = TransactionMinedArgs(
           data: watchTxResult["data"].getStr,


### PR DESCRIPTION
### Updates status-desktop [#10474](https://github.com/status-im/status-desktop/issues/10474)

`status-go` change [#3441](https://github.com/status-im/status-go/pull/3441)

Previously this was done only for multi-transaction ID. Learned that not all the transactions are multi-transaction (e.g. ens, airdrop collectible)