### PR TITLE
fix: crash when request to join fails + add error toast when it fails

### DIFF
--- a/src/app/modules/main/communities/controller.nim
+++ b/src/app/modules/main/communities/controller.nim
@@ -90,6 +90,10 @@ proc init*(self: Controller) =
     let args = CommunityRequestArgs(e)
     self.delegate.communityAccessRequested(args.communityRequest.communityId)
 
+  self.events.on(SIGNAL_COMMUNITY_MY_REQUEST_FAILED) do(e:Args):
+    let args = CommunityRequestFailedArgs(e)
+    self.delegate.communityAccessFailed(args.communityId, args.error)
+
   self.events.on(SIGNAL_DISCORD_CATEGORIES_AND_CHANNELS_EXTRACTED) do(e:Args):
     let args = DiscordCategoriesAndChannelsArgs(e)
     self.delegate.discordCategoriesAndChannelsExtracted(args.categories, args.channels, args.oldestMessageTimestamp, args.errors, args.errorsCount)

--- a/src/app/modules/main/communities/io_interface.nim
+++ b/src/app/modules/main/communities/io_interface.nim
@@ -118,6 +118,9 @@ method communityMuted*(self: AccessInterface, communityId: string, muted: bool) 
 method communityAccessRequested*(self: AccessInterface, communityId: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method communityAccessFailed*(self: AccessInterface, communityId: string, error: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method requestExtractDiscordChannelsAndCategories*(self: AccessInterface, filesToImport: seq[string]) {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/communities/module.nim
+++ b/src/app/modules/main/communities/module.nim
@@ -270,6 +270,9 @@ method communityMuted*(self: Module, communityId: string, muted: bool) =
 method communityAccessRequested*(self: Module, communityId: string) =
   self.view.communityAccessRequested(communityId)
 
+method communityAccessFailed*(self: Module, communityId, error: string) =
+  self.view.communityAccessFailed(communityId, error)
+
 method communityHistoryArchivesDownloadStarted*(self: Module, communityId: string) =
   self.view.setDownloadingCommunityHistoryArchives(true)
 

--- a/src/app/modules/main/communities/view.nim
+++ b/src/app/modules/main/communities/view.nim
@@ -109,6 +109,7 @@ QtObject:
   proc discordOldestMessageTimestampChanged*(self: View) {.signal.}
   proc discordImportErrorsCountChanged*(self: View) {.signal.}
   proc communityAccessRequested*(self: View, communityId: string) {.signal.}
+  proc communityAccessFailed*(self: View, communityId: string, error: string) {.signal.}
   proc communityInfoAlreadyRequested*(self: View) {.signal.}
 
   proc communityTagsChanged*(self: View) {.signal.}

--- a/src/app_service/service/community/service.nim
+++ b/src/app_service/service/community/service.nim
@@ -46,6 +46,10 @@ type
   CommunityRequestArgs* = ref object of Args
     communityRequest*: CommunityMembershipRequestDto
 
+  CommunityRequestFailedArgs* = ref object of Args
+    communityId*: string
+    error*: string
+
   CommunityChatOrderArgs* = ref object of Args
     communityId*: string
     chat*: ChatDto
@@ -122,6 +126,7 @@ const SIGNAL_COMMUNITY_DATA_LOADED* = "communityDataLoaded"
 const SIGNAL_COMMUNITY_JOINED* = "communityJoined"
 const SIGNAL_COMMUNITY_SPECTATED* = "communitySpectated"
 const SIGNAL_COMMUNITY_MY_REQUEST_ADDED* = "communityMyRequestAdded"
+const SIGNAL_COMMUNITY_MY_REQUEST_FAILED* = "communityMyRequestFailed"
 const SIGNAL_COMMUNITY_LEFT* = "communityLeft"
 const SIGNAL_COMMUNITY_CREATED* = "communityCreated"
 const SIGNAL_COMMUNITY_ADDED* = "communityAdded"
@@ -1414,21 +1419,23 @@ QtObject:
       error "Error request to join community", msg = e.msg 
     
   proc onAsyncRequestToJoinCommunityDone*(self: Service, communityIdAndRpcResponse: string) {.slot.} =
+    let rpcResponseObj = communityIdAndRpcResponse.parseJson
     try:
-      let rpcResponseObj = communityIdAndRpcResponse.parseJson
-      if (rpcResponseObj{"response"}{"error"}.kind != JNull):
-        let error = Json.decode($rpcResponseObj["response"]["error"], RpcError)
-        error "Error requesting to join community", msg = error.message
-        return
+      if (rpcResponseObj{"error"}.kind != JNull and rpcResponseObj{"error"}.getStr != ""):
+        raise newException(CatchableError, rpcResponseObj{"error"}.getStr)
 
       let rpcResponse = Json.decode($rpcResponseObj["response"], RpcResponse[JsonNode])
       self.activityCenterService.parseActivityCenterResponse(rpcResponse)
       
       if not self.processRequestsToJoinCommunity(rpcResponse.result):
-        error "error: ", procName="onAsyncRequestToJoinCommunityDone", errDesription = "no 'requestsToJoinCommunity' key in response"
+        raise newException(CatchableError, "no 'requestsToJoinCommunity' key in response")
 
     except Exception as e:
       error "Error requesting to join the community", msg = e.msg
+      self.events.emit(SIGNAL_COMMUNITY_MY_REQUEST_FAILED, CommunityRequestFailedArgs(
+        communityId: rpcResponseObj["communityId"].getStr,
+        error: e.msg
+      ))
 
   proc asyncAcceptRequestToJoinCommunity*(self: Service, communityId: string, requestId: string) =
     try:

--- a/ui/app/AppLayouts/Communities/views/CommunityColumnView.qml
+++ b/ui/app/AppLayouts/Communities/views/CommunityColumnView.qml
@@ -87,6 +87,7 @@ Item {
         }
 
         Connections {
+            enabled: joinCommunityButton.loading
             target: root.store.communitiesModuleInst
             function onCommunityAccessRequested(communityId: string) {
                 if (communityId === communityData.id) {
@@ -94,9 +95,22 @@ Item {
                     joinCommunityButton.loading = false
                 }
             }
+            function onCommunityAccessFailed(communityId: string) {
+                if (communityId === communityData.id) {
+                    joinCommunityButton.invitationPending = false
+                    joinCommunityButton.loading = false
+                    Global.displayToastMessage(qsTr("Request to join failed"),
+                            qsTr("Please try again later"),
+                            "",
+                            false,
+                            Constants.ephemeralNotificationType.normal,
+                            "")
+                }
+            }
         }
 
         Connections {
+            enabled: joinCommunityButton.loading
             target: communitySectionModule
             function onUserAuthenticationCanceled() {
                 joinCommunityButton.invitationPending = false


### PR DESCRIPTION
Fixes #11514

The problem was that we were not handling the error from request to join correctly.

Then I added an event that sends a signal to the QML to show a toast about an error. I don't show the actual error to the user because usually it's not super helpful. It will be in the logs.

The status-go change makes it so that we don't save the request to join if the permission check failed.

status-go PR: https://github.com/status-im/status-go/pull/3748