### PR TITLE
chore(@desktop): fix typo in Hold% wording

### DIFF
--- a/ui/app/AppLayouts/Chat/panels/communities/SortableTokenHoldersList.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/SortableTokenHoldersList.qml
@@ -142,7 +142,7 @@ StatusListView {
                 }
 
                 ColumnHeader {
-                    text: qsTr("Hodling")
+                    text: qsTr("Holding")
 
                     onClicked: {
                         if (sorting !== StatusSortableColumnHeader.Sorting.NoSorting)

--- a/ui/app/AppLayouts/Chat/panels/communities/SortableTokenHoldersPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/SortableTokenHoldersPanel.qml
@@ -85,7 +85,7 @@ Control {
             minimumHeight: 36 // by design
             maximumHeight: minimumHeight
 
-            placeholderText: qsTr("Search hodlers")
+            placeholderText: qsTr("Search holders")
         }
 
         StatusBaseText {
@@ -99,7 +99,7 @@ Control {
             visible: searcher.text.length > 0
 
             text: (searcher.text.length > 0 && proxyModel.count > 0)
-                  ? qsTr("Search results") : qsTr("No hodlers found")
+                  ? qsTr("Search results") : qsTr("No holders found")
         }
 
         NoHoldersPanel {


### PR DESCRIPTION
### What does the PR do

Fix typo for `hodl%` in tokens files. Fixes #11210

### Affected areas

`ui/app/AppLayouts/Chat/panels/communities/SortableTokenHoldersPanel.qml
ui/app/AppLayouts/Chat/panels/communities/SortableTokenHoldersList.qml`