### PR TITLE
feat(communities): Adds mute category interval

### DIFF
--- a/src/app/modules/main/chat_section/controller.nim
+++ b/src/app/modules/main/chat_section/controller.nim
@@ -122,11 +122,11 @@ proc init*(self: Controller) =
 
   self.events.on(chat_service.SIGNAL_CHAT_MUTED) do(e:Args):
     let args = chat_service.ChatArgs(e)
-    self.delegate.onChatMuted(args.chatId)
+    self.delegate.changeMutedOnChat(args.chatId, true)
 
   self.events.on(chat_service.SIGNAL_CHAT_UNMUTED) do(e:Args):
     let args = chat_service.ChatArgs(e)
-    self.delegate.onChatUnmuted(args.chatId)
+    self.delegate.changeMutedOnChat(args.chatId, false)
 
   self.events.on(message_service.SIGNAL_MESSAGES_MARKED_AS_READ) do(e: Args):
     let args = message_service.MessagesMarkedAsReadArgs(e)
@@ -597,8 +597,8 @@ proc editCommunity*(
 proc exportCommunity*(self: Controller): string =
   self.communityService.exportCommunity(self.sectionId)
 
-proc muteCategory*(self: Controller, categoryId: string) =
-  self.communityService.muteCategory(self.sectionId, categoryId)
+proc muteCategory*(self: Controller, categoryId: string, interval: int) =
+  self.communityService.muteCategory(self.sectionId, categoryId, interval)
 
 proc unmuteCategory*(self: Controller, categoryId: string) =
   self.communityService.unmuteCategory(self.sectionId, categoryId)

--- a/src/app/modules/main/chat_section/io_interface.nim
+++ b/src/app/modules/main/chat_section/io_interface.nim
@@ -105,10 +105,7 @@ method onNewMessagesReceived*(self: AccessInterface, sectionIdMsgBelongsTo: stri
   chatTypeMsgBelongsTo: ChatType, lastMessageTimestamp: int, unviewedMessagesCount: int, unviewedMentionsCount: int, message: MessageDto) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method onChatMuted*(self: AccessInterface, chatId: string) {.base.} =
-  raise newException(ValueError, "No implementation available")
-
-method onChatUnmuted*(self: AccessInterface, chatId: string) {.base.} =
+method changeMutedOnChat*(self: AccessInterface, chatId: string, muted: bool) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method onMarkAllMessagesRead*(self: AccessInterface, chat: ChatDto) {.base.} =
@@ -204,7 +201,7 @@ method muteChat*(self: AccessInterface, chatId: string, interval: int) {.base.} 
 method unmuteChat*(self: AccessInterface, chatId: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method muteCategory*(self: AccessInterface, categoryId: string) {.base.} =
+method muteCategory*(self: AccessInterface, categoryId: string, interval: int) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method unmuteCategory*(self: AccessInterface, categoryId: string) {.base.} =

--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -769,8 +769,8 @@ method muteChat*(self: Module, chatId: string, interval: int) =
 method unmuteChat*(self: Module, chatId: string) =
   self.controller.unmuteChat(chatId)
 
-method muteCategory*(self: Module, categoryId: string) =
-  self.controller.muteCategory(categoryId)
+method muteCategory*(self: Module, categoryId: string, interval: int) =
+  self.controller.muteCategory(categoryId, interval)
 
 method unmuteCategory*(self: Module, categoryId: string) =
   self.controller.unmuteCategory(categoryId)
@@ -781,11 +781,8 @@ method onCategoryMuted*(self: Module, categoryId: string) =
 method onCategoryUnmuted*(self: Module, categoryId: string) =
   self.view.chatsModel().changeMutedOnItemByCategoryId(categoryId, false)
 
-method onChatMuted*(self: Module, chatId: string) =
-  self.view.chatsModel().changeMutedOnItemById(chatId, muted=true)
-
-method onChatUnmuted*(self: Module, chatId: string) =
-  self.view.chatsModel().changeMutedOnItemById(chatId, muted=false)
+method changeMutedOnChat*(self: Module, chatId: string, muted: bool) =
+  self.view.chatsModel().changeMutedOnItemById(chatId, muted)
 
 method onCommunityTokenPermissionDeleted*(self: Module, communityId: string, permissionId: string) =
   self.rebuildCommunityTokenPermissionsModel()
@@ -1175,6 +1172,7 @@ proc addOrUpdateChat(self: Module,
     self.updateActiveChatMembership()
 
   if chatExists:
+    self.changeMutedOnChat(chat.id, chat.muted)
     if (chat.chatType == ChatType.PrivateGroupChat):
       self.onGroupChatDetailsUpdated(chat.id, chat.name, chat.color, chat.icon)
     elif (chat.chatType != ChatType.OneToOne):

--- a/src/app/modules/main/chat_section/view.nim
+++ b/src/app/modules/main/chat_section/view.nim
@@ -200,8 +200,8 @@ QtObject:
   proc unmuteChat*(self: View, chatId: string) {.slot.} =
     self.delegate.unmuteChat(chatId)
 
-  proc muteCategory*(self: View, categoryId: string) {.slot.} =
-    self.delegate.muteCategory(categoryId)
+  proc muteCategory*(self: View, categoryId: string, interval: int) {.slot.} =
+    self.delegate.muteCategory(categoryId, interval)
 
   proc unmuteCategory*(self: View, categoryId: string) {.slot.} =
     self.delegate.unmuteCategory(categoryId)

--- a/src/app_service/service/community/service.nim
+++ b/src/app_service/service/community/service.nim
@@ -1648,9 +1648,9 @@ QtObject:
       error "Error sharing community", msg = e.msg
       result = "Error sharing community: " & e.msg
 
-  proc muteCategory*(self: Service, communityId: string, categoryId: string) =
+  proc muteCategory*(self: Service, communityId: string, categoryId: string, interval: int) =
     try:
-      let response = status_go.muteCategory(communityId, categoryId)
+      let response = status_go.muteCategory(communityId, categoryId, interval)
       if (not response.error.isNil):
         let msg = response.error.message & " categoryId=" & categoryId
         error "error while mute category ", msg

--- a/src/backend/communities.nim
+++ b/src/backend/communities.nim
@@ -9,13 +9,17 @@ export response_type
 proc getCommunityTags*(): RpcResponse[JsonNode] {.raises: [Exception].} =
   result = callPrivateRPC("communityTags".prefix)
   
-proc muteCategory*(communityId: string, categoryId: string): RpcResponse[JsonNode] {.raises: [Exception].} =
-  let payload = %* [communityId, categoryId]
-  result = callPrivateRPC("muteCommunityCategory".prefix, payload)
+proc muteCategory*(communityId: string, categoryId: string, interval: int): RpcResponse[JsonNode] {.raises: [Exception].} =
+  result = callPrivateRPC("muteCommunityCategory".prefix, %* [
+    {
+      "communityId": communityId,
+      "categoryId": categoryId,
+      "mutedType": interval,
+    }
+  ])
 
 proc unmuteCategory*(communityId: string, categoryId: string): RpcResponse[JsonNode] {.raises: [Exception].} =
-  let payload = %* [communityId, categoryId]
-  result = callPrivateRPC("unmuteCommunityCategory".prefix, payload)
+  result = callPrivateRPC("unmuteCommunityCategory".prefix, %* [communityId, categoryId])
 
 proc getCuratedCommunities*(): RpcResponse[JsonNode] {.raises: [Exception].} =
   let payload = %* []

--- a/ui/app/AppLayouts/Chat/views/CommunityColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/CommunityColumnView.qml
@@ -14,6 +14,8 @@ import utils 1.0
 import shared 1.0
 import shared.popups 1.0
 import shared.status 1.0
+import shared.controls.chat.menuItems 1.0
+
 import "../popups/community"
 import "../panels"
 import "../panels/communities"
@@ -229,18 +231,24 @@ Item {
             }
 
             categoryPopupMenu: StatusMenu {
-
+                id: contextMenuCategory
                 property var categoryItem
 
+                MuteChatMenuItem {
+                    enabled: !!categoryItem && !categoryItem.muted
+                    title: qsTr("Mute category")
+                    onMuteTriggered: {
+                        root.communitySectionModule.muteCategory(categoryItem.itemId, interval)
+                        contextMenuCategory.close()
+                    }
+                }
+
                 StatusAction {
-                    text: !!categoryItem ? categoryItem.muted ? qsTr("Unmute category") : qsTr("Mute category") : ""
+                    enabled: !!categoryItem && categoryItem.muted
+                    text: qsTr("Unmute category")
                     icon.name: "notification"
                     onTriggered: {
-                        if (categoryItem.muted) {
-                            root.communitySectionModule.unmuteCategory(categoryItem.itemId)
-                        } else {
-                            root.communitySectionModule.muteCategory(categoryItem.itemId)
-                        }
+                        root.communitySectionModule.unmuteCategory(categoryItem.itemId)
                     }
                 }
 


### PR DESCRIPTION
Part of: #9369

[STATUSGO PR](https://github.com/status-im/status-go/pull/3534)

### What does the PR do

Adds mute interval for categories

### Affected areas

Muting category

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it


![Снимок экрана 2023-05-30 в 20 47 47](https://github.com/status-im/status-desktop/assets/82511785/87d01c06-c7f6-4fbc-a848-09216088dd16)
