### PR TITLE
feat(NewChat): open contact popup when pasting key of user in request

### DIFF
--- a/ui/app/AppLayouts/Chat/views/MembersSelectorView.qml
+++ b/ui/app/AppLayouts/Chat/views/MembersSelectorView.qml
@@ -87,19 +87,26 @@ MembersSelectorBase {
                 return
             }
 
-            if (contactDetails.publicKey === root.rootStore.contactsStore.myPublicKey ||
-                contactDetails.isBlocked) {
-                root.suggestionsDialog.forceHide = false
-                return
-            };
-
             if (contactDetails.isContact) {
+                // Is a contact, we add their name to the list
                 root.pastedChatKey = contactDetails.publicKey
                 root.suggestionsDialog.forceHide = false
                 return
             }
 
-            if (root.model.count === 0 && !root.rootStore.contactsStore.hasPendingContactRequest(contactDetails.publicKey)) {
+            let hasPendingContactRequest = root.rootStore.contactsStore.hasPendingContactRequest(contactDetails.publicKey)
+
+            if ((root.model.count === 0 && hasPendingContactRequest) ||
+                    contactDetails.publicKey === root.rootStore.contactsStore.myPublicKey || contactDetails.isBlocked) {
+                // List is empty and we have a contact request
+                // OR it's our own chat key or a banned user
+                // Then open the contact's profile popup
+                Global.openProfilePopup(contactDetails.publicKey, null,  popup => popup.closed.connect(root.rejected))
+                return
+            }
+
+            if (root.model.count === 0 && !hasPendingContactRequest) {
+                // List is empty and not a contact yet. Open the contact request popup
                 Global.openContactRequestPopup(contactDetails.publicKey,
                                                popup => popup.closed.connect(root.rejected))
                 return

--- a/ui/app/mainui/Popups.qml
+++ b/ui/app/mainui/Popups.qml
@@ -85,8 +85,8 @@ QtObject {
         popup.openPopup(image)
     }
 
-    function openProfilePopup(publicKey: string, parentPopup) {
-        openPopup(profilePopupComponent, {publicKey: publicKey, parentPopup: parentPopup})
+    function openProfilePopup(publicKey: string, parentPopup, cb) {
+        openPopup(profilePopupComponent, {publicKey: publicKey, parentPopup: parentPopup}, cb)
     }
 
     function openNicknamePopup(publicKey: string, nickname: string, subtitle: string) {

--- a/ui/imports/utils/Global.qml
+++ b/ui/imports/utils/Global.qml
@@ -33,7 +33,7 @@ QtObject {
     signal openChangeProfilePicPopup(var cb)
     signal openBackUpSeedPopup()
     signal openImagePopup(var image)
-    signal openProfilePopupRequested(string publicKey, var parentPopup)
+    signal openProfilePopupRequested(string publicKey, var parentPopup, var cb)
     signal openEditDisplayNamePopup()
     signal openActivityCenterPopupRequested()
     signal openSendIDRequestPopup(string publicKey, var cb)
@@ -60,8 +60,8 @@ QtObject {
     signal playNotificationSound()
     signal playErrorSound()
 
-    function openProfilePopup(publicKey, parentPopup) {
-        root.openProfilePopupRequested(publicKey, parentPopup)
+    function openProfilePopup(publicKey, parentPopup, cb) {
+        root.openProfilePopupRequested(publicKey, parentPopup, cb)
     }
 
     function openActivityCenterPopup() {


### PR DESCRIPTION
Fixes #9736

When pasting the chat key of a user to whom you already sent a request to, but for which they haven't answered yet, we open the popup instead of doing nothing. If you paste the chat key of a user you are not a contact at all and sent no request, it opens the contact request popup as before. Also, same as before, if you paste the key of a mutual contact, their name will show in the suggestion list.

[new-chat.webm](https://github.com/status-im/status-desktop/assets/11926403/f88cb998-f9b3-4deb-b4d8-6c3f81e595ff)
