### PR TITLE
fix(Communities): Remotely destruct popup for regular collectibles integrated

### DIFF
--- a/storybook/pages/RemotelyDestructPopupPage.qml
+++ b/storybook/pages/RemotelyDestructPopupPage.qml
@@ -31,7 +31,9 @@ SplitView {
         orientation: Qt.Vertical
         SplitView.fillWidth: true
 
-        Item {
+        Pane {
+            id: pane
+
             SplitView.fillWidth: true
             SplitView.fillHeight: true
 
@@ -49,17 +51,35 @@ SplitView {
             RemotelyDestructPopup {
                 id: dialog
 
-                anchors.centerIn: parent
+                margins: 250
+                topMargin: 30
+
+                closePolicy: Popup.NoAutoClose
+                visible: true
+                modal: false
+                destroyOnClose: false
+                parent: pane
+                anchors.centerIn: pane
+
+
                 collectibleName: editorCollectible.text
                 model: TokenHoldersModel {}
                 accounts: accountsModel
                 chainName: "Optimism"
-                feeText: "0,01et(100Usd)"
+                feeText: "0,01 ETH (60,34 USD)"
                 onRemotelyDestructClicked: {
-                    logs.logEvent("RemoteSelfDestructPopup::onRemotelyDestructClicked")
+                    logs.logEvent("RemoteSelfDestructPopup::onRemotelyDestructClicked",
+                                  ["walletsAndAmounts", "accountAddress"], [
+                                      JSON.stringify(walletsAndAmounts), accountAddress
+                                  ])
                     close()
                 }
-                onRemotelyDestructFeesRequested: logs.logEvent("RemoteSelfDestructPopup::onRemotelyDestructClicked")
+                onRemotelyDestructFeesRequested: {
+                    logs.logEvent("RemoteSelfDestructPopup::onRemotelyDestructFeesRequested",
+                                  ["walletsAndAmounts", "accountAddress"], [
+                                      JSON.stringify(walletsAndAmounts), accountAddress
+                                  ])
+                }
 
                 Component.onCompleted: {
                     open()

--- a/ui/StatusQ/src/StatusQ/Core/Utils/ModelUtils.qml
+++ b/ui/StatusQ/src/StatusQ/Core/Utils/ModelUtils.qml
@@ -56,6 +56,9 @@ QtObject {
     }
 
     function indexOf(model, role, key) {
+        if (!model)
+            return -1
+
         const count = model.rowCount()
 
         for (let i = 0; i < count; i++)

--- a/ui/app/AppLayouts/Communities/panels/TokenHoldersPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/TokenHoldersPanel.qml
@@ -79,12 +79,9 @@ Control {
             Layout.topMargin: 12
             isSelectorMode: root.isSelectorMode
             model: filteredModel
-            onSelfDestructRemoved: {
-                root.selfDestructRemoved(walletAddress);
-            }
-            onSelfDestructAmountChanged: {
-                root.selfDestructAmountChanged(walletAddress, amount);
-            }
+            onSelfDestructRemoved: root.selfDestructRemoved(walletAddress)
+            onSelfDestructAmountChanged: root.selfDestructAmountChanged(
+                                             walletAddress, amount)
         }
         Rectangle {
             Layout.fillWidth: true

--- a/ui/app/AppLayouts/Communities/popups/RemotelyDestructPopup.qml
+++ b/ui/app/AppLayouts/Communities/popups/RemotelyDestructPopup.qml
@@ -1,7 +1,7 @@
-import QtQuick 2.14
-import QtQuick.Controls 2.14
-import QtQuick.Layouts 1.14
-import QtQml.Models 2.14
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+import QtQml.Models 2.15
 
 import StatusQ.Core 0.1
 import StatusQ.Controls 0.1
@@ -26,10 +26,12 @@ StatusDialog {
     property string feeErrorText: ""
     property string feeLabel: qsTr("Remotely destruct %1 token on %2").arg(root.collectibleName).arg(root.chainName)
 
+    readonly property alias tokenCount: d.tokenCount
+
     // Account expected roles: address, name, color, emoji, walletType
     property var accounts
-    signal remotelyDestructClicked(int tokenCount, var remotelyDestructTokensList, string accountAddress)
-    signal remotelyDestructFeesRequested(int tokenCount, var remotelyDestructTokensList, string accountAddress)
+    signal remotelyDestructClicked(var walletsAndAmounts, string accountAddress)
+    signal remotelyDestructFeesRequested(var walletsAndAmounts, string accountAddress)
 
     QtObject {
         id: d
@@ -37,7 +39,7 @@ StatusDialog {
         property string accountAddress
         readonly property int maxHeight: 560 // by design
         property int tokenCount: 0
-        readonly property ListModel selfDestructTokensList: ListModel {}
+        readonly property ListModel walletsAndAmountsList: ListModel {}
         readonly property bool isFeeError: root.feeErrorText !== ""
 
         function getVerticalPadding() {
@@ -49,28 +51,41 @@ StatusDialog {
         }
 
         function updateTokensToDestruct(walletAddress, amount) {
-            if(ModelUtils.contains(d.selfDestructTokensList, "walletAddress", walletAddress))
-                clearTokensToDesctruct(walletAddress)
+            const index = ModelUtils.indexOf(d.walletsAndAmountsList,
+                                             "walletAddress", walletAddress)
 
-            d.selfDestructTokensList.append({"walletAddress": walletAddress,
-                                            "amount": amount})
+            if (index !== -1)
+                d.walletsAndAmountsList.setProperty(index, "amount", amount)
+            else
+                d.walletsAndAmountsList.append({ walletAddress, amount })
+
             updateTokensCount()
         }
 
-        function clearTokensToDesctruct(walletAddress) {
-            var index = ModelUtils.indexOf(d.selfDestructTokensList, "walletAddress", walletAddress)
-            d.selfDestructTokensList.remove(index)
+        function clearTokensToDestruct(walletAddress) {
+            const index = ModelUtils.indexOf(d.walletsAndAmountsList,
+                                             "walletAddress", walletAddress)
+            d.walletsAndAmountsList.remove(index)
             updateTokensCount()
         }
 
-       function updateTokensCount() {
-           d.tokenCount = 0
-           for(var i = 0; i < d.selfDestructTokensList.count; i ++)
-               d.tokenCount += ModelUtils.get(d.selfDestructTokensList, i, "amount")
-           if (d.tokenCount > 0) {
-               root.remotelyDestructFeesRequested(d.tokenCount, d.selfDestructTokensList, d.accountAddress);
-           }
-       }
+        function updateTokensCount() {
+            const amounts = ModelUtils.modelToFlatArray(
+                              d.walletsAndAmountsList, "amount")
+            const sum = amounts.reduce((a, b) => a + b, 0)
+            d.tokenCount = sum
+
+            if (sum > 0)
+                sendFeeRequest()
+        }
+
+        function sendFeeRequest() {
+            const walletsAndAmounts = ModelUtils.modelToArray(
+                                        d.walletsAndAmountsList)
+
+            root.remotelyDestructFeesRequested(walletsAndAmounts,
+                                               d.accountAddress)
+        }
     }
 
     title: qsTr("Remotely destruct %1 token").arg(root.collectibleName)
@@ -86,7 +101,7 @@ StatusDialog {
             Layout.fillHeight: true
             isSelectorMode: true
             onSelfDestructAmountChanged: d.updateTokensToDestruct(walletAddress, amount)
-            onSelfDestructRemoved: d.clearTokensToDesctruct(walletAddress)
+            onSelfDestructRemoved: d.clearTokensToDestruct(walletAddress)
         }
 
         FeesBox {
@@ -101,28 +116,20 @@ StatusDialog {
             accountErrorText: root.feeErrorText
             placeholderText: qsTr("Select a hodler to see remote destruction gas fees")
             showAccountsSelector: true
-            model: d.tokenCount > 0 ? singleFeeModel : undefined            
+            model: d.tokenCount > 0 ? singleFeeModel : undefined
             accountsSelector.model: root.accounts
 
             accountsSelector.onCurrentIndexChanged: {
                 if (accountsSelector.currentIndex < 0)
                     return
 
-                const item = ModelUtils.get(accountsSelector.model, accountsSelector.currentIndex)
+                const item = ModelUtils.get(accountsSelector.model,
+                                            accountsSelector.currentIndex)
                 d.accountAddress = item.address
 
                 // Whenever a change in the form happens, new fee calculation:
-                if(d.tokenCount > 0)
-                    root.remotelyDestructFeesRequested(d.tokenCount, d.selfDestructTokensList, d.accountAddress)
-            }
-
-            ModelChangeTracker {
-                model: d.selfDestructTokensList
-
-                // Whenever a change in the form happens, new fee calculation:
-                onRevisionChanged: {
-                    root.remotelyDestructFeesRequested(d.tokenCount, d.selfDestructTokensList, d.accountAddress)
-                }
+                if (d.tokenCount > 0)
+                    d.sendFeeRequest()
             }
 
             QtObject {
@@ -149,9 +156,14 @@ StatusDialog {
                 enabled: d.tokenCount > 0
                 text: qsTr("Remotely destruct %n token(s)", "", d.tokenCount)
                 type: StatusBaseButton.Type.Danger
-                onClicked:  root.remotelyDestructClicked(d.tokenCount,
-                                                         ModelUtils.modelToArray(d.selfDestructTokensList,["walletAddress", "amount"]),
-                                                         d.accountAddress)
+
+                onClicked: {
+                    const walletsAndAmounts = ModelUtils.modelToArray(
+                                                d.walletsAndAmountsList)
+
+                    root.remotelyDestructClicked(walletsAndAmounts,
+                                                 d.accountAddress)
+                }
             }
         }
     }

--- a/ui/app/AppLayouts/Communities/views/CommunitySettingsView.qml
+++ b/ui/app/AppLayouts/Communities/views/CommunitySettingsView.qml
@@ -385,11 +385,11 @@ StatusSectionLayout {
 
             onRemotelyDestructFeesRequest:
                 communityTokensStore.computeSelfDestructFee(
-                    remotelyDestructTokensList, tokenKey, accountAddress)
+                    walletsAndAmounts, tokenKey, accountAddress)
 
             onRemotelyDestructCollectibles:
                 communityTokensStore.remoteSelfDestructCollectibles(
-                    root.community.id, remotelyDestructTokensList, tokenKey, accountAddress)
+                    root.community.id, walletsAndAmounts, tokenKey, accountAddress)
 
             onSignBurnTransactionOpened:
                 communityTokensStore.computeBurnFee(tokenKey, amount, accountAddress)

--- a/ui/imports/shared/stores/CommunityTokensStore.qml
+++ b/ui/imports/shared/stores/CommunityTokensStore.qml
@@ -108,14 +108,23 @@ QtObject {
         communityTokensModuleInst.computeDeployFee(chainId, accountAddress, tokenType, isOwnerDeployment)
     }
 
-    function computeSelfDestructFee(selfDestructTokensList, tokenKey, accountAddress) {
+    /**
+      * walletsAndAmounts - array of following structure is expected:
+      * [
+      *   {
+      *      walletAddress: string
+      *      amount: int
+      *   }
+      * ]
+      */
+    function computeSelfDestructFee(walletsAndAmounts, tokenKey, accountAddress) {
         //TODO uncomment accountAddress when supported in backend
-        communityTokensModuleInst.computeSelfDestructFee(JSON.stringify(selfDestructTokensList), tokenKey, /*accountAddress*/)
+        communityTokensModuleInst.computeSelfDestructFee(JSON.stringify(walletsAndAmounts), tokenKey, /*accountAddress*/)
     }
 
-    function remoteSelfDestructCollectibles(communityId, selfDestructTokensList, tokenKey, accountAddress) {
+    function remoteSelfDestructCollectibles(communityId, walletsAndAmounts, tokenKey, accountAddress) {
         //TODO uncomment accountAddress when supported in backend
-        communityTokensModuleInst.selfDestructCollectibles(communityId, JSON.stringify(selfDestructTokensList), tokenKey, /*accountAddress*/)
+        communityTokensModuleInst.selfDestructCollectibles(communityId, JSON.stringify(walletsAndAmounts), tokenKey, /*accountAddress*/)
     }
 
     // Burn:


### PR DESCRIPTION
### What does the PR do

Properly integrates `RemotelyDestructPopup` with the backend api. Fixes crash on selecting address for Remotely destruct action.

Closes: #11924

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas

`RemotelyDestructPopup`, `MintTokensSettingsPanel`, `CommunitySettingsView`, `CommunityTokensStore`

### Screenshot of functionality (including design for comparison)

[Kazam_screencast_00014.webm](https://github.com/status-im/status-desktop/assets/20650004/8849b859-d3f6-474c-b462-1ccda1050199)
