### PR TITLE
fix(MessageView): Show correct name of who pinned the message

### DIFF
--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -394,7 +394,7 @@ Loader {
         StatusBaseText {
             width: parent.width - 120
             horizontalAlignment: Text.AlignHCenter
-            text: qsTr("%1 pinned a message").arg(quotedMessageAuthorDetailsDisplayName)
+            text: qsTr("%1 pinned a message").arg(senderDisplayName)
             color: Theme.palette.directColor3
             font.family: Theme.palette.baseFont.name
             font.pixelSize: Theme.primaryTextFontSize


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/10669

<img width="918" alt="image" src="https://github.com/status-im/status-desktop/assets/25482501/44637a93-73cc-4bd5-956b-6be13d4cf07a">
