### PR TITLE
fix(backup): fix import not setting recoverAccount so backup wasn't used

### DIFF
--- a/src/app/modules/startup/internal/user_profile_confirm_password_state.nim
+++ b/src/app/modules/startup/internal/user_profile_confirm_password_state.nim
@@ -24,7 +24,7 @@ method executePrimaryCommand*(self: UserProfileConfirmPasswordState, controller:
   elif self.flowType == FlowType.FirstRunNewUserNewKeycardKeys:
     controller.storeKeycardAccountAndLogin(storeToKeychain, newKeycard = true)
   elif self.flowType == FlowType.FirstRunOldUserImportSeedPhrase:
-    controller.storeImportedAccountAndLogin(storeToKeychain)
+    controller.storeImportedAccountAndLogin(storeToKeychain, recoverAccount = true)
   elif self.flowType == FlowType.LostKeycardConvertToRegularAccount:
     controller.loginAccountKeycardUsingSeedPhrase(storeToKeychain)
 


### PR DESCRIPTION
The import process never worked correctly. It seemed like it was never fetching anything from store nodes.

Well it was a simple boolean that was missing. Without it, we ignore the backup messages when we receive messages from mailserver.