### PR TITLE
fix(Community): Fix community channel admin flag

### DIFF
--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -583,6 +583,9 @@ method addNewChat*(
     chatImage = chatDto.icon
 
   var amIChatAdmin = self.amIMarkedAsAdminUser(chatDto.members)
+  if not amIChatAdmin and len(chatDto.communityId) != 0:
+    let community = communityService.getCommunityById(chatDto.communityId)
+    amIChatAdmin = amIChatAdmin or community.admin
   if chatDto.chatType != ChatType.PrivateGroupChat:
     amIChatAdmin = amIChatAdmin or channelGroup.admin
 


### PR DESCRIPTION
Fixes: #10382

### What does the PR do

When user crates new channel it returns without `members` from status-go. But community admin can remove channel anyway so I add the check if user is community admin.

### Affected areas

Community

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

