### PR TITLE
[CHERRY-PICK] ci: fix read-only FS errors in AppImage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -446,7 +446,7 @@ endif
 
 NIM_PARAMS += -d:chronicles_sinks=textlines[stdout],textlines[nocolors,dynamic],textlines[file,nocolors] -d:chronicles_runtime_filtering=on -d:chronicles_default_output_device=dynamic
 
-RESOURCES_LAYOUT := -d:development
+RESOURCES_LAYOUT ?= -d:development
 
 # When modifying files that are not tracked in NIM_SOURCES (see below),
 # e.g. vendor/*.nim, REBUILD_NIM=true can be supplied to `make` to ensure a

--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -79,6 +79,11 @@ pipeline {
     }
 
     stage('Client') {
+      environment {
+        /* Hack-fix for wrong config path location causing:
+         * Error: unhandled exception: Read-only file system */
+        RESOURCES_LAYOUT = '-d:production'
+      }
       steps { script {
         /* Temporary hack-fix for failing Linux builds:
          * https://github.com/status-im/infra-ci/issues/88 */

--- a/ci/Jenkinsfile.tests-e2e
+++ b/ci/Jenkinsfile.tests-e2e
@@ -96,6 +96,9 @@ pipeline {
     stage('build') {
       environment {
         GANACHE_NETWORK_RPC_URL = "http://localhost:${env.GANACHE_RPC_PORT}"
+        /* Hack-fix for wrong config path location causing:
+         * Error: unhandled exception: Read-only file system */
+        RESOURCES_LAYOUT = '-d:production'
       }
 
       steps { script {


### PR DESCRIPTION
Cherry-pick of https://github.com/status-im/status-desktop/pull/11427

After a LOT of work from @jrainville bisecting the release branch he identified the issue to be this commit:
https://github.com/status-im/status-desktop/commit/dad8e453 ci: bump client build retries to 20

Which actually was poorly squashed by @iurimatias and contains the commit that also adds the retries in the first place: https://github.com/status-im/status-desktop/commit/a5ba2537 ci: retry nim_status_client build 3 times

The reason why that's an issue is because normally it was caled by `make tgz-linux` target which included this setting:
```
override RESOURCES_LAYOUT := $(PRODUCTION_PARAMETERS)
```
Which caused `NIM_PARAMS` to use `-d:development` instead of `-d:production`. The result was the app trying to write config file changes to the read-only filesystem of the AppImage.

Resolves: https://github.com/status-im/status-desktop/issues/11295