### PR TITLE
fix: Mint tokens screen uses different border colors for boxes

### DIFF
--- a/storybook/pages/IntroPanelPage.qml
+++ b/storybook/pages/IntroPanelPage.qml
@@ -23,6 +23,7 @@ SplitView {
             anchors.fill: tokenPanel
             border.width: 1
             anchors.margins: -15
+            color: "transparent"
         }
 
         IntroPanel {

--- a/ui/StatusQ/src/StatusQ/Components/StatusCommunityCard.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusCommunityCard.qml
@@ -130,17 +130,17 @@ Rectangle {
 
     QtObject {
         id: d
-        property int cardWidth: 335
-        property int bannerHeigth: 64
-        property int cardHeigth: 190
-        property int totalHeigth: 230
-        property int margins: 12
-        property int bannerRadius: 20
-        property int cardRadius: 16
-        property color cardColor: Theme.palette.indirectColor1
-        property color fontColor: Theme.palette.directColor1
-        property color loadingColor1: Theme.palette.baseColor5
-        property color loadingColor2: Theme.palette.baseColor4
+        readonly property int cardWidth: 335
+        readonly property int bannerHeigth: 64
+        readonly property int cardHeigth: 190
+        readonly property int totalHeigth: 230
+        readonly property int margins: 12
+        readonly property int bannerRadius: 20
+        readonly property int cardRadius: 16
+        readonly property color cardColor: Theme.palette.name === "light" ? Theme.palette.indirectColor1 : Theme.palette.baseColor2
+        readonly property color fontColor: Theme.palette.directColor1
+        readonly property color loadingColor1: Theme.palette.baseColor5
+        readonly property color loadingColor2: Theme.palette.baseColor4
 
         function numberFormat(number) {
             var res = number

--- a/ui/StatusQ/src/StatusQ/Controls/StatusTagItem.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusTagItem.qml
@@ -6,11 +6,11 @@ import StatusQ.Core.Theme 0.1
 
 /*!
      \qmltype StatusTagItem
-     \inherits Item
+     \inherits Control
      \inqmlmodule StatusQ.Controls
      \since StatusQ.Controls 0.1
-     \brief Reprsents a tag item.
-     Inherits \l{https://doc.qt.io/qt-5/qml-qtquick-rectangle.html}{Item}.
+     \brief Represents a tag item.
+     Inherits \l{https://doc.qt.io/qt-5/qml-qtquick-controls2-control.html}{Control}.
 
      The \c StatusTagItem represents a tag item where a name and icon can be displayed and can be clicked.
      Example:
@@ -54,16 +54,13 @@ Control {
 
     QtObject {
         id: d
-        property int tagMargins: 8
-        property int tagIconsSize: 20
+        readonly property int tagMargins: 8
+        readonly property int tagIconsSize: 20
 
         function getTagColor(isReadonly) {
-            if(isReadonly) {
+            if(isReadonly)
                 return Theme.palette.baseColor1
-            }
-            else {
-                return mouseArea.containsMouse ? Theme.palette.miscColor1 : Theme.palette.primaryColor1
-            }
+            return mouseArea.containsMouse ? Theme.palette.miscColor1 : Theme.palette.primaryColor1
         }
     }
 

--- a/ui/app/AppLayouts/Communities/panels/IntroPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/IntroPanel.qml
@@ -35,7 +35,7 @@ Control {
     background: Rectangle {
         color: "transparent"
         radius: 16
-        border.color: Theme.palette.baseColor5
+        border.color: Theme.palette.baseColor2
     }
 
     contentItem: ColumnLayout {

--- a/ui/app/AppLayouts/Communities/views/EditPermissionView.qml
+++ b/ui/app/AppLayouts/Communities/views/EditPermissionView.qml
@@ -561,6 +561,7 @@ StatusScrollView {
         }
         Separator {
             Layout.topMargin: 24
+            color: Theme.palette.baseColor2
         }
 
         HidePermissionPanel {

--- a/ui/app/AppLayouts/Onboarding/views/ProfileFetchingView.qml
+++ b/ui/app/AppLayouts/Onboarding/views/ProfileFetchingView.qml
@@ -74,7 +74,7 @@ Item {
                     icon: model.icon
                 }
 
-                Text {
+                StatusBaseText {
                     id: entity
                     anchors.left: icon.right
                     anchors.right: indicator.visible? indicator.left : loaded.left
@@ -107,7 +107,7 @@ Item {
                     visible: model.totalMessages === 0
                 }
 
-                Text {
+                StatusBaseText {
                     id: loaded
                     anchors.right: parent.right
                     anchors.verticalCenter: parent.verticalCenter
@@ -144,7 +144,6 @@ Item {
         StatusButton {
             id: button
             Layout.alignment: Qt.AlignHCenter
-            Layout.preferredWidth: root.startupStore.currentStartupState.stateType === Constants.startupState.profileFetching? 80 : -1
             focus: true
             enabled: root.startupStore.currentStartupState.stateType !== Constants.startupState.profileFetching
 

--- a/ui/imports/shared/views/ExistingContacts.qml
+++ b/ui/imports/shared/views/ExistingContacts.qml
@@ -84,7 +84,7 @@ Item {
             isContact: model.isContact
             status: model.onlineStatus
             height: visible ? implicitHeight : 0
-            color: sensor.containsMouse ? Style.current.backgroundHover : Style.current.transparent
+            color: sensor.containsMouse ? Theme.palette.baseColor2 : "transparent"
             nickName: model.localNickname
             userName: ProfileUtils.displayName("", model.ensName, model.displayName, model.alias)
             asset.name: model.icon


### PR DESCRIPTION
plus a couple of other dark mode fixes

Fixes #11633

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

Mint tokens, dark:
![image](https://github.com/status-im/status-desktop/assets/5377645/0dd9c88e-4465-4fca-b019-12a381c22c61)

Mint tokens, light:
![image](https://github.com/status-im/status-desktop/assets/5377645/43cc9ebe-cd8c-42d6-bd27-e94e5c861006)

Community portal cards, dark:
![image](https://github.com/status-im/status-desktop/assets/5377645/e6ff21ce-feac-4e91-b037-a1272bad8f92)

Community portal cards, light:
![image](https://github.com/status-im/status-desktop/assets/5377645/d2f2de86-9e7c-4f3c-8c2f-85de526691d1)

Profile fetching view, dark:
![image](https://github.com/status-im/status-desktop/assets/5377645/1959ac47-894e-4671-bac2-9fe9f9efbbc5)

Profile fetching view, light:
![image](https://github.com/status-im/status-desktop/assets/5377645/99a003f5-c42b-4e26-95be-cee86db90e1c)



