### PR TITLE
[Mint Token] Update validation rule for name property

### DIFF
--- a/storybook/pages/CommunityNewTokenViewPage.qml
+++ b/storybook/pages/CommunityNewTokenViewPage.qml
@@ -34,7 +34,7 @@ SplitView {
                 enabledNetworks: NetworksModel.enabledNetworks
                 allNetworks: enabledNetworks
                 accounts: WalletAccountsModel {}
-                tokensModel: MintedTokensModel.mintedTokensModel
+                tokensModel: isAssetBox.checked ? MintedTokensModel.mintedAssetsModel :  MintedTokensModel.mintedCollectiblesModel
 
                 onPreviewClicked: logs.logEvent("CommunityNewTokenView::previewClicked")
             }

--- a/ui/StatusQ/include/StatusQ/modelutilsinternal.h
+++ b/ui/StatusQ/include/StatusQ/modelutilsinternal.h
@@ -24,6 +24,8 @@ public:
     Q_INVOKABLE QVariant get(QAbstractItemModel *model, int row,
                              const QString &roleName) const;
 
+    Q_INVOKABLE bool contains(QAbstractItemModel *model, const QString &roleName, const QVariant &value, int mode = Qt::CaseSensitive) const;
+
     static QObject* qmlInstance(QQmlEngine *engine, QJSEngine *scriptEngine)
     {
         Q_UNUSED(engine);

--- a/ui/StatusQ/src/StatusQ/Core/Utils/ModelUtils.qml
+++ b/ui/StatusQ/src/StatusQ/Core/Utils/ModelUtils.qml
@@ -55,8 +55,8 @@ QtObject {
         return -1
     }
 
-    function contains(model, role, key) {
-        return indexOf(model, role, key) !== -1
+    function contains(model, roleName, value, mode = Qt.CaseSensitive) {
+        return Internal.ModelUtils.contains(model, roleName, value, mode)
     }
 
     function checkItemsEquality(itemA, itemB, roles) {

--- a/ui/StatusQ/src/modelutilsinternal.cpp
+++ b/ui/StatusQ/src/modelutilsinternal.cpp
@@ -12,15 +12,8 @@ QStringList ModelUtilsInternal::roleNames(QAbstractItemModel *model) const
     if (model == nullptr)
         return {};
 
-    QHash<int, QByteArray> roles = model->roleNames();
-
-    QStringList strings;
-    strings.reserve(roles.size());
-
-    for (auto it = roles.begin(); it != roles.end(); ++it)
-        strings << QString::fromUtf8(it.value());
-
-    return strings;
+    const auto roles = model->roleNames();
+    return {roles.cbegin(), roles.cend()};
 }
 
 
@@ -40,8 +33,8 @@ QVariantMap ModelUtilsInternal::get(QAbstractItemModel *model, int row) const
     if (model == nullptr)
         return map;
 
-    QModelIndex modelIndex = model->index(row, 0);
-    QHash<int, QByteArray> roles = model->roleNames();
+    const auto modelIndex = model->index(row, 0);
+    const auto roles = model->roleNames();
 
     for (auto it = roles.begin(); it != roles.end(); ++it)
         map.insert(it.value(), model->data(modelIndex, it.key()));
@@ -53,4 +46,17 @@ QVariant ModelUtilsInternal::get(QAbstractItemModel *model,
                                  int row, const QString &roleName) const
 {
     return model->data(model->index(row, 0), roleByName(model, roleName));
+}
+
+bool ModelUtilsInternal::contains(QAbstractItemModel* model,
+                                  const QString& roleName,
+                                  const QVariant& value,
+                                  int mode) const
+{
+    if(!model) return false;
+
+    Qt::MatchFlags flags = Qt::MatchFixedString; // Qt::CaseInsensitive by default
+    if(mode == Qt::CaseSensitive) flags |= Qt::MatchCaseSensitive;
+    const auto indexes = model->match(model->index(0, 0), roleByName(model, roleName), value, 1, flags);
+    return !indexes.isEmpty();
 }

--- a/ui/app/AppLayouts/Chat/views/communities/CommunityNewTokenView.qml
+++ b/ui/app/AppLayouts/Chat/views/communities/CommunityNewTokenView.qml
@@ -127,14 +127,14 @@ StatusScrollView {
             minLengthValidator.errorMessage: qsTr("Please name your token name (use A-Z and 0-9, hyphens and underscores only)")
             regexValidator.errorMessage: qsTr("Your token name contains invalid characters (use A-Z and 0-9, hyphens and underscores only)")
             extraValidator.validate: function (value) {
-                // If minted failed, we can retry same deployment, so same name allowed
-                var allowRepeatedName = (root.isAssetView ? asset.deployState : collectible.deployState) === Constants.ContractTransactionStatus.Failed
+                // If minting failed, we can retry same deployment, so same name allowed
+                const allowRepeatedName = (root.isAssetView ? asset.deployState : collectible.deployState) === Constants.ContractTransactionStatus.Failed
                 if(allowRepeatedName)
                     if(nameInput.text === root.referenceName)
                         return true
 
                 // Otherwise, no repeated names allowed:
-                return !SQUtils.ModelUtils.contains(root.tokensModel, "name", nameInput.text)
+                return !SQUtils.ModelUtils.contains(root.tokensModel, "name", nameInput.text, Qt.CaseInsensitive)
             }
             extraValidator.errorMessage: qsTr("You have used this token name before")
 


### PR DESCRIPTION
Fixes checking for duplicate token name in a case insensitive manner

Redo the `ModelUtils.contains(model, roleName, value, mode = Qt.CaseSensitive)` in C++; more speed and add ability to search case in/ sensitive

Some more smaller fixes/speedups

Fixes #11204

### What does the PR do

Fixes checking for duplicate token name in a case insensitive manner

### Affected areas

CommunityNewTokenView

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![Snímek obrazovky z 2023-06-27 21-08-05](https://github.com/status-im/status-desktop/assets/5377645/a68fe007-84b6-4c51-9858-091be6fcdd27)

