### PR TITLE
fix(Community Permissions): handling collectible icons fixed

### DIFF
--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -48,11 +48,11 @@ QtObject {
         sourceModel: communitiesModuleInst.collectiblesModel
 
         proxyRoles: ExpressionRole {
-            function icon(icon) {
+            function collectibleIcon(icon) {
                 return !!icon ? icon : Style.png("tokens/DEFAULT-TOKEN")
             }
             name: "iconSource"
-            expression: icon(model.icon)
+            expression: collectibleIcon(model.icon)
         }
     }
 


### PR DESCRIPTION
Closes: #11297

### What does the PR do

Fixes collectible icons in community permissions.

### Affected areas
`AppLayouts/Chat/stores/RootStore.qml`

### Screenshot of functionality (including design for comparison)


https://github.com/status-im/status-desktop/assets/20650004/42090deb-4cfb-463b-b9e7-be783f70cc37

