### PR TITLE
chore(@keycard makefile): extend condition to accept env variable as true and 1 values

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -394,7 +394,9 @@ export STATUSKEYCARDGO_LIBDIR
 
 STATUSKEYCARDGO_RULE := build-lib
 ifeq ($(TEST_ENVIRONMENT),true)
-	STATUSKEYCARDGO_RULE := build-mocked-lib
+    STATUSKEYCARDGO_RULE := build-mocked-lib
+else ifeq ($(TEST_ENVIRONMENT),1)
+    STATUSKEYCARDGO_RULE := build-mocked-lib
 endif
 
 status-keycard-go: $(STATUSKEYCARDGO)


### PR DESCRIPTION

### What does the PR do

Accept `true` and `1` as values for TEST_ENVIRONMENT variable for keycard mock lib

### Affected areas

Keycard mock lib