### PR TITLE
fix(@desktop/activity): Fix filter layout and added recipient search

### DIFF
--- a/ui/StatusQ/src/StatusQ/Controls/StatusInput.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusInput.qml
@@ -65,6 +65,11 @@ Item {
     */
     property alias placeholderText: statusBaseInput.placeholderText
     /*!
+        \qmlproperty alias StatusInput::placeholderFont
+        This property holds a reference to the TextEdit's placeholder font property.
+    */
+    property alias placeholderFont: statusBaseInput.placeholderFont
+    /*!
         \qmlproperty alias StatusInput::font
         This property holds a reference to the TextEdit's font property.
     */

--- a/ui/app/AppLayouts/Wallet/WalletLayout.qml
+++ b/ui/app/AppLayouts/Wallet/WalletLayout.qml
@@ -97,12 +97,12 @@ Item {
             id: leftTab
             anchors.fill: parent
             changeSelectedAccount: function(address) {
-                RootStore.setFilterAddress(address)
                 root.resetView()
+                RootStore.setFilterAddress(address)
             }
             selectAllAccounts: function() {
-                RootStore.setFillterAllAddresses()
                 root.resetView()
+                RootStore.setFillterAllAddresses()
             }
             onShowSavedAddressesChanged: {
                 if(showSavedAddresses)

--- a/ui/app/AppLayouts/Wallet/popups/ActivityFilterMenu.qml
+++ b/ui/app/AppLayouts/Wallet/popups/ActivityFilterMenu.qml
@@ -84,7 +84,7 @@ StatusMenu {
         }
         ActivityTokensFilterSubMenu {
             id: tokensMenu
-            height: Math.min(439, tokensMenu.implicitHeight)
+            height: 439
             onBack: root.open()
             tokensList: root.tokensList
             tokensFilter: root.tokensFilter
@@ -96,7 +96,7 @@ StatusMenu {
         }
         ActivityCounterpartyFilterSubMenu {
             id: counterPartyMenu
-            height: Math.min(439, counterPartyMenu.implicitHeight)
+            height: 439
             onBack: root.open()
             store: root.store
             recentsList: root.recentsList

--- a/ui/app/AppLayouts/Wallet/popups/filterSubMenus/ActivityTokensFilterSubMenu.qml
+++ b/ui/app/AppLayouts/Wallet/popups/filterSubMenus/ActivityTokensFilterSubMenu.qml
@@ -28,7 +28,7 @@ StatusMenu {
     signal tokenToggled(string tokenSymbol)
     signal collectibleToggled(double id)
 
-    property var searchTokenSymbolByAddressFn: function (address) { return "" }
+    property var searchTokenSymbolByAddressFn: function (address) { return "" } // TODO
 
     implicitWidth: 289
 
@@ -37,140 +37,148 @@ StatusMenu {
         property bool isFetching: root.collectiblesList.isFetching
     }
 
-    MenuBackButton {
-        id: backButton
-        width: parent.width
-        onClicked: {
-            close()
-            back()
-        }
-    }
-
-    StatusSwitchTabBar {
-        id: tabBar
-        anchors.horizontalCenter: parent.horizontalCenter
-        anchors.top: backButton.bottom
-        anchors.topMargin: 12
-        width: parent.width - 16
-        StatusSwitchTabButton {
-            text: qsTr("Assets")
-        }
-        StatusSwitchTabButton {
-            text: qsTr("Collectibles")
-        }
-    }
-
-    StackLayout {
-        id: layout
-        width: parent.width
-        anchors.top: tabBar.bottom
-        anchors.topMargin: 12
-        currentIndex: tabBar.currentIndex
-
-        Column {
+    contentItem: ColumnLayout {
+        spacing: 12
+        MenuBackButton {
+            id: backButton
             Layout.fillWidth: true
-            spacing: 8
-
-            ButtonGroup {
-                id: tokenButtonGroup
-                exclusive: false
-            }
-
-            StatusBaseText {
-                anchors.horizontalCenter: parent.horizontalCenter
-                text: qsTr("No Assets")
-                visible: root.tokensList.count === 0
-            }
-
-            SearchBox {
-                id: tokensSearchBox
-                anchors.horizontalCenter: parent.horizontalCenter
-                width: parent.width - 16
-                input.height: 36
-                placeholderText: qsTr("Search asset name")
-            }
-
-            StatusListView {
-                width: parent.width
-                height: root.height - tabBar.height - tokensSearchBox.height - 12
-                spacing: 0
-                model: SortFilterProxyModel {
-                    sourceModel: root.tokensList
-                    filters: ExpressionFilter {
-                        enabled: root.tokensList.count > 0
-                        expression: {
-                            var tokenSymbolByAddress = root.searchTokenSymbolByAddressFn(tokensSearchBox.text)
-                            return symbol.startsWith(tokensSearchBox.text.toUpperCase()) || name.toUpperCase().startsWith(tokensSearchBox.text.toUpperCase()) || (tokenSymbolByAddress!=="" && symbol.startsWith(tokenSymbolByAddress))
-                        }
-                    }
-                }
-                delegate: ActivityTypeCheckBox {
-                    width: ListView.view.width
-                    height: 44
-                    title: model.name
-                    titleAsideText: model.symbol
-                    assetSettings.name: model.symbol ? Constants.tokenIcon(symbol) : ""
-                    assetSettings.isImage: true
-                    buttonGroup: tokenButtonGroup
-                    allChecked: root.allTokensChecked
-                    checked: root.allTokensChecked || root.tokensFilter.includes(model.symbol)
-                    onActionTriggered: root.tokenToggled(model.symbol)
-                }
+            onClicked: {
+                close()
+                back()
             }
         }
 
-        Column {
-            width: parent.width
-            spacing: 8
-
-            ButtonGroup {
-                id: collectibleButtonGroup
-                exclusive: false
+        StatusSwitchTabBar {
+            id: tabBar
+            Layout.alignment: Qt.AlignHCenter
+            Layout.fillWidth: true
+            Layout.leftMargin: 8
+            Layout.rightMargin: 8
+            StatusSwitchTabButton {
+                text: qsTr("Assets")
             }
-
-            StatusBaseText {
-                anchors.horizontalCenter: parent.horizontalCenter
-                text: qsTr("No Collectibles")
-                visible: root.collectiblesList.count === 0
+            StatusSwitchTabButton {
+                text: qsTr("Collectibles")
             }
+        }
 
-            SearchBox {
-                id: collectiblesSearchBox
-                anchors.horizontalCenter: parent.horizontalCenter
-                width: parent.width - 16
-                input.height: 36
-                placeholderText: qsTr("Search collectible name")
-            }
+        StackLayout {
+            id: layout
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            currentIndex: tabBar.currentIndex
 
-            StatusListView {
-                width: parent.width
-                height: root.height - tabBar.height - tokensSearchBox.height - 12
-                spacing: 0
-                reuseItems: true
-                model: SortFilterProxyModel {
-                    sourceModel: root.collectiblesList
-                    filters: ExpressionFilter {
-                        enabled: root.collectiblesList.count > 0 && !!collectiblesSearchBox.text
-                        expression: {
-                            let searchText = collectiblesSearchBox.text.toUpperCase()
-                            return name.toUpperCase().startsWith(searchText)
+            ColumnLayout {
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                spacing: 8
+
+                ButtonGroup {
+                    id: tokenButtonGroup
+                    exclusive: false
+                }
+
+                StatusBaseText {
+                    Layout.alignment: Qt.AlignHCenter
+                    text: qsTr("No Assets")
+                    visible: root.tokensList.count === 0
+                }
+
+                SearchBox {
+                    id: tokensSearchBox
+                    Layout.alignment: Qt.AlignHCenter
+                    Layout.fillWidth: true
+                    Layout.leftMargin: 8
+                    Layout.rightMargin: 8
+                    input.height: 36
+                    placeholderText: qsTr("Search asset name")
+                }
+
+                StatusListView {
+                    Layout.fillWidth: true
+                    Layout.fillHeight: true
+                    spacing: 0
+                    model: SortFilterProxyModel {
+                        sourceModel: root.tokensList
+                        filters: ExpressionFilter {
+                            enabled: root.tokensList.count > 0
+                            expression: {
+                                const tokenSymbolByAddress = root.searchTokenSymbolByAddressFn(tokensSearchBox.text)
+                                return symbol.startsWith(tokensSearchBox.text.toUpperCase()) || name.toUpperCase().startsWith(tokensSearchBox.text.toUpperCase()) || (tokenSymbolByAddress!=="" && symbol.startsWith(tokenSymbolByAddress))
+                            }
                         }
                     }
+                    delegate: ActivityTypeCheckBox {
+                        width: ListView.view.width
+                        height: 44
+                        title: model.name
+                        titleAsideText: model.symbol
+                        assetSettings.name: model.symbol ? Constants.tokenIcon(symbol) : ""
+                        assetSettings.isImage: true
+                        buttonGroup: tokenButtonGroup
+                        allChecked: root.allTokensChecked
+                        checked: root.allTokensChecked || root.tokensFilter.includes(model.symbol)
+                        onActionTriggered: root.tokenToggled(model.symbol)
+                    }
                 }
-                delegate: ActivityTypeCheckBox {
-                    width: ListView.view.width
-                    height: 44
-                    title: model.name
-                    assetSettings.name: model.imageUrl
-                    assetSettings.isImage: true
-                    assetSettings.bgWidth: 32
-                    assetSettings.bgHeight: 32
-                    assetSettings.bgRadius: assetSettings.bgHeight/2
-                    buttonGroup: collectibleButtonGroup
-                    allChecked: root.allCollectiblesChecked
-                    checked: root.allCollectiblesChecked || root.collectiblesFilter.includes(model.id)
-                    onActionTriggered: root.collectibleToggled(model.id)
-                    loading: d.isFetching
+            }
+
+            ColumnLayout {
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                spacing: 8
+
+                ButtonGroup {
+                    id: collectibleButtonGroup
+                    exclusive: false
+                }
+
+                StatusBaseText {
+                    Layout.alignment: Qt.AlignHCenter
+                    text: qsTr("No Collectibles")
+                    visible: root.collectiblesList.count === 0
+                }
+
+                SearchBox {
+                    id: collectiblesSearchBox
+                    Layout.alignment: Qt.AlignHCenter
+                    Layout.fillWidth: true
+                    Layout.leftMargin: 8
+                    Layout.rightMargin: 8
+                    input.height: 36
+                    placeholderText: qsTr("Search collectible name")
+                }
+
+                StatusListView {
+                    Layout.fillWidth: true
+                    Layout.fillHeight: true
+                    spacing: 0
+                    reuseItems: true
+                    model: SortFilterProxyModel {
+                        sourceModel: root.collectiblesList
+                        filters: ExpressionFilter {
+                            enabled: root.collectiblesList.count > 0 && !!collectiblesSearchBox.text
+                            expression: {
+                                const searchText = collectiblesSearchBox.text.toUpperCase()
+                                return name.toUpperCase().startsWith(searchText)
+                            }
+                        }
+                    }
+                    delegate: ActivityTypeCheckBox {
+                        width: ListView.view.width
+                        height: 44
+                        title: model.name
+                        assetSettings.name: model.imageUrl
+                        assetSettings.isImage: true
+                        assetSettings.bgWidth: 32
+                        assetSettings.bgHeight: 32
+                        assetSettings.bgRadius: assetSettings.bgHeight/2
+                        buttonGroup: collectibleButtonGroup
+                        allChecked: root.allCollectiblesChecked
+                        checked: root.allCollectiblesChecked || root.collectiblesFilter.includes(model.id)
+                        onActionTriggered: root.collectibleToggled(model.id)
+                        loading: d.isFetching
+                    }
                 }
             }
         }

--- a/ui/app/AppLayouts/Wallet/views/TransactionDetailView.qml
+++ b/ui/app/AppLayouts/Wallet/views/TransactionDetailView.qml
@@ -486,6 +486,7 @@ Item {
                             }
                         }
                         tertiaryTitle: !d.loadingInputDate && !d.decodedInputData ? qsTr("Data could not be decoded") : ""
+                        statusListItemTertiaryTitle.anchors.top: undefined
                         statusListItemTertiaryTitle.anchors.baseline: statusListItemTitle.baseline
                         statusListItemTertiaryTitle.font: statusListItemTitle.font
                         onButtonClicked: addressMenu.openInputDataMenu(this, !!d.decodedInputData ? d.decodedInputData : root.transaction.input)


### PR DESCRIPTION
fixes #11879 
fixes #11878

### What does the PR do

#### #11879
* Disabled refreshing activity model when changing account while activity tab is selected
#### #11878
* fixed filter layout for tokens and recipients lists
* added search for recipients and saved addresss
* fixed saved wallets icons size

### Affected areas

Wallet activity UI

### Screenshot of functionality (including design for comparison)


https://github.com/status-im/status-desktop/assets/11396062/3dc759a9-c3e5-4ff0-9f9a-519d28b09a57

