### PR TITLE
fix(Airdrop): Navigation from community settings overview to airdrop option enabled

### DIFF
--- a/ui/app/AppLayouts/Chat/views/CommunitySettingsView.qml
+++ b/ui/app/AppLayouts/Chat/views/CommunitySettingsView.qml
@@ -205,7 +205,7 @@ StatusSectionLayout {
                                                              null)
                 }
 
-                onAirdropTokensClicked: { /* TODO in future */ }
+                onAirdropTokensClicked: root.goTo(Constants.CommunitySettingsSections.Airdrops)
                 onBackUpClicked: {
                     Global.openPopup(transferOwnershipPopup, {
                                          privateKey: root.chatCommunitySectionModule.exportCommunity(root.community.id),


### PR DESCRIPTION
Fixes #10659

### What does the PR do

It enables navigation from community settings overview to airdrop page.

### Affected areas

Community Settings / Overview - Airdrop

### Screenshot of functionality

https://github.com/status-im/status-desktop/assets/97019400/618c7176-0928-40c5-8643-220ea03a76b7

