### PR TITLE
fix(AssetsDetailView): don't display "Dummy" for zero values

### DIFF
--- a/ui/app/AppLayouts/Wallet/views/AssetsDetailView.qml
+++ b/ui/app/AppLayouts/Wallet/views/AssetsDetailView.qml
@@ -300,7 +300,7 @@ Item {
                 readonly property double changePctHour: token.changePctHour ?? 0
                 maxWidth: parent.width
                 primaryText: qsTr("Hour")
-                secondaryText: changePctHour ? "%1%".arg(LocaleUtils.numberToLocaleString(changePctHour, 2)) : Constants.dummyText
+                secondaryText: "%1%".arg(LocaleUtils.numberToLocaleString(changePctHour, 2))
                 secondaryLabel.customColor: changePctHour === 0 ? Theme.palette.directColor1 :
                                                                   changePctHour < 0 ? Theme.palette.dangerColor1 :
                                                                                       Theme.palette.successColor1
@@ -310,7 +310,7 @@ Item {
                 readonly property double changePctDay: token.changePctDay ?? 0
                 maxWidth: parent.width
                 primaryText: qsTr("Day")
-                secondaryText: changePctDay ? "%1%".arg(LocaleUtils.numberToLocaleString(changePctDay, 2)) : Constants.dummyText
+                secondaryText: "%1%".arg(LocaleUtils.numberToLocaleString(changePctDay, 2))
                 secondaryLabel.customColor: changePctDay === 0 ? Theme.palette.directColor1 :
                                                                  changePctDay < 0 ? Theme.palette.dangerColor1 :
                                                                                     Theme.palette.successColor1
@@ -320,7 +320,7 @@ Item {
                 readonly property double changePct24hour: token.changePct24hour ?? 0
                 maxWidth: parent.width
                 primaryText: qsTr("24 Hours")
-                secondaryText: changePct24hour ? "%1%".arg(LocaleUtils.numberToLocaleString(changePct24hour, 2)) : Constants.dummyText
+                secondaryText: "%1%".arg(LocaleUtils.numberToLocaleString(changePct24hour, 2))
                 secondaryLabel.customColor: changePct24hour === 0 ? Theme.palette.directColor1 :
                                                                     changePct24hour < 0 ? Theme.palette.dangerColor1 :
                                                                                           Theme.palette.successColor1


### PR DESCRIPTION
zero (0) is a valid change value here, it's a "stable" coin

### What does the PR do

Fixes displaying invalid "Dummy" values

### Affected areas

AssetDetailView

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

Before:
![Snímek obrazovky z 2023-05-02 16-01-30](https://user-images.githubusercontent.com/5377645/235690986-7a6a8b2f-8e8b-4b9e-bb3d-4bd89e3c2183.png)

After fix:
![Snímek obrazovky z 2023-05-02 16-03-35](https://user-images.githubusercontent.com/5377645/235690977-5b7cc5ca-7f6c-4c73-9777-6902a5fb4f83.png)


