### PR TITLE
feat: Link preview settings to Status chat input unfurling mode

### DIFF
--- a/src/app/modules/main/chat_section/chat_content/input_area/io_interface.nim
+++ b/src/app/modules/main/chat_section/chat_content/input_area/io_interface.nim
@@ -99,6 +99,9 @@ method viewDidLoad*(self: AccessInterface) {.base.} =
 method setText*(self: AccessInterface, text: string, unfurlUrls: bool) {.base.} =
   raise newException(ValueError, "No implementation available")
 
+method getPlainText*(self: AccessInterface): string =
+  raise newException(ValueError, "No implementation available")
+
 method setUrls*(self: AccessInterface, urls: seq[string]) {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/chat_section/chat_content/input_area/module.nim
+++ b/src/app/modules/main/chat_section/chat_content/input_area/module.nim
@@ -157,6 +157,9 @@ method isFavorite*(self: Module, item: GifDto): bool =
 method setText*(self: Module, text: string, unfurlUrls: bool) =
   self.controller.setText(text, unfurlUrls)
 
+method getPlainText*(self: Module): string =
+  return self.view.getPlainText()
+
 method clearLinkPreviewCache*(self: Module) {.slot.} =
   self.controller.clearLinkPreviewCache()
 

--- a/src/app/modules/main/chat_section/chat_content/input_area/view.nim
+++ b/src/app/modules/main/chat_section/chat_content/input_area/view.nim
@@ -216,6 +216,9 @@ QtObject:
   proc setText*(self: View, text: string) {.slot.} =
     self.delegate.setText(text, true)
 
+  proc getPlainText*(self: View): string {.slot.} =
+    return plain_text(self.preservedProperties.getText())
+
   proc updateLinkPreviewsFromCache*(self: View, urls: seq[string]) =
     let linkPreviews = self.delegate.linkPreviewsFromCache(urls)
     self.linkPreviewModel.updateLinkPreviews(linkPreviews)

--- a/src/app/modules/main/profile_section/privacy/controller.nim
+++ b/src/app/modules/main/profile_section/privacy/controller.nim
@@ -70,6 +70,10 @@ proc init*(self: Controller) =
     var args = OperationSuccessArgs(e)
     self.delegate.onPasswordChanged(args.success, args.errorMsg)
 
+  self.events.on(SIGNAL_URL_UNFURLING_MODE_UPDATED) do(e: Args):
+    var args = UrlUnfurlingModeArgs(e)
+    self.delegate.onUrlUnfurlingModeUpdated(args.value.int)
+
 proc isMnemonicBackedUp*(self: Controller): bool =
   return self.privacyService.isMnemonicBackedUp()
 

--- a/src/app/modules/main/profile_section/privacy/io_interface.nim
+++ b/src/app/modules/main/profile_section/privacy/io_interface.nim
@@ -79,3 +79,6 @@ method onUserAuthenticated*(self: AccessInterface, pin: string, password: string
 
 method backupData*(self: AccessInterface): int64 {.base.} =
   raise newException(ValueError, "No implementation available")
+
+method onUrlUnfurlingModeUpdated*(self: AccessInterface, mode: int) {.base.} =
+  raise newException(ValueError, "No implementation available")

--- a/src/app/modules/main/profile_section/privacy/module.nim
+++ b/src/app/modules/main/profile_section/privacy/module.nim
@@ -124,3 +124,6 @@ method onUserAuthenticated*(self: Module, pin: string, password: string, keyUid:
 
 method backupData*(self: Module): int64 =
   return self.controller.backupData()
+
+method onUrlUnfurlingModeUpdated*(self: Module, mode: int) =
+  self.view.emitUrlUnfurlingModeUpdated(mode)

--- a/src/app/modules/main/profile_section/privacy/view.nim
+++ b/src/app/modules/main/profile_section/privacy/view.nim
@@ -64,7 +64,7 @@ QtObject:
     if self.getUrlUnfurlingMode() == value:
       return
     self.delegate.setUrlUnfurlingMode(value)
-    self.urlUnfurlingModeChanged()
+
   QtProperty[int] urlUnfurlingMode:
     read = getUrlUnfurlingMode
     write = setUrlUnfurlingMode
@@ -92,3 +92,6 @@ QtObject:
     
   proc backupData*(self: View): int {.slot.} =
     return self.delegate.backupData().int
+  
+  proc emitUrlUnfurlingModeUpdated*(self: View, mode: int) =
+    self.urlUnfurlingModeChanged()

--- a/src/app_service/service/settings/service.nim
+++ b/src/app_service/service/settings/service.nim
@@ -28,7 +28,7 @@ const SIGNAL_MNEMONIC_REMOVED* = "mnemonicRemoved"
 const SIGNAL_SOCIAL_LINKS_UPDATED* = "socialLinksUpdated"
 const SIGNAL_CURRENT_USER_STATUS_UPDATED* = "currentUserStatusUpdated"
 const SIGNAL_PROFILE_MIGRATION_NEEDED_UPDATED* = "profileMigrationNeededUpdated"
-const SIGNAL_URL_UNFURLING_MODEL_UPDATED* = "urlUnfurlingModeUpdated"
+const SIGNAL_URL_UNFURLING_MODE_UPDATED* = "urlUnfurlingModeUpdated"
 
 logScope:
   topics = "settings-service"
@@ -119,7 +119,7 @@ QtObject:
             self.events.emit(SIGNAL_PROFILE_MIGRATION_NEEDED_UPDATED, SettingsBoolValueArgs(value: self.settings.profileMigrationNeeded))
           if settingsField.name == KEY_URL_UNFURLING_MODE:
             self.settings.urlUnfurlingMode = toUrlUnfurlingMode(settingsField.value.getInt)
-            self.events.emit(SIGNAL_URL_UNFURLING_MODEL_UPDATED, UrlUnfurlingModeArgs(value: self.settings.urlUnfurlingMode))
+            self.events.emit(SIGNAL_URL_UNFURLING_MODE_UPDATED, UrlUnfurlingModeArgs(value: self.settings.urlUnfurlingMode))
 
       if receivedData.socialLinksInfo.links.len > 0 or
         receivedData.socialLinksInfo.removed:
@@ -501,7 +501,7 @@ QtObject:
     if not self.saveSetting(KEY_URL_UNFURLING_MODE, int(value)):
       return false
     self.settings.urlUnfurlingMode = value
-    self.events.emit(SIGNAL_URL_UNFURLING_MODEL_UPDATED, UrlUnfurlingModeArgs(value: self.settings.urlUnfurlingMode))
+    self.events.emit(SIGNAL_URL_UNFURLING_MODE_UPDATED, UrlUnfurlingModeArgs(value: self.settings.urlUnfurlingMode))
     return true
 
   proc notifSettingAllowNotificationsChanged*(self: Service) {.signal.}

--- a/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
+++ b/ui/app/AppLayouts/Chat/views/ChatColumnView.qml
@@ -19,6 +19,7 @@ import shared.popups.send 1.0
 import SortFilterProxyModel 0.2
 
 import AppLayouts.Communities.popups 1.0
+import AppLayouts.Communities.panels 1.0
 
 import "../helpers"
 import "../controls"
@@ -26,7 +27,6 @@ import "../popups"
 import "../panels"
 import "../../Wallet"
 import "../stores"
-import AppLayouts.Communities.panels 1.0
 
 Item {
     id: root
@@ -153,8 +153,6 @@ Item {
             d.restoreInputAttachments()
         }
 
-        signal updateLinkPreviewsRequested
-
         readonly property var updateLinkPreviews: {
             return Backpressure.debounce(this, 250, () => {
                                              const messageText = root.rootStore.cleanMessageText(chatInput.textInput.text)
@@ -171,14 +169,6 @@ Item {
             d.activeChatContentModule.inputAreaModule.clearLinkPreviewCache()
             // Call later to make sure activeUsersStore and activeMessagesStore bindings are updated
             Qt.callLater(d.restoreInputState, preservedText)
-        }
-    }
-
-    Connections {
-        enabled: root.rootStore.privacyModule.urlUnfurlingMode !== Constants.UrlUnfurlingModeDisableAll
-        target: d
-        function onUpdateLinkPreviewsRequested() {
-            d.updateLinkPreviews()
         }
     }
 
@@ -294,7 +284,7 @@ Item {
                     textInput.onTextChanged: {
                         if (!!d.activeChatContentModule) {
                             d.activeChatContentModule.inputAreaModule.preservedProperties.text = textInput.text
-                            d.updateLinkPreviewsRequested()
+                            d.updateLinkPreviews()
                         }
                     }
 


### PR DESCRIPTION
### What does the PR do

Closing #12442

Changes:
1. Update privacy controller to react to external unfurling settings change
2. Add handler to input controller and react to external unfurling settings change
3. Small other fixes

<!-- Fill in the relevant information below to help us evaluate your proposed changes. -->

### Affected areas

Link preview settings

### Screenshot of functionality (including design for comparison)

#### Changes in settings visible in chat input

https://github.com/status-im/status-desktop/assets/47811206/c47a3b9a-9fd3-46c9-9d61-e588721e0ba2

#### Changes in chat input visible in settings

https://github.com/status-im/status-desktop/assets/47811206/e647b9bd-c229-4b72-b5c9-a706b6a579af

- [x] I've checked the design and this PR matches it
