### PR TITLE
fix: Channels stay highlighted when they are not selected

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/StatusChatList.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusChatList.qml
@@ -68,6 +68,8 @@ Item {
             }
 
             onDropped: function(drop) {
+                statusChatListCategoryItem.highlighted = false;
+                statusChatListItem.highlighted = false;
                 const from = drop.source.visualIndex;
                 const to = chatListDelegate.visualIndex;
                 if (to === from)


### PR DESCRIPTION
disable the highlight also when not exiting the DropArea

Fixes #11459

### What does the PR do

Fixes chat items staying highlighted even after a slight move

### Affected areas

StatusChatList
