### PR TITLE
feat(MintTokens): Artwork image field missing cropping tool

### DIFF
--- a/storybook/PagesModel.qml
+++ b/storybook/PagesModel.qml
@@ -270,6 +270,10 @@ ListModel {
         section: "Components"
     }
     ListElement {
+        title: "StatusImageCropPanel"
+        section: "Components"
+    }
+    ListElement {
          title: "BrowserSettings"
          section: "Settings"
     }

--- a/storybook/pages/CommunityMintTokensSettingsPanelPage.qml
+++ b/storybook/pages/CommunityMintTokensSettingsPanelPage.qml
@@ -29,7 +29,6 @@ SplitView {
             anchors.fill: parent
             anchors.topMargin: 50
             tokensModel: editorModelChecked.checked ? emptyModel : MintedCollectiblesModel.mintedCollectibleModel
-            holdersModel: TokenHoldersModel {}
             layer1Networks: NetworksModel.layer1Networks
             layer2Networks: NetworksModel.layer2Networks
             testNetworks: NetworksModel.testNetworks

--- a/storybook/pages/StatusImageCropPanelPage.qml
+++ b/storybook/pages/StatusImageCropPanelPage.qml
@@ -1,0 +1,298 @@
+import QtQuick 2.14
+import QtQuick.Controls 2.14
+import QtQuick.Layouts 1.14
+import QtQuick.Dialogs 1.3
+import QtQml 2.14
+import QtGraphicalEffects 1.14
+
+import Storybook 1.0
+import Models 1.0
+
+import StatusQ.Components 0.1
+import StatusQ.Controls 0.1
+import StatusQ.Popups 0.1
+
+SplitView {
+    id: root
+
+    property var testControls: [ctrl1, ctrl2, ctrl3]
+
+    property bool globalStylePreferRound: true
+    property var testImageList: [ModelsData.banners.dragonereum,
+        ModelsData.banners.superRare,
+        ModelsData.banners.socks]
+    property int testImageIndex: 0
+    property int testSpacing: 0
+    property int testFrameMargins: 10
+
+    implicitWidth: mainLayout.implicitWidth
+    implicitHeight: mainLayout.implicitHeight
+
+    Logs { id: logs }
+
+    SplitView {
+        orientation: Qt.Horizontal
+        SplitView.fillWidth: true
+        SplitView.fillHeight: true
+
+
+        RowLayout {
+            id: mainLayout
+
+            anchors.fill: parent
+            spacing: root.testSpacing
+
+            ColumnLayout {
+                spacing: root.testSpacing
+
+                Layout.margins: root.testSpacing
+                Layout.fillWidth: true
+
+                Text {
+                    text: `AR: ${ctrl1.aspectRatio.toFixed(2)}`
+                }
+
+                StatusImageCropPanel {
+                    id: ctrl1
+
+                    Layout.fillWidth: true
+                    Layout.fillHeight: true
+
+                    source: root.testImageList[root.testImageIndex]
+                    windowStyle: globalStylePreferRound ? StatusImageCrop.WindowStyle.Rounded : StatusImageCrop.WindowStyle.Rectangular
+                    margins: root.testFrameMargins
+                }
+
+                Text {
+                    text: `AR: ${ctrl2.aspectRatio.toFixed(2)}`
+                }
+
+                StatusImageCropPanel {
+                    id: ctrl2
+
+                    Layout.fillWidth: true
+                    Layout.fillHeight: true
+
+                    source: root.testImageList[root.testImageIndex]
+                    windowStyle: globalStylePreferRound ? StatusImageCrop.WindowStyle.Rectangular : StatusImageCrop.WindowStyle.Rounded
+                    aspectRatio: 16/9
+                    enableCheckers: true
+                    margins: root.testFrameMargins + 2
+                }
+            }
+
+            ColumnLayout {
+                Layout.margins: root.testSpacing
+                Layout.fillWidth: true
+
+                Text {
+                    text: `AR: ${ctrl3.aspectRatio.toFixed(2)}`
+                }
+
+                StatusImageCropPanel {
+                    id: ctrl3
+
+                    Layout.fillWidth: true
+                    Layout.fillHeight: true
+
+                    source: root.testImageList[root.testImageIndex]
+                    windowStyle: globalStylePreferRound ? StatusImageCrop.WindowStyle.Rounded : StatusImageCrop.WindowStyle.Rectangular
+                    aspectRatio: 0.8
+
+                    margins: root.testFrameMargins + 5.3
+                }
+            }
+        }
+
+        Loader {
+            id: workflowLoader
+
+            sourceComponent: workflowComponent
+            active: false
+            onStatusChanged: {
+                if(status === Loader.Ready) {
+                    item.imageFileDialogTitle = qsTr("Test Title")
+                    item.title = "Test popup"
+                    item.acceptButtonText = "Load Custom Image"
+                    item.chooseImageToCrop()
+                }
+            }
+
+            Connections {
+                target: workflowLoader.item
+                function onImageCropped(image, cropRect) {
+                    ctrl1.source = image
+                    ctrl2.source = image
+                    ctrl3.source = image
+                }
+                function onCanceled() {
+                    workflowLoader.active = false
+                }
+            }
+        }
+
+        Component {
+            id: workflowComponent
+
+            Item {
+                id: workflowItem
+
+                property alias aspectRatio: imageCropper.aspectRatio
+                property alias windowStyle: imageCropper.windowStyle
+                property string imageFileDialogTitle: ""
+                property string title: ""
+                property string acceptButtonText: ""
+                property bool roundedImage: true
+
+                signal imageCropped(var image, var cropRect)
+                signal canceled()
+
+                function chooseImageToCrop() {
+                    fileDialog.open()
+                }
+
+                FileDialog {
+                    id: fileDialog
+
+                    title: workflowItem.imageFileDialogTitle
+                    folder: workflowItem.userSelectedImage ? imageCropper.source.substr(0, imageCropper.source.lastIndexOf("/")) : shortcuts.pictures
+                    nameFilters: [qsTr("Supported image formats (%1)").arg("*.jpg *.jpeg *.jfif *.webp *.png *.heif")]
+                    onAccepted: {
+                        if (fileDialog.fileUrls.length > 0) {
+                            imageCropper.source = fileDialog.fileUrls[0]
+                            imageCropperModal.open()
+                        }
+                    }
+                    onRejected: workflowItem.canceled()
+                } // FileDialog
+
+                StatusModal {
+                    id: imageCropperModal
+
+                    header.title: workflowItem.title
+
+                    anchors.centerIn: Overlay.overlay
+
+                    width: workflowItem.roundedImage ? 480 : 580
+
+                    onClosed: workflowItem.canceled()
+
+                    StatusImageCropPanel {
+                        id: imageCropper
+
+                        implicitHeight: workflowItem.roundedImage ? 350 : 370
+
+                        anchors {
+                            fill: parent
+                            leftMargin: 10 * 2
+                            rightMargin: 10 * 2
+                            topMargin: 15
+                            bottomMargin: 15
+                        }
+
+                        margins: workflowItem.roundedImage ? 10 : 20
+                        windowStyle: workflowItem.roundedImage ? StatusImageCrop.WindowStyle.Rounded : StatusImageCrop.WindowStyle.Rectangular
+                        enableCheckers: true
+                    }
+
+                    rightButtons: [
+                        StatusButton {
+                            text: workflowItem.acceptButtonText
+
+                            enabled: imageCropper.sourceSize.width > 0 && imageCropper.sourceSize.height > 0
+
+                            onClicked: {
+                                workflowItem.imageCropped(imageCropper.source, imageCropper.cropRect)
+                                imageCropperModal.close()
+                            }
+                        }
+                    ]
+                } // StatusModal
+            } // Item
+        }
+
+        Shortcut {
+            sequence: StandardKey.ZoomIn
+            onActivated: {
+                for(let i in testControls) {
+                    const c = testControls[i]
+                    c.setCropRect(ctrl1.inflateRectBy(c.cropRect, -0.05))
+                }
+            }
+        }
+
+        Shortcut {
+            sequence: StandardKey.ZoomOut
+            onActivated: {
+                for(let i in testControls) {
+                    const c = testControls[i]
+                    c.setCropRect(ctrl1.inflateRectBy(c.cropRect, 0.05))
+                }
+            }
+        }
+
+        Shortcut {
+            sequences: ["Ctrl+W"]
+            onActivated: globalStylePreferRound = !globalStylePreferRound
+        }
+
+        LogsAndControlsPanel {
+            id: logsAndControlsPanel
+
+            SplitView.minimumHeight: 100
+            SplitView.preferredHeight: 200
+
+            logsView.logText: logs.logText
+        }
+    }
+
+    Control {
+        SplitView.minimumWidth: 300
+        SplitView.preferredWidth: 300
+
+        font.pixelSize: 13
+
+        ColumnLayout {
+            anchors.centerIn: parent
+            spacing: 16
+
+            StatusButton {
+                Layout.alignment: Qt.AlignHCenter
+                text: qsTr("Cycle image")
+                onClicked: {
+                    let newIndex = root.testImageIndex
+                    newIndex++
+                    if(newIndex >= root.testImageList.length)
+                        newIndex = 0
+                    root.testImageIndex = newIndex
+                }
+            }
+
+            StatusButton {
+                Layout.alignment: Qt.AlignHCenter
+                text: qsTr("Cycle spacing")
+                onClicked: {
+                    root.testSpacing += (root.testSpacing/2) + 1
+                    if(root.testSpacing > 35)
+                        root.testSpacing = 0
+                }
+            }
+
+            StatusButton {
+                Layout.alignment: Qt.AlignHCenter
+                text: qsTr("Cycle frame margins")
+                onClicked: {
+                    root.testFrameMargins += (root.testFrameMargins/2) + 1
+                    if(root.testFrameMargins > 50)
+                        root.testFrameMargins = 0
+                }
+            }
+
+            StatusButton {
+                Layout.alignment: Qt.AlignHCenter
+                text: qsTr("Load external image")
+                onClicked: workflowLoader.active = true
+            }
+        }
+    }
+}

--- a/ui/app/AppLayouts/Chat/controls/community/CommunityBannerPicker.qml
+++ b/ui/app/AppLayouts/Chat/controls/community/CommunityBannerPicker.qml
@@ -57,7 +57,7 @@ Item {
                 anchors.centerIn: parent
 
                 visible: !editor.userSelectedImage && !root.imageData
-                showARHint: true
+                showAdditionalInfo: true
             }
         }
     }

--- a/ui/app/AppLayouts/Chat/panels/communities/CommunityMintTokensSettingsPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/CommunityMintTokensSettingsPanel.qml
@@ -47,7 +47,8 @@ SettingsPageLayout {
                            bool selfDestruct,
                            int chainId,
                            string accountName,
-                           string accountAddress)
+                           string accountAddress,
+                           var artworkCropRect)
 
     signal signMintTransactionOpened(int chainId, string accountAddress)
 
@@ -226,7 +227,8 @@ SettingsPageLayout {
                                      selfDestruct,
                                      chainId,
                                      accountName,
-                                     d.accountAddress)
+                                     d.accountAddress,
+                                     artworkCropRect)
 
                 stackManager.clear(d.initialViewState, StackView.Immediate)
             }

--- a/ui/app/AppLayouts/Chat/panels/communities/CommunityMintTokensSettingsPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/CommunityMintTokensSettingsPanel.qml
@@ -191,6 +191,7 @@ SettingsPageLayout {
                                       preview: true,
                                       name,
                                       artworkSource,
+                                      artworkCropRect,
                                       symbol,
                                       description,
                                       supplyAmount,

--- a/ui/app/AppLayouts/Chat/views/CommunitySettingsView.qml
+++ b/ui/app/AppLayouts/Chat/views/CommunitySettingsView.qml
@@ -299,7 +299,8 @@ StatusSectionLayout {
                                                            selfDestruct,
                                                            chainId,
                                                            artworkSource,
-                                                           accountName)
+                                                           accountName,
+                                                           artworkCropRect)
                 }
                 onSignSelfDestructTransactionOpened: communityTokensStore.computeSelfDestructFee(chainId)
                 onRemoteSelfDestructCollectibles: {

--- a/ui/app/AppLayouts/Chat/views/communities/CommunityCollectibleView.qml
+++ b/ui/app/AppLayouts/Chat/views/communities/CommunityCollectibleView.qml
@@ -1,5 +1,6 @@
-import QtQuick 2.14
+import QtQuick 2.15
 import QtQuick.Layouts 1.14
+import QtGraphicalEffects 1.0
 
 import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
@@ -19,6 +20,7 @@ StatusScrollView {
 
     // Collectible object properties:
     property alias artworkSource: image.source
+    property rect artworkCropRect
     property alias symbol: symbolBox.value
     property alias description: descriptionItem.text
     property alias chainName: chainText.text
@@ -78,14 +80,24 @@ StatusScrollView {
         Rectangle {
             Layout.preferredHeight: d.imageSelectorRectSize
             Layout.preferredWidth: Layout.preferredHeight
+
             radius: 8
-            color: Theme.palette.baseColor2
+            color:Theme.palette.baseColor2
+            clip: true
 
             Image {
                 id: image
 
                 anchors.fill: parent
                 fillMode: Image.PreserveAspectFit
+                visible: false
+                sourceClipRect: root.artworkCropRect ? root.artworkCropRect : undefined
+            }
+
+            OpacityMask {
+                anchors.fill: image
+                source: image
+                maskSource: parent
             }
         }
 

--- a/ui/app/AppLayouts/Chat/views/communities/CommunityNewCollectibleView.qml
+++ b/ui/app/AppLayouts/Chat/views/communities/CommunityNewCollectibleView.qml
@@ -87,6 +87,7 @@ StatusScrollView {
             title: qsTr("Collectible artwork")
             acceptButtonText: qsTr("Upload collectible artwork")
             roundedImage: false
+            isDraggable: true
 
             NoImageUploadedPanel {
                 width: parent.width

--- a/ui/app/AppLayouts/Chat/views/communities/CommunityNewCollectibleView.qml
+++ b/ui/app/AppLayouts/Chat/views/communities/CommunityNewCollectibleView.qml
@@ -10,8 +10,9 @@ import StatusQ.Core.Utils 0.1
 
 import utils 1.0
 
-import "../../../Wallet/controls"
+import AppLayouts.Wallet.controls 1.0
 import shared.panels 1.0
+import shared.popups 1.0
 
 StatusScrollView {
     id: root
@@ -26,7 +27,8 @@ StatusScrollView {
     readonly property alias notTransferable: transferableChecker.checked
     readonly property alias selfDestruct: selfDestructChecker.checked
     readonly property int supplyAmount: supplyInput.text ? parseInt(supplyInput.text) : 0
-    property url artworkSource
+    property alias artworkSource: editor.source
+    property alias artworkCropRect: editor.cropRect
     property int chainId
     property string chainName
     property string chainIcon
@@ -57,7 +59,7 @@ StatusScrollView {
                                               && (root.infiniteSupply || (!root.infiniteSupply && root.supplyAmount > 0))
 
 
-        readonly property int imageSelectorRectWidth: 280
+        readonly property int imageSelectorRectWidth: 290
     }
 
     contentWidth: mainLayout.width
@@ -70,16 +72,31 @@ StatusScrollView {
         width: root.viewWidth
         spacing: Style.current.padding
 
-        StatusImageSelector {
-            Layout.preferredHeight: d.imageSelectorRectWidth + headerHeight
-            Layout.preferredWidth: d.imageSelectorRectWidth + buttonsInsideOffset
-            labelText: qsTr("Artwork")
-            uploadText: qsTr("Drag and Drop or Upload Artwork")
-            additionalText: qsTr("Images only")
-            acceptedImageExtensions: Constants.acceptedDragNDropImageExtensions
-            file: root.artworkSource
+        StatusBaseText {
+            elide: Text.ElideRight
+            font.pixelSize: Theme.primaryTextFontSize
+            text: qsTr("Artwork")
+        }
 
-            onFileSelected: root.artworkSource = file
+        EditCroppedImagePanel {
+            id: editor
+
+            Layout.preferredHeight: d.imageSelectorRectWidth
+            Layout.preferredWidth: d.imageSelectorRectWidth
+
+            title: qsTr("Collectible artwork")
+            acceptButtonText: qsTr("Upload collectible artwork")
+            roundedImage: false
+
+            NoImageUploadedPanel {
+                width: parent.width
+                anchors.centerIn: parent
+                visible: !editor.userSelectedImage
+                uploadText: qsTr("Drag and Drop or Upload Artwork")
+                additionalText: qsTr("Images only")
+                showAdditionalInfo: true
+                additionalTextPixelSize: Theme.secondaryTextFontSize
+            }
         }
 
         CustomStatusInput {
@@ -280,11 +297,12 @@ StatusScrollView {
             isChainVisible: false
             multiSelection: false
 
-            onToggleNetwork: (network) => {
-                root.chainId = network.chainId
-                root.chainName = network.chainName
-                root.chainIcon = network.iconUrl
-            }
+            onToggleNetwork: (network) =>
+                             {
+                                 root.chainId = network.chainId
+                                 root.chainName = network.chainName
+                                 root.chainIcon = network.iconUrl
+                             }
         }
     }
 }

--- a/ui/imports/shared/panels/EditCroppedImagePanel.qml
+++ b/ui/imports/shared/panels/EditCroppedImagePanel.qml
@@ -37,6 +37,8 @@ Item {
 
     readonly property alias cropWorkflow : imageCropWorkflow
 
+    property bool isDraggable: false
+
     function chooseImageToCrop() {
         imageCropWorkflow.chooseImageToCrop()
     }
@@ -145,9 +147,18 @@ Item {
             Layout.fillHeight: true
 
             visible: root.state === d.noImageState
-
             radius: roundedImage ? Math.max(width, height)/2 : croppedPreview.radius
             color: Style.current.inputBackground
+            states: [
+                State {
+                    when: dropArea.containsDrag
+                    PropertyChanges {target: imageCropEditor; border.color: Theme.palette.primaryColor1 }
+                },
+                State {
+                    when: !dropArea.containsDrag
+                    PropertyChanges {target: imageCropEditor; border.color: Theme.palette.baseColor2 }
+                }
+            ]
 
             StatusRoundButton {
                 id: addButton
@@ -199,6 +210,18 @@ Item {
             visible: root.state == d.backgroundComponentState
 
             sourceComponent: root.backgroundComponent
+        }
+    }
+
+    DropArea {
+        id: dropArea
+
+        anchors.fill: parent
+        enabled: root.isDraggable
+        onDropped: {
+            if (drop.urls.length > 0) {
+                imageCropWorkflow.cropImage(drop.urls[0])
+            }
         }
     }
 

--- a/ui/imports/shared/panels/NoImageUploadedPanel.qml
+++ b/ui/imports/shared/panels/NoImageUploadedPanel.qml
@@ -1,4 +1,5 @@
 import QtQuick 2.14
+import QtQuick.Controls 2.13
 import QtQuick.Layouts 1.14
 
 import utils 1.0
@@ -10,16 +11,40 @@ import StatusQ.Core.Theme 0.1
 /*!
   /brief Image icon and ulopad text hints for banner and logo
  */
-Item {
+Control {
     id: root
 
-    implicitWidth: mainLayout.implicitWidth
-    implicitHeight: mainLayout.implicitHeight
+    /*!
+       \qmlproperty alias StatusImageSelector::uploadText.
+       This property holds the main image upload text value.
+    */
+    property alias uploadText: uploadText.text
 
-    property bool showARHint: false
+    /*!
+       \qmlproperty alias StatusImageSelector::additionalText.
+       This property holds an additional text value.
+    */
+    property alias additionalText: additionalText.text
 
-    ColumnLayout {
-        id: mainLayout
+    /*!
+       \qmlproperty alias StatusImageSelector::showAdditionalInfo.
+       This property holds if the additional text is shown or not.
+    */
+    property alias showAdditionalInfo: additionalText.visible
+
+    /*!
+       \qmlproperty alias StatusImageSelector::additionalTextPixelSize.
+       This property holds the additional text font pixel size value.
+    */
+    property alias additionalTextPixelSize: additionalText.font.pixelSize
+
+    QtObject {
+        id: d
+
+        readonly property int imageSelectorPadding: 75
+    }
+
+    contentItem: ColumnLayout {
 
         Image {
             id: imageImg
@@ -34,20 +59,26 @@ Item {
 
         StatusBaseText {
             id: uploadText
+
             text: qsTr("Upload")
             Layout.alignment: Qt.AlignVCenter | Qt.AlignHCenter
             Layout.topMargin: 5
-            font.pixelSize: 15
+            Layout.preferredWidth: root.width - 2 * d.imageSelectorPadding
+            font.pixelSize: Theme.primaryTextFontSize
             color: Theme.palette.baseColor1
+            wrapMode: Text.WordWrap
+            lineHeight: 1.2
+            horizontalAlignment: Text.AlignHCenter
         }
 
         StatusBaseText {
-            id: optimalARText
+            id: additionalText
+
             text: qsTr("Wide aspect ratio is optimal")
             Layout.alignment: Qt.AlignVCenter | Qt.AlignHCenter
-            visible: root.showARHint
+            visible: false
             Layout.topMargin: 5
-            font.pixelSize: 15
+            font.pixelSize: Theme.primaryTextFontSize
             color: Theme.palette.baseColor1
         }
     }

--- a/ui/imports/shared/stores/CommunityTokensStore.qml
+++ b/ui/imports/shared/stores/CommunityTokensStore.qml
@@ -19,11 +19,13 @@ QtObject {
 
     // Minting tokens:
     function deployCollectible(communityId, accountAddress, name, symbol, description, supply,
-                             infiniteSupply, transferable, selfDestruct, chainId, artworkSource, accountName)
+                             infiniteSupply, transferable, selfDestruct, chainId, artworkSource, accountName, artworkCropRect)
     {
         // TODO: Backend needs to create new role `accountName` and update this call accordingly
+        // TODO: Backend needs to modify the call to expect an image JSON file with cropped artwork information:
+        const jsonArtworkFile = Utils.getImageAndCropInfoJson(artworkSource, artworkCropRect)
         communityTokensModuleInst.deployCollectible(communityId, accountAddress, name, symbol, description, supply,
-                                                    infiniteSupply, transferable, selfDestruct, chainId, artworkSource)
+                                                    infiniteSupply, transferable, selfDestruct, chainId, artworkSource/*instead: jsonArtworkFile*/)
     }
 
     readonly property Connections connections: Connections {


### PR DESCRIPTION
### What does the PR do

UI part of [#10317](https://github.com/status-im/status-desktop/issues/10317)

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas

- Added `StatusImageCropPanel` into `storybook`.
- Added **cropping tool** into the mint token workflow.
- Extended `EditCroppedImagePanel` to be able to drag/drop images.

**NOTE:** Only UI part done. 
- _UI --> backend_: UI will pass a `json` file with the crop image details and backend will be in charge of cropping it and store it accordingly. 
- _Backend --> UI_: Expected artwork image read from backend: Image already cropped.

### Screenshot of functionality

- Mint token workflow with cropping tool:

https://user-images.githubusercontent.com/97019400/236849439-df3d94ae-3a58-4012-8b8c-9554321f7e84.mov

- Storybook new page (exported from `sandbox`):

https://user-images.githubusercontent.com/97019400/236847109-016f9c04-5d9b-4978-b683-932553e6a6bb.mov


