### PR TITLE
fix(ShowcaseDelegate): community icon is not rounded

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/StatusRoundedImage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusRoundedImage.qml
@@ -22,6 +22,7 @@ StatusRoundedComponent {
 
     isLoading: image.isLoading
     isError: image.isError
+    border.width: 0
 
     StatusImage {
         id: image

--- a/ui/app/AppLayouts/Profile/controls/AssetShowcaseDelegate.qml
+++ b/ui/app/AppLayouts/Profile/controls/AssetShowcaseDelegate.qml
@@ -6,7 +6,7 @@ import utils 1.0
 
 ShowcaseDelegate {
     title: !!showcaseObj && !!showcaseObj.name ? showcaseObj.name : ""
-    secondaryTitle: !!showcaseObj ? LocaleUtils.currencyAmountToLocaleString(showcaseObj.enabledNetworkBalance) : "0"
+    secondaryTitle: !!showcaseObj ? LocaleUtils.currencyAmountToLocaleString(showcaseObj.enabledNetworkBalance) : Qt.locale().zeroDigit
     hasImage: true
     icon.source: !!showcaseObj ? Constants.tokenIcon(showcaseObj.symbol) : ""
 }

--- a/ui/app/AppLayouts/Profile/controls/CommunityShowcaseDelegate.qml
+++ b/ui/app/AppLayouts/Profile/controls/CommunityShowcaseDelegate.qml
@@ -3,9 +3,9 @@ import QtQuick 2.15
 ShowcaseDelegate {
     title: !!showcaseObj && !!showcaseObj.name ? showcaseObj.name : ""
     secondaryTitle: !!showcaseObj && !!showcaseObj.amISectionAdmin ? qsTr("Admin") : qsTr("Member")
-    hasImage: !!showcaseObj ? showcaseObj.image : false
+    hasImage: !!showcaseObj && !!showcaseObj.image
 
     icon.name: !!showcaseObj ? showcaseObj.name : ""
     icon.source: !!showcaseObj ? showcaseObj.image : ""
-    icon.color: !!showcaseObj ? showcaseObj.color : ""
+    icon.color: !!showcaseObj ? showcaseObj.color : "transparent"
 }

--- a/ui/imports/shared/panels/RoundedImage.qml
+++ b/ui/imports/shared/panels/RoundedImage.qml
@@ -38,7 +38,6 @@ Rectangle {
         smooth: false
         radius: root.radius
         anchors.fill: parent
-        source: thumbnail
         onClicked: root.clicked()
     }
 }


### PR DESCRIPTION
- this needs proper bg color (transparent) and a `border.width: 0` to work properly with the

Fixes #10754

### What does the PR do

Fixes rounded icons in the Profile Showcase settings view

### Affected areas

Settings/Profile/Showcase

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![image](https://github.com/status-im/status-desktop/assets/5377645/d518d7f7-76b8-4c70-b697-18d8603cf0ba)

