### PR TITLE
fix(@desktop/wallet): fixes weird scrolling behaviour in Wallet settings

### DIFF
--- a/ui/app/AppLayouts/Profile/views/WalletView.qml
+++ b/ui/app/AppLayouts/Profile/views/WalletView.qml
@@ -47,6 +47,10 @@ SettingsContentBase {
         id: stackContainer
 
         width: root.contentWidth
+        height: stackContainer.currentIndex === root.mainViewIndex ? main.height:
+                stackContainer.currentIndex === root.networksViewIndex ? networksView.height:
+                stackContainer.currentIndex === root.editNetworksViewIndex ? editNetwork.height:
+                stackContainer.currentIndex === root.accountOrderViewIndex ? accountOrderView.height: accountView.height
         currentIndex: mainViewIndex
 
         onCurrentIndexChanged: {
@@ -86,6 +90,7 @@ SettingsContentBase {
             id: main
 
             Layout.fillWidth: true
+            Layout.fillHeight: false
 
             walletStore: root.walletStore
             emojiPopup: root.emojiPopup
@@ -105,7 +110,9 @@ SettingsContentBase {
         }
 
         NetworksView {
+            id: networksView
             Layout.fillWidth: true
+            Layout.fillHeight: false
 
             walletStore: root.walletStore
 
@@ -129,6 +136,7 @@ SettingsContentBase {
         }
 
         AccountOrderView {
+            id: accountOrderView
             Layout.fillWidth: true
             Layout.leftMargin: Style.current.padding
             Layout.rightMargin: Style.current.padding
@@ -140,6 +148,7 @@ SettingsContentBase {
 
         AccountView {
             id: accountView
+            Layout.fillHeight: false
             walletStore: root.walletStore
             emojiPopup: root.emojiPopup
 

--- a/ui/app/AppLayouts/Profile/views/wallet/AccountView.qml
+++ b/ui/app/AppLayouts/Profile/views/wallet/AccountView.qml
@@ -17,6 +17,8 @@ import "../../popups"
 
 Item {
     id: root
+
+    implicitHeight: childrenRect.height
     signal goBack
 
     property WalletStore walletStore


### PR DESCRIPTION
fixes #11526

### What does the PR do

The elements should be the size of its children and scroll only if they area to scroll is larger than available space

### Affected areas

Wallet Settings

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it


https://github.com/status-im/status-desktop/assets/60327365/628442cd-51c2-4526-a207-d63fda3e0339

