### PR TITLE
fix(wallet) forever loading balances

### DIFF
--- a/src/app_service/service/wallet_account/dto/balance_dto.nim
+++ b/src/app_service/service/wallet_account/dto/balance_dto.nim
@@ -22,7 +22,12 @@ proc getCurrencyBalance*(self: BalanceDto, currencyPrice: float64): float64 =
 
 proc toBalanceDto*(jsonObj: JsonNode): BalanceDto =
   result = BalanceDto()
-  result.rawBalance = jsonObj{"rawBalance"}.getStr.parse(Uint256)
+
+  # Expecting "<nil>" values comming from status-go when the entry is nil
+  let rawBalanceStr = jsonObj{"rawBalance"}.getStr
+  if not rawBalanceStr.contains("nil"):
+    result.rawBalance = rawBalanceStr.parse(Uint256)
+
   result.balance = jsonObj{"balance"}.getStr.parseFloat()
   discard jsonObj.getProp("address", result.address)
   discard jsonObj.getProp("chainId", result.chainId)


### PR DESCRIPTION
### Closes: #12330

Accept the balances to be "nil" in the BalanceDTO.

In some corner-cases, the balances are returned with rawBalance as `<nil>` which can't be parsed as a valid `Int256`;
This side-effect was introduced with this change: https://github.com/status-im/status-go/pull/4030

`<nil>` is not a valid JSON value, so this is still a workaround.