### PR TITLE
fix: extend/fix DND and clipboard image operations

### DIFF
--- a/ci/Jenkinsfile.tests-e2e
+++ b/ci/Jenkinsfile.tests-e2e
@@ -32,7 +32,7 @@ pipeline {
     string(
       name: 'NIMFLAGS',
       description: 'Extra Nim flags. Examples: --verbosity:2 --passL:"-v" --passC:"-v"',
-      defaultValue: '--colors:off'
+      defaultValue: '-d:useOpenssl3 --colors:off'
     )
   }
 
@@ -67,7 +67,7 @@ pipeline {
     QTDIR = '/opt/qt/5.15.2/gcc_64'
     PATH = "${env.QTDIR}/bin:${env.PATH}"
     /* Include library in order to compile the project */
-    LD_LIBRARY_PATH = "$QTDIR/lib:$WORKSPACE/vendor/status-go/build/bin:$WORKSPACE/vendor/status-keycard-go/build/libkeycard/"
+    LD_LIBRARY_PATH = "$QTDIR/lib:$WORKSPACE/vendor/status-go/build/bin:$WORKSPACE/vendor/status-keycard-go/build/libkeycard/:${env.LD_LIBRARY_PATH}"
     /* Container ports */
     RPC_PORT = "${8545 + env.EXECUTOR_NUMBER.toInteger()}"
     P2P_PORT = "${6010 + env.EXECUTOR_NUMBER.toInteger()}"

--- a/src/app/global/utils.nim
+++ b/src/app/global/utils.nim
@@ -76,16 +76,6 @@ QtObject:
   proc generateAlias*(self: Utils, pk: string): string {.slot.} =
     return generateAliasFromPk(pk)
 
-  proc getFileSize*(self: Utils, filename: string): string {.slot.} =
-    var f: File = nil
-    if f.open(self.formatImagePath(filename)):
-      try:
-        result = $(f.getFileSize())
-      finally:
-        close(f)
-    else:
-      raise newException(IOError, "cannot open: " & filename)
-
   proc readTextFile*(self: Utils, filepath: string): string {.slot.} =
     try:
       return readFile(filepath)

--- a/src/app_service/service/chat/service.nim
+++ b/src/app_service/service/chat/service.nim
@@ -1,5 +1,5 @@
 import NimQml, Tables, json, sequtils, strformat, chronicles, os, std/algorithm, strutils, uuids, base64
-import std/[times, os]
+import std/[times, os, httpclient, uri]
 
 import ../../../app/core/tasks/[qt, threadpool]
 import ./dto/chat as chat_dto
@@ -465,33 +465,19 @@ QtObject:
       var imagePaths: seq[string] = @[]
 
       for imagePathOrSource in images.mitems:
+        var imageUrl = imagePathOrSource
 
-        var imagePath = ""
+        if not imageUrl.startsWith(base64JPGPrefix):
+          let parsedImageUrl = parseUri(imageUrl)
+          if parsedImageUrl.scheme.startsWith("http"): # remote URL, download it first
+            var client = newHttpClient()
+            let tmpPath = TMPDIR & $genUUID() & ".jpg"
+            client.downloadFile(parsedImageUrl, tmpPath)
+            imageUrl = tmpPath
 
-        if imagePathOrSource.startsWith(base64JPGPrefix):
-          # If an image was copied to clipboard we're receiving it from there
-          # as base64 encoded string. The base64 string will always have JPG data
-          # because image_resizer (a few lines below) will always generate jpgs
-          # (which needs to be fixed as well). 
-          #
-          # We save the image data to a tmp location because image_resizer expects
-          # a filepath to operate on.
-          #
-          # TODO: 
-          # Make image_resizer work for all image types (and ensure the same 
-          # for base64 encoded string received via clipboard
-          let base64Str = imagePathOrSource.replace(base64JPGPrefix, "")
-          let bytes = base64.decode(base64Str)
-          let tmpPath = TMPDIR & $genUUID() & ".jpg"
-          writeFile(tmpPath, bytes)
-          imagePath = tmpPath
-        else:
-          imagePath = imagePathOrSource
-
-        var image = singletonInstance.utils.formatImagePath(imagePath)
-        imagePath = image_resizer(image, 2000, TMPDIR)
-
-        imagePaths.add(imagePath)
+        let imagePath = image_resizer(imageUrl, 2000, TMPDIR)
+        if imagePath != "":
+          imagePaths.add(imagePath)
 
       let response = status_chat.sendImages(chatId, imagePaths, msg, replyTo)
 

--- a/ui/StatusQ/include/StatusQ/QClipboardProxy.h
+++ b/ui/StatusQ/include/StatusQ/QClipboardProxy.h
@@ -52,6 +52,9 @@ public:
         return new QClipboardProxy;
     }
 
+    Q_INVOKABLE bool isValidImageUrl(const QUrl &url, const QStringList &acceptedExtensions) const;
+    Q_INVOKABLE qint64 getFileSize(const QUrl &url) const;
+
 signals:
     void contentChanged();
 };

--- a/ui/StatusQ/src/QClipboardProxy.cpp
+++ b/ui/StatusQ/src/QClipboardProxy.cpp
@@ -6,6 +6,9 @@
 #include <QImage>
 #include <QMimeData>
 #include <QUrl>
+#include <QFile>
+
+#include <algorithm>
 
 QClipboardProxy::QClipboardProxy()
     : m_clipboard(QGuiApplication::clipboard())
@@ -66,4 +69,20 @@ bool QClipboardProxy::hasUrls() const
 QList<QUrl> QClipboardProxy::urls() const
 {
     return m_clipboard->mimeData()->urls();
+}
+
+bool QClipboardProxy::isValidImageUrl(const QUrl& url, const QStringList& acceptedExtensions) const
+{
+    const auto strippedUrl = url.url(QUrl::RemoveAuthority | QUrl::RemoveFragment | QUrl::RemoveQuery);
+    return std::any_of(acceptedExtensions.constBegin(), acceptedExtensions.constEnd(), [strippedUrl](const auto & ext) {
+        return strippedUrl.endsWith(ext);
+    });
+}
+
+qint64 QClipboardProxy::getFileSize(const QUrl& url) const
+{
+    if (url.isLocalFile()) {
+        return QFile(url.toLocalFile()).size();
+    }
+    return 0;
 }

--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -943,7 +943,15 @@ Rectangle {
         target: Global.dragArea
         ignoreUnknownSignals: true
         function onDroppedOnValidScreen(drop) {
-            if (validateImagesAndShowImageArea(drop.urls)) {
+            let dropUrls = drop.urls
+            if (!drop.hasUrls) {
+                console.warn("Trying to drop, list of URLs is empty tho; formats:", drop.formats)
+                if (drop.formats.includes("text/x-moz-url"))  { // Chrome uses a non-standard MIME type
+                    dropUrls = drop.getDataAsString("text/x-moz-url")
+                }
+            }
+
+            if (validateImagesAndShowImageArea(dropUrls)) {
                 drop.acceptProposedAction()
             }
         }

--- a/ui/imports/utils/Utils.qml
+++ b/ui/imports/utils/Utils.qml
@@ -3,6 +3,8 @@ pragma Singleton
 import QtQuick 2.13
 
 import shared 1.0
+
+import StatusQ 0.1
 import StatusQ.Core.Theme 0.1
 import StatusQ.Core.Utils 0.1 as StatusQUtils
 
@@ -335,16 +337,15 @@ QtObject {
     }
 
     function isValidDragNDropImage(url) {
-        let lowerCaseUrl = url.toLowerCase()
-        return Constants.acceptedDragNDropImageExtensions.some(ext => lowerCaseUrl.endsWith(ext)) ||
-            lowerCaseUrl.startsWith(Constants.dataImagePrefix);
+        return url.startsWith(Constants.dataImagePrefix) ||
+                QClipboardProxy.isValidImageUrl(url, Constants.acceptedDragNDropImageExtensions)
     }
 
     function isFilesizeValid(img) {
         if (img.startsWith(Constants.dataImagePrefix)) {
             return img.length < maxImgSizeBytes
         }
-        let size = parseInt(globalUtils.getFileSize(img))
+        const size = QClipboardProxy.getFileSize(img)
         return size <= maxImgSizeBytes
     }
 

--- a/vendor/DOtherSide/lib/include/DOtherSide/DOtherSide.h
+++ b/vendor/DOtherSide/lib/include/DOtherSide/DOtherSide.h
@@ -110,7 +110,7 @@ DOS_API char * DOS_CALL dos_escape_html(char* input);
 
 DOS_API void DOS_CALL dos_qncm_delete(DosQNetworkConfigurationManager *vptr);
 
-DOS_API char * DOS_CALL dos_image_resizer(char* imagePath, int maxSize, char* tmpDirPath);
+DOS_API char * DOS_CALL dos_image_resizer(const char* imagePathOrData, int maxSize, const char* tmpDirPath);
 
 DOS_API char * DOS_CALL dos_qurl_fromUserInput(char* input);
 


### PR DESCRIPTION
### What does the PR do

Fixes several issues/deficiencies we had with handling image data (paste, drag'n'drop, resizing); pls see the individual commits for explanation; namely: 
- fix crash when dropping a remote URL (non-Chrome browsers)
- fix DND checks for URLs containing a query
- missing support for dropping URLs
- fixup support for dropping URLs from Chrome (uses a non standard MIME type)
- fix missing support for dropping a bunch of files (e.g. from a file manager)
- more efficient `image_resizer` C++ code, more robust file size/extension checks

### Affected areas

StatusChatInput, `sendImages`

### Screenshot of functionality (including design for comparison)

- [ ] I've checked the design and this PR matches it

TODO: video
