### PR TITLE
fix(community): Trim emojis in channels

### DIFF
--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -325,7 +325,7 @@ QtObject {
     function createCommunityChannel(channelName, channelDescription, channelEmoji, channelColor,
             categoryId) {
         chatCommunitySectionModule.createCommunityChannel(channelName, channelDescription,
-            channelEmoji, channelColor, categoryId);
+            channelEmoji.trim(), channelColor, categoryId);
     }
 
     function editCommunityChannel(chatId, newName, newDescription, newEmoji, newColor,


### PR DESCRIPTION
Fixes: #11443

### What does the PR do

Trim emoji for community channels on create step. Its hard to test result because both sides (mobile and desktop) trim it in UI.

### Affected areas

Community channels
 
### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

