### PR TITLE
fix(chatSearch): fix chat search to include all and only chats

### DIFF
--- a/src/app/modules/main/controller.nim
+++ b/src/app/modules/main/controller.nim
@@ -21,6 +21,8 @@ import ../../../app_service/service/community_tokens/service as community_tokens
 import ../../../app_service/service/wallet_account/service as wallet_account_service
 import ../../../app_service/service/token/service as token_service
 import ../../../app_service/service/network/service as networks_service
+import ../../../app_service/service/visual_identity/service as procs_from_visual_identity_service
+
 from backend/collectibles_types import CollectibleOwner
 
 import io_interface
@@ -441,17 +443,8 @@ proc setActiveSection*(self: Controller, sectionId: string, skipSavingInSettings
     singletonInstance.localAccountSensitiveSettings.setActiveSection(sectionIdToSave)
   self.delegate.activeSectionSet(self.activeSectionId)
 
-proc getNumOfNotificaitonsForChat*(self: Controller): tuple[unviewed:int, mentions:int] =
-  result.unviewed = 0
-  result.mentions = 0
-  let chats = self.chatService.getAllChats()
-  for chat in chats:
-    if(chat.chatType == ChatType.CommunityChat):
-      continue
-
-    if not chat.muted:
-      result.unviewed += chat.unviewedMessagesCount
-    result.mentions += chat.unviewedMentionsCount
+proc getAllChats*(self: Controller): seq[ChatDto] =
+  result = self.chatService.getAllChats()
 
 proc sectionUnreadMessagesAndMentionsCount*(self: Controller, communityId: string):
     tuple[unviewedMessagesCount: int, unviewedMentionsCount: int] =
@@ -525,3 +518,9 @@ proc slowdownArchivesImport*(self:Controller) =
 
 proc speedupArchivesImport*(self:Controller) =
   communityService.speedupArchivesImport()
+
+proc getColorHash*(self: Controller, pubkey: string): ColorHashDto =
+  procs_from_visual_identity_service.colorHashOf(pubkey)
+
+proc getColorId*(self: Controller, pubkey: string): int =
+  procs_from_visual_identity_service.colorIdOf(pubkey)


### PR DESCRIPTION
Fixes #10770

There were two issues, the first one was that categories were included in the search model because the categories are now part of the chat_model.

Also, since it used the chat_model, some chats were not part of the search model at start, because they weren't loaded yet.

I fixed by using the chats from the service directly instead.

[chats-serahc.webm](https://github.com/status-im/status-desktop/assets/11926403/ef423c16-80ca-4d53-a6b3-d15cd8f636a9)
