### PR TITLE
feat(Mint Assets): Update minted tokens view with assets

### DIFF
--- a/storybook/PagesModel.qml
+++ b/storybook/PagesModel.qml
@@ -194,7 +194,7 @@ ListModel {
          section: "Popups"
     }
     ListElement {
-         title: "RemotelyDestructAlertPopup"
+         title: "AlertPopup"
          section: "Popups"
     }
     ListElement {

--- a/storybook/pages/AlertPopupPage.qml
+++ b/storybook/pages/AlertPopupPage.qml
@@ -29,14 +29,16 @@ SplitView {
                 onClicked: dialog.open()
             }
 
-            RemotelyDestructAlertPopup {
+            AlertPopup {
                 id: dialog
 
                 anchors.centerIn: parent
-                tokenCount: 12
+                title: qsTr("Remotely destruct %n token(s)", "", 12)
+                acceptBtnText: qsTr("Remotely destruct")
+                alertText: qsTr("Continuing will destroy tokens held by members and revoke any perissions they given. To undo you will have to issue them new tokens.")
 
-                onRemotelyDestructClicked: logs.logEvent("RemotelyDestructAlertPopup::onRemotelyDestructClicked")
-                onCancelClicked: logs.logEvent("RemotelyDestructAlertPopup::onCancelClicked")
+                onAcceptClicked: logs.logEvent("AlertPopup::onAcceptClicked")
+                onCancelClicked: logs.logEvent("AlertPopup::onCancelClicked")
 
             }
         }

--- a/storybook/pages/CommunityMintTokensSettingsPanelPage.qml
+++ b/storybook/pages/CommunityMintTokensSettingsPanelPage.qml
@@ -37,6 +37,8 @@ SplitView {
             accounts: WalletAccountsModel {}
 
             onMintCollectible: logs.logEvent("CommunityMintTokensSettingsPanel::mintCollectible")
+            onMintAsset: logs.logEvent("CommunityMintTokensSettingsPanel::mintAssets")
+            onDeleteToken: logs.logEvent("CommunityMintTokensSettingsPanel::deleteToken: " + key)
         }
     }
 

--- a/storybook/pages/CommunityMintTokensSettingsPanelPage.qml
+++ b/storybook/pages/CommunityMintTokensSettingsPanelPage.qml
@@ -28,7 +28,7 @@ SplitView {
         CommunityMintTokensSettingsPanel {
             anchors.fill: parent
             anchors.topMargin: 50
-            tokensModel: editorModelChecked.checked ? emptyModel : MintedCollectiblesModel.mintedCollectibleModel
+            tokensModel: editorModelChecked.checked ? emptyModel : MintedTokensModel.mintedTokensModel
             layer1Networks: NetworksModel.layer1Networks
             layer2Networks: NetworksModel.layer2Networks
             testNetworks: NetworksModel.testNetworks
@@ -71,9 +71,9 @@ SplitView {
                     checked: true
                     onCheckedChanged:{
                         if(checked)
-                            MintedCollectiblesModel.changeAllMintingStates(1/*In progress*/)
+                            MintedTokensModel.changeAllMintingStates(1/*In progress*/)
                         else
-                            MintedCollectiblesModel.changeAllMintingStates(2/*Deployed*/)
+                            MintedTokensModel.changeAllMintingStates(2/*Deployed*/)
                     }
 
                 }

--- a/storybook/pages/CommunityMintTokensSettingsPanelPage.qml
+++ b/storybook/pages/CommunityMintTokensSettingsPanelPage.qml
@@ -20,12 +20,18 @@ SplitView {
         id: emptyModel
     }
 
+    Button {
+        text: "Back"
+        onClicked: panel.navigateBack()
+    }
     Rectangle {
         SplitView.fillWidth: true
         SplitView.fillHeight: true
-        color: Theme.palette.statusAppLayout.rightPanelBackgroundColor
+        color: Theme.palette.statusAppLayout.rightPanelBackgroundColor        
 
         CommunityMintTokensSettingsPanel {
+            id: panel
+
             anchors.fill: parent
             anchors.topMargin: 50
             tokensModel: editorModelChecked.checked ? emptyModel : MintedTokensModel.mintedTokensModel
@@ -39,6 +45,7 @@ SplitView {
             onMintCollectible: logs.logEvent("CommunityMintTokensSettingsPanel::mintCollectible")
             onMintAsset: logs.logEvent("CommunityMintTokensSettingsPanel::mintAssets")
             onDeleteToken: logs.logEvent("CommunityMintTokensSettingsPanel::deleteToken: " + key)
+            onRetryMintToken: logs.logEvent("CommunityMintTokensSettingsPanel::retryMintToken: " + key)
         }
     }
 

--- a/storybook/pages/CommunityMintedTokensViewPage.qml
+++ b/storybook/pages/CommunityMintedTokensViewPage.qml
@@ -28,7 +28,7 @@ SplitView {
                 anchors.fill: parent
                 anchors.margins: 50
                 model: MintedTokensModel.mintedTokensModel
-                onItemClicked: logs.logEvent("CommunityMintedTokensView::itemClicked")
+                onItemClicked: logs.logEvent("CommunityMintedTokensView::itemClicked --> " + contractUniqueKey)
             }
         }
 

--- a/storybook/pages/CommunityMintedTokensViewPage.qml
+++ b/storybook/pages/CommunityMintedTokensViewPage.qml
@@ -24,10 +24,10 @@ SplitView {
             SplitView.fillWidth: true
             SplitView.fillHeight: true
 
-            CommunityMintedTokensView {
+            CommunityMintedTokensView {               
                 anchors.fill: parent
                 anchors.margins: 50
-                model: MintedCollectiblesModel.mintedCollectibleModel
+                model: MintedTokensModel.mintedTokensModel
                 onItemClicked: logs.logEvent("CommunityMintedTokensView::itemClicked")
             }
         }
@@ -39,6 +39,25 @@ SplitView {
             SplitView.preferredHeight: 150
 
             logsView.logText: logs.logText
+
+            RowLayout {
+                RadioButton {
+                   text: "Assets and collectibles"
+                   checked: true
+                   onCheckedChanged: if(checked) MintedTokensModel.buildMintedTokensModel(true, true)
+                }
+
+                RadioButton {
+                   text: "Only assets"
+                   onCheckedChanged: if(checked) MintedTokensModel.buildMintedTokensModel(true, false)
+                }
+
+                RadioButton {
+                   text: "Only collectibles"
+                   onCheckedChanged: if(checked) MintedTokensModel.buildMintedTokensModel(false, true)
+                }
+            }
         }
     }
+
 }

--- a/storybook/pages/CommunityNewTokenViewPage.qml
+++ b/storybook/pages/CommunityNewTokenViewPage.qml
@@ -34,7 +34,7 @@ SplitView {
                 enabledNetworks: NetworksModel.enabledNetworks
                 allNetworks: enabledNetworks
                 accounts: WalletAccountsModel {}
-                tokensModel: MintedCollectiblesModel.mintedCollectibleModel
+                tokensModel: MintedTokensModel.mintedTokensModel
 
                 onPreviewClicked: logs.logEvent("CommunityNewTokenView::previewClicked")
             }

--- a/storybook/pages/CommunityTokenViewPage.qml
+++ b/storybook/pages/CommunityTokenViewPage.qml
@@ -115,20 +115,20 @@ SplitView {
                     RadioButton {
                         id: mintingInProgress
                         text: "In progress"
-                        onCheckedChanged: if(checked) view.deployState = Constants.BackendProcessState.InProgress
+                        onCheckedChanged: if(checked) view.deployState = Constants.ContractTransactionStatus.InProgress
                     }
 
                     RadioButton {
                         id: mintingFailed
                         text: "Failed"
-                        onCheckedChanged: if(checked) view.deployState = Constants.BackendProcessState.Failed
+                        onCheckedChanged: if(checked) view.deployState = Constants.ContractTransactionStatus.Failed
                     }
 
                     RadioButton {
                         id: mintingCompleted
                         text: "Completed"
                         checked: true
-                        onCheckedChanged: if(checked) view.deployState = Constants.BackendProcessState.Completed
+                        onCheckedChanged: if(checked) view.deployState = Constants.ContractTransactionStatus.Completed
                     }
                 }
 

--- a/storybook/src/Models/MintedTokensModel.qml
+++ b/storybook/src/Models/MintedTokensModel.qml
@@ -33,6 +33,7 @@ QtObject {
 
         Component.onCompleted: append([
                                           {
+                                              contractUniqueKey: "0x1726362343",
                                               tokenType: 2,
                                               name: "SuperRare artwork",
                                               image: ModelsData.banners.superRare,
@@ -50,6 +51,7 @@ QtObject {
                                               accountName: "Status Account"
                                           },
                                           {
+                                              contractUniqueKey: "0x847843",
                                               tokenType: 2,
                                               name: "Kitty artwork",
                                               image: ModelsData.collectibles.kitty1Big,
@@ -67,6 +69,7 @@ QtObject {
                                               accountName: "Status New Account"
                                           },
                                           {
+                                              contractUniqueKey: "0x1234525",
                                               tokenType: 2,
                                               name: "More artwork",
                                               image: ModelsData.banners.status,
@@ -84,6 +87,7 @@ QtObject {
                                               accountName: "Other Account"
                                           },
                                           {
+                                              contractUniqueKey: "0x38576852",
                                               tokenType: 2,
                                               name: "Crypto Punks artwork",
                                               image: ModelsData.banners.cryptPunks,
@@ -108,6 +112,7 @@ QtObject {
 
         Component.onCompleted: append([
                                           {
+                                              contractUniqueKey: "0x38745623865",
                                               tokenType: 1,
                                               name: "Unisocks",
                                               image: ModelsData.assets.socks,
@@ -124,6 +129,7 @@ QtObject {
                                               accountName: "Status SNT Account"
                                           },
                                           {
+                                              contractUniqueKey: "0x872364871623",
                                               tokenType: 1,
                                               name: "Dai",
                                               image: ModelsData.assets.dai,

--- a/storybook/src/Models/MintedTokensModel.qml
+++ b/storybook/src/Models/MintedTokensModel.qml
@@ -14,11 +14,26 @@ QtObject {
         }
     }
 
-    readonly property ListModel mintedCollectibleModel: ListModel {
-        id: model
+    function buildMintedTokensModel(isAssets, isCollectibles) {
+        model.clear()
+
+        if(isAssets) {
+            for(var i = 0; i < mintedAssetsModel.count; i++)
+                model.append(mintedAssetsModel.get(i))
+        }
+
+        if(isCollectibles) {
+            for(var j = 0; j < collectiblesModel.count; j++)
+                model.append(collectiblesModel.get(j))
+        }
+    }
+
+    readonly property ListModel mintedCollectiblesModel: ListModel {
+        id: collectiblesModel
 
         Component.onCompleted: append([
                                           {
+                                              tokenType: 2,
                                               name: "SuperRare artwork",
                                               image: ModelsData.banners.superRare,
                                               deployState: 0,
@@ -35,6 +50,7 @@ QtObject {
                                               accountName: "Status Account"
                                           },
                                           {
+                                              tokenType: 2,
                                               name: "Kitty artwork",
                                               image: ModelsData.collectibles.kitty1Big,
                                               deployState: 2,
@@ -51,6 +67,7 @@ QtObject {
                                               accountName: "Status New Account"
                                           },
                                           {
+                                              tokenType: 2,
                                               name: "More artwork",
                                               image: ModelsData.banners.status,
                                               deployState: 1,
@@ -67,6 +84,7 @@ QtObject {
                                               accountName: "Other Account"
                                           },
                                           {
+                                              tokenType: 2,
                                               name: "Crypto Punks artwork",
                                               image: ModelsData.banners.cryptPunks,
                                               deployState: 2,
@@ -83,5 +101,50 @@ QtObject {
                                               accountName: "Account"
                                           }
                                       ])
+    }
+
+    readonly property ListModel mintedAssetsModel: ListModel {
+        id: assetsModel
+
+        Component.onCompleted: append([
+                                          {
+                                              tokenType: 1,
+                                              name: "Unisocks",
+                                              image: ModelsData.assets.socks,
+                                              deployState: 2,
+                                              symbol: "SOCKS",
+                                              description: "Socks description",
+                                              supply: 14,
+                                              remainingTokens: 2,
+                                              infiniteSupply: false,
+                                              decimals: 2,
+                                              chainId: 2,
+                                              chainName: "Optimism",
+                                              chainIcon: ModelsData.networks.optimism,
+                                              accountName: "Status SNT Account"
+                                          },
+                                          {
+                                              tokenType: 1,
+                                              name: "Dai",
+                                              image: ModelsData.assets.dai,
+                                              deployState: 0,
+                                              symbol: "DAI",
+                                              description: "Desc",
+                                              supply: 1,
+                                              remainingTokens: 1,
+                                              infiniteSupply: true,
+                                              decimals: 1,
+                                              chainId: 1,
+                                              chainName: "Testnet",
+                                              chainIcon: ModelsData.networks.testnet,
+                                              accountName: "Status Account"
+                                          }
+                                      ])
+    }
+
+    readonly property ListModel mintedTokensModel: ListModel {
+        id: model
+
+        Component.onCompleted: buildMintedTokensModel(true, true)
     }
 }

--- a/storybook/src/Models/qmldir
+++ b/storybook/src/Models/qmldir
@@ -9,7 +9,7 @@ TokenHoldersModel 1.0 TokenHoldersModel.qml
 UsersModel 1.0 UsersModel.qml
 WalletAccountsModel 1.0 WalletAccountsModel.qml
 WalletAssetsModel 1.0 WalletAssetsModel.qml
-singleton MintedCollectiblesModel 1.0 MintedCollectiblesModel.qml
+singleton MintedTokensModel 1.0 MintedTokensModel.qml
 singleton ModelsData 1.0 ModelsData.qml
 singleton NetworksModel 1.0 NetworksModel.qml
 singleton PermissionsModel 1.0 PermissionsModel.qml

--- a/test/ui-test/testSuites/suite_communities/shared/scripts/community_names.py
+++ b/test/ui-test/testSuites/suite_communities/shared/scripts/community_names.py
@@ -92,4 +92,4 @@ community_welcome_screen_subtitle = {"container": statusDesktop_mainWindow, "obj
 community_welcome_screen_checkList_element1 = {"container": statusDesktop_mainWindow, "objectName": "checkListText_0", "type": "StatusBaseText", "visible": True}
 community_welcome_screen_checkList_element2 = {"container": statusDesktop_mainWindow, "objectName": "checkListText_1", "type": "StatusBaseText", "visible": True}
 community_welcome_screen_checkList_element3 = {"container": statusDesktop_mainWindow, "objectName": "checkListText_2", "type": "StatusBaseText", "visible": True}
-community_welcome_screen_add_new_item = {"container": statusDesktop_mainWindow, "objectName": "addNewItemActionButton", "type": "StatusButton", "visible": True}
+community_welcome_screen_add_new_item = {"container": statusDesktop_mainWindow, "objectName": "primaryHeaderButton", "type": "StatusButton", "visible": True}

--- a/ui/app/AppLayouts/Chat/layouts/SettingsPageLayout.qml
+++ b/ui/app/AppLayouts/Chat/layouts/SettingsPageLayout.qml
@@ -16,16 +16,15 @@ Item {
     property alias title: itemHeader.text
     property Component content
 
-
     // optional
     property Component footer
     property bool dirty: false
     property bool editable: false
-    property bool headerButtonVisible: false
-    property string headerButtonText: ""
-    property int headerWidth: 0
+    property int headerWidth: d.defaultContentWidth
     property string previousPageName: ""
     property bool saveChangesButtonEnabled: !!root.contentItem && !!root.contentItem.saveChangesButtonEnabled
+    property alias primaryHeaderButton: primaryHeaderBtn
+    property alias secondaryHeaderButton: secondaryHeaderBtn
     property alias saveChangesText: settingsDirtyToastMessage.saveChangesText
     property alias cancelChangesText: settingsDirtyToastMessage.cancelChangesText
     property alias changesDetectedText: settingsDirtyToastMessage.changesDetectedText
@@ -38,7 +37,15 @@ Item {
 
     signal saveChangesClicked
     signal resetChangesClicked
-    signal headerButtonClicked
+    signal primaryHeaderButtonClicked
+    signal secondaryHeaderButtonClicked
+
+    QtObject {
+        id: d
+
+        readonly property int leftMargin: 64
+        readonly property int defaultContentWidth: 560
+    }
 
     function reloadContent() {
         contentLoader.active = false
@@ -49,27 +56,28 @@ Item {
         settingsDirtyToastMessage.notifyDirty()
     }
 
-    implicitWidth: layout.implicitWidth
     implicitHeight: layout.implicitHeight
+    implicitWidth: layout.implicitWidth
 
     ColumnLayout {
         id: layout
 
         anchors.fill: parent
+        anchors.bottomMargin: 24
         spacing: 16
 
         RowLayout {
-            Layout.maximumWidth: root.headerWidth === 0 ? parent.width : (root.headerWidth + itemHeader.Layout.leftMargin)
-            Layout.preferredHeight: 56
+            Layout.leftMargin: d.leftMargin
+            Layout.maximumWidth: root.headerWidth
+            Layout.maximumHeight: 44
+
+            spacing: 9
 
             RowLayout {
                 Layout.alignment: Qt.AlignVCenter
-                Layout.fillWidth: true
 
                 StatusBaseText {
                     id: itemHeader
-
-                    Layout.leftMargin: 64
 
                     color: Theme.palette.directColor1
                     font.pixelSize: 26
@@ -87,22 +95,40 @@ Item {
                 }
             }
 
+            // Filler
+            Item {
+                Layout.fillWidth: true
+            }
+
             StatusButton {
-                objectName: "addNewItemActionButton"
-                visible: root.headerButtonVisible
-                text: root.headerButtonText
-                Layout.preferredHeight: 44
-                Layout.alignment: Qt.AlignHCenter
-                onClicked: root.headerButtonClicked()
+                id: secondaryHeaderBtn
+
+                Layout.fillHeight: true
+
+                objectName: "secondaryHeaderButton"
+                visible: false
+
+                onClicked: root.secondaryHeaderButtonClicked()
+            }
+
+            StatusButton {
+                id: primaryHeaderBtn
+
+                Layout.fillHeight: true
+
+                objectName: "primaryHeaderButton"
+                visible: false
+
+                onClicked: root.primaryHeaderButtonClicked()
             }
         }
 
         Loader {
             id: contentLoader
+
             Layout.fillWidth: true
             Layout.fillHeight: true
-            Layout.topMargin: 16
-            Layout.leftMargin: 64
+            Layout.leftMargin: d.leftMargin
             Layout.rightMargin: 24
 
             sourceComponent: root.content

--- a/ui/app/AppLayouts/Chat/panels/communities/CommunityAirdropsSettingsPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/CommunityAirdropsSettingsPanel.qml
@@ -58,20 +58,18 @@ SettingsPageLayout {
             name: d.welcomeViewState
             PropertyChanges {target: root; title: d.welcomePageTitle}
             PropertyChanges {target: root; previousPageName: ""}
-            PropertyChanges {target: root; headerButtonVisible: true}
-            PropertyChanges {target: root; headerButtonText: qsTr("New Airdrop")}
-            PropertyChanges {target: root; headerWidth: root.viewWidth}
+            PropertyChanges {target: root; primaryHeaderButton.visible: true}
+            PropertyChanges {target: root; primaryHeaderButton.text: qsTr("New Airdrop")}
         },
         State {
             name: d.newAirdropViewState
             PropertyChanges {target: root; title: d.newAirdropViewPageTitle}
             PropertyChanges {target: root; previousPageName: d.welcomePageTitle}
-            PropertyChanges {target: root; headerButtonVisible: false}
-            PropertyChanges {target: root; headerWidth: 0}
+            PropertyChanges {target: root; primaryHeaderButton.visible: false}
         }
     ]
 
-    onHeaderButtonClicked: stackManager.push(d.newAirdropViewState, newAirdropView, null, StackView.Immediate)
+    onPrimaryHeaderButtonClicked: stackManager.push(d.newAirdropViewState, newAirdropView, null, StackView.Immediate)
 
     StackViewStates {
         id: stackManager

--- a/ui/app/AppLayouts/Chat/panels/communities/CommunityMintTokensSettingsPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/CommunityMintTokensSettingsPanel.qml
@@ -387,19 +387,19 @@ SettingsPageLayout {
 
                 anchors.centerIn: Overlay.overlay
                 title: qsTr("Sign transaction - Mint %1 token").arg(popup.tokenName)
-                tokenName: parent.name
-                accountName: parent.accountName
-                networkName: parent.chainName
+                tokenName: preview.name
+                accountName: preview.accountName
+                networkName: preview.chainName
                 feeText: root.feeText
                 errorText: root.errorText
                 isFeeLoading: root.isFeeLoading
 
                 onOpened: {
                     root.setFeeLoading()
-                    root.signMintTransactionOpened(parent.chainId, d.accountAddress)
+                    root.signMintTransactionOpened(preview.chainId, d.accountAddress)
                 }
                 onCancelClicked: close()
-                onSignTransactionClicked: parent.signMintTransaction()
+                onSignTransactionClicked: preview.signMintTransaction()
             }
         }
     }

--- a/ui/app/AppLayouts/Chat/panels/communities/CommunityMintTokensSettingsPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/CommunityMintTokensSettingsPanel.qml
@@ -68,17 +68,17 @@ SettingsPageLayout {
     signal signMintTransactionOpened(int chainId, string accountAddress)
 
     signal signSelfDestructTransactionOpened(var selfDestructTokensList, // [key , amount]
-                                             string contractUniqueKey)
+                                             string tokenKey)
 
     signal remoteSelfDestructCollectibles(var selfDestructTokensList, // [key , amount]
-                                          string contractUniqueKey)
+                                          string tokenKey)
 
     signal signBurnTransactionOpened(int chainId)
 
     signal burnCollectibles(string tokenKey,
                             int amount)
 
-    signal airdropCollectible(string key)
+    signal airdropCollectible(string tokenKey)
 
     function setFeeLoading() {
         root.isFeeLoading = true
@@ -114,7 +114,7 @@ SettingsPageLayout {
         property var selfDestructTokensList
         property bool selfDestruct
         property bool burnEnabled
-        //property string tokenKey -- TODO: Backend key role
+        property string tokenKey
         property int burnAmount
         property int remainingTokens
         property url artworkSource
@@ -234,7 +234,7 @@ SettingsPageLayout {
                 Layout.preferredWidth: root.viewWidth
                 Layout.fillHeight: true
 
-                currentIndex: optionsTab.currentItem == collectiblesTab ? 0 : 1
+                currentIndex: optionsTab.currentItem === collectiblesTab ? 0 : 1
 
                 CommunityNewTokenView {
                     viewWidth: root.viewWidth
@@ -438,9 +438,9 @@ SettingsPageLayout {
                 function signTransaction() {
                     root.setFeeLoading()
                     if(signTransactionPopup.isRemotelyDestructTransaction) {
-                        root.remoteSelfDestructCollectibles(d.selfDestructTokensList, d.contractUniqueKey)
+                        root.remoteSelfDestructCollectibles(d.selfDestructTokensList, d.tokenKey)
                     } else {
-                        root.burnCollectibles("TODO - KEY"/*d.tokenKey*/, d.burnAmount)
+                        root.burnCollectibles(d.tokenKey, d.burnAmount)
                     }
 
                     footerPanel.closePopups()
@@ -457,7 +457,7 @@ SettingsPageLayout {
 
                 onOpened: {
                     root.setFeeLoading()
-                    signTransactionPopup.isRemotelyDestructTransaction ? root.signSelfDestructTransactionOpened(d.selfDestructTokensList, d.contractUniqueKey) :
+                    signTransactionPopup.isRemotelyDestructTransaction ? root.signSelfDestructTransactionOpened(d.selfDestructTokensList, d.tokenKey) :
                                                                          root.signBurnTransactionOpened(d.chainId)
                 }
                 onCancelClicked: close()
@@ -490,15 +490,14 @@ SettingsPageLayout {
             onItemClicked: {
                 d.accountAddress = accountAddress
                 d.chainId = chainId
-                d.contractUniqueKey = contractUniqueKey
                 d.chainName = chainName
                 d.accountName = accountName
-                //d.tokenKey = key // TODO: Backend key role
+                d.tokenKey = contractUniqueKey
                 stackManager.push(d.tokenViewState,
                                   tokenView,
                                   {
                                       preview: false,
-                                      index
+                                      contractUniqueKey
                                   },
                                   StackView.Immediate)
             }
@@ -511,7 +510,7 @@ SettingsPageLayout {
         CommunityTokenView {
             id: view
 
-            property int index // TODO: Update it to key when model has role key implemented
+            property string contractUniqueKey
 
             viewWidth: root.viewWidth
 
@@ -562,12 +561,11 @@ SettingsPageLayout {
             Instantiator {
                 id: instantiator
 
-
                 model: SortFilterProxyModel {
                     sourceModel: root.tokensModel
-                    filters: IndexFilter {
-                        minimumIndex: view.index
-                        maximumIndex: view.index
+                    filters: ValueFilter {
+                        roleName: "contractUniqueKey"
+                        value: view.contractUniqueKey
                     }
                 }
                 delegate: QtObject {

--- a/ui/app/AppLayouts/Chat/panels/communities/CommunityMintTokensSettingsPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/CommunityMintTokensSettingsPanel.qml
@@ -96,7 +96,7 @@ SettingsPageLayout {
         readonly property string initialViewState: "WELCOME_OR_LIST_TOKENS"
         readonly property string newTokenViewState: "NEW_TOKEN"
         readonly property string previewTokenViewState: "PREVIEW_TOKEN"
-        readonly property string collectibleViewState: "VIEW_COLLECTIBLE"
+        readonly property string tokenViewState: "VIEW_TOKEN"
 
         readonly property string welcomePageTitle: qsTr("Tokens")
         readonly property string newCollectiblePageTitle: qsTr("Mint collectible")
@@ -166,7 +166,7 @@ SettingsPageLayout {
             PropertyChanges {target: root; headerWidth: 0}
         },
         State {
-            name: d.collectibleViewState
+            name: d.tokenViewState
             PropertyChanges {target: root; previousPageName: d.backButtonText}
             PropertyChanges {target: root; headerButtonVisible: false}
             PropertyChanges {target: root; headerWidth: 0}
@@ -226,7 +226,7 @@ SettingsPageLayout {
                 Binding {
                     target: root
                     property: "title"
-                    value: optionsTab.currentItem == collectiblesTab ? d.newCollectiblePageTitle : d.newAssetPageTitle
+                    value: optionsTab.currentItem === collectiblesTab ? d.newCollectiblePageTitle : d.newAssetPageTitle
                 }
             }
 
@@ -494,8 +494,8 @@ SettingsPageLayout {
                 d.chainName = chainName
                 d.accountName = accountName
                 //d.tokenKey = key // TODO: Backend key role
-                stackManager.push(d.collectibleViewState,
-                                  collectibleView,
+                stackManager.push(d.tokenViewState,
+                                  tokenView,
                                   {
                                       preview: false,
                                       index
@@ -506,7 +506,7 @@ SettingsPageLayout {
     }
 
     Component {
-        id: collectibleView
+        id: tokenView
 
         CommunityTokenView {
             id: view
@@ -573,6 +573,7 @@ SettingsPageLayout {
                 delegate: QtObject {
                     component Bind: Binding { target: view }
                     readonly property list<Binding> bindings: [
+                        Bind { property: "isAssetView"; value: model.tokenType === Constants.TokenType.ERC20 },
                         Bind { property: "deployState"; value: model.deployState },
                         Bind { property: "remotelyDestructState"; value: model.remotelyDestructState },
                         Bind { property: "burnState"; value: model.burnState },
@@ -588,7 +589,8 @@ SettingsPageLayout {
                         Bind { property: "chainName"; value: model.chainName },
                         Bind { property: "chainIcon"; value: model.chainIcon },
                         Bind { property: "accountName"; value: model.accountName },
-                        Bind { property: "tokenOwnersModel"; value: model.tokenOwnersModel }
+                        Bind { property: "tokenOwnersModel"; value: model.tokenOwnersModel },
+                        Bind { property: "assetDecimals"; value: model.decimals }
                     ]
                 }
             }

--- a/ui/app/AppLayouts/Chat/panels/communities/CommunityPermissionsSettingsPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/CommunityPermissionsSettingsPanel.qml
@@ -97,38 +97,34 @@ SettingsPageLayout {
             PropertyChanges {target: root; title: qsTr("Permissions")}
             PropertyChanges {target: root; previousPageName: ""}
             PropertyChanges {target: root; content: welcomeView}
-            PropertyChanges {target: root; headerButtonVisible: true}
-            PropertyChanges {target: root; headerButtonText: qsTr("Add new permission")}
-            PropertyChanges {target: root; headerWidth: root.viewWidth}
+            PropertyChanges {target: root; primaryHeaderButton.visible: true}
+            PropertyChanges {target: root; primaryHeaderButton.text: qsTr("Add new permission")}
         },
         State {
             name: d.newPermissionViewState
             PropertyChanges {target: root; title: qsTr("New permission")}
             PropertyChanges {target: root; previousPageName: qsTr("Permissions")}
             PropertyChanges {target: root; content: newPermissionView}
-            PropertyChanges {target: root; headerButtonVisible: false}
-            PropertyChanges {target: root; headerWidth: 0}
+            PropertyChanges {target: root; primaryHeaderButton.visible: false}
         },
         State {
             name: d.permissionsViewState
             PropertyChanges {target: root; title: qsTr("Permissions")}
             PropertyChanges {target: root; previousPageName: ""}
             PropertyChanges {target: root; content: permissionsView}
-            PropertyChanges {target: root; headerButtonVisible: true}
-            PropertyChanges {target: root; headerButtonText: qsTr("Add new permission")}
-            PropertyChanges {target: root; headerWidth: root.viewWidth}
+            PropertyChanges {target: root; primaryHeaderButton.visible: true}
+            PropertyChanges {target: root; primaryHeaderButton.text: qsTr("Add new permission")}
         },
         State {
             name: d.editPermissionViewState
             PropertyChanges {target: root; title: qsTr("Edit permission")}
             PropertyChanges {target: root; previousPageName: qsTr("Permissions")}
             PropertyChanges {target: root; content: newPermissionView}
-            PropertyChanges {target: root; headerButtonVisible: false}
-            PropertyChanges {target: root; headerWidth: 0}
+            PropertyChanges {target: root; primaryHeaderButton.visible: false}
         }
     ]
 
-    onHeaderButtonClicked: {
+    onPrimaryHeaderButtonClicked: {
         if(root.state === d.welcomeViewState || root.state === d.permissionsViewState) {
             d.initializeData()
             root.state = d.newPermissionViewState

--- a/ui/app/AppLayouts/Chat/popups/community/AlertPopup.qml
+++ b/ui/app/AppLayouts/Chat/popups/community/AlertPopup.qml
@@ -15,17 +15,18 @@ import utils 1.0
 StatusDialog {
     id: root
 
-    property int tokenCount: 0
+    property alias acceptBtnText: acceptBtn.text
+    property alias alertText: contentTextItem.text
 
-    signal remotelyDestructClicked
+    signal acceptClicked
     signal cancelClicked
 
-    title: qsTr("Remotely destruct %n token(s)", "", root.tokenCount)
     implicitWidth: 400 // by design
     topPadding: Style.current.padding
     bottomPadding: topPadding
     contentItem: StatusBaseText {
-        text: qsTr("Continuing will destroy tokens held by members and revoke any perissions they given. To undo you will have to issue them new tokens.")
+        id: contentTextItem
+
         font.pixelSize: Style.current.primaryTextFontSize
         wrapMode: Text.WordWrap
         lineHeight: 1.2
@@ -46,11 +47,12 @@ StatusDialog {
             }
 
             StatusButton {
-                text: qsTr("Remotely destruct")
+                id: acceptBtn
+
                 type: StatusBaseButton.Type.Danger
 
                 onClicked: {
-                    root.remotelyDestructClicked()
+                    root.acceptClicked()
                     close()
                 }
             }

--- a/ui/app/AppLayouts/Chat/popups/community/qmldir
+++ b/ui/app/AppLayouts/Chat/popups/community/qmldir
@@ -1,6 +1,6 @@
+AlertPopup 1.0 AlertPopup.qml
 BurnTokensPopup 1.0 BurnTokensPopup.qml
 CreateChannelPopup 1.0 CreateChannelPopup.qml
 CommunityTokenPermissionsPopup 1.0 CommunityTokenPermissionsPopup.qml
 RemotelyDestructPopup 1.0 RemotelyDestructPopup.qml
-RemotelyDestructAlertPopup 1.0 RemotelyDestructAlertPopup.qml
 SignTokenTransactionsPopup 1.0 SignTokenTransactionsPopup.qml

--- a/ui/app/AppLayouts/Chat/views/CommunitySettingsView.qml
+++ b/ui/app/AppLayouts/Chat/views/CommunitySettingsView.qml
@@ -343,6 +343,8 @@ StatusSectionLayout {
                 onSignBurnTransactionOpened: communityTokensStore.computeBurnFee(chainId)
                 onBurnCollectibles: communityTokensStore.burnCollectibles(tokenKey, amount)
                 onAirdropCollectible: root.goTo(Constants.CommunitySettingsSections.Airdrops)
+                onDeleteToken: communityTokensStore.deleteToken(root.community.id, tokenKey)
+                onRetryMintToken: communityTokensStore.retryMintToken(root.community.id, tokenKey)
 
                 Connections {
                     target: rootStore.communityTokensStore
@@ -478,7 +480,7 @@ StatusSectionLayout {
 
                     function onAirdropCollectible(key) {
                         // Here it is forced a navigation to the new airdrop form, like if it was clicked the header button
-                        airdropPanel.headerButtonClicked()
+                        airdropPanel.primaryHeaderButtonClicked()
 
                         // Force a token selection to be airdroped with default amount 1
                         airdropPanel.selectCollectible(key, 1)

--- a/ui/app/AppLayouts/Chat/views/CommunitySettingsView.qml
+++ b/ui/app/AppLayouts/Chat/views/CommunitySettingsView.qml
@@ -334,11 +334,11 @@ StatusSectionLayout {
                                                      accountName,
                                                      artworkCropRect)
                 }
-                onSignSelfDestructTransactionOpened: communityTokensStore.computeSelfDestructFee(selfDestructTokensList, contractUniqueKey)
+                onSignSelfDestructTransactionOpened: communityTokensStore.computeSelfDestructFee(selfDestructTokensList, tokenKey)
                 onRemoteSelfDestructCollectibles: {
                     communityTokensStore.remoteSelfDestructCollectibles(root.community.id,
                                                                         selfDestructTokensList,
-                                                                        contractUniqueKey)
+                                                                        tokenKey)
                 }
                 onSignBurnTransactionOpened: communityTokensStore.computeBurnFee(chainId)
                 onBurnCollectibles: communityTokensStore.burnCollectibles(tokenKey, amount)

--- a/ui/app/AppLayouts/Chat/views/communities/CommunityMintedTokensView.qml
+++ b/ui/app/AppLayouts/Chat/views/communities/CommunityMintedTokensView.qml
@@ -17,9 +17,8 @@ StatusScrollView {
     property int viewWidth: 560 // by design
     property var model
 
-    signal itemClicked(int index,
+    signal itemClicked(string contractUniqueKey,
                        int chainId,
-                       string contractUniqueKey,
                        string chainName,
                        string accountName,
                        string accountAddress)
@@ -97,7 +96,7 @@ StatusScrollView {
                         color: Theme.palette.baseColor1
                     }
                 ]
-                onClicked: root.itemClicked(model.index, model.chainId, model.chainName, model.accountName, model.address) // TODO: Replace to model.key when role exists in backend
+                onClicked: root.itemClicked(model.contractUniqueKey, model.chainId, model.chainName, model.accountName, model.address)
             }
         }
 
@@ -147,7 +146,7 @@ StatusScrollView {
                 isLoading: false
                 navigationIconVisible: true
 
-                onClicked: root.itemClicked(model.index, model.chainId, model.contractUniqueKey, model.chainName, model.accountName, model.address)
+                onClicked: root.itemClicked(model.contractUniqueKey, model.chainId, model.chainName, model.accountName, model.address)
             }
         }
 

--- a/ui/app/AppLayouts/Chat/views/communities/CommunityMintedTokensView.qml
+++ b/ui/app/AppLayouts/Chat/views/communities/CommunityMintedTokensView.qml
@@ -5,7 +5,9 @@ import StatusQ.Core 0.1
 import StatusQ.Components 0.1
 import StatusQ.Core.Theme 0.1
 
+import SortFilterProxyModel 0.2
 import utils 1.0
+import shared.controls 1.0
 
 import AppLayouts.Wallet.views.collectibles 1.0
 
@@ -25,7 +27,9 @@ StatusScrollView {
     QtObject {
         id: d
 
-        function getSubtitle(deployState, remainingTokens, supply) {
+        readonly property int delegateAssetsHeight: 64
+
+        function getSubtitle(deployState, remainingTokens, supply, isCollectible) {
             if(deployState === Constants.ContractTransactionStatus.Failed) {
                 return qsTr("Minting failed")
             }
@@ -39,7 +43,7 @@ StatusScrollView {
                 remainingTokens = 0
             if(supply === 0)
                 supply = "∞"
-            return  qsTr("%1 / %2 remaining").arg(remainingTokens).arg(supply)
+            return isCollectible ? qsTr("%1 / %2 remaining").arg(remainingTokens).arg(supply) :  ""
         }
     }
 
@@ -49,35 +53,111 @@ StatusScrollView {
         id: mainLayout
 
         width: root.viewWidth
-        spacing: Style.current.padding
+        spacing: Style.current.halfPadding
 
         StatusBaseText {
+            Layout.leftMargin: Style.current.padding
+
+            text: qsTr("Assets")
+            font.pixelSize: Theme.primaryTextFontSize
+            color: Theme.palette.baseColor1
+        }
+
+        StatusListView {
+            id: assetsList
+
+            Layout.fillWidth: true
+            Layout.preferredHeight: childrenRect.height
+
+            visible: count > 0
+            model: SortFilterProxyModel {
+                sourceModel: root.model
+                filters: ValueFilter {
+                    roleName: "tokenType"
+                    value: Constants.TokenType.ERC20
+                }
+            }
+            delegate: StatusListItem {
+                height: 64
+                width: mainLayout.width
+                title: model.name
+                subTitle: model.symbol
+                asset.name: model.image ? model.image : ""
+                asset.isImage: true
+                components: [
+                    StatusBaseText {
+                        anchors.verticalCenter: parent.verticalCenter
+                        text: d.getSubtitle(model.deployState, model.remainingTokens, model.supply, false)
+                        color: (model.deployState === Constants.ContractTransactionStatus.Failed) ? Theme.palette.dangerColor1 : Theme.palette.baseColor1
+                        font.pixelSize: 13
+                    },
+                    StatusIcon {
+                        anchors.verticalCenter: parent.verticalCenter
+                        icon: "next"
+                        color: Theme.palette.baseColor1
+                    }
+                ]
+                onClicked: root.itemClicked(model.index, model.chainId, model.chainName, model.accountName, model.address) // TODO: Replace to model.key when role exists in backend
+            }
+        }
+
+        // Empty placeholder when no assets; dashed rounded rectangle
+        ShapeRectangle {
+            Layout.alignment: Qt.AlignHCenter
+            Layout.preferredWidth: parent.width - 4 // The rectangular path is rendered outside
+            Layout.preferredHeight: 44
+            visible: assetsList.count === 0
+            text: qsTr("You currently have no minted assets")
+        }
+
+        StatusBaseText {
+            Layout.leftMargin: Style.current.padding
+            Layout.topMargin: Style.current.halfPadding
+
             text: qsTr("Collectibles")
             font.pixelSize: Theme.primaryTextFontSize
             color: Theme.palette.baseColor1
         }
 
         StatusGridView {
-            id: gridView
+            id: collectiblesGrid
 
             Layout.fillWidth: true
-            Layout.preferredHeight: 500 // TODO
-            model: root.model
+            Layout.preferredHeight: childrenRect.height
+
+            visible: count > 0
+            model: SortFilterProxyModel {
+                sourceModel: root.model
+                filters: ValueFilter {
+                    roleName: "tokenType"
+                    value: Constants.TokenType.ERC721
+                }
+            }
             cellHeight: 229
             cellWidth: 176
+            leftMargin: 16
             delegate: CollectibleView {
-                height: gridView.cellHeight
-                width: gridView.cellWidth
+                height: collectiblesGrid.cellHeight
+                width: collectiblesGrid.cellWidth
                 title: model.name ? model.name : "..."
-                subTitle: d.getSubtitle(model.deployState, model.remainingTokens, model.supply)
+                subTitle: d.getSubtitle(model.deployState, model.remainingTokens, model.supply, true)
                 subTitleColor: (model.deployState === Constants.ContractTransactionStatus.Failed) ? Theme.palette.dangerColor1 : Theme.palette.baseColor1
                 fallbackImageUrl: model.image ? model.image : ""
-                backgroundColor: model.backgroundColor ? model.backgroundColor : "transparent" // TODO BACKEND
+                backgroundColor: "transparent"
                 isLoading: false
                 navigationIconVisible: true
 
                 onClicked: root.itemClicked(model.index, model.chainId, model.contractUniqueKey, model.chainName, model.accountName, model.address)
             }
+        }
+
+        // Empty placeholder when no collectibles; dashed rounded rectangle
+        ShapeRectangle {
+            Layout.alignment: Qt.AlignHCenter
+            Layout.preferredWidth: parent.width - 4 // The rectangular path is rendered outside
+            Layout.preferredHeight: 44
+            visible: collectiblesGrid.count == 0
+            text: qsTr("You currently have no minted collectibles")
         }
     }
 }

--- a/ui/app/AppLayouts/Chat/views/communities/CommunityWelcomeSettingsView.qml
+++ b/ui/app/AppLayouts/Chat/views/communities/CommunityWelcomeSettingsView.qml
@@ -16,7 +16,8 @@ StatusScrollView {
 
     property int imageWidth: 256
     property int imageHeigth: root.imageWidth
-
+    
+    padding: 0
 
     ColumnLayout {
         id: mainLayout

--- a/ui/imports/shared/stores/CommunityTokensStore.qml
+++ b/ui/imports/shared/stores/CommunityTokensStore.qml
@@ -62,12 +62,12 @@ QtObject {
         communityTokensModuleInst.computeDeployFee(chainId, accountAddress)
     }
 
-    function computeSelfDestructFee(selfDestructTokensList, contractUniqueKey) {
-        communityTokensModuleInst.computeSelfDestructFee(JSON.stringify(selfDestructTokensList), contractUniqueKey)
+    function computeSelfDestructFee(selfDestructTokensList, tokenKey) {
+        communityTokensModuleInst.computeSelfDestructFee(JSON.stringify(selfDestructTokensList), tokenKey)
     }
 
-    function remoteSelfDestructCollectibles(communityId, selfDestructTokensList, contractUniqueKey) {
-        communityTokensModuleInst.selfDestructCollectibles(communityId, JSON.stringify(selfDestructTokensList), contractUniqueKey)
+    function remoteSelfDestructCollectibles(communityId, selfDestructTokensList, tokenKey) {
+        communityTokensModuleInst.selfDestructCollectibles(communityId, JSON.stringify(selfDestructTokensList), tokenKey)
     }
 
     // Burn:
@@ -77,7 +77,7 @@ QtObject {
         console.warn("TODO: Compute burn fee backend")
     }
 
-    function burnCollectibles(tokenKey,burnAmount) {
+    function burnCollectibles(tokenKey, burnAmount) {
         // TODO BACKEND
         console.warn("TODO: Burn collectible backend")
     }

--- a/ui/imports/shared/stores/CommunityTokensStore.qml
+++ b/ui/imports/shared/stores/CommunityTokensStore.qml
@@ -42,6 +42,14 @@ QtObject {
         console.log("TODO: Deploy Asset backend!")
     }
 
+    function deleteToken(communityId, contractUniqueKey) {
+        console.log("TODO: Delete token bakend!")
+    }
+
+    function retryMintToken(communityId, contractUniqueKey) {
+        console.log("TODO: Retry mint token bakend!")
+    }
+
     readonly property Connections connections: Connections {
       target: communityTokensModuleInst
       function onDeployFeeUpdated(ethCurrency, fiatCurrency, errorCode) {

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -910,6 +910,13 @@ QtObject {
         Dismissed = 4
     }
 
+
+    enum TokenType {
+        Unknown = 0,
+        ERC20 = 1,
+        ERC721 = 2
+    }
+
     readonly property QtObject walletSection: QtObject {
         readonly property string cancelledMessage: "cancelled"
     }


### PR DESCRIPTION
Closes #10625 and #10765

### What does the PR do

- It adds assets list UI in minted tokens view.
- It adds flow to open token view depending on type (asset or collectible).
- It updates minting flow to use `contractUniqueKey` instead of `index`.
- It refactors `SettingsPageLayout`.
- It adds `retry mint` and `delete` options when deploy process fails.
- It renames `RemotelyDestructAlertPopup` to generic name `AlertPopup`.
- It updates `storybook` accordingly.

**NOTE:** Only UI. Assets backend management is not ready, neither delete or retry minting.

### Affected areas

Community Settings / Mint Tokens

### Screenshot of functionality

https://github.com/status-im/status-desktop/assets/97019400/a6409554-6517-46d1-8062-eb1a948a6595

https://github.com/status-im/status-desktop/assets/97019400/696a671a-3a69-4012-a06d-4f75e550dc49