### PR TITLE
fix: ensure client checks available ENS names in join community view

### DIFF
--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -35,6 +35,7 @@ import ../../../../app_service/service/wallet_account/service as wallet_account_
 import ../../../../app_service/service/token/service as token_service
 import ../../../../app_service/service/collectible/service as collectible_service
 import ../../../../app_service/service/community_tokens/service as community_tokens_service
+import ../../../../app_service/service/ens/service as ens_service
 import ../../../../app_service/service/visual_identity/service as visual_identity
 import ../../../../app_service/service/contacts/dto/contacts as contacts_dto
 import ../../../../app_service/service/community/dto/community as community_dto
@@ -106,11 +107,12 @@ proc newModule*(
     tokenService: token_service.Service,
     collectibleService: collectible_service.Service,
     communityTokensService: community_tokens_service.Service,
+    ensService: ens_service.Service,
   ): Module =
   result = Module()
   result.delegate = delegate
   result.controller = controller.newController(result, sectionId, isCommunity, events, settingsService, nodeConfigurationService,
-  contactService, chatService, communityService, messageService, gifService, mailserversService, walletAccountService, tokenService, collectibleService, communityTokensService)
+  contactService, chatService, communityService, messageService, gifService, mailserversService, walletAccountService, tokenService, collectibleService, communityTokensService, ensService)
   result.view = view.newView(result)
   result.viewVariant = newQVariant(result.view)
   result.moduleLoaded = false
@@ -1303,6 +1305,9 @@ proc buildTokenPermissionItem*(self: Module, tokenPermission: CommunityTokenPerm
         tokenCriteriaMet = self.controller.ownsCollectible(chainId, address, tc.tokenIds)
         if tokenCriteriaMet:
           break
+
+    if tc.`type` == TokenType.ENS:
+      tokenCriteriaMet = self.controller.ownsENS(tc.ensPattern)
 
     let tokenCriteriaItem = initTokenCriteriaItem(
       tc.symbol,

--- a/src/app/modules/main/controller.nim
+++ b/src/app/modules/main/controller.nim
@@ -18,6 +18,7 @@ import ../../../app_service/service/mailservers/service as mailservers_service
 import ../../../app_service/service/privacy/service as privacy_service
 import ../../../app_service/service/node/service as node_service
 import ../../../app_service/service/community_tokens/service as community_tokens_service
+import ../../../app_service/service/ens/service as ens_service
 import ../../../app_service/service/wallet_account/service as wallet_account_service
 import ../../../app_service/service/token/service as token_service
 import ../../../app_service/service/network/service as networks_service
@@ -48,6 +49,7 @@ type
     mailserversService: mailservers_service.Service
     nodeService: node_service.Service
     communityTokensService: community_tokens_service.Service
+    ensService: ens_service.Service
     activeSectionId: string
     authenticateUserFlowRequestedBy: string
     walletAccountService: wallet_account_service.Service
@@ -72,6 +74,7 @@ proc newController*(delegate: io_interface.AccessInterface,
   mailserversService: mailservers_service.Service,
   nodeService: node_service.Service,
   communityTokensService: community_tokens_service.Service,
+  ensService: ens_service.Service,
   walletAccountService: wallet_account_service.Service,
   tokenService: token_service.Service,
   networksService: networks_service.Service,
@@ -118,7 +121,8 @@ proc init*(self: Controller) =
       self.walletAccountService,
       self.tokenService,
       self.collectibleService,
-      self.communityTokensService
+      self.communityTokensService,
+      self.ensService
     )
 
   self.events.on(SIGNAL_COMMUNITY_DATA_LOADED) do(e:Args):
@@ -135,7 +139,8 @@ proc init*(self: Controller) =
       self.walletAccountService,
       self.tokenService,
       self.collectibleService,
-      self.communityTokensService
+      self.communityTokensService,
+      self.ensService
     )
 
   self.events.on(SIGNAL_CHANNEL_GROUPS_LOADING_FAILED) do(e:Args):
@@ -172,6 +177,7 @@ proc init*(self: Controller) =
       self.tokenService,
       self.collectibleService,
       self.communityTokensService,
+      self.ensService,
       setActive = args.fromUserAction
     )
 
@@ -192,6 +198,7 @@ proc init*(self: Controller) =
       self.tokenService,
       self.collectibleService,
       self.communityTokensService,
+      self.ensService,
       setActive = args.fromUserAction
     )
 
@@ -216,6 +223,7 @@ proc init*(self: Controller) =
       self.tokenService,
       self.collectibleService,
       self.communityTokensService,
+      self.ensService,
       setActive = true
     )
 
@@ -238,6 +246,7 @@ proc init*(self: Controller) =
       self.tokenService,
       self.collectibleService,
       self.communityTokensService,
+      self.ensService,
       setActive = false
     )
 

--- a/src/app/modules/main/io_interface.nim
+++ b/src/app/modules/main/io_interface.nim
@@ -13,6 +13,7 @@ import ../../../app_service/service/wallet_account/service as wallet_account_ser
 import ../../../app_service/service/token/service as token_service
 import ../../../app_service/service/collectible/service as collectible_service
 import ../../../app_service/service/community_tokens/service as community_tokens_service
+import ../../../app_service/service/ens/service as ens_service
 from ../../../app_service/common/types import StatusType
 
 import ../../global/app_signals
@@ -88,7 +89,8 @@ method onChannelGroupsLoaded*(
   walletAccountService: wallet_account_service.Service,
   tokenService: token_service.Service,
   collectibleService: collectible_service.Service,
-  communityTokensService: community_tokens_service.Service)
+  communityTokensService: community_tokens_service.Service,
+  ensService: ens_service.Service)
   {.base.} =
   raise newException(ValueError, "No implementation available")
 
@@ -106,7 +108,8 @@ method onCommunityDataLoaded*(
   walletAccountService: wallet_account_service.Service,
   tokenService: token_service.Service,
   collectibleService: collectible_service.Service,
-  communityTokensService: community_tokens_service.Service)
+  communityTokensService: community_tokens_service.Service,
+  ensService: ens_service.Service)
   {.base.} =
   raise newException(ValueError, "No implementation available")
 
@@ -155,6 +158,7 @@ method communityJoined*(self: AccessInterface, community: CommunityDto, events: 
   tokenService: token_service.Service,
   collectibleService: collectible_service.Service,
   communityTokensService: community_tokens_service.Service,
+  ensService: ens_service.Service,
   setActive: bool = false,) {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -54,6 +54,7 @@ import ../../../app_service/service/mailservers/service as mailservers_service
 import ../../../app_service/service/gif/service as gif_service
 import ../../../app_service/service/ens/service as ens_service
 import ../../../app_service/service/community_tokens/service as community_tokens_service
+import ../../../app_service/service/ens/service as ens_service
 import ../../../app_service/service/network/service as network_service
 import ../../../app_service/service/general/service as general_service
 import ../../../app_service/service/keycard/service as keycard_service
@@ -165,6 +166,7 @@ proc newModule*[T](
     mailserversService,
     nodeService,
     communityTokensService,
+    ensService,
     walletAccountService,
     tokenService,
     networkService,
@@ -541,7 +543,8 @@ method onChannelGroupsLoaded*[T](
   walletAccountService: wallet_account_service.Service,
   tokenService: token_service.Service,
   collectibleService: collectible_service.Service,
-  communityTokensService: community_tokens_service.Service
+  communityTokensService: community_tokens_service.Service,
+  ensService: ens_service.Service
 ) =
   self.chatsLoaded = true
   if not self.communityDataLoaded:
@@ -568,7 +571,8 @@ method onChannelGroupsLoaded*[T](
       walletAccountService,
       tokenService,
       collectibleService,
-      communityTokensService
+      communityTokensService,
+      ensService
     )
     let channelGroupItem = self.createChannelGroupItem(channelGroup)
     self.view.model().addItem(channelGroupItem)
@@ -601,7 +605,8 @@ method onCommunityDataLoaded*[T](
   walletAccountService: wallet_account_service.Service,
   tokenService: token_service.Service,
   collectibleService: collectible_service.Service,
-  communityTokensService: community_tokens_service.Service
+  communityTokensService: community_tokens_service.Service,
+  ensService: ens_service.Service
 ) =
   self.communityDataLoaded = true
   if not self.chatsLoaded:
@@ -621,7 +626,8 @@ method onCommunityDataLoaded*[T](
     walletAccountService,
     tokenService,
     collectibleService,
-    communityTokensService
+    communityTokensService,
+    ensService
   )
 
 method onChatsLoadingFailed*[T](self: Module[T]) =
@@ -844,6 +850,7 @@ method communityJoined*[T](
   tokenService: token_service.Service,
   collectibleService: collectible_service.Service,
   communityTokensService: community_tokens_service.Service,
+  ensService: ens_service.Service,
   setActive: bool = false,
 ) =
   var firstCommunityJoined = false
@@ -865,7 +872,8 @@ method communityJoined*[T](
       walletAccountService,
       tokenService,
       collectibleService,
-      communityTokensService
+      communityTokensService,
+      ensService
     )
   let channelGroup = community.toChannelGroupDto()
   self.channelGroupModules[community.id].load(channelGroup, events, settingsService, nodeConfigurationService, contactsService,

--- a/src/app_service/service/community/service.nim
+++ b/src/app_service/service/community/service.nim
@@ -572,15 +572,12 @@ QtObject:
 
               permissionUpdated = true
 
-          for tc in tokenPermission.tokenCriteria:
-            let index = findIndexBySymbol(tc.symbol, prevTokenPermission.tokenCriteria)
-            if index == -1:
-              continue
-
-            let prevTc = prevTokenPermission.tokenCriteria[index]
-            if tc.amount != prevTc.amount or tc.ensPattern != prevTc.ensPattern:
-              permissionUpdated = true
-              break
+          if not permissionUpdated:
+            for i, tc in tokenPermission.tokenCriteria:
+              let prevTc = prevTokenPermission.tokenCriteria[i]
+              if tc.amount != prevTc.amount or tc.ensPattern != prevTc.ensPattern or tc.`type` != prevTc.`type`:
+                permissionUpdated = true
+                break
 
           if permissionUpdated:
             self.events.emit(SIGNAL_COMMUNITY_TOKEN_PERMISSION_UPDATED, 

--- a/src/app_service/service/ens/service.nim
+++ b/src/app_service/service/ens/service.nim
@@ -411,6 +411,17 @@ QtObject:
     let balances = status_go_backend.getTokensBalancesForChainIDs(@[self.getChainId()], @[account], @[token.addressAsString()]).result
     return ens_utils.hex2Token(balances{account}{token.addressAsString()}.getStr, token.decimals)
 
+  proc reverseResolveENS*(self: Service, addresses: seq[string]): seq[string] =
+    try:
+      let response = status_ens.reverseResolveENS(addresses)
+      result = @[]
+      if response.result.kind != JNull:
+        for ensName in response.result:
+          result.add(ensName.getStr)
+    except Exception as e:
+      error "Error reverse resolving ENS names", exception=e.msg
+      raise
+
   proc resourceUrl*(self: Service, username: string): (string, string, string) =
     try:
       let response = status_ens.resourceURL(self.getChainId(), username)

--- a/src/backend/ens.nim
+++ b/src/backend/ens.nim
@@ -7,6 +7,10 @@ proc getEnsUsernames*(): RpcResponse[JsonNode] {.raises: [Exception].} =
   let payload = %* []
   return core.callPrivateRPC("ens_getEnsUsernames", payload)
 
+proc reverseResolveENS*(addresses: seq[string]): RpcResponse[JsonNode] {.raises: [Exception].} =
+  let payload = %* [addresses]
+  return core.callPrivateRPC("reverseResolveENS".prefix, payload)
+
 proc add*(chainId: int, username: string): RpcResponse[JsonNode] {.raises: [Exception].} =
   let payload = %* [chainId, username]
   return core.callPrivateRPC("ens_add", payload)


### PR DESCRIPTION
We haven't checked for ENS previously. This is now done in this commit.

Depends on: https://github.com/status-im/status-go/pull/3467

Closes #4393

