### PR TITLE
fix(contacts): fix inconsistency when banning or unbanning contact

### DIFF
--- a/src/app_service/service/contacts/service.nim
+++ b/src/app_service/service/contacts/service.nim
@@ -516,12 +516,12 @@ QtObject:
     var contact = self.getContactById(publicKey)
 
     let response = status_contacts.unblockContact(contact.id)
+    # TODO there are chat updates too. We need to send them to the chat service
     if not response.error.isNil:
       error "error unblocking contact ", msg = response.error.message
       return
 
-    contact.blocked = false
-    self.saveContact(contact)
+    self.parseContactsResponse(response)
     self.events.emit(SIGNAL_CONTACT_UNBLOCKED, ContactArgs(contactId: contact.id))
 
   proc blockContact*(self: Service, publicKey: string) =
@@ -532,8 +532,7 @@ QtObject:
       error "error blocking contact ", msg = response.error.message
       return
 
-    contact.blocked = true
-    self.saveContact(contact)
+    self.parseContactsResponse(response)
     self.events.emit(SIGNAL_CONTACT_BLOCKED, ContactArgs(contactId: contact.id))
 
   proc removeContact*(self: Service, publicKey: string) =

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -699,7 +699,7 @@ QtObject {
 
         readonly property bool isUserAllowedToSendMessage: {
             if (_d.activeChatType === Constants.chatType.oneToOne && _d.oneToOneChatContact) {
-                return _d.oneToOneChatContact.contactRequestState == Constants.ContactRequestState.Mutual
+                return _d.oneToOneChatContact.contactRequestState === Constants.ContactRequestState.Mutual
             }
             else if(_d.activeChatType === Constants.chatType.privateGroupChat) {
                 return _d.amIMember

--- a/ui/app/AppLayouts/Chat/views/ChatContentView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatContentView.qml
@@ -77,6 +77,8 @@ ColumnLayout {
     QtObject {
         id: d
 
+        readonly property string blockedText: qsTr("This user has been blocked.")
+
         function showReplyArea(messageId) {
             let obj = messageStore.getMessageByIdAsJson(messageId)
             if (!obj) {
@@ -109,6 +111,7 @@ ColumnLayout {
                 stickersLoaded: root.stickersLoaded
                 chatId: root.chatId
                 isOneToOne: root.chatType === Constants.chatType.oneToOne
+                isContactBlocked: root.isBlocked
                 isChatBlocked: root.isBlocked || !root.isUserAllowedToSendMessage
                 channelEmoji: !chatContentModule ? "" : (chatContentModule.chatDetails.emoji || "")
                 isActiveChannel: root.isActiveChannel
@@ -158,14 +161,17 @@ ColumnLayout {
                     anchors.fill: parent
                     anchors.margins: Style.current.smallPadding
 
-                    enabled: root.rootStore.sectionDetails.joined && !root.rootStore.sectionDetails.amIBanned &&
-                             root.isUserAllowedToSendMessage
+                    // We enable the component if the contact is blocked, because if we disable it, the `Unban` button
+                    // becomes disabled. All the local components inside already disable themselves when blocked
+                    enabled: root.isBlocked ||
+                            (root.rootStore.sectionDetails.joined && !root.rootStore.sectionDetails.amIBanned &&
+                             root.isUserAllowedToSendMessage)
 
                     store: root.rootStore
                     usersStore: root.usersStore
 
                     textInput.text: inputAreaLoader.preservedText
-                    textInput.placeholderText: root.chatInputPlaceholder
+                    textInput.placeholderText: root.isBlocked ? d.blockedText : root.chatInputPlaceholder
                     emojiPopup: root.emojiPopup
                     stickersPopup: root.stickersPopup
                     isContactBlocked: root.isBlocked
@@ -176,7 +182,7 @@ ColumnLayout {
 
                     Binding on chatInputPlaceholder {
                         when: root.isBlocked
-                        value: qsTr("This user has been blocked.")
+                        value: d.blockedText
                     }
 
                     Binding on chatInputPlaceholder {

--- a/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
@@ -36,6 +36,7 @@ Item {
     property string chatId: ""
     property bool stickersLoaded: false
     property alias chatLogView: chatLogView
+    property bool isContactBlocked: false
     property bool isChatBlocked: false
     property bool isOneToOne: false
     property bool isActiveChannel: false
@@ -329,7 +330,7 @@ Item {
             }
         }
         header: {
-            if (root.isOneToOne && root.rootStore.oneToOneChatContact) {
+            if (!root.isContactBlocked && root.isOneToOne && root.rootStore.oneToOneChatContact) {
                 switch (root.rootStore.oneToOneChatContact.contactRequestState) {
                 case Constants.ContactRequestState.None: // no break
                 case Constants.ContactRequestState.Dismissed:


### PR DESCRIPTION
Fixes #10501

status-go PR https://github.com/status-im/status-go/pull/3558

The problem was that didn't have access to the updated contact from status-go after banning or unbanning, so we just changed the banned property, but there is more that gets changed in the backend, like `removed` being set to `true` as well. With this fix, when you unban someone, you go back to a fresh start, as **non** contact, so you need to send a request again. That was the state you got if you restarted the app, so "re-sync" the state with status-go.

Another issue was on the frontend (QML). When banned,  and after restarting to get the right state, the unban button would be disabled and the Add contact request button would show, which is not good. We only want to send requests when unbanned.

[ban.webm](https://github.com/status-im/status-desktop/assets/11926403/fac599f0-66b7-40d1-999f-03b7a36177ba)
