### PR TITLE
[communities]: increased token holders combo width

### DIFF
--- a/ui/app/AppLayouts/Chat/panels/communities/TokenHoldersPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/TokenHoldersPanel.qml
@@ -100,10 +100,8 @@ Control {
 
                 StatusComboBox {
                     id: combo
-
-                    Layout.preferredWidth: 70
+                    Layout.preferredWidth: 88
                     Layout.preferredHeight: 44
-
                     visible: root.isSelectorMode && amount > 1
                     control.spacing: Style.current.halfPadding / 2
                     model: amount


### PR DESCRIPTION
Closes #10258

### What does the PR do
TokenHoldersPanel: increased token holders combo width

### Affected areas
TokenHoldersPanel

### Screenshot of functionality (including design for comparison)
<img width="633" alt="r" src="https://user-images.githubusercontent.com/31625338/236212774-714e7c4f-047b-4f3f-b268-a16d9701b3ba.png">

