### PR TITLE
feat(category): hook category Drag and Drop to backend correctly

### DIFF
--- a/src/app/modules/main/chat_section/controller.nim
+++ b/src/app/modules/main/chat_section/controller.nim
@@ -615,7 +615,7 @@ proc inviteUsersToCommunity*(self: Controller, pubKeys: string, inviteMessage: s
 proc reorderCommunityCategories*(self: Controller, categoryId: string, position: int) =
   self.communityService.reorderCommunityCategories(self.sectionId, categoryId, position)
 
-proc reorderCommunityChat*(self: Controller, categoryId: string, chatId: string, position: int): string =
+proc reorderCommunityChat*(self: Controller, categoryId: string, chatId: string, position: int) =
   self.communityService.reorderCommunityChat(self.sectionId, categoryId, chatId, position)
 
 proc getRenderedText*(self: Controller, parsedTextArray: seq[ParsedText], communityChats: seq[ChatDto]): string =

--- a/src/app/modules/main/chat_section/io_interface.nim
+++ b/src/app/modules/main/chat_section/io_interface.nim
@@ -328,7 +328,7 @@ method prepareEditCategoryModel*(self: AccessInterface, categoryId: string) {.ba
 method reorderCommunityCategories*(self: AccessInterface, categoryId: string, position: int) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method reorderCommunityChat*(self: AccessInterface, categoryId: string, chatId: string, position: int): string {.base.} =
+method reorderCommunityChat*(self: AccessInterface, categoryId: string, chatId: string, position: int) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method downloadMessages*(self: AccessInterface, chatId: string, filePath: string) {.base.} =

--- a/src/app/modules/main/chat_section/model.nim
+++ b/src/app/modules/main/chat_section/model.nim
@@ -174,15 +174,6 @@ QtObject:
   proc getItemIdxById*(self: Model, id: string): int =
     return getItemIdxById(self.items, id)
 
-  proc getClosestCategoryAtIndex*(self: Model, index: int): tuple[categoryIem: Item, categoryIndex: int] =
-    if index > self.items.len:
-      return (Item(), -1)
-    # Count down from the index to 0 and find the first category
-    for i in countdown(index - 1, 0):
-      if self.items[i].isCategory:
-        return (self.items[i], i)
-    return (Item(), -1)
-
   proc cmpChatsAndCats*(x, y: Item): int =
     # Sort proc to compare chats and categories
     # Compares first by categoryPosition, then by position

--- a/src/app/modules/main/chat_section/model.nim
+++ b/src/app/modules/main/chat_section/model.nim
@@ -532,6 +532,8 @@ QtObject:
       categoryId: string,
       position: int,
     ) =
+    self.beginResetModel()
+
     for i in 0 ..< self.items.len:
       var item = self.items[i]
       if item.categoryId != categoryId:
@@ -539,8 +541,9 @@ QtObject:
       if item.categoryPosition == position:
         continue
       item.categoryPosition = position
-      let modelIndex = self.createIndex(i, 0, nil)
-      self.dataChanged(modelIndex, modelIndex, @[ModelRole.CategoryPosition.int])
+
+    self.items.sort(cmpChatsAndCats)
+    self.endResetModel()
 
   proc clearItems*(self: Model) =
     self.beginResetModel()

--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -1123,28 +1123,15 @@ method prepareEditCategoryModel*(self: Module, categoryId: string) =
     )
     self.view.editCategoryChannelsModel().appendItem(chatItem, ignoreCategory = true)
 
-method reorderCommunityCategories*(self: Module, categoryId: string, categoryPositon: int) =
-  var finalPosition = categoryPositon
+method reorderCommunityCategories*(self: Module, categoryId: string, categoryPosition: int) =
+  var finalPosition = categoryPosition
   if finalPosition < 0:
     finalPosition = 0
 
   self.controller.reorderCommunityCategories(categoryId, finalPosition)
 
-method reorderCommunityChat*(self: Module, categoryId: string, chatId: string, toPosition: int): string =
-  # Calculate actual position, since the position coming from the UI is assuming a single list where categories are items
-  # eg: if we have 2 categories with 2 channels each, then it means 6 items (2 categories, 2 chats)
-  #  if we move the 2nd channel of the 2nd category to the 1st position of the 2nd category, then the UI would say
-  #  that we move the chat from position 5 to position 4
-  #  We need to translate that to position 1 of category 2
-  let (category, categoryIndex) = self.view.chatsModel().getClosestCategoryAtIndex(toPosition + 1)
-  var categoryId = ""
-  var newPos = toPosition
-  if (categoryIndex > -1):
-    categoryId = category.id
-    newPos = toPosition - categoryIndex - 1 # position is 0 based
-  if newPos < 0:
-    newPos = 0
-  self.controller.reorderCommunityChat(categoryId, chatId, newPos)
+method reorderCommunityChat*(self: Module, categoryId: string, chatId: string, toPosition: int) =
+  self.controller.reorderCommunityChat(categoryId, chatId, toPosition + 1)
 
 method setLoadingHistoryMessagesInProgress*(self: Module, isLoading: bool) =
   self.view.setLoadingHistoryMessagesInProgress(isLoading)

--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -1123,8 +1123,12 @@ method prepareEditCategoryModel*(self: Module, categoryId: string) =
     )
     self.view.editCategoryChannelsModel().appendItem(chatItem, ignoreCategory = true)
 
-method reorderCommunityCategories*(self: Module, categoryId: string, position: int) =
-  self.controller.reorderCommunityCategories(categoryId, position)
+method reorderCommunityCategories*(self: Module, categoryId: string, categoryPositon: int) =
+  var finalPosition = categoryPositon
+  if finalPosition < 0:
+    finalPosition = 0
+
+  self.controller.reorderCommunityCategories(categoryId, finalPosition)
 
 method reorderCommunityChat*(self: Module, categoryId: string, chatId: string, toPosition: int): string =
   # Calculate actual position, since the position coming from the UI is assuming a single list where categories are items

--- a/src/app/modules/main/chat_section/view.nim
+++ b/src/app/modules/main/chat_section/view.nim
@@ -344,10 +344,10 @@ QtObject:
   proc prepareEditCategoryModel*(self: View, categoryId: string) {.slot.} =
     self.delegate.prepareEditCategoryModel(categoryId)
 
-  proc reorderCommunityCategories*(self: View, categoryId: string, categoryPositon: int) {.slot} =
-    self.delegate.reorderCommunityCategories(categoryId, categoryPositon)
+  proc reorderCommunityCategories*(self: View, categoryId: string, categoryPosition: int) {.slot} =
+    self.delegate.reorderCommunityCategories(categoryId, categoryPosition)
 
-  proc reorderCommunityChat*(self: View, categoryId: string, chatId: string, position: int): string {.slot} =
+  proc reorderCommunityChat*(self: View, categoryId: string, chatId: string, position: int) {.slot} =
     self.delegate.reorderCommunityChat(categoryId, chatId, position)
     
   proc loadingHistoryMessagesInProgressChanged*(self: View) {.signal.}

--- a/src/app/modules/main/chat_section/view.nim
+++ b/src/app/modules/main/chat_section/view.nim
@@ -344,8 +344,8 @@ QtObject:
   proc prepareEditCategoryModel*(self: View, categoryId: string) {.slot.} =
     self.delegate.prepareEditCategoryModel(categoryId)
 
-  proc reorderCommunityCategories*(self: View, categoryId: string, position: int) {.slot} =
-    self.delegate.reorderCommunityCategories(categoryId, position)
+  proc reorderCommunityCategories*(self: View, categoryId: string, categoryPositon: int) {.slot} =
+    self.delegate.reorderCommunityCategories(categoryId, categoryPositon)
 
   proc reorderCommunityChat*(self: View, categoryId: string, chatId: string, position: int): string {.slot} =
     self.delegate.reorderCommunityChat(categoryId, chatId, position)

--- a/src/app_service/service/community/service.nim
+++ b/src/app_service/service/community/service.nim
@@ -399,22 +399,22 @@ QtObject:
 
   proc checkForCategoryPropertyUpdates(self: Service, community: CommunityDto, prev_community: CommunityDto) =
     for category in community.categories:
-          # id is present
-          let index = findIndexById(category.id, prev_community.categories)
-          if index == -1:
-            continue
-          # but something is different
-          let prev_category = prev_community.categories[index]
+      # id is present
+      let index = findIndexById(category.id, prev_community.categories)
+      if index == -1:
+        continue
+      # but something is different
+      let prev_category = prev_community.categories[index]
 
-          if category.position != prev_category.position:
-            self.events.emit(SIGNAL_COMMUNITY_CATEGORY_REORDERED,
-              CommunityCategoryOrderArgs(
-                communityId: community.id,
-                categoryId: category.id,
-                position: category.position))
-          if category.name != prev_category.name:
-            self.events.emit(SIGNAL_COMMUNITY_CATEGORY_NAME_EDITED,
-              CommunityCategoryArgs(communityId: community.id, category: category))
+      if category.position != prev_category.position:
+        self.events.emit(SIGNAL_COMMUNITY_CATEGORY_REORDERED,
+          CommunityCategoryOrderArgs(
+            communityId: community.id,
+            categoryId: category.id,
+            position: category.position))
+      if category.name != prev_category.name:
+        self.events.emit(SIGNAL_COMMUNITY_CATEGORY_NAME_EDITED,
+          CommunityCategoryArgs(communityId: community.id, category: category))
 
     
   proc handleCommunityUpdates(self: Service, communities: seq[CommunityDto], updatedChats: seq[ChatDto], removedChats: seq[string]) =
@@ -1313,6 +1313,10 @@ QtObject:
         let error = Json.decode($response.error, RpcError)
         raise newException(RpcException, "Error reordering community category: " & error.message)
 
+      let updatedCommunity = response.result["communities"][0].toCommunityDto()
+      # Update community categories
+      self.checkForCategoryPropertyUpdates(updatedCommunity, self.communities[communityId])
+      self.communities[communityId].categories = updatedCommunity.categories
     except Exception as e:
       error "Error reordering category channel", msg = e.msg, communityId, categoryId, position
 

--- a/ui/StatusQ/src/StatusQ/Components/StatusChatList.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusChatList.qml
@@ -51,6 +51,7 @@ Item {
             readonly property int visualIndex: index
             readonly property string chatId: model.itemId
             readonly property string categoryId: model.categoryId
+            readonly property int position: model.position // needed for the DnD
             readonly property int categoryPosition: model.categoryPosition // needed for the DnD
             readonly property bool isCategory: model.isCategory
             readonly property Item item: isCategory ? draggableItem.actions[0] : draggableItem.actions[1]
@@ -70,10 +71,18 @@ Item {
                 const to = chatListDelegate.visualIndex;
                 if (to === from)
                     return;
-                if (!drop.source.isCategory) {
-                    root.chatItemReordered(statusChatListItems.itemAtIndex(from).categoryId, statusChatListItems.itemAtIndex(from).chatId, to);
+                if (drop.source.isCategory) {
+                    root.categoryReordered(
+                        statusChatListItems.itemAtIndex(from).categoryId,
+                        statusChatListItems.itemAtIndex(to).categoryPosition
+                    );
+                    
                 } else {
-                    root.categoryReordered(statusChatListItems.itemAtIndex(from).categoryId, statusChatListItems.itemAtIndex(to).categoryPosition);
+                    root.chatItemReordered(
+                        statusChatListItems.itemAtIndex(to).categoryId,
+                        statusChatListItems.itemAtIndex(from).chatId,
+                        statusChatListItems.itemAtIndex(to).position,
+                    );
                 }
             }
 

--- a/ui/StatusQ/src/StatusQ/Components/StatusChatList.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusChatList.qml
@@ -51,6 +51,7 @@ Item {
             readonly property int visualIndex: index
             readonly property string chatId: model.itemId
             readonly property string categoryId: model.categoryId
+            readonly property int categoryPosition: model.categoryPosition // needed for the DnD
             readonly property bool isCategory: model.isCategory
             readonly property Item item: isCategory ? draggableItem.actions[0] : draggableItem.actions[1]
 
@@ -72,7 +73,7 @@ Item {
                 if (!drop.source.isCategory) {
                     root.chatItemReordered(statusChatListItems.itemAtIndex(from).categoryId, statusChatListItems.itemAtIndex(from).chatId, to);
                 } else {
-                    root.categoryReordered(statusChatListItems.itemAtIndex(from).categoryId, to);
+                    root.categoryReordered(statusChatListItems.itemAtIndex(from).categoryId, statusChatListItems.itemAtIndex(to).categoryPosition);
                 }
             }
 


### PR DESCRIPTION
Fixes #10733

The category Drag and Drop code was already pretty much all there. It just needed to be hooked appropriately and to change the model code to adapt to the new sorted model. 

[cat-dnd.webm](https://github.com/status-im/status-desktop/assets/11926403/5026c8d6-0507-472a-bc4e-3c3b34f102b7)

edit: I added a new commit that improves the code for the chat reorder too by passing the new position and category directly
