### PR TITLE
feat(CommunityOwnership): Finalise ownership UI flows

### DIFF
--- a/storybook/figma.json
+++ b/storybook/figma.json
@@ -279,5 +279,16 @@
     ],
     "UserProfileCard": [
         "https://www.figma.com/file/Mr3rqxxgKJ2zMQ06UAKiWL/💬-Chat⎜Desktop?type=design&node-id=21961-655678&mode=design&t=JiMnPfMaLPWlrFK3-0"
+    ],
+    "TransferOwnershipAlertPopup": [
+        "https://www.figma.com/file/qHfFm7C9LwtXpfdbxssCK3/Kuba%E2%8E%9CDesktop---Communities?type=design&node-id=37206%3A86828&mode=design&t=coHVo1E6fHrKNNhQ-1",
+        "https://www.figma.com/file/qHfFm7C9LwtXpfdbxssCK3/Kuba%E2%8E%9CDesktop---Communities?type=design&node-id=37206%3A86847&mode=design&t=coHVo1E6fHrKNNhQ-1"
+    ],
+    "FinaliseOwnershipPopup": [
+        "https://www.figma.com/file/qHfFm7C9LwtXpfdbxssCK3/Kuba%E2%8E%9CDesktop---Communities?type=design&node-id=37206%3A87869&mode=design&t=olSRjSKm7CM2vv5O-1",
+        "https://www.figma.com/file/qHfFm7C9LwtXpfdbxssCK3/Kuba%E2%8E%9CDesktop---Communities?type=design&node-id=37206%3A93588&mode=design&t=olSRjSKm7CM2vv5O-1"
+    ],
+    "FinaliseOwnershipDeclinePopup": [
+        "https://www.figma.com/file/qHfFm7C9LwtXpfdbxssCK3/Kuba%E2%8E%9CDesktop---Communities?type=design&node-id=37206%3A93540&mode=design&t=olSRjSKm7CM2vv5O-1"
     ]
 }

--- a/storybook/pages/FinaliseOwnershipDeclinePopupPage.qml
+++ b/storybook/pages/FinaliseOwnershipDeclinePopupPage.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.14
-import QtQuick.Controls 2.14
-import QtQuick.Layouts 1.14
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
 
 import Storybook 1.0
 import Models 1.0
@@ -40,7 +40,6 @@ SplitView {
 
                 communityName: communityNameText.text
 
-                onCancelClicked: logs.logEvent("FinaliseOwnershipDeclinePopup::onCancelClicked")
                 onDeclineClicked: logs.logEvent("FinaliseOwnershipDeclinePopup::onDeclineClicked")
             }
         }

--- a/storybook/pages/FinaliseOwnershipDeclinePopupPage.qml
+++ b/storybook/pages/FinaliseOwnershipDeclinePopupPage.qml
@@ -1,0 +1,80 @@
+import QtQuick 2.14
+import QtQuick.Controls 2.14
+import QtQuick.Layouts 1.14
+
+import Storybook 1.0
+import Models 1.0
+
+import AppLayouts.Communities.popups 1.0
+import AppLayouts.Communities.helpers 1.0
+
+SplitView {
+    Logs { id: logs }
+
+    SplitView {
+        orientation: Qt.Vertical
+        SplitView.fillWidth: true
+
+        Item {
+            SplitView.fillWidth: true
+            SplitView.fillHeight: true
+
+            PopupBackground {
+                anchors.fill: parent
+            }
+
+            Button {
+                anchors.centerIn: parent
+                text: "Reopen"
+
+                onClicked: dialog.open()
+            }
+
+            FinaliseOwnershipDeclinePopup {
+                id: dialog
+
+                anchors.centerIn: parent
+                closePolicy: Popup.NoAutoClose
+                visible: true
+                modal: false
+
+                communityName: communityNameText.text
+
+                onCancelClicked: logs.logEvent("FinaliseOwnershipDeclinePopup::onCancelClicked")
+                onDeclineClicked: logs.logEvent("FinaliseOwnershipDeclinePopup::onDeclineClicked")
+            }
+        }
+
+        LogsAndControlsPanel {
+            id: logsAndControlsPanel
+
+            SplitView.minimumHeight: 100
+            SplitView.preferredHeight: 150
+
+            logsView.logText: logs.logText
+        }
+    }
+
+    Pane {
+        SplitView.minimumWidth: 300
+        SplitView.preferredWidth: 300
+
+        Column {
+            spacing: 12
+
+            Label {
+                text: "Community Name"
+                font.bold: true
+            }
+
+            TextInput {
+                id: communityNameText
+
+                text: "Doodles"
+
+            }
+        }
+    }
+}
+
+// category: Popups

--- a/storybook/pages/FinaliseOwnershipPopupPage.qml
+++ b/storybook/pages/FinaliseOwnershipPopupPage.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.14
-import QtQuick.Controls 2.14
-import QtQuick.Layouts 1.14
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
 
 import Storybook 1.0
 import Models 1.0

--- a/storybook/pages/FinaliseOwnershipPopupPage.qml
+++ b/storybook/pages/FinaliseOwnershipPopupPage.qml
@@ -30,19 +30,44 @@ SplitView {
                 onClicked: dialog.open()
             }
 
-            TransferOwnershipAlertPopup {
+            FinaliseOwnershipPopup {
                 id: dialog
 
-                anchors.centerIn: parent                
+                anchors.centerIn: parent
                 closePolicy: Popup.NoAutoClose
                 visible: true
                 modal: false
 
                 communityName: communityNameText.text
                 communityLogo: ModelsData.collectibles.doodles
+                communityColor: color1.checked ?  "#FFC4E9" : "#f44336"
 
-                onCancelClicked: logs.logEvent("TransferOwnershipAlertPopup::onCancelClicked")
-                onMintClicked: logs.logEvent("TransferOwnershipAlertPopup::onMintClicked")
+                tokenSymbol: communitySymbolText.text
+                tokenChainName: tokenChainText.text
+
+                accounts: ListModel {
+                    ListElement {
+                        name: "Test account"
+                        emoji: "😋"
+                        address: "0x7F47C2e18a4BBf5487E6fb082eC2D9Ab0E6d7240"
+                        color: "red"
+                    }
+                    ListElement {
+                        name: "Another account - generated"
+                        emoji: "🚗"
+                        address: "0x7F47C2e98a4BBf5487E6fb082eC2D9Ab0E6d8888"
+                        color: "blue"
+                    }
+                }
+
+                feeText: !feesErrorChecker.checked ? "13.34 USD (0.0072 ETH)" : ""
+                isFeeLoading: feesLoadingChecker.checked
+                feeErrorText: feesErrorChecker.checked ? "Error getting fees" : ""
+
+                onRejectClicked: logs.logEvent("FinaliseOwnershipPopup::onRejectClicked")
+                onFinaliseOwnershipClicked: logs.logEvent("FinaliseOwnershipPopup::onFinaliseOwnershipClicked")
+                onVisitCommunityClicked: logs.logEvent("FinaliseOwnershipPopup::onVisitCommunityClicked")
+                onOpenControlNodeDocClicked: logs.logEvent("FinaliseOwnershipPopup::onOpenControlNodeDocClicked --> " + link)
             }
         }
 
@@ -73,6 +98,28 @@ SplitView {
 
                 text: "Doodles"
 
+            }
+
+            Label {
+                text: "Community Symbol"
+                font.bold: true
+            }
+
+            TextInput {
+                id: communitySymbolText
+
+                text: "OWNDOO"
+            }
+
+            Label {
+                text: "Token chain name"
+                font.bold: true
+            }
+
+            TextInput {
+                id: tokenChainText
+
+                text: "Optimism"
             }
 
             Label {
@@ -109,28 +156,40 @@ SplitView {
             }
 
             Label {
-                text: "Mode"
+                text: "Community Color"
                 font.bold: true
             }
 
-            Column {
-
+            RowLayout {
                 RadioButton {
-                    id: transferMode
+                    id: color1
 
-                    text: "Transfer Ownership"
+                    text: "Light pink"
                     checked: true
-
-                    onCheckedChanged: dialog.mode = TransferOwnershipAlertPopup.Mode.TransferOwnership
                 }
 
                 RadioButton {
-                    id: moveNodeMode
-
-                    text: "Move Control Node"
-
-                    onCheckedChanged: dialog.mode = TransferOwnershipAlertPopup.Mode.MoveControlNode
+                    text: "Orange"
                 }
+            }
+
+            Label {
+                text: "Fees"
+                font.bold: true
+            }
+
+            Switch {
+                id: feesErrorChecker
+
+                text: "Is there fees error?"
+                checked: false
+            }
+
+            Switch {
+                id: feesLoadingChecker
+
+                text: "Is fees loading?"
+                checked: false
             }
         }
     }

--- a/storybook/pages/OverviewSettingsFooterPage.qml
+++ b/storybook/pages/OverviewSettingsFooterPage.qml
@@ -6,19 +6,44 @@ import AppLayouts.Communities.panels 1.0
 
 import utils 1.0
 
+import Storybook 1.0
+
 SplitView {
     id: root
 
-    Item {
-        id: wrapper
+    Logs { id: logs }
+
+    SplitView {
+        orientation: Qt.Vertical
         SplitView.fillWidth: true
-        SplitView.fillHeight: true
-        OverviewSettingsFooter {
-            id: footer
-            width: parent.width
-            anchors.centerIn: parent
-            isControlNode: controlNodeSwitch.checked
-            communityName: "Socks"
+        Item {
+            id: wrapper
+            SplitView.fillWidth: true
+            SplitView.fillHeight: true
+
+            OverviewSettingsFooter {
+                id: footer
+                width: parent.width
+                anchors.centerIn: parent
+                isControlNode: controlNodeSwitch.checked
+                isPendingOwnershipRequest: pendingOwnershipSwitch.checked
+                communityName: "Socks"
+                communityColor: "orange"
+
+                onExportControlNodeClicked: logs.logEvent("OverviewSettingsFooter::onExportControlNodeClicked")
+                onImportControlNodeClicked: logs.logEvent("OverviewSettingsFooter::onImportControlNodeClicked")
+                onLearnMoreClicked: logs.logEvent("OverviewSettingsFooter::onLearnMoreClicked")
+                onFinaliseOwnershipTransferClicked: logs.logEvent("OverviewSettingsFooter::onFinaliseOwnershipTransferClicked")
+            }
+        }
+
+        LogsAndControlsPanel {
+            id: logsAndControlsPanel
+
+            SplitView.minimumHeight: 100
+            SplitView.preferredHeight: 150
+
+            logsView.logText: logs.logText
         }
     }
     
@@ -30,6 +55,12 @@ SplitView {
             Switch {
                 id: controlNodeSwitch
                 text: "Control node on/off"
+                checked: true
+            }
+
+            Switch {
+                id: pendingOwnershipSwitch
+                text: "Is there a pending transfer ownership request?"
                 checked: true
             }
         }

--- a/storybook/pages/OverviewSettingsPanelPage.qml
+++ b/storybook/pages/OverviewSettingsPanelPage.qml
@@ -24,15 +24,26 @@ SplitView {
 
         communityShardingEnabled: communityEditor.shardingEnabled
         communityShardIndex: communityEditor.shardIndex
+        
+        isPendingOwnershipRequest: pendingOwnershipSwitch.checked
+        finaliseOwnershipTransferPopup: undefined
     }
 
     Pane {
         SplitView.minimumWidth: 300
         SplitView.preferredWidth: 300
 
-        CommunityInfoEditor {
-            id: communityEditor
-            anchors.fill: parent
+        ColumnLayout {
+            CommunityInfoEditor{
+                id: communityEditor
+                anchors.fill: parent
+            }
+
+            Switch {
+                id: pendingOwnershipSwitch
+                text: "Is there a pending transfer ownership request?"
+                checked: true
+            }
         }
     }
 }

--- a/ui/app/AppLayouts/Chat/views/ChatView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatView.qml
@@ -74,6 +74,10 @@ StatusSectionLayout {
         return false
     }
 
+    // Community transfer ownership related props:
+    required property var finaliseOwnershipTransferPopup
+    required property bool isPendingOwnershipRequest
+
     signal communityInfoButtonClicked()
     signal communityManageButtonClicked()
     signal profileButtonClicked()
@@ -242,6 +246,8 @@ StatusSectionLayout {
             communitiesStore: root.communitiesStore
             emojiPopup: root.emojiPopup
             hasAddedContacts: root.hasAddedContacts
+            finaliseOwnershipTransferPopup: root.finaliseOwnershipTransferPopup
+            isPendingOwnershipRequest: root.isPendingOwnershipRequest
             onInfoButtonClicked: root.communityInfoButtonClicked()
             onManageButtonClicked: root.communityManageButtonClicked()
         }

--- a/ui/app/AppLayouts/Communities/controls/FeesBoxFooter.qml
+++ b/ui/app/AppLayouts/Communities/controls/FeesBoxFooter.qml
@@ -21,6 +21,8 @@ Control {
 
     property alias accountErrorText: accountErrorText.text
 
+    required property string accountSelectorText
+
     component Separator: Rectangle {
         Layout.fillWidth: true
         Layout.preferredHeight: 1
@@ -73,7 +75,7 @@ Control {
             Layout.fillWidth: true
 
             visible: accountSelector.visible
-            text: qsTr("Select account to pay gas fees from")
+            text: root.accountSelectorText
             color: Theme.palette.baseColor1
             font.pixelSize: Theme.primaryTextFontSize
             lineHeight: 1.2

--- a/ui/app/AppLayouts/Communities/helpers/SingleFeeSubscriber.qml
+++ b/ui/app/AppLayouts/Communities/helpers/SingleFeeSubscriber.qml
@@ -6,11 +6,12 @@ import utils 1.0
 /*!
     \qmltype SingleFeeSubscriber
     \inherits QtObject
-    \brief Helper object that parses fees response and provides fee text and error text for single fee respnse
+    \brief Helper object that parses fees response and provides fee text and error text for single fee response
 */
 
  QtObject {
     id: root
+
     // Published properties
     property var feesResponse
 

--- a/ui/app/AppLayouts/Communities/helpers/TransactionFeesBroker.qml
+++ b/ui/app/AppLayouts/Communities/helpers/TransactionFeesBroker.qml
@@ -112,6 +112,7 @@ QtObject {
             function onDeployFeeUpdated(ethCurrency, fiatCurrency, errorCode, responseId) {
                 d.feesBroker.response(responseId, { ethCurrency: ethCurrency, fiatCurrency: fiatCurrency, errorCode: errorCode })
             }
+
             function onAirdropFeeUpdated(response) {
                 d.feesBroker.response(response.requestId, response)
             }

--- a/ui/app/AppLayouts/Communities/panels/FeesBox.qml
+++ b/ui/app/AppLayouts/Communities/panels/FeesBox.qml
@@ -30,6 +30,8 @@ StatusGroupBox {
     property alias generalErrorText: footer.generalErrorText
     property alias accountErrorText: footer.accountErrorText
 
+    property string accountSelectorText: qsTr("Select account to pay gas fees from")
+
     FeesPanel {
         id: feesBox
 
@@ -50,6 +52,7 @@ StatusGroupBox {
                      || root.generalErrorText)
 
             showTotal: feesBox.count > 1
+            accountSelectorText: root.accountSelectorText
         }
     }
 }

--- a/ui/app/AppLayouts/Communities/panels/OverviewSettingsFooter.qml
+++ b/ui/app/AppLayouts/Communities/panels/OverviewSettingsFooter.qml
@@ -12,12 +12,18 @@ import utils 1.0
 
 Control {
     id: root
-    property bool isControlNode: true
+
+    property bool isControlNode: true   
     property string communityName: ""
+    property string communityColor: ""
+
+    // Community transfer ownership related props:
+    required property bool isPendingOwnershipRequest
 
     signal exportControlNodeClicked
     signal importControlNodeClicked
     signal learnMoreClicked
+    signal finaliseOwnershipTransferClicked
 
     QtObject {
         id: d
@@ -31,6 +37,7 @@ Control {
         property string secondaryButtonText
         property string indicatorBgColor
         property string indicatorColor
+        property string indicatorName
         property var primaryButtonAction: root.exportControlNodeClicked
     }
 
@@ -45,7 +52,7 @@ Control {
             Layout.column: 0
             color: d.indicatorBgColor
             asset.color: d.indicatorColor
-            asset.name: "desktop"
+            asset.name: d.indicatorName
         }
 
         ColumnLayout {
@@ -104,24 +111,37 @@ Control {
     // Behavior
     states: [
         State {
+            name: "isPendingOwnershipRequest"
+            when: root.isPendingOwnershipRequest
+            PropertyChanges { target: d; indicatorBgColor: Theme.palette.alphaColor(root.communityColor, 0.1) }
+            PropertyChanges { target: d; indicatorColor: root.communityColor }
+            PropertyChanges { target: d; paragraphTitle: qsTr("Finalise your ownership of the %1 Community").arg(root.communityName) }
+            PropertyChanges { target: d; paragraphSubtitle: qsTr("You currently hodl the Owner token for %1. Make your device the control node to finalise ownership.").arg(root.communityName) }
+            PropertyChanges { target: d; primaryButtonText: qsTr("Finalise %1 ownership").arg(root.communityName) }
+            PropertyChanges { target: d; primaryButtonAction: root.finaliseOwnershipTransferClicked }
+            PropertyChanges { target: d; indicatorName: "crown" }
+        },
+        State {
             name: "isControlNode"
-            when: root.isControlNode
+            when: root.isControlNode && !root.isPendingOwnershipRequest
             PropertyChanges { target: d; indicatorBgColor: Theme.palette.successColor2 }
             PropertyChanges { target: d; indicatorColor: Theme.palette.successColor1 }
             PropertyChanges { target: d; paragraphTitle: qsTr("This device is currently the control node for the %1 Community").arg(root.communityName) }
             PropertyChanges { target: d; paragraphSubtitle: qsTr("For your Community to function correctly keep this device online with Status running as much as possible.") }
             PropertyChanges { target: d; primaryButtonText: qsTr("How to move control node") }
             PropertyChanges { target: d; primaryButtonAction: root.exportControlNodeClicked }
+            PropertyChanges { target: d; indicatorName: "desktop" }
         },
         State {
             name: "isNotControlNode"
-            when: !root.isControlNode
+            when: !root.isControlNode && !root.isPendingOwnershipRequest
             PropertyChanges { target: d; indicatorBgColor: Theme.palette.primaryColor3 }
             PropertyChanges { target: d; indicatorColor: Theme.palette.primaryColor1 }
             PropertyChanges { target: d; paragraphTitle: qsTr("Make this device the control node for the %1 Community").arg(root.communityName) }
             PropertyChanges { target: d; paragraphSubtitle: qsTr("Ensure this is a device you can keep online with Status running.") }
             PropertyChanges { target: d; primaryButtonText: qsTr("Make this device the control node") }
             PropertyChanges { target: d; primaryButtonAction: root.importControlNodeClicked }
+            PropertyChanges { target: d; indicatorName: "desktop" }
         }
     ]
 }

--- a/ui/app/AppLayouts/Communities/panels/OverviewSettingsPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/OverviewSettingsPanel.qml
@@ -52,6 +52,10 @@ StackLayout {
 
     property bool communityShardingEnabled
     property int communityShardIndex: -1
+    
+    // Community transfer ownership related props:
+    required property var finaliseOwnershipTransferPopup
+    required property bool isPendingOwnershipRequest
 
     function navigateBack() {
         if (editSettingsPanelLoader.item.dirty)
@@ -176,13 +180,17 @@ StackLayout {
 
     Component {
         id: overviewSettingsFooterComp
+
         OverviewSettingsFooter {
             rightPadding: 64
             leftPadding: 64
             bottomPadding: 64
             topPadding: 0
             communityName: root.name
+            communityColor: root.color
             isControlNode: root.isControlNode
+            isPendingOwnershipRequest: root.isPendingOwnershipRequest
+
             onExportControlNodeClicked:{
                 if(!!root.ownerToken && root.ownerToken.deployState === Constants.ContractTransactionStatus.Completed) {
                     root.exportControlNodeClicked()
@@ -191,6 +199,7 @@ StackLayout {
                 }
             }
             onImportControlNodeClicked: root.importControlNodeClicked()
+            onFinaliseOwnershipTransferClicked: Global.openPopup(root.finaliseOwnershipTransferPopup)
             //TODO update once the domain changes
             onLearnMoreClicked: Global.openLink(Constants.statusHelpLinkPrefix + "status-communities/about-the-control-node-in-status-communities")
         }

--- a/ui/app/AppLayouts/Communities/popups/FinaliseOwnershipDeclinePopup.qml
+++ b/ui/app/AppLayouts/Communities/popups/FinaliseOwnershipDeclinePopup.qml
@@ -20,15 +20,11 @@ StatusDialog {
 
     width: 480 // by design
     padding: Style.current.padding
+    title: qsTr("Are you sure you don’t want to be the owner?")
     contentItem: StatusBaseText {
         wrapMode: Text.WrapAtWordBoundaryOrAnywhere
         text: qsTr("If you don’t want to be the owner of the %1 Community it is important that you let the previous owner know so they can organise another owner to take over. You will have to send the Owner token back to them or on to the next designated owner.").arg(root.communityName)
         lineHeight: 1.2
-    }
-
-    header: StatusDialogHeader {
-        headline.title: qsTr("Are you sure you don’t want to be the owner?")
-        actions.closeButton.onClicked: root.close()
     }
 
     footer: StatusDialogFooter {
@@ -37,10 +33,7 @@ StatusDialog {
             StatusFlatButton {
                 text: qsTr("Cancel")
 
-                onClicked: {
-                    root.cancelClicked()
-                    close()
-                }
+                onClicked: close()
             }
 
             StatusButton {

--- a/ui/app/AppLayouts/Communities/popups/FinaliseOwnershipDeclinePopup.qml
+++ b/ui/app/AppLayouts/Communities/popups/FinaliseOwnershipDeclinePopup.qml
@@ -1,0 +1,57 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQml.Models 2.15
+
+import StatusQ.Core 0.1
+import StatusQ.Controls 0.1
+import StatusQ.Popups.Dialog 0.1
+import StatusQ.Core.Theme 0.1
+
+import utils 1.0
+
+StatusDialog {
+    id: root
+
+    // Community related props:
+    required property string communityName
+
+    signal cancelClicked
+    signal declineClicked
+
+    width: 480 // by design
+    padding: Style.current.padding
+    contentItem: StatusBaseText {
+        wrapMode: Text.WrapAtWordBoundaryOrAnywhere
+        text: qsTr("If you don’t want to be the owner of the %1 Community it is important that you let the previous owner know so they can organise another owner to take over. You will have to send the Owner token back to them or on to the next designated owner.").arg(root.communityName)
+        lineHeight: 1.2
+    }
+
+    header: StatusDialogHeader {
+        headline.title: qsTr("Are you sure you don’t want to be the owner?")
+        actions.closeButton.onClicked: root.close()
+    }
+
+    footer: StatusDialogFooter {
+        spacing: Style.current.padding
+        rightButtons: ObjectModel {
+            StatusFlatButton {
+                text: qsTr("Cancel")
+
+                onClicked: {
+                    root.cancelClicked()
+                    close()
+                }
+            }
+
+            StatusButton {
+                text: qsTr("I don't want to be the owner")
+                type: StatusBaseButton.Type.Danger
+
+                onClicked: {
+                    root.declineClicked()
+                    close()
+                }
+            }
+        }
+    }
+}

--- a/ui/app/AppLayouts/Communities/popups/FinaliseOwnershipPopup.qml
+++ b/ui/app/AppLayouts/Communities/popups/FinaliseOwnershipPopup.qml
@@ -43,7 +43,7 @@ StatusDialog {
     QtObject {
         id: d
 
-        readonly property string controlNodeLink: "https://help.status.im/en/status-communities/about-the-control-node-in-status-communities/"
+        readonly property string controlNodeLink: Constants.statusHelpLinkPrefix + "status-communities/about-the-control-node-in-status-communities/"
         readonly property int init: 0
         readonly property int finalise: 1
 
@@ -149,8 +149,6 @@ StatusDialog {
 
             StatusButton {
                 id: acceptBtn
-
-                type: StatusBaseButton.Type.Normal
             }
         }
         leftButtons: ObjectModel {
@@ -171,7 +169,7 @@ StatusDialog {
 
             CustomText {
                 textFormat: Text.RichText
-                text: qsTr("To finalise your ownership and assume ultimate admin rights for the %1 Community, you need to make your device the Community's <a style=\"color: inherit;\" href=\"%2\">control node</a><a style=\"color: inherit;text-decoration: none\" href=\"%2\">↗</a>. You will also need to sign a small transaction to update the %1 Community smart contract to make you the official signatory for all Community changes.").arg(root.communityName).arg(d.controlNodeLink)
+                text: qsTr("To finalise your ownership and assume ultimate admin rights for the %1 Community, you need to make your device the Community's <a style=\"color:%3;\" href=\"%2\">control node</a><a style=\"color:%3;text-decoration: none\" href=\"%2\">↗</a>. You will also need to sign a small transaction to update the %1 Community smart contract to make you the official signatory for all Community changes.").arg(root.communityName).arg(d.controlNodeLink).arg(color)
 
                 onLinkActivated: root.openControlNodeDocClicked(link)
             }
@@ -196,6 +194,7 @@ StatusDialog {
 
                 radius: 8
                 border.color: Theme.palette.baseColor2
+                color: "transparent"
 
                 ColumnLayout {
                     id: boxContent

--- a/ui/app/AppLayouts/Communities/popups/FinaliseOwnershipPopup.qml
+++ b/ui/app/AppLayouts/Communities/popups/FinaliseOwnershipPopup.qml
@@ -1,0 +1,335 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQml.Models 2.15
+import QtQuick.Layouts 1.15
+
+import StatusQ.Core 0.1
+import StatusQ.Controls 0.1
+import StatusQ.Popups.Dialog 0.1
+import StatusQ.Components 0.1
+import StatusQ.Core.Theme 0.1
+import StatusQ.Core.Utils 0.1
+
+import AppLayouts.Communities.panels 1.0
+
+import utils 1.0
+
+StatusDialog {
+    id: root
+
+    // Community related props:
+    required property string communityName
+    required property string communityLogo
+    required property string communityColor
+
+    // Owner token related props:
+    required property string tokenSymbol
+    required property string tokenChainName
+
+    // Fees calculation props:
+    property string feeText
+    property string feeErrorText
+    property bool isFeeLoading
+    property string feeLabel: qsTr("Update %1 Community smart contract on %2").arg(root.communityName).arg(root.tokenChainName)
+
+    // Account expected roles: address, name, color, emoji, walletType
+    property var accounts
+
+    signal finaliseOwnershipClicked
+    signal rejectClicked
+    signal visitCommunityClicked
+    signal openControlNodeDocClicked(string link)
+
+    QtObject {
+        id: d
+
+        readonly property string controlNodeLink: "https://help.status.im/en/status-communities/about-the-control-node-in-status-communities/"
+        readonly property int init: 0
+        readonly property int finalise: 1
+
+        property bool ackCheck: false
+
+        // Fees related props:
+        property string accountAddress: ""
+        property string accountName: ""
+    }
+
+    width: 640 // by design
+    padding: 0
+
+    component CustomText : StatusBaseText {
+        Layout.fillWidth: true
+
+        wrapMode: Text.WrapAtWordBoundaryOrAnywhere
+        lineHeight: 1.2
+    }
+
+    contentItem: StatusScrollView {
+        id: scrollView
+
+        contentWidth: availableWidth
+        contentHeight: loader.item.height
+
+        padding: Style.current.padding
+
+        Loader {
+            id: loader
+
+            width: scrollView.availableWidth
+            sourceComponent: initialPanel
+            state: d.init
+            states: [
+                State {
+                    name: d.init
+
+                    PropertyChanges { target: loader; sourceComponent: initialPanel }
+                    PropertyChanges {
+                        target: acceptBtn
+                        text: qsTr("Finalise %1 ownership").arg(root.communityName)
+                        enabled: true
+
+                        onClicked: loader.state = d.finalise
+                    }
+                    PropertyChanges {
+                        target: rejectBtn
+                        visible: true
+
+                        onClicked: root.rejectClicked()
+                    }
+                    PropertyChanges { target: backButton; visible: false }
+                },
+                State {
+                    name: d.finalise
+
+                    PropertyChanges { target: loader; sourceComponent: finalisePanel }
+                    PropertyChanges {
+                        target: acceptBtn
+                        text: qsTr("Make this device the control node and update smart contract")
+                        enabled: d.ackCheck && !root.isFeeLoading && root.feeErrorText === ""
+
+                        onClicked: {
+                            root.finaliseOwnershipClicked()
+                            close()
+                        }
+                    }
+                    PropertyChanges { target: rejectBtn; visible: false }
+                    PropertyChanges {
+                        target: backButton
+                        visible: true
+
+                        onClicked: loader.state = d.init
+                    }
+                }
+            ]
+        }
+    }
+
+    header: StatusDialogHeader {
+        headline.title: qsTr("Finalise %1 ownership").arg(root.communityName)
+        actions.closeButton.onClicked: root.close()
+        leftComponent: StatusSmartIdenticon {
+            asset.name: root.communityLogo
+            asset.isImage: !!asset.name
+        }
+    }
+
+    footer: StatusDialogFooter {
+        spacing: Style.current.padding
+        rightButtons: ObjectModel {
+            StatusFlatButton {
+                id: rejectBtn
+
+                text: qsTr("I don't want to be the owner")
+
+                onClicked: {
+                    root.rejectClicked()
+                    close()
+                }
+            }
+
+            StatusButton {
+                id: acceptBtn
+
+                type: StatusBaseButton.Type.Normal
+            }
+        }
+        leftButtons: ObjectModel {
+            StatusBackButton { id: backButton }
+        }
+    }
+
+    Component {
+        id: initialPanel
+
+        ColumnLayout {
+            spacing: Style.current.padding
+
+            CustomText {
+                text: qsTr("Congratulations! You have been sent the %1 Community Owner token.").arg(root.communityName)
+                font.bold: true
+            }
+
+            CustomText {
+                textFormat: Text.RichText
+                text: qsTr("To finalise your ownership and assume ultimate admin rights for the %1 Community, you need to make your device the Community's <a style=\"color: inherit;\" href=\"%2\">control node</a><a style=\"color: inherit;text-decoration: none\" href=\"%2\">↗</a>. You will also need to sign a small transaction to update the %1 Community smart contract to make you the official signatory for all Community changes.").arg(root.communityName).arg(d.controlNodeLink)
+
+                onLinkActivated: root.openControlNodeDocClicked(link)
+            }
+
+            PrivilegedTokenArtworkPanel {
+                id: tokenPanel
+
+                Layout.alignment: Qt.AlignHCenter
+                Layout.topMargin: Style.current.padding
+
+                isOwner: true
+                artwork: root.communityLogo
+                color: root.communityColor
+                size: PrivilegedTokenArtworkPanel.Size.Large
+            }
+
+            Rectangle {
+                Layout.alignment: Qt.AlignHCenter
+                Layout.preferredWidth: tokenPanel.width
+                Layout.preferredHeight: boxContent.implicitHeight + Style.current.padding
+                Layout.bottomMargin: Style.current.padding
+
+                radius: 8
+                border.color: Theme.palette.baseColor2
+
+                ColumnLayout {
+                    id: boxContent
+
+                    anchors.verticalCenter: parent.verticalCenter
+                    spacing: 2
+
+                    StatusBaseText {
+                        Layout.leftMargin: Style.current.padding
+
+                        text: qsTr("Symbol")
+                        elide: Text.ElideRight
+                        font.pixelSize: Style.current.additionalTextSize
+                        color: Theme.palette.baseColor1
+                    }
+
+                    StatusBaseText {
+                        Layout.leftMargin: Style.current.padding
+
+                        text: root.tokenSymbol
+                        elide: Text.ElideRight
+                        font.pixelSize: Theme.primaryTextFontSize
+                        color: Theme.palette.directColor1
+                    }
+                }
+            }
+
+            StatusListItem {
+                Layout.fillWidth: true
+                Layout.bottomMargin: Style.current.padding
+
+                title: root.communityName
+                border.color: Theme.palette.baseColor2
+                asset.name: root.communityLogo
+                asset.isImage: true
+                asset.isLetterIdenticon: !asset.name
+                components: [
+                    RowLayout {
+                        StatusIcon {
+                            Layout.alignment: Qt.AlignVCenter
+
+                            icon: "arrow-right"
+                            color: Theme.palette.primaryColor1
+                        }
+
+                        StatusBaseText {
+                            Layout.alignment: Qt.AlignVCenter
+                            Layout.rightMargin: Style.current.padding
+
+                            text: qsTr("Visit Community")
+                            font.pixelSize: Style.current.additionalTextSize
+                            color: Theme.palette.primaryColor1
+                        }
+                    }
+                ]
+
+                onClicked: {
+                    close()
+                    root.visitCommunityClicked()
+                }
+            }
+        }
+    }
+
+    Component {
+        id: finalisePanel
+
+        ColumnLayout {
+            spacing: Style.current.padding
+
+            CustomText {
+                text: qsTr("Finalising your ownership of the %1 Community requires you to:").arg(root.communityName)
+            }
+
+            CustomText {
+                text: qsTr("1. Make this device the control node for the Community")
+                font.bold: true
+            }
+
+            CustomText {
+                Layout.topMargin: -Style.current.halfPadding
+
+                text: qsTr("It is vital to keep your device online and running Status in order for the Community to operate effectively. Login with this account via another synced desktop device if you think it might be better suited for this purpose.")
+            }
+
+            CustomText {
+                text: qsTr("2. Update the %1 Community smart contract").arg(root.communityName)
+                font.bold: true
+            }
+
+            CustomText {
+                Layout.topMargin: -Style.current.halfPadding
+
+                text: qsTr("This transaction updates the %1 Community smart contract, making you the %1 Community owner.").arg(root.communityName)
+            }
+
+            FeesBox {
+                Layout.fillWidth: true
+
+                implicitWidth: 0
+
+                accountsSelector.model: root.accounts
+                accountErrorText: root.feeErrorText
+                accountSelectorText: qsTr("Gas fees will be paid from")
+
+                model: QtObject {
+                    id: singleFeeModel
+
+                    readonly property string title: root.feeLabel
+                    readonly property string feeText: root.isFeeLoading ? "" : root.feeText
+                    readonly property bool error: root.feeErrorText !== ""
+                }
+
+                accountsSelector.onCurrentIndexChanged: {
+                    if (accountsSelector.currentIndex < 0)
+                        return
+
+                    const item = ModelUtils.get(accountsSelector.model,
+                                                accountsSelector.currentIndex)
+                    d.accountAddress = item.address
+                    d.accountName = item.name
+                }
+            }
+
+            StatusCheckBox {
+                Layout.topMargin: -Style.current.halfPadding
+                Layout.fillWidth: true
+
+                checked: d.ackCheck
+                font.pixelSize: Style.current.primaryTextFontSize
+                text: qsTr("I acknowledge that I must keep this device online and running Status as much of the time as possible for the %1 Community to operate effectively").arg(root.communityName)
+
+                onCheckStateChanged: d.ackCheck = checked
+            }
+        }
+    }
+}

--- a/ui/app/AppLayouts/Communities/popups/qmldir
+++ b/ui/app/AppLayouts/Communities/popups/qmldir
@@ -7,6 +7,8 @@ CreateCommunityPopup 1.0 CreateCommunityPopup.qml
 DiscordImportProgressDialog 1.0 DiscordImportProgressDialog.qml
 EnableShardingPopup 1.0 EnableShardingPopup.qml
 ExportControlNodePopup 1.0 ExportControlNodePopup.qml
+FinaliseOwnershipDeclinePopup 1.0 FinaliseOwnershipDeclinePopup.qml
+FinaliseOwnershipPopup 1.0 FinaliseOwnershipPopup.qml
 HoldingsDropdown 1.0 HoldingsDropdown.qml
 ImportControlNodePopup 1.0 ImportControlNodePopup.qml
 InDropdown 1.0 InDropdown.qml

--- a/ui/app/AppLayouts/Communities/views/CommunitySettingsView.qml
+++ b/ui/app/AppLayouts/Communities/views/CommunitySettingsView.qml
@@ -44,6 +44,10 @@ StatusSectionLayout {
     readonly property bool isTokenMasterOwner: community.memberRole === Constants.memberRole.tokenMaster
     readonly property bool isControlNode: community.isControlNode
 
+    // Community transfer ownership related props:
+    required property var finaliseOwnershipTransferPopup
+    required property bool isPendingOwnershipRequest
+
     readonly property string filteredSelectedTags: {
         let tagsArray = []
         if (community && community.tags) {
@@ -186,6 +190,9 @@ StatusSectionLayout {
             sendModalPopup: root.sendModalPopup
             tokensModel: root.community.communityTokens
             accounts: root.walletAccountsModel
+
+            finaliseOwnershipTransferPopup: root.finaliseOwnershipTransferPopup
+            isPendingOwnershipRequest: root.isPendingOwnershipRequest
 
             onCollectCommunityMetricsMessagesCount: {
                 rootStore.collectCommunityMetricsMessagesCount(intervals)

--- a/ui/imports/shared/stores/CommunityTokensStore.qml
+++ b/ui/imports/shared/stores/CommunityTokensStore.qml
@@ -60,6 +60,10 @@ QtObject {
         communityTokensModuleInst.removeCommunityToken(communityId, parts[0], parts[1])
     }
 
+    function updateSmartContract(communityId, collectibleItem) {
+        console.warn("TODO: Backend to update smart contract and finalise community transfer ownership! The token owner is: " + collectibleItem.symbol)
+    }
+
     readonly property Connections connections: Connections {
         target: communityTokensModuleInst
 


### PR DESCRIPTION
Closes #12174 

### What does the PR do
- Created finalise popup and added it into storybook.
- Decline popup created and added support in storybook.
- Itegration of the finalise flow in the app from: community column button and from community overview footer button.
- Updated storybook pages (settings overview related) according to new components requirements.

**NOTE: Only UI, backend not ready. Navigation from activity center not covered (missing backend).**

### Affected areas

Community Column / Community Overview

### Screenshot of functionality 

- App:

https://github.com/status-im/status-desktop/assets/97019400/56053dec-3d61-4d67-afff-7558f8d7d94c

- Storybook:

https://github.com/status-im/status-desktop/assets/97019400/ab124bc0-2709-483a-ab1e-1fdae4b3c6cc

https://github.com/status-im/status-desktop/assets/97019400/ac1b397d-e3d2-4355-a09c-a513a8263bd3


