### PR TITLE
fix(@desktop/wallet): Edit Networks: Add warning when failover and main rpc are the same

### DIFF
--- a/src/app/modules/main/profile_section/wallet/networks/controller.nim
+++ b/src/app/modules/main/profile_section/wallet/networks/controller.nim
@@ -36,7 +36,7 @@ proc init*(self: Controller) =
 
   self.events.on(SIGNAL_WALLET_ACCOUNT_CHAIN_ID_FOR_URL_FETCHED) do(e: Args):
     let args = ChainIdForUrlArgs(e)
-    self.delegate.chainIdFetchedForUrl(args.url, args.chainId, args.success)
+    self.delegate.chainIdFetchedForUrl(args.url, args.chainId, args.success, args.isMainUrl)
 
   self.events.on(SIGNAL_NETWORK_ENDPOINT_UPDATED) do(e: Args):
     self.delegate.refreshNetworks()
@@ -50,8 +50,8 @@ proc areTestNetworksEnabled*(self: Controller): bool =
 proc toggleTestNetworksEnabled*(self: Controller) =
   self.walletAccountService.toggleTestNetworksEnabled()
 
-proc fetchChainIdForUrl*(self: Controller, url: string) =
-  self.walletAccountService.fetchChainIdForUrl(url)
+proc fetchChainIdForUrl*(self: Controller, url: string, isMainUrl: bool) =
+  self.walletAccountService.fetchChainIdForUrl(url, isMainUrl)
 
 proc updateNetworkEndPointValues*(self: Controller, chainId: int, newMainRpcInput, newFailoverRpcUrl: string) =
   self.networkService.updateNetworkEndPointValues(chainId, newMainRpcInput, newFailoverRpcUrl)

--- a/src/app/modules/main/profile_section/wallet/networks/io_interface.nim
+++ b/src/app/modules/main/profile_section/wallet/networks/io_interface.nim
@@ -31,8 +31,8 @@ method getModuleAsVariant*(self: AccessInterface): QVariant {.base.} =
 method updateNetworkEndPointValues*(self: AccessInterface, chainId: int, newMainRpcInput, newFailoverRpcUrl: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method fetchChainIdForUrl*(self: AccessInterface, url: string) {.base.} =
+method fetchChainIdForUrl*(self: AccessInterface, url: string, isMainUrl: bool) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method chainIdFetchedForUrl*(self: AccessInterface, url: string, chainId: int, success: bool) {.base.} =
+method chainIdFetchedForUrl*(self: AccessInterface, url: string, chainId: int, success: bool, isMainUrl: bool) {.base.} =
   raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/profile_section/wallet/networks/module.nim
+++ b/src/app/modules/main/profile_section/wallet/networks/module.nim
@@ -103,8 +103,8 @@ method toggleTestNetworksEnabled*(self: Module) =
 method updateNetworkEndPointValues*(self: Module, chainId: int, newMainRpcInput, newFailoverRpcUrl: string) =
   self.controller.updateNetworkEndPointValues(chainId, newMainRpcInput, newFailoverRpcUrl)
 
-method fetchChainIdForUrl*(self: Module, url: string) =
-  self.controller.fetchChainIdForUrl(url)
+method fetchChainIdForUrl*(self: Module, url: string, isMainUrl: bool) =
+  self.controller.fetchChainIdForUrl(url, isMainUrl)
 
-method chainIdFetchedForUrl*(self: Module, url: string, chainId: int, success: bool) =
-  self.view.chainIdFetchedForUrl(url, chainId, success)
+method chainIdFetchedForUrl*(self: Module, url: string, chainId: int, success: bool, isMainUrl: bool) =
+  self.view.chainIdFetchedForUrl(url, chainId, success, isMainUrl)

--- a/src/app/modules/main/profile_section/wallet/networks/view.nim
+++ b/src/app/modules/main/profile_section/wallet/networks/view.nim
@@ -76,7 +76,7 @@ QtObject:
   proc updateNetworkEndPointValues*(self: View, chainId: int, newMainRpcInput: string, newFailoverRpcUrl: string) {.slot.} =
     self.delegate.updateNetworkEndPointValues(chainId, newMainRpcInput, newFailoverRpcUrl)
 
-  proc fetchChainIdForUrl*(self: View, url: string) {.slot.} = 
-    self.delegate.fetchChainIdForUrl(url)
+  proc fetchChainIdForUrl*(self: View, url: string, isMainUrl: bool) {.slot.} =
+    self.delegate.fetchChainIdForUrl(url, isMainUrl)
 
-  proc chainIdFetchedForUrl*(self: View, url: string, chainId: int, success: bool) {.signal.}
+  proc chainIdFetchedForUrl*(self: View, url: string, chainId: int, success: bool, isMainUrl: bool) {.signal.}

--- a/src/app_service/service/wallet_account/async_tasks.nim
+++ b/src/app_service/service/wallet_account/async_tasks.nim
@@ -164,6 +164,7 @@ const deleteKeycardAccountsTask*: Task = proc(argEncoded: string) {.gcsafe, nimc
 type
   FetchChainIdForUrlTaskArg* = ref object of QObjectTaskArg
     url: string
+    isMainUrl: bool
 
 const fetchChainIdForUrlTask*: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[FetchChainIdForUrlTaskArg](argEncoded)
@@ -172,14 +173,16 @@ const fetchChainIdForUrlTask*: Task = proc(argEncoded: string) {.gcsafe, nimcall
     arg.finish(%*{
       "success": true,
       "chainId": response.result.getInt,
-      "url": arg.url
+      "url": arg.url,
+      "isMainUrl": arg.isMainUrl
     })
   except Exception as e:
     error "error when fetching chaind id from url: ", message = e.msg
     arg.finish(%*{
       "success": false,
       "chainId": -1,
-      "url": arg.url
+      "url": arg.url,
+      "isMainUrl": arg.isMainUrl
     })
 
 #################################################

--- a/src/app_service/service/wallet_account/service_account.nim
+++ b/src/app_service/service/wallet_account/service_account.nim
@@ -731,14 +731,16 @@ proc onFetchChainIdForUrl*(self: Service, jsonString: string) {.slot.} =
     chainId: response{"chainId"}.getInt,
     success: response{"success"}.getBool,
     url: response{"url"}.getStr,
+    isMainUrl: response{"isMainUrl"}.getBool
   ))
 
-proc fetchChainIdForUrl*(self: Service, url: string) =
+proc fetchChainIdForUrl*(self: Service, url: string, isMainUrl: bool) =
   let arg = FetchChainIdForUrlTaskArg(
     tptr: cast[ByteAddress](fetchChainIdForUrlTask),
     vptr: cast[ByteAddress](self.vptr),
     slot: "onFetchChainIdForUrl",
-    url: url
+    url: url,
+    isMainUrl: isMainUrl
   )
   self.threadpool.start(arg)
 

--- a/src/app_service/service/wallet_account/signals_and_payloads.nim
+++ b/src/app_service/service/wallet_account/signals_and_payloads.nim
@@ -81,3 +81,4 @@ type ChainIdForUrlArgs* = ref object of Args
   chainId*: int
   success*: bool
   url*: string
+  isMainUrl*: bool

--- a/storybook/pages/EditNetworkViewPage.qml
+++ b/storybook/pages/EditNetworkViewPage.qml
@@ -67,7 +67,7 @@ SplitView {
         signal urlVerified(string url, int status)
         property string url
 
-        function evaluateRpcEndPoint(url) {
+        function evaluateRpcEndPoint(url, isMainUrl) {
             networkModule.url = url
             d.timer.restart()
         }

--- a/ui/app/AppLayouts/Profile/stores/WalletStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/WalletStore.qml
@@ -72,8 +72,8 @@ QtObject {
         root.walletModule.runKeypairImportPopup(keyUid, mode)
     }
 
-    function evaluateRpcEndPoint(url) {
-        return networksModule.fetchChainIdForUrl(url)
+    function evaluateRpcEndPoint(url, isMainUrl) {
+        return networksModule.fetchChainIdForUrl(url, isMainUrl)
     }
 
     function updateNetworkEndPointValues(chainId, newMainRpcInput, newFailoverRpcUrl) {

--- a/ui/app/AppLayouts/Profile/views/WalletView.qml
+++ b/ui/app/AppLayouts/Profile/views/WalletView.qml
@@ -152,7 +152,7 @@ SettingsContentBase {
             Layout.fillHeight: true
             Layout.fillWidth: true
             networksModule: root.walletStore.networksModule
-            onEvaluateRpcEndPoint: root.walletStore.evaluateRpcEndPoint(url)
+            onEvaluateRpcEndPoint: root.walletStore.evaluateRpcEndPoint(url, isMainUrl)
             onUpdateNetworkValues: {
                 root.walletStore.updateNetworkEndPointValues(chainId, newMainRpcInput, newFailoverRpcUrl)
                 stackContainer.currentIndex = networksViewIndex

--- a/ui/app/AppLayouts/Profile/views/wallet/EditNetworkView.qml
+++ b/ui/app/AppLayouts/Profile/views/wallet/EditNetworkView.qml
@@ -13,7 +13,7 @@ ColumnLayout {
     property var networksModule
     property var combinedNetwork
 
-    signal evaluateRpcEndPoint(string url)
+    signal evaluateRpcEndPoint(string url, bool isMainUrl)
     signal updateNetworkValues(int chainId, string newMainRpcInput, string newFailoverRpcUrl)
 
     StatusTabBar {
@@ -39,7 +39,7 @@ ColumnLayout {
         EditNetworkForm {
             network: !!root.combinedNetwork ? root.combinedNetwork.prod: null
             networksModule: root.networksModule
-            onEvaluateRpcEndPoint: root.evaluateRpcEndPoint(url)
+            onEvaluateRpcEndPoint: root.evaluateRpcEndPoint(url, isMainUrl)
             onUpdateNetworkValues: root.updateNetworkValues(chainId, newMainRpcInput, newFailoverRpcUrl)
         }
     }
@@ -49,7 +49,7 @@ ColumnLayout {
         EditNetworkForm {
             network: !!root.combinedNetwork ? root.combinedNetwork.test: null
             networksModule: root.networksModule
-            onEvaluateRpcEndPoint: root.evaluateRpcEndPoint(url)
+            onEvaluateRpcEndPoint: root.evaluateRpcEndPoint(url, isMainUrl)
             onUpdateNetworkValues: root.updateNetworkValues(chainId, newMainRpcInput, newFailoverRpcUrl)
         }
     }


### PR DESCRIPTION
…in rpc are the same

closes #11551

### What does the PR do

Implements https://www.figma.com/file/idUoxN7OIW2Jpp3PMJ1Rl8/%E2%9A%99%EF%B8%8F-Settings-%7C-Desktop?type=design&node-id=18442-531470&mode=dev when Main and Failover RPCS are the same

### Affected areas

Profiel Wallet Networks Settings

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

https://github.com/status-im/status-desktop/assets/60327365/395bec13-76a3-46fc-bd2e-178354b79cc0


