### PR TITLE
chore(@e2e_tests): enable back disabled tests

### DIFF
--- a/test/ui-test/testSuites/suite_wallet/shared/steps/walletSteps.py
+++ b/test/ui-test/testSuites/suite_wallet/shared/steps/walletSteps.py
@@ -36,24 +36,18 @@ def step(context, name):
     _walletScreen.left_panel.select_account(name)
 
 
-@When("the user adds a watch only account \"|any|\" with \"|any|\" color \"|any|\" and emoji \"|any|\" via \"|any|\"")
+@When("the user adds a watch only account \"|any|\" with \"|any|\" color \"|any|\" and emoji \"|any|\"")
 @verify_screenshot
-def step(context, address, name, color, emoji, via_right_click_menu):
-    if via_right_click_menu == VALUE_YES:
-        account_popup = _walletScreen.left_panel.open_add_watch_anly_account_popup()
-    else:
-        account_popup = _walletScreen.left_panel.open_add_account_popup()
+def step(context, address, name, color, emoji):
+    account_popup = _walletScreen.left_panel.open_add_account_popup()
     account_popup.set_name(name).set_emoji(emoji).set_color(color).set_origin_eth_address(address).save()
     account_popup.wait_until_hidden()
 
 
-@When("the user adds a generated account with \"|any|\" color \"|any|\" and emoji \"|any|\" via \"|any|\"")
+@When("the user adds a generated account with \"|any|\" color \"|any|\" and emoji \"|any|\"")
 @verify_screenshot
-def step(context, name, color, emoji, via_right_click_menu):
-    if via_right_click_menu == VALUE_YES:
-        account_popup = _walletScreen.left_panel.open_add_new_account_popup()
-    else:
-        account_popup = _walletScreen.left_panel.open_add_account_popup()
+def step(context, name, color, emoji):
+    account_popup = _walletScreen.left_panel.open_add_account_popup()
     account_popup.set_name(name).set_emoji(emoji).set_color(color).save()
     AuthenticatePopup().wait_until_appears().authenticate()
     account_popup.wait_until_hidden()

--- a/test/ui-test/testSuites/suite_wallet/tst_wallet_accountsManagement/test.feature
+++ b/test/ui-test/testSuites/suite_wallet/tst_wallet_accountsManagement/test.feature
@@ -9,7 +9,7 @@ Feature: Status Desktop Wallet Section Wallet Account Management
         And the user opens the wallet section
         And the user accepts the signing phrase
 
-    Scenario Outline: The user edits default wallet account
+    Scenario Outline: The user can edit the default wallet account
         When the user selects wallet account with "<name>"
         And the user edits an account with "<name>" to "<new_name>" with color "#<new_color>" and emoji "<new_emoji>"
         Then the account is correctly displayed with "<new_name>" and "#<new_color>" and emoji unicode "<new_emoji_unicode>" in accounts list
@@ -17,19 +17,90 @@ Feature: Status Desktop Wallet Section Wallet Account Management
             | name           | new_name         | new_color | new_emoji  | new_emoji_unicode |
             | Status account | MyPrimaryAccount | 216266    | sunglasses | 1f60e             |
 
-		# Change to use main button. add account with context menu is no longer a thing
-		@mayfail
-    	Scenario Outline: The user manages a watch only account
-        When the user adds a watch only account "<address>" with "<name>" color "#<color>" and emoji "<emoji>" via "<add_via_context_menu>"
+    	Scenario Outline: The user can add, edit and remove a watch only account
+        When the user adds a watch only account "<address>" with "<name>" color "#<color>" and emoji "<emoji>"
         Then the account is correctly displayed with "<name>" and "#<color>" and emoji unicode "<emoji_unicode>" in accounts list
         When the user edits an account with "<name>" to "<new_name>" with color "#<new_color>" and emoji "<new_emoji>"
         Then the account is correctly displayed with "<new_name>" and "#<new_color>" and emoji unicode "<new_emoji_unicode>" in accounts list
         When the user removes account "<new_name>"
         Then the account with "<new_name>" is not displayed
         Examples:
-            | address                                    | name      | color  | emoji      | emoji_unicode | add_via_context_menu | new_name        | new_color | new_emoji | new_emoji_unicode |
-            | 0xea123F7beFF45E3C9fdF54B324c29DBdA14a639A | AccWatch1 | 2a4af5 | sunglasses | 1f60e         | yes                  | AccWatch1edited | 216266    | thumbsup  | 1f44d             |
-            | 0xea123F7beFF45E3C9fdF54B324c29DBdA14a639B | AccWatch2 | 7140fd | sunglasses | 1f60e         | no                   | AccWatch2edited | 2a799b    | thumbsup  | 1f44d             |
+            | address                                    | name      | color  | emoji      | emoji_unicode | new_name        | new_color | new_emoji | new_emoji_unicode |
+            | 0xea123F7beFF45E3C9fdF54B324c29DBdA14a639A | AccWatch1 | 2a4af5 | sunglasses | 1f60e         | AccWatch1edited | 216266    | thumbsup  | 1f44d             |
+
+        Scenario Outline: The user can add, edit and remove generated account with default derivation path
+        When the user adds a generated account with "<name>" color "#<color>" and emoji "<emoji>"
+        Then the account is correctly displayed with "<name>" and "#<color>" and emoji unicode "<emoji_unicode>" in accounts list
+        When the user edits an account with "<name>" to "<new_name>" with color "#<new_color>" and emoji "<new_emoji>"
+        Then the account is correctly displayed with "<new_name>" and "#<new_color>" and emoji unicode "<new_emoji_unicode>" in accounts list
+        When the user removes account "<new_name>" with agreement
+        Then the account with "<new_name>" is not displayed
+
+        Examples:
+            | name    | color  | emoji      | emoji_unicode | new_name      | new_color | new_emoji | new_emoji_unicode |
+            | GenAcc1 | 2a4af5 | sunglasses | 1f60e         | GenAcc1edited | 216266    | thumbsup  | 1f44d             |
+
+        Scenario Outline: The user can add, edit and remove an account, imported with private key
+        When the user adds a private key account "<private_key>" with "<name>" color "#<color>" and emoji "<emoji>"
+        Then the account is correctly displayed with "<name>" and "#<color>" and emoji unicode "<emoji_unicode>" in accounts list
+        When the user edits an account with "<name>" to "<new_name>" with color "#<new_color>" and emoji "<new_emoji>"
+        Then the account is correctly displayed with "<new_name>" and "#<new_color>" and emoji unicode "<new_emoji_unicode>" in accounts list
+        When the user removes account "<new_name>"
+        Then the account with "<new_name>" is not displayed
+
+        Examples:
+            | private_key                                                      | name        | color  | emoji      | emoji_unicode | new_name          | new_color | new_emoji | new_emoji_unicode |
+            | 2daa36a3abe381a9c01610bf10fda272fbc1b8a22179a39f782c512346e3e470 | PrivKeyAcc1 | 2a4af5 | sunglasses | 1f60e         | PrivKeyAcc1edited | 216266    | thumbsup  | 1f44d             |
+
+		Scenario Outline: The user can add, edit and remove generated account with custom derivation path
+        When the user adds a custom generated account with "<name>" color "#<color>" emoji "<emoji>" and derivation "<path>" "<address_index>"
+        Then the account is correctly displayed with "<name>" and "#<color>" and emoji unicode "<emoji_unicode>" in accounts list
+        When the user removes account "<name>" with agreement
+        Then the account with "<name>" is not displayed
+
+        Examples:
+            | address_index | path                           | name                 | color  | emoji      | emoji_unicode |
+            | 5             | Ethereum                       | Ethereum             | 216266 | sunglasses | 1f60e         |
+            | 10            | Ethereum Testnet (Ropsten)     | Ethereum Testnet     | 7140fd | sunglasses | 1f60e         |
+            | 15            | Ethereum (Ledger)              | Ethereum Ledger      | 2a799b | sunglasses | 1f60e         |
+            | 20            | Ethereum (Ledger Live/KeepKey) | Ethereum Ledger Live | 7140fd | sunglasses | 1f60e         |
+            | 95            | N/A                            | Custom path          | 216266 | sunglasses | 1f60e         |
+
+		Scenario Outline: The user manages can add, edit and remove an account, imported with seed phrase of 12, 18 and 24 words
+        When the user adds an imported seed phrase account "<seed_phrase>" with "<name>" color "#<color>" and emoji "<emoji>"
+        Then the account is correctly displayed with "<name>" and "#<color>" and emoji unicode "<emoji_unicode>" in accounts list
+        When the user edits an account with "<name>" to "<new_name>" with color "#<new_color>" and emoji "<new_emoji>"
+        Then the account is correctly displayed with "<new_name>" and "#<new_color>" and emoji unicode "<new_emoji_unicode>" in accounts list
+        When the user removes account "<new_name>" with agreement
+        Then the account with "<name>" is not displayed
+
+        Examples:
+            | seed_phrase                                                                                                                                                   | name    | color  | emoji      | emoji_unicode | new_name      | new_color | new_emoji | new_emoji_unicode |
+            | elite dinosaur flavor canoe garbage palace antique dolphin virtual mixed sand impact solution inmate hair pipe affair cage vote estate gloom lamp robust like | SPAcc24 | 2a4af5 | sunglasses | 1f60e         | SPAcc24edited | 216266    | thumbsup  | 1f44d             |
+            | kitten tiny cup admit cactus shrug shuffle accident century faith roof plastic beach police barely vacant sign blossom                                        | SPAcc18 | 2a4af5 | sunglasses | 1f60e         | SPAcc18edited | 216266    | thumbsup  | 1f44d             |
+            | pelican chief sudden oval media rare swamp elephant lawsuit wheat knife initial                                                                               | SPAcc12 | 2a4af5 | sunglasses | 1f60e         | SPAcc12edited | 216266    | thumbsup  | 1f44d             |
+
+		Scenario Outline: The user can add, edit and remove an account, generated with new master key
+        When the user adds a generated seed phrase account with "<name>" color "#<color>" emoji "<emoji>" and keypair "<keypair_name>"
+        Then the account is correctly displayed with "<name>" and "#<color>" and emoji unicode "<emoji_unicode>" in accounts list
+        When the user edits an account with "<name>" to "<new_name>" with color "#<new_color>" and emoji "<new_emoji>"
+        Then the account is correctly displayed with "<new_name>" and "#<new_color>" and emoji unicode "<new_emoji_unicode>" in accounts list
+        When the user removes account "<new_name>" with agreement
+        Then the account with "<name>" is not displayed
+
+        Examples:
+            | keypair_name | name  | color  | emoji      | emoji_unicode | new_name     | new_color | new_emoji | new_emoji_unicode |
+            | SPKeyPair    | SPAcc | 2a4af5 | sunglasses | 1f60e         | SPAcc_edited | 216266    | thumbsup  | 1f44d             |
+
+        Scenario Outline: The user can cancel generated account deletion
+        When the user adds a generated account with "<name>" color "#<color>" and emoji "<emoji>"
+        Then the account is correctly displayed with "<name>" and "#<color>" and emoji unicode "<emoji_unicode>" in accounts list
+        When the user start removing account "<name>" and cancel it
+        Then the account is correctly displayed with "<name>" and "#<color>" and emoji unicode "<emoji_unicode>" in accounts list
+        Examples:
+            | name    | color  | emoji      | emoji_unicode |
+            | GenAcc1 | 2a4af5 | sunglasses | 1f60e         |
+
 
     	# Test should be changed to reflect balance change instead of accounts list, will be done after it is changed in the app
 		@mayfail
@@ -57,73 +128,8 @@ Feature: Status Desktop Wallet Section Wallet Account Management
             | address                                    | name      | color  | emoji      | emoji_unicode |
             | 0xea123F7beFF45E3C9fdF54B324c29DBdA14a639A | AccWatch1 | 2a4af5 | sunglasses | 1f60e         |
 
-		# Change to use main button. add account with context menu is no longer a thing
+		# Test should be changed to check that adding more accounts to the keypair reflects in settings, otherwise it is almost a duplicated test
 		@mayfail
-        Scenario Outline: The user manages a generated account
-        When the user adds a generated account with "<name>" color "#<color>" and emoji "<emoji>" via "<add_via_context_menu>"
-        Then the account is correctly displayed with "<name>" and "#<color>" and emoji unicode "<emoji_unicode>" in accounts list
-        When the user edits an account with "<name>" to "<new_name>" with color "#<new_color>" and emoji "<new_emoji>"
-        Then the account is correctly displayed with "<new_name>" and "#<new_color>" and emoji unicode "<new_emoji_unicode>" in accounts list
-        When the user removes account "<new_name>" with agreement
-        Then the account with "<new_name>" is not displayed
-
-        Examples:
-            | name    | color  | emoji      | emoji_unicode | add_via_context_menu | new_name      | new_color | new_emoji | new_emoji_unicode |
-            | GenAcc1 | 2a4af5 | sunglasses | 1f60e         | yes                  | GenAcc1edited | 216266    | thumbsup  | 1f44d             |
-            | GenAcc2 | 7140fd | sunglasses | 1f60e         | no                   | GenAcc2edited | 2a799b    | thumbsup  | 1f44d             |
-
-		# Change to use main button. add account with context menu is no longer a thing
-		@mayfail
-        Scenario Outline: The user cancel deleting generated account
-        When the user adds a generated account with "<name>" color "#<color>" and emoji "<emoji>" via "<add_via_context_menu>"
-        Then the account is correctly displayed with "<name>" and "#<color>" and emoji unicode "<emoji_unicode>" in accounts list
-        When the user start removing account "<name>" and cancel it
-        Then the account is correctly displayed with "<name>" and "#<color>" and emoji unicode "<emoji_unicode>" in accounts list
-        Examples:
-            | name    | color  | emoji      | emoji_unicode | add_via_context_menu |
-            | GenAcc1 | 2a4af5 | sunglasses | 1f60e         | yes                  |
-
-        Scenario Outline: The user manages a custom generated account
-        When the user adds a custom generated account with "<name>" color "#<color>" emoji "<emoji>" and derivation "<path>" "<address_index>"
-        Then the account is correctly displayed with "<name>" and "#<color>" and emoji unicode "<emoji_unicode>" in accounts list
-        When the user removes account "<name>" with agreement
-        Then the account with "<name>" is not displayed
-
-        Examples:
-            | address_index | path                           | name          | color  | emoji      | emoji_unicode |
-            | 5             | Ethereum                       | CustomGenAcc1 | 216266 | sunglasses | 1f60e         |
-            | 10            | Ethereum Testnet (Ropsten)     | CustomGenAcc2 | 7140fd | sunglasses | 1f60e         |
-            | 15            | Ethereum (Ledger)              | CustomGenAcc3 | 2a799b | sunglasses | 1f60e         |
-            | 20            | Ethereum (Ledger Live/KeepKey) | CustomGenAcc4 | 7140fd | sunglasses | 1f60e         |
-            | 95            | N/A                            | CustomGenAcc1 | 216266 | sunglasses | 1f60e         |
-
-
-        Scenario Outline: The user manages a private key imported account
-        When the user adds a private key account "<private_key>" with "<name>" color "#<color>" and emoji "<emoji>"
-        Then the account is correctly displayed with "<name>" and "#<color>" and emoji unicode "<emoji_unicode>" in accounts list
-        When the user edits an account with "<name>" to "<new_name>" with color "#<new_color>" and emoji "<new_emoji>"
-        Then the account is correctly displayed with "<new_name>" and "#<new_color>" and emoji unicode "<new_emoji_unicode>" in accounts list
-        When the user removes account "<new_name>"
-        Then the account with "<new_name>" is not displayed
-
-        Examples:
-            | private_key                                                      | name        | color  | emoji      | emoji_unicode | new_name          | new_color | new_emoji | new_emoji_unicode |
-            | 2daa36a3abe381a9c01610bf10fda272fbc1b8a22179a39f782c512346e3e470 | PrivKeyAcc1 | 2a4af5 | sunglasses | 1f60e         | PrivKeyAcc1edited | 216266    | thumbsup  | 1f44d             |
-
-        Scenario Outline: The user manages a seed phrase imported account
-        When the user adds an imported seed phrase account "<seed_phrase>" with "<name>" color "#<color>" and emoji "<emoji>"
-        Then the account is correctly displayed with "<name>" and "#<color>" and emoji unicode "<emoji_unicode>" in accounts list
-        When the user edits an account with "<name>" to "<new_name>" with color "#<new_color>" and emoji "<new_emoji>"
-        Then the account is correctly displayed with "<new_name>" and "#<new_color>" and emoji unicode "<new_emoji_unicode>" in accounts list
-        When the user removes account "<new_name>" with agreement
-        Then the account with "<name>" is not displayed
-
-        Examples:
-            | seed_phrase                                                                                                                                                   | name    | color  | emoji      | emoji_unicode | new_name      | new_color | new_emoji | new_emoji_unicode |
-            | elite dinosaur flavor canoe garbage palace antique dolphin virtual mixed sand impact solution inmate hair pipe affair cage vote estate gloom lamp robust like | SPAcc24 | 2a4af5 | sunglasses | 1f60e         | SPAcc24edited | 216266    | thumbsup  | 1f44d             |
-            | kitten tiny cup admit cactus shrug shuffle accident century faith roof plastic beach police barely vacant sign blossom                                        | SPAcc18 | 2a4af5 | sunglasses | 1f60e         | SPAcc18edited | 216266    | thumbsup  | 1f44d             |
-            | pelican chief sudden oval media rare swamp elephant lawsuit wheat knife initial                                                                               | SPAcc12 | 2a4af5 | sunglasses | 1f60e         | SPAcc12edited | 216266    | thumbsup  | 1f44d             |
-
         Scenario Outline: The user manages an account created from the imported seed phrase
         When the user adds an imported seed phrase account "pelican chief sudden oval media rare swamp elephant lawsuit wheat knife initial" with "SPAcc12" color "#2a4af5" and emoji "sunglasses"
         Then the account with "SPAcc12" is displayed
@@ -139,17 +145,7 @@ Feature: Status Desktop Wallet Section Wallet Account Management
             | 20            | Ethereum (Ledger Live/KeepKey) | CustomGenAcc4 | 7140fd | sunglasses |
             | 95            | N/A                            | CustomGenAcc1 | 216266 | sunglasses |
 
-
-        Scenario Outline: The user adds and edits an account from the generated seed phrase
-        When the user adds a generated seed phrase account with "<name>" color "#<color>" emoji "<emoji>" and keypair "<keypair_name>"
-        Then the account is correctly displayed with "<name>" and "#<color>" and emoji unicode "<emoji_unicode>" in accounts list
-        When the user edits an account with "<name>" to "<new_name>" with color "#<new_color>" and emoji "<new_emoji>"
-        Then the account is correctly displayed with "<new_name>" and "#<new_color>" and emoji unicode "<new_emoji_unicode>" in accounts list
-
-        Examples:
-            | keypair_name | name  | color  | emoji      | emoji_unicode | new_name     | new_color | new_emoji | new_emoji_unicode |
-            | SPKeyPair    | SPAcc | 2a4af5 | sunglasses | 1f60e         | SPAcc_edited | 216266    | thumbsup  | 1f44d             |
-
+		# Test should be changed to check that adding more accounts to the keypair reflects in settings, otherwise it is almost a duplicated test
 		@mayfail
         Scenario Outline: The user manages an account created from the generated seed phrase
         When the user adds a generated seed phrase account with "SPKeyPair" color "#<color>" emoji "<emoji>" and keypair "<keypair_name>"


### PR DESCRIPTION
### What does the PR do

Fixes https://github.com/status-im/desktop-qa-automation/issues/82

1. enabled back the tests which were disabled because of context menu changes
2. renamed several to make them look alike
3. disabled 2 tests because they need to be changed a little (additional verifications needed), for now they are duplicating existing stuff

### Affected areas

Wallet tests