### PR TITLE
fix(@desktop/activity): Fixed section glitch

### DIFF
--- a/ui/imports/shared/views/HistoryView.qml
+++ b/ui/imports/shared/views/HistoryView.qml
@@ -138,6 +138,7 @@ ColumnLayout {
         ScrollBar.vertical: StatusScrollBar {}
 
         section.property: "date"
+        topMargin: -20 // Top margin for first section. Section cannot have different sizes
         section.delegate: ColumnLayout {
             id: sectionDelegate
 
@@ -145,21 +146,23 @@ ColumnLayout {
 
             width: ListView.view.width
             // display always first section. Other sections when more items are being fetched must not be visible
-            visible: isFirstSection || section.length > 1
+            // 1 because we don't use empty for loading state
+            // Additionaly height must be defined so all sections use same height to to glitch sections when updating model
+            height: isFirstSection || section.length > 1 ? 58 : 0
+            visible: height > 0 // display always first section. Other sections when more items are being fetched must not be visible
             spacing: 0
 
             required property string section
 
             Separator {
                 Layout.fillWidth: true
-                Layout.topMargin: sectionDelegate.isFirstSection ? 0 : 20
+                Layout.topMargin: 20
                 implicitHeight: 1
             }
 
             StatusTextWithLoadingState {
                 id: sectionText
-
-                Layout.topMargin: 12
+                Layout.alignment: Qt.AlignBottom
                 leftPadding: 16
                 bottomPadding: 8
                 text: loading ? "dummy" : parent.section // dummy text because loading component height depends on text height, and not visible with height == 0


### PR DESCRIPTION
fixes #10472

### What does the PR do

I found out glitch visible after my implementation of new activity section delegate.

How to reproduce:
* Have wallet with activity across multiple days (there must be few sections)
* Go to different wallet activity list (must be long enough to scroll whole screen), scroll down and scroll up
* Now at the top 2 sections can be visible
![image](https://user-images.githubusercontent.com/11396062/236828927-3d1b137a-9913-4f1a-b302-35da0acd682a.png)



### Affected areas

Activity list

### Image after fix:

![image](https://user-images.githubusercontent.com/11396062/236828129-4bea67d8-4b91-43fd-9c7c-9bb5edfed801.png)


