### PR TITLE
fix: Channel picker doesn't render 1-1 chats correctly

### DIFF
--- a/src/app/modules/main/chat_search_item.nim
+++ b/src/app/modules/main/chat_search_item.nim
@@ -3,16 +3,20 @@ type
     chatId: string
     name: string
     color: string
+    colorId: int
     icon: string
     sectionId: string
     sectionName: string
+    colorHash: string
 
-proc initItem*(chatId, name, color, icon, sectionId, sectionName: string): Item =
+proc initItem*(chatId, name, color: string, colorId: int, icon, colorHash, sectionId, sectionName: string): Item =
   result = Item()
   result.chatId = chatId
   result.name = name
   result.color = color
+  result.colorId = colorId
   result.icon = icon
+  result.colorHash = colorHash
   result.sectionId = sectionId
   result.sectionName = sectionName
 
@@ -25,8 +29,14 @@ proc name*(self: Item): string =
 proc color*(self: Item): string =
   self.color
 
+proc colorId*(self: Item): int =
+  self.colorId
+
 proc icon*(self: Item): string =
   self.icon
+
+proc colorHash*(self: Item): string =
+  self.colorHash
 
 proc sectionId*(self: Item): string =
   self.sectionId

--- a/src/app/modules/main/chat_search_model.nim
+++ b/src/app/modules/main/chat_search_model.nim
@@ -6,7 +6,9 @@ type
     ChatId = UserRole + 1
     Name
     Color
+    ColorId
     Icon
+    ColorHash
     SectionId
     SectionName
 
@@ -38,7 +40,9 @@ QtObject:
       ModelRole.ChatId.int:"chatId",
       ModelRole.Name.int:"name",
       ModelRole.Color.int:"color",
+      ModelRole.ColorId.int:"colorId",
       ModelRole.Icon.int:"icon",
+      ModelRole.ColorHash.int:"colorHash",
       ModelRole.SectionId.int:"sectionId",
       ModelRole.SectionName.int:"sectionName",
     }.toTable
@@ -58,8 +62,12 @@ QtObject:
         result = newQVariant(item.name)
       of ModelRole.Color:
         result = newQVariant(item.color)
+      of ModelRole.ColorId:
+        result = newQVariant(item.colorId)
       of ModelRole.Icon:
         result = newQVariant(item.icon)
+      of ModelRole.ColorHash:
+        result = newQVariant(item.colorHash)
       of ModelRole.SectionId:
         result = newQVariant(item.sectionId)
       of ModelRole.SectionName:

--- a/src/app/modules/main/chat_section/item.nim
+++ b/src/app/modules/main/chat_section/item.nim
@@ -121,6 +121,7 @@ proc toJsonNode*(self: Item): JsonNode =
     "memberRole": self.memberRole,
     "icon": self.icon,
     "color": self.color,
+    "colorId": self.colorId,
     "emoji": self.emoji,
     "description": self.description,
     "type": self.`type`,

--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -259,7 +259,7 @@ proc createItemFromPublicKey(self: Module, publicKey: string): UserItem =
     alias = contactDetails.dto.alias,
     icon = contactDetails.icon,
     colorId = contactDetails.colorId,
-    colorHash = contactDetails.colorHash,
+    colorHash = if not contactDetails.dto.ensVerified: contactDetails.colorHash else: "",
     onlineStatus = toOnlineStatus(self.controller.getStatusForContactWithId(publicKey).statusType),
     isContact = contactDetails.dto.isContact(),
     isVerified = contactDetails.dto.isContactVerified(),
@@ -572,7 +572,8 @@ method addNewChat*(
     chatImage = contactDetails.icon
     blocked = contactDetails.dto.isBlocked()
     isUsersListAvailable = false
-    colorHash = self.controller.getColorHash(chatDto.id)
+    if not contactDetails.dto.ensVerified:
+      colorHash = self.controller.getColorHash(chatDto.id)
     colorId = self.controller.getColorId(chatDto.id)
     onlineStatus = toOnlineStatus(self.controller.getStatusForContactWithId(chatDto.id).statusType)
 

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -4,6 +4,7 @@ import io_interface, view, controller, chat_search_item, chat_search_model
 import ephemeral_notification_item, ephemeral_notification_model
 import ./communities/models/[pending_request_item, pending_request_model]
 import ../shared_models/[user_item, member_item, member_model, section_item, section_model, section_details]
+import ../shared_models/[color_hash_item, color_hash_model]
 import ../shared_modules/keycard_popup/module as keycard_shared_module
 import ../../global/app_sections_config as conf
 import ../../global/app_signals
@@ -792,7 +793,7 @@ method getCommunitySectionModule*[T](self: Module[T], communityId: string): QVar
 
 method rebuildChatSearchModel*[T](self: Module[T]) =
   let transformItem = proc(item: chat_item.Item, sectionId, sectionName: string): chat_search_item.Item =
-    result = chat_search_item.initItem(item.id(), item.name(), item.color(), item.icon(), sectionId, sectionName)
+    result = chat_search_item.initItem(item.id(), item.name(), item.color(), item.colorId(), item.icon(), item.colorHash().toJson(), sectionId, sectionName)
 
   let transform = proc(items: seq[chat_item.Item], sectionId, sectionName: string): seq[chat_search_item.Item] =
     for item in items:

--- a/ui/StatusQ/src/StatusQ/Controls/StatusItemDelegate.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusItemDelegate.qml
@@ -24,7 +24,7 @@ ItemDelegate {
         StatusIcon {
             Layout.alignment: Qt.AlignVCenter
             visible: !!icon
-            icon: root.icon.name
+            icon: root.icon.name || root.icon.source
             color: root.enabled ? root.icon.color : Theme.palette.baseColor1
             width: root.icon.width
             height: root.icon.height

--- a/ui/app/AppLayouts/Profile/controls/CommunityShowcaseDelegate.qml
+++ b/ui/app/AppLayouts/Profile/controls/CommunityShowcaseDelegate.qml
@@ -1,8 +1,11 @@
 import QtQuick 2.15
 
+import utils 1.0
+
 ShowcaseDelegate {
     title: !!showcaseObj && !!showcaseObj.name ? showcaseObj.name : ""
-    secondaryTitle: !!showcaseObj && !!showcaseObj.amISectionAdmin ? qsTr("Admin") : qsTr("Member")
+    secondaryTitle: !!showcaseObj && (showcaseObj.memberRole === Constants.memberRole.owner ||
+                                      showcaseObj.memberRole === Constants.memberRole.admin) ? qsTr("Admin") : qsTr("Member")
     hasImage: !!showcaseObj && !!showcaseObj.image
 
     icon.name: !!showcaseObj ? showcaseObj.name : ""

--- a/ui/app/AppLayouts/Profile/panels/ProfileShowcaseCommunitiesPanel.qml
+++ b/ui/app/AppLayouts/Profile/panels/ProfileShowcaseCommunitiesPanel.qml
@@ -9,7 +9,7 @@ ProfileShowcasePanel {
 
     settingsKey: "communities"
     keyRole: "id"
-    roleNames: ["id", "name", "amISectionAdmin", "image", "color"]
+    roleNames: ["id", "name", "memberRole", "image", "color"]
     filterFunc: (modelData) => modelData.joined && !showcaseModel.hasItem(modelData.id)
     hiddenPlaceholderBanner: qsTr("Communities here will show on your profile")
     showcasePlaceholderBanner: qsTr("Communities here will be hidden from your profile")

--- a/ui/app/AppLayouts/Profile/stores/WalletStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/WalletStore.qml
@@ -10,7 +10,7 @@ QtObject {
 
     property var accountSensitiveSettings: Global.appIsReady? localAccountSensitiveSettings : null
 
-    property var areTestNetworksEnabled: networksModule.areTestNetworksEnabled
+    readonly property bool areTestNetworksEnabled: networksModule.areTestNetworksEnabled
     property var networks: networksModule.networks
 
     function toggleTestNetworksEnabled(){
@@ -20,7 +20,7 @@ QtObject {
     // TODO(alaibe): there should be no access to wallet section, create collectible in profile
     property var overview: walletSectionOverview
     property var flatCollectibles: Global.appIsReady ? walletSectionCollectibles.model : null
-
+    property var assets: walletSectionAssets.assets
     property var accounts: Global.appIsReady? accountsModule.accounts : null
     
     function deleteAccount(address) {

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -1273,8 +1273,11 @@ Item {
                     }
                     asset.width: 30
                     asset.height: 30
-                    asset.color: modelData ? modelData.color : ""
+                    asset.color: modelData ? modelData.color ? modelData.color : Utils.colorForColorId(modelData.colorId) : ""
                     asset.name: modelData ? modelData.icon : ""
+                    asset.charactersLen: 2
+                    asset.letterSize: asset._twoLettersSize
+                    ringSettings.ringSpecModel: modelData ? modelData.colorHash : undefined
                 }
 
                 onAboutToShow: rootStore.rebuildChatSearchModel()

--- a/ui/imports/shared/status/StatusSearchListPopup.qml
+++ b/ui/imports/shared/status/StatusSearchListPopup.qml
@@ -54,8 +54,6 @@ Popup {
             id: searchBox
 
             Layout.fillWidth: true
-            leftPadding: 0
-            rightPadding: 0
             placeholderText: root.searchBoxPlaceholder
             input.asset.name: "search"
 
@@ -158,9 +156,5 @@ Popup {
         listView.selectByHover = false
         searchBox.text = ""
         searchBox.input.edit.forceActiveFocus()
-    }
-
-    onClosed: {
-        root.destroy();
     }
 }

--- a/ui/imports/shared/views/profile/ProfileShowcaseView.qml
+++ b/ui/imports/shared/views/profile/ProfileShowcaseView.qml
@@ -84,7 +84,7 @@ Control {
                     }
                     sorters: [
                         RoleSorter {
-                            roleName: "amISectionAdmin"
+                            roleName: "memberRole"
                             sortOrder: Qt.DescendingOrder // admin first
                         },
                         StringSorter {
@@ -103,7 +103,7 @@ Control {
                     subTitle: model.description
                     tertiaryTitle: qsTr("%n member(s)", "", model.members.count)
                     asset.name: model.image ?? model.name
-                    asset.isImage: asset.name.startsWith("data:image/")
+                    asset.isImage: asset.name.startsWith(Constants.dataImagePrefix)
                     asset.isLetterIdenticon: !model.image
                     asset.color: model.color
                     asset.width: 40
@@ -112,7 +112,8 @@ Control {
                     border.color: Theme.palette.baseColor2
                     components: [
                         StatusIcon {
-                            visible: model.amISectionAdmin
+                            visible: model.memberRole === Constants.memberRole.owner ||
+                                     model.memberRole === Constants.memberRole.admin
                             anchors.verticalCenter: parent.verticalCenter
                             icon: "crown"
                             color: Theme.palette.directColor1


### PR DESCRIPTION
- expose `colorId` and `colorHash`, the latter only for non-ENS verified users
- use them in the results :)

Fixes #11086

### What does the PR do

Fixes missing chat colors and identicon rings in the channel picker (Ctrl+K) jump list

### Affected areas

AppMain/StatusSearchListPopup

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![Snímek obrazovky z 2023-06-14 21-42-56](https://github.com/status-im/status-desktop/assets/5377645/ccc3177c-a348-41e0-8f60-6e75c87c5e67)
