### PR TITLE
fix(i18n): timestamp stripping year part

### DIFF
--- a/ui/StatusQ/src/StatusQ/Core/LocaleUtils.qml
+++ b/ui/StatusQ/src/StatusQ/Core/LocaleUtils.qml
@@ -431,17 +431,14 @@ QtObject {
             return qsTr("%1 %2").arg(loc.standaloneDayName(value.getDay(), Locale.ShortFormat)).arg(value.toLocaleTimeString(loc, formatString))
         }
 
-        // otherwise
-        var fullFormatString = d.fixupTimeFormatString(loc.dateTimeFormat(Locale.ShortFormat))
+        // within this year
         if (now.getFullYear() === value.getFullYear()) {
-            // strip year part, if current year -> "31 December 09:41"
-            // It remove preceding dot or space
-            fullFormatString = fullFormatString.replace(/([.\s])?\b(y+)\b/g, "")
-        } else if (!fullFormatString.includes("yyyy")) {
-            fullFormatString = fullFormatString.replace("yy", "yyyy") // different year -> "31 December 2022 09:41"
+            // strip year part, if current year -> "31 Dec 09:41"
+            return getDayMonth(value) + " " + formatTime(value, Locale.ShortFormat)
         }
 
-        return value.toLocaleString(loc, fullFormatString)
+        // otherwise
+        return formatDateTime(value, Locale.ShortFormat)
     }
 
     function getTimeDifference(d1, d2) {


### PR DESCRIPTION
Use locale-neutral `getDayMonth()` plus the time part as there's no way to programatically check for date parts separator.

Fixes #10615

### Affected areas

LocaleUtils

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![image](https://github.com/status-im/status-desktop/assets/5377645/88fe3d7e-339d-403e-8c4b-2bc78019bc5c)

