### PR TITLE
chore: Update StatusBaseButton content item layout

### DIFF
--- a/storybook/PagesModel.qml
+++ b/storybook/PagesModel.qml
@@ -222,6 +222,10 @@ ListModel {
         section: "Popups"
     }
     ListElement {
+        title: "StatusButton"
+        section: "Controls"
+    }
+    ListElement {
         title: "MembersSelector"
         section: "Components"
     }

--- a/storybook/figma.json
+++ b/storybook/figma.json
@@ -215,5 +215,8 @@
     ],
     "UserAgreementPopup": [
         "https://www.figma.com/file/17fc13UBFvInrLgNUKJJg5/Kuba⎜Desktop?type=design&node-id=31450-560694&t=Q4MOViPCoHsTjhs6-0"
+    ],
+    "StatusButton": [
+        "https://www.figma.com/file/MtAO3a7HnEH5xjCDVNilS7/%F0%9F%8E%A8-Design-System-%E2%8E%9C-Desktop?type=design&node-id=1-12&t=UHegCbqAa5K7qUKd-0"
     ]
 }

--- a/storybook/pages/StatusButtonPage.qml
+++ b/storybook/pages/StatusButtonPage.qml
@@ -1,0 +1,272 @@
+import QtQuick 2.14
+import QtQuick.Controls 2.14
+import QtQuick.Layouts 1.14
+
+import StatusQ.Controls 0.1
+
+import Storybook 1.0
+
+SplitView {
+    Logs { id: logs }
+
+    QtObject {
+        id: d
+        readonly property var sizesModel: [StatusBaseButton.Size.Tiny, StatusBaseButton.Size.Small, StatusBaseButton.Size.Large]
+
+        readonly property string effectiveEmoji: ctrlEmojiEnabled.checked ? ctrlEmoji.text : ""
+        readonly property int effectiveTextPosition: ctrlTextPosLeft.checked ? StatusBaseButton.TextPosition.Left
+                                                                             : StatusBaseButton.TextPosition.Right
+    }
+
+    SplitView {
+        orientation: Qt.Horizontal
+        SplitView.fillWidth: true
+
+        Pane {
+            SplitView.fillWidth: true
+            SplitView.fillHeight: true
+
+            GridLayout {
+                anchors.centerIn: parent
+                rowSpacing: 10
+                columnSpacing: 10
+                columns: 4
+
+                Label { text: "" }
+                Label { text: "Tiny" }
+                Label { text: "Small" }
+                Label { text: "Large" }
+
+                Label {
+                    text: "StatusButton"
+                    Layout.columnSpan: 4
+                    font.bold: true
+                }
+
+                Label { text: "Text only:" }
+                Repeater {
+                    model: d.sizesModel
+                    delegate: StatusButton {
+                        Layout.preferredWidth: ctrlWidth.value || implicitWidth
+                        size: modelData
+                        text: ctrlText.text
+                        asset.emoji: d.effectiveEmoji
+                        textPosition: d.effectiveTextPosition
+                        type: ctrlType.currentIndex
+                        loading: ctrlLoading.checked
+                        enabled: ctrlEnabled.checked
+                        textFillWidth: ctrlFillWidth.checked
+                    }
+                }
+
+                Label { text: "Icon only:" }
+                Repeater {
+                    model: d.sizesModel
+                    delegate: StatusButton {
+                        Layout.preferredWidth: ctrlWidth.value || implicitWidth
+                        size: modelData
+                        icon.name: ctrlIconName.text
+                        asset.emoji: d.effectiveEmoji
+                        textPosition: d.effectiveTextPosition
+                        type: ctrlType.currentIndex
+                        loading: ctrlLoading.checked
+                        enabled: ctrlEnabled.checked
+                        textFillWidth: ctrlFillWidth.checked
+                    }
+                }
+
+                Label { text: "Text + icon:" }
+                Repeater {
+                    model: d.sizesModel
+                    delegate: StatusButton {
+                        Layout.preferredWidth: ctrlWidth.value || implicitWidth
+                        size: modelData
+                        text: ctrlText.text
+                        icon.name: ctrlIconName.text
+                        asset.emoji: d.effectiveEmoji
+                        textPosition: d.effectiveTextPosition
+                        type: ctrlType.currentIndex
+                        loading: ctrlLoading.checked
+                        enabled: ctrlEnabled.checked
+                        textFillWidth: ctrlFillWidth.checked
+                    }
+                }
+
+                Label { text: "Round icon:" }
+                Repeater {
+                    model: d.sizesModel
+                    delegate: StatusButton {
+                        Layout.preferredWidth: ctrlWidth.value || implicitWidth
+                        Layout.preferredHeight: width
+                        size: modelData
+                        icon.name: ctrlIconName.text
+                        asset.emoji: d.effectiveEmoji
+                        textPosition: d.effectiveTextPosition
+                        type: ctrlType.currentIndex
+                        loading: ctrlLoading.checked
+                        enabled: ctrlEnabled.checked
+                        isRoundIcon: true
+                        radius: height/2
+                        textFillWidth: ctrlFillWidth.checked
+                    }
+                }
+
+                Label {
+                    text: "StatusFlatButton (no Primary variant)"
+                    Layout.columnSpan: 4
+                    font.bold: true
+                }
+
+                Label { text: "Text only:" }
+                Repeater {
+                    model: d.sizesModel
+                    delegate: StatusFlatButton {
+                        Layout.preferredWidth: ctrlWidth.value || implicitWidth
+                        size: modelData
+                        text: ctrlText.text
+                        asset.emoji: d.effectiveEmoji
+                        textPosition: d.effectiveTextPosition
+                        type: ctrlType.currentIndex
+                        loading: ctrlLoading.checked
+                        enabled: ctrlEnabled.checked
+                        textFillWidth: ctrlFillWidth.checked
+                    }
+                }
+
+                Label { text: "Icon only:" }
+                Repeater {
+                    model: d.sizesModel
+                    delegate: StatusFlatButton {
+                        Layout.preferredWidth: ctrlWidth.value || implicitWidth
+                        size: modelData
+                        icon.name: ctrlIconName.text
+                        asset.emoji: d.effectiveEmoji
+                        textPosition: d.effectiveTextPosition
+                        type: ctrlType.currentIndex
+                        loading: ctrlLoading.checked
+                        enabled: ctrlEnabled.checked
+                        textFillWidth: ctrlFillWidth.checked
+                    }
+                }
+
+                Label { text: "Text + icon:" }
+                Repeater {
+                    model: d.sizesModel
+                    delegate: StatusFlatButton {
+                        Layout.preferredWidth: ctrlWidth.value || implicitWidth
+                        size: modelData
+                        text: ctrlText.text
+                        icon.name: ctrlIconName.text
+                        asset.emoji: d.effectiveEmoji
+                        textPosition: d.effectiveTextPosition
+                        type: ctrlType.currentIndex
+                        loading: ctrlLoading.checked
+                        enabled: ctrlEnabled.checked
+                        textFillWidth: ctrlFillWidth.checked
+                    }
+                }
+
+                Label { text: "Round icon:" }
+                Repeater {
+                    model: d.sizesModel
+                    delegate: StatusFlatButton {
+                        Layout.preferredWidth: ctrlWidth.value || implicitWidth
+                        Layout.preferredHeight: width
+                        size: modelData
+                        icon.name: ctrlIconName.text
+                        asset.emoji: d.effectiveEmoji
+                        textPosition: d.effectiveTextPosition
+                        type: ctrlType.currentIndex
+                        loading: ctrlLoading.checked
+                        enabled: ctrlEnabled.checked
+                        isRoundIcon: true
+                        radius: height/2
+                        textFillWidth: ctrlFillWidth.checked
+                    }
+                }
+            }
+        }
+
+        LogsAndControlsPanel {
+            id: logsAndControlsPanel
+
+            SplitView.minimumWidth: 300
+            SplitView.preferredWidth: 400
+
+            logsView.logText: logs.logText
+
+            ColumnLayout {
+                width: parent.width
+                RowLayout {
+                    Label { text: "Text:" }
+                    TextField {
+                        id: ctrlText
+                        placeholderText: "Button text"
+                        text: "Foobar"
+                    }
+                    // enum StatusBaseButton.TextPosition.xxx
+                    RadioButton {
+                        id: ctrlTextPosLeft
+                        text: "left"
+                    }
+                    RadioButton {
+                        id: ctrlTextPosRight
+                        text: "right"
+                        checked: true
+                    }
+                }
+                RowLayout {
+                    Label { text: "Icon name:" }
+                    TextField {
+                        id: ctrlIconName
+                        placeholderText: "Icon name"
+                        text: "gif"
+                    }
+                }
+                RowLayout {
+                    Label { text: "Emoji:" }
+                    TextField {
+                        id: ctrlEmoji
+                        text: "💩"
+                    }
+                    CheckBox {
+                        id: ctrlEmojiEnabled
+                        text: "enabled"
+                    }
+                }
+                RowLayout {
+                    Label { text: "Type:" }
+                    ComboBox {
+                        id: ctrlType
+                        model: ["Normal", "Danger", "Primary"] // enum StatusBaseButton.Type.xxx
+                    }
+                }
+                RowLayout {
+                    Label { text: "Width:" }
+                    SpinBox {
+                        id: ctrlWidth
+                        from: 0
+                        to: 280
+                        value: 0 // 0 == implicitWidth
+                        stepSize: 10
+                        textFromValue: function(value, locale) { return value === 0 ? "Implicit" : value }
+                    }
+                    CheckBox {
+                        id: ctrlFillWidth
+                        text: "Fill width"
+                    }
+                }
+                Switch {
+                    id: ctrlLoading
+                    text: "Loading"
+                }
+                Switch {
+                    id: ctrlEnabled
+                    text: "Enabled"
+                    checked: true
+                }
+            }
+        }
+    }
+}
+

--- a/storybook/pages/TransactionDelegatePage.qml
+++ b/storybook/pages/TransactionDelegatePage.qml
@@ -13,13 +13,19 @@ SplitView {
 
     readonly property QtObject mockupModelData: QtObject {
         property int timestamp: Date.now() / 1000
-        property int txStatus: 0
+        property int txType: ctrlType.currentValue
         property string from: "0xfB8131c260749c7835a08ccBdb64728De432858E"
         property string to: "0x3fb81384583b3910BB14Cc72582E8e8a56E83ae9"
         property bool isNFT: false
         property string tokenID: "4981676894159712808201908443964193325271219637660871887967796332739046670337"
         property string nftName: "Happy Meow"
         property string nftImageUrl: Style.png("collectibles/HappyMeow")
+    }
+
+    readonly property QtObject mockupStore: QtObject {
+        function formatCurrencyAmount(cryptoValue, symbol) {
+            return "%1 %2".arg(cryptoValue).arg(symbol)
+        }
     }
 
     SplitView {
@@ -58,17 +64,8 @@ SplitView {
                     bridgeNetworkName: "Mainnet"
                     feeFiatValue: 10.34
                     feeCryptoValue: 0.013
-                    transactionStatus: Constants.TransactionStatus.Pending
-                    transactionType: Constants.TransactionType.Send
-                    formatCurrencyAmount: function(amount, symbol, options = null, locale = null) {
-                        const currencyAmount = {
-                            amount: amount,
-                            symbol: symbol,
-                            displayDecimals: 8,
-                            stripTrailingZeroes: true
-                        }
-                        return LocaleUtils.currencyAmountToLocaleString(currencyAmount, options)
-                    }
+                    transactionStatus: ctrlStatus.currentValue
+                    rootStore: root.mockupStore
                 }
             }
         }
@@ -111,6 +108,7 @@ SplitView {
             }
 
             ComboBox {
+                id: ctrlType
                 Layout.fillWidth: true
                 textRole: "name"
                 valueRole: "type"
@@ -123,7 +121,6 @@ SplitView {
                     ListElement { name: "Swap"; type: Constants.TransactionType.Swap }
                     ListElement { name: "Bridge"; type: Constants.TransactionType.Bridge }
                 }
-                onActivated: delegate.transactionType = model.get(currentIndex).type
             }
 
             Label {
@@ -133,16 +130,16 @@ SplitView {
             }
 
             ComboBox {
+                id: ctrlStatus
                 Layout.fillWidth: true
                 textRole: "name"
-                valueRole: "type"
+                valueRole: "status"
                 model: ListModel {
-                    ListElement { name: "Pending"; status: Constants.TransactionStatus.Pending }
                     ListElement { name: "Failed"; status: Constants.TransactionStatus.Failed }
+                    ListElement { name: "Pending"; status: Constants.TransactionStatus.Pending }
                     ListElement { name: "Complete"; status: Constants.TransactionStatus.Complete }
                     ListElement { name: "Finished"; status: Constants.TransactionStatus.Finished }
                 }
-                onActivated: delegate.transactionStatus = model.get(currentIndex).status
             }
         }
     }

--- a/storybook/pages/WalletHeaderPage.qml
+++ b/storybook/pages/WalletHeaderPage.qml
@@ -42,11 +42,12 @@ SplitView {
         property var dummyOverview: updateDummyView(StatusColors.colors['black'])
 
         function updateDummyView(color) {
+            const clr = Utils.getIdForColor(color)
             dummyOverview = ({
                                  name: "helloworld",
                                  mixedcaseAddress: "0xcdc2ea3b6ba8fed3a3402f8db8b2fab53e7b7421",
                                  ens: emptyString,
-                                 color: color,
+                                 colorId: clr,
                                  emoji: "⚽",
                                  balanceLoading: false,
                                  hasBalanceCache: true,
@@ -56,7 +57,6 @@ SplitView {
                                                        stripTrailingZeroes: false}),
                                  isAllAccounts: false,
                                  hideWatchAccounts: false
-
                              })
         }
 
@@ -64,7 +64,7 @@ SplitView {
                                                    name: "",
                                                    mixedcaseAddress: "0xcdc2ea3b6ba8fed3a3402f8db8b2fab53e7b7421",
                                                    ens: emptyString,
-                                                   color: "",
+                                                   colorId: "",
                                                    emoji: "",
                                                    balanceLoading: false,
                                                    hasBalanceCache: true,
@@ -74,10 +74,7 @@ SplitView {
                                                                          stripTrailingZeroes: false}),
                                                    isAllAccounts: true,
                                                    hideWatchAccounts: true,
-                                                   colors: StatusColors.colors['blue2']+ ";" +
-                                                   StatusColors.colors['yellow']+ ";" +
-                                                   StatusColors.colors['green2'] + ";" +
-                                                   StatusColors.colors['red2']
+                                                   colorIds: "purple;pink;magenta"
                                                })
 
         readonly property QtObject connectionStore: QtObject {
@@ -169,14 +166,11 @@ SplitView {
                     id: repeater
                     model: Theme.palette.customisationColorsArray
                     delegate: StatusColorRadioButton {
-                        radioButtonColor: repeater.model[index]
+                        radioButtonColor: modelData
                         checked: index === 0
-                        onCheckedChanged: d.updateDummyView(repeater.model[index])
+                        onToggled: d.updateDummyView(modelData)
                     }
                 }
-            }
-            ButtonGroup {
-                buttons: row.children
             }
         }
     }

--- a/test/ui-test/testSuites/global_shared/scripts/wallet_names.py
+++ b/test/ui-test/testSuites/global_shared/scripts/wallet_names.py
@@ -6,7 +6,7 @@ from scripts.settings_names import *
 # Main:
 mainWindow_WalletLayout = {"container": statusDesktop_mainWindow, "type": "WalletLayout", "unnamed": 1, "visible": True}
 mainWallet_LeftTab = {"container": statusDesktop_mainWindow, "objectName": "walletLeftTab", "type": "LeftTabView", "visible": True}
-mainWallet_Saved_Addresses_Button = {"container": mainWindow_RighPanel, "objectName": "savedAddressesBtn", "type": "StatusButton"}
+mainWallet_Saved_Addresses_Button = {"container": mainWindow_RighPanel, "objectName": "savedAddressesBtn", "type": "StatusFlatButton"}
 walletAccounts_StatusListView = {"container": statusDesktop_mainWindow, "objectName": "walletAccountsListView", "type": "StatusListView", "visible": True}
 walletAccounts_WalletAccountItem_Placeholder = {"container": walletAccounts_StatusListView, "objectName": "walletAccount-%NAME%", "type": "StatusListItem", "visible": True}
 walletAccount_StatusListItem = {"container": walletAccounts_StatusListView, "objectName": RegularExpression("walletAccount*"), "type": "StatusListItem", "visible": True}

--- a/ui/StatusQ/src/StatusQ/Controls/StatusIconTextButton.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusIconTextButton.qml
@@ -59,7 +59,7 @@ AbstractButton {
          spacing: root.spacing
          StatusIcon {
              Layout.alignment: Qt.AlignVCenter
-             icon: root.statusIcon
+             icon: root.statusIcon || root.icon.source || root.icon.name
              color: root.icon.color
              width: root.icon.width
              height: root.icon.height

--- a/ui/StatusQ/src/StatusQ/Core/Theme/ThemePalette.qml
+++ b/ui/StatusQ/src/StatusQ/Core/Theme/ThemePalette.qml
@@ -279,7 +279,7 @@ QtObject {
         property color yinYang
     }
 
-    property var customisationColorsArray: [
+    readonly property var customisationColorsArray: [
         customisationColors.blue,
         customisationColors.purple,
         customisationColors.orange,
@@ -294,7 +294,7 @@ QtObject {
         customisationColors.yinYang
     ]
 
-    property var communityColorsArray: [
+    readonly property var communityColorsArray: [
         customisationColors.blue,
         customisationColors.yellow,
         customisationColors.magenta,

--- a/ui/app/AppLayouts/Chat/controls/community/MembersDropdown.qml
+++ b/ui/app/AppLayouts/Chat/controls/community/MembersDropdown.qml
@@ -241,8 +241,6 @@ StatusDropdown {
 
             Layout.fillWidth: true
 
-            textFillWidth: true
-
             enabled: {
                 if (root.forceButtonDisabled)
                     return false

--- a/ui/app/AppLayouts/Wallet/panels/WalletHeader.qml
+++ b/ui/app/AppLayouts/Wallet/panels/WalletHeader.qml
@@ -69,7 +69,6 @@ Item {
                 hoverColor: Theme.palette.baseColor2
 
                 font.weight: Font.Normal
-                textAlignment: Qt.AlignTop | Qt.AlignHCenter
                 textPosition: StatusBaseButton.TextPosition.Left
                 textColor: Theme.palette.baseColor1
                 text: overview.ens ||  StatusQUtils.Utils.elideText(overview.mixedcaseAddress, 6, 4)
@@ -96,7 +95,6 @@ Item {
                 hoverColor: Theme.palette.baseColor2
 
                 font.weight: Font.Normal
-                textAlignment: Qt.AlignTop | Qt.AlignHCenter
                 textColor: Theme.palette.baseColor1
                 text: overview.hideWatchAccounts ? qsTr("Show watch-only"):  qsTr("Hide watch-only")
 

--- a/ui/app/AppLayouts/Wallet/views/LeftTabView.qml
+++ b/ui/app/AppLayouts/Wallet/views/LeftTabView.qml
@@ -391,23 +391,19 @@ Rectangle {
                     }
                 }
 
-                contentItem: StatusButton {
+                contentItem: StatusFlatButton {
                     id: savedAddressesBtn
 
                     objectName: "savedAddressesBtn"
-                    size: StatusBaseButton.Size.Large
-                    normalColor: "transparent"
                     hoverColor: Theme.palette.primaryColor3
-                    asset.color: Theme.palette.primaryColor1
                     asset.bgColor: Theme.palette.primaryColor3
-                    font.weight: Font.Medium
                     text: qsTr("Saved addresses")
                     icon.name: "address"
                     icon.width: 40
                     icon.height: 40
+                    icon.color: Theme.palette.primaryColor1
                     isRoundIcon: true
                     textColor: Theme.palette.directColor1
-                    textAlignment: Qt.AlignVCenter | Qt.AlignLeft
                     textFillWidth: true
                     spacing: parent.ListView.view.firstItem.statusListItemTitleArea.anchors.leftMargin
                     onClicked: {

--- a/ui/imports/shared/controls/TransactionDelegate.qml
+++ b/ui/imports/shared/controls/TransactionDelegate.qml
@@ -349,13 +349,13 @@ StatusListItem {
                 break
             }
             if (type === Constants.TransactionType.Swap) {
-                const crypto = rootStore.formatCurrencyAmount(d.swapCryptoValue, d.swapSymbol)
-                const fiat = rootStore.formatCurrencyAmount(d.swapCryptoValue, d.swapSymbol)
+                const crypto = rootStore.formatCurrencyAmount(root.swapCryptoValue, root.swapSymbol)
+                const fiat = rootStore.formatCurrencyAmount(root.swapCryptoValue, root.swapSymbol)
                 valuesString += qsTr("Amount received %1 (%2)").arg(crypto).arg(fiat) + endl2
             } else if (type === Constants.TransactionType.Bridge) {
                 // Reduce crypto value by fee value
                 const valueInCrypto = rootStore.getCryptoValue(root.fiatValue - feeFiatValue, root.symbol, root.currentCurrency)
-                const crypto = rootStore.formatCurrencyAmount(valueInCrypto, d.symbol)
+                const crypto = rootStore.formatCurrencyAmount(valueInCrypto, root.symbol)
                 const fiat = rootStore.formatCurrencyAmount(root.fiatValue - feeFiatValue, root.currentCurrency)
                 valuesString += qsTr("Amount received %1 (%2)").arg(crypto).arg(fiat) + endl2
             }
@@ -658,11 +658,10 @@ StatusListItem {
                     height: parent.height * 0.7
                     verticalPadding: 0
                     horizontalPadding: radius
-                    textFillWidth: true
                     text: qsTr("Retry")
                     size: StatusButton.Small
                     type: StatusButton.Primary
-                    visible: !root.loading && root.transactionStatus === Constants.TransactionType.Failed
+                    visible: !root.loading && root.transactionStatus === Constants.TransactionStatus.Failed
                     onClicked: root.retryClicked()
                 }
 
@@ -705,7 +704,7 @@ StatusListItem {
             }
             PropertyChanges {
                 target: root.asset
-                bgBorderWidth: root.transactionStatus === Constants.TransactionType.Failed ? 0 : 1
+                bgBorderWidth: root.transactionStatus === Constants.TransactionStatus.Failed ? 0 : 1
                 width: 34
                 height: 34
                 bgWidth: 56

--- a/ui/imports/shared/popups/CommunityIntroDialog.qml
+++ b/ui/imports/shared/popups/CommunityIntroDialog.qml
@@ -36,7 +36,6 @@ StatusDialog {
                 type: root.isInvitationPending ? StatusBaseButton.Type.Danger
                                                : StatusBaseButton.Type.Normal
                 enabled: checkBox.checked || root.isInvitationPending
-                textFillWidth: true
                 onClicked: {
                     if (root.isInvitationPending) {
                         root.cancelMembershipRequest()

--- a/ui/imports/shared/views/ProfileDialogView.qml
+++ b/ui/imports/shared/views/ProfileDialogView.qml
@@ -384,7 +384,6 @@ Pane {
                 Layout.preferredWidth: height
 
                 visible: !d.isCurrentUser
-                size: StatusBaseButton.Size.Small
                 horizontalPadding: 6
                 verticalPadding: 6
                 icon.name: "more"

--- a/ui/imports/utils/Utils.qml
+++ b/ui/imports/utils/Utils.qml
@@ -731,7 +731,7 @@ QtObject {
 
 
     function getIdForColor(color){
-        let c = color.toUpperCase()
+        let c = color.toString().toUpperCase()
         switch(c) {
         case Theme.palette.customisationColors.blue.toString().toUpperCase():
             return Constants.walletAccountColors.primary


### PR DESCRIPTION
- introduce StatusButton storybook page with controls to play around with the its options and variants
- StatusBaseButton: make the content item horizontally centered by default
- StatusBaseButton: remove `textAlignment` and fix `textFillWidth` for the intended usage
- fixup usage of the 2 above options which were introduced merely as a workaround, mostly in wallet + corresponding storybook pages

Fixes #10903

### What does the PR do

Fixes alignment issues in Status[Base,Flat]Button

### Affected areas

Status[Base,Flat]Button

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

Storybook button overview with controls:
![image](https://github.com/status-im/status-desktop/assets/5377645/6d2a3208-dfcb-445d-b991-7647872427e1)

Transaction Copy details button:
![image](https://github.com/status-im/status-desktop/assets/5377645/acf73b99-1bec-49b0-802d-f4215ea8ceed)

Wallet header & Saved addresses button:
![image](https://github.com/status-im/status-desktop/assets/5377645/2dc69520-fda3-4f25-94a7-26cdfd850096)

Transaction delegate:
![image](https://github.com/status-im/status-desktop/assets/5377645/5c4455fa-88d5-41ea-928f-441dc503370e)

Members dropdown:
![image](https://github.com/status-im/status-desktop/assets/5377645/6e4f5a17-da42-4a3e-871f-18b38c6b53c3)



