### PR TITLE
fix(StatusChatInput): New handler method for large messages in StatusChatInput

### DIFF
--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -437,7 +437,8 @@ Rectangle {
             } else if (QClipboardProxy.hasText) {
                 const clipboardText = Utils.plainText(QClipboardProxy.text)
                 // prevent repetitive & huge clipboard paste, where huge is total char count > than messageLimitHard
-                if ((messageLength + clipboardText.length) > control.messageLimitHard)
+                const selectionLength = messageInputField.selectionEnd - messageInputField.selectionStart;
+                if ((messageLength + clipboardText.length - selectionLength) > control.messageLimitHard)
                 {
                     messageLengthLimitTooltip.open();
                     event.accepted = true;

--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -44,9 +44,9 @@ Rectangle {
     property bool isImage: false
     property bool isEdit: false
 
-    property int messageLimit: 2000 // actual message limit, we don't allow sending more than that
-    property int messageLimitSoft: 200 // we start showing a char counter when this no. of chars left in the message
-    property int messageLimitHard: 20000 // still cut-off attempts to paste beyond this limit, for app usability reasons
+    readonly property int messageLimit: 2000 // actual message limit, we don't allow sending more than that
+    readonly property int messageLimitSoft: 200 // we start showing a char counter when this no. of chars left in the message
+    readonly property int messageLimitHard: 20000 // still cut-off attempts to paste beyond this limit, for app usability reasons
 
     property int chatType
 
@@ -326,7 +326,8 @@ Rectangle {
     }
 
     function onKeyPress(event) {
-        let messageLength = messageInputField.getText(0, messageInputField.length).length;
+        // get text without HTML formatting
+        const messageLength = messageInputField.getText(0, messageInputField.length).length;
 
         if (event.modifiers === Qt.NoModifier && (event.key === Qt.Key_Enter || event.key === Qt.Key_Return)) {
             if (checkTextInsert()) {
@@ -1048,7 +1049,7 @@ Rectangle {
 
             StatusQ.StatusToolTip {
                 id: messageLengthLimitTooltip
-                text: qsTr("Maximum message character count is %1").arg(control.messageLimit)
+                text: qsTr("Maximum message character count is %n", "", control.messageLimit)
                 orientation: StatusQ.StatusToolTip.Orientation.Top
                 timeout: 3000 // show for 3 seconds
             }

--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -1424,11 +1424,21 @@ Rectangle {
                             }
                             text: visible ? remainingChars.toString() : ""
 
+                            MouseArea {
+                                id: mouseArea
+                                anchors.fill: parent
+                                hoverEnabled: true
+                                onEntered: {
+                                    messageLengthLimitTooltip.open()
+                                }
+                                onExited: {
+                                    messageLengthLimitTooltip.close()
+                                }
+                            }
+
                             StatusQ.StatusToolTip {
                                 id: messageLengthLimitTooltip
                                 text: qsTr("Maximum message character count is " + control.messageLimit)
-                                //FIXME: The popup fails to show when hovering the parent
-                                visible: parent.hovered && parent.visible
                                 orientation: StatusQ.StatusToolTip.Orientation.Top
 //                                offset: Style.current.halfPadding
 //                                y: parent.height + 12

--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -326,20 +326,21 @@ Rectangle {
     }
 
     function onKeyPress(event) {
+        let messageLength = messageInputField.getText(0, messageInputField.length).length;
+
         if (event.modifiers === Qt.NoModifier && (event.key === Qt.Key_Enter || event.key === Qt.Key_Return)) {
             if (checkTextInsert()) {
                 event.accepted = true;
                 return
             }
-
-            if (messageInputField.getText(0, messageInputField.length).length <= messageLimit) {
+            if (messageLength <= messageLimit) {
                 checkForInlineEmojis(true);
                 control.sendMessage(event);
                 control.hideExtendedArea();
                 event.accepted = true;
                 return;
             }
-            else if (messageInputField.getText(0, messageInputField.length).length  <= messageLimitHard) {
+            else if (messageLength <= messageLimitHard) {
                 // pop-up a warning message when trying to send a message over the limit
                 messageLengthLimitTooltip.open();
                 event.accepted = true;
@@ -433,16 +434,9 @@ Rectangle {
                 validateImagesAndShowImageArea([clipboardImage])
                 event.accepted = true
             } else if (QClipboardProxy.hasText) {
-                // cursor position must be stored in a helper property because setting readonly to true causes change
-                // of the cursor position to the end of the input
-                d.copyTextStart = messageInputField.cursorPosition
-                messageInputField.readOnly = true
-
                 const clipboardText = Utils.plainText(QClipboardProxy.text)
-                const copiedText = Utils.plainText(d.copiedTextPlain)
-
                 // prevent repetitive & huge clipboard paste, where huge is total char count > than messageLimitHard
-                if ((messageInputField.getText(0, messageInputField.length).length + clipboardText.length) > control.messageLimitHard)
+                if ((messageLength + clipboardText.length) > control.messageLimitHard)
                 {
                     messageLengthLimitTooltip.open();
                     event.accepted = false;
@@ -450,6 +444,13 @@ Rectangle {
                 }
 
                 messageInputField.remove(messageInputField.selectionStart, messageInputField.selectionEnd)
+
+                // cursor position must be stored in a helper property because setting readonly to true causes change
+                // of the cursor position to the end of the input
+                d.copyTextStart = messageInputField.cursorPosition
+                messageInputField.readOnly = true
+
+                const copiedText = Utils.plainText(d.copiedTextPlain)
                 if (copiedText === clipboardText) {
                     if (d.copiedTextPlain.includes("@")) {
                         d.copiedTextFormatted = d.copiedTextFormatted.replace(/span style="/g, "span style=\" text-decoration:none;")

--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -1048,7 +1048,7 @@ Rectangle {
 
             StatusQ.StatusToolTip {
                 id: messageLengthLimitTooltip
-                text: qsTr("Maximum message character count is " + control.messageLimit)
+                text: qsTr("Maximum message character count is %1").arg(control.messageLimit)
                 orientation: StatusQ.StatusToolTip.Orientation.Top
                 timeout: 3000 // show for 3 seconds
             }

--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -55,7 +55,7 @@ Rectangle {
 
     property var fileUrlsAndSources: []
 
-    property var imageErrorMessageLocation: StatusChatInput.ImageErrorMessageLocation.Top // TODO: Remove this proeprty?
+    property var imageErrorMessageLocation: StatusChatInput.ImageErrorMessageLocation.Top // TODO: Remove this property?
 
     property alias suggestions: suggestionsBox
 
@@ -274,7 +274,7 @@ Rectangle {
     }
 
     function insertInTextInput(start, text) {
-        // Repace new lines with entities because `insert` gets rid of them
+        // Replace new lines with entities because `insert` gets rid of them
         messageInputField.insert(start, text.replace(/\n/g, "<br/>"));
     }
 
@@ -529,7 +529,7 @@ Rectangle {
     function unwrapSelection(unwrapWith, selectedTextWithFormationChars) {
         if (messageInputField.selectionStart - messageInputField.selectionEnd === 0) return
 
-        // calulate the new selection start and end positions
+        // Calculate the new selection start and end positions
         var newSelectionStart = messageInputField.selectionStart -  unwrapWith.length
         var newSelectionEnd = messageInputField.selectionEnd-messageInputField.selectionStart + newSelectionStart
 
@@ -910,7 +910,7 @@ Rectangle {
         control.fileUrlsAndSources = imageArea.imageSource
     }
 
-    // Use this to validate and show the images. The concatanation of previous selected images is done automatically
+    // Use this to validate and show the images. The concatenation of previous selected images is done automatically
     // Returns true if the images were valid and added
     function validateImagesAndShowImageArea(imagePaths) {
         const validImages = validateImages(imagePaths)

--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -1094,6 +1094,12 @@ Rectangle {
             color: isEdit ? Theme.palette.statusChatInput.secondaryBackgroundColor : Style.current.inputBackground
             radius: 20
 
+            StatusQ.StatusToolTip {
+                id: messageLengthLimitTooltip
+                text: qsTr("Maximum message character count is " + control.messageLimit)
+                orientation: StatusQ.StatusToolTip.Orientation.Top
+            }
+
             Component {
                 id: textFormatMenuComponent
 
@@ -1434,14 +1440,6 @@ Rectangle {
                                 onExited: {
                                     messageLengthLimitTooltip.close()
                                 }
-                            }
-
-                            StatusQ.StatusToolTip {
-                                id: messageLengthLimitTooltip
-                                text: qsTr("Maximum message character count is " + control.messageLimit)
-                                orientation: StatusQ.StatusToolTip.Orientation.Top
-//                                offset: Style.current.halfPadding
-//                                y: parent.height + 12
                             }
                         }
 

--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -332,27 +332,25 @@ Rectangle {
                 return
             }
 
-            if (messageInputField.length <= messageLimit) {
+            if (messageInputField.getText(0, messageInputField.length).length <= messageLimit) {
                 checkForInlineEmojis(true);
                 control.sendMessage(event);
                 control.hideExtendedArea();
                 event.accepted = true;
                 return;
             }
-            else
-            {
-                // pop-up a warning message when typing over the limit
+            else if (messageInputField.getText(0, messageInputField.length).length  <= messageLimitHard) {
+                // pop-up a warning message when trying to send a message over the limit
                 messageLengthLimitTooltip.open();
-                // TODO: should we also prevent the user from typing over messagelimitHard?
+                event.accepted = true;
+                return;
             }
+        }
 
-            if (event) {
-                event.accepted = true
-                console.error("Attempting to send a message exceeding length limit")
-            }
-        } else if (event.key === Qt.Key_Escape && control.isReply) {
-            control.isReply = false
-            event.accepted = true
+        if (event.key === Qt.Key_Escape && control.isReply) {
+            control.isReply = false;
+            event.accepted = true;
+            return;
         }
 
         const symbolPressed = event.text.length > 0 &&
@@ -446,6 +444,7 @@ Rectangle {
                 // prevent repetitive & huge clipboard paste, where huge is total char count > than messageLimitHard
                 if ((messageInputField.getText(0, messageInputField.length).length + clipboardText.length) > control.messageLimitHard)
                 {
+                    messageLengthLimitTooltip.open();
                     event.accepted = false;
                     return;
                 }

--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -328,6 +328,7 @@ Rectangle {
     function onKeyPress(event) {
         // get text without HTML formatting
         const messageLength = messageInputField.getText(0, messageInputField.length).length;
+        console.log("messageLength: " + messageLength);
 
         if (event.modifiers === Qt.NoModifier && (event.key === Qt.Key_Enter || event.key === Qt.Key_Return)) {
             if (checkTextInsert()) {
@@ -1050,7 +1051,8 @@ Rectangle {
 
             StatusQ.StatusToolTip {
                 id: messageLengthLimitTooltip
-                text: qsTr("Maximum message character count is %n", "", control.messageLimit)
+                text: messageInputField.length >= control.messageLimitHard ? qsTr("Please reduce the message length")
+                      : qsTr("Maximum message character count is %n", "", control.messageLimit)
                 orientation: StatusQ.StatusToolTip.Orientation.Top
                 timeout: 3000 // show for 3 seconds
             }
@@ -1265,12 +1267,17 @@ Rectangle {
                             }
 
                             onTextChanged: {
+                                console.log("onTextChanged: length: " + length)
                                 if (length <= control.messageLimit) {
                                     if (length === 0) {
                                         mentionsPos = [];
                                     } else {
                                         checkForInlineEmojis()
                                     }
+                                } else if (length > control.messageLimitHard) {
+                                    const removeFrom = (cursorPosition < messageLimitHard) ? cursorWhenPressed : messageLimitHard;
+                                    remove(removeFrom, cursorPosition);
+                                    messageLengthLimitTooltip.open();
                                 }
 
                                 d.updateMentionsPositions()

--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -342,7 +342,7 @@ Rectangle {
             else
             {
                 // pop-up a warning message when typing over the limit
-                messageLengthLimitTooltip.visible = true;
+                messageLengthLimitTooltip.open();
                 // TODO: should we also prevent the user from typing over messagelimitHard?
             }
 
@@ -1095,6 +1095,7 @@ Rectangle {
                 id: messageLengthLimitTooltip
                 text: qsTr("Maximum message character count is " + control.messageLimit)
                 orientation: StatusQ.StatusToolTip.Orientation.Top
+                timeout: 3000 // show for 3 seconds
             }
 
             Component {
@@ -1433,7 +1434,7 @@ Rectangle {
                                     messageLengthLimitTooltip.open()
                                 }
                                 onExited: {
-                                    messageLengthLimitTooltip.close()
+                                    messageLengthLimitTooltip.hide()
                                 }
                             }
                         }

--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -1084,10 +1084,7 @@ Rectangle {
         Rectangle {
             id: messageInput
 
-            readonly property int defaultInputFieldHeight: 40
-
             Layout.fillWidth: true
-
             implicitHeight: inputLayout.implicitHeight + inputLayout.anchors.topMargin + inputLayout.anchors.bottomMargin
             implicitWidth: inputLayout.implicitWidth + inputLayout.anchors.leftMargin + inputLayout.anchors.rightMargin
 
@@ -1225,7 +1222,7 @@ Rectangle {
                 RowLayout {
                     Layout.fillWidth: true
                     Layout.minimumHeight: (messageInputField.contentHeight + messageInputField.topPadding + messageInputField.bottomPadding)
-                    Layout.maximumHeight: 112
+                    Layout.maximumHeight: 200
                     spacing: Style.current.radius
                     StatusScrollView {
                         id: inputScrollView

--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -617,51 +617,6 @@ Rectangle {
         return result
     }
 
-    function setFormatInInput(formationFunction, startTag, endTag, formationChar, numFormationChars) {
-        const inputText = getFormattedText()
-        const plainInputText = messageInputField.getText(0, messageInputField.length)
-
-        let lengthDifference
-
-        try {
-            const result = formationFunction(inputText)
-
-            if (!result) {
-                return
-            }
-            const parsed = JSON.parse(result)
-
-            let substring
-            let nbEmojis
-            parsed.forEach(function (match) {
-                match[1] += 1
-                const truncatedInputText = inputText.substring(0, match[1] + numFormationChars)
-                const truncatedPlainText = plainInputText.substring(0, messageInputField.cursorPosition)
-
-                const lengthDifference = truncatedInputText.length - truncatedPlainText.length
-
-                nbEmojis = StatusQUtils.Emoji.nbEmojis(truncatedInputText)
-
-
-                match[1] += (nbEmojis * -2)
-                match[0] += (nbEmojis * -2)
-                substring = inputText.substring(match[0], match[1])
-
-                if (plainInputText.charAt(match[0] - 1) !== formationChar) {
-                    match[0] -= lengthDifference
-                    match[1] -= lengthDifference
-                } else {
-                    match[1] -= lengthDifference
-                }
-
-                messageInputField.remove(match[0], match[1])
-                insertInTextInput(match[0], `${startTag}${substring}${endTag}`)
-            })
-        } catch (e) {
-            //
-        }
-    }
-
     function onRelease(event) {
         if ((event.modifiers & Qt.ControlModifier) || (event.modifiers & Qt.MetaModifier)) // these are likely shortcuts with no meaningful text
             return

--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -328,7 +328,6 @@ Rectangle {
     function onKeyPress(event) {
         // get text without HTML formatting
         const messageLength = messageInputField.getText(0, messageInputField.length).length;
-        console.log("messageLength: " + messageLength);
 
         if (event.modifiers === Qt.NoModifier && (event.key === Qt.Key_Enter || event.key === Qt.Key_Return)) {
             if (checkTextInsert()) {
@@ -1267,7 +1266,6 @@ Rectangle {
                             }
 
                             onTextChanged: {
-                                console.log("onTextChanged: length: " + length)
                                 if (length <= control.messageLimit) {
                                     if (length === 0) {
                                         mentionsPos = [];

--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -1421,10 +1421,8 @@ Rectangle {
                             rightPadding: Style.current.halfPadding
                             visible: messageInputField.length >= control.messageLimit - control.messageLimitSoft
                             color: {
-                                if ( remainingChars > control.messageLimitSoft )
+                                if (remainingChars  >= 0)
                                     return Style.current.textColor
-                                else if (remainingChars  >= 0)
-                                    return Style.current.warning
                                 else
                                     return Style.current.danger
                             }

--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -340,7 +340,7 @@ Rectangle {
                 event.accepted = true;
                 return;
             }
-            else if (messageLength <= messageLimitHard) {
+            else {
                 // pop-up a warning message when trying to send a message over the limit
                 messageLengthLimitTooltip.open();
                 event.accepted = true;
@@ -439,7 +439,7 @@ Rectangle {
                 if ((messageLength + clipboardText.length) > control.messageLimitHard)
                 {
                     messageLengthLimitTooltip.open();
-                    event.accepted = false;
+                    event.accepted = true;
                     return;
                 }
 


### PR DESCRIPTION
## What does the PR do

Currently, large text clipboard paste's are silently cut off if beyond 2000 (Waku?) character count limit.

Change the way we handle large messages in the StatusChatInput by:
1. Introducing three text limits:
https://github.com/status-im/status-desktop/blob/7b0c45a14a122e67e5721e86e4ae05d5596a1b33/ui/imports/shared/status/StatusChatInput.qml#L49-L51
2. Disable sending the message via `Return ↵` key if current text in the input control is beyond the `2000` character limit. A popup is displayed from the message character counter to inform the user of that.
3. When the user reaches the `1800` character limit, via typing or pasting text, the char counter is displayed. The counter is orange for the last `200` characters, then red when negative (beyond `2000` limit). The char counter label goes away again when there's more than the soft limit of `200` chars left to type.
4. Pasting beyond `2000` character limit is allowed, up to that hard limit of `20000`, to not silently cut text like we do currently nor bluntly deny paste actions with text beyond that. Reasoning is two-fold, so the user can still edit a reasonable chunk of text inside the text input, second, to block what is beyond comfortable to edit in there or what could impact the app performance, i.e. pasting 5mb worth of text.

## Code issues

- [x] Char counter label tooltip doesn't pop-up on hovering parent
- [x] Align the tooltip either to content or char counter label
- [x] Paste block stops at `18000` limit (is not precise yet)


## To figure out UX/UI wise
- [ ] ~~Increase the `200` char soft limit?~~
- [x] _Prevent the user from typing over hard limit of `20000`, in addition to denying paste over that? I'm currently not doing this, but maybe we should cover the _🐈 is sitting on the keyboard_ scenario too._
-> **Allow typing and pasting as long as it doesn't impact app performance too much, change tooltip to inform the user that typing and pasting beyond that is no longer allowed.**
-> **I cannot find a good method for denying typing of standard ASCII character set anyway, without interfering with other commands and processing, in both `onKeyReleased` and `onKeyPressed`.**
- [x] _Once displayed, keep the char counter label visible (going back to normal black color if beyond soft limit), until a message is sent or input label is cleared? (some apps do that)_
-> **Yes, keep visible until message is sent or discarded, continuous feedback should, generally, help the user with editing a large message.**
- [x] Amber color (`Style.current.warning`) for when typing within softLimit range is not necessary. Still keep the softLimit to decide when to display the char count label. So we should only have normal color for when within `messageLimit` range and `Style.current.danger` when out of it.
- [x] Quickly check if we can make the text input height adjustable or at least have ceiling at 8 rows (double current height).

NB: Pointing to some of these items as code references in comments.

## Video walk-through for 1st iteration 

https://github.com/status-im/status-desktop/assets/544446/d5b21f90-dd74-4326-9058-08b397ac4a29

## Video walk-through for 2nd iteration 

https://github.com/status-im/status-desktop/assets/544446/b439dbd1-61b2-4594-8475-abbe02e6fbbc


## Video walk-through for 3rd iteration <a href="#third-iteration" id="third-iteration">#</a>

https://github.com/status-im/status-desktop/assets/544446/95880d9f-0aba-4bb4-9b96-49c7d1e8b9dd


## Video walk-through for 4th iteration <a href="#fourth-iteration" id="fourth-iteration">#</a>

https://github.com/status-im/status-desktop/assets/544446/5238e559-2ab0-4f16-b728-8fb45b355853


---
Closes #11767