### PR TITLE
feat(@desktop/wallet): Include watch only per account

### DIFF
--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -447,10 +447,6 @@ proc connectForNotificationsOnly[T](self: Module[T]) =
     let args = NetworkEndpointUpdatedArgs(e)
     self.view.showNetworkEndpointUpdated(args.networkName, args.isTest, args.revertedToDefault)
 
-  self.events.on(SIGNAL_INCLUDE_WATCH_ONLY_ACCOUNTS_UPDATED) do(e: Args):
-    let args = SettingsBoolValueArgs(e)
-    self.view.showIncludeWatchOnlyAccountUpdated(args.value)
-
   self.events.on(SIGNAL_KEYPAIR_DELETED) do(e: Args):
     let args = KeypairArgs(e)
     self.view.showToastKeypairRemoved(args.keyPairName)

--- a/src/app/modules/main/profile_section/wallet/accounts/controller.nim
+++ b/src/app/modules/main/profile_section/wallet/accounts/controller.nim
@@ -52,12 +52,6 @@ proc getWalletAccount*(self: Controller, address: string): WalletAccountDto =
 proc getKeypairs*(self: Controller): seq[KeypairDto] =
   return self.walletAccountService.getKeypairs()
 
-proc toggleIncludeWatchOnlyAccount*(self: Controller) =
-  self.walletAccountService.toggleIncludeWatchOnlyAccount()
-
-proc isIncludeWatchOnlyAccount*(self: Controller): bool =
-  return self.walletAccountService.isIncludeWatchOnlyAccount()
-
 proc getEnabledChainIds*(self: Controller): seq[int] =
   return self.walletAccountService.getEnabledChainIds()
 
@@ -78,3 +72,6 @@ proc areTestNetworksEnabled*(self: Controller): bool =
 
 proc getCurrencyBalance*(self: Controller, address: string, chainIds: seq[int], currency: string): float64 =
   return self.walletAccountService.getCurrencyBalance(address, chainIds, currency)
+
+proc updateWatchAccountHiddenFromTotalBalance*(self: Controller, address: string, hideFromTotalBalance: bool) =
+  discard self.walletAccountService.updateWatchAccountHiddenFromTotalBalance(address, hideFromTotalBalance)

--- a/src/app/modules/main/profile_section/wallet/accounts/io_interface.nim
+++ b/src/app/modules/main/profile_section/wallet/accounts/io_interface.nim
@@ -46,11 +46,11 @@ method getModuleAsVariant*(self: AccessInterface): QVariant {.base.} =
 method getCollectiblesModel*(self: AccessInterface): QVariant {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method toggleIncludeWatchOnlyAccount*(self: AccessInterface) {.base.} =
-  raise newException(ValueError, "No implementation available")
-
 method updateWalletAccountProdPreferredChains*(self: AccessInterface, address, preferredChainIds: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method updateWalletAccountTestPreferredChains*(self: AccessInterface, address, preferredChainIds: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method updateWatchAccountHiddenFromTotalBalance*(self: AccessInterface, address: string, hideFromTotalBalance: bool) {.base.} =
   raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/profile_section/wallet/accounts/module.nim
+++ b/src/app/modules/main/profile_section/wallet/accounts/module.nim
@@ -79,7 +79,8 @@ method convertWalletAccountDtoToKeyPairAccountItem(self: Module, account: Wallet
     isDefaultAccount = account.isWallet,
     self.controller.areTestNetworksEnabled(),
     prodPreferredChainIds = account.prodPreferredChainIds,
-    testPreferredChainIds = account.testPreferredChainIds)
+    testPreferredChainIds = account.testPreferredChainIds,
+    hideFromTotalBalance = account.hideFromTotalBalance)
 
 method setBalance(self: Module, accountsTokens: OrderedTable[string, seq[WalletTokenDto]]) =
   let enabledChainIds = self.controller.getEnabledChainIds()
@@ -179,17 +180,16 @@ method load*(self: Module) =
   self.events.on(SIGNAL_WALLET_ACCOUNT_POSITION_UPDATED) do(e:Args):
     self.refreshWalletAccounts()
 
-  self.events.on(SIGNAL_INCLUDE_WATCH_ONLY_ACCOUNTS_UPDATED) do(e: Args):
-    let args = SettingsBoolValueArgs(e)
-    self.view.setIncludeWatchOnlyAccount(args.value)
-
   self.events.on(SIGNAL_WALLET_ACCOUNT_PREFERRED_SHARING_CHAINS_UPDATED) do(e: Args):
     let args = AccountArgs(e)
     self.view.onPreferredSharingChainsUpdated(args.account.keyUid, args.account.address, args.account.prodPreferredChainIds, args.account.testPreferredChainIds)
 
+  self.events.on(SIGNAL_WALLET_ACCOUNT_HIDDEN_UPDATED) do(e: Args):
+    let args = AccountArgs(e)
+    self.view.onHideFromTotalBalanceUpdated(args.account.keyUid, args.account.address, args.account.hideFromTotalBalance)
+
   self.controller.init()
   self.view.load()
-  self.view.setIncludeWatchOnlyAccount(self.controller.isIncludeWatchOnlyAccount())
 
 method isLoaded*(self: Module): bool =
   return self.moduleLoaded
@@ -211,9 +211,6 @@ method deleteAccount*(self: Module, address: string) =
 method deleteKeypair*(self: Module, keyUid: string) =
   self.controller.deleteKeypair(keyUid)
 
-method toggleIncludeWatchOnlyAccount*(self: Module) =
-  self.controller.toggleIncludeWatchOnlyAccount()
-
 method renameKeypair*(self: Module, keyUid: string, name: string) =
   self.controller.renameKeypair(keyUid, name)
 
@@ -225,3 +222,6 @@ method updateWalletAccountProdPreferredChains*(self: Module, address, preferredC
 
 method updateWalletAccountTestPreferredChains*(self: Module, address, preferredChainIds: string) =
   self.controller.updateWalletAccountTestPreferredChains(address, preferredChainIds)
+
+method updateWatchAccountHiddenFromTotalBalance*(self: Module, address: string, hideFromTotalBalance: bool) =
+  self.controller.updateWatchAccountHiddenFromTotalBalance(address, hideFromTotalBalance)

--- a/src/app/modules/main/profile_section/wallet/accounts/view.nim
+++ b/src/app/modules/main/profile_section/wallet/accounts/view.nim
@@ -13,7 +13,6 @@ QtObject:
       accounts: Model
       accountsVariant: QVariant
       keyPairModel: KeyPairModel
-      includeWatchOnlyAccount: bool
 
   proc delete*(self: View) =
     self.accounts.delete
@@ -57,6 +56,9 @@ QtObject:
   proc onPreferredSharingChainsUpdated*(self: View, keyUid, address, prodPreferredChainIds, testPreferredChainIds: string) =
     self.keyPairModel.onPreferredSharingChainsUpdated(keyUid, address, prodPreferredChainIds, testPreferredChainIds)
 
+  proc onHideFromTotalBalanceUpdated*(self: View, keyUid, address: string, hideFromTotalBalance: bool) =
+    self.keyPairModel.onHideFromTotalBalanceUpdated(keyUid, address, hideFromTotalBalance)
+
   proc deleteAccount*(self: View, address: string) {.slot.} =
     self.delegate.deleteAccount(address)
 
@@ -76,20 +78,6 @@ QtObject:
   proc setKeyPairModelItems*(self: View, items: seq[KeyPairItem]) =
     self.keyPairModel.setItems(items)
     self.keyPairModelChanged()
-
-  proc includeWatchOnlyAccountChanged*(self: View) {.signal.}
-  proc getIncludeWatchOnlyAccount(self: View): bool {.slot.} =
-    return self.includeWatchOnlyAccount
-  QtProperty[bool] includeWatchOnlyAccount:
-    read = getIncludeWatchOnlyAccount
-    notify = includeWatchOnlyAccountChanged
-
-  proc toggleIncludeWatchOnlyAccount*(self: View) {.slot.} =
-    self.delegate.toggleIncludeWatchOnlyAccount()
-
-  proc setIncludeWatchOnlyAccount*(self: View, includeWatchOnlyAccount: bool) =
-    self.includeWatchOnlyAccount = includeWatchOnlyAccount
-    self.includeWatchOnlyAccountChanged()
 
   proc keypairNameExists*(self: View, name: string): bool {.slot.} =
     return self.keyPairModel.keypairNameExists(name)
@@ -111,3 +99,6 @@ QtObject:
 
   proc setBalanceForKeyPairs*(self: View, address: string, balance: CurrencyAmount) =
     self.keyPairModel.setBalanceForAddress(address, balance)
+
+  proc updateWatchAccountHiddenFromTotalBalance*(self: View, address: string, hideFromTotalBalance: bool) {.slot.} =
+    self.delegate.updateWatchAccountHiddenFromTotalBalance(address, hideFromTotalBalance)

--- a/src/app/modules/main/view.nim
+++ b/src/app/modules/main/view.nim
@@ -293,7 +293,6 @@ QtObject:
   proc showToastAccountAdded*(self: View, name: string) {.signal.}
   proc showToastKeypairRenamed*(self: View, oldName: string, newName: string) {.signal.}
   proc showNetworkEndpointUpdated*(self: View, name: string, isTest: bool, revertedToDefault: bool) {.signal.}
-  proc showIncludeWatchOnlyAccountUpdated*(self: View, includeWatchOnly: bool) {.signal.}
   proc showToastKeypairRemoved*(self: View, keypairName: string) {.signal.}
   proc showToastKeypairsImported*(self: View, keypairName: string, keypairsCount: int, error: string) {.signal.}
   proc showToastTransactionSent*(self: View, chainId: int, txHash: string, uuid: string, error: string) {.signal.}

--- a/src/app/modules/main/wallet_section/accounts/controller.nim
+++ b/src/app/modules/main/wallet_section/accounts/controller.nim
@@ -70,3 +70,6 @@ proc areTestNetworksEnabled*(self: Controller): bool =
 
 proc getCurrencyBalance*(self: Controller, address: string, chainIds: seq[int], currency: string): float64 =
   return self.walletAccountService.getCurrencyBalance(address, chainIds, currency)
+
+proc updateWatchAccountHiddenFromTotalBalance*(self: Controller, address: string, hideFromTotalBalance: bool) =
+  discard self.walletAccountService.updateWatchAccountHiddenFromTotalBalance(address, hideFromTotalBalance)

--- a/src/app/modules/main/wallet_section/accounts/io_interface.nim
+++ b/src/app/modules/main/wallet_section/accounts/io_interface.nim
@@ -36,3 +36,6 @@ method updateWalletAccountProdPreferredChains*(self: AccessInterface, address, p
 
 method updateWalletAccountTestPreferredChains*(self: AccessInterface, address, preferredChainIds: string) {.base.} =
   raise newException(ValueError, "No implementation available")
+
+method updateWatchAccountHiddenFromTotalBalance*(self: AccessInterface, address: string, hideFromTotalBalance: bool) {.base.} =
+  raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/wallet_section/accounts/item.nim
+++ b/src/app/modules/main/wallet_section/accounts/item.nim
@@ -27,7 +27,8 @@ proc initItem*(
   isWallet: bool = false,
   areTestNetworksEnabled: bool = false,
   prodPreferredChainIds: string = "",
-  testPreferredChainIds: string = ""
+  testPreferredChainIds: string = "",
+  hideFromTotalBalance: bool = false
 ): Item =
   result = Item()
   result.WalletAccountItem.setup(name,
@@ -42,7 +43,8 @@ proc initItem*(
     operability = wa_dto.AccountFullyOperable,
     areTestNetworksEnabled,
     prodPreferredChainIds,
-    testPreferredChainIds)
+    testPreferredChainIds,
+    hideFromTotalBalance)
   result.createdAt = createdAt
   result.assetsLoading = assetsLoading
   result.currencyBalance = currencyBalance

--- a/src/app/modules/main/wallet_section/accounts/model.nim
+++ b/src/app/modules/main/wallet_section/accounts/model.nim
@@ -19,7 +19,8 @@ type
     KeycardAccount,
     AssetsLoading,
     IsWallet,
-    PreferredSharingChainIds
+    PreferredSharingChainIds,
+    HideFromTotalBalance
 
 QtObject:
   type
@@ -69,7 +70,8 @@ QtObject:
       ModelRole.KeycardAccount.int: "keycardAccount",
       ModelRole.AssetsLoading.int: "assetsLoading",
       ModelRole.IsWallet.int: "isWallet",
-      ModelRole.PreferredSharingChainIds.int: "preferredSharingChainIds"
+      ModelRole.PreferredSharingChainIds.int: "preferredSharingChainIds",
+      ModelRole.HideFromTotalBalance.int: "hideFromTotalBalance"
     }.toTable
 
 
@@ -121,6 +123,8 @@ QtObject:
       result = newQVariant(item.isWallet())
     of ModelRole.PreferredSharingChainIds:
       result = newQVariant(item.preferredSharingChainIds())
+    of ModelRole.HideFromTotalBalance:
+      result = newQVariant(item.hideFromTotalBalance())
 
   proc getNameByAddress*(self: Model, address: string): string =
     for item in self.items:

--- a/src/app/modules/main/wallet_section/accounts/module.nim
+++ b/src/app/modules/main/wallet_section/accounts/module.nim
@@ -83,3 +83,6 @@ method updateWalletAccountProdPreferredChains*(self: Module, address, preferredC
 
 method updateWalletAccountTestPreferredChains*(self: Module, address, preferredChainIds: string) =
   self.controller.updateWalletAccountTestPreferredChains(address, preferredChainIds)
+
+method updateWatchAccountHiddenFromTotalBalance*(self: Module, address: string, hideFromTotalBalance: bool) =
+  self.controller.updateWatchAccountHiddenFromTotalBalance(address, hideFromTotalBalance)

--- a/src/app/modules/main/wallet_section/accounts/view.nim
+++ b/src/app/modules/main/wallet_section/accounts/view.nim
@@ -63,3 +63,6 @@ QtObject:
 
   proc updateWalletAccountTestPreferredChains*(self: View, address: string, preferredChainIds: string) {.slot.} =
     self.delegate.updateWalletAccountTestPreferredChains(address, preferredChainIds)
+
+  proc updateWatchAccountHiddenFromTotalBalance*(self: View, address: string, hideFromTotalBalance: bool) {.slot.} =
+    self.delegate.updateWatchAccountHiddenFromTotalBalance(address, hideFromTotalBalance)

--- a/src/app/modules/main/wallet_section/controller.nim
+++ b/src/app/modules/main/wallet_section/controller.nim
@@ -63,12 +63,6 @@ proc getWalletAccounts*(self: Controller): seq[wallet_account_service.WalletAcco
 proc getEnabledChainIds*(self: Controller): seq[int] =
   return self.networkService.getNetworks().filter(n => n.enabled).map(n => n.chainId)
 
-proc toggleIncludeWatchOnlyAccount*(self: Controller) =
-  self.walletAccountService.toggleIncludeWatchOnlyAccount()
-
-proc isIncludeWatchOnlyAccount*(self: Controller): bool =
-  return self.walletAccountService.isIncludeWatchOnlyAccount()
-
 proc getKeypairByAccountAddress*(self: Controller, address: string): KeypairDto =
   return self.walletAccountService.getKeypairByAccountAddress(address)
 

--- a/src/app/modules/main/wallet_section/filter.nim
+++ b/src/app/modules/main/wallet_section/filter.nim
@@ -27,17 +27,11 @@ proc `$`*(self: Filter): string =
 
 proc setFillterAllAddresses*(self: Filter) = 
   self.allAddresses = true
-  self.addresses = self.controller.getWalletAccounts().map(a => a.address)
-
-proc toggleWatchOnlyAccounts*(self: Filter) =
-  self.controller.toggleIncludeWatchOnlyAccount()
-
-proc includeWatchOnlyToggled*(self: Filter) =
-  let includeWatchOnly = self.controller.isIncludeWatchOnlyAccount()
-  if includeWatchOnly:
-    self.setFillterAllAddresses()
-  else:
-    self.addresses = self.controller.getWalletAccounts().filter(a => a.walletType != "watch").map(a => a.address)
+  var allAccounts = self.controller.getWalletAccounts()
+  var accountsExclWatchAccs = allAccounts.filter(a => not a.hideFromTotalBalance)
+  if allAccounts.len != accountsExclWatchAccs.len:
+    self.allAddresses = false
+  self.addresses = self.controller.getWalletAccounts().filter(a => not a.hideFromTotalBalance).map(a => a.address)
 
 proc setAddress*(self: Filter, address: string) =
   self.allAddresses = false
@@ -58,5 +52,5 @@ proc updateNetworks*(self: Filter) =
   self.allChainsEnabled = (self.chainIds.len == self.controller.getNetworks().len)
 
 proc load*(self: Filter) =
-  self.includeWatchOnlyToggled()
+  self.setFillterAllAddresses()
   self.updateNetworks()

--- a/src/app/modules/main/wallet_section/io_interface.nim
+++ b/src/app/modules/main/wallet_section/io_interface.nim
@@ -21,9 +21,6 @@ method setFilterAddress*(self: AccessInterface, address: string) {.base.} =
 method setFillterAllAddresses*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method toggleWatchOnlyAccounts*(self: AccessInterface) {.base.} =
-  raise newException(ValueError, "No implementation available")
-
 method updateCurrency*(self: AccessInterface, currency: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/wallet_section/overview/io_interface.nim
+++ b/src/app/modules/main/wallet_section/overview/io_interface.nim
@@ -17,5 +17,5 @@ method isLoaded*(self: AccessInterface): bool {.base.} =
 method viewDidLoad*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method filterChanged*(self: AccessInterface, addresses: seq[string], chainIds: seq[int], includeWatchOnly: bool, allAddresses: bool) {.base.} =
+method filterChanged*(self: AccessInterface, addresses: seq[string], chainIds: seq[int], allAddresses: bool) {.base.} =
   raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/wallet_section/overview/item.nim
+++ b/src/app/modules/main/wallet_section/overview/item.nim
@@ -10,7 +10,6 @@ type
     emoji: string
     isWatchOnlyAccount: bool
     isAllAccounts: bool
-    includeWatchOnly: bool
     colorIds: seq[string]
 
 proc initItem*(
@@ -22,7 +21,6 @@ proc initItem*(
   emoji: string,
   isWatchOnlyAccount: bool=false,
   isAllAccounts: bool = false,
-  includeWatchOnly: bool = true,
   colorIds: seq[string] = @[]
 ): Item =
   result.name = name
@@ -32,7 +30,6 @@ proc initItem*(
   result.colorId = colorId
   result.emoji = emoji
   result.isAllAccounts = isAllAccounts
-  result.includeWatchOnly = includeWatchOnly
   result.colorIds = colorIds
   result.isWatchOnlyAccount = isWatchOnlyAccount
 
@@ -46,7 +43,6 @@ proc `$`*(self: Item): string =
     emoji: {self.emoji},
     isWatchOnlyAccount: {self.isWatchOnlyAccount},
     isAllAccounts: {self.isAllAccounts},
-    includeWatchOnly: {self.includeWatchOnly},
     colorIds: {self.colorIds}
     ]"""
 
@@ -70,9 +66,6 @@ proc getEmoji*(self: Item): string =
 
 proc getIsAllAccounts*(self: Item): bool =
   return self.isAllAccounts
-
-proc getIncludeWatchOnly*(self: Item): bool =
-  return self.includeWatchOnly
 
 proc getColorIds*(self: Item): string =
   return self.colorIds.join(";")

--- a/src/app/modules/main/wallet_section/overview/module.nim
+++ b/src/app/modules/main/wallet_section/overview/module.nim
@@ -65,7 +65,7 @@ proc getWalletAccoutColors(self: Module, walletAccounts: seq[WalletAccountDto]) 
     colors.add(account.colorId)
   return colors
 
-method filterChanged*(self: Module, addresses: seq[string], chainIds: seq[int], includeWatchOnly: bool, allAddresses: bool) =
+method filterChanged*(self: Module, addresses: seq[string], chainIds: seq[int], allAddresses: bool) =
   let walletAccounts = self.controller.getWalletAccountsByAddresses(addresses)
   if allAddresses:
     let item = initItem(
@@ -77,7 +77,6 @@ method filterChanged*(self: Module, addresses: seq[string], chainIds: seq[int], 
       "",
       isWatchOnlyAccount=false,
       isAllAccounts=true,
-      includeWatchOnly=includeWatchOnly,
       self.getWalletAccoutColors(walletAccounts)
     )
     self.view.setData(item)

--- a/src/app/modules/main/wallet_section/overview/view.nim
+++ b/src/app/modules/main/wallet_section/overview/view.nim
@@ -17,7 +17,6 @@ QtObject:
       colorId: string
       emoji: string
       isAllAccounts: bool
-      includeWatchOnly: bool
       colorIds: string
       isWatchOnlyAccount: bool
 
@@ -99,13 +98,6 @@ QtObject:
     read = getIsAllAccounts
     notify = isAllAccountsChanged
 
-  proc getIncludeWatchOnly(self: View): QVariant {.slot.} =
-    return newQVariant(self.includeWatchOnly)
-  proc includeWatchOnlyChanged(self: View) {.signal.}
-  QtProperty[QVariant] includeWatchOnly:
-    read = getIncludeWatchOnly
-    notify = includeWatchOnlyChanged
-
   proc getColorIds(self: View): QVariant {.slot.} =
     return newQVariant(self.colorIds)
   proc colorIdsChanged(self: View) {.signal.}
@@ -147,6 +139,3 @@ QtObject:
     if(self.isAllAccounts != item.getIsAllAccounts()):
       self.isAllAccounts = item.getIsAllAccounts()
       self.isAllAccountsChanged()
-    if(self.includeWatchOnly != item.getIncludeWatchOnly()):
-      self.includeWatchOnly = item.getIncludeWatchOnly()
-      self.includeWatchOnlyChanged()

--- a/src/app/modules/main/wallet_section/send/module.nim
+++ b/src/app/modules/main/wallet_section/send/module.nim
@@ -227,6 +227,9 @@ method load*(self: Module) =
   self.events.on(SIGNAL_WALLET_ACCOUNT_PREFERRED_SHARING_CHAINS_UPDATED) do(e:Args):
     self.refreshWalletAccounts()
 
+  self.events.on(SIGNAL_WALLET_ACCOUNT_HIDDEN_UPDATED) do(e: Args):
+    self.refreshWalletAccounts()
+
   self.controller.init()
   self.view.load()
 

--- a/src/app/modules/main/wallet_section/view.nim
+++ b/src/app/modules/main/wallet_section/view.nim
@@ -47,7 +47,7 @@ QtObject:
   QtProperty[string] currentCurrency:
     read = getCurrentCurrency
 
-  proc filterChanged*(self: View, addresses: string, includeWatchOnly: bool, allAddresses: bool)  {.signal.}
+  proc filterChanged*(self: View, addresses: string, allAddresses: bool)  {.signal.}
 
   proc totalCurrencyBalanceChanged*(self: View) {.signal.}
 
@@ -75,9 +75,6 @@ QtObject:
 
   proc setFillterAllAddresses(self: View) {.slot.} =
     self.delegate.setFillterAllAddresses()
-
-  proc toggleWatchOnlyAccounts(self: View) {.slot.} =
-    self.delegate.toggleWatchOnlyAccounts()
 
   proc setTotalCurrencyBalance*(self: View, totalCurrencyBalance: CurrencyAmount) =
     self.totalCurrencyBalance = totalCurrencyBalance

--- a/src/app/modules/shared/keypairs.nim
+++ b/src/app/modules/shared/keypairs.nim
@@ -48,7 +48,7 @@ proc buildKeypairItem*(keypair: KeypairDto, areTestNetworksEnabled: bool): KeyPa
       icon = "wallet"
     item.addAccount(newKeyPairAccountItem(acc.name, acc.path, acc.address, acc.publicKey, acc.emoji, acc.colorId,
       icon, newCurrencyAmount(), balanceFetched = true, operability = acc.operable, acc.isWallet, areTestNetworksEnabled,
-      acc.prodPreferredChainIds, acc.testPreferredChainIds))
+      acc.prodPreferredChainIds, acc.testPreferredChainIds, acc.hideFromTotalBalance))
   return item
 
 proc buildKeyPairsList*(keypairs: seq[KeypairDto], excludeAlreadyMigratedPairs: bool,

--- a/src/app/modules/shared/wallet_utils.nim
+++ b/src/app/modules/shared/wallet_utils.nim
@@ -42,7 +42,8 @@ proc walletAccountToWalletAccountItem*(w: WalletAccountDto, keycardAccount: bool
     w.operable,
     areTestNetworksEnabled,
     w.prodPreferredChainIds,
-    w.testPreferredChainIds
+    w.testPreferredChainIds,
+    w.hideFromTotalBalance
   )
 
 proc walletAccountToWalletAccountsItem*(w: WalletAccountDto, keycardAccount: bool,
@@ -63,7 +64,8 @@ proc walletAccountToWalletAccountsItem*(w: WalletAccountDto, keycardAccount: boo
     w.isWallet,
     areTestNetworksEnabled,
     w.prodPreferredChainIds,
-    w.testPreferredChainIds
+    w.testPreferredChainIds,
+    w.hideFromTotalBalance
   )
 
 proc walletAccountToWalletAssetsItem*(w: WalletAccountDto): wallet_assets_item.Item =

--- a/src/app/modules/shared_models/keypair_account_item.nim
+++ b/src/app/modules/shared_models/keypair_account_item.nim
@@ -20,13 +20,14 @@ QtObject:
     areTestNetworksEnabled: bool
     prodPreferredChainIds: string
     testPreferredChainIds: string
+    hideFromTotalBalance: bool
 
   proc delete*(self: KeyPairAccountItem) =
     self.QObject.delete
 
   proc newKeyPairAccountItem*(name = "", path = "", address = "", pubKey = "", emoji = "", colorId = "", icon = "",
     balance = newCurrencyAmount(), balanceFetched = true, operability = wa_dto.AccountFullyOperable,
-    isDefaultAccount = false, areTestNetworksEnabled =false, prodPreferredChainIds = "", testPreferredChainIds = ""): KeyPairAccountItem =
+    isDefaultAccount = false, areTestNetworksEnabled =false, prodPreferredChainIds = "", testPreferredChainIds = "", hideFromTotalBalance = false): KeyPairAccountItem =
     new(result, delete)
     result.QObject.setup
     result.name = name
@@ -43,6 +44,7 @@ QtObject:
     result.areTestNetworksEnabled = areTestNetworksEnabled
     result.prodPreferredChainIds = prodPreferredChainIds
     result.testPreferredChainIds = testPreferredChainIds
+    result.hideFromTotalBalance = hideFromTotalBalance
 
   proc `$`*(self: KeyPairAccountItem): string =
     result = fmt"""KeyPairAccountItem[
@@ -59,7 +61,8 @@ QtObject:
       isDefaultAccount: {self.isDefaultAccount},
       areTestNetworksEnabled: {self.areTestNetworksEnabled},
       prodPreferredChainIds: {self.prodPreferredChainIds},
-      testPreferredChainIds: {self.testPreferredChainIds}
+      testPreferredChainIds: {self.testPreferredChainIds},
+      hideFromTotalBalance: {self.hideFromTotalBalance}
       ]"""
 
   proc nameChanged*(self: KeyPairAccountItem) {.signal.}
@@ -191,3 +194,13 @@ QtObject:
   QtProperty[string] preferredSharingChainIds:
     read = preferredSharingChainIds
     notify = preferredSharingChainIdsChanged
+
+  proc hideFromTotalBalanceChanged*(self: KeyPairAccountItem) {.signal.}
+  proc hideFromTotalBalance*(self: KeyPairAccountItem): bool {.slot.} =
+    return self.hideFromTotalBalance
+  proc setHideFromTotalBalance*(self: KeyPairAccountItem, value: bool) =
+    self.hideFromTotalBalance = value
+    self.hideFromTotalBalanceChanged()
+  QtProperty[bool] hideFromTotalBalance:
+    read = hideFromTotalBalance
+    notify = hideFromTotalBalanceChanged

--- a/src/app/modules/shared_models/keypair_account_model.nim
+++ b/src/app/modules/shared_models/keypair_account_model.nim
@@ -141,3 +141,8 @@ QtObject:
           self.items[i].setProdPreferredChainIds(prodPreferredChainIds)
         if testPreferredChainIds.len > 0:
           self.items[i].setTestPreferredChainIds(testPreferredChainIds)
+
+  proc updateAccountHiddenInTotalBalance*(self: KeyPairAccountModel, address: string, hideFromTotalBalance: bool) =
+    for i in 0 ..< self.items.len:
+      if cmpIgnoreCase(self.items[i].getAddress(), address) == 0:
+        self.items[i].setHideFromTotalBalance(hideFromTotalBalance)

--- a/src/app/modules/shared_models/keypair_item.nim
+++ b/src/app/modules/shared_models/keypair_item.nim
@@ -268,6 +268,8 @@ QtObject:
     self.accounts.updateDetailsForAddressIfTheyAreSet(address, name, colorId, emoji)
   proc updatePreferredSharingChainsForAddress*(self: KeyPairItem, address, prodPreferredChainIds, testPreferredChainIds: string) =
     self.accounts.updatePreferredSharingChainsForAddress(address, prodPreferredChainIds, testPreferredChainIds)
+  proc updateAccountHiddenInTotalBalance*(self: KeyPairItem, address: string, hideFromTotalBalance: bool) =
+    self.accounts.updateAccountHiddenInTotalBalance(address, hideFromTotalBalance)
   proc setBalanceForAddress*(self: KeyPairItem, address: string, balance: CurrencyAmount) =
     self.accounts.setBalanceForAddress(address, balance)
   proc updateOperabilityForAllAddresses*(self: KeyPairItem, operability: string) =

--- a/src/app/modules/shared_models/keypair_model.nim
+++ b/src/app/modules/shared_models/keypair_model.nim
@@ -88,10 +88,16 @@ QtObject:
         item.updateOperabilityForAllAddresses(operability)
         break
 
-  proc onPreferredSharingChainsUpdated*(self: KeyPairModel,keyUid, address, prodPreferredChainIds, testPreferredChainIds: string) =
+  proc onPreferredSharingChainsUpdated*(self: KeyPairModel, keyUid, address, prodPreferredChainIds, testPreferredChainIds: string) =
     for item in self.items:
       if keyUid == item.getKeyUid():
         item.getAccountsModel().updatePreferredSharingChainsForAddress(address, prodPreferredChainIds, testPreferredChainIds)
+        break
+
+  proc onHideFromTotalBalanceUpdated*(self: KeyPairModel, keyUid, address: string, hideFromTotalBalance: bool) =
+    for item in self.items:
+      if keyUid == item.getKeyUid():
+        item.getAccountsModel().updateAccountHiddenInTotalBalance(address, hideFromTotalBalance)
         break
 
   proc keypairNameExists*(self: KeyPairModel, name: string): bool =

--- a/src/app/modules/shared_models/wallet_account_item.nim
+++ b/src/app/modules/shared_models/wallet_account_item.nim
@@ -18,6 +18,7 @@ QtObject:
     areTestNetworksEnabled: bool
     prodPreferredChainIds: string
     testPreferredChainIds: string
+    hideFromTotalBalance: bool
 
   proc setup*(self: WalletAccountItem,
     name: string = "",
@@ -32,7 +33,8 @@ QtObject:
     operability: string = wa_dto.AccountFullyOperable,
     areTestNetworksEnabled: bool = false,
     prodPreferredChainIds: string = "",
-    testPreferredChainIds: string = ""
+    testPreferredChainIds: string = "",
+    hideFromTotalBalance: bool = true
     ) =
       self.QObject.setup
       self.name = name
@@ -48,6 +50,7 @@ QtObject:
       self.areTestNetworksEnabled = areTestNetworksEnabled
       self.prodPreferredChainIds = prodPreferredChainIds
       self.testPreferredChainIds = testPreferredChainIds
+      self.hideFromTotalBalance = hideFromTotalBalance
 
   proc delete*(self: WalletAccountItem) =
       self.QObject.delete
@@ -65,7 +68,8 @@ QtObject:
     operability: string = wa_dto.AccountFullyOperable,
     areTestNetworksEnabled: bool = false,
     prodPreferredChainIds: string = "",
-    testPreferredChainIds: string = ""): WalletAccountItem =
+    testPreferredChainIds: string = "",
+    hideFromTotalBalance: bool = true): WalletAccountItem =
     new(result, delete)
     result.QObject.setup
     result.name = name
@@ -81,6 +85,7 @@ QtObject:
     result.areTestNetworksEnabled = areTestNetworksEnabled
     result.prodPreferredChainIds = prodPreferredChainIds
     result.testPreferredChainIds = testPreferredChainIds
+    result.hideFromTotalBalance = hideFromTotalBalance
 
   proc `$`*(self: WalletAccountItem): string =
     result = fmt"""WalletAccountItem(
@@ -97,6 +102,7 @@ QtObject:
       areTestNetworksEnabled: {self.areTestNetworksEnabled},
       prodPreferredChainIds: {self.prodPreferredChainIds},
       testPreferredChainIds: {self.testPreferredChainIds},
+      hideFromTotalBalance: {self.hideFromTotalBalance}
       ]"""
 
   proc nameChanged*(self: WalletAccountItem) {.signal.}
@@ -198,3 +204,10 @@ QtObject:
   QtProperty[string] preferredSharingChainIds:
     read = preferredSharingChainIds
     notify = preferredSharingChainIdsChanged
+
+  proc hideFromTotalBalanceChanged*(self: WalletAccountItem) {.signal.}
+  proc hideFromTotalBalance*(self: WalletAccountItem): bool {.slot.} =
+    return self.hideFromTotalBalance
+  QtProperty[bool] hideFromTotalBalance:
+    read = hideFromTotalBalance
+    notify = hideFromTotalBalanceChanged

--- a/src/app/modules/shared_modules/add_account/controller.nim
+++ b/src/app/modules/shared_modules/add_account/controller.nim
@@ -145,7 +145,7 @@ proc fetchDetailsForAddresses*(self: Controller, addresses: seq[string]) =
   self.walletAccountService.fetchDetailsForAddresses(self.uniqueFetchingDetailsId, addresses)
 
 proc addWalletAccount*(self: Controller, createKeystoreFile, doPasswordHashing: bool, name, address, path, publicKey,
-  keyUid, accountType, colorId, emoji: string): bool =
+  keyUid, accountType, colorId, emoji: string, hideFromTotalBalance: bool): bool =
   var password: string
   if createKeystoreFile:
     password = self.getPassword()
@@ -153,7 +153,7 @@ proc addWalletAccount*(self: Controller, createKeystoreFile, doPasswordHashing: 
       info "cannot create keystore file if provided password is empty", name=name, address=address
       return false
   let err = self.walletAccountService.addWalletAccount(password, doPasswordHashing, name, address, path, publicKey,
-    keyUid, accountType, colorId, emoji)
+    keyUid, accountType, colorId, emoji, hideFromTotalBalance)
   if err.len > 0:
     info "adding wallet account failed", name=name, address=address
     return false

--- a/src/app/modules/shared_modules/add_account/module.nim
+++ b/src/app/modules/shared_modules/add_account/module.nim
@@ -599,6 +599,7 @@ proc doAddAccount[T](self: Module[T]) =
     keyUid = selectedOrigin.getKeyUid()
     createKeystoreFile = not selectedOrigin.getMigratedToKeycard()
     doPasswordHashing = not singletonInstance.userProfile.getIsKeycardUser()
+    hideFromTotalBalance = false
 
   if selectedOrigin.getPairType() == KeyPairType.Profile.int:
     accountType = account_constants.GENERATED
@@ -616,6 +617,7 @@ proc doAddAccount[T](self: Module[T]) =
     addingNewKeyPair = not self.isKeyPairAlreadyAdded(keyUid)
   else:
     accountType = account_constants.WATCH
+    hideFromTotalBalance = true
     createKeystoreFile = false
     doPasswordHashing = false
     keypairName = ""
@@ -678,7 +680,8 @@ proc doAddAccount[T](self: Module[T]) =
       keyUid = keyUid,
       accountType = accountType,
       colorId = self.view.getSelectedColorId(),
-      emoji = self.view.getSelectedEmoji())
+      emoji = self.view.getSelectedEmoji(),
+      hideFromTotalBalance = hideFromTotalBalance)
     if not success:
       error "failed to store account", address=selectedAddrItem.getAddress()
 

--- a/src/app/modules/shared_modules/keycard_popup/controller.nim
+++ b/src/app/modules/shared_modules/keycard_popup/controller.nim
@@ -744,16 +744,6 @@ proc updateKeycardUid*(self: Controller, keyUid: string, keycardUid: string) =
       self.tmpKeycardUid = keycardUid
       info "update keycard uid failed", oldKeycardUid=self.tmpKeycardUid, newKeycardUid=keycardUid
 
-proc addWalletAccount*(self: Controller, name, address, path, publicKey, keyUid, accountType, colorId, emoji: string): bool =
-  if not serviceApplicable(self.walletAccountService):
-    return false
-  let err = self.walletAccountService.addWalletAccount(password = "", doPasswordHashing = false, name, address, path,
-    publicKey, keyUid, accountType, colorId, emoji)
-  if err.len > 0:
-    info "adding wallet account failed", name=name, path=path
-    return false
-  return true
-
 proc addNewSeedPhraseKeypair*(self: Controller, seedPhrase, keyUid, keypairName, rootWalletMasterKey: string,
   accounts: seq[WalletAccountDto]): bool =
   let err = self.walletAccountService.addNewSeedPhraseKeypair(seedPhrase, password = "", doPasswordHashing = false, keyUid,

--- a/src/app_service/service/settings/dto/settings.nim
+++ b/src/app_service/service/settings/dto/settings.nim
@@ -45,7 +45,6 @@ const KEY_DISPLAY_NAME* = "display-name"
 const KEY_BIO* = "bio"
 const KEY_TEST_NETWORKS_ENABLED* = "test-networks-enabled?"
 const KEY_IS_SEPOLIA_ENABLED* = "is-sepolia-enabled?"
-const INCLUDE_WATCH_ONLY_ACCOUNT* = "include-watch-only-account?"
 const PROFILE_MIGRATION_NEEDED* = "profile-migration-needed"
 
 # Notifications Settings Values
@@ -138,7 +137,6 @@ type
     notificationsSoundsEnabled*: bool
     notificationsVolume*: int
     notificationsMessagePreview*: int
-    includeWatchOnlyAccount*: bool
     profileMigrationNeeded*: bool
     isSepoliaEnabled*: bool
 
@@ -195,7 +193,6 @@ proc toSettingsDto*(jsonObj: JsonNode): SettingsDto =
   discard jsonObj.getProp(KEY_GIF_FAVORITES, result.gifFavorites)
   discard jsonObj.getProp(KEY_TEST_NETWORKS_ENABLED, result.testNetworksEnabled)
   discard jsonObj.getProp(KEY_IS_SEPOLIA_ENABLED, result.isSepoliaEnabled)
-  discard jsonObj.getProp(INCLUDE_WATCH_ONLY_ACCOUNT, result.includeWatchOnlyAccount)
   discard jsonObj.getProp(PROFILE_MIGRATION_NEEDED, result.profileMigrationNeeded)
 
   var pinnedMailserverObj: JsonNode

--- a/src/app_service/service/settings/service.nim
+++ b/src/app_service/service/settings/service.nim
@@ -27,7 +27,6 @@ const SIGNAL_BIO_UPDATED* = "bioUpdated"
 const SIGNAL_MNEMONIC_REMOVED* = "mnemonicRemoved"
 const SIGNAL_SOCIAL_LINKS_UPDATED* = "socialLinksUpdated"
 const SIGNAL_CURRENT_USER_STATUS_UPDATED* = "currentUserStatusUpdated"
-const SIGNAL_INCLUDE_WATCH_ONLY_ACCOUNTS_UPDATED* = "includeWatchOnlyAccounts"
 const SIGNAL_PROFILE_MIGRATION_NEEDED_UPDATED* = "profileMigrationNeededUpdated"
 
 logScope:
@@ -114,9 +113,6 @@ QtObject:
           if settingsField.name == KEY_MNEMONIC:
             self.settings.mnemonic = ""
             self.events.emit(SIGNAL_MNEMONIC_REMOVED, Args())
-          if settingsField.name == INCLUDE_WATCH_ONLY_ACCOUNT:
-            self.settings.includeWatchOnlyAccount = settingsField.value.getBool
-            self.events.emit(SIGNAL_INCLUDE_WATCH_ONLY_ACCOUNTS_UPDATED, SettingsBoolValueArgs(value: self.settings.includeWatchOnlyAccount))
           if settingsField.name == PROFILE_MIGRATION_NEEDED:
             self.settings.profileMigrationNeeded = settingsField.value.getBool
             self.events.emit(SIGNAL_PROFILE_MIGRATION_NEEDED_UPDATED, SettingsBoolValueArgs(value: self.settings.profileMigrationNeeded))
@@ -983,15 +979,6 @@ QtObject:
       data.error = e.msg
       error "error saving social links", errDescription=data.error
     self.storeSocialLinksAndNotify(data)
-
-  proc isIncludeWatchOnlyAccount*(self: Service): bool =
-    return self.settings.includeWatchOnlyAccount
-
-  proc toggleIncludeWatchOnlyAccount*(self: Service) =
-    let newValue = not self.settings.includeWatchOnlyAccount
-    if(self.saveSetting(INCLUDE_WATCH_ONLY_ACCOUNT, newValue)):
-      self.settings.includeWatchOnlyAccount = newValue
-      self.events.emit(SIGNAL_INCLUDE_WATCH_ONLY_ACCOUNTS_UPDATED, SettingsBoolValueArgs(value: newValue))
 
   proc getProfileMigrationNeeded*(self: Service): bool =
     self.settings.profileMigrationNeeded

--- a/src/app_service/service/wallet_account/dto/account_dto.nim
+++ b/src/app_service/service/wallet_account/dto/account_dto.nim
@@ -38,6 +38,7 @@ type
     position*: int
     prodPreferredChainIDs*: string
     testPreferredChainIDs*: string
+    hideFromTotalBalance*: bool
 
 proc toWalletAccountDto*(jsonObj: JsonNode): WalletAccountDto =
   result = WalletAccountDto()
@@ -59,6 +60,7 @@ proc toWalletAccountDto*(jsonObj: JsonNode): WalletAccountDto =
   discard jsonObj.getProp("position", result.position)
   discard jsonObj.getProp("prodPreferredChainIds", result.prodPreferredChainIds)
   discard jsonObj.getProp("testPreferredChainIds", result.testPreferredChainIds)
+  discard jsonObj.getProp("hidden", result.hideFromTotalBalance)
   result.assetsLoading = true
   result.hasBalanceCache = false
   result.hasMarketValuesCache = false
@@ -81,5 +83,6 @@ proc `$`*(self: WalletAccountDto): string =
     removed: {self.removed},
     operable: {self.operable},
     prodPreferredChainIds: {self.prodPreferredChainIds},
-    testPreferredChainIds: {self.testPreferredChainIds}
+    testPreferredChainIds: {self.testPreferredChainIds},
+    hideFromTotalBalance: {self.hideFromTotalBalance}
     ]"""

--- a/src/app_service/service/wallet_account/signals_and_payloads.nim
+++ b/src/app_service/service/wallet_account/signals_and_payloads.nim
@@ -21,6 +21,7 @@ const SIGNAL_WALLET_ACCOUNT_POSITION_UPDATED* = "walletAccount/positionUpdated"
 const SIGNAL_WALLET_ACCOUNT_OPERABILITY_UPDATED* = "walletAccount/operabilityUpdated"
 const SIGNAL_WALLET_ACCOUNT_CHAIN_ID_FOR_URL_FETCHED* = "walletAccount/chainIdForUrlFetched"
 const SIGNAL_WALLET_ACCOUNT_PREFERRED_SHARING_CHAINS_UPDATED* = "walletAccount/preferredSharingChainsUpdated"
+const SIGNAL_WALLET_ACCOUNT_HIDDEN_UPDATED* = "walletAccount/accountHiddenChanged"
 
 const SIGNAL_KEYPAIR_SYNCED* = "keypairSynced"
 const SIGNAL_KEYPAIR_NAME_CHANGED* = "keypairNameChanged"

--- a/src/backend/accounts.nim
+++ b/src/backend/accounts.nim
@@ -41,7 +41,7 @@ proc deleteKeypair*(keyUid: string): RpcResponse[JsonNode] {.raises: [Exception]
   return core.callPrivateRPC("accounts_deleteKeypair", payload)
 
 ## Adds a new account and creates a Keystore file if password is provided, otherwise it only creates a new account. Notifies paired devices.
-proc addAccount*(password, name, address, path, publicKey, keyUid, accountType, colorId, emoji: string):
+proc addAccount*(password, name, address, path, publicKey, keyUid, accountType, colorId, emoji: string, hideFromTotalBalance: bool):
   RpcResponse[JsonNode] {.raises: [Exception].} =
   let payload = %* [
     password,
@@ -56,7 +56,7 @@ proc addAccount*(password, name, address, path, publicKey, keyUid, accountType, 
       "name": name,
       "emoji": emoji,
       "colorId": colorId,
-      #"hidden" present on the status-go side, but we don't use it
+      "hidden": hideFromTotalBalance
       #"clock" we leave this empty, set on the status-go side
       #"removed" present on the status-go side, used for synchronization, no need to set it here
     }
@@ -90,7 +90,7 @@ proc addKeypair*(password, keyUid, keypairName, keypairType, rootWalletMasterKey
           "name": acc.name,
           "emoji": acc.emoji,
           "colorId": acc.colorId,
-          #"hidden" present on the status-go side, but we don't use it
+          "hidden": acc.hideFromTotalBalance
           #"clock" we leave this empty, set on the status-go side
           #"removed" present on the status-go side, used for synchronization, no need to set it here
         }
@@ -100,13 +100,13 @@ proc addKeypair*(password, keyUid, keypairName, keypairType, rootWalletMasterKey
   return core.callPrivateRPC("accounts_addKeypair", payload)
 
 ## Adds a new account without creating a Keystore file and notifies paired devices
-proc addAccountWithoutKeystoreFileCreation*(name, address, path, publicKey, keyUid, accountType, colorId, emoji: string):
+proc addAccountWithoutKeystoreFileCreation*(name, address, path, publicKey, keyUid, accountType, colorId, emoji: string, hideFromTotalBalance: bool):
   RpcResponse[JsonNode] {.raises: [Exception].} =
-  return addAccount(password = "", name, address, path, publicKey, keyUid, accountType, colorId, emoji)
+  return addAccount(password = "", name, address, path, publicKey, keyUid, accountType, colorId, emoji, hideFromTotalBalance)
 
 ## Updates either regular or keycard account, without interaction to a Keystore file and notifies paired devices
 proc updateAccount*(name, address, path: string, publicKey, keyUid, accountType, colorId, emoji: string,
-  walletDefaultAccount: bool, chatDefaultAccount: bool, prodPreferredChainIds, testPreferredChainIds: string):
+  walletDefaultAccount: bool, chatDefaultAccount: bool, prodPreferredChainIds, testPreferredChainIds: string, hideFromTotalBalance: bool):
   RpcResponse[JsonNode] {.raises: [Exception].} =
   let payload = %* [
     {
@@ -121,8 +121,8 @@ proc updateAccount*(name, address, path: string, publicKey, keyUid, accountType,
       "emoji": emoji,
       "colorId": colorId,
       "prodPreferredChainIds": prodPreferredChainIds,
-      "testPreferredChainIds": testPreferredChainIds
-      #"hidden" present on the status-go side, but we don't use it
+      "testPreferredChainIds": testPreferredChainIds,
+      "hidden": hideFromTotalBalance
       #"clock" we leave this empty, set on the status-go side
       #"removed" present on the status-go side, used for synchronization, no need to set it here
     }

--- a/storybook/pages/AccountViewPage.qml
+++ b/storybook/pages/AccountViewPage.qml
@@ -39,7 +39,6 @@ SplitView {
                                                displayDecimals: 4,
                                                stripTrailingZeroes: false}),
                                  isAllAccounts: false,
-                                 includeWatchOnly: false,
                                  path: "m/44’/60’/0’/0’/34",
                                  preferredSharingChainIds:  walletStore.areTestNetworksEnabled ? "5:420:421613": "1:10:42161"
                              })
@@ -87,6 +86,9 @@ SplitView {
             account: d.dummyOverview
             walletStore: d.walletStore
             keyPair: d.keyPairModel.data[0].keyPair
+            onUpdateWatchAccountHiddenFromTotalBalance: {
+                console.warn("updateWatchAccountHiddenFromTotalBalance :: address ::", address, "hideFromTotalBalance :: ", hideFromTotalBalance)
+            }
         }
     }  
 

--- a/storybook/pages/ActivityFilterMenuPage.qml
+++ b/storybook/pages/ActivityFilterMenuPage.qml
@@ -48,7 +48,6 @@ SplitView {
                                                               displayDecimals: 4,
                                                               stripTrailingZeroes: false}),
                                         isAllAccounts: false,
-                                        includeWatchOnly: false
                                     })
 
             function getNameForAddress(address) {

--- a/storybook/pages/WalletHeaderPage.qml
+++ b/storybook/pages/WalletHeaderPage.qml
@@ -56,7 +56,6 @@ SplitView {
                                                        displayDecimals: 4,
                                                        stripTrailingZeroes: false}),
                                  isAllAccounts: false,
-                                 includeWatchOnly: false
                              })
         }
 
@@ -73,7 +72,6 @@ SplitView {
                                                                          displayDecimals: 4,
                                                                          stripTrailingZeroes: false}),
                                                    isAllAccounts: true,
-                                                   includeWatchOnly: true,
                                                    colorIds: "purple;pink;magenta"
                                                })
 

--- a/ui/app/AppLayouts/Profile/controls/WalletKeyPairDelegate.qml
+++ b/ui/app/AppLayouts/Profile/controls/WalletKeyPairDelegate.qml
@@ -18,10 +18,8 @@ Rectangle {
     property bool hasPairedDevices
     property var getNetworkShortNames: function(chainIds){}
     property string userProfilePublicKey
-    property bool includeWatchOnlyAccount
 
     signal goToAccountView(var account)
-    signal toggleIncludeWatchOnlyAccount()
     signal runExportQrFlow()
     signal runImportViaQrFlow()
     signal runImportViaSeedPhraseFlow()
@@ -98,16 +96,6 @@ Rectangle {
                             onRunStopUsingKeycardFlow: root.runStopUsingKeycardFlow()
                         }
                     }
-                },
-                StatusBaseText {
-                    anchors.verticalCenter: parent.verticalCenter
-                    text: qsTr("Include in total balance")
-                    visible: d.isWatchOnly
-                },
-                StatusSwitch {
-                    visible: d.isWatchOnly
-                    checked: root.includeWatchOnlyAccount
-                    onClicked: root.toggleIncludeWatchOnlyAccount()
                 }
             ]
         }
@@ -120,6 +108,7 @@ Rectangle {
             model: d.relatedAccounts
             delegate: WalletAccountDelegate {
                 width: ListView.view.width
+                label: keyPair.pairType !== Constants.keypair.type.watchOnly ? "" : model.account.hideFromTotalBalance ? qsTr("Excl. from total balance"): qsTr("Incl. in total balance")
                 account: model.account
                 totalCount: ListView.view.count
                 getNetworkShortNames: root.getNetworkShortNames

--- a/ui/app/AppLayouts/Profile/stores/WalletStore.qml
+++ b/ui/app/AppLayouts/Profile/stores/WalletStore.qml
@@ -28,11 +28,6 @@ QtObject {
     property var assets: walletSectionAssets.assets
     property var accounts: Global.appIsReady? accountsModule.accounts : null
     property var originModel: accountsModule.keyPairModel
-    property bool includeWatchOnlyAccount: accountsModule.includeWatchOnlyAccount
-
-    function toggleIncludeWatchOnlyAccount() {
-       accountsModule.toggleIncludeWatchOnlyAccount()
-    }
 
     property string userProfilePublicKey: userProfile.pubKey
 
@@ -149,5 +144,9 @@ QtObject {
                 nativeCurrencySymbol: combinedNetwork.test.nativeCurrencySymbol},
             layer: combinedNetwork.layer
         }
+    }
+
+    function updateWatchAccountHiddenFromTotalBalance(address, hideFromTotalBalance) {
+        accountsModule.updateWatchAccountHiddenFromTotalBalance(address, hideFromTotalBalance)
     }
 }

--- a/ui/app/AppLayouts/Profile/views/WalletView.qml
+++ b/ui/app/AppLayouts/Profile/views/WalletView.qml
@@ -199,6 +199,9 @@ SettingsContentBase {
             onRunStopUsingKeycardFlow: {
                 root.rootStore.keycardStore.runStopUsingKeycardPopup(keyPair.keyUid)
             }
+            onUpdateWatchAccountHiddenFromTotalBalance: {
+                root.walletStore.updateWatchAccountHiddenFromTotalBalance(address, hideFromTotalBalance)
+            }
         }
 
         DappPermissionsView {

--- a/ui/app/AppLayouts/Profile/views/wallet/AccountView.qml
+++ b/ui/app/AppLayouts/Profile/views/wallet/AccountView.qml
@@ -29,6 +29,7 @@ ColumnLayout {
     signal runImportMissingKeypairFlow()
     signal runMoveKeypairToKeycardFlow()
     signal runStopUsingKeycardFlow()
+    signal updateWatchAccountHiddenFromTotalBalance(string address, bool hideFromTotalBalance)
 
     property var account
     property var keyPair
@@ -218,6 +219,27 @@ ColumnLayout {
 
     StatusListItem {
         Layout.fillWidth: true
+        title: qsTr("Include in total balance")
+        visible: d.watchOnlyAccount
+        color: Theme.palette.transparent
+        components: [
+            StatusSwitch {
+                checked: !!root.account && !account.hideFromTotalBalance
+                onToggled: root.updateWatchAccountHiddenFromTotalBalance(account.address, !checked)
+            }
+        ]
+    }
+
+    Separator {
+        visible: d.watchOnlyAccount
+        Layout.fillWidth: true
+        Layout.preferredHeight: 1
+        color: Theme.palette.baseColor2
+    }
+
+    StatusListItem {
+        Layout.fillWidth: true
+        Layout.topMargin: Style.current.halfPadding
         title: qsTr("Preferred networks when sharing this address")
         color: Theme.palette.transparent
         components: [

--- a/ui/app/AppLayouts/Profile/views/wallet/MainView.qml
+++ b/ui/app/AppLayouts/Profile/views/wallet/MainView.qml
@@ -223,9 +223,7 @@ Column {
                 hasPairedDevices: root.walletStore.walletModule.hasPairedDevices
                 getNetworkShortNames: walletStore.getNetworkShortNames
                 userProfilePublicKey: walletStore.userProfilePublicKey
-                includeWatchOnlyAccount: walletStore.includeWatchOnlyAccount
                 onGoToAccountView: root.goToAccountView(account, keyPair)
-                onToggleIncludeWatchOnlyAccount: walletStore.toggleIncludeWatchOnlyAccount()
                 onRunRenameKeypairFlow: root.runRenameKeypairFlow(model)
                 onRunRemoveKeypairFlow: root.runRemoveKeypairFlow(model)
                 onRunImportViaSeedPhraseFlow: {

--- a/ui/app/AppLayouts/Wallet/WalletLayout.qml
+++ b/ui/app/AppLayouts/Wallet/WalletLayout.qml
@@ -30,7 +30,7 @@ Item {
     Connections {
         target: walletSection
 
-        function onFilterChanged(address, includeWatchOnly, allAddresses) {
+        function onFilterChanged(address, allAddresses) {
             root.showAllAccounts = allAddresses
         }
 

--- a/ui/app/AppLayouts/Wallet/panels/WalletHeader.qml
+++ b/ui/app/AppLayouts/Wallet/panels/WalletHeader.qml
@@ -82,31 +82,6 @@ Item {
                 visible: !overview.isAllAccounts
             }
 
-
-            StatusButton {
-                objectName: "hideShowWatchOnlyButton"
-                Layout.preferredHeight: 38
-                Layout.alignment: Qt.AlignTop
-
-                spacing: 8
-                size: StatusBaseButton.Size.Small
-                borderColor: Theme.palette.directColor7
-                normalColor: Theme.palette.transparent
-                hoverColor: Theme.palette.baseColor2
-
-                font.weight: Font.Normal
-                textColor: Theme.palette.baseColor1
-                text: overview.includeWatchOnly ? qsTr("Hide watched addresses"): qsTr("Show watched addresses")
-
-                icon.name: overview.includeWatchOnly ? "hide" : "show"
-                icon.height: 16
-                icon.width: 16
-                icon.color: Theme.palette.baseColor1
-
-                onClicked: switchHideWatchOnlyAccounts()
-                visible: overview.isAllAccounts
-            }
-
             // network filter
             NetworkFilter {
                 id: networkFilter

--- a/ui/app/AppLayouts/Wallet/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Wallet/stores/RootStore.qml
@@ -378,4 +378,8 @@ QtObject {
         }
         return prefChains
     }
+
+    function updateWatchAccountHiddenFromTotalBalance(address, hideFromTotalBalance) {
+        walletSectionAccounts.updateWatchAccountHiddenFromTotalBalance(address, hideFromTotalBalance)
+    }
 }

--- a/ui/app/AppLayouts/Wallet/views/AccountContextMenu.qml
+++ b/ui/app/AppLayouts/Wallet/views/AccountContextMenu.qml
@@ -5,6 +5,8 @@ import StatusQ.Popups 0.1
 
 import "../stores"
 
+import utils 1.0
+
 StatusMenu {
     id: root
 
@@ -14,6 +16,7 @@ StatusMenu {
     signal deleteAccountClicked()
     signal addNewAccountClicked()
     signal addWatchOnlyAccountClicked()
+    signal hideFromTotalBalanceClicked(string address, bool hideFromTotalBalance)
 
     width: 204
 
@@ -40,6 +43,14 @@ StatusMenu {
         onTriggered: {
             root.editAccountClicked()
         }
+    }   
+
+    StatusAction {
+        objectName: "AccountMenu-HideFromTotalBalance-%1".arg(root.uniqueIdentifier)
+        enabled: !!root.account && root.account.walletType === Constants.watchWalletType
+        text: !!root.account ? root.account.hideFromTotalBalance ? qsTr("Include in total balance"): qsTr("Exclude from total balance"): ""
+        icon.name: !!root.account ? root.account.hideFromTotalBalance ? "show" : "hide": ""
+        onTriggered: root.hideFromTotalBalanceClicked(root.account.address, !root.account.hideFromTotalBalance)
     }
 
     StatusAction {

--- a/ui/app/AppLayouts/Wallet/views/LeftTabView.qml
+++ b/ui/app/AppLayouts/Wallet/views/LeftTabView.qml
@@ -115,6 +115,8 @@ Rectangle {
                 removeAccountConfirmation.accountDerivationPath = account.path
                 removeAccountConfirmation.active = true
             }
+
+            onHideFromTotalBalanceClicked: RootStore.updateWatchAccountHiddenFromTotalBalance(address, hideFromTotalBalance)
         }
     }
 
@@ -158,7 +160,7 @@ Rectangle {
         function onDestroyAddAccountPopup() {
             addAccount.active = false
         }
-        function onFilterChanged(address, includeWatchOnly, allAddresses) {
+        function onFilterChanged(address, allAddresses) {
             root.currentAddress = allAddresses ? "" : address
             root.showAllAccounts = allAddresses
         }
@@ -269,7 +271,7 @@ Rectangle {
                     }
                     anchors.horizontalCenter: !!parent ? parent.horizontalCenter : undefined
                     title: model.name
-                    subTitle: LocaleUtils.currencyAmountToLocaleString(model.currencyBalance)
+                    subTitle: !model.hideFromTotalBalance ? LocaleUtils.currencyAmountToLocaleString(model.currencyBalance): ""
                     asset.emoji: !!model.emoji ? model.emoji: ""
                     asset.color: Utils.getColorForId(model.colorId)
                     asset.name: !model.emoji ? "filled-account": ""

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -142,16 +142,6 @@ Item {
             )
         }
 
-        function onShowIncludeWatchOnlyAccountUpdated(includeWatchOnly: bool) {
-            Global.displayToastMessage(
-                        includeWatchOnly ? qsTr("Your wallet’s total balance will now include balances of watched addresses") : qsTr("Your wallet’s total balance will not include balances of watched addresses") ,
-                        "",
-                        "checkmark-circle",
-                        false,
-                        Constants.ephemeralNotificationType.success,
-                        "")
-        }
-
         function onShowToastKeypairRemoved(keypairName: string) {
             Global.displayToastMessage(
                 qsTr("“%1” keypair and its derived accounts were successfully removed from all devices").arg(keypairName),


### PR DESCRIPTION
fixes #12305

go PR: https://github.com/status-im/status-go/pull/4153/files

### What does the PR do

Goal is to control per account which watch address is being displayed

Design: https://www.figma.com/file/idUoxN7OIW2Jpp3PMJ1Rl8/%E2%9A%99%EF%B8%8F-Settings-%7C-Desktop?type=design&node-id=19218-313442&mode=design&t=HnNmumCrgH8Vl23C-0

### Affected areas

Wallet Account Settings
Main Wallet View
Context menu on right click of account list

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

https://github.com/status-im/status-desktop/assets/60327365/1f12eb1a-9643-4d6d-830f-4abc0c271e82


