### PR TITLE
fix(URLUnfurling): Updated image context menu

### DIFF
--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -231,11 +231,6 @@ QtObject {
         stickersModuleInst.send(channelId, hash, replyTo, pack, url)
     }
 
-    // TODO: This seems to be better in Utils.qml
-    function copyToClipboard(text) {
-        globalUtilsInst.copyToClipboard(text)
-    }
-
     function isCurrentUser(pubkey) {
         return userProfileInst.pubKey === pubkey
     }

--- a/ui/app/AppLayouts/Communities/panels/ProfilePopupInviteFriendsPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/ProfilePopupInviteFriendsPanel.qml
@@ -90,7 +90,7 @@ ColumnLayout {
         asset.name: "copy"
         iconButton.onClicked: {
             let link = Utils.getCommunityShareLink(root.community.id)
-            root.rootStore.copyToClipboard(link)
+            Utils.copyToClipboard(link)
             tooltip.visible = !tooltip.visible
         }
     }

--- a/ui/app/AppLayouts/Communities/popups/CommunityProfilePopup.qml
+++ b/ui/app/AppLayouts/Communities/popups/CommunityProfilePopup.qml
@@ -69,7 +69,7 @@ StatusModal {
                                              : Global.leaveCommunityRequested(root.community.name, root.community.id, root.community.outroMessage)
                 }
                 onCopyToClipboard: {
-                    root.store.copyToClipboard(link);
+                    Utils.copyToClipboard(link);
                 }
             }
         }

--- a/ui/app/AppLayouts/Communities/popups/TransferOwnershipPopup.qml
+++ b/ui/app/AppLayouts/Communities/popups/TransferOwnershipPopup.qml
@@ -56,7 +56,7 @@ StatusDialog {
                 objectName: "copyCommunityPrivateKeyButton"
                 onClicked: {
                     text = qsTr("Copied")
-                    root.store.copyToClipboard(root.privateKey)
+                    Utils.copyToClipboard(root.privateKey)
                 }
             }
         }

--- a/ui/app/mainui/Popups.qml
+++ b/ui/app/mainui/Popups.qml
@@ -106,9 +106,8 @@ QtObject {
         openPopup(downloadPageComponent, popupProperties)
     }
 
-    function openImagePopup(image) {
-        var popup = imagePopupComponent.createObject(popupParent)
-        popup.openPopup(image)
+    function openImagePopup(image, url) {
+        openPopup(imagePopupComponent, {image: image, url: url})
     }
 
     function openProfilePopup(publicKey: string, parentPopup, cb) {

--- a/ui/imports/shared/status/StatusImageModal.qml
+++ b/ui/imports/shared/status/StatusImageModal.qml
@@ -12,6 +12,8 @@ Popup {
     id: root
 
     property var store
+    property var image
+    property string url: ""
 
     modal: true
     Overlay.modal: Rectangle {
@@ -26,23 +28,18 @@ Popup {
     }
     padding: 0
 
-    function setPopupData(image) {
-        messageImage.source = image.source;
+    onOpened: {
+        messageImage.source = root.image.source;
         const maxHeight = Global.applicationWindow.height - 80
         const maxWidth = Global.applicationWindow.width - 80
 
-        if (image.sourceSize.width >= maxWidth || image.sourceSize.height >= maxHeight) {
+        if (root.image.sourceSize.width >= maxWidth || root.image.sourceSize.height >= maxHeight) {
             this.width = maxWidth
             this.height = maxHeight
         } else {
             this.width = image.sourceSize.width
             this.height = image.sourceSize.height
         }
-    }
-
-    function openPopup(image) {
-        setPopupData(image);
-        open()
     }
 
     contentItem: AnimatedImage {
@@ -64,7 +61,7 @@ Popup {
                 if (mouse.button === Qt.RightButton)
                     Global.openMenu(imageContextMenu,
                                     messageImage,
-                                    { imageSource: messageImage.source })
+                                    { imageSource: messageImage.source, url: root.url})
             }
         }
     }

--- a/ui/imports/shared/views/chat/ImageContextMenu.qml
+++ b/ui/imports/shared/views/chat/ImageContextMenu.qml
@@ -1,16 +1,21 @@
+import QtQuick 2.15
 import StatusQ.Popups 0.1
-
 import utils 1.0
 
 StatusMenu {
     id: root
 
+    property string url
     property string imageSource
 
-    readonly property bool isGif: root.imageSource.toLowerCase().endsWith(".gif")
+    QtObject {
+        id: d
+        readonly property bool isUnfurled: (!!url&&url!=="")
+        readonly property bool isGif: root.imageSource.toLowerCase().endsWith(".gif")
+    }
 
     StatusAction {
-        text: root.isGif ? qsTr("Copy GIF") : qsTr("Copy image")
+        text: d.isGif ? qsTr("Copy GIF") : qsTr("Copy image")
         icon.name: "copy"
         enabled: !!root.imageSource
         onTriggered: {
@@ -19,11 +24,29 @@ StatusMenu {
     }
 
     StatusAction {
-        text: root.isGif ? qsTr("Download GIF") : qsTr("Download image")
+        text: d.isGif ? qsTr("Download GIF") : qsTr("Download image")
         icon.name: "download"
         enabled: !!root.imageSource
         onTriggered: {
-            Global.openDownloadImageDialog(root.imageSource)
+            Global.openDownloadImageDialog(root.imageSource);
+        }
+    }
+
+    StatusAction {
+        text: qsTr("Copy link")
+        icon.name: "copy"
+        enabled: d.isUnfurled
+        onTriggered: {
+            Utils.copyToClipboard(url);
+        }
+    }
+
+    StatusAction {
+        text: qsTr("Open link")
+        icon.name: "browser"
+        enabled: d.isUnfurled
+        onTriggered: {
+            Qt.openUrlExternally(url);
         }
     }
 }

--- a/ui/imports/shared/views/chat/LinksMessageView.qml
+++ b/ui/imports/shared/views/chat/LinksMessageView.qml
@@ -24,7 +24,7 @@ ColumnLayout {
 
     property bool isCurrentUser: false
 
-    signal imageClicked(var image, var mouse, var imageSource)
+    signal imageClicked(var image, var mouse, var imageSource, string url)
 
     Repeater {
         id: linksRepeater
@@ -86,8 +86,8 @@ ColumnLayout {
                 id: linkImage
 
                 readonly property bool globalAnimationEnabled: root.messageStore.playAnimation
+                readonly property string urlLink: url
                 property bool localAnimationEnabled: true
-
                 objectName: "LinksMessageView_unfurledImageComponent_linkImage"
                 anchors.centerIn: parent
                 source: thumbnailUrl
@@ -101,7 +101,7 @@ ColumnLayout {
                     if (isAnimated && !playing)
                         localAnimationEnabled = true
                     else
-                        root.imageClicked(linkImage.imageAlias, mouse, source)
+                        root.imageClicked(linkImage.imageAlias, mouse, source, urlLink)
                 }
                 imageAlias.cache: localAnimationEnabled // GIFs can only loop/play properly with cache enabled
                 Loader {

--- a/ui/imports/shared/views/chat/MessageView.qml
+++ b/ui/imports/shared/views/chat/MessageView.qml
@@ -312,13 +312,13 @@ Loader {
             Global.openMenu(addReactionContextMenu, root, {}, point)
         }
 
-        function onImageClicked(image, mouse, imageSource) {
+        function onImageClicked(image, mouse, imageSource, url = "") {
             switch (mouse.button) {
             case Qt.LeftButton:
-                Global.openImagePopup(image)
+                Global.openImagePopup(image, url)
                 break;
             case Qt.RightButton:
-                Global.openMenu(imageContextMenuComponent, image, { imageSource })
+                Global.openMenu(imageContextMenuComponent, image, { imageSource, url })
                 break;
             }
         }
@@ -762,8 +762,8 @@ Loader {
                         messageStore: root.messageStore
                         store: root.rootStore
                         isCurrentUser: root.amISender
-                        onImageClicked: (image, mouse, imageSource) => {
-                            d.onImageClicked(image, mouse, imageSource)
+                        onImageClicked: (image, mouse, imageSource, url) => {
+                            d.onImageClicked(image, mouse, imageSource, url)
                         }
                     }
                 }

--- a/ui/imports/utils/Global.qml
+++ b/ui/imports/utils/Global.qml
@@ -33,7 +33,7 @@ QtObject {
     signal openDownloadModalRequested(bool available, string version, string url)
     signal openChangeProfilePicPopup(var cb)
     signal openBackUpSeedPopup()
-    signal openImagePopup(var image)
+    signal openImagePopup(var image, string url)
     signal openProfilePopupRequested(string publicKey, var parentPopup, var cb)
     signal openEditDisplayNamePopup()
     signal openActivityCenterPopupRequested()

--- a/ui/imports/utils/Utils.qml
+++ b/ui/imports/utils/Utils.qml
@@ -704,6 +704,10 @@ QtObject {
         return text
     }
 
+    function copyToClipboard(text) {
+        globalUtilsInst.copyToClipboard(text)
+    }
+
     function copyImageToClipboardByUrl(content) {
         globalUtilsInst.copyImageToClipboardByUrl(content)
     }


### PR DESCRIPTION
Also moved copyToClipboard function in Utils
and updated Chat section to use it from there

Closes #11941

### What does the PR do
Updated image context menu to only show Copy link and Open link options

### Affected areas
ImageContextMenu

### Screenshot of functionality (including design for comparison)

https://github.com/status-im/status-desktop/assets/31625338/426e5e2b-c347-4f97-b942-e3ef86f24788

