### PR TITLE
feat(airdrop): get revealed accounts using new API instead of desc

### DIFF
--- a/src/app/modules/main/chat_section/chat_content/users/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/users/module.nim
@@ -133,7 +133,6 @@ proc addChatMember(self: Module,  member: ChatMember) =
     memberRole = member.role,
     joined = member.joined,
     isUntrustworthy = contactDetails.dto.trustStatus == TrustStatus.Untrustworthy,
-    airdropAddress = member.airdropAccount.address,
     ))
 
 method onChatMembersAdded*(self: Module, ids: seq[string]) =

--- a/src/app/modules/main/controller.nim
+++ b/src/app/modules/main/controller.nim
@@ -1,4 +1,4 @@
-import chronicles, stint
+import chronicles, stint, tables
 import ../../global/app_sections_config as conf
 import ../../global/global_singleton
 import ../../global/app_signals
@@ -247,6 +247,10 @@ proc init*(self: Controller) =
   self.events.on(SIGNAL_COMMUNITY_EDITED) do(e:Args):
     let args = CommunityArgs(e)
     self.delegate.communityEdited(args.community)
+
+  self.events.on(SIGNAL_COMMUNITY_MEMBERS_REVEALED_ACCOUNTS_LOADED) do(e:Args):
+    let args = CommunityMembersRevealedAccountsArgs(e)
+    self.delegate.communityMembersRevealedAccountsLoaded(args.communityId, args.membersRevealedAccounts)
 
   self.events.on(SIGNAL_COMMUNITY_PRIVATE_KEY_REMOVED) do(e:Args):
     let args = CommunityArgs(e)
@@ -524,3 +528,6 @@ proc getColorHash*(self: Controller, pubkey: string): ColorHashDto =
 
 proc getColorId*(self: Controller, pubkey: string): int =
   procs_from_visual_identity_service.colorIdOf(pubkey)
+
+proc asyncGetRevealedAccountsForAllMembers*(self: Controller, communityId: string) =
+  self.communityService.asyncGetRevealedAccountsForAllMembers(communityId)

--- a/src/app/modules/main/io_interface.nim
+++ b/src/app/modules/main/io_interface.nim
@@ -330,6 +330,9 @@ method windowActivated*(self: AccessInterface) {.base.} =
 method windowDeactivated*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method communityMembersRevealedAccountsLoaded*(self: AccessInterface, communityId: string, membersRevealedAccounts: MembersRevealedAccounts) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 # This way (using concepts) is used only for the modules managed by AppController
 type
   DelegateInterface* = concept c

--- a/src/app/modules/shared_models/member_model.nim
+++ b/src/app/modules/shared_models/member_model.nim
@@ -298,19 +298,33 @@ QtObject:
       ModelRole.IsUntrustworthy.int,
     ])
 
-  proc setOnlineStatus*(self: Model, pubKey: string,
-      onlineStatus: OnlineStatus) =
-    let ind = self.findIndexForMember(pubKey)
-    if(ind == -1):
+  proc setOnlineStatus*(self: Model, pubKey: string, onlineStatus: OnlineStatus) =
+    let idx = self.findIndexForMember(pubKey)
+    if(idx == -1):
       return
 
-    if(self.items[ind].onlineStatus == onlineStatus):
+    if(self.items[idx].onlineStatus == onlineStatus):
       return
 
-    var item = self.items[ind]
-    item.onlineStatus = onlineStatus
-    self.removeItemWithIndex(ind)
-    self.addItem(item)
+    self.items[idx].onlineStatus = onlineStatus
+    let index = self.createIndex(idx, 0, nil)
+    self.dataChanged(index, index, @[
+      ModelRole.OnlineStatus.int
+    ])
+
+  proc setAirdropAddress*(self: Model, pubKey: string, airdropAddress: string) =
+    let idx = self.findIndexForMember(pubKey)
+    if(idx == -1):
+      return
+
+    if(self.items[idx].airdropAddress == airdropAddress):
+      return
+
+    self.items[idx].airdropAddress = airdropAddress
+    let index = self.createIndex(idx, 0, nil)
+    self.dataChanged(index, index, @[
+      ModelRole.AirdropAddress.int
+    ])
 
 # TODO: rename me to removeItemByPubkey
   proc removeItemById*(self: Model, pubKey: string) =

--- a/src/app/modules/shared_models/section_model.nim
+++ b/src/app/modules/shared_models/section_model.nim
@@ -446,3 +446,12 @@ QtObject:
           "encrypted": item.encrypted,
         }
         return $jsonObj
+
+  proc setMembersAirdropAddress*(self: SectionModel, id: string, communityMembersAirdropAddress: Table[string, string]) = 
+    let index = self.getItemIndex(id)
+    if (index == -1):
+      return
+
+    for pubkey, revealedAccounts in communityMembersAirdropAddress.pairs:
+      self.items[index].members.setAirdropAddress(pubkey, revealedAccounts)
+      

--- a/src/app_service/service/chat/dto/chat.nim
+++ b/src/app_service/service/chat/dto/chat.nim
@@ -35,16 +35,10 @@ type
     large*: string
     banner*: string
 
-type RevealedAccount* = object
-  address*: string
-  chainIds*: seq[int]
-  isAirdropAddress*: bool
-
 type ChatMember* = object
   id*: string
   joined*: bool
   role*: MemberRole
-  airdropAccount*: RevealedAccount
 
 type CheckPermissionsResultDto* = object
   criteria*: seq[bool]
@@ -242,22 +236,6 @@ proc toChannelMember*(jsonObj: JsonNode, memberId: string, joined: bool): ChatMe
   if(jsonObj.getProp("roles", rolesObj)):
     for roleObj in rolesObj:
       roles.add(roleObj.getInt)
-
-  var revealedAccountsObj: JsonNode
-  if jsonObj.getProp("revealed_accounts", revealedAccountsObj):
-    for revealedAccountObj in revealedAccountsObj:
-      if revealedAccountObj{"isAirdropAddress"}.getBool:
-        var chainIdsObj: JsonNode
-        var chainIds: seq[int] = @[]
-        if revealedAccountObj.getProp("chain_ids", chainIdsObj):
-          for chainIdObj in chainIdsObj:
-            chainIds.add(chainIdObj.getInt)
-
-        result.airdropAccount = RevealedAccount(
-          address: revealedAccountObj["address"].getStr,
-          chainIds: chainIds,
-          isAirdropAddress: true,
-        )
   
   result.role = MemberRole.None
   if roles.contains(MemberRole.Owner.int): 

--- a/src/app_service/service/community/async_tasks.nim
+++ b/src/app_service/service/community/async_tasks.nim
@@ -185,3 +185,22 @@ const asyncImportCommunityTask: Task = proc(argEncoded: string) {.gcsafe, nimcal
     arg.finish(%* {
       "error": e.msg,
     })
+
+type
+  AsyncGetRevealedAccountsForAllMembersArg = ref object of QObjectTaskArg
+    communityId: string
+
+const asyncGetRevealedAccountsForAllMembersTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+  let arg = decode[AsyncGetRevealedAccountsForAllMembersArg](argEncoded)
+  try:
+    let response = status_go.getRevealedAccountsForAllMembers(arg.communityId)
+    arg.finish(%* {
+      "communityId": arg.communityId,
+      "response": response,
+      "error": "",
+    })
+  except Exception as e:
+    arg.finish(%* {
+      "communityId": arg.communityId,
+      "error": e.msg,
+    })

--- a/src/backend/communities.nim
+++ b/src/backend/communities.nim
@@ -61,6 +61,17 @@ proc editSharedAddresses*(
     "airdropAddress": airdropAddress,
   }])
 
+proc getRevealedAccountsForMember*(
+    communityId: string,
+    memberPubkey: string,
+  ): RpcResponse[JsonNode] {.raises: [Exception].} =
+  result = callPrivateRPC("getRevealedAccounts".prefix, %*[communityId, memberPubkey])
+
+proc getRevealedAccountsForAllMembers*(
+    communityId: string,
+  ): RpcResponse[JsonNode] {.raises: [Exception].} =
+  result = callPrivateRPC("getRevealedAccountsForAllMembers".prefix, %*[communityId])
+
 proc checkPermissionsToJoinCommunity*(communityId: string): RpcResponse[JsonNode] {.raises: [Exception].} =
   result = callPrivateRPC("checkPermissionsToJoinCommunity".prefix, %*[{
     "communityId": communityId

--- a/ui/app/AppLayouts/Communities/views/CommunitySettingsView.qml
+++ b/ui/app/AppLayouts/Communities/views/CommunitySettingsView.qml
@@ -504,14 +504,7 @@ StatusSectionLayout {
 
             assetsModel: assetsModelLoader.item
             collectiblesModel: collectiblesModelLoader.item
-            membersModel: {
-                const chatContentModule = root.rootStore.currentChatContentModule()
-                if (!chatContentModule || !chatContentModule.usersModule) {
-                    // New communities have no chats, so no chatContentModule
-                    return null
-                }
-                return chatContentModule.usersModule.model
-            }
+            membersModel: community.members
 
             accountsModel: SortFilterProxyModel {
                 sourceModel: root.rootStore.accounts


### PR DESCRIPTION
Fixes #11817

Instead of getting revealed accounts from the community description (it's no longer available), uses the new `getRevealedAccountsForAllMembers` API. Uses it async so that we do not slow the start process. The model is updated correctly when we finish loading them.

status-go PR: https://github.com/status-im/status-go/pull/3864

Screenshot shows a "hacked" version of the member downdown that shows that we indeed have the airdrop address

![image](https://github.com/status-im/status-desktop/assets/11926403/612c075d-57ce-4218-9076-b7f25e168a2e)
