### PR TITLE
fix(@desktop/onboarding): the app crashes when converting a keycard to a regular account, or just being in loading state forever

### DIFF
--- a/src/app/modules/startup/module.nim
+++ b/src/app/modules/startup/module.nim
@@ -163,6 +163,9 @@ method moveToAppState*[T](self: Module[T]) =
 method moveToStartupState*[T](self: Module[T]) =
   self.view.setAppState(AppState.StartupState)
 
+proc moveToAppEncryptionProcessState[T](self: Module[T]) =
+  self.view.setAppState(AppState.AppEncryptionProcessState)
+
 method startUpUIRaised*[T](self: Module[T]) =
   self.view.startUpUIRaised()
 
@@ -412,7 +415,6 @@ method onNodeLogin*[T](self: Module[T], error: string) =
           return
         self.delegate.logout()
         self.view.setCurrentStartupState(newLoginKeycardConvertedToRegularAccountState(currStateObj.flowType(), nil))
-        self.moveToStartupState()
     else:
       let err = self.delegate.userLoggedIn(recoverAccount = false)
       if err.len > 0:
@@ -530,7 +532,13 @@ method onLocalPairingStatusUpdate*[T](self: Module[T], status: LocalPairingStatu
   self.view.onLocalPairingStatusUpdate(status)
 
 method onReencryptionProcessStarted*[T](self: Module[T]) =
-  self.view.onReencryptionProcessStarted()
+  self.moveToAppEncryptionProcessState()
 
 method onReencryptionProcessFinished*[T](self: Module[T]) =
-  self.view.onReencryptionProcessFinished()
+  let currStateObj = self.view.currentStartupStateObj()
+  if not currStateObj.isNil and
+    currStateObj.flowType() == FlowType.LostKeycardConvertToRegularAccount and
+    currStateObj.stateType() == StateType.LoginKeycardConvertedToRegularAccount:
+      self.moveToStartupState()
+      return
+  self.moveToLoadingAppState()

--- a/src/app/modules/startup/view.nim
+++ b/src/app/modules/startup/view.nim
@@ -104,7 +104,7 @@ QtObject:
 
   proc onSecondaryActionClicked*(self: View) {.slot.} =
     self.delegate.onSecondaryActionClicked()
-  
+
   proc onTertiaryActionClicked*(self: View) {.slot.} =
     self.delegate.onTertiaryActionClicked()
 
@@ -373,9 +373,3 @@ QtObject:
 
   proc validateLocalPairingConnectionString*(self: View, connectionString: string): string {.slot.} =
     return self.delegate.validateLocalPairingConnectionString(connectionString)
-
-  proc onReencryptionProcessStarted*(self: View) =
-    self.setAppState(AppState.AppEncryptionProcessState)
-
-  proc onReencryptionProcessFinished*(self: View) =
-    self.setAppState(AppState.AppLoadingState)


### PR DESCRIPTION
- crash was happening because of some issue on the status-go side, rebasing to the latest master resolved that
- app was in loading state forever because of `db.reEncryption.started` and `db.reEncryption.finished` signals emitted for db re-encryption process while conversion from keycard to a regular account is ongoing

Fixes: #11507