### PR TITLE
Retrieve community token contract addresses from token metadata

### DIFF
--- a/src/app/modules/main/chat_section/controller.nim
+++ b/src/app/modules/main/chat_section/controller.nim
@@ -653,7 +653,7 @@ proc getTokenDecimals*(self: Controller, symbol: string): int =
 
 proc getContractAddressesForToken*(self: Controller, symbol: string): Table[int, string] =
   var contractAddresses = self.tokenService.getContractAddressesForToken(symbol)
-  let communityToken = self.communityTokensService.getCommunityTokenBySymbol(self.getMySectionId(), symbol)
+  let communityToken = self.communityService.getCommunityTokenBySymbol(self.getMySectionId(), symbol)
   if communityToken.address != "":
     contractAddresses[communityToken.chainId] = communityToken.address
   return contractAddresses

--- a/src/app_service/service/community/service.nim
+++ b/src/app_service/service/community/service.nim
@@ -2,6 +2,7 @@ import NimQml, Tables, json, sequtils, std/sets, std/algorithm, strformat, strut
 import json_serialization/std/tables as ser_tables
 
 import ./dto/community as community_dto
+import ../community_tokens/dto/community_token as community_token_dto
 
 import ../activity_center/service as activity_center_service
 import ../message/service as message_service
@@ -681,6 +682,22 @@ QtObject:
 
   proc getCommunityIds*(self: Service): seq[string] =
     return toSeq(self.communities.keys)
+
+  proc getCommunityTokenBySymbol*(self: Service, communityId: string, symbol: string): CommunityTokenDto =
+    let community = self.getCommunityById(communityId)
+    for metadata in community.communityTokensMetadata:
+      if metadata.symbol == symbol:
+        var communityToken = CommunityTokenDto()
+        communityToken.name = metadata.name
+        communityToken.symbol = metadata.symbol
+        communityToken.description = metadata.description
+        communityToken.tokenType = metadata.tokenType
+
+        for chainId, contractAddress in metadata.addresses:
+          communityToken.chainId = chainId
+          communityToken.address = contractAddress
+          break
+        return communityToken
 
   proc sortAsc[T](t1, t2: T): int =
     if(t1.position > t2.position):


### PR DESCRIPTION
Prior to this change, the control node would try to fetch the community token data from its database entries.

However, when a community has been recovered from importing an account via seedphrase, the database for community tokens will be empty.

So it's better to retrieve the contract addresses from the community description's metadata (which should always be there).

This change determines the community token from the community metadata.


