### PR TITLE
fix(Chat): Allow receiving messages from non-contacts in 1-to-1

### DIFF
--- a/src/app_service/service/message/service.nim
+++ b/src/app_service/service/message/service.nim
@@ -271,11 +271,6 @@ QtObject:
         error "error: new message with an unknown chat type received", chatId=chatId
         continue
 
-      # Ignore 1-1 chats for which we are not contact
-      if(chats[i].chatType == ChatType.OneToOne and not self.contactService.getContactById(chatId).isContact):
-        continue
-
-      
       if self.chatService.getChatById(chats[i].id, showWarning = false).id == "":
         # Chat is not present in the chat cache. We need to add it first
         self.chatService.updateOrAddChat(chats[i])


### PR DESCRIPTION
Close #10522

### What does the PR do

Why do we need to remove this check here:

- There should be spam protection in status-go
- We need to receive CR messages in chat for non contacts

### Affected areas

Chat

### Screenshot of functionality (including design for comparison)

<img width="995" alt="Screenshot 2023-05-15 at 19 33 38" src="https://github.com/status-im/status-desktop/assets/2522130/c5736990-db8d-4e0d-953c-e06cc8875738">

