### PR TITLE
[Community sharding] UI to enable static sharding for a community

### DIFF
--- a/src/app/global/local_app_settings.nim
+++ b/src/app/global/local_app_settings.nim
@@ -18,6 +18,8 @@ const DEFAULT_CUSTOM_MOUSE_SCROLLING_ENABLED = false
 const DEFAULT_VISIBILITY = 2 #windowed visibility, from qml
 const LAS_KEY_FAKE_LOADING_SCREEN_ENABLED = "global/fake_loading_screen"
 const DEFAULT_FAKE_LOADING_SCREEN_ENABLED = defined(production) and (not existsEnv(TEST_ENVIRONMENT_VAR)) #enabled in production, disabled in development and e2e tests
+const LAS_KEY_SHARDED_COMMUNITIES_ENABLED = "global/sharded_communities"
+const DEFAULT_LAS_KEY_SHARDED_COMMUNITIES_ENABLED = false
 
 QtObject:
   type LocalAppSettings* = ref object of QObject
@@ -160,3 +162,16 @@ QtObject:
     read = getFakeLoadingScreenEnabled
     write = setFakeLoadingScreenEnabled
     notify = fakeLoadingScreenEnabledChanged
+
+  proc wakuV2ShardedCommunitiesEnabledChanged*(self: LocalAppSettings) {.signal.}
+  proc getWakuV2ShardedCommunitiesEnabled*(self: LocalAppSettings): bool {.slot.} =
+    self.settings.value(LAS_KEY_SHARDED_COMMUNITIES_ENABLED, newQVariant(DEFAULT_LAS_KEY_SHARDED_COMMUNITIES_ENABLED)).boolVal
+
+  proc setWakuV2ShardedCommunitiesEnabled*(self: LocalAppSettings, enabled: bool) {.slot.} =
+    self.settings.setValue(LAS_KEY_SHARDED_COMMUNITIES_ENABLED, newQVariant(enabled))
+    self.wakuV2ShardedCommunitiesEnabledChanged()
+
+  QtProperty[bool] wakuV2ShardedCommunitiesEnabled:
+    read = getWakuV2ShardedCommunitiesEnabled
+    write = setWakuV2ShardedCommunitiesEnabled
+    notify = wakuV2ShardedCommunitiesEnabledChanged

--- a/storybook/figma.json
+++ b/storybook/figma.json
@@ -91,6 +91,9 @@
     "EditSettingsPanel": [
         "https://www.figma.com/file/17fc13UBFvInrLgNUKJJg5/Kuba⎜Desktop?node-id=3132%3A383870&mode=dev"
     ],
+    "EnableShardingPopup": [
+        "https://www.figma.com/file/qHfFm7C9LwtXpfdbxssCK3/Kuba%E2%8E%9CDesktop---Communities?node-id=37239%3A184324&mode=dev"
+    ],
     "ExportControlNodePopup": [
         "https://www.figma.com/file/qHfFm7C9LwtXpfdbxssCK3/Kuba%E2%8E%9CDesktop---Communities?type=design&node-id=36894-685070&mode=design&t=6k1ago8SSQ5Ip9J8-0",
         "https://www.figma.com/file/qHfFm7C9LwtXpfdbxssCK3/Kuba%E2%8E%9CDesktop---Communities?type=design&node-id=37275-289960&mode=design&t=6k1ago8SSQ5Ip9J8-0",
@@ -137,6 +140,9 @@
     ],
     "LoginView": [
         "https://www.figma.com/file/17fc13UBFvInrLgNUKJJg5/Kuba%E2%8E%9CDesktop?node-id=1080%3A313192"
+    ],
+    "ManageShardingPopup": [
+        "https://www.figma.com/file/qHfFm7C9LwtXpfdbxssCK3/Kuba%E2%8E%9CDesktop---Communities?type=design&node-id=37242-186255&mode=design&t=tn8u8VaIZDDrCXN4-0"
     ],
     "MembersDropdown": [
         "https://www.figma.com/file/17fc13UBFvInrLgNUKJJg5/Kuba%E2%8E%9CDesktop?node-id=22647-498410",
@@ -264,14 +270,14 @@
         "https://www.figma.com/file/17fc13UBFvInrLgNUKJJg5/Kuba%E2%8E%9CDesktop?node-id=8159%3A416159",
         "https://www.figma.com/file/17fc13UBFvInrLgNUKJJg5/Kuba%E2%8E%9CDesktop?node-id=8159%3A416160"
     ],
+    "TransferOwnershipAlertPopup": [
+        "https://www.figma.com/file/qHfFm7C9LwtXpfdbxssCK3/Kuba%E2%8E%9CDesktop---Communities?type=design&node-id=37206%3A86828&mode=design&t=coHVo1E6fHrKNNhQ-1",
+        "https://www.figma.com/file/qHfFm7C9LwtXpfdbxssCK3/Kuba%E2%8E%9CDesktop---Communities?type=design&node-id=37206%3A86847&mode=design&t=coHVo1E6fHrKNNhQ-1"
+    ],
     "UserAgreementPopup": [
         "https://www.figma.com/file/17fc13UBFvInrLgNUKJJg5/Kuba⎜Desktop?type=design&node-id=31450-560694&t=Q4MOViPCoHsTjhs6-0"
     ],
     "UserProfileCard": [
         "https://www.figma.com/file/Mr3rqxxgKJ2zMQ06UAKiWL/💬-Chat⎜Desktop?type=design&node-id=21961-655678&mode=design&t=JiMnPfMaLPWlrFK3-0"
-    ],
-    "TransferOwnershipAlertPopup": [
-        "https://www.figma.com/file/qHfFm7C9LwtXpfdbxssCK3/Kuba%E2%8E%9CDesktop---Communities?type=design&node-id=37206%3A86828&mode=design&t=coHVo1E6fHrKNNhQ-1",
-        "https://www.figma.com/file/qHfFm7C9LwtXpfdbxssCK3/Kuba%E2%8E%9CDesktop---Communities?type=design&node-id=37206%3A86847&mode=design&t=coHVo1E6fHrKNNhQ-1"
     ]
 }

--- a/storybook/pages/CommunityInfoEditor.qml
+++ b/storybook/pages/CommunityInfoEditor.qml
@@ -8,7 +8,7 @@ ColumnLayout {
     id: root
 
     property string name: "Socks"
-    property string description: "We like the sock! A community of Unisocks wearers we like the sock a community of Unisocks we like the sock a community of Unisocks wearers we like the sock."
+    property string description: "We like the sock. A community of Unisocks wearers we like the sock. Unisocks wearers we like the sock."
 
     property int membersCount: 184
     property bool amISectionAdmin: true

--- a/storybook/pages/CommunityInfoEditor.qml
+++ b/storybook/pages/CommunityInfoEditor.qml
@@ -18,7 +18,7 @@ ColumnLayout {
     property bool colorVisible: false
     property url banner: ctrlCommunityBanner.checked ? Style.png("settings/communities@2x") : ""
     readonly property bool shardingEnabled: ctrlShardingEnabled.checked
-    readonly property int shardIndex: ctrlShardIndex.value
+    property alias shardIndex: ctrlShardIndex.value
 
     spacing: 24
 

--- a/storybook/pages/CommunityInfoEditor.qml
+++ b/storybook/pages/CommunityInfoEditor.qml
@@ -16,7 +16,9 @@ ColumnLayout {
     property color color: "orchid"
     property url image: Style.png("tokens/UNI")
     property bool colorVisible: false
-    property url banner: Style.png("settings/communities@2x")
+    property url banner: ctrlCommunityBanner.checked ? Style.png("settings/communities@2x") : ""
+    readonly property bool shardingEnabled: ctrlShardingEnabled.checked
+    readonly property int shardIndex: ctrlShardIndex.value
 
     spacing: 24
 
@@ -133,11 +135,26 @@ ColumnLayout {
         RadioButton {
             checked: true
             text: "No banner"
-            onCheckedChanged: if(checked) root.banner = ""
         }
         RadioButton {
+            id: ctrlCommunityBanner
             text: "Communities"
-            onCheckedChanged: if(checked) root.banner = Style.png("settings/communities@2x")
+        }
+    }
+    RowLayout {
+        Layout.fillWidth: true
+        CheckBox {
+            id: ctrlShardingEnabled
+            text: "Sharding enabled"
+            checkable: true
+            checked: false
+        }
+        SpinBox {
+            id: ctrlShardIndex
+            visible: ctrlShardingEnabled.checked
+            from: -1
+            to: 1023
+            value: -1 // -1 == disabled
         }
     }
 }

--- a/storybook/pages/EditSettingsPanelPage.qml
+++ b/storybook/pages/EditSettingsPanelPage.qml
@@ -27,6 +27,7 @@ SplitView {
         communityId: "0xdeadbeef"
         communityShardingEnabled: communityEditor.shardingEnabled
         communityShardIndex: communityEditor.shardIndex
+        onCommunityShardIndexChanged: communityEditor.shardIndex = communityShardIndex
     }
 
     ScrollView {

--- a/storybook/pages/EditSettingsPanelPage.qml
+++ b/storybook/pages/EditSettingsPanelPage.qml
@@ -2,6 +2,7 @@ import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
 
+import mainui 1.0
 import AppLayouts.Communities.panels 1.0
 
 import Storybook 1.0
@@ -9,6 +10,11 @@ import Storybook 1.0
 SplitView {
     id: root
     SplitView.fillWidth: true
+
+    Popups {
+        popupParent: root
+        rootStore: QtObject {}
+    }
 
     EditSettingsPanel {
         SplitView.fillWidth: true
@@ -18,6 +24,7 @@ SplitView {
         logoImageData: communityEditor.image
         description: communityEditor.description
         bannerImageData: communityEditor.banner
+        communityId: "0xdeadbeef"
         communityShardingEnabled: communityEditor.shardingEnabled
         communityShardIndex: communityEditor.shardIndex
     }

--- a/storybook/pages/EditSettingsPanelPage.qml
+++ b/storybook/pages/EditSettingsPanelPage.qml
@@ -18,13 +18,15 @@ SplitView {
         logoImageData: communityEditor.image
         description: communityEditor.description
         bannerImageData: communityEditor.banner
+        communityShardingEnabled: communityEditor.shardingEnabled
+        communityShardIndex: communityEditor.shardIndex
     }
 
     ScrollView {
          SplitView.minimumWidth: 300
          SplitView.preferredWidth: 300
 
-         CommunityInfoEditor{
+         CommunityInfoEditor {
              id: communityEditor
              anchors.fill: parent
              colorVisible: true

--- a/storybook/pages/EnableShardingPopupPage.qml
+++ b/storybook/pages/EnableShardingPopupPage.qml
@@ -1,0 +1,59 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+import Storybook 1.0
+
+import AppLayouts.Communities.popups 1.0
+
+SplitView {
+    orientation: Qt.Vertical
+
+    Logs { id: logs }
+
+    Item {
+        SplitView.fillWidth: true
+        SplitView.fillHeight: true
+
+        PopupBackground {
+            anchors.fill: parent
+        }
+
+        Button {
+            anchors.centerIn: parent
+            text: "Reopen"
+
+            onClicked: dialog.open()
+        }
+
+        EnableShardingPopup {
+            id: dialog
+
+            anchors.centerIn: parent
+            visible: true
+            modal: false
+            closePolicy: Popup.NoAutoClose
+
+            communityName: "Foobar"
+            publicKey: "0xdeadbeef"
+            shardingInProgress: ctrlShardingInProgress.checked
+            onEnableSharding: logs.logEvent("enableSharding", ["shardIndex"], arguments)
+        }
+    }
+
+    LogsAndControlsPanel {
+        SplitView.minimumHeight: 100
+        SplitView.preferredHeight: 200
+
+        logsView.logText: logs.logText
+
+        ColumnLayout {
+            Switch {
+                id: ctrlShardingInProgress
+                text: "Sharding in progress"
+            }
+        }
+    }
+}
+
+// category: Popups

--- a/storybook/pages/ManageShardingPopupPage.qml
+++ b/storybook/pages/ManageShardingPopupPage.qml
@@ -1,0 +1,55 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+import Storybook 1.0
+
+import AppLayouts.Communities.popups 1.0
+
+SplitView {
+    orientation: Qt.Vertical
+
+    Logs { id: logs }
+
+    Item {
+        SplitView.fillWidth: true
+        SplitView.fillHeight: true
+
+        PopupBackground {
+            anchors.fill: parent
+        }
+
+        Button {
+            anchors.centerIn: parent
+            text: "Reopen"
+
+            onClicked: dialog.open()
+        }
+
+        ManageShardingPopup {
+            id: dialog
+
+            anchors.centerIn: parent
+            visible: true
+            modal: false
+            closePolicy: Popup.NoAutoClose
+
+            communityName: "Foobar"
+
+            shardIndex: 33
+            pubSubTopic: '{"pubsubTopic":"/waku/2/rs/16/%1", "publicKey":"%2"}'.arg(shardIndex).arg("0xdeadbeef")
+
+            onDisableShardingRequested: logs.logEvent("ManageShardingPopup::disableShardingRequested")
+            onEditShardIndexRequested: logs.logEvent("ManageShardingPopup::editShardIndexRequested")
+        }
+    }
+
+    LogsAndControlsPanel {
+        SplitView.minimumHeight: 100
+        SplitView.preferredHeight: 200
+
+        logsView.logText: logs.logText
+    }
+}
+
+// category: Popups

--- a/storybook/pages/OverviewSettingsPanelPage.qml
+++ b/storybook/pages/OverviewSettingsPanelPage.qml
@@ -16,17 +16,21 @@ SplitView {
         description: communityEditor.description
         logoImageData: communityEditor.image
         color: communityEditor.color
+        bannerImageData: communityEditor.banner
 
         editable: communityEditor.isCommunityEditable
-        owned: communityEditor.amISectionAdmin
+        isOwner: communityEditor.amISectionAdmin
         communitySettingsDisabled: !editable
+
+        communityShardingEnabled: communityEditor.shardingEnabled
+        communityShardIndex: communityEditor.shardIndex
     }
 
     Pane {
         SplitView.minimumWidth: 300
         SplitView.preferredWidth: 300
 
-        CommunityInfoEditor{
+        CommunityInfoEditor {
             id: communityEditor
             anchors.fill: parent
         }

--- a/storybook/stubs/shared/stores/RootStore.qml
+++ b/storybook/stubs/shared/stores/RootStore.qml
@@ -28,4 +28,8 @@ QtObject {
     property var getChainShortNamesForSavedWalletAddress
     property var getGasEthValue
     property var getNetworkLayer
+
+    function copyToClipboard(text) {
+        console.warn("STUB: copyToClipboard:", text)
+    }
 }

--- a/ui/StatusQ/src/StatusQ/Controls/StatusBaseInput.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusBaseInput.qml
@@ -278,8 +278,7 @@ Item {
     Rectangle {
         id: background
         anchors.fill: parent
-        color: root.showBackground ? Theme.palette.baseColor2
-                                              : "transparent"
+        color: root.showBackground ? Theme.palette.baseColor2 : "transparent"
         radius: 8
 
         clip: true
@@ -292,7 +291,7 @@ Item {
             if (!root.valid && root.dirty) {
                 return Theme.palette.dangerColor1
             }
-            if (edit.activeFocus) {
+            if (edit.cursorVisible) {
                 return Theme.palette.primaryColor1
             }
             return sensor.containsMouse ? Theme.palette.primaryColor2 : "transparent"

--- a/ui/StatusQ/src/StatusQ/Controls/StatusCheckBox.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusCheckBox.qml
@@ -40,6 +40,7 @@ CheckBox {
     }
 
     font.family: Theme.palette.baseFont.name
+    font.pixelSize: size === StatusCheckBox.Size.Regular ? 15 : 13
 
     indicator: Rectangle {
         anchors.left: root.leftSide? parent.left : undefined

--- a/ui/StatusQ/src/StatusQ/Controls/StatusTextArea.qml
+++ b/ui/StatusQ/src/StatusQ/Controls/StatusTextArea.qml
@@ -6,13 +6,13 @@ import StatusQ.Components 0.1
 
 /*!
       \qmltype StatusTextArea
-      \inherits Item
+      \inherits TextArea
       \inqmlmodule StatusQ.Controls
       \since StatusQ.Controls 0.1
       \brief Displays a multi line text input component.
       Inherits \l{https://doc.qt.io/qt-5/qml-qtquick-controls2-textarea.html}{QQC.TextArea}.
 
-      The \c StatusTextArea displays a styled TextArea for users to type multiple lines of text.
+      The \c StatusTextArea displays a styled TextArea for users to type or display multiple lines of text.
       For example:
 
       \qml
@@ -55,9 +55,6 @@ TextArea {
     */
     property bool valid: true
 
-    implicitWidth: 448 // by design
-    implicitHeight: 108
-
     leftPadding: 16
     rightPadding: 16
     topPadding: 10
@@ -82,12 +79,14 @@ TextArea {
 
     background: Rectangle {
         radius: 8
-        color: root.enabled ? Theme.palette.baseColor2 : Theme.palette.baseColor4
+        color: root.readOnly ? "transparent" : root.enabled ? Theme.palette.baseColor2 : Theme.palette.baseColor4
         border.width: 1
         border.color: {
             if (!root.valid)
                 return Theme.palette.dangerColor1
-            if (root.activeFocus)
+            if (root.readOnly)
+                return Theme.palette.baseColor2
+            if (root.cursorVisible)
                 return Theme.palette.primaryColor1
             if (root.hovered)
                 return Theme.palette.primaryColor2

--- a/ui/StatusQ/src/StatusQ/Core/StatusAnimatedStack.qml
+++ b/ui/StatusQ/src/StatusQ/Core/StatusAnimatedStack.qml
@@ -11,6 +11,7 @@ StackLayout {
 
     readonly property var previousItem: items[previousIndex]
     readonly property var currentItem: items[currentIndex]
+    readonly property bool animating: !!d.crossFaderAnim && d.crossFaderAnim.running
 
     clip: true
 
@@ -20,6 +21,11 @@ StackLayout {
         for(var i = 1; i < count; ++i) {
             children[i].opacity = 0
         }
+    }
+
+    QtObject {
+        id: d
+        property var crossFaderAnim
     }
 
     Component {
@@ -68,12 +74,14 @@ StackLayout {
         if (previousItem && currentItem && (previousItem != currentItem)) {
             previousItem.visible = true;
             currentItem.visible = true;
-            var crossFaderAnim = crossFader.createObject(parent,
+            if (!!d.crossFaderAnim)
+                d.crossFaderAnim.destroy()
+            d.crossFaderAnim = crossFader.createObject(parent,
             {
                 fadeOutTarget: previousItem,
                 fadeInTarget: currentItem
             });
-            crossFaderAnim.restart();
+            d.crossFaderAnim.restart();
         }
         previousIndex = currentIndex;
     }

--- a/ui/StatusQ/src/StatusQ/Popups/StatusStackModal.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/StatusStackModal.qml
@@ -18,6 +18,7 @@ StatusModal {
 
     readonly property int itemsCount: stackLayout.count
     readonly property var currentItem: stackLayout.currentItem
+    readonly property alias animating: stackLayout.animating
 
     property Item backButton: StatusBackButton {
         visible: replaceItem || stackLayout.currentIndex > 0

--- a/ui/app/AppLayouts/Communities/panels/EditSettingsPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/EditSettingsPanel.qml
@@ -2,9 +2,13 @@ import QtQuick 2.15
 import QtQuick.Layouts 1.15
 
 import StatusQ.Core 0.1
+import StatusQ.Controls 0.1
 import StatusQ.Popups 0.1
+import StatusQ.Core.Theme 0.1
 
 import AppLayouts.Communities.controls 1.0
+
+import utils 1.0
 
 StatusScrollView {
     id: root
@@ -18,6 +22,8 @@ StatusScrollView {
     property alias tags: baseLayout.tags
     property alias selectedTags: baseLayout.selectedTags
     property alias options: baseLayout.options
+    property bool communityShardingEnabled
+    property int communityShardIndex: -1
 
     property alias logoImageData: baseLayout.logoImageData
     property alias logoImagePath: baseLayout.logoImagePath
@@ -35,10 +41,11 @@ StatusScrollView {
                                                        (outroMessageTextInput.input.dirty && !outroMessageTextInput.valid))
 
     padding: 0
+
     ColumnLayout {
         id: mainLayout
         width: baseLayout.width
-        spacing: 16
+        spacing: Style.current.padding
         EditCommunitySettingsForm {
             id: baseLayout
             Layout.fillHeight: true
@@ -60,6 +67,32 @@ StatusScrollView {
             id: outroMessageTextInput
             input.edit.objectName: "editCommunityOutroInput"
             Layout.fillWidth: true
+        }
+
+        StatusModalDivider {
+            Layout.fillWidth: true
+            Layout.topMargin: -baseLayout.spacing
+            Layout.bottomMargin: 2
+            visible: root.communityShardingEnabled
+        }
+
+        RowLayout {
+            spacing: Style.current.halfPadding
+            visible: root.communityShardingEnabled
+            StatusBaseText {
+                Layout.fillWidth: true
+                text: qsTr("Community sharding")
+            }
+            Item { Layout.fillWidth: true }
+            StatusBaseText {
+                color: Theme.palette.baseColor1
+                visible: root.communityShardIndex !== -1
+                text: qsTr("Active: on shard #%1").arg(root.communityShardIndex)
+            }
+            StatusButton {
+                size: StatusBaseButton.Size.Small
+                text: root.communityShardIndex === -1 ? qsTr("Make %1 a sharded community").arg(root.name) : qsTr("Manage")
+            }
         }
 
         Item {

--- a/ui/app/AppLayouts/Communities/panels/EditSettingsPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/EditSettingsPanel.qml
@@ -7,6 +7,7 @@ import StatusQ.Popups 0.1
 import StatusQ.Core.Theme 0.1
 
 import AppLayouts.Communities.controls 1.0
+import AppLayouts.Communities.popups 1.0
 
 import utils 1.0
 
@@ -22,6 +23,7 @@ StatusScrollView {
     property alias tags: baseLayout.tags
     property alias selectedTags: baseLayout.selectedTags
     property alias options: baseLayout.options
+    property string communityId
     property bool communityShardingEnabled
     property int communityShardIndex: -1
 
@@ -79,6 +81,9 @@ StatusScrollView {
         RowLayout {
             spacing: Style.current.halfPadding
             visible: root.communityShardingEnabled
+
+            readonly property bool shardingActive: root.communityShardIndex !== -1
+
             StatusBaseText {
                 Layout.fillWidth: true
                 text: qsTr("Community sharding")
@@ -86,12 +91,13 @@ StatusScrollView {
             Item { Layout.fillWidth: true }
             StatusBaseText {
                 color: Theme.palette.baseColor1
-                visible: root.communityShardIndex !== -1
+                visible: parent.shardingActive
                 text: qsTr("Active: on shard #%1").arg(root.communityShardIndex)
             }
             StatusButton {
                 size: StatusBaseButton.Size.Small
-                text: root.communityShardIndex === -1 ? qsTr("Make %1 a sharded community").arg(root.name) : qsTr("Manage")
+                text: parent.shardingActive ? qsTr("Manage") : qsTr("Make %1 a sharded community").arg(root.name)
+                onClicked: Global.openPopup(enableShardingPopupCmp) // TODO manage popup
             }
         }
 
@@ -101,6 +107,16 @@ StatusScrollView {
             implicitWidth: root.bottomReservedSpace.width
             implicitHeight: root.bottomReservedSpace.height
         }
+
+        Component {
+            id: enableShardingPopupCmp
+            EnableShardingPopup {
+                communityName: root.name
+                publicKey: root.communityId
+                shardingInProgress: false // TODO community sharding backend: set to "true" when generating the pubSub topic
+                onEnableSharding: (shardIndex) => console.warn("TODO: enable community sharding for shardIndex:", shardIndex) // TODO community sharding backend
+                onClosed: destroy()
+            }
+        }
     }
 }
-

--- a/ui/app/AppLayouts/Communities/panels/OverviewSettingsPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/OverviewSettingsPanel.qml
@@ -280,6 +280,7 @@ StackLayout {
                     pinMessagesEnabled: root.pinMessagesEnabled
                 }
 
+                communityId: root.communityId
                 communityShardingEnabled: root.communityShardingEnabled
                 communityShardIndex: root.communityShardIndex
 

--- a/ui/app/AppLayouts/Communities/panels/OverviewSettingsPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/OverviewSettingsPanel.qml
@@ -41,7 +41,6 @@ StackLayout {
 
     property bool archiveSupporVisible: true
     property bool editable: false
-    property bool owned: false
     property bool isControlNode: false
     property int loginType: Constants.LoginType.Password
     property bool communitySettingsDisabled
@@ -50,6 +49,9 @@ StackLayout {
     readonly property var ownerToken: SQUtils.ModelUtils.getByKey(root.tokensModel, "privilegesLevel", Constants.TokenPrivilegesLevel.Owner)
 
     property string overviewChartData: ""
+
+    property bool communityShardingEnabled
+    property int communityShardIndex: -1
 
     function navigateBack() {
         if (editSettingsPanelLoader.item.dirty)
@@ -277,6 +279,9 @@ StackLayout {
                     requestToJoinEnabled: root.requestToJoinEnabled
                     pinMessagesEnabled: root.pinMessagesEnabled
                 }
+
+                communityShardingEnabled: root.communityShardingEnabled
+                communityShardIndex: root.communityShardIndex
 
                 bottomReservedSpace:
                     Qt.size(settingsDirtyToastMessage.implicitWidth,

--- a/ui/app/AppLayouts/Communities/popups/EnableShardingPopup.qml
+++ b/ui/app/AppLayouts/Communities/popups/EnableShardingPopup.qml
@@ -1,0 +1,126 @@
+import QtQuick 2.15
+import QtQuick.Layouts 1.15
+import QtQuick.Controls 2.15
+
+import StatusQ.Core 0.1
+import StatusQ.Core.Theme 0.1
+import StatusQ.Controls 0.1
+import StatusQ.Controls.Validators 0.1
+import StatusQ.Components 0.1
+import StatusQ.Popups 0.1
+
+import shared.controls 1.0
+import utils 1.0
+
+StatusStackModal {
+    id: root
+
+    required property string communityName
+    required property string publicKey
+    property int initialShardIndex: -1
+    property bool shardingInProgress
+
+    signal enableSharding(int shardIndex)
+
+    stackTitle: qsTr("Enable community sharding for %1").arg(communityName)
+    width: 640
+
+    readonly property var cancelButton: StatusFlatButton {
+        text: qsTr("Cancel")
+        onClicked: root.close()
+    }
+
+    nextButton: StatusButton {
+        text: qsTr("Next")
+        enabled: typeof(currentItem.canGoNext) == "undefined" || currentItem.canGoNext
+        loading: root.shardingInProgress
+        onClicked: {
+            let nextAction = currentItem.nextAction
+            if (typeof(nextAction) == "function") {
+                return nextAction()
+            }
+            root.currentIndex++
+        }
+    }
+
+    finishButton: StatusButton {
+        text: qsTr("Enable community sharding")
+        enabled: typeof(currentItem.canGoNext) == "undefined" || currentItem.canGoNext
+        onClicked: {
+            root.enableSharding(d.shardIndex)
+            root.close()
+        }
+    }
+
+    rightButtons: [cancelButton, nextButton, finishButton]
+
+    QtObject {
+        id: d
+        readonly property string pubSubTopic: '{"pubsubTopic":"/waku/2/rs/16/%1", "publicKey":"%2"}'.arg(shardIndex).arg(root.publicKey) // FIXME backend
+        property int shardIndex: root.initialShardIndex
+    }
+
+    onAboutToShow: shardIndexEdit.focus = true
+
+    stackItems: [
+        ColumnLayout {
+            id: firstPage
+            spacing: Style.current.halfPadding
+
+            readonly property bool canGoNext: shardIndexEdit.valid
+            readonly property var nextAction: function () {
+                d.shardIndex = parseInt(shardIndexEdit.text)
+                root.currentIndex++
+            }
+
+            StatusInput {
+                id: shardIndexEdit
+                Layout.fillWidth: true
+                label: qsTr("Enter shard number")
+                placeholderText: qsTr("Enter a number between 0 and 1023")
+                text: d.shardIndex !== -1 ? d.shardIndex : ""
+                validators: [
+                    StatusIntValidator {
+                        bottom: 0
+                        top: 1023
+                        errorMessage: qsTr("Invalid shard number. Number must be 0 — 1023.")
+                    }
+                ]
+                Keys.onPressed: {
+                    if (!shardIndexEdit.valid)
+                        return
+                    if (event.key === Qt.Key_Enter || event.key === Qt.Key_Return) {
+                        event.accepted = true
+                        firstPage.nextAction()
+                    }
+                }
+            }
+        },
+        ColumnLayout {
+            readonly property bool canGoNext: agreement.checked
+
+            StatusInput {
+                Layout.fillWidth: true
+                minimumHeight: 88
+                maximumHeight: 88
+                multiline: true
+                input.edit.readOnly: true
+                label: qsTr("Pub/Sub topic")
+                text: d.pubSubTopic
+
+                CopyButton {
+                    anchors.right: parent.right
+                    anchors.top: parent.top
+                    anchors.rightMargin: 12
+                    anchors.topMargin: (parent.height - parent.input.height) + 12
+                    textToCopy: parent.text
+                }
+            }
+
+            StatusCheckBox {
+                id: agreement
+                text: qsTr("I have made a copy of the Pub/Sub topic and public key string")
+            }
+        }
+    ]
+}

--- a/ui/app/AppLayouts/Communities/popups/EnableShardingPopup.qml
+++ b/ui/app/AppLayouts/Communities/popups/EnableShardingPopup.qml
@@ -99,20 +99,23 @@ StatusStackModal {
         ColumnLayout {
             readonly property bool canGoNext: agreement.checked
 
-            StatusInput {
+            StatusBaseText {
+                text: qsTr("Pub/Sub topic")
+            }
+
+            StatusTextArea {
                 Layout.fillWidth: true
-                minimumHeight: 88
-                maximumHeight: 88
-                multiline: true
-                input.edit.readOnly: true
-                label: qsTr("Pub/Sub topic")
+                Layout.preferredHeight: 138
+                readOnly: true
                 text: d.pubSubTopic
+                rightPadding: 48
+                wrapMode: TextEdit.Wrap
 
                 CopyButton {
                     anchors.right: parent.right
                     anchors.top: parent.top
                     anchors.rightMargin: 12
-                    anchors.topMargin: (parent.height - parent.input.height) + 12
+                    anchors.topMargin: 10
                     textToCopy: parent.text
                 }
             }

--- a/ui/app/AppLayouts/Communities/popups/ManageShardingPopup.qml
+++ b/ui/app/AppLayouts/Communities/popups/ManageShardingPopup.qml
@@ -1,0 +1,90 @@
+import QtQuick 2.15
+import QtQuick.Layouts 1.15
+import QtQuick.Controls 2.15
+import QtQml.Models 2.15
+import QtQml 2.15
+
+import StatusQ.Core 0.1
+import StatusQ.Core.Theme 0.1
+import StatusQ.Controls 0.1
+import StatusQ.Components 0.1
+import StatusQ.Popups.Dialog 0.1
+
+import shared.controls 1.0
+import shared.popups 1.0
+import utils 1.0
+
+StatusDialog {
+    id: root
+
+    required property string communityName
+    required property int shardIndex
+    required property string pubSubTopic
+
+    signal disableShardingRequested()
+    signal editShardIndexRequested()
+
+    title: qsTr("Manage community sharding for %1").arg(communityName)
+    width: 640
+
+    footer: StatusDialogFooter {
+        rightButtons: ObjectModel {
+            StatusFlatButton {
+                type: StatusBaseButton.Type.Danger
+                text: qsTr("Disable community sharding")
+                onClicked: confirmationPopup.open()
+            }
+            StatusButton {
+                text: qsTr("Edit shard number")
+                onClicked: {
+                    root.editShardIndexRequested()
+                    root.close()
+                }
+            }
+        }
+    }
+
+    contentItem: ColumnLayout {
+        spacing: Style.current.halfPadding
+        StatusInput {
+            Layout.fillWidth: true
+            label: qsTr("Shard number")
+            input.edit.readOnly: true
+            text: root.shardIndex
+        }
+
+        StatusInput {
+            Layout.fillWidth: true
+            minimumHeight: 88
+            maximumHeight: 88
+            multiline: true
+            input.edit.readOnly: true
+            label: qsTr("Pub/Sub topic")
+            text: root.pubSubTopic
+
+            CopyButton {
+                anchors.right: parent.right
+                anchors.top: parent.top
+                anchors.rightMargin: 12
+                anchors.topMargin: (parent.height - parent.input.height) + 12
+                textToCopy: parent.text
+            }
+        }
+    }
+
+    ConfirmationDialog {
+        id: confirmationPopup
+        anchors.centerIn: parent
+        headerSettings.title: qsTr("Are you sure you want to disable sharding?")
+        showCancelButton: true
+        cancelBtnType: ""
+        confirmationText: qsTr("Are you sure you want to disable community sharding? Your community will automatically revert to using the general shared Waku network.")
+        confirmButtonLabel: qsTr("Disable community sharding")
+        onCancelButtonClicked: close()
+        onConfirmButtonClicked: {
+            close()
+            root.disableShardingRequested()
+            root.close()
+        }
+    }
+}

--- a/ui/app/AppLayouts/Communities/popups/ManageShardingPopup.qml
+++ b/ui/app/AppLayouts/Communities/popups/ManageShardingPopup.qml
@@ -46,27 +46,35 @@ StatusDialog {
 
     contentItem: ColumnLayout {
         spacing: Style.current.halfPadding
-        StatusInput {
+
+        StatusBaseText {
+            text: qsTr("Shard number")
+        }
+
+        StatusTextArea {
             Layout.fillWidth: true
-            label: qsTr("Shard number")
-            input.edit.readOnly: true
+            readOnly: true
             text: root.shardIndex
         }
 
-        StatusInput {
+        StatusBaseText {
+            Layout.topMargin: Style.current.halfPadding
+            text: qsTr("Pub/Sub topic")
+        }
+
+        StatusTextArea {
             Layout.fillWidth: true
-            minimumHeight: 88
-            maximumHeight: 88
-            multiline: true
-            input.edit.readOnly: true
-            label: qsTr("Pub/Sub topic")
+            Layout.preferredHeight: 138
+            readOnly: true
             text: root.pubSubTopic
+            rightPadding: 48
+            wrapMode: TextEdit.Wrap
 
             CopyButton {
                 anchors.right: parent.right
                 anchors.top: parent.top
                 anchors.rightMargin: 12
-                anchors.topMargin: (parent.height - parent.input.height) + 12
+                anchors.topMargin: 10
                 textToCopy: parent.text
             }
         }

--- a/ui/app/AppLayouts/Communities/popups/qmldir
+++ b/ui/app/AppLayouts/Communities/popups/qmldir
@@ -12,6 +12,7 @@ ImportControlNodePopup 1.0 ImportControlNodePopup.qml
 InDropdown 1.0 InDropdown.qml
 InviteFriendsToCommunityPopup 1.0 InviteFriendsToCommunityPopup.qml
 KickBanPopup 1.0 KickBanPopup.qml
+ManageShardingPopup 1.0 ManageShardingPopup.qml
 MembersDropdown 1.0 MembersDropdown.qml
 PermissionsDropdown 1.0 PermissionsDropdown.qml
 RecipientTypeSelectionDropdown 1.0 RecipientTypeSelectionDropdown.qml

--- a/ui/app/AppLayouts/Communities/popups/qmldir
+++ b/ui/app/AppLayouts/Communities/popups/qmldir
@@ -5,6 +5,7 @@ CreateCategoryPopup 1.0 CreateCategoryPopup.qml
 CreateChannelPopup 1.0 CreateChannelPopup.qml
 CreateCommunityPopup 1.0 CreateCommunityPopup.qml
 DiscordImportProgressDialog 1.0 DiscordImportProgressDialog.qml
+EnableShardingPopup 1.0 EnableShardingPopup.qml
 ExportControlNodePopup 1.0 ExportControlNodePopup.qml
 HoldingsDropdown 1.0 HoldingsDropdown.qml
 ImportControlNodePopup 1.0 ImportControlNodePopup.qml

--- a/ui/app/AppLayouts/Communities/views/CommunitySettingsView.qml
+++ b/ui/app/AppLayouts/Communities/views/CommunitySettingsView.qml
@@ -176,11 +176,12 @@ StatusSectionLayout {
             requestToJoinEnabled: root.community.access === Constants.communityChatOnRequestAccess
             pinMessagesEnabled: root.community.pinMessageAllMembersEnabled
             editable: true
-            owned: root.community.memberRole === Constants.memberRole.owner
             loginType: root.rootStore.loginType
             isControlNode: root.isControlNode
             communitySettingsDisabled: root.communitySettingsDisabled
             overviewChartData: rootStore.overviewChartData
+            communityShardingEnabled: localAppSettings.wakuV2ShardedCommunitiesEnabled ?? false
+            communityShardIndex: root.community.shardIndex ?? -1 // TODO community sharding backend
 
             sendModalPopup: root.sendModalPopup
             tokensModel: root.community.communityTokens

--- a/ui/app/AppLayouts/Profile/stores/AdvancedStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/AdvancedStore.qml
@@ -14,6 +14,7 @@ QtObject {
     property bool isAutoMessageEnabled: advancedModule? advancedModule.isAutoMessageEnabled : false
     property bool isDebugEnabled: advancedModule? advancedModule.isDebugEnabled : false
     property bool isWakuV2StoreEnabled: advancedModule ? advancedModule.isWakuV2StoreEnabled : false
+    readonly property bool isWakuV2ShardedCommunitiesEnabled: localAppSettings.wakuV2ShardedCommunitiesEnabled ?? false
     property int logMaxBackups: advancedModule ? advancedModule.logMaxBackups : 1
 
     property var customNetworksModel: advancedModule? advancedModule.customNetworksModel : []
@@ -148,6 +149,13 @@ QtObject {
             return
 
         localAppSettings.fakeLoadingScreenEnabled = !localAppSettings.fakeLoadingScreenEnabled
+    }
+
+    function toggleWakuV2ShardedCommunities() {
+        if(!localAppSettings)
+            return
+
+        localAppSettings.wakuV2ShardedCommunitiesEnabled = !localAppSettings.wakuV2ShardedCommunitiesEnabled
     }
 
     function setCustomScrollingEnabled(value) {

--- a/ui/app/AppLayouts/Profile/views/AdvancedView.qml
+++ b/ui/app/AppLayouts/Profile/views/AdvancedView.qml
@@ -82,7 +82,6 @@ SettingsContentBase {
                 anchors.leftMargin: Style.current.padding
                 anchors.rightMargin: Style.current.padding
                 text: qsTr("Application Logs")
-                font.pixelSize: 15
                 font.underline: mouseArea.containsMouse
                 color: Style.current.blue
                 topPadding: 23
@@ -165,6 +164,17 @@ SettingsContentBase {
                 text: qsTr("WakuV2 options")
                 topPadding: Style.current.bigPadding
                 bottomPadding: Style.current.padding
+            }
+
+            // TODO: replace with StatusQ component
+            StatusSettingsLineButton {
+                anchors.leftMargin: 0
+                anchors.rightMargin: 0
+                text: qsTr("Enable creation of sharded communities")
+                isSwitch: true
+                visible: root.advancedStore.isWakuV2
+                switchChecked: root.advancedStore.isWakuV2ShardedCommunitiesEnabled
+                onClicked: root.advancedStore.toggleWakuV2ShardedCommunities()
             }
 
             // TODO: replace with StatusQ component
@@ -454,6 +464,7 @@ SettingsContentBase {
                 property bool mode: false
 
                 id: confirmDialog
+                destroyOnClose: true
                 showCancelButton: true
                 confirmationText: qsTr("Are you sure you want to enable all the developer features? The app will be restarted.")
                 onConfirmButtonClicked: {
@@ -473,6 +484,7 @@ SettingsContentBase {
                 property bool mode: false
 
                 id: confirmDialog
+                destroyOnClose: true
                 showCancelButton: true
                 confirmationText: qsTr("Are you sure you want to enable telemetry? This will reduce your privacy level while using Status. You need to restart the app for this change to take effect.")
                 onConfirmButtonClicked: {
@@ -491,6 +503,7 @@ SettingsContentBase {
                 property bool mode: false
 
                 id: confirmDialog
+                destroyOnClose: true
                 showCancelButton: true
                 confirmationText: qsTr("Are you sure you want to enable auto message? You need to restart the app for this change to take effect.")
                 onConfirmButtonClicked: {
@@ -509,6 +522,7 @@ SettingsContentBase {
                 property bool mode: false
 
                 id: confirmDialog
+                destroyOnClose: true
                 showCancelButton: true
                 confirmationText: qsTr("Are you sure you want to %1 WakuV2 Store? You need to restart the app for this change to take effect.")
                     .arg(root.advancedStore.isWakuV2StoreEnabled ?
@@ -530,6 +544,7 @@ SettingsContentBase {
                 property bool mode: false
 
                 id: confirmDialog
+                destroyOnClose: true
                 showCancelButton: true
                 confirmationText: qsTr("Are you sure you want to %1 debug mode? You need to restart the app for this change to take effect.").arg(root.advancedStore.isDebugEnabled ?
                     qsTr("disable") :
@@ -559,8 +574,6 @@ SettingsContentBase {
                     width: parent.width
                     StatusBaseText {
                         width: parent.width
-                        font.pixelSize: 15
-                        color: Theme.palette.directColor1
                         padding: 15
                         wrapMode: Text.WordWrap
                         text: qsTr("Choose a number between 1 and 100")
@@ -587,8 +600,6 @@ SettingsContentBase {
 
                     StatusBaseText {
                         width: parent.width
-                        font.pixelSize: 15
-                        color: Theme.palette.directColor1
                         padding: 15
                         wrapMode: Text.WordWrap
                         text: qsTr("This change will only come into action after a restart")

--- a/ui/imports/shared/popups/ImportCommunityPopup.qml
+++ b/ui/imports/shared/popups/ImportCommunityPopup.qml
@@ -107,7 +107,7 @@ StatusDialog {
             StatusTextArea {
                 id: keyInput
                 Layout.fillWidth: true
-                implicitHeight: 108
+                Layout.preferredHeight: 108
                 placeholderText: "0x0..."
                 wrapMode: TextEdit.WrapAtWordBoundaryOrAnywhere
                 onTextChanged: d.importErrorMessage = ""


### PR DESCRIPTION
### What does the PR do

Implement the UI flow for enabling static sharding for owned communities and manage the respective community's shard index

Best review commit by commit, there are additional fixes to various components

Fixes https://github.com/status-im/status-desktop/issues/12197

### Affected areas

changed: CommunitySettingsView, Community/OverviewSettingsPanel, Community/EditSettingsPanel
new: EnableShardingPopup, ManageShardingPopup

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

Master switch to enable creation and manage sharded communities:
![image](https://github.com/status-im/status-desktop/assets/5377645/bb3bcb48-0c86-4f71-a557-2490d322c735)

Edit community settings with sharding disabled:
![image](https://github.com/status-im/status-desktop/assets/5377645/18771d13-f1f0-4d73-b046-18d3d91581a5)

Enabling a dedicated sharding index:

[Enabling a dedicated sharding index](https://github.com/status-im/status-desktop/assets/5377645/227b15f8-749b-4be7-ba20-1a0cfe0f1a5b)

Manage the sharding index, disable:

[Manage the sharding index, disable](https://github.com/status-im/status-desktop/assets/5377645/a0528b90-67e3-4dee-b57a-55dbad1d305c)

Edit the sharding index:

[Záznam obrazovky z 2023-09-28 12-04-47.webm](https://github.com/status-im/status-desktop/assets/5377645/9df474df-0478-4d9c-8f3c-dd82947d2cd7)

