### PR TITLE
fix(MintToken): App crash when trying to create new token

### DIFF
--- a/ui/app/AppLayouts/Chat/views/communities/CommunityNewTokenView.qml
+++ b/ui/app/AppLayouts/Chat/views/communities/CommunityNewTokenView.qml
@@ -10,10 +10,11 @@ import StatusQ.Core.Utils 0.1 as SQUtils
 
 import utils 1.0
 
-
 import AppLayouts.Wallet.controls 1.0
 import shared.panels 1.0
 import shared.popups 1.0
+
+import SortFilterProxyModel 0.2
 
 StatusScrollView {
     id: root
@@ -150,7 +151,22 @@ StatusScrollView {
             readonly property string address: SQUtils.ModelUtils.get(root.accounts, currentIndex, "address")
 
             Layout.fillWidth: true
-            model: root.accounts
+            model: SortFilterProxyModel {
+                sourceModel: root.accounts
+                proxyRoles: [
+                    ExpressionRole {
+                        name: "color"
+
+                        function getColor(colorId) {
+                            return Utils.getColorForId(colorId)
+                        }
+
+                        // Direct call for singleton function is not handled properly by
+                        // SortFilterProxyModel that's why helper function is used instead.
+                        expression: { return getColor(model.colorId) }
+                    }
+                ]
+            }
             type: StatusComboBox.Type.Secondary
             size: StatusComboBox.Size.Small
             implicitHeight: 44


### PR DESCRIPTION
Closes #10991

### What does the PR do

Accounts `color` role was changed to `colorId` so, `CommunityNewTokenView` has been updated accordingly.

### Affected areas

Community Settings / Mint Tokens

### Screenshot of functionality 

https://github.com/status-im/status-desktop/assets/97019400/a284896e-bc27-49c6-84d7-e7a1295208fc


