### PR TITLE
feat(@desktop/wallet): Loading state for input data decoding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,9 +146,11 @@ QML_DEBUG ?= false
 QML_DEBUG_PORT ?= 49152
 
 ifneq ($(QML_DEBUG), false)
+ STATUSQ_BUILD_TYPE=Debug
  DOTHERSIDE_CMAKE_PARAMS := -DCMAKE_BUILD_TYPE=Debug -DQML_DEBUG_PORT=$(QML_DEBUG_PORT)
  DOTHERSIDE_BUILD_CMD := cmake --build . --config Debug
 else
+ STATUSQ_BUILD_TYPE=Release
  DOTHERSIDE_CMAKE_PARAMS := -DCMAKE_BUILD_TYPE=Release
  DOTHERSIDE_BUILD_CMD := cmake --build . --config Release
 endif
@@ -259,7 +261,7 @@ STATUSQ_CMAKE_CACHE := $(STATUSQ_BUILD_PATH)/CMakeCache.txt
 $(STATUSQ_CMAKE_CACHE): | deps
 	echo -e "\033[92mConfiguring:\033[39m StatusQ"
 	cmake -DCMAKE_INSTALL_PREFIX=$(STATUSQ_INSTALL_PATH) \
-		-DCMAKE_BUILD_TYPE=Release \
+		-DCMAKE_BUILD_TYPE=$(STATUSQ_BUILD_TYPE) \
 		-DSTATUSQ_BUILD_SANDBOX=OFF \
 		-DSTATUSQ_BUILD_SANITY_CHECKER=OFF \
 		-DSTATUSQ_BUILD_TESTS=OFF \
@@ -275,7 +277,7 @@ statusq-build: | statusq-configure
 	echo -e "\033[92mBuilding:\033[39m StatusQ"
 	cmake --build $(STATUSQ_BUILD_PATH) \
 		--target StatusQ \
-		--config Release \
+		--config $(STATUSQ_BUILD_TYPE) \
 		$(HANDLE_OUTPUT)
 
 statusq-install: | statusq-build

--- a/ui/StatusQ/src/StatusQ/Components/StatusListItem.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusListItem.qml
@@ -86,6 +86,8 @@ Rectangle {
     property alias errorIcon: errorIcon
     property alias statusListItemTagsRowLayout: statusListItemSubtitleTagsRow
 
+    property int subTitleBadgeLoaderAlignment: Qt.AlignVCenter
+
     signal clicked(string itemId, var mouse)
     signal titleClicked(string titleId)
     signal iconClicked(var mouse)
@@ -279,7 +281,7 @@ Rectangle {
 
                 Loader {
                     id: subTitleBadgeLoader
-                    Layout.alignment: Qt.AlignVCenter
+                    Layout.alignment: root.subTitleBadgeLoaderAlignment
                     visible: sourceComponent
                 }
 

--- a/ui/imports/shared/controls/TransactionDataTile.qml
+++ b/ui/imports/shared/controls/TransactionDataTile.qml
@@ -89,6 +89,7 @@ StatusListItem {
     statusListItemTagsRowLayout.spacing: 8
     subTitleBadgeComponent: !!asset.name ? iconComponent : null
     statusListItemIcon.asset: StatusAssetSettings {}
+    statusListItemIcon.name: ""
 
     Component {
         id: iconComponent


### PR DESCRIPTION
closes #11333 

### What does the PR do

* Added loading state for input data tile while decoding is in progress

Additional:
* Updated StatusQ build type when building in QML debug mode
* Updated `Network` field to display icon aligned to top

### Affected areas

Wallet Activity UI

### Screenshot of functionality (including design for comparison)

![image](https://github.com/status-im/status-desktop/assets/11396062/455825c7-4502-4931-9595-b535648bdbc5)

![image](https://github.com/status-im/status-desktop/assets/11396062/b779940b-2041-4d93-beb8-c7e11c3b7ed9)

![image](https://github.com/status-im/status-desktop/assets/11396062/c16dfbb1-40b7-4328-8a06-888102fdc186)

