### PR TITLE
[Control Node] Add toast messages when the control node is removed/added

### DIFF
--- a/src/app/modules/main/communities/module.nim
+++ b/src/app/modules/main/communities/module.nim
@@ -330,7 +330,7 @@ method isCommunityRequestPending*(self: Module, communityId: string): bool =
   self.controller.isCommunityRequestPending(communityId)
 
 method communityImported*(self: Module, community: CommunityDto) =
-  self.view.addItem(self.getCommunityItem(community))
+  self.view.addOrUpdateItem(self.getCommunityItem(community))
   self.view.emitImportingCommunityStateChangedSignal(community.id, ImportCommunityState.Imported.int, errorMsg = "")
 
 method communityDataImported*(self: Module, community: CommunityDto) = 

--- a/src/app/modules/main/communities/view.nim
+++ b/src/app/modules/main/communities/view.nim
@@ -274,7 +274,17 @@ QtObject:
   proc addItem*(self: View, item: SectionItem) =
     self.model.addItem(item)
     self.communityAdded(item.id)
+  
+  proc updateItem(self: View, item: SectionItem) =
+    self.model.editItem(item)
+    self.communityChanged(item.id)
 
+  proc addOrUpdateItem*(self: View, item: SectionItem) =
+    if self.model.itemExists(item.id):
+      self.updateItem(item)
+    else:
+      self.addItem(item)
+  
   proc model*(self: View): SectionModel =
     result = self.model
 
@@ -484,6 +494,7 @@ QtObject:
       "name": communityItem.name,
       "image": communityItem.image,
       "color": communityItem.color,
+      "isControlNode": communityItem.isControlNode,
     }
     return $jsonObj
 

--- a/src/app/modules/shared_models/section_model.nim
+++ b/src/app/modules/shared_models/section_model.nim
@@ -204,7 +204,7 @@ QtObject:
     of ModelRole.AmIBanned:
       result = newQVariant(item.amIBanned)
 
-  proc isItemExist(self: SectionModel, id: string): bool =
+  proc itemExists*(self: SectionModel, id: string): bool =
     for it in self.items:
       if(it.id == id):
         return true
@@ -215,7 +215,7 @@ QtObject:
     let parentModelIndex = newQModelIndex()
     defer: parentModelIndex.delete
 
-    if not self.isItemExist(item.id):
+    if not self.itemExists(item.id):
       self.beginInsertRows(parentModelIndex, self.items.len, self.items.len)
       self.items.add(item)
       self.endInsertRows()
@@ -226,7 +226,7 @@ QtObject:
     let parentModelIndex = newQModelIndex()
     defer: parentModelIndex.delete
 
-    if not self.isItemExist(item.id):
+    if not self.itemExists(item.id):
       self.beginInsertRows(parentModelIndex, index, index)
       self.items.insert(item, index)
       self.endInsertRows()

--- a/ui/StatusQ/sandbox/pages/StatusToastMessagePage.qml
+++ b/ui/StatusQ/sandbox/pages/StatusToastMessagePage.qml
@@ -19,7 +19,8 @@ Item {
                 {"title":"Verification Request Sent", "subTitle":"", "icon":"checkmark-circle", "loading":false, "type":1,"url":"", "duration":4000},
                 {"title":"Collectible is being minted...", "subTitle":"View on Etherscan", "icon":"", "loading":true, "type":0,"url":"http://google.com", "duration":0},
                 {"title":"Contact request sent", "subTitle":"", "icon":"checkmark-circle", "loading":false, "type":1,"url":"", "duration":4000},
-                {"title":"Test User", "subTitle":"Hello message...", "icon":"", "loading":false, "type":0,"url":"", "duration":4000}
+                {"title":"Test User", "subTitle":"Hello message...", "icon":"", "loading":false, "type":0,"url":"", "duration":4000},
+                {"title":"This device is no longer the control node for the Socks Community", "subTitle":"", "icon":"info", "loading":false, "type":0,"url":"", "duration":0}
             ]
             delegate: StatusToastMessage {
                 primaryText: modelData.title

--- a/ui/StatusQ/src/StatusQ/Components/StatusToastMessage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusToastMessage.qml
@@ -38,7 +38,7 @@ import StatusQ.Core.Theme 0.1
 Control {
     id: root
     width: 343
-    height: !!secondaryText ? 68 : 48
+    height: !!secondaryText || title.lineCount > 1 ? 68 : 48
     anchors.right: parent.right
 
     /*!
@@ -261,26 +261,32 @@ Control {
                     }
                 }
             }
-            Column {
+            ColumnLayout {
                 Layout.fillWidth: true
-                Layout.alignment: Qt.AlignVCenter
+                Layout.fillHeight: true
                 StatusBaseText {
-                    width: parent.width
+                    id: title
+                    Layout.fillWidth: true
                     font.pixelSize: 13
                     color: Theme.palette.directColor1
                     elide: Text.ElideRight
+                    wrapMode: Text.Wrap
                     text: root.primaryText
+                    maximumLineCount: 2
                 }
                 StatusBaseText {
-                    width: parent.width
+                    Layout.fillWidth: true
                     visible: (!root.linkUrl && !!root.secondaryText)
                     height: visible ? contentHeight : 0
                     font.pixelSize: 13
                     color: Theme.palette.baseColor1
                     text: root.secondaryText
                     elide: Text.ElideRight
+                    wrapMode: Text.Wrap
+                    maximumLineCount: 2
                 }
                 StatusSelectableText {
+                    Layout.fillWidth: true
                     visible: (!!root.linkUrl)
                     height: visible ? implicitHeight : 0
                     font.pixelSize: 13

--- a/ui/app/AppLayouts/Chat/views/ContactsColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ContactsColumnView.qml
@@ -217,49 +217,4 @@ Item {
             }
         }
     }
-
-    Connections {
-        target: root.store
-
-        function onImportingCommunityStateChanged(communityId, state, errorMsg) {
-            const community = root.store.getCommunityDetailsAsJson(communityId)
-            let title = ""
-            let subTitle = ""
-            let loading = false
-
-            switch (state)
-            {
-            case Constants.communityImported:
-                title = qsTr("'%1' community imported").arg(community.name);
-                break
-            case Constants.communityImportingInProgress:
-                title = qsTr("Importing community is in progress")
-                loading = true
-                break
-            case Constants.communityImportingError:
-                title = qsTr("Failed to import community '%1'").arg(community.name)
-                subTitle = errorMsg
-                break
-            default:
-                console.error("unknown state while importing community: %1").arg(state)
-                return
-            }
-
-            Global.displayToastMessage(title,
-                                       subTitle,
-                                       "",
-                                       loading,
-                                       Constants.ephemeralNotificationType.normal,
-                                       "")
-        }
-
-        function onCommunityInfoAlreadyRequested() {
-            Global.displayToastMessage(qsTr("Community data not loaded yet."),
-                                       qsTr("Please wait for the unfurl to show"),
-                                       "",
-                                       true,
-                                       Constants.ephemeralNotificationType.normal,
-                                       "")
-        }
-    }
 }

--- a/ui/app/AppLayouts/Communities/stores/CommunitiesStore.qml
+++ b/ui/app/AppLayouts/Communities/stores/CommunitiesStore.qml
@@ -57,6 +57,10 @@ QtObject {
     property string communityTags: communitiesModuleInst.tags
 
     signal importingCommunityStateChanged(string communityId, int state, string errorMsg)
+    
+    signal communityPrivateKeyRemoved(string communityId)
+
+    signal communityInfoAlreadyRequested()
 
     function createCommunity(args = {
                                 name: "",
@@ -143,6 +147,17 @@ QtObject {
         root.communitiesModuleInst.resetDiscordImport(false)
     }
 
+    function getCommunityDetailsAsJson(id) {
+        const jsonObj = communitiesModuleInst.getCommunityDetails(id)
+        try {
+            return JSON.parse(jsonObj)
+        }
+        catch (e) {
+            console.warn("error parsing community by id: ", id, " error: ", e.message)
+            return {}
+        }
+    }
+
     function requestImportDiscordCommunity(args = {
                                 name: "",
                                 description: "",
@@ -175,6 +190,14 @@ QtObject {
         target: communitiesModuleInst
         function onImportingCommunityStateChanged(communityId, state, errorMsg) {
             root.importingCommunityStateChanged(communityId, state, errorMsg)
+        }
+
+        function onCommunityInfoAlreadyRequested() {
+          root.communityInfoAlreadyRequested()
+        }
+
+        function onCommunityPrivateKeyRemoved(communityId) {
+            root.communityPrivateKeyRemoved(communityId)
         }
     }
 }

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -228,6 +228,69 @@ Item {
     }
 
     Connections {
+        target: appMain.communitiesStore
+
+        function onImportingCommunityStateChanged(communityId, state, errorMsg) {
+            const community = appMain.communitiesStore.getCommunityDetailsAsJson(communityId)
+            let title = ""
+            let subTitle = ""
+            let loading = false
+            let notificationType = Constants.ephemeralNotificationType.normal
+            let icon = ""
+            
+            switch (state)
+            {
+            case Constants.communityImported:
+                if(community.isControlNode) {
+                    title = qsTr("This device is now the control node for the %1 Community").arg(community.name)
+                    notificationType = Constants.ephemeralNotificationType.success
+                    icon = "checkmark-circle"
+                } else {
+                    title = qsTr("'%1' community imported").arg(community.name)
+                }
+                break
+            case Constants.communityImportingInProgress:
+                title = qsTr("Importing community is in progress")
+                loading = true
+                break
+            case Constants.communityImportingError:
+                title = qsTr("Failed to import community '%1'").arg(community.name)
+                subTitle = errorMsg
+                break
+            default:
+                console.error("unknown state while importing community: %1").arg(state)
+                return
+            }
+
+            Global.displayToastMessage(title,
+                                       subTitle,
+                                       icon,
+                                       loading,
+                                       notificationType,
+                                       "")
+        }
+
+        function onCommunityInfoAlreadyRequested() {
+            Global.displayToastMessage(qsTr("Community data not loaded yet."),
+                                       qsTr("Please wait for the unfurl to show"),
+                                       "",
+                                       true,
+                                       Constants.ephemeralNotificationType.normal,
+                                       "")
+        }
+
+        function onCommunityPrivateKeyRemoved(communityId) {
+            const community = appMain.communitiesStore.getCommunityDetailsAsJson(communityId)
+            Global.displayToastMessage(qsTr("This device is no longer the control node for the %1 Community").arg(community.name),
+                                "",
+                                "info",
+                                false,
+                                Constants.ephemeralNotificationType.normal,
+                                "")
+        }
+    }
+
+    Connections {
         target: Global.applicationWindow
 
         function onActiveChanged() {


### PR DESCRIPTION
### What does the PR do

Closing #11652 

There are two commits:
eeb70d4e27ca2063e8911324ff331ef25b9736b7 - Display two lines of text in StatusToastMessage

4d10ea61dc4c21c861137bcf373db0dd2bb1886f - Adding the toast messages:
1. Fix an issue where importing a community using private key triggers the import finished event without updating the community data if the community is already imported with public key
2. Show toast messages on importCommunity and privateKeyRemoved events
3. Group community import toast messages handlers and move them from ContactsColumnView to AppMain. IMO these toast messages handlers should not be dependent on ContactsColumnView.
<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas

StatusQ
Import Community flow
ContactsColumnView
<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

### StatusToastMessage:

<img width="438" alt="Screenshot 2023-07-27 at 16 48 51" src="https://github.com/status-im/status-desktop/assets/47811206/a1691853-fe08-48ba-93f5-c47b0584cb91">

### Control node toast notifications:


https://github.com/status-im/status-desktop/assets/47811206/141b0099-1eab-41ab-ab8d-7eaf4a2119f8

### Design:
![Tost messages-2](https://github.com/status-im/status-desktop/assets/47811206/be229db1-dcff-4424-88bc-292b38291682)
![Tost messages](https://github.com/status-im/status-desktop/assets/47811206/cad7700f-60f6-4422-88bb-780b41a0c8e3)


<!-- screenshot (or gif/video) that demonstrates the functionality, specially important if it's a bug fix. -->

### Cool Spaceship Picture

<!-- optional but cool ->
