### PR TITLE
Stop archiving all log files + add setting to change how may to keep

### DIFF
--- a/src/app/modules/main/profile_section/advanced/controller.nim
+++ b/src/app/modules/main/profile_section/advanced/controller.nim
@@ -67,6 +67,16 @@ proc toggleWakuV2Store*(self: Controller) =
 proc isWakuV2StoreEnabled*(self: Controller): bool =
   return self.nodeConfigurationService.isWakuV2StoreEnabled()
 
+proc getLogMaxBackups*(self: Controller): int =
+  return self.nodeConfigurationService.getLogMaxBackups()
+
+proc setMaxLogBackups*(self: Controller, value: int) =
+  if(not self.nodeConfigurationService.setMaxLogBackups(value)):
+    # in the future we may do a call from here to show a popup about this error
+    error "an error occurred, we couldn't set the Max Log Backups"
+    return
+
+  self.delegate.onLogMaxBackupsChanged()
 
 proc getWakuV2LightClientEnabled*(self: Controller): bool =
   return self.nodeConfigurationService.getV2LightMode()

--- a/src/app/modules/main/profile_section/advanced/io_interface.nim
+++ b/src/app/modules/main/profile_section/advanced/io_interface.nim
@@ -101,3 +101,12 @@ method isWakuV2StoreEnabled*(self: AccessInterface): bool {.base.} =
 
 method toggleWakuV2Store*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
+
+method getLogMaxBackups*(self: AccessInterface): int {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method setMaxLogBackups*(self: AccessInterface, value: int) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method onLogMaxBackupsChanged*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/profile_section/advanced/module.nim
+++ b/src/app/modules/main/profile_section/advanced/module.nim
@@ -139,3 +139,12 @@ method toggleWakuV2Store*(self: Module) =
 
 method isWakuV2StoreEnabled*(self: Module): bool =
   self.controller.isWakuV2StoreEnabled()
+
+method getLogMaxBackups*(self: Module): int =
+  self.controller.getLogMaxBackups()
+
+method setMaxLogBackups*(self: Module, value: int) =
+  self.controller.setMaxLogBackups(value)
+
+method onLogMaxBackupsChanged*(self: Module) =
+  self.view.logMaxBackupsChanged()

--- a/src/app/modules/main/profile_section/advanced/view.nim
+++ b/src/app/modules/main/profile_section/advanced/view.nim
@@ -132,3 +132,13 @@ QtObject:
 
   proc toggleWakuV2Store*(self: View) {.slot.} =
     self.delegate.toggleWakuV2Store()
+
+  proc logMaxBackupsChanged*(self: View) {.signal.}
+  proc getLogMaxBackups*(self: View): int {.slot.} =
+    return self.delegate.getLogMaxBackups()
+  QtProperty[int] logMaxBackups:
+    read = getLogMaxBackups
+    notify = logMaxBackupsChanged
+
+  proc setMaxLogBackups*(self: View, value: int) {.slot.} =
+    self.delegate.setMaxLogBackups(value)

--- a/src/app_service/common/network_constants.nim
+++ b/src/app_service/common/network_constants.nim
@@ -318,6 +318,11 @@ var NODE_CONFIG* = %* {
   "IPFSDir": "./ipfs",
   "LogEnabled": true,
   "LogFile": "geth.log",
+  # Set Max number of log files kept to 1
+  # Setting it to 0 creates a problem where all log files are kepts
+  # Docs: https://pkg.go.dev/gopkg.in/natefinch/lumberjack.v2@v2.0.0#readme-cleaning-up-old-log-files
+  "LogMaxBackups": 1,
+  "LogMaxSize": 100, # MB
   "LogLevel": $LogLevel.INFO,
   "MailserversConfig": {
     "Enabled": true

--- a/src/app_service/service/node_configuration/service.nim
+++ b/src/app_service/service/node_configuration/service.nim
@@ -79,16 +79,6 @@ proc init*(self: Service) =
     error "error: ", errDesription
     return
 
-proc fetchNodeConfig(self: Service) =
-  try:
-    let response = status_node_config.getNodeConfig()
-    self.configuration = response.result.toNodeConfigDto()
-  except Exception as e:
-    let errDesription = e.msg
-    error "error: ", errDesription
-    return
-
-
 proc saveConfiguration(self: Service, configuration: NodeConfigDto): bool =
   if(not self.settingsService.saveNodeConfiguration(configuration.toJsonNode())):
     error "error saving node configuration "
@@ -293,4 +283,12 @@ proc setWakuV2StoreEnabled*(self: Service, enabled: bool, storeCapacity: int = 0
   newConfiguration.WakuV2Config.EnableStore = enabled
   newConfiguration.WakuV2Config.StoreCapacity = storeCapacity
   newConfiguration.WakuV2Config.StoreSeconds = storeSeconds
+  return self.saveConfiguration(newConfiguration)
+
+proc getLogMaxBackups*(self: Service): int =
+  return self.configuration.LogMaxBackups
+
+proc setMaxLogBackups*(self: Service, value: int): bool =
+  var newConfiguration = self.configuration
+  newConfiguration.LogMaxBackups = value
   return self.saveConfiguration(newConfiguration)

--- a/ui/app/AppLayouts/Profile/stores/AdvancedStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/AdvancedStore.qml
@@ -14,6 +14,7 @@ QtObject {
     property bool isAutoMessageEnabled: advancedModule? advancedModule.isAutoMessageEnabled : false
     property bool isDebugEnabled: advancedModule? advancedModule.isDebugEnabled : false
     property bool isWakuV2StoreEnabled: advancedModule ? advancedModule.isWakuV2StoreEnabled : false
+    property int logMaxBackups: advancedModule ? advancedModule.logMaxBackups : 1
 
     property var customNetworksModel: advancedModule? advancedModule.customNetworksModel : []
 
@@ -91,6 +92,13 @@ QtObject {
             return
 
         root.advancedModule.toggleDebug()
+    }
+
+    function setMaxLogBackups(value) {
+        if(!root.advancedModule)
+            return
+
+        root.advancedModule.setMaxLogBackups(value)
     }
 
     function enableDeveloperFeatures() {

--- a/ui/app/AppLayouts/Profile/views/AdvancedView.qml
+++ b/ui/app/AppLayouts/Profile/views/AdvancedView.qml
@@ -11,10 +11,12 @@ import shared.popups 1.0
 import shared.status 1.0
 
 import StatusQ.Core 0.1
+import StatusQ.Popups 0.1
 import StatusQ.Popups.Dialog 0.1
 import StatusQ.Components 0.1
 import StatusQ.Core.Theme 0.1
 import StatusQ.Controls 0.1
+import StatusQ.Controls.Validators 0.1
 
 import "../stores"
 import "../controls"
@@ -417,6 +419,16 @@ SettingsContentBase {
                     root.advancedStore.toggleFakeLoadingScreen()
                 }
             }
+
+            StatusSettingsLineButton {
+                anchors.leftMargin: 0
+                anchors.rightMargin: 0
+                text: qsTr("How many log files to keep archived")
+                currentValue: root.advancedStore.logMaxBackups
+                onClicked: {
+                    Global.openPopup(changeNumberOfLogsArchived)
+                }
+            }
         }
 
         FleetsModal {
@@ -525,6 +537,77 @@ SettingsContentBase {
                 onCancelButtonClicked: {
                     close()
                 }
+            }
+        }
+
+        Component {
+            id: changeNumberOfLogsArchived
+
+            StatusModal {
+                id: logChangerModal
+
+                onClosed: destroy()
+                anchors.centerIn: parent
+                width: 400
+                header.title: qsTr("How many log files do you want to keep archived?")
+
+                contentItem: Column {
+                    width: parent.width
+                    StatusBaseText {
+                        width: parent.width
+                        font.pixelSize: 15
+                        color: Theme.palette.directColor1
+                        padding: 15
+                        wrapMode: Text.WordWrap
+                        text: qsTr("Choose a number between 1 and 100")
+                    }
+
+                    StatusInput {
+                        id: numberInput
+                        anchors.left: parent.left
+                        anchors.right: parent.right
+                        anchors.leftMargin: Style.current.padding
+                        anchors.rightMargin: Style.current.padding
+                        label: qsTr("Number of archives files")
+                        input.text: root.advancedStore.logMaxBackups
+                        placeholderText: qsTr("Number between 1 and 100")
+                        validators: [
+                            StatusFloatValidator {
+                                bottom: 1
+                                top: 100
+                                errorMessage: qsTr("Number needs to be between 1 and 100")
+                                locale: LocaleUtils.userInputLocale
+                            }
+                        ]
+                    }
+
+                    StatusBaseText {
+                        width: parent.width
+                        font.pixelSize: 15
+                        color: Theme.palette.directColor1
+                        padding: 15
+                        wrapMode: Text.WordWrap
+                        text: qsTr("This change will only come into action after a restart")
+                    }
+                }
+
+                rightButtons: [
+                    StatusButton {
+                        text: qsTr("Cancel")
+                        onClicked: logChangerModal.close()
+                        normalColor: "transparent"
+                        hoverColor: "transparent"
+                    },
+                    StatusButton {
+                        id: banButton
+                        text: qsTr("Change")
+                        type: StatusBaseButton.Type.Normal
+                        onClicked: {
+                            root.advancedStore.setMaxLogBackups(numberInput.input.text)
+                            logChangerModal.close()
+                        }
+                    }
+                ]
             }
         }
 


### PR DESCRIPTION
Fixes #3610

status-go PR: https://github.com/status-im/status-go/pull/3465

Commit 1 fixes status-go to not accept a MaxBackups of 0, because the lib we use is dumb and when it's set to 0, it actually keeps them ALL

Commit 2 adds a setting in Advanced Settings to modify the number of archived logs to keep. Between 1 and 100

Edit: I just realized that we also have the Nim logs being saved in `Status/logs`. We probably want to fix that too, but they are way lighter. However, chronicles, the lib we use for logging,  is not as smart as lumberjack, the one in go. So it doesn't have a rotation mechanism.
Do we want to make it so we just keep one file. That would be easy. We just need to rename the file path to a set one, so we just always overwrite it with each new run.
If we want the setting for that too, it's more complex, as we need to create our own rotating log mechanism. 
cc @iurimatias 