### PR TITLE
fix(@desktop/wallet): fix transparent background color in detailed co…

### DIFF
--- a/src/app/modules/shared_models/collectible_details_entry.nim
+++ b/src/app/modules/shared_models/collectible_details_entry.nim
@@ -113,9 +113,10 @@ QtObject:
     read = getMediaType
 
   proc getBackgroundColor*(self: CollectibleDetailsEntry): string {.slot.} =
-    if self.data == nil:
-      return ""
-    return self.data.backgroundColor
+    var color = "transparent"
+    if self.data != nil and self.data.backgroundColor != "":
+      color = "#" & self.data.backgroundColor
+    return color
 
   QtProperty[string] backgroundColor:
     read = getBackgroundColor


### PR DESCRIPTION
…llectible view

Fixes #12163

### What does the PR do

Transparent background was not properly handled in the detailed collectibles view. This PR fixes that.