### PR TITLE
feat(ChatContextMenu): Add confirmation dialog when the user tries to leave a group chat

### DIFF
--- a/ui/imports/shared/views/chat/ChatContextMenuView.qml
+++ b/ui/imports/shared/views/chat/ChatContextMenuView.qml
@@ -231,7 +231,7 @@ StatusMenu {
         type: StatusAction.Type.Danger
         onTriggered: {
             if (root.chatType === Constants.chatType.privateGroupChat) {
-                root.leaveChat(root.chatId);
+                Global.openPopup(leaveGroupConfirmationDialogComponent);
             } else {
                 Global.openPopup(deleteChatConfirmationDialogComponent);
             }
@@ -271,6 +271,29 @@ StatusMenu {
             }
             onConfirmButtonClicked: {
                 root.clearChatHistory(root.chatId)
+                close()
+            }
+        }
+    }
+
+    Component {
+        id: leaveGroupConfirmationDialogComponent
+        ConfirmationDialog {
+            confirmButtonObjectName: "leaveGroupConfirmationDialogLeaveButton"
+            headerSettings.title: qsTr("Leave group")
+            confirmationText: qsTr("Are you sure you want to leave group chat <b>%1</b>?").arg(root.chatName)
+            confirmButtonLabel: qsTr("Leave")
+            showCancelButton: true
+            cancelBtnType: "normal"
+
+            onClosed: {
+                destroy()
+            }
+            onCancelButtonClicked: {
+                close()
+            }
+            onConfirmButtonClicked: {
+                root.leaveChat(root.chatId)
                 close()
             }
         }


### PR DESCRIPTION
### What does the PR do

Since leaving a private group chat is not easily reversible, confirm the user's intent, just as we do with deleting chat history or a 1-to-1 chat.

### Screenshot of functionality (including design for comparison)

<img width="723" alt="SCR-20230831-oucg" src="https://github.com/status-im/status-desktop/assets/544446/4d53fdf2-5cb2-4f2c-9b73-58370f64b808">

Closes #11998 