### PR TITLE
feat: implement retrying deploying community contracts

### DIFF
--- a/src/app_service/service/community_tokens/service.nim
+++ b/src/app_service/service/community_tokens/service.nim
@@ -379,7 +379,6 @@ QtObject:
       if response.error != nil:
         let error = Json.decode($response.error, RpcError)
         raise newException(RpcException, "error removing community token: " & error.message)
-        return
       self.events.emit(SIGNAL_COMMUNITY_TOKEN_REMOVED, CommunityTokenRemovedArgs(communityId: communityId, contractAddress: address, chainId: chainId))
 
     except RpcException as e:

--- a/ui/app/AppLayouts/Communities/panels/MintTokensSettingsPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/MintTokensSettingsPanel.qml
@@ -497,10 +497,11 @@ StackView {
                          (!tokenViewPage.isPrivilegedTokenItem && !root.isAdminOnly && tokenViewPage.deploymentFailed)
 
                 onClicked: {
-                    if(tokenViewPage.isPrivilegedTokenItem)
+                    if(tokenViewPage.isPrivilegedTokenItem) {
                         retryPrivilegedToken()
-                    else
+                    } else {
                         retryAssetOrCollectible()
+                    }
                 }
             }
         ]

--- a/ui/imports/shared/stores/CommunityTokensStore.qml
+++ b/ui/imports/shared/stores/CommunityTokensStore.qml
@@ -26,8 +26,9 @@ QtObject {
     // Minting tokens:
     function deployCollectible(communityId, collectibleItem)
     {        
-        // TODO: Backend will need to check if the collectibleItem has a valid tokenKey, so it means a deployment retry,
-        // otherwise, it is a new deployment.
+        if (collectibleItem.key !== "") {
+            deleteToken(communityId, collectibleItem.key)
+        }
         const jsonArtworkFile = Utils.getImageAndCropInfoJson(collectibleItem.artworkSource, collectibleItem.artworkCropRect)
         communityTokensModuleInst.deployCollectible(communityId, collectibleItem.accountAddress, collectibleItem.name,
                                                     collectibleItem.symbol, collectibleItem.description, collectibleItem.supply,
@@ -37,8 +38,9 @@ QtObject {
 
     function deployAsset(communityId, assetItem)
     {
-        // TODO: Backend will need to check if the collectibleItem has a valid tokenKey, so it means a deployment retry,
-        // otherwise, it is a new deployment.
+        if (assetItem.key !== "") {
+            deleteToken(communityId, assetItem.key)
+        }
         const jsonArtworkFile = Utils.getImageAndCropInfoJson(assetItem.artworkSource, assetItem.artworkCropRect)
         communityTokensModuleInst.deployAssets(communityId, assetItem.accountAddress, assetItem.name,
                                                assetItem.symbol, assetItem.description, assetItem.supply,


### PR DESCRIPTION
Ultimately, this means deleting/removing the entry of the previously failed deployment, then performing a new transaction.

Closes #11186