### PR TITLE
fix(message/service): fix msg not appearing in new chat because of race

### DIFF
--- a/src/app/boot/app_controller.nim
+++ b/src/app/boot/app_controller.nim
@@ -183,7 +183,13 @@ proc newAppController*(statusFoundation: StatusFoundation): AppController =
     result.tokenService, result.networkService
   )
   result.messageService = message_service.newService(
-    statusFoundation.events, statusFoundation.threadpool, result.contactsService, result.tokenService, result.walletAccountService, result.networkService
+    statusFoundation.events,
+    statusFoundation.threadpool,
+    result.chatService,
+    result.contactsService,
+    result.tokenService,
+    result.walletAccountService,
+    result.networkService,
   )
   result.communityService = community_service.newService(statusFoundation.events,
     statusFoundation.threadpool, result.chatService, result.activityCenterService, result.messageService)

--- a/src/app_service/service/chat/service.nim
+++ b/src/app_service/service/chat/service.nim
@@ -36,7 +36,6 @@ type
 
   ChatUpdateArgs* = ref object of Args
     chats*: seq[ChatDto]
-    messages*: seq[MessageDto]
 
   CreatedChatArgs* = ref object of Args
     chat*: ChatDto
@@ -151,7 +150,7 @@ QtObject:
               self.events.emit(SIGNAL_CHAT_MEMBERS_CHANGED, ChatMembersChangedArgs(chatId: chatDto.id, members: chatDto.members))
             self.updateOrAddChat(chatDto)
 
-        self.events.emit(SIGNAL_CHAT_UPDATE, ChatUpdateArgs(messages: receivedData.messages, chats: chats))
+        self.events.emit(SIGNAL_CHAT_UPDATE, ChatUpdateArgs(chats: chats))
 
       if (receivedData.clearedHistories.len > 0):
         for clearedHistoryDto in receivedData.clearedHistories:
@@ -357,12 +356,12 @@ QtObject:
           break
 
   proc processUpdateForTransaction*(self: Service, messageId: string, response: RpcResponse[JsonNode]) =
-    var (chats, messages) = self.processMessageUpdateAfterSend(response)
+    var (chats, _) = self.processMessageUpdateAfterSend(response)
     self.events.emit(SIGNAL_MESSAGE_DELETED, MessageArgs(id: messageId, channel: chats[0].id))
 
   proc emitUpdate(self: Service, response: RpcResponse[JsonNode]) =
-    var (chats, messages) = self.parseChatResponse(response)
-    self.events.emit(SIGNAL_CHAT_UPDATE, ChatUpdateArgs(messages: messages, chats: chats))
+    var (chats, _) = self.parseChatResponse(response)
+    self.events.emit(SIGNAL_CHAT_UPDATE, ChatUpdateArgs(chats: chats))
 
   proc getAllChats*(self: Service): seq[ChatDto] =
     return toSeq(self.chats.values)


### PR DESCRIPTION
Fixes #10340

Fixes a race condition when receiving a message in a channel that doesn't exist yet (for example in a delete 1-1 chat). What happens is that the status-go signal contains both the message and the chat. Both are handled by different services, so there was a race between the two of them. If the chat service handled the chat first, then the message was added correctly, but in the case of the message service handling it first, it would try to add the message to a chat that doesn't exist yet, so it wouldn't work.

I also cleaned the ChatUpdateArgs by removing the messages arg that was not used anywhere and also was a bit counter-intuitive. Why did a Chat arg have messages?