### PR TITLE
fix: Fixed community channel emoji not updated

### DIFF
--- a/src/app_service/service/community/service.nim
+++ b/src/app_service/service/community/service.nim
@@ -520,7 +520,7 @@ QtObject:
             )
 
           # Handle name/description changes
-          if chat.name != prev_chat.name or chat.description != prev_chat.description or chat.color != prev_chat.color:
+          if chat.name != prev_chat.name or chat.description != prev_chat.description or chat.color != prev_chat.color or chat.emoji != prev_chat.emoji:
             var updatedChat = findChatById(chat.id, updatedChats)
             updatedChat.updateMissingFields(chat)
             self.chatService.updateOrAddChat(updatedChat) # we have to update chats stored in the chat service.
@@ -665,8 +665,11 @@ QtObject:
     return toSeq(self.getFilteredCuratedCommunities.values)
 
   proc getCommunityById*(self: Service, communityId: string): CommunityDto =
-    if(not self.communities.hasKey(communityId)):
-      error "error: requested community doesn't exists", communityId
+    if communityId == "":
+      return
+
+    if not self.communities.hasKey(communityId):
+      error "requested community doesn't exists", communityId
       return
 
     return self.communities[communityId]

--- a/ui/app/AppLayouts/Chat/panels/ChatsLoadingPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/ChatsLoadingPanel.qml
@@ -15,9 +15,12 @@ Loader {
             anchors.horizontalCenter: parent.horizontalCenter
             spacing: 6
             StatusBaseText {
+                anchors.verticalCenter: parent.verticalCenter
                 text: qsTr("Loading chats...")
             }
-            LoadingAnimation {}
+            LoadingAnimation {
+                anchors.verticalCenter: parent.verticalCenter
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/10190

### What does the PR do

1. Fix that the community channel emoji wasn't updating on change
2. Hide "requested community doesn't exists" for empty `communityId` 
3. Fix "loading chats" indicator alignment