### PR TITLE
chore: fix StatusChatInput tests

### DIFF
--- a/storybook/qmlTests/TestComponents/tst_StatusChatInput.qml
+++ b/storybook/qmlTests/TestComponents/tst_StatusChatInput.qml
@@ -339,7 +339,7 @@ Item {
         function test_standard_key_shortcuts_data() {
             return [
                          { tag: "Delete", key: StandardKey.Delete, initialCursorPosition: 0, initialSelectionStart: 0, initialSelectionEnd: 0, expectIdenticalPlainText: true },
-                         { tag: "Undo", key: StandardKey.Undo, initialCursorPosition: 0, initialSelectionStart: 0, initialSelectionEnd: 0, expectIdenticalPlainText: true },
+                         { tag: "Undo", key: StandardKey.Undo, initialCursorPosition: 0, initialSelectionStart: 0, initialSelectionEnd: 0, expectIdenticalPlainText: false },
                          { tag: "Redo", key: StandardKey.Redo, initialCursorPosition: 0, initialSelectionStart: 0, initialSelectionEnd: 0, expectIdenticalPlainText: true  },
                          { tag: "SelectAll", key: StandardKey.SelectAll, initialCursorPosition: 0, initialSelectionStart: 0, initialSelectionEnd: 0  , expectIdenticalPlainText: true },
                          { tag: "Bold", key: StandardKey.Bold, initialCursorPosition: 0, initialSelectionStart: 0, initialSelectionEnd: 3, expectIdenticalPlainText: false, expectIdenticalSelection: false  },


### PR DESCRIPTION
### What does the PR do
#### Fixing StatusChatInput test

Updating the `Undo` test that compares the `Undo` done in StatusChatInput with a standard TextEdit component. 

Undo/Redo feature was changed by https://github.com/status-im/status-desktop/pull/12262. Now we're using a custom undo/redo logic and the undo is more granular as opposed to TextEdit.

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas

StatusChatInput test
