### PR TITLE
fix: wrong error message on incorrect password

### DIFF
--- a/ui/app/AppLayouts/Onboarding/views/LoginView.qml
+++ b/ui/app/AppLayouts/Onboarding/views/LoginView.qml
@@ -138,7 +138,7 @@ Item {
             if (error) {
                 if (!root.startupStore.selectedLoginAccount.keycardCreatedAccount) {
                     // SQLITE_NOTADB: "file is not a database"
-                    if (error === "file is not a database") {
+                    if (error === "file is not a database" || error.startsWith("failed to set ")) {
                         txtPassword.validationError = qsTr("Password incorrect")
                     } else {
                         txtPassword.validationError = qsTr("Login failed: %1").arg(error.toUpperCase())


### PR DESCRIPTION
Adjust to the new error messages when opening the database with the DB pool

Fixes #10830

### Affected areas

Onboarding/Password login

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![image](https://github.com/status-im/status-desktop/assets/5377645/3fa6ec8a-bb9e-469c-bb9b-abaa25d85e71)

