### PR TITLE
fix(@desktop/wallet): Update transaction status UI

### DIFF
--- a/src/app/modules/main/wallet_section/accounts/model.nim
+++ b/src/app/modules/main/wallet_section/accounts/model.nim
@@ -139,3 +139,9 @@ QtObject:
       if(cmpIgnoreCase(item.address(), address) == 0):
         return item.colorId()
     return ""
+
+  proc isOwnedAccount*(self: Model, address: string): bool =
+    for item in self.items:
+      if cmpIgnoreCase(item.address(), address) == 0 and item.walletType != "watch":
+        return true
+    return false

--- a/src/app/modules/main/wallet_section/accounts/view.nim
+++ b/src/app/modules/main/wallet_section/accounts/view.nim
@@ -55,9 +55,11 @@ QtObject:
   proc getColorByAddress(self: View, address: string): string {.slot.}=
     return self.accounts.getColorByAddress(address)
 
+  proc isOwnedAccount(self: View, address: string): bool {.slot.} =
+    return self.accounts.isOwnedAccount(address)
+
   proc updateWalletAccountProdPreferredChains*(self: View, address: string, preferredChainIds: string) {.slot.} =
     self.delegate.updateWalletAccountProdPreferredChains(address, preferredChainIds)
 
   proc updateWalletAccountTestPreferredChains*(self: View, address: string, preferredChainIds: string) {.slot.} =
     self.delegate.updateWalletAccountTestPreferredChains(address, preferredChainIds)
-

--- a/src/app/modules/main/wallet_section/view.nim
+++ b/src/app/modules/main/wallet_section/view.nim
@@ -150,7 +150,7 @@ QtObject:
   proc getLatestBlockNumber*(self: View, chainId: int): string {.slot.} =
     return self.delegate.getLatestBlockNumber(chainId)
 
-  proc fetchDecodedTxData*(self: View, txHash: string, data: string)   =
+  proc fetchDecodedTxData*(self: View, txHash: string, data: string) {.slot.}   =
     self.delegate.fetchDecodedTxData(txHash, data)
 
   proc getIsNonArchivalNode(self: View): bool {.slot.} =

--- a/src/backend/activity.nim
+++ b/src/backend/activity.nim
@@ -89,6 +89,19 @@ proc fromJson*(jn: JsonNode, T: typedesc[ActivityStatus]): ActivityStatus {.inli
 proc `%`*(tt: TokenType): JsonNode {.inline.} =
   return newJInt(ord(tt))
 
+proc `$`*(tt: TokenType): string {.inline.} =
+  case tt:
+    of Native:
+      return "ETH"
+    of Erc20:
+      return "ERC-20"
+    of Erc721:
+      return "ERC-721"
+    of Erc1155:
+      return "ERC-1155"
+    else:
+      return ""
+
 proc fromJson*(jn: JsonNode, T: typedesc[TokenType]): TokenType {.inline.} =
   return cast[TokenType](jn.getInt())
 

--- a/ui/app/AppLayouts/Wallet/controls/StatusTxProgressBar.qml
+++ b/ui/app/AppLayouts/Wallet/controls/StatusTxProgressBar.qml
@@ -10,6 +10,7 @@ ColumnLayout {
 
     property bool isLayer1: true
     property bool error: false
+    property bool pending: false
     property int steps: isLayer1 ? 64 : 1
     property int confirmations: 0
     property int confirmationBlocks: isLayer1 ? 4 : 1
@@ -43,14 +44,18 @@ ColumnLayout {
         color: Theme.palette.directColor1
         lineHeight: 22
         lineHeightMode: Text.FixedHeight
-        text: error ? qsTr("Failed on %1").arg(root.chainName) :
-                      d.finalized ?
-                          qsTr("Finalised on %1").arg(root.chainName) :
-                          d.confirmed ?
-                              qsTr("Confirmed on %1, finalisation in progress...").arg(root.chainName):
-                              confirmations > 0 ?
-                                  qsTr("Confirmation in progress on %1...").arg(root.chainName) :
-                                  qsTr("Pending on %1...").arg(root.chainName)
+        text: {
+            if (error) {
+                return qsTr("Failed on %1").arg(root.chainName)
+            } else if (pending) {
+                return qsTr("Confirmation in progress on %1...").arg(root.chainName)
+            } else if (d.finalized) {
+                return qsTr("Finalised on %1").arg(root.chainName)
+            } else if (d.confirmed) {
+                return qsTr("Confirmed on %1, finalisation in progress...").arg(root.chainName)
+            }
+            return qsTr("Pending on %1...").arg(root.chainName)
+        }
     }
 
     RowLayout {
@@ -99,8 +104,13 @@ ColumnLayout {
         color: Theme.palette.baseColor1
         lineHeight: 18
         lineHeightMode: Text.FixedHeight
-        text: d.finalized && !root.error ? qsTr("In epoch %1").arg(root.confirmations) : d.confirmed && !root.isLayer1 ?
-                                               qsTr("%n day(s) until finality", "", Math.ceil((root.duration - root.progress)/d.hoursInADay)):
-                                               qsTr("%1 / %2 confirmations").arg(root.confirmations).arg(root.steps)
+        text: {
+            if (d.finalized && !root.error) {
+                return qsTr("In epoch %1").arg(root.confirmations)
+            } else if (d.confirmed && !root.isLayer1) {
+                return qsTr("%n day(s) until finality", "", Math.ceil((root.duration - root.progress)/d.hoursInADay))
+            }
+            return qsTr("%1 / %2 confirmations").arg(root.confirmations).arg(root.steps)
+        }
     }
 }

--- a/ui/app/AppLayouts/Wallet/panels/WalletTxProgressBlock.qml
+++ b/ui/app/AppLayouts/Wallet/panels/WalletTxProgressBlock.qml
@@ -15,6 +15,7 @@ ColumnLayout {
     // To-do adapt this for multi-tx, not sure how the data will look for that yet
     property bool isLayer1: true
     property bool error: false
+    property bool pending: false
     property int confirmations: 0
     property string chainName
     property double timeStamp
@@ -23,8 +24,8 @@ ColumnLayout {
 
     QtObject {
         id: d
-        readonly property bool finalized: (isLayer1 ? confirmations >= progressBar.steps : progress >= duration) && !error
-        readonly property bool confirmed: confirmations >= progressBar.confirmationBlocks && !error
+        readonly property bool finalized: (isLayer1 ? confirmations >= progressBar.steps : progress >= duration) && !error && !pending
+        readonly property bool confirmed: confirmations >= progressBar.confirmationBlocks && !error && !pending
         readonly property double confirmationTimeStamp: {
             if (root.isLayer1) {
                 return root.timeStamp + 12 * 4 // A block on layer1 is every 12s
@@ -42,7 +43,7 @@ ColumnLayout {
         }
 
         readonly property int duration: 168 // 7 days in hours
-        readonly property int progress: (Math.floor(Date.now() / 1000) - root.timeStamp) / 3600
+        readonly property int progress: pending || error ? 0 : (Math.floor(Date.now() / 1000) - root.timeStamp) / 3600
     }
 
     StatusTxProgressBar {

--- a/ui/app/AppLayouts/Wallet/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Wallet/stores/RootStore.qml
@@ -190,6 +190,10 @@ QtObject {
         return name
     }
 
+    function isOwnedAccount(address) {
+        return walletSectionAccounts.isOwnedAccount(address)
+    }
+
     function getEmojiForWalletAddress(address) {
         return walletSectionAccounts.getEmojiByAddress(address)
     }

--- a/ui/imports/shared/stores/RootStore.qml
+++ b/ui/imports/shared/stores/RootStore.qml
@@ -239,6 +239,10 @@ QtObject {
             walletSectionAllTokens.getHistoricalDataForToken(symbol,currency)
     }
 
+    function fetchDecodedTxData(txHash, input) {
+        walletSectionInst.fetchDecodedTxData(txHash, input)
+    }
+
     property bool marketHistoryIsLoading: Global.appIsReady? walletSectionAllTokens.marketHistoryIsLoading : false
 
     function fetchHistoricalBalanceForTokenAsJson(address, tokenSymbol, currencySymbol, timeIntervalEnum) {


### PR DESCRIPTION
fixes #11534

### What does the PR do

* hide network field if network was not provided
* show second token icon in details for Swap when it's value is 0
* use token address instead of contract for unkown token
* Using hash from transaction identity instead of transaction item
* failed and pending transactions now shows 0 / N confirmations below progress bar in details view
* show retry button for failed transaction only on non watch-only accounts in details view

### Affected areas

Wallet activity details 

### Screenshot of functionality (including design for comparison)

<img width="853" alt="image" src="https://github.com/status-im/status-desktop/assets/11396062/1e8160c8-8ddb-4136-b02f-27accb522a03">


<img width="622" alt="image" src="https://github.com/status-im/status-desktop/assets/11396062/83da3a77-c4c7-4eb3-a9cf-09082f72f1be">


<img width="852" alt="image" src="https://github.com/status-im/status-desktop/assets/11396062/b5c75d8c-a1ad-490e-b588-6df9071a020a">
