### PR TITLE
feat(communities): add spectatedCommunityPermissionModel to communities

### DIFF
--- a/src/app/modules/main/communities/controller.nim
+++ b/src/app/modules/main/communities/controller.nim
@@ -187,6 +187,9 @@ proc getCommunityTags*(self: Controller): string =
 proc getAllCommunities*(self: Controller): seq[CommunityDto] =
   result = self.communityService.getAllCommunities()
 
+proc getCommunityById*(self: Controller, communityId: string): CommunityDto =
+  result = self.communityService.getCommunityById(communityId)
+
 proc getCuratedCommunities*(self: Controller): seq[CommunityDto] =
   result = self.communityService.getCuratedCommunities()
 

--- a/src/app/modules/main/communities/io_interface.nim
+++ b/src/app/modules/main/communities/io_interface.nim
@@ -200,3 +200,6 @@ method authenticateWithCallback*(self: AccessInterface) {.base.} =
 
 method callbackFromAuthentication*(self: AccessInterface, authenticated: bool) {.base.} =
   raise newException(ValueError, "No implementation available")
+
+method prepareTokenModelForCommunity*(self: AccessInterface, communityId: string) {.base.} =
+  raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/communities/module.nim
+++ b/src/app/modules/main/communities/module.nim
@@ -500,3 +500,14 @@ method authenticateWithCallback*(self: Module) =
 
 method callbackFromAuthentication*(self: Module, authenticated: bool) =
   self.view.callbackFromAuthentication(authenticated)
+
+method prepareTokenModelForCommunity*(self: Module, communityId: string) =
+  let community = self.controller.getCommunityById(communityId)
+  var tokenPermissionsItems: seq[TokenPermissionItem] = @[]
+
+  for id, tokenPermission in community.tokenPermissions:
+    let chats = self.controller.getChatDetailsByIds(tokenPermission.chatIDs)
+    let tokenPermissionItem = buildTokenPermissionItem(tokenPermission, chats)
+    tokenPermissionsItems.add(tokenPermissionItem)
+
+  self.view.spectatedCommunityPermissionModel.setItems(tokenPermissionsItems)

--- a/src/app/modules/main/communities/view.nim
+++ b/src/app/modules/main/communities/view.nim
@@ -1,7 +1,8 @@
 import NimQml, json, strutils, sequtils
 
 import ./io_interface
-import ../../shared_models/[section_model, section_item, section_details, token_list_model, token_list_item]
+import ../../shared_models/[section_model, section_item, section_details, token_list_model, token_list_item,
+  token_permissions_model]
 import ./models/curated_community_model
 import ./models/discord_file_list_model
 import ./models/discord_file_item
@@ -17,6 +18,8 @@ QtObject:
       delegate: io_interface.AccessInterface
       model: SectionModel
       modelVariant: QVariant
+      spectatedCommunityPermissionModel: TokenPermissionsModel
+      spectatedCommunityPermissionModelVariant: QVariant
       curatedCommunitiesModel: CuratedCommunityModel
       curatedCommunitiesModelVariant: QVariant
       curatedCommunitiesLoading: bool
@@ -51,6 +54,8 @@ QtObject:
   proc delete*(self: View) =
     self.model.delete
     self.modelVariant.delete
+    self.spectatedCommunityPermissionModel.delete
+    self.spectatedCommunityPermissionModelVariant.delete
     self.curatedCommunitiesModel.delete
     self.curatedCommunitiesModelVariant.delete
     self.discordFileListModel.delete
@@ -75,6 +80,8 @@ QtObject:
     result.delegate = delegate
     result.model = newModel()
     result.modelVariant = newQVariant(result.model)
+    result.spectatedCommunityPermissionModel = newTokenPermissionsModel()
+    result.spectatedCommunityPermissionModelVariant = newQVariant(result.spectatedCommunityPermissionModel)
     result.curatedCommunitiesModel = newCuratedCommunityModel()
     result.curatedCommunitiesModelVariant = newQVariant(result.curatedCommunitiesModel)
     result.curatedCommunitiesLoading = false
@@ -300,6 +307,18 @@ QtObject:
 
   QtProperty[QVariant] model:
     read = getModel
+
+  proc spectatedCommunityPermissionModel*(self: View): TokenPermissionsModel =
+    result = self.spectatedCommunityPermissionModel
+
+  proc prepareTokenModelForCommunity(self: View, communityId: string) {.slot.} =
+    self.delegate.prepareTokenModelForCommunity(communityId)
+
+  proc getSpectatedCommunityPermissionModel(self: View): QVariant {.slot.} =
+    return self.spectatedCommunityPermissionModelVariant
+
+  QtProperty[QVariant] spectatedCommunityPermissionModel:
+    read = getSpectatedCommunityPermissionModel
 
   proc curatedCommunitiesModel*(self: View): CuratedCommunityModel =
     result = self.curatedCommunitiesModel

--- a/ui/app/AppLayouts/Communities/stores/CommunitiesStore.qml
+++ b/ui/app/AppLayouts/Communities/stores/CommunitiesStore.qml
@@ -111,6 +111,10 @@ QtObject {
         root.communitiesModuleInst.spectateCommunity(publicKey, "");
     }
 
+    function prepareTokenModelForCommunity(publicKey) {
+        root.communitiesModuleInst.prepareTokenModelForCommunity(publicKey);
+    }
+
     function getCommunityDetails(communityId, importing = false) {
         const publicKey = Utils.isCompressedPubKey(communityId)
                             ? Utils.changeCommunityKeyCompression(communityId)

--- a/ui/imports/shared/popups/ImportCommunityPopup.qml
+++ b/ui/imports/shared/popups/ImportCommunityPopup.qml
@@ -24,9 +24,7 @@ StatusDialog {
         id: d
         property string importErrorMessage
         readonly property bool communityFound: (d.isPublicKey && !!d.communityDetails)
-        readonly property var communityDetails: {
-            return root.store.getCommunityDetails(Utils.getCompressedPk(publicKey));
-        }
+        readonly property var communityDetails: root.store.getCommunityDetails(publicKey)
         readonly property string inputErrorMessage: isInputValid ? "" : qsTr("Invalid key")
         readonly property string errorMessage: importErrorMessage || inputErrorMessage
         readonly property string inputKey: keyInput.text.trim()


### PR DESCRIPTION
Fixes #11732

Adds `spectatedCommunityPermissionModel` to the communities view. It is needed for the import popup to be able to show the permissions of a community when joining without first spectating.

How to use in QML:
```qml
            communitiesModuleInst.prepareTokenModelForCommunity(publicKey)
            const model = communitiesModuleInst.spectatedCommunityPermissionModel
```