### PR TITLE
fix(@desktop/wallet): SendModal: Move logic to nim Part 2, parsing recipient address string to separate the chain prefixes

### DIFF
--- a/src/app/modules/main/wallet_section/send/io_interface.nim
+++ b/src/app/modules/main/wallet_section/send/io_interface.nim
@@ -65,3 +65,6 @@ method getCollectiblesModel*(self: AccessInterface): collectibles.Model =
 
 method getNestedCollectiblesModel*(self: AccessInterface): nested_collectibles.Model =
   raise newException(ValueError, "No implementation available")
+
+method splitAndFormatAddressPrefix*(self: AccessInterface, text : string, updateInStore: bool): string {.base.} =
+  raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/wallet_section/send/module.nim
+++ b/src/app/modules/main/wallet_section/send/module.nim
@@ -334,3 +334,26 @@ method getCollectiblesModel*(self: Module): collectibles.Model =
 method getNestedCollectiblesModel*(self: Module): nested_collectibles.Model =
   return self.nestedCollectiblesModel
 
+method splitAndFormatAddressPrefix*(self: Module, text : string, updateInStore: bool): string {.slot.} =
+  var tempPreferredChains: seq[int]
+  var chainFound = false
+  var editedText = ""
+
+  for word in plainText(text).split(':'):
+    if word.startsWith("0x"):
+      editedText = editedText & word
+    else:
+      let chainColor = self.view.getNetworkColor(word)
+      if not chainColor.isEmptyOrWhitespace():
+        chainFound = true
+        tempPreferredChains.add(self.view.getNetworkChainId(word))
+        editedText = editedText & "<span style='color: " & chainColor & "'>" & word & "</span>" & ":"
+
+  if updateInStore:
+    if not chainFound:
+      self.view.updateRoutePreferredChains(self.view.getLayer1NetworkChainId())
+    else:
+      self.view.updateRoutePreferredChains(tempPreferredChains.join(":"))
+
+  editedText = "<a><p>" & editedText & "</a></p>"
+  return editedText

--- a/src/app/modules/main/wallet_section/send/network_model.nim
+++ b/src/app/modules/main/wallet_section/send/network_model.nim
@@ -166,25 +166,30 @@ QtObject:
 
   proc updateFromNetworks*(self: NetworkModel, path: SuggestedRouteItem, hasGas: bool) =
     for i in 0 ..< self.items.len:
+      let index = self.createIndex(i, 0, nil)
+      defer: index.delete
+      self.items[i].amountIn = ""
+      self.items[i].resetToNetworks
+      self.items[i].hasGas = true
+      self.items[i].locked = false
       if path.getfromNetwork() == self.items[i].getChainId():
-        let index = self.createIndex(i, 0, nil)
-        defer: index.delete
         self.items[i].amountIn = path.getAmountIn()
         self.items[i].toNetworks = path.getToNetwork()
         self.items[i].hasGas = hasGas
         self.items[i].locked = path.getAmountInLocked()
-        self.dataChanged(index, index, @[ModelRole.AmountIn.int, ModelRole.ToNetworks.int, ModelRole.HasGas.int, ModelRole.Locked.int])
+      self.dataChanged(index, index, @[ModelRole.AmountIn.int, ModelRole.ToNetworks.int, ModelRole.HasGas.int, ModelRole.Locked.int])
 
   proc updateToNetworks*(self: NetworkModel, path: SuggestedRouteItem) =
     for i in 0 ..< self.items.len:
+      let index = self.createIndex(i, 0, nil)
+      defer: index.delete
+      self.items[i].amountOut = ""
       if path.getToNetwork() == self.items[i].getChainId():
-        let index = self.createIndex(i, 0, nil)
-        defer: index.delete
         if self.items[i].getAmountOut().len != 0:
           self.items[i].amountOut = $(parseInt(self.items[i].getAmountOut()) + parseInt(path.getAmountOut()))
         else:
           self.items[i].amountOut = path.getAmountOut()
-        self.dataChanged(index, index, @[ModelRole.AmountOut.int])
+      self.dataChanged(index, index, @[ModelRole.AmountOut.int])
 
   proc getRouteDisabledNetworkChainIds*(self: NetworkModel): seq[int] =
     var disbaledChains: seq[int] = @[]
@@ -303,3 +308,8 @@ QtObject:
           self.items[i].lockedAmount = amount
           self.dataChanged(index, index, @[ModelRole.LockedAmount.int])
 
+  proc getLayer1Network*(self: NetworkModel): int =
+    for item in self.items:
+      if item.getLayer() == 1:
+        return item.getChainId()
+    return 0

--- a/src/app/modules/main/wallet_section/send/view.nim
+++ b/src/app/modules/main/wallet_section/send/view.nim
@@ -228,8 +228,6 @@ QtObject:
     return self.selectedSenderAccount.address()
 
   proc updatedNetworksWithRoutes*(self: View, paths: seq[SuggestedRouteItem], totalFeesInEth: float) =
-    self.fromNetworksModel.reset()
-    self.toNetworksModel.reset()
     for path in paths:
       let fromChainId = path.getfromNetwork()
       let hasGas = self.selectedSenderAccount.getAssets().hasGas(fromChainId, self.fromNetworksModel.getNetworkNativeGasSymbol(fromChainId), totalFeesInEth)
@@ -242,3 +240,30 @@ QtObject:
     self.transactionRoutes = newTransactionRoutes()
     self.selectedAssetSymbol = ""
     self.showUnPreferredChains = false
+
+  proc getLayer1NetworkChainId*(self: View): string =
+    return $self.fromNetworksModel.getLayer1Network()
+
+  proc getNetworkColor*(self: View, shortName : string): string =
+    return self.fromNetworksModel.getNetworkColor(shortName)
+
+  proc getNetworkChainId*(self: View, shortName : string): int =
+    return self.fromNetworksModel.getNetworkChainId(shortName)
+
+  proc splitAndFormatAddressPrefix(self: View, text : string, updateInStore: bool): string {.slot.} =
+    return self.delegate.splitAndFormatAddressPrefix(text, updateInStore)
+
+  proc getAddressFromFormattedString(self: View, text : string): string {.slot.} =
+    var splitWords = plainText(text).split(':')
+    for i in countdown(splitWords.len-1, 0):
+      if splitWords[i].startsWith("0x"):
+        return splitWords[i]
+    return ""
+
+  proc getShortChainIds(self: View, chainShortNames : string): string {.slot.} =
+    if chainShortNames.isEmptyOrWhitespace():
+      return ""
+    var preferredChains: seq[int]
+    for shortName in chainShortNames.split(':'):
+      preferredChains.add(self.fromNetworksModel.getNetworkChainId(shortName))
+    return preferredChains.join(":")

--- a/ui/imports/shared/popups/send/SendModal.qml
+++ b/ui/imports/shared/popups/send/SendModal.qml
@@ -450,7 +450,7 @@ StatusDialog {
                         store: popup.store
                         interactive: popup.interactive
                         selectedAccount: popup.selectedAccount
-                        ensAddressOrEmpty: recipientLoader.isENSValid ? recipientLoader.resolvedENSAddress : ""
+                        ensAddressOrEmpty: recipientLoader.resolvedENSAddress
                         amountToSend: amountToSendInput.cryptoValueToSendFloat
                         minSendCryptoDecimals: amountToSendInput.minSendCryptoDecimals
                         minReceiveCryptoDecimals: amountToSendInput.minReceiveCryptoDecimals

--- a/ui/imports/shared/popups/send/views/TabAddressSelectorView.qml
+++ b/ui/imports/shared/popups/send/views/TabAddressSelectorView.qml
@@ -33,7 +33,6 @@ Item {
 
     enum Type {
         Address,
-        Contact,
         Account,
         SavedAddress,
         RecentsAddress,

--- a/ui/imports/shared/stores/send/TransactionStore.qml
+++ b/ui/imports/shared/stores/send/TransactionStore.qml
@@ -226,40 +226,14 @@ QtObject {
         nestedCollectiblesModel.currentCollectionUid = ""
     }
 
-    // TODO: move to nim
     function splitAndFormatAddressPrefix(text, updateInStore) {
-        let address = ""
-        let tempPreferredChains = []
-        let chainFound = false
-        let splitWords = plainText(text).split(':')
-        let editedText = ""
-
-        for(var i=0; i<splitWords.length; i++) {
-            const word = splitWords[i]
-            if(word.startsWith("0x")) {
-                address = word
-                editedText += word
-            } else {
-                let chainColor = fromNetworksModel.getNetworkColor(word)
-                if(!!chainColor) {
-                    chainFound = true
-                    tempPreferredChains.push(fromNetworksModel.getNetworkChainId(word))
-                    editedText += `<span style='color: %1'>%2</span>`.arg(chainColor).arg(word)+':'
-                }
-            }
-        }
-
-        if(updateInStore) {
-            if(!chainFound)
-                updateRoutePreferredChains(networksModule.getMainnetChainId())
-            else
-                updateRoutePreferredChains(tempPreferredChains.join(":"))
-        }
-
-        editedText +="</a></p>"
         return {
-            formattedText: editedText,
-            address: address
+            formattedText: walletSectionSendInst.splitAndFormatAddressPrefix(text, updateInStore),
+            address: walletSectionSendInst.getAddressFromFormattedString(text)
         }
+    }
+
+    function getShortChainIds(chainShortNames) {
+        return walletSectionSendInst.getShortChainIds(chainShortNames)
     }
 }


### PR DESCRIPTION
fix(@desktop/wallet): SendModal: Move logic to nim Part 2, parsing recipient address string to separate the chain prefixes
fixes #12149

### What does the PR do

Move logic for parsing recipient text to nim side

### Affected areas

SendModal

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it