### PR TITLE
fix(Onboarding): Recover from seed - Fetching data screen layout

### DIFF
--- a/ui/app/AppLayouts/Onboarding/views/ProfileFetchingView.qml
+++ b/ui/app/AppLayouts/Onboarding/views/ProfileFetchingView.qml
@@ -21,6 +21,9 @@ Item {
         id: d
 
         property int counter: Constants.onboarding.profileFetching.timeout
+
+        readonly property string fetchingDataText: qsTr("Fetching data...")
+        readonly property string continueText: qsTr("Continue")
     }
 
     onStateChanged: {
@@ -31,7 +34,6 @@ Item {
 
     ColumnLayout {
         anchors.centerIn: parent
-        height: Constants.onboarding.loginHeight
         spacing: Style.current.bigPadding
 
         ProfileFetchingAnimation {
@@ -177,7 +179,7 @@ Item {
             when: root.startupStore.currentStartupState.stateType === Constants.startupState.profileFetching
             PropertyChanges {
                 target: title
-                text: qsTr("Fetching data...")
+                text: d.fetchingDataText
             }
             PropertyChanges {
                 target: button
@@ -197,11 +199,11 @@ Item {
             when: root.startupStore.currentStartupState.stateType === Constants.startupState.profileFetchingTimeout
             PropertyChanges {
                 target: title
-                text: qsTr("Fetching data...")
+                text: d.fetchingDataText
             }
             PropertyChanges {
                 target: button
-                text: qsTr("Continue")
+                text: d.continueText
             }
         },
         State {
@@ -209,11 +211,11 @@ Item {
             when: root.startupStore.currentStartupState.stateType === Constants.startupState.profileFetchingSuccess
             PropertyChanges {
                 target: title
-                text: qsTr("Fetching data...")
+                text: d.fetchingDataText
             }
             PropertyChanges {
                 target: button
-                text: qsTr("Continue")
+                text: d.continueText
             }
         }
     ]


### PR DESCRIPTION
Fixes #10939

### What does the PR do

Following the design, it does not include a scroll bar as all rows and button can fit in the minimum window height, but the content was not centered correctly when the application is resized. So fixed that point in here.

### Affected areas

Onboarding / Fetch data screen

### Screenshot of functionality

https://github.com/status-im/status-desktop/assets/97019400/85ba91f9-b865-4e72-986c-cb889748bae4