### PR TITLE
fix(Chat): Context menu for gif downloads a PNG file

### DIFF
--- a/src/app/global/utils.nim
+++ b/src/app/global/utils.nim
@@ -105,8 +105,7 @@ QtObject:
     downloadImage(content, path)
 
   proc downloadImageByUrl*(self: Utils, url: string, path: string) {.slot.} =
-    let pathFormatted = self.formatImagePath(path)
-    downloadImageByUrl(url, pathFormatted)
+    downloadImageByUrl(url, path)
 
   proc generateQRCodeSVG*(self: Utils, text: string, border: int = 0): string =
     var qr0: array[0..qrcodegen_BUFFER_LEN_MAX, uint8]

--- a/ui/app/mainui/Popups.qml
+++ b/ui/app/mainui/Popups.qml
@@ -224,7 +224,6 @@ QtObject {
 
     function openDownloadImageDialog(imageSource) {
         // We don't use `openPopup`, because there's no `FileDialog::closed` signal.
-        // And multiple file dialogs are (almost) ok
         const popup = downloadImageDialogComponent.createObject(popupParent, { imageSource })
         popup.open()
     }
@@ -498,11 +497,7 @@ QtObject {
                 onRejected: {
                     destroy()
                 }
-                Component.onCompleted: {
-                    open()
-                }
             }
         }
-
     ]
 }

--- a/ui/imports/shared/views/chat/ImageContextMenu.qml
+++ b/ui/imports/shared/views/chat/ImageContextMenu.qml
@@ -7,9 +7,10 @@ StatusMenu {
 
     property string imageSource
 
+    readonly property bool isGif: root.imageSource.toLowerCase().endsWith(".gif")
+
     StatusAction {
-        text: root.imageSource.endsWith(".gif") ? qsTr("Copy GIF")
-                                                : qsTr("Copy image")
+        text: root.isGif ? qsTr("Copy GIF") : qsTr("Copy image")
         icon.name: "copy"
         enabled: !!root.imageSource
         onTriggered: {
@@ -18,8 +19,7 @@ StatusMenu {
     }
 
     StatusAction {
-        text: root.imageSource.endsWith(".gif") ? qsTr("Download GIF")
-                                                : qsTr("Download image")
+        text: root.isGif ? qsTr("Download GIF") : qsTr("Download image")
         icon.name: "download"
         enabled: !!root.imageSource
         onTriggered: {


### PR DESCRIPTION
Detect the MIME type using `QMimeDatabase` from the actual content and save it in that same format using `QSaveFile`, as `QImage` does NOT support saving a GIF

Fixes #10747

### What does the PR do

Fixes saving images from chat

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

[Záznam obrazovky z 2023-06-12 10-38-22.webm](https://github.com/status-im/status-desktop/assets/5377645/da8447c4-7374-46c7-bb90-1bf6e5c81adb)