### PR TITLE
Wallet: Send doesn't load preferred chains on account selection as recipient Fix/issue 11743

### DIFF
--- a/src/app/modules/main/profile_section/wallet/accounts/module.nim
+++ b/src/app/modules/main/profile_section/wallet/accounts/module.nim
@@ -118,7 +118,7 @@ method load*(self: Module) =
     let args = AccountArgs(e)
     let keycardAccount = self.controller.isKeycardAccount(args.account)
     let areTestNetworksEnabled = self.controller.areTestNetworksEnabled()
-    self.view.onUpdatedAccount(walletAccountToWalletAccountItem(args.account, keycardAccount, areTestNetworksEnabled), args.account.prodPreferredChainIds, args.account.testPreferredChainIds)
+    self.view.onUpdatedAccount(walletAccountToWalletAccountItem(args.account, keycardAccount, areTestNetworksEnabled))
 
   self.events.on(SIGNAL_NEW_KEYCARD_SET) do(e: Args):
     let args = KeycardArgs(e)
@@ -139,6 +139,10 @@ method load*(self: Module) =
 
   self.events.on(SIGNAL_INCLUDE_WATCH_ONLY_ACCOUNTS_UPDATED) do(e: Args):
     self.view.setIncludeWatchOnlyAccount(self.controller.isIncludeWatchOnlyAccount())
+
+  self.events.on(SIGNAL_WALLET_ACCOUNT_PREFERRED_SHARING_CHAINS_UPDATED) do(e: Args):
+    let args = AccountArgs(e)
+    self.view.onPreferredSharingChainsUpdated(args.account.keyUid, args.account.address, args.account.prodPreferredChainIds, args.account.testPreferredChainIds)
 
   self.controller.init()
   self.view.load()

--- a/src/app/modules/main/profile_section/wallet/accounts/view.nim
+++ b/src/app/modules/main/profile_section/wallet/accounts/view.nim
@@ -46,9 +46,12 @@ QtObject:
   proc updateAccount(self: View, address: string, accountName: string, colorId: string, emoji: string) {.slot.} =
     self.delegate.updateAccount(address, accountName, colorId, emoji)
 
-  proc onUpdatedAccount*(self: View, account: WalletAccountItem, prodPreferredChainIds: string, testPreferredChainIds: string) =
+  proc onUpdatedAccount*(self: View, account: WalletAccountItem) =
     self.accounts.onUpdatedAccount(account)
-    self.keyPairModel.onUpdatedAccount(account.keyUid, account.address, account.name, account.colorId, account.emoji, prodPreferredChainIds, testPreferredChainIds)
+    self.keyPairModel.onUpdatedAccount(account.keyUid, account.address, account.name, account.colorId, account.emoji)
+
+  proc onPreferredSharingChainsUpdated*(self: View, keyUid, address, prodPreferredChainIds, testPreferredChainIds: string) =
+    self.keyPairModel.onPreferredSharingChainsUpdated(keyUid, address, prodPreferredChainIds, testPreferredChainIds)
 
   proc deleteAccount*(self: View, address: string) {.slot.} =
     self.delegate.deleteAccount(address)

--- a/src/app/modules/main/wallet_section/send/module.nim
+++ b/src/app/modules/main/wallet_section/send/module.nim
@@ -114,6 +114,9 @@ method load*(self: Module) =
       return
     self.refreshWalletAccounts()
 
+  self.events.on(SIGNAL_WALLET_ACCOUNT_PREFERRED_SHARING_CHAINS_UPDATED) do(e:Args):
+    self.refreshWalletAccounts()
+
   self.controller.init()
   self.view.load()
 

--- a/src/app/modules/shared_models/keypair_account_model.nim
+++ b/src/app/modules/shared_models/keypair_account_model.nim
@@ -114,7 +114,7 @@ QtObject:
         self.removeItemAtIndex(i)
         return
 
-  proc updateDetailsForAddressIfTheyAreSet*(self: KeyPairAccountModel, address, name, colorId, emoji, prodPreferredChainIds, testPreferredChainIds: string) =
+  proc updateDetailsForAddressIfTheyAreSet*(self: KeyPairAccountModel, address, name, colorId, emoji: string) =
     for i in 0 ..< self.items.len:
       if cmpIgnoreCase(self.items[i].getAddress(), address) == 0:
         if name.len > 0:
@@ -123,10 +123,6 @@ QtObject:
           self.items[i].setColorId(colorId)
         if emoji.len > 0:
           self.items[i].setEmoji(emoji)
-        if prodPreferredChainIds.len > 0:
-          self.items[i].setProdPreferredChainIds(prodPreferredChainIds)
-        if testPreferredChainIds.len > 0:
-          self.items[i].setTestPreferredChainIds(testPreferredChainIds)
         return
 
   proc updateOperabilityForAddress*(self: KeyPairAccountModel, address: string, operability: string) =
@@ -139,3 +135,10 @@ QtObject:
       if cmpIgnoreCase(self.items[i].getAddress(), address) == 0:
         self.items[i].setBalance(balance)
 
+  proc updatePreferredSharingChainsForAddress*(self: KeyPairAccountModel, address, prodPreferredChainIds, testPreferredChainIds: string) =
+    for i in 0 ..< self.items.len:
+      if cmpIgnoreCase(self.items[i].getAddress(), address) == 0:
+        if prodPreferredChainIds.len > 0:
+          self.items[i].setProdPreferredChainIds(prodPreferredChainIds)
+        if testPreferredChainIds.len > 0:
+          self.items[i].setTestPreferredChainIds(testPreferredChainIds)

--- a/src/app/modules/shared_models/keypair_item.nim
+++ b/src/app/modules/shared_models/keypair_item.nim
@@ -248,8 +248,10 @@ QtObject:
     return self.accounts.containsAccountPath(path)
   proc containsPathOutOfTheDefaultStatusDerivationTree*(self: KeyPairItem): bool {.slot.} =
     return self.accounts.containsPathOutOfTheDefaultStatusDerivationTree()
-  proc updateDetailsForAccountWithAddressIfTheyAreSet*(self: KeyPairItem, address, name, colorId, emoji, prodPreferredChainIds, testPreferredChainIds: string) =
-    self.accounts.updateDetailsForAddressIfTheyAreSet(address, name, colorId, emoji, prodPreferredChainIds, testPreferredChainIds)
+  proc updateDetailsForAccountWithAddressIfTheyAreSet*(self: KeyPairItem, address, name, colorId, emoji: string) =
+    self.accounts.updateDetailsForAddressIfTheyAreSet(address, name, colorId, emoji)
+  proc updatePreferredSharingChainsForAddress*(self: KeyPairItem, address, prodPreferredChainIds, testPreferredChainIds: string) =
+    self.accounts.updatePreferredSharingChainsForAddress(address, prodPreferredChainIds, testPreferredChainIds)
   proc setBalanceForAddress*(self: KeyPairItem, address: string, balance: CurrencyAmount) =
     self.accounts.setBalanceForAddress(address, balance)
   proc updateOperabilityForAccountWithAddress*(self: KeyPairItem, address: string, operability: string) =

--- a/src/app/modules/shared_models/keypair_model.nim
+++ b/src/app/modules/shared_models/keypair_model.nim
@@ -75,10 +75,16 @@ QtObject:
         return self.items[i]
     return nil
 
-  proc onUpdatedAccount*(self: KeyPairModel, keyUid, address, name, colorId, emoji, prodPreferredChainIds, testPreferredChainIds: string) =
+  proc onUpdatedAccount*(self: KeyPairModel, keyUid, address, name, colorId, emoji: string) =
     for item in self.items:
       if keyUid == item.getKeyUid():
-        item.getAccountsModel().updateDetailsForAddressIfTheyAreSet(address, name, colorId, emoji, prodPreferredChainIds, testPreferredChainIds)
+        item.getAccountsModel().updateDetailsForAddressIfTheyAreSet(address, name, colorId, emoji)
+        break
+
+  proc onPreferredSharingChainsUpdated*(self: KeyPairModel,keyUid, address, prodPreferredChainIds, testPreferredChainIds: string) =
+    for item in self.items:
+      if keyUid == item.getKeyUid():
+        item.getAccountsModel().updatePreferredSharingChainsForAddress(address, prodPreferredChainIds, testPreferredChainIds)
         break
 
   proc keypairNameExists*(self: KeyPairModel, name: string): bool =

--- a/ui/app/AppLayouts/Wallet/popups/ReceiveModal.qml
+++ b/ui/app/AppLayouts/Wallet/popups/ReceiveModal.qml
@@ -23,7 +23,8 @@ StatusModal {
     id: root
 
     property string address: RootStore.selectedReceiveAccount.address
-    property string chainShortNames: ""
+    property string chainShortNames: RootStore.getNetworkShortNames(d.preferredSharingNetworksString)
+    property var preferredSharingNetworksArray: d.preferredSharingNetworksString.split(":").filter(Boolean)
 
     property string description: qsTr("Your Address")
 
@@ -31,8 +32,12 @@ StatusModal {
 
     QtObject {
         id: d
-        property string completeAddressWithNetworkPrefix
-        property var preferredSharingNetworksArray: !!RootStore.selectedReceiveAccount ? RootStore.selectedReceiveAccount.preferredSharingChainIds.split(":").filter(Boolean): []
+        property string completeAddressWithNetworkPrefix: root.chainShortNames + root.address
+        property string preferredSharingNetworksString: !!RootStore.selectedReceiveAccount ? RootStore.selectedReceiveAccount.preferredSharingChainIds : ""
+        onPreferredSharingNetworksStringChanged: {
+            root.preferredSharingNetworksArray = d.preferredSharingNetworksString.split(":").filter(Boolean)
+            root.chainShortNames = RootStore.getNetworkShortNames(d.preferredSharingNetworksString)
+        }
     }
 
     headerSettings.title: qsTr("Receive")
@@ -100,7 +105,7 @@ StatusModal {
                             tagPrimaryLabel.text: model.shortName
                             tagPrimaryLabel.color: model.chainColor
                             image.source: Style.svg("tiny/" + model.iconUrl)
-                            visible: d.preferredSharingNetworksArray.includes(model.chainId.toString())
+                            visible: root.preferredSharingNetworksArray.includes(model.chainId.toString())
                             MouseArea {
                                 anchors.fill: parent
                                 cursorShape: root.readOnly ? Qt.ArrowCursor : Qt.PointingHandCursor
@@ -210,7 +215,7 @@ StatusModal {
                                 font.pixelSize: 15
                                 color: chainColor
                                 text: shortName + ":"
-                                visible: d.preferredSharingNetworksArray.includes(model.chainId.toString())
+                                visible: root.preferredSharingNetworksArray.includes(model.chainId.toString())
                                 onVisibleChanged: {
                                     if (root.readOnly)
                                         return
@@ -260,17 +265,17 @@ StatusModal {
             layer1Networks: layer1NetworksClone
             layer2Networks: layer2NetworksClone
             preferredNetworksMode: true
-            preferredSharingNetworks: d.preferredSharingNetworksArray
+            preferredSharingNetworks: root.preferredSharingNetworksArray
 
             useEnabledRole: false
 
             closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
 
             onToggleNetwork: (network, networkModel, index) => {
-                                 d.preferredSharingNetworksArray = RootStore.processPreferredSharingNetworkToggle( d.preferredSharingNetworksArray, network)
+                                 root.preferredSharingNetworksArray = RootStore.processPreferredSharingNetworkToggle(root.preferredSharingNetworksArray, network)
                              }
 
-            onClosed: RootStore.updateWalletAccountPreferredChains(root.address, d.preferredSharingNetworksArray.join(":"))
+            onClosed: RootStore.updateWalletAccountPreferredChains(root.address, root.preferredSharingNetworksArray.join(":"))
 
             CloneModel {
                 id: layer1NetworksClone

--- a/ui/imports/shared/views/RecipientView.qml
+++ b/ui/imports/shared/views/RecipientView.qml
@@ -139,6 +139,7 @@ Loader {
     Component {
         id: myAccountRecipient
         WalletAccountListItem {
+            property string chainShortNames: store.getNetworkShortNames(modelData.preferredSharingChainIds)
             implicitWidth: parent.width
             modelData: root.selectedRecipient
             radius: 8


### PR DESCRIPTION
#11743 

### What does the PR do

Fixes :
1. Send modal on choosing an account as recipient , the preferred networks should be chosen
2. The receive modal resets after updating sharing networks which is incorrect 
3. 
### Affected areas

Send and Receive Modal

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

https://github.com/status-im/status-desktop/assets/60327365/bb061e80-c152-4a3d-b26e-87bbfbc2caac

