### PR TITLE
refactor(communities): rename `inviteUsersToCommunity` to `shareCommu…

### DIFF
--- a/src/app/modules/main/chat_section/controller.nim
+++ b/src/app/modules/main/chat_section/controller.nim
@@ -52,7 +52,7 @@ type
     tmpAuthenticationWithCallbackInProgress: bool
 
 proc newController*(delegate: io_interface.AccessInterface, sectionId: string, isCommunity: bool, events: EventEmitter,
-  settingsService: settings_service.Service, nodeConfigurationService: node_configuration_service.Service, 
+  settingsService: settings_service.Service, nodeConfigurationService: node_configuration_service.Service,
   contactService: contact_service.Service, chatService: chat_service.Service, communityService: community_service.Service,
   messageService: message_service.Service, gifService: gif_service.Service,
   mailserversService: mailservers_service.Service,
@@ -84,7 +84,7 @@ proc newController*(delegate: io_interface.AccessInterface, sectionId: string, i
   result.tmpAirdropAddress = ""
   result.tmpAddressesToShare = @[]
   result.tmpAuthenticationWithCallbackInProgress = true
-  
+
 proc delete*(self: Controller) =
   self.events.disconnect()
 
@@ -301,12 +301,12 @@ proc init*(self: Controller) =
       let args = ReloadMessagesArgs(e)
       if (args.communityId == self.sectionId):
         self.messageService.asyncLoadInitialMessagesForChat(self.getActiveChatId())
-    
+
     self.events.on(SIGNAL_CATEGORY_MUTED) do(e: Args):
       let args = CategoryArgs(e)
       if (args.communityId == self.sectionId):
         self.delegate.onCategoryMuted(args.categoryId)
-    
+
     self.events.on(SIGNAL_CATEGORY_UNMUTED) do(e: Args):
       let args = CategoryArgs(e)
       if (args.communityId == self.sectionId):
@@ -414,7 +414,7 @@ proc init*(self: Controller) =
     if (self.sectionId != args.sectionId):
       return
     self.delegate.makeChatWithIdActive(args.chatId)
-    
+
   if (not self.isCommunitySection):
     self.events.on(SIGNAL_CHAT_SWITCH_TO_OR_CREATE_1_1_CHAT) do(e:Args):
       let args = ChatExtArgs(e)
@@ -679,8 +679,8 @@ proc unmuteCategory*(self: Controller, categoryId: string) =
 proc setCommunityMuted*(self: Controller, mutedType: int) =
   self.communityService.setCommunityMuted(self.sectionId, mutedType)
 
-proc inviteUsersToCommunity*(self: Controller, pubKeys: string, inviteMessage: string): string =
-  result = self.communityService.inviteUsersToCommunityById(self.sectionId, pubKeys, inviteMessage)
+proc shareCommunityToUsers*(self: Controller, pubKeys: string, inviteMessage: string): string =
+  result = self.communityService.shareCommunityToUsers(self.sectionId, pubKeys, inviteMessage)
 
 proc reorderCommunityCategories*(self: Controller, categoryId: string, position: int) =
   self.communityService.reorderCommunityCategories(self.sectionId, categoryId, position)
@@ -717,7 +717,7 @@ proc ownsCollectible*(self: Controller, chainId: int, contractAddress: string, t
 
   for address in addresses:
     let data = self.collectibleService.getOwnedCollectibles(chainId, @[address])
-    
+
     for collectible in data[0].collectibles:
       if collectible.id.contractAddress == contractAddress.toLowerAscii:
         return true

--- a/src/app/modules/main/chat_section/io_interface.nim
+++ b/src/app/modules/main/chat_section/io_interface.nim
@@ -101,7 +101,7 @@ method addOrUpdateChat*(self: AccessInterface,
   ): Item {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method onNewMessagesReceived*(self: AccessInterface, sectionIdMsgBelongsTo: string, chatIdMsgBelongsTo: string, 
+method onNewMessagesReceived*(self: AccessInterface, sectionIdMsgBelongsTo: string, chatIdMsgBelongsTo: string,
   chatTypeMsgBelongsTo: ChatType, lastMessageTimestamp: int, unviewedMessagesCount: int, unviewedMentionsCount: int, message: MessageDto) {.base.} =
   raise newException(ValueError, "No implementation available")
 
@@ -307,7 +307,7 @@ method exportCommunity*(self: AccessInterface): string {.base.} =
 method setCommunityMuted*(self: AccessInterface, mutedType: int) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method inviteUsersToCommunity*(self: AccessInterface, pubKeysJSON: string, inviteMessage: string): string {.base.} =
+method shareCommunityToUsers*(self: AccessInterface, pubKeysJSON: string, inviteMessage: string): string {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method createCommunityCategory*(self: AccessInterface, name: string, channels: seq[string]) {.base.} =
@@ -392,7 +392,7 @@ method editSharedAddressesWithAuthentication*(self: AccessInterface, addressesTo
 
 
 method onCommunityCheckPermissionsToJoinResponse*(self: AccessInterface, checkPermissionsToJoinResponse: CheckPermissionsToJoinResponseDto) {.base.} =
- 
+
   raise newException(ValueError, "No implementation available")
 
 method onCommunityCheckChannelPermissionsResponse*(self: AccessInterface, chatId: string, checkChannelPermissionsResponse: CheckChannelPermissionsResponseDto) {.base.} =

--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -282,10 +282,10 @@ proc rebuildCommunityTokenPermissionsModel(self: Module) =
     let tokenPermissionItem = buildTokenPermissionItem(tokenPermission, chats)
     tokenPermissionsItems.add(tokenPermissionItem)
 
-  let memberPermissions = filter(tokenPermissionsItems, tokenPermissionsItem => 
+  let memberPermissions = filter(tokenPermissionsItems, tokenPermissionsItem =>
     tokenPermissionsItem.getType() == TokenPermissionType.BecomeMember.int)
-  
-  let adminPermissions = filter(tokenPermissionsItems, tokenPermissionsItem => 
+
+  let adminPermissions = filter(tokenPermissionsItems, tokenPermissionsItem =>
     tokenPermissionsItem.getType() == TokenPermissionType.BecomeAdmin.int)
 
   self.view.tokenPermissionsModel().setItems(tokenPermissionsItems)
@@ -442,13 +442,13 @@ method activeItemSet*(self: Module, itemId: string) =
 
   # save last open chat in settings for restore on the next app launch
   singletonInstance.localAccountSensitiveSettings.setSectionLastOpenChat(mySectionId, activeChatId)
-  
+
   let (deactivateSectionId, deactivateChatId) = singletonInstance.loaderDeactivator.addChatInMemory(mySectionId, activeChatId)
 
   # notify parent module about active chat/channel
   self.delegate.onActiveChatChange(mySectionId, activeChatId)
   self.delegate.onDeactivateChatLoader(deactivateSectionId, deactivateChatId)
-  
+
   if self.controller.isCommunity():
     self.controller.asyncCheckChannelPermissions(mySectionId, activeChatId)
 
@@ -571,7 +571,7 @@ method addNewChat*(
     chatImage = chatDto.icon
 
   var memberRole = self.getUserMemberRole(chatDto.members)
-  
+
   if memberRole == MemberRole.None and len(chatDto.communityId) != 0:
     memberRole = channelGroup.memberRole
   if chatDto.chatType != ChatType.PrivateGroupChat:
@@ -701,7 +701,7 @@ method setFirstChannelAsActive*(self: Module) =
   for chat_item in chat_items:
     if chat_item.`type` != CATEGORY_TYPE:
       self.setActiveItem(chat_item.id)
-      break    
+      break
 
 method onReorderChat*(self: Module, updatedChat: ChatDto) =
   self.view.chatsModel().reorderChats(@[updatedChat])
@@ -788,7 +788,7 @@ method onCommunityTokenPermissionCreated*(self: Module, communityId: string, tok
   self.reevaluateRequiresTokenPermissionToJoin()
   singletonInstance.globalEvents.showCommunityTokenPermissionCreatedNotification(communityId, "Community permission created", "A token permission has been added")
 
-proc updateTokenPermissionModel*(self: Module, permissions: Table[string, CheckPermissionsResultDto], community: CommunityDto) = 
+proc updateTokenPermissionModel*(self: Module, permissions: Table[string, CheckPermissionsResultDto], community: CommunityDto) =
   for id, criteriaResult in permissions:
     if community.tokenPermissions.hasKey(id):
       let tokenPermissionItem = self.view.tokenPermissionsModel.getItemById(id)
@@ -815,7 +815,7 @@ proc updateTokenPermissionModel*(self: Module, permissions: Table[string, CheckP
         updatedTokenCriteriaItems.add(updatedTokenCriteriaItem)
 
       let updatedTokenPermissionItem = initTokenPermissionItem(
-          tokenPermissionItem.id, 
+          tokenPermissionItem.id,
           tokenPermissionItem.`type`,
           updatedTokenCriteriaItems,
           tokenPermissionItem.getChatList().getItems(),
@@ -826,18 +826,18 @@ proc updateTokenPermissionModel*(self: Module, permissions: Table[string, CheckP
 
   let tokenPermissionsItems = self.view.tokenPermissionsModel().getItems()
 
-  let memberPermissions = filter(tokenPermissionsItems, tokenPermissionsItem => 
+  let memberPermissions = filter(tokenPermissionsItems, tokenPermissionsItem =>
     tokenPermissionsItem.getType() == TokenPermissionType.BecomeMember.int)
-  
-  let adminPermissions = filter(tokenPermissionsItems, tokenPermissionsItem => 
+
+  let adminPermissions = filter(tokenPermissionsItems, tokenPermissionsItem =>
     tokenPermissionsItem.getType() == TokenPermissionType.BecomeAdmin.int)
 
   # multiple permissions of the same type act as logical OR
   # so if at least one of them is fulfilled we can mark the view
   # as all lights green
-  let memberRequirementMet = memberPermissions.len() > 0 and any(memberPermissions, 
+  let memberRequirementMet = memberPermissions.len() > 0 and any(memberPermissions,
     proc (item: TokenPermissionItem): bool = item.tokenCriteriaMet)
-  
+
   let adminRequirementMet = adminPermissions.len() > 0 and any(adminPermissions, proc (item: TokenPermissionItem): bool = item.tokenCriteriaMet)
 
   let requiresPermissionToJoin = (adminPermissions.len() > 0 and adminRequirementMet) or memberPermissions.len() > 0
@@ -845,7 +845,7 @@ proc updateTokenPermissionModel*(self: Module, permissions: Table[string, CheckP
 
   self.view.setAllTokenRequirementsMet(tokenRequirementsMet)
   self.view.setRequiresTokenPermissionToJoin(requiresPermissionToJoin)
-      
+
 
 proc updateChannelPermissionViewData*(self: Module, chatId: string, viewOnlyPermissions: ViewOnlyOrViewAndPostPermissionsResponseDto, viewAndPostPermissions: ViewOnlyOrViewAndPostPermissionsResponseDto, community: CommunityDto) =
   self.updateTokenPermissionModel(viewOnlyPermissions.permissions, community)
@@ -1119,8 +1119,8 @@ method exportCommunity*(self: Module): string =
 method setCommunityMuted*(self: Module, mutedType: int) =
   self.controller.setCommunityMuted(mutedType)
 
-method inviteUsersToCommunity*(self: Module, pubKeysJSON: string, inviteMessage: string): string =
-  result = self.controller.inviteUsersToCommunity(pubKeysJSON, inviteMessage)
+method shareCommunityToUsers*(self: Module, pubKeysJSON: string, inviteMessage: string): string =
+  result = self.controller.shareCommunityToUsers(pubKeysJSON, inviteMessage)
 
 method prepareEditCategoryModel*(self: Module, categoryId: string) =
   self.view.editCategoryChannelsModel().clearItems()
@@ -1317,14 +1317,14 @@ method createOrEditCommunityTokenPermission*(self: Module, communityId: string, 
     if contractAddresses.len == 0 and tokenCriteriaDto.`type` != community_dto.TokenType.ENS:
       if permissionId == "":
         self.onCommunityTokenPermissionCreationFailed(communityId)
-        return 
+        return
       self.onCommunityTokenPermissionUpdateFailed(communityId)
       return
 
     tokenCriteriaDto.amount = viewAmount.formatBiggestFloat(ffDecimal)
     tokenCriteriaDto.contractAddresses = contractAddresses
     tokenPermission.tokenCriteria.add(tokenCriteriaDto)
-  
+
   self.controller.createOrEditCommunityTokenPermission(communityId, tokenPermission)
 
 method deleteCommunityTokenPermission*(self: Module, communityId: string, permissionId: string) =

--- a/src/app/modules/main/chat_section/view.nim
+++ b/src/app/modules/main/chat_section/view.nim
@@ -20,14 +20,14 @@ QtObject:
       listOfMyContactsVariant: QVariant
       editCategoryChannelsModel: chats_model.Model
       editCategoryChannelsVariant: QVariant
-      loadingHistoryMessagesInProgress: bool 
+      loadingHistoryMessagesInProgress: bool
       tokenPermissionsModel: TokenPermissionsModel
       tokenPermissionsVariant: QVariant
       allTokenRequirementsMet: bool
       requiresTokenPermissionToJoin: bool
       amIMember: bool
       chatsLoaded: bool
-      
+
   proc delete*(self: View) =
     self.model.delete
     self.modelVariant.delete
@@ -303,7 +303,7 @@ QtObject:
 
   proc leaveCommunity*(self: View) {.slot.} =
     self.delegate.leaveCommunity()
-  
+
   proc removeUserFromCommunity*(self: View, pubKey: string) {.slot.} =
     self.delegate.removeUserFromCommunity(pubKey)
 
@@ -311,7 +311,7 @@ QtObject:
     self.delegate.banUserFromCommunity(pubKey)
 
   proc editCommunity*(self: View, name: string, description: string, introMessage: string, outroMessage: string, access: int,
-                      color: string, tags: string, logoJsonData: string, bannerJsonData: string, historyArchiveSupportEnabled: bool, 
+                      color: string, tags: string, logoJsonData: string, bannerJsonData: string, historyArchiveSupportEnabled: bool,
                       pinMessageAllMembersEnabled: bool) {.slot.} =
     self.delegate.editCommunity(name, description, introMessage, outroMessage, access, color, tags,
                                 logoJsonData, bannerJsonData, historyArchiveSupportEnabled, pinMessageAllMembersEnabled)
@@ -325,8 +325,8 @@ QtObject:
   proc setCommunityMuted*(self: View, mutedType: int) {.slot.} =
     self.delegate.setCommunityMuted(mutedType)
 
-  proc inviteUsersToCommunity*(self: View, pubKeysJSON: string, inviteMessage: string): string {.slot.} =
-    result = self.delegate.inviteUsersToCommunity(pubKeysJSON, inviteMessage)
+  proc shareCommunityToUsers*(self: View, pubKeysJSON: string, inviteMessage: string): string {.slot.} =
+    result = self.delegate.shareCommunityToUsers(pubKeysJSON, inviteMessage)
 
   proc createCommunityCategory*(self: View, name: string, channels: string) {.slot.} =
     let channelsSeq = map(parseJson(channels).getElems(), proc(x:JsonNode):string = x.getStr())
@@ -347,12 +347,12 @@ QtObject:
 
   proc reorderCommunityChat*(self: View, categoryId: string, chatId: string, position: int) {.slot} =
     self.delegate.reorderCommunityChat(categoryId, chatId, position)
-    
+
   proc loadingHistoryMessagesInProgressChanged*(self: View) {.signal.}
 
   proc getLoadingHistoryMessagesInProgress*(self: View): bool {.slot.} =
     return self.loadingHistoryMessagesInProgress
-  
+
   QtProperty[bool] loadingHistoryMessagesInProgress:
     read = getLoadingHistoryMessagesInProgress
     notify = loadingHistoryMessagesInProgressChanged
@@ -408,7 +408,7 @@ QtObject:
       return
     self.amIMember = value
     self.amIMemberChanged()
-  
+
   QtProperty[bool] amIMember:
     read = getAmIMember
     notify = amIMemberChanged
@@ -423,7 +423,7 @@ QtObject:
       return
     self.allTokenRequirementsMet = value
     self.allTokenRequirementsMetChanged()
-  
+
   QtProperty[bool] allTokenRequirementsMet:
     read = getAllTokenRequirementsMet
     notify = allTokenRequirementsMetChanged
@@ -432,5 +432,5 @@ QtObject:
 
   proc authenticateWithCallback*(self: View) {.slot.} =
     self.delegate.authenticateWithCallback()
-  
+
   proc callbackFromAuthentication*(self: View, authenticated: bool) {.signal.}

--- a/src/app/modules/main/profile_section/communities/controller.nim
+++ b/src/app/modules/main/profile_section/communities/controller.nim
@@ -17,8 +17,8 @@ proc newController*(delegate: io_interface.AccessInterface,
 proc delete*(self: Controller) =
   discard
 
-proc inviteUsersToCommunity*(self: Controller, communityID: string, pubKeys: string, inviteMessage: string): string =
-  result = self.communityService.inviteUsersToCommunityById(communityID, pubKeys, inviteMessage)
+proc shareCommunityToUsers*(self: Controller, communityID: string, pubKeys: string, inviteMessage: string): string =
+  result = self.communityService.shareCommunityToUsers(communityID, pubKeys, inviteMessage)
 
 proc leaveCommunity*(self: Controller, communityID: string) =
   self.communityService.leaveCommunity(communityID)

--- a/src/app/modules/main/profile_section/communities/io_interface.nim
+++ b/src/app/modules/main/profile_section/communities/io_interface.nim
@@ -22,7 +22,7 @@ method getModuleAsVariant*(self: AccessInterface): QVariant {.base.} =
 method viewDidLoad*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method inviteUsersToCommunity*(self: AccessInterface, communityID: string, pubKeysJSON: string, inviteMessage: string): string {.base.} =
+method shareCommunityToUsers*(self: AccessInterface, communityID: string, pubKeysJSON: string, inviteMessage: string): string {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method leaveCommunity*(self: AccessInterface, communityID: string) {.base.} =

--- a/src/app/modules/main/profile_section/communities/module.nim
+++ b/src/app/modules/main/profile_section/communities/module.nim
@@ -42,8 +42,8 @@ method viewDidLoad*(self: Module) =
 method getModuleAsVariant*(self: Module): QVariant =
   return self.viewVariant
 
-method inviteUsersToCommunity*(self: Module, communityID: string, pubKeysJSON: string, inviteMessage: string): string =
-  result = self.controller.inviteUsersToCommunity(communityID, pubKeysJSON, inviteMessage)
+method shareCommunityToUsers*(self: Module, communityID: string, pubKeysJSON: string, inviteMessage: string): string =
+  result = self.controller.shareCommunityToUsers(communityID, pubKeysJSON, inviteMessage)
 
 method leaveCommunity*(self: Module, communityID: string) =
   self.controller.leaveCommunity(communityID)

--- a/src/app/modules/main/profile_section/communities/view.nim
+++ b/src/app/modules/main/profile_section/communities/view.nim
@@ -19,8 +19,8 @@ QtObject:
   proc load*(self: View) =
     self.delegate.viewDidLoad()
 
-  method inviteUsersToCommunity*(self: View, communityID: string, pubKeysJSON: string, inviteMessage: string): string {.slot.} =
-    result = self.delegate.inviteUsersToCommunity(communityID, pubKeysJSON, inviteMessage)
+  method shareCommunityToUsers*(self: View, communityID: string, pubKeysJSON: string, inviteMessage: string): string {.slot.} =
+    result = self.delegate.shareCommunityToUsers(communityID, pubKeysJSON, inviteMessage)
 
   method leaveCommunity*(self: View, communityID: string) {.slot.} =
     self.delegate.leaveCommunity(communityID)

--- a/src/app_service/service/community/service.nim
+++ b/src/app_service/service/community/service.nim
@@ -257,7 +257,7 @@ QtObject:
       self.events.emit(SIGNAL_COMMUNITY_DATA_IMPORTED, CommunityArgs(community: receivedData.community))
 
       if self.communities.contains(receivedData.community.id) and
-          self.communities[receivedData.community.id].listedInDirectory and not 
+          self.communities[receivedData.community.id].listedInDirectory and not
           self.communities[receivedData.community.id].isAvailable:
         self.events.emit(SIGNAL_CURATED_COMMUNITY_FOUND, CommunityArgs(community: self.communities[receivedData.community.id]))
 
@@ -292,7 +292,7 @@ QtObject:
               community.pendingRequestsToJoin.delete(indexPending)
               self.communities[membershipRequest.communityId] = community
               self.events.emit(SIGNAL_COMMUNITY_EDITED, CommunityArgs(community: community))
-          
+
           of RequestToJoinType.Declined:
             break
           of RequestToJoinType.Accepted:
@@ -436,7 +436,7 @@ QtObject:
         self.events.emit(SIGNAL_COMMUNITY_CATEGORY_NAME_EDITED,
           CommunityCategoryArgs(communityId: community.id, category: category))
 
-    
+
   proc handleCommunityUpdates(self: Service, communities: seq[CommunityDto], updatedChats: seq[ChatDto], removedChats: seq[string]) =
     try:
       var community = communities[0]
@@ -552,7 +552,7 @@ QtObject:
 
       # members list was changed
       if (community.isMember or community.tokenPermissions.len == 0) and community.members != prev_community.members:
-        self.events.emit(SIGNAL_COMMUNITY_MEMBERS_CHANGED, 
+        self.events.emit(SIGNAL_COMMUNITY_MEMBERS_CHANGED,
         CommunityMembersArgs(communityId: community.id, members: community.members))
 
       # token metadata was added
@@ -608,7 +608,7 @@ QtObject:
 
           if permissionUpdated:
             self.communities[community.id].tokenPermissions[id] = tokenPermission
-            self.events.emit(SIGNAL_COMMUNITY_TOKEN_PERMISSION_UPDATED, 
+            self.events.emit(SIGNAL_COMMUNITY_TOKEN_PERMISSION_UPDATED,
               CommunityTokenPermissionArgs(communityId: community.id, tokenPermission: tokenPermission))
 
       let wasJoined = self.communities[community.id].joined
@@ -622,7 +622,7 @@ QtObject:
       self.events.emit(SIGNAL_COMMUNITIES_UPDATE, CommunitiesArgs(communities: @[community]))
       if wasJoined and not community.joined and not community.isMember:
         self.events.emit(SIGNAL_COMMUNITY_KICKED, CommunityArgs(community: community))
-    
+
     except Exception as e:
       error "Error handling community updates", msg = e.msg
 
@@ -735,7 +735,7 @@ QtObject:
     else:
       return 0
 
-  proc getCategoryById*(self: Service, communityId: string, categoryId: string): Category = 
+  proc getCategoryById*(self: Service, communityId: string, categoryId: string): Category =
     if(not self.communities.contains(communityId)):
       error "trying to get community categories for an unexisting community id"
       return
@@ -1018,7 +1018,7 @@ QtObject:
         self.communities[community.id] = community
         # add new community channel group and chats to chat service
         self.chatService.updateOrAddChannelGroup(community.toChannelGroupDto())
-        for chat in community.chats: 
+        for chat in community.chats:
           self.chatService.updateOrAddChat(chat)
 
         self.events.emit(SIGNAL_COMMUNITY_CREATED, CommunityArgs(community: community))
@@ -1201,7 +1201,7 @@ QtObject:
         chatDetails.updateMissingFields(self.communities[communityId].chats[prev_chat_idx])
         self.chatService.updateOrAddChat(chatDetails) # we have to update chats stored in the chat service.
         updatedChats.add(chat)
-    
+
       self.events.emit(SIGNAL_COMMUNITY_CHANNELS_REORDERED,
         CommunityChatsOrderArgs(communityId: updatedCommunity.id, chats: updatedChats))
 
@@ -1374,7 +1374,7 @@ QtObject:
       community.id = requestedCommunityId
       self.events.emit(SIGNAL_COMMUNITY_LOAD_DATA_FAILED, CommunityArgs(community: community, error: "Couldn't find community info"))
       return
-    
+
     self.communities[community.id] = community
 
     if rpcResponseObj{"importing"}.getBool():
@@ -1421,8 +1421,8 @@ QtObject:
       )
       self.threadpool.start(arg)
     except Exception as e:
-      error "Error request to join community", msg = e.msg 
-    
+      error "Error request to join community", msg = e.msg
+
   proc onAsyncRequestToJoinCommunityDone*(self: Service, communityIdAndRpcResponse: string) {.slot.} =
     let rpcResponseObj = communityIdAndRpcResponse.parseJson
     try:
@@ -1431,7 +1431,7 @@ QtObject:
 
       let rpcResponse = Json.decode($rpcResponseObj["response"], RpcResponse[JsonNode])
       self.activityCenterService.parseActivityCenterResponse(rpcResponse)
-      
+
       if not self.processRequestsToJoinCommunity(rpcResponse.result):
         raise newException(CatchableError, "no 'requestsToJoinCommunity' key in response")
 
@@ -1454,7 +1454,7 @@ QtObject:
       airdropAddress: airdropAddress,
     )
     self.threadpool.start(arg)
-    
+
   proc onAsyncEditSharedAddressesDone*(self: Service, communityIdAndRpcResponse: string) {.slot.} =
     let rpcResponseObj = communityIdAndRpcResponse.parseJson
     try:
@@ -1485,7 +1485,7 @@ QtObject:
       )
       self.threadpool.start(arg)
     except Exception as e:
-      error "Error accepting request to join community", msg = e.msg 
+      error "Error accepting request to join community", msg = e.msg
 
   proc onAsyncAcceptRequestToJoinCommunityDone*(self: Service, response: string) {.slot.} =
     var communityId: string
@@ -1504,7 +1504,7 @@ QtObject:
         else:
           self.events.emit(SIGNAL_ACCEPT_REQUEST_TO_JOIN_FAILED, CommunityMemberArgs(communityId: communityId, pubKey: userKey, requestId: requestId))
         return
-    
+
       discard self.removeMembershipRequestFromCommunityAndGetMemberPubkey(communityId, requestId,
         rpcResponseObj["response"]["result"]["communities"][0].toCommunityDto)
 
@@ -1533,7 +1533,7 @@ QtObject:
       )
       self.threadpool.start(arg)
     except Exception as e:
-      error "Error loading curated communities", msg = e.msg 
+      error "Error loading curated communities", msg = e.msg
 
   proc onAsyncLoadCuratedCommunitiesDone*(self: Service, response: string) {.slot.} =
     try:
@@ -1730,7 +1730,7 @@ QtObject:
           return
 
         i.inc()
-      
+
     except Exception as e:
       error "Error canceled request to join community", msg = e.msg
 
@@ -1745,7 +1745,7 @@ QtObject:
     except Exception as e:
       error "Error declining request to join community", msg = e.msg
 
-  proc inviteUsersToCommunityById*(self: Service, communityId: string, pubKeysJson: string, inviteMessage: string): string =
+  proc shareCommunityToUsers*(self: Service, communityId: string, pubKeysJson: string, inviteMessage: string): string =
     try:
       let pubKeysParsed = pubKeysJson.parseJson
       var pubKeys: seq[string] = @[]
@@ -1812,7 +1812,7 @@ QtObject:
       if not response.error.isNil:
         error "error muting the community", msg = response.error.message
         return
-      
+
       let muted = if (MutedType(mutedType) == MutedType.Unmuted): false else: true
       self.events.emit(SIGNAL_COMMUNITY_MUTED,
         CommunityMutedArgs(communityId: communityId, muted: muted))

--- a/src/backend/communities.nim
+++ b/src/backend/communities.nim
@@ -401,12 +401,6 @@ proc setCommunityMuted*(communityId: string, mutedType: int): RpcResponse[JsonNo
     "mutedType": mutedType 
   }])
 
-proc inviteUsersToCommunity*(communityId: string, pubKeys: seq[string]): RpcResponse[JsonNode] {.raises: [Exception].} =
-  return callPrivateRPC("inviteUsersToCommunity".prefix, %*[{
-    "communityId": communityId,
-    "users": pubKeys
-  }])
-
 proc shareCommunityToUsers*(communityId: string, pubKeys: seq[string], inviteMessage: string): RpcResponse[JsonNode] {.raises: [Exception].} =
   return callPrivateRPC("shareCommunity".prefix, %*[{
     "communityId": communityId,

--- a/storybook/pages/InviteFriendsToCommunityPopupPage.qml
+++ b/storybook/pages/InviteFriendsToCommunityPopupPage.qml
@@ -94,8 +94,8 @@ SplitView {
                 }
 
                 communitySectionModule: QtObject {
-                    function inviteUsersToCommunity(keys, message) {
-                        logs.logEvent("communitySectionModule::inviteUsersToCommunity",
+                    function shareCommunityToUsers(keys, message) {
+                        logs.logEvent("communitySectionModule::shareCommunityToUsers",
                                       ["keys", "message"], arguments)
                     }
                 }

--- a/ui/app/AppLayouts/Communities/popups/InviteFriendsToCommunityPopup.qml
+++ b/ui/app/AppLayouts/Communities/popups/InviteFriendsToCommunityPopup.qml
@@ -30,8 +30,8 @@ StatusStackModal {
         readonly property int footerButtonsHeight: 44
         readonly property int popupContentHeight: 551
 
-        function sendInvites(pubKeys, inviteMessage) {
-            const error = root.communitySectionModule.inviteUsersToCommunity(JSON.stringify(pubKeys), inviteMessage);
+        function shareCommunity(pubKeys, inviteMessage) {
+            const error = root.communitySectionModule.shareCommunityToUsers(JSON.stringify(pubKeys), inviteMessage);
             d.processInviteResult(error);
         }
 
@@ -75,7 +75,7 @@ StatusStackModal {
         enabled: root.pubKeys.length > 0
         text: qsTr("Send %n invite(s)", "", root.pubKeys.length)
         onClicked: {
-            d.sendInvites(root.pubKeys, root.inviteMessage);
+            d.shareCommunity(root.pubKeys, root.inviteMessage);
             root.close();
         }
     }


### PR DESCRIPTION
This change corrects legacy naming that was causing confusion.

Community invites are no longer sent to users. Instead, the community is just shared. If a user is interested in joining this shared commmunity, they must submit a request to join.

