### PR TITLE
Minting: Improved binding from token model to CommunityTokenView and other fixes

### DIFF
--- a/storybook/pages/CommunityTokenViewPage.qml
+++ b/storybook/pages/CommunityTokenViewPage.qml
@@ -111,14 +111,14 @@ SplitView {
                             id: isAssetRadioButton
 
                             readonly property int type:
-                                TokenObject.Type.Asset
+                                Constants.TokenType.ERC20
 
                             text: "Asset"
                         }
 
                         RadioButton {
                             readonly property int type:
-                                TokenObject.Type.Collectible
+                                Constants.TokenType.ERC721
 
                             checked: true
                             text: "Collectible"

--- a/ui/app/AppLayouts/Communities/helpers/TokenObject.qml
+++ b/ui/app/AppLayouts/Communities/helpers/TokenObject.qml
@@ -8,11 +8,7 @@ import utils 1.0
     \brief Token object properties definition.
 */
 QtObject {
-    enum Type {
-        Asset, Collectible
-    }
-
-    property int type: TokenObject.Type.Asset
+    property int type: Constants.TokenType.ERC20
 
     // Unique identifier:
     property string key

--- a/ui/app/AppLayouts/Communities/views/CommunityTokenView.qml
+++ b/ui/app/AppLayouts/Communities/views/CommunityTokenView.qml
@@ -21,7 +21,7 @@ StatusScrollView {
     property bool preview: false
 
     // https://bugreports.qt.io/browse/QTBUG-84269
-    /* readonly */ property TokenObject token
+    /* required */ property TokenObject token
 
     readonly property bool isAssetView: token.type === Constants.TokenType.ERC20
 
@@ -43,6 +43,9 @@ StatusScrollView {
     readonly property bool transferable: token.transferable
     readonly property string chainIcon: token.chainIcon
     readonly property int decimals: token.decimals
+
+    readonly property bool deploymentCompleted:
+        deployState === Constants.ContractTransactionStatus.Completed
 
     // Models:
     property var tokenOwnersModel
@@ -83,8 +86,7 @@ StatusScrollView {
         spacing: Style.current.padding
 
         RowLayout {
-            visible: !root.preview && ((root.deployState === Constants.ContractTransactionStatus.InProgress) ||
-                                       (root.deployState === Constants.ContractTransactionStatus.Failed))
+            visible: !root.preview && !root.deploymentCompleted
             spacing: Style.current.halfPadding
 
             StatusDotsLoadingIndicator { visible: (root.deployState === Constants.ContractTransactionStatus.InProgress) }
@@ -338,7 +340,7 @@ StatusScrollView {
         }
 
         SortableTokenHoldersPanel {
-            visible: !root.preview
+            visible: !root.preview && root.deploymentCompleted
 
             model: root.tokenOwnersModel
             tokenName: root.name

--- a/ui/app/AppLayouts/Communities/views/CommunityTokenView.qml
+++ b/ui/app/AppLayouts/Communities/views/CommunityTokenView.qml
@@ -23,7 +23,7 @@ StatusScrollView {
     // https://bugreports.qt.io/browse/QTBUG-84269
     /* readonly */ property TokenObject token
 
-    readonly property bool isAssetView: token.type === TokenObject.Type.Asset
+    readonly property bool isAssetView: token.type === Constants.TokenType.ERC20
 
     readonly property string name: token.name
     readonly property string description: token.description

--- a/ui/app/AppLayouts/Communities/views/EditCommunityTokenView.qml
+++ b/ui/app/AppLayouts/Communities/views/EditCommunityTokenView.qml
@@ -27,11 +27,11 @@ StatusScrollView {
 
 
     property TokenObject collectible: TokenObject {
-        type: TokenObject.Type.Collectible
+        type: Constants.TokenType.ERC721
     }
 
     property TokenObject asset: TokenObject{
-        type: TokenObject.Type.Asset
+        type: Constants.TokenType.ERC20
     }
 
     // Used for reference validation when editing a failed deployment

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -948,8 +948,8 @@ QtObject {
 
     enum TokenType {
         Unknown = 0,
-        ERC20 = 1,
-        ERC721 = 2
+        ERC20 = 1, // Asset
+        ERC721 = 2 // Collectible
     }
 
     // Mirrors src/backend/activity.nim ActivityStatus


### PR DESCRIPTION
### What does the PR do

- Improved binding from token model to `CommunityTokenView` instance (instantiating whole view as a Repeater delegate)
- `Constants.TokenType` used consistently, `TokenObject.Type` enum removed
- `CommunityTokenView` - holdings list hidden when token not deployed

Closes: https://github.com/status-im/status-desktop/issues/11387
Closes: https://github.com/status-im/status-desktop/issues/11384
Closes: https://github.com/status-im/status-desktop/issues/11386

### Affected areas
`TokenObject`, `MintTokensSettingsPanel`, `CommunityTokenView`, `EditCommunityTokenView`

### Screenshot of functionality (including design for comparison)

https://github.com/status-im/status-desktop/assets/20650004/491c443d-9ef6-4a3a-afac-16b50ea0863e

