### PR TITLE
fix(curated_communities): support curated.communities.update signal

### DIFF
--- a/src/app/core/signals/remote_signals/signal_type.nim
+++ b/src/app/core/signals/remote_signals/signal_type.nim
@@ -20,6 +20,7 @@ type SignalType* {.pure.} = enum
   SubscriptionsError = "subscriptions.error"
   WhisperFilterAdded = "whisper.filter.added"
   CommunityFound = "community.found"
+  CuratedCommunitiesUpdated = "curated.communities.update"
   PeerStats = "wakuv2.peerstats"
   Stats = "stats"
   ChroniclesLogs = "chronicles-log"

--- a/src/app/core/signals/signals_manager.nim
+++ b/src/app/core/signals/signals_manager.nim
@@ -81,6 +81,7 @@ QtObject:
       of SignalType.MailserverRequestCompleted: MailserverRequestCompletedSignal.fromEvent(jsonSignal)
       of SignalType.MailserverRequestExpired: MailserverRequestExpiredSignal.fromEvent(jsonSignal)
       of SignalType.CommunityFound: CommunitySignal.fromEvent(jsonSignal)
+      of SignalType.CuratedCommunitiesUpdated: CuratedCommunitiesSignal.fromEvent(jsonSignal)
       of SignalType.Stats: StatsSignal.fromEvent(jsonSignal)
       of SignalType.ChroniclesLogs: ChroniclesLogsSignal.fromEvent(jsonSignal)
       of SignalType.HistoryRequestCompleted: HistoryRequestCompletedSignal.fromEvent(jsonSignal)

--- a/src/app/modules/main/communities/controller.nim
+++ b/src/app/modules/main/communities/controller.nim
@@ -111,6 +111,11 @@ proc init*(self: Controller) =
       self.delegate.communityEdited(community)
       self.delegate.curatedCommunityEdited(community)
 
+  self.events.on(SIGNAL_CURATED_COMMUNITIES_UPDATED) do(e:Args):
+    let args = CommunitiesArgs(e)
+    for community in args.communities:
+      self.delegate.curatedCommunityEdited(community)
+
   self.events.on(SIGNAL_COMMUNITY_MUTED) do(e:Args):
     let args = CommunityMutedArgs(e)
     self.delegate.communityMuted(args.communityId, args.muted)

--- a/src/app_service/service/community/service.nim
+++ b/src/app_service/service/community/service.nim
@@ -174,6 +174,7 @@ const SIGNAL_COMMUNITY_KICKED* = "communityKicked"
 const SIGNAL_NEW_REQUEST_TO_JOIN_COMMUNITY* = "newRequestToJoinCommunity"
 const SIGNAL_REQUEST_TO_JOIN_COMMUNITY_CANCELED* = "requestToJoinCommunityCanceled"
 const SIGNAL_CURATED_COMMUNITY_FOUND* = "curatedCommunityFound"
+const SIGNAL_CURATED_COMMUNITIES_UPDATED* = "curatedCommunitiesUpdated"
 const SIGNAL_COMMUNITY_MUTED* = "communityMuted"
 const SIGNAL_CATEGORY_MUTED* = "categoryMuted"
 const SIGNAL_CATEGORY_UNMUTED* = "categoryUnmuted"
@@ -285,6 +286,11 @@ QtObject:
           self.communities[receivedData.community.id].listedInDirectory and not
           self.communities[receivedData.community.id].isAvailable:
         self.events.emit(SIGNAL_CURATED_COMMUNITY_FOUND, CommunityArgs(community: self.communities[receivedData.community.id]))
+
+    self.events.on(SignalType.CuratedCommunitiesUpdated.event) do(e: Args):
+      var receivedData = CuratedCommunitiesSignal(e)
+      self.events.emit(SIGNAL_CURATED_COMMUNITIES_UPDATED,
+        CommunitiesArgs(communities: receivedData.communities))
 
     self.events.on(SignalType.Message.event) do(e: Args):
       var receivedData = MessageSignal(e)


### PR DESCRIPTION
Fixes #12207

Adds support for the "unknown signal". This removes the spam, as we just do something with it now.

I also upped the timer for unknown communities to 1 minute instead of 3 seconds. https://github.com/status-im/status-go/pull/4046#pullrequestreview-1633952634