### PR TITLE
feat(wallet): make filter API async

### DIFF
--- a/src/app/modules/main/wallet_section/activity/model.nim
+++ b/src/app/modules/main/wallet_section/activity/model.nim
@@ -65,26 +65,24 @@ QtObject:
     of ModelRole.ActivityEntryRole:
       result = newQVariant(entry)
 
-  proc setEntries*(self: Model, entries: seq[ActivityEntry]) =
+  proc hasMoreChanged*(self: Model) {.signal.}
+
+  proc setHasMore(self: Model, hasMore: bool) {.slot.} =
+    self.hasMore = hasMore
+    self.hasMoreChanged()
+
+  proc setEntries*(self: Model, entries: seq[ActivityEntry], hasMore: bool) =
     self.beginResetModel()
     self.entries = entries
     self.endResetModel()
     self.countChanged()
-
-  # TODO: update data
+    self.setHasMore(hasMore)
 
   # TODO: fetch more
-
-  proc hasMoreChanged*(self: Model) {.signal.}
 
   proc getHasMore*(self: Model): bool {.slot.} =
     return self.hasMore
 
-  proc setHasMore*(self: Model, hasMore: bool) {.slot.} =
-    self.hasMore = hasMore
-    self.hasMoreChanged()
-
   QtProperty[bool] hasMore:
     read = getHasMore
-    write = setHasMore
     notify = hasMoreChanged

--- a/src/app/modules/main/wallet_section/module.nim
+++ b/src/app/modules/main/wallet_section/module.nim
@@ -101,7 +101,7 @@ proc newModule*(
   result.networksModule = networks_module.newModule(result, events, networkService, walletAccountService, settingsService)
   result.filter = initFilter(result.controller)
 
-  result.activityController = activityc.newController(result.transactionsModule)
+  result.activityController = activityc.newController(result.transactionsModule, events)
   result.view = newView(result, result.activityController)
 
 

--- a/ui/imports/shared/views/ActivityView.qml
+++ b/ui/imports/shared/views/ActivityView.qml
@@ -142,7 +142,7 @@ Control {
                 id: timeFilterLayout
 
                 RowLayout {
-                    Label { text: "Past Days Span: 100" }
+                    Label { text: qsTr("Past Days Span: 100") }
                     Slider {
                         id: fromSlider
 
@@ -170,12 +170,12 @@ Control {
                         stepSize: 1
                         value: 0
                     }
-                    Label { text: "0" }
+                    Label { text: qsTr("0") }
                 }
-                Label { text: `Interval: ${d.start > 0 ? root.epochToDateStr(d.start) : "all time"} - ${d.end > 0 ? root.epochToDateStr(d.end) : "now"}` }
+                Label { text: `Interval: ${d.start > 0 ? root.epochToDateStr(d.start) : qsTr("all time")} - ${d.end > 0 ? root.epochToDateStr(d.end) : qsTr("now")}` }
             }
             RowLayout {
-                Label { text: "Type" }
+                Label { text: qsTr("Type") }
                 // Models the ActivityType
                 ListModel {
                     id: typeModel
@@ -198,7 +198,7 @@ Control {
                     delegate: ItemOnOffDelegate {}
                 }
 
-                Label { text: "Status" }
+                Label { text: qsTr("Status") }
                 // ActivityStatus
                 ListModel {
                     id: statusModel
@@ -219,7 +219,7 @@ Control {
                     delegate: ItemOnOffDelegate {}
                 }
 
-                Label { text: "To addresses" }
+                Label { text: qsTr("To addresses") }
                 TextField {
                     id: toAddressesInput
 
@@ -235,7 +235,7 @@ Control {
             }
             RowLayout {
 
-                Label { text: "Addresses" }
+                Label { text: qsTr("Addresses") }
                 TextField {
                     id: addressesInput
 
@@ -244,7 +244,7 @@ Control {
                     placeholderText: qsTr("0x1234, 0x5678, ...")
                 }
 
-                Label { text: "Chains" }
+                Label { text: qsTr("Chains") }
                 ComboBox {
                     displayText: qsTr("Select chains")
 
@@ -256,7 +256,7 @@ Control {
                     delegate: ItemOnOffDelegate {}
                 }
 
-                Label { text: "Assets" }
+                Label { text: qsTr("Assets") }
                 ComboBox {
                     displayText: assetsLoader.status != Loader.Ready ? qsTr("Loading...") : qsTr("Select an asset")
 
@@ -321,6 +321,16 @@ Control {
             }
         }
 
+        Text {
+            id: loadingText
+
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+
+            text: qsTr("Loading...")
+            visible: controller.loadingData
+            horizontalAlignment: Text.AlignHCenter
+        }
         ListView {
             id: listView
 
@@ -328,6 +338,7 @@ Control {
             Layout.fillHeight: true
 
             model: controller.model
+            visible: !controller.loadingData
 
             delegate: Item {
                 width: parent ? parent.width : 0
@@ -339,25 +350,25 @@ Control {
                     id: itemLayout
                     anchors.fill: parent
 
-                    Label { text: entry.isMultiTransaction ? "MT" : entry.isPendingTransaction ? "PT" : " T" }
+                    Label { text: entry.isMultiTransaction ? qsTr("MT") : entry.isPendingTransaction ? qsTr("PT") : qsTr(" T") }
                     Label { text: `[${root.epochToDateStr(entry.timestamp)}] ` }
                     Label { text: entry.isMultiTransaction ? entry.fromAmount : entry.amount }
-                    Label { text: "from"; Layout.leftMargin: 5; Layout.rightMargin: 5 }
+                    Label { text: qsTr("from"); Layout.leftMargin: 5; Layout.rightMargin: 5 }
                     Label { text: entry.sender; Layout.maximumWidth: 200; elide: Text.ElideMiddle }
-                    Label { text: "to"; Layout.leftMargin: 5; Layout.rightMargin: 5 }
+                    Label { text: qsTr("to"); Layout.leftMargin: 5; Layout.rightMargin: 5 }
                     Label { text: entry.recipient; Layout.maximumWidth: 200; elide: Text.ElideMiddle }
-                    Label { text: "got"; Layout.leftMargin: 5; Layout.rightMargin: 5; visible: entry.isMultiTransaction }
+                    Label { text: qsTr("got"); Layout.leftMargin: 5; Layout.rightMargin: 5; visible: entry.isMultiTransaction }
                     Label { text: entry.toAmount; Layout.leftMargin: 5; Layout.rightMargin: 5; visible: entry.isMultiTransaction }
                     Label {
                         text: `{${
                             function() {
                                 switch (entry.status) {
-                                    case Constants.TransactionStatus.Failed: return "F";
-                                    case Constants.TransactionStatus.Pending: return "P";
-                                    case Constants.TransactionStatus.Complete: return "C";
-                                    case Constants.TransactionStatus.Finalized: return "FZ";
+                                    case Constants.TransactionStatus.Failed: return qsTr("F");
+                                    case Constants.TransactionStatus.Pending: return qsTr("P");
+                                    case Constants.TransactionStatus.Complete: return qsTr("C");
+                                    case Constants.TransactionStatus.Finalized: return qsTr("FZ");
                                 }
-                                return "-"
+                                return qsTr("-")
                             }()}}`
                         Layout.leftMargin: 5;
                     }
@@ -365,6 +376,30 @@ Control {
                     RowLayout {}    // Spacer
                 }
             }
+
+            footer: Component {
+                Item {
+                    width: listView.width
+                    height: footerText.implicitHeight
+
+                    Text {
+                        id: footerText
+                        text: qsTr("Loading more items...")
+                        anchors.centerIn: parent
+                    }
+
+                    visible: controller.model.hasMore
+
+                    // Load more items when this footer comes into view.
+                    onVisibleChanged: {
+                        if (visible) {
+                            controller.loadMoreItems();
+                        }
+                    }
+                }
+            }
+
+            ScrollBar.vertical: ScrollBar {}
         }
     }
 


### PR DESCRIPTION
### Update #10994

Bump status-go with [#3593](https://github.com/status-im/status-go/pull/3593) to include the async API changes
Handle the wallet-activity-filtering-done event
Propagate has more flag
Extend the debugging UX