### PR TITLE
fix(@desktop/communities): Pass addressFrom from UI to contract calls.

### DIFF
--- a/src/app/modules/main/communities/tokens/controller.nim
+++ b/src/app/modules/main/communities/tokens/controller.nim
@@ -94,17 +94,17 @@ proc deployOwnerContracts*(self: Controller, communityId: string, addressFrom: s
 proc removeCommunityToken*(self: Controller, communityId: string, chainId: int, address: string) =
   self.communityTokensService.removeCommunityToken(communityId, chainId, address)
 
-proc airdropTokens*(self: Controller, communityId: string, password: string, tokensAndAmounts: seq[CommunityTokenAndAmount], walletAddresses: seq[string]) =
-  self.communityTokensService.airdropTokens(communityId, password, tokensAndAmounts, walletAddresses)
+proc airdropTokens*(self: Controller, communityId: string, password: string, tokensAndAmounts: seq[CommunityTokenAndAmount], walletAddresses: seq[string], addressFrom: string) =
+  self.communityTokensService.airdropTokens(communityId, password, tokensAndAmounts, walletAddresses, addressFrom)
 
-proc computeAirdropFee*(self: Controller, tokensAndAmounts: seq[CommunityTokenAndAmount], walletAddresses: seq[string]) =
-  self.communityTokensService.computeAirdropFee(tokensAndAmounts, walletAddresses)
+proc computeAirdropFee*(self: Controller, tokensAndAmounts: seq[CommunityTokenAndAmount], walletAddresses: seq[string], addressFrom: string) =
+  self.communityTokensService.computeAirdropFee(tokensAndAmounts, walletAddresses, addressFrom)
 
-proc selfDestructCollectibles*(self: Controller, communityId: string, password: string, walletAndAmounts: seq[WalletAndAmount], contractUniqueKey: string) =
-  self.communityTokensService.selfDestructCollectibles(communityId, password, walletAndAmounts, contractUniqueKey)
+proc selfDestructCollectibles*(self: Controller, communityId: string, password: string, walletAndAmounts: seq[WalletAndAmount], contractUniqueKey: string, addressFrom: string) =
+  self.communityTokensService.selfDestructCollectibles(communityId, password, walletAndAmounts, contractUniqueKey, addressFrom)
 
-proc burnTokens*(self: Controller, communityId: string, password: string, contractUniqueKey: string, amount: Uint256) =
-  self.communityTokensService.burnTokens(communityId, password, contractUniqueKey, amount)
+proc burnTokens*(self: Controller, communityId: string, password: string, contractUniqueKey: string, amount: Uint256, addressFrom: string) =
+  self.communityTokensService.burnTokens(communityId, password, contractUniqueKey, amount, addressFrom)
 
 proc authenticateUser*(self: Controller, keyUid = "") =
   let data = SharedKeycarModuleAuthenticationArgs(uniqueIdentifier: UNIQUE_DEPLOY_COLLECTIBLES_COMMUNITY_TOKENS_MODULE_IDENTIFIER, keyUid: keyUid)
@@ -119,14 +119,14 @@ proc computeDeployFee*(self: Controller, chainId: int, accountAddress: string, t
 proc computeDeployOwnerContractsFee*(self: Controller, chainId: int, accountAddress: string) =
   self.communityTokensService.computeDeployOwnerContractsFee(chainId, accountAddress)
 
-proc computeSelfDestructFee*(self: Controller, walletAndAmountList: seq[WalletAndAmount], contractUniqueKey: string) =
-  self.communityTokensService.computeSelfDestructFee(walletAndAmountList, contractUniqueKey)
+proc computeSelfDestructFee*(self: Controller, walletAndAmountList: seq[WalletAndAmount], contractUniqueKey: string, addressFrom: string) =
+  self.communityTokensService.computeSelfDestructFee(walletAndAmountList, contractUniqueKey, addressFrom)
 
 proc findContractByUniqueId*(self: Controller, contractUniqueKey: string): CommunityTokenDto =
   return self.communityTokensService.findContractByUniqueId(contractUniqueKey)
 
-proc computeBurnFee*(self: Controller, contractUniqueKey: string, amount: Uint256) =
-  self.communityTokensService.computeBurnFee(contractUniqueKey, amount)
+proc computeBurnFee*(self: Controller, contractUniqueKey: string, amount: Uint256, addressFrom: string) =
+  self.communityTokensService.computeBurnFee(contractUniqueKey, amount, addressFrom)
 
 proc getNetwork*(self:Controller, chainId: int): NetworkDto =
   self.networksService.getNetwork(chainId)

--- a/src/app/modules/main/communities/tokens/io_interface.nim
+++ b/src/app/modules/main/communities/tokens/io_interface.nim
@@ -12,16 +12,16 @@ method delete*(self: AccessInterface) {.base.} =
 method load*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method airdropTokens*(self: AccessInterface, communityId: string, tokensJsonString: string, walletsJsonString: string) {.base.} =
+method airdropTokens*(self: AccessInterface, communityId: string, tokensJsonString: string, walletsJsonString: string, addressFrom: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method computeAirdropFee*(self: AccessInterface, communityId: string, tokensJsonString: string, walletsJsonString: string) {.base.} =
+method computeAirdropFee*(self: AccessInterface, communityId: string, tokensJsonString: string, walletsJsonString: string, addressFrom: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method selfDestructCollectibles*(self: AccessInterface, communityId: string, collectiblesToBurnJsonString: string, contractUniqueKey: string) {.base.} =
+method selfDestructCollectibles*(self: AccessInterface, communityId: string, collectiblesToBurnJsonString: string, contractUniqueKey: string, addressFrom: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method burnTokens*(self: AccessInterface, communityId: string, contractUniqueKey: string, amount: string) {.base.} =
+method burnTokens*(self: AccessInterface, communityId: string, contractUniqueKey: string, amount: string, addressFrom: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method deployCollectibles*(self: AccessInterface, communityId: string, address: string, name: string, symbol: string, description: string, supply: string, infiniteSupply: bool, transferable: bool,
@@ -45,10 +45,10 @@ method resetTempValues*(self: AccessInterface) {.base.} =
 method computeDeployFee*(self: AccessInterface, chainId: int, accountAddress: string, tokenType: TokenType, isOwnerDeployment: bool) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method computeSelfDestructFee*(self: AccessInterface, collectiblesToBurnJsonString: string, contractUniqueKey: string) {.base.} =
+method computeSelfDestructFee*(self: AccessInterface, collectiblesToBurnJsonString: string, contractUniqueKey: string, addressFrom: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method computeBurnFee*(self: AccessInterface, contractUniqueKey: string, amount: string) {.base.} =
+method computeBurnFee*(self: AccessInterface, contractUniqueKey: string, amount: string, addressFrom: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method onDeployFeeComputed*(self: AccessInterface, ethCurrency: CurrencyAmount, fiatCurrency: CurrencyAmount, errorCode: ComputeFeeErrorCode) {.base.} =

--- a/src/app/modules/main/communities/tokens/view.nim
+++ b/src/app/modules/main/communities/tokens/view.nim
@@ -33,17 +33,17 @@ QtObject:
   proc removeCommunityToken*(self: View, communityId: string, chainId: int, address: string) {.slot.} =
     self.communityTokensModule.removeCommunityToken(communityId, chainId, address)
 
-  proc airdropTokens*(self: View, communityId: string, tokensJsonString: string, walletsJsonString: string) {.slot.} =
-    self.communityTokensModule.airdropTokens(communityId, tokensJsonString, walletsJsonString)
+  proc airdropTokens*(self: View, communityId: string, tokensJsonString: string, walletsJsonString: string, addressFrom: string) {.slot.} =
+    self.communityTokensModule.airdropTokens(communityId, tokensJsonString, walletsJsonString, addressFrom)
 
-  proc computeAirdropFee*(self: View, communityId: string, tokensJsonString: string, walletsJsonString: string) {.slot.} =
-    self.communityTokensModule.computeAirdropFee(communityId, tokensJsonString, walletsJsonString)
+  proc computeAirdropFee*(self: View, communityId: string, tokensJsonString: string, walletsJsonString: string, addressFrom: string) {.slot.} =
+    self.communityTokensModule.computeAirdropFee(communityId, tokensJsonString, walletsJsonString, addressFrom)
 
-  proc selfDestructCollectibles*(self: View, communityId: string, collectiblesToBurnJsonString: string, contractUniqueKey: string) {.slot.} =
-    self.communityTokensModule.selfDestructCollectibles(communityId, collectiblesToBurnJsonString, contractUniqueKey)
+  proc selfDestructCollectibles*(self: View, communityId: string, collectiblesToBurnJsonString: string, contractUniqueKey: string, addressFrom: string) {.slot.} =
+    self.communityTokensModule.selfDestructCollectibles(communityId, collectiblesToBurnJsonString, contractUniqueKey, addressFrom)
 
-  proc burnTokens*(self: View, communityId: string, contractUniqueKey: string, amount: string) {.slot.} =
-    self.communityTokensModule.burnTokens(communityId, contractUniqueKey, amount)
+  proc burnTokens*(self: View, communityId: string, contractUniqueKey: string, amount: string, addressFrom: string) {.slot.} =
+    self.communityTokensModule.burnTokens(communityId, contractUniqueKey, amount, addressFrom)
 
   proc deployFeeUpdated*(self: View, ethCurrency: QVariant, fiatCurrency: QVariant, errorCode: int) {.signal.}
   proc selfDestructFeeUpdated*(self: View, ethCurrency: QVariant, fiatCurrency: QVariant, errorCode: int) {.signal.}
@@ -53,11 +53,11 @@ QtObject:
   proc computeDeployFee*(self: View, chainId: int, accountAddress: string, tokenType: int, isOwnerDeployment: bool) {.slot.} =
     self.communityTokensModule.computeDeployFee(chainId, accountAddress, intToEnum(tokenType, TokenType.Unknown), isOwnerDeployment)
 
-  proc computeSelfDestructFee*(self: View, collectiblesToBurnJsonString: string, contractUniqueKey: string) {.slot.} =
-    self.communityTokensModule.computeSelfDestructFee(collectiblesToBurnJsonString, contractUniqueKey)
+  proc computeSelfDestructFee*(self: View, collectiblesToBurnJsonString: string, contractUniqueKey: string, addressFrom: string) {.slot.} =
+    self.communityTokensModule.computeSelfDestructFee(collectiblesToBurnJsonString, contractUniqueKey, addressFrom)
 
-  proc computeBurnFee*(self: View, contractUniqueKey: string, amount: string) {.slot.} =
-    self.communityTokensModule.computeBurnFee(contractUniqueKey, amount)
+  proc computeBurnFee*(self: View, contractUniqueKey: string, amount: string, addressFrom: string) {.slot.} =
+    self.communityTokensModule.computeBurnFee(contractUniqueKey, amount, addressFrom)
 
   proc updateDeployFee*(self: View, ethCurrency: CurrencyAmount, fiatCurrency: CurrencyAmount, errorCode: int) =
     self.deployFeeUpdated(newQVariant(ethCurrency), newQVariant(fiatCurrency), errorCode)

--- a/src/app_service/service/community_tokens/async_tasks.nim
+++ b/src/app_service/service/community_tokens/async_tasks.nim
@@ -20,6 +20,7 @@ proc tableToJsonArray[A, B](t: var Table[A, B]): JsonNode =
 type
   AsyncDeployOwnerContractsFeesArg = ref object of QObjectTaskArg
     chainId: int
+    addressFrom: string
 
 const asyncGetDeployOwnerContractsFeesTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AsyncDeployOwnerContractsFeesArg](argEncoded)
@@ -33,6 +34,8 @@ const asyncGetDeployOwnerContractsFeesTask: Task = proc(argEncoded: string) {.gc
     arg.finish(%* {
       "feeTable": tableToJsonArray(feeTable),
       "gasTable": tableToJsonArray(gasTable),
+      "chainId": arg.chainId,
+      "addressFrom": arg.addressFrom,
       "error": "",
     })
   except Exception as e:
@@ -43,6 +46,7 @@ const asyncGetDeployOwnerContractsFeesTask: Task = proc(argEncoded: string) {.gc
 type
   AsyncGetDeployFeesArg = ref object of QObjectTaskArg
     chainId: int
+    addressFrom: string
     tokenType: TokenType
 
 const asyncGetDeployFeesTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
@@ -58,6 +62,8 @@ const asyncGetDeployFeesTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.
     arg.finish(%* {
       "feeTable": tableToJsonArray(feeTable),
       "gasTable": tableToJsonArray(gasTable),
+      "chainId": arg.chainId,
+      "addressFrom": arg.addressFrom,
       "error": "",
     })
   except Exception as e:
@@ -84,6 +90,8 @@ const asyncGetRemoteBurnFeesTask: Task = proc(argEncoded: string) {.gcsafe, nimc
     arg.finish(%* {
       "feeTable": tableToJsonArray(feeTable),
       "gasTable": tableToJsonArray(gasTable),
+      "chainId": arg.chainId,
+      "addressFrom": arg.addressFrom,
       "error": "" })
   except Exception as e:
     arg.finish(%* {
@@ -109,6 +117,8 @@ const asyncGetBurnFeesTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} 
     arg.finish(%* {
       "feeTable": tableToJsonArray(feeTable),
       "gasTable": tableToJsonArray(gasTable),
+      "chainId": arg.chainId,
+      "addressFrom": arg.addressFrom,
       "error": "" })
   except Exception as e:
     arg.finish(%* {
@@ -119,6 +129,7 @@ type
   AsyncGetMintFees = ref object of QObjectTaskArg
     collectiblesAndAmounts: seq[CommunityTokenAndAmount]
     walletAddresses: seq[string]
+    addressFrom: string
 
 const asyncGetMintFeesTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AsyncGetMintFees](argEncoded)
@@ -134,12 +145,13 @@ const asyncGetMintFeesTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} 
 
       # get gas for smart contract
       let gas = community_tokens.estimateMintTokens(chainId,
-        collectibleAndAmount.communityToken.address, collectibleAndAmount.communityToken.deployer,
+        collectibleAndAmount.communityToken.address, arg.addressFrom,
         arg.walletAddresses, collectibleAndAmount.amount).result.getInt
       gasTable[(chainId, collectibleAndAmount.communityToken.address)] = gas
     arg.finish(%* {
       "feeTable": tableToJsonArray(feeTable),
       "gasTable": tableToJsonArray(gasTable),
+      "addressFrom": arg.addressFrom,
       "error": "" })
   except Exception as e:
     let output = %* {

--- a/src/app_service/service/community_tokens/service.nim
+++ b/src/app_service/service/community_tokens/service.nim
@@ -229,8 +229,7 @@ QtObject:
       tokenService: token_service.Service
       settingsService: settings_service.Service
       walletAccountService: wallet_account_service.Service
-      tempAccountAddress: string
-      tempChainId: int
+
       tokenOwnersTimer: QTimer
       tokenOwners1SecTimer: QTimer # used to update 1 sec after changes in owners
       tempTokenOwnersToFetch: CommunityTokenDto # used by 1sec timer
@@ -239,12 +238,6 @@ QtObject:
       tempFeeTable: Table[int, SuggestedFeesDto] # fees per chain, filled during gas computation, used during operation (deployment, mint, burn)
       tempGasTable: Table[ContractTuple, int] # gas per contract, filled during gas computation, used during operation (deployment, mint, burn)
       tempTokensAndAmounts: seq[CommunityTokenAndAmount]
-
-      tempDeploymentChainId: int
-      tempDeploymentCommunityId: string
-      tempDeploymentParams: DeploymentParameters
-      tempDeploymentCroppedImageJson: string
-      tempDeploymentAddressFrom: string
 
   # Forward declaration
   proc fetchAllTokenOwners*(self: Service)
@@ -616,10 +609,9 @@ QtObject:
     except RpcException:
       error "Error getting remote destructed amount", message = getCurrentExceptionMsg()
 
-  proc airdropTokens*(self: Service, communityId: string, password: string, collectiblesAndAmounts: seq[CommunityTokenAndAmount], walletAddresses: seq[string]) =
+  proc airdropTokens*(self: Service, communityId: string, password: string, collectiblesAndAmounts: seq[CommunityTokenAndAmount], walletAddresses: seq[string], addressFrom: string) =
     try:
       for collectibleAndAmount in collectiblesAndAmounts:
-        let addressFrom = collectibleAndAmount.communityToken.deployer
         let txData = self.buildTransactionDataDto(addressFrom, collectibleAndAmount.communityToken.chainId, collectibleAndAmount.communityToken.address)
         if txData.source == parseAddress(ZERO_ADDRESS):
           return
@@ -643,7 +635,7 @@ QtObject:
     except RpcException:
       error "Error airdropping tokens", message = getCurrentExceptionMsg()
 
-  proc computeAirdropFee*(self: Service, collectiblesAndAmounts: seq[CommunityTokenAndAmount], walletAddresses: seq[string]) =
+  proc computeAirdropFee*(self: Service, collectiblesAndAmounts: seq[CommunityTokenAndAmount], walletAddresses: seq[string], addressFrom: string) =
     try:
       self.tempTokensAndAmounts = collectiblesAndAmounts
       let arg = AsyncGetMintFees(
@@ -651,7 +643,8 @@ QtObject:
         vptr: cast[ByteAddress](self.vptr),
         slot: "onAirdropFees",
         collectiblesAndAmounts: collectiblesAndAmounts,
-        walletAddresses: walletAddresses
+        walletAddresses: walletAddresses,
+        addressFrom: addressFrom
       )
       self.threadpool.start(arg)
     except Exception as e:
@@ -669,13 +662,12 @@ QtObject:
       if tokenType != TokenType.ERC20 and tokenType != TokenType.ERC721:
         error "Error loading fees: unknown token type", tokenType = tokenType
         return
-      self.tempAccountAddress = accountAddress
-      self.tempChainId = chainId
       let arg = AsyncGetDeployFeesArg(
         tptr: cast[ByteAddress](asyncGetDeployFeesTask),
         vptr: cast[ByteAddress](self.vptr),
         slot: "onDeployFees",
         chainId: chainId,
+        addressFrom: accountAddress,
         tokenType: tokenType
       )
       self.threadpool.start(arg)
@@ -684,13 +676,12 @@ QtObject:
 
   proc computeDeployOwnerContractsFee*(self: Service, chainId: int, accountAddress: string) =
     try:
-      self.tempAccountAddress = accountAddress
-      self.tempChainId = chainId
       let arg = AsyncDeployOwnerContractsFeesArg(
         tptr: cast[ByteAddress](asyncGetDeployOwnerContractsFeesTask),
         vptr: cast[ByteAddress](self.vptr),
         slot: "onDeployOwnerContractsFees",
         chainId: chainId,
+        addressFrom: accountAddress
       )
       self.threadpool.start(arg)
     except Exception as e:
@@ -729,13 +720,12 @@ QtObject:
       error "Can't find token ids to burn"
     return tokenIds
 
-  proc selfDestructCollectibles*(self: Service, communityId: string, password: string, walletAndAmounts: seq[WalletAndAmount], contractUniqueKey: string) =
+  proc selfDestructCollectibles*(self: Service, communityId: string, password: string, walletAndAmounts: seq[WalletAndAmount], contractUniqueKey: string, addressFrom: string) =
     try:
       let contract = self.findContractByUniqueId(contractUniqueKey)
       let tokenIds = self.getTokensToBurn(walletAndAmounts, contract)
       if len(tokenIds) == 0:
         return
-      let addressFrom = contract.deployer
       let txData = self.buildTransactionDataDto(addressFrom, contract.chainId, contract.address)
       debug "Remote destruct collectibles ", chainId=contract.chainId, address=contract.address, tokens=tokenIds
       let response = tokens_backend.remoteBurn(contract.chainId, contract.address, %txData, password, tokenIds)
@@ -761,11 +751,9 @@ QtObject:
     except Exception as e:
       error "Remote self destruct error", msg = e.msg
 
-  proc computeSelfDestructFee*(self: Service, walletAndAmountList: seq[WalletAndAmount], contractUniqueKey: string) =
+  proc computeSelfDestructFee*(self: Service, walletAndAmountList: seq[WalletAndAmount], contractUniqueKey: string, addressFrom: string) =
     try:
       let contract = self.findContractByUniqueId(contractUniqueKey)
-      self.tempAccountAddress = contract.deployer
-      self.tempChainId = contract.chainId
       let tokenIds = self.getTokensToBurn(walletAndAmountList, contract)
       if len(tokenIds) == 0:
         warn "token list is empty"
@@ -777,7 +765,7 @@ QtObject:
         chainId: contract.chainId,
         contractAddress: contract.address,
         tokenIds: tokenIds,
-        addressFrom: contract.deployer
+        addressFrom: addressFrom
       )
       self.threadpool.start(arg)
     except Exception as e:
@@ -799,10 +787,9 @@ QtObject:
       errorCode = ComputeFeeErrorCode.Infura
     return errorCode
 
-  proc burnTokens*(self: Service, communityId: string, password: string, contractUniqueKey: string, amount: Uint256) =
+  proc burnTokens*(self: Service, communityId: string, password: string, contractUniqueKey: string, amount: Uint256, addressFrom: string) =
     try:
       var contract = self.findContractByUniqueId(contractUniqueKey)
-      let addressFrom = contract.deployer
       let txData = self.buildTransactionDataDto(addressFrom, contract.chainId, contract.address)
       debug "Burn tokens ", chainId=contract.chainId, address=contract.address, amount=amount
       let response = tokens_backend.burn(contract.chainId, contract.address, %txData, password, amount)
@@ -825,11 +812,9 @@ QtObject:
     except Exception as e:
       error "Burn error", msg = e.msg
 
-  proc computeBurnFee*(self: Service, contractUniqueKey: string, amount: Uint256) =
+  proc computeBurnFee*(self: Service, contractUniqueKey: string, amount: Uint256, addressFrom: string) =
     try:
       let contract = self.findContractByUniqueId(contractUniqueKey)
-      self.tempAccountAddress = contract.deployer
-      self.tempChainId = contract.chainId
       let arg = AsyncGetBurnFees(
         tptr: cast[ByteAddress](asyncGetBurnFeesTask),
         vptr: cast[ByteAddress](self.vptr),
@@ -837,7 +822,7 @@ QtObject:
         chainId: contract.chainId,
         contractAddress: contract.address,
         amount: amount,
-        addressFrom: contract.deployer
+        addressFrom: addressFrom
       )
       self.threadpool.start(arg)
     except Exception as e:
@@ -907,14 +892,16 @@ QtObject:
         return
       let gasTable = responseJson{"gasTable"}.toGasTable
       let feeTable = responseJson{"feeTable"}.toFeeTable
+      let chainId = responseJson{"chainId"}.getInt
+      let addressFrom = responseJson{"addressFrom"}.getStr
       self.tempGasTable = gasTable
       self.tempFeeTable = feeTable
       let gasUnits = toSeq(gasTable.values())[0]
       let suggestedFees = toSeq(feeTable.values())[0]
-      let data = self.createComputeFeeArgs(gasUnits, suggestedFees, self.tempChainId, self.tempAccountAddress)
+      let data = self.createComputeFeeArgs(gasUnits, suggestedFees, chainId, addressFrom)
       self.events.emit(signalName, data)
     except Exception:
-      error "Error creating self destruct fee args", message = getCurrentExceptionMsg()
+      error "Error creating fee args", message = getCurrentExceptionMsg()
       let data = self.createComputeFeeArgsWithError(getCurrentExceptionMsg())
       self.events.emit(signalName, data)
 
@@ -954,6 +941,7 @@ QtObject:
 
       let gasTable = responseJson{"gasTable"}.toGasTable
       let feeTable = responseJson{"feeTable"}.toFeeTable
+      let addressFrom = responseJson{"addressFrom"}.getStr
       self.tempGasTable = gasTable
       self.tempFeeTable = feeTable
 
@@ -963,8 +951,7 @@ QtObject:
         let gasUnits = self.tempGasTable[(collectibleAndAmount.communityToken.chainId, collectibleAndAmount.communityToken.address)]
         let suggestedFees = self.tempFeeTable[collectibleAndAmount.communityToken.chainId]
         let ethValue = self.computeEthValue(gasUnits, suggestedFees)
-        let walletAddress = collectibleAndAmount.communityToken.deployer
-        wholeEthCostForChainWallet[(collectibleAndAmount.communityToken.chainId, walletAddress)] = wholeEthCostForChainWallet.getOrDefault((collectibleAndAmount.communityToken.chainId, walletAddress), 0.0) + ethValue
+        wholeEthCostForChainWallet[(collectibleAndAmount.communityToken.chainId, addressFrom)] = wholeEthCostForChainWallet.getOrDefault((collectibleAndAmount.communityToken.chainId, addressFrom), 0.0) + ethValue
         ethValuesForContracts[(collectibleAndAmount.communityToken.chainId, collectibleAndAmount.communityToken.address)] = ethValue
 
       var totalEthVal = 0.0
@@ -974,9 +961,8 @@ QtObject:
         let contractTuple = (chainId: collectibleAndAmount.communityToken.chainId,
                                           address: collectibleAndAmount.communityToken.address)
         let ethValue = ethValuesForContracts[contractTuple]
-        let walletAddress = collectibleAndAmount.communityToken.deployer
-        var balance = self.getWalletBalanceForChain(walletAddress, contractTuple.chainId)
-        if balance < wholeEthCostForChainWallet[(contractTuple.chainId, walletAddress)]:
+        var balance = self.getWalletBalanceForChain(addressFrom, contractTuple.chainId)
+        if balance < wholeEthCostForChainWallet[(contractTuple.chainId, addressFrom)]:
           # if wallet balance for this chain is less than the whole cost
           # then we can't afford it; setting balance to 0.0 will set balance error code in Args
           balance = 0.0

--- a/ui/app/AppLayouts/Communities/panels/MintTokensSettingsPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/MintTokensSettingsPanel.qml
@@ -698,6 +698,7 @@ StackView {
 
                 onOpened: {
                     root.setFeeLoading()
+
                     signTransactionPopup.isRemotelyDestructTransaction
                             ? root.remotelyDestructFeesRequest(footer.walletsAndAmounts, tokenKey, footer.accountAddress)
                             : root.signBurnTransactionOpened(tokenKey, footer.burnAmount, footer.accountAddress)

--- a/ui/imports/shared/stores/CommunityTokensStore.qml
+++ b/ui/imports/shared/stores/CommunityTokensStore.qml
@@ -118,38 +118,32 @@ QtObject {
       * ]
       */
     function computeSelfDestructFee(walletsAndAmounts, tokenKey, accountAddress) {
-        //TODO uncomment accountAddress when supported in backend
-        communityTokensModuleInst.computeSelfDestructFee(JSON.stringify(walletsAndAmounts), tokenKey, /*accountAddress*/)
+        communityTokensModuleInst.computeSelfDestructFee(JSON.stringify(walletsAndAmounts), tokenKey, accountAddress)
     }
 
     function remoteSelfDestructCollectibles(communityId, walletsAndAmounts, tokenKey, accountAddress) {
-        //TODO uncomment accountAddress when supported in backend
-        communityTokensModuleInst.selfDestructCollectibles(communityId, JSON.stringify(walletsAndAmounts), tokenKey, /*accountAddress*/)
+        communityTokensModuleInst.selfDestructCollectibles(communityId, JSON.stringify(walletsAndAmounts), tokenKey, accountAddress)
     }
 
     // Burn:
     function computeBurnFee(tokenKey, amount, accountAddress) {
         console.assert(typeof amount === "string")
-        // TODO: Backend. It should include the account address in the calculation.
-        communityTokensModuleInst.computeBurnFee(tokenKey, amount/*, accountAddress*/)
+        communityTokensModuleInst.computeBurnFee(tokenKey, amount, accountAddress)
     }
 
     function burnToken(communityId, tokenKey, burnAmount, accountAddress) {
         console.assert(typeof burnAmount === "string")
-         // TODO: Backend. It should include the account address in the burn action.
-        communityTokensModuleInst.burnTokens(communityId, tokenKey, burnAmount/*, accountAddress*/)
+        communityTokensModuleInst.burnTokens(communityId, tokenKey, burnAmount, accountAddress)
     }
 
     // Airdrop tokens:
     function airdrop(communityId, airdropTokens, addresses, feeAccountAddress) {
-        // TODO: Take `feeAccountAddress` into account for the airdrop
-        communityTokensModuleInst.airdropTokens(communityId, JSON.stringify(airdropTokens), JSON.stringify(addresses))
+        communityTokensModuleInst.airdropTokens(communityId, JSON.stringify(airdropTokens), JSON.stringify(addresses), feeAccountAddress)
     }
 
     function computeAirdropFee(communityId, contractKeysAndAmounts, addresses, feeAccountAddress) {
-        // TODO: Take `feeAccountAddress` into account when calculating fee
         communityTokensModuleInst.computeAirdropFee(
                     communityId, JSON.stringify(contractKeysAndAmounts),
-                    JSON.stringify(addresses))
+                    JSON.stringify(addresses), feeAccountAddress)
     }
 }


### PR DESCRIPTION
Use address set in UI instead of deployer.

Fix #11827

The aim of this ticket is that the wallet address chosen in fees dialog will be used to pay for the operation.
From owner perspective it should not change anything. All operations should be doable.
More thorough testing will be done soon with @mprakhov when we check also master token holders.

Also there is an issue: https://github.com/status-im/status-desktop/issues/11929 which blocked good testing of the ticket because we do not see fees.
