### PR TITLE
feat(@desktop/wallet): Watch only account toggle + persisted

### DIFF
--- a/src/app/modules/main/profile_section/wallet/accounts/controller.nim
+++ b/src/app/modules/main/profile_section/wallet/accounts/controller.nim
@@ -48,3 +48,9 @@ proc getKeypairs*(self: Controller): seq[KeypairDto] =
 
 proc getAllKnownKeycardsGroupedByKeyUid*(self: Controller): seq[KeycardDto] =
   return self.walletAccountService.getAllKnownKeycardsGroupedByKeyUid()
+
+proc toggleIncludeWatchOnlyAccount*(self: Controller) =
+  self.walletAccountService.toggleIncludeWatchOnlyAccount()
+
+proc isIncludeWatchOnlyAccount*(self: Controller): bool =
+  return self.walletAccountService.isIncludeWatchOnlyAccount()

--- a/src/app/modules/main/profile_section/wallet/accounts/io_interface.nim
+++ b/src/app/modules/main/profile_section/wallet/accounts/io_interface.nim
@@ -36,3 +36,6 @@ method viewDidLoad*(self: AccessInterface) {.base.} =
 
 method getModuleAsVariant*(self: AccessInterface): QVariant {.base.} =
   raise newException(ValueError, "No implementation available")
+
+method toggleIncludeWatchOnlyAccount*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/profile_section/wallet/accounts/module.nim
+++ b/src/app/modules/main/profile_section/wallet/accounts/module.nim
@@ -10,6 +10,7 @@ import ../../../../../core/eventemitter
 import ../../../../../../app_service/service/keycard/service as keycard_service
 import ../../../../../../app_service/service/wallet_account/service as wallet_account_service
 import ../../../../../../app_service/service/network/service as network_service
+import ../../../../../../app_service/service/settings/service
 
 export io_interface
 
@@ -107,8 +108,12 @@ method load*(self: Module) =
   self.events.on(SIGNAL_WALLET_ACCOUNT_POSITION_UPDATED) do(e:Args):
     self.refreshWalletAccounts()
 
+  self.events.on(SIGNAL_INCLUDE_WATCH_ONLY_ACCOUNTS_UPDATED) do(e: Args):
+    self.view.setIncludeWatchOnlyAccount(self.controller.isIncludeWatchOnlyAccount())
+
   self.controller.init()
   self.view.load()
+  self.view.setIncludeWatchOnlyAccount(self.controller.isIncludeWatchOnlyAccount())
 
 method isLoaded*(self: Module): bool =
   return self.moduleLoaded
@@ -126,3 +131,6 @@ method updateAccountPosition*(self: Module, address: string, position: int) =
 
 method deleteAccount*(self: Module, address: string) =
   self.controller.deleteAccount(address)
+
+method toggleIncludeWatchOnlyAccount*(self: Module) =
+  self.controller.toggleIncludeWatchOnlyAccount()

--- a/src/app/modules/main/profile_section/wallet/accounts/view.nim
+++ b/src/app/modules/main/profile_section/wallet/accounts/view.nim
@@ -12,6 +12,7 @@ QtObject:
       accounts: Model
       accountsVariant: QVariant
       keyPairModel: KeyPairModel
+      includeWatchOnlyAccount: bool
 
   proc delete*(self: View) =
     self.accounts.delete
@@ -65,3 +66,17 @@ QtObject:
   proc setKeyPairModelItems*(self: View, items: seq[KeyPairItem]) =
     self.keyPairModel.setItems(items)
     self.keyPairModelChanged()
+
+  proc includeWatchOnlyAccountChanged*(self: View) {.signal.}
+  proc getIncludeWatchOnlyAccount(self: View): bool {.slot.} =
+    return self.includeWatchOnlyAccount
+  QtProperty[bool] includeWatchOnlyAccount:
+    read = getIncludeWatchOnlyAccount
+    notify = includeWatchOnlyAccountChanged
+
+  proc toggleIncludeWatchOnlyAccount*(self: View) {.slot.} =
+    self.delegate.toggleIncludeWatchOnlyAccount()
+
+  proc setIncludeWatchOnlyAccount*(self: View, includeWatchOnlyAccount: bool) =
+    self.includeWatchOnlyAccount = includeWatchOnlyAccount
+    self.includeWatchOnlyAccountChanged()

--- a/src/app/modules/main/wallet_section/accounts/io_interface.nim
+++ b/src/app/modules/main/wallet_section/accounts/io_interface.nim
@@ -19,7 +19,7 @@ method deleteAccount*(self: AccessInterface, address: string) {.base.} =
 method refreshWalletAccounts*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method filterChanged*(self: AccessInterface, addresses: seq[string], chainIds: seq[int], excludeWatchOnly: bool) {.base.} =
+method filterChanged*(self: AccessInterface, addresses: seq[string], chainIds: seq[int]) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method updateAccount*(self: AccessInterface, address: string, accountName: string, colorId: string, emoji: string) {.base.} =

--- a/src/app/modules/main/wallet_section/accounts/module.nim
+++ b/src/app/modules/main/wallet_section/accounts/module.nim
@@ -42,11 +42,11 @@ method delete*(self: Module) =
   self.view.delete
   self.controller.delete
 
-method filterChanged*(self: Module, addresses: seq[string], chainIds: seq[int], excludeWatchOnly: bool) =
+method filterChanged*(self: Module, addresses: seq[string], chainIds: seq[int]) =
   let walletAccounts = self.controller.getWalletAccounts()
   let currency = self.controller.getCurrentCurrency()
   let currencyFormat = self.controller.getCurrencyFormat(currency)
-  let items = walletAccounts.filter(w => not excludeWatchOnly or w.walletType != "watch").map(w => (block:
+  let items = walletAccounts.map(w => (block:
     let keycardAccount = self.controller.isKeycardAccount(w)
     walletAccountToWalletAccountsItem(
       w,

--- a/src/app/modules/main/wallet_section/controller.nim
+++ b/src/app/modules/main/wallet_section/controller.nim
@@ -65,3 +65,9 @@ proc getWalletAccounts*(self: Controller): seq[wallet_account_service.WalletAcco
 
 proc getEnabledChainIds*(self: Controller): seq[int] = 
   return self.networkService.getNetworks().filter(n => n.enabled).map(n => n.chainId)
+
+proc toggleIncludeWatchOnlyAccount*(self: Controller) =
+  self.walletAccountService.toggleIncludeWatchOnlyAccount()
+
+proc isIncludeWatchOnlyAccount*(self: Controller): bool =
+  return self.walletAccountService.isIncludeWatchOnlyAccount()

--- a/src/app/modules/main/wallet_section/overview/io_interface.nim
+++ b/src/app/modules/main/wallet_section/overview/io_interface.nim
@@ -17,5 +17,5 @@ method isLoaded*(self: AccessInterface): bool {.base.} =
 method viewDidLoad*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method filterChanged*(self: AccessInterface, addresses: seq[string], chainIds: seq[int], excludeWatchOnly: bool, allAddresses: bool) {.base.} =
+method filterChanged*(self: AccessInterface, addresses: seq[string], chainIds: seq[int], includeWatchOnly: bool, allAddresses: bool) {.base.} =
   raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/wallet_section/overview/item.nim
+++ b/src/app/modules/main/wallet_section/overview/item.nim
@@ -10,7 +10,7 @@ type
     emoji: string
     isWatchOnlyAccount: bool
     isAllAccounts: bool
-    hideWatchAccounts: bool
+    includeWatchOnly: bool
     colorIds: seq[string]
 
 proc initItem*(
@@ -22,7 +22,7 @@ proc initItem*(
   emoji: string,
   isWatchOnlyAccount: bool=false,
   isAllAccounts: bool = false,
-  hideWatchAccounts: bool = false,
+  includeWatchOnly: bool = true,
   colorIds: seq[string] = @[]
 ): Item =
   result.name = name
@@ -32,7 +32,7 @@ proc initItem*(
   result.colorId = colorId
   result.emoji = emoji
   result.isAllAccounts = isAllAccounts
-  result.hideWatchAccounts = hideWatchAccounts
+  result.includeWatchOnly = includeWatchOnly
   result.colorIds = colorIds
   result.isWatchOnlyAccount = isWatchOnlyAccount
 
@@ -46,7 +46,7 @@ proc `$`*(self: Item): string =
     emoji: {self.emoji},
     isWatchOnlyAccount: {self.isWatchOnlyAccount},
     isAllAccounts: {self.isAllAccounts},
-    hideWatchAccounts: {self.hideWatchAccounts},
+    includeWatchOnly: {self.includeWatchOnly},
     colorIds: {self.colorIds}
     ]"""
 
@@ -71,8 +71,8 @@ proc getEmoji*(self: Item): string =
 proc getIsAllAccounts*(self: Item): bool =
   return self.isAllAccounts
 
-proc getHideWatchAccounts*(self: Item): bool =
-  return self.hideWatchAccounts
+proc getIncludeWatchOnly*(self: Item): bool =
+  return self.includeWatchOnly
 
 proc getColorIds*(self: Item): string =
   return self.colorIds.join(";")

--- a/src/app/modules/main/wallet_section/overview/module.nim
+++ b/src/app/modules/main/wallet_section/overview/module.nim
@@ -65,7 +65,7 @@ proc getWalletAccoutColors(self: Module, walletAccounts: seq[WalletAccountDto]) 
     colors.add(account.colorId)
   return colors
 
-method filterChanged*(self: Module, addresses: seq[string], chainIds: seq[int], excludeWatchOnly: bool, allAddresses: bool) =
+method filterChanged*(self: Module, addresses: seq[string], chainIds: seq[int], includeWatchOnly: bool, allAddresses: bool) =
   let walletAccounts = self.controller.getWalletAccountsByAddresses(addresses)
   if allAddresses:
     let item = initItem(
@@ -77,7 +77,7 @@ method filterChanged*(self: Module, addresses: seq[string], chainIds: seq[int], 
       "",
       isWatchOnlyAccount=false,
       isAllAccounts=true,
-      hideWatchAccounts=excludeWatchOnly,
+      includeWatchOnly=includeWatchOnly,
       self.getWalletAccoutColors(walletAccounts)
     )
     self.view.setData(item)

--- a/src/app/modules/main/wallet_section/overview/view.nim
+++ b/src/app/modules/main/wallet_section/overview/view.nim
@@ -17,7 +17,7 @@ QtObject:
       colorId: string
       emoji: string
       isAllAccounts: bool
-      hideWatchAccounts: bool
+      includeWatchOnly: bool
       colorIds: string
       isWatchOnlyAccount: bool
 
@@ -99,12 +99,12 @@ QtObject:
     read = getIsAllAccounts
     notify = isAllAccountsChanged
 
-  proc getHideWatchAccounts(self: View): QVariant {.slot.} =
-    return newQVariant(self.hideWatchAccounts)
-  proc hideWatchAccountsChanged(self: View) {.signal.}
-  QtProperty[QVariant] hideWatchAccounts:
-    read = getHideWatchAccounts
-    notify = hideWatchAccountsChanged
+  proc getIncludeWatchOnly(self: View): QVariant {.slot.} =
+    return newQVariant(self.includeWatchOnly)
+  proc includeWatchOnlyChanged(self: View) {.signal.}
+  QtProperty[QVariant] includeWatchOnly:
+    read = getIncludeWatchOnly
+    notify = includeWatchOnlyChanged
 
   proc getColorIds(self: View): QVariant {.slot.} =
     return newQVariant(self.colorIds)
@@ -113,10 +113,10 @@ QtObject:
     read = getColorIds
     notify = colorIdsChanged
 
-  proc getIsWatchOnlyAccount(self: View): QVariant {.slot.} =
-    return newQVariant(self.isWatchOnlyAccount)
+  proc getIsWatchOnlyAccount(self: View): bool {.slot.} =
+    return self.isWatchOnlyAccount
   proc isWatchOnlyAccountChanged(self: View) {.signal.}
-  QtProperty[QVariant] isWatchOnlyAccount:
+  QtProperty[bool] isWatchOnlyAccount:
     read = getIsWatchOnlyAccount
     notify = isWatchOnlyAccountChanged
 
@@ -147,6 +147,6 @@ QtObject:
     if(self.isAllAccounts != item.getIsAllAccounts()):
       self.isAllAccounts = item.getIsAllAccounts()
       self.isAllAccountsChanged()
-    if(self.hideWatchAccounts != item.getHideWatchAccounts()):
-      self.hideWatchAccounts = item.getHideWatchAccounts()
-      self.hideWatchAccountsChanged()
+    if(self.includeWatchOnly != item.getIncludeWatchOnly()):
+      self.includeWatchOnly = item.getIncludeWatchOnly()
+      self.includeWatchOnlyChanged()

--- a/src/app/modules/main/wallet_section/view.nim
+++ b/src/app/modules/main/wallet_section/view.nim
@@ -39,7 +39,7 @@ QtObject:
   QtProperty[string] currentCurrency:
     read = getCurrentCurrency
 
-  proc filterChanged*(self: View, addresses: string, excludeWatchOnly: bool, allAddresses: bool)  {.signal.}
+  proc filterChanged*(self: View, addresses: string, includeWatchOnly: bool, allAddresses: bool)  {.signal.}
 
   proc totalCurrencyBalanceChanged*(self: View) {.signal.}
 

--- a/src/app_service/service/settings/dto/settings.nim
+++ b/src/app_service/service/settings/dto/settings.nim
@@ -44,6 +44,7 @@ const KEY_GIF_API_KEY* = "gifs/api-key"
 const KEY_DISPLAY_NAME* = "display-name"
 const KEY_BIO* = "bio"
 const KEY_TEST_NETWORKS_ENABLED* = "test-networks-enabled?"
+const INCLUDE_WATCH_ONLY_ACCOUNT* = "include-watch-only-account?"
 
 # Notifications Settings Values
 const VALUE_NOTIF_SEND_ALERTS* = "SendAlerts"
@@ -136,6 +137,7 @@ type
     notificationsSoundsEnabled*: bool
     notificationsVolume*: int
     notificationsMessagePreview*: int
+    includeWatchOnlyAccount*: bool
 
 proc toPinnedMailserver*(jsonObj: JsonNode): PinnedMailserver =
   # we maintain pinned mailserver per fleet
@@ -192,6 +194,7 @@ proc toSettingsDto*(jsonObj: JsonNode): SettingsDto =
   discard jsonObj.getProp(KEY_GIF_RECENTS, result.gifRecents)
   discard jsonObj.getProp(KEY_GIF_FAVORITES, result.gifFavorites)
   discard jsonObj.getProp(KEY_TEST_NETWORKS_ENABLED, result.testNetworksEnabled)
+  discard jsonObj.getProp(INCLUDE_WATCH_ONLY_ACCOUNT, result.includeWatchOnlyAccount)
 
   var pinnedMailserverObj: JsonNode
   if(jsonObj.getProp(KEY_PINNED_MAILSERVERS, pinnedMailserverObj)):

--- a/src/app_service/service/settings/service.nim
+++ b/src/app_service/service/settings/service.nim
@@ -27,6 +27,7 @@ const SIGNAL_BIO_UPDATED* = "bioUpdated"
 const SIGNAL_MNEMONIC_REMOVED* = "mnemonicRemoved"
 const SIGNAL_SOCIAL_LINKS_UPDATED* = "socialLinksUpdated"
 const SIGNAL_CURRENT_USER_STATUS_UPDATED* = "currentUserStatusUpdated"
+const SIGNAL_INCLUDE_WATCH_ONLY_ACCOUNTS_UPDATED* = "includeWatchOnlyAccounts"
 
 logScope:
   topics = "settings-service"
@@ -109,6 +110,9 @@ QtObject:
           if settingsField.name == KEY_MNEMONIC:
             self.settings.mnemonic = ""
             self.events.emit(SIGNAL_MNEMONIC_REMOVED, Args())
+          if settingsField.name == INCLUDE_WATCH_ONLY_ACCOUNT:
+            self.settings.includeWatchOnlyAccount = parseBool(settingsField.value)
+            self.events.emit(SIGNAL_INCLUDE_WATCH_ONLY_ACCOUNTS_UPDATED, Args())
 
       if receivedData.socialLinksInfo.links.len > 0 or
         receivedData.socialLinksInfo.removed:
@@ -966,3 +970,12 @@ QtObject:
       data.error = e.msg
       error "error saving social links", errDescription=data.error
     self.storeSocialLinksAndNotify(data)
+
+  proc isIncludeWatchOnlyAccount*(self: Service): bool =
+    return self.settings.includeWatchOnlyAccount
+
+  proc toggleIncludeWatchOnlyAccount*(self: Service) =
+    let newValue = not self.settings.includeWatchOnlyAccount
+    if(self.saveSetting(INCLUDE_WATCH_ONLY_ACCOUNT, newValue)):
+      self.settings.includeWatchOnlyAccount = newValue
+      self.events.emit(SIGNAL_INCLUDE_WATCH_ONLY_ACCOUNTS_UPDATED, Args())

--- a/src/app_service/service/wallet_account/service.nim
+++ b/src/app_service/service/wallet_account/service.nim
@@ -965,3 +965,9 @@ QtObject:
             totalTokenBalance += token.getTotalBalanceOfSupportedChains()
 
     return totalTokenBalance
+
+  proc isIncludeWatchOnlyAccount*(self: Service): bool =
+    return self.settingsService.isIncludeWatchOnlyAccount()
+
+  proc toggleIncludeWatchOnlyAccount*(self: Service) =
+    self.settingsService.toggleIncludeWatchOnlyAccount()

--- a/storybook/pages/ActivityFilterMenuPage.qml
+++ b/storybook/pages/ActivityFilterMenuPage.qml
@@ -48,7 +48,7 @@ SplitView {
                                                               displayDecimals: 4,
                                                               stripTrailingZeroes: false}),
                                         isAllAccounts: false,
-                                        hideWatchAccounts: false
+                                        includeWatchOnly: false
 
                                     })
 

--- a/storybook/pages/WalletHeaderPage.qml
+++ b/storybook/pages/WalletHeaderPage.qml
@@ -56,7 +56,7 @@ SplitView {
                                                        displayDecimals: 4,
                                                        stripTrailingZeroes: false}),
                                  isAllAccounts: false,
-                                 hideWatchAccounts: false
+                                 includeWatchOnly: false
                              })
         }
 
@@ -73,7 +73,7 @@ SplitView {
                                                                          displayDecimals: 4,
                                                                          stripTrailingZeroes: false}),
                                                    isAllAccounts: true,
-                                                   hideWatchAccounts: true,
+                                                   includeWatchOnly: true,
                                                    colorIds: "purple;pink;magenta"
                                                })
 

--- a/ui/app/AppLayouts/Profile/controls/WalletKeyPairDelegate.qml
+++ b/ui/app/AppLayouts/Profile/controls/WalletKeyPairDelegate.qml
@@ -13,8 +13,10 @@ Rectangle {
 
     property string chainShortNames
     property string userProfilePublicKey
+    property bool includeWatchOnlyAccount
 
     signal goToAccountView(var account)
+    signal toggleIncludeWatchOnlyAccount()
 
     QtObject {
         id: d
@@ -68,9 +70,8 @@ Rectangle {
                 },
                 StatusSwitch {
                     visible: d.isWatchOnly
-                    // To-do connect in different task
-//                    checked: false
-//                    onCheckedChanged: {}
+                    checked: root.includeWatchOnlyAccount
+                    onClicked: root.toggleIncludeWatchOnlyAccount()
                 }
             ]
         }

--- a/ui/app/AppLayouts/Profile/stores/WalletStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/WalletStore.qml
@@ -23,6 +23,11 @@ QtObject {
     property var assets: walletSectionAssets.assets
     property var accounts: Global.appIsReady? accountsModule.accounts : null
     property var originModel: accountsModule.keyPairModel
+    property bool includeWatchOnlyAccount: accountsModule.includeWatchOnlyAccount
+
+    function toggleIncludeWatchOnlyAccount() {
+       accountsModule.toggleIncludeWatchOnlyAccount()
+    }
 
     property string userProfilePublicKey: userProfile.pubKey
     

--- a/ui/app/AppLayouts/Profile/views/wallet/MainView.qml
+++ b/ui/app/AppLayouts/Profile/views/wallet/MainView.qml
@@ -95,7 +95,9 @@ Column {
                 width: parent.width
                 chainShortNames: walletStore.getAllNetworksSupportedPrefix()
                 userProfilePublicKey: walletStore.userProfilePublicKey
+                includeWatchOnlyAccount: walletStore.includeWatchOnlyAccount
                 onGoToAccountView: root.goToAccountView(account)
+                onToggleIncludeWatchOnlyAccount: walletStore.toggleIncludeWatchOnlyAccount()
             }
         }
     }

--- a/ui/app/AppLayouts/Wallet/panels/WalletHeader.qml
+++ b/ui/app/AppLayouts/Wallet/panels/WalletHeader.qml
@@ -96,9 +96,9 @@ Item {
 
                 font.weight: Font.Normal
                 textColor: Theme.palette.baseColor1
-                text: overview.hideWatchAccounts ? qsTr("Show watch-only"):  qsTr("Hide watch-only")
+                text: overview.includeWatchOnly ? qsTr("Hide watch-only"): qsTr("Show watch-only")
 
-                icon.name: overview.hideWatchAccounts ? "show" : "hide"
+                icon.name: overview.includeWatchOnly ? "hide" : "show"
                 icon.height: 16
                 icon.width: 16
                 icon.color: Theme.palette.baseColor1

--- a/ui/app/AppLayouts/Wallet/views/LeftTabView.qml
+++ b/ui/app/AppLayouts/Wallet/views/LeftTabView.qml
@@ -125,7 +125,7 @@ Rectangle {
         function onDestroyAddAccountPopup() {
             addAccount.active = false
         }
-        function onFilterChanged(address, excludeWatchOnly, allAddresses) {
+        function onFilterChanged(address, includeWatchOnly, allAddresses) {
             root.currentAddress = allAddresses ? "" : address
             root.showAllAccounts = allAddresses
         }


### PR DESCRIPTION
fixes #11221

statusgo PR : https://github.com/status-im/status-go/pull/3676

Note to QA: Please also test if this setting is synced correctly 

### What does the PR do

Implements and sync watch only account settings in all c overview and wallet settings

### Affected areas

Wallet Account overview + Wallet Settings

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it


https://github.com/status-im/status-desktop/assets/60327365/44fe625f-5a56-4aef-a20d-e7bc923303b2


