### PR TITLE
Reduce number of calls to `buildTokensAndCollectibles` and use an async function on init

### DIFF
--- a/src/app/modules/main/communities/controller.nim
+++ b/src/app/modules/main/communities/controller.nim
@@ -72,7 +72,7 @@ proc delete*(self: Controller) =
   discard
 
 proc init*(self: Controller) =
-  self.events.on(SIGNAL_COMMUNITY_DATA_LOADED) do(e:Args):
+  self.events.once(SIGNAL_COMMUNITY_DATA_LOADED) do(e:Args):
     self.delegate.communityDataLoaded()
 
   self.events.on(SIGNAL_COMMUNITY_CREATED) do(e:Args):
@@ -190,12 +190,6 @@ proc init*(self: Controller) =
         args.memberRevealedAccounts,
       )
       self.tmpCommunityIdForRevealedAccounts = ""
-
-  self.events.on(SignalType.Wallet.event, proc(e: Args) =
-    var data = WalletSignal(e)
-    if data.eventType == backend_collectibles.eventCollectiblesOwnershipUpdateFinished:
-      self.delegate.onOwnedCollectiblesUpdated()
-  )
 
   self.events.on(SIGNAL_WALLET_ACCOUNT_TOKENS_REBUILT) do(e: Args):
     self.delegate.onWalletAccountTokensRebuilt()

--- a/src/app/modules/main/communities/controller.nim
+++ b/src/app/modules/main/communities/controller.nim
@@ -162,6 +162,11 @@ proc init*(self: Controller) =
     let args = CommunitiesArgs(e)
     self.delegate.curatedCommunitiesLoaded(args.communities)
 
+  # We use once here because we only need it to generate the original list of tokens from communities
+  self.events.once(SIGNAL_ALL_COMMUNITY_TOKENS_LOADED) do(e: Args):
+    let args = CommunityTokensArgs(e)
+    self.delegate.onAllCommunityTokensLoaded(args.communityTokens)
+
   self.events.on(SIGNAL_COMMUNITY_TOKEN_METADATA_ADDED) do(e: Args):
     let args = CommunityTokenMetadataArgs(e)
     self.delegate.onCommunityTokenMetadataAdded(args.communityId, args.tokenMetadata)
@@ -342,6 +347,9 @@ proc requestCancelDiscordCommunityImport*(self: Controller, id: string) =
 
 proc getCommunityTokens*(self: Controller, communityId: string): seq[CommunityTokenDto] =
   self.communityTokensService.getCommunityTokens(communityId)
+
+proc getAllCommunityTokensAsync*(self: Controller) =
+  self.communityTokensService.getAllCommunityTokensAsync()
 
 proc getNetwork*(self:Controller, chainId: int): NetworkDto =
   self.networksService.getNetwork(chainId)

--- a/src/app/modules/main/communities/io_interface.nim
+++ b/src/app/modules/main/communities/io_interface.nim
@@ -161,9 +161,6 @@ method communityInfoAlreadyRequested*(self: AccessInterface) {.base.} =
 method onCommunityTokenMetadataAdded*(self: AccessInterface, communityId: string, tokenMetadata: CommunityTokensMetadataDto) {.base.} = 
   raise newException(ValueError, "No implementation available")
 
-method onOwnedCollectiblesUpdated*(self: AccessInterface) {.base.} =
-  raise newException(ValueError, "No implementation available")
-
 method onWalletAccountTokensRebuilt*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/communities/io_interface.nim
+++ b/src/app/modules/main/communities/io_interface.nim
@@ -1,6 +1,7 @@
 import tables
 import ../../../../app_service/service/community/service as community_service
 import ../../../../app_service/service/chat/service as chat_service
+import ../../../../app_service/service/community_tokens/dto/community_token
 import ../../shared_models/section_item
 
 type
@@ -217,4 +218,7 @@ method onCommunityCheckAllChannelPermissionsFailed*(self: AccessInterface, commu
 
 method onCommunityMemberRevealedAccountsLoaded*(self: AccessInterface, communityId: string, memberPubkey: string,
     revealedAccounts: seq[RevealedAccount]) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method onAllCommunityTokensLoaded*(self: AccessInterface, communityTokens: seq[CommunityTokenDto]) {.base.} =
   raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/communities/module.nim
+++ b/src/app/modules/main/communities/module.nim
@@ -51,7 +51,6 @@ type
 method setCommunityTags*(self: Module, communityTags: string)
 method setAllCommunities*(self: Module, communities: seq[CommunityDto])
 method setCuratedCommunities*(self: Module, curatedCommunities: seq[CommunityDto])
-proc buildTokensAndCollectiblesFromCommunities(self: Module)
 
 proc newModule*(
     delegate: delegate_interface.AccessInterface,
@@ -107,7 +106,8 @@ method viewDidLoad*(self: Module) =
 method communityDataLoaded*(self: Module) =
   self.setCommunityTags(self.controller.getCommunityTags())
   self.setAllCommunities(self.controller.getAllCommunities())
-  self.buildTokensAndCollectiblesFromCommunities()
+  # Get all community tokens to construct the original list of collectibles and assets from communities
+  self.controller.getAllCommunityTokensAsync()
 
 method onActivated*(self: Module) =
   self.controller.asyncLoadCuratedCommunities()
@@ -420,7 +420,7 @@ proc createCommunityTokenItem(self: Module, token: CommunityTokensMetadataDto, c
     infiniteSupply,
   )
 
-proc buildTokensAndCollectiblesFromCommunities(self: Module) =
+proc buildTokensAndCollectiblesFromCommunities(self: Module, communityTokens: seq[CommunityTokenDto]) =
   var tokenListItems: seq[TokenListItem]
   var collectiblesListItems: seq[TokenListItem]
 
@@ -430,7 +430,6 @@ proc buildTokensAndCollectiblesFromCommunities(self: Module) =
       # No need to include those tokens, we do not manage that community
       continue
 
-    let communityTokens = self.controller.getCommunityTokens(community.id)
     for tokenMetadata in community.communityTokensMetadata:
       # Set fallback supply to infinite in case we don't have it
       var supply = "1"
@@ -478,6 +477,9 @@ proc buildTokensAndCollectiblesFromWallet(self: Module) =
 
 method onWalletAccountTokensRebuilt*(self: Module) =
   self.buildTokensAndCollectiblesFromWallet()
+
+method onAllCommunityTokensLoaded*(self: Module, communityTokens: seq[CommunityTokenDto]) =
+  self.buildTokensAndCollectiblesFromCommunities(communityTokens)
 
 method onCommunityTokenMetadataAdded*(self: Module, communityId: string, tokenMetadata: CommunityTokensMetadataDto) =
   let communityTokens = self.controller.getCommunityTokens(communityId)

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -302,10 +302,11 @@ proc createChannelGroupItem[T](self: Module[T], channelGroup: ChannelGroupDto): 
   var communityTokensItems: seq[TokenItem]
   if (isCommunity):
     communityDetails = self.controller.getCommunityById(channelGroup.id)
-    self.controller.getCommunityTokensDetailsAsync(channelGroup.id)
-    # Get community members' revealed accounts
-    # We will update the model later when we finish loading the accounts
     if communityDetails.memberRole == MemberRole.Owner or communityDetails.memberRole == MemberRole.TokenMaster:
+      self.controller.getCommunityTokensDetailsAsync(channelGroup.id)
+
+      # Get community members' revealed accounts
+      # We will update the model later when we finish loading the accounts
       self.controller.asyncGetRevealedAccountsForAllMembers(channelGroup.id)
 
   let unviewedCount = channelGroup.unviewedMessagesCount

--- a/src/app/modules/shared_models/token_list_model.nim
+++ b/src/app/modules/shared_models/token_list_model.nim
@@ -44,6 +44,17 @@ QtObject:
     self.endResetModel()
     self.countChanged()
 
+  proc setWalletTokenItems*(self: TokenListModel, items: seq[TokenListItem]) =
+    var newItems = items
+    for item in self.items:
+      # Add back the community tokens
+      if item.communityId != "":
+        newItems.add(item)
+    self.beginResetModel()
+    self.items = newItems
+    self.endResetModel()
+    self.countChanged()
+
   proc hasItem*(self: TokenListModel, symbol: string): bool =
     for item in self.items:
       if item.getSymbol() == symbol:

--- a/src/app_service/service/community_tokens/async_tasks.nim
+++ b/src/app_service/service/community_tokens/async_tasks.nim
@@ -314,3 +314,22 @@ const getCommunityTokensDetailsTaskArg: Task = proc(argEncoded: string) {.gcsafe
       "error": e.msg
     }
     arg.finish(output)
+
+type
+  GetAllCommunityTokensArg = ref object of QObjectTaskArg
+
+const getAllCommunityTokensTaskArg: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
+  let arg = decode[GetAllCommunityTokensArg](argEncoded)
+  try:
+    let response = tokens_backend.getAllCommunityTokens()
+
+    let output = %* {
+      "response": response,
+      "error": ""
+    }
+    arg.finish(output)
+  except Exception as e:
+    let output = %* {
+      "error": e.msg
+    }
+    arg.finish(output)


### PR DESCRIPTION
Fixes [#12032](https://github.com/status-im/status-desktop/issues/12032)

- only call getCommunityTokens once per community: we used to call it each time the wallet updated
- use async getCommunityTokens for list creation

We still use `getCommunityTokens` sync in some places, but they happen more rarely and are harder to make async