### PR TITLE
chore(enableStatusGoOptimizations): Optimise Release build with O3 CFLAG

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -220,6 +220,8 @@ else
  # Additional optimization flags for release builds are not included at present;
  # adding them will involve refactoring config.nims in the root of this repo
  NIM_PARAMS += -d:release
+ STATUSGO_MAKE_PARAMS += CGO_CFLAGS="-O3"
+ STATUSKEYCARDGO_MAKE_PARAMS += CGO_CFLAGS="-O3"
 endif
 
 NIM_PARAMS += --outdir:./bin


### PR DESCRIPTION
### What does the PR do

Enable -O3 when compiling status-go for Release builds.

#### Motivation:
Testing the external c libs we're using in status-go with the following code revealed that the code is not optimised when compiling Release builds:
```
#ifdef __OPTIMIZE__
#pragma message "!!!!!!!Optimizing!!!!!!!"
#endif

#ifdef __OPTIMIZE_SIZE__
#pragma message "!!!!!!!Optimizing for size!!!!!!!"
#endif

#ifdef __NO_INLINE__
#pragma message "!!!!!!!Disabling inlining!!!!!!!"
#endif


//Expected output: !!!!!!!Optimizing!!!!!!!
//Actual output: !!!!!!!Disabling inlining!!!!!!!
```

The login time and overall app experience seems better with -O3
<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas

<!-- List the affected areas (e.g wallet, browser, etc..) -->
status-go, status-keycard-go build configuration on Release
