### PR TITLE
fix(@desktop/wallet): Show networks for Bridge txs

### DIFF
--- a/src/app/modules/main/wallet_section/activity/entry.nim
+++ b/src/app/modules/main/wallet_section/activity/entry.nim
@@ -166,14 +166,22 @@ QtObject:
   QtProperty[int] status:
     read = getStatus
 
-  proc getChainId*(self: ActivityEntry): int {.slot.} =
-    if self.metadata.payloadType == backend.PayloadType.MultiTransaction:
-      error "getChainId: ActivityEntry is not a transaction"
-      return 0
+  proc getChainIdIn*(self: ActivityEntry): int {.slot.} =
+    return self.metadata.chainIdIn.get(ChainId(0)).int
 
-    if self.isInTransactionType():
-      return self.metadata.chainIdIn.get(ChainId(0)).int
+  QtProperty[int] chainIdIn:
+    read = getChainIdIn
+    
+  proc getChainIdOut*(self: ActivityEntry): int {.slot.} =
     return self.metadata.chainIdOut.get(ChainId(0)).int
+
+  QtProperty[int] chainIdOut:
+    read = getChainIdOut
+
+  proc getChainId*(self: ActivityEntry): int {.slot.} =
+    if self.isInTransactionType():
+      return self.getChainIdIn()
+    return self.getChainIdOut()
 
   QtProperty[int] chainId:
     read = getChainId

--- a/ui/imports/shared/controls/TransactionDelegate.qml
+++ b/ui/imports/shared/controls/TransactionDelegate.qml
@@ -60,6 +60,8 @@ StatusListItem {
     readonly property double feeFiatValue: 0.0 // TODO fill when bridge data is implemented
     readonly property string networkColor: isModelDataValid ? rootStore.getNetworkColor(modelData.chainId) : ""
     readonly property string networkName: isModelDataValid ? rootStore.getNetworkFullName(modelData.chainId) : ""
+    readonly property string networkNameIn: isMultiTransaction ? rootStore.getNetworkFullName(modelData.chainIdIn) : ""
+    readonly property string networkNameOut: isMultiTransaction ? rootStore.getNetworkFullName(modelData.chainIdOut) : ""
     readonly property string addressNameTo: isModelDataValid ? walletRootStore.getNameForAddress(modelData.recipient) : ""
     readonly property string addressNameFrom: isModelDataValid ? walletRootStore.getNameForAddress(modelData.sender) : ""
     readonly property bool isNFT: isModelDataValid && modelData.isNFT
@@ -268,17 +270,16 @@ StatusListItem {
         }
 
         // SUMMARY ADRESSES
-        const toNetworkName = "" // TODO fill when bridge data is implemented
         switch (type) {
         case Constants.TransactionType.Swap:
             details += qsTr("From") + endl + modelData.outSymbol + endl2
             details += qsTr("To") + endl + modelData.inSymbol + endl2
-            details += qsTr("In") + endl + root.fromAddress + endl2
+            details += qsTr("In") + endl + modelData.sender + endl2
             break
         case Constants.TransactionType.Bridge:
-            details += qsTr("From") + endl + root.networkName + endl2
-            details += qsTr("To") + endl + toNetworkName + endl2
-            details += qsTr("In") + endl + modelData.from + endl2
+            details += qsTr("From") + endl + networkNameOut + endl2
+            details += qsTr("To") + endl + networkNameIn + endl2
+            details += qsTr("In") + endl + modelData.sender + endl2
             break
         case Constants.TransactionType.ContractDeployment:
             details += qsTr("From") + endl + modelData.sender + endl2
@@ -306,7 +307,7 @@ StatusListItem {
         }
         const bridgeTxHash = "" // TODO fill tx hash for Bridge
         if (!!bridgeTxHash) {
-            details += qsTr("%1 Tx hash").arg(toNetworkName) + endl + bridgeTxHash + endl2
+            details += qsTr("%1 Tx hash").arg(networkNameOut) + endl + bridgeTxHash + endl2
         }
         const protocolFromContractAddress = "" // TODO fill protocol contract address for 'from' network for Bridge and Swap
         if (!!protocolName && !!protocolFromContractAddress) {
@@ -320,7 +321,7 @@ StatusListItem {
         }
         const protocolToContractAddress = "" // TODO fill protocol contract address for 'to' network for Bridge
         if (!!protocolToContractAddress && !!protocolName) {
-            details += qsTr("%1 %2 contract address").arg(toNetworkName).arg(protocolName) + endl
+            details += qsTr("%1 %2 contract address").arg(networkNameOut).arg(protocolName) + endl
             details += protocolToContractAddress + endl2
         }
         const swapContractAddress = "" // TODO fill swap contract address for Swap
@@ -334,7 +335,7 @@ StatusListItem {
             break
         case Constants.TransactionType.Bridge:
             if (!!bridgeContractAddress) {
-                details += qsTr("%1 %2 contract address").arg(toNetworkName).arg(modelData.symbol) + endl
+                details += qsTr("%1 %2 contract address").arg(networkNameOut).arg(modelData.symbol) + endl
                 details += bridgeContractAddress + endl2
             }
             break
@@ -351,7 +352,7 @@ StatusListItem {
         if (type === Constants.TransactionType.Bridge) {
             details += qsTr("Included in Block on %1").arg(networkName) + endl
             details += rootStore.hex2Dec(modelData.blockNumber)  + endl2
-            details += qsTr("Included in Block on %1").arg(toNetworkName) + endl
+            details += qsTr("Included in Block on %1").arg(networkNameOut) + endl
             const bridgeBlockNumber = 0 // TODO fill when bridge data is implemented
             details += rootStore.hex2Dec(bridgeBlockNumber)  + endl2
         } else {
@@ -430,8 +431,8 @@ StatusListItem {
             details += valuesString + endl2
         }
 
-        // Remove unicode characters
-        details = details.replace(/[^\x00-\x7F]/g, " ");
+        // Remove no-break space
+        details = details.replace(/[\xA0]/g, " ");
         // Remove empty new lines at the end
         return details.replace(/[\r\n\s]*$/, '')
     }
@@ -453,13 +454,12 @@ StatusListItem {
             return qsTr("%1 at %2 via %3").arg(inTransactionValue).arg(toAddress).arg(networkName)
         case Constants.TransactionType.Swap:
             if (allAccounts)
-                return qsTr("%1 to %2 via %3 in %4").arg(outTransactionValue).arg(inTransactionValue).arg(networkName).arg(toAddress)
+                return qsTr("%1 to %2 via %3 in %4").arg(outTransactionValue).arg(inTransactionValue).arg(networkName).arg(fromAddress)
             return qsTr("%1 to %2 via %3").arg(outTransactionValue).arg(inTransactionValue).arg(networkName)
         case Constants.TransactionType.Bridge:
-            let toNetworkName = "" // TODO fill when Bridge data is implemented
             if (allAccounts)
-                return qsTr("%1 from %2 to %3 in %4").arg(inTransactionValue).arg(networkName).arg(toNetworkName).arg(toAddress)
-            return qsTr("%1 from %2 to %3").arg(inTransactionValue).arg(networkName).arg(toNetworkName)
+                return qsTr("%1 from %2 to %3 in %4").arg(inTransactionValue).arg(networkNameOut).arg(networkNameIn).arg(fromAddress)
+            return qsTr("%1 from %2 to %3").arg(inTransactionValue).arg(networkNameOut).arg(networkNameIn)
         case Constants.TransactionType.ContractDeployment:
             const name = addressNameTo || addressNameFrom
             return !!modelData.contract ? qsTr("Contract %1 via %2 on %3").arg(Utils.compactAddress(modelData.contract, 4)).arg(name).arg(networkName)


### PR DESCRIPTION
fixes #11886 

### What does the PR do

* show network name in description and activity details for Bridge
* remove only no-break space from activity details

Missing data (fees, hashes and other) will be resolved in #11897

### Affected areas

Wallet activity UI

### Screenshot of functionality (including design for comparison)

![image](https://github.com/status-im/status-desktop/assets/11396062/2b5115cd-8d1f-489f-9480-42bdd2c31935)

![image](https://github.com/status-im/status-desktop/assets/11396062/ca98e219-0166-41c6-a55f-3d1e965ff604)

