### PR TITLE
fix(Entitlements.plist): not yet support apple associated domains

### DIFF
--- a/Entitlements.plist
+++ b/Entitlements.plist
@@ -4,9 +4,9 @@
 <dict>
 	<key>com.apple.security.device.camera</key>
 	<true/>
-    <key>com.apple.developer.associated-domains</key>
+    <!-- <key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>applinks:status.app</string>
-	</array>
+	</array> -->
 </dict>
 </plist>


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/11762

### What does the PR do

In https://github.com/status-im/status-desktop/pull/11748 I added the `com.apple.developer.associated-domains` entitlement. But it was too early for that, as there are no provisioning profiles yet.

Working build from this branch: https://ci.infra.status.im/job/status-desktop/job/systems/job/macos/job/aarch64/job/package/774/
