### PR TITLE
fix(shared-addresses): wrong account color and type

### DIFF
--- a/storybook/src/Models/WalletAccountsModel.qml
+++ b/storybook/src/Models/WalletAccountsModel.qml
@@ -94,7 +94,7 @@ ListModel {
         {
             name: "Tag Heuer (watch)",
             emoji: "⌚",
-            colorId: Constants.walletAccountColors.cooper,
+            colorId: Constants.walletAccountColors.copper,
             color: "#CB6256",
             address: "0x7F47C2e98a4BBf5487E6fb082eC2D9Ab0E6d8883",
             walletType: Constants.watchWalletType,

--- a/ui/app/AppLayouts/Chat/ChatLayout.qml
+++ b/ui/app/AppLayouts/Chat/ChatLayout.qml
@@ -158,7 +158,7 @@ StackLayout {
         sourceComponent: CommunitySettingsView {
             id: communitySettingsView
             rootStore: root.rootStore
-            walletAccountsModel: WalletStore.RootStore.watchOnlyAccounts
+            walletAccountsModel: WalletStore.RootStore.nonWatchAccounts
 
             chatCommunitySectionModule: root.rootStore.chatCommunitySectionModule
             community: sectionItemModel
@@ -185,7 +185,7 @@ StackLayout {
             property string communityId
 
             loginType: root.rootStore.loginType
-            walletAccountsModel: WalletStore.RootStore.watchOnlyAccounts
+            walletAccountsModel: WalletStore.RootStore.nonWatchAccounts
             permissionsModel: {
                 root.rootStore.prepareTokenModelForCommunity(communityIntroDialog.communityId)
                 return root.rootStore.permissionsModel
@@ -221,5 +221,4 @@ StackLayout {
             }
         }
     }
-
 }

--- a/ui/app/AppLayouts/Communities/views/CommunityColumnView.qml
+++ b/ui/app/AppLayouts/Communities/views/CommunityColumnView.qml
@@ -125,7 +125,7 @@ Item {
                 imageSrc: communityData.image
                 accessType: communityData.access
                 loginType: root.store.loginType
-                walletAccountsModel: WalletStore.RootStore.watchOnlyAccounts
+                walletAccountsModel: WalletStore.RootStore.nonWatchAccounts
                 permissionsModel: {
                     root.store.prepareTokenModelForCommunity(communityData.id)
                     return root.store.permissionsModel

--- a/ui/app/AppLayouts/Communities/views/HoldingsSelectionModel.qml
+++ b/ui/app/AppLayouts/Communities/views/HoldingsSelectionModel.qml
@@ -33,7 +33,7 @@ SortFilterProxyModel {
                             : collectiblesModel
                 const item = PermissionsHelpers.getTokenByKey(model, key)
 
-                return item ? item.shortName || item.name : ""
+                return item ? item.symbol || item.shortName || item.name : ""
             }
 
             function getText(type, key, amount) {

--- a/ui/app/AppLayouts/Profile/stores/WalletStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/WalletStore.qml
@@ -11,6 +11,7 @@ QtObject {
     property var collectibles: root.walletModule.collectiblesModel
 
     property var accountSensitiveSettings: Global.appIsReady? localAccountSensitiveSettings : null
+    property var dappList: Global.appIsReady? dappPermissionsModule.dapps : null
 
     readonly property bool areTestNetworksEnabled: networksModule.areTestNetworksEnabled
     readonly property var networks: networksModule.networks

--- a/ui/app/AppLayouts/Profile/views/CommunitiesView.qml
+++ b/ui/app/AppLayouts/Profile/views/CommunitiesView.qml
@@ -233,7 +233,7 @@ SettingsContentBase {
             }
 
             loginType: chatStore.loginType
-            walletAccountsModel: WalletStore.RootStore.watchOnlyAccounts
+            walletAccountsModel: WalletStore.RootStore.nonWatchAccounts
             permissionsModel: {
                 root.rootStore.prepareTokenModelForCommunity(communityIntroDialog.communityId)
                 return root.rootStore.permissionsModel

--- a/ui/app/AppLayouts/Wallet/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Wallet/stores/RootStore.qml
@@ -44,7 +44,7 @@ QtObject {
         ]
     }
 
-    property var watchOnlyAccounts: SortFilterProxyModel {
+    property var nonWatchAccounts: SortFilterProxyModel {
         sourceModel: receiveAccounts
         proxyRoles: [
             ExpressionRole {

--- a/ui/app/AppLayouts/Wallet/views/TransactionDetailView.qml
+++ b/ui/app/AppLayouts/Wallet/views/TransactionDetailView.qml
@@ -356,7 +356,7 @@ Item {
                         // Used for Bridge to display 'To' network Protocol contract address
                         address: "" // TODO fill protocol contract address for 'to' network for Bridge
                         symbol: "" // TODO fill protocol name for Bridge
-                        networkName: transactionHeader.networknameOut
+                        networkName: transactionHeader.networkNameOut
                         shortNetworkName: d.networkShortNameOut
                         visible: !!subTitle && d.transactionType === Constants.TransactionType.Bridge
                     }

--- a/ui/app/AppLayouts/stores/RootStore.qml
+++ b/ui/app/AppLayouts/stores/RootStore.qml
@@ -42,7 +42,7 @@ QtObject {
 
     readonly property var permissionsModel: !!root.communitiesModuleInst.spectatedCommunityPermissionModel ?
                                      root.communitiesModuleInst.spectatedCommunityPermissionModel : null
-    property var walletAccountsModel: WalletStore.RootStore.watchOnlyAccounts
+    property var walletAccountsModel: WalletStore.RootStore.nonWatchAccounts
     property var assetsModel: SortFilterProxyModel {
         sourceModel: communitiesModuleInst.tokenList
         proxyRoles: ExpressionRole {

--- a/ui/app/mainui/Popups.qml
+++ b/ui/app/mainui/Popups.qml
@@ -712,7 +712,7 @@ QtObject {
                 //selectedSharedAddresses: [???]
                 //selectedAirdropAddress: "???"
                 loginType: chatStore.loginType
-                walletAccountsModel: WalletStore.RootStore.receiveAccounts
+                walletAccountsModel: root.rootStore.walletAccountsModel
                 permissionsModel: {
                     root.rootStore.prepareTokenModelForCommunity(editSharedAddressesPopup.communityId)
                     return root.rootStore.permissionsModel


### PR DESCRIPTION
- rename `watchOnlyAccounts` to `nonWatchAccounts` to reflect what the property returns
- some warning fixes

Fixes #12023

### What does the PR do

Fixes wrong account colors and type

### Affected areas

SharedAddressesAccountSelector

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

Accounts have the correct color and watch-only accounts are not displayed:
![image](https://github.com/status-im/status-desktop/assets/5377645/3c15d206-7ea4-4f85-bf8d-f31c7ce582c1)
