### PR TITLE
fix(invitation-bubble): Adds loading state for unfurling links

### DIFF
--- a/src/app/modules/main/communities/controller.nim
+++ b/src/app/modules/main/communities/controller.nim
@@ -52,6 +52,9 @@ proc init*(self: Controller) =
     let args = CommunityArgs(e)
     self.delegate.onImportCommunityErrorOccured(args.community.id, args.error)
 
+  self.events.on(SIGNAL_COMMUNITY_INFO_ALREADY_REQUESTED) do(e: Args):
+    self.delegate.communityInfoAlreadyRequested()
+
   self.events.on(SIGNAL_CURATED_COMMUNITY_FOUND) do(e:Args):
     let args = CommunityArgs(e)
     self.delegate.curatedCommunityAdded(args.community)

--- a/src/app/modules/main/communities/io_interface.nim
+++ b/src/app/modules/main/communities/io_interface.nim
@@ -159,3 +159,6 @@ method curatedCommunitiesLoadingFailed*(self: AccessInterface) {.base.} =
 
 method curatedCommunitiesLoaded*(self: AccessInterface, curatedCommunities: seq[CommunityDto]) {.base.} =
   raise newException(ValueError, "No implementation available")
+
+method communityInfoAlreadyRequested*(self: AccessInterface) {.base.} = 
+  raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/communities/module.nim
+++ b/src/app/modules/main/communities/module.nim
@@ -382,3 +382,5 @@ method discordImportProgressUpdated*(
 method requestCancelDiscordCommunityImport*(self: Module, id: string) =
   self.controller.requestCancelDiscordCommunityImport(id)
 
+method communityInfoAlreadyRequested*(self: Module) =
+  self.view.communityInfoAlreadyRequested()

--- a/src/app/modules/main/communities/view.nim
+++ b/src/app/modules/main/communities/view.nim
@@ -101,6 +101,7 @@ QtObject:
   proc discordOldestMessageTimestampChanged*(self: View) {.signal.}
   proc discordImportErrorsCountChanged*(self: View) {.signal.}
   proc communityAccessRequested*(self: View, communityId: string) {.signal.}
+  proc communityInfoAlreadyRequested*(self: View) {.signal.}
 
   proc communityTagsChanged*(self: View) {.signal.}
   

--- a/src/app_service/service/community/service.nim
+++ b/src/app_service/service/community/service.nim
@@ -166,6 +166,8 @@ const SIGNAL_ACCEPT_REQUEST_TO_JOIN_LOADING* = "acceptRequestToJoinLoading"
 const SIGNAL_ACCEPT_REQUEST_TO_JOIN_FAILED* = "acceptRequestToJoinFailed"
 const SIGNAL_ACCEPT_REQUEST_TO_JOIN_FAILED_NO_PERMISSION* = "acceptRequestToJoinFailedNoPermission"
 
+const SIGNAL_COMMUNITY_INFO_ALREADY_REQUESTED* = "communityInfoAlreadyRequested"
+
 const TOKEN_PERMISSIONS_ADDED = "tokenPermissionsAdded"
 const TOKEN_PERMISSIONS_MODIFIED = "tokenPermissionsModified"
 
@@ -1453,6 +1455,7 @@ QtObject:
 
     if communityId in self.requestedCommunityIds:
       info "requestCommunityInfo: skipping as already requested", communityId
+      self.events.emit(SIGNAL_COMMUNITY_INFO_ALREADY_REQUESTED, Args())
       return
 
     self.requestedCommunityIds.incl(communityId)

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -76,6 +76,8 @@ QtObject {
 
     signal importingCommunityStateChanged(string communityId, int state, string errorMsg)
 
+    signal communityInfoAlreadyRequested()
+
     signal goToMembershipRequestsPage()
 
     function setActiveCommunity(communityId) {
@@ -614,6 +616,10 @@ QtObject {
       target: communitiesModuleInst
       function onImportingCommunityStateChanged(communityId, state, errorMsg) {
           root.importingCommunityStateChanged(communityId, state, errorMsg)
+      }
+
+      function onCommunityInfoAlreadyRequested() {
+          root.communityInfoAlreadyRequested()
       }
     }
 

--- a/ui/app/AppLayouts/Chat/views/ContactsColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ContactsColumnView.qml
@@ -249,5 +249,14 @@ Item {
                                        Constants.ephemeralNotificationType.normal,
                                        "")
         }
+
+        function onCommunityInfoAlreadyRequested() {
+            Global.displayToastMessage(qsTr("Community data not loaded yet."),
+                                       qsTr("Please wait for the unfurl to show"),
+                                       "",
+                                       true,
+                                       Constants.ephemeralNotificationType.normal,
+                                       "")
+        }
     }
 }

--- a/ui/imports/shared/views/chat/InvitationBubbleView.qml
+++ b/ui/imports/shared/views/chat/InvitationBubbleView.qml
@@ -15,11 +15,12 @@ import shared.popups 1.0
 Control {
     id: root
 
-    implicitWidth: d.invitedCommunity ? 270 /*by design*/ : 0
+    implicitWidth: d.invitedCommunity || loading ? 270 /*by design*/ : 0
     padding: 1
 
     property var store
     property string communityId
+    property bool loading: false
 
     QtObject {
         id: d
@@ -133,6 +134,8 @@ Control {
                     color: d.communityColor
                     isImage: true
                 }
+
+                visible: !root.loading
             }
 
             ColumnLayout {
@@ -141,7 +144,7 @@ Control {
                 StatusBaseText {
                     Layout.fillWidth: true
 
-                    text: d.communityName
+                    text: root.loading ? qsTr("Community data not loaded yet.") : d.communityName
                     font.weight: Font.Bold
                     wrapMode: Text.WrapAtWordBoundaryOrAnywhere
                     font.pixelSize: 17
@@ -151,7 +154,7 @@ Control {
                 StatusBaseText {
                     Layout.fillWidth: true
 
-                    text: d.communityDescription
+                    text: root.loading ? qsTr("Please wait for the unfurl to show") : d.communityDescription
                     wrapMode: Text.WrapAtWordBoundaryOrAnywhere
                     color: Theme.palette.directColor1
                 }
@@ -159,7 +162,7 @@ Control {
                 StatusBaseText {
                     Layout.fillWidth: true
 
-                    text: qsTr("%n member(s)", "", d.communityNbMembers)
+                    text: root.loading ? "" : qsTr("%n member(s)", "", d.communityNbMembers)
                     font.pixelSize: 13
                     font.weight: Font.Medium
                     color: Theme.palette.baseColor1
@@ -180,6 +183,7 @@ Control {
             Layout.preferredHeight: 44
 
             text: qsTr("Go to Community")
+            loading: root.loading
             radius: d.radius - 1 // We do -1, otherwise there's a gap between border and button
 
             onClicked: {

--- a/ui/imports/shared/views/chat/LinksMessageView.qml
+++ b/ui/imports/shared/views/chat/LinksMessageView.qml
@@ -190,7 +190,8 @@ Column {
             store: root.store
             communityId: invitationData ? invitationData.communityId : ""
             anchors.left: parent.left
-            visible: !!invitationData && !invitationData.fetching
+            visible: !!invitationData
+            loading: invitationData.fetching
 
             Connections {
                 enabled: !!invitationData && invitationData.fetching


### PR DESCRIPTION
Fixes: #10422

### What does the PR do

Displays loading state for invitation bubble and show notification about loading in progress

### Affected areas

Invitation bubble

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

- [ ] I've checked the design and this PR matches it

![Снимок экрана 2023-05-24 в 14 57 22](https://github.com/status-im/status-desktop/assets/82511785/6ffe9b8f-6a63-42ee-a861-f6e5250092df)


![Снимок экрана 2023-05-24 в 14 57 28](https://github.com/status-im/status-desktop/assets/82511785/f243a629-52fa-420f-a0fd-781948ffbea7)


