### PR TITLE
chore(@desktop/wallet): Move send modal logic over to nim side

### DIFF
--- a/src/app/modules/main/profile_section/ens_usernames/controller.nim
+++ b/src/app/modules/main/profile_section/ens_usernames/controller.nim
@@ -88,7 +88,7 @@ proc setPubKeyGasEstimate*(self: Controller, chainId: int, ensUsername: string, 
   return self.ensService.setPubKeyGasEstimate(chainId, ensUsername, address)
 
 proc setPubKey*(self: Controller, chainId: int, ensUsername: string, address: string, gas: string, gasPrice: string,
-  maxPriorityFeePerGas: string, maxFeePerGas: string, password: string, eip1559Enabled: bool): string =
+  maxPriorityFeePerGas: string, maxFeePerGas: string, password: string, eip1559Enabled: bool): EnsTxResultArgs =
   return self.ensService.setPubKey(chainId, ensUsername, address, gas, gasPrice, maxPriorityFeePerGas, maxFeePerGas, password, eip1559Enabled)
 
 proc getSigningPhrase*(self: Controller): string =
@@ -108,7 +108,7 @@ proc releaseEnsEstimate*(self: Controller, chainId: int, ensUsername: string, ad
 
 proc release*(self: Controller, chainId: int, ensUsername: string, address: string, gas: string, gasPrice: string,
   maxPriorityFeePerGas: string, maxFeePerGas: string, password: string, eip1559Enabled: bool):
-  string =
+  EnsTxResultArgs =
   return self.ensService.release(chainId, ensUsername, address, gas, gasPrice, maxPriorityFeePerGas, maxFeePerGas, password, eip1559Enabled)
 
 proc setPreferredName*(self: Controller, preferredName: string) =
@@ -137,7 +137,7 @@ proc registerEnsGasEstimate*(self: Controller, chainId: int, ensUsername: string
   return self.ensService.registerEnsGasEstimate(chainId, ensUsername, address)
 
 proc registerEns*(self: Controller, chainId: int, ensUsername: string, address: string, gas: string, gasPrice: string,
-  maxPriorityFeePerGas: string, maxFeePerGas: string, password: string, eip1559Enabled: bool): string =
+  maxPriorityFeePerGas: string, maxFeePerGas: string, password: string, eip1559Enabled: bool): EnsTxResultArgs =
   return self.ensService.registerEns(chainId, ensUsername, address, gas, gasPrice, maxPriorityFeePerGas, maxFeePerGas, password, eip1559Enabled)
 
 proc getSNTBalance*(self: Controller): string =

--- a/src/app/modules/main/profile_section/ens_usernames/view.nim
+++ b/src/app/modules/main/profile_section/ens_usernames/view.nim
@@ -74,9 +74,9 @@ QtObject:
     self.loading(false)
     self.detailsObtained(chainId, ensUsername, address, pubkey, isStatus, expirationTime)
 
-  proc transactionWasSent(self: View, txResult: string) {.signal.}
-  proc emitTransactionWasSentSignal*(self: View, txResult: string) =
-    self.transactionWasSent(txResult)
+  proc transactionWasSent(self: View, chainId: int, txHash: string, error: string) {.signal.}
+  proc emitTransactionWasSentSignal*(self: View, chainId: int, txHash: string, error: string) =
+    self.transactionWasSent(chainId, txHash, error)
 
   proc setPubKeyGasEstimate*(self: View, chainId: int, ensUsername: string, address: string): int {.slot.} =
     return self.delegate.setPubKeyGasEstimate(chainId, ensUsername, address)

--- a/src/app/modules/main/stickers/controller.nim
+++ b/src/app/modules/main/stickers/controller.nim
@@ -97,7 +97,7 @@ proc init*(self: Controller) =
     let args = StickerPackInstalledArgs(e)
     self.delegate.onStickerPackInstalled(args.packId)
 
-proc buy*(self: Controller, packId: string, address: string, gas: string, gasPrice: string, maxPriorityFeePerGas: string, maxFeePerGas: string, password: string, eip1559Enabled: bool): tuple[response: string, success: bool] =
+proc buy*(self: Controller, packId: string, address: string, gas: string, gasPrice: string, maxPriorityFeePerGas: string, maxFeePerGas: string, password: string, eip1559Enabled: bool): StickerBuyResultArgs =
   self.stickerService.buy(packId, address, gas, gasPrice, maxPriorityFeePerGas, maxFeePerGas, password, eip1559Enabled)
 
 proc getRecentStickers*(self: Controller): seq[StickerDto] = 

--- a/src/app/modules/main/stickers/module.nim
+++ b/src/app/modules/main/stickers/module.nim
@@ -107,9 +107,9 @@ method authenticateAndBuy*(self: Module, packId: string, address: string, gas: s
 method onUserAuthenticated*(self: Module, password: string) =
   if password.len == 0:
     let response = %* {"success": false, "error": cancelledRequest}
-    self.view.transactionWasSent($response)
+    self.view.transactionWasSent(chainId = 0, txHash = "", error = cancelledRequest)
   else:
-    let responseTuple = self.controller.buy(
+    let response = self.controller.buy(
       self.tmpBuyStickersTransactionDetails.packId,
       self.tmpBuyStickersTransactionDetails.address,
       self.tmpBuyStickersTransactionDetails.gas,
@@ -119,11 +119,9 @@ method onUserAuthenticated*(self: Module, password: string) =
       password,
       self.tmpBuyStickersTransactionDetails.eip1559Enabled
     )
-    let response = responseTuple.response
-    let success = responseTuple.success
-    if success:
+    if response.error.isEmptyOrWhitespace():
       self.view.stickerPacks.updateStickerPackInList(self.tmpBuyStickersTransactionDetails.packId, false, true)
-    self.view.transactionWasSent($(%*{"success": success, "result": response}))
+    self.view.transactionWasSent(chainId = response.chainId, txHash = response.txHash, error = response.error)
 
 method obtainMarketStickerPacks*(self: Module) =
   self.controller.obtainMarketStickerPacks()

--- a/src/app/modules/main/stickers/view.nim
+++ b/src/app/modules/main/stickers/view.nim
@@ -55,7 +55,7 @@ QtObject:
     read = getRecentStickerList
     notify = recentStickersUpdated
 
-  proc transactionWasSent*(self: View, txResult: string) {.signal.}
+  proc transactionWasSent*(self: View, chainId: int, txHash: string, error: string) {.signal.}
 
   proc transactionCompleted*(self: View, success: bool, txHash: string) {.signal.}
 

--- a/src/app/modules/main/wallet_section/send/gas_estimate_item.nim
+++ b/src/app/modules/main/wallet_section/send/gas_estimate_item.nim
@@ -1,0 +1,56 @@
+import NimQml
+
+QtObject:
+  type GasEstimateItem* = ref object of QObject
+    totalFeesInEth: float
+    totalTokenFees: float
+    totalTime: int
+
+  proc setup*(self: GasEstimateItem,
+    totalFeesInEth: float,
+    totalTokenFees: float,
+    totalTime: int
+  ) =
+    self.QObject.setup
+    self.totalFeesInEth = totalFeesInEth
+    self.totalTokenFees = totalTokenFees
+    self.totalTime = totalTime
+
+  proc delete*(self: GasEstimateItem) =
+      self.QObject.delete
+
+  proc newGasEstimateItem*(
+    totalFeesInEth: float = 0,
+    totalTokenFees: float = 0,
+    totalTime: int = 0
+    ): GasEstimateItem =
+      new(result, delete)
+      result.setup(totalFeesInEth, totalTokenFees, totalTime)
+
+  proc `$`*(self: GasEstimateItem): string =
+    result = "GasEstimateItem("
+    result = result & "\ntotalFeesInEth: " & $self.totalFeesInEth
+    result = result & "\ntotalTokenFees: " & $self.totalTokenFees
+    result = result & "\ntotalTime: " & $self.totalTime
+    result = result & ")"
+
+  proc totalFeesInEthChanged*(self: GasEstimateItem) {.signal.}
+  proc getTotalFeesInEth*(self: GasEstimateItem): float {.slot.} =
+    return self.totalFeesInEth
+  QtProperty[float] totalFeesInEth:
+    read = getTotalFeesInEth
+    notify = totalFeesInEthChanged
+
+  proc totalTokenFeesChanged*(self: GasEstimateItem) {.signal.}
+  proc getTotalTokenFees*(self: GasEstimateItem): float {.slot.} =
+    return self.totalTokenFees
+  QtProperty[float] totalTokenFees:
+    read = getTotalTokenFees
+    notify = totalTokenFeesChanged
+
+  proc totalTimeChanged*(self: GasEstimateItem) {.signal.}
+  proc getTotalTime*(self: GasEstimateItem): int {.slot.} =
+    return self.totalTime
+  QtProperty[int] totalTime:
+    read = getTotalTime
+    notify = totalTimeChanged

--- a/src/app/modules/main/wallet_section/send/gas_fees_item.nim
+++ b/src/app/modules/main/wallet_section/send/gas_fees_item.nim
@@ -1,0 +1,104 @@
+import NimQml, strformat
+
+QtObject:
+  type GasFeesItem* = ref object of QObject
+    gasPrice: float
+    baseFee: float
+    maxPriorityFeePerGas: float
+    maxFeePerGasL: float
+    maxFeePerGasM: float
+    maxFeePerGasH: float
+    eip1559Enabled: bool
+
+  proc setup*(self: GasFeesItem,
+    gasPrice: float,
+    baseFee: float,
+    maxPriorityFeePerGas: float,
+    maxFeePerGasL: float,
+    maxFeePerGasM: float,
+    maxFeePerGasH: float,
+    eip1559Enabled: bool
+  ) =
+    self.QObject.setup
+    self.gasPrice = gasPrice
+    self.baseFee = baseFee
+    self.maxPriorityFeePerGas = maxPriorityFeePerGas
+    self.maxFeePerGasL = maxFeePerGasL
+    self.maxFeePerGasM = maxFeePerGasM
+    self.maxFeePerGasH = maxFeePerGasH
+    self.eip1559Enabled = eip1559Enabled
+
+  proc delete*(self: GasFeesItem) =
+      self.QObject.delete
+
+  proc newGasFeesItem*(
+    gasPrice: float = 0,
+    baseFee: float = 0,
+    maxPriorityFeePerGas: float = 0,
+    maxFeePerGasL: float = 0,
+    maxFeePerGasM: float = 0,
+    maxFeePerGasH: float = 0,
+    eip1559Enabled: bool = false
+    ): GasFeesItem =
+      new(result, delete)
+      result.setup(gasPrice, baseFee, maxPriorityFeePerGas, maxFeePerGasL, maxFeePerGasM, maxFeePerGasH, eip1559Enabled)
+
+  proc `$`*(self: GasFeesItem): string =
+    result = "GasFeesItem("
+    result = result & "\ngasPrice: " & $self.gasPrice
+    result = result & "\nbaseFee: " & $self.baseFee
+    result = result & "\nmaxPriorityFeePerGas: " & $self.maxPriorityFeePerGas
+    result = result & "\nmaxFeePerGasL: " & $self.maxFeePerGasL
+    result = result & "\nmaxFeePerGasM: " & $self.maxFeePerGasM
+    result = result & "\nmaxFeePerGasH: " & $self.maxFeePerGasH
+    result = result & "\neip1559Enabled: " & $self.eip1559Enabled
+    result = result & ")"
+
+  proc gasPriceChanged*(self: GasFeesItem) {.signal.}
+  proc getGasPrice*(self: GasFeesItem): float {.slot.} =
+    return self.gasPrice
+  QtProperty[float] gasPrice:
+    read = getGasPrice
+    notify = gasPriceChanged
+
+  proc baseFeeChanged*(self: GasFeesItem) {.signal.}
+  proc getBaseFee*(self: GasFeesItem): float {.slot.} =
+    return self.baseFee
+  QtProperty[float] baseFee:
+    read = getBaseFee
+    notify = baseFeeChanged
+
+  proc maxPriorityFeePerGasChanged*(self: GasFeesItem) {.signal.}
+  proc getMaxPriorityFeePerGas*(self: GasFeesItem): float {.slot.} =
+    return self.maxPriorityFeePerGas
+  QtProperty[float] maxPriorityFeePerGas:
+    read = getMaxPriorityFeePerGas
+    notify = maxPriorityFeePerGasChanged
+
+  proc maxFeePerGasLChanged*(self: GasFeesItem) {.signal.}
+  proc getMaxFeePerGasL*(self: GasFeesItem): float {.slot.} =
+    return self.maxFeePerGasL
+  QtProperty[float] maxFeePerGasL:
+    read = getMaxFeePerGasL
+    notify = maxFeePerGasLChanged
+
+  proc maxFeePerGasMChanged*(self: GasFeesItem) {.signal.}
+  proc getMaxFeePerGasM*(self: GasFeesItem): float {.slot.} =
+    return self.maxFeePerGasM
+  QtProperty[float] maxFeePerGasM:
+    read = getMaxFeePerGasM
+    notify = maxFeePerGasMChanged
+
+  proc maxFeePerGasHChanged*(self: GasFeesItem) {.signal.}
+  proc getMaxFeePerGasH*(self: GasFeesItem): float {.slot.} =
+    return self.maxFeePerGasH
+  QtProperty[float] maxFeePerGasH:
+    read = getMaxFeePerGasH
+    notify = maxFeePerGasHChanged
+
+  proc eip1559EnabledChanged*(self: GasFeesItem) {.signal.}
+  proc getEip1559Enabled*(self: GasFeesItem): bool {.slot.} =
+    return self.eip1559Enabled
+  QtProperty[bool] eip1559Enabled:
+    read = getEip1559Enabled
+    notify = eip1559EnabledChanged

--- a/src/app/modules/main/wallet_section/send/io_interface.nim
+++ b/src/app/modules/main/wallet_section/send/io_interface.nim
@@ -1,5 +1,6 @@
 import stint
 import ../../../shared_models/currency_amount
+import app_service/service/transaction/dto
 
 type
   AccessInterface* {.pure inheritable.} = ref object of RootObj
@@ -20,26 +21,20 @@ method refreshWalletAccounts*(self: AccessInterface) {.base.} =
 method getTokenBalanceOnChain*(self: AccessInterface, address: string, chainId: int, symbol: string): CurrencyAmount {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method suggestedRoutes*(self: AccessInterface, account: string, amount: UInt256, token: string, disabledFromChainIDs, disabledToChainIDs, preferredChainIDs: seq[uint64], sendType: int, lockedInAmounts: string): string {.base.} =
+method suggestedRoutes*(self: AccessInterface, account: string, amount: UInt256, token: string, disabledFromChainIDs, disabledToChainIDs, preferredChainIDs: seq[int], sendType: int, lockedInAmounts: string): string {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method suggestedRoutesReady*(self: AccessInterface, suggestedRoutes: string) {.base.} =
-  raise newException(ValueError, "No implementation available")
-
-method getEstimatedTime*(self: AccessInterface, chainId: int, maxFeePerGas: string): int {.base.} = 
-  raise newException(ValueError, "No implementation available")
-
-method suggestedFees*(self: AccessInterface, chainId: int): string {.base.} = 
+method suggestedRoutesReady*(self: AccessInterface, suggestedRoutes: SuggestedRoutesDto) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method authenticateAndTransfer*(self: AccessInterface, from_addr: string, to_addr: string,
-    tokenSymbol: string, value: string, uuid: string, selectedRoutes: string) {.base.} =
+    tokenSymbol: string, value: string, uuid: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method onUserAuthenticated*(self: AccessInterface, password: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method transactionWasSent*(self: AccessInterface, result: string) {.base.} =
+method transactionWasSent*(self: AccessInterface, chainId: int, txHash, uuid, error: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 # View Delegate Interface

--- a/src/app/modules/main/wallet_section/send/network_item.nim
+++ b/src/app/modules/main/wallet_section/send/network_item.nim
@@ -1,0 +1,161 @@
+import strformat, strutils
+
+import app/modules/shared_models/currency_amount
+
+type
+  NetworkItem* = ref object
+    chainId: int
+    chainName: string
+    iconUrl: string
+    chainColor: string
+    shortName: string
+    layer: int
+    nativeCurrencyDecimals: int
+    nativeCurrencyName: string
+    nativeCurrencySymbol: string
+    isEnabled: bool
+    isPreferred: bool
+    hasGas: bool
+    tokenBalance: CurrencyAmount
+    locked: bool
+    lockedAmount: string
+    amountIn: string
+    amountOut: string
+    toNetworks: seq[int]
+
+proc initNetworkItem*(
+    chainId: int,
+    chainName: string,
+    iconUrl: string,
+    chainColor: string,
+    shortName: string,
+    layer: int,
+    nativeCurrencyDecimals: int,
+    nativeCurrencyName: string,
+    nativeCurrencySymbol: string,
+    isEnabled: bool,
+    isPreferred: bool,
+    hasGas: bool,
+    tokenBalance: CurrencyAmount,
+    locked: bool = false,
+    lockedAmount: string = "",
+    amountIn: string = "",
+    amountOut: string = "",
+    toNetworks: seq[int] = @[]
+): NetworkItem =
+  result = NetworkItem()
+  result.chainId = chainId
+  result.chainName = chainName
+  result.iconUrl = iconUrl
+  result.chainColor = chainColor
+  result.shortName = shortName
+  result.layer = layer
+  result.nativeCurrencyDecimals = nativeCurrencyDecimals
+  result.nativeCurrencyName = nativeCurrencyName
+  result.nativeCurrencySymbol = nativeCurrencySymbol
+  result.isEnabled = isEnabled
+  result.isPreferred = isPreferred
+  result.hasGas = hasGas
+  result.tokenBalance = tokenBalance
+  result.locked = locked
+  result.lockedAmount = lockedAmount
+  result.amountIn = amountIn
+  result.amountOut = amountOut
+  result.toNetworks = toNetworks
+
+proc `$`*(self: NetworkItem): string =
+  result = fmt"""NetworkItem(
+    chainId: {self.chainId},
+    chainName: {self.chainName},
+    iconUrl:{self.iconUrl},
+    chainColor: {self.chainColor},
+    shortName: {self.shortName},
+    layer: {self.layer},
+    nativeCurrencyDecimals: {self.nativeCurrencyDecimals},
+    nativeCurrencyName:{self.nativeCurrencyName},
+    nativeCurrencySymbol:{self.nativeCurrencySymbol},
+    isEnabled:{self.isEnabled},
+    isPreferred:{self.isPreferred},
+    hasGas:{self.hasGas},
+    tokenBalance:{self.tokenBalance},
+    locked:{self.locked},
+    lockedAmount:{self.lockedAmount},
+    amountIn:{self.amountIn},
+    amountOut:{self.amountOut},
+    toNetworks:{self.toNetworks},
+    ]"""
+
+proc getChainId*(self: NetworkItem): int =
+  return self.chainId
+
+proc getChainName*(self: NetworkItem): string =
+  return self.chainName
+
+proc getIconURL*(self: NetworkItem): string =
+  return self.iconUrl
+
+proc getShortName*(self: NetworkItem): string =
+  return self.shortName
+
+proc getChainColor*(self: NetworkItem): string =
+  return self.chainColor
+
+proc getLayer*(self: NetworkItem): int =
+  return self.layer
+
+proc getNativeCurrencyDecimals*(self: NetworkItem): int =
+  return self.nativeCurrencyDecimals
+
+proc getNativeCurrencyName*(self: NetworkItem): string =
+  return self.nativeCurrencyName
+
+proc getNativeCurrencySymbol*(self: NetworkItem): string =
+  return self.nativeCurrencySymbol
+
+proc getIsEnabled*(self: NetworkItem): bool =
+  return self.isEnabled
+proc `isEnabled=`*(self: NetworkItem, value: bool) {.inline.} =
+  self.isEnabled = value
+
+proc getIsPreferred*(self: NetworkItem): bool =
+  return self.isPreferred
+proc `isPreferred=`*(self: NetworkItem, value: bool) {.inline.} =
+  self.isPreferred = value
+
+proc getHasGas*(self: NetworkItem): bool =
+  return self.hasGas
+proc `hasGas=`*(self: NetworkItem, value: bool) {.inline.} =
+  self.hasGas = value
+
+proc getTokenBalance*(self: NetworkItem): CurrencyAmount =
+  return self.tokenBalance
+proc `tokenBalance=`*(self: NetworkItem, value: CurrencyAmount) {.inline.} =
+  self.tokenBalance = value
+
+proc getLocked*(self: NetworkItem): bool =
+  return self.locked
+proc `locked=`*(self: NetworkItem, value: bool) {.inline.} =
+  self.locked = value
+
+proc getLockedAmount*(self: NetworkItem): string =
+  return self.lockedAmount
+proc `lockedAmount=`*(self: NetworkItem, value: string) {.inline.} =
+  self.lockedAmount = value
+
+proc getAmountIn*(self: NetworkItem): string =
+  return self.amountIn
+proc `amountIn=`*(self: NetworkItem, value: string) {.inline.} =
+  self.amountIn = value
+
+proc getAmountOut*(self: NetworkItem): string =
+  return self.amountOut
+proc `amountOut=`*(self: NetworkItem, value: string) {.inline.} =
+  self.amountOut = value
+
+proc getToNetworks*(self: NetworkItem): string =
+  return self.toNetworks.join(":")
+proc `toNetworks=`*(self: NetworkItem, value: int) {.inline.} =
+  self.toNetworks.add(value)
+proc resetToNetworks*(self: NetworkItem) =
+   self.toNetworks = @[]
+

--- a/src/app/modules/main/wallet_section/send/network_model.nim
+++ b/src/app/modules/main/wallet_section/send/network_model.nim
@@ -1,0 +1,287 @@
+import NimQml, Tables, strutils, strformat, sequtils, sugar, json
+
+import app/modules/shared_models/currency_amount
+import ./network_item, ./suggested_route_item
+
+type
+  ModelRole* {.pure.} = enum
+    ChainId = UserRole + 1,
+    ChainName
+    IconUrl
+    ChainColor
+    ShortName
+    Layer
+    NativeCurrencyDecimals
+    NativeCurrencyName
+    NativeCurrencySymbol
+    IsEnabled
+    IsPreferred
+    HasGas
+    TokenBalance
+    Locked
+    LockedAmount
+    AmountIn
+    AmountOut
+    ToNetworks
+
+QtObject:
+  type NetworkModel* = ref object of QAbstractListModel
+    items*: seq[NetworkItem]
+
+  proc delete(self: NetworkModel) =
+    self.items = @[]
+    self.QAbstractListModel.delete
+
+  proc setup(self: NetworkModel) =
+    self.QAbstractListModel.setup
+
+  proc newNetworkModel*(): NetworkModel =
+    new(result, delete)
+    result.setup
+
+  proc `$`*(self: NetworkModel): string =
+    for i in 0 ..< self.items.len:
+      result &= fmt"""[{i}]:({$self.items[i]})"""
+
+  proc countChanged(self: NetworkModel) {.signal.}
+
+  proc getCount(self: NetworkModel): int {.slot.} =
+    self.items.len
+
+  QtProperty[int] count:
+    read = getCount
+    notify = countChanged
+
+  method rowCount*(self: NetworkModel, index: QModelIndex = nil): int =
+    return self.items.len
+
+  method roleNames(self: NetworkModel): Table[int, string] =
+    {
+      ModelRole.ChainId.int:"chainId",
+      ModelRole.ChainName.int:"chainName",
+      ModelRole.IconUrl.int:"iconUrl",
+      ModelRole.ShortName.int: "shortName",
+      ModelRole.Layer.int: "layer",
+      ModelRole.ChainColor.int: "chainColor",
+      ModelRole.NativeCurrencyDecimals.int:"nativeCurrencyDecimals",
+      ModelRole.NativeCurrencyName.int:"nativeCurrencyName",
+      ModelRole.NativeCurrencySymbol.int:"nativeCurrencySymbol",
+      ModelRole.IsEnabled.int:"isEnabled",
+      ModelRole.IsPreferred.int:"isPreferred",
+      ModelRole.HasGas.int:"hasGas",
+      ModelRole.TokenBalance.int:"tokenBalance",
+      ModelRole.Locked.int:"locked",
+      ModelRole.LockedAmount.int:"lockedAmount",
+      ModelRole.AmountIn.int:"amountIn",
+      ModelRole.AmountOut.int:"amountOut",
+      ModelRole.ToNetworks.int:"toNetworks"
+    }.toTable
+
+  method data(self: NetworkModel, index: QModelIndex, role: int): QVariant =
+    if (not index.isValid):
+      return
+
+    if (index.row < 0 or index.row >= self.items.len):
+      return
+
+    let item = self.items[index.row]
+    let enumRole = role.ModelRole
+
+    case enumRole:
+    of ModelRole.ChainId:
+      result = newQVariant(item.getChainId())
+    of ModelRole.ChainName:
+      result = newQVariant(item.getChainName())
+    of ModelRole.IconUrl:
+      result = newQVariant(item.getIconURL())
+    of ModelRole.ShortName:
+      result = newQVariant(item.getShortName())
+    of ModelRole.Layer:
+      result = newQVariant(item.getLayer())
+    of ModelRole.ChainColor:
+      result = newQVariant(item.getChainColor())
+    of ModelRole.NativeCurrencyDecimals:
+      result = newQVariant(item.getNativeCurrencyDecimals())
+    of ModelRole.NativeCurrencyName:
+      result = newQVariant(item.getNativeCurrencyName())
+    of ModelRole.NativeCurrencySymbol:
+      result = newQVariant(item.getNativeCurrencySymbol())
+    of ModelRole.IsEnabled:
+      result = newQVariant(item.getIsEnabled())
+    of ModelRole.IsPreferred:
+      result = newQVariant(item.getIsPreferred())
+    of ModelRole.HasGas:
+      result = newQVariant(item.getHasGas())
+    of ModelRole.TokenBalance:
+      result = newQVariant(item.getTokenBalance())
+    of ModelRole.Locked:
+      result = newQVariant(item.getLocked())
+    of ModelRole.LockedAmount:
+      result = newQVariant(item.getLockedAmount())
+    of ModelRole.AmountIn:
+      result = newQVariant(item.getAmountIn())
+    of ModelRole.AmountOut:
+      result = newQVariant(item.getAmountOut())
+    of ModelRole.ToNetworks:
+      result = newQVariant(item.getToNetworks())
+
+  proc setItems*(self: NetworkModel, items: seq[NetworkItem]) =
+    self.beginResetModel()
+    self.items = items
+    self.endResetModel()
+    self.countChanged()
+
+  proc getAllNetworksChainIds*(self: NetworkModel): seq[int] =
+    return self.items.map(x => x.getChainId())
+
+  proc getNetworkNativeGasSymbol*(self: NetworkModel, chainId: int): string =
+    for item in self.items:
+      if item.getChainId() == chainId:
+        return item.getNativeCurrencySymbol()
+    return ""
+
+  proc reset*(self: NetworkModel) =
+    for i in 0 ..< self.items.len:
+      let index = self.createIndex(i, 0, nil)
+      self.items[i].amountIn = ""
+      self.items[i].amountOut = ""
+      self.items[i].resetToNetworks()
+      self.items[i].hasGas = true
+      self.dataChanged(index, index, @[ModelRole.AmountIn.int])
+      self.dataChanged(index, index, @[ModelRole.ToNetworks.int])
+      self.dataChanged(index, index, @[ModelRole.HasGas.int])
+      self.dataChanged(index, index, @[ModelRole.AmountOut.int])
+
+  proc updateTokenBalanceForSymbol*(self: NetworkModel, chainId: int, tokenBalance: CurrencyAmount) =
+    for i in 0 ..< self.items.len:
+      if(self.items[i].getChainId() == chainId):
+        let index = self.createIndex(i, 0, nil)
+        self.items[i].tokenBalance = tokenBalance
+        self.dataChanged(index, index, @[ModelRole.TokenBalance.int])
+
+  proc updateFromNetworks*(self: NetworkModel, path: SuggestedRouteItem, hasGas: bool) =
+    for i in 0 ..< self.items.len:
+      if path.getfromNetwork() == self.items[i].getChainId():
+        let index = self.createIndex(i, 0, nil)
+        self.items[i].amountIn = path.getAmountIn()
+        self.items[i].toNetworks = path.getToNetwork()
+        self.items[i].hasGas = hasGas
+        self.items[i].locked = path.getAmountInLocked()
+        self.dataChanged(index, index, @[ModelRole.AmountIn.int])
+        self.dataChanged(index, index, @[ModelRole.ToNetworks.int])
+        self.dataChanged(index, index, @[ModelRole.HasGas.int])
+        self.dataChanged(index, index, @[ModelRole.Locked.int])
+
+  proc updateToNetworks*(self: NetworkModel, path: SuggestedRouteItem) =
+    for i in 0 ..< self.items.len:
+      if path.getToNetwork() == self.items[i].getChainId():
+        let index = self.createIndex(i, 0, nil)
+        if self.items[i].getAmountOut().len != 0:
+          self.items[i].amountOut = $(parseInt(self.items[i].getAmountOut()) + parseInt(path.getAmountOut()))
+        else:
+          self.items[i].amountOut = path.getAmountOut()
+        self.dataChanged(index, index, @[ModelRole.AmountOut.int])
+
+  proc getDisabledNetworkChainIds*(self: NetworkModel): seq[int] =
+    var disbaledChains: seq[int] = @[]
+    for item in self.items:
+      if not item.getIsEnabled():
+        disbaledChains.add(item.getChainId())
+    return disbaledChains
+
+  proc getLockedChainIds*(self: NetworkModel): string =
+    var jsonObject = newJObject()
+    for item in self.items:
+      if item.getLocked():
+        jsonObject[$item.getChainId()] = %* ("0x" & item.getLockedAmount())
+    return $jsonObject
+
+  proc updatePreferredChains*(self: NetworkModel, chainIds: string) =
+    try:
+      for i in 0 ..< self.items.len:
+        let index = self.createIndex(i, 0, nil)
+        self.items[i].isPreferred = false
+        self.items[i].isEnabled = false
+        if chainIds.len == 0:
+          if self.items[i].getLayer() == 1:
+            self.items[i].isPreferred = true
+            self.items[i].isEnabled = true
+        else:
+          for chainID in chainIds.split(':'):
+            if $self.items[i].getChainId() == chainID:
+              self.items[i].isPreferred = true
+              self.items[i].isEnabled = true
+        self.dataChanged(index, index, @[ModelRole.IsPreferred.int])
+        self.dataChanged(index, index, @[ModelRole.IsEnabled.int])
+    except:
+      discard
+
+  proc getPreferredNetworkChainIds*(self: NetworkModel): seq[int] =
+    var preferredChains: seq[int] = @[]
+    for item in self.items:
+      if item.getIsPreferred():
+        preferredChains.add(item.getChainId())
+    return preferredChains
+
+  proc disableUnpreferredChains*(self: NetworkModel) =
+    for i in 0 ..< self.items.len:
+      if not self.items[i].getIsPreferred():
+        let index = self.createIndex(i, 0, nil)
+        self.items[i].isEnabled = false
+        self.dataChanged(index, index, @[ModelRole.IsEnabled.int])
+
+  proc enableUnpreferredChains*(self: NetworkModel) =
+    for i in 0 ..< self.items.len:
+      if not self.items[i].getIsPreferred():
+        let index = self.createIndex(i, 0, nil)
+        self.items[i].isEnabled = true
+        self.dataChanged(index, index, @[ModelRole.IsEnabled.int])
+
+  proc setAllNetworksAsPreferredChains*(self: NetworkModel) {.slot.} =
+    for i in 0 ..< self.items.len:
+      let index = self.createIndex(i, 0, nil)
+      self.items[i].isPreferred = true
+      self.dataChanged(index, index, @[ModelRole.IsPreferred.int])
+
+  proc getNetworkColor*(self: NetworkModel, shortName: string): string {.slot.} =
+    for item in self.items:
+      if cmpIgnoreCase(item.getShortName(), shortName) == 0:
+        return item.getChainColor()
+    return ""
+
+  proc getNetworkChainId*(self: NetworkModel, shortName: string): int {.slot.} =
+    for item in self.items:
+      if cmpIgnoreCase(item.getShortName(), shortName) == 0:
+        return item.getChainId()
+    return 0
+
+  proc getNetworkName*(self: NetworkModel, chainId: int): string  {.slot.} =
+    for item in self.items:
+      if item.getChainId() == chainId:
+        return item.getChainName()
+    return ""
+
+  proc toggleDisabledChains*(self: NetworkModel, chainId: int) {.slot.} =
+    for i in 0 ..< self.items.len:
+      if(self.items[i].getChainId() == chainId):
+        let index = self.createIndex(i, 0, nil)
+        self.items[i].isEnabled = not self.items[i].getIsEnabled()
+        self.dataChanged(index, index, @[ModelRole.IsEnabled.int])
+
+  proc setDisabledChains*(self: NetworkModel, chainId: int, disabled: bool) {.slot.} =
+    for i in 0 ..< self.items.len:
+      if(self.items[i].getChainId() == chainId):
+        let index = self.createIndex(i, 0, nil)
+        self.items[i].isEnabled = not disabled
+        self.dataChanged(index, index, @[ModelRole.IsEnabled.int])
+
+  proc lockCard*(self: NetworkModel, chainId: int, amount: string, lock: bool) {.slot.} =
+    for i in 0 ..< self.items.len:
+      if(self.items[i].getChainId() == chainId):
+        let index = self.createIndex(i, 0, nil)
+        self.items[i].locked = lock
+        self.dataChanged(index, index, @[ModelRole.Locked.int])
+        if self.items[i].getLocked():
+          self.items[i].lockedAmount = amount
+          self.dataChanged(index, index, @[ModelRole.LockedAmount.int])
+

--- a/src/app/modules/main/wallet_section/send/suggested_route_item.nim
+++ b/src/app/modules/main/wallet_section/send/suggested_route_item.nim
@@ -1,0 +1,215 @@
+import NimQml, strformat
+
+import ./gas_fees_item
+
+QtObject:
+  type SuggestedRouteItem* = ref object of QObject
+    bridgeName: string
+    fromNetwork: int
+    toNetwork: int
+    maxAmountIn: string
+    amountIn: string
+    amountOut: string
+    gasAmount: string
+    gasFees: GasFeesItem
+    tokenFees: float
+    cost: float
+    estimatedTime: int
+    amountInLocked: bool
+    isFirstSimpleTx: bool
+    isFirstBridgeTx: bool
+    approvalRequired: bool
+    approvalGasFees: float
+
+  proc setup*(self: SuggestedRouteItem,
+    bridgeName: string,
+    fromNetwork: int,
+    toNetwork: int,
+    maxAmountIn: string,
+    amountIn: string,
+    amountOut: string,
+    gasAmount: string,
+    gasFees: GasFeesItem,
+    tokenFees: float,
+    cost: float,
+    estimatedTime: int,
+    amountInLocked: bool,
+    isFirstSimpleTx: bool,
+    isFirstBridgeTx: bool,
+    approvalRequired: bool,
+    approvalGasFees: float
+  ) =
+    self.QObject.setup
+    self.bridgeName = bridgeName
+    self.fromNetwork = fromNetwork
+    self.toNetwork = toNetwork
+    self.maxAmountIn = maxAmountIn
+    self.amountIn = amountIn
+    self.amountOut = amountOut
+    self.gasAmount = gasAmount
+    self.gasFees = gasFees
+    self.tokenFees = tokenFees
+    self.cost = cost
+    self.estimatedTime = estimatedTime
+    self.amountInLocked = amountInLocked
+    self.isFirstSimpleTx = isFirstSimpleTx
+    self.isFirstBridgeTx = isFirstBridgeTx
+    self.approvalRequired = approvalRequired
+    self.approvalGasFees = approvalGasFees
+
+  proc delete*(self: SuggestedRouteItem) =
+      self.QObject.delete
+
+  proc newSuggestedRouteItem*(
+    bridgeName: string = "",
+    fromNetwork: int = 0,
+    toNetwork: int = 0,
+    maxAmountIn: string = "",
+    amountIn: string = "",
+    amountOut: string = "",
+    gasAmount: string = "",
+    gasFees: GasFeesItem = newGasFeesItem(),
+    tokenFees: float = 0,
+    cost: float = 0,
+    estimatedTime: int = 0,
+    amountInLocked: bool = false,
+    isFirstSimpleTx: bool = false,
+    isFirstBridgeTx: bool = false,
+    approvalRequired: bool = false,
+    approvalGasFees: float = 0
+    ): SuggestedRouteItem =
+      new(result, delete)
+      result.setup(bridgeName, fromNetwork, toNetwork, maxAmountIn, amountIn, amountOut, gasAmount, gasFees, tokenFees,
+        cost, estimatedTime, amountInLocked, isFirstSimpleTx, isFirstBridgeTx, approvalRequired, approvalGasFees)
+
+  proc `$`*(self: SuggestedRouteItem): string =
+    result = "SuggestedRouteItem("
+    result = result & "\nbridgeName: " & $self.bridgeName
+    result = result & "\nfromNetwork: " & $self.fromNetwork
+    result = result & "\ntoNetwork: " & $self.toNetwork
+    result = result & "\nmaxAmountIn: " & $self.maxAmountIn
+    result = result & "\namountIn: " & $self.amountIn
+    result = result & "\namountOut: " & $self.amountOut
+    result = result & "\ngasAmount: " & $self.gasAmount
+    result = result & "\ngasFees: " & $self.gasFees
+    result = result & "\ntokenFees: " & $self.tokenFees
+    result = result & "\ncost: " & $self.cost
+    result = result & "\nestimatedTime: " & $self.estimatedTime
+    result = result & "\namountInLocked: " & $self.amountInLocked
+    result = result & "\nisFirstSimpleTx: " & $self.isFirstSimpleTx
+    result = result & "\nisFirstBridgeTx: " & $self.isFirstBridgeTx
+    result = result & "\napprovalRequired: " & $self.approvalRequired
+    result = result & "\napprovalGasFees: " & $self.approvalGasFees
+    result = result & ")"
+
+  proc bridgeNameChanged*(self: SuggestedRouteItem) {.signal.}
+  proc getBridgeName*(self: SuggestedRouteItem): string {.slot.} =
+    return self.bridgeName
+  QtProperty[string] bridgeName:
+    read = getBridgeName
+    notify = bridgeNameChanged
+
+  proc fromNetworkChanged*(self: SuggestedRouteItem) {.signal.}
+  proc getfromNetwork*(self: SuggestedRouteItem): int {.slot.} =
+    return self.fromNetwork
+  QtProperty[int] fromNetwork:
+    read = getfromNetwork
+    notify = fromNetworkChanged
+
+  proc toNetworkChanged*(self: SuggestedRouteItem) {.signal.}
+  proc getToNetwork*(self: SuggestedRouteItem): int {.slot.} =
+    return self.toNetwork
+  QtProperty[int] toNetwork:
+    read = getToNetwork
+    notify = toNetworkChanged
+
+  proc maxAmountInChanged*(self: SuggestedRouteItem) {.signal.}
+  proc getMaxAmountIn*(self: SuggestedRouteItem): string {.slot.} =
+    return self.maxAmountIn
+  QtProperty[string] maxAmountIn:
+    read = getMaxAmountIn
+    notify = maxAmountInChanged
+
+  proc amountInChanged*(self: SuggestedRouteItem) {.signal.}
+  proc getAmountIn*(self: SuggestedRouteItem): string {.slot.} =
+    return self.amountIn
+  QtProperty[string] amountIn:
+    read = getAmountIn
+    notify = amountInChanged
+
+  proc amountOutChanged*(self: SuggestedRouteItem) {.signal.}
+  proc getAmountOut*(self: SuggestedRouteItem): string {.slot.} =
+    return self.amountOut
+  QtProperty[string] amountOut:
+    read = getAmountOut
+    notify = amountOutChanged
+
+  proc gasAmountChanged*(self: SuggestedRouteItem) {.signal.}
+  proc getGasAmount*(self: SuggestedRouteItem): string {.slot.} =
+    return self.gasAmount
+  QtProperty[string] gasAmount:
+    read = getGasAmount
+    notify = gasAmountChanged
+
+  proc gasFeesChanged*(self: SuggestedRouteItem) {.signal.}
+  proc getGasFees*(self: SuggestedRouteItem): QVariant {.slot.} =
+    return newQVariant(self.gasFees)
+  QtProperty[QVariant] gasFees:
+    read = getGasFees
+    notify = gasFeesChanged
+
+  proc tokenFeesChanged*(self: SuggestedRouteItem) {.signal.}
+  proc getTokenFees*(self: SuggestedRouteItem): float {.slot.} =
+    return self.tokenFees
+  QtProperty[float] tokenFees:
+    read = getTokenFees
+    notify = tokenFeesChanged
+
+  proc costChanged*(self: SuggestedRouteItem) {.signal.}
+  proc getCost*(self: SuggestedRouteItem): float {.slot.} =
+    return self.cost
+  QtProperty[float] cost:
+    read = getCost
+    notify = costChanged
+
+  proc estimatedTimeChanged*(self: SuggestedRouteItem) {.signal.}
+  proc getEstimatedTime*(self: SuggestedRouteItem): int {.slot.} =
+    return self.estimatedTime
+  QtProperty[int] estimatedTime:
+    read = getEstimatedTime
+    notify = estimatedTimeChanged
+
+  proc amountInLockedChanged*(self: SuggestedRouteItem) {.signal.}
+  proc getAmountInLocked*(self: SuggestedRouteItem): bool {.slot.} =
+    return self.amountInLocked
+  QtProperty[bool] amountInLocked:
+    read = getAmountInLocked
+    notify = amountInLockedChanged
+
+  proc isFirstSimpleTxChanged*(self: SuggestedRouteItem) {.signal.}
+  proc getIsFirstSimpleTx*(self: SuggestedRouteItem): bool {.slot.} =
+    return self.isFirstSimpleTx
+  QtProperty[bool] isFirstSimpleTx:
+    read = getIsFirstSimpleTx
+    notify = isFirstSimpleTxChanged
+
+  proc isFirstBridgeTxChanged*(self: SuggestedRouteItem) {.signal.}
+  proc getIsFirstBridgeTx*(self: SuggestedRouteItem): bool {.slot.} =
+    return self.isFirstBridgeTx
+  QtProperty[bool] isFirstBridgeTx:
+    read = getIsFirstBridgeTx
+    notify = isFirstBridgeTxChanged
+
+  proc approvalRequiredChanged*(self: SuggestedRouteItem) {.signal.}
+  proc getApprovalRequired*(self: SuggestedRouteItem): bool {.slot.} =
+    return self.approvalRequired
+  QtProperty[bool] approvalRequired:
+    read = getApprovalRequired
+    notify = approvalRequiredChanged
+
+  proc approvalGasFeesChanged*(self: SuggestedRouteItem) {.signal.}
+  proc getApprovalGasFees*(self: SuggestedRouteItem): float {.slot.} =
+    return self.approvalGasFees
+  QtProperty[float] approvalGasFees:
+    read = getApprovalGasFees
+    notify = approvalGasFeesChanged

--- a/src/app/modules/main/wallet_section/send/suggested_route_model.nim
+++ b/src/app/modules/main/wallet_section/send/suggested_route_model.nim
@@ -1,0 +1,70 @@
+import NimQml, Tables, strutils, strformat
+
+import ./suggested_route_item
+
+type
+  ModelRole {.pure.} = enum
+    Route = UserRole + 1,
+
+QtObject:
+  type
+    SuggestedRouteModel* = ref object of QAbstractListModel
+      items*: seq[SuggestedRouteItem]
+
+  proc delete(self: SuggestedRouteModel) =
+    self.items = @[]
+    self.QAbstractListModel.delete
+
+  proc setup(self: SuggestedRouteModel) =
+    self.QAbstractListModel.setup
+
+  proc newSuggestedRouteModel*(): SuggestedRouteModel =
+    new(result, delete)
+    result.setup
+
+  proc `$`*(self: SuggestedRouteModel): string =
+    for i in 0 ..< self.items.len:
+      result &= fmt"""[{i}]:({$self.items[i]})"""
+
+  proc countChanged(self: SuggestedRouteModel) {.signal.}
+
+  proc getCount*(self: SuggestedRouteModel): int {.slot.} =
+    self.items.len
+
+  QtProperty[int] count:
+    read = getCount
+    notify = countChanged
+
+  proc firstItem*(self: SuggestedRouteModel): QVariant {.slot.} =
+    let index = 0
+    if index < 0 or index >= self.items.len:
+      return newQVariant(newSuggestedRouteItem())
+    return newQVariant(self.items[index])
+
+  method rowCount(self: SuggestedRouteModel, index: QModelIndex = nil): int =
+    return self.items.len
+
+  method roleNames(self: SuggestedRouteModel): Table[int, string] =
+    {
+      ModelRole.Route.int:"route",
+    }.toTable
+
+  proc setItems*(self: SuggestedRouteModel, items: seq[SuggestedRouteItem]) =
+    self.beginResetModel()
+    self.items = items
+    self.endResetModel()
+    self.countChanged()
+
+  method data(self: SuggestedRouteModel, index: QModelIndex, role: int): QVariant =
+    if (not index.isValid):
+      return
+
+    if (index.row < 0 or index.row >= self.items.len):
+      return
+
+    let item = self.items[index.row]
+    let enumRole = role.ModelRole
+
+    case enumRole:
+    of ModelRole.Route:
+      result = newQVariant(item)

--- a/src/app/modules/main/wallet_section/send/transaction_routes.nim
+++ b/src/app/modules/main/wallet_section/send/transaction_routes.nim
@@ -1,0 +1,70 @@
+import NimQml, strformat, stint
+
+import ./gas_estimate_item, ./suggested_route_model, ./network_model
+
+QtObject:
+  type TransactionRoutes* = ref object of QObject
+    suggestedRoutes: SuggestedRouteModel
+    gasTimeEstimate: GasEstimateItem
+    amountToReceive: UInt256
+    toNetworksModel: NetworkModel
+
+  proc setup*(self: TransactionRoutes,
+    suggestedRoutes: SuggestedRouteModel,
+    gasTimeEstimate: GasEstimateItem,
+    amountToReceive: UInt256,
+    toNetworksModel: NetworkModel
+    ) =
+      self.QObject.setup
+      self.suggestedRoutes = suggestedRoutes
+      self.gasTimeEstimate = gasTimeEstimate
+      self.amountToReceive = amountToReceive
+      self.toNetworksModel = toNetworksModel
+
+  proc delete*(self: TransactionRoutes) =
+      self.QObject.delete
+
+  proc newTransactionRoutes*(
+    suggestedRoutes: SuggestedRouteModel = newSuggestedRouteModel(),
+    gasTimeEstimate: GasEstimateItem = newGasEstimateItem(),
+    amountToReceive: UInt256 = stint.u256(0),
+    toNetworksModel: NetworkModel = newNetworkModel()
+    ): TransactionRoutes =
+    new(result, delete)
+    result.setup(suggestedRoutes, gasTimeEstimate, amountToReceive, toNetworksModel)
+
+  proc `$`*(self: TransactionRoutes): string =
+    result = fmt"""TransactionRoutes(
+      suggestedRoutes: {self.suggestedRoutes},
+      gasTimeEstimate: {self.gasTimeEstimate},
+      amountToReceive: {self.amountToReceive},
+      toNetworksModel: {self.toNetworksModel},
+      ]"""
+
+  proc suggestedRoutesChanged*(self: TransactionRoutes) {.signal.}
+  proc getSuggestedRoutes*(self: TransactionRoutes): QVariant {.slot.} =
+    return newQVariant(self.suggestedRoutes)
+  QtProperty[QVariant] suggestedRoutes:
+    read = getSuggestedRoutes
+    notify = suggestedRoutesChanged
+
+  proc gasTimeEstimateChanged*(self: TransactionRoutes) {.signal.}
+  proc getGasTimeEstimate*(self: TransactionRoutes): QVariant {.slot.} =
+    return newQVariant(self.gasTimeEstimate)
+  QtProperty[QVariant] gasTimeEstimate:
+    read = getGasTimeEstimate
+    notify = gasTimeEstimateChanged
+
+  proc amountToReceiveChanged*(self: TransactionRoutes) {.signal.}
+  proc getAmountToReceive*(self: TransactionRoutes): string {.slot.} =
+    return self.amountToReceive.toString()
+  QtProperty[string] amountToReceive:
+    read = getAmountToReceive
+    notify = amountToReceiveChanged
+
+  proc toNetworksChanged*(self: TransactionRoutes) {.signal.}
+  proc getToNetworks*(self: TransactionRoutes): QVariant {.slot.} =
+    return newQVariant(self.toNetworksModel)
+  QtProperty[QVariant] toNetworksModel:
+    read = getToNetworks
+    notify = toNetworksChanged

--- a/src/app_service/service/ens/service.nim
+++ b/src/app_service/service/ens/service.nim
@@ -57,6 +57,11 @@ type
     ensUsername*: string
     transactionType*: string
 
+  EnsTxResultArgs* = ref object of Args
+    chainId*: int
+    txHash*: string
+    error*: string
+
 # Signals which may be emitted by this service:
 const SIGNAL_ENS_USERNAME_AVAILABILITY_CHECKED* = "ensUsernameAvailabilityChecked"
 const SIGNAL_ENS_USERNAME_DETAILS_FETCHED* = "ensUsernameDetailsFetched"
@@ -284,7 +289,7 @@ QtObject:
       maxFeePerGas: string,
       password: string,
       eip1559Enabled: bool,
-    ): string =    
+    ): EnsTxResultArgs =
     try:
       let txData = ens_utils.buildTransaction(parseAddress(address), 0.u256, gas, gasPrice,
           eip1559Enabled, maxPriorityFeePerGas, maxFeePerGas)
@@ -300,10 +305,10 @@ QtObject:
       let dto = EnsUsernameDto(chainId: chainId, username: ensUsername)
       self.pendingEnsUsernames.incl(dto)
 
-      result = $(%* { "result": hash, "success": true })
+      result = EnsTxResultArgs(chainId: chainId, txHash: hash, error: "")
     except Exception as e:
       error "error occurred", procName="setPubKey", msg = e.msg
-      result = $(%* { "result": e.msg, "success": false })
+      result = EnsTxResultArgs(chainId: 0, txHash: "", error: e.msg)
 
   proc releaseEnsEstimate*(self: Service, chainId: int, ensUsername: string, address: string): int =
     try:
@@ -332,7 +337,7 @@ QtObject:
       maxFeePerGas: string,
       password: string,
       eip1559Enabled: bool
-    ): string =    
+    ): EnsTxResultArgs =
     try:
       let
         txData = ens_utils.buildTransaction(parseAddress(address), 0.u256, gas, gasPrice,
@@ -353,10 +358,10 @@ QtObject:
       let dto = EnsUsernameDto(chainId: chainId, username: ensUsername)
       self.pendingEnsUsernames.excl(dto)
 
-      result = $(%* { "result": hash, "success": true })
+      result = EnsTxResultArgs(chainId: chainId, txHash: hash, error: "")
     except Exception as e:
       error "error occurred", procName="release", msg = e.msg
-      result = $(%* { "result": e.msg, "success": false })
+      result = EnsTxResultArgs(chainId: 0, txHash: "", error: e.msg)
 
   proc registerENSGasEstimate*(self: Service, chainId: int, ensUsername: string, address: string): int =
     try:
@@ -383,7 +388,7 @@ QtObject:
       maxFeePerGas: string,
       password: string,
       eip1559Enabled: bool,
-    ): string =    
+    ): EnsTxResultArgs =
     try:
       let txData = ens_utils.buildTransaction(parseAddress(address), 0.u256, gas, gasPrice,
           eip1559Enabled, maxPriorityFeePerGas, maxFeePerGas)
@@ -400,10 +405,10 @@ QtObject:
 
       let dto = EnsUsernameDto(chainId: chainId, username: ensUsername)
       self.pendingEnsUsernames.incl(dto)
-      result = $(%* { "result": hash, "success": true })
+      result = EnsTxResultArgs(chainId: chainId, txHash: hash, error: "")
     except Exception as e:
       error "error occurred", procName="registerEns", msg = e.msg
-      result = $(%* { "result": e.msg, "success": false })
+      result = EnsTxResultArgs(chainId: 0, txHash: "", error: e.msg)
 
   proc getSNTBalance*(self: Service): string =
     let token = self.getStatusToken()

--- a/src/backend/eth.nim
+++ b/src/backend/eth.nim
@@ -28,6 +28,6 @@ proc suggestedFees*(chainId: int): RpcResponse[JsonNode] {.raises: [Exception].}
   let payload = %* [chainId]
   return core.callPrivateRPC("wallet_getSuggestedFees", payload)
 
-proc suggestedRoutes*(account: string, amount: string, token: string, disabledFromChainIDs, disabledToChainIDs, preferredChainIDs: seq[uint64], sendType: int, lockedInAmounts: var Table[string, string]): RpcResponse[JsonNode] {.raises: [Exception].} =
+proc suggestedRoutes*(account: string, amount: string, token: string, disabledFromChainIDs, disabledToChainIDs, preferredChainIDs: seq[int], sendType: int, lockedInAmounts: var Table[string, string]): RpcResponse[JsonNode] {.raises: [Exception].} =
   let payload = %* [sendType, account, amount, token, disabledFromChainIDs, disabledToChainIDs, preferredChainIDs, 1 , lockedInAmounts]
   return core.callPrivateRPC("wallet_getSuggestedRoutes", payload)

--- a/storybook/pages/SendModalPage.qml
+++ b/storybook/pages/SendModalPage.qml
@@ -53,7 +53,7 @@ SplitView {
                         }
                     }
 
-                    function splitAndFormatAddressPrefix(textAddrss, isBridgeTx, showUnpreferredNetworks) {
+                    function splitAndFormatAddressPrefix(textAddrss, isBridgeTx) {
                         return textAddrss
                     }
 
@@ -83,8 +83,6 @@ SplitView {
                     function plainText(text) {
                         return text
                     }
-
-                    function setDefaultPreferredDisabledChains() {}
 
                     function prepareTransactionsForAddress(address) {
                         console.log("prepareTransactionsForAddress:", address)

--- a/ui/StatusQ/sandbox/pages/StatusCardPage.qml
+++ b/ui/StatusQ/sandbox/pages/StatusCardPage.qml
@@ -29,7 +29,7 @@ Item {
                 cardIconName: "status"
                 advancedInputText: "75,0000000"
                 disabledText: "Disabled"
-                onCardLocked: locked = isLocked
+                onLockCard: locked = !lock
                 disableText: "Disable"
                 enableText: "Enable"
             }
@@ -99,7 +99,7 @@ Item {
                         advancedMode: card.advancedMode
                         advancedInputText: tokensToSend
                         disabledText: "Disabled"
-                        onCardLocked: locked = isLocked
+                        onLockCard: locked = !lock
                         disableText: "Disable"
                         enableText: "Enable"
                     }
@@ -121,7 +121,7 @@ Item {
                         advancedMode: card.advancedMode
                         advancedInputText: tokensToReceive
                         disabledText: "Disabled"
-                        onCardLocked: locked = isLocked
+                        onLockCard: locked = !lock
                         disableText: "Disable"
                         enableText: "Enable"
                     }

--- a/ui/StatusQ/src/StatusQ/Components/StatusCard.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusCard.qml
@@ -176,10 +176,10 @@ Rectangle {
     signal clicked()
 
     /*!
-        \qmlsignal StatusCard::cardLocked
+        \qmlsignal StatusCard::lockCard
         This signal is emitted when the card is locked or unlocked
     */
-    signal cardLocked(bool isLocked)
+    signal lockCard(bool lock)
 
     /*!
        \qmlproperty string StatusCard::state
@@ -285,7 +285,6 @@ Rectangle {
         }
         StatusInput {
             id: advancedInput
-            property bool tempLock: false
             Layout.preferredWidth: layout.width
             maximumHeight: 32
             topPadding: 0
@@ -305,17 +304,13 @@ Rectangle {
                     anchors.verticalCenter: parent.verticalCenter
                     width: 12
                     height: 12
-                    icon.name: root.locked && advancedInput.tempLock ? "lock" : "unlock"
+                    icon.name: root.locked ? "lock" : "unlock"
                     icon.width: 12
                     icon.height: 12
-                    icon.color: root.locked && advancedInput.tempLock ? Theme.palette.primaryColor1 : Theme.palette.baseColor1
+                    icon.color: root.locked ? Theme.palette.primaryColor1 : Theme.palette.baseColor1
                     type: StatusFlatRoundButton.Type.Secondary
                     enabled: !disabled
-                    onClicked: {
-                        advancedInput.tempLock = !advancedInput.tempLock
-                        root.locked = advancedInput.tempLock
-                        root.cardLocked(advancedInput.tempLock)
-                    }
+                    onClicked: root.lockCard(!root.locked)
                 }
             }
             validators: [
@@ -328,18 +323,13 @@ Rectangle {
                 }
             ]
             text: root.preCalculatedAdvancedText
-            onTextChanged: {
-                advancedInput.tempLock = false
-                waitTimer.restart()
-            }
+            onTextChanged: waitTimer.restart()           
             Timer {
                 id: waitTimer
                 interval: lockTimeout
                 onTriggered: {
-                    advancedInput.tempLock = true
                     if(!!advancedInput.text && root.preCalculatedAdvancedText !== advancedInput.text) {
-                        root.locked = advancedInput.tempLock
-                        root.cardLocked(advancedInput.tempLock)
+                        root.lockCard(true)
                     }
                 }
             }

--- a/ui/app/AppLayouts/Profile/stores/EnsUsernamesStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/EnsUsernamesStore.qml
@@ -142,18 +142,10 @@ QtObject {
         return ensUsernamesModule.getGasEthValue(gweiValue, gasLimit)
     }
 
-    function getEstimatedTime(chainId, maxFeePerGas) {
-       return walletSectionSend.getEstimatedTime(chainId, maxFeePerGas)
-    }
-
     function getStatusToken() {
         if(!root.ensUsernamesModule)
             return ""
         return ensUsernamesModule.getStatusToken()
-    }
-
-    function suggestedFees(chainId) {
-        return JSON.parse(walletSectionSend.suggestedFees(chainId))
     }
 
     function removeEnsUsername(chainId, ensUsername) {

--- a/ui/app/AppLayouts/Profile/views/EnsDetailsView.qml
+++ b/ui/app/AppLayouts/Profile/views/EnsDetailsView.qml
@@ -122,8 +122,8 @@ Item {
             preDefinedAmountToSend: LocaleUtils.numberToLocaleString(0)
             preSelectedAsset: store.getAsset(releaseEnsModal.store.assets, "ETH")
             sendTransaction: function() {
-                if(bestRoutes.length === 1) {
-                    let path = bestRoutes[0]
+                if(bestRoutes.count === 1) {
+                    let path = bestRoutes.firstItem()
                     let eip1559Enabled = path.gasFees.eip1559Enabled
                     let maxFeePerGas = path.gasFees.maxFeePerGasM
                     root.ensUsernamesStore.authenticateAndReleaseEns(
@@ -140,29 +140,22 @@ Item {
             }
             Connections {
                 target: root.ensUsernamesStore.ensUsernamesModule
-                function onTransactionWasSent(txResult: string) {
-                    try {
-                        let response = JSON.parse(txResult)
-                        if (!response.success) {
-                            if (response.result.includes(Constants.walletSection.cancelledMessage)) {
-                                return
-                            }
-                            releaseEnsModal.sendingError.text = response.result
-                            return releaseEnsModal.sendingError.open()
+                function onTransactionWasSent(chainId: int, txHash: string, error: string) {
+                    if (!!error) {
+                        if (error.includes(Constants.walletSection.cancelledMessage)) {
+                            return
                         }
-                        for(var i=0; i<releaseEnsModal.bestRoutes.length; i++) {
-                            usernameReleased()
-                            let url =  "%1/%2".arg(releaseEnsModal.store.getEtherscanLink(releaseEnsModal.bestRoutes[i].fromNetwork.chainId)).arg(response.result)
-                            Global.displayToastMessage(qsTr("Transaction pending..."),
-                                                       qsTr("View on etherscan"),
-                                                       "",
-                                                       true,
-                                                       Constants.ephemeralNotificationType.normal,
-                                                       url)
-                        }
-                    } catch (e) {
-                        console.error('Error parsing the response', e)
+                        releaseEnsModal.sendingError.text = error
+                        return releaseEnsModal.sendingError.open()
                     }
+                    usernameReleased()
+                    let url =  "%1/%2".arg(releaseEnsModal.store.getEtherscanLink(chainId)).arg(txHash)
+                    Global.displayToastMessage(qsTr("Transaction pending..."),
+                                               qsTr("View on etherscan"),
+                                               "",
+                                               true,
+                                               Constants.ephemeralNotificationType.normal,
+                                               url)
                     releaseEnsModal.close()
                 }
             }

--- a/ui/app/AppLayouts/Profile/views/EnsSearchView.qml
+++ b/ui/app/AppLayouts/Profile/views/EnsSearchView.qml
@@ -68,8 +68,8 @@ Item {
             preDefinedAmountToSend: LocaleUtils.numberToLocaleString(0)
             preSelectedAsset: store.getAsset(connectEnsModal.store.assets, "ETH")
             sendTransaction: function() {
-                if(bestRoutes.length === 1) {
-                    let path = bestRoutes[0]
+                if(bestRoutes.count === 1) {
+                    let path = bestRoutes.firstItem()
                     let eip1559Enabled = path.gasFees.eip1559Enabled
                     root.ensUsernamesStore.authenticateAndSetPubKey(
                                 root.ensUsernamesStore.chainId,
@@ -85,29 +85,22 @@ Item {
             }
             Connections {
                 target: root.ensUsernamesStore.ensUsernamesModule
-                function onTransactionWasSent(txResult: string) {
-                    try {
-                        let response = JSON.parse(txResult)
-                        if (!response.success) {
-                            if (response.result.includes(Constants.walletSection.cancelledMessage)) {
-                                return
-                            }
-                            connectEnsModal.sendingError.text = response.result
-                            return connectEnsModal.sendingError.open()
+                function onTransactionWasSent(chainId: int, txHash: string, error: string) {
+                    if (!!error) {
+                        if (error.includes(Constants.walletSection.cancelledMessage)) {
+                            return
                         }
-                        for(var i=0; i<connectEnsModal.bestRoutes.length; i++) {
-                            usernameUpdated(ensUsername.text);
-                            let url =  "%1/%2".arg(connectEnsModal.store.getEtherscanLink(connectEnsModal.bestRoutes[i].fromNetwork.chainId)).arg(response.result)
-                            Global.displayToastMessage(qsTr("Transaction pending..."),
-                                                       qsTr("View on etherscan"),
-                                                       "",
-                                                       true,
-                                                       Constants.ephemeralNotificationType.normal,
-                                                       url)
-                        }
-                    } catch (e) {
-                        console.error('Error parsing the response', e)
+                        connectEnsModal.sendingError.text = error
+                        return connectEnsModal.sendingError.open()
                     }
+                    usernameUpdated(ensUsername.text);
+                    let url =  "%1/%2".arg(connectEnsModal.store.getEtherscanLink(chainId)).arg(txHash)
+                    Global.displayToastMessage(qsTr("Transaction pending..."),
+                                               qsTr("View on etherscan"),
+                                               "",
+                                               true,
+                                               Constants.ephemeralNotificationType.normal,
+                                               url)
                     connectEnsModal.close()
                 }
             }

--- a/ui/app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml
+++ b/ui/app/AppLayouts/Profile/views/EnsTermsAndConditionsView.qml
@@ -52,8 +52,8 @@ Item {
             preDefinedAmountToSend: LocaleUtils.numberToLocaleString(10)
             preSelectedAsset: store.getAsset(buyEnsModal.store.assets, JSON.parse(root.stickersStore.getStatusToken()).symbol)
             sendTransaction: function() {
-                if(bestRoutes.length === 1) {
-                    let path = bestRoutes[0]
+                if(bestRoutes.count === 1) {
+                    let path = bestRoutes.firstItem()
                     let eip1559Enabled = path.gasFees.eip1559Enabled
                     let maxFeePerGas = path.gasFees.maxFeePerGasM
                     root.ensUsernamesStore.authenticateAndRegisterEns(
@@ -70,29 +70,22 @@ Item {
             }
             Connections {
                 target: root.ensUsernamesStore.ensUsernamesModule
-                function onTransactionWasSent(txResult: string) {
-                    try {
-                        let response = JSON.parse(txResult)
-                        if (!response.success) {
-                            if (response.result.includes(Constants.walletSection.cancelledMessage)) {
+                function onTransactionWasSent(chainId: int, txHash: string, error: string) {
+                        if (!!error) {
+                            if (error.includes(Constants.walletSection.cancelledMessage)) {
                                 return
                             }
-                            buyEnsModal.sendingError.text = response.result
+                            buyEnsModal.sendingError.text = error
                             return buyEnsModal.sendingError.open()
                         }
-                        for(var i=0; i<buyEnsModal.bestRoutes.length; i++) {
                             usernameRegistered(username)
-                            let url =  "%1/%2".arg(buyEnsModal.store.getEtherscanLink(buyEnsModal.bestRoutes[i].fromNetwork.chainId)).arg(response.result)
+                            let url =  "%1/%2".arg(buyEnsModal.store.getEtherscanLink(chainId)).arg(txHash)
                             Global.displayToastMessage(qsTr("Transaction pending..."),
                                                        qsTr("View on etherscan"),
                                                        "",
                                                        true,
                                                        Constants.ephemeralNotificationType.normal,
                                                        url)
-                        }
-                    } catch (e) {
-                        console.error('Error parsing the response', e)
-                    }
                 }
             }
         }

--- a/ui/app/AppLayouts/stores/RootStore.qml
+++ b/ui/app/AppLayouts/stores/RootStore.qml
@@ -200,14 +200,6 @@ QtObject {
         return profileSectionStore.ensUsernamesStore.getGasEthValue(gweiValue, gasLimit)
     }
 
-    function suggestedFees(chainId) {
-        return JSON.parse(walletSectionSendInst.suggestedFees(chainId))
-    }
-
-    function getEstimatedTime(chainId, maxFeePerGas) {
-       return walletSectionSendInst.getEstimatedTime(chainId, maxFeePerGas)
-    }
-
     function hex2Eth(value) {
         return globalUtils.hex2Eth(value)
     }

--- a/ui/imports/shared/controls/GasSelector.qml
+++ b/ui/imports/shared/controls/GasSelector.qml
@@ -17,10 +17,11 @@ Item {
     property string selectedTokenSymbol
     property string currentCurrency
 
-    property var bestRoutes: []
+    property var bestRoutes
     property var getGasEthValue: function () {}
     property var getFiatValue: function () {}
     property var formatCurrencyAmount: function () {}
+    property var getNetworkName: function () {}
 
     width: parent.width
     height: visible ? advancedGasSelector.height + Style.current.halfPadding : 0
@@ -47,7 +48,7 @@ Item {
                 asset.color: Theme.palette.directColor1
                 statusListItemIcon.active: true
                 statusListItemIcon.opacity: modelData.isFirstSimpleTx
-                title: qsTr("%1 transaction fee").arg(modelData.fromNetwork.chainName)
+                title: qsTr("%1 transaction fee").arg(root.getNetworkName(modelData.fromNetwork))
                 subTitle: root.formatCurrencyAmount(totalGasAmountEth, "ETH")
                 property double totalGasAmountEth: {
                     let maxFees = modelData.gasFees.maxFeePerGasM
@@ -64,8 +65,6 @@ Item {
                         text: root.formatCurrencyAmount(totalGasAmountFiat, root.currentCurrency)
                         font.pixelSize: 15
                         color: Theme.palette.baseColor1
-                        width: listItem.width/2 - Style.current.padding
-                        elide: Text.ElideRight
                     }
                 ]
             }
@@ -75,19 +74,19 @@ Item {
         Repeater {
             model: root.bestRoutes
             StatusListItem {
-                id: listItem
+                id: listItem1
                 color: Theme.palette.statusListItem.backgroundColor
                 width: parent.width
                 asset.name: "tiny/checkmark"
                 asset.color: Theme.palette.directColor1
                 statusListItemIcon.active: true
                 statusListItemIcon.opacity: modelData.isFirstSimpleTx
-                title: qsTr("Approve %1 %2 Bridge").arg(modelData.fromNetwork.chainName).arg(root.selectedTokenSymbol)
+                title: qsTr("Approve %1 %2 Bridge").arg(root.getNetworkName(modelData.fromNetwork)).arg(root.selectedTokenSymbol)
                 property double approvalGasFees: modelData.approvalGasFees
                 property string approvalGasFeesSymbol: "ETH"
                 property double approvalGasFeesFiat: root.getFiatValue(approvalGasFees, approvalGasFeesSymbol, root.currentCurrency)
                 subTitle: root.formatCurrencyAmount(approvalGasFees, approvalGasFeesSymbol)
-                statusListItemSubTitle.width: listItem.width/2 - Style.current.smallPadding
+                statusListItemSubTitle.width: listItem1.width/2 - Style.current.smallPadding
                 statusListItemSubTitle.elide: Text.ElideMiddle
                 statusListItemSubTitle.wrapMode: Text.NoWrap
                 visible: modelData.approvalRequired
@@ -97,8 +96,6 @@ Item {
                         text:  root.formatCurrencyAmount(approvalGasFeesFiat, root.currentCurrency)
                         font.pixelSize: 15
                         color: Theme.palette.baseColor1
-                        width: listItem.width/2 - Style.current.padding
-                        elide: Text.ElideRight
                     }
                 ]
             }
@@ -116,7 +113,7 @@ Item {
                 asset.color: Theme.palette.directColor1
                 statusListItemIcon.active: true
                 statusListItemIcon.opacity: modelData.isFirstBridgeTx
-                title: qsTr("%1 -> %2 bridge").arg(modelData.fromNetwork.chainName).arg(modelData.toNetwork.chainName)
+                title: qsTr("%1 -> %2 bridge").arg(root.getNetworkName(modelData.fromNetwork)).arg(root.getNetworkName(modelData.toNetwork))
                 property double tokenFees: modelData.tokenFees
                 property double tokenFeesFiat: root.getFiatValue(tokenFees, root.selectedTokenSymbol, root.currentCurrency)
                 subTitle: root.formatCurrencyAmount(tokenFees, root.selectedTokenSymbol)
@@ -129,8 +126,6 @@ Item {
                         text: root.formatCurrencyAmount(tokenFeesFiat, root.currentCurrency)
                         font.pixelSize: 15
                         color: Theme.palette.baseColor1
-                        width: listItem2.width/2 - Style.current.padding
-                        elide: Text.ElideRight
                     }
                 ]
             }

--- a/ui/imports/shared/status/StatusStickerMarket.qml
+++ b/ui/imports/shared/status/StatusStickerMarket.qml
@@ -148,7 +148,7 @@ Item {
                         onCancelClicked: root.cancelClicked(packId)
                         onUpdateClicked: root.updateClicked(packId)
                         onBuyClicked: {
-                            Global.openPopup(stickerPackPurchaseModal, {price})
+                            Global.openPopup(stickerPackPurchaseModal, {price, packId})
                             root.buyClicked(packId)
                         }
                     }
@@ -181,7 +181,7 @@ Item {
                         onCancelClicked: root.cancelClicked(packId)
                         onUpdateClicked: root.updateClicked(packId)
                         onBuyClicked: {
-                            Global.openPopup(stickerPackPurchaseModal, {price})
+                            Global.openPopup(stickerPackPurchaseModal, {price, packId})
                             root.buyClicked(packId)
                         }
                     }
@@ -196,6 +196,7 @@ Item {
             id: buyStickersModal
 
             required property int price
+            required property string packId
 
             interactive: false
             sendType: Constants.SendType.StickersBuy
@@ -203,8 +204,8 @@ Item {
             preDefinedAmountToSend: LocaleUtils.numberToLocaleString(parseFloat(price))
             preSelectedAsset: store.getAsset(buyStickersModal.store.assets, JSON.parse(root.store.stickersStore.getStatusToken()).symbol)
             sendTransaction: function() {
-                if(bestRoutes.length === 1) {
-                    let path = bestRoutes[0]
+                if(bestRoutes.count === 1) {
+                    let path = bestRoutes.firstItem()
                     let eip1559Enabled = path.gasFees.eip1559Enabled
                     let maxFeePerGas = path.gasFees.maxFeePerGasM
                     root.store.stickersStore.authenticateAndBuy(packId,
@@ -218,29 +219,22 @@ Item {
             }
             Connections {
                 target: root.store.stickersStore.stickersModule
-                function onTransactionWasSent(txResult: string) {
-                    try {
-                        let response = JSON.parse(txResult)
-                        if (!response.success) {
-                            if (response.result.includes(Constants.walletSection.cancelledMessage)) {
-                                return
-                            }
-                            buyStickersModal.sendingError.text = response.result
-                            return buyStickersModal.sendingError.open()
+                function onTransactionWasSent(chainId: int, txHash: string, error: string) {
+                    if (!!error) {
+                        if (error.includes(Constants.walletSection.cancelledMessage)) {
+                            return
                         }
-                        for(var i=0; i<buyStickersModal.bestRoutes.length; i++) {
-                            let url =  "%1/%2".arg(buyStickersModal.store.getEtherscanLink(buyStickersModal.bestRoutes[i].fromNetwork.chainId)).arg(response.result)
-                            Global.displayToastMessage(qsTr("Transaction pending..."),
-                                                       qsTr("View on etherscan"),
-                                                       "",
-                                                       true,
-                                                       Constants.ephemeralNotificationType.normal,
-                                                       url)
-                        }
-                        buyStickersModal.close()
-                    } catch (e) {
-                        console.error('Error parsing the response', e)
+                        buyStickersModal.sendingError.text = error
+                        return buyStickersModal.sendingError.open()
                     }
+                    let url =  "%1/%2".arg(buyStickersModal.store.getEtherscanLink(chainId)).arg(txHash)
+                    Global.displayToastMessage(qsTr("Transaction pending..."),
+                                               qsTr("View on etherscan"),
+                                               "",
+                                               true,
+                                               Constants.ephemeralNotificationType.normal,
+                                               url)
+                    buyStickersModal.close()
                 }
             }
         }

--- a/ui/imports/shared/stores/TransactionStore.qml
+++ b/ui/imports/shared/stores/TransactionStore.qml
@@ -1,32 +1,26 @@
 import QtQuick 2.13
 
-import utils 1.0
+import SortFilterProxyModel 0.2
 
 import shared.stores 1.0
-import "../../../app/AppLayouts/Profile/stores"
-import SortFilterProxyModel 0.2
+
+import utils 1.0
 
 QtObject {
     id: root
 
     property CurrenciesStore currencyStore: CurrenciesStore {}
-    property ProfileSectionStore profileSectionStore: ProfileSectionStore {}
-    property var contactStore: profileSectionStore.contactsStore
 
     property var mainModuleInst: mainModule
     property var walletSectionSendInst: walletSectionSend
-    property var walletSectionInst: walletSection
 
-    property var tmpActivityController: walletSectionInst.tmpActivityController
-
-    property string currentCurrency: walletSectionInst.currentCurrency
-    property var allNetworks: networksModule.all
-    property var overview: walletSectionOverview
-    property var accounts: walletSectionSendInst.accounts
+    property var fromNetworksModel: walletSectionSendInst.fromNetworksModel
+    property var toNetworksModel: walletSectionSendInst.toNetworksModel
     property var senderAccounts: walletSectionSendInst.senderAccounts
     property var selectedSenderAccount: walletSectionSendInst.selectedSenderAccount
-    property string signingPhrase: walletSectionInst.signingPhrase
+    property var accounts: walletSectionSendInst.accounts
     property bool areTestNetworksEnabled: networksModule.areTestNetworksEnabled
+    property var tmpActivityController: walletSection.tmpActivityController
     property var savedAddressesModel: SortFilterProxyModel {
         sourceModel: walletSectionSavedAddresses.model
         filters: [
@@ -36,38 +30,8 @@ QtObject {
             }
         ]
     }
-    property var disabledChainIdsFromList: []
-    property var disabledChainIdsToList: []
-
-    property var assets: walletSectionAssets.assets
-
-    function addRemoveDisabledFromChain(chainID, isDisabled) {
-        if(isDisabled) {
-            if(!root.disabledChainIdsFromList.includes(chainID))
-                disabledChainIdsFromList.push(chainID)
-        }
-        else {
-            for(var i = 0; i < disabledChainIdsFromList.length;i++) {
-                if(disabledChainIdsFromList[i] === chainID) {
-                    disabledChainIdsFromList.splice(i, 1)
-                }
-            }
-        }
-    }
-
-    function addRemoveDisabledToChain(chainID, isDisabled) {
-        if(isDisabled) {
-            if(!root.disabledChainIdsToList.includes(chainID))
-                root.disabledChainIdsToList.push(chainID)
-        }
-        else {
-            for(var i = 0; i < root.disabledChainIdsToList.length;i++) {
-                if(root.disabledChainIdsToList[i] === chainID) {
-                    root.disabledChainIdsToList.splice(i, 1)
-                }
-            }
-        }
-    }
+    property string selectedAssetSymbol: walletSectionSendInst.selectedAssetSymbol
+    property bool showUnPreferredChains: walletSectionSendInst.showUnPreferredChains
 
     function getEtherscanLink(chainID) {
         return networksModule.all.getBlockExplorerURL(chainID)
@@ -77,24 +41,12 @@ QtObject {
         globalUtils.copyToClipboard(text)
     }
 
-    function authenticateAndTransfer(from, to, tokenSymbol, amount, uuid, selectedRoutes) {
-        walletSectionSendInst.authenticateAndTransfer(from, to, tokenSymbol, amount, uuid, selectedRoutes)
+    function authenticateAndTransfer(from, to, tokenSymbol, amount, uuid) {
+        walletSectionSendInst.authenticateAndTransfer(from, to, tokenSymbol, amount, uuid)
     }
 
-    function suggestedFees(chainId) {
-        return JSON.parse(walletSectionSendInst.suggestedFees(chainId))
-    }
-
-    function getEstimatedTime(chainId, maxFeePerGas) {
-       return walletSectionSendInst.getEstimatedTime(chainId, maxFeePerGas)
-    }
-
-    function suggestedRoutes(account, amount, token, disabledFromChainIDs, disabledToChainIDs, preferredChainIds, sendType, lockedInAmounts) {
-        walletSectionSendInst.suggestedRoutes(account, amount, token, disabledFromChainIDs, disabledToChainIDs, preferredChainIds, sendType, JSON.stringify(lockedInAmounts))
-    }
-
-    function hex2Eth(value) {
-        return globalUtils.hex2Eth(value)
+    function suggestedRoutes(amount, sendType) {
+        walletSectionSendInst.suggestedRoutes(amount, sendType)
     }
 
     function resolveENS(value) {
@@ -105,111 +57,8 @@ QtObject {
         return globalUtils.wei2Eth(wei, decimals)
     }
 
-    function getEth2Wei(eth, decimals) {
-         return globalUtils.eth2Wei(eth, decimals)
-    }
-
     function plainText(text) {
         return globalUtils.plainText(text)
-    }
-
-    function setDefaultPreferredDisabledChains() {
-        let mainnetChainId = getMainnetChainId()
-        preferredChainIds.push(mainnetChainId)
-        addUnpreferredChainsToDisabledChains()
-    }
-
-    function setAllNetworksAsPreferredChains() {
-        var preferredChains = []
-        for(var i = 0; i < allNetworks.count; i++) {
-            let chainId = allNetworks.rowData(i, "chainId") * 1
-            if(!preferredChainIds.includes(chainId)) {
-                preferredChainIds.push(chainId)
-            }
-        }
-    }
-
-    function resetTxStoreProperties() {
-        disabledChainIdsFromList = []
-        disabledChainIdsToList = []
-        preferredChainIds = []
-        lockedInAmounts = []
-    }
-
-    property var preferredChainIds: []
-
-    function getMainnetChainId() {
-        return networksModule.getMainnetChainId()
-    }
-
-    // We should move all this over to nim
-    function addPreferredChains(preferredchains, showUnpreferredNetworks) {
-        let tempPreferredChains = preferredChainIds
-        for(const chain of preferredchains) {
-            if(!tempPreferredChains.includes(chain)) {
-                tempPreferredChains.push(chain)
-                // remove from disabled accounts as it was added as preferred
-                addRemoveDisabledToChain(chain, false)
-            }
-        }
-
-        // here we are trying to remove chains that are not preferred from the list and
-        // also disable them incase the showUnpreferredNetworks toggle is turned off
-        for(var i = 0; i < tempPreferredChains.length; i++) {
-            if(!preferredchains.includes(tempPreferredChains[i])) {
-                if(!showUnpreferredNetworks)
-                    addRemoveDisabledToChain(tempPreferredChains[i], true)
-                tempPreferredChains.splice(i, 1)
-            }
-        }
-
-        preferredChainIds = tempPreferredChains
-    }
-
-    function addUnpreferredChainsToDisabledChains() {
-        for(var i = 0; i < allNetworks.count; i++) {
-            let chainId = allNetworks.rowData(i, "chainId") * 1
-            if(!preferredChainIds.includes(chainId)) {
-                addRemoveDisabledToChain(chainId, true)
-            }
-        }
-    }
-
-    function splitAndFormatAddressPrefix(text, isBridgeTx, showUnpreferredNetworks) {
-        let address = ""
-        let tempPreferredChains = []
-        let chainFound = false
-        let splitWords = plainText(text).split(':')
-        let editedText = ""
-
-        for(var i=0; i<splitWords.length; i++) {
-            const word = splitWords[i]
-            if(word.startsWith("0x")) {
-                address = word
-                editedText += word
-            } else {
-                let chainColor = allNetworks.getNetworkColor(word)
-                if(!!chainColor) {
-                    chainFound = true
-                    if(!isBridgeTx)
-                        tempPreferredChains.push(allNetworks.getNetworkChainId(word))
-                    editedText += `<span style='color: %1'>%2</span>`.arg(chainColor).arg(word)+':'
-                }
-            }
-        }
-
-        if(!isBridgeTx) {
-            if(!chainFound)
-                addPreferredChains([getMainnetChainId()], showUnpreferredNetworks)
-            else
-                addPreferredChains(tempPreferredChains, showUnpreferredNetworks)
-        }
-
-        editedText +="</a></p>"
-        return {
-            formattedText: editedText,
-            address: address
-        }
     }
 
     enum EstimatedTime {
@@ -235,33 +84,6 @@ QtObject {
         }
     }
 
-    property var lockedInAmounts: []
-
-    function addLockedInAmount(chainID, value, decimals, locked) {
-        let amount = value * Math.pow(10, decimals)
-        let index  = lockedInAmounts.findIndex(lockedItem => lockedItem !== undefined && lockedItem.chainID === chainID)
-        if(index === -1) {
-            lockedInAmounts.push({"chainID": chainID, "value": amount.toString(16)})
-        }
-        else {
-            if(locked) {
-                lockedInAmounts[index].value = amount.toString(16)
-            } else {
-                lockedInAmounts.splice(index,1)
-            }
-        }
-    }
-
-    function getTokenBalanceOnChain(selectedAccount, chainId: int, tokenSymbol: string) {
-        if (!selectedAccount) {
-            console.warn("selectedAccount invalid")
-            return undefined
-        }
-
-        walletSectionSendInst.prepareTokenBalanceOnChain(selectedAccount.address, chainId, tokenSymbol)
-        return walletSectionSendInst.getPreparedTokenBalanceOnChain()
-    }
-
     function findTokenSymbolByAddress(address) {
         if (Global.appIsReady)
             return walletSectionAllTokens.findTokenSymbolByAddress(address)
@@ -283,15 +105,89 @@ QtObject {
         return {}
     }
 
-    function getAllNetworksSupportedPrefix() {
-        return networksModule.getAllNetworksSupportedPrefix()
-    }
-
     function switchSenderAccount(index) {
         walletSectionSendInst.switchSenderAccount(index)
     }
 
     function getNetworkShortNames(chainIds) {
        return networksModule.getNetworkShortNames(chainIds)
+    }
+
+    function toggleFromDisabledChains(chainId) {
+        fromNetworksModel.toggleDisabledChains(chainId)
+    }
+
+    function toggleToDisabledChains(chainId) {
+        toNetworksModel.toggleDisabledChains(chainId)
+    }
+
+    function setDisabledChains(chainId, disabled) {
+        toNetworksModel.setDisabledChains(chainId, disabled)
+    }
+
+    function setSelectedAssetSymbol(symbol) {
+        walletSectionSendInst.setSelectedAssetSymbol(symbol)
+    }
+
+    function getNetworkName(chainId) {
+      return fromNetworksModel.getNetworkName(chainId)
+    }
+
+    function updatePreferredChains(chainIds) {
+       walletSectionSendInst.updatePreferredChains(chainIds)
+    }
+
+    function toggleShowUnPreferredChains() {
+        walletSectionSendInst.toggleShowUnPreferredChains()
+    }
+
+    function setAllNetworksAsPreferredChains() {
+        toNetworksModel.setAllNetworksAsPreferredChains()
+    }
+
+    function lockCard(chainId, amount, lock) {
+        fromNetworksModel.lockCard(chainId, amount, lock)
+    }
+
+    function resetStoredProperties() {
+        walletSectionSendInst.resetStoredProperties()
+    }
+
+    // TODO: move to nim
+    function splitAndFormatAddressPrefix(text, isBridgeTx) {
+        let address = ""
+        let tempPreferredChains = []
+        let chainFound = false
+        let splitWords = plainText(text).split(':')
+        let editedText = ""
+
+        for(var i=0; i<splitWords.length; i++) {
+            const word = splitWords[i]
+            if(word.startsWith("0x")) {
+                address = word
+                editedText += word
+            } else {
+                let chainColor = fromNetworksModel.getNetworkColor(word)
+                if(!!chainColor) {
+                    chainFound = true
+                    if(!isBridgeTx)
+                        tempPreferredChains.push(fromNetworksModel.getNetworkChainId(word))
+                    editedText += `<span style='color: %1'>%2</span>`.arg(chainColor).arg(word)+':'
+                }
+            }
+        }
+
+        if(!isBridgeTx) {
+            if(!chainFound)
+                updatePreferredChains(networksModule.getMainnetChainId())
+            else
+                updatePreferredChains(tempPreferredChains.join(":"))
+        }
+
+        editedText +="</a></p>"
+        return {
+            formattedText: editedText,
+            address: address
+        }
     }
 }

--- a/ui/imports/shared/views/AmountToReceive.qml
+++ b/ui/imports/shared/views/AmountToReceive.qml
@@ -10,7 +10,6 @@ import shared.stores 1.0
 ColumnLayout {
     id: root
 
-    property var store
     property string selectedSymbol
     property bool isLoading: false
     property double cryptoValueToReceive

--- a/ui/imports/shared/views/FeesView.qml
+++ b/ui/imports/shared/views/FeesView.qml
@@ -63,7 +63,7 @@ Rectangle {
                     text: root.isLoading ? "..." : root.currencyStore.formatCurrencyAmount(root.gasFiatAmount, root.currencyStore.currentCurrency)
                     font.pixelSize: 15
                     color: Theme.palette.directColor1
-                    visible: !!root.bestRoutes && root.bestRoutes !== undefined && root.bestRoutes.length > 0
+                    visible: !!root.bestRoutes && root.bestRoutes !== undefined && root.bestRoutes.count > 0
                 }
             }
             GasSelector {
@@ -76,6 +76,7 @@ Rectangle {
                 visible: root.errorType === Constants.NoError && !root.isLoading
                 bestRoutes: root.bestRoutes
                 selectedTokenSymbol: root.selectedTokenSymbol
+                getNetworkName: root.store.getNetworkName
             }
             GasValidator {
                 id: gasValidator

--- a/ui/imports/shared/views/NetworkSelector.qml
+++ b/ui/imports/shared/views/NetworkSelector.qml
@@ -25,15 +25,12 @@ Item {
     property var amountToSend
     property int minSendCryptoDecimals: 0
     property int minReceiveCryptoDecimals: 0
-    property var requiredGasInEth
-    property var bestRoutes
     property bool isLoading: false
     property bool advancedOrCustomMode: (tabBar.currentIndex === 1) || (tabBar.currentIndex === 2)
     property bool errorMode: advancedNetworkRoutingPage.errorMode
     property bool interactive: true
     property bool isBridgeTx: false
-    property bool showUnpreferredNetworks: advancedNetworkRoutingPage.showUnpreferredNetworks
-    property var toNetworksList: []
+    property var toNetworksList
     property int errorType: Constants.NoError
 
     signal reCalculateSuggestedRoute()
@@ -78,19 +75,18 @@ Item {
                 anchors.left: parent.left
                 anchors.margins: Style.current.padding
                 width: stackLayout.width  - Style.current.bigPadding
-                bestRoutes: root.bestRoutes
                 isBridgeTx: root.isBridgeTx
                 amountToSend: root.amountToSend
                 minReceiveCryptoDecimals: root.minReceiveCryptoDecimals
                 isLoading: root.isLoading
                 store: root.store
-                selectedAsset: root.selectedAsset
                 selectedAccount: root.selectedAccount
                 errorMode: root.errorMode
                 errorType: root.errorType
                 toNetworksList: root.toNetworksList
                 weiToEth: function(wei) {
-                    return parseFloat(store.getWei2Eth(wei, selectedAsset.decimals))
+                    if(root.selectedAsset !== undefined)
+                        return parseFloat(store.getWei2Eth(wei, root.selectedAsset.decimals))
                 }
                 formatCurrencyAmount: root.currencyStore.formatCurrencyAmount
                 reCalculateSuggestedRoute: function() {
@@ -114,18 +110,17 @@ Item {
                 selectedAccount: root.selectedAccount
                 ensAddressOrEmpty: root.ensAddressOrEmpty
                 amountToSend: root.amountToSend
-                requiredGasInEth: root.requiredGasInEth
                 minSendCryptoDecimals: root.minSendCryptoDecimals
                 minReceiveCryptoDecimals: root.minReceiveCryptoDecimals
                 selectedAsset: root.selectedAsset
                 onReCalculateSuggestedRoute: root.reCalculateSuggestedRoute()
-                bestRoutes: root.bestRoutes
                 isLoading: root.isLoading
                 interactive: root.interactive
                 isBridgeTx: root.isBridgeTx
                 errorType: root.errorType
                 weiToEth: function(wei) {
-                    return parseFloat(store.getWei2Eth(wei, selectedAsset.decimals))
+                    if(selectedAsset !== undefined)
+                        return parseFloat(store.getWei2Eth(wei, selectedAsset.decimals))
                 }
             }
         }

--- a/ui/imports/shared/views/NetworksAdvancedCustomRoutingView.qml
+++ b/ui/imports/shared/views/NetworksAdvancedCustomRoutingView.qml
@@ -8,6 +8,7 @@ import StatusQ.Popups 0.1
 import StatusQ.Components 0.1
 import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
+import StatusQ.Core.Utils 0.1 as StatusQUtils
 
 import "../controls"
 
@@ -20,16 +21,13 @@ ColumnLayout {
     property double amountToSend
     property int minSendCryptoDecimals: 0
     property int minReceiveCryptoDecimals: 0
-    property double requiredGasInEth
     property bool customMode: false
     property var selectedAsset
-    property var bestRoutes
     property bool isLoading: false
     property bool errorMode: networksLoader.item ? networksLoader.item.errorMode : false
     property var weiToEth: function(wei) {}
     property bool interactive: true
     property bool isBridgeTx: false
-    property bool showUnpreferredNetworks: preferredToggleButton.checked
     property int errorType: Constants.NoError
 
     signal reCalculateSuggestedRoute()
@@ -58,7 +56,6 @@ ColumnLayout {
                     wrapMode: Text.WordWrap
                 }
                 StatusButton {
-                    id: preferredToggleButton
                     Layout.alignment: Qt.AlignRight
                     Layout.preferredHeight: 22
                     verticalPadding: -1
@@ -68,8 +65,12 @@ ColumnLayout {
                     icon.height: 16
                     icon.width: 16
                     text: checked ? qsTr("Hide Unpreferred Networks"): qsTr("Show Unpreferred Networks")
-                    onToggled: if(!checked) store.addUnpreferredChainsToDisabledChains()
                     visible: !isBridgeTx
+                    checked: root.store.showUnPreferredChains
+                    onClicked: {
+                        root.store.toggleShowUnPreferredChains()
+                        root.reCalculateSuggestedRoute()
+                    }
                 }
             }
             StatusBaseText {
@@ -87,20 +88,17 @@ ColumnLayout {
                 visible: active
                 sourceComponent: NetworkCardsComponent {
                     store: root.store
-                    selectedAccount: root.selectedAccount
-                    ensAddressOrEmpty: root.ensAddressOrEmpty
-                    allNetworks: root.store.allNetworks
+                    receiverIdentityText: root.ensAddressOrEmpty.length > 0 ?
+                                              root.ensAddressOrEmpty : !!root.selectedAccount ?
+                                                  StatusQUtils.Utils.elideText(root.selectedAccount.address, 6, 4).toUpperCase() :  ""
                     amountToSend: root.amountToSend
                     minSendCryptoDecimals: root.minSendCryptoDecimals
                     minReceiveCryptoDecimals: root.minReceiveCryptoDecimals
                     customMode: root.customMode
-                    requiredGasInEth: root.requiredGasInEth
                     selectedAsset: root.selectedAsset
                     reCalculateSuggestedRoute: function() {
                         root.reCalculateSuggestedRoute()
                     }
-                    showPreferredChains: preferredToggleButton.checked
-                    bestRoutes: root.bestRoutes
                     weiToEth: root.weiToEth
                     interactive: root.interactive
                     errorType: root.errorType

--- a/ui/imports/shared/views/RecipientView.qml
+++ b/ui/imports/shared/views/RecipientView.qml
@@ -18,7 +18,6 @@ Loader {
     property var store
     property bool isBridgeTx: false
     property bool interactive: true
-    property bool showUnpreferredNetworks: false
     property var selectedAsset
     property var selectedRecipient: null
     property int selectedRecipientType
@@ -36,6 +35,10 @@ Loader {
     onSelectedRecipientChanged: {
         root.isLoading()
         d.waitTimer.restart()
+        if(!root.isBridgeTx)
+            root.store.updatePreferredChains(root.selectedRecipient.preferredSharingChainIds)
+        else
+            root.store.setAllNetworksAsPreferredChains()
         if(!!root.selectedRecipient && root.selectedRecipientType !== TabAddressSelectorView.Type.None) {
             switch(root.selectedRecipientType) {
             case TabAddressSelectorView.Type.SavedAddress: {
@@ -85,10 +88,10 @@ Loader {
                         if(!!root.item.input)
                             root.item.input.text = root.resolvedENSAddress
                         root.addressText = root.resolvedENSAddress
-                        store.splitAndFormatAddressPrefix(root.address, root.isBridgeTx, root.showUnpreferredNetworks)
+                        store.splitAndFormatAddressPrefix(root.address, root.isBridgeTx)
                     } else {
                         let address = d.getAddress()
-                        let result = store.splitAndFormatAddressPrefix(address, root.isBridgeTx, root.showUnpreferredNetworks)
+                        let result = store.splitAndFormatAddressPrefix(address, root.isBridgeTx)
                         if(!!result.address) {
                             root.addressText = result.address
                             if(!!root.item.input)
@@ -139,7 +142,7 @@ Loader {
     Component {
         id: myAccountRecipient
         WalletAccountListItem {
-            property string chainShortNames: store.getNetworkShortNames(modelData.preferredSharingChainIds)
+            property string chainShortNames: !!modelData ? store.getNetworkShortNames(modelData.preferredSharingChainIds): ""
             implicitWidth: parent.width
             modelData: root.selectedRecipient
             radius: 8


### PR DESCRIPTION
fixes #11881

### What does the PR do

**This is the first step to the SendModal refactor. What this covers is-**
1. Removing the Json parsing on qml side and creating QT components on nim side to represent them
2. Moving logic of disabled networks, preferred networks and locked amounts to the nim
3. Create a list of to from from networks on the nim side to showcase the possible routes in advanced and custom views

**Things yet to be done-**
1. Bug for 2nd notification for tx not shown
2. Move selected recipient and send type to nim
3. isBridgeTx should be a type of send type we can remove the boolean property in the SendModal
4. Also improve overall Bridge logic in sendModal
5. Move parsing user entered preferred chains logic to nim and remore code not required in case of accounts/saved addresses and preferred chains is already known
6. Remove all chat send modal code, not needed and its annoying
7. Automatic refresh of balance after send/receive
8. can we add refresh buttons for assets/transactions?

### Affected areas

SendModal

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it