### PR TITLE
fix: Add camera entitlement on MacOS

### DIFF
--- a/Entitlements.plist
+++ b/Entitlements.plist
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>com.apple.security.cs.disable-executable-page-protection</key>
-	<true/>
 	<key>com.apple.security.device.camera</key>
 	<true/>
 </dict>

--- a/Entitlements.plist
+++ b/Entitlements.plist
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-    <dict>
-        <key>com.apple.security.cs.disable-executable-page-protection</key>
-        <true/>
-    </dict>
+<dict>
+    <key>com.apple.security.cs.disable-executable-page-protection</key>
+    <true/>
+	<key>com.apple.security.device.camera</key>
+	<true/>
+</dict>
 </plist>

--- a/Entitlements.plist
+++ b/Entitlements.plist
@@ -2,8 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>com.apple.security.cs.disable-executable-page-protection</key>
-    <true/>
+	<key>com.apple.security.cs.disable-executable-page-protection</key>
+	<true/>
 	<key>com.apple.security.device.camera</key>
 	<true/>
 </dict>

--- a/Info.plist
+++ b/Info.plist
@@ -38,6 +38,6 @@
         <key>NSHighResolutionCapable</key>
         <string>True</string>
         <key>NSCameraUsageDescription</key>
-        <string>Scan QR codes</string>
+        <string>Status uses camera to scan QR codes</string>
     </dict>
 </plist>

--- a/Makefile
+++ b/Makefile
@@ -623,9 +623,7 @@ $(STATUS_CLIENT_DMG): nim_status_client $(DMG_TOOL)
 	# if MACOS_CODESIGN_IDENT is not set then the outer and inner .app
 	# bundles are not signed
 ifdef MACOS_CODESIGN_IDENT
-	scripts/sign-macos-pkg.sh $(MACOS_OUTER_BUNDLE) $(MACOS_CODESIGN_IDENT)
-	scripts/sign-macos-pkg.sh $(MACOS_INNER_BUNDLE) $(MACOS_CODESIGN_IDENT) \
-		--entitlements Entitlements.plist
+	scripts/sign-macos-pkg.sh $(MACOS_OUTER_BUNDLE) $(MACOS_CODESIGN_IDENT) --entitlements Entitlements.plist
 endif
 	echo -e $(BUILD_MSG) "dmg"
 	mkdir -p pkg

--- a/Makefile
+++ b/Makefile
@@ -625,7 +625,7 @@ $(STATUS_CLIENT_DMG): nim_status_client $(DMG_TOOL)
 ifdef MACOS_CODESIGN_IDENT
 	scripts/sign-macos-pkg.sh $(MACOS_OUTER_BUNDLE) $(MACOS_CODESIGN_IDENT)
 	scripts/sign-macos-pkg.sh $(MACOS_INNER_BUNDLE) $(MACOS_CODESIGN_IDENT) \
-		--entitlements QtWebEngineProcess.plist
+		--entitlements Entitlements.plist
 endif
 	echo -e $(BUILD_MSG) "dmg"
 	mkdir -p pkg


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/11643

## What does the PR do

- Added [Camera Entitlement](https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_security_device_camera?language=objc)
- Fixed codesign calling to include entitlements
- Updated camera access message

### ⚠️ I removed [disable-executable-page-protection](https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_security_cs_disable-executable-page-protection?language=objc) entitlement. 

- It seems that earlier it wasn't possible to sign anything with `QtWebEngine` without such entitlement, but now it seems fine.
Here's a thread about this: [QtWebEngine signing issues](https://forum.qt.io/topic/102212/qtwebengine-signing-issues/12)
- It was initially added here: https://github.com/status-im/status-desktop/pull/375.
- Apple docs says that it is "an extreme entitlement that removes a fundamental security protection from your app".
- It seems to be not included in our app for awhile already (because of a bug in Makefile. Though I'm not sure, maybe it was intended to double-codesign it right there.)
- The browser seems to be working fine.

Signed AppBundle can be downloaded [here](https://ci.infra.status.im/job/status-desktop/job/systems/job/macos/job/x86_64/job/package/695/).

## Screenshot of functionality (including design for comparison)

https://github.com/status-im/status-desktop/assets/25482501/7e7b3d0f-6eba-4777-a113-73bf93cc468d

