### PR TITLE
fix: Holdings dropdown searcher locked

### DIFF
--- a/storybook/src/Storybook/PageToolBar.qml
+++ b/storybook/src/Storybook/PageToolBar.qml
@@ -65,7 +65,7 @@ ToolBar {
         ToolSeparator {}
 
         ToolButton {
-            text: "Inspect"
+            text: "Inspect (Ctrl+Shift+I)"
 
             Layout.rightMargin: parent.spacing
 

--- a/ui/app/AppLayouts/Chat/controls/community/EnsPanel.qml
+++ b/ui/app/AppLayouts/Chat/controls/community/EnsPanel.qml
@@ -66,6 +66,8 @@ ColumnLayout {
                 addOrUpdateButton.clicked()
         }
 
+        KeyNavigation.backtab: domainNameInput
+
         Component.onCompleted: {
             if (text) {
                 input.dirty = true

--- a/ui/app/AppLayouts/Chat/controls/community/ExtendedDropdownContent.qml
+++ b/ui/app/AppLayouts/Chat/controls/community/ExtendedDropdownContent.qml
@@ -393,6 +393,8 @@ Item {
                 return qsTr("Search collectibles")
             }
 
+            KeyNavigation.backtab: searcher
+
             Binding on placeholderText {
                 when: d.currentItemName !== ""
                 value: qsTr("Search %1").arg(d.currentItemName)


### PR DESCRIPTION
Set the `KeyNavigation.backtab` to itself to avoid accidentally pressing
`Shift+Tab` and tab away from the focused `StatusInput` (which makes it
look like it's disabled)

(a second commit fixes storybook inspection for Popup-like components)

Fixes #10561

