### PR TITLE
feat(communities): add API to edit shared addresses

### DIFF
--- a/src/app/modules/main/chat_section/io_interface.nim
+++ b/src/app/modules/main/chat_section/io_interface.nim
@@ -386,6 +386,11 @@ method requestToJoinCommunityWithAuthentication*(self: AccessInterface, ensName:
     airdropAddress: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method editSharedAddressesWithAuthentication*(self: AccessInterface, addressesToShare: seq[string], airdropAddress: string)
+    {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+
 method onCommunityCheckPermissionsToJoinResponse*(self: AccessInterface, checkPermissionsToJoinResponse: CheckPermissionsToJoinResponseDto) {.base.} =
  
   raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -903,7 +903,7 @@ method onUserAuthenticated*(self: Module, pin: string, password: string, keyUid:
     self.controller.userAuthenticationCanceled()
     return
 
-  self.controller.requestToJoinCommunityAuthenticated(password)
+  self.controller.userAuthenticated(password)
 
 method onMarkAllMessagesRead*(self: Module, chat: ChatDto) =
   self.updateBadgeNotifications(chat, hasUnreadMessages=false, unviewedMentionsCount=0)
@@ -1332,6 +1332,9 @@ method deleteCommunityTokenPermission*(self: Module, communityId: string, permis
 method requestToJoinCommunityWithAuthentication*(self: Module, ensName: string, addressesToShare: seq[string],
     airdropAddress: string) =
   self.controller.authenticateToRequestToJoinCommunity(ensName, addressesToShare, airdropAddress)
+
+method editSharedAddressesWithAuthentication*(self: Module, addressesToShare: seq[string], airdropAddress: string) =
+  self.controller.authenticateToEditSharedAddresses(addressesToShare, airdropAddress)
 
 method onDeactivateChatLoader*(self: Module, chatId: string) =
   self.view.chatsModel().disableChatLoader(chatId)

--- a/src/app/modules/main/chat_section/view.nim
+++ b/src/app/modules/main/chat_section/view.nim
@@ -251,6 +251,13 @@ QtObject:
     except Exception as e:
       echo "Error requesting to join community with authetication and shared addresses: ", e.msg
 
+  proc editSharedAddressesWithAuthentication*(self: View, addressesToShare: string, airdropAddress: string) {.slot.} =
+    try:
+      let addressesArray = map(parseJson(addressesToShare).getElems(), proc(x:JsonNode):string = x.getStr())
+      self.delegate.editSharedAddressesWithAuthentication(addressesArray, airdropAddress)
+    except Exception as e:
+      echo "Error editing shared addresses with authentication: ", e.msg
+
   proc joinGroupChatFromInvitation*(self: View, groupName: string, chatId: string, adminPK: string) {.slot.} =
     self.delegate.joinGroupChatFromInvitation(groupName, chatId, adminPK)
 

--- a/src/app/modules/main/communities/controller.nim
+++ b/src/app/modules/main/communities/controller.nim
@@ -94,6 +94,14 @@ proc init*(self: Controller) =
     let args = CommunityRequestFailedArgs(e)
     self.delegate.communityAccessFailed(args.communityId, args.error)
 
+  self.events.on(SIGNAL_COMMUNITY_EDIT_SHARED_ADDRESSES_SUCCEEDED) do(e:Args):
+    let args = CommunityIdArgs(e)
+    self.delegate.communityEditSharedAddressesSucceeded(args.communityId)
+
+  self.events.on(SIGNAL_COMMUNITY_EDIT_SHARED_ADDRESSES_FAILED) do(e:Args):
+    let args = CommunityRequestFailedArgs(e)
+    self.delegate.communityEditSharedAddressesFailed(args.communityId, args.error)
+
   self.events.on(SIGNAL_DISCORD_CATEGORIES_AND_CHANNELS_EXTRACTED) do(e:Args):
     let args = DiscordCategoriesAndChannelsArgs(e)
     self.delegate.discordCategoriesAndChannelsExtracted(args.categories, args.channels, args.oldestMessageTimestamp, args.errors, args.errorsCount)

--- a/src/app/modules/main/communities/io_interface.nim
+++ b/src/app/modules/main/communities/io_interface.nim
@@ -121,6 +121,12 @@ method communityAccessRequested*(self: AccessInterface, communityId: string) {.b
 method communityAccessFailed*(self: AccessInterface, communityId: string, error: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method communityEditSharedAddressesSucceeded*(self: AccessInterface, communityId: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method communityEditSharedAddressesFailed*(self: AccessInterface, communityId: string, error: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method requestExtractDiscordChannelsAndCategories*(self: AccessInterface, filesToImport: seq[string]) {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/communities/module.nim
+++ b/src/app/modules/main/communities/module.nim
@@ -273,6 +273,12 @@ method communityAccessRequested*(self: Module, communityId: string) =
 method communityAccessFailed*(self: Module, communityId, error: string) =
   self.view.communityAccessFailed(communityId, error)
 
+method communityEditSharedAddressesSucceeded*(self: Module, communityId: string) =
+  self.view.communityEditSharedAddressesSucceeded(communityId)
+
+method communityEditSharedAddressesFailed*(self: Module, communityId, error: string) =
+  self.view.communityEditSharedAddressesFailed(communityId, error)
+
 method communityHistoryArchivesDownloadStarted*(self: Module, communityId: string) =
   self.view.setDownloadingCommunityHistoryArchives(true)
 

--- a/src/app/modules/main/communities/view.nim
+++ b/src/app/modules/main/communities/view.nim
@@ -110,6 +110,8 @@ QtObject:
   proc discordImportErrorsCountChanged*(self: View) {.signal.}
   proc communityAccessRequested*(self: View, communityId: string) {.signal.}
   proc communityAccessFailed*(self: View, communityId: string, error: string) {.signal.}
+  proc communityEditSharedAddressesSucceeded*(self: View, communityId: string) {.signal.}
+  proc communityEditSharedAddressesFailed*(self: View, communityId: string, error: string) {.signal.}
   proc communityInfoAlreadyRequested*(self: View) {.signal.}
 
   proc communityTagsChanged*(self: View) {.signal.}

--- a/src/app_service/service/community/async_tasks.nim
+++ b/src/app_service/service/community/async_tasks.nim
@@ -102,8 +102,29 @@ const asyncRequestToJoinCommunityTask: Task = proc(argEncoded: string) {.gcsafe,
     arg.finish(%* {
       "error": e.msg,
       "communityId": arg.communityId,
-      "ensName": arg.ensName,
-      "password": arg.password
+    })
+
+type
+  AsyncEditSharedAddressesTaskArg = ref object of QObjectTaskArg
+    communityId: string
+    password: string
+    addressesToShare: seq[string]
+    airdropAddress: string
+
+const asyncEditSharedAddressesTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+  let arg = decode[AsyncEditSharedAddressesTaskArg](argEncoded)
+  try:
+    let response = status_go.editSharedAddresses(arg.communityId, arg.password, arg.addressesToShare,
+      arg.airdropAddress)
+    arg.finish(%* {
+      "response": response,
+      "communityId": arg.communityId,
+      "error": "",
+    })
+  except Exception as e:
+    arg.finish(%* {
+      "error": e.msg,
+      "communityId": arg.communityId,
     })
 
 type

--- a/src/backend/communities.nim
+++ b/src/backend/communities.nim
@@ -43,7 +43,21 @@ proc requestToJoinCommunity*(
     "communityId": communityId,
     "ensName": ensName,
     "password": if passwordToSend != "": utils.hashPassword(password) else: "",
-    "addressesToShare": addressesToShare,
+    "addressesToReveal": addressesToShare,
+    "airdropAddress": airdropAddress,
+  }])
+
+proc editSharedAddresses*(
+    communityId: string,
+    password: string,
+    addressesToShare: seq[string],
+    airdropAddress: string,
+  ): RpcResponse[JsonNode] {.raises: [Exception].} =
+  var passwordToSend = password
+  result = callPrivateRPC("editSharedAddressesForCommunity".prefix, %*[{
+    "communityId": communityId,
+    "password": if passwordToSend != "": utils.hashPassword(password) else: "",
+    "addressesToReveal": addressesToShare,
     "airdropAddress": airdropAddress,
   }])
 


### PR DESCRIPTION
Fixes #11153

Adds `editSharedAddressesWithAuthentication` in the chat_section view to be called from QML.

Also adds the `communityEditSharedAddressesSucceeded` and `communityEditSharedAddressesFailed` signals in the communities module to be used by QML to know if it worked.
