### PR TITLE
fix: download remote image URLs in DOS/C++

### DIFF
--- a/ci/Jenkinsfile.tests-e2e
+++ b/ci/Jenkinsfile.tests-e2e
@@ -32,7 +32,7 @@ pipeline {
     string(
       name: 'NIMFLAGS',
       description: 'Extra Nim flags. Examples: --verbosity:2 --passL:"-v" --passC:"-v"',
-      defaultValue: '-d:useOpenssl3 --colors:off'
+      defaultValue: '--colors:off'
     )
   }
 
@@ -67,7 +67,7 @@ pipeline {
     QTDIR = '/opt/qt/5.15.2/gcc_64'
     PATH = "${env.QTDIR}/bin:${env.PATH}"
     /* Include library in order to compile the project */
-    LD_LIBRARY_PATH = "$QTDIR/lib:$WORKSPACE/vendor/status-go/build/bin:$WORKSPACE/vendor/status-keycard-go/build/libkeycard/:${env.LD_LIBRARY_PATH}"
+    LD_LIBRARY_PATH = "$QTDIR/lib:$WORKSPACE/vendor/status-go/build/bin:$WORKSPACE/vendor/status-keycard-go/build/libkeycard/"
     /* Container ports */
     RPC_PORT = "${8545 + env.EXECUTOR_NUMBER.toInteger()}"
     P2P_PORT = "${6010 + env.EXECUTOR_NUMBER.toInteger()}"

--- a/src/app_service/service/chat/service.nim
+++ b/src/app_service/service/chat/service.nim
@@ -1,5 +1,5 @@
 import NimQml, Tables, json, sequtils, strformat, chronicles, os, std/algorithm, strutils, uuids, base64
-import std/[times, os, httpclient, uri]
+import std/[times, os]
 
 import ../../../app/core/tasks/[qt, threadpool]
 import ./dto/chat as chat_dto
@@ -474,17 +474,7 @@ QtObject:
       var imagePaths: seq[string] = @[]
 
       for imagePathOrSource in images.mitems:
-        var imageUrl = imagePathOrSource
-
-        if not imageUrl.startsWith(base64JPGPrefix):
-          let parsedImageUrl = parseUri(imageUrl)
-          if parsedImageUrl.scheme.startsWith("http"): # remote URL, download it first
-            var client = newHttpClient()
-            let tmpPath = TMPDIR & $genUUID() & ".jpg"
-            client.downloadFile(parsedImageUrl, tmpPath)
-            imageUrl = tmpPath
-
-        let imagePath = image_resizer(imageUrl, 2000, TMPDIR)
+        let imagePath = image_resizer(imagePathOrSource, 2000, TMPDIR)
         if imagePath != "":
           imagePaths.add(imagePath)
 

--- a/vendor/DOtherSide/lib/CMakeLists.txt
+++ b/vendor/DOtherSide/lib/CMakeLists.txt
@@ -31,7 +31,7 @@ macro(add_target name type)
         target_compile_definitions(${name} PRIVATE -DWIN32)
     endif()
 
-    set_target_properties(${name} PROPERTIES CXX_STANDARD 11 AUTOMOC ON)
+    set_target_properties(${name} PROPERTIES CXX_STANDARD 17 AUTOMOC ON)
 
     target_include_directories(${name} PUBLIC include include/Qt)
 


### PR DESCRIPTION
this should resolve the CI issues in `e2e` target by moving away the httpclient NIM impl to DOS (C++). Potentially this should be even faster as we don't save to a temporary file anymore and just load the recieved data directly into the QImage

### Affected areas

DOS, sendImages

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

Still good, can DND remote URLs and send them:

![image](https://github.com/status-im/status-desktop/assets/5377645/9a047880-a303-480b-9c96-cab8f0ee2b3f)

