### PR TITLE
fix(MessageView): Show header when prev message is system PinnedMessage

### DIFF
--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -490,6 +490,7 @@ Loader {
 
                 showHeader: root.shouldRepeatHeader || dateGroupLabel.visible || isAReply ||
                             root.prevMessageContentType === Constants.messageContentType.systemMessagePrivateGroupType ||
+                            root.prevMessageContentType === Constants.messageContentType.systemMessagePinnedMessage ||
                             root.senderId !== root.prevMessageSenderId
                 isActiveMessage: d.isMessageActive
                 topPadding: showHeader ? Style.current.halfPadding : 0


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/10689

<img width="825" alt="Screenshot 2023-05-15 at 15 18 30" src="https://github.com/status-im/status-desktop/assets/25482501/8800c216-491e-4225-b3de-2ec68afbcbe8">
