### PR TITLE
feat: disable community settings while in Testnet mode

### DIFF
--- a/storybook/pages/OverviewSettingsPanelPage.qml
+++ b/storybook/pages/OverviewSettingsPanelPage.qml
@@ -19,6 +19,7 @@ SplitView {
 
         editable: communityEditor.isCommunityEditable
         owned: communityEditor.amISectionAdmin
+        communitySettingsDisabled: !editable
     }
 
     Pane {

--- a/storybook/pages/StatusInfoBoxPanelPage.qml
+++ b/storybook/pages/StatusInfoBoxPanelPage.qml
@@ -35,6 +35,8 @@ SplitView {
                 Layout.preferredWidth: slider.value
 
                 title: "No hodlers just yet"
+                icon: "settings"
+                iconType: ctrlIconType.currentIndex
                 text: ModelsData.descriptions.airdropInfo
                 buttonText: "Airdrop"
 
@@ -51,19 +53,39 @@ SplitView {
 
         logsView.logText: logs.logText
 
-        Row {
-            Label {
-                anchors.verticalCenter: parent.verticalCenter
-                text: "Panel width:"
+        ColumnLayout {
+            Row {
+                Label {
+                    anchors.verticalCenter: parent.verticalCenter
+                    text: "Panel width: "
+                }
+
+                Slider {
+                    id: slider
+                    value: 700
+                    from: 300
+                    to: 600
+                }
             }
 
-            Slider {
-                id: slider
-                value: 700
-                from: 300
-                to: 600
+            Row {
+                Label {
+                    anchors.verticalCenter: parent.verticalCenter
+                    text: "Icon type: "
+                }
+
+                ComboBox {
+                    id: ctrlIconType
+                    textRole: "text"
+                    valueRole: "value"
+                    model: [
+                        { value: StatusInfoBoxPanel.Type.Info, text: "Info" },
+                        { value: StatusInfoBoxPanel.Type.Danger, text: "Danger" },
+                        { value: StatusInfoBoxPanel.Type.Success, text: "Success" },
+                        { value: StatusInfoBoxPanel.Type.Warning, text: "Warning" }
+                    ]
+                }
             }
         }
-
     }
 }

--- a/ui/StatusQ/src/StatusQ/Components/StatusInfoBoxPanel.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusInfoBoxPanel.qml
@@ -6,19 +6,54 @@ import StatusQ.Controls 0.1
 import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
 
+import utils 1.0
 
 Control {
     id: root
 
     property alias title: titleComponent.text
     property alias text: textComponent.text
+    property string icon
+    property int iconType: StatusInfoBoxPanel.Type.Info
     property alias buttonText: button.text
     property alias buttonVisible: button.visible
+
+    enum Type {
+        Info,
+        Danger,
+        Success,
+        Warning
+    }
 
     signal clicked
 
     verticalPadding: 40
     horizontalPadding: 56
+
+    QtObject {
+        id: d
+        property color bgColor
+        property color fgColor
+    }
+
+    states: [
+        State {
+            when: root.iconType === StatusInfoBoxPanel.Type.Info
+            PropertyChanges { target: d; bgColor: Theme.palette.primaryColor3; fgColor: Theme.palette.primaryColor1 }
+        },
+        State {
+            when: root.iconType === StatusInfoBoxPanel.Type.Danger
+            PropertyChanges { target: d; bgColor: Theme.palette.dangerColor3; fgColor: Theme.palette.dangerColor1 }
+        },
+        State {
+            when: root.iconType === StatusInfoBoxPanel.Type.Success
+            PropertyChanges { target: d; bgColor: Theme.palette.successColor2; fgColor: Theme.palette.successColor1 }
+        },
+        State {
+            when: root.iconType === StatusInfoBoxPanel.Type.Warning
+            PropertyChanges { target: d; bgColor: Theme.palette.warningColor3; fgColor: Theme.palette.warningColor1 }
+        }
+    ]
 
     background: Rectangle {
         color: Theme.palette.statusListItem.backgroundColor
@@ -27,6 +62,20 @@ Control {
     }
 
     contentItem: ColumnLayout {
+        spacing: Style.current.padding
+
+        StatusRoundIcon {
+            id: iconComponent
+            Layout.preferredWidth: 40
+            Layout.preferredHeight: 40
+            Layout.alignment: Qt.AlignCenter
+            Layout.bottomMargin: 12
+            visible: !!root.icon
+            asset.name: root.icon
+            asset.color: d.fgColor
+            asset.bgColor: d.bgColor
+        }
+
         StatusBaseText {
             id: titleComponent
 
@@ -44,8 +93,6 @@ Control {
             id: textComponent
 
             Layout.fillWidth: true
-            Layout.topMargin: 8
-            Layout.bottomMargin: 16
 
             wrapMode: Text.Wrap
             font.pixelSize: 15

--- a/ui/StatusQ/src/StatusQ/Components/StatusInfoBoxPanel.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusInfoBoxPanel.qml
@@ -6,8 +6,6 @@ import StatusQ.Controls 0.1
 import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
 
-import utils 1.0
-
 Control {
     id: root
 
@@ -27,8 +25,8 @@ Control {
 
     signal clicked
 
-    verticalPadding: 40
-    horizontalPadding: 56
+    verticalPadding: 32
+    horizontalPadding: 16
 
     QtObject {
         id: d
@@ -57,12 +55,12 @@ Control {
 
     background: Rectangle {
         color: Theme.palette.statusListItem.backgroundColor
-        radius: 8
+        radius: 16
         border.color: Theme.palette.baseColor2
     }
 
     contentItem: ColumnLayout {
-        spacing: Style.current.padding
+        spacing: 16
 
         StatusRoundIcon {
             id: iconComponent

--- a/ui/StatusQ/src/StatusQ/Components/StatusListItem.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusListItem.qml
@@ -46,8 +46,16 @@ Rectangle {
         isLetterIdenticon: false
         letterSize: 21
         charactersLen: 1
-        color: isLetterIdenticon ? bgColor : type === StatusListItem.Type.Danger ?
-            Theme.palette.dangerColor1 : Theme.palette.primaryColor1
+        color: {
+            if (!root.enabled)
+                return Theme.palette.baseColor1
+            if (isLetterIdenticon)
+                return bgColor
+            if (type === StatusListItem.Type.Danger)
+                return Theme.palette.dangerColor1
+
+            return Theme.palette.primaryColor1
+        }
         bgWidth: 40
         bgHeight: 40
         bgRadius: bgWidth / 2

--- a/ui/StatusQ/src/StatusQ/Controls/StatusBanner.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusBanner.qml
@@ -134,9 +134,9 @@ Column {
         },
         State {
             when: statusBanner.type === StatusBanner.Type.Warning
-            PropertyChanges { target: d; backgroundColor: Theme.palette.pinColor3}
-            PropertyChanges { target: d; bordersColor: Theme.palette.pinColor2}
-            PropertyChanges { target: d; fontColor: Theme.palette.pinColor1}
+            PropertyChanges { target: d; backgroundColor: Theme.palette.warningColor3}
+            PropertyChanges { target: d; bordersColor: Theme.palette.warningColor2}
+            PropertyChanges { target: d; fontColor: Theme.palette.warningColor1}
         }
     ]
 }

--- a/ui/app/AppLayouts/Chat/ChatLayout.qml
+++ b/ui/app/AppLayouts/Chat/ChatLayout.qml
@@ -23,6 +23,8 @@ StackLayout {
 
     property var sectionItemModel
 
+    property bool communitySettingsDisabled
+
     property var emojiPopup
     property var stickersPopup
     signal profileButtonClicked()
@@ -154,9 +156,10 @@ StackLayout {
             id: communitySettingsView
             rootStore: root.rootStore
 
-            hasAddedContacts: root.contactsStore.myContactsModel.count > 0
             chatCommunitySectionModule: root.rootStore.chatCommunitySectionModule
             community: sectionItemModel
+            communitySettingsDisabled: root.communitySettingsDisabled
+            onCommunitySettingsDisabledChanged: if (communitySettingsDisabled) goTo(Constants.CommunitySettingsSections.Overview)
 
             onBackToCommunityClicked: root.currentIndex = 0
 

--- a/ui/app/AppLayouts/Communities/panels/OverviewSettingsPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/OverviewSettingsPanel.qml
@@ -38,6 +38,7 @@ StackLayout {
     property bool owned: false
     property bool isControlNode: false
     property int loginType: Constants.LoginType.Password
+    property bool communitySettingsDisabled
 
     function navigateBack() {
         if (editSettingsPanelLoader.item.dirty)
@@ -54,13 +55,9 @@ StackLayout {
 
     clip: true
 
-    SettingsPage {
-
-        rightPadding: 64
-        bottomPadding: 50
-        topPadding: 0
-        header: null
-        contentItem: ColumnLayout {
+    Component {
+        id: mainSettingsPageComp
+        ColumnLayout {
             spacing: 16
             RowLayout {
                 Layout.fillWidth: true
@@ -127,8 +124,11 @@ StackLayout {
                 color: Theme.palette.statusMenu.separatorColor
             }
         }
+    }
 
-        footer: OverviewSettingsFooter {
+    Component {
+        id: overviewSettingsFooterComp
+        OverviewSettingsFooter {
             rightPadding: 64
             leftPadding: 64
             bottomPadding: 64
@@ -139,6 +139,36 @@ StackLayout {
             onExportControlNodeClicked: root.exportControlNodeClicked()
             //TODO update once the domain changes
             onLearnMoreClicked: Global.openLink(Constants.statusHelpLinkPrefix + "en/status-communities/about-the-control-node-in-status-communities")
+        }
+    }
+
+    Component {
+        id: disabledSettingsBannerComp
+        StatusInfoBoxPanel {
+            title: qsTr("Community administration is disabled when in testnet mode")
+            text: qsTr("To access your %1 community admin area, you need to turn off testnet mode.").arg(root.name)
+            icon: "settings"
+            iconType: StatusInfoBoxPanel.Type.Warning
+            buttonText: qsTr("Turn off testnet mode")
+            onClicked: Global.openTestnetPopup()
+        }
+    }
+
+    SettingsPage {
+        Layout.fillWidth: !root.communitySettingsDisabled
+        Layout.preferredWidth: root.communitySettingsDisabled ? 560 + leftPadding + rightPadding : -1
+        Layout.fillHeight: !root.communitySettingsDisabled
+        rightPadding: 64
+        bottomPadding: 50
+        topPadding: 0
+        header: null
+        contentItem: Loader {
+            sourceComponent: root.communitySettingsDisabled ? disabledSettingsBannerComp : mainSettingsPageComp
+        }
+
+        footer: Loader {
+            sourceComponent: overviewSettingsFooterComp
+            active: !root.communitySettingsDisabled
         }
     }
 

--- a/ui/app/AppLayouts/Communities/views/CommunitySettingsView.qml
+++ b/ui/app/AppLayouts/Communities/views/CommunitySettingsView.qml
@@ -32,8 +32,8 @@ StatusSectionLayout {
     property var rootStore
     property var chatCommunitySectionModule
     property var community
-    property bool hasAddedContacts: false
     property var transactionStore: TransactionStore {}
+    property bool communitySettingsDisabled
 
     readonly property bool isOwner: community.memberRole === Constants.memberRole.owner
     readonly property bool isAdmin: isOwner || community.memberRole === Constants.memberRole.admin
@@ -106,6 +106,7 @@ StatusSectionLayout {
                 Layout.rightMargin: Style.current.padding
                 model: stackLayout.children
                 spacing: 8
+                enabled: !root.communitySettingsDisabled
 
                 delegate: StatusNavigationListItem {
                     objectName: "CommunitySettingsView_NavigationListItem_" + model.sectionName
@@ -114,7 +115,7 @@ StatusSectionLayout {
                     asset.name: model.sectionIcon
                     asset.height: 24
                     asset.width: 24
-                    selected: d.currentIndex === index
+                    selected: d.currentIndex === index && !root.communitySettingsDisabled
                     onClicked: d.currentIndex = index
                     visible: model.sectionEnabled
                     height: visible ? implicitHeight : 0
@@ -175,6 +176,7 @@ StatusSectionLayout {
             owned: root.community.memberRole === Constants.memberRole.owner
             loginType: root.rootStore.loginType
             isControlNode: root.isControlNode
+            communitySettingsDisabled: root.communitySettingsDisabled
 
             onEdited: {
                 const error = root.chatCommunitySectionModule.editCommunity(
@@ -207,7 +209,7 @@ StatusSectionLayout {
             onExportControlNodeClicked: {
                 if(!root.isControlNode)
                     return
-                    
+
                 root.rootStore.authenticateWithCallback((authenticated) => {
                     if(!authenticated)
                         return
@@ -217,7 +219,7 @@ StatusSectionLayout {
                         // Delete private key and remove control node status
                         popup.onDeletePrivateKey.connect(() => {
                             console.log("Delete private key")
-                        })  
+                        })
                     })
                 })
             }

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -1103,6 +1103,7 @@ Item {
                                 emojiPopup: statusEmojiPopup.item
                                 stickersPopup: statusStickersPopupLoader.item
                                 sectionItemModel: model
+                                communitySettingsDisabled: production && appMain.rootStore.profileSectionStore.walletStore.areTestNetworksEnabled
 
                                 rootStore: ChatStores.RootStore {
                                     contactsStore: appMain.rootStore.contactStore

--- a/ui/imports/shared/panels/ModuleWarning.qml
+++ b/ui/imports/shared/panels/ModuleWarning.qml
@@ -49,7 +49,7 @@ Item {
     }
 
     function close() {
-        closeButtonMouseArea.clicked(null)
+        root.closeClicked()
     }
 
     signal linkActivated(string link)


### PR DESCRIPTION
### What does the PR do

- display an info box when in wallet testnet mode with a CTA to disable
it (functionality enabled for production builds only)
- the CTA can be tested/seen via OverviewSettingsPanelPage storybook page
- plus separate commits to add support for icon in `StatusInfoBox` and fix consistent usage of its `warning` color

Closes #11468

### Affected areas

CommunitySettingsView, OverviewSettingsPanel, StatusInfoBox

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

[Záznam obrazovky z 2023-07-24 13-27-35.webm](https://github.com/status-im/status-desktop/assets/5377645/b06e708e-bdba-438b-a809-a4a0efeade73)

Testnet info banner (with Community editable off):
![image](https://github.com/status-im/status-desktop/assets/5377645/0848494a-d131-404c-bbc0-2ea770a67a34)

