### PR TITLE
feat(@desktop/wallet): Use estimated latest block for details

### DIFF
--- a/src/app/modules/main/wallet_section/io_interface.nim
+++ b/src/app/modules/main/wallet_section/io_interface.nim
@@ -97,6 +97,9 @@ method getChainIdForChat*(self: AccessInterface): int {.base.} =
 method getLatestBlockNumber*(self: AccessInterface, chainId: int): string {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method getEstimatedLatestBlockNumber*(self: AccessInterface, chainId: int): string {.base.} =
+  raise newException(ValueError, "No implementation available")
+
 method fetchDecodedTxData*(self: AccessInterface, txHash: string, data: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/wallet_section/module.nim
+++ b/src/app/modules/main/wallet_section/module.nim
@@ -374,6 +374,9 @@ method getChainIdForChat*(self: Module): int =
 method getLatestBlockNumber*(self: Module, chainId: int): string =
   return self.transactionService.getLatestBlockNumber(chainId)
 
+method getEstimatedLatestBlockNumber*(self: Module, chainId: int): string =
+  return self.transactionService.getEstimatedLatestBlockNumber(chainId)
+
 method fetchDecodedTxData*(self: Module, txHash: string, data: string) =
   self.transactionService.fetchDecodedTxData(txHash, data)
 

--- a/src/app/modules/main/wallet_section/view.nim
+++ b/src/app/modules/main/wallet_section/view.nim
@@ -151,6 +151,9 @@ QtObject:
   proc getLatestBlockNumber*(self: View, chainId: int): string {.slot.} =
     return self.delegate.getLatestBlockNumber(chainId)
 
+  proc getEstimatedLatestBlockNumber*(self: View, chainId: int): string {.slot.} =
+    return self.delegate.getEstimatedLatestBlockNumber(chainId)
+
   proc fetchDecodedTxData*(self: View, txHash: string, data: string) {.slot.}   =
     self.delegate.fetchDecodedTxData(txHash, data)
 

--- a/src/app_service/service/transaction/service.nim
+++ b/src/app_service/service/transaction/service.nim
@@ -446,6 +446,12 @@ QtObject:
       return response.result{"number"}.getStr
     except Exception as e:
       error "Error getting latest block number", message = e.msg
+    
+  proc getEstimatedLatestBlockNumber*(self: Service, chainId: int): string =
+    try:
+      return $eth.getEstimatedLatestBlockNumber(chainId).result
+    except Exception as e:
+      error "Error getting estimated latest block number", message = e.msg
       return ""
 
 proc getMultiTransactions*(transactionIDs: seq[int]): seq[MultiTransactionDto] =

--- a/src/backend/eth.nim
+++ b/src/backend/eth.nim
@@ -1,5 +1,6 @@
 import json, stint, tables
 import ./core, ./response_type
+from ./gen import rpc
 
 export response_type
 
@@ -31,3 +32,6 @@ proc suggestedFees*(chainId: int): RpcResponse[JsonNode] {.raises: [Exception].}
 proc suggestedRoutes*(account: string, amount: string, token: string, disabledFromChainIDs, disabledToChainIDs, preferredChainIDs: seq[int], sendType: int, lockedInAmounts: var Table[string, string]): RpcResponse[JsonNode] {.raises: [Exception].} =
   let payload = %* [sendType, account, amount, token, disabledFromChainIDs, disabledToChainIDs, preferredChainIDs, 1 , lockedInAmounts]
   return core.callPrivateRPC("wallet_getSuggestedRoutes", payload)
+
+rpc(getEstimatedLatestBlockNumber, "wallet"):
+  chainId: int

--- a/ui/app/AppLayouts/Wallet/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Wallet/stores/RootStore.qml
@@ -165,7 +165,13 @@ QtObject {
     }
 
     function getLatestBlockNumber(chainId) {
+        // NOTE returns hex
         return walletSection.getLatestBlockNumber(chainId)
+    }
+
+    function getEstimatedLatestBlockNumber(chainId) {
+        // NOTE returns decimal
+        return walletSection.getEstimatedLatestBlockNumber(chainId)
     }
 
     function setFilterAddress(address) {

--- a/ui/app/AppLayouts/Wallet/views/TransactionDetailView.qml
+++ b/ui/app/AppLayouts/Wallet/views/TransactionDetailView.qml
@@ -163,7 +163,8 @@ Item {
             WalletTxProgressBlock {
                 id: progressBlock
                 width: Math.min(513, root.width)
-                readonly property int latestBlockNumber: root.isTransactionValid && !pending && !error ? RootStore.hex2Dec(WalletStores.RootStore.getLatestBlockNumber(root.transaction.chainId)) : 0
+                readonly property int latestBlockNumber: root.isTransactionValid && !pending && !error ? WalletStores.RootStore.getEstimatedLatestBlockNumber(root.transaction.chainId) : 0
+                readonly property int latestBlockNumberIn: root.isTransactionValid && !pending && !error && transactionHeader.isMultiTransaction && d.isBridge ? WalletStores.RootStore.getEstimatedLatestBlockNumber(root.transaction.chainIdIn) : 0
                 error: transactionHeader.transactionStatus === Constants.TransactionStatus.Failed
                 pending: transactionHeader.transactionStatus === Constants.TransactionStatus.Pending
                 outNetworkLayer: root.isTransactionValid ? Number(RootStore.getNetworkLayer(transactionHeader.isMultiTransaction ? root.transaction.chainIdOut : root.transaction.chainId)) : 0
@@ -173,7 +174,7 @@ Item {
                 outChainName: transactionHeader.isMultiTransaction ? transactionHeader.networkNameOut : transactionHeader.networkName
                 inChainName: transactionHeader.isMultiTransaction && d.isBridge ? transactionHeader.networkNameIn : ""
                 outNetworkConfirmations: root.isTransactionValid && latestBlockNumber > 0 ? latestBlockNumber - d.blockNumber : 0
-                inNetworkConfirmations: root.isTransactionValid && latestBlockNumber > 0 ? latestBlockNumber - d.blockNumber : 0
+                inNetworkConfirmations: root.isTransactionValid && latestBlockNumberIn > 0 ? latestBlockNumberIn - d.blockNumber : 0
             }
 
             Separator {

--- a/ui/imports/shared/controls/TransactionDelegate.qml
+++ b/ui/imports/shared/controls/TransactionDelegate.qml
@@ -240,39 +240,65 @@ StatusListItem {
         }
 
         // PROGRESS
-        const networkLayer = rootStore.getNetworkLayer(modelData.chainId) === 1
-        // A block on layer1 is every 12s
-        const confirmationTimeStamp = WalletUtils.calculateConfirmationTimestamp(networkLayer, modelData.timestamp)
-        const finalisationTimeStamp = WalletUtils.calculateFinalisationTimestamp(networkLayer, modelData.timestamp)
+        const networkLayer = rootStore.getNetworkLayer(modelData.chainId)
+
+        const isBridge = type === Constants.TransactionType.Bridge
         switch(transactionStatus) {
         case Constants.TransactionStatus.Pending:
             details += qsTr("Status") + endl
             details += qsTr("Pending on %1").arg(root.networkName) + endl2
+            if (isBridge) {
+                details += qsTr("Pending on %1").arg(root.networkNameIn) + endl2
+            }
             break
         case Constants.TransactionStatus.Failed:
             details += qsTr("Status") + endl
             details += qsTr("Failed on %1").arg(root.networkName) + endl2
+            if (isBridge) {
+                details += qsTr("Failed on %1").arg(root.networkNameIn) + endl2
+            }
             break
         case Constants.TransactionStatus.Complete: {
+            const confirmationTimeStamp = WalletUtils.calculateConfirmationTimestamp(networkLayer, modelData.timestamp)
             const timestampString = LocaleUtils.formatDateTime(modelData.timestamp * 1000, Locale.LongFormat)
             details += qsTr("Status") + endl
-            const epoch = parseFloat(Math.abs(walletRootStore.getLatestBlockNumber(modelData.chainId) - detailsObj.blockNumber).toFixed(0)).toLocaleString()
-            details += qsTr("Signed") + endl + root.timestampString + endl2
-            details += qsTr("Signed") + endl + timestampString + endl2
-            details += qsTr("Confirmed") + endl
+            details += qsTr("Signed on %1").arg(root.networkName) + endl + timestampString + endl2
+            details += qsTr("Confirmed on %1").arg(root.networkName) + endl
             details += LocaleUtils.formatDateTime(confirmationTimeStamp * 1000, Locale.LongFormat) + endl2
+            if (isBridge) {
+                const networkInLayer = rootStore.getNetworkLayer(modelData.chainIdIn)
+                const confirmationTimeStampIn = WalletUtils.calculateConfirmationTimestamp(networkInLayer, modelData.timestamp)
+                details += qsTr("Signed on %1").arg(root.networkNameIn) + endl + timestampString + endl2
+                details += qsTr("Confirmed on %1").arg(root.networkNameIn) + endl
+                details += LocaleUtils.formatDateTime(confirmationTimeStampIn * 1000, Locale.LongFormat) + endl2
+            }
             break
         }
         case Constants.TransactionStatus.Finalised: {
             const timestampString = LocaleUtils.formatDateTime(modelData.timestamp * 1000, Locale.LongFormat)
+            const confirmationTimeStamp = WalletUtils.calculateConfirmationTimestamp(networkLayer, modelData.timestamp)
+            const finalisationTimeStamp = WalletUtils.calculateFinalisationTimestamp(networkLayer, modelData.timestamp)
             details += qsTr("Status") + endl
-            const epoch = Math.abs(walletRootStore.getLatestBlockNumber(modelData.chainId) - detailsObj.blockNumber)
-            details += qsTr("Finalised in epoch %1").arg(epoch.toFixed(0)) + endl2
-            details += qsTr("Signed") + endl + timestampString + endl2
-            details += qsTr("Confirmed") + endl
+            const epoch = Math.abs(walletRootStore.getEstimatedLatestBlockNumber(modelData.chainId) - detailsObj.blockNumber)
+            details += qsTr("Finalised in epoch %1 on %2").arg(epoch.toFixed(0)).arg(root.networkName) + endl2
+            details += qsTr("Signed on %1").arg(root.networkName) + endl + timestampString + endl2
+            details += qsTr("Confirmed on %1").arg(root.networkName) + endl
             details += LocaleUtils.formatDateTime(confirmationTimeStamp * 1000, Locale.LongFormat) + endl2
-            details += qsTr("Finalised") + endl
+            details += qsTr("Finalised on %1").arg(root.networkName) + endl
             details += LocaleUtils.formatDateTime(finalisationTimeStamp * 1000, Locale.LongFormat) + endl2
+            if (isBridge) {
+                const networkInLayer = rootStore.getNetworkLayer(modelData.chainIdIn)
+                const confirmationTimeStampIn = WalletUtils.calculateConfirmationTimestamp(networkInLayer, modelData.timestamp)
+                const finalisationTimeStampIn = WalletUtils.calculateFinalisationTimestamp(networkInLayer, modelData.timestamp)
+                const epochIn = Math.abs(walletRootStore.getEstimatedLatestBlockNumber(modelData.chainIdIn) - detailsObj.blockNumber)
+                details += qsTr("Finalised in epoch %1 on %2").arg(epochIn.toFixed(0)).arg(root.networkNameIn) + endl2
+                details += qsTr("Signed on %1").arg(root.networkNameIn) + endl + timestampString + endl2
+                details += qsTr("Confirmed on %1").arg(root.networkNameIn) + endl
+                details += LocaleUtils.formatDateTime(confirmationTimeStampIn * 1000, Locale.LongFormat) + endl2
+                details += qsTr("Finalised on %1").arg(root.networkNameIn) + endl
+                details += LocaleUtils.formatDateTime(finalisationTimeStampIn * 1000, Locale.LongFormat) + endl2
+            }
+
             break
         }
         default:
@@ -356,7 +382,9 @@ StatusListItem {
         if (type !== Constants.TransactionType.Bridge) {
             details += qsTr("Network") + endl + networkName + endl2
         }
-        details += qsTr("Token format") + endl + modelData.tokenType.toUpperCase() + endl2
+        if (!!detailsObj.tokenType) {
+            details += qsTr("Token format") + endl + detailsObj.tokenType.toUpperCase() + endl2
+        }
         details += qsTr("Nonce") + endl + detailsObj.nonce + endl2
         if (type === Constants.TransactionType.Bridge) {
             details += qsTr("Included in Block on %1").arg(networkName) + endl


### PR DESCRIPTION
closes #11564 
status-go change: https://github.com/status-im/status-go/pull/3973

### What does the PR do

* Use estimated latest block in activity details
* For Bridge get in chain block number
* Updated activity details text to contain in and out chain progress info (confirmation, epoch)

### Affected areas

Wallet activity

### Screenshot of functionality (including design for comparison)

![image](https://github.com/status-im/status-desktop/assets/11396062/d03279f4-e9ce-431f-aa9d-af14ca1b3a39)

