### PR TITLE
ci: upgrade from Go 1.19.5 to 1.20.4

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -81,8 +81,8 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.1/cmake-3.22.1
 ENV PATH="/opt/cmake/bin:${PATH}"
 
 # Installing Golang
-RUN GOLANG_SHA256="36519702ae2fd573c9869461990ae550c8c0d955cd28d2827a6b159fda81ff95" \
- && GOLANG_TARBALL="go1.19.5.linux-amd64.tar.gz" \
+RUN GOLANG_SHA256="698ef3243972a51ddb4028e4a1ac63dc6d60821bf18e59a807e051fee0a385bd" \
+ && GOLANG_TARBALL="go1.20.4.linux-amd64.tar.gz" \
  && wget -q "https://dl.google.com/go/${GOLANG_TARBALL}" \
  && echo "${GOLANG_SHA256} ${GOLANG_TARBALL}" | sha256sum -c \
  && sudo tar -C /usr/local -xzf "${GOLANG_TARBALL}" \

--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -8,7 +8,7 @@ pipeline {
     /* Necessary image with Ubuntu 18.04 for older Glibc. */
     docker {
       label 'linux'
-      image 'statusteam/nim-status-client-build:1.2.1-qt5.15.2'
+      image 'statusteam/nim-status-client-build:1.2.2-qt5.15.2'
       /* allows jenkins use cat and mounts '/dev/fuse' for linuxdeployqt */
       args '--entrypoint="" --cap-add SYS_ADMIN --security-opt apparmor:unconfined --device /dev/fuse'
     }

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -6,7 +6,7 @@ def isPRBuild = utils.isPRBuild()
 pipeline {
   /* This way we run the same Jenkinsfile on different platforms. */
   agent {
-    label "${getAgentLabels().join(' && ')} && qt-5.15"
+    label "${getAgentLabels().join(' && ')} && qt-5.15 && go-1.20"
   }
 
   parameters {

--- a/scripts/macos_build_setup.sh
+++ b/scripts/macos_build_setup.sh
@@ -42,8 +42,8 @@ function install_golang {
   fi
   declare -A GO_SHA256_MAP
   GO_SHA256_MAP=(
-    ["amd64"]="23d22bb6571bbd60197bee8aaa10e702f9802786c2e2ddce5c84527e86b66aa0"
-    ["arm64"]="4a67f2bf0601afe2177eb58f825adf83509511d77ab79174db0712dc9efa16c8"
+    ["amd64"]="242b099b5b9bd9c5d4d25c041216bc75abcdf8e0541aec975eeabcbce61ad47f"
+    ["arm64"]="61bd4f7f2d209e2a6a7ce17787fc5fea52fb11cc9efb3d8471187a8b39ce0dc9"
   )
   echo "Install GoLang ${GO_VERSION}"
   GO_ARCH=$(get_go_arch)

--- a/scripts/ubuntu_build_setup.sh
+++ b/scripts/ubuntu_build_setup.sh
@@ -66,9 +66,9 @@ function install_golang {
   fi
   declare -A GO_SHA256_MAP
   GO_SHA256_MAP=(
-    ["amd64"]="36519702ae2fd573c9869461990ae550c8c0d955cd28d2827a6b159fda81ff95"
-    ["arm64"]="fc0aa29c933cec8d76f5435d859aaf42249aa08c74eb2d154689ae44c08d23b3"
-    ["armv6l"]="ec14f04bdaf4a62bdcf8b55b9b6434cc27c2df7d214d0bb7076a7597283b026a"
+    ["amd64"]="698ef3243972a51ddb4028e4a1ac63dc6d60821bf18e59a807e051fee0a385bd"
+    ["arm64"]="105889992ee4b1d40c7c108555222ca70ae43fccb42e20fbf1eebb822f5e72c6"
+    ["armv6l"]="0b75ca23061a9996840111f5f19092a1bdbc42ec1ae25237ed2eec1c838bd819"
   )
   echo "Install GoLang ${GO_VERSION}"
   GO_OS=$(uname -s | tr '[:upper:]' '[:lower:]')

--- a/scripts/windows_build_setup.ps1
+++ b/scripts/windows_build_setup.ps1
@@ -18,7 +18,7 @@ function Install-Dependencies {
     scoop install --global `
         7zip git dos2unix findutils `
         wget rcedit inno-setup `
-        make cmake gcc go@1.19.5
+        make cmake gcc go@1.20.4
     scoop bucket add extras
     scoop install --global vcredist2019
 }


### PR DESCRIPTION
Release notes: https://go.dev/doc/devel/release#go1.20

This is supposed to fix crashes on M1 Macs:
- https://github.com/status-im/status-desktop/issues/10548
- https://github.com/status-im/status-desktop/pull/10442

Specifically this commit:
- https://github.com/golang/go/commit/c00e9285eae4599f6a123d0a355633379be998e8 - runtime: save frame pointer to the stack in signal handlers for arm64