### PR TITLE
feat(wallet) handle multi-transaction update events for activity filter

### DIFF
--- a/src/app/modules/main/wallet_section/activity/controller.nim
+++ b/src/app/modules/main/wallet_section/activity/controller.nim
@@ -186,6 +186,7 @@ QtObject:
     self.status.setIsFilterDirty(false)
     self.model.resetModel(@[])
     self.eventsHandler.updateSubscribedAddresses(self.addresses)
+    self.eventsHandler.updateSubscribedChainIDs(self.chainIds)
     self.status.setNewDataAvailable(false)
 
     let response = backend_activity.filterActivityAsync(self.addresses, seq[backend_activity.ChainId](self.chainIds), self.currentActivityFilter, 0, FETCH_BATCH_COUNT_DEFAULT)

--- a/src/backend/transactions.nim
+++ b/src/backend/transactions.nim
@@ -39,6 +39,7 @@ const EventNonArchivalNodeDetected*: string = "non-archival-node-detected"
 
 # Mirrors the pending transfer event from status-go, status-go/services/wallet/transfer/transaction.go
 const EventPendingTransactionUpdate*: string = "pending-transaction-update"
+const EventMTTransactionUpdate*: string = "multi-transaction-update"
 
 proc getTransactionByHash*(chainId: int, hash: string): RpcResponse[JsonNode] {.raises: [Exception].} =
   core.callPrivateRPCWithChainId("eth_getTransactionByHash", chainId, %* [hash])


### PR DESCRIPTION
### Closes #11233

Bumps status-go https://github.com/status-im/status-go/pull/3731

Handle ChainIDs also (don't show new data if not from the enabled chains)
Throttle down new data in filter events to show the activity at a maximum every two seconds.