### PR TITLE
feat(mute): Adds intervals for muting channels and chats

### DIFF
--- a/src/app/modules/main/chat_section/chat_content/controller.nim
+++ b/src/app/modules/main/chat_section/chat_content/controller.nim
@@ -210,8 +210,8 @@ proc isUsersListAvailable*(self: Controller): bool =
 proc getMyMutualContacts*(self: Controller): seq[ContactsDto] =
   return self.contactService.getContactsByGroup(ContactsGroup.MyMutualContacts)
 
-proc muteChat*(self: Controller) =
-  self.chatService.muteChat(self.chatId)
+proc muteChat*(self: Controller, interval: int) =
+  self.chatService.muteChat(self.chatId, interval)
 
 proc unmuteChat*(self: Controller) =
   self.chatService.unmuteChat(self.chatId)

--- a/src/app/modules/main/chat_section/chat_content/io_interface.nim
+++ b/src/app/modules/main/chat_section/chat_content/io_interface.nim
@@ -89,7 +89,7 @@ method getMyChatId*(self: AccessInterface): string {.base.} =
 method isMyContact*(self: AccessInterface, contactId: string): bool {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method muteChat*(self: AccessInterface) {.base.} =
+method muteChat*(self: AccessInterface, interval: int) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method unmuteChat*(self: AccessInterface) {.base.} =

--- a/src/app/modules/main/chat_section/chat_content/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/module.nim
@@ -260,8 +260,8 @@ method getMyChatId*(self: Module): string =
 method isMyContact*(self: Module, contactId: string): bool =
   self.controller.getMyMutualContacts().filter(x => x.id == contactId).len > 0
 
-method muteChat*(self: Module) =
-  self.controller.muteChat()
+method muteChat*(self: Module, interval: int) =
+  self.controller.muteChat(interval)
 
 method unmuteChat*(self: Module) =
   self.controller.unmuteChat()

--- a/src/app/modules/main/chat_section/chat_content/view.nim
+++ b/src/app/modules/main/chat_section/chat_content/view.nim
@@ -74,8 +74,8 @@ QtObject:
   proc isMyContact*(self: View, contactId: string): bool {.slot.} =
     return self.delegate.isMyContact(contactId)
 
-  proc muteChat*(self: View) {.slot.} =
-    self.delegate.muteChat()
+  proc muteChat*(self: View, interval: int) {.slot.} =
+    self.delegate.muteChat(interval)
 
   proc unmuteChat*(self: View) {.slot.} =
     self.delegate.unmuteChat()

--- a/src/app/modules/main/chat_section/controller.nim
+++ b/src/app/modules/main/chat_section/controller.nim
@@ -440,8 +440,8 @@ proc switchToOrCreateOneToOneChat*(self: Controller, chatId: string, ensName: st
 proc leaveChat*(self: Controller, chatId: string) =
   self.chatService.leaveChat(chatId)
 
-proc muteChat*(self: Controller, chatId: string) =
-  self.chatService.muteChat(chatId)
+proc muteChat*(self: Controller, chatId: string, interval: int) =
+  self.chatService.muteChat(chatId, interval)
 
 proc unmuteChat*(self: Controller, chatId: string) =
   self.chatService.unmuteChat(chatId)

--- a/src/app/modules/main/chat_section/io_interface.nim
+++ b/src/app/modules/main/chat_section/io_interface.nim
@@ -198,7 +198,7 @@ method removeCommunityChat*(self: AccessInterface, chatId: string) {.base.} =
 method getActiveChatId*(self: AccessInterface): string {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method muteChat*(self: AccessInterface, chatId: string) {.base.} =
+method muteChat*(self: AccessInterface, chatId: string, interval: int) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method unmuteChat*(self: AccessInterface, chatId: string) {.base.} =

--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -763,8 +763,8 @@ method createOneToOneChat*(self: Module, communityID: string, chatId: string, en
 method leaveChat*(self: Module, chatId: string) =
   self.controller.leaveChat(chatId)
 
-method muteChat*(self: Module, chatId: string) =
-  self.controller.muteChat(chatId)
+method muteChat*(self: Module, chatId: string, interval: int) =
+  self.controller.muteChat(chatId, interval)
 
 method unmuteChat*(self: Module, chatId: string) =
   self.controller.unmuteChat(chatId)

--- a/src/app/modules/main/chat_section/view.nim
+++ b/src/app/modules/main/chat_section/view.nim
@@ -194,8 +194,8 @@ QtObject:
       return
     return $jsonObj
 
-  proc muteChat*(self: View, chatId: string) {.slot.} =
-    self.delegate.muteChat(chatId)
+  proc muteChat*(self: View, chatId: string, interval: int) {.slot.} =
+    self.delegate.muteChat(chatId, interval)
 
   proc unmuteChat*(self: View, chatId: string) {.slot.} =
     self.delegate.unmuteChat(chatId)

--- a/src/app_service/service/chat/service.nim
+++ b/src/app_service/service/chat/service.nim
@@ -573,13 +573,13 @@ QtObject:
     except Exception as e:
       error "Error requesting transaction", msg = e.msg
 
-  proc muteChat*(self: Service, chatId: string) =
+  proc muteChat*(self: Service, chatId: string, interval: int) =
     try:
       if(chatId.len == 0):
         error "error trying to mute chat with an empty id"
         return
 
-      let response = status_chat.muteChat(chatId)
+      let response = status_chat.muteChat(chatId, interval)
       if(not response.error.isNil):
         let msg = response.error.message & " chatId=" & chatId
         error "error while mute chat ", msg

--- a/src/backend/chat.nim
+++ b/src/backend/chat.nim
@@ -93,9 +93,13 @@ proc sendImages*(chatId: string, images: var seq[string], msg: string, replyTo: 
     )
   callPrivateRPC("sendChatMessages".prefix, %* [imagesJson])
 
-proc muteChat*(chatId: string): RpcResponse[JsonNode] {.raises: [Exception].} =
-  let payload = %* [chatId]
-  result = callPrivateRPC("muteChat".prefix, payload)
+proc muteChat*(chatId: string, interval: int): RpcResponse[JsonNode] {.raises: [Exception].} =
+  result = callPrivateRPC("muteChatV2".prefix, %* [
+    {
+      "chatId": chatId,
+      "mutedType": interval,
+    }
+  ])
 
 proc unmuteChat*(chatId: string): RpcResponse[JsonNode] {.raises: [Exception].} =
   let payload = %* [chatId]

--- a/ui/StatusQ/src/StatusQ/Popups/StatusMenuItem.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/StatusMenuItem.qml
@@ -84,9 +84,12 @@ MenuItem {
             rotation: 0
             // Link to standard Qt properties. Not because it's a good idea,
             // but because it we use it in some places and it will make refactor easier.
-            name: d.isSubMenu ? "" : (d.hasAction ? root.action.icon.name : root.icon.name)
-            source: d.isSubMenu ? "" : (d.hasAction ? root.action.icon.source : root.icon.source)
-            color: d.isSubMenu ? "" : (d.hasAction ? root.action.icon.color : root.icon.color)
+            name: d.isSubMenu ? (d.isStatusSubMenu ? root.subMenu.assetSettings.name : "")
+                              : (d.hasAction ? root.action.icon.name : root.icon.name)
+            source: d.isSubMenu ? (d.isStatusSubMenu ? root.subMenu.assetSettings.source : "")
+                                : (d.hasAction ? root.action.icon.source : root.icon.source)
+            color: d.isSubMenu ? (d.isStatusSubMenu ? root.subMenu.assetSettings.color : "")
+                               : (d.hasAction ? root.action.icon.color : root.icon.color)
         }
 
         readonly property StatusFontSettings defaultFontSettings: StatusFontSettings {

--- a/ui/app/AppLayouts/Chat/views/ChatContextMenuView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatContextMenuView.qml
@@ -32,7 +32,7 @@ StatusMenu {
     signal displayProfilePopup(string publicKey)
     signal requestAllHistoricMessages(string chatId)
     signal unmuteChat(string chatId)
-    signal muteChat(string chatId)
+    signal muteChat(string chatId, int interval)
     signal markAllMessagesRead(string chatId)
     signal clearChatHistory(string chatId)
     signal downloadMessages(string file)
@@ -89,12 +89,20 @@ StatusMenu {
     }
 
     MuteChatMenuItem {
-        muted: root.chatMuted
+        enabled: !root.chatMuted
+        isCommunityChat: root.isCommunityChat
+
+        onMuteTriggered: {
+            root.muteChat(root.chatId, interval)
+        }
+    }
+
+    StatusAction {
+        enabled: root.chatMuted
+        text: root.isCommunityChat ? qsTr("Unmute Channel") : qsTr("Unmute Chat")
+        icon.name: "notification"
         onTriggered: {
-            if(root.chatMuted)
-                root.unmuteChat(root.chatId)
-            else
-                root.muteChat(root.chatId)
+            root.unmuteChat(root.chatId)
         }
     }
 

--- a/ui/app/AppLayouts/Chat/views/ChatHeaderContentView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatHeaderContentView.qml
@@ -163,7 +163,7 @@ Item {
                         console.debug("error on mute chat from context menu - chat content module is not set")
                         return
                     }
-                    chatContentModule.muteChat()
+                    chatContentModule.muteChat(interval)
                 }
 
                 onUnmuteChat: {

--- a/ui/app/AppLayouts/Chat/views/CommunityColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/CommunityColumnView.qml
@@ -344,7 +344,7 @@ Item {
                 }
 
                 onMuteChat: {
-                    root.communitySectionModule.muteChat(chatId)
+                    root.communitySectionModule.muteChat(chatId, interval)
                 }
 
                 onUnmuteChat: {

--- a/ui/app/AppLayouts/Chat/views/ContactsColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ContactsColumnView.qml
@@ -162,7 +162,7 @@ Item {
                     }
 
                     onMuteChat: {
-                        root.chatSectionModule.muteChat(chatId)
+                        root.chatSectionModule.muteChat(chatId, interval)
                     }
 
                     onUnmuteChat: {

--- a/ui/imports/shared/controls/chat/menuItems/MuteChatMenuItem.qml
+++ b/ui/imports/shared/controls/chat/menuItems/MuteChatMenuItem.qml
@@ -1,10 +1,43 @@
 import QtQuick 2.14
+import QtQuick.Controls 2.14
+
+import utils 1.0
 
 import StatusQ.Popups 0.1
+import shared.controls.chat.menuItems 1.0
 
-StatusAction {
-    property bool muted: false
 
-    text: muted ? qsTr("Unmute Chat") : qsTr("Mute Chat")
-    icon.name: "notification"
+StatusMenu {
+    property bool isCommunityChat: false
+
+    signal muteTriggered(interval: int)
+
+    title: isCommunityChat ? qsTr("Mute Channel") : qsTr("Mute Chat")
+
+    assetSettings.name: "notification"
+
+    StatusAction {
+        text: qsTr("For 15 mins")
+        onTriggered: muteTriggered(Constants.MutingVariations.For15min)
+    }
+
+    StatusAction {
+        text: qsTr("For 1 hour")
+        onTriggered: muteTriggered(Constants.MutingVariations.For1hr)
+    }
+
+    StatusAction {
+        text: qsTr("For 8 hours")
+        onTriggered: muteTriggered(Constants.MutingVariations.For8hr)
+    }
+
+    StatusAction {
+        text: qsTr("For 7 days")
+        onTriggered: muteTriggered(Constants.MutingVariations.For1week)
+    }
+
+    StatusAction {
+        text: qsTr("Until you turn it back on")
+        onTriggered: muteTriggered(Constants.MutingVariations.TillUnmuted)
+    }
 }

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -997,4 +997,13 @@ QtObject {
         RejectedMembers,
         BannedMembers
     }
+
+    enum MutingVariations {
+        For15min = 1,
+        For1hr = 2,
+        For8hr = 3,
+        For1week = 4,
+        TillUnmuted = 5,
+        For1min = 6
+    }
 }


### PR DESCRIPTION
Part of: #9369

### What does the PR do

Adds mute type usage to chats and channels:

PS: I make decision to split this tasks cos it requires some changes in status-go for `Community` and `Category` parts.l

### Affected areas

Muting chats and channels

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)


![Снимок экрана 2023-05-26 в 16 30 40](https://github.com/status-im/status-desktop/assets/82511785/8e3aa0e6-8242-4053-b703-11efb3bc5ab1)


![Снимок экрана 2023-05-26 в 16 30 57](https://github.com/status-im/status-desktop/assets/82511785/03564123-11ed-485c-b3da-8ce5be8d42bd)

![Снимок экрана 2023-05-26 в 16 31 09](https://github.com/status-im/status-desktop/assets/82511785/eb4a7728-22f1-40e8-a04e-6049a543284e)
