### PR TITLE
feat(CommunitySettingsView): Integrate Kick/Ban/Destruct popups for TokenMaster

### DIFF
--- a/ui/StatusQ/src/StatusQ/Core/Utils/Utils.qml
+++ b/ui/StatusQ/src/StatusQ/Core/Utils/Utils.qml
@@ -246,6 +246,11 @@ QtObject {
         return text.substr(0, leftCharsCount) + "..." + text.substr(text.length - rightCharsCount)
     }
 
+    function elideAndFormatWalletAddress(address) {
+        return elideText(address, 5, 3).replace(
+                    "0x", "0" + String.fromCodePoint(0x00D7))
+    }
+
     function ensureVisible(flickable, rect) {
         const rectRight = rect.x + rect.width
         const rectBottom = rect.y + rect.height

--- a/ui/app/AppLayouts/Communities/controls/TokenHolderListItem.qml
+++ b/ui/app/AppLayouts/Communities/controls/TokenHolderListItem.qml
@@ -36,8 +36,8 @@ ItemDelegate {
 
     property var contactDetails: null
 
-    readonly property string addressElided: StatusQUtils.Utils.elideText(root.walletAddress, 6, 3).replace(
-                                                "0x", "0" + String.fromCodePoint(0x00D7))
+    readonly property string addressElided:
+        StatusQUtils.Utils.elideAndFormatWalletAddress(root.walletAddress)
 
     signal clicked(var mouse)
 

--- a/ui/app/AppLayouts/Communities/panels/MintTokensSettingsPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/MintTokensSettingsPanel.qml
@@ -600,7 +600,8 @@ StackView {
 
                 function openPopup(type, userName, address) {
                     tokenMasterActionPopup.actionType = type
-                    tokenMasterActionPopup.userName = userName
+                    tokenMasterActionPopup.userName = userName ||
+                            SQUtils.Utils.elideAndFormatWalletAddress(address)
                     tokenMasterActionPopup.address = address
                     open()
                 }

--- a/ui/app/AppLayouts/Communities/panels/SortableTokenHoldersPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/SortableTokenHoldersPanel.qml
@@ -31,8 +31,8 @@ Control {
     signal viewMessagesRequested(string contactId)
     signal airdropRequested(string address)
     signal remoteDestructRequested(string name, string address)
-    signal kickRequested(string name, string contactId)
-    signal banRequested(string name, string contactId)
+    signal kickRequested(string name, string contactId, string address)
+    signal banRequested(string name, string contactId, string address)
 
     signal generalAirdropRequested
 
@@ -202,7 +202,8 @@ Control {
             enabled: !menu.rawAddress
             type: StatusBaseButton.Type.Danger
 
-            onTriggered: root.kickRequested(menu.name, menu.contactId)
+            onTriggered: root.kickRequested(menu.name, menu.contactId,
+                                            menu.currentAddress)
         }
 
         StatusAction {
@@ -213,7 +214,8 @@ Control {
             enabled: !menu.rawAddress
             type: StatusBaseButton.Type.Danger
 
-            onTriggered: root.banRequested(menu.name, menu.contactId)
+            onTriggered: root.banRequested(menu.name, menu.contactId,
+                                           menu.currentAddress)
         }
     }
 }

--- a/ui/app/AppLayouts/Communities/popups/TokenMasterActionPopup.qml
+++ b/ui/app/AppLayouts/Communities/popups/TokenMasterActionPopup.qml
@@ -45,6 +45,9 @@ StatusDialog {
 
     property var accountsModel
     readonly property alias selectedAccount: d.accountAddress
+    readonly property alias selectedAccountName: d.accountName
+
+    readonly property alias deleteMessages: deleteMessagesSwitch.checked
 
     readonly property string feeLabel: qsTr("Remotely destruct 1 TokenMaster token on %1").arg(
                                            root.networkName)
@@ -52,6 +55,13 @@ StatusDialog {
     signal remotelyDestructClicked
     signal kickClicked
     signal banClicked
+
+    QtObject {
+        id: d
+
+        property string accountAddress: ""
+        property string accountName: ""
+    }
 
     ColumnLayout {
         anchors.fill: parent
@@ -155,6 +165,7 @@ StatusDialog {
                 const item = ModelUtils.get(accountsSelector.model,
                                             accountsSelector.currentIndex)
                 d.accountAddress = item.address
+                d.accountName = item.name
             }
         }
     }
@@ -190,11 +201,5 @@ StatusDialog {
                 }
             }
         }
-    }
-
-    QtObject {
-        id: d
-
-        property string accountAddress: ""
     }
 }

--- a/ui/app/AppLayouts/Communities/views/CommunitySettingsView.qml
+++ b/ui/app/AppLayouts/Communities/views/CommunitySettingsView.qml
@@ -353,6 +353,14 @@ StatusSectionLayout {
                 communityTokensStore.remoteSelfDestructCollectibles(
                     root.community.id, walletsAndAmounts, tokenKey, accountAddress)
 
+            onRemotelyDestructAndBan:
+                communityTokensStore.remotelyDestructAndBan(
+                    root.community.id, contactId, tokenKey, accountAddress)
+
+            onRemotelyDestructAndKick:
+                communityTokensStore.remotelyDestructAndKick(
+                    root.community.id, contactId, tokenKey, accountAddress)
+
             onBurnToken:
                 communityTokensStore.burnToken(root.community.id, tokenKey, amount, accountAddress)
 

--- a/ui/app/AppLayouts/Communities/views/CommunityTokenView.qml
+++ b/ui/app/AppLayouts/Communities/views/CommunityTokenView.qml
@@ -71,8 +71,8 @@ StatusScrollView {
     signal viewMessagesRequested(string contactId)
 
     signal remoteDestructRequested(string name, string address)
-    signal kickRequested(string name, string contactId)
-    signal banRequested(string name, string contactId)
+    signal kickRequested(string name, string contactId, string address)
+    signal banRequested(string name, string contactId, string address)
 
     QtObject {
         id: d
@@ -213,8 +213,8 @@ StatusScrollView {
             onGeneralAirdropRequested: root.generalAirdropRequested()
             onRemoteDestructRequested: root.remoteDestructRequested(name, address)
 
-            onKickRequested: root.kickRequested(name, contactId)
-            onBanRequested: root.banRequested(name, contactId)
+            onKickRequested: root.kickRequested(name, contactId, address)
+            onBanRequested: root.banRequested(name, contactId, address)
         }
     }
 }

--- a/ui/imports/shared/stores/CommunityTokensStore.qml
+++ b/ui/imports/shared/stores/CommunityTokensStore.qml
@@ -137,6 +137,14 @@ QtObject {
         communityTokensModuleInst.selfDestructCollectibles(communityId, JSON.stringify(walletsAndAmounts), tokenKey, accountAddress)
     }
 
+    function remotelyDestructAndBan(communityId, contactId, tokenKey, accountAddress, deleteMessages) {
+        console.warn("remotelyDestructAndBan, not implemented yet!")
+    }
+
+    function remotelyDestructAndKick(communityId, contactId, tokenKey, accountAddress) {
+        console.warn("remotelyDestructAndKick, not implemented yet!")
+    }
+
     function burnToken(communityId, tokenKey, burnAmount, accountAddress) {
         console.assert(typeof burnAmount === "string")
         communityTokensModuleInst.burnTokens(communityId, tokenKey, burnAmount, accountAddress)


### PR DESCRIPTION
### What does the PR do

- Integrates `TokenMasterActionPopup` and sign popup for:
   - remotely destruct - the same API as for regular tokens, currently fully working
   - kick - the action not implemented on the backend (remotelyDestructAndKick)
   - ban - the action not implemented on the backend (remotelyDestructAndBan)
- Displays elided wallet address when contact name is not available in case of remotely destruct

Closes: https://github.com/status-im/status-desktop/issues/12066

### Affected areas
`MintTokensSettingsPanel`

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

[Kazam_screencast_00032.webm](https://github.com/status-im/status-desktop/assets/20650004/b86951a0-b9dc-4967-a6ae-90960ebd59d3)

