### PR TITLE
fix(MintTokens): Network is not correctly initialized when the new token form is prefilled

### DIFF
--- a/storybook/pages/NetworkFilterPage.qml
+++ b/storybook/pages/NetworkFilterPage.qml
@@ -9,46 +9,110 @@ import AppLayouts.Wallet.controls 1.0
 
 SplitView {
     id: root
+    Logs { id: logs }
 
-    orientation: Qt.Vertical
+    SplitView {
 
-    Item {
-        id: container
-
+        orientation: Qt.Vertical
         SplitView.fillWidth: true
-        SplitView.fillHeight: true
 
-        Rectangle {
-            width: 800
-            height: 200
-            border.width: 1
-            anchors.centerIn: parent
+        Item {
+            id: container
 
-            NetworkFilter {
+            SplitView.fillWidth: true
+            SplitView.fillHeight: true
+
+            Rectangle {
+                width: 800
+                height: 200
+                border.width: 1
                 anchors.centerIn: parent
-                width: 200
 
-                layer1Networks: NetworksModel.layer1Networks
-                layer2Networks: NetworksModel.layer2Networks
-                testNetworks: NetworksModel.testNetworks
-                enabledNetworks: NetworksModel.enabledNetworks
-                allNetworks: enabledNetworks
+                NetworkFilter {
+                    id: networkFilter
 
-                multiSelection: multiSelectionCheckBox.checked
+                    anchors.centerIn: parent
+                    width: 200
+
+                    layer1Networks: NetworksModel.layer1Networks
+                    layer2Networks: NetworksModel.layer2Networks
+                    testNetworks: NetworksModel.testNetworks
+                    enabledNetworks: NetworksModel.enabledNetworks
+                    allNetworks: enabledNetworks
+
+                    multiSelection: multiSelectionCheckBox.checked
+
+                    onToggleNetwork: logs.logEvent("onToggleNetwork: " + network.chainName)
+                }
             }
+        }
+
+        LogsAndControlsPanel {
+            id: logsAndControlsPanel
+
+            SplitView.minimumHeight: 100
+            SplitView.preferredHeight: 150
+
+            logsView.logText: logs.logText
         }
     }
 
-    LogsAndControlsPanel {
-        SplitView.minimumHeight: 100
-        SplitView.preferredHeight: 150
+    Pane {
+        SplitView.minimumWidth: 300
+        SplitView.preferredWidth: 300
 
-        SplitView.fillWidth: true
+        ColumnLayout {
+            spacing: 16
 
-        CheckBox {
-            id: multiSelectionCheckBox
-            text: "Multi selection"
-            checked: true
+            CheckBox {
+                id: multiSelectionCheckBox
+                text: "Multi selection"
+                checked: true
+                onCheckedChanged: if(!checked) ethRadioBtn.checked = true
+            }
+
+            ColumnLayout {
+                visible: !multiSelectionCheckBox.checked
+                Label {
+                    Layout.fillWidth: true
+                    text: "Chain Id:"
+                }
+
+                RadioButton {
+                    id: ethRadioBtn
+
+                    text: "Ethereum Mainnet"
+                    onCheckedChanged: if(checked) networkFilter.setChain(NetworksModel.ethNet)
+                }
+                RadioButton {
+                    text: "Optimism"
+                    onCheckedChanged: if(checked) networkFilter.setChain(NetworksModel.optimismNet)
+                }
+                RadioButton {
+                    text: "Arbitrum"
+                    onCheckedChanged: if(checked) networkFilter.setChain(NetworksModel.arbitrumNet)
+                }
+                RadioButton {
+                    text: "Hermez"
+                    onCheckedChanged: if(checked) networkFilter.setChain(NetworksModel.hermezNet)
+                }
+                RadioButton {
+                    text: "Testnet"
+                    onCheckedChanged: if(checked) networkFilter.setChain(NetworksModel.testnetNet)
+                }
+                RadioButton {
+                    text: "Custom"
+                    onCheckedChanged: if(checked) networkFilter.setChain(NetworksModel.customNet)
+                }
+                RadioButton {
+                    text: "Undefined"
+                    onCheckedChanged: if(checked) networkFilter.setChain()
+                }
+                RadioButton {
+                    text: "Not existing network id"
+                    onCheckedChanged: if(checked) networkFilter.setChain(77)
+                }
+            }
         }
     }
 }

--- a/storybook/src/Models/NetworksModel.qml
+++ b/storybook/src/Models/NetworksModel.qml
@@ -4,6 +4,13 @@ import QtQuick 2.15
 
 QtObject {
 
+    readonly property int ethNet: 1
+    readonly property int optimismNet: 2
+    readonly property int arbitrumNet: 3
+    readonly property int hermezNet: 4
+    readonly property int testnetNet: 5
+    readonly property int customNet: 6
+
     readonly property var layer1Networks: ListModel {
         function rowData(index, propName) {
             return get(index)[propName]
@@ -12,7 +19,7 @@ QtObject {
         Component.onCompleted:
             append([
                        {
-                           chainId: 1,
+                           chainId: ethNet,
                            chainName: "Ethereum Mainnet",
                            iconUrl: ModelsData.networks.ethereum,
                            isActive: true,
@@ -28,7 +35,7 @@ QtObject {
         Component.onCompleted:
             append([
                        {
-                           chainId: 2,
+                           chainId: optimismNet,
                            chainName: "Optimism",
                            iconUrl: ModelsData.networks.optimism,
                            isActive: false,
@@ -38,7 +45,7 @@ QtObject {
                            isTest: false
                        },
                        {
-                           chainId: 3,
+                           chainId: arbitrumNet,
                            chainName: "Arbitrum",
                            iconUrl: ModelsData.networks.arbitrum,
                            isActive: false,
@@ -54,7 +61,7 @@ QtObject {
         Component.onCompleted:
             append([
                        {
-                           chainId: 4,
+                           chainId: hermezNet,
                            chainName: "Hermez",
                            iconUrl: ModelsData.networks.hermez,
                            isActive: false,
@@ -64,7 +71,7 @@ QtObject {
                            isTest: true
                        },
                        {
-                           chainId: 5,
+                           chainId: testnetNet,
                            chainName: "Testnet",
                            iconUrl: ModelsData.networks.testnet,
                            isActive: false,
@@ -74,7 +81,7 @@ QtObject {
                            isTest: true
                        },
                        {
-                           chainId: 6,
+                           chainId: customNet,
                            chainName: "Custom",
                            iconUrl: ModelsData.networks.custom,
                            isActive: false,

--- a/ui/app/AppLayouts/Chat/views/communities/CommunityNewTokenView.qml
+++ b/ui/app/AppLayouts/Chat/views/communities/CommunityNewTokenView.qml
@@ -60,6 +60,13 @@ StatusScrollView {
 
     padding: 0
 
+    Component.onCompleted: {
+        if(root.isAssetView)
+            networkSelector.setChain(asset.chainId)
+        else
+            networkSelector.setChain(collectible.chainId)
+    }
+
     ColumnLayout {
         id: mainLayout
 
@@ -239,6 +246,8 @@ StatusScrollView {
         }
 
         CustomNetworkFilterRowComponent {
+            id: networkSelector
+
             label: qsTr("Select network")
             description: qsTr("The network on which this token will be minted")
         }
@@ -408,6 +417,8 @@ StatusScrollView {
         property string label
         property string description
 
+        function setChain(chainId) { netFilter.setChain(chainId) }
+
         Layout.fillWidth: true
         Layout.topMargin: Style.current.padding
         spacing: 32
@@ -418,6 +429,8 @@ StatusScrollView {
         }
 
         NetworkFilter {
+            id: netFilter
+
             Layout.preferredWidth: 160
 
             allNetworks: root.allNetworks


### PR DESCRIPTION
Fixes #11030 

### What does the PR do

- It updates `NetworkFilter.qml` to allow setting a specific `chainId` when single selection mode is on.
- It adds `storybook` use case for setting specific `chainId` in single selection mode.
- It integrates new network initialization process in mint new token view form to initialize network combobox properly.

### Affected areas

Community Settings / Mint Tokens

### Screenshot of functionality 

- App integration:

https://github.com/status-im/status-desktop/assets/97019400/a97052c0-ba51-4fd8-bdd4-9895e853e5cc

- Storybook usecase:

https://github.com/status-im/status-desktop/assets/97019400/421ebb6d-59dd-4280-b4e2-7d9ab9636c44