### PR TITLE
feat(MintToken):  Remote self-destruct footer option hidden if the minted collectible doesn't have self-destruct property set

### DIFF
--- a/ui/app/AppLayouts/Chat/panels/communities/CommunityMintTokensSettingsPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/CommunityMintTokensSettingsPanel.qml
@@ -91,6 +91,7 @@ SettingsPageLayout {
 
         property var tokenOwnersModel
         property var selfDestructTokensList
+        property bool selfDestruct
 
         readonly property var initialItem: (root.tokensModel && root.tokensModel.count > 0) ? mintedTokensView : welcomeView
         onInitialItemChanged: updateInitialStackView()
@@ -275,7 +276,7 @@ SettingsPageLayout {
 
             airdropEnabled: true
             retailEnabled: false
-            remotelySelfDestructEnabled: true
+            remotelySelfDestructVisible: d.selfDestruct
             burnEnabled: false
 
             onAirdropClicked: d.airdropClicked()
@@ -370,6 +371,12 @@ SettingsPageLayout {
                 target: d
                 property: "tokenOwnersModel"
                 value: view.tokenOwnersModel
+            }
+
+            Binding {
+                target: d
+                property: "selfDestruct"
+                value: view.selfDestruct
             }
 
             Instantiator {

--- a/ui/app/AppLayouts/Chat/panels/communities/MintTokensFooterPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/MintTokensFooterPanel.qml
@@ -13,7 +13,7 @@ Control {
 
     property alias airdropEnabled: airdropButton.enabled
     property alias retailEnabled: retailButton.enabled
-    property alias remotelySelfDestructEnabled: remotelySelfDestructButton.enabled
+    property alias remotelySelfDestructVisible: remotelySelfDestructButton.visible
     property alias burnEnabled: burnButton.enabled
 
     signal airdropClicked


### PR DESCRIPTION
Closes #10579

### What does the PR do

Added property binded with model info and with needed footer visible property option.

### Affected areas

Community Settings / Mint tokens

### Screenshot of functionality

https://user-images.githubusercontent.com/97019400/237017076-57ffea66-204b-4cd3-b210-cc3a5d8720c9.mov