### PR TITLE
fix(contacts): fetches info for contacts missing it + loading in AC

### DIFF
--- a/src/app/core/signals/remote_signals/messages.nim
+++ b/src/app/core/signals/remote_signals/messages.nim
@@ -18,7 +18,7 @@ type MessageSignal* = ref object of Signal
   messages*: seq[MessageDto]
   pinnedMessages*: seq[PinnedMessageUpdateDto]
   chats*: seq[ChatDto]
-  contacts*: seq[ContactsDto]
+  contacts*: seq[ContactDto]
   installations*: seq[InstallationDto]
   emojiReactions*: seq[ReactionDto]
   communities*: seq[CommunityDto]

--- a/src/app/modules/main/chat_section/chat_content/controller.nim
+++ b/src/app/modules/main/chat_section/chat_content/controller.nim
@@ -207,7 +207,7 @@ proc getMessageById*(self: Controller, messageId: string):
 proc isUsersListAvailable*(self: Controller): bool =
   return self.isUsersListAvailable
 
-proc getMyMutualContacts*(self: Controller): seq[ContactsDto] =
+proc getMyMutualContacts*(self: Controller): seq[ContactDto] =
   return self.contactService.getContactsByGroup(ContactsGroup.MyMutualContacts)
 
 proc muteChat*(self: Controller, interval: int) =
@@ -231,7 +231,7 @@ proc clearChatHistory*(self: Controller) =
 proc leaveChat*(self: Controller) =
   self.chatService.leaveChat(self.chatId)
 
-proc getContactById*(self: Controller, contactId: string): ContactsDto =
+proc getContactById*(self: Controller, contactId: string): ContactDto =
   return self.contactService.getContactById(contactId)
 
 proc getContactDetails*(self: Controller, contactId: string): ContactDetails =

--- a/src/app/modules/main/chat_section/chat_content/messages/controller.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/controller.nim
@@ -261,7 +261,7 @@ proc removeReaction*(self: Controller, messageId: string, emojiId: int, reaction
 proc pinUnpinMessage*(self: Controller, messageId: string, pin: bool) =
   self.messageService.pinUnpinMessage(self.chatId, messageId, pin)
 
-proc getContactById*(self: Controller, contactId: string): ContactsDto =
+proc getContactById*(self: Controller, contactId: string): ContactDto =
   return self.contactService.getContactById(contactId)
 
 proc getContactDetails*(self: Controller, contactId: string): ContactDetails =

--- a/src/app/modules/main/chat_section/controller.nim
+++ b/src/app/modules/main/chat_section/controller.nim
@@ -455,10 +455,10 @@ proc clearChatHistory*(self: Controller, chatId: string) =
 proc getCurrentFleet*(self: Controller): string =
   return self.nodeConfigurationService.getFleetAsString()
 
-proc getContacts*(self: Controller, group: ContactsGroup): seq[ContactsDto] =
+proc getContacts*(self: Controller, group: ContactsGroup): seq[ContactDto] =
   return self.contactService.getContactsByGroup(group)
 
-proc getContactById*(self: Controller, id: string): ContactsDto =
+proc getContactById*(self: Controller, id: string): ContactDto =
   return self.contactService.getContactById(id)
 
 proc getContactDetails*(self: Controller, id: string): ContactDetails =

--- a/src/app/modules/main/controller.nim
+++ b/src/app/modules/main/controller.nim
@@ -436,10 +436,10 @@ proc setCurrentUserStatus*(self: Controller, status: StatusType) =
   else:
     error "error updating user status"
 
-proc getContact*(self: Controller, id: string): ContactsDto =
+proc getContact*(self: Controller, id: string): ContactDto =
   return self.contactsService.getContactById(id)
 
-proc getContacts*(self: Controller, group: ContactsGroup): seq[ContactsDto] =
+proc getContacts*(self: Controller, group: ContactsGroup): seq[ContactDto] =
   return self.contactsService.getContactsByGroup(group)
 
 proc getContactNameAndImage*(self: Controller, contactId: string):

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -957,6 +957,7 @@ method getContactDetailsAsJson*[T](self: Module[T], publicKey: string, getVerifi
     "verificationStatus": contact.verificationStatus.int,
     "incomingVerificationStatus": requestStatus,
     "hasAddedUs": contact.hasAddedUs,
+    "fetching": contact.fetching,
     "socialLinks": $contact.socialLinks.toJsonNode(),
     "bio": contact.bio
   }

--- a/src/app/modules/main/profile_section/contacts/controller.nim
+++ b/src/app/modules/main/profile_section/contacts/controller.nim
@@ -89,10 +89,10 @@ proc init*(self: Controller) =
     let args = ContactInfoRequestArgs(e)
     self.delegate.onContactInfoRequestFinished(args.publicKey, args.ok)
 
-proc getContacts*(self: Controller, group: ContactsGroup): seq[ContactsDto] =
+proc getContacts*(self: Controller, group: ContactsGroup): seq[ContactDto] =
   return self.contactsService.getContactsByGroup(group)
 
-proc getContact*(self: Controller, id: string): ContactsDto =
+proc getContact*(self: Controller, id: string): ContactDto =
   return self.contactsService.getContactById(id)
 
 proc getContactNameAndImage*(self: Controller, contactId: string):

--- a/src/app_service/common/message.nim
+++ b/src/app_service/common/message.nim
@@ -3,7 +3,7 @@ import ../service/contacts/dto/contacts
 from conversion import SystemTagMapping
 
 
-proc replacePubKeysWithDisplayNames*(allKnownContacts: seq[ContactsDto], message: string): string =
+proc replacePubKeysWithDisplayNames*(allKnownContacts: seq[ContactDto], message: string): string =
   let pubKeyPattern = re(r"(@0x[a-f0-9]+)", flags = {reStudy, reIgnoreCase})
   let pubKeys = findAll(message, pubKeyPattern)
   var updatedMessage = message
@@ -19,7 +19,7 @@ proc replacePubKeysWithDisplayNames*(allKnownContacts: seq[ContactsDto], message
 
   return updatedMessage
 
-proc replaceMentionsWithPubKeys*(allKnownContacts: seq[ContactsDto], message: string): string =
+proc replaceMentionsWithPubKeys*(allKnownContacts: seq[ContactDto], message: string): string =
   let aliasPattern = re(r"(@[A-z][a-z]+ [A-z][a-z]* [A-z][a-z]*)", flags = {reStudy, reIgnoreCase})
   let ensPattern = re(r"(@\w+((\.stateofus)?\.eth))", flags = {reStudy, reIgnoreCase})
   let namePattern = re(r"(@\w+)", flags = {reStudy, reIgnoreCase})

--- a/src/app_service/service/contacts/dto/contact_details.nim
+++ b/src/app_service/service/contacts/dto/contact_details.nim
@@ -12,4 +12,4 @@ type
     isCurrentUser*: bool
     colorId*: int
     colorHash*: string
-    dto*: ContactsDto
+    dto*: ContactDto

--- a/ui/StatusQ/src/StatusQ/Components/StatusMessageHeader.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusMessageHeader.qml
@@ -38,6 +38,7 @@ Item {
     RowLayout {
         id: layout
         spacing: 4
+
         StatusBaseText {
             id: primaryDisplayName
             objectName: "StatusMessageHeader_DisplayName"
@@ -47,7 +48,7 @@ Item {
             font.underline: mouseArea.containsMouse
             font.pixelSize: Theme.primaryTextFontSize
             wrapMode: Text.WordWrap
-            color: Theme.palette.primaryColor1
+            color: root.sender.contactFetching ? "transparent" : Theme.palette.primaryColor1
             text: root.amISender ? qsTr("You") : root.sender.displayName
             MouseArea {
                 id: mouseArea
@@ -58,6 +59,16 @@ Item {
                 hoverEnabled: true
                 onClicked: {
                     root.clicked(this, mouse)
+                }
+            }
+
+
+            Loader {
+                anchors.fill: parent
+                active: root.sender.contactFetching
+
+                sourceComponent: LoadingComponent {
+                    radius: 4
                 }
             }
         }

--- a/ui/StatusQ/src/StatusQ/Components/StatusMessageSenderDetails.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusMessageSenderDetails.qml
@@ -10,6 +10,7 @@ QtObject {
 
     property bool isEnsVerified: false
     property bool isContact: false
+    property bool contactFetching: false
     property int trustIndicator: StatusContactVerificationIcons.TrustedType.None
 
     property StatusProfileImageSettings profileImage: StatusProfileImageSettings {

--- a/ui/app/mainui/activitycenter/views/ActivityNotificationContactRequest.qml
+++ b/ui/app/mainui/activitycenter/views/ActivityNotificationContactRequest.qml
@@ -36,8 +36,8 @@ ActivityNotificationMessage {
     messageDetails.messageText: !root.isOutgoingMessage && notification ? notification.message.messageText : ""
 
     messageSubheaderComponent: StatusBaseText {
-        text: root.isOutgoingMessage ? qsTr("Сontact request sent to %1").arg(contactName) :
-                                       qsTr("Сontact request:")
+        text: root.isOutgoingMessage ? qsTr("Contact request sent to %1").arg(contactDetails.fetching ? "..." : contactName) :
+                                       qsTr("Contact request:")
         font.italic: true
         font.pixelSize: 15
         maximumLineCount: 2

--- a/ui/app/mainui/activitycenter/views/ActivityNotificationMessage.qml
+++ b/ui/app/mainui/activitycenter/views/ActivityNotificationMessage.qml
@@ -32,10 +32,13 @@ ActivityNotificationBase {
         sender.trustIndicator: contactDetails ? contactDetails.trustStatus : Constants.trustStatus.unknown
         sender.isEnsVerified: !!contactDetails && contactDetails.ensVerified
         sender.isContact: !!contactDetails && contactDetails.isContact
+        sender.contactFetching: !!contactDetails && contactDetails.fetching
         sender.profileImage {
             width: 40
             height: 40
             name: contactDetails ? contactDetails.displayIcon : ""
+            assetSettings.bgWidth: 40
+            assetSettings.bgHeight: 40
             assetSettings.isImage: contactDetails && contactDetails.displayIcon.startsWith("data")
             pubkey: contactId
             colorId: Utils.colorIdForPubkey(contactId)

--- a/ui/imports/shared/popups/SendContactRequestModal.qml
+++ b/ui/imports/shared/popups/SendContactRequestModal.qml
@@ -71,6 +71,9 @@ StatusModal {
         target: root.rootStore.contactStore.contactsModule
 
         function onContactInfoRequestFinished(publicKey, ok) {
+            if (publicKey !== userPublicKey) {
+                return
+            }
             if (ok) {
                 const details = Utils.getContactDetailsAsJson(userPublicKey, false)
                 d.updateContactDetails(details)

--- a/ui/imports/shared/views/chat/SimplifiedMessageView.qml
+++ b/ui/imports/shared/views/chat/SimplifiedMessageView.qml
@@ -36,6 +36,7 @@ RowLayout {
             name: root.messageDetails.sender.displayName
             asset: root.messageDetails.sender.profileImage.assetSettings
             ringSettings: root.messageDetails.sender.profileImage.ringSettings
+            loading: root.messageDetails.sender.contactFetching
 
             MouseArea {
                 anchors.fill: parent

--- a/ui/imports/utils/Utils.qml
+++ b/ui/imports/utils/Utils.qml
@@ -417,6 +417,7 @@ QtObject {
             requestReceived: false,
             isSyncing: false,
             removed: false,
+            fetching: false,
             trustStatus: Constants.trustStatus.unknown,
             verificationStatus: Constants.verificationStatus.unverified,
             incomingVerificationStatus: Constants.verificationStatus.unverified


### PR DESCRIPTION
Fixes #10400

This calls `requestContactInfo` for all contacts for which we do not have the display name. While it does that, it sets `fetching`, a new client-side property, to let the UI know that this contact's info are being fetched.

That `fetching` property is used in the AC to show a loading state while it's fetching.

Once the fetching resolves, it removes the loaders and the contact info is updated.

Sadly, in some cases, the fetching can "fail", ie it might not find the info, so we just default back to the 3 word name. The reason for that is that those contacts have not been online for the last 7-9 days.

This screen capture, I kinda cheat. I have a contact I know doesn't resolve, but I still set the display name to show the loading to update flow.

[loadingcontact.webm](https://github.com/status-im/status-desktop/assets/11926403/62510f13-ca05-48b4-9b6e-972dde413678)

