### PR TITLE
fix(EditPermissionView): Dirty state validation fixed

### DIFF
--- a/ui/app/AppLayouts/Communities/views/EditPermissionView.qml
+++ b/ui/app/AppLayouts/Communities/views/EditPermissionView.qml
@@ -79,7 +79,7 @@ StatusScrollView {
         modelA: root.dirtyValues.selectedChannelsModel
         modelB: root.selectedChannelsModel
 
-        roles: ["itemId"]
+        roles: ["key"]
         mode: ModelsComparator.CompareMode.Set
     }
 


### PR DESCRIPTION
### What does the PR do

It solves problem with detecting dirty state in "Edit permission" form when changing channels in `In` section. The issue was caused by changed role name in the model of channels.

Closes: #11063

### Screenshot of functionality (including design for comparison)

https://github.com/status-im/status-desktop/assets/20650004/83c6530d-17b6-4630-a02b-28cc281935e2


