### PR TITLE
feat(@desktop/communities): automatically encrypt closed communities

### DIFF
--- a/src/app/modules/main/communities/controller.nim
+++ b/src/app/modules/main/communities/controller.nim
@@ -138,8 +138,7 @@ proc createCommunity*(
     aX: int, aY: int, bX: int, bY: int,
     historyArchiveSupportEnabled: bool,
     pinMessageAllMembersEnabled: bool,
-    bannerJsonStr: string,
-    encrypted: bool) =
+    bannerJsonStr: string) =
   self.communityService.createCommunity(
     name,
     description,
@@ -152,8 +151,7 @@ proc createCommunity*(
     aX, aY, bX, bY,
     historyArchiveSupportEnabled,
     pinMessageAllMembersEnabled,
-    bannerJsonStr,
-    encrypted)
+    bannerJsonStr)
 
 proc requestImportDiscordCommunity*(
     self: Controller,
@@ -169,8 +167,7 @@ proc requestImportDiscordCommunity*(
     historyArchiveSupportEnabled: bool,
     pinMessageAllMembersEnabled: bool,
     filesToImport: seq[string],
-    fromTimestamp: int,
-    encrypted: bool) =
+    fromTimestamp: int) =
   self.communityService.requestImportDiscordCommunity(
     name,
     description,
@@ -184,8 +181,7 @@ proc requestImportDiscordCommunity*(
     historyArchiveSupportEnabled,
     pinMessageAllMembersEnabled,
     filesToImport,
-    fromTimestamp,
-    encrypted)
+    fromTimestamp)
 
 proc reorderCommunityChat*(
     self: Controller,

--- a/src/app/modules/main/communities/io_interface.nim
+++ b/src/app/modules/main/communities/io_interface.nim
@@ -40,14 +40,13 @@ method spectateCommunity*(self: AccessInterface, communityId: string): string {.
 
 method createCommunity*(self: AccessInterface, name: string, description, introMessage, outroMessage: string, access: int,
                         color: string, tags: string, imagePath: string, aX: int, aY: int, bX: int, bY: int,
-                        historyArchiveSupportEnabled: bool, pinMessageAllMembersEnabled: bool, bannerJsonStr: string,
-                        encrypted: bool) {.base.} =
+                        historyArchiveSupportEnabled: bool, pinMessageAllMembersEnabled: bool, bannerJsonStr: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method requestImportDiscordCommunity*(self: AccessInterface, name: string, description, introMessage, outroMessage: string, access: int,
                         color: string, tags: string, imagePath: string, aX: int, aY: int, bX: int, bY: int,
                         historyArchiveSupportEnabled: bool, pinMessageAllMembersEnabled: bool, filesToImport: seq[string],
-                        fromTimestamp: int, encrypted: bool) {.base.} =
+                        fromTimestamp: int) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method deleteCommunityCategory*(self: AccessInterface, communityId: string, categoryId: string) {.base.} =

--- a/src/app/modules/main/communities/module.nim
+++ b/src/app/modules/main/communities/module.nim
@@ -252,11 +252,10 @@ method createCommunity*(self: Module, name: string,
                         aX: int, aY: int, bX: int, bY: int,
                         historyArchiveSupportEnabled: bool,
                         pinMessageAllMembersEnabled: bool,
-                        bannerJsonStr: string,
-                        encrypted: bool) =
+                        bannerJsonStr: string) =
   self.controller.createCommunity(name, description, introMessage, outroMessage, access, color, tags,
                                   imagePath, aX, aY, bX, bY, historyArchiveSupportEnabled, pinMessageAllMembersEnabled, 
-                                  bannerJsonStr, encrypted)
+                                  bannerJsonStr)
 
 method deleteCommunityCategory*(self: Module, communityId: string, categoryId: string) =
   self.controller.deleteCommunityCategory(communityId, categoryId)
@@ -339,9 +338,9 @@ method requestExtractDiscordChannelsAndCategories*(self: Module, filesToImport: 
 method requestImportDiscordCommunity*(self: Module, name: string, description, introMessage, outroMessage: string, access: int,
                         color: string, tags: string, imagePath: string, aX: int, aY: int, bX: int, bY: int,
                         historyArchiveSupportEnabled: bool, pinMessageAllMembersEnabled: bool, filesToImport: seq[string], 
-                        fromTimestamp: int, encrypted: bool) =
+                        fromTimestamp: int) =
   self.view.setDiscordImportHasCommunityImage(imagePath != "")
-  self.controller.requestImportDiscordCommunity(name, description, introMessage, outroMessage, access, color, tags, imagePath, aX, aY, bX, bY, historyArchiveSupportEnabled, pinMessageAllMembersEnabled, filesToImport, fromTimestamp, encrypted)
+  self.controller.requestImportDiscordCommunity(name, description, introMessage, outroMessage, access, color, tags, imagePath, aX, aY, bX, bY, historyArchiveSupportEnabled, pinMessageAllMembersEnabled, filesToImport, fromTimestamp)
 
 proc getDiscordImportTaskItem(self: Module, t: DiscordImportTaskProgress): DiscordImportTaskItem =
   return initDiscordImportTaskItem(

--- a/src/app/modules/main/communities/view.nim
+++ b/src/app/modules/main/communities/view.nim
@@ -421,11 +421,10 @@ QtObject:
                         imagePath: string,
                         aX: int, aY: int, bX: int, bY: int,
                         historyArchiveSupportEnabled: bool,
-                        pinMessageAllMembersEnabled: bool, bannerJsonStr: string,
-                        encrypted: bool) {.slot.} =
+                        pinMessageAllMembersEnabled: bool, bannerJsonStr: string) {.slot.} =
     self.delegate.createCommunity(name, description, introMessage, outroMessage, access, color, tags,
                                   imagePath, aX, aY, bX, bY, historyArchiveSupportEnabled, pinMessageAllMembersEnabled, 
-                                  bannerJsonStr, encrypted)
+                                  bannerJsonStr)
 
   proc clearFileList*(self: View) {.slot.} =
     self.discordFileListModel.clearItems()
@@ -459,7 +458,7 @@ QtObject:
                         aX: int, aY: int, bX: int, bY: int,
                         historyArchiveSupportEnabled: bool,
                         pinMessageAllMembersEnabled: bool,
-                        fromTimestamp: int, encrypted: bool) {.slot.} =
+                        fromTimestamp: int) {.slot.} =
     let selectedItems = self.discordChannelsModel.getSelectedItems()
     var filesToImport: seq[string] = @[]
 
@@ -470,7 +469,7 @@ QtObject:
     self.setDiscordImportInProgress(true)
     self.delegate.requestImportDiscordCommunity(name, description, introMessage, outroMessage, access, color, tags,
                                   imagePath, aX, aY, bX, bY, historyArchiveSupportEnabled, pinMessageAllMembersEnabled,
-                                  filesToImport, fromTimestamp, encrypted)
+                                  filesToImport, fromTimestamp)
 
   proc deleteCommunityCategory*(self: View, communityId: string, categoryId: string): string {.slot.} =
     self.delegate.deleteCommunityCategory(communityId, categoryId)

--- a/src/app_service/service/community/service.nim
+++ b/src/app_service/service/community/service.nim
@@ -907,8 +907,7 @@ QtObject:
       historyArchiveSupportEnabled: bool,
       pinMessageAllMembersEnabled: bool,
       filesToImport: seq[string],
-      fromTimestamp: int,
-      encrypted: bool) =
+      fromTimestamp: int) =
     try:
       var image = singletonInstance.utils.formatImagePath(imageUrl)
       var tagsString = tags
@@ -928,8 +927,7 @@ QtObject:
         historyArchiveSupportEnabled,
         pinMessageAllMembersEnabled,
         filesToImport,
-        fromTimestamp,
-        encrypted)
+        fromTimestamp)
 
       if response.error != nil:
         let error = Json.decode($response.error, RpcError)
@@ -951,8 +949,7 @@ QtObject:
       aX: int, aY: int, bX: int, bY: int,
       historyArchiveSupportEnabled: bool,
       pinMessageAllMembersEnabled: bool,
-      bannerJsonStr: string,
-      encrypted: bool) =
+      bannerJsonStr: string) =
     try:
       var bannerJson = bannerJsonStr.parseJson
       bannerJson{"imagePath"} = newJString(singletonInstance.utils.formatImagePath(bannerJson["imagePath"].getStr))
@@ -972,8 +969,7 @@ QtObject:
         aX, aY, bX, bY,
         historyArchiveSupportEnabled,
         pinMessageAllMembersEnabled,
-        $bannerJson,
-        encrypted)
+        $bannerJson)
 
       if response.error != nil:
         let error = Json.decode($response.error, RpcError)

--- a/src/backend/communities.nim
+++ b/src/backend/communities.nim
@@ -70,8 +70,7 @@ proc createCommunity*(
     aX: int, aY: int, bX: int, bY: int,
     historyArchiveSupportEnabled: bool,
     pinMessageAllMembersEnabled: bool,
-    bannerJsonStr: string,
-    encrypted: bool
+    bannerJsonStr: string
     ): RpcResponse[JsonNode] {.raises: [Exception].} =
   let bannerImage = newCroppedImage(bannerJsonStr)
   result = callPrivateRPC("createCommunity".prefix, %*[{
@@ -91,8 +90,7 @@ proc createCommunity*(
       "imageBy": bY,
       "historyArchiveSupportEnabled": historyArchiveSupportEnabled,
       "pinMessageAllMembersEnabled": pinMessageAllMembersEnabled,
-      "banner": bannerImage,
-      "encrypted": encrypted
+      "banner": bannerImage
     }])
 
 proc editCommunity*(
@@ -131,7 +129,7 @@ proc editCommunity*(
     "imageBy": bY,
     "banner": bannerImage,
     "historyArchiveSupportEnabled": historyArchiveSupportEnabled,
-    "pinMessageAllMembersEnabled": pinMessageAllMembersEnabled
+    "pinMessageAllMembersEnabled": pinMessageAllMembersEnabled,
   }])
 
 proc requestImportDiscordCommunity*(
@@ -148,7 +146,6 @@ proc requestImportDiscordCommunity*(
     pinMessageAllMembersEnabled: bool,
     filesToImport: seq[string],
     fromTimestamp: int,
-    encrypted: bool,
     ): RpcResponse[JsonNode] {.raises: [Exception].} =
   result = callPrivateRPC("requestImportDiscordCommunity".prefix, %*[{
       # TODO this will need to be renamed membership (small m)
@@ -168,8 +165,7 @@ proc requestImportDiscordCommunity*(
       "historyArchiveSupportEnabled": historyArchiveSupportEnabled,
       "pinMessageAllMembersEnabled": pinMessageAllMembersEnabled,
       "from": fromTimestamp,
-      "filesToImport": filesToImport,
-      "encrypted": encrypted,
+      "filesToImport": filesToImport
     }])
 
 proc createCommunityTokenPermission*(communityId: string, permissionType: int, tokenCriteria: string, isPrivate: bool): RpcResponse[JsonNode] {.raises: [Exception].} =

--- a/ui/app/AppLayouts/Chat/controls/community/CommunityOptions.qml
+++ b/ui/app/AppLayouts/Chat/controls/community/CommunityOptions.qml
@@ -12,9 +12,6 @@ Column {
     property alias archiveSupportEnabled: archiveSupportToggle.checked
     property alias requestToJoinEnabled: requestToJoinToggle.checked
     property alias pinMessagesEnabled: pinMessagesToggle.checked
-    property alias encrypted: encryptedToggle.checked
-
-    property bool encryptReadOnly: false
 
     spacing: 0
 
@@ -74,26 +71,6 @@ Column {
 
         StatusCheckBox {
             id: pinMessagesToggle
-        }
-    }
-
-    RowLayout {
-        width: visible ? parent.width : 0
-        height: visible ? d.optionHeight : 0
-        visible: requestToJoinToggle.checked
-
-        StatusBaseText {
-            Layout.fillWidth: true
-            text: qsTr("Encrypted")
-            TapHandler {
-                enabled: !encryptReadOnly
-                onTapped: encryptedToggle.toggle()
-            }
-        }
-
-        StatusCheckBox {
-            id: encryptedToggle
-            enabled: !encryptReadOnly
         }
     }
 }

--- a/ui/app/AppLayouts/Chat/panels/communities/CommunityOverviewSettingsPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/CommunityOverviewSettingsPanel.qml
@@ -29,7 +29,6 @@ StackLayout {
     property bool archiveSupportEnabled
     property bool requestToJoinEnabled
     property bool pinMessagesEnabled
-    property bool encrypted
     property string previousPageName: (currentIndex === 1) ? qsTr("Overview") : ""
 
     property bool editable: false
@@ -188,8 +187,6 @@ StackLayout {
                 archiveSupportEnabled: root.archiveSupportEnabled
                 requestToJoinEnabled: root.requestToJoinEnabled
                 pinMessagesEnabled: root.pinMessagesEnabled
-                encrypted: root.encrypted
-                encryptReadOnly: true
             }
 
             bottomReservedSpace: editCommunityPage.settingsDirtyToastMessageImplicitSize

--- a/ui/app/AppLayouts/Chat/views/CommunitySettingsView.qml
+++ b/ui/app/AppLayouts/Chat/views/CommunitySettingsView.qml
@@ -197,7 +197,6 @@ StatusSectionLayout {
                 tags: root.rootStore.communityTags
                 selectedTags: root.filteredSelectedTags
                 archiveSupportEnabled: root.community.historyArchiveSupportEnabled
-                encrypted: root.community.encrypted
                 requestToJoinEnabled: root.community.access === Constants.communityChatOnRequestAccess
                 pinMessagesEnabled: root.community.pinMessageAllMembersEnabled
                 editable: root.community.amISectionAdmin

--- a/ui/app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml
+++ b/ui/app/AppLayouts/CommunitiesPortal/popups/CreateCommunityPopup.qml
@@ -509,7 +509,6 @@ StatusStackModal {
                     historyArchiveSupportEnabled: options.archiveSupportEnabled,
                     checkedMembership: options.requestToJoinEnabled ? Constants.communityChatOnRequestAccess : Constants.communityChatPublicAccess,
                     pinMessagesAllowedForMembers: options.pinMessagesEnabled,
-                    encrypted: options.requestToJoinEnabled && options.encrypted // Only communities with memberships can be encrypted
                 },
                 bannerJsonStr: JSON.stringify({imagePath: String(bannerPicker.source).replace("file://", ""), cropRect: bannerPicker.cropRect})
             }

--- a/ui/app/AppLayouts/CommunitiesPortal/stores/CommunitiesStore.qml
+++ b/ui/app/AppLayouts/CommunitiesPortal/stores/CommunitiesStore.qml
@@ -161,14 +161,13 @@ QtObject {
                                     historyArchiveSupportEnabled: false,
                                     checkedMembership: false,
                                     pinMessagesAllowedForMembers: false,
-                                    encrypted: false
                                 }
                              }, from = 0) {
         return communitiesModuleInst.requestImportDiscordCommunity(
                     args.name, args.description, args.introMessage, args.outroMessage, args.options.checkedMembership,
                     args.color, args.tags,
                     args.image.src, args.image.AX, args.image.AY, args.image.BX, args.image.BY,
-                    args.options.historyArchiveSupportEnabled, args.options.pinMessagesAllowedForMembers, from, args.options.encrypted);
+                    args.options.historyArchiveSupportEnabled, args.options.pinMessagesAllowedForMembers, from);
     }
 
 


### PR DESCRIPTION
### What does the PR do

Create/edit encrypted community option removed
The community will be encrypted automatically if the community will be closed and decrypted if it became open
Fixed bug, when edition community description changed encryption

Closes: #9942

Status-go PR: https://github.com/status-im/status-go/pull/3455

### Affected areas

Community encryption

Status-go PR https://github.com/status-im/status-go/pull/3455