### PR TITLE
refactor(section_details): simplify section_details to only contain needed props

### DIFF
--- a/src/app/modules/main/communities/view.nim
+++ b/src/app/modules/main/communities/view.nim
@@ -1,7 +1,7 @@
 import NimQml, json, strutils, sequtils
 
 import ./io_interface
-import ../../shared_models/[section_model, section_item, section_details, token_list_model, token_list_item,
+import ../../shared_models/[section_model, section_item, token_list_model, token_list_item,
   token_permissions_model]
 import ./models/curated_community_model
 import ./models/discord_file_list_model

--- a/src/app/modules/main/controller.nim
+++ b/src/app/modules/main/controller.nim
@@ -270,30 +270,6 @@ proc init*(self: Controller) =
     var args = ResolvedContactArgs(e)
     self.delegate.resolvedENS(args.pubkey, args.address, args.uuid, args.reason)
 
-  self.events.on(SIGNAL_CONTACT_UPDATED) do(e: Args):
-    var args = ContactArgs(e)
-    self.delegate.contactUpdated(args.contactId)
-
-  self.events.on(SIGNAL_CONTACTS_STATUS_UPDATED) do(e: Args):
-    let args = ContactsStatusUpdatedArgs(e)
-    self.delegate.contactsStatusUpdated(args.statusUpdates)
-
-  self.events.on(SIGNAL_CONTACT_NICKNAME_CHANGED) do(e: Args):
-    var args = ContactArgs(e)
-    self.delegate.contactUpdated(args.contactId)
-
-  self.events.on(SIGNAL_CONTACT_UNTRUSTWORTHY) do(e: Args):
-    var args = TrustArgs(e)
-    self.delegate.contactUpdated(args.publicKey)
-
-  self.events.on(SIGNAL_CONTACT_TRUSTED) do(e: Args):
-    var args = TrustArgs(e)
-    self.delegate.contactUpdated(args.publicKey)
-
-  self.events.on(SIGNAL_REMOVED_TRUST_STATUS) do(e: Args):
-    var args = TrustArgs(e)
-    self.delegate.contactUpdated(args.publicKey)
-
   self.events.on(SIGNAL_MNEMONIC_REMOVED) do(e: Args):
     self.delegate.mnemonicBackedUp()
 

--- a/src/app/modules/main/io_interface.nim
+++ b/src/app/modules/main/io_interface.nim
@@ -168,12 +168,6 @@ method communityLeft*(self: AccessInterface, communityId: string) {.base.} =
 method resolvedENS*(self: AccessInterface, publicKey: string, address: string, uuid: string, reason: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method contactsStatusUpdated*(self: AccessInterface, statusUpdates: seq[StatusUpdateDto]) {.base.} =
-  raise newException(ValueError, "No implementation available")
-
-method contactUpdated*(self: AccessInterface, publicKey: string) {.base.} =
-  raise newException(ValueError, "No implementation available")
-
 method mnemonicBackedUp*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -10,7 +10,7 @@ import ../../global/app_sections_config as conf
 import ../../global/app_signals
 import ../../global/global_singleton
 import ../../global/utils as utils
-import ../../../constants as main_constants
+import ../../../constants
 
 import chat_section/model as chat_model
 import chat_section/item as chat_item
@@ -479,7 +479,7 @@ method load*[T](
     hasNotification = false,
     notificationsCount = 0,
     active = false,
-    enabled = main_constants.WALLET_ENABLED,
+    enabled = WALLET_ENABLED,
   )
   self.view.model().addItem(walletSectionItem)
   if(activeSectionId == walletSectionItem.id):
@@ -1052,11 +1052,6 @@ method resolvedENS*[T](self: Module[T], publicKey: string, address: string, uuid
   else:
     self.view.emitResolvedENSSignal(publicKey, address, uuid)
 
-method contactsStatusUpdated*[T](self: Module[T], statusUpdates: seq[StatusUpdateDto]) =
-  for s in statusUpdates:
-    let status = toOnlineStatus(s.statusType)
-    self.view.activeSection().setOnlineStatusForMember(s.publicKey, status)
-
 method onCommunityTokenDeploymentStarted*[T](self: Module[T], communityToken: CommunityTokenDto) =
   let item = self.view.model().getItemById(communityToken.communityId)
   if item.id != "":
@@ -1137,21 +1132,6 @@ method onAcceptRequestToJoinSuccess*[T](self: Module[T], communityId: string, me
   let item = self.view.model().getItemById(communityId)
   if item.id != "":
     item.updatePendingRequestLoadingState(memberKey, false)
-
-method contactUpdated*[T](self: Module[T], publicKey: string) =
-  let contactDetails = self.controller.getContactDetails(publicKey)
-  self.view.activeSection().updateMember(
-    publicKey,
-    contactDetails.dto.displayName,
-    contactDetails.dto.name,
-    contactDetails.dto.ensVerified,
-    contactDetails.dto.localNickname,
-    contactDetails.dto.alias,
-    contactDetails.icon,
-    isContact = contactDetails.dto.isContact,
-    isVerified = contactDetails.dto.isContactVerified(),
-    isUntrustworthy = contactDetails.dto.isContactUntrustworthy(),
-    )
 
 method calculateProfileSectionHasNotification*[T](self: Module[T]): bool =
   return not self.controller.isMnemonicBackedUp()

--- a/src/app/modules/main/view.nim
+++ b/src/app/modules/main/view.nim
@@ -24,7 +24,7 @@ QtObject:
       ephemeralNotificationModelVariant: QVariant
       tmpCommunityId: string # shouldn't be used anywhere except in prepareCommunitySectionModuleForCommunityId/getCommunitySectionModule procs
 
-  proc activeSectionChanged*(self:View) {.signal.}
+  proc activeSectionSet*(self: View, item: SectionItem)
 
   proc delete*(self: View) =
     self.model.delete
@@ -61,7 +61,7 @@ QtObject:
   proc editItem*(self: View, item: SectionItem) =
     self.model.editItem(item)
     if (self.activeSection.getId() == item.id):
-      self.activeSection.setActiveSectionData(item)
+      self.activeSectionSet(item)
 
   proc model*(self: View): SectionModel =
     return self.model
@@ -127,6 +127,8 @@ QtObject:
 
   proc activeSection*(self: View): SectionDetails =
     return self.activeSection
+
+  proc activeSectionChanged*(self:View) {.signal.}
 
   proc getActiveSection(self: View): QVariant {.slot.} =
     return self.activeSectionVariant

--- a/src/app/modules/shared_models/section_details.nim
+++ b/src/app/modules/shared_models/section_details.nim
@@ -1,12 +1,11 @@
 import NimQml
 import section_item
-import ../../../app_service/service/contacts/dto/contacts
-
-import ../../../app_service/common/types
 
 QtObject:
   type SectionDetails* = ref object of QObject
-    item: SectionItem
+    id: string
+    sectionType: SectionType
+    joined: bool
 
   proc setup(self: SectionDetails) =
     self.QObject.setup
@@ -18,253 +17,25 @@ QtObject:
     new(result, delete)
     result.setup
 
-  proc membersChanged*(self: SectionDetails) {.signal.}
-  proc bannedMembersChanged*(self: SectionDetails) {.signal.}
-  proc pendingRequestsToJoinChanged*(self: SectionDetails) {.signal.}
-  proc pendingMemberRequestsChanged*(self: SectionDetails) {.signal.}
-  proc declinedMemberRequestsChanged*(self: SectionDetails) {.signal.}
-  proc communityTokensChanged*(self: SectionDetails) {.signal.}
-
   proc setActiveSectionData*(self: SectionDetails, item: SectionItem) =
-    self.item = item
-    self.membersChanged()
-    self.bannedMembersChanged()
-    self.pendingMemberRequestsChanged()
-    self.declinedMemberRequestsChanged()
-    self.pendingRequestsToJoinChanged()
-    self.communityTokensChanged()
+    self.id = item.id
+    self.sectionType = item.sectionType
+    self.joined = item.joined
 
   proc getId*(self: SectionDetails): string {.slot.} =
-    return self.item.id
+    return self.id
 
   QtProperty[string] id:
     read = getId
 
   proc getSectionType(self: SectionDetails): int {.slot.} =
-    return self.item.sectionType.int
+    return self.sectionType.int
 
   QtProperty[int] sectionType:
     read = getSectionType
 
-  proc getName(self: SectionDetails): string {.slot.} =
-    return self.item.name
-
-  QtProperty[string] name:
-    read = getName
-
-  proc getMemberRole(self: SectionDetails): int {.slot.} =
-    return self.item.memberRole.int
-
-  QtProperty[int] memberRole:
-    read = getMemberRole
-
-  proc description(self: SectionDetails): string {.slot.} =
-    return self.item.description
-
-  QtProperty[string] description:
-    read = description
-
-  proc introMessage(self: SectionDetails): string {.slot.} =
-    return self.item.introMessage
-
-  QtProperty[string] introMessage:
-    read = introMessage
-
-  proc outroMessage(self: SectionDetails): string {.slot.} =
-    return self.item.outroMessage
-
-  QtProperty[string] outroMessage:
-    read = outroMessage
-
-  proc getImage(self: SectionDetails): string {.slot.} =
-    return self.item.image
-
-  QtProperty[string] image:
-    read = getImage
-
-  proc getBannerImageData(self: SectionDetails): string {.slot.} =
-    return self.item.bannerImageData
-
-  QtProperty[string] bannerImageData:
-    read = getBannerImageData
-
-  proc getIcon(self: SectionDetails): string {.slot.} =
-    return self.item.icon
-
-  QtProperty[string] icon:
-    read = getIcon
-
-  proc getColor(self: SectionDetails): string {.slot.} =
-    return self.item.color
-
-  QtProperty[string] color:
-    read = getColor
-
-  proc getTags(self: SectionDetails): string {.slot.} =
-    return self.item.tags
-
-  QtProperty[string] tags:
-    read = getTags
-
-  proc getHasNotification(self: SectionDetails): bool {.slot.} =
-    return self.item.hasNotification
-
-  QtProperty[bool] hasNotification:
-    read = getHasNotification
-
-  proc getNotificationCount(self: SectionDetails): int {.slot.} =
-    return self.item.notificationsCount
-
-  QtProperty[int] notificationCount:
-    read = getNotificationCount
-
-  proc canJoin(self: SectionDetails): bool {.slot.} =
-    return self.item.canJoin
-
-  QtProperty[bool] canJoin:
-    read = canJoin
-
-  proc canRequestAccess(self: SectionDetails): bool {.slot.} =
-    return self.item.canRequestAccess
-
-  QtProperty[bool] canRequestAccess:
-    read = canRequestAccess
-
-  proc canManageUsers(self: SectionDetails): bool {.slot.} =
-    return self.item.canManageUsers
-
-  QtProperty[bool] canManageUsers:
-    read = canManageUsers
-
   proc getJoined(self: SectionDetails): bool {.slot.} =
-    return self.item.joined
+    return self.joined
 
   QtProperty[bool] joined:
     read = getJoined
-
-  proc getIsMember(self: SectionDetails): bool {.slot.} =
-    return self.item.isMember
-
-  QtProperty[bool] isMember:
-    read = getIsMember
-
-  proc access(self: SectionDetails): int {.slot.} =
-    return self.item.access
-
-  QtProperty[int] access:
-    read = access
-
-  proc ensOnly(self: SectionDetails): bool {.slot.} =
-    return self.item.ensOnly
-
-  QtProperty[bool] ensOnly:
-    read = ensOnly
-
-  proc historyArchiveSupportEnabled(self: SectionDetails): bool {.slot.} =
-    return self.item.historyArchiveSupportEnabled
-
-  QtProperty[bool] historyArchiveSupportEnabled:
-    read = historyArchiveSupportEnabled
-
-  proc pinMessageAllMembersEnabled(self: SectionDetails): bool {.slot.} =
-    return self.item.pinMessageAllMembersEnabled
-
-  QtProperty[bool] pinMessageAllMembersEnabled:
-    read = pinMessageAllMembersEnabled
-
-  proc encrypted(self: SectionDetails): bool {.slot.} =
-    return self.item.encrypted
-
-  QtProperty[bool] encrypted:
-    read = encrypted
-
-  proc members(self: SectionDetails): QVariant {.slot.} =
-    if (self.item.id == ""):
-      # FIXME (Jo) I don't know why but the Item is sometimes empty and doing anything here crashes the app
-      return newQVariant("")
-    return newQVariant(self.item.members)
-
-  QtProperty[QVariant] members:
-    read = members
-    notify = membersChanged
-
-
-  proc bannedMembers(self: SectionDetails): QVariant {.slot.} =
-    if (self.item.id == ""):
-      # FIXME (Jo) I don't know why but the Item is sometimes empty and doing anything here crashes the app
-      return newQVariant("")
-    return newQVariant(self.item.bannedMembers)
-
-  QtProperty[QVariant] bannedMembers:
-    read = bannedMembers
-    notify = bannedMembersChanged
-
-  proc communityTokens(self: SectionDetails): QVariant {.slot.} =
-    if (self.item.id == ""):
-      # FIXME (Jo) I don't know why but the Item is sometimes empty and doing anything here crashes the app
-      return newQVariant("")
-    return newQVariant(self.item.communityTokens)
-
-  QtProperty[QVariant] communityTokens:
-    read = communityTokens
-    notify = communityTokensChanged
-
-  proc amIBanned(self: SectionDetails): bool {.slot.} =
-    return self.item.amIBanned
-
-  QtProperty[bool] amIBanned:
-    read = amIBanned
-    notify = bannedMembersChanged
-
-  proc pendingMemberRequests(self: SectionDetails): QVariant {.slot.} =
-    if (self.item.id == ""):
-      # FIXME (Jo) I don't know why but the Item is sometimes empty and doing anything here crashes the app
-      return newQVariant("")
-    return newQVariant(self.item.pendingMemberRequests)
-
-  QtProperty[QVariant] pendingMemberRequests:
-    read = pendingMemberRequests
-    notify = pendingMemberRequestsChanged
-
-
-  proc declinedMemberRequests(self: SectionDetails): QVariant {.slot.} =
-    if (self.item.id == ""):
-      # FIXME (Jo) I don't know why but the Item is sometimes empty and doing anything here crashes the app
-      return newQVariant("")
-    return newQVariant(self.item.declinedMemberRequests)
-
-  QtProperty[QVariant] declinedMemberRequests:
-    read = declinedMemberRequests
-    notify = declinedMemberRequestsChanged
-
-  proc hasMember(self: SectionDetails, pubkey: string): bool {.slot.} =
-    return self.item.hasMember(pubkey)
-
-  proc setOnlineStatusForMember*(self: SectionDetails, pubKey: string,
-      onlineStatus: OnlineStatus) =
-    self.item.setOnlineStatusForMember(pubKey, onlineStatus)
-
-  proc updateMember*(
-      self: SectionDetails,
-      pubkey: string,
-      name: string,
-      ensName: string,
-      isEnsVerified: bool,
-      localNickname: string,
-      alias: string,
-      image: string,
-      isContact: bool,
-      isVerified: bool,
-      isUntrustworthy: bool) =
-    self.item.updateMember(pubkey, name, ensName, isEnsVerified, localNickname, alias, image, isContact,
-      isVerified, isUntrustworthy)
-
-  proc pendingRequestsToJoin(self: SectionDetails): QVariant {.slot.} =
-    if (self.item.id == ""):
-      # FIXME (Jo) I don't know why but the Item is sometimes empty and doing anything here crashes the app
-      return newQVariant("")
-    return newQVariant(self.item.pendingRequestsToJoin)
-
-  QtProperty[QVariant] pendingRequestsToJoin:
-    read = pendingRequestsToJoin
-    notify = pendingRequestsToJoinChanged

--- a/src/app/modules/shared_models/section_item.nim
+++ b/src/app/modules/shared_models/section_item.nim
@@ -286,8 +286,7 @@ proc members*(self: SectionItem): member_model.Model {.inline.} =
 proc hasMember*(self: SectionItem, pubkey: string): bool =
   self.membersModel.isContactWithIdAdded(pubkey)
 
-proc setOnlineStatusForMember*(self: SectionItem, pubKey: string,
-    onlineStatus: OnlineStatus) =
+proc setOnlineStatusForMember*(self: SectionItem, pubKey: string, onlineStatus: OnlineStatus) =
   self.membersModel.setOnlineStatus(pubkey, onlineStatus)
 
 proc updateMember*(


### PR DESCRIPTION
While searching for what might be causing the crashes, I ran into the section_details item.

It is only used for the `activeSection` QVariant in the main module. Also, `activeSection` is only used for its `id`, `section_type` and `joined` properties, which makes sense, because sections that need more details than that already get it from the actual module it is in (eg the chat section or chat content).

Therefore, the section_details item contained a LOT of useless properties that were never used, but still kept in memory and edited on multiple events.
The biggest offenders where the member properties, because each contact event modified it.

Anyway, I don't think this will fix the crashes; that's why I didn't put it on top of the release branch. However, I do think it simplifies the code a ton. It reduces the boilerplate we had, reduces the number of handled events and the amount of stuff kept in memory.