### PR TITLE
fix: attach link previews in `SendImages`

### DIFF
--- a/src/app/modules/main/chat_section/chat_content/input_area/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/input_area/module.nim
@@ -66,7 +66,7 @@ proc getChatId*(self: Module): string =
   return self.controller.getChatId()
 
 method sendImages*(self: Module, imagePathsAndDataJson: string, msg: string, replyTo: string): string =
-  self.controller.sendImages(imagePathsAndDataJson, msg, replyTo)
+  self.controller.sendImages(imagePathsAndDataJson, msg, replyTo, singletonInstance.userProfile.getPreferredName())
 
 method sendChatMessage*(
     self: Module,

--- a/src/app_service/service/chat/service.nim
+++ b/src/app_service/service/chat/service.nim
@@ -499,7 +499,13 @@ QtObject:
       error "Error deleting channel", chatId, msg = e.msg
       return
 
-  proc sendImages*(self: Service, chatId: string, imagePathsAndDataJson: string, msg: string, replyTo: string): string =
+  proc sendImages*(self: Service, 
+                   chatId: string, 
+                   imagePathsAndDataJson: string, 
+                   msg: string, 
+                   replyTo: string,
+                   preferredUsername: string = "",
+                   linkPreviews: seq[LinkPreview] = @[]): string =
     result = ""
     try:
       var images = Json.decode(imagePathsAndDataJson, seq[string])
@@ -511,7 +517,7 @@ QtObject:
         if imagePath != "":
           imagePaths.add(imagePath)
 
-      let response = status_chat.sendImages(chatId, imagePaths, msg, replyTo)
+      let response = status_chat.sendImages(chatId, imagePaths, msg, replyTo, preferredUsername, linkPreviews)
 
       for imagePath in imagePaths:
         removeFile(imagePath)

--- a/src/backend/chat.nim
+++ b/src/backend/chat.nim
@@ -82,16 +82,22 @@ proc sendChatMessage*(
     }
   ])
 
-proc sendImages*(chatId: string, images: var seq[string], msg: string, replyTo: string): RpcResponse[JsonNode] {.raises: [Exception].} =
+proc sendImages*(chatId: string, 
+                 images: var seq[string], 
+                 msg: string, 
+                 replyTo: string,
+                 preferredUsername: string,
+                 linkPreviews: seq[LinkPreview],
+                 ): RpcResponse[JsonNode] {.raises: [Exception].} =
   let imagesJson = %* images.map(image => %*
       {
         "chatId": chatId,
         "contentType": 7, # TODO how do we unhardcode this
         "imagePath": image,
-        # TODO is this still needed
-        # "ensName": preferredUsername,
+        "ensName": preferredUsername,
         "text": msg,
         "responseTo": replyTo,
+        "linkPreviews": linkPreviews
       }
     )
   callPrivateRPC("sendChatMessages".prefix, %* [imagesJson])


### PR DESCRIPTION
Fixes https://github.com/status-im/status-desktop/issues/12396

### What does the PR do

1. Link previews are sent with image messages
2. Preferred username is send with image messages (removed a TODO there. AFAIK, it's still used)

### Screenshot of functionality (including design for comparison)

<img width="1312" alt="Screenshot 2023-10-10 at 14 03 13" src="https://github.com/status-im/status-desktop/assets/25482501/4200acb4-8f99-4da2-9da3-0e205af22f34">
