### PR TITLE
fix(@desktop/wallet): Update activity delegates subtitle

### DIFF
--- a/ui/app/AppLayouts/Wallet/WalletLayout.qml
+++ b/ui/app/AppLayouts/Wallet/WalletLayout.qml
@@ -66,6 +66,7 @@ Item {
             contactsStore: root.contactsStore
             sendModal: root.sendModalPopup
             networkConnectionStore: root.networkConnectionStore
+            showAllAccounts: leftTab.showAllAccounts
             onLaunchShareAddressModal: Global.openPopup(receiveModalComponent);
         }
     }

--- a/ui/app/AppLayouts/Wallet/views/RightTabView.qml
+++ b/ui/app/AppLayouts/Wallet/views/RightTabView.qml
@@ -21,6 +21,7 @@ Item {
     property var contactsStore
     property var sendModal
     property var networkConnectionStore
+    property bool showAllAccounts: false
 
     signal launchShareAddressModal()
 
@@ -122,6 +123,7 @@ Item {
                 }
                 HistoryView {
                     overview: RootStore.overview
+                    showAllAccounts: root.showAllAccounts
                     onLaunchTransactionDetail: {
                         transactionDetailView.transaction = transaction
                         stack.currentIndex = 3
@@ -154,6 +156,7 @@ Item {
                 if (!visible)
                     transaction = null
             }
+            showAllAccounts: root.showAllAccounts
             sendModal: root.sendModal
             contactsStore: root.contactsStore
             visible: (stack.currentIndex === 3)

--- a/ui/app/AppLayouts/Wallet/views/TransactionDetailView.qml
+++ b/ui/app/AppLayouts/Wallet/views/TransactionDetailView.qml
@@ -28,6 +28,7 @@ Item {
     property var contactsStore
     property var transaction
     property var sendModal
+    property bool showAllAccounts: false
     readonly property bool isTransactionValid: transaction !== undefined && !!transaction
 
     onTransactionChanged: {
@@ -138,6 +139,7 @@ Item {
                     color: Theme.palette.transparent
                     state: "header"
 
+                    showAllAccounts: root.showAllAccounts
                     modelData: transaction
                     timeStampText: root.isTransactionValid ? qsTr("Signed at %1").arg(LocaleUtils.formatDateTime(transaction.timestamp * 1000, Locale.LongFormat)): ""
                     rootStore: RootStore

--- a/ui/imports/shared/views/HistoryView.qml
+++ b/ui/imports/shared/views/HistoryView.qml
@@ -27,6 +27,7 @@ ColumnLayout {
     id: root
 
     property var overview
+    property bool showAllAccounts: false
 
     signal launchTransactionDetail(var transaction)
 
@@ -335,6 +336,7 @@ ColumnLayout {
             timeStampText: isModelDataValid ? LocaleUtils.formatRelativeTimestamp(modelData.timestamp * 1000, true) : ""
             rootStore: RootStore
             walletRootStore: WalletStores.RootStore
+            showAllAccounts: root.showAllAccounts
             onClicked: {
                 if (mouse.button === Qt.RightButton) {
                     delegateMenu.openMenu(this, mouse, modelData)


### PR DESCRIPTION
fixes #11628 

### What does the PR do

* Updated delegate subtitle to show from and to or in what account transaction was done when `All accounts` is selected
* Updated copy details to always show from and to subtitle.

### Affected areas

Wallet activity view

### Screenshot of functionality (including design for comparison)

https://github.com/status-im/status-desktop/assets/11396062/5e22982b-82c2-4d88-93c0-2429331fbb40

