### PR TITLE
chore(0.13.x): Backport Mint tokens view - exclude watch accounts from accounts dropdown

### DIFF
--- a/storybook/src/Models/WalletAccountsModel.qml
+++ b/storybook/src/Models/WalletAccountsModel.qml
@@ -1,6 +1,9 @@
 import QtQuick 2.15
 
 ListModel {
-    ListElement { name: "Test account"; emoji: "😋"; colorId: "primary"; address: "0x7F47C2e18a4BBf5487E6fb082eC2D9Ab0E6d7240" }
-    ListElement { name: "Another account"; emoji: "🚗"; colorId: "army"; address: "0x7F47C2e98a4BBf5487E6fb082eC2D9Ab0E6d8888"  }
+    ListElement { name: "Test account"; emoji: "😋"; colorId: "primary"; address: "0x7F47C2e18a4BBf5487E6fb082eC2D9Ab0E6d7240"; walletType: "" }
+    ListElement { name: "Another account - generated"; emoji: "🚗"; colorId: "army"; address: "0x7F47C2e98a4BBf5487E6fb082eC2D9Ab0E6d8888"; walletType: "generated" }
+    ListElement { name: "Another account - seed"; emoji: "🎨"; colorId: "army"; address: "0x7F47C2e98a4BBf5487E6fb082eC2D9Ab0E6d8888"; walletType: "seed" }
+    ListElement { name: "Another account - watch"; emoji: "🔗"; colorId: "army"; address: "0x7F47C2e98a4BBf5487E6fb082eC2D9Ab0E6d8888"; walletType: "watch" }
+    ListElement { name: "Another account - key"; emoji: "💼"; colorId: "army"; address: "0x7F47C2e98a4BBf5487E6fb082eC2D9Ab0E6d8888"; walletType: "key" }
 }

--- a/ui/app/AppLayouts/Chat/panels/communities/CommunityMintTokensSettingsPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/communities/CommunityMintTokensSettingsPanel.qml
@@ -26,7 +26,7 @@ SettingsPageLayout {
 
     // Models:
     property var tokensModel
-    property var accounts // Expected roles: address, name, color, emoji
+    property var accounts // Expected roles: address, name, color, emoji, walletType
 
     // Transaction related properties:
     property string feeText

--- a/ui/app/AppLayouts/Chat/views/communities/CommunityNewTokenView.qml
+++ b/ui/app/AppLayouts/Chat/views/communities/CommunityNewTokenView.qml
@@ -39,7 +39,7 @@ StatusScrollView {
     property var enabledNetworks
     property var allNetworks
 
-    // Account expected roles: address, name, color, emoji
+    // Account expected roles: address, name, color, emoji, walletType
     property var accounts
 
     signal chooseArtWork
@@ -225,6 +225,11 @@ StatusScrollView {
                         expression: { return getColor(model.colorId) }
                     }
                 ]
+                filters: ValueFilter {
+                        roleName: "walletType"
+                        value: Constants.watchWalletType
+                        inverted: true
+                    }
             }
             type: StatusComboBox.Type.Secondary
             size: StatusComboBox.Size.Small


### PR DESCRIPTION
### What does the PR do
Backport `Mint tokens view - exclude watch accounts from accounts dropdown` to 0.13:
https://github.com/status-im/status-desktop/pull/11168

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->