### PR TITLE
fix(Mint token): Network selector not shown properly 

### DIFF
--- a/storybook/pages/AirdropsSettingsPanelPage.qml
+++ b/storybook/pages/AirdropsSettingsPanelPage.qml
@@ -198,6 +198,7 @@ SplitView {
                     readonly property string color: "red"
                     readonly property bool owner: true
                 }
+                accountsModel: WalletAccountsModel {}
 
                 onAirdropClicked: logs.logEvent("AirdropsSettingsPanel::onAirdropClicked")
             }

--- a/storybook/pages/MembersDropdownPage.qml
+++ b/storybook/pages/MembersDropdownPage.qml
@@ -85,7 +85,8 @@ SplitView {
                 onlineStatus: 1,
                 pubKey: key,
                 isVerified: true,
-                isUntrustworthy: false
+                isUntrustworthy: false,
+                airdropAddress: `0x${firstLetter}${i}`
             })
         }
 

--- a/storybook/src/Models/NetworksModel.qml
+++ b/storybook/src/Models/NetworksModel.qml
@@ -9,13 +9,16 @@ QtObject {
     readonly property int arbitrumNet: 3
     readonly property int hermezNet: 4
     readonly property int testnetNet: 5
-    readonly property int customNet: 6   
+    readonly property int customNet: 6
 
-    readonly property var layer1Networks: ListModel {
+    component CustomNetworkModel: ListModel {
+        // Simulate Nim's way of providing access to data
         function rowData(index, propName) {
             return get(index)[propName]
         }
+    }
 
+    readonly property var layer1Networks: CustomNetworkModel {
         Component.onCompleted:
             append([
                        {
@@ -31,7 +34,7 @@ QtObject {
                    ])
     }
 
-    readonly property var layer2Networks: ListModel {
+    readonly property var layer2Networks: CustomNetworkModel {
         Component.onCompleted:
             append([
                        {
@@ -57,7 +60,7 @@ QtObject {
                    ])
     }
 
-    readonly property var testNetworks: ListModel {
+    readonly property var testNetworks: CustomNetworkModel {
         Component.onCompleted:
             append([
                        {
@@ -93,12 +96,7 @@ QtObject {
                    ])
     }
 
-    readonly property var enabledNetworks: ListModel {
-        // Simulate Nim's way of providing access to data
-        function rowData(index, propName) {
-            return get(index)[propName]
-        }
-
+    readonly property var enabledNetworks: CustomNetworkModel {
         Component.onCompleted:
             append([
                        {
@@ -170,12 +168,7 @@ QtObject {
                    ])
     }
 
-    readonly property var allNetworks: ListModel {
-        // Simulate Nim's way of providing access to data
-        function rowData(index, propName) {
-            return get(index)[propName]
-        }
-
+    readonly property var allNetworks: CustomNetworkModel {
         Component.onCompleted: append([
             {
                 chainId: 1,
@@ -264,7 +257,7 @@ QtObject {
         )
     }
 
-    readonly property var mainNetworks: ListModel {
+    readonly property var mainNetworks: CustomNetworkModel {
         Component.onCompleted: append([
                    {
                        chainId: 1,

--- a/ui/app/AppLayouts/Wallet/controls/NetworkFilter.qml
+++ b/ui/app/AppLayouts/Wallet/controls/NetworkFilter.qml
@@ -66,7 +66,7 @@ StatusComboBox {
         readonly property bool noneSelected: (!!root.enabledNetworks) ? root.enabledNetworks.count === 0 : false
 
         // Persist selection between selectPopupLoader reloads
-        property var currentModel: layer1Networks
+        property var currentModel: layer2Networks
         property int currentIndex: 0
     }
 
@@ -116,7 +116,7 @@ StatusComboBox {
             visible: !d.allSelected && chainRepeater.count > 0
             Repeater {
                 id: chainRepeater
-                model: root.enabledNetworks
+                model: root.multiSelection ? root.enabledNetworks : []
                 delegate: StatusRoundedImage {
                     width: 24
                     height: 24

--- a/ui/app/AppLayouts/Wallet/stores/NetworkSelectPopup/SingleSelectionInfo.qml
+++ b/ui/app/AppLayouts/Wallet/stores/NetworkSelectPopup/SingleSelectionInfo.qml
@@ -3,6 +3,6 @@ import QtQml 2.15
 /// Inline component was failing on Linux with "Cannot assign to property of unknown type" so we need to use a separate file for it.
 QtObject {
     property bool enabled: false
-    property var currentModel: root.layer1Networks
+    property var currentModel: root.layer2Networks
     property int currentIndex: 0
 }


### PR DESCRIPTION
### What does the PR do

Fixes 2 problems, mainly visible when switching between test and non-test
networks:
- do not display network icons in single selection mode
- make really sure the default chain is Optimism

Separate commit to fix some other storybook run failures/issues

Fixes #11846

### Affected areas

<!-- List the affected areas (e.g wallet, browser, etc..) -->

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

[Záznam obrazovky z 2023-08-15 14-07-23.webm](https://github.com/status-im/status-desktop/assets/5377645/5d9528a1-e35f-4c80-8eb2-73df40818a4b)
