### PR TITLE
fix(@desktop/wallet): Wallet Footer for watch only accounts should show only "Receive" as an option

### DIFF
--- a/src/app/modules/main/wallet_section/overview/item.nim
+++ b/src/app/modules/main/wallet_section/overview/item.nim
@@ -8,6 +8,7 @@ type
     balanceLoading: bool
     color: string
     emoji: string
+    isWatchOnlyAccount: bool
     isAllAccounts: bool
     hideWatchAccounts: bool
     colors: seq[string]
@@ -19,6 +20,7 @@ proc initItem*(
   balanceLoading: bool  = true,
   color: string,
   emoji: string,
+  isWatchOnlyAccount: bool=false,
   isAllAccounts: bool = false,
   hideWatchAccounts: bool = false,
   colors: seq[string] = @[]
@@ -32,6 +34,7 @@ proc initItem*(
   result.isAllAccounts = isAllAccounts
   result.hideWatchAccounts = hideWatchAccounts
   result.colors = colors
+  result.isWatchOnlyAccount = isWatchOnlyAccount
 
 proc `$`*(self: Item): string =
   result = fmt"""OverviewItem(
@@ -41,6 +44,7 @@ proc `$`*(self: Item): string =
     balanceLoading: {self.balanceLoading},
     color: {self.color},
     emoji: {self.emoji},
+    isWatchOnlyAccount: {self.isWatchOnlyAccount},
     isAllAccounts: {self.isAllAccounts},
     hideWatchAccounts: {self.hideWatchAccounts},
     colors: {self.colors}
@@ -78,3 +82,5 @@ proc getColors*(self: Item): string =
       result = result & ";" & color
   return result
 
+proc getIsWatchOnlyAccount*(self: Item): bool =
+  return self.isWatchOnlyAccount

--- a/src/app/modules/main/wallet_section/overview/module.nim
+++ b/src/app/modules/main/wallet_section/overview/module.nim
@@ -75,6 +75,7 @@ method filterChanged*(self: Module, addresses: seq[string], chainIds: seq[int], 
       walletAccounts[0].assetsLoading,
       "",
       "",
+      isWatchOnlyAccount=false,
       isAllAccounts=true,
       hideWatchAccounts=excludeWatchOnly,
       self.getWalletAccoutColors(walletAccounts)
@@ -89,6 +90,7 @@ method filterChanged*(self: Module, addresses: seq[string], chainIds: seq[int], 
       walletAccount.assetsLoading,
       walletAccount.color,
       walletAccount.emoji,
+      isWatchOnlyAccount=walletAccount.walletType == "watch"
     )
     self.view.setData(item)
 

--- a/src/app/modules/main/wallet_section/overview/view.nim
+++ b/src/app/modules/main/wallet_section/overview/view.nim
@@ -19,6 +19,7 @@ QtObject:
       isAllAccounts: bool
       hideWatchAccounts: bool
       colors: string
+      isWatchOnlyAccount: bool
 
   proc setup(self: View) =
     self.QObject.setup
@@ -112,6 +113,13 @@ QtObject:
     read = getColors
     notify = colorsChanged
 
+  proc getIsWatchOnlyAccount(self: View): QVariant {.slot.} =
+    return newQVariant(self.isWatchOnlyAccount)
+  proc isWatchOnlyAccountChanged(self: View) {.signal.}
+  QtProperty[QVariant] isWatchOnlyAccount:
+    read = getIsWatchOnlyAccount
+    notify = isWatchOnlyAccountChanged
+
   proc setData*(self: View, item: Item) =
     if(self.name != item.getName()):
       self.name = item.getName()
@@ -129,6 +137,9 @@ QtObject:
     if(self.emoji != item.getEmoji()):
       self.emoji = item.getEmoji()
       self.emojiChanged()
+    if(self.isWatchOnlyAccount != item.getIsWatchOnlyAccount()):
+      self.isWatchOnlyAccount = item.getIsWatchOnlyAccount()
+      self.isWatchOnlyAccountChanged()
     if(self.isAllAccounts != item.getIsAllAccounts()):
       self.isAllAccounts = item.getIsAllAccounts()
       self.isAllAccountsChanged()

--- a/ui/app/AppLayouts/Wallet/panels/WalletFooter.qml
+++ b/ui/app/AppLayouts/Wallet/panels/WalletFooter.qml
@@ -44,6 +44,7 @@ Rectangle {
                 sendModal.open()
             }
             tooltipText: networkConnectionStore.sendBuyBridgeToolTipText
+            visible: !walletStore.overview.isWatchOnlyAccount
         }
 
         StatusFlatButton {
@@ -64,6 +65,7 @@ Rectangle {
                 sendModal.open()
             }
             tooltipText: networkConnectionStore.sendBuyBridgeToolTipText
+            visible: !walletStore.overview.isWatchOnlyAccount
         }
         
         StatusFlatButton {


### PR DESCRIPTION
fix(@desktop/wallet): Wallet Footer for watch only accounts should show only "Receive" as an option
fixes #10786

### What does the PR do

For watch only account only let Receive button on footer be visible as sending with watch only account is not possible

### Affected areas

WalletFooter

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it


https://github.com/status-im/status-desktop/assets/60327365/fbaf83b6-bbfe-4702-93c6-556c6c71d2c5




