### PR TITLE
fix(@desktop/keycard): crash by just running "Setup a new Keycard with an existing account" flow and closing it

### DIFF
--- a/ui/app/AppLayouts/Profile/views/KeycardView.qml
+++ b/ui/app/AppLayouts/Profile/views/KeycardView.qml
@@ -94,21 +94,26 @@ SettingsContentBase {
             target: root.keycardStore.keycardModule
 
             function onDisplayKeycardSharedModuleFlow() {
-                Global.openPopup(keycardPopup);
+                keycardPopup.active = true
             }
             function onDestroyKeycardSharedModuleFlow() {
-                Global.closePopup();
+                keycardPopup.active = false
             }
             function onSharedModuleBusy() {
                 Global.openPopup(sharedModuleBusyPopupComponent)
             }
         }
 
-        Component {
+        Loader {
             id: keycardPopup
-            KeycardPopup {
+            active: false
+            sourceComponent: KeycardPopup {
                 sharedKeycardModule: root.keycardStore.keycardModule.keycardSharedModule
                 emojiPopup: root.emojiPopup
+            }
+
+            onLoaded: {
+                keycardPopup.item.open()
             }
         }
     }

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -72,11 +72,11 @@ Item {
         }
 
         function onDisplayKeycardSharedModuleFlow() {
-            Global.openPopup(keycardPopup);
+            keycardPopup.active = true
         }
 
         function onDestroyKeycardSharedModuleFlow() {
-            Global.closePopup();
+            keycardPopup.active = false
         }
 
         function onMailserverWorking() {
@@ -1427,11 +1427,15 @@ Item {
         Global.settingsLoaded()
     }
 
-    Component {
+    Loader {
         id: keycardPopup
-        KeycardPopup {
-            anchors.centerIn: parent
+        active: false
+        sourceComponent: KeycardPopup {
             sharedKeycardModule: appMain.rootStore.mainModuleInst.keycardSharedModule
+        }
+
+        onLoaded: {
+            keycardPopup.item.open()
         }
     }
 


### PR DESCRIPTION
This one also fixes the issue if user runs `"Import or restore via a seed phrase"` and after successful import click on `"View imported accounts in Wallet"` button.

Fixes: #11346