### PR TITLE
fix(SendContactRequestModal): Display name / image problems with CR dialog

### DIFF
--- a/ui/StatusQ/src/StatusQ/Core/StatusBaseText.qml
+++ b/ui/StatusQ/src/StatusQ/Core/StatusBaseText.qml
@@ -27,6 +27,7 @@ import StatusQ.Core.Theme 0.1
 
 Text {
     font.family: Theme.palette.baseFont.name
+    font.pixelSize: Theme.primaryTextFontSize
     color: Theme.palette.directColor1
     linkColor: hoveredLink ? Qt.lighter(Theme.palette.primaryColor1)
                            : Theme.palette.primaryColor1

--- a/ui/app/AppLayouts/Profile/panels/ContactsListPanel.qml
+++ b/ui/app/AppLayouts/Profile/panels/ContactsListPanel.qml
@@ -89,6 +89,20 @@ Item {
                     }
                 }
             ]
+            proxyRoles: ExpressionRole {
+                function displayNameProxy(nickname, ensName, displayName, aliasName) {
+                    return ProfileUtils.displayName(nickname, ensName, displayName, aliasName)
+                }
+                name: "preferredDisplayName"
+                expression: displayNameProxy(model.localNickname, model.ensName, model.displayName, model.alias)
+            }
+
+            sorters: [
+                StringSorter {
+                    roleName: "preferredDisplayName"
+                    caseSensitivity: Qt.CaseInsensitive
+                }
+            ]
         }
 
         delegate: ContactPanel {
@@ -96,7 +110,7 @@ Item {
 
             width: ListView.view.width
             contactsStore: root.contactsStore
-            name: ProfileUtils.displayName(model.localNickname, model.ensName, model.displayName, model.alias)
+            name: model.preferredDisplayName
             ensVerified: model.isEnsVerified
             publicKey: model.pubKey
             compressedPk: Utils.getCompressedPk(model.pubKey)

--- a/ui/app/AppLayouts/Profile/popups/SendContactRequestModal.qml
+++ b/ui/app/AppLayouts/Profile/popups/SendContactRequestModal.qml
@@ -16,6 +16,7 @@ StatusModal {
     property var contactsStore
 
     headerSettings.title: qsTr("Send Contact Request to chat key")
+    padding: d.contentMargins
 
     QtObject {
         id: d
@@ -104,52 +105,47 @@ StatusModal {
         }
     }
 
-    contentItem: Item {
-        Column {
-            id: content
-            anchors.left: parent.left
-            anchors.right: parent.right
-            anchors.margins: d.contentMargins
-            spacing: d.contentSpacing
+    contentItem: Column {
+        id: content
+        spacing: d.contentSpacing
 
-            StatusInput {
-                id: chatKeyInput
-                input.edit.objectName: "SendContactRequestModal_ChatKey_Input"
+        StatusInput {
+            id: chatKeyInput
+            input.edit.objectName: "SendContactRequestModal_ChatKey_Input"
 
-                placeholderText: qsTr("Enter chat key here")
-                input.text: input.edit.focus? d.realChatKey : d.elidedChatKey
-                input.rightComponent: {
-                    if(d.showPasteButton)
-                        return pasteButtonComponent
-                    else if(d.showChatKeyValidationIndicator)
-                        return chatKeyValidationIndicator
-                    else
-                        return null
-                }
-                input.onTextChanged: {
-                    if(input.edit.focus)
-                    {
-                        d.textChanged(text)
-                    }
+            placeholderText: qsTr("Enter chat key here")
+            input.text: input.edit.focus? d.realChatKey : d.elidedChatKey
+            input.rightComponent: {
+                if(d.showPasteButton)
+                    return pasteButtonComponent
+                else if(d.showChatKeyValidationIndicator)
+                    return chatKeyValidationIndicator
+                else
+                    return null
+            }
+            input.onTextChanged: {
+                if(input.edit.focus)
+                {
+                    d.textChanged(text)
                 }
             }
+        }
 
-            StatusInput {
-                id: messageInput
-                input.edit.objectName: "SendContactRequestModal_SayWhoYouAre_Input"
-                charLimit: d.maxMsgLength
+        StatusInput {
+            id: messageInput
+            input.edit.objectName: "SendContactRequestModal_SayWhoYouAre_Input"
+            charLimit: d.maxMsgLength
 
-                placeholderText: qsTr("Say who you are / why you want to become a contact...")
-                input.multiline: true
-                minimumHeight: d.msgHeight
-                maximumHeight: d.msgHeight
-                input.verticalAlignment: TextEdit.AlignTop
+            placeholderText: qsTr("Say who you are / why you want to become a contact...")
+            input.multiline: true
+            minimumHeight: d.msgHeight
+            maximumHeight: d.msgHeight
+            input.verticalAlignment: TextEdit.AlignTop
 
-                validators: [StatusMinLengthValidator {
-                        minLength: d.minMsgLength
-                        errorMessage: Utils.getErrorMessage(messageInput.errors, qsTr("who are you"))
-                    }]
-            }
+            validators: [StatusMinLengthValidator {
+                    minLength: d.minMsgLength
+                    errorMessage: Utils.getErrorMessage(messageInput.errors, qsTr("who are you"))
+                }]
         }
     }
 

--- a/ui/app/AppLayouts/Profile/views/ContactsView.qml
+++ b/ui/app/AppLayouts/Profile/views/ContactsView.qml
@@ -315,6 +315,7 @@ SettingsContentBase {
             id: sendContactRequest
             SendContactRequestModal {
                 contactsStore: root.contactsStore
+                onClosed: destroy()
             }
         }
     }

--- a/ui/app/mainui/Popups.qml
+++ b/ui/app/mainui/Popups.qml
@@ -142,13 +142,12 @@ QtObject {
 
     function openSendIDRequestPopup(publicKey, cb) {
         const contactDetails = Utils.getContactDetailsAsJson(publicKey, false)
+        const mainDisplayName = ProfileUtils.displayName(contactDetails.localNickname, contactDetails.name, contactDetails.displayName, contactDetails.alias)
         openPopup(sendIDRequestPopupComponent, {
             userPublicKey: publicKey,
-            userDisplayName: contactDetails.displayName,
-            userIcon: contactDetails.largeImage,
-            userIsEnsVerified: contactDetails.ensVerified,
-            "headerSettings.title": qsTr("Verify %1's Identity").arg(contactDetails.displayName),
-            challengeText: qsTr("Ask a question that only the real %1 will be able to answer e.g. a question about a shared experience, or ask %1 to enter a code or phrase you have sent to them via a different communication channel (phone, post, etc...).").arg(contactDetails.displayName),
+            contactDetails: contactDetails,
+            title: qsTr("Verify %1's Identity").arg(mainDisplayName),
+            challengeText: qsTr("Ask a question that only the real %1 will be able to answer e.g. a question about a shared experience, or ask %1 to enter a code or phrase you have sent to them via a different communication channel (phone, post, etc...).").arg(mainDisplayName),
             buttonText: qsTr("Send verification request")
         }, cb)
     }
@@ -189,9 +188,7 @@ QtObject {
         const contactDetails = Utils.getContactDetailsAsJson(publicKey, false)
         const popupProperties = {
             userPublicKey: publicKey,
-            userDisplayName: contactDetails.displayName,
-            userIcon: contactDetails.largeImage,
-            userIsEnsVerified: contactDetails.ensVerified
+            contactDetails: contactDetails
         }
 
         openPopup(sendContactRequestPopupComponent, popupProperties, cb)
@@ -200,7 +197,7 @@ QtObject {
     function openContactRequestPopupWithContactData(contactData, cb) {
         const popupProperties = {
             userPublicKey: contactData.publicKey,
-            userDisplayName: contactData.displayName
+            contactDetails: { displayName: contactData.displayName }
         }
         openPopup(sendContactRequestPopupComponent, popupProperties, cb)
     }


### PR DESCRIPTION
### What does the PR do

- fix missing profile image
- fix displaying wrong name when a nickname or ENS name is present
- fix ID verification flow ignoring nickname
- fix empty results when a contact has only an alias name
- fix needlessly requesting contact details several times (and
overwriting it); we get this info already from Popups.qml
- switch the popup to `StatusDialog` and fix hardcoded height

2 other smaller commits related to contact display

Fixes https://github.com/status-im/status-desktop/issues/11726

### Affected areas

SendContactRequestModal, Popups

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

1. Sending a contact request (CR) has a correct profile image:
![image](https://github.com/status-im/status-desktop/assets/5377645/d826837a-905b-468d-832d-fcba409ad81d)

2. Correct display name and image for a user with an ENS name:
![image](https://github.com/status-im/status-desktop/assets/5377645/8ddfc4b8-971f-4da0-b38c-4d8341de757b)

3. Correct nickname displayed when sending an ID verification request:
![image](https://github.com/status-im/status-desktop/assets/5377645/6feff494-4923-4d84-ac0e-41cb525c8b74)

4. Alias name not discarded, even when the user is unknown:
![image](https://github.com/status-im/status-desktop/assets/5377645/a54b6322-c480-4a48-9960-f560cfbe8582)

5. Nickname + ENS name:
![image](https://github.com/status-im/status-desktop/assets/5377645/b4885f00-e9b6-458a-ab99-9b9dc7ccd7a8)

6. Contact list using correct displayName and sorted by the same thing (not by alias as before):
![image](https://github.com/status-im/status-desktop/assets/5377645/37e275e6-b9f3-4b52-ace8-affb98c6ac00)


