### PR TITLE
feat: trigger collectibles refresh on transfer

### DIFF
--- a/src/app/modules/shared_modules/collectibles/controller.nim
+++ b/src/app/modules/shared_modules/collectibles/controller.nim
@@ -60,7 +60,7 @@ QtObject:
           break
 
     case overallState:
-      of OwnershipStateIdle:
+      of OwnershipStateIdle, OwnershipStateDelayed:
         self.model.setIsUpdating(false)
         self.model.setIsError(false)
       of OwnershipStateUpdating:

--- a/src/backend/collectibles.nim
+++ b/src/backend/collectibles.nim
@@ -35,6 +35,7 @@ type
   # Mirrors services/wallet/collectibles/service.go OwnershipState
   OwnershipState* = enum
     OwnershipStateIdle = 1,
+    OwnershipStateDelayed,
     OwnershipStateUpdating,
     OwnershipStateError
 


### PR DESCRIPTION
Fixes #9823
status-go part: https://github.com/status-im/status-go/pull/4127

### What does the PR do

Implements collectibles re-fetch when an NFT transfer is detected


