### PR TITLE
fix: clear chat history leaves user/channel page blank

### DIFF
--- a/src/app/modules/main/chat_section/chat_content/messages/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/module.nim
@@ -632,6 +632,8 @@ method onMessageEdited*(self: Module, message: MessageDto) =
 
 method onHistoryCleared*(self: Module) =
   self.view.model().clear()
+  # Add ChatIdentifier back after model is cleared, so that the chat screen is not blank
+  self.view.model().insertItemBasedOnClock(self.createChatIdentifierItem())
 
 method updateChatIdentifier*(self: Module) =
   let chatDto = self.controller.getChatDetails()


### PR DESCRIPTION
We should at least keep the Chat Identifier _bogus message_ pinned up, as first message in the model.

Fixes #10889
