### PR TITLE
fix: Permission types are broken when creating new token permission

### DIFF
--- a/ui/app/AppLayouts/Communities/views/EditPermissionView.qml
+++ b/ui/app/AppLayouts/Communities/views/EditPermissionView.qml
@@ -14,6 +14,7 @@ import shared.panels 1.0
 import AppLayouts.Communities.helpers 1.0
 import AppLayouts.Communities.popups 1.0
 import AppLayouts.Communities.panels 1.0
+import AppLayouts.Communities.controls 1.0
 
 StatusScrollView {
     id: root


### PR DESCRIPTION
add the necessary import; was gone due to some recent refactorings

Fixes #11372

### What does the PR do

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas

EditPermissionsView

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![image](https://github.com/status-im/status-desktop/assets/5377645/c7195d1c-c98a-4822-acc2-174a2a8f00d9)

