### PR TITLE
fix(@desktop/wallet): Replaced watched-only with watched address/addresses text

### DIFF
--- a/ui/app/AppLayouts/Onboarding/views/ProfileFetchingView.qml
+++ b/ui/app/AppLayouts/Onboarding/views/ProfileFetchingView.qml
@@ -95,7 +95,7 @@ Item {
                         case Constants.onboarding.profileFetching.entity.keypairs:
                             return qsTr("Keypairs")
                         case Constants.onboarding.profileFetching.entity.watchOnlyAccounts:
-                            return qsTr("Watch-only accounts")
+                            return qsTr("Watched addresses")
                         }
                     }
                 }

--- a/ui/app/AppLayouts/Profile/controls/WalletAccountDetailsKeypairItem.qml
+++ b/ui/app/AppLayouts/Profile/controls/WalletAccountDetailsKeypairItem.qml
@@ -14,7 +14,7 @@ StatusListItem {
 
     signal buttonClicked()
 
-    title: !!root.keyPair? root.keyPair.pairType === Constants.keypair.type.watchOnly ? qsTr("Watch only") : root.keyPair.name: ""
+    title: !!root.keyPair? root.keyPair.pairType === Constants.keypair.type.watchOnly ? qsTr("Watched address") : root.keyPair.name: ""
     titleAsideText: !!root.keyPair && root.keyPair.pairType === Constants.keypair.type.profile? Utils.getElidedCompressedPk(root.keyPair.pubKey): ""
     asset {
         width: !!root.keyPair && root.keyPair.icon? Style.current.bigPadding : 40

--- a/ui/app/AppLayouts/Wallet/panels/WalletHeader.qml
+++ b/ui/app/AppLayouts/Wallet/panels/WalletHeader.qml
@@ -96,7 +96,7 @@ Item {
 
                 font.weight: Font.Normal
                 textColor: Theme.palette.baseColor1
-                text: overview.includeWatchOnly ? qsTr("Hide watch-only"): qsTr("Show watch-only")
+                text: overview.includeWatchOnly ? qsTr("Hide watched addresses"): qsTr("Show watched addresses")
 
                 icon.name: overview.includeWatchOnly ? "hide" : "show"
                 icon.height: 16

--- a/ui/app/AppLayouts/Wallet/views/AccountContextMenu.qml
+++ b/ui/app/AppLayouts/Wallet/views/AccountContextMenu.qml
@@ -65,7 +65,7 @@ StatusMenu {
 
     StatusAction {
         objectName: "AccountMenu-AddWatchOnlyAccountAction-%1".arg(root.uniqueIdentifier)
-        text: qsTr("Add watch-only account")
+        text: qsTr("Add watched address")
         enabled: !root.account
         icon.name: "show"
         onTriggered: {

--- a/ui/imports/utils/Utils.qml
+++ b/ui/imports/utils/Utils.qml
@@ -655,9 +655,9 @@ QtObject {
         case Constants.appTranslatableConstants.loginAccountsListLostKeycard:
             return qsTr("Lost Keycard")
         case Constants.appTranslatableConstants.addAccountLabelNewWatchOnlyAccount:
-            return qsTr("New watch-only account")
+            return qsTr("New watched address")
         case Constants.appTranslatableConstants.addAccountLabelWatchOnlyAccount:
-            return qsTr("Watch-only account")
+            return qsTr("Watched address")
         case Constants.appTranslatableConstants.addAccountLabelExisting:
             return qsTr("Existing")
         case Constants.appTranslatableConstants.addAccountLabelImportNew:
@@ -665,7 +665,7 @@ QtObject {
         case Constants.appTranslatableConstants.addAccountLabelOptionAddNewMasterKey:
             return qsTr("Add new master key")
         case Constants.appTranslatableConstants.addAccountLabelOptionAddWatchOnlyAcc:
-            return qsTr("Add watch-only account")
+            return qsTr("Add watched address")
         }
 
         // special handling because on an index attached to the constant


### PR DESCRIPTION

### What does the PR do

fix(@desktop/wallet): Replaced watched-only with watched address/addresses text as per 2nd point in https://github.com/status-im/status-desktop/issues/11675
 
### Affected areas

Walet Settings and Wallet view where we use watch-only keywords
### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it