### PR TITLE
fix(StatusScrollView): Changed implementation to inherit `ScrollView`

### DIFF
--- a/ui/StatusQ/sandbox/controls/Icons.qml
+++ b/ui/StatusQ/sandbox/controls/Icons.qml
@@ -1,12 +1,13 @@
 import QtQuick 2.14
 import QtQuick.Layouts 1.14
+
 import StatusQ.Core 0.1
+import StatusQ.Core.Theme 0.1
 
 GridLayout {
     columns: 6
     columnSpacing: 5
     rowSpacing: 5
-    property color iconColor
 
     Repeater {
         model: ["activity", "add-circle", "add-contact", "add",
@@ -16,7 +17,7 @@ GridLayout {
 
         delegate: StatusIcon {
             icon: modelData
-            color: iconColor
+            color: Theme.palette.primaryColor1
         }
     }
 }

--- a/ui/StatusQ/sandbox/controls/ListItems.qml
+++ b/ui/StatusQ/sandbox/controls/ListItems.qml
@@ -39,34 +39,31 @@ ColumnLayout {
     }
 
     StatusChatListCategoryItem {
-        title: "Chat list category"
+        text: "Chat list category"
         opened: false
         showActionButtons: true
     }
 
     StatusChatListCategoryItem {
-        title: "Chat list category (opened)"
+        text: "Chat list category (opened)"
         opened: true
         showActionButtons: true
     }
 
     StatusChatListCategoryItem {
-        title: "Chat list category (no buttons)"
+        text: "Chat list category (no buttons)"
         opened: true
     }
 
     StatusChatListCategoryItem {
         id: categoryItemInteractive
-        title: "Chat category interactive"
+        text: "Chat category interactive"
         showActionButtons: true
         onAddButtonClicked: testEventsList.eventTriggered("Add button clicked")
         onMenuButtonClicked: testEventsList.eventTriggered("Menu button clicked")
         onToggleButtonClicked: {
             opened = !opened
             testEventsList.eventTriggered("Toggle button clicked")
-        }
-        onTitleClicked: {
-            testEventsList.eventTriggered("Title clicked")
         }
         onClicked: {
             opened = !opened

--- a/ui/StatusQ/sandbox/demoapp/data/Models.qml
+++ b/ui/StatusQ/sandbox/demoapp/data/Models.qml
@@ -1199,7 +1199,7 @@ QtObject {
             notificationsCount: 0
         }
         ListElement {
-            sectionId: "demoApp"
+            sectionId: "qrScanner"
             sectionType: 103
             name: "QR Scanner"
             active: false

--- a/ui/StatusQ/sandbox/main.qml
+++ b/ui/StatusQ/sandbox/main.qml
@@ -146,11 +146,14 @@ StatusWindow {
             }
 
             leftPanel: StatusScrollView {
+                id: sectionsScrollView
                 anchors.fill: parent
-                anchors.topMargin: 48
+                topPadding: 48
+                contentWidth: availableWidth
 
                 Column {
                     id: navigation
+                    width: sectionsScrollView.availableWidth
                     spacing: 0
 
                     StatusListSectionHeadline { text: "StatusQ.Core" }
@@ -158,6 +161,11 @@ StatusWindow {
                         title: "Icons"
                         selected: viewLoader.source.toString().includes(title)
                         onClicked: mainPageView.control(title);
+                    }
+                    StatusNavigationListItem {
+                        title: "ScrollView"
+                        selected: viewLoader.source.toString().includes(title)
+                        onClicked: mainPageView.page("StatusScrollView");
                     }
 
                     StatusListSectionHeadline { text: "StatusQ.Layout" }
@@ -374,34 +382,35 @@ StatusWindow {
                 anchors.fill: parent
 
                 StatusScrollView {
+                    id: scrollView
                     visible: !storeSettings.fillPage
+
                     anchors.fill: parent
-                    anchors.topMargin: 64
-                    contentHeight: (pageWrapper.height + pageWrapper.anchors.topMargin) * rootWindow.factor
-                    contentWidth: (pageWrapper.width * rootWindow.factor)
-                    clip: true
+                    topPadding: 64
+                    padding: 20
+
+                    contentWidth: viewLoader.width * rootWindow.factor
+                    contentHeight: viewLoader.height * rootWindow.factor
 
                     Item {
                         id: pageWrapper
-                        width: centerPanel.width
-                        anchors.top: parent.top
-                        height: Math.max(rootWindow.height, viewLoader.height + 128)
+
+                        width: Math.max(scrollView.availableWidth, viewLoader.width)
+                        height: Math.max(scrollView.availableHeight, viewLoader.height)
                         scale: rootWindow.factor
 
                         Loader {
                             id: viewLoader
-                            active: !storeSettings.fillPage
                             anchors.centerIn: parent
+                            active: !storeSettings.fillPage
                             source: storeSettings.selected.length === 0 ? mainPageView.control("Icons") : storeSettings.selected
                             onSourceChanged: {
                                 storeSettings.selected = viewLoader.source
-                                if (source.toString().includes("Icons")) {
-                                    item.iconColor = Theme.palette.primaryColor1;
-                                }
                             }
                         }
                     }
                 }
+
                 Loader {
                     active: storeSettings.fillPage
                     anchors.fill: parent

--- a/ui/StatusQ/sandbox/pages/StatusScrollViewPage.qml
+++ b/ui/StatusQ/sandbox/pages/StatusScrollViewPage.qml
@@ -1,0 +1,336 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+import StatusQ.Core 0.1
+import StatusQ.Core.Theme 0.1
+import StatusQ.Controls 0.1
+import StatusQ.Components 0.1
+import StatusQ.Layout 0.1
+import StatusQ.Platform 0.1
+import StatusQ.Popups 0.1
+
+Rectangle {
+    id: root
+
+    color: "transparent"
+
+    implicitWidth: layout.implicitWidth
+    implicitHeight: layout.implicitHeight
+
+    QtObject {
+        id: d
+
+        readonly property string text1: "felis imperdiet proin fermentum leo vel orci porta non pulvinar neque laoreet suspendisse interdum consectetur libero id faucibus nisl tincidunt eget nullam non nisi est sit amet facilisis magna etiam tempor orci eu lobortis elementum nibh tellus molestie nunc non blandit massa enim nec dui nunc mattis enim ut tellus elementum sagittis vitae et leo duis ut diam quam nulla porttitor massa id neque aliquam vestibulum morbi blandit cursus risus at ultrices mi tempus imperdiet nulla malesuada pellentesque elit eget gravida cum sociis natoque penatibus et magnis dis parturient montes nascetur ridiculus mus mauris vitae ultricies leo integer malesuada nunc vel risus commodo viverra maecenas accumsan lacus vel facilisis volutpat est velit egestas dui id ornare arcu odio ut sem nulla pharetra diam sit amet nisl suscipit adipiscing bibendum est ultricies integer quis auctor elit sed vulputate mi sit amet mauris commodo quis imperdiet massa tincidunt nunc pulvinar sapien et ligula ullamcorper malesuada proin libero nunc consequat interdum varius sit amet mattis vulputate enim nulla aliquet porttitor lacus luctus accumsan tortor posuere ac ut consequat semper viverra nam libero justo laoreet sit amet cursus sit amet dictum sit amet justo donec enim diam vulputate ut pharetra sit amet aliquam id diam maecenas ultricies mi eget mauris pharetra et ultrices neque ornare aenean euismod elementum nisi quis eleifend quam adipiscing vitae proin sagittis nisl rhoncus mattis rhoncus urna neque viverra justo nec ultrices dui sapien eget mi proin sed libero enim sed faucibus turpis in eu mi bibendum neque egestas congue quisque egestas diam in arcu cursus euismod quis viverra nibh cras pulvinar mattis nunc sed blandit libero volutpat sed cras ornare arcu dui vivamus arcu felis bibendum ut tristique et egestas quis ipsum suspendisse ultrices gravida dictum fusce ut placerat orci nulla pellentesque dignissim enim sit amet venenatis urna cursus eget nunc scelerisque viverra mauris in aliquam sem fringilla ut morbi tincidunt augue interdum velit euismod in pellentesque massa placerat duis ultricies lacus sed turpis tincidunt id aliquet risus feugiat in ante metus dictum at tempor commodo ullamcorper a lacus vestibulum sed arcu non odio euismod lacinia at quis risus sed vulputate odio ut enim blandit volutpat maecenas volutpat blandit aliquam etiam erat velit scelerisque in dictum non consectetur a erat nam at lectus urna duis convallis convallis tellus id interdum velit laoreet id donec ultrices tincidunt arcu non sodales neque sodales ut etiam sit amet nisl purus in mollis"
+        readonly property string text2: text1.repeat(8)
+        readonly property int padding: 20
+    }
+
+    component Docs: StatusBaseText {
+        id: docs
+        textFormat: Text.MarkdownText
+        wrapMode: Text.WordWrap
+
+        onLinkActivated: (link) => {
+            Qt.openUrlExternally(link)
+        }
+
+        MouseArea {
+            anchors.fill: parent
+            visible: !!docs.hoveredLink
+            cursorShape: Qt.PointingHandCursor
+            acceptedButtons: Qt.NoButton
+        }
+    }
+
+    component Modal: StatusModal {
+        anchors.centerIn: parent
+        header.title: `Popup with fixed width ${width}px`
+        rightButtons: [ StatusButton { text: "Button" } ]
+    }
+
+    ColumnLayout {
+        id: layout
+        anchors.fill: parent
+        spacing: 20
+
+        Docs {
+            Layout.fillWidth: true
+            text:
+"
+## ScrollView
+* single item: content size is automatically calculated based on the implicit size of its contained item.
+* more than one item (or implicit size is not provided): the contentWidth and contentHeight must be set
+* `ScrollView contentWidth: availableWidth` (this takes any padding or scroll bars into account)
+* `Itemwidth: scrollView.availableWidth`
+* Qt ScrollView has twitching bugs: [#5781](https://github.com/status-im/status-desktop/issues/5781)
+* `contentItem` is a `Flickable`
+
+Here's how `contentWidth` is calculated internally:
+* [QQuickScrollViewPrivate::getContentWidth](https://codebrowser.dev/qt5/qtquickcontrols2/src/quicktemplates2/qquickscrollview.cpp.html#_ZNK23QQuickScrollViewPrivate15getContentWidthEv)
+* [QQuickPanePrivate::getContentWidth](https://codebrowser.dev/qt5/qtquickcontrols2/src/quicktemplates2/qquickpane.cpp.html#_ZNK17QQuickPanePrivate15getContentWidthEv)
+"
+        }
+
+        RowLayout {
+            Layout.fillWidth: true
+            spacing: 20
+
+            StatusButton {
+                type: StatusBaseButton.Type.Primary
+                text: "StatusScrollView"
+                onClicked: statusScrollViewPopup.open()
+            }
+
+            StatusButton {
+                text: "ScrollView"
+                onClicked: scrollViewPopup.open()
+            }
+
+            StatusButton {
+                text: "ScrollView with applied fix"
+                onClicked: fixedScrollViewPopup.open()
+            }
+        }
+
+        Docs {
+            Layout.fillWidth: true
+            text:
+"
+## Flickable
+* contentWidth and contentHeight must be set
+* size of the contentItem is determined by contentWidth and contentHeight.
+* items are parented to Flickable's contentItem
+* items cannot anchor to Flickable. Use parent, which refers to the Flickable's contentItem
+* `Item width: parent.width`
+"
+        }
+
+        RowLayout {
+            Layout.fillWidth: true
+            spacing: 20
+
+            StatusButton {
+                text: "Flickable"
+                onClicked: flickable1Popup.open()
+            }
+
+            StatusButton {
+                text: "Flickable with attached ScrollBars"
+                onClicked: flickable2Popup.open()
+            }
+
+            StatusButton {
+                text: "Flickable with ScrollBars"
+                onClicked: flickable3Popup.open()
+            }
+        }
+    }
+
+    Modal {
+        id: scrollViewPopup
+
+        ScrollView {
+            id: scrollView
+            anchors.fill: parent
+            padding: d.padding
+            contentWidth: availableWidth
+            clip: true
+
+            StatusBaseText {
+                id: modalItem
+                width: scrollView.availableWidth
+                wrapMode: Text.WordWrap
+                text: d.text2
+            }
+        }
+    }
+
+    Modal {
+        id: fixedScrollViewPopup
+
+        ScrollView {
+            id: fixedScrollView
+            anchors.fill: parent
+            padding: d.padding
+            contentWidth: availableWidth
+
+            clip: true
+
+            readonly property Flickable flickable: contentItem
+
+            Component.onCompleted: {
+                flickable.boundsBehavior = Flickable.StopAtBounds
+                flickable.maximumFlickVelocity = 2000
+                flickable.synchronousDrag = true
+            }
+
+            StatusBaseText {
+                width: fixedScrollView.availableWidth
+                wrapMode: Text.WordWrap
+                text: d.text2
+            }
+
+            ScrollBar.horizontal: StatusScrollBar {
+                parent: fixedScrollView
+                x: fixedScrollView.mirrored ? 0 : fixedScrollView.width - width
+                y: fixedScrollView.topPadding
+                height: fixedScrollView.availableHeight
+                active: fixedScrollView.ScrollBar.horizontal.active
+                policy: ScrollBar.AlwaysOn
+            }
+
+            ScrollBar.vertical: StatusScrollBar {
+                parent: fixedScrollView
+                x: fixedScrollView.mirrored ? 0 : fixedScrollView.width - width
+                y: fixedScrollView.topPadding
+                height: fixedScrollView.availableHeight
+                active: fixedScrollView.ScrollBar.horizontal.active
+                policy: ScrollBar.AlwaysOn
+            }
+        }
+    }
+
+
+    Modal {
+        id: flickable1Popup
+
+        Flickable {
+            id: flickable1
+            anchors.fill: parent
+
+            clip: true
+
+            topMargin: d.padding
+            bottomMargin: d.padding
+            leftMargin: d.padding
+            rightMargin: d.padding
+
+            implicitWidth: contentWidth // + leftMargin + rightMargin
+            implicitHeight: contentHeight + topMargin + bottomMargin
+
+            contentHeight: contentItem.childrenRect.height
+
+            StatusBaseText {
+                id: fliackable1Item
+                width: parent.width
+                wrapMode: Text.WordWrap
+                text: d.text2
+            }
+        }
+    }
+
+    Modal {
+        id: flickable2Popup
+
+        contentWidth: flickable2.implicitWidth
+        contentHeight: flickable2.implicitHeight
+
+        Flickable {
+            id: flickable2
+            anchors.fill: parent
+
+            clip: true
+
+            topMargin: d.padding
+            bottomMargin: d.padding
+            leftMargin: d.padding
+            rightMargin: d.padding
+
+            implicitWidth: contentWidth // + leftMargin + rightMargin
+            implicitHeight: contentHeight + topMargin + bottomMargin
+
+            contentHeight: flickable2Item.height
+
+            ScrollBar.horizontal: StatusScrollBar {
+                policy: ScrollBar.AlwaysOn
+            }
+
+            ScrollBar.vertical: StatusScrollBar {
+                policy: ScrollBar.AlwaysOn
+            }
+
+            StatusBaseText {
+                id: flickable2Item
+                width: parent.width
+                wrapMode: Text.WordWrap
+                text: d.text2
+            }
+        }
+    }
+
+    Modal {
+        id: flickable3Popup
+
+        contentWidth: flickable3.implicitWidth
+        contentHeight: flickable3.implicitHeight
+
+        Flickable {
+            id: flickable3
+            anchors.fill: parent
+
+            clip: true
+
+            topMargin: d.padding
+            bottomMargin: d.padding
+            leftMargin: d.padding
+            rightMargin: d.padding
+
+            implicitWidth: contentWidth // + leftMargin + rightMargin
+            implicitHeight: contentHeight + topMargin + bottomMargin
+
+            contentHeight: flickable3Item.height
+
+            StatusBaseText {
+                id: flickable3Item
+                width: parent.width
+                wrapMode: Text.WordWrap
+                text: d.text2
+            }
+        }
+
+        ScrollBar {
+            id: vbar
+            hoverEnabled: true
+            active: hovered || pressed
+            orientation: Qt.Vertical
+            size: flickable3.visibleArea.heightRatio
+            position: flickable3.visibleArea.yPosition
+            anchors.top: parent.top
+            anchors.right: parent.right
+            anchors.bottom: parent.bottom
+            policy: ScrollBar.AlwaysOn
+        }
+
+        ScrollBar {
+            id: hbar
+            hoverEnabled: true
+            active: hovered || pressed
+            orientation: Qt.Horizontal
+            size: flickable3.visibleArea.widthRatio
+            position: flickable3.visibleArea.xPosition
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.bottom: parent.bottom
+            policy: ScrollBar.AlwaysOn
+        }
+    }
+
+    Modal {
+        id: statusScrollViewPopup
+
+        StatusScrollView {
+            id: statusScrollView
+            anchors.fill: parent
+            contentWidth: availableWidth
+            padding: d.padding
+
+            StatusBaseText {
+                id: statusScrollViewItem
+                width: statusScrollView.availableWidth
+                wrapMode: Text.WordWrap
+                text: d.text2
+            }
+        }
+    }
+}

--- a/ui/StatusQ/sandbox/pages/StatusTextAreaPage.qml
+++ b/ui/StatusQ/sandbox/pages/StatusTextAreaPage.qml
@@ -40,7 +40,6 @@ Column {
         padding: 0 // use our own (StatusTextArea) padding
         width: parent.width
         height: 120
-        TextArea.flickable: longTextArea
         StatusTextArea {
             id: longTextArea
             text: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Integer imperdiet lectus quis justo. Sed vel lectus. \

--- a/ui/StatusQ/src/StatusQ/Components/StatusListItem.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusListItem.qml
@@ -321,7 +321,6 @@ Rectangle {
                     contentWidth: row.width
                     padding: 0
                     clip: true
-                    interactive: false
                     Row {
                         id: row
                         spacing: 4

--- a/ui/StatusQ/src/StatusQ/Controls/StatusScrollBar.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusScrollBar.qml
@@ -27,10 +27,10 @@ import StatusQ.Core.Theme 0.1
 T.ScrollBar {
     id: root
 
-    function resolveVisibility(policy, length, availableLength) {
+    function resolveVisibility(policy, availableSize, contentSize) {
         switch (policy) {
         case T.ScrollBar.AsNeeded:
-            return availableLength > length;
+            return contentSize > availableSize;
         case T.ScrollBar.AlwaysOn:
             return true;
         case T.ScrollBar.AlwaysOff:

--- a/ui/StatusQ/src/StatusQ/Controls/StatusTextArea.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusTextArea.qml
@@ -36,7 +36,6 @@ import StatusQ.Components 0.1
         padding: 0 // use our own (StatusTextArea) padding
         width: parent.width
         height: 120
-        TextArea.flickable: longTextArea
         StatusTextArea {
           id: longTextArea
           text: "Very\nlong\ntext\nwith\nmany\nlinebreaks"

--- a/ui/StatusQ/src/StatusQ/Core/StatusScrollView.qml
+++ b/ui/StatusQ/src/StatusQ/Core/StatusScrollView.qml
@@ -1,7 +1,7 @@
-import QtQuick 2.14
-import QtQuick.Controls 2.14
-import QtQuick.Controls.impl 2.12
-import QtQuick.Templates 2.12 as T
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Controls.impl 2.15
+import QtQuick.Templates 2.15 as T
 
 import StatusQ.Controls 0.1
 import StatusQ.Core.Utils 0.1

--- a/ui/app/AppLayouts/Chat/panels/InlineSelectorPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/InlineSelectorPanel.qml
@@ -84,9 +84,9 @@ Item {
 
                         function positionViewAtEnd() {
                             if (scrollView.contentWidth > scrollView.width) {
-                                scrollView.contentX = scrollView.contentWidth - scrollView.width
+                                scrollView.flickable.contentX = scrollView.contentWidth - scrollView.width
                             } else {
-                                scrollView.contentX = 0
+                                scrollView.flickable.contentX = 0
                             }
                         }
 
@@ -181,7 +181,7 @@ Item {
                             anchors.left: scrollView.left
                             anchors.right: scrollView.right
                             policy: ScrollBar.AsNeeded
-                            visible: resolveVisibility(policy, scrollView.width, scrollView.contentWidth)
+                            visible: resolveVisibility(policy, scrollView.availableWidth, scrollView.contentWidth)
                         }
                     }
                 }


### PR DESCRIPTION
First step for https://github.com/status-im/status-desktop/issues/9864

This is a draft PR with main required changes.
If this one is ok, I will proceed further and fix all places where `StatusScrollView` is used.

### What does the PR do

- Inherit `StatusScrollView` from `ScrollView`.
- Much easier to set correct sizes `StatusScrollView`. And in a `Popup` too.
- `implicitWidth` and `implicitHeight` out of the box. 
- No binding loops
- No need to attach manually `TextArea` to a `Flickable`. Just wrap it around.
- No glitches.
- Use standard `padding` and `available` sizes.
- Vertical and horizontal `ScrollBar` don't overlap each other in bottom-right corner.
- Added `StatusScrollViewPage` showing the difference in using `ScrollView` and `Flickable` with various options.

cons:
- `StatusScrollView` can't be dragged by mouse anymore
It doesn't drag with mouse, though I _think_ that it might work with real touch screen.
Also, I don't think it's a problem. Discord doesn't support dragging messages or chats list.

minor sandbox fixes:
- Removed customization for `Icons` page
- Fixed `Models` to correctly highlight app selected, not qr scanner
- Fixed `ListItem` to use new `text` property instead of `title`


https://github.com/status-im/status-desktop/assets/25482501/59c277a0-ee02-464a-99e1-1f0f2e77d1d3

