### PR TITLE
feat(ci): add USE_MOCKED_KEYCARD_LIB parameter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -389,21 +389,14 @@ status-go-clean:
 	rm -f $(STATUSGO)
 
 STATUSKEYCARDGO := vendor/status-keycard-go/build/libkeycard/libkeycard.$(LIBSTATUS_EXT)
-STATUSKEYCARDGO_LIBDIR := $(shell pwd)/$(shell dirname "$(STATUSKEYCARDGO)")
-export STATUSKEYCARDGO_LIBDIR
-
-STATUSKEYCARDGO_RULE := build-lib
-ifeq ($(TEST_ENVIRONMENT),true)
-    STATUSKEYCARDGO_RULE := build-mocked-lib
-else ifeq ($(TEST_ENVIRONMENT),1)
-    STATUSKEYCARDGO_RULE := build-mocked-lib
-endif
+export STATUSKEYCARDGO_LIBDIR := "$(shell pwd)/$(shell dirname "$(STATUSKEYCARDGO)")"
 
 status-keycard-go: $(STATUSKEYCARDGO)
 $(STATUSKEYCARDGO): | deps
 	echo -e $(BUILD_MSG) "status-keycard-go"
-	+ cd vendor/status-keycard-go && \
-	  $(MAKE) $(STATUSKEYCARDGO_RULE) $(STATUSKEYCARDGO_MAKE_PARAMS) $(HANDLE_OUTPUT)
+	+ $(MAKE) -C vendor/status-keycard-go \
+		$(if $(filter 1 true,$(USE_MOCKED_KEYCARD_LIB)), build-mocked-lib, build-lib) \
+		$(STATUSKEYCARDGO_MAKE_PARAMS) $(HANDLE_OUTPUT)
 
 QRCODEGEN := vendor/QR-Code-generator/c/libqrcodegen.a
 

--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -31,6 +31,11 @@ pipeline {
       description: 'Extra Nim flags. Examples: --verbosity:2 --passL:"-v" --passC:"-v"',
       defaultValue: '--colors:off'
     )
+    booleanParam(
+      name: 'USE_MOCKED_KEYCARD_LIB',
+      description: 'Decides whether the mocked status-keycard-go library is built.',
+      defaultValue: getMockedKeycardLibDefault()
+    )
   }
 
   options {
@@ -113,4 +118,8 @@ def getArch() {
     for (def arch in ['x86_64', 'aarch64']) {
       if (tokens.contains(arch)) { return arch }
     }
+}
+
+def getMockedKeycardLibDefault() {
+    return utils.isReleaseBuild() ? 'false' : 'true'
 }

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -26,6 +26,11 @@ pipeline {
       description: 'Extra Nim flags. Examples: --verbosity:2 --passL:"-v" --passC:"-v"',
       defaultValue: '--colors:off'
     )
+    booleanParam(
+      name: 'USE_MOCKED_KEYCARD_LIB',
+      description: 'Decides whether the mocked status-keycard-go library is built.',
+      defaultValue: false
+    )
   }
 
   options {

--- a/ci/Jenkinsfile.tests-e2e
+++ b/ci/Jenkinsfile.tests-e2e
@@ -77,7 +77,8 @@ pipeline {
     /* Ganache config */
     GANACHE_RPC_PORT = "${9545 + env.EXECUTOR_NUMBER.toInteger()}"
     GANACHE_MNEMONIC = 'pelican chief sudden oval media rare swamp elephant lawsuit wheat knife initial'
-    TEST_ENVIRONMENT = '1'
+    /* Runtime flag to make testing of the app easier. */
+    STATUS_RUNTIME_TEST_MODE = '1'
   }
 
   stages {

--- a/ci/Jenkinsfile.windows
+++ b/ci/Jenkinsfile.windows
@@ -23,6 +23,11 @@ pipeline {
       description: 'Extra Nim flags. Examples: --verbosity:2 --passL:"-v" --passC:"-v"',
       defaultValue: '--colors:off'
     )
+    booleanParam(
+      name: 'USE_MOCKED_KEYCARD_LIB',
+      description: 'Decides whether the mocked status-keycard-go library is built.',
+      defaultValue: false
+    )
   }
 
   options {

--- a/src/app/global/local_account_settings.nim
+++ b/src/app/global/local_account_settings.nim
@@ -46,7 +46,7 @@ QtObject:
       self.storeToKeychainValueChanged()
 
   proc getStoreToKeychainValue*(self: LocalAccountSettings): string {.slot.} =
-    if(self.settings.isNil or existsEnv(TEST_ENVIRONMENT_VAR)):
+    if self.settings.isNil or TEST_MODE_ENABLED:
       return DEFAULT_STORE_TO_KEYCHAIN
 
     self.settings.value(LS_KEY_STORE_TO_KEYCHAIN).stringVal

--- a/src/app/global/local_app_settings.nim
+++ b/src/app/global/local_app_settings.nim
@@ -17,7 +17,7 @@ const LAS_KEY_CUSTOM_MOUSE_SCROLLING_ENABLED = "global/custom_mouse_scroll_enabl
 const DEFAULT_CUSTOM_MOUSE_SCROLLING_ENABLED = false
 const DEFAULT_VISIBILITY = 2 #windowed visibility, from qml
 const LAS_KEY_FAKE_LOADING_SCREEN_ENABLED = "global/fake_loading_screen"
-const DEFAULT_FAKE_LOADING_SCREEN_ENABLED = defined(production) and (not existsEnv(TEST_ENVIRONMENT_VAR)) #enabled in production, disabled in development and e2e tests
+const DEFAULT_FAKE_LOADING_SCREEN_ENABLED = defined(production) and not TEST_MODE_ENABLED #enabled in production, disabled in development and e2e tests
 const LAS_KEY_SHARDED_COMMUNITIES_ENABLED = "global/sharded_communities"
 const DEFAULT_LAS_KEY_SHARDED_COMMUNITIES_ENABLED = false
 
@@ -144,8 +144,7 @@ QtObject:
 
 
   proc getTestEnvironment*(self: LocalAppSettings): bool {.slot.} =
-    let value = getEnv(TEST_ENVIRONMENT_VAR)
-    return value.toUpperAscii() == "TRUE" or value == "1"
+    return TEST_MODE_ENABLED
 
   QtProperty[bool] testEnvironment:
     read = getTestEnvironment

--- a/src/constants.nim
+++ b/src/constants.nim
@@ -88,4 +88,7 @@ const GIT_COMMIT* {.strdefine.} = ""
 const APP_VERSION* = if defined(production): DESKTOP_VERSION else: fmt("{GIT_COMMIT}")
 
 # Name of the test environment var to check for
-const TEST_ENVIRONMENT_VAR* = "TEST_ENVIRONMENT"
+const STATUS_RUNTIME_TEST_MODE_VAR* = "STATUS_RUNTIME_TEST_MODE"
+
+const TEST_MODE_ENABLED* = getEnv(STATUS_RUNTIME_TEST_MODE_VAR).toUpperAscii() == "TRUE" or
+  getEnv(STATUS_RUNTIME_TEST_MODE_VAR) == "1"


### PR DESCRIPTION
Changes:

* Refactors the `status-keycard-go` to use `USE_MOCKED_KEYCARD_LIB` env variable.
  - Use of `TEST_ENVIRONMENT` makes no sense since it's used at runtime.
* Renames `TEST_ENVIRONMENT` env variables to `STATUS_RUNTIME_TEST_MODE`.
  - Because it needs to be clear this is runtime and what it actually does.
* Adds `USE_MOCKED_KEYCARD_LIB` parameter to Jenkins CI builds
  - It will default to `true` for linux builds except release ones.
  - This setting can always be overriden manually for any build.
    
Resolves:
* https://github.com/status-im/status-desktop/issues/12412