### PR TITLE
fix(@deaktop/wallet): fixes below issues in sendModal:

### DIFF
--- a/ui/imports/shared/popups/send/controls/TokenBalancePerChainDelegate.qml
+++ b/ui/imports/shared/popups/send/controls/TokenBalancePerChainDelegate.qml
@@ -78,6 +78,7 @@ StatusListItem {
         id: expandedItem
         StatusListItemTag {
             height: 16
+            leftPadding: 0
             title: LocaleUtils.currencyAmountToLocaleString(balance)
             titleText.font.pixelSize: 12
             closeButtonVisible: false

--- a/ui/imports/shared/popups/send/panels/HoldingItemSelector.qml
+++ b/ui/imports/shared/popups/send/panels/HoldingItemSelector.qml
@@ -127,7 +127,7 @@ Item {
                 Layout.preferredHeight: 16
                 icon: "chevron-down"
                 color: Theme.palette.miscColor1
-                visible: d.isItemSelected
+                visible: !!root.selectedItem
             }
         }
 


### PR DESCRIPTION
1. A dropdown arrow should not be visible in the context of selecting token
2. Unnecessary padding added when expanding balances in the send modal popup

fixes #12254,#12256

### What does the PR do

Read above.

### Affected areas

SendModal

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it


https://github.com/status-im/status-desktop/assets/60327365/aa98d9f9-955c-4a67-85c5-2e72813075ad


