### PR TITLE
fix(@desktop/wallet): return transaction list even if nft metadata fe…

### DIFF
--- a/src/app_service/service/transaction/async_tasks.nim
+++ b/src/app_service/service/transaction/async_tasks.nim
@@ -53,10 +53,12 @@ const loadTransactionsTask*: Task = proc(argEncoded: string) {.gcsafe, nimcall.}
       let collectiblesResponse = collectibles.getOpenseaAssetsByNFTUniqueID(arg.chainId, uniqueIds, arg.collectiblesLimit)
 
       if not collectiblesResponse.error.isNil:
-        raise newException(ValueError, "Error getOpenseaAssetsByNFTUniqueID" & collectiblesResponse.error.message)
-
-      output["collectibles"] = collectiblesResponse.result
-    
+        # We don't want to prevent getting the list of transactions if we cannot get
+        # NFT metadata. Just don't return the metadata.
+        let errDesription = "Error getOpenseaAssetsByNFTUniqueID" & collectiblesResponse.error.message
+        error "error loadTransactionsTask: ", errDesription
+      else:
+        output["collectibles"] = collectiblesResponse.result
   except Exception as e:
     let errDesription = e.msg
     error "error loadTransactionsTask: ", errDesription


### PR DESCRIPTION
…tch fails

Fixes #11054

### What does the PR do

When fetching NFT metadata fails for some erc721 transaction, we'll return the transaction list anyway so at least a "basic" version of it can be shown on the list.

![image](https://github.com/status-im/status-desktop/assets/11161531/bf68bcc2-9f50-4db9-9f5d-21f56708c51a)
