### PR TITLE
[LinkPreviews] Show toast messages when link preview settings changes from StatusChatInput

### DIFF
--- a/src/app/modules/main/ephemeral_notification_item.nim
+++ b/src/app/modules/main/ephemeral_notification_item.nim
@@ -4,6 +4,7 @@ type
   EphemeralNotificationType* {.pure.} = enum
     Default = 0
     Success
+    Danger
 
 type
   Item* = object

--- a/src/app/modules/main/module.nim
+++ b/src/app/modules/main/module.nim
@@ -1228,6 +1228,9 @@ method displayEphemeralNotification*[T](self: Module[T], title: string, subTitle
   var finalEphNotifType = EphemeralNotificationType.Default
   if(ephNotifType == EphemeralNotificationType.Success.int):
     finalEphNotifType = EphemeralNotificationType.Success
+  elif(ephNotifType == EphemeralNotificationType.Danger.int):
+    finalEphNotifType = EphemeralNotificationType.Danger
+    
   let item = ephemeral_notification_item.initItem(id, title, TOAST_MESSAGE_VISIBILITY_DURATION_IN_MS, subTitle, icon,
   loading, finalEphNotifType, url, details)
   self.view.ephemeralNotificationModel().addItem(item)

--- a/ui/StatusQ/sandbox/CMakeLists.txt
+++ b/ui/StatusQ/sandbox/CMakeLists.txt
@@ -1,5 +1,6 @@
 project(Sandbox)
-
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 find_package(
         Qt5
         COMPONENTS Core Quick QuickControls2

--- a/ui/StatusQ/sandbox/pages/StatusToastMessagePage.qml
+++ b/ui/StatusQ/sandbox/pages/StatusToastMessagePage.qml
@@ -20,7 +20,8 @@ Item {
                 {"title":"Collectible is being minted...", "subTitle":"View on Etherscan", "icon":"", "loading":true, "type":0,"url":"http://google.com", "duration":0},
                 {"title":"Contact request sent", "subTitle":"", "icon":"checkmark-circle", "loading":false, "type":1,"url":"", "duration":4000},
                 {"title":"Test User", "subTitle":"Hello message...", "icon":"", "loading":false, "type":0,"url":"", "duration":4000},
-                {"title":"This device is no longer the control node for the Socks Community", "subTitle":"", "icon":"info", "loading":false, "type":0,"url":"", "duration":0}
+                {"title":"This device is no longer the control node for the Socks Community", "subTitle":"", "icon":"info", "loading":false, "type":0,"url":"", "duration":0},
+                {"title":`This is, but not now, probably later on the road even it doesn't make sense, a very long title with <a style="text-decoration:none" href="www.qt.io">hyperlink</a>.`, "subTitle":"", "icon":"info", "loading":false, "type":2,"url":"", "duration":0},
             ]
             delegate: StatusToastMessage {
                 primaryText: modelData.title

--- a/ui/StatusQ/sandbox/sandboxapp.cpp
+++ b/ui/StatusQ/sandbox/sandboxapp.cpp
@@ -15,7 +15,7 @@ SandboxApp::SandboxApp(int &argc, char **argv)
     });
 #endif
 }
-
+#ifdef QT_DEBUG
 void SandboxApp::watchDirectoryChanges(const QString& path)
 {
     qDebug() << "Iterating to watch over:" << path;
@@ -29,7 +29,7 @@ void SandboxApp::watchDirectoryChanges(const QString& path)
         }
     }
 }
-
+#endif
 void SandboxApp::startEngine()
 {
 #ifdef QT_DEBUG

--- a/ui/StatusQ/sandbox/sandboxapp.h
+++ b/ui/StatusQ/sandbox/sandboxapp.h
@@ -23,6 +23,7 @@ private:
 
 #ifdef QT_DEBUG
     QFileSystemWatcher m_watcher;
+    void watchDirectoryChanges(const QString& path);
 #endif
 
     const QUrl m_url {
@@ -32,8 +33,6 @@ private:
         QStringLiteral("qrc:/main.qml")
 #endif
     };
-
-    void watchDirectoryChanges(const QString& path);
 };
 
 #endif // SANDBOXAPP_H

--- a/ui/StatusQ/src/StatusQ/Components/StatusToastMessage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusToastMessage.qml
@@ -37,9 +37,12 @@ import StatusQ.Core.Theme 0.1
 
 Control {
     id: root
-    width: 343
-    height: !!secondaryText || title.lineCount > 1 ? 68 : 48
-    anchors.right: parent.right
+    implicitWidth: 374
+
+    topPadding: 15
+    bottomPadding: 15
+    leftPadding: 12
+    rightPadding: 8
 
     /*!
         \qmlproperty bool StatusToastMessage::open
@@ -95,7 +98,8 @@ Control {
     property int type: StatusToastMessage.Type.Default
     enum Type {
         Default,
-        Success
+        Success,
+        Danger
     }
 
     /*!
@@ -209,11 +213,8 @@ Control {
     }
 
     contentItem: Item {
-        anchors.left: parent.left
-        anchors.leftMargin: 16
-        anchors.right: parent.right
-        anchors.rightMargin: 4
-        height: parent.height
+        implicitWidth: layout.implicitWidth
+        implicitHeight: layout.implicitHeight
         MouseArea {
             anchors.fill: parent
             onMouseXChanged: {
@@ -224,15 +225,25 @@ Control {
             }
         }
         RowLayout {
+            id: layout
             anchors.fill: parent
-            spacing: 16
+            spacing: 12
             Rectangle {
                 implicitWidth: 32
                 implicitHeight: 32
                 Layout.alignment: Qt.AlignVCenter
                 radius: (root.width/2)
-                color: (root.type === StatusToastMessage.Type.Success) ?
-                        Theme.palette.successColor2 : Theme.palette.primaryColor3
+                color: {
+                    print("color type", root.type)
+                    switch(root.type) {
+                    case StatusToastMessage.Type.Success:
+                        return Theme.palette.successColor2
+                    case StatusToastMessage.Type.Danger:
+                        return Theme.palette.dangerColor3
+                    default:
+                        return Theme.palette.primaryColor3
+                    }
+                }
                 visible: loader.sourceComponent != undefined
                 Loader {
                     id: loader
@@ -244,8 +255,14 @@ Control {
                     Component {
                         id: loadingInd
                         StatusLoadingIndicator {
-                            color: (root.type === StatusToastMessage.Type.Success) ?
-                                   Theme.palette.successColor1 : Theme.palette.primaryColor1
+                            color: switch(root.type) {
+                                case StatusToastMessage.Type.Success:
+                                    return Theme.palette.successColor1
+                                case StatusToastMessage.Type.Danger:
+                                    return Theme.palette.dangerColor1
+                                default:
+                                   return Theme.palette.primaryColor1
+                            }
                         }
                     }
                     Component {
@@ -254,8 +271,17 @@ Control {
                             anchors.centerIn: parent
                             width: root.icon.width
                             height: root.icon.height
-                            color: (root.type === StatusToastMessage.Type.Success) ?
-                                   Theme.palette.successColor1 : Theme.palette.primaryColor1
+                            color: {
+                                print("color type", root.type)
+                                    switch(root.type) {
+                                    case StatusToastMessage.Type.Success:
+                                        return Theme.palette.successColor1
+                                    case StatusToastMessage.Type.Danger:
+                                        return Theme.palette.dangerColor1
+                                    default:
+                                        return Theme.palette.primaryColor1
+                                }
+                            }
                             icon: root.icon.name
                         }
                     }
@@ -271,8 +297,12 @@ Control {
                     color: Theme.palette.directColor1
                     elide: Text.ElideRight
                     wrapMode: Text.Wrap
+                    textFormat: Text.RichText
                     text: root.primaryText
-                    maximumLineCount: 2
+                    maximumLineCount: root.secondaryText ? 2 : 3
+                    onLinkActivated: {
+                        root.linkActivated(link);
+                    }
                 }
                 StatusBaseText {
                     Layout.fillWidth: true
@@ -293,7 +323,7 @@ Control {
                     hoveredLinkColor: Theme.palette.primaryColor1
                     text: "<p><a style=\"text-decoration:none\" href=\'" + root.linkUrl + " \'>" + root.secondaryText + "</a></p>"
                     onLinkActivated: {
-                        root.linkActivated(root.linkUrl);
+                        root.linkActivated(link);
                     }
                 }
             }

--- a/ui/StatusQ/src/StatusQ/Components/StatusToastMessage.qml
+++ b/ui/StatusQ/src/StatusQ/Components/StatusToastMessage.qml
@@ -39,8 +39,7 @@ Control {
     id: root
     implicitWidth: 374
 
-    topPadding: 15
-    bottomPadding: 15
+    verticalPadding: 15
     leftPadding: 12
     rightPadding: 8
 
@@ -151,6 +150,14 @@ Control {
 
         readonly property string openedState: "opened"
         readonly property string closedState: "closed"
+        readonly property string iconColor: switch(root.type) {
+            case StatusToastMessage.Type.Success:
+                return Theme.palette.successColor1
+            case StatusToastMessage.Type.Danger:
+                return Theme.palette.dangerColor1
+            default:
+                return Theme.palette.primaryColor1
+        }
     }
 
     Timer {
@@ -234,7 +241,6 @@ Control {
                 Layout.alignment: Qt.AlignVCenter
                 radius: (root.width/2)
                 color: {
-                    print("color type", root.type)
                     switch(root.type) {
                     case StatusToastMessage.Type.Success:
                         return Theme.palette.successColor2
@@ -255,14 +261,7 @@ Control {
                     Component {
                         id: loadingInd
                         StatusLoadingIndicator {
-                            color: switch(root.type) {
-                                case StatusToastMessage.Type.Success:
-                                    return Theme.palette.successColor1
-                                case StatusToastMessage.Type.Danger:
-                                    return Theme.palette.dangerColor1
-                                default:
-                                   return Theme.palette.primaryColor1
-                            }
+                            color: d.iconColor
                         }
                     }
                     Component {
@@ -271,17 +270,7 @@ Control {
                             anchors.centerIn: parent
                             width: root.icon.width
                             height: root.icon.height
-                            color: {
-                                print("color type", root.type)
-                                    switch(root.type) {
-                                    case StatusToastMessage.Type.Success:
-                                        return Theme.palette.successColor1
-                                    case StatusToastMessage.Type.Danger:
-                                        return Theme.palette.dangerColor1
-                                    default:
-                                        return Theme.palette.primaryColor1
-                                }
-                            }
+                            color: d.iconColor
                             icon: root.icon.name
                         }
                     }

--- a/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
@@ -89,6 +89,13 @@ Item {
             chatSectionModule: root.rootStore.chatCommunitySectionModule
         }
 
+        readonly property string linkPreviewBeginAnchor: `<a style="text-decoration:none" href="#${Constants.appSection.profile}/${Constants.settingsSubsection.messaging}">`
+        readonly property string linkPreviewEndAnchor: `</a>`
+
+        readonly property string linkPreviewEnabledNotification: qsTr("Link previews will be shown for all sites. You can manage link previews in %1.", "Go to settings").arg(linkPreviewBeginAnchor + qsTr("Settings", "Go to settings page") + linkPreviewEndAnchor)
+        readonly property string linkPreviewDisabledNotification: qsTr("Link previews will never be shown. You can manage link previews in %1.").arg(linkPreviewBeginAnchor + qsTr("Settings", "Go to settings page") + linkPreviewEndAnchor)
+        readonly property string linkPreviewEnabledForMessageNotification: qsTr("Link previews will be shown for this message. You can manage link previews in %1.").arg(linkPreviewBeginAnchor + qsTr("Settings", "Go to settings page") + linkPreviewEndAnchor)
+
         function getChatContentModule(chatId) {
             root.parentModule.prepareChatContentModuleForChatId(chatId)
             return root.parentModule.getChatContentModule()
@@ -335,10 +342,21 @@ Item {
                     }
                     
                     onLinkPreviewReloaded: (link) => d.activeChatContentModule.inputAreaModule.reloadLinkPreview(link)
-                    onEnableLinkPreview: () => d.activeChatContentModule.inputAreaModule.enableLinkPreview()
-                    onDisableLinkPreview: () => d.activeChatContentModule.inputAreaModule.disableLinkPreview()
-                    onEnableLinkPreviewForThisMessage: () => d.activeChatContentModule.inputAreaModule.setLinkPreviewEnabledForCurrentMessage(true)
-                    onDismissLinkPreviewSettings: () => d.activeChatContentModule.inputAreaModule.setLinkPreviewEnabledForCurrentMessage(false)
+                    onEnableLinkPreview: () => {
+                        d.activeChatContentModule.inputAreaModule.enableLinkPreview()
+                        Global.displayToastMessage(d.linkPreviewEnabledNotification, "", "show", false, Constants.ephemeralNotificationType.success, "")
+                    }
+                    onDisableLinkPreview: () => {
+                        d.activeChatContentModule.inputAreaModule.disableLinkPreview()
+                        Global.displayToastMessage(d.linkPreviewDisabledNotification, "", "hide", false, Constants.ephemeralNotificationType.danger, "")
+                    }
+                    onEnableLinkPreviewForThisMessage: () => {
+                        d.activeChatContentModule.inputAreaModule.setLinkPreviewEnabledForCurrentMessage(true)
+                        Global.displayToastMessage(d.linkPreviewEnabledForMessageNotification, "", "show", false, Constants.ephemeralNotificationType.success, "")
+                    }
+                    onDismissLinkPreviewSettings: () => {
+                        d.activeChatContentModule.inputAreaModule.setLinkPreviewEnabledForCurrentMessage(false)
+                    }
                     onDismissLinkPreview: (index) => d.activeChatContentModule.inputAreaModule.removeLinkPreviewData(index)
                 }
 

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -1565,7 +1565,7 @@ Item {
         anchors.rightMargin: 8
         anchors.bottom: parent.bottom
         anchors.bottomMargin: 60
-        width: 343
+        width: 374
         height: Math.min(parent.height - 120, toastArea.contentHeight)
         spacing: 8
         verticalLayoutDirection: ListView.BottomToTop
@@ -1573,6 +1573,7 @@ Item {
         clip: false
 
         delegate: StatusToastMessage {
+            width: ListView.view.width
             primaryText: model.title
             secondaryText: model.subTitle
             icon.name: model.icon
@@ -1585,8 +1586,12 @@ Item {
                 this.open = false
             }
             onLinkActivated: {
-                if (link.startsWith("#")) // internal link to section
-                    globalConns.onAppSectionBySectionTypeChanged(link.substring(1))
+                if (link.startsWith("#") && link !== "#") { // internal link to section
+                    const sectionArgs = link.substring(1).split("/")
+                    const section = sectionArgs[0]
+                    let subsection = sectionArgs.length > 1 ? sectionArgs[1] : 0
+                    Global.changeAppSectionBySectionType(section, subsection)
+                }
                 else
                     Global.openLink(link)
             }

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -607,6 +607,7 @@ QtObject {
     readonly property QtObject ephemeralNotificationType: QtObject {
         readonly property int normal: 0
         readonly property int success: 1
+        readonly property int danger: 2
     }
 
     readonly property QtObject translationsState: QtObject {


### PR DESCRIPTION
### What does the PR do
Closing #12398 
<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

Changes:
1. StatusToastMessage now supports dynamic content height
2. Add new StatusToastMessage type: Danger
3. Update StatusToastMessage to support RichText content
4. Fix StatusQ sanboxapp compilation
5. Add the new StatusToastMessage content to sandbox
6. Show toast messages when the link preview settings changes from StatusChatInput

### Affected areas
StatusQ - StatusToastMessage.qml
Toast notifications
ChatColumnView
<!-- List the affected areas (e.g wallet, browser, etc..) -->

### StatusQ checklist
- [x] update sandbox app
  - in case of new component, add new component page
  - in case of new features, add variation to existing component page
  - nice to have: add it to the demo application as well
- [x] test changes in both light and dark theme?

### Screenshot of functionality (including design for comparison)

<img width="437" alt="Screenshot 2023-10-17 at 11 04 53" src="https://github.com/status-im/status-desktop/assets/47811206/f1ea9224-c732-4016-8c3f-dd60adf8a34a">

https://github.com/status-im/status-desktop/assets/47811206/a06032cb-a8c0-4024-8463-2b7d70e819c3

- [x] I've checked the design and this PR matches it
