### PR TITLE
feat: Passing an empty seq to dataChanged doesn't apply all roles

### DIFF
--- a/src/app/modules/main/browser_section/bookmark/model.nim
+++ b/src/app/modules/main/browser_section/bookmark/model.nim
@@ -123,6 +123,5 @@ QtObject:
     defer: bottomRight.delete
 
     self.items[index] = item
-    self.dataChanged(topLeft, bottomRight, @[ModelRole.Name.int, ModelRole.Url.int, ModelRole.ImageUrl.int])
+    self.dataChanged(topLeft, bottomRight)
     self.modelChanged()
-

--- a/src/app/modules/main/communities/models/curated_community_model.nim
+++ b/src/app/modules/main/communities/models/curated_community_model.nim
@@ -136,21 +136,9 @@ QtObject:
     let idx = self.findIndexById(item.getId())
     if idx > -1:
       let index = self.createIndex(idx, 0, nil)
+      defer: index.delete
       self.items[idx] = item
-      self.dataChanged(index, index, @[
-        ModelRole.Name.int,
-        ModelRole.Available.int,
-        ModelRole.Description.int,
-        ModelRole.Icon.int,
-        ModelRole.Banner.int,
-        ModelRole.Featured.int,
-        ModelRole.Members.int,
-        ModelRole.ActiveMembers.int,
-        ModelRole.Color.int,
-        ModelRole.Popularity.int,
-        ModelRole.Tags.int,
-        ModelRole.Permissions.int,
-      ])
+      self.dataChanged(index, index)
     else:
       let parentModelIndex = newQModelIndex()
       defer: parentModelIndex.delete

--- a/src/app/modules/main/profile_section/wallet/accounts/model.nim
+++ b/src/app/modules/main/profile_section/wallet/accounts/model.nim
@@ -74,9 +74,8 @@ QtObject:
         item.colorId = account.colorId
         item.emoji = account.emoji
         let index = self.createIndex(i, 0, nil)
-        self.dataChanged(index, index, @[ModelRole.Name.int])
-        self.dataChanged(index, index, @[ModelRole.ColorId.int])
-        self.dataChanged(index, index, @[ModelRole.Emoji.int])
+        defer: index.delete
+        self.dataChanged(index, index, @[ModelRole.Name.int, ModelRole.ColorId.int, ModelRole.Emoji.int])
         break
       i.inc
 

--- a/src/app/modules/main/wallet_section/send/network_model.nim
+++ b/src/app/modules/main/wallet_section/send/network_model.nim
@@ -143,14 +143,12 @@ QtObject:
   proc reset*(self: NetworkModel) =
     for i in 0 ..< self.items.len:
       let index = self.createIndex(i, 0, nil)
+      defer: index.delete
       self.items[i].amountIn = ""
       self.items[i].amountOut = ""
       self.items[i].resetToNetworks()
       self.items[i].hasGas = true
-      self.dataChanged(index, index, @[ModelRole.AmountIn.int])
-      self.dataChanged(index, index, @[ModelRole.ToNetworks.int])
-      self.dataChanged(index, index, @[ModelRole.HasGas.int])
-      self.dataChanged(index, index, @[ModelRole.AmountOut.int])
+      self.dataChanged(index, index, @[ModelRole.AmountIn.int, ModelRole.ToNetworks.int, ModelRole.HasGas.int, ModelRole.AmountOut.int])
 
   proc updateTokenBalanceForSymbol*(self: NetworkModel, chainId: int, tokenBalance: CurrencyAmount) =
     for i in 0 ..< self.items.len:
@@ -163,14 +161,12 @@ QtObject:
     for i in 0 ..< self.items.len:
       if path.getfromNetwork() == self.items[i].getChainId():
         let index = self.createIndex(i, 0, nil)
+        defer: index.delete
         self.items[i].amountIn = path.getAmountIn()
         self.items[i].toNetworks = path.getToNetwork()
         self.items[i].hasGas = hasGas
         self.items[i].locked = path.getAmountInLocked()
-        self.dataChanged(index, index, @[ModelRole.AmountIn.int])
-        self.dataChanged(index, index, @[ModelRole.ToNetworks.int])
-        self.dataChanged(index, index, @[ModelRole.HasGas.int])
-        self.dataChanged(index, index, @[ModelRole.Locked.int])
+        self.dataChanged(index, index, @[ModelRole.AmountIn.int, ModelRole.ToNetworks.int, ModelRole.HasGas.int, ModelRole.Locked.int])
 
   proc updateToNetworks*(self: NetworkModel, path: SuggestedRouteItem) =
     for i in 0 ..< self.items.len:
@@ -211,8 +207,7 @@ QtObject:
             if $self.items[i].getChainId() == chainID:
               self.items[i].isPreferred = true
               self.items[i].isEnabled = true
-        self.dataChanged(index, index, @[ModelRole.IsPreferred.int])
-        self.dataChanged(index, index, @[ModelRole.IsEnabled.int])
+        self.dataChanged(index, index, @[ModelRole.IsPreferred.int, ModelRole.IsEnabled.int])
     except:
       discard
 

--- a/src/app/modules/shared_models/link_preview_model.nim
+++ b/src/app/modules/shared_models/link_preview_model.nim
@@ -74,20 +74,6 @@ QtObject:
       ModelRole.ThumbnailDataUri.int:"thumbnailDataUri",
     }.toTable
 
-  method allLinkPreviewRoles(self: Model): seq[int] =
-    return @[
-      ModelRole.Url.int,
-      ModelRole.Unfurled.int,
-      ModelRole.Hostname.int,
-      ModelRole.Title.int,
-      ModelRole.Description.int,
-      ModelRole.LinkType.int,
-      ModelRole.ThumbnailWidth.int,
-      ModelRole.ThumbnailHeight.int,
-      ModelRole.ThumbnailUrl.int,
-      ModelRole.ThumbnailDataUri.int,
-    ]
-
   method data(self: Model, index: QModelIndex, role: int): QVariant =
     if (not index.isValid):
       return
@@ -148,4 +134,4 @@ QtObject:
       item.linkPreview = linkPreviews[item.linkPreview.url]
       let modelIndex = self.createIndex(row, 0, nil)
       defer: modelIndex.delete
-      self.dataChanged(modelIndex, modelIndex, self.allLinkPreviewRoles())
+      self.dataChanged(modelIndex, modelIndex)

--- a/src/app/modules/shared_models/message_model.nim
+++ b/src/app/modules/shared_models/message_model.nim
@@ -69,7 +69,6 @@ QtObject:
   type
     Model* = ref object of QAbstractListModel
       items*: seq[Item]
-      allKeys: seq[int]
       firstUnseenMessageId: string
 
   proc delete(self: Model) =
@@ -82,12 +81,6 @@ QtObject:
   proc newModel*(): Model =
     new(result, delete)
     result.setup
-
-    # This is just a clean way to have all roles in a seq, without typing long seq manualy, and this way we're sure that
-    # all new added roles will be included here as well.
-    for i in result.roleNames().keys:
-      result.allKeys.add(i)
-
     result.firstUnseenMessageId = ""
 
   proc `$`*(self: Model): string =
@@ -320,7 +313,8 @@ QtObject:
 
   proc updateItemAtIndex(self: Model, index: int) =
     let ind = self.createIndex(index, 0, nil)
-    self.dataChanged(ind, ind, self.allKeys)
+    defer: ind.delete
+    self.dataChanged(ind, ind)
 
   proc findIndexForMessageId*(self: Model, messageId: string): int =
     result = -1

--- a/src/app/modules/shared_models/message_reaction_model.nim
+++ b/src/app/modules/shared_models/message_reaction_model.nim
@@ -114,8 +114,8 @@ QtObject:
         return
       self.items[ind].addReaction(didIReactWithThisEmoji, userPublicKey, userDisplayName, reactionId)
       let index = self.createIndex(ind, 0, nil)
-      self.dataChanged(index, index, @[ModelRole.EmojiId.int, ModelRole.DidIReactWithThisEmoji.int,
-      ModelRole.NumberOfReactions.int, ModelRole.JsonArrayOfUsersReactedWithThisEmoji.int])
+      defer: index.delete
+      self.dataChanged(index, index)
     else:
       let parentModelIndex = newQModelIndex()
       defer: parentModelIndex.delete
@@ -147,5 +147,5 @@ QtObject:
       self.countChanged()
     else:
       let index = self.createIndex(ind, 0, nil)
-      self.dataChanged(index, index, @[ModelRole.EmojiId.int, ModelRole.DidIReactWithThisEmoji.int,
-      ModelRole.NumberOfReactions.int, ModelRole.JsonArrayOfUsersReactedWithThisEmoji.int])
+      defer: index.delete
+      self.dataChanged(index, index)

--- a/src/app/modules/shared_models/section_model.nim
+++ b/src/app/modules/shared_models/section_model.nim
@@ -272,38 +272,7 @@ QtObject:
     self.items[index] = item
     let dataIndex = self.createIndex(index, 0, nil)
     defer: dataIndex.delete
-    self.dataChanged(dataIndex, dataIndex, @[
-      ModelRole.Name.int,
-      ModelRole.MemberRole.int,
-      ModelRole.IsControlNode.int,
-      ModelRole.Description.int,
-      ModelRole.IntroMessage.int,
-      ModelRole.OutroMessage.int,
-      ModelRole.Image.int,
-      ModelRole.BannerImageData.int,
-      ModelRole.Icon.int,
-      ModelRole.Color.int,
-      ModelRole.Tags.int,
-      ModelRole.HasNotification.int,
-      ModelRole.NotificationsCount.int,
-      ModelRole.IsMember.int,
-      ModelRole.CanJoin.int,
-      ModelRole.Joined.int,
-      ModelRole.Spectated.int,
-      ModelRole.Access.int,
-      ModelRole.EnsOnly.int,
-      ModelRole.Muted.int, 
-      ModelRole.MembersModel.int,
-      ModelRole.PendingRequestsToJoinModel.int,
-      ModelRole.HistoryArchiveSupportEnabled.int,
-      ModelRole.PinMessageAllMembersEnabled.int,
-      ModelRole.BannedMembersModel.int,
-      ModelRole.Encrypted.int,
-      ModelRole.CommunityTokensModel.int,
-      ModelRole.PendingMemberRequestsModel.int,
-      ModelRole.DeclinedMemberRequestsModel.int,
-      ModelRole.AmIBanned.int,
-      ])
+    self.dataChanged(dataIndex, dataIndex)
 
   proc getNthEnabledItem*(self: SectionModel, nth: int): SectionItem =
     if nth >= 0 and nth < self.items.len:
@@ -454,4 +423,3 @@ QtObject:
 
     for pubkey, revealedAccounts in communityMembersAirdropAddress.pairs:
       self.items[index].members.setAirdropAddress(pubkey, revealedAccounts)
-      

--- a/src/app/modules/shared_models/token_permissions_model.nim
+++ b/src/app/modules/shared_models/token_permissions_model.nim
@@ -145,11 +145,11 @@ QtObject:
     self.items[idx].tokenCriteriaMet = item.tokenCriteriaMet
 
     let index = self.createIndex(idx, 0, nil)
+    defer: index.delete
     self.dataChanged(index, index, @[
-      ModelRole.Id.int,
-      ModelRole.Key.int,
       ModelRole.Type.int,
       ModelRole.TokenCriteria.int,
+      ModelRole.ChatList.int,
       ModelRole.IsPrivate.int,
       ModelRole.TokenCriteriaMet.int
     ])

--- a/vendor/DOtherSide/lib/src/DOtherSide.cpp
+++ b/vendor/DOtherSide/lib/src/DOtherSide.cpp
@@ -1301,8 +1301,11 @@ void dos_qabstractitemmodel_dataChanged(::DosQAbstractItemModel *vptr,
     auto model = dynamic_cast<DOS::DosIQAbstractItemModelImpl *>(object);
     auto topLeft = static_cast<const QModelIndex *>(topLeftIndex);
     auto bottomRight = static_cast<const QModelIndex *>(bottomRightIndex);
-    auto roles = QVector<int>(rolesArrayPtr, rolesArrayPtr + rolesArrayLength);
-    model->publicDataChanged(*topLeft, *bottomRight, roles);
+    if (rolesArrayPtr && rolesArrayLength > 0) {
+        model->publicDataChanged(*topLeft, *bottomRight, {rolesArrayPtr, rolesArrayPtr + rolesArrayLength});
+    } else {
+        model->publicDataChanged(*topLeft, *bottomRight);
+    }
 }
 
 DosQModelIndex *dos_qabstractitemmodel_createIndex(::DosQAbstractItemModel *vptr,


### PR DESCRIPTION
When calling `QAIM.dataChanged(index, index, [roles])`, passing nothing (ie omitting the parameter altogether), an empty array `[]`, or an empty sequence `@[]` means "all roles", just like the C++ counterpart in https://doc.qt.io/qt-5/qabstractitemmodel.html#dataChanged

Depends on https://github.com/status-im/nimqml/pull/54

Fixes #11830