### PR TITLE
chore: `MembersDropdown` simplified, workaround for QTBUG-87804 added to `StatusDropdown`

### DIFF
--- a/storybook/PagesModel.qml
+++ b/storybook/PagesModel.qml
@@ -293,4 +293,8 @@ ListModel {
         title: "WalletHeader"
         section: "Panels"
     }
+    ListElement {
+        title: "PopupSizing"
+        section: "Research / Examples"
+    }
 }

--- a/storybook/pages/PopupSizingPage.qml
+++ b/storybook/pages/PopupSizingPage.qml
@@ -1,0 +1,254 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+import QtQml 2.15
+
+
+Item {
+    id: root
+
+    readonly property string bugLink:
+        "https://bugreports.qt.io/browse/QTBUG-87804"
+
+    Popup {
+        id: popup
+
+        visible: true
+
+        width: 200
+
+        x: draggableRectangle.width / 2
+        y: draggableRectangle.height / 2
+
+        parent: {
+            anchors.centerIn = undefined
+            Qt.callLater(() => anchors.centerIn = Qt.binding(
+                             () => centerInParentCheckBox.checked ? parent
+                                                                  : undefined))
+            if (pageRootRadioButton.checked)
+                return root
+
+            if (overlayRadioButton.checked)
+                return Overlay.overlay
+
+            return draggableRectangle
+        }
+
+        closePolicy: Popup.NoAutoClose
+
+        margins: marginsSlider.value
+
+        background: Rectangle {
+            border.color: "black"
+        }
+
+        Binding on margins{
+            id: workaroundBinding
+
+            when: false
+        }
+
+        ColumnLayout {
+            Button {
+                text: "Some button 1"
+
+                Layout.fillWidth: true
+            }
+            Button {
+                text: "Some button 2"
+
+                 Layout.fillWidth: true
+            }
+
+            onImplicitHeightChanged: {
+                if (!workAroundCheckBox.checked)
+                    return
+
+                workaroundBinding.value = popup.margins + 1
+                workaroundBinding.when = true
+                workaroundBinding.when = false
+            }
+
+            anchors.fill: parent
+
+            ListView {
+                id: listView
+
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                Layout.preferredHeight: contentHeight
+
+                model: itemsCountSlider.value
+                spacing: 2
+                clip: true
+
+                delegate: Rectangle {
+                    width: popup.availableWidth
+                    color: "lightblue"
+                    border.color: "black"
+                    height: 20
+
+                    Label {
+                        text: index
+                        anchors.centerIn: parent
+                    }
+                }
+            }
+
+            Button {
+                text: "Some button 3"
+
+                 Layout.fillWidth: true
+            }
+        }
+    }
+
+    Rectangle {
+        id: draggableRectangle
+
+        visible: draggableRadioButton.checked
+
+        border.color: "green"
+        color: "lightgreen"
+        border.width: 3
+
+        width: 50
+        height: width
+        x: 100
+        y: 100
+        radius: width / 2
+
+        Drag.active: dragArea.drag.active
+
+        MouseArea {
+            id: dragArea
+
+            anchors.fill: parent
+            drag.target: parent
+        }
+    }
+
+    Pane {
+        anchors.bottom: parent.bottom
+
+        ColumnLayout {
+            RowLayout {
+                Label {
+                    text: "items count:"
+                }
+
+                Slider {
+                    id: itemsCountSlider
+
+                    from: 5
+                    to: 100
+                    stepSize: 1
+
+                    value: 10
+                }
+
+                Label {
+                    text: `(${itemsCountSlider.value})`
+                }
+            }
+
+            RowLayout {
+                Label {
+                    text: "margins:"
+                }
+
+                Slider {
+                    id: marginsSlider
+
+                    from: -1
+                    to: 100
+                    stepSize: 1
+
+                    value: 10
+                }
+
+                Label {
+                    text: `(${marginsSlider.value})`
+                }
+            }
+
+            CheckBox {
+                id: centerInParentCheckBox
+
+                checked: true
+                text: "Center in parent"
+            }
+
+            CheckBox {
+                id: workAroundCheckBox
+
+                checked: true
+                text: "Use workaround for " +
+                      `<a href="${bugLink}">${bugLink}</a>` +
+                      " (not needed in Qt 6)"
+
+                contentItem: Label {
+                     text: parent.text
+                     font: parent.font
+                     verticalAlignment: Text.AlignVCenter
+                     leftPadding: parent.indicator.width + parent.spacing
+
+                     onLinkActivated: Qt.openUrlExternally(link)
+                 }
+            }
+
+            RowLayout {
+                Label {
+                    text: "parent:"
+                }
+
+                RadioButton {
+                    id: pageRootRadioButton
+
+                    text: "page root"
+                    checked: true
+                }
+
+                RadioButton {
+                    id: overlayRadioButton
+
+                    text: "overlay"
+                }
+
+                RadioButton {
+                    id: draggableRadioButton
+
+                    text: "draggable item"
+                }
+            }
+        }
+    }
+
+    Pane {
+        anchors.left: parent.left
+        anchors.right: parent.right
+
+        z: -1
+
+        Label {
+            anchors.fill: parent
+
+            wrapMode: Text.Wrap
+
+            textFormat: Text.MarkdownText
+            text: `Conclusions:
+
+* When component size depends on both content and screen position, it is
+  important to set both **Layout.fillHeight: true** and
+  **Layout.preferredHeight** for a variable height component.
+* There is a bug in Qt causing the default height calculation mechanism doesn't
+  work properly in Qt 5.15 (it's ok in Qt 6). The proposed solution works
+  transparently and does not change other aspects of behavior.
+* The value **margins: -1** has a special meaning and changes the behavior of
+  the popup when **anchors.centerIn** is not used. Causes the popup to never be
+  positioned higher than the given position, regardless of the amount of space
+  available (probably undesirable behavior in most cases).
+`
+        }
+    }
+}

--- a/ui/StatusQ/src/StatusQ/Controls/StatusDropdown.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusDropdown.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.13
-import QtGraphicalEffects 1.13
-import QtQuick.Controls 2.14 as QC
+import QtQuick 2.15
+import QtGraphicalEffects 1.15
+import QtQuick.Controls 2.15 as QC
 
 import StatusQ.Core.Theme 0.1
 
@@ -28,16 +28,17 @@ import StatusQ.Core.Theme 0.1
    For a list of components available see StatusQ.
 */
 QC.Popup {
+    id: root
+
     dim: false
     closePolicy: QC.Popup.CloseOnPressOutside | QC.Popup.CloseOnEscape
     background: Rectangle {
-       id: border
        color: Theme.palette.statusMenu.backgroundColor
        radius: 8
        border.color: "transparent"
        layer.enabled: true
        layer.effect: DropShadow {
-           source: border
+           source: root.background
            horizontalOffset: 0
            verticalOffset: 4
            radius: 12
@@ -45,5 +46,22 @@ QC.Popup {
            spread: 0.2
            color: Theme.palette.dropShadow
        }
+    }
+
+    // workaround for https://bugreports.qt.io/browse/QTBUG-87804
+    Binding on margins{
+        id: workaroundBinding
+
+        when: false
+    }
+
+    Connections {
+        target: root.contentItem
+
+        function onImplicitHeightChanged() {
+            workaroundBinding.value = root.margins + 1
+            workaroundBinding.when = true
+            workaroundBinding.when = false
+        }
     }
 }

--- a/ui/app/AppLayouts/Chat/controls/community/MembersDropdown.qml
+++ b/ui/app/AppLayouts/Chat/controls/community/MembersDropdown.qml
@@ -22,8 +22,6 @@ StatusDropdown {
 
     readonly property alias searchText: filterInput.text
 
-    property bool fixedYPosition: !anchors.centerIn && margins < 0
-
     enum Mode {
         Add, Update
     }
@@ -34,10 +32,6 @@ StatusDropdown {
     signal addButtonClicked
 
     width: 295
-
-    height: Math.min(
-                d.availableExternalHeight,
-                content.requestedHeight + d.vPadding)
 
     padding: 11
     bottomInset: 10
@@ -53,13 +47,7 @@ StatusDropdown {
 
         readonly property int sectionDelegateHeight: 40
         readonly property int delegateHeight: 47
-
-        readonly property int vPadding: root.topPadding + root.bottomPadding
         readonly property int scrollBarWidth: 4
-
-        readonly property int availableExternalHeight:
-            (root.Overlay.overlay ? root.Overlay.overlay.height : 0) - root.bottomMargin -
-            (root.fixedYPosition ? contentItem.parent.y : root.topMargin)
     }
 
     contentItem: ColumnLayout {
@@ -68,14 +56,6 @@ StatusDropdown {
         spacing: 8
         height: root.availableHeight
         clip: true
-
-        readonly property int requestedHeight:
-            backButton.height +
-            spacing + filterInput.height +
-            spacing + (listView.count
-                       ? Math.min(listView.contentHeight, root.maximumListHeight)
-                       : noContactsText.Layout.preferredHeight) +
-            spacing + addButton.height
 
         StatusIconTextButton {
             id: backButton
@@ -132,6 +112,8 @@ StatusDropdown {
 
             Layout.fillWidth: true
             Layout.fillHeight: true
+            Layout.preferredHeight: Math.min(contentHeight,
+                                             root.maximumListHeight)
 
             verticalScrollBar {
                 implicitWidth: d.scrollBarWidth + ScrollBar.vertical.padding * 2


### PR DESCRIPTION
### What does the PR do

- Adds `PopupSizing` page to storybook clarifying issues related to popup's height calculation and positioning
- Added workaround for https://bugreports.qt.io/browse/QTBUG-87804 to `StatusDropdown`
- `MembersDropdown` implementation simplified, no "manual" height calculation

Closes: https://github.com/status-im/status-desktop/issues/10661

### Affected areas
`StatusDropdown`, `MembersDropdown`

### Screenshot of functionality (including design for comparison)

![Screenshot from 2023-05-12 14-45-00](https://github.com/status-im/status-desktop/assets/20650004/f23b85ac-8239-4650-81c7-db7dc61de8b8)
