### PR TITLE
fix: community freezes when editing because of sync operations

### DIFF
--- a/src/app/modules/main/controller.nim
+++ b/src/app/modules/main/controller.nim
@@ -432,6 +432,10 @@ proc init*(self: Controller) =
   self.events.on(SIGNAL_PROFILE_MIGRATION_NEEDED_UPDATED) do(e: Args):
     self.delegate.checkAndPerformProfileMigrationIfNeeded()
 
+  self.events.on(SIGNAL_COMMUNITY_TOKENS_DETAILS_LOADED) do(e: Args):
+    let args = CommunityTokensDetailsArgs(e)
+    self.delegate.onCommunityTokensDetailsLoaded(args.communityId, args.communityTokens, args.communityTokenJsonItems)
+
 proc isConnected*(self: Controller): bool =
   return self.nodeService.isConnected()
 
@@ -494,8 +498,8 @@ proc getStatusForContactWithId*(self: Controller, publicKey: string): StatusUpda
 proc getVerificationRequestFrom*(self: Controller, publicKey: string): VerificationRequest =
   self.contactsService.getVerificationRequestFrom(publicKey)
 
-proc getCommunityTokens*(self: Controller, communityId: string): seq[CommunityTokenDto] =
-  self.communityTokensService.getCommunityTokens(communityId)
+proc getCommunityTokensDetailsAsync*(self: Controller, communityId: string) =
+  self.communityTokensService.getCommunityTokensDetailsAsync(communityId)
 
 proc getCommunityTokenOwners*(self: Controller, communityId: string, chainId: int, contractAddress: string): seq[CommunityCollectibleOwner] =
   return self.communityTokensService.getCommunityTokenOwners(communityId, chainId, contractAddress)

--- a/src/app/modules/main/io_interface.nim
+++ b/src/app/modules/main/io_interface.nim
@@ -1,4 +1,4 @@
-import NimQml, stint
+import NimQml, stint, json
 
 import app_service/service/settings/service as settings_service
 import app_service/service/node_configuration/service as node_configuration_service
@@ -368,6 +368,10 @@ method insertMockedKeycardAction*(self: AccessInterface, cardIndex: int) {.base.
   raise newException(ValueError, "No implementation available")
 
 method removeMockedKeycardAction*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method onCommunityTokensDetailsLoaded*(self: AccessInterface, communityId: string,
+    communityTokens: seq[CommunityTokenDto], communityTokenJsonItems: JsonNode) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 # This way (using concepts) is used only for the modules managed by AppController

--- a/src/app/modules/shared_models/section_model.nim
+++ b/src/app/modules/shared_models/section_model.nim
@@ -3,7 +3,7 @@ import NimQml, Tables, strutils, strformat
 import json
 
 import section_item, member_model
-import ../main/communities/tokens/models/token_item
+import ../main/communities/tokens/models/[token_item, token_model]
 
 type
   ModelRole {.pure.} = enum
@@ -425,3 +425,10 @@ QtObject:
 
     for pubkey, revealedAccounts in communityMembersAirdropAddress.pairs:
       self.items[index].members.setAirdropAddress(pubkey, revealedAccounts)
+
+  proc setTokenItems*(self: SectionModel, id: string, communityTokensItems: seq[TokenItem]) = 
+    let index = self.getItemIndex(id)
+    if (index == -1):
+      return
+
+    self.items[index].communityTokens.setItems(communityTokensItems)


### PR DESCRIPTION
Fixes #11808

The problem was that when creating and editing communities, we get the community tokens and all the details about it. The thing is, those fetches were all done sync, and half of them needed to go to status-go for it.

I fixed it by making those operations async.