### PR TITLE
chore(@desktop/wallet): Show address link for both networks in Bridge tx

### DIFF
--- a/ui/app/AppLayouts/Wallet/popups/TransactionAddressMenu.qml
+++ b/ui/app/AppLayouts/Wallet/popups/TransactionAddressMenu.qml
@@ -64,17 +64,19 @@ StatusMenu {
             }
         }
 
-        function refreshShowOnActionsVisiblity(shortChainName) {
-            switch(shortChainName.toLowerCase()) {
-            case Constants.networkShortChainNames.arbiscan.toLowerCase():
-                showOnArbiscanAction.enabled = true
-                break
-            case Constants.networkShortChainNames.optimism.toLowerCase():
-                showOnOptimismAction.enabled = true
-                break
-            default:
-                showOnEtherscanAction.enabled = true
-                break
+        function refreshShowOnActionsVisiblity(shortChainNameList) {
+            for (let i = 0 ; i < shortChainNameList.length ; i++) {
+                switch(shortChainNameList[i].toLowerCase()) {
+                case Constants.networkShortChainNames.arbiscan.toLowerCase():
+                    showOnArbiscanAction.enabled = true
+                    break
+                case Constants.networkShortChainNames.optimism.toLowerCase():
+                    showOnOptimismAction.enabled = true
+                    break
+                default:
+                    showOnEtherscanAction.enabled = true
+                    break
+                }
             }
         }
 
@@ -100,17 +102,17 @@ StatusMenu {
         }
     }
 
-    function openSenderMenu(delegate, address, chainShortName = "") {
+    function openSenderMenu(delegate, address, chainShortNameList = []) {
         d.addressType = TransactionAddressMenu.AddressType.Sender
-        openEthAddressMenu(delegate, address, chainShortName)
+        openEthAddressMenu(delegate, address, chainShortNameList)
     }
 
-    function openReceiverMenu(delegate, address, chainShortName = "") {
+    function openReceiverMenu(delegate, address, chainShortNameList = []) {
         d.addressType = TransactionAddressMenu.AddressType.Receiver
-        openEthAddressMenu(delegate, address, chainShortName)
+        openEthAddressMenu(delegate, address, chainShortNameList)
     }
 
-    function openEthAddressMenu(delegate, address, chainShortName = "") {
+    function openEthAddressMenu(delegate, address, chainShortNameList = []) {
         d.selectedAddress = address
 
         address = address.toLowerCase()
@@ -135,6 +137,7 @@ StatusMenu {
         showOnEtherscanAction.enabled = true
         showOnArbiscanAction.enabled = address.includes(Constants.networkShortChainNames.arbiscan + ":")
         showOnOptimismAction.enabled = address.includes(Constants.networkShortChainNames.optimism + ":")
+        d.refreshShowOnActionsVisiblity(chainShortNameList)
         saveAddressAction.enabled = d.addressName.length === 0
         editAddressAction.enabled = !isWalletAccount && !isContact && d.addressName.length > 0
         sendToAddressAction.enabled = true
@@ -143,18 +146,18 @@ StatusMenu {
         d.openMenu(delegate)
     }
 
-    function openTxMenu(delegate, address, chainShortName="") {
+    function openTxMenu(delegate, address, chainShortNameList=[]) {
         d.addressType = TransactionAddressMenu.AddressType.Tx
         d.selectedAddress = address
-        d.refreshShowOnActionsVisiblity(chainShortName)
+        d.refreshShowOnActionsVisiblity(chainShortNameList)
         d.openMenu(delegate)
     }
 
-    function openContractMenu(delegate, address, chainShortName="", name="") {
+    function openContractMenu(delegate, address, chainShortNameList=[], name="") {
         d.addressType = TransactionAddressMenu.AddressType.Contract
         d.contractName = name
         d.selectedAddress = address
-        d.refreshShowOnActionsVisiblity(chainShortName)
+        d.refreshShowOnActionsVisiblity(chainShortNameList)
         d.openMenu(delegate)
     }
 

--- a/ui/app/AppLayouts/Wallet/views/TransactionDetailView.qml
+++ b/ui/app/AppLayouts/Wallet/views/TransactionDetailView.qml
@@ -46,7 +46,7 @@ Item {
         readonly property int blockNumber: isDetailsValid ? details.blockNumber : 0
         readonly property int toBlockNumber: 0 // TODO fill when bridge data is implemented
         readonly property string networkShortNameOut: networkShortName
-        readonly property string networkShortNameIn: transactionHeader.isMultiTransaction ? RootStore.getNetworkShortName(transaction.chainIdOut) : ""
+        readonly property string networkShortNameIn: transactionHeader.isMultiTransaction ? RootStore.getNetworkShortName(transaction.chainIdIn) : ""
         readonly property string symbol: isTransactionValid ? transaction.symbol : ""
         readonly property string inSymbol: isTransactionValid ? transaction.inSymbol : ""
         readonly property string outSymbol: isTransactionValid ? transaction.outSymbol : ""
@@ -281,9 +281,9 @@ Item {
                         rootStore: WalletStores.RootStore
                         onButtonClicked: {
                             if (d.transactionType === Constants.TransactionType.Swap || d.transactionType === Constants.TransactionType.Bridge) {
-                                addressMenu.openEthAddressMenu(this, addresses[0], d.networkShortNameOut)
+                                addressMenu.openEthAddressMenu(this, addresses[0], [d.networkShortNameIn, d.networkShortNameOut])
                             } else {
-                                addressMenu.openSenderMenu(this, addresses[0], d.networkShortName)
+                                addressMenu.openSenderMenu(this, addresses[0], [d.networkShortName])
                             }
                         }
                     }
@@ -305,7 +305,7 @@ Item {
                         }
                         buttonIconName: hasValue ? "more" : ""
                         statusListItemSubTitle.customColor: hasValue ? Theme.palette.directColor1 : Theme.palette.directColor5
-                        onButtonClicked: addressMenu.openContractMenu(this, d.details.contract, transactionHeader.networkName, d.symbol)
+                        onButtonClicked: addressMenu.openContractMenu(this, d.details.contract, [d.networkShortName], d.symbol)
                         components: [
                             Loader {
                                 anchors.verticalCenter: parent.verticalCenter
@@ -322,7 +322,7 @@ Item {
                         addresses: root.isTransactionValid && visible ? [root.transaction.recipient] : []
                         contactsStore: root.contactsStore
                         rootStore: WalletStores.RootStore
-                        onButtonClicked: addressMenu.openReceiverMenu(this, addresses[0], d.networkShortName)
+                        onButtonClicked: addressMenu.openReceiverMenu(this, addresses[0], [d.networkShortName])
                         visible: d.transactionType !== Constants.TransactionType.ContractDeployment && d.transactionType !== Constants.TransactionType.Swap && d.transactionType !== Constants.TransactionType.Bridge && d.transactionType !== Constants.TransactionType.Destroy
                     }
                     TransactionDataTile {
@@ -340,7 +340,7 @@ Item {
                         subTitle: d.isDetailsValid ? d.details.txHash : ""
                         visible: !!subTitle
                         buttonIconName: "more"
-                        onButtonClicked: addressMenu.openTxMenu(this, subTitle, d.networkShortName)
+                        onButtonClicked: addressMenu.openTxMenu(this, subTitle, [d.networkShortName])
                     }
                     TransactionDataTile {
                         width: parent.width
@@ -348,7 +348,7 @@ Item {
                         subTitle: "" // TODO fill tx hash for Bridge
                         visible: !!subTitle
                         buttonIconName: "more"
-                        onButtonClicked: addressMenu.openTxMenu(this, subTitle, d.networkShortNameIn)
+                        onButtonClicked: addressMenu.openTxMenu(this, subTitle, [d.networkShortNameIn])
                     }
                     TransactionContractTile {
                         // Used for Bridge and Swap to display 'From' network Protocol contract address

--- a/ui/imports/shared/stores/RootStore.qml
+++ b/ui/imports/shared/stores/RootStore.qml
@@ -232,7 +232,7 @@ QtObject {
 
     function getFeeEthValue(feeCurrency) {
         if (!feeCurrency || feeCurrency.symbol !== "Gwei")
-            return qsTr("N/A")
+            return 0
         return currencyStore.getGasEthValue(feeCurrency.amount / Math.pow(10, feeCurrency.displayDecimals), 1)
     }
 


### PR DESCRIPTION
### What does the PR do

Show both networks options for addresses in Bridge transaction

### Affected areas

Wallet activity details view

### Screenshot of functionality (including design for comparison)

![image](https://github.com/status-im/status-desktop/assets/11396062/26a0d811-73b6-403e-af41-317989f0c031)

