### PR TITLE
fix(SyncingView): only suggest to sync non-synced devices

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/StatusSyncDeviceDelegate.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusSyncDeviceDelegate.qml
@@ -15,6 +15,7 @@ StatusListItem {
 
     property string deviceName: ""
     property string deviceType: ""
+    property bool deviceEnabled
     property real timestamp: 0
     property bool isCurrentDevice: false
     property bool showOnlineBadge: !isCurrentDevice
@@ -22,7 +23,7 @@ StatusListItem {
     signal itemClicked
     signal setupSyncingButtonClicked
 
-    title: root.deviceName || qsTr("No device name")
+    title: root.deviceName || qsTr("Unknown device")
 
     asset.name: Utils.deviceIcon(root.deviceType)
     asset.bgColor: Theme.palette.primaryColor3
@@ -56,7 +57,7 @@ StatusListItem {
     components: [
         StatusButton {
             anchors.verticalCenter: parent.verticalCenter
-            visible: root.enabled && !root.isCurrentDevice
+            visible: root.enabled && !root.deviceEnabled && !root.isCurrentDevice
             text: qsTr("Setup syncing")
             size: StatusBaseButton.Size.Small
             onClicked: {
@@ -65,7 +66,7 @@ StatusListItem {
         },
         StatusIcon {
             anchors.verticalCenter: parent.verticalCenter
-            visible: root.enabled
+            visible: root.deviceEnabled
             icon: "next"
             color: Theme.palette.baseColor1
         }
@@ -80,6 +81,9 @@ StatusListItem {
         readonly property int minutesFromSync: secondsFromSync / 60
         readonly property int daysFromSync: LocaleUtils.daysBetween(new Date(now), new Date(d.deviceLastTimestamp))
         readonly property bool onlineNow: secondsFromSync <= 120
+
+        // We know if the device is paired (aka syncing is set up), if we have it's metadata
+        readonly property bool paired: root.deviceName
     }
 
     Timer {

--- a/ui/app/AppLayouts/Profile/ProfileLayout.qml
+++ b/ui/app/AppLayouts/Profile/ProfileLayout.qml
@@ -45,6 +45,7 @@ StatusSectionLayout {
     Component.onCompleted: {
         profileContainer.currentIndex = -1
         profileContainer.currentIndex = Qt.binding(() => Global.settingsSubsection)
+        root.store.devicesStore.loadDevices() // Load devices to get non-paired number for badge
     }
 
     QtObject {

--- a/ui/app/AppLayouts/Profile/panels/MenuPanel.qml
+++ b/ui/app/AppLayouts/Profile/panels/MenuPanel.qml
@@ -6,12 +6,15 @@ import shared 1.0
 
 import utils 1.0
 
+import "../stores"
+
 Column {
     id: root
     spacing: 8
 
-    property var privacyStore
-    property var contactsStore
+    property PrivacyStore privacyStore
+    property ContactsStore contactsStore
+    property DevicesStore devicesStore
     property alias mainMenuItems: mainMenuItems.model
     property alias settingsMenuItems: settingsMenuItems.model
     property alias extraMenuItems: extraMenuItems.model
@@ -36,6 +39,8 @@ Column {
                 switch (model.subsection) {
                     case Constants.settingsSubsection.backUpSeed:
                         return !root.privacyStore.mnemonicBackedUp
+                    case Constants.settingsSubsection.syncingSettings:
+                        return root.devicesStore.devicesModel.count - root.devicesStore.devicesModel.pairedCount
                     default: return "";
                 }
             }

--- a/ui/app/AppLayouts/Profile/views/LeftTabView.qml
+++ b/ui/app/AppLayouts/Profile/views/LeftTabView.qml
@@ -41,6 +41,7 @@ Item {
             width: scrollView.availableWidth
             privacyStore: store.privacyStore
             contactsStore: store.contactsStore
+            devicesStore: store.devicesStore
             mainMenuItems: store.mainMenuItems
             settingsMenuItems: store.settingsMenuItems
             extraMenuItems: store.extraMenuItems

--- a/ui/app/AppLayouts/Profile/views/SyncingView.qml
+++ b/ui/app/AppLayouts/Profile/views/SyncingView.qml
@@ -32,10 +32,6 @@ SettingsContentBase {
     property PrivacyStore privacyStore
     property AdvancedStore advancedStore
 
-    Component.onCompleted: {
-        root.devicesStore.loadDevices()
-    }
-
     ColumnLayout {
         id: layout
         width: root.contentWidth
@@ -117,23 +113,35 @@ SettingsContentBase {
 
             model: SortFilterProxyModel {
                 sourceModel: root.devicesStore.devicesModel
-                sorters: StringSorter {
-                    roleName: "isCurrentDevice"
-                    sortOrder: Qt.DescendingOrder
-                }
+                sorters: [
+                    RoleSorter {
+                        roleName: "isCurrentDevice"
+                        sortOrder: Qt.DescendingOrder
+                        priority: 2
+                    },
+                    RoleSorter {
+                        roleName: "enabled"
+                        sortOrder: Qt.DescendingOrder
+                        priority: 1 // Higher number === higher priority
+                    }
+                ]
             }
 
             delegate: StatusSyncDeviceDelegate {
                 width: ListView.view.width
                 deviceName: model.name
                 deviceType: model.deviceType
+                deviceEnabled: model.enabled
                 timestamp: model.timestamp
                 isCurrentDevice: model.isCurrentDevice
                 onSetupSyncingButtonClicked: {
                     d.setupSyncing(SetupSyncingPopup.GenerateSyncCode)
                 }
                 onClicked: {
-                    d.personalizeDevice(model)
+                    if (deviceEnabled)
+                        d.personalizeDevice(model)
+                    else
+                        d.setupSyncing(SetupSyncingPopup.GenerateSyncCode)
                 }
             }
         }


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/11082

### What does the PR do

* Show `Setup Syncing` button only for non-paired devices
* Clicking on non-paired device will start pairing process
* Show non-paired devices badge for `Settings/Syncing`

### Screenshot of functionality (including design for comparison)
<img width="1312" alt="Screenshot 2023-06-14 at 19 12 56" src="https://github.com/status-im/status-desktop/assets/25482501/85f81a17-412f-4173-87b1-99ce86aa1d64">
