### PR TITLE
fix(biometrics): Change keychain keys from DisplayName to KeyUid

### DIFF
--- a/src/app/boot/app_controller.nim
+++ b/src/app/boot/app_controller.nim
@@ -360,21 +360,19 @@ proc checkForStoringPasswordToKeychain(self: AppController) =
   ## This proc is used to store pass/pin depends on user's selection during onboarding flow.
   let account = self.accountsService.getLoggedInAccount()
   let value = singletonInstance.localAccountSettings.getStoreToKeychainValue()
-  if not main_constants.IS_MACOS or # This is MacOS only feature
+  if not main_constants.SUPPORTS_FINGERPRINT or # This is MacOS only feature
     value == LS_VALUE_STORE or # means pass is already stored, no need to store it again
     value == LS_VALUE_NEVER or # means pass doesn't need to be stored at all
     account.name.len == 0:
       return
   # We are here if stored "storeToKeychain" property for the logged in user is either empty or set to "NotNow".
 
-  #TODO: we should store PubKey of this account instead of display name (display name is not unique)
-  #      and we may run into a problem if 2 accounts with the same display name are generated.
   self.connectKeychain()
   let pass = self.startupModule.getPassword()
   if pass.len > 0:
-    self.keychainService.storeData(account.name, pass)
+    self.keychainService.storeData(account.keyUid, pass)
   else:
-    self.keychainService.storeData(account.name, self.startupModule.getPin())
+    self.keychainService.storeData(account.keyUid, self.startupModule.getPin())
 
 proc startupDidLoad*(self: AppController) =
   singletonInstance.engine.setRootContextProperty("localAppSettings", self.localAppSettingsVariant)

--- a/src/app/modules/main/profile_section/privacy/controller.nim
+++ b/src/app/modules/main/profile_section/privacy/controller.nim
@@ -101,16 +101,16 @@ method getPasswordStrengthScore*(self: Controller, password, userName: string): 
   return self.generalService.getPasswordStrengthScore(password, userName)
 
 proc storeToKeychain*(self: Controller, data: string) =
-  let myName = singletonInstance.userProfile.getName()
+  let myKeyUid = singletonInstance.userProfile.getKeyUid()
   let value = singletonInstance.localAccountSettings.getStoreToKeychainValue()
-  if not main_constants.IS_MACOS or # Dealing with Keychain is the MacOS only feature
+  if not main_constants.SUPPORTS_FINGERPRINT or # Dealing with Keychain is the MacOS only feature
     data.len == 0 or
     value == LS_VALUE_STORE or
-    myName.len == 0:
+    myKeyUid.len == 0:
       self.delegate.onStoreToKeychainError("", "")
       return
   self.connectKeychain()
-  self.keychainService.storeData(myName, data)
+  self.keychainService.storeData(myKeyUid, data)
 
 proc removeFromKeychain*(self: Controller, key: string) =
   let value = singletonInstance.localAccountSettings.getStoreToKeychainValue()

--- a/src/app/modules/main/profile_section/privacy/module.nim
+++ b/src/app/modules/main/profile_section/privacy/module.nim
@@ -109,8 +109,8 @@ method tryStoreToKeyChain*(self: Module) =
 
 method tryRemoveFromKeyChain*(self: Module) =
   self.keychainActivityReason = KeychainActivityReason.RemoveFrom
-  let myName = singletonInstance.userProfile.getName()
-  self.controller.removeFromKeychain(myName)
+  let myKeyUid = singletonInstance.userProfile.getKeyUid()
+  self.controller.removeFromKeychain(myKeyUid)
 
 method onUserAuthenticated*(self: Module, pin: string, password: string, keyUid: string) =
   self.keychainActivityReason = KeychainActivityReason.StoreTo

--- a/src/app/modules/shared_modules/keycard_popup/controller.nim
+++ b/src/app/modules/shared_modules/keycard_popup/controller.nim
@@ -767,10 +767,10 @@ proc tryToObtainDataFromKeychain*(self: Controller) =
   if(not singletonInstance.userProfile.getUsingBiometricLogin()):
     return
   let loggedInAccount = self.getLoggedInAccount()
-  self.keychainService.tryToObtainData(loggedInAccount.name)
+  self.keychainService.tryToObtainData(loggedInAccount.keyUid)
 
 proc tryToStoreDataToKeychain*(self: Controller, password: string) =
   if not serviceApplicable(self.keychainService):
     return
   let loggedInAccount = self.getLoggedInAccount()
-  self.keychainService.storeData(loggedInAccount.name, password)
+  self.keychainService.storeData(loggedInAccount.keyUid, password)

--- a/src/app/modules/startup/controller.nim
+++ b/src/app/modules/startup/controller.nim
@@ -334,7 +334,7 @@ proc tryToObtainDataFromKeychain*(self: Controller) =
   self.connectKeychain() # handling the results is done in slots connected in `connectKeychain` proc 
   self.tmpKeychainErrorOccurred = false
   let selectedAccount = self.getSelectedLoginAccount()
-  self.keychainService.tryToObtainData(selectedAccount.name)
+  self.keychainService.tryToObtainData(selectedAccount.keyUid)
 
 proc storeIdentityImage*(self: Controller): seq[Image] =
   if self.tmpProfileImageDetails.url.len == 0:

--- a/src/constants.nim
+++ b/src/constants.nim
@@ -13,6 +13,9 @@ let WALLET_ENABLED* = if (existsEnv("ENABLE_WALLET")):
 ## on other platform if we just change the value here
 const IS_MACOS* = defined(macosx)
 
+# For future supporting fingerprints on other platforms
+const SUPPORTS_FINGERPRINT* = IS_MACOS
+
 const sep* = when defined(windows): "\\" else: "/"
 
 proc defaultDataDir*(): string =


### PR DESCRIPTION
Fixes: #10424

### What does the PR do

All case from issue isn't reproduced. This PR change usage of `DisplayName` to `KeyUid` as a key for `keychain`

### Affected areas

Biometrics

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?
