### PR TITLE
feat(@desktop/wallet): Fetch txs only when opening activity tab

### DIFF
--- a/src/app/modules/main/wallet_section/activity/controller.nim
+++ b/src/app/modules/main/wallet_section/activity/controller.nim
@@ -183,6 +183,7 @@ QtObject:
 
   proc updateFilter*(self: Controller) {.slot.} =
     self.status.setLoadingData(true)
+    self.status.setIsFilterDirty(false)
     self.model.resetModel(@[])
     self.eventsHandler.updateSubscribedAddresses(self.addresses)
     self.status.setNewDataAvailable(false)
@@ -387,7 +388,8 @@ QtObject:
   QtProperty[QVariant] status:
     read = getStatus
 
+
   proc globalFilterChanged*(self: Controller, addresses: seq[string], chainIds: seq[int]) = 
     self.setFilterAddresses(addresses)
     self.setFilterChains(chainIds)
-    self.updateFilter()
+    self.status.setIsFilterDirty(true)

--- a/src/app/modules/main/wallet_section/activity/status.nim
+++ b/src/app/modules/main/wallet_section/activity/status.nim
@@ -21,6 +21,8 @@ QtObject:
 
       newDataAvailable: bool
 
+      isFilterDirty: bool
+
   proc setup(self: Status) =
     self.QObject.setup
 
@@ -55,6 +57,7 @@ QtObject:
     new(result, delete)
 
     result.errorCode = backend_activity.ErrorCode.ErrorCodeSuccess
+    result.isFilterDirty = false
 
     result.setup()
 
@@ -112,3 +115,16 @@ QtObject:
   QtProperty[bool] newDataAvailable:
     read = getNewDataAvailable
     notify = newDataAvailableChanged
+
+  proc isFilterDirtyChanged*(self: Status) {.signal.}
+
+  proc setIsFilterDirty*(self: Status, value: bool) =
+    self.isFilterDirty = value
+    self.isFilterDirtyChanged()
+
+  proc getIsFilterDirty*(self: Status): bool {.slot.} =
+    return self.isFilterDirty
+
+  QtProperty[bool] isFilterDirty:
+    read = getIsFilterDirty
+    notify = isFilterDirtyChanged

--- a/src/app/modules/main/wallet_section/filter.nim
+++ b/src/app/modules/main/wallet_section/filter.nim
@@ -9,7 +9,7 @@ type Filter* = ref object
   allAddresses*: bool
 
 proc initFilter*(
-  controller: controller.Controller,
+  controller: controller.Controller
 ): Filter =
   result = Filter()
   result.controller = controller
@@ -55,7 +55,6 @@ proc removeAddress*(self: Filter, address: string) =
   let ind = self.addresses.find(address)
   if ind > -1:
     self.addresses.delete(ind)
-
   
 proc updateNetworks*(self: Filter) =
   self.chainIds = self.controller.getEnabledChainIds()

--- a/ui/imports/shared/stores/RootStore.qml
+++ b/ui/imports/shared/stores/RootStore.qml
@@ -40,6 +40,7 @@ QtObject {
     property var historyTransactions: Global.appIsReady? walletSection.activityController.model : null
     readonly property bool loadingHistoryTransactions: Global.appIsReady && walletSection.activityController.status.loadingData
     readonly property bool newDataAvailable: Global.appIsReady && walletSection.activityController.status.newDataAvailable
+    readonly property bool isTransactionFilterDirty: Global.appIsReady && walletSection.activityController.status.isFilterDirty
     property bool isNonArchivalNode: history ? history.isNonArchivalNode
                                              : false
     property var marketValueStore: TokenMarketValuesStore{}
@@ -184,6 +185,11 @@ QtObject {
                 || loadingHistoryTransactions)
             return
         walletSection.activityController.loadMoreItems()
+    }
+
+    function updateTransactionFilter() {
+        if (isTransactionFilterDirty)
+            walletSection.activityController.updateFilter()
     }
 
     function hex2Eth(value) {

--- a/ui/imports/shared/views/HistoryView.qml
+++ b/ui/imports/shared/views/HistoryView.qml
@@ -30,6 +30,20 @@ ColumnLayout {
 
     signal launchTransactionDetail(var transaction)
 
+    onVisibleChanged: {
+        if (visible) {
+            RootStore.updateTransactionFilter()
+        }
+    }
+
+    Connections {
+        target: RootStore
+        enabled: root.visible
+        function onIsTransactionFilterDirtyChanged() {
+            RootStore.updateTransactionFilter()
+        }
+    }
+
     QtObject {
         id: d
         readonly property bool isInitialLoading: RootStore.loadingHistoryTransactions && transactionListRoot.count === 0
@@ -303,7 +317,7 @@ ColumnLayout {
             }
 
             Repeater {
-                model: RootStore.historyTransactions.hasMore || d.isInitialLoading ? 10 : 0
+                model: !noTxs.visible && (RootStore.historyTransactions.hasMore || d.isInitialLoading) ? 10 : 0
                 TransactionDelegate {
                     Layout.fillWidth: true
                     rootStore: RootStore


### PR DESCRIPTION
closes #11356 

### What does the PR do

Instead of fetching activities on start-up, they are requested when user click activity tab

### Affected areas

Activity UI

### Screenshot of functionality (including design for comparison)


https://github.com/status-im/status-desktop/assets/11396062/64e17973-7e21-452e-a8b4-fcb94a1540a6


