### PR TITLE
chore: adapt to new collectibles api

### DIFF
--- a/src/app/modules/main/wallet_section/collectible_details/events_handler.nim
+++ b/src/app/modules/main/wallet_section/collectible_details/events_handler.nim
@@ -21,8 +21,8 @@ QtObject:
   proc delete*(self: EventsHandler) =
     self.QObject.delete
 
-  proc onGetCollectiblesDataDone*(self: EventsHandler, handler: EventCallbackProc) =
-    self.eventHandlers[backend_collectibles.eventGetCollectiblesDataDone] = handler
+  proc onGetCollectiblesDetailsDone*(self: EventsHandler, handler: EventCallbackProc) =
+    self.eventHandlers[backend_collectibles.eventGetCollectiblesDetailsDone] = handler
 
   proc handleApiEvents(self: EventsHandler, e: Args) =
     var data = WalletSignal(e)

--- a/src/app/modules/shared_models/collectible_details_entry.nim
+++ b/src/app/modules/shared_models/collectible_details_entry.nim
@@ -17,7 +17,7 @@ QtObject:
   type
     CollectibleDetailsEntry* = ref object of QObject
       id: backend.CollectibleUniqueID
-      data: backend.CollectibleData
+      data: backend.CollectibleDetails
       extradata: ExtraData
       traits: TraitModel
 
@@ -27,7 +27,7 @@ QtObject:
   proc delete*(self: CollectibleDetailsEntry) =
     self.QObject.delete
 
-  proc newCollectibleDetailsFullEntry*(data: backend.CollectibleData, extradata: ExtraData): CollectibleDetailsEntry =
+  proc newCollectibleDetailsFullEntry*(data: backend.CollectibleDetails, extradata: ExtraData): CollectibleDetailsEntry =
     new(result, delete)
     result.id = data.id
     result.data = data
@@ -45,6 +45,10 @@ QtObject:
 
   proc newCollectibleDetailsEmptyEntry*(): CollectibleDetailsEntry =
     let id = backend.CollectibleUniqueID(
+      contractID: backend.ContractID(
+        chainID: 0,
+        address: ""
+      ),
       tokenID: stint.u256(0)
     )
     let extradata = ExtraData()
@@ -59,13 +63,13 @@ QtObject:
     )"""
 
   proc getChainID*(self: CollectibleDetailsEntry): int {.slot.} =
-    return self.id.chainID
+    return self.id.contractID.chainID
 
   QtProperty[int] chainId:
     read = getChainID
 
   proc getContractAddress*(self: CollectibleDetailsEntry): string {.slot.} =
-    return self.id.contractAddress
+    return self.id.contractID.address
 
   QtProperty[string] contractAddress:
     read = getContractAddress
@@ -119,7 +123,7 @@ QtObject:
   proc getCollectionName*(self: CollectibleDetailsEntry): string {.slot.} =
     if self.data == nil:
       return ""
-    return self.data.collectionData.name
+    return self.data.collectionName
 
   QtProperty[string] collectionName:
     read = getCollectionName
@@ -135,7 +139,7 @@ QtObject:
   proc getCollectionImageURL*(self: CollectibleDetailsEntry): string {.slot.} =
     if self.data == nil:
       return ""
-    return self.data.collectionData.imageUrl
+    return self.data.collectionImageUrl
 
   QtProperty[string] collectionImageUrl:
     read = getCollectionImageURL

--- a/src/app/modules/shared_models/collectibles_utils.nim
+++ b/src/app/modules/shared_models/collectibles_utils.nim
@@ -10,8 +10,8 @@ proc collectibleToItem*(c: backend.CollectibleHeader, isPinned: bool = false) : 
     mediaType = "image"
 
   return initItem(
-    c.id.chainID,
-    c.id.contractAddress,
+    c.id.contractID.chainID,
+    c.id.contractID.address,
     c.id.tokenID,
     c.name,
     mediaUrl,

--- a/src/backend/collectibles.nim
+++ b/src/backend/collectibles.nim
@@ -14,7 +14,7 @@ const eventCollectiblesOwnershipUpdateFinished*: string = "wallet-collectibles-o
 const eventCollectiblesOwnershipUpdateFinishedWithError*: string = "wallet-collectibles-ownership-update-finished-with-error"
 
 const eventOwnedCollectiblesFilteringDone*: string = "wallet-owned-collectibles-filtering-done"
-const eventGetCollectiblesDataDone*: string = "wallet-get-collectibles-data-done"
+const eventGetCollectiblesDetailsDone*: string = "wallet-get-collectibles-details-done"
 
 type
   # Mirrors services/wallet/collectibles/service.go ErrorCode
@@ -30,9 +30,9 @@ type
     hasMore*: bool
     errorCode*: ErrorCode
 
-  # Mirrors services/wallet/collectibles/service.go GetCollectiblesDataResponse
-  GetCollectiblesDataResponse* = object
-    collectibles*: seq[CollectibleData]
+  # Mirrors services/wallet/collectibles/service.go GetCollectiblesDetailsResponse
+  GetCollectiblesDetailsResponse* = object
+    collectibles*: seq[CollectibleDetails]
     errorCode*: ErrorCode
 
 
@@ -53,12 +53,12 @@ proc fromJson*(e: JsonNode, T: typedesc[FilterOwnedCollectiblesResponse]): Filte
     errorCode: ErrorCode(e["errorCode"].getInt())
   )
 
-proc fromJson*(e: JsonNode, T: typedesc[GetCollectiblesDataResponse]): GetCollectiblesDataResponse {.inline.} =
-  var collectibles: seq[CollectibleData] = @[]
+proc fromJson*(e: JsonNode, T: typedesc[GetCollectiblesDetailsResponse]): GetCollectiblesDetailsResponse {.inline.} =
+  var collectibles: seq[CollectibleDetails] = @[]
   if e.hasKey("collectibles"):
     let jsonCollectibles = e["collectibles"]
     for item in jsonCollectibles.getElems():
-      collectibles.add(fromJson(item, CollectibleData))
+      collectibles.add(fromJson(item, CollectibleDetails))
 
   result = T(
     collectibles: collectibles,
@@ -91,5 +91,5 @@ rpc(filterOwnedCollectiblesAsync, "wallet"):
   offset: int
   limit: int
 
-rpc(getCollectiblesDataAsync, "wallet"):
+rpc(getCollectiblesDetailsAsync, "wallet"):
   uniqueIds: seq[CollectibleUniqueID]


### PR DESCRIPTION
Closes https://github.com/status-im/status-desktop/issues/10728
Status-go part: https://github.com/status-im/status-go/pull/3840

Bumps status-go
Adapt client to new Collectibles API

We should now be able to fetch collectibles from all chains we own:

![image](https://github.com/status-im/status-go/assets/11161531/706de096-15dc-47ca-8c02-311f04356c79)

![image](https://github.com/status-im/status-go/assets/11161531/efc05cfa-fe8b-4f2c-9bd5-51d53032df15)

- Infura (Used for Arb NFTs) doesn't provide Collection metadata we need (missing Collection Name + CollectionImageURL). Implementation of separate collection metadata fetching is left for another PR.
- We now have more than one provider for some chains, main+fallback providers mechanism for Collectibles ownership is left for another PR.