### PR TITLE
test(@tst_wallet_settingsManagement): add test to add new account from settings

### DIFF
--- a/test/ui-test/src/screens/SettingsScreen.py
+++ b/test/ui-test/src/screens/SettingsScreen.py
@@ -21,6 +21,7 @@ from .StatusMainScreen import MainScreenComponents
 from .StatusMainScreen import authenticate_popup_enter_password
 from .components.change_password_popup import ChangePasswordPopup
 from .components.social_links_popup import SocialLinksPopup
+from .components.wallet_account_popups import AccountPopup
 
 
 class SignOutPopup(BaseElement):
@@ -38,18 +39,17 @@ class MenuPanel(BaseElement):
     def __init__(self):
         super(MenuPanel, self).__init__('mainWindow_LeftTabView')
         self._scroll = Scroll('LeftTabView_ScrollView')
-        self._back_up_seed_phrase_item = Button('sign_out_Quit_StatusNavigationListItem')
+        self._sign_out_and_quit_item = Button('sign_out_Quit_StatusNavigationListItem')
 
     def sign_out_and_quit(self):
-        self._scroll.vertical_scroll_to(self._back_up_seed_phrase_item)
-        self._back_up_seed_phrase_item.click()
+        self._scroll.vertical_scroll_to(self._sign_out_and_quit_item)
+        self._sign_out_and_quit_item.click()
         SignOutPopup().wait_until_appears().sign_out_and_quit()
 
 
 class SidebarComponents(Enum):
     ADVANCED_OPTION: str = "advanced_StatusNavigationListItem"
     KEYCARD_OPTION: str = "keycard_StatusNavigationListItem"
-    WALLET_OPTION: str = "wallet_StatusNavigationListItem"
     LANGUAGE_CURRENCY_OPTION: str = "language_StatusNavigationListItem"
     SIGN_OUT_AND_QUIT_OPTION: str = "sign_out_Quit_StatusNavigationListItem"
     COMMUNITIES_OPTION: str = "communities_StatusNavigationListItem"
@@ -142,6 +142,8 @@ class SettingsScreen:
         self.menu = MenuPanel()
         self._profile_view = ProfileSettingsView()
         self._profile_button = Button('profile_StatusNavigationListItem')
+        self._wallet_settings_button = Button('wallet_StatusNavigationListItem')
+        self._add_new_account_button = Button('settings_Wallet_MainView_AddNewAccountButton')
 
     @property
     def profile_settings(self) -> 'ProfileSettingsView':
@@ -154,10 +156,20 @@ class SettingsScreen:
         click_obj_by_name(SidebarComponents.ADVANCED_OPTION.value)
 
     def open_wallet_settings(self):
-        click_obj_by_name(SidebarComponents.WALLET_OPTION.value)
+        self._wallet_settings_button.click()
 
     def open_wallet_section(self):
-        click_obj_by_name(MainScreenComponents.WALLET_BUTTON.value)
+        click_obj_by_name(MainScreenComponents.WALLET_BUTTON.value)   
+
+    def open_add_new_account_popup(self, attempt=2):
+        self._add_new_account_button.click()
+        try:
+            return AccountPopup().wait_until_appears()
+        except AssertionError as err:
+            if attempt:
+                return self.open_add_new_account_popup(attempt - 1)
+            else:
+                raise err
 
     def delete_account(self, account_name: str, password: str):
         self.open_wallet_settings()
@@ -255,7 +267,7 @@ class SettingsScreen:
     def select_default_account(self):
         accounts = get_obj(WalletSettingsScreen.GENERATED_ACCOUNTS.value)
         click_obj(accounts.itemAt(0))
-        click_obj_by_name(WalletSettingsScreen.EDIT_ACCOUNT_BUTTON.value)
+        click_obj_by_name(WalletSettingsScreen.EDIT_ACCOUNT_BUTTON.value)    
 
     def edit_account(self, account_name: str, account_color: str):
         type_text(WalletSettingsScreen.EDIT_ACCOUNT_NAME_INPUT.value, account_name)

--- a/test/ui-test/testSuites/global_shared/scripts/settings_names.py
+++ b/test/ui-test/testSuites/global_shared/scripts/settings_names.py
@@ -104,6 +104,7 @@ settings_Wallet_AccountView_EditAccountColorRepeater = {"container": statusDeskt
 settings_Wallet_AccountView_AccountName = {"container": statusDesktop_mainWindow, "type": "StatusBaseText", "objectName": "walletAccountViewAccountName"}
 settings_Wallet_AccountView_IconSettings = {"container": statusDesktop_mainWindow, "type": "StatusEmoji", "objectName": "walletAccountViewAccountImage" , "visible": True}
 settings_Wallet_MainView_BackupSeedPhrase = {"container": mainWindow_ScrollView, "objectName": SettingsSubsection.BACKUP_SEED.value, "type": "StatusNavigationListItem", "visible": True}
+settings_Wallet_MainView_AddNewAccountButton = {"container": statusDesktop_mainWindow, "objectName": "settings_Wallet_MainView_AddNewAccountButton", "type": "StatusButton", "visible": True}
 
 generatedAccounts_ListView = {"container": statusDesktop_mainWindow, "objectName": "generatedAccounts", "type": "ListView"}
 

--- a/test/ui-test/testSuites/global_shared/steps/settingsSteps.py
+++ b/test/ui-test/testSuites/global_shared/steps/settingsSteps.py
@@ -99,6 +99,18 @@ def step(context: any):
 def step(context: any):
     the_user_opens_the_wallet_settings()
 
+@When("the user adds a generated account with \"|any|\" color \"|any|\" and emoji \"|any|\" in Settings")
+def step(context, name, color, emoji):
+    account_popup = _settingsScreen.open_add_new_account_popup()
+    account_popup.set_name(name).set_emoji(emoji).set_color(color).save()
+    AuthenticatePopup().wait_until_appears().authenticate()
+    account_popup.wait_until_hidden()
+    
+@Then("the account is present with \"|any|\" and \"|any|\" and emoji unicode \"|any|\" in the accounts list in Settings")
+def step(context: any, account_name, color, emoji):
+    _settingsScreen._find_account_index(account_name)
+
+
 @When("the user deletes the account \"|any|\" with password \"|any|\"")
 def step(context: any, account_name: str, password: str):
     _statusMain.open_settings()

--- a/test/ui-test/testSuites/suite_wallet/tst_wallet_settingsManagement/test.feature
+++ b/test/ui-test/testSuites/suite_wallet/tst_wallet_settingsManagement/test.feature
@@ -1,16 +1,26 @@
 Feature: Settings -> Wallet
 
 
-Background:
-    Given A first time user lands on the status desktop and generates new key
-	And the user signs up with username "tester123" and password "TesTEr16843/!@00"
-	And the user lands on the signed in app
-    And the user opens the wallet section
-    And the user accepts the signing phrase
+    Background:
+        Given A first time user lands on the status desktop and generates new key
+        And the user signs up with username "tester123" and password "TesTEr16843/!@00"
+        And the user lands on the signed in app
+        And the user opens the wallet section
+        And the user accepts the signing phrase
 
-    Scenario: The user edits the default account
+    Scenario: The user can edit the default Status account from Settings
         Given the user opens app settings screen
         And the user opens the wallet settings
         When the user selects the default Status account
         And the user edits default Status account to "Default" name and "#f6af3c" color
         Then the default account is updated to be named "DefaultStatus account" with color "#f6af3c"
+
+    Scenario Outline: The user can generate new account from Settings for default Status account keypair
+        Given the user opens app settings screen
+        And the user opens the wallet settings
+        When the user adds a generated account with "<name>" color "#<color>" and emoji "<emoji>" in Settings
+        Then the account is present with "<name>" and "#<color>" and emoji unicode "<emoji_unicode>" in the accounts list in Settings
+
+        Examples:
+            | name    | color  | emoji      | emoji_unicode |
+            | GenAcc1 | 2a4af5 | sunglasses | 1f60e |

--- a/ui/app/AppLayouts/Profile/views/WalletView.qml
+++ b/ui/app/AppLayouts/Profile/views/WalletView.qml
@@ -165,6 +165,7 @@ SettingsContentBase {
         Component {
             id: addNewAccountButtonComponent
             StatusButton {
+                objectName: "settings_Wallet_MainView_AddNewAccountButton"
                 text: qsTr("Add new account")
                 onClicked: root.walletStore.runAddAccountPopup()
             }


### PR DESCRIPTION
### What does the PR do

Fixes https://github.com/status-im/desktop-qa-automation/issues/84

Add interaction with Add new account button in wallet settings

<img width="705" alt="Screenshot 2023-07-26 at 12 56 59" src="https://github.com/status-im/status-desktop/assets/82375995/9182f8a1-64a0-4e38-8888-3cf82da8c4fe">

### Affected areas

wallet tests