### PR TITLE
fix(BurnTokensPopup): Handle non-integer values for assets 

### DIFF
--- a/storybook/figma.json
+++ b/storybook/figma.json
@@ -28,9 +28,7 @@
         "https://www.figma.com/file/idUoxN7OIW2Jpp3PMJ1Rl8/%E2%9A%99%EF%B8%8F-Settings-%7C-Desktop?node-id=1573%3A296338"
     ],
     "BurnTokensPopup": [
-        "https://www.figma.com/file/17fc13UBFvInrLgNUKJJg5/Kuba%E2%8E%9CDesktop?type=design&node-id=29528%3A588403&t=GUxMZEWcfRO7pXJb-1",
-        "https://www.figma.com/file/17fc13UBFvInrLgNUKJJg5/Kuba%E2%8E%9CDesktop?type=design&node-id=29528%3A588563&t=GUxMZEWcfRO7pXJb-1",
-        "https://www.figma.com/file/17fc13UBFvInrLgNUKJJg5/Kuba%E2%8E%9CDesktop?type=design&node-id=29528%3A587660&t=GUxMZEWcfRO7pXJb-1"
+        "https://www.figma.com/file/qHfFm7C9LwtXpfdbxssCK3/Kuba%E2%8E%9CDesktop---Communities?type=design&node-id=35082-612599&mode=design&t=XTDQ4GeU1k9LPuVK-0"
     ],
     "ChatAnchorButtonsPanel": [
         "https://www.figma.com/file/Mr3rqxxgKJ2zMQ06UAKiWL/%F0%9F%92%AC-Chat%E2%8E%9CDesktop?node-id=14632-460085&t=SGTU2JeRA8ifbv2E-0"

--- a/storybook/pages/BurnTokensPopupPage.qml
+++ b/storybook/pages/BurnTokensPopupPage.qml
@@ -44,23 +44,49 @@ SplitView {
                 anchors.centerIn: parent
                 text: "Reopen"
 
-                onClicked: dialog.open()
+                onClicked: burnTokensPopup.open()
             }
 
             BurnTokensPopup {
-                id: dialog
+                id: burnTokensPopup
 
                 anchors.centerIn: parent
+                visible: true
+                modal: false
+                closePolicy: Popup.NoAutoClose
+
                 communityName: editorCommunity.text
                 tokenName: editorToken.text
                 remainingTokens: editorAmount.text
+                multiplierIndex: assetButton.checked ? 18 : 0
                 isAsset: assetButton.checked
-                tokenSource: assetButton.checked ? ModelsData.assets.socks :  ModelsData.collectibles.kitty1Big
+                tokenSource: assetButton.checked
+                             ? ModelsData.assets.socks
+                             : ModelsData.collectibles.kitty1Big
                 accounts: accountsModel
                 chainName: "Optimism"
 
                 onBurnClicked: logs.logEvent("BurnTokensPopup::onBurnClicked --> Burn amount: " + burnAmount)
                 onCancelClicked: logs.logEvent("BurnTokensPopup::onCancelClicked")
+
+                onBurnFeesRequested: {
+                    feeText = ""
+                    feeErrorText = ""
+                    isFeeLoading = true
+
+                    feeCalculationTimer.restart()
+                }
+            }
+
+            Timer {
+                id: feeCalculationTimer
+
+                interval: 1000
+
+                onTriggered: {
+                    burnTokensPopup.feeText = "0.0015 ETH ($75.43)"
+                    burnTokensPopup.isFeeLoading = false
+                }
             }
         }
 
@@ -79,6 +105,7 @@ SplitView {
         SplitView.preferredWidth: 300
 
         ColumnLayout {
+            anchors.fill: parent
 
             Label {
                 Layout.fillWidth: true
@@ -87,8 +114,8 @@ SplitView {
 
             TextField {
                 id: editorCommunity
-                background: Rectangle { border.color: 'lightgrey' }
-                Layout.preferredWidth: 200
+
+                Layout.fillWidth: true
                 text: "Community lovers"
             }
 
@@ -101,8 +128,8 @@ SplitView {
 
             TextField {
                 id: editorToken
-                background: Rectangle { border.color: 'lightgrey' }
-                Layout.preferredWidth: 200
+
+                Layout.fillWidth: true
                 text: "Anniversary"
             }
 
@@ -115,8 +142,8 @@ SplitView {
 
             TextField {
                 id: editorAmount
-                background: Rectangle { border.color: 'lightgrey' }
-                Layout.preferredWidth: 200
+
+                Layout.fillWidth: true
                 text: "123"
             }
 
@@ -138,6 +165,10 @@ SplitView {
                 id: collectibleButton
 
                 text: "Collectible"
+            }
+
+            Item {
+                Layout.fillHeight: true
             }
         }
     }

--- a/ui/StatusQ/src/StatusQ/Controls/StatusRadioButton.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusRadioButton.qml
@@ -49,5 +49,6 @@ RadioButton {
         leftPadding: root.indicator && !root.mirrored ? root.indicator.width + root.spacing : 0
         rightPadding: root.indicator && root.mirrored ? root.indicator.width + root.spacing : 0
         visible: !!text
+        wrapMode: Text.Wrap
     }
 }

--- a/ui/imports/shared/controls/AmountInput.qml
+++ b/ui/imports/shared/controls/AmountInput.qml
@@ -21,6 +21,11 @@ Input {
 
     property bool validateMaximumAmount: false
     property string maximumAmount: "0"
+    property bool allowZero: true
+
+    property alias labelText: labelText.text
+
+    property string maximumExceededErrorText: qsTr("Amount exceeds balance")
 
     validationErrorTopMargin: 8
     fontPixelSize: 13
@@ -79,6 +84,12 @@ Input {
                 return
             }
 
+            if (!root.allowZero && amountNumber === 0) {
+                d.amount = "0"
+                root.validationError = qsTr("Amount must be greater than 0")
+                return
+            }
+
             const amount = SQUtils.AmountsArithmetic.fromNumber(
                              amountNumber, d.multiplierIndex)
 
@@ -90,7 +101,7 @@ Input {
                                       amount, maximumAmount) === 1
 
                 if (SQUtils.AmountsArithmetic.cmp(amount, maximumAmount) === 1) {
-                    root.validationError = qsTr("Amount exceeds balance")
+                    root.validationError = root.maximumExceededErrorText
                     return
                 }
             }


### PR DESCRIPTION
### What does the PR do

- Support for non-integer values in `BurnTokensPopup`
- validation fixed
- Setting wrap to StatusRadioButton
- `AmountInput` - added possibility to customize err msg for exceeding max and label  and flag for zero as valid input

### Affected areas

`BurnTokensPopup`, `StatusRadioButton`, `AmountInput`

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

[Kazam_screencast_00018.webm](https://github.com/status-im/status-desktop/assets/20650004/491422b2-ae86-4063-bfb6-5694979cc058)

