### PR TITLE
refactor: make use of newly introduce `SaveCommunityToken()` API

### DIFF
--- a/src/backend/community_tokens.nim
+++ b/src/backend/community_tokens.nim
@@ -23,9 +23,13 @@ proc getAllCommunityTokens*(): RpcResponse[JsonNode] {.raises: [Exception].} =
   let payload = %* []
   return core.callPrivateRPC("wakuext_getAllCommunityTokens", payload)
 
-proc addCommunityToken*(token: CommunityTokenDto, croppedImageJson: string): RpcResponse[JsonNode] {.raises: [Exception].} =
+proc saveCommunityToken*(token: CommunityTokenDto, croppedImageJson: string): RpcResponse[JsonNode] {.raises: [Exception].} =
   let croppedImage = newCroppedImage(croppedImageJson)
   let payload = %* [token.toJsonNode(), croppedImage]
+  return core.callPrivateRPC("wakuext_saveCommunityToken", payload)
+
+proc addCommunityToken*(communityId: string, chainId: int, address: string): RpcResponse[JsonNode] {.raises: [Exception].} =
+  let payload = %* [communityId, chainId, address]
   return core.callPrivateRPC("wakuext_addCommunityToken", payload)
 
 proc updateCommunityTokenState*(chainId: int, contractAddress: string, deployState: DeployState): RpcResponse[JsonNode] {.raises: [Exception].} =


### PR DESCRIPTION
As discussed in https://github.com/status-im/status-go/pull/3798, there was a need to separate the logic in `AddCommunityToken()` into two API.

This commit adjust the client to these changes such that:

1. After community token deployment tx was sent, we create a `CommunityToken` and add it to the database for tracking purposes
2. Once the tx is mined or dropped, we add the community token to the community description and publish it, or we update the deployment state in the database

Needs: https://github.com/status-im/status-go/pull/3798
