### PR TITLE
[Community] Accepting/Rejecting membership requests when control node is offline

### DIFF
--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -313,6 +313,7 @@ proc createChannelGroupItem[T](self: Module[T], channelGroup: ChannelGroupDto): 
         isVerified = contactDetails.dto.isContactVerified(),
         memberRole = member.role,
         airdropAddress = member.airdropAccount.address,
+        membershipRequestState = MembershipRequestState.Accepted
         )),
     # pendingRequestsToJoin
     if (isCommunity): communityDetails.pendingRequestsToJoin.map(x => pending_request_item.initItem(
@@ -341,6 +342,7 @@ proc createChannelGroupItem[T](self: Module[T], channelGroup: ChannelGroupDto): 
         onlineStatus = toOnlineStatus(self.controller.getStatusForContactWithId(bannedMemberId).statusType),
         isContact = contactDetails.dto.isContact,
         isVerified = contactDetails.dto.isContactVerified(),
+        membershipRequestState = MembershipRequestState.Banned,
       )
     ),
     # pendingMemberRequests
@@ -360,6 +362,7 @@ proc createChannelGroupItem[T](self: Module[T], channelGroup: ChannelGroupDto): 
         isContact = contactDetails.dto.isContact,
         isVerified = contactDetails.dto.isContactVerified(),
         requestToJoinId = requestDto.id,
+        membershipRequestState = MembershipRequestState(requestDto.state),
       )
     ) else: @[],
     # declinedMemberRequests
@@ -379,6 +382,7 @@ proc createChannelGroupItem[T](self: Module[T], channelGroup: ChannelGroupDto): 
         isContact = contactDetails.dto.isContact,
         isVerified = contactDetails.dto.isContactVerified(),
         requestToJoinId = requestDto.id,
+        membershipRequestState = MembershipRequestState(requestDto.state),
       )
     ) else: @[],
     channelGroup.encrypted,

--- a/src/app/modules/shared_models/member_item.nim
+++ b/src/app/modules/shared_models/member_item.nim
@@ -12,6 +12,7 @@ type
     requestToJoinId: string
     requestToJoinLoading*: bool
     airdropAddress*: string
+    membershipRequestState: MembershipRequestState
 
 # FIXME: remove defaults
 proc initMemberItem*(
@@ -37,6 +38,7 @@ proc initMemberItem*(
   requestToJoinId: string = "",
   requestToJoinLoading: bool = false,
   airdropAddress: string = "",
+  membershipRequestState: MembershipRequestState = MembershipRequestState.None
 ): MemberItem =
   result = MemberItem()
   result.memberRole = memberRole
@@ -44,6 +46,7 @@ proc initMemberItem*(
   result.requestToJoinId = requestToJoinId
   result.requestToJoinLoading = requestToJoinLoading
   result.airdropAddress = airdropAddress
+  result.membershipRequestState = membershipRequestState
   result.UserItem.setup(
     pubKey = pubKey,
     displayName = displayName,
@@ -86,7 +89,8 @@ proc `$`*(self: MemberItem): string =
     outgoingVerificationStatus: {$self.outgoingVerificationStatus.int},
     memberRole: {self.memberRole},
     joined: {self.joined},
-    requestToJoinId: {self.requestToJoinId}
+    requestToJoinId: {self.requestToJoinId},
+    membershipRequestState: {$self.membershipRequestState.int}
     ]"""
 
 proc memberRole*(self: MemberItem): MemberRole {.inline.} =
@@ -112,3 +116,6 @@ proc requestToJoinLoading*(self: MemberItem): bool {.inline.} =
 
 proc airdropAddress*(self: MemberItem): string {.inline.} =
   self.airdropAddress
+
+proc membershipRequestState*(self: MemberItem): MembershipRequestState {.inline.} =
+  self.membershipRequestState

--- a/src/app/modules/shared_models/member_model.nim
+++ b/src/app/modules/shared_models/member_model.nim
@@ -30,6 +30,7 @@ type
     RequestToJoinId
     RequestToJoinLoading
     AirdropAddress
+    MembershipRequestState
 
 QtObject:
   type
@@ -98,6 +99,7 @@ QtObject:
       ModelRole.RequestToJoinId.int: "requestToJoinId",
       ModelRole.RequestToJoinLoading.int: "requestToJoinLoading",
       ModelRole.AirdropAddress.int: "airdropAddress",
+      ModelRole.MembershipRequestState.int: "membershipRequestState"
     }.toTable
 
   method data(self: Model, index: QModelIndex, role: int): QVariant =
@@ -155,6 +157,8 @@ QtObject:
       result = newQVariant(item.requestToJoinLoading)
     of ModelRole.AirdropAddress:
       result = newQVariant(item.airdropAddress)
+    of ModelRole.MembershipRequestState:
+      result = newQVariant(item.membershipRequestState.int)
 
   proc addItem*(self: Model, item: MemberItem) =
     self.beginInsertRows(newQModelIndex(), self.items.len, self.items.len)

--- a/src/app_service/common/types.nim
+++ b/src/app_service/common/types.nim
@@ -54,6 +54,18 @@ type MemberRole* {.pure} = enum
   ModerateContent
   Admin
 
+type MembershipRequestState* {.pure} = enum 
+  None = 0,
+  Pending = 1,
+  Accepted = 2,
+  Declined = 3,
+  AcceptedPending = 4,
+  DeclinedPending = 5,
+  Banned = 6,
+  Kicked = 7,
+  BannedPending = 8,
+  KickedPending = 9
+
 type
   ContractTransactionStatus* {.pure.} = enum
     Failed,

--- a/src/app_service/service/activity_center/dto/notification.nim
+++ b/src/app_service/service/activity_center/dto/notification.nim
@@ -41,7 +41,9 @@ type ActivityCenterMembershipStatus* {.pure.}= enum
   Idle = 0,
   Pending = 1,
   Accepted = 2,
-  Declined = 3
+  Declined = 3,
+  AcceptedPending = 4,
+  DeclinedPending = 5,
 
 type ActivityCenterNotificationDto* = ref object of RootObj
   id*: string # ID is the id of the chat, for public chats it is the name e.g. status, for one-to-one is the hex encoded public key and for group chats is a random uuid appended with the hex encoded pk of the creator of the chat

--- a/storybook/figma.json
+++ b/storybook/figma.json
@@ -3,6 +3,9 @@
         "https://www.figma.com/file/idUoxN7OIW2Jpp3PMJ1Rl8/%E2%9A%99%EF%B8%8F-Settings-%7C-Desktop?node-id=1159%3A114479",
         "https://www.figma.com/file/idUoxN7OIW2Jpp3PMJ1Rl8/%E2%9A%99%EF%B8%8F-Settings-%7C-Desktop?node-id=1684%3A127762"
     ],
+    "ActivityNotificationCommunityMembershipRequest": [
+        "https://www.figma.com/file/17fc13UBFvInrLgNUKJJg5/Kuba⎜Desktop?type=design&node-id=35909-606817&mode=design&t=Ia7Z0AzyYIjkuPtr-0"
+    ],
     "AirdropRecipientsSelector": [
         "https://www.figma.com/file/17fc13UBFvInrLgNUKJJg5/Kuba%E2%8E%9CDesktop?node-id=22628-494998",
         "https://www.figma.com/file/17fc13UBFvInrLgNUKJJg5/Kuba%E2%8E%9CDesktop?node-id=22628-495258",

--- a/storybook/figma.json
+++ b/storybook/figma.json
@@ -142,6 +142,9 @@
         "https://www.figma.com/file/17fc13UBFvInrLgNUKJJg5/Kuba%E2%8E%9CDesktop?node-id=22647-498410",
         "https://www.figma.com/file/17fc13UBFvInrLgNUKJJg5/Kuba%E2%8E%9CDesktop?node-id=22642-497015"
     ],
+    "MembersTabPanel": [
+        "https://www.figma.com/file/17fc13UBFvInrLgNUKJJg5/Kuba⎜Desktop?type=design&node-id=35909-605774&mode=design&t=KfrAekLfW5mTy68x-0"
+    ],
     "MintTokensSettingsPanel": [
         "https://www.figma.com/file/17fc13UBFvInrLgNUKJJg5/Kuba%E2%8E%9CDesktop?node-id=22721%3A498587&t=v2Krj5iZQaSTK7Om-1",
         "https://www.figma.com/file/17fc13UBFvInrLgNUKJJg5/Kuba%E2%8E%9CDesktop?node-id=2934%3A480877&t=v2Krj5iZQaSTK7Om-1",

--- a/storybook/pages/ActivityNotificationCommunityMembershipRequestPage.qml
+++ b/storybook/pages/ActivityNotificationCommunityMembershipRequestPage.qml
@@ -1,0 +1,179 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+import Qt.labs.settings 1.0
+
+import mainui.activitycenter.views 1.0
+import mainui.activitycenter.stores 1.0
+
+import utils 1.0
+
+import Storybook 1.0
+
+SplitView {
+    id: root
+
+    property bool utilsReady: false
+
+    orientation: Qt.Vertical
+
+    Logs { id: logs }
+
+    Item {
+        id: wrapper
+        SplitView.fillHeight: true
+        SplitView.fillWidth: true
+
+        Loader {
+            active: root.utilsReady
+            anchors.centerIn: parent
+            width: parent.width - 50
+            height: 80
+
+            sourceComponent : ActivityNotificationCommunityMembershipRequest {
+                store: storeMock
+                notification: notificationMock
+            }
+        }
+    }
+
+    LogsAndControlsPanel {
+        SplitView.minimumHeight: 100
+        SplitView.preferredHeight: 160
+
+        logsView.logText: logs.logText
+
+        ColumnLayout {
+            anchors.top: parent.top
+            anchors.left: parent.left
+            anchors.right: parent.right
+            Label {
+                text: "Request state"
+            }
+
+            ComboBox {
+                id: stateSelector
+                textRole: "text"
+                valueRole: "value"
+                model: ListModel {
+                         id: model
+                         ListElement { text: "Pending"; value: ActivityCenterStore.ActivityCenterMembershipStatus.Pending }
+                         ListElement { text: "Accepted"; value: ActivityCenterStore.ActivityCenterMembershipStatus.Accepted }
+                         ListElement { text: "Declined"; value: ActivityCenterStore.ActivityCenterMembershipStatus.Declined }
+                         ListElement { text: "AcceptedPending"; value: ActivityCenterStore.ActivityCenterMembershipStatus.AcceptedPending }
+                         ListElement { text: "DeclinedPending"; value: ActivityCenterStore.ActivityCenterMembershipStatus.DeclinedPending }
+                     }
+            }
+        }
+    }
+
+    QtObject {
+        id: utilsMock
+        function getContactDetailsAsJson(arg1, arg2) {
+            return JSON.stringify({
+                displayName: "Mock user",
+                displayIcon: Style.png("tokens/AST"),
+                publicKey: 123456789,
+                name: "",
+                ensVerified: false,
+                alias: "",
+                lastUpdated: 0,
+                lastUpdatedLocally: 0,
+                localNickname: "",
+                thumbnailImage: "",
+                largeImage: "",
+                isContact: false,
+                isAdded: false,
+                isBlocked: false,
+                requestReceived: false,
+                isSyncing: false,
+                removed: false,
+                trustStatus: Constants.trustStatus.unknown,
+                verificationStatus: Constants.verificationStatus.unverified,
+                incomingVerificationStatus: Constants.verificationStatus.unverified
+            })
+        }
+
+        function isCompressedPubKey(key) {
+            return true
+        }
+
+        function getColorId(publicKey) {
+            return 1
+        }
+
+        function isEnsVerified(publicKey) {
+            return true
+        }
+
+        function getCompressedPk(publicKey) {
+            return "0x00000"
+        }
+
+        Component.onCompleted: {
+            Utils.mainModuleInst = this
+            Utils.globalUtilsInst = this
+            root.utilsReady = true
+        }
+        Component.onDestruction: {
+            root.utilsReady = false
+            Utils.mainModuleInst = {}
+            Utils.globalUtilsInst = {}
+        }
+    }
+
+    QtObject {
+        id: storeMock
+
+        function getCommunityDetailsAsJson(community) {
+            return {
+                name : "Mock Community",
+                image : Style.png("tokens/UNI"),
+                color : "orchid"
+            }
+        }
+
+        function acceptRequestToJoinCommunity(notificationId, communityId) {
+            stateSelector.currentIndex = stateSelector.indexOfValue(ActivityCenterStore.ActivityCenterMembershipStatus.AcceptedPending)
+        }
+
+        function declineRequestToJoinCommunity(notificationId, communityId) {
+            stateSelector.currentIndex = stateSelector.indexOfValue(ActivityCenterStore.ActivityCenterMembershipStatus.DeclinedPending)
+        }
+
+        property var contactsStore: QtObject {
+            property var myContactsModel: QtObject {
+                signal itemChanged(string pubKey)
+            }
+        }
+    }
+
+    QtObject {
+        id: notificationMock
+        property string id: "1"
+        property string chatId: "1"
+        property string communityId: "1"
+        property int membershipStatus: stateSelector.currentValue
+        property int verificationStatus: 1
+        property string sectionId: "1"
+        property string name: "name"
+        property string author: "author"
+        property int notificationType: 1
+        property var message: QtObject {
+            property bool amISender: false
+        }
+
+        property int timestamp: Date.now()
+        property int previousTimestamp: 0
+        property bool read: false
+        property bool dismissed: false
+        property bool accepted: false
+        property var repliedMessage: ({})
+        property int chatType: 1
+    }
+
+    Settings {
+        property alias activityNotificationRequestState: stateSelector.currentIndex
+    }
+}

--- a/storybook/pages/MembersTabPanelPage.qml
+++ b/storybook/pages/MembersTabPanelPage.qml
@@ -1,0 +1,39 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+import AppLayouts.Communities.panels 1.0
+
+import Models 1.0
+import SortFilterProxyModel 0.2
+
+SplitView {
+    id: root
+
+    MembersTabPanel {
+        id: membersTabPanelPage
+        placeholderText: "Placeholder text"
+        model: usersModelWithMembershipState
+        panelType: MembersTabPanel.TabType.PendingRequests
+    }
+
+    UsersModel {
+        id: usersModel
+    }
+
+    SortFilterProxyModel {
+        id: usersModelWithMembershipState
+        readonly property var acceptedStates: [0, 3, 4]
+        sourceModel: usersModel
+
+        proxyRoles: [
+            ExpressionRole {
+                name: "membershipRequestState"
+                expression: usersModelWithMembershipState.acceptedStates[model.index % (usersModelWithMembershipState.acceptedStates.length)]
+            },
+            ExpressionRole {
+                name: "requestToJoinLoading"
+                expression: false
+            }
+        ]
+    }
+}

--- a/ui/app/AppLayouts/Communities/panels/qmldir
+++ b/ui/app/AppLayouts/Communities/panels/qmldir
@@ -14,6 +14,7 @@ JoinCommunityCenterPanel 1.0 JoinCommunityCenterPanel.qml
 JoinCommunityHeaderPanel 1.0 JoinCommunityHeaderPanel.qml
 JoinPermissionsOverlayPanel 1.0 JoinPermissionsOverlayPanel.qml
 MembersSettingsPanel 1.0 MembersSettingsPanel.qml
+MembersTabPanel 1.0 MembersTabPanel.qml
 MintTokensFooterPanel 1.0 MintTokensFooterPanel.qml
 MintTokensSettingsPanel 1.0 MintTokensSettingsPanel.qml
 OverviewSettingsChart 1.0 OverviewSettingsChart.qml

--- a/ui/app/mainui/activitycenter/panels/MembershipCta.qml
+++ b/ui/app/mainui/activitycenter/panels/MembershipCta.qml
@@ -1,4 +1,5 @@
 import QtQuick 2.14
+import QtQuick.Layouts 1.15
 
 import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
@@ -14,6 +15,9 @@ Item {
     property bool pending: false
     property bool accepted: false
     property bool declined: false
+    property bool acceptedPending: false
+    property bool declinedPending: false
+    property bool ctaAllowed: true
 
     signal acceptRequestToJoinCommunity()
     signal declineRequestToJoinCommunity()
@@ -47,30 +51,31 @@ Item {
         }
     }
 
-    Row {
+    RowLayout {
         id: buttons
         anchors.centerIn: parent
-        visible: pending
-        spacing: Style.current.padding
-
-        StatusRoundButton {
-            icon.name: "thumbs-up"
-            icon.color: Style.current.white
-            icon.hoverColor: Style.current.white
-            implicitWidth: 28
-            implicitHeight: 28
-            color: Theme.palette.successColor1
+        visible: pending || acceptedPending || declinedPending
+        spacing: Style.current.halfPadding
+        StatusFlatButton {
+            icon.name: "checkmark-circle"
+            icon.color: enabled ? Theme.palette.successColor1 : disabledTextColor
             onClicked: root.acceptRequestToJoinCommunity()
+            enabled: !root.acceptedPending
+            text: root.acceptedPending ? qsTr("Accept pending") : ""
+            verticalPadding: 4
+            horizontalPadding: 4
+            visible: root.ctaAllowed || !enabled
         }
 
-        StatusRoundButton {
-            icon.name: "thumbs-down"
-            icon.color: Style.current.white
-            icon.hoverColor: Style.current.white
-            implicitWidth: 28
-            implicitHeight: 28
-            color: Theme.palette.dangerColor1
+        StatusFlatButton {
+            icon.name: "close-circle"
+            icon.color: enabled ? Theme.palette.dangerColor1 : disabledTextColor
             onClicked: root.declineRequestToJoinCommunity()
+            enabled: !root.declinedPending
+            text: root.declinedPending ? qsTr("Reject pending") : ""
+            verticalPadding: 4
+            horizontalPadding: 4
+            visible: root.ctaAllowed || !enabled
         }
     }
 }

--- a/ui/app/mainui/activitycenter/panels/MembershipCta.qml
+++ b/ui/app/mainui/activitycenter/panels/MembershipCta.qml
@@ -9,15 +9,19 @@ import StatusQ.Components 0.1
 import utils 1.0
 import shared.panels 1.0
 
+import "../stores"
+
 Item {
     id: root
 
-    property bool pending: false
-    property bool accepted: false
-    property bool declined: false
-    property bool acceptedPending: false
-    property bool declinedPending: false
+    property int membershipStatus: ActivityCenterStore.ActivityCenterMembershipStatus.None
     property bool ctaAllowed: true
+
+    readonly property bool pending: membershipStatus === ActivityCenterStore.ActivityCenterMembershipStatus.Pending
+    readonly property bool accepted: membershipStatus === ActivityCenterStore.ActivityCenterMembershipStatus.Accepted
+    readonly property bool declined: membershipStatus === ActivityCenterStore.ActivityCenterMembershipStatus.Declined
+    readonly property bool acceptedPending: membershipStatus === ActivityCenterStore.ActivityCenterMembershipStatus.AcceptedPending
+    readonly property bool declinedPending: membershipStatus === ActivityCenterStore.ActivityCenterMembershipStatus.DeclinedPending
 
     signal acceptRequestToJoinCommunity()
     signal declineRequestToJoinCommunity()

--- a/ui/app/mainui/activitycenter/stores/ActivityCenterStore.qml
+++ b/ui/app/mainui/activitycenter/stores/ActivityCenterStore.qml
@@ -41,7 +41,9 @@ QtObject {
     enum ActivityCenterMembershipStatus {
         Pending = 1,
         Accepted = 2,
-        Declined = 3
+        Declined = 3,
+        AcceptedPending = 4,
+        DeclinedPending = 5
     }
 
     enum ActivityCenterContactRequestState {

--- a/ui/app/mainui/activitycenter/stores/ActivityCenterStore.qml
+++ b/ui/app/mainui/activitycenter/stores/ActivityCenterStore.qml
@@ -39,6 +39,7 @@ QtObject {
     }
 
     enum ActivityCenterMembershipStatus {
+        None = 0,
         Pending = 1,
         Accepted = 2,
         Declined = 3,

--- a/ui/app/mainui/activitycenter/views/ActivityNotificationCommunityMembershipRequest.qml
+++ b/ui/app/mainui/activitycenter/views/ActivityNotificationCommunityMembershipRequest.qml
@@ -43,11 +43,7 @@ ActivityNotificationMessage {
     }
 
     ctaComponent: MembershipCta {
-        pending: notification && notification.membershipStatus === ActivityCenterStore.ActivityCenterMembershipStatus.Pending
-        accepted: notification && notification.membershipStatus === ActivityCenterStore.ActivityCenterMembershipStatus.Accepted
-        declined: notification && notification.membershipStatus === ActivityCenterStore.ActivityCenterMembershipStatus.Declined
-        acceptedPending: notification && notification.membershipStatus === ActivityCenterStore.ActivityCenterMembershipStatus.AcceptedPending
-        declinedPending: notification && notification.membershipStatus === ActivityCenterStore.ActivityCenterMembershipStatus.DeclinedPending
+        membershipStatus: notification && notification.membershipStatus ? notification.membershipStatus : ActivityNotification.MembershipStatus.None
         onAcceptRequestToJoinCommunity: root.store.acceptRequestToJoinCommunity(notification.id, notification.communityId)
         onDeclineRequestToJoinCommunity: root.store.declineRequestToJoinCommunity(notification.id, notification.communityId)
         //TODO: Get backend value. If the membersip is in acceptedPending or declinedPending state, another user can't accept or decline the request

--- a/ui/app/mainui/activitycenter/views/ActivityNotificationCommunityMembershipRequest.qml
+++ b/ui/app/mainui/activitycenter/views/ActivityNotificationCommunityMembershipRequest.qml
@@ -46,7 +46,12 @@ ActivityNotificationMessage {
         pending: notification && notification.membershipStatus === ActivityCenterStore.ActivityCenterMembershipStatus.Pending
         accepted: notification && notification.membershipStatus === ActivityCenterStore.ActivityCenterMembershipStatus.Accepted
         declined: notification && notification.membershipStatus === ActivityCenterStore.ActivityCenterMembershipStatus.Declined
+        acceptedPending: notification && notification.membershipStatus === ActivityCenterStore.ActivityCenterMembershipStatus.AcceptedPending
+        declinedPending: notification && notification.membershipStatus === ActivityCenterStore.ActivityCenterMembershipStatus.DeclinedPending
         onAcceptRequestToJoinCommunity: root.store.acceptRequestToJoinCommunity(notification.id, notification.communityId)
         onDeclineRequestToJoinCommunity: root.store.declineRequestToJoinCommunity(notification.id, notification.communityId)
+        //TODO: Get backend value. If the membersip is in acceptedPending or declinedPending state, another user can't accept or decline the request
+        //Only the user who requested can cancel the request
+        ctaAllowed: true
     }
 }

--- a/ui/app/mainui/activitycenter/views/qmldir
+++ b/ui/app/mainui/activitycenter/views/qmldir
@@ -1,0 +1,1 @@
+ActivityNotificationCommunityMembershipRequest 1.0 ActivityNotificationCommunityMembershipRequest.qml

--- a/ui/imports/shared/controls/DisabledTooltipButton.qml
+++ b/ui/imports/shared/controls/DisabledTooltipButton.qml
@@ -10,6 +10,8 @@ Item {
     property alias tooltipText: tooltip.text
     property int buttonType: DisabledTooltipButton.Normal
     property bool interactive: true
+    property Component buttonComponent: buttonType === DisabledTooltipButton.Normal ? normalButton : flatButton
+    
     signal clicked()
 
     enum Type {
@@ -23,7 +25,7 @@ Item {
     Loader {
         id: buttonLoader
         anchors.centerIn: parent
-        sourceComponent: buttonType === DisabledTooltipButton.Normal ? normalButton : flatButton
+        sourceComponent: buttonComponent
         active: root.visible
     }
     HoverHandler {

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -1113,7 +1113,20 @@ QtObject {
         MembershipRequests,
         RejectedMembers,
         BannedMembers
-    }   
+    }
+
+    enum CommunityMembershipRequestState {
+        None = 0,
+        Pending,
+        Accepted,
+        Rejected,
+        AcceptedPending,
+        RejectedPending,
+        Banned,
+        Kicked,
+        BannedPending,
+        KickedPending
+    }
 
     readonly property QtObject walletAccountColors: QtObject {
         readonly property string primary: "primary"


### PR DESCRIPTION
### What does the PR do

Closing #11770 
<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

Changes:
1. Adding Accepted/Rejected Pending in activity notification and community members settings
2. Adding storybook pages for `ActivityNotificationCommunityMembershipRequest` and `MembersTabPanel`
3. Update the `MembershipCta` design for Accept/Reject buttons 
4. Adding the new states in nim


Can be tested only in Storybook.

Not handled in this PR:
1. Link the backend implementation for the new states
2. Accepted/Rejected Pending states can be changed only by the admin that initiated the request. In this case the other options needs to be hidden in the UI

### Affected areas

Community members settings
Membership request notification

<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

https://github.com/status-im/status-desktop/assets/47811206/b71fba82-5bb6-4052-abbe-1e3b8681b10b

<img width="1312" alt="Screenshot 2023-08-07 at 16 27 42" src="https://github.com/status-im/status-desktop/assets/47811206/ab523eb8-f94b-425a-8f4c-a9f65dcb43b0">

