### PR TITLE
feat(settings): add Privacy Statement and Terms of Use 

### DIFF
--- a/test/ui-test/testSuites/global_shared/scripts/settings_names.py
+++ b/test/ui-test/testSuites/global_shared/scripts/settings_names.py
@@ -25,8 +25,8 @@ class SettingsSubsection(Enum):
     ABOUT: str = "11" + _EXTRA_MENU_ITEM_OBJ_NAME
     COMMUNITY: str = "12" + _APP_MENU_ITEM_OBJ_NAME
     KEYCARD: str = "13" + _MAIN_MENU_ITEM_OBJ_NAME
-    SIGNOUT: str = "14" + _EXTRA_MENU_ITEM_OBJ_NAME
-    BACKUP_SEED: str = "15" + _MAIN_MENU_ITEM_OBJ_NAME
+    SIGNOUT: str = "16" + _EXTRA_MENU_ITEM_OBJ_NAME
+    BACKUP_SEED: str = "17" + _MAIN_MENU_ITEM_OBJ_NAME
 
 # Main:
 navBarListView_Settings_navbar_StatusNavBarTabButton = {"checkable": True, "container": mainWindow_navBarListView_ListView, "objectName": "Settings-navbar", "type": "StatusNavBarTabButton", "visible": True}

--- a/ui/StatusQ/include/StatusQ/stringutilsinternal.h
+++ b/ui/StatusQ/include/StatusQ/stringutilsinternal.h
@@ -11,9 +11,12 @@ class StringUtilsInternal : public QObject
     Q_OBJECT
 
 public:
-    explicit StringUtilsInternal(QObject* parent = nullptr);
+    explicit StringUtilsInternal(QQmlEngine* engine, QObject* parent = nullptr);
 
     Q_INVOKABLE QString escapeHtml(const QString &unsafe) const;
 
-    static QObject* qmlInstance(QQmlEngine *engine, QJSEngine *scriptEngine);
+    Q_INVOKABLE QString readTextFile(const QString& filePath) const;
+
+private:
+    QQmlEngine *m_engine{nullptr};
 };

--- a/ui/StatusQ/src/StatusQ/Components/StatusNavigationListItem.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusNavigationListItem.qml
@@ -12,8 +12,10 @@ StatusListItem {
     implicitWidth: 286
     implicitHeight: 48
 
-    asset.bgWidth: 20
-    asset.bgHeight: 20
+    asset.bgWidth: 24
+    asset.bgHeight: 24
+    asset.width: 24
+    asset.height: 24
     asset.bgColor: "transparent"
 
     statusListItemIcon.anchors.topMargin: 14

--- a/ui/StatusQ/src/StatusQ/Components/StatusToolBar.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusToolBar.qml
@@ -1,9 +1,8 @@
-import QtQuick 2.14
-import QtQuick.Controls 2.14
-import QtQuick.Layouts 1.13
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
 
 import StatusQ.Core 0.1
-import StatusQ.Core.Theme 0.1
 import StatusQ.Controls 0.1
 
 ToolBar {
@@ -21,23 +20,20 @@ ToolBar {
     objectName: "statusToolBar"
     implicitWidth: visible ? 518 : 0
     implicitHeight: visible ? 56 : 0
-    padding: 4
+    leftPadding: 24
+    rightPadding: 10
+    topPadding: 8
+    bottomPadding: 4
     background: null
 
     RowLayout {
         anchors.fill: parent
-        anchors.rightMargin: 4
         spacing: 0
         StatusFlatButton {
             objectName: "toolBarBackButton"
             icon.name: "arrow-left"
-            icon.width: 20
-            icon.height: 20
-            Layout.alignment: Qt.AlignLeft | Qt.AlignVCenter
-            Layout.leftMargin: 18
             visible: !!root.backButtonName
             text: root.backButtonName
-            size: StatusBaseButton.Size.Large
             onClicked: { root.backButtonClicked(); }
         }
 

--- a/ui/StatusQ/src/StatusQ/Core/Utils/StringUtils.qml
+++ b/ui/StatusQ/src/StatusQ/Core/Utils/StringUtils.qml
@@ -8,4 +8,8 @@ QtObject {
     function escapeHtml(unsafe) {
         return Internal.StringUtils.escapeHtml(unsafe)
     }
+
+    function readTextFile(file) {
+        return Internal.StringUtils.readTextFile(file)
+    }
 }

--- a/ui/StatusQ/src/plugin.cpp
+++ b/ui/StatusQ/src/plugin.cpp
@@ -1,4 +1,4 @@
-#include <QtQml/QQmlExtensionPlugin>
+#include <QQmlExtensionPlugin>
 
 #include <QZXing.h>
 #include <qqmlsortfilterproxymodeltypes.h>
@@ -11,7 +11,8 @@
 #include "StatusQ/statuswindow.h"
 #include "StatusQ/stringutilsinternal.h"
 
-class StatusQPlugin : public QQmlExtensionPlugin {
+class StatusQPlugin : public QQmlExtensionPlugin
+{
     Q_OBJECT
     Q_PLUGIN_METADATA(IID QQmlExtensionInterface_iid)
 public:
@@ -27,20 +28,19 @@ public:
 
         qmlRegisterSingletonType<ModelUtilsInternal>(
             "StatusQ.Internal", 0, 1, "ModelUtils", &ModelUtilsInternal::qmlInstance);
-        qmlRegisterSingletonType<StringUtilsInternal>(
-            "StatusQ.Internal", 0, 1, "StringUtils", &StringUtilsInternal::qmlInstance);
 
-        qmlRegisterSingletonType<PermissionUtilsInternal>("StatusQ.Internal", 0, 1, "PermissionUtils", [](QQmlEngine *, QJSEngine *) {
-            return new PermissionUtilsInternal;
-        });
+        qmlRegisterSingletonType<StringUtilsInternal>(
+            "StatusQ.Internal", 0, 1, "StringUtils", [](QQmlEngine* engine, QJSEngine*) {
+                return new StringUtilsInternal(engine);
+            });
+
+        qmlRegisterSingletonType<PermissionUtilsInternal>(
+            "StatusQ.Internal", 0, 1, "PermissionUtils", [](QQmlEngine*, QJSEngine*) {
+                return new PermissionUtilsInternal;
+            });
 
         QZXing::registerQMLTypes();
         qqsfpm::registerTypes();
-    }
-
-    void initializeEngine(QQmlEngine* engine, const char* uri) override
-    {
-        QQmlExtensionPlugin::initializeEngine(engine, uri);
     }
 };
 

--- a/ui/StatusQ/src/stringutilsinternal.cpp
+++ b/ui/StatusQ/src/stringutilsinternal.cpp
@@ -5,13 +5,12 @@
 #include <QQmlEngine>
 #include <QQmlFileSelector>
 
-StringUtilsInternal::StringUtilsInternal(QQmlEngine *engine, QObject* parent)
+StringUtilsInternal::StringUtilsInternal(QQmlEngine* engine, QObject* parent)
     : m_engine(engine)
     , QObject(parent)
-{
-}
+{ }
 
-QString StringUtilsInternal::escapeHtml(const QString &unsafe) const
+QString StringUtilsInternal::escapeHtml(const QString& unsafe) const
 {
     return unsafe.toHtmlEscaped();
 }

--- a/ui/app/AppLayouts/Communities/views/CommunitySettingsView.qml
+++ b/ui/app/AppLayouts/Communities/views/CommunitySettingsView.qml
@@ -106,10 +106,10 @@ StatusSectionLayout {
 
                 Layout.fillWidth: true
                 Layout.fillHeight: true
-                Layout.leftMargin: Style.current.padding
+                Layout.leftMargin: Style.current.halfPadding
                 Layout.rightMargin: Style.current.padding
                 model: stackLayout.children
-                spacing: 8
+                spacing: Style.current.halfPadding
                 enabled: !root.communitySettingsDisabled
 
                 delegate: StatusNavigationListItem {
@@ -117,8 +117,6 @@ StatusSectionLayout {
                     width: ListView.view.width
                     title: model.sectionName
                     asset.name: model.sectionIcon
-                    asset.height: 24
-                    asset.width: 24
                     selected: d.currentIndex === index && !root.communitySettingsDisabled
                     onClicked: d.currentIndex = index
                     visible: model.sectionEnabled

--- a/ui/app/AppLayouts/Profile/ProfileLayout.qml
+++ b/ui/app/AppLayouts/Profile/ProfileLayout.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.13
-import QtQuick.Controls 2.13
-import QtQuick.Layouts 1.13
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
 
 import utils 1.0
 import shared 1.0
@@ -18,6 +18,7 @@ import StatusQ.Core 0.1
 import StatusQ.Layout 0.1
 import StatusQ.Controls 0.1
 import StatusQ.Popups.Dialog 0.1
+import StatusQ.Core.Utils 0.1 as SQUtils
 
 StatusSectionLayout {
     id: root
@@ -37,6 +38,10 @@ StatusSectionLayout {
         switch (Global.settingsSubsection) {
         case Constants.settingsSubsection.contacts:
             Global.changeAppSectionBySectionType(Constants.appSection.profile, Constants.settingsSubsection.messaging)
+            break;
+        case Constants.settingsSubsection.about_privacy:
+        case Constants.settingsSubsection.about_terms:
+            Global.changeAppSectionBySectionType(Constants.appSection.profile, Constants.settingsSubsection.about)
             break;
         case Constants.settingsSubsection.wallet:
             walletView.item.resetStack()
@@ -96,6 +101,8 @@ StatusSectionLayout {
 
             if (currentIndex === Constants.settingsSubsection.contacts) {
                 root.store.backButtonName = root.store.getNameForSubsection(Constants.settingsSubsection.messaging)
+            } else if (currentIndex === Constants.settingsSubsection.about_privacy || currentIndex === Constants.settingsSubsection.about_terms) {
+                root.store.backButtonName = root.store.getNameForSubsection(Constants.settingsSubsection.about)
             } else if (currentIndex === Constants.settingsSubsection.wallet) {
                 walletView.item.resetStack()
             } else if (currentIndex === Constants.settingsSubsection.keycard) {
@@ -334,6 +341,46 @@ StatusSectionLayout {
                 sectionTitle: root.store.getNameForSubsection(Constants.settingsSubsection.keycard)
                 mainSectionTitle: root.store.getNameForSubsection(Constants.settingsSubsection.keycard)
                 contentWidth: d.contentWidth
+            }
+        }
+
+        Loader {
+            active: false
+            asynchronous: true
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            sourceComponent: SettingsContentBase {
+                implicitWidth: parent.width
+                implicitHeight: parent.height
+                sectionTitle: "Status Software Terms of Use"
+                contentWidth: d.contentWidth
+
+                StatusBaseText {
+                    width: d.contentWidth
+                    wrapMode: Text.Wrap
+                    textFormat: Text.MarkdownText
+                    text: SQUtils.StringUtils.readTextFile(":/imports/assets/docs/terms-of-use.mdwn")
+                }
+            }
+        }
+
+        Loader {
+            active: false
+            asynchronous: true
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            sourceComponent: SettingsContentBase {
+                implicitWidth: parent.width
+                implicitHeight: parent.height
+                sectionTitle: "Status Software Privacy Statement"
+                contentWidth: d.contentWidth
+
+                StatusBaseText {
+                    width: d.contentWidth
+                    wrapMode: Text.Wrap
+                    textFormat: Text.MarkdownText
+                    text: SQUtils.StringUtils.readTextFile(":/imports/assets/docs/privacy.mdwn")
+                }
             }
         }
     }

--- a/ui/app/AppLayouts/Profile/panels/MenuPanel.qml
+++ b/ui/app/AppLayouts/Profile/panels/MenuPanel.qml
@@ -89,7 +89,7 @@ Column {
     }
 
     StatusListSectionHeadline {
-        text: qsTr("Settings")
+        text: qsTr("Preferences")
         width: root.width
     }
 

--- a/ui/app/AppLayouts/Profile/views/AboutView.qml
+++ b/ui/app/AppLayouts/Profile/views/AboutView.qml
@@ -6,6 +6,7 @@ import StatusQ.Core 0.1
 import StatusQ.Core.Theme 0.1
 import StatusQ.Controls 0.1
 import StatusQ.Components 0.1
+import StatusQ.Popups.Dialog 0.1
 
 import utils 1.0
 import shared 1.0
@@ -24,6 +25,26 @@ SettingsContentBase {
         onClicked: {
             root.store.checkForUpdates()
         }
+    }
+
+    component LinkItem: StatusListItem {
+        Layout.fillWidth: true
+        components: [
+            StatusIcon {
+                icon: "external-link"
+                color: Theme.palette.directColor1
+            }
+        ]
+    }
+
+    component DocumentItem: StatusListItem {
+        Layout.fillWidth: true
+        components: [
+            StatusIcon {
+                icon: "next"
+                color: Theme.palette.directColor1
+            }
+        ]
     }
 
     ColumnLayout {
@@ -53,7 +74,6 @@ SettingsContentBase {
 
             StatusBaseText {
                 anchors.horizontalCenter: parent.horizontalCenter
-                font.pixelSize: 15
                 text: qsTr("Current Version")
             }
 
@@ -70,7 +90,7 @@ SettingsContentBase {
 
             StatusBaseText {
                 anchors.horizontalCenter: parent.horizontalCenter
-                font.pixelSize: 13
+                font.pixelSize: Style.current.additionalTextSize
                 text: qsTr("Status Go Version")
             }
 
@@ -82,124 +102,80 @@ SettingsContentBase {
                 icon.name: "info"
                 text: qsTr("Release Notes")
                 visible: root.store.isProduction
-                onClicked: {
-                    root.store.getReleaseNotes()
-                }
+                onClicked: root.store.getReleaseNotes()
             }
         } // Column
 
-        StatusListItem {
-            title: qsTr("Our Principles")
+        ColumnLayout {
             Layout.fillWidth: true
-            implicitHeight: 64
-            components: [
-                StatusIcon {
-                    icon: "next"
-                    color: Theme.palette.baseColor1
-                }
-            ]
-            onClicked: root.store.openLink("https://status.im/about/#our-principles")
-        }
+            Layout.topMargin: Style.current.padding
 
-        Column {
-            Layout.fillWidth: true
-            spacing: 4
+            LinkItem {
+                title: qsTr("Status Manifesto")
+                Layout.fillWidth: true
+                onClicked: root.store.openLink("https://status.app/manifesto")
+            }
+
+            StatusDialogDivider {
+                Layout.fillWidth: true
+            }
+
             StatusBaseText {
+                Layout.fillWidth: true
+                Layout.topMargin: Style.current.padding
+                Layout.leftMargin: Style.current.padding
                 text: qsTr("Status desktop’s GitHub Repositories")
-                anchors.left: parent.left
-                anchors.leftMargin: Style.current.padding
-                font.pixelSize: 15
                 color: Style.current.secondaryText
             }
 
-            StatusFlatButton {
-                Layout.fillWidth: true
-                leftPadding: Style.current.padding
-                rightPadding: Style.current.padding
-                text: qsTr("Status Desktop")
-                icon.width: 0
-                onClicked: {
-                    root.store.openLink("https://github.com/status-im/status-desktop")
-                }
+            LinkItem {
+                title: qsTr("status-desktop")
+                onClicked: root.store.openLink("https://github.com/status-im/status-desktop")
             }
 
-            StatusFlatButton {
-                Layout.fillWidth: true
-                leftPadding: Style.current.padding
-                rightPadding: Style.current.padding
-                text: qsTr("Status Go")
-                icon.width: 0
-                onClicked: {
-                    root.store.openLink("https://github.com/status-im/status-go")
-                }
+            LinkItem {
+                title: qsTr("status-go")
+                onClicked: root.store.openLink("https://github.com/status-im/status-go")
             }
 
-            StatusFlatButton {
-                Layout.fillWidth: true
-                leftPadding: Style.current.padding
-                rightPadding: Style.current.padding
-                text: qsTr("StatusQ")
-                icon.width: 0
-                onClicked: {
-                    root.store.openLink("https://github.com/status-im/statusq")
-                }
+            LinkItem {
+                title: qsTr("StatusQ")
+                onClicked: root.store.openLink("https://github.com/status-im/status-desktop/tree/master/ui/StatusQ")
             }
 
-            StatusFlatButton {
+            LinkItem {
+                title: qsTr("go-waku")
+                onClicked: root.store.openLink("https://github.com/status-im/go-waku")
+            }
+
+            StatusDialogDivider {
                 Layout.fillWidth: true
-                leftPadding: Style.current.padding
-                rightPadding: Style.current.padding
-                text: qsTr("go-waku")
-                icon.width: 0
-                onClicked: {
-                    root.store.openLink("https://github.com/status-im/go-waku")
-                }
+            }
+
+            StatusBaseText {
+                Layout.fillWidth: true
+                Layout.topMargin: Style.current.padding
+                Layout.leftMargin: Style.current.padding
+                text: qsTr("Legal & Privacy Documents")
+                color: Style.current.secondaryText
+            }
+
+            DocumentItem {
+                title: qsTr("Terms of Use")
+                onClicked: Global.changeAppSectionBySectionType(Constants.appSection.profile,
+                                                                Constants.settingsSubsection.about_terms)
+            }
+
+            DocumentItem {
+                title: qsTr("Privacy Statement")
+                onClicked: Global.changeAppSectionBySectionType(Constants.appSection.profile,
+                                                                Constants.settingsSubsection.about_privacy)
+            }
+
+            LinkItem {
+                title: qsTr("Software License")
+                onClicked: root.store.openLink("https://github.com/status-im/status-desktop/blob/master/LICENSE.md")
             }
         }
-
-        Column {
-            Layout.fillWidth: true
-            spacing: 4
-            StatusBaseText {
-                anchors.left: parent.left
-                anchors.leftMargin: Style.current.padding
-                text: qsTr("Legal & Privacy Documents")
-                font.pixelSize: 15
-                color: Style.current.secondaryText
-            }
-
-            StatusFlatButton {
-                Layout.fillWidth: true
-                leftPadding: Style.current.padding
-                rightPadding: Style.current.padding
-                text: qsTr("Terms of Use")
-                icon.width: 0
-                onClicked: {
-                    root.store.openLink("https://status.im/terms-of-use/")
-                }
-            }
-
-            StatusFlatButton {
-                Layout.fillWidth: true
-                leftPadding: Style.current.padding
-                rightPadding: Style.current.padding
-                text: qsTr("Privacy Policy")
-                icon.width: 0
-                onClicked: {
-                    root.store.openLink("https://status.im/privacy-policy/")
-                }
-            }
-
-            StatusFlatButton {
-                Layout.fillWidth: true
-                leftPadding: Style.current.padding
-                rightPadding: Style.current.padding
-                text: qsTr("Software License")
-                icon.width: 0
-                onClicked: {
-                    root.store.openLink("https://github.com/status-im/status-desktop/blob/master/LICENSE.md")
-                }
-            }
-        } // Column
     }
 }

--- a/ui/app/AppLayouts/Profile/views/AppearanceView.qml
+++ b/ui/app/AppLayouts/Profile/views/AppearanceView.qml
@@ -40,7 +40,6 @@ SettingsContentBase {
     Item {
         id: appearanceContainer
         anchors.left: !!parent ? parent.left : undefined
-        anchors.leftMargin: Style.current.padding
         width: appearanceView.contentWidth - 2 * Style.current.padding
         height: childrenRect.height
 

--- a/ui/app/AppLayouts/Profile/views/LanguageView.qml
+++ b/ui/app/AppLayouts/Profile/views/LanguageView.qml
@@ -48,8 +48,6 @@ SettingsContentBase {
 
         RowLayout {
             Layout.fillWidth: true
-            Layout.leftMargin: Style.current.padding
-            Layout.rightMargin: Style.current.padding
             z: root.z + 2
 
             StatusBaseText {
@@ -87,8 +85,6 @@ SettingsContentBase {
 
         RowLayout {
             Layout.fillWidth: true
-            Layout.leftMargin: Style.current.padding
-            Layout.rightMargin: Style.current.padding
             z: root.z + 1
 
             StatusBaseText {
@@ -162,8 +158,6 @@ SettingsContentBase {
         // Time format options:
         Column {
             Layout.fillWidth: true
-            Layout.leftMargin: Style.current.padding
-            Layout.rightMargin: Style.current.padding
             Layout.topMargin: Style.current.padding
             spacing: Style.current.padding
             StatusBaseText {

--- a/ui/app/AppLayouts/Profile/views/LeftTabView.qml
+++ b/ui/app/AppLayouts/Profile/views/LeftTabView.qml
@@ -32,6 +32,7 @@ Item {
         contentHeight: profileMenu.height + Style.current.bigPadding
         anchors.right: parent.right
         anchors.left: parent.left
+        leftPadding: Style.current.halfPadding
         anchors.top: title.bottom
         anchors.topMargin: Style.current.halfPadding
         anchors.bottom: parent.bottom

--- a/ui/app/AppLayouts/Profile/views/MyProfileView.qml
+++ b/ui/app/AppLayouts/Profile/views/MyProfileView.qml
@@ -49,6 +49,7 @@ SettingsContentBase {
     bottomHeaderComponents: StatusTabBar {
         id: editPreviwTabBar
         StatusTabButton {
+            leftPadding: 0
             width: implicitWidth
             text: qsTr("Edit")
         }

--- a/ui/app/AppLayouts/Profile/views/SettingsContentBase.qml
+++ b/ui/app/AppLayouts/Profile/views/SettingsContentBase.qml
@@ -62,9 +62,8 @@ Item {
 
         RowLayout {
             id: titleLayout
-            Layout.preferredWidth: (parent.width - Style.current.padding)
+            Layout.fillWidth: true
             Layout.preferredHeight: visible ? d.titleRowHeight : 0
-            Layout.leftMargin: Style.current.padding
             visible: (root.sectionTitle !== "")
 
             Loader {

--- a/ui/app/AppLayouts/Profile/views/wallet/EditNetworkView.qml
+++ b/ui/app/AppLayouts/Profile/views/wallet/EditNetworkView.qml
@@ -19,6 +19,7 @@ ColumnLayout {
     StatusTabBar {
         id: editPreviwTabBar
         StatusTabButton {
+            leftPadding: 0
             text: qsTr("Live Network")
             width: implicitWidth
         }

--- a/ui/generate-rcc.go
+++ b/ui/generate-rcc.go
@@ -25,6 +25,7 @@ var qrcExtensions = map[string]bool{
 	".txt":  true,
 	".gif":  true,
 	".json": true,
+	".mdwn": true,
 }
 
 func main() {

--- a/ui/imports/assets/docs/privacy.mdwn
+++ b/ui/imports/assets/docs/privacy.mdwn
@@ -1,0 +1,54 @@
+Last updated: 2023-09-22
+
+### Who we are
+
+Status is developing a set of open source projects that use peer-to-peer technologies to help people transact securely, communicate freely, and organise with confidence. Anyone participating in these projects helps to build technology and tools that empowers people to advance their own sovereign communities.
+
+Whenever “Status” or “we” or “us” or any similar variation, are used in these terms, we’re referring to Status Research & Development GmbH, a Swiss company with its registered office at Baarerstrasse 10, Zug, Switzerland, and includes its “representatives”, which means Status’ affiliates, directors, officers, employees, agents and any other representatives of Status. For the purposes of these terms, “representatives” also includes Status core contributors without prejudice to the other legal categories mentioned.
+
+Status does not provide any services, such as financial services, to users of Status Software or any third party. Status is not an intermediary, agent, advisor, or custodian, and does not owe you any fiduciary duty. 
+&nbsp;
+
+### Status Software
+
+At Status, we strive to develop open source software that can serve as a secure communication tool that helps to uphold human rights. Status Software is specifically designed to facilitate the free flow of information, protect the right to private, secure communications and promote the sovereignty of individuals.
+
+Status Software is composed of a secure messaging tool, a crypto wallet, and a Web 3 browser integrated together. The software developed by Status in this regard is simply called “Status Software” and you can find more details about its development on Status’ GitHub page.
+&nbsp;
+
+### Our role in your privacy
+
+This Privacy Statement applies to you as a user of Status Software. 
+
+Under the relevant data protection legislation, we would be under certain obligations if we process any personal data when you use Status Software. Personal data means all information by which a person can be directly or indirectly identified, in line with the definitions of the General Data Protection Regulation (GDPR), the Swiss Federal Act on Data Protection of June 19, 1992 (DPA) (as amended from time to time) and its ordinances, and other relevant legislation on the protection of personal data. When we refer to privacy legislation in this Privacy Statement, we mean GDPR and all such relevant legislation.
+
+However, since we do not collect or process any of your personal data when you use Status Software, we have decided to inform you of the following instead: 
+
+- **Ethereum is a public blockchain**
+Ethereum is the community-run technology powering the cryptocurrency ether (ETH) and thousands of decentralized applications (DApps). Status Software provides a mobile portal and streamlined access to Ethereum’s growing ecosystem of decentralized applications.
+&nbsp;
+The Ethereum public network is accessible to anyone in the world with an internet connection. Anyone can read or create transactions on a public blockchain and validate the transactions being executed. Therefore, information you share on the Ethereum blockchain is public, whether or not you use Status Software. 
+&nbsp;
+You will also be able to create (and join) open and public communities on Status Software that are accessible to other users. We note that content in these open and public communities will be accessible to all other users of Status Software. Nonetheless, all content will still be protected by the same end-to-end encryption utilised in Status Software. 
+&nbsp;
+Ethereum Name Service (ENS) allows Ethereum addresses to be replaced by custom text-based names. Anyone can register a stateofus.eth username by staking the required Status Network Tokens (SNT) from within the profile tab on Status Software. When you register an ENS name with a given wallet address, that address becomes associated with the username, reducing the privacy of that account.
+
+- **Offering secure, private messaging**
+When generating an account, a randomisation process is started on your own device that generates a key pair. Status does not have visibility of or access to your private keys. You will then be given display name options to choose from (derived from this key pair). Your display name will only be shared if you choose to share it by chatting with Status or other users.
+&nbsp;
+Within Status Software, you can create a list of trusted contacts based on the chat keys you choose to trust. Your trusted contacts are also stored locally on your own device. This means Status has no access to your contact list and does not collect or process any personal data in this respect.
+&nbsp;
+On Status Software, you can exchange messages with other users, including photos and audio messages. Only the recipient of a message can decrypt the message by opening it on their own device. This means that Status can never access any user messages in private chats.
+&nbsp;
+Messaging on Status Software uses an open source, peer-to-peer protocol with end-to-end encryption and metadata suppression, to protect your messages from third parties (including Status). End-to-end encryption means that only the sender and recipient of a message can read its contents, and no one else. This protocol, known as Waku, relies on a distributed network of nodes instead of a centralised server which means that there is no central party or server from which messages can be intercepted, modified or blocked. Learn more about Waku and how it works on Waku’s website. 
+
+- **A quick bite on cookies**
+We do not set any cookies for the use of Status Software. However, the Web 3.0 browser embedded within Status Software technically supports the use of cookies set by websites you might choose to visit through the Web 3.0 browser.
+&nbsp;
+
+### Changes to Status Privacy Statement
+It is unlikely that this Privacy Statement will change because we do not intend to collect or process your personal data, ever. That said, we reserve the right to modify or replace any part of this Privacy Statement at any time and in our sole discretion. 
+
+If you have any questions about the Status Software Privacy Statement, please contact us at legal@status.im or through the means of communication indicated on the Status website. 
+
+This document is CC-BY-SA.

--- a/ui/imports/assets/docs/terms-of-use.mdwn
+++ b/ui/imports/assets/docs/terms-of-use.mdwn
@@ -1,0 +1,345 @@
+Last updated: 2023-09-22
+
+### 1. Introduction
+
+#### 1.1 Who we are
+
+Status is developing a set of open source projects that use peer-to-peer technologies to help people transact securely, communicate freely, and organise with confidence. Anyone participating in these projects helps to build technology and tools that empowers people to advance their own sovereign communities.
+
+Whenever “Status” or “we” or “us” or any similar variation, are used in these terms, we are referring to Status Research & Development GmbH, a Swiss company with its registered office at Baarerstrasse 10, Zug, Switzerland, and includes its “representatives”, which means Status’ affiliates, directors, officers, employees, agents and any other representatives of Status. For the purposes of these terms, “representatives” also includes Status core contributors without prejudice to the other legal categories mentioned.
+
+Status does not provide any services, such as financial services, to users of Status Software or any third party. Status is not an intermediary, agent, advisor, or custodian, and does not owe you any fiduciary duty. 
+
+#### 1.2 About these terms
+
+These terms are a contract between you and Status and apply to your use of Status Software. The term “Status Software” as used herein means a software developed by Status and is composed of a secure messaging tool, a crypto wallet, and a Web 3 browser integrated together.
+
+Please read these terms carefully before using Status Software. By installing or using Status Software on any device, you agree to these terms. If you do not agree, you should not install or use Status Software. 
+
+We would like to draw your attention to certain parts of these terms which are summarised here for your convenience and we ask that you refer to the corresponding provisions below:
+
+- You are solely responsible for the use of Status Software:
+You are ultimately solely responsible for the use of Status Software. Throughout these terms, we have indicated where you are solely responsible in relation to your use of Status Software, for example, your use of the Wallet, securing your seed phrase and private keys (including backups) and the content you may create and submit through Status Software.
+
+- Third party services and Web 3
+When using Status Software, you may access or use Third Party Services or interact with Web 3. We note that Status does not control or operate any of these Third Party Services or Web 3 and that there may be applicable terms and conditions which you should refer to if you choose to interact with them. 
+
+- Acceptable use of Status Software
+Status adheres to a number of Principles which are reflected in the design and development of Status Software. We ask that you use Status Software in a way that promotes and aligns with the Status Principles, particularly not acting or using Status Software in manner as set out in the relevant provision below. 
+
+- Risks
+The use of Status Software is not without risk. You should understand the risks involved and how they may affect you. We have listed a number of risks in these terms, such as from your use of the Wallet, the novel and experimental nature of Web 3, the unpredictable and volatile nature of Digital Assets and potential legal, and regulatory and tax implications. The risks listed in these terms are not exhaustive and ultimately, you are solely responsible for evaluating the risks and deciding whether or not to use Status Software. 
+
+- Indemnity
+You provide Status a broad indemnity from and against any and all claims, damages and expenses, including attorneys’ fees, arising from or related to your use of Status Software.
+
+- Release and limitation of liability
+You not only release Status’ liability on a number of items, but also agree that Status’ aggregate liability is limited to EUR 100 (one hundred Euros) or to the extent permitted by law. 
+
+- Arbitration
+If a dispute arises between you and Status, we will seek to first solve it amicably with you before proceeding to the use of an arbitration administered by the Swiss Chambers’ Arbitration Institution.
+&nbsp;
+
+### 2. About Status Software
+
+#### 2.1 What is Status Software
+
+At Status, we strive to develop open source software that can serve as a secure communication tool that helps to uphold human rights. Status Software is specifically designed to facilitate the free flow of information, protect the right to private, secure communications and promote the sovereignty of individuals.
+
+Status Software is composed of a secure messaging tool, a crypto wallet, and a Web 3 browser integrated together. The software developed by Status in this regard is simply called “Status Software” and you can find more details about its development on Status’ GitHub page.
+
+Status Software is open source client software that is designed to be user-friendly and can be installed or run in a web browser on your local desktop or mobile device. You can use Status Software to interact with and participate in Web 3 protocols, applications and peer to peer networks (referred to in these terms collectively, as “Web 3”). Please note that Status Software is not a blockchain protocol, or a blockchain network, a platform or a web-based platform.
+
+Status develops Status Software and makes it available for you to run in a web browser or for your local use on your desktop or mobile device. This means that you are solely responsible for your activity and any potential risk or loss you may incur through using the Status Software as further detailed below in these terms. 
+
+#### 2.1.1 Wallet
+
+Status Software includes a crypto wallet. We will refer to such wallet functionality in these terms as “Wallet”.
+
+The Wallet is your own personal crypto wallet. This type of wallet is sometimes also called “non-custodial”, “self-custodial” or “self-hosted”, which means you are in complete control of the crypto tokens (the “Digital Assets”) in the Wallet. Status will never have access to or control over your seed phrase, private keys or Digital Assets in your Wallet given its design. 
+ 
+Using the Wallet, you are able to send, receive and store Digital Assets and connect to and interact with third-party services that enable the exchange of Digital Assets for fiat currency and Web 3, including certain blockchain bridges and decentralised exchanges. 
+
+The Wallet contains the latest security standards, anti-phishing mechanisms and locally generated and stored public and private keys to ensure that your Digital Assets are secured to the highest standards. 
+
+When generating an account, a randomisation process is started on your own device that generates a key pair. Status does not have visibility of or access to your private keys. You are solely responsible for storing and securing your seed phrase and private keys, and creating, storing and securing their backups. If you fail to maintain the appropriate security measures of your private keys, it may result in you losing access to your Wallet and control of any Digital Assets in your Wallet. If you lose or forget your seed phrase or private keys, Status will not be able to help you recover or replace them and further, Status will not be able to assist you with the recovery of your Digital Assets. 
+
+In order to further enhance the security of storing your private keys, you may also choose to store your keys on a keycard,such as the Status Keycard. 
+
+#### 2.1.2 Messaging
+
+Status Software includes messaging functionality that enables secure communication between users. We will refer to the messaging functionality of Status Software and the Status Community Spaces collectively in these terms, as “Messaging”. 
+
+Messaging uses an open source, peer-to-peer protocol with end-to-end encryption and metadata suppression, to protect your messages from third parties (including Status). End-to-end encryption means that only the sender and recipient of a message can read its contents, and no one else. Peer to peer communication is accomplished using the Waku peer-to-peer messaging protocol, which relies on a distributed network of nodes instead of a centralised server. This means there is no central party or server from which messages can be intercepted, modified or blocked. Learn more about Waku and how it works on Waku’s relevant website. 
+
+Within Messaging, you will also be able to participate in Status Community Spaces. This feature allows users to create their own token-gated communities where you can create group chats and engage with your communities, while leveraging the possibilities, functionality and benefits of blockchain technology. You will also be able to create (and join) open and public communities on Status Software that are accessible to other users. We note that content in these open and public communities will be accessible to all other users of Status Software. Nonetheless, all content will still be protected by the same end-to-end encryption utilised in Status Software. 
+
+#### 2.1.2 Web 3 browser
+
+Status Software also includes a Web 3 browser through which you may access and interact with Web 3, exchanges, marketplaces, games and more. We will refer to the Web 3 browser in these terms as the “Web 3 Browser”. 
+&nbsp;
+
+### 3. Privacy
+
+Status uses an open source, peer-to-peer protocol with end-to-end encryption and metadata suppression, which by design, means that Status (and any third party) is unable to and does not collect, store, own, control or have any visibility or means of access to your identity, Wallet, browsing information, any user private keys, Digital Assets, messages, content, history of interactions, transactions, user accounts or any other user information. 
+
+Therefore, Status does not monetise any users’ data or content, such as messages or browser information and Status does have any interest in doing so. 
+
+When generating an account on Status Software, you will have the option to utilise your phone number and certain social media handles such as your Twitter account, to generate an account. While this information is not shared with Status and Status has no access to it, third party service providers may receive it to authenticate your ownership of such accounts. Using your phone number or social media handle, such as X (formerly known as Twitter), will allow you to find your contacts who are also using Status Software and it will help your contacts to find you. This will allow them to discover and potentially interact with you, if you accept their request to connect, so that you can start building up your network of contacts on Status Software. Please note that this is not required for you to access or utilise Status Software, and you can always choose to generate an account anonymously without utilising your phone number or social media handle. 
+
+In addition, you may opt in to submit certain technical information (also referred to as telemetry) to assist Status with the development of the Status Software, particularly to measure message reliability and bandwidth usage. In any event this technical information is anonymised by Status Software and also protected by end-to-end encryption. We note that even anonymised data can be vulnerable to being potentially compromised, such as by correlation attacks. You should opt in to submit this technical information only if you are willing to accept these risks. 
+
+You acknowledge that an inherent feature of Web 3 is its transparency, particularly in the context of blockchain networks. This means that your public key and wallet address will be visible to others when you engage in transactions on such networks and that third parties may be able to (and for the avoidance of doubt, not through the use of Status Software) connect your public key and wallet address to your identity and determine the Digital Assets you own in your Wallet. You should also be aware that entries on blockchain networks are practically immutable, which means that they generally cannot be deleted or modified by anyone, including Status, even if the transaction turns out to have been made in error or otherwise. 
+
+If you use third party services offered through Status Software, your privacy may not be protected and you will be subject to the privacy terms and conditions of such third parties. Please refer to our full terms regarding third party services below.
+
+
+Learn more about how we protect your data on Status Software by reading the Status Privacy Statement and relevant security page on the Status website.
+&nbsp;
+
+### 4. Using third party services and interacting with Web 3 
+
+When using Status Software, you may access or use third party products, services or tools (“Third Party Services”) and interact with Web 3. Status Software is only one means of interacting with these Third Party Services and Web 3 and you can independently utilise other means and tools to do so as well. 
+
+Your interactions with Web 3 could include many aspects, such as interacting with smart contracts that reside on blockchain networks, for example to swap Digital Assets or use (crypto) bridges, or deploying your own smart contracts through Status Community Spaces. You may also interact with and participate in peer-to-peer networks which could vary in their level of decentralisation, ranging from more centralised networks controlled by a single party to networks governed by decentralised communities. 
+
+You acknowledge when you use Third Party Services or interact with Web 3, that Status does not control or operate any Third Party Service or Web 3. These are products, services or tools that are respectively provided by others or may be operating autonomously, and not by Status. 
+
+Please note that when you use Third Party Services or interact with Web 3 that there may be applicable terms and conditions, including privacy policies which govern your use of Third Party Services or interaction with Web 3. In case of interactions with Web 3, such as decentralised exchanges, there may be in some cases no applicable terms and conditions, and the relevant software code will govern your interactions.
+
+Please also note that bridges are used to move tokens from one blockchain network to another. When you use a bridge, for example in the course of sending or bridging tokens, Status utilises an algorithm that aims to determine the lowest service fee which the user may incur at the time of a bridge’s use. This algorithm relies on information extracted directly from the relevant blockchain networks. Status is not responsible for the accuracy and correctness of any information that these algorithms may extract from such networks 
+
+You are solely responsible for your use of Third Party Services and your interactions with Web 3. If you have any technical issues or other issues with any of these Third Party Services or Web 3, you should contact the relevant third party or appropriate point of contact directly (if any).
+
+In principle, Status does not provide any advice, recommendation, support or endorse Third Party Services you may use or any aspect of Web 3 that you may interact with through Status Software. Their integration or availability through Status Software does not imply any support or endorsement by Status. Status may also receive a fee from certain third parties who provide the Third Party Services. 
+
+Please also note that Status participates in the development of open source projects that utilise peer-to-peer technologies, which you can find more details about on Status’ GitHub page. 
+&nbsp;
+
+### 5. Nodes 
+
+The use of Status Software on your device will turn it into a node that supports the Waku network.
+
+In general, by participating in or interacting with Web 3 networks, you may choose or be required to operate a node or perform other functions in support of such a network. Status is not responsible for the operation or functioning of such nodes. 
+&nbsp;
+
+### 6. Security 
+
+Although security is a top priority for us and many functions of Status Software are privacy-mode by default, we cannot guarantee the full security of Status Software and we are not responsible for alerting you to potential security risks. We intend to continuously update the security measures of Status Software and we will from time to time post updates on the security of Status Software through our communication channels.
+&nbsp;
+
+### 7. Content
+
+At Status, we believe in the sovereignty of individuals and we stand for the cause of personal liberty. We aim to promote social, political, and economic freedoms through Status Software, which is built on the principles of the free flow of information and censorship resistance. Through Status Software, particularly when using Messenger and Status Community Spaces, you will be able to create and interact with various content. We consider content to include anything you (or any other user) create, post, distribute or exchange through Status Software (as well as any future functions that may be added to Status Software), whether its text, links, GIFs, emoji, photos or any other media formats.
+
+You are solely responsible for any content that you create, post, distribute or submit, messages you exchange or any other activity you may engage in related to your content on or through Status Software and any harm or liability that may result from such content.
+
+You represent and warrant in respect of such content that:
+1. your creation, posting, distribution or submission of content does not infringe on any intellectual property or other proprietary rights of any third party; and
+2. you are the creator and owner or that you have the necessary permissions to create, post, distribute or submit such content through Status Software. 
+
+Please note that Status has no means of monitoring, moderating, removing, modifying or regulating users’ content or activity. Status has no ability to verify the accuracy or reliability of such content or activity and is not responsible for it. While you use Status Software, you may view content that:
+1. may be offensive, indecent, or otherwise objectionable; 
+2. contains technical inaccuracies, typographical mistakes, and other errors; or 
+3. may violate others’ rights, including but not limited to privacy, publicity, intellectual property, or other proprietary rights. 
+&nbsp;
+
+### 8. Acceptable use of Status software
+
+#### 8.1 Adherence to Status Principles 
+
+One of Status’ goals is the widespread adoption of the decentralised web while also staying true to our Principles. These terms are designed to reflect our Principles, while providing important legal protections for Status and setting out guidelines and terms for the Status Software community of users. We ask that you use Status Software in a way that promotes and aligns with the Status Principles.
+
+#### 8.2 Limitation on certain uses of and acts in Status Software
+
+You shall not, nor try to, encourage or assist others using Status Software to: 
+1. gain or try to gain unauthorised access to Status Software; 
+2. interfere with or disrupt the integrity, safety, security, availability or performance of Status Software; 
+3. generate accounts on Status Software through unauthorised means; 
+4. install or transmit on or through Status Software, any viruses, worms, malware, Trojan horses, or other harmful or destructive code or content; 
+5. use spam, data mining, or other unsolicited promotional methods, machine generated content, or unethical or unwanted commercial content; 
+6. engage in phishing, spoofing, or similar fraudulent acts; 
+7. knowingly spread misinformation or impersonate another person or legal entity; 
+8. incite to, commit or threaten, harm or engage in illegal or inappropriate conduct including stalking, bullying, harassment, intimidation or abuse another individual or group; 
+9. engage in or organise child sexual exploitation of any kind; 
+10. use Status Software if you are subject to sanctions, or otherwise designated on a list of prohibited or restricted parties as maintained by, the United Nations, the European Union or any of its member states or the Singaporean, Swiss or US government, or intend to interact or transact with such parties;
+11. violate, misappropriate or infringe the rights of Status, other users of Status Software, or any other third parties in any way, including but not limited to privacy, publicity, intellectual property, confidentiality, property or other rights; 
+12. engage in any activity through Status Software that may be in violation of applicable law, rules or regulations in your jurisdiction; 
+13. interfere, disrupt, negatively affect, or inhibit other users from their use of Status Software; or 
+14. engage in any attack, hack, denial-of-service attack, interference, or exploit of any smart contract in connection with use of Status Software.
+&nbsp;
+
+### 9. Fees
+
+When you use Status Software to interact with Third Party Services or Web 3, you may incur costs and may have to pay various fees, such as service fees, transfer fees, transaction fees, swap fees, bridge fees or network fees. You will be solely liable for any such fees, costs and expenses. Status has no control over and is unable to influence these fees in any manner. 
+&nbsp;
+
+### 10. Intellectual property and branding
+
+#### 10.1 Status develops open source software
+
+We want everyone to benefit from Status Software, so we made it available under free and open source licences. This means that anyone can use, share, and modify the source code, as long as they follow the terms of the applicable licence. We believe in permission-less participation, which means that everyone has the right to participate in the development of our software. The applicable licences can be found on Status’ GitHub page.
+
+#### 10.2 Respect the Status brand
+
+Status (and its affiliates as the case may be) owns all the rights to Status brand, including copyrights, domains, trade dress (look and feel), design rights and themes, trademarks, logos, graphics, and other intellectual property. These terms do not grant you any rights to use the Status brand or its intellectual property.
+ 
+We love to see creative work from the Status community, but please let us know in advance and in writing if you want to use trademarks, logos, or graphics or modify them from our standard colours and designs. If you write articles, blogs, create websites, or talk about Status, please make sure it is clear that you are not speaking for, on behalf of, or under endorsement by Status.
+
+To request permission to use our copyrighted material or trademarks or any other intellectual property, such as logos, please contact: marketing@status.im. If we grant you permission, you must follow our guidelines and instructions for using our intellectual property. 
+&nbsp;
+
+### 11. Risks
+
+Before you use Status Software, you should understand the risks involved and how they may affect you. The risks listed below are not intended to be exhaustive and may not reflect all the potential risks you could be exposed to from using Status Software. 
+
+You are solely responsible for evaluating the risks and deciding whether or not to use Status Software. By using Status Software, you agree to accept all of the risks identified below, as well as any other risks that a reasonable person should have been aware about. Status is not responsible for notifying you on an ongoing basis about any changes in the risks associated with using Status Software.
+
+#### 11.1 Wallet
+
+By using the Wallet, you represent that you have a sufficient understanding about crypto wallets and Digital Assets. 
+
+You acknowledge that Digital Assets stored in the Wallet are at risk of loss due to various factors, including but not limited to: theft, hacking (or other cyber-attacks), malware, technical or human error. You further acknowledge that transactions made through the Wallet are final and cannot be reversed by anyone, including Status. You are solely responsible for the transactions you undertake using Status Software, including verifying the accuracy and legitimacy of your transactions before confirming and proceeding with them. 
+
+Status is not a service provider or an intermediary or custodian. We do not store, control, custody, transfer, or handle any users’ funds or Digital Assets. Transactions are processed by validators, nodes, miners, and other participants on the Web 3 network (and not by Status). We do not have visibility of and cannot interfere with, modify, stop, block, change, reverse, or refund any transactions. 
+
+#### 11.2 Novel and experimental nature of Web 3		
+
+You acknowledge that there are inherent risks related to Web 3, arising from its novel and experimental nature. These risks include but are not limited to security risks (such as hacking and malware or other cyber-attacks, unauthorised access to your Wallet, attacks on blockchain networks, among others), technical risks (such as software errors, vulnerabilities or bugs) or operational risks related to Digital Assets, smart contracts, use of certain services, such as (crypto) bridges and swaps or other aspects and functionalities of Web 3. 
+
+The technology underlying Web 3 is also novel and experimental, as for the most part, it is based on still unproven, emerging and complex technologies, such as blockchain networks, that are developed or operated by third parties and distributed across a series of unaffiliated nodes across the world. As such, these changes and development in this technology may adversely affect your use of Web 3 and even Status Software. It is your sole responsibility to monitor such changes and the potential impact on your use of Web 3 and Status Software. 
+
+Given the novel and experimental nature of Web 3, the laws, rules and regulations, or their interpretation, may change and develop in a manner which could adversely affect your ability to interact with any aspect of Web 3, including deploying smart contracts, as well as creating, using, distributing or purchasing Digital Assets. These rules and regulations vary significantly in maturity across jurisdictions, but are for the most part, still in the early stages of development and may rapidly evolve and as such, their potential impact is subject to significant uncertainty. This could result in adverse consequences to you that may include criminal or civil penalties, including fines. It is your sole responsibility to ensure that you comply with all applicable laws, rules and regulations, including crypto laws, financial laws, securities laws and anti-money laundering regulations.
+
+Web 3 is also decentralised to varying degrees and this may lead to a lack of predictability, accountability, or control over Web 3. There is no guarantee that the protocols and networks will function as expected. Changes may occur suddenly, like forks, which may affect Status Software and your experience of using Status Software. Status may decide not to support a forked network in its sole discretion. 
+
+#### 11.3 Unpredictable and volatile nature of Digital Assets
+
+With Status Software, you can interact with and transact in Digital Assets and their markets. You acknowledge that these markets and Digital Assets are often highly unpredictable and volatile due to multiple factors, such as supply and demand, changes in technology, the regulatory environment, political, natural and economic events in a jurisdiction, and price speculation. In addition, the underlying factors that determine the price of a Digital Asset are often opaque and could be subject to speculation and market manipulation. This means that the value of Digital Assets can be lost in part or in full and you should not interact with Digital Assets unless you have the necessary advice, knowledge, expertise or risk appetite. 
+
+#### 11.4 Potential legal, regulatory and tax implications 
+
+You acknowledge that there might be legal and regulatory implications applicable to you when using Status Software and interacting with Web 3 and that may also adversely impact your use of Status Software. 
+
+You are solely responsible for evaluating the legal and regulatory implications and taking appropriate actions, which could include obtaining any necessary licences, permits or approvals. Additionally, you are solely responsible for any tax implications, such as the payment of any taxes, resulting from your activities conducted through Status Software, including any transactions in Digital Assets.
+&nbsp;
+
+### 12. Disclaimers
+
+Status Software is provided on an “as is” basis. Status does not make any express or implied representations or warranties in relation to Status Software. This includes warranties of merchantability, fitness for use or for a particular purpose, and non-infringement of any copyright or intellectual property rights. In particular, Status makes no representations or warranties:
+1. about the completeness, accuracy, utility, reliability, suitability or availability of any information provided by Status; 
+2. that Status Software will be operational, secure, safe or free from failures, disruptions, unauthorised access, bugs, errors, or delays, viruses, malicious code or any other technical or security issues; 
+3. regarding the completeness, accuracy, legality, utility, suitability, availability, functionality, timeliness or security of Web 3 or any Third Party Services; 
+4. regarding the value, utility or legality of any Digital Asset; 
+5. regarding the completeness, accuracy, legality, utility, suitability, functionality, security or availability of any smart contract that you may interact with or deploy; or 
+6. regarding the completeness, accuracy, legality, utility, reliability, suitability or availability of any user content. 
+&nbsp;
+
+### 13. Releases you should read closely
+
+You release Status from all liability related to any claim, cause of action, controversy, dispute, loss, or damages, known or unknown, related to, arising from, or in any way connected with your use of Status Software. This includes, but is not limited to: 
+1. user error, such as forgotten passwords, incorrectly constructed transactions, or mistyped wallet addresses; 
+2. your inability to access your Wallet or the Digital Assets held in within it, for any reason, such as the loss of your seed phrase or private keys; 
+3. your transactions or transfers of Digital Assets from and to your Wallet; 
+4. any loss of value (in part or full) of your Digital Assets held in your Wallet; 
+5. the failure of your hardware, software, or Internet connection;
+6. unauthorised access to your account, or your data on or through the Status Software, including any loss of data (such as your wallet address, private key and seed phrase);
+7. technical or operational errors in or related to Status Software, including underlying code or its functionalities, as well as the code of smart contracts you might deploy;
+8. any modification, suspension or discontinuance of Status Software or any feature or functionality of Status Software;
+9. your use of any Third Party Service or aspect of Web 3, including smart contracts and Digital Assets, as well as your interaction with such Third Party Service or Web 3; 
+10. your content or other users’ content; 
+11. any unauthorised third party activities, including without limitation the use of viruses, phishing, brute forcing, or other means of attack against Status Software; and
+12. any risks identified in these terms or any that a reasonable person should have been aware of in relation to using Status Software. 
+&nbsp;
+
+### 14. Limitation of liability
+
+Status will not be held liable to you under any contract, negligence, strict liability, or other legal or equitable theory for any lost profits, cost of procurement for substitute services, or any special, incidental, or consequential damages related to, arising from, or in any way connected with these terms, Status, your use of Status Software, particularly where Status has indicated that it is not responsible. This includes without limitation, your use of SNT or other Digital Assets (creating, distributing, transacting in or otherwise) even if Status has been advised of the possibility of such damages. 
+In any event, Status’ aggregate liability for any claims is limited to EUR 100 (one hundred Euros). This limitation of liability will apply to the extent permitted by applicable law.
+&nbsp;
+
+### 15. Indemnity
+
+You shall indemnify and hold harmless Status from and against any and all claims, damages and expenses, including attorneys’ fees, arising from or related to your use of Status Software. This includes, but is not limited to: 
+1. your breach or alleged breach of these terms; 
+2. any content you create, post, distribute or submit, messages you exchange or any other activity you may engage in related to your content on or through Status Software; 
+3. your use of Status Software; 
+4. your violation of any laws, rules or regulations; 
+5. your harm to or violation of the rights of any third party, including any privacy, intellectual property, publicity, confidentiality, property or any other rights; 
+6. your use of Third Party Services or any aspect of Web 3; or
+7. any misrepresentation or fraudulent statements made by you. 
+&nbsp;
+
+### 16. Restricted jurisdictions
+
+Status is a Swiss company which makes Status Software available through third party platforms, such as third party app stores, which enables global distribution to potential users. 
+
+You acknowledge that Status Software is not intended for use or distribution in any jurisdiction where such use or distribution of software that is similar or identical to Status Software is prohibited or restricted in any way. Your use of Status Software does not and will not subject Status to such jurisdiction under any circumstance, particularly if there are any prohibitions or restrictions on the use of such software. Status reserves the right to limit the availability of Status Software in any jurisdiction.
+
+Status does not conduct any business activities (i.e. activities undertaken for the purpose of earning a profit) within the United States of America, District of Columbia, Puerto Rico, the U.S. Virgin Islands, and all other U.S. territories and possessions, as well as all Swiss Embargoed Countries. 
+&nbsp;
+
+### 17. Materials provided are solely for informational purposes
+
+Status provides materials and other information through Status Software for informational purposes only and they may not always be entirely accurate, complete, or current and may also include inaccuracies or typographical errors. You are solely responsible for verifying their adequacy, completeness and accuracy and any reliance you place on such information is at your own risk, including any decisions or actions you might take in this respect. Status is not liable for any loss resulting from your action (or inaction) and decisions based on these materials or any other information. 
+
+You should always conduct your own research and seek independent professional advice if necessary. The materials and other information that Status may provide through Status Software does not constitute financial, legal, tax, or other advice and should not be treated as such. 
+
+Additionally, Status is not responsible for any information, content, or services contained on any third-party websites accessible or linked through the Status Software. By linking such third party websites, in principle, Status does not represent or imply that it endorses or supports such third party websites or content therein, or that it believes such third party websites and content therein to be accurate, useful or non-harmful. In principle, Status has no control over such third party websites and will not be liable for your use of or activities on any third party websites accessed through Status Software. If you access such third party websites through Status Software, it is at your own risk and you are solely responsible for your activities on such third party websites.  
+&nbsp;
+
+### 18. Governing law and dispute resolution
+
+#### 18.1 Governing law
+
+Swiss law governs these terms and any disputes between you and Status, whether in court or arbitration, without regard to conflict of laws provisions.
+
+#### 18.2 Dispute resolution
+
+In these terms, “dispute” has the broadest meaning enforceable by law and includes any claim you make against or controversy you may have in relation to these terms, with Status or your use of Status Software. 
+
+We prefer arbitration over litigation as we believe it meets our Principle of resolving disputes in the most effective and cost effective manner. You are bound by the following arbitration clause, which waives your right to litigation and to be heard by a judge. Please note that court review of an arbitration award is limited. You also waive all your rights to a jury trial (if any) in any and all jurisdictions. 
+
+If a (potential) dispute arises, you must first use your reasonable efforts to resolve it amicably with Status by reaching out to Status’ legal team at legal@status.im. If these efforts do not result in a resolution of such dispute, you shall then send to legal@status.im a written notice of dispute setting out (i) the nature of the dispute, and the claim you are making; and (ii) the remedy you are seeking. 
+
+If you and Status are unable to further resolve this dispute within sixty (60) calendar days of Status receiving this notice of dispute, then any such dispute will be referred to and finally resolved by you and Status through an arbitration administered by the Swiss Chambers’ Arbitration Institution in accordance with the Swiss Rules of International Arbitration for the time being in force, which rules are deemed to be incorporated herein by reference. The arbitral decision may be enforced in any court. The arbitration will be held in Zug, Switzerland, and may be conducted via video conference virtual/online methods if possible. The tribunal will consist of one arbitrator, and all proceedings as well as communications between the parties will be kept confidential. The language of the arbitration will be in English. Payment of all relevant fees in respect of the arbitration, including filing, administration and arbitrator fees will be in accordance with the Swiss Rules of International Arbitration. 
+
+Regardless of any applicable statute of limitations, you must bring any claims within one year after the claim arose or the time when you should have reasonably known about the claim. You also waive the right to participate in a class action lawsuit or a classwide arbitration against Status. 
+&nbsp;
+
+### 19. What happens if you stop using Status Software
+
+If, at any time, you no longer agree to these terms, you must immediately stop using the Status Software and uninstall it from all your devices. You acknowledge that even after uninstalling Status Software from all your devices, messages you have sent might still remain on the recipient’s device, blockchain transactions you have might still be recorded on the blockchain, and any smart contracts you have deployed to a blockchain might still remain deployed.
+
+Even after you have stopped using Status Software, all provisions of these terms which by their nature should survive termination shall survive termination. These provisions include, but are not limited to, warranty disclaimers, indemnity, limitations of liability, dispute resolution, and governing law.
+&nbsp;
+
+### 20. General provisions
+
+#### 20.1 Entire agreement
+
+These terms, including the underlying open source licences governing the Status Software, cover the entire agreement between you and Status regarding the Status Software. If these terms are considered an offer by Status, acceptance is expressly limited to these terms. Any failure by Status to exercise or enforce any right or provision of these terms will not constitute our waiver of such right or provision.
+
+#### 20.2 Severability
+
+If any section of these terms is determined to be unlawful, void, or unenforceable, the unenforceable portion will be deemed to be severed from these terms. Such determination shall not affect the validity and enforceability of any other remaining provisions.
+
+#### 20.3 Captions and headings
+
+The captions and headings identifying sections and subsections of these terms are for reference only and do not define, modify, expand, limit, or affect the interpretation of any provisions of these terms. Any illustrative graphics and links to websites are provided for your information and education, and, unless otherwise specifically indicated, they are not included in or part of these terms.
+
+#### 20.4 Changes to Status Software and terms of use
+
+#### 20.4.1 Changes to Status Software
+
+Status Software is an open source, community-driven project. Users can both request and contribute to feature or functionality development by contacting us directly. Status may change or discontinue some or all features and functionality on Status Software at any time in our sole discretion, including features or support for certain devices. We will not be liable to you or any third party for any modification, suspension, or discontinuation of any features or functionality of Status Software. Any and all new functions added to Status Software are also subject to these terms.
+
+#### 20.4.2 Notice of changes to the terms of use
+
+We reserve the right to modify or replace any part of these terms at any time and in our sole discretion. You are solely responsible for checking Status Software, or the relevant location where these terms are published, periodically for any changes. Your continued use of Status Software following changes to these terms means that you have accepted those changes. If you do not accept such changes, then you must immediately stop using Status Software and uninstall it from your devices. 
+
+#### 20.5 Contact us
+
+If you have any questions about these terms, please contact us at legal@status.im or through the means of communication indicated on the Status website. 
+
+This document is CC-BY-SA.

--- a/ui/imports/shared/panels/StyledText.qml
+++ b/ui/imports/shared/panels/StyledText.qml
@@ -4,5 +4,6 @@ import utils 1.0
 
 Text {
     font.family: Style.current.baseFont.name
+    font.pixelSize: Style.current.primaryTextFontSize
     color: Style.current.textColor
 }

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -329,22 +329,26 @@ QtObject {
     }
 
     readonly property QtObject settingsSubsection: QtObject {
-        property int profile: 0
-        property int contacts: 1
-        property int ensUsernames: 2
-        property int messaging: 3
-        property int wallet: 4
-        property int appearance: 5
-        property int language: 6
-        property int notifications: 7
-        property int syncingSettings: 8
-        property int browserSettings: 9
-        property int advanced: 10
-        property int about: 11
-        property int communitiesSettings: 12
-        property int keycard: 13
-        property int signout: 14
-        property int backUpSeed: 15
+        readonly property int profile: 0
+        readonly property int contacts: 1
+        readonly property int ensUsernames: 2
+        readonly property int messaging: 3
+        readonly property int wallet: 4
+        readonly property int appearance: 5
+        readonly property int language: 6
+        readonly property int notifications: 7
+        readonly property int syncingSettings: 8
+        readonly property int browserSettings: 9
+        readonly property int advanced: 10
+        readonly property int about: 11
+        readonly property int communitiesSettings: 12
+        readonly property int keycard: 13
+        readonly property int about_terms: 14 // a subpage under "About"
+        readonly property int about_privacy: 15 // a subpage under "About"
+
+        // special treatment; these do not participate in the main settings' StackLayout
+        readonly property int signout: 16
+        readonly property int backUpSeed: 17
     }
 
     readonly property QtObject currentUserStatus: QtObject{


### PR DESCRIPTION
### What does the PR do

- bundle Privacy Statement and Terms of Use documents as Markdown
- some UI fixes according to latest Figma
- separate 2 commits for providing a C++ helper to read contents of a text file and additional UI fixes for the overall Settings layout (most notable left margin and icon size)

Fixes #12192

### Affected areas

Settings/About

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![image](https://github.com/status-im/status-desktop/assets/5377645/9364da76-d8de-4691-8e1a-d58ecccf4494)

Terms of use MD:
![image](https://github.com/status-im/status-desktop/assets/5377645/18e02c55-5c85-4ea8-a144-e44d2479840c)

Privacy statement MD:
![image](https://github.com/status-im/status-desktop/assets/5377645/ea24d7cd-e60d-4115-b23c-58b514628855)
