### PR TITLE
Hook pending join request backend to new UI

### DIFF
--- a/src/app_service/service/community/dto/community.nim
+++ b/src/app_service/service/community/dto/community.nim
@@ -14,7 +14,9 @@ type RequestToJoinType* {.pure.}= enum
   Pending = 1,
   Declined = 2,
   Accepted = 3,
-  Canceled = 4
+  Canceled = 4,
+  AcceptedPending = 5,
+  DeclinedPending = 6,
 
 type MutedType* {.pure.}= enum
   For15min = 1,

--- a/src/app_service/service/community/service.nim
+++ b/src/app_service/service/community/service.nim
@@ -296,15 +296,17 @@ QtObject:
 
           let requestToJoinState = RequestToJoinType(membershipRequest.state)
 
-          if requestToJoinState != RequestToJoinType.Pending:
-            try:
-              self.updateMembershipRequestToNewState(membershipRequest.communityId, membershipRequest.id, community, requestToJoinState)
-            except Exception as e:
-              error "Unknown request", msg = e.msg
-          else:
+          if self.getPendingRequestIndex(membershipRequest.communityId, membershipRequest.id) == -1:
             community.pendingRequestsToJoin.add(membershipRequest)
             self.communities[membershipRequest.communityId] = community
-            self.events.emit(SIGNAL_NEW_REQUEST_TO_JOIN_COMMUNITY, CommunityRequestArgs(communityRequest: membershipRequest))
+            self.events.emit(SIGNAL_NEW_REQUEST_TO_JOIN_COMMUNITY,
+              CommunityRequestArgs(communityRequest: membershipRequest))
+          else:
+            try:
+              self.updateMembershipRequestToNewState(membershipRequest.communityId, membershipRequest.id, community,
+                requestToJoinState)
+            except Exception as e:
+              error "Unknown request", msg = e.msg
 
           self.events.emit(SIGNAL_COMMUNITY_EDITED, CommunityArgs(community: self.communities[membershipRequest.communityId]))
 

--- a/src/backend/communities.nim
+++ b/src/backend/communities.nim
@@ -97,6 +97,9 @@ proc myCanceledRequestsToJoin*(): RpcResponse[JsonNode] {.raises: [Exception].} 
 proc pendingRequestsToJoinForCommunity*(communityId: string): RpcResponse[JsonNode] {.raises: [Exception].} =
   result = callPrivateRPC("pendingRequestsToJoinForCommunity".prefix, %*[communityId])
 
+proc allPendingRequestsToJoinForCommunity*(communityId: string): RpcResponse[JsonNode] {.raises: [Exception].} =
+  result = callPrivateRPC("allPendingRequestsToJoinForCommunity".prefix, %*[communityId])
+
 proc declinedRequestsToJoinForCommunity*(communityId: string): RpcResponse[JsonNode] {.raises: [Exception].} =
   result = callPrivateRPC("declinedRequestsToJoinForCommunity".prefix, %*[communityId])
 

--- a/ui/app/AppLayouts/Communities/panels/MembersSettingsPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/MembersSettingsPanel.qml
@@ -23,6 +23,7 @@ SettingsPage {
     property var declinedMemberRequestsModel
     property string communityName
 
+    property int memberRole
     property bool editable: true
 
     signal membershipRequestsClicked()
@@ -107,6 +108,7 @@ SettingsPage {
             MembersTabPanel {
                 model: root.membersModel
                 rootStore: root.rootStore
+                memberRole: root.memberRole
                 placeholderText: {
                     if (root.membersModel.count === 0)
                         return qsTr("No members to search")
@@ -134,6 +136,7 @@ SettingsPage {
             MembersTabPanel {
                 model: root.pendingMemberRequestsModel
                 rootStore: root.rootStore
+                memberRole: root.memberRole
                 placeholderText: {
                     if (root.pendingMemberRequestsModel.count === 0)
                         return qsTr("No pending requests to search")
@@ -152,6 +155,7 @@ SettingsPage {
             MembersTabPanel {
                 model: root.declinedMemberRequestsModel
                 rootStore: root.rootStore
+                memberRole: root.memberRole
                 placeholderText: {
                     if (root.declinedMemberRequestsModel.count === 0)
                         return qsTr("No rejected members to search")
@@ -169,6 +173,7 @@ SettingsPage {
             MembersTabPanel {
                 model: root.bannedMembersModel
                 rootStore: root.rootStore
+                memberRole: root.memberRole
                 placeholderText: {
                     if (root.bannedMembersModel.count === 0)
                         return qsTr("No banned members to search")

--- a/ui/app/AppLayouts/Communities/panels/MembersTabPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/MembersTabPanel.qml
@@ -122,7 +122,7 @@ Item {
                         case Constants.memberRole.tokenMaster: return root.isOwner
                         // Admin can only be banned by owner and tokenMaster
                         case Constants.memberRole.admin: return root.isOwner || root.isTokenMaster
-                        // Everyone can be banned by everyone
+                        // All normal members can be banned by all privileged users
                         default: return true
                     }
                 }

--- a/ui/app/AppLayouts/Communities/panels/MembersTabPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/MembersTabPanel.qml
@@ -21,6 +21,10 @@ Item {
     property string placeholderText
     property var model
     property var rootStore
+    property int memberRole: Constants.memberRole.none
+
+    property bool isOwner: memberRole === Constants.memberRole.owner
+    property bool isTokenMaster: memberRole === Constants.memberRole.tokenMaster
 
     signal kickUserClicked(string id, string name)
     signal banUserClicked(string id, string name)
@@ -107,7 +111,21 @@ Item {
 
                 readonly property bool itsMe: model.pubKey.toLowerCase() === Global.userProfile.pubKey.toLowerCase()
                 readonly property bool isHovered: memberItem.sensor.containsMouse
-                readonly property bool canBeBanned: !memberItem.itsMe && (model.memberRole !== Constants.memberRole.owner && model.memberRole !== Constants.memberRole.admin)
+                readonly property bool canBeBanned: {
+                    if (memberItem.itsMe) {
+                        return false
+                    }
+                    switch ( model.memberRole) {
+                        // Owner can't be banned
+                        case Constants.memberRole.owner: return false
+                        // TokenMaster can only be banned by owner
+                        case Constants.memberRole.tokenMaster: return root.isOwner
+                        // Admin can only be banned by owner and tokenMaster
+                        case Constants.memberRole.admin: return root.isOwner || root.isTokenMaster
+                        // Everyone can be banned by everyone
+                        default: return true
+                    }
+                }
                 readonly property bool showOnHover: isHovered && ctaAllowed
 
                 /// Button visibility ///

--- a/ui/app/AppLayouts/Communities/panels/MembersTabPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/MembersTabPanel.qml
@@ -23,8 +23,8 @@ Item {
     property var rootStore
     property int memberRole: Constants.memberRole.none
 
-    property bool isOwner: memberRole === Constants.memberRole.owner
-    property bool isTokenMaster: memberRole === Constants.memberRole.tokenMaster
+    readonly property bool isOwner: memberRole === Constants.memberRole.owner
+    readonly property bool isTokenMaster: memberRole === Constants.memberRole.tokenMaster
 
     signal kickUserClicked(string id, string name)
     signal banUserClicked(string id, string name)
@@ -115,7 +115,7 @@ Item {
                     if (memberItem.itsMe) {
                         return false
                     }
-                    switch ( model.memberRole) {
+                    switch (model.memberRole) {
                         // Owner can't be banned
                         case Constants.memberRole.owner: return false
                         // TokenMaster can only be banned by owner

--- a/ui/app/AppLayouts/Communities/views/CommunitySettingsView.qml
+++ b/ui/app/AppLayouts/Communities/views/CommunitySettingsView.qml
@@ -249,6 +249,7 @@ StatusSectionLayout {
             pendingMemberRequestsModel: root.community.pendingMemberRequests
             declinedMemberRequestsModel: root.community.declinedMemberRequests
             editable: root.isAdmin
+            memberRole: community.memberRole
             communityName: root.community.name
 
             onKickUserClicked: root.rootStore.removeUserFromCommunity(id)

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -1145,8 +1145,9 @@ QtObject {
     enum CommunityMembershipRequestState {
         None = 0,
         Pending,
-        Accepted,
         Rejected,
+        Accepted,
+        Canceled,
         AcceptedPending,
         RejectedPending,
         Banned,


### PR DESCRIPTION
Fixes #11851

status-go PR: https://github.com/status-im/status-go/pull/3902

Hooks the new pending states for the requests to join to the UI. This starts by getting those requests on app start and adding them in the community cache.

Then, I also fixed a lot of mess with handling of community requests in the service.

Finally, I fixed a bug where an owner couldn't kick an admin.