### PR TITLE
fix(MembersdSelectorView): fix the logic of opening CR popup

### DIFF
--- a/ui/app/AppLayouts/Chat/views/MembersSelectorView.qml
+++ b/ui/app/AppLayouts/Chat/views/MembersSelectorView.qml
@@ -86,13 +86,6 @@ MembersSelectorBase {
         }
 
         function processContact(contactData) {
-            // Open contact request if we have data from url
-            if (contactData.publicKey !== "" && contactData.displayName !== "") {
-                Global.openContactRequestPopupWithContactData(contactData,
-                                                              popup => popup.closed.connect(root.rejected))
-                return
-            }
-
             const contactDetails = Utils.getContactDetailsAsJson(contactData.publicKey, false)
             if (contactDetails.publicKey === "") {
                 // not a valid key given
@@ -121,8 +114,18 @@ MembersSelectorBase {
 
             if (root.model.count === 0 && !hasPendingContactRequest) {
                 // List is empty and not a contact yet. Open the contact request popup
-                Global.openContactRequestPopup(contactDetails.publicKey,
-                                               popup => popup.closed.connect(root.rejected))
+
+                // If `displayName` is not undefiend and not empty,
+                // then we open the popup with given `contactData`, which probably came from URL.
+                if (contactData.displayName) {
+                    // Open contact request if we have data from url
+                    Global.openContactRequestPopupWithContactData(contactData,
+                                                                  popup => popup.closed.connect(root.rejected))
+                    
+                } else {
+                    Global.openContactRequestPopup(contactDetails.publicKey,
+                                                   popup => popup.closed.connect(root.rejected))
+                }
                 return
             }
 
@@ -171,7 +174,7 @@ MembersSelectorBase {
                 root.suggestionsDialog.forceHide = false
                 return
             }
-            d.processContact(resolvedPubKey)
+            d.processContact({publicKey: resolvedPubKey})
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/11778

### What does the PR do

1. Fix opening the CR popup for ENS name
- pass `contactData` object to `processContact`
https://github.com/status-im/status-desktop/blob/e97f77621457be3b42dcb7297140cda3bac14575/ui/app/AppLayouts/Chat/views/MembersSelectorView.qml#L177
- change check `contactData.displayName !== ""` to `contactData.displayName`, which also checks for `undefined`.
https://github.com/status-im/status-desktop/blob/e97f77621457be3b42dcb7297140cda3bac14575/ui/app/AppLayouts/Chat/views/MembersSelectorView.qml#L120

2. Fix the logic of opening the popup.
Popup opening should only happen after all other cases failed (is contact, pending contact request, blocked, ...)

### Affected areas

`MembersSelectorView`

### Screenshot of functionality (including design for comparison)

https://github.com/status-im/status-desktop/assets/25482501/5edfe921-d415-47c1-9bb4-cc728333734b
