### PR TITLE
feat(@desktop/communities): Compute minting fees and displaying minti…

### DIFF
--- a/src/app/modules/main/communities/tokens/controller.nim
+++ b/src/app/modules/main/communities/tokens/controller.nim
@@ -48,6 +48,9 @@ proc init*(self: Controller) =
   self.events.on(SIGNAL_COMPUTE_SELF_DESTRUCT_FEE) do(e:Args):
     let args = ComputeFeeArgs(e)
     self.communityTokensModule.onSelfDestructFeeComputed(args.ethCurrency, args.fiatCurrency, args.errorCode)
+  self.events.on(SIGNAL_COMPUTE_AIRDROP_FEE) do(e:Args):
+    let args = AirdropFeesArgs(e)
+    self.communityTokensModule.onAirdropFeesComputed(args)
   self.events.on(SIGNAL_COMMUNITY_TOKEN_DEPLOYED) do(e: Args):
     let args = CommunityTokenDeployedArgs(e)
     self.communityTokensModule.onCommunityTokenDeployStateChanged(args.communityToken.communityId, args.communityToken.chainId, args.transactionHash, args.communityToken.deployState)
@@ -57,12 +60,18 @@ proc init*(self: Controller) =
   self.events.on(SIGNAL_REMOTE_DESTRUCT_STATUS) do(e: Args):
     let args = RemoteDestructArgs(e)
     self.communityTokensModule.onRemoteDestructStateChanged(args.communityToken.communityId, args.communityToken.name, args.communityToken.chainId, args.transactionHash, args.status)
+  self.events.on(SIGNAL_AIRDROP_STATUS) do(e: Args):
+    let args = AirdropArgs(e)
+    self.communityTokensModule.onAirdropStateChanged(args.communityToken.communityId, args.communityToken.name, args.communityToken.chainId, args.transactionHash, args.status)
 
 proc deployCollectibles*(self: Controller, communityId: string, addressFrom: string, password: string, deploymentParams: DeploymentParameters, tokenMetadata: CommunityTokensMetadataDto, chainId: int) =
   self.communityTokensService.deployCollectibles(communityId, addressFrom, password, deploymentParams, tokenMetadata, chainId)
 
 proc airdropCollectibles*(self: Controller, communityId: string, password: string, collectiblesAndAmounts: seq[CommunityTokenAndAmount], walletAddresses: seq[string]) =
   self.communityTokensService.airdropCollectibles(communityId, password, collectiblesAndAmounts, walletAddresses)
+
+proc computeAirdropCollectiblesFee*(self: Controller, collectiblesAndAmounts: seq[CommunityTokenAndAmount], walletAddresses: seq[string]) =
+  self.communityTokensService.computeAirdropCollectiblesFee(collectiblesAndAmounts, walletAddresses)
 
 proc selfDestructCollectibles*(self: Controller, communityId: string, password: string, walletAndAmounts: seq[WalletAndAmount], contractUniqueKey: string) =
   self.communityTokensService.selfDestructCollectibles(communityId, password, walletAndAmounts, contractUniqueKey)
@@ -80,8 +89,8 @@ proc computeDeployFee*(self: Controller, chainId: int, accountAddress: string) =
 proc computeSelfDestructFee*(self: Controller, walletAndAmountList: seq[WalletAndAmount], contractUniqueKey: string) =
   self.communityTokensService.computeSelfDestructFee(walletAndAmountList, contractUniqueKey)
 
-proc getCommunityTokenBySymbol*(self: Controller, communityId: string, symbol: string): CommunityTokenDto =
-  return self.communityTokensService.getCommunityTokenBySymbol(communityId, symbol)
+proc findContractByUniqueId*(self: Controller, contractUniqueKey: string): CommunityTokenDto =
+  return self.communityTokensService.findContractByUniqueId(contractUniqueKey)
 
 proc getNetwork*(self:Controller, chainId: int): NetworkDto =
   self.networksService.getNetwork(chainId)

--- a/src/app/modules/main/communities/tokens/io_interface.nim
+++ b/src/app/modules/main/communities/tokens/io_interface.nim
@@ -13,6 +13,9 @@ method load*(self: AccessInterface) {.base.} =
 method airdropCollectibles*(self: AccessInterface, communityId: string, collectiblesJsonString: string, walletsJsonString: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method computeAirdropCollectiblesFee*(self: AccessInterface, communityId: string, collectiblesJsonString: string, walletsJsonString: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method selfDestructCollectibles*(self: AccessInterface, communityId: string, collectiblesToBurnJsonString: string, contractUniqueKey: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
@@ -38,8 +41,14 @@ method onDeployFeeComputed*(self: AccessInterface, ethCurrency: CurrencyAmount, 
 method onSelfDestructFeeComputed*(self: AccessInterface, ethCurrency: CurrencyAmount, fiatCurrency: CurrencyAmount, errorCode: ComputeFeeErrorCode) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method onAirdropFeesComputed*(self: AccessInterface, args: AirdropFeesArgs) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method onCommunityTokenDeployStateChanged*(self: AccessInterface, communityId: string, chainId: int, transactionHash: string, deployState: DeployState) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method onRemoteDestructStateChanged*(self: AccessInterface, communityId: string, tokenName: string, chainId: int, transactionHash: string, status: ContractTransactionStatus) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method onAirdropStateChanged*(self: AccessInterface, communityId: string, tokenName: string, chainId: int, transactionHash: string, status: ContractTransactionStatus) {.base.} =
   raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/communities/tokens/view.nim
+++ b/src/app/modules/main/communities/tokens/view.nim
@@ -25,11 +25,15 @@ QtObject:
   proc airdropCollectibles*(self: View, communityId: string, collectiblesJsonString: string, walletsJsonString: string) {.slot.} =
     self.communityTokensModule.airdropCollectibles(communityId, collectiblesJsonString, walletsJsonString)
 
+  proc computeAirdropCollectiblesFee*(self: View, communityId: string, collectiblesJsonString: string, walletsJsonString: string) {.slot.} =
+    self.communityTokensModule.computeAirdropCollectiblesFee(communityId, collectiblesJsonString, walletsJsonString)
+
   proc selfDestructCollectibles*(self: View, communityId: string, collectiblesToBurnJsonString: string, contractUniqueKey: string) {.slot.} =
     self.communityTokensModule.selfDestructCollectibles(communityId, collectiblesToBurnJsonString, contractUniqueKey)
 
   proc deployFeeUpdated*(self: View, ethCurrency: QVariant, fiatCurrency: QVariant, errorCode: int) {.signal.}
   proc selfDestructFeeUpdated*(self: View, ethCurrency: QVariant, fiatCurrency: QVariant, errorCode: int) {.signal.}
+  proc airdropFeesUpdated*(self: View, json: string) {.signal.}
 
   proc computeDeployFee*(self: View, chainId: int, accountAddress: string) {.slot.} =
     self.communityTokensModule.computeDeployFee(chainId, accountAddress)
@@ -43,6 +47,9 @@ QtObject:
   proc updateSelfDestructFee*(self: View, ethCurrency: CurrencyAmount, fiatCurrency: CurrencyAmount, errorCode: int) =
     self.selfDestructFeeUpdated(newQVariant(ethCurrency), newQVariant(fiatCurrency), errorCode)
 
+  proc updateAirdropFees*(self: View, args: JsonNode) =
+    self.airdropFeesUpdated($args)
+
   proc deploymentStateChanged*(self: View, communityId: string, status: int, url: string) {.signal.}
   proc emitDeploymentStateChanged*(self: View, communityId: string, status: int, url: string) =
     self.deploymentStateChanged(communityId, status, url)
@@ -50,3 +57,7 @@ QtObject:
   proc remoteDestructStateChanged*(self: View, communityId: string, tokenName: string, status: int, url: string) {.signal.}
   proc emitRemoteDestructStateChanged*(self: View, communityId: string, tokenName: string, status: int, url: string) =
     self.remoteDestructStateChanged(communityId, tokenName, status, url)
+
+  proc airdropStateChanged*(self: View, communityId: string, tokenName: string, status: int, url: string) {.signal.}
+  proc emitAirdropStateChanged*(self: View, communityId: string, tokenName: string, status: int, url: string) =
+    self.airdropStateChanged(communityId, tokenName, status, url)

--- a/src/backend/community_tokens.nim
+++ b/src/backend/community_tokens.nim
@@ -30,6 +30,10 @@ proc mintTo*(chainId: int, contractAddress: string, txData: JsonNode, password: 
   let payload = %* [chainId, contractAddress, txData, utils.hashPassword(password), walletAddresses, amount]
   return core.callPrivateRPC("collectibles_mintTo", payload)
 
+proc estimateMintTo*(chainId: int, contractAddress: string, walletAddresses: seq[string], amount: int): RpcResponse[JsonNode] {.raises: [Exception].} =
+  let payload = %* [chainId, contractAddress, walletAddresses, amount]
+  return core.callPrivateRPC("collectibles_estimateMintTo", payload)
+
 proc remoteBurn*(chainId: int, contractAddress: string, txData: JsonNode, password: string, tokenIds: seq[UInt256]): RpcResponse[JsonNode] {.raises: [Exception].} =
   let payload = %* [chainId, contractAddress, txData, utils.hashPassword(password), tokenIds.map(x => x.toString(10))]
   return core.callPrivateRPC("collectibles_remoteBurn", payload)

--- a/ui/app/AppLayouts/Chat/views/communities/CommunityNewAirdropView.qml
+++ b/ui/app/AppLayouts/Chat/views/communities/CommunityNewAirdropView.qml
@@ -79,7 +79,8 @@ StatusScrollView {
                 networkText: modelItem.chainName,
                 networkImage: Style.svg(modelItem.chainIcon),
                 supply: modelItem.supply,
-                infiniteSupply: modelItem.infiniteSupply
+                infiniteSupply: modelItem.infiniteSupply,
+                contractUniqueKey: modelItem.contractUniqueKey,
             }
         }
     }
@@ -402,7 +403,7 @@ StatusScrollView {
             onClicked: {
                 const airdropTokens = ModelUtils.modelToArray(
                                         root.selectedHoldingsModel,
-                                        ["key", "amount"])
+                                        ["contractUniqueKey", "amount"])
 
                 const addresses_ = ModelUtils.modelToArray(
                                     addresses, ["address"]).map(e => e.address)

--- a/ui/imports/shared/stores/CommunityTokensStore.qml
+++ b/ui/imports/shared/stores/CommunityTokensStore.qml
@@ -58,6 +58,10 @@ QtObject {
       function onSelfDestructFeeUpdated(ethCurrency, fiatCurrency, errorCode) {
           root.selfDestructFeeUpdated(ethCurrency, fiatCurrency, errorCode)
       }
+      function onAirdropFeesUpdated(jsonFees) {
+          console.log("Fees:", jsonFees)
+      }
+
       function onDeploymentStateChanged(communityId, status, url) {
           root.deploymentStateChanged(communityId, status, url)
       }
@@ -93,5 +97,9 @@ QtObject {
     // Airdrop tokens:
     function airdrop(communityId, airdropTokens, addresses) {
         communityTokensModuleInst.airdropCollectibles(communityId, JSON.stringify(airdropTokens), JSON.stringify(addresses))
+    }
+
+    function computeAirdropFee(communityId, airdropTokens, addresses) {
+        communityTokensModuleInst.computeAirdropCollectiblesFee(communityId, JSON.stringify(airdropTokens), JSON.stringify(addresses))
     }
 }


### PR DESCRIPTION
This is a draft pr because the UI is not ready yet and I can't test the flow.
I created it to gather some early reviews.
This branch is a base branch for the next task: burning collectibles.

Major changes:
- all async tasks for computing fees are unified and they return 2 tables: fees per chain and gas cost per smart contract; this is because minting is complex and can be done for many smart contracts
- tabs from async tasks are temporary kept by a service and used during blockchain operation; thanks to that we do not have to compute fees 2 times
- preparing fees info for UI is quite complex because we need to group the costs by wallet and chain and also check if we can afford it.

Related status-go pr: https://github.com/status-im/status-go/pull/3563

This pr will be used by UI task: https://github.com/status-im/status-desktop/issues/10484
