### PR TITLE
feat(CommunityOwnership): Add transfer ownership popup flow from wallet collectible view

### DIFF
--- a/ui/app/AppLayouts/Communities/popups/TransferOwnershipPopup.qml
+++ b/ui/app/AppLayouts/Communities/popups/TransferOwnershipPopup.qml
@@ -24,7 +24,7 @@ StatusDialog {
     property string communityLogo
 
     // Transaction related props:
-    property var token
+    property var token // Expected roles: accountAddress, key, chainId, name, artworkSource
     property var accounts
     property var sendModalPopup
 
@@ -109,8 +109,8 @@ StatusDialog {
 
                 onClicked: {
                     // Pre-populated dialog with the relevant Owner token info:
-                    root.sendModalPopup.sendType = Constants.SendType.Transfer
-                    root.sendModalPopup.selectedAccount = ModelUtils.getByKey(root.accounts, "address", token.accountAddress)
+                    root.sendModalPopup.preSelectedSendType = Constants.SendType.Transfer
+                    root.sendModalPopup.preSelectedAccount = ModelUtils.getByKey(root.accounts, "address", token.accountAddress)
                     root.sendModalPopup.preSelectedHolding = {
                         uid : token.key,
                         chainId: token.chainId,

--- a/ui/app/AppLayouts/Wallet/WalletLayout.qml
+++ b/ui/app/AppLayouts/Wallet/WalletLayout.qml
@@ -148,13 +148,34 @@ Item {
             height: root.showAllAccounts ? implicitHeight : 61
             walletStore: RootStore
             networkConnectionStore: root.networkConnectionStore
+            isCommunityOwnershipTransfer: (!!walletStore.currentViewedCollectible && walletStore.currentViewedHoldingID !== "") ?
+                                              (walletStore.currentViewedCollectible.communityPrivilegesLevel === Constants.TokenPrivilegesLevel.Owner) : false
+            communityName: !!walletStore.currentViewedCollectible ? walletStore.currentViewedCollectible.communityName : ""
             onLaunchShareAddressModal: Global.openPopup(receiveModalComponent)
             onLaunchSendModal: {
-                root.sendModalPopup.preSelectedSendType = Constants.SendType.Transfer
-                root.sendModalPopup.preSelectedHoldingID = walletStore.currentViewedHoldingID
-                root.sendModalPopup.preSelectedHoldingType = walletStore.currentViewedHoldingType
-                root.sendModalPopup.onlyAssets = false
-                root.sendModalPopup.open()
+                if(isCommunityOwnershipTransfer) {
+                    let tokenItem = walletStore.currentViewedCollectible
+                    Global.openTransferOwnershipPopup(tokenItem.communityName,
+                                                      tokenItem.communityImage,
+                                                      {
+                                                          "key": walletStore.currentViewedHoldingID,
+                                                          "privilegesLevel": tokenItem.communityPrivilegesLevel,
+                                                          "chainId": tokenItem.communityPrivilegesLevel,
+                                                          "privilegesLevel": tokenItem.chainId,
+                                                          "name": tokenItem.name,
+                                                          "artworkSource": tokenItem.artworkSource,
+                                                          "accountAddress": tokenItem.contractAddress
+                                                      },
+                                                      walletStore.accounts,
+                                                      root.sendModalPopup)
+                } else {
+                    // Common send modal popup:
+                    root.sendModalPopup.preSelectedSendType = Constants.SendType.Transfer
+                    root.sendModalPopup.preSelectedHoldingID = walletStore.currentViewedHoldingID
+                    root.sendModalPopup.preSelectedHoldingType = walletStore.currentViewedHoldingType
+                    root.sendModalPopup.onlyAssets = false
+                    root.sendModalPopup.open()
+                }
             }
             onLaunchBridgeModal: {
                 root.sendModalPopup.preSelectedSendType = Constants.SendType.Bridge

--- a/ui/app/AppLayouts/Wallet/panels/WalletFooter.qml
+++ b/ui/app/AppLayouts/Wallet/panels/WalletFooter.qml
@@ -18,6 +18,10 @@ Rectangle {
     property var walletStore
     property var networkConnectionStore
 
+    // Community-token related properties:
+    required property bool isCommunityOwnershipTransfer
+    property string communityName: ""
+
     signal launchShareAddressModal()
     signal launchSendModal()
     signal launchBridgeModal()
@@ -38,7 +42,7 @@ Rectangle {
             buttonType: DisabledTooltipButton.Flat
             aliasedObjectName: "walletFooterSendButton"
             icon: "send"
-            text: qsTr("Send")
+            text: root.isCommunityOwnershipTransfer ? qsTr("Send Owner token to transfer %1 Community ownership").arg(root.communityName) : qsTr("Send")
             interactive: networkConnectionStore.sendBuyBridgeEnabled
             onClicked: root.launchSendModal()
             tooltipText: networkConnectionStore.sendBuyBridgeToolTipText
@@ -60,11 +64,13 @@ Rectangle {
             interactive: networkConnectionStore.sendBuyBridgeEnabled
             onClicked: root.launchBridgeModal()
             tooltipText: networkConnectionStore.sendBuyBridgeToolTipText
-            visible: !walletStore.overview.isWatchOnlyAccount
+            visible: !walletStore.overview.isWatchOnlyAccount && !root.isCommunityOwnershipTransfer
         }
         
         StatusFlatButton {
             id: buySellBtn
+
+            visible: !root.isCommunityOwnershipTransfer
             icon.name: "token"
             text: qsTr("Buy")
             onClicked: function () {

--- a/ui/app/AppLayouts/Wallet/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Wallet/stores/RootStore.qml
@@ -120,7 +120,7 @@ QtObject {
 
     function resetCurrentViewedHolding() {
         currentViewedHoldingID = ""
-        currentViewedHoldingType = null
+        currentViewedHoldingType = Constants.HoldingType.Unknown
     }
 
     function setCurrentViewedHoldingType(type) {
@@ -135,6 +135,7 @@ QtObject {
 
     property string currentViewedHoldingID: ""
     property int currentViewedHoldingType
+    readonly property var currentViewedCollectible: collectiblesStore.detailedCollectible
 
     // This should be exposed to the UI via "walletModule", WalletModule should use
     // Accounts Service which keeps the info about that (isFirstTimeAccountLogin).
@@ -289,7 +290,7 @@ QtObject {
     }
 
     function getNetworkShortNames(chainIds) {
-       return networksModule.getNetworkShortNames(chainIds)
+        return networksModule.getNetworkShortNames(chainIds)
     }
 
     function updateWalletAccountPreferredChains(address, preferredChainIds) {

--- a/ui/app/AppLayouts/Wallet/views/CollectiblesView.qml
+++ b/ui/app/AppLayouts/Wallet/views/CollectiblesView.qml
@@ -63,6 +63,8 @@ Item {
                 fallbackImageUrl: model.imageUrl ?? ""
                 backgroundColor: model.backgroundColor ? model.backgroundColor : "transparent"
                 isLoading: !!model.isLoading
+                privilegesLevel: model.communityPrivilegesLevel ?? Constants.TokenPrivilegesLevel.Community
+                ornamentColor: model.communityColor ?? "transparent"
 
                 onClicked: root.collectibleClicked(model.chainId, model.contractAddress, model.tokenId, model.uid)
             }

--- a/ui/app/AppLayouts/Wallet/views/collectibles/CollectibleDetailView.qml
+++ b/ui/app/AppLayouts/Wallet/views/collectibles/CollectibleDetailView.qml
@@ -7,6 +7,8 @@ import StatusQ.Core 0.1
 import StatusQ.Controls 0.1
 import StatusQ.Core.Utils 0.1 as StatusQUtils
 
+import AppLayouts.Communities.panels 1.0
+
 import utils 1.0
 import shared.controls 1.0
 
@@ -19,6 +21,10 @@ Item {
     property var collectible
     property bool isCollectibleLoading
     readonly property int isNarrowMode : width < 700
+
+    // Community related token props:
+    readonly property bool isOwnerTokenType: !!collectible ? (collectible.communityPrivilegesLevel === Constants.TokenPrivilegesLevel.Owner) : false
+    readonly property bool isTMasterTokenType: !!collectible ? (collectible.communityPrivilegesLevel === Constants.TokenPrivilegesLevel.TMaster) : false
 
     CollectibleDetailsHeader {
         id: collectibleHeader
@@ -48,13 +54,31 @@ Item {
 
         Row {
             id: collectibleImageDetails
-            Layout.preferredHeight: root.isNarrowMode ? 152 : collectibleimage.height
+
+            readonly property real visibleImageHeight: (collectibleimage.visible ? collectibleimage.height : privilegedCollectibleImage.height)
+            readonly property real visibleImageWidth: (collectibleimage.visible ? collectibleimage.width : privilegedCollectibleImage.width)
+
+            Layout.preferredHeight: collectibleImageDetails.visibleImageHeight
             Layout.preferredWidth: parent.width
             spacing: 24
 
+            // Special artwork representation for community `Owner and Master Token` token types:
+            PrivilegedTokenArtworkPanel {
+                id: privilegedCollectibleImage
+
+                visible: root.isOwnerTokenType || root.isTMasterTokenType
+                size: root.isNarrowMode ? PrivilegedTokenArtworkPanel.Size.Medium : PrivilegedTokenArtworkPanel.Size.Large
+                artwork: collectible.imageUrl
+                color: !!collectible ? collectible.communityColor : "transparent"
+                isOwner: root.isOwnerTokenType
+            }
+
             StatusRoundedMedia {
                 id: collectibleimage
+
                 readonly property int size : root.isNarrowMode ? 132 : 253
+
+                visible: !privilegedCollectibleImage.visible
                 width: size
                 height: size
                 radius: 2
@@ -70,7 +94,7 @@ Item {
                 id: collectibleNameAndDescription
                 spacing: 12
 
-                width: parent.width - collectibleimage.width - Style.current.bigPadding
+                width: parent.width - collectibleImageDetails.visibleImageWidth - Style.current.bigPadding
 
                 StatusBaseText {
                     id: collectibleName
@@ -114,7 +138,7 @@ Item {
         StatusTabBar {
             id: collectiblesDetailsTab
             Layout.fillWidth: true
-            Layout.topMargin: root.isNarrowMode ? 0 : Style.current.xlPadding
+            Layout.topMargin: root.isNarrowMode ? Style.current.padding : Style.current.xlPadding
             visible: collectible.traits.count > 0
 
             StatusTabButton {

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -1336,11 +1336,14 @@ Item {
                 // this.sourceComponent = undefined // kill an opened instance
                 this.active = false
             }
+
+            property var preSelectedAccount
             property var preSelectedHolding
             property string preSelectedHoldingID
             property int preSelectedHoldingType
             property int preSelectedSendType: Constants.SendType.Unknown
             property bool onlyAssets: false
+
             sourceComponent: SendModal {
                 onlyAssets: sendModal.onlyAssets
                 onClosed: {
@@ -1349,9 +1352,13 @@ Item {
                     sendModal.preSelectedHoldingID = ""
                     sendModal.preSelectedHoldingType = Constants.HoldingType.Unknown
                     sendModal.preSelectedHolding = undefined
+                    sendModal.preSelectedAccount = undefined
                 }
             }
             onLoaded: {
+                if (!!sendModal.preSelectedAccount) {
+                    item.preSelectedAccount = sendModal.preSelectedAccount
+                }
                 if(sendModal.preSelectedSendType !== Constants.SendType.Unknown) {
                     item.preSelectedSendType = sendModal.preSelectedSendType
                 }

--- a/ui/imports/shared/popups/send/SendModal.qml
+++ b/ui/imports/shared/popups/send/SendModal.qml
@@ -32,6 +32,7 @@ StatusDialog {
     property int preSelectedSendType
     property bool interactive: true
     property alias onlyAssets: holdingSelector.onlyAssets
+    property var preSelectedAccount: store.selectedSenderAccount
 
     property alias modalHeader: modalHeader.text
 
@@ -55,7 +56,7 @@ StatusDialog {
     }
 
     property var recalculateRoutesAndFees: Backpressure.debounce(popup, 600, function() {
-        if(!!store.selectedSenderAccount && !!holdingSelector.selectedItem
+        if(!!popup.preSelectedAccount && !!holdingSelector.selectedItem
                 && recipientLoader.ready && amountToSendInput.inputNumberValid) {
             popup.isLoading = true
             popup.store.suggestedRoutes(d.isERC721Transfer ? "1" : amountToSendInput.cryptoValueToSend)
@@ -163,7 +164,7 @@ StatusDialog {
 
         if(d.isBridgeTx) {
             recipientLoader.selectedRecipientType = TabAddressSelectorView.Type.Address
-            recipientLoader.selectedRecipient = {address: store.selectedSenderAccount.address}
+            recipientLoader.selectedRecipient = {address: popup.preSelectedAccount.address}
         }
     }
 
@@ -177,7 +178,7 @@ StatusDialog {
 
             sorters: RoleSorter { roleName: "position"; sortOrder: Qt.AscendingOrder }
         }
-        selectedAccount: !!store.selectedSenderAccount ? store.selectedSenderAccount: {}
+        selectedAccount: !!popup.preSelectedAccount ? popup.preSelectedAccount: {}
         getNetworkShortNames: function(chainIds) {return store.getNetworkShortNames(chainIds)}
         onSelectedIndexChanged: {
             store.switchSenderAccount(selectedIndex)
@@ -243,8 +244,8 @@ StatusDialog {
                             id: holdingSelector
                             Layout.fillWidth: true
                             Layout.fillHeight: true
-                            assetsModel:store.selectedSenderAccount && store.selectedSenderAccount.assets ? store.selectedSenderAccount.assets : null
-                            collectiblesModel: store.selectedSenderAccount ? popup.nestedCollectiblesModel : null
+                            assetsModel: popup.preSelectedAccount && popup.preSelectedAccount.assets ? popup.preSelectedAccount.assets : null
+                            collectiblesModel: popup.preSelectedAccount ? popup.nestedCollectiblesModel : null
                             currentCurrencySymbol: RootStore.currencyStore.currentCurrencySymbol
                             visible: (!!d.selectedHolding && d.selectedHoldingType !== Constants.HoldingType.Unknown) ||
                                      (!!d.hoveredHolding && d.hoveredHoldingType !== Constants.HoldingType.Unknown)
@@ -370,8 +371,8 @@ StatusDialog {
                         anchors.rightMargin: Style.current.bigPadding
 
                         visible: !d.selectedHolding
-                        assets: store.selectedSenderAccount && store.selectedSenderAccount.assets ? store.selectedSenderAccount.assets : null
-                        collectibles: store.selectedSenderAccount ? popup.nestedCollectiblesModel : null
+                        assets: popup.preSelectedAccount && popup.preSelectedAccount.assets ? popup.preSelectedAccount.assets : null
+                        collectibles: popup.preSelectedAccount ? popup.nestedCollectiblesModel : null
                         onlyAssets: holdingSelector.onlyAssets
                         searchTokenSymbolByAddressFn: function (address) {
                             return store.findTokenSymbolByAddress(address)
@@ -427,7 +428,7 @@ StatusDialog {
                         anchors.leftMargin: Style.current.bigPadding
                         anchors.rightMargin: Style.current.bigPadding
                         store: popup.store
-                        selectedAccount: store.selectedSenderAccount
+                        selectedAccount: popup.preSelectedAccount
                         onRecipientSelected:  {
                             recipientLoader.selectedRecipientType = type
                             recipientLoader.selectedRecipient = recipient
@@ -444,7 +445,7 @@ StatusDialog {
                         anchors.rightMargin: Style.current.bigPadding
                         store: popup.store
                         interactive: popup.interactive
-                        selectedAccount: store.selectedSenderAccount
+                        selectedAccount: popup.preSelectedAccount
                         ensAddressOrEmpty: recipientLoader.resolvedENSAddress
                         amountToSend: amountToSendInput.cryptoValueToSendFloat
                         minSendCryptoDecimals: amountToSendInput.minSendCryptoDecimals


### PR DESCRIPTION
Closes #12172

It needes https://github.com/status-im/status-desktop/pull/12219

### What does the PR do

- It updates `CollectibleDetailsView` to show **owner** and **tMaster** token collectible types with the correct design.
- It updates `CollectiblesView` to show **owner** and **tMaster** token collectible types with the correct design.
- It modifies send footer option if collectible selected is an owner token.
- It adds needed logic in wallet rootstore to handle selected collectible object data.

### Affected areas

Wallet / Collectibles

### Screenshot of functionality

https://github.com/status-im/status-desktop/assets/97019400/d0908596-d8ec-4459-9b5b-f5fb12c7b84e


