### PR TITLE
feat(wallet): extend API to continue loading activity

### DIFF
--- a/src/app/modules/main/wallet_section/activity/entry.nim
+++ b/src/app/modules/main/wallet_section/activity/entry.nim
@@ -78,7 +78,7 @@ QtObject:
     return self.transaction
 
   proc getSender*(self: ActivityEntry): string {.slot.} =
-    # TODO: lookup sender's name from addressbook and cache it or in advance
+    # TODO: lookup sender's name
     if self.isMultiTransaction():
       return self.multi_transaction.fromAddress
 
@@ -88,7 +88,7 @@ QtObject:
     read = getSender
 
   proc getRecipient*(self: ActivityEntry): string {.slot.} =
-    # TODO: lookup recipient name from addressbook and cache it or in advance
+    # TODO: lookup recipient name
     if self.isMultiTransaction():
       return self.multi_transaction.toAddress
 

--- a/src/backend/activity.nim
+++ b/src/backend/activity.nim
@@ -157,7 +157,8 @@ type
 
   FilterResponse* = object
     activities*: seq[ActivityEntry]
-    thereMightBeMore*: bool
+    offset*: int
+    hasMore*: bool
     errorCode*: ErrorCode
 
 # Define toJson proc for PayloadType
@@ -198,7 +199,8 @@ proc fromJson*(e: JsonNode, T: typedesc[FilterResponse]): FilterResponse {.inlin
 
   result = T(
     activities: backendEntities,
-    thereMightBeMore: if e.hasKey("thereMightBeMore"): e["thereMightBeMore"].getBool()
+    offset: e["offset"].getInt(),
+    hasMore: if e.hasKey("hasMore"): e["hasMore"].getBool()
                       else: false,
     errorCode: ErrorCode(e["errorCode"].getInt())
   )


### PR DESCRIPTION
### Closes status-desktop #10994

Bump status-go with [#3598](https://github.com/status-im/status-go/pull/3598) the refactoring of `hasMore` and addition of the required `offset`
Add support for continuously loading activity in the wallet API.
Extend the debugging demo with continuous loading.
