### PR TITLE
fix(wallet) don't show too big account index for custom path

### DIFF
--- a/storybook/pages/DerivationPathInputPage.qml
+++ b/storybook/pages/DerivationPathInputPage.qml
@@ -21,7 +21,7 @@ SplitView {
             anchors.fill: parent
 
             DerivationPathInput {
-                id: devTxtEdit
+                id: testControl
 
                 initialDerivationPath: initialBasePath + (initialBasePath.split("'").length > 4 ? "/0" : "/0'")
                 initialBasePath: stdBaseListView.currentIndex >= 0
@@ -41,7 +41,7 @@ SplitView {
                         hoverEnabled: true
                         cursorShape: Qt.PointingHandCursor
                         onClicked: {
-                            derivationPathSelection.popup(0, devTxtEdit.height + Style.current.halfPadding)
+                            derivationPathSelection.popup(0, testControl.height + Style.current.halfPadding)
                         }
                     }
                 }
@@ -110,13 +110,13 @@ SplitView {
                 highlighted: hovered
 
                 onClicked: {
-                    devTxtEdit.resetDerivationPath(customDerivationPathBaseInput.text, customDerivationPathInput.text)
+                    testControl.resetDerivationPath(customDerivationPathBaseInput.text, customDerivationPathInput.text)
                 }
             }
 
             Label {
-                text: devTxtEdit.errorMessage
-                visible: devTxtEdit.errorMessage.length > 0
+                text: testControl.errorMessage
+                visible: testControl.errorMessage.length > 0
 
                 Layout.fillWidth: true
 
@@ -125,8 +125,8 @@ SplitView {
                 color: "red"
             }
             Label {
-                text: devTxtEdit.warningMessage
-                visible: devTxtEdit.warningMessage.length > 0
+                text: testControl.warningMessage
+                visible: testControl.warningMessage.length > 0
 
                 Layout.fillWidth: true
 
@@ -136,11 +136,37 @@ SplitView {
             }
             RowLayout {
                 Label { text: "Output: " }
-                Label { id: base; text: devTxtEdit.derivationPath }
+                Label { id: base; text: testControl.derivationPath }
             }
             RowLayout {
                 Label { text: "Last event: " }
                 Label { id: lastEvent; text: "" }
+            }
+            CheckBox {
+                id: reflexiveMode
+                text: "Auto echo derivation path onto itself every " + reflexiveTimer.interval + " ms"
+                checked: false
+            }
+            CheckBox {
+                text: "Standard base path detected"
+                checked: testControl.detectedStandardBasePath
+                enabled: false
+            }
+        }
+
+        Timer {
+            id: reflexiveTimer
+            interval: 100
+            running: false
+            repeat: false
+            onTriggered: testControl.resetDerivationPath(testControl.basePath, testControl.derivationPath)
+        }
+        Connections {
+            target: testControl
+            function onDerivationPathChanged() {
+                if (reflexiveMode.checked) {
+                    reflexiveTimer.restart()
+                }
             }
         }
 
@@ -151,10 +177,10 @@ SplitView {
             target: customDerivationPathBaseInput
         }
         Border {
-            target: devTxtEdit
+            target: testControl
         }
         Border {
-            target: devTxtEdit
+            target: testControl
             radius: 0
             border.color: "#22FF0000"
         }
@@ -172,7 +198,7 @@ SplitView {
 
             onCurrentIndexChanged: {
                 const newBasePath = standardBasePathModel.get(currentIndex).derivationPath
-                devTxtEdit.resetDerivationPath(newBasePath, newBasePath + (newBasePath.split("'").length > 3 ? "/0" : "/0'"))
+                testControl.resetDerivationPath(newBasePath, newBasePath + (newBasePath.split("'").length > 3 ? "/0" : "/0'"))
             }
 
             delegate: ItemDelegate {

--- a/ui/app/AppLayouts/Wallet/addaccount/panels/DerivationPathInput.qml
+++ b/ui/app/AppLayouts/Wallet/addaccount/panels/DerivationPathInput.qml
@@ -16,6 +16,7 @@ Item {
     id: root
 
     readonly property alias derivationPath: d.currentDerivationPath
+    readonly property alias basePath: d.currentBasePath
 
     required property string initialDerivationPath
     required property string initialBasePath
@@ -26,6 +27,8 @@ Item {
     property alias warningMessage: d.warningMessage
 
     property alias input: input
+
+    readonly property alias detectedStandardBasePath: d.detectedStandardBasePath
 
     signal editingFinished()
 
@@ -41,7 +44,12 @@ Item {
         }
         d.resetMessages()
         d.elements = res.elements
+
+        // Check if we enforced a standard derivation path
+        d.frozenLevelCount = d.elements.filter((e) => e.isFrozen && e.isNumber()).length
+
         d.updateText(d.elements)
+        d.currentBasePath = basePath
         input.cursorPosition = d.elements[d.elements.length - 1].endIndex
         return true
     }
@@ -50,6 +58,7 @@ Item {
         id: d
 
         property string currentDerivationPath: ""
+        property string currentBasePath: ""
 
         property var elements: []
         /// element index at cursor position
@@ -59,6 +68,9 @@ Item {
 
         property string errorMessage: ""
         property string warningMessage: ""
+
+        property int frozenLevelCount: 0
+        property bool detectedStandardBasePath: frozenLevelCount >= 3
 
         function resetMessages() { errorMessage = ""; warningMessage = "" }
 
@@ -85,6 +97,7 @@ Item {
         frozenColor: Theme.palette.getColor('grey5')
         errorColor: Theme.palette.dangerColor1
         warningColor: Theme.palette.warningColor1
+        complainTooBigAccIndex: d.detectedStandardBasePath
     }
 
     StatusBaseInput {

--- a/ui/app/AppLayouts/Wallet/addaccount/panels/DerivationPathInput/Controller.qml
+++ b/ui/app/AppLayouts/Wallet/addaccount/panels/DerivationPathInput/Controller.qml
@@ -14,6 +14,7 @@ Item {
 
     /// Don't allow inserting more than \c levelsLimit Number elements
     property int levelsLimit: 0
+    property bool complainTooBigAccIndex: true
 
     readonly property string inputError: qsTr("Please enter numbers only")
     readonly property string tooBigError: qsTr("Account number must be <100")
@@ -415,7 +416,7 @@ Item {
             return {error: root.inputError, warning: ""}
         } else if(numberLevel == 0 && !element.isEmptyNumber() && element.number() != d.ethereumCoinType) {
             return {error: "", warning: root.nonEthCoinWarning}
-        } else if(numberLevel >= d.addressIndexStart && element.number() >= 100) {
+        } else if(root.complainTooBigAccIndex && numberLevel >= d.addressIndexStart && element.number() >= 100) {
             return {error: root.tooBigError, warning: ""}
         }
         return {error: "", warning: ""}


### PR DESCRIPTION
Updates #10479

The warning for not being supported account index bigger than `99` make sense only for standard derivation paths we support. Therefore, remove the warning in case of derivation path

The change adds a test case to story book for investigating issue #10479. However, the control seems to work well with reflected values.

![image](https://user-images.githubusercontent.com/47554641/235625509-a3af73bf-92d7-4bac-a6df-c97ae05bd0c6.png)

![image](https://user-images.githubusercontent.com/47554641/235625554-6e55ed27-9433-4941-b6eb-10cc7a837e6a.png)
