### PR TITLE
feature: copy channel link menu action

### DIFF
--- a/ui/imports/shared/views/chat/ChatContextMenuView.qml
+++ b/ui/imports/shared/views/chat/ChatContextMenuView.qml
@@ -59,8 +59,18 @@ StatusMenu {
         onTriggered: { root.addRemoveGroupMember() }
     }
 
+    StatusAction {
+        text: qsTr("Copy channel link")
+        icon.name: "copy"
+        enabled: root.isCommunityChat
+        onTriggered: {
+            const link = Utils.getCommunityChannelShareLinkWithChatId(root.chatId)
+            Utils.copyToClipboard(link)
+        }
+    }
+
     StatusMenuSeparator {
-        visible: root.chatType === Constants.chatType.oneToOne || root.chatType === Constants.chatType.privateGroupChat
+        visible: root.chatType === Constants.chatType.oneToOne || root.chatType === Constants.chatType.privateGroupChat || root.isCommunityChat
     }
 
     StatusAction {

--- a/ui/imports/utils/Utils.qml
+++ b/ui/imports/utils/Utils.qml
@@ -15,6 +15,7 @@ QtObject {
     property var communitiesModuleInst: typeof communitiesModule !== "undefined" ? communitiesModule : null
 
     readonly property int maxImgSizeBytes: Constants.maxUploadFilesizeMB * 1048576 /* 1 MB in bytes */
+    readonly property int communityIdLength: 68
 
     function isDigit(value) {
       return /^\d$/.test(value);
@@ -33,11 +34,19 @@ QtObject {
     }
 
     function isCommunityPublicKey(value) {
-        return (startsWith0x(value) && isHex(value) && value.length === 68) || globalUtilsInst.isCompressedPubKey(value)
+        return (startsWith0x(value) && isHex(value) && value.length === communityIdLength) || globalUtilsInst.isCompressedPubKey(value)
     }
 
     function isCompressedPubKey(pubKey) {
       return globalUtilsInst.isCompressedPubKey(pubKey)
+    }
+
+    function getCommunityIdFromFullChatId(fullChatId) {
+        return fullChatId.substr(0, communityIdLength)
+    }
+
+    function getChannelUuidFromFullChatId(fullChatId) {
+        return fullChatId.substr(communityIdLength, fullChatId.length)
     }
 
     function isValidETHNamePrefix(value) {
@@ -490,6 +499,18 @@ QtObject {
         }
 
         return communitiesModuleInst.shareCommunityUrlWithData(communityId)
+    }
+
+    function getCommunityChannelShareLink(communityId, channelId) {
+        if (communityId === "" || channelId === "")
+            return ""
+        return communitiesModuleInst.shareCommunityChannelUrlWithData(communityId, channelId)
+    }
+
+    function getCommunityChannelShareLinkWithChatId(chatId) {
+        const communityId = getCommunityIdFromFullChatId(chatId)
+        const channelId = getChannelUuidFromFullChatId(chatId)
+        return getCommunityChannelShareLink(communityId, channelId)
     }
 
     function getChatKeyFromShareLink(link) {


### PR DESCRIPTION
### What does the PR do

Added a channel context menu option to copy link to channel.

I'm not sure why it wasn't added in the first place, but we need to test URL unfurling.
If this button shouldn't exist, or it should be of different design, let me know 🙂 

<img width="1396" alt="Screenshot 2023-10-19 at 14 05 22" src="https://github.com/status-im/status-desktop/assets/25482501/becb5f4a-d96b-4bcc-8016-e666283e1277">

<img width="1396" alt="Screenshot 2023-10-19 at 14 05 28" src="https://github.com/status-im/status-desktop/assets/25482501/68c943bc-4d3c-4f0c-9de1-f3abcac68cae">

https://github.com/status-im/status-desktop/assets/25482501/b6644a79-1d12-4d1a-9ba1-971855030ad7

