### PR TITLE
fix(MintToken): Account selector is no longer present under fees section

### DIFF
--- a/ui/app/AppLayouts/Communities/panels/FeesPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/FeesPanel.qml
@@ -27,7 +27,10 @@ Control {
     property Item footer
 
     states: State {
-        when: root.footer
+        // Setting condition on root.footer doesn't work for some configurations (macOS or specific qt version)
+        // Setting when directly to true seems to be relable option because ParentChange and PropertyChanges tolerate target set to null
+        // when: root.footer
+        when: true
 
         ParentChange {
             target: root.footer


### PR DESCRIPTION
Fixes #11742

### What does the PR do

It seems that for `macOS`, `ParentChange` trigger was not correctly working if using specific `when` condition on **desktop app** (working properly on _storybook_ and also on _linux desktop app_). Setting it always to `true`, it does the trick and reparents footer component as expected.

### Affected areas

Community Settings / Mint Token

### Screenshot of functionality
<img width="1195" alt="Screenshot 2023-08-04 at 13 59 03" src="https://github.com/status-im/status-desktop/assets/97019400/13010ca0-ba48-41a5-a96e-f04e5546332f">
