### PR TITLE
fix(@desktop/wallet): fix wrong model update when items are fetched

### DIFF
--- a/src/app/modules/main/wallet_section/collectibles/events_handler.nim
+++ b/src/app/modules/main/wallet_section/collectibles/events_handler.nim
@@ -16,6 +16,7 @@ QtObject:
       events: EventEmitter
       eventHandlers: Table[string, EventCallbackProc]
       walletEventHandlers: Table[string, WalletEventCallbackProc]
+      collectiblesOwnershipUpdateStartedFn: proc()
       collectiblesOwnershipUpdateFinishedFn: proc()
 
   proc setup(self: EventsHandler) =
@@ -26,6 +27,9 @@ QtObject:
 
   proc onOwnedCollectiblesFilteringDone*(self: EventsHandler, handler: EventCallbackProc) =
     self.eventHandlers[backend_collectibles.eventOwnedCollectiblesFilteringDone] = handler
+
+  proc onCollectiblesOwnershipUpdateStarted*(self: EventsHandler, handler: proc()) =
+    self.collectiblesOwnershipUpdateStartedFn = handler
 
   proc onCollectiblesOwnershipUpdateFinished*(self: EventsHandler, handler: proc()) =
     self.collectiblesOwnershipUpdateFinishedFn = handler
@@ -49,6 +53,11 @@ QtObject:
       discard
 
   proc setupWalletEventHandlers(self: EventsHandler) =
+    self.walletEventHandlers[backend_collectibles.eventCollectiblesOwnershipUpdateStarted] = proc (data: WalletSignal) =
+      if self.collectiblesOwnershipUpdateStartedFn == nil:
+        return
+      self.collectiblesOwnershipUpdateStartedFn()
+
     self.walletEventHandlers[backend_collectibles.eventCollectiblesOwnershipUpdateFinished] = proc (data: WalletSignal) =
       if self.collectiblesOwnershipUpdateFinishedFn == nil:
         return


### PR DESCRIPTION
### What does the PR do

Fixes https://github.com/status-im/status-desktop/issues/11785

The model was not properly updated when the loading items were present and new collectibles were fetched. Clicking one of these corrupted items caused the app to crash.
![image](https://github.com/status-im/status-desktop/assets/11161531/235ff1e3-e679-4a68-b623-a6069d35977a)

This PR changes how loading items are managed. Also added a workaround for when the user quickly scrolls to the bottom of the list while items are being loaded, for some reason `fetchMore` is not called in this case.

The loading items mechanism should be simplified, added a task for working on that: https://github.com/status-im/status-desktop/issues/11802