### PR TITLE
feat(ci): trigger new E2E run after Linux build

### DIFF
--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -105,6 +105,17 @@ pipeline {
         }
       }
     }
+
+    stage('E2E') {
+      when { expression { getE2EBuildType() != null } }
+      steps { script {
+        build(
+          job: "status-desktop/e2e/${getE2EBuildType()}",
+          parameters: jenkins.mapToParams([BUILD_SOURCE: JOB_NAME]),
+          wait: false
+        )
+      } }
+    }
   }
   post {
     success { script { github.notifyPR(true) } }
@@ -114,12 +125,19 @@ pipeline {
 }
 
 def getArch() {
-    def tokens = Thread.currentThread().getName().split('/')
-    for (def arch in ['x86_64', 'aarch64']) {
-      if (tokens.contains(arch)) { return arch }
-    }
+  def tokens = Thread.currentThread().getName().split('/')
+  for (def arch in ['x86_64', 'aarch64']) {
+    if (tokens.contains(arch)) { return arch }
+  }
+}
+
+def getE2EBuildType() {
+  if (utils.isPRBuild()) { return 'prs' }
+  def parent = parentOrCurrentBuild()
+  if (parent != null && parent.name == 'nightly') { return nightly }
+  return null
 }
 
 def getMockedKeycardLibDefault() {
-    return utils.isReleaseBuild() ? 'false' : 'true'
+  return utils.isReleaseBuild() ? 'false' : 'true'
 }


### PR DESCRIPTION
We run `prs` job for PRs and `nightly` for... nightly.

Result:
```
21:38:21  Scheduling project: [status-desktop » e2e » prs](https://ci.status.im/job/status-desktop/job/e2e/job/prs/)
```

![image](https://github.com/status-im/status-desktop/assets/2212681/d46db0cb-3a19-41b7-8268-55cfee56589f)

https://ci.status.im/job/status-desktop/job/e2e/job/prs/51/

Depends on:
* https://github.com/status-im/desktop-qa-automation/pull/195