### PR TITLE
feat(Communities): Request to join should ask for a wallet password

### DIFF
--- a/ui/app/AppLayouts/Chat/views/CommunityColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/CommunityColumnView.qml
@@ -106,7 +106,7 @@ Item {
 
                 onJoined: {
                     joinCommunityButton.loading = true
-                    root.store.requestToJoinCommunity(communityData.id, root.store.userProfileInst.name)
+                    root.store.requestToJoinCommunityWithAuthentication(communityData.id, root.store.userProfileInst.name)
                 }
                 onCancelMembershipRequest: {
                     root.store.cancelPendingRequest(communityData.id)


### PR DESCRIPTION
Close #10853
Waits https://github.com/status-im/status-go/pull/3609

### What does the PR do

- [x] Use `requestToJoinCommunityWithAuthentication` for joining open communities

### Affected areas

Communities

### Screenshot of functionality (including design for comparison)


https://github.com/status-im/status-desktop/assets/2522130/ed6a8487-7537-460f-97e0-c0d2eb62ee06

