### PR TITLE
fix(@desktop/wallet): Send modal don't expand vertically

### DIFF
--- a/storybook/pages/SendModalPage.qml
+++ b/storybook/pages/SendModalPage.qml
@@ -46,10 +46,21 @@ SplitView {
                             for (let i = 0; i < 10; i++)
                                 append({
                                     name: "some saved addr name " + i,
-                                    ens: []
+                                    ens: [],
+                                    address: "0x2B748A02e06B159C7C3E98F5064577B96E55A7b4",
+                                    chainShortNames: "eth:arb"
                                 })
                         }
                     }
+
+                    function splitAndFormatAddressPrefix(textAddrss, isBridgeTx, showUnpreferredNetworks) {
+                        return textAddrss
+                    }
+
+                    function resolveENS() {
+                        return ""
+                    }
+
 
                     readonly property string currentCurrency: "USD"
 

--- a/ui/imports/shared/popups/SendModal.qml
+++ b/ui/imports/shared/popups/SendModal.qml
@@ -99,7 +99,7 @@ StatusDialog {
 
     width: 556
     topMargin: 64 + header.height
-    bottomPadding: footer.visible ? 0 : 32
+    bottomPadding: footer.visible ? footer.height : 32
 
     padding: 0
     background: StatusDialogBackground {
@@ -398,7 +398,6 @@ StatusDialog {
 
                     TabAddressSelectorView {
                         id: addressSelector
-                        width: parent.width
                         anchors.left: parent.left
                         anchors.right: parent.right
                         anchors.leftMargin: Style.current.bigPadding
@@ -414,7 +413,6 @@ StatusDialog {
 
                     NetworkSelector {
                         id: networkSelector
-                        width: parent.width
                         anchors.left: parent.left
                         anchors.right: parent.right
                         anchors.leftMargin: Style.current.bigPadding
@@ -438,7 +436,6 @@ StatusDialog {
 
                     FeesView {
                         id: fees
-                        width: parent.width
                         anchors.left: parent.left
                         anchors.right: parent.right
                         anchors.leftMargin: Style.current.bigPadding

--- a/ui/imports/shared/views/NetworkCardsComponent.qml
+++ b/ui/imports/shared/views/NetworkCardsComponent.qml
@@ -71,7 +71,6 @@ Item {
     onBestRoutesChanged: d.draw()
     onErrorModeChanged: if(errorMode) d.draw()
 
-    width: 410
     height: visible ? networkCardsLayout.height : 0
 
     RowLayout {

--- a/ui/imports/shared/views/NetworkSelector.qml
+++ b/ui/imports/shared/views/NetworkSelector.qml
@@ -108,6 +108,7 @@ Item {
                 anchors.top: parent.top
                 anchors.left: parent.left
                 anchors.margins: Style.current.padding
+                width: stackLayout.width - Style.current.xlPadding
                 store: root.store
                 customMode: tabBar.currentIndex === 2
                 selectedAccount: root.selectedAccount

--- a/ui/imports/shared/views/NetworksAdvancedCustomRoutingView.qml
+++ b/ui/imports/shared/views/NetworksAdvancedCustomRoutingView.qml
@@ -35,6 +35,7 @@ ColumnLayout {
     signal reCalculateSuggestedRoute()
 
     RowLayout {
+        Layout.fillWidth: true
         spacing: 10
 
         StatusRoundIcon {
@@ -47,9 +48,9 @@ ColumnLayout {
             Layout.alignment: Qt.AlignTop
             Layout.fillWidth: true
             RowLayout {
-                Layout.maximumWidth: 410
+                Layout.fillWidth: true
                 StatusBaseText {
-                    Layout.maximumWidth: 410
+                    Layout.fillWidth: true
                     font.pixelSize: 15
                     font.weight: Font.Medium
                     color: Theme.palette.directColor1
@@ -72,7 +73,7 @@ ColumnLayout {
                 }
             }
             StatusBaseText {
-                Layout.maximumWidth: 410
+                Layout.fillWidth: true
                 font.pixelSize: 15
                 color: Theme.palette.baseColor1
                 text: qsTr("The networks where the receipient will receive tokens. Amounts calculated automatically for the lowest cost.")
@@ -80,6 +81,8 @@ ColumnLayout {
             }
             Loader {
                 id: networksLoader
+                Layout.fillWidth: true
+                Layout.preferredHeight: item.height
                 Layout.topMargin: Style.current.padding
                 visible: active
                 sourceComponent: NetworkCardsComponent {

--- a/ui/imports/shared/views/NetworksSimpleRoutingView.qml
+++ b/ui/imports/shared/views/NetworksSimpleRoutingView.qml
@@ -82,6 +82,7 @@ RowLayout {
             Layout.fillWidth: true
             Layout.alignment: Qt.AlignHCenter
             Layout.topMargin: Style.current.smallPadding
+            Layout.rightMargin: Style.current.padding
             amountToSend: root.amountToSend
             errorType: root.errorType
             isLoading: root.isLoading && !root.isBridgeTx

--- a/ui/imports/shared/views/RecipientView.qml
+++ b/ui/imports/shared/views/RecipientView.qml
@@ -43,6 +43,7 @@ Loader {
                     d.isPending = true
                     return  store.resolveENS(root.selectedRecipient.ens)
                 }
+                break
             }
             case TabAddressSelectorView.Type.RecentsAddress: {
                 let isIncoming = root.selectedRecipient.to === root.selectedRecipient.address
@@ -52,6 +53,7 @@ Loader {
             }
             case TabAddressSelectorView.Type.Address: {
                 root.item.input.text = root.selectedRecipient.address
+                break
             }
             }
             root.addressText = root.selectedRecipient.address


### PR DESCRIPTION
fuixes #11352

### What does the PR do

Fixes the issue of the simple networks view not displaying completely on the UI.


### Affected areas

SendModal

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it


https://github.com/status-im/status-desktop/assets/60327365/c113bfaa-9fbd-49f8-97e4-1bb8c709c97a


