### PR TITLE
feat(communities): Makes `requestToJoinCommunity` async

### DIFF
--- a/src/app/modules/main/chat_section/controller.nim
+++ b/src/app/modules/main/chat_section/controller.nim
@@ -90,12 +90,12 @@ proc setIsCurrentSectionActive*(self: Controller, active: bool) =
   self.isCurrentSectionActive = active
 
 proc requestToJoinCommunityAuthenticated*(self: Controller, password: string) =
-  self.communityService.requestToJoinCommunity(self.tmpRequestToJoinCommunityId, self.tmpRequestToJoinEnsName, password)
+  self.communityService.asyncRequestToJoinCommunity(self.tmpRequestToJoinCommunityId, self.tmpRequestToJoinEnsName, password)
   self.tmpRequestToJoinCommunityId = ""
   self.tmpRequestToJoinEnsName = ""
 
 proc requestToJoinCommunity*(self: Controller, communityId: string, ensName: string) =
-  self.communityService.requestToJoinCommunity(communityId, ensName, "")
+  self.communityService.asyncRequestToJoinCommunity(communityId, ensName, "")
 
 proc authenticate*(self: Controller, keyUid = "") =
   let data = SharedKeycarModuleAuthenticationArgs(uniqueIdentifier: UNIQUE_MAIN_MODULE_AUTH_IDENTIFIER,

--- a/src/app/modules/main/communities/controller.nim
+++ b/src/app/modules/main/communities/controller.nim
@@ -123,7 +123,7 @@ proc cancelRequestToJoinCommunity*(self: Controller, communityId: string) =
   self.communityService.cancelRequestToJoinCommunity(communityId)
 
 proc requestToJoinCommunity*(self: Controller, communityId: string, ensName: string) =
-  self.communityService.requestToJoinCommunity(communityId, ensName, password="")
+  self.communityService.asyncRequestToJoinCommunity(communityId, ensName, password="")
 
 proc createCommunity*(
     self: Controller,

--- a/src/app_service/service/community/async_tasks.nim
+++ b/src/app_service/service/community/async_tasks.nim
@@ -79,3 +79,26 @@ const asyncAcceptRequestToJoinCommunityTask: Task = proc(argEncoded: string) {.g
       "communityId": arg.communityId,
       "requestId": arg.requestId
     })
+
+type
+  AsyncRequestToJoinCommunityTaskArg = ref object of QObjectTaskArg
+    communityId: string
+    ensName: string
+    password: string
+
+const asyncRequestToJoinCommunityTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+  let arg = decode[AsyncRequestToJoinCommunityTaskArg](argEncoded)
+  try:
+    let response = status_go.requestToJoinCommunity(arg.communityId, arg.ensName, arg.password)
+    arg.finish(%* {
+      "response": response,
+      "communityId": arg.communityId,
+      "error": "",
+    })
+  except Exception as e:
+    arg.finish(%* {
+      "error": e.msg,
+      "communityId": arg.communityId,
+      "ensName": arg.ensName,
+      "password": arg.password
+    })

--- a/ui/app/AppLayouts/Chat/views/CommunityColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/CommunityColumnView.qml
@@ -95,6 +95,7 @@ Item {
             function onCommunityAccessRequested(communityId: string) {
                 if (communityId === communityData.id) {
                     joinCommunityButton.invitationPending = root.store.isCommunityRequestPending(communityData.id)
+                    joinCommunityButton.loading = false
                 }
             }
         }
@@ -108,7 +109,10 @@ Item {
             imageSrc: communityData.image
             accessType: communityData.access
 
-            onJoined: root.store.requestToJoinCommunity(communityData.id, root.store.userProfileInst.name)
+            onJoined: {
+                joinCommunityButton.loading = true
+                root.store.requestToJoinCommunity(communityData.id, root.store.userProfileInst.name)
+            }
             onCancelMembershipRequest: {
                 root.store.cancelPendingRequest(communityData.id)
                 joinCommunityButton.invitationPending = root.store.isCommunityRequestPending(communityData.id)


### PR DESCRIPTION
Fixes: #10719

### What does the PR do

- Makes request to join async
- Add `Loading...` everywhere when `Pending` state was used

### Affected areas

Request to join community 

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

