### PR TITLE
fix(@desktop/wallet): Clicking "Send" button on saved address does not add it into recipient input on SendModal Fix/issue 10685

### DIFF
--- a/ui/imports/shared/stores/TransactionStore.qml
+++ b/ui/imports/shared/stores/TransactionStore.qml
@@ -36,6 +36,8 @@ QtObject {
     property var disabledChainIdsFromList: []
     property var disabledChainIdsToList: []
 
+    property var assets: walletSectionAssets.assets
+
     function addRemoveDisabledFromChain(chainID, isDisabled) {
         if(isDisabled) {
             if(!root.disabledChainIdsFromList.includes(chainID))

--- a/ui/imports/shared/views/RecipientView.qml
+++ b/ui/imports/shared/views/RecipientView.qml
@@ -171,6 +171,7 @@ Loader {
             input.edit.readOnly: !root.interactive
             multiline: false
             input.edit.textFormat: TextEdit.RichText
+            text: addressText
 
             input.rightComponent: RowLayout {
                 StatusButton {


### PR DESCRIPTION
fix(@desktop/wallet): Clicking "Send" button on saved address does not add it into recipient input on SendModal Fix/issue 10685

#10685 

### What does the PR do

Assigning the address from saved address was not handled properly fixed that.
Ens and Stickers also need to have token preselected, that was not working either so fixed that too

### Affected areas

SendModal (From SavedAddreses, ENS and Stickers)

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it


https://github.com/status-im/status-desktop/assets/60327365/5747c754-ae5a-416c-a04d-5d205264f075


