### PR TITLE
feat(CommunityOverview): Update Control Node help page URL opened by Learn more button

### DIFF
--- a/ui/app/AppLayouts/Communities/panels/OverviewSettingsPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/OverviewSettingsPanel.qml
@@ -138,7 +138,7 @@ StackLayout {
             isControlNode: root.isControlNode
             onExportControlNodeClicked: root.exportControlNodeClicked()
             //TODO update once the domain changes
-            onLearnMoreClicked: Global.openLink(Constants.statusHelpLinkPrefix + "en/status-communities/about-the-control-node-in-status-communities")
+            onLearnMoreClicked: Global.openLink(Constants.statusHelpLinkPrefix + "status-communities/about-the-control-node-in-status-communities")
         }
     }
 

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -880,7 +880,7 @@ QtObject {
     readonly property string communityLinkPrefix: externalStatusLinkWithHttps + '/c/'
     readonly property string userLinkPrefix: externalStatusLinkWithHttps + '/u/'
     readonly property string statusLinkPrefix: 'https://status.im/'
-    readonly property string statusHelpLinkPrefix: `https://help.status.im/`
+    readonly property string statusHelpLinkPrefix: `https://status.app/help/`
 
     readonly property int maxUploadFiles: 5
     readonly property double maxUploadFilesizeMB: 10


### PR DESCRIPTION
### What does the PR do

Closing: #11451 

Updating the help page URL opened by `Learn more` button from Community Overview.


note: the page is currently behind authentication wall.
<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas
Community overview
<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Screenshot of functionality (including design for comparison)

https://github.com/status-im/status-desktop/assets/47811206/838dcdfc-9e3a-41cf-9f71-2d656b432e69


- [x] I've checked the design and this PR matches it

