### PR TITLE
fix(Minting): After minting completed 1 airdrop button is enabled and the other disabled

### DIFF
--- a/storybook/pages/SortableTokenHoldersPanelPage.qml
+++ b/storybook/pages/SortableTokenHoldersPanelPage.qml
@@ -43,6 +43,7 @@ SplitView {
 
             model: emptyCheckBox.checked ? emptyModel : tokenHoldersModel
             showRemotelyDestructMenuItem: remotelyDestructCheckBox.checked
+            isAirdropEnabled: airdropCheckBox.checked
 
             onViewProfileRequested:
                 logs.logEvent("onViewProfileRequested: " + address)
@@ -78,6 +79,12 @@ SplitView {
 
                 checked: true
                 text: "Show \"Remotely Destruct\"  menu item"
+            }
+            CheckBox {
+                id: airdropCheckBox
+
+                text: "Airdrop enabled"
+                checked: true
             }
         }
     }

--- a/storybook/pages/StatusInfoBoxPanelPage.qml
+++ b/storybook/pages/StatusInfoBoxPanelPage.qml
@@ -27,6 +27,8 @@ SplitView {
                 title: "Get started"
                 text: ModelsData.descriptions.ownerTokenInfo
                 buttonText: "Mint Owner token"
+                buttonVisible: btnVisible.checked
+                buttonEnabled: btnEnabled.checked
 
                 onClicked: logs.logEvent("StatusInfoBoxPanel::onClicked --> First Panel")
             }
@@ -39,6 +41,8 @@ SplitView {
                 iconType: ctrlIconType.currentIndex
                 text: ModelsData.descriptions.airdropInfo
                 buttonText: "Airdrop"
+                buttonVisible: btnVisible.checked
+                buttonEnabled: btnEnabled.checked
 
                 onClicked: logs.logEvent("StatusInfoBoxPanel::onClicked --> Second Panel")
             }
@@ -85,6 +89,18 @@ SplitView {
                         { value: StatusInfoBoxPanel.Type.Warning, text: "Warning" }
                     ]
                 }
+            }
+
+            CheckBox {
+                id: btnVisible
+                text: "Button visible"
+                checked: true
+            }
+
+            CheckBox {
+                id: btnEnabled
+                text: "Button enabled"
+                checked: true
             }
         }
     }

--- a/ui/StatusQ/src/StatusQ/Components/StatusInfoBoxPanel.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusInfoBoxPanel.qml
@@ -14,7 +14,8 @@ Control {
     property string icon
     property int iconType: StatusInfoBoxPanel.Type.Info
     property alias buttonText: button.text
-    property alias buttonVisible: button.visible
+    property bool buttonVisible: true
+    property bool buttonEnabled: true
 
     enum Type {
         Info,
@@ -105,7 +106,8 @@ Control {
 
             Layout.alignment: Qt.AlignHCenter
 
-            visible: true
+            visible: root.buttonVisible
+            enabled: root.buttonEnabled
 
             onClicked: root.clicked()
         }

--- a/ui/app/AppLayouts/Communities/panels/MintTokensSettingsPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/MintTokensSettingsPanel.qml
@@ -555,6 +555,7 @@ StackView {
             id: footer
 
             readonly property TokenObject token: view.token
+            readonly property bool isAssetView: view.isAssetView
 
             readonly property bool deployStateCompleted: token.deployState === Constants.ContractTransactionStatus.Completed
 
@@ -577,7 +578,7 @@ StackView {
             }
             airdropEnabled: deployStateCompleted &&
                             (token.infiniteSupply ||
-                             token.remainingTokens !== 0)
+                             token.remainingTokens > 0)
 
             remotelyDestructEnabled: deployStateCompleted &&
                                      !!view.tokenOwnersModel &&

--- a/ui/app/AppLayouts/Communities/panels/SortableTokenHoldersPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/SortableTokenHoldersPanel.qml
@@ -20,6 +20,7 @@ Control {
 
     property string tokenName
     property bool showRemotelyDestructMenuItem: true
+    property alias isAirdropEnabled: infoBoxPanel.buttonEnabled
 
     readonly property alias sortBy: holdersList.sortBy
     readonly property alias sorting: holdersList.sorting
@@ -104,6 +105,8 @@ Control {
         }
 
         StatusInfoBoxPanel {
+            id: infoBoxPanel
+
             Layout.fillWidth: true
             Layout.topMargin: Style.current.padding
 

--- a/ui/app/AppLayouts/Communities/views/CommunityTokenView.qml
+++ b/ui/app/AppLayouts/Communities/views/CommunityTokenView.qml
@@ -222,6 +222,8 @@ StatusScrollView {
             model: root.tokenOwnersModel
             tokenName: root.name
             showRemotelyDestructMenuItem: !root.isAssetView && root.remotelyDestruct
+            isAirdropEnabled: root.deploymentCompleted &&
+                              (token.infiniteSupply || token.remainingTokens > 0)
 
             Layout.topMargin: Style.current.padding
             Layout.fillWidth: true


### PR DESCRIPTION
Fixes #11496

### What does the PR do

- Added `buttonEnabled` property to `StatusInfoBoxPanel` so it can be set from outside.
- Fixed airdrop button enable condition in minting flow. It is enabled when minting state is **completed** and if the token properties are **infinite supply or** there are still **remaining tokens** to be airdropped.
- Updated storybook accordingly.

### Affected areas

Community Settings / Tokens


### Screenshot of functionality

https://github.com/status-im/status-desktop/assets/97019400/115419dd-5b8e-4b8c-827d-e4714b27d4ad

https://github.com/status-im/status-desktop/assets/97019400/d170e790-387f-4e5a-8975-cac960b92320
