### PR TITLE
fix: Only `scrollToMessage` when it's available in the database

### DIFF
--- a/src/app/modules/main/chat_section/chat_content/controller.nim
+++ b/src/app/modules/main/chat_section/chat_content/controller.nim
@@ -202,9 +202,8 @@ proc belongsToCommunity*(self: Controller): bool =
 proc unpinMessage*(self: Controller, messageId: string) =
   self.messageService.pinUnpinMessage(self.chatId, messageId, false)
 
-proc getMessageById*(self: Controller, messageId: string):
-    tuple[message: MessageDto, error: string] =
-  return self.messageService.getMessageByMessageId(self.chatId, messageId)
+proc getMessageById*(self: Controller, messageId: string): GetMessageResult =
+  return self.messageService.getMessageByMessageId(messageId)
 
 proc isUsersListAvailable*(self: Controller): bool =
   return self.isUsersListAvailable

--- a/src/app/modules/main/chat_section/chat_content/controller.nim
+++ b/src/app/modules/main/chat_section/chat_content/controller.nim
@@ -204,7 +204,7 @@ proc unpinMessage*(self: Controller, messageId: string) =
 
 proc getMessageById*(self: Controller, messageId: string):
     tuple[message: MessageDto, error: string] =
-  return self.messageService.fetchMessageByMessageId(self.chatId, messageId)
+  return self.messageService.getMessageByMessageId(self.chatId, messageId)
 
 proc isUsersListAvailable*(self: Controller): bool =
   return self.isUsersListAvailable

--- a/src/app/modules/main/chat_section/chat_content/messages/controller.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/controller.nim
@@ -228,7 +228,7 @@ proc init*(self: Controller) =
 
   self.events.on(SIGNAL_GET_MESSAGE_FINISHED) do(e: Args):
     let args = GetMessageResult(e)
-    self.delegate.onGetMessageById(args.requestId, args.message, args.error)
+    self.delegate.onGetMessageById(args.requestId, args.messageId, args.message, args.error)
 
 proc getMySectionId*(self: Controller): string =
   return self.sectionId

--- a/src/app/modules/main/chat_section/chat_content/messages/controller.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/controller.nim
@@ -13,6 +13,7 @@ import ../../../../../global/app_signals
 import ../../../../../core/signals/types
 import ../../../../../core/eventemitter
 import ../../../../../core/unique_event_emitter
+import ../../../../../../app_service/service/message/dto/call_reason
 
 logScope:
   topics = "messages-controller"
@@ -226,6 +227,14 @@ proc init*(self: Controller) =
       return
     self.delegate.onFirstUnseenMessageLoaded(args.messageId)
 
+  self.events.on(SIGNAL_GET_MESSAGE_FINISHED) do(e: Args):
+    let args = GetMessageResult(e)
+    if args.chatId != self.chatId:
+      return
+    if args.callReason != GetMessageByIdCallReason.ScrollTomessage:
+      return
+    self.delegate.continueScrollToMessage(args.messageId, args.message, args.error)
+
 proc getMySectionId*(self: Controller): string =
   return self.sectionId
 
@@ -321,6 +330,5 @@ proc leaveChat*(self: Controller) =
 proc resendChatMessage*(self: Controller, messageId: string): string =
   return self.messageService.resendChatMessage(messageId)
 
-proc messageFetched*(self: Controller, messageId: string): bool =
-  let (message, err) = self.messageService.getMessageByMessageId(self.chatId, messageId)
-  return err.len == 0
+proc asyncGetMessageById*(self: Controller, messageId: string, callReason: GetMessageByIdCallReason) =
+  self.messageService.asyncGetMessageById(self.chatId, messageId, callReason)

--- a/src/app/modules/main/chat_section/chat_content/messages/controller.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/controller.nim
@@ -320,3 +320,7 @@ proc leaveChat*(self: Controller) =
 
 proc resendChatMessage*(self: Controller, messageId: string): string =
   return self.messageService.resendChatMessage(messageId)
+
+proc messageFetched*(self: Controller, messageId: string): bool =
+  let (message, err) = self.messageService.getMessageByMessageId(self.chatId, messageId)
+  return err.len == 0

--- a/src/app/modules/main/chat_section/chat_content/messages/controller.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/controller.nim
@@ -1,4 +1,4 @@
-import chronicles
+import chronicles, uuids
 import io_interface
 import json
 
@@ -13,7 +13,6 @@ import ../../../../../global/app_signals
 import ../../../../../core/signals/types
 import ../../../../../core/eventemitter
 import ../../../../../core/unique_event_emitter
-import ../../../../../../app_service/service/message/dto/call_reason
 
 logScope:
   topics = "messages-controller"
@@ -229,11 +228,7 @@ proc init*(self: Controller) =
 
   self.events.on(SIGNAL_GET_MESSAGE_FINISHED) do(e: Args):
     let args = GetMessageResult(e)
-    if args.chatId != self.chatId:
-      return
-    if args.callReason != GetMessageByIdCallReason.ScrollTomessage:
-      return
-    self.delegate.continueScrollToMessage(args.messageId, args.message, args.error)
+    self.delegate.onGetMessageById(args.requestId, args.message, args.error)
 
 proc getMySectionId*(self: Controller): string =
   return self.sectionId
@@ -330,5 +325,5 @@ proc leaveChat*(self: Controller) =
 proc resendChatMessage*(self: Controller, messageId: string): string =
   return self.messageService.resendChatMessage(messageId)
 
-proc asyncGetMessageById*(self: Controller, messageId: string, callReason: GetMessageByIdCallReason) =
-  self.messageService.asyncGetMessageById(self.chatId, messageId, callReason)
+proc asyncGetMessageById*(self: Controller, messageId: string): UUID =
+  return self.messageService.asyncGetMessageById(messageId)

--- a/src/app/modules/main/chat_section/chat_content/messages/io_interface.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/io_interface.nim
@@ -1,4 +1,4 @@
-import NimQml
+import NimQml, uuids
 
 import ../../../../../../app_service/service/message/dto/[message, reaction, pinned_message]
 import ../../../../../../app_service/service/community/dto/community
@@ -180,5 +180,5 @@ method isFirstUnseenMessageInitialized*(self: AccessInterface): bool {.base.} =
 method reevaluateViewLoadingState*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method continueScrollToMessage*(self: AccessInterface, messageId: string, message: MessageDto, error: string) {.base.} =
+method onGetMessageById*(self: AccessInterface, requestId: UUID, message: MessageDto, error: string) {.base.} =
   raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/chat_section/chat_content/messages/io_interface.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/io_interface.nim
@@ -180,5 +180,5 @@ method isFirstUnseenMessageInitialized*(self: AccessInterface): bool {.base.} =
 method reevaluateViewLoadingState*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method onGetMessageById*(self: AccessInterface, requestId: UUID, message: MessageDto, error: string) {.base.} =
+method onGetMessageById*(self: AccessInterface, requestId: UUID, messageId: string, message: MessageDto, error: string) {.base.} =
   raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/chat_section/chat_content/messages/io_interface.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/io_interface.nim
@@ -179,3 +179,6 @@ method isFirstUnseenMessageInitialized*(self: AccessInterface): bool {.base.} =
 
 method reevaluateViewLoadingState*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
+
+method continueScrollToMessage*(self: AccessInterface, messageId: string, message: MessageDto, error: string) {.base.} =
+  raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/chat_section/chat_content/messages/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/module.nim
@@ -15,6 +15,7 @@ import ../../../../../../app_service/service/chat/service as chat_service
 import ../../../../../../app_service/service/message/service as message_service
 import ../../../../../../app_service/service/mailservers/service as mailservers_service
 import ../../../../../../app_service/common/types
+import ../../../../../../app_service/service/message/dto/call_reason
 
 export io_interface
 
@@ -667,11 +668,15 @@ method scrollToMessage*(self: Module, messageId: string) =
   if self.view.getMessageSearchOngoing():
     return
 
-  if not self.controller.messageFetched(messageId):
-    warn "attempting to scroll to a not fetched message", messageId, chatId = self.controller.getMyChatId()
+  self.controller.asyncGetMessageById(messageId, GetMessageByIdCallReason.ScrollTomessage)
+  self.view.setMessageSearchOngoing(true)
+
+method continueScrollToMessage*(self: Module, messageId: string, message: MessageDto, errorMessage: string) =
+  if errorMessage != "":
+    error "attempted to scroll to a not fetched message", errorMessage, messageId, chatId = self.controller.getMyChatId()
+    self.view.setMessageSearchOngoing(false)
     return
 
-  self.view.setMessageSearchOngoing(true)
   self.controller.setSearchedMessageId(messageId)
   self.checkIfMessageLoadedAndScrollToItIfItIs()
   self.reevaluateViewLoadingState()

--- a/src/app/modules/main/chat_section/chat_content/messages/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/module.nim
@@ -661,10 +661,14 @@ proc switchToMessage*(self: Module, messageId: string) =
     self.controller.setSearchedMessageId(messageId)
 
 method scrollToMessage*(self: Module, messageId: string) =
-  if(messageId == ""):
+  if messageId == "":
     return
 
-  if(self.view.getMessageSearchOngoing()):
+  if self.view.getMessageSearchOngoing():
+    return
+
+  if not self.controller.messageFetched(messageId):
+    warn "attempting to scroll to a not fetched message", messageId, chatId = self.controller.getMyChatId()
     return
 
   self.view.setMessageSearchOngoing(true)

--- a/src/app/modules/main/chat_section/chat_content/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/module.nim
@@ -248,8 +248,10 @@ method onUnpinMessage*(self: Module, messageId: string) =
 
 method onPinMessage*(self: Module, messageId: string, actionInitiatedBy: string) =
   var item: pinned_msg_item.Item
-  let (message, err) = self.controller.getMessageById(messageId)
-  if(err.len > 0 or not self.buildPinnedMessageItem(message, actionInitiatedBy, item)):
+  let response = self.controller.getMessageById(messageId)
+  if response.error.len > 0:
+    return
+  if not self.buildPinnedMessageItem(response.message, actionInitiatedBy, item):
     return
 
   self.view.pinnedModel().insertItemBasedOnClock(item)

--- a/src/app_service/service/message/async_tasks.nim
+++ b/src/app_service/service/message/async_tasks.nim
@@ -1,11 +1,10 @@
-import std/uri
+import std/uri, uuids
 include ../../common/json_utils
 include ../../../app/core/tasks/common
 
 import ../../../backend/chat as status_go_chat
 
 import ../../../app/core/custom_urls/urls_manager
-import dto/call_reason
 
 
 #################################################
@@ -321,9 +320,8 @@ const asyncUnfurlUrlsTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
 
 type
   AsyncGetMessageByMessageIdTaskArg = ref object of QObjectTaskArg
+    requestId*: string
     messageId*: string
-    chatId*: string
-    callReason*: GetMessageByIdCallReason
 
 const asyncGetMessageByMessageIdTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AsyncGetMessageByMessageIdTaskArg](argEncoded)
@@ -332,9 +330,7 @@ const asyncGetMessageByMessageIdTask: Task = proc(argEncoded: string) {.gcsafe, 
     let output = %*{
       "error": (if response.error != nil: response.error.message else: ""),
       "message": response.result,
-      "messageId": arg.messageId,
-      "chatId": arg.chatId,
-      "callReason": arg.callReason
+      "requestId": arg.requestId
     }
     arg.finish(output)
   except Exception as e:
@@ -342,9 +338,7 @@ const asyncGetMessageByMessageIdTask: Task = proc(argEncoded: string) {.gcsafe, 
     let output = %*{
       "error": e.msg,
       "message": "",
-      "messageId": arg.messageId,
-      "chatId": arg.chatId,
-      "callReason": arg.callReason
+      "requestId": arg.requestId
     }
     arg.finish(output)
 

--- a/src/app_service/service/message/async_tasks.nim
+++ b/src/app_service/service/message/async_tasks.nim
@@ -330,7 +330,8 @@ const asyncGetMessageByMessageIdTask: Task = proc(argEncoded: string) {.gcsafe, 
     let output = %*{
       "error": (if response.error != nil: response.error.message else: ""),
       "message": response.result,
-      "requestId": arg.requestId
+      "requestId": arg.requestId,
+      "messageId": arg.messageId,
     }
     arg.finish(output)
   except Exception as e:
@@ -338,7 +339,8 @@ const asyncGetMessageByMessageIdTask: Task = proc(argEncoded: string) {.gcsafe, 
     let output = %*{
       "error": e.msg,
       "message": "",
-      "requestId": arg.requestId
+      "requestId": arg.requestId,
+      "messageId": arg.messageId,
     }
     arg.finish(output)
 

--- a/src/app_service/service/message/dto/call_reason.nim
+++ b/src/app_service/service/message/dto/call_reason.nim
@@ -1,4 +1,0 @@
-type
-  GetMessageByIdCallReason* {.pure.} = enum
-    Unknown
-    ScrollTomessage

--- a/src/app_service/service/message/dto/call_reason.nim
+++ b/src/app_service/service/message/dto/call_reason.nim
@@ -1,0 +1,4 @@
+type
+  GetMessageByIdCallReason* {.pure.} = enum
+    Unknown
+    ScrollTomessage

--- a/src/app_service/service/message/service.nim
+++ b/src/app_service/service/message/service.nim
@@ -563,10 +563,10 @@ QtObject:
     except Exception as e:
       error "error: ", procName="pinUnpinMessage", errName = e.name, errDesription = e.msg
 
-  proc fetchMessageByMessageId*(self: Service, chatId: string, messageId: string):
+  proc getMessageByMessageId*(self: Service, chatId: string, messageId: string):
       tuple[message: MessageDto, error: string] =
     try:
-      let msgResponse = status_go.fetchMessageByMessageId(messageId)
+      let msgResponse = status_go.getMessageByMessageId(messageId)
       if(msgResponse.error.isNil):
         result.message = msgResponse.result.toMessageDto()
 
@@ -575,7 +575,7 @@ QtObject:
         return
     except Exception as e:
       result.error = e.msg
-      error "error: ", procName="fetchMessageByMessageId", errName = e.name, errDesription = e.msg
+      error "error: ", procName="getMessageByMessageId", errName = e.name, errDesription = e.msg
 
   proc finishAsyncSearchMessagesWithError*(self: Service, chatId, errorMessage: string) =
     error "error: ", procName="onAsyncSearchMessages", errDescription = errorMessage

--- a/src/app_service/service/message/service.nim
+++ b/src/app_service/service/message/service.nim
@@ -136,6 +136,7 @@ type
 
   GetMessageResult* = ref object of Args
     requestId*: UUID
+    messageId*: string
     message*: MessageDto
     error*: string
 
@@ -588,15 +589,13 @@ QtObject:
       if responseObj.kind != JObject:
         raise newException(RpcException, "getMessageById response is not an json object")
 
-      let requestId = responseObj["requestId"].getStr
-      let responseError = responseObj["error"].getStr
-
-      var signalData = GetMessageResult( 
-        requestId: parseUUID(requestId),
-        error: responseError,
+      var signalData = GetMessageResult(
+        requestId: parseUUID(responseObj["requestId"].getStr),
+        messageId: responseObj["messageId"].getStr,
+        error: responseObj["error"].getStr,
       )
       
-      if responseError == "":
+      if signalData.error == "":
         signalData.message = responseObj["message"].toMessageDto()
 
       if signalData.message.id.len == 0:

--- a/src/backend/messages.nim
+++ b/src/backend/messages.nim
@@ -32,7 +32,7 @@ proc pinUnpinMessage*(chatId: string, messageId: string, pin: bool): RpcResponse
   }]
   result = callPrivateRPC("sendPinMessage".prefix, payload)
 
-proc fetchMessageByMessageId*(messageId: string): RpcResponse[JsonNode] {.raises: [Exception].} =
+proc getMessageByMessageId*(messageId: string): RpcResponse[JsonNode] {.raises: [Exception].} =
   let payload = %* [messageId]
   result = callPrivateRPC("messageByMessageID".prefix, payload)
 

--- a/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
@@ -89,7 +89,7 @@ Control {
     signal activeChanged(string messageId, bool active)
 
     function startMessageFoundAnimation() {
-        messageFoundAnimation.start();
+        messageFoundAnimation.restart();
     }
 
     onMessageAttachmentsChanged: {

--- a/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusMessage.qml
@@ -133,14 +133,11 @@ Control {
         SequentialAnimation {
             id: messageFoundAnimation
 
-            PauseAnimation {
-                duration: 600
-            }
             NumberAnimation {
                 target: highlightRect
                 property: "opacity"
                 to: 1.0
-                duration: 1500
+                duration: 250
             }
             PauseAnimation {
                 duration: 1000

--- a/ui/StatusQ/src/StatusQ/Components/StatusMessageDetails.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusMessageDetails.qml
@@ -12,6 +12,7 @@ QtObject {
     property string messageText: ""
     property string messageContent: ""
     property string messageOriginInfo: ""
+    property bool messageDeleted: false
     property var album: []
     property int albumCount: 0
 }

--- a/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusMessageReply.qml
+++ b/ui/StatusQ/src/StatusQ/Components/private/statusMessage/StatusMessageReply.qml
@@ -174,8 +174,9 @@ Item {
 
                     MouseArea {
                         anchors.fill: parent
+                        enabled: !root.replyDetails.messageDeleted && root.replyDetails.sender.id
                         hoverEnabled: true
-                        cursorShape: Qt.PointingHandCursor
+                        cursorShape: enabled ? Qt.PointingHandCursor : Qt.ArrowCursor
                         onClicked: {
                             root.messageClicked(mouse)
                         }

--- a/ui/app/AppLayouts/Chat/views/MembersSelectorView.qml
+++ b/ui/app/AppLayouts/Chat/views/MembersSelectorView.qml
@@ -115,7 +115,7 @@ MembersSelectorBase {
             if (root.model.count === 0 && !hasPendingContactRequest) {
                 // List is empty and not a contact yet. Open the contact request popup
 
-                // If `displayName` is not undefiend and not empty,
+                // If `displayName` is not undefined and not empty,
                 // then we open the popup with given `contactData`, which probably came from URL.
                 if (contactData.displayName) {
                     // Open contact request if we have data from url

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -576,8 +576,7 @@ Loader {
                 }
 
                 onReplyMessageClicked: {
-                    if (!root.quotedMessageDeleted && root.quotedMessageFrom)
-                        root.messageStore.messageModule.jumpToMessage(root.responseToMessageWithId)
+                    root.messageStore.messageModule.jumpToMessage(root.responseToMessageWithId)
                 }
 
                 onSenderNameClicked: {
@@ -679,14 +678,13 @@ Loader {
                     }
 
                     messageText: {
-                        if (root.quotedMessageDeleted) {
+                        if (messageDeleted)
                             return qsTr("Message deleted")
-                        }
-                        if (!root.quotedMessageText && !root.quotedMessageFrom) {
+                        if (!root.quotedMessageText && !root.quotedMessageFrom)
                             return qsTr("Unknown message. Try fetching more messages")
-                        }
                         return root.quotedMessageText
                     }
+                    messageDeleted: root.quotedMessageDeleted
                     contentType: d.convertContentType(root.quotedMessageContentType)
                     amISender: root.quotedMessageFrom === userProfile.pubKey
                     sender.id: root.quotedMessageFrom


### PR DESCRIPTION
Fixes #11759

### What does the PR do

1. `scrollToMessage` will not scroll if the message doesn't exist in the database
2. Now it's impossible to click on a deleted/unavailable message (even pointing hand cursor will not appear)
3. Moved reply clicking logic to `StatusMessageReply`
4. Made "message found" animation faster 
5. Renamed `fetchMessageByMessageId` to `getMessageByMessageId`, 
because by "fetch" we usually mean "fetch from waku", which doens't happen here. And the status-go method is "get" anyway.

I should say that I wasn't able to reproduce the bug actually.
But this should fix any potential problems.

### Screenshot of functionality (including design for comparison)


https://github.com/status-im/status-desktop/assets/25482501/a69c7bd9-07dd-4830-90be-ec49630ca1a9

