### PR TITLE
fix(ActivityCenterStore): Fix `switchTo` messageId argument

### DIFF
--- a/ui/app/mainui/activitycenter/stores/ActivityCenterStore.qml
+++ b/ui/app/mainui/activitycenter/stores/ActivityCenterStore.qml
@@ -86,7 +86,7 @@ QtObject {
     }
 
     function switchTo(notification) {
-        root.activityCenterModuleInst.switchTo(notification.sectionId, notification.chatId, notification.id)
+        root.activityCenterModuleInst.switchTo(notification.sectionId, notification.chatId, notification.message.id)
     }
 
     function setActiveNotificationGroup(group) {


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/11616

Notification ID was passed as a message ID. Fixed that.
This was causing the chat to open but never find a message (cause the ID was invalid).