### PR TITLE
fix: community context menu should not say "Leave community" if not joined

### DIFF
--- a/ui/app/AppLayouts/Chat/ChatLayout.qml
+++ b/ui/app/AppLayouts/Chat/ChatLayout.qml
@@ -42,6 +42,7 @@ StackLayout {
             id: joinCommunityView
             readonly property var communityData: sectionItemModel
             name: communityData.name
+            introMessage: communityData.introMessage
             communityDesc: communityData.description
             color: communityData.color
             image: communityData.image
@@ -62,10 +63,16 @@ StackLayout {
             loginType: root.rootStore.loginType
             onNotificationButtonClicked: Global.openActivityCenterPopup()
             onAdHocChatButtonClicked: rootStore.openCloseCreateChatView()
-            onRevealAddressClicked: {
-                communityIntroDialog.open()
-            }
+            onRevealAddressClicked: openJoinCommunityDialog()
             onInvitationPendingClicked: {
+                root.rootStore.cancelPendingRequest(communityData.id)
+                joinCommunityView.isInvitationPending = root.rootStore.isCommunityRequestPending(communityData.id)
+            }
+            onJoined: {
+                root.rootStore.requestToJoinCommunityWithAuthentication(communityData.id, root.rootStore.userProfileInst.name)
+            }
+
+            onCancelMembershipRequest: {
                 root.rootStore.cancelPendingRequest(communityData.id)
                 joinCommunityView.isInvitationPending = root.rootStore.isCommunityRequestPending(communityData.id)
             }
@@ -78,28 +85,7 @@ StackLayout {
                     }
                 }
             }
-
-            CommunityIntroDialog {
-                id: communityIntroDialog
-
-                isInvitationPending: joinCommunityView.isInvitationPending
-                name: communityData.name
-                introMessage: communityData.introMessage
-                imageSrc: communityData.image
-                accessType: communityData.access
-
-                onJoined: {
-                    root.rootStore.requestToJoinCommunityWithAuthentication(communityData.id, root.rootStore.userProfileInst.name)
-                }
-
-                onCancelMembershipRequest: {
-                    root.rootStore.cancelPendingRequest(communityData.id)
-                    joinCommunityView.isInvitationPending = root.rootStore.isCommunityRequestPending(communityData.id)
-                }
-            }
         }
-
-
     }
 
     Component {

--- a/ui/app/AppLayouts/Chat/panels/communities/CommunityProfilePopupOverviewPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/CommunityProfilePopupOverviewPanel.qml
@@ -73,8 +73,9 @@ Column {
 
     StatusListItem {
         anchors.horizontalCenter: parent.horizontalCenter
-        title: qsTr("Leave community")
-        asset.name: "arrow-left"
+        visible: !root.community.amISectionAdmin
+        title: root.community.spectated ? qsTr("Close Community") : qsTr("Leave Community")
+        asset.name: root.community.spectated ? "close-circle" : "arrow-left"
         type: StatusListItem.Type.Danger
         onClicked: root.leaveButtonClicked()
     }

--- a/ui/app/AppLayouts/Chat/popups/community/CommunityProfilePopup.qml
+++ b/ui/app/AppLayouts/Chat/popups/community/CommunityProfilePopup.qml
@@ -64,8 +64,9 @@ StatusModal {
                     store: root.store
                 })
                 onLeaveButtonClicked: {
-                    communitySectionModule.leaveCommunity();
                     root.close();
+                    root.community.spectated ? communitySectionModule.leaveCommunity()
+                                             : Global.leaveCommunityRequested(root.community.name, root.community.id, root.community.outroMessage)
                 }
                 onCopyToClipboard: {
                     root.store.copyToClipboard(link);
@@ -77,17 +78,6 @@ StatusModal {
             id: transferOwnershiproot
             TransferOwnershipPopup {
                 destroyOnClose: true
-            }
-        }
-
-        Component {
-            id: inviteFriendsView
-            CommunityProfilePopupInviteFriendsPanel {
-                width: stack.width
-                headerTitle: qsTr("Invite friends")
-                community: root.community
-                contactsStore: root.contactsStore
-                rootStore: root.store
             }
         }
     }
@@ -102,18 +92,4 @@ StatusModal {
             }
         }
     ]
-
-    rightButtons: [
-        StatusButton {
-            text: qsTr("Invite")
-            visible: root.contentItem.depth > 2
-            height: !visible ? 0 : implicitHeight
-            enabled: root.contentItem.currentItem !== undefined && root.contentItem.currentItem.pubKeys.length > 0
-            onClicked: {
-                root.contentItem.currentItem.sendInvites(root.contentItem.currentItem.pubKeys, "") // NOTE: empty message
-                root.contentItem.pop()
-            }
-        }
-    ]
 }
-

--- a/ui/app/AppLayouts/Chat/views/CommunityColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/CommunityColumnView.qml
@@ -112,6 +112,7 @@ Item {
                     root.store.cancelPendingRequest(communityData.id)
                     joinCommunityButton.invitationPending = root.store.isCommunityRequestPending(communityData.id)
                 }
+                onClosed: destroy()
             }
         }
     }

--- a/ui/app/AppLayouts/CommunitiesPortal/stores/CommunitiesStore.qml
+++ b/ui/app/AppLayouts/CommunitiesPortal/stores/CommunitiesStore.qml
@@ -172,9 +172,9 @@ QtObject {
 
 
     readonly property Connections connections: Connections {
-      target: communitiesModuleInst
-      function onImportingCommunityStateChanged(communityId, state, errorMsg) {
-          root.importingCommunityStateChanged(communityId, state, errorMsg)
-      }
+        target: communitiesModuleInst
+        function onImportingCommunityStateChanged(communityId, state, errorMsg) {
+            root.importingCommunityStateChanged(communityId, state, errorMsg)
+        }
     }
 }

--- a/ui/app/AppLayouts/Profile/panels/CommunitiesListPanel.qml
+++ b/ui/app/AppLayouts/Profile/panels/CommunitiesListPanel.qml
@@ -15,7 +15,8 @@ StatusListView {
     property bool hasAddedContacts: false
 
     signal inviteFriends(var communityData)
-    signal leaveCommunityClicked(string communityId)
+    signal closeCommunityClicked(string communityId)
+    signal leaveCommunityClicked(string community, string communityId, string outroMessage)
     signal setCommunityMutedClicked(string communityId, bool muted)
     signal setActiveCommunityClicked(string communityId)
 
@@ -43,17 +44,14 @@ StatusListView {
 
         components: [
             StatusFlatButton {
+                anchors.verticalCenter: parent.verticalCenter
                 objectName: "CommunitiesListPanel_leaveCommunityPopupButton"
                 size: StatusBaseButton.Size.Small
                 type: StatusBaseButton.Type.Danger
                 borderColor: "transparent"
-                text: qsTr("Leave Community")
-                onClicked: {
-                    Global.openPopup(leaveCommunityPopup, {
-                                         community: model.name,
-                                         communityId: model.id
-                                     })
-                }
+                enabled: !model.amISectionAdmin
+                text: model.spectated ? qsTr("Close Community") : qsTr("Leave Community")
+                onClicked: model.spectated ? root.closeCommunityClicked(model.id) : root.leaveCommunityClicked(model.name, model.id, model.outroMessage)
             },
             StatusFlatButton {
                 anchors.verticalCenter: parent.verticalCenter
@@ -68,46 +66,5 @@ StatusListView {
                 onClicked: root.inviteFriends(model)
             }
         ]
-    } // StatusListItem
-
-    property Component leaveCommunityPopup: StatusModal {
-        id: leavePopup
-
-        property string community: ""
-        property string communityId: ""
-
-        anchors.centerIn: parent
-        headerSettings.title: qsTr("Leave %1").arg(community)
-        contentItem: Item {
-            implicitWidth: 368
-            implicitHeight: msg.implicitHeight + 32
-            StatusBaseText {
-                id: msg
-                anchors.left: parent.left
-                anchors.right: parent.right
-                anchors.verticalCenter: parent.verticalCenter
-                anchors.margins: 16
-                wrapMode: Text.WrapAtWordBoundaryOrAnywhere
-                text: qsTr("Are you sure you want to leave? Once you leave, you will have to request to rejoin if you change your mind.")
-                color: Theme.palette.directColor1
-                font.pixelSize: 15
-            }
-        }
-
-        rightButtons: [
-            StatusButton {
-                text: qsTr("Cancel")
-                onClicked: leavePopup.close()
-            },
-            StatusButton {
-                objectName: "CommunitiesListPanel_leaveCommunityButtonInPopup"
-                type: StatusBaseButton.Type.Danger
-                text: qsTr("Leave community")
-                onClicked: {
-                    root.leaveCommunityClicked(leavePopup.communityId)
-                    leavePopup.close()
-                }
-            }
-        ]
     }
-} // ListView
+}

--- a/ui/app/AppLayouts/Profile/views/CommunitiesView.qml
+++ b/ui/app/AppLayouts/Profile/views/CommunitiesView.qml
@@ -30,9 +30,7 @@ SettingsContentBase {
     titleRowComponentLoader.sourceComponent: StatusButton {
         text: qsTr("Import community")
         size: StatusBaseButton.Size.Small
-        onClicked: {
-            Global.openPopup(importCommunitiesPopupComponent)
-        }
+        onClicked: Global.importCommunityPopupRequested()
     }
 
     Item {
@@ -117,8 +115,12 @@ SettingsContentBase {
                     ]
                 }
 
-                onLeaveCommunityClicked: {
+                onCloseCommunityClicked: {
                     root.profileSectionStore.communitiesProfileModule.leaveCommunity(communityId)
+                }
+
+                onLeaveCommunityClicked: {
+                    Global.leaveCommunityRequested(community, communityId, outroMessage)
                 }
 
                 onSetCommunityMutedClicked: {
@@ -135,16 +137,6 @@ SettingsContentBase {
                                                              null)
                 }
             }
-
-        } // Column
-    } // Item
-
-    property Component importCommunitiesPopupComponent: ImportCommunityPopup {
-        anchors.centerIn: parent
-        store: root.profileSectionStore
-        onClosed: {
-            destroy()
         }
     }
-
-} // ScrollView
+}

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -354,6 +354,8 @@ Item {
                             onTriggered: popups.openCommunityProfilePopup(appMain.rootStore, model, communityContextMenu.chatCommunitySectionModule)
                         }
 
+                        StatusMenuSeparator {}
+
                         StatusAction {
                             text: model.muted ? qsTr("Unmute Community") : qsTr("Mute Community")
                             icon.name: model.muted ? "notification-muted" : "notification"
@@ -362,13 +364,20 @@ Item {
                             }
                         }
 
-                        StatusMenuSeparator {}
+                        StatusMenuSeparator { visible: leaveCommunityMenuItem.enabled }
 
                         StatusAction {
-                            text: qsTr("Leave Community")
-                            icon.name: "arrow-left"
+                            id: leaveCommunityMenuItem
+                            enabled: !model.amISectionAdmin
+                            text: {
+                                if (model.spectated)
+                                    return qsTr("Close Community")
+                                return qsTr("Leave Community")
+                            }
+                            icon.name: model.spectated ? "close-circle" : "arrow-left"
                             type: StatusAction.Type.Danger
-                            onTriggered: communityContextMenu.chatCommunitySectionModule.leaveCommunity()
+                            onTriggered: model.spectated ? communityContextMenu.chatCommunitySectionModule.leaveCommunity()
+                                                         : popups.openLeaveCommunityPopup(model.name, model.id, model.outroMessage)
                         }
                     }
                 }

--- a/ui/imports/utils/Global.qml
+++ b/ui/imports/utils/Global.qml
@@ -56,6 +56,7 @@ QtObject {
     signal switchToCommunity(string communityId)
     signal createCommunityPopupRequested(bool isDiscordImport)
     signal importCommunityPopupRequested()
+    signal leaveCommunityRequested(string community, string communityId, string outroMessage)
 
     signal playSendMessageSound()
     signal playNotificationSound()


### PR DESCRIPTION
- differentiate between "Close" and "Leave" a community where the former applies to spectated communities
- move the "leave community" confirmation popup to a shared place (Popups.qml), extend it with the outro message and reuse it everywhere
- don't let admins leave a community
- some minor cleanups and dead code removals

Fixes #10963

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

No "leave" items when admin:
![image](https://github.com/status-im/status-desktop/assets/5377645/893b4372-af94-45f3-b3c6-1761efbe042d)
![image](https://github.com/status-im/status-desktop/assets/5377645/def94e4b-f2df-46c8-8789-d7f64f7b681d)
![image](https://github.com/status-im/status-desktop/assets/5377645/62402e4c-fa6c-4e20-9aed-aaf53ac6728e)


Regular "leave" item:
![image](https://github.com/status-im/status-desktop/assets/5377645/69634748-3a09-4de0-bedf-aab49bd7ce8b)

"Close" spectated community
![image](https://github.com/status-im/status-desktop/assets/5377645/2e9d79be-ade0-4e60-b48b-8b3e55cd1204)

Confirmation when leaving from context menu (with outro message):
![image](https://github.com/status-im/status-desktop/assets/5377645/2f1ea222-8a66-427f-886a-f2640e50d489)

Confirmation when leaving from settings (with outro message):
![image](https://github.com/status-im/status-desktop/assets/5377645/a502917f-f608-4895-93cf-1e4a973020c4)


