### PR TITLE
Ask for confirmation before clearing chat history

### DIFF
--- a/ui/imports/shared/views/chat/ChatContextMenuView.qml
+++ b/ui/imports/shared/views/chat/ChatContextMenuView.qml
@@ -197,13 +197,14 @@ StatusMenu {
     }
 
     StatusMenuSeparator {
-        visible: deleteOrLeaveMenuItem.enabled
+        visible: clearHistoryMenuItem.enabled || deleteOrLeaveMenuItem.enabled
     }
 
     StatusAction {
         objectName: "clearHistoryMenuItem"
         text: qsTr("Clear History")
         icon.name: "close-circle"
+        type: deleteOrLeaveMenuItem.enabled ? StatusAction.Type.Normal : StatusAction.Type.Danger
         onTriggered: {
             Global.openPopup(clearChatConfirmationDialogComponent);
         }


### PR DESCRIPTION
# What

Currently, when the user clears the chat history for a 1-to-1, group or community channel, the action is performed without any confirmation and this is a destructive action (at least for the current user).

# How

Add a confirmation dialog, similar to the one used for delete chat/leave group chat, with the following amendments:

1. Move the context menu action item to the third vertical section, along with delete/leave action, since both are irrevocable.
2. Don't show both context menu action items in red label, only one, with delete taking priority, even though the user profile context menu sports this
<img width="195" alt="image" src="https://github.com/status-im/status-desktop/assets/544446/2ec41db0-b511-4e88-93e6-35563f7b4ad1">

3. The Cancel button for dialog dismissal is displayed in **normal** type, only the destructive confirm button is in red **danger** type.
4. Show the Cancel button even if we are clearing a Community channel chat.

# TODO

- [x] Add video showcasing the improvement
- [ ] Shouldn't we also **confirm leaving a private group chat**? https://github.com/status-im/status-desktop/pull/11891#issuecomment-1680442396
- [x] Confirm that we don't need to show a **Leave button** for community chat admins (see ecc1b53 and #10963)? https://github.com/status-im/status-desktop/blob/3373973e7f64e3ea443415520ef62ed315413c14/ui/imports/shared/views/chat/ChatContextMenuView.qml#L239

---

Closes #10651 