### PR TITLE
fix: disable importing channel from discord

### DIFF
--- a/ui/app/AppLayouts/Communities/views/CommunityColumnView.qml
+++ b/ui/app/AppLayouts/Communities/views/CommunityColumnView.qml
@@ -57,6 +57,8 @@ Item {
 
         readonly property bool showJoinButton: !communityData.joined || root.communityData.amIBanned
         readonly property bool showFinaliseOwnershipButton: root.isPendingOwnershipRequest
+        readonly property bool discordImportInProgress: (root.communitiesStore.discordImportProgress > 0 && root.communitiesStore.discordImportProgress < 100)
+                                                        || root.communitiesStore.discordImportInProgress
 
         property bool invitationPending: root.store.isCommunityRequestPending(communityData.id)
         property bool isJoinBtnLoading: false
@@ -100,6 +102,7 @@ Item {
     StatusMenu {
         id: adminPopupMenu
         enabled: root.isSectionAdmin
+        hideDisabledItems: !showInviteButton
 
         property bool showInviteButton: false
 
@@ -116,6 +119,7 @@ Item {
             objectName: "importCommunityChannelBtn"
             text: qsTr("Create channel via Discord import")
             icon.name: "download"
+            enabled: !d.discordImportInProgress
             onTriggered: Global.openPopup(createChannelPopup, {isDiscordImport: true})
         }
 
@@ -189,6 +193,7 @@ Item {
                                                          })
 
             popupMenu: StatusMenu {
+                hideDisabledItems: false
                 StatusAction {
                     text: qsTr("Create channel")
                     icon.name: "channel"
@@ -200,6 +205,7 @@ Item {
                     objectName: "importCommunityChannelBtn"
                     text: qsTr("Create channel via Discord import")
                     icon.name: "download"
+                    enabled: !d.discordImportInProgress
                     onTriggered: Global.openPopup(createChannelPopup, {isDiscordImport: true})
                 }
 
@@ -432,15 +438,12 @@ Item {
         anchors.bottomMargin: active ? Style.current.padding : 0
         active: root.isSectionAdmin
         sourceComponent: Component {
-            StatusBaseText {
+            StatusLinkText {
                 id: createChannelOrCategoryBtn
                 objectName: "createChannelOrCategoryBtn"
-                color: Theme.palette.baseColor1
                 height: visible ? implicitHeight : 0
                 text: qsTr("Create channel or category")
                 font.underline: true
-                font.pixelSize: 13
-                textFormat: Text.RichText
 
                 MouseArea {
                     anchors.fill: parent


### PR DESCRIPTION
when another import is already in progress

Fixes #12239

### What does the PR do

Disable (not hide) the respective menu items to import a single channel from discord when another discord import job is already in progress

### Affected areas

CommunityColumnView

### Screenshot of functionality (including design for comparison)

- [x] I've checked the design and this PR matches it

![Snímek obrazovky z 2023-10-16 13-13-01](https://github.com/status-im/status-desktop/assets/5377645/65e3bf83-e869-453e-bcd3-070c845ad258)

![Snímek obrazovky z 2023-10-16 13-13-04](https://github.com/status-im/status-desktop/assets/5377645/563ec1c2-36a9-462d-a8bf-a6a155041704)

