### PR TITLE
fix: ensure view-and-post permissions are hidden when satisfied

### DIFF
--- a/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
@@ -358,7 +358,7 @@ Item {
                     anchors.left: parent.left
                     anchors.leftMargin: (2*Style.current.bigPadding)
                     visible: (!!root.viewAndPostHoldingsModel && (root.viewAndPostHoldingsModel.count > 0)
-                              && !root.amISectionAdmin)
+                              && !root.amISectionAdmin && !root.viewAndPostPermissionsSatisfied)
                     assetsModel: root.rootStore.assetsModel
                     collectiblesModel: root.rootStore.collectiblesModel
                     holdingsModel: root.viewAndPostHoldingsModel


### PR DESCRIPTION
This has slipped through during rebase.
We don't want to show the list of permissions to be fullfilled if they are already satisfied


