### PR TITLE
Fix: Crash when reordering community channels

### DIFF
--- a/src/app/modules/main/activity_center/model.nim
+++ b/src/app/modules/main/activity_center/model.nim
@@ -49,6 +49,8 @@ QtObject:
 
     let topLeft = self.createIndex(0, 0, nil)
     let bottomRight = self.createIndex(self.activityCenterNotifications.len - 1, 0, nil)
+    defer: topLeft.delete
+    defer: bottomRight.delete
     self.dataChanged(topLeft, bottomRight, @[NotifRoles.Read.int])
 
   method rowCount*(self: Model, index: QModelIndex = nil): int = self.activityCenterNotifications.len
@@ -113,6 +115,7 @@ QtObject:
       if (acnViewItem.id == notificationId):
         acnViewItem.read = false
         let index = self.createIndex(i, 0, nil)
+        defer: index.delete
         self.dataChanged(index, index, @[NotifRoles.Read.int])
         break
       i.inc
@@ -123,6 +126,7 @@ QtObject:
       if (acnViewItem.id == notificationId):
         acnViewItem.read = true
         let index = self.createIndex(i, 0, nil)
+        defer: index.delete
         self.dataChanged(index, index, @[NotifRoles.Read.int])
         break
       i.inc
@@ -140,7 +144,9 @@ QtObject:
     i = 0
     for index in indexesToDelete:
       let indexUpdated = index - i
-      self.beginRemoveRows(newQModelIndex(), indexUpdated, indexUpdated)
+      let modelIndex = newQModelIndex()
+      defer: modelIndex.delete
+      self.beginRemoveRows(modelIndex, indexUpdated, indexUpdated)
       self.activityCenterNotifications.delete(indexUpdated)
       self.endRemoveRows()
       i = i + 1
@@ -151,13 +157,17 @@ QtObject:
     self.endResetModel()
 
   proc addActivityNotificationItemToList*(self: Model, activityCenterNotification: Item, addToCount: bool = true) =
-    self.beginInsertRows(newQModelIndex(), 0, 0)
+    let modelIndex = newQModelIndex()
+    defer: modelIndex.delete
+    self.beginInsertRows(modelIndex, 0, 0)
     self.activityCenterNotifications.insert(activityCenterNotification, 0)
     self.endInsertRows()
 
     if self.activityCenterNotifications.len > 1:
       let topLeft = self.createIndex(0, 0, nil)
       let bottomRight = self.createIndex(1, 0, nil)
+      defer: topLeft.delete
+      defer: bottomRight.delete
       self.dataChanged(topLeft, bottomRight, @[NotifRoles.Timestamp.int, NotifRoles.PreviousTimestamp.int])
 
   proc addActivityNotificationItemsToList*(self: Model, activityCenterNotifications: seq[Item]) =

--- a/src/app/modules/main/app_search/result_model.nim
+++ b/src/app/modules/main/app_search/result_model.nim
@@ -117,7 +117,9 @@ QtObject:
       result = newQVariant(item.colorHash)
 
   proc add*(self: Model, item: Item) =
-    self.beginInsertRows(newQModelIndex(), self.resultList.len, self.resultList.len)
+    let modelIndex = newQModelIndex()
+    defer: modelIndex.delete
+    self.beginInsertRows(modelIndex, self.resultList.len, self.resultList.len)
     self.resultList.add(item)
     self.endInsertRows()
 

--- a/src/app/modules/main/chat_section/model.nim
+++ b/src/app/modules/main/chat_section/model.nim
@@ -340,6 +340,7 @@ QtObject:
     self.items[index].icon = icon
     self.items[index].trustStatus = trustStatus
     let modelIndex = self.createIndex(index, 0, nil)
+    defer: modelIndex.delete
     self.dataChanged(modelIndex, modelIndex, @[
       ModelRole.Name.int,
       ModelRole.Icon.int,
@@ -355,6 +356,7 @@ QtObject:
     self.items[index].emoji = emoji
     self.items[index].color = color
     let modelIndex = self.createIndex(index, 0, nil)
+    defer: modelIndex.delete
     self.dataChanged(modelIndex, modelIndex, @[
       ModelRole.Name.int,
       ModelRole.Description.int,
@@ -509,6 +511,7 @@ QtObject:
       return
     self.items[index].lastMessageTimestamp = lastMessageTimestamp
     let modelIndex = self.createIndex(index, 0, nil)
+    defer: modelIndex.delete
     self.dataChanged(modelIndex, modelIndex, @[ModelRole.LastMessageTimestamp.int])
 
   proc reorderChats*(

--- a/src/app/modules/main/chat_section/model.nim
+++ b/src/app/modules/main/chat_section/model.nim
@@ -222,6 +222,7 @@ QtObject:
       if self.items[i].categoryId == categoryId:
         self.items[i].categoryOpened = opened
         let index = self.createIndex(i, 0, nil)
+        defer: index.delete
         self.dataChanged(index, index, @[ModelRole.CategoryOpened.int])
 
   proc removeItemByIndex(self: Model, idx: int) =
@@ -267,6 +268,7 @@ QtObject:
       return
     self.items[index].hasUnreadMessages = unread
     let modelIndex = self.createIndex(index, 0, nil)
+    defer: modelIndex.delete
     self.dataChanged(modelIndex, modelIndex, @[ModelRole.HasUnreadMessages.int])
 
   proc setActiveItem*(self: Model, id: string) =
@@ -274,6 +276,7 @@ QtObject:
       let isChannelToSetActive = (self.items[i].id == id)
       if self.items[i].active != isChannelToSetActive:
         let index = self.createIndex(i, 0, nil)
+        defer: index.delete
         # Set active channel to true and others to false
         self.items[i].active = isChannelToSetActive
         if (isChannelToSetActive):
@@ -288,6 +291,7 @@ QtObject:
       return
     self.items[index].locked = locked
     let modelIndex = self.createIndex(index, 0, nil)
+    defer: modelIndex.delete
     self.dataChanged(modelIndex, modelIndex, @[ModelRole.Locked.int])
 
   proc setItemPermissionsRequired*(self: Model, id: string, value: bool) =
@@ -296,6 +300,7 @@ QtObject:
       return
     self.items[index].requiresPermissions = value
     let modelIndex = self.createIndex(index, 0, nil)
+    defer: modelIndex.delete
     self.dataChanged(modelIndex, modelIndex, @[ModelRole.RequiresPermissions.int])
 
   proc getItemPermissionsRequired*(self: Model, id: string): bool =
@@ -313,12 +318,14 @@ QtObject:
       return
     self.items[index].muted = muted
     let modelIndex = self.createIndex(index, 0, nil)
+    defer: modelIndex.delete
     self.dataChanged(modelIndex, modelIndex, @[ModelRole.Muted.int])
 
   proc changeMutedOnItemByCategoryId*(self: Model, categoryId: string, muted: bool) =
     for i in 0 ..< self.items.len:
       if self.items[i].categoryId == categoryId and self.items[i].muted != muted:
         let index = self.createIndex(i, 0, nil)
+        defer: index.delete
         self.items[i].muted = muted
         self.dataChanged(index, index, @[ModelRole.Muted.int])
 
@@ -330,6 +337,7 @@ QtObject:
       return
     self.items[index].blocked = blocked
     let modelIndex = self.createIndex(index, 0, nil)
+    defer: modelIndex.delete
     self.dataChanged(modelIndex, modelIndex, @[ModelRole.Blocked.int])
 
   proc updateItemDetailsById*(self: Model, id, name, icon: string, trustStatus: TrustStatus) =
@@ -372,6 +380,7 @@ QtObject:
     self.items[index].color = color
     self.items[index].icon = icon
     let modelIndex = self.createIndex(index, 0, nil)
+    defer: modelIndex.delete
     self.dataChanged(modelIndex, modelIndex, @[
       ModelRole.Name.int,
       ModelRole.Color.int,
@@ -390,6 +399,7 @@ QtObject:
     self.items[categoryIndex].name = newCategoryName
     self.items[categoryIndex].categoryPosition = newCategoryPosition
     let modelIndex = self.createIndex(categoryIndex, 0, nil)
+    defer: modelIndex.delete
     self.dataChanged(modelIndex, modelIndex, @[
       ModelRole.Name.int,
       ModelRole.CategoryPosition.int,
@@ -416,6 +426,7 @@ QtObject:
         item.categoryId = chat.categoryId
         item.categoryPosition = if nowHasCategory: newCategoryPosition else: -1
         let modelIndex = self.createIndex(i, 0, nil)
+        defer: modelIndex.delete
         var roleChanges = @[
           ModelRole.Position.int,
           ModelRole.CategoryId.int,
@@ -448,6 +459,7 @@ QtObject:
         item.categoryPosition = -1
         item.categoryOpened = true
         let modelIndex = self.createIndex(i, 0, nil)
+        defer: modelIndex.delete
         self.dataChanged(modelIndex, modelIndex, @[
           ModelRole.Position.int,
           ModelRole.CategoryId.int,
@@ -464,6 +476,7 @@ QtObject:
       return
     self.items[index].name = newName
     let modelIndex = self.createIndex(index, 0, nil)
+    defer: modelIndex.delete
     self.dataChanged(modelIndex, modelIndex, @[ModelRole.Name.int])
 
   proc renameItemById*(self: Model, id, name: string) =
@@ -474,6 +487,7 @@ QtObject:
       return
     self.items[index].name = name
     let modelIndex = self.createIndex(index, 0, nil)
+    defer: modelIndex.delete
     self.dataChanged(modelIndex, modelIndex, @[ModelRole.Name.int])
 
   proc updateItemOnlineStatusById*(self: Model, id: string, onlineStatus: OnlineStatus) =
@@ -484,6 +498,7 @@ QtObject:
       return
     self.items[index].onlineStatus = onlineStatus
     let modelIndex = self.createIndex(index, 0, nil)
+    defer: modelIndex.delete
     self.dataChanged(modelIndex, modelIndex, @[ModelRole.OnlineStatus.int])
 
   proc updateNotificationsForItemById*(self: Model, id: string, hasUnreadMessages: bool,
@@ -494,6 +509,7 @@ QtObject:
     self.items[index].hasUnreadMessages = hasUnreadMessages
     self.items[index].notificationsCount = notificationsCount
     let modelIndex = self.createIndex(index, 0, nil)
+    defer: modelIndex.delete
     self.dataChanged(modelIndex, modelIndex, @[ModelRole.HasUnreadMessages.int, ModelRole.NotificationsCount.int])
 
   proc incrementNotificationsForItemByIdAndGetNotificationCount*(self: Model, id: string): int =
@@ -558,6 +574,7 @@ QtObject:
         continue
       item.categoryPosition = position
       let modelIndex = self.createIndex(i, 0, nil)
+      defer: modelIndex.delete
       self.dataChanged(modelIndex, modelIndex, @[ModelRole.CategoryPosition.int])
 
   proc clearItems*(self: Model) =
@@ -580,4 +597,5 @@ QtObject:
     self.items[index].loaderActive = false
     self.items[index].active = false
     let modelIndex = self.createIndex(index, 0, nil)
+    defer: modelIndex.delete
     self.dataChanged(modelIndex, modelIndex, @[ModelRole.Active.int, ModelRole.LoaderActive.int])

--- a/src/app/modules/main/chat_section/model.nim
+++ b/src/app/modules/main/chat_section/model.nim
@@ -539,6 +539,7 @@ QtObject:
 
       self.items[index].position = updatedChat.position
       let modelIndex = self.createIndex(index, 0, nil)
+      defer: modelIndex.delete
       self.dataChanged(modelIndex, modelIndex, roles)
 
   proc reorderCategoryById*(

--- a/src/app/modules/main/communities/models/curated_community_model.nim
+++ b/src/app/modules/main/communities/models/curated_community_model.nim
@@ -136,6 +136,7 @@ QtObject:
     let idx = self.findIndexById(item.getId())
     if idx > -1:
       let index = self.createIndex(idx, 0, nil)
+      defer: index.delete
       self.items[idx] = item
       self.dataChanged(index, index, @[
         ModelRole.Name.int,

--- a/src/app/modules/main/communities/models/discord_categories_model.nim
+++ b/src/app/modules/main/communities/models/discord_categories_model.nim
@@ -98,6 +98,7 @@ QtObject:
     let idx = self.findIndexById(id)
     if idx > -1:
       let index = self.createIndex(idx, 0, nil)
+      defer: index.delete
       self.items[idx].selected = false
       self.dataChanged(index, index, @[ModelRole.Selected.int])
 
@@ -105,5 +106,6 @@ QtObject:
     let idx = self.findIndexById(id)
     if idx > -1:
       let index = self.createIndex(idx, 0, nil)
+      defer: index.delete
       self.items[idx].selected = true
       self.dataChanged(index, index, @[ModelRole.Selected.int])

--- a/src/app/modules/main/communities/models/discord_channels_model.nim
+++ b/src/app/modules/main/communities/models/discord_channels_model.nim
@@ -176,6 +176,7 @@ QtObject:
     for i in 0 ..< self.items.len:
       if(self.items[i].getCategoryId() == id):
         let index = self.createIndex(i, 0, nil)
+        defer: index.delete
         self.items[i].selected = false
         self.dataChanged(index, index, @[ModelRole.Selected.int])
     self.hasSelectedItemsChanged()
@@ -184,6 +185,7 @@ QtObject:
     for i in 0 ..< self.items.len:
       if(self.items[i].getCategoryId() == id):
         let index = self.createIndex(i, 0, nil)
+        defer: index.delete
         self.items[i].selected = true
         self.dataChanged(index, index, @[ModelRole.Selected.int])
     self.hasSelectedItemsChanged()
@@ -203,6 +205,7 @@ QtObject:
     let idx = self.findIndexById(id)
     if idx > -1:
       let index = self.createIndex(idx, 0, nil)
+      defer: index.delete
       self.items[idx].selected = false
       self.dataChanged(index, index, @[ModelRole.Selected.int])
       self.hasSelectedItemsChanged()
@@ -211,6 +214,7 @@ QtObject:
     let idx = self.findIndexById(id)
     if idx > -1:
       let index = self.createIndex(idx, 0, nil)
+      defer: index.delete
       self.items[idx].selected = true
       self.dataChanged(index, index, @[ModelRole.Selected.int])
       self.hasSelectedItemsChanged()

--- a/src/app/modules/main/communities/models/discord_file_list_model.nim
+++ b/src/app/modules/main/communities/models/discord_file_list_model.nim
@@ -156,6 +156,7 @@ QtObject:
   proc setAllValidated*(self: DiscordFileListModel) =
     for i in 0 ..< self.items.len:
       let index = self.createIndex(i, 0, nil)
+      defer: index.delete
       self.items[i].validated = true
       self.dataChanged(index, index, @[ModelRole.Validated.int])
     self.selectedFilesValidChanged()
@@ -164,6 +165,7 @@ QtObject:
     let idx = self.findIndexByFilePath(filePath)
     if idx > -1:
       let index = self.createIndex(idx, 0, nil)
+      defer: index.delete
       self.items[idx].errorMessage = errorMessage
       self.items[idx].errorCode = errorCode
       self.items[idx].selected = false

--- a/src/app/modules/main/communities/models/discord_import_tasks_model.nim
+++ b/src/app/modules/main/communities/models/discord_import_tasks_model.nim
@@ -93,6 +93,7 @@ QtObject:
     let idx = self.findIndexByType(item.`type`)
     if idx > -1:
       let index = self.createIndex(idx, 0, nil)
+      defer: index.delete
       let errorsAndWarningsCount = self.items[idx].warningsCount + self.items[idx].errorsCount
       self.items[idx].progress = item.progress
       self.items[idx].state = item.state

--- a/src/app/modules/main/profile_section/ens_usernames/model.nim
+++ b/src/app/modules/main/profile_section/ens_usernames/model.nim
@@ -106,4 +106,5 @@ QtObject:
     self.items[ind].isPending = pendingStatus
 
     let index = self.createIndex(ind, 0, nil)
+    defer: index.delete
     self.dataChanged(index, index, @[ModelRole.IsPending.int])

--- a/src/app/modules/main/profile_section/notifications/model.nim
+++ b/src/app/modules/main/profile_section/notifications/model.nim
@@ -157,6 +157,7 @@ QtObject:
     self.items[ind].otherMessages = otherMessages
 
     let index = self.createIndex(ind, 0, nil)
+    defer: index.delete
     self.dataChanged(index, index, @[ModelRole.MuteAllMessages.int, ModelRole.PersonalMentions.int,
       ModelRole.GlobalMentions.int, ModelRole.OtherMessages.int, ModelRole.Customized.int])
 
@@ -168,4 +169,5 @@ QtObject:
     self.items[ind].name = name
 
     let index = self.createIndex(ind, 0, nil)
+    defer: index.delete
     self.dataChanged(index, index, @[ModelRole.Name.int])

--- a/src/app/modules/main/profile_section/wallet/accounts/model.nim
+++ b/src/app/modules/main/profile_section/wallet/accounts/model.nim
@@ -74,6 +74,7 @@ QtObject:
         item.colorId = account.colorId
         item.emoji = account.emoji
         let index = self.createIndex(i, 0, nil)
+        defer: index.delete
         self.dataChanged(index, index, @[ModelRole.Name.int])
         self.dataChanged(index, index, @[ModelRole.ColorId.int])
         self.dataChanged(index, index, @[ModelRole.Emoji.int])

--- a/src/app/modules/main/stickers/models/sticker_list.nim
+++ b/src/app/modules/main/stickers/models/sticker_list.nim
@@ -48,7 +48,9 @@ QtObject:
   proc addStickerToList*(self: StickerList, sticker: Item) =
     if(self.stickers.any(proc(existingSticker: Item): bool = return existingSticker.getHash == sticker.getHash)):
       return
-    self.beginInsertRows(newQModelIndex(), 0, 0)
+    let modelIndex = newQModelIndex()
+    defer: modelIndex.delete
+    self.beginInsertRows(modelIndex, 0, 0)
     self.stickers.insert(sticker, 0)
     self.endInsertRows()
 
@@ -62,6 +64,8 @@ QtObject:
     let idx = self.findIndexByPackId(packId)
     if idx == -1:
       return
-    self.beginRemoveRows(newQModelIndex(), idx, idx)
+    let modelIndex = newQModelIndex()
+    defer: modelIndex.delete
+    self.beginRemoveRows(modelIndex, idx, idx)
     self.stickers.delete(idx)
     self.endRemoveRows()

--- a/src/app/modules/main/stickers/models/sticker_pack_list.nim
+++ b/src/app/modules/main/stickers/models/sticker_pack_list.nim
@@ -99,13 +99,17 @@ QtObject:
     result = eth_utils.find(self.packs, (view: StickerPackView) => view.pack.id == packId).pack
 
   proc addStickerPackToList*(self: StickerPackList, pack: PackItem, stickers: StickerList, installed, bought, pending: bool) =
-    self.beginInsertRows(newQModelIndex(), 0, 0)
+    let modelIndex = newQModelIndex()
+    defer: modelIndex.delete
+    self.beginInsertRows(modelIndex, 0, 0)
     self.packs.insert((pack: pack, stickers: stickers, installed: installed, bought: bought, pending: pending), 0)
     self.endInsertRows()
 
   proc removeStickerPackFromList*(self: StickerPackList, packId: string) =
     let idx = self.findIndexById(packId)
-    self.beginRemoveRows(newQModelIndex(), idx, idx)
+    let modelIndex = newQModelIndex()
+    defer: modelIndex.delete
+    self.beginRemoveRows(modelIndex, idx, idx)
     self.packs.delete(idx)
     self.endRemoveRows()
 
@@ -114,6 +118,7 @@ QtObject:
     if idx == -1:
       return
     let index = self.createIndex(idx, 0, nil)
+    defer: index.delete
     self.packs.apply(proc(it: var StickerPackView) =
       if it.pack.id == packId:
         it.installed = installed

--- a/src/app/modules/shared_models/member_model.nim
+++ b/src/app/modules/shared_models/member_model.nim
@@ -161,7 +161,9 @@ QtObject:
       result = newQVariant(item.membershipRequestState.int)
 
   proc addItem*(self: Model, item: MemberItem) =
-    self.beginInsertRows(newQModelIndex(), self.items.len, self.items.len)
+    let modelIndex = newQModelIndex()
+    defer: modelIndex.delete
+    self.beginInsertRows(modelIndex, self.items.len, self.items.len)
     self.items.add(item)
     self.endInsertRows()
     self.countChanged()
@@ -196,6 +198,7 @@ QtObject:
     self.items[ind].localNickname = localNickname
 
     let index = self.createIndex(ind, 0, nil)
+    defer: index.delete
     self.dataChanged(index, index, @[
       ModelRole.DisplayName.int,
       ModelRole.EnsName.int,
@@ -210,6 +213,7 @@ QtObject:
     self.items[ind].icon = icon
 
     let index = self.createIndex(ind, 0, nil)
+    defer: index.delete
     self.dataChanged(index, index, @[ModelRole.Icon.int])
 
   proc updateItem*(
@@ -244,6 +248,7 @@ QtObject:
     self.items[ind].isUntrustworthy = isUntrustworthy
 
     let index = self.createIndex(ind, 0, nil)
+    defer: index.delete
     self.dataChanged(index, index, @[
       ModelRole.DisplayName.int,
       ModelRole.IsEnsVerified.int,
@@ -286,6 +291,7 @@ QtObject:
     self.items[ind].isUntrustworthy = isUntrustworthy
 
     let index = self.createIndex(ind, 0, nil)
+    defer: index.delete
     self.dataChanged(index, index, @[
       ModelRole.DisplayName.int,
       ModelRole.EnsName.int,
@@ -308,6 +314,7 @@ QtObject:
 
     self.items[idx].onlineStatus = onlineStatus
     let index = self.createIndex(idx, 0, nil)
+    defer: index.delete
     self.dataChanged(index, index, @[
       ModelRole.OnlineStatus.int
     ])
@@ -322,6 +329,7 @@ QtObject:
 
     self.items[idx].airdropAddress = airdropAddress
     let index = self.createIndex(idx, 0, nil)
+    defer: index.delete
     self.dataChanged(index, index, @[
       ModelRole.AirdropAddress.int
     ])
@@ -345,6 +353,7 @@ QtObject:
 
     self.items[idx].requestToJoinLoading = requestToJoinLoading
     let index = self.createIndex(idx, 0, nil)
+    defer: index.delete
     self.dataChanged(index, index, @[
       ModelRole.RequestToJoinLoading.int
     ])

--- a/src/app/modules/shared_models/message_model.nim
+++ b/src/app/modules/shared_models/message_model.nim
@@ -320,6 +320,7 @@ QtObject:
 
   proc updateItemAtIndex(self: Model, index: int) =
     let ind = self.createIndex(index, 0, nil)
+    defer: ind.delete
     self.dataChanged(ind, ind, self.allKeys)
 
   proc findIndexForMessageId*(self: Model, messageId: string): int =
@@ -366,6 +367,7 @@ QtObject:
           oldItem.quotedMessageText = newItem.unparsedText
           oldItem.quotedMessageContentType = newItem.contentType
           let index = self.createIndex(i, 0, nil)
+          defer: index.delete
           self.dataChanged(index, index, @[
             ModelRole.QuotedMessageFrom.int,
             ModelRole.QuotedMessageAuthorDisplayName.int,
@@ -426,6 +428,7 @@ QtObject:
     for i in 0 ..< self.items.len:
       if(self.items[i].responseToMessageWithId == messageId):
         let ind = self.createIndex(i, 0, nil)
+        defer: ind.delete
         var item = self.items[i]
         item.quotedMessageText = ""
         item.quotedMessageParsedText = ""
@@ -487,6 +490,7 @@ QtObject:
       return
     self.items[ind].outgoingStatus = status
     let index = self.createIndex(ind, 0, nil)
+    defer: index.delete
     self.dataChanged(index, index, @[ModelRole.OutgoingStatus.int])
 
   proc itemSending*(self: Model, messageId: string) =
@@ -507,6 +511,7 @@ QtObject:
       return
     self.items[ind].resendError = error
     let index = self.createIndex(ind, 0, nil)
+    defer: index.delete
     self.dataChanged(index, index, @[ModelRole.ResendError.int])
 
   proc addReaction*(self: Model, messageId: string, emojiId: EmojiId, didIReactWithThisEmoji: bool,
@@ -518,6 +523,7 @@ QtObject:
     self.items[ind].addReaction(emojiId, didIReactWithThisEmoji, userPublicKey, userDisplayName, reactionId)
 
     let index = self.createIndex(ind, 0, nil)
+    defer: index.delete
     self.dataChanged(index, index, @[ModelRole.Reactions.int])
 
   proc removeReaction*(self: Model, messageId: string, emojiId: EmojiId, reactionId: string, didIRemoveThisReaction: bool) =
@@ -528,6 +534,7 @@ QtObject:
     self.items[ind].removeReaction(emojiId, reactionId, didIRemoveThisReaction)
 
     let index = self.createIndex(ind, 0, nil)
+    defer: index.delete
     self.dataChanged(index, index, @[ModelRole.Reactions.int])
 
   proc pinUnpinMessage*(self: Model, messageId: string, pin: bool, pinnedBy: string) =
@@ -539,6 +546,7 @@ QtObject:
     self.items[ind].pinnedBy = pinnedBy
 
     let index = self.createIndex(ind, 0, nil)
+    defer: index.delete
     self.dataChanged(index, index, @[ModelRole.Pinned.int, ModelRole.PinnedBy.int])
 
   proc getMessageByIdAsJson*(self: Model, messageId: string): JsonNode =
@@ -579,6 +587,7 @@ QtObject:
 
       if(roles.len > 0):
         let index = self.createIndex(i, 0, nil)
+        defer: index.delete
         self.dataChanged(index, index, roles)
 
   proc setEditModeOn*(self: Model, messageId: string)  =
@@ -589,6 +598,7 @@ QtObject:
     self.items[ind].editMode = true
 
     let index = self.createIndex(ind, 0, nil)
+    defer: index.delete
     self.dataChanged(index, index, @[ModelRole.EditMode.int])
 
   proc setEditModeOff*(self: Model, messageId: string)  =
@@ -599,6 +609,7 @@ QtObject:
     self.items[ind].editMode = false
 
     let index = self.createIndex(ind, 0, nil)
+    defer: index.delete
     self.dataChanged(index, index, @[ModelRole.EditMode.int])
 
   proc updateEditedMsg*(
@@ -626,6 +637,7 @@ QtObject:
     self.items[ind].parsedText = updatedParsedText
 
     let index = self.createIndex(ind, 0, nil)
+    defer: index.delete
     self.dataChanged(index, index, @[
       ModelRole.MessageText.int,
       ModelRole.UnparsedText.int,
@@ -643,6 +655,7 @@ QtObject:
         self.items[i].quotedMessageText = updatedRawMsg
         self.items[i].quotedMessageContentType = contentType
         let index = self.createIndex(i, 0, nil)
+        defer: index.delete
         self.dataChanged(index, index, @[
           ModelRole.QuotedMessageText.int,
           ModelRole.QuotedMessageParsedText.int,
@@ -718,6 +731,7 @@ QtObject:
       if not item.seen:
         item.seen = true
         let index = self.createIndex(i, 0, nil)
+        defer: index.delete
         self.dataChanged(index, index, @[ModelRole.Seen.int])
 
   proc markAsSeen*(self: Model, messages: seq[string]) =
@@ -729,6 +743,7 @@ QtObject:
       if messagesSet.contains(currentItemID):
         self.items[i].seen = true
         let index = self.createIndex(i, 0, nil)
+        defer: index.delete
         self.dataChanged(index, index, @[ModelRole.Seen.int])
         messagesSet.excl(currentItemID)
 
@@ -757,6 +772,7 @@ QtObject:
         item.albumMessageIds = albumMessagesIds
         
         let index = self.createIndex(i, 0, nil)
+        defer: index.delete
         self.dataChanged(index, index, @[ModelRole.AlbumMessageImages.int])
         return true
     return false

--- a/src/app/modules/shared_models/message_reaction_model.nim
+++ b/src/app/modules/shared_models/message_reaction_model.nim
@@ -114,6 +114,7 @@ QtObject:
         return
       self.items[ind].addReaction(didIReactWithThisEmoji, userPublicKey, userDisplayName, reactionId)
       let index = self.createIndex(ind, 0, nil)
+      defer: index.delete
       self.dataChanged(index, index, @[ModelRole.EmojiId.int, ModelRole.DidIReactWithThisEmoji.int,
       ModelRole.NumberOfReactions.int, ModelRole.JsonArrayOfUsersReactedWithThisEmoji.int])
     else:
@@ -147,5 +148,6 @@ QtObject:
       self.countChanged()
     else:
       let index = self.createIndex(ind, 0, nil)
+      defer: index.delete
       self.dataChanged(index, index, @[ModelRole.EmojiId.int, ModelRole.DidIReactWithThisEmoji.int,
       ModelRole.NumberOfReactions.int, ModelRole.JsonArrayOfUsersReactedWithThisEmoji.int])

--- a/src/app/modules/shared_models/section_model.nim
+++ b/src/app/modules/shared_models/section_model.nim
@@ -370,6 +370,8 @@ QtObject:
 
       let topIndex = self.createIndex(topInd, 0, nil)
       let bottomIndex = self.createIndex(bottomInd, 0, nil)
+      defer: topIndex.delete
+      defer: bottomIndex.delete
       self.dataChanged(topIndex, bottomIndex, @[ModelRole.Enabled.int])
 
     # This signal is emitted to update buttons visibility in the left navigation bar,

--- a/src/app/modules/shared_models/token_permission_chat_list_model.nim
+++ b/src/app/modules/shared_models/token_permission_chat_list_model.nim
@@ -72,5 +72,6 @@ QtObject:
       if self.items[i].getKey() == chatId:
         self.items[i] = initTokenPermissionChatListItem(chatId, newName)
         let index = self.createIndex(i, 0, nil)
+        defer: index.delete
         self.dataChanged(index, index, @[ModelRole.ChannelName.int])
         return

--- a/src/app/modules/shared_models/token_permissions_model.nim
+++ b/src/app/modules/shared_models/token_permissions_model.nim
@@ -145,6 +145,7 @@ QtObject:
     self.items[idx].tokenCriteriaMet = item.tokenCriteriaMet
 
     let index = self.createIndex(idx, 0, nil)
+    defer: index.delete
     self.dataChanged(index, index, @[
       ModelRole.Id.int,
       ModelRole.Key.int,

--- a/src/app/modules/shared_models/user_model.nim
+++ b/src/app/modules/shared_models/user_model.nim
@@ -211,6 +211,7 @@ QtObject:
     self.items[ind].localNickname = localNickname
 
     let index = self.createIndex(ind, 0, nil)
+    defer: index.delete
     self.dataChanged(index, index, @[
       ModelRole.DisplayName.int,
       ModelRole.EnsName.int,
@@ -226,6 +227,7 @@ QtObject:
     self.items[ind].icon = icon
 
     let index = self.createIndex(ind, 0, nil)
+    defer: index.delete
     self.dataChanged(index, index, @[ModelRole.Icon.int])
     self.itemChanged(pubKey)
 
@@ -253,6 +255,7 @@ QtObject:
     self.items[ind].isUntrustworthy = isUntrustworthy
 
     let index = self.createIndex(ind, 0, nil)
+    defer: index.delete
     self.dataChanged(index, index, @[
       ModelRole.DisplayName.int,
       ModelRole.EnsName.int,
@@ -276,6 +279,7 @@ QtObject:
     self.items[ind].incomingVerificationStatus = requestStatus
 
     let index = self.createIndex(ind, 0, nil)
+    defer: index.delete
     self.dataChanged(index, index, @[
       ModelRole.IncomingVerificationStatus.int
     ])
@@ -288,6 +292,8 @@ QtObject:
 
     let first = self.createIndex(ind, 0, nil)
     let last = self.createIndex(ind, 0, nil)
+    defer: first.delete
+    defer: last.delete
     self.items[ind].isUntrustworthy = isUntrustworthy
     self.dataChanged(first, last, @[ModelRole.IsUntrustworthy.int])
     self.itemChanged(pubKey)

--- a/src/app/modules/shared_modules/keycard_popup/models/keycard_model.nim
+++ b/src/app/modules/shared_modules/keycard_popup/models/keycard_model.nim
@@ -47,7 +47,9 @@ QtObject:
     self.lockedItemsCountChanged()
 
   proc addItem*(self: KeycardModel, item: KeycardItem) =
-    self.beginInsertRows(newQModelIndex(), self.items.len, self.items.len)
+    let modelIndex = newQModelIndex()
+    defer: modelIndex.delete
+    self.beginInsertRows(modelIndex, self.items.len, self.items.len)
     self.items.add(item)
     self.endInsertRows()
     self.countChanged()

--- a/src/app/modules/startup/models/fetching_data_model.nim
+++ b/src/app/modules/startup/models/fetching_data_model.nim
@@ -93,6 +93,7 @@ QtObject:
       return
     self.items[ind].receivedMessageAtPosition(position)
     let index = self.createIndex(ind, 0, nil)
+    defer: index.delete
     self.dataChanged(index, index, @[ModelRole.LoadedMessages.int])
 
   proc evaluateWhetherToProcessReceivedData*(self: Model, backedUpMsgClock: uint64, entities: seq[tuple[entity: string, icon: string]]): bool =
@@ -119,6 +120,7 @@ QtObject:
     self.items[ind].totalMessages = totalMessages
     self.reevaluateAllTotals()
     let index = self.createIndex(ind, 0, nil)
+    defer: index.delete
     self.dataChanged(index, index, @[ModelRole.TotalMessages.int, ModelRole.LoadedMessages.int])
 
   proc removeSection*(self: Model, entity: string) =


### PR DESCRIPTION
### What does the PR do
Closes #11996

I've found at lease 3 flows where the app is crashing, each one involving a SortFilterProxyModel on top of a nim model:
1. Reordering community channels
2. Reordering chats in chat column by receiving a new message or sending a message from/to a contact that is not the first one in the list.

The app is always crashing in `QQmlDelegateModel::_q_dataChanged(QModelIndex const&, QModelIndex const&, QVector<int> const&)` with different call stacks, in different flows. It appears that the model indexes used here are deleted too early.
The crash is generated by nim models using `dataChanged` event with a newly created QModelIndex. It seems the GC will collect this index too early.

The fix that appears to be working in these cases is to defer the QModelIndex.delete. I've added the `defer: index.delete` everywhere where it's missing. 