### PR TITLE
feat(MintToken): Implement UI burn footer option

### DIFF
--- a/storybook/PagesModel.qml
+++ b/storybook/PagesModel.qml
@@ -146,6 +146,10 @@ ListModel {
         section: "Panels"
     }
     ListElement {
+         title: "BurnTokensPopup"
+         section: "Popups"
+    }
+    ListElement {
         title: "InviteFriendsToCommunityPopup"
         section: "Popups"
     }

--- a/storybook/PagesModel.qml
+++ b/storybook/PagesModel.qml
@@ -178,7 +178,7 @@ ListModel {
          section: "Popups"
     }
     ListElement {
-         title: "SignMintTokenTransactionPopup"
+         title: "SignTokenTransactionsPopup"
          section: "Popups"
     }
     ListElement {

--- a/storybook/figma.json
+++ b/storybook/figma.json
@@ -201,5 +201,10 @@
         "https://www.figma.com/file/17fc13UBFvInrLgNUKJJg5/Kuba%E2%8E%9CDesktop?node-id=28570-546277&t=PVEC7ehRew4RnGFa-0",
         "https://www.figma.com/file/17fc13UBFvInrLgNUKJJg5/Kuba%E2%8E%9CDesktop?node-id=8159%3A416159&t=bTEq7jsSZT0nfC4y-1",
         "https://www.figma.com/file/WQZcp6S0EnzxdTL4taoKDv/Design-System-for-Mobile?node-id=17582-215241&t=8cRmw5jIlzUtfJbY-0"
+    ],
+    "BurnTokensPopup": [
+        "https://www.figma.com/file/17fc13UBFvInrLgNUKJJg5/Kuba%E2%8E%9CDesktop?type=design&node-id=29528%3A588403&t=GUxMZEWcfRO7pXJb-1",
+        "https://www.figma.com/file/17fc13UBFvInrLgNUKJJg5/Kuba%E2%8E%9CDesktop?type=design&node-id=29528%3A588563&t=GUxMZEWcfRO7pXJb-1",
+        "https://www.figma.com/file/17fc13UBFvInrLgNUKJJg5/Kuba%E2%8E%9CDesktop?type=design&node-id=29528%3A587660&t=GUxMZEWcfRO7pXJb-1"
     ]
 }

--- a/storybook/figma.json
+++ b/storybook/figma.json
@@ -184,7 +184,7 @@
     "ProfileSocialLinksPanel": [
         "https://www.figma.com/file/idUoxN7OIW2Jpp3PMJ1Rl8/%E2%9A%99%EF%B8%8F-Settings-%7C-Desktop?node-id=14588%3A308727&t=cwFGbBHsAGOP0T5R-0"
     ],
-    "SignMintTokenTransactionPopup": [
+    "SignTokenTransactionsPopup": [
         "https://www.figma.com/file/17fc13UBFvInrLgNUKJJg5/Kuba%E2%8E%9CDesktop?node-id=27140%3A521359&t=V6wYVbwctoC6uD2E-1"
     ],
     "StatusCommunityCard": [

--- a/storybook/pages/BurnTokensPopupPage.qml
+++ b/storybook/pages/BurnTokensPopupPage.qml
@@ -1,0 +1,126 @@
+import QtQuick 2.14
+import QtQuick.Controls 2.14
+import QtQuick.Layouts 1.14
+
+import Storybook 1.0
+import Models 1.0
+
+import AppLayouts.Chat.popups.community 1.0
+
+SplitView {
+    Logs { id: logs }
+
+    SplitView {
+        orientation: Qt.Vertical
+        SplitView.fillWidth: true
+
+        Item {
+            SplitView.fillWidth: true
+            SplitView.fillHeight: true
+
+            PopupBackground {
+                anchors.fill: parent
+            }
+
+            Button {
+                anchors.centerIn: parent
+                text: "Reopen"
+
+                onClicked: dialog.open()
+            }
+
+            BurnTokensPopup {
+                id: dialog
+
+                anchors.centerIn: parent
+                communityName: editorCommunity.text
+                tokenName: editorToken.text
+                remainingTokens: editorAmount.text
+                isAsset: assetButton.checked
+                tokenSource: assetButton.checked ? ModelsData.assets.socks :  ModelsData.collectibles.kitty1Big
+
+                onBurnClicked: logs.logEvent("BurnTokensPopup::onBurnClicked --> Burn amount: " + burnAmount)
+                onCancelClicked: logs.logEvent("BurnTokensPopup::onCancelClicked")
+            }
+        }
+
+        LogsAndControlsPanel {
+            id: logsAndControlsPanel
+
+            SplitView.minimumHeight: 100
+            SplitView.preferredHeight: 150
+
+            logsView.logText: logs.logText
+        }
+    }
+
+    Pane {
+        SplitView.minimumWidth: 300
+        SplitView.preferredWidth: 300
+
+        ColumnLayout {
+
+            Label {
+                Layout.fillWidth: true
+                text: "Community name:"
+            }
+
+            TextField {
+                id: editorCommunity
+                background: Rectangle { border.color: 'lightgrey' }
+                Layout.preferredWidth: 200
+                text: "Community lovers"
+            }
+
+            Label {
+                Layout.fillWidth: true
+                Layout.topMargin: 16
+
+                text: "Token name:"
+            }
+
+            TextField {
+                id: editorToken
+                background: Rectangle { border.color: 'lightgrey' }
+                Layout.preferredWidth: 200
+                text: "Anniversary"
+            }
+
+            Label {
+                Layout.fillWidth: true
+                Layout.topMargin: 16
+
+                text: "Amount to burn:"
+            }
+
+            TextField {
+                id: editorAmount
+                background: Rectangle { border.color: 'lightgrey' }
+                Layout.preferredWidth: 200
+                text: "123"
+            }
+
+            Label {
+                Layout.fillWidth: true
+                Layout.topMargin: 16
+
+                text: "Token source:"
+            }
+
+            RadioButton {
+                id: assetButton
+
+                text: "Asset"
+                checked: true
+            }
+
+            RadioButton {
+                id: collectibleButton
+
+                text: "Collectible"
+            }
+        }
+    }
+}
+
+

--- a/storybook/pages/SignTokenTransactionsPopupPage.qml
+++ b/storybook/pages/SignTokenTransactionsPopupPage.qml
@@ -29,18 +29,19 @@ SplitView {
                 onClicked: dialog.open()
             }
 
-            SignMintTokenTransactionPopup {
+            SignTokenTransactionsPopup {
                 id: dialog
 
                 anchors.centerIn: parent
+                title: qsTr("Sign transaction - Self-destruct %1 tokens").arg(dialog.collectibleName)
                 accountName: editorAccount.text
                 collectibleName: editorCollectible.text
                 networkName: editorNetwork.text
                 feeText: editorFee.text
                 isFeeLoading: editorFeeLoader.checked
 
-                onSignTransactionClicked: logs.logEvent("SignMintTokenTransactionPopup::onSignTransactionClicked")
-                onCancelClicked: logs.logEvent("SignMintTokenTransactionPopup::onCancelClicked")
+                onSignTransactionClicked: logs.logEvent("SignTokenTransactionsPopup::onSignTransactionClicked")
+                onCancelClicked: logs.logEvent("SignTokenTransactionsPopup::onCancelClicked")
 
             }
         }

--- a/ui/app/AppLayouts/Chat/panels/communities/CommunityMintTokensSettingsPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/CommunityMintTokensSettingsPanel.qml
@@ -252,10 +252,11 @@ SettingsPageLayout {
                 restoreMode: Binding.RestoreBindingOrValue
             }
 
-            SignMintTokenTransactionPopup {
+            SignTokenTransactionsPopup {
                 id: popup
 
                 anchors.centerIn: Overlay.overlay
+                title: qsTr("Sign transaction - Mint %1 token").arg(popup.collectibleName)
                 collectibleName: parent.name
                 accountName: parent.accountName
                 networkName: parent.chainName
@@ -312,7 +313,7 @@ SettingsPageLayout {
                 onRemotelyDestructClicked: signSelfDestructPopup.open()
             }
 
-            SignMintTokenTransactionPopup {
+            SignTokenTransactionsPopup {
                 id: signSelfDestructPopup
 
                 function signSelfRemoteDestructTransaction() {

--- a/ui/app/AppLayouts/Chat/panels/communities/MintTokensFooterPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/MintTokensFooterPanel.qml
@@ -14,7 +14,7 @@ Control {
     property alias airdropEnabled: airdropButton.enabled
     property alias retailEnabled: retailButton.enabled
     property alias remotelySelfDestructVisible: remotelySelfDestructButton.visible
-    property alias burnEnabled: burnButton.enabled
+    property alias burnVisible: burnButton.visible
 
     signal airdropClicked
     signal retailClicked
@@ -69,7 +69,6 @@ Control {
                 id: burnButton
 
                 icon.name: "delete"
-                visible: false // Post MVP
                 text: qsTr("Burn")
                 type: StatusBaseButton.Type.Danger
                 borderColor: "transparent"

--- a/ui/app/AppLayouts/Chat/popups/community/BurnTokensPopup.qml
+++ b/ui/app/AppLayouts/Chat/popups/community/BurnTokensPopup.qml
@@ -1,0 +1,177 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.14
+import QtQuick.Layouts 1.14
+import QtQml.Models 2.14
+import QtGraphicalEffects 1.0
+
+import StatusQ.Core 0.1
+import StatusQ.Controls 0.1
+import StatusQ.Popups.Dialog 0.1
+import StatusQ.Core.Theme 0.1
+import StatusQ.Core.Utils 0.1
+import StatusQ.Controls.Validators 0.1
+import StatusQ.Components 0.1
+
+import AppLayouts.Chat.panels.communities 1.0
+
+import utils 1.0
+
+StatusDialog {
+    id: root
+
+    property string communityName
+    property string tokenName
+    property int remainingTokens
+    property url tokenSource
+    property bool isAsset // If asset isAsset = true; if collectible --> isAsset = false
+
+    signal burnClicked(int burnAmount)
+    signal cancelClicked
+
+    QtObject {
+        id: d
+
+        property alias amountToBurn: amountToBurnInput.text
+
+        function initialize() {
+            specificAmountButton.checked = true
+            amountToBurnInput.forceActiveFocus()
+        }
+
+        function getVerticalPadding() {
+            return root.topPadding + root.bottomPadding
+        }
+
+        function getHorizontalPadding() {
+            return root.leftPadding + root.rightPadding
+        }
+    }
+
+    implicitWidth: 600 // by design
+    implicitHeight: content.implicitHeight + footer.height + header.height + d.getVerticalPadding()
+
+    contentItem: ColumnLayout {
+        id: content
+
+        spacing: Style.current.padding
+
+        StatusBaseText {
+            Layout.fillWidth: true
+
+            text: qsTr("How many of %1’s remaining %n %2 tokens would you like to burn?", "", root.remainingTokens).arg(root.communityName).arg(root.tokenName)
+            wrapMode: Text.WordWrap
+            lineHeight: 1.2
+            font.pixelSize: Style.current.primaryTextFontSize
+        }
+
+        RowLayout {
+            Layout.bottomMargin: 12
+            Layout.leftMargin: -Style.current.halfPadding
+
+            spacing: 26
+
+            ColumnLayout {
+                StatusRadioButton {
+                    id: specificAmountButton
+
+                    text: qsTr("Specific amount")
+                    font.pixelSize: Style.current.primaryTextFontSize
+                    ButtonGroup.group: radioGroup
+
+                    onToggled: if(checked) amountToBurnInput.forceActiveFocus()
+                }
+
+                StatusInput {
+                    id: amountToBurnInput
+
+                    Layout.preferredWidth: 192
+                    Layout.leftMargin: 30
+                    enabled: specificAmountButton.checked
+                    validationMode: StatusInput.ValidationMode.OnlyWhenDirty
+                    validators: [
+                        StatusValidator {
+                            validate: (value) => { return (parseInt(value) > 0 && parseInt(value) <= root.remainingTokens) }
+                            errorMessage: qsTr("Exceeds available remaining")
+                        },
+                        StatusValidator {
+                            validate: (value) => { return parseInt(value) !== 0 }
+                            errorMessage: qsTr("Amount must be greater than 0")
+                        },
+                        StatusRegularExpressionValidator {
+                            regularExpression: Constants.regularExpressions.numerical
+                            errorMessage: qsTr("Invalid characters (0-9 only)")
+                        }
+                    ]
+                }
+            }
+
+            StatusRadioButton {
+                id: allTokensButton
+
+                Layout.alignment: Qt.AlignTop
+
+                text: qsTr("All available remaining (%1)").arg(root.remainingTokens)
+                font.pixelSize: Style.current.primaryTextFontSize
+                ButtonGroup.group: radioGroup
+            }
+
+            ButtonGroup { id: radioGroup }
+        }
+    }
+
+    header: StatusDialogHeader {
+        headline.title: qsTr("Burn %1 tokens").arg(root.tokenName)       
+        headline.subtitle: qsTr("%n %1 remaining in smart contract", "", root.remainingTokens).arg(root.tokenName)
+        leftComponent: Rectangle {
+            height: 40
+            width: height
+            radius: root.isAsset ? height/2 : 8
+            color:Theme.palette.baseColor2
+
+            Image {
+                id: image
+
+                source: root.tokenSource
+                anchors.fill: parent
+                fillMode: Image.PreserveAspectFit
+                visible: false
+            }
+
+            OpacityMask {
+                anchors.fill: image
+                source: image
+                maskSource: parent
+            }
+        }
+        actions.closeButton.onClicked: root.close()
+    }
+
+    footer: StatusDialogFooter {
+        spacing: Style.current.padding
+        rightButtons: ObjectModel {
+            StatusButton {
+                text: qsTr("Cancel")
+                normalColor: "transparent"
+
+                onClicked: {
+                    root.cancelClicked()
+                    close()
+                }
+            }
+
+            StatusButton {
+                enabled: specificAmountButton.checked && amountToBurnInput.valid || allTokensButton.checked
+                text: qsTr("Burn tokens")
+                type: StatusBaseButton.Type.Danger
+                onClicked: {
+                    if(specificAmountButton.checked)
+                        root.burnClicked(parseInt(amountToBurnInput.text))
+                    else
+                        root.burnClicked(root.remainingTokens)
+                }
+            }
+        }
+    }
+
+    onOpened: d.initialize()
+}

--- a/ui/app/AppLayouts/Chat/popups/community/SignTokenTransactionsPopup.qml
+++ b/ui/app/AppLayouts/Chat/popups/community/SignTokenTransactionsPopup.qml
@@ -30,7 +30,6 @@ StatusDialog {
         property int minTextWidth: 50
     }
 
-    title: qsTr("Sign transaction - Mint %1 token").arg(root.collectibleName)
     implicitWidth: 520 // by design
     topPadding: 2 * Style.current.padding // by design
     bottomPadding: topPadding

--- a/ui/app/AppLayouts/Chat/popups/community/qmldir
+++ b/ui/app/AppLayouts/Chat/popups/community/qmldir
@@ -3,4 +3,4 @@ CreateChannelPopup 1.0 CreateChannelPopup.qml
 CommunityTokenPermissionsPopup 1.0 CommunityTokenPermissionsPopup.qml
 RemotelyDestructPopup 1.0 RemotelyDestructPopup.qml
 RemotelyDestructAlertPopup 1.0 RemotelyDestructAlertPopup.qml
-SignMintTokenTransactionPopup 1.0 SignMintTokenTransactionPopup.qml
+SignTokenTransactionsPopup 1.0 SignTokenTransactionsPopup.qml

--- a/ui/app/AppLayouts/Chat/popups/community/qmldir
+++ b/ui/app/AppLayouts/Chat/popups/community/qmldir
@@ -1,3 +1,4 @@
+BurnTokensPopup 1.0 BurnTokensPopup.qml
 CreateChannelPopup 1.0 CreateChannelPopup.qml
 CommunityTokenPermissionsPopup 1.0 CommunityTokenPermissionsPopup.qml
 RemotelyDestructPopup 1.0 RemotelyDestructPopup.qml

--- a/ui/app/AppLayouts/Chat/views/CommunitySettingsView.qml
+++ b/ui/app/AppLayouts/Chat/views/CommunitySettingsView.qml
@@ -277,6 +277,7 @@ StatusSectionLayout {
                 readonly property CommunityTokensStore communityTokensStore:
                     rootStore.communityTokensStore
 
+                communityName: root.community.name
                 tokensModel: root.community.communityTokens
                 layer1Networks: communityTokensStore.layer1Networks
                 layer2Networks: communityTokensStore.layer2Networks
@@ -309,6 +310,8 @@ StatusSectionLayout {
                                                                         accountName,
                                                                         accountAddress)
                 }
+                onSignBurnTransactionOpened: communityTokensStore.computeBurnFee(chainId)
+                onBurnCollectibles: communityTokensStore.burnCollectibles(tokenKey, amount)
                 onAirdropCollectible: root.goTo(Constants.CommunitySettingsSections.Airdrops)
 
                 Connections {

--- a/ui/imports/shared/stores/CommunityTokensStore.qml
+++ b/ui/imports/shared/stores/CommunityTokensStore.qml
@@ -16,6 +16,7 @@ QtObject {
     signal deployFeeUpdated(var ethCurrency, var fiatCurrency, int error)
     signal deploymentStateChanged(string communityId, int status, string url)
     signal selfDestructFeeUpdated(string value) // TO BE REMOVED
+    signal burnFeeUpdated(string value) // TO BE REMOVED
 
     // Minting tokens:
     function deployCollectible(communityId, accountAddress, name, symbol, description, supply,
@@ -42,6 +43,7 @@ QtObject {
         communityTokensModuleInst.computeDeployFee(chainId, accountAddress)
     }
 
+    // Remotely destruct:
     function computeSelfDestructFee(chainId) {
         // TODO BACKEND
         root.selfDestructFeeUpdated("0,0005 ETH")
@@ -52,6 +54,18 @@ QtObject {
         // TODO BACKEND
         // selfDestructTokensList is a js array with properties: `walletAddress` and `amount`
         console.warn("TODO: Remote self-destruct collectible backend")
+    }
+
+    // Burn:
+    function computeBurnFee(chainId) {
+        // TODO BACKEND
+        root.burnFeeUpdated("0,0010 ETH")
+        console.warn("TODO: Compute burn fee backend")
+    }
+
+    function burnCollectibles(tokenKey,burnAmount) {
+        // TODO BACKEND
+        console.warn("TODO: Burn collectible backend")
     }
 
     // Airdrop tokens:

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -594,6 +594,7 @@ QtObject {
         readonly property var alphanumericalExpanded: /^$|^[a-zA-Z0-9\-_ ]+$/
         readonly property var asciiPrintable:         /^$|^[!-~]+$/
         readonly property var ascii:                  /^$|^[\x00-\x7F]+$/
+        readonly property var numerical: /^\d+$/
     }
 
     readonly property QtObject errorMessages: QtObject {


### PR DESCRIPTION
Closes [#10050](https://github.com/status-im/status-desktop/issues/10050)

### What does the PR do
- It creates new `BurnTokensPopup` and adds it to `storybook`.
- It enables `burn` footer option and integrates `BurnTokensPopup` in mint tokens flow. It also integrates `SignTokenTransaction` in burn flow (added needed signals to interact with backend).

**NOTE**: Only UI. Backend need.

### Affected areas

Community Settings / Mint tokens

### Screenshot of functionality

**APP:**

https://github.com/status-im/status-desktop/assets/97019400/75408a8d-cf7c-44b9-a502-57e97e867ba2

**STORYBOOK:**

https://github.com/status-im/status-desktop/assets/97019400/459e8d58-39ee-41a3-8a40-4b40dbbcd682