### PR TITLE
chore(@e2e_tests): disable test for hiding w/o accounts

### DIFF
--- a/test/ui-test/testSuites/suite_wallet/tst_wallet_accountsManagement/test.feature
+++ b/test/ui-test/testSuites/suite_wallet/tst_wallet_accountsManagement/test.feature
@@ -28,7 +28,8 @@ Feature: Status Desktop Wallet Section Wallet Account Management
             | address                                    | name      | color  | emoji      | emoji_unicode | add_via_context_menu | new_name        | new_color | new_emoji | new_emoji_unicode |
             | 0xea123F7beFF45E3C9fdF54B324c29DBdA14a639A | AccWatch1 | 2a4af5 | sunglasses | 1f60e         | yes                  | AccWatch1edited | 216266    | thumbsup  | 1f44d             |
             | 0xea123F7beFF45E3C9fdF54B324c29DBdA14a639B | AccWatch2 | 7140fd | sunglasses | 1f60e         | no                   | AccWatch2edited | 2a799b    | thumbsup  | 1f44d             |
-
+    
+    @mayfail # Test should be changed to reflect balance change instead of accounts list, will be done after it is changed in the app
      Scenario Outline: The user can hide and show watch only account by clicking Hide / Show button
         When the user adds a watch only account "<address>" with "<name>" color "#<color>" and emoji "<emoji>" via "<add_via_context_menu>"
         Then the account is correctly displayed with "<name>" and "#<color>" and emoji unicode "<emoji_unicode>" in accounts list
@@ -43,7 +44,7 @@ Feature: Status Desktop Wallet Section Wallet Account Management
             | address                                    | name      | color  | emoji      | emoji_unicode | add_via_context_menu |
             | 0xea123F7beFF45E3C9fdF54B324c29DBdA14a639A | AccWatch1 | 2a4af5 | sunglasses | 1f60e         | yes                  |
 
-        Scenario Outline: The user cancel deliting watch only account
+        Scenario Outline: The user cancel deleting watch only account
         When the user adds a watch only account "<address>" with "<name>" color "#<color>" and emoji "<emoji>" via "<add_via_context_menu>"
         Then the account is correctly displayed with "<name>" and "#<color>" and emoji unicode "<emoji_unicode>" in accounts list
         When the user start removing account "<name>" and cancel it
@@ -67,7 +68,7 @@ Feature: Status Desktop Wallet Section Wallet Account Management
             | GenAcc2 | 7140fd | sunglasses | 1f60e         | no                   | GenAcc2edited | 2a799b    | thumbsup  | 1f44d             |
 
 
-        Scenario Outline: The user cancel deliting generated account
+        Scenario Outline: The user cancel deleting generated account
         When the user adds a generated account with "<name>" color "#<color>" and emoji "<emoji>" via "<add_via_context_menu>"
         Then the account is correctly displayed with "<name>" and "#<color>" and emoji unicode "<emoji_unicode>" in accounts list
         When the user start removing account "<name>" and cancel it


### PR DESCRIPTION
### What does the PR do

Hide/show w/o accounts button should not hide/show accounts but should reflect the total balance. This will be implemented in the app soon and the test has to be re-written to handle that

### Affected areas

Wallet tests