### PR TITLE
test(suite_communities): move a test to different feature file

### DIFF
--- a/test/ui-test/src/screens/StatusCommunityScreen.py
+++ b/test/ui-test/src/screens/StatusCommunityScreen.py
@@ -291,6 +291,7 @@ class StatusCommunityScreen:
         type_text(CommunitySettingsComponents.EDIT_COMMUNITY_DESCRIPTION_INPUT.value, new_community_description)
 
     def change_community_color(self, new_community_color: str):
+        # TODO: fix scroll to the color component on Mac https://github.com/status-im/desktop-qa-automation/issues/57
         scroll_obj_by_name(CommunitySettingsComponents.EDIT_COMMUNITY_SCROLL_VIEW.value)
         scroll_obj_by_name(CommunitySettingsComponents.EDIT_COMMUNITY_SCROLL_VIEW.value)
         scroll_obj_by_name(CommunitySettingsComponents.EDIT_COMMUNITY_SCROLL_VIEW.value)
@@ -305,7 +306,6 @@ class StatusCommunityScreen:
     
     def edit_community(self, new_community_name: str, new_community_description: str, new_community_color: str):
         self.open_edit_community_by_community_header()
-
         self.change_community_name(new_community_name)
         self.change_community_description(new_community_description)
         self.change_community_color(new_community_color)

--- a/test/ui-test/testSuites/suite_communities/tst_communityFlows/test.feature
+++ b/test/ui-test/testSuites/suite_communities/tst_communityFlows/test.feature
@@ -88,17 +88,6 @@ Feature: Status Desktop community
             | new_community_name       | new_community_description  | new_community_color |
             | myCommunityNamedChanged  | Cool new description 123   | #ff0000             |
 
-    Scenario Outline: The admin edits a community name, description and color
-        When the admin renames the community to "<new_community_name>" and description to "<new_community_description>" and color to "<new_community_color>"
-        Then the community overview name is "<new_community_name>"
-        And the community overview description is "<new_community_description>"
-        And the community overview color is "<new_community_color>"
-        When the admin goes back to the community
-        Then the user lands on the community named "<new_community_name>"
-        Examples:
-            | new_community_name       | new_community_description  | new_community_color |
-            | myCommunityNamedChanged  | Cool new description 123   | #ff0000             |
-
     Scenario Outline: The admin changes the emoji of a channel
         When the admin changes the current community channel emoji to "<new_emoji_description>"
         Then the community channel has emoji "<new_emoji>"

--- a/test/ui-test/testSuites/suite_communities/tst_communityManageCommunity/test.feature
+++ b/test/ui-test/testSuites/suite_communities/tst_communityManageCommunity/test.feature
@@ -18,3 +18,14 @@ Background:
    	| Permissions|
    	| Mint Tokens|
    	| Airdrops   |
+
+ Scenario Outline: Manage community -> Overview: community admin edits the community name, description and color
+   When the admin renames the community to "<new_community_name>" and description to "<new_community_description>" and color to "<new_community_color>"
+   Then the community overview name is "<new_community_name>"
+   And the community overview description is "<new_community_description>"
+   And the community overview color is "<new_community_color>"
+   When the admin goes back to the community
+   Then the user lands on the community named "<new_community_name>"
+   Examples:
+     | new_community_name       | new_community_description  | new_community_color |
+     | myCommunityNamedChanged  | Cool new description 123   | #ff0000             |


### PR DESCRIPTION
### What does the PR do

1. moved community edition test to a feature file that covers actions that are allowed from Overview page of the community settings
2. added a todo to fix scrolling issue (perhaps Mac only but it is reproducible to me in 100% cases) https://github.com/status-im/desktop-qa-automation/issues/57

### Affected areas

UI tests