### PR TITLE
fix(deeplinks): Update plist files and into-setup file to new url scheme

### DIFF
--- a/Info.dev.plist
+++ b/Info.dev.plist
@@ -25,7 +25,7 @@
                 <string>status.im.customurl</string>
                 <key>CFBundleURLSchemes</key>
                 <array>
-                    <string>status-im</string>
+                    <string>status-app</string>
                 </array>
             </dict>
         </array>

--- a/Info.plist
+++ b/Info.plist
@@ -25,7 +25,7 @@
                 <string>status.im.customurl</string>
                 <key>CFBundleURLSchemes</key>
                 <array>
-                    <string>status-im</string>
+                    <string>status-app</string>
                 </array>
             </dict>
         </array>

--- a/status.iss
+++ b/status.iss
@@ -1,6 +1,6 @@
 #define   Name       "Status"
 #define   Publisher  "Status.im"
-#define   URL        "https://status.im"
+#define   URL        "https://status.app"
 #define   ExeName    "Status.exe"
 #define   IcoName    "status.ico"
 


### PR DESCRIPTION
Fixes: #8102

### What does the PR do

Updates url scheme for deep links from `status-im` to `status-app` on macOS and inno-setup file

### Affected areas

deeplinks

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?
