### PR TITLE
fix(Storybook): reenable inspection tool for popup pages

### DIFF
--- a/storybook/main.qml
+++ b/storybook/main.qml
@@ -36,6 +36,7 @@ ApplicationWindow {
         }
 
         function performInspection() {
+            // Find the items to inspect on the current page
             const getItems = typeName =>
                            InspectionUtils.findItemsByTypeName(
                                viewLoader.item, typeName)
@@ -44,18 +45,29 @@ ApplicationWindow {
                 ...getItems("Custom" + root.currentPage)
             ]
 
+            // Find lowest commont ancestor of found items
             const lca = InspectionUtils.lowestCommonAncestor(
                           items, viewLoader.item)
 
-            if (!!lca && lca.Overlay.overlay.children.length > 0) {
-                activateInspection(lca.Overlay.overlay.children[0])
-                return
-            }
-
+            // Inspect lca
             if (lca) {
                 activateInspection(lca.parent.contentItem === lca
                                    ? lca.parent : lca)
                 return
+            }
+
+            // Look for the item for inspection on the Overlay, skip items
+            // without contentItem which can be, for example, instance of
+            // Overlay.modal or Overlay.modeless
+            const overlayChildren = root.Overlay.overlay.children
+
+            for (let i = 0; i < overlayChildren.length; i++) {
+                const item = overlayChildren[i]
+
+                if (item.contentItem) {
+                    activateInspection(item)
+                    return
+                }
             }
 
             nothingToInspectDialog.open()


### PR DESCRIPTION
### What does the PR do

Heuristic for finding for the subject of inspection fixed.

Closes: #11110

### Affected areas
`Storybook`

### Screenshot of functionality (including design for comparison)


![Screenshot from 2023-06-15 16-59-51](https://github.com/status-im/status-desktop/assets/20650004/87cf6c38-0dbd-482f-b760-8dbe39421421)
