### PR TITLE
Feat/collectibles ownership update improvements

### DIFF
--- a/src/app/modules/shared_modules/collectibles/events_handler.nim
+++ b/src/app/modules/shared_modules/collectibles/events_handler.nim
@@ -24,6 +24,7 @@ QtObject:
       collectiblesOwnershipUpdateStartedFn: OwnershipUpdateCallbackProc
       collectiblesOwnershipUpdatePartialFn: OwnershipUpdateCallbackProc
       collectiblesOwnershipUpdateFinishedFn: OwnershipUpdateCallbackProc
+      collectiblesOwnershipUpdateFinishedWithErrorFn: OwnershipUpdateCallbackProc
 
       requestId: int32
 
@@ -44,6 +45,9 @@ QtObject:
 
   proc onCollectiblesOwnershipUpdateFinished*(self: EventsHandler, handler: OwnershipUpdateCallbackProc) =
     self.collectiblesOwnershipUpdateFinishedFn = handler
+
+  proc onCollectiblesOwnershipUpdateFinishedWithError*(self: EventsHandler, handler: OwnershipUpdateCallbackProc) =
+    self.collectiblesOwnershipUpdateFinishedWithErrorFn = handler
 
   proc handleApiEvents(self: EventsHandler, e: Args) =
     var data = WalletSignal(e)
@@ -88,6 +92,11 @@ QtObject:
       if self.collectiblesOwnershipUpdateFinishedFn == nil or self.shouldIgnoreEvent(data):
         return
       self.collectiblesOwnershipUpdateFinishedFn(data.accounts[0], data.chainID)
+
+    self.walletEventHandlers[backend_collectibles.eventCollectiblesOwnershipUpdateFinishedWithError] = proc (data: WalletSignal) =
+      if self.collectiblesOwnershipUpdateFinishedWithErrorFn == nil or self.shouldIgnoreEvent(data):
+        return
+      self.collectiblesOwnershipUpdateFinishedWithErrorFn(data.accounts[0], data.chainID)
 
   proc newEventsHandler*(requestId: int32, events: EventEmitter): EventsHandler =
     new(result, delete)

--- a/src/backend/collectibles.nim
+++ b/src/backend/collectibles.nim
@@ -16,6 +16,7 @@ type
 
 # Declared in services/wallet/collectibles/service.go
 const eventCollectiblesOwnershipUpdateStarted*: string = "wallet-collectibles-ownership-update-started"
+const eventCollectiblesOwnershipUpdatePartial*: string = "wallet-collectibles-ownership-update-partial"
 const eventCollectiblesOwnershipUpdateFinished*: string = "wallet-collectibles-ownership-update-finished"
 const eventCollectiblesOwnershipUpdateFinishedWithError*: string = "wallet-collectibles-ownership-update-finished-with-error"
 

--- a/src/backend/collectibles.nim
+++ b/src/backend/collectibles.nim
@@ -1,5 +1,5 @@
 import json, json_serialization, strformat
-import stint, Tables
+import stint, Tables, strutils
 import core
 import response_type, collectibles_types
 
@@ -23,6 +23,8 @@ const eventCollectiblesOwnershipUpdateFinishedWithError*: string = "wallet-colle
 const eventOwnedCollectiblesFilteringDone*: string = "wallet-owned-collectibles-filtering-done"
 const eventGetCollectiblesDetailsDone*: string = "wallet-get-collectibles-details-done"
 
+const invalidTimestamp*: int = -1
+
 type
   # Mirrors services/wallet/collectibles/service.go ErrorCode
   ErrorCode* = enum
@@ -30,17 +32,42 @@ type
     ErrorCodeTaskCanceled,
     ErrorCodeFailed
 
+  # Mirrors services/wallet/collectibles/service.go OwnershipState
+  OwnershipState* = enum
+    OwnershipStateIdle = 1,
+    OwnershipStateUpdating,
+    OwnershipStateError
+
+  # Mirrors services/wallet/collectibles/service.go OwnershipState
+  OwnershipStatus* = ref object
+    state*: OwnershipState
+    timestamp*: int
+
   # Mirrors services/wallet/collectibles/service.go FilterOwnedCollectiblesResponse
   FilterOwnedCollectiblesResponse* = object
     collectibles*: seq[CollectibleHeader]
     offset*: int
     hasMore*: bool
+    ownershipStatus*: Table[string, Table[int, OwnershipStatus]]
     errorCode*: ErrorCode
 
   # Mirrors services/wallet/collectibles/service.go GetCollectiblesDetailsResponse
   GetCollectiblesDetailsResponse* = object
     collectibles*: seq[CollectibleDetails]
     errorCode*: ErrorCode
+
+# CollectibleOwnershipState
+proc `$`*(self: OwnershipStatus): string =
+  return fmt"""OwnershipStatus(
+    state:{self.state}, 
+    timestamp:{self.timestamp}
+    """
+
+proc fromJson*(t: JsonNode, T: typedesc[OwnershipStatus]): OwnershipStatus {.inline.} =
+    return OwnershipStatus(
+        state: OwnershipState(t{"state"}.getInt),
+        timestamp: t{"timestamp"}.getInt
+    )
 
 # Responses
 proc fromJson*(e: JsonNode, T: typedesc[FilterOwnedCollectiblesResponse]): FilterOwnedCollectiblesResponse {.inline.} =
@@ -51,11 +78,21 @@ proc fromJson*(e: JsonNode, T: typedesc[FilterOwnedCollectiblesResponse]): Filte
     for i in 0 ..< jsonCollectibles.len:
       collectibles[i] = fromJson(jsonCollectibles[i], CollectibleHeader)
 
+  var ownershipStatus = initTable[string, Table[int, OwnershipStatus]]()
+  if e.hasKey("ownershipStatus"):
+    let jsonOwnershipStatus = e["ownershipStatus"]
+    for address, jsonStatusPerChain in jsonOwnershipStatus.getFields():
+      var statusPerChain = initTable[int, OwnershipStatus]()
+      for chainId, jsonStatus in jsonStatusPerChain.getFields():
+        statusPerChain[parseInt(chainId)] = fromJson(jsonStatus, OwnershipStatus)
+      ownershipStatus[address] = statusPerChain
+
   result = T(
     collectibles: collectibles,
     offset: e["offset"].getInt(),
     hasMore: if e.hasKey("hasMore"): e["hasMore"].getBool()
                       else: false,
+    ownershipStatus: ownershipStatus,
     errorCode: ErrorCode(e["errorCode"].getInt())
   )
 


### PR DESCRIPTION
### What does the PR do

Fixes https://github.com/status-im/status-desktop/issues/12150 and https://github.com/status-im/status-desktop/issues/12159
status-go part: https://github.com/status-im/status-go/pull/4027#issuecomment-1720215634

Changes split in 2 commits:
1. Update collectibles list when partial update progress is reported (faster update when a new account with lots of collectibles is added)
2. Use Ownership Status reported by backend. These allows properly setting the loading state, and enables management of the error state (to be done in a separate PR).
