### PR TITLE
fix(Permissions): Disable amount input for unique tokens + update amount indicator

### DIFF
--- a/storybook/pages/HoldingsDropdownPage.qml
+++ b/storybook/pages/HoldingsDropdownPage.qml
@@ -66,11 +66,11 @@ SplitView {
                 proxyRoles: [
                     ExpressionRole {
                         name: "supply"
-                        expression: (model.index + 1) * 115
+                        expression: model.index === 1 ? model.index : (model.index + 1) * 115
                     },
                     ExpressionRole {
                         name: "infiniteSupply"
-                        expression: !(model.index % 4)
+                        expression: !((model.index + 1) % 4)
                     },
                     ExpressionRole {
                         name: "chainName"
@@ -85,11 +85,6 @@ SplitView {
                         expression: model.index ? icon1 : icon2
                     }
                 ]
-
-                filters: ValueFilter {
-                    roleName: "category"
-                    value: TokenCategories.Category.Community
-                }
             }
 
             AssetsModel {
@@ -130,13 +125,9 @@ SplitView {
                 }
             }
 
-            collectiblesModel: isAirdropMode.checked
-                               ? collectiblesModelWithSupply
-                               : collectiblesModel
+            collectiblesModel: collectiblesModelWithSupply
 
-            assetsModel: isAirdropMode.checked
-                         ? assetsModelWithSupply
-                         : assetsModel
+            assetsModel: assetsModelWithSupply
             isENSTab: isEnsTabChecker.checked
 
             onOpened: contentItem.parent.parent = container

--- a/ui/app/AppLayouts/Communities/controls/ExtendedDropdownContent.qml
+++ b/ui/app/AppLayouts/Communities/controls/ExtendedDropdownContent.qml
@@ -28,7 +28,7 @@ Item {
 
     property string noDataText: qsTr("No data found")
     property bool showAllTokensMode: false
-
+    property bool showTokenAmount: true
     readonly property bool canGoBack: root.state !== d.depth1_ListState
 
     signal itemClicked(string key, string name, url iconSource)
@@ -491,6 +491,7 @@ Item {
             isFooterButtonVisible: !root.showAllTokensMode && !d.searchMode
                                    && filteredModel.item && d.currentModel.count > filteredModel.item.count
 
+            showTokenAmount: root.showTokenAmount
             onHeaderItemClicked: root.navigateToMintTokenSettings()
             onFooterButtonClicked: root.footerButtonClicked()
 
@@ -537,6 +538,7 @@ Item {
                                    && filteredModel.item && d.currentModel
                                    && d.currentModel.count > filteredModel.item.count
 
+            showTokenAmount: root.showTokenAmount
             onHeaderItemClicked: root.navigateToMintTokenSettings()
             onFooterButtonClicked: root.footerButtonClicked()
 

--- a/ui/app/AppLayouts/Communities/controls/ListDropdownContent.qml
+++ b/ui/app/AppLayouts/Communities/controls/ListDropdownContent.qml
@@ -27,6 +27,7 @@ StatusListView {
     property string noDataText: qsTr("No data found")
 
     property int maxHeight: 381 // default by design
+    property bool showTokenAmount: true
 
     signal headerItemClicked(string key)
     signal itemClicked(var key, string name, var shortName,  url iconSource, var subItems)
@@ -96,7 +97,15 @@ StatusListView {
         iconSource: model.iconSource ?? ""
         showSubItemsIcon: !!model.subItems && model.subItems.count > 0
         selected: root.checkedKeys.includes(model.key)
-        amount: !!model.infiniteSupply ? "∞" : model.supply ?? ""
+        amount: {
+            if(!model.infiniteSupply && !!model.supply && model.supply == 1)
+                return qsTr("Max. 1")
+
+            if(root.showTokenAmount)
+                return !!model.infiniteSupply ? "∞" : model.supply ?? ""
+            
+            return ""
+        }
 
         onItemClicked: root.itemClicked(
                            model.key, name, shortName, iconSource, model.subItems)

--- a/ui/app/AppLayouts/Communities/popups/HoldingsDropdown.qml
+++ b/ui/app/AppLayouts/Communities/popups/HoldingsDropdown.qml
@@ -41,6 +41,7 @@ StatusDropdown {
     property real collectibleAmount: 1
 
     property string ensDomainName: ""
+    property bool showTokenAmount: true
 
     signal addAsset(string key, real amount)
     signal addCollectible(string key, real amount)
@@ -284,6 +285,7 @@ StatusDropdown {
             checkedKeys: root.usedTokens.map(entry => entry.key)
             type: d.extendedDropdownType
             showAllTokensMode: d.allTokensMode
+            showTokenAmount: root.showTokenAmount
 
             Binding on showAllTokensMode {
                 value: true
@@ -324,7 +326,18 @@ StatusDropdown {
                 if(d.extendedDropdownType === ExtendedDropdownContent.Type.Assets)
                     root.assetKey = key
                 else
+                {
                     root.collectibleKey = key
+                    const amount = PermissionsHelpers.getTokenAmountByKey(root.collectiblesModel, root.collectibleKey)
+                    //When the collectible is unique, there is no need for the user to select amount
+                    //Just send the add/update events
+                    if(amount == 1) {
+                        root.collectibleAmount = amount
+                        d.updateSelected ? root.updateCollectible(root.collectibleKey, amount)
+                                            : root.addCollectible(root.collectibleKey, amount)
+                        return
+                    }
+                }
 
                 statesStack.push(HoldingsDropdown.FlowType.Selected)
             }

--- a/ui/app/AppLayouts/Communities/views/EditPermissionView.qml
+++ b/ui/app/AppLayouts/Communities/views/EditPermissionView.qml
@@ -236,6 +236,7 @@ StatusScrollView {
 
                 assetsModel: root.assetsModel
                 collectiblesModel: root.collectiblesModel
+                showTokenAmount: false
 
                 function addItem(type, item, amount) {
                     const key = item.key


### PR DESCRIPTION
### What does the PR do
Closes: #10546 

Changes in the Permissions design:
1. If the collectible is unique the amount input is disabled. 1 is auto-selected
2. Show `Max. 1` for unique tokens and empty string for other tokens

Changes in the Airdrop design:
1. Show `Max. 1` for unique tokens

### Affected areas

Permissions
Airdrop

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it


https://github.com/status-im/status-desktop/assets/47811206/cf3848f6-e1f9-45a5-9374-4b88850fc5e7


<!-- screenshot (or gif/video) that demonstrates the functionality, specially important if it's a bug fix. -->

### Cool Spaceship Picture

<!-- optional but cool ->
