### PR TITLE
feat(@desktop/wallet): Account View Setting Actions

### DIFF
--- a/ui/app/AppLayouts/Profile/controls/WalletAccountDetailsKeypairItem.qml
+++ b/ui/app/AppLayouts/Profile/controls/WalletAccountDetailsKeypairItem.qml
@@ -3,11 +3,16 @@ import QtQuick 2.13
 import StatusQ.Components 0.1
 import StatusQ.Core.Theme 0.1
 import StatusQ.Core.Utils 0.1
+import StatusQ.Controls 0.1
 
 import utils 1.0
 
 StatusListItem {
+    id: root
+
     property var keyPair
+
+    signal buttonClicked()
 
     title: keyPair ? keyPair.pairType === Constants.keycard.keyPairType.watchOnly ? qsTr("Watch only") : keyPair.name: ""
     titleAsideText: keyPair && keyPair.pairType === Constants.keycard.keyPairType.profile ? Utils.getElidedCompressedPk(keyPair.pubKey): ""
@@ -21,7 +26,12 @@ StatusListItem {
         charactersLen: 2
         isLetterIdenticon: !!keyPair && !keyPair.icon && !asset.name.toString()
     }
-    color: Theme.palette.transparent
+    color: {
+        if (sensor.containsMouse || root.highlighted) {
+            return Theme.palette.baseColor2
+        }
+        return Theme.palette.transparent
+    }
     ringSettings {
         ringSpecModel: keyPair && keyPair.pairType === Constants.keycard.keyPairType.profile ? Utils.getColorHashAsJson(root.userProfilePublicKey) : []
         ringPxSize: Math.max(asset.width / 24.0)
@@ -42,4 +52,17 @@ StatusListItem {
         titleText.font.pixelSize: 12
         titleText.color: Theme.palette.indirectColor1
     }
+    components: [
+        StatusRoundButton {
+            width: 32
+            height: 32
+            radius: 8
+            visible: root.sensor.containsMouse
+            type: StatusRoundButton.Type.Quinary
+            icon.name: "more"
+            icon.color: hovered ? Theme.palette.directColor1 : Theme.palette.baseColor1
+            icon.hoverColor: Theme.palette.primaryColor3
+            onClicked: root.buttonClicked()
+        }
+    ]
 }

--- a/ui/app/AppLayouts/Profile/controls/WalletAccountDetailsListItem.qml
+++ b/ui/app/AppLayouts/Profile/controls/WalletAccountDetailsListItem.qml
@@ -2,16 +2,71 @@ import QtQuick 2.13
 
 import StatusQ.Components 0.1
 import StatusQ.Core.Theme 0.1
+import StatusQ.Controls 0.1
+
+import shared.controls 1.0
 
 StatusListItem {
+    id: root
+
+    property bool isInteractive: false
+    property bool copyButtonEnabled: false
+    property bool moreButtonEnabled: false
+
+    signal buttonClicked()
+    signal copyClicked()
+
+    QtObject {
+        id: d
+        readonly property var timer: Timer {}
+    }
+
     statusListItemTitle.customColor: Theme.palette.baseColor1
     statusListItemTitle.font.pixelSize: 13
     statusListItemTitle.lineHeightMode: Text.FixedHeight
     statusListItemTitle.lineHeight: 18
     statusListItemSubTitle.customColor: Theme.palette.directColor1
     statusListItemSubTitle.textFormat: Qt.RichText
-    statusListItemSubTitle.wrapMode: Qt.TextWrapAnywhere
     statusListItemSubTitle.lineHeightMode: Text.FixedHeight
     statusListItemSubTitle.lineHeight: 22
-    color: Theme.palette.transparent
+    statusListItemSubTitle.elide: Text.ElideNone
+    statusListItemSubTitle.wrapMode: Text.WrapAnywhere
+    color: {
+        if (isInteractive && (sensor.containsMouse || root.highlighted)) {
+            return Theme.palette.baseColor2
+        }
+        return Theme.palette.transparent
+    }
+    components: [
+        StatusRoundButton {
+            width: 32
+            height: 32
+            radius: 8
+            visible: moreButtonEnabled && isInteractive  && root.sensor.containsMouse
+            type: StatusRoundButton.Type.Quinary
+            icon.name: "more"
+            icon.color: hovered ? Theme.palette.directColor1 : Theme.palette.baseColor1
+            icon.hoverColor: Theme.palette.primaryColor3
+            onClicked: root.buttonClicked()
+        },
+        StatusRoundButton {
+            id: copyButton
+            property bool checked: false
+            width: 32
+            height: 32
+            radius: 8
+            visible: copyButtonEnabled && isInteractive  && root.sensor.containsMouse
+            type: StatusRoundButton.Type.Quinary
+            icon.name: copyButton.checked ? "tiny/checkmark": "copy"
+            icon.color: copyButton.checked ? Theme.palette.successColor1 : hovered ? Theme.palette.directColor1 : Theme.palette.baseColor1
+            icon.hoverColor: copyButton.checked ? Theme.palette.successColor1 : Theme.palette.primaryColor3
+            onClicked: {
+                copyButton.checked = true
+                root.copyClicked()
+                d.timer.setTimeout(function() {
+                    copyButton.checked = false
+                }, 1500)
+            }
+        }
+    ]
 }

--- a/ui/app/AppLayouts/Profile/controls/WalletKeyPairDelegate.qml
+++ b/ui/app/AppLayouts/Profile/controls/WalletKeyPairDelegate.qml
@@ -9,6 +9,8 @@ import StatusQ.Popups 0.1
 
 import utils 1.0
 
+import AppLayouts.Profile.popups 1.0
+
 Rectangle {
     id: root
 
@@ -75,60 +77,13 @@ Rectangle {
                     Loader {
                         id: menuLoader
                         active: false
-                        sourceComponent: StatusMenu {
+                        sourceComponent: WalletAccountKeycardMenu {
                             onClosed: {
                                 menuLoader.active = false
                             }
-
-                            StatusAction {
-                                text: enabled? qsTr("Show encrypted QR of keypairs on device") : ""
-                                enabled: !d.isProfileKeypair &&
-                                         !model.keyPair.migratedToKeycard &&
-                                         !model.keyPair.operability === Constants.keypair.operability.nonOperable
-                                icon.name: "qr"
-                                icon.color: Theme.palette.primaryColor1
-                                onTriggered: {
-                                    console.warn("TODO: show encrypted QR")
-                                }
-                            }
-
-
-                            StatusAction {
-                                text: model.keyPair.migratedToKeycard? qsTr("Stop using Keycard") : qsTr("Move keys to a Keycard")
-                                icon.name: model.keyPair.migratedToKeycard? "keycard-crossed" : "keycard"
-                                icon.color: Theme.palette.primaryColor1
-                                onTriggered: {
-                                    if (model.keyPair.migratedToKeycard)
-                                        console.warn("TODO: stop using Keycard")
-                                    else
-                                        console.warn("TODO: move keys to a Keycard")
-                                }
-                            }
-
-                            StatusAction {
-                                text: enabled? qsTr("Rename keypair") : ""
-                                enabled: !d.isProfileKeypair
-                                icon.name: "edit"
-                                icon.color: Theme.palette.primaryColor1
-                                onTriggered: {
-                                    root.runRenameKeypairFlow()
-                                }
-                            }
-
-                            StatusMenuSeparator {
-                                visible: !d.isProfileKeypair
-                            }
-
-                            StatusAction {
-                                text: enabled? qsTr("Remove keypair and associated accounts") : ""
-                                enabled: !d.isProfileKeypair
-                                type: StatusAction.Type.Danger
-                                icon.name: "delete"
-                                icon.color: Theme.palette.dangerColor1
-                                onTriggered: {
-                                    root.runRemoveKeypairFlow()
-                                }
-                            }
+                            keyPair: root.keyPair
+                            onRunRenameKeypairFlow: root.runRenameKeypairFlow()
+                            onRunRemoveKeypairFlow: root.runRemoveKeypairFlow()
                         }
                     }
                 },

--- a/ui/app/AppLayouts/Profile/popups/WalletAccountKeycardMenu.qml
+++ b/ui/app/AppLayouts/Profile/popups/WalletAccountKeycardMenu.qml
@@ -1,0 +1,69 @@
+import QtQuick 2.15
+
+import StatusQ.Core.Theme 0.1
+import StatusQ.Popups 0.1
+
+import utils 1.0
+
+StatusMenu {
+    id: root
+
+    property var keyPair
+
+    signal runRenameKeypairFlow()
+    signal runRemoveKeypairFlow()
+
+    QtObject {
+        id: d
+        readonly property bool isProfileKeypair: keyPair.pairType === Constants.keycard.keyPairType.profile
+    }
+
+    StatusAction {
+        text: enabled? qsTr("Show encrypted QR of keypairs on device") : ""
+        enabled: !d.isProfileKeypair &&
+                 !keyPair.migratedToKeycard &&
+                 !keyPair.operability === Constants.keypair.operability.nonOperable
+        icon.name: "qr"
+        icon.color: Theme.palette.primaryColor1
+        onTriggered: {
+            console.warn("TODO: show encrypted QR")
+        }
+    }
+
+    StatusAction {
+        text: keyPair.migratedToKeycard? qsTr("Stop using Keycard") : qsTr("Move keys to a Keycard")
+        icon.name: keyPair.migratedToKeycard? "keycard-crossed" : "keycard"
+        icon.color: Theme.palette.primaryColor1
+        onTriggered: {
+            if (keyPair.migratedToKeycard)
+                console.warn("TODO: stop using Keycard")
+            else
+                console.warn("TODO: move keys to a Keycard")
+        }
+    }
+
+    StatusAction {
+        text: enabled? qsTr("Rename keypair") : ""
+        enabled: !d.isProfileKeypair
+        icon.name: "edit"
+        icon.color: Theme.palette.primaryColor1
+        onTriggered: {
+            root.runRenameKeypairFlow()
+        }
+    }
+
+    StatusMenuSeparator {
+        visible: !d.isProfileKeypair
+    }
+
+    StatusAction {
+        text: enabled? qsTr("Remove keypair and associated accounts") : ""
+        enabled: !d.isProfileKeypair
+        type: StatusAction.Type.Danger
+        icon.name: "delete"
+        icon.color: Theme.palette.dangerColor1
+        onTriggered: {
+            root.runRemoveKeypairFlow()
+        }
+    }
+}

--- a/ui/app/AppLayouts/Profile/popups/WalletAddressMenu.qml
+++ b/ui/app/AppLayouts/Profile/popups/WalletAddressMenu.qml
@@ -1,0 +1,80 @@
+import QtQuick 2.15
+
+import StatusQ.Popups 0.1
+
+import utils 1.0
+
+import AppLayouts.Wallet.popups 1.0
+
+StatusMenu {
+    id: root
+
+    property string selectedAddress
+    property bool areTestNetworksEnabled: false
+    property string preferredSharingNetworks
+    property var preferredSharingNetworksArray
+
+    signal copyToClipboard(string address)
+
+    function openMenu(delegate) {
+        const x = delegate.width - 40
+        const y = delegate.height / 2 + 20
+        root.popup(delegate, x, y)
+    }
+
+    StatusAction {
+        id: showOnEtherscanAction
+        text: qsTr("View address on Etherscan")
+        icon.name: "link"
+        onTriggered: {
+            const link = areTestNetworksEnabled ? Constants.networkExplorerLinks.goerliEtherscan : Constants.networkExplorerLinks.etherscan
+            Global.openLink("%1/%2/%3".arg(link).arg(Constants.networkExplorerLinks.addressPath).arg(root.selectedAddress))
+        }
+    }
+    StatusAction {
+        id: showOnArbiscanAction
+        text: qsTr("View address on Arbiscan")
+        icon.name: "link"
+        onTriggered: {
+            const link = areTestNetworksEnabled ? Constants.networkExplorerLinks.goerliArbiscan : Constants.networkExplorerLinks.arbiscan
+            Global.openLink("%1/%2/%3".arg(link).arg(Constants.networkExplorerLinks.addressPath).arg(root.selectedAddress))
+        }
+    }
+    StatusAction {
+        id: showOnOptimismAction
+        text: qsTr("View address on Optimism Explorer")
+        icon.name: "link"
+        onTriggered: {
+            const link = areTestNetworksEnabled ? Constants.networkExplorerLinks.goerliOptimistic : Constants.networkExplorerLinks.optimistic
+            Global.openLink("%1/%2/%3".arg(link).arg(Constants.networkExplorerLinks.addressPath).arg(root.selectedAddress))
+        }
+    }
+    StatusSuccessAction {
+        id: copyAddressAction
+        successText:  qsTr("Address copied")
+        text: qsTr("Copy address")
+        icon.name: "copy"
+        onTriggered: root.copyToClipboard(root.selectedAddress)
+    }
+    StatusAction {
+        id: showQrAction
+        text: qsTr("Show address QR")
+        icon.name: "qr"
+        onTriggered: Global.openPopup(addressQr)
+    }
+
+    Component {
+        id: addressQr
+        ReceiveModal {
+            anchors.centerIn: parent
+            address: root.selectedAddress
+            chainShortNames: root.preferredSharingNetworks
+            preferredSharingNetworksArray: root.preferredSharingNetworksArray
+            readOnly: true
+            hasFloatingButtons: false
+            advancedHeaderComponent: null
+            description: qsTr("Address")
+            onClosed: destroy()
+        }
+    }
+}

--- a/ui/app/AppLayouts/Profile/popups/qmldir
+++ b/ui/app/AppLayouts/Profile/popups/qmldir
@@ -3,3 +3,6 @@ SetupSyncingPopup 1.0 SetupSyncingPopup.qml
 AddSocialLinkModal 1.0 AddSocialLinkModal.qml
 ModifySocialLinkModal 1.0 ModifySocialLinkModal.qml
 RenameKeypairPopup 1.0 RenameKeypairPopup.qml
+WalletAccountKeycardMenu 1.0 WalletAccountKeycardMenu.qml
+WalletAddressMenu 1.0 WalletAddressMenu.qml
+RenameAccontModal 1.0 RenameAccontModal.qml

--- a/ui/app/AppLayouts/Profile/stores/WalletStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/WalletStore.qml
@@ -104,4 +104,8 @@ QtObject {
         }
         return prefChains
     }
+
+    function copyToClipboard(textToCopy) {
+        globalUtils.copyToClipboard(textToCopy)
+    }
 }

--- a/ui/app/AppLayouts/Profile/views/WalletView.qml
+++ b/ui/app/AppLayouts/Profile/views/WalletView.qml
@@ -109,6 +109,17 @@ SettingsContentBase {
             onGoToAccountOrderView: {
                 stackContainer.currentIndex = accountOrderViewIndex
             }
+            onRunRenameKeypairFlow: {
+                renameKeypairPopup.keyUid = model.keyPair.keyUid
+                renameKeypairPopup.name = model.keyPair.name
+                renameKeypairPopup.accounts = model.keyPair.accounts
+                renameKeypairPopup.active = true
+            }
+            onRunRemoveKeypairFlow: {
+                removeKeypairPopup.keyUid = model.keyPair.keyUid
+                removeKeypairPopup.name = model.keyPair.name
+                removeKeypairPopup.active = true
+            }
         }
 
         NetworksView {
@@ -156,6 +167,17 @@ SettingsContentBase {
             userProfilePublicKey: walletStore.userProfilePublicKey
             onGoBack: stackContainer.currentIndex = mainViewIndex
             onVisibleChanged: if(!visible) root.walletStore.selectedAccount = null
+            onRunRenameKeypairFlow: {
+                renameKeypairPopup.keyUid = keyPair.keyUid
+                renameKeypairPopup.name = keyPair.name
+                renameKeypairPopup.accounts = keyPair.accounts
+                renameKeypairPopup.active = true
+            }
+            onRunRemoveKeypairFlow: {
+                removeKeypairPopup.keyUid = keyPair.keyUid
+                removeKeypairPopup.name = keyPair.name
+                removeKeypairPopup.active = true
+            }
         }
 
         DappPermissionsView {
@@ -178,6 +200,53 @@ SettingsContentBase {
                 height: 28
                 image.source: Style.svg(!!editNetwork.combinedNetwork.prod && !!editNetwork.combinedNetwork.prod.iconUrl ? editNetwork.combinedNetwork.prod.iconUrl: "")
                 image.fillMode: Image.PreserveAspectCrop
+            }
+        }
+
+        Loader {
+            id: renameKeypairPopup
+            active: false
+
+            property string keyUid
+            property string name
+            property var accounts
+
+            sourceComponent: RenameKeypairPopup {
+                accountsModule: root.walletStore.accountsModule
+                keyUid: renameKeypairPopup.keyUid
+                name: renameKeypairPopup.name
+                accounts: renameKeypairPopup.accounts
+
+                onClosed: {
+                    renameKeypairPopup.active = false
+                }
+            }
+
+            onLoaded: {
+                renameKeypairPopup.item.open()
+            }
+        }
+
+        Loader {
+            id: removeKeypairPopup
+            active: false
+
+            property string keyUid
+            property string name
+
+            sourceComponent: ConfirmationDialog {
+                headerSettings.title: qsTr("Confirm %1 Removal").arg(removeKeypairPopup.name)
+
+                confirmationText: qsTr("You will not be able to restore viewing access to any account of this keypair in the future unless you import this keypair again.")
+                confirmButtonLabel: qsTr("Remove keypair")
+                onConfirmButtonClicked: {
+                    root.walletStore.deleteKeypair(removeKeypairPopup.keyUid)
+                    removeKeypairPopup.active = false
+                }
+            }
+
+            onLoaded: {
+                removeKeypairPopup.item.open()
             }
         }
     }

--- a/ui/app/AppLayouts/Profile/views/wallet/MainView.qml
+++ b/ui/app/AppLayouts/Profile/views/wallet/MainView.qml
@@ -25,6 +25,8 @@ Column {
     signal goToAccountOrderView()
     signal goToAccountView(var account, var keypair)
     signal goToDappPermissionsView()
+    signal runRenameKeypairFlow(var model)
+    signal runRemoveKeypairFlow(var model)
 
     spacing: 8
 
@@ -108,65 +110,9 @@ Column {
                 includeWatchOnlyAccount: walletStore.includeWatchOnlyAccount
                 onGoToAccountView: root.goToAccountView(account, keyPair)
                 onToggleIncludeWatchOnlyAccount: walletStore.toggleIncludeWatchOnlyAccount()
-                onRunRenameKeypairFlow: {
-                    renameKeypairPopup.keyUid = model.keyPair.keyUid
-                    renameKeypairPopup.name = model.keyPair.name
-                    renameKeypairPopup.accounts = model.keyPair.accounts
-                    renameKeypairPopup.active = true
-                }
-                onRunRemoveKeypairFlow: {
-                    removeKeypairPopup.keyUid = model.keyPair.keyUid
-                    removeKeypairPopup.name = model.keyPair.name
-                    removeKeypairPopup.active = true
-                }
+                onRunRenameKeypairFlow: root.runRenameKeypairFlow(model)
+                onRunRemoveKeypairFlow: root.runRemoveKeypairFlow(model)
             }
-        }
-    }
-
-    Loader {
-        id: renameKeypairPopup
-        active: false
-
-        property string keyUid
-        property string name
-        property var accounts
-
-        sourceComponent: RenameKeypairPopup {
-            accountsModule: root.walletStore.accountsModule
-            keyUid: renameKeypairPopup.keyUid
-            name: renameKeypairPopup.name
-            accounts: renameKeypairPopup.accounts
-
-            onClosed: {
-                renameKeypairPopup.active = false
-            }
-        }
-
-        onLoaded: {
-            renameKeypairPopup.item.open()
-        }
-    }
-
-    Loader {
-        id: removeKeypairPopup
-        active: false
-
-        property string keyUid
-        property string name
-
-        sourceComponent: ConfirmationDialog {
-            headerSettings.title: qsTr("Confirm %1 Removal").arg(removeKeypairPopup.name)
-
-            confirmationText: qsTr("You will not be able to restore viewing access to any account of this keypair in the future unless you import this keypair again.")
-            confirmButtonLabel: qsTr("Remove keypair")
-            onConfirmButtonClicked: {
-                root.walletStore.deleteKeypair(removeKeypairPopup.keyUid)
-                removeKeypairPopup.active = false
-            }
-        }
-
-        onLoaded: {
-            removeKeypairPopup.item.open()
         }
     }
 }

--- a/ui/app/AppLayouts/Wallet/popups/qmldir
+++ b/ui/app/AppLayouts/Wallet/popups/qmldir
@@ -2,3 +2,4 @@ NetworkSelectPopup 1.0 NetworkSelectPopup.qml
 ActivityFilterMenu 1.0 ActivityFilterMenu.qml
 ActivityPeriodFilterSubMenu 1.0 filterSubMenus/ActivityPeriodFilterSubMenu.qml
 ActivityTypeFilterSubMenu 1.0 filterSubMenus/ActivityTypeFilterSubMenu.qml
+ReceiveModal 1.0 ReceiveModal.qml


### PR DESCRIPTION
fixes #11689

### What does the PR do

Implements Actions in the Account View https://www.figma.com/file/idUoxN7OIW2Jpp3PMJ1Rl8/%E2%9A%99%EF%B8%8F-Settings-%7C-Desktop?type=design&node-id=15215-280406&mode=dev

### Affected areas

Account View - Settings

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it



https://github.com/status-im/status-desktop/assets/60327365/fbe1315b-cd28-49c7-b4ef-1b918fa905d0


