### PR TITLE
fix(badges): fix muted chat not being marked as read

### DIFF
--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -554,7 +554,7 @@ method addNewChat*(
     setChatAsActive: bool = true,
     insertIntoModel: bool = true,
   ): Item =
-  let hasNotification = not chatDto.muted and (chatDto.unviewedMessagesCount > 0 or chatDto.unviewedMentionsCount > 0)
+  let hasNotification =chatDto.unviewedMessagesCount > 0
   let notificationsCount = chatDto.unviewedMentionsCount
 
   var chatName = chatDto.name
@@ -1198,10 +1198,7 @@ proc addOrUpdateChat(self: Module,
 
   if not self.chatsLoaded or chatExists:
     # Update badges
-    var hasUnreadMessages = false
-    if not chat.muted:
-      hasUnreadMessages = chat.unviewedMessagesCount > 0
-    self.updateBadgeNotifications(chat, hasUnreadMessages, chat.unviewedMentionsCount)
+    self.updateBadgeNotifications(chat, chat.unviewedMessagesCount > 0, chat.unviewedMentionsCount)
 
   if not self.chatsLoaded:
     return

--- a/src/app_service/service/chat/service.nim
+++ b/src/app_service/service/chat/service.nim
@@ -279,7 +279,8 @@ QtObject:
 
     for chat in self.channelGroups[communityId].chats:
       result.unviewedMentionsCount += chat.unviewedMentionsCount
-      if chat.muted:
+      # We count the unread messages if we are unmuted and it's not a mention, we want to show a badge on mentions
+      if chat.unviewedMentionsCount == 0 and chat.muted:
         continue
       if chat.unviewedMessagesCount > 0:
         result.unviewedMessagesCount = result.unviewedMessagesCount + chat.unviewedMessagesCount

--- a/ui/StatusQ/src/StatusQ/Components/StatusChatListItem.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusChatListItem.qml
@@ -200,7 +200,7 @@ Rectangle {
             anchors.rightMargin: 8
             StatusBadge {
                 id: statusBadge
-                readonly property bool onlyUnread: (root.notificationsCount === 0 && root.hasUnreadMessages)
+                readonly property bool onlyUnread: !root.muted && root.notificationsCount === 0 && root.hasUnreadMessages
                 anchors.centerIn: parent
                 color: onlyUnread ? Theme.palette.baseColor1 :
                                     root.muted ? Theme.palette.primaryColor2 : Theme.palette.primaryColor1


### PR DESCRIPTION
Fixes #11041

status-go PR https://github.com/status-im/status-go/pull/3619

Fixes the bug where going to a muted channel with a mention doesn't mark it as read. This was because the QML doesn't call mark as read when a channel doesn't have unviewed messages. That was because our Nim code put 0 as unviewedMessageCount when a channel is muted.

I changed it so that channels always have the value from status-go. No more conditions on the Nim side. Now the condition is on the QML side. So we hide the badge in QML instead. That also means that showing the number of unviewed message, even in a muted channel works.

I also fixed a bug where we counted muted messages on app restart for the normal badge. Usually it didn't cause issues, because it's rare that you had messages in a muted channel and nothing else. You'd also have unread messages in an unmuted channel. so you'd go there, read it, and it would then update the parent badge.  While testing this issue, I discovered that we in fact count muted channels for the parent badge. So i fixed it in this one too.
So while chats don't have any Nim code for muted chats, sections do, because status-go doesn't really give us that information.
