### PR TITLE
fix(wallet): change placeholder for watch-only account

### DIFF
--- a/ui/app/AppLayouts/Wallet/addaccount/panels/WatchOnlyAddressSection.qml
+++ b/ui/app/AppLayouts/Wallet/addaccount/panels/WatchOnlyAddressSection.qml
@@ -26,7 +26,7 @@ Column {
         maximumHeight: Constants.addAccountPopup.itemHeight
         minimumHeight: Constants.addAccountPopup.itemHeight
         label: qsTr("Ethereum address or ENS name")
-        placeholderText: "0x95222293DD7278Aa3Cdd389Cc1D1d165CCBAfe5"
+        placeholderText: qsTr("Type or paste ETH address")
         input.multiline: true
         input.rightComponent: StatusButton {
             anchors.verticalCenter: parent.verticalCenter


### PR DESCRIPTION
### What does the PR do

Fixes https://github.com/status-im/status-desktop/issues/10513. It was confirmed with @benjthayer to change the placeholder to the one in figma https://www.figma.com/file/FkFClTCYKf83RJWoifWgoX/Wallet-v2?node-id=12272-280578&t=QIlxb9Ht7sPwTp3S-4

### Affected areas

Add account form

### Screenshot of functionality (including design for comparison)

<img width="1552" alt="Screenshot 2023-05-02 at 17 18 16" src="https://user-images.githubusercontent.com/82375995/235694718-22f93714-b050-4f8b-8a47-8f7282907ec7.png">
