### PR TITLE
fix(shared addresses) wallet address selection broken

### DIFF
--- a/storybook/pages/SharedAddressesPopupPage.qml
+++ b/storybook/pages/SharedAddressesPopupPage.qml
@@ -62,12 +62,13 @@ SplitView {
             }
 
             Binding on selectedAirdropAddress {
-                value: "0x7F47C2e98a4BBf5487E6fb082eC2D9Ab0E6d8881"
+                value: "0x7F47C2e98a4BBf5487E6fb082eC2D9Ab0E6d8884"
                 when: ctrlEditMode.checked
             }
 
             onShareSelectedAddressesClicked: logs.logEvent("::shareSelectedAddressesClicked", ["airdropAddress", "sharedAddresses"], arguments)
             onSaveSelectedAddressesClicked: logs.logEvent("::saveSelectedAddressesClicked", ["airdropAddress", "sharedAddresses"], arguments)
+            onSharedAddressesChanged: logs.logEvent("::sharedAddressesChanged", ["airdropAddress", "sharedAddresses"], arguments)
             onClosed: destroy()
         }
     }

--- a/ui/app/AppLayouts/Communities/panels/SharedAddressesAccountSelector.qml
+++ b/ui/app/AppLayouts/Communities/panels/SharedAddressesAccountSelector.qml
@@ -86,7 +86,7 @@ StatusListView {
             StatusBaseText {
                 anchors.verticalCenter: parent.verticalCenter
                 font.pixelSize: Theme.tertiaryTextFontSize
-                text: LocaleUtils.currencyAmountToLocaleString(enabledNetworkBalance)
+                text: LocaleUtils.currencyAmountToLocaleString(model.enabledNetworkBalance)
             }
         }
 
@@ -105,7 +105,7 @@ StatusListView {
                 icon.color: hovered ? Theme.palette.primaryColor3 :
                                       checked ? Theme.palette.primaryColor1 : disabledTextColor
                 checkable: true
-                checked: listItem.address === root.selectedAirdropAddress
+                checked: listItem.address === root.selectedAirdropAddress.toLowerCase()
                 enabled: shareAddressCheckbox.checked && root.selectedSharedAddresses.length > 1 // last cannot be unchecked
                 visible: shareAddressCheckbox.checked
                 opacity: enabled ? 1.0 : 0.3
@@ -123,11 +123,11 @@ StatusListView {
                 ButtonGroup.group: d.addressesGroup
                 anchors.verticalCenter: parent.verticalCenter
                 checkable: true
-                checked: root.selectedSharedAddresses.includes(listItem.address)
+                checked: root.selectedSharedAddresses.some((address) => address.toLowerCase() === listItem.address )
                 enabled: !(root.selectedSharedAddresses.length === 1 && checked) // last cannot be unchecked
                 onToggled: {
                     // handle selected addresses
-                    const index = root.selectedSharedAddresses.indexOf(listItem.address)
+                    const index = root.selectedSharedAddresses.findIndex((address) => address.toLowerCase() === listItem.address)
                     const selectedSharedAddressesCopy = Object.assign([], root.selectedSharedAddresses) // deep copy
                     if (index === -1) {
                         selectedSharedAddressesCopy.push(listItem.address)
@@ -137,7 +137,7 @@ StatusListView {
                     root.selectedSharedAddresses = selectedSharedAddressesCopy
 
                     // switch to next available airdrop address when unchecking
-                    if (!checked && listItem.address === root.selectedAirdropAddress) {
+                    if (!checked && listItem.address === root.selectedAirdropAddress.toLowerCase()) {
                         d.selectFirstAvailableAirdropAddress()
                     }
 


### PR DESCRIPTION
compare the addresses to share in a case insensitive manner

Fixes #12152

### What does the PR do

Fixes shared addresses handling

### Affected areas

SharedAddressesPopup

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

[Záznam obrazovky z 2023-09-18 12-25-36.webm](https://github.com/status-im/status-desktop/assets/5377645/54a7ba0d-65c2-493b-bc72-fb2dc57d6278)

