### PR TITLE
test(AUT) Skip closing AUT process at the end of the test

### DIFF
--- a/test/ui-test/src/drivers/aut.py
+++ b/test/ui-test/src/drivers/aut.py
@@ -54,7 +54,9 @@ class ExecutableAut(AbstractAut):
         return self
 
     def close(self):
-        local_system.kill_process(self.fp.name)
+        # https://github.com/status-im/desktop-qa-automation/issues/85
+        # local_system.kill_process(self.fp.name)
+        pass
 
 
 class StatusAut(ExecutableAut):


### PR DESCRIPTION
Fixes ([Skip closing AUT process at the end of the test](https://github.com/status-im/desktop-qa-automation/issues/85))

### Skip closing AUT process at the end of the test

