### PR TITLE
feat(OwnerToken): Add `Retry` button

### DIFF
--- a/storybook/pages/MintTokensSettingsPanelPage.qml
+++ b/storybook/pages/MintTokensSettingsPanelPage.qml
@@ -77,6 +77,7 @@ SplitView {
             // Owner and TMaster related props:
             isOwnerTokenDeployed: deployCheck.checked
             isTMasterTokenDeployed: deployCheck.checked
+            anyPrivilegedTokenFailed: failedCheck.checked
 
             // Models:
             tokensModel: editorModelChecked.checked ? emptyModel :
@@ -148,6 +149,7 @@ SplitView {
                     id: privilegedModelChecked
 
                     text: "Owner token and TMaster token only"
+
                 }
                 RadioButton {
                     id: completeModelChecked
@@ -165,7 +167,10 @@ SplitView {
                 }
 
                 RadioButton {
+                    id: failedCheck
+
                     text: "Set all to 'Error'"
+                    checked: true
 
                     onClicked: mintedTokensModel.changeAllMintingStates(0)
                 }

--- a/ui/app/AppLayouts/Communities/panels/PrivilegedTokenArtworkPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/PrivilegedTokenArtworkPanel.qml
@@ -37,13 +37,13 @@ Control {
 
         readonly property int iconSize: ({
                                              [PrivilegedTokenArtworkPanel.Size.Small]: 14,
-                                             [PrivilegedTokenArtworkPanel.Size.Medium]: 16,
+                                             [PrivilegedTokenArtworkPanel.Size.Medium]: 24,
                                              [PrivilegedTokenArtworkPanel.Size.Large]: 38
                                          }[size])
 
         readonly property int iconMargins: ({
                                                 [PrivilegedTokenArtworkPanel.Size.Small]: 8,
-                                                [PrivilegedTokenArtworkPanel.Size.Medium]: 12,
+                                                [PrivilegedTokenArtworkPanel.Size.Medium]: 10,
                                                 [PrivilegedTokenArtworkPanel.Size.Large]: 16
                                             }[size])
     }


### PR DESCRIPTION
Closes #11613

### What does the PR do

- In case of `Owner` and `TMaster` token deployment failed, a `Retry` button must be shown in minted tokens pages and it will navigate to the `Edit page` the same way it's done by using `Retry` button inside the item selected.
- Updated storybook accordingly.

**NOTE**: Only UI. Tested with `storybook`.

### Affected areas

Community Settings / Tokens - Owner and TMaster tokens

### Screenshot of functionality

https://github.com/status-im/status-desktop/assets/97019400/3e9288fd-06cd-4463-86d9-fbf6c41b36ed