### PR TITLE
feat(CommunityAirdrops): Summary popup with multiple fees listed

### DIFF
--- a/storybook/PagesModel.qml
+++ b/storybook/PagesModel.qml
@@ -194,6 +194,10 @@ ListModel {
          section: "Popups"
     }
     ListElement {
+         title: "SignMultiTokenTransactionsPopup"
+         section: "Popups"
+    }
+    ListElement {
          title: "RemotelyDestructPopup"
          section: "Popups"
     }

--- a/storybook/pages/SignMultiTokenTransactionsPopupPage.qml
+++ b/storybook/pages/SignMultiTokenTransactionsPopupPage.qml
@@ -1,0 +1,133 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+import Storybook 1.0
+
+import AppLayouts.Chat.popups.community 1.0
+
+
+SplitView {
+    Logs { id: logs }
+
+    SplitView {
+        orientation: Qt.Vertical
+        SplitView.fillWidth: true
+
+        Pane {
+            id: pane
+
+            SplitView.fillWidth: true
+            SplitView.fillHeight: true
+
+            PopupBackground {
+                anchors.fill: parent
+            }
+
+            Button {
+                anchors.centerIn: parent
+                text: "Reopen"
+
+                onClicked: dialog.open()
+            }
+
+            SignMultiTokenTransactionsPopup {
+                id: dialog
+
+                model: ListModel {
+                    id: feesModel
+
+                    ListElement {
+                        account: "My Account 1"
+                        network: "Optimism"
+                        symbol: "TAT"
+                        amount: 2
+                        feeText: "0.0015 ($75.43)"
+                    }
+                    ListElement {
+                        account: "My Account 2"
+                        network: "Arbitrum"
+                        symbol: "SNT"
+                        amount: 34
+                        feeText: "0.0085 ETH ($175.43)"
+                    }
+                }
+
+                closePolicy: Popup.NoAutoClose
+                visible: true
+                modal: false
+                destroyOnClose: false
+
+                title: `Sign transaction - Airdrop ${model.count} token(s) to 32 recipients`
+
+                isFeeLoading: loadingSwitch.checked
+                showSummary: showSummarySwitch.checked
+
+                errorText: errorTextField.text
+                totalFeeText: "0.01 ETH ($265.43)"
+
+                onSignTransactionClicked: logs.logEvent("SignTokenTransactionsPopup::onSignTransactionClicked")
+                onCancelClicked: logs.logEvent("SignTokenTransactionsPopup::onCancelClicked")
+            }
+        }
+
+        LogsAndControlsPanel {
+            id: logsAndControlsPanel
+
+            SplitView.minimumHeight: 100
+            SplitView.preferredHeight: 150
+
+            logsView.logText: logs.logText
+        }
+    }
+
+    Pane {
+        SplitView.minimumWidth: 300
+        SplitView.preferredWidth: 300
+
+        ColumnLayout {
+            anchors.fill: parent
+
+            Label {
+                Layout.fillWidth: true
+
+                text: "Error text"
+            }
+
+            TextField {
+                id: errorTextField
+
+                Layout.fillWidth: true
+
+                text: ""
+            }
+
+            SpinBox {
+                id: recipientsCountSpinBox
+
+                from: 1
+                to: 1000
+            }
+
+            Switch {
+                id: loadingSwitch
+
+                text: "Is fee loading"
+                checked: false
+            }
+
+            Switch {
+                id: showSummarySwitch
+
+                text: "Is summary visible"
+                checked: true
+            }
+
+            Item {
+                Layout.fillHeight: true
+            }
+        }
+    }
+}
+
+

--- a/ui/StatusQ/src/StatusQ/Core/Utils/ModelUtils.qml
+++ b/ui/StatusQ/src/StatusQ/Core/Utils/ModelUtils.qml
@@ -117,4 +117,8 @@ QtObject {
 
         return true
     }
+
+    function roleNames(model) {
+        return Internal.ModelUtils.roleNames(model)
+    }
 }

--- a/ui/app/AppLayouts/Chat/panels/communities/CommunityAirdropsSettingsPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/CommunityAirdropsSettingsPanel.qml
@@ -19,11 +19,17 @@ SettingsPageLayout {
 
     required property var membersModel
 
+    // JS object specifing fees for the airdrop operation, should be set to
+    // provide response to airdropFeesRequested signal.
+    // Refer CommunityNewAirdropView::airdropFees for details.
+    property var airdropFees: null
+
     property int viewWidth: 560 // by design
 
     signal airdropClicked(var airdropTokens, var addresses, var membersPubKeys)
-    signal navigateToMintTokenSettings
+    signal airdropFeesRequested(var contractKeysAndAmounts, var addresses)
 
+    signal navigateToMintTokenSettings
 
     function navigateBack() {
         stackManager.pop(StackView.Immediate)
@@ -109,6 +115,10 @@ SettingsPageLayout {
             collectiblesModel: root.collectiblesModel
             membersModel: root.membersModel
 
+            Binding on airdropFees {
+                value: root.airdropFees
+            }
+
             onAirdropClicked: {
                 root.airdropClicked(airdropTokens, addresses, membersPubKeys)
                 stackManager.clear(d.welcomeViewState, StackView.Immediate)
@@ -118,6 +128,7 @@ SettingsPageLayout {
             Component.onCompleted: {
                 d.selectToken.connect(view.selectToken)
                 d.addAddresses.connect(view.addAddresses)
+                airdropFeesRequested.connect(root.airdropFeesRequested)
             }
         }
     }

--- a/ui/app/AppLayouts/Chat/popups/community/SignMultiTokenTransactionsPopup.qml
+++ b/ui/app/AppLayouts/Chat/popups/community/SignMultiTokenTransactionsPopup.qml
@@ -1,0 +1,179 @@
+import QtQuick 2.15
+import QtQuick.Layouts 1.15
+import QtQml.Models 2.15
+
+import StatusQ.Core 0.1
+import StatusQ.Controls 0.1
+import StatusQ.Components 0.1
+import StatusQ.Popups.Dialog 0.1
+import StatusQ.Core.Theme 0.1
+
+import utils 1.0
+
+StatusDialog {
+    id: root
+
+    // account, amount, symbol, network, feeText
+    property alias model: repeater.model
+    property alias showSummary: summaryRow.visible
+    property alias errorText: errorTxt.text
+    property alias totalFeeText: totalFeeText.text
+
+    property bool isFeeLoading
+
+    signal signTransactionClicked()
+    signal cancelClicked()
+
+    QtObject {
+        id: d
+
+        property int minTextWidth: 50
+    }
+
+    implicitWidth: 600 // by design
+    topPadding: 2 * Style.current.padding // by design
+    bottomPadding: topPadding
+
+    contentItem: ColumnLayout {
+        id: column
+
+        spacing: Style.current.padding
+
+        Repeater {
+            id: repeater
+
+            Item {
+                Layout.fillWidth: true
+
+                implicitHeight: delegateColumn.implicitHeight
+
+                ColumnLayout {
+                    id: delegateColumn
+
+                    width: parent.width
+
+                    RowLayout {
+                        Layout.fillWidth: true
+
+                        StatusBaseText {
+                            Layout.fillWidth: true
+
+                            text: qsTr("Airdropping %1 %2 on %3")
+                                .arg(model.amount).arg(model.symbol)
+                                .arg(model.network)
+
+                            font.pixelSize: Style.current.primaryTextFontSize
+                            elide: Text.ElideMiddle
+                        }
+
+                        StatusDotsLoadingIndicator {
+                            visible: root.isFeeLoading
+
+                            Layout.rightMargin: Style.current.padding
+                        }
+
+                        StatusBaseText {
+                            text: model.feeText
+
+                            font.pixelSize: Style.current.primaryTextFontSize
+                            elide: Text.ElideMiddle
+
+                            color: Theme.palette.baseColor1
+
+                            visible: !root.isFeeLoading
+                        }
+                    }
+
+                    StatusBaseText {
+                        Layout.fillWidth: true
+
+                        text: qsTr("via %1").arg(model.account)
+                        horizontalAlignment: Text.AlignLeft
+                        font.pixelSize: Style.current.primaryTextFontSize
+                        elide: Text.ElideMiddle
+
+                        color: Theme.palette.baseColor1
+                    }
+                }
+            }
+        }
+
+        Rectangle {
+            Layout.fillWidth: true
+            Layout.preferredHeight: 1
+
+            color: Theme.palette.baseColor2
+        }
+
+        RowLayout {
+            id: summaryRow
+
+            Layout.fillHeight: false
+            Layout.fillWidth: true
+
+            Layout.topMargin: Style.current.halfPadding
+            Layout.bottomMargin: -Style.current.halfPadding
+
+            StatusBaseText {
+                Layout.fillWidth: true
+
+                text: qsTr("Total")
+
+                font.pixelSize: Style.current.primaryTextFontSize
+                elide: Text.ElideMiddle
+            }
+
+            StatusDotsLoadingIndicator {
+                visible: root.isFeeLoading
+
+                Layout.rightMargin: Style.current.padding
+            }
+
+            StatusBaseText {
+                id: totalFeeText
+
+                font.pixelSize: Style.current.primaryTextFontSize
+                visible: !root.isFeeLoading
+            }
+        }
+
+        StatusBaseText {
+            id: errorTxt
+
+            Layout.topMargin: Style.current.halfPadding
+            Layout.bottomMargin: -Style.current.halfPadding
+            Layout.fillWidth: true
+
+            wrapMode: Text.Wrap
+            horizontalAlignment: Text.AlignRight
+            font.pixelSize: Style.current.primaryTextFontSize
+            color: Theme.palette.dangerColor1
+
+            text: root.errorText
+            visible: root.errorText !== ""
+        }
+    }
+
+    footer: StatusDialogFooter {
+        spacing: Style.current.padding
+        rightButtons: ObjectModel {
+            StatusButton {
+                text: qsTr("Cancel")
+                type: StatusBaseButton.Type.Danger
+                onClicked: {
+                    root.cancelClicked()
+                    root.close()
+                }
+            }
+            StatusButton {
+                enabled: root.errorText === "" && !root.isFeeLoading
+                icon.name: "password"
+                text: qsTr("Sign transaction")
+                onClicked: {
+                    root.signTransactionClicked()
+                    root.close()
+                }
+            }
+        }
+    }
+}

--- a/ui/app/AppLayouts/Chat/popups/community/qmldir
+++ b/ui/app/AppLayouts/Chat/popups/community/qmldir
@@ -1,6 +1,7 @@
 AlertPopup 1.0 AlertPopup.qml
 BurnTokensPopup 1.0 BurnTokensPopup.qml
-CreateChannelPopup 1.0 CreateChannelPopup.qml
 CommunityTokenPermissionsPopup 1.0 CommunityTokenPermissionsPopup.qml
+CreateChannelPopup 1.0 CreateChannelPopup.qml
 RemotelyDestructPopup 1.0 RemotelyDestructPopup.qml
+SignMultiTokenTransactionsPopup 1.0 SignMultiTokenTransactionsPopup.qml
 SignTokenTransactionsPopup 1.0 SignTokenTransactionsPopup.qml

--- a/ui/app/AppLayouts/Chat/views/CommunitySettingsView.qml
+++ b/ui/app/AppLayouts/Chat/views/CommunitySettingsView.qml
@@ -447,6 +447,10 @@ StatusSectionLayout {
                 onAirdropClicked: communityTokensStore.airdrop(root.community.id, airdropTokens, addresses)
                 onNavigateToMintTokenSettings: root.goTo(Constants.CommunitySettingsSections.MintTokens)
 
+                onAirdropFeesRequested:
+                    communityTokensStore.computeAirdropFee(
+                        root.community.id, contractKeysAndAmounts, addresses)
+
                 Connections {
                     target: mintPanel
 
@@ -459,6 +463,14 @@ StatusSectionLayout {
                         
                         // Set given addresses as recipients
                         airdropPanel.addAddresses(addresses)
+                    }
+                }
+
+                Connections {
+                    target: rootStore.communityTokensStore
+
+                    function onAirdropFeeUpdated(airdropFees) {
+                        airdropPanel.airdropFees = airdropFees
                     }
                 }
             }

--- a/ui/imports/shared/stores/CommunityTokensStore.qml
+++ b/ui/imports/shared/stores/CommunityTokensStore.qml
@@ -15,6 +15,7 @@ QtObject {
 
     signal deployFeeUpdated(var ethCurrency, var fiatCurrency, int error)
     signal selfDestructFeeUpdated(var ethCurrency, var fiatCurrency, int error)
+    signal airdropFeeUpdated(var airdropFees)
 
     signal deploymentStateChanged(string communityId, int status, string url)
 
@@ -51,23 +52,27 @@ QtObject {
     }
 
     readonly property Connections connections: Connections {
-      target: communityTokensModuleInst
-      function onDeployFeeUpdated(ethCurrency, fiatCurrency, errorCode) {
-          root.deployFeeUpdated(ethCurrency, fiatCurrency, errorCode)
-      }
-      function onSelfDestructFeeUpdated(ethCurrency, fiatCurrency, errorCode) {
-          root.selfDestructFeeUpdated(ethCurrency, fiatCurrency, errorCode)
-      }
-      function onAirdropFeesUpdated(jsonFees) {
-          console.log("Fees:", jsonFees)
-      }
+        target: communityTokensModuleInst
 
-      function onDeploymentStateChanged(communityId, status, url) {
-          root.deploymentStateChanged(communityId, status, url)
-      }
-      function onRemoteDestructStateChanged(communityId, tokenName, status, url) {
-          root.remoteDestructStateChanged(communityId, tokenName, status, url)
-      }
+        function onDeployFeeUpdated(ethCurrency, fiatCurrency, errorCode) {
+            root.deployFeeUpdated(ethCurrency, fiatCurrency, errorCode)
+        }
+
+        function onSelfDestructFeeUpdated(ethCurrency, fiatCurrency, errorCode) {
+            root.selfDestructFeeUpdated(ethCurrency, fiatCurrency, errorCode)
+        }
+
+        function onAirdropFeesUpdated(jsonFees) {
+            root.airdropFeeUpdated(JSON.parse(jsonFees))
+        }
+
+        function onDeploymentStateChanged(communityId, status, url) {
+            root.deploymentStateChanged(communityId, status, url)
+        }
+
+        function onRemoteDestructStateChanged(communityId, tokenName, status, url) {
+            root.remoteDestructStateChanged(communityId, tokenName, status, url)
+        }
     }
 
     function computeDeployFee(chainId, accountAddress) {
@@ -99,7 +104,9 @@ QtObject {
         communityTokensModuleInst.airdropCollectibles(communityId, JSON.stringify(airdropTokens), JSON.stringify(addresses))
     }
 
-    function computeAirdropFee(communityId, airdropTokens, addresses) {
-        communityTokensModuleInst.computeAirdropCollectiblesFee(communityId, JSON.stringify(airdropTokens), JSON.stringify(addresses))
+    function computeAirdropFee(communityId, contractKeysAndAmounts, addresses) {
+        communityTokensModuleInst.computeAirdropCollectiblesFee(
+                    communityId, JSON.stringify(contractKeysAndAmounts),
+                    JSON.stringify(addresses))
     }
 }


### PR DESCRIPTION
### What does the PR do

Introduces `SignMultiTokenTransactionsPopup` for displaying fees broken down into individual tokens and integrates it into the Airdrop flow.

Closes: #10484

### Affected areas
`CommunityNewAirdropView`

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

[Screencast from 14.06.2023 11:45:00.webm](https://github.com/status-im/status-desktop/assets/20650004/946e175d-cb23-4dd7-8102-8edff3fc1897)

![Screenshot from 2023-06-07 17-36-11](https://github.com/status-im/status-desktop/assets/20650004/a7d9f197-9e15-46cd-a522-79efd1961d3d)

![Screenshot from 2023-06-07 17-29-21](https://github.com/status-im/status-desktop/assets/20650004/019d3f35-7aea-4b73-8e82-04b2a9c9624d)


