### PR TITLE
fix(@wallet): add missing field to multitransaction

### DIFF
--- a/src/app_service/service/transaction/dto.nim
+++ b/src/app_service/service/transaction/dto.nim
@@ -150,6 +150,7 @@ proc toMultiTransactionDto*(jsonObj: JsonNode): MultiTransactionDto =
   discard jsonObj.getProp("fromAsset", result.fromAsset)
   discard jsonObj.getProp("toAsset", result.toAsset)
   discard jsonObj.getProp("fromAmount", result.fromAmount)
+  discard jsonObj.getProp("toAmount", result.toAmount)
   var multiTxType: int
   discard jsonObj.getProp("type", multiTxType)
   result.multiTxType = cast[MultiTransactionType](multiTxType)

--- a/src/backend/transactions.nim
+++ b/src/backend/transactions.nim
@@ -17,6 +17,7 @@ type
     fromAsset* {.serializedFieldName("fromAsset").}: string
     toAsset* {.serializedFieldName("toAsset").}: string
     fromAmount* {.serializedFieldName("fromAmount").}: string
+    toAmount* {.serializedFieldName("toAmount").}: string
     multiTxType* {.serializedFieldName("type").}: MultiTransactionType
 
 proc getTransactionByHash*(chainId: int, hash: string): RpcResponse[JsonNode] {.raises: [Exception].} =


### PR DESCRIPTION
Fixes #11010

### What does the PR do

A new field was added to the MultiTransaction field in status-go, but this change was not reflected in status-desktop, causing crashes when performing a send/bridge operation.

This PR adds the missing field. It's not used when sending objects from status-desktop to status-go, only the other way around for detected Swap operations.