### PR TITLE
fix(StatusDropdown, StatusDialog): height calculation improved

### DIFF
--- a/storybook/pages/PopupSizingPage.qml
+++ b/storybook/pages/PopupSizingPage.qml
@@ -48,6 +48,15 @@ Item {
             when: false
         }
 
+        onImplicitContentHeightChanged: {
+            if (!workAroundCheckBox.checked)
+                return
+
+            workaroundBinding.value = popup.margins + 1
+            workaroundBinding.when = true
+            workaroundBinding.when = false
+        }
+
         ColumnLayout {
             Button {
                 text: "Some button 1"
@@ -58,15 +67,6 @@ Item {
                 text: "Some button 2"
 
                  Layout.fillWidth: true
-            }
-
-            onImplicitHeightChanged: {
-                if (!workAroundCheckBox.checked)
-                    return
-
-                workaroundBinding.value = popup.margins + 1
-                workaroundBinding.when = true
-                workaroundBinding.when = false
             }
 
             anchors.fill: parent

--- a/ui/StatusQ/src/StatusQ/Controls/StatusDropdown.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusDropdown.qml
@@ -57,13 +57,9 @@ QC.Popup {
         restoreMode: Binding.RestoreBindingOrValue
     }
 
-    Connections {
-        target: root.contentItem
-
-        function onImplicitHeightChanged() {
-            workaroundBinding.value = root.margins + 1
-            workaroundBinding.when = true
-            workaroundBinding.when = false
-        }
+    onImplicitContentHeightChanged: {
+        workaroundBinding.value = root.margins + 1
+        workaroundBinding.when = true
+        workaroundBinding.when = false
     }
 }

--- a/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusDialog.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/Dialog/StatusDialog.qml
@@ -37,6 +37,12 @@ Dialog {
         restoreMode: Binding.RestoreBindingOrValue
     }
 
+    onImplicitContentHeightChanged: {
+        workaroundBinding.value = root.margins + 1
+        workaroundBinding.when = true
+        workaroundBinding.when = false
+    }
+
     standardButtons: Dialog.Cancel | Dialog.Ok
 
     Overlay.modal: Rectangle {

--- a/ui/imports/shared/popups/SendModal.qml
+++ b/ui/imports/shared/popups/SendModal.qml
@@ -167,12 +167,6 @@ StatusDialog {
 
         anchors.fill: parent
 
-        // Workaround for https://bugreports.qt.io/browse/QTBUG-87804
-        onImplicitHeightChanged: {
-            margins--
-            margins++
-        }
-
         ClippingWrapper {
             Layout.fillWidth: true
             Layout.preferredHeight: assetAndAmountSelector.implicitHeight


### PR DESCRIPTION
### What does the PR do

It improves workaround for QTBUG-87804 in `StatusDropdown`, to work nicely whenever content is set via contentItem or not. The same solution is added to `StatusDialog`.

Closes: #11768

### Affected areas
`StatusDropdown`, `StatusDialog`

