### PR TITLE
fix: Wallet: Authentication popup is broken

### DIFF
--- a/ui/imports/shared/popups/keycard/KeycardPopup.qml
+++ b/ui/imports/shared/popups/keycard/KeycardPopup.qml
@@ -64,9 +64,8 @@ StatusModal {
     StatusScrollView {
         id: scrollView
         anchors.fill: parent
-
-        implicitWidth: Constants.keycard.general.popupWidth
         contentWidth: availableWidth
+        horizontalPadding: 0
 
         KeycardPopupContent {
             id: content

--- a/ui/imports/shared/popups/keycard/states/EnterPassword.qml
+++ b/ui/imports/shared/popups/keycard/states/EnterPassword.qml
@@ -67,12 +67,14 @@ Item {
         StatusBaseText {
             id: title
             Layout.alignment: Qt.AlignCenter
+            Layout.maximumWidth: parent.width
             font.weight: Font.Bold
         }
 
         StatusBaseText {
             id: message
             Layout.alignment: Qt.AlignCenter
+            Layout.maximumWidth: parent.width
             wrapMode: Text.WordWrap
             visible: text != ""
         }
@@ -81,6 +83,7 @@ Item {
             id: password
             objectName: "keycardPasswordInput"
             Layout.alignment: Qt.AlignHCenter
+            Layout.maximumWidth: parent.width
             signingPhrase: root.sharedKeycardModule.getSigningPhrase()
             placeholderText: qsTr("Password")
             selectByMouse: true
@@ -102,6 +105,7 @@ Item {
         StatusBaseText {
             id: info
             Layout.alignment: Qt.AlignCenter
+            Layout.maximumWidth: parent.width
             wrapMode: Text.WordWrap
         }
 


### PR DESCRIPTION
- do no let text/input overflow our overall width
- set the scrollview horizontal padding to 0, the content item has its own margins already

Fixes #10915
Fixes #10906

### Affected areas

KeycardPopup

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![Snímek obrazovky z 2023-06-05 14-00-24](https://github.com/status-im/status-desktop/assets/5377645/e535f73d-f3a5-4ad9-a39d-8eea7eb66ec7)

