### PR TITLE
feat(wallet) make filer apis async

### DIFF
--- a/src/app_service/service/transaction/service.nim
+++ b/src/app_service/service/transaction/service.nim
@@ -259,7 +259,7 @@ QtObject:
     let allTxLoaded = historyData["allTxLoaded"].getBool
     var transactions: seq[TransactionDto] = @[]
     var collectibles: seq[CollectibleDto] = @[]
-     
+
     for tx in historyData["history"].getElems():
       let dto = tx.toTransactionDto()
       self.allTransactions.mgetOrPut(address, initTable[string, TransactionDto]())[dto.txHash] = dto

--- a/ui/app/AppLayouts/Wallet/panels/ActivityFilterPanel.qml
+++ b/ui/app/AppLayouts/Wallet/panels/ActivityFilterPanel.qml
@@ -231,6 +231,7 @@ Column {
 
         store: root.store
         recentsList: activityFilterStore.recentsList
+        loadingRecipients: activityFilterStore.loadingRecipients
         recentsFilters: activityFilterStore.recentsFilters
         savedAddressList: activityFilterStore.savedAddressList
         savedAddressFilters: activityFilterStore.savedAddressFilters

--- a/ui/app/AppLayouts/Wallet/popups/ActivityFilterMenu.qml
+++ b/ui/app/AppLayouts/Wallet/popups/ActivityFilterMenu.qml
@@ -38,6 +38,7 @@ StatusMenu {
 
     // Recents filter
     property var recentsList
+    property bool loadingRecipients: false
     property var recentsFilters
     readonly property bool allRecentsChecked: counterPartyMenu.allRecentsChecked
     signal updateRecentsFilter(string address)
@@ -99,6 +100,7 @@ StatusMenu {
             onBack: root.open()
             store: root.store
             recentsList: root.recentsList
+            loadingRecipients: root.loadingRecipients
             recentsFilters: root.recentsFilters
             savedAddressList: root.savedAddressList
             savedAddressFilters: root.savedAddressFilters

--- a/ui/app/AppLayouts/Wallet/popups/filterSubMenus/ActivityCounterpartyFilterSubMenu.qml
+++ b/ui/app/AppLayouts/Wallet/popups/filterSubMenus/ActivityCounterpartyFilterSubMenu.qml
@@ -23,6 +23,7 @@ StatusMenu {
     property var store
 
     property var recentsList
+    property bool loadingRecipients: false
     property var recentsFilters
     readonly property bool allRecentsChecked: recentsFilters.length === 0
 
@@ -80,9 +81,15 @@ StatusMenu {
             StatusBaseText {
                 anchors.horizontalCenter: parent.horizontalCenter
                 text: qsTr("No Recents")
-                visible: root.recentsList.count === 0
+                visible: root.recentsList.count === 0 && !root.loadingRecipients
+            }
+            StatusBaseText {
+                anchors.horizontalCenter: parent.horizontalCenter
+                text: qsTr("Loading Recents")
+                visible: root.loadingRecipients
             }
             StatusListView {
+                visible: !root.loadingRecipients
                 width: parent.width
                 height: root.height - tabBar.height - 12
                 model: root.recentsList

--- a/ui/app/AppLayouts/Wallet/stores/ActivityFiltersStore.qml
+++ b/ui/app/AppLayouts/Wallet/stores/ActivityFiltersStore.qml
@@ -137,6 +137,7 @@ QtObject {
 
 
     property var recentsList: activityController.recipientsModel
+    property bool loadingRecipients: activityController.loadingRecipients
     property var recentsFilters: []
     function updateRecipientsModel() {
         activityController.updateRecipientsModel()


### PR DESCRIPTION
### Closes #11170

Bump status-go HEAD to [#3699](https://github.com/status-im/status-go/pull/3699) which includes required changes

Refactor the API usage to use the new async APIs.
Support multiple events in the same block
Report the loading state for all the APIs

Also

- reset the model to empty when the filter is invalidated due to address and chain IDs change


