### PR TITLE
feat(Advanced): Add toggle to enable managing community on testnet

### DIFF
--- a/ui/app/AppLayouts/Profile/stores/AdvancedStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/AdvancedStore.qml
@@ -27,6 +27,7 @@ QtObject {
                             root.fleet === Constants.status_prod
 
     readonly property bool isFakeLoadingScreenEnabled: localAppSettings.fakeLoadingScreenEnabled ?? false
+    property bool isManageCommunityOnTestModeEnabled: false
     readonly property QtObject experimentalFeatures: QtObject {
         readonly property string browser: "browser"
         readonly property string communities: "communities"
@@ -153,6 +154,10 @@ QtObject {
             return
 
         localAppSettings.fakeLoadingScreenEnabled = !localAppSettings.fakeLoadingScreenEnabled
+    }
+
+    function toggleManageCommunityOnTestnet() {
+        root.isManageCommunityOnTestModeEnabled = !root.isManageCommunityOnTestModeEnabled
     }
 
     function toggleWakuV2ShardedCommunities() {

--- a/ui/app/AppLayouts/Profile/views/AdvancedView.qml
+++ b/ui/app/AppLayouts/Profile/views/AdvancedView.qml
@@ -448,6 +448,17 @@ SettingsContentBase {
             StatusSettingsLineButton {
                 anchors.leftMargin: 0
                 anchors.rightMargin: 0
+                text: qsTr("Manage communities on testnet")
+                isSwitch: true
+                switchChecked: root.advancedStore.isManageCommunityOnTestModeEnabled
+                onClicked: {
+                    root.advancedStore.toggleManageCommunityOnTestnet()
+                }
+            }
+
+            StatusSettingsLineButton {
+                anchors.leftMargin: 0
+                anchors.rightMargin: 0
                 text: qsTr("How many log files to keep archived")
                 currentValue: root.advancedStore.logMaxBackups
                 onClicked: {

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -1266,6 +1266,8 @@ Item {
                             sourceComponent: ChatLayout {
                                 id: chatLayoutComponent
 
+                                readonly property bool isManageCommunityEnabledInAdvanced: appMain.rootStore.profileSectionStore.advancedStore.isManageCommunityOnTestModeEnabled
+
                                 Binding {
                                     target: rootDropAreaPanel
                                     property: "enabled"
@@ -1289,8 +1291,8 @@ Item {
                                 sectionItemModel: model
                                 createChatPropertiesStore: appMain.createChatPropertiesStore
                                 communitiesStore: appMain.communitiesStore
-                                communitySettingsDisabled: production && appMain.rootStore.profileSectionStore.walletStore.areTestNetworksEnabled
-
+                                communitySettingsDisabled: !chatLayoutComponent.isManageCommunityEnabledInAdvanced &&
+                                                           (production && appMain.rootStore.profileSectionStore.walletStore.areTestNetworksEnabled)
                                 rootStore: ChatStores.RootStore {
                                     contactsStore: appMain.rootStore.contactStore
                                     communityTokensStore: appMain.communityTokensStore


### PR DESCRIPTION
Fixes #12276

### What does the PR do
It adds a new switch in `Settings/Advanced` to **enable community management** on testnet.

**NOTE:** The state of the change is managed only in qml, so the state will not persist from one instance to another. It will always be initialized as `disabled`. We agreed with the **QA team** that this is a sufficient solution for the tests purpose.

### Affected areas

Settings / Advanced

### Screenshot of functionality
![Screenshot 2023-10-09 at 13 09 42](https://github.com/status-im/status-desktop/assets/97019400/15c30aab-228a-429c-a326-eac4fc8c5358)
