### PR TITLE
fix: Community permissions and tokens view horizontal scrolling

### DIFF
--- a/storybook/pages/CommunityNewPermissionViewPage.qml
+++ b/storybook/pages/CommunityNewPermissionViewPage.qml
@@ -24,7 +24,6 @@ SplitView {
 
             isEditState: isEditStateCheckBox.checked
             isPrivate: isPrivateCheckBox.checked
-            isOwner: isOwnerCheckBox.checked
             permissionDuplicated: isPermissionDuplicatedCheckBox.checked
             permissionTypeLimitReached: isLimitReachedCheckBox.checked
 
@@ -38,6 +37,7 @@ SplitView {
                 readonly property string name: "Socks"
                 readonly property string image: ModelsData.icons.socks
                 readonly property string color: "red"
+                readonly property string owner: isOwnerCheckBox.checked
             }
 
             onCreatePermissionClicked: {

--- a/ui/app/AppLayouts/Chat/views/communities/CommunityNewPermissionView.qml
+++ b/ui/app/AppLayouts/Chat/views/communities/CommunityNewPermissionView.qml
@@ -174,7 +174,9 @@ StatusScrollView {
     }
 
     onPermissionTypeChanged: Qt.callLater(() => d.loadInitValues())
-
+    contentWidth: mainLayout.width
+    contentHeight: mainLayout.height
+    
     SequenceColumnLayout {
         id: mainLayout
 

--- a/ui/app/AppLayouts/Chat/views/communities/CommunityNewTokenView.qml
+++ b/ui/app/AppLayouts/Chat/views/communities/CommunityNewTokenView.qml
@@ -59,6 +59,8 @@ StatusScrollView {
     }
 
     padding: 0
+    contentWidth: mainLayout.width
+    contentHeight: mainLayout.height
 
     Component.onCompleted: {
         if(root.isAssetView)

--- a/ui/app/AppLayouts/Chat/views/communities/CommunityTokenView.qml
+++ b/ui/app/AppLayouts/Chat/views/communities/CommunityTokenView.qml
@@ -64,6 +64,8 @@ StatusScrollView {
     }
 
     padding: 0
+    contentWidth: mainLayout.width
+    contentHeight: mainLayout.height
 
     ColumnLayout {
         id: mainLayout


### PR DESCRIPTION
### What does the PR do

Closing: #11123 

Setting `contentWidth` and `contentHeight` to match the layout size.

+ fixing [CommunityNewPermissionViewPage.qml](https://github.com/status-im/status-desktop/compare/11123-token-minting-mint-form-is-needlessly-scrollable-horizontally?expand=1#diff-a4b90148169dc21a14ff1e5ce2af8e89693786b801b229dde0f43f30c71e388d)
### Affected areas
[CommunityNewPermissionView.qml](https://github.com/status-im/status-desktop/compare/11123-token-minting-mint-form-is-needlessly-scrollable-horizontally?expand=1#diff-b2ca4384028f15ee26d1e29080a31641d2e67f62e1de1275ed4a2a8d0743f069)

[CommunityNewTokenView.qml](https://github.com/status-im/status-desktop/compare/11123-token-minting-mint-form-is-needlessly-scrollable-horizontally?expand=1#diff-eaa091d8f7020da4397179dd6c593694c9b7503e8f927e277f5fbb6e0b4a598e)

<!-- List the affected areas (e.g wallet, browser, etc..) -->
### Screenshot of functionality (including design for comparison)

https://github.com/status-im/status-desktop/assets/47811206/b08fb8d9-806f-4b8f-a99f-d4cfe9066f9c
