### PR TITLE
fix(Communities): ensure permission CTAs are rendered with admin

### DIFF
--- a/ui/app/AppLayouts/Communities/views/CommunitySettingsView.qml
+++ b/ui/app/AppLayouts/Communities/views/CommunitySettingsView.qml
@@ -605,6 +605,7 @@ StatusSectionLayout {
             readonly property string image: root.community.image
             readonly property string color: root.community.color
             readonly property bool owner: root.community.memberRole === Constants.memberRole.owner
+            readonly property bool admin: root.community.memberRole === Constants.memberRole.admin
         }
 
         function goTo(section: int, subSection: int) {

--- a/ui/app/AppLayouts/Communities/views/PermissionsView.qml
+++ b/ui/app/AppLayouts/Communities/views/PermissionsView.qml
@@ -16,7 +16,7 @@ StatusScrollView {
     required property var collectiblesModel
     required property var channelsModel
 
-    // id, name, image, color, owner properties expected
+    // id, name, image, color, owner, admin properties expected
     required property var communityDetails
 
     property int viewWidth: 560 // by design
@@ -73,7 +73,7 @@ StatusScrollView {
                                    ? channelsSelectionModel : communityItemModel
                 isPrivate: model.isPrivate
 
-                showButtons: root.communityDetails.owner
+                showButtons: root.communityDetails.owner || (root.communityDetails.admin && model.permissionType !== PermissionTypes.Type.Admin)
 
                 onEditClicked: root.editPermissionRequested(model.index)
                 onDuplicateClicked: root.duplicatePermissionRequested(model.index)


### PR DESCRIPTION
permissions

This commit fixes a bug that admins are not able to do any permission actions (editing/deleting). The issue was that there was a check for those CTAs only to be visible if the logged-in user is the owner of the community, not an admin.

Closes #11092

