### PR TITLE
fix(Airdrop): Use remaining supply to display and validate amounts

### DIFF
--- a/ui/app/AppLayouts/Communities/controls/ListDropdownContent.qml
+++ b/ui/app/AppLayouts/Communities/controls/ListDropdownContent.qml
@@ -99,19 +99,20 @@ StatusListView {
         showSubItemsIcon: !!model.subItems && model.subItems.count > 0
         selected: root.checkedKeys.includes(model.key)
         amount: {
-            if (model.supply === undefined
+            if (model.remainingSupply === undefined
                     || model.multiplierIndex === undefined)
                 return ""
 
             if (model.infiniteSupply)
                 return "∞"
 
-            if (model.supply === "1")
+            if (model.remainingSupply === "1" && model.multiplierIndex === 0)
                 return qsTr("Max. 1")
 
             if (root.showTokenAmount)
-                return SQUtils.AmountsArithmetic.toNumber(model.supply,
-                                                          model.multiplierIndex)
+                return LocaleUtils.numberToLocaleString(
+                            SQUtils.AmountsArithmetic.toNumber(
+                                model.remainingSupply, model.multiplierIndex))
 
             return ""
         }

--- a/ui/app/AppLayouts/Communities/helpers/PermissionsHelpers.qml
+++ b/ui/app/AppLayouts/Communities/helpers/PermissionsHelpers.qml
@@ -53,15 +53,19 @@ QtObject {
         return ""
     }
 
-    function getTokenAmountByKey(model, key) {
+    function getTokenRemainingSupplyByKey(model, key) {
         const item = getTokenByKey(model, key)
-        if (item) {
-            if (item.infiniteSupply === true)
-                return "∞"
 
-            return item.supply ?? ""
-        }
-        return ""
+        if (!item || item.remainingSupply === undefined
+                || item.multiplierIndex === undefined)
+            return ""
+
+        if (item.infiniteSupply)
+            return "∞"
+
+        return LocaleUtils.numberToLocaleString(
+                    AmountsArithmetic.toNumber(item.remainingSupply,
+                                               item.multiplierIndex))
     }
 
     function getUniquePermissionTokenKeys(model) {

--- a/ui/app/AppLayouts/Communities/popups/HoldingsDropdown.qml
+++ b/ui/app/AppLayouts/Communities/popups/HoldingsDropdown.qml
@@ -331,13 +331,16 @@ StatusDropdown {
                 else
                 {
                     root.collectibleKey = key
-                    const amount = PermissionsHelpers.getTokenAmountByKey(root.collectiblesModel, root.collectibleKey)
+                    const item = PermissionsHelpers.getTokenByKey(root.collectiblesModel, root.collectibleKey)
+
                     //When the collectible is unique, there is no need for the user to select amount
                     //Just send the add/update events
-                    if(amount == 1) {
-                        root.collectibleAmount = amount
-                        d.updateSelected ? root.updateCollectible(root.collectibleKey, amount)
-                                            : root.addCollectible(root.collectibleKey, amount)
+                    if(item.supply.toString() === "1"
+                            || (item.remainingSupply
+                                && item.remainingSupply.toString() === "1")) {
+                        root.collectibleAmount = "1"
+                        d.updateSelected ? root.updateCollectible(root.collectibleKey, "1")
+                                            : root.addCollectible(root.collectibleKey, "1")
                         return
                     }
                 }
@@ -397,6 +400,7 @@ StatusDropdown {
             tokenName: PermissionsHelpers.getTokenNameByKey(root.assetsModel, root.assetKey)
             tokenShortName: PermissionsHelpers.getTokenShortNameByKey(root.assetsModel, root.assetKey)
             tokenImage: PermissionsHelpers.getTokenIconByKey(root.assetsModel, root.assetKey)
+            tokenAmount: PermissionsHelpers.getTokenRemainingSupplyByKey(root.assetsModel, root.assetKey)
             amountText: d.assetAmountText
             tokenCategoryText: qsTr("Asset")
             addOrUpdateButtonEnabled: d.assetsReady
@@ -421,7 +425,7 @@ StatusDropdown {
                     append({
                         name: chainName,
                         icon: chainIcon,
-                        amount: asset.supply,
+                        amount: asset.remainingSupply,
                         multiplierIndex: asset.multiplierIndex,
                         infiniteAmount: asset.infiniteSupply
                     })
@@ -469,7 +473,7 @@ StatusDropdown {
             tokenName: PermissionsHelpers.getTokenNameByKey(root.collectiblesModel, root.collectibleKey)
             tokenShortName: ""
             tokenImage: PermissionsHelpers.getTokenIconByKey(root.collectiblesModel, root.collectibleKey)
-            tokenAmount: PermissionsHelpers.getTokenAmountByKey(root.collectiblesModel, root.collectibleKey)
+            tokenAmount: PermissionsHelpers.getTokenRemainingSupplyByKey(root.collectiblesModel, root.collectibleKey)
             amountText: d.collectibleAmountText
             tokenCategoryText: qsTr("Collectible")
             addOrUpdateButtonEnabled: d.collectiblesReady
@@ -495,7 +499,7 @@ StatusDropdown {
                     append({
                         name:chainName,
                         icon: chainIcon,
-                        amount: collectible.supply,
+                        amount: collectible.remainingSupply,
                         multiplierIndex: collectible.multiplierIndex,
                         infiniteAmount: collectible.infiniteSupply
                     })

--- a/ui/app/AppLayouts/Communities/views/EditAirdropView.qml
+++ b/ui/app/AppLayouts/Communities/views/EditAirdropView.qml
@@ -191,7 +191,7 @@ StatusScrollView {
                 tokenImage: modelItem.iconSource,
                 networkText: modelItem.chainName,
                 networkImage: Style.svg(modelItem.chainIcon),
-                supply: modelItem.supply,
+                remainingSupply: modelItem.remainingSupply,
                 multiplierIndex: modelItem.multiplierIndex,
                 infiniteSupply: modelItem.infiniteSupply,
                 contractUniqueKey: modelItem.contractUniqueKey,
@@ -277,7 +277,7 @@ StatusScrollView {
                 if (!item || item.infiniteSupply)
                     continue
 
-                const dividient = AmountsArithmetic.fromString(item.supply)
+                const dividient = AmountsArithmetic.fromString(item.remainingSupply)
                 const divisor = AmountsArithmetic.fromString(item.amount)
 
                 const quotient = AmountsArithmetic.toNumber(
@@ -291,7 +291,7 @@ StatusScrollView {
         }
 
         delegate: QtObject {
-            readonly property string supply: model.supply
+            readonly property string remainingSupply: model.remainingSupply
             readonly property string amount: model.amount
             readonly property bool infiniteSupply: model.infiniteSupply
 
@@ -304,13 +304,13 @@ StatusScrollView {
                                  AmountsArithmetic.fromString(amount),
                                  recipientsCount)
 
-                const available = AmountsArithmetic.fromString(supply)
+                const available = AmountsArithmetic.fromString(remainingSupply)
 
                 return AmountsArithmetic.cmp(demand, available) <= 0
             }
 
 
-            onSupplyChanged: recipientsCountInstantiator.findRecipientsCount()
+            onRemainingSupplyChanged: recipientsCountInstantiator.findRecipientsCount()
             onAmountChanged: recipientsCountInstantiator.findRecipientsCount()
             onInfiniteSupplyChanged: recipientsCountInstantiator.findRecipientsCount()
 


### PR DESCRIPTION
### What does the PR do

- Remaining supply is used instead of supply for validating amount used for airdrop
- Remaining supply is displayed properly in TokenPanel (it was presented for collectibles but missing for assets)
- Presented amounts are properly localized

Now, validation should behave correctly in situation like the one described in https://github.com/status-im/status-desktop/pull/11862#issuecomment-1677585550

Closes: #11917

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas
`HoldingsDropdown` and related subcomponents

<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

[Kazam_screencast_00016.webm](https://github.com/status-im/status-desktop/assets/20650004/a4beb8ff-fd8c-46a6-b1cc-84eaa650408a)

![Screenshot from 2023-08-18 11-58-51](https://github.com/status-im/status-desktop/assets/20650004/2191e2ce-81db-4118-8f1f-dafd0f4dc0cb)
![Screenshot from 2023-08-18 11-59-01](https://github.com/status-im/status-desktop/assets/20650004/ec4902e6-301c-4431-8925-f0129d044dd2)
