### PR TITLE
Connect Export control node popup to backend - Delete private key

### DIFF
--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -618,6 +618,10 @@ QtObject {
         chatCommunitySectionModule.authenticateWithCallback()
     }
 
+    function removePrivateKey(communityId) {
+        root.communitiesModuleInst.removePrivateKey(communityId)
+    }
+
     readonly property Connections communitiesModuleConnections: Connections {
       target: communitiesModuleInst
       function onImportingCommunityStateChanged(communityId, state, errorMsg) {

--- a/ui/app/AppLayouts/Communities/views/CommunitySettingsView.qml
+++ b/ui/app/AppLayouts/Communities/views/CommunitySettingsView.qml
@@ -215,11 +215,9 @@ StatusSectionLayout {
                         return
 
                     Global.openExportControlNodePopup(root.community.name, root.chatCommunitySectionModule.exportCommunity(root.community.id), (popup) => {
-                        //TODO: connect to backend
-                        // Delete private key and remove control node status
                         popup.onDeletePrivateKey.connect(() => {
-                            console.log("Delete private key")
-                        })
+                            root.rootStore.removePrivateKey(root.community.id)
+                        })  
                     })
                 })
             }


### PR DESCRIPTION
### What does the PR do

Depends on: #11640
Related to: #11547

Enabling remove private key action from Export control node popup by connecting the action to backend.
<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas

Community Overview
<!-- List the affected areas (e.g wallet, browser, etc..) -->

https://github.com/status-im/status-desktop/assets/47811206/f3c1dbc4-6492-4a03-9efb-3b7b7d794d2e

