### PR TITLE
chore(Communities): Fee handling updated in the airdrop flow

### DIFF
--- a/storybook/pages/EditAirdropViewPage.qml
+++ b/storybook/pages/EditAirdropViewPage.qml
@@ -252,6 +252,23 @@ SplitView {
                 assetsModel: AssetsModel {}
                 collectiblesModel: CollectiblesModel {}
                 membersModel: members
+
+                accountsModel: ListModel {
+                    ListElement {
+                        name: "Test account"
+                        emoji: "😋"
+                        address: "0x7F47C2e18a4BBf5487E6fb082eC2D9Ab0E6d7240"
+                        color: "red"
+                    }
+
+                    ListElement {
+                        name: "Another account - generated"
+                        emoji: "🚗"
+                        address: "0x7F47C2e98a4BBf5487E6fb082eC2D9Ab0E6d8888"
+                        color: "blue"
+                    }
+                }
+
                 communityDetails: QtObject {
                     readonly property string name: "Socks"
                     readonly property string id: "SOCKS"
@@ -262,13 +279,15 @@ SplitView {
 
                 onAirdropClicked: {
                     logs.logEvent("EditAirdropView::airdropClicked",
-                                  ["airdropTokens", "addresses", "membersPubKeys"],
+                                  ["airdropTokens", "addresses",
+                                   "membersPubKeys", "feeAccountAddress"],
                                   arguments)
                 }
 
                 onAirdropFeesRequested: {
                     logs.logEvent("EditAirdropView::airdropFeesRequested",
-                                  ["contractKeysAndAmounts", "addresses"],
+                                  ["contractKeysAndAmounts", "addresses",
+                                   "feeAccountAddress"],
                                   arguments)
 
                     feesCalculationTimer.requestMockedFees(contractKeysAndAmounts)

--- a/storybook/pages/FeesBoxPage.qml
+++ b/storybook/pages/FeesBoxPage.qml
@@ -53,7 +53,10 @@ SplitView {
             width: 600
 
             model: filteredModel
-            accountsModel: accountsSwitch.checked ? accountsModel : null
+
+            accountsSelector.model: accountsModel
+            showAccountsSelector: accountsSwitch.checked
+
             placeholderText: placeholderTextField.text
 
             totalFeeText: totalCheckBox.checked ?

--- a/ui/StatusQ/src/StatusQ/Controls/StatusComboBox.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusComboBox.qml
@@ -12,6 +12,7 @@ Item {
 
     property alias control: comboBox
     property alias model: comboBox.model
+    property alias count: comboBox.count
     property alias delegate: comboBox.delegate
     property alias contentItem: comboBox.contentItem
 
@@ -20,6 +21,7 @@ Item {
 
     property alias label: labelItem.text
     property alias validationError: validationErrorItem.text
+    property bool forceError: false
 
     property string popupContentItemObjectName: ""
     property string indicatorIcon: "chevron-down"
@@ -74,9 +76,14 @@ Item {
             background: Rectangle {
                 color: root.type === StatusComboBox.Type.Secondary ? "transparent" : Theme.palette.baseColor2
                 radius: 8
-                border.width: (!!root.validationError || comboBox.hovered || comboBox.down || comboBox.visualFocus || root.type === StatusComboBox.Type.Secondary) ? 1 : 0
+                border.width: (!!root.validationError || root.forceError
+                               || comboBox.hovered || comboBox.down
+                               || comboBox.visualFocus
+                               || root.type === StatusComboBox.Type.Secondary)
+                              ? 1 : 0
+
                 border.color: {
-                    if (!!root.validationError)
+                    if (!!root.validationError || root.forceError)
                         return Theme.palette.dangerColor1
 
                     if (comboBox.visualFocus || comboBox.popup.opened)

--- a/ui/app/AppLayouts/Communities/controls/FeeRow.qml
+++ b/ui/app/AppLayouts/Communities/controls/FeeRow.qml
@@ -28,10 +28,6 @@ Control {
             id: titleText
 
             width: parent.halfWidth
-            anchors.left: parent.left
-            anchors.top: parent.top
-            anchors.bottom: parent.bottom
-
 
             text: root.title
             wrapMode: Text.Wrap
@@ -51,7 +47,6 @@ Control {
 
             width: parent.halfWidth
             anchors.right: parent.right
-            anchors.top: parent.top
 
             textFormat: Text.RichText
             text: `<span style="color:${baseColor};` +

--- a/ui/app/AppLayouts/Communities/controls/FeesBoxFooter.qml
+++ b/ui/app/AppLayouts/Communities/controls/FeesBoxFooter.qml
@@ -87,6 +87,7 @@ Control {
             Layout.topMargin: Style.current.halfPadding
 
             visible: root.showAccountsSelector
+            forceError: accountErrorText.visible
         }
 
         ErrorText {

--- a/ui/app/AppLayouts/Communities/controls/FeesBoxFooter.qml
+++ b/ui/app/AppLayouts/Communities/controls/FeesBoxFooter.qml
@@ -16,7 +16,9 @@ Control {
     property bool showTotal: true
     property alias totalFeeText: feeTotalRow.feeText
 
-    property alias accountsModel: accountSelector.model
+    readonly property alias accountsSelector: accountSelector
+    property bool showAccountsSelector: true
+
     property alias accountErrorText: accountErrorText.text
 
     component Separator: Rectangle {
@@ -28,7 +30,6 @@ Control {
     }
 
     component ErrorText: StatusBaseText {
-
         Layout.fillWidth: true
         Layout.topMargin: Style.current.halfPadding
         horizontalAlignment: Text.AlignRight
@@ -85,7 +86,7 @@ Control {
             Layout.fillWidth: true
             Layout.topMargin: Style.current.halfPadding
 
-            visible: !!model
+            visible: root.showAccountsSelector
         }
 
         ErrorText {

--- a/ui/app/AppLayouts/Communities/panels/AirdropsSettingsPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/AirdropsSettingsPanel.qml
@@ -30,6 +30,7 @@ StackView {
     required property var collectiblesModel
 
     required property var membersModel
+    required property var accountsModel
 
     // JS object specifing fees for the airdrop operation, should be set to
     // provide response to airdropFeesRequested signal.
@@ -39,8 +40,10 @@ StackView {
     property int viewWidth: 560 // by design
     property string previousPageName: depth > 1 ? qsTr("Airdrops") : ""
 
-    signal airdropClicked(var airdropTokens, var addresses, var membersPubKeys)
-    signal airdropFeesRequested(var contractKeysAndAmounts, var addresses)
+    signal airdropClicked(var airdropTokens, var addresses, var membersPubKeys,
+                          string feeAccountAddress)
+    signal airdropFeesRequested(var contractKeysAndAmounts, var addresses,
+                                string feeAccountAddress)
     signal navigateToMintTokenSettings(bool isAssetType)
 
     function navigateBack() {
@@ -135,6 +138,7 @@ StackView {
                 assetsModel: root.assetsModel
                 collectiblesModel: root.collectiblesModel
                 membersModel: root.membersModel
+                accountsModel: root.accountsModel
 
                 Binding on airdropFees {
                     value: root.airdropFees

--- a/ui/app/AppLayouts/Communities/panels/FeesBox.qml
+++ b/ui/app/AppLayouts/Communities/panels/FeesBox.qml
@@ -18,8 +18,11 @@ StatusGroupBox {
     // feeText (string)
     // error (bool), optional
     property alias model: feesBox.model
+    readonly property alias count: feesBox.count
 
-    property alias accountsModel: footer.accountsModel
+    readonly property alias accountsSelector: footer.accountsSelector
+    property alias showAccountsSelector: footer.showAccountsSelector
+
     property alias placeholderText: feesBox.placeholderText
 
     property alias totalFeeText: footer.totalFeeText
@@ -43,8 +46,8 @@ StatusGroupBox {
         footer: FeesBoxFooter {
             id: footer
 
-            visible: !!accountsModel || showTotal
-                     || root.generalErrorText || root.accountErrorText
+            visible: feesBox.count && (root.showAccountsSelector || showTotal
+                     || root.generalErrorText)
 
             showTotal: feesBox.count > 1
         }

--- a/ui/app/AppLayouts/Communities/panels/FeesBox.qml
+++ b/ui/app/AppLayouts/Communities/panels/FeesBox.qml
@@ -32,7 +32,8 @@ StatusGroupBox {
 
         width: root.availableWidth
         padding: Style.current.padding
-        verticalPadding: 18
+
+        verticalPadding: 20
 
         background: Rectangle {
             radius: Style.current.radius

--- a/ui/app/AppLayouts/Communities/panels/FeesPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/FeesPanel.qml
@@ -42,7 +42,7 @@ Control {
     QtObject {
         id: d
 
-        readonly property int delegateHeight: 28
+        readonly property int placeholderHeight: 24
     }
 
     contentItem: ColumnLayout {
@@ -52,10 +52,10 @@ Control {
             id: placeholderText
 
             Layout.fillWidth: true
-            Layout.preferredHeight: Math.max(implicitHeight, d.delegateHeight)
+            Layout.preferredHeight: Math.max(implicitHeight,
+                                             d.placeholderHeight)
 
             visible: repeater.count === 0
-
             font.pixelSize: Style.current.primaryTextFontSize
             wrapMode: Text.Wrap
             color: Theme.palette.baseColor1
@@ -67,8 +67,6 @@ Control {
 
             FeeRow {
                 Layout.fillWidth: true
-                Layout.preferredHeight: Math.max(implicitHeight,
-                                                 d.delegateHeight)
 
                 title: model.title
                 feeText: model.feeText

--- a/ui/app/AppLayouts/Communities/views/CommunitySettingsView.qml
+++ b/ui/app/AppLayouts/Communities/views/CommunitySettingsView.qml
@@ -491,8 +491,31 @@ StatusSectionLayout {
                 return chatContentModule.usersModule.model
             }
 
-            onAirdropClicked: communityTokensStore.airdrop(root.community.id,
-                                                           airdropTokens, addresses)
+            accountsModel: SortFilterProxyModel {
+                sourceModel: root.rootStore.accounts
+                proxyRoles: [
+                    ExpressionRole {
+                        name: "color"
+
+                        function getColor(colorId) {
+                            return Utils.getColorForId(colorId)
+                        }
+
+                        // Direct call for singleton function is not handled properly by
+                        // SortFilterProxyModel that's why helper function is used instead.
+                        expression: { return getColor(model.colorId) }
+                    }
+                ]
+                filters: ValueFilter {
+                    roleName: "walletType"
+                    value: Constants.watchWalletType
+                    inverted: true
+                }
+            }
+
+            onAirdropClicked: communityTokensStore.airdrop(
+                                  root.community.id, airdropTokens, addresses,
+                                  feeAccountAddress)
 
             onNavigateToMintTokenSettings: {
                 root.goTo(Constants.CommunitySettingsSections.MintTokens)
@@ -501,7 +524,8 @@ StatusSectionLayout {
 
             onAirdropFeesRequested:
                 communityTokensStore.computeAirdropFee(
-                    root.community.id, contractKeysAndAmounts, addresses)
+                    root.community.id, contractKeysAndAmounts, addresses,
+                    feeAccountAddress)
         }
     }
 

--- a/ui/imports/shared/stores/CommunityTokensStore.qml
+++ b/ui/imports/shared/stores/CommunityTokensStore.qml
@@ -116,11 +116,13 @@ QtObject {
     }
 
     // Airdrop tokens:
-    function airdrop(communityId, airdropTokens, addresses) {
+    function airdrop(communityId, airdropTokens, addresses, feeAccountAddress) {
+        // TODO: Take `feeAccountAddress` into account for the airdrop
         communityTokensModuleInst.airdropTokens(communityId, JSON.stringify(airdropTokens), JSON.stringify(addresses))
     }
 
-    function computeAirdropFee(communityId, contractKeysAndAmounts, addresses) {
+    function computeAirdropFee(communityId, contractKeysAndAmounts, addresses, feeAccountAddress) {
+        // TODO: Take `feeAccountAddress` into account when calculating fee
         communityTokensModuleInst.computeAirdropFee(
                     communityId, JSON.stringify(contractKeysAndAmounts),
                     JSON.stringify(addresses))


### PR DESCRIPTION
### What does the PR do

Update airdrop flow to use account selector in fees box. Also amends some inconsistencies with the design after recent updates.

Closes: https://github.com/status-im/status-desktop/issues/11605

### Affected areas

`EditAirdropView`, `FeesBox`, `FeesBoxFooter`, `StatusComboBox`

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![Screenshot from 2023-07-25 16-33-59](https://github.com/status-im/status-desktop/assets/20650004/9db7b3ec-81b8-409d-8305-2c488b051945)
![Screenshot from 2023-07-25 16-34-07](https://github.com/status-im/status-desktop/assets/20650004/72abee1b-f10f-4a8e-b465-bc8977bb6bfc)
