### PR TITLE
fix(newChat): fix sending messages in new ad hoc chat with new store

### DIFF
--- a/ui/app/AppLayouts/Chat/ChatLayout.qml
+++ b/ui/app/AppLayouts/Chat/ChatLayout.qml
@@ -16,6 +16,7 @@ StackLayout {
     id: root
 
     property RootStore rootStore
+    property var createChatPropertiesStore
     readonly property var contactsStore: rootStore.contactsStore
     readonly property var permissionsStore: rootStore.permissionsStore
 
@@ -108,6 +109,7 @@ StackLayout {
             stickersPopup: root.stickersPopup
             contactsStore: root.contactsStore
             rootStore: root.rootStore
+            createChatPropertiesStore: root.createChatPropertiesStore
             sectionItemModel: root.sectionItemModel
 
             onCommunityInfoButtonClicked: root.currentIndex = 1

--- a/ui/app/AppLayouts/Chat/stores/CreateChatPropertiesStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/CreateChatPropertiesStore.qml
@@ -1,0 +1,22 @@
+import QtQuick 2.15
+
+QtObject {
+    id: root
+
+    property string createChatInitMessage: ""
+    property var createChatFileUrls: []
+    property bool createChatStartSendTransactionProcess: false
+    property bool createChatStartReceiveTransactionProcess: false
+    property string createChatStickerHashId: ""
+    property string createChatStickerPackId: ""
+    property string createChatStickerUrl: ""
+
+    function resetProperties() {
+        root.createChatInitMessage = "";
+        root.createChatFileUrls = [];
+        root.createChatStartSendTransactionProcess = false;
+        root.createChatStartReceiveTransactionProcess = false;
+        root.createChatStickerHashId = "";
+        root.createChatStickerPackId = "";
+    }
+}

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -19,13 +19,6 @@ QtObject {
     }
 
     property bool openCreateChat: false
-    property string createChatInitMessage: ""
-    property var createChatFileUrls: []
-    property bool createChatStartSendTransactionProcess: false
-    property bool createChatStartReceiveTransactionProcess: false
-    property string createChatStickerHashId: ""
-    property string createChatStickerPackId: ""
-    property string createChatStickerUrl: ""
 
     property var contactsModel: root.contactsStore.myContactsModel
 

--- a/ui/app/AppLayouts/Chat/stores/qmldir
+++ b/ui/app/AppLayouts/Chat/stores/qmldir
@@ -1,4 +1,5 @@
 CommunitiesStore 1.0 CommunitiesStore.qml
+CreateChatPropertiesStore 1.0 CreateChatPropertiesStore.qml
 PermissionsStore 1.0 PermissionsStore.qml
 RootStore 1.0 RootStore.qml
 StickerData 1.0 StickerData.qml

--- a/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
@@ -27,6 +27,7 @@ Item {
     property var parentModule
 
     property var rootStore
+    property var createChatPropertiesStore
     property var contactsStore
     property var emojiPopup
     property var stickersPopup
@@ -63,43 +64,37 @@ Item {
 
     // This function is called once `1:1` or `group` chat is created.
     function checkForCreateChatOptions(chatId) {
-        if(root.rootStore.createChatStartSendTransactionProcess) {
+        if(root.createChatPropertiesStore.createChatStartSendTransactionProcess) {
             if (root.contactDetails.ensVerified) {
                 Global.openPopup(cmpSendTransactionWithEns);
             } else {
                 Global.openPopup(cmpSendTransactionNoEns);
             }
         }
-        else if (root.rootStore.createChatStartSendTransactionProcess) {
+        else if (root.createChatPropertiesStore.createChatStartSendTransactionProcess) {
             Global.openPopup(cmpReceiveTransaction);
         }
-        else if (root.rootStore.createChatStickerHashId !== "" &&
-                 root.rootStore.createChatStickerPackId !== "" &&
-                 root.rootStore.createChatStickerUrl !== "") {
+        else if (root.createChatPropertiesStore.createChatStickerHashId !== "" &&
+                 root.createChatPropertiesStore.createChatStickerPackId !== "" &&
+                 root.createChatPropertiesStore.createChatStickerUrl !== "") {
             root.rootStore.sendSticker(chatId,
-                                       root.rootStore.createChatStickerHashId,
+                                       root.createChatPropertiesStore.createChatStickerHashId,
                                        "",
-                                       root.rootStore.createChatStickerPackId,
-                                       root.rootStore.createChatStickerUrl);
+                                       root.createChatPropertiesStore.createChatStickerPackId,
+                                       root.createChatPropertiesStore.createChatStickerUrl);
         }
-        else if (root.rootStore.createChatInitMessage !== "" ||
-                 root.rootStore.createChatFileUrls.length > 0) {
+        else if (root.createChatPropertiesStore.createChatInitMessage !== "" ||
+                 root.createChatPropertiesStore.createChatFileUrls.length > 0) {
 
             root.rootStore.sendMessage(chatId,
                                        Qt.Key_Enter,
-                                       root.rootStore.createChatInitMessage,
+                                       root.createChatPropertiesStore.createChatInitMessage,
                                        "",
-                                       root.rootStore.createChatFileUrls
+                                       root.createChatPropertiesStore.createChatFileUrls
                                        );
         }
 
-        // Clear.
-        root.rootStore.createChatInitMessage = "";
-        root.rootStore.createChatFileUrls = [];
-        root.rootStore.createChatStartSendTransactionProcess = false;
-        root.rootStore.createChatStartReceiveTransactionProcess = false;
-        root.rootStore.createChatStickerHashId = "";
-        root.rootStore.createChatStickerPackId = "";
+        root.createChatPropertiesStore.resetProperties()
     }
 
     function updateContactDetails() {

--- a/ui/app/AppLayouts/Chat/views/ChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatView.qml
@@ -28,6 +28,7 @@ StatusSectionLayout {
     property bool hasAddedContacts: root.contactsStore.myContactsModel.count > 0
 
     property RootStore rootStore
+    property var createChatPropertiesStore
     property var sectionItemModel
 
     property var emojiPopup
@@ -80,6 +81,7 @@ StatusSectionLayout {
         anchors.fill: parent
         parentModule: root.rootStore.chatCommunitySectionModule
         rootStore: root.rootStore
+        createChatPropertiesStore: root.createChatPropertiesStore
         contactsStore: root.contactsStore
         stickersLoaded: root.stickersLoaded
         emojiPopup: root.emojiPopup

--- a/ui/app/AppLayouts/Chat/views/CreateChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/CreateChatView.qml
@@ -17,6 +17,7 @@ Page {
     id: root
 
     property var rootStore
+    property var createChatPropertiesStore
     property var emojiPopup: null
     property var stickersPopup: null
 
@@ -24,8 +25,8 @@ Page {
         id: d
 
         function createChat() {
-            root.rootStore.createChatInitMessage = chatInput.textInput.text
-            root.rootStore.createChatFileUrls = chatInput.fileUrlsAndSources
+            root.createChatPropertiesStore.createChatInitMessage = chatInput.textInput.text
+            root.createChatPropertiesStore.createChatFileUrls = chatInput.fileUrlsAndSources
             membersSelector.createChat()
 
             membersSelector.cleanup()
@@ -161,17 +162,17 @@ Page {
                     usersModel: membersSelector.model
                 })
                 onSendTransactionCommandButtonClicked: {
-                    root.rootStore.createChatStartSendTransactionProcess = true;
+                    root.createChatPropertiesStore.createChatStartSendTransactionProcess = true;
                     membersSelector.createChat();
                 }
                 onReceiveTransactionCommandButtonClicked: {
-                    root.rootStore.createChatStartReceiveTransactionProcess = true;
+                    root.createChatPropertiesStore.createChatStartReceiveTransactionProcess = true;
                     membersSelector.createChat();
                 }
                 onStickerSelected: {
-                    root.rootStore.createChatStickerHashId = hashId;
-                    root.rootStore.createChatStickerPackId = packId;
-                    root.rootStore.createChatStickerUrl = url;
+                    root.createChatPropertiesStore.createChatStickerHashId = hashId;
+                    root.createChatPropertiesStore.createChatStickerPackId = packId;
+                    root.createChatPropertiesStore.createChatStickerUrl = url;
                     membersSelector.createChat();
                 }
 

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -55,6 +55,7 @@ Item {
         openCreateChat: createChatView.opened
         networkConnectionStore: appMain.networkConnectionStore
     }
+    property var createChatPropertiesStore: ChatStores.CreateChatPropertiesStore {}
     property ActivityCenterStore activityCenterStore: ActivityCenterStore {}
     property NetworkConnectionStore networkConnectionStore: NetworkConnectionStore {}
     property CommunityTokensStore communityTokensStore: CommunityTokensStore {}
@@ -926,6 +927,7 @@ Item {
                                     chatCommunitySectionModule: appMain.rootStore.mainModuleInst.getChatSectionModule()
                                     networkConnectionStore: appMain.networkConnectionStore
                                 }
+                                createChatPropertiesStore: appMain.createChatPropertiesStore
                                 emojiPopup: statusEmojiPopup.item
                                 stickersPopup: statusStickersPopupLoader.item
 
@@ -1095,6 +1097,7 @@ Item {
                             openCreateChat: createChatView.opened
                             chatCommunitySectionModule: appMain.rootStore.mainModuleInst.getChatSectionModule()
                         }
+                        createChatPropertiesStore: appMain.createChatPropertiesStore
                         emojiPopup: statusEmojiPopup.item
                         stickersPopup: statusStickersPopupLoader.item
                     }


### PR DESCRIPTION
Fixes #10523

The problem was that the CreateChatView now uses an isolated Chat RootStore, since we can't be sure if the personal chat section will be loaded yet.

To fix that, I created a new store that is only for storing the properties needed for that new chat. That way we are sure that it is created and shared to necessary components.
