### PR TITLE
MintToken: Mint token views refactor / enable retry / validation bugs / qml warnings

### DIFF
--- a/storybook/pages/CommunityMintTokensSettingsPanelPage.qml
+++ b/storybook/pages/CommunityMintTokensSettingsPanelPage.qml
@@ -45,7 +45,6 @@ SplitView {
             onMintCollectible: logs.logEvent("CommunityMintTokensSettingsPanel::mintCollectible")
             onMintAsset: logs.logEvent("CommunityMintTokensSettingsPanel::mintAssets")
             onDeleteToken: logs.logEvent("CommunityMintTokensSettingsPanel::deleteToken: " + key)
-            onRetryMintToken: logs.logEvent("CommunityMintTokensSettingsPanel::retryMintToken: " + key)
         }
     }
 

--- a/storybook/pages/CommunityMintedTokensViewPage.qml
+++ b/storybook/pages/CommunityMintedTokensViewPage.qml
@@ -28,7 +28,7 @@ SplitView {
                 anchors.fill: parent
                 anchors.margins: 50
                 model: MintedTokensModel.mintedTokensModel
-                onItemClicked: logs.logEvent("CommunityMintedTokensView::itemClicked --> " + contractUniqueKey)
+                onItemClicked: logs.logEvent("CommunityMintedTokensView::itemClicked --> " + tokenKey)
             }
         }
 

--- a/storybook/pages/CommunityTokenViewPage.qml
+++ b/storybook/pages/CommunityTokenViewPage.qml
@@ -3,6 +3,7 @@ import QtQuick.Controls 2.14
 import QtQuick.Layouts 1.14
 
 import AppLayouts.Chat.views.communities 1.0
+import AppLayouts.Chat.helpers 1.0
 
 import StatusQ.Core 0.1
 
@@ -23,59 +24,59 @@ SplitView {
             SplitView.fillWidth: true
             SplitView.fillHeight: true
 
-            CommunityTokenView {
-                id: view
+            CollectibleObject {
+                id: collectibleObj
 
-                anchors.fill: parent
-                anchors.margins: 50
                 artworkSource: ModelsData.icons.superRare
-                preview: previewBox.checked
-                isAssetView: isAssetBox.checked
                 remotelyDestructState: remotelyDestructStateBox.checked ? 1 /*In progress*/ : 2 /*Completed*/
                 burnState: burnDestructStateBox.checked ? 1 /*In progress*/ : 2 /*Completed*/
                 name: nameText.text
                 symbol: symbolText.text
                 description: descriptionText.text
-                supplyAmount: parseInt(supplyText.text)
+                supply: parseInt(supplyText.text)
                 infiniteSupply: unlimitedSupplyChecker.checked
-                assetDecimals: parseInt(decimalText.text)
                 remainingTokens: parseInt(remainingText.text)
                 transferable: transferibleChecker.checked
-                selfDestruct: selfdestructChecker.checked
+                remotelyDestruct: selfdestructChecker.checked
                 chainId: 1
                 chainName: "Ethereum Mainnet"
                 chainIcon: ModelsData.networks.ethereum
                 accountName: "helloworld"
-
-                tokenOwnersModel: TokenHoldersModel {
-
-                }
-
-                onMintCollectible: logs.logEvent("CommunityTokenView::onMintCollectible: \n"
-                                                 + "artworkSource: " + artworkSource + "\n"
-                                                 + "name: " + name + "\n"
-                                                 + "symbol: " + symbol + "\n"
-                                                 + "description: " + description + "\n"
-                                                 + "supply: " + supply + "\n"
-                                                 + "infiniteSupply: " + infiniteSupply + "\n"
-                                                 + "transferable: " + transferable + "\n"
-                                                 + "selfDestruct: " + selfDestruct + "\n"
-                                                 + "chainId: " + chainId + "\n"
-                                                 + "accountName: " + accountName)
-
-                onMintAsset: logs.logEvent("CommunityTokenView::onMintAsset: \n"
-                                           + "artworkSource: " + artworkSource + "\n"
-                                           + "name: " + name + "\n"
-                                           + "symbol: " + symbol + "\n"
-                                           + "description: " + description + "\n"
-                                           + "supply: " + supply + "\n"
-                                           + "infiniteSupply: " + infiniteSupply + "\n"
-                                           + "decimals: " + decimals + "\n"
-                                           + "chainId: " + chainId + "\n"
-                                           + "accountName: " + accountName)
             }
+
+            AssetObject {
+                id: assetObj
+
+                artworkSource: ModelsData.icons.superRare
+                burnState: burnDestructStateBox.checked ? 1 /*In progress*/ : 2 /*Completed*/
+                name: nameText.text
+                symbol: symbolText.text
+                description: descriptionText.text
+                supply: parseInt(supplyText.text)
+                infiniteSupply: unlimitedSupplyChecker.checked
+                decimals: parseInt(decimalText.text)
+                remainingTokens: parseInt(remainingText.text)
+                chainId: 1
+                chainName: "Ethereum Mainnet"
+                chainIcon: ModelsData.networks.ethereum
+                accountName: "helloworld"
+            }
+
+            CommunityTokenView {
+                id: view
+
+                anchors.fill: parent
+                anchors.margins: 50
+                preview: previewBox.checked
+                isAssetView: isAssetBox.checked
+                collectible: collectibleObj
+                asset: assetObj
+                tokenOwnersModel: TokenHoldersModel {}
+                
+                onMintClicked: logs.logEvent("CommunityTokenView::onMintClicked")
         }
 
+        }
         LogsAndControlsPanel {
             id: logsAndControlsPanel
 
@@ -119,20 +120,29 @@ SplitView {
                     RadioButton {
                         id: mintingInProgress
                         text: "In progress"
-                        onCheckedChanged: if(checked) view.deployState = Constants.ContractTransactionStatus.InProgress
+                        onCheckedChanged: {
+                            if(view.isAssetView) assetObj.deployState = Constants.ContractTransactionStatus.InProgress
+                            else collectibleObj.deployState = Constants.ContractTransactionStatus.InProgress
+                        }
                     }
 
                     RadioButton {
                         id: mintingFailed
                         text: "Failed"
-                        onCheckedChanged: if(checked) view.deployState = Constants.ContractTransactionStatus.Failed
+                        onCheckedChanged: {
+                            if(view.isAssetView) assetObj.deployState = Constants.ContractTransactionStatus.Failed
+                            else collectibleObj.deployState = Constants.ContractTransactionStatus.Failed
+                        }
                     }
 
                     RadioButton {
                         id: mintingCompleted
                         text: "Completed"
                         checked: true
-                        onCheckedChanged: if(checked) view.deployState = Constants.ContractTransactionStatus.Completed
+                        onCheckedChanged: {
+                            if(view.isAssetView) assetObj.deployState = Constants.ContractTransactionStatus.Completed
+                            else collectibleObj.deployState = Constants.ContractTransactionStatus.Completed
+                        }
                     }
                 }
 
@@ -158,17 +168,26 @@ SplitView {
                 RadioButton {
                     text: "Small"
                     checked: true
-                    onCheckedChanged: view.artworkSource = ModelsData.icons.superRare
+                    onCheckedChanged: {
+                        if(view.isAssetView) assetObj.artworkSource = ModelsData.icons.superRare
+                        else collectibleObj.artworkSource = ModelsData.icons.superRare
+                    }
                 }
 
                 RadioButton {
                     text: "Medium"
-                    onCheckedChanged: view.artworkSource = ModelsData.collectibles.kitty2Big
+                    onCheckedChanged: {
+                        if(view.isAssetView) assetObj.artworkSource = ModelsData.collectibles.kitty2Big
+                        else collectibleObj.artworkSource = ModelsData.collectibles.kitty2Big
+                    }
                 }
 
                 RadioButton {
                     text: "Large"
-                    onCheckedChanged: view.artworkSource = ModelsData.banners.superRare
+                    onCheckedChanged: {
+                        if(view.isAssetView) assetObj.artworkSource = ModelsData.banners.superRare
+                        else collectibleObj.artworkSource = ModelsData.banners.superRare
+                    }
                 }
 
                 Label {
@@ -280,9 +299,15 @@ SplitView {
                     text: "Ethereum Mainnet"
                     checked: true
                     onCheckedChanged:  {
-                        view.chainName = text
-                        view.chainIcon = ModelsData.networks.ethereum
-                        view.chainId = 1
+                        if(view.isAssetView) {
+                            assetObj.chainName = text
+                            assetObj.chainIcon = ModelsData.networks.ethereum
+                            assetObj.chainId = 1
+                        } else {
+                            collectibleObj.chainName = text
+                            collectibleObj.chainIcon = ModelsData.networks.ethereum
+                            collectibleObj.chainId = 1
+                        }
                     }
                 }
 
@@ -290,9 +315,15 @@ SplitView {
                     id: opt
                     text: "Optimism"
                     onCheckedChanged:  {
-                        view.chainName = text
-                        view.chainIcon = ModelsData.networks.optimism
-                        view.chainId = 2
+                        if(view.isAssetView) {
+                            assetObj.chainName = text
+                            assetObj.chainIcon = ModelsData.networks.optimism
+                            assetObj.chainId = 2
+                        } else {
+                            collectibleObj.chainName = text
+                            collectibleObj.chainIcon = ModelsData.networks.optimism
+                            collectibleObj.chainId = 2
+                        }
                     }
                 }
 
@@ -300,9 +331,15 @@ SplitView {
                     id: arb
                     text: "Arbitrum"
                     onCheckedChanged:  {
-                        view.chainName = text
-                        view.chainIcon = ModelsData.networks.arbitrum
-                        view.chainId = 3
+                        if(view.isAssetView) {
+                            assetObj.chainName = text
+                            assetObj.chainIcon = ModelsData.networks.arbitrum
+                            assetObj.chainId = 3
+                        } else {
+                            collectibleObj.chainName = text
+                            collectibleObj.chainIcon = ModelsData.networks.arbitrum
+                            collectibleObj.chainId = 3
+                        }
                     }
                 }
             }

--- a/storybook/src/Models/MintedTokensModel.qml
+++ b/storybook/src/Models/MintedTokensModel.qml
@@ -55,7 +55,7 @@ QtObject {
                                               tokenType: 2,
                                               name: "Kitty artwork",
                                               image: ModelsData.collectibles.kitty1Big,
-                                              deployState: 2,
+                                              deployState: 0,
                                               symbol: "KAT",
                                               description: "Desc",
                                               supply: 10,

--- a/storybook/src/Models/WalletAccountsModel.qml
+++ b/storybook/src/Models/WalletAccountsModel.qml
@@ -1,6 +1,6 @@
 import QtQuick 2.15
 
 ListModel {
-    ListElement { name: "Test account"; emoji: "😋"; color: "red"; address: "0x7F47C2e18a4BBf5487E6fb082eC2D9Ab0E6d7240" }
-    ListElement { name: "Another account"; emoji: "🚗"; color: "blue"; address: "0x7F47C2e98a4BBf5487E6fb082eC2D9Ab0E6d8888"  }
+    ListElement { name: "Test account"; emoji: "😋"; colorId: "primary"; address: "0x7F47C2e18a4BBf5487E6fb082eC2D9Ab0E6d7240" }
+    ListElement { name: "Another account"; emoji: "🚗"; colorId: "army"; address: "0x7F47C2e98a4BBf5487E6fb082eC2D9Ab0E6d8888"  }
 }

--- a/ui/app/AppLayouts/Chat/helpers/AssetObject.qml
+++ b/ui/app/AppLayouts/Chat/helpers/AssetObject.qml
@@ -1,0 +1,15 @@
+import QtQuick 2.15
+
+/*!
+    \qmltype AssetObject
+    \inherits TokenObject
+    \brief ERC20 token object properties definition (also known as asset).
+*/
+TokenObject {
+    property int decimals: 2 // Default value
+
+    function copyAsset(tokenObject) {
+        copyToken(tokenObject)
+        decimals = tokenObject.decimals
+    }
+}

--- a/ui/app/AppLayouts/Chat/helpers/CollectibleObject.qml
+++ b/ui/app/AppLayouts/Chat/helpers/CollectibleObject.qml
@@ -1,0 +1,21 @@
+import QtQuick 2.15
+
+import utils 1.0
+
+/*!
+    \qmltype CollectibleObject
+    \inherits TokenObject
+    \brief ERC721 token object properties definition (also known as collectible).
+*/
+TokenObject {
+    property bool transferable: false
+    property bool remotelyDestruct: true
+    property int remotelyDestructState: Constants.ContractTransactionStatus.None
+
+    function copyCollectible(tokenObject) {
+        copyToken(tokenObject)
+        transferable = tokenObject.transferable
+        remotelyDestruct = tokenObject.remotelyDestruct
+        remotelyDestructState = tokenObject.remotelyDestructState
+    }
+}

--- a/ui/app/AppLayouts/Chat/helpers/TokenObject.qml
+++ b/ui/app/AppLayouts/Chat/helpers/TokenObject.qml
@@ -1,0 +1,57 @@
+import QtQuick 2.15
+
+import utils 1.0
+
+/*!
+    \qmltype TokenObject
+    \inherits QtObject
+    \brief Token object properties definition.
+*/
+QtObject {
+    // Unique identifier:
+    property string key
+
+    // General descriptive properties:
+    property string name
+    property string symbol
+    property string description
+    property bool infiniteSupply: true
+    property int supply: 1
+    property int remainingTokens
+
+    // Artwork related properties:
+    property url artworkSource
+    property rect artworkCropRect: Qt.rect(0, 0, 0, 0)
+
+    // Network related properties:
+    property int chainId
+    property string chainName
+    property string chainIcon
+
+    // Account related properties (from where they will be / have been deployed):
+    property string accountAddress
+    property string accountName
+
+    // Contract transactions states:
+    property int deployState: Constants.ContractTransactionStatus.None
+    property int burnState: Constants.ContractTransactionStatus.None
+
+    function copyToken(tokenObject) {
+        key = tokenObject.key
+        name = tokenObject.name
+        symbol = tokenObject.symbol
+        description = tokenObject.description
+        infiniteSupply = tokenObject.infiniteSupply
+        supply = tokenObject.supply
+        remainingTokens = tokenObject.remainingTokens
+        artworkSource = tokenObject.artworkSource
+        artworkCropRect = tokenObject.artworkCropRect
+        chainId = tokenObject.chainId
+        chainName = tokenObject.chainName
+        chainIcon = tokenObject.chainIcon
+        accountAddress = tokenObject.accountAddress
+        accountName = tokenObject.accountName
+        deployState = tokenObject.deployState
+        burnState = tokenObject.burnState
+    }
+}

--- a/ui/app/AppLayouts/Chat/helpers/qmldir
+++ b/ui/app/AppLayouts/Chat/helpers/qmldir
@@ -1,1 +1,4 @@
 singleton CommunityPermissionsHelpers 1.0 CommunityPermissionsHelpers.qml
+AssetObject 1.0 AssetObject.qml
+CollectibleObject 1.0 CollectibleObject.qml
+TokenObject 1.0 TokenObject.qml

--- a/ui/app/AppLayouts/Chat/panels/communities/CommunityAirdropsSettingsPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/CommunityAirdropsSettingsPanel.qml
@@ -29,8 +29,8 @@ SettingsPageLayout {
         stackManager.pop(StackView.Immediate)
     }
 
-    function selectCollectible(key, amount) {
-        d.selectCollectible(key, amount)
+    function selectToken(key, amount, type) {
+        d.selectToken(key, amount, type)
     }
 
     function addAddresses(addresses) {
@@ -46,7 +46,7 @@ SettingsPageLayout {
         readonly property string welcomePageTitle: qsTr("Airdrops")
         readonly property string newAirdropViewPageTitle: qsTr("New airdrop")
 
-        signal selectCollectible(string key, int amount)
+        signal selectToken(string key, int amount, int type)
         signal addAddresses(var addresses)
     }
 
@@ -116,7 +116,7 @@ SettingsPageLayout {
             onNavigateToMintTokenSettings: root.navigateToMintTokenSettings()
 
             Component.onCompleted: {
-                d.selectCollectible.connect(view.selectCollectible)
+                d.selectToken.connect(view.selectToken)
                 d.addAddresses.connect(view.addAddresses)
             }
         }

--- a/ui/app/AppLayouts/Chat/panels/communities/CommunityMintTokensSettingsPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/CommunityMintTokensSettingsPanel.qml
@@ -83,7 +83,7 @@ SettingsPageLayout {
         property var tokenOwnersModel
         property var remotelyDestructTokensList
         property bool remotelyDestruct
-        property bool burnEnabled
+        property bool burnVisible
         property string tokenKey
         property int burnAmount
         property int remainingTokens
@@ -397,16 +397,20 @@ SettingsPageLayout {
         MintTokensFooterPanel {
             id: footerPanel
 
+            readonly property bool deployStateFailed : (!!d.currentToken) ? d.currentToken.deployState === Constants.ContractTransactionStatus.Failed : false
+
             function closePopups() {
                 remotelyDestructPopup.close()
                 alertPopup.close()
                 signTransactionPopup.close()
             }
 
-            airdropEnabled: true
-            retailEnabled: false
-            remotelySelfDestructVisible: d.remotelyDestruct
-            burnVisible: d.burnEnabled
+            airdropEnabled: !deployStateFailed
+            remotelyDestructEnabled: !deployStateFailed
+            burnEnabled: !deployStateFailed
+
+            remotelyDestructVisible: d.remotelyDestruct
+            burnVisible: d.burnVisible
 
             onAirdropClicked: d.airdropClicked()
             onRemotelyDestructClicked: remotelyDestructPopup.open()
@@ -589,7 +593,7 @@ SettingsPageLayout {
 
             Binding {
                 target: d
-                property: "burnEnabled"
+                property: "burnVisible"
                 value: !view.infiniteSupply
                 restoreMode: Binding.RestoreBindingOrValue
             }

--- a/ui/app/AppLayouts/Chat/panels/communities/CommunityMintTokensSettingsPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/CommunityMintTokensSettingsPanel.qml
@@ -112,8 +112,8 @@ SettingsPageLayout {
     QtObject {
         id: temp_
 
-        property CollectibleObject collectible: CollectibleObject{}
-        property AssetObject asset: AssetObject{}
+        readonly property CollectibleObject collectible: CollectibleObject{}
+        readonly property AssetObject asset: AssetObject{}
     }
 
     secondaryHeaderButton.type: StatusBaseButton.Type.Danger
@@ -165,8 +165,7 @@ SettingsPageLayout {
         if(root.state == d.tokenViewState) {
             if(d.currentToken) {
                 if(d.isAssetType) {
-                    // Create new asset instance:
-                    temp_.asset.clearAsset()
+                    // Copy current data:
                     temp_.asset.copyAsset(d.currentToken)
 
                     // Update to point to new instance
@@ -187,8 +186,7 @@ SettingsPageLayout {
                                       },
                                       StackView.Immediate)
                 } else {
-                    // Create new collectible instance:
-                    temp_.collectible.clearCollectible()
+                    // Copy current data:
                     temp_.collectible.copyCollectible(d.currentToken)
 
                     // Update to point to new instance
@@ -245,7 +243,7 @@ SettingsPageLayout {
         id: newTokenView
 
         ColumnLayout {
-            id: _colLayout
+            id: colLayout
 
             property CollectibleObject collectible: CollectibleObject{}
             property AssetObject asset: AssetObject{}
@@ -261,7 +259,7 @@ SettingsPageLayout {
                 id: optionsTab
 
                 Layout.preferredWidth: root.viewWidth
-                currentIndex: _colLayout.isAssetView ? 1 : 0
+                currentIndex: colLayout.isAssetView ? 1 : 0
 
                 StatusSwitchTabButton {
                     id: collectiblesTab
@@ -286,20 +284,20 @@ SettingsPageLayout {
                     id: newCollectibleView
 
                     isAssetView: false
-                    validationMode: !_colLayout.isAssetView ? _colLayout.validationMode : StatusInput.ValidationMode.OnlyWhenDirty
-                    collectible: _colLayout.collectible
-                    referenceName: _colLayout.referenceName
-                    referenceSymbol: _colLayout.referenceSymbol
+                    validationMode: !colLayout.isAssetView ? colLayout.validationMode : StatusInput.ValidationMode.OnlyWhenDirty
+                    collectible: colLayout.collectible
+                    referenceName: colLayout.referenceName
+                    referenceSymbol: colLayout.referenceSymbol
                 }
 
                 CustomCommunityNewTokenView {
                     id: newAssetView
 
                     isAssetView: true
-                    validationMode: _colLayout.isAssetView ? _colLayout.validationMode : StatusInput.ValidationMode.OnlyWhenDirty
-                    asset: _colLayout.asset
-                    referenceName: _colLayout.referenceName
-                    referenceSymbol: _colLayout.referenceSymbol
+                    validationMode: colLayout.isAssetView ? colLayout.validationMode : StatusInput.ValidationMode.OnlyWhenDirty
+                    asset: colLayout.asset
+                    referenceName: colLayout.referenceName
+                    referenceSymbol: colLayout.referenceSymbol
                 }
 
                 component CustomCommunityNewTokenView: CommunityNewTokenView {
@@ -317,7 +315,7 @@ SettingsPageLayout {
                         stackManager.push(d.previewTokenViewState,
                                           previewTokenView,
                                           {
-                                              preview : true,
+                                              preview: true,
                                               isAssetView,
                                               asset,
                                               collectible

--- a/ui/app/AppLayouts/Chat/panels/communities/CommunityMintTokensSettingsPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/CommunityMintTokensSettingsPanel.qml
@@ -180,6 +180,9 @@ SettingsPageLayout {
                                       newTokenView,
                                       {
                                           isAssetView: d.isAssetType,
+                                          referenceName: d.currentToken.name,
+                                          referenceSymbol: d.currentToken.symbol,
+                                          validationMode: StatusInput.ValidationMode.Always,
                                           asset: d.currentToken
                                       },
                                       StackView.Immediate)
@@ -199,6 +202,9 @@ SettingsPageLayout {
                                       newTokenView,
                                       {
                                           isAssetView: d.isAssetType,
+                                          referenceName: d.currentToken.name,
+                                          referenceSymbol: d.currentToken.symbol,
+                                          validationMode: StatusInput.ValidationMode.Always,
                                           collectible: d.currentToken
                                       },
                                       StackView.Immediate)
@@ -244,6 +250,9 @@ SettingsPageLayout {
             property CollectibleObject collectible: CollectibleObject{}
             property AssetObject asset: AssetObject{}
             property bool isAssetView: false
+            property int validationMode: StatusInput.ValidationMode.OnlyWhenDirty
+            property string referenceName: ""
+            property string referenceSymbol: ""
 
             width: root.viewWidth
             spacing: Style.current.padding
@@ -277,14 +286,20 @@ SettingsPageLayout {
                     id: newCollectibleView
 
                     isAssetView: false
+                    validationMode: !_colLayout.isAssetView ? _colLayout.validationMode : StatusInput.ValidationMode.OnlyWhenDirty
                     collectible: _colLayout.collectible
+                    referenceName: _colLayout.referenceName
+                    referenceSymbol: _colLayout.referenceSymbol
                 }
 
                 CustomCommunityNewTokenView {
                     id: newAssetView
 
                     isAssetView: true
+                    validationMode: _colLayout.isAssetView ? _colLayout.validationMode : StatusInput.ValidationMode.OnlyWhenDirty
                     asset: _colLayout.asset
+                    referenceName: _colLayout.referenceName
+                    referenceSymbol: _colLayout.referenceSymbol
                 }
 
                 component CustomCommunityNewTokenView: CommunityNewTokenView {

--- a/ui/app/AppLayouts/Chat/panels/communities/MintTokensFooterPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/MintTokensFooterPanel.qml
@@ -13,7 +13,9 @@ Control {
 
     property alias airdropEnabled: airdropButton.enabled
     property alias retailEnabled: retailButton.enabled
-    property alias remotelySelfDestructVisible: remotelySelfDestructButton.visible
+    property alias remotelyDestructEnabled: remotelyDestructButton.enabled
+    property alias burnEnabled: burnButton.enabled
+    property alias remotelyDestructVisible: remotelyDestructButton.visible
     property alias burnVisible: burnButton.visible
 
     signal airdropClicked
@@ -55,7 +57,7 @@ Control {
             }
 
             StatusFlatButton {
-                id: remotelySelfDestructButton
+                id: remotelyDestructButton
 
                 icon.name: "remotely-destruct"
                 text: qsTr("Remotely destruct")

--- a/ui/app/AppLayouts/Chat/popups/community/RemotelyDestructPopup.qml
+++ b/ui/app/AppLayouts/Chat/popups/community/RemotelyDestructPopup.qml
@@ -20,7 +20,7 @@ StatusDialog {
 
     property string collectibleName
 
-    signal remotelyDestructClicked(int tokenCount, var selfDestructTokensList)
+    signal remotelyDestructClicked(int tokenCount, var remotelyDestructTokensList)
 
     QtObject {
         id: d

--- a/ui/app/AppLayouts/Chat/views/CommunitySettingsView.qml
+++ b/ui/app/AppLayouts/Chat/views/CommunitySettingsView.qml
@@ -305,48 +305,18 @@ StatusSectionLayout {
 
                 onPreviousPageNameChanged: root.backButtonName = previousPageName
                 onSignMintTransactionOpened: communityTokensStore.computeDeployFee(chainId, accountAddress)
-                onMintCollectible: {
-                    communityTokensStore.deployCollectible(root.community.id,
-                                                           accountAddress,
-                                                           name,
-                                                           symbol,
-                                                           description,
-                                                           supply,
-                                                           infiniteSupply,
-                                                           transferable,
-                                                           selfDestruct,
-                                                           chainId,
-                                                           artworkSource,
-                                                           accountName,
-                                                           artworkCropRect)
-                }
-                onMintAsset: {
-                    communityTokensStore.deployAsset(root.community.id,
-                                                     accountAddress,
-                                                     name,
-                                                     symbol,
-                                                     description,
-                                                     supply,
-                                                     infiniteSupply,
-                                                     decimals,
-                                                     chainId,
-                                                     artworkSource,
-                                                     accountName,
-                                                     artworkCropRect)
-                }
-                onSignSelfDestructTransactionOpened: communityTokensStore.computeSelfDestructFee(selfDestructTokensList, tokenKey)
-                onRemoteSelfDestructCollectibles: {
+                onMintCollectible: communityTokensStore.deployCollectible(root.community.id, collectibleItem)
+                onMintAsset: communityTokensStore.deployAsset(root.community.id, assetItem)
+                onSignRemoteDestructTransactionOpened: communityTokensStore.computeSelfDestructFee(remotelyDestructTokensList, tokenKey)
+                onRemotelyDestructCollectibles: {
                     communityTokensStore.remoteSelfDestructCollectibles(root.community.id,
-                                                                        selfDestructTokensList,
+                                                                        remotelyDestructTokensList,
                                                                         tokenKey)
                 }
                 onSignBurnTransactionOpened: communityTokensStore.computeBurnFee(chainId)
-                onBurnCollectibles: communityTokensStore.burnCollectibles(tokenKey, amount)
-                onAirdropCollectible: {
-                    root.goTo(Constants.CommunitySettingsSections.Airdrops)
-                }
+                onBurnToken: communityTokensStore.burnToken(tokenKey, amount)
+                onAirdropToken: root.goTo(Constants.CommunitySettingsSections.Airdrops)
                 onDeleteToken: communityTokensStore.deleteToken(root.community.id, tokenKey)
-                onRetryMintToken: communityTokensStore.retryMintToken(root.community.id, tokenKey)
 
                 Connections {
                     target: rootStore.communityTokensStore
@@ -480,13 +450,13 @@ StatusSectionLayout {
                 Connections {
                     target: mintPanel
 
-                    function onAirdropCollectible(key, addresses) {
+                    function onAirdropToken(tokenKey, type, addresses) {
                         // Here it is forced a navigation to the new airdrop form, like if it was clicked the header button
                         airdropPanel.primaryHeaderButtonClicked()
 
                         // Force a token selection to be airdroped with default amount 1
-                        airdropPanel.selectCollectible(key, 1)
-
+                        airdropPanel.selectToken(tokenKey, 1, type)
+                        
                         // Set given addresses as recipients
                         airdropPanel.addAddresses(addresses)
                     }

--- a/ui/app/AppLayouts/Chat/views/communities/CommunityMintedTokensView.qml
+++ b/ui/app/AppLayouts/Chat/views/communities/CommunityMintedTokensView.qml
@@ -17,7 +17,7 @@ StatusScrollView {
     property int viewWidth: 560 // by design
     property var model
 
-    signal itemClicked(string contractUniqueKey,
+    signal itemClicked(string tokenKey,
                        int chainId,
                        string chainName,
                        string accountName,

--- a/ui/app/AppLayouts/Chat/views/communities/CommunityNewAirdropView.qml
+++ b/ui/app/AppLayouts/Chat/views/communities/CommunityNewAirdropView.qml
@@ -37,11 +37,17 @@ StatusScrollView {
     signal airdropClicked(var airdropTokens, var addresses, var membersPubKeys)
     signal navigateToMintTokenSettings
 
-    function selectCollectible(key, amount) {
-        const modelItem = CommunityPermissionsHelpers.getTokenByKey(
-                            root.collectiblesModel, key)
+    function selectToken(key, amount, type) {
+        var tokenModel = null
+        if(type === Constants.TokenType.ERC20)
+            tokenModel = root.assetsModel
+        else if (type === Constants.TokenType.ERC721)
+            tokenModel = root.collectiblesModel
 
-        const entry = d.prepareEntry(key, amount)
+        const modelItem = CommunityPermissionsHelpers.getTokenByKey(
+                            tokenModel, key)
+
+        const entry = d.prepareEntry(key, amount, type)
         entry.valid = true
         selectedHoldingsModel.append(entry)
     }
@@ -57,9 +63,14 @@ StatusScrollView {
         readonly property int dropdownHorizontalOffset: 4
         readonly property int dropdownVerticalOffset: 1
 
-        function prepareEntry(key, amount) {
-            const modelItem = CommunityPermissionsHelpers.getTokenByKey(
-                                root.collectiblesModel, key)
+        function prepareEntry(key, amount, type) {
+            var tokenModel = null
+            if(type === Constants.TokenType.ERC20)
+                tokenModel = root.assetsModel
+            else if (type === Constants.TokenType.ERC721)
+                tokenModel = root.collectiblesModel
+
+            const modelItem = CommunityPermissionsHelpers.getTokenByKey(tokenModel, key)
 
             return {
                 key, amount,
@@ -170,7 +181,7 @@ StatusScrollView {
                 }
 
                 onAddCollectible: {
-                    const entry = d.prepareEntry(key, amount)
+                    const entry = d.prepareEntry(key, amount, Constants.TokenType.ERC721)
                     entry.valid = true
 
                     selectedHoldingsModel.append(entry)
@@ -180,7 +191,7 @@ StatusScrollView {
                 onUpdateCollectible: {
                     const itemIndex = prepareUpdateIndex(key)
 
-                    const entry = d.prepareEntry(key, amount)
+                    const entry = d.prepareEntry(key, amount, Constants.TokenType.ERC721)
                     const modelItem = CommunityPermissionsHelpers.getTokenByKey(
                                         root.collectiblesModel, key)
 

--- a/ui/app/AppLayouts/Chat/views/communities/CommunityNewTokenView.qml
+++ b/ui/app/AppLayouts/Chat/views/communities/CommunityNewTokenView.qml
@@ -72,7 +72,8 @@ StatusScrollView {
 
             Layout.fillWidth: true
             Layout.preferredHeight: d.imageSelectorRectWidth
-            artworkSource: root.isAssetView ? assetObj.artworkSource : collectibleObj.artworkSource
+            dataImage: root.isAssetView ? asset.artworkSource : collectible.artworkSource
+            artworkSource: root.isAssetView ? asset.artworkSource : collectible.artworkSource
             editorAnchorLeft: !root.isAssetView
             editorRoundedImage: root.isAssetView
             uploadTextLabel.uploadText: root.isAssetView ? qsTr("Upload") : qsTr("Drag and Drop or Upload Artwork")

--- a/ui/app/AppLayouts/Wallet/controls/NetworkFilter.qml
+++ b/ui/app/AppLayouts/Wallet/controls/NetworkFilter.qml
@@ -31,7 +31,8 @@ StatusComboBox {
 
         property string selectedChainName: ""
         property string selectedIconUrl: ""
-        readonly property bool allSelected: root.enabledNetworks.count === root.allNetworks.count
+        readonly property bool allSelected: (!!root.enabledNetworks && !!root.allNetworks) ? root.enabledNetworks.count === root.allNetworks.count :
+                                                                                             false
 
         // Persist selection between selectPopupLoader reloads
         property var currentModel: layer1Networks

--- a/ui/imports/shared/panels/DropAndEditImagePanel.qml
+++ b/ui/imports/shared/panels/DropAndEditImagePanel.qml
@@ -24,6 +24,7 @@ Item {
     property bool editorAnchorLeft: true
     property alias uploadTextLabel: textLabel
     property alias editorRoundedImage: editor.roundedImage
+    property alias dataImage: editor.dataImage
     property alias artworkSource: editor.source
     property alias artworkCropRect: editor.cropRect
     property alias editorTitle: editor.title
@@ -75,7 +76,7 @@ Item {
             id: textLabel
             width: parent.width
             anchors.centerIn: parent
-            visible: !editor.userSelectedImage
+            visible: !editor.userSelectedImage && !root.dataImage
             additionalTextPixelSize: Theme.secondaryTextFontSize
         }
     }

--- a/ui/imports/shared/stores/CommunityTokensStore.qml
+++ b/ui/imports/shared/stores/CommunityTokensStore.qml
@@ -23,31 +23,31 @@ QtObject {
     signal remoteDestructStateChanged(string communityId, string tokenName, int status, string url)
 
     // Minting tokens:
-    function deployCollectible(communityId, accountAddress, name, symbol, description, supply,
-                             infiniteSupply, transferable, selfDestruct, chainId, artworkSource, accountName, artworkCropRect)
-    {
+    function deployCollectible(communityId, collectibleItem)
+    {        
         // TODO: Backend needs to create new role `accountName` and update this call accordingly
+        // TODO: Backend will need to check if the collectibleItem has a valid tokenKey, so it means a deployment retry,
+        // otherwise, it is a new deployment.
         // TODO: Backend needs to modify the call to expect an image JSON file with cropped artwork information:
-        const jsonArtworkFile = Utils.getImageAndCropInfoJson(artworkSource, artworkCropRect)
-        communityTokensModuleInst.deployCollectible(communityId, accountAddress, name, symbol, description, supply,
-                                                    infiniteSupply, transferable, selfDestruct, chainId, artworkSource/*instead: jsonArtworkFile*/)
+        const jsonArtworkFile = Utils.getImageAndCropInfoJson(collectibleItem.artworkSource, collectibleItem.artworkCropRect)
+        communityTokensModuleInst.deployCollectible(communityId, collectibleItem.accountAddress, collectibleItem.name,
+                                                    collectibleItem.symbol, collectibleItem.description, collectibleItem.supply,
+                                                    collectibleItem.infiniteSupply, collectibleItem.transferable, collectibleItem.remotelyDestruct,
+                                                    collectibleItem.chainId, collectibleItem.artworkSource/*instead: jsonArtworkFile*/)
     }
 
-    function deployAsset(communityId, accountAddress, name, symbol, description, supply,
-                         infiniteSupply, decimals, chainId, artworkSource, accountName, artworkCropRect)
+    function deployAsset(communityId, assetItem)
     {
         // TODO: Backend needs to create new role `accountName` and update this call accordingly
+        // TODO: Backend will need to check if the collectibleItem has a valid tokenKey, so it means a deployment retry,
+        // otherwise, it is a new deployment.
         // TODO: Backend needs to modify the call to expect an image JSON file with cropped artwork information:
-        const jsonArtworkFile = Utils.getImageAndCropInfoJson(artworkSource, artworkCropRect)
+        const jsonArtworkFile = Utils.getImageAndCropInfoJson(assetItem.artworkSource, assetItem.artworkCropRect)
         console.log("TODO: Deploy Asset backend!")
     }
 
     function deleteToken(communityId, contractUniqueKey) {
         console.log("TODO: Delete token bakend!")
-    }
-
-    function retryMintToken(communityId, contractUniqueKey) {
-        console.log("TODO: Retry mint token bakend!")
     }
 
     readonly property Connections connections: Connections {
@@ -85,7 +85,7 @@ QtObject {
         console.warn("TODO: Compute burn fee backend")
     }
 
-    function burnCollectibles(tokenKey, burnAmount) {
+    function burnToken(tokenKey, burnAmount) {
         // TODO BACKEND
         console.warn("TODO: Burn collectible backend")
     }

--- a/ui/imports/utils/Utils.qml
+++ b/ui/imports/utils/Utils.qml
@@ -765,35 +765,37 @@ QtObject {
     }
 
     function getColorForId(colorId) {
-        switch(colorId.toUpperCase()) {
-        case Constants.walletAccountColors.primary.toUpperCase():
-            return Theme.palette.customisationColors.blue
-        case Constants.walletAccountColors.purple.toUpperCase():
-            return Theme.palette.customisationColors.purple
-        case Constants.walletAccountColors.orange.toUpperCase():
-            return Theme.palette.customisationColors.orange
-        case  Constants.walletAccountColors.army.toUpperCase():
-            return Theme.palette.customisationColors.army
-        case  Constants.walletAccountColors.turquoise.toUpperCase():
-            return Theme.palette.customisationColors.turquoise
-        case  Constants.walletAccountColors.sky.toUpperCase():
-            return Theme.palette.customisationColors.sky
-        case  Constants.walletAccountColors.yellow.toUpperCase():
-            return Theme.palette.customisationColors.yellow
-        case  Constants.walletAccountColors.pink.toUpperCase():
-            return Theme.palette.customisationColors.pink
-        case  Constants.walletAccountColors.copper.toUpperCase():
-            return Theme.palette.customisationColors.copper
-        case  Constants.walletAccountColors.camel.toUpperCase():
-            return Theme.palette.customisationColors.camel
-        case  Constants.walletAccountColors.magenta.toUpperCase():
-            return Theme.palette.customisationColors.magenta
-        case  Constants.walletAccountColors.yinYang.toUpperCase():
-            return Theme.palette.customisationColors.yinYang
-        case  Constants.walletAccountColors.undefinedAccount.toUpperCase():
-            return Theme.palette.baseColor1
-        default:
-            return Theme.palette.customisationColors.blue
+        if(colorId) {
+            switch(colorId.toUpperCase()) {
+            case Constants.walletAccountColors.primary.toUpperCase():
+                return Theme.palette.customisationColors.blue
+            case Constants.walletAccountColors.purple.toUpperCase():
+                return Theme.palette.customisationColors.purple
+            case Constants.walletAccountColors.orange.toUpperCase():
+                return Theme.palette.customisationColors.orange
+            case  Constants.walletAccountColors.army.toUpperCase():
+                return Theme.palette.customisationColors.army
+            case  Constants.walletAccountColors.turquoise.toUpperCase():
+                return Theme.palette.customisationColors.turquoise
+            case  Constants.walletAccountColors.sky.toUpperCase():
+                return Theme.palette.customisationColors.sky
+            case  Constants.walletAccountColors.yellow.toUpperCase():
+                return Theme.palette.customisationColors.yellow
+            case  Constants.walletAccountColors.pink.toUpperCase():
+                return Theme.palette.customisationColors.pink
+            case  Constants.walletAccountColors.copper.toUpperCase():
+                return Theme.palette.customisationColors.copper
+            case  Constants.walletAccountColors.camel.toUpperCase():
+                return Theme.palette.customisationColors.camel
+            case  Constants.walletAccountColors.magenta.toUpperCase():
+                return Theme.palette.customisationColors.magenta
+            case  Constants.walletAccountColors.yinYang.toUpperCase():
+                return Theme.palette.customisationColors.yinYang
+            case  Constants.walletAccountColors.undefinedAccount.toUpperCase():
+                return Theme.palette.baseColor1
+            default:
+                return Theme.palette.customisationColors.blue
+            }
         }
     }
 


### PR DESCRIPTION
Closes [#10878](https://github.com/status-im/status-desktop/issues/10878)
Fixes [#10860](https://github.com/status-im/status-desktop/issues/10860)

### What does the PR do

1. Mint Token views refactor:
- Created `TokenObject` files and use them inside `CommunityNewTokenView` instead of plain properties.
- Updated `CommunityTokenView` to use `TokenObject` properties instead of plain properties.
- Updated store calls to use `TokenObject` properties instead of plain properties.
- Remote destruct properties renames.
- Airdrop navigation extended passing token type (asset or collectible).
- Updated `storybook` according to new changes.

2. Adds navigation from retry to filled token form.
3. Fixes new tokens form validation rules.

### Affected areas
Community Settings / Mint token

### Screenshot of functionality

- Retry enabled:

https://github.com/status-im/status-desktop/assets/97019400/f4f7bc8c-7b08-4791-a19d-45a1667c3da8

- Validation rules:

https://github.com/status-im/status-desktop/assets/97019400/1a0cd784-41d1-4bb1-8472-ba51abf07fc8

- Assets in `storybook` (backend not ready)

https://github.com/status-im/status-desktop/assets/97019400/f5583986-ea73-479e-b205-2cdc12eb01ed