### PR TITLE
fix: InDropdown scrollable height

### DIFF
--- a/ui/app/AppLayouts/Chat/controls/community/InDropdown.qml
+++ b/ui/app/AppLayouts/Chat/controls/community/InDropdown.qml
@@ -151,7 +151,7 @@ StatusDropdown {
         StatusScrollView {
             id: scrollView
             Layout.fillWidth: true
-            Layout.minimumHeight: Math.min(d.maxHeightCountNo, topRepeater.count) * d.itemStandardHeight
+            Layout.minimumHeight: Math.min(d.maxHeightCountNo * d.itemStandardHeight, contentHeight)
             Layout.maximumHeight: Layout.minimumHeight
             contentWidth: availableWidth
             Layout.bottomMargin: d.defaultVMargin
@@ -389,33 +389,29 @@ StatusDropdown {
                         }
                     }
                 }
-            }
 
-            StatusBaseText {
-                id: noContactsText
+                StatusBaseText {
+                    id: noContactsText
 
-                parent: scrollView
+                    horizontalAlignment: Text.AlignHCenter
+                    verticalAlignment: Text.AlignVCenter
 
-                anchors.centerIn: parent
+                    visible: {
+                        for (let i = 0; i < topRepeater.count; i++) {
+                            const item = topRepeater.itemAt(i)
+                            if (item && item.visible)
+                                return false
+                        }
 
-                horizontalAlignment: Text.AlignHCenter
-                verticalAlignment: Text.AlignVCenter
-
-                visible: {
-                    for (let i = 0; i < topRepeater.count; i++) {
-                        const item = topRepeater.itemAt(i)
-                        if (item && item.visible)
-                            return false
+                        return true
                     }
 
-                    return true
+                    text: qsTr("No channels found")
+                    color: Theme.palette.baseColor1
+                    font.pixelSize: Theme.tertiaryTextFontSize
+                    elide: Text.ElideRight
+                    lineHeight: 1.2
                 }
-
-                text: qsTr("No channels found")
-                color: Theme.palette.baseColor1
-                font.pixelSize: Theme.tertiaryTextFontSize
-                elide: Text.ElideRight
-                lineHeight: 1.2
             }
         }
 


### PR DESCRIPTION
### What does the PR do
Closing: #11142 

Use contentHeight to determine the scrollable height when it's smaller than max height.

Also fixing a bug where `No channels found` was overlapping `+ Add channel` button by including the `+ Add channel` button in the column layout.
<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas

Channels selection dropdown in permissions settings.
<!-- List the affected areas (e.g wallet, browser, etc..) -->
### Screenshot of functionality (including design for comparison)


https://github.com/status-im/status-desktop/assets/47811206/da539429-1f6d-4ed6-b014-ac82ceb03025

https://github.com/status-im/status-desktop/assets/47811206/b66b341c-ce59-4662-bf9a-7fdf3539802a


