### PR TITLE
feat(Communities): Integrate kick/ban actions with token holders list

### DIFF
--- a/storybook/pages/KickBanPopupPage.qml
+++ b/storybook/pages/KickBanPopupPage.qml
@@ -1,0 +1,111 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+import Storybook 1.0
+
+import AppLayouts.Communities.popups 1.0
+
+
+SplitView {
+    Logs { id: logs }
+
+    orientation: Qt.Vertical
+    SplitView.fillWidth: true
+
+    Item {
+        SplitView.fillWidth: true
+        SplitView.fillHeight: true
+
+        PopupBackground {
+            anchors.fill: parent
+        }
+
+        Button {
+            anchors.centerIn: parent
+            text: "Reopen"
+
+            onClicked: dialog.open()
+        }
+
+        KickBanPopup {
+            id: dialog
+
+            mode: modesButtonGroup.checkedButton.mode
+            username: usernameTextField.text
+            communityName: communityNameTextField.text
+
+            closePolicy: Popup.NoAutoClose
+            visible: true
+            modal: false
+            destroyOnClose: false
+            anchors.centerIn: parent
+
+            onAccepted: logs.logEvent("KickBanPopup::accepted")
+        }
+    }
+
+    LogsAndControlsPanel {
+        id: logsAndControlsPanel
+
+        SplitView.minimumHeight: 100
+        SplitView.preferredHeight: 250
+
+        logsView.logText: logs.logText
+
+        ColumnLayout {
+            ButtonGroup {
+                id: modesButtonGroup
+
+                buttons: modesRow.children
+            }
+
+            RowLayout {
+                id: modesRow
+
+                RadioButton {
+                    readonly property int mode: KickBanPopup.Mode.Kick
+
+                    text: "Kick"
+                    checked: true
+                }
+
+                RadioButton {
+                    readonly property int mode: KickBanPopup.Mode.Ban
+
+                    text: "Ban"
+                }
+            }
+
+            MenuSeparator {
+                Layout.fillWidth: true
+            }
+
+            RowLayout {
+                Label {
+                    text: "Username:"
+                }
+
+                TextField {
+                    id: usernameTextField
+
+                    text: "John"
+                }
+            }
+
+            RowLayout {
+                Label {
+                    text: "Community:"
+                }
+
+                TextField {
+                    id: communityNameTextField
+
+                    text: "CryptoKitties"
+                }
+            }
+        }
+    }
+}
+
+// category: Popups

--- a/ui/app/AppLayouts/Communities/panels/MembersSettingsPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/MembersSettingsPanel.qml
@@ -1,17 +1,11 @@
 import QtQuick 2.15
 import QtQuick.Layouts 1.15
-import QtQuick.Controls 2.15
 
-import StatusQ.Core 0.1
-import StatusQ.Core.Theme 0.1
 import StatusQ.Controls 0.1
-import StatusQ.Components 0.1
-import StatusQ.Popups 0.1
-
 import utils 1.0
-import shared.controls.chat 1.0
 
 import AppLayouts.Communities.layouts 1.0
+import AppLayouts.Communities.popups 1.0
 
 SettingsPage {
     id: root
@@ -121,15 +115,17 @@ SettingsPage {
                 Layout.fillHeight: true
 
                 onKickUserClicked: {
-                    kickModal.userNameToKick = name
-                    kickModal.userIdToKick = id
-                    kickModal.open()
+                    kickBanPopup.mode = KickBanPopup.Mode.Kick
+                    kickBanPopup.username = name
+                    kickBanPopup.userId = id
+                    kickBanPopup.open()
                 }
 
                 onBanUserClicked: {
-                    banModal.userNameToBan = name
-                    banModal.userIdToBan = id
-                    banModal.open()
+                    kickBanPopup.mode = KickBanPopup.Mode.Ban
+                    kickBanPopup.username = name
+                    kickBanPopup.userId = id
+                    kickBanPopup.open()
                 }
             }
 
@@ -190,85 +186,18 @@ SettingsPage {
         }
     }
 
-    StatusModal {
-        id: banModal
+    KickBanPopup {
+        id: kickBanPopup
 
-        property string userNameToBan: ""
-        property string userIdToBan: ""
+        property string userId
 
-        readonly property string text: qsTr("Are you sure you ban <b>%1</b> from %2?").arg(userNameToBan).arg(root.communityName)
+        communityName: root.communityName
 
-        anchors.centerIn: parent
-        width: 400
-        headerSettings.title: qsTr("Ban %1").arg(userNameToBan)
-
-        contentItem: StatusBaseText {
-            id: banContentText
-            anchors.centerIn: parent
-            font.pixelSize: 15
-            color: Theme.palette.directColor1
-            padding: 15
-            wrapMode: Text.WordWrap
-            text: banModal.text
+        onAccepted: {
+            if (mode === KickBanPopup.Mode.Kick)
+                root.kickUserClicked(userId)
+            else
+                root.banUserClicked(userId)
         }
-
-        rightButtons: [
-            StatusButton {
-                text: qsTr("Cancel")
-                onClicked: banModal.close()
-                normalColor: "transparent"
-                hoverColor: "transparent"
-            },
-            StatusButton {
-                id: banButton
-                text: qsTr("Ban")
-                type: StatusBaseButton.Type.Danger
-                onClicked: {
-                    root.banUserClicked(banModal.userIdToBan)
-                    banModal.close()
-                }
-            }
-        ]
-    }
-
-    StatusModal {
-        id: kickModal
-
-        property string userNameToKick: ""
-        property string userIdToKick: ""
-
-        readonly property string text : qsTr("Are you sure you kick <b>%1</b> from %2?").arg(userNameToKick).arg(communityName)
-
-        anchors.centerIn: parent
-        width: 400
-        headerSettings.title: qsTr("Kick %1").arg(userNameToKick)
-
-        contentItem: StatusBaseText {
-            id: kickContentText
-            anchors.centerIn: parent
-            font.pixelSize: 15
-            color: Theme.palette.directColor1
-            padding: 15
-            wrapMode: Text.WordWrap
-            text: kickModal.text
-        }
-
-        rightButtons: [
-            StatusButton {
-                text: qsTr("Cancel")
-                onClicked: kickModal.close()
-                normalColor: "transparent"
-                hoverColor: "transparent"
-            },
-            StatusButton {
-                objectName: "CommunityMembers_KickModal_KickButton"
-                text: qsTr("Kick")
-                type: StatusBaseButton.Type.Danger
-                onClicked: {
-                    root.kickUserClicked(kickModal.userIdToKick)
-                    kickModal.close()
-                }
-            }
-        ]
     }
 }

--- a/ui/app/AppLayouts/Communities/panels/MintTokensSettingsPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/MintTokensSettingsPanel.qml
@@ -65,6 +65,9 @@ StackView {
     signal mintAsset(var assetItem)
     signal mintOwnerToken(var ownerToken, var tMasterToken)
 
+    signal kickUserRequested(string contactId)
+    signal banUserRequested(string contactId)
+
     signal deployFeesRequested(int chainId, string accountAddress, int tokenType)
     signal burnFeesRequested(string tokenKey, string amount, string accountAddress)
     signal remotelyDestructFeesRequest(var walletsAndAmounts, // { [walletAddress (string), amount (int)] }
@@ -551,13 +554,19 @@ StackView {
             }
 
             onBanRequested: {
-                tokenMasterActionPopup.openPopup(
-                            TokenMasterActionPopup.ActionType.Ban, name)
+                if (token.isPrivilegedToken)
+                    tokenMasterActionPopup.openPopup(
+                                TokenMasterActionPopup.ActionType.Ban, name)
+                else
+                    kickBanPopup.openPopup(KickBanPopup.Mode.Ban, name, contactId)
             }
 
             onKickRequested: {
-                tokenMasterActionPopup.openPopup(
-                            TokenMasterActionPopup.ActionType.Kick, name)
+                if (token.isPrivilegedToken)
+                    tokenMasterActionPopup.openPopup(
+                                TokenMasterActionPopup.ActionType.Kick, name)
+                else
+                    kickBanPopup.openPopup(KickBanPopup.Mode.Kick, name, contactId)
             }
 
             TokenMasterActionPopup {
@@ -571,6 +580,28 @@ StackView {
                 function openPopup(type, userName) {
                     tokenMasterActionPopup.actionType = type
                     tokenMasterActionPopup.userName = userName
+                    open()
+                }
+            }
+
+            KickBanPopup {
+                id: kickBanPopup
+
+                property string contactId
+
+                communityName: root.communityName
+
+                onAccepted: {
+                    if (mode === KickBanPopup.Mode.Kick)
+                        root.kickUserRequested(contactId)
+                    else
+                        root.banUserRequested(contactId)
+                }
+
+                function openPopup(mode, userName, contactId) {
+                    kickBanPopup.mode = mode
+                    kickBanPopup.username = userName
+                    kickBanPopup.contactId = contactId
                     open()
                 }
             }

--- a/ui/app/AppLayouts/Communities/panels/SortableTokenHoldersPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/SortableTokenHoldersPanel.qml
@@ -31,8 +31,8 @@ Control {
     signal viewMessagesRequested(string contactId)
     signal airdropRequested(string address)
     signal remoteDestructRequested(string name, string address)
-    signal kickRequested(string name, string address)
-    signal banRequested(string name, string address)
+    signal kickRequested(string name, string contactId)
+    signal banRequested(string name, string contactId)
 
     signal generalAirdropRequested
 
@@ -202,8 +202,7 @@ Control {
             enabled: !menu.rawAddress
             type: StatusBaseButton.Type.Danger
 
-            onTriggered: root.kickRequested(menu.name,
-                                            menu.currentAddress)
+            onTriggered: root.kickRequested(menu.name, menu.contactId)
         }
 
         StatusAction {
@@ -214,8 +213,7 @@ Control {
             enabled: !menu.rawAddress
             type: StatusBaseButton.Type.Danger
 
-            onTriggered: root.banRequested(menu.name,
-                                           menu.currentAddress)
+            onTriggered: root.banRequested(menu.name, menu.contactId)
         }
     }
 }

--- a/ui/app/AppLayouts/Communities/popups/KickBanPopup.qml
+++ b/ui/app/AppLayouts/Communities/popups/KickBanPopup.qml
@@ -1,0 +1,64 @@
+import QtQuick 2.15
+import QtQml.Models 2.15
+
+import StatusQ.Controls 0.1
+import StatusQ.Core 0.1
+import StatusQ.Popups.Dialog 0.1
+
+import utils 1.0
+
+
+StatusDialog {
+    id: root
+
+    property string username: ""
+    property string communityName: ""
+    property int mode: KickBanPopup.Mode.Kick
+
+    enum Mode {
+        Kick, Ban
+    }
+
+    width: 400
+
+    title: root.mode === KickBanPopup.Mode.Kick
+           ? qsTr("Kick %1").arg(root.username)
+           : qsTr("Ban %1").arg(root.username)
+
+    contentItem: StatusBaseText {
+        anchors.centerIn: parent
+        font.pixelSize: Style.current.primaryTextFontSize
+        wrapMode: Text.Wrap
+
+        text: root.mode === KickBanPopup.Mode.Kick
+              ? qsTr("Are you sure you kick <b>%1</b> from %2?")
+                .arg(root.username).arg(root.communityName)
+              : qsTr("Are you sure you ban <b>%1</b> from %2?")
+                .arg(root.username).arg(root.communityName)
+    }
+
+    footer: StatusDialogFooter {
+        rightButtons: ObjectModel {
+            StatusFlatButton {
+                text: qsTr("Cancel")
+
+                onClicked: root.close()
+            }
+            StatusButton {
+                id: banButton
+
+                objectName: root.mode === KickBanPopup.Mode.Kick
+                            ? "CommunityMembers_KickModal_KickButton"
+                            : "CommunityMembers_BanModal_BanButton"
+
+                text: root.mode === KickBanPopup.Mode.Kick ? qsTr("Kick")
+                                                           : qsTr("Ban")
+                type: StatusBaseButton.Type.Danger
+                onClicked: {
+                    root.accept()
+                    root.close()
+                }
+            }
+        }
+    }
+}

--- a/ui/app/AppLayouts/Communities/popups/qmldir
+++ b/ui/app/AppLayouts/Communities/popups/qmldir
@@ -10,6 +10,7 @@ HoldingsDropdown 1.0 HoldingsDropdown.qml
 ImportControlNodePopup 1.0 ImportControlNodePopup.qml
 InDropdown 1.0 InDropdown.qml
 InviteFriendsToCommunityPopup 1.0 InviteFriendsToCommunityPopup.qml
+KickBanPopup 1.0 KickBanPopup.qml
 MembersDropdown 1.0 MembersDropdown.qml
 PermissionsDropdown 1.0 PermissionsDropdown.qml
 RecipientTypeSelectionDropdown 1.0 RecipientTypeSelectionDropdown.qml

--- a/ui/app/AppLayouts/Communities/views/CommunitySettingsView.qml
+++ b/ui/app/AppLayouts/Communities/views/CommunitySettingsView.qml
@@ -410,6 +410,9 @@ StatusSectionLayout {
                 // Set given addresses as recipients
                 airdropPanel.addAddresses(addresses)
             }
+
+            onKickUserRequested: root.rootStore.removeUserFromCommunity(contactId)
+            onBanUserRequested: root.rootStore.banUserFromCommunity(contactId)
         }
 
         AirdropsSettingsPanel {

--- a/ui/app/AppLayouts/Communities/views/CommunityTokenView.qml
+++ b/ui/app/AppLayouts/Communities/views/CommunityTokenView.qml
@@ -71,8 +71,8 @@ StatusScrollView {
     signal viewMessagesRequested(string contactId)
 
     signal remoteDestructRequested(string name, string address)
-    signal kickRequested(string name, string address)
-    signal banRequested(string name, string address)
+    signal kickRequested(string name, string contactId)
+    signal banRequested(string name, string contactId)
 
     signal deployFeesRequested
 
@@ -217,8 +217,8 @@ StatusScrollView {
             onGeneralAirdropRequested: root.generalAirdropRequested()
             onRemoteDestructRequested: root.remoteDestructRequested(name, address)
 
-            onKickRequested: root.kickRequested(name, address)
-            onBanRequested: root.banRequested(name, address)
+            onKickRequested: root.kickRequested(name, contactId)
+            onBanRequested: root.banRequested(name, contactId)
         }
     }
 }


### PR DESCRIPTION
### What does the PR do

Closes: #11033

Integrates kick/ban actions with token holders list

Moreover:
- kick/ban popup refactored and moved to a separate file
- position of the popup fixed
- storybook page added

### Affected areas
`MembersSettingsPanel`, `MintTokensSettingsPanel`
<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

[Kazam_screencast_00022.webm](https://github.com/status-im/status-desktop/assets/20650004/0be2f96c-7359-426a-aaf0-6d31b420db89)

