### PR TITLE
fix: Increase keycard popup width

### DIFF
--- a/ui/imports/shared/popups/keycard/KeycardPopup.qml
+++ b/ui/imports/shared/popups/keycard/KeycardPopup.qml
@@ -12,6 +12,7 @@ StatusModal {
     property var sharedKeycardModule
     property var emojiPopup
 
+    width: Constants.keycard.general.popupWidth
     closePolicy: d.disableActionPopupButtons || d.disableCloseButton? Popup.NoAutoClose : Popup.CloseOnEscape | Popup.CloseOnPressOutside
     hasCloseButton: !d.disableActionPopupButtons && !d.disableCloseButton
 


### PR DESCRIPTION
### What does the PR do
Closing #11335 

Increase the keycard popup with to predefined value.
<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas
Keycard popup
<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Screenshot of functionality (including design for comparison)
<img width="640" alt="Screenshot 2023-07-06 at 16 56 44" src="https://github.com/status-im/status-desktop/assets/47811206/699a6757-e5ec-421c-8bf2-f48b0674eef5">

