### PR TITLE
fix: Update the Beta dialog design to better fit the content

### DIFF
--- a/ui/StatusQ/src/StatusQ/Popups/StatusModal.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/StatusModal.qml
@@ -10,10 +10,10 @@ import "statusModal" as Spares
 
 /*!
    \qmltype StatusModal
-   \inherits Popup
+   \inherits StatusDialog
    \inqmlmodule StatusQ.Popups
    \since StatusQ.Popups 0.1
-   \brief The StatusModal provides a template for creating Modals.
+   \brief DEPRECATED: for new code, please use StatusDialog! The StatusModal provides a template for creating Modals.
 
    Example of how to use it:
 
@@ -134,7 +134,10 @@ StatusDialog {
         type: StatusModalHeaderSettings
         This property exposes the different properties of the standard header.
     */
-    property StatusModalHeaderSettings headerSettings: StatusModalHeaderSettings {}
+    property StatusModalHeaderSettings headerSettings: StatusModalHeaderSettings {
+        title: root.title
+        subTitle: root.subtitle
+    }
     /*!
        \qmlproperty rightButtons
         This property helps user assign the right buttons on the footer.

--- a/ui/imports/shared/popups/UserAgreementPopup.qml
+++ b/ui/imports/shared/popups/UserAgreementPopup.qml
@@ -14,13 +14,13 @@ import utils 1.0
 StatusModal {
     id: root
     width: 640
-    headerSettings.title: qsTr("Welcome to Status Desktop Beta")
+    title: qsTr("Welcome to Status Desktop Beta")
     hasCloseButton: false
+    verticalPadding: 20
 
     closePolicy: Popup.NoAutoClose
 
     component Paragraph: StatusBaseText {
-        font.pixelSize: 15
         lineHeightMode: Text.FixedHeight
         lineHeight: 22
         visible: !!text
@@ -30,7 +30,7 @@ StatusModal {
     component AgreementSection: ColumnLayout {
         property alias title: titleItem.text
         property alias body: bodyItem.text
-        spacing: 12
+        spacing: 8
         Paragraph {
             id: titleItem
             Layout.fillWidth: true
@@ -53,63 +53,39 @@ StatusModal {
         ColumnLayout {
             id: layout
             width: scrollView.availableWidth
-            spacing: 22
-            StatusRoundedImage {
-                id: statusRoundedImage
-                objectName: "headerImage"
-                Layout.preferredWidth: 64
-                Layout.preferredHeight: 64
-                Layout.alignment: Qt.AlignHCenter
-                image.source: Style.png("status-logo")
-                image.mipmap: true
-            }
+            spacing: 20
 
             AgreementSection {
                 title: qsTr("Warning - Status desktop is currently in Beta")
-                body: qsTr("•  The Wallet is not yet safe or secure to use
-•  Do not use real funds in the Wallet
-•  Do not use accounts that contain tokens of value in the Wallet")
+                body: qsTr(" •  The Wallet is not yet safe or secure to use
+ •  Do not use real funds in the Wallet
+ •  Do not use accounts that contain tokens of value in the Wallet")
             }
 
             AgreementSection {
                 title: qsTr("Also be aware")
-                body: qsTr("•  Status Desktop is incompatible with Status Mobile versions 1.x
-•  This version of Status may break or stop working without warning
-•  Communities created with this version may be broken by future releases
-•  Status desktop currently consumes large amounts of bandwidth")
+                body: qsTr(" •  Status Desktop is incompatible with Status Mobile versions 1.x
+ •  This version of Status may break or stop working without warning
+ •  Communities created with this version may be broken by future releases
+ •  Status desktop currently consumes large amounts of bandwidth")
             }
 
             AgreementSection {
                 body: qsTr("We are working to fix all these issues ASAP, ahead of Status Desktop’s 1.0 release!")
             }
 
-            StatusDialogDivider {
-                Layout.fillWidth: true
-            }
-
-            AgreementSection {
-                body: qsTr("I confirm that...")
-            }
-
             StatusCheckBox {
                 id: agreeToUse
                 Layout.fillWidth: true
-                Layout.topMargin: -10 //reduced margin by design
-                contentItem: Paragraph {
-                    text: qsTr("I’ve read the above and understand that Status Desktop is Beta software")
-                    leftPadding: readyToUse.indicator.width + readyToUse.spacing
-                }
+                Layout.topMargin: -8 //reduced margin by design
+                text: qsTr("I’ve read the above and understand that Status Desktop is Beta software")
             }
 
             StatusCheckBox {
                 id: readyToUse
                 Layout.fillWidth: true
-                Layout.topMargin: -10 //reduced margin by design
-                Layout.bottomMargin: layout.spacing
-                contentItem: Paragraph {
-                    text: qsTr("I’m ready to use Status Desktop Beta")
-                    leftPadding: readyToUse.indicator.width + readyToUse.spacing
-                }
+                Layout.topMargin: -16 //reduced margin by design
+                text: qsTr("I’m ready to use Status Desktop Beta")
             }
         }
     }


### PR DESCRIPTION
- no logo
- tighter content, smaller vertical spacing

Fixes https://github.com/status-im/status-desktop/issues/12400

### What does the PR do

Fixes the beta dialog to fit minimum height better

### Affected areas

UserAgreementPopup

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![image](https://github.com/status-im/status-desktop/assets/5377645/0dc92668-a07c-4acc-833b-d784e183055b)

