### PR TITLE
fix(StatusMessageReply): Fix clicking on sender

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusMessageReply.qml
+++ b/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusMessageReply.qml
@@ -62,6 +62,15 @@ Item {
             implicitHeight: messageLayout.implicitHeight
             implicitWidth: messageLayout.implicitWidth
 
+            MouseArea {
+                anchors.fill: parent
+                hoverEnabled: true
+                cursorShape: Qt.PointingHandCursor
+                onClicked: {
+                    root.messageClicked(mouse)
+                }
+            }
+
             ColumnLayout {
                 id: messageLayout
                 anchors.fill: parent
@@ -89,6 +98,19 @@ Item {
                         font.pixelSize: Theme.secondaryTextFontSize
                         font.weight: Font.Medium
                         text: replyDetails.amISender ? qsTr("You") : replyDetails.sender.displayName
+                        font.underline: mouseArea.containsMouse
+
+                        MouseArea {
+                            id: mouseArea
+                            anchors.fill: parent
+                            cursorShape: enabled ? Qt.PointingHandCursor : Qt.ArrowCursor
+                            acceptedButtons: Qt.LeftButton | Qt.RightButton
+                            enabled: root.profileClickable
+                            hoverEnabled: true
+                            onClicked: {
+                                root.replyProfileClicked(this, mouse)
+                            }
+                        }
                     }
                 }
                 Loader {
@@ -106,7 +128,6 @@ Item {
                         messageDetails: root.replyDetails
                     }
                 }
-
 
                 Loader {
                     Layout.fillWidth: true
@@ -147,15 +168,6 @@ Item {
                         isPreview: true
                         audioSource: replyDetails.messageContent
                     }
-                }
-            }
-
-            MouseArea {
-                anchors.fill: parent
-                hoverEnabled: true
-                cursorShape: Qt.PointingHandCursor
-                onClicked: {
-                    root.messageClicked(mouse)
                 }
             }
         }


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/10716

### What does the PR do

1. Move main `MouseArea` behind sender's `MouseArea`
2. Implemented clicking on sender's name

### Screenshot of functionality (including design for comparison)


https://github.com/status-im/status-desktop/assets/25482501/4e5939b2-016e-414d-a35e-8a9c272d3784

