### PR TITLE
[Mint Token] Automatically switch the typed text to uppercase in symbol input

### DIFF
--- a/ui/app/AppLayouts/Chat/views/communities/CommunityNewTokenView.qml
+++ b/ui/app/AppLayouts/Chat/views/communities/CommunityNewTokenView.qml
@@ -183,10 +183,10 @@ StatusScrollView {
             regexValidator.errorMessage: qsTr("Your token symbol contains invalid characters (use A-Z only)")
             regexValidator.regularExpression: Constants.regularExpressions.capitalOnly
             extraValidator.validate: function (value) {
-                // If minted failed, we can retry same deployment, so same symbol allowed
-                var allowRepeatedName = (root.isAssetView ? asset.deployState : collectible.deployState) === Constants.ContractTransactionStatus.Failed
+                // If minting failed, we can retry same deployment, so same symbol allowed
+                const allowRepeatedName = (root.isAssetView ? asset.deployState : collectible.deployState) === Constants.ContractTransactionStatus.Failed
                 if(allowRepeatedName)
-                    if(symbolInput.text === root.referenceSymbol)
+                    if(symbolInput.text.toUpperCase() === root.referenceSymbol.toUpperCase())
                         return true
 
                 // Otherwise, no repeated names allowed:
@@ -195,10 +195,14 @@ StatusScrollView {
             extraValidator.errorMessage: qsTr("You have used this token symbol before")
 
             onTextChanged: {
+                const cursorPos = input.edit.cursorPosition
+                const upperSymbol = text.toUpperCase()
                 if(root.isAssetView)
-                    asset.symbol = text
+                    asset.symbol = upperSymbol
                 else
-                    collectible.symbol = text
+                    collectible.symbol = upperSymbol
+                text = upperSymbol // breaking the binding on purpose but so does validate() and onTextChanged() internal handler
+                input.edit.cursorPosition = cursorPos
             }
         }
 


### PR DESCRIPTION
allow uppercase ASCII only input, up to 6 characters

Fixes #11201

### What does the PR do

Fixes input of asset/collectible symbol name

### Affected areas

CommunityNewTokenView

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![image](https://github.com/status-im/status-desktop/assets/5377645/9013f519-cbc9-4563-bfa5-21ddac5b525c)

Non-letters entered:
![image](https://github.com/status-im/status-desktop/assets/5377645/f8298096-169f-47c8-8b97-b9c7b6470336)

