### PR TITLE
StatusChatInput: remove unmaintained integration with ChatCommandsPopup

### DIFF
--- a/ui/app/AppLayouts/Chat/stores/CreateChatPropertiesStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/CreateChatPropertiesStore.qml
@@ -5,18 +5,14 @@ QtObject {
 
     property string createChatInitMessage: ""
     property var createChatFileUrls: []
-    property bool createChatStartSendTransactionProcess: false
-    property bool createChatStartReceiveTransactionProcess: false
     property string createChatStickerHashId: ""
     property string createChatStickerPackId: ""
     property string createChatStickerUrl: ""
 
     function resetProperties() {
-        root.createChatInitMessage = "";
-        root.createChatFileUrls = [];
-        root.createChatStartSendTransactionProcess = false;
-        root.createChatStartReceiveTransactionProcess = false;
-        root.createChatStickerHashId = "";
-        root.createChatStickerPackId = "";
+        root.createChatInitMessage = ""
+        root.createChatFileUrls = []
+        root.createChatStickerHashId = ""
+        root.createChatStickerPackId = ""
     }
 }

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -624,10 +624,6 @@ QtObject {
         return globalUtilsInst.wei2Eth(wei,18)
     }
 
-    function getEth2Wei(eth) {
-         return globalUtilsInst.eth2Wei(eth, 18)
-    }
-
     function getEtherscanLink() {
         return profileSectionModule.ensUsernamesModule.getEtherscanLink()
     }

--- a/ui/app/AppLayouts/Chat/views/CreateChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/CreateChatView.qml
@@ -161,14 +161,6 @@ Page {
                 usersStore: ({
                     usersModel: membersSelector.model
                 })
-                onSendTransactionCommandButtonClicked: {
-                    root.createChatPropertiesStore.createChatStartSendTransactionProcess = true;
-                    membersSelector.createChat();
-                }
-                onReceiveTransactionCommandButtonClicked: {
-                    root.createChatPropertiesStore.createChatStartReceiveTransactionProcess = true;
-                    membersSelector.createChat();
-                }
                 onStickerSelected: {
                     root.createChatPropertiesStore.createChatStickerHashId = hashId;
                     root.createChatPropertiesStore.createChatStickerPackId = packId;

--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -24,8 +24,6 @@ Rectangle {
     id: control
     objectName: "statusChatInput"
 
-    signal sendTransactionCommandButtonClicked()
-    signal receiveTransactionCommandButtonClicked()
     signal stickerSelected(string hashId, string packId, string url)
     signal sendMessage(var event)
     signal keyUpPress()
@@ -172,7 +170,6 @@ Rectangle {
             }
         }
 
-        property bool chatCommandsPopupOpen: false
         property Menu textFormatMenu: null
 
         function copyMentions(start, end) {
@@ -1021,35 +1018,6 @@ Rectangle {
     }
 
     Component {
-        id: chatCommandsPopupComponent
-
-        ChatCommandsPopup {
-            id: chatCommandsPopup
-            x: 8
-            y: -height
-            onSendTransactionCommandButtonClicked: {
-                control.sendTransactionCommandButtonClicked()
-                close()
-            }
-            onReceiveTransactionCommandButtonClicked: {
-                control.receiveTransactionCommandButtonClicked()
-                close()
-            }
-            onClosed: {
-                chatCommandsBtn.highlighted = false
-                destroy()
-            }
-            onOpened: {
-                chatCommandsBtn.highlighted = true
-            }
-            Component.onDestruction: {
-                if (d.chatCommandsPopupOpen)
-                    d.chatCommandsPopupOpen = false;
-            }
-        }
-    }
-
-    Component {
         id: gifPopupComponent
 
         StatusGifPopup {
@@ -1080,26 +1048,6 @@ Rectangle {
         id: layout
         anchors.fill: parent
         spacing: 4
-
-        // TODO remove that Loader when the Chat Commands are re-implemented and fixed
-        Loader {
-            id: chatCommandsBtnLoader
-            active: false
-            sourceComponent: StatusQ.StatusFlatRoundButton {
-                id: chatCommandsBtn
-                Layout.preferredWidth: 32
-                Layout.preferredHeight: 32
-                Layout.alignment: Qt.AlignBottom
-                Layout.bottomMargin: 4
-                icon.name: "chat-commands"
-                type: StatusQ.StatusFlatRoundButton.Type.Tertiary
-                onClicked: {
-                    d.chatCommandsPopupOpen ? Global.closePopup() : Global.openPopup(chatCommandsPopup);
-                    d.chatCommandsPopupOpen = !d.chatCommandsPopupOpen;
-                }
-                visible: RootStore.isWalletEnabled && !isEdit && control.chatType === Constants.chatType.oneToOne
-            }
-        }
 
         StatusQ.StatusFlatRoundButton {
             id: imageBtn
@@ -1534,6 +1482,5 @@ Rectangle {
                 }
             }
         }
-
     }
 }


### PR DESCRIPTION
### What does the PR do

The functionality for sending/receiving funds directly from chat is currently not supported, both code and designs are outdated. This commit removes integration part but leaves `ChatCommandsPopup` component for potential future use.

Related figma design:  https://www.figma.com/file/Mr3rqxxgKJ2zMQ06UAKiWL/%F0%9F%92%AC-Chat%E2%8E%9CDesktop?type=design&node-id=1335-145&mode=design&t=2k8OmchnCFOe6IRQ-0

Closes: #12118

### Affected areas
`StatusChatInput`
