### PR TITLE
fix(StatusChatInput): Sent message image attachment persists when changing chat types

### DIFF
--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -937,6 +937,7 @@ Rectangle {
 
     Connections {
         target: Global.dragArea
+        enabled: control.visible
         ignoreUnknownSignals: true
         function onDroppedOnValidScreen(drop) {
             let dropUrls = drop.urls


### PR DESCRIPTION
The issue looks related to the recent conversion of `StatusChatInput` to a *resident* like control, where text, reply and image attachment data is persistent across the two types of chat modules, regular and community chats, and is restored when switching between the two types of chat.

After some investigation, the simplest fix, is to allow image drops only in the currently visible `StatusChatInput` control.

# Video demo


https://github.com/status-im/status-desktop/assets/544446/5f149c43-0b48-426c-812c-77e0d080f92b



Fixes #10885
