### PR TITLE
Fix some mint token UI issues

### DIFF
--- a/storybook/src/Models/MintedTokensModel.qml
+++ b/storybook/src/Models/MintedTokensModel.qml
@@ -28,6 +28,8 @@ QtObject {
         }
     }
 
+    readonly property ListModel tokenOwnersModel: TokenHoldersModel {}
+
     readonly property ListModel mintedCollectiblesModel: ListModel {
         id: collectiblesModel
 
@@ -41,7 +43,7 @@ QtObject {
                                               symbol: "SRW",
                                               description: "Desc",
                                               supply: 1,
-                                              remainingTokens: 1,
+                                              remainingSupply: 1,
                                               infiniteSupply: true,
                                               transferable: false,
                                               remoteSelfDestruct: true,
@@ -59,7 +61,7 @@ QtObject {
                                               symbol: "KAT",
                                               description: "Desc",
                                               supply: 10,
-                                              remainingTokens: 5,
+                                              remainingSupply: 5,
                                               infiniteSupply: false,
                                               transferable: false,
                                               remoteSelfDestruct: true,
@@ -77,7 +79,7 @@ QtObject {
                                               symbol: "MMM",
                                               description: "Desc",
                                               supply: 1,
-                                              remainingTokens: 0,
+                                              remainingSupply: 0,
                                               infiniteSupply: true,
                                               transferable: false,
                                               remoteSelfDestruct: true,
@@ -94,15 +96,16 @@ QtObject {
                                               deployState: 2,
                                               symbol: "CPA",
                                               description: "Desc",
-                                              supply: 5000,
-                                              remainingTokens: 1500,
+                                              supply: 5,
+                                              remainingSupply: 0,
                                               infiniteSupply: false,
                                               transferable: false,
-                                              remoteSelfDestruct: false,
+                                              remoteSelfDestruct: true,
                                               chainId: 1,
                                               chainName: "Hermez",
                                               chainIcon: ModelsData.networks.hermez,
-                                              accountName: "Account"
+                                              accountName: "Account",
+                                              tokenOwnersModel: root.tokenOwnersModel
                                           }
                                       ])
     }
@@ -120,7 +123,7 @@ QtObject {
                                               symbol: "SOCKS",
                                               description: "Socks description",
                                               supply: 14,
-                                              remainingTokens: 2,
+                                              remainingSupply: 2,
                                               infiniteSupply: false,
                                               decimals: 2,
                                               chainId: 2,
@@ -137,7 +140,7 @@ QtObject {
                                               symbol: "DAI",
                                               description: "Desc",
                                               supply: 1,
-                                              remainingTokens: 1,
+                                              remainingSupply: 1,
                                               infiniteSupply: true,
                                               decimals: 1,
                                               chainId: 1,

--- a/ui/app/AppLayouts/Chat/panels/communities/CommunityAirdropsSettingsPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/CommunityAirdropsSettingsPanel.qml
@@ -81,7 +81,10 @@ SettingsPageLayout {
         }
     ]
 
-    onPrimaryHeaderButtonClicked: stackManager.push(d.newAirdropViewState, newAirdropView, null, StackView.Immediate)
+    onPrimaryHeaderButtonClicked: {
+        if(root.state !== d.newAirdropViewState)
+            stackManager.push(d.newAirdropViewState, newAirdropView, null, StackView.Immediate)
+    }
 
     StackViewStates {
         id: stackManager

--- a/ui/app/AppLayouts/Chat/panels/communities/CommunityMintTokensSettingsPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/CommunityMintTokensSettingsPanel.qml
@@ -94,7 +94,7 @@ SettingsPageLayout {
         property var tokenOwnersModel
         property var remotelyDestructTokensList
         property bool remotelyDestruct
-        property bool burnVisible
+        property bool infiniteSupply
         property string tokenKey
         property int burnAmount
         property int remainingTokens
@@ -413,7 +413,7 @@ SettingsPageLayout {
         MintTokensFooterPanel {
             id: footerPanel
 
-            readonly property bool deployStateFailed : (!!d.currentToken) ? d.currentToken.deployState === Constants.ContractTransactionStatus.Failed : false
+            readonly property bool deployStateCompleted : (!!d.currentToken) ? d.currentToken.deployState === Constants.ContractTransactionStatus.Completed : false
 
             function closePopups() {
                 remotelyDestructPopup.close()
@@ -422,12 +422,12 @@ SettingsPageLayout {
                 burnTokensPopup.close()
             }
 
-            airdropEnabled: !deployStateFailed
-            remotelyDestructEnabled: !deployStateFailed
-            burnEnabled: !deployStateFailed
+            airdropEnabled: deployStateCompleted && (d.infiniteSupply || d.remainingTokens != 0)
+            remotelyDestructEnabled: deployStateCompleted && (d.tokenOwnersModel && d.tokenOwnersModel.count > 0)
+            burnEnabled: deployStateCompleted
 
             remotelyDestructVisible: d.remotelyDestruct
-            burnVisible: d.burnVisible
+            burnVisible: !d.infiniteSupply
 
             onAirdropClicked: d.airdropClicked()
             onRemotelyDestructClicked: remotelyDestructPopup.open()
@@ -610,8 +610,8 @@ SettingsPageLayout {
 
             Binding {
                 target: d
-                property: "burnVisible"
-                value: !view.infiniteSupply
+                property: "infiniteSupply"
+                value: view.infiniteSupply
                 restoreMode: Binding.RestoreBindingOrValue
             }
 

--- a/ui/app/AppLayouts/Chat/panels/communities/CommunityMintTokensSettingsPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/CommunityMintTokensSettingsPanel.qml
@@ -44,11 +44,11 @@ SettingsPageLayout {
     signal mintAsset(var assetItem)
     signal signMintTransactionOpened(int chainId, string accountAddress)
 
-    signal signRemoteDestructTransactionOpened(var selfDestructTokensList, // [key , amount]
-                                             string tokenKey)
+    signal signRemoteDestructTransactionOpened(var remotelyDestructTokensList, // [key , amount]
+                                               string tokenKey)
 
-    signal remotelyDestructCollectibles(var selfDestructTokensList, // [key , amount]
-                                          string tokenKey)
+    signal remotelyDestructCollectibles(var remotelyDestructTokensList, // [key , amount]
+                                        string tokenKey)
 
     signal signBurnTransactionOpened(string tokenKey, int amount)
 

--- a/ui/app/AppLayouts/Chat/panels/communities/CommunityMintTokensSettingsPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/CommunityMintTokensSettingsPanel.qml
@@ -54,7 +54,7 @@ SettingsPageLayout {
 
     signal burnToken(string tokenKey, int amount)
 
-    signal airdropToken(string tokenKey)
+    signal airdropToken(string tokenKey, int type, var addresses)
 
     signal deleteToken(string tokenKey)
 

--- a/ui/app/AppLayouts/Chat/views/communities/CommunityMintedTokensView.qml
+++ b/ui/app/AppLayouts/Chat/views/communities/CommunityMintedTokensView.qml
@@ -28,7 +28,7 @@ StatusScrollView {
 
         readonly property int delegateAssetsHeight: 64
 
-        function getSubtitle(deployState, remainingTokens, supply, isCollectible) {
+        function getSubtitle(deployState, remainingSupply, supply, isCollectible, isInfiniteSupply) {
             if(deployState === Constants.ContractTransactionStatus.Failed) {
                 return qsTr("Minting failed")
             }
@@ -37,12 +37,10 @@ StatusScrollView {
                 return qsTr("Minting...")
             }
 
-            // TO REMOVE: Just added bc backend still doesn't have `availableTokens` property in model. Once it is added, the following 2 lines can be removed.
-            if(!remainingTokens)
-                remainingTokens = 0
-            if(supply === 0)
-                supply = "∞"
-            return isCollectible ? qsTr("%1 / %2 remaining").arg(remainingTokens).arg(supply) :  ""
+            if(isInfiniteSupply) {
+                return isCollectible ? qsTr("∞ remaining") : ""
+            }
+            return isCollectible ? qsTr("%1 / %2 remaining").arg(remainingSupply).arg(supply) : ""
         }
     }
 
@@ -86,7 +84,7 @@ StatusScrollView {
                 components: [
                     StatusBaseText {
                         anchors.verticalCenter: parent.verticalCenter
-                        text: d.getSubtitle(model.deployState, model.remainingSupply, model.supply, false)
+                        text: d.getSubtitle(model.deployState, model.remainingSupply, model.supply, false, model.infiniteSupply)
                         color: (model.deployState === Constants.ContractTransactionStatus.Failed) ? Theme.palette.dangerColor1 : Theme.palette.baseColor1
                         font.pixelSize: 13
                     },
@@ -139,7 +137,7 @@ StatusScrollView {
                 height: collectiblesGrid.cellHeight
                 width: collectiblesGrid.cellWidth
                 title: model.name ? model.name : "..."
-                subTitle: d.getSubtitle(model.deployState, model.remainingSupply, model.supply, true)
+                subTitle: d.getSubtitle(model.deployState, model.remainingSupply, model.supply, true, model.infiniteSupply)
                 subTitleColor: (model.deployState === Constants.ContractTransactionStatus.Failed) ? Theme.palette.dangerColor1 : Theme.palette.baseColor1
                 fallbackImageUrl: model.image ? model.image : ""
                 backgroundColor: "transparent"

--- a/ui/app/AppLayouts/Chat/views/communities/CommunityNewAirdropView.qml
+++ b/ui/app/AppLayouts/Chat/views/communities/CommunityNewAirdropView.qml
@@ -79,6 +79,8 @@ StatusScrollView {
     signal navigateToMintTokenSettings(bool isAssetType)
 
     function selectToken(key, amount, type) {
+        if(selectedHoldingsModel)
+            selectedHoldingsModel.clear()
         var tokenModel = null
         if(type === Constants.TokenType.ERC20)
             tokenModel = root.assetsModel

--- a/ui/app/AppLayouts/Chat/views/communities/CommunityTokenView.qml
+++ b/ui/app/AppLayouts/Chat/views/communities/CommunityTokenView.qml
@@ -243,7 +243,7 @@ StatusScrollView {
 
             CustomPreviewBox {
                 visible: !root.isAssetView
-                label: qsTr("Remotely destructible")
+                label: qsTr("Destructible")
                 value: collectible.remotelyDestruct ? qsTr("Yes") : qsTr("No")
             }
 

--- a/ui/app/AppLayouts/Chat/views/communities/CommunityTokenView.qml
+++ b/ui/app/AppLayouts/Chat/views/communities/CommunityTokenView.qml
@@ -28,7 +28,8 @@ StatusScrollView {
     readonly property string symbol: root.isAssetView ? asset.symbol : collectible.symbol
     readonly property url artworkSource: root.isAssetView ? asset.artworkSource : collectible.artworkSource
     readonly property bool infiniteSupply: root.isAssetView ? asset.infiniteSupply : collectible.infiniteSupply
-    readonly property int remainingTokens: root.isAssetView ? asset.remainingTokens : collectible.remainingTokens
+    readonly property int supply: root.isAssetView ? asset.supply : collectible.supply
+    readonly property int remainingTokens: root.preview ? root.supply : (root.isAssetView ? asset.remainingTokens : collectible.remainingTokens)
     readonly property int deployState: root.isAssetView ? asset.deployState : collectible.deployState
     readonly property string accountName: root.isAssetView ? asset.accountName : collectible.accountName
     readonly property string chainName: root.isAssetView ? asset.chainName : collectible.chainName
@@ -210,12 +211,10 @@ StatusScrollView {
             }
 
             CustomPreviewBox {
-                id: totalbox
-
-                property int supply: root.isAssetView ? asset.supply : collectible.supply
+                id: totalbox                
 
                 label: qsTr("Total")
-                value: root.infiniteSupply ? d.infiniteSymbol : LocaleUtils.numberToLocaleString(supply)
+                value: root.infiniteSupply ? d.infiniteSymbol : LocaleUtils.numberToLocaleString(root.supply)
                 isLoading: !root.infiniteSupply &&
                            ((!root.isAssetView && collectible.remotelyDestructState === Constants.ContractTransactionStatus.InProgress) ||
                             (d.burnState === Constants.ContractTransactionStatus.InProgress))


### PR DESCRIPTION
There are 5 fixes here solved in different commits:
https://github.com/status-im/status-desktop/issues/11149
https://github.com/status-im/status-desktop/issues/11147
https://github.com/status-im/status-desktop/issues/11199
https://github.com/status-im/status-desktop/issues/11198
https://github.com/status-im/status-desktop/issues/11208

### What does the PR do

The fixes are mainly issues created after a rebase so, just some property names or signal params changed incorrectly.

- Remotely destruct tokens flow should work correctly (I cannot test it in the app bc of the frozen app with accounts that have some minted and airdroped tokens)
- Airdrop item inserted correctly when there is navigation between minting view and airdrop.
- Minting footer options disabled logic.
- A label changed in a minting view box as per new design requirement.
- Updated remaining supply information when token is deployed with infinite supply.
- Storybook updates.

### Affected areas

Mint token / Airdrop token

### Screenshot of functionality 
- Airdrop navigation:

https://github.com/status-im/status-desktop/assets/97019400/cabb42cf-fc2e-43a0-80af-43d171350f21

- New label:
![Screenshot 2023-06-21 at 18 26 07](https://github.com/status-im/status-desktop/assets/97019400/ec9f8d85-f2cf-4ba7-992c-d4cd63f016c5)

- Footer disabled bc of minting in progress:

https://github.com/status-im/status-desktop/assets/97019400/f40f3e69-f32c-4e90-8784-4a77b597bc5e

- Airdrop disabled bc no remaining tokens:
![Screenshot 2023-06-22 at 07 48 52](https://github.com/status-im/status-desktop/assets/97019400/33eb2496-44c7-40d2-b194-57ad7780fe32)

- Airdrop disabled bc no remaining tokens AND remotely destruct enabled bc of there are hodlers:
![Screenshot 2023-06-22 at 07 59 20](https://github.com/status-im/status-desktop/assets/97019400/2790a601-a45e-4e88-b289-8ac42303bd8a)

- Remotely destruct disabled bc no hodlers:

![Screenshot 2023-06-22 at 07 47 49](https://github.com/status-im/status-desktop/assets/97019400/c626f250-e724-43a3-b330-f60edf455281)

- Remaining tokens info when infinite supply set:
![Screenshot 2023-06-22 at 07 23 36](https://github.com/status-im/status-desktop/assets/97019400/2f1bf79c-c4b8-4145-a9e9-361f4d1ea440)




