### PR TITLE
fix(StatusDropdown):  added to Binding to avoid warning (QTBUG-81787)

### DIFF
--- a/ui/StatusQ/src/StatusQ/Controls/StatusDropdown.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusDropdown.qml
@@ -1,6 +1,7 @@
 import QtQuick 2.15
 import QtGraphicalEffects 1.15
 import QtQuick.Controls 2.15 as QC
+import QtQml 2.15
 
 import StatusQ.Core.Theme 0.1
 
@@ -53,6 +54,7 @@ QC.Popup {
         id: workaroundBinding
 
         when: false
+        restoreMode: Binding.RestoreBindingOrValue
     }
 
     Connections {


### PR DESCRIPTION
### What does the PR do

Follow up to https://github.com/status-im/status-desktop/pull/10664 because of https://github.com/status-im/status-desktop/pull/10664#issuecomment-1545890322

### Affected areas
`StatusDropdown`

### Screenshot of functionality (including design for comparison)

![Screenshot from 2023-05-12 19-52-57](https://github.com/status-im/status-desktop/assets/20650004/771c31c4-0c92-4cf2-aaa1-538e79cf0fbd)

