### PR TITLE
fix: process community info requests fails

### DIFF
--- a/src/app/modules/main/communities/controller.nim
+++ b/src/app/modules/main/communities/controller.nim
@@ -85,7 +85,7 @@ proc init*(self: Controller) =
 
   self.events.on(SIGNAL_COMMUNITY_LOAD_DATA_FAILED) do(e: Args):
     let args = CommunityArgs(e)
-    self.delegate.onImportCommunityErrorOccured(args.community.id, args.error)
+    self.delegate.onImportCommunityErrorOccured(args.communityId, args.error)
 
   self.events.on(SIGNAL_COMMUNITY_INFO_ALREADY_REQUESTED) do(e: Args):
     self.delegate.communityInfoAlreadyRequested()

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -308,7 +308,6 @@ Item {
         target: appMain.communitiesStore
 
         function onImportingCommunityStateChanged(communityId, state, errorMsg) {
-            const community = appMain.communitiesStore.getCommunityDetailsAsJson(communityId)
             let title = ""
             let subTitle = ""
             let loading = false
@@ -318,6 +317,7 @@ Item {
             switch (state)
             {
             case Constants.communityImported:
+                const community = appMain.communitiesStore.getCommunityDetailsAsJson(communityId)
                 if(community.isControlNode) {
                     title = qsTr("This device is now the control node for the %1 Community").arg(community.name)
                     notificationType = Constants.ephemeralNotificationType.success
@@ -331,7 +331,7 @@ Item {
                 loading = true
                 break
             case Constants.communityImportingError:
-                title = qsTr("Failed to import community '%1'").arg(community.name)
+                title = qsTr("Failed to import community '%1'").arg(communityId)
                 subTitle = errorMsg
                 break
             default:


### PR DESCRIPTION
Related to https://github.com/status-im/status-go/pull/4110

### What does the PR do

1. Fix error signalling in `asyncCommunityInfoLoaded`
This allows you to try again!
2. Add `communityId` argument to fails, because `community` is empty
3. In `onImportingCommunityStateChanged` only get community data in success case
