### PR TITLE
test(tst_userIdentity): Skipped scenario `The user can change own display name in profile popup`

### DIFF
--- a/test/ui-test/testSuites/suite_settings/tst_userIdentity/test.feature
+++ b/test/ui-test/testSuites/suite_settings/tst_userIdentity/test.feature
@@ -50,6 +50,7 @@ Feature: User Identity
 		| tester123_changed | Hello, I am super tester! |
 
 
+ 	@mayfail
     Scenario Outline: The user can change own display name in profile popup
         Given the user opens own profile popup
         And the user's display name is "tester123"


### PR DESCRIPTION
App bug to be solved: #10827

### What does the PR do

Skips `suite_settings/tst_userIdentity/The user can change own display name in profile popup`

### Affected areas

`e2e tests`