### PR TITLE
fix(MessageContextMenu): Cleanup. Separate menu for profile. 

### DIFF
--- a/storybook/CMakeLists.txt
+++ b/storybook/CMakeLists.txt
@@ -67,7 +67,9 @@ add_executable(
 
 target_compile_definitions(${PROJECT_NAME} PRIVATE
         QML_IMPORT_ROOT="${CMAKE_CURRENT_LIST_DIR}"
-        STATUSQ_MODULE_IMPORT_PATH="${STATUSQ_MODULE_IMPORT_PATH}")
+        STATUSQ_MODULE_IMPORT_PATH="${STATUSQ_MODULE_IMPORT_PATH}"
+        $<$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>:QT_QML_DEBUG>
+    )
 
 target_link_libraries(
     ${PROJECT_LIB} PUBLIC Qt5::Core Qt5::Gui Qt5::Quick Qt5::QuickControls2)

--- a/storybook/PagesModel.qml
+++ b/storybook/PagesModel.qml
@@ -62,6 +62,10 @@ ListModel {
         section: "Views"
     }
     ListElement {
+        title: "MessageContextMenu"
+        section: "Views"
+    }
+    ListElement {
          title: "StatusCommunityCard"
          section: "Panels"
     }

--- a/storybook/pages/MessageContextMenuPage.qml
+++ b/storybook/pages/MessageContextMenuPage.qml
@@ -1,0 +1,76 @@
+import QtQuick 2.14
+import QtQuick.Controls 2.14
+import QtQuick.Layouts 1.14
+
+import StatusQ.Controls 0.1
+import StatusQ.Core.Theme 0.1
+import StatusQ.Components 0.1
+
+import AppLayouts.Chat.views.communities 1.0
+
+import Storybook 1.0
+import Models 1.0
+
+import utils 1.0
+import shared.views.chat 1.0
+
+SplitView {
+
+    QtObject {
+        id: d
+    }
+
+    Logs { id: logs }
+
+    SplitView {
+        orientation: Qt.Vertical
+        SplitView.fillWidth: true
+
+        Rectangle {
+            SplitView.fillWidth: true
+            SplitView.fillHeight: true
+            color: Theme.palette.statusAppLayout.rightPanelBackgroundColor
+            clip: true
+
+            StatusButton {
+                anchors.centerIn: parent
+                text: "Open menu"
+                onClicked: {
+                    messageContextMenu.open()
+                }
+            }
+
+            MessageContextMenuView {
+                id: messageContextMenu
+                anchors.centerIn: parent
+                visible: true
+                modal: false
+                closePolicy: Popup.NoAutoClose
+                hideDisabledItems: false
+            }
+        }
+
+        LogsAndControlsPanel {
+            id: logsAndControlsPanel
+
+            SplitView.minimumHeight: 100
+            SplitView.preferredHeight: 150
+
+            logsView.logText: logs.logText
+        }
+    }
+
+    Pane {
+        SplitView.minimumWidth: 300
+        SplitView.preferredWidth: 300
+
+        ScrollView {
+            anchors.fill: parent
+
+            ColumnLayout {
+                spacing: 16
+
+            }
+        }
+    }
+}

--- a/storybook/pages/MessageContextMenuPage.qml
+++ b/storybook/pages/MessageContextMenuPage.qml
@@ -32,21 +32,76 @@ SplitView {
             color: Theme.palette.statusAppLayout.rightPanelBackgroundColor
             clip: true
 
-            StatusButton {
+            RowLayout {
                 anchors.centerIn: parent
-                text: "Open menu"
-                onClicked: {
-                    messageContextMenu.open()
+                Button {
+                    text: "Message context menu"
+                    onClicked: {
+                        menu1.createObject(this).popup()
+                    }
+                }
+                Button {
+                    text: "Message context menu (hide disabled items)"
+                    onClicked: {
+                        menu2.createObject(this).popup()
+                    }
+                }
+                Button {
+                    text: "Profile context menu"
+                    onClicked: {
+                        menu3.createObject(this).popup()
+                    }
+                }
+                Button {
+                    text: "Profile context menu (hide disabled items)"
+                    onClicked: {
+                        menu4.createObject(this).popup()
+                    }
                 }
             }
 
-            MessageContextMenuView {
-                id: messageContextMenu
-                anchors.centerIn: parent
-                visible: true
-                modal: false
-                closePolicy: Popup.NoAutoClose
-                hideDisabledItems: false
+            Component {
+                id: menu1
+                MessageContextMenuView {
+                    anchors.centerIn: parent
+                    hideDisabledItems: false
+                    onClosed: {
+                        destroy()
+                    }
+                }
+            }
+
+            Component {
+                id: menu2
+                MessageContextMenuView {
+                    anchors.centerIn: parent
+                    hideDisabledItems: true
+                    onClosed: {
+                        destroy()
+                    }
+                }
+            }
+
+            Component {
+                id: menu3
+                ProfileContextMenu {
+                    anchors.centerIn: parent
+                    hideDisabledItems: false
+                    onClosed: {
+                        destroy()
+                    }
+                }
+            }
+
+            Component {
+                id: menu4
+                ProfileContextMenu {
+                    anchors.centerIn: parent
+                    hideDisabledItems: true
+                    onClosed: {
+                        destroy()
+                    }
+                }
             }
         }
 

--- a/storybook/pages/UserListPanelPage.qml
+++ b/storybook/pages/UserListPanelPage.qml
@@ -66,7 +66,6 @@ SplitView {
 
             sourceComponent: UserListPanel {
                 usersModel: model
-                messageContextMenu: null
                 label: "Some label"
             }
         }

--- a/ui/StatusQ/src/StatusQ/Popups/StatusMenu.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/StatusMenu.qml
@@ -71,7 +71,7 @@ Menu {
     closePolicy: Popup.CloseOnPressOutside | Popup.CloseOnEscape
     topPadding: 8
     bottomPadding: 8
-    bottomMargin: 16
+    margins: 16
 
     onOpened: {
         if (typeof openHandler === "function") {

--- a/ui/app/AppLayouts/Chat/panels/UserListPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/UserListPanel.qml
@@ -8,16 +8,16 @@ import StatusQ.Components 0.1
 import shared 1.0
 import shared.panels 1.0
 import shared.status 1.0
+import shared.views.chat 1.0
 import utils 1.0
 
 import SortFilterProxyModel 0.2
 
 Item {
     id: root
-    anchors.fill: parent
 
+    property var store
     property var usersModel
-    property var messageContextMenu
     property string label
 
     StatusBaseText {
@@ -98,15 +98,13 @@ Item {
                 ringSettings.ringSpecModel: model.colorHash
                 onClicked: {
                     if (mouse.button === Qt.RightButton) {
-                        // Set parent, X & Y positions for the messageContextMenu
-                        messageContextMenu.parent = this
-                        messageContextMenu.isProfile = true
-                        messageContextMenu.myPublicKey = userProfile.pubKey
-                        messageContextMenu.selectedUserPublicKey = model.pubKey
-                        messageContextMenu.selectedUserDisplayName = title
-                        messageContextMenu.selectedUserIcon = model.icon
-                        messageContextMenu.popup(4, 4)
-                    } else if (mouse.button === Qt.LeftButton && !!messageContextMenu) {
+                        Global.openMenu(profileContextMenuComponent, this, {
+                                            myPublicKey: userProfile.pubKey,
+                                            selectedUserPublicKey: model.pubKey,
+                                            selectedUserDisplayName: title,
+                                            selectedUserIcon: model.icon,
+                                        })
+                    } else if (mouse.button === Qt.LeftButton) {
                         Global.openProfilePopup(model.pubKey);
                     }
                 }
@@ -133,6 +131,25 @@ Item {
                             return qsTr("Inactive")
                     }
                 }
+            }
+        }
+    }
+
+    Component {
+        id: profileContextMenuComponent
+
+        ProfileContextMenu {
+            store: root.store
+            margins: 8
+            onOpenProfileClicked: {
+                Global.openProfilePopup(publicKey, null)
+            }
+            onCreateOneToOneChat: {
+                Global.changeAppSectionBySectionType(Constants.appSection.chat)
+                root.store.chatCommunitySectionModule.createOneToOneChat(communityId, chatId, ensName)
+            }
+            onClosed: {
+                destroy()
             }
         }
     }

--- a/ui/app/AppLayouts/Chat/panels/communities/CommunityMembersSettingsPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/CommunityMembersSettingsPanel.qml
@@ -21,12 +21,10 @@ SettingsPageLayout {
     property var pendingMemberRequestsModel
     property var declinedMemberRequestsModel
     property string communityName
-    property var communityMemberContextMenu
 
     property bool editable: true
 
     signal membershipRequestsClicked()
-    signal userProfileClicked(string id)
     signal kickUserClicked(string id)
     signal banUserClicked(string id)
     signal unbanUserClicked(string id)
@@ -120,7 +118,6 @@ SettingsPageLayout {
                 Layout.fillWidth: true
                 Layout.fillHeight: true
 
-                onUserProfileClicked: root.userProfileClicked(id)
                 onKickUserClicked: {
                     kickModal.userNameToKick = name
                     kickModal.userIdToKick = id
@@ -151,7 +148,6 @@ SettingsPageLayout {
                 Layout.fillWidth: true
                 Layout.fillHeight: true
 
-                onUserProfileClicked: root.userProfileClicked(id)
                 onAcceptRequestToJoin: root.acceptRequestToJoin(id)
                 onDeclineRequestToJoin: root.declineRequestToJoin(id)
             }
@@ -173,7 +169,6 @@ SettingsPageLayout {
                 Layout.fillWidth: true
                 Layout.fillHeight: true
 
-                onUserProfileClicked: root.userProfileClicked(id)
                 onAcceptRequestToJoin: root.acceptRequestToJoin(id)
             }
 
@@ -194,7 +189,6 @@ SettingsPageLayout {
                 Layout.fillWidth: true
                 Layout.fillHeight: true
 
-                onUserProfileClicked: root.userProfileClicked(id)
                 onUnbanUserClicked: root.unbanUserClicked(id)
             }
         }

--- a/ui/app/AppLayouts/Chat/panels/communities/CommunityMembersTabPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/CommunityMembersTabPanel.qml
@@ -9,6 +9,7 @@ import StatusQ.Components 0.1
 import StatusQ.Popups 0.1
 
 import utils 1.0
+import shared.views.chat 1.0
 import shared.controls.chat 1.0
 
 import "../../layouts"
@@ -20,7 +21,6 @@ Item {
     property var model
     property var communityMemberContextMenu
 
-    signal userProfileClicked(string id)
     signal kickUserClicked(string id, string name)
     signal banUserClicked(string id, string name)
     signal unbanUserClicked(string id)
@@ -146,17 +146,37 @@ Item {
 
                 onClicked: {
                     if(mouse.button === Qt.RightButton) {
-                        // Set parent, X & Y positions for the messageContextMenu
-                        root.communityMemberContextMenu.parent = this
-                        root.communityMemberContextMenu.isProfile = true
-                        root.communityMemberContextMenu.selectedUserPublicKey = model.pubKey
-                        root.communityMemberContextMenu.selectedUserDisplayName = userName
-                        root.communityMemberContextMenu.selectedUserIcon = asset.name
-                        root.communityMemberContextMenu.popup()
+                        Global.openMenu(memberContextMenuComponent, this, {
+                                            selectedUserPublicKey: model.pubKey,
+                                            selectedUserDisplayName: userName,
+                                            selectedUserIcon: asset.name,
+                                        })
                     } else {
-                        root.userProfileClicked(model.pubKey)
+                        Global.openProfilePopup(model.pubKey)
                     }
                 }
+            }
+        }
+    }
+
+    Component {
+        id: memberContextMenuComponent
+
+        ProfileContextMenu {
+            id: memberContextMenuView
+            store: root.rootStore
+            amIChatAdmin: root.rootStore.amIChatAdmin()
+            myPublicKey: root.rootStore.myPublicKey()
+
+            onOpenProfileClicked: {
+                Global.openProfilePopup(publicKey, null)
+            }
+            onCreateOneToOneChat: {
+                Global.changeAppSectionBySectionType(Constants.appSection.chat)
+                root.rootStore.chatCommunitySectionModule.createOneToOneChat(communityId, chatId, ensName)
+            }
+            onClosed: {
+                destroy()
             }
         }
     }

--- a/ui/app/AppLayouts/Chat/panels/communities/CommunityMembersTabPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/CommunityMembersTabPanel.qml
@@ -165,7 +165,6 @@ Item {
         ProfileContextMenu {
             id: memberContextMenuView
             store: root.rootStore
-            amIChatAdmin: root.rootStore.amIChatAdmin()
             myPublicKey: root.rootStore.myPublicKey()
 
             onOpenProfileClicked: {

--- a/ui/app/AppLayouts/Chat/popups/PinnedMessagesPopup.qml
+++ b/ui/app/AppLayouts/Chat/popups/PinnedMessagesPopup.qml
@@ -168,9 +168,6 @@ StatusDialog {
             store: root.store
             pinnedPopup: true
             pinnedMessage: true
-            onShouldCloseParentPopup: {
-                root.close()
-            }
 
             onUnpinMessage: {
                 root.messageStore.unpinMessage(messageId)
@@ -178,6 +175,8 @@ StatusDialog {
 
             onJumpToMessage: {
                 root.messageStore.messageModule.jumpToMessage(messageId)
+                close()
+                root.close()
             }
         }
 

--- a/ui/app/AppLayouts/Chat/popups/PinnedMessagesPopup.qml
+++ b/ui/app/AppLayouts/Chat/popups/PinnedMessagesPopup.qml
@@ -131,22 +131,21 @@ StatusDialog {
                     z: 55
                     acceptedButtons: Qt.LeftButton | Qt.RightButton
                     onClicked: (mouse) => {
-                        if (mouse.button === Qt.RightButton) {
-                            Global.openMenu(pinnedPopupMessageContextMenuComponent, this, {
-                                                messageId: messageItem.messageId,
-                                            })
-                            return
-                        }
-
-                        if (mouse.button === Qt.LeftButton) {
-                           if (!!root.messageToPin) {
-                               if (!radio.checked)
-                               radio.checked = true
-                           } else {
-                               d.jumpToMessage(model.id)
-                           }
-                           return
-                       }
+                                   switch (mouse.button) {
+                                       case Qt.RightButton:
+                                           Global.openMenu(pinnedPopupMessageContextMenuComponent, this, {
+                                                               messageId: messageItem.messageId,
+                                                           })
+                                           break
+                                       case Qt.LeftButton:
+                                           if (!!root.messageToPin) {
+                                               if (!radio.checked)
+                                                radio.checked = true
+                                           } else {
+                                               d.jumpToMessage(model.id)
+                                           }
+                                           break
+                                   }
                     }
                 }
 

--- a/ui/app/AppLayouts/Chat/popups/PinnedMessagesPopup.qml
+++ b/ui/app/AppLayouts/Chat/popups/PinnedMessagesPopup.qml
@@ -7,6 +7,7 @@ import QtGraphicalEffects 1.14
 import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
 import StatusQ.Controls 0.1
+import StatusQ.Popups 0.1
 import StatusQ.Popups.Dialog 0.1
 
 import utils 1.0
@@ -132,17 +133,7 @@ StatusDialog {
                     onClicked: (mouse) => {
                         if (mouse.button === Qt.RightButton) {
                             Global.openMenu(pinnedPopupMessageContextMenuComponent, this, {
-                                                myPublicKey: userProfile.pubKey,
-                                                amIChatAdmin: root.amIChatAdmin,
-                                                pinMessageAllowedForMembers: messageStore.isPinMessageAllowedForMembers,
-                                                chatType: root.messageStore.chatType,
                                                 messageId: messageItem.messageId,
-                                                unparsedText: messageItem.unparsedText,
-                                                messageSenderId: messageItem.senderId,
-                                                messageContentType: messageItem.messageContentType,
-                                                pinnedMessage: messageItem.pinnedMessage,
-                                                canPin: !!messageItem.messageStore && messageItem.messageStore.getNumberOfPinnedMessages() < Constants.maxNumberOfPins,
-                                                editRestricted: messageItem.isSticker || messageItem.isImage,
                                             })
                             return
                         }
@@ -192,18 +183,29 @@ StatusDialog {
                 Component {
                     id: pinnedPopupMessageContextMenuComponent
 
-                    MessageContextMenuView {
-                        store: root.store
-                        pinnedPopup: true
-                        pinnedMessage: true
+                    StatusMenu {
+                        id: messageContextMenu
 
-                        onUnpinMessage: {
-                            root.messageStore.unpinMessage(messageId)
+                        property string messageId
+
+                        StatusAction {
+                            text: qsTr("Unpin")
+                            icon.name: "unpin"
+                            onTriggered: {
+                                root.messageStore.unpinMessage(messageContextMenu.messageId)
+                                close()
+                            }
                         }
-                        onJumpToMessage: {
-                            close()
-                            d.jumpToMessage(messageId)
+
+                        StatusAction {
+                            text: qsTr("Jump to")
+                            icon.name: "arrow-up"
+                            onTriggered: {
+                                d.jumpToMessage(messageContextMenu.messageId)
+                                close()
+                            }
                         }
+
                         onOpened: {
                             messageItem.setMessageActive(model.id, true)
                         }

--- a/ui/app/AppLayouts/Chat/stores/MessageStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/MessageStore.qml
@@ -124,6 +124,13 @@ QtObject {
         messageModule.deleteMessage(messageId)
     }
 
+    function warnAndDeleteMessage(messageId) {
+        if (localAccountSensitiveSettings.showDeleteMessageWarning)
+            Global.openDeleteMessagePopup(messageId, this)
+        else
+            deleteMessage(messageId)
+    }
+
     function setEditModeOn(messageId) {
         if(!messageModule)
             return

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -209,16 +209,9 @@ QtObject {
         stickersModuleInst.send(channelId, hash, replyTo, pack, url)
     }
 
+    // TODO: This seems to be better in Utils.qml
     function copyToClipboard(text) {
         globalUtilsInst.copyToClipboard(text)
-    }
-
-    function copyImageToClipboardByUrl(content) {
-        globalUtilsInst.copyImageToClipboardByUrl(content)
-    }
-
-    function downloadImageByUrl(url, path) {
-        globalUtilsInst.downloadImageByUrl(url, path)
     }
 
     function isCurrentUser(pubkey) {

--- a/ui/app/AppLayouts/Chat/views/ChatContentView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatContentView.qml
@@ -124,21 +124,12 @@ ColumnLayout {
                 root.messageStore.toggleReaction(messageId, emojiId)
             }
 
-            onOpenProfileClicked: (publicKey) => {
-                Global.openProfilePopup(publicKey, null)
-            }
-
             onDeleteMessage: (messageId) => {
                 root.messageStore.warnAndDeleteMessage(messageId)
             }
 
             onEditClicked: (messageId) => {
                 root.messageStore.setEditModeOn(messageId)
-            }
-
-            onCreateOneToOneChat: (communityId, chatId, ensName) => {
-                Global.changeAppSectionBySectionType(Constants.appSection.chat)
-                root.rootStore.chatCommunitySectionModule.createOneToOneChat("", chatId, ensName)
             }
 
             onShowReplyArea: (messageId) => {

--- a/ui/app/AppLayouts/Chat/views/ChatContentView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatContentView.qml
@@ -88,55 +88,6 @@ ColumnLayout {
         }
     }
 
-    Loader {
-        id: contextMenuLoader
-        active: root.isActiveChannel
-        asynchronous: true
-
-        // FIXME: `MessageContextMenuView` is way too heavy
-        // see: https://github.com/status-im/status-desktop/pull/10343#issuecomment-1515103756
-        sourceComponent: MessageContextMenuView {
-            store: root.rootStore
-            reactionModel: root.rootStore.emojiReactionsModel
-            disabledForChat: !root.rootStore.isUserAllowedToSendMessage
-
-            onPinMessage: (messageId) => {
-                root.messageStore.pinMessage(messageId)
-            }
-
-            onUnpinMessage: (messageId) => {
-                root.messageStore.unpinMessage(messageId)
-            }
-
-            onPinnedMessagesLimitReached: (messageId) => {
-                if (!root.chatContentModule) {
-                    console.warn("error on open pinned messages limit reached from message context menu - chat content module is not set")
-                    return
-                }
-                Global.openPinnedMessagesPopupRequested(root.rootStore,
-                                                        root.messageStore,
-                                                        root.chatContentModule.pinnedMessagesModel,
-                                                        messageId,
-                                                        root.chatId)
-            }
-
-            onToggleReaction: (messageId, emojiId) => {
-                root.messageStore.toggleReaction(messageId, emojiId)
-            }
-
-            onDeleteMessage: (messageId) => {
-                root.messageStore.warnAndDeleteMessage(messageId)
-            }
-
-            onEditClicked: (messageId) => {
-                root.messageStore.setEditModeOn(messageId)
-            }
-
-            onShowReplyArea: (messageId) => {
-                d.showReplyArea(messageId)
-            }
-        }
-    }
     ColumnLayout {
         Layout.fillWidth: true
         Layout.fillHeight: true
@@ -151,13 +102,12 @@ ColumnLayout {
                 chatContentModule: root.chatContentModule
                 rootStore: root.rootStore
                 contactsStore: root.contactsStore
-                messageContextMenu: contextMenuLoader.item
                 messageStore: root.messageStore
                 emojiPopup: root.emojiPopup
                 stickersPopup: root.stickersPopup
                 usersStore: root.usersStore
                 stickersLoaded: root.stickersLoaded
-                publicKey: root.chatId
+                chatId: root.chatId
                 isOneToOne: root.chatType === Constants.chatType.oneToOne
                 isChatBlocked: root.isBlocked || !root.isUserAllowedToSendMessage
                 channelEmoji: !chatContentModule ? "" : (chatContentModule.chatDetails.emoji || "")

--- a/ui/app/AppLayouts/Chat/views/ChatContentView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatContentView.qml
@@ -111,7 +111,7 @@ ColumnLayout {
             }
 
             onDeleteMessage: {
-                messageStore.deleteMessage(messageId)
+                messageStore.warnAndDeleteMessage(messageId)
             }
 
             onEditClicked: messageStore.setEditModeOn(messageId)

--- a/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
@@ -33,14 +33,12 @@ Item {
     property var emojiPopup
     property var stickersPopup
 
-    property string publicKey: ""
+    property string chatId: ""
     property bool stickersLoaded: false
     property alias chatLogView: chatLogView
     property bool isChatBlocked: false
     property bool isOneToOne: false
     property bool isActiveChannel: false
-
-    property var messageContextMenu
 
     signal openStickerPackPopup(string stickerPackId)
     signal showReplyArea(string messageId, string author)
@@ -250,11 +248,12 @@ Item {
             emojiPopup: root.emojiPopup
             stickersPopup: root.stickersPopup
             chatLogView: ListView.view
+            chatContentModule: root.chatContentModule
 
             isActiveChannel: root.isActiveChannel
             isChatBlocked: root.isChatBlocked
-            messageContextMenu: root.messageContextMenu
 
+            chatId: root.chatId
             messageId: model.id
             communityId: model.communityId
             responseToMessageWithId: model.responseToMessageWithId
@@ -373,7 +372,7 @@ Item {
             anchors.horizontalCenter: parent.horizontalCenter
             text: qsTr("Send Contact Request")
             onClicked: {
-                Global.openContactRequestPopup(root.publicKey, null)
+                Global.openContactRequestPopup(root.chatId, null)
             }
         }
     }
@@ -388,14 +387,14 @@ Item {
                 text: qsTr("Reject Contact Request")
                 type: StatusBaseButton.Type.Danger
                 onClicked: {
-                    root.contactsStore.dismissContactRequest(root.publicKey, "")
+                    root.contactsStore.dismissContactRequest(root.chatId, "")
                 }
             }
 
             StatusButton {
                 text: qsTr("Accept Contact Request")
                 onClicked: {
-                    root.contactsStore.acceptContactRequest(root.publicKey, "")
+                    root.contactsStore.acceptContactRequest(root.chatId, "")
                 }
             }
         }

--- a/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
@@ -321,17 +321,6 @@ Item {
                 root.showReplyArea(messageId, author)
             }
 
-            onImageClicked: (image, mouse, imageSource) => {
-                switch (mouse.button) {
-                case Qt.LeftButton:
-                    Global.openImagePopup(image)
-                    break;
-                case Qt.RightButton:
-                    Global.openMenu(imageContextMenu, image, { imageSource })
-                    break;
-                }
-            }
-
             stickersLoaded: root.stickersLoaded
 
             onVisibleChanged: {
@@ -407,16 +396,6 @@ Item {
             anchors.horizontalCenter: parent.horizontalCenter
             enabled: false
             text: qsTr("Contact Request Pending...")
-        }
-    }
-
-    Component {
-        id: imageContextMenu
-
-        ImageContextMenu {
-            onClosed: {
-                destroy()
-            }
         }
     }
 }

--- a/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
@@ -322,7 +322,16 @@ Item {
                 root.showReplyArea(messageId, author)
             }
 
-            onImageClicked: Global.openImagePopup(image, messageContextMenu)
+            onImageClicked: (image, mouse, imageSource) => {
+                switch (mouse.button) {
+                case Qt.LeftButton:
+                    Global.openImagePopup(image)
+                    break;
+                case Qt.RightButton:
+                    Global.openMenu(imageContextMenu, image, { imageSource })
+                    break;
+                }
+            }
 
             stickersLoaded: root.stickersLoaded
 
@@ -399,6 +408,16 @@ Item {
             anchors.horizontalCenter: parent.horizontalCenter
             enabled: false
             text: qsTr("Contact Request Pending...")
+        }
+    }
+
+    Component {
+        id: imageContextMenu
+
+        ImageContextMenu {
+            onClosed: {
+                destroy()
+            }
         }
     }
 }

--- a/ui/app/AppLayouts/Chat/views/ChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatView.qml
@@ -112,8 +112,9 @@ StatusSectionLayout {
     rightPanel: Component {
         id: userListComponent
         UserListPanel {
+            anchors.fill: parent
+            store: root.rootStore
             label: qsTr("Members")
-            messageContextMenu: quickActionMessageOptionsMenu
             usersModel: {
                 let chatContentModule = root.rootStore.currentChatContentModule()
                 if (!chatContentModule || !chatContentModule.usersModule) {
@@ -164,19 +165,6 @@ StatusSectionLayout {
             onClosed: {
                 destroy();
             }
-        }
-    }
-
-    MessageContextMenuView {
-        id: quickActionMessageOptionsMenu
-        store: root.rootStore
-
-        onOpenProfileClicked: {
-            Global.openProfilePopup(publicKey, null)
-        }
-        onCreateOneToOneChat: {
-            Global.changeAppSectionBySectionType(Constants.appSection.chat)
-            root.rootStore.chatCommunitySectionModule.createOneToOneChat(communityId, chatId, ensName)
         }
     }
 }

--- a/ui/app/AppLayouts/Chat/views/CommunitySettingsView.qml
+++ b/ui/app/AppLayouts/Chat/views/CommunitySettingsView.qml
@@ -221,9 +221,7 @@ StatusSectionLayout {
                 declinedMemberRequestsModel: root.community.declinedMemberRequests
                 editable: root.community.amISectionAdmin
                 communityName: root.community.name
-                communityMemberContextMenu: memberContextMenuView
 
-                onUserProfileClicked: Global.openProfilePopup(id)
                 onKickUserClicked: root.rootStore.removeUserFromCommunity(id)
                 onBanUserClicked: root.rootStore.banUserFromCommunity(id)
                 onUnbanUserClicked: root.rootStore.unbanUserFromCommunity(id)
@@ -482,22 +480,6 @@ StatusSectionLayout {
                 close()
             }
             onClosed: destroy()
-        }
-    }
-
-    MessageContextMenuView {
-        id: memberContextMenuView
-        store: root.rootStore
-        isProfile: true
-        amIChatAdmin: root.rootStore.amIChatAdmin()
-        myPublicKey: root.rootStore.myPublicKey()
-
-        onOpenProfileClicked: {
-            Global.openProfilePopup(publicKey, null)
-        }
-        onCreateOneToOneChat: {
-            Global.changeAppSectionBySectionType(Constants.appSection.chat)
-            root.rootStore.chatCommunitySectionModule.createOneToOneChat(communityId, chatId, ensName)
         }
     }
 

--- a/ui/app/AppLayouts/Profile/views/ContactsView.qml
+++ b/ui/app/AppLayouts/Profile/views/ContactsView.qml
@@ -34,10 +34,11 @@ SettingsContentBase {
     }
 
     function openContextMenu(publicKey, name, icon) {
-        contactContextMenu.selectedUserPublicKey = publicKey
-        contactContextMenu.selectedUserDisplayName = name
-        contactContextMenu.selectedUserIcon = icon
-        contactContextMenu.popup()
+        Global.openMenu(contactContextMenuComponent, this, {
+                            selectedUserPublicKey: publicKey,
+                            selectedUserDisplayName: name,
+                            selectedUserIcon: icon,
+                        })
     }
 
     Item {
@@ -46,17 +47,22 @@ SettingsContentBase {
         height: (searchBox.height + contactsTabBar.height
                 + stackLayout.height + (2 * Style.current.bigPadding))
 
-        MessageContextMenuView {
-            id: contactContextMenu
-            store: ({contactsStore: root.contactsStore})
-            isProfile: true
+        Component {
+            id: contactContextMenuComponent
 
-            onOpenProfileClicked: function (pubkey) {
-                Global.openProfilePopup(pubkey, null)
-            }
+            ProfileContextMenu {
+                id: contactContextMenu
+                store: ({contactsStore: root.contactsStore})
 
-            onCreateOneToOneChat: function (communityId, chatId, ensName) {
-                root.contactsStore.joinPrivateChat(chatId)
+                onOpenProfileClicked: function (pubkey) {
+                    Global.openProfilePopup(pubkey, null)
+                }
+                onCreateOneToOneChat: function (communityId, chatId, ensName) {
+                    root.contactsStore.joinPrivateChat(chatId)
+                }
+                onClosed: {
+                    destroy()
+                }
             }
         }
 

--- a/ui/app/mainui/Popups.qml
+++ b/ui/app/mainui/Popups.qml
@@ -40,6 +40,7 @@ QtObject {
         Global.importCommunityPopupRequested.connect(openImportCommunityPopup)
         Global.removeContactRequested.connect(openRemoveContactConfirmationPopup)
         Global.openPopupRequested.connect(openPopup)
+        Global.openDeleteMessagePopup.connect(openDeleteMessagePopup)
     }
 
     function openPopup(popupComponent, params = {}, cb = null) {
@@ -204,6 +205,14 @@ QtObject {
             displayName: displayName,
             publicKey: publicKey
         })
+    }
+
+    function openDeleteMessagePopup(messageId, messageStore) {
+        openPopup(deleteMessageConfirmationDialogComponent,
+                  {
+                      messageId,
+                      messageStore
+                  })
     }
 
     readonly property list<Component> _components: [
@@ -461,6 +470,12 @@ QtObject {
             DiscordImportProgressDialog {
                 store: root.communitiesStore
             }
+        },
+
+        Component {
+            id: deleteMessageConfirmationDialogComponent
+
+            DeleteMessageConfirmationPopup { }
         }
     ]
 }

--- a/ui/app/mainui/Popups.qml
+++ b/ui/app/mainui/Popups.qml
@@ -487,6 +487,10 @@ QtObject {
                 modality: Qt.NonModal
                 onAccepted: {
                     Utils.downloadImageByUrl(imageSource, fileUrl)
+                    destroy()
+                }
+                onRejected: {
+                    destroy()
                 }
                 Component.onCompleted: {
                     open()

--- a/ui/imports/shared/controls/chat/MessageReactionsRow.qml
+++ b/ui/imports/shared/controls/chat/MessageReactionsRow.qml
@@ -1,0 +1,29 @@
+import QtQuick 2.15
+
+import utils 1.0
+import shared 1.0
+
+Row {
+    id: root
+
+    property var reactionsModel
+    property var messageReactionsModel: [] // TODO: We never used this correctly. And this is not Discord-like behavior.
+
+    signal toggleReaction(int emojiId)
+
+    spacing: Style.current.halfPadding
+    leftPadding: Style.current.halfPadding
+    rightPadding: Style.current.halfPadding
+
+    Repeater {
+        model: root.reactionsModel
+        delegate: EmojiReaction {
+            source: Style.svg(filename)
+            emojiId: model.emojiId
+            // reactedByUser: !!root.messageReactionsModel[emojiId]
+            onCloseModal: {
+                root.toggleReaction(emojiId)
+            }
+        }
+    }
+}

--- a/ui/imports/shared/controls/chat/MessageReactionsRow.qml
+++ b/ui/imports/shared/controls/chat/MessageReactionsRow.qml
@@ -7,7 +7,7 @@ Row {
     id: root
 
     property var reactionsModel
-    property var messageReactionsModel: [] // TODO: We never used this correctly. And this is not Discord-like behavior.
+    property var messageReactionsModel: [] // TODO: https://github.com/status-im/status-desktop/issues/10703
 
     signal toggleReaction(int emojiId)
 

--- a/ui/imports/shared/controls/chat/ProfileHeader.qml
+++ b/ui/imports/shared/controls/chat/ProfileHeader.qml
@@ -138,7 +138,7 @@ Item {
 
                 onClicked: {
                     if (!!root.store.profileLargeImage)
-                        imageEditMenu.popup(this, mouse.x, mouse.y);
+                        Global.openMenu(editImageMenuComponent, this)
                     else
                         Global.openChangeProfilePicPopup(tempIcon);
                 }
@@ -271,30 +271,33 @@ Item {
         }
     }
 
-    StatusMenu {
-        id: imageEditMenu
-        width: 200
+    Component {
+        id: editImageMenuComponent
 
-        StatusAction {
-            text: qsTr("Select different image")
-            assetSettings.name: "image"
-            onTriggered: Global.openChangeProfilePicPopup(editButton.tempIcon)
-        }
+        StatusMenu {
+            width: 200
 
-        StatusAction {
-            text: qsTr("Use an NFT")
-            assetSettings.name: "nft-profile"
-            onTriggered: Global.openChangeProfilePicPopup(editButton.tempIcon)
-            enabled: false // TODO enable this with the profile showcase
-        }
+            StatusAction {
+                text: qsTr("Select different image")
+                assetSettings.name: "image"
+                onTriggered: Global.openChangeProfilePicPopup(editButton.tempIcon)
+            }
 
-        StatusMenuSeparator {}
+            StatusAction {
+                text: qsTr("Use an NFT")
+                assetSettings.name: "nft-profile"
+                onTriggered: Global.openChangeProfilePicPopup(editButton.tempIcon)
+                enabled: false // TODO enable this with the profile showcase
+            }
 
-        StatusAction {
-            text: qsTr("Remove image")
-            type: StatusAction.Danger
-            assetSettings.name: "delete"
-            onTriggered: root.icon = ""
+            StatusMenuSeparator {}
+
+            StatusAction {
+                text: qsTr("Remove image")
+                type: StatusAction.Danger
+                assetSettings.name: "delete"
+                onTriggered: root.icon = ""
+            }
         }
     }
 }

--- a/ui/imports/shared/controls/chat/qmldir
+++ b/ui/imports/shared/controls/chat/qmldir
@@ -14,3 +14,4 @@ MessageBorder 1.0 MessageBorder.qml
 EmojiReaction 1.0 EmojiReaction.qml
 ProfileHeader 1.0 ProfileHeader.qml
 VerificationLabel 1.0 VerificationLabel.qml
+MessageReactionsRow 1.0 MessageReactionsRow.qml

--- a/ui/imports/shared/popups/DeleteMessageConfirmationPopup.qml
+++ b/ui/imports/shared/popups/DeleteMessageConfirmationPopup.qml
@@ -10,6 +10,7 @@ ConfirmationDialog {
     confirmationText: qsTr("Are you sure you want to delete this message? Be aware that other clients are not guaranteed to delete the message as well.")
     height: 260
     checkbox.visible: true
+    confirmButtonObjectName: "chatButtonsPanelConfirmDeleteMessageButton"
 
     executeConfirm: () => {
         if (checkbox.checked) {

--- a/ui/imports/shared/popups/DeleteMessageConfirmationPopup.qml
+++ b/ui/imports/shared/popups/DeleteMessageConfirmationPopup.qml
@@ -1,0 +1,25 @@
+import QtQuick 2.15
+
+ConfirmationDialog {
+    id: root
+
+    property var messageStore
+    property string messageId
+
+    header.title: qsTr("Confirm deleting this message")
+    confirmationText: qsTr("Are you sure you want to delete this message? Be aware that other clients are not guaranteed to delete the message as well.")
+    height: 260
+    checkbox.visible: true
+
+    executeConfirm: () => {
+        if (checkbox.checked) {
+            localAccountSensitiveSettings.showDeleteMessageWarning = false
+        }
+        close()
+        messageStore.deleteMessage(messageId)
+    }
+
+    onClosed: {
+        destroy()
+    }
+}

--- a/ui/imports/shared/popups/qmldir
+++ b/ui/imports/shared/popups/qmldir
@@ -27,3 +27,4 @@ AccountsModalHeader 1.0 AccountsModalHeader.qml
 GetSyncCodeInstructionsPopup 1.0 GetSyncCodeInstructionsPopup.qml
 NoPermissionsToJoinPopup 1.0 NoPermissionsToJoinPopup.qml
 RemoveAccountConfirmationPopup 1.0 RemoveAccountConfirmationPopup.qml
+DeleteMessageConfirmationPopup 1.0 DeleteMessageConfirmationPopup.qml

--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -63,8 +63,6 @@ Rectangle {
 
     property var imageErrorMessageLocation: StatusChatInput.ImageErrorMessageLocation.Top // TODO: Remove this proeprty?
 
-    property var messageContextMenu
-
     property alias suggestions: suggestionsBox
 
     enum ImageErrorMessageLocation {

--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -1226,7 +1226,9 @@ Rectangle {
                     Layout.leftMargin: Style.current.halfPadding
                     Layout.rightMargin: Style.current.halfPadding
                     visible: isImage
-                    onImageClicked: Global.openImagePopup(chatImage, messageContextMenu)
+                    onImageClicked: {
+                        Global.openImagePopup(chatImage)
+                    }
                     onImageRemoved: {
                         if (control.fileUrlsAndSources.length > index && control.fileUrlsAndSources[index]) {
                             control.fileUrlsAndSources.splice(index, 1)

--- a/ui/imports/shared/status/StatusImageModal.qml
+++ b/ui/imports/shared/status/StatusImageModal.qml
@@ -6,13 +6,12 @@ import QtGraphicalEffects 1.13
 
 import utils 1.0
 import shared 1.0
+import shared.views.chat 1.0
 
 Popup {
     id: root
 
-    signal clicked(var mouse)
-    property string imageSource: messageImage.source
-    property var contextMenu
+    property var store
 
     modal: true
     Overlay.modal: Rectangle {
@@ -32,7 +31,6 @@ Popup {
         const maxHeight = Global.applicationWindow.height - 80
         const maxWidth = Global.applicationWindow.width - 80
 
-
         if (image.sourceSize.width >= maxWidth || image.sourceSize.height >= maxHeight) {
             this.width = maxWidth
             this.height = maxHeight
@@ -44,7 +42,7 @@ Popup {
 
     function openPopup(image) {
         setPopupData(image);
-        root.open();
+        open()
     }
 
     contentItem: AnimatedImage {
@@ -61,7 +59,22 @@ Popup {
             anchors.fill: parent
             acceptedButtons: Qt.LeftButton | Qt.RightButton
             onClicked: {
-                root.clicked(mouse)
+                if (mouse.button === Qt.LeftButton)
+                    root.close()
+                if (mouse.button === Qt.RightButton)
+                    Global.openMenu(imageContextMenu,
+                                    messageImage,
+                                    { imageSource: messageImage.source })
+            }
+        }
+    }
+
+    Component {
+        id: imageContextMenu
+
+        ImageContextMenu {
+            onClosed: {
+                destroy()
             }
         }
     }

--- a/ui/imports/shared/views/chat/ImageContextMenu.qml
+++ b/ui/imports/shared/views/chat/ImageContextMenu.qml
@@ -1,6 +1,3 @@
-import QtQuick 2.15
-import QtQuick.Dialogs 1.0
-
 import StatusQ.Popups 0.1
 
 import utils 1.0

--- a/ui/imports/shared/views/chat/ImageContextMenu.qml
+++ b/ui/imports/shared/views/chat/ImageContextMenu.qml
@@ -1,0 +1,32 @@
+import QtQuick 2.15
+import QtQuick.Dialogs 1.0
+
+import StatusQ.Popups 0.1
+
+import utils 1.0
+
+StatusMenu {
+    id: root
+
+    property string imageSource
+
+    StatusAction {
+        text: root.imageSource.endsWith(".gif") ? qsTr("Copy GIF")
+                                                : qsTr("Copy image")
+        icon.name: "copy"
+        enabled: !!root.imageSource
+        onTriggered: {
+            Utils.copyImageToClipboardByUrl(root.imageSource)
+        }
+    }
+
+    StatusAction {
+        text: root.imageSource.endsWith(".gif") ? qsTr("Download GIF")
+                                                : qsTr("Download image")
+        icon.name: "download"
+        enabled: !!root.imageSource
+        onTriggered: {
+            Global.openDownloadImageDialog(root.imageSource)
+        }
+    }
+}

--- a/ui/imports/shared/views/chat/LinksMessageView.qml
+++ b/ui/imports/shared/views/chat/LinksMessageView.qml
@@ -25,7 +25,7 @@ Column {
     readonly property alias unfurledImagesCount: d.unfurledImagesCount
     property bool isCurrentUser: false
 
-    signal imageClicked(var image)
+    signal imageClicked(var image, var mouse, var imageSource)
     signal linksLoaded()
 
     spacing: 4
@@ -138,7 +138,12 @@ Column {
                 isOnline: root.store.mainModuleInst.isOnline
                 asynchronous: true
                 isAnimated: result.contentType ? result.contentType.toLowerCase().endsWith("gif") : false
-                onClicked: isAnimated && !playing ? localAnimationEnabled = true : root.imageClicked(linkImage.imageAlias)
+                onClicked: {
+                    if (isAnimated && !playing)
+                        localAnimationEnabled = true
+                    else
+                        root.imageClicked(linkImage.imageAlias, mouse, source)
+                }
                 imageAlias.cache: localAnimationEnabled // GIFs can only loop/play properly with cache enabled
                 Loader {
                     width: 45

--- a/ui/imports/shared/views/chat/MessageAddReactionContextMenu.qml
+++ b/ui/imports/shared/views/chat/MessageAddReactionContextMenu.qml
@@ -1,0 +1,34 @@
+import QtQuick 2.12
+import QtQuick.Controls 2.3
+import QtQuick.Layouts 1.3
+import QtQml.Models 2.3
+
+import StatusQ.Popups 0.1
+import StatusQ.Components 0.1
+
+import utils 1.0
+import shared 1.0
+import shared.panels 1.0
+import shared.popups 1.0
+import shared.status 1.0
+import shared.controls.chat 1.0
+import shared.controls.chat.menuItems 1.0
+
+StatusMenu {
+    id: root
+
+    property alias reactionsModel: emojiRow.reactionsModel
+    property alias messageReactionsModel: emojiRow.messageReactionsModel
+
+    signal toggleReaction(int emojiId)
+
+    width: emojiRow.width
+
+    MessageReactionsRow {
+        id: emojiRow
+        onToggleReaction: {
+            root.toggleReaction(emojiId)
+            root.close()
+        }
+    }
+}

--- a/ui/imports/shared/views/chat/MessageAddReactionContextMenu.qml
+++ b/ui/imports/shared/views/chat/MessageAddReactionContextMenu.qml
@@ -1,18 +1,6 @@
-import QtQuick 2.12
-import QtQuick.Controls 2.3
-import QtQuick.Layouts 1.3
-import QtQml.Models 2.3
-
 import StatusQ.Popups 0.1
-import StatusQ.Components 0.1
 
-import utils 1.0
-import shared 1.0
-import shared.panels 1.0
-import shared.popups 1.0
-import shared.status 1.0
 import shared.controls.chat 1.0
-import shared.controls.chat.menuItems 1.0
 
 StatusMenu {
     id: root

--- a/ui/imports/shared/views/chat/MessageContextMenuView.qml
+++ b/ui/imports/shared/views/chat/MessageContextMenuView.qml
@@ -19,15 +19,10 @@ StatusMenu {
 
     property var store
     property var reactionModel
-    property alias emojiContainer: emojiContainer
 
     property string myPublicKey: ""
     property bool amIChatAdmin: false
     property bool disabledForChat: false
-
-    property string selectedUserPublicKey: ""
-    property string selectedUserDisplayName: ""
-    property string selectedUserIcon: ""
 
     property int chatType: Constants.chatType.unknown
     property string messageId: ""
@@ -35,90 +30,26 @@ StatusMenu {
     property string messageSenderId: ""
     property int messageContentType: Constants.messageContentType.unknownContentType
 
-    property bool isProfile: false
     property bool pinnedPopup: false
     property bool pinMessageAllowedForMembers: false
     property bool isDebugEnabled: store && store.isDebugEnabled
-    property bool isSticker: false
-    property bool hideEmojiPicker: true
+    property bool editRestricted: false
     property bool pinnedMessage: false
     property bool canPin: false
 
     readonly property bool isMyMessage: {
         return root.messageSenderId !== "" && root.messageSenderId === root.myPublicKey;
     }
-    readonly property bool isMe: {
-        return root.selectedUserPublicKey === root.store.contactsStore.myPublicKey;
-    }
-    readonly property var contactDetails: {
-        if (root.selectedUserPublicKey === "" || isMe) {
-            return {}
-        }
-        return Utils.getContactDetailsAsJson(root.selectedUserPublicKey);
-    }
-    readonly property bool isContact: {
-        return root.selectedUserPublicKey !== "" && !!contactDetails.isContact
-    }
-    readonly property bool isBlockedContact: (!!contactDetails && contactDetails.isBlocked) || false
 
-    readonly property int outgoingVerificationStatus: {
-        if (root.selectedUserPublicKey === "" || root.isMe || !root.isContact) {
-            return 0
-        }
-        return contactDetails.verificationStatus
-    }
-    readonly property int incomingVerificationStatus: {
-        if (root.selectedUserPublicKey === "" || root.isMe || !root.isContact) {
-            return 0
-        }
-        return contactDetails.incomingVerificationStatus
-    }
-    readonly property bool hasPendingContactRequest: {
-        return !root.isMe && root.selectedUserPublicKey !== "" &&
-            root.store.contactsStore.hasPendingContactRequest(root.selectedUserPublicKey);
-    }
-    readonly property bool hasActiveReceivedVerificationRequestFrom: {
-        if (!root.selectedUserPublicKey || root.isMe || !root.isContact) {
-            return false
-        }
-        return contactDetails.incomingVerificationStatus === Constants.verificationStatus.verifying ||
-                contactDetails.incomingVerificationStatus === Constants.verificationStatus.verified
-    }
-    readonly property bool isVerificationRequestSent: {
-        if (!root.selectedUserPublicKey || root.isMe || !root.isContact) {
-            return false
-        }
-        return root.outgoingVerificationStatus !== Constants.verificationStatus.unverified &&
-                root.outgoingVerificationStatus !== Constants.verificationStatus.verified &&
-                root.outgoingVerificationStatus !== Constants.verificationStatus.trusted
-    }
-    readonly property bool isTrusted: {
-        if (!root.selectedUserPublicKey || root.isMe || !root.isContact) {
-            return false
-        }
-        return root.outgoingVerificationStatus === Constants.verificationStatus.trusted ||
-                root.incomingVerificationStatus === Constants.verificationStatus.trusted
-    }
-
-    readonly property bool userTrustIsUnknown: contactDetails && contactDetails.trustStatus === Constants.trustStatus.unknown
-    readonly property bool userIsUntrustworthy: contactDetails && contactDetails.trustStatus === Constants.trustStatus.untrustworthy
-
-    signal openProfileClicked(string publicKey)
     signal pinMessage(string messageId)
     signal unpinMessage(string messageId)
     signal pinnedMessagesLimitReached(string messageId)
     signal jumpToMessage(string messageId)
     signal shouldCloseParentPopup()
-    signal createOneToOneChat(string communityId, string chatId, string ensName)
     signal showReplyArea(string messageId)
     signal toggleReaction(string messageId, int emojiId)
     signal deleteMessage(string messageId)
     signal editClicked(string messageId)
-
-    onClosed: {
-        // Reset selectedUserPublicKey so that associated properties get recalculated on re-open
-        selectedUserPublicKey = ""
-    }
 
     width: Math.max(emojiContainer.visible ? emojiContainer.width : 0, 230)
 
@@ -126,7 +57,7 @@ StatusMenu {
         id: emojiContainer
         width: emojiRow.width
         height: visible ? emojiRow.height : 0
-        visible: !root.hideEmojiPicker && !root.isProfile && !root.pinnedPopup && !root.disabledForChat
+        visible: !root.pinnedPopup && !root.disabledForChat
 
         MessageReactionsRow {
             id: emojiRow
@@ -139,157 +70,8 @@ StatusMenu {
         }
     }
 
-    ProfileHeader {
-        visible: root.isProfile
-        width: parent.width
-        height: visible ? implicitHeight : 0
-
-        displayNameVisible: false
-        displayNamePlusIconsVisible: true
-        editButtonVisible: false
-        displayName: root.selectedUserDisplayName
-        pubkey: root.selectedUserPublicKey
-        icon: root.selectedUserIcon
-        trustStatus: contactDetails && contactDetails.trustStatus ? contactDetails.trustStatus
-                                                                  : Constants.trustStatus.unknown
-        isContact: root.isContact
-        isCurrentUser: root.isMe
-        userIsEnsVerified: (!!contactDetails && contactDetails.ensVerified) || false
-    }
-
-    Item {
-        visible: root.isProfile
-        height: visible ? root.topPadding : 0
-    }
-
     StatusMenuSeparator {
-        anchors.bottom: viewProfileAction.top
-        visible: !root.hideEmojiPicker && !pinnedPopup
-    }
-
-    ViewProfileMenuItem {
-        id: viewProfileAction
-        enabled: root.isProfile && !root.pinnedPopup
-        onTriggered: {
-            root.openProfileClicked(root.selectedUserPublicKey)
-            root.close()
-        }
-    }
-
-    SendMessageMenuItem {
-        id: sendMessageMenuItem
-        enabled: root.isProfile && root.isContact && !root.isBlockedContact
-        onTriggered: {
-            root.createOneToOneChat("", root.selectedUserPublicKey, "")
-            root.close()
-        }
-    }
-
-    SendContactRequestMenuItem {
-        id: sendContactRequestMenuItem
-        enabled: root.isProfile && !root.isMe && !root.isContact
-                                && !root.isBlockedContact && !root.hasPendingContactRequest
-        onTriggered: {
-            Global.openContactRequestPopup(root.selectedUserPublicKey, null)
-            root.close()
-        }
-    }
-
-    StatusAction {
-        id: verifyIdentityAction
-        text: qsTr("Verify Identity")
-        icon.name: "checkmark-circle"
-        enabled: root.isProfile && !root.isMe && root.isContact
-                                && !root.isBlockedContact
-                                && root.outgoingVerificationStatus === Constants.verificationStatus.unverified
-                                && !root.hasActiveReceivedVerificationRequestFrom
-        onTriggered: {
-            Global.openSendIDRequestPopup(root.selectedUserPublicKey, null)
-            root.close()
-        }
-    }
-
-    StatusAction {
-        id: pendingIdentityAction
-        text: isVerificationRequestSent ||
-            root.incomingVerificationStatus === Constants.verificationStatus.verified ?
-            qsTr("ID Request Pending....") :
-            qsTr("Respond to ID Request...")
-        icon.name: "checkmark-circle"
-        enabled: root.isProfile && !root.isMe && root.isContact
-                                && !root.isBlockedContact && !root.isTrusted
-                                && (root.hasActiveReceivedVerificationRequestFrom
-                                    || root.isVerificationRequestSent)
-        onTriggered: {
-            if (hasActiveReceivedVerificationRequestFrom) {
-                Global.openIncomingIDRequestPopup(root.selectedUserPublicKey, null)
-            } else if (root.isVerificationRequestSent) {
-                Global.openOutgoingIDRequestPopup(root.selectedUserPublicKey, null)
-            }
-
-            root.close()
-        }
-    }
-
-    StatusAction {
-        id: renameAction
-        text: qsTr("Rename")
-        icon.name: "edit_pencil"
-        enabled: root.isProfile && !root.isMe
-        onTriggered: {
-            Global.openNicknamePopupRequested(root.selectedUserPublicKey, contactDetails.localNickname,
-                                              "%1 (%2)".arg(root.selectedUserDisplayName).arg(Utils.getElidedCompressedPk(root.selectedUserPublicKey)))
-            root.close()
-        }
-    }
-
-    StatusAction {
-        id: unblockAction
-        text: qsTr("Unblock User")
-        icon.name: "remove-circle"
-        enabled: root.isProfile && !root.isMe && root.isBlockedContact
-        onTriggered: Global.unblockContactRequested(root.selectedUserPublicKey, root.selectedUserDisplayName)
-    }
-
-    StatusMenuSeparator {
-        visible: blockMenuItem.enabled || markUntrustworthyMenuItem.enabled || removeUntrustworthyMarkMenuItem.enabled
-    }
-
-    StatusAction {
-        id: markUntrustworthyMenuItem
-        text: qsTr("Mark as Untrustworthy")
-        icon.name: "warning"
-        type: StatusAction.Type.Danger
-        enabled: root.isProfile && !root.isMe && root.userTrustIsUnknown
-        onTriggered: root.store.contactsStore.markUntrustworthy(root.selectedUserPublicKey)
-    }
-
-    StatusAction {
-        id: removeUntrustworthyMarkMenuItem
-        text: qsTr("Remove Untrustworthy Mark")
-        icon.name: "warning"
-        enabled: root.isProfile && !root.isMe && root.userIsUntrustworthy
-        onTriggered: root.store.contactsStore.removeTrustStatus(root.selectedUserPublicKey)
-    }
-
-    StatusAction {
-        text: qsTr("Remove Contact")
-        icon.name: "remove-contact"
-        type: StatusAction.Type.Danger
-        enabled: root.isContact && !root.isBlockedContact && !root.hasPendingContactRequest
-        onTriggered: {
-            Global.removeContactRequested(root.selectedUserDisplayName, root.selectedUserPublicKey);
-            root.close();
-        }
-    }
-
-    StatusAction {
-        id: blockMenuItem
-        text: qsTr("Block User")
-        icon.name: "cancel"
-        type: StatusAction.Type.Danger
-        enabled: root.isProfile && !root.isMe && !root.isBlockedContact
-        onTriggered: Global.blockContactRequested(root.selectedUserPublicKey, root.selectedUserDisplayName)
+        visible: emojiContainer.visible
     }
 
     StatusAction {
@@ -300,10 +82,8 @@ StatusMenu {
             root.showReplyArea(root.messageId)
             root.close()
         }
-        enabled: (!root.hideEmojiPicker &&
-                  !root.isProfile &&
-                  !root.pinnedPopup &&
-                  !root.disabledForChat)
+        enabled: !root.pinnedPopup &&
+                 !root.disabledForChat
     }
 
     StatusAction {
@@ -314,9 +94,7 @@ StatusMenu {
         }
         icon.name: "edit"
         enabled: root.isMyMessage &&
-                 !root.hideEmojiPicker &&
-                 !root.isSticker &&
-                 !root.isProfile &&
+                 !root.editRestricted &&
                  !root.pinnedPopup &&
                  !root.disabledForChat
     }
@@ -368,7 +146,7 @@ StatusMenu {
         }
         icon.name: "pin"
         enabled: {
-            if (root.isProfile || root.disabledForChat)
+            if (root.disabledForChat)
                 return false
 
             if (root.pinnedPopup)
@@ -391,9 +169,7 @@ StatusMenu {
 
     StatusMenuSeparator {
         visible: deleteMessageAction.enabled &&
-                 (viewProfileAction.enabled ||
-                  sendMessageMenuItem.enabled ||
-                  replyToMenuItem.enabled ||
+                 (replyToMenuItem.enabled ||
                   copyMessageMenuItem.enabled ||
                   editMessageAction.enabled ||
                   pinAction.enabled)
@@ -403,7 +179,6 @@ StatusMenu {
         id: deleteMessageAction
         enabled: (root.isMyMessage || root.amIChatAdmin) &&
                  !root.disabledForChat &&
-                 !root.isProfile &&
                  !root.pinnedPopup &&
                  (root.messageContentType === Constants.messageContentType.messageType ||
                   root.messageContentType === Constants.messageContentType.stickerType ||
@@ -420,7 +195,7 @@ StatusMenu {
 
     StatusAction {
         id: jumpToAction
-        enabled: root.pinnedPopup && !root.isProfile
+        enabled: root.pinnedPopup
         text: qsTr("Jump to")
         onTriggered: {
             root.jumpToMessage(root.messageId)

--- a/ui/imports/shared/views/chat/MessageContextMenuView.qml
+++ b/ui/imports/shared/views/chat/MessageContextMenuView.qml
@@ -30,7 +30,6 @@ StatusMenu {
     property string messageSenderId: ""
     property int messageContentType: Constants.messageContentType.unknownContentType
 
-    property bool pinnedPopup: false
     property bool pinMessageAllowedForMembers: false
     property bool isDebugEnabled: store && store.isDebugEnabled
     property bool editRestricted: false
@@ -44,7 +43,6 @@ StatusMenu {
     signal pinMessage(string messageId)
     signal unpinMessage(string messageId)
     signal pinnedMessagesLimitReached(string messageId)
-    signal jumpToMessage(string messageId)
     signal showReplyArea(string messageId, string messageSenderId)
     signal toggleReaction(string messageId, int emojiId)
     signal deleteMessage(string messageId)
@@ -56,7 +54,7 @@ StatusMenu {
         id: emojiContainer
         width: emojiRow.width
         height: visible ? emojiRow.height : 0
-        visible: !root.pinnedPopup && !root.disabledForChat
+        visible: !root.disabledForChat
 
         MessageReactionsRow {
             id: emojiRow
@@ -81,8 +79,7 @@ StatusMenu {
             root.showReplyArea(root.messageId, root.messageSenderId)
             root.close()
         }
-        enabled: !root.pinnedPopup &&
-                 !root.disabledForChat
+        enabled: !root.disabledForChat
     }
 
     StatusAction {
@@ -94,7 +91,6 @@ StatusMenu {
         icon.name: "edit"
         enabled: root.isMyMessage &&
                  !root.editRestricted &&
-                 !root.pinnedPopup &&
                  !root.disabledForChat
     }
 
@@ -122,13 +118,8 @@ StatusMenu {
 
     StatusAction {
         id: pinAction
-        text: {
-            if (root.pinnedMessage) {
-                return qsTr("Unpin")
-            }
-            return qsTr("Pin")
-
-        }
+        text: root.pinnedMessage ? qsTr("Unpin") : qsTr("Pin")
+        icon.name: root.pinnedMessage ? "unpin" : "pin"
         onTriggered: {
             if (root.pinnedMessage) {
                 root.unpinMessage(root.messageId)
@@ -143,13 +134,9 @@ StatusMenu {
             root.pinMessage(root.messageId)
             root.close()
         }
-        icon.name: "pin"
         enabled: {
             if (root.disabledForChat)
                 return false
-
-            if (root.pinnedPopup)
-                return true
 
             switch (root.chatType) {
             case Constants.chatType.profile:
@@ -170,6 +157,7 @@ StatusMenu {
         visible: deleteMessageAction.enabled &&
                  (replyToMenuItem.enabled ||
                   copyMessageMenuItem.enabled ||
+                  copyMessageIdAction ||
                   editMessageAction.enabled ||
                   pinAction.enabled)
     }
@@ -178,7 +166,6 @@ StatusMenu {
         id: deleteMessageAction
         enabled: (root.isMyMessage || root.amIChatAdmin) &&
                  !root.disabledForChat &&
-                 !root.pinnedPopup &&
                  (root.messageContentType === Constants.messageContentType.messageType ||
                   root.messageContentType === Constants.messageContentType.stickerType ||
                   root.messageContentType === Constants.messageContentType.emojiType ||
@@ -188,17 +175,7 @@ StatusMenu {
         icon.name: "delete"
         type: StatusAction.Type.Danger
         onTriggered: {
-            deleteMessage(messageId)
+            root.deleteMessage(messageId)
         }
-    }
-
-    StatusAction {
-        id: jumpToAction
-        enabled: root.pinnedPopup
-        text: qsTr("Jump to")
-        onTriggered: {
-            root.jumpToMessage(root.messageId)
-        }
-        icon.name: "arrow-up"
     }
 }

--- a/ui/imports/shared/views/chat/MessageContextMenuView.qml
+++ b/ui/imports/shared/views/chat/MessageContextMenuView.qml
@@ -39,7 +39,7 @@ StatusMenu {
     property bool pinnedPopup: false
     property bool pinMessageAllowedForMembers: false
     property bool isDebugEnabled: store && store.isDebugEnabled
-    property bool isEmoji: false
+    property bool isReactions: false
     property bool isSticker: false
     property bool hideEmojiPicker: true
     property bool pinnedMessage: false
@@ -113,7 +113,7 @@ StatusMenu {
     signal jumpToMessage(string messageId)
     signal shouldCloseParentPopup()
     signal createOneToOneChat(string communityId, string chatId, string ensName)
-    signal showReplyArea()
+    signal showReplyArea(string messageId)
     signal toggleReaction(string messageId, int emojiId)
     signal deleteMessage(string messageId)
     signal editClicked(string messageId)
@@ -141,14 +141,14 @@ StatusMenu {
         id: emojiContainer
         width: emojiRow.width
         height: visible ? emojiRow.height : 0
-        visible: !root.hideEmojiPicker && (root.isEmoji || !root.isProfile) && !root.pinnedPopup && !root.disabledForChat
+        visible: !root.hideEmojiPicker && (root.isReactions || !root.isProfile) && !root.pinnedPopup && !root.disabledForChat
 
         Row {
             id: emojiRow
             spacing: Style.current.halfPadding
             leftPadding: Style.current.halfPadding
             rightPadding: Style.current.halfPadding
-            bottomPadding: root.isEmoji ? 0 : Style.current.padding
+            bottomPadding: root.isReactions ? 0 : Style.current.padding
 
             Repeater {
                 model: root.reactionModel
@@ -190,7 +190,7 @@ StatusMenu {
 
     StatusMenuSeparator {
         anchors.bottom: viewProfileAction.top
-        visible: !root.isEmoji && !root.hideEmojiPicker && !pinnedPopup
+        visible: !root.isReactions && !root.hideEmojiPicker && !pinnedPopup
     }
 
     ViewProfileMenuItem {
@@ -323,11 +323,11 @@ StatusMenu {
         text: qsTr("Reply to")
         icon.name: "chat"
         onTriggered: {
-            root.showReplyArea()
+            root.showReplyArea(root.messageId)
             root.close()
         }
         enabled: (!root.hideEmojiPicker &&
-                  !root.isEmoji &&
+                  !root.isReactions &&
                   !root.isProfile &&
                   !root.pinnedPopup &&
                   !root.disabledForChat)
@@ -342,7 +342,7 @@ StatusMenu {
         icon.name: "edit"
         enabled: root.isMyMessage &&
                  !root.hideEmojiPicker &&
-                 !root.isEmoji &&
+                 !root.isReactions &&
                  !root.isSticker &&
                  !root.isProfile &&
                  !root.pinnedPopup &&
@@ -396,7 +396,7 @@ StatusMenu {
         }
         icon.name: "pin"
         enabled: {
-            if (root.isProfile || root.isEmoji || root.disabledForChat)
+            if (root.isProfile || root.isReactions || root.disabledForChat)
                 return false
 
             if (root.pinnedPopup)
@@ -432,7 +432,7 @@ StatusMenu {
         enabled: (root.isMyMessage || root.amIChatAdmin) &&
                  !root.disabledForChat &&
                  !root.isProfile &&
-                 !root.isEmoji &&
+                 !root.isReactions &&
                  !root.pinnedPopup &&
                  (root.messageContentType === Constants.messageContentType.messageType ||
                   root.messageContentType === Constants.messageContentType.stickerType ||

--- a/ui/imports/shared/views/chat/MessageContextMenuView.qml
+++ b/ui/imports/shared/views/chat/MessageContextMenuView.qml
@@ -45,7 +45,6 @@ StatusMenu {
     signal unpinMessage(string messageId)
     signal pinnedMessagesLimitReached(string messageId)
     signal jumpToMessage(string messageId)
-    signal shouldCloseParentPopup()
     signal showReplyArea(string messageId)
     signal toggleReaction(string messageId, int emojiId)
     signal deleteMessage(string messageId)
@@ -199,8 +198,6 @@ StatusMenu {
         text: qsTr("Jump to")
         onTriggered: {
             root.jumpToMessage(root.messageId)
-            root.close()
-            root.shouldCloseParentPopup()
         }
         icon.name: "arrow-up"
     }

--- a/ui/imports/shared/views/chat/MessageContextMenuView.qml
+++ b/ui/imports/shared/views/chat/MessageContextMenuView.qml
@@ -45,7 +45,7 @@ StatusMenu {
     signal unpinMessage(string messageId)
     signal pinnedMessagesLimitReached(string messageId)
     signal jumpToMessage(string messageId)
-    signal showReplyArea(string messageId)
+    signal showReplyArea(string messageId, string messageSenderId)
     signal toggleReaction(string messageId, int emojiId)
     signal deleteMessage(string messageId)
     signal editClicked(string messageId)
@@ -78,7 +78,7 @@ StatusMenu {
         text: qsTr("Reply to")
         icon.name: "chat"
         onTriggered: {
-            root.showReplyArea(root.messageId)
+            root.showReplyArea(root.messageId, root.messageSenderId)
             root.close()
         }
         enabled: !root.pinnedPopup &&

--- a/ui/imports/shared/views/chat/MessageContextMenuView.qml
+++ b/ui/imports/shared/views/chat/MessageContextMenuView.qml
@@ -471,16 +471,11 @@ StatusMenu {
                   root.messageContentType === Constants.messageContentType.imageType ||
                   root.messageContentType === Constants.messageContentType.audioType)
         text: qsTr("Delete message")
-        onTriggered: {
-            if (!localAccountSensitiveSettings.showDeleteMessageWarning) {
-                deleteMessage(messageId)
-            }
-            else {
-                Global.openPopup(deleteMessageConfirmationDialogComponent)
-            }
-        }
         icon.name: "delete"
         type: StatusAction.Type.Danger
+        onTriggered: {
+            deleteMessage(messageId)
+        }
     }
 
     StatusAction {
@@ -505,27 +500,6 @@ StatusMenu {
         onAccepted: {
             if (root.imageSource) {
                 root.store.downloadImageByUrl(root.imageSource, fileDialog.fileUrl)
-            }
-        }
-    }
-
-    Component {
-        id: deleteMessageConfirmationDialogComponent
-        ConfirmationDialog {
-            header.title: qsTr("Confirm deleting this message")
-            confirmationText: qsTr("Are you sure you want to delete this message? Be aware that other clients are not guaranteed to delete the message as well.")
-            height: 260
-            checkbox.visible: true
-            executeConfirm: function () {
-                if (checkbox.checked) {
-                    localAccountSensitiveSettings.showDeleteMessageWarning = false
-                }
-
-                close()
-                root.deleteMessage(messageId)
-            }
-            onClosed: {
-                destroy()
             }
         }
     }

--- a/ui/imports/shared/views/chat/MessageContextMenuView.qml
+++ b/ui/imports/shared/views/chat/MessageContextMenuView.qml
@@ -2,7 +2,6 @@ import QtQuick 2.12
 import QtQuick.Controls 2.3
 import QtQuick.Layouts 1.3
 import QtQml.Models 2.3
-import QtQuick.Dialogs 1.0
 
 import StatusQ.Popups 0.1
 import StatusQ.Components 0.1
@@ -35,10 +34,8 @@ StatusMenu {
     property string unparsedText: ""
     property string messageSenderId: ""
     property int messageContentType: Constants.messageContentType.unknownContentType
-    property string imageSource: ""
 
     property bool isProfile: false
-    property bool isRightClickOnImage: false
     property bool pinnedPopup: false
     property bool pinMessageAllowedForMembers: false
     property bool isDebugEnabled: store && store.isDebugEnabled
@@ -138,8 +135,7 @@ StatusMenu {
         selectedUserPublicKey = ""
     }
 
-    width: Math.max(emojiContainer.visible ? emojiContainer.width : 0,
-                    (root.isRightClickOnImage && !root.pinnedPopup) ? 176 : 230)
+    width: Math.max(emojiContainer.visible ? emojiContainer.width : 0, 230)
 
     Item {
         id: emojiContainer
@@ -195,30 +191,6 @@ StatusMenu {
     StatusMenuSeparator {
         anchors.bottom: viewProfileAction.top
         visible: !root.isEmoji && !root.hideEmojiPicker && !pinnedPopup
-    }
-
-    StatusAction {
-        id: copyImageAction
-        text: (root.imageSource.endsWith(".gif")) ? qsTr("Copy GIF") : qsTr("Copy image")
-        onTriggered: {
-            if (root.imageSource) {
-                root.store.copyImageToClipboardByUrl(root.imageSource)
-            }
-            root.close()
-        }
-        icon.name: "copy"
-        enabled: root.isRightClickOnImage && !root.pinnedPopup
-    }
-
-    StatusAction {
-        id: downloadImageAction
-        text: (root.imageSource.endsWith(".gif")) ? qsTr("Download GIF") : qsTr("Download image")
-        onTriggered: {
-            fileDialog.open()
-            root.close()
-        }
-        icon.name: "download"
-        enabled: root.isRightClickOnImage && !root.pinnedPopup
     }
 
     ViewProfileMenuItem {
@@ -358,7 +330,6 @@ StatusMenu {
                   !root.isEmoji &&
                   !root.isProfile &&
                   !root.pinnedPopup &&
-                  !root.isRightClickOnImage &&
                   !root.disabledForChat)
     }
 
@@ -375,7 +346,6 @@ StatusMenu {
                  !root.isSticker &&
                  !root.isProfile &&
                  !root.pinnedPopup &&
-                 !root.isRightClickOnImage &&
                  !root.disabledForChat
     }
 
@@ -426,7 +396,7 @@ StatusMenu {
         }
         icon.name: "pin"
         enabled: {
-            if (root.isProfile || root.isEmoji || root.isRightClickOnImage || root.disabledForChat)
+            if (root.isProfile || root.isEmoji || root.disabledForChat)
                 return false
 
             if (root.pinnedPopup)
@@ -464,7 +434,6 @@ StatusMenu {
                  !root.isProfile &&
                  !root.isEmoji &&
                  !root.pinnedPopup &&
-                 !root.isRightClickOnImage &&
                  (root.messageContentType === Constants.messageContentType.messageType ||
                   root.messageContentType === Constants.messageContentType.stickerType ||
                   root.messageContentType === Constants.messageContentType.emojiType ||
@@ -488,19 +457,5 @@ StatusMenu {
             root.shouldCloseParentPopup()
         }
         icon.name: "arrow-up"
-    }
-
-    FileDialog {
-        id: fileDialog
-        title: qsTr("Please choose a directory")
-        selectFolder: true
-        selectExisting: true
-        selectMultiple: false
-        modality: Qt.NonModal
-        onAccepted: {
-            if (root.imageSource) {
-                root.store.downloadImageByUrl(root.imageSource, fileDialog.fileUrl)
-            }
-        }
     }
 }

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -22,6 +22,8 @@ Loader {
     property var messageStore
     property var usersStore
     property var contactsStore
+    property var chatContentModule
+
     property var messageContextMenu: null
     property string channelEmoji
     property bool isActiveChannel: false
@@ -129,7 +131,7 @@ Loader {
                                                isSticker = false,
                                                isImage = false,
                                                image = null,
-                                               isEmoji = false,
+                                               isReactions = false,
                                                hideEmojiPicker = false,
                                                isReply = false) {
 
@@ -154,7 +156,7 @@ Loader {
         messageContextMenu.selectedUserIcon = root.senderIcon
 
         messageContextMenu.isProfile = !!isProfileClick
-        messageContextMenu.isEmoji = isEmoji
+        messageContextMenu.isReactions = isReactions
         messageContextMenu.isSticker = isSticker
         messageContextMenu.hideEmojiPicker = hideEmojiPicker
 
@@ -584,8 +586,8 @@ Loader {
                              !root.placeholderMessage &&
                              delegate.contentType !== StatusMessage.ContentType.Image
                     onClicked: {
-                        if (root.messageClickHandler(this, Qt.point(mouse.x, mouse.y),
-                            false, false, false, null, root.isEmoji, false, false, false, ""))
+                        const menuOpened = root.messageClickHandler(this, Qt.point(mouse.x, mouse.y), false, false, false, null, root.isEmoji)
+                        if (menuOpened)
                             d.setMessageActive(root.messageId, true)
                     }
                 }
@@ -703,7 +705,6 @@ Loader {
                         usersStore: root.usersStore
                         emojiPopup: root.emojiPopup
                         stickersPopup: root.stickersPopup
-                        messageContextMenu: root.messageContextMenu
 
                         chatType: root.messageStore.chatType
                         isEdit: true
@@ -725,8 +726,8 @@ Loader {
                         messageStore: root.messageStore
                         store: root.rootStore
                         isCurrentUser: root.amISender
-                        onImageClicked: {
-                            root.imageClicked(image);
+                        onImageClicked: (image, mouse, imageSource) => {
+                            root.imageClicked(image, mouse, imageSource)
                         }
                         onLinksLoaded: {
                             // If there is only one image and no links, hide the message

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -886,39 +886,11 @@ Loader {
                             type: StatusFlatRoundButton.Type.Tertiary
                             tooltip.text: qsTr("Delete")
                             onClicked: {
-                                if (!localAccountSensitiveSettings.showDeleteMessageWarning) {
-                                    messageStore.deleteMessage(root.messageId)
-                                }
-                                else {
-                                    Global.openPopup(deleteMessageConfirmationDialogComponent)
-                                }
+                                messageStore.warnAndDeleteMessage(root.messageId)
                             }
                         }
                     }
                 ]
-            }
-        }
-    }
-
-    Component {
-        id: deleteMessageConfirmationDialogComponent
-
-        ConfirmationDialog {
-            confirmButtonObjectName: "chatButtonsPanelConfirmDeleteMessageButton"
-            header.title: qsTr("Confirm deleting this message")
-            confirmationText: qsTr("Are you sure you want to delete this message? Be aware that other clients are not guaranteed to delete the message as well.")
-            height: 260
-            checkbox.visible: true
-            executeConfirm: function () {
-                if (checkbox.checked) {
-                    localAccountSensitiveSettings.showDeleteMessageWarning = false
-                }
-
-                close()
-                messageStore.deleteMessage(root.messageId)
-            }
-            onClosed: {
-                destroy()
             }
         }
     }

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -125,7 +125,7 @@ Loader {
     function openProfileContextMenu(sender, mouse, isReply = false) {
         if (isReply && !quotedMessageFrom) {
             // The responseTo message was deleted
-            // so we don't enable to right click the unaviable profile
+            // so we don't enable to right click the unavailable profile
             return false
         }
 
@@ -231,7 +231,7 @@ Loader {
         property string activeMessage
         readonly property bool isMessageActive: d.activeMessage === root.messageId
 
-        readonly property bool addReactionAllowed: !root.isInPinnedPopup && !root.rootStore.isUserAllowedToSendMessage
+        readonly property bool addReactionAllowed: !root.isInPinnedPopup && !root.isChatBlocked
 
         function nextMessageHasHeader() {
             if(!root.nextMessageAsJsonObj) {
@@ -284,9 +284,7 @@ Loader {
         }
 
         function addReactionClicked(mouseArea, mouse) {
-            if (root.isChatBlocked)
-                return
-            if (d.addReactionAllowed)
+            if (!d.addReactionAllowed)
                 return
             // Don't use mouseArea as parent, as it will be destroyed right after opening menu
             const point = mouseArea.mapToItem(root, mouse.x, mouse.y)
@@ -736,7 +734,7 @@ Loader {
 
                 quickActions: [
                     Loader {
-                        active: !d.addReactionAllowed && delegate.hovered && !delegate.hideQuickActions
+                        active: d.addReactionAllowed && delegate.hovered && !delegate.hideQuickActions
                         visible: active
                         sourceComponent: StatusFlatRoundButton {
                             width: d.chatButtonSize

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -120,19 +120,18 @@ Loader {
     readonly property bool isExpired: d.getIsExpired(messageTimestamp, messageOutgoingStatus)
     readonly property bool isSending: messageOutgoingStatus === Constants.sending && !isExpired
 
-    signal imageClicked(var image)
+    signal imageClicked(var image, var mouse, var imageSource)
 
     // WARNING: To much arguments here. Create an object argument.
-    property var messageClickHandler: function(sender, point,
+    property var messageClickHandler: function(sender,
+                                               point,
                                                isProfileClick,
                                                isSticker = false,
                                                isImage = false,
                                                image = null,
                                                isEmoji = false,
                                                hideEmojiPicker = false,
-                                               isReply = false,
-                                               isRightClickOnImage = false,
-                                               imageSource = "") {
+                                               isReply = false) {
 
         if (placeholderMessage || !(root.rootStore.mainModuleInst.activeSection.joined || isProfileClick)) {
             return false
@@ -154,10 +153,7 @@ Loader {
         messageContextMenu.selectedUserDisplayName = root.senderDisplayName
         messageContextMenu.selectedUserIcon = root.senderIcon
 
-        messageContextMenu.imageSource = imageSource
-
         messageContextMenu.isProfile = !!isProfileClick
-        messageContextMenu.isRightClickOnImage = isRightClickOnImage
         messageContextMenu.isEmoji = isEmoji
         messageContextMenu.isSticker = isSticker
         messageContextMenu.hideEmojiPicker = hideEmojiPicker
@@ -514,15 +510,8 @@ Loader {
 
                 onEditCompleted: delegate.editCompletedHandler(newMsgText)
 
-                onImageClicked: {
-                    switch (mouse.button) {
-                    case Qt.LeftButton:
-                        root.imageClicked(image, mouse);
-                        break;
-                    case Qt.RightButton:
-                        root.messageClickHandler(image, Qt.point(mouse.x, mouse.y), false, false, true, image, false, true, false, true, imageSource)
-                        break;
-                    }
+                onImageClicked: (image, mouse, imageSource) => {
+                    root.imageClicked(image, mouse, imageSource)
                 }
 
                 onLinkActivated: {

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -122,8 +122,6 @@ Loader {
     readonly property bool isExpired: d.getIsExpired(messageTimestamp, messageOutgoingStatus)
     readonly property bool isSending: messageOutgoingStatus === Constants.sending && !isExpired
 
-    signal imageClicked(var image, var mouse, var imageSource)
-
     function openProfileContextMenu(sender, mouse, isReply = false) {
         if (isReply && !quotedMessageFrom) {
             // The responseTo message was deleted
@@ -293,6 +291,17 @@ Loader {
             // Don't use mouseArea as parent, as it will be destroyed right after opening menu
             const point = mouseArea.mapToItem(root, mouse.x, mouse.y)
             Global.openMenu(addReactionContextMenu, root, {}, point)
+        }
+
+        function onImageClicked(image, mouse, imageSource) {
+            switch (mouse.button) {
+            case Qt.LeftButton:
+                Global.openImagePopup(image)
+                break;
+            case Qt.RightButton:
+                Global.openMenu(imageContextMenuComponent, image, { imageSource })
+                break;
+            }
         }
     }
 
@@ -495,7 +504,7 @@ Loader {
                 onEditCompleted: delegate.editCompletedHandler(newMsgText)
 
                 onImageClicked: (image, mouse, imageSource) => {
-                    root.imageClicked(image, mouse, imageSource)
+                    d.onImageClicked(image, mouse, imageSource)
                 }
 
                 onLinkActivated: {
@@ -699,7 +708,7 @@ Loader {
                         store: root.rootStore
                         isCurrentUser: root.amISender
                         onImageClicked: (image, mouse, imageSource) => {
-                            root.imageClicked(image, mouse, imageSource)
+                            d.onImageClicked(image, mouse, imageSource)
                         }
                         onLinksLoaded: {
                             // If there is only one image and no links, hide the message
@@ -875,6 +884,16 @@ Loader {
             }
             onClosed: {
                 root.setMessageActive(root.messageId, false)
+                destroy()
+            }
+        }
+    }
+
+    Component {
+        id: imageContextMenuComponent
+
+        ImageContextMenu {
+            onClosed: {
                 destroy()
             }
         }

--- a/ui/imports/shared/views/chat/ProfileContextMenu.qml
+++ b/ui/imports/shared/views/chat/ProfileContextMenu.qml
@@ -20,8 +20,6 @@ StatusMenu {
     property var store
 
     property string myPublicKey: ""
-    property bool amIChatAdmin: false
-    property bool disabledForChat: false
 
     property string selectedUserPublicKey: ""
     property string selectedUserDisplayName: ""

--- a/ui/imports/shared/views/chat/ProfileContextMenu.qml
+++ b/ui/imports/shared/views/chat/ProfileContextMenu.qml
@@ -1,0 +1,243 @@
+import QtQuick 2.12
+import QtQuick.Controls 2.3
+import QtQuick.Layouts 1.3
+import QtQml.Models 2.3
+
+import StatusQ.Popups 0.1
+import StatusQ.Components 0.1
+
+import utils 1.0
+import shared 1.0
+import shared.panels 1.0
+import shared.popups 1.0
+import shared.status 1.0
+import shared.controls.chat 1.0
+import shared.controls.chat.menuItems 1.0
+
+StatusMenu {
+    id: root
+
+    property var store
+
+    property string myPublicKey: ""
+    property bool amIChatAdmin: false
+    property bool disabledForChat: false
+
+    property string selectedUserPublicKey: ""
+    property string selectedUserDisplayName: ""
+    property string selectedUserIcon: ""
+
+    readonly property bool isMe: {
+        return root.selectedUserPublicKey === root.store.contactsStore.myPublicKey;
+    }
+    readonly property var contactDetails: {
+        if (root.selectedUserPublicKey === "" || isMe) {
+            return {}
+        }
+        return Utils.getContactDetailsAsJson(root.selectedUserPublicKey);
+    }
+    readonly property bool isContact: {
+        return root.selectedUserPublicKey !== "" && !!contactDetails.isContact
+    }
+    readonly property bool isBlockedContact: (!!contactDetails && contactDetails.isBlocked) || false
+
+    readonly property int outgoingVerificationStatus: {
+        if (root.selectedUserPublicKey === "" || root.isMe || !root.isContact) {
+            return 0
+        }
+        return contactDetails.verificationStatus
+    }
+    readonly property int incomingVerificationStatus: {
+        if (root.selectedUserPublicKey === "" || root.isMe || !root.isContact) {
+            return 0
+        }
+        return contactDetails.incomingVerificationStatus
+    }
+    readonly property bool hasPendingContactRequest: {
+        return !root.isMe && root.selectedUserPublicKey !== "" &&
+            root.store.contactsStore.hasPendingContactRequest(root.selectedUserPublicKey);
+    }
+    readonly property bool hasActiveReceivedVerificationRequestFrom: {
+        if (!root.selectedUserPublicKey || root.isMe || !root.isContact) {
+            return false
+        }
+        return contactDetails.incomingVerificationStatus === Constants.verificationStatus.verifying ||
+                contactDetails.incomingVerificationStatus === Constants.verificationStatus.verified
+    }
+    readonly property bool isVerificationRequestSent: {
+        if (!root.selectedUserPublicKey || root.isMe || !root.isContact) {
+            return false
+        }
+        return root.outgoingVerificationStatus !== Constants.verificationStatus.unverified &&
+                root.outgoingVerificationStatus !== Constants.verificationStatus.verified &&
+                root.outgoingVerificationStatus !== Constants.verificationStatus.trusted
+    }
+    readonly property bool isTrusted: {
+        if (!root.selectedUserPublicKey || root.isMe || !root.isContact) {
+            return false
+        }
+        return root.outgoingVerificationStatus === Constants.verificationStatus.trusted ||
+                root.incomingVerificationStatus === Constants.verificationStatus.trusted
+    }
+
+    readonly property bool userTrustIsUnknown: contactDetails && contactDetails.trustStatus === Constants.trustStatus.unknown
+    readonly property bool userIsUntrustworthy: contactDetails && contactDetails.trustStatus === Constants.trustStatus.untrustworthy
+
+    signal openProfileClicked(string publicKey)
+    signal createOneToOneChat(string communityId, string chatId, string ensName)
+
+    onClosed: {
+        // Reset selectedUserPublicKey so that associated properties get recalculated on re-open
+        selectedUserPublicKey = ""
+    }
+
+    width: 230
+
+    ProfileHeader {
+        width: parent.width
+        height: visible ? implicitHeight : 0
+
+        displayNameVisible: false
+        displayNamePlusIconsVisible: true
+        editButtonVisible: false
+        displayName: root.selectedUserDisplayName
+        pubkey: root.selectedUserPublicKey
+        icon: root.selectedUserIcon
+        trustStatus: contactDetails && contactDetails.trustStatus ? contactDetails.trustStatus
+                                                                  : Constants.trustStatus.unknown
+        isContact: root.isContact
+        isCurrentUser: root.isMe
+        userIsEnsVerified: (!!contactDetails && contactDetails.ensVerified) || false
+    }
+
+    StatusMenuSeparator {
+        topPadding: root.topPadding
+    }
+
+    ViewProfileMenuItem {
+        id: viewProfileAction
+        onTriggered: {
+            root.openProfileClicked(root.selectedUserPublicKey)
+            root.close()
+        }
+    }
+
+    SendMessageMenuItem {
+        id: sendMessageMenuItem
+        enabled: root.isContact && !root.isBlockedContact
+        onTriggered: {
+            root.createOneToOneChat("", root.selectedUserPublicKey, "")
+            root.close()
+        }
+    }
+
+    SendContactRequestMenuItem {
+        id: sendContactRequestMenuItem
+        enabled: !root.isMe && !root.isContact
+                                && !root.isBlockedContact && !root.hasPendingContactRequest
+        onTriggered: {
+            Global.openContactRequestPopup(root.selectedUserPublicKey, null)
+            root.close()
+        }
+    }
+
+    StatusAction {
+        id: verifyIdentityAction
+        text: qsTr("Verify Identity")
+        icon.name: "checkmark-circle"
+        enabled: !root.isMe && root.isContact
+                                && !root.isBlockedContact
+                                && root.outgoingVerificationStatus === Constants.verificationStatus.unverified
+                                && !root.hasActiveReceivedVerificationRequestFrom
+        onTriggered: {
+            Global.openSendIDRequestPopup(root.selectedUserPublicKey, null)
+            root.close()
+        }
+    }
+
+    StatusAction {
+        id: pendingIdentityAction
+        text: isVerificationRequestSent ||
+            root.incomingVerificationStatus === Constants.verificationStatus.verified ?
+            qsTr("ID Request Pending....") :
+            qsTr("Respond to ID Request...")
+        icon.name: "checkmark-circle"
+        enabled: !root.isMe && root.isContact
+                                && !root.isBlockedContact && !root.isTrusted
+                                && (root.hasActiveReceivedVerificationRequestFrom
+                                    || root.isVerificationRequestSent)
+        onTriggered: {
+            if (hasActiveReceivedVerificationRequestFrom) {
+                Global.openIncomingIDRequestPopup(root.selectedUserPublicKey, null)
+            } else if (root.isVerificationRequestSent) {
+                Global.openOutgoingIDRequestPopup(root.selectedUserPublicKey, null)
+            }
+
+            root.close()
+        }
+    }
+
+    StatusAction {
+        id: renameAction
+        text: qsTr("Rename")
+        icon.name: "edit_pencil"
+        enabled: !root.isMe
+        onTriggered: {
+            Global.openNicknamePopupRequested(root.selectedUserPublicKey, contactDetails.localNickname,
+                                              "%1 (%2)".arg(root.selectedUserDisplayName).arg(Utils.getElidedCompressedPk(root.selectedUserPublicKey)))
+            root.close()
+        }
+    }
+
+    StatusAction {
+        id: unblockAction
+        text: qsTr("Unblock User")
+        icon.name: "remove-circle"
+        enabled: !root.isMe && root.isBlockedContact
+        onTriggered: Global.unblockContactRequested(root.selectedUserPublicKey, root.selectedUserDisplayName)
+    }
+
+    StatusMenuSeparator {
+        visible: blockMenuItem.enabled
+                 || markUntrustworthyMenuItem.enabled
+                 || removeUntrustworthyMarkMenuItem.enabled
+    }
+
+    StatusAction {
+        id: markUntrustworthyMenuItem
+        text: qsTr("Mark as Untrustworthy")
+        icon.name: "warning"
+        type: StatusAction.Type.Danger
+        enabled: !root.isMe && root.userTrustIsUnknown
+        onTriggered: root.store.contactsStore.markUntrustworthy(root.selectedUserPublicKey)
+    }
+
+    StatusAction {
+        id: removeUntrustworthyMarkMenuItem
+        text: qsTr("Remove Untrustworthy Mark")
+        icon.name: "warning"
+        enabled: !root.isMe && root.userIsUntrustworthy
+        onTriggered: root.store.contactsStore.removeTrustStatus(root.selectedUserPublicKey)
+    }
+
+    StatusAction {
+        text: qsTr("Remove Contact")
+        icon.name: "remove-contact"
+        type: StatusAction.Type.Danger
+        enabled: root.isContact && !root.isBlockedContact && !root.hasPendingContactRequest
+        onTriggered: {
+            Global.removeContactRequested(root.selectedUserDisplayName, root.selectedUserPublicKey)
+            root.close()
+        }
+    }
+
+    StatusAction {
+        id: blockMenuItem
+        text: qsTr("Block User")
+        icon.name: "cancel"
+        type: StatusAction.Type.Danger
+        enabled: !root.isMe && !root.isBlockedContact
+        onTriggered: Global.blockContactRequested(root.selectedUserPublicKey, root.selectedUserDisplayName)
+    }
+
+}

--- a/ui/imports/shared/views/chat/qmldir
+++ b/ui/imports/shared/views/chat/qmldir
@@ -11,4 +11,5 @@ TransactionBubbleView 1.0 TransactionBubbleView.qml
 NewMessagesMarker 1.0 NewMessagesMarker.qml
 SimplifiedMessageView 1.0 SimplifiedMessageView.qml
 ImageContextMenu 1.0 ImageContextMenu.qml
+ProfileContextMenu 1.0 ProfileContextMenu.qml
 MessageAddReactionContextMenu 1.0 MessageAddReactionContextMenu.qml

--- a/ui/imports/shared/views/chat/qmldir
+++ b/ui/imports/shared/views/chat/qmldir
@@ -10,3 +10,4 @@ ProfileHeaderContextMenuView 1.0 ProfileHeaderContextMenuView.qml
 TransactionBubbleView 1.0 TransactionBubbleView.qml
 NewMessagesMarker 1.0 NewMessagesMarker.qml
 SimplifiedMessageView 1.0 SimplifiedMessageView.qml
+ImageContextMenu 1.0 ImageContextMenu.qml

--- a/ui/imports/shared/views/chat/qmldir
+++ b/ui/imports/shared/views/chat/qmldir
@@ -11,3 +11,4 @@ TransactionBubbleView 1.0 TransactionBubbleView.qml
 NewMessagesMarker 1.0 NewMessagesMarker.qml
 SimplifiedMessageView 1.0 SimplifiedMessageView.qml
 ImageContextMenu 1.0 ImageContextMenu.qml
+MessageAddReactionContextMenu 1.0 MessageAddReactionContextMenu.qml

--- a/ui/imports/utils/Global.qml
+++ b/ui/imports/utils/Global.qml
@@ -42,6 +42,7 @@ QtObject {
     signal openInviteFriendsToCommunityPopup(var community, var communitySectionModule, var cb)
     signal openIncomingIDRequestPopup(string publicKey, var cb)
     signal openOutgoingIDRequestPopup(string publicKey, var cb)
+    signal openDeleteMessagePopup(string messageId, var messageStore)
     signal contactRenamed(string publicKey)
 
     signal openLink(string link)

--- a/ui/imports/utils/Global.qml
+++ b/ui/imports/utils/Global.qml
@@ -80,9 +80,12 @@ QtObject {
         root.appSectionBySectionTypeChanged(sectionType, subsection);
     }
 
-    function openMenu(menuComponent, menuParent, params = {}) {
+    function openMenu(menuComponent, menuParent, params = {}, point = undefined) {
         const menu = menuComponent.createObject(menuParent, params)
-        menu.popup()
+        if (point)
+            menu.popup(point)
+        else
+            menu.popup()
         return menu
     }
 }

--- a/ui/imports/utils/Global.qml
+++ b/ui/imports/utils/Global.qml
@@ -32,7 +32,7 @@ QtObject {
     signal openDownloadModalRequested(bool available, string version, string url)
     signal openChangeProfilePicPopup(var cb)
     signal openBackUpSeedPopup()
-    signal openImagePopup(var image, var contextMenu)
+    signal openImagePopup(var image)
     signal openProfilePopupRequested(string publicKey, var parentPopup)
     signal openEditDisplayNamePopup()
     signal openActivityCenterPopupRequested()
@@ -43,6 +43,7 @@ QtObject {
     signal openIncomingIDRequestPopup(string publicKey, var cb)
     signal openOutgoingIDRequestPopup(string publicKey, var cb)
     signal openDeleteMessagePopup(string messageId, var messageStore)
+    signal openDownloadImageDialog(string imageSource)
     signal contactRenamed(string publicKey)
 
     signal openLink(string link)
@@ -77,5 +78,11 @@ QtObject {
 
     function changeAppSectionBySectionType(sectionType, subsection = 0) {
         root.appSectionBySectionTypeChanged(sectionType, subsection);
+    }
+
+    function openMenu(menuComponent, menuParent, params = {}) {
+        const menu = menuComponent.createObject(menuParent, params)
+        menu.popup()
+        return menu
     }
 }

--- a/ui/imports/utils/Utils.qml
+++ b/ui/imports/utils/Utils.qml
@@ -678,6 +678,14 @@ QtObject {
         return text
     }
 
+    function copyImageToClipboardByUrl(content) {
+        globalUtilsInst.copyImageToClipboardByUrl(content)
+    }
+
+    function downloadImageByUrl(url, path) {
+        globalUtilsInst.downloadImageByUrl(url, path)
+    }
+
     // Leave this function at the bottom of the file as QT Creator messes up the code color after this
     function isPunct(c) {
         return /(!|\@|#|\$|%|\^|&|\*|\(|\)|\+|\||-|=|\\|{|}|[|]|"|;|'|<|>|\?|,|\.|\/)/.test(c)


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/10437
Fixes https://github.com/status-im/status-desktop/issues/10695
Fixes https://github.com/status-im/status-desktop/issues/10737
Fixes https://github.com/status-im/status-desktop/issues/10738

### What does the PR do

1. Separate `ProfileContextMenu`
3. Separate `ImageContextMenu`
4. Separate `AddReactionContextMenu`
5. Separate context menu for `PinnedMessagesPopup`
6. Moved `deleteMessageConfirmationDialogComponent` to `Popups`
7. Moved `FileDialog` to Popups
8. All mentioned menus are moved to where they're created
9. All mentioned menus are created dynamically and destroyed on closing
10. Bind `MessageView.setActiveState` to menus `opened/closed` signals
11. Edit image menu in `ProfileDialog` is created dynamically
12. Right-click on an Image message works now
13. Editing an sticker message is disabled from menu

Also minor bugfixes on the way:
1. Fixed opening context menu on Image message
3. `StatusMenu` default all sides `margins`

### Affected areas

* Message context menu
* Message "Add Reaction" context menu
* `PinnedMessagesPopup` message context menu
* Profile context menus
* ImageModal context menu