### PR TITLE
Add permissions model to curated communities

### DIFF
--- a/src/app/modules/main/communities/controller.nim
+++ b/src/app/modules/main/communities/controller.nim
@@ -7,6 +7,9 @@ import ../../../../app_service/service/community/service as community_service
 import ../../../../app_service/service/contacts/service as contacts_service
 import ../../../../app_service/service/network/service as networks_service
 import ../../../../app_service/service/community_tokens/service as community_tokens_service
+import ../../../../app_service/service/token/service as token_service
+
+import ../../shared_models/token_permissions_model
 
 type
   Controller* = ref object of RootObj
@@ -16,6 +19,7 @@ type
     contactsService: contacts_service.Service
     communityTokensService: community_tokens_service.Service
     networksService: networks_service.Service
+    tokenService: token_service.Service
 
 proc newController*(
     delegate: io_interface.AccessInterface,
@@ -24,6 +28,7 @@ proc newController*(
     contactsService: contacts_service.Service,
     communityTokensService: community_tokens_service.Service,
     networksService: networks_service.Service,
+    tokenService: token_service.Service,
     ): Controller =
   result = Controller()
   result.delegate = delegate
@@ -32,6 +37,7 @@ proc newController*(
   result.contactsService = contactsService
   result.communityTokensService = communityTokensService
   result.networksService = networksService
+  result.tokenService = tokenService
 
 proc delete*(self: Controller) =
   discard
@@ -252,3 +258,6 @@ proc getCommunityTokens*(self: Controller, communityId: string): seq[CommunityTo
 
 proc getNetwork*(self:Controller, chainId: int): NetworkDto =
   self.networksService.getNetwork(chainId)
+
+proc getTokenList*(self: Controller): seq[TokenDto] =
+  return self.tokenService.getTokenList()

--- a/src/app/modules/main/communities/controller.nim
+++ b/src/app/modules/main/communities/controller.nim
@@ -204,18 +204,6 @@ proc reorderCommunityChat*(
     chatId,
     position)
 
-proc deleteCommunityChat*(
-    self: Controller,
-    communityId: string,
-    chatId: string) =
-  self.communityService.deleteCommunityChat(communityId, chatId)
-
-proc deleteCommunityCategory*(
-    self: Controller,
-    communityId: string,
-    categoryId: string) =
-  self.communityService.deleteCommunityCategory(communityId, categoryId)
-
 proc requestCommunityInfo*(self: Controller, communityId: string, importing: bool) =
   self.communityService.requestCommunityInfo(communityId, importing)
 

--- a/src/app/modules/main/communities/io_interface.nim
+++ b/src/app/modules/main/communities/io_interface.nim
@@ -49,15 +49,6 @@ method requestImportDiscordCommunity*(self: AccessInterface, name: string, descr
                         fromTimestamp: int) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method deleteCommunityCategory*(self: AccessInterface, communityId: string, categoryId: string) {.base.} =
-  raise newException(ValueError, "No implementation available")
-
-method reorderCommunityCategories*(self: AccessInterface, communityId: string, categoryId: string, position: int) {.base} =
-  raise newException(ValueError, "No implementation available")
-
-method reorderCommunityChannel*(self: AccessInterface, communityId: string, categoryId: string, chatId: string, position: int) {.base} =
-  raise newException(ValueError, "No implementation available")
-
 method isUserMemberOfCommunity*(self: AccessInterface, communityId: string): bool {.base.} =
   raise newException(ValueError, "No implementation available")
 
@@ -74,9 +65,6 @@ method requestToJoinCommunity*(self: AccessInterface, communityId: string, ensNa
   raise newException(ValueError, "No implementation available")
 
 method requestCommunityInfo*(self: AccessInterface, communityId: string, importing: bool) {.base.} =
-  raise newException(ValueError, "No implementation available")
-
-method deleteCommunityChat*(self: AccessInterface, communityId: string, channelId: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method importCommunity*(self: AccessInterface, communityKey: string) {.base.} =

--- a/src/app/modules/main/communities/models/curated_community_item.nim
+++ b/src/app/modules/main/communities/models/curated_community_item.nim
@@ -1,4 +1,5 @@
 import strformat
+import ../../../shared_models/[token_permissions_model, token_permission_item]
 
 type
   CuratedCommunityItem* = object
@@ -13,6 +14,7 @@ type
     members: int
     activeMembers: int
     featured: bool
+    permissionModel: TokenPermissionsModel
 
 proc initCuratedCommunityItem*(
   id: string,
@@ -25,7 +27,8 @@ proc initCuratedCommunityItem*(
   tags: string,
   members: int,
   activeMembers: int,
-  featured: bool
+  featured: bool,
+  tokenPermissionsItems: seq[TokenPermissionItem]
 ): CuratedCommunityItem =
   result.id = id
   result.name = name
@@ -38,6 +41,9 @@ proc initCuratedCommunityItem*(
   result.members = members
   result.activeMembers = activeMembers
   result.featured = featured
+  result.permissionModel = newTokenPermissionsModel()
+  if tokenPermissionsItems.len > 0:
+    result.permissionModel.setItems(tokenPermissionsItems)
 
 proc `$`*(self: CuratedCommunityItem): string =
   result = fmt"""CuratedCommunityItem(
@@ -84,3 +90,9 @@ proc getTags*(self: CuratedCommunityItem): string =
 
 proc getFeatured*(self: CuratedCommunityItem): bool =
   return self.featured
+
+proc getPermissionsModel*(self: CuratedCommunityItem): TokenPermissionsModel =
+  return self.permissionModel
+
+proc setPermissionModelItems*(self: CuratedCommunityItem, items: seq[TokenPermissionItem]) =
+  self.permissionModel.setItems(items)

--- a/src/app/modules/main/communities/models/curated_community_model.nim
+++ b/src/app/modules/main/communities/models/curated_community_model.nim
@@ -1,5 +1,6 @@
 import NimQml, Tables
 import curated_community_item
+import ../../../shared_models/[token_permissions_model, token_permission_item]
 
 type
   ModelRole {.pure.} = enum
@@ -15,6 +16,7 @@ type
     Popularity
     Color
     Tags
+    Permissions
 
 QtObject:
   type CuratedCommunityModel* = ref object of QAbstractListModel
@@ -62,6 +64,7 @@ QtObject:
       ModelRole.Color.int:"color",
       ModelRole.Popularity.int:"popularity",
       ModelRole.Tags.int:"tags",
+      ModelRole.Permissions.int:"permissionsModel",
     }.toTable
 
   method data(self: CuratedCommunityModel, index: QModelIndex, role: int): QVariant =
@@ -95,6 +98,8 @@ QtObject:
         result = newQVariant(index.row)
       of ModelRole.Tags:
         result = newQVariant(item.getTags())
+      of ModelRole.Permissions:
+        result = newQVariant(item.getPermissionsModel())
       of ModelRole.Featured:
         result = newQVariant(item.getFeatured())
 
@@ -132,17 +137,20 @@ QtObject:
     if idx > -1:
       let index = self.createIndex(idx, 0, nil)
       self.items[idx] = item
-      self.dataChanged(index, index, @[ModelRole.Name.int,
-                                       ModelRole.Available.int,
-                                       ModelRole.Description.int,
-                                       ModelRole.Icon.int,
-                                       ModelRole.Banner.int,
-                                       ModelRole.Featured.int,
-                                       ModelRole.Members.int,
-                                       ModelRole.ActiveMembers.int,
-                                       ModelRole.Color.int,
-                                       ModelRole.Popularity.int,
-                                       ModelRole.Tags.int])
+      self.dataChanged(index, index, @[
+        ModelRole.Name.int,
+        ModelRole.Available.int,
+        ModelRole.Description.int,
+        ModelRole.Icon.int,
+        ModelRole.Banner.int,
+        ModelRole.Featured.int,
+        ModelRole.Members.int,
+        ModelRole.ActiveMembers.int,
+        ModelRole.Color.int,
+        ModelRole.Popularity.int,
+        ModelRole.Tags.int,
+        ModelRole.Permissions.int,
+      ])
     else:
       let parentModelIndex = newQModelIndex()
       defer: parentModelIndex.delete
@@ -150,3 +158,10 @@ QtObject:
       self.items.add(item)
       self.endInsertRows()
       self.countChanged()
+
+  proc setPermissionItems*(self: CuratedCommunityModel, itemId: string, items: seq[TokenPermissionItem]) =
+    let idx = self.findIndexById(itemId)
+    if idx == -1:
+      echo "Tried to set permission items on an item that doesn't exist. Item ID: ", itemId
+      return
+    self.items[idx].setPermissionModelItems(items)

--- a/src/app/modules/main/communities/module.nim
+++ b/src/app/modules/main/communities/module.nim
@@ -264,13 +264,6 @@ method createCommunity*(self: Module, name: string,
                                   imagePath, aX, aY, bX, bY, historyArchiveSupportEnabled, pinMessageAllMembersEnabled, 
                                   bannerJsonStr)
 
-method deleteCommunityCategory*(self: Module, communityId: string, categoryId: string) =
-  self.controller.deleteCommunityCategory(communityId, categoryId)
-
-method reorderCommunityCategories*(self: Module, communityId: string, categoryId: string, position: int) =
-#   self.controller.reorderCommunityCategories(communityId, categoryId, position)
-  discard
-
 method communityMuted*(self: Module, communityId: string, muted: bool) =
   self.view.model().setMuted(communityId, muted)
 
@@ -320,9 +313,6 @@ method userCanJoin*(self: Module, communityId: string): bool =
 
 method isCommunityRequestPending*(self: Module, communityId: string): bool =
   self.controller.isCommunityRequestPending(communityId)
-
-method deleteCommunityChat*(self: Module, communityId: string, channelId: string) =
-  self.controller.deleteCommunityChat(communityId, channelId)
 
 method communityImported*(self: Module, community: CommunityDto) =
   self.view.addItem(self.getCommunityItem(community))

--- a/src/app/modules/main/communities/view.nim
+++ b/src/app/modules/main/communities/view.nim
@@ -1,9 +1,7 @@
 import NimQml, json, strutils, sequtils
 
 import ./io_interface
-import ../../shared_models/section_model
-import ../../shared_models/section_item
-import ../../shared_models/section_details
+import ../../shared_models/[section_model, section_item, section_details, token_list_model, token_list_item]
 import ./models/curated_community_model
 import ./models/discord_file_list_model
 import ./models/discord_file_item
@@ -22,6 +20,10 @@ QtObject:
       curatedCommunitiesModel: CuratedCommunityModel
       curatedCommunitiesModelVariant: QVariant
       curatedCommunitiesLoading: bool
+      tokenListModel: TokenListModel
+      tokenListModelVariant: QVariant
+      collectiblesListModel: TokenListModel
+      collectiblesListModelVariant: QVariant
       discordFileListModel: DiscordFileListModel
       discordFileListModelVariant: QVariant
       discordCategoriesModel: DiscordCategoriesModel
@@ -59,6 +61,11 @@ QtObject:
     self.discordChannelsModelVariant.delete
     self.discordImportTasksModel.delete
     self.discordImportTasksModelVariant.delete
+    self.tokenListModel.delete
+    self.tokenListModelVariant.delete
+    self.collectiblesListModel.delete
+    self.collectiblesListModelVariant.delete
+
     self.QObject.delete
 
   proc newView*(delegate: io_interface.AccessInterface): View =
@@ -89,6 +96,10 @@ QtObject:
     result.discordImportTasksModel = newDiscordDiscordImportTasksModel()
     result.discordImportTasksModelVariant = newQVariant(result.discordImportTasksModel)
     result.downloadingCommunityHistoryArchives = false
+    result.tokenListModel = newTokenListModel()
+    result.tokenListModelVariant = newQVariant(result.tokenListModel)
+    result.collectiblesListModel = newTokenListModel()
+    result.collectiblesListModelVariant = newQVariant(result.collectiblesListModel)
 
   proc load*(self: View) =
     self.delegate.viewDidLoad()
@@ -566,3 +577,26 @@ QtObject:
       if self.discordChannelsModel.allChannelsByCategoryUnselected(item.getCategoryId()):
         self.discordCategoriesModel.unselectItem(item.getCategoryId())
 
+  proc tokenListModel*(self: View): TokenListModel =
+    result = self.tokenListModel
+
+  proc getTokenListModel(self: View): QVariant{.slot.} =
+    return self.tokenListModelVariant
+
+  QtProperty[QVariant] tokenList:
+    read = getTokenListModel
+
+  proc setTokenListItems*(self: View, tokenListItems: seq[TokenListItem]) =
+    self.tokenListModel.setItems(tokenListItems)
+
+  proc collectiblesListModel*(self: View): TokenListModel =
+    result = self.collectiblesListModel
+
+  proc getCollectiblesListModel(self: View): QVariant{.slot.} =
+    return self.collectiblesListModelVariant
+
+  QtProperty[QVariant] collectiblesModel:
+    read = getCollectiblesListModel
+
+  proc setCollectiblesListItems*(self: View, tokenListItems: seq[TokenListItem]) =
+    self.collectiblesListModel.setItems(tokenListItems)

--- a/src/app/modules/main/communities/view.nim
+++ b/src/app/modules/main/communities/view.nim
@@ -464,15 +464,6 @@ QtObject:
                                   imagePath, aX, aY, bX, bY, historyArchiveSupportEnabled, pinMessageAllMembersEnabled,
                                   filesToImport, fromTimestamp)
 
-  proc deleteCommunityCategory*(self: View, communityId: string, categoryId: string): string {.slot.} =
-    self.delegate.deleteCommunityCategory(communityId, categoryId)
-
-  proc reorderCommunityCategories*(self: View, communityId: string, categoryId: string, position: int) {.slot} =
-    self.delegate.reorderCommunityCategories(communityId, categoryId, position)
-
-  proc reorderCommunityChannel*(self: View, communityId: string, categoryId: string, chatId: string, position: int): string {.slot} =
-    self.delegate.reorderCommunityChannel(communityId, categoryId, chatId, position)
-
   proc cancelRequestToJoinCommunity*(self: View, communityId: string) {.slot.} =
     self.delegate.cancelRequestToJoinCommunity(communityId)
 
@@ -503,9 +494,6 @@ QtObject:
 
   proc isCommunityRequestPending*(self: View, communityId: string): bool {.slot.} =
     self.delegate.isCommunityRequestPending(communityId)
-
-  proc deleteCommunityChat*(self: View, communityId: string, channelId: string) {.slot.} =
-    self.delegate.deleteCommunityChat(communityId, channelId)
 
   proc importCommunity*(self: View, communityKey: string) {.slot.} =
     self.delegate.importCommunity(communityKey)

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -207,7 +207,7 @@ proc newModule*[T](
   result.stickersModule = stickers_module.newModule(result, events, stickersService, settingsService, walletAccountService, networkService, tokenService)
   result.activityCenterModule = activity_center_module.newModule(result, events, activityCenterService, contactsService,
   messageService, chatService, communityService)
-  result.communitiesModule = communities_module.newModule(result, events, communityService, contactsService, communityTokensService, networkService, transactionService)
+  result.communitiesModule = communities_module.newModule(result, events, communityService, contactsService, communityTokensService, networkService, transactionService, tokenService)
   result.appSearchModule = app_search_module.newModule(result, events, contactsService, chatService, communityService,
   messageService)
   result.nodeSectionModule = node_section_module.newModule(result, events, settingsService, nodeService, nodeConfigurationService)

--- a/src/app/modules/shared_models/token_permission_item.nim
+++ b/src/app/modules/shared_models/token_permission_item.nim
@@ -1,4 +1,4 @@
-import strformat
+import strformat, strutils
 import ../../../app_service/service/community/dto/community
 import ../../../app_service/service/chat/dto/chat
 import token_criteria_model
@@ -62,3 +62,31 @@ proc getIsPrivate*(self: TokenPermissionItem): bool =
 
 proc getTokenCriteriaMet*(self: TokenPermissionItem): bool =
   return self.tokenCriteriaMet
+
+
+proc buildTokenPermissionItem*(tokenPermission: CommunityTokenPermissionDto): TokenPermissionItem =
+  var tokenCriteriaItems: seq[TokenCriteriaItem] = @[]
+
+  for tc in tokenPermission.tokenCriteria:
+
+    let tokenCriteriaItem = initTokenCriteriaItem(
+      tc.symbol,
+      tc.name,
+      tc.amount.parseFloat,
+      tc.`type`.int,
+      tc.ensPattern,
+      false # tokenCriteriaMet will be updated by a call to checkPermissionsToJoin
+    )
+
+    tokenCriteriaItems.add(tokenCriteriaItem)
+
+  let tokenPermissionItem = initTokenPermissionItem(
+      tokenPermission.id, 
+      tokenPermission.`type`.int, 
+      tokenCriteriaItems,
+      @[], # TODO: handle chat list items
+      tokenPermission.isPrivate,
+      false # allTokenCriteriaMet will be update by a call to checkPermissinosToJoin
+  )
+
+  return tokenPermissionItem

--- a/src/app/modules/shared_models/token_permissions_model.nim
+++ b/src/app/modules/shared_models/token_permissions_model.nim
@@ -32,13 +32,13 @@ QtObject:
       ModelRole.Key.int:"key",
       ModelRole.Type.int:"permissionType",
       ModelRole.TokenCriteria.int:"holdingsListModel",
-      ModelRole.ChatList.int:"channelsModel",
+      ModelRole.ChatList.int:"channelsListModel",
       ModelRole.IsPrivate.int:"isPrivate",
     }.toTable
 
   proc countChanged(self: TokenPermissionsModel) {.signal.}
   proc getCount*(self: TokenPermissionsModel): int {.slot.} =
-    self.items.len
+    return self.items.len
   QtProperty[int] count:
     read = getCount
     notify = countChanged
@@ -126,6 +126,5 @@ QtObject:
       ModelRole.Key.int,
       ModelRole.Type.int,
       ModelRole.TokenCriteria.int,
-      ModelRole.IsPrivate.int
+      ModelRole.IsPrivate.int,
     ])
-

--- a/ui/app/AppLayouts/Chat/controls/community/CommunityPermissionsRow.qml
+++ b/ui/app/AppLayouts/Chat/controls/community/CommunityPermissionsRow.qml
@@ -228,6 +228,12 @@ Control {
     }
 
     onModelChanged: d.buildShortModel(root.model)
+    Connections {
+        target: root.model
+        function onCountChanged() {
+            d.buildShortModel(root.model)
+        }
+    }
     Component.onCompleted: d.buildShortModel(root.model)
 
     ListModel { id: shortModel }
@@ -268,6 +274,12 @@ Control {
         spacing: -root.overlapping
 
         onModelChanged: buildTokensRowModel(singlePermissionItem.model)
+        Connections {
+            target: singlePermissionItem.model
+            function onCountChanged() {
+                buildTokensRowModel(singlePermissionItem.model)
+            }
+        }
         Component.onCompleted: buildTokensRowModel(singlePermissionItem.model)
 
         ListModel{ id: shortTokensRowModel }

--- a/ui/app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml
+++ b/ui/app/AppLayouts/CommunitiesPortal/CommunitiesPortalLayout.qml
@@ -25,8 +25,8 @@ StatusSectionLayout {
 
     property var communitiesStore
 
-    property alias assetsModel: communitiesGrid.assetsModel
-    property alias collectiblesModel: communitiesGrid.collectiblesModel
+    property var assetsModel
+    property var collectiblesModel
 
     objectName: "communitiesPortalLayout"
     onNotificationButtonClicked: Global.openActivityCenterPopup()

--- a/ui/app/AppLayouts/CommunitiesPortal/views/CommunitiesGridView.qml
+++ b/ui/app/AppLayouts/CommunitiesPortal/views/CommunitiesGridView.qml
@@ -84,9 +84,10 @@ StatusScrollView {
             popularity: model.popularity
             categories: tagsJson.model
 
-            // Community restriccions
+
+            // Community restrictions
             rigthHeaderComponent: CommunityPermissionsRow {
-                visible: !!card.permissionsList
+                visible: !!card.permissionsList && card.permissionsList.count > 0
                 assetsModel: root.assetsModel
                 collectiblesModel: root.collectiblesModel
                 model: card.permissionsList

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -967,8 +967,28 @@ Item {
                         CommunitiesPortalLayout {
                             anchors.fill: parent
                             communitiesStore: appMain.communitiesStore
-                            assetsModel: appMain.rootChatStore.assetsModel
-                            collectiblesModel: appMain.rootChatStore.collectiblesModel
+                            assetsModel: SortFilterProxyModel {
+                                sourceModel: appMain.communitiesStore.communitiesModuleInst.tokenList
+
+                                proxyRoles: ExpressionRole {
+                                    function tokenIcon(symbol) {
+                                        return Constants.tokenIcon(symbol)
+                                    }
+                                    name: "iconSource"
+                                    expression: !!model.icon ? model.icon : tokenIcon(model.symbol)
+                                }
+                            }
+                            collectiblesModel: SortFilterProxyModel {
+                                sourceModel: appMain.communitiesStore.communitiesModuleInst.collectiblesModel
+
+                                proxyRoles: ExpressionRole {
+                                    function icon(icon) {
+                                        return !!icon ? icon : Style.png("tokens/DEFAULT-TOKEN")
+                                    }
+                                    name: "iconSource"
+                                    expression: icon(model.icon)
+                                }
+                            }
                             notificationCount: appMain.activityCenterStore.unreadNotificationsCount
                             hasUnseenNotifications: activityCenterStore.hasUnseenNotifications
                         }


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/10410

Adds the permission model to the curated communities model.

Also fixes the assetsModel and collectiblesModel used by the community portal, because it was using the basic Chat Store created in AppMain, but that store doesn't have the assets model.

---

I had to do a lot of duplication of code, because the assets model lives in each chat section. IMO, we should just use the one that I created/duplicated in the communities, that way we have less to save in memory, but it would also remove the duplication of code.

The only downside is that if there is a token that is created in a community, it would also appear in the dropdowns of other communities. I think I can live with that. We can also easily filter it if we add the community ID in the token Item.
So in the end, there would be no downside.
It would just be cleaner and lighter.

---

Known issue with this PR: when a token (ERC20 or 721) is created, it will NOT be added the token list that is in the communities module. I plan on adding that with the refactor I described above.
Doing a reset of the app will make it appear though, so I don't think it's a blocking issue for this issue. (edit: created this issue: https://github.com/status-im/status-desktop/issues/11125)

~~Another issue I just found is that if a permission is added or removed on the community, the `count` changes to 0 for some reason. I don't understand why. This should be fixed before merging. Let me know if you have an idea why.~~
Fixed

## Screenshot
![image](https://github.com/status-im/status-desktop/assets/11926403/470a97fe-71a6-42a5-b899-848a3ec9bf2c)
