### PR TITLE
feat(TransferOwnershipAlertPopup): Add information popups when owner token is not created yet

### DIFF
--- a/storybook/figma.json
+++ b/storybook/figma.json
@@ -269,5 +269,9 @@
     ],
     "UserProfileCard": [
         "https://www.figma.com/file/Mr3rqxxgKJ2zMQ06UAKiWL/💬-Chat⎜Desktop?type=design&node-id=21961-655678&mode=design&t=JiMnPfMaLPWlrFK3-0"
+    ],
+    "TransferOwnershipAlertPopup": [
+        "https://www.figma.com/file/qHfFm7C9LwtXpfdbxssCK3/Kuba%E2%8E%9CDesktop---Communities?type=design&node-id=37206%3A86828&mode=design&t=coHVo1E6fHrKNNhQ-1",
+        "https://www.figma.com/file/qHfFm7C9LwtXpfdbxssCK3/Kuba%E2%8E%9CDesktop---Communities?type=design&node-id=37206%3A86847&mode=design&t=coHVo1E6fHrKNNhQ-1"
     ]
 }

--- a/storybook/pages/TransferOwnershipAlertPopupPage.qml
+++ b/storybook/pages/TransferOwnershipAlertPopupPage.qml
@@ -1,0 +1,136 @@
+import QtQuick 2.14
+import QtQuick.Controls 2.14
+import QtQuick.Layouts 1.14
+
+import Storybook 1.0
+import Models 1.0
+
+import AppLayouts.Communities.popups 1.0
+import AppLayouts.Communities.helpers 1.0
+
+SplitView {
+    Logs { id: logs }
+
+    SplitView {
+        orientation: Qt.Vertical
+        SplitView.fillWidth: true
+
+        Item {
+            SplitView.fillWidth: true
+            SplitView.fillHeight: true
+
+            PopupBackground {
+                anchors.fill: parent
+            }
+
+            Button {
+                anchors.centerIn: parent
+                text: "Reopen"
+
+                onClicked: dialog.open()
+            }
+
+            TransferOwnershipAlertPopup {
+                id: dialog
+
+                anchors.centerIn: parent
+
+                communityName: communityNameText.text
+                communityLogo: ModelsData.collectibles.doodles
+
+                onCancelClicked: logs.logEvent("TransferOwnershipAlertPopup::onCancelClicked")
+                onMintClicked: logs.logEvent("TransferOwnershipAlertPopup::onMintClicked")
+            }
+        }
+
+        LogsAndControlsPanel {
+            id: logsAndControlsPanel
+
+            SplitView.minimumHeight: 100
+            SplitView.preferredHeight: 150
+
+            logsView.logText: logs.logText
+        }
+    }
+
+    Pane {
+        SplitView.minimumWidth: 300
+        SplitView.preferredWidth: 300
+
+        Column {
+            spacing: 12
+
+            Label {
+                text: "Community Name"
+                font.bold: true
+            }
+
+            TextInput {
+                id: communityNameText
+
+                text: "Doodles"
+
+            }
+
+            Label {
+                text: "Community Logo"
+                font.bold: true
+            }
+
+            Column {
+
+                RadioButton {
+                    id: doodleLogo
+
+                    text: "Doodle"
+                    checked: true
+
+                    onCheckedChanged: dialog.communityLogo =  ModelsData.collectibles.doodles
+                }
+
+                RadioButton {
+                    id: manaLogo
+
+                    text: "Mana"
+
+                    onCheckedChanged: dialog.communityLogo =  ModelsData.collectibles.mana
+                }
+
+                RadioButton {
+                    id: superRareLogo
+
+                    text: "Status"
+
+                    onCheckedChanged: dialog.communityLogo =  ModelsData.collectibles.custom
+                }
+            }
+
+            Label {
+                text: "Mode"
+                font.bold: true
+            }
+
+            Column {
+
+                RadioButton {
+                    id: transferMode
+
+                    text: "Transfer Ownership"
+                    checked: true
+
+                    onCheckedChanged: dialog.mode = TransferOwnershipAlertPopup.Mode.TransferOwnership
+                }
+
+                RadioButton {
+                    id: moveNodeMode
+
+                    text: "Move Control Node"
+
+                    onCheckedChanged: dialog.mode = TransferOwnershipAlertPopup.Mode.MoveControlNode
+                }
+            }
+        }
+    }
+}
+
+// category: Popups

--- a/ui/app/AppLayouts/Communities/panels/OverviewSettingsPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/OverviewSettingsPanel.qml
@@ -66,6 +66,7 @@ StackLayout {
     signal airdropTokensClicked
     signal exportControlNodeClicked
     signal importControlNodeClicked
+    signal mintOwnerTokenClicked
 
     clip: true
 
@@ -111,15 +112,21 @@ StackLayout {
                     Layout.preferredHeight: 38
                     Layout.alignment: Qt.AlignTop
                     objectName: "communityOverviewSettingsTransferOwnershipButton"
-                    visible: root.isOwner && !!root.ownerToken && root.ownerToken.deployState === Constants.ContractTransactionStatus.Completed
+                    visible: root.isOwner
                     text: qsTr("Transfer ownership")
                     size: StatusBaseButton.Size.Small
 
-                    onClicked: Global.openTransferOwnershipPopup(root.name,
-                                                                 root.logoImageData,
-                                                                 root.ownerToken,
-                                                                 root.accounts,
-                                                                 root.sendModalPopup)
+                    onClicked: {
+                        if(!!root.ownerToken && root.ownerToken.deployState === Constants.ContractTransactionStatus.Completed) {
+                            Global.openTransferOwnershipPopup(root.name,
+                                                              root.logoImageData,
+                                                              root.ownerToken,
+                                                              root.accounts,
+                                                              root.sendModalPopup)
+                        } else {
+                            Global.openPopup(transferOwnershipAlertPopup, { mode: TransferOwnershipAlertPopup.Mode.TransferOwnership })
+                        }
+                    }
                 }
 
                 StatusButton {
@@ -174,7 +181,13 @@ StackLayout {
             topPadding: 0
             communityName: root.name
             isControlNode: root.isControlNode
-            onExportControlNodeClicked: root.exportControlNodeClicked()
+            onExportControlNodeClicked:{
+                if(!!root.ownerToken && root.ownerToken.deployState === Constants.ContractTransactionStatus.Completed) {
+                    root.exportControlNodeClicked()
+                } else {
+                    Global.openPopup(transferOwnershipAlertPopup, { mode: TransferOwnershipAlertPopup.Mode.MoveControlNode })
+                }
+            }
             onImportControlNodeClicked: root.importControlNodeClicked()
             //TODO update once the domain changes
             onLearnMoreClicked: Global.openLink(Constants.statusHelpLinkPrefix + "status-communities/about-the-control-node-in-status-communities")
@@ -304,6 +317,17 @@ StackLayout {
                 root.edited(editSettingsPanelLoader.item)
                 editSettingsPanelLoader.reloadContent()
             }
+        }
+    }
+
+    Component {
+        id: transferOwnershipAlertPopup
+
+        TransferOwnershipAlertPopup {
+            communityName: root.name
+            communityLogo: root.logoImageData
+
+            onMintClicked: root.mintOwnerTokenClicked()
         }
     }
 }

--- a/ui/app/AppLayouts/Communities/popups/TransferOwnershipAlertPopup.qml
+++ b/ui/app/AppLayouts/Communities/popups/TransferOwnershipAlertPopup.qml
@@ -1,0 +1,80 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQml.Models 2.15
+
+import StatusQ.Core 0.1
+import StatusQ.Controls 0.1
+import StatusQ.Popups.Dialog 0.1
+import StatusQ.Components 0.1
+
+import utils 1.0
+
+StatusDialog {
+    id: root
+
+    property int mode: TransferOwnershipAlertPopup.Mode.TransferOwnership
+
+    // Community related props:
+    required property string communityName
+    required property string communityLogo
+
+    signal mintClicked
+    signal cancelClicked
+
+    enum Mode {
+        TransferOwnership,
+        MoveControlNode
+    }
+
+    QtObject {
+        id: d
+
+        readonly property string headerTitle: (root.mode === TransferOwnershipAlertPopup.Mode.TransferOwnership) ?
+                                                  qsTr("Transfer ownership of %1").arg(root.communityName) :
+                                                  qsTr("How to move the %1 control node to another device").arg(root.communityName)
+        readonly property string alertText: (root.mode === TransferOwnershipAlertPopup.Mode.TransferOwnership) ?
+                                                qsTr("<b>It looks like you haven’t minted the %1 Owner token yet.</b> Once you have minted this token, you can transfer ownership of %1 by sending the Owner token to the account of the person you want to be the new Community owner.").arg(root.communityName) :
+                                                qsTr("<b>It looks like you haven’t minted the %1 Owner token yet.</b> Once you have minted this token, you can make one of your other synced desktop devices the control node for the %1 Community.").arg(root.communityName)
+    }
+
+    width: 640 // by design
+    padding: Style.current.padding
+    contentItem: StatusBaseText {
+        wrapMode: Text.WrapAtWordBoundaryOrAnywhere
+        text: d.alertText
+        lineHeight: 1.2
+    }
+
+    header: StatusDialogHeader {
+        headline.title: d.headerTitle
+        actions.closeButton.onClicked: root.close()
+        leftComponent: StatusSmartIdenticon {
+            asset.name: root.communityLogo
+            asset.isImage: !!asset.name
+        }
+    }
+
+    footer: StatusDialogFooter {
+        spacing: Style.current.padding
+        rightButtons: ObjectModel {
+            StatusFlatButton {
+                text: qsTr("Cancel")
+
+                onClicked: {
+                    root.cancelClicked()
+                    close()
+                }
+            }
+
+            StatusButton {
+                text: qsTr("Mint %1 Owner token").arg(root.communityName)
+                type: StatusBaseButton.Type.Normal
+
+                onClicked: {
+                    root.mintClicked()
+                    close()
+                }
+            }
+        }
+    }
+}

--- a/ui/app/AppLayouts/Communities/popups/qmldir
+++ b/ui/app/AppLayouts/Communities/popups/qmldir
@@ -20,3 +20,4 @@ SignTransactionsPopup 1.0 SignTransactionsPopup.qml
 TokenMasterActionPopup 1.0 TokenMasterActionPopup.qml
 TokenPermissionsPopup 1.0 TokenPermissionsPopup.qml
 TransferOwnershipPopup 1.0 TransferOwnershipPopup.qml
+TransferOwnershipAlertPopup 1.0 TransferOwnershipAlertPopup.qml

--- a/ui/app/AppLayouts/Communities/views/CommunitySettingsView.qml
+++ b/ui/app/AppLayouts/Communities/views/CommunitySettingsView.qml
@@ -233,6 +233,12 @@ StatusSectionLayout {
 
                 Global.openImportControlNodePopup(root.community)
             }
+
+            onMintOwnerTokenClicked: {
+                root.goTo(Constants.CommunitySettingsSections.MintTokens)
+                mintPanel.openNewTokenForm(false/*Collectible owner token*/)
+            }
+
         }
 
         MembersSettingsPanel {
@@ -322,6 +328,7 @@ StatusSectionLayout {
             isOwnerTokenDeployed: tokensModelChangesTracker.isOwnerTokenDeployed
             isTMasterTokenDeployed: tokensModelChangesTracker.isTMasterTokenDeployed
             anyPrivilegedTokenFailed: tokensModelChangesTracker.isOwnerTokenFailed || tokensModelChangesTracker.isTMasterTokenFailed
+            ownerOrTMasterTokenItemsExist: tokensModelChangesTracker.ownerOrTMasterTokenItemsExist
 
             // Models
             tokensModel: root.community.communityTokens


### PR DESCRIPTION
Closes #12173

### What does the PR do

It opens information popups when community owner token is still not created:

- From Overview / Transfer ownership button
- From Overview / How to move control node button

### Affected areas

Community Settings / Overview + Tokens

### Screenshot of functionality

https://github.com/status-im/status-desktop/assets/97019400/cf5b0503-0faf-4837-a9c6-47da7bcffc7c