### PR TITLE
fix(PasswordView): Space is not allowed in password

### DIFF
--- a/storybook/PagesModel.qml
+++ b/storybook/PagesModel.qml
@@ -70,6 +70,10 @@ ListModel {
         section: "Views"
     }
     ListElement {
+        title: "PasswordView"
+        section: "Views"
+    }
+    ListElement {
         title: "CommunitiesView"
         section: "Views"
     }

--- a/storybook/pages/PasswordViewPage.qml
+++ b/storybook/pages/PasswordViewPage.qml
@@ -1,0 +1,69 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+import QtQuick.Extras 1.4
+
+import shared.views 1.0
+
+import Storybook 1.0
+
+SplitView {
+    orientation: Qt.Vertical
+
+    Logs { id: logs }
+
+    Item {
+        id: wrapper
+        SplitView.fillWidth: true
+        SplitView.fillHeight: true
+
+        PasswordView {
+            id: passwordView
+            width: 460
+            height: 416
+            anchors.centerIn: parent
+            onReturnPressed: logs.logEvent("Return pressed", ["Current Password", "New Password", "Confirmation Password"], [passwordView.currentPswText, passwordView.newPswText, passwordView.confirmationPswText])
+
+            createNewPsw: createNewPassword.checked
+            titleVisible: titleVisibleSwitch.checked
+            highSizeIntro: highSizeIntroSwitch.checked
+            passwordStrengthScoreFunction: (newPass) => Math.min(newPass.length, 4)
+        }
+    }
+
+    LogsAndControlsPanel {
+        id: logsAndControlsPanel
+
+        SplitView.minimumHeight: 100
+        SplitView.preferredHeight: 150
+
+        logsView.logText: logs.logText
+
+        RowLayout {
+            StatusIndicator {
+                color: "green"
+                active: passwordView.ready
+            }
+
+            Text {
+                leftPadding: 10
+                text: "Ready"
+            }
+
+            Switch {
+                id: createNewPassword
+                text: "Create new password"
+            }
+
+            Switch {
+                id: highSizeIntroSwitch
+                text: "High size Intro"
+            }
+
+            Switch {
+                id: titleVisibleSwitch
+                text: "Title visible"
+            }
+        }
+    }
+}


### PR DESCRIPTION
### What does the PR do
Closing: #8385 
Update new password input validators to allow any character input and show error message if the character is invalid.
Add PasswordView to storybook
<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas
PasswordView
<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Screenshot of functionality (including design for comparison)

https://github.com/status-im/status-desktop/assets/47811206/b0f3d5ee-e903-4327-8e46-15f27f88ad21

- [x] I've checked the design and this PR matches it

<!-- screenshot (or gif/video) that demonstrates the functionality, specially important if it's a bug fix. -->
