### PR TITLE
fix(Airdrop): Update owner and tmaster tokens visualization in airdrop's list

### DIFF
--- a/ui/app/AppLayouts/Communities/views/CommunitySettingsView.qml
+++ b/ui/app/AppLayouts/Communities/views/CommunitySettingsView.qml
@@ -481,10 +481,20 @@ StatusSectionLayout {
                 sourceComponent: SortFilterProxyModel {
 
                     sourceModel: airdropPanel.communityTokens
-                    filters: ValueFilter {
-                        roleName: "tokenType"
-                        value: Constants.TokenType.ERC721
-                    }
+                    filters: [
+                        ValueFilter {
+                            roleName: "tokenType"
+                            value: Constants.TokenType.ERC721
+                        },
+                        ExpressionFilter {
+                            function getPrivileges(privilegesLevel) {
+                                return privilegesLevel === Constants.TokenPrivilegesLevel.Community ||
+                                        (root.isOwner && privilegesLevel === Constants.TokenPrivilegesLevel.TMaster)
+                            }
+
+                            expression: { return getPrivileges(model.privilegesLevel) }
+                        }
+                    ]
                     proxyRoles: [
                         ExpressionRole {
                             name: "category"


### PR DESCRIPTION
Fixes #12089

### What does the PR do
 
Added filter in collectibles airdrop's list:
- TMaster token will be shown ONLY if user is the community owner.
- Owner token is always hidden.

### Affected areas

Community settings / Airdrop

### Screenshot of functionality 
- Member owning TMaster token:
![Screenshot 2023-09-07 at 18 07 54](https://github.com/status-im/status-desktop/assets/97019400/f19b6d0b-8861-4306-9d07-041a2476ac60)

- Community owner:
![Screenshot 2023-09-07 at 18 08 56](https://github.com/status-im/status-desktop/assets/97019400/589c0a2c-f124-470d-bafa-3f48a5bb65d8)


