### PR TITLE
Community kicking and banning members when control node is offline

### DIFF
--- a/storybook/pages/MembersTabPanelPage.qml
+++ b/storybook/pages/MembersTabPanelPage.qml
@@ -1,39 +1,115 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+import Qt.labs.settings 1.0
 
 import AppLayouts.Communities.panels 1.0
 
+import utils 1.0
+
 import Models 1.0
 import SortFilterProxyModel 0.2
+import Storybook 1.0
 
 SplitView {
     id: root
 
+    orientation: Qt.Vertical
+    Logs { id: logs }
+
     MembersTabPanel {
         id: membersTabPanelPage
+        SplitView.fillWidth: true
+        SplitView.fillHeight: true
         placeholderText: "Placeholder text"
         model: usersModelWithMembershipState
-        panelType: MembersTabPanel.TabType.PendingRequests
+        panelType: viewStateSelector.currentValue
+
+        onKickUserClicked: {
+            logs.logEvent("MembersTabPanel::onKickUserClicked")
+        }
+
+        onBanUserClicked: {
+            logs.logEvent("MembersTabPanel::onBanUserClicked")
+        }
+
+        onUnbanUserClicked: {
+            logs.logEvent("MembersTabPanel::onUnbanUserClicked")
+        }
+
+        onAcceptRequestToJoin: {
+            logs.logEvent("MembersTabPanel::onAcceptRequestToJoin")
+        }
+
+        onDeclineRequestToJoin: {
+            logs.logEvent("MembersTabPanel::onDeclineRequestToJoin")
+        }
     }
 
     UsersModel {
         id: usersModel
     }
 
+
     SortFilterProxyModel {
         id: usersModelWithMembershipState
-        readonly property var acceptedStates: [0, 3, 4]
+        readonly property var membershipStatePerView: [
+            [Constants.CommunityMembershipRequestState.Accepted , Constants.CommunityMembershipRequestState.BannedPending, Constants.CommunityMembershipRequestState.KickedPending],
+            [Constants.CommunityMembershipRequestState.Banned],
+            [Constants.CommunityMembershipRequestState.Pending, Constants.CommunityMembershipRequestState.AcceptedPending, Constants.CommunityMembershipRequestState.RejectedPending],
+            [Constants.CommunityMembershipRequestState.Rejected]
+        ]
+
         sourceModel: usersModel
+        sortRole: membersTabPanelPage.panelType
 
         proxyRoles: [
             ExpressionRole {
                 name: "membershipRequestState"
-                expression: usersModelWithMembershipState.acceptedStates[model.index % (usersModelWithMembershipState.acceptedStates.length)]
+                expression: {
+                    var memberStates = usersModelWithMembershipState.membershipStatePerView[membersTabPanelPage.panelType]
+                    return memberStates[model.index % (memberStates.length)]
+                }
             },
             ExpressionRole {
                 name: "requestToJoinLoading"
                 expression: false
             }
         ]
+    }
+
+    LogsAndControlsPanel {
+        SplitView.minimumHeight: 100
+        SplitView.preferredHeight: 320
+
+        logsView.logText: logs.logText
+
+        ColumnLayout {
+            anchors.top: parent.top
+            anchors.left: parent.left
+            anchors.right: parent.right
+            Label {
+                text: "View state"
+            }
+
+            ComboBox {
+                id: viewStateSelector
+                textRole: "text"
+                valueRole: "value"
+                model: ListModel {
+                     id: model
+                     ListElement { text: "All members"; value: MembersTabPanel.TabType.AllMembers }
+                     ListElement { text: "Banned Members"; value: MembersTabPanel.TabType.BannedMembers }
+                     ListElement { text: "Pending Members"; value: MembersTabPanel.TabType.PendingRequests }
+                     ListElement { text: "Declined Members"; value: MembersTabPanel.TabType.DeclinedRequests }
+                 }
+            }
+        }
+
+    }
+
+    Settings {
+        property alias membersTabPanelSelection: viewStateSelector.currentIndex
     }
 }

--- a/test/ui-test/testSuites/suite_communities/shared/scripts/community_names.py
+++ b/test/ui-test/testSuites/suite_communities/shared/scripts/community_names.py
@@ -31,7 +31,7 @@ communitySettingsView_NavigationListItem_Mint_Tokens = {"container": statusDeskt
 communitySettings_Permissions_NavigationListItem = {"container": statusDesktop_mainWindow, "objectName": "CommunitySettingsView_NavigationListItem_Permissions", "type": "StatusNavigationListItem", "visible": True}
 communitySettingsView_NavigationListItem_Overview = {"container": statusDesktop_mainWindow, "objectName": "CommunitySettingsView_NavigationListItem_Overview", "type": "StatusNavigationListItem", "visible": True}
 communitySettings_MembersTab_Members_ListView = {"container": statusDesktop_mainWindow, "objectName": "CommunityMembersTabPanel_MembersListViews", "type": "ListView", "visible": True}
-communitySettings_MembersTab_Member_Kick_Button = {"container": communitySettings_MembersTab_Members_ListView, "objectName": "MemberListIten_KickButton", "type": "StatusButton", "visible": True}
+communitySettings_MembersTab_Member_Kick_Button = {"container": communitySettings_MembersTab_Members_ListView, "objectName": "MemberListItem_KickButton", "type": "StatusButton", "visible": True}
 communitySettings_KickModal_Kick_Button = {"container": statusDesktop_mainWindow_overlay, "objectName": "CommunityMembers_KickModal_KickButton", "type": "StatusButton", "visible": True}
 
 # Chat components


### PR DESCRIPTION
### What does the PR do

Closes: #11771 

This PR depends on https://github.com/status-im/status-desktop/pull/11820

Adding Ban pending and Kick pending states in the Community members settings - All members page.

Specifications: The `pending` state will be set by the backend if the control node is not online. If the state is pending no other option should be available for that specific member.

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas

Members settings
<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

https://github.com/status-im/status-desktop/assets/47811206/49767c55-f7aa-408d-b72d-58675d3b1a30
