### PR TITLE
fix: don't allow admins to kick or ban admins

### DIFF
--- a/ui/app/AppLayouts/Chat/panels/communities/CommunityMembersTabPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/CommunityMembersTabPanel.qml
@@ -70,7 +70,7 @@ Item {
 
                 readonly property bool itsMe: model.pubKey.toLowerCase() === userProfile.pubKey.toLowerCase()
                 readonly property bool isHovered: memberItem.sensor.containsMouse
-                readonly property bool canBeBanned: !memberItem.itsMe && model.memberRole !== Constants.memberRole.owner
+                readonly property bool canBeBanned: !memberItem.itsMe && (model.memberRole !== Constants.memberRole.owner && model.memberRole !== Constants.memberRole.admin)
 
                 statusListItemComponentsSlot.spacing: 16
                 statusListItemTitleArea.anchors.rightMargin: 0


### PR DESCRIPTION
This hides the action items to kick or ban users if they happen to be admins. There's also a change in status-go that prevents admins to kick or ban other admins that has to land first here:

https://github.com/status-im/status-go/pull/3666

Closes #10936


