### PR TITLE
feat(scripts): simple python script to interact with database

### DIFF
--- a/scripts/common/PasswordFunctions.py
+++ b/scripts/common/PasswordFunctions.py
@@ -1,0 +1,7 @@
+from Crypto.Hash import keccak
+
+def hash_password(password, old_desktop=False):
+    hasher = keccak.new(digest_bits=256)
+    hasher.update(password.encode())
+    hash = hasher.hexdigest()
+    return '0x' + (hash.upper() if old_desktop else hash.lower())

--- a/scripts/open_database.py
+++ b/scripts/open_database.py
@@ -3,19 +3,28 @@ import sqlcipher3
 from getpass import getpass
 from common import PasswordFunctions
 
-def open_db(file_path, passwordHash: str):
+def open_db(file_path, passwordHash: str, kdfIterations: int):
     db = sqlcipher3.connect(file_path)
     pageSize = 8192 if file_path.endswith("-v4.db") else 1024
 
     print(f'> Opening database. Selected cipher_page_size: {pageSize}')
     db.execute(f'PRAGMA key = "{passwordHash}"')
     db.execute(f'PRAGMA cipher_page_size = {pageSize}') #1024 for older db, 8192 for newer
-    db.execute('PRAGMA kdf_iter = 256000')
+    db.execute(f'PRAGMA kdf_iter = {kdfIterations}')
     db.execute('PRAGMA cipher_hmac_algorithm = HMAC_SHA1')
     db.execute('PRAGMA cipher_kdf_algorithm = PBKDF2_HMAC_SHA1')
     # db.execute('PRAGMA cipher_compatibility = 3;')
 
     return db
+
+class Account:
+    def __init__(self, name, keyUid, kdfIterations):
+        self.name = name
+        self.keyUid = keyUid
+        self.kdfIterations = kdfIterations
+
+    def __str__(self):
+        return f"{self.name} - {self.keyUid}, kdfIterations: {self.kdfIterations}"
 
 class Config:
     def __init__(self):
@@ -31,19 +40,22 @@ class Config:
             
     def read_accounts(self):
         db = sqlcipher3.connect(self.base_path + '/accounts.sql')
-        self.accounts = db.execute('SELECT name, keyUid FROM accounts').fetchall()
+        accounts = db.execute('SELECT name, keyUid, kdfIterations FROM accounts').fetchall()
         db.close()
 
-        if len(self.accounts) == 0:
+        if len(accounts) == 0:
             print("no accoutns found")
             exit(0)
 
+        self.accounts = []
         print(f'> Accounts found: ')
-        for i, a in enumerate(self.accounts):
-            print(f'{i}: {a}')
+        for i, a in enumerate(accounts):
+            account = Account(a[0], a[1], a[2])
+            self.accounts.append(account)
+            print(f'{i}: {str(account)}')
 
     def find_database(self):
-        regex = re.compile(f'{self.selectedKeyUid}(\-v4)?.db$')
+        regex = re.compile(f'{self.selectedAccount.keyUid}(\-v4)?.db$')
         for _, _, files in os.walk(self.base_path):
             for file in files:
                 if regex.match(file):
@@ -55,7 +67,7 @@ class Config:
             self.account_index = int(self.args[1])
         else:
             self.account_index = int(input('> Select an account by index: '))
-        self.selectedKeyUid = self.accounts[self.account_index][1] # KeyUid is second
+        self.selectedAccount = self.accounts[self.account_index]
         self.database_path = self.base_path + self.find_database()
         print(f'selected database: {self.database_path}')
 
@@ -75,7 +87,7 @@ config.input_password()
 
 ## Select and open database
 
-db = open_db(config.database_path, config.password_hash)
+db = open_db(config.database_path, config.password_hash, config.selectedAccount.kdfIterations)
 
 ## use the `db` instance to execute queries
 

--- a/scripts/open_database.py
+++ b/scripts/open_database.py
@@ -1,0 +1,94 @@
+import sys, os, re
+import sqlcipher3
+from getpass import getpass
+from common import PasswordFunctions
+
+def open_db(file_path, passwordHash: str):
+    db = sqlcipher3.connect(file_path)
+    pageSize = 8192 if file_path.endswith("-v4.db") else 1024
+
+    print(f'> Opening database. Selected cipher_page_size: {pageSize}')
+    db.execute(f'PRAGMA key = "{passwordHash}"')
+    db.execute(f'PRAGMA cipher_page_size = {pageSize}') #1024 for older db, 8192 for newer
+    db.execute('PRAGMA kdf_iter = 256000')
+    db.execute('PRAGMA cipher_hmac_algorithm = HMAC_SHA1')
+    db.execute('PRAGMA cipher_kdf_algorithm = PBKDF2_HMAC_SHA1')
+    # db.execute('PRAGMA cipher_compatibility = 3;')
+
+    return db
+
+class Config:
+    def __init__(self):
+        self.args = sys.argv[1:]
+
+    def input_base_path(self):
+        if len(self.args) > 0:
+            self.base_path = self.args[0]
+        else:
+            self.base_path = input('> Input a base path: ')
+        if not self.base_path.endswith('/'):
+            self.base_path += '/'
+            
+    def read_accounts(self):
+        db = sqlcipher3.connect(self.base_path + '/accounts.sql')
+        self.accounts = db.execute('SELECT name, keyUid FROM accounts').fetchall()
+        db.close()
+
+        if len(self.accounts) == 0:
+            print("no accoutns found")
+            exit(0)
+
+        print(f'> Accounts found: ')
+        for i, a in enumerate(self.accounts):
+            print(f'{i}: {a}')
+
+    def find_database(self):
+        regex = re.compile(f'{self.selectedKeyUid}(\-v4)?.db$')
+        for _, _, files in os.walk(self.base_path):
+            for file in files:
+                if regex.match(file):
+                    return file
+        return ''
+
+    def select_account(self):
+        if len(self.args) > 1:
+            self.account_index = int(self.args[1])
+        else:
+            self.account_index = int(input('> Select an account by index: '))
+        self.selectedKeyUid = self.accounts[self.account_index][1] # KeyUid is second
+        self.database_path = self.base_path + self.find_database()
+        print(f'selected database: {self.database_path}')
+
+    def input_password(self):
+        if len(self.args) > 2:
+            password = self.args[2]
+        else:
+            password = getpass("> Input password: ")
+        config.password_hash = PasswordFunctions.hash_password(password, old_desktop=False)
+
+
+config = Config()
+config.input_base_path()
+config.read_accounts()
+config.select_account()
+config.input_password()
+
+## Select and open database
+
+db = open_db(config.database_path, config.password_hash)
+
+## use the `db` instance to execute queries
+
+tables = db.execute("SELECT name FROM sqlite_master WHERE type='table';").fetchall()
+print(f"> Database opened. {len(tables)} tables found.")
+
+## loop sql operations
+
+while True:
+    cmd = input("SQL> ")
+    if cmd == "exit":
+        break
+    output = db.execute(cmd).fetchall()
+    print(output)
+
+db.close()

--- a/scripts/password-hash.py
+++ b/scripts/password-hash.py
@@ -1,12 +1,9 @@
-import sha3
 import pyperclip
+from common import PasswordFunctions
 
 print("Type your password...")
 password = input()
-
-hasher = sha3.keccak_256()
-hasher.update(password.encode())
-hash = '0x' + hasher.hexdigest()
+hash = PasswordFunctions.hash_password(password)
 pyperclip.copy(hash)
-
 print(f'Hash: {hash} is copied to clipboard')
+


### PR DESCRIPTION
### What does the PR do

Made this for easier testing https://github.com/status-im/status-desktop/issues/11132.
Implemented according to [Notion | How-to-browse-sqlcipher-database](https://www.notion.so/How-to-browse-sqlcipher-database-3300824d1d3242ec837bf8f99adeea33?pvs=4#f8e68616f9754a9cb0ef7762e34d9ec3)

Also fixed `password-hash.py`, as it wasn't working after os/python update.

* list all accounts in given directory
* select an account from the list 
* connect to database using auto-detected `kdfIterations` and `pageSize`
* print tables count
* loop sql commands

### Screenshot of functionality (including design for comparison)

https://github.com/status-im/status-desktop/assets/25482501/d746dfd2-74c8-40ae-8678-f39004b6d64d

CLI arguments shortcut is also available:

<img width="923" alt="image" src="https://github.com/status-im/status-desktop/assets/25482501/878ff929-6735-4f6e-86ce-67900d61ccd0">

