### PR TITLE
fix: Fix pairing same devices

### DIFF
--- a/src/app/core/signals/remote_signals/pairing.nim
+++ b/src/app/core/signals/remote_signals/pairing.nim
@@ -1,4 +1,4 @@
-import json, tables
+import json, tables, chronicles
 import base
 import ../../../../app_service/service/accounts/dto/accounts
 import ../../../../app_service/service/devices/dto/installation
@@ -21,6 +21,7 @@ proc fromEvent*(T: type LocalPairingSignal, event: JsonNode): LocalPairingSignal
     result.action = e["action"].getInt().parse()
   if e.contains("error"):
     result.error = e["error"].getStr()
+  debug "local pairing event", `type` = result.eventType, action = result.action, error = result.error, event = $event
   if not e.contains("data"):
     return
   case result.eventType:

--- a/src/app/modules/main/profile_section/devices/model.nim
+++ b/src/app/modules/main/profile_section/devices/model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, sequtils
+import NimQml, Tables, sequtils, chronicles
 import item
 import ../../../../../app_service/service/devices/dto/[installation]
 
@@ -113,7 +113,15 @@ QtObject:
     defer: index.delete
 
     self.items[i].installation = installation
-    self.dataChanged(index, index, @[])
+    self.dataChanged(index, index, @[
+      ModelRole.Identity.int,
+      ModelRole.Version.int,
+      ModelRole.Enabled.int,
+      ModelRole.Timestamp.int,
+      ModelRole.Name.int,
+      ModelRole.DeviceType.int,
+      ModelRole.FcmToken.int,
+    ])
 
   proc updateItemName*(self: Model, installationId: string, name: string) =
     var i = self.findIndexByInstallationId(installationId)

--- a/src/app_service/service/devices/service.nim
+++ b/src/app_service/service/devices/service.nim
@@ -188,6 +188,7 @@ QtObject:
         "timeout": 5 * 60 * 1000,
       }
     }
+    self.localPairingStatus.reset()
     self.localPairingStatus.mode = LocalPairingMode.Sender
     return status_go.getConnectionStringForBootstrappingAnotherDevice($configJSON)
 
@@ -204,6 +205,7 @@ QtObject:
       },
       "clientConfig": %* {}
     }
+    self.localPairingStatus.reset()
     self.localPairingStatus.mode = LocalPairingMode.Receiver
 
     let arg = AsyncInputConnectionStringArg(


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/10096

### What does the PR do

- Fixed `dataChanged` roles list, which can't be empty to simply update everything
- Fixed that `SetupSyncingPopup` wasn't showing the progress correctly when pairing twice in a row
- Added some logging

### Screenshot of functionality (including design for comparison)

https://github.com/status-im/status-desktop/assets/25482501/38da24f6-6163-4ce1-b6d2-b7f80d18d74e
