### PR TITLE
feat: implement delelete community token functionality

### DIFF
--- a/src/app/modules/main/communities/tokens/controller.nim
+++ b/src/app/modules/main/communities/tokens/controller.nim
@@ -74,6 +74,9 @@ proc init*(self: Controller) =
 proc deployContract*(self: Controller, communityId: string, addressFrom: string, password: string, deploymentParams: DeploymentParameters, tokenMetadata: CommunityTokensMetadataDto, tokenImageCropInfoJson: string, chainId: int) =
   self.communityTokensService.deployContract(communityId, addressFrom, password, deploymentParams, tokenMetadata, tokenImageCropInfoJson, chainId)
 
+proc removeCommunityToken*(self: Controller, communityId: string, chainId: int, address: string) =
+  self.communityTokensService.removeCommunityToken(communityId, chainId, address)
+
 proc airdropTokens*(self: Controller, communityId: string, password: string, tokensAndAmounts: seq[CommunityTokenAndAmount], walletAddresses: seq[string]) =
   self.communityTokensService.airdropTokens(communityId, password, tokensAndAmounts, walletAddresses)
 

--- a/src/app/modules/main/communities/tokens/io_interface.nim
+++ b/src/app/modules/main/communities/tokens/io_interface.nim
@@ -70,3 +70,6 @@ method onBurnStateChanged*(self: AccessInterface, communityId: string, tokenName
 
 method onAirdropStateChanged*(self: AccessInterface, communityId: string, tokenName: string, chainId: int, transactionHash: string, status: ContractTransactionStatus) {.base.} =
   raise newException(ValueError, "No implementation available")
+
+method removeCommunityToken*(self: AccessInterface, communityId: string, chainId: int, address: string) {.base.} =
+  raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/communities/tokens/models/token_model.nim
+++ b/src/app/modules/main/communities/tokens/models/token_model.nim
@@ -112,6 +112,18 @@ QtObject:
     self.endInsertRows()
     self.countChanged()
 
+  proc removeItemByChainIdAndAddress*(self: TokenModel, chainId: int, address: string) =
+    for i in 0 ..< self.items.len:
+      if((self.items[i].tokenDto.address == address) and (self.items[i].tokenDto.chainId == chainId)):
+        let parentModelIndex = newQModelIndex()
+        defer: parentModelIndex.delete
+
+        self.beginRemoveRows(parentModelIndex, i, i)
+        self.items.delete(i)
+        self.endRemoveRows()
+        self.countChanged()
+        return
+
   proc getCount*(self: TokenModel): int {.slot.} =
     self.items.len
 

--- a/src/app/modules/main/communities/tokens/module.nim
+++ b/src/app/modules/main/communities/tokens/module.nim
@@ -184,6 +184,9 @@ method deployAssets*(self: Module, communityId: string, fromAddress: string, nam
   self.tempContractAction = ContractAction.Deploy
   self.authenticate()
 
+method removeCommunityToken*(self: Module, communityId: string, chainId: int, address: string) =
+  self.controller.removeCommunityToken(communityId, chainId, address)
+
 method onUserAuthenticated*(self: Module, password: string) =
   defer: self.resetTempValues()
   if password.len == 0:

--- a/src/app/modules/main/communities/tokens/view.nim
+++ b/src/app/modules/main/communities/tokens/view.nim
@@ -27,6 +27,9 @@ QtObject:
   proc deployAssets*(self: View, communityId: string, fromAddress: string, name: string, symbol: string, description: string, supply: float, infiniteSupply: bool, decimals: int, chainId: int, imageCropInfoJson: string) {.slot.} =
     self.communityTokensModule.deployAssets(communityId, fromAddress, name, symbol, description, supply, infiniteSupply, decimals, chainId, imageCropInfoJson)
 
+  proc removeCommunityToken*(self: View, communityId: string, chainId: int, address: string) {.slot.} =
+    self.communityTokensModule.removeCommunityToken(communityId, chainId, address)
+
   proc airdropTokens*(self: View, communityId: string, tokensJsonString: string, walletsJsonString: string) {.slot.} =
     self.communityTokensModule.airdropTokens(communityId, tokensJsonString, walletsJsonString)
 

--- a/src/app/modules/main/controller.nim
+++ b/src/app/modules/main/controller.nim
@@ -348,6 +348,10 @@ proc init*(self: Controller) =
     let args = CommunityTokenDeployedStatusArgs(e)
     self.delegate.onCommunityTokenDeployStateChanged(args.communityId, args.chainId, args.contractAddress, args.deployState)
 
+  self.events.on(SIGNAL_COMMUNITY_TOKEN_REMOVED) do(e: Args):
+    let args = CommunityTokenRemovedArgs(e)
+    self.delegate.onCommunityTokenRemoved(args.communityId, args.chainId, args.contractAddress)
+
   self.events.on(SIGNAL_BURN_STATUS) do(e: Args):
     let args = RemoteDestructArgs(e)
     let communityToken = args.communityToken

--- a/src/app/modules/main/io_interface.nim
+++ b/src/app/modules/main/io_interface.nim
@@ -303,6 +303,9 @@ method onCommunityTokenDeployStateChanged*(self: AccessInterface, communityId: s
 method onCommunityTokenSupplyChanged*(self: AccessInterface, communityId: string, chainId: int, contractAddress: string, supply: Uint256, remainingSupply: Uint256) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method onCommunityTokenRemoved*(self: AccessInterface, communityId: string, chainId: int, contractAddress: string) =
+  raise newException(ValueError, "No implementation available")
+
 method onBurnStateChanged*(self: AccessInterface, communityId: string, chainId: int, contractAddress: string, burnState: ContractTransactionStatus) {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -1014,6 +1014,11 @@ method onCommunityTokenDeploymentStarted*[T](self: Module[T], communityToken: Co
   if item.id != "":
     item.appendCommunityToken(self.createTokenItem(communityToken))
 
+method onCommunityTokenRemoved*[T](self: Module[T], communityId: string, chainId: int, address: string) =
+  let item = self.view.model().getItemById(communityId)
+  if item.id != "":
+    item.removeCommunityToken(chainId, address)
+
 method onCommunityTokenOwnersFetched*[T](self: Module[T], communityId: string, chainId: int, contractAddress: string, owners: seq[CollectibleOwner]) =
   let item = self.view.model().getItemById(communityId)
   if item.id != "":

--- a/src/app/modules/shared_models/section_item.nim
+++ b/src/app/modules/shared_models/section_item.nim
@@ -332,6 +332,9 @@ proc encrypted*(self: SectionItem): bool {.inline.} =
 proc appendCommunityToken*(self: SectionItem, item: TokenItem) {.inline.} =
   self.communityTokensModel.appendItem(item)
 
+proc removeCommunityToken*(self: SectionItem, chainId: int, contractAddress: string) {.inline.} =
+  self.communityTokensModel.removeItemByChainIdAndAddress(chainId, contractAddress)
+
 proc updateCommunityTokenDeployState*(self: SectionItem, chainId: int, contractAddress: string, deployState: DeployState) {.inline.} =
   self.communityTokensModel.updateDeployState(chainId, contractAddress, deployState)
 

--- a/src/backend/community_tokens.nim
+++ b/src/backend/community_tokens.nim
@@ -15,6 +15,10 @@ proc deployAssets*(chainId: int, deploymentParams: JsonNode, txData: JsonNode, p
   let payload = %* [chainId, deploymentParams, txData, utils.hashPassword(password)]
   return core.callPrivateRPC("collectibles_deployAssets", payload)
 
+proc removeCommunityToken*(chainId: int, address: string): RpcResponse[JsonNode] {.raises: [Exception].} =
+  let payload = %* [chainId, address]
+  return core.callPrivateRPC("wakuext_removeCommunityToken", payload)
+
 proc getCommunityTokens*(communityId: string): RpcResponse[JsonNode] {.raises: [Exception].} =
   let payload = %* [communityId]
   return core.callPrivateRPC("wakuext_getCommunityTokens", payload)

--- a/ui/imports/shared/stores/CommunityTokensStore.qml
+++ b/ui/imports/shared/stores/CommunityTokensStore.qml
@@ -55,7 +55,8 @@ QtObject {
     }
 
     function deleteToken(communityId, contractUniqueKey) {
-        console.log("TODO: Delete token bakend!")
+        let parts = contractUniqueKey.split("_");
+        communityTokensModuleInst.removeCommunityToken(communityId, parts[0], parts[1])
     }
 
     readonly property Connections connections: Connections {


### PR DESCRIPTION
This partially addresses #11186 as it implements the delete functionality for community tokens.

If a deployment failed, users have the ability to delete the added community token from the list.

The retry functionality will be implemented in a follow up commit.

