### PR TITLE
11467 Replace MainNet with Optimism as default network selection

### DIFF
--- a/ui/app/AppLayouts/Wallet/controls/NetworkFilter.qml
+++ b/ui/app/AppLayouts/Wallet/controls/NetworkFilter.qml
@@ -49,7 +49,7 @@ StatusComboBox {
             }
             else {
                  // Default value if not specified
-                d.currentModel = root.layer1Networks
+                d.currentModel = root.layer2Networks
                 d.currentIndex = 0
             }
 

--- a/ui/app/AppLayouts/Wallet/controls/NetworkSelectItemDelegate.qml
+++ b/ui/app/AppLayouts/Wallet/controls/NetworkSelectItemDelegate.qml
@@ -25,11 +25,6 @@ StatusListItem {
         Disabled
     }
 
-    QtObject {
-        id: d
-        property SingleSelectionInfo tmpObject: SingleSelectionInfo { enabled: true }
-    }
-
     objectName: model.chainName
     title: model.chainName
     asset.height: 24
@@ -40,7 +35,7 @@ StatusListItem {
         if(!root.singleSelection.enabled) {
             checkBox.nextCheckState()
         } else if(!radioButton.checked) {   // Don't allow uncheck
-            radioButton.toggle()
+            root.toggleNetwork(({chainId: model.chainId, chainName: model.chainName, iconUrl: model.iconUrl}), root.networkModel, model.index)
         }
     }
 
@@ -77,19 +72,8 @@ StatusListItem {
             ButtonGroup.group: root.radioButtonGroup
             checked: root.singleSelection.currentModel === root.networkModel && root.singleSelection.currentIndex === model.index
 
-            property SingleSelectionInfo exchangeObject: null
-            function setNewInfo(networkModel, index) {
-                d.tmpObject.currentModel = networkModel
-                d.tmpObject.currentIndex = index
-                exchangeObject = d.tmpObject
-                d.tmpObject = root.singleSelection
-                root.singleSelection = exchangeObject
-                exchangeObject = null
-            }
-
-            onCheckedChanged: {
-                if(checked && (root.singleSelection.currentModel !== root.networkModel || root.singleSelection.currentIndex !== model.index)) {
-                    setNewInfo(root.networkModel, model.index)
+            onToggled: {
+                if(checked) {
                     root.toggleNetwork(({chainId: model.chainId, chainName: model.chainName, iconUrl: model.iconUrl}), root.networkModel, model.index)
                 }
             }


### PR DESCRIPTION
### What does the PR do

Closes #11467 
<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

There are two changes in this PR:
 - Make the L2 chain as the default one - implicitly making Optimism as the default network 903fcf7b659abcda238e9385af18c5323b604ff6
 - Fix a bug in the network selector for single selection configuration. Whenever a network is selected, the bindings are broken making it impossible to be selected again. 903fcf7b659abcda238e9385af18c5323b604ff6

### Affected areas

NetworkFilter

<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Screenshot of functionality (including design for comparison)

https://github.com/status-im/status-desktop/assets/47811206/c0b72510-32ef-433e-a329-92a4876ef211

