### PR TITLE
fix(@desktop/wallet): Wallet: Send a multi tx, the notification for the 2nd transfer is not visible

### DIFF
--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -423,6 +423,10 @@ proc connectForNotificationsOnly[T](self: Module[T]) =
       kpName = args.keypairs[0].name
     self.view.showToastKeypairsImported(kpName, args.keypairs.len, args.error)
 
+  self.events.on(SIGNAL_TRANSACTION_SENT) do(e:Args):
+    let args = TransactionSentArgs(e)
+    self.view.showToastTransactionSent(args.chainId, args.txHash, args.uuid, args.error)
+
 method load*[T](
   self: Module[T],
   events: EventEmitter,

--- a/src/app/modules/main/view.nim
+++ b/src/app/modules/main/view.nim
@@ -296,6 +296,7 @@ QtObject:
   proc showIncludeWatchOnlyAccountUpdated*(self: View, includeWatchOnly: bool) {.signal.}
   proc showToastKeypairRemoved*(self: View, keypairName: string) {.signal.}
   proc showToastKeypairsImported*(self: View, keypairName: string, keypairsCount: int, error: string) {.signal.}
+  proc showToastTransactionSent*(self: View, chainId: int, txHash: string, uuid: string, error: string) {.signal.}
 
   ## Used in test env only, for testing keycard flows
   proc registerMockedKeycard*(self: View, cardIndex: int, readerState: int, keycardState: int,

--- a/src/app/modules/main/wallet_section/send/network_model.nim
+++ b/src/app/modules/main/wallet_section/send/network_model.nim
@@ -1,4 +1,4 @@
-import NimQml, Tables, strutils, strformat, sequtils, sugar, json
+import NimQml, Tables, strutils, strformat, sequtils, sugar, json, stint
 
 import app/modules/shared_models/currency_amount
 import ./network_item, ./suggested_route_item
@@ -181,7 +181,7 @@ QtObject:
         let index = self.createIndex(i, 0, nil)
         defer: index.delete
         if self.items[i].getAmountOut().len != 0:
-          self.items[i].amountOut = $(parseInt(self.items[i].getAmountOut()) + parseInt(path.getAmountOut()))
+          self.items[i].amountOut = $(stint.u256(self.items[i].getAmountOut()) + stint.u256(path.getAmountOut()))
         else:
           self.items[i].amountOut = path.getAmountOut()
         self.dataChanged(index, index, @[ModelRole.AmountOut.int])

--- a/ui/app/AppLayouts/stores/RootStore.qml
+++ b/ui/app/AppLayouts/stores/RootStore.qml
@@ -167,8 +167,8 @@ QtObject {
 
     property var allNetworks: networksModule.all
 
-    function getEtherscanLink() {
-        return profileSectionModule.ensUsernamesModule.getEtherscanLink()
+    function getEtherscanLink(chainID) {
+        return allNetworks.getBlockExplorerURL(chainID)
     }
 
     function createCommunity(communityName, communityDescription, checkedMembership, communityColor, communityTags,

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -180,6 +180,17 @@ Item {
                 ""
             )
         }
+
+        function onShowToastTransactionSent(chainId: int, txHash: string, uuid: string, error: string) {
+            if (!error) {
+                Global.displayToastMessage(qsTr("Transaction pending..."),
+                                           qsTr("View on etherscan"),
+                                           "",
+                                           true,
+                                           Constants.ephemeralNotificationType.normal,
+                                           "%1/%2".arg(appMain.rootStore.getEtherscanLink(chainId)).arg(txHash))
+            }
+        }
     }
 
     QtObject {

--- a/ui/imports/shared/popups/send/SendModal.qml
+++ b/ui/imports/shared/popups/send/SendModal.qml
@@ -510,13 +510,6 @@ StatusDialog {
                 sendingError.text = error
                 return sendingError.open()
             }
-            let url =  "%1/%2".arg(popup.store.getEtherscanLink(chainId)).arg(txHash)
-            Global.displayToastMessage(qsTr("Transaction pending..."),
-                                       qsTr("View on etherscan"),
-                                       "",
-                                       true,
-                                       Constants.ephemeralNotificationType.normal,
-                                       url)
             popup.close()
         }
     }


### PR DESCRIPTION
fix(@desktop/wallet): Wallet: Send a multi tx, the notification for the 2nd transfer is not visible

fixes #12242

### What does the PR do

in case 2 transactions were made to complete a send, the 2nd tx would not show up as an ephemeral toast because the sendModal was closed after the first notification was shown.

Hence iv moved the logic of showing the toast via the AppMain.qml instead

### Affected areas

SendModal

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

https://github.com/status-im/status-desktop/assets/60327365/54025ad2-5163-414f-a35c-a8635f6d59f0

