### PR TITLE
fix(crash): fix crash about community permissions

### DIFF
--- a/src/app/modules/main/chat_section/chat_content/messages/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/module.nim
@@ -555,16 +555,16 @@ method getChatIcon*(self: Module): string =
   return chatDto.icon
 
 method amIChatAdmin*(self: Module): bool =
-  if(not self.controller.belongsToCommunity()):
+  if not self.controller.belongsToCommunity():
     let chatDto = self.controller.getChatDetails()
     for member in chatDto.members:
       if (member.id == singletonInstance.userProfile.getPubKey()):
+        # TODO untangle this. There is no special roles for group chats
         return member.role == MemberRole.Owner or member.role == MemberRole.Admin or member.role == MemberRole.TokenMaster
     return false
   else:
     let communityDto = self.controller.getCommunityDetails()
-    return communityDto.memberRole == MemberRole.Owner or
-        communityDto.memberRole == MemberRole.Admin or communityDto.memberRole == MemberRole.TokenMaster
+    return communityDto.isPrivilegedUser
 
 method pinMessageAllowedForMembers*(self: Module): bool =
   if(self.controller.belongsToCommunity()):
@@ -734,8 +734,7 @@ method markMessagesAsRead*(self: Module, messages: seq[string]) =
   self.view.model().markAsSeen(messages)
 
 method updateCommunityDetails*(self: Module, community: CommunityDto) =
-  self.view.setAmIChatAdmin(community.memberRole == MemberRole.Owner or
-    community.memberRole == MemberRole.Admin or community.memberRole == MemberRole.TokenMaster)
+  self.view.setAmIChatAdmin(community.isPrivilegedUser)
   self.view.setIsPinMessageAllowedForMembers(community.adminSettings.pinMessageAllMembersEnabled)
 
 proc setChatDetails(self: Module, chatDetails: ChatDto) =

--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -350,10 +350,6 @@ method onChatsLoaded*(
       if chatId == activeChatId:
         cModule.onMadeActive()
 
-    if(self.controller.isCommunity()):
-      let community = self.controller.getMyCommunity()
-      self.controller.asyncCheckChannelPermissions(community.id, activeChatId)
-
   self.view.chatsLoaded()
 
 proc checkIfModuleDidLoad(self: Module) =
@@ -432,8 +428,9 @@ method activeItemSet*(self: Module, itemId: string) =
   self.delegate.onDeactivateChatLoader(deactivateSectionId, deactivateChatId)
 
   if self.controller.isCommunity():
-    self.controller.asyncCheckChannelPermissions(mySectionId, activeChatId)
-
+    let community = self.controller.getMyCommunity()
+    if not community.isPrivilegedUser:
+      self.controller.asyncCheckChannelPermissions(mySectionId, activeChatId)
 
 method getModuleAsVariant*(self: Module): QVariant =
   return self.viewVariant
@@ -505,8 +502,10 @@ method onActiveSectionChange*(self: Module, sectionId: string) =
     self.setActiveItem(activeChatId)
 
   if self.isCommunity():
-    self.controller.asyncCheckPermissionsToJoin()
-    self.controller.asyncCheckAllChannelsPermissions()
+    let community = self.controller.getMyCommunity()
+    if not community.isPrivilegedUser:
+      self.controller.asyncCheckPermissionsToJoin()
+      self.controller.asyncCheckAllChannelsPermissions()
 
   self.delegate.onActiveChatChange(self.controller.getMySectionId(), self.controller.getActiveChatId())
 

--- a/src/app_service/service/community/dto/community.nim
+++ b/src/app_service/service/community/dto/community.nim
@@ -567,3 +567,15 @@ proc getCommunityChats*(self: CommunityDto, chatsIds: seq[string]): seq[ChatDto]
         chats.add(communityChat)
         break
   return chats
+
+proc isOwner*(self: CommunityDto): bool =
+  return self.memberRole == MemberRole.Owner
+
+proc isTokenMaster*(self: CommunityDto): bool =
+  return self.memberRole == MemberRole.TokenMaster
+
+proc isAdmin*(self: CommunityDto): bool =
+  return self.memberRole == MemberRole.Admin
+
+proc isPrivilegedUser*(self: CommunityDto): bool =
+  return self.isControlNode or self.isOwner or self.isTokenMaster or self.isAdmin

--- a/ui/app/AppLayouts/Chat/ChatLayout.qml
+++ b/ui/app/AppLayouts/Chat/ChatLayout.qml
@@ -23,6 +23,12 @@ StackLayout {
 
     property var sectionItemModel
 
+    readonly property bool isOwner: community.memberRole === Constants.memberRole.owner
+    readonly property bool isAdmin: community.memberRole === Constants.memberRole.admin
+    readonly property bool isTokenMasterOwner: community.memberRole === Constants.memberRole.tokenMaster
+    readonly property bool isControlNode: community.isControlNode
+    readonly property bool isPrivilegedUser: isControlNode || isOwner || isAdmin || isTokenMasterOwner
+
     property bool communitySettingsDisabled
 
     property var emojiPopup
@@ -153,7 +159,7 @@ StackLayout {
 
     Loader {
         id: communitySettingsLoader
-        active: root.rootStore.chatCommunitySectionModule.isCommunity()
+        active: root.rootStore.chatCommunitySectionModule.isCommunity() && root.isPrivilegedUser
 
         sourceComponent: CommunitySettingsView {
             id: communitySettingsView


### PR DESCRIPTION
Fixes #11996

I was able to fix this by having a repro state on my release DB. I think in release mode, there was a race condition about permissions being checked too fast and creating the crash.

With these changes, I no longer experience the crash, though some of the crashes seemed very random, so further testing will be needed with a real build.

The changes I did here include:
- Stop checking for permissions as much
  - We had verification-itis. We would call the function to check permissions in like 4 different places, so we'd check way too often
  - The one i removed was that when creating the chat section, we'd call it on creation, then also on setting the chat active
  - I kept only the one on set active
- I made sure that we only check permissions for members. Privileged users always satisfy the permissions, so no need to check channel or join perms
- This one is probably the main culprit: I removed the CommunitySettingPanel being loaded if you are **not** a privileged user
  - A normal member will never see the settings panel, but somehow, we still loaded the panel, so all the models were loaded
  - commenting that model would remove the crash, so I think this is the actual fix

