### PR TITLE
feat(@dekstop/wallet): use amounts from activity backend

### DIFF
--- a/src/app/modules/main/wallet_section/activity/controller.nim
+++ b/src/app/modules/main/wallet_section/activity/controller.nim
@@ -1,5 +1,5 @@
 import NimQml, logging, std/json, sequtils, sugar, options
-import tables
+import tables, stint
 
 import model
 import entry
@@ -15,6 +15,7 @@ import backend/activity as backend_activity
 import backend/backend as backend
 import backend/transactions
 
+import app_service/service/currency/service as currency_service
 import app_service/service/transaction/service as transaction_service
 
 proc toRef*[T](obj: T): ref T =
@@ -31,6 +32,7 @@ QtObject:
       recipientsModel: RecipientsModel
       transactionsModule: transactions_module.AccessInterface
       currentActivityFilter: backend_activity.ActivityFilter
+      currencyService: currency_service.Service
 
       events: EventEmitter
 
@@ -58,6 +60,20 @@ QtObject:
 
   QtProperty[QVariant] recipientsModel:
     read = getRecipientsModel
+
+  proc buildMultiTransactionExtraData(self: Controller, metadata: backend_activity.ActivityEntry, item: MultiTransactionDto): ExtraData =
+    # TODO: Use symbols from backendEntry when they're available
+    result.inSymbol = item.toAsset
+    result.inAmount = self.currencyService.parseCurrencyValue(result.inSymbol, metadata.amountIn)
+    result.outSymbol = item.fromAsset
+    result.outAmount = self.currencyService.parseCurrencyValue(result.outSymbol, metadata.amountOut)
+
+  proc buildTransactionExtraData(self: Controller, metadata: backend_activity.ActivityEntry, item: ref Item): ExtraData =
+    # TODO: Use symbols from backendEntry when they're available
+    result.inSymbol = item[].getSymbol()
+    result.inAmount = self.currencyService.parseCurrencyValue(result.inSymbol, metadata.amountIn)
+    result.outSymbol = item[].getSymbol()
+    result.outAmount = self.currencyService.parseCurrencyValue(result.outSymbol, metadata.amountOut)
 
   proc backendToPresentation(self: Controller, backendEntities: seq[backend_activity.ActivityEntry]): seq[entry.ActivityEntry] =
     var multiTransactionsIds: seq[int] = @[]
@@ -116,21 +132,27 @@ QtObject:
         of MultiTransaction:
           let id = multiTransactionsIds[mtIndex]
           if multiTransactions.hasKey(id):
-            result.add(entry.newMultiTransactionActivityEntry(multiTransactions[id], backendEntry))
+            let mt = multiTransactions[id]
+            let extraData = self.buildMultiTransactionExtraData(backendEntry, mt)
+            result.add(entry.newMultiTransactionActivityEntry(mt, backendEntry, extraData))
           else:
             error "failed to find multi transaction with id: ", id
           mtIndex += 1
         of SimpleTransaction:
           let identity = transactionIdentities[tIndex]
           if transactions.hasKey(identity):
-            result.add(entry.newTransactionActivityEntry(transactions[identity], backendEntry, self.addresses))
+            let tr = transactions[identity]
+            let extraData = self.buildTransactionExtraData(backendEntry, tr)
+            result.add(entry.newTransactionActivityEntry(tr, backendEntry, self.addresses, extraData))
           else:
             error "failed to find transaction with identity: ", identity
           tIndex += 1
         of PendingTransaction:
           let identity = pendingTransactionIdentities[ptIndex]
           if pendingTransactions.hasKey(identity):
-            result.add(entry.newTransactionActivityEntry(pendingTransactions[identity], backendEntry, self.addresses))
+            let tr = pendingTransactions[identity]
+            let extraData = self.buildTransactionExtraData(backendEntry, tr)
+            result.add(entry.newTransactionActivityEntry(tr, backendEntry, self.addresses, extraData))
           else:
             error "failed to find pending transaction with identity: ", identity
           ptIndex += 1
@@ -192,13 +214,14 @@ QtObject:
 
     self.currentActivityFilter.types = types
 
-  proc newController*(transactionsModule: transactions_module.AccessInterface, events: EventEmitter): Controller =
+  proc newController*(transactionsModule: transactions_module.AccessInterface, events: EventEmitter, currencyService: currency_service.Service): Controller =
     new(result, delete)
     result.model = newModel()
     result.recipientsModel = newRecipientsModel()
     result.transactionsModule = transactionsModule
     result.currentActivityFilter = backend_activity.getIncludeAllActivityFilter()
     result.events = events
+    result.currencyService = currencyService
     result.setup()
 
     let controller = result

--- a/src/app/modules/main/wallet_section/module.nim
+++ b/src/app/modules/main/wallet_section/module.nim
@@ -101,7 +101,7 @@ proc newModule*(
   result.overviewModule = overview_module.newModule(result, events, walletAccountService, currencyService)
   result.networksModule = networks_module.newModule(result, events, networkService, walletAccountService, settingsService)
   result.networksService = networkService
-  result.activityController = activityc.newController(result.transactionsModule, events)
+  result.activityController = activityc.newController(result.transactionsModule, events, currencyService)
   result.filter = initFilter(result.controller, result.activityController)
 
   result.view = newView(result, result.activityController)

--- a/src/backend/activity.nim
+++ b/src/backend/activity.nim
@@ -1,6 +1,7 @@
 import times, strformat, options
 import json, json_serialization
 import core, response_type
+import stint
 from gen import rpc
 import backend
 import transactions
@@ -148,6 +149,8 @@ type
     activityType*: MultiTransactionType
     activityStatus*: ActivityStatus
     tokenType*: TokenType
+    amountOut*: UInt256
+    amountIn*: UInt256
 
   # Mirrors services/wallet/activity/service.go ErrorCode
   ErrorCode* = enum
@@ -174,7 +177,9 @@ proc fromJson*(e: JsonNode, T: typedesc[ActivityEntry]): ActivityEntry {.inline.
                  else: none(TransactionIdentity),
     id: e["id"].getInt(),
     activityStatus: fromJson(e["activityStatus"], ActivityStatus),
-    timestamp: e["timestamp"].getInt()
+    timestamp: e["timestamp"].getInt(),
+    amountOut: stint.fromHex(UInt256, e["amountOut"].getStr()),
+    amountIn: stint.fromHex(UInt256, e["amountIn"].getStr())
   )
 
 proc `$`*(self: ActivityEntry): string =
@@ -188,6 +193,8 @@ proc `$`*(self: ActivityEntry): string =
     activityType* {$self.activityType},
     activityStatus* {$self.activityStatus},
     tokenType* {$self.tokenType},
+    amountOut* {$self.amountOut},
+    amountIn* {$self.amountIn},
   )"""
 
 proc fromJson*(e: JsonNode, T: typedesc[FilterResponse]): FilterResponse {.inline.} =

--- a/storybook/pages/TransactionDetailViewPage.qml
+++ b/storybook/pages/TransactionDetailViewPage.qml
@@ -130,7 +130,7 @@ SplitView {
         }
 
         readonly property var totalFees: QtObject {
-            property real amount: (transactionData.value.amount / 15) * Math.pow(10, 9)
+            property real amount: (transactionData.value / 15) * Math.pow(10, 9)
             property string symbol: "Gwei"
             property int displayDecimals: 8
             property bool stripTrailingZeroes: true

--- a/ui/app/AppLayouts/Wallet/views/TransactionDetailView.qml
+++ b/ui/app/AppLayouts/Wallet/views/TransactionDetailView.qml
@@ -52,10 +52,10 @@ Item {
         readonly property string swapSymbol: "" // TODO fill when swap data is implemented
         readonly property string symbol: root.isTransactionValid ? transaction.symbol : ""
         readonly property var multichainNetworks: [] // TODO fill icon for networks for multichain
-        readonly property double cryptoValue: root.isTransactionValid && transaction.value ? transaction.value.amount: 0.0
+        readonly property double cryptoValue: root.isTransactionValid ? transaction.value : 0.0
         readonly property double fiatValue: root.isTransactionValid ? RootStore.getFiatValue(cryptoValue, symbol, RootStore.currentCurrency): 0.0
         readonly property string fiatValueFormatted: root.isTransactionValid ? RootStore.formatCurrencyAmount(d.fiatValue, RootStore.currentCurrency) : ""
-        readonly property string cryptoValueFormatted: root.isTransactionValid && transaction.value ? LocaleUtils.currencyAmountToLocaleString(transaction.value) : ""
+        readonly property string cryptoValueFormatted: root.isTransactionValid ? RootStore.formatCurrencyAmount(d.cryptoValue, symbol) : ""
         readonly property real feeEthValue: root.isTransactionValid && transaction.totalFees ? RootStore.getGasEthValue(transaction.totalFees.amount, 1) : 0
         readonly property real feeFiatValue: root.isTransactionValid ? RootStore.getFiatValue(d.feeEthValue, "ETH", RootStore.currentCurrency) : 0
         readonly property int transactionType: root.isTransactionValid ? transaction.txType : Constants.TransactionType.Send
@@ -278,7 +278,7 @@ Item {
                     TransactionContractTile {
                         // Used to display contract address for any network
                         address: root.isTransactionValid ? transaction.contract : ""
-                        symbol: root.isTransactionValid && transaction.value ? transaction.value.symbol.toUpperCase() : ""
+                        symbol: root.isTransactionValid ? d.symbol : ""
                         networkName: d.networkFullName
                         shortNetworkName: d.networkShortName
                     }
@@ -311,7 +311,7 @@ Item {
                             case Constants.TransactionType.Swap:
                                 return d.swapSymbol
                             case Constants.TransactionType.Bridge:
-                                return transaction.value.symbol.toUpperCase()
+                                return d.symbol
                             default:
                                 return ""
                             }

--- a/ui/imports/shared/views/ActivityView.qml
+++ b/ui/imports/shared/views/ActivityView.qml
@@ -344,13 +344,14 @@ Control {
                     spacing: 5
 
                     RowLayout {
-                        Label { text: entry.isMultiTransaction ? entry.fromAmount : entry.amount }
+                        Label { text: qsTr("in"); Layout.leftMargin: 5; Layout.rightMargin: 5 }
+                        Label { text: entry.inAmount }
+                        Label { text: qsTr("out"); Layout.leftMargin: 5; Layout.rightMargin: 5 }
+                        Label { text: entry.outAmount }
                         Label { text: qsTr("from"); Layout.leftMargin: 5; Layout.rightMargin: 5 }
                         Label { text: entry.sender; Layout.maximumWidth: 200; elide: Text.ElideMiddle }
                         Label { text: qsTr("to"); Layout.leftMargin: 5; Layout.rightMargin: 5 }
                         Label { text: entry.recipient; Layout.maximumWidth: 200; elide: Text.ElideMiddle }
-                        Label { text: qsTr("got"); Layout.leftMargin: 5; Layout.rightMargin: 5; visible: entry.isMultiTransaction }
-                        Label { text: entry.toAmount; Layout.leftMargin: 5; Layout.rightMargin: 5; visible: entry.isMultiTransaction }
                         RowLayout {}    // Spacer
                     }
                     RowLayout {

--- a/ui/imports/shared/views/HistoryView.qml
+++ b/ui/imports/shared/views/HistoryView.qml
@@ -275,7 +275,7 @@ ColumnLayout {
             width: ListView.view.width
             modelData: model.activityEntry
             currentCurrency: RootStore.currentCurrency
-            cryptoValue: isModelDataValid && modelData.value ? modelData.value.amount : 0.0
+            cryptoValue: isModelDataValid ? modelData.value : 0.0
             fiatValue: isModelDataValid ? RootStore.getFiatValue(cryptoValue, symbol, currentCurrency): 0.0
             networkIcon: isModelDataValid ? RootStore.getNetworkIcon(modelData.chainId) : ""
             networkColor: isModelDataValid ? RootStore.getNetworkColor(modelData.chainId) : ""


### PR DESCRIPTION
Part of #11080

status-go: https://github.com/status-im/status-go/pull/3620

### What does the PR do

Make use of the new in/out amount values added to the backend entry.
Compatibility with the old model was maintained. The old interface should be removed when support for multitransactions gets added.

A workaround for a bug in status-go was introduced, since the activity for simple transactions is not properly detected (they're all detected as Receive type). This should be removed when that gets fixed.
