### PR TITLE
Community -> New community: make community banner and logo required

### DIFF
--- a/ui/app/AppLayouts/Communities/controls/BannerPicker.qml
+++ b/ui/app/AppLayouts/Communities/controls/BannerPicker.qml
@@ -23,6 +23,8 @@ Item {
     property alias cropRect: editor.cropRect
     property alias imageData: editor.dataImage
 
+    readonly property bool hasSelectedImage: localAppSettings.testEnvironment ? true : editor.userSelectedImage
+
     implicitHeight: layout.childrenRect.height
 
     ColumnLayout {

--- a/ui/app/AppLayouts/Communities/controls/LogoPicker.qml
+++ b/ui/app/AppLayouts/Communities/controls/LogoPicker.qml
@@ -23,6 +23,8 @@ Item {
     property alias cropRect: editor.cropRect
     property alias imageData: editor.dataImage
 
+    readonly property bool hasSelectedImage: localAppSettings.testEnvironment ? true : editor.userSelectedImage
+
     implicitHeight: layout.childrenRect.height
 
     ColumnLayout {

--- a/ui/app/AppLayouts/Communities/popups/CreateCommunityPopup.qml
+++ b/ui/app/AppLayouts/Communities/popups/CreateCommunityPopup.qml
@@ -23,6 +23,7 @@ StatusStackModal {
 
     property var store
     property bool isDiscordImport // creating new or importing from discord?
+    property bool isDevBuild
 
     stackTitle: isDiscordImport ? qsTr("Import a community from Discord into Status") :
                                   qsTr("Create New Community")
@@ -367,7 +368,7 @@ StatusStackModal {
         StatusScrollView {
             id: generalView
             contentWidth: availableWidth
-            readonly property bool canGoNext: nameInput.valid && descriptionTextInput.valid
+            readonly property bool canGoNext: nameInput.valid && descriptionTextInput.valid && (root.isDevBuild || (logoPicker.hasSelectedImage && bannerPicker.hasSelectedImage))
 
             padding: 0
             clip: false

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -119,6 +119,7 @@ Item {
         popupParent: appMain
         rootStore: appMain.rootStore
         communitiesStore: appMain.communitiesStore
+        isDevBuild: !production
     }
 
     Connections {

--- a/ui/app/mainui/Popups.qml
+++ b/ui/app/mainui/Popups.qml
@@ -24,6 +24,7 @@ QtObject {
     required property var popupParent
     required property var rootStore
     property var communitiesStore
+    property bool isDevBuild
 
     property var activePopupComponents: []
 
@@ -467,6 +468,7 @@ QtObject {
             id: createCommunitiesPopupComponent
             CreateCommunityPopup {
                 store: root.communitiesStore
+                isDevBuild: root.isDevBuild
                 onClosed: {
                     destroy()
                 }

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -626,7 +626,7 @@ QtObject {
         readonly property string alphanumericalRegExp: qsTr("Only letters and numbers allowed")
         readonly property string alphanumericalWithSpaceRegExp: qsTr("Special characters are not allowed")
         readonly property string alphanumericalExpandedRegExp: qsTr("Only letters, numbers, underscores, whitespaces and hyphens allowed")
-        readonly property string asciiRegExp: qsTr("Only letters, numbers and ASII characters allowed")
+        readonly property string asciiRegExp: qsTr("Only letters, numbers and ASCII characters allowed")
     }
 
     readonly property QtObject socialLinkType: QtObject {


### PR DESCRIPTION
Fixes #11234

### What does the PR do

Makes the logo and banner mandatory when creating a new community in production builds

### Affected areas

CreateCommunityPopup

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

Logo and banner not filled -> `Next` disabled:
![Snímek obrazovky z 2023-06-28 14-02-52](https://github.com/status-im/status-desktop/assets/5377645/ec67c567-669f-4dbc-81cf-8fb0b3e371f4)
