### PR TITLE
Fix/issue 11854 2

### DIFF
--- a/src/app/modules/main/chat_section/chat_content/io_interface.nim
+++ b/src/app/modules/main/chat_section/chat_content/io_interface.nim
@@ -139,3 +139,6 @@ method setPermissionsCheckOngoing*(self: AccessInterface, value: bool) {.base.} 
 
 method getPermissionsCheckOngoing*(self: AccessInterface): bool {.base.} =
   raise newException(ValueError, "No implementation available")
+
+method stopLoadingFirstMessage*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/chat_section/chat_content/messages/io_interface.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/io_interface.nim
@@ -182,3 +182,6 @@ method reevaluateViewLoadingState*(self: AccessInterface) {.base.} =
 
 method onGetMessageById*(self: AccessInterface, requestId: UUID, messageId: string, message: MessageDto, error: string) {.base.} =
   raise newException(ValueError, "No implementation available")
+
+method stopLoadingFirstMessage*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/chat_section/chat_content/messages/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/messages/module.nim
@@ -778,4 +778,9 @@ method onFirstUnseenMessageLoaded*(self: Module, messageId: string) =
     self.scrollToMessage(messageId)
   self.firstUnseenMessageState.initialized = true
   self.firstUnseenMessageState.fetching = false
+
+  # If there're no messages, consider initial message as loaded to hide loading animation. 
+  if messageId == "":
+    self.initialMessagesLoaded = true
+
   self.reevaluateViewLoadingState()

--- a/src/app/modules/main/chat_section/chat_content/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/module.nim
@@ -412,3 +412,6 @@ method setPermissionsCheckOngoing*(self: Module, value: bool) =
 
 method getPermissionsCheckOngoing*(self: Module): bool =
   self.view.getPermissionsCheckOngoing()
+
+method stopLoadingFirstMessage*(self: Module) =
+  self.messagesModule.stopLoadingFirstMessage() 

--- a/src/app/modules/main/chat_section/io_interface.nim
+++ b/src/app/modules/main/chat_section/io_interface.nim
@@ -171,7 +171,7 @@ method viewDidLoad*(self: AccessInterface) {.base.} =
 method setActiveItem*(self: AccessInterface, itemId: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method getChatContentModule*(self: AccessInterface, chatId: string): QVariant {.base.} =
+method getChatContentModuleVariant*(self: AccessInterface, chatId: string): QVariant {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method isCommunity*(self: AccessInterface): bool {.base.} =

--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -435,12 +435,16 @@ method activeItemSet*(self: Module, itemId: string) =
 method getModuleAsVariant*(self: Module): QVariant =
   return self.viewVariant
 
-method getChatContentModule*(self: Module, chatId: string): QVariant =
-  if(not self.chatContentModules.contains(chatId)):
+method getChatContentModule(self: Module, chatId: string): chat_content_module.AccessInterface =
+  if not self.chatContentModules.contains(chatId):
     error "unexisting chat key", chatId, methodName="getChatContentModule"
-    return
+    return nil
+  return self.chatContentModules[chatId]
 
-  return self.chatContentModules[chatId].getModuleAsVariant()
+method getChatContentModuleVariant*(self: Module, chatId: string): QVariant =
+  let module = self.getChatContentModule(chatId)
+  if module != nil:
+    result = module.getModuleAsVariant()
 
 proc updateParentBadgeNotifications(self: Module) =
   let (unviewedMessagesCount, unviewedMentionsCount) = self.controller.sectionUnreadMessagesAndMentionsCount(
@@ -894,6 +898,7 @@ method onJoinedCommunity*(self: Module) =
 
 method onMarkAllMessagesRead*(self: Module, chat: ChatDto) =
   self.updateBadgeNotifications(chat, hasUnreadMessages=false, unviewedMentionsCount=0)
+  self.getChatContentModule(chat.id).stopLoadingFirstMessage()
 
 method markAllMessagesRead*(self: Module, chatId: string) =
   self.controller.markAllMessagesRead(chatId)

--- a/src/app/modules/main/chat_section/view.nim
+++ b/src/app/modules/main/chat_section/view.nim
@@ -164,7 +164,7 @@ QtObject:
     self.tmpChatId = chatId
 
   proc getChatContentModule*(self: View): QVariant {.slot.} =
-    var chatContentVariant = self.delegate.getChatContentModule(self.tmpChatId)
+    var chatContentVariant = self.delegate.getChatContentModuleVariant(self.tmpChatId)
     self.tmpChatId = ""
     if(chatContentVariant.isNil):
       return newQVariant()


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/11854
Requires https://github.com/status-im/status-go/pull/3992

### What does the PR do

1. When chat is "marked as read", scrolling to first unseen message is stopped.
https://github.com/status-im/status-desktop/blob/0883f61bf59076492d0de837ac33eaf77d944503/src/app/modules/main/chat_section/chat_content/messages/module.nim#L792-L795

2. If there're no messages in the chat, consider initial message as loaded to hide loading animation. 
https://github.com/status-im/status-desktop/blob/0883f61bf59076492d0de837ac33eaf77d944503/src/app/modules/main/chat_section/chat_content/messages/module.nim#L787-L788

3. Update status-go to get https://github.com/status-im/status-go/pull/3992.


### Screenshot of functionality

https://github.com/status-im/status-desktop/assets/25482501/b4afc41d-7623-4c03-87cd-d7a450420765
