### PR TITLE
feat(communities): Adds mute community intervals

### DIFF
--- a/src/app/modules/main/chat_section/controller.nim
+++ b/src/app/modules/main/chat_section/controller.nim
@@ -636,8 +636,8 @@ proc muteCategory*(self: Controller, categoryId: string, interval: int) =
 proc unmuteCategory*(self: Controller, categoryId: string) =
   self.communityService.unmuteCategory(self.sectionId, categoryId)
 
-proc setCommunityMuted*(self: Controller, muted: bool) =
-  self.communityService.setCommunityMuted(self.sectionId, muted)
+proc setCommunityMuted*(self: Controller, mutedType: int) =
+  self.communityService.setCommunityMuted(self.sectionId, mutedType)
 
 proc inviteUsersToCommunity*(self: Controller, pubKeys: string, inviteMessage: string): string =
   result = self.communityService.inviteUsersToCommunityById(self.sectionId, pubKeys, inviteMessage)

--- a/src/app/modules/main/chat_section/io_interface.nim
+++ b/src/app/modules/main/chat_section/io_interface.nim
@@ -304,7 +304,7 @@ method unbanUserFromCommunity*(self: AccessInterface, pubKey: string) {.base.} =
 method exportCommunity*(self: AccessInterface): string {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method setCommunityMuted*(self: AccessInterface, muted: bool) {.base.} =
+method setCommunityMuted*(self: AccessInterface, mutedType: int) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method inviteUsersToCommunity*(self: AccessInterface, pubKeysJSON: string, inviteMessage: string): string {.base.} =

--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -1164,8 +1164,8 @@ method editCommunity*(self: Module, name: string,
 method exportCommunity*(self: Module): string =
   self.controller.exportCommunity()
 
-method setCommunityMuted*(self: Module, muted: bool) =
-  self.controller.setCommunityMuted(muted)
+method setCommunityMuted*(self: Module, mutedType: int) =
+  self.controller.setCommunityMuted(mutedType)
 
 method inviteUsersToCommunity*(self: Module, pubKeysJSON: string, inviteMessage: string): string =
   result = self.controller.inviteUsersToCommunity(pubKeysJSON, inviteMessage)

--- a/src/app/modules/main/chat_section/view.nim
+++ b/src/app/modules/main/chat_section/view.nim
@@ -324,8 +324,8 @@ QtObject:
   proc exportCommunity*(self: View): string {.slot.} =
     self.delegate.exportCommunity()
 
-  proc setCommunityMuted*(self: View, muted: bool) {.slot.} =
-    self.delegate.setCommunityMuted(muted)
+  proc setCommunityMuted*(self: View, mutedType: int) {.slot.} =
+    self.delegate.setCommunityMuted(mutedType)
 
   proc inviteUsersToCommunity*(self: View, pubKeysJSON: string, inviteMessage: string): string {.slot.} =
     result = self.delegate.inviteUsersToCommunity(pubKeysJSON, inviteMessage)

--- a/src/app/modules/main/communities/controller.nim
+++ b/src/app/modules/main/communities/controller.nim
@@ -210,8 +210,8 @@ proc requestCommunityInfo*(self: Controller, communityId: string, importing: boo
 proc importCommunity*(self: Controller, communityKey: string) =
   self.communityService.importCommunity(communityKey)
 
-proc setCommunityMuted*(self: Controller, communityId: string, muted: bool) =
-  self.communityService.setCommunityMuted(communityId, muted)
+proc setCommunityMuted*(self: Controller, communityId: string, mutedType: int) =
+  self.communityService.setCommunityMuted(communityId, mutedType)
 
 proc getContactNameAndImage*(self: Controller, contactId: string):
     tuple[name: string, image: string, largeImage: string] =

--- a/src/app/modules/main/profile_section/communities/controller.nim
+++ b/src/app/modules/main/profile_section/communities/controller.nim
@@ -23,6 +23,6 @@ proc inviteUsersToCommunity*(self: Controller, communityID: string, pubKeys: str
 proc leaveCommunity*(self: Controller, communityID: string) =
   self.communityService.leaveCommunity(communityID)
 
-method setCommunityMuted*(self: Controller, communityID: string, muted: bool) =
-  self.communityService.setCommunityMuted(communityID, muted)
+method setCommunityMuted*(self: Controller, communityID: string, mutedType: int) =
+  self.communityService.setCommunityMuted(communityID, mutedType)
 

--- a/src/app/modules/main/profile_section/communities/io_interface.nim
+++ b/src/app/modules/main/profile_section/communities/io_interface.nim
@@ -28,6 +28,6 @@ method inviteUsersToCommunity*(self: AccessInterface, communityID: string, pubKe
 method leaveCommunity*(self: AccessInterface, communityID: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method setCommunityMuted*(self: AccessInterface, communityID: string, muted: bool) {.base.} =
+method setCommunityMuted*(self: AccessInterface, communityID: string, mutedType: int) {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/profile_section/communities/module.nim
+++ b/src/app/modules/main/profile_section/communities/module.nim
@@ -48,5 +48,5 @@ method inviteUsersToCommunity*(self: Module, communityID: string, pubKeysJSON: s
 method leaveCommunity*(self: Module, communityID: string) =
   self.controller.leaveCommunity(communityID)
 
-method setCommunityMuted*(self: Module, communityID: string, muted: bool) =
-  self.controller.setCommunityMuted(communityID, muted)
+method setCommunityMuted*(self: Module, communityID: string, mutedType: int) =
+  self.controller.setCommunityMuted(communityID, mutedType)

--- a/src/app/modules/main/profile_section/communities/view.nim
+++ b/src/app/modules/main/profile_section/communities/view.nim
@@ -25,5 +25,5 @@ QtObject:
   method leaveCommunity*(self: View, communityID: string) {.slot.} =
     self.delegate.leaveCommunity(communityID)
 
-  method setCommunityMuted*(self: View, communityID: string, muted: bool) {.slot.} =
-    self.delegate.setCommunityMuted(communityID, muted)
+  method setCommunityMuted*(self: View, communityID: string, mutedType: int) {.slot.} =
+    self.delegate.setCommunityMuted(communityID, mutedType)

--- a/src/app_service/service/community/dto/community.nim
+++ b/src/app_service/service/community/dto/community.nim
@@ -16,6 +16,15 @@ type RequestToJoinType* {.pure.}= enum
   Accepted = 3,
   Canceled = 4
 
+type MutedType* {.pure.}= enum
+  For15min = 1,
+  For1hr = 2,
+  For8hr = 3,
+  For1week = 4,
+  TillUnmuted = 5,
+  For1min = 6,
+  Unmuted = 7
+
 type CommunityMembershipRequestDto* = object
   id*: string
   publicKey*: string

--- a/src/app_service/service/community/service.nim
+++ b/src/app_service/service/community/service.nim
@@ -1813,10 +1813,14 @@ QtObject:
     except Exception as e:
       error "Error banning user from community", msg = e.msg
 
-  proc setCommunityMuted*(self: Service, communityId: string, muted: bool) =
+  proc setCommunityMuted*(self: Service, communityId: string, mutedType: int) =
     try:
-      discard status_go.setCommunityMuted(communityId, muted)
-
+      let response = status_go.setCommunityMuted(communityId, mutedType)
+      if not response.error.isNil:
+        error "error muting the community", msg = response.error.message
+        return
+      
+      let muted = if (MutedType(mutedType) == MutedType.Unmuted): false else: true
       self.events.emit(SIGNAL_COMMUNITY_MUTED,
         CommunityMutedArgs(communityId: communityId, muted: muted))
     except Exception as e:

--- a/src/backend/communities.nim
+++ b/src/backend/communities.nim
@@ -370,8 +370,11 @@ proc unbanUserFromCommunity*(communityId: string, pubKey: string): RpcResponse[J
     "user": pubKey
   }])
 
-proc setCommunityMuted*(communityId: string, muted: bool): RpcResponse[JsonNode] {.raises: [Exception].}  =
-  return callPrivateRPC("setCommunityMuted".prefix, %*[communityId, muted])
+proc setCommunityMuted*(communityId: string, mutedType: int): RpcResponse[JsonNode] {.raises: [Exception].}  =
+  return callPrivateRPC("setCommunityMuted".prefix, %*[{ 
+    "communityId": communityId, 
+    "mutedType": mutedType 
+  }])
 
 proc inviteUsersToCommunity*(communityId: string, pubKeys: seq[string]): RpcResponse[JsonNode] {.raises: [Exception].} =
   return callPrivateRPC("inviteUsersToCommunity".prefix, %*[{

--- a/ui/app/AppLayouts/Profile/panels/CommunitiesListPanel.qml
+++ b/ui/app/AppLayouts/Profile/panels/CommunitiesListPanel.qml
@@ -9,15 +9,20 @@ import StatusQ.Popups 0.1
 
 import utils 1.0
 
+import shared.controls.chat.menuItems 1.0
+
 StatusListView {
     id: root
 
     property bool hasAddedContacts: false
 
     signal inviteFriends(var communityData)
+
     signal closeCommunityClicked(string communityId)
     signal leaveCommunityClicked(string community, string communityId, string outroMessage)
-    signal setCommunityMutedClicked(string communityId, bool muted)
+
+    signal setCommunityMutedClicked(string communityId, int mutedType)
+
     signal setActiveCommunityClicked(string communityId)
 
     interactive: false
@@ -43,27 +48,50 @@ StatusListView {
         onClicked: setActiveCommunityClicked(model.id)
 
         components: [
-            StatusFlatButton {
-                anchors.verticalCenter: parent.verticalCenter
-                objectName: "CommunitiesListPanel_leaveCommunityPopupButton"
-                size: StatusBaseButton.Size.Small
-                type: StatusBaseButton.Type.Danger
-                borderColor: "transparent"
-                enabled: model.memberRole !== Constants.memberRole.owner
-                text: model.spectated ? qsTr("Close Community") : qsTr("Leave Community")
-                onClicked: model.spectated ? root.closeCommunityClicked(model.id) : root.leaveCommunityClicked(model.name, model.id, model.outroMessage)
-            },
+
             StatusFlatButton {
                 anchors.verticalCenter: parent.verticalCenter
                 size: StatusBaseButton.Size.Small
-                icon.name: model.muted ? "notification-muted" : "notification"
-                onClicked: root.setCommunityMutedClicked(model.id, !model.muted)
-            },
-            StatusFlatButton {
-                anchors.verticalCenter: parent.verticalCenter
-                size: StatusBaseButton.Size.Small
-                icon.name: "invite-users"
-                onClicked: root.inviteFriends(model)
+                icon.name: "dots-icon"
+                onClicked: menu.popup(0, height)
+
+                property StatusMenu menu: StatusMenu {
+                    id: communityContextMenu
+                    width: 180
+
+                    StatusAction {
+                        text: qsTr("Invite People")
+                        icon.name: "share-ios"
+                        enabled: model.canManageUsers
+                        onTriggered: root.inviteFriends(model)
+                    }
+
+                    MuteChatMenuItem {
+                        enabled: !model.muted
+                        title: qsTr("Mute Community")
+                        onMuteTriggered: {
+                            root.setCommunityMutedClicked(model.id, interval)
+                            communityContextMenu.close()
+                        }
+                    }
+
+                    StatusAction {
+                        enabled: model.muted
+                        text: qsTr("Unmute Community")
+                        icon.name: "notification-muted"
+                        onTriggered: root.setCommunityMutedClicked(model.id, Constants.MutingVariations.Unmuted)
+                    }
+
+                    StatusMenuSeparator {}
+
+                    StatusAction {
+                        text: model.spectated ? qsTr("Close Community") : qsTr("Leave Community")
+                        icon.name: "arrow-left"
+                        type: StatusAction.Type.Danger
+                        onTriggered: model.spectated ? root.closeCommunityClicked(model.id)
+                                                     : root.leaveCommunityClicked(model.name, model.id, model.outroMessage)
+                    }
+                }
             }
         ]
     }

--- a/ui/app/AppLayouts/Profile/views/CommunitiesView.qml
+++ b/ui/app/AppLayouts/Profile/views/CommunitiesView.qml
@@ -124,7 +124,7 @@ SettingsContentBase {
                 }
 
                 onSetCommunityMutedClicked: {
-                    root.profileSectionStore.communitiesProfileModule.setCommunityMuted(communityId, muted)
+                    root.profileSectionStore.communitiesProfileModule.setCommunityMuted(communityId, mutedType)
                 }
 
                 onSetActiveCommunityClicked: {

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -17,6 +17,7 @@ import AppLayouts.CommunitiesPortal 1.0
 import utils 1.0
 import shared 1.0
 import shared.controls 1.0
+import shared.controls.chat.menuItems 1.0
 import shared.panels 1.0
 import shared.popups 1.0
 import shared.popups.keycard 1.0
@@ -327,7 +328,7 @@ Item {
                 popupMenu: Component {
                     StatusMenu {
                         id: communityContextMenu
-
+                        width: 180
                         property var chatCommunitySectionModule
 
                         openHandler: function () {
@@ -356,11 +357,21 @@ Item {
 
                         StatusMenuSeparator {}
 
+                        MuteChatMenuItem {
+                            enabled: !model.muted
+                            title: qsTr("Mute Community")
+                            onMuteTriggered: {
+                                communityContextMenu.chatCommunitySectionModule.setCommunityMuted(interval)
+                                communityContextMenu.close()
+                            }
+                        }
+
                         StatusAction {
-                            text: model.muted ? qsTr("Unmute Community") : qsTr("Mute Community")
-                            icon.name: model.muted ? "notification-muted" : "notification"
+                            enabled: model.muted
+                            text: qsTr("Unmute Community")
+                            icon.name: "notification-muted"
                             onTriggered: {
-                                communityContextMenu.chatCommunitySectionModule.setCommunityMuted(!model.muted)
+                                communityContextMenu.chatCommunitySectionModule.setCommunityMuted(Constants.MutingVariations.Unmuted)
                             }
                         }
 

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -1078,6 +1078,7 @@ QtObject {
         For8hr = 3,
         For1week = 4,
         TillUnmuted = 5,
-        For1min = 6
+        For1min = 6,
+        Unmuted = 7
     }
 }


### PR DESCRIPTION
Fixes: #9369

### What does the PR do

Now community can be muted for some intervals

### Affected areas

Communities

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

- [ ] I've checked the design and this PR matches it

![Снимок экрана 2023-06-07 в 13 43 40](https://github.com/status-im/status-desktop/assets/82511785/fbf4c83a-b7af-485c-ae3e-8bf95266a00a)

![Снимок экрана 2023-06-07 в 13 43 49](https://github.com/status-im/status-desktop/assets/82511785/690b01cf-7450-4709-92e0-35979c7f3994)

