### PR TITLE
fix(desktop/wallet): fixed regex for derivation path as Qt 5.15 regex

### DIFF
--- a/ui/app/AppLayouts/Wallet/addaccount/panels/DerivationPathInput/Controller.qml
+++ b/ui/app/AppLayouts/Wallet/addaccount/panels/DerivationPathInput/Controller.qml
@@ -23,7 +23,8 @@ Item {
         id: d
 
         // d flag and named capture groups not supported in Qt 5.15. Use multiple regexes instead
-        readonly property var derivationPathRegex: /^m\/44[’|']\/?(?:(?<coin_type_h>.*?)[’|'])?(?<coin_type_s>.*?)(?:\/(?<account>.*?)[’|']?)?(?:\/(?<change>.*?))?((?:\/.*?)?)$/
+        // Captured groups:                                     ?<coin_type_h> ?<coin_type_s> ?<account> ?<change>
+        readonly property var derivationPathRegex: /^m\/44[’|']\/?(?:(.*?)[’|'])?(.*?)(?:\/(.*?)[’|']?)?(?:\/(.*?))?((?:\/.*?)?)$/
         // The expected characters before each group. Workaround to missing capture group offsets in Qt 5.15
         readonly property var offsets: [6, 0, 2, 2]
 


### PR DESCRIPTION
on Linux does not support named groups

### What does the PR do

Fixed regex for derivation path

### Affected areas

wallet->add new address -> custom derivation path

### Screenshot of functionality (including design for comparison)
![fixed_deriv_path_combobox](https://github.com/status-im/status-desktop/assets/15627093/7702497c-22b2-4441-beeb-5b2977a2fc06)

