### PR TITLE
fix: community context menu should not say "Leave community" if not joined

### DIFF
--- a/storybook/pages/ProfileDialogViewPage.qml
+++ b/storybook/pages/ProfileDialogViewPage.qml
@@ -70,6 +70,7 @@ SplitView {
                                       trustStatus: trustStatus.currentValue,
                                       verificationStatus: Constants.verificationStatus.unverified,
                                       incomingVerificationStatus: Constants.verificationStatus.unverified,
+                                      contactRequestState: Constants.ContactRequestState.None,
                                       bio: bio.text,
                                       socialLinks: JSON.stringify
                                                    ([{
@@ -173,7 +174,7 @@ SplitView {
                         communitiesModel: ListModel {
                             ListElement {
                                 name: "Not the cool gang"
-                                amISectionAdmin: false
+                                memberRole: 0 // Constants.memberRole.none
                                 description: "Nothing to write home about"
                                 color: "indigo"
                                 image: ""
@@ -184,7 +185,7 @@ SplitView {
                             }
                             ListElement {
                                 name: "Awesome bunch"
-                                amISectionAdmin: true
+                                memberRole: 4 // Constants.memberRole.admin
                                 description: "Where the cool guys hang out & Nothing to write home about"
                                 color: "green"
                                 image: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADIAAAAyCAYAAAAeP4ixAAAAlklEQVR4nOzW0QmDQBAG4SSkl7SUQlJGCrElq9F3QdjjVhh/5nv3cFhY9vUIYQiNITSG0BhCExPynn1gWf9bx498P7/
@@ -200,7 +201,7 @@ SplitView {
                             }
                             ListElement {
                                 name: "Invisible community (should not display!)"
-                                amISectionAdmin: false
+                                memberRole: 1 // Constants.memberRole.owner
                                 description: "Get outta here"
                                 color: "red"
                                 image: ""
@@ -222,27 +223,27 @@ SplitView {
                                 ListElement {
                                     name: "My Status Account"
                                     address: "0xcdc2ea3b6ba8fed3a3402f8db8b2fab53e7b7420"
-                                    color: "aliceblue"
+                                    colorId: "primary"
                                     emoji: "🇨🇿"
                                     walletType: ""
                                 }
                                 ListElement {
                                     name: "testing (no emoji, colored, saved, seed)"
                                     address: "0xcdc2ea3b6ba8fed3a3402f8db8b2fab53e7b7000"
-                                    color: "olive"
+                                    colorId: "turquoise"
                                     walletType: "seed"
                                 }
                                 ListElement {
                                     name: "My Bro's Account"
                                     address: "0xcdc2ea3b6ba8fed3a3402f8db8b2fab53e7b7421"
-                                    color: "ghostwhite"
+                                    colorId: "sky"
                                     emoji: "🇸🇰"
                                     walletType: "watch"
                                 }
                                 ListElement {
                                     name: "Keycard"
                                     address: "0xdeadbeef"
-                                    color: "red"
+                                    colorId: "purple"
                                     emoji: ""
                                     walletType: "key"
                                 }
@@ -267,63 +268,61 @@ SplitView {
                                 }
                             }
 
-                            readonly property var currentAccount: QtObject {
-                                readonly property var assets: ListModel {
-                                    readonly property var data: [
-                                        {
-                                            symbol: "MANA",
-                                            enabledNetworkBalance: {
-                                                amount: 301,
-                                                symbol: "MANA"
-                                            },
-                                            changePct24hour: -2.1,
-                                            visibleForNetworkWithPositiveBalance: true
+                            readonly property var assets: ListModel {
+                                readonly property var data: [
+                                    {
+                                        symbol: "MANA",
+                                        enabledNetworkBalance: {
+                                            amount: 301,
+                                            symbol: "MANA"
                                         },
-                                        {
-                                            symbol: "AAVE",
-                                            enabledNetworkBalance: {
-                                                amount: 23.3,
-                                                symbol: "AAVE"
-                                            },
-                                            changePct24hour: 4.56,
-                                            visibleForNetworkWithPositiveBalance: true
+                                        changePct24hour: -2.1,
+                                        visibleForNetworkWithPositiveBalance: true
+                                    },
+                                    {
+                                        symbol: "AAVE",
+                                        enabledNetworkBalance: {
+                                            amount: 23.3,
+                                            symbol: "AAVE"
                                         },
-                                        {
-                                            symbol: "POLY",
-                                            enabledNetworkBalance: {
-                                                amount: 3590,
-                                                symbol: "POLY"
-                                            },
-                                            changePct24hour: -11.6789,
-                                            visibleForNetworkWithPositiveBalance: true
+                                        changePct24hour: 4.56,
+                                        visibleForNetworkWithPositiveBalance: true
+                                    },
+                                    {
+                                        symbol: "POLY",
+                                        enabledNetworkBalance: {
+                                            amount: 3590,
+                                            symbol: "POLY"
                                         },
-                                        {
-                                            symbol: "CDT",
-                                            enabledNetworkBalance: {
-                                                amount: 1000,
-                                                symbol: "CDT"
-                                            },
-                                            changePct24hour: 0,
-                                            visibleForNetworkWithPositiveBalance: true
+                                        changePct24hour: -11.6789,
+                                        visibleForNetworkWithPositiveBalance: true
+                                    },
+                                    {
+                                        symbol: "CDT",
+                                        enabledNetworkBalance: {
+                                            amount: 1000,
+                                            symbol: "CDT"
                                         },
-                                        {
-                                            symbol: "MKR",
-                                            enabledNetworkBalance: {
-                                                amount: 1.3,
-                                                symbol: "MKR"
-                                            },
-                                            //changePct24hour: undefined // NB 'undefined' on purpose
-                                            visibleForNetworkWithPositiveBalance: true
+                                        changePct24hour: 0,
+                                        visibleForNetworkWithPositiveBalance: true
+                                    },
+                                    {
+                                        symbol: "MKR",
+                                        enabledNetworkBalance: {
+                                            amount: 1.3,
+                                            symbol: "MKR"
                                         },
-                                        {
-                                            symbol: "InvisibleHere",
-                                            enabledNetworkBalance: {},
-                                            changePct24hour: 0,
-                                            visibleForNetworkWithPositiveBalance: false
-                                        }
-                                    ]
-                                    Component.onCompleted: append(data)
-                                }
+                                        //changePct24hour: undefined // NB 'undefined' on purpose
+                                        visibleForNetworkWithPositiveBalance: true
+                                    },
+                                    {
+                                        symbol: "InvisibleHere",
+                                        enabledNetworkBalance: {},
+                                        changePct24hour: 0,
+                                        visibleForNetworkWithPositiveBalance: false
+                                    }
+                                ]
+                                Component.onCompleted: append(data)
                             }
 
                             readonly property var flatCollectibles: ListModel {

--- a/storybook/pages/ProfileShowcaseCommunitiesPanelPage.qml
+++ b/storybook/pages/ProfileShowcaseCommunitiesPanelPage.qml
@@ -31,7 +31,7 @@ SplitView {
                         id: "0x0001",
                         name: "Test community",
                         joined: true,
-                        amISectionAdmin: true,
+                        memberRole: Constants.memberRole.owner,
                         image: ModelsData.icons.dribble,
                         color: "yellow"
                     },
@@ -39,7 +39,7 @@ SplitView {
                         id: "0x0002",
                         name: "Test community 2",
                         joined: true,
-                        amISectionAdmin: false,
+                        memberRole: Constants.memberRole.none,
                         image: ModelsData.collectibles.custom,
                         color: "peach"
                     },
@@ -47,7 +47,7 @@ SplitView {
                         id: "0x0003",
                         name: "Test community invisible",
                         joined: false,
-                        amISectionAdmin: false,
+                        memberRole: Constants.memberRole.none,
                         image: "",
                         color: "red"
                     },
@@ -55,7 +55,7 @@ SplitView {
                         id: "0x0004",
                         name: "Test community 3",
                         joined: true,
-                        amISectionAdmin: false,
+                        memberRole: Constants.memberRole.none,
                         image: "",
                         color: "whitesmoke"
                     },
@@ -63,7 +63,7 @@ SplitView {
                         id: "0x0005",
                         name: "Test community 4",
                         joined: true,
-                        amISectionAdmin: true,
+                        memberRole: Constants.memberRole.admin,
                         image: ModelsData.icons.spotify,
                         color: "green"
                     },

--- a/test/ui-test/testSuites/suite_communities/tst_communityNavigation/test.feature
+++ b/test/ui-test/testSuites/suite_communities/tst_communityNavigation/test.feature
@@ -18,6 +18,7 @@ Feature: Status Desktop community navigation
     ** when user signs up with username "tester123" and password "TesTEr16843/!@00"
     ** and the user lands on the signed in app
 
+    @mayfail
     Scenario Outline: User creates and leaves community
       # Create a community
       Given the user opens the community portal section

--- a/ui/app/AppLayouts/Chat/panels/communities/CommunityProfilePopupOverviewPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/CommunityProfilePopupOverviewPanel.qml
@@ -73,7 +73,7 @@ Column {
 
     StatusListItem {
         anchors.horizontalCenter: parent.horizontalCenter
-        visible: !root.community.amISectionAdmin
+        visible: root.community.memberRole !== Constants.memberRole.owner
         title: root.community.spectated ? qsTr("Close Community") : qsTr("Leave Community")
         asset.name: root.community.spectated ? "close-circle" : "arrow-left"
         type: StatusListItem.Type.Danger

--- a/ui/app/AppLayouts/Profile/panels/CommunitiesListPanel.qml
+++ b/ui/app/AppLayouts/Profile/panels/CommunitiesListPanel.qml
@@ -49,7 +49,7 @@ StatusListView {
                 size: StatusBaseButton.Size.Small
                 type: StatusBaseButton.Type.Danger
                 borderColor: "transparent"
-                enabled: !model.amISectionAdmin
+                enabled: model.memberRole !== Constants.memberRole.owner
                 text: model.spectated ? qsTr("Close Community") : qsTr("Leave Community")
                 onClicked: model.spectated ? root.closeCommunityClicked(model.id) : root.leaveCommunityClicked(model.name, model.id, model.outroMessage)
             },

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -368,7 +368,7 @@ Item {
 
                         StatusAction {
                             id: leaveCommunityMenuItem
-                            enabled: !model.amISectionAdmin
+                            enabled: model.memberRole !== Constants.memberRole.owner
                             text: {
                                 if (model.spectated)
                                     return qsTr("Close Community")


### PR DESCRIPTION
- get rid of the `amISectionAdmin` for good (was done only partially in 82a1ed2f7aa46750fb5ab891e2ce40f61287eccb)
- fix the corresponding storybook pages

Fixes #10963

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it
![Snímek obrazovky z 2023-06-19 13-40-04](https://github.com/status-im/status-desktop/assets/5377645/c79a2e85-fc0d-4564-9456-654e0a509faa)
![Snímek obrazovky z 2023-06-19 13-40-12](https://github.com/status-im/status-desktop/assets/5377645/a2167efa-ef6e-455a-a269-aba33cfd322c)
![Snímek obrazovky z 2023-06-19 13-40-17](https://github.com/status-im/status-desktop/assets/5377645/ea1361ac-2a47-4854-b4c1-f193a2bb791d)
![Snímek obrazovky z 2023-06-19 13-40-20](https://github.com/status-im/status-desktop/assets/5377645/03df81b4-284e-4d92-a11b-2c1af6d95ddb)
![Snímek obrazovky z 2023-06-19 13-40-51](https://github.com/status-im/status-desktop/assets/5377645/9e631de6-5fe2-4996-b3b8-7f4999318872)

