### PR TITLE
fix: Rename "Communities Portal" button tooltip to "Discover Communities"

### DIFF
--- a/ui/imports/utils/Utils.qml
+++ b/ui/imports/utils/Utils.qml
@@ -605,7 +605,7 @@ QtObject {
         case Constants.appSection.node:
             return qsTr("Node Management")
         case Constants.appSection.communitiesPortal:
-            return qsTr("Communities Portal")
+            return qsTr("Discover Communities")
         default:
             return fallback
         }


### PR DESCRIPTION
Closes #8480

### Affected areas

Primary Navbar tooltip

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![image](https://github.com/status-im/status-desktop/assets/5377645/a437341c-0040-457d-9d1e-02e6a7dc5fcd)

