### PR TITLE
feat(@desktop/wallet): Use separate filter for each wallet account

### DIFF
--- a/src/app/modules/main/wallet_section/module.nim
+++ b/src/app/modules/main/wallet_section/module.nim
@@ -186,6 +186,7 @@ method load*(self: Module) =
     let args = AccountArgs(e)
     self.setTotalCurrencyBalance()
     self.filter.removeAddress(args.account.address)
+    self.view.emitWalletAccountRemoved(args.account.address)
     self.notifyFilterChanged()
   self.events.on(SIGNAL_WALLET_ACCOUNT_NETWORK_ENABLED_UPDATED) do(e:Args):
     self.filter.updateNetworks()

--- a/src/app/modules/main/wallet_section/view.nim
+++ b/src/app/modules/main/wallet_section/view.nim
@@ -111,6 +111,10 @@ QtObject:
   proc emitDestroyAddAccountPopup*(self: View) =
     self.destroyAddAccountPopup()
 
+  proc walletAccountRemoved*(self: View, address: string) {.signal.}
+  proc emitWalletAccountRemoved*(self: View, address: string) =
+    self.walletAccountRemoved(address)
+
   proc getActivityController(self: View): QVariant {.slot.} =
     return newQVariant(self.activityController)
   QtProperty[QVariant] activityController:

--- a/ui/StatusQ/src/StatusQ/Controls/StatusTextWithLoadingState.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusTextWithLoadingState.qml
@@ -52,6 +52,7 @@ StatusBaseText {
 
     Loader {
         anchors.left: parent.left
+        anchors.leftMargin: root.leftPadding
         anchors.verticalCenter: parent.verticalCenter
         active: root.loading
         sourceComponent: LoadingComponent {

--- a/ui/app/AppLayouts/Wallet/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Wallet/stores/RootStore.qml
@@ -44,13 +44,40 @@ QtObject {
         ]
     }
 
+    readonly property var currentActivityFiltersStore: {
+        const address = root.overview.mixedcaseAddress
+        if (address in d.activityFiltersStoreDictionary) {
+            return d.activityFiltersStoreDictionary[address]
+        }
+        let store = d.activityFilterStoreComponent.createObject(root)
+        d.activityFiltersStoreDictionary[address] = store
+        return store
+    }
+
     property QtObject _d: QtObject {
         id: d
+
+        property var activityFiltersStoreDictionary: ({})
+        readonly property Component activityFilterStoreComponent: ActivityFiltersStore{}
+
         property var chainColors: ({})
 
         function initChainColors(model) {
             for (let i = 0; i < model.count; i++) {
                 chainColors[model.rowData(i, "shortName")] = model.rowData(i, "chainColor")
+            }
+        }
+
+        readonly property Connections walletSectionConnections: Connections {
+            target: root.walletSectionInst
+            function onWalletAccountRemoved(address) {
+                address = address.toLowerCase();
+                for (var addressKey in d.activityFiltersStoreDictionary){
+                    if (address === addressKey.toLowerCase()){
+                        delete d.activityFiltersStoreDictionary[addressKey]
+                        return
+                    }
+                }
             }
         }
     }

--- a/ui/app/AppLayouts/Wallet/views/LeftTabView.qml
+++ b/ui/app/AppLayouts/Wallet/views/LeftTabView.qml
@@ -331,9 +331,7 @@ Rectangle {
                         id: walletAmountValue
                         objectName: "walletLeftListAmountValue"
                         customColor: Style.current.textColor
-                        text: {
-                            LocaleUtils.currencyAmountToLocaleString(RootStore.totalCurrencyBalance)
-                        }
+                        text: LocaleUtils.currencyAmountToLocaleString(RootStore.totalCurrencyBalance)
                         font.pixelSize: 22
                         loading: RootStore.assetsLoading
                         visible: !networkConnectionStore.accountBalanceNotAvailable

--- a/ui/app/AppLayouts/Wallet/views/TransactionDetailView.qml
+++ b/ui/app/AppLayouts/Wallet/views/TransactionDetailView.qml
@@ -434,9 +434,9 @@ Item {
                             if (d.loadingInputDate) {
                                 return ""
                             } else if (!!d.decodedInputData) {
-                                return d.decodedInputData.substring(0, 100)
+                                return d.decodedInputData.substring(0, 200)
                             } else if (root.isTransactionValid) {
-                                return String(root.transaction.input).substring(0, 100)
+                                return String(root.transaction.input).substring(0, 200)
                             }
                             return ""
                         }

--- a/ui/imports/shared/views/HistoryView.qml
+++ b/ui/imports/shared/views/HistoryView.qml
@@ -32,8 +32,7 @@ ColumnLayout {
 
     onVisibleChanged: {
         if (visible && RootStore.isTransactionFilterDirty) {
-            // TODO(#11412) restore filter for selected wallet account
-            d.activityFiltersStore.resetAllFilters()
+            WalletStores.RootStore.currentActivityFiltersStore.applyAllFilters()
         }
     }
 
@@ -48,7 +47,7 @@ ColumnLayout {
     QtObject {
         id: d
         readonly property bool isInitialLoading: RootStore.loadingHistoryTransactions && transactionListRoot.count === 0
-        property var activityFiltersStore: WalletStores.ActivityFiltersStore{}
+
         readonly property int loadingSectionWidth: 56
         readonly property int topSectionMargin: 20
 
@@ -75,16 +74,16 @@ ColumnLayout {
         id: noTxs
         Layout.fillWidth: true
         Layout.preferredHeight: 42
-        visible: !d.isInitialLoading && !d.activityFiltersStore.filtersSet && transactionListRoot.count === 0
+        visible: !d.isInitialLoading && !WalletStores.RootStore.currentActivityFiltersStore.filtersSet && transactionListRoot.count === 0
         font.pixelSize: Style.current.primaryTextFontSize
         text: qsTr("Activity for this account will appear here")
     }
 
     ActivityFilterPanel {
         id: filterComponent
-        visible: d.isInitialLoading || transactionListRoot.count > 0 || d.activityFiltersStore.filtersSet
+        visible: d.isInitialLoading || transactionListRoot.count > 0 || WalletStores.RootStore.currentActivityFiltersStore.filtersSet
         Layout.fillWidth: true
-        activityFilterStore: d.activityFiltersStore
+        activityFilterStore: WalletStores.RootStore.currentActivityFiltersStore
         store: WalletStores.RootStore
         isLoading: d.isInitialLoading
     }


### PR DESCRIPTION
closes #11412 

### What does the PR do

* Each wallet account uses it's own filters

Fixes:
* Loading component didn't account the left padding

### Affected areas

Wallet activity UI

### Screenshot of functionality (including design for comparison)


https://github.com/status-im/status-desktop/assets/11396062/f7d06c35-beb6-4c18-9fa5-88537aaa2a6d

