### PR TITLE
feat: introduce and handle `checkPermissionsToJoinCommunity()`

### DIFF
--- a/src/app/modules/main/chat_section/controller.nim
+++ b/src/app/modules/main/chat_section/controller.nim
@@ -257,6 +257,7 @@ proc init*(self: Controller) =
       let args = CommunityTokenPermissionArgs(e)
       if (args.communityId == self.sectionId):
         self.delegate.onCommunityTokenPermissionCreated(args.communityId, args.tokenPermission)
+        self.communityService.asyncCheckPermissionsToJoin(self.sectionId)
 
     self.events.on(SIGNAL_COMMUNITY_TOKEN_PERMISSION_CREATION_FAILED) do(e: Args):
       let args = CommunityTokenPermissionArgs(e)
@@ -267,6 +268,8 @@ proc init*(self: Controller) =
       let args = CommunityTokenPermissionArgs(e)
       if (args.communityId == self.sectionId):
         self.delegate.onCommunityTokenPermissionUpdated(args.communityId, args.tokenPermission)
+        self.communityService.asyncCheckPermissionsToJoin(self.sectionId)
+
 
     self.events.on(SIGNAL_COMMUNITY_TOKEN_PERMISSION_UPDATE_FAILED) do(e: Args):
       let args = CommunityTokenPermissionArgs(e)
@@ -277,11 +280,17 @@ proc init*(self: Controller) =
       let args = CommunityTokenPermissionRemovedArgs(e)
       if (args.communityId == self.sectionId):
         self.delegate.onCommunityTokenPermissionDeleted(args.communityId, args.permissionId)
+        self.communityService.asyncCheckPermissionsToJoin(self.sectionId)
 
     self.events.on(SIGNAL_COMMUNITY_TOKEN_PERMISSION_DELETION_FAILED) do(e: Args):
       let args = CommunityTokenPermissionArgs(e)
       if (args.communityId == self.sectionId):
         self.delegate.onCommunityTokenPermissionDeletionFailed(args.communityId)
+
+    self.events.on(SIGNAL_CHECK_PERMISSIONS_TO_JOIN_RESPONSE) do(e: Args):
+      let args = CheckPermissionsToJoinResponseArgs(e)
+      if (args.communityId == self.sectionId):
+        self.delegate.onCommunityCheckPermissionsToJoinResponse(args.checkPermissionsToJoinResponse)
 
     self.events.on(SIGNAL_COMMUNITY_TOKEN_METADATA_ADDED) do(e: Args):
       let args = CommunityTokenMetadataArgs(e)
@@ -660,3 +669,6 @@ proc getContractAddressesForToken*(self: Controller, symbol: string): Table[int,
 
 proc getCommunityTokenList*(self: Controller): seq[CommunityTokenDto] =
   return self.communityTokensService.getCommunityTokens(self.getMySectionId())
+
+proc asyncCheckPermissionsToJoin*(self: Controller) =
+  self.communityService.asyncCheckPermissionsToJoin(self.getMySectionId())

--- a/src/app/modules/main/chat_section/io_interface.nim
+++ b/src/app/modules/main/chat_section/io_interface.nim
@@ -396,3 +396,6 @@ method requestToJoinCommunityWithAuthentication*(self: AccessInterface, communit
 
 method onOwnedcollectiblesUpdated*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
+
+method onCommunityCheckPermissionsToJoinResponse*(self: AccessInterface, checkPermissionsToJoinResponse: CheckPermissionsToJoinResponseDto) {.base.} =
+  raise newException(ValueError, "No implementation available")

--- a/src/app/modules/shared_models/token_permissions_model.nim
+++ b/src/app/modules/shared_models/token_permissions_model.nim
@@ -103,6 +103,13 @@ QtObject:
     self.endRemoveRows()
     self.countChanged()
 
+  proc getItemById*(self: TokenPermissionsModel, permissionId: string): TokenPermissionItem =
+    let idx = self.findIndexById(permissionId)
+    if(idx == -1):
+      return
+
+    return self.items[idx]
+
   proc updateItem*(self: TokenPermissionsModel, permissionId: string, item: TokenPermissionItem) =
     let idx = self.findIndexById(permissionId)
     if(idx == -1):

--- a/src/app_service/service/community/async_tasks.nim
+++ b/src/app_service/service/community/async_tasks.nim
@@ -102,3 +102,22 @@ const asyncRequestToJoinCommunityTask: Task = proc(argEncoded: string) {.gcsafe,
       "ensName": arg.ensName,
       "password": arg.password
     })
+
+type
+  AsyncCheckPermissionsToJoinTaskArg = ref object of QObjectTaskArg
+    communityId: string
+
+const asyncCheckPermissionsToJoinTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+  let arg = decode[AsyncCheckPermissionsToJoinTaskArg](argEncoded)
+  try:
+    let response = status_go.checkPermissionsToJoinCommunity(arg.communityId)
+    arg.finish(%* {
+      "response": response,
+      "communityId": arg.communityId,
+      "error": "",
+    })
+  except Exception as e:
+    arg.finish(%* {
+      "communityId": arg.communityId,
+      "error": e.msg,
+    })

--- a/src/backend/communities.nim
+++ b/src/backend/communities.nim
@@ -39,6 +39,11 @@ proc requestToJoinCommunity*(communityId: string, ensName: string, password: str
     "password": if passwordToSend != "": utils.hashPassword(password) else: ""
   }])
 
+proc checkPermissionsToJoinCommunity*(communityId: string): RpcResponse[JsonNode] {.raises: [Exception].} =
+  result = callPrivateRPC("checkPermissionsToJoinCommunity".prefix, %*[{
+    "communityId": communityId
+  }])
+
 proc myPendingRequestsToJoin*(): RpcResponse[JsonNode] {.raises: [Exception].} =
   result =  callPrivateRPC("myPendingRequestsToJoin".prefix)
 


### PR DESCRIPTION
This is an improved version to check wether a user has permission to join a community and updating the join community view accordingly.

We now asynchronously do all the checks in status-go and process a single result upon token permission updates, additions and deletions.

Depends on: https://github.com/status-im/status-go/pull/3494

Closes #10481 #4939

