### PR TITLE
ci: hack-fix for randomly failing Linux builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -516,6 +516,9 @@ endif
 endif
 
 nim_status_client: force-rebuild-status-go $(NIM_STATUS_CLIENT)
+# FIXME: Hack to avoid Squish sending SIGKILL to 'make nim_status_client'.
+# https://github.com/status-im/infra-ci/issues/88
+not_nim_status_client: force-rebuild-status-go $(NIM_STATUS_CLIENT)
 
 _APPIMAGE_TOOL := appimagetool-x86_64.AppImage
 APPIMAGE_TOOL := tmp/linux/tools/$(_APPIMAGE_TOOL)

--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -88,9 +88,7 @@ pipeline {
       steps { script {
         /* Temporary hack-fix for failing Linux builds:
          * https://github.com/status-im/infra-ci/issues/88 */
-        timeout(10) { retry(20) {
-          sh 'make nim_status_client'
-        } }
+        sh 'make not_nim_status_client'
       } }
     }
 


### PR DESCRIPTION
After long and painful research into random Linux build failures in CI have identified the cause as being Squish test runner itsel. By utilizng the `execsnoop`, `exitsnoop`, and `killsnoop` utilities from [bcc](https://github.com/iovisor/bcc) suite I have caught the `_squishrunner` process sending `SIGKILL` to `make nim_status_client`:
```
admin@linux-01.he-eu-hel1.ci.release:~ % grep -C1 3048267 killsnoop.log
08:14:20  3048217 _squishrunner    9    3039605 0
08:14:20  3048217 _squishrunner    9    3048267 0
08:14:20  3048217 _squishrunner    9    3048565 0
08:14:20  3048217 _squishrunner    9    3048659 0
08:14:21  3048199 _squishserver    15   -3048267 -3
08:14:21  3048199 _squishserver    9    -3048267 -
```
Which we can clearly see that all processes in question except for `3048267` are related to the package build and not the `test-e2e` job:
```
admin@linux-01.he-eu-hel1.ci.release:~ % grep -E '  (3039605|3048267|3048565|3048659)' execsnoop.log | cut -c -170
08:10:36 1001  make             3039605 3039603   0 /usr/bin/make nim_status_client
08:13:51 1001  nim_status_clie  3048267 3048199   0 /home/jenkins/workspace/status-desktop/systems/linux/x86_64/tests-e2e/bin/nim_status_client --dataDir=/home/jenkins/wo
08:14:07 1001  bash             3048565 3039605   0 /usr/bin/bash -c "/home/jenkins/workspace/status-desktop/systems/linux/x86_64/package/vendor/nimbus-build-system/scrip
08:14:07 1001  env.sh           3048565 3039605   0 /home/jenkins/workspace/status-desktop/systems/linux/x86_64/package/vendor/nimbus-build-system/scripts/env.sh nim c --
08:14:07 1001  bash             3048565 3039605   0 /usr/bin/bash /home/jenkins/workspace/status-desktop/systems/linux/x86_64/package/vendor/nimbus-build-system/scripts/e
08:14:07 1001  nim              3048659 3048565   0 /home/jenkins/workspace/status-desktop/systems/linux/x86_64/package/vendor/nimbus-build-system/vendor/Nim/bin/nim c --
```
My best guess is that `_squishrunner` is using something like `pgrep` or similar method to find processes to kill based on full command line, which results in it casting a wide net and kiling an unrelated `make` call.

People used to be tarred, feathered, and driven out of town for shit like this.

This isn't a fix. A real fix would involve FrogLogic actually fixing their shitty software, but we have no idea when that be, so this might be a decent stopgap. Better than retrying, that's for sure.

Related:
* https://github.com/status-im/infra-ci/issues/88