### PR TITLE
fix(@desktop/wallet): Wallet -> Setting -> Edit network: toast message is not displayed when reverting to default

### DIFF
--- a/src/app_service/service/network/service.nim
+++ b/src/app_service/service/network/service.nim
@@ -173,9 +173,6 @@ proc getNetworkForCollectibles*(self: Service): NetworkDto =
 proc updateNetworkEndPointValues*(self: Service, chainId: int, newMainRpcInput, newFailoverRpcUrl: string, revertToDefault: bool) =
   let network = self.getNetworkByChainId(chainId)
 
-  if network.rpcURL == newMainRpcInput and network.fallbackURL == newFailoverRpcUrl:
-    return
-
   if network.rpcURL != newMainRpcInput:
     network.rpcURL = newMainRpcInput
 


### PR DESCRIPTION
fix(@desktop/wallet): Wallet -> Setting -> Edit network: toast message is not displayed when reverting to default
fixes #12419

### What does the PR do

Fixes error that no toast message is shown when revert to default is clicked

### Affected areas

Wallet network settings

### StatusQ checklist

- [ ] add documentation if necessary (new component, new feature)
- [ ] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [ ] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

https://github.com/status-im/status-desktop/assets/60327365/4a4c94a7-0c52-4324-a787-bca1eaffdf30


