### PR TITLE
chore(e2e_tests): extend saved address creation with network options

### DIFF
--- a/test/ui-test/src/screens/components/saved_address_popup.py
+++ b/test/ui-test/src/screens/components/saved_address_popup.py
@@ -8,17 +8,56 @@ class SavedAddressPopup(BasePopup):
         super(SavedAddressPopup, self).__init__()
         self._name_text_edit = TextEdit('mainWallet_Saved_Addreses_Popup_Name_Input')
         self._save_add_address_button = Button('mainWallet_Saved_Addreses_Popup_Address_Add_Button')
-
+        self._add_networks_selector = BaseElement('mainWallet_Saved_Addreses_Popup_Add_Network_Selector_Tag')
+        self._ethereum_mainnet_checkbox = CheckBox('mainWallet_Saved_Addresses_Popup_Add_Network_Selector_Mainnet_checkbox')
+        self._optimism_mainnet_checkbox = CheckBox('mainWallet_Saved_Addresses_Popup_Add_Network_Selector_Optimism_checkbox')
+        self._arbitrum_mainnet_checkbox = CheckBox('mainWallet_Saved_Addresses_Popup_Add_Network_Selector_Arbitrum_checkbox')
+        self._ethereum_mainnet_network_tag = BaseElement('mainWallet_Saved_Addresses_Popup_Network_Selector_Mainnet_network_tag')
+        self._optimism_mainnet_network_tag = BaseElement('mainWallet_Saved_Addresses_Popup_Network_Selector_Optimism_network_tag')
+        self._arbitrum_mainnet_network_tag = BaseElement('mainWallet_Saved_Addresses_Popup_Network_Selector_Arbitrum_network_tag')
 
 class AddSavedAddressPopup(SavedAddressPopup):
     def __init__(self):
         super(AddSavedAddressPopup, self).__init__()
         self._address_text_edit = TextEdit('mainWallet_Saved_Addreses_Popup_Address_Input_Edit')
 
+    def set_ethereum_mainnet_network(self, value: bool):
+        self._ethereum_mainnet_checkbox.set(value)
+        return self
+    
+    def set_optimism_mainnet_network(self, value: bool):
+        self._optimism_mainnet_checkbox.set(value)
+        return self
+    
+    def set_arbitrum_mainnet_network(self, value: bool):
+        self._arbitrum_mainnet_checkbox.set(value)
+        return self
+    
+    def verify_network_selector_enabled(self):
+        assert self._add_networks_selector.is_visible, f'Network selector is not active'
+
+    def verify_ethereum_mainnet_network_tag_present(self):
+        assert self._ethereum_mainnet_network_tag.is_visible, f'Ethereum Mainnet network tag is not present'
+
+    def verify_otimism_mainnet_network_tag_present(self):
+        assert self._optimism_mainnet_network_tag.is_visible, f'Optimism Mainnet network tag is not present' 
+
+    def verify_arbitrum_mainnet_network_tag_present(self):
+        assert self._arbitrum_mainnet_network_tag.is_visible, f'Arbitrum Mainnet network tag is not present'       
+
     def add_saved_address(self, name: str, address: str):
         self._name_text_edit.text = name
         self._address_text_edit.clear(verify=False)
         self._address_text_edit.type_text(address)
+        self.verify_network_selector_enabled()
+        self._add_networks_selector.click(1, 1)
+        self.set_ethereum_mainnet_network(True)
+        self.set_optimism_mainnet_network(True)
+        self.set_arbitrum_mainnet_network(True)
+        self._save_add_address_button.click() # i click it twice to close the network selector pop up
+        self.verify_ethereum_mainnet_network_tag_present()
+        self.verify_otimism_mainnet_network_tag_present()
+        self.verify_arbitrum_mainnet_network_tag_present()
         self._save_add_address_button.click()
         self.wait_until_hidden()
 

--- a/test/ui-test/testSuites/global_shared/scripts/wallet_names.py
+++ b/test/ui-test/testSuites/global_shared/scripts/wallet_names.py
@@ -165,7 +165,14 @@ mainWallet_Saved_Addreses_Popup_Name_Input = {"container": statusDesktop_mainWin
 mainWallet_Saved_Addreses_Popup_Address_Input = {"container": statusDesktop_mainWindow, "objectName": "savedAddressAddressInput", "type": "StatusInput"}
 mainWallet_Saved_Addreses_Popup_Address_Input_Edit = {"container": statusDesktop_mainWindow, "objectName": "savedAddressAddressInputEdit", "type": "TextEdit"}
 mainWallet_Saved_Addreses_Popup_Address_Add_Button = {"container": statusDesktop_mainWindow, "objectName": "addSavedAddress", "type": "StatusButton"}
-
+mainWallet_Saved_Addreses_Popup_Add_Network_Selector = {"container": statusDesktop_mainWindow, "objectName": "addSavedAddressNetworkSelector", "type": "StatusNetworkSelector", "visible": True}
+mainWallet_Saved_Addreses_Popup_Add_Network_Selector_Tag = {"container": statusDesktop_mainWindow_overlay, "objectName": "networkSelectorTag", "type": "StatusNetworkListItemTag"}
+mainWallet_Saved_Addresses_Popup_Add_Network_Selector_Mainnet_checkbox = {"container": statusDesktop_mainWindow_overlay, "objectName": "networkSelectionCheckbox_Ethereum Mainnet", "type": "StatusCheckBox", "visible": True}
+mainWallet_Saved_Addresses_Popup_Add_Network_Selector_Optimism_checkbox = {"container": statusDesktop_mainWindow_overlay, "objectName": "networkSelectionCheckbox_Optimism", "type": "StatusCheckBox", "visible": True}
+mainWallet_Saved_Addresses_Popup_Add_Network_Selector_Arbitrum_checkbox = {"container": statusDesktop_mainWindow_overlay, "objectName": "networkSelectionCheckbox_Arbitrum", "type": "StatusCheckBox", "visible": True}
+mainWallet_Saved_Addresses_Popup_Network_Selector_Mainnet_network_tag = {"container": statusDesktop_mainWindow_overlay, "objectName": "networkTagRectangle_Ethereum Mainnet", "type": "Rectangle", "visible": True}
+mainWallet_Saved_Addresses_Popup_Network_Selector_Optimism_network_tag = {"container": statusDesktop_mainWindow_overlay, "objectName": "networkTagRectangle_Optimism", "type": "Rectangle", "visible": True}
+mainWallet_Saved_Addresses_Popup_Network_Selector_Arbitrum_network_tag = {"container": statusDesktop_mainWindow_overlay, "objectName": "networkTagRectangle_Arbitrum", "type": "Rectangle", "visible": True}
 # Collectibles view
 mainWallet_Collections_Repeater = {"container": statusDesktop_mainWindow, "objectName": "collectionsRepeater", "type": "Repeater"}
 mainWallet_Collectibles_Repeater = {"container": statusDesktop_mainWindow, "objectName": "collectiblesRepeater", "type": "Repeater"}

--- a/test/ui-test/testSuites/suite_wallet/tst_wallet_savedAddresses/test.feature
+++ b/test/ui-test/testSuites/suite_wallet/tst_wallet_savedAddresses/test.feature
@@ -8,23 +8,18 @@ Background:
     And the user opens the wallet section
     And the user accepts the signing phrase
 
-    Scenario Outline: The user can manage a saved address
+    Scenario Outline: The user can add saved address with all network options, edit address name and delete address record
         When the user adds a saved address named "<name>" and address "<address>"
         And the user edits a saved address with name "<name>" to "<new_name>"
         Then the name "<new_name>" is in the list of saved addresses
         When the user deletes the saved address with name "<new_name>"
         Then the name "<new_name>" is not in the list of saved addresses
-        When the user adds a saved address named "<name>" and ENS name "<ens_name>"
-        Then the name "<name>" is in the list of saved addresses
-        # Test for toggling favourite button is disabled until favourite functionality is enabled
-        # When the user adds a saved address named "<name>" and address "<address>"
-        # And the user toggles favourite for the saved address with name "<name>"
-        # Then the saved address "<name>" has favourite status "true"
         Examples:
-            | name | address                                    | new_name | ens_name |
-            | bar  | 0x8397bc3c5a60a1883174f722403d63a8833312b7 | foo      | status.eth |
-     # TODO: add saved address with all the networks
+            | name | address                                    |new_name |
+            | bar  | 0x8397bc3c5a60a1883174f722403d63a8833312b7 |foo      |
+           # | foo  | nastya.stateofus.eth | bar | https://github.com/status-im/status-desktop/issues/11090
      # TODO: actions from burger menu
-     # TODO: split the scenario above to several (exlude delete i think)
+     # TODO: split the scenario above to several (exclude delete i think)
      # TODO: enhance edit actions to change networks
      # TODO: test for Share button
+     # TODO: add logic to recognize mainnet / testnet and select appropriate networks

--- a/ui/app/AppLayouts/Wallet/controls/NetworkSelectItemDelegate.qml
+++ b/ui/app/AppLayouts/Wallet/controls/NetworkSelectItemDelegate.qml
@@ -47,6 +47,7 @@ StatusListItem {
     components: [
         StatusCheckBox {
             id: checkBox
+            objectName: "networkSelectionCheckbox_" + model.chainName
             tristate: true
             visible: !root.singleSelection.enabled
 

--- a/ui/app/AppLayouts/Wallet/controls/StatusNetworkListItemTag.qml
+++ b/ui/app/AppLayouts/Wallet/controls/StatusNetworkListItemTag.qml
@@ -43,6 +43,7 @@ Control {
     implicitHeight: d.minHeight
 
     background: Rectangle {
+        objectName: "networkTagRectangle_" + root.title
         color: root.hovered ? Theme.palette.primaryColor3 : asset.bgColor
         radius: asset.bgRadius
         border.color: asset.bgBorderColor

--- a/ui/app/AppLayouts/Wallet/controls/StatusNetworkSelector.qml
+++ b/ui/app/AppLayouts/Wallet/controls/StatusNetworkSelector.qml
@@ -156,7 +156,7 @@ Rectangle {
 
             StatusRoundButton {
                 id: addItemButton
-
+                
                 implicitHeight: 32
                 implicitWidth: implicitHeight
                 height: width
@@ -169,7 +169,7 @@ Rectangle {
 
             StatusNetworkListItemTag {
                 id: defaultListItemTag
-
+                objectName: "networkSelectorTag"
                 visible: !itemsModel || itemsModel.count === 0
                 title: root.defaultItemText
                 button.visible: true

--- a/ui/app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml
+++ b/ui/app/AppLayouts/Wallet/popups/AddEditSavedAddressPopup.qml
@@ -247,7 +247,7 @@ StatusDialog {
 
         StatusNetworkSelector {
             id: networkSelector
-
+            objectName: "addSavedAddressNetworkSelector"
             title: "Network preference"
             enabled: addressInput.valid && !d.addressInputIsENS
             defaultItemText: "Add networks"


### PR DESCRIPTION
### What does the PR do

Fixes https://github.com/status-im/desktop-qa-automation/issues/62

The whole test was refactored:
- removed unnecessary steps
- added networks selection
- added verification for network selector enabled
- added validation for network tag presence when selected
- commented out adding saved address with ens option because of https://github.com/status-im/status-desktop/issues/11090

### Affected areas

Saved addresses tests