### PR TITLE
11182 remote destruct state

### DIFF
--- a/src/app/modules/main/communities/tokens/models/token_item.nim
+++ b/src/app/modules/main/communities/tokens/models/token_item.nim
@@ -16,7 +16,9 @@ type
     chainIcon*: string
     accountName*: string
     remainingSupply*: Uint256
+    destructedAmount*: Uint256
     burnState*: ContractTransactionStatus
+    remoteDestructedAddresses*: seq[string]
     tokenOwnersModel*: token_owners_model.TokenOwnersModel
 
 proc initTokenItem*(
@@ -25,7 +27,9 @@ proc initTokenItem*(
   tokenOwners: seq[CollectibleOwner],
   accountName: string,
   burnState: ContractTransactionStatus,
-  remainingSupply: Uint256
+  remoteDestructedAddresses: seq[string],
+  remainingSupply: Uint256,
+  destructedAmount: Uint256
 ): TokenItem =
   result.tokenDto = tokenDto
   if network != nil:
@@ -33,11 +37,13 @@ proc initTokenItem*(
     result.chainIcon = network.iconURL
   result.accountName = accountName
   result.remainingSupply = remainingSupply
+  result.destructedAmount = destructedAmount
   result.burnState = burnState
+  result.remoteDestructedAddresses = remoteDestructedAddresses
   result.tokenOwnersModel = newTokenOwnersModel()
   result.tokenOwnersModel.setItems(tokenOwners.map(proc(owner: CollectibleOwner): TokenOwnersItem =
           # TODO find member with the address - later when airdrop to member will be added
-          result = initTokenOwnersItem("", "", owner)
+          result = initTokenOwnersItem("", "", owner, remoteDestructedAddresses)
         ))
 
 proc `$`*(self: TokenItem): string =
@@ -46,7 +52,9 @@ proc `$`*(self: TokenItem): string =
     chainName: {self.chainName},
     chainIcon: {self.chainIcon},
     remainingSupply: {self.remainingSupply},
+    destructedAmount: {self.destructedAmount},
     burnState: {self.burnState},
-    tokenOwnersModel: {self.tokenOwnersModel}
+    tokenOwnersModel: {self.tokenOwnersModel},
+    remoteDestructedAddresses: {self.remoteDestructedAddresses}
     ]"""
 

--- a/src/app/modules/main/communities/tokens/models/token_owners_item.nim
+++ b/src/app/modules/main/communities/tokens/models/token_owners_item.nim
@@ -1,5 +1,6 @@
 import strformat, stint
 import backend/collectibles_types
+import ../../../../../../app_service/common/types
 
 type
   TokenOwnersItem* = object
@@ -7,15 +8,23 @@ type
     imageSource*: string
     ownerDetails*: CollectibleOwner
     amount*: int
+    remotelyDestructState*: ContractTransactionStatus
+
+proc remoteDestructTransactionStatus*(remoteDestructedAddresses: seq[string], address: string): ContractTransactionStatus =
+  if remoteDestructedAddresses.contains(address):
+    return ContractTransactionStatus.InProgress
+  return ContractTransactionStatus.Completed
 
 proc initTokenOwnersItem*(
   name: string,
   imageSource: string,
-  ownerDetails: CollectibleOwner
+  ownerDetails: CollectibleOwner,
+  remoteDestructedAddresses: seq[string]
 ): TokenOwnersItem =
   result.name = name
   result.imageSource = imageSource
   result.ownerDetails = ownerDetails
+  result.remotelyDestructState = remoteDestructTransactionStatus(remoteDestructedAddresses, ownerDetails.address)
   for balance in ownerDetails.balances:
     result.amount = result.amount + balance.balance.truncate(int)
 

--- a/src/app/modules/main/communities/tokens/models/token_owners_model.nim
+++ b/src/app/modules/main/communities/tokens/models/token_owners_model.nim
@@ -7,6 +7,7 @@ type
     ImageSource
     WalletAddress
     Amount
+    RemotelyDestructState
 
 QtObject:
   type TokenOwnersModel* = ref object of QAbstractListModel
@@ -47,7 +48,17 @@ QtObject:
       ModelRole.ImageSource.int:"imageSource",
       ModelRole.WalletAddress.int:"walletAddress",
       ModelRole.Amount.int:"amount",
+      ModelRole.RemotelyDestructState.int:"remotelyDestructState"
     }.toTable
+
+  proc updateRemoteDestructState*(self: TokenOwnersModel, remoteDestructedAddresses: seq[string]) =
+    let indexBegin = self.createIndex(0, 0, nil)
+    let indexEnd = self.createIndex(self.items.len - 1, 0, nil)
+    defer: indexBegin.delete
+    defer: indexEnd.delete
+    for i in 0 ..< self.items.len:
+      self.items[0].remotelyDestructState = remoteDestructTransactionStatus(remoteDestructedAddresses, self.items[0].ownerDetails.address)
+    self.dataChanged(indexBegin, indexEnd, @[ModelRole.RemotelyDestructState.int])
 
   method data(self: TokenOwnersModel, index: QModelIndex, role: int): QVariant =
     if not index.isValid:
@@ -65,6 +76,8 @@ QtObject:
         result = newQVariant(item.ownerDetails.address)
       of ModelRole.Amount:
         result = newQVariant(item.amount)
+      of ModelRole.RemotelyDestructState:
+        result = newQVariant(item.remotelyDestructState.int)
 
   proc `$`*(self: TokenOwnersModel): string =
       for i in 0 ..< self.items.len:

--- a/src/app/modules/main/io_interface.nim
+++ b/src/app/modules/main/io_interface.nim
@@ -297,13 +297,16 @@ method onCommunityTokenOwnersFetched*(self: AccessInterface, communityId: string
 method onCommunityTokenDeployStateChanged*(self: AccessInterface, communityId: string, chainId: int, contractAddress: string, deployState: DeployState) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method onCommunityTokenSupplyChanged*(self: AccessInterface, communityId: string, chainId: int, contractAddress: string, supply: Uint256, remainingSupply: Uint256) {.base.} =
+method onCommunityTokenSupplyChanged*(self: AccessInterface, communityId: string, chainId: int, contractAddress: string, supply: Uint256, remainingSupply: Uint256, destructedAmount: Uint256) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method onCommunityTokenRemoved*(self: AccessInterface, communityId: string, chainId: int, contractAddress: string) =
   raise newException(ValueError, "No implementation available")
 
 method onBurnStateChanged*(self: AccessInterface, communityId: string, chainId: int, contractAddress: string, burnState: ContractTransactionStatus) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method onRemoteDestructed*(self: AccessInterface, communityId: string, chainId: int, contractAddress: string, addresses: seq[string]) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method onAcceptRequestToJoinFailed*(self: AccessInterface, communityId: string, memberKey: string, requestId: string) {.base.} =

--- a/src/app/modules/shared_models/section_item.nim
+++ b/src/app/modules/shared_models/section_item.nim
@@ -338,14 +338,17 @@ proc removeCommunityToken*(self: SectionItem, chainId: int, contractAddress: str
 proc updateCommunityTokenDeployState*(self: SectionItem, chainId: int, contractAddress: string, deployState: DeployState) {.inline.} =
   self.communityTokensModel.updateDeployState(chainId, contractAddress, deployState)
 
-proc updateCommunityTokenSupply*(self: SectionItem, chainId: int, contractAddress: string, supply: Uint256) {.inline.} =
-  self.communityTokensModel.updateSupply(chainId, contractAddress, supply)
+proc updateCommunityTokenSupply*(self: SectionItem, chainId: int, contractAddress: string, supply: Uint256, destructedAmount: Uint256) {.inline.} =
+  self.communityTokensModel.updateSupply(chainId, contractAddress, supply, destructedAmount)
 
 proc updateCommunityRemainingSupply*(self: SectionItem, chainId: int, contractAddress: string, remainingSupply: Uint256) {.inline.} =
   self.communityTokensModel.updateRemainingSupply(chainId, contractAddress, remainingSupply)
 
 proc updateBurnState*(self: SectionItem, chainId: int, contractAddress: string, burnState: ContractTransactionStatus) {.inline.} =
   self.communityTokensModel.updateBurnState(chainId, contractAddress, burnState)
+
+proc updateRemoteDestructedAddresses*(self: SectionItem, chainId: int, contractAddress: string, addresess: seq[string]) {.inline.} =
+  self.communityTokensModel.updateRemoteDestructedAddresses(chainId, contractAddress, addresess)
 
 proc setCommunityTokenOwners*(self: SectionItem, chainId: int, contractAddress: string, owners: seq[CollectibleOwner]) {.inline.} =
   self.communityTokensModel.setCommunityTokenOwners(chainId, contractAddress, owners)

--- a/src/backend/community_tokens.nim
+++ b/src/backend/community_tokens.nim
@@ -83,3 +83,7 @@ proc deployCollectiblesEstimate*(): RpcResponse[JsonNode] {.raises: [Exception].
 proc deployAssetsEstimate*(): RpcResponse[JsonNode] {.raises: [Exception].} =
   let payload = %*[]
   return core.callPrivateRPC("collectibles_deployAssetsEstimate", payload)
+
+proc remoteDestructedAmount*(chainId: int, contractAddress: string): RpcResponse[JsonNode] {.raises: [Exception].} =
+  let payload = %*[chainId, contractAddress]
+  return core.callPrivateRPC("collectibles_remoteDestructedAmount", payload)

--- a/ui/app/AppLayouts/Communities/panels/MintTokensSettingsPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/MintTokensSettingsPanel.qml
@@ -739,9 +739,9 @@ StackView {
                     token.transferable: model.transferable
                     token.type: model.tokenType
                     token.burnState: model.burnState
+                    token.remotelyDestructState: model.remotelyDestructState
                     // TODO: Backend
                     //token.accountAddress: model.accountAddress
-                    //token.remotelyDestructState: model.remotelyDestructState
                 }
 
                 onCountChanged: {


### PR DESCRIPTION
### What does the PR do

Expose remote destruct state via tokens model and token holders model.

_Technical details:_
There are 2 new properties in the model: destructedAmount and remoteDestructedAddresses.
1. destructedAmount is used to show the correct Total value. During remote destruction we do not change supply, but we need to show the decreased supply for the user. We show total(UI) = supply - destructed_tokens. Example:
Total = 10, Airdropped= 5, Remaining=5 , Destructed = 0
Then we destruct 1 airdropped token and we have:
Total = 9, Airdropped=4, Remaining=5, Destructed = 1
2. remoteDestructedAddresses is used to show the remote destruct state (by checking len()) and also to set destruct state for concrete holders.

@noeliaSD @micieslak we need a new UI task to show burn icon in holders view. The name of property is "remotelyDestructState".

### Screenshot of functionality (including design for comparison)

https://github.com/status-im/status-desktop/assets/61889657/4c124ed3-9065-46af-ac39-e74810fa08e7

