### PR TITLE
fix(CommunitySettingsView): Fix community settings after removing old legacy popup ref

### DIFF
--- a/ui/app/AppLayouts/Chat/views/CommunitySettingsView.qml
+++ b/ui/app/AppLayouts/Chat/views/CommunitySettingsView.qml
@@ -83,7 +83,7 @@ StatusSectionLayout {
         ColumnLayout {
             anchors {
                 top: parent.top
-                bottom: footer.top
+                bottom: backToCommunityButton.top
                 bottomMargin: 12
                 topMargin: Style.current.smallPadding
                 horizontalCenter: parent.horizontalCenter
@@ -133,6 +133,7 @@ StatusSectionLayout {
         }
 
         StatusBaseText {
+            id: backToCommunityButton
             objectName: "communitySettingsBackToCommunityButton"
             anchors {
                 bottom: parent.bottom


### PR DESCRIPTION
I missed an `id` when old legacy popup was removed [there](https://github.com/status-im/status-desktop/pull/9964)

### What does the PR do

Fix community settings view

### Affected areas

CommunitySsettingsView

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)
![Снимок экрана 2023-05-05 в 14 17 21](https://user-images.githubusercontent.com/82511785/236444045-70e277f3-e04d-47b0-8a86-ae62b4cce616.png)

