### PR TITLE
fix(Edit community settings): Fixing width after merge error

### DIFF
--- a/ui/app/AppLayouts/Communities/controls/EditCommunitySettingsForm.qml
+++ b/ui/app/AppLayouts/Communities/controls/EditCommunitySettingsForm.qml
@@ -36,8 +36,9 @@ Control {
     property alias bannerPath: bannerPicker.source
     property alias bannerCropRect: bannerPicker.cropRect
     
-    contentItem: ColumnLayout {
-        implicitWidth: 608
+    implicitWidth: 608
+
+    contentItem: ColumnLayout {    
         spacing: 16
 
         NameInput {


### PR DESCRIPTION
### What does the PR do
Related to #11323
Fixing Edit Community Form width
<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas
Edit community panel
Create community popup
<!-- List the affected areas (e.g wallet, browser, etc..) -->
### Functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

<!-- screenshot (or gif/video) that demonstrates the functionality, specially important if it's a bug fix. -->
<img width="719" alt="Screenshot 2023-07-06 at 11 51 39" src="https://github.com/status-im/status-desktop/assets/47811206/17f4616e-8245-41bb-8a26-0ccb0a0d521e">
