### PR TITLE
chore(@EditNetworkForm.qml): add object names to main input objects

### DIFF
--- a/ui/app/AppLayouts/Profile/views/wallet/EditNetworkForm.qml
+++ b/ui/app/AppLayouts/Profile/views/wallet/EditNetworkForm.qml
@@ -167,6 +167,7 @@ ColumnLayout {
         }
         StatusInput {
             id: mainRpcInput
+            objectName: "mainRpcInputObject"
             input.edit.objectName: "editNetworkMainRpcInput"
             width: parent.width
             label: qsTr("Main JSON RPC URL")
@@ -209,6 +210,7 @@ ColumnLayout {
 
     StatusInput {
         id: failoverRpcUrlInput
+        objectName: "failoverRpcUrlInputObject"
         input.edit.objectName: "editNetworkFailoverRpcUrlInput"
         Layout.fillWidth: true
         label: qsTr("Failover JSON RPC URL")


### PR DESCRIPTION
### What does the PR do

I need to access main input object so i can grab the error messages later on

![image](https://github.com/status-im/status-desktop/assets/82375995/5f366709-25c7-46e5-9bbc-ade57e03bbf2)


### Affected areas

`ui/app/AppLayouts/Profile/views/wallet/EditNetworkForm.qml`