### PR TITLE
feat(ActivityCenter): Make reply badge more interactive

### DIFF
--- a/ui/app/mainui/activitycenter/controls/ReplyBadge.qml
+++ b/ui/app/mainui/activitycenter/controls/ReplyBadge.qml
@@ -2,6 +2,7 @@ import QtQuick 2.4
 import QtQuick.Layouts 1.4
 
 import StatusQ.Core 0.1
+import StatusQ.Core.Theme 0.1
 import StatusQ.Core.Utils 0.1 as StatusQUtils
 
 import utils 1.0
@@ -17,6 +18,7 @@ Badge {
 
     implicitWidth: layout.implicitWidth + layout.anchors.leftMargin + layout.anchors.rightMargin
     implicitHeight: layout.implicitHeight + layout.anchors.topMargin + layout.anchors.bottomMargin
+    color: hoverArea.containsMouse ? hoverArea.pressed ? Theme.palette.baseColor3 : Theme.palette.baseColor2 : Style.current.transparent
 
     RowLayout {
         id: layout
@@ -49,6 +51,7 @@ Badge {
     }
 
     MouseArea {
+        id: hoverArea
         hoverEnabled: true
         anchors.fill: layout
         cursorShape: Qt.PointingHandCursor

--- a/ui/app/mainui/activitycenter/views/ActivityNotificationReply.qml
+++ b/ui/app/mainui/activitycenter/views/ActivityNotificationReply.qml
@@ -35,6 +35,7 @@ ActivityNotificationMessage {
         onReplyClicked: {
             root.activityCenterStore.switchTo(notification)
             root.closeActivityCenter()
+            root.store.messageStore.messageModule.jumpToMessage(model.id)
         }
     }
 


### PR DESCRIPTION
Close #8758

### What does the PR do

- [x] add `jumpToMessage ` call to highlight replied message  
- [x] add hove and click colors to ReplyBadge 

### Affected areas

ActivityCenter

### StatusQ checklist

- [x] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

https://github.com/status-im/status-desktop/assets/2522130/61f8affc-3e84-4763-a564-391a462ab6ff

