### PR TITLE
feat/issue-11472: Admin view of Tokens and Airdrops home - pre-Owner token minting

### DIFF
--- a/storybook/pages/AirdropsSettingsPanelPage.qml
+++ b/storybook/pages/AirdropsSettingsPanelPage.qml
@@ -91,6 +91,8 @@ SplitView {
                 anchors.fill: parent
                 anchors.topMargin: 50
                 isOwner: ownerChecked.checked
+                isTokenMasterOwner: masterTokenOwnerChecked.checked
+                isAdmin: adminChecked.checked
                 tokensModel: editorModelChecked.checked ? emptyModel : mintedTokensModel
                 assetsModel: AssetsModel {}
                 collectiblesModel: ListModel {}
@@ -199,7 +201,7 @@ SplitView {
         id: logsAndControlsPanel
 
         SplitView.minimumHeight: 100
-        SplitView.preferredHeight: 150
+        SplitView.preferredHeight: 250
 
         logsView.logText: logs.logText
 
@@ -208,14 +210,28 @@ SplitView {
                 id: ownerChecked
                 checked: true
 
-                text: "Is owner?"
+                text: "Is Owner? [Owner will be able to create an OWNER and TOKEN MASTER token]"
+            }
+
+            CheckBox {
+                id: masterTokenOwnerChecked
+                checked: true
+
+                text: "Is TMaster token owner? [TMaster token owner will be able to mint / airdrop tokens once the TMaster is already created]"
+            }
+
+            CheckBox {
+                id: adminChecked
+                checked: true
+
+                text: "Is admin? [Admis will be able to see token views, but NOT manage them, like creating new artwork or asset]"
             }
 
             CheckBox {
                 id: editorModelChecked
                 checked: true
 
-                text: "Empty model"
+                text: "No tokens minted yet"
             }
         }
     }

--- a/storybook/pages/MintTokensSettingsPanelPage.qml
+++ b/storybook/pages/MintTokensSettingsPanelPage.qml
@@ -80,7 +80,7 @@ SplitView {
         id: logsAndControlsPanel
 
         SplitView.minimumHeight: 100
-        SplitView.preferredHeight: 200
+        SplitView.preferredHeight: 250
 
         logsView.logText: logs.logText
 
@@ -102,28 +102,28 @@ SplitView {
                 id: ownerChecked
                 checked: true
 
-                text: "Is owner?"
+                text: "Is Owner? [Owner will be able to create an OWNER and TOKEN MASTER token]"
             }
 
             CheckBox {
                 id: masterTokenOwnerChecked
                 checked: true
 
-                text: "Is TMaster token owner?"
+                text: "Is TMaster token owner? [TMaster token owner will be able to mint / airdrop tokens once the TMaster is already created]"
             }
 
             CheckBox {
                 id: adminChecked
                 checked: true
 
-                text: "Is admin?"
+                text: "Is admin? [Admis will be able to see token views, but NOT manage them, like creating new artwork or asset]"
             }
 
             CheckBox {
                 id: editorModelChecked
                 checked: true
 
-                text: "Empty model"
+                text: "No tokens minted yet"
             }
 
             RowLayout {

--- a/ui/StatusQ/src/StatusQ/Components/StatusInfoBoxPanel.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusInfoBoxPanel.qml
@@ -13,6 +13,7 @@ Control {
     property alias title: titleComponent.text
     property alias text: textComponent.text
     property alias buttonText: button.text
+    property alias buttonVisible: button.visible
 
     signal clicked
 
@@ -58,6 +59,8 @@ Control {
             id: button
 
             Layout.alignment: Qt.AlignHCenter
+
+            visible: true
 
             onClicked: root.clicked()
         }

--- a/ui/app/AppLayouts/Communities/panels/AirdropsSettingsPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/AirdropsSettingsPanel.qml
@@ -14,6 +14,8 @@ StackView {
     // id, name, image, color, owner properties expected
     required property var communityDetails
     required property bool isOwner
+    required property bool isTokenMasterOwner
+    required property bool isAdmin
 
     // Token models:
     required property var assetsModel
@@ -53,6 +55,8 @@ StackView {
     QtObject {
         id: d
 
+        readonly property bool isAdminOnly: root.isAdmin && !root.isOwner && !root.isTokenMasterOwner
+
         signal selectToken(string key, int amount, int type)
         signal addAddresses(var addresses)
     }
@@ -62,10 +66,11 @@ StackView {
         title: qsTr("Airdrops")
 
         buttons: StatusButton {
+
             objectName: "addNewItemButton"
 
             text: qsTr("New Airdrop")
-            enabled: root.tokensModel.count > 0 // TODO: Replace to checker to ensure owner token is deployed
+            enabled: !d.isAdminOnly && root.tokensModel.count > 0 // TODO: Replace to checker to ensure owner token is deployed
 
             onClicked: root.push(newAirdropView, StackView.Immediate)
         }
@@ -80,11 +85,13 @@ StackView {
                 qsTr("Incentivise joining, retention, moderation and desired behaviour"),
                 qsTr("Require holding a token or NFT to obtain exclusive membership rights")
             ]
-            infoBoxVisible: root.isOwner && root.tokensModel.count === 0 // TODO: Replace to checker to ensure owner token is NOT deployed yet
+            infoBoxVisible: d.isAdminOnly || ((root.isOwner || root.isTokenMasterOwner) && root.tokensModel.count === 0) // TODO: Replace to checker to ensure owner token is NOT deployed yet
             infoBoxTitle: qsTr("Get started")
-            infoBoxText: qsTr("In order to Mint, Import and Airdrop community tokens, you first need to mint your Owner token which will give you permissions to access the token management features for your community.")
+            infoBoxText: d.isAdminOnly ? qsTr("Token airdropping can only be performed by admins that hodl the Community’s TokenMaster token. If you would like this permission, contact the Community founder (they will need to mint the Community Owner token before they can airdrop this to you)."):
+                                       qsTr("In order to Mint, Import and Airdrop community tokens, you first need to mint your Owner token which will give you permissions to access the token management features for your community.")
             buttonText: qsTr("Mint Owner token")
-            onClicked: root.navigateToMintTokenSettings(false) // TEMP: Replace to mint owner token page
+            buttonVisible: root.isOwner
+            onClicked: root.navigateToMintTokenSettings(false)
         }
     }
 

--- a/ui/app/AppLayouts/Communities/panels/MintTokensSettingsPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/MintTokensSettingsPanel.qml
@@ -99,13 +99,13 @@ StackView {
         title: qsTr("Tokens")
 
         buttons: DisabledTooltipButton {
-            property bool onlyAdmin: root.isAdmin && !root.isOwner
-            property bool buttonEnabled: (root.isOwner || root.isTokenMasterOwner) && d.isTokenOwnerDeployed
+            readonly property bool isAdminOnly: root.isAdmin && !root.isOwner && !root.isTokenMasterOwner
+            readonly property bool buttonEnabled: (root.isOwner || root.isTokenMasterOwner) && d.isTokenOwnerDeployed
 
             buttonType: DisabledTooltipButton.Normal
             aliasedObjectName: "addNewItemButton"
             text: qsTr("Mint token")
-            enabled: onlyAdmin || buttonEnabled
+            enabled: isAdminOnly || buttonEnabled
             interactive: buttonEnabled
             onClicked: root.push(newTokenViewComponent, StackView.Immediate)
             tooltipText: qsTr("In order to mint, you must hodl the TokenMaster token for %1").arg(root.communityName)
@@ -114,6 +114,7 @@ StackView {
         contentItem: MintedTokensView {
             model: root.tokensModel
             isOwner: root.isOwner
+            isAdmin: root.isAdmin
 
             onItemClicked: root.push(tokenViewComponent, { tokenKey }, StackView.Immediate)
             onMintOwnerTokenClicked: root.push(ownerTokenViewComponent, StackView.Immediate)

--- a/ui/app/AppLayouts/Communities/views/CommunitySettingsView.qml
+++ b/ui/app/AppLayouts/Communities/views/CommunitySettingsView.qml
@@ -364,6 +364,8 @@ StatusSectionLayout {
 
             communityDetails: d.communityDetails
             isOwner: root.isOwner
+            isTokenMasterOwner: false // TODO: Backend
+            isAdmin: root.isAdmin
             tokensModel: root.community.communityTokens
 
             readonly property CommunityTokensStore communityTokensStore:

--- a/ui/app/AppLayouts/Communities/views/MintedTokensView.qml
+++ b/ui/app/AppLayouts/Communities/views/MintedTokensView.qml
@@ -16,6 +16,7 @@ StatusScrollView {
     id: root
 
     required property bool isOwner
+    required property bool isAdmin
 
     property int viewWidth: 560 // by design
     property var model
@@ -99,13 +100,17 @@ StatusScrollView {
             }
 
             StatusInfoBoxPanel {
+
+                readonly property bool isAdminOnly: root.isAdmin && !root.isOwner
+
                 Layout.fillWidth: true
                 Layout.bottomMargin: 20
 
-                visible: root.isOwner
                 title: qsTr("Get started")
-                text: qsTr("In order to Mint, Import and Airdrop community tokens, you first need to mint your Owner token which will give you permissions to access the token management features for your community.")
+                text: isAdminOnly ? qsTr("Token minting can only be performed by admins that hodl the Community’s TokenMaster token. If you would like this permission, contact the Community founder (they will need to mint the Community Owner token before they can airdrop this to you)."):
+                                    qsTr("In order to Mint, Import and Airdrop community tokens, you first need to mint your Owner token which will give you permissions to access the token management features for your community.")
                 buttonText: qsTr("Mint Owner token")
+                buttonVisible: root.isOwner
                 horizontalPadding: 16
                 verticalPadding: 20
 

--- a/ui/app/AppLayouts/Communities/views/WelcomeSettingsView.qml
+++ b/ui/app/AppLayouts/Communities/views/WelcomeSettingsView.qml
@@ -20,6 +20,7 @@ StatusScrollView {
     property alias infoBoxTitle: infoBox.title
     property alias infoBoxText: infoBox.text
     property alias buttonText: infoBox.buttonText
+    property alias buttonVisible: infoBox.buttonVisible
 
     signal clicked
 


### PR DESCRIPTION
Closes #11472

### What does the PR do

- New `Get started` panel for admins in `Tokens` and `Airdrops` section added.
- Added support in `storybook`.

### Affected areas

Community Settings / Tokens and Airdops

### Screenshot of functionality 
- Tokens:

https://github.com/status-im/status-desktop/assets/97019400/39954171-3d4c-4998-84dc-6fb6c7f66fc3

- Airdrops:

https://github.com/status-im/status-desktop/assets/97019400/6d969ce3-d268-4747-8bbd-53f6df83ac7c

