### PR TITLE
feat: Add settings card to control link previews settings in chat input

### DIFF
--- a/src/app/modules/main/chat_section/chat_content/input_area/io_interface.nim
+++ b/src/app/modules/main/chat_section/chat_content/input_area/io_interface.nim
@@ -111,5 +111,17 @@ method clearLinkPreviewCache*(self: AccessInterface) {.base.} =
 method linkPreviewsFromCache*(self: AccessInterface, urls: seq[string]): Table[string, LinkPreview] {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method reloadLinkPreview*(self: AccessInterface, url: string) {.base.} =
+method loadLinkPreviews*(self: AccessInterface, urls: seq[string]) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method getLinkPreviewEnabled*(self: AccessInterface): bool =
+  raise newException(ValueError, "No implementation available")
+
+method setLinkPreviewEnabled*(self: AccessInterface, enabled: bool) =
+  raise newException(ValueError, "No implementation available")
+
+method setAskToEnableLinkPreview*(self: AccessInterface, value: bool) =
+  raise newException(ValueError, "No implementation available")
+
+method setLinkPreviewEnabledForThisMessage*(self: AccessInterface, enabled: bool) =
   raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/chat_section/chat_content/input_area/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/input_area/module.nim
@@ -167,5 +167,17 @@ method setUrls*(self: Module, urls: seq[string]) =
 method linkPreviewsFromCache*(self: Module, urls: seq[string]): Table[string, LinkPreview] =
   return self.controller.linkPreviewsFromCache(urls)
 
-method reloadLinkPreview*(self: Module, url: string) =
-  self.controller.reloadLinkPreview(url)
+method loadLinkPreviews*(self: Module, urls: seq[string]) =
+  self.controller.loadLinkPreviews(urls)
+
+method getLinkPreviewEnabled*(self: Module): bool =
+  return self.controller.getLinkPreviewEnabled()
+
+method setLinkPreviewEnabled*(self: Module, enabled: bool) =
+  self.controller.setLinkPreviewEnabled(enabled)
+
+method setAskToEnableLinkPreview*(self: Module, value: bool) =
+  self.view.setAskToEnableLinkPreview(value)
+
+method setLinkPreviewEnabledForThisMessage*(self: Module, value: bool) =
+  self.controller.setLinkPreviewEnabledForThisMessage(value)

--- a/src/app/modules/main/chat_section/chat_content/input_area/preserved_properties.nim
+++ b/src/app/modules/main/chat_section/chat_content/input_area/preserved_properties.nim
@@ -56,3 +56,4 @@ QtObject:
     read = getFileUrlsAndSourcesJson
     write = setFileUrlsAndSourcesJson
     notify = fileUrlsAndSourcesJsonChanged
+

--- a/src/app/modules/shared_models/link_preview_model.nim
+++ b/src/app/modules/shared_models/link_preview_model.nim
@@ -213,8 +213,17 @@ QtObject:
     defer: modelIndex.delete
     self.dataChanged(modelIndex, modelIndex)
 
+  proc removeAllPreviewData*(self: Model) {.slot.} =
+    for i in 0 ..< self.items.len:
+      self.removePreviewData(i)
+      
   proc getUnfuledLinkPreviews*(self: Model): seq[LinkPreview] =
     result = @[]
     for item in self.items:
       if item.unfurled and item.linkPreview.hostName != "":
         result.add(item.linkPreview)
+
+  proc getLinks*(self: Model): seq[string] =
+    result = @[]
+    for item in self.items:
+      result.add(item.linkPreview.url)

--- a/storybook/pages/ChatInputLinksPreviewAreaPage.qml
+++ b/storybook/pages/ChatInputLinksPreviewAreaPage.qml
@@ -1,24 +1,81 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
 import QtGraphicalEffects 1.15
+
+import Storybook 1.0
 
 import StatusQ.Core.Theme 0.1
 import shared.controls.chat 1.0
 
-Page {
-    Rectangle {
-        id: wrapper
-        anchors.fill: parent
-        color: Theme.palette.statusChatInput.secondaryBackgroundColor
+SplitView {
 
-        ChatInputLinksPreviewArea {
-            id: chatInputLinkPreviewsArea
-            anchors.centerIn: parent
-            width: parent.width
-            imagePreviewModel: ["https://picsum.photos/200/300?random=1", "https://picsum.photos/200/300?random=1"]
-            linkPreviewModel: linkPreviewListModel
-            onLinkRemoved: linkPreviewListModel.remove(index)
+    Logs { id: logs }
+    orientation: Qt.Vertical
+
+    SplitView {
+
+        SplitView.fillWidth: true
+        SplitView.fillHeight: true
+
+        Pane {
+            SplitView.fillWidth: true
+            Rectangle {
+                id: wrapper
+                anchors.fill: parent
+                color: Theme.palette.statusChatInput.secondaryBackgroundColor
+
+                ChatInputLinksPreviewArea {
+                    id: chatInputLinkPreviewsArea
+                    anchors.centerIn: parent
+                    width: parent.width
+                    imagePreviewArray: ["https://picsum.photos/200/300?random=1", "https://picsum.photos/200/300?random=1"]
+                    linkPreviewModel: showLinkPreviewSettings ? emptyModel : linkPreviewListModel
+                    showLinkPreviewSettings: !linkPreviewEnabledSwitch.checked
+                    visible: hasContent
+
+                    onImageRemoved: (index) =>  logs.logEvent("ChatInputLinksPreviewArea::onImageRemoved: " + index)
+                    onImageClicked: (chatImage) => logs.logEvent("ChatInputLinksPreviewArea::onImageClicked: " + chatImage)
+                    onLinkReload: (link) => logs.logEvent("ChatInputLinksPreviewArea::onLinkReload: " + link)
+                    onLinkClicked: (link) => logs.logEvent("ChatInputLinksPreviewArea::onLinkClicked: " + link)
+
+                    onEnableLinkPreview: () => {
+                                         linkPreviewEnabledSwitch.checked = true
+                                         logs.logEvent("ChatInputLinksPreviewArea::onEnableLinkPreview")
+                                        }
+                    onEnableLinkPreviewForThisMessage: () => logs.logEvent("ChatInputLinksPreviewArea::onEnableLinkPreviewForThisMessage")
+                    onDisableLinkPreview: () => logs.logEvent("ChatInputLinksPreviewArea::onDisableLinkPreview")
+                    onDismissLinkPreviewSettings: () => logs.logEvent("ChatInputLinksPreviewArea::onDismissLinkPreviewSettings")
+                    onDismissLinkPreview: (index) => logs.logEvent("ChatInputLinksPreviewArea::onDismissLinkPreview: " + index)
+                }
+            }
         }
+
+        Pane {
+            SplitView.preferredWidth: 300
+            SplitView.fillHeight: true
+            ColumnLayout {
+                Label {
+                    text: "Links preview enabled"
+                }
+                Switch {
+                    id: linkPreviewEnabledSwitch
+                }
+            }
+        }
+    }
+
+    LogsAndControlsPanel {
+        id: logsAndControlsPanel
+
+        SplitView.minimumHeight: 100
+        SplitView.preferredHeight: 200
+
+        logsView.logText: logs.logText
+    }
+
+    ListModel {
+        id: emptyModel
     }
 
     ListModel {

--- a/storybook/pages/LinkPreviewSettingsCardPage.qml
+++ b/storybook/pages/LinkPreviewSettingsCardPage.qml
@@ -1,0 +1,30 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+import StatusQ.Core.Theme 0.1
+
+import shared.controls.chat 1.0
+
+Pane {
+    id: root
+
+    layer.enabled: true
+    layer.samples: 4
+    background: Rectangle {
+        color: Theme.palette.statusChatInput.secondaryBackgroundColor
+    }
+
+    LinkPreviewSettingsCard {
+        id: previewMiniCard
+        anchors.centerIn: parent
+        onDismiss: ToolTip.show(qsTr("Link previews disabled for this message"), 1000)
+        onEnableLinkPreviewForThisMessage: ToolTip.show(qsTr("Link previews enabled for this message"), 1000)
+        onEnableLinkPreview: ToolTip.show(qsTr("Link previews enabled"), 1000)
+        onDisableLinkPreview: ToolTip.show(qsTr("Link previews disabled"), 1000)
+    }
+}
+
+
+//category: Controls
+
+//https://www.figma.com/file/Mr3rqxxgKJ2zMQ06UAKiWL/💬-Chat⎜Desktop?type=design&node-id=22341-184809&mode=design&t=91pnQgUZAqFJLcqM-0

--- a/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
@@ -130,17 +130,17 @@ Item {
             chatInput.validateImagesAndShowImageArea(filesList)
         }
 
-        function restoreInputState() {
+        function restoreInputState(textInput) {
 
             if (!d.activeChatContentModule) {
-                chatInput.setText("")
+                chatInput.clear()
                 chatInput.resetReplyArea()
                 chatInput.resetImageArea()
                 return
             }
 
             // Restore message text
-            chatInput.setText(d.activeChatContentModule.inputAreaModule.preservedProperties.text)
+            chatInput.setText(textInput)
 
             d.restoreInputReply()
             d.restoreInputAttachments()
@@ -154,9 +154,14 @@ Item {
         }
 
         onActiveChatContentModuleChanged: {
+            let preservedText = ""
+            if (d.activeChatContentModule) {
+                preservedText = d.activeChatContentModule.inputAreaModule.preservedProperties.text
+            }
+
             d.activeChatContentModule.inputAreaModule.clearLinkPreviewCache()
             // Call later to make sure activeUsersStore and activeMessagesStore bindings are updated
-            Qt.callLater(d.restoreInputState)
+            Qt.callLater(d.restoreInputState, preservedText)
         }
     }
 
@@ -243,7 +248,12 @@ Item {
                     store: root.rootStore
                     usersStore: d.activeUsersStore
                     linkPreviewModel: d.activeChatContentModule.inputAreaModule.linkPreviewModel
+                    askToEnableLinkPreview: {
+                        if(!d.activeChatContentModule || !d.activeChatContentModule.inputAreaModule || !d.activeChatContentModule.inputAreaModule.preservedProperties)
+                            return false
 
+                        return d.activeChatContentModule.inputAreaModule.askToEnableLinkPreview
+                    }
                     textInput.placeholderText: {
                         if (!channelPostRestrictions.visible) {
                             if (d.activeChatContentModule.chatDetails.blocked)
@@ -315,6 +325,11 @@ Item {
                     }
                     
                     onLinkPreviewReloaded: (link) => d.activeChatContentModule.inputAreaModule.reloadLinkPreview(link)
+                    onEnableLinkPreview: () => d.activeChatContentModule.inputAreaModule.enableLinkPreview()
+                    onDisableLinkPreview: () => d.activeChatContentModule.inputAreaModule.disableLinkPreview()
+                    onEnableLinkPreviewForThisMessage: () => d.activeChatContentModule.inputAreaModule.setLinkPreviewEnabledForCurrentMessage(true)
+                    onDismissLinkPreviewSettings: () => d.activeChatContentModule.inputAreaModule.setLinkPreviewEnabledForCurrentMessage(false)
+                    onDismissLinkPreview: (index) => d.activeChatContentModule.inputAreaModule.removeLinkPreviewData(index)
                 }
 
                 ChatPermissionQualificationPanel {

--- a/ui/imports/shared/controls/chat/LinkPreviewMiniCard.qml
+++ b/ui/imports/shared/controls/chat/LinkPreviewMiniCard.qml
@@ -42,6 +42,7 @@ CalloutCard {
     signal close()
     signal retry()
     signal clicked(var eventPoint)
+    signal rightClicked(var eventPoint)
 
     implicitWidth: 260
     implicitHeight: 64
@@ -181,7 +182,6 @@ CalloutCard {
                         icon: "tiny/chevron-right"
                         color: Theme.palette.baseColor1
                         visible: secondTitleText.visible
-
                     }
                     StatusBaseText {
                         id: secondTitleText
@@ -245,5 +245,9 @@ CalloutCard {
         id: tapHandler
         target: background
         onTapped: root.clicked(eventPoint)
+    }
+    TapHandler {
+        acceptedButtons: Qt.RightButton
+        onTapped: root.rightClicked(eventPoint)
     }
 }

--- a/ui/imports/shared/controls/chat/LinkPreviewSettingsCard.qml
+++ b/ui/imports/shared/controls/chat/LinkPreviewSettingsCard.qml
@@ -1,0 +1,144 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+import StatusQ.Controls 0.1
+import StatusQ.Core 0.1
+import StatusQ.Core.Theme 0.1
+import StatusQ.Popups 0.1
+
+import utils 1.0
+
+CalloutCard {
+    id: root
+
+    signal dismiss()
+    signal enableLinkPreviewForThisMessage()
+    signal enableLinkPreview()
+    signal disableLinkPreview()
+
+    implicitHeight: 64
+    borderWidth: 0
+    topPadding: 13
+    bottomPadding: 13
+    horizontalPadding: Style.current.padding
+
+    contentItem: RowLayout {
+        spacing: Style.current.halfPadding
+        ColumnLayout {
+            spacing: 0
+            Layout.fillHeight: true
+            Layout.fillWidth: true
+            StatusBaseText {
+                Layout.alignment: Qt.AlignTop
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                font.pixelSize: Style.current.additionalTextSize
+                font.weight: Font.Medium
+                wrapMode: Text.Wrap
+                elide: Text.ElideRight
+                maximumLineCount: 1
+                text: qsTr("Show link previews?")
+            }
+            StatusBaseText {
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                font.pixelSize: Style.current.additionalTextSize
+                color: Theme.palette.baseColor1
+                wrapMode: Text.Wrap
+                elide: Text.ElideRight
+                maximumLineCount: 1
+                text: qsTr("A preview of your link will be shown here before you send it")
+            }
+        }
+        ComboBox {
+            id: optionsComboBox
+            Layout.leftMargin: 12
+            Layout.preferredHeight: 38
+            leftPadding: 12
+            rightPadding: 12
+            hoverEnabled: true
+            flat: true
+            contentItem: RowLayout {
+                spacing: Style.current.halfPadding
+                StatusBaseText {
+                    Layout.fillWidth: true
+                    Layout.fillHeight: true
+                    verticalAlignment: Text.AlignVCenter
+                    font.pixelSize: Style.current.additionalTextSize
+                    elide: Text.ElideRight
+                    text: qsTr("Options")
+                    color: Theme.palette.baseColor1
+                }
+                StatusIcon {
+                    Layout.preferredWidth: 16
+                    Layout.preferredHeight: 16
+                    icon: "chevron-down"
+                    color: Theme.palette.baseColor1
+                }
+            }
+            background: Rectangle {
+                border.width: 1
+                border.color: Theme.palette.directColor7
+                color: optionsComboBox.popup.visible ? Theme.palette.baseColor2 : "transparent"
+                radius: Style.current.radius
+                HoverHandler {
+                    cursorShape: Qt.PointingHandCursor
+                    enabled: optionsComboBox.enabled
+                }
+            }
+            popup: ContextMenu {
+                y: - (height + 4)
+                onEnableLinkPreviewForThisMessage: root.enableLinkPreviewForThisMessage()
+                onEnableLinkPreview: root.enableLinkPreview()
+                onDisableLinkPreview: root.disableLinkPreview()
+            }
+            indicator: null
+        }
+
+        StatusFlatRoundButton {
+            id: closeButton
+            Layout.preferredHeight: 38
+            Layout.preferredWidth: 38
+            type: StatusFlatRoundButton.Type.Secondary
+            icon.name: "close"
+            icon.color: Theme.palette.directColor1
+            onClicked: root.dismiss()
+        }
+    }
+
+    component ContextMenu: StatusMenu {
+        id: contextMenu
+
+        signal enableLinkPreviewForThisMessage()
+        signal enableLinkPreview()
+        signal disableLinkPreview()
+
+        hideDisabledItems: false
+        StatusAction {
+            text: qsTr("Link previews")
+            enabled: false
+        }
+
+        StatusAction {
+            text: qsTr("Show for this message")
+            icon.name: "show"
+            onTriggered: contextMenu.enableLinkPreviewForThisMessage()
+        }
+
+        StatusAction {
+            text: qsTr("Always show previews")
+            icon.name: "show"
+            onTriggered: contextMenu.enableLinkPreview()
+        }
+
+        StatusMenuSeparator { }
+
+        StatusAction {
+            text: qsTr("Never show previews")
+            icon.name: "hide"
+            type: StatusAction.Type.Danger
+            onTriggered: contextMenu.disableLinkPreview()
+        }
+    }
+}

--- a/ui/imports/shared/controls/chat/qmldir
+++ b/ui/imports/shared/controls/chat/qmldir
@@ -5,6 +5,7 @@ FetchMoreMessagesButton 1.0 FetchMoreMessagesButton.qml
 GapComponent 1.0 GapComponent.qml
 LinkPreviewCard 1.0 LinkPreviewCard.qml
 LinkPreviewMiniCard 1.0 LinkPreviewMiniCard.qml
+LinkPreviewSettingsCard 1.0 LinkPreviewSettingsCard.qml
 UsernameLabel 1.0 UsernameLabel.qml
 UserProfileCard 1.0 UserProfileCard.qml
 DateGroup 1.0 DateGroup.qml

--- a/ui/imports/shared/status/StatusChatInput.qml
+++ b/ui/imports/shared/status/StatusChatInput.qml
@@ -28,9 +28,13 @@ Rectangle {
     signal stickerSelected(string hashId, string packId, string url)
     signal sendMessage(var event)
     signal keyUpPress()
-    signal linkPreviewRemoved(string link)
     signal linkPreviewReloaded(string link)
-
+    signal enableLinkPreview()
+    signal enableLinkPreviewForThisMessage()
+    signal disableLinkPreview()
+    signal dismissLinkPreviewSettings()
+    signal dismissLinkPreview(int index)
+    
     property var usersStore
     property var store
 
@@ -60,6 +64,8 @@ Rectangle {
     property var fileUrlsAndSources: []
 
     property var linkPreviewModel: null
+
+    property bool askToEnableLinkPreview: false
 
     property var imageErrorMessageLocation: StatusChatInput.ImageErrorMessageLocation.Top // TODO: Remove this property?
 
@@ -1179,11 +1185,12 @@ Rectangle {
                 ChatInputLinksPreviewArea {
                     id: linkPreviewArea
                     Layout.fillWidth: true
-                    visible: contentItemsCount > 0
+                    visible: hasContent
                     horizontalPadding: 12
                     topPadding: 12
-                    imagePreviewModel: control.fileUrlsAndSources
+                    imagePreviewArray: control.fileUrlsAndSources
                     linkPreviewModel: control.linkPreviewModel
+                    showLinkPreviewSettings: control.askToEnableLinkPreview
                     onImageRemoved: (index) => {
                         //Just do a copy and replace the whole thing because it's a plain JS array and thre's no signal when a single item is removed
                         let urls = control.fileUrlsAndSources
@@ -1194,8 +1201,12 @@ Rectangle {
                     }
                     onImageClicked: (chatImage) => Global.openImagePopup(chatImage)
                     onLinkReload: (link) => control.linkPreviewReloaded(link)
-                    onLinkRemoved: (link) => control.linkPreviewRemoved(link)
                     onLinkClicked: (link) => Global.openLink(link)
+                    onEnableLinkPreview: () => control.enableLinkPreview()
+                    onEnableLinkPreviewForThisMessage: () => control.enableLinkPreviewForThisMessage()
+                    onDisableLinkPreview: () => control.disableLinkPreview()
+                    onDismissLinkPreviewSettings: () => control.dismissLinkPreviewSettings()
+                    onDismissLinkPreview: (index) => control.dismissLinkPreview(index)
                 }
 
                 RowLayout {

--- a/ui/imports/shared/status/StatusChatInputImageArea.qml
+++ b/ui/imports/shared/status/StatusChatInputImageArea.qml
@@ -20,7 +20,7 @@ Row {
 
     Repeater {
         id: rptImages
-    
+
         Item {
             height: chatImage.height
             width: chatImage.width

--- a/ui/imports/utils/UndoStackManager.qml
+++ b/ui/imports/utils/UndoStackManager.qml
@@ -117,9 +117,7 @@ Item {
             }
 
             const newStackSize = Math.ceil(root.maxStackSize / 2)
-            print("Reducing undo stack to " + newStackSize + " items")
             for(var i = 1; i <= newStackSize; i++) {
-                print("Removing " + Math.ceil(root.maxStackSize / newStackSize) + " items from index " + i)
                 d.undoStack.splice(i, Math.ceil(root.maxStackSize / newStackSize))
             }
         }


### PR DESCRIPTION
### What does the PR do
Closing: #12180

Depends on #12262 to be merged first.

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

This commit adds the link preview settings card in the chat input area and connects the settings to the controller.

Not included in this commit: Backend for the preserving the settings, syncing the settings and enforcing the settings on the backend side.

Whenever an url is detected in the chat input area, the link preview settings card is presented. This card enables the user to choose one of the following options:

1. `Show for this message` - All the link previews in the current message will be loaded without asking again. The current message can be defined as the message currently typed/pasted in the chat input. Deleting or sending the current content is resetting this setting and the link preview settings card will be presented again when a new url is detected.
2. `Always show previews` - All the link previews will be loaded automatically. The link preview settings card will not be presented again (in the current state, this settings is enabled for the lifetime of the controller. This will change once the settings are preserved and synced)
3. `Never show previews` - No link preview will be loaded. Same as the `Always show previews` option, this will be preserved for the lifetime of the controller for now.
4. Dismiss (x button) - The link preview settings card will be dismissed. It will be loaded again when a new link preview is detected

The same options can be loaded as a context menu on the link preview card.

Changes:
1. Adding `LinkPreviewSettingsCard`
2. Adding the settings context menu to `LinkPreviewSettingsCard` and `LinkPreviewMiniCard`
3. Connect settings events to the nim controller
4. Adding the controller logic for settings change
5. Adding the link preview dismiss settings flag to the preserverd properties and use it as a condition to load the settings.
6. Adding/Updating corresponding storybook pages

### Affected areas

Link previews
StatusChatInput
Storybook
<!-- List the affected areas (e.g wallet, browser, etc..) -->

### Screenshot of functionality (including design for comparison)

#### New url detected

https://github.com/status-im/status-desktop/assets/47811206/a901d56b-b2c1-46c4-9969-571de00d0c33

#### Dismiss settings

https://github.com/status-im/status-desktop/assets/47811206/6270be5b-6c1f-4912-a258-e91d4cd90e8f

#### Enable for current message

https://github.com/status-im/status-desktop/assets/47811206/f5cdfa73-af18-4c67-a74c-834bd227734b

#### Enable (partial implementation - needs backend for persistent settings. Currently this setting is preserved for the controller lifetime)

https://github.com/status-im/status-desktop/assets/47811206/c5606180-97da-4031-a243-c6b62bd1cc59

#### Disable

https://github.com/status-im/status-desktop/assets/47811206/b069fdc2-1af1-4361-91a9-b2c3498bf3c9

#### Disable from the link preview card

https://github.com/status-im/status-desktop/assets/47811206/7c29d3b6-cf92-45b2-a9b7-2c97b0bc5098

- [x] I've checked the design and this PR matches it

<!-- screenshot (or gif/video) that demonstrates the functionality, specially important if it's a bug fix. -->

### Cool Spaceship Picture

<!-- optional but cool ->
