### PR TITLE
feat(wallet/desktop): Enable new scheduler

### DIFF
--- a/src/app_service/common/network_constants.nim
+++ b/src/app_service/common/network_constants.nim
@@ -396,7 +396,8 @@ var NODE_CONFIG* = %* {
       "420": ALCHEMY_OPTIMISM_GOERLI_TOKEN_RESOLVED
     },
     "InfuraAPIKey": INFURA_TOKEN_RESOLVED,
-    "InfuraAPIKeySecret": INFURA_TOKEN_SECRET_RESOLVED
+    "InfuraAPIKeySecret": INFURA_TOKEN_SECRET_RESOLVED,
+    "LoadAllTransfers": true,
   },
   "EnsConfig": {
     "Enabled": true

--- a/src/app_service/service/accounts/service.nim
+++ b/src/app_service/service/accounts/service.nim
@@ -661,7 +661,8 @@ QtObject:
             "420": ALCHEMY_OPTIMISM_GOERLI_TOKEN_RESOLVED
           },
           "InfuraAPIKey": INFURA_TOKEN_RESOLVED,
-          "InfuraAPIKeySecret": INFURA_TOKEN_SECRET_RESOLVED
+          "InfuraAPIKeySecret": INFURA_TOKEN_SECRET_RESOLVED,
+          "LoadAllTransfers": true
         },
         "TorrentConfig": {
           "Enabled": false,

--- a/src/app_service/service/transaction/service.nim
+++ b/src/app_service/service/transaction/service.nim
@@ -46,6 +46,7 @@ const SIGNAL_HISTORY_FETCHING* = "historyFetching"
 const SIGNAL_HISTORY_READY* = "historyReady"
 const SIGNAL_HISTORY_NON_ARCHIVAL_NODE* = "historyNonArchivalNode"
 const SIGNAL_HISTORY_ERROR* = "historyError"
+const SIGNAL_NEW_TRANSFERS* = "newTransfers"
 const SIGNAL_CRYPTO_SERVICES_READY* = "cryptoServicesReady"
 
 const SIMPLE_TX_BRIDGE_NAME = "Simple"
@@ -144,6 +145,16 @@ QtObject:
           self.events.emit(SIGNAL_HISTORY_NON_ARCHIVAL_NODE, Args())
         of "fetching-history-error":
           self.events.emit(SIGNAL_HISTORY_ERROR, Args())
+        of "new-transfers":
+          # TODO delete this, once activity filter is integrated
+          # with scheduler (Reactor) in status-go.
+          # It should handle proper updates of activity list. Proper
+          # handling of new and old transfers with current implementation
+          # requires lots of refactoring.
+          for account in data.accounts:
+            self.loadTransactions(account, stint.fromHex(Uint256, "0x0"))
+
+          self.events.emit(SIGNAL_NEW_TRANSFERS, HistoryArgs(addresses: data.accounts))
 
   proc getPendingTransactions*(self: Service): seq[TransactionDto] =
     try:


### PR DESCRIPTION
Enabled new transfers scheduler with `LoadAllTransfers=true` in wallet config.
Handled 'new transfers' event to load transactions. It is a temporary solution until integration of sequential transfer fetching is properly done with activity filter

### Affected areas

wallet/activity

### Description
When a new account added, it can take several minutes before first transaction appears on the list
Currently `new transfers` event handling causes reloading all transactions and resetting activities listview position. This is to be fixed in subsequent PRs.

Closes #10246 

