### PR TITLE
feat(community): add airdropAddress param to request to join functions

### DIFF
--- a/src/app/modules/main/chat_section/controller.nim
+++ b/src/app/modules/main/chat_section/controller.nim
@@ -47,6 +47,7 @@ type
     tmpAuthenticationForJoinInProgress: bool
     tmpRequestToJoinEnsName: string
     tmpRequestToJoinAddressesToShare: seq[string]
+    tmpRequestToJoinAirdropAddress: string
 
 proc newController*(delegate: io_interface.AccessInterface, sectionId: string, isCommunity: bool, events: EventEmitter,
   settingsService: settings_service.Service, nodeConfigurationService: node_configuration_service.Service, 
@@ -77,6 +78,7 @@ proc newController*(delegate: io_interface.AccessInterface, sectionId: string, i
   result.communityTokensService = communityTokensService
   result.tmpAuthenticationForJoinInProgress = false
   result.tmpRequestToJoinEnsName = ""
+  result.tmpRequestToJoinAirdropAddress = ""
   result.tmpRequestToJoinAddressesToShare = @[]
 
 proc delete*(self: Controller) =
@@ -94,13 +96,15 @@ proc setIsCurrentSectionActive*(self: Controller, active: bool) =
 proc userAuthenticationCanceled*(self: Controller) =
   self.tmpAuthenticationForJoinInProgress = false
   self.tmpRequestToJoinEnsName = ""
+  self.tmpRequestToJoinAirdropAddress = ""
   self.tmpRequestToJoinAddressesToShare = @[]
 
 proc requestToJoinCommunityAuthenticated*(self: Controller, password: string) =
   self.communityService.asyncRequestToJoinCommunity(self.sectionId, self.tmpRequestToJoinEnsName,
-    password, self.tmpRequestToJoinAddressesToShare)
+    password, self.tmpRequestToJoinAddressesToShare, self.tmpRequestToJoinAirdropAddress)
   self.tmpAuthenticationForJoinInProgress = false
   self.tmpRequestToJoinEnsName = ""
+  self.tmpRequestToJoinAirdropAddress = ""
   self.tmpRequestToJoinAddressesToShare = @[]
 
 proc authenticate*(self: Controller, keyUid = "") =
@@ -108,9 +112,10 @@ proc authenticate*(self: Controller, keyUid = "") =
     keyUid: keyUid)
   self.events.emit(SIGNAL_SHARED_KEYCARD_MODULE_AUTHENTICATE_USER, data)
 
-proc authenticateToRequestToJoinCommunity*(self: Controller, ensName: string, addressesToShare: seq[string]) =
+proc authenticateToRequestToJoinCommunity*(self: Controller, ensName: string, addressesToShare: seq[string], airdropAddress: string) =
   self.tmpAuthenticationForJoinInProgress = true
   self.tmpRequestToJoinEnsName = ensName
+  self.tmpRequestToJoinAirdropAddress = airdropAddress
   self.tmpRequestToJoinAddressesToShare = addressesToShare
   self.authenticate()
 

--- a/src/app/modules/main/chat_section/io_interface.nim
+++ b/src/app/modules/main/chat_section/io_interface.nim
@@ -382,7 +382,8 @@ method onUserAuthenticated*(self: AccessInterface, pin: string, password: string
 method onDeactivateChatLoader*(self: AccessInterface, chatId: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method requestToJoinCommunityWithAuthentication*(self: AccessInterface, ensName: string, addressesToShare: seq[string]) {.base.} =
+method requestToJoinCommunityWithAuthentication*(self: AccessInterface, ensName: string, addressesToShare: seq[string],
+    airdropAddress: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method onCommunityCheckPermissionsToJoinResponse*(self: AccessInterface, checkPermissionsToJoinResponse: CheckPermissionsToJoinResponseDto) {.base.} =

--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -1329,8 +1329,9 @@ method createOrEditCommunityTokenPermission*(self: Module, communityId: string, 
 method deleteCommunityTokenPermission*(self: Module, communityId: string, permissionId: string) =
   self.controller.deleteCommunityTokenPermission(communityId, permissionId)
 
-method requestToJoinCommunityWithAuthentication*(self: Module, ensName: string, addressesToShare: seq[string]) =
-  self.controller.authenticateToRequestToJoinCommunity(ensName, addressesToShare)
+method requestToJoinCommunityWithAuthentication*(self: Module, ensName: string, addressesToShare: seq[string],
+    airdropAddress: string) =
+  self.controller.authenticateToRequestToJoinCommunity(ensName, addressesToShare, airdropAddress)
 
 method onDeactivateChatLoader*(self: Module, chatId: string) =
   self.view.chatsModel().disableChatLoader(chatId)

--- a/src/app/modules/main/chat_section/view.nim
+++ b/src/app/modules/main/chat_section/view.nim
@@ -241,13 +241,13 @@ QtObject:
     self.delegate.createGroupChat(communityID, groupName, pubKeys)
 
   proc requestToJoinCommunityWithAuthentication*(self: View, ensName: string) {.slot.} =
-    self.delegate.requestToJoinCommunityWithAuthentication(ensName, @[])
+    self.delegate.requestToJoinCommunityWithAuthentication(ensName, @[], "")
 
   proc requestToJoinCommunityWithAuthenticationWithSharedAddresses*(self: View, ensName: string,
-      addressesToShare: string) {.slot.} =
+      addressesToShare: string, airdropAddress: string) {.slot.} =
     try:
       let addressesArray = map(parseJson(addressesToShare).getElems(), proc(x:JsonNode):string = x.getStr())
-      self.delegate.requestToJoinCommunityWithAuthentication(ensName, addressesArray)
+      self.delegate.requestToJoinCommunityWithAuthentication(ensName, addressesArray, airdropAddress)
     except Exception as e:
       echo "Error requesting to join community with authetication and shared addresses: ", e.msg
 

--- a/src/app_service/service/community/async_tasks.nim
+++ b/src/app_service/service/community/async_tasks.nim
@@ -86,11 +86,13 @@ type
     ensName: string
     password: string
     addressesToShare: seq[string]
+    airdropAddress: string
 
 const asyncRequestToJoinCommunityTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AsyncRequestToJoinCommunityTaskArg](argEncoded)
   try:
-    let response = status_go.requestToJoinCommunity(arg.communityId, arg.ensName, arg.password, arg.addressesToShare)
+    let response = status_go.requestToJoinCommunity(arg.communityId, arg.ensName, arg.password, arg.addressesToShare,
+      arg.airdropAddress)
     arg.finish(%* {
       "response": response,
       "communityId": arg.communityId,

--- a/src/app_service/service/community/service.nim
+++ b/src/app_service/service/community/service.nim
@@ -1398,7 +1398,7 @@ QtObject:
       error "error checking permissions to join: ", errMsg
 
   proc asyncRequestToJoinCommunity*(self: Service, communityId: string, ensName: string, password: string,
-      addressesToShare: seq[string]) =
+      addressesToShare: seq[string], airdropAddress: string) =
     try:
       let arg = AsyncRequestToJoinCommunityTaskArg(
         tptr: cast[ByteAddress](asyncRequestToJoinCommunityTask),
@@ -1408,6 +1408,7 @@ QtObject:
         ensName: ensName,
         password: password,
         addressesToShare: addressesToShare,
+        airdropAddress: airdropAddress,
       )
       self.threadpool.start(arg)
     except Exception as e:

--- a/src/backend/communities.nim
+++ b/src/backend/communities.nim
@@ -36,6 +36,7 @@ proc requestToJoinCommunity*(
     ensName: string,
     password: string,
     addressesToShare: seq[string],
+    airdropAddress: string,
   ): RpcResponse[JsonNode] {.raises: [Exception].} =
   var passwordToSend = password
   result = callPrivateRPC("requestToJoinCommunity".prefix, %*[{
@@ -43,6 +44,7 @@ proc requestToJoinCommunity*(
     "ensName": ensName,
     "password": if passwordToSend != "": utils.hashPassword(password) else: "",
     "addressesToShare": addressesToShare,
+    "airdropAddress": airdropAddress,
   }])
 
 proc checkPermissionsToJoinCommunity*(communityId: string): RpcResponse[JsonNode] {.raises: [Exception].} =


### PR DESCRIPTION
Fixes #11479

status-go PR https://github.com/status-im/status-go/pull/3756

To use it on the front-end, just call this function:
```nim
proc requestToJoinCommunityWithAuthenticationWithSharedAddresses*(self: View, ensName: string,
    addressesToShare: string, airdropAddress: string) {.slot.} =
 ```
Where `addressesToShare` is a stringified array of strings and `airdropAddress` is a one of the addresses from `addressesToShare`.

QML example:
```qml
const exampleAddresses = [
  "0xB69aca9A59566b8fBC0AA63A5e4c0F1DEf209f46",
  "0x0d5795eB5F333b67569428Ae5374BEf010Cb7fea"
]
chatCommunitySectionModule.requestToJoinCommunityWithAuthenticationWithSharedAddresses(
  ensName,
  JSON.stringify(exampleAddresses),
  "0x0d5795eB5F333b67569428Ae5374BEf010Cb7fea"
)
```