### PR TITLE
fix(Communities): Align Constants.CommunityMembershipRequestState with backend

### DIFF
--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -1156,9 +1156,8 @@ QtObject {
     enum CommunityMembershipRequestState {
         None = 0,
         Pending,
-        Rejected,
         Accepted,
-        Canceled,
+        Rejected,
         AcceptedPending,
         RejectedPending,
         Banned,


### PR DESCRIPTION
### What does the PR do

Aligns UI constants with backend counterpart.

Closes: #12042 

### Affected areas
`Constants.qml`

### Screenshot of functionality (including design for comparison)

![Screenshot from 2023-08-31 15-46-23](https://github.com/status-im/status-desktop/assets/20650004/97c0f831-6d04-4deb-9e2f-9335e6864807)
