### PR TITLE
feat: Hide community membership request actions when the request is in action pending state

### DIFF
--- a/ui/app/mainui/activitycenter/panels/MembershipCta.qml
+++ b/ui/app/mainui/activitycenter/panels/MembershipCta.qml
@@ -15,7 +15,7 @@ Item {
     id: root
 
     property int membershipStatus: ActivityCenterStore.ActivityCenterMembershipStatus.None
-    property bool ctaAllowed: true
+    property bool ctaAllowed: !acceptedPending && !declinedPending
 
     readonly property bool pending: membershipStatus === ActivityCenterStore.ActivityCenterMembershipStatus.Pending
     readonly property bool accepted: membershipStatus === ActivityCenterStore.ActivityCenterMembershipStatus.Accepted

--- a/ui/app/mainui/activitycenter/views/ActivityNotificationCommunityMembershipRequest.qml
+++ b/ui/app/mainui/activitycenter/views/ActivityNotificationCommunityMembershipRequest.qml
@@ -48,6 +48,6 @@ ActivityNotificationMessage {
         onDeclineRequestToJoinCommunity: root.store.declineRequestToJoinCommunity(notification.id, notification.communityId)
         //TODO: Get backend value. If the membersip is in acceptedPending or declinedPending state, another user can't accept or decline the request
         //Only the user who requested can cancel the request
-        ctaAllowed: true
+        //ctaAllowed: true
     }
 }


### PR DESCRIPTION
### What does the PR do

Closing #11902 

When the control node is offline, the membership request cannot be processed. The admin can still accept/reject/kick/ban users, but the final action will be handled by the control node. This means we have new states for the membership request:
Accept pending; Reject pending; Kick pending; Ban pending; These states are set until the control node is online and the request is processed.
The admin that initiated the pending state can change his mind and change the pending state. Eg. When the request is in Accept pending, the admin that initiated the pending state can click on Reject and change the state to Reject pending.
This part is missing from backend.

The purpose of this PR it to hide the opposite action for all admins once the request is in pending state so that no admin can change the state. This is handled by `ctaAllowed` property. Once we'll have the backend implementation mentioned above, this property will be set based on backend value and the admin that initiated the pending state will be able to change the membership request state from one pending state to another.


Changes:
1. Hide actions by default when the membership request is in pending state
2. Fix a bug where the tooltip is showing when hovering a button that is not visible
3. Try to improve readability for all the conditions in MembersTabPanel.qml

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas

Community members settings
Community membership request notification


#### CTA allowed

https://github.com/status-im/status-desktop/assets/47811206/ca277ffd-1851-426f-a6f3-d2a67c8a6fbb

#### CTA not allowed (default) 

https://github.com/status-im/status-desktop/assets/47811206/6e44c487-3454-4219-80ef-153607b97ee5

