### PR TITLE
Settings/Communities: fix duplicate entries

### DIFF
--- a/ui/app/AppLayouts/Profile/panels/CommunitiesListPanel.qml
+++ b/ui/app/AppLayouts/Profile/panels/CommunitiesListPanel.qml
@@ -47,6 +47,7 @@ StatusListView {
 
         onClicked: setActiveCommunityClicked(model.id)
 
+        readonly property bool isSpectator: model.spectated && !model.joined
         readonly property bool isOwner: model.memberRole === Constants.memberRole.owner
         readonly property bool isAdmin: model.memberRole === Constants.memberRole.admin
         readonly property bool isInvitationPending: root.rootStore.isCommunityRequestPending(model.id)
@@ -64,7 +65,7 @@ StatusListView {
                 anchors.verticalCenter: parent.verticalCenter
                 size: StatusBaseButton.Size.Small
                 text: listItem.isInvitationPending ? qsTr("Membership Request Sent") : qsTr("View & Join Community")
-                visible: model.spectated
+                visible: listItem.isSpectator
                 onClicked: root.showCommunityIntroDialog(model.id, model.name, model.introMessage, model.image, model.access)
             },
             StatusFlatButton {
@@ -98,7 +99,7 @@ StatusListView {
                         }
                     }
                     MuteChatMenuItem {
-                        enabled: (model.joined || (model.spectated && !listItem.isInvitationPending)) && !model.muted
+                        enabled: (model.joined || (listItem.isSpectator && !listItem.isInvitationPending)) && !model.muted
                         title: qsTr("Mute Community")
                         onMuteTriggered: {
                             moreMenu.close()
@@ -120,7 +121,7 @@ StatusListView {
                         enabled: {
                             if (listItem.isOwner)
                                 return false
-                            if (model.spectated && !listItem.isInvitationPending)
+                            if (listItem.isSpectator && !listItem.isInvitationPending)
                                 return false
                             return true
                         }
@@ -139,12 +140,12 @@ StatusListView {
                         text: {
                             if (listItem.isInvitationPending)
                                 return qsTr("Cancel Membership Request")
-                            return model.spectated ? qsTr("Close Community") : qsTr("Leave Community")
+                            return listItem.isSpectator ? qsTr("Close Community") : qsTr("Leave Community")
                         }
                         icon.name: {
                             if (listItem.isInvitationPending)
                                 return "arrow-left"
-                            return model.spectated ? "close-circle" : "arrow-left"
+                            return listItem.isSpectator ? "close-circle" : "arrow-left"
                         }
                         type: StatusAction.Type.Danger
                         enabled: !listItem.isOwner
@@ -152,7 +153,7 @@ StatusListView {
                             moreMenu.close()
                             if (listItem.isInvitationPending)
                                 root.cancelMembershipRequest(model.id)
-                            else if (model.spectated)
+                            else if (listItem.isSpectator)
                                 root.closeCommunityClicked(model.id)
                             else
                                 root.leaveCommunityClicked(model.name, model.id, model.outroMessage)

--- a/ui/app/AppLayouts/Profile/views/CommunitiesView.qml
+++ b/ui/app/AppLayouts/Profile/views/CommunitiesView.qml
@@ -139,9 +139,8 @@ SettingsContentBase {
 
             Panel {
                 id: panelPendingRequests
-                filters: ValueFilter {
-                    roleName: "spectated"
-                    value: true
+                filters: ExpressionFilter {
+                    expression: model.spectated && !model.joined
                 }
             }
         }


### PR DESCRIPTION
in case a community is both `spectated` and `joined`

Fixes #11301

### What does the PR do

Fixes potential dupes in Settings/Communities

### Affected areas

Settings/Communities

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

Before:
![249469571-7892d122-9522-42c5-a357-93e71adaf60f](https://github.com/status-im/status-desktop/assets/5377645/015e7225-be4d-4616-9194-a31f6a600406)

After ("Contributors' test community" gone from `Pending`)
![Snímek obrazovky z 2023-06-28 17-58-38](https://github.com/status-im/status-desktop/assets/5377645/8242f135-26b8-4c41-a5ff-056a0560ce71)

