### PR TITLE
chore(@CommunityNewTokenView.qml): add validation for decimal points input

### DIFF
--- a/ui/app/AppLayouts/Chat/views/communities/CommunityNewTokenView.qml
+++ b/ui/app/AppLayouts/Chat/views/communities/CommunityNewTokenView.qml
@@ -335,7 +335,8 @@ StatusScrollView {
             minLengthValidator.errorMessage: qsTr("Please enter how many decimals your token should have")
             regexValidator.errorMessage: qsTr("Your decimal amount contains invalid characters (use 0-9 only)")
             regexValidator.regularExpression: Constants.regularExpressions.numerical
-
+            extraValidator.validate: function (value) { return parseInt(value) > 0 && parseInt(value) <= 10 }
+            extraValidator.errorMessage: qsTr("Enter a number between 1 and 10")
             onTextChanged: asset.decimals = parseInt(text)
         }
 


### PR DESCRIPTION
### What does the PR do

Add validation to allow 1-10 for decimal points input on NewTokenView for Asset

**Before:**


https://github.com/status-im/status-desktop/assets/82375995/dac4dd3e-e471-4f2c-bd33-9afed760daf3


<img width="580" alt="Screenshot 2023-06-23 at 15 14 48" src="https://github.com/status-im/status-desktop/assets/82375995/fbe9bcbe-3e43-4acd-9001-e529798b1e45">

**After**:

<img width="580" alt="Screenshot 2023-06-23 at 15 10 46" src="https://github.com/status-im/status-desktop/assets/82375995/269f6d5f-c6ef-498a-a742-312b72af067f">

<img width="580" alt="Screenshot 2023-06-23 at 15 10 37" src="https://github.com/status-im/status-desktop/assets/82375995/cc26d5ba-f449-448f-9bf8-77a65fee583a">


