### PR TITLE
feat(universal-links): Adds universal links support for macOS

### DIFF
--- a/Status.entitlements
+++ b/Status.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:status.app</string>
+	</array>
+</dict>
+</plist>

--- a/vendor/DOtherSide/lib/include/DOtherSide/Status/AppDelegate.h
+++ b/vendor/DOtherSide/lib/include/DOtherSide/Status/AppDelegate.h
@@ -1,0 +1,5 @@
+namespace app_delegate {
+
+    void install();
+
+}

--- a/vendor/DOtherSide/lib/src/DOtherSide.cpp
+++ b/vendor/DOtherSide/lib/src/DOtherSide.cpp
@@ -74,6 +74,7 @@
 #include "DOtherSide/Status/OSNotification.h"
 #include "DOtherSide/Status/KeychainManager.h"
 #include "DOtherSide/Status/SoundManager.h"
+#include "DOtherSide/Status/AppDelegate.h"
 
 #ifdef MONITORING
 #include <QProcessEnvironment>
@@ -241,6 +242,9 @@ void dos_qguiapplication_create()
     qInstallMessageHandler(myMessageOutput);
 
     new QGuiApplication(argc, argv);
+#ifdef Q_OS_MACOS
+    app_delegate::install();
+#endif
     register_meta_types();
 }
 

--- a/vendor/DOtherSide/lib/src/Status/AppDelegate.mm
+++ b/vendor/DOtherSide/lib/src/Status/AppDelegate.mm
@@ -1,0 +1,39 @@
+#include "DOtherSide/Status/AppDelegate.h"
+
+#include <QString>
+#include <QUrl>
+
+#import <AppKit/NSApplication.h>
+
+
+@interface AppDelegate: NSObject <NSApplicationDelegate>
+- (BOOL)application:(NSApplication *)application
+continueUserActivity:(NSUserActivity *)userActivity
+ restorationHandler:(void (^)(NSArray<id<NSUserActivityRestoring>> *restorableObjects))restorationHandler;
+@end
+
+@implementation AppDelegate
+- (BOOL)application:(NSApplication *)application continueUserActivity:(NSUserActivity *)userActivity restorationHandler:(void (^)(NSArray<id<NSUserActivityRestoring>> *))restorationHandler {
+    if (userActivity.activityType == NSUserActivityTypeBrowsingWeb) {
+        NSURL *url = userActivity.webpageURL;
+        if (!url) {
+           return FALSE;
+        }
+        QUrl deeplink = QUrl::fromNSURL(url);
+        // set it to nim
+        return TRUE;
+    }
+    return FALSE;
+}
+
+@end
+
+namespace app_delegate {
+
+void install()
+{
+    NSApplication* applicationShared = [NSApplication sharedApplication];
+    [applicationShared setDelegate:([[[AppDelegate alloc] init] autorelease])];
+}
+
+}


### PR DESCRIPTION
Fixes: #7957

### What does the PR do

Adds `entitlements` with `status.app` domain and introduce `ApplicationDelegate` for macOS

Next step [here](https://github.com/status-im/status-desktop/issues/11087). THIS PR NOT WORKING without correct sign.

### Affected areas

App for macOS

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?
