### PR TITLE
Storybook: track pages directory on the fly

### DIFF
--- a/storybook/main.cpp
+++ b/storybook/main.cpp
@@ -1,5 +1,6 @@
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
+#include <QQmlContext>
 
 #include "cachecleaner.h"
 #include "directorieswatcher.h"
@@ -42,6 +43,9 @@ int main(int argc, char *argv[])
 
     for (const auto& path : additionalImportPaths)
         engine.addImportPath(path);
+
+    engine.rootContext()->setContextProperty(
+                "pagesFolder", QML_IMPORT_ROOT + QStringLiteral("/pages"));
 
     qmlRegisterType<FigmaDecoratorModel>("Storybook", 1, 0, "FigmaDecoratorModel");
     qmlRegisterType<FigmaLinksSource>("Storybook", 1, 0, "FigmaLinksSource");

--- a/storybook/main.qml
+++ b/storybook/main.qml
@@ -102,59 +102,71 @@ ApplicationWindow {
     SplitView {
         anchors.fill: parent
 
-        Pane {
+        ColumnLayout {
             SplitView.preferredWidth: 270
 
-            ColumnLayout {
-                width: parent.width
-                height: parent.height
+            Pane {
+                Layout.fillWidth: true
+                Layout.fillHeight: true
 
-                Button {
-                    Layout.fillWidth: true
+                ColumnLayout {
+                    width: parent.width
+                    height: parent.height
 
-                    text: "Settings"
+                    Button {
+                        Layout.fillWidth: true
 
-                    onClicked: settingsPopup.open()
-                }
+                        text: "Settings"
 
-                CheckBox {
-                    id: darkModeCheckBox
+                        onClicked: settingsPopup.open()
+                    }
 
-                    Layout.fillWidth: true
+                    CheckBox {
+                        id: darkModeCheckBox
 
-                    text: "Dark mode"
+                        Layout.fillWidth: true
 
-                    StatusLightTheme { id: lightTheme }
-                    StatusDarkTheme { id: darkTheme }
+                        text: "Dark mode"
 
-                    Binding {
-                        target: Theme
-                        property: "palette"
-                        value: darkModeCheckBox.checked ? darkTheme : lightTheme
+                        StatusLightTheme { id: lightTheme }
+                        StatusDarkTheme { id: darkTheme }
+
+                        Binding {
+                            target: Theme
+                            property: "palette"
+                            value: darkModeCheckBox.checked ? darkTheme : lightTheme
+                        }
+                    }
+
+                    HotReloaderControls {
+                        id: hotReloaderControls
+
+                        Layout.fillWidth: true
+
+                        onForceReloadClicked: reloader.forceReload()
+                    }
+
+                    MenuSeparator {
+                        Layout.fillWidth: true
+                    }
+
+                    FilteredPagesList {
+                        Layout.fillWidth: true
+                        Layout.fillHeight: true
+
+                        currentPage: root.currentPage
+                        model: pagesModel
+
+                        onPageSelected: root.currentPage = page
                     }
                 }
+            }
 
-                HotReloaderControls {
-                    id: hotReloaderControls
+            Button {
+                Layout.fillWidth: true
+                text: "Open pages directory"
 
-                    Layout.fillWidth: true
-
-                    onForceReloadClicked: reloader.forceReload()
-                }
-
-                MenuSeparator {
-                    Layout.fillWidth: true
-                }
-
-                FilteredPagesList {
-                    Layout.fillWidth: true
-                    Layout.fillHeight: true
-
-                    currentPage: root.currentPage
-                    model: pagesModel
-
-                    onPageSelected: root.currentPage = page
-                }
+                onClicked: Qt.openUrlExternally(Qt.resolvedUrl(pagesFolder))
             }
         }
 

--- a/storybook/pagesmodel.cpp
+++ b/storybook/pagesmodel.cpp
@@ -1,43 +1,148 @@
 #include "pagesmodel.h"
 
-#include <QRegularExpression>
 #include <QDir>
+#include <QFileSystemWatcher>
+#include <QRegularExpression>
 
 namespace {
 const auto categoryUncategorized QStringLiteral("Uncategorized");
 }
 
 PagesModel::PagesModel(const QString &path, QObject *parent)
-    : QAbstractListModel{parent}
+    : QAbstractListModel{parent}, m_path{path},
+      fsWatcher(new QFileSystemWatcher(this))
 {
-    QDir dir(path);
-    dir.setFilter(QDir::Files);
+    m_items = load();
+    readMetadata(m_items);
 
+    fsWatcher->addPath(path);
+
+    connect(fsWatcher, &QFileSystemWatcher::directoryChanged,
+            this, &PagesModel::reload);
+}
+
+QList<PagesModelItem> PagesModel::load() {
     static QRegularExpression fileNameRegex(
                 QRegularExpression::anchoredPattern("(.*)Page\\.qml"));
-    static QRegularExpression categoryRegex(
-                "^//(\\s)*category:(.+)$", QRegularExpression::MultilineOption);
+
+    QDir dir(m_path);
+    dir.setFilter(QDir::Files);
 
     const QFileInfoList files = dir.entryInfoList();
+    QList<PagesModelItem> items;
 
-    std::for_each(files.begin(), files.end(), [this] (auto &fileInfo) {
+    std::for_each(files.begin(), files.end(), [this, &items] (auto &fileInfo) {
         QString fileName = fileInfo.fileName();
         QRegularExpressionMatch fileNameMatch = fileNameRegex.match(fileName);
 
         if (!fileNameMatch.hasMatch())
             return;
 
-        QFile file(fileInfo.filePath());
-        file.open(QIODevice::ReadOnly);
-        QByteArray content = file.readAll();
+        PagesModelItem item;
+        item.path = fileInfo.filePath();
+        item.title = fileNameMatch.captured(1);
+        item.lastModified = fileInfo.lastModified();
 
-        QRegularExpressionMatch categoryMatch = categoryRegex.match(content);
-        QString category = categoryMatch.hasMatch()
-                ? categoryMatch.captured(2).trimmed() : categoryUncategorized;
-
-        QString title = fileNameMatch.captured(1);
-        m_items << PagesModelItem { title, category };
+        items << item;
     });
+
+    return items;
+}
+
+void PagesModel::readMetadata(PagesModelItem& item) {
+    static QRegularExpression categoryRegex(
+                "^//(\\s)*category:(.+)$", QRegularExpression::MultilineOption);
+
+    QFile file(item.path);
+    file.open(QIODevice::ReadOnly);
+    QByteArray content = file.readAll();
+
+    QRegularExpressionMatch categoryMatch = categoryRegex.match(content);
+    QString category = categoryMatch.hasMatch()
+            ? categoryMatch.captured(2).trimmed() : categoryUncategorized;
+
+    item.category = category;
+}
+
+void PagesModel::readMetadata(QList<PagesModelItem> &items) {
+    std::for_each(items.begin(), items.end(), [](auto&item) {
+        readMetadata(item);
+    });
+}
+
+void PagesModel::reload() {
+    QList<PagesModelItem> currentItems = load();
+    std::map<QString, PagesModelItem> mapping;
+
+    for (const PagesModelItem &item : qAsConst(m_items))
+        mapping[item.title] = item;
+
+    std::vector<PagesModelItem> newItems;
+    std::vector<PagesModelItem> changedItems;
+    std::vector<PagesModelItem> removedItems;
+
+    for (const PagesModelItem &item : qAsConst(currentItems)) {
+        auto it = mapping.find(item.title);
+
+        if (it == mapping.end()) {
+            newItems.push_back(item);
+        } else {
+            if (item.lastModified != it->second.lastModified)
+                changedItems.push_back(item);
+
+            mapping.erase(it);
+        }
+    }
+
+    for (auto& [key, value] : mapping)
+        removedItems.push_back(value);
+
+    for (auto& item : removedItems) {
+
+        auto it = std::find_if(m_items.begin(), m_items.end(), [&item](auto& it){
+            return it.title == item.title;
+        });
+
+        auto index = std::distance(m_items.begin(), it);
+
+        beginRemoveRows(QModelIndex{}, index, index);
+        m_items.removeAt(index);
+        endRemoveRows();
+    }
+
+    if (newItems.size()) {
+        beginInsertRows(QModelIndex{}, rowCount(), rowCount() + newItems.size() - 1);
+
+        for (auto& item : newItems) {
+            readMetadata(item);
+            m_items << item;
+        }
+
+        endInsertRows();
+    }
+
+    for (auto& item : changedItems) {
+        auto it = std::find_if(m_items.begin(), m_items.end(), [&item](auto& it){
+            return it.title == item.title;
+        });
+
+        auto index = std::distance(m_items.begin(), it);
+        const auto& previous = *it;
+        readMetadata(item);
+
+        if (previous.category != item.category) {
+            // For simplicity category change is handled by removing and
+            // adding item. In the future it can be changed to regular dataChanged
+            // event and handled properly in upstream models like SectionSDecoratorModel.
+            beginRemoveRows(QModelIndex{}, index, index);
+            m_items.removeAt(index);
+            endRemoveRows();
+
+            beginInsertRows(QModelIndex{}, rowCount(), rowCount());
+            m_items << item;
+            endInsertRows();
+        }
+    }
 }
 
 QHash<int, QByteArray> PagesModel::roleNames() const

--- a/storybook/pagesmodel.cpp
+++ b/storybook/pagesmodel.cpp
@@ -21,7 +21,7 @@ PagesModel::PagesModel(const QString &path, QObject *parent)
             this, &PagesModel::reload);
 }
 
-QList<PagesModelItem> PagesModel::load() {
+QList<PagesModelItem> PagesModel::load() const {
     static QRegularExpression fileNameRegex(
                 QRegularExpression::anchoredPattern("(.*)Page\\.qml"));
 
@@ -71,8 +71,8 @@ void PagesModel::readMetadata(QList<PagesModelItem> &items) {
 }
 
 void PagesModel::reload() {
-    QList<PagesModelItem> currentItems = load();
-    std::map<QString, PagesModelItem> mapping;
+    const QList<PagesModelItem> currentItems = load();
+    std::unordered_map<QString, PagesModelItem> mapping;
 
     for (const PagesModelItem &item : qAsConst(m_items))
         mapping[item.title] = item;
@@ -81,7 +81,7 @@ void PagesModel::reload() {
     std::vector<PagesModelItem> changedItems;
     std::vector<PagesModelItem> removedItems;
 
-    for (const PagesModelItem &item : qAsConst(currentItems)) {
+    for (const auto &item : currentItems) {
         auto it = mapping.find(item.title);
 
         if (it == mapping.end()) {
@@ -94,7 +94,7 @@ void PagesModel::reload() {
         }
     }
 
-    for (auto& [key, value] : mapping)
+    for (const auto& [key, value] : mapping)
         removedItems.push_back(value);
 
     for (auto& item : removedItems) {

--- a/storybook/pagesmodel.h
+++ b/storybook/pagesmodel.h
@@ -1,8 +1,13 @@
 #pragma once
 
 #include <QAbstractListModel>
+#include <QDateTime>
+
+class QFileSystemWatcher;
 
 struct PagesModelItem {
+    QString path;
+    QDateTime lastModified;
     QString title;
     QString category;
 };
@@ -22,6 +27,14 @@ public:
     int rowCount(const QModelIndex &parent = QModelIndex()) const override;
     QVariant data(const QModelIndex &index, int role) const override;
 
+    void reload();
 private:
+    QList<PagesModelItem> load();
+
+    static void readMetadata(PagesModelItem &item);
+    static void readMetadata(QList<PagesModelItem> &items);
+
+    QString m_path;
     QList<PagesModelItem> m_items;
+    QFileSystemWatcher* fsWatcher;
 };

--- a/storybook/pagesmodel.h
+++ b/storybook/pagesmodel.h
@@ -29,7 +29,7 @@ public:
 
     void reload();
 private:
-    QList<PagesModelItem> load();
+    QList<PagesModelItem> load() const;
 
     static void readMetadata(PagesModelItem &item);
     static void readMetadata(QList<PagesModelItem> &items);

--- a/storybook/sectionsdecoratormodel.cpp
+++ b/storybook/sectionsdecoratormodel.cpp
@@ -23,10 +23,15 @@ void SectionsDecoratorModel::setSourceModel(QAbstractItemModel *sourceModel)
 
     initialize();
 
-    connect(sourceModel, &QAbstractItemModel::modelReset, this, &SectionsDecoratorModel::initialize);
-    connect(sourceModel, &QAbstractItemModel::rowsInserted, this, &SectionsDecoratorModel::initialize);
-    connect(sourceModel, &QAbstractItemModel::rowsRemoved, this, &SectionsDecoratorModel::initialize);
-    connect(sourceModel, &QAbstractItemModel::rowsMoved, this, &SectionsDecoratorModel::initialize);
+    connect(sourceModel, &QAbstractItemModel::modelReset, this,
+            &SectionsDecoratorModel::initialize);
+    connect(sourceModel, &QAbstractItemModel::rowsMoved, this,
+            &SectionsDecoratorModel::initialize);
+
+    connect(sourceModel, &QAbstractItemModel::rowsInserted, this,
+            &SectionsDecoratorModel::onInserted);
+    connect(sourceModel, &QAbstractItemModel::rowsRemoved, this,
+            &SectionsDecoratorModel::onRemoved);
 
     emit sourceModelChanged();
 }
@@ -159,4 +164,128 @@ void SectionsDecoratorModel::initialize()
     }
 
     calculateOffsets();
+}
+
+void SectionsDecoratorModel::onInserted(const QModelIndex &parent,
+                                        int first, int last)
+{
+    if (first != last) {
+        initialize();
+        return;
+    }
+
+    const QVariant sectionVariant = m_sourceModel->data(
+                m_sourceModel->index(first, 0), m_sectionRole);
+    const QString section = sectionVariant.toString();
+
+    auto insertNewSection = [this, &section](int index) {
+        beginInsertRows(QModelIndex{}, index, index + 1);
+
+        m_rowsMetadata.insert(m_rowsMetadata.begin() + index, RowMetadata{});
+        m_rowsMetadata.insert(m_rowsMetadata.begin() + index,
+                              RowMetadata{ true, section, false, 0, 1});
+        calculateOffsets();
+        endInsertRows();
+    };
+
+    int itemsCounter = 0;
+    int sectionIndex = 0;
+
+    while (sectionIndex < m_rowsMetadata.size()) {
+        auto& sectionMetadata = m_rowsMetadata.at(sectionIndex);
+
+        if (sectionMetadata.sectionName == section) {
+            sectionMetadata.count++;
+
+            emit dataChanged(index(sectionIndex, 0), index(sectionIndex, 0),
+                             { Roles::SubitemsCountRole });
+
+            if (sectionMetadata.folded) {
+                // update folded section only
+                calculateOffsets();
+
+            } else {
+                // insert item into unfolded section
+                auto insertIndex = sectionIndex + (first - itemsCounter) + 1;
+
+                beginInsertRows(QModelIndex{}, insertIndex, insertIndex);
+                m_rowsMetadata.insert(m_rowsMetadata.begin() + insertIndex, RowMetadata{});
+                calculateOffsets();
+                endInsertRows();
+            }
+
+            break;
+        }
+
+        if (sectionMetadata.sectionName != section && itemsCounter == first) {
+            insertNewSection(sectionIndex);
+            break;
+        }
+
+        itemsCounter += sectionMetadata.count;
+        sectionIndex += 1 + (sectionMetadata.folded ? 0 : sectionMetadata.count);
+    }
+
+    if (sectionIndex == m_rowsMetadata.size())
+        insertNewSection(sectionIndex);
+}
+
+void SectionsDecoratorModel::onRemoved(const QModelIndex &parent,
+                                       int first, int last)
+{
+    if (first != last) {
+        initialize();
+        return;
+    }
+
+    int itemsCounter = 0;
+    int sectionIndex = 0;
+
+    while (sectionIndex < m_rowsMetadata.size()) {
+        auto& sectionMetadata = m_rowsMetadata.at(sectionIndex);
+
+        if (first < itemsCounter + sectionMetadata.count) {
+
+            if (sectionMetadata.folded) {
+                if (sectionMetadata.count == 1) {
+                    auto removeIndex = sectionIndex + (first - itemsCounter);
+                    beginRemoveRows(QModelIndex{}, removeIndex, removeIndex);
+                    m_rowsMetadata.erase(m_rowsMetadata.begin() + removeIndex,
+                                         m_rowsMetadata.begin() + removeIndex + 1);
+                    calculateOffsets();
+                    endRemoveRows();
+                } else {
+                    sectionMetadata.count--;
+                    calculateOffsets();
+
+                    emit dataChanged(index(sectionIndex, 0), index(sectionIndex, 0),
+                                     { Roles::SubitemsCountRole });
+                }
+            } else {
+                if (sectionMetadata.count == 1) {
+                    auto removeIndex = sectionIndex + (first - itemsCounter);
+                    beginRemoveRows(QModelIndex{}, removeIndex, removeIndex + 1);
+                    m_rowsMetadata.erase(m_rowsMetadata.begin() + removeIndex,
+                                         m_rowsMetadata.begin() + removeIndex + 2);
+                } else {
+                    sectionMetadata.count--;
+                    emit dataChanged(index(sectionIndex, 0), index(sectionIndex, 0),
+                                     { Roles::SubitemsCountRole });
+
+                    auto removeIndex = sectionIndex + (first - itemsCounter) + 1;
+
+                    beginRemoveRows(QModelIndex{}, removeIndex, removeIndex);
+                    m_rowsMetadata.erase(m_rowsMetadata.begin() + removeIndex);
+                }
+
+                calculateOffsets();
+                endRemoveRows();
+            }
+
+            break;
+        }
+
+        itemsCounter += sectionMetadata.count;
+        sectionIndex += 1 + (sectionMetadata.folded ? 0 : sectionMetadata.count);
+    }
 }

--- a/storybook/sectionsdecoratormodel.h
+++ b/storybook/sectionsdecoratormodel.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <QAbstractListModel>
-#include <optional>
 
 class SectionsDecoratorModel : public QAbstractListModel
 {
@@ -41,6 +40,9 @@ private:
 
     void initialize();
     void calculateOffsets();
+
+    void onInserted(const QModelIndex &parent, int first, int last);
+    void onRemoved(const QModelIndex &parent, int first, int last);
 
     QAbstractItemModel* m_sourceModel = nullptr;
     std::vector<RowMetadata> m_rowsMetadata;

--- a/storybook/tests/tst_SectionsDecoratorModel.cpp
+++ b/storybook/tests/tst_SectionsDecoratorModel.cpp
@@ -14,6 +14,13 @@ public:
     explicit TestSourceModel(QStringList categories)
         : m_categories(std::move(categories))
     {
+        for (int i = 0; i < m_categories.size(); i++)
+            m_titles << QString("title %1").arg(i);
+    }
+
+    explicit TestSourceModel(QStringList categories, QStringList titles)
+        : m_categories(std::move(categories)), m_titles(std::move(titles))
+    {
     }
 
     static constexpr int TitleRole = Qt::UserRole + 1;
@@ -27,11 +34,28 @@ public:
         if (!index.isValid())
             return {};
 
-        if (role == TitleRole) {
-            return QString("title %1").arg(index.row());
-        }
+        const auto row = index.row();
 
-        return m_categories.at(index.row());
+        if (role == TitleRole)
+            return m_titles.at(row);
+
+        return m_categories.at(row);
+    }
+
+    void insert(int index, QString category, QString title)
+    {
+        beginInsertRows(QModelIndex{}, index, index);
+        m_categories.insert(index, category);
+        m_titles.insert(index, title);
+        endInsertRows();
+    }
+
+    void remove(int index)
+    {
+        beginRemoveRows(QModelIndex{}, index, index);
+        m_categories.removeAt(index);
+        m_titles.removeAt(index);
+        endRemoveRows();
     }
 
     QHash<int, QByteArray> roleNames() const override {
@@ -42,6 +66,7 @@ public:
     }
 
     QStringList m_categories;
+    QStringList m_titles;
 };
 
 } // unnamed namespace
@@ -691,12 +716,8 @@ private slots:
         SectionsDecoratorModel model;
         model.setSourceModel(&proxy);
 
-        QSignalSpy spy(&model, &SectionsDecoratorModel::modelReset);
-
         proxy.setFilterRole(TestSourceModel::TitleRole);
         proxy.setFilterWildcard("*1");
-
-        QVERIFY(spy.count() > 1);
 
         QCOMPARE(model.rowCount(), 2);
         QCOMPARE(model.roleNames().count(), 6);
@@ -712,6 +733,810 @@ private slots:
 
         QCOMPARE(model.data(model.index(0, 0), SectionsDecoratorModel::SubitemsCountRole).toInt(), 1);
         QCOMPARE(model.data(model.index(1, 0), SectionsDecoratorModel::SubitemsCountRole).toInt(), 0);
+    }
+
+    void insertionTest() {
+        {
+            TestSourceModel src(
+                        QStringList{"Section 1", "Section 1", "Section 1", "Section 2", "Section 2", "Section 3"},
+                        QStringList{"Title__ 1", "Title__ 2", "Title__ 3", "Title__ 4", "Title__ 5", "Title__ 6"});
+
+            SectionsDecoratorModel model;
+            model.setSourceModel(&src);
+
+            QSignalSpy insertionSpy(&model, &SectionsDecoratorModel::rowsInserted);
+            QSignalSpy changeSpy(&model, &SectionsDecoratorModel::dataChanged);
+
+            src.insert(0, "Section 1", "New Title");
+            QCOMPARE(model.rowCount(), 10);
+            QCOMPARE(insertionSpy.count(), 1);
+            QCOMPARE(changeSpy.count(), 1);
+
+            auto insertionArguments = insertionSpy.takeFirst();
+            QCOMPARE(insertionArguments.at(1).toInt(), 1);
+            QCOMPARE(insertionArguments.at(2).toInt(), 1);
+
+            auto changeArguments = changeSpy.takeFirst();
+            QCOMPARE(changeArguments.at(0).toModelIndex(), model.index(0, 0));
+            QCOMPARE(changeArguments.at(1).toModelIndex(), model.index(0, 0));
+
+            QCOMPARE(model.data(model.index(0, 0), TestSourceModel::TitleRole), QVariant{});
+            QCOMPARE(model.data(model.index(1, 0), TestSourceModel::TitleRole).toString(), QString("New Title"));
+            QCOMPARE(model.data(model.index(2, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 1"));
+            QCOMPARE(model.data(model.index(3, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 2"));
+            QCOMPARE(model.data(model.index(4, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 3"));
+            QCOMPARE(model.data(model.index(5, 0), TestSourceModel::TitleRole), QVariant{});
+            QCOMPARE(model.data(model.index(6, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 4"));
+            QCOMPARE(model.data(model.index(7, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 5"));
+            QCOMPARE(model.data(model.index(8, 0), TestSourceModel::TitleRole), QVariant{});
+            QCOMPARE(model.data(model.index(9, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 6"));
+        }
+        {
+            TestSourceModel src(
+                        QStringList{"Section 1", "Section 1", "Section 1", "Section 2", "Section 2", "Section 3"},
+                        QStringList{"Title__ 1", "Title__ 2", "Title__ 3", "Title__ 4", "Title__ 5", "Title__ 6"});
+
+            SectionsDecoratorModel model;
+            model.setSourceModel(&src);
+
+            QSignalSpy insertionSpy(&model, &SectionsDecoratorModel::rowsInserted);
+            QSignalSpy changeSpy(&model, &SectionsDecoratorModel::dataChanged);
+
+            src.insert(1, "Section 1", "New Title");
+            QCOMPARE(model.rowCount(), 10);
+            QCOMPARE(insertionSpy.count(), 1);
+
+            auto insertionArguments = insertionSpy.takeFirst();
+            QCOMPARE(insertionArguments.at(1).toInt(), 2);
+            QCOMPARE(insertionArguments.at(2).toInt(), 2);
+
+            auto changeArguments = changeSpy.takeFirst();
+            QCOMPARE(changeArguments.at(0).toModelIndex(), model.index(0, 0));
+            QCOMPARE(changeArguments.at(1).toModelIndex(), model.index(0, 0));
+
+            QCOMPARE(model.data(model.index(0, 0), TestSourceModel::TitleRole), QVariant{});
+            QCOMPARE(model.data(model.index(1, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 1"));
+            QCOMPARE(model.data(model.index(2, 0), TestSourceModel::TitleRole).toString(), QString("New Title"));
+            QCOMPARE(model.data(model.index(3, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 2"));
+            QCOMPARE(model.data(model.index(4, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 3"));
+            QCOMPARE(model.data(model.index(5, 0), TestSourceModel::TitleRole), QVariant{});
+            QCOMPARE(model.data(model.index(6, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 4"));
+            QCOMPARE(model.data(model.index(7, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 5"));
+            QCOMPARE(model.data(model.index(8, 0), TestSourceModel::TitleRole), QVariant{});
+            QCOMPARE(model.data(model.index(9, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 6"));
+        }
+        {
+            TestSourceModel src(
+                        QStringList{"Section 1", "Section 1", "Section 1", "Section 2", "Section 2", "Section 3"},
+                        QStringList{"Title__ 1", "Title__ 2", "Title__ 3", "Title__ 4", "Title__ 5", "Title__ 6"});
+
+            SectionsDecoratorModel model;
+            model.setSourceModel(&src);
+
+            QSignalSpy insertionSpy(&model, &SectionsDecoratorModel::rowsInserted);
+            QSignalSpy changeSpy(&model, &SectionsDecoratorModel::dataChanged);
+
+            src.insert(2, "Section 1", "New Title");
+            QCOMPARE(model.rowCount(), 10);
+            QCOMPARE(insertionSpy.count(), 1);
+
+            auto insertionArguments = insertionSpy.takeFirst();
+            QCOMPARE(insertionArguments.at(1).toInt(), 3);
+            QCOMPARE(insertionArguments.at(2).toInt(), 3);
+
+            auto changeArguments = changeSpy.takeFirst();
+            QCOMPARE(changeArguments.at(0).toModelIndex(), model.index(0, 0));
+            QCOMPARE(changeArguments.at(1).toModelIndex(), model.index(0, 0));
+
+            QCOMPARE(model.data(model.index(0, 0), TestSourceModel::TitleRole), QVariant{});
+            QCOMPARE(model.data(model.index(1, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 1"));
+            QCOMPARE(model.data(model.index(2, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 2"));
+            QCOMPARE(model.data(model.index(3, 0), TestSourceModel::TitleRole).toString(), QString("New Title"));
+            QCOMPARE(model.data(model.index(4, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 3"));
+            QCOMPARE(model.data(model.index(5, 0), TestSourceModel::TitleRole), QVariant{});
+            QCOMPARE(model.data(model.index(6, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 4"));
+            QCOMPARE(model.data(model.index(7, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 5"));
+            QCOMPARE(model.data(model.index(8, 0), TestSourceModel::TitleRole), QVariant{});
+            QCOMPARE(model.data(model.index(9, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 6"));
+        }
+        {
+            TestSourceModel src(
+                        QStringList{"Section 1", "Section 1", "Section 1", "Section 2", "Section 2", "Section 3"},
+                        QStringList{"Title__ 1", "Title__ 2", "Title__ 3", "Title__ 4", "Title__ 5", "Title__ 6"});
+
+            SectionsDecoratorModel model;
+            model.setSourceModel(&src);
+
+            QSignalSpy insertionSpy(&model, &SectionsDecoratorModel::rowsInserted);
+            QSignalSpy changeSpy(&model, &SectionsDecoratorModel::dataChanged);
+
+            src.insert(3, "Section 1", "New Title");
+            QCOMPARE(model.rowCount(), 10);
+            QCOMPARE(insertionSpy.count(), 1);
+
+            auto insertionArguments = insertionSpy.takeFirst();
+            QCOMPARE(insertionArguments.at(1).toInt(), 4);
+            QCOMPARE(insertionArguments.at(2).toInt(), 4);
+
+            auto changeArguments = changeSpy.takeFirst();
+            QCOMPARE(changeArguments.at(0).toModelIndex(), model.index(0, 0));
+            QCOMPARE(changeArguments.at(1).toModelIndex(), model.index(0, 0));
+
+            QCOMPARE(model.data(model.index(0, 0), TestSourceModel::TitleRole), QVariant{});
+            QCOMPARE(model.data(model.index(1, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 1"));
+            QCOMPARE(model.data(model.index(2, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 2"));
+            QCOMPARE(model.data(model.index(3, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 3"));
+            QCOMPARE(model.data(model.index(4, 0), TestSourceModel::TitleRole).toString(), QString("New Title"));
+            QCOMPARE(model.data(model.index(5, 0), TestSourceModel::TitleRole), QVariant{});
+            QCOMPARE(model.data(model.index(6, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 4"));
+            QCOMPARE(model.data(model.index(7, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 5"));
+            QCOMPARE(model.data(model.index(8, 0), TestSourceModel::TitleRole), QVariant{});
+            QCOMPARE(model.data(model.index(9, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 6"));
+        }
+        {
+            TestSourceModel src(
+                        QStringList{"Section 1", "Section 1", "Section 1", "Section 2", "Section 2", "Section 3"},
+                        QStringList{"Title__ 1", "Title__ 2", "Title__ 3", "Title__ 4", "Title__ 5", "Title__ 6"});
+
+            SectionsDecoratorModel model;
+            model.setSourceModel(&src);
+
+            QSignalSpy insertionSpy(&model, &SectionsDecoratorModel::rowsInserted);
+            QSignalSpy changeSpy(&model, &SectionsDecoratorModel::dataChanged);
+
+            src.insert(3, "Section 2", "New Title");
+            QCOMPARE(model.rowCount(), 10);
+            QCOMPARE(insertionSpy.count(), 1);
+
+            auto insertionArguments = insertionSpy.takeFirst();
+            QCOMPARE(insertionArguments.at(1).toInt(), 5);
+            QCOMPARE(insertionArguments.at(2).toInt(), 5);
+
+            auto changeArguments = changeSpy.takeFirst();
+            QCOMPARE(changeArguments.at(0).toModelIndex(), model.index(4, 0));
+            QCOMPARE(changeArguments.at(1).toModelIndex(), model.index(4, 0));
+
+            QCOMPARE(model.data(model.index(0, 0), TestSourceModel::TitleRole), QVariant{});
+            QCOMPARE(model.data(model.index(1, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 1"));
+            QCOMPARE(model.data(model.index(2, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 2"));
+            QCOMPARE(model.data(model.index(3, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 3"));
+            QCOMPARE(model.data(model.index(4, 0), TestSourceModel::TitleRole), QVariant{});
+            QCOMPARE(model.data(model.index(5, 0), TestSourceModel::TitleRole).toString(), QString("New Title"));
+            QCOMPARE(model.data(model.index(6, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 4"));
+            QCOMPARE(model.data(model.index(7, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 5"));
+            QCOMPARE(model.data(model.index(8, 0), TestSourceModel::TitleRole), QVariant{});
+            QCOMPARE(model.data(model.index(9, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 6"));
+        }
+        {
+            TestSourceModel src(
+                        QStringList{"Section 1", "Section 1", "Section 1", "Section 2", "Section 2", "Section 3"},
+                        QStringList{"Title__ 1", "Title__ 2", "Title__ 3", "Title__ 4", "Title__ 5", "Title__ 6"});
+
+            SectionsDecoratorModel model;
+            model.setSourceModel(&src);
+
+            QSignalSpy insertionSpy(&model, &SectionsDecoratorModel::rowsInserted);
+            QSignalSpy changeSpy(&model, &SectionsDecoratorModel::dataChanged);
+
+            src.insert(4, "Section 2", "New Title");
+            QCOMPARE(model.rowCount(), 10);
+            QCOMPARE(insertionSpy.count(), 1);
+
+            auto insertionArguments = insertionSpy.takeFirst();
+            QCOMPARE(insertionArguments.at(1).toInt(), 6);
+            QCOMPARE(insertionArguments.at(2).toInt(), 6);
+
+            auto changeArguments = changeSpy.takeFirst();
+            QCOMPARE(changeArguments.at(0).toModelIndex(), model.index(4, 0));
+            QCOMPARE(changeArguments.at(1).toModelIndex(), model.index(4, 0));
+
+            QCOMPARE(model.data(model.index(0, 0), TestSourceModel::TitleRole), QVariant{});
+            QCOMPARE(model.data(model.index(1, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 1"));
+            QCOMPARE(model.data(model.index(2, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 2"));
+            QCOMPARE(model.data(model.index(3, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 3"));
+            QCOMPARE(model.data(model.index(4, 0), TestSourceModel::TitleRole), QVariant{});
+            QCOMPARE(model.data(model.index(5, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 4"));
+            QCOMPARE(model.data(model.index(6, 0), TestSourceModel::TitleRole).toString(), QString("New Title"));
+            QCOMPARE(model.data(model.index(7, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 5"));
+            QCOMPARE(model.data(model.index(8, 0), TestSourceModel::TitleRole), QVariant{});
+            QCOMPARE(model.data(model.index(9, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 6"));
+        }
+        {
+            TestSourceModel src(
+                        QStringList{"Section 1", "Section 1", "Section 1", "Section 2", "Section 2", "Section 3"},
+                        QStringList{"Title__ 1", "Title__ 2", "Title__ 3", "Title__ 4", "Title__ 5", "Title__ 6"});
+
+            SectionsDecoratorModel model;
+            model.setSourceModel(&src);
+
+            QSignalSpy insertionSpy(&model, &SectionsDecoratorModel::rowsInserted);
+            QSignalSpy changeSpy(&model, &SectionsDecoratorModel::dataChanged);
+
+            src.insert(5, "Section 3", "New Title");
+            QCOMPARE(model.rowCount(), 10);
+            QCOMPARE(insertionSpy.count(), 1);
+
+            auto insertionArguments = insertionSpy.takeFirst();
+            QCOMPARE(insertionArguments.at(1).toInt(), 8);
+            QCOMPARE(insertionArguments.at(2).toInt(), 8);
+
+            auto changeArguments = changeSpy.takeFirst();
+            QCOMPARE(changeArguments.at(0).toModelIndex(), model.index(7, 0));
+            QCOMPARE(changeArguments.at(1).toModelIndex(), model.index(7, 0));
+
+            QCOMPARE(model.data(model.index(0, 0), TestSourceModel::TitleRole), QVariant{});
+            QCOMPARE(model.data(model.index(1, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 1"));
+            QCOMPARE(model.data(model.index(2, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 2"));
+            QCOMPARE(model.data(model.index(3, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 3"));
+            QCOMPARE(model.data(model.index(4, 0), TestSourceModel::TitleRole), QVariant{});
+            QCOMPARE(model.data(model.index(5, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 4"));
+            QCOMPARE(model.data(model.index(6, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 5"));
+            QCOMPARE(model.data(model.index(7, 0), TestSourceModel::TitleRole), QVariant{});
+            QCOMPARE(model.data(model.index(8, 0), TestSourceModel::TitleRole).toString(), QString("New Title"));
+            QCOMPARE(model.data(model.index(9, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 6"));
+        }
+        {
+            TestSourceModel src(
+                        QStringList{"Section 1", "Section 1", "Section 1", "Section 2", "Section 2", "Section 3"},
+                        QStringList{"Title__ 1", "Title__ 2", "Title__ 3", "Title__ 4", "Title__ 5", "Title__ 6"});
+
+            SectionsDecoratorModel model;
+            model.setSourceModel(&src);
+
+            QSignalSpy insertionSpy(&model, &SectionsDecoratorModel::rowsInserted);
+            QSignalSpy changeSpy(&model, &SectionsDecoratorModel::dataChanged);
+
+            src.insert(6, "Section 3", "New Title");
+            QCOMPARE(model.rowCount(), 10);
+            QCOMPARE(insertionSpy.count(), 1);
+
+            auto insertionArguments = insertionSpy.takeFirst();
+            QCOMPARE(insertionArguments.at(1).toInt(), 9);
+            QCOMPARE(insertionArguments.at(2).toInt(), 9);
+
+            auto changeArguments = changeSpy.takeFirst();
+            QCOMPARE(changeArguments.at(0).toModelIndex(), model.index(7, 0));
+            QCOMPARE(changeArguments.at(1).toModelIndex(), model.index(7, 0));
+
+            QCOMPARE(model.data(model.index(0, 0), TestSourceModel::TitleRole), QVariant{});
+            QCOMPARE(model.data(model.index(1, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 1"));
+            QCOMPARE(model.data(model.index(2, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 2"));
+            QCOMPARE(model.data(model.index(3, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 3"));
+            QCOMPARE(model.data(model.index(4, 0), TestSourceModel::TitleRole), QVariant{});
+            QCOMPARE(model.data(model.index(5, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 4"));
+            QCOMPARE(model.data(model.index(6, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 5"));
+            QCOMPARE(model.data(model.index(7, 0), TestSourceModel::TitleRole), QVariant{});
+            QCOMPARE(model.data(model.index(8, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 6"));
+            QCOMPARE(model.data(model.index(9, 0), TestSourceModel::TitleRole).toString(), QString("New Title"));
+        }
+        {
+            TestSourceModel src(
+                        QStringList{"Section 1", "Section 1", "Section 1", "Section 2", "Section 2", "Section 3"},
+                        QStringList{"Title__ 1", "Title__ 2", "Title__ 3", "Title__ 4", "Title__ 5", "Title__ 6"});
+
+            SectionsDecoratorModel model;
+            model.setSourceModel(&src);
+
+
+            model.flipFolding(0);
+
+            QSignalSpy insertionSpy(&model, &SectionsDecoratorModel::rowsInserted);
+            QSignalSpy changeSpy(&model, &SectionsDecoratorModel::dataChanged);
+
+            src.insert(0, "Section 1", "New Title");
+            QCOMPARE(model.rowCount(), 6);
+            QCOMPARE(insertionSpy.count(), 0);
+            QCOMPARE(changeSpy.count(), 1);
+
+            QCOMPARE(model.data(model.index(0, 0), TestSourceModel::TitleRole), QVariant{});
+            QCOMPARE(model.data(model.index(1, 0), TestSourceModel::TitleRole), QVariant{});
+            QCOMPARE(model.data(model.index(2, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 4"));
+            QCOMPARE(model.data(model.index(3, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 5"));
+            QCOMPARE(model.data(model.index(4, 0), TestSourceModel::TitleRole), QVariant{});
+            QCOMPARE(model.data(model.index(5, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 6"));
+        }
+        {
+            TestSourceModel src(
+                        QStringList{"Section 1", "Section 1", "Section 1", "Section 2", "Section 2", "Section 3"},
+                        QStringList{"Title__ 1", "Title__ 2", "Title__ 3", "Title__ 4", "Title__ 5", "Title__ 6"});
+
+            SectionsDecoratorModel model;
+            model.setSourceModel(&src);
+
+
+            model.flipFolding(0);
+
+            QSignalSpy insertionSpy(&model, &SectionsDecoratorModel::rowsInserted);
+            QSignalSpy changeSpy(&model, &SectionsDecoratorModel::dataChanged);
+
+            src.insert(1, "Section 1", "New Title");
+            QCOMPARE(model.rowCount(), 6);
+            QCOMPARE(insertionSpy.count(), 0);
+            QCOMPARE(changeSpy.count(), 1);
+
+            QCOMPARE(model.data(model.index(0, 0), TestSourceModel::TitleRole), QVariant{});
+            QCOMPARE(model.data(model.index(1, 0), TestSourceModel::TitleRole), QVariant{});
+            QCOMPARE(model.data(model.index(2, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 4"));
+            QCOMPARE(model.data(model.index(3, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 5"));
+            QCOMPARE(model.data(model.index(4, 0), TestSourceModel::TitleRole), QVariant{});
+            QCOMPARE(model.data(model.index(5, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 6"));
+        }
+        {
+            TestSourceModel src(
+                        QStringList{"Section 1", "Section 1", "Section 1", "Section 2", "Section 2", "Section 3"},
+                        QStringList{"Title__ 1", "Title__ 2", "Title__ 3", "Title__ 4", "Title__ 5", "Title__ 6"});
+
+            SectionsDecoratorModel model;
+            model.setSourceModel(&src);
+
+
+            model.flipFolding(0);
+
+            QSignalSpy insertionSpy(&model, &SectionsDecoratorModel::rowsInserted);
+            QSignalSpy changeSpy(&model, &SectionsDecoratorModel::dataChanged);
+
+            src.insert(3, "Section 1", "New Title");
+            QCOMPARE(model.rowCount(), 6);
+            QCOMPARE(insertionSpy.count(), 0);
+            QCOMPARE(changeSpy.count(), 1);
+
+            QCOMPARE(model.data(model.index(0, 0), TestSourceModel::TitleRole), QVariant{});
+            QCOMPARE(model.data(model.index(1, 0), TestSourceModel::TitleRole), QVariant{});
+            QCOMPARE(model.data(model.index(2, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 4"));
+            QCOMPARE(model.data(model.index(3, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 5"));
+            QCOMPARE(model.data(model.index(4, 0), TestSourceModel::TitleRole), QVariant{});
+            QCOMPARE(model.data(model.index(5, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 6"));
+        }
+        {
+            TestSourceModel src(
+                        QStringList{"Section 1", "Section 1", "Section 1", "Section 2", "Section 2", "Section 3"},
+                        QStringList{"Title__ 1", "Title__ 2", "Title__ 3", "Title__ 4", "Title__ 5", "Title__ 6"});
+
+            SectionsDecoratorModel model;
+            model.setSourceModel(&src);
+
+
+            model.flipFolding(0);
+
+            QSignalSpy insertionSpy(&model, &SectionsDecoratorModel::rowsInserted);
+            QSignalSpy changeSpy(&model, &SectionsDecoratorModel::dataChanged);
+
+            src.insert(3, "Section 2", "New Title");
+            QCOMPARE(model.rowCount(), 7);
+            QCOMPARE(insertionSpy.count(), 1);
+
+            QCOMPARE(changeSpy.count(), 1);
+
+            auto changeArguments = changeSpy.takeFirst();
+            QCOMPARE(changeArguments.at(0).toModelIndex(), model.index(1, 0));
+            QCOMPARE(changeArguments.at(1).toModelIndex(), model.index(1, 0));
+
+            QCOMPARE(model.data(model.index(0, 0), TestSourceModel::TitleRole), QVariant{});
+            QCOMPARE(model.data(model.index(1, 0), TestSourceModel::TitleRole), QVariant{});
+            QCOMPARE(model.data(model.index(2, 0), TestSourceModel::TitleRole).toString(), QString("New Title"));
+            QCOMPARE(model.data(model.index(3, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 4"));
+            QCOMPARE(model.data(model.index(4, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 5"));
+            QCOMPARE(model.data(model.index(5, 0), TestSourceModel::TitleRole), QVariant{});
+            QCOMPARE(model.data(model.index(6, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 6"));
+        }
+        {
+            TestSourceModel src(
+                        QStringList{"Section 1", "Section 1", "Section 1", "Section 2", "Section 2", "Section 3"},
+                        QStringList{"Title__ 1", "Title__ 2", "Title__ 3", "Title__ 4", "Title__ 5", "Title__ 6"});
+
+            SectionsDecoratorModel model;
+            model.setSourceModel(&src);
+
+
+            model.flipFolding(0);
+
+            QSignalSpy insertionSpy(&model, &SectionsDecoratorModel::rowsInserted);
+            QSignalSpy changeSpy(&model, &SectionsDecoratorModel::dataChanged);
+
+            src.insert(4, "Section 2", "New Title");
+            QCOMPARE(model.rowCount(), 7);
+            QCOMPARE(insertionSpy.count(), 1);
+            QCOMPARE(changeSpy.count(), 1);
+
+            auto changeArguments = changeSpy.takeFirst();
+            QCOMPARE(changeArguments.at(0).toModelIndex(), model.index(1, 0));
+            QCOMPARE(changeArguments.at(1).toModelIndex(), model.index(1, 0));
+
+            QCOMPARE(model.data(model.index(0, 0), TestSourceModel::TitleRole), QVariant{});
+            QCOMPARE(model.data(model.index(1, 0), TestSourceModel::TitleRole), QVariant{});
+            QCOMPARE(model.data(model.index(2, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 4"));
+            QCOMPARE(model.data(model.index(3, 0), TestSourceModel::TitleRole).toString(), QString("New Title"));
+            QCOMPARE(model.data(model.index(4, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 5"));
+            QCOMPARE(model.data(model.index(5, 0), TestSourceModel::TitleRole), QVariant{});
+            QCOMPARE(model.data(model.index(6, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 6"));
+        }
+        {
+            TestSourceModel src(
+                        QStringList{"Section 1", "Section 1", "Section 1", "Section 2", "Section 2", "Section 3"},
+                        QStringList{"Title__ 1", "Title__ 2", "Title__ 3", "Title__ 4", "Title__ 5", "Title__ 6"});
+
+            SectionsDecoratorModel model;
+            model.setSourceModel(&src);
+
+            QSignalSpy insertionSpy(&model, &SectionsDecoratorModel::rowsInserted);
+            QSignalSpy changeSpy(&model, &SectionsDecoratorModel::dataChanged);
+
+            src.insert(0, "Section 0", "New Title");
+            QCOMPARE(model.rowCount(), 11);
+            QCOMPARE(insertionSpy.count(), 1);
+            QCOMPARE(changeSpy.count(), 0);
+
+            auto arguments = insertionSpy.takeFirst();
+            QCOMPARE(arguments.at(1).toInt(), 0);
+            QCOMPARE(arguments.at(2).toInt(), 1);
+
+            QCOMPARE(model.data(model.index(0, 0), TestSourceModel::TitleRole), QVariant{});
+            QCOMPARE(model.data(model.index(1, 0), TestSourceModel::TitleRole).toString(), QString("New Title"));
+            QCOMPARE(model.data(model.index(2, 0), TestSourceModel::TitleRole), QVariant{});
+            QCOMPARE(model.data(model.index(3, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 1"));
+            QCOMPARE(model.data(model.index(4, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 2"));
+            QCOMPARE(model.data(model.index(5, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 3"));
+            QCOMPARE(model.data(model.index(6, 0), TestSourceModel::TitleRole), QVariant{});
+            QCOMPARE(model.data(model.index(7, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 4"));
+            QCOMPARE(model.data(model.index(8, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 5"));
+            QCOMPARE(model.data(model.index(9, 0), TestSourceModel::TitleRole), QVariant{});
+            QCOMPARE(model.data(model.index(10, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 6"));
+        }
+        {
+            TestSourceModel src(
+                        QStringList{"Section 1", "Section 1", "Section 1", "Section 2", "Section 2", "Section 3"},
+                        QStringList{"Title__ 1", "Title__ 2", "Title__ 3", "Title__ 4", "Title__ 5", "Title__ 6"});
+
+            SectionsDecoratorModel model;
+            model.setSourceModel(&src);
+
+            QSignalSpy insertionSpy(&model, &SectionsDecoratorModel::rowsInserted);
+            QSignalSpy changeSpy(&model, &SectionsDecoratorModel::dataChanged);
+
+            src.insert(3, "Section 0", "New Title");
+            QCOMPARE(model.rowCount(), 11);
+            QCOMPARE(insertionSpy.count(), 1);
+            QCOMPARE(changeSpy.count(), 0);
+
+            auto arguments = insertionSpy.takeFirst();
+            QCOMPARE(arguments.at(1).toInt(), 4);
+            QCOMPARE(arguments.at(2).toInt(), 5);
+
+            QCOMPARE(model.data(model.index(0, 0), TestSourceModel::TitleRole), QVariant{});
+            QCOMPARE(model.data(model.index(1, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 1"));
+            QCOMPARE(model.data(model.index(2, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 2"));
+            QCOMPARE(model.data(model.index(3, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 3"));
+            QCOMPARE(model.data(model.index(4, 0), TestSourceModel::TitleRole), QVariant{});
+            QCOMPARE(model.data(model.index(5, 0), TestSourceModel::TitleRole).toString(), QString("New Title"));
+            QCOMPARE(model.data(model.index(6, 0), TestSourceModel::TitleRole), QVariant{});
+            QCOMPARE(model.data(model.index(7, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 4"));
+            QCOMPARE(model.data(model.index(8, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 5"));
+            QCOMPARE(model.data(model.index(9, 0), TestSourceModel::TitleRole), QVariant{});
+            QCOMPARE(model.data(model.index(10, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 6"));
+        }
+        {
+            TestSourceModel src(
+                        QStringList{"Section 1", "Section 1", "Section 1", "Section 2", "Section 2", "Section 3"},
+                        QStringList{"Title__ 1", "Title__ 2", "Title__ 3", "Title__ 4", "Title__ 5", "Title__ 6"});
+
+            SectionsDecoratorModel model;
+            model.setSourceModel(&src);
+
+            QSignalSpy insertionSpy(&model, &SectionsDecoratorModel::rowsInserted);
+            QSignalSpy changeSpy(&model, &SectionsDecoratorModel::dataChanged);
+
+            src.insert(6, "Section 0", "New Title");
+            QCOMPARE(model.rowCount(), 11);
+            QCOMPARE(insertionSpy.count(), 1);
+            QCOMPARE(changeSpy.count(), 0);
+
+            auto arguments = insertionSpy.takeFirst();
+            QCOMPARE(arguments.at(1).toInt(), 9);
+            QCOMPARE(arguments.at(2).toInt(), 10);
+
+            QCOMPARE(model.data(model.index(0, 0), TestSourceModel::TitleRole), QVariant{});
+            QCOMPARE(model.data(model.index(1, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 1"));
+            QCOMPARE(model.data(model.index(2, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 2"));
+            QCOMPARE(model.data(model.index(3, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 3"));
+            QCOMPARE(model.data(model.index(4, 0), TestSourceModel::TitleRole), QVariant{});
+            QCOMPARE(model.data(model.index(5, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 4"));
+            QCOMPARE(model.data(model.index(6, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 5"));
+            QCOMPARE(model.data(model.index(7, 0), TestSourceModel::TitleRole), QVariant{});
+            QCOMPARE(model.data(model.index(8, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 6"));
+            QCOMPARE(model.data(model.index(9, 0), TestSourceModel::TitleRole), QVariant{});
+            QCOMPARE(model.data(model.index(10, 0), TestSourceModel::TitleRole).toString(), QString("New Title"));
+        }
+        {
+            TestSourceModel src(
+                        QStringList{"Section 1", "Section 1", "Section 1", "Section 2", "Section 2", "Section 3"},
+                        QStringList{"Title__ 1", "Title__ 2", "Title__ 3", "Title__ 4", "Title__ 5", "Title__ 6"});
+
+            SectionsDecoratorModel model;
+            model.setSourceModel(&src);
+
+            model.flipFolding(4);
+
+            QSignalSpy insertionSpy(&model, &SectionsDecoratorModel::rowsInserted);
+            QSignalSpy changeSpy(&model, &SectionsDecoratorModel::dataChanged);
+
+            src.insert(6, "Section 0", "New Title");
+            QCOMPARE(model.rowCount(), 9);
+            QCOMPARE(insertionSpy.count(), 1);
+            QCOMPARE(changeSpy.count(), 0);
+
+            auto arguments = insertionSpy.takeFirst();
+            QCOMPARE(arguments.at(1).toInt(), 7);
+            QCOMPARE(arguments.at(2).toInt(), 8);
+
+            QCOMPARE(model.data(model.index(0, 0), TestSourceModel::TitleRole), QVariant{});
+            QCOMPARE(model.data(model.index(1, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 1"));
+            QCOMPARE(model.data(model.index(2, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 2"));
+            QCOMPARE(model.data(model.index(3, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 3"));
+            QCOMPARE(model.data(model.index(4, 0), TestSourceModel::TitleRole), QVariant{});
+            QCOMPARE(model.data(model.index(5, 0), TestSourceModel::TitleRole), QVariant{});
+            QCOMPARE(model.data(model.index(6, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 6"));
+            QCOMPARE(model.data(model.index(7, 0), TestSourceModel::TitleRole), QVariant{});
+            QCOMPARE(model.data(model.index(8, 0), TestSourceModel::TitleRole).toString(), QString("New Title"));
+        }
+    }
+
+    void removalTest() {
+        {
+            TestSourceModel src(
+                        QStringList{"Section 1", "Section 1", "Section 1", "Section 2", "Section 2", "Section 3"},
+                        QStringList{"Title__ 1", "Title__ 2", "Title__ 3", "Title__ 4", "Title__ 5", "Title__ 6"});
+
+            SectionsDecoratorModel model;
+            model.setSourceModel(&src);
+
+            QSignalSpy removalSpy(&model, &SectionsDecoratorModel::rowsRemoved);
+            QSignalSpy changeSpy(&model, &SectionsDecoratorModel::dataChanged);
+
+            src.remove(0);
+            QCOMPARE(model.rowCount(), 8);
+            QCOMPARE(removalSpy.count(), 1);
+            QCOMPARE(changeSpy.count(), 1);
+
+            auto removalArguments = removalSpy.takeFirst();
+            QCOMPARE(removalArguments.at(1).toInt(), 1);
+            QCOMPARE(removalArguments.at(2).toInt(), 1);
+
+            auto changeArguments = changeSpy.takeFirst();
+            QCOMPARE(changeArguments.at(0).toModelIndex(), model.index(0, 0));
+            QCOMPARE(changeArguments.at(1).toModelIndex(), model.index(0, 0));
+
+            QCOMPARE(model.data(model.index(0, 0), TestSourceModel::TitleRole), QVariant{});
+            QCOMPARE(model.data(model.index(1, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 2"));
+            QCOMPARE(model.data(model.index(2, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 3"));
+            QCOMPARE(model.data(model.index(3, 0), TestSourceModel::TitleRole), QVariant{});
+            QCOMPARE(model.data(model.index(4, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 4"));
+            QCOMPARE(model.data(model.index(5, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 5"));
+            QCOMPARE(model.data(model.index(6, 0), TestSourceModel::TitleRole), QVariant{});
+            QCOMPARE(model.data(model.index(7, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 6"));
+        }
+        {
+            TestSourceModel src(
+                        QStringList{"Section 1", "Section 1", "Section 1", "Section 2", "Section 2", "Section 3"},
+                        QStringList{"Title__ 1", "Title__ 2", "Title__ 3", "Title__ 4", "Title__ 5", "Title__ 6"});
+
+            SectionsDecoratorModel model;
+            model.setSourceModel(&src);
+
+            QSignalSpy removalSpy(&model, &SectionsDecoratorModel::rowsRemoved);
+            QSignalSpy changeSpy(&model, &SectionsDecoratorModel::dataChanged);
+
+            src.remove(1);
+            QCOMPARE(model.rowCount(), 8);
+            QCOMPARE(removalSpy.count(), 1);
+            QCOMPARE(changeSpy.count(), 1);
+
+            auto removalArguments = removalSpy.takeFirst();
+            QCOMPARE(removalArguments.at(1).toInt(), 2);
+            QCOMPARE(removalArguments.at(2).toInt(), 2);
+
+            auto changeArguments = changeSpy.takeFirst();
+            QCOMPARE(changeArguments.at(0).toModelIndex(), model.index(0, 0));
+            QCOMPARE(changeArguments.at(1).toModelIndex(), model.index(0, 0));
+
+            QCOMPARE(model.data(model.index(0, 0), TestSourceModel::TitleRole), QVariant{});
+            QCOMPARE(model.data(model.index(1, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 1"));
+            QCOMPARE(model.data(model.index(2, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 3"));
+            QCOMPARE(model.data(model.index(3, 0), TestSourceModel::TitleRole), QVariant{});
+            QCOMPARE(model.data(model.index(4, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 4"));
+            QCOMPARE(model.data(model.index(5, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 5"));
+            QCOMPARE(model.data(model.index(6, 0), TestSourceModel::TitleRole), QVariant{});
+            QCOMPARE(model.data(model.index(7, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 6"));
+        }
+        {
+            TestSourceModel src(
+                        QStringList{"Section 1", "Section 1", "Section 1", "Section 2", "Section 2", "Section 3"},
+                        QStringList{"Title__ 1", "Title__ 2", "Title__ 3", "Title__ 4", "Title__ 5", "Title__ 6"});
+
+            SectionsDecoratorModel model;
+            model.setSourceModel(&src);
+
+            QSignalSpy removalSpy(&model, &SectionsDecoratorModel::rowsRemoved);
+            QSignalSpy changeSpy(&model, &SectionsDecoratorModel::dataChanged);
+
+            src.remove(2);
+            QCOMPARE(model.rowCount(), 8);
+            QCOMPARE(removalSpy.count(), 1);
+            QCOMPARE(changeSpy.count(), 1);
+
+            auto removalArguments = removalSpy.takeFirst();
+            QCOMPARE(removalArguments.at(1).toInt(), 3);
+            QCOMPARE(removalArguments.at(2).toInt(), 3);
+
+            auto changeArguments = changeSpy.takeFirst();
+            QCOMPARE(changeArguments.at(0).toModelIndex(), model.index(0, 0));
+            QCOMPARE(changeArguments.at(1).toModelIndex(), model.index(0, 0));
+
+            QCOMPARE(model.data(model.index(0, 0), TestSourceModel::TitleRole), QVariant{});
+            QCOMPARE(model.data(model.index(1, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 1"));
+            QCOMPARE(model.data(model.index(2, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 2"));
+            QCOMPARE(model.data(model.index(3, 0), TestSourceModel::TitleRole), QVariant{});
+            QCOMPARE(model.data(model.index(4, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 4"));
+            QCOMPARE(model.data(model.index(5, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 5"));
+            QCOMPARE(model.data(model.index(6, 0), TestSourceModel::TitleRole), QVariant{});
+            QCOMPARE(model.data(model.index(7, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 6"));
+        }
+        {
+            TestSourceModel src(
+                        QStringList{"Section 1", "Section 1", "Section 1", "Section 2", "Section 2", "Section 3"},
+                        QStringList{"Title__ 1", "Title__ 2", "Title__ 3", "Title__ 4", "Title__ 5", "Title__ 6"});
+
+            SectionsDecoratorModel model;
+            model.setSourceModel(&src);
+
+            QSignalSpy removalSpy(&model, &SectionsDecoratorModel::rowsRemoved);
+            QSignalSpy changeSpy(&model, &SectionsDecoratorModel::dataChanged);
+
+            src.remove(5);
+            QCOMPARE(model.rowCount(), 7);
+            QCOMPARE(removalSpy.count(), 1);
+            QCOMPARE(changeSpy.count(), 0);
+
+            auto removalArguments = removalSpy.takeFirst();
+            QCOMPARE(removalArguments.at(1).toInt(), 7);
+            QCOMPARE(removalArguments.at(2).toInt(), 8);
+
+            QCOMPARE(model.data(model.index(0, 0), TestSourceModel::TitleRole), QVariant{});
+            QCOMPARE(model.data(model.index(1, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 1"));
+            QCOMPARE(model.data(model.index(2, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 2"));
+            QCOMPARE(model.data(model.index(3, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 3"));
+            QCOMPARE(model.data(model.index(4, 0), TestSourceModel::TitleRole), QVariant{});
+            QCOMPARE(model.data(model.index(5, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 4"));
+            QCOMPARE(model.data(model.index(6, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 5"));
+        }
+        {
+            TestSourceModel src(
+                        QStringList{"Section 1", "Section 1", "Section 1", "Section 2", "Section 3"},
+                        QStringList{"Title__ 1", "Title__ 2", "Title__ 3", "Title__ 4", "Title__ 5"});
+
+            SectionsDecoratorModel model;
+            model.setSourceModel(&src);
+
+            QSignalSpy removalSpy(&model, &SectionsDecoratorModel::rowsRemoved);
+            QSignalSpy changeSpy(&model, &SectionsDecoratorModel::dataChanged);
+
+            src.remove(3);
+            QCOMPARE(model.rowCount(), 6);
+            QCOMPARE(removalSpy.count(), 1);
+            QCOMPARE(changeSpy.count(), 0);
+
+            auto arguments = removalSpy.takeFirst();
+            QCOMPARE(arguments.at(1).toInt(), 4);
+            QCOMPARE(arguments.at(2).toInt(), 5);
+
+            QCOMPARE(model.data(model.index(0, 0), TestSourceModel::TitleRole), QVariant{});
+            QCOMPARE(model.data(model.index(1, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 1"));
+            QCOMPARE(model.data(model.index(2, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 2"));
+            QCOMPARE(model.data(model.index(3, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 3"));
+            QCOMPARE(model.data(model.index(4, 0), TestSourceModel::TitleRole), QVariant{});
+            QCOMPARE(model.data(model.index(5, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 5"));
+        }
+        {
+            TestSourceModel src(QStringList{"Section 1"}, QStringList{"Title__ 1"});
+
+            SectionsDecoratorModel model;
+            model.setSourceModel(&src);
+
+            QSignalSpy removalSpy(&model, &SectionsDecoratorModel::rowsRemoved);
+            QSignalSpy changeSpy(&model, &SectionsDecoratorModel::dataChanged);
+
+            src.remove(0);
+            QCOMPARE(model.rowCount(), 0);
+            QCOMPARE(removalSpy.count(), 1);
+            QCOMPARE(changeSpy.count(), 0);
+
+            auto arguments = removalSpy.takeFirst();
+            QCOMPARE(arguments.at(1).toInt(), 0);
+            QCOMPARE(arguments.at(2).toInt(), 1);
+        }
+        {
+            TestSourceModel src(
+                        QStringList{"Section 1", "Section 1", "Section 1", "Section 2", "Section 2", "Section 3"},
+                        QStringList{"Title__ 1", "Title__ 2", "Title__ 3", "Title__ 4", "Title__ 5", "Title__ 6"});
+
+            SectionsDecoratorModel model;
+            model.setSourceModel(&src);
+            model.flipFolding(0);
+
+            QSignalSpy removalSpy(&model, &SectionsDecoratorModel::rowsRemoved);
+            QSignalSpy changeSpy(&model, &SectionsDecoratorModel::dataChanged);
+
+            src.remove(0);
+            QCOMPARE(model.rowCount(), 6);
+            QCOMPARE(removalSpy.count(), 0);
+            QCOMPARE(changeSpy.count(), 1);
+
+            auto changeArguments = changeSpy.takeFirst();
+            QCOMPARE(changeArguments.at(0).toModelIndex(), model.index(0, 0));
+            QCOMPARE(changeArguments.at(1).toModelIndex(), model.index(0, 0));
+
+            QCOMPARE(model.data(model.index(0, 0), TestSourceModel::TitleRole), QVariant{});
+            QCOMPARE(model.data(model.index(1, 0), TestSourceModel::TitleRole), QVariant{});
+            QCOMPARE(model.data(model.index(2, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 4"));
+            QCOMPARE(model.data(model.index(3, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 5"));
+            QCOMPARE(model.data(model.index(4, 0), TestSourceModel::TitleRole), QVariant{});
+            QCOMPARE(model.data(model.index(5, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 6"));
+        }
+        {
+            TestSourceModel src(
+                        QStringList{"Section 1", "Section 1", "Section 1", "Section 2", "Section 2", "Section 3"},
+                        QStringList{"Title__ 1", "Title__ 2", "Title__ 3", "Title__ 4", "Title__ 5", "Title__ 6"});
+
+            SectionsDecoratorModel model;
+            model.setSourceModel(&src);
+            model.flipFolding(0);
+            model.flipFolding(1);
+            model.flipFolding(2);
+
+            QSignalSpy removalSpy(&model, &SectionsDecoratorModel::rowsRemoved);
+            QSignalSpy changeSpy(&model, &SectionsDecoratorModel::dataChanged);
+
+            src.remove(1);
+            QCOMPARE(model.rowCount(), 3);
+            QCOMPARE(removalSpy.count(), 0);
+            QCOMPARE(changeSpy.count(), 1);
+
+            auto changeArguments = changeSpy.takeFirst();
+            QCOMPARE(changeArguments.at(0).toModelIndex(), model.index(0, 0));
+            QCOMPARE(changeArguments.at(1).toModelIndex(), model.index(0, 0));
+
+            QCOMPARE(model.data(model.index(0, 0), TestSourceModel::TitleRole), QVariant{});
+            QCOMPARE(model.data(model.index(1, 0), TestSourceModel::TitleRole), QVariant{});
+            QCOMPARE(model.data(model.index(2, 0), TestSourceModel::TitleRole), QVariant{});
+        }
+        {
+            TestSourceModel src(
+                        QStringList{"Section 1", "Section 1", "Section 1", "Section 2", "Section 2", "Section 3"},
+                        QStringList{"Title__ 1", "Title__ 2", "Title__ 3", "Title__ 4", "Title__ 5", "Title__ 6"});
+
+            SectionsDecoratorModel model;
+            model.setSourceModel(&src);
+            model.flipFolding(7);
+
+            QSignalSpy removalSpy(&model, &SectionsDecoratorModel::rowsRemoved);
+            QSignalSpy changeSpy(&model, &SectionsDecoratorModel::dataChanged);
+
+            src.remove(5);
+            QCOMPARE(model.rowCount(), 7);
+            QCOMPARE(removalSpy.count(), 1);
+            QCOMPARE(changeSpy.count(), 0);
+
+            auto removalArguments = removalSpy.takeFirst();
+            QCOMPARE(removalArguments.at(1).toInt(), 7);
+            QCOMPARE(removalArguments.at(2).toInt(), 7);
+
+            QCOMPARE(model.data(model.index(0, 0), TestSourceModel::TitleRole), QVariant{});
+            QCOMPARE(model.data(model.index(1, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 1"));
+            QCOMPARE(model.data(model.index(2, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 2"));
+            QCOMPARE(model.data(model.index(3, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 3"));
+            QCOMPARE(model.data(model.index(4, 0), TestSourceModel::TitleRole), QVariant{});
+            QCOMPARE(model.data(model.index(5, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 4"));
+            QCOMPARE(model.data(model.index(6, 0), TestSourceModel::TitleRole).toString(), QString("Title__ 5"));
+        }
     }
 };
 


### PR DESCRIPTION
### What does the PR do

- watch pages directory for changes, notify add/remove and metadata change (read from the file)
- handle changes from pages model in a proxy model providing sections decoration
- add convenience button for opening pages directory

Closes: #12216
Closes: #12271

### Affected areas
`PagesModel`, `SectionsDecoratorModel`, storybook's `main.cpp`/``main.qml`

### Screenshot of functionality (including design for comparison)

[Kazam_screencast_00035.webm](https://github.com/status-im/status-desktop/assets/20650004/5f0051f6-e577-4d8f-b69b-cee82a0ae203)

