### PR TITLE
fix(@desktop/wallet): Calculate block number approximation

### DIFF
--- a/src/app/modules/main/wallet_section/io_interface.nim
+++ b/src/app/modules/main/wallet_section/io_interface.nim
@@ -87,3 +87,6 @@ method onAddAccountModuleLoaded*(self: AccessInterface) {.base.} =
 
 method destroyAddAccountPopup*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
+
+method getNetworkLayer*(self: AccessInterface, chainId: int): string {.base.} =
+  raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/wallet_section/module.nim
+++ b/src/app/modules/main/wallet_section/module.nim
@@ -325,3 +325,6 @@ method getAddAccountModule*(self: Module): QVariant =
 
 method onAddAccountModuleLoaded*(self: Module) =
   self.view.emitDisplayAddAccountPopup()
+
+method getNetworkLayer*(self: Module, chainId: int): string =
+  return self.networksModule.getNetworkLayer(chainId)

--- a/src/app/modules/main/wallet_section/networks/io_interface.nim
+++ b/src/app/modules/main/wallet_section/networks/io_interface.nim
@@ -24,3 +24,6 @@ method setNetworksState*(self: AccessInterface, chainIds: seq[int], enable: bool
 
 method refreshNetworks*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
+
+method getNetworkLayer*(self: AccessInterface, chainId: int): string {.base.} =
+  raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/wallet_section/networks/module.nim
+++ b/src/app/modules/main/wallet_section/networks/module.nim
@@ -62,3 +62,6 @@ method viewDidLoad*(self: Module) =
 
 method setNetworksState*(self: Module, chainIds: seq[int], enabled: bool) =
   self.controller.setNetworksState(chainIds, enabled)
+
+method getNetworkLayer*(self: Module, chainId: int): string =
+  return self.view.getNetworkLayer(chainId)

--- a/src/app/modules/main/wallet_section/networks/view.nim
+++ b/src/app/modules/main/wallet_section/networks/view.nim
@@ -139,3 +139,6 @@ proc networkEnabledToUxEnabledState(enabled: bool, allEnabled: bool): UxEnabledS
 
 proc areAllEnabled(networks: seq[NetworkDto]): bool =
   return networks.allIt(it.enabled)
+
+proc getNetworkLayer*(self: View, chainId: int): string =
+  return self.all.getNetworkLayer(chainId)

--- a/src/app/modules/main/wallet_section/transactions/io_interface.nim
+++ b/src/app/modules/main/wallet_section/transactions/io_interface.nim
@@ -71,3 +71,6 @@ method getLatestBlockNumber*(self: AccessInterface, chainId: int): string {.base
 
 method transactionsToItems*(self: AccessInterface, transactions: seq[TransactionDto], collectibles: seq[CollectibleDto]): seq[Item] {.base.} =
   raise newException(ValueError, "No implementation available")
+
+method getNetworkLayer*(self: AccessInterface, chainId: int): string {.base.} =
+  raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/wallet_section/transactions/module.nim
+++ b/src/app/modules/main/wallet_section/transactions/module.nim
@@ -143,3 +143,6 @@ method fetchDecodedTxData*(self: Module, txHash: string, data: string) =
 
 method txDecoded*(self: Module, txHash: string, dataDecoded: string) =
   self.view.txDecoded(txHash, dataDecoded)
+
+method getNetworkLayer*(self: Module, chainId: int): string =
+  return self.delegate.getNetworkLayer(chainId)


### PR DESCRIPTION
fixes #11018 

### What does the PR do

* Calculate approximate block number instead of querying it every time.
* Request nawest block number after 10 minutes on request

After some testing values were nearly the same after 10 minutes
* Layer 1 was at most 1 off the current value
* Optimism similar was around 5 off the current value
* Arbitrum had biggest difference, at most 15. Looks like it might not be constant like other ones, but for such small refresh period it is fine.
