### PR TITLE
fix: Use `StatusCursorDelegate` for password inputs

### DIFF
--- a/ui/StatusQ/src/StatusQ/Controls/StatusPasswordInput.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusPasswordInput.qml
@@ -5,6 +5,7 @@ import QtQuick.Controls 2.14
 import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
 import StatusQ.Controls 0.1
+import StatusQ.Components 0.1
 
 /*!
    \qmltype StatusPasswordInput
@@ -63,6 +64,7 @@ TextField {
     color: Theme.palette.directColor1
     selectionColor: Theme.palette.primaryColor2
     selectedTextColor: Theme.palette.directColor1
+
     background: Rectangle {
         id: inputRectangle
         anchors.fill: parent
@@ -77,6 +79,9 @@ TextField {
         }
     }
 
+    cursorDelegate: StatusCursorDelegate {
+        cursorVisible: root.cursorVisible
+    }
 
     RowLayout {
         id: phrase

--- a/ui/imports/shared/controls/StyledTextField.qml
+++ b/ui/imports/shared/controls/StyledTextField.qml
@@ -3,10 +3,18 @@ import QtQuick.Controls 2.13
 
 import utils 1.0
 
+import StatusQ.Components 0.1
+
 TextField {
+    id: root
+
     font.family: Style.current.baseFont.name
     color: readOnly ? Style.current.secondaryText : Style.current.textColor
     selectByMouse: !readOnly
     selectedTextColor: Style.current.textColor
     selectionColor: Style.current.primarySelectionColor
+
+    cursorDelegate: StatusCursorDelegate {
+        cursorVisible: root.cursorVisible
+    }
 }


### PR DESCRIPTION
We have a beautiful cursor. Let's use it! 🙂 

<img width="479" alt="image" src="https://github.com/status-im/status-desktop/assets/25482501/2eddb9c1-c9dd-40ee-8667-61455c105e5a">