### PR TITLE
fix: Revisit character set usage in description fields

### DIFF
--- a/ui/app/AppLayouts/Communities/popups/CreateCategoryPopup.qml
+++ b/ui/app/AppLayouts/Communities/popups/CreateCategoryPopup.qml
@@ -61,10 +61,16 @@ StatusModal {
             label: qsTr("Category title")
             charLimit: maxCategoryNameLength
             placeholderText: qsTr("Name the category")
-            validators: [StatusMinLengthValidator {
-                minLength: 1
-                errorMessage: Utils.getErrorMessage(nameInput.errors, qsTr("category name"))
-            }]
+            validators: [
+                StatusMinLengthValidator {
+                    minLength: 1
+                    errorMessage: Utils.getErrorMessage(nameInput.errors, qsTr("category name"))
+                },
+                StatusRegularExpressionValidator {
+                    regularExpression: Constants.regularExpressions.alphanumericalExpanded
+                    errorMessage: Constants.errorMessages.alphanumericalExpandedRegExp
+                }
+            ]
         }
 
         StatusModalDivider {

--- a/ui/app/AppLayouts/Communities/popups/CreateChannelPopup.qml
+++ b/ui/app/AppLayouts/Communities/popups/CreateChannelPopup.qml
@@ -230,10 +230,16 @@ StatusDialog {
                 input.multiline: true
                 minimumHeight: 88
                 maximumHeight: 88
-                validators: [StatusMinLengthValidator {
+                validators: [
+                    StatusMinLengthValidator {
                         minLength: 1
-                        errorMessage:  Utils.getErrorMessage(descriptionTextArea.errors, qsTr("channel description"))
-                    }]
+                        errorMessage: Utils.getErrorMessage(descriptionTextArea.errors, qsTr("channel description"))
+                    },
+                    StatusRegularExpressionValidator {
+                        regularExpression: Constants.regularExpressions.alphanumericalExpanded
+                        errorMessage: Constants.errorMessages.alphanumericalExpandedRegExp
+                    }
+                ]
             }
 
             /* TODO: use the code below to enable private channels and message limit */

--- a/ui/imports/shared/popups/RenameGroupPopup.qml
+++ b/ui/imports/shared/popups/RenameGroupPopup.qml
@@ -9,6 +9,7 @@ import utils 1.0
 
 import StatusQ.Components 0.1
 import StatusQ.Controls 0.1
+import StatusQ.Controls.Validators 0.1
 import StatusQ.Core 0.1
 import StatusQ.Popups 0.1
 import StatusQ.Popups.Dialog 0.1
@@ -39,7 +40,7 @@ StatusDialog {
         colorSelectionGrid.selectedColor = activeGroupColor
 
         for (let i = 0; i < colorSelectionGrid.model.length; i++) {
-            if(colorSelectionGrid.model[i] === root.activeGroupColor.toUpperCase())
+            if(colorSelectionGrid.model[i].toString().toUpperCase() === root.activeGroupColor.toUpperCase())
                 colorSelectionGrid.selectedColorIndex = i
         }
 
@@ -56,13 +57,23 @@ StatusDialog {
             Layout.alignment: Qt.AlignHCenter
             label: qsTr("Name the group")
             charLimit: d.nameCharLimit
+
+            validators: [
+                StatusMinLengthValidator {
+                    minLength: 1
+                    errorMessage: Utils.getErrorMessage(groupName.errors, qsTr("group name"))
+                },
+                StatusRegularExpressionValidator {
+                    regularExpression: Constants.regularExpressions.alphanumericalExpanded
+                    errorMessage: Constants.errorMessages.alphanumericalExpandedRegExp
+                }
+            ]
         }
 
         StatusBaseText {
             id: imgText
             text: qsTr("Group image")
             leftPadding: groupName.leftPadding - root.padding
-            font.pixelSize: 15
         }
 
         EditCroppedImagePanel {
@@ -75,49 +86,12 @@ StatusDialog {
             imageFileDialogTitle: qsTr("Choose an image as logo")
             title: qsTr("Edit group name and image")
             acceptButtonText: qsTr("Use as an icon for this group chat")
-
-            backgroundComponent:
-                StatusLetterIdenticon {
-                id: letter
-                color: colorSelectionGrid.selectedColor
-                name: root.activeGroupName
-                height: 100
-                width: 100
-                letterSize: 64
-
-                StatusRoundButton {
-                    id: addButton
-
-                    icon.name: "add"
-                    type: StatusRoundButton.Type.Secondary
-
-                    transform: [
-                        Translate {
-                            x: -addButton.width/2 - 5
-                            y: -addButton.height/2 + 5
-                        },
-                        Rotation { angle: -addRotationTransform.angle },
-                        Rotation {
-                            id: addRotationTransform
-                            angle: 135
-                            origin.x: letter.radius
-                        },
-                        Translate {
-                            x: letter.width - 2 * letter.radius
-                            y: letter.radius
-                        }
-                    ]
-
-                    onClicked: imageEditor.chooseImageToCrop()
-                }
-            }
         }
 
         StatusBaseText {
             id: colorText
             text: qsTr("Standard colours")
             leftPadding: groupName.leftPadding - root.padding
-            font.pixelSize: 15
         }
 
         StatusColorSelectorGrid {

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -503,12 +503,12 @@ QtObject {
                 errorMessage: qsTr("Usernames starting with whitespace are not allowed")
             },
             StatusRegularExpressionValidator {
-                regularExpression: /^[a-zA-Z0-9\-_ ]+$/
+                regularExpression: regularExpressions.alphanumericalExpanded
                 errorMessage: errorMessages.alphanumericalExpandedRegExp
             },
             StatusMinLengthValidator {
                 minLength: keypair.nameLengthMin
-                errorMessage: qsTr("Username must be at least %1 characters").arg(keypair.nameLengthMin)
+                errorMessage: qsTr("Username must be at least %n character(s)", "", keypair.nameLengthMin)
             },
             StatusValidator {
                 name: "endsWithSpaceValidator"
@@ -645,7 +645,7 @@ QtObject {
 
     readonly property QtObject regularExpressions: QtObject {
         readonly property var alphanumerical: /^$|^[a-zA-Z0-9]+$/
-        readonly property var alphanumericalExpanded: /^$|^[a-zA-Z0-9\-_ ]+$/
+        readonly property var alphanumericalExpanded: /^$|^[a-zA-Z0-9\-_.\u0020]+$/
         readonly property var alphanumericalWithSpace: /^$|^[a-zA-Z0-9\s]+$/
         readonly property var asciiPrintable:         /^$|^[!-~]+$/
         readonly property var ascii:                  /^$|^[\x00-\x7F]+$/
@@ -655,8 +655,8 @@ QtObject {
 
     readonly property QtObject errorMessages: QtObject {
         readonly property string alphanumericalRegExp: qsTr("Only letters and numbers allowed")
-        readonly property string alphanumericalWithSpaceRegExp: qsTr("Special characters are not allowed")
         readonly property string alphanumericalExpandedRegExp: qsTr("Only letters, numbers, underscores, whitespaces and hyphens allowed")
+        readonly property string alphanumericalWithSpaceRegExp: qsTr("Special characters are not allowed")
         readonly property string asciiRegExp: qsTr("Only letters, numbers and ASCII characters allowed")
     }
 


### PR DESCRIPTION
Restrict the character set to basically 7-bit ASCII plus some punctuation in community/chat/profile related popups in order to:
- reduce the risk of impersonation (UTF-8 characters might look the same despite being a different codepoint)
- narrow down the set of characters in order to keep the new share URL format short

Closes #11307

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

Create chat category:
![image](https://github.com/status-im/status-desktop/assets/5377645/ce3f2c80-7574-41b1-9441-24541320bcd5)

Create channel:
![image](https://github.com/status-im/status-desktop/assets/5377645/fc9bb7bb-ae5d-4290-8642-161f73bd74da)

Edit group chat:
![image](https://github.com/status-im/status-desktop/assets/5377645/13d25c1a-613c-4f54-946a-eea5e98d82a2)

Profile display name:
![image](https://github.com/status-im/status-desktop/assets/5377645/206a2ddf-60dc-4a12-8d45-282fcbdaa8e1)

Community name/description:
![image](https://github.com/status-im/status-desktop/assets/5377645/fb840aa4-c906-4edc-bb5b-65ca65039b18)

