### PR TITLE
fix(CommunitySettingsView): Add expected roles to assets/collectibles models

### DIFF
--- a/ui/app/AppLayouts/Communities/views/CommunitySettingsView.qml
+++ b/ui/app/AppLayouts/Communities/views/CommunitySettingsView.qml
@@ -388,6 +388,10 @@ StatusSectionLayout {
                         ExpressionRole {
                             name: "key"
                             expression: model.symbol
+                        },
+                        ExpressionRole {
+                            name: "communityId"
+                            expression: ""
                         }
                     ]
                 }
@@ -419,6 +423,10 @@ StatusSectionLayout {
                         ExpressionRole {
                             name: "key"
                             expression: model.symbol
+                        },
+                        ExpressionRole {
+                            name: "communityId"
+                            expression: ""
                         }
                     ]
                 }


### PR DESCRIPTION
### What does the PR do

The same components are used to display data from rootStore.assetsModel, rootStore.collectiblesModel (permissions) and
root.community.communityTokens (airdrops). The models have different roles and need adjustments before passing to ui components.

Closes: #11309

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas

<!-- List the affected areas (e.g wallet, browser, etc..) -->

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

https://github.com/status-im/status-desktop/assets/20650004/0992262a-2ac9-43f2-a6fa-e6c2e9b3da4f


