### PR TITLE
feat: speedup/slowdown archives import based on window state

### DIFF
--- a/src/app/modules/main/controller.nim
+++ b/src/app/modules/main/controller.nim
@@ -479,3 +479,9 @@ proc getCommunityTokenOwnerName*(self: Controller, chainId: int, contractAddress
 
 proc getNetwork*(self:Controller, chainId: int): NetworkDto =
   self.networksService.getNetwork(chainId)
+
+proc slowdownArchivesImport*(self:Controller) =
+  communityService.slowdownArchivesImport()
+
+proc speedupArchivesImport*(self:Controller) =
+  communityService.speedupArchivesImport()

--- a/src/app/modules/main/io_interface.nim
+++ b/src/app/modules/main/io_interface.nim
@@ -315,6 +315,12 @@ method onAcceptRequestToJoinSuccess*(self: AccessInterface, communityId: string,
 method onDeactivateChatLoader*(self: AccessInterface, sectionId: string, chatId: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method windowActivated*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method windowDeactivated*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 # This way (using concepts) is used only for the modules managed by AppController
 type
   DelegateInterface* = concept c

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -1211,3 +1211,9 @@ method activateStatusDeepLink*[T](self: Module[T], statusDeepLink: string) =
 method onDeactivateChatLoader*[T](self: Module[T], sectionId: string, chatId: string) =
   if (sectionId.len > 0 and self.channelGroupModules.contains(sectionId)):
     self.channelGroupModules[sectionId].onDeactivateChatLoader(chatId)
+
+method windowActivated*[T](self: Module[T]) =
+  self.controller.slowdownArchivesImport()
+
+method windowDeactivated*[T](self: Module[T]) =
+  self.controller.speedupArchivesImport()

--- a/src/app/modules/main/view.nim
+++ b/src/app/modules/main/view.nim
@@ -263,5 +263,8 @@ QtObject:
   proc emitDestroyKeycardSharedModuleFlow*(self: View) =
     self.destroyKeycardSharedModuleFlow()
 
-  proc setCommunityIdToSpectate*(self: View, communityId: string) {.slot.} = 
-    self.delegate.setCommunityIdToSpectate(communityId)
+  proc windowActivated*(self: View) {.slot.} = 
+    self.delegate.windowActivated()
+
+  proc windowDeactivated*(self: View) {.slot.} = 
+    self.delegate.windowDeactivated()

--- a/src/app_service/service/community/service.nim
+++ b/src/app_service/service/community/service.nim
@@ -1534,6 +1534,24 @@ QtObject:
     except Exception as e:
       error "Error exporting community", msg = e.msg
 
+  proc speedupArchivesImport*() =
+    try:
+      let response = status_go.speedupArchivesImport()
+      if (response.error != nil):
+        let error = Json.decode($response.error, RpcError)
+        raise newException(RpcException, fmt"err: {error.message}")
+    except Exception as e:
+      error "Error speeding up archives import: ", msg = e.msg
+
+  proc slowdownArchivesImport*() =
+    try:
+      let response = status_go.slowdownArchivesImport()
+      if (response.error != nil):
+        let error = Json.decode($response.error, RpcError)
+        raise newException(RpcException, fmt"err: {error.message}")
+    except Exception as e:
+      error "Error slowing down archives import: ", msg = e.msg
+
   proc getPendingRequestIndex(self: Service, communityId: string, requestId: string): int =
     let community = self.communities[communityId]
     var i = 0

--- a/src/backend/communities.nim
+++ b/src/backend/communities.nim
@@ -317,6 +317,12 @@ proc importCommunity*(communityKey: string): RpcResponse[JsonNode] {.raises: [Ex
 proc exportCommunity*(communityId: string): RpcResponse[JsonNode] {.raises: [Exception].}  =
   result = callPrivateRPC("exportCommunity".prefix, %*[communityId])
 
+proc speedupArchivesImport*(): RpcResponse[JsonNode] {.raises: [Exception].} =
+  result = callPrivateRPC("speedupArchivesImport".prefix)
+
+proc slowdownArchivesImport*(): RpcResponse[JsonNode] {.raises: [Exception].} =
+  result = callPrivateRPC("slowdownArchivesImport".prefix)
+
 proc removeUserFromCommunity*(communityId: string, pubKey: string): RpcResponse[JsonNode] {.raises: [Exception].} =
   result = callPrivateRPC("removeUserFromCommunity".prefix, %*[communityId, pubKey])
 

--- a/ui/app/AppLayouts/stores/RootStore.qml
+++ b/ui/app/AppLayouts/stores/RootStore.qml
@@ -148,4 +148,12 @@ QtObject {
     function resolveENS(value) {
         mainModuleInst.resolveENS(value, "")
     }
+
+    function windowActivated() {
+        mainModuleInst.windowActivated()
+    }
+
+    function windowDeactivated() {
+        mainModuleInst.windowDeactivated()
+    }
 }

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -200,6 +200,15 @@ Item {
         }
     }
 
+    Connections {
+        target: Global.applicationWindow
+
+        function onActiveChanged() {
+            if (Global.applicationWindow.active) appMain.rootStore.windowActivated()
+            else appMain.rootStore.windowDeactivated()
+        }
+    }
+
     function changeAppSectionBySectionId(sectionId) {
         appMain.rootStore.mainModuleInst.setActiveSectionById(sectionId)
     }


### PR DESCRIPTION
### What does the PR do

closes: #10815 

- speedups/slowdowns archives import based on window state

status-go PR: https://github.com/status-im/status-go/pull/3568

### Affected areas

- importing archives

### Screenshot of functionality (including design for comparison)

https://github.com/status-im/status-desktop/assets/33099791/9ed94887-306b-4ef7-81af-d108193d69b2


