### PR TITLE
chore(@e2e_tests): temp disable several wallet tests because of changing feature

### DIFF
--- a/test/ui-test/testSuites/suite_wallet/tst_wallet_accountsManagement/test.feature
+++ b/test/ui-test/testSuites/suite_wallet/tst_wallet_accountsManagement/test.feature
@@ -17,7 +17,9 @@ Feature: Status Desktop Wallet Section Wallet Account Management
             | name           | new_name         | new_color | new_emoji  | new_emoji_unicode |
             | Status account | MyPrimaryAccount | 216266    | sunglasses | 1f60e             |
 
-    Scenario Outline: The user manages a watch only account
+		# Change to use main button. add account with context menu is no longer a thing
+		@mayfail
+    	Scenario Outline: The user manages a watch only account
         When the user adds a watch only account "<address>" with "<name>" color "#<color>" and emoji "<emoji>" via "<add_via_context_menu>"
         Then the account is correctly displayed with "<name>" and "#<color>" and emoji unicode "<emoji_unicode>" in accounts list
         When the user edits an account with "<name>" to "<new_name>" with color "#<new_color>" and emoji "<new_emoji>"
@@ -29,9 +31,9 @@ Feature: Status Desktop Wallet Section Wallet Account Management
             | 0xea123F7beFF45E3C9fdF54B324c29DBdA14a639A | AccWatch1 | 2a4af5 | sunglasses | 1f60e         | yes                  | AccWatch1edited | 216266    | thumbsup  | 1f44d             |
             | 0xea123F7beFF45E3C9fdF54B324c29DBdA14a639B | AccWatch2 | 7140fd | sunglasses | 1f60e         | no                   | AccWatch2edited | 2a799b    | thumbsup  | 1f44d             |
 
-    # Test should be changed to reflect balance change instead of accounts list, will be done after it is changed in the app
-	@mayfail
- 	Scenario Outline: The user can hide and show watch only account by clicking Hide / Show button
+    	# Test should be changed to reflect balance change instead of accounts list, will be done after it is changed in the app
+		@mayfail
+ 		Scenario Outline: The user can hide and show watch only account by clicking Hide / Show button
         When the user adds a watch only account "<address>" with "<name>" color "#<color>" and emoji "<emoji>" via "<add_via_context_menu>"
         Then the account is correctly displayed with "<name>" and "#<color>" and emoji unicode "<emoji_unicode>" in accounts list
         When the user opens All accounts view
@@ -44,8 +46,9 @@ Feature: Status Desktop Wallet Section Wallet Account Management
         Examples:
             | address                                    | name      | color  | emoji      | emoji_unicode | add_via_context_menu |
             | 0xea123F7beFF45E3C9fdF54B324c29DBdA14a639A | AccWatch1 | 2a4af5 | sunglasses | 1f60e         | yes                  |
-
-        Scenario Outline: The user cancel deleting watch only account
+		# Test should be changed to reflect balance change instead of accounts list, will be done after it is changed in the app
+		@mayfail
+    	Scenario Outline: The user cancel deleting watch only account
         When the user adds a watch only account "<address>" with "<name>" color "#<color>" and emoji "<emoji>" via "<add_via_context_menu>"
         Then the account is correctly displayed with "<name>" and "#<color>" and emoji unicode "<emoji_unicode>" in accounts list
         When the user start removing account "<name>" and cancel it
@@ -54,7 +57,8 @@ Feature: Status Desktop Wallet Section Wallet Account Management
             | address                                    | name      | color  | emoji      | emoji_unicode |
             | 0xea123F7beFF45E3C9fdF54B324c29DBdA14a639A | AccWatch1 | 2a4af5 | sunglasses | 1f60e         |
 
-
+		# Change to use main button. add account with context menu is no longer a thing
+		@mayfail
         Scenario Outline: The user manages a generated account
         When the user adds a generated account with "<name>" color "#<color>" and emoji "<emoji>" via "<add_via_context_menu>"
         Then the account is correctly displayed with "<name>" and "#<color>" and emoji unicode "<emoji_unicode>" in accounts list
@@ -68,7 +72,8 @@ Feature: Status Desktop Wallet Section Wallet Account Management
             | GenAcc1 | 2a4af5 | sunglasses | 1f60e         | yes                  | GenAcc1edited | 216266    | thumbsup  | 1f44d             |
             | GenAcc2 | 7140fd | sunglasses | 1f60e         | no                   | GenAcc2edited | 2a799b    | thumbsup  | 1f44d             |
 
-
+		# Change to use main button. add account with context menu is no longer a thing
+		@mayfail
         Scenario Outline: The user cancel deleting generated account
         When the user adds a generated account with "<name>" color "#<color>" and emoji "<emoji>" via "<add_via_context_menu>"
         Then the account is correctly displayed with "<name>" and "#<color>" and emoji unicode "<emoji_unicode>" in accounts list


### PR DESCRIPTION
### What does the PR do

Disable some tests for account management, should be refactored due to changes introduced in https://github.com/status-im/status-desktop/pull/11368. The expected behavior is to use `+`button to add accounts instead of context menu.

