### PR TITLE
ci: disable QML cache to avoid stale cache

### DIFF
--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -57,6 +57,8 @@ pipeline {
     /* Makefile assumes the compiler folder is included */
     QTDIR = "/opt/qt/5.15.2/gcc_64"
     PATH = "${env.QTDIR}/bin:${env.PATH}"
+    /* Avoid weird bugs caused by stale cache. */
+    QML_DISABLE_DISK_CACHE = "true"
     /* Control output the filename */
     STATUS_CLIENT_APPIMAGE = "pkg/${utils.pkgFilename(ext: 'AppImage', arch: getArch())}"
     STATUS_CLIENT_TARBALL = "pkg/${utils.pkgFilename(ext: 'tar.gz', arch: getArch())}"

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -52,6 +52,8 @@ pipeline {
     /* WARNING: Qt 5.15.8 installed via Brew. */
     QTDIR = '/opt/homebrew/opt/qt@5'
     PATH = "${env.QTDIR}/bin:${env.PATH}"
+    /* Avoid weird bugs caused by stale cache. */
+    QML_DISABLE_DISK_CACHE = "true"
     /* Control output the filename */
     STATUS_CLIENT_DMG = "pkg/${utils.pkgFilename(ext: 'dmg', arch: getArch())}"
     /* Apple Team ID for Notarization */

--- a/ci/Jenkinsfile.tests-e2e
+++ b/ci/Jenkinsfile.tests-e2e
@@ -66,6 +66,8 @@ pipeline {
     /* Makefile assumes the compiler folder is included */
     QTDIR = '/opt/qt/5.15.2/gcc_64'
     PATH = "${env.QTDIR}/bin:${env.PATH}"
+    /* Avoid weird bugs caused by stale cache. */
+    QML_DISABLE_DISK_CACHE = "true"
     /* Include library in order to compile the project */
     LD_LIBRARY_PATH = "$QTDIR/lib:$WORKSPACE/vendor/status-go/build/bin:$WORKSPACE/vendor/status-keycard-go/build/libkeycard/"
     /* Container ports */

--- a/ci/Jenkinsfile.tests-nim
+++ b/ci/Jenkinsfile.tests-nim
@@ -46,6 +46,8 @@ pipeline {
     MAKEFLAGS = "-j4 V=${params.VERBOSE}"
     /* Makefile assumes the compiler folder is included */
     QTDIR = "/opt/qt/5.15.2/gcc_64"
+    /* Avoid weird bugs caused by stale cache. */
+    QML_DISABLE_DISK_CACHE = "true"
     /* Include library in order to compile the project */
     LD_LIBRARY_PATH = "$QTDIR/lib"
   }

--- a/ci/Jenkinsfile.windows
+++ b/ci/Jenkinsfile.windows
@@ -49,6 +49,8 @@ pipeline {
     /* Explicitly set the QT version */
     QTDIR = "/c/Qt/5.15.2/msvc2019_64"
     PATH = "${env.QTDIR}/bin:${env.PATH}"
+    /* Avoid weird bugs caused by stale cache. */
+    QML_DISABLE_DISK_CACHE = "true"
     /* Control output the filename */
     STATUS_CLIENT_EXE = "pkg/${utils.pkgFilename(ext: 'exe', arch: getArch())}"
     /* 7zip archive filename */


### PR DESCRIPTION
Possible fix for random build crashes on Linux:
* https://github.com/status-im/infra-ci/issues/88