### PR TITLE
fix(@desktop/general): env vars evaluation fixed

### DIFF
--- a/src/app/global/local_app_settings.nim
+++ b/src/app/global/local_app_settings.nim
@@ -17,7 +17,7 @@ const LAS_KEY_CUSTOM_MOUSE_SCROLLING_ENABLED = "global/custom_mouse_scroll_enabl
 const DEFAULT_CUSTOM_MOUSE_SCROLLING_ENABLED = false
 const DEFAULT_VISIBILITY = 2 #windowed visibility, from qml
 const LAS_KEY_FAKE_LOADING_SCREEN_ENABLED = "global/fake_loading_screen"
-const DEFAULT_FAKE_LOADING_SCREEN_ENABLED = defined(production) and not TEST_MODE_ENABLED #enabled in production, disabled in development and e2e tests
+let DEFAULT_FAKE_LOADING_SCREEN_ENABLED = defined(production) and not TEST_MODE_ENABLED #enabled in production, disabled in development and e2e tests
 const LAS_KEY_SHARDED_COMMUNITIES_ENABLED = "global/sharded_communities"
 const DEFAULT_LAS_KEY_SHARDED_COMMUNITIES_ENABLED = false
 

--- a/src/constants.nim
+++ b/src/constants.nim
@@ -90,5 +90,5 @@ const APP_VERSION* = if defined(production): DESKTOP_VERSION else: fmt("{GIT_COM
 # Name of the test environment var to check for
 const STATUS_RUNTIME_TEST_MODE_VAR* = "STATUS_RUNTIME_TEST_MODE"
 
-const TEST_MODE_ENABLED* = getEnv(STATUS_RUNTIME_TEST_MODE_VAR).toUpperAscii() == "TRUE" or
+let TEST_MODE_ENABLED* = getEnv(STATUS_RUNTIME_TEST_MODE_VAR).toUpperAscii() == "TRUE" or
   getEnv(STATUS_RUNTIME_TEST_MODE_VAR) == "1"


### PR DESCRIPTION
Env vars were read correctly and evaluated during the runtime, but then assigned to a const evaluated during the compile time and that const was used in the code, leading to ignoring a real env value.