### PR TITLE
fix: Airdrop section of deployed NFT doesn't seem to apply darkmode

### DIFF
--- a/storybook/pages/EditAirdropViewPage.qml
+++ b/storybook/pages/EditAirdropViewPage.qml
@@ -135,7 +135,6 @@ SplitView {
 
             const view = loader.item
             view.airdropFees = response
-
         }
     }
 
@@ -183,7 +182,6 @@ SplitView {
                             expression: model.index ? "Optimism" : "Arbitrum"
                         },
                         ExpressionRole {
-
                             readonly property string icon1: "network/Network=Optimism"
                             readonly property string icon2: "network/Network=Arbitrum"
 
@@ -221,11 +219,18 @@ SplitView {
                             expression: !(model.index % 4)
                         },
                         ExpressionRole {
+                            name: "accountName"
+                            expression: "StatusAccount"
+                        },
+                        ExpressionRole {
+                            name: "contractUniqueKey"
+                            expression: "contractUniqueKey_" + model.index
+                        },
+                        ExpressionRole {
                             name: "chainName"
                             expression: model.index ? "Ethereum Mainnet" : "Goerli"
                         },
                         ExpressionRole {
-
                             readonly property string icon1: "network/Network=Ethereum"
                             readonly property string icon2: "network/Network=Testnet"
 
@@ -238,7 +243,6 @@ SplitView {
                         roleName: "category"
                         value: TokenCategories.Category.Community
                     }
-
 
                     Component.onCompleted: {
                         Qt.callLater(() => editAirdropView.assetsModel = this)

--- a/storybook/pages/EditPermissionViewPage.qml
+++ b/storybook/pages/EditPermissionViewPage.qml
@@ -32,10 +32,11 @@ SplitView {
             channelsModel: ChannelsModel {}
 
             communityDetails: QtObject {
+                readonly property string id: "sox"
                 readonly property string name: "Socks"
                 readonly property string image: ModelsData.icons.socks
                 readonly property string color: "red"
-                readonly property string owner: isOwnerCheckBox.checked
+                readonly property bool owner: isOwnerCheckBox.checked
             }
 
             onCreatePermissionClicked: {

--- a/storybook/pages/MintTokensSettingsPanelPage.qml
+++ b/storybook/pages/MintTokensSettingsPanelPage.qml
@@ -44,7 +44,7 @@ SplitView {
 
             onMintCollectible: logs.logEvent("CommunityMintTokensSettingsPanel::mintCollectible")
             onMintAsset: logs.logEvent("CommunityMintTokensSettingsPanel::mintAssets")
-            onDeleteToken: logs.logEvent("CommunityMintTokensSettingsPanel::deleteToken: " + key)
+            onDeleteToken: logs.logEvent("CommunityMintTokensSettingsPanel::deleteToken: " + tokenKey)
         }
     }
 

--- a/storybook/pages/PermissionsViewPage.qml
+++ b/storybook/pages/PermissionsViewPage.qml
@@ -47,9 +47,11 @@ SplitView {
                 }
 
                 communityDetails: QtObject {
+                    readonly property string id: "sox"
                     readonly property string name: "Socks"
                     readonly property string image: ModelsData.icons.socks
                     readonly property string color: "red"
+                    readonly property bool owner: true
                 }
 
                 function log(method, index) {

--- a/storybook/pages/SortableTokenHoldersPanelPage.qml
+++ b/storybook/pages/SortableTokenHoldersPanelPage.qml
@@ -21,6 +21,7 @@ SplitView {
         Rectangle {
             anchors.fill: holdersPanel
 
+            color: "transparent"
             border.color: "lightgray"
             anchors.margins: -1
         }

--- a/storybook/pages/StatusTxProgressBarPage.qml
+++ b/storybook/pages/StatusTxProgressBarPage.qml
@@ -66,12 +66,8 @@ SplitView {
                     error: failureCheckBox.checked
                     isLayer1: mainnetCheckbox.checked
                     confirmations: confirmationsSlider.value
-                    duration: durationSlider.to
-                    progress: durationSlider.value
                     chainName: isLayer1 ? "Mainnet" :"Optimism"
-                    confirmationTimeStamp: 1670419848
-                    finalisationTimeStamp: 1670419848
-                    failedTimeStamp: 1670419848
+                    timeStamp: 1670419848
                 }
             }
         }

--- a/storybook/src/Models/AssetsModel.qml
+++ b/storybook/src/Models/AssetsModel.qml
@@ -9,49 +9,63 @@ ListModel {
             iconSource: ModelsData.assets.socks,
             name: "Unisocks",
             shortName: "SOCKS",
-            category: TokenCategories.Category.Community
+            symbol: "SOCKS",
+            category: TokenCategories.Category.Community,
+            communityId: ""
         },
         {
             key: "zrx",
             iconSource: ModelsData.assets.zrx,
             name: "Ox",
             shortName: "ZRX",
-            category: TokenCategories.Category.Community
+            symbol: "ZRX",
+            category: TokenCategories.Category.Community,
+            communityId: ""
         },
         {
             key: "1inch",
             iconSource: ModelsData.assets.inch,
             name: "1inch",
             shortName: "1INCH",
-            category: TokenCategories.Category.Own
+            symbol: "1INCH",
+            category: TokenCategories.Category.Own,
+            communityId: ""
         },
         {
             key: "Aave",
             iconSource: ModelsData.assets.aave,
             name: "Aave",
             shortName: "AAVE",
-            category: TokenCategories.Category.Own
+            symbol: "AAVE",
+            category: TokenCategories.Category.Own,
+            communityId: ""
         },
         {
             key: "Amp",
             iconSource: ModelsData.assets.amp,
             name: "Amp",
             shortName: "AMP",
-            category: TokenCategories.Category.Own
+            symbol: "AMP",
+            category: TokenCategories.Category.Own,
+            communityId: ""
         },
         {
             key: "Dai",
             iconSource: ModelsData.assets.dai,
             name: "Dai",
             shortName: "DAI",
-            category: TokenCategories.Category.General
+            symbol: "DAI",
+            category: TokenCategories.Category.General,
+            communityId: ""
         },
         {
             key: "snt",
             iconSource: ModelsData.assets.snt,
             name: "snt",
             shortName: "snt",
-            category: TokenCategories.Category.General
+            symbol: "snt",
+            category: TokenCategories.Category.General,
+            communityId: ""
         }
     ]
 

--- a/storybook/src/Models/CollectiblesModel.qml
+++ b/storybook/src/Models/CollectiblesModel.qml
@@ -8,22 +8,27 @@ ListModel {
             key: "Anniversary",
             iconSource: ModelsData.collectibles.anniversary,
             name: "Anniversary",
+            symbol: "Anniversary",
             category: TokenCategories.Category.Community,
             imageUrl: ModelsData.collectibles.anniversary,
-            id: 1767698
+            id: 1767698,
+            communityId: ""
         },
         {
             key: "Anniversary2",
             iconSource: ModelsData.collectibles.anniversary,
             name: "Anniversary2",
+            symbol: "Anniversary2",
             category: TokenCategories.Category.Community,
             imageUrl: ModelsData.collectibles.anniversary,
-            id: 1767699
+            id: 1767699,
+            communityId: ""
         },
         {
             key: "CryptoKitties",
             iconSource: ModelsData.collectibles.cryptoKitties,
             name: "CryptoKitties",
+            symbol: "CryptoKitties",
             category: TokenCategories.Category.Own,
             subItems: [
                 {
@@ -70,23 +75,28 @@ ListModel {
                 }
             ],
             imageUrl: ModelsData.collectibles.cryptoKitties,
-            id: 1767700
+            id: 1767700,
+            communityId: ""
         },
         {
             key: "SuperRare",
             iconSource: ModelsData.collectibles.superRare,
             name: "SuperRare",
+            symbol: "SuperRare",
             category: TokenCategories.Category.Own,
             imageUrl: ModelsData.collectibles.superRare,
-            id: 1767701
+            id: 1767701,
+            communityId: ""
         },
         {
             key: "Custom",
             iconSource: ModelsData.collectibles.custom,
             name: "Custom Collectible",
+            symbol: "Custom",
             category: TokenCategories.Category.General,
             imageUrl: ModelsData.collectibles.custom,
-            id: 1767764
+            id: 1767764,
+            communityId: ""
         }
     ]
 

--- a/storybook/src/Models/MintedTokensModel.qml
+++ b/storybook/src/Models/MintedTokensModel.qml
@@ -84,7 +84,7 @@ QtObject {
                                               transferable: false,
                                               remoteSelfDestruct: true,
                                               chainId: 5,
-                                              chainName: "Curstom",
+                                              chainName: "Custom",
                                               chainIcon: ModelsData.networks.custom,
                                               accountName: "Other Account"
                                           },

--- a/storybook/src/Models/ModelsData.qml
+++ b/storybook/src/Models/ModelsData.qml
@@ -78,7 +78,3 @@ QtObject {
         readonly property string _long: "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum."
     }
 }
-
-
-
-

--- a/ui/app/AppLayouts/Communities/controls/AddressesInputList.qml
+++ b/ui/app/AppLayouts/Communities/controls/AddressesInputList.qml
@@ -50,7 +50,7 @@ Control {
 
     background: Rectangle {
         radius: Style.current.radius
-        color: Theme.palette.indirectColor1
+        color: Theme.palette.statusListItem.backgroundColor
     }
 
     contentItem: StatusListView {

--- a/ui/app/AppLayouts/Communities/controls/MembersSelectorPanel.qml
+++ b/ui/app/AppLayouts/Communities/controls/MembersSelectorPanel.qml
@@ -61,7 +61,7 @@ Control {
                              d.delegateHeight * root.count)
 
             radius: Style.current.radius
-            color: Theme.palette.indirectColor1
+            color: Theme.palette.statusListItem.backgroundColor
 
             StatusListView {
                 id: listView

--- a/ui/app/AppLayouts/Communities/panels/NoHoldersPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/NoHoldersPanel.qml
@@ -17,6 +17,7 @@ Control {
     horizontalPadding: 56
 
     background: Rectangle {
+        color: Theme.palette.statusListItem.backgroundColor
         radius: Style.current.radius
         border.color: Theme.palette.baseColor2
     }

--- a/ui/app/AppLayouts/Communities/views/EditAirdropView.qml
+++ b/ui/app/AppLayouts/Communities/views/EditAirdropView.qml
@@ -603,7 +603,7 @@ StatusScrollView {
 
                 background: Rectangle {
                     radius: Style.current.radius
-                    color: Theme.palette.indirectColor1
+                    color: Theme.palette.statusListItem.backgroundColor
                 }
 
                 contentItem: Loader {

--- a/ui/imports/shared/panels/SequenceColumnLayout.qml
+++ b/ui/imports/shared/panels/SequenceColumnLayout.qml
@@ -26,7 +26,7 @@ ColumnLayout {
         Layout.leftMargin: parent.lineMargin
         Layout.preferredWidth: parent.lineWidth
         Layout.preferredHeight: parent.lineHeight
-        color: Style.current.separator
+        color: Theme.palette.baseColor4
     }
 
     RowLayout {
@@ -50,7 +50,7 @@ ColumnLayout {
 
                 color: "transparent"
                 border.width: root.lineWidth
-                border.color: Style.current.separator
+                border.color: Theme.palette.baseColor4
             }
         }
 


### PR DESCRIPTION
- fix some colors to look correct in dark mode too
- update/unbreak the corresponding storybook pages

Fixes #11289

### Affected areas

EditAirdropView

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

Airdrop view:
![image](https://github.com/status-im/status-desktop/assets/5377645/d7320ace-95c4-4787-8969-8399df614b29)
![image](https://github.com/status-im/status-desktop/assets/5377645/4a73cf2a-9855-4fee-b114-f8e93121e7d8)

![image](https://github.com/status-im/status-desktop/assets/5377645/be09c158-2741-41dc-a20b-763ba8ad0e95)
![image](https://github.com/status-im/status-desktop/assets/5377645/6c2f59f0-e193-491e-9770-88e1ef289550)


Empty holders panel:
![image](https://github.com/status-im/status-desktop/assets/5377645/96fb95b2-387b-461d-8435-061f86824f46)
![image](https://github.com/status-im/status-desktop/assets/5377645/6b7775cd-3264-475b-87c2-da9afe56f9aa)

