### PR TITLE
fix(ImportCommunityPopup): no UI information when requesting info failed

### DIFF
--- a/ui/imports/shared/popups/ImportCommunityPopup.qml
+++ b/ui/imports/shared/popups/ImportCommunityPopup.qml
@@ -20,19 +20,26 @@ StatusDialog {
     title: qsTr("Import Community")
 
     signal joinCommunity(string communityId, var communityDetails)
+
     QtObject {
         id: d
         property string importErrorMessage
 
-        readonly property bool communityFound: (d.communityDetails !== null && !!d.communityDetails.name)
-        readonly property var communityDetails: {
-            if (isInputValid) {
-                let key = isPublicKey ? Utils.getCompressedPk(publicKey) :
-                          root.store.getCommunityPublicKeyFromPrivateKey(inputKey);
-                return root.store.getCommunityDetails(key);
-            } else {
-                return null;
+        property bool loading
+        property bool communityFound: (d.communityDetails !== null && !!d.communityDetails.name)
+        property var communityDetails: {
+            if (!isInputValid) {
+                loading = false
+                return null
             }
+            loading = true
+            const key = isPublicKey ? Utils.getCompressedPk(publicKey) :
+                                      root.store.getCommunityPublicKeyFromPrivateKey(inputKey, true /*importing*/);
+
+            const details = root.store.getCommunityDetails(key)
+            if (!!details) // the above can return `null` in which case we continue loading
+                loading = false
+            return details
         }
 
         readonly property string inputErrorMessage: isInputValid ? "" : qsTr("Invalid key")
@@ -56,14 +63,56 @@ StatusDialog {
         readonly property bool isInputValid: isPrivateKey || isPublicKey
     }
 
+    Timer {
+        interval: 20000  // 20s
+        running: d.loading
+        onTriggered: {
+            d.loading = false
+            d.importErrorMessage = qsTr("Timeout reached while getting community info")
+        }
+    }
+
+    Connections {
+        target: root.store
+
+        function onImportingCommunityStateChanged(communityId, state, errorMsg) {
+            switch (state)
+            {
+            case Constants.communityImported:
+                const community = root.store.getCommunityDetailsAsJson(communityId)
+                d.loading = false
+                d.communityFound = true
+                d.communityDetails = community
+                d.importErrorMessage = ""
+                break
+            case Constants.communityImportingInProgress:
+                d.loading = true
+                break
+            case Constants.communityImportingError:
+                d.loading = false
+                d.communityFound = false
+                d.communityDetails = null
+                d.importErrorMessage = errorMsg
+                break
+            default:
+                const msg = qsTr("Error state '%1' while importing community: %2").arg(state).arg(communityId)
+                console.error(msg)
+                d.loading = false
+                d.communityFound = false
+                d.communityDetails = null
+                d.importErrorMessage = msg
+                return
+            }
+        }
+    }
+
     footer: StatusDialogFooter {
         rightButtons: ObjectModel {
             StatusButton {
-                id: importButton
-                enabled: (d.isInputValid && (d.isPrivateKey && d.communityFound ? agreeToKeepOnline.checked : true))
-                loading: (enabled && !d.communityFound)
-                text: !d.publicKey ? qsTr("Make this device the control node for %1").arg((!loading && !!d.communityDetails) ? d.communityDetails.name : "")
-                                   : qsTr("Import")
+                enabled: d.communityFound && ((d.isPublicKey) || (d.isPrivateKey && agreeToKeepOnline.checked))
+                loading: d.loading
+                text: d.isPrivateKey && d.communityFound ? qsTr("Make this device the control node for %1").arg(d.communityDetails.name)
+                                                         : qsTr("Import")
                 onClicked: {
                     if (d.isPrivateKey) {
                         root.store.importCommunity(d.privateKey);
@@ -75,7 +124,6 @@ StatusDialog {
             }
         }
     }
-
 
     StatusScrollView {
         id: scrollContent
@@ -93,7 +141,7 @@ StatusDialog {
                 Layout.fillWidth: true
                 text: qsTr("Enter the public key of the community you wish to access, or enter the private key of a community you own. Remember to always keep any private key safe and never share a private key with anyone else.")
                 wrapMode: Text.WordWrap
-                font.pixelSize: 13
+                font.pixelSize: Style.current.additionalTextSize
                 color: Theme.palette.baseColor1
             }
 
@@ -101,7 +149,6 @@ StatusDialog {
                 id: inputLabel
                 text: qsTr("Community key")
                 color: Theme.palette.directColor1
-                font.pixelSize: 15
             }
 
             StatusTextArea {
@@ -128,8 +175,8 @@ StatusDialog {
                 StatusBaseText {
                     id: detectionLabel
                     Layout.alignment: Qt.AlignRight
-                    font.pixelSize: 13
-                    visible: keyInput.text.trim() !== ""
+                    font.pixelSize: Style.current.additionalTextSize
+                    visible: !!d.inputKey
                     text: {
                         if (d.errorMessage !== "") {
                             return d.errorMessage
@@ -160,13 +207,11 @@ StatusDialog {
                 StatusBaseText {
                     Layout.topMargin: Style.current.halfPadding
                     visible: (d.communityFound && d.isPrivateKey)
-                    font.pixelSize: Style.current.primaryTextFontSize
                     text: qsTr("I acknowledge that...")
                 }
                 StatusCheckBox {
                     id: agreeToKeepOnline
                     Layout.fillWidth: true
-                    font.pixelSize: Style.current.primaryTextFontSize
                     text: qsTr("I must keep this device online and running Status for the Community to function")
                 }
             }


### PR DESCRIPTION
- track the import progress manually as `root.store.getCommunityDetails(key)` can optionally return `null` immediately if the community is not known and launch an async task
- as an additional measure, since the above async call sometimes never finishes, add a `Timer` that unsets the internal `loading` state

Fixes #12358

### What does the PR do

Fixes the ever spinning loading animation when trying to import a community

### Affected areas

ImportCommunityPopup

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

Typing an invalid key:
![image](https://github.com/status-im/status-desktop/assets/5377645/d4b78453-8c12-41e4-a41b-41b45accb3bc)

Loading community info:
![image](https://github.com/status-im/status-desktop/assets/5377645/13d384ce-be99-4817-8190-3177de3cf60c)

The happy error path, async call finishes with error:
![image](https://github.com/status-im/status-desktop/assets/5377645/7f1a10df-bba2-4cc0-bf3e-4d79aa49c72d)


The manual timeout error path:
![image](https://github.com/status-im/status-desktop/assets/5377645/5f3ec07b-9bbc-4f87-87d8-7b3bba02eb33)


