### PR TITLE
fix(@desktop/wallet): Several fixes + rename rules

### DIFF
--- a/ui/app/AppLayouts/Wallet/addaccount/states/Main.qml
+++ b/ui/app/AppLayouts/Wallet/addaccount/states/Main.qml
@@ -25,7 +25,7 @@ Item {
             colorSelection.selectedColorIndex = Math.floor(Math.random() * colorSelection.model.length)
         }
         else {
-            let ind = d.evaluateColorIndex(root.store.addAccountModule.selectedColorId)
+            let ind = d.evaluateColorIndex(Utils.getColorForId(root.store.addAccountModule.selectedColorId))
             colorSelection.selectedColorIndex = ind
         }
 
@@ -130,8 +130,8 @@ Item {
                         errorMessage: Utils.getErrorMessage(accountName.errors, qsTr("wallet account name"))
                     },
                     StatusRegularExpressionValidator {
-                        regularExpression: Constants.regularExpressions.alphanumerical
-                        errorMessage: Constants.errorMessages.alphanumericalRegExp
+                        regularExpression: Constants.regularExpressions.alphanumericalWithSpace
+                        errorMessage: Constants.errorMessages.alphanumericalWithSpaceRegExp
                     }
                 ]
 

--- a/ui/app/AppLayouts/Wallet/views/LeftTabView.qml
+++ b/ui/app/AppLayouts/Wallet/views/LeftTabView.qml
@@ -198,7 +198,7 @@ Rectangle {
                 readonly property bool itemLoaded: !model.assetsLoading // needed for e2e tests
                 width: ListView.view.width - Style.current.padding * 2
                 highlighted: !ListView.view.footerItem.button.highlighted &&
-                             RootStore.overview.name === model.name
+                             RootStore.overview.mixedcaseAddress.toLowerCase() === model.address.toLowerCase()
                 anchors.horizontalCenter: !!parent ? parent.horizontalCenter : undefined
                 title: model.name
                 subTitle: LocaleUtils.currencyAmountToLocaleString(model.currencyBalance)

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -596,6 +596,7 @@ QtObject {
     readonly property QtObject regularExpressions: QtObject {
         readonly property var alphanumerical: /^$|^[a-zA-Z0-9]+$/
         readonly property var alphanumericalExpanded: /^$|^[a-zA-Z0-9\-_ ]+$/
+        readonly property var alphanumericalWithSpace: /^$|^[a-zA-Z0-9\s]+$/
         readonly property var asciiPrintable:         /^$|^[!-~]+$/
         readonly property var ascii:                  /^$|^[\x00-\x7F]+$/
         readonly property var capitalOnly: /^$|^[A-Z]+$/
@@ -604,6 +605,7 @@ QtObject {
 
     readonly property QtObject errorMessages: QtObject {
         readonly property string alphanumericalRegExp: qsTr("Only letters and numbers allowed")
+        readonly property string alphanumericalWithSpaceRegExp: qsTr("Special characters are not allowed")
         readonly property string alphanumericalExpandedRegExp: qsTr("Only letters, numbers, underscores, whitespaces and hyphens allowed")
         readonly property string asciiRegExp: qsTr("Only letters, numbers and ASII characters allowed")
     }


### PR DESCRIPTION
fixes #10908 

### What does the PR do

* proper account color wasn't selected when opening edit account modal
* account name wasn't allowed to use space
* having at least 2 accounts to same name, on selection all accounts with same name would be highlighted

### Affected areas

* Add account popup
* Wallet view

### Screenshot of functionality (including design for comparison)


https://github.com/status-im/status-desktop/assets/11396062/e325c33c-9ea0-4c79-b592-0b4fb846d300


