### PR TITLE
ci: pass RELEASE parameter to child jobs from parent

### DIFF
--- a/ci/Jenkinsfile.combined
+++ b/ci/Jenkinsfile.combined
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.7.10'
+library 'status-jenkins-lib@v1.7.11'
 
 pipeline {
   agent { label 'linux' }

--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.7.10'
+library 'status-jenkins-lib@v1.7.11'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.7.10'
+library 'status-jenkins-lib@v1.7.11'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/Jenkinsfile.tests-e2e
+++ b/ci/Jenkinsfile.tests-e2e
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.7.10'
+library 'status-jenkins-lib@v1.7.11'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/Jenkinsfile.tests-imports
+++ b/ci/Jenkinsfile.tests-imports
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.7.10'
+library 'status-jenkins-lib@v1.7.11'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/Jenkinsfile.tests-nim
+++ b/ci/Jenkinsfile.tests-nim
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.7.10'
+library 'status-jenkins-lib@v1.7.11'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/Jenkinsfile.windows
+++ b/ci/Jenkinsfile.windows
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.7.10'
+library 'status-jenkins-lib@v1.7.11'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/cpp/Jenkinsfile.linux
+++ b/ci/cpp/Jenkinsfile.linux
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.7.10'
+library 'status-jenkins-lib@v1.7.11'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/cpp/Jenkinsfile.macos
+++ b/ci/cpp/Jenkinsfile.macos
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.7.10'
+library 'status-jenkins-lib@v1.7.11'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()

--- a/ci/cpp/Jenkinsfile.windows
+++ b/ci/cpp/Jenkinsfile.windows
@@ -1,4 +1,4 @@
-library 'status-jenkins-lib@v1.7.10'
+library 'status-jenkins-lib@v1.7.11'
 
 /* Options section can't access functions in objects. */
 def isPRBuild = utils.isPRBuild()


### PR DESCRIPTION
This is a possible fix for issues with `x86_64` app failures:
- https://github.com/status-im/status-desktop/issues/11762

Most probably caused by some jobs remembering `RELEASE` parameter, manifesting partially in the filename:

![image](https://github.com/status-im/status-desktop/assets/2212681/fde3fe51-4afc-4505-8a57-e58fbd226292)