### PR TITLE
fix: Fixing MacOs arm64 crash on SIGURG signal

### DIFF
--- a/src/nim_status_client.nim
+++ b/src/nim_status_client.nim
@@ -94,6 +94,16 @@ proc mainProc() =
         echo("sigaltstack error!")
         quit()
 
+    var sa: ptr Sigaction = cast[ptr Sigaction](allocShared0(sizeof(Sigaction)))
+    var sa2: Sigaction
+
+    sa.sa_handler = SIG_DFL
+    sa.sa_flags = SA_ONSTACK
+
+    if sigaction(SIGURG, sa[], addr sa2) < 0:
+        echo("sigaction error!")
+        quit()
+
   if main_constants.IS_MACOS and defined(production):
     setCurrentDir(getAppDir())
 


### PR DESCRIPTION
### What does the PR do

Closing #10743

The root cause of this issue is still unknown to me. It can be reproduced while using the keycard to login. On most calls to status-keycard-go signal 16 will be triggered. Most of the times the signal handling works fine, but sometimes the signal handler is called outside of gsignal stack, goroutine scheduling stack, or sigaltstack. On some environments it happens quite often, on my environment it happens once every 10-50k calls to status-keycard-go.

Go is reporting the following error:
```
signal 16 received but handler not on signal stack
fatal error: non-Go code set up signal handler without SA_ONSTACK flag
```

Looking through go reported issues, I found 3 main reasons for this error:
1. Missing SA_ONSTACK on the sigaction - not in our case. When main is called there is a sigaction registered with SA_ONSTACK flag and I couldn't find any change in this signal during the app lifetime.
2. Stack is too small. IDK how to rule out this 100% certainty. nim_status_client is registering an alternative stack at startup and it should be used by go. Increasing the stack size has no effect.
3. Chained sigactions - When registering a new sig handler with `sigaction` there is the option to cache the old handler in order to chain the sigactions. Depending on implementation details, chaining signals can trigger the go handler on another stack. This seems to be the case here.

A workaround for this issue is to register the default signahdler for SIGURG.

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas

MacOs arm64 builds
