### PR TITLE
feat(requestToJoin): add addressesToShare to requestToJoin call

### DIFF
--- a/src/app/modules/main/chat_section/io_interface.nim
+++ b/src/app/modules/main/chat_section/io_interface.nim
@@ -379,13 +379,10 @@ method onAcceptRequestToJoinFailedNoPermission*(self: AccessInterface, community
 method onUserAuthenticated*(self: AccessInterface, pin: string, password: string, keyUid: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method requestToJoinCommunity*(self: AccessInterface, communityId: string, ensName: string) {.base.} =
-  raise newException(ValueError, "No implementation available")
-
 method onDeactivateChatLoader*(self: AccessInterface, chatId: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method requestToJoinCommunityWithAuthentication*(self: AccessInterface, communityId: string, ensName: string) {.base.} =
+method requestToJoinCommunityWithAuthentication*(self: AccessInterface, ensName: string, addressesToShare: seq[string]) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method onCommunityCheckPermissionsToJoinResponse*(self: AccessInterface, checkPermissionsToJoinResponse: CheckPermissionsToJoinResponseDto) {.base.} =

--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -1324,11 +1324,8 @@ method createOrEditCommunityTokenPermission*(self: Module, communityId: string, 
 method deleteCommunityTokenPermission*(self: Module, communityId: string, permissionId: string) =
   self.controller.deleteCommunityTokenPermission(communityId, permissionId)
 
-method requestToJoinCommunity*(self: Module, communityId: string, ensName: string) =
-  self.controller.requestToJoinCommunity(communityId, ensName)
-
-method requestToJoinCommunityWithAuthentication*(self: Module, communityId: string, ensName: string) =
-  self.controller.authenticateToRequestToJoinCommunity(communityId, ensName)
+method requestToJoinCommunityWithAuthentication*(self: Module, ensName: string, addressesToShare: seq[string]) =
+  self.controller.authenticateToRequestToJoinCommunity(ensName, addressesToShare)
 
 method onDeactivateChatLoader*(self: Module, chatId: string) =
   self.view.chatsModel().disableChatLoader(chatId)

--- a/src/app/modules/main/chat_section/view.nim
+++ b/src/app/modules/main/chat_section/view.nim
@@ -240,11 +240,16 @@ QtObject:
   proc createGroupChat*(self: View, communityID: string, groupName: string, pubKeys: string) {.slot.} =
     self.delegate.createGroupChat(communityID, groupName, pubKeys)
 
-  proc requestToJoinCommunity*(self: View, communityId: string, ensName: string) {.slot.} =
-    self.delegate.requestToJoinCommunity(communityId, ensName)
+  proc requestToJoinCommunityWithAuthentication*(self: View, ensName: string) {.slot.} =
+    self.delegate.requestToJoinCommunityWithAuthentication(ensName, @[])
 
-  proc requestToJoinCommunityWithAuthentication*(self: View, communityId: string, ensName: string) {.slot.} =
-    self.delegate.requestToJoinCommunityWithAuthentication(communityId, ensName)
+  proc requestToJoinCommunityWithAuthenticationWithSharedAddresses*(self: View, ensName: string,
+      addressesToShare: string) {.slot.} =
+    try:
+      let addressesArray = map(parseJson(addressesToShare).getElems(), proc(x:JsonNode):string = x.getStr())
+      self.delegate.requestToJoinCommunityWithAuthentication(ensName, addressesArray)
+    except Exception as e:
+      echo "Error requesting to join community with authetication and shared addresses: ", e.msg
 
   proc joinGroupChatFromInvitation*(self: View, groupName: string, chatId: string, adminPK: string) {.slot.} =
     self.delegate.joinGroupChatFromInvitation(groupName, chatId, adminPK)

--- a/src/app/modules/main/communities/controller.nim
+++ b/src/app/modules/main/communities/controller.nim
@@ -141,9 +141,6 @@ proc spectateCommunity*(self: Controller, communityId: string): string =
 proc cancelRequestToJoinCommunity*(self: Controller, communityId: string) =
   self.communityService.cancelRequestToJoinCommunity(communityId)
 
-proc requestToJoinCommunity*(self: Controller, communityId: string, ensName: string) =
-  self.communityService.asyncRequestToJoinCommunity(communityId, ensName, password="")
-
 proc createCommunity*(
     self: Controller,
     name: string,

--- a/src/app/modules/main/communities/io_interface.nim
+++ b/src/app/modules/main/communities/io_interface.nim
@@ -61,9 +61,6 @@ method isCommunityRequestPending*(self: AccessInterface, communityId: string): b
 method cancelRequestToJoinCommunity*(self: AccessInterface, communityId: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method requestToJoinCommunity*(self: AccessInterface, communityId: string, ensName: string) {.base.} =
-  raise newException(ValueError, "No implementation available")
-
 method requestCommunityInfo*(self: AccessInterface, communityId: string, importing: bool) {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/communities/module.nim
+++ b/src/app/modules/main/communities/module.nim
@@ -299,9 +299,6 @@ method discordCategoriesAndChannelsExtracted*(self: Module, categories: seq[Disc
 method cancelRequestToJoinCommunity*(self: Module, communityId: string) =
   self.controller.cancelRequestToJoinCommunity(communityId)
 
-method requestToJoinCommunity*(self: Module, communityId: string, ensName: string) =
-  self.controller.requestToJoinCommunity(communityId, ensName)
-
 method requestCommunityInfo*(self: Module, communityId: string, importing: bool) =
   self.controller.requestCommunityInfo(communityId, importing)
 

--- a/src/app/modules/main/communities/view.nim
+++ b/src/app/modules/main/communities/view.nim
@@ -467,9 +467,6 @@ QtObject:
   proc cancelRequestToJoinCommunity*(self: View, communityId: string) {.slot.} =
     self.delegate.cancelRequestToJoinCommunity(communityId)
 
-  proc requestToJoinCommunity*(self: View, communityId: string, ensName: string) {.slot.} =
-    self.delegate.requestToJoinCommunity(communityId, ensName)
-
   proc requestCommunityInfo*(self: View, communityId: string, importing: bool) {.slot.} =
     self.delegate.requestCommunityInfo(communityId, importing)
 

--- a/src/app_service/service/community/async_tasks.nim
+++ b/src/app_service/service/community/async_tasks.nim
@@ -85,11 +85,12 @@ type
     communityId: string
     ensName: string
     password: string
+    addressesToShare: seq[string]
 
 const asyncRequestToJoinCommunityTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AsyncRequestToJoinCommunityTaskArg](argEncoded)
   try:
-    let response = status_go.requestToJoinCommunity(arg.communityId, arg.ensName, arg.password)
+    let response = status_go.requestToJoinCommunity(arg.communityId, arg.ensName, arg.password, arg.addressesToShare)
     arg.finish(%* {
       "response": response,
       "communityId": arg.communityId,

--- a/src/app_service/service/community/service.nim
+++ b/src/app_service/service/community/service.nim
@@ -1397,7 +1397,8 @@ QtObject:
       let errMsg = e.msg
       error "error checking permissions to join: ", errMsg
 
-  proc asyncRequestToJoinCommunity*(self: Service, communityId: string, ensName: string, password: string) =
+  proc asyncRequestToJoinCommunity*(self: Service, communityId: string, ensName: string, password: string,
+      addressesToShare: seq[string]) =
     try:
       let arg = AsyncRequestToJoinCommunityTaskArg(
         tptr: cast[ByteAddress](asyncRequestToJoinCommunityTask),
@@ -1405,7 +1406,8 @@ QtObject:
         slot: "onAsyncRequestToJoinCommunityDone",
         communityId: communityId,
         ensName: ensName,
-        password: password
+        password: password,
+        addressesToShare: addressesToShare,
       )
       self.threadpool.start(arg)
     except Exception as e:
@@ -1419,7 +1421,6 @@ QtObject:
         error "Error requesting community info", msg = error.message
         return
 
-      let communityId = rpcResponseObj{"communityId"}.getStr()
       let rpcResponse = Json.decode($rpcResponseObj["response"], RpcResponse[JsonNode])
       self.activityCenterService.parseActivityCenterResponse(rpcResponse)
       

--- a/src/backend/communities.nim
+++ b/src/backend/communities.nim
@@ -31,12 +31,18 @@ proc getAllCommunities*(): RpcResponse[JsonNode] {.raises: [Exception].} =
 proc spectateCommunity*(communityId: string): RpcResponse[JsonNode] {.raises: [Exception].} =
   result = callPrivateRPC("spectateCommunity".prefix, %*[communityId])
 
-proc requestToJoinCommunity*(communityId: string, ensName: string, password: string): RpcResponse[JsonNode] {.raises: [Exception].} =
+proc requestToJoinCommunity*(
+    communityId: string,
+    ensName: string,
+    password: string,
+    addressesToShare: seq[string],
+  ): RpcResponse[JsonNode] {.raises: [Exception].} =
   var passwordToSend = password
   result = callPrivateRPC("requestToJoinCommunity".prefix, %*[{
     "communityId": communityId,
     "ensName": ensName,
-    "password": if passwordToSend != "": utils.hashPassword(password) else: ""
+    "password": if passwordToSend != "": utils.hashPassword(password) else: "",
+    "addressesToShare": addressesToShare,
   }])
 
 proc checkPermissionsToJoinCommunity*(communityId: string): RpcResponse[JsonNode] {.raises: [Exception].} =

--- a/ui/app/AppLayouts/Chat/ChatLayout.qml
+++ b/ui/app/AppLayouts/Chat/ChatLayout.qml
@@ -177,7 +177,7 @@ StackLayout {
             property string communityId
 
             onJoined: {
-                root.rootStore.requestToJoinCommunityWithAuthentication(communityIntroDialog.communityId, root.rootStore.userProfileInst.name)
+                root.rootStore.requestToJoinCommunityWithAuthentication(root.rootStore.userProfileInst.name)
             }
 
             onCancelMembershipRequest: {

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -376,12 +376,8 @@ QtObject {
         return communitiesModuleInst.spectateCommunity(id, ensName)
     }
 
-    function requestToJoinCommunity(id, ensName) {
-        chatCommunitySectionModule.requestToJoinCommunity(id, ensName)
-    }
-
-    function requestToJoinCommunityWithAuthentication(id, ensName) {
-        chatCommunitySectionModule.requestToJoinCommunityWithAuthentication(id, ensName)
+    function requestToJoinCommunityWithAuthentication(ensName) {
+        chatCommunitySectionModule.requestToJoinCommunityWithAuthentication(ensName)
     }
 
     function userCanJoin(id) {
@@ -477,7 +473,7 @@ QtObject {
             const userCanJoin = userCanJoin(result.communityId)
             // TODO find what to do when you can't join
             if (userCanJoin) {
-                requestToJoinCommunity(result.communityId, userProfileInst.preferredName)
+                requestToJoinCommunityWithAuthentication(userProfileInst.preferredName)
             }
         }
         return result

--- a/ui/app/AppLayouts/Communities/views/CommunityColumnView.qml
+++ b/ui/app/AppLayouts/Communities/views/CommunityColumnView.qml
@@ -107,7 +107,7 @@ Item {
 
                 onJoined: {
                     joinCommunityButton.loading = true
-                    root.store.requestToJoinCommunityWithAuthentication(communityData.id, root.store.userProfileInst.name)
+                    root.store.requestToJoinCommunityWithAuthentication(root.store.userProfileInst.name)
                 }
                 onCancelMembershipRequest: {
                     root.store.cancelPendingRequest(communityData.id)

--- a/ui/app/AppLayouts/Profile/views/CommunitiesView.qml
+++ b/ui/app/AppLayouts/Profile/views/CommunitiesView.qml
@@ -215,7 +215,7 @@ SettingsContentBase {
             }
 
             onJoined: {
-                chatCommunitySectionModule.requestToJoinCommunityWithAuthentication(communityIntroDialog.communityId, root.rootStore.userProfileInst.name)
+                chatCommunitySectionModule.requestToJoinCommunityWithAuthentication(root.rootStore.userProfileInst.name)
             }
 
             onCancelMembershipRequest: {


### PR DESCRIPTION
Fixes #11154

Adds the Nim code and status-go code to enable passing the user's wanted addresses, instead of using all addresses.

Status-go PR https://github.com/status-im/status-go/pull/3656

The new view function is  
```nim
requestToJoinCommunityWithAuthenticationWithSharedAddresses*
  (self: View, ensName: string, addressesToShare: string) {.slot.}
```
When `addressesToShare` is a stringified array of string addresses.