### PR TITLE
feat: enable filter full node by default

### DIFF
--- a/src/app_service/common/network_constants.nim
+++ b/src/app_service/common/network_constants.nim
@@ -397,6 +397,7 @@ var NODE_CONFIG* = %* {
     "PeerExchange": true,
     "AutoUpdate": true,
     "Rendezvous": true,
+    "EnableFilterFullNode": true,
   },
   "WalletConfig": {
     "Enabled": true,

--- a/src/app_service/service/node_configuration/dto/node_config.nim
+++ b/src/app_service/service/node_configuration/dto/node_config.nim
@@ -103,6 +103,7 @@ type
     EnableStore*: bool
     StoreCapacity*: int
     StoreSeconds*: int
+    EnableFilterFullNode*: bool
 
   ShhextConfig* = object
     PFSEnabled*: bool
@@ -328,6 +329,7 @@ proc toWaku2Config*(jsonObj: JsonNode): Waku2Config =
   discard jsonObj.getProp("EnableStore", result.EnableStore)
   discard jsonObj.getProp("StoreCapacity", result.StoreCapacity)
   discard jsonObj.getProp("StoreSeconds", result.StoreSeconds)
+  discard jsonObj.getProp("EnableFilterFullNode", result.EnableFilterFullNode)
 
 proc toWakuConfig*(jsonObj: JsonNode): WakuConfig =
   discard jsonObj.getProp("Enabled", result.Enabled)


### PR DESCRIPTION
### What does the PR do
This PR enables Filter Full Node so desktop nodes can push messages to other nodes, and this way not depend only on the status fleet

Requires:
- https://github.com/status-im/status-go/pull/4071