### PR TITLE
fix(@desktop/communities): Restart fee timer only when the dialog is …

### DIFF
--- a/ui/app/AppLayouts/Communities/popups/BurnTokensPopup.qml
+++ b/ui/app/AppLayouts/Communities/popups/BurnTokensPopup.qml
@@ -168,7 +168,9 @@ StatusDialog {
                 allTokensButton.checked
                 feesBox.accountsSelector.currentIndex
 
-                requestFeeDelayTimer.restart()
+                if (root.opened) {
+                    requestFeeDelayTimer.restart()
+                }
                 return true
             }
 


### PR DESCRIPTION
Restart fee timer only when the dialog is opened.
