### PR TITLE
fix(community_tokens/service): fix crash when receiving bad event

### DIFF
--- a/src/app/modules/main/view.nim
+++ b/src/app/modules/main/view.nim
@@ -62,7 +62,6 @@ QtObject:
     self.model.editItem(item)
     if (self.activeSection.getId() == item.id):
       self.activeSection.setActiveSectionData(item)
-      self.activeSectionChanged()
 
   proc model*(self: View): SectionModel =
     return self.model

--- a/src/app_service/service/transaction/service.nim
+++ b/src/app_service/service/transaction/service.nim
@@ -67,6 +67,15 @@ type
     chainId*: int
     success*: bool
 
+proc `$`*(self: TransactionMinedArgs): string =
+  result = fmt"""TransactionMinedArgs(
+    transactionHash: {$self.transactionHash},
+    chainId: {$self.chainId},
+    success: {$self.success},
+    data: {self.data},
+    ]"""
+
+
 type
   HistoryArgs* = ref object of Args
     addresses*: seq[string]

--- a/vendor/DOtherSide/lib/src/DOtherSide.cpp
+++ b/vendor/DOtherSide/lib/src/DOtherSide.cpp
@@ -875,7 +875,6 @@ void dos_qvariant_setArray(::DosQVariant *vptr, int size, ::DosQVariant **array)
 void dos_qobject_delete(::DosQObject *vptr)
 {
     auto qobject = static_cast<QObject *>(vptr);
-    qobject->disconnect();
     delete qobject;
 }
 


### PR DESCRIPTION
Fixes #11176

This fixes the crash experienced after minting. It doesn't fix the root cause. It seems like the event didn't have any data, but I couldn't reproduce the bug.

I'm still positive that this should resolve the crash though. I also added better logging if it happens again, so we'll be able to find the origin.