### PR TITLE
feat(@desktop/wallet): Glue between activity UI filters and backend

### DIFF
--- a/storybook/pages/ActivityFilterMenuPage.qml
+++ b/storybook/pages/ActivityFilterMenuPage.qml
@@ -5,6 +5,7 @@ import QtQuick.Layouts 1.14
 import AppLayouts.Wallet.controls 1.0
 import AppLayouts.Wallet.popups 1.0
 import AppLayouts.Wallet.panels 1.0
+import AppLayouts.Wallet.stores 1.0
 import AppLayouts.stores 1.0
 
 import StatusQ.Core 0.1
@@ -31,285 +32,7 @@ SplitView {
 
     QtObject {
         id: d
-        property int selectedTime: Constants.TransactionTimePeriod.All
-        property double fromTimestamp: new Date().setDate(new Date().getDate() - 7)
-        property double toTimestamp: Date.now()
-        function changeSelectedTime(newTime) {
-            selectedTime = newTime
-        }
-        function setCustomTimeRange(fromTimestamp , toTimestamp) {
-            d.fromTimestamp = fromTimestamp
-            d.toTimestamp = toTimestamp
-        }
-        property var typeFilters: [
-            Constants.TransactionType.Send,
-            Constants.TransactionType.Receive,
-            Constants.TransactionType.Buy,
-            Constants.TransactionType.Swap,
-            Constants.TransactionType.Bridge]
-
-        function toggleType(type) {
-            let tempFilters = typeFilters
-            let allCheckedIs = false
-            if(tempFilters.length === 5)
-                allCheckedIs = true
-
-            // if all were selected then only select one of them
-            if(allCheckedIs) {
-                tempFilters = [type]
-            }
-            else {
-                // if last one is being deselected, select all
-                if(tempFilters.length === 1 && tempFilters[0] === type) {
-                    tempFilters = [
-                                Constants.TransactionType.Send,
-                                Constants.TransactionType.Receive,
-                                Constants.TransactionType.Buy,
-                                Constants.TransactionType.Swap,
-                                Constants.TransactionType.Bridge]
-                }
-                else {
-                    let index = tempFilters.indexOf(type)
-                    if(index === -1) {
-                        tempFilters.push(type)
-                    }
-                    else {
-                        tempFilters.splice(index, 1)
-                    }
-                }
-            }
-            typeFilters = tempFilters
-        }
-
-        property var statusFilters: [
-            Constants.TransactionStatus.Failed,
-            Constants.TransactionStatus.Pending,
-            Constants.TransactionStatus.Complete,
-            Constants.TransactionStatus.Finished]
-
-        function toggleStatus(status) {
-            let tempFilters = statusFilters
-            let allCheckedIs = false
-            if(tempFilters.length === 4)
-                allCheckedIs = true
-
-            // if all were selected then only select one of them
-            if(allCheckedIs) {
-                tempFilters = [status]
-            }
-            else {
-                // if last one is being deselected, select all
-                if(tempFilters.length === 1 && tempFilters[0] === status) {
-                    tempFilters = [
-                                Constants.TransactionStatus.Failed,
-                                Constants.TransactionStatus.Pending,
-                                Constants.TransactionStatus.Complete,
-                                Constants.TransactionStatus.Finished]
-                }
-                else {
-                    let index = tempFilters.indexOf(status)
-                    if(index === -1) {
-                        tempFilters.push(status)
-                    }
-                    else {
-                        tempFilters.splice(index, 1)
-                    }
-                }
-            }
-            statusFilters = tempFilters
-        }
-
-        property var simulatedAssetsModel: WalletAssetsModel {}
-        function toggleToken(tokenSymbol) {
-            let tempodel = simulatedAssetsModel
-            let allChecked = true
-            let allChecked1 = true
-            let checkedTokens = []
-            simulatedAssetsModel = []
-            for (let k =0; k<tempodel.count; k++) {
-                if(!tempodel.get(k).checked)
-                    allChecked = false
-                else {
-                    checkedTokens.push(tempodel.get(k))
-                }
-            }
-
-            if(allChecked) {
-                for (let i = 0; i<tempodel.count; i++) {
-                    if(tempodel.get(i).symbol === tokenSymbol) {
-                        tempodel.get(i).checked = true
-                    }
-                    else
-                        tempodel.get(i).checked = false
-                }
-
-            }
-            else if(checkedTokens.length === 1 && checkedTokens[0].symbol === tokenSymbol) {
-                for (let j = 0; j<tempodel.count; j++) {
-                    tempodel.get(j).checked = true
-                    tempodel.get(j).allChecked = true
-                }
-            }
-            else {
-                for (let l =0; l<tempodel.count; l++) {
-                    if(tempodel.get(l).symbol === tokenSymbol)
-                        tempodel.get(l).checked = !tempodel.get(l).checked
-                }
-            }
-            for (let l =0; l<tempodel.count; l++) {
-                if(!tempodel.get(l).checked)
-                    allChecked1 = false
-            }
-            for (let j =0; j<tempodel.count; j++) {
-                tempodel.get(j).allChecked = allChecked1
-            }
-            simulatedAssetsModel = tempodel
-        }
-
-        property var simulatedCollectiblesModel: CollectiblesModel {}
-        function toggleCollectibles(name) {
-            let tempodel = simulatedCollectiblesModel
-            let allChecked = true
-            let allChecked1 = true
-            let checkedTokens = []
-            simulatedCollectiblesModel = []
-            for (let k =0; k<tempodel.count; k++) {
-                if(!tempodel.get(k).checked)
-                    allChecked = false
-                else {
-                    checkedTokens.push(tempodel.get(k))
-                }
-            }
-
-            if(allChecked) {
-                for (let i = 0; i<tempodel.count; i++) {
-                    if(tempodel.get(i).name === name) {
-                        tempodel.get(i).checked = true
-                    }
-                    else
-                        tempodel.get(i).checked = false
-                }
-
-            }
-            else if(checkedTokens.length === 1 && checkedTokens[0].name === name) {
-                for (let j = 0; j<tempodel.count; j++) {
-                    tempodel.get(j).checked = true
-                    tempodel.get(j).allChecked = true
-                }
-            }
-            else {
-                for (let l =0; l<tempodel.count; l++) {
-                    if(tempodel.get(l).name === name)
-                        tempodel.get(l).checked = !tempodel.get(l).checked
-                }
-            }
-            for (let l =0; l<tempodel.count; l++) {
-                if(!tempodel.get(l).checked)
-                    allChecked1 = false
-            }
-            for (let j =0; j<tempodel.count; j++) {
-                tempodel.get(j).allChecked = allChecked1
-            }
-            simulatedCollectiblesModel = tempodel
-        }
-
         property var recipeintModel: RecipientModel {}
-        property var simulatedSavedList: recipeintModel.savedAddresses
-        property var simulatedRecentsList: recipeintModel.recents
-
-        function toggleSavedAddress(address) {
-            let tempodel = simulatedSavedList
-            let allChecked = true
-            let allChecked1 = true
-            let checkedTokens = []
-            simulatedSavedList = []
-            for (let k =0; k<tempodel.count; k++) {
-                if(!tempodel.get(k).checked)
-                    allChecked = false
-                else {
-                    checkedTokens.push(tempodel.get(k))
-                }
-            }
-
-            if(allChecked) {
-                for (let i = 0; i<tempodel.count; i++) {
-                    if(tempodel.get(i).address === address) {
-                        tempodel.get(i).checked = true
-                    }
-                    else
-                        tempodel.get(i).checked = false
-                }
-
-            }
-            else if(checkedTokens.length === 1 && checkedTokens[0].address === address) {
-                for (let j = 0; j<tempodel.count; j++) {
-                    tempodel.get(j).checked = true
-                    tempodel.get(j).allChecked = true
-                }
-            }
-            else {
-                for (let l =0; l<tempodel.count; l++) {
-                    if(tempodel.get(l).address === address)
-                        tempodel.get(l).checked = !tempodel.get(l).checked
-                }
-            }
-            for (let l =0; l<tempodel.count; l++) {
-                if(!tempodel.get(l).checked)
-                    allChecked1 = false
-            }
-            for (let j =0; j<tempodel.count; j++) {
-                tempodel.get(j).allChecked = allChecked1
-            }
-            simulatedSavedList = tempodel
-        }
-
-        function toggleRecents(address) {
-            let tempodel = simulatedRecentsList
-            let allChecked = true
-            let allChecked1 = true
-            let checkedTokens = []
-            simulatedRecentsList = []
-            for (let k =0; k<tempodel.count; k++) {
-                if(!tempodel.get(k).checked)
-                    allChecked = false
-                else {
-                    checkedTokens.push(tempodel.get(k))
-                }
-            }
-
-            if(allChecked) {
-                for (let i = 0; i<tempodel.count; i++) {
-                    let addresstoFind = tempodel.get(i).to.toLowerCase() === d.store.overview.mixedcaseAddress.toLowerCase() ? tempodel.get(i).from : tempodel.get(i).to
-                    if(addresstoFind === address) {
-                        tempodel.get(i).checked = true
-                    }
-                    else
-                        tempodel.get(i).checked = false
-                }
-
-            }
-            else if(checkedTokens.length === 1 && (checkedTokens[0].to.toLowerCase() === d.store.overview.mixedcaseAddress.toLowerCase() ? checkedTokens[0].from : checkedTokens[0].to) === address) {
-                for (let j = 0; j<tempodel.count; j++) {
-                    tempodel.get(j).checked = true
-                    tempodel.get(j).allChecked = true
-                }
-            }
-            else {
-                for (let l =0; l<tempodel.count; l++) {
-                    let addresstoFind = tempodel.get(l).to.toLowerCase() === d.store.overview.mixedcaseAddress.toLowerCase() ? tempodel.get(l).from : tempodel.get(l).to
-                    if(addresstoFind === address )
-                        tempodel.get(l).checked = !tempodel.get(l).checked
-                }
-            }
-            for (let m =0; m<tempodel.count; m++) {
-                if(!tempodel.get(m).checked)
-                    allChecked1 = false
-            }
-            for (let n =0; n<tempodel.count; n++) {
-                tempodel.get(n).allChecked = allChecked1
-            }
-            simulatedRecentsList = tempodel
-        }
 
         property var store: QtObject {
             property var overview: ({
@@ -333,6 +56,35 @@ SplitView {
                 return ""
             }
         }
+
+        property var activityController: QtObject {
+            function setFilterTime(fromTimestamp, toTimestamp) {
+                console.warn("activityController:: setFilterTime:: fromTimestamp: ",fromTimestamp, " toTimestamp:: ",toTimestamp)
+            }
+            function setFilterType(typeFilters) {
+                console.warn("activityController:: setFilterType:: ",typeFilters)
+            }
+            function setFilterStatus(statusFilters) {
+                console.warn("activityController:: setFilterStatus:: ",statusFilters)
+            }
+            function setFilterAssets(tokensFilter) {
+                console.warn("activityController:: setFilterAssets:: ",tokensFilter)
+            }
+            function setFilterToAddresses(filters) {
+                console.warn("activityController:: setFilterToAddresses:: ",filters)
+            }
+            function updateFilter() {
+                console.warn("activityController:: updateFilter")
+            }
+        }
+    }
+    ActivityFiltersStore {
+        id: actvityStore
+        tokensList: WalletAssetsModel {}
+        collectiblesList: CollectiblesModel {}
+        savedAddressesModel: d.recipeintModel.savedAddresses
+        activityController: d.activityController
+        areTestNetworksEnabled: false
     }
 
     Item {
@@ -344,133 +96,7 @@ SplitView {
             width: 800
             anchors.centerIn: parent
             store: d.store
-            fromTimestamp: d.fromTimestamp
-            toTimestamp: d.toTimestamp
-            selectedTime: d.selectedTime
-            typeFilters: d.typeFilters
-            statusFilters: d.statusFilters
-            assetsList: d.simulatedAssetsModel
-            collectiblesList: d.simulatedCollectiblesModel
-            savedAddressList: d.simulatedSavedList
-            recentsList: d.simulatedRecentsList
-            onChangeSelectedTime: d.changeSelectedTime(selectedTime)
-            onSetCustomTimeRange: d.setCustomTimeRange(from, to)
-            onToggleType: d.toggleType(type)
-            onToggleStatus: d.toggleStatus(status)
-            onToggleToken: d.toggleToken(tokenSymbol)
-            onToggleCollectibles: d.toggleCollectibles(name)
-            onToggleSavedAddress: d.toggleSavedAddress(address)
-            onToggleRecents: d.toggleRecents(address)
-        }
-    }
-
-    LogsAndControlsPanel {
-        id: logsAndControlsPanel
-
-        SplitView.minimumHeight: 100
-        SplitView.preferredHeight: 200
-
-        logsView.logText: logs.logText
-
-        ButtonGroup {
-            buttons: periodRow.children
-        }
-
-        Column {
-            spacing: 20
-
-            Row {
-                id: periodRow
-                spacing: 20
-
-                RadioButton {
-                    checked: true
-                    text: "All"
-                    onCheckedChanged: if(checked) { d.selectedTime =  Constants.TransactionTimePeriod.All}
-                }
-                RadioButton {
-                    text: "Today"
-                    onCheckedChanged: if(checked) { d.selectedTime =  Constants.TransactionTimePeriod.Today}
-                }
-                RadioButton {
-                    text: "Yesterday"
-                    onCheckedChanged: if(checked) { d.selectedTime =  Constants.TransactionTimePeriod.Yesterday}
-                }
-                RadioButton {
-                    text: "ThisWeek"
-                    onCheckedChanged: if(checked) { d.selectedTime =  Constants.TransactionTimePeriod.ThisWeek}
-                }
-                RadioButton {
-                    text: "LastWeek"
-                    onCheckedChanged: if(checked) { d.selectedTime =  Constants.TransactionTimePeriod.LastWeek}
-                }
-                RadioButton {
-                    text: "ThisMonth"
-                    onCheckedChanged: if(checked) { d.selectedTime =  Constants.TransactionTimePeriod.ThisMonth}
-                }
-                RadioButton {
-                    text: "LastMonth"
-                    onCheckedChanged: if(checked) { d.selectedTime =  Constants.TransactionTimePeriod.LastMonth}
-                }
-                RadioButton {
-                    text: "Custom"
-                    onCheckedChanged: if(checked) { d.selectedTime =  Constants.TransactionTimePeriod.Custom}
-                }
-            }
-
-            Row {
-                spacing: 20
-                CheckBox {
-                    text: "Send"
-                    checked: d.typeFilters.includes(Constants.TransactionType.Send)
-                    onClicked: d.toggleType(Constants.TransactionType.Send)
-                }
-                CheckBox {
-                    text: "Receive"
-                    checked: d.typeFilters.includes(Constants.TransactionType.Receive)
-                    onClicked: d.toggleType(Constants.TransactionType.Receive)
-                }
-                CheckBox {
-                    text: "Buy"
-                    checked: d.typeFilters.includes(Constants.TransactionType.Buy)
-                    onClicked: d.toggleType(Constants.TransactionType.Buy)
-                }
-                CheckBox {
-                    text: "Swap"
-                    checked: d.typeFilters.includes(Constants.TransactionType.Swap)
-                    onClicked: d.toggleType(Constants.TransactionType.Swap)
-                }
-                CheckBox {
-                    text: "Bridge"
-                    checked: d.typeFilters.includes(Constants.TransactionType.Bridge)
-                    onClicked: d.toggleType(Constants.TransactionType.Bridge)
-                }
-            }
-
-
-            Row {
-                spacing: 20
-                CheckBox {
-                    text: "Failed"
-                    checked: d.statusFilters.includes(Constants.TransactionStatus.Failed)
-                    onClicked: d.toggleStatus(Constants.TransactionStatus.Failed)
-                }
-                CheckBox {
-                    text: "Pending"
-                    checked: d.statusFilters.includes(Constants.TransactionStatus.Pending)
-                    onClicked: d.toggleStatus(Constants.TransactionStatus.Pending)
-                }
-                CheckBox {
-                    text: "Complete"
-                    checked: d.statusFilters.includes(Constants.TransactionStatus.Complete)
-                    onClicked: d.toggleStatus(Constants.TransactionStatus.Complete)
-                }
-                CheckBox {
-                    text: "Finished"
-                    checked: d.statusFilters.includes(Constants.TransactionStatus.Finished)
-                    onClicked: d.toggleStatus(Constants.TransactionStatus.Finished)
-                }
-            }
+            activityFilterStore: actvityStore
         }
     }
 }

--- a/storybook/src/Models/CollectiblesModel.qml
+++ b/storybook/src/Models/CollectiblesModel.qml
@@ -9,16 +9,16 @@ ListModel {
             iconSource: ModelsData.collectibles.anniversary,
             name: "Anniversary",
             category: TokenCategories.Category.Community,
-            checked: true,
-            allChecked: true
+            imageUrl: ModelsData.collectibles.anniversary,
+            id: 1767698
         },
         {
             key: "Anniversary2",
             iconSource: ModelsData.collectibles.anniversary,
             name: "Anniversary2",
             category: TokenCategories.Category.Community,
-            checked: true,
-            allChecked: true
+            imageUrl: ModelsData.collectibles.anniversary,
+            id: 1767699
         },
         {
             key: "CryptoKitties",
@@ -69,26 +69,28 @@ ListModel {
                     name: "Magicat-4"
                 }
             ],
-            checked: true,
-            allChecked: true
+            imageUrl: ModelsData.collectibles.cryptoKitties,
+            id: 1767700
         },
         {
             key: "SuperRare",
             iconSource: ModelsData.collectibles.superRare,
             name: "SuperRare",
             category: TokenCategories.Category.Own,
-            checked: true,
-            allChecked: true
+            imageUrl: ModelsData.collectibles.superRare,
+            id: 1767701
         },
         {
             key: "Custom",
             iconSource: ModelsData.collectibles.custom,
             name: "Custom Collectible",
             category: TokenCategories.Category.General,
-            checked: true,
-            allChecked: true
+            imageUrl: ModelsData.collectibles.custom,
+            id: 1767764
         }
     ]
+
+    property bool isFetching: false
 
     Component.onCompleted: append(data)
 }

--- a/ui/app/AppLayouts/Wallet/controls/ActivityTypeCheckBox.qml
+++ b/ui/app/AppLayouts/Wallet/controls/ActivityTypeCheckBox.qml
@@ -34,6 +34,7 @@ StatusListItem {
     components: [
         StatusCheckBox {
             id: checkBox
+            visible: !root.loading
             tristate: true
             checkable: true
             spacing: 0

--- a/ui/app/AppLayouts/Wallet/popups/ActivityFilterMenu.qml
+++ b/ui/app/AppLayouts/Wallet/popups/ActivityFilterMenu.qml
@@ -8,32 +8,45 @@ import "./filterSubMenus"
 StatusMenu {
     id: root
 
+    property var store
+
     // Time filter
     property int selectedTime: ActivityFilterMenu.All
     signal setSelectedTime(int selectedTime)
 
     // Type filter
     property var typeFilters: []
-    property bool allTypesChecked: typeMenu.allChecked
-    signal updateTypeFilter(int type)
+    readonly property bool allTypesChecked: typeMenu.allChecked
+    signal updateTypeFilter(int type, int allFiltersCount)
 
     // Status filter
     property var statusFilters: []
-    property bool allStatusChecked: statusMenu.allChecked
-    signal updateStatusFilter(int status)
+    readonly property bool allStatusChecked: statusMenu.allChecked
+    signal updateStatusFilter(int status, int allFiltersCount)
 
-    // Assets filter
+    // Tokens filter
     property var tokensList: []
-    property var collectiblesList
+    property var tokensFilter: []
+    readonly property bool allTokensChecked: tokensMenu.allTokensChecked
     signal updateTokensFilter(string tokenSymbol)
-    signal updateCollectiblesFilter(string name)
 
-    // Counterparty filter
-    property var store
+    // Collectibles filter
+    property var collectiblesList: []
+    property var collectiblesFilter: []
+    readonly property bool allCollectiblesChecked: tokensMenu.allCollectiblesChecked
+    signal updateCollectiblesFilter(double id)
+
+    // Recents filter
     property var recentsList
-    property var savedAddressList
-    signal updateSavedAddressFilter(string address)
+    property var recentsFilters
+    readonly property bool allRecentsChecked: counterPartyMenu.allRecentsChecked
     signal updateRecentsFilter(string address)
+
+    // Collectibles filter
+    property var savedAddressList
+    property var savedAddressFilters
+    readonly property bool allSavedAddressesChecked: counterPartyMenu.allSavedAddressesChecked
+    signal updateSavedAddressFilter(string address)
 
     implicitWidth: 176
 
@@ -57,14 +70,14 @@ StatusMenu {
             id: typeMenu
             onBack: root.open()
             typeFilters: root.typeFilters
-            onActionTriggered: updateTypeFilter(type)
+            onActionTriggered: updateTypeFilter(type, allFiltersCount)
             closePolicy: root.closePolicy
         }
         ActivityStatusFilterSubMenu {
             id: statusMenu
             onBack: root.open()
             statusFilters: root.statusFilters
-            onActionTriggered: updateStatusFilter(status)
+            onActionTriggered: updateStatusFilter(status, allFiltersCount)
             closePolicy: root.closePolicy
         }
         ActivityTokensFilterSubMenu {
@@ -72,9 +85,11 @@ StatusMenu {
             height: Math.min(439, tokensMenu.implicitHeight)
             onBack: root.open()
             tokensList: root.tokensList
+            tokensFilter: root.tokensFilter
             collectiblesList: root.collectiblesList
+            collectiblesFilter: root.collectiblesFilter
             onTokenToggled: updateTokensFilter(tokenSymbol)
-            onCollectibleToggled: updateCollectiblesFilter(name)
+            onCollectibleToggled: updateCollectiblesFilter(id)
             closePolicy: root.closePolicy
         }
         ActivityCounterpartyFilterSubMenu {
@@ -83,7 +98,9 @@ StatusMenu {
             onBack: root.open()
             store: root.store
             recentsList: root.recentsList
+            recentsFilters: root.recentsFilters
             savedAddressList: root.savedAddressList
+            savedAddressFilters: root.savedAddressFilters
             onSavedAddressToggled: root.updateSavedAddressFilter(address)
             onRecentsToggled: root.updateRecentsFilter(address)
             closePolicy: root.closePolicy

--- a/ui/app/AppLayouts/Wallet/popups/filterSubMenus/ActivityStatusFilterSubMenu.qml
+++ b/ui/app/AppLayouts/Wallet/popups/filterSubMenus/ActivityStatusFilterSubMenu.qml
@@ -11,7 +11,8 @@ StatusMenu {
     id: root
 
     property var statusFilters: []
-    readonly property bool allChecked: statusFilters.length === typeButtonGroup.buttons.length
+    readonly property bool allChecked: statusFilters.length === 0
+    readonly property int allFiltersCount: typeButtonGroup.buttons.length
 
     signal back()
     signal actionTriggered(int status)
@@ -37,7 +38,7 @@ StatusMenu {
         buttonGroup: typeButtonGroup
         allChecked: root.allChecked
         type: Constants.TransactionStatus.Failed
-        checked: statusFilters.includes(type)
+        checked: root.allChecked || statusFilters.includes(type)
         onActionTriggered: root.actionTriggered(type)
     }
 
@@ -49,7 +50,7 @@ StatusMenu {
         buttonGroup: typeButtonGroup
         allChecked: root.allChecked
         type: Constants.TransactionStatus.Pending
-        checked: statusFilters.includes(type)
+        checked: root.allChecked || statusFilters.includes(type)
         onActionTriggered: root.actionTriggered(type)
     }
 
@@ -61,7 +62,7 @@ StatusMenu {
         buttonGroup: typeButtonGroup
         allChecked: root.allChecked
         type: Constants.TransactionStatus.Complete
-        checked: statusFilters.includes(type)
+        checked: root.allChecked || statusFilters.includes(type)
         onActionTriggered: root.actionTriggered(type)
     }
 
@@ -73,7 +74,7 @@ StatusMenu {
         buttonGroup: typeButtonGroup
         allChecked: root.allChecked
         type: Constants.TransactionStatus.Finished
-        checked: statusFilters.includes(type)
+        checked: root.allChecked || statusFilters.includes(type)
         onActionTriggered: root.actionTriggered(type)
     }
 }

--- a/ui/app/AppLayouts/Wallet/popups/filterSubMenus/ActivityTypeFilterSubMenu.qml
+++ b/ui/app/AppLayouts/Wallet/popups/filterSubMenus/ActivityTypeFilterSubMenu.qml
@@ -11,7 +11,8 @@ StatusMenu {
     id: root
 
     property var typeFilters: []
-    readonly property bool allChecked: typeFilters.length === typeButtonGroup.buttons.length
+    readonly property bool allChecked: typeFilters.length === 0
+    readonly property int allFiltersCount: typeButtonGroup.buttons.length
 
     signal back()
     signal actionTriggered(int type)
@@ -36,7 +37,7 @@ StatusMenu {
         buttonGroup: typeButtonGroup
         allChecked: root.allChecked
         type: Constants.TransactionType.Send
-        checked: typeFilters.includes(type)
+        checked: root.allChecked || typeFilters.includes(type)
         onActionTriggered: root.actionTriggered(type)
     }
 
@@ -47,7 +48,7 @@ StatusMenu {
         buttonGroup: typeButtonGroup
         allChecked: root.allChecked
         type: Constants.TransactionType.Receive
-        checked: typeFilters.includes(type)
+        checked: root.allChecked || typeFilters.includes(type)
         onActionTriggered: root.actionTriggered(type)
     }
 
@@ -58,7 +59,7 @@ StatusMenu {
         buttonGroup: typeButtonGroup
         allChecked: root.allChecked
         type: Constants.TransactionType.Buy
-        checked: typeFilters.includes(type)
+        checked: root.allChecked || typeFilters.includes(type)
         onActionTriggered: root.actionTriggered(type)
     }
 
@@ -69,7 +70,7 @@ StatusMenu {
         buttonGroup: typeButtonGroup
         allChecked: root.allChecked
         type: Constants.TransactionType.Swap
-        checked: typeFilters.includes(type)
+        checked: root.allChecked || typeFilters.includes(type)
         onActionTriggered: root.actionTriggered(type)
     }
 
@@ -80,7 +81,7 @@ StatusMenu {
         buttonGroup: typeButtonGroup
         allChecked: root.allChecked
         type: Constants.TransactionType.Bridge
-        checked: typeFilters.includes(type)
+        checked: root.allChecked || typeFilters.includes(type)
         onActionTriggered: root.actionTriggered(type)
     }
 }

--- a/ui/app/AppLayouts/Wallet/stores/ActivityFiltersStore.qml
+++ b/ui/app/AppLayouts/Wallet/stores/ActivityFiltersStore.qml
@@ -1,0 +1,176 @@
+import QtQuick 2.13
+
+import SortFilterProxyModel 0.2
+
+import utils 1.0
+
+QtObject {
+    id: root
+
+    property var activityController: walletSection.activityController
+    property bool filtersSet: fromTimestamp !== 0 || toTimestamp !== 0 ||
+                                typeFilters.length !== 0 ||
+                                statusFilters.length !== 0 ||
+                                tokensFilter.length !== 0 ||
+                                collectiblesFilter.length !== 0 ||
+                                recentsFilters.length !== 0 ||
+                                savedAddressFilters.length !== 0
+
+    // Time filters
+    property int selectedTime: Constants.TransactionTimePeriod.All
+    // To-do get this from the backend once oldest Tx timestamp is available
+    property double fromTimestamp
+    property double toTimestamp: new Date().valueOf()
+    function setSelectedTimestamp(selcTime) {
+        selectedTime = selcTime
+        var currDate = new Date() // current date
+        switch(selectedTime) {
+        case Constants.TransactionTimePeriod.All:
+            fromTimestamp = 0
+            toTimestamp = 0
+            break
+        case Constants.TransactionTimePeriod.Today:
+            fromTimestamp = currDate.valueOf() // Today
+            toTimestamp = fromTimestamp
+            break
+        case Constants.TransactionTimePeriod.Yesterday:
+            fromTimestamp = new Date().setDate(currDate.getDate() - 1).valueOf() // Yesterday
+            toTimestamp = fromTimestamp
+            break
+        case Constants.TransactionTimePeriod.ThisWeek:
+            var firstDayOfCurrentWeek = currDate.getDate() - currDate.getDay()
+            fromTimestamp = new Date().setDate(firstDayOfCurrentWeek).valueOf() // This week
+            toTimestamp = currDate.valueOf()
+            break
+        case Constants.TransactionTimePeriod.LastWeek:
+            fromTimestamp = new Date().setDate(currDate.getDate() - 7).valueOf() // Last week
+            toTimestamp = currDate.valueOf()
+            break
+        case Constants.TransactionTimePeriod.ThisMonth:
+            fromTimestamp = new Date().setDate(1).valueOf() // This month
+            toTimestamp = currDate.valueOf()
+            break
+        case Constants.TransactionTimePeriod.LastMonth:
+            let x = new Date()
+            x.setDate(1)
+            x.setMonth(x.getMonth()-1)
+            fromTimestamp = x.valueOf() // Last month
+            x.setDate(new Date(x.getFullYear(), x.getMonth(), 0).getDate() + 1)
+            toTimestamp = x.valueOf()
+            break
+        default:
+            return ""
+        }
+
+        activityController.setFilterTime(root.fromTimestamp/1000, root.toTimestamp/1000)
+        activityController.updateFilter()
+    }
+    function setCustomTimeRange(fromTimestamp, toTimestamp) {
+        root.fromTimestamp = fromTimestamp
+        root.toTimestamp = toTimestamp
+
+        activityController.setFilterTime(root.fromTimestamp/1000, root.toTimestamp/1000)
+        activityController.updateFilter()
+    }
+
+    // Type Filters
+    property var typeFilters: []
+    function toggleType(type, allFiltersCount) {
+        // update filters
+        typeFilters = toggleFilterState(typeFilters, type, allFiltersCount)
+        // Set backend values
+        activityController.setFilterType(JSON.stringify(typeFilters))
+        activityController.updateFilter()
+    }
+
+    // Status Filters
+    property var statusFilters: []
+    function toggleStatus(status, allFiltersCount) {
+        // update filters
+        statusFilters = toggleFilterState(statusFilters, status, allFiltersCount)
+        // Set backend values
+        activityController.setFilterStatus(JSON.stringify(statusFilters))
+        activityController.updateFilter()
+    }
+
+    // Tokens Filters
+    property var tokensList: walletSectionAssets.assets
+    property var tokensFilter: []
+    function toggleToken(symbol) {
+        // update filters
+        tokensFilter = toggleFilterState(tokensFilter, symbol, tokensList.count)
+        // Set backend values
+        activityController.setFilterAssets(JSON.stringify(tokensFilter))
+        activityController.updateFilter()
+    }
+
+    // Collectibles Filters
+    property var collectiblesList: walletSectionCollectibles.model
+    property var collectiblesFilter: []
+    function toggleCollectibles(id) {
+        // update filters
+        collectiblesFilter = toggleFilterState(collectiblesFilter, id, collectiblesList.count)
+        // To-do go side filtering is pending
+        //        activityController.setFilterCollectibles(JSON.stringify(collectiblesFilter))
+        //        activityController.updateFilter()
+    }
+
+
+    // To-do get correct model unaffected by filters from go side
+    property var recentsList: []
+    property var recentsFilters: []
+    function toggleRecents(address) {
+        // update filters
+        recentsFilters = toggleFilterState(recentsFilters, address, recentsList.count)
+        // Set backend values
+        activityController.setFilterToAddresses(JSON.stringify(recentsFilters.concat(savedAddressFilters)))
+        activityController.updateFilter()
+    }
+
+    property var savedAddressesModel: walletSectionSavedAddresses.model
+    property bool areTestNetworksEnabled: networksModule.areTestNetworksEnabled
+    property var savedAddressList:  SortFilterProxyModel {
+        sourceModel: savedAddressesModel
+        filters: [
+            ValueFilter {
+                roleName: "isTest"
+                value: areTestNetworksEnabled
+            }
+        ]
+    }
+    property var savedAddressFilters: []
+    function toggleSavedAddress(address) {
+        // update filters
+        savedAddressFilters = toggleFilterState(savedAddressFilters, address, savedAddressList.count)
+        // Set backend values
+        activityController.setFilterToAddresses(JSON.stringify(recentsFilters.concat(savedAddressFilters)))
+        activityController.updateFilter()
+    }
+
+    function toggleFilterState(filters, attribute, allFiltersCount) {
+        let tempFilters = filters
+        // if all were selected then only select one of them
+        if(tempFilters.length === 0) {
+            tempFilters = [attribute]
+        }
+        else {
+            // if last one is being deselected, select all
+            if(tempFilters.length === 1 && tempFilters[0] === attribute) {
+                tempFilters = []
+            }
+            else {
+                let index = tempFilters.indexOf(attribute)
+                if(index === -1) {
+                    if(allFiltersCount === tempFilters.length + 1)
+                        tempFilters = []
+                    else
+                        tempFilters.push(attribute)
+                }
+                else {
+                    tempFilters.splice(index, 1)
+                }
+            }
+        }
+        return tempFilters
+    }
+}

--- a/ui/app/AppLayouts/Wallet/stores/qmldir
+++ b/ui/app/AppLayouts/Wallet/stores/qmldir
@@ -1,1 +1,2 @@
 singleton RootStore 1.0 RootStore.qml
+ActivityFiltersStore 1.0 ActivityFiltersStore.qml

--- a/ui/imports/shared/views/HistoryView.qml
+++ b/ui/imports/shared/views/HistoryView.qml
@@ -33,6 +33,7 @@ ColumnLayout {
     QtObject {
         id: d
         property bool isLoading: false
+        property var activityFiltersStore: WalletStores.ActivityFiltersStore{}
     }
 
     Connections {
@@ -58,7 +59,7 @@ ColumnLayout {
         id: noTxs
         Layout.fillWidth: true
         Layout.preferredHeight: 42
-        visible: !d.isLoading && transactionListRoot.count === 0
+        visible: !d.isLoading && transactionListRoot.count === 0 && !d.activityFiltersStore.filtersSet
         font.pixelSize: Style.current.primaryTextFontSize
         text: qsTr("Activity for this account will appear here")
     }
@@ -66,24 +67,11 @@ ColumnLayout {
     // Tp-do make connections with nim once logic is ready
     ActivityFilterPanel {
         id: filterComponent
-        visible: !d.isLoading && transactionListRoot.count !== 0
+        visible: !d.isLoading && (transactionListRoot.count !== 0 || d.activityFiltersStore.filtersSet)
         Layout.fillWidth: true
         Layout.preferredHeight: 50
-        store: RootStore
-        selectedTime: Constants.TransactionTimePeriod.All
-        typeFilters: [
-            Constants.TransactionType.Send,
-            Constants.TransactionType.Receive,
-            Constants.TransactionType.Buy,
-            Constants.TransactionType.Swap,
-            Constants.TransactionType.Bridge
-        ]
-        statusFilters: [
-            Constants.TransactionStatus.Failed,
-            Constants.TransactionStatus.Pending,
-            Constants.TransactionStatus.Complete,
-            Constants.TransactionStatus.Finished
-        ]
+        activityFilterStore: d.activityFiltersStore
+        store: WalletStores.RootStore
     }
 
     Separator {


### PR DESCRIPTION
### What does the PR do

Activity filter functionality
Things that don't work are
1. The from timestamp is not correctly set when we launch the custom date picker
2. The Type (Send , Receive ) doesnt work correctly, will check it in a different issue
3. The recents list of contacts is still WIP under https://github.com/status-im/status-go/pull/3623#issuecomment-1593443407
4. Filtering by collectibles not yet implemented
all of these will be handled under https://github.com/status-im/status-desktop/issues/11117

### Affected areas

Activity view

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

https://github.com/status-im/status-desktop/assets/60327365/7caa5418-5959-4862-bbb2-a677c2164cb2


https://github.com/status-im/status-desktop/assets/60327365/85368e8a-f4a0-4487-9302-e42b596ce697


