### PR TITLE
fix(chat): enabled "everyone" in group chat mentions

### DIFF
--- a/ui/app/AppLayouts/Chat/panels/SuggestionFilterPanel.qml
+++ b/ui/app/AppLayouts/Chat/panels/SuggestionFilterPanel.qml
@@ -13,7 +13,6 @@ Item {
     property int cursorPosition: 0
     property int lastAtPosition: 0
     property var property: ([])
-    property bool addSystemSuggestions: false
 
     onFilterChanged: invalidateFilter()
     onPropertyChanged: invalidateFilter()
@@ -86,7 +85,7 @@ Item {
             name: "everyone",
             icon: ""
         }
-        if (suggestionsPanelRoot.addSystemSuggestions && (all || isAcceptedItem(filter, everyoneItem))) {
+        if (all || isAcceptedItem(filter, everyoneItem)) {
             filterModel.append(everyoneItem)
         }
     }

--- a/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
@@ -320,7 +320,6 @@ Item {
                     emojiPopup: root.emojiPopup
                     stickersPopup: root.stickersPopup
                     chatType: root.activeChatType
-                    suggestions.suggestionFilter.addSystemSuggestions: chatType === Constants.chatType.communityChat
 
                     textInput.onTextChanged: {
                         d.updateLinkPreviews()


### PR DESCRIPTION
Closes #11029

### What does the PR do
Enables "everyone" suggestion in group chat mentions box

### Affected areas
group chat mentions box

### Screenshot of functionality (including design for comparison)

https://github.com/status-im/status-desktop/assets/31625338/03903100-ac8e-4c92-95df-1c9de8c05e11

