### PR TITLE
Wallet Settings: Tweaked import keypair flows to work around current inability to know which keypairs are fully imported on which synced device

### DIFF
--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -197,7 +197,7 @@ proc newModule*[T](
     result, events, tokenService, currencyService,
     transactionService, walletAccountService,
     settingsService, savedAddressService, networkService, accountsService,
-    keycardService, nodeService, networkConnectionService
+    keycardService, nodeService, networkConnectionService, devicesService
   )
   result.browserSectionModule = browser_section_module.newModule(
     result, events, bookmarkService, settingsService, networkService,
@@ -1355,6 +1355,6 @@ method communityMembersRevealedAccountsLoaded*[T](self: Module[T], communityId: 
       if revealedAccount.isAirdropAddress:
         communityMembersAirdropAddress[pubkey] = revealedAccount.address
         discard
-  
+
   self.view.model.setMembersAirdropAddress(communityId, communityMembersAirdropAddress)
 

--- a/src/app/modules/main/wallet_section/controller.nim
+++ b/src/app/modules/main/wallet_section/controller.nim
@@ -68,3 +68,9 @@ proc toggleIncludeWatchOnlyAccount*(self: Controller) =
 
 proc isIncludeWatchOnlyAccount*(self: Controller): bool =
   return self.walletAccountService.isIncludeWatchOnlyAccount()
+
+proc getKeypairByAccountAddress*(self: Controller, address: string): KeypairDto =
+  return self.walletAccountService.getKeypairByAccountAddress(address)
+
+proc hasPairedDevices*(self: Controller): bool =
+  return self.walletAccountService.hasPairedDevices()

--- a/src/app/modules/main/wallet_section/io_interface.nim
+++ b/src/app/modules/main/wallet_section/io_interface.nim
@@ -99,3 +99,18 @@ method getLatestBlockNumber*(self: AccessInterface, chainId: int): string {.base
 
 method fetchDecodedTxData*(self: AccessInterface, txHash: string, data: string) {.base.} =
   raise newException(ValueError, "No implementation available")
+
+method runKeypairImportPopup*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method getKeypairImportModule*(self: AccessInterface): QVariant {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method onKeypairImportModuleLoaded*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method destroyKeypairImportPopup*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method hasPairedDevices*(self: AccessInterface): bool {.base.} =
+  raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/wallet_section/view.nim
+++ b/src/app/modules/main/wallet_section/view.nim
@@ -20,6 +20,7 @@ QtObject:
       collectiblesController: collectiblesc.Controller
       collectibleDetailsController: collectible_detailsc.Controller
       isNonArchivalNode: bool
+      keypairOperabilityForObservedAccount: string
 
   proc setup(self: View) =
     self.QObject.setup
@@ -167,3 +168,38 @@ QtObject:
     notify = isNonArchivalNodeChanged
 
   proc txDecoded*(self: View, txHash: string, dataDecoded: string) {.signal.}
+
+  proc hasPairedDevicesChanged*(self: View) {.signal.}
+  proc emitHasPairedDevicesChangedSignal*(self: View) =
+    self.hasPairedDevicesChanged()
+  proc getHasPairedDevices(self: View): bool {.slot.} =
+    return self.delegate.hasPairedDevices()
+  QtProperty[bool] hasPairedDevices:
+    read = getHasPairedDevices
+    notify = hasPairedDevicesChanged
+
+  proc keypairOperabilityForObservedAccountChanged(self: View) {.signal.}
+  proc getKeypairOperabilityForObservedAccount(self: View): string {.slot.} =
+    return self.keypairOperabilityForObservedAccount
+  QtProperty[string] keypairOperabilityForObservedAccount:
+    read = getKeypairOperabilityForObservedAccount
+    notify = keypairOperabilityForObservedAccountChanged
+  proc setKeypairOperabilityForObservedAccount*(self: View, value: string) =
+    self.keypairOperabilityForObservedAccount = value
+    self.keypairOperabilityForObservedAccountChanged()
+
+  proc runKeypairImportPopup*(self: View) {.slot.} =
+    self.delegate.runKeypairImportPopup()
+
+  proc getKeypairImportModule(self: View): QVariant {.slot.} =
+    return self.delegate.getKeypairImportModule()
+  QtProperty[QVariant] keypairImportModule:
+    read = getKeypairImportModule
+
+  proc displayKeypairImportPopup*(self: View) {.signal.}
+  proc emitDisplayKeypairImportPopup*(self: View) =
+    self.displayKeypairImportPopup()
+
+  proc destroyKeypairImportPopup*(self: View) {.signal.}
+  proc emitDestroyKeypairImportPopup*(self: View) =
+    self.destroyKeypairImportPopup()

--- a/src/app/modules/shared_modules/keypair_import/io_interface.nim
+++ b/src/app/modules/shared_modules/keypair_import/io_interface.nim
@@ -5,6 +5,7 @@ import app_service/service/wallet_account/dto/derived_address_dto
 
 type ImportKeypairModuleMode* {.pure.}= enum
   SelectKeypair = 1
+  SelectImportMethod
   ImportViaSeedPhrase
   ImportViaPrivateKey
   ImportViaQr

--- a/src/app/modules/shared_modules/keypair_import/module.nim
+++ b/src/app/modules/shared_modules/keypair_import/module.nim
@@ -58,6 +58,9 @@ method load*[T](self: Module[T], keyUid: string, mode: ImportKeypairModuleMode) 
     self.view.setCurrentState(newSelectKeypairState(nil))
   else:
     self.view.setSelectedKeypairItem(newKeyPairItem(keyUid = keyUid))
+    let keypair = self.controller.getKeypairByKeyUid(keyUid)
+    if not keypair.isNil:
+      self.view.getSelectedKeypair().setName(keypair.name)
     if mode == ImportKeypairModuleMode.ExportKeypairQr:
       self.view.setCurrentState(newExportKeypairState(nil))
       self.controller.authenticateLoggedInUser()
@@ -66,7 +69,6 @@ method load*[T](self: Module[T], keyUid: string, mode: ImportKeypairModuleMode) 
       self.view.setCurrentState(newImportQrState(nil))
       self.delegate.onKeypairImportModuleLoaded()
       return
-    let keypair = self.controller.getKeypairByKeyUid(keyUid)
     if keypair.isNil:
       error "ki_trying to import an unknown keypair"
       self.closeKeypairImportPopup()

--- a/src/app/modules/shared_modules/keypair_import/module.nim
+++ b/src/app/modules/shared_modules/keypair_import/module.nim
@@ -79,7 +79,9 @@ method load*[T](self: Module[T], keyUid: string, mode: ImportKeypairModuleMode) 
       self.closeKeypairImportPopup()
       return
     self.view.setSelectedKeypairItem(keypairItem)
-    if mode == ImportKeypairModuleMode.ImportViaPrivateKey:
+    if mode == ImportKeypairModuleMode.SelectImportMethod:
+      self.view.setCurrentState(newSelectImportMethodState(nil))
+    elif mode == ImportKeypairModuleMode.ImportViaPrivateKey:
       self.view.setCurrentState(newImportPrivateKeyState(nil))
     elif mode == ImportKeypairModuleMode.ImportViaSeedPhrase:
       self.view.setCurrentState(newImportSeedPhraseState(nil))

--- a/src/app_service/service/activity_center/dto/notification.nim
+++ b/src/app_service/service/activity_center/dto/notification.nim
@@ -20,6 +20,7 @@ type ActivityCenterNotificationType* {.pure.}= enum
   CommunityKicked = 9,
   ContactVerification = 10
   ContactRemoved = 11
+  NewKeypairAddedToPairedDevice = 12
 
 type ActivityCenterGroup* {.pure.}= enum
   All = 0,
@@ -144,7 +145,8 @@ proc activityCenterNotificationTypesByGroup*(group: ActivityCenterGroup) : seq[i
         ActivityCenterNotificationType.CommunityMembershipRequest.int,
         ActivityCenterNotificationType.CommunityKicked.int,
         ActivityCenterNotificationType.ContactVerification.int,
-        ActivityCenterNotificationType.ContactRemoved.int
+        ActivityCenterNotificationType.ContactRemoved.int,
+        ActivityCenterNotificationType.NewKeypairAddedToPairedDevice.int
       ]
     of ActivityCenterGroup.Mentions:
       return @[ActivityCenterNotificationType.Mention.int]

--- a/src/app_service/service/wallet_account/service_account.nim
+++ b/src/app_service/service/wallet_account/service_account.nim
@@ -30,6 +30,12 @@ proc getKeypairByKeyUid*(self: Service, keyUid: string): KeypairDto =
     return
   return self.keypairs[keyUid]
 
+proc getKeypairByAccountAddress*(self: Service, address: string): KeypairDto =
+  for _, kp in self.keypairs:
+    for acc in kp.accounts:
+      if cmpIgnoreCase(acc.address, address) == 0:
+        return kp
+
 proc getWatchOnlyAccounts*(self: Service): seq[WalletAccountDto] =
   return toSeq(self.watchOnlyAccounts.values)
 

--- a/ui/app/AppLayouts/Profile/popups/RemoveKeypairPopup.qml
+++ b/ui/app/AppLayouts/Profile/popups/RemoveKeypairPopup.qml
@@ -98,7 +98,7 @@ StatusDialog {
             }
             StatusButton {
                 type: StatusBaseButton.Type.Danger
-                text: qsTr("Remove keypair & associated accounts")
+                text: qsTr("Remove keypair and derived accounts")
                 onClicked: root.confirmClicked()
                 Keys.onReturnPressed: function(event) {
                     root.confirmClicked()

--- a/ui/app/AppLayouts/Profile/popups/WalletKeypairAccountMenu.qml
+++ b/ui/app/AppLayouts/Profile/popups/WalletKeypairAccountMenu.qml
@@ -94,7 +94,7 @@ StatusMenu {
     }
 
     StatusAction {
-        text: enabled? qsTr("Remove keypair and associated accounts") : ""
+        text: enabled? qsTr("Remove keypair and derived accounts") : ""
         enabled: !!root.keyPair &&
                  root.keyPair.pairType !== Constants.keypair.type.profile
         type: StatusAction.Type.Danger

--- a/ui/app/AppLayouts/Profile/views/WalletView.qml
+++ b/ui/app/AppLayouts/Profile/views/WalletView.qml
@@ -184,6 +184,9 @@ SettingsContentBase {
                 removeKeypairPopup.accounts= keyPair.accounts
                 removeKeypairPopup.active = true
             }
+            onRunImportMissingKeypairFlow: {
+                root.walletStore.runKeypairImportPopup(keyPair.keyUid, Constants.keypairImportPopup.mode.selectImportMethod)
+            }
         }
 
         DappPermissionsView {

--- a/ui/app/AppLayouts/Profile/views/wallet/AccountView.qml
+++ b/ui/app/AppLayouts/Profile/views/wallet/AccountView.qml
@@ -25,6 +25,7 @@ ColumnLayout {
     signal goBack
     signal runRenameKeypairFlow()
     signal runRemoveKeypairFlow()
+    signal runImportMissingKeypairFlow()
 
     property var account
     property var keyPair
@@ -77,6 +78,50 @@ ColumnLayout {
             onClicked: Global.openPopup(renameAccountModalComponent)
         }
     }
+
+    Rectangle {
+        Layout.fillWidth: true
+        Layout.topMargin: Style.current.bigPadding
+        Layout.preferredHeight: childrenRect.height
+        visible: !!root.keyPair && root.keyPair.operability === Constants.keypair.operability.nonOperable
+        radius: Style.current.radius
+        border.width: 1
+        border.color: Theme.palette.directColor8
+        color: Theme.palette.transparent
+
+        ColumnLayout {
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.leftMargin: Style.current.padding
+            anchors.rightMargin: Style.current.padding
+            spacing: Style.current.halfPadding
+
+            StatusBaseText {
+                Layout.fillWidth: true
+                Layout.topMargin: Style.current.padding
+                text: qsTr("Import keypair to use this account")
+                color: Theme.palette.warningColor1
+            }
+
+            StatusBaseText {
+                Layout.fillWidth: true
+                wrapMode: Text.WordWrap
+                text: qsTr("This account was added to one of your synced devices. To use this account you will first need import the associated keypair to this device.")
+            }
+
+            StatusButton {
+                Layout.alignment: Qt.AlignLeft
+                Layout.bottomMargin: Style.current.padding
+                text: qsTr("Import keypair")
+                type: StatusBaseButton.Type.Warning
+                icon.name: "download"
+                onClicked: {
+                    root.runImportMissingKeypairFlow()
+                }
+            }
+        }
+    }
+
 
     StatusBaseText {
         Layout.topMargin: Style.current.bigPadding

--- a/ui/app/AppLayouts/Profile/views/wallet/AccountView.qml
+++ b/ui/app/AppLayouts/Profile/views/wallet/AccountView.qml
@@ -11,6 +11,7 @@ import AppLayouts.Wallet 1.0
 import AppLayouts.Wallet.controls 1.0
 import AppLayouts.Profile.popups 1.0
 
+import shared.controls 1.0
 import shared.popups 1.0
 import shared.panels 1.0
 import utils 1.0
@@ -79,49 +80,16 @@ ColumnLayout {
         }
     }
 
-    Rectangle {
+    ImportKeypairInfo {
         Layout.fillWidth: true
         Layout.topMargin: Style.current.bigPadding
         Layout.preferredHeight: childrenRect.height
         visible: !!root.keyPair && root.keyPair.operability === Constants.keypair.operability.nonOperable
-        radius: Style.current.radius
-        border.width: 1
-        border.color: Theme.palette.directColor8
-        color: Theme.palette.transparent
 
-        ColumnLayout {
-            anchors.left: parent.left
-            anchors.right: parent.right
-            anchors.leftMargin: Style.current.padding
-            anchors.rightMargin: Style.current.padding
-            spacing: Style.current.halfPadding
-
-            StatusBaseText {
-                Layout.fillWidth: true
-                Layout.topMargin: Style.current.padding
-                text: qsTr("Import keypair to use this account")
-                color: Theme.palette.warningColor1
-            }
-
-            StatusBaseText {
-                Layout.fillWidth: true
-                wrapMode: Text.WordWrap
-                text: qsTr("This account was added to one of your synced devices. To use this account you will first need import the associated keypair to this device.")
-            }
-
-            StatusButton {
-                Layout.alignment: Qt.AlignLeft
-                Layout.bottomMargin: Style.current.padding
-                text: qsTr("Import keypair")
-                type: StatusBaseButton.Type.Warning
-                icon.name: "download"
-                onClicked: {
-                    root.runImportMissingKeypairFlow()
-                }
-            }
+        onRunImport: {
+            root.runImportMissingKeypairFlow()
         }
     }
-
 
     StatusBaseText {
         Layout.topMargin: Style.current.bigPadding

--- a/ui/app/AppLayouts/Wallet/WalletLayout.qml
+++ b/ui/app/AppLayouts/Wallet/WalletLayout.qml
@@ -6,6 +6,7 @@ import StatusQ.Layout 0.1
 
 import utils 1.0
 import shared.controls 1.0
+import shared.popups.keypairimport 1.0
 
 import "popups"
 import "panels"
@@ -31,6 +32,14 @@ Item {
 
         function onFilterChanged(address, includeWatchOnly, allAddresses) {
             root.showAllAccounts = allAddresses
+        }
+
+        function onDisplayKeypairImportPopup() {
+            keypairImport.active = true
+        }
+
+        function onDestroyKeypairImportPopup() {
+            keypairImport.active = false
         }
     }
     
@@ -148,6 +157,20 @@ Item {
         id: receiveModalComponent
         ReceiveModal {
             anchors.centerIn: parent
+        }
+    }
+
+    Loader {
+        id: keypairImport
+        active: false
+        asynchronous: true
+
+        sourceComponent: KeypairImportPopup {
+            store.keypairImportModule: root.store.walletSectionInst.keypairImportModule
+        }
+
+        onLoaded: {
+            keypairImport.item.open()
         }
     }
 }

--- a/ui/app/AppLayouts/Wallet/views/RightTabView.qml
+++ b/ui/app/AppLayouts/Wallet/views/RightTabView.qml
@@ -5,6 +5,7 @@ import StatusQ.Core 0.1
 import StatusQ.Controls 0.1
 
 import utils 1.0
+import shared.controls 1.0
 import shared.views 1.0
 import shared.stores 1.0
 
@@ -76,6 +77,18 @@ Item {
                 onLaunchShareAddressModal: root.launchShareAddressModal()
                 onSwitchHideWatchOnlyAccounts: RootStore.toggleWatchOnlyAccounts()
             }
+
+            ImportKeypairInfo {
+                Layout.fillWidth: true
+                Layout.topMargin: Style.current.bigPadding
+                Layout.preferredHeight: childrenRect.height
+                visible: root.store.walletSectionInst.hasPairedDevices && root.store.walletSectionInst.keypairOperabilityForObservedAccount === Constants.keypair.operability.nonOperable
+
+                onRunImport: {
+                    root.store.walletSectionInst.runKeypairImportPopup()
+                }
+            }
+
             StatusTabBar {
                 id: walletTabBar
                 objectName: "rightSideWalletTabBar"

--- a/ui/app/AppLayouts/stores/RootStore.qml
+++ b/ui/app/AppLayouts/stores/RootStore.qml
@@ -11,6 +11,7 @@ QtObject {
     id: root
 
     property var mainModuleInst: mainModule
+    property var walletSectionInst: walletSection
     property var aboutModuleInst: aboutModule
     property var communitiesModuleInst: communitiesModule
     property bool newVersionAvailable: false

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -140,7 +140,7 @@ Item {
 
         function onShowToastKeypairRemoved(keypairName: string) {
             Global.displayToastMessage(
-                qsTr("“%1” keypair and its associated accounts were successfully removed from all devices").arg(keypairName),
+                qsTr("“%1” keypair and its derived accounts were successfully removed from all devices").arg(keypairName),
                 "",
                 "checkmark-circle",
                 false,

--- a/ui/app/mainui/activitycenter/popups/ActivityCenterPopup.qml
+++ b/ui/app/mainui/activitycenter/popups/ActivityCenterPopup.qml
@@ -113,6 +113,8 @@ Popup {
                         return communityKickedNotificationComponent
                     case ActivityCenterStore.ActivityCenterNotificationType.ContactRemoved:
                         return contactRemovedComponent
+                    case ActivityCenterStore.ActivityCenterNotificationType.NewKeypairAddedToPairedDevice:
+                        return newKeypairFromPairedDeviceComponent
                     default:
                         return null
                 }
@@ -217,6 +219,16 @@ Popup {
             notification: parent.notification
             store: root.store
             activityCenterStore: root.activityCenterStore
+            onCloseActivityCenter: root.close()
+        }
+    }
+
+    Component {
+        id: newKeypairFromPairedDeviceComponent
+
+        ActivityNotificationNewKeypairFromPairedDevice {
+            filteredIndex: parent.filteredIndex
+            notification: parent.notification
             onCloseActivityCenter: root.close()
         }
     }

--- a/ui/app/mainui/activitycenter/stores/ActivityCenterStore.qml
+++ b/ui/app/mainui/activitycenter/stores/ActivityCenterStore.qml
@@ -29,7 +29,8 @@ QtObject {
         CommunityMembershipRequest = 8,
         CommunityKicked = 9,
         ContactVerification = 10,
-        ContactRemoved = 11
+        ContactRemoved = 11,
+        NewKeypairAddedToPairedDevice = 12
     }
 
     enum ActivityCenterReadType {

--- a/ui/app/mainui/activitycenter/views/ActivityNotificationNewKeypairFromPairedDevice.qml
+++ b/ui/app/mainui/activitycenter/views/ActivityNotificationNewKeypairFromPairedDevice.qml
@@ -1,0 +1,67 @@
+import QtQuick 2.15
+import QtQuick.Layouts 1.15
+
+import StatusQ.Core 0.1
+import StatusQ.Core.Theme 0.1
+import StatusQ.Controls 0.1
+import StatusQ.Components 0.1
+
+import utils 1.0
+
+ActivityNotificationBase {
+    id: root
+
+    ctaComponent: StatusLinkText {
+        text: qsTr("View keypair import options")
+        color: Theme.palette.primaryColor1
+        font.pixelSize: Theme.primaryTextFontSize
+        font.weight: Font.Normal
+        onClicked: {
+            Global.changeAppSectionBySectionType(Constants.appSection.profile, Constants.settingsSubsection.wallet)
+            root.closeActivityCenter()
+        }
+    }
+
+    bodyComponent: RowLayout {
+        implicitWidth: parent.width
+
+        spacing: 8
+
+        StatusSmartIdenticon {
+            Layout.preferredWidth: 40
+            Layout.preferredHeight: 40
+            Layout.alignment: Qt.AlignTop
+            Layout.leftMargin: Style.current.padding
+            Layout.topMargin: 2
+
+            asset {
+                width: 24
+                height: 24
+                name: "wallet"
+                color: Theme.palette.primaryColor1
+                bgWidth: 40
+                bgHeight: 40
+                bgColor: Theme.palette.primaryColor3
+            }
+        }
+
+        ColumnLayout {
+            spacing: 2
+            Layout.alignment: Qt.AlignTop
+            Layout.fillWidth: true
+
+            StatusMessageHeader {
+                displayNameLabel.text: qsTr("New keypair added")
+                timestamp: root.notification.timestamp
+            }
+
+            StatusBaseText {
+                Layout.fillWidth: true
+                text: qsTr("%1 keypair was added to one of your synced devices").arg(root.notification.message.unparsedText)
+                font.italic: true
+                wrapMode: Text.WordWrap
+                color: Theme.palette.baseColor1
+            }
+        }
+    }
+}

--- a/ui/imports/shared/controls/GetSyncCodeDesktopInstructions.qml
+++ b/ui/imports/shared/controls/GetSyncCodeDesktopInstructions.qml
@@ -1,9 +1,5 @@
-import QtQuick 2.0
-import QtQuick.Layouts 1.12
+import QtQuick 2.15
 
-import StatusQ.Controls 0.1
-import StatusQ.Components 0.1
-import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
 
 import shared.views 1.0
@@ -11,134 +7,159 @@ import shared.views 1.0
 Column {
     id: root
 
-    property int type: SyncingCodeInstructions.Type.AppSync
+    property int purpose: SyncingCodeInstructions.Purpose.AppSync
+    property int type: SyncingCodeInstructions.Type.QRCode
 
     spacing: 4
 
-    QtObject {
-        id: d
-        readonly property int listItemHeight: 40
-    }
-
-    RowLayout {
-        height: d.listItemHeight
-
-        StatusBaseText {
-            Layout.alignment: Qt.AlignVCenter
-            font.pixelSize: 15
-            color: Theme.palette.baseColor1
-            text: qsTr("1. Open Status App on your desktop device")
-        }
-    }
-
-    RowLayout {
-        height: d.listItemHeight
-
-        StatusBaseText {
-            Layout.alignment: Qt.AlignVCenter
-            font.pixelSize: 15
-            color: Theme.palette.baseColor1
-            text: qsTr("2. Open")
-        }
-        StatusRoundIcon {
-            asset.name: "settings"
-        }
-        StatusBaseText {
-            Layout.alignment: Qt.AlignVCenter
-            font.pixelSize: 15
-            color: Theme.palette.directColor1
-            text: qsTr("Settings")
-        }
-    }
-
-    RowLayout {
-        height: d.listItemHeight
-
-        StatusBaseText {
-            Layout.alignment: Qt.AlignVCenter
-            font.pixelSize: 15
-            color: Theme.palette.baseColor1
-            text: qsTr("3. Navigate to the ")
-        }
-        StatusRoundIcon {
-            asset.name: {
-                if (root.type === SyncingCodeInstructions.Type.KeypairSync) {
-                    return "wallet"
-                }
-                return "rotate"
+    GetSyncCodeInstruction {
+        order: "1."
+        orderColor: Theme.palette.baseColor1
+        text1: {
+            if (root.purpose === SyncingCodeInstructions.Purpose.KeypairSync) {
+                return qsTr("Open Status on the device you want to import from")
             }
+            return qsTr("Open Status App on your desktop device")
         }
-        StatusBaseText {
-            Layout.alignment: Qt.AlignVCenter
-            text: {
-                if (root.type === SyncingCodeInstructions.Type.KeypairSync) {
-                    return qsTr("Wallet tab")
-                }
-                return qsTr("Syncing tab")
+        text1Color: Theme.palette.baseColor1
+    }
+
+    GetSyncCodeInstruction {
+        order: "2."
+        orderColor: Theme.palette.baseColor1
+        text1: qsTr("Open")
+        text1Color: Theme.palette.baseColor1
+        icon: "settings"
+        text2: {
+            if (root.purpose === SyncingCodeInstructions.Purpose.KeypairSync) {
+                return qsTr("Settings / Wallet")
             }
-            font.pixelSize: 15
-            color: Theme.palette.directColor1
+            return qsTr("Settings")
+        }
+        text2Color: Theme.palette.directColor1
+    }
+
+    GetSyncCodeInstruction {
+        order: "3."
+        orderColor: Theme.palette.baseColor1
+        text1: {
+            if (root.purpose === SyncingCodeInstructions.Purpose.KeypairSync) {
+                return qsTr("Click")
+            }
+            return qsTr("Navigate to the")
+        }
+        text1Color: Theme.palette.baseColor1
+        icon: {
+            if (root.purpose === SyncingCodeInstructions.Purpose.KeypairSync) {
+                return ""
+            }
+            return "rotate"
+        }
+        text2: {
+            if (root.purpose === SyncingCodeInstructions.Purpose.KeypairSync) {
+                return qsTr("Show encrypted QR of keypairs on this device")
+            }
+            return qsTr("Syncing tab")
+        }
+        text2Color: Theme.palette.directColor1
+    }
+
+    GetSyncCodeInstruction {
+        order: "4."
+        orderColor: Theme.palette.baseColor1
+        text1: {
+            if (root.purpose === SyncingCodeInstructions.Purpose.KeypairSync) {
+                if (root.type === SyncingCodeInstructions.Type.EncryptedKey) {
+                    return qsTr("Copy the")
+                }
+                return qsTr("Enable camera")
+            }
+            return qsTr("Click")
+        }
+        text1Color: {
+            if (root.purpose === SyncingCodeInstructions.Purpose.KeypairSync) {
+                if (root.type === SyncingCodeInstructions.Type.EncryptedKey) {
+                    return Theme.palette.baseColor1
+                }
+                return Theme.palette.directColor1
+            }
+            return Theme.palette.baseColor1
+        }
+        text2: {
+            if (root.purpose === SyncingCodeInstructions.Purpose.KeypairSync) {
+                if (root.type === SyncingCodeInstructions.Type.EncryptedKey) {
+                    return qsTr("encrypted keypairs code")
+                }
+                return qsTr("on this device")
+            }
+            return qsTr("Setup Syncing")
+        }
+        text2Color: {
+            if (root.purpose === SyncingCodeInstructions.Purpose.KeypairSync) {
+                if (root.type === SyncingCodeInstructions.Type.EncryptedKey) {
+                    return Theme.palette.directColor1
+                }
+                return Theme.palette.baseColor1
+            }
+            return Theme.palette.directColor1
         }
     }
 
-    RowLayout {
-        height: d.listItemHeight
-
-        StatusBaseText {
-            Layout.alignment: Qt.AlignVCenter
-            text: qsTr("4. Click")
-            font.pixelSize: 15
-            color: Theme.palette.baseColor1
-        }
-        StatusBaseText {
-            Layout.alignment: Qt.AlignVCenter
-            text: {
-                if (root.type === SyncingCodeInstructions.Type.KeypairSync) {
-                    return qsTr("Import missing keypairs")
+    GetSyncCodeInstruction {
+        order: "5."
+        orderColor: Theme.palette.baseColor1
+        text1: {
+            if (root.purpose === SyncingCodeInstructions.Purpose.KeypairSync) {
+                if (root.type === SyncingCodeInstructions.Type.EncryptedKey) {
+                    return qsTr("Paste the")
                 }
-                return qsTr("Setup Syncing")
+                return qsTr("Scan or enter the encrypted QR with this device")
             }
-            font.pixelSize: 15
-            color: Theme.palette.directColor1
+            return ""
         }
+        text1Color: Theme.palette.baseColor1
+        text2: {
+            if (root.purpose === SyncingCodeInstructions.Purpose.KeypairSync) {
+                if (root.type === SyncingCodeInstructions.Type.EncryptedKey) {
+                    return qsTr("encrypted keypairs code")
+                }
+                return ""
+            }
+            return qsTr("Enable camera")
+        }
+        text2Color: Theme.palette.directColor1
+        text3: {
+            if (root.purpose === SyncingCodeInstructions.Purpose.KeypairSync) {
+                if (root.type === SyncingCodeInstructions.Type.EncryptedKey) {
+                    return qsTr("to this device")
+                }
+                return ""
+            }
+            return qsTr("on this device")
+        }
+        text3Color: Theme.palette.baseColor1
     }
 
-    RowLayout {
-        height: d.listItemHeight
-
-        StatusBaseText {
-            Layout.alignment: Qt.AlignVCenter
-            text: qsTr("5.")
-            font.pixelSize: 15
-            color: Theme.palette.baseColor1
-        }
-        StatusBaseText {
-            Layout.alignment: Qt.AlignVCenter
-            text: qsTr("Enable camera")
-            font.pixelSize: 15
-            color: Theme.palette.directColor1
-        }
-        StatusBaseText {
-            Layout.alignment: Qt.AlignVCenter
-            text: qsTr("on this device")
-            font.pixelSize: 15
-            color: Theme.palette.baseColor1
-        }
-    }
-
-    RowLayout {
-        height: d.listItemHeight
-
-        StatusBaseText {
-            Layout.alignment: Qt.AlignVCenter
-            text: {
-                if (root.type === SyncingCodeInstructions.Type.KeypairSync) {
-                    return qsTr("6. Scan or enter the encrypted key with this device")
+    GetSyncCodeInstruction {
+        order: {
+            if (root.purpose === SyncingCodeInstructions.Purpose.KeypairSync) {
+                if (root.type === SyncingCodeInstructions.Type.EncryptedKey) {
+                    return "6."
                 }
-                return qsTr("6. Scan or enter the code")
+                return ""
             }
-            font.pixelSize: 15
-            color: Theme.palette.baseColor1
+            return "6."
         }
+        orderColor: Theme.palette.baseColor1
+        text1: {
+            if (root.purpose === SyncingCodeInstructions.Purpose.KeypairSync) {
+                if (root.type === SyncingCodeInstructions.Type.EncryptedKey) {
+                    return qsTr("For security, delete the code as soon as you are done")
+                }
+                return ""
+            }
+            return qsTr("Scan or enter the code")
+        }
+        text1Color: Theme.palette.baseColor1
     }
 }

--- a/ui/imports/shared/controls/GetSyncCodeInstruction.qml
+++ b/ui/imports/shared/controls/GetSyncCodeInstruction.qml
@@ -1,0 +1,49 @@
+import QtQuick.Layouts 1.15
+
+import StatusQ.Core 0.1
+import StatusQ.Components 0.1
+
+RowLayout {
+    id: root
+
+    height: 40
+
+    property string order: ""
+    property string orderColor: ""
+    property string text1: ""
+    property string text1Color: ""
+    property string icon: ""
+    property string text2: ""
+    property string text2Color: ""
+    property string text3: ""
+    property string text3Color: ""
+
+    StatusBaseText {
+        Layout.alignment: Qt.AlignVCenter
+        visible: !!root.order
+        color: root.orderColor
+        text: root.order
+    }
+    StatusBaseText {
+        Layout.alignment: Qt.AlignVCenter
+        visible: !!root.text1
+        color: root.text1Color
+        text: "%1".arg(root.text1)
+    }
+    StatusRoundIcon {
+        visible: !!root.icon
+        asset.name: root.icon
+    }
+    StatusBaseText {
+        Layout.alignment: Qt.AlignVCenter
+        visible: !!root.text2
+        color: root.text2Color
+        text: "%1".arg(root.text2)
+    }
+    StatusBaseText {
+        Layout.alignment: Qt.AlignVCenter
+        visible: !!root.text3
+        color: root.text3Color
+        text: "%1".arg(root.text3)
+    }
+}

--- a/ui/imports/shared/controls/GetSyncCodeMobileInstructions.qml
+++ b/ui/imports/shared/controls/GetSyncCodeMobileInstructions.qml
@@ -1,9 +1,5 @@
-import QtQuick 2.0
-import QtQuick.Layouts 1.12
+import QtQuick 2.15
 
-import StatusQ.Controls 0.1
-import StatusQ.Components 0.1
-import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
 
 import shared.views 1.0
@@ -11,134 +7,164 @@ import shared.views 1.0
 Column {
     id: root
 
-    property int type: SyncingCodeInstructions.Type.AppSync
+    property int purpose: SyncingCodeInstructions.Purpose.AppSync
+    property int type: SyncingCodeInstructions.Type.QRCode
 
     spacing: 4
 
-    QtObject {
-        id: d
-        readonly property int listItemHeight: 40
-    }
-
-    RowLayout {
-        height: d.listItemHeight
-
-        StatusBaseText {
-            Layout.alignment: Qt.AlignVCenter
-            font.pixelSize: 15
-            color: Theme.palette.baseColor1
-            text: qsTr("1. Open Status App on your mobile device")
-        }
-    }
-
-    RowLayout {
-        height: d.listItemHeight
-
-        StatusBaseText {
-            Layout.alignment: Qt.AlignVCenter
-            font.pixelSize: 15
-            color: Theme.palette.baseColor1
-            text: qsTr("2. Open")
-        }
-        StatusRoundIcon {
-            asset.name: "profile"
-        }
-        StatusBaseText {
-            Layout.alignment: Qt.AlignVCenter
-            font.pixelSize: 15
-            color: Theme.palette.directColor1
-            text: qsTr("Settings")
-        }
-    }
-
-    RowLayout {
-        height: d.listItemHeight
-
-        StatusBaseText {
-            Layout.alignment: Qt.AlignVCenter
-            font.pixelSize: 15
-            color: Theme.palette.baseColor1
-            text: qsTr("3. Go to")
-        }
-        StatusRoundIcon {
-            asset.name: {
-                if (root.type === SyncingCodeInstructions.Type.KeypairSync) {
-                    return "wallet"
-                }
-                return "rotate"
+    GetSyncCodeInstruction {
+        order: "1."
+        orderColor: Theme.palette.baseColor1
+        text1: {
+            if (root.purpose === SyncingCodeInstructions.Purpose.KeypairSync) {
+                return qsTr("Open Status on the device you want to import from")
             }
+            return qsTr("Open Status App on your mobile device")
         }
-        StatusBaseText {
-            Layout.alignment: Qt.AlignVCenter
-            text: {
-                if (root.type === SyncingCodeInstructions.Type.KeypairSync) {
-                    return qsTr("Wallet")
-                }
-                return qsTr("Syncing")
+        text1Color: Theme.palette.baseColor1
+    }
+
+    GetSyncCodeInstruction {
+        order: "2."
+        orderColor: Theme.palette.baseColor1
+        text1: qsTr("Open")
+        text1Color: Theme.palette.baseColor1
+        icon: {
+            if (root.purpose === SyncingCodeInstructions.Purpose.KeypairSync) {
+                return "settings"
             }
-            font.pixelSize: 15
-            color: Theme.palette.directColor1
+            return "profile"
+        }
+        text2: {
+            if (root.purpose === SyncingCodeInstructions.Purpose.KeypairSync) {
+                return qsTr("Settings / Wallet")
+            }
+            return qsTr("Settings")
+        }
+        text2Color: Theme.palette.directColor1
+    }
+
+    GetSyncCodeInstruction {
+        order: "3."
+        orderColor: Theme.palette.baseColor1
+        text1: {
+            if (root.purpose === SyncingCodeInstructions.Purpose.KeypairSync) {
+                return qsTr("Tap")
+            }
+            return qsTr("Go to")
+        }
+        text1Color: Theme.palette.baseColor1
+        icon: {
+            if (root.purpose === SyncingCodeInstructions.Purpose.KeypairSync) {
+                return ""
+            }
+            return "rotate"
+        }
+        text2: {
+            if (root.purpose === SyncingCodeInstructions.Purpose.KeypairSync) {
+                return qsTr("Show encrypted keypairs code")
+            }
+            return qsTr("Syncing")
+        }
+        text2Color: Theme.palette.directColor1
+    }
+
+    GetSyncCodeInstruction {
+        order: "4."
+        orderColor: Theme.palette.baseColor1
+        text1: {
+            if (root.purpose === SyncingCodeInstructions.Purpose.KeypairSync) {
+                if (root.type === SyncingCodeInstructions.Type.EncryptedKey) {
+                    return qsTr("Copy the")
+                }
+                return qsTr("Enable camera")
+            }
+            return qsTr("Tap")
+        }
+        text1Color: {
+            if (root.purpose === SyncingCodeInstructions.Purpose.KeypairSync) {
+                if (root.type === SyncingCodeInstructions.Type.EncryptedKey) {
+                    return Theme.palette.baseColor1
+                }
+                return Theme.palette.directColor1
+            }
+            return Theme.palette.baseColor1
+        }
+        text2: {
+            if (root.purpose === SyncingCodeInstructions.Purpose.KeypairSync) {
+                if (root.type === SyncingCodeInstructions.Type.EncryptedKey) {
+                    return qsTr("encrypted keypairs code")
+                }
+                return qsTr("on this device")
+            }
+            return qsTr("Sync new device")
+        }
+        text2Color: {
+            if (root.purpose === SyncingCodeInstructions.Purpose.KeypairSync) {
+                if (root.type === SyncingCodeInstructions.Type.EncryptedKey) {
+                    return Theme.palette.directColor1
+                }
+                return Theme.palette.baseColor1
+            }
+            return Theme.palette.directColor1
         }
     }
 
-    RowLayout {
-        height: d.listItemHeight
-
-        StatusBaseText {
-            Layout.alignment: Qt.AlignVCenter
-            text: qsTr("4. Tap")
-            font.pixelSize: 15
-            color: Theme.palette.baseColor1
-        }
-        StatusBaseText {
-            Layout.alignment: Qt.AlignVCenter
-            text: {
-                if (root.type === SyncingCodeInstructions.Type.KeypairSync) {
-                    return qsTr("Import missing keypairs")
+    GetSyncCodeInstruction {
+        order: "5."
+        orderColor: Theme.palette.baseColor1
+        text1: {
+            if (root.purpose === SyncingCodeInstructions.Purpose.KeypairSync) {
+                if (root.type === SyncingCodeInstructions.Type.EncryptedKey) {
+                    return qsTr("Paste the")
                 }
-                return qsTr("Sync new device")
+                return qsTr("Scan or enter the encrypted QR with this device")
             }
-            font.pixelSize: 15
-            color: Theme.palette.directColor1
+            return qsTr("Tap")
         }
+        text1Color: Theme.palette.baseColor1
+        text2: {
+            if (root.purpose === SyncingCodeInstructions.Purpose.KeypairSync) {
+                if (root.type === SyncingCodeInstructions.Type.EncryptedKey) {
+                    return qsTr("encrypted keypairs code")
+                }
+                return ""
+            }
+            return qsTr("Enable camera")
+        }
+        text2Color: Theme.palette.directColor1
+        text3: {
+            if (root.purpose === SyncingCodeInstructions.Purpose.KeypairSync) {
+                if (root.type === SyncingCodeInstructions.Type.EncryptedKey) {
+                    return qsTr("to this device")
+                }
+                return ""
+            }
+            return qsTr("on this device")
+        }
+        text3Color: Theme.palette.baseColor1
     }
 
-    RowLayout {
-        height: d.listItemHeight
-
-        StatusBaseText {
-            Layout.alignment: Qt.AlignVCenter
-            text: qsTr("5.")
-            font.pixelSize: 15
-            color: Theme.palette.baseColor1
-        }
-        StatusBaseText {
-            Layout.alignment: Qt.AlignVCenter
-            text: qsTr("Enable camera")
-            font.pixelSize: 15
-            color: Theme.palette.directColor1
-        }
-        StatusBaseText {
-            Layout.alignment: Qt.AlignVCenter
-            text: qsTr("on this device")
-            font.pixelSize: 15
-            color: Theme.palette.baseColor1
-        }
-    }
-
-    RowLayout {
-        height: d.listItemHeight
-
-        StatusBaseText {
-            Layout.alignment: Qt.AlignVCenter
-            text: {
-                if (root.type === SyncingCodeInstructions.Type.KeypairSync) {
-                    return qsTr("6. Scan or enter the encrypted key with this device")
+    GetSyncCodeInstruction {
+        order: {
+            if (root.purpose === SyncingCodeInstructions.Purpose.KeypairSync) {
+                if (root.type === SyncingCodeInstructions.Type.EncryptedKey) {
+                    return "6."
                 }
-                return qsTr("6. Scan or enter the code")
+                return ""
             }
-            font.pixelSize: 15
-            color: Theme.palette.baseColor1
+            return "6."
         }
+        orderColor: Theme.palette.baseColor1
+        text1: {
+            if (root.purpose === SyncingCodeInstructions.Purpose.KeypairSync) {
+                if (root.type === SyncingCodeInstructions.Type.EncryptedKey) {
+                    return qsTr("For security, delete the code as soon as you are done")
+                }
+                return ""
+            }
+            return qsTr("Scan or enter the code")
+        }
+        text1Color: Theme.palette.baseColor1
     }
 }

--- a/ui/imports/shared/controls/ImportKeypairInfo.qml
+++ b/ui/imports/shared/controls/ImportKeypairInfo.qml
@@ -1,0 +1,55 @@
+import QtQuick 2.15
+import QtQuick.Layouts 1.15
+
+import StatusQ.Core 0.1
+import StatusQ.Controls 0.1
+import StatusQ.Core.Theme 0.1
+
+import utils 1.0
+
+Rectangle {
+    id: root
+
+    property string title: qsTr("Import keypair to use this account")
+    property string info: qsTr("This account was added to one of your synced devices. To use this account you will first need import the associated keypair to this device.")
+    property string buttonName: qsTr("Import keypair")
+
+    signal runImport()
+
+    radius: Style.current.radius
+    border.width: 1
+    border.color: Theme.palette.directColor8
+    color: Theme.palette.transparent
+
+    ColumnLayout {
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.leftMargin: Style.current.padding
+        anchors.rightMargin: Style.current.padding
+        spacing: Style.current.halfPadding
+
+        StatusBaseText {
+            Layout.fillWidth: true
+            Layout.topMargin: Style.current.padding
+            text: root.title
+            color: Theme.palette.warningColor1
+        }
+
+        StatusBaseText {
+            Layout.fillWidth: true
+            wrapMode: Text.WordWrap
+            text: root.info
+        }
+
+        StatusButton {
+            Layout.alignment: Qt.AlignLeft
+            Layout.bottomMargin: Style.current.padding
+            text: root.buttonName
+            type: StatusBaseButton.Type.Warning
+            icon.name: "download"
+            onClicked: {
+                root.runImport()
+            }
+        }
+    }
+}

--- a/ui/imports/shared/controls/qmldir
+++ b/ui/imports/shared/controls/qmldir
@@ -45,3 +45,4 @@ ErrorDetails 1.0 ErrorDetails.qml
 CopyButton 1.0 CopyButton.qml
 DisabledTooltipButton 1.0 DisabledTooltipButton.qml
 WalletAccountListItem 1.0 WalletAccountListItem.qml
+ImportKeypairInfo 1.0 ImportKeypairInfo.qml

--- a/ui/imports/shared/popups/common/EnterPrivateKey.qml
+++ b/ui/imports/shared/popups/common/EnterPrivateKey.qml
@@ -36,7 +36,7 @@ Item {
 
             StatusBaseText {
                 width: parent.width
-                text: root.store.isAddAccountPopup? qsTr("Private key") : qsTr("Private key for %1 keypair").arg(root.store.selectedKeypair.name)
+                text: root.store.isAddAccountPopup? qsTr("Private key") : qsTr("Enter seed phrase for %1 keypair").arg(root.store.selectedKeypair.name)
                 font.pixelSize: Constants.addAccountPopup.labelFontSize1
                 elide: Text.ElideRight
             }

--- a/ui/imports/shared/popups/common/EnterSeedPhrase.qml
+++ b/ui/imports/shared/popups/common/EnterSeedPhrase.qml
@@ -27,7 +27,7 @@ Item {
 
         StatusBaseText {
             width: parent.width
-            text: root.store.isAddAccountPopup? qsTr("Enter seed phrase") : qsTr("Enter seed phrase for %1 keypair").arg(root.store.selectedKeypair.name)
+            text: root.store.isAddAccountPopup? qsTr("Enter seed phrase") : qsTr("Enter private key for %1 keypair").arg(root.store.selectedKeypair.name)
             font.pixelSize: Constants.addAccountPopup.labelFontSize1
             elide: Text.ElideRight
         }

--- a/ui/imports/shared/popups/keypairimport/KeypairImportPopup.qml
+++ b/ui/imports/shared/popups/keypairimport/KeypairImportPopup.qml
@@ -32,7 +32,10 @@ StatusModal {
         case Constants.keypairImportPopup.state.importQr:
             return qsTr("Scan encrypted keypair QR code")
         case Constants.keypairImportPopup.state.displayInstructions:
-            return qsTr("How to generate the encrypted QR")
+            if (root.store.syncViaQr) {
+                return Constants.keypairImportPopup.instructionsLabelForQr
+            }
+            return Constants.keypairImportPopup.instructionsLabelForEncryptedKey
         }
 
         return qsTr("Import %1 keypair").arg(root.store.selectedKeypair.name)
@@ -137,6 +140,7 @@ StatusModal {
                 id: displayInstructionsComponent
                 DisplayInstructions {
                     height: Constants.keypairImportPopup.contentHeight
+                    store: root.store
                 }
             }
         }

--- a/ui/imports/shared/popups/keypairimport/KeypairImportPopup.qml
+++ b/ui/imports/shared/popups/keypairimport/KeypairImportPopup.qml
@@ -24,12 +24,13 @@ StatusModal {
         switch (root.store.currentState.stateType) {
         case Constants.keypairImportPopup.state.selectKeypair:
             return qsTr("Import missing keypairs")
-        case Constants.keypairImportPopup.state.selectImportMethod:
-            return qsTr("Import %1 keypair").arg(root.store.selectedKeypair.name)
         case Constants.keypairImportPopup.state.exportKeypair:
+            if (!!root.store.selectedKeypair.name) {
+                return qsTr("Encrypted QR for %1 keypair").arg(root.store.selectedKeypair.name)
+            }
             return qsTr("Encrypted QR for keypairs on this device")
         case Constants.keypairImportPopup.state.importQr:
-            return qsTr("Scan encrypted QR")
+            return qsTr("Scan encrypted keypair QR code")
         case Constants.keypairImportPopup.state.displayInstructions:
             return qsTr("How to generate the encrypted QR")
         }
@@ -163,9 +164,13 @@ StatusModal {
                 case Constants.keypairImportPopup.state.exportKeypair:
                     return qsTr("Done")
                 case Constants.keypairImportPopup.state.importQr:
+                    if (root.store.syncViaQr) {
+                        return qsTr("Done")
+                    }
+                    return qsTr("Import keypair")
                 case Constants.keypairImportPopup.state.importPrivateKey:
                 case Constants.keypairImportPopup.state.importSeedPhrase:
-                    return qsTr("Import %1 keypair").arg(root.store.selectedKeypair.name)
+                    return qsTr("Import keypair")
                 }
 
                 return ""
@@ -174,7 +179,8 @@ StatusModal {
             enabled: root.store.primaryPopupButtonEnabled
 
             icon.name: {
-                if (root.store.currentState.stateType === Constants.keypairImportPopup.state.exportKeypair) {
+                if (root.store.currentState.stateType === Constants.keypairImportPopup.state.exportKeypair ||
+                        root.store.currentState.stateType === Constants.keypairImportPopup.state.importQr && root.store.syncViaQr) {
                     return ""
                 }
 

--- a/ui/imports/shared/popups/keypairimport/states/DisplayInstructions.qml
+++ b/ui/imports/shared/popups/keypairimport/states/DisplayInstructions.qml
@@ -3,8 +3,12 @@ import QtQuick.Layouts 1.14
 
 import shared.views 1.0
 
+import "../stores"
+
 Item {
     id: root
+
+    property KeypairImportStore store
 
     implicitHeight: layout.implicitHeight
 
@@ -14,6 +18,9 @@ Item {
         anchors.fill: parent
         anchors.margins: 24
 
-        type: SyncingCodeInstructions.Type.KeypairSync
+        purpose: SyncingCodeInstructions.Purpose.KeypairSync
+        type: root.store.syncViaQr?
+                  SyncingCodeInstructions.Type.QRCode :
+                  SyncingCodeInstructions.Type.EncryptedKey
     }
 }

--- a/ui/imports/shared/popups/keypairimport/states/ScanOrEnterQrCode.qml
+++ b/ui/imports/shared/popups/keypairimport/states/ScanOrEnterQrCode.qml
@@ -3,6 +3,8 @@ import QtQuick.Layouts 1.14
 
 import shared.views 1.0
 
+import utils 1.0
+
 import "../stores"
 
 Item {
@@ -23,8 +25,8 @@ Item {
         secondTabName: qsTr("Enter encrypted key")
         syncQrErrorMessage: qsTr("This does not look like the correct keypair QR code")
         syncCodeErrorMessage: qsTr("This does not look like an encrypted keypair code")
-        firstInstructionButtonName: qsTr("How to display the QR code on your other device")
-        secondInstructionButtonName: qsTr("How to copy the encrypted key from your other device")
+        firstInstructionButtonName: Constants.keypairImportPopup.instructionsLabelForQr
+        secondInstructionButtonName: Constants.keypairImportPopup.instructionsLabelForEncryptedKey
         syncCodeLabel: qsTr("Paste encrypted key")
 
         validateConnectionString: function(connectionString) {

--- a/ui/imports/shared/popups/keypairimport/states/ScanOrEnterQrCode.qml
+++ b/ui/imports/shared/popups/keypairimport/states/ScanOrEnterQrCode.qml
@@ -23,13 +23,17 @@ Item {
         secondTabName: qsTr("Enter encrypted key")
         syncQrErrorMessage: qsTr("This does not look like the correct keypair QR code")
         syncCodeErrorMessage: qsTr("This does not look like an encrypted keypair code")
-        firstInstructionButtonName: qsTr("How to generate the QR")
-        secondInstructionButtonName: qsTr("How to generate the key")
+        firstInstructionButtonName: qsTr("How to display the QR code on your other device")
+        secondInstructionButtonName: qsTr("How to copy the encrypted key from your other device")
         syncCodeLabel: qsTr("Paste encrypted key")
 
         validateConnectionString: function(connectionString) {
             const result = root.store.validateConnectionString(connectionString)
             return result === ""
+        }
+
+        onSyncViaQrChanged: {
+            root.store.syncViaQr = syncViaQr
         }
 
         onProceed: {

--- a/ui/imports/shared/popups/keypairimport/states/SelectKeypair.qml
+++ b/ui/imports/shared/popups/keypairimport/states/SelectKeypair.qml
@@ -45,7 +45,7 @@ Item {
             Layout.fillWidth: true
             Layout.leftMargin: d.margin
             Layout.rightMargin: d.margin
-            text: qsTr("To use the associated accounts on this device, you need to import their keypairs.")
+            text: qsTr("To use the derived accounts on this device, you need to import their keypairs.")
             wrapMode: Text.WordWrap
         }
 

--- a/ui/imports/shared/popups/keypairimport/stores/KeypairImportStore.qml
+++ b/ui/imports/shared/popups/keypairimport/stores/KeypairImportStore.qml
@@ -11,6 +11,7 @@ BasePopupStore {
 
     property bool userProfileIsKeycardUser: userProfile.isKeycardUser
     property bool userProfileUsingBiometricLogin: userProfile.usingBiometricLogin
+    property bool syncViaQr: true
 
     // Module Properties
     property var currentState: root.keypairImportModule.currentState
@@ -19,7 +20,7 @@ BasePopupStore {
     privateKeyAccAddress: root.keypairImportModule.privateKeyAccAddress
 
     submitPopup: function(event) {
-        if (!root.primaryPopupButtonEnabled) {
+        if (!root.syncViaQr && !root.primaryPopupButtonEnabled) {
             return
         }
 
@@ -51,7 +52,8 @@ BasePopupStore {
 
     readonly property bool primaryPopupButtonEnabled: {
         if (root.currentState.stateType === Constants.keypairImportPopup.state.importQr) {
-            return !!root.keypairImportModule.connectionString &&
+            return !root.syncViaQr &&
+                    !!root.keypairImportModule.connectionString &&
                     !root.keypairImportModule.connectionStringError
         }
 

--- a/ui/imports/shared/views/SyncingCodeInstructions.qml
+++ b/ui/imports/shared/views/SyncingCodeInstructions.qml
@@ -8,12 +8,18 @@ import shared.controls 1.0
 ColumnLayout {
     id: root
 
-    enum Type {
+    enum Purpose {
         AppSync,
         KeypairSync
     }
 
-    property int type: SyncingCodeInstructions.Type.AppSync
+    enum Type {
+        QRCode,
+        EncryptedKey
+    }
+
+    property int purpose: SyncingCodeInstructions.Purpose.AppSync
+    property int type: SyncingCodeInstructions.Type.QRCode
 
     spacing: 0
 
@@ -50,6 +56,7 @@ ColumnLayout {
             Layout.fillWidth: false
             Layout.alignment: Qt.AlignHCenter
 
+            purpose: root.purpose
             type: root.type
         }
 
@@ -59,6 +66,7 @@ ColumnLayout {
             Layout.fillWidth: false
             Layout.alignment: Qt.AlignHCenter
 
+            purpose: root.purpose
             type: root.type
         }
     }

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -748,10 +748,11 @@ QtObject {
 
         readonly property QtObject mode: QtObject {
             readonly property int selectKeypair: 1
-            readonly property int importViaSeedPhrase: 2
-            readonly property int importViaPrivateKey: 3
-            readonly property int importViaQr: 4
-            readonly property int exportKeypairQr: 5
+            readonly property int selectImportMethod: 2
+            readonly property int importViaSeedPhrase: 3
+            readonly property int importViaPrivateKey: 4
+            readonly property int importViaQr: 5
+            readonly property int exportKeypairQr: 6
         }
 
         readonly property QtObject state: QtObject {

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -743,6 +743,8 @@ QtObject {
         readonly property int contentHeight: 626
         readonly property int footerButtonsHeight: 44
         readonly property int labelFontSize1: 15
+        readonly property string instructionsLabelForQr: qsTr("How to display the QR code on your other device")
+        readonly property string instructionsLabelForEncryptedKey: qsTr("How to copy the encrypted key from your other device")
 
         readonly property QtObject mode: QtObject {
             readonly property int selectKeypair: 1

--- a/ui/imports/utils/Utils.qml
+++ b/ui/imports/utils/Utils.qml
@@ -846,11 +846,9 @@ QtObject {
         }
         if (keypair.operability === Constants.keypair.operability.nonOperable) {
             if (keypair.syncedFrom === Constants.keypair.syncedFrom.backup) {
-                if (keypair.pairType === Constants.keypair.type.seedImport) {
-                    return qsTr("Restored from backup. Re-enter seed phrase to use.")
-                }
-                if (keypair.pairType === Constants.keypair.type.privateKeyImport) {
-                    return qsTr("Restored from backup. Re-enter private key to use.")
+                if (keypair.pairType === Constants.keypair.type.seedImport ||
+                        keypair.pairType === Constants.keypair.type.privateKeyImport) {
+                    return qsTr("Restored from backup. Import keypair to use derived accounts.")
                 }
             }
             if (keypair.syncedFrom !== "") {

--- a/ui/imports/utils/Utils.qml
+++ b/ui/imports/utils/Utils.qml
@@ -854,7 +854,7 @@ QtObject {
                 }
             }
             if (keypair.syncedFrom !== "") {
-                return qsTr("Requires import to use")
+                return qsTr("Import keypair to use derived accounts")
             }
         }
 


### PR DESCRIPTION
Corresponding `status-go` PR:
- https://github.com/status-im/status-go/pull/3947

Closes #11968

Here is a video of the point 1, added notification to activity center:


https://github.com/status-im/status-desktop/assets/86303051/e6e9959f-5a29-4856-92de-1f262860f39c

