### PR TITLE
fix(ProfileDialogView): impossible to copy one's chat key 

### DIFF
--- a/storybook/pages/ProfileDialogViewPage.qml
+++ b/storybook/pages/ProfileDialogViewPage.qml
@@ -99,7 +99,13 @@ SplitView {
 
     Popups {
         popupParent: root
-        rootStore: QtObject {}
+        rootStore: QtObject {
+            property var contactStore: QtObject {
+                function changeContactNickname(publicKey, newNickname) {
+                    logs.logEvent("rootStore::contactStore::changeContactNickname", ["publicKey", "newNickname"], arguments)
+                }
+            }
+        }
     }
 
     SplitView {
@@ -169,13 +175,17 @@ SplitView {
                             function verifiedUntrustworthy(publicKey) {
                                 logs.logEvent("contactsStore::verifiedUntrustworthy", ["publicKey"], arguments)
                             }
+
+                            function getLinkToProfile(publicKey) {
+                                return "https://status.app/u/" + publicKey
+                            }
                         }
 
                         communitiesModel: ListModel {
                             ListElement {
                                 name: "Not the cool gang"
                                 memberRole: 0 // Constants.memberRole.none
-                                isControlNode: false,
+                                isControlNode: false
                                 description: "Nothing to write home about"
                                 color: "indigo"
                                 image: ""
@@ -187,7 +197,7 @@ SplitView {
                             ListElement {
                                 name: "Awesome bunch"
                                 memberRole: 4 // Constants.memberRole.admin
-                                isControlNode: false,
+                                isControlNode: false
                                 description: "Where the cool guys hang out & Nothing to write home about"
                                 color: "green"
                                 image: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADIAAAAyCAYAAAAeP4ixAAAAlklEQVR4nOzW0QmDQBAG4SSkl7SUQlJGCrElq9F3QdjjVhh/5nv3cFhY9vUIYQiNITSG0BhCExPynn1gWf9bx498P7/
@@ -204,7 +214,7 @@ SplitView {
                             ListElement {
                                 name: "Invisible community (should not display!)"
                                 memberRole: 1 // Constants.memberRole.owner
-                                isControlNode: true,
+                                isControlNode: true
                                 description: "Get outta here"
                                 color: "red"
                                 image: ""

--- a/ui/imports/shared/panels/ProfileBioSocialsPanel.qml
+++ b/ui/imports/shared/panels/ProfileBioSocialsPanel.qml
@@ -72,7 +72,6 @@ Control {
 
             visible: root.bio
             padding: 0
-            topPadding: Style.current.halfPadding
             rightPadding: ScrollBar.vertical.visible ? 16 : 0
 
             Layout.maximumHeight: 108

--- a/ui/imports/shared/views/ProfileDialogView.qml
+++ b/ui/imports/shared/views/ProfileDialogView.qml
@@ -327,6 +327,32 @@ Pane {
                     objectName: "ProfileDialog_userEmojiHash"
                     publicKey: root.publicKey
                 }
+                RowLayout {
+                    StatusBaseText {
+                        font.pixelSize: 12
+                        color: Theme.palette.baseColor1
+                        text: Utils.getElidedCompressedPk(root.publicKey)
+                    }
+                    StatusFlatButton {
+                        size: StatusFlatButton.Size.Tiny
+                        icon.name: "copy"
+                        enabled: !d.timer.running
+
+                        onClicked: {
+                            copyKeyTooltip.text = qsTr("Copied")
+                            root.profileStore.copyToClipboard(Utils.getCompressedPk(root.publicKey))
+                            d.timer.setTimeout(function() {
+                                copyKeyTooltip.text = qsTr("Copy Chat Key")
+                            }, 1500);
+                        }
+
+                        StatusToolTip {
+                            id: copyKeyTooltip
+                            text: qsTr("Copy Chat Key")
+                            visible: parent.hovered || d.timer.running
+                        }
+                    }
+                }
             }
 
             Loader {

--- a/ui/imports/shared/views/ProfileDialogView.qml
+++ b/ui/imports/shared/views/ProfileDialogView.qml
@@ -516,7 +516,6 @@ Pane {
             Layout.fillHeight: true
             Layout.leftMargin: -column.anchors.leftMargin
             Layout.rightMargin: -column.anchors.rightMargin
-            Layout.topMargin: -column.spacing
             padding: 0
             contentWidth: availableWidth
 


### PR DESCRIPTION
### What does the PR do

put a little label below the emoji hash with the elided compressed chat
key plus a copy button with a tooltip

(some minor spacing and storybook fixes in a separate commit)

Fixes https://github.com/status-im/status-desktop/issues/11665

### Affected areas

ProfileDialogView

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

Own profile, dark:
![image](https://github.com/status-im/status-desktop/assets/5377645/05fd0127-a2b2-46c2-bbe5-899e5bc390ad)

Jo's profile, light:
![image](https://github.com/status-im/status-desktop/assets/5377645/8df40832-6966-4936-be5b-62a7203d448c)

