### PR TITLE
feat(@desktop/community): support joining community if addresses to be revealed belong to a keypair that is migrated to a keycard

### DIFF
--- a/src/app/modules/main/communities/controller.nim
+++ b/src/app/modules/main/communities/controller.nim
@@ -39,7 +39,6 @@ type
     tmpRequestToJoinEnsName: string
     tmpAddressesToShare: seq[string]
     tmpAirdropAddress: string
-    tmpAuthenticationWithCallbackInProgress: bool
 
 proc newController*(
     delegate: io_interface.AccessInterface,
@@ -66,7 +65,6 @@ proc newController*(
   result.tmpRequestToJoinEnsName = ""
   result.tmpAirdropAddress = ""
   result.tmpAddressesToShare = @[]
-  result.tmpAuthenticationWithCallbackInProgress = false
 
 proc delete*(self: Controller) =
   discard
@@ -204,10 +202,6 @@ proc init*(self: Controller) =
     if args.uniqueIdentifier != UNIQUE_COMMUNITIES_MODULE_AUTH_IDENTIFIER:
       return
     self.delegate.onUserAuthenticated(args.pin, args.password, args.keyUid)
-    if self.tmpAuthenticationWithCallbackInProgress:
-      let authenticated = not (args.password == "" and args.pin == "")
-      self.delegate.callbackFromAuthentication(authenticated)
-      self.tmpAuthenticationWithCallbackInProgress = false
 
     self.events.on(SIGNAL_CHECK_PERMISSIONS_TO_JOIN_FAILED) do(e: Args):
       let args = CheckPermissionsToJoinFailedArgs(e)
@@ -429,9 +423,6 @@ proc authenticateToEditSharedAddresses*(self: Controller, communityId: string, a
   self.tmpAddressesToShare = addressesToShare
   self.authenticate()
 
-proc authenticateWithCallback*(self: Controller) =
-  self.tmpAuthenticationWithCallbackInProgress = true
-  self.authenticate()
 
 proc getCommunityPublicKeyFromPrivateKey*(self: Controller, communityPrivateKey: string): string =
   result = self.communityService.getCommunityPublicKeyFromPrivateKey(communityPrivateKey)

--- a/src/app/modules/main/communities/io_interface.nim
+++ b/src/app/modules/main/communities/io_interface.nim
@@ -191,12 +191,6 @@ method editSharedAddressesWithAuthentication*(self: AccessInterface, communityId
     {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method authenticateWithCallback*(self: AccessInterface) {.base.} =
-  raise newException(ValueError, "No implementation available")
-
-method callbackFromAuthentication*(self: AccessInterface, authenticated: bool) {.base.} =
-  raise newException(ValueError, "No implementation available")
-
 method prepareTokenModelForCommunity*(self: AccessInterface, communityId: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 

--- a/src/app/modules/main/communities/io_interface.nim
+++ b/src/app/modules/main/communities/io_interface.nim
@@ -159,10 +159,10 @@ method curatedCommunitiesLoadingFailed*(self: AccessInterface) {.base.} =
 method curatedCommunitiesLoaded*(self: AccessInterface, curatedCommunities: seq[CommunityDto]) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method communityInfoAlreadyRequested*(self: AccessInterface) {.base.} = 
+method communityInfoAlreadyRequested*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method onCommunityTokenMetadataAdded*(self: AccessInterface, communityId: string, tokenMetadata: CommunityTokensMetadataDto) {.base.} = 
+method onCommunityTokenMetadataAdded*(self: AccessInterface, communityId: string, tokenMetadata: CommunityTokensMetadataDto) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method onWalletAccountTokensRebuilt*(self: AccessInterface) {.base.} =
@@ -183,12 +183,20 @@ method shareCommunityChannelUrlWithData*(self: AccessInterface, communityId: str
 method onUserAuthenticated*(self: AccessInterface, pin: string, password: string, keyUid: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method requestToJoinCommunityWithAuthentication*(self: AccessInterface, communityId, ensName: string, addressesToShare: seq[string],
-    airdropAddress: string) {.base.} =
+method onDataSigned*(self: AccessInterface, keyUid: string, path: string, r: string, s: string, v: string, pin: string) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method editSharedAddressesWithAuthentication*(self: AccessInterface, communityId: string, addressesToShare: seq[string], airdropAddress: string)
-    {.base.} =
+method prepareKeypairsForSigning*(self: AccessInterface, communityId: string, ensName: string, addresses: string,
+  airdropAddress: string, editMode: bool) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method signSharedAddressesForAllNonKeycardKeypairs*(self: AccessInterface) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method signSharedAddressesForKeypair*(self: AccessInterface, keyUid: string, pin: string) {.base.} =
+  raise newException(ValueError, "No implementation available")
+
+method joinCommunityOrEditSharedAddresses*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method prepareTokenModelForCommunity*(self: AccessInterface, communityId: string) {.base.} =

--- a/src/app/modules/main/communities/module.nim
+++ b/src/app/modules/main/communities/module.nim
@@ -549,11 +549,7 @@ method requestToJoinCommunityWithAuthentication*(self: Module, communityId, ensN
 method editSharedAddressesWithAuthentication*(self: Module, communityId: string, addressesToShare: seq[string], airdropAddress: string) =
   self.controller.authenticateToEditSharedAddresses(communityId, addressesToShare, airdropAddress)
 
-method authenticateWithCallback*(self: Module) =
-  self.controller.authenticateWithCallback()
 
-method callbackFromAuthentication*(self: Module, authenticated: bool) =
-  self.view.callbackFromAuthentication(authenticated)
 
 method getCommunityPublicKeyFromPrivateKey*(self: Module, communityPrivateKey: string): string =
   result = self.controller.getCommunityPublicKeyFromPrivateKey(communityPrivateKey)

--- a/src/app/modules/main/communities/view.nim
+++ b/src/app/modules/main/communities/view.nim
@@ -127,7 +127,7 @@ QtObject:
   proc communityInfoAlreadyRequested*(self: View) {.signal.}
 
   proc communityTagsChanged*(self: View) {.signal.}
-  
+
   proc setCommunityTags*(self: View, communityTags: string) =
     self.communityTags = newQVariant(communityTags)
     self.communityTagsChanged()
@@ -285,7 +285,7 @@ QtObject:
   proc addItem*(self: View, item: SectionItem) =
     self.model.addItem(item)
     self.communityAdded(item.id)
-  
+
   proc updateItem(self: View, item: SectionItem) =
     self.model.editItem(item)
     self.communityChanged(item.id)
@@ -295,7 +295,7 @@ QtObject:
       self.updateItem(item)
     else:
       self.addItem(item)
-  
+
   proc model*(self: View): SectionModel =
     result = self.model
 
@@ -674,11 +674,6 @@ QtObject:
     return self.delegate.shareCommunityChannelUrlWithData(communityId, chatId)
 
   proc userAuthenticationCanceled*(self: View) {.signal.}
-
-  proc authenticateWithCallback*(self: View) {.slot.} =
-    self.delegate.authenticateWithCallback()
-  
-  proc callbackFromAuthentication*(self: View, authenticated: bool) {.signal.}
 
   proc requestToJoinCommunityWithAuthentication*(self: View, communityId: string, ensName: string) {.slot.} =
     self.delegate.requestToJoinCommunityWithAuthentication(communityId, ensName, @[], "")

--- a/src/app/modules/main/io_interface.nim
+++ b/src/app/modules/main/io_interface.nim
@@ -256,13 +256,13 @@ method onStatusUrlRequested*(self: AccessInterface, action: StatusUrlAction, com
 method getVerificationRequestFrom*(self: AccessInterface, publicKey: string): VerificationRequest {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method getKeycardSharedModuleForAuthentication*(self: AccessInterface): QVariant {.base.} =
+method getKeycardSharedModuleForAuthenticationOrSigning*(self: AccessInterface): QVariant {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method onDisplayKeycardSharedModuleForAuthentication*(self: AccessInterface) {.base.} =
+method onDisplayKeycardSharedModuleForAuthenticationOrSigning*(self: AccessInterface) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method onSharedKeycarModuleForAuthenticationTerminated*(self: AccessInterface, lastStepInTheCurrentFlow: bool) {.base.} =
+method onSharedKeycarModuleForAuthenticationOrSigningTerminated*(self: AccessInterface, lastStepInTheCurrentFlow: bool) {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method getKeycardSharedModule*(self: AccessInterface): QVariant {.base.} =
@@ -275,7 +275,8 @@ method onSharedKeycarModuleFlowTerminated*(self: AccessInterface, lastStepInTheC
   nextFlow: keycard_shared_module.FlowType, forceFlow: bool, nextKeyUid: string, returnToFlow: keycard_shared_module.FlowType) {.base.} =
   raise newException(ValueError, "No implementation available")
 
-method runAuthenticationPopup*(self: AccessInterface, keyUid: string, bip44Paths: seq[string] = @[]) {.base.} =
+method runAuthenticationOrSigningPopup*(self: AccessInterface, flow: keycard_shared_module.FlowType, keyUid: string,
+  bip44Paths: seq[string] = @[], dataToSign: string = "") {.base.} =
   raise newException(ValueError, "No implementation available")
 
 method onSharedKeycarModuleRunningKeycardFlowsPurposeTerminated*(self: AccessInterface, lastStepInTheCurrentFlow: bool) {.base.} =

--- a/src/app/modules/main/view.nim
+++ b/src/app/modules/main/view.nim
@@ -245,13 +245,13 @@ QtObject:
   proc emitDisplayUserProfileSignal*(self: View, publicKey: string) =
     self.displayUserProfile(publicKey)
 
-  proc getKeycardSharedModuleForAuthentication(self: View): QVariant {.slot.} =
-    let module = self.delegate.getKeycardSharedModuleForAuthentication()
+  proc getKeycardSharedModuleForAuthenticationOrSigning(self: View): QVariant {.slot.} =
+    let module = self.delegate.getKeycardSharedModuleForAuthenticationOrSigning()
     if not module.isNil:
       return module
     return newQVariant()
-  QtProperty[QVariant] keycardSharedModuleForAuthentication:
-    read = getKeycardSharedModuleForAuthentication
+  QtProperty[QVariant] keycardSharedModuleForAuthenticationOrSigning:
+    read = getKeycardSharedModuleForAuthenticationOrSigning
 
   proc activateStatusDeepLink*(self: View, statusDeepLink: string) {.slot.} =
     self.delegate.activateStatusDeepLink(statusDeepLink)
@@ -264,13 +264,13 @@ QtObject:
   QtProperty[QVariant] keycardSharedModule:
     read = getKeycardSharedModule
 
-  proc displayKeycardSharedModuleForAuthentication*(self: View) {.signal.}
-  proc emitDisplayKeycardSharedModuleForAuthentication*(self: View) =
-    self.displayKeycardSharedModuleForAuthentication()
+  proc displayKeycardSharedModuleForAuthenticationOrSigning*(self: View) {.signal.}
+  proc emitDisplayKeycardSharedModuleForAuthenticationOrSigning*(self: View) =
+    self.displayKeycardSharedModuleForAuthenticationOrSigning()
 
-  proc destroyKeycardSharedModuleForAuthentication*(self: View) {.signal.}
-  proc emitDestroyKeycardSharedModuleForAuthentication*(self: View) =
-    self.destroyKeycardSharedModuleForAuthentication()
+  proc destroyKeycardSharedModuleForAuthenticationOrSigning*(self: View) {.signal.}
+  proc emitDestroyKeycardSharedModuleForAuthenticationOrSigning*(self: View) =
+    self.destroyKeycardSharedModuleForAuthenticationOrSigning()
 
   proc displayKeycardSharedModuleFlow*(self: View) {.signal.}
   proc emitDisplayKeycardSharedModuleFlow*(self: View) =

--- a/src/app/modules/shared_models/keypair_item.nim
+++ b/src/app/modules/shared_models/keypair_item.nim
@@ -28,6 +28,7 @@ QtObject:
     syncedFrom: string
     accounts: KeyPairAccountModel
     observedAccount: KeyPairAccountItem
+    ownershipVerified: bool
 
   proc setup*(self: KeyPairItem,
     keyUid: string,
@@ -40,7 +41,8 @@ QtObject:
     derivedFrom: string,
     lastUsedDerivationIndex: int,
     migratedToKeycard: bool,
-    syncedFrom: string
+    syncedFrom: string,
+    ownershipVerified: bool
     ) =
     self.QObject.setup
     self.keyUid = keyUid
@@ -54,6 +56,7 @@ QtObject:
     self.lastUsedDerivationIndex = lastUsedDerivationIndex
     self.migratedToKeycard = migratedToKeycard
     self.syncedFrom = syncedFrom
+    self.ownershipVerified = ownershipVerified
     self.accounts = newKeyPairAccountModel()
 
   proc delete*(self: KeyPairItem) =
@@ -69,10 +72,11 @@ QtObject:
     derivedFrom = "",
     lastUsedDerivationIndex = 0,
     migratedToKeycard = false,
-    syncedFrom = ""): KeyPairItem =
+    syncedFrom = "",
+    ownershipVerified = false): KeyPairItem =
     new(result, delete)
     result.setup(keyUid, pubKey, locked, name, image, icon, pairType, derivedFrom, lastUsedDerivationIndex,
-      migratedToKeycard, syncedFrom)
+      migratedToKeycard, syncedFrom, ownershipVerified)
 
   proc `$`*(self: KeyPairItem): string =
     result = fmt"""KeyPairItem[
@@ -88,7 +92,8 @@ QtObject:
       migratedToKeycard: {self.migratedToKeycard},
       operability: {self.operability},
       syncedFrom: {self.syncedFrom},
-      accounts: {$self.accounts}
+      ownershipVerified: {$self.ownershipVerified}
+      accounts: {$self.accounts},
       ]"""
 
   proc keyUidChanged*(self: KeyPairItem) {.signal.}
@@ -224,6 +229,17 @@ QtObject:
     write = setSyncedFrom
     notify = syncedFromChanged
 
+  proc ownershipVerifiedChanged*(self: KeyPairItem) {.signal.}
+  proc getOwnershipVerified*(self: KeyPairItem): bool {.slot.} =
+    return self.ownershipVerified
+  proc setOwnershipVerified*(self: KeyPairItem, value: bool) {.slot.} =
+    self.ownershipVerified = value
+    self.ownershipVerifiedChanged()
+  QtProperty[bool] ownershipVerified:
+    read = getOwnershipVerified
+    write = setOwnershipVerified
+    notify = ownershipVerifiedChanged
+
   proc observedAccountChanged*(self: KeyPairItem) {.signal.}
   proc getObservedAccountAsVariant*(self: KeyPairItem): QVariant {.slot.} =
     return newQVariant(self.observedAccount)
@@ -288,4 +304,5 @@ QtObject:
     self.setMigratedToKeycard(item.getMigratedToKeycard())
     self.setLastUsedDerivationIndex(item.getLastUsedDerivationIndex())
     self.setAccounts(item.getAccountsModel().getItems())
+    self.setOwnershipVerified(item.getOwnershipVerified())
     self.setLastAccountAsObservedAccount()

--- a/src/app/modules/shared_models/keypair_model.nim
+++ b/src/app/modules/shared_models/keypair_model.nim
@@ -109,6 +109,12 @@ QtObject:
       return
     item.setName(name)
 
+  proc setOwnershipVerified*(self: KeyPairModel, keyUid: string, ownershipVerified: bool) =
+    let item = self.findItemByKeyUid(keyUid)
+    if item.isNil:
+      return
+    item.setOwnershipVerified(ownershipVerified)
+
   proc setBalanceForAddress*(self: KeyPairModel, address: string, balance: CurrencyAmount) =
     for item in self.items:
       item.setBalanceForAddress(address, balance)

--- a/src/app/modules/shared_modules/keycard_popup/internal/biometrics_pin_failed_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/biometrics_pin_failed_state.nim
@@ -9,21 +9,25 @@ proc delete*(self: BiometricsPinFailedState) =
   self.State.delete
 
 method executePrePrimaryStateCommand*(self: BiometricsPinFailedState, controller: Controller) =
-  if self.flowType == FlowType.Authentication:
-    controller.tryToObtainDataFromKeychain()
+  if self.flowType == FlowType.Authentication or
+    self.flowType == FlowType.Sign:
+      controller.tryToObtainDataFromKeychain()
 
 method executePreSecondaryStateCommand*(self: BiometricsPinFailedState, controller: Controller) =
-  if self.flowType == FlowType.Authentication:
-    controller.setUsePinFromBiometrics(true)
+  if self.flowType == FlowType.Authentication or
+    self.flowType == FlowType.Sign:
+      controller.setUsePinFromBiometrics(true)
 
 method getNextSecondaryState*(self: BiometricsPinFailedState, controller: Controller): State =
-  if self.flowType == FlowType.Authentication:
-    return createState(StateType.EnterPin, self.flowType, nil)
+  if self.flowType == FlowType.Authentication or
+    self.flowType == FlowType.Sign:
+      return createState(StateType.EnterPin, self.flowType, nil)
 
 method executeCancelCommand*(self: BiometricsPinFailedState, controller: Controller) =
-  if self.flowType == FlowType.Authentication:
-    controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)
+  if self.flowType == FlowType.Authentication or
+    self.flowType == FlowType.Sign:
+      controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)
 
-method resolveKeycardNextState*(self: BiometricsPinFailedState, keycardFlowType: string, keycardEvent: KeycardEvent, 
+method resolveKeycardNextState*(self: BiometricsPinFailedState, keycardFlowType: string, keycardEvent: KeycardEvent,
   controller: Controller): State =
   return ensureReaderAndCardPresenceAndResolveNextState(self, keycardFlowType, keycardEvent, controller)

--- a/src/app/modules/shared_modules/keycard_popup/internal/biometrics_pin_invalid_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/biometrics_pin_invalid_state.nim
@@ -9,22 +9,26 @@ proc delete*(self: BiometricsPinInvalidState) =
   self.State.delete
 
 method executePrePrimaryStateCommand*(self: BiometricsPinInvalidState, controller: Controller) =
-  if self.flowType == FlowType.Authentication:
-    controller.tryToObtainDataFromKeychain()
+  if self.flowType == FlowType.Authentication or
+    self.flowType == FlowType.Sign:
+      controller.tryToObtainDataFromKeychain()
 
 method executePreSecondaryStateCommand*(self: BiometricsPinInvalidState, controller: Controller) =
-  if self.flowType == FlowType.Authentication:
-    controller.setUsePinFromBiometrics(true)
-    controller.setOfferToStoreUpdatedPinToKeychain(true)
+  if self.flowType == FlowType.Authentication or
+    self.flowType == FlowType.Sign:
+      controller.setUsePinFromBiometrics(true)
+      controller.setOfferToStoreUpdatedPinToKeychain(true)
 
 method getNextSecondaryState*(self: BiometricsPinInvalidState, controller: Controller): State =
-  if self.flowType == FlowType.Authentication:
-    return createState(StateType.EnterPin, self.flowType, nil)
+  if self.flowType == FlowType.Authentication or
+    self.flowType == FlowType.Sign:
+      return createState(StateType.EnterPin, self.flowType, nil)
 
 method executeCancelCommand*(self: BiometricsPinInvalidState, controller: Controller) =
-  if self.flowType == FlowType.Authentication:
-    controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)
+  if self.flowType == FlowType.Authentication or
+    self.flowType == FlowType.Sign:
+      controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)
 
-method resolveKeycardNextState*(self: BiometricsPinInvalidState, keycardFlowType: string, keycardEvent: KeycardEvent, 
+method resolveKeycardNextState*(self: BiometricsPinInvalidState, keycardFlowType: string, keycardEvent: KeycardEvent,
   controller: Controller): State =
   return ensureReaderAndCardPresenceAndResolveNextState(self, keycardFlowType, keycardEvent, controller)

--- a/src/app/modules/shared_modules/keycard_popup/internal/biometrics_ready_to_sign_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/biometrics_ready_to_sign_state.nim
@@ -9,44 +9,49 @@ proc delete*(self: BiometricsReadyToSignState) =
   self.State.delete
 
 method executePrePrimaryStateCommand*(self: BiometricsReadyToSignState, controller: Controller) =
-  if self.flowType == FlowType.Authentication:
-    controller.tryToObtainDataFromKeychain()
+  if self.flowType == FlowType.Authentication or
+    self.flowType == FlowType.Sign:
+      controller.tryToObtainDataFromKeychain()
 
 method executePreSecondaryStateCommand*(self: BiometricsReadyToSignState, controller: Controller) =
-  if self.flowType == FlowType.Authentication:
-    controller.setUsePinFromBiometrics(true)
+  if self.flowType == FlowType.Authentication or
+    self.flowType == FlowType.Sign:
+      controller.setUsePinFromBiometrics(true)
 
 method getNextSecondaryState*(self: BiometricsReadyToSignState, controller: Controller): State =
-  if self.flowType == FlowType.Authentication:
-    return createState(StateType.EnterPin, self.flowType, nil)
+  if self.flowType == FlowType.Authentication or
+    self.flowType == FlowType.Sign:
+      return createState(StateType.EnterPin, self.flowType, nil)
 
 method executeCancelCommand*(self: BiometricsReadyToSignState, controller: Controller) =
-  if self.flowType == FlowType.Authentication:
-    controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)
+  if self.flowType == FlowType.Authentication or
+    self.flowType == FlowType.Sign:
+      controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)
 
-method resolveKeycardNextState*(self: BiometricsReadyToSignState, keycardFlowType: string, keycardEvent: KeycardEvent, 
+method resolveKeycardNextState*(self: BiometricsReadyToSignState, keycardFlowType: string, keycardEvent: KeycardEvent,
   controller: Controller): State =
   let state = ensureReaderAndCardPresence(self, keycardFlowType, keycardEvent, controller)
   if not state.isNil:
     return state
-  if self.flowType == FlowType.Authentication:
-    if keycardFlowType == ResponseTypeValueEnterPIN and 
-      keycardEvent.error.len > 0 and
-      keycardEvent.error == ErrorPIN:
-      controller.setRemainingAttempts(keycardEvent.pinRetries)
-      if keycardEvent.pinRetries > 0:
-        if singletonInstance.userProfile.getUsingBiometricLogin() and not controller.usePinFromBiometrics():
-          return createState(StateType.WrongKeychainPin, self.flowType, nil)
-        return createState(StateType.WrongPin, self.flowType, nil)
-      return createState(StateType.MaxPinRetriesReached, self.flowType, nil)
-    if keycardFlowType == ResponseTypeValueEnterPIN and 
-      keycardEvent.error.len == 0:
+  if self.flowType == FlowType.Authentication or
+    self.flowType == FlowType.Sign:
+      if keycardFlowType == ResponseTypeValueEnterPIN and
+        keycardEvent.error.len > 0 and
+        keycardEvent.error == ErrorPIN:
+        controller.setRemainingAttempts(keycardEvent.pinRetries)
+        if keycardEvent.pinRetries > 0:
+          if singletonInstance.userProfile.getUsingBiometricLogin() and not controller.usePinFromBiometrics():
+            return createState(StateType.WrongKeychainPin, self.flowType, nil)
+          return createState(StateType.WrongPin, self.flowType, nil)
         return createState(StateType.MaxPinRetriesReached, self.flowType, nil)
-    if keycardFlowType == ResponseTypeValueEnterPUK and 
-      keycardEvent.error.len == 0:
-        if keycardEvent.pinRetries == 0 and keycardEvent.pukRetries > 0:
+      if keycardFlowType == ResponseTypeValueEnterPIN and
+        keycardEvent.error.len == 0:
           return createState(StateType.MaxPinRetriesReached, self.flowType, nil)
-    if keycardFlowType == ResponseTypeValueKeycardFlowResult:
-      if keycardEvent.error.len == 0:
-        controller.terminateCurrentFlow(lastStepInTheCurrentFlow = true)
-        return nil
+      if keycardFlowType == ResponseTypeValueEnterPUK and
+        keycardEvent.error.len == 0:
+          if keycardEvent.pinRetries == 0 and keycardEvent.pukRetries > 0:
+            return createState(StateType.MaxPinRetriesReached, self.flowType, nil)
+      if keycardFlowType == ResponseTypeValueKeycardFlowResult:
+        if keycardEvent.error.len == 0:
+          controller.terminateCurrentFlow(lastStepInTheCurrentFlow = true)
+          return nil

--- a/src/app/modules/shared_modules/keycard_popup/internal/insert_keycard_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/insert_keycard_state.nim
@@ -20,6 +20,7 @@ method executeCancelCommand*(self: InsertKeycardState, controller: Controller) =
     self.flowType == FlowType.SetupNewKeycardOldSeedPhrase or
     self.flowType == FlowType.ImportFromKeycard or
     self.flowType == FlowType.Authentication or
+    self.flowType == FlowType.Sign or
     self.flowType == FlowType.UnlockKeycard or
     self.flowType == FlowType.DisplayKeycardContent or
     self.flowType == FlowType.RenameKeycard or

--- a/src/app/modules/shared_modules/keycard_popup/internal/keycard_empty_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/keycard_empty_state.nim
@@ -12,6 +12,7 @@ method executePrePrimaryStateCommand*(self: KeycardEmptyState, controller: Contr
   if self.flowType == FlowType.FactoryReset or
     self.flowType == FlowType.ImportFromKeycard or
     self.flowType == FlowType.Authentication or
+    self.flowType == FlowType.Sign or
     self.flowType == FlowType.DisplayKeycardContent or
     self.flowType == FlowType.RenameKeycard or
     self.flowType == FlowType.ChangeKeycardPin or
@@ -35,6 +36,7 @@ method executeCancelCommand*(self: KeycardEmptyState, controller: Controller) =
   if self.flowType == FlowType.FactoryReset or
     self.flowType == FlowType.ImportFromKeycard or
     self.flowType == FlowType.Authentication or
+    self.flowType == FlowType.Sign or
     self.flowType == FlowType.UnlockKeycard or
     self.flowType == FlowType.DisplayKeycardContent or
     self.flowType == FlowType.RenameKeycard or

--- a/src/app/modules/shared_modules/keycard_popup/internal/keycard_inserted_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/keycard_inserted_state.nim
@@ -27,6 +27,7 @@ method executeCancelCommand*(self: KeycardInsertedState, controller: Controller)
     self.flowType == FlowType.SetupNewKeycardOldSeedPhrase or
     self.flowType == FlowType.ImportFromKeycard or
     self.flowType == FlowType.Authentication or
+    self.flowType == FlowType.Sign or
     self.flowType == FlowType.UnlockKeycard or
     self.flowType == FlowType.DisplayKeycardContent or
     self.flowType == FlowType.RenameKeycard or

--- a/src/app/modules/shared_modules/keycard_popup/internal/max_pairing_slots_reached_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/max_pairing_slots_reached_state.nim
@@ -21,6 +21,7 @@ method getNextPrimaryState*(self: MaxPairingSlotsReachedState, controller: Contr
       return createState(StateType.FactoryResetConfirmation, self.flowType, self)
   if self.flowType == FlowType.ImportFromKeycard or
     self.flowType == FlowType.Authentication or
+    self.flowType == FlowType.Sign or
     self.flowType == FlowType.DisplayKeycardContent or
     self.flowType == FlowType.RenameKeycard or
     self.flowType == FlowType.ChangeKeycardPin or
@@ -38,6 +39,7 @@ method executeCancelCommand*(self: MaxPairingSlotsReachedState, controller: Cont
     self.flowType == FlowType.SetupNewKeycardOldSeedPhrase or
     self.flowType == FlowType.ImportFromKeycard or
     self.flowType == FlowType.Authentication or
+    self.flowType == FlowType.Sign or
     self.flowType == FlowType.UnlockKeycard or
     self.flowType == FlowType.DisplayKeycardContent or
     self.flowType == FlowType.RenameKeycard or

--- a/src/app/modules/shared_modules/keycard_popup/internal/max_pin_retries_reached_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/max_pin_retries_reached_state.nim
@@ -33,12 +33,14 @@ method getNextPrimaryState*(self: MaxPinRetriesReachedState, controller: Control
         controller.runSharedModuleFlow(FlowType.UnlockKeycard)
         return
       return createState(StateType.FactoryResetConfirmation, self.flowType, self)
-  if self.flowType == FlowType.Authentication:
-    controller.setKeycardData(updatePredefinedKeycardData(controller.getKeycardData(), PredefinedKeycardData.DisableSeedPhraseForUnlock, add = true))
-    controller.runSharedModuleFlow(FlowType.UnlockKeycard)
+  if self.flowType == FlowType.Authentication or
+    self.flowType == FlowType.Sign:
+      controller.setKeycardData(updatePredefinedKeycardData(controller.getKeycardData(), PredefinedKeycardData.DisableSeedPhraseForUnlock, add = true))
+      controller.runSharedModuleFlow(FlowType.UnlockKeycard)
 
 method executeCancelCommand*(self: MaxPinRetriesReachedState, controller: Controller) =
   if self.flowType == FlowType.Authentication or
+    self.flowType == FlowType.Sign or
     self.flowType == FlowType.RenameKeycard or
     self.flowType == FlowType.ChangeKeycardPin or
     self.flowType == FlowType.ChangeKeycardPuk or

--- a/src/app/modules/shared_modules/keycard_popup/internal/max_puk_retries_reached_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/max_puk_retries_reached_state.nim
@@ -21,6 +21,7 @@ method getNextPrimaryState*(self: MaxPukRetriesReachedState, controller: Control
       return createState(StateType.FactoryResetConfirmation, self.flowType, self)
   if self.flowType == FlowType.ImportFromKeycard or
     self.flowType == FlowType.Authentication or
+    self.flowType == FlowType.Sign or
     self.flowType == FlowType.DisplayKeycardContent or
     self.flowType == FlowType.RenameKeycard or
     self.flowType == FlowType.ChangeKeycardPin or
@@ -38,6 +39,7 @@ method executeCancelCommand*(self: MaxPukRetriesReachedState, controller: Contro
     self.flowType == FlowType.SetupNewKeycardOldSeedPhrase or
     self.flowType == FlowType.ImportFromKeycard or
     self.flowType == FlowType.Authentication or
+    self.flowType == FlowType.Sign or
     self.flowType == FlowType.UnlockKeycard or
     self.flowType == FlowType.DisplayKeycardContent or
     self.flowType == FlowType.RenameKeycard or

--- a/src/app/modules/shared_modules/keycard_popup/internal/not_keycard_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/not_keycard_state.nim
@@ -15,6 +15,7 @@ method executeCancelCommand*(self: NotKeycardState, controller: Controller) =
     self.flowType == FlowType.SetupNewKeycardOldSeedPhrase or
     self.flowType == FlowType.ImportFromKeycard or
     self.flowType == FlowType.Authentication or
+    self.flowType == FlowType.Sign or
     self.flowType == FlowType.UnlockKeycard or
     self.flowType == FlowType.DisplayKeycardContent or
     self.flowType == FlowType.RenameKeycard or

--- a/src/app/modules/shared_modules/keycard_popup/internal/plugin_reader_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/plugin_reader_state.nim
@@ -20,6 +20,7 @@ method executeCancelCommand*(self: PluginReaderState, controller: Controller) =
     self.flowType == FlowType.SetupNewKeycardOldSeedPhrase or
     self.flowType == FlowType.ImportFromKeycard or
     self.flowType == FlowType.Authentication or
+    self.flowType == FlowType.Sign or
     self.flowType == FlowType.UnlockKeycard or
     self.flowType == FlowType.DisplayKeycardContent or
     self.flowType == FlowType.RenameKeycard or

--- a/src/app/modules/shared_modules/keycard_popup/internal/wrong_keycard_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/wrong_keycard_state.nim
@@ -28,6 +28,7 @@ method executePrePrimaryStateCommand*(self: WrongKeycardState, controller: Contr
 
 method executeCancelCommand*(self: WrongKeycardState, controller: Controller) =
   if self.flowType == FlowType.Authentication or
+    self.flowType == FlowType.Sign or
     self.flowType == FlowType.UnlockKeycard or
     self.flowType == FlowType.RenameKeycard or
     self.flowType == FlowType.ChangeKeycardPin or

--- a/src/app/modules/shared_modules/keycard_popup/internal/wrong_keychain_pin_state.nim
+++ b/src/app/modules/shared_modules/keycard_popup/internal/wrong_keychain_pin_state.nim
@@ -9,34 +9,37 @@ proc delete*(self: WrongKeychainPinState) =
   self.State.delete
 
 method getNextPrimaryState*(self: WrongKeychainPinState, controller: Controller): State =
-  if self.flowType == FlowType.Authentication:
-    if controller.getPin().len == PINLengthForStatusApp:
-      controller.enterKeycardPin(controller.getPin())
+  if self.flowType == FlowType.Authentication or
+    self.flowType == FlowType.Sign:
+      if controller.getPin().len == PINLengthForStatusApp:
+        controller.enterKeycardPin(controller.getPin())
   return nil
 
 method executeCancelCommand*(self: WrongKeychainPinState, controller: Controller) =
-  if self.flowType == FlowType.Authentication:
-    controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)
+  if self.flowType == FlowType.Authentication or
+    self.flowType == FlowType.Sign:
+      controller.terminateCurrentFlow(lastStepInTheCurrentFlow = false)
 
-method resolveKeycardNextState*(self: WrongKeychainPinState, keycardFlowType: string, keycardEvent: KeycardEvent, 
+method resolveKeycardNextState*(self: WrongKeychainPinState, keycardFlowType: string, keycardEvent: KeycardEvent,
   controller: Controller): State =
   let state = ensureReaderAndCardPresence(self, keycardFlowType, keycardEvent, controller)
   if not state.isNil:
     return state
-  if self.flowType == FlowType.Authentication:
-    if keycardFlowType == ResponseTypeValueEnterPIN and 
-      keycardEvent.error.len > 0 and
-      keycardEvent.error == ErrorPIN:
-      controller.setRemainingAttempts(keycardEvent.pinRetries)
-      if keycardEvent.pinRetries > 0:
-        return self
-      return createState(StateType.MaxPinRetriesReached, self.flowType, nil)
-    if keycardFlowType == ResponseTypeValueEnterPUK and 
-      keycardEvent.error.len == 0:
-        if keycardEvent.pinRetries == 0 and keycardEvent.pukRetries > 0:
-          return createState(StateType.MaxPinRetriesReached, self.flowType, nil)
-    if keycardFlowType == ResponseTypeValueKeycardFlowResult:
-      if keycardEvent.error.len == 0:
-        controller.tryToStoreDataToKeychain(controller.getPin())
-        controller.terminateCurrentFlow(lastStepInTheCurrentFlow = true)
-        return nil
+  if self.flowType == FlowType.Authentication or
+    self.flowType == FlowType.Sign:
+      if keycardFlowType == ResponseTypeValueEnterPIN and
+        keycardEvent.error.len > 0 and
+        keycardEvent.error == ErrorPIN:
+        controller.setRemainingAttempts(keycardEvent.pinRetries)
+        if keycardEvent.pinRetries > 0:
+          return self
+        return createState(StateType.MaxPinRetriesReached, self.flowType, nil)
+      if keycardFlowType == ResponseTypeValueEnterPUK and
+        keycardEvent.error.len == 0:
+          if keycardEvent.pinRetries == 0 and keycardEvent.pukRetries > 0:
+            return createState(StateType.MaxPinRetriesReached, self.flowType, nil)
+      if keycardFlowType == ResponseTypeValueKeycardFlowResult:
+        if keycardEvent.error.len == 0:
+          controller.tryToStoreDataToKeychain(controller.getPin())
+          controller.terminateCurrentFlow(lastStepInTheCurrentFlow = true)
+          return nil

--- a/src/app/modules/shared_modules/keycard_popup/io_interface.nim
+++ b/src/app/modules/shared_modules/keycard_popup/io_interface.nim
@@ -21,6 +21,7 @@ type FlowType* {.pure.} = enum
   CreateCopyOfAKeycard = "CreateCopyOfAKeycard"
   MigrateFromKeycardToApp = "MigrateFromKeycardToApp"
   MigrateFromAppToKeycard = "MigrateFromAppToKeycard"
+  Sign = "Sign"
 
 # For the following flows we don't run card syncing.
 const FlowsWeShouldNotTryAKeycardSyncFor* = @[
@@ -35,6 +36,7 @@ const FlowsWeShouldNotTryAKeycardSyncFor* = @[
   FlowType.CreateCopyOfAKeycard,
   FlowType.MigrateFromKeycardToApp,
   FlowType.MigrateFromAppToKeycard,
+  FlowType.Sign,
 ]
 
 const SIGNAL_SHARED_KEYCARD_MODULE_DISPLAY_POPUP* = "sharedKeycarModuleDisplayPopup"

--- a/src/app/modules/shared_modules/keycard_popup/io_interface.nim
+++ b/src/app/modules/shared_modules/keycard_popup/io_interface.nim
@@ -45,6 +45,8 @@ const SIGNAL_SHARED_KEYCARD_MODULE_AUTHENTICATE_USER* = "sharedKeycarModuleAuthe
 const SIGNAL_SHARED_KEYCARD_MODULE_USER_AUTHENTICATED* = "sharedKeycarModuleUserAuthenticated"
 const SIGNAL_SHARED_KEYCARD_MODULE_TRY_KEYCARD_SYNC* = "sharedKeycarModuleTryKeycardSync"
 const SIGNAL_SHARED_KEYCARD_MODULE_KEYCARD_SYNC_TERMINATED* = "sharedKeycarModuleKeycardSyncTerminated"
+const SIGNAL_SHARED_KEYCARD_MODULE_SIGN_DATA* = "sharedKeycarModuleSignData"
+const SIGNAL_SHARED_KEYCARD_MODULE_DATA_SIGNED* = "sharedKeycarModuleDataSigned"
 
 ## Authentication in the app is a global thing and may be used from any part of the app. How to achieve that... it's enough just to send
 ## `SIGNAL_SHARED_KEYCARD_MODULE_AUTHENTICATE_USER` signal with properly set `SharedKeycarModuleAuthenticationArgs` and props there:
@@ -74,6 +76,10 @@ type
     keyUid*: string
     keycardUid*: string
     additinalPathsDetails*: Table[string, KeyDetails] # [path, KeyDetails]
+    path*: string
+    r*: string
+    s*: string
+    v*: string
 
 type
   SharedKeycarModuleFlowTerminatedArgs* = ref object of SharedKeycarModuleArgs
@@ -87,6 +93,12 @@ type
   SharedKeycarModuleAuthenticationArgs* = ref object of SharedKeycarModuleBaseArgs
     keyUid*: string
     additionalBip44Paths*: seq[string] # can be used in authentication flow to export additinal paths if needed except encryption path
+
+type
+  SharedKeycarModuleSigningArgs* = ref object of SharedKeycarModuleBaseArgs
+    keyUid*: string
+    path*: string
+    dataToSign*: string
 
 type
   AccessInterface* {.pure inheritable.} = ref object of RootObj

--- a/src/app/modules/shared_modules/keycard_popup/models/keycard_item.nim
+++ b/src/app/modules/shared_modules/keycard_popup/models/keycard_item.nim
@@ -25,7 +25,7 @@ QtObject:
       ): KeycardItem =
     new(result, delete)
     result.KeyPairItem.setup(keyUid, pubKey, locked, name, image, icon, pairType, derivedFrom,lastUsedDerivationIndex,
-      migratedToKeycard, syncedFrom = "")
+      migratedToKeycard, syncedFrom = "", ownershipVerified = false)
     result.keycardUid = keycardUid
 
   proc `$`*(self: KeycardItem): string =

--- a/src/app_service/service/community/async_tasks.nim
+++ b/src/app_service/service/community/async_tasks.nim
@@ -157,15 +157,15 @@ type
   AsyncRequestToJoinCommunityTaskArg = ref object of QObjectTaskArg
     communityId: string
     ensName: string
-    password: string
     addressesToShare: seq[string]
+    signatures: seq[string]
     airdropAddress: string
 
 const asyncRequestToJoinCommunityTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AsyncRequestToJoinCommunityTaskArg](argEncoded)
   try:
-    let response = status_go.requestToJoinCommunity(arg.communityId, arg.ensName, arg.password, arg.addressesToShare,
-      arg.airdropAddress)
+    let response = status_go.requestToJoinCommunity(arg.communityId, arg.ensName, arg.addressesToShare,
+      arg.signatures, arg.airdropAddress)
     arg.finish(%* {
       "response": response,
       "communityId": arg.communityId,
@@ -180,14 +180,14 @@ const asyncRequestToJoinCommunityTask: Task = proc(argEncoded: string) {.gcsafe,
 type
   AsyncEditSharedAddressesTaskArg = ref object of QObjectTaskArg
     communityId: string
-    password: string
     addressesToShare: seq[string]
+    signatures: seq[string]
     airdropAddress: string
 
 const asyncEditSharedAddressesTask: Task = proc(argEncoded: string) {.gcsafe, nimcall.} =
   let arg = decode[AsyncEditSharedAddressesTaskArg](argEncoded)
   try:
-    let response = status_go.editSharedAddresses(arg.communityId, arg.password, arg.addressesToShare,
+    let response = status_go.editSharedAddresses(arg.communityId, arg.addressesToShare, arg.signatures,
       arg.airdropAddress)
     arg.finish(%* {
       "response": response,

--- a/src/app_service/service/community/dto/sign_params.nim
+++ b/src/app_service/service/community/dto/sign_params.nim
@@ -1,0 +1,21 @@
+import json
+
+include app_service/common/json_utils
+
+type SignParamsDto* = object
+  data*: string
+  address*: string
+  password*: string
+
+proc toSignParamsDto*(jsonObj: JsonNode): SignParamsDto =
+  result = SignParamsDto()
+  discard jsonObj.getProp("data", result.data)
+  discard jsonObj.getProp("account", result.address)
+  discard jsonObj.getProp("password", result.password)
+
+proc toJson*(self: SignParamsDto): JsonNode =
+  return %* {
+    "data": $self.data,
+    "account": $self.address,
+    "password": $self.password
+  }

--- a/src/app_service/service/keycard/internal.nim
+++ b/src/app_service/service/keycard/internal.nim
@@ -89,9 +89,13 @@ proc toCardMetadata(jsonObj: JsonNode): CardMetadata =
 proc toTransactionSignature(jsonObj: JsonNode): TransactionSignature =
   discard jsonObj.getProp(ResponseParamTxSignatureR, result.r)
   discard jsonObj.getProp(ResponseParamTxSignatureS, result.s)
-  discard jsonObj.getProp(ResponseParamTxSignatureV, result.v)
-  if result.v.len == 0:
-    result.v = "0"
+  var v: int
+  discard jsonObj.getProp(ResponseParamTxSignatureV, v)
+  ## The signature must conform to the secp256k1 curve R, S and V values, where the V value must be 27 or 28 for legacy reasons.
+  ## Transform V from 0/1 to 27/28 (1b/1c) according to the yellow paper https://ethereum.github.io/yellowpaper/paper.pdf
+  result.v = "1b"
+  if v == 1:
+    result.v = "1c"
 
 proc toKeycardEvent(jsonObj: JsonNode): KeycardEvent =
   discard jsonObj.getProp(ResponseParamErrorKey, result.error)

--- a/src/app_service/service/keycard/service.nim
+++ b/src/app_service/service/keycard/service.nim
@@ -346,7 +346,7 @@ QtObject:
     self.currentFlow = KCSFlowType.StoreMetadata
     self.startFlow(payload)
 
-  proc startSignFlow*(self: Service, bip44Path: string, txHash: string, pin: string) =
+  proc startSignFlow*(self: Service, bip44Path: string, txHash: string, pin: string = "") =
     var payload = %* {
       RequestParamTXHash: EmptyTxHash,
       RequestParamBIP44Path: DefaultBIP44Path

--- a/src/backend/communities.nim
+++ b/src/backend/communities.nim
@@ -31,31 +31,54 @@ proc getAllCommunities*(): RpcResponse[JsonNode] {.raises: [Exception].} =
 proc spectateCommunity*(communityId: string): RpcResponse[JsonNode] {.raises: [Exception].} =
   result = callPrivateRPC("spectateCommunity".prefix, %*[communityId])
 
+proc generateJoiningCommunityRequestsForSigning*(
+    memberPubKey: string,
+    communityId: string,
+    addressesToReveal: seq[string]
+  ): RpcResponse[JsonNode] {.raises: [Exception].} =
+  let payload = %*[memberPubKey, communityId, addressesToReveal]
+  result = callPrivateRPC("generateJoiningCommunityRequestsForSigning".prefix, payload)
+
+proc generateEditCommunityRequestsForSigning*(
+    memberPubKey: string,
+    communityId: string,
+    addressesToReveal: seq[string]
+  ): RpcResponse[JsonNode] {.raises: [Exception].} =
+  let payload = %*[memberPubKey, communityId, addressesToReveal]
+  result = callPrivateRPC("generateEditCommunityRequestsForSigning".prefix, payload)
+
+## `signParams` represents a json array of SignParamsDto.
+proc signData*(signParams: JsonNode): RpcResponse[JsonNode] {.raises: [Exception].} =
+  if signParams.kind != JArray:
+    raise newException(Exception, "signParams must be an array")
+  let payload = %*[signParams]
+  result = callPrivateRPC("signData".prefix, payload)
+
 proc requestToJoinCommunity*(
     communityId: string,
     ensName: string,
-    password: string,
     addressesToShare: seq[string],
+    signatures: seq[string],
     airdropAddress: string,
   ): RpcResponse[JsonNode] {.raises: [Exception].} =
   result = callPrivateRPC("requestToJoinCommunity".prefix, %*[{
     "communityId": communityId,
     "ensName": ensName,
-    "password": password,
     "addressesToReveal": addressesToShare,
+    "signatures": signatures,
     "airdropAddress": airdropAddress,
   }])
 
 proc editSharedAddresses*(
     communityId: string,
-    password: string,
     addressesToShare: seq[string],
+    signatures: seq[string],
     airdropAddress: string,
   ): RpcResponse[JsonNode] {.raises: [Exception].} =
   result = callPrivateRPC("editSharedAddressesForCommunity".prefix, %*[{
     "communityId": communityId,
-    "password": password,
     "addressesToReveal": addressesToShare,
+    "signatures": signatures,
     "airdropAddress": airdropAddress,
   }])
 

--- a/storybook/pages/CommunityIntroDialogPage.qml
+++ b/storybook/pages/CommunityIntroDialogPage.qml
@@ -53,8 +53,13 @@ Nemo enim 😋 ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit,
                 assetsModel: AssetsModel {}
                 collectiblesModel: CollectiblesModel {}
 
-                onJoined: logs.logEvent("CommunityIntroDialog::onJoined", ["airdropAddress", "sharedAddresses"], arguments)
                 onCancelMembershipRequest: logs.logEvent("CommunityIntroDialog::onCancelMembershipRequest()")
+
+                onPrepareForSigning: logs.logEvent("CommunityIntroDialog::onPrepareForSigning", ["airdropAddress", "sharedAddresses"], arguments)
+                onJoinCommunity: logs.logEvent("CommunityIntroDialog::onJoinCommunity")
+                onSignSharedAddressesForAllNonKeycardKeypairs: logs.logEvent("CommunityIntroDialog::onSignSharedAddressesForAllNonKeycardKeypairs")
+                onSignSharedAddressesForKeypair: logs.logEvent("CommunityIntroDialog::onSignSharedAddressesForKeypair", ["keyUid"], arguments)
+                onSharedAddressesUpdated: logs.logEvent("CommunityIntroDialog::onSharedAddressesUpdated", ["sharedAddresses"], arguments)
             }
         }
 

--- a/storybook/pages/SharedAddressesPopupPage.qml
+++ b/storybook/pages/SharedAddressesPopupPage.qml
@@ -27,24 +27,12 @@ SplitView {
             walletAccountsModel: WalletAccountsModel {}
             permissionsModel: {
                 if (ctrlPermissions.checked && ctrlTokenGatedChannels.checked) {
-                    if (selectedSharedAddresses.length === 1 && ctrlEditMode.checked) {
-                        console.warn("Simulation: Losing BOTH the join and VIP read channel permissions !!!")
-                        return PermissionsModel.complexCombinedPermissionsModelNotMet
-                    }
                     return PermissionsModel.complexCombinedPermissionsModel
                 }
                 if (ctrlPermissions.checked) {
-                    if (selectedSharedAddresses.length === 1 && ctrlEditMode.checked) {
-                        console.warn("Simulation: Losing the join community permission !!!")
-                        return PermissionsModel.complexPermissionsModelNotMet
-                    }
                     return PermissionsModel.complexPermissionsModel
                 }
                 if (ctrlTokenGatedChannels.checked) {
-                    if (selectedSharedAddresses.length === 1 && ctrlEditMode.checked) {
-                        console.warn("Simulation: Losing the VIP read channel permission !!!")
-                        return PermissionsModel.channelsOnlyPermissionsModelNotMet
-                    }
                     return PermissionsModel.channelsOnlyPermissionsModel
                 }
 
@@ -56,19 +44,12 @@ SplitView {
             collectiblesModel: CollectiblesModel {}
             visible: true
 
-            Binding on selectedSharedAddresses {
-                value: ["0x7F47C2e18a4BBf5487E6fb082eC2D9Ab0E6d7240", "0x7F47C2e98a4BBf5487E6fb082eC2D9Ab0E6d8881", "0x7F47C2e98a4BBf5487E6fb082eC2D9Ab0E6d8884"]
-                when: ctrlEditMode.checked
-            }
-
-            Binding on selectedAirdropAddress {
-                value: "0x7F47C2e98a4BBf5487E6fb082eC2D9Ab0E6d8884"
-                when: ctrlEditMode.checked
-            }
-
             onShareSelectedAddressesClicked: logs.logEvent("::shareSelectedAddressesClicked", ["airdropAddress", "sharedAddresses"], arguments)
-            onSaveSelectedAddressesClicked: logs.logEvent("::saveSelectedAddressesClicked", ["airdropAddress", "sharedAddresses"], arguments)
             onSharedAddressesChanged: logs.logEvent("::sharedAddressesChanged", ["airdropAddress", "sharedAddresses"], arguments)
+            onPrepareForSigning: logs.logEvent("::onPrepareForSigning", ["airdropAddress", "sharedAddresses"], arguments)
+            onEditRevealedAddresses: logs.logEvent("::onEditRevealedAddresses")
+            onSignSharedAddressesForAllNonKeycardKeypairs: logs.logEvent("::onSignSharedAddressesForAllNonKeycardKeypairs")
+            onSignSharedAddressesForKeypair: logs.logEvent("::onSignSharedAddressesForKeypair", ["keyUid"], arguments)
             onClosed: destroy()
         }
     }

--- a/ui/StatusQ/src/StatusQ/Popups/StatusStackModal.qml
+++ b/ui/StatusQ/src/StatusQ/Popups/StatusStackModal.qml
@@ -13,6 +13,7 @@ StatusModal {
 
     property alias stackItems: stackLayout.children
     property alias currentIndex: stackLayout.currentIndex
+    property alias replaceLoader: replaceLoader
     property alias replaceItem: replaceLoader.sourceComponent
     property alias subHeaderItem: subHeaderLoader.sourceComponent
 

--- a/ui/app/AppLayouts/Chat/ChatLayout.qml
+++ b/ui/app/AppLayouts/Chat/ChatLayout.qml
@@ -229,8 +229,22 @@ StackLayout {
             assetsModel: root.rootStore.assetsModel
             collectiblesModel: root.rootStore.collectiblesModel
 
-            onJoined: {
-                root.rootStore.requestToJoinCommunityWithAuthentication(communityIntroDialog.communityId, root.rootStore.userProfileInst.name, sharedAddresses, airdropAddress)
+            onPrepareForSigning: {
+                root.rootStore.prepareKeypairsForSigning(sharedAddresses)
+
+                communityIntroDialog.keypairSigningModel = root.rootStore.communitiesModuleInst.keypairsSigningModel
+            }
+
+            onSignSharedAddressesForAllNonKeycardKeypairs: {
+                root.rootStore.signSharedAddressesForAllNonKeycardKeypairs()
+            }
+
+            onSignSharedAddressesForKeypair: {
+                root.rootStore.signSharedAddressesForKeypair(keyUid)
+            }
+
+            onJoinCommunity: {
+                root.rootStore.joinCommunityOrEditSharedAddresses()
             }
 
             onCancelMembershipRequest: {
@@ -244,6 +258,16 @@ StackLayout {
 
             onClosed: {
                 destroy()
+            }
+
+            Connections {
+                target: root.rootStore.communitiesModuleInst
+
+                function onSharedAddressesForAllNonKeycardKeypairsSigned() {
+                    if (!!communityIntroDialog.replaceItem) {
+                        communityIntroDialog.replaceLoader.item.sharedAddressesForAllNonKeycardKeypairsSigned()
+                    }
+                }
             }
         }
     }

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -394,8 +394,20 @@ QtObject {
         return communitiesModuleInst.spectateCommunity(id, ensName)
     }
 
-    function requestToJoinCommunityWithAuthentication(communityId, ensName, addressesToShare = [], airdropAddress = "") {
-        communitiesModuleInst.requestToJoinCommunityWithAuthenticationWithSharedAddresses(communityId, ensName, JSON.stringify(addressesToShare), airdropAddress)
+    function prepareKeypairsForSigning(communityId, ensName, addressesToShare = [], airdropAddress = "", editMode = false) {
+        communitiesModuleInst.prepareKeypairsForSigning(communityId, ensName, JSON.stringify(addressesToShare), airdropAddress, editMode)
+    }
+
+    function signSharedAddressesForAllNonKeycardKeypairs() {
+        communitiesModuleInst.signSharedAddressesForAllNonKeycardKeypairs()
+    }
+
+    function signSharedAddressesForKeypair(keyUid) {
+        communitiesModuleInst.signSharedAddressesForKeypair(keyUid)
+    }
+
+    function joinCommunityOrEditSharedAddresses() {
+        communitiesModuleInst.joinCommunityOrEditSharedAddresses()
     }
 
     function getChainIdForChat() {
@@ -612,9 +624,9 @@ QtObject {
         readonly property bool amIMember: chatCommunitySectionModule ? chatCommunitySectionModule.amIMember : false
 
         property var oneToOneChatContact: undefined
-        readonly property string oneToOneChatContactName: !!_d.oneToOneChatContact ? ProfileUtils.displayName(_d.oneToOneChatContact.localNickname, 
-                                                                                                    _d.oneToOneChatContact.name, 
-                                                                                                    _d.oneToOneChatContact.displayName, 
+        readonly property string oneToOneChatContactName: !!_d.oneToOneChatContact ? ProfileUtils.displayName(_d.oneToOneChatContact.localNickname,
+                                                                                                    _d.oneToOneChatContact.name,
+                                                                                                    _d.oneToOneChatContact.displayName,
                                                                                                     _d.oneToOneChatContact.alias) : ""
 
         //Update oneToOneChatContact when the contact is updated
@@ -674,7 +686,7 @@ QtObject {
 
         //Update oneToOneChatContact when activeChat id changes
         Binding on oneToOneChatContact {
-            when: _d.activeChatId && _d.activeChatType === Constants.chatType.oneToOne 
+            when: _d.activeChatId && _d.activeChatType === Constants.chatType.oneToOne
             value: Utils.getContactDetailsAsJson(_d.activeChatId, false)
             restoreMode: Binding.RestoreBindingOrValue
         }

--- a/ui/app/AppLayouts/Chat/stores/RootStore.qml
+++ b/ui/app/AppLayouts/Chat/stores/RootStore.qml
@@ -557,11 +557,6 @@ QtObject {
         return Constants.LoginType.Password
     }
 
-    function authenticateWithCallback(callback) {
-        _d.authenticationCallbacks.push(callback)
-        communitiesModuleInst.authenticateWithCallback()
-    }
-
     readonly property Connections communitiesModuleConnections: Connections {
       target: communitiesModuleInst
       function onImportingCommunityStateChanged(communityId, state, errorMsg) {
@@ -593,19 +588,6 @@ QtObject {
     }
 
     readonly property QtObject _d: QtObject {
-        property var authenticationCallbacks: []
-
-        readonly property Connections chatCommunitySectionModuleConnections: Connections {
-            target: communitiesModuleInst
-            function onCallbackFromAuthentication(authenticated: bool) {
-                _d.authenticationCallbacks.forEach((callback) => {
-                    if(!!callback)
-                        callback(authenticated)
-                })
-                _d.authenticationCallbacks = []
-            }
-        }
-
         readonly property var sectionDetailsInstantiator: Instantiator {
             model: SortFilterProxyModel {
                 sourceModel: mainModuleInst.sectionsModel

--- a/ui/app/AppLayouts/Communities/panels/SharedAddressesSigningPanel.qml
+++ b/ui/app/AppLayouts/Communities/panels/SharedAddressesSigningPanel.qml
@@ -1,0 +1,181 @@
+import QtQuick 2.15
+import QtQuick.Layouts 1.15
+
+import StatusQ.Core 0.1
+import StatusQ.Controls 0.1
+import StatusQ.Core.Theme 0.1
+
+import utils 1.0
+import shared.popups.keycard.helpers 1.0
+
+import SortFilterProxyModel 0.2
+
+ColumnLayout {
+    id: root
+
+    property var keypairSigningModel
+
+    readonly property string title: qsTr("Prove ownership of keypairs")
+    readonly property var rightButtons: [d.rightBtn]
+    readonly property bool allSigned: regularKeypairs.visible == d.sharedAddressesForAllNonKeycardKeypairsSigned &&
+                                      keycardKeypairs.visible == d.allKeycardKeypairsSigned
+
+    signal joinCommunity()
+    signal signSharedAddressesForAllNonKeycardKeypairs()
+    signal signSharedAddressesForKeypair(string keyUid)
+
+    function sharedAddressesForAllNonKeycardKeypairsSigned() {
+        d.sharedAddressesForAllNonKeycardKeypairsSigned = true
+    }
+
+    QtObject {
+        id: d
+
+        property bool sharedAddressesForAllNonKeycardKeypairsSigned: false
+        property bool allKeycardKeypairsSigned: false
+
+        readonly property var rightBtn: StatusButton {
+            enabled: root.allSigned
+            text: qsTr("Share your addresses to join")
+            onClicked: {
+                root.joinCommunity()
+            }
+        }
+
+        function reEvaluateSignedKeypairs() {
+            let allKeypairsSigned = true
+            for(var i = 0; i< keycardKeypairs.model.count; i++) {
+                if(!keycardKeypairs.model.get(i).keyPair.ownershipVerified) {
+                    allKeypairsSigned = false
+                    break
+                }
+            }
+
+            d.allKeycardKeypairsSigned = allKeypairsSigned
+        }
+    }
+
+    ColumnLayout {
+        Layout.fillWidth: true
+        Layout.margins: Style.current.xlPadding
+
+        spacing: Style.current.padding
+
+        RowLayout {
+            Layout.fillWidth: true
+
+            visible: regularKeypairs.visible
+
+            StatusBaseText {
+                Layout.fillWidth: true
+                text: qsTr("Keypairs we need an authentication for")
+                font.pixelSize: Constants.keycard.general.fontSize2
+                color: Theme.palette.baseColor1
+                wrapMode: Text.WordWrap
+            }
+
+            StatusButton {
+                text: d.sharedAddressesForAllNonKeycardKeypairsSigned? qsTr("Authenticated") : qsTr("Authenticate")
+                enabled: !d.sharedAddressesForAllNonKeycardKeypairsSigned
+                icon.name: userProfile.usingBiometricLogin? "touch-id" : "password"
+
+                onClicked: {
+                    root.signSharedAddressesForAllNonKeycardKeypairs()
+                }
+            }
+        }
+
+        StatusListView {
+            id: regularKeypairs
+            Layout.fillWidth: true
+            Layout.preferredHeight: regularKeypairs.contentHeight
+            visible: regularKeypairs.model.count > 0
+            spacing: Style.current.padding
+            model: SortFilterProxyModel {
+                sourceModel: root.keypairSigningModel
+                filters: ExpressionFilter {
+                    expression: !model.keyPair.migratedToKeycard
+                }
+            }
+            delegate: KeyPairItem {
+                width: ListView.view.width
+                sensor.hoverEnabled: false
+                additionalInfoForProfileKeypair: ""
+
+                keyPairType: model.keyPair.pairType
+                keyPairKeyUid: model.keyPair.keyUid
+                keyPairName: model.keyPair.name
+                keyPairIcon: model.keyPair.icon
+                keyPairImage: model.keyPair.image
+                keyPairDerivedFrom: model.keyPair.derivedFrom
+                keyPairAccounts: model.keyPair.accounts
+            }
+        }
+
+        Item {
+            visible: regularKeypairs.visible && keycardKeypairs.visible
+            Layout.fillWidth: true
+            Layout.preferredHeight: Style.current.xlPadding
+        }
+
+        StatusBaseText {
+            Layout.fillWidth: true
+            visible: keycardKeypairs.visible
+            text: qsTr("Keypairs that need to be singed using appropriate Keycard")
+            font.pixelSize: Constants.keycard.general.fontSize2
+            color: Theme.palette.baseColor1
+            wrapMode: Text.WordWrap
+        }
+
+        StatusListView {
+            id: keycardKeypairs
+            Layout.fillWidth: true
+            Layout.preferredHeight: keycardKeypairs.contentHeight
+            visible: keycardKeypairs.model.count > 0
+            spacing: Style.current.padding
+            model: SortFilterProxyModel {
+                sourceModel: root.keypairSigningModel
+                filters: ExpressionFilter {
+                    expression: model.keyPair.migratedToKeycard
+                }
+            }
+            delegate: KeyPairItem {
+                width: ListView.view.width
+                sensor.hoverEnabled: !model.keyPair.ownershipVerified
+                additionalInfoForProfileKeypair: ""
+
+                keyPairType: model.keyPair.pairType
+                keyPairKeyUid: model.keyPair.keyUid
+                keyPairName: model.keyPair.name
+                keyPairIcon: model.keyPair.icon
+                keyPairImage: model.keyPair.image
+                keyPairDerivedFrom: model.keyPair.derivedFrom
+                keyPairAccounts: model.keyPair.accounts
+
+                components: [
+                    StatusBaseText {
+                        font.weight: Font.Medium
+                        font.underline: mouseArea.containsMouse
+                        font.pixelSize: Theme.primaryTextFontSize
+                        color: model.keyPair.ownershipVerified? Theme.palette.baseColor1 : Theme.palette.primaryColor1
+                        text: model.keyPair.ownershipVerified? qsTr("Signed") : qsTr("Sign")
+                        MouseArea {
+                            id: mouseArea
+                            anchors.fill: parent
+                            cursorShape: enabled ? Qt.PointingHandCursor : Qt.ArrowCursor
+                            acceptedButtons: Qt.LeftButton | Qt.RightButton
+                            hoverEnabled: !model.keyPair.ownershipVerified
+                            enabled: !model.keyPair.ownershipVerified
+                            onEnabledChanged: {
+                                d.reEvaluateSignedKeypairs()
+                            }
+                            onClicked: {
+                                root.signSharedAddressesForKeypair(model.keyPair.keyUid)
+                            }
+                        }
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/ui/app/AppLayouts/Communities/panels/qmldir
+++ b/ui/app/AppLayouts/Communities/panels/qmldir
@@ -30,6 +30,7 @@ ProfilePopupInviteMessagePanel 1.0 ProfilePopupInviteMessagePanel.qml
 ProfilePopupOverviewPanel 1.0 ProfilePopupOverviewPanel.qml
 RequirementsCheckPendingLoader 1.0 RequirementsCheckPendingLoader.qml
 SharedAddressesPanel 1.0 SharedAddressesPanel.qml
+SharedAddressesSigningPanel 1.0 SharedAddressesSigningPanel.qml
 SortableTokenHoldersList 1.0 SortableTokenHoldersList.qml
 SortableTokenHoldersPanel 1.0 SortableTokenHoldersPanel.qml
 TagsPanel 1.0 TagsPanel.qml

--- a/ui/app/AppLayouts/Communities/popups/SharedAddressesPopup.qml
+++ b/ui/app/AppLayouts/Communities/popups/SharedAddressesPopup.qml
@@ -1,6 +1,10 @@
 import QtQuick 2.15
+import QtQml.Models 2.15
+import QtQuick.Layouts 1.15
 
+import StatusQ.Controls 0.1
 import StatusQ.Popups.Dialog 0.1
+import StatusQ.Core.Theme 0.1
 
 import AppLayouts.Communities.panels 1.0
 
@@ -12,6 +16,7 @@ StatusDialog {
     property bool isEditMode
 
     property bool requirementsCheckPending
+    property var keypairSigningModel
 
     required property string communityName
     required property string communityIcon
@@ -22,46 +27,138 @@ StatusDialog {
     required property var assetsModel
     required property var collectiblesModel
 
-    property alias selectedSharedAddresses: panel.selectedSharedAddresses
-    property alias selectedAirdropAddress: panel.selectedAirdropAddress
-
     signal shareSelectedAddressesClicked(string airdropAddress, var sharedAddresses)
-    signal saveSelectedAddressesClicked(string airdropAddress, var sharedAddresses)
     signal sharedAddressesChanged(string airdropAddress, var sharedAddresses)
 
+    signal prepareForSigning(string airdropAddress, var sharedAddresses)
+    signal editRevealedAddresses()
+    signal signSharedAddressesForAllNonKeycardKeypairs()
+    signal signSharedAddressesForKeypair(string keyUid)
+
     function setOldSharedAddresses(oldSharedAddresses) {
-        panel.setOldSharedAddresses(oldSharedAddresses)
+        if (!d.displaySigningPanel && !!loader.item) {
+            d.oldSharedAddresses = oldSharedAddresses
+            loader.item.setOldSharedAddresses(oldSharedAddresses)
+        }
     }
 
     function setOldAirdropAddress(oldAirdropAddress) {
-        panel.setOldAirdropAddress(oldAirdropAddress)
+        if (!d.displaySigningPanel && !!loader.item) {
+            d.oldAirdropAddress = oldAirdropAddress
+            loader.item.setOldAirdropAddress(oldAirdropAddress)
+        }
     }
 
-    title: panel.title
+    function sharedAddressesForAllNonKeycardKeypairsSigned() {
+        if (d.displaySigningPanel && !!loader.item) {
+            loader.item.sharedAddressesForAllNonKeycardKeypairsSigned()
+        }
+    }
+
+    title: !!loader.item? loader.item.title : ""
     implicitWidth: 640 // by design
     padding: 0
 
-    contentItem: SharedAddressesPanel {
-        id: panel
-        isEditMode: root.isEditMode
-        requirementsCheckPending: root.requirementsCheckPending
-        communityName: root.communityName
-        communityIcon: root.communityIcon
-        loginType: root.loginType
-        walletAccountsModel: root.walletAccountsModel
-        permissionsModel: root.permissionsModel
-        assetsModel: root.assetsModel
-        collectiblesModel: root.collectiblesModel
-        onShareSelectedAddressesClicked: root.shareSelectedAddressesClicked(airdropAddress, sharedAddresses)
-        onSaveSelectedAddressesClicked: root.saveSelectedAddressesClicked(airdropAddress, sharedAddresses)
-        onSharedAddressesChanged: {
-            root.sharedAddressesChanged(airdropAddress, sharedAddresses)
+    QtObject {
+        id: d
+
+        property bool displaySigningPanel: false
+        property bool allSigned: false
+
+        property var oldSharedAddresses
+        property string oldAirdropAddress
+
+        property var selectAddressesPanelButtons: ObjectModel {}
+        readonly property var signingPanelButtons: ObjectModel {
+            StatusFlatButton {
+                visible: root.isEditMode
+                borderColor: Theme.palette.baseColor2
+                text: qsTr("Cancel")
+                onClicked: root.close()
+            }
+            StatusButton {
+                text: qsTr("Save changes")
+                enabled: d.allSigned
+                onClicked: {
+                    root.editRevealedAddresses()
+                    root.close()
+                }
+            }
         }
-        onClose: root.close()
+
+        readonly property var signingPanelBackButtons: ObjectModel {
+            StatusBackButton {
+                onClicked: {
+                    d.displaySigningPanel = false
+                }
+            }
+        }
+    }
+
+    contentItem: Loader {
+        id: loader
+        sourceComponent: d.displaySigningPanel? sharedAddressesSigningPanelComponent : selectSharedAddressesPanelComponent
+
+        onLoaded: {
+            if (!d.displaySigningPanel) {
+                if (!!d.oldSharedAddresses) {
+                    root.setOldSharedAddresses(d.oldSharedAddresses)
+                }
+                if (!!d.oldAirdropAddress) {
+                    root.setOldAirdropAddress(d.oldAirdropAddress)
+                }
+                d.selectAddressesPanelButtons = loader.item.buttons
+            }
+        }
+    }
+
+    Component {
+        id: selectSharedAddressesPanelComponent
+        SharedAddressesPanel {
+            isEditMode: root.isEditMode
+            requirementsCheckPending: root.requirementsCheckPending
+            communityName: root.communityName
+            communityIcon: root.communityIcon
+            loginType: root.loginType
+            walletAccountsModel: root.walletAccountsModel
+            permissionsModel: root.permissionsModel
+            assetsModel: root.assetsModel
+            collectiblesModel: root.collectiblesModel
+            onShareSelectedAddressesClicked: root.shareSelectedAddressesClicked(airdropAddress, sharedAddresses)
+            onPrepareForSigning: {
+                root.prepareForSigning(airdropAddress, sharedAddresses)
+                d.displaySigningPanel = true
+            }
+            onSharedAddressesChanged: {
+                root.sharedAddressesChanged(airdropAddress, sharedAddresses)
+            }
+            onClose: root.close()
+        }
+    }
+
+    Component {
+        id: sharedAddressesSigningPanelComponent
+        SharedAddressesSigningPanel {
+
+            keypairSigningModel: root.keypairSigningModel
+
+            onSignSharedAddressesForAllNonKeycardKeypairs: {
+                root.signSharedAddressesForAllNonKeycardKeypairs()
+            }
+
+            onSignSharedAddressesForKeypair: {
+                root.signSharedAddressesForKeypair(keyUid)
+            }
+
+            onAllSignedChanged: {
+                d.allSigned = allSigned
+            }
+        }
     }
 
     footer: StatusDialogFooter {
         spacing: Style.current.padding
-        rightButtons: panel.buttons
+        rightButtons: d.displaySigningPanel? d.signingPanelButtons : d.selectAddressesPanelButtons
+        leftButtons: d.displaySigningPanel? d.signingPanelBackButtons : null
     }
 }

--- a/ui/app/AppLayouts/Profile/views/CommunitiesView.qml
+++ b/ui/app/AppLayouts/Profile/views/CommunitiesView.qml
@@ -242,7 +242,24 @@ SettingsContentBase {
             assetsModel: chatStore.assetsModel
             collectiblesModel: chatStore.collectiblesModel
 
-            onJoined: chatStore.requestToJoinCommunityWithAuthentication(communityIntroDialog.communityId, root.rootStore.userProfileInst.name, sharedAddresses, airdropAddress)
+            onPrepareForSigning: {
+                chatStore.prepareKeypairsForSigning(communityIntroDialog.communityId, root.rootStore.userProfileInst.name, sharedAddresses, airdropAddress, false)
+
+                communityIntroDialog.keypairSigningModel = chatStore.communitiesModuleInst.keypairsSigningModel
+            }
+
+            onSignSharedAddressesForAllNonKeycardKeypairs: {
+                chatStore.signSharedAddressesForAllNonKeycardKeypairs()
+            }
+
+            onSignSharedAddressesForKeypair: {
+                chatStore.signSharedAddressesForKeypair(keyUid)
+            }
+
+            onJoinCommunity: {
+                chatStore.joinCommunityOrEditSharedAddresses()
+            }
+
             onCancelMembershipRequest: root.rootStore.cancelPendingRequest(communityIntroDialog.communityId)
 
             onSharedAddressesUpdated: {
@@ -250,6 +267,16 @@ SettingsContentBase {
             }
 
             onClosed: destroy()
+
+            Connections {
+                target: chatStore.communitiesModuleInst
+
+                function onSharedAddressesForAllNonKeycardKeypairsSigned() {
+                    if (!!communityIntroDialog.replaceItem) {
+                        communityIntroDialog.replaceLoader.item.sharedAddressesForAllNonKeycardKeypairsSigned()
+                    }
+                }
+            }
         }
     }
 }

--- a/ui/app/AppLayouts/stores/RootStore.qml
+++ b/ui/app/AppLayouts/stores/RootStore.qml
@@ -241,14 +241,20 @@ QtObject {
         mainModuleInst.windowDeactivated()
     }
 
-    function requestToJoinCommunityWithAuthentication(communityId, ensName, addressesToShare = [], airdropAddress = "") {
-        communitiesModuleInst.requestToJoinCommunityWithAuthenticationWithSharedAddresses(
-            communityId, ensName, JSON.stringify(addressesToShare), airdropAddress)
+    function prepareKeypairsForSigning(communityId, ensName, addressesToShare = [], airdropAddress = "", editMode = false) {
+        communitiesModuleInst.prepareKeypairsForSigning(communityId, ensName, JSON.stringify(addressesToShare), airdropAddress, editMode)
     }
 
-    function editSharedAddressesWithAuthentication(communityId, addressesToShare = [], airdropAddress = "") {
-        communitiesModuleInst.editSharedAddressesWithAuthentication(
-            communityId, JSON.stringify(addressesToShare), airdropAddress)
+    function signSharedAddressesForAllNonKeycardKeypairs() {
+        communitiesModuleInst.signSharedAddressesForAllNonKeycardKeypairs()
+    }
+
+    function signSharedAddressesForKeypair(keyUid) {
+        communitiesModuleInst.signSharedAddressesForKeypair(keyUid)
+    }
+
+    function joinCommunityOrEditSharedAddresses() {
+        communitiesModuleInst.joinCommunityOrEditSharedAddresses()
     }
 
     function updatePermissionsModel(communityId, sharedAddresses) {

--- a/ui/app/mainui/AppMain.qml
+++ b/ui/app/mainui/AppMain.qml
@@ -77,12 +77,12 @@ Item {
             popups.openProfilePopup(publicKey)
         }
 
-        function onDisplayKeycardSharedModuleForAuthentication() {
-            keycardPopupForAuthentication.active = true
+        function onDisplayKeycardSharedModuleForAuthenticationOrSigning() {
+            keycardPopupForAuthenticationOrSigning.active = true
         }
 
-        function onDestroyKeycardSharedModuleForAuthentication() {
-            keycardPopupForAuthentication.active = false
+        function onDestroyKeycardSharedModuleForAuthenticationOrSigning() {
+            keycardPopupForAuthenticationOrSigning.active = false
         }
 
         function onDisplayKeycardSharedModuleFlow() {
@@ -333,7 +333,7 @@ Item {
             let loading = false
             let notificationType = Constants.ephemeralNotificationType.normal
             let icon = ""
-            
+
             switch (state)
             {
             case Constants.communityImported:
@@ -1612,14 +1612,14 @@ Item {
     }
 
     Loader {
-        id: keycardPopupForAuthentication
+        id: keycardPopupForAuthenticationOrSigning
         active: false
         sourceComponent: KeycardPopup {
-            sharedKeycardModule: appMain.rootStore.mainModuleInst.keycardSharedModuleForAuthentication
+            sharedKeycardModule: appMain.rootStore.mainModuleInst.keycardSharedModuleForAuthenticationOrSigning
         }
 
         onLoaded: {
-            keycardPopupForAuthentication.item.open()
+            keycardPopupForAuthenticationOrSigning.item.open()
         }
     }
 

--- a/ui/imports/shared/popups/keycard/KeycardPopup.qml
+++ b/ui/imports/shared/popups/keycard/KeycardPopup.qml
@@ -32,6 +32,8 @@ StatusModal {
             return qsTr("Factory reset a Keycard")
         case Constants.keycardSharedFlow.authentication:
             return qsTr("Authenticate")
+        case Constants.keycardSharedFlow.sign:
+            return qsTr("Signing")
         case Constants.keycardSharedFlow.unlockKeycard:
             return qsTr("Unlock Keycard")
         case Constants.keycardSharedFlow.displayKeycardContent:

--- a/ui/imports/shared/popups/keycard/KeycardPopupDetails.qml
+++ b/ui/imports/shared/popups/keycard/KeycardPopupDetails.qml
@@ -220,6 +220,27 @@ QtObject {
                     }
                     break
 
+                case Constants.keycardSharedFlow.sign:
+                    switch (root.sharedKeycardModule.currentState.stateType) {
+                    case Constants.keycardSharedState.pluginReader:
+                    case Constants.keycardSharedState.readingKeycard:
+                    case Constants.keycardSharedState.insertKeycard:
+                    case Constants.keycardSharedState.keycardInserted:
+                    case Constants.keycardSharedState.wrongPin:
+                    case Constants.keycardSharedState.wrongKeychainPin:
+                    case Constants.keycardSharedState.biometricsReadyToSign:
+                    case Constants.keycardSharedState.maxPinRetriesReached:
+                    case Constants.keycardSharedState.maxPukRetriesReached:
+                    case Constants.keycardSharedState.maxPairingSlotsReached:
+                    case Constants.keycardSharedState.notKeycard:
+                    case Constants.keycardSharedState.wrongKeycard:
+                    case Constants.keycardSharedState.biometricsPinFailed:
+                    case Constants.keycardSharedState.biometricsPinInvalid:
+                    case Constants.keycardSharedState.enterPin:
+                        return true
+                    }
+                    break
+
                 case Constants.keycardSharedFlow.unlockKeycard:
                     switch (root.sharedKeycardModule.currentState.stateType) {
                     case Constants.keycardSharedState.pluginReader:
@@ -429,6 +450,32 @@ QtObject {
                     }
                     break
 
+                case Constants.keycardSharedFlow.sign:
+                    if (userProfile.usingBiometricLogin) {
+
+                        switch (root.sharedKeycardModule.currentState.stateType) {
+
+                        case Constants.keycardSharedState.enterPin:
+                        case Constants.keycardSharedState.wrongPin:
+                            return qsTr("Use biometrics")
+
+                        case Constants.keycardSharedState.pluginReader:
+                        case Constants.keycardSharedState.insertKeycard:
+                        case Constants.keycardSharedState.keycardInserted:
+                        case Constants.keycardSharedState.readingKeycard:
+                        case Constants.keycardSharedState.biometricsReadyToSign:
+                        case Constants.keycardSharedState.notKeycard:
+                        case Constants.keycardSharedState.biometricsPinFailed:
+                        case Constants.keycardSharedState.wrongKeycard:
+                        case Constants.keycardSharedState.keycardEmpty:
+                            return qsTr("Use PIN")
+
+                        case Constants.keycardSharedState.biometricsPinInvalid:
+                            return qsTr("Update PIN")
+                        }
+                    }
+                    break
+
                 case Constants.keycardSharedFlow.unlockKeycard:
                     switch (root.sharedKeycardModule.currentState.stateType) {
 
@@ -502,6 +549,19 @@ QtObject {
                 switch (root.sharedKeycardModule.currentState.flowType) {
 
                 case Constants.keycardSharedFlow.authentication:
+                    if (userProfile.usingBiometricLogin) {
+                        switch (root.sharedKeycardModule.currentState.stateType) {
+                        case Constants.keycardSharedState.pluginReader:
+                        case Constants.keycardSharedState.insertKeycard:
+                        case Constants.keycardSharedState.notKeycard:
+                        case Constants.keycardSharedState.wrongKeycard:
+                        case Constants.keycardSharedState.keycardEmpty:
+                            return false
+                        }
+                    }
+                    break
+
+                case Constants.keycardSharedFlow.sign:
                     if (userProfile.usingBiometricLogin) {
                         switch (root.sharedKeycardModule.currentState.stateType) {
                         case Constants.keycardSharedState.pluginReader:
@@ -793,6 +853,38 @@ QtObject {
                         return qsTr("Update PIN & authenticate")
 
                     case Constants.keycardSharedState.biometricsPasswordFailed:
+                    case Constants.keycardSharedState.biometricsPinFailed:
+                    case Constants.keycardSharedState.biometricsPinInvalid:
+                        return qsTr("Try biometrics again")
+
+                    case Constants.keycardSharedState.maxPinRetriesReached:
+                    case Constants.keycardSharedState.maxPukRetriesReached:
+                    case Constants.keycardSharedState.maxPairingSlotsReached:
+                        return qsTr("Unlock Keycard")
+
+                    }
+                    break
+
+                case Constants.keycardSharedFlow.sign:
+                    switch (root.sharedKeycardModule.currentState.stateType) {
+
+                    case Constants.keycardSharedState.pluginReader:
+                    case Constants.keycardSharedState.readingKeycard:
+                    case Constants.keycardSharedState.insertKeycard:
+                    case Constants.keycardSharedState.keycardInserted:
+                    case Constants.keycardSharedState.wrongPin:
+                    case Constants.keycardSharedState.notKeycard:
+                    case Constants.keycardSharedState.biometricsReadyToSign:
+                    case Constants.keycardSharedState.wrongKeycard:
+                    case Constants.keycardSharedState.enterPin:
+                        return qsTr("Sign")
+
+                    case Constants.keycardSharedState.keycardEmpty:
+                        return qsTr("Done")
+
+                    case Constants.keycardSharedState.wrongKeychainPin:
+                        return qsTr("Update PIN & authenticate")
+
                     case Constants.keycardSharedState.biometricsPinFailed:
                     case Constants.keycardSharedState.biometricsPinInvalid:
                         return qsTr("Try biometrics again")
@@ -1178,6 +1270,20 @@ QtObject {
                     }
                     break
 
+                case Constants.keycardSharedFlow.sign:
+                    switch (root.sharedKeycardModule.currentState.stateType) {
+
+                    case Constants.keycardSharedState.pluginReader:
+                    case Constants.keycardSharedState.insertKeycard:
+                    case Constants.keycardSharedState.wrongPin:
+                    case Constants.keycardSharedState.wrongKeychainPin:
+                    case Constants.keycardSharedState.notKeycard:
+                    case Constants.keycardSharedState.wrongKeycard:
+                    case Constants.keycardSharedState.enterPin:
+                        return root.primaryButtonEnabled
+                    }
+                    break
+
                 case Constants.keycardSharedFlow.unlockKeycard:
                     switch (root.sharedKeycardModule.currentState.stateType) {
 
@@ -1261,6 +1367,24 @@ QtObject {
                         case Constants.keycardSharedState.keycardInserted:
                         case Constants.keycardSharedState.readingKeycard:
                         case Constants.keycardSharedState.biometricsPasswordFailed:
+                        case Constants.keycardSharedState.biometricsPinFailed:
+                        case Constants.keycardSharedState.biometricsPinInvalid:
+                        case Constants.keycardSharedState.biometricsReadyToSign:
+                        case Constants.keycardSharedState.notKeycard:
+                        case Constants.keycardSharedState.wrongKeycard:
+                            return "touch-id"
+                        }
+                    }
+                    break
+
+                case Constants.keycardSharedFlow.sign:
+                    if (userProfile.usingBiometricLogin) {
+                        switch (root.sharedKeycardModule.currentState.stateType) {
+
+                        case Constants.keycardSharedState.pluginReader:
+                        case Constants.keycardSharedState.insertKeycard:
+                        case Constants.keycardSharedState.keycardInserted:
+                        case Constants.keycardSharedState.readingKeycard:
                         case Constants.keycardSharedState.biometricsPinFailed:
                         case Constants.keycardSharedState.biometricsPinInvalid:
                         case Constants.keycardSharedState.biometricsReadyToSign:

--- a/ui/imports/shared/popups/keycard/states/KeycardInit.qml
+++ b/ui/imports/shared/popups/keycard/states/KeycardInit.qml
@@ -48,6 +48,8 @@ Item {
                                                               root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.importingFromKeycard ||
                                                               root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.unlockingKeycard ||
                                                               root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.copyingKeycard
+        readonly property bool authenticationOrSigning: root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.authentication ||
+                                                        root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.sign
     }
 
     Timer {
@@ -236,7 +238,7 @@ Item {
                         root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.wrongKeycard))
                     return true
             }
-            if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.authentication &&
+            if (d.authenticationOrSigning &&
                     !!root.sharedKeycardModule.keyPairForProcessing &&
                     root.sharedKeycardModule.keyPairForProcessing.name !== "") {
                 if(root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardInserted ||
@@ -429,7 +431,7 @@ Item {
                         root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.wrongKeycard))
                     return keyPairForProcessingComponent
             }
-            if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.authentication) {
+            if (d.authenticationOrSigning) {
                 if (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.keycardInserted ||
                         root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.insertKeycard ||
                         root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.readingKeycard ||
@@ -758,19 +760,19 @@ Item {
             }
             PropertyChanges {
                 target: image
-                pattern: root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.authentication?
+                pattern: d.authenticationOrSigning?
                              "" : Constants.keycardAnimations.strongError.pattern
-                source: root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.authentication?
+                source: d.authenticationOrSigning?
                             Style.png("keycard/plain-error") : ""
-                startImgIndexForTheFirstLoop: root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.authentication?
+                startImgIndexForTheFirstLoop: d.authenticationOrSigning?
                                                   0 : Constants.keycardAnimations.strongError.startImgIndexForTheFirstLoop
-                startImgIndexForOtherLoops: root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.authentication?
+                startImgIndexForOtherLoops: d.authenticationOrSigning?
                                                 0 : Constants.keycardAnimations.strongError.startImgIndexForOtherLoops
-                endImgIndex: root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.authentication?
+                endImgIndex: d.authenticationOrSigning?
                                  0 : Constants.keycardAnimations.strongError.endImgIndex
-                duration: root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.authentication?
+                duration: d.authenticationOrSigning?
                               0 : Constants.keycardAnimations.strongError.duration
-                loops: root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.authentication?
+                loops: d.authenticationOrSigning?
                            -1 : Constants.keycardAnimations.strongError.loops
             }
             PropertyChanges {
@@ -831,7 +833,7 @@ Item {
             PropertyChanges {
                 target: message
                 text: {
-                    if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.authentication ||
+                    if (d.authenticationOrSigning ||
                             root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.renameKeycard ||
                             root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.changeKeycardPin ||
                             root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.changeKeycardPuk ||

--- a/ui/imports/shared/popups/keycard/states/KeycardPin.qml
+++ b/ui/imports/shared/popups/keycard/states/KeycardPin.qml
@@ -40,6 +40,7 @@ Item {
 
     Component.onCompleted: {
         if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.authentication ||
+                root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.sign ||
                 root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.factoryReset) {
             timer.start()
         }
@@ -84,7 +85,8 @@ Item {
         anchors.bottomMargin: Style.current.halfPadding
         anchors.leftMargin: Style.current.xlPadding
         anchors.rightMargin: Style.current.xlPadding
-        spacing: root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.authentication?
+        spacing: root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.authentication ||
+                 root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.sign?
                      Style.current.halfPadding : Style.current.padding
 
         KeycardImage {
@@ -127,7 +129,8 @@ Item {
                         root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.wrongPin ||
                         root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.wrongKeychainPin) {
                     root.sharedKeycardModule.setPin(pinInput)
-                    if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.authentication)
+                    if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.authentication ||
+                            root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.sign)
                         return
                     root.sharedKeycardModule.currentState.doSecondaryAction()
                 }
@@ -174,7 +177,8 @@ Item {
                         return true
                     }
                 }
-                if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.authentication) {
+                if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.authentication ||
+                        root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.sign) {
                     if (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.enterPin ||
                             root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.wrongPin ||
                             root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.wrongKeychainPin) {
@@ -193,7 +197,8 @@ Item {
                         return keyPairForProcessingComponent
                     }
                 }
-                if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.authentication) {
+                if (root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.authentication ||
+                        root.sharedKeycardModule.currentState.flowType === Constants.keycardSharedFlow.sign) {
                     if (root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.enterPin ||
                             root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.wrongPin ||
                             root.sharedKeycardModule.currentState.stateType === Constants.keycardSharedState.wrongKeychainPin) {

--- a/ui/imports/utils/Constants.qml
+++ b/ui/imports/utils/Constants.qml
@@ -125,6 +125,7 @@ QtObject {
         readonly property string createCopyOfAKeycard: "CreateCopyOfAKeycard"
         readonly property string migrateFromKeycardToApp: "MigrateFromKeycardToApp"
         readonly property string migrateFromAppToKeycard: "MigrateFromAppToKeycard"
+        readonly property string sign: "Sign"
     }
 
     readonly property QtObject keycardSharedState: QtObject {


### PR DESCRIPTION
Corresponding `status-go` PR:
- https://github.com/status-im/status-go/pull/4178

**Review:**
Checking commit by commit will make the review easier since each commit represents a single thing that was necessary to have this feature implemented.

**UI note:**
The design is not the final one. Actually, we don't have it yet, but after discussing with @benjthayer we agreed on the steps we need, so once the design is provided we will need to adjust only the UI part (very likely just labels, but will see). 

**How it looks at this moment:**

https://github.com/status-im/status-desktop/assets/86303051/195fca1b-e7de-45a5-93d1-389f5b7674ea

Closes #12170 