### PR TITLE
ci: upgrade docker image to Ubuntu 20.04

### DIFF
--- a/build-linux.sh
+++ b/build-linux.sh
@@ -13,5 +13,5 @@ docker run -it --rm \
   -u jenkins:$(getent group $(whoami) | cut -d: -f3) \
   -v "${PWD}:/status-desktop" \
   -w /status-desktop \
-  statusteam/nim-status-client-build:1.2.1-qt5.15.2 \
+  statusteam/nim-status-client-build:1.3.0-qt5.15.2 \
   ./docker-linux-app-image.sh

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,7 +1,7 @@
 ARG QT_VERSION=5.15.2
 
 # QT Installation Image --------------------------------------------------------
-FROM ubuntu:18.04 AS qt-install
+FROM ubuntu:20.04 AS qt-install
 
 ARG QT_VERSION
 
@@ -17,7 +17,7 @@ RUN python3 -m pip install setuptools \
  && python3 -m aqt install --output /opt/qt ${QT_VERSION} linux desktop -m qtwebengine
 
 # Build Image ------------------------------------------------------------------
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 ARG LINUXDEPLOYQT_VERSION=continuous
 ARG QT_VERSION
@@ -41,7 +41,7 @@ RUN apt update -yq && apt install -yq software-properties-common \
  && add-apt-repository -y ppa:ubuntu-toolchain-r/test \
  && apt update -yq && apt full-upgrade -yq && apt install -yq --no-install-recommends --fix-missing  \
     gnupg2 openssh-client ca-certificates locales sudo jq curl wget fuse s3cmd file llvm tk-dev xz-utils \
-    git make build-essential pkg-config cmake extra-cmake-modules gcc-9 g++-9 \
+    git make build-essential pkg-config extra-cmake-modules gcc-9 g++-9 \
     libgl1-mesa-dev libsm6 libice6 libfontconfig1 libdbus-1-3 libssl-dev libz-dev \
     zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev unixodbc-dev libpq-dev \
     libncurses5-dev libncursesw5-dev libpcsclite-dev  libpcre3-dev libnss3 \

--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -5,10 +5,10 @@ def isPRBuild = utils.isPRBuild()
 
 pipeline {
   agent {
-    /* Necessary image with Ubuntu 18.04 for older Glibc. */
+    /* Necessary image with Ubuntu 20.04 for older Glibc. */
     docker {
       label 'linux'
-      image 'statusteam/nim-status-client-build:1.2.2-qt5.15.2'
+      image 'statusteam/nim-status-client-build:1.3.0-qt5.15.2'
       /* allows jenkins use cat and mounts '/dev/fuse' for linuxdeployqt */
       args '--entrypoint="" --cap-add SYS_ADMIN --security-opt apparmor:unconfined --device /dev/fuse'
     }

--- a/ci/README.md
+++ b/ci/README.md
@@ -7,7 +7,7 @@ https://ci.status.im/job/nim-status-client/
 
 ## Linux
 
-In order to build the Linux version of the application we use the ubuntu:18.04 Docker image where we install the Qt 5.15.2 provided by [aqt](https://github.com/miurahr/aqtinstall), linuxdeployqt provided by https://github.com/probonopd/linuxdeployqt and other dependencies (go, cmake, gcc etc.). We're using Ubuntu 18.04 to ensure glibc compatibility with the oldest still-supported LTS release and to comply with linuxdeployqt requirements.
+In order to build the Linux version of the application we use the `ubuntu:20.04` Docker image where we install the Qt 5.15.2 provided by [aqt](https://github.com/miurahr/aqtinstall), linuxdeployqt provided by https://github.com/probonopd/linuxdeployqt and other dependencies (go, cmake, gcc etc.). We're using Ubuntu 20.04 to ensure glibc compatibility with the oldest still-supported LTS release and to comply with linuxdeployqt requirements.
 
 The image is built with [`Dockerfile`](./Dockerfile) using:
 ```


### PR DESCRIPTION
Ubuntu 18.04 LTS support has ended on the 31st of May 2023. It's about time we upgraded to 20.04, which uses Glibc `2.31` instead of `2.27`.