### PR TITLE
fix(Chat): Confirmation button UI is broken when deleting 1-1 chat

### DIFF
--- a/storybook/pages/StatusImageCropPanelPage.qml
+++ b/storybook/pages/StatusImageCropPanelPage.qml
@@ -169,7 +169,7 @@ SplitView {
                 StatusModal {
                     id: imageCropperModal
 
-                    header.title: workflowItem.title
+                    headerSettings.title: workflowItem.title
 
                     anchors.centerIn: Overlay.overlay
 

--- a/ui/StatusQ/sandbox/DemoApp.qml
+++ b/ui/StatusQ/sandbox/DemoApp.qml
@@ -206,8 +206,8 @@ Rectangle {
     Component {
         id: statusAppCommunityView
         StatusAppCommunityView {
-            communityDetailModalTitle: demoCommunityDetailModal.header.title
-            communityDetailModalImage: demoCommunityDetailModal.header.asset.name
+            communityDetailModalTitle: demoCommunityDetailModal.headerSettings.title
+            communityDetailModalImage: demoCommunityDetailModal.headerSettings.asset.name
             onChatInfoButtonClicked: {
                 demoCommunityDetailModal.open();
             }

--- a/ui/StatusQ/sandbox/pages/StatusScrollViewPage.qml
+++ b/ui/StatusQ/sandbox/pages/StatusScrollViewPage.qml
@@ -45,7 +45,7 @@ Rectangle {
 
     component Modal: StatusModal {
         anchors.centerIn: parent
-        header.title: `Popup with fixed width ${width}px`
+        headerSettings.title: `Popup with fixed width ${width}px`
         rightButtons: [ StatusButton { text: "Button" } ]
     }
 

--- a/ui/app/AppLayouts/Communities/views/CommunityColumnView.qml
+++ b/ui/app/AppLayouts/Communities/views/CommunityColumnView.qml
@@ -293,7 +293,7 @@ Item {
                     type: StatusAction.Type.Danger
                     onTriggered: {
                         Global.openPopup(deleteCategoryConfirmationDialogComponent, {
-                            "header.title": qsTr("Delete '%1' category").arg(categoryItem.name),
+                            "headerSettings.title": qsTr("Delete '%1' category").arg(categoryItem.name),
                             confirmationText: qsTr("Are you sure you want to delete '%1' category? Channels inside the category won't be deleted.")
                                 .arg(categoryItem.name),
                             categoryId: categoryItem.itemId
@@ -527,7 +527,6 @@ Item {
         ConfirmationDialog {
             property string categoryId
             confirmButtonObjectName: "confirmDeleteCategoryButton"
-            btnType: "warn"
             showCancelButton: true
             onClosed: {
                 destroy()

--- a/ui/imports/shared/views/chat/ChatContextMenuView.qml
+++ b/ui/imports/shared/views/chat/ChatContextMenuView.qml
@@ -255,12 +255,11 @@ StatusMenu {
         id: deleteChatConfirmationDialogComponent
         ConfirmationDialog {
             confirmButtonObjectName: "deleteChatConfirmationDialogDeleteButton"
-            btnType: "warn"
             headerSettings.title: root.isCommunityChat ? qsTr("Delete #%1").arg(root.chatName) :
                                             root.chatType === Constants.chatType.oneToOne ?
                                             qsTr("Delete chat") :
                                             qsTr("Leave chat")
-            confirmButtonLabel: root.isCommunityChat ? qsTr("Delete") : header.title
+            confirmButtonLabel: root.isCommunityChat ? qsTr("Delete") : headerSettings.title
             confirmationText: root.isCommunityChat ? qsTr("Are you sure you want to delete #%1 channel?").arg(root.chatName) :
                                                 root.chatType === Constants.chatType.oneToOne ?
                                                 qsTr("Are you sure you want to delete this chat?"):


### PR DESCRIPTION
fixes a `StatusModal` porting error that broke `title` in a couple of popups/modals

Closes #11503

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

Delete 1-1 chat:
![Snímek obrazovky z 2023-07-13 15-20-44](https://github.com/status-im/status-desktop/assets/5377645/ca2f025e-7519-40c7-9c1e-f7f347fdef6a)

Delete chat category:
![Snímek obrazovky z 2023-07-13 15-20-33](https://github.com/status-im/status-desktop/assets/5377645/ac103899-e168-4a26-b400-bfa6905a6311)
