### PR TITLE
fix(threadpool): stop logging task args because they may contain pwd

### DIFF
--- a/src/app/core/tasks/threadpool.nim
+++ b/src/app/core/tasks/threadpool.nim
@@ -51,8 +51,8 @@ proc runTask(safeTaskArg: ThreadSafeTaskArg) {.gcsafe, nimcall.} =
 
   let messageType = parsed{"$type"}.getStr
     
-  debug "[threadpool task thread] initiating task", messageType=messageType,
-    threadid=getThreadId(), task=taskArg
+  # TODO re-add the taskArg to the log once all the passwords in the app are hashed before being sent to another thread
+  debug "[threadpool task thread] initiating task", messageType=messageType, threadid=getThreadId()
 
   try:
     let task = cast[Task](parsed{"tptr"}.getInt)


### PR DESCRIPTION
Same as https://github.com/status-im/status-desktop/pull/11911 but for master