### PR TITLE
fix(ChatColumnView): fix `StatusChatInput` blocked state

### DIFF
--- a/src/app/modules/main/chat_section/chat_content/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/module.nim
@@ -93,7 +93,7 @@ method load*(self: Module, chatItem: chat_item.Item) =
     self.controller.isUsersListAvailable(), chatName, chatImage,
     chatItem.color, chatItem.description, chatItem.emoji, chatItem.hasUnreadMessages, chatItem.notificationsCount,
     chatItem.muted, chatItem.position, isUntrustworthy = trustStatus == TrustStatus.Untrustworthy,
-    isContact)
+    isContact, chatItem.blocked)
 
   self.inputAreaModule.load()
   self.messagesModule.load()

--- a/src/app/modules/main/chat_section/chat_content/view.nim
+++ b/src/app/modules/main/chat_section/chat_content/view.nim
@@ -35,10 +35,10 @@ QtObject:
   proc load*(self: View, id: string, `type`: int, belongsToCommunity, isUsersListAvailable: bool,
       name, icon: string, color, description, emoji: string, hasUnreadMessages: bool,
       notificationsCount: int, muted: bool, position: int, isUntrustworthy: bool,
-      isContact: bool) =
+      isContact: bool, blocked: bool) =
     self.chatDetails.setChatDetails(id, `type`, belongsToCommunity, isUsersListAvailable, name,
       icon, color, description, emoji, hasUnreadMessages, notificationsCount, muted, position,
-      isUntrustworthy, isContact)
+      isUntrustworthy, isContact, blocked)
     self.delegate.viewDidLoad()
     self.chatDetailsChanged()
 

--- a/storybook/pages/StatusChatInputPage.qml
+++ b/storybook/pages/StatusChatInputPage.qml
@@ -89,6 +89,7 @@ SplitView {
             sourceComponent: StatusChatInput {
                 id: chatInput
                 property var globalUtils: globalUtilsMock.globalUtils
+                enabled: enabledCheckBox.checked
                 usersStore: QtObject {
                     readonly property var usersModel: fakeUsersModel
                 }
@@ -114,14 +115,26 @@ SplitView {
          SplitView.minimumWidth: 300
          SplitView.preferredWidth: 300
 
-         UsersModelEditor {
-             id: modelEditor
+         ColumnLayout {
              anchors.fill: parent
-             model: fakeUsersModel
+             CheckBox {
+                 id: enabledCheckBox
+                 text: "enabled"
+                 checked: true
+             }
+             MenuSeparator {
+                 Layout.fillWidth: true
+             }
+             UsersModelEditor {
+                 id: modelEditor
+                 Layout.fillWidth: true
+                 Layout.fillHeight: true
+                 model: fakeUsersModel
 
-             onRemoveClicked: fakeUsersModel.remove(index, 1)
-             onRemoveAllClicked: fakeUsersModel.clear()
-             onAddClicked: fakeUsersModel.append(modelEditor.getNewUser(fakeUsersModel.count))
+                 onRemoveClicked: fakeUsersModel.remove(index, 1)
+                 onRemoveAllClicked: fakeUsersModel.clear()
+                 onAddClicked: fakeUsersModel.append(modelEditor.getNewUser(fakeUsersModel.count))
+             }
          }
      }
 }

--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -45,7 +45,6 @@ Rectangle {
 
     property bool isImage: false
     property bool isEdit: false
-    property bool isContactBlocked: false
 
     property int messageLimit: 2000
     property int messageLimitVisible: 200
@@ -135,8 +134,10 @@ Rectangle {
         // common popups are emoji, jif and stickers
         // Put controlWidth as argument with default value for binding
         function getCommonPopupRelativePosition(popup, popupParent, controlWidth = control.width) {
-            const controlX = controlWidth - emojiPopup.width - Style.current.halfPadding
-            const controlY = -emojiPopup.height
+            const popupWidth = emojiPopup ? emojiPopup.width : 0
+            const popupHeight = emojiPopup ? emojiPopup.height : 0
+            const controlX = controlWidth - popupWidth - Style.current.halfPadding
+            const controlY = -popupHeight
             return popupParent.mapFromItem(control, controlX, controlY)
         }
 
@@ -1094,7 +1095,6 @@ Rectangle {
                 Layout.bottomMargin: 4
                 icon.name: "chat-commands"
                 type: StatusQ.StatusFlatRoundButton.Type.Tertiary
-                enabled: !control.isContactBlocked
                 onClicked: {
                     d.chatCommandsPopupOpen ? Global.closePopup() : Global.openPopup(chatCommandsPopup);
                     d.chatCommandsPopupOpen = !d.chatCommandsPopupOpen;
@@ -1112,7 +1112,6 @@ Rectangle {
             icon.name: "image"
             type: StatusQ.StatusFlatRoundButton.Type.Tertiary
             visible: !isEdit
-            enabled: !control.isContactBlocked
             onClicked: {
                 highlighted = true
                 const popup = imageDialogComponent.createObject(control)
@@ -1130,7 +1129,6 @@ Rectangle {
             implicitHeight: inputLayout.implicitHeight + inputLayout.anchors.topMargin + inputLayout.anchors.bottomMargin
             implicitWidth: inputLayout.implicitWidth + inputLayout.anchors.leftMargin + inputLayout.anchors.rightMargin
 
-            enabled: !control.isContactBlocked
             color: isEdit ? Theme.palette.statusChatInput.secondaryBackgroundColor : Style.current.inputBackground
             radius: 20
 
@@ -1539,13 +1537,5 @@ Rectangle {
             }
         }
 
-        StatusQ.StatusButton {
-            Layout.fillHeight: true
-            Layout.bottomMargin: 4
-            visible: control.isContactBlocked
-            text: qsTr("Unblock")
-            type: StatusQ.StatusBaseButton.Type.Danger
-            onClicked: control.unblockChat()
-        }
     }
 }


### PR DESCRIPTION
### What does the PR do

* Fix `blocked` state wasn't loading on app start 
* Move `Unblock` button to `ChatColumnView`, because:
    * It's only used there
    * This simplifies the logic with `enabled`/`blocked` properties
* Fixed `Unblock` button size to fit the input 
* Added `enabled` property for corresponding storybook page


### Screenshot of functionality (including design for comparison)

![image](https://github.com/status-im/status-desktop/assets/25482501/f7aa48c0-265d-406b-82b4-9c2b68b6b250)
