### PR TITLE
Support for synchronized & backed up settings

### DIFF
--- a/src/app/modules/main/controller.nim
+++ b/src/app/modules/main/controller.nim
@@ -290,7 +290,7 @@ proc init*(self: Controller) =
     var args = TrustArgs(e)
     self.delegate.contactUpdated(args.publicKey)
 
-  self.events.on(SIGNAL_MNEMONIC_REMOVAL) do(e: Args):
+  self.events.on(SIGNAL_MNEMONIC_REMOVED) do(e: Args):
     self.delegate.mnemonicBackedUp()
 
   self.events.on(SIGNAL_MAKE_SECTION_CHAT_ACTIVE) do(e: Args):

--- a/src/app/modules/main/profile_section/module.nim
+++ b/src/app/modules/main/profile_section/module.nim
@@ -94,7 +94,7 @@ proc newModule*(delegate: delegate_interface.AccessInterface,
   result.controller = controller.newController(result)
   result.moduleLoaded = false
 
-  result.profileModule = profile_module.newModule(result, profileService, settingsService)
+  result.profileModule = profile_module.newModule(result, events, profileService, settingsService)
   result.contactsModule = contacts_module.newModule(result, events, contactsService, chatService)
   result.languageModule = language_module.newModule(result, events, languageService)
   result.privacyModule = privacy_module.newModule(result, events, settingsService, keychainService, privacyService, generalService)
@@ -108,7 +108,7 @@ proc newModule*(delegate: delegate_interface.AccessInterface,
     result, events, settingsService, ensService, walletAccountService, networkService, tokenService
   )
   result.communitiesModule = communities_module.newModule(result, communityService)
-  result.keycardModule = keycard_module.newModule(result, events, keycardService, settingsService, networkService, 
+  result.keycardModule = keycard_module.newModule(result, events, keycardService, settingsService, networkService,
     privacyService, accountsService, walletAccountService, keychainService)
 
   result.walletModule = wallet_module.newModule(result, events, walletAccountService, settingsService, networkService)

--- a/src/app/modules/main/profile_section/privacy/controller.nim
+++ b/src/app/modules/main/profile_section/privacy/controller.nim
@@ -63,8 +63,8 @@ proc init*(self: Controller) =
       return
     self.delegate.onUserAuthenticated(args.pin, args.password, args.keyUid)
 
-  self.events.on(SIGNAL_MNEMONIC_REMOVAL) do(e: Args):
-    self.delegate.onMnemonicUpdated()
+  self.events.on(SIGNAL_MNEMONIC_REMOVED) do(e: Args):
+    self.delegate.mnemonicBackedUp()
 
   self.events.on(SIGNAL_PASSWORD_CHANGED) do(e: Args):
     var args = OperationSuccessArgs(e)
@@ -97,7 +97,7 @@ proc setMessagesFromContactsOnly*(self: Controller, value: bool): bool =
 proc validatePassword*(self: Controller, password: string): bool =
   return self.privacyService.validatePassword(password)
 
-method getPasswordStrengthScore*(self: Controller, password, userName: string): int = 
+method getPasswordStrengthScore*(self: Controller, password, userName: string): int =
   return self.generalService.getPasswordStrengthScore(password, userName)
 
 proc storeToKeychain*(self: Controller, data: string) =

--- a/src/app/modules/main/profile_section/privacy/io_interface.nim
+++ b/src/app/modules/main/profile_section/privacy/io_interface.nim
@@ -41,7 +41,7 @@ method getMnemonicWordAtIndex*(self: AccessInterface, index: int): string {.base
   raise newException(ValueError, "No implementation available")
 
 # Controller Delegate Interface
-method onMnemonicUpdated*(self: AccessInterface) {.base.} =
+method mnemonicBackedUp*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method onPasswordChanged*(self: AccessInterface, success: bool, errorMsg: string) {.base.} =

--- a/src/app/modules/main/profile_section/privacy/module.nim
+++ b/src/app/modules/main/profile_section/privacy/module.nim
@@ -66,7 +66,7 @@ method changePassword*(self: Module, password: string, newPassword: string) =
 method isMnemonicBackedUp*(self: Module): bool =
   return self.controller.isMnemonicBackedUp()
 
-method onMnemonicUpdated*(self: Module) =
+method mnemonicBackedUp*(self: Module) =
   self.view.emitMnemonicBackedUpSignal()
 
 method onPasswordChanged*(self: Module, success: bool, errorMsg: string) =
@@ -97,7 +97,7 @@ method getPasswordStrengthScore*(self: Module, password: string): int =
 method onStoreToKeychainError*(self: Module, errorDescription: string, errorType: string) =
   self.view.emitStoreToKeychainError(errorDescription)
 
-method onStoreToKeychainSuccess*(self: Module, data: string) = 
+method onStoreToKeychainSuccess*(self: Module, data: string) =
   if self.keychainActivityReason == KeychainActivityReason.StoreTo:
     singletonInstance.localAccountSettings.setStoreToKeychainValue(LS_VALUE_STORE)
   elif self.keychainActivityReason == KeychainActivityReason.RemoveFrom:

--- a/src/app/modules/main/profile_section/profile/io_interface.nim
+++ b/src/app/modules/main/profile_section/profile/io_interface.nim
@@ -25,7 +25,10 @@ method deleteIdentityImage*(self: AccessInterface) {.base.} =
 method getBio*(self: AccessInterface): string {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method setBio*(self: AccessInterface, bio: string): bool {.base.} =
+method setBio*(self: AccessInterface, bio: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method onBioChanged*(self: AccessInterface, bio: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method setDisplayName*(self: AccessInterface, displayName: string) {.base.} =

--- a/src/app/modules/main/profile_section/profile/view.nim
+++ b/src/app/modules/main/profile_section/profile/view.nim
@@ -76,7 +76,7 @@ QtObject:
   proc temporarySocialLinksJsonChanged*(self: View) {.signal.}
   proc getTemporarySocialLinksJson(self: View): string {.slot.} =
     $(%*self.temporarySocialLinksModel.items)
-    
+
 
   QtProperty[string] socialLinksJson:
     read = getSocialLinksJson
@@ -126,13 +126,13 @@ QtObject:
   proc bioChanged*(self: View) {.signal.}
   proc getBio(self: View): string {.slot.} =
     self.delegate.getBio()
-
   QtProperty[string] bio:
     read = getBio
     notify = bioChanged
 
-  proc setBio(self: View, bio: string): bool {.slot.} =
-    result = self.delegate.setBio(bio)
-    if (result):
-      self.bioChanged()
+  proc setBio(self: View, bio: string) {.slot.} =
+    self.delegate.setBio(bio)
+
+  proc emitBioChangedSignal*(self: View) =
+    self.bioChanged()
 

--- a/src/app/modules/main/wallet_section/accounts/module.nim
+++ b/src/app/modules/main/wallet_section/accounts/module.nim
@@ -71,9 +71,6 @@ method load*(self: Module) =
   self.events.on(SIGNAL_WALLET_ACCOUNT_DELETED) do(e:Args):
     self.refreshWalletAccounts()
 
-  self.events.on(SIGNAL_WALLET_ACCOUNT_CURRENCY_UPDATED) do(e:Args):
-    self.refreshWalletAccounts()
-
   self.events.on(SIGNAL_WALLET_ACCOUNT_UPDATED) do(e:Args):
     self.refreshWalletAccounts()
 

--- a/src/app/modules/main/wallet_section/io_interface.nim
+++ b/src/app/modules/main/wallet_section/io_interface.nim
@@ -27,6 +27,9 @@ method toggleWatchOnlyAccounts*(self: AccessInterface) {.base.} =
 method updateCurrency*(self: AccessInterface, currency: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method getCurrentCurrency*(self: AccessInterface): string {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method setTotalCurrencyBalance*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/wallet_section/send/module.nim
+++ b/src/app/modules/main/wallet_section/send/module.nim
@@ -91,9 +91,6 @@ method load*(self: Module) =
   self.events.on(SIGNAL_WALLET_ACCOUNT_DELETED) do(e:Args):
     self.refreshWalletAccounts()
 
-  self.events.on(SIGNAL_WALLET_ACCOUNT_CURRENCY_UPDATED) do(e:Args):
-    self.refreshWalletAccounts()
-
   self.events.on(SIGNAL_WALLET_ACCOUNT_UPDATED) do(e:Args):
     self.refreshWalletAccounts()
 
@@ -150,13 +147,13 @@ method authenticateAndTransfer*(
 
   ##################################
   ## Do Not Delete
-  ## 
+  ##
   ## Once we start with signing a transactions we shold check if the address we want to send a transaction from is migrated
   ## or not. In case it's not we should just authenticate logged in user, otherwise we should use one of the keycards that
   ## address (key pair) is migrated to and sign the transaction using it.
-  ## 
+  ##
   ## The code bellow is an example how we can achieve that in future, when we start with signing transactions.
-  ## 
+  ##
   ## let acc = self.controller.getAccountByAddress(from_addr)
   ## if acc.isNil:
   ##   echo "error: selected account to send a transaction from is not known"
@@ -166,7 +163,7 @@ method authenticateAndTransfer*(
   ##   self.controller.authenticateUser()
   ## else:
   ##   self.controller.authenticateUser(acc.keyUid, acc.path)
-  ## 
+  ##
   ##################################
 
 method onUserAuthenticated*(self: Module, password: string) =
@@ -176,14 +173,14 @@ method onUserAuthenticated*(self: Module, password: string) =
   else:
     self.controller.transfer(
       self.tmpSendTransactionDetails.fromAddr, self.tmpSendTransactionDetails.toAddr,
-      self.tmpSendTransactionDetails.tokenSymbol, self.tmpSendTransactionDetails.value, self.tmpSendTransactionDetails.uuid, 
+      self.tmpSendTransactionDetails.tokenSymbol, self.tmpSendTransactionDetails.value, self.tmpSendTransactionDetails.uuid,
       self.tmpSendTransactionDetails.selectedRoutes, password
     )
 
 method transactionWasSent*(self: Module, result: string) =
   self.view.transactionWasSent(result)
 
-method suggestedFees*(self: Module, chainId: int): string = 
+method suggestedFees*(self: Module, chainId: int): string =
   return self.controller.suggestedFees(chainId)
 
 method suggestedRoutes*(self: Module, account: string, amount: UInt256, token: string, disabledFromChainIDs, disabledToChainIDs, preferredChainIDs: seq[uint64], sendType: int, lockedInAmounts: string): string =
@@ -192,7 +189,7 @@ method suggestedRoutes*(self: Module, account: string, amount: UInt256, token: s
 method suggestedRoutesReady*(self: Module, suggestedRoutes: string) =
   self.view.suggestedRoutesReady(suggestedRoutes)
 
-method getEstimatedTime*(self: Module, chainId: int, maxFeePerGas: string): int = 
+method getEstimatedTime*(self: Module, chainId: int, maxFeePerGas: string): int =
   return self.controller.getEstimatedTime(chainId, maxFeePerGas).int
 
 method filterChanged*(self: Module, addresses: seq[string], chainIds: seq[int]) =

--- a/src/app/modules/main/wallet_section/view.nim
+++ b/src/app/modules/main/wallet_section/view.nim
@@ -8,7 +8,6 @@ QtObject:
   type
     View* = ref object of QObject
       delegate: io_interface.AccessInterface
-      currentCurrency: string
       totalCurrencyBalance: CurrencyAmount
       signingPhrase: string
       isMnemonicBackedUp: bool
@@ -33,19 +32,12 @@ QtObject:
 
   proc showToastAccountAdded*(self: View, name: string) {.signal.}
 
-  proc currentCurrencyChanged*(self: View) {.signal.}
-
   proc updateCurrency*(self: View, currency: string) {.slot.} =
     self.delegate.updateCurrency(currency)
-    self.currentCurrency = currency
-    self.currentCurrencyChanged()
-
-  proc getCurrentCurrency(self: View): QVariant {.slot.} =
-    return newQVariant(self.currentCurrency)
-
-  QtProperty[QVariant] currentCurrency:
+  proc getCurrentCurrency(self: View): string {.slot.} =
+    return self.delegate.getCurrentCurrency()
+  QtProperty[string] currentCurrency:
     read = getCurrentCurrency
-    notify = currentCurrencyChanged
 
   proc totalCurrencyBalanceChanged*(self: View) {.signal.}
 
@@ -81,10 +73,6 @@ QtObject:
     self.totalCurrencyBalance = totalCurrencyBalance
     self.totalCurrencyBalanceChanged()
 
-  proc setCurrentCurrency*(self: View, currency: string) =
-    self.currentCurrency = currency
-    self.currentCurrencyChanged()
-
 # Returning a QVariant from a slot with parameters other than "self" won't compile
 #  proc getCurrencyAmount*(self: View, amount: float, symbol: string): QVariant {.slot.} =
 #    return newQVariant(self.delegate.getCurrencyAmount(amount, symbol))
@@ -100,11 +88,9 @@ QtObject:
     self.tmpSymbol = "ERROR"
     return newQVariant(currencyAmount)
 
-  proc setData*(self: View, currency, signingPhrase: string, mnemonicBackedUp: bool) =
-    self.currentCurrency = currency
+  proc setData*(self: View, signingPhrase: string, mnemonicBackedUp: bool) =
     self.signingPhrase = signingPhrase
     self.isMnemonicBackedUp = mnemonicBackedUp
-    self.currentCurrencyChanged()
 
   proc runAddAccountPopup*(self: View, addingWatchOnlyAccount: bool) {.slot.} =
     self.delegate.runAddAccountPopup(addingWatchOnlyAccount)

--- a/src/app_service/service/privacy/service.nim
+++ b/src/app_service/service/privacy/service.nim
@@ -13,7 +13,6 @@ logScope:
   topics = "privacy-service"
 
 # Signals which may be emitted by this service:
-const SIGNAL_MNEMONIC_REMOVAL* = "menmonicRemoval"
 const SIGNAL_PASSWORD_CHANGED* = "passwordChanged"
 
 type
@@ -115,8 +114,6 @@ QtObject:
     if(not self.settingsService.saveMnemonic("")):
       data.success = false
       error "error: ", procName="removeMnemonic", errDesription = "an error occurred removing mnemonic"
-
-    self.events.emit(SIGNAL_MNEMONIC_REMOVAL, data)
 
   proc getMnemonicWordAtIndex*(self: Service, index: int): string =
     let mnemonic = self.settingsService.getMnemonic()

--- a/src/app_service/service/profile/service.nim
+++ b/src/app_service/service/profile/service.nim
@@ -27,7 +27,9 @@ proc newService*(events: EventEmitter, settingsService: settings_service.Service
   result.settingsService = settingsService
 
 proc init*(self: Service) =
-  discard
+  self.events.on(SIGNAL_DISPLAY_NAME_UPDATED) do(e:Args):
+    let args = SettingsTextValueArgs(e)
+    singletonInstance.userProfile.setDisplayName(args.value)
 
 proc storeIdentityImage*(self: Service, address: string, image: string, aX: int, aY: int, bX: int, bY: int): seq[Image] =
   try:
@@ -74,8 +76,5 @@ proc setDisplayName*(self: Service, displayName: string) =
     if(not self.settingsService.saveDisplayName(displayName)):
       error "could save display name to the settings"
       return
-    
-    singletonInstance.userProfile.setDisplayName(displayName)
-
   except Exception as e:
     error "error: ", procName="setDisplayName", errName = e.name, errDesription = e.msg

--- a/src/app_service/service/settings/service.nim
+++ b/src/app_service/service/settings/service.nim
@@ -24,6 +24,7 @@ const DEFAULT_FLEET* = $Fleet.StatusProd
 const SIGNAL_CURRENCY_UPDATED* = "currencyUpdated"
 const SIGNAL_DISPLAY_NAME_UPDATED* = "displayNameUpdated"
 const SIGNAL_BIO_UPDATED* = "bioUpdated"
+const SIGNAL_MNEMONIC_REMOVED* = "mnemonicRemoved"
 const SIGNAL_CURRENT_USER_STATUS_UPDATED* = "currentUserStatusUpdated"
 
 logScope:
@@ -98,6 +99,9 @@ QtObject:
           if settingsField.name == KEY_BIO:
             self.settings.bio = settingsField.value
             self.events.emit(SIGNAL_BIO_UPDATED, SettingsTextValueArgs(value: settingsField.value))
+          if settingsField.name == KEY_MNEMONIC:
+            self.settings.mnemonic = ""
+            self.events.emit(SIGNAL_MNEMONIC_REMOVED, Args())
 
     self.initialized = true
 
@@ -236,6 +240,7 @@ QtObject:
   proc saveMnemonic*(self: Service, value: string): bool =
     if(self.saveSetting(KEY_MNEMONIC, value)):
       self.settings.mnemonic = value
+      self.events.emit(SIGNAL_MNEMONIC_REMOVED, Args())
       return true
     return false
 

--- a/src/app_service/service/settings/service.nim
+++ b/src/app_service/service/settings/service.nim
@@ -22,6 +22,7 @@ const DEFAULT_FLEET* = $Fleet.StatusProd
 
 # Signals:
 const SIGNAL_CURRENCY_UPDATED* = "currencyUpdated"
+const SIGNAL_DISPLAY_NAME_UPDATED* = "displayNameUpdated"
 const SIGNAL_CURRENT_USER_STATUS_UPDATED* = "currentUserStatusUpdated"
 
 logScope:
@@ -90,6 +91,9 @@ QtObject:
           if settingsField.name == KEY_CURRENCY:
             self.settings.currency = settingsField.value
             self.events.emit(SIGNAL_CURRENCY_UPDATED, SettingsTextValueArgs(value: settingsField.value))
+          if settingsField.name == KEY_DISPLAY_NAME:
+            self.settings.displayName = settingsField.value
+            self.events.emit(SIGNAL_DISPLAY_NAME_UPDATED, SettingsTextValueArgs(value: settingsField.value))
 
     self.initialized = true
 
@@ -185,6 +189,7 @@ QtObject:
   proc saveDisplayName*(self: Service, value: string): bool =
     if(self.saveSetting(KEY_DISPLAY_NAME, value)):
       self.settings.displayName = value
+      self.events.emit(SIGNAL_DISPLAY_NAME_UPDATED, SettingsTextValueArgs(value: self.settings.displayName))
       return true
     return false
 

--- a/src/app_service/service/settings/service.nim
+++ b/src/app_service/service/settings/service.nim
@@ -23,6 +23,7 @@ const DEFAULT_FLEET* = $Fleet.StatusProd
 # Signals:
 const SIGNAL_CURRENCY_UPDATED* = "currencyUpdated"
 const SIGNAL_DISPLAY_NAME_UPDATED* = "displayNameUpdated"
+const SIGNAL_BIO_UPDATED* = "bioUpdated"
 const SIGNAL_CURRENT_USER_STATUS_UPDATED* = "currentUserStatusUpdated"
 
 logScope:
@@ -94,6 +95,9 @@ QtObject:
           if settingsField.name == KEY_DISPLAY_NAME:
             self.settings.displayName = settingsField.value
             self.events.emit(SIGNAL_DISPLAY_NAME_UPDATED, SettingsTextValueArgs(value: settingsField.value))
+          if settingsField.name == KEY_BIO:
+            self.settings.bio = settingsField.value
+            self.events.emit(SIGNAL_BIO_UPDATED, SettingsTextValueArgs(value: settingsField.value))
 
     self.initialized = true
 
@@ -901,19 +905,12 @@ QtObject:
   proc getBio*(self: Service): string =
     self.settings.bio
 
-  proc setBio*(self: Service, bio: string): bool =
-    result = false
-    try:
-      let response = status_settings.setBio(bio)
-
-      if(not response.error.isNil):
-        error "error setting bio", errDescription = response.error.message
-
-      self.settings.bio = bio
-      result = true
-    except Exception as e:
-      error "error setting bio", errDesription = e.msg
-
+  proc saveBio*(self: Service, value: string): bool =
+    if(self.saveSetting(KEY_BIO, value)):
+      self.settings.bio = value
+      self.events.emit(SIGNAL_BIO_UPDATED, SettingsTextValueArgs(value: self.settings.bio))
+      return true
+    return false
 
   proc getSocialLinks*(self: Service): SocialLinks =
     return self.socialLinks

--- a/src/backend/settings.nim
+++ b/src/backend/settings.nim
@@ -96,9 +96,6 @@ proc setExemptions*(id: string, muteAllMessages: bool, personalMentions: string,
 proc deleteExemptions*(id: string): RpcResponse[JsonNode] {.raises: [Exception].} =
   return core.callPrivateRPC("settings_deleteExemptions", %* [id])
 
-proc setBio*(value: string): RpcResponse[JsonNode] {.raises: [Exception].} =
-  return core.callPrivateRPC("settings_setBio", %* [value])
-
 proc setSocialLinks*(value: JsonNode): RpcResponse[JsonNode] {.raises: [Exception].} =
   return core.callPrivateRPC("settings_setSocialLinks", %* [value])
 


### PR DESCRIPTION
This PR handles items from the `settings` table on the desktop app side and this way aligns mobile and desktop app.

There are items which are marked as inactive on the status-go side and because of that they are excluded from syncing and backing up.

There is a table in the description of #10389 describing the state of handling synced&backed up settings' items.

The work is splitted in several commits that can be easier for review. Single commit handles single setting.

Fixes: #10389 