### PR TITLE
fix(accountDerivation): App is crashing when the account derivation fails in status-go

### DIFF
--- a/src/app/modules/main/wallet_section/add_account/module.nim
+++ b/src/app/modules/main/wallet_section/add_account/module.nim
@@ -474,7 +474,11 @@ proc setDerivedAddresses[T](self: Module[T], derivedAddresses: seq[DerivedAddres
 method onDerivedAddressesFetched*[T](self: Module[T], derivedAddresses: seq[DerivedAddressDto], error: string) =
   if error.len > 0:
     error "fetching derived addresses error", err=error
+    self.fetchingAddressesIsInProgress = false
+    if self.authenticationReason == AuthenticationReason.AddingAccount:
+      self.view.setDisablePopup(false)
     return
+
   let selectedOrigin = self.view.getSelectedOrigin()
   if selectedOrigin.getPairType() != KeyPairType.Profile.int and
     selectedOrigin.getPairType() != KeyPairType.SeedImport.int:

--- a/src/app_service/service/wallet_account/async_tasks.nim
+++ b/src/app_service/service/wallet_account/async_tasks.nim
@@ -13,7 +13,7 @@ type
 const fetchDerivedAddressesTask*: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[FetchDerivedAddressesTaskArg](argEncoded)
   var output = %*{
-    "derivedAddress": "",
+    "derivedAddresses": "",
     "error": ""
   }
   try:
@@ -30,7 +30,7 @@ type
 const fetchDerivedAddressesForMnemonicTask*: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[FetchDerivedAddressesForMnemonicTaskArg](argEncoded)
   var output = %*{
-    "derivedAddress": "",
+    "derivedAddresses": "",
     "error": ""
   }
   try:


### PR DESCRIPTION
### What does the PR do

1. Fixing a crash caused by missing `derivedAddresses` property on the response of fetchDerivedAddresses task
2. Unblock the add account modal on error.

Might be related to: https://github.com/status-im/status-desktop/issues/11010

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas
Wallet
