### PR TITLE
fix: ensure notification settings are cached from RPC

### DIFF
--- a/src/app_service/service/settings/dto/settings.nim
+++ b/src/app_service/service/settings/dto/settings.nim
@@ -125,6 +125,17 @@ type
     gifRecents*: JsonNode
     gifFavorites*: JsonNode
     testNetworksEnabled*: bool
+    notificationsAllowNotifications*: bool
+    notificationsOneToOneChats*: string
+    notificationsGroupChats*: string
+    notificationsPersonalMentions*: string
+    notificationsGlobalMentions*: string
+    notificationsAllMessages*: string
+    notificationsContactRequests*: string
+    notificationsIdentityVerificationRequests*: string
+    notificationsSoundsEnabled*: bool
+    notificationsVolume*: int
+    notificationsMessagePreview*: int
 
 proc toPinnedMailserver*(jsonObj: JsonNode): PinnedMailserver =
   # we maintain pinned mailserver per fleet


### PR DESCRIPTION
There are a bunch of notification related settings that cause RPC calls when read from the UI in QML/Qt.

This is bad because whenever the view tries to read a notification setting it causes an RPC call and then rerenders the view. This happens pretty much every time a new signal arrives in the client.

To account for that we now fetch all notification settings once and mark the service as initialized so it know when to simply return cached values. The cache is updated when the notification settings change.

Fixes #10493
