### PR TITLE
fix(wallet) duplicate entries in activity

### DIFF
--- a/src/app_service/service/transaction/service.nim
+++ b/src/app_service/service/transaction/service.nim
@@ -123,8 +123,7 @@ QtObject:
 
   proc getPendingTransactions*(self: Service): seq[TransactionDto] =
     try:
-      let chainIds = self.networkService.getNetworks().map(a => a.chainId)
-      let response = backend.getPendingTransactionsByChainIDs(chainIds).result
+      let response = backend.getPendingTransactions().result
       if (response.kind == JArray and response.len > 0):
         return response.getElems().map(x => x.toPendingTransactionDto())
 
@@ -192,12 +191,6 @@ QtObject:
       slot: "onFetchDecodedTxData",
     )
     self.threadpool.start(arg)
-
-  proc watchPendingTransactions*(self: Service): seq[TransactionDto] =
-    let pendingTransactions = self.getPendingTransactions()
-    for tx in pendingTransactions:
-      self.watchTransaction(tx.txHash, tx.fromAddress, tx.to, tx.typeValue, tx.input, tx.chainId, track = false)
-    return pendingTransactions
 
   proc createApprovalPath*(self: Service, route: TransactionPathDto, from_addr: string, toAddress: Address, gasFees: string): TransactionBridgeDto =
     var txData = TransactionDataDto()

--- a/src/backend/backend.nim
+++ b/src/backend/backend.nim
@@ -98,8 +98,8 @@ rpc(getTokensBalancesForChainIDs, "wallet"):
   accounts: seq[string]
   tokens: seq[string]
 
-rpc(getPendingTransactionsByChainIDs, "wallet"):
-  chainIds: seq[int]
+rpc(getPendingTransactions, "wallet"):
+  discard
 
 type
   TransactionIdentity* = ref object


### PR DESCRIPTION
### Closes https://github.com/status-im/status-desktop/issues/11754

The multi-transaction ID was not propagated. The status-go change fixes this.

Bumps status-go [#3839](https://github.com/status-im/status-go/pull/3839)