### PR TITLE
Refresh filter on pending 11233

### DIFF
--- a/src/app/modules/main/wallet_section/activity/controller.nim
+++ b/src/app/modules/main/wallet_section/activity/controller.nim
@@ -110,7 +110,7 @@ QtObject:
       let response = backend.getTransfersForIdentities(transactionIdentities)
       let res = response.result
       if response.error != nil or res.kind != JArray or res.len == 0:
-        raise newException(Defect, "failed fetching transaction details")
+        error "failed fetching transaction details; err: ", response.error, ", kind: ", res.kind, ", res.len: ", res.len
 
       let transactionsDtos = res.getElems().map(x => x.toTransactionDto())
       let trItems = self.transactionsModule.transactionsToItems(transactionsDtos, @[])
@@ -122,7 +122,7 @@ QtObject:
       let response = backend.getPendingTransactionsForIdentities(pendingTransactionIdentities)
       let res = response.result
       if response.error != nil or res.kind != JArray or res.len == 0:
-        raise newException(Defect, "failed fetching pending transactions details")
+        error "failed fetching pending transactions details; err: ", response.error, ", kind: ", res.kind, ", res.len: ", res.len
 
       let pendingTransactionsDtos = res.getElems().map(x => x.toPendingTransactionDto())
       let trItems = self.transactionsModule.transactionsToItems(pendingTransactionsDtos, @[])
@@ -174,12 +174,12 @@ QtObject:
     if res.errorCode != ErrorCodeSuccess:
       error "error fetching activity entries: ", res.errorCode
       return
-    
-    try: 
-      let entries = self.backendToPresentation(res.activities)
-      self.model.setEntries(entries, res.offset, res.hasMore)
-    except Exception as e:
-      error "Error converting activity entries: ", e.msg
+
+    let entries = self.backendToPresentation(res.activities)
+    self.model.setEntries(entries, res.offset, res.hasMore)
+
+    if len(entries) > 0:
+      self.eventsHandler.updateRelevantTimestamp(entries[len(entries) - 1].getTimestamp())
 
   proc updateFilter*(self: Controller) {.slot.} =
     self.status.setLoadingData(true)

--- a/src/backend/activity.nim
+++ b/src/backend/activity.nim
@@ -1,4 +1,4 @@
-import times, strformat, options
+import times, strformat, options, logging
 import json, json_serialization
 import core, response_type
 import stint
@@ -289,9 +289,12 @@ proc fromJson*(e: JsonNode, T: typedesc[FilterResponse]): FilterResponse {.inlin
   var backendEntities: seq[ActivityEntry]
   if e.hasKey("activities"):
     let jsonEntries = e["activities"]
-    backendEntities = newSeq[ActivityEntry](jsonEntries.len)
-    for i in 0 ..< jsonEntries.len:
-      backendEntities[i] = fromJson(jsonEntries[i], ActivityEntry)
+    if jsonEntries.kind == JArray:
+      backendEntities = newSeq[ActivityEntry](jsonEntries.len)
+      for i in 0 ..< jsonEntries.len:
+        backendEntities[i] = fromJson(jsonEntries[i], ActivityEntry)
+    elif jsonEntries.kind != JNull:
+      error "Invalid activities field in FilterResponse; kind: ", jsonEntries.kind
 
   result = T(
     activities: backendEntities,

--- a/src/backend/transactions.nim
+++ b/src/backend/transactions.nim
@@ -37,6 +37,9 @@ const EventRecentHistoryReady*: string = "recent-history-ready"
 const EventFetchingHistoryError*: string = "fetching-history-error"
 const EventNonArchivalNodeDetected*: string = "non-archival-node-detected"
 
+# Mirrors the pending transfer event from status-go, status-go/services/wallet/transfer/transaction.go
+const EventPendingTransactionUpdate*: string = "pending-transaction-update"
+
 proc getTransactionByHash*(chainId: int, hash: string): RpcResponse[JsonNode] {.raises: [Exception].} =
   core.callPrivateRPCWithChainId("eth_getTransactionByHash", chainId, %* [hash])
 


### PR DESCRIPTION
### Updates #11233

Bump status-go to include events: https://github.com/status-im/status-go/pull/3721
Process pending updates events and trigger button show

Also: improve parsing of the activity entry

- [x] Pending displays forever
  - Root cause found here: https://github.com/status-im/status-desktop/issues/11404#issuecomment-1623849498
- [x] Moving from pending to transfers doesn't trigger any notification
  - renamed new-pending notification in pending updates and triggered it also on delete
