### PR TITLE
fix(@desktop): Fix decimal input for components using AmountInput

### DIFF
--- a/ui/imports/shared/controls/AmountInput.qml
+++ b/ui/imports/shared/controls/AmountInput.qml
@@ -79,7 +79,8 @@ Input {
         decimals: root.allowDecimals ? 100 : 0
         bottom: 0
         notation: DoubleValidator.StandardNotation
-        locale: root.locale.name
+        locale: root.locale.name.split("_")[0]  // For whatever reason, this doesn't work properly when being
+                                                // passed "language_country". We pass only the language part.
     }
 
     StatusBaseText {


### PR DESCRIPTION
Fixes #10413

### What does the PR do

Components using `AmountInput`(currently only `TokenPanel`) did not allow entering decimal numbers if the system had a locale configured which used comma as decimal separator. This apparently only affected macOS.

It seems to be related to some bug in the base QML `DoubleValidator` component which takes some locale parameters from the system config instead of the one passed through the corresponding property. Anyway, passing only the locale part (`en`) instead of the full locale_country string ( `en_US`) seems to do the trick.

https://user-images.githubusercontent.com/11161531/236901665-e1122b16-00c0-4d3e-afb6-ac3f1c4e2e42.mov

IMO a "definitive" solution to this locale thing would be using the same locale for displaying and for user input, and give the user a setting where they can choose which number format they want to use.

Also, unifying components `Input` and `StatusInput` would be a healthy thing to do.