### PR TITLE
fix: CTRL+K navigation doesn't work for 1-1 chats (only for communities)

### DIFF
--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -887,6 +887,8 @@ method rebuildChatSearchModel*[T](self: Module[T]) =
     var chatImage = chat.icon
     var colorHash: ColorHashDto = @[]
     var colorId: int = 0
+    var sectionId = self.view.model().getItemBySectionType(SectionType.Chat).id()
+    var sectionName = self.view.model().getItemBySectionType(SectionType.Chat).name()
     if chat.chatType == ChatType.OneToOne:
       let contactDetails = self.controller.getContactDetails(chat.id)
       chatName = contactDetails.defaultDisplayName
@@ -894,6 +896,9 @@ method rebuildChatSearchModel*[T](self: Module[T]) =
       if not contactDetails.dto.ensVerified:
         colorHash = self.controller.getColorHash(chat.id)
       colorId = self.controller.getColorId(chat.id)
+    elif chat.chatType == ChatType.CommunityChat:
+      sectionId = chat.communityId
+      sectionName = self.view.model().getItemById(sectionId).name()
     items.add(chat_search_item.initItem(
       chat.id,
       chatName,
@@ -901,8 +906,8 @@ method rebuildChatSearchModel*[T](self: Module[T]) =
       colorId,
       chatImage,
       colorHash.toJson(),
-      chat.communityId,
-      self.view.model().getItemById(chat.communityId).name(),
+      sectionId,
+      sectionName,
     ))
 
   self.view.chatSearchModel().setItems(items)


### PR DESCRIPTION
make a few "fixups" for OneToOne and Group chats so that we set the correct `sectionId` and `sectionName`

Fixes #12264

### What does the PR do

Fix quick search (Ctrl+K) navigation to work in all cases

### Affected areas

ChatSearchModel

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

[Záznam obrazovky z 2023-10-13 15-54-33.webm](https://github.com/status-im/status-desktop/assets/5377645/9b72d9dc-e13d-4a53-9162-2469f7c1ae93)

