### PR TITLE
fix(@desktop/wallet): Update wallet account color correctly

### DIFF
--- a/ui/app/AppLayouts/Wallet/views/RightTabView.qml
+++ b/ui/app/AppLayouts/Wallet/views/RightTabView.qml
@@ -160,6 +160,10 @@ Item {
             id: transactionDetailView
             Layout.fillWidth: true
             Layout.fillHeight: true
+            onVisibleChanged: {
+                if (!visible)
+                    transaction = null
+            }
             sendModal: root.sendModal
             contactsStore: root.contactsStore
             visible: (stack.currentIndex === 3)

--- a/ui/imports/shared/controls/TransactionAddress.qml
+++ b/ui/imports/shared/controls/TransactionAddress.qml
@@ -73,11 +73,17 @@ Item {
         readonly property var prefixAndAddress: Utils.splitToChainPrefixAndAddress(root.address)
         readonly property bool isContact: contactData.isContact
         readonly property bool isWallet: !isContact && !!walletAddressName
-        property var contactData: Utils.getContactDetailsAsJson(d.contactPubKey)
-        property string savedAddressName: !!root.rootStore ? root.rootStore.getNameForSavedWalletAddress(root.address) : ""
-        property string walletAddressName: !!root.rootStore ? root.rootStore.getNameForWalletAddress(root.address) : ""
-        property string walletAddressEmoji: !!root.rootStore ? root.rootStore.getEmojiForWalletAddress(root.address) : ""
-        property string walletAddressColor: !!root.rootStore ? root.rootStore.getColorForWalletAddress(root.address) : ""
+        property var contactData
+        property string savedAddressName
+        property string walletAddressName
+        property string walletAddressEmoji
+        property string walletAddressColor
+
+        Component.onCompleted: {
+            refreshContactData()
+            refreshSavedAddressName()
+            refreshWalletAddress()
+        }
 
         function refreshContactData() {
             d.contactData = Utils.getContactDetailsAsJson(d.contactPubKey)
@@ -90,7 +96,7 @@ Item {
         function refreshWalletAddress() {
             d.walletAddressName = !!root.rootStore ? root.rootStore.getNameForWalletAddress(root.address) : ""
             d.walletAddressEmoji = !!root.rootStore ? root.rootStore.getEmojiForWalletAddress(root.address) : ""
-            d.walletAddressColor = !!root.rootStore ? root.rootStore.getColorForWalletAddress(root.address) : ""
+            d.walletAddressColor = Utils.getColorForId(!!root.rootStore ? root.rootStore.getColorForWalletAddress(root.address) : "")
         }
 
         function getName() {


### PR DESCRIPTION
### What does the PR do

Fixes color for wallet accounts showed in Activity Details View. After wallet account color changes it was showing as a black.

### Affected areas

Wallet Activity UI

### Screenshot of functionality (including design for comparison)

![image](https://github.com/status-im/status-desktop/assets/11396062/26b869cd-f693-412b-af01-ee68a4b5bc5d)
