### PR TITLE
token-permissions: implement the UI "edit" flow for shared addresses

### DIFF
--- a/storybook/pages/SharedAddressesPopupPage.qml
+++ b/storybook/pages/SharedAddressesPopupPage.qml
@@ -26,13 +26,29 @@ SplitView {
             loginType: ctrlLoginType.currentIndex
             walletAccountsModel: WalletAccountsModel {}
             permissionsModel: {
-                if (ctrlPermissions.checked && ctrlTokenGatedChannels.checked)
+                if (ctrlPermissions.checked && ctrlTokenGatedChannels.checked) {
+                    if (selectedSharedAddresses.length === 1 && ctrlEditMode.checked) {
+                        console.warn("Simulation: Losing BOTH the join and VIP read channel permissions !!!")
+                        return PermissionsModel.complexCombinedPermissionsModelNotMet
+                    }
+                    return PermissionsModel.complexCombinedPermissionsModel
+                }
+                if (ctrlPermissions.checked) {
+                    if (selectedSharedAddresses.length === 1 && ctrlEditMode.checked) {
+                        console.warn("Simulation: Losing the join community permission !!!")
+                        return PermissionsModel.complexPermissionsModelNotMet
+                    }
                     return PermissionsModel.complexPermissionsModel
-                if (ctrlPermissions.checked)
-                    return PermissionsModel.permissionsModel
-                if (ctrlTokenGatedChannels.checked)
+                }
+                if (ctrlTokenGatedChannels.checked) {
+                    if (selectedSharedAddresses.length === 1 && ctrlEditMode.checked) {
+                        console.warn("Simulation: Losing the VIP read channel permission !!!")
+                        return PermissionsModel.channelsOnlyPermissionsModelNotMet
+                    }
                     return PermissionsModel.channelsOnlyPermissionsModel
+                }
 
+                console.warn("!!! EMPTY MODEL !!!")
                 return emptyModel
             }
 
@@ -40,7 +56,18 @@ SplitView {
             collectiblesModel: CollectiblesModel {}
             visible: true
 
+            Binding on selectedSharedAddresses {
+                value: ["0x7F47C2e18a4BBf5487E6fb082eC2D9Ab0E6d7240", "0x7F47C2e98a4BBf5487E6fb082eC2D9Ab0E6d8881", "0x7F47C2e98a4BBf5487E6fb082eC2D9Ab0E6d8884"]
+                when: ctrlEditMode.checked
+            }
+
+            Binding on selectedAirdropAddress {
+                value: "0x7F47C2e98a4BBf5487E6fb082eC2D9Ab0E6d8881"
+                when: ctrlEditMode.checked
+            }
+
             onShareSelectedAddressesClicked: logs.logEvent("::shareSelectedAddressesClicked", ["airdropAddress", "sharedAddresses"], arguments)
+            onSaveSelectedAddressesClicked: logs.logEvent("::saveSelectedAddressesClicked", ["airdropAddress", "sharedAddresses"], arguments)
             onClosed: destroy()
         }
     }

--- a/storybook/src/Models/PermissionsModel.qml
+++ b/storybook/src/Models/PermissionsModel.qml
@@ -28,6 +28,23 @@ QtObject {
         }
     ]
 
+    readonly property var permissionsModelDataNotMet: [
+        {
+            holdingsListModel: root.createHoldingsModel1(),
+            channelsListModel: root.createChannelsModel1(),
+            permissionType: PermissionTypes.Type.Admin,
+            isPrivate: true,
+            tokenCriteriaMet: false
+        },
+        {
+            holdingsListModel: root.createHoldingsModel1(),
+            channelsListModel: root.createChannelsModel2(),
+            permissionType: PermissionTypes.Type.Member,
+            isPrivate: false,
+            tokenCriteriaMet: false
+        }
+    ]
+
     readonly property var shortPermissionsModelData: [
         {
             holdingsListModel: root.createHoldingsModel4(),
@@ -197,6 +214,41 @@ QtObject {
         }
     ]
 
+    readonly property var complexPermissionsModelDataNotMet: [
+        {
+            id: "admin1",
+            holdingsListModel: root.createHoldingsModel1(),
+            channelsListModel: root.createChannelsModel2(),
+            permissionType: PermissionTypes.Type.Admin,
+            isPrivate: false,
+            tokenCriteriaMet: false
+        },
+        {
+            id: "admin2",
+            holdingsListModel: root.createHoldingsModel3(),
+            channelsListModel: root.createChannelsModel2(),
+            permissionType: PermissionTypes.Type.Admin,
+            isPrivate: false,
+            tokenCriteriaMet: false
+        },
+        {
+            id: "member1",
+            holdingsListModel: root.createHoldingsModel1(),
+            channelsListModel: root.createChannelsModel2(),
+            permissionType: PermissionTypes.Type.Member,
+            isPrivate: false,
+            tokenCriteriaMet: false
+        },
+        {
+            id: "member2",
+            holdingsListModel: root.createHoldingsModel4(),
+            channelsListModel: root.createChannelsModel2(),
+            permissionType: PermissionTypes.Type.Member,
+            isPrivate: false,
+            tokenCriteriaMet: false
+        }
+    ]
+
     readonly property var channelsOnlyPermissionsModelData: [
         {
             id: "read1a",
@@ -290,6 +342,89 @@ QtObject {
         }
     ]
 
+    readonly property var channelsOnlyPermissionsModelDataNotMet: [
+        {
+            id: "read1a",
+            holdingsListModel: root.createHoldingsModel1b(),
+            channelsListModel: root.createChannelsModel1(),
+            permissionType: PermissionTypes.Type.Read,
+            isPrivate: false,
+            tokenCriteriaMet: true
+        },
+        {
+            id: "read1b",
+            holdingsListModel: root.createHoldingsModel1(),
+            channelsListModel: root.createChannelsModel1(),
+            permissionType: PermissionTypes.Type.Read,
+            isPrivate: false,
+            tokenCriteriaMet: false
+        },
+        {
+            id: "read1c",
+            holdingsListModel: root.createHoldingsModel3(),
+            channelsListModel: root.createChannelsModel1(),
+            permissionType: PermissionTypes.Type.Read,
+            isPrivate: false,
+            tokenCriteriaMet: false
+        },
+        {
+            id: "read2a",
+            holdingsListModel: root.createHoldingsModel1(),
+            channelsListModel: root.createChannelsModel3(),
+            permissionType: PermissionTypes.Type.Read,
+            isPrivate: false,
+            tokenCriteriaMet: false
+        },
+        {
+            id: "read2b",
+            holdingsListModel: root.createHoldingsModel3(),
+            channelsListModel: root.createChannelsModel3(),
+            permissionType: PermissionTypes.Type.Read,
+            isPrivate: false,
+            tokenCriteriaMet: false
+        },
+        {
+            id: "viewAndPost1a",
+            holdingsListModel: root.createHoldingsModel3(),
+            channelsListModel: root.createChannelsModel1(),
+            permissionType: PermissionTypes.Type.ViewAndPost,
+            isPrivate: false,
+            tokenCriteriaMet: false
+        },
+        {
+            id: "viewAndPost1b",
+            holdingsListModel: root.createHoldingsModel2b(),
+            channelsListModel: root.createChannelsModel1(),
+            permissionType: PermissionTypes.Type.ViewAndPost,
+            isPrivate: false,
+            tokenCriteriaMet: true
+        },
+        {
+            id: "viewAndPost2a",
+            holdingsListModel: root.createHoldingsModel3(),
+            channelsListModel: root.createChannelsModel3(),
+            permissionType: PermissionTypes.Type.ViewAndPost,
+            isPrivate: false,
+            tokenCriteriaMet: false
+        },
+        {
+            id: "viewAndPost2b",
+            holdingsListModel: root.createHoldingsModel5(),
+            channelsListModel: root.createChannelsModel3(),
+            permissionType: PermissionTypes.Type.ViewAndPost,
+            isPrivate: false,
+            tokenCriteriaMet: false
+        },
+        {
+            id: "viewAndPost2c",
+            holdingsListModel: root.createHoldingsModel1(),
+            channelsListModel: root.createChannelsModel3(),
+            permissionType: PermissionTypes.Type.ViewAndPost,
+            isPrivate: false,
+            tokenCriteriaMet: false
+        }
+    ]
+
     readonly property ListModel permissionsModel: ListModel {
         readonly property ModelChangeGuard guard: ModelChangeGuard {
             model: root.permissionsModel
@@ -297,6 +432,17 @@ QtObject {
 
         Component.onCompleted: {
             append(permissionsModelData)
+            guard.enabled = true
+        }
+    }
+
+    readonly property ListModel permissionsModelNotMet: ListModel {
+        readonly property ModelChangeGuard guard: ModelChangeGuard {
+            model: root.permissionsModelNotMet
+        }
+
+        Component.onCompleted: {
+            append(permissionsModelDataNotMet)
             guard.enabled = true
         }
     }
@@ -367,6 +513,30 @@ QtObject {
         }
     }
 
+    readonly property var complexCombinedPermissionsModel: ListModel {
+        readonly property ModelChangeGuard guard: ModelChangeGuard {
+            model: root.complexCombinedPermissionsModel
+        }
+
+        Component.onCompleted: {
+            append(complexPermissionsModelData)
+            append(channelsOnlyPermissionsModelData)
+            guard.enabled = true
+        }
+    }
+
+    readonly property var complexCombinedPermissionsModelNotMet: ListModel {
+        readonly property ModelChangeGuard guard: ModelChangeGuard {
+            model: root.complexCombinedPermissionsModelNotMet
+        }
+
+        Component.onCompleted: {
+            append(complexPermissionsModelDataNotMet)
+            append(channelsOnlyPermissionsModelDataNotMet)
+            guard.enabled = true
+        }
+    }
+
     readonly property var complexPermissionsModel: ListModel {
         readonly property ModelChangeGuard guard: ModelChangeGuard {
             model: root.complexPermissionsModel
@@ -374,7 +544,17 @@ QtObject {
 
         Component.onCompleted: {
             append(complexPermissionsModelData)
-            append(channelsOnlyPermissionsModelData)
+            guard.enabled = true
+        }
+    }
+
+    readonly property var complexPermissionsModelNotMet: ListModel {
+        readonly property ModelChangeGuard guard: ModelChangeGuard {
+            model: root.complexPermissionsModelNotMet
+        }
+
+        Component.onCompleted: {
+            append(complexPermissionsModelDataNotMet)
             guard.enabled = true
         }
     }
@@ -386,6 +566,17 @@ QtObject {
 
         Component.onCompleted: {
             append(channelsOnlyPermissionsModelData)
+            guard.enabled = true
+        }
+    }
+
+    readonly property var channelsOnlyPermissionsModelNotMet: ListModel {
+        readonly property ModelChangeGuard guard: ModelChangeGuard {
+            model: root.channelsOnlyPermissionsModelNotMet
+        }
+
+        Component.onCompleted: {
+            append(channelsOnlyPermissionsModelDataNotMet)
             guard.enabled = true
         }
     }

--- a/ui/StatusQ/include/StatusQ/modelutilsinternal.h
+++ b/ui/StatusQ/include/StatusQ/modelutilsinternal.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <QJSValue>
 #include <QObject>
 #include <QString>
 #include <QVariant>
@@ -27,6 +28,10 @@ public:
                              const QString &roleName) const;
 
     Q_INVOKABLE bool contains(QAbstractItemModel *model, const QString &roleName, const QVariant &value, int mode = Qt::CaseSensitive) const;
+
+    ///< performs a strict check whether @lhs and @rhs arrays (QList<T>) contain the same elements;
+    /// eg. `["a", "c", "b"]` and `["b", "c", "a"]` are considered equal
+    Q_INVOKABLE bool isSameArray(const QJSValue& lhs, const QJSValue& rhs) const;
 
     static QObject* qmlInstance(QQmlEngine *engine, QJSEngine *scriptEngine)
     {

--- a/ui/StatusQ/include/StatusQ/permissionutilsinternal.h
+++ b/ui/StatusQ/include/StatusQ/permissionutilsinternal.h
@@ -15,7 +15,7 @@ public:
     //!< traverse the permissions @p model, and look for unique token keys recursively under holdingsListModel->key
     Q_INVOKABLE QStringList getUniquePermissionTokenKeys(QAbstractItemModel *model) const;
 
-    //!< traverse the permissions @p model, and look for unique channels recursively under channelsListModel->key; filtering out @permissionTypes ([PermissionTypes.Type.FOO])
-    //! @return an array of array<key,channelName>
+    //!< traverse the permissions @p model, and look for unique channels recursively under channelsListModel->key; filtering out @p permissionTypes ([PermissionTypes.Type.FOO])
+    //! @return an array of `array<key,channelName>`, sorted by `channelName`
     Q_INVOKABLE QJsonArray getUniquePermissionChannels(QAbstractItemModel *model, const QList<int> &permissionTypes = {}) const;
 };

--- a/ui/StatusQ/src/modelutilsinternal.cpp
+++ b/ui/StatusQ/src/modelutilsinternal.cpp
@@ -72,3 +72,20 @@ bool ModelUtilsInternal::contains(QAbstractItemModel* model,
     const auto indexes = model->match(model->index(0, 0), roleByName(model, roleName), value, 1, flags);
     return !indexes.isEmpty();
 }
+
+bool ModelUtilsInternal::isSameArray(const QJSValue& lhs, const QJSValue& rhs) const
+{
+    if (!lhs.isArray() || !rhs.isArray())
+        return false;
+
+    auto left = lhs.toVariant().toStringList();
+    auto right = rhs.toVariant().toStringList();
+
+    if (left.size() != right.size())
+        return false;
+
+    left.sort();
+    right.sort();
+
+    return left == right;
+}

--- a/ui/app/AppLayouts/Chat/ChatLayout.qml
+++ b/ui/app/AppLayouts/Chat/ChatLayout.qml
@@ -65,7 +65,7 @@ StackLayout {
             viewAndPostHoldingsModel: root.permissionsStore.viewAndPostPermissionsModel
             assetsModel: root.rootStore.assetsModel
             collectiblesModel: root.rootStore.collectiblesModel
-            isInvitationPending: root.rootStore.isCommunityRequestPending(communityData.id)
+            isInvitationPending: root.rootStore.isCommunityRequestPending(communityId)
             notificationCount: activityCenterStore.unreadNotificationsCount
             hasUnseenNotifications: activityCenterStore.hasUnseenNotifications
             openCreateChat: rootStore.openCreateChat
@@ -74,7 +74,7 @@ StackLayout {
             onAdHocChatButtonClicked: rootStore.openCloseCreateChatView()
             onRevealAddressClicked: {
                 Global.openPopup(communityIntroDialogPopup, {
-                    communityId: communityData.id,
+                    communityId: joinCommunityView.communityId,
                     isInvitationPending: joinCommunityView.isInvitationPending,
                     name: communityData.name,
                     introMessage: communityData.introMessage,
@@ -83,15 +83,15 @@ StackLayout {
                 })
             }
             onInvitationPendingClicked: {
-                root.rootStore.cancelPendingRequest(communityData.id)
-                joinCommunityView.isInvitationPending = root.rootStore.isCommunityRequestPending(communityData.id)
+                root.rootStore.cancelPendingRequest(communityId)
+                joinCommunityView.isInvitationPending = root.rootStore.isCommunityRequestPending(communityId)
             }
 
             Connections {
                 target: root.rootStore.communitiesModuleInst
                 function onCommunityAccessRequested(communityId: string) {
-                    if (communityId === joinCommunityView.communityData.id) {
-                        joinCommunityView.isInvitationPending = root.rootStore.isCommunityRequestPending(communityData.id)
+                    if (communityId === joinCommunityView.communityId) {
+                        joinCommunityView.isInvitationPending = root.rootStore.isCommunityRequestPending(communityId)
                     }
                 }
             }

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -670,7 +670,7 @@ QtObject {
         target: mainModuleInst
         enabled: !!chatCommunitySectionModule
         function onOpenCommunityMembershipRequestsView(sectionId: string) {
-            if(root.getMySectionId() != sectionId)
+            if(root.getMySectionId() !== sectionId)
                 return
 
             root.goToMembershipRequestsPage()
@@ -703,6 +703,7 @@ QtObject {
                 readonly property string id: model.id
                 readonly property int sectionType: model.sectionType
                 readonly property string name: model.name
+                readonly property string image: model.image
                 readonly property bool joined: model.joined
                 readonly property bool amIBanned: model.amIBanned
                 // add others when needed..

--- a/ui/app/AppLayouts/Communities/helpers/PermissionsHelpers.qml
+++ b/ui/app/AppLayouts/Communities/helpers/PermissionsHelpers.qml
@@ -69,7 +69,6 @@ QtObject {
     }
 
     function getUniquePermissionChannels(model, permissionsTypesArray = []) {
-        // TODO return a QVariantMap (https://github.com/status-im/status-desktop/issues/11481)
         return Internal.PermissionUtils.getUniquePermissionChannels(model, permissionsTypesArray)
     }
 

--- a/ui/app/AppLayouts/Communities/panels/SharedAddressesAccountSelector.qml
+++ b/ui/app/AppLayouts/Communities/panels/SharedAddressesAccountSelector.qml
@@ -18,8 +18,10 @@ StatusListView {
     property var uniquePermissionTokenKeys
 
     // read/write properties
-    property string selectedAirdropAddress: selectedSharedAddresses.length ? selectedSharedAddresses[0] : ""
-    property var selectedSharedAddresses: count ? ModelUtils.modelToFlatArray(model, "address") : []
+    property string selectedAirdropAddress
+    property var selectedSharedAddresses: []
+
+    signal addressesChanged()
 
     leftMargin: d.absLeftMargin
     topMargin: Style.current.padding
@@ -105,6 +107,7 @@ StatusListView {
                 visible: shareAddressCheckbox.checked
                 opacity: enabled ? 1.0 : 0.3
                 onCheckedChanged: if (checked) root.selectedAirdropAddress = model.address
+                onToggled: root.addressesChanged()
 
                 StatusToolTip {
                     text: qsTr("Use this address for any Community airdrops")
@@ -134,6 +137,8 @@ StatusListView {
                     if (!checked && model.address === root.selectedAirdropAddress) {
                         d.selectFirstAvailableAirdropAddress()
                     }
+
+                    root.addressesChanged()
                 }
             }
         ]

--- a/ui/app/AppLayouts/Communities/popups/SharedAddressesPopup.qml
+++ b/ui/app/AppLayouts/Communities/popups/SharedAddressesPopup.qml
@@ -20,10 +20,11 @@ StatusDialog {
     required property var assetsModel
     required property var collectiblesModel
 
-    readonly property string selectedAirdropAddress: panel.selectedAirdropAddress
-    readonly property var selectedSharedAddresses: panel.selectedSharedAddresses
+    property alias selectedSharedAddresses: panel.selectedSharedAddresses
+    property alias selectedAirdropAddress: panel.selectedAirdropAddress
 
     signal shareSelectedAddressesClicked(string airdropAddress, var sharedAddresses)
+    signal saveSelectedAddressesClicked(string airdropAddress, var sharedAddresses)
 
     title: panel.title
     implicitWidth: 640 // by design
@@ -40,6 +41,7 @@ StatusDialog {
         assetsModel: root.assetsModel
         collectiblesModel: root.collectiblesModel
         onShareSelectedAddressesClicked: root.shareSelectedAddressesClicked(airdropAddress, sharedAddresses)
+        onSaveSelectedAddressesClicked: root.saveSelectedAddressesClicked(airdropAddress, sharedAddresses)
         onClose: root.close()
     }
 

--- a/ui/app/AppLayouts/Profile/panels/CommunitiesListPanel.qml
+++ b/ui/app/AppLayouts/Profile/panels/CommunitiesListPanel.qml
@@ -128,7 +128,6 @@ StatusListView {
                         onTriggered: {
                             moreMenu.close()
                             Global.openEditSharedAddressesFlow(model.id)
-                            // TODO shared addresses flow, cf https://github.com/status-im/status-desktop/issues/11138
                         }
                     }
                     StatusMenuSeparator {


### PR DESCRIPTION
### What does the PR do

- makes `selectedSharedAddresses` and `selectedAirdropAddress` properties writable so that it's possible to pass these addresses to the popup upon opening
- makes the "Save" button change its icon and warning state based on the changes made
- `SharedAddressesPermissionsPanel` recalculates the overall and individual permission states based on modifications in the permissions model
- adds the possibility to start the whole "edit" flow from AppMain/Navbar context menu and Settings/Communities
- added some additional storybook models variations to simulate the loss of either channel or community level permissions (happens on unselecting all but last wallet address)
- added a C++ helper method `ModelUtilsInternal::isSameArray(a,b)` to compare JS 2D arrays for same elements

Actual implementation depends on:
- https://github.com/status-im/status-desktop/issues/11480
- https://github.com/status-im/status-desktop/issues/11822

Fixes #11599

### Affected areas

AppMain/Navbar, Settings/Communities

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

Navbar context menu:
![image](https://github.com/status-im/status-desktop/assets/5377645/de83b85f-7104-4a67-9b31-28f9ecbee878)

Settings/Communities:
![image](https://github.com/status-im/status-desktop/assets/5377645/6b76a262-b6d8-4d39-ad35-ad73f3a77869)

Popup:
![image](https://github.com/status-im/status-desktop/assets/5377645/7571ee3a-38cf-4149-80d0-277be9bd02d9)

### Cool Spaceship Picture

<!-- optional but cool ->
