### PR TITLE
ci: upgrade to GCC 11 to match build outside Docker

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -41,7 +41,7 @@ RUN apt update -yq && apt install -yq software-properties-common \
  && add-apt-repository -y ppa:ubuntu-toolchain-r/test \
  && apt update -yq && apt full-upgrade -yq && apt install -yq --no-install-recommends --fix-missing  \
     gnupg2 openssh-client ca-certificates locales sudo jq curl wget fuse s3cmd file llvm tk-dev xz-utils \
-    git make build-essential pkg-config cmake extra-cmake-modules gcc-9 g++-9 \
+    git make build-essential pkg-config cmake extra-cmake-modules gcc-11 g++-11 \
     libgl1-mesa-dev libsm6 libice6 libfontconfig1 libdbus-1-3 libssl-dev libz-dev \
     zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev unixodbc-dev libpq-dev \
     libncurses5-dev libncursesw5-dev libpcsclite-dev  libpcre3-dev libnss3 \
@@ -52,8 +52,8 @@ RUN apt update -yq && apt install -yq software-properties-common \
     libxrandr2 libxcursor1 libxi6 libxcb-randr0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 \
     libxcb-render-util0 libxcb-shape0 libxcb-render0 libxcb-xinerama0 \
  &&  update-alternatives \
-    --install /usr/bin/gcc gcc /usr/bin/gcc-9 100 \
-    --slave /usr/bin/g++ g++ /usr/bin/g++-9 \
+    --install /usr/bin/gcc gcc /usr/bin/gcc-11 100 \
+    --slave /usr/bin/g++ g++ /usr/bin/g++-11 \
  && apt-get -qq clean
 
 # Install linuxdeployqt

--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -8,7 +8,7 @@ pipeline {
     /* Necessary image with Ubuntu 18.04 for older Glibc. */
     docker {
       label 'linux'
-      image 'statusteam/nim-status-client-build:1.2.2-qt5.15.2'
+      image 'statusteam/nim-status-client-build:1.3.0-qt5.15.2'
       /* allows jenkins use cat and mounts '/dev/fuse' for linuxdeployqt */
       args '--entrypoint="" --cap-add SYS_ADMIN --security-opt apparmor:unconfined --device /dev/fuse'
     }

--- a/ci/Jenkinsfile.tests-nim
+++ b/ci/Jenkinsfile.tests-nim
@@ -7,7 +7,7 @@ pipeline {
   agent {
     docker {
       label 'linux'
-      image 'statusteam/nim-status-client-build:1.2.1-qt5.15.2'
+      image 'statusteam/nim-status-client-build:1.3.0-qt5.15.2'
     }
   }
 


### PR DESCRIPTION
Possible fix for weird Linux crashes:
* https://github.com/status-im/infra-ci/issues/88