### PR TITLE
Fix mutual state update messages

### DIFF
--- a/src/app/modules/main/profile_section/contacts/controller.nim
+++ b/src/app/modules/main/profile_section/contacts/controller.nim
@@ -109,9 +109,7 @@ proc blockContact*(self: Controller, publicKey: string) =
   self.contactsService.blockContact(publicKey)
 
 proc removeContact*(self: Controller, publicKey: string) =
-  let response = self.contactsService.removeContact(publicKey)
-  # TODO: segfault if using SIGNAL_CHAT_REQUEST_UPDATE_AFTER_SEND
-  discard self.chatService.processMessageUpdateAfterSend(response)
+  self.contactsService.removeContact(publicKey)
 
 proc changeContactNickname*(self: Controller, publicKey: string, nickname: string) =
   self.contactsService.changeContactNickname(publicKey, nickname)

--- a/src/app_service/common/types.nim
+++ b/src/app_service/common/types.nim
@@ -19,7 +19,9 @@ type
     ContactIdentityVerification = 13
     # Local only
     SystemMessagePinnedMessage = 14
-    SystemMessageMutualStateUpdate = 15
+    SystemMessageMutualEventSent = 15
+    SystemMessageMutualEventAccepted = 16
+    SystemMessageMutualEventRemoved = 17
 
 proc toContentType*(value: int): ContentType =
   try:

--- a/src/app_service/service/message/service.nim
+++ b/src/app_service/service/message/service.nim
@@ -265,11 +265,8 @@ QtObject:
       error "error: received `chats` array for handling messages update is empty"
       return
 
-    # Temporary commented until we provide appropriate flags on the `status-go` side to cover all sections.
-    # blocking contact deletes the chat on the `status-go` side, after unblocking it, `active` prop is still false
-    # that's the reason why the following check is commented out here.
-    # if (not chats[0].active):
-    #   return
+    if (not chats[0].active):
+      return
 
     self.bulkReplacePubKeysWithDisplayNames(messages)
 
@@ -383,6 +380,10 @@ QtObject:
       let data = EnvelopeExpiredArgs(messagesIds: receivedData.messageIds)
       self.events.emit(SIGNAL_ENVELOPE_EXPIRED, data)
 
+    self.events.on(SIGNAL_RELOAD_ONE_TO_ONE_CHAT) do(e: Args):
+      let args = ReloadOneToOneArgs(e)
+      self.resetMessageCursor(args.sectionId)
+      self.asyncLoadMoreMessagesForChat(args.sectionId)
 
     self.events.on(SignalType.Message.event) do(e: Args):
       var receivedData = MessageSignal(e)

--- a/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
@@ -23,7 +23,9 @@ Control {
         Invitation = 7,
         DiscordMessage = 8,
         SystemMessagePinnedMessage = 14,
-        SystemMessageMutualStateUpdate = 15
+        SystemMessageMutualEventSent = 15,
+        SystemMessageMutualEventAccepted = 16,
+        SystemMessageMutualEventRemoved = 17
     }
 
     property list<Item> quickActions
@@ -191,7 +193,9 @@ Control {
                 Layout.fillWidth: true
                 active: isAReply &&
                     root.messageDetails.contentType !== StatusMessage.ContentType.SystemMessagePinnedMessage &&
-                    root.messageDetails.contentType !== StatusMessage.ContentType.SystemMessageMutualStateUpdate
+                    root.messageDetails.contentType !== StatusMessage.ContentType.SystemMessageMutualEventSent &&
+                    root.messageDetails.contentType !== StatusMessage.ContentType.SystemMessageMutualEventAccepted &&
+                    root.messageDetails.contentType !== StatusMessage.ContentType.SystemMessageMutualEventRemoved
 
                 visible: active
                 sourceComponent: StatusMessageReply {

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -195,8 +195,11 @@ Loader {
         case Constants.messageContentType.fetchMoreMessagesButton:
             return fetchMoreMessagesButtonComponent
         case Constants.messageContentType.systemMessagePrivateGroupType: // no break
-        case Constants.messageContentType.systemMessageMutualStateUpdate:
-            return systemMessageComponent
+            return systemMessageGroupComponent
+        case Constants.messageContentType.systemMessageMutualEventSent:
+        case Constants.messageContentType.systemMessageMutualEventAccepted:
+        case Constants.messageContentType.systemMessageMutualEventRemoved:
+            return systemMessageMutualEventComponent
         case Constants.messageContentType.systemMessagePinnedMessage:
             return systemMessagePinnedMessageComponent
         case Constants.messageContentType.gapType:
@@ -271,8 +274,12 @@ Loader {
                 return StatusMessage.ContentType.DiscordMessage;
             case Constants.messageContentType.systemMessagePinnedMessage:
                 return StatusMessage.ContentType.SystemMessagePinnedMessage;
-            case Constants.messageContentType.systemMessageMutualStateUpdate:
-                return StatusMessage.ContentType.SystemMessageMutualStateUpdate;
+            case Constants.messageContentType.systemMessageMutualEventSent:
+                return StatusMessage.ContentType.SystemMessageMutualEventSent;
+            case Constants.messageContentType.systemMessageMutualEventAccepted:
+                return StatusMessage.ContentType.SystemMessageMutualEventAccepted;
+            case Constants.messageContentType.systemMessageMutualEventRemoved:
+                return StatusMessage.ContentType.SystemMessageMutualEventRemoved;
             case Constants.messageContentType.fetchMoreMessagesButton:
             case Constants.messageContentType.chatIdentifier:
             case Constants.messageContentType.unknownContentType:
@@ -348,7 +355,7 @@ Loader {
     }
 
     Component {
-        id: systemMessageComponent
+        id: systemMessageGroupComponent
 
         StyledText {
             wrapMode: Text.Wrap
@@ -368,6 +375,39 @@ Loader {
                         `${systemMessageText}`+
                         `</body>`+
                         `</html>`;
+            }
+            font.pixelSize: 14
+            color: Style.current.secondaryText
+            width: parent.width - 120
+            horizontalAlignment: Text.AlignHCenter
+            anchors.horizontalCenter: parent.horizontalCenter
+            textFormat: Text.RichText
+            topPadding: root.prevMessageIndex === 1 ? Style.current.bigPadding : 0
+        }
+    }
+
+    Component{
+        id: systemMessageMutualEventComponent
+
+        StyledText {
+            text: {
+                var displayName = root.amISender ? Utils.getContactDetailsAsJson(chatId, false).displayName : root.senderDisplayName
+                switch (root.messageContentType) {
+                    case Constants.messageContentType.systemMessageMutualEventSent:
+                        return root.amISender ?
+                            qsTr("You sent a contact request to %1").arg(displayName) :
+                            qsTr("%1 sent you a contact request").arg(displayName)
+                    case Constants.messageContentType.systemMessageMutualEventAccepted:
+                        return root.amISender ?
+                            qsTr("You accepted %1's contact request").arg(displayName) :
+                            qsTr("%1 accepted your contact request").arg(displayName)
+                    case Constants.messageContentType.systemMessageMutualEventRemoved:
+                        return root.amISender ?
+                            qsTr("You removed %1 as a contact").arg(displayName) :
+                            qsTr("%1 removed you as a contact").arg(displayName)
+                    default:
+                        return root.messageText
+                }
             }
             font.pixelSize: 14
             color: Style.current.secondaryText
@@ -481,7 +521,9 @@ Loader {
                 showHeader: root.shouldRepeatHeader || dateGroupLabel.visible || isAReply ||
                             root.prevMessageContentType === Constants.messageContentType.systemMessagePrivateGroupType ||
                             root.prevMessageContentType === Constants.messageContentType.systemMessagePinnedMessage ||
-                            root.prevMessageContentType === Constants.messageContentType.systemMessageMutualStateUpdate ||
+                            root.prevMessageContentType === Constants.messageContentType.systemMessageMutualEventSent ||
+                            root.prevMessageContentType === Constants.messageContentType.systemMessageMutualEventAccepted ||
+                            root.prevMessageContentType === Constants.messageContentType.systemMessageMutualEventRemoved ||
                             root.senderId !== root.prevMessageSenderId
                 isActiveMessage: d.isMessageActive
                 topPadding: showHeader ? Style.current.halfPadding : 0

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -430,7 +430,9 @@ QtObject {
         readonly property int contactRequestType: 11
         readonly property int discordMessageType: 12
         readonly property int systemMessagePinnedMessage: 14
-        readonly property int systemMessageMutualStateUpdate: 15
+        readonly property int systemMessageMutualEventSent: 15
+        readonly property int systemMessageMutualEventAccepted: 16
+        readonly property int systemMessageMutualEventRemoved: 17
     }
 
     readonly property QtObject messageModelRoles: QtObject {


### PR DESCRIPTION
Close #11121
Requires https://github.com/status-im/status-go/pull/3640

See the desired flow in the status-go PR

### What does the PR do

- [x] Don't activate chat until CR is accepted
- [x] Don't delete sent messages
- [x] Change `added` messages to `accepted`
- [x] Fix CR and mutual update messages order
- [x] Remove `@` from system messages

### Affected areas

Chat, Contacts, ActivityCenter

### Screenshot of functionality (including design for comparison)

<img width="1020" alt="Screenshot 2023-07-10 at 13 29 08" src="https://github.com/status-im/status-desktop/assets/2522130/d631efa5-5f13-49ca-b9a3-56fac323c2fc">

<img width="1015" alt="Screenshot 2023-07-10 at 13 28 58" src="https://github.com/status-im/status-desktop/assets/2522130/99c44e4b-10d0-4d52-a400-998a99580976">


