### PR TITLE
feat(Chat): display MutualStateUpdate system messages in 1-to-1 chats

### DIFF
--- a/src/app/modules/main/profile_section/contacts/controller.nim
+++ b/src/app/modules/main/profile_section/contacts/controller.nim
@@ -109,7 +109,9 @@ proc blockContact*(self: Controller, publicKey: string) =
   self.contactsService.blockContact(publicKey)
 
 proc removeContact*(self: Controller, publicKey: string) =
-  self.contactsService.removeContact(publicKey)
+  let response = self.contactsService.removeContact(publicKey)
+  # TODO: segfault if using SIGNAL_CHAT_REQUEST_UPDATE_AFTER_SEND
+  discard self.chatService.processMessageUpdateAfterSend(response)
 
 proc changeContactNickname*(self: Controller, publicKey: string, nickname: string) =
   self.contactsService.changeContactNickname(publicKey, nickname)

--- a/src/app_service/common/types.nim
+++ b/src/app_service/common/types.nim
@@ -9,7 +9,7 @@ type
     Status = 3
     Emoji = 4
     Transaction = 5
-    Group = 6
+    SystemMessageGroup = 6
     Image = 7
     Audio = 8
     Community = 9
@@ -19,6 +19,7 @@ type
     ContactIdentityVerification = 13
     # Local only
     SystemMessagePinnedMessage = 14
+    SystemMessageMutualStateUpdate = 15
 
 proc toContentType*(value: int): ContentType =
   try:

--- a/src/app_service/service/activity_center/dto/notification.nim
+++ b/src/app_service/service/activity_center/dto/notification.nim
@@ -19,6 +19,7 @@ type ActivityCenterNotificationType* {.pure.}= enum
   CommunityMembershipRequest = 8,
   CommunityKicked = 9,
   ContactVerification = 10
+  ContactRemoved = 11
 
 type ActivityCenterGroup* {.pure.}= enum
   All = 0,
@@ -140,7 +141,8 @@ proc activityCenterNotificationTypesByGroup*(group: ActivityCenterGroup) : seq[i
         ActivityCenterNotificationType.CommunityRequest.int,
         ActivityCenterNotificationType.CommunityMembershipRequest.int,
         ActivityCenterNotificationType.CommunityKicked.int,
-        ActivityCenterNotificationType.ContactVerification.int
+        ActivityCenterNotificationType.ContactVerification.int,
+        ActivityCenterNotificationType.ContactRemoved.int
       ]
     of ActivityCenterGroup.Mentions:
       return @[ActivityCenterNotificationType.Mention.int]
@@ -157,7 +159,10 @@ proc activityCenterNotificationTypesByGroup*(group: ActivityCenterGroup) : seq[i
     of ActivityCenterGroup.Admin:
       return @[ActivityCenterNotificationType.CommunityMembershipRequest.int]
     of ActivityCenterGroup.ContactRequests:
-      return @[ActivityCenterNotificationType.ContactRequest.int]
+      return @[
+        ActivityCenterNotificationType.ContactRequest.int,
+        ActivityCenterNotificationType.ContactRemoved.int
+      ]
     of ActivityCenterGroup.IdentityVerification:
       return @[ActivityCenterNotificationType.ContactVerification.int]
     else:

--- a/src/app_service/service/contacts/service.nim
+++ b/src/app_service/service/contacts/service.nim
@@ -550,7 +550,7 @@ QtObject:
     self.parseContactsResponse(response)
     self.events.emit(SIGNAL_CONTACT_BLOCKED, ContactArgs(contactId: contact.id))
 
-  proc removeContact*(self: Service, publicKey: string) =
+  proc removeContact*(self: Service, publicKey: string): RpcResponse[JsonNode] =
     let response = status_contacts.retractContactRequest(publicKey)
     if not response.error.isNil:
       error "error removing contact ", msg = response.error.message
@@ -558,7 +558,7 @@ QtObject:
 
     self.parseContactsResponse(response)
     self.activityCenterService.parseActivityCenterResponse(response)
-    self.events.emit(SIGNAL_CHAT_REQUEST_UPDATE_AFTER_SEND, RpcResponseArgs(response: response))
+    return response
 
   proc ensResolved*(self: Service, jsonObj: string) {.slot.} =
     let jsonObj = jsonObj.parseJson()

--- a/src/app_service/service/contacts/service.nim
+++ b/src/app_service/service/contacts/service.nim
@@ -51,6 +51,9 @@ type
     publicKey*: string
     ok*: bool
 
+  RpcResponseArgs* = ref object of Args
+    response*: RpcResponse[JsonNode]
+
 # Signals which may be emitted by this service:
 const SIGNAL_ENS_RESOLVED* = "ensResolved"
 const SIGNAL_CONTACT_ADDED* = "contactAdded"
@@ -73,6 +76,7 @@ const SIGNAL_CONTACT_VERIFICATION_ACCEPTED* = "contactVerificationRequestAccepte
 const SIGNAL_CONTACT_VERIFICATION_ADDED* = "contactVerificationRequestAdded"
 const SIGNAL_CONTACT_VERIFICATION_UPDATED* = "contactVerificationRequestUpdated"
 const SIGNAL_CONTACT_INFO_REQUEST_FINISHED* = "contactInfoRequestFinished"
+const SIGNAL_CHAT_REQUEST_UPDATE_AFTER_SEND* = "chatRequestUpdateAfterSend"
 
 type
   ContactsGroup* {.pure.} = enum
@@ -453,8 +457,6 @@ QtObject:
     if response.result["contacts"] != nil:
       for contactJson in response.result["contacts"]:
         self.updateContact(contactJson.toContactsDto())
-    # NOTE: this response may also contain chats and messages
-    self.activityCenterService.parseActivityCenterResponse(response)
 
   proc sendContactRequest*(self: Service, publicKey: string, message: string) =
     # Prefetch contact to avoid race condition with AC notification
@@ -467,6 +469,8 @@ QtObject:
         return
 
       self.parseContactsResponse(response)
+      self.activityCenterService.parseActivityCenterResponse(response)
+      self.events.emit(SIGNAL_CHAT_REQUEST_UPDATE_AFTER_SEND, RpcResponseArgs(response: response))
 
     except Exception as e:
       error "an error occurred while sending contact request", msg = e.msg
@@ -485,6 +489,8 @@ QtObject:
         return
 
       self.parseContactsResponse(response)
+      self.activityCenterService.parseActivityCenterResponse(response)
+      self.events.emit(SIGNAL_CHAT_REQUEST_UPDATE_AFTER_SEND, RpcResponseArgs(response: response))
 
     except Exception as e:
       error "an error occurred while accepting contact request", msg=e.msg
@@ -503,6 +509,8 @@ QtObject:
         return
 
       self.parseContactsResponse(response)
+      self.activityCenterService.parseActivityCenterResponse(response)
+      self.events.emit(SIGNAL_CHAT_REQUEST_UPDATE_AFTER_SEND, RpcResponseArgs(response: response))
 
     except Exception as e:
       error "an error occurred while dismissing contact request", msg=e.msg
@@ -549,6 +557,8 @@ QtObject:
       return
 
     self.parseContactsResponse(response)
+    self.activityCenterService.parseActivityCenterResponse(response)
+    self.events.emit(SIGNAL_CHAT_REQUEST_UPDATE_AFTER_SEND, RpcResponseArgs(response: response))
 
   proc ensResolved*(self: Service, jsonObj: string) {.slot.} =
     let jsonObj = jsonObj.parseJson()

--- a/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
@@ -22,7 +22,8 @@ Control {
         Transaction = 6,
         Invitation = 7,
         DiscordMessage = 8,
-        SystemMessagePinnedMessage = 14
+        SystemMessagePinnedMessage = 14,
+        SystemMessageMutualStateUpdate = 15
     }
 
     property list<Item> quickActions
@@ -188,7 +189,10 @@ Control {
 
             Loader {
                 Layout.fillWidth: true
-                active: isAReply && root.messageDetails.contentType !== StatusMessage.ContentType.SystemMessagePinnedMessage
+                active: isAReply &&
+                    root.messageDetails.contentType !== StatusMessage.ContentType.SystemMessagePinnedMessage &&
+                    root.messageDetails.contentType !== StatusMessage.ContentType.SystemMessageMutualStateUpdate
+
                 visible: active
                 sourceComponent: StatusMessageReply {
                     objectName: "StatusMessage_replyDetails"

--- a/ui/app/mainui/activitycenter/popups/ActivityCenterPopup.qml
+++ b/ui/app/mainui/activitycenter/popups/ActivityCenterPopup.qml
@@ -111,6 +111,8 @@ Popup {
                         return communityRequestNotificationComponent
                     case ActivityCenterStore.ActivityCenterNotificationType.CommunityKicked:
                         return communityKickedNotificationComponent
+                    case ActivityCenterStore.ActivityCenterNotificationType.ContactRemoved:
+                        return contactRemovedComponent
                     default:
                         return null
                 }
@@ -199,6 +201,18 @@ Popup {
         id: communityKickedNotificationComponent
 
         ActivityNotificationCommunityKicked {
+            filteredIndex: parent.filteredIndex
+            notification: parent.notification
+            store: root.store
+            activityCenterStore: root.activityCenterStore
+            onCloseActivityCenter: root.close()
+        }
+    }
+
+    Component {
+        id: contactRemovedComponent
+
+        ActivityNotificationContactRemoved {
             filteredIndex: parent.filteredIndex
             notification: parent.notification
             store: root.store

--- a/ui/app/mainui/activitycenter/stores/ActivityCenterStore.qml
+++ b/ui/app/mainui/activitycenter/stores/ActivityCenterStore.qml
@@ -28,7 +28,8 @@ QtObject {
         CommunityRequest = 7,
         CommunityMembershipRequest = 8,
         CommunityKicked = 9,
-        ContactVerification = 10
+        ContactVerification = 10,
+        ContactRemoved = 11
     }
 
     enum ActivityCenterReadType {

--- a/ui/app/mainui/activitycenter/views/ActivityNotificationContactRemoved.qml
+++ b/ui/app/mainui/activitycenter/views/ActivityNotificationContactRemoved.qml
@@ -17,6 +17,27 @@ import "../stores"
 ActivityNotificationMessage {
     id: root
 
+    function checkAndUpdateContactDetails(pubKey) {
+        if (pubKey === root.contactId)
+            root.updateContactDetails()
+    }
+
+    Connections {
+        target: root.store.contactsStore.sentContactRequestsModel
+
+        function onItemChanged(pubKey) {
+            root.checkAndUpdateContactDetails(pubKey)
+        }
+    }
+
+    Connections {
+        target: root.store.contactsStore.receivedContactRequestsModel
+
+        function onItemChanged(pubKey) {
+            root.checkAndUpdateContactDetails(pubKey)
+        }
+    }
+
     messageSubheaderComponent: StatusBaseText {
         text: qsTr("Removed you as a contact")
         font.italic: true
@@ -25,7 +46,7 @@ ActivityNotificationMessage {
     }
 
     ctaComponent: StatusFlatButton {
-        enabled: root.contactDetails && !root.contactDetails.isContact
+        enabled: root.contactDetails && !root.contactDetails.added && !root.contactDetails.hasAddedUs
         size: StatusBaseButton.Size.Small
         text: qsTr("Send Contact Request")
         onClicked: Global.openContactRequestPopup(root.contactId, null)

--- a/ui/app/mainui/activitycenter/views/ActivityNotificationContactRemoved.qml
+++ b/ui/app/mainui/activitycenter/views/ActivityNotificationContactRemoved.qml
@@ -1,0 +1,33 @@
+import QtQuick 2.14
+import QtQuick.Layouts 1.14
+
+import StatusQ.Core 0.1
+import StatusQ.Core.Theme 0.1
+import StatusQ.Components 0.1
+import StatusQ.Controls 0.1
+
+import shared 1.0
+import shared.panels 1.0
+import utils 1.0
+
+import "../panels"
+import "../popups"
+import "../stores"
+
+ActivityNotificationMessage {
+    id: root
+
+    messageSubheaderComponent: StatusBaseText {
+        text: qsTr("Removed you as a contact")
+        font.italic: true
+        font.pixelSize: 15
+        color: Theme.palette.baseColor1
+    }
+
+    ctaComponent: StatusFlatButton {
+        enabled: root.contactDetails && !root.contactDetails.isContact
+        size: StatusBaseButton.Size.Small
+        text: qsTr("Send Contact Request")
+        onClicked: Global.openContactRequestPopup(root.contactId, null)
+    }
+}

--- a/ui/app/mainui/activitycenter/views/ActivityNotificationMessage.qml
+++ b/ui/app/mainui/activitycenter/views/ActivityNotificationMessage.qml
@@ -12,7 +12,7 @@ import utils 1.0
 ActivityNotificationBase {
     id: root
 
-    readonly property bool isOutgoingMessage: notification && notification.message.amISender
+    readonly property bool isOutgoingMessage: notification && notification.message && notification.message.amISender
     readonly property string contactId: notification ? isOutgoingMessage ? notification.chatId : notification.author : ""
     readonly property string contactName: contactDetails ? ProfileUtils.displayName(contactDetails.localNickname, contactDetails.name,
                                                                       contactDetails.displayName, contactDetails.alias) : ""
@@ -23,7 +23,7 @@ ActivityNotificationBase {
     signal messageClicked()
 
     property StatusMessageDetails messageDetails: StatusMessageDetails {
-        messageText: notification ? notification.message.messageText : ""
+        messageText: notification && notification.message ? notification.message.messageText : ""
         amISender: false
         sender.id: contactId
         sender.displayName: contactName

--- a/ui/app/mainui/activitycenter/views/qmldir
+++ b/ui/app/mainui/activitycenter/views/qmldir
@@ -1,1 +1,0 @@
-ActivityCenterGroupRequest 1.0 ActivityCenterGroupRequest.qml

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -111,7 +111,6 @@ Loader {
     property bool isEmoji: messageContentType === Constants.messageContentType.emojiType
     property bool isImage: messageContentType === Constants.messageContentType.imageType || (isDiscordMessage && messageImage != "")
     property bool isAudio: messageContentType === Constants.messageContentType.audioType
-    property bool isStatusMessage: messageContentType === Constants.messageContentType.systemMessagePrivateGroupType
     property bool isSticker: messageContentType === Constants.messageContentType.stickerType
     property bool isDiscordMessage: messageContentType === Constants.messageContentType.discordMessageType
     property bool isText: messageContentType === Constants.messageContentType.messageType || messageContentType === Constants.messageContentType.contactRequestType || isDiscordMessage
@@ -195,8 +194,9 @@ Loader {
             return channelIdentifierComponent
         case Constants.messageContentType.fetchMoreMessagesButton:
             return fetchMoreMessagesButtonComponent
-        case Constants.messageContentType.systemMessagePrivateGroupType:
-            return privateGroupHeaderComponent
+        case Constants.messageContentType.systemMessagePrivateGroupType: // no break
+        case Constants.messageContentType.systemMessageMutualStateUpdate:
+            return systemMessageComponent
         case Constants.messageContentType.systemMessagePinnedMessage:
             return systemMessagePinnedMessageComponent
         case Constants.messageContentType.gapType:
@@ -271,6 +271,8 @@ Loader {
                 return StatusMessage.ContentType.DiscordMessage;
             case Constants.messageContentType.systemMessagePinnedMessage:
                 return StatusMessage.ContentType.SystemMessagePinnedMessage;
+            case Constants.messageContentType.systemMessageMutualStateUpdate:
+                return StatusMessage.ContentType.SystemMessageMutualStateUpdate;
             case Constants.messageContentType.fetchMoreMessagesButton:
             case Constants.messageContentType.chatIdentifier:
             case Constants.messageContentType.unknownContentType:
@@ -345,11 +347,13 @@ Loader {
         }
     }
 
-    // Private group Messages
     Component {
-        id: privateGroupHeaderComponent
+        id: systemMessageComponent
+
         StyledText {
             wrapMode: Text.Wrap
+
+            readonly property string systemMessageText: root.messageText.length > 0 ? root.messageText : root.unparsedText
             text: {
                 return `<html>`+
                         `<head>`+
@@ -361,14 +365,13 @@ Loader {
                         `</style>`+
                         `</head>`+
                         `<body>`+
-                        `${messageText}`+
+                        `${systemMessageText}`+
                         `</body>`+
                         `</html>`;
             }
-            visible: isStatusMessage
             font.pixelSize: 14
             color: Style.current.secondaryText
-            width:  parent.width - 120
+            width: parent.width - 120
             horizontalAlignment: Text.AlignHCenter
             anchors.horizontalCenter: parent.horizontalCenter
             textFormat: Text.RichText
@@ -478,6 +481,7 @@ Loader {
                 showHeader: root.shouldRepeatHeader || dateGroupLabel.visible || isAReply ||
                             root.prevMessageContentType === Constants.messageContentType.systemMessagePrivateGroupType ||
                             root.prevMessageContentType === Constants.messageContentType.systemMessagePinnedMessage ||
+                            root.prevMessageContentType === Constants.messageContentType.systemMessageMutualStateUpdate ||
                             root.senderId !== root.prevMessageSenderId
                 isActiveMessage: d.isMessageActive
                 topPadding: showHeader ? Style.current.halfPadding : 0
@@ -970,6 +974,4 @@ Loader {
             }
         }
     }
-
-
 }

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -414,6 +414,7 @@ QtObject {
         readonly property int contactRequestType: 11
         readonly property int discordMessageType: 12
         readonly property int systemMessagePinnedMessage: 14
+        readonly property int systemMessageMutualStateUpdate: 15
     }
 
     readonly property QtObject messageModelRoles: QtObject {


### PR DESCRIPTION
Close #10395
Waits  https://github.com/status-im/status-go/pull/3519

### What does the PR do

- [x] Display MutualStateUpdate system messages in 1-to-1 chats
- [x] AC notification when a contact get removed 

### Affected areas

Chat, Contacts

### Screenshot of functionality (including design for comparison)

<img width="1007" alt="Screenshot 2023-06-06 at 14 57 07" src="https://github.com/status-im/status-desktop/assets/2522130/e9adbb0c-c38e-4b61-a26e-84f306dd5cc1">
