### PR TITLE
Revert Chat model sorting in Nim and go back to SortFilterProxy because of performance issue

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/StatusChatList.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusChatList.qml
@@ -142,10 +142,10 @@ Item {
                                 highlighted = true;
                                 categoryPopupMenuSlot.item.popup()
                             } else if (mouse.button === Qt.LeftButton) {
-                                root.model.changeCategoryOpened(model.categoryId, !statusChatListCategoryItem.opened)
+                                root.model.sourceModel.changeCategoryOpened(model.categoryId, !statusChatListCategoryItem.opened)
                             }
                         }
-                        onToggleButtonClicked: root.model.changeCategoryOpened(model.categoryId, !statusChatListCategoryItem.opened)
+                        onToggleButtonClicked: root.model.sourceModel.changeCategoryOpened(model.categoryId, !statusChatListCategoryItem.opened)
                         onMenuButtonClicked: {
                             statusChatListCategoryItem.setupPopup()
                             highlighted = true

--- a/ui/StatusQ/src/StatusQ/Components/StatusChatListAndCategories.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusChatListAndCategories.qml
@@ -7,6 +7,8 @@ import StatusQ.Components 0.1
 import StatusQ.Popups 0.1
 import StatusQ.Core 0.1
 
+import SortFilterProxyModel 0.2
+
 Item {
     id: root
 
@@ -68,7 +70,19 @@ Item {
                     root.categoryAddButtonClicked(id)
                 }
 
-                model: root.model
+                 model: SortFilterProxyModel {
+                    sourceModel: root.model
+                    sorters: [
+                        RoleSorter {
+                            roleName: "categoryPosition"
+                            priority: 2 // Higher number === higher priority
+                        },
+                        RoleSorter {
+                            roleName: "position"
+                            priority: 1
+                        }
+                    ]
+                }
 
                 popupMenu: root.chatListPopupMenu
                 categoryPopupMenu: root.categoryPopupMenu


### PR DESCRIPTION
Reverts the work done to do the chat model sorting in Nim and instead goes back to an unordered list in Nim and using SortFilterProxy to do the ordering.

The reason is that doing the model resets was a big CPU hog.

Also, the reason why I did the sort in the Nim model is no longer there.
It used to be that I needed the model sorted to get the closest category, but I just pass the destination category from the QML instead (duh) (that was done in a previous PR when I added the category drag and drop).

**Possible drawback:**
We might get again the issue of the duplicated categories. We're not sure why or when that issue happens, but the possible suspect was SortFilterProxy.
I think that small bug is less important than the performance improvement that we gain from going back to using SortFilterProxy, so it's worth it.
Maybe we'll be able to find a fix to the bug as well if we find a repro step.