### PR TITLE
chore(wallet): split multitransaction command from full struct

### DIFF
--- a/src/app_service/service/transaction/service.nim
+++ b/src/app_service/service/transaction/service.nim
@@ -359,7 +359,7 @@ QtObject:
         paths.add(self.createPath(route, txData, tokenSymbol, to_addr))
 
       let response = transactions.createMultiTransaction(
-        MultiTransactionDto(
+        MultiTransactionCommandDto(
           fromAddress: from_addr,
           toAddress: to_addr,
           fromAsset: tokenSymbol,
@@ -426,7 +426,7 @@ QtObject:
         paths.add(self.createPath(route, txData, tokenSymbol, to_addr))
 
       let response = transactions.createMultiTransaction(
-        MultiTransactionDto(
+        MultiTransactionCommandDto(
           fromAddress: from_addr,
           toAddress: to_addr,
           fromAsset: tokenSymbol,

--- a/src/backend/transactions.nim
+++ b/src/backend/transactions.nim
@@ -9,6 +9,14 @@ type
   MultiTransactionType* = enum
     MultiTransactionSend = 0, MultiTransactionSwap = 1, MultiTransactionBridge = 2
 
+  MultiTransactionCommandDto* = ref object of RootObj
+    fromAddress* {.serializedFieldName("fromAddress").}: string
+    toAddress* {.serializedFieldName("toAddress").}: string
+    fromAsset* {.serializedFieldName("fromAsset").}: string
+    toAsset* {.serializedFieldName("toAsset").}: string
+    fromAmount* {.serializedFieldName("fromAmount").}: string
+    multiTxType* {.serializedFieldName("type").}: MultiTransactionType
+
   MultiTransactionDto* = ref object of RootObj
     id* {.serializedFieldName("id").}: int
     timestamp* {.serializedFieldName("timestamp").}: int
@@ -60,8 +68,8 @@ proc deletePendingTransaction*(chainId: int, transactionHash: string): RpcRespon
 proc fetchCryptoServices*(): RpcResponse[JsonNode] {.raises: [Exception].} =
   result = core.callPrivateRPC("wallet_getCryptoOnRamps", %* [])
 
-proc createMultiTransaction*(multiTransaction: MultiTransactionDto, data: seq[TransactionBridgeDto], password: string): RpcResponse[JsonNode] {.raises: [Exception].} =
-  let payload = %* [multiTransaction, data, hashPassword(password)]
+proc createMultiTransaction*(multiTransactionCommand: MultiTransactionCommandDto, data: seq[TransactionBridgeDto], password: string): RpcResponse[JsonNode] {.raises: [Exception].} =
+  let payload = %* [multiTransactionCommand, data, hashPassword(password)]
   result = core.callPrivateRPC("wallet_createMultiTransaction", payload)
 
 proc getMultiTransactions*(transactionIDs: seq[int]): RpcResponse[JsonNode] {.raises: [Exception].} =


### PR DESCRIPTION
Part of #10791

### What does the PR do

status-go side: https://github.com/status-im/status-go/pull/3603

Split `MultiTransactionCommand` from main `MultiTransaction` struct to decouple them, since the latter will face several changes in the near future.