### PR TITLE
fix: Bind `linkPreviewModel` property

### DIFF
--- a/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
@@ -39,6 +39,7 @@ Control {
 
     property string messageAttachments: ""
     property var reactionIcons: []
+    property var linkPreviewModel
 
     property string messageId: ""
     property bool editMode: false
@@ -351,7 +352,7 @@ Control {
                     Loader {
                         id: linksLoader
                         Layout.fillWidth: true
-                        active: !root.editMode && root.linkPreviewModel.count > 0
+                        active: !root.editMode && root.linkPreviewModel && root.linkPreviewModel.count > 0
                         visible: active
                     }
                     Loader {

--- a/ui/app/AppLayouts/Chat/popups/PinnedMessagesPopup.qml
+++ b/ui/app/AppLayouts/Chat/popups/PinnedMessagesPopup.qml
@@ -98,7 +98,7 @@ StatusDialog {
                     messagePinnedBy: model.pinnedBy
                     sticker: model.sticker
                     stickerPack: model.stickerPack
-                    linkUrls: model.links
+                    linkPreviewModel: model.linkPreviewModel
                     transactionParams: model.transactionParameters
                     quotedMessageText: model.quotedMessageParsedText
                     quotedMessageFrom: model.quotedMessageFrom

--- a/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatMessagesView.qml
@@ -296,7 +296,6 @@ Item {
             editModeOn: model.editMode
             onEditModeOnChanged: root.editModeChanged(editModeOn)
             isEdited: model.isEdited
-            linkUrls: model.links
             linkPreviewModel: model.linkPreviewModel
             messageAttachments: model.messageAttachments
             transactionParams: model.transactionParameters

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -60,7 +60,6 @@ Loader {
     property bool pinnedMessage: false
     property string messagePinnedBy: ""
     property var reactionsModel: []
-    property string linkUrls: ""
     property var linkPreviewModel
     property string messageAttachments: ""
     property var transactionParams
@@ -518,6 +517,7 @@ Loader {
                 isSending: root.isSending
                 resendError: root.resendError
                 reactionsModel: root.reactionsModel
+                linkPreviewModel: root.linkPreviewModel
 
                 showHeader: root.shouldRepeatHeader || dateGroupLabel.visible || isAReply ||
                             root.prevMessageContentType === Constants.messageContentType.systemMessagePrivateGroupType ||


### PR DESCRIPTION
### What does the PR do

Missed some property bindings in my original PR, as @caybro noticed 🙂 
Also removed `linkUrls` property, which is not used anymore for now.