### PR TITLE
bug(@desktop/wallet): Unkown symbol and Gwei decimals

### DIFF
--- a/src/app/modules/main/wallet_section/activity/controller.nim
+++ b/src/app/modules/main/wallet_section/activity/controller.nim
@@ -82,10 +82,10 @@ QtObject:
       result.outAmount = self.currencyService.parseCurrencyValue(metadata.symbolOut.get(), metadata.amountOut)
 
   proc buildTransactionExtraData(self: Controller, metadata: backend_activity.ActivityEntry): ExtraData =
-    if metadata.symbolIn.isSome():
-      result.inAmount = self.currencyService.parseCurrencyValue(metadata.symbolIn.get(), metadata.amountIn)
-    if metadata.symbolOut.isSome():
-      result.outAmount = self.currencyService.parseCurrencyValue(metadata.symbolOut.get(), metadata.amountOut)
+    if metadata.symbolIn.isSome() or metadata.amountIn > 0:
+      result.inAmount = self.currencyService.parseCurrencyValue(metadata.symbolIn.get(""), metadata.amountIn)
+    if metadata.symbolOut.isSome() or metadata.amountOut > 0:
+      result.outAmount = self.currencyService.parseCurrencyValue(metadata.symbolOut.get(""), metadata.amountOut)
 
   proc backendToPresentation(self: Controller, backendEntities: seq[backend_activity.ActivityEntry]): seq[entry.ActivityEntry] =
     let amountToCurrencyConvertor = proc(amount: UInt256, symbol: string): CurrencyAmount =

--- a/src/app/modules/main/wallet_section/activity/entry.nim
+++ b/src/app/modules/main/wallet_section/activity/entry.nim
@@ -250,13 +250,13 @@ QtObject:
     read = getTokenID
 
   proc getOutAmount*(self: ActivityEntry): float {.slot.} =
-    return float(self.extradata.outAmount)
+    return self.extradata.outAmount
 
   QtProperty[float] outAmount:
     read = getOutAmount
 
   proc getInAmount*(self: ActivityEntry): float {.slot.} =
-    return float(self.extradata.inAmount)
+    return self.extradata.inAmount
 
   QtProperty[float] inAmount:
     read = getInAmount

--- a/src/app_service/service/currency/dto.nim
+++ b/src/app_service/service/currency/dto.nim
@@ -21,7 +21,7 @@ proc newCurrencyFormatDto*(
 proc newCurrencyFormatDto*(symbol: string = ""): CurrencyFormatDto =
   return CurrencyFormatDto(
     symbol: symbol,
-    displayDecimals: 8,
+    displayDecimals: if len(symbol) == 0: 0 else: 8,
     stripTrailingZeroes: true
   )
 

--- a/ui/StatusQ/src/StatusQ/Core/LocaleUtils.qml
+++ b/ui/StatusQ/src/StatusQ/Core/LocaleUtils.qml
@@ -113,6 +113,13 @@ QtObject {
         if (typeof currencyAmount.amount === "undefined")
             return qsTr("N/A")
 
+        let currencyValue = currencyAmount.amount
+
+        if (currencyAmount.symbol === "Gwei") {
+            // Special case when currency amount must be converted to float to properly display it
+            currencyValue = currencyAmount.amount / Math.pow(10, currencyAmount.displayDecimals)
+        }
+
         locale = locale || Qt.locale()
 
         // Parse options
@@ -139,26 +146,26 @@ QtObject {
         var amountSuffix = ""
 
         let minAmount = 10**-optDisplayDecimals
-        if (currencyAmount.amount > 0 && currencyAmount.amount < minAmount && !optRawAmount)
+        if (currencyValue > 0 && currencyValue < minAmount && !optRawAmount)
         {
             // Handle amounts smaller than resolution
             amountStr = "<%1".arg(numberToLocaleString(minAmount, optDisplayDecimals, locale))
         } else {
             var amount
             var displayDecimals
-            const numIntegerDigits = integralPartLength(currencyAmount.amount)
+            const numIntegerDigits = integralPartLength(currencyValue)
             const maxDigits = 11 // We add "B" suffix only after 999 Billion
             const maxDigitsToShowDecimal = 6 // We do not display decimal places after 1 million
             // For large numbers, we use the short scale system (https://en.wikipedia.org/wiki/Long_and_short_scales)
             // and 2 decimal digits.
             if (numIntegerDigits > maxDigits && !optRawAmount) {
-                amount = currencyAmount.amount/10**9 // Billion => 9 zeroes
+                amount = currencyValue/10**9 // Billion => 9 zeroes
                 displayDecimals = 2
                 amountSuffix = qsTr("B", "Billion")
             } else {
                 // For normal numbers, we show the whole integral part and as many decimal places not
                 // not to exceed the maximum
-                amount = currencyAmount.amount
+                amount = currencyValue
                 // For numbers over 1M , dont show decimal places
                 if(numIntegerDigits > maxDigitsToShowDecimal) {
                     displayDecimals = 0
@@ -175,6 +182,8 @@ QtObject {
         // Add symbol
         if (currencyAmount.symbol && !optNoSymbol) {
             amountStr = "%1%2 %3".arg(amountStr).arg(amountSuffix).arg(currencyAmount.symbol)
+        } else {
+            amountStr = "%1%2".arg(amountStr).arg(amountSuffix)
         }
 
         return amountStr

--- a/ui/app/AppLayouts/Wallet/views/TransactionDetailView.qml
+++ b/ui/app/AppLayouts/Wallet/views/TransactionDetailView.qml
@@ -627,7 +627,7 @@ Item {
                         width: parent.width
                         title: d.symbol ? qsTr("Fees") : qsTr("Estimated max fee")
                         subTitle: {
-                            if (!root.isTransactionValid || transactionHeader.isNFT || !!d.isDetailsValid)
+                            if (!root.isTransactionValid || transactionHeader.isNFT || !d.isDetailsValid)
                                 return ""
                             if (!d.symbol) {
                                 const maxFeeEth = RootStore.getFeeEthValue(d.details.maxTotalFees)
@@ -638,7 +638,7 @@ Item {
                             case Constants.TransactionType.Send:
                             case Constants.TransactionType.Swap:
                             case Constants.TransactionType.Bridge:
-                                return d.details ? LocaleUtils.currencyAmountToLocaleString(d.details.totalFees) : ""
+                                return LocaleUtils.currencyAmountToLocaleString(d.details.totalFees)
                             default:
                                 return ""
                             }

--- a/ui/imports/shared/stores/RootStore.qml
+++ b/ui/imports/shared/stores/RootStore.qml
@@ -231,6 +231,8 @@ QtObject {
     }
 
     function getFeeEthValue(feeCurrency) {
+        if (!feeCurrency || feeCurrency.symbol !== "Gwei")
+            return qsTr("N/A")
         return currencyStore.getGasEthValue(feeCurrency.amount / Math.pow(10, feeCurrency.displayDecimals), 1)
     }
 


### PR DESCRIPTION
fixes #11492

### What does the PR do

* Fixed Gwei decimal conversion
* Showed unkown tokens instead of ETH. (It was reverted by mistake)
* Fixed amounts for unkown tokens
* Use 0 decimals for empty symbols

### Screenshot of functionality (including design for comparison)

![image](https://github.com/status-im/status-desktop/assets/11396062/772fde0f-633a-4be1-9a66-25671171dcf1)


https://goerli.etherscan.io/tx/0xe9e766807ad304e90de26e962e83d63fb5b8d08a42f40c9089f4008e8981749e

Decimals: 18

![image](https://github.com/status-im/status-desktop/assets/11396062/1c6e8822-a48b-450e-b2a0-0cae6582032f)
