### PR TITLE
ci: retry nim_status_client build 3 times

### DIFF
--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -35,7 +35,7 @@ pipeline {
   options {
     timestamps()
     /* Prevent Jenkins jobs from running forever */
-    timeout(time: 20, unit: 'MINUTES')
+    timeout(time: 25, unit: 'MINUTES')
     /* manage how many builds we keep */
     buildDiscarder(logRotator(
       numToKeepStr: '10',
@@ -76,6 +76,16 @@ pipeline {
       steps {
         sh 'make status-go'
       }
+    }
+
+    stage('Client') {
+      steps { script {
+        /* Temporary hack-fix for failing Linux builds:
+         * https://github.com/status-im/infra-ci/issues/88 */
+        timeout(10) { retry(10) {
+          sh 'make nim_status_client'
+        } }
+      } }
     }
 
     stage('Package') {

--- a/ci/Jenkinsfile.tests-e2e
+++ b/ci/Jenkinsfile.tests-e2e
@@ -93,13 +93,17 @@ pipeline {
       }
     }
 
-    stage('build') {
+    stage('Client') {
       environment {
         GANACHE_NETWORK_RPC_URL = "http://localhost:${env.GANACHE_RPC_PORT}"
       }
-      steps {
-        sh 'make'
-      }
+      steps { script {
+        /* Temporary hack-fix for failing Linux builds:
+         * https://github.com/status-im/infra-ci/issues/88 */
+        timeout(10) { retry(10) {
+          sh 'make nim_status_client'
+        } }
+      } }
     }
 
     stage('Containers') {


### PR DESCRIPTION
This is a temporary stop-gap fix for a known linux build issue: https://github.com/status-im/infra-ci/issues/88

Since currently this issue is very hard to reproduce and there is no good solution in sight this should minimize the pain caused by it.

Thanks for good suggestion from @yakimant .