### PR TITLE
feat(walllet): Removed storing/deletion of pending txs.

### DIFF
--- a/src/app_service/service/transaction/service.nim
+++ b/src/app_service/service/transaction/service.nim
@@ -99,10 +99,6 @@ type
     suggestedRoutes*: string
 
 type
-  PendingTxCompletedArgs* = ref object of Args
-    txHash*: string
-
-type
   CryptoServicesArgs* = ref object of Args
     data*: seq[CryptoRampDto]
 type
@@ -186,11 +182,6 @@ QtObject:
       let address = watchTxResult["address"].getStr
       let transactionReceipt = transactions.getTransactionReceipt(chainId, hash).result
       if transactionReceipt != nil and transactionReceipt.kind != JNull:
-        # Delete pending transaction. Deleting it in status-go didn't work for all the cases
-        # TODO: make delete pending and save transaction atomc in status-go after fixing the crash
-        discard transactions.deletePendingTransaction(chainId, hash)
-
-        echo watchTxResult["data"].getStr
         let ev = TransactionMinedArgs(
           data: watchTxResult["data"].getStr,
           transactionHash: hash,
@@ -203,13 +194,6 @@ QtObject:
   proc watchTransaction*(
     self: Service, hash: string, fromAddress: string, toAddress: string, trxType: string, data: string, chainId: int, track: bool = true
   ) =
-    if track:
-      try:
-        discard transactions.trackPendingTransaction(hash, fromAddress, toAddress, trxType, data, chainId)
-      except Exception as e:
-        let errDescription = e.msg
-        error "error: ", errDescription
-
     let arg = WatchTransactionTaskArg(
       chainId: chainId,
       hash: hash,

--- a/src/backend/transactions.nim
+++ b/src/backend/transactions.nim
@@ -54,29 +54,8 @@ proc getTransfersByAddress*(chainId: int, address: string, toBlock: Uint256, lim
 
   core.callPrivateRPC("wallet_getTransfersByAddressAndChainID", %* [chainId, address, toBlockParsed, limitAsHexWithoutLeadingZeros, loadMore])
 
-proc trackPendingTransaction*(hash: string, fromAddress: string, toAddress: string, trxType: string, data: string, chainId: int):
-  RpcResponse[JsonNode] {.raises: [Exception].} =
-  let payload = %* [{
-    "hash": hash,
-    "from": fromAddress,
-    "to": toAddress,
-    "type": trxType,
-    "additionalData": data,
-    "data": "",
-    "value": 0,
-    "timestamp": 0,
-    "gasPrice": 0,
-    "gasLimit": 0,
-    "network_id": chainId
-  }]
-  core.callPrivateRPC("wallet_storePendingTransaction", payload)
-
 proc getTransactionReceipt*(chainId: int, transactionHash: string): RpcResponse[JsonNode] {.raises: [Exception].} =
   core.callPrivateRPCWithChainId("eth_getTransactionReceipt", chainId, %* [transactionHash])
-
-proc deletePendingTransaction*(chainId: int, transactionHash: string): RpcResponse[JsonNode] {.raises: [Exception].} =
-  let payload = %* [chainId, transactionHash]
-  result = core.callPrivateRPC("wallet_deletePendingTransactionByChainID", payload)
 
 proc fetchCryptoServices*(): RpcResponse[JsonNode] {.raises: [Exception].} =
   result = core.callPrivateRPC("wallet_getCryptoOnRamps", %* [])


### PR DESCRIPTION
- Storing and deleting pending transactions is moved to status-go side.
- ~Moved handling of "new-transfers" and "history-ready" events to activity controller~ Was done by Stefan with #11411 commit while I was absent.

### NOTE
- Watching pending transactions is still called from NIM. When watching pending transactions is moved to status-go, watching must be restarted after app restart to make sure proper events are fired and pending transactions are deleted from DB in any case.
This should be done in #11139

### ISSUES
- ~Pending transaction is not returned by activity controller in response to `updateFilter` call. I made sure pending transaction is added to `pending_transaction` table correctly and removed from it once the tx is confiirmed. The issue must be either in SQL query or propagating pending transactions to UI~ Should have been fixed
- After send transaction is made and loaded from blockchain, it is not properly filled in Activity UI - no value, no address, no other data

## To test:
- Pending transactions are visible on activity tab after sending ETH/tokens
- When pending transaction is confirmed it should become normal transaction with all the needed data filled in. (There might be slight delay or transaction duplication for a short (less than 10 seconds) period of time after transaction is confirmed, but that will be fixed in #11139 

Closes #10474
