### PR TITLE
feat(airdrop): make the airdrop member selector use the airdropAddress

### DIFF
--- a/ui/app/AppLayouts/Communities/panels/AirdropsSettingsPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/AirdropsSettingsPanel.qml
@@ -40,10 +40,8 @@ StackView {
     property int viewWidth: 560 // by design
     property string previousPageName: depth > 1 ? qsTr("Airdrops") : ""
 
-    signal airdropClicked(var airdropTokens, var addresses, var membersPubKeys,
-                          string feeAccountAddress)
-    signal airdropFeesRequested(var contractKeysAndAmounts, var addresses,
-                                string feeAccountAddress)
+    signal airdropClicked(var airdropTokens, var addresses, string feeAccountAddress)
+    signal airdropFeesRequested(var contractKeysAndAmounts, var addresses, string feeAccountAddress)
     signal navigateToMintTokenSettings(bool isAssetType)
 
     function navigateBack() {
@@ -145,7 +143,7 @@ StackView {
                 }
 
                 onAirdropClicked: {
-                    root.airdropClicked(airdropTokens, addresses, membersPubKeys)
+                    root.airdropClicked(airdropTokens, addresses, feeAccountAddress)
                     root.pop(StackView.Immediate)
                 }
 

--- a/ui/app/AppLayouts/Communities/popups/MembersDropdown.qml
+++ b/ui/app/AppLayouts/Communities/popups/MembersDropdown.qml
@@ -34,7 +34,7 @@ StatusDropdown {
         property var keys: []
 
         delegate: QtObject {
-            readonly property string key: model.pubKey
+            readonly property string key: model.airdropAddress
         }
 
         readonly property bool allSelected:
@@ -194,10 +194,10 @@ StatusDropdown {
                 onClicked: {
                     const selectedKeysCopy = new Set([...root.selectedKeys])
 
-                    if (root.selectedKeys.has(model.pubKey))
-                        selectedKeysCopy.delete(model.pubKey)
+                    if (root.selectedKeys.has(model.airdropAddress))
+                        selectedKeysCopy.delete(model.airdropAddress)
                     else
-                        selectedKeysCopy.add(model.pubKey)
+                        selectedKeysCopy.add(model.airdropAddress)
 
                     root.selectedKeys = selectedKeysCopy
                 }
@@ -207,7 +207,7 @@ StatusDropdown {
                         id: contactCheckbox
 
                         size: StatusCheckBox.Size.Small
-                        checked: root.selectedKeys.has(model.pubKey)
+                        checked: root.selectedKeys.has(model.airdropAddress)
 
                         MouseArea {
                             anchors.fill: parent

--- a/ui/app/AppLayouts/Communities/views/EditAirdropView.qml
+++ b/ui/app/AppLayouts/Communities/views/EditAirdropView.qml
@@ -78,11 +78,9 @@ StatusScrollView {
                                           airdropRecipientsSelector.count > 0 &&
                                           airdropRecipientsSelector.valid
 
-    signal airdropClicked(var airdropTokens, var addresses, var membersPubKeys,
-                          string feeAccountAddress)
+    signal airdropClicked(var airdropTokens, var addresses, string feeAccountAddress)
 
-    signal airdropFeesRequested(var contractKeysAndAmounts, var addresses,
-                                string feeAccountAddress)
+    signal airdropFeesRequested(var contractKeysAndAmounts, var addresses, string feeAccountAddress)
 
     signal navigateToMintTokenSettings(bool isAssetType)
 
@@ -234,11 +232,13 @@ StatusScrollView {
             }))
             const addressesArray = ModelUtils.modelToArray(
                                      addresses, ["address"]).map(e => e.address)
+            
+            const airdropAddresses = [...selectedKeysFilter.keys]
 
             const accountItem = ModelUtils.get(root.accountsModel,
                                                feesBox.accountIndex)
 
-            airdropFeesRequested(contractKeysAndAmounts, addressesArray,
+            airdropFeesRequested(contractKeysAndAmounts, addressesArray.concat(airdropAddresses),
                                  accountItem.address)
         }
 
@@ -466,14 +466,14 @@ StatusScrollView {
 
                     property var keys: new Set()
 
-                    expression: keys.has(model.pubKey)
+                    expression: keys.has(model.airdropAddress) && model.airdropAddress !== ""
                 }
             }
 
             onRemoveMemberRequested: {
-                const pubKey = ModelUtils.get(membersModel, index, "pubKey")
+                const airdropAddress = ModelUtils.get(membersModel, index, "airdropAddress")
 
-                selectedKeysFilter.keys.delete(pubKey)
+                selectedKeysFilter.keys.delete(airdropAddress)
                 selectedKeysFilter.keys = new Set([...selectedKeysFilter.keys])
             }
 
@@ -572,6 +572,9 @@ StatusScrollView {
                                          || model.localNickname.toLowerCase().includes(filter)
                                          || model.pubKey.toLowerCase().includes(filter)
                             }
+                        },
+                        ExpressionFilter {
+                            expression: !!model.airdropAddress
                         }
                     ]
                 }
@@ -667,9 +670,9 @@ StatusScrollView {
                 const addresses_ = ModelUtils.modelToArray(
                                     addresses, ["address"]).map(e => e.address)
 
-                const pubKeys = [...selectedKeysFilter.keys]
+                const airdropAddresses = [...selectedKeysFilter.keys]
 
-                root.airdropClicked(airdropTokens, addresses_, pubKeys,
+                root.airdropClicked(airdropTokens, addresses_.concat(airdropAddresses),
                                     accountAddress)
             }
         }


### PR DESCRIPTION
Fixes #11532

Hooks the Airdrop views to the new airdropAddress model property so that the fee calculation and the airdrop transaction can use a valid address.

To test this, I had to "hack" the view so that it let me through, since it requires the Owner Token to be minted, but we can't do that yet. Anyway, that restriction is UI only. I included the "hack" in the PR so that QAs can test.

[airdrop.webm](https://github.com/status-im/status-desktop/assets/11926403/15bf98a7-6b47-4a5e-ab0c-119f9e027e2f)

Successful transaction: https://goerli.etherscan.io/tx/0x70f81b3209f97d2306236883e229ca8a6f6d443dfd84b309fc94ba3ded62cf96