### PR TITLE
fix(StatusQ): Dynamic width calculation for StatusMenu

### DIFF
--- a/ui/StatusQ/src/StatusQ/Popups/StatusMenu.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/StatusMenu.qml
@@ -1,4 +1,5 @@
 import QtQuick 2.15
+import QtQml 2.15
 import QtQuick.Controls 2.15
 import QtGraphicalEffects 1.15
 
@@ -32,6 +33,7 @@ import StatusQ.Popups 0.1
 Menu {
     id: root
 
+    property real maxImplicitWidth: 640
     readonly property color defaultIconColor: Theme.palette.primaryColor1
 
     property StatusAssetSettings assetSettings: StatusAssetSettings {
@@ -72,6 +74,7 @@ Menu {
     topPadding: 8
     bottomPadding: 8
     margins: 16
+    width: Math.min(implicitWidth, root.maxImplicitWidth)
 
     onOpened: {
         if (typeof openHandler === "function") {
@@ -85,15 +88,24 @@ Menu {
         }
     }
 
+    QtObject {
+        id: d
+        //helper property to get the max implicit width of the delegate
+        property real maxDelegateImplWidth: 0
+    }
+
     delegate: StatusMenuItem {
         visible: root.hideDisabledItems ? enabled : true
         height: visible ? implicitHeight : 0
+        onImplicitWidthChanged: {
+            d.maxDelegateImplWidth = Math.max(d.maxDelegateImplWidth, implicitWidth)
+        }
     }
 
     contentItem: StatusListView {
         currentIndex: root.currentIndex
         implicitHeight: contentHeight
-        implicitWidth: contentWidth
+        implicitWidth: d.maxDelegateImplWidth
         interactive: contentHeight > availableHeight
         model: root.contentModel
     }

--- a/ui/StatusQ/src/StatusQ/Popups/StatusMenuItem.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/StatusMenuItem.qml
@@ -9,9 +9,7 @@ import StatusQ.Popups 0.1
 
 MenuItem {
     id: root
-
-    implicitWidth: parent ? parent.width : 0
-    implicitHeight: 38
+    
     objectName: action ? action.objectName : "StatusMenuItemDelegate"
 
     spacing: 4

--- a/ui/imports/shared/controls/chat/ProfileHeader.qml
+++ b/ui/imports/shared/controls/chat/ProfileHeader.qml
@@ -275,7 +275,6 @@ Item {
         id: editImageMenuComponent
 
         StatusMenu {
-            width: 200
 
             StatusAction {
                 text: qsTr("Select different image")

--- a/ui/imports/shared/panels/EditCroppedImagePanel.qml
+++ b/ui/imports/shared/panels/EditCroppedImagePanel.qml
@@ -207,7 +207,6 @@ Item {
 
     StatusMenu {
         id: imageEditMenu
-        width: 200
 
         StatusAction {
             text: qsTr("Select different image")

--- a/ui/imports/shared/popups/UserStatusContextMenu.qml
+++ b/ui/imports/shared/popups/UserStatusContextMenu.qml
@@ -15,8 +15,6 @@ StatusMenu {
 
     property var store
 
-    width: 210
-
     ProfileHeader {
         width: parent.width
 

--- a/ui/imports/shared/views/ProfileDialogView.qml
+++ b/ui/imports/shared/views/ProfileDialogView.qml
@@ -394,7 +394,7 @@ Pane {
 
                 StatusMenu {
                     id: moreMenu
-                    width: 230
+
                     SendContactRequestMenuItem {
                         enabled: !d.isContact && !d.isBlocked && d.contactRequestState !== Constants.ContactRequestState.Sent &&
                                  d.contactDetails.trustStatus === Constants.trustStatus.untrustworthy // we have an action button otherwise

--- a/ui/imports/shared/views/chat/ProfileContextMenu.qml
+++ b/ui/imports/shared/views/chat/ProfileContextMenu.qml
@@ -89,8 +89,6 @@ StatusMenu {
         selectedUserPublicKey = ""
     }
 
-    width: 230
-
     ProfileHeader {
         width: parent.width
         height: visible ? implicitHeight : 0


### PR DESCRIPTION
### What does the PR do
Closing: #11028 

Calculating the `StatusMenu` implicitWidth based on content width.
<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas
`StatusMenu`
<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Screenshot of functionality (including design for comparison)

<img width="577" alt="Screenshot 2023-06-15 at 13 35 36" src="https://github.com/status-im/status-desktop/assets/47811206/b08fcfed-5202-462e-a606-c6ace0d6b2e9">

Checking for regressions:
<img width="287" alt="Screenshot 2023-06-15 at 13 37 03" src="https://github.com/status-im/status-desktop/assets/47811206/fe560dc9-2cb4-48c7-bc09-506d28e238f6">
<img width="287" alt="Screenshot 2023-06-15 at 13 37 28" src="https://github.com/status-im/status-desktop/assets/47811206/73ab1cc2-2eec-4c7e-957d-a4ead7fed6c9">


