### PR TITLE
fix: chat input preserved properties bugs

### DIFF
--- a/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
@@ -241,11 +241,16 @@ Item {
                 Layout.fillWidth: true
                 visible: !!d.activeChatContentModule
 
-                enabled: !!d.activeChatContentModule
-                         && !d.activeChatContentModule.chatDetails.blocked
-                         && root.rootStore.sectionDetails.joined
-                         && !root.rootStore.sectionDetails.amIBanned
-                         && root.rootStore.isUserAllowedToSendMessage
+                // When `enabled` is switched true->false, `textInput.text` is cleared before d.activeChatContentModule updates.
+                // We delay the binding so that the `inputAreaModule.preservedProperties.text` doesn't get overriden with empty value.
+                Binding on enabled {
+                    delayed: true
+                    value: !!d.activeChatContentModule
+                             && !d.activeChatContentModule.chatDetails.blocked
+                             && root.rootStore.sectionDetails.joined
+                             && !root.rootStore.sectionDetails.amIBanned
+                             && root.rootStore.isUserAllowedToSendMessage
+                }
 
                 store: root.rootStore
                 usersStore: d.activeUsersStore

--- a/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
@@ -371,7 +371,7 @@ Item {
         id: sendContactRequestComponent
 
         StatusButton {
-            anchors.horizontalCenter: parent.horizontalCenter
+            anchors.horizontalCenter: parent ? parent.horizontalCenter : undefined
             text: qsTr("Send Contact Request")
             onClicked: {
                 Global.openContactRequestPopup(root.chatId, null)
@@ -383,7 +383,7 @@ Item {
         id: acceptOrDeclineContactRequestComponent
 
         RowLayout {
-            anchors.horizontalCenter: parent.horizontalCenter
+            anchors.horizontalCenter: parent ? parent.horizontalCenter : undefined
 
             StatusButton {
                 text: qsTr("Reject Contact Request")
@@ -406,7 +406,7 @@ Item {
         id: pendingContactRequestComponent
 
         StatusButton {
-            anchors.horizontalCenter: parent.horizontalCenter
+            anchors.horizontalCenter: parent ? parent.horizontalCenter : undefined
             enabled: false
             text: qsTr("Contact Request Pending...")
         }

--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -22,6 +22,7 @@ import StatusQ.Controls 0.1 as StatusQ
 
 Rectangle {
     id: control
+    objectName: "statusChatInput"
 
     signal sendTransactionCommandButtonClicked()
     signal receiveTransactionCommandButtonClicked()
@@ -65,7 +66,6 @@ Rectangle {
         Bottom
     }
 
-    objectName: "statusChatInput"
     function parseMessage(message) {
         let mentionsMap = new Map()
         let index = 0
@@ -883,9 +883,8 @@ Rectangle {
     }
 
     function resetReplyArea() {
-        isReply = false;
-        replyArea.userName = ""
-        replyArea.message = ""
+        isReply = false
+        replyArea.messageId = ""
     }
 
     function hideExtendedArea() {


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/11167

### What does the PR do

* Clear input `replyMessageId` on message sending
* Delay `enabled` input property binding to fix switching to a chat with Blocked contact

### Affected areas

chat input area

### Screenshot of functionality (including design for comparison)

https://github.com/status-im/status-desktop/assets/25482501/e8c20a77-a63f-4367-ac5e-b5be2ab53629
