### PR TITLE
feat(Token master): create category in Settings/Communities

### DIFF
--- a/storybook/pages/CommunitiesViewPage.qml
+++ b/storybook/pages/CommunitiesViewPage.qml
@@ -31,7 +31,7 @@ SplitView {
         Component.onCompleted:
             append([{
                         id: "0x0001",
-                        name: "Test community",
+                        name: "I am 0wner!1!!",
                         description: "Lorem ipsum dolor sit amet",
                         introMessage: "Welcome to ze club",
                         outroMessage: "Sad to see you go",
@@ -66,7 +66,7 @@ SplitView {
                         joined: false,
                         spectated: true,
                         memberRole: Constants.memberRole.none,
-                        image: "",
+                        image: ModelsData.icons.coinbase,
                         color: "red",
                         muted: false,
                         members: [ { pubKey: "0xdeadbeef" } ]
@@ -87,14 +87,14 @@ SplitView {
                     },
                     {
                         id: "0x0005",
-                        name: "Test community 4",
+                        name: "Admin test community",
                         description: "Lorem ipsum dolor sit amet",
                         introMessage: "Welcome to ze club",
                         outroMessage: "Sad to see you go",
                         joined: true,
                         spectated: false,
                         memberRole: Constants.memberRole.admin,
-                        image: ModelsData.icons.spotify,
+                        image: ModelsData.icons.socks,
                         color: "green",
                         muted: false,
                         members: [{ pubKey: "0xdeadbeef" }, { pubKey: "0xdeadbeef" }, { pubKey: "0xdeadbeef" }, { pubKey: "0xdeadbeef" }]
@@ -112,6 +112,20 @@ SplitView {
                         color: "pink",
                         muted: false,
                         members: [{ pubKey: "0xdeadbeef" }]
+                    },
+                    {
+                        id: "0x0007",
+                        name: "Token Master Club",
+                        description: "Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi",
+                        introMessage: "Welcome to ze club",
+                        outroMessage: "Sad to see you go",
+                        joined: true,
+                        spectated: false,
+                        memberRole: Constants.memberRole.tokenMaster,
+                        image: ModelsData.icons.cryptPunks,
+                        color: "lightslategrey",
+                        muted: false,
+                        members: [{ pubKey: "0xdeadbeef" }, { pubKey: "0xdeadbeef" }]
                     }
                    ])
     }

--- a/storybook/stubs/AppLayouts/Chat/stores/RootStore.qml
+++ b/storybook/stubs/AppLayouts/Chat/stores/RootStore.qml
@@ -1,3 +1,5 @@
 import QtQuick 2.15
 
-QtObject {}
+QtObject {
+    property var chatCommunitySectionModule
+}

--- a/ui/app/AppLayouts/Profile/panels/CommunitiesListPanel.qml
+++ b/ui/app/AppLayouts/Profile/panels/CommunitiesListPanel.qml
@@ -50,6 +50,7 @@ StatusListView {
         readonly property bool isSpectator: model.spectated && !model.joined
         readonly property bool isOwner: model.memberRole === Constants.memberRole.owner
         readonly property bool isAdmin: model.memberRole === Constants.memberRole.admin
+        readonly property bool isTokenMaster: model.memberRole === Constants.memberRole.tokenMaster
         readonly property bool isInvitationPending: root.rootStore.isCommunityRequestPending(model.id)
 
         components: [
@@ -82,7 +83,7 @@ StatusListView {
                     StatusAction {
                         text: qsTr("Community Admin")
                         icon.name: "settings"
-                        enabled: listItem.isOwner || listItem.isAdmin
+                        enabled: listItem.isOwner || listItem.isAdmin || listItem.isTokenMaster
                         onTriggered: {
                             moreMenu.close()
                             Global.switchToCommunity(model.id)
@@ -115,7 +116,6 @@ StatusListView {
                         }
                     }
                     StatusAction {
-                        id: shareAddressesMenuItem
                         text: qsTr("Edit Shared Addresses")
                         icon.name: "wallet"
                         enabled: {
@@ -132,7 +132,7 @@ StatusListView {
                         }
                     }
                     StatusMenuSeparator {
-                        visible: shareAddressesMenuItem.enabled && leaveMenuItem.enabled
+                        visible: leaveMenuItem.enabled
                     }
                     StatusAction {
                         id: leaveMenuItem

--- a/ui/app/AppLayouts/Profile/views/CommunitiesView.qml
+++ b/ui/app/AppLayouts/Profile/views/CommunitiesView.qml
@@ -107,6 +107,20 @@ SettingsContentBase {
             }
 
             Heading {
+                text: qsTr("TokenMaster")
+                visible: panelTokenMasters.count
+            }
+
+            Panel {
+                id: panelTokenMasters
+                filters: ValueFilter {
+                    readonly property int role: Constants.memberRole.tokenMaster
+                    roleName: "memberRole"
+                    value: role
+                }
+            }
+
+            Heading {
                 text: qsTr("Admin")
                 visible: panelAdmins.count
             }
@@ -130,7 +144,8 @@ SettingsContentBase {
                 filters: ExpressionFilter {
                     readonly property int ownerRole: Constants.memberRole.owner
                     readonly property int adminRole: Constants.memberRole.admin
-                    expression: model.joined && model.memberRole !== ownerRole && model.memberRole !== adminRole
+                    readonly property int tokenMasterRole: Constants.memberRole.tokenMaster
+                    expression: model.joined && model.memberRole !== ownerRole && model.memberRole !== adminRole && model.memberRole !== tokenMasterRole
                 }
             }
 

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -402,6 +402,7 @@ QtObject {
         readonly property int manageUsers: 2
         readonly property int moderateContent: 3
         readonly property int admin: 4
+        readonly property int tokenMaster: 5 // TODO no real backend for this yet
     }
 
     readonly property QtObject permissionType: QtObject{


### PR DESCRIPTION
Add a `memberRole` value and section for the TokenMaster category in Settings/Communities

Fixes #11308

### Affected areas

Settings/Communities

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![Snímek obrazovky z 2023-07-19 22-08-28](https://github.com/status-im/status-desktop/assets/5377645/e58229d0-7bc5-4c16-bae9-b92243432ee0)
