### PR TITLE
fix(@desktop/wallet): properly handle collectibles api call errors

### DIFF
--- a/src/app_service/service/collectible/async_tasks.nim
+++ b/src/app_service/service/collectible/async_tasks.nim
@@ -9,6 +9,10 @@ const fetchOwnedCollectiblesTaskArg: Task = proc(argEncoded: string) {.gcsafe, n
   let arg = decode[FetchOwnedCollectiblesTaskArg](argEncoded)
   try:
     let response = collectibles.getOpenseaAssetsByOwnerWithCursor(arg.chainId, arg.address, arg.cursor, arg.limit)
+
+    if not response.error.isNil:
+      raise newException(ValueError, "Error getOpenseaAssetsByOwnerWithCursor" & response.error.message)
+
     let output = %* {
       "chainId": arg.chainId,
       "address": arg.address,
@@ -39,6 +43,10 @@ const fetchOwnedCollectiblesFromContractAddressesTaskArg: Task = proc(argEncoded
   let arg = decode[FetchOwnedCollectiblesFromContractAddressesTaskArg](argEncoded)
   try:
     let response = collectibles.getOpenseaAssetsByOwnerAndContractAddressWithCursor(arg.chainId, arg.address, arg.contractAddresses, arg.cursor, arg.limit)
+
+    if not response.error.isNil:
+      raise newException(ValueError, "Error getOpenseaAssetsByOwnerAndContractAddressWithCursor" & response.error.message)
+
     let output = %* {
       "chainId": arg.chainId,
       "address": arg.address,
@@ -67,6 +75,10 @@ const fetchCollectiblesTaskArg: Task = proc(argEncoded: string) {.gcsafe, nimcal
   let arg = decode[FetchCollectiblesTaskArg](argEncoded)
   try:
     let response = collectibles.getOpenseaAssetsByNFTUniqueID(arg.chainId, arg.ids, arg.limit)
+
+    if not response.error.isNil:
+      raise newException(ValueError, "Error getOpenseaAssetsByNFTUniqueID" & response.error.message)
+
     let output = %* {
       "chainId": arg.chainId,
       "collectibles": response.result,

--- a/src/app_service/service/community_tokens/async_tasks.nim
+++ b/src/app_service/service/community_tokens/async_tasks.nim
@@ -32,6 +32,10 @@ const fetchCollectibleOwnersTaskArg: Task = proc(argEncoded: string) {.gcsafe, n
   let arg = decode[FetchCollectibleOwnersArg](argEncoded)
   try:
     let response = collectibles.getCollectibleOwnersByContractAddress(arg.chainId, arg.contractAddress)
+
+    if not response.error.isNil:
+      raise newException(ValueError, "Error getCollectibleOwnersByContractAddress" & response.error.message)
+
     let output = %* {
       "chainId": arg.chainId,
       "contractAddress": arg.contractAddress,

--- a/src/app_service/service/transaction/async_tasks.nim
+++ b/src/app_service/service/transaction/async_tasks.nim
@@ -50,8 +50,12 @@ const loadTransactionsTask*: Task = proc(argEncoded: string) {.gcsafe, nimcall.}
           uniqueIds.add(nftId)
 
     if len(uniqueIds) > 0:
-      let collectiblesResponse = collectibles.getOpenseaAssetsByNFTUniqueID(arg.chainId, uniqueIds, arg.collectiblesLimit).result
-      output["collectibles"] = collectiblesResponse
+      let collectiblesResponse = collectibles.getOpenseaAssetsByNFTUniqueID(arg.chainId, uniqueIds, arg.collectiblesLimit)
+
+      if not collectiblesResponse.error.isNil:
+        raise newException(ValueError, "Error getOpenseaAssetsByNFTUniqueID" & collectiblesResponse.error.message)
+
+      output["collectibles"] = collectiblesResponse.result
     
   except Exception as e:
     let errDesription = e.msg


### PR DESCRIPTION
Fixes #10771

### What does the PR do

For collectibles API calls from status-go, exceptions were properly handled but errors were not, causing a crash when OpenSea is not reachable for some reason. This was fixed in this PR in all places where that part of the backend is used..
