### PR TITLE
feat(Communities): Remote destruct, Ban and Kick actions for TokenMaster

### DIFF
--- a/storybook/pages/MintTokensSettingsPanelPage.qml
+++ b/storybook/pages/MintTokensSettingsPanelPage.qml
@@ -1,6 +1,8 @@
-import QtQuick 2.14
-import QtQuick.Controls 2.14
-import QtQuick.Layouts 1.14
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+import Qt.labs.settings 1.0
 
 import AppLayouts.Communities.panels 1.0
 import AppLayouts.Chat.stores 1.0
@@ -184,6 +186,12 @@ SplitView {
                 }
             }
         }
+    }
+
+    Settings {
+        property alias editorModelChecked: editorModelChecked.checked
+        property alias privilegedModelChecked: privilegedModelChecked.checked
+        property alias completeModelChecked: completeModelChecked.checked
     }
 }
 

--- a/storybook/pages/TokenMasterActionPopupPage.qml
+++ b/storybook/pages/TokenMasterActionPopupPage.qml
@@ -1,0 +1,147 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+import Qt.labs.settings 1.0
+
+import Storybook 1.0
+import Models 1.0
+
+import AppLayouts.Communities.popups 1.0
+
+
+SplitView {
+    orientation: Qt.Vertical
+
+    Logs { id: logs }
+
+    ListModel {
+        id: accountsModel
+
+        ListElement {
+            name: "Test account"
+            emoji: "😋"
+            address: "0x7F47C2e18a4BBf5487E6fb082eC2D9Ab0E6d7240"
+            color: "red"
+        }
+
+        ListElement {
+            name: "Another account - generated"
+            emoji: "🚗"
+            address: "0x7F47C2e98a4BBf5487E6fb082eC2D9Ab0E6d8888"
+            color: "blue"
+        }
+    }
+
+    Item {
+        id: content
+
+        SplitView.fillWidth: true
+        SplitView.fillHeight: true
+
+        PopupBackground {
+            anchors.fill: parent
+        }
+
+        Button {
+            anchors.centerIn: parent
+            text: "Reopen"
+
+            onClicked: dialog.open()
+        }
+
+        TokenMasterActionPopup {
+            id: dialog
+
+            parent: content
+            visible: true
+            closePolicy: Popup.NoAutoClose
+            anchors.centerIn: parent
+            modal: false
+
+            actionType: actionTypesRadioButtonGroup.checkedButton.actionType
+
+            accountsModel: accountsModel
+            communityName: "Doodles"
+            userName: "simon"
+            networkName: "Optimism"
+
+            isFeeLoading: feeLoadingCheckBox.checked
+            feeText: "0.0015 ETH ($75.43)"
+            feeErrorText: feeErrorCheckBox.checked ? "Some fee error" : ""
+
+            onRemotelyDestructClicked: logs.logEvent("onRemotelyDestructClicked")
+            onBanClicked: logs.logEvent("onBanClicked")
+            onKickClicked: logs.logEvent("onKickClicked")
+        }
+    }
+
+    LogsAndControlsPanel {
+        SplitView.minimumHeight: 100
+        SplitView.preferredHeight: 150
+
+        logsView.logText: logs.logText
+
+        ColumnLayout {
+            RowLayout {
+                CheckBox {
+                    id: feeLoadingCheckBox
+
+                    text: "Loading fee"
+                }
+
+                CheckBox {
+                    id: feeErrorCheckBox
+
+                    text: "Fee error"
+                }
+            }
+
+            ButtonGroup {
+                id: actionTypesRadioButtonGroup
+
+                buttons: actionTypesRow.children
+            }
+
+            RowLayout {
+                id: actionTypesRow
+
+                RadioButton {
+                    id: remotelyDestructRadioButton
+
+                    readonly property int actionType:
+                        TokenMasterActionPopup.ActionType.RemotelyDestruct
+
+                    text: "Remotely destruct"
+                    checked: true
+                }
+
+                RadioButton {
+                    id: kickRadioButton
+
+                    readonly property int actionType:
+                        TokenMasterActionPopup.ActionType.Kick
+
+                    text: "Kick"
+                }
+
+                RadioButton {
+                    id: banRadioButton
+
+                    readonly property int actionType:
+                        TokenMasterActionPopup.ActionType.Ban
+
+                    text: "Ban"
+                }
+            }
+        }
+    }
+
+    Settings {
+        property alias remotelyDestructRadioButtonChecked: remotelyDestructRadioButton.checked
+        property alias kickRadioButtonChecked: kickRadioButton.checked
+        property alias banRadioButtonChecked: banRadioButton.checked
+    }
+}
+
+// category: Popups

--- a/storybook/src/Models/MintedTokensModel.qml
+++ b/storybook/src/Models/MintedTokensModel.qml
@@ -4,6 +4,7 @@ ListModel {
     id: root
 
     readonly property ListModel tokenOwnersModel: TokenHoldersModel {}
+    readonly property ListModel emptyModel: ListModel {}
 
     readonly property var data: [
         {
@@ -24,7 +25,8 @@ ListModel {
             chainId: 2,
             chainName: "Optimism",
             chainIcon: ModelsData.networks.optimism,
-            accountName: "Another account - generated"
+            accountName: "Another account - generated",
+            tokenOwnersModel: root.emptyModel
         },
         {
             isPrivilegedToken: true,
@@ -44,7 +46,8 @@ ListModel {
             chainId: 2,
             chainName: "Optimism",
             chainIcon: ModelsData.networks.optimism,
-            accountName: "Another account - generated"
+            accountName: "Another account - generated",
+            tokenOwnersModel: root.tokenOwnersModel
         },
         {
             isPrivilegedToken: false,
@@ -64,7 +67,8 @@ ListModel {
             chainId: 1,
             chainName: "Testnet",
             chainIcon: ModelsData.networks.testnet,
-            accountName: "Status Account"
+            accountName: "Status Account",
+            tokenOwnersModel: root.emptyModel
         },
         {
             isPrivilegedToken: false,
@@ -84,7 +88,8 @@ ListModel {
             chainId: 2,
             chainName: "Optimism",
             chainIcon: ModelsData.networks.optimism,
-            accountName: "Status New Account"
+            accountName: "Status New Account",
+            tokenOwnersModel: root.emptyModel
         },
         {
             isPrivilegedToken: false,
@@ -104,7 +109,8 @@ ListModel {
             chainId: 5,
             chainName: "Custom",
             chainIcon: ModelsData.networks.custom,
-            accountName: "Other Account"
+            accountName: "Other Account",
+            tokenOwnersModel: root.emptyModel
         },
         {
             isPrivilegedToken: false,
@@ -144,7 +150,8 @@ ListModel {
             chainId: 2,
             chainName: "Optimism",
             chainIcon: ModelsData.networks.optimism,
-            accountName: "Status SNT Account"
+            accountName: "Status SNT Account",
+            tokenOwnersModel: root.emptyModel
         },
         {
             isPrivilegedToken: false,
@@ -163,7 +170,8 @@ ListModel {
             chainId: 1,
             chainName: "Testnet",
             chainIcon: ModelsData.networks.testnet,
-            accountName: "Status Account"
+            accountName: "Status Account",
+            tokenOwnersModel: root.emptyModel
         }
     ]
 

--- a/ui/app/AppLayouts/Communities/panels/MintTokensSettingsPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/MintTokensSettingsPanel.qml
@@ -540,8 +540,58 @@ StackView {
             }
 
             onRemoteDestructRequested: {
-                remotelyDestructPopup.open()
-                // TODO: set the address selected in the popup's list
+                if (token.isPrivilegedToken) {
+                    tokenMasterActionPopup.openPopup(
+                                TokenMasterActionPopup.ActionType.RemotelyDestruct, name)
+                } else {
+                    remotelyDestructPopup.open()
+                    // TODO: set the address selected in the popup's list
+                }
+            }
+
+            onBanRequested: {
+                tokenMasterActionPopup.openPopup(
+                            TokenMasterActionPopup.ActionType.Ban, name)
+            }
+
+            onKickRequested: {
+                tokenMasterActionPopup.openPopup(
+                            TokenMasterActionPopup.ActionType.Kick, name)
+            }
+
+            TokenMasterActionPopup {
+                id: tokenMasterActionPopup
+
+                communityName: root.communityName
+                networkName: view.token.chainName
+
+                accountsModel: SortFilterProxyModel {
+                    sourceModel: root.accounts
+                    proxyRoles: [
+                        ExpressionRole {
+                            name: "color"
+
+                            function getColor(colorId) {
+                                return Utils.getColorForId(colorId)
+                            }
+
+                            // Direct call for singleton function is not handled properly by
+                            // SortFilterProxyModel that's why helper function is used instead.
+                            expression: { return getColor(model.colorId) }
+                        }
+                    ]
+                    filters: ValueFilter {
+                        roleName: "walletType"
+                        value: Constants.watchWalletType
+                        inverted: true
+                    }
+                }
+
+                function openPopup(type, userName) {
+                    tokenMasterActionPopup.actionType = type
+                    tokenMasterActionPopup.userName = userName
+                    open()
+                }
             }
         }
 

--- a/ui/app/AppLayouts/Communities/panels/SortableTokenHoldersPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/SortableTokenHoldersPanel.qml
@@ -30,9 +30,9 @@ Control {
     signal viewProfileRequested(string address)
     signal viewMessagesRequested(string address)
     signal airdropRequested(string address)
-    signal remoteDestructRequested(string address)
-    signal kickRequested(string address)
-    signal banRequested(string address)
+    signal remoteDestructRequested(string name, string address)
+    signal kickRequested(string name, string address)
+    signal banRequested(string name, string address)
 
     signal generalAirdropRequested
 
@@ -134,11 +134,9 @@ Control {
                     return
 
                 const entry = ModelUtils.get(proxyModel, index)
-                const address = entry.walletAddress
-                const name = entry.name
 
-                menu.rawAddress = name === ""
-                menu.currentAddress = address
+                menu.name = entry.name
+                menu.currentAddress = entry.walletAddress
                 menu.popup(parent, mouse.x, mouse.y)
 
                 holdersList.currentIndex = index
@@ -149,8 +147,9 @@ Control {
     StatusMenu {
         id: menu
 
+        property string name
         property string currentAddress
-        property bool rawAddress
+        readonly property bool rawAddress: name === ""
 
         onClosed: holdersList.currentIndex = -1
 
@@ -190,7 +189,8 @@ Control {
             enabled: root.showRemotelyDestructMenuItem
             type: StatusBaseButton.Type.Danger
 
-            onTriggered: root.remoteDestructRequested(menu.currentAddress)
+            onTriggered: root.remoteDestructRequested(menu.name,
+                                                      menu.currentAddress)
         }
 
         StatusAction {
@@ -201,7 +201,8 @@ Control {
             enabled: !menu.rawAddress
             type: StatusBaseButton.Type.Danger
 
-            onTriggered: root.kickRequested(menu.currentAddress)
+            onTriggered: root.kickRequested(menu.name,
+                                            menu.currentAddress)
         }
 
         StatusAction {
@@ -212,7 +213,8 @@ Control {
             enabled: !menu.rawAddress
             type: StatusBaseButton.Type.Danger
 
-            onTriggered: root.banRequested(menu.currentAddress)
+            onTriggered: root.banRequested(menu.name,
+                                           menu.currentAddress)
         }
     }
 }

--- a/ui/app/AppLayouts/Communities/popups/TokenMasterActionPopup.qml
+++ b/ui/app/AppLayouts/Communities/popups/TokenMasterActionPopup.qml
@@ -1,0 +1,182 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+import QtQml.Models 2.15
+
+import StatusQ.Core 0.1
+import StatusQ.Controls 0.1
+import StatusQ.Popups.Dialog 0.1
+import StatusQ.Core.Theme 0.1
+
+import AppLayouts.Communities.panels 1.0
+
+import utils 1.0
+
+
+StatusDialog {
+    id: root
+
+    enum ActionType {
+        RemotelyDestruct, Kick, Ban
+    }
+
+    title: {
+        if (actionType === TokenMasterActionPopup.ActionType.Ban)
+            return qsTr("Ban %1").arg(userName)
+        if (actionType === TokenMasterActionPopup.ActionType.Kick)
+            return qsTr("Kick %1").arg(userName)
+
+        return qsTr("Remotely destruct TokenMaster token")
+    }
+
+    implicitWidth: 600
+
+    property int actionType: TokenMasterActionPopup.ActionType.RemotelyDestruct
+
+    property string communityName
+    property string userName
+    property string networkName
+
+    property string feeText
+    property string feeErrorText
+    property bool isFeeLoading
+    property var accountsModel
+
+    readonly property string feeLabel: qsTr("Remotely destruct 1 TokenMaster token on %1").arg(
+                                           root.networkName)
+
+    signal remotelyDestructClicked
+    signal kickClicked
+    signal banClicked
+
+    ColumnLayout {
+        anchors.fill: parent
+        spacing: 20
+
+        StatusBaseText {
+            Layout.fillWidth: true
+            text: {
+                if (root.actionType === TokenMasterActionPopup.ActionType.RemotelyDestruct)
+                    return qsTr('Continuing will destroy the TokenMaster token held by <span style="font-weight:600;">%1</span> and revoke the permissions they have by virtue of holding this token.')
+                        .arg(root.userName)
+
+                if (root.actionType === TokenMasterActionPopup.ActionType.Kick)
+                    return qsTr('Are you sure you kick <span style="font-weight:600;">%1</span> from %2? <span style="font-weight:600;">%1</span> is a TokenMaster hodler. In order to kick them you must also remotely destruct their TokenMaster token to revoke the permissions they have by virtue of holding this token.')
+                        .arg(root.userName).arg(root.communityName)
+
+                if (root.actionType === TokenMasterActionPopup.ActionType.Ban)
+                    return qsTr('Are you sure you ban <span style="font-weight:600;">%1</span> from %2? <span style="font-weight:600;">%1</span> is a TokenMaster hodler. In order to kick them you must also remotely destruct their TokenMaster token to revoke the permissions they have by virtue of holding this token.')
+                        .arg(root.userName).arg(root.communityName)
+            }
+
+            textFormat: Text.RichText
+            wrapMode: Text.Wrap
+            lineHeight: 22
+            lineHeightMode: Text.FixedHeight
+        }
+
+        Rectangle {
+            Layout.bottomMargin: 2
+            Layout.preferredHeight: 1
+            Layout.fillWidth: true
+
+            visible: root.actionType
+                     !== TokenMasterActionPopup.ActionType.RemotelyDestruct
+            color: Theme.palette.baseColor2
+        }
+
+        RowLayout {
+            visible: root.actionType === TokenMasterActionPopup.ActionType.Ban
+
+            StatusBaseText {
+                Layout.fillWidth: true
+
+                text: qsTr("Delete all messages posted by the user")
+                color: Theme.palette.directColor1
+                font.pixelSize: Theme.primaryTextFontSize
+            }
+
+            StatusSwitch {
+                id: deleteMessagesSwitch
+
+                checked: true
+                verticalPadding: 2
+            }
+        }
+
+        RowLayout {
+            Layout.bottomMargin: 2
+
+            visible: root.actionType
+                     !== TokenMasterActionPopup.ActionType.RemotelyDestruct
+
+            StatusBaseText {
+                Layout.fillWidth: true
+
+                text: qsTr("Remotely destruct 1 TokenMaster token")
+                color: Theme.palette.directColor1
+                font.pixelSize: Theme.primaryTextFontSize
+            }
+
+            StatusSwitch {
+                id: remotelyDestructSwitch
+
+                checked: true
+                enabled: false
+                verticalPadding: 2
+            }
+        }
+
+        FeesBox {
+            Layout.fillWidth: true
+
+            implicitWidth: 0
+
+            accountsSelector.model: root.accountsModel
+            accountErrorText: root.feeErrorText
+
+            model: QtObject {
+                id: singleFeeModel
+
+                readonly property string title: root.feeLabel
+                readonly property string feeText: root.isFeeLoading ?
+                                                      "" : root.feeText
+                readonly property bool error: root.feeErrorText !== ""
+            }
+        }
+    }
+
+    footer: StatusDialogFooter {
+        spacing: Style.current.padding
+
+        rightButtons: ObjectModel {
+            StatusFlatButton {
+                text: qsTr("Cancel")
+                onClicked: close()
+            }
+            StatusButton {
+                enabled: !root.isFeeLoading && root.feeErrorText === ""
+                         && root.feeText !== ""
+                text: {
+                    if (root.actionType === TokenMasterActionPopup.ActionType.Ban)
+                        return qsTr("Ban %1 and remotely destruct 1 token").arg(root.userName)
+
+                    if (root.actionType === TokenMasterActionPopup.ActionType.Kick)
+                        return qsTr("Kick %1 and remotely destruct 1 token").arg(root.userName)
+
+                    return qsTr("Remotely destruct 1 token")
+                }
+
+                type: StatusBaseButton.Type.Danger
+                onClicked: {
+                    if (root.actionType === TokenMasterActionPopup.ActionType.RemotelyDestruct)
+                        root.remotelyDestructClicked()
+                    else if (root.actionType === TokenMasterActionPopup.ActionType.Ban)
+                        root.banClicked()
+                    else if (root.actionType === TokenMasterActionPopup.ActionType.Kick)
+                        root.kickClicked()
+                }
+            }
+        }
+    }
+}

--- a/ui/app/AppLayouts/Communities/popups/qmldir
+++ b/ui/app/AppLayouts/Communities/popups/qmldir
@@ -1,7 +1,6 @@
 AlertPopup 1.0 AlertPopup.qml
 BurnTokensPopup 1.0 BurnTokensPopup.qml
 CommunityProfilePopup 1.0 CommunityProfilePopup.qml
-TokenPermissionsPopup 1.0 TokenPermissionsPopup.qml
 CreateCategoryPopup 1.0 CreateCategoryPopup.qml
 CreateChannelPopup 1.0 CreateChannelPopup.qml
 CreateCommunityPopup 1.0 CreateCommunityPopup.qml
@@ -15,7 +14,9 @@ MembersDropdown 1.0 MembersDropdown.qml
 PermissionsDropdown 1.0 PermissionsDropdown.qml
 RecipientTypeSelectionDropdown 1.0 RecipientTypeSelectionDropdown.qml
 RemotelyDestructPopup 1.0 RemotelyDestructPopup.qml
+SharedAddressesPopup 1.0 SharedAddressesPopup.qml
 SignMultiTokenTransactionsPopup 1.0 SignMultiTokenTransactionsPopup.qml
 SignTokenTransactionsPopup 1.0 SignTokenTransactionsPopup.qml
+TokenMasterActionPopup 1.0 TokenMasterActionPopup.qml
+TokenPermissionsPopup 1.0 TokenPermissionsPopup.qml
 TransferOwnershipPopup 1.0 TransferOwnershipPopup.qml
-SharedAddressesPopup 1.0 SharedAddressesPopup.qml

--- a/ui/app/AppLayouts/Communities/views/CommunityTokenView.qml
+++ b/ui/app/AppLayouts/Communities/views/CommunityTokenView.qml
@@ -67,7 +67,9 @@ StatusScrollView {
     signal airdropRequested(string address)
     signal generalAirdropRequested
 
-    signal remoteDestructRequested(string address)
+    signal remoteDestructRequested(string name, string address)
+    signal kickRequested(string name, string address)
+    signal banRequested(string name, string address)
 
     signal deployFeesRequested
 
@@ -150,8 +152,6 @@ StatusScrollView {
             accountErrorText: root.feeErrorText
 
             model: QtObject {
-                id: singleFeeModel
-
                 readonly property string title: root.feeLabel
                 readonly property string feeText: root.isFeeLoading ?
                                                       "" : root.feeText
@@ -159,7 +159,7 @@ StatusScrollView {
             }
 
             accountsSelector.model: SortFilterProxyModel {
-                sourceModel: root.accounts
+                sourceModel: root.accounts || null
                 proxyRoles: [
                     ExpressionRole {
                         name: "color"
@@ -230,7 +230,10 @@ StatusScrollView {
 
             onAirdropRequested: root.airdropRequested(address)
             onGeneralAirdropRequested: root.generalAirdropRequested()
-            onRemoteDestructRequested: root.remoteDestructRequested(address)
+            onRemoteDestructRequested: root.remoteDestructRequested(name, address)
+
+            onKickRequested: root.kickRequested(name, address)
+            onBanRequested: root.banRequested(name, address)
         }
     }
 }


### PR DESCRIPTION
### What does the PR do

Adds popups for handling `Remote destruct`, `Kick` and `Ban` actions for `TokenMaster`

Closes: #11622

### Affected areas
`MintTokensSettingsPanel`

<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![Screenshot from 2023-08-02 17-11-36](https://github.com/status-im/status-desktop/assets/20650004/887b888b-ef5b-45ee-944d-0a47057b1d48)
![Screenshot from 2023-08-02 17-11-42](https://github.com/status-im/status-desktop/assets/20650004/9a64ee33-c5bb-4671-b31b-3b2c410415f8)
![Screenshot from 2023-08-02 17-11-50](https://github.com/status-im/status-desktop/assets/20650004/c2a6a796-599f-45f9-b491-66001ec10f87)
