### PR TITLE
feat(Community Overview): Trigger chart data updates on specific actions + reduce the backend call frequency

### DIFF
--- a/src/app/modules/main/chat_section/controller.nim
+++ b/src/app/modules/main/chat_section/controller.nim
@@ -173,11 +173,7 @@ proc init*(self: Controller) =
       let args = CommunityMetricsArgs(e)
       if args.communityId == self.sectionId:
         let metrics = self.communityService.getCommunityMetrics(args.communityId, args.metricsType)
-        var strings: seq[string]
-        for interval in metrics.intervals:
-          for timestamp in interval.timestamps:
-            strings.add($timestamp)
-        self.delegate.setOverviewChartData("[" & join(strings, ", ") & "]")
+        self.delegate.setCommunityMetrics(metrics)
 
     self.events.on(SIGNAL_COMMUNITY_CHANNEL_DELETED) do(e:Args):
       let args = CommunityChatIdArgs(e)
@@ -665,3 +661,6 @@ proc getCommunityTokenList*(self: Controller): seq[CommunityTokenDto] =
 
 proc collectCommunityMetricsMessagesTimestamps*(self: Controller, intervals: string) =
   self.communityService.collectCommunityMetricsMessagesTimestamps(self.getMySectionId(), intervals)
+
+proc collectCommunityMetricsMessagesCount*(self: Controller, intervals: string) =
+  self.communityService.collectCommunityMetricsMessagesCount(self.getMySectionId(), intervals)

--- a/src/app/modules/main/chat_section/io_interface.nim
+++ b/src/app/modules/main/chat_section/io_interface.nim
@@ -352,7 +352,10 @@ method deleteCommunityTokenPermission*(self: AccessInterface, communityId: strin
 method collectCommunityMetricsMessagesTimestamps*(self: AccessInterface, intervals: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method setOverviewChartData*(self: AccessInterface, metrics: string) {.base.} =
+method collectCommunityMetricsMessagesCount*(self: AccessInterface, intervals: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method setCommunityMetrics*(self: AccessInterface, metrics: CommunityMetricsDto) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method onCommunityTokenPermissionCreated*(self: AccessInterface, communityId: string, tokenPermission: CommunityTokenPermissionDto) {.base.} =

--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, chronicles, json, sequtils, strutils, strformat, sugar
+import NimQml, Tables, chronicles, json, sequtils, strutils, strformat, sugar, marshal
 
 import io_interface
 import ../io_interface as delegate_interface
@@ -1326,5 +1326,8 @@ method onDeactivateChatLoader*(self: Module, chatId: string) =
 method collectCommunityMetricsMessagesTimestamps*(self: Module, intervals: string) =
   self.controller.collectCommunityMetricsMessagesTimestamps(intervals)
 
-method setOverviewChartData*(self: Module, metrics: string) =
-  self.view.setOverviewChartData(metrics)
+method setCommunityMetrics*(self: Module, metrics: CommunityMetricsDto) =
+  self.view.setCommunityMetrics($$metrics)
+
+method collectCommunityMetricsMessagesCount*(self: Module, intervals: string) =
+  self.controller.collectCommunityMetricsMessagesCount(intervals)

--- a/src/app/modules/main/chat_section/view.nim
+++ b/src/app/modules/main/chat_section/view.nim
@@ -422,9 +422,12 @@ QtObject:
     read = getOverviewChartData
     notify = overviewChartDataChanged
 
-  proc setOverviewChartData*(self: View, communityMetrics: string) =
+  proc setCommunityMetrics*(self: View, communityMetrics: string) =
     self.communityMetrics = communityMetrics
     self.overviewChartDataChanged()
 
   proc collectCommunityMetricsMessagesTimestamps*(self: View, intervals: string) {.slot.} =
     self.delegate.collectCommunityMetricsMessagesTimestamps(intervals)
+
+  proc collectCommunityMetricsMessagesCount*(self: View, intervals: string) {.slot.} =
+    self.delegate.collectCommunityMetricsMessagesCount(intervals)

--- a/src/app_service/service/community/dto/community.nim
+++ b/src/app_service/service/community/dto/community.nim
@@ -338,7 +338,7 @@ proc toCommunityMetricsDto*(jsonObj: JsonNode): CommunityMetricsDto =
 
   result.metricsType = CommunityMetricsType.MessagesTimestamps
   var metricsTypeInt: int
-  if (jsonObj.getProp("metricsType", metricsTypeInt) and (metricsTypeInt >= ord(low(CommunityMetricsType)) and
+  if (jsonObj.getProp("type", metricsTypeInt) and (metricsTypeInt >= ord(low(CommunityMetricsType)) and
       metricsTypeInt <= ord(high(CommunityMetricsType)))):
     result.metricsType = CommunityMetricsType(metricsTypeInt)
 

--- a/src/app_service/service/community/service.nim
+++ b/src/app_service/service/community/service.nim
@@ -1374,7 +1374,7 @@ QtObject:
       return
 
     let communityId = rpcResponseObj{"communityId"}.getStr()
-    let metricsType = rpcResponseObj{"metricsType"}.getInt()
+    let metricsType = rpcResponseObj{"response"}{"result"}{"type"}.getInt()
 
     var metrics = rpcResponseObj{"response"}{"result"}.toCommunityMetricsDto()
     self.communityMetrics[communityId] = metrics

--- a/storybook/pages/OverviewSettingsChartPage.qml
+++ b/storybook/pages/OverviewSettingsChartPage.qml
@@ -4,28 +4,66 @@ import QtQuick.Controls 2.15
 import AppLayouts.Communities.panels 1.0
 import Models 1.0
 
+import Storybook 1.0
+
 SplitView {
+    id: root
+
+    orientation: Qt.Vertical
 
     OverviewSettingsChart {
         id: chart
         SplitView.fillWidth: true
         SplitView.fillHeight: true
-
-        model: generateRandomModel()
+        onCollectCommunityMetricsMessagesCount: generateRandomModel(intervals)
     }
 
-    function generateRandomModel() {
+    function generateRandomModel(intervalsStr) {
+        if(!intervalsStr) return
+
+        var response = {
+            communityId: "",
+            metricsType: timestampMetrics.checked ? "MessagesTimestamps" : "MessagesCount",
+            intervals: []
+        }
+
+        var intervals = JSON.parse(intervalsStr)
+
+        response.intervals = intervals.map( x => {
+            var timestamps = generateRandomDate(x.startTimestamp, x.endTimestamp, Math.random() * 10)
+
+            return {
+                startTimestamp: x.startTimestamp,
+                endTimestamp: x.endTimestamp,
+                timestamps: timestamps,
+                count: timestamps.length
+            }
+        })
+
+        chart.model = response
+    }
+
+    function generateRandomDate(from, to, count) {
         var newModel = []
-        const now = Date.now()
-        for(var i = 0; i < 500000; i++) {
-            var date = generateRandomDate(1463154962000, now)
+        for(var i = 0; i < count; i++) {
+            var date = from + Math.random() * (to - from)
             newModel.push(date)
         }
         return newModel
     }
 
-    function generateRandomDate(from, to) {
-      return from + Math.random() * (to - from)
+    LogsAndControlsPanel {
+        id: logsAndControlsPanel
+
+        SplitView.minimumHeight: 100
+        SplitView.preferredHeight: 150
+
+        CheckBox {
+            id: timestampMetrics
+            text: "Metrics using timestamps"
+            checked: false
+            onCheckedChanged: chart.reset()
+        }
     }
 }
 

--- a/ui/StatusQ/src/StatusQ/Components/private/chart/Chart.qml
+++ b/ui/StatusQ/src/StatusQ/Components/private/chart/Chart.qml
@@ -27,6 +27,8 @@ Canvas {
 
     function updateToNewData()
     {
+        if(!jsChart) return
+        
         jsChart.update('none');
         root.requestPaint();
     }

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -423,6 +423,10 @@ QtObject {
         chatCommunitySectionModule.collectCommunityMetricsMessagesTimestamps(intervals)
     }
 
+    function collectCommunityMetricsMessagesCount(intervals) {
+        chatCommunitySectionModule.collectCommunityMetricsMessagesCount(intervals)
+    }
+
     function requestCommunityInfo(id, importing = false) {
         communitiesModuleInst.requestCommunityInfo(id, importing)
     }

--- a/ui/app/AppLayouts/Communities/panels/OverviewSettingsPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/OverviewSettingsPanel.qml
@@ -49,7 +49,7 @@ StackLayout {
             root.currentIndex = 0
     }
 
-    signal collectCommunityMetricsMessagesTimestamps(var intervals)
+    signal collectCommunityMetricsMessagesCount(var intervals)
 
     signal edited(Item item) // item containing edited fields (name, description, logoImagePath, color, options, etc..)
 
@@ -118,8 +118,8 @@ StackLayout {
 
             OverviewSettingsChart {
                 model: JSON.parse(root.overviewChartData)
-                onCollectCommunityMetricsMessagesTimestamps: {
-                    root.collectCommunityMetricsMessagesTimestamps(intervals)
+                onCollectCommunityMetricsMessagesCount: {
+                    root.collectCommunityMetricsMessagesCount(intervals)
                 }
                 Layout.topMargin: 16
                 Layout.fillWidth: true
@@ -128,7 +128,7 @@ StackLayout {
 
                 Connections {
                     target: root
-                    onCommunityIdChanged: requestCommunityMetrics()
+                    onCommunityIdChanged: reset()
                 }
             }
 

--- a/ui/app/AppLayouts/Communities/views/CommunitySettingsView.qml
+++ b/ui/app/AppLayouts/Communities/views/CommunitySettingsView.qml
@@ -178,8 +178,8 @@ StatusSectionLayout {
             communitySettingsDisabled: root.communitySettingsDisabled
             overviewChartData: rootStore.overviewChartData
 
-            onCollectCommunityMetricsMessagesTimestamps: {
-                rootStore.collectCommunityMetricsMessagesTimestamps(intervals)
+            onCollectCommunityMetricsMessagesCount: {
+                rootStore.collectCommunityMetricsMessagesCount(intervals)
             }
 
             onEdited: {


### PR DESCRIPTION
### What does the PR do
Closing #11758 

This PR includes the following changes:
1. Request from backend the messages count in a specific time interval as opposed to all messages timestamps in that interval.
2. Update the chart end date before refreshing the data - this is fixing an issue where the chart was not updated after initialisation.
3. Fix metrics type parsing in community service
4. Fix a bug where the new incoming data was not processed by ChartJs without a hover event on the chart. The fix here is to manually request paint() on model changes.

Issues found and not handled here:
1. On large communities the backend request can take 3 minutes to complete
2. CPU usage can easily go to 100% when switching chart tabs on large communities.

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas
Community Overview
Community metrics
<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Screenshot of functionality (including design for comparison)

https://github.com/status-im/status-desktop/assets/47811206/ffb2c84e-a675-4b3c-b3af-24d55ec86296
