### PR TITLE
feat(token-permissions): display channel names in SharedAddressesPanel

### DIFF
--- a/storybook/src/Models/PermissionsModel.qml
+++ b/storybook/src/Models/PermissionsModel.qml
@@ -504,10 +504,12 @@ QtObject {
     function createChannelsModel1() {
         return [
                     {
-                        key: "_welcome"
+                        key: "_welcome",
+                        channelName: "Intro/welcome channel"
                     },
                     {
-                        key: "_general"
+                        key: "_general",
+                        channelName: "General"
                     }
                 ]
     }
@@ -517,6 +519,11 @@ QtObject {
     }
 
     function createChannelsModel3() {
-        return [{ key: "_vip" } ]
+        return [
+                    {
+                        key: "_vip",
+                        channelName: "Club VIP"
+                    }
+                ]
     }
 }

--- a/ui/StatusQ/include/StatusQ/permissionutilsinternal.h
+++ b/ui/StatusQ/include/StatusQ/permissionutilsinternal.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QObject>
+#include <QJsonArray>
 
 class QAbstractItemModel;
 
@@ -14,6 +15,7 @@ public:
     //!< traverse the permissions @p model, and look for unique token keys recursively under holdingsListModel->key
     Q_INVOKABLE QStringList getUniquePermissionTokenKeys(QAbstractItemModel *model) const;
 
-    //!< traverse the permissions @p model, and look for unique channel keys recursively under channelsListModel->key; filtering out @permissionTypes ([PermissionTypes.Type.FOO])
-    Q_INVOKABLE QStringList getUniquePermissionChannels(QAbstractItemModel *model, const QList<int> &permissionTypes = {}) const;
+    //!< traverse the permissions @p model, and look for unique channels recursively under channelsListModel->key; filtering out @permissionTypes ([PermissionTypes.Type.FOO])
+    //! @return an array of array<key,channelName>
+    Q_INVOKABLE QJsonArray getUniquePermissionChannels(QAbstractItemModel *model, const QList<int> &permissionTypes = {}) const;
 };

--- a/ui/app/AppLayouts/Communities/panels/SharedAddressesPermissionsPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/SharedAddressesPermissionsPanel.qml
@@ -103,7 +103,7 @@ Rectangle {
             }
 
             Repeater { // channel repeater
-                model: d.uniquePermissionChannels // TODO get channelName in addition (https://github.com/status-im/status-desktop/issues/11481)
+                model: d.uniquePermissionChannels
                 delegate: ChannelPermissionPanel {}
             }
         }
@@ -144,7 +144,7 @@ Rectangle {
             case PermissionTypes.Type.Member:
                 return qsTr("Join %1").arg(root.communityName)
             default:
-                return modelData // TODO display channel name https://github.com/status-im/status-desktop/issues/11481
+                return d.uniquePermissionChannels[index][1]
             }
         }
     }
@@ -304,7 +304,7 @@ Rectangle {
         padding: d.absLeftMargin
         background: PanelBg {}
 
-        readonly property string channelKey: modelData
+        readonly property string channelKey: d.uniquePermissionChannels[index][0]
 
         contentItem: RowLayout {
             spacing: Style.current.padding


### PR DESCRIPTION
Modify the PermissionUtils a bit to return an array of `[key, channelName]` instead of just the keys and use it to display the channel names in the permissions overview panel

(I could have used `QVariantMap` or `QJSonObject` here but those are always sorted by `key`, so had to resort to using a plain vector/array)

Fixes #11584

### What does the PR do

Fixes displaying proper channel names in the permissions panel

### Affected areas

SharedAddressesPermissionsPanel

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![image](https://github.com/status-im/status-desktop/assets/5377645/70474e90-3ef9-47e6-995a-eea3b9a18dab)
