### PR TITLE
AC order fix and small cleanup

### DIFF
--- a/src/app/modules/main/activity_center/controller.nim
+++ b/src/app/modules/main/activity_center/controller.nim
@@ -46,6 +46,11 @@ proc updateActivityGroupCounters*(self: Controller) =
   self.delegate.setActivityGroupCounters(counters)
 
 proc init*(self: Controller) =
+  self.events.once(chat_service.SIGNAL_CHANNEL_GROUPS_LOADED) do(e:Args):
+    # Only fectch activity center notification once channel groups are loaded,
+    # since we need the chats to associate the notifications to
+    self.activity_center_service.asyncActivityNotificationLoad()
+
   self.events.on(activity_center_service.SIGNAL_ACTIVITY_CENTER_NOTIFICATIONS_LOADED) do(e: Args):
     let args = ActivityCenterNotificationsArgs(e)
     self.delegate.addActivityCenterNotifications(args.activityCenterNotifications)

--- a/src/app/modules/main/chat_section/controller.nim
+++ b/src/app/modules/main/chat_section/controller.nim
@@ -406,9 +406,6 @@ proc getChatDetailsForChatTypes*(self: Controller, types: seq[ChatType]): seq[Ch
 proc chatsWithCategoryHaveUnreadMessages*(self: Controller, communityId: string, categoryId: string): bool =
   return self.chatService.chatsWithCategoryHaveUnreadMessages(communityId, categoryId)
 
-proc getCommunityDetails*(self: Controller, communityId: string): CommunityDto =
-  return self.communityService.getCommunityById(communityId)
-
 proc getCommunityCategoryDetails*(self: Controller, communityId: string, categoryId: string): Category =
   return self.communityService.getCategoryById(communityId, categoryId)
 

--- a/src/app_service/service/activity_center/service.nim
+++ b/src/app_service/service/activity_center/service.nim
@@ -119,7 +119,6 @@ QtObject:
     self.events.emit(SIGNAL_ACTIVITY_CENTER_NOTIFICATIONS_COUNT_MAY_HAVE_CHANGED, Args())
 
   proc init*(self: Service) =
-    self.asyncActivityNotificationLoad()
     self.events.on(SignalType.Message.event) do(e: Args):
       let receivedData = MessageSignal(e)
       if (receivedData.activityCenterNotifications.len > 0):

--- a/src/app_service/service/chat/service.nim
+++ b/src/app_service/service/chat/service.nim
@@ -165,13 +165,6 @@ QtObject:
   proc getChannelGroups*(self: Service): seq[ChannelGroupDto] =
     return toSeq(self.channelGroups.values)
 
-  proc loadChannelGroups*(self: Service) =
-    try:
-      let response = status_chat.getChannelGroups()
-      self.hydrateChannelGroups(response.result)
-    except Exception as e:
-      error "error loadChannelGroups: ", errorDescription = e.msg
-
   proc loadChannelGroupById*(self: Service, channelGroupId: string) =
     try:
       let response = status_chat.getChannelGroupById(channelGroupId)
@@ -329,15 +322,14 @@ QtObject:
 
   # Community channel groups have less info because they come from community signals
   proc updateOrAddChannelGroup*(self: Service, channelGroup: ChannelGroupDto, isCommunityChannelGroup: bool = false) =
-
-    var newChannelGroups = channelGroup
+    var newChannelGroup = channelGroup
     if isCommunityChannelGroup and self.channelGroups.contains(channelGroup.id):
       # We need to update missing fields in the chats seq before saving
       let newChats = channelGroup.chats.mapIt(self.updateMissingFieldsInCommunityChat(channelGroup.id, it))
-      newChannelGroups.chats = newChats
+      newChannelGroup.chats = newChats
         
-    self.channelGroups[channelGroup.id] = newChannelGroups
-    for chat in newChannelGroups.chats:
+    self.channelGroups[channelGroup.id] = newChannelGroup
+    for chat in newChannelGroup.chats:
       self.updateOrAddChat(chat)
 
   proc getChannelGroupById*(self: Service, channelGroupId: string): ChannelGroupDto =


### PR DESCRIPTION
While trying to find out why the badge resets, I ran into this error that was thrown from the AC because it didn't have the chats yet.

I fixed it by waiting for channels to be loaded before fetching the AC notifications.

The other commit is just some random clean up