### PR TITLE
Add missing object id for QML object

### DIFF
--- a/ui/imports/shared/views/chat/ChatContextMenuView.qml
+++ b/ui/imports/shared/views/chat/ChatContextMenuView.qml
@@ -201,8 +201,8 @@ StatusMenu {
     }
 
     StatusAction {
-        objectName: "clearHistoryMenuItem"
         id: clearHistoryMenuItem
+        objectName: "clearHistoryMenuItem"
         text: qsTr("Clear History")
         icon.name: "close-circle"
         type: deleteOrLeaveMenuItem.enabled ? StatusAction.Type.Normal : StatusAction.Type.Danger
@@ -212,8 +212,8 @@ StatusMenu {
     }
 
     StatusAction {
-        objectName: "deleteOrLeaveMenuItem"
         id: deleteOrLeaveMenuItem
+        objectName: "deleteOrLeaveMenuItem"
         text: {
             if (root.isCommunityChat) {
                 return qsTr("Delete Channel")

--- a/ui/imports/shared/views/chat/ChatContextMenuView.qml
+++ b/ui/imports/shared/views/chat/ChatContextMenuView.qml
@@ -202,6 +202,7 @@ StatusMenu {
 
     StatusAction {
         objectName: "clearHistoryMenuItem"
+        id: clearHistoryMenuItem
         text: qsTr("Clear History")
         icon.name: "close-circle"
         type: deleteOrLeaveMenuItem.enabled ? StatusAction.Type.Normal : StatusAction.Type.Danger


### PR DESCRIPTION
### What does the PR do

This was omitted in PR #11891, besides a LOG warning, it should have resulted in a failure to show a section line separator in the context menu when clearHistory is the sole option available, but it doesn't anyhow:

https://github.com/status-im/status-desktop/blob/17965d01952a303b2a6c3ea510d54f16cabdd109/ui/imports/shared/views/chat/ChatContextMenuView.qml#L199-L201