### PR TITLE
fix: blurry icons in Network Filter combobox

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/StatusImage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusImage.qml
@@ -27,7 +27,7 @@ Image {
     id: root
 
     /*!
-        \qmlproperty bool StatusAnimatedImage::isLoading
+        \qmlproperty bool StatusImage::isLoading
 
         \c true when the image is currently being loaded (status === Image.Loading).
         \c false otherwise.
@@ -35,7 +35,7 @@ Image {
     */
     readonly property bool isLoading: status === Image.Loading
     /*!
-        \qmlproperty bool StatusAnimatedImage::isError
+        \qmlproperty bool StatusImage::isError
 
         \c true when an error occurred while loading the image (status === Image.Error).
         \c false otherwise.
@@ -47,7 +47,10 @@ Image {
     fillMode: Image.PreserveAspectFit
 
     onSourceChanged: {
-        if (sourceSize.width < width || sourceSize.height < height) {
+        // SVGs must have sourceSize, PNGs not; otherwise blurry
+        if (source.toString().endsWith(".svg"))
+            sourceSize = Qt.binding(() => Qt.size(width, height))
+        else if (sourceSize.width < width || sourceSize.height < height) {
             sourceSize = Qt.binding(() => Qt.size(width * 2, height * 2))
         } else {
             sourceSize = undefined

--- a/ui/StatusQ/src/StatusQ/Components/StatusRoundIcon.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusRoundIcon.qml
@@ -31,7 +31,7 @@ Rectangle {
         height: statusRoundedIcon.asset.height
 
         color: statusRoundedIcon.asset.color
-        icon: statusRoundedIcon.asset.name
+        icon: statusRoundedIcon.asset.name || statusRoundedIcon.asset.source
         rotation: statusRoundedIcon.asset.rotation
     }
 }

--- a/ui/app/AppLayouts/Wallet/controls/NetworkFilter.qml
+++ b/ui/app/AppLayouts/Wallet/controls/NetworkFilter.qml
@@ -31,7 +31,7 @@ StatusComboBox {
 
         property string selectedChainName: ""
         property string selectedIconUrl: ""
-        property bool allSelected: root.enabledNetworks.count === root.allNetworks.count
+        readonly property bool allSelected: root.enabledNetworks.count === root.allNetworks.count
 
         // Persist selection between selectPopupLoader reloads
         property var currentModel: layer1Networks
@@ -97,7 +97,7 @@ StatusComboBox {
                     visible: image.source !== ""
                     border.width: index === 0 ? 0 : 1
                     border.color: Theme.palette.white
-                    image.source: Style.svg("tiny/" + model.iconUrl)
+                    image.source: Style.svg(model.iconUrl)
                     z: index + 1
                 }
             }


### PR DESCRIPTION
Do not load a lowres image, breaks on hires displays. Also make sure we treat any SVG image the same way we do with icons, that is set the `sourceSize` to the required displayed size.

Fixes #9853

### Affected areas

NetworkFilter combobox

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![image](https://github.com/status-im/status-desktop/assets/5377645/1662a424-5f51-49cf-a3c1-d6c44e389891)

![Snímek obrazovky z 2023-05-29 13-54-40](https://github.com/status-im/status-desktop/assets/5377645/57327fe5-f919-4530-bf76-077a1bb88743)
