### PR TITLE
Trim white space before and after profile bio text

### DIFF
--- a/ui/app/AppLayouts/Profile/views/profile/MyProfileSettingsView.qml
+++ b/ui/app/AppLayouts/Profile/views/profile/MyProfileSettingsView.qml
@@ -55,7 +55,7 @@ ColumnLayout {
     function save() {
         if (!descriptionPanel.isEnsName)
             profileStore.setDisplayName(descriptionPanel.displayName.text)
-        profileStore.setBio(descriptionPanel.bio.text)
+        profileStore.setBio(descriptionPanel.bio.text.trim())
         profileStore.saveSocialLinks()
         if (profileHeader.icon === "") {
             root.profileStore.removeImage()

--- a/ui/imports/shared/panels/ProfileBioSocialsPanel.qml
+++ b/ui/imports/shared/panels/ProfileBioSocialsPanel.qml
@@ -84,7 +84,7 @@ Control {
 
             StatusBaseText {
                 id: bioText
-                text: root.bio
+                text: root.bio.trim()
                 wrapMode: Text.Wrap
                 font.weight: Font.Medium
                 lineHeight: 1.2


### PR DESCRIPTION
Fixes #7924

# What's fixed

1. Profile bio text is now trimmed when the user updates his profile.
2. Profile bio text is trimmed when displaying a user profile (own or other). This is to amend bio text that has already been saved with leading or tailing whitespace via the app or other means.

# Note 

I've also considered the need to implement this safeguard in the `StatusInput` control, however, I couldn't justify it. Looking for feedback on this.

# TODO
~~add video showcasing the trim in action?~~