### PR TITLE
feat(OwnerToken): Add all mint states views design details

### DIFF
--- a/storybook/pages/AirdropsSettingsPanelPage.qml
+++ b/storybook/pages/AirdropsSettingsPanelPage.qml
@@ -90,10 +90,17 @@ SplitView {
 
                 anchors.fill: parent
                 anchors.topMargin: 50
+
+                // User profile
                 isOwner: ownerChecked.checked
                 isTokenMasterOwner: masterTokenOwnerChecked.checked
                 isAdmin: adminChecked.checked
-                tokensModel: editorModelChecked.checked ? emptyModel : mintedTokensModel
+
+                // Owner and TMaster related props:
+                isOwnerTokenDeployed: deployCheck.checked
+                isTMasterTokenDeployed: deployCheck.checked
+
+                // Models
                 assetsModel: AssetsModel {}
                 collectiblesModel: ListModel {}
 
@@ -228,10 +235,10 @@ SplitView {
             }
 
             CheckBox {
-                id: editorModelChecked
-                checked: true
+                id: deployCheck
+                checked: false
 
-                text: "No tokens minted yet"
+                text: "Owner and TMaster tokens deployed"
             }
         }
     }

--- a/storybook/pages/MintTokensSettingsPanelPage.qml
+++ b/storybook/pages/MintTokensSettingsPanelPage.qml
@@ -6,6 +6,8 @@ import AppLayouts.Communities.panels 1.0
 import AppLayouts.Chat.stores 1.0
 import StatusQ.Core.Theme 0.1
 
+import SortFilterProxyModel 0.2
+
 import Storybook 1.0
 import Models 1.0
 
@@ -48,15 +50,37 @@ SplitView {
                 id: mintedTokensModel
             }
 
+            SortFilterProxyModel {
+                id: privilegedTokensModel
+
+                sourceModel: mintedTokensModel
+
+                filters: ValueFilter {
+                    roleName: "isPrivilegedToken"
+                    value: true
+                }
+            }
+
             anchors.fill: parent
             anchors.topMargin: 50
-            tokensModel: editorModelChecked.checked ? emptyModel : mintedTokensModel
-            isAdmin: adminChecked.checked
-            isOwner: ownerChecked.checked
+
+            // General:
             communityLogo: ModelsData.collectibles.doodles
             communityColor: "#FFC4E9"
-            communityName: communityNameText.text
+            communityName: "Doodles" // It cannot be changed since owner token and tMaster token in tokenModel used are related to the `Doodles` community
+
+            // Profile type:
+            isAdmin: adminChecked.checked
+            isOwner: ownerChecked.checked
             isTokenMasterOwner: masterTokenOwnerChecked.checked
+
+            // Owner and TMaster related props:
+            isOwnerTokenDeployed: deployCheck.checked
+            isTMasterTokenDeployed: deployCheck.checked
+
+            // Models:
+            tokensModel: editorModelChecked.checked ? emptyModel :
+                                                      privilegedModelChecked.checked ? privilegedTokensModel : mintedTokensModel
             layer1Networks: NetworksModel.layer1Networks
             layer2Networks: NetworksModel.layer2Networks
             testNetworks: NetworksModel.testNetworks
@@ -68,10 +92,10 @@ SplitView {
                     symbol: "MAI"
                 }
             }
+
             onMintCollectible: logs.logEvent("CommunityMintTokensSettingsPanel::mintCollectible")
             onMintAsset: logs.logEvent("CommunityMintTokensSettingsPanel::mintAssets")
             onDeleteToken: logs.logEvent("CommunityMintTokensSettingsPanel::deleteToken: " + tokenKey)
-
             onSignMintTransactionOpened: feesTimer.restart()
         }
     }
@@ -80,24 +104,11 @@ SplitView {
         id: logsAndControlsPanel
 
         SplitView.minimumHeight: 100
-        SplitView.preferredHeight: 250
+        SplitView.preferredHeight: 300
 
         logsView.logText: logs.logText
 
         ColumnLayout {
-
-            Row {
-                Label {
-                    text: "Community name: "
-                }
-
-                TextEdit {
-                    id: communityNameText
-
-                    text: "TEST COMMUNITY"
-                }
-            }
-
             CheckBox {
                 id: ownerChecked
                 checked: true
@@ -119,28 +130,46 @@ SplitView {
                 text: "Is admin? [Admis will be able to see token views, but NOT manage them, like creating new artwork or asset]"
             }
 
-            CheckBox {
-                id: editorModelChecked
-                checked: true
+            RowLayout {
+                RadioButton {
+                    id: editorModelChecked
 
-                text: "No tokens minted yet"
+                    checked: true
+
+                    text: "No tokens minted yet"
+                }
+                RadioButton {
+                    id: privilegedModelChecked
+
+                    text: "Owner token and TMaster token only"
+                }
+                RadioButton {
+                    id: completeModelChecked
+
+                    text: "Minted tokens list"
+                }
             }
 
             RowLayout {
-                Button {
+
+                RadioButton {
                     text: "Set all to 'In progress'"
 
                     onClicked: mintedTokensModel.changeAllMintingStates(1)
                 }
-                Button {
-                    text: "Set all to 'Deployed'"
 
-                    onClicked: mintedTokensModel.changeAllMintingStates(2)
-                }
-                Button {
+                RadioButton {
                     text: "Set all to 'Error'"
 
                     onClicked: mintedTokensModel.changeAllMintingStates(0)
+                }
+
+                RadioButton {
+                    id: deployCheck
+
+                    text: "Set all to 'Deployed'"
+
+                    onClicked: mintedTokensModel.changeAllMintingStates(2)
                 }
             }
         }

--- a/storybook/pages/MintedTokensViewPage.qml
+++ b/storybook/pages/MintedTokensViewPage.qml
@@ -51,6 +51,9 @@ SplitView {
                 anchors.fill: parent
                 anchors.margins: 50
                 model: filteredTokensModel
+                isOwner: true
+                isAdmin: false
+
                 onItemClicked: logs.logEvent("MintedTokensView::itemClicked",
                                              ["tokenKey"], [tokenKey])
             }

--- a/storybook/src/Models/MintedTokensModel.qml
+++ b/storybook/src/Models/MintedTokensModel.qml
@@ -7,6 +7,48 @@ ListModel {
 
     readonly property var data: [
         {
+            isPrivilegedToken: true,
+            isOwner: true,
+            contractUniqueKey: "0x15a23414a3",
+            tokenType: 2,
+            name: "Owner-Doodles",
+            image: ModelsData.collectibles.doodles,
+            deployState: 0,
+            symbol: "OWNDOO",
+            description: "Owner doodles desc",
+            supply: 1,
+            remainingSupply: 1,
+            infiniteSupply: false,
+            transferable: true,
+            remoteSelfDestruct: false,
+            chainId: 2,
+            chainName: "Optimism",
+            chainIcon: ModelsData.networks.optimism,
+            accountName: "Another account - generated"
+        },
+        {
+            isPrivilegedToken: true,
+            isOwner: false,
+            contractUniqueKey: "0x23124443",
+            tokenType: 2,
+            name: "TMaster-Doodles",
+            image: ModelsData.collectibles.doodles,
+            deployState: 0,
+            symbol: "TMDOO",
+            description: "Doodles Token master token description",
+            supply: 1,
+            remainingSupply: 1,
+            infiniteSupply: true,
+            transferable: false,
+            remoteSelfDestruct: true,
+            chainId: 2,
+            chainName: "Optimism",
+            chainIcon: ModelsData.networks.optimism,
+            accountName: "Another account - generated"
+        },
+        {
+            isPrivilegedToken: false,
+            isOwner: false,
             contractUniqueKey: "0x1726362343",
             tokenType: 2,
             name: "SuperRare artwork",
@@ -25,6 +67,8 @@ ListModel {
             accountName: "Status Account"
         },
         {
+            isPrivilegedToken: false,
+            isOwner: false,
             contractUniqueKey: "0x847843",
             tokenType: 2,
             name: "Kitty artwork",
@@ -43,6 +87,8 @@ ListModel {
             accountName: "Status New Account"
         },
         {
+            isPrivilegedToken: false,
+            isOwner: false,
             contractUniqueKey: "0x1234525",
             tokenType: 2,
             name: "More artwork",
@@ -61,6 +107,8 @@ ListModel {
             accountName: "Other Account"
         },
         {
+            isPrivilegedToken: false,
+            isOwner: false,
             contractUniqueKey: "0x38576852",
             tokenType: 2,
             name: "Crypto Punks artwork",
@@ -80,6 +128,8 @@ ListModel {
             tokenOwnersModel: root.tokenOwnersModel
         },
         {
+            isPrivilegedToken: false,
+            isOwner: false,
             contractUniqueKey: "0x38745623865",
             tokenType: 1,
             name: "Unisocks",
@@ -97,6 +147,8 @@ ListModel {
             accountName: "Status SNT Account"
         },
         {
+            isPrivilegedToken: false,
+            isOwner: false,
             contractUniqueKey: "0x872364871623",
             tokenType: 1,
             name: "Dai",

--- a/ui/app/AppLayouts/Communities/helpers/PermissionsHelpers.qml
+++ b/ui/app/AppLayouts/Communities/helpers/PermissionsHelpers.qml
@@ -83,13 +83,19 @@ QtObject {
         }
     }
 
+    // OWNER AND TMASTER TOKENS related helpers:
+    readonly property string ownerTokenNameTag: "Owner-"
+    readonly property string tMasterTokenNameTag: "TMaster-"
+    readonly property string ownerTokenSymbolTag: "OWN"
+    readonly property string tMasterTokenSymbolTag: "TM"
+
     // It generates a symbol from a given community name.
     // It will be used to autogenerate the Owner and Token Master token symbols.
-    function autogenerateSymbol(isOwner, communityName) {
+    function communityNameToSymbol(isOwner, communityName) {
         const shortName = communityName.substring(0, 3)
         if(isOwner)
-            return "OWN" + shortName.toUpperCase()
+            return ownerTokenSymbolTag + shortName.toUpperCase()
         else
-            return "TM" + shortName.toUpperCase()
+            return tMasterTokenSymbolTag + shortName.toUpperCase()
     }
 }

--- a/ui/app/AppLayouts/Communities/panels/PrivilegedTokenArtworkPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/PrivilegedTokenArtworkPanel.qml
@@ -23,14 +23,34 @@ Control {
     QtObject {
         id: d
 
-        readonly property int imageSize: size === PrivilegedTokenArtworkPanel.Size.Small ? 80 : 186
-        readonly property int bgSize: size === PrivilegedTokenArtworkPanel.Size.Small ? 120 : 280
-        readonly property int iconSize: size === PrivilegedTokenArtworkPanel.Size.Small ? 16 : 38
-        readonly property int iconMargins: size === PrivilegedTokenArtworkPanel.Size.Small ? 8 : 16
+        readonly property int imageSize: ({
+                                              [PrivilegedTokenArtworkPanel.Size.Small]: 80,
+                                              [PrivilegedTokenArtworkPanel.Size.Medium]: 109,
+                                              [PrivilegedTokenArtworkPanel.Size.Large]: 186
+                                          }[size])
+
+        readonly property int bgSize: ({
+                                           [PrivilegedTokenArtworkPanel.Size.Small]: 120,
+                                           [PrivilegedTokenArtworkPanel.Size.Medium]: 164,
+                                           [PrivilegedTokenArtworkPanel.Size.Large]: 280
+                                       }[size])
+
+        readonly property int iconSize: ({
+                                             [PrivilegedTokenArtworkPanel.Size.Small]: 14,
+                                             [PrivilegedTokenArtworkPanel.Size.Medium]: 16,
+                                             [PrivilegedTokenArtworkPanel.Size.Large]: 38
+                                         }[size])
+
+        readonly property int iconMargins: ({
+                                                [PrivilegedTokenArtworkPanel.Size.Small]: 8,
+                                                [PrivilegedTokenArtworkPanel.Size.Medium]: 12,
+                                                [PrivilegedTokenArtworkPanel.Size.Large]: 16
+                                            }[size])
     }
 
     enum Size {
         Small,
+        Medium,
         Large
     }
 
@@ -38,7 +58,7 @@ Control {
     implicitHeight: implicitWidth
 
     background: Rectangle {
-        color: "transparent"
+        color: Theme.palette.statusAppLayout.rightPanelBackgroundColor
         radius: 8
         border.color: Theme.palette.baseColor2
     }

--- a/ui/app/AppLayouts/Communities/panels/TokenInfoPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/TokenInfoPanel.qml
@@ -19,6 +19,8 @@ Control {
 
     // Panel properties:
     property bool preview: false
+    property bool accountBoxVisible: true
+    property bool networkBoxVisible: true
 
     // Token object properties:
     /* required */ property TokenObject token // https://bugreports.qt.io/browse/QTBUG-84269
@@ -211,14 +213,14 @@ Control {
             }
 
             CustomPreviewBox {
-                visible: !token.isPrivilegedToken
+                visible: root.accountBoxVisible
 
                 label: qsTr("Account")
                 value: token.accountName
             }
 
             Rectangle {
-                visible: !token.isPrivilegedToken
+                visible: root.networkBoxVisible
                 height: symbolBox.height
                 width: rowChain.implicitWidth + 2 * Style.current.padding
                 border.width: 1

--- a/ui/app/AppLayouts/Communities/views/CommunitySettingsView.qml
+++ b/ui/app/AppLayouts/Communities/views/CommunitySettingsView.qml
@@ -20,6 +20,7 @@ import utils 1.0
 import AppLayouts.Communities.controls 1.0
 import AppLayouts.Communities.panels 1.0
 import AppLayouts.Communities.popups 1.0
+import AppLayouts.Communities.helpers 1.0
 
 StatusSectionLayout {
     id: root
@@ -300,12 +301,21 @@ StatusSectionLayout {
                 mintPanel.isFeeLoading = true
             }
 
+            // General community props
             communityName: root.community.name
             communityLogo: root.community.image
             communityColor: root.community.color
+
+            // User profile props
             isOwner: root.isOwner
             isAdmin: root.isAdmin
             isTokenMasterOwner: false // TODO: Backend
+
+            // Owner and TMaster properties
+            isOwnerTokenDeployed: tokensModelChangesTracker.isOwnerTokenDeployed
+            isTMasterTokenDeployed: tokensModelChangesTracker.isTMasterTokenDeployed
+
+            // Models
             tokensModel: root.community.communityTokens
             tokensModelWallet: root.rootStore.tokensModelWallet
             layer1Networks: communityTokensStore.layer1Networks
@@ -367,10 +377,15 @@ StatusSectionLayout {
             readonly property bool sectionEnabled: root.isOwner
 
             communityDetails: d.communityDetails
+
+            // Profile type
             isOwner: root.isOwner
             isTokenMasterOwner: false // TODO: Backend
             isAdmin: root.isAdmin
-            tokensModel: root.community.communityTokens
+
+            // Owner and TMaster properties
+            isOwnerTokenDeployed: tokensModelChangesTracker.isOwnerTokenDeployed
+            isTMasterTokenDeployed: tokensModelChangesTracker.isTMasterTokenDeployed
 
             readonly property CommunityTokensStore communityTokensStore:
                 rootStore.communityTokensStore
@@ -501,6 +516,64 @@ StatusSectionLayout {
                     break
                 }
             }
+        }
+    }
+
+    StatusQUtils.ModelChangeTracker {
+        id: tokensModelChangesTracker
+
+        // Owner and TMaster token deployment states
+        property bool isOwnerTokenDeployed: false
+        property bool isTMasterTokenDeployed: false
+
+        // It will monitorize if Owner and/or TMaster token items are included in the `model` despite the deployment state
+        property bool ownerOrTMasterTokenItemsExist: false
+
+        function checkIfPrivilegedTokenItemsExist() {
+           return SQUtils.ModelUtils.contains(model, "name", PermissionsHelpers.ownerTokenNameTag + root.communityName) ||
+                  SQUtils.ModelUtils.contains(model, "name", PermissionsHelpers.tMasterTokenNameTag + root.communityName)
+        }
+
+        function reviewTokenDeployState(tagType, isOwner) {
+            const index = SQUtils.ModelUtils.indexOf(model, "name", tagType + root.communityName)
+            if(index === -1)
+                return false
+
+            const token = SQUtils.ModelUtils.get(model, index)
+
+            // Some assertions:
+            if(!token.isPrivilegedToken)
+                return false
+
+            if(token.isOwner !== isOwner)
+                return false
+
+            // Deploy state check:
+            if(token.deployState !== Constants.ContractTransactionStatus.Completed)
+                return false
+
+            // Token deployed!!
+            return true
+        }
+
+        model: root.community.communityTokens
+
+        onRevisionChanged: {
+            // It will update property to know if Owner and TMaster token items have been added into the tokens list.
+            ownerOrTMasterTokenItemsExist = checkIfPrivilegedTokenItemsExist()
+            if(!ownerOrTMasterTokenItemsExist)
+                return
+
+            // It monitors the deployment:
+            if(!isOwnerTokenDeployed)
+                isOwnerTokenDeployed = reviewTokenDeployState(PermissionsHelpers.ownerTokenNameTag, true)
+
+            if(!isTMasterTokenDeployed)
+                isTMasterTokenDeployed = reviewTokenDeployState(PermissionsHelpers.tMasterTokenNameTag, false)
+
+            // Not necessary to track more changes since privileged tokens have been correctly deployed.
+            if(isOwnerTokenDeployed && isTMasterTokenDeployed)
+                tokensModelChangesTracker.enabled = false
         }
     }
 

--- a/ui/app/AppLayouts/Communities/views/EditOwnerTokenView.qml
+++ b/ui/app/AppLayouts/Communities/views/EditOwnerTokenView.qml
@@ -44,7 +44,7 @@ StatusScrollView {
         isOwner: true
         artworkSource: root.communityLogo
         color: root.communityColor
-        symbol: PermissionsHelpers.autogenerateSymbol(isOwner, root.communityName)
+        symbol: PermissionsHelpers.communityNameToSymbol(isOwner, root.communityName)
         transferable: true
         remotelyDestruct: false
         supply: 1
@@ -56,7 +56,7 @@ StatusScrollView {
         isPrivilegedToken: true
         artworkSource: root.communityLogo
         color: root.communityColor
-        symbol: PermissionsHelpers.autogenerateSymbol(isOwner, root.communityName)
+        symbol: PermissionsHelpers.communityNameToSymbol(isOwner, root.communityName)
         remotelyDestruct: true
         description: qsTr("This is the %1 TokenMaster token. The hodler of this collectible has full admin rights for the %1 Community in Status and can mint and airdrop %1 Community tokens.").arg(root.communityName)
     }
@@ -90,13 +90,15 @@ StatusScrollView {
             font.pixelSize: d.titleSize
             font.bold: true
 
-            text: qsTr("Owner-%1").arg(root.communityName)
+            text: PermissionsHelpers.ownerTokenNameTag + root.communityName
         }
 
         TokenInfoPanel {
             Layout.fillWidth: true
 
             token: root.ownerToken
+            accountBoxVisible: false
+            networkBoxVisible: false
         }
 
         StatusModalDivider {
@@ -114,13 +116,15 @@ StatusScrollView {
             font.pixelSize: d.titleSize
             font.bold: true
 
-            text: qsTr("TMaster-%1").arg(root.communityName)
+            text: PermissionsHelpers.tMasterTokenNameTag + root.communityName
         }
 
         TokenInfoPanel {
             Layout.fillWidth: true
 
             token: root.tMasterToken
+            accountBoxVisible: false
+            networkBoxVisible: false
         }
 
         StatusModalDivider {

--- a/ui/app/AppLayouts/Communities/views/OwnerTokenWelcomeView.qml
+++ b/ui/app/AppLayouts/Communities/views/OwnerTokenWelcomeView.qml
@@ -134,7 +134,7 @@ StatusScrollView {
 
                                 Layout.alignment: Qt.AlignBottom
 
-                                text: PermissionsHelpers.autogenerateSymbol(panel.isOwner, root.communityName)
+                                text: PermissionsHelpers.communityNameToSymbol(panel.isOwner, root.communityName)
                                 font.pixelSize: Style.current.primaryTextFontSize
                                 color: Theme.palette.baseColor1
                             }

--- a/ui/app/AppLayouts/Wallet/views/collectibles/CollectibleView.qml
+++ b/ui/app/AppLayouts/Wallet/views/collectibles/CollectibleView.qml
@@ -7,6 +7,8 @@ import StatusQ.Core.Theme 0.1
 import StatusQ.Components 0.1
 import StatusQ.Controls 0.1
 
+import AppLayouts.Communities.panels 1.0
+
 import utils 1.0
 
 Control {
@@ -21,6 +23,11 @@ Control {
     property url fallbackImageUrl : ""
     property bool isLoading: false
     property bool navigationIconVisible: false
+
+    // Special Owner and TMaster token properties
+    property bool isPrivilegedToken: false // Owner or TMaster tokens
+    property bool isOwner: false // Owner token
+    property color ornamentColor // Relevant color for these special tokens (community color)
 
     signal clicked
 
@@ -43,6 +50,8 @@ Control {
             Layout.margins: Style.current.halfPadding
             Layout.fillWidth: true
             Layout.preferredHeight: width
+
+            visible: !root.isPrivilegedToken
             radius: 8
             mediaUrl: root.mediaUrl
             mediaType: root.mediaType
@@ -51,6 +60,25 @@ Control {
             border.width: 1
             showLoadingIndicator: true
             color: root.isLoading ? "transparent": root.backgroundColor
+
+            Loader {
+                anchors.fill: parent
+                active: root.isLoading
+                sourceComponent: LoadingComponent {radius: image.radius}
+            }
+        }
+
+        PrivilegedTokenArtworkPanel {
+            Layout.alignment: Qt.AlignHCenter
+            Layout.margins: Style.current.halfPadding
+            Layout.fillWidth: true
+            Layout.preferredHeight: width
+
+            visible: root.isPrivilegedToken
+            size: PrivilegedTokenArtworkPanel.Size.Medium
+            artwork: root.fallbackImageUrl
+            color: root.ornamentColor
+            isOwner: root.isOwner
 
             Loader {
                 anchors.fill: parent
@@ -90,6 +118,7 @@ Control {
             id: subTitleItem
 
             Layout.alignment: Qt.AlignLeft
+            Layout.topMargin: 3
             Layout.leftMargin: Style.current.halfPadding
             Layout.rightMargin: Layout.leftMargin
             Layout.fillWidth: !root.isLoading

--- a/ui/imports/shared/stores/CommunityTokensStore.qml
+++ b/ui/imports/shared/stores/CommunityTokensStore.qml
@@ -49,6 +49,8 @@ QtObject {
     {
         // NOTE for backend team: `ownerToken` and `tMasterToken` can be used to do an assertion before the deployment process starts, since
         // the objects have been created to display the token details to the user and must be the same than backend builds.
+        // TODO: Backend will need to check if the ownerToken or tMasterToken have a valid tokenKey, so it means a deployment retry,
+        // otherwise, it is a new deployment.
         console.log("TODO: Backend Owner and Token Master token deployment!")
     }
 


### PR DESCRIPTION
Closes #11299

### What does the PR do

- Added `storybook` support to change minted tokens model with Owner and TMaster tokens.
- Added new properties into the `tokenModel` model.
- Extended `CollectiblesView` to allow Owner and TMaster tokens representation.
- Updated `MintedTokensView` in order to display Owner and TMaster tokens.
- Added logic to `enable/disable` MINT and AIRDROP token depending on the owner /  tmaster tokens deploy state.
- Added temp buttons in MINT and AIRDROP pages that keeps enabled the flows although owner and tmaster backend is not ready. **They will be removed by this [task](https://github.com/status-im/status-desktop/issues/11612)**
- Extended navigation from outsite to minting section, depending on user profile and owner and tmaster states.
- Hide footer options in case of owner or tmaster token item visualized and user profile type.
- Added retry flow. [Use case not covered here](https://github.com/status-im/status-desktop/issues/11613)

**NOTE: Backend not ready. Just UI and mocked data in `storybook`.**

### Affected areas

Community Settings / Mint Tokens - Airdrop

### Screenshot of functionality 

- Owner profile flows and options:

https://github.com/status-im/status-desktop/assets/97019400/226f8f96-e13b-4461-88a1-97a4fab50c1e

- TMaster owner profile flows and options:

https://github.com/status-im/status-desktop/assets/97019400/9d1a7ab7-7e40-494b-9347-fc2a4fedd4c3

- Admin profile flows and options:

https://github.com/status-im/status-desktop/assets/97019400/6b82e06e-5dd0-4dbf-8ed8-28a57f02e72a

- Some app navigations:

https://github.com/status-im/status-desktop/assets/97019400/e2763557-30e1-4871-8b2a-b95df3986c8a