### PR TITLE
fix(replies): Blocks `jumpToMessage` for deleted and unknown messages

### DIFF
--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -552,7 +552,8 @@ Loader {
                 }
 
                 onReplyMessageClicked: {
-                    root.messageStore.messageModule.jumpToMessage(root.responseToMessageWithId)
+                    if (!root.quotedMessageDeleted && root.quotedMessageFrom)
+                        root.messageStore.messageModule.jumpToMessage(root.responseToMessageWithId)
                 }
 
                 onSenderNameClicked: {
@@ -666,7 +667,7 @@ Loader {
                         if (root.quotedMessageDeleted) {
                             return qsTr("Message deleted")
                         }
-                        if (!root.quotedMessageText && contentType !== StatusMessage.ContentType.Image) {
+                        if (!root.quotedMessageText && !root.quotedMessageFrom) {
                             return qsTr("Unknown message. Try fetching more messages")
                         }
                         return root.quotedMessageText


### PR DESCRIPTION
Fixes: #10614

### What does the PR do

Blocks `jumpToMessage` for deleted and unknown messages

### Affected areas

Reply messages

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

