### PR TITLE
fix(desktop/wallet): Fixed `Save` button not enabled when ENS name

### DIFF
--- a/test/ui-test/testSuites/suite_wallet/shared/steps/walletSteps.py
+++ b/test/ui-test/testSuites/suite_wallet/shared/steps/walletSteps.py
@@ -25,7 +25,7 @@ def step(context):
 @When("the user opens wallet section")
 def step(context):
     wallet_init_steps.the_user_opens_wallet_screen()
-    
+
 @When("the user clicks on the default wallet account")
 def step(context):
     _walletScreen.click_default_wallet_account()
@@ -63,7 +63,7 @@ def step(context, keypair_name, name, color, emoji, password, index, order, is_e
     _walletScreen.add_account_popup_change_account_color(color)
     _walletScreen.add_account_popup_change_account_emoji(emoji)
     if keypair_name != NOT_APPLICABLE:
-        _walletScreen.add_account_popup_change_origin_by_keypair_name(keypair_name)    
+        _walletScreen.add_account_popup_change_origin_by_keypair_name(keypair_name)
     _walletScreen.add_account_popup_open_edit_derivation_path_section(password)
     _walletScreen.add_account_popup_change_derivation_path(index, order, is_ethereum_root)
     _walletScreen.add_account_popup_do_primary_action()
@@ -110,7 +110,7 @@ def step(context, name, new_name, new_color, new_emoji):
     _walletScreen.add_account_popup_change_account_color(new_color)
     _walletScreen.add_account_popup_change_account_emoji(new_emoji)
     _walletScreen.add_account_popup_do_primary_action()
-    
+
 @When("the user removes an account with name \"|any|\" and path \"|any|\" using password \"|any|\" and test cancel \"|any|\"")
 def step(context, name, path, password, test_cancel):
     _walletScreen.click_option_from_right_click_menu_of_account_with_name(MainWalletRightClickMenu.DELETE_ACCOUNT_ACTION_PLACEHOLDER.value, name)
@@ -119,15 +119,19 @@ def step(context, name, path, password, test_cancel):
         _walletScreen.remove_account_popup_do_cancel_action()
         _walletScreen.click_option_from_right_click_menu_of_account_with_name(MainWalletRightClickMenu.DELETE_ACCOUNT_ACTION_PLACEHOLDER.value, name)
         _walletScreen.remove_account_popup_verify_account_account_to_be_removed(name, path)
-    _walletScreen.remove_account_popup_do_remove_action(True if path != NOT_APPLICABLE else False, password)    
-    
+    _walletScreen.remove_account_popup_do_remove_action(True if path != NOT_APPLICABLE else False, password)
+
 @When("the user sends a transaction to himself from account \"|any|\" of \"|any|\" \"|any|\" on \"|any|\" with password \"|any|\"")
 def step(context, account_name, amount, token, chain_name, password):
     _walletScreen.send_transaction(account_name, amount, token, chain_name, password)
-    
+
 @When("the user adds a saved address named \"|any|\" and address \"|any|\"")
 def step(context, name, address):
     _walletScreen.add_saved_address(name, address)
+
+@When("the user adds a saved address named \"|any|\" and ENS name \"|any|\"")
+def step(context, name, ens_name):
+    _walletScreen.add_saved_address(name, ens_name)
 
 @When("the user edits a saved address with name \"|any|\" to \"|any|\"")
 def step(context, name, new_name):
@@ -153,11 +157,11 @@ def step(context, network_name):
 @Then("the account is correctly displayed with \"|any|\" and \"|any|\" and emoji unicode \"|any|\"")
 def step(context, name, color, emoji_unicode):
     _walletScreen.verify_account_existence(name, color, emoji_unicode)
-    
+
 @Then("settings keycard section is opened")
 def step(context):
     _walletScreen.verify_keycard_settings_is_opened()
-        
+
 @Then("the account with \"|any|\" is not displayed")
 def step(context, name):
     _walletScreen.verify_account_doesnt_exist(name)
@@ -170,27 +174,27 @@ def step(context, symbol):
 @Then("the transaction is in progress")
 def step(context):
     _walletScreen.verify_transaction()
-    
+
 @Then("the name \"|any|\" is in the list of saved addresses")
 def step(context, name: str):
-    _walletScreen.verify_saved_address_exists(name) 
-    
+    _walletScreen.verify_saved_address_exists(name)
+
 @Then("the name \"|any|\" is not in the list of saved addresses")
 def step(context, name: str):
-    _walletScreen.verify_saved_address_doesnt_exist(name)     
-    
+    _walletScreen.verify_saved_address_doesnt_exist(name)
+
 @Then("the collectibles are listed for the |any|")
 def step(context, account_name: str):
-    _walletScreen.verify_collectibles_exist(account_name)    
-    
+    _walletScreen.verify_collectibles_exist(account_name)
+
 @Then("the transactions are listed for the added account")
 def step(context):
     _walletScreen.verify_transactions_exist()
-    
+
 @Then("the saved address \"|any|\" has favourite status \"|any|\"")
 def step(context, name, favourite):
     _walletScreen.check_favourite_status_for_saved_address(name, str_to_bool(favourite))
-    
+
 ###########################################################################
 ### COMMON methods used in different steps given/when/then region:
-########################################################################### 
+###########################################################################

--- a/test/ui-test/testSuites/suite_wallet/tst_wallet/test.feature
+++ b/test/ui-test/testSuites/suite_wallet/tst_wallet/test.feature
@@ -22,13 +22,16 @@ Feature: Status Desktop Wallet
         When the user deletes the saved address with name "<new_name>"
         Then the name "<new_name>" is not in the list of saved addresses
 
+        When the user adds a saved address named "<name>" and ENS name "<ens_name>"
+        Then the name "<name>" is in the list of saved addresses
+
         # Test for toggling favourite button is disabled until favourite functionality is enabled
         # When the user adds a saved address named "<name>" and address "<address>"
         # And the user toggles favourite for the saved address with name "<name>"
         # Then the saved address "<name>" has favourite status "true"
         Examples:
-            | name | address                                    | new_name |
-            | bar  | 0x8397bc3c5a60a1883174f722403d63a8833312b7 | foo      |
+            | name | address                                    | new_name | ens_name |
+            | bar  | 0x8397bc3c5a60a1883174f722403d63a8833312b7 | foo      | status.eth |
 
 
 	#############################################

--- a/ui/app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml
+++ b/ui/app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml
@@ -45,13 +45,13 @@ StatusDialog {
         readonly property int validationMode: root.edit ?
                                          StatusInput.ValidationMode.Always
                                        : StatusInput.ValidationMode.OnlyWhenDirty
-        readonly property bool valid: addressInput.valid && nameInput.valid && root.address !== Constants.zeroAddress
+        readonly property bool valid: addressInput.valid && nameInput.valid
         property bool chainShortNamesDirty: false
         readonly property bool dirty: nameInput.input.dirty || chainShortNamesDirty
 
         readonly property var chainPrefixRegexPattern: /[^:]+\:?|:/g
         readonly property string visibleAddress: root.address == Constants.zeroAddress ? "" : root.address
-        readonly property bool addressInputIsENS: !visibleAddress
+        readonly property bool addressInputIsENS: !!root.ens
 
         /// Ensures that the \c root.address and \c root.chainShortNames are not reset when the initial text is set
         property bool initialized: false
@@ -135,7 +135,7 @@ StatusDialog {
                 StatusValidator {
                     errorMessage: addressInput.plainText ? qsTr("Please enter a valid address or ENS name.") : ""
                     validate: function (t) {
-                        return Utils.isValidAddressWithChainPrefix(t) || Utils.isValidEns(t)
+                        return t !== Constants.zeroAddress && (Utils.isValidAddressWithChainPrefix(t) || Utils.isValidEns(t))
                             ? true : { actual: t }
                     }
                 }


### PR DESCRIPTION
is entered in address input when adding a new saved address.

Fixes #10640

### What does the PR do

Fixes `Save` button not enabled when ENS name is entered in address input  when adding a new saved address.

### Affected areas

Wallet->Saved addresses

### Screenshot of functionality (including design for comparison)
![save_button_Active_on_saved_addresses_With_ens](https://github.com/status-im/status-desktop/assets/15627093/85a3d208-7690-4fcd-8d71-81576cb1dec1)

