### PR TITLE
fix(messenger_contacts): Add toast notification when removing a contact

### DIFF
--- a/src/app/core/notifications/details.nim
+++ b/src/app/core/notifications/details.nim
@@ -10,6 +10,7 @@ type
     TestNotification,
     NewContactRequest,
     AcceptedContactRequest,
+    ContactRemoved,
     JoinCommunityRequest,
     MyRequestToJoinCommunityAccepted,
     MyRequestToJoinCommunityRejected,

--- a/src/app/core/notifications/notifications_manager.nim
+++ b/src/app/core/notifications/notifications_manager.nim
@@ -75,6 +75,10 @@ QtObject:
       self, "onShowMessageNotification(QString, QString, QString, bool, bool, QString, bool, QString, int, bool, bool)", 2)
     signalConnect(singletonInstance.globalEvents, "showNewContactRequestNotification(QString, QString, QString)", 
       self, "onShowNewContactRequestNotification(QString, QString, QString)", 2)
+    signalConnect(singletonInstance.globalEvents, "showAcceptedContactRequest(QString, QString, QString)",
+      self, "onShowAcceptedContactRequest(QString, QString, QString)", 2)
+    signalConnect(singletonInstance.globalEvents, "showContactRemoved(QString, QString, QString)",
+      self, "onShowContactRemoved(QString, QString, QString)", 2)
     signalConnect(singletonInstance.globalEvents, "newCommunityMembershipRequestNotification(QString, QString, QString)", 
       self, "onNewCommunityMembershipRequestNotification(QString, QString, QString)", 2)
     signalConnect(singletonInstance.globalEvents, "myRequestToJoinCommunityAcccepted(QString, QString, QString)", 
@@ -83,8 +87,6 @@ QtObject:
       self, "onMyRequestToJoinCommunityRejected(QString, QString, QString)", 2)
     signalConnect(singletonInstance.globalEvents, "meMentionedIconBadgeNotification(int)",
       self, "onMeMentionedIconBadgeNotification(int)", 2)
-    signalConnect(singletonInstance.globalEvents, "showAcceptedContactRequest(QString, QString, QString)", 
-      self, "onShowAcceptedContactRequest(QString, QString, QString)", 2)
     signalConnect(singletonInstance.globalEvents, "showCommunityTokenPermissionCreatedNotification(QString, QString, QString)", self, "onShowCommunityTokenPermissionCreatedNotification(QString, QString, QString)", 2)
     signalConnect(singletonInstance.globalEvents, "showCommunityTokenPermissionUpdatedNotification(QString, QString, QString)", self, "onShowCommunityTokenPermissionUpdatedNotification(QString, QString, QString)", 2)
     signalConnect(singletonInstance.globalEvents, "showCommunityTokenPermissionDeletedNotification(QString, QString, QString)", self, "onShowCommunityTokenPermissionDeletedNotification(QString, QString, QString)", 2)
@@ -180,6 +182,11 @@ QtObject:
     let details = NotificationDetails(notificationType: NotificationType.AcceptedContactRequest, sectionId: sectionId)
     self.processNotification(title, message, details)
 
+  proc onShowContactRemoved*(self: NotificationsManager, title: string, message: string,
+    sectionId: string) {.slot.} =
+    let details = NotificationDetails(notificationType: NotificationType.ContactRemoved, sectionId: sectionId)
+    self.processNotification(title, message, details)
+
   proc onNewCommunityMembershipRequestNotification*(self: NotificationsManager, title: string, message: string, 
     sectionId: string) {.slot.} =
     let details = NotificationDetails(notificationType: NotificationType.JoinCommunityRequest, sectionId: sectionId)
@@ -217,6 +224,7 @@ QtObject:
       details.notificationType == NotificationType.NewMessageWithPersonalMention or
       details.notificationType == NotificationType.NewMessageWithGlobalMention or
       details.notificationType == NotificationType.NewContactRequest or 
+      details.notificationType == NotificationType.ContactRemoved or
       details.notificationType == NotificationType.IdentityVerificationRequest):
 
       if(notificationWay == VALUE_NOTIF_DELIVER_QUIETLY):
@@ -335,7 +343,7 @@ QtObject:
             self.notificationCheck(title, message, details, self.settingsService.getNotifSettingGroupChats())
             return
 
-    # In all other cases (TestNotification, AcceptedContactRequest, JoinCommunityRequest,  MyRequestToJoinCommunityAccepted,
+    # In all other cases (TestNotification, AcceptedContactRequest, ContactRemoved, JoinCommunityRequest,  MyRequestToJoinCommunityAccepted,
     # MyRequestToJoinCommunityRejected)
     else:
       self.notificationCheck(title, message, details, "")

--- a/src/app/global/global_events.nim
+++ b/src/app/global/global_events.nim
@@ -31,8 +31,14 @@ QtObject:
     isCommunitySection: bool, isSectionActive: bool, chatId: string, isChatActive: bool, messageId: string, 
     notificationType: int, isOneToOne: bool, isGroupChat: bool) {.signal.}
   
-  proc showNewContactRequestNotification*(self: GlobalEvents, title: string, message: string, sectionId: string) 
-    {.signal.}
+  proc showNewContactRequestNotification*(self: GlobalEvents, title: string, message: string,
+    sectionId: string) {.signal.}
+
+  proc showAcceptedContactRequest*(self: GlobalEvents, title: string, message: string,
+    sectionId: string) {.signal.}
+
+  proc showContactRemoved*(self: GlobalEvents, title: string, message: string,
+    sectionId: string) {.signal.}
   
   proc newCommunityMembershipRequestNotification*(self: GlobalEvents, title: string, message: string, 
     sectionId: string) {.signal.}
@@ -41,9 +47,6 @@ QtObject:
     sectionId: string) {.signal.}
 
   proc myRequestToJoinCommunityRejected*(self: GlobalEvents, title: string, message: string, 
-    sectionId: string) {.signal.}
-
-  proc showAcceptedContactRequest*(self: GlobalEvents, title: string, message: string, 
     sectionId: string) {.signal.}
 
   proc meMentionedIconBadgeNotification*(self: GlobalEvents, allMentions: int) {.signal.}

--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -1013,10 +1013,9 @@ method onNewMessagesReceived*(self: Module, sectionIdMsgBelongsTo: string, chatI
   let messageBelongsToActiveChat = self.controller.getActiveChatId() == chatIdMsgBelongsTo
 
   singletonInstance.globalEvents.showMessageNotification(notificationTitle, plainText, sectionIdMsgBelongsTo,
-
-  self.controller.isCommunity(), messageBelongsToActiveSection, chatIdMsgBelongsTo, messageBelongsToActiveChat,
-  message.id, notificationType.int, chatTypeMsgBelongsTo == ChatType.OneToOne,
-  chatTypeMsgBelongsTo == ChatType.PrivateGroupChat)
+    self.controller.isCommunity(), messageBelongsToActiveSection, chatIdMsgBelongsTo, messageBelongsToActiveChat,
+    message.id, notificationType.int, chatTypeMsgBelongsTo == ChatType.OneToOne,
+    chatTypeMsgBelongsTo == ChatType.PrivateGroupChat)
 
 method addGroupMembers*(self: Module, chatId: string, pubKeys: string) =
   self.controller.addGroupMembers(chatId, self.convertPubKeysToJson(pubKeys))

--- a/src/app/modules/main/chat_section/module.nim
+++ b/src/app/modules/main/chat_section/module.nim
@@ -1013,9 +1013,10 @@ method onNewMessagesReceived*(self: Module, sectionIdMsgBelongsTo: string, chatI
   let messageBelongsToActiveChat = self.controller.getActiveChatId() == chatIdMsgBelongsTo
 
   singletonInstance.globalEvents.showMessageNotification(notificationTitle, plainText, sectionIdMsgBelongsTo,
-    self.controller.isCommunity(), messageBelongsToActiveSection, chatIdMsgBelongsTo, messageBelongsToActiveChat,
-    message.id, notificationType.int, chatTypeMsgBelongsTo == ChatType.OneToOne,
-    chatTypeMsgBelongsTo == ChatType.PrivateGroupChat)
+
+  self.controller.isCommunity(), messageBelongsToActiveSection, chatIdMsgBelongsTo, messageBelongsToActiveChat,
+  message.id, notificationType.int, chatTypeMsgBelongsTo == ChatType.OneToOne,
+  chatTypeMsgBelongsTo == ChatType.PrivateGroupChat)
 
 method addGroupMembers*(self: Module, chatId: string, pubKeys: string) =
   self.controller.addGroupMembers(chatId, self.convertPubKeysToJson(pubKeys))

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -1191,7 +1191,8 @@ method displayEphemeralNotification*[T](self: Module[T], title: string, subTitle
     self.displayEphemeralNotification(title, subTitle, "", false, EphemeralNotificationType.Default.int, "", details)
 
   elif(details.notificationType == NotificationType.NewContactRequest or
-    details.notificationType == NotificationType.IdentityVerificationRequest):
+    details.notificationType == NotificationType.IdentityVerificationRequest or
+    details.notificationType == NotificationType.ContactRemoved):
     self.displayEphemeralNotification(title, subTitle, "contact", false, EphemeralNotificationType.Default.int, "", details)
 
   elif(details.notificationType == NotificationType.AcceptedContactRequest):

--- a/src/app_service/service/contacts/service.nim
+++ b/src/app_service/service/contacts/service.nim
@@ -450,6 +450,7 @@ QtObject:
       if self.contacts[publicKey].dto.added and not self.contacts[publicKey].dto.removed and contact.added and not contact.removed:
         signal = SIGNAL_CONTACT_UPDATED
     if contact.removed:
+      singletonInstance.globalEvents.showContactRemoved("Contact removed", fmt "You removed {contact.displayName} as a contact", contact.id)
       signal = SIGNAL_CONTACT_REMOVED
 
     self.contacts[publicKey] = self.constructContactDetails(contact)


### PR DESCRIPTION
# What

Show a toast notification when a contact is removed by the user. This is in addition to the system message displayed in the message view.

# Demo

<img width="843" alt="SCR-20231002-lcfq-3" src="https://github.com/status-im/status-desktop/assets/544446/3e92140a-c72c-4abe-94bb-7de791959796">


Fixes #10497