### PR TITLE
feat(@desktop/wallet): implement collectibles error states and retry

### DIFF
--- a/src/app/modules/main/network_connection/view.nim
+++ b/src/app/modules/main/network_connection/view.nim
@@ -62,7 +62,7 @@ QtObject:
   proc refreshCollectiblesValues*(self: View) {.slot.} =
     self.delegate.refreshCollectiblesValues()
 
-  proc networkConnectionStatusUpdate*(self: View, website: string, completelyDown: bool, connectionState: int, chainIds: string, lastCheckedAt: int) {.signal.}
+  proc networkConnectionStatusUpdate*(self: View, website: string, completelyDown: bool, connectionState: int, chainIds: string, lastCheckedAt: float) {.signal.}
 
   proc updateNetworkConnectionStatus*(self: View, website: string, completelyDown: bool, connectionState: int, chainIds: string, lastCheckedAt: int) =
     case website:
@@ -75,5 +75,5 @@ QtObject:
       of MARKET:
         self.marketValuesNetworkConnection.updateValues(completelyDown, connectionState, chainIds, lastCheckedAt)
         self.marketValuesNetworkConnectionChanged()
-    self.networkConnectionStatusUpdate(website, completelyDown, connectionState, chainIds, lastCheckedAt)
+    self.networkConnectionStatusUpdate(website, completelyDown, connectionState, chainIds, float(lastCheckedAt))
 

--- a/src/backend/collectibles.nim
+++ b/src/backend/collectibles.nim
@@ -138,3 +138,6 @@ rpc(filterOwnedCollectiblesAsync, "wallet"):
 rpc(getCollectiblesDetailsAsync, "wallet"):
   requestId: int32
   uniqueIds: seq[CollectibleUniqueID]
+
+rpc(refetchOwnedCollectibles, "wallet"):
+  discard

--- a/src/backend/connection_status.nim
+++ b/src/backend/connection_status.nim
@@ -1,0 +1,50 @@
+import json, strformat, tables
+
+const INVALID_TIMESTAMP* = -1
+
+type
+  # Mirrors services/wallet/connection/types.go StateValue
+  StateValue* {.pure.} = enum
+    Unknown,
+    Connected,
+    Disconnected
+
+  # Mirrors services/wallet/connection/types.go State
+  ConnectionState* = ref object of RootObj
+    value*: StateValue
+    lastCheckedAt*: int
+    lastSuccessAt*: int
+
+  # Mirrors services/wallet/connection/status_notifier.go StatusNotification
+  ConnectionStatusNotification* = Table[string, ConnectionState]
+
+# ConnectionState
+proc initConnectionState*(value: StateValue, lastCheckedAt: int = INVALID_TIMESTAMP, lastSuccessAt: int = INVALID_TIMESTAMP): ConnectionState =
+  result = ConnectionState()
+  result.value = value
+  result.lastCheckedAt = lastCheckedAt
+  result.lastSuccessAt = lastSuccessAt
+
+proc `$`*(self: ConnectionState): string =
+  return fmt"""ConnectionState(
+    value:{self.value},
+    lastCheckedAt:{self.lastCheckedAt},
+    lastSuccessAt:{self.lastSuccessAt}
+  )"""
+
+proc fromJson*(t: JsonNode, T: typedesc[ConnectionState]): ConnectionState {.inline.} =
+  result = ConnectionState()
+  result.value = StateValue(t["value"].getInt())
+  result.lastCheckedAt = t["last_checked_at"].getInt()
+  result.lastSuccessAt = t["last_success_at"].getInt()
+
+# ConnectionStatusNotification
+proc initCustomStatusNotification*(): ConnectionStatusNotification =
+  result = initTable[string, ConnectionState]()
+
+proc fromJson*(t: JsonNode, T: typedesc[ConnectionStatusNotification]): ConnectionStatusNotification {.inline.} =
+  result = initCustomStatusNotification()
+  if t.kind != JNull:
+    for k, v in t.pairs:
+      if v.kind != JNull:
+        result[k] = fromJson(v, ConnectionState)

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -925,21 +925,49 @@ Item {
                     objectName: "walletCollectiblesConnectionBanner"
                     Layout.fillWidth: true
                     websiteDown: Constants.walletConnections.collectibles
-                    withCache: networkConnectionStore.collectiblesCache
+                    withCache: lastCheckedAtUnix > 0
                     networkConnectionStore: appMain.networkConnectionStore
+                    tooltipMessage: {
+                        if(withCache)
+                            return qsTr("Collectibles providers are currently unavailable for %1. Collectibles for those chains are as of %2.").arg(jointChainIdString).arg(lastCheckedAt)
+                        else
+                            return qsTr("Collectibles providers are currently unavailable for %1.").arg(jointChainIdString)
+                    }
                     toastText: {
                         switch(connectionState) {
                         case Constants.ConnectionStatus.Success:
-                            return qsTr("Opensea connection successful")
+                            return qsTr("Collectibles providers connection successful")
                         case Constants.ConnectionStatus.Failure:
-                            if(withCache){
-                                return qsTr("Opensea down. Collectibles are as of %1.").arg(lastCheckedAt)
+                            if(completelyDown) {
+                                if(withCache)
+                                    return qsTr("Collectibles providers down. Collectibles are as of %1.").arg(lastCheckedAt)
+                                else
+                                    return qsTr("Collectibles providers down. Collectibles cannot be retrieved.")
                             }
-                            else {
-                                return qsTr("Opensea down.")
+                            else if(chainIdsDown.length > 0) {
+                                if(chainIdsDown.length > 2) {
+                                    if(withCache)
+                                        return qsTr("Collectibles providers down for <a href='#'>multiple chains</a>. Collectibles for these chains are as of %1.".arg(lastCheckedAt))
+                                    else
+                                        return qsTr("Collectibles providers down for <a href='#'>multiple chains</a>. Collectibles for these chains cannot be retrieved.")
+                                }
+                                else if(chainIdsDown.length === 1) {
+                                    if(withCache)
+                                        return qsTr("Collectibles providers down for %1. Collectibles for this chain are as of %2.").arg(jointChainIdString).arg(lastCheckedAt)
+                                    else
+                                        return qsTr("Collectibles providers down for %1. Collectibles for this chain cannot be retrieved.").arg(jointChainIdString)
+                                }
+                                else {
+                                    if(withCache)
+                                        return qsTr("Collectibles providers down for %1. Collectibles for these chains are as of %2.").arg(jointChainIdString).arg(lastCheckedAt)
+                                    else
+                                        return qsTr("Collectibles providers down for %1. Collectibles for these chains cannot be retrieved.").arg(jointChainIdString)
+                                }
                             }
+                            else
+                                return ""
                         case Constants.ConnectionStatus.Retrying:
-                            return qsTr("Retrying connection to Opensea...")
+                            return qsTr("Retrying connection to collectibles providers...")
                         default:
                             return ""
                         }

--- a/ui/imports/shared/panels/ConnectionWarnings.qml
+++ b/ui/imports/shared/panels/ConnectionWarnings.qml
@@ -15,6 +15,7 @@ Loader {
     property int connectionState: -1
     property var chainIdsDown: []
     property bool completelyDown: false
+    property double lastCheckedAtUnix: -1
     property string lastCheckedAt
     property bool withCache: false
     property string tooltipMessage
@@ -57,12 +58,13 @@ Loader {
 
     Connections {
         target: networkConnectionStore.networkConnectionModuleInst
-        function onNetworkConnectionStatusUpdate(website: string, completelyDown: bool, connectionState: int, chainIds: string, lastCheckedAt: int)  {
+        function onNetworkConnectionStatusUpdate(website: string, completelyDown: bool, connectionState: int, chainIds: string, lastCheckedAtUnix: double)  {
             if (website === websiteDown) {
                 root.connectionState = connectionState
                 root.chainIdsDown = chainIds.split(";")
                 root.completelyDown = completelyDown
-                root.lastCheckedAt = LocaleUtils.formatDateTime(new Date(lastCheckedAt*1000))
+                root.lastCheckedAtUnix = lastCheckedAtUnix
+                root.lastCheckedAt = LocaleUtils.formatDateTime(new Date(lastCheckedAtUnix*1000))
                 root.updateBanner()
             }
         }

--- a/ui/imports/shared/stores/NetworkConnectionStore.qml
+++ b/ui/imports/shared/stores/NetworkConnectionStore.qml
@@ -13,7 +13,6 @@ QtObject {
 
     readonly property bool balanceCache: walletSectionAssets.hasBalanceCache
     readonly property bool marketValuesCache: walletSectionAssets.hasMarketValuesCache
-    readonly property bool collectiblesCache: false // TODO: Issue #11636
 
     readonly property var blockchainNetworksDown: !!networkConnectionModule.blockchainNetworkConnection.chainIds ? networkConnectionModule.blockchainNetworkConnection.chainIds.split(";") : []
     readonly property bool atleastOneBlockchainNetworkAvailable: blockchainNetworksDown.length <  networksModule.all.count


### PR DESCRIPTION
Fixes #11636
status-go part: https://github.com/status-im/status-go/pull/4066

### What does the PR do
Implements the connection error banner for Collectibles, as per https://www.figma.com/file/FkFClTCYKf83RJWoifWgoX/Wallet-v2?type=design&node-id=18105-123946&mode=design&t=ImrRpdHoBnXhPhFf-0

https://github.com/status-im/status-desktop/assets/11161531/6e324a26-7c1b-40ba-a37b-fe53ac2b6019

