### PR TITLE
fix(community-permissions): Fixed failed event sending and fix method declaration

### DIFF
--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -1010,7 +1010,7 @@ method onAcceptRequestToJoinLoading*[T](self: Module[T], communityId: string, me
   if item.id != "":
     item.updatePendingRequestLoadingState(memberKey, true)
 
-method onAcceptRequestToJoinFailed*[T](self: Module[T], communityId: string, memberKey: string) =
+method onAcceptRequestToJoinFailed*[T](self: Module[T], communityId: string, memberKey: string, requestId: string) =
   let item = self.view.model().getItemById(communityId)
   if item.id != "":
     item.updatePendingRequestLoadingState(memberKey, false)

--- a/src/app_service/service/community/service.nim
+++ b/src/app_service/service/community/service.nim
@@ -1367,11 +1367,14 @@ QtObject:
       error "Error accepting request to join community", msg = e.msg 
 
   proc onAsyncAcceptRequestToJoinCommunityDone*(self: Service, response: string) {.slot.} =
+    var communityId: string
+    var requestId: string
+    var userKey: string
     try:
       let rpcResponseObj = response.parseJson
-      let communityId = rpcResponseObj{"communityId"}.getStr
-      let requestId = rpcResponseObj{"requestId"}.getStr
-      let userKey = self.getUserPubKeyFromPendingRequest(communityId, requestId)
+      communityId = rpcResponseObj{"communityId"}.getStr
+      requestId = rpcResponseObj{"requestId"}.getStr
+      userKey = self.getUserPubKeyFromPendingRequest(communityId, requestId)
       if rpcResponseObj{"error"}.kind != JNull and rpcResponseObj{"error"}.getStr != "":
         let errorMessage = rpcResponseObj{"error"}.getStr
 
@@ -1395,7 +1398,7 @@ QtObject:
     except Exception as e:
       let errMsg = e.msg
       error "error accepting request to join: ", errMsg
-      self.events.emit(SIGNAL_ACCEPT_REQUEST_TO_JOIN_FAILED, Args())
+      self.events.emit(SIGNAL_ACCEPT_REQUEST_TO_JOIN_FAILED, CommunityMemberArgs(communityId: communityId, pubKey: userKey, requestId: requestId))
 
   proc asyncLoadCuratedCommunities*(self: Service) =
     self.events.emit(SIGNAL_CURATED_COMMUNITIES_LOADING, Args())


### PR DESCRIPTION
Fixes: #10736

### What does the PR do

The problem was in the `Args()` sending when expected `CommunityMemberArgs` and wrong implementation interface of method. This PR fix the crash, but I still see an error from status-go `message: no opensea client` which means that membership request was not accepted.

### Affected areas

Community permissions 

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?
