### PR TITLE
chore(@CommunityNewTokenView): placeholder should differ depends on view

### DIFF
--- a/ui/app/AppLayouts/Chat/views/communities/CommunityNewTokenView.qml
+++ b/ui/app/AppLayouts/Chat/views/communities/CommunityNewTokenView.qml
@@ -171,7 +171,7 @@ StatusScrollView {
             label: qsTr("Symbol")
             text: root.isAssetView ? asset.symbol : collectible.symbol
             charLimit: 6
-            placeholderText: qsTr("e.g. DOODLE")
+            placeholderText: root.isAssetView ? qsTr("e.g. ETH"): qsTr("e.g. DOODLE")
             validationMode: root.validationMode
             minLengthValidator.errorMessage: qsTr("Please enter your token symbol (use A-Z only)")
             regexValidator.errorMessage: qsTr("Your token symbol contains invalid characters (use A-Z only)")


### PR DESCRIPTION
Different placeholders for Asset and Collectibles view per figma

### What does the PR do

<img width="580" alt="Screenshot 2023-06-23 at 12 20 47" src="https://github.com/status-im/status-desktop/assets/82375995/868f95b0-b3ef-48fb-98b2-d7888d870419">

<img width="580" alt="Screenshot 2023-06-23 at 12 20 56" src="https://github.com/status-im/status-desktop/assets/82375995/34111783-0428-4cb5-89dc-37f015766ef8">