### PR TITLE
refactor: rename SIGNAL_COMMUNITY_TOKEN_DEPLOYED

### DIFF
--- a/src/app/modules/main/communities/tokens/controller.nim
+++ b/src/app/modules/main/communities/tokens/controller.nim
@@ -55,8 +55,8 @@ proc init*(self: Controller) =
   self.events.on(SIGNAL_COMPUTE_AIRDROP_FEE) do(e:Args):
     let args = AirdropFeesArgs(e)
     self.communityTokensModule.onAirdropFeesComputed(args)
-  self.events.on(SIGNAL_COMMUNITY_TOKEN_DEPLOYED) do(e: Args):
-    let args = CommunityTokenDeployedArgs(e)
+  self.events.on(SIGNAL_COMMUNITY_TOKEN_DEPLOYMENT_STARTED) do(e: Args):
+    let args = CommunityTokenDeploymentArgs(e)
     self.communityTokensModule.onCommunityTokenDeployStateChanged(args.communityToken.communityId, args.communityToken.chainId, args.transactionHash, args.communityToken.deployState)
   self.events.on(SIGNAL_COMMUNITY_TOKEN_DEPLOY_STATUS) do(e: Args):
     let args = CommunityTokenDeployedStatusArgs(e)

--- a/src/app/modules/main/controller.nim
+++ b/src/app/modules/main/controller.nim
@@ -340,9 +340,9 @@ proc init*(self: Controller) =
   self.events.on(SIGNAL_COMMUNITY_MY_REQUEST_ADDED) do(e: Args):
     self.delegate.onMyRequestAdded();
 
-  self.events.on(SIGNAL_COMMUNITY_TOKEN_DEPLOYED) do(e: Args):
-    let args = CommunityTokenDeployedArgs(e)
-    self.delegate.onCommunityTokenDeployed(args.communityToken)
+  self.events.on(SIGNAL_COMMUNITY_TOKEN_DEPLOYMENT_STARTED) do(e: Args):
+    let args = CommunityTokenDeploymentArgs(e)
+    self.delegate.onCommunityTokenDeploymentStarted(args.communityToken)
 
   self.events.on(SIGNAL_COMMUNITY_TOKEN_DEPLOY_STATUS) do(e: Args):
     let args = CommunityTokenDeployedStatusArgs(e)

--- a/src/app/modules/main/io_interface.nim
+++ b/src/app/modules/main/io_interface.nim
@@ -291,7 +291,7 @@ method tryKeycardSync*(self: AccessInterface, keyUid: string, pin: string) {.bas
 method onSharedKeycarModuleKeycardSyncPurposeTerminated*(self: AccessInterface, lastStepInTheCurrentFlow: bool) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method onCommunityTokenDeployed*(self: AccessInterface, communityToken: CommunityTokenDto) {.base.} =
+method onCommunityTokenDeploymentStarted*(self: AccessInterface, communityToken: CommunityTokenDto) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method onCommunityTokenOwnersFetched*(self: AccessInterface, communityId: string, chainId: int, contractAddress: string, owners: seq[CollectibleOwner]) {.base.} =

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -1009,7 +1009,7 @@ method contactsStatusUpdated*[T](self: Module[T], statusUpdates: seq[StatusUpdat
     let status = toOnlineStatus(s.statusType)
     self.view.activeSection().setOnlineStatusForMember(s.publicKey, status)
 
-method onCommunityTokenDeployed*[T](self: Module[T], communityToken: CommunityTokenDto) =
+method onCommunityTokenDeploymentStarted*[T](self: Module[T], communityToken: CommunityTokenDto) =
   let item = self.view.model().getItemById(communityToken.communityId)
   if item.id != "":
     item.appendCommunityToken(self.createTokenItem(communityToken))

--- a/src/app_service/service/community_tokens/service.nim
+++ b/src/app_service/service/community_tokens/service.nim
@@ -73,7 +73,7 @@ type
     deployState*: DeployState
 
 type
-  CommunityTokenDeployedArgs* = ref object of Args
+  CommunityTokenDeploymentArgs* = ref object of Args
     communityToken*: CommunityTokenDto
     transactionHash*: string
 
@@ -141,7 +141,7 @@ type
 
 # Signals which may be emitted by this service:
 const SIGNAL_COMMUNITY_TOKEN_DEPLOY_STATUS* = "communityTokenDeployStatus"
-const SIGNAL_COMMUNITY_TOKEN_DEPLOYED* = "communityTokenDeployed"
+const SIGNAL_COMMUNITY_TOKEN_DEPLOYMENT_STARTED* = "communityTokenDeploymentStarted"
 const SIGNAL_COMPUTE_DEPLOY_FEE* = "computeDeployFee"
 const SIGNAL_COMPUTE_SELF_DESTRUCT_FEE* = "computeSelfDestructFee"
 const SIGNAL_COMPUTE_BURN_FEE* = "computeBurnFee"
@@ -331,8 +331,8 @@ QtObject:
       # save token to db
       let communityTokenJson = tokens_backend.saveCommunityToken(communityToken, $croppedImage)
       communityToken = communityTokenJson.result.toCommunityTokenDto()
-      let data = CommunityTokenDeployedArgs(communityToken: communityToken, transactionHash: transactionHash)
-      self.events.emit(SIGNAL_COMMUNITY_TOKEN_DEPLOYED, data)
+      let data = CommunityTokenDeploymentArgs(communityToken: communityToken, transactionHash: transactionHash)
+      self.events.emit(SIGNAL_COMMUNITY_TOKEN_DEPLOYMENT_STARTED, data)
 
       # observe transaction state
       self.transactionService.watchTransaction(


### PR DESCRIPTION
We've been using this signal whenever a user has sent a transaction that attemps to deploy a smart contract onchain.

However, at this point it's not yet known if the transaction will actually go through. So to reflect what's actually happening, this commits renames a few things:

- `SIGNAL_COMMUNITY_TOKEN_DEPLOYED` becomes `SIGNAL_COMMUNITY_TOKEN_DEPLOYMENT_STARTED`
- `CommunityTokenDeployedArgs` becomes `CommunityTokenDeploymentArgs`
- `onCommunityTokenDeployed` becomes `onCommunityTokenDeploymentStarted`

This should remove any confusion around whether or not deployment is indeed finished.

