### PR TITLE
feat: Support unfurl images

### DIFF
--- a/src/app/modules/shared_models/link_preview_model.nim
+++ b/src/app/modules/shared_models/link_preview_model.nim
@@ -9,23 +9,11 @@ type
     Hostname
     Title
     Description
+    LinkType
     ThumbnailWidth
     ThumbnailHeight
     ThumbnailUrl
     ThumbnailDataUri
-
-    #
-    # TODO: 
-    #
-    #   Consider adding a `LinkType` property, which would probably follow the way of unfurling:
-    #       - basic       (maybe divide OpenGraph/oEmbed/...)
-    #       - image       (contantType == "image/.*")
-    #       - status link (hostname == "status.app")
-    #
-    # In future, we can also unfurl other types, like PDF/audio/etc !
-    #
-    # This is needed on receiver side to know how to render the preview 
-    # and what to do on click.
 
 QtObject:
   type
@@ -79,6 +67,7 @@ QtObject:
       ModelRole.Hostname.int:"hostname",
       ModelRole.Title.int:"title",
       ModelRole.Description.int:"description",
+      ModelRole.LinkType.int:"linkType",
       ModelRole.ThumbnailWidth.int:"thumbnailWidth",
       ModelRole.ThumbnailHeight.int:"thumbnailHeight",
       ModelRole.ThumbnailUrl.int:"thumbnailUrl",
@@ -87,14 +76,16 @@ QtObject:
 
   method allLinkPreviewRoles(self: Model): seq[int] =
     return @[
-      Unfurled.int,
-      Hostname.int,
-      Title.int,
-      Description.int,
-      ThumbnailWidth.int,
-      ThumbnailHeight.int,
-      ThumbnailUrl.int,
-      ThumbnailDataUri.int,
+      ModelRole.Url.int,
+      ModelRole.Unfurled.int,
+      ModelRole.Hostname.int,
+      ModelRole.Title.int,
+      ModelRole.Description.int,
+      ModelRole.LinkType.int,
+      ModelRole.ThumbnailWidth.int,
+      ModelRole.ThumbnailHeight.int,
+      ModelRole.ThumbnailUrl.int,
+      ModelRole.ThumbnailDataUri.int,
     ]
 
   method data(self: Model, index: QModelIndex, role: int): QVariant =
@@ -118,6 +109,8 @@ QtObject:
       result = newQVariant(item.linkPreview.title)
     of ModelRole.Description:
       result = newQVariant(item.linkPreview.description)
+    of ModelRole.LinkType:
+      result = newQVariant(item.linkPreview.linkType.int)
     of ModelRole.ThumbnailWidth:
       result = newQVariant(item.linkPreview.thumbnail.width)
     of ModelRole.ThumbnailHeight:

--- a/ui/imports/shared/views/chat/LinksMessageView.qml
+++ b/ui/imports/shared/views/chat/LinksMessageView.qml
@@ -32,36 +32,35 @@ ColumnLayout {
             id: linkMessageLoader
 
             // properties from the model
+            required property string url
             required property bool unfurled
+            required property string hostname
             required property string title
             required property string description
-            required property string hostname
+            required property int linkType
             required property int thumbnailWidth
             required property int thumbnailHeight
             required property string thumbnailUrl
             required property string thumbnailDataUri
 
             asynchronous: true
-            sourceComponent: unfurledLinkComponent
 
             StateGroup {
                 //Using StateGroup as a warkardound for https://bugreports.qt.io/browse/QTBUG-47796
                 states: [
                     State {
                         name: "loadLinkPreview"
-                        when: !linkMessageLoader.isImage && !linkMessageLoader.isStatusDeepLink
+                        when: linkMessageLoader.linkType === Constants.LinkPreviewType.Link
                         PropertyChanges { target: linkMessageLoader; sourceComponent: unfurledLinkComponent }
+                    },
+                    State {
+                        name: "loadImage"
+                        when: linkMessageLoader.linkType === Constants.LinkPreviewType.Image
+                        PropertyChanges { target: linkMessageLoader; sourceComponent: unfurledImageComponent }
                     }
-                    // NOTE: New unfurling not yet suppport images and status links.
+                    // NOTE: New unfurling not yet suppport status links.
                     //       Uncomment code below when implemented:
-                    //       - https://github.com/status-im/status-go/issues/3761
                     //       - https://github.com/status-im/status-go/issues/3762
-
-                    // State {
-                    //     name: "loadImage"
-                    //     when: linkMessageLoader.isImage
-                    //     PropertyChanges { target: linkMessageLoader; sourceComponent: unfurledImageComponent }
-                    // },
                     // State {
                     //     name: "statusInvitation"
                     //     when: linkMessageLoader.isStatusDeepLink
@@ -88,13 +87,13 @@ ColumnLayout {
 
                 objectName: "LinksMessageView_unfurledImageComponent_linkImage"
                 anchors.centerIn: parent
-                source: result.thumbnailUrl
+                source: thumbnailUrl
                 imageWidth: 300
                 isCurrentUser: root.isCurrentUser
                 playing: globalAnimationEnabled && localAnimationEnabled
                 isOnline: root.store.mainModuleInst.isOnline
                 asynchronous: true
-                isAnimated: result.contentType ? result.contentType.toLowerCase().endsWith("gif") : false
+                isAnimated: false // FIXME: GIFs are not supported with new unfurling yet
                 onClicked: {
                     if (isAnimated && !playing)
                         localAnimationEnabled = true
@@ -190,7 +189,7 @@ ColumnLayout {
                 isOnline: root.store.mainModuleInst.isOnline
                 asynchronous: true
                 onClicked: {
-                    Global.openLink(result.address)
+                    Global.openLink(url)
                 }
             }
 
@@ -227,7 +226,7 @@ ColumnLayout {
                 anchors.bottom: linkSite.bottom
                 cursorShape: Qt.PointingHandCursor
                 onClicked:  {
-                    Global.openLink(link)
+                    Global.openLink(url)
                 }
             }
         }

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -1181,4 +1181,9 @@ QtObject {
         For1min = 6,
         Unmuted = 7
     }
+
+    enum LinkPreviewType {
+        Link = 0,
+        Image = 1
+    }
 }


### PR DESCRIPTION
Closes https://github.com/status-im/status-desktop/issues/11634
Requires https://github.com/status-im/status-go/pull/3901

### What does the PR do

This PR adds support for new `type` property of link preview.
Image URLs are now unfurled again 🪄 

### Some bad news

1. Unfortunately, this doesn't yet support GIF unfurling. I've opened a separate issue to track this:
    - https://github.com/status-im/status-desktop/issues/11939
2. I was planning to update the image context menu to add `Copy/Open Link` instead of `Copy/Download Image`. 
But currently `StatusImageModal` is taking a whole `Image` component as an argument, so there's no "good" way of passing the link as well. This might require some refactoring. For now the URL in the text itself can still be clicked.
    - https://github.com/status-im/status-desktop/issues/11941

### Affected areas

Chat URL previews

### Screenshot of functionality (including design for comparison)

https://github.com/status-im/status-desktop/assets/25482501/33f2cc09-b8a1-4cb4-a10f-97de49fd516b
