### PR TITLE
fix(@desktop/communities): Fix communitytokens status-go calls

### DIFF
--- a/src/backend/community_tokens.nim
+++ b/src/backend/community_tokens.nim
@@ -9,11 +9,11 @@ import interpret/cropped_image
 
 proc deployCollectibles*(chainId: int, deploymentParams: JsonNode, txData: JsonNode, password: string): RpcResponse[JsonNode] {.raises: [Exception].} =
   let payload = %* [chainId, deploymentParams, txData, utils.hashPassword(password)]
-  return core.callPrivateRPC("collectibles_deployCollectibles", payload)
+  return core.callPrivateRPC("communitytokens_deployCollectibles", payload)
 
 proc deployAssets*(chainId: int, deploymentParams: JsonNode, txData: JsonNode, password: string): RpcResponse[JsonNode] {.raises: [Exception].} =
   let payload = %* [chainId, deploymentParams, txData, utils.hashPassword(password)]
-  return core.callPrivateRPC("collectibles_deployAssets", payload)
+  return core.callPrivateRPC("communitytokens_deployAssets", payload)
 
 proc removeCommunityToken*(chainId: int, address: string): RpcResponse[JsonNode] {.raises: [Exception].} =
   let payload = %* [chainId, address]
@@ -50,52 +50,52 @@ proc updateCommunityTokenSupply*(chainId: int, contractAddress: string, supply: 
 
 proc mintTokens*(chainId: int, contractAddress: string, txData: JsonNode, password: string, walletAddresses: seq[string], amount: Uint256): RpcResponse[JsonNode] {.raises: [Exception].} =
   let payload = %* [chainId, contractAddress, txData, utils.hashPassword(password), walletAddresses, amount.toString(10)]
-  return core.callPrivateRPC("collectibles_mintTokens", payload)
+  return core.callPrivateRPC("communitytokens_mintTokens", payload)
 
 proc estimateMintTokens*(chainId: int, contractAddress: string, fromAddress: string, walletAddresses: seq[string], amount: Uint256): RpcResponse[JsonNode] {.raises: [Exception].} =
   let payload = %* [chainId, contractAddress, fromAddress, walletAddresses, amount.toString(10)]
-  return core.callPrivateRPC("collectibles_estimateMintTokens", payload)
+  return core.callPrivateRPC("communitytokens_estimateMintTokens", payload)
 
 proc remoteBurn*(chainId: int, contractAddress: string, txData: JsonNode, password: string, tokenIds: seq[UInt256]): RpcResponse[JsonNode] {.raises: [Exception].} =
   let payload = %* [chainId, contractAddress, txData, utils.hashPassword(password), tokenIds.map(x => x.toString(10))]
-  return core.callPrivateRPC("collectibles_remoteBurn", payload)
+  return core.callPrivateRPC("communitytokens_remoteBurn", payload)
 
 proc estimateRemoteBurn*(chainId: int, contractAddress: string, fromAddress: string, tokenIds: seq[UInt256]): RpcResponse[JsonNode] {.raises: [Exception].} =
   let payload = %* [chainId, contractAddress, fromAddress, tokenIds.map(x => x.toString(10))]
-  return core.callPrivateRPC("collectibles_estimateRemoteBurn", payload)
+  return core.callPrivateRPC("communitytokens_estimateRemoteBurn", payload)
 
 proc burn*(chainId: int, contractAddress: string, txData: JsonNode, password: string, amount: Uint256): RpcResponse[JsonNode] {.raises: [Exception].} =
   let payload = %* [chainId, contractAddress, txData, utils.hashPassword(password), amount.toString(10)]
-  return core.callPrivateRPC("collectibles_burn", payload)
+  return core.callPrivateRPC("communitytokens_burn", payload)
 
 proc estimateBurn*(chainId: int, contractAddress: string, fromAddress: string, amount: Uint256): RpcResponse[JsonNode] {.raises: [Exception].} =
   let payload = %* [chainId, contractAddress, fromAddress, amount.toString(10)]
-  return core.callPrivateRPC("collectibles_estimateBurn", payload)
+  return core.callPrivateRPC("communitytokens_estimateBurn", payload)
 
 proc remainingSupply*(chainId: int, contractAddress: string): RpcResponse[JsonNode] {.raises: [Exception].} =
   let payload = %* [chainId, contractAddress]
-  return core.callPrivateRPC("collectibles_remainingSupply", payload)
+  return core.callPrivateRPC("communitytokens_remainingSupply", payload)
 
 proc deployCollectiblesEstimate*(): RpcResponse[JsonNode] {.raises: [Exception].} =
   let payload = %*[]
-  return core.callPrivateRPC("collectibles_deployCollectiblesEstimate", payload)
+  return core.callPrivateRPC("communitytokens_deployCollectiblesEstimate", payload)
 
 proc deployAssetsEstimate*(): RpcResponse[JsonNode] {.raises: [Exception].} =
   let payload = %*[]
-  return core.callPrivateRPC("collectibles_deployAssetsEstimate", payload)
+  return core.callPrivateRPC("communitytokens_deployAssetsEstimate", payload)
 
 proc remoteDestructedAmount*(chainId: int, contractAddress: string): RpcResponse[JsonNode] {.raises: [Exception].} =
   let payload = %*[chainId, contractAddress]
-  return core.callPrivateRPC("collectibles_remoteDestructedAmount", payload)
+  return core.callPrivateRPC("communitytokens_remoteDestructedAmount", payload)
 
 proc deployOwnerTokenEstimate*(): RpcResponse[JsonNode] {.raises: [Exception].} =
   let payload = %*[]
-  return core.callPrivateRPC("collectibles_deployOwnerTokenEstimate", payload)
+  return core.callPrivateRPC("communitytokens_deployOwnerTokenEstimate", payload)
 
 proc deployOwnerToken*(chainId: int, ownerParams: JsonNode, masterParams: JsonNode, txData: JsonNode, password: string): RpcResponse[JsonNode] {.raises: [Exception].} =
   let payload = %*[chainId, ownerParams, masterParams, txData, utils.hashPassword(password)]
-  return core.callPrivateRPC("collectibles_deployOwnerToken", payload)
+  return core.callPrivateRPC("communitytokens_deployOwnerToken", payload)
 
 proc getMasterTokenContractAddressFromHash*(chainId: int, transactionHash: string): RpcResponse[JsonNode] {.raises: [Exception].} =
   let payload = %*[chainId, transactionHash]
-  return core.callPrivateRPC("collectibles_getMasterTokenContractAddressFromHash", payload)
+  return core.callPrivateRPC("communitytokens_getMasterTokenContractAddressFromHash", payload)


### PR DESCRIPTION
Fix wrong status-go calls.
Rename from "collectibles_" to "communitytokens_".
Fix #12270 

All names are ok in master. Probably some mismatch when merging to 0.14.