### PR TITLE
Update deep link and external links to use the new format

### DIFF
--- a/src/app/core/custom_urls/urls_manager.nim
+++ b/src/app/core/custom_urls/urls_manager.nim
@@ -8,7 +8,7 @@ import ../../../app_service/service/accounts/utils
 logScope:
   topics = "urls-manager"
 
-const StatusInternalLink = "status-im"
+const StatusInternalLink = "status-app"
 const StatusExternalLink = "join.status.im"
 
 const UriFormatUserProfile = StatusInternalLink & "://u/"

--- a/src/app/core/custom_urls/urls_manager.nim
+++ b/src/app/core/custom_urls/urls_manager.nim
@@ -8,10 +8,12 @@ import ../../../app_service/service/accounts/utils
 logScope:
   topics = "urls-manager"
 
-const StatusInternalLink = "status-app"
-const StatusExternalLink = "join.status.im"
+const StatusInternalLink* = "status-app"
+const StatusExternalLink* = "status.app"
 
-const UriFormatUserProfile = StatusInternalLink & "://u/"
+const profileLinkPrefix* = "/u/"
+
+const UriFormatUserProfile = StatusInternalLink & ":/" & profileLinkPrefix
 
 const UriFormatCommunity = StatusInternalLink & "://c/"
 

--- a/src/app_service/service/community/service.nim
+++ b/src/app_service/service/community/service.nim
@@ -1325,9 +1325,8 @@ QtObject:
 
   proc asyncCommunityInfoLoaded*(self: Service, communityIdAndRpcResponse: string) {.slot.} =
     let rpcResponseObj = communityIdAndRpcResponse.parseJson
-    if (rpcResponseObj{"response"}{"error"}.kind != JNull):
-      let error = Json.decode($rpcResponseObj["response"]["error"], RpcError)
-      error "Error requesting community info", msg = error.message
+    if (rpcResponseObj{"error"}.kind != JNull):
+      error "Error requesting community info", msg = rpcResponseObj{"error"}
       return
 
     var community = rpcResponseObj{"response"}{"result"}.toCommunityDto()

--- a/src/app_service/service/message/async_tasks.nim
+++ b/src/app_service/service/message/async_tasks.nim
@@ -4,6 +4,8 @@ include ../../../app/core/tasks/common
 
 import ../../../backend/chat as status_go_chat
 
+import ../../../app/core/custom_urls/urls_manager
+
 
 #################################################
 # Async load messages
@@ -197,8 +199,9 @@ const asyncGetLinkPreviewDataTask: Task = proc(argEncoded: string) {.gcsafe, nim
     let path = uri.path
     let domain = uri.hostname.toLower()
     let isSupportedImage = any(parsedWhiteListImgExtensions, proc (extenstion: string): bool = path.endsWith(extenstion))
-    let isWhitelistedUrl = parsedWhiteListUrls.hasKey(domain)
-    let processUrl = isWhitelistedUrl or isSupportedImage
+    let isListed = parsedWhiteListUrls.hasKey(domain)
+    let isProfileLink = path.startsWith(profileLinkPrefix)
+    let processUrl = not isProfileLink and (isListed or isSupportedImage)
 
     if domain == "" or processUrl == false:
       continue
@@ -229,7 +232,7 @@ const asyncGetLinkPreviewDataTask: Task = proc(argEncoded: string) {.gcsafe, nim
 
     #2. Process whitelisted url
     #status deep links are handled internally
-    if domain == "status-app" or domain == "join.status.im":
+    if domain == StatusInternalLink or domain == StatusExternalLink:
       responseJson["success"] = %true
       responseJson["isStatusDeepLink"] = %true
       responseJson["result"] = %*{

--- a/src/app_service/service/message/async_tasks.nim
+++ b/src/app_service/service/message/async_tasks.nim
@@ -229,7 +229,7 @@ const asyncGetLinkPreviewDataTask: Task = proc(argEncoded: string) {.gcsafe, nim
 
     #2. Process whitelisted url
     #status deep links are handled internally
-    if domain == "status-im" or domain == "join.status.im":
+    if domain == "status-app" or domain == "join.status.im":
       responseJson["success"] = %true
       responseJson["isStatusDeepLink"] = %true
       responseJson["result"] = %*{

--- a/src/constants.nim
+++ b/src/constants.nim
@@ -48,7 +48,7 @@ type StatusDesktopConfig = object
       abbr: "d" .}: string
     uri* {.
       defaultValue: ""
-      desc: "status-im:// URI to open a chat or other"
+      desc: "status-app:// URI to open a chat or other"
       name: "uri" .}: string
 
 

--- a/status.iss
+++ b/status.iss
@@ -74,10 +74,10 @@ Type: files; Name: "{userdesktop}\{#Name}"
 Type: files; Name: "{commondesktop}\{#Name}"
 
 [Registry]
-Root: HKCR; Subkey: "status-im"; ValueType: "string"; ValueData: "URL:status-im Protocol"; Flags: uninsdeletekey
-Root: HKCR; Subkey: "status-im"; ValueType: "string"; ValueName: "URL Protocol"; ValueData: ""
-Root: HKCR; Subkey: "status-im\DefaultIcon"; ValueType: "string"; ValueData: "{app}\Status.exe,1"
-Root: HKCR; Subkey: "status-im\shell\open\command"; ValueType: "string"; ValueData: """{app}\bin\Status.exe"" ""--uri=%1"""
+Root: HKCR; Subkey: "status-app"; ValueType: "string"; ValueData: "URL:status-app Protocol"; Flags: uninsdeletekey
+Root: HKCR; Subkey: "status-app"; ValueType: "string"; ValueName: "URL Protocol"; ValueData: ""
+Root: HKCR; Subkey: "status-app\DefaultIcon"; ValueType: "string"; ValueData: "{app}\Status.exe,1"
+Root: HKCR; Subkey: "status-app\shell\open\command"; ValueType: "string"; ValueData: """{app}\bin\Status.exe"" ""--uri=%1"""
 
 [Code]
 function IsAppRunning(const FileName : string): Boolean;

--- a/ui/StatusQ/sandbox/demoapp/DemoCommunityDetailModal.qml
+++ b/ui/StatusQ/sandbox/demoapp/DemoCommunityDetailModal.qml
@@ -42,7 +42,7 @@ StatusModal {
 
         StatusDescriptionListItem {
             title: "Share community"
-            subTitle: "https://join.status.im/u/0x04...45f19"
+            subTitle: "https://status.app/u/0x04...45f19"
             tooltip.text: "Copy to clipboard"
             asset.name: "copy"
             iconButton.onClicked: tooltip.visible = !tooltip.visible

--- a/ui/StatusQ/src/StatusQ/Core/Utils/Utils.qml
+++ b/ui/StatusQ/src/StatusQ/Core/Utils/Utils.qml
@@ -156,8 +156,8 @@ QtObject {
     }
 
     function linkifyAndXSS(inputText) {
-        //URLs starting with http://, https://, ftp:// or status-im://
-        var replacePattern1 = /(\b(https?|ftp|status-im):\/\/[-A-Z0-9+&@#\/%?=~_|!:,.;\(\)]*[-A-Z0-9+&@#\/%=~_|])/gim;
+        //URLs starting with http://, https://, ftp:// or status-app://
+        var replacePattern1 = /(\b(https?|ftp|status-app):\/\/[-A-Z0-9+&@#\/%?=~_|!:,.;\(\)]*[-A-Z0-9+&@#\/%=~_|])/gim;
         var replacedText = inputText.replace(replacePattern1, "<a href='$1'>$1</a>");
 
         //URLs starting with "www." (without // before it, or it'd re-link the ones done above).

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -488,7 +488,7 @@ QtObject {
         const result = getLinkTitleAndCb(link)
 
         return {
-            site: "https://join.status.im",
+            site: Constants.externalStatusLinkWithHttps,
             title: result.title,
             communityId: result.communityId,
             fetching: result.fetching,

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -1324,7 +1324,7 @@ Item {
 
             // Add Status links to whitelist
             whiteListedSites.push({title: "Status", address: Constants.deepLinkPrefix, imageSite: false})
-            whiteListedSites.push({title: "Status", address: Constants.joinStatusLink, imageSite: false})
+            whiteListedSites.push({title: "Status", address: Constants.externalStatusLink, imageSite: false})
             let settings = localAccountSensitiveSettings.whitelistedUnfurlingSites
 
             if (!settings) {
@@ -1332,9 +1332,9 @@ Item {
             }
 
             // Set Status links as true. We intercept those URLs so it is privacy-safe
-            if (!settings[Constants.deepLinkPrefix] || !settings[Constants.joinStatusLink]) {
+            if (!settings[Constants.deepLinkPrefix] || !settings[Constants.externalStatusLink]) {
                 settings[Constants.deepLinkPrefix] = true
-                settings[Constants.joinStatusLink] = true
+                settings[Constants.externalStatusLink] = true
                 settingsUpdated = true
             }
 

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -802,7 +802,7 @@ QtObject {
 
     readonly property int repeatHeaderInterval: 2
 
-    readonly property string deepLinkPrefix: 'status-im://'
+    readonly property string deepLinkPrefix: 'status-app://'
     readonly property string joinStatusLink: 'join.status.im'
     readonly property string communityLinkPrefix: 'https://join.status.im/c/'
     readonly property string userLinkPrefix: 'https://join.status.im/u/'

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -803,9 +803,10 @@ QtObject {
     readonly property int repeatHeaderInterval: 2
 
     readonly property string deepLinkPrefix: 'status-app://'
-    readonly property string joinStatusLink: 'join.status.im'
-    readonly property string communityLinkPrefix: 'https://join.status.im/c/'
-    readonly property string userLinkPrefix: 'https://join.status.im/u/'
+    readonly property string externalStatusLink: 'status.app'
+    readonly property string externalStatusLinkWithHttps: 'https://' + externalStatusLink
+    readonly property string communityLinkPrefix: externalStatusLinkWithHttps + '/c/'
+    readonly property string userLinkPrefix: externalStatusLinkWithHttps + '/u/'
     readonly property string statusLinkPrefix: 'https://status.im/'
 
     readonly property int maxUploadFiles: 5

--- a/ui/imports/utils/Utils.qml
+++ b/ui/imports/utils/Utils.qml
@@ -315,7 +315,7 @@ QtObject {
     }
 
     function isStatusDeepLink(link) {
-        return link.includes(Constants.deepLinkPrefix) || link.includes(Constants.joinStatusLink)
+        return link.includes(Constants.deepLinkPrefix) || link.includes(Constants.externalStatusLink)
     }
 
     function hasImageExtension(url) {


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/9549
Fixes https://github.com/status-im/status-desktop/issues/10777
Fixes https://github.com/status-im/status-desktop/issues/10748

Update the Windows installer to use status-app instead of status-im

Also updates the code that references the old deep link

Also updates the external links to use `https/status.app` instead of `join.status.com`

Also fixes an issue that would make the app crash if a profile url was pasted in chat