### PR TITLE
fix(Community mint token): Fix default network selection

### DIFF
--- a/ui/app/AppLayouts/Wallet/controls/NetworkFilter.qml
+++ b/ui/app/AppLayouts/Wallet/controls/NetworkFilter.qml
@@ -3,6 +3,7 @@ import QtQuick.Controls 2.15
 
 import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
+import StatusQ.Core.Utils 0.1
 import StatusQ.Components 0.1
 
 import shared 1.0
@@ -46,6 +47,7 @@ Item {
         if (d.currentModel.count > 0) {
             d.selectedChainName = d.currentModel.rowData(d.currentIndex, "chainName")
             d.selectedIconUrl = d.currentModel.rowData(d.currentIndex, "iconUrl")
+            root.toggleNetwork(ModelUtils.get(d.currentModel, d.currentIndex))
         }
     }
 


### PR DESCRIPTION
### What does the PR do
Closing #10470

NetworkFilter.qml needs to emit `toggleNetwork` to inform the parent of the initial network state.
<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas
NetworkFilter
<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Screenshot of functionality (including design for comparison)


https://user-images.githubusercontent.com/47811206/235619314-073dcc73-081e-4081-8908-35ec7b214151.mov


