### PR TITLE
fix: Update link preview border to match the new design

### DIFF
--- a/ui/imports/shared/controls/chat/CalloutCard.qml
+++ b/ui/imports/shared/controls/chat/CalloutCard.qml
@@ -2,6 +2,8 @@ import QtQuick 2.13
 import QtQuick.Controls 2.15
 import QtQuick.Shapes 1.5
 
+import QtGraphicalEffects 1.15
+
 import utils 1.0
 import shared 1.0
 import shared.controls 1.0
@@ -14,6 +16,7 @@ Control {
     property color backgroundColor: Style.current.background
     property color borderColor: Style.current.border
     property bool dashedBorder: false
+    property bool dropShadow: false
     property real borderWidth: 1
 
     readonly property Component clippingEffect: CalloutOpacityMask {
@@ -30,5 +33,14 @@ Control {
         radius: Style.current.radius * 2
         leftBottomRadius: root.leftTail ? Style.current.radius / 2 : Style.current.radius * 2
         rightBottomRadius: root.leftTail ? Style.current.radius * 2 : Style.current.radius / 2
+        layer.enabled: root.dropShadow
+        layer.effect: DropShadow {
+            verticalOffset: 3
+            radius: 8
+            samples: 15
+            fast: true
+            cached: true
+            color: Style.current.dropShadow
+        }
     }
 }

--- a/ui/imports/shared/controls/chat/LinkPreviewCard.qml
+++ b/ui/imports/shared/controls/chat/LinkPreviewCard.qml
@@ -33,7 +33,8 @@ CalloutCard {
     implicitHeight: 290
     implicitWidth: 305
     hoverEnabled: true
-    borderColor: hovered || highlight ? Style.current.borderTertiary : Style.current.border
+    dropShadow: d.highlight
+    borderColor: d.highlight ? Style.current.background : Style.current.border
 
     Behavior on borderColor {
         ColorAnimation { duration: 200 }
@@ -116,5 +117,6 @@ CalloutCard {
     QtObject {
         id: d
         property real bannerImageMargins: 1 / Screen.devicePixelRatio // image size isn't pixel perfect..
+        property bool highlight: root.highlight || root.hovered
     }
 }

--- a/ui/imports/shared/views/chat/LinksMessageView.qml
+++ b/ui/imports/shared/views/chat/LinksMessageView.qml
@@ -148,6 +148,7 @@ Flow {
             title: standardPreview ? standardPreview.title : ""
             description: standardPreview ? standardPreview.description : ""
             footer: standardPreview ? standardPreview.hostname : ""
+            highlight: root.highlightLink === url
             onClicked: (mouse) => {
                 switch (mouse.button) {
                     case Qt.RightButton:


### PR DESCRIPTION
### What does the PR do

Closing #12444

Replace the 1px blue border with `DropShadow` and fix link preview highlighting when hovering the URL

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

<img width="655" alt="Screenshot 2023-10-16 at 10 30 31" src="https://github.com/status-im/status-desktop/assets/47811206/2e9c627f-3d62-4a08-8254-3363e762b30c">
<img width="656" alt="Screenshot 2023-10-16 at 10 30 09" src="https://github.com/status-im/status-desktop/assets/47811206/728523a6-a14b-484f-a340-f3745e25aac1">

### Affected areas

LinkPreviewCard