### PR TITLE
fix(community): fix cancel of authentication still requests to join

### DIFF
--- a/src/app/modules/main/chat_section/controller.nim
+++ b/src/app/modules/main/chat_section/controller.nim
@@ -91,6 +91,11 @@ proc getIsCurrentSectionActive*(self: Controller): bool =
 proc setIsCurrentSectionActive*(self: Controller, active: bool) =
   self.isCurrentSectionActive = active
 
+proc userAuthenticationCanceled*(self: Controller) =
+  self.tmpAuthenticationForJoinInProgress = false
+  self.tmpRequestToJoinEnsName = ""
+  self.tmpRequestToJoinAddressesToShare = @[]
+
 proc requestToJoinCommunityAuthenticated*(self: Controller, password: string) =
   self.communityService.asyncRequestToJoinCommunity(self.sectionId, self.tmpRequestToJoinEnsName,
     password, self.tmpRequestToJoinAddressesToShare)

--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -898,6 +898,11 @@ method onJoinedCommunity*(self: Module) =
   self.view.setAmIMember(true)
 
 method onUserAuthenticated*(self: Module, pin: string, password: string, keyUid: string) =
+  if password == "" and pin == "":
+    self.view.userAuthenticationCanceled()
+    self.controller.userAuthenticationCanceled()
+    return
+
   self.controller.requestToJoinCommunityAuthenticated(password)
 
 method onMarkAllMessagesRead*(self: Module, chat: ChatDto) =

--- a/src/app/modules/main/chat_section/view.nim
+++ b/src/app/modules/main/chat_section/view.nim
@@ -420,3 +420,5 @@ QtObject:
   QtProperty[bool] allTokenRequirementsMet:
     read = getAllTokenRequirementsMet
     notify = allTokenRequirementsMetChanged
+
+  proc userAuthenticationCanceled*(self: View) {.signal.}

--- a/ui/app/AppLayouts/Communities/views/CommunityColumnView.qml
+++ b/ui/app/AppLayouts/Communities/views/CommunityColumnView.qml
@@ -95,6 +95,14 @@ Item {
                 }
             }
         }
+
+        Connections {
+            target: communitySectionModule
+            function onUserAuthenticationCanceled() {
+                joinCommunityButton.invitationPending = false
+                joinCommunityButton.loading = false
+            }
+        }
         Component {
             id: communityIntroDialog
             CommunityIntroDialog {


### PR DESCRIPTION
Fixes #11272

The problem was that we didn't handle the cancellation (checking with password was empty). 

Now we do and we send the signal to cancel when it's the case.

[cancel.webm](https://github.com/status-im/status-desktop/assets/11926403/6deb0da3-843b-4f83-a9cd-ec9ee8c7f54d)
