### PR TITLE
fix: add/remove account modal positioning is wrong

### DIFF
--- a/ui/app/AppLayouts/Wallet/views/LeftTabView.qml
+++ b/ui/app/AppLayouts/Wallet/views/LeftTabView.qml
@@ -55,7 +55,6 @@ Rectangle {
         sourceComponent: AddAccountPopup {
             store.emojiPopup: root.emojiPopup
             store.addAccountModule: walletSection.addAccountModule
-            anchors.centerIn: parent
         }
 
         onLoaded: {
@@ -94,9 +93,6 @@ Rectangle {
         property string accountDerivationPath
 
         sourceComponent: RemoveAccountConfirmationPopup {
-            anchors.centerIn: parent
-            width: 400
-
             simple: removeAccountConfirmation.simple
             accountName: removeAccountConfirmation.accountName
             accountAddress: removeAccountConfirmation.accountAddress


### PR DESCRIPTION
A small regression from porting StatusModal to StatusDialog

Fixes #10913

### What does the PR do

Fixes Add/Remove wallet account modals

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

Add:
![Snímek obrazovky z 2023-06-05 12-22-47](https://github.com/status-im/status-desktop/assets/5377645/8a717c4a-fe8d-4835-a5d4-fbb583af68dd)

Remove:
![Snímek obrazovky z 2023-06-05 12-25-04](https://github.com/status-im/status-desktop/assets/5377645/f7c5a7fe-04ec-40e0-a94c-b3b0e7ef9fcd)

