### PR TITLE
sign-macos-pkg.sh: move gatekeeper verification

### DIFF
--- a/scripts/notarize-macos-pkg.sh
+++ b/scripts/notarize-macos-pkg.sh
@@ -64,4 +64,11 @@ fi
 # Optional but preferrable to attach the ticket to the bundle.
 echo -e "\n### Stapling Notarization Ticket..."
 xcrun stapler staple "${BUNDLE_PATH}"
+
+echo -e "\n### Validating Signature and Notarization..."
+spctl --verbose=2 \
+    --assess --type open \
+    --context context:primary-signature \
+    "${BUNDLE_PATH}"
+
 exit $?

--- a/scripts/sign-macos-pkg.sh
+++ b/scripts/sign-macos-pkg.sh
@@ -17,7 +17,7 @@ CODESIGN_OPTS_EXTRA=("${@}")
 
 function clean_up {
     STATUS=$?
-    if [[ "${STATUS}" -eq 0 ]]; then
+    if [[ "${STATUS}" -ne 0 ]]; then
         echo -e "\n###### ERROR: See above for details."
     fi
     set +e
@@ -80,15 +80,5 @@ codesign ${CODESIGN_OPTS[@]} "${TARGET}"
 
 echo -e "\n### Verifying signature..."
 codesign --verify --strict=all --deep --verbose=4 "${TARGET}"
-
-echo -e "\n### Assessing Gatekeeper validation..."
-if [[ -d "${TARGET}" ]]; then
-    spctl --assess --type execute --verbose=2 "${TARGET}"
-else
-    echo "WARNING: The 'open' type security assesment is disabled due to lack of 'Notarization'"
-    # Issue: https://github.com/status-im/status-mobile/pull/9172
-    # Details: https://developer.apple.com/documentation/security/notarizing_your_app_before_distribution
-    #spctl --assess --type open --context context:primary-signature --verbose=2 "${OBJECT}"
-fi
 
 echo -e "\n###### DONE"


### PR DESCRIPTION
This now fails when the app is signed with a new certificate create from our new Apple organization but is not notarized:
```
tmp/macos/dist/Status.app: rejected
source=Unnotarized Developer ID
```
I actually have absolutely no idea why this verification worked with the old certificate, but it did.

For that reason I'm moving it to after notarization.