### PR TITLE
fix(@desktop/wallet): The issue is that when switching between SavedAddresses to Account, the NetworkFilter was toggling a network causing the selection to be reset

### DIFF
--- a/ui/app/AppLayouts/Wallet/controls/NetworkFilter.qml
+++ b/ui/app/AppLayouts/Wallet/controls/NetworkFilter.qml
@@ -39,7 +39,7 @@ StatusComboBox {
     }
 
     Component.onCompleted: {
-        if (d.currentModel.count > 0) {
+        if (!multiSelection && d.currentModel.count > 0) {
             d.selectedChainName = d.currentModel.rowData(d.currentIndex, "chainName")
             d.selectedIconUrl = d.currentModel.rowData(d.currentIndex, "iconUrl")
             root.toggleNetwork(ModelUtils.get(d.currentModel, d.currentIndex))


### PR DESCRIPTION
fix(@desktop/wallet): The issue is that when switching between SavedAddresses to Account, the NetworkFilter was toggling a network causing the selection to be reset
now we only do it when multiselection is false

### What does the PR do

fix(@desktop/wallet): The issue is that when switching between SavedAddresses to Account, the NetworkFilter was toggling a network causing the selection to be reset
now we only do it when multiselection is false

### Affected areas

NetworkFilter (Account View and New Community token)

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it


https://github.com/status-im/status-desktop/assets/60327365/ac423896-ac94-4109-a504-7a8969531d82

