### PR TITLE
fix(@desktop/wallet): the app crashes when receives "show/hide watch only" value from paired device

### DIFF
--- a/src/app/modules/main/profile_section/wallet/accounts/module.nim
+++ b/src/app/modules/main/profile_section/wallet/accounts/module.nim
@@ -176,7 +176,8 @@ method load*(self: Module) =
     self.refreshWalletAccounts()
 
   self.events.on(SIGNAL_INCLUDE_WATCH_ONLY_ACCOUNTS_UPDATED) do(e: Args):
-    self.view.setIncludeWatchOnlyAccount(self.controller.isIncludeWatchOnlyAccount())
+    let args = SettingsBoolValueArgs(e)
+    self.view.setIncludeWatchOnlyAccount(args.value)
 
   self.events.on(SIGNAL_WALLET_ACCOUNT_PREFERRED_SHARING_CHAINS_UPDATED) do(e: Args):
     let args = AccountArgs(e)

--- a/src/app_service/service/settings/service.nim
+++ b/src/app_service/service/settings/service.nim
@@ -116,7 +116,7 @@ QtObject:
             self.events.emit(SIGNAL_MNEMONIC_REMOVED, Args())
           if settingsField.name == INCLUDE_WATCH_ONLY_ACCOUNT:
             self.settings.includeWatchOnlyAccount = settingsField.value.getBool
-            self.events.emit(SIGNAL_INCLUDE_WATCH_ONLY_ACCOUNTS_UPDATED, Args())
+            self.events.emit(SIGNAL_INCLUDE_WATCH_ONLY_ACCOUNTS_UPDATED, SettingsBoolValueArgs(value: self.settings.includeWatchOnlyAccount))
           if settingsField.name == PROFILE_MIGRATION_NEEDED:
             self.settings.profileMigrationNeeded = settingsField.value.getBool
             self.events.emit(SIGNAL_PROFILE_MIGRATION_NEEDED_UPDATED, SettingsBoolValueArgs(value: self.settings.profileMigrationNeeded))


### PR DESCRIPTION
Fixes: #12115