### PR TITLE
fix: Burn and self destruct pop-ups are not closed after signing

### DIFF
--- a/ui/app/AppLayouts/Communities/panels/MintTokensSettingsPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/MintTokensSettingsPanel.qml
@@ -476,9 +476,9 @@ StackView {
 
                 collectibleName: view.token.name
                 model: view.tokenOwnersModel || null
-                destroyOnClose: false
 
                 onRemotelyDestructClicked: {
+                    remotelyDestructPopup.close()
                     footer.remotelyDestructTokensList = remotelyDestructTokensList
                     alertPopup.tokenCount = tokenCount
                     alertPopup.open()
@@ -489,8 +489,6 @@ StackView {
                 id: alertPopup
 
                 property int tokenCount
-
-                destroyOnClose: false
 
                 title: qsTr("Remotely destruct %n token(s)", "", tokenCount)
                 acceptBtnText: qsTr("Remotely destruct")
@@ -521,8 +519,8 @@ StackView {
                 }
 
                 title: signTransactionPopup.isRemotelyDestructTransaction
-                       ? qsTr("Sign transaction - Self-destruct %1 tokens").arg(root.title)
-                       : qsTr("Sign transaction - Burn %1 tokens").arg(root.title)
+                       ? qsTr("Sign transaction - Self-destruct %1 tokens").arg(tokenName)
+                       : qsTr("Sign transaction - Burn %1 tokens").arg(tokenName)
 
                 tokenName: footer.token.name
                 accountName: footer.token.accountName
@@ -537,7 +535,6 @@ StackView {
                             ? root.signRemoteDestructTransactionOpened(footer.remotelyDestructTokensList, tokenKey)
                             : root.signBurnTransactionOpened(tokenKey, footer.burnAmount)
                 }
-                onCancelClicked: close()
                 onSignTransactionClicked: signTransaction()
             }
 
@@ -550,6 +547,7 @@ StackView {
                 tokenSource: footer.token.artworkSource
 
                 onBurnClicked: {
+                    burnTokensPopup.close()
                     footer.burnAmount = burnAmount
                     signTransactionPopup.isRemotelyDestructTransaction = false
                     signTransactionPopup.open()
@@ -571,7 +569,6 @@ StackView {
                 root.deleteToken(tokenViewPage.token.key)
                 root.navigateBack()
             }
-            onCancelClicked: close()
         }
     }
 


### PR DESCRIPTION
- close the first popup before opening another
- fix `SignTokenTransactionsPopup` title (it would display "Burn undefined tokens")
- remove duplicate close() calls
- `destroyOnClose: false` is the default

Fixes #11498

### Affected areas

MintTokensSettingsPanel

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

[Záznam obrazovky z 2023-07-21 14-12-15.webm](https://github.com/status-im/status-desktop/assets/5377645/4bbb199b-acaf-4f57-8170-d651ffe9a0d2)
