### PR TITLE
feat(AirdropAssets): Enable assets tab in airdrop dropdown

### DIFF
--- a/storybook/pages/CommunityAirdropsSettingsPanelPage.qml
+++ b/storybook/pages/CommunityAirdropsSettingsPanelPage.qml
@@ -119,6 +119,49 @@ SplitView {
                     }
                 }
 
+                AssetsModel {
+                    id: assetsModel
+                }
+
+                SortFilterProxyModel {
+                    id: assetsModelWithSupply
+
+                    sourceModel: assetsModel
+
+                    proxyRoles: [
+                        ExpressionRole {
+                            name: "supply"
+                            expression: ((model.index + 1) * 258).toString()
+                        },
+                        ExpressionRole {
+                            name: "infiniteSupply"
+                            expression: !(model.index % 4)
+                        },
+                        ExpressionRole {
+                            name: "chainName"
+                            expression: model.index ? "Ethereum Mainnet" : "Goerli"
+                        },
+                        ExpressionRole {
+
+                            readonly property string icon1: "network/Network=Ethereum"
+                            readonly property string icon2: "network/Network=Testnet"
+
+                            name: "chainIcon"
+                            expression: model.index ? icon1 : icon2
+                        }
+                    ]
+
+                    filters: ValueFilter {
+                        roleName: "category"
+                        value: TokenCategories.Category.Community
+                    }
+
+
+                    Component.onCompleted: {
+                        Qt.callLater(() => communityAirdropsSettingsPanel.assetsModel = this)
+                    }
+                }
+
                 membersModel: UsersModel {}
 
                 onAirdropClicked: logs.logEvent("CommunityAirdropsSettingsPanel::onAirdropClicked")

--- a/storybook/pages/CommunityNewAirdropViewPage.qml
+++ b/storybook/pages/CommunityNewAirdropViewPage.qml
@@ -103,7 +103,7 @@ SplitView {
             active: globalUtilsReady && mainModuleReady
 
             sourceComponent: CommunityNewAirdropView {
-                id: communityNewPermissionView
+                id: communityNewAirdropView
 
                 CollectiblesModel {
                     id: collectiblesModel
@@ -144,7 +144,50 @@ SplitView {
 
 
                     Component.onCompleted: {
-                        Qt.callLater(() => communityNewPermissionView.collectiblesModel = this)
+                        Qt.callLater(() => communityNewAirdropView.collectiblesModel = this)
+                    }
+                }
+
+                AssetsModel {
+                    id: assetsModel
+                }
+
+                SortFilterProxyModel {
+                    id: assetsModelWithSupply
+
+                    sourceModel: assetsModel
+
+                    proxyRoles: [
+                        ExpressionRole {
+                            name: "supply"
+                            expression: ((model.index + 1) * 258).toString()
+                        },
+                        ExpressionRole {
+                            name: "infiniteSupply"
+                            expression: !(model.index % 4)
+                        },
+                        ExpressionRole {
+                            name: "chainName"
+                            expression: model.index ? "Ethereum Mainnet" : "Goerli"
+                        },
+                        ExpressionRole {
+
+                            readonly property string icon1: "network/Network=Ethereum"
+                            readonly property string icon2: "network/Network=Testnet"
+
+                            name: "chainIcon"
+                            expression: model.index ? icon1 : icon2
+                        }
+                    ]
+
+                    filters: ValueFilter {
+                        roleName: "category"
+                        value: TokenCategories.Category.Community
+                    }
+
+
+                    Component.onCompleted: {
+                        Qt.callLater(() => communityNewAirdropView.assetsModel = this)
                     }
                 }
 

--- a/storybook/pages/HoldingsDropdownPage.qml
+++ b/storybook/pages/HoldingsDropdownPage.qml
@@ -89,14 +89,52 @@ SplitView {
                 }
             }
 
+            AssetsModel {
+                id: assetsModel
+            }
+
+            SortFilterProxyModel {
+                id: assetsModelWithSupply
+
+                sourceModel: assetsModel
+
+                proxyRoles: [
+                    ExpressionRole {
+                        name: "supply"
+                        expression: (model.index + 1) * 584
+                    },
+                    ExpressionRole {
+                        name: "infiniteSupply"
+                        expression: !(model.index % 4)
+                    },
+                    ExpressionRole {
+                        name: "chainName"
+                        expression: model.index ? "Ethereum Mainnet" : "Goerli"
+                    },
+                    ExpressionRole {
+
+                        readonly property string icon1: "network/Network=Ethereum"
+                        readonly property string icon2: "network/Network=Testnet"
+
+                        name: "chainIcon"
+                        expression: model.index ? icon1 : icon2
+                    }
+                ]
+
+                filters: ValueFilter {
+                    roleName: "category"
+                    value: TokenCategories.Category.Community
+                }
+            }
 
             collectiblesModel: isAirdropMode.checked
                                ? collectiblesModelWithSupply
                                : collectiblesModel
 
-            assetsModel: AssetsModel {}
+            assetsModel: isAirdropMode.checked
+                         ? assetsModelWithSupply
+                         : assetsModel
             isENSTab: isEnsTabChecker.checked
-            isCollectiblesOnly: isCollectiblesOnlyChecker.checked
 
             onOpened: contentItem.parent.parent = container
             Component.onCompleted: {
@@ -116,12 +154,6 @@ SplitView {
                 id: isEnsTabChecker
                 text: "ENS tab visible"
                 checked: true
-            }
-
-            CheckBox {
-                id: isCollectiblesOnlyChecker
-                text: "Collectibles only"
-                checked: false
             }
 
             CheckBox {

--- a/storybook/src/Models/AssetsModel.qml
+++ b/storybook/src/Models/AssetsModel.qml
@@ -16,7 +16,7 @@ ListModel {
             iconSource: ModelsData.assets.zrx,
             name: "Ox",
             shortName: "ZRX",
-            category: TokenCategories.Category.Own
+            category: TokenCategories.Category.Community
         },
         {
             key: "1inch",

--- a/ui/app/AppLayouts/Chat/controls/community/ExtendedDropdownContent.qml
+++ b/ui/app/AppLayouts/Chat/controls/community/ExtendedDropdownContent.qml
@@ -439,11 +439,18 @@ Item {
         ListDropdownContent {
             availableData: d.availableData
             noDataText: root.noDataText
+            areHeaderButtonsVisible: root.state === d.depth1_ListState
+                                     && !root.showAllTokensMode
             headerModel: ListModel {
-                ListElement { key: "MINT"; icon: "add"; iconSize: 16; description: qsTr("Mint asset"); rotation: 0; spacing: 8 }
-                ListElement { key: "IMPORT"; icon: "invite-users"; iconSize: 16; description: qsTr("Import existing asset"); rotation: 180; spacing: 8 }
+               ListElement {
+                   key: "MINT"
+                   icon: "add"
+                   iconSize: 16
+                   description: qsTr("Mint asset")
+                   rotation: 0
+                   spacing: 8
+               }
             }
-            areHeaderButtonsVisible: false  // TEMPORARILY hidden. These 2 header options will be implemented after MVP.
             checkedKeys: root.checkedKeys
             searchMode: d.searchMode
 
@@ -454,12 +461,9 @@ Item {
             isFooterButtonVisible: !root.showAllTokensMode && !d.searchMode
                                    && filteredModel.item && d.currentModel.count > filteredModel.item.count
 
+            onHeaderItemClicked: root.navigateToMintTokenSettings()
             onFooterButtonClicked: root.footerButtonClicked()
 
-            onHeaderItemClicked: {
-                if(key === "MINT") console.log("TODO: Mint asset")
-                else if(key === "IMPORT") console.log("TODO: Import existing asset")
-            }
             onItemClicked: root.itemClicked(key, shortName, iconSource)
 
             onImplicitHeightChanged: root.layoutChanged()

--- a/ui/app/AppLayouts/Chat/controls/community/ListDropdownContent.qml
+++ b/ui/app/AppLayouts/Chat/controls/community/ListDropdownContent.qml
@@ -188,7 +188,7 @@ StatusListView {
                 anchors.leftMargin: Style.current.halfPadding
                 anchors.left: parent.left
                 anchors.verticalCenter: parent.verticalCenter
-                width: parent.width
+                width: parent.width - anchors.leftMargin
                 text: sectionDelegateRoot.section
                 color: Theme.palette.baseColor1
                 font.pixelSize: 12

--- a/ui/app/AppLayouts/Chat/panels/communities/CommunityAirdropsSettingsPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/CommunityAirdropsSettingsPanel.qml
@@ -27,9 +27,10 @@ SettingsPageLayout {
     property int viewWidth: 560 // by design
 
     signal airdropClicked(var airdropTokens, var addresses, var membersPubKeys)
+
     signal airdropFeesRequested(var contractKeysAndAmounts, var addresses)
 
-    signal navigateToMintTokenSettings
+    signal navigateToMintTokenSettings(bool isAssetType)
 
     function navigateBack() {
         stackManager.pop(StackView.Immediate)
@@ -123,7 +124,7 @@ SettingsPageLayout {
                 root.airdropClicked(airdropTokens, addresses, membersPubKeys)
                 stackManager.clear(d.welcomeViewState, StackView.Immediate)
             }
-            onNavigateToMintTokenSettings: root.navigateToMintTokenSettings()
+            onNavigateToMintTokenSettings: root.navigateToMintTokenSettings(isAssetType)
 
             Component.onCompleted: {
                 d.selectToken.connect(view.selectToken)

--- a/ui/app/AppLayouts/Chat/views/CommunitySettingsView.qml
+++ b/ui/app/AppLayouts/Chat/views/CommunitySettingsView.qml
@@ -396,26 +396,37 @@ StatusSectionLayout {
                                                    url)
                     }
                 }
+
+                Connections {
+                    target: airdropPanel
+
+                    function onNavigateToMintTokenSettings(isAssetType) {
+                        // Here it is forced a navigation to the new airdrop form, like if it was clicked the header button
+                        mintPanel.resetNavigation(isAssetType)
+                        mintPanel.primaryHeaderButtonClicked()
+                    }
+                }
             }
 
             CommunityAirdropsSettingsPanel {
                 id: airdropPanel
 
                 readonly property CommunityTokensStore communityTokensStore:
-                    rootStore.communityTokensStore
-
-                assetsModel: ListModel {}
+                    rootStore.communityTokensStore                
 
                 readonly property var communityTokens: root.community.communityTokens
 
                 Loader {
-                    id: modelLoader
+                    id: assetsModelLoader
                     active: airdropPanel.communityTokens
 
                     sourceComponent: SortFilterProxyModel {
 
                         sourceModel: airdropPanel.communityTokens
-
+                        filters: ValueFilter {
+                            roleName: "tokenType"
+                            value: Constants.TokenType.ERC20
+                        }
                         proxyRoles: [
                             ExpressionRole {
                                 name: "category"
@@ -436,8 +447,39 @@ StatusSectionLayout {
                     }
                 }
 
-                collectiblesModel: modelLoader.item
+                Loader {
+                    id: collectiblesModelLoader
+                    active: airdropPanel.communityTokens
 
+                    sourceComponent: SortFilterProxyModel {
+
+                        sourceModel: airdropPanel.communityTokens
+                        filters: ValueFilter {
+                            roleName: "tokenType"
+                            value: Constants.TokenType.ERC721
+                        }
+                        proxyRoles: [
+                            ExpressionRole {
+                                name: "category"
+
+                                // Singleton cannot be used directly in the epression
+                                readonly property int category: TokenCategories.Category.Own
+                                expression: category
+                            },
+                            ExpressionRole {
+                                name: "iconSource"
+                                expression: model.image
+                            },
+                            ExpressionRole {
+                                name: "key"
+                                expression: model.symbol
+                            }
+                        ]
+                    }
+                }
+
+                assetsModel: assetsModelLoader.item
+                collectiblesModel: collectiblesModelLoader.item
                 membersModel: {
                     const chatContentModule = root.rootStore.currentChatContentModule()
                     if (!chatContentModule || !chatContentModule.usersModule) {


### PR DESCRIPTION
Closes #11056

### What does the PR do

- It adds assets model.
- It adds no data text for assets tab.
- It adds navigation from airdrop to mint specific tab.
- It updates `HoldingsDropdown` component to allow network information for assets.
- It removes `isCollectiblesOnly` option in `HoldingsDropdown`. No longer needed.
- It udates `storybook` to support airdrop assets testing.

**NOTE**: Pending assets backend so the functionality has been tested only using `storybook`.

### Affected areas

Community Settings / Airdrop tokens

### Screenshot of functionality 

- Storybook - Assets model:

https://github.com/status-im/status-desktop/assets/97019400/9a487f56-5f87-4bd8-8a8b-bbcaad51d89b

- App navigation between airdrop and mint settings:

https://github.com/status-im/status-desktop/assets/97019400/35c5e216-02b1-4cea-a8fc-1fbf5195068b




