### PR TITLE
fix: Add Copy/Open Link as context menu actions on GIF message previews

### DIFF
--- a/ui/imports/shared/controls/chat/LinkPreviewCard.qml
+++ b/ui/imports/shared/controls/chat/LinkPreviewCard.qml
@@ -22,7 +22,7 @@ CalloutCard {
     
     property string bannerImageSource: ""
 
-    signal clicked()
+    signal clicked(var mouse)
 
     borderWidth: 1
     padding: borderWidth
@@ -96,6 +96,7 @@ CalloutCard {
         anchors.fill: root
         hoverEnabled: true
         cursorShape: Qt.PointingHandCursor
-        onClicked: root.clicked()
+        acceptedButtons: Qt.LeftButton | Qt.RightButton
+        onClicked: root.clicked(mouse)
     }
 }

--- a/ui/imports/shared/views/chat/ImageContextMenu.qml
+++ b/ui/imports/shared/views/chat/ImageContextMenu.qml
@@ -36,17 +36,13 @@ StatusMenu {
         text: qsTr("Copy link")
         icon.name: "copy"
         enabled: d.isUnfurled
-        onTriggered: {
-            Utils.copyToClipboard(url);
-        }
+        onTriggered: Utils.copyToClipboard(url)
     }
 
     StatusAction {
         text: qsTr("Open link")
         icon.name: "browser"
         enabled: d.isUnfurled
-        onTriggered: {
-            Qt.openUrlExternally(url);
-        }
+        onTriggered: Global.openLink(root.url)
     }
 }

--- a/ui/imports/shared/views/chat/LinksMessageView.qml
+++ b/ui/imports/shared/views/chat/LinksMessageView.qml
@@ -1,6 +1,5 @@
 import QtQuick 2.15
-import QtGraphicalEffects 1.13
-import QtQuick.Layouts 1.13
+import QtQuick.Layouts 1.15
 
 import utils 1.0
 
@@ -58,9 +57,17 @@ ColumnLayout {
                 title: parent.title
                 description: parent.description
                 footer: hostname
-                onClicked:  {
-                    Global.openLink(url)
-                }
+                onClicked:
+                    (mouse) => {
+                        switch (mouse.button) {
+                            case Qt.RightButton:
+                            root.imageClicked(unfurledLink, mouse, "", url) // request a dumb context menu with just "copy/open link" items
+                            break
+                            default:
+                            Global.openLink(url) // FIXME https://github.com/status-im/status-desktop/issues/12388
+                            break
+                        }
+                    }
             }
         }
     }
@@ -78,7 +85,7 @@ ColumnLayout {
                 id: linkImage
 
                 readonly property bool globalAnimationEnabled: root.messageStore.playAnimation
-                readonly property string urlLink: url
+                readonly property string urlLink: link
                 property bool localAnimationEnabled: true
                 objectName: "LinksMessageView_unfurledImageComponent_linkImage"
                 anchors.centerIn: parent
@@ -88,7 +95,7 @@ ColumnLayout {
                 playing: globalAnimationEnabled && localAnimationEnabled
                 isOnline: root.store.mainModuleInst.isOnline
                 asynchronous: true
-                isAnimated: animated // FIXME: GIFs are not supported with new unfurling yet
+                isAnimated: animated
                 onClicked: {
                     if (isAnimated && !playing)
                         localAnimationEnabled = true
@@ -178,7 +185,6 @@ ColumnLayout {
 
 
         onGetLinkPreviewDataIdChanged: {
-
             linkFetchConnections.enabled = root.localUnfurlLinks !== ""
         }
     }
@@ -233,7 +239,7 @@ ColumnLayout {
             readonly property string thumbnailUrl: result && result.thumbnailUrl ? result.thumbnailUrl : ""
             readonly property string title: result && result.title ? result.title : ""
             readonly property string hostname: result && result.site ? result.site : ""
-            readonly property bool animated: true
+            readonly property bool animated: isImage && result.contentType === "image/gif" // TODO support more types of animated images?
 
             StateGroup {
                 //Using StateGroup as a warkardound for https://bugreports.qt.io/browse/QTBUG-47796


### PR DESCRIPTION
- also fix the issue of not having the respective image context menu for the new unfurled links component
- open the resulting link using a centralized `Global.openLink(url)`

Fixes #12183

### What does the PR do

Fixes context menu for image-like elements

### Affected areas

LinksMessageView,ImageContextMenu

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

New unfurled component:
![image](https://github.com/status-im/status-desktop/assets/5377645/ea03dbeb-24e7-47e8-bb10-0151130441b6)

Regular message context menu:
![image](https://github.com/status-im/status-desktop/assets/5377645/d9a8d9ce-8e6b-4ebd-9a05-814de7fe5755)

GIF context menu:
![image](https://github.com/status-im/status-desktop/assets/5377645/99adf604-b48e-4ea2-b5a1-a42bd9659bbf)

