### PR TITLE
fix(@desktop/communities): Catch all exceptions

### DIFF
--- a/src/app_service/service/community_tokens/async_tasks.nim
+++ b/src/app_service/service/community_tokens/async_tasks.nim
@@ -265,15 +265,22 @@ const getCommunityTokensDetailsTaskArg: Task = proc(argEncoded: string) {.gcsafe
 
     proc createTokenItemJson(communityTokens: seq[CommunityTokenDto], tokenDto: CommunityTokenDto): JsonNode =
       try:
-        let remainingSupply = if tokenDto.infiniteSupply:
-            "0"
-          else:
-            getRemainingSupply(tokenDto.chainId, tokenDto.address)
+        var remainingSupply = tokenDto.supply.toString(10)
+        var burnState = ContractTransactionStatus.Completed
+        var remoteDestructedAddresses: seq[string] = @[]
+        var destructedAmount = "0"
 
-        let burnState = getCommunityTokenBurnState(tokenDto.chainId, tokenDto.address)
-        let remoteDestructedAddresses = getRemoteDestructedAddresses(tokenDto.chainId, tokenDto.address)
+        if tokenDto.deployState == DeployState.Deployed:
+          remainingSupply =
+            if tokenDto.infiniteSupply:
+              "0"
+            else:
+              getRemainingSupply(tokenDto.chainId, tokenDto.address)
+
+          burnState = getCommunityTokenBurnState(tokenDto.chainId, tokenDto.address)
+          remoteDestructedAddresses = getRemoteDestructedAddresses(tokenDto.chainId, tokenDto.address)
         
-        let destructedAmount = getRemoteDestructedAmount(communityTokens, tokenDto.chainId, tokenDto.address)
+          destructedAmount = getRemoteDestructedAmount(communityTokens, tokenDto.chainId, tokenDto.address)
 
         return %* {
           "address": tokenDto.address,

--- a/src/app_service/service/community_tokens/service.nim
+++ b/src/app_service/service/community_tokens/service.nim
@@ -502,7 +502,7 @@ QtObject:
           communityTokens: communityTokens,
           communityTokenJsonItems: communityTokenJsonItems,
         ))
-    except RpcException as e:
+    except Exception as e:
       error "Error getting community tokens details", message = e.msg
 
   proc removeCommunityToken*(self: Service, communityId: string, chainId: int, address: string) =


### PR DESCRIPTION
Fix #12315

Crash was caught during application startup.
Some exceptions were of different type than RpcException and were not caught.
